### PR TITLE
libMesh Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libmesh"]
-	path = libmesh
-	url = git@github.com:libMesh/libmesh.git
+        path = libmesh
+        url = https://github.com/libMesh/libmesh.git
         ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libmesh"]
+	path = libmesh
+	url = git@github.com:libMesh/libmesh.git
+        ignore = dirty

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -5,9 +5,9 @@
 # Set LIBMESH_DIR if it is not already set in the environment (try our best to guess!)
 IS_MOOSE_PROJECT  := $(shell dirname `pwd` | grep 'moose\>')
 ifeq (,$(IS_MOOSE_PROJECT))
-  LIBMESH_DIR     ?= ../libmesh/installed
+  LIBMESH_DIR     ?= ../moose/libmesh/installed
 else
-  LIBMESH_DIR     ?= ../../libmesh/installed
+  LIBMESH_DIR     ?= ../libmesh/installed
 endif
 
 # If the user has no environment variable

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+export LIBMESH_DIR=${LIBMESH_DIR:=`pwd`/libmesh/installed}
+export METHODS=${METHODS:="opt oprof dbg"}
+export JOBS=${JOBS:=1}
+
+git submodule init
+git submodule update
+cd libmesh
+rm -rf build installed
+mkdir build
+cd build
+../configure --with-methods="${METHODS}" \
+             --prefix=$LIBMESH_DIR \
+             --enable-silent-rules \
+             --enable-unique-id \
+             --disable-warnings \
+             --enable-openmp $*
+
+make -j $JOBS
+make install

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 
-export LIBMESH_DIR=${LIBMESH_DIR:=`pwd`/libmesh/installed}
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo $SCRIPT_DIR
+
+export LIBMESH_DIR=$SCRIPT_DIR/../libmesh/installed
 export METHODS=${METHODS:="opt oprof dbg"}
 export JOBS=${JOBS:=1}
 
+cd $SCRIPT_DIR/..
+
 git submodule init
 git submodule update
-cd libmesh
+
+cd $SCRIPT_DIR/../libmesh
+
 rm -rf build installed
 mkdir build
 cd build
+
 ../configure --with-methods="${METHODS}" \
              --prefix=$LIBMESH_DIR \
              --enable-silent-rules \


### PR DESCRIPTION
Refs #2460

This adds libMesh as a submodule in the moose directory and adds a script (update_and_rebuild_libmesh.sh) to a top level "scripts" directory.

How to use this script is detailed here: https://github.com/idaholab/moose/wiki/libMesh
