### PR TITLE
Added Checkpoint output type

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -691,6 +691,23 @@ public:
   virtual void registerRestartableData(std::string name, RestartableDataValue * data, THREAD_ID tid);
 
   /**
+   * Return reference to the restatable data object
+   * @return A const reference to the restatable data object
+   */
+  const RestartableDatas & getRestartableData() { return _restartable_data; }
+
+  /**
+   * Return a reference to the recoverable data object
+   * @return A const reference to the recoverable data
+   */
+  std::set<std::string> & getRecoverableData() { return _recoverable_data; }
+
+  /** Return a reference to the material property storage
+   * @return A const reference to the material property storage
+   */
+  const MaterialPropertyStorage & getMaterialPropertyStorage() { return _material_props; }
+
+  /**
    * Get the solver parameters
    */
   SolverParams & solverParams();

--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -1,0 +1,133 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef CHECKPOINT_H
+#define CHECKPOINT_H
+
+// MOOSE includes
+#include "OutputBase.h"
+#include "FileOutputInterface.h"
+#include "MaterialPropertyStorage.h"
+#include "RestartableData.h"
+#include "MaterialPropertyIO.h"
+#include "RestartableDataIO.h"
+
+// Forward declerations
+class Checkpoint;
+struct CheckpointFileNames;
+
+template<>
+InputParameters validParams<Checkpoint>();
+
+/**
+ * A structure for storing the various output files associated with checkpoint output
+ */
+struct CheckpointFileNames
+{
+  /// Filename for CheckpointIO file
+  std::string checkpoint;
+
+  /// Filename for EquationsSystems::write
+  std::string system;
+
+  /// Filename for stateful material property file
+  std::string material;
+
+  /// Filename for restartable data filename
+  std::string restart;
+};
+
+/**
+ *
+ */
+class Checkpoint:
+  public OutputBase,
+  public FileOutputInterface
+{
+public:
+
+  /**
+   * Class constructor
+   * @param name
+   * @param parameters
+   */
+  Checkpoint(const std::string & name, InputParameters & parameters);
+
+  /**
+   * Class destructor
+   */
+  virtual ~Checkpoint();
+
+  /**
+   * Outputs a checkpoint file.
+   * Each call to this function creates various files associated with
+   */
+  void output();
+
+  /**
+   * Returns the base filename for the checkpoint files
+   */
+  std::string filename();
+
+protected:
+
+  //@{
+  /**
+   * Invalid for Checkpoint output
+   */
+  virtual void outputNodalVariables();
+  virtual void outputElementalVariables();
+  virtual void outputScalarVariables();
+  virtual void outputPostprocessors();
+  //@}
+
+  void updateCheckpointFiles(CheckpointFileNames file_struct);
+
+private:
+
+  /**
+   * Retrieve the checkpoint output directory
+   * @return String containing the checkpoint output directory
+   */
+  std::string directory();
+
+  /// Max no. of output files to store
+  unsigned int _num_files;
+
+  /// Directory suffix
+  const std::string _suffix;
+
+  /// True if outputing checkpoint files in binary format
+  bool _binary;
+
+  /// Reference to the restartable data
+  const RestartableDatas & _restartable_data;
+
+  /// Reference to the recoverable data
+  std::set<std::string> & _recoverable_data;
+
+  /// Reference to the material property storage
+  const MaterialPropertyStorage & _material_property_storage;
+
+  /// MaterialProperty input/output interface
+  MaterialPropertyIO _material_property_io;
+
+  /// RestrableData input/output interface
+  RestartableDataIO _restartable_data_io;
+
+  /// Vector of checkpoint filename structures
+  std::vector<CheckpointFileNames> _file_names;
+};
+
+#endif //CHECKPOINT_H

--- a/framework/include/outputs/OutputBase.h
+++ b/framework/include/outputs/OutputBase.h
@@ -273,6 +273,12 @@ protected:
 
 protected:
 
+  /**
+   * Returns true if the output interval is satisfied
+   * \todo{Implement additional types of intervals (e.g., simulation time and real time)}
+   */
+  bool checkInterval();
+
   /// Pointer the the FEProblem object for output object (use this)
   FEProblem * _problem_ptr;
 
@@ -316,12 +322,6 @@ protected:
   bool _mesh_changed;
 
 private:
-
-  /**
-   * Returns true if the output interval is satisfied
-   * \todo{Implement additional types of intervals (e.g., simulation time and real time)}
-   */
-  bool checkInterval();
 
   /**
    * Initializes the available lists for each of the output types

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -29,6 +29,7 @@ InputParameters validParams<CommonOutputAction>()
    params.addParam<bool>("exodus", false, "Output the results using the default settings via the Exodus output");
    params.addParam<bool>("console", false, "Output the results to the screen using the default settings via the Console output");
    params.addParam<bool>("csv", false, "Output the scalar variable and postprocessors to a *.csv file using the default CSV output.");
+   params.addParam<bool>("checkpoint", false, "Create checkpoint files using the default options.");
 
    // Common parameters
    params.addParam<bool>("output_initial", true,  "Request that the initial condition is output to the solution file");
@@ -64,6 +65,9 @@ CommonOutputAction::act()
 
   if (getParam<bool>("csv"))
     create("CSV");
+
+  if (getParam<bool>("checkpoint"))
+    create("Checkpoint");
 }
 
 void

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -320,6 +320,7 @@
 #include "Exodus.h"
 #include "Console.h"
 #include "CSV.h"
+#include "Checkpoint.h"
 
 namespace Moose {
 
@@ -572,7 +573,7 @@ registerObjects(Factory & factory)
   registerOutput(Exodus);
   registerOutput(Console);
   registerOutput(CSV);
-
+  registerOutput(Checkpoint);
 
   registered = true;
 }

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -1,0 +1,225 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+// STL includes
+//#include <stdio.h>
+#include <sys/stat.h>
+
+// Moose includes
+#include "Checkpoint.h"
+#include "FEProblem.h"
+
+// libMesh includes
+#include "libmesh/checkpoint_io.h"
+
+template<>
+InputParameters validParams<Checkpoint>()
+{
+  // Get the parameters from the base classes
+  InputParameters params = validParams<OutputBase>();
+  params += validParams<FileOutputInterface>();
+
+  // Typical checkpoint options
+  params.addParam<unsigned int>("num_files", 2, "Number of the restart files to save");
+  params.addParam<std::string>("suffix", "cp", "This will be appended to the file_base to create the directory name for checkpoint files.");
+
+  // Advanced settings
+  params.addParam<bool>("binary", true, "Toggle the output of binary files");
+  params.addParamNamesToGroup("binary", "Advanced");
+
+  // Checkpoint files always output everything, so suppress the toggles
+  params.suppressParameter<bool>("output_nodal_variables");
+  params.suppressParameter<bool>("output_elemental_variables");
+  params.suppressParameter<bool>("output_scalar_variables");
+  params.suppressParameter<bool>("output_postprocessors");
+
+  return params;
+}
+
+Checkpoint::Checkpoint(const std::string & name, InputParameters & parameters) :
+    OutputBase(name, parameters),
+    FileOutputInterface(name, parameters),
+    _num_files(getParam<unsigned int>("num_files")),
+    _suffix(getParam<std::string>("suffix")),
+    _binary(getParam<bool>("binary")),
+    _restartable_data(_problem_ptr->getRestartableData()),
+    _recoverable_data(_problem_ptr->getRecoverableData()),
+    _material_property_storage(_problem_ptr->getMaterialPropertyStorage()),
+    _material_property_io(MaterialPropertyIO(*_problem_ptr)),
+    _restartable_data_io(RestartableDataIO(*_problem_ptr))
+{
+}
+
+Checkpoint::~Checkpoint()
+{
+}
+
+std::string
+Checkpoint::filename()
+{
+  // Get the time step with correct zero padding
+  std::ostringstream output;
+  output << std::setw(4)
+         << std::setprecision(0)
+         << std::setfill('0')
+         << std::right
+         << _t_step;
+  return output.str();
+}
+
+std::string
+Checkpoint::directory()
+{
+  return _file_base + "_" + _suffix;
+}
+
+
+void
+Checkpoint::output()
+{
+  // Do nothing if not on the desired interval
+  if (!checkInterval())
+    return;
+
+  // Start the performance log
+  Moose::perf_log.push("output()", "Checkpoint");
+
+  // Create the output directory
+  std::string cp_dir = directory();
+  mkdir(cp_dir.c_str(),  S_IRWXU | S_IRGRP);
+
+  // Create the output filename
+  std::string current_file = cp_dir + "/" + filename();
+
+  // Create the libMesh Checkpoint_IO object
+  MeshBase & mesh = _es_ptr->get_mesh();
+  CheckpointIO io(mesh, _binary);
+
+  // Set renumbering flag (renumber if adaptivity is on)
+  bool renumber = false;
+  if(_problem_ptr->adaptivity().isOn())
+    renumber = true;
+
+  // Create checkpoint file structure
+  CheckpointFileNames current_file_struct;
+  if (_binary)
+  {
+    current_file_struct.checkpoint = current_file + "_mesh.cpr";
+    current_file_struct.system = current_file + ".xdr";
+  }
+  else
+  {
+    current_file_struct.checkpoint = current_file + "_mesh.cpa";
+    current_file_struct.system = current_file + ".xda";
+  }
+  current_file_struct.restart = current_file + ".rd";
+  current_file_struct.material = current_file + ".msmp";
+
+  // Write the checkpoint file
+  io.write(current_file_struct.checkpoint);
+
+  // Write the xdr
+  _es_ptr->write(current_file_struct.system, libMeshEnums::ENCODE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA | EquationSystems::WRITE_PARALLEL_FILES, renumber);
+
+  // Write the restartable data
+  _restartable_data_io.writeRestartableData(current_file_struct.restart, _restartable_data, _recoverable_data);
+
+  // Write the material property data
+  if (_material_property_storage.hasStatefulProperties())
+    _material_property_io.write(current_file_struct.material);
+
+  // Remove old checkpoint files
+  updateCheckpointFiles(current_file_struct);
+
+  // Stop the logging
+  Moose::perf_log.pop("output()", "Checkpoint");
+}
+
+void
+Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
+{
+
+  // Update the list of stored files
+  _file_names.push_back(file_struct);
+
+  // Remove un-wanted files
+  if (_file_names.size() > _num_files)
+  {
+    // Extract the filenames to be removed
+    CheckpointFileNames delete_files = _file_names[0];
+
+    // Remove these filenames from the list
+    _file_names.erase(_file_names.begin());
+
+    // Get thread and proc information
+    unsigned int n_threads = libMesh::n_threads();
+    processor_id_type proc_id = libMesh::processor_id();
+
+    // Delete checkpoint files (_mesh.cpr)
+    remove(delete_files.checkpoint.c_str());
+
+    // Delete the system files (xdr and xdr.0000, ...)
+    remove(delete_files.system.c_str());
+    {
+      std::ostringstream oss;
+      oss << delete_files.system
+          << "." << std::setw(4)
+          << std::setprecision(0)
+          << std::setfill('0')
+          << proc_id;
+      remove( oss.str().c_str() );
+    }
+
+    // Remove material property files
+    remove(delete_files.material.c_str());
+
+    // Remove the material files
+    {
+      std::ostringstream oss;
+      oss << delete_files.material << '-' << proc_id;
+      remove(oss.str().c_str());
+    }
+
+    // Remove the restart files (rd)
+    {
+      std::ostringstream oss;
+      oss << delete_files.restart << "-" << proc_id;
+      remove(oss.str().c_str());
+    }
+  }
+}
+
+void
+Checkpoint::outputNodalVariables()
+{
+  mooseError("Invalid for Checkpoint output type");
+}
+
+void
+Checkpoint::outputElementalVariables()
+{
+  mooseError("Invalid for Checkpoint output type");
+}
+
+void
+Checkpoint::outputScalarVariables()
+{
+  mooseError("Invalid for Checkpoint output type");
+}
+
+void
+Checkpoint::outputPostprocessors()
+{
+  mooseError("Invalid for Checkpoint output type");
+}

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -13,7 +13,6 @@
 /****************************************************************/
 
 // STL includes
-//#include <stdio.h>
 #include <sys/stat.h>
 
 // Moose includes

--- a/test/tests/checkpoint/checkpoint_interval.i
+++ b/test/tests/checkpoint/checkpoint_interval.i
@@ -48,14 +48,19 @@
   petsc_options_value = 'hypre boomeramg'
 []
 
-[Output]
-  # Test the checkpoint interval parameter
-  checkpoint_interval = 3  # output every third timestep
-  num_checkpoint_files = 2  # keep the last two most recent checkpoint copies
-
+[Outputs]
   linear_residuals = true
   output_initial = true
   exodus = true
-  perf_log = true
+  [./checkpoint]
+  # Test the checkpoint interval parameter	   
+    type = Checkpoint
+     interval = 3  # output every third timestep
+     num_files = 2  # keep the last two most recent checkpoint copies
+  [../]
+  [./console]
+    type = Console
+    perf_log = true
+  [../]
 []
 

--- a/test/tests/outputs/checkpoint/checkpoint_interval.i
+++ b/test/tests/outputs/checkpoint/checkpoint_interval.i
@@ -1,0 +1,59 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+  distribution = serial
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Transient
+  num_steps = 11
+  dt = 0.1
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+  console = true
+  [./checkpoint]
+    type = Checkpoint
+    interval = 3
+    num_files = 2
+  [../]
+[]

--- a/test/tests/outputs/checkpoint/tests
+++ b/test/tests/outputs/checkpoint/tests
@@ -1,0 +1,35 @@
+[Tests]
+  [./test_files]
+    type = 'CheckFiles'
+    input = 'checkpoint_interval.i'
+    check_files =      'checkpoint_interval_out_cp/0006.xdr
+                        checkpoint_interval_out_cp/0006.xdr.0000
+			checkpoint_interval_out_cp/0006.rd-0
+			checkpoint_interval_out_cp/0006_mesh.cpr
+    		        checkpoint_interval_out_cp/0009.xdr
+                        checkpoint_interval_out_cp/0009.xdr.0000
+			checkpoint_interval_out_cp/0009.rd-0
+			checkpoint_interval_out_cp/0009_mesh.cpr'
+    check_not_exists = 'checkpoint_interval_out_cp/0003.xdr
+                        checkpoint_interval_out_cp/0003.xdr.0000
+			checkpoint_interval_out_cp/0003.rd-0
+			checkpoint_interval_out_cp/0003_mesh.cpr
+			checkpoint_interval_out_cp/0007.xdr
+                        checkpoint_interval_out_cp/0007.xdr.0000
+			checkpoint_interval_out_cp/0007.rd-0
+			checkpoint_interval_out_cp/0007_mesh.cpr
+			checkpoint_interval_out_cp/0008.xdr
+                        checkpoint_interval_out_cp/0008.xdr.0000
+			checkpoint_interval_out_cp/0008.rd-0
+			checkpoint_interval_out_cp/0008_mesh.cpr
+    		        checkpoint_interval_out_cp/0010.xdr
+                        checkpoint_interval_out_cp/0010.xdr.0000
+			checkpoint_interval_out_cp/0010.rd-0
+			checkpoint_interval_out_cp/0010_mesh.cpr'
+    recover = false
+
+    # The suffixes of these files change when running in parallel or with threads
+    max_parallel = 1
+    max_threads = 1
+  [../]
+[]

--- a/test/tests/restart/restart/part1.i
+++ b/test/tests/restart/restart/part1.i
@@ -74,12 +74,16 @@
   num_steps = 5
 []
 
-[Output]
+[Outputs]
   file_base = out_part1
-  output_initial = true
-  interval = 1
   exodus = true
-  xda = true
-  perf_log = true
-  num_checkpoint_files = 1
+  [./checkpoint]
+    type = Checkpoint
+    num_files = 1
+  [../]
+
+  [./console]
+    type = Console
+    perf_log = true
+  [../]
 []

--- a/test/tests/restart/restart/part2.i
+++ b/test/tests/restart/restart/part2.i
@@ -56,10 +56,11 @@
   restart_file_base = out_part1_cp/0005
 []
 
-[Output]
+[Outputs]
   file_base = out_part2
-  output_initial = true
-  interval = 1
   exodus = true
-  perf_log = true
+  [./console]
+    type = Console
+    perf_log = true
+  [../]
 []


### PR DESCRIPTION
Adds checkpoint file output (#1927):
- This new object handles all checkpoint/restart related output by creating *.rd, *.xdr/xda, *.msmp, *_mesh.cpr.
- This will eliminate the need for Resurrector::write() when the old system is removed.
