### PR TITLE
Unknown command line args passed to make

### DIFF
--- a/framework/scripts/dmake
+++ b/framework/scripts/dmake
@@ -138,7 +138,7 @@ def parseArguments(args=None):
   parser.parse_args('-mqvlrbdpoce'.split())
 
   # Parse the input and return the options
-  options = parser.parse_args()
+  options, unknown = parser.parse_known_args()
 
   # Set the output to be verbose and refresh to be true if --summary is used
   if options.summary:
@@ -146,7 +146,7 @@ def parseArguments(args=None):
     options.refresh = True
 
   # Return the options
-  return options
+  return (options, unknown)
 
 
 ## Helper function to extract options for **kwargs input
@@ -170,7 +170,8 @@ if __name__ == "__main__":
       sys.argv = sys.argv[0:idx]
 
   # Extract the options from the command line
-  options = parseArguments()
+  options, unknown = parseArguments()
+  make_args += unknown
 
   # Create the MachineWarehouse object, limit to the known networks
   opt = subOptions(options, 'allow')


### PR DESCRIPTION
All unknown command line arguments are now passed to make automatically (#2468), this is in addition to the arguments after the '--'.
