### PR TITLE
Not necessary to explicitly specify the libMeshEnums namespace.

### DIFF
--- a/framework/src/output/CheckpointOutput.C
+++ b/framework/src/output/CheckpointOutput.C
@@ -65,12 +65,12 @@ CheckpointOutput::output(const std::string & file_base, Real /*time*/, unsigned 
   if (_binary)
   {
     io.write(getFileName(file_base, t_step)+"_mesh.cpr");
-    _es.write (getFileName(file_base, t_step)+".xdr", libMeshEnums::ENCODE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA | EquationSystems::WRITE_PARALLEL_FILES, renumber);
+    _es.write (getFileName(file_base, t_step)+".xdr", ENCODE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA | EquationSystems::WRITE_PARALLEL_FILES, renumber);
   }
   else
   {
     io.write(getFileName(file_base, t_step)+"_mesh.cpa");
-    _es.write (getFileName(file_base, t_step)+".xda", libMeshEnums::WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA | EquationSystems::WRITE_PARALLEL_FILES, renumber);
+    _es.write (getFileName(file_base, t_step)+".xda", WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA | EquationSystems::WRITE_PARALLEL_FILES, renumber);
   }
 }
 

--- a/framework/src/output/XDAOutput.C
+++ b/framework/src/output/XDAOutput.C
@@ -53,12 +53,12 @@ XDAOutput::output(const std::string & file_base, Real /*time*/, unsigned int t_s
   if (_binary)
   {
     mesh.write(getFileName(file_base, t_step)+"_mesh.xdr");
-    _es.write (getFileName(file_base, t_step)+".xdr", libMeshEnums::ENCODE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
+    _es.write (getFileName(file_base, t_step)+".xdr", ENCODE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
   }
   else
   {
     mesh.write(getFileName(file_base, t_step)+"_mesh.xda");
-    _es.write (getFileName(file_base, t_step)+".xda", libMeshEnums::WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
+    _es.write (getFileName(file_base, t_step)+".xda", WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
   }
 }
 

--- a/framework/src/restart/Resurrector.C
+++ b/framework/src/restart/Resurrector.C
@@ -47,7 +47,7 @@ Resurrector::restartFromFile()
   Moose::setup_perf_log.push("restartFromFile()","Resurrector");
   std::string file_name(_restart_file_base + ".xdr");
   MooseUtils::checkFileReadable(file_name);
-  _fe_problem._eq.read(file_name, libMeshEnums::DECODE, EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA, _fe_problem.adaptivity().isOn());
+  _fe_problem._eq.read(file_name, DECODE, EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA, _fe_problem.adaptivity().isOn());
   _fe_problem._nl.update();
   Moose::setup_perf_log.pop("restartFromFile()","Resurrector");
 }


### PR DESCRIPTION
Also, this namespace will be going away soon - all libmesh enums
will be moving to the libMesh namespace instead.
