### PR TITLE
Added call to reinitScalars (closes #2459)

### DIFF
--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -560,6 +560,10 @@ void FEProblem::initialSetup()
   if(isRestarting() || isRecovering())
     _resurrector->restartRestartableData();
 
+  // Scalar variables need to reinited for the initial conditions to be available for output
+  for(unsigned int tid = 0; tid < n_threads; tid++)
+    reinitScalars(tid);
+
   // Initial setup of output objects
   _app.getOutputWarehouse().initialSetup();
 }

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -356,7 +356,7 @@ Console::outputScalarVariables()
   if (!_scalar_table.empty())
   {
     std::stringstream oss;
-    oss << "\nScalar AuxVariable Values:\n";
+    oss << "\nScalar Variable Values:\n";
     _scalar_table.printTable(oss, _max_rows, _fit_mode);
     oss << std::endl;
 

--- a/test/tests/outputs/csv/csv_transient.i
+++ b/test/tests/outputs/csv/csv_transient.i
@@ -83,15 +83,7 @@
   verbose = true
 []
 
-[Output]
-  # output_initial = true
-  # exodus = true
-  # perf_log = true
-  linear_residuals = false
-[]
-
 [Outputs]
   console = true
   csv = true
 []
-


### PR DESCRIPTION
This pull request does the following:
- `FEProblem::reinitScalars` must be called for initial conditions to be available across all processors for scalar variables, see #2459.
- Changes the title of the output table for scalars, after #2453 was complete both aux and nonlinear scalars are output.
- Removed old output syntax from test
