### PR TITLE
Optimizing couling matrix entries (closes #2535)

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -366,7 +366,7 @@ public:
   DenseMatrix<Number> & jacobianBlockNeighbor(Moose::DGJacobianType type, unsigned int ivar, unsigned int jvar);
   void cacheJacobianBlock(DenseMatrix<Number> & jac_block, std::vector<dof_id_type> & idof_indices, std::vector<dof_id_type> & jdof_indices, Real scaling_factor);
 
-  std::vector<std::pair<unsigned int, unsigned int> > & couplingEntries() { return _cm_entry; }
+  std::vector<std::pair<MooseVariable *, MooseVariable *> > & couplingEntries() { return _cm_entry; }
 
   const VariablePhiValue & phi() { return _phi; }
   const VariablePhiGradient & gradPhi() { return _grad_phi; }
@@ -426,8 +426,8 @@ protected:
   SystemBase & _sys;
   /// Reference to coupling matrix
   CouplingMatrix * & _cm;
-  /// Entries in the coupling matrix (only for element variables)
-  std::vector<std::pair<unsigned int, unsigned int> > _cm_entry;
+  /// Entries in the coupling matrix (only for field variables)
+  std::vector<std::pair<MooseVariable *, MooseVariable *> > _cm_entry;
   /// DOF map
   const DofMap & _dof_map;
   /// Thread number (id)

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -125,7 +125,7 @@ public:
   void setCouplingMatrix(CouplingMatrix * cm);
   CouplingMatrix * & couplingMatrix() { return _cm; }
 
-  std::vector<std::pair<unsigned int, unsigned int> > & couplingEntries(THREAD_ID tid) { return _assembly[tid]->couplingEntries(); }
+  std::vector<std::pair<MooseVariable *, MooseVariable *> > & couplingEntries(THREAD_ID tid) { return _assembly[tid]->couplingEntries(); }
 
   /**
    * Check for converence of the nonlinear solution

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -651,7 +651,7 @@ Assembly::init()
     {
       unsigned int i = (*it)->index();
       if ((*_cm)(i, j) != 0)
-        _cm_entry.push_back(std::pair<unsigned int, unsigned int>(i, j));
+        _cm_entry.push_back(std::pair<MooseVariable *, MooseVariable *>(*it, *jt));
     }
   }
 
@@ -706,13 +706,13 @@ Assembly::init()
 void
 Assembly::prepare()
 {
-  for (std::vector<std::pair<unsigned int, unsigned int> >::iterator it = _cm_entry.begin(); it != _cm_entry.end(); ++it)
+  for (std::vector<std::pair<MooseVariable *, MooseVariable *> >::iterator it = _cm_entry.begin(); it != _cm_entry.end(); ++it)
   {
-    unsigned int vi = (*it).first;
-    unsigned int vj = (*it).second;
+    MooseVariable & ivar = *(*it).first;
+    MooseVariable & jvar = *(*it).second;
 
-    MooseVariable & ivar = _sys.getVariable(_tid, vi);
-    MooseVariable & jvar = _sys.getVariable(_tid, vj);
+    unsigned int vi = ivar.index();
+    unsigned int vj = jvar.index();
 
     jacobianBlock(vi, vj).resize(ivar.dofIndices().size(), jvar.dofIndices().size());
     jacobianBlock(vi, vj).zero();
@@ -733,16 +733,16 @@ Assembly::prepare()
 void
 Assembly::prepareVariable(MooseVariable * var)
 {
-  for (std::vector<std::pair<unsigned int, unsigned int> >::iterator it = _cm_entry.begin(); it != _cm_entry.end(); ++it)
+  for (std::vector<std::pair<MooseVariable *, MooseVariable *> >::iterator it = _cm_entry.begin(); it != _cm_entry.end(); ++it)
   {
-    unsigned int vi = (*it).first;
-    unsigned int vj = (*it).second;
+    MooseVariable & ivar = *(*it).first;
+    MooseVariable & jvar = *(*it).second;
 
-    if(vi == var->index() || vj == var->index())
+    unsigned int vi = ivar.index();
+    unsigned int vj = jvar.index();
+
+    if (vi == var->index() || vj == var->index())
     {
-      MooseVariable & ivar = _sys.getVariable(_tid, vi);
-      MooseVariable & jvar = _sys.getVariable(_tid, vj);
-
       jacobianBlock(vi,vj).resize(ivar.dofIndices().size(), jvar.dofIndices().size());
     }
   }
@@ -757,13 +757,13 @@ Assembly::prepareVariable(MooseVariable * var)
 void
 Assembly::prepareNeighbor()
 {
-  for (std::vector<std::pair<unsigned int, unsigned int> >::iterator it = _cm_entry.begin(); it != _cm_entry.end(); ++it)
+  for (std::vector<std::pair<MooseVariable *, MooseVariable *> >::iterator it = _cm_entry.begin(); it != _cm_entry.end(); ++it)
   {
-    unsigned int vi = (*it).first;
-    unsigned int vj = (*it).second;
+    MooseVariable & ivar = *(*it).first;
+    MooseVariable & jvar = *(*it).second;
 
-    MooseVariable & ivar = _sys.getVariable(_tid, vi);
-    MooseVariable & jvar = _sys.getVariable(_tid, vj);
+    unsigned int vi = ivar.index();
+    unsigned int vj = jvar.index();
 
     jacobianBlockNeighbor(Moose::ElementNeighbor, vi, vj).resize(ivar.dofIndices().size(), jvar.dofIndicesNeighbor().size());
     jacobianBlockNeighbor(Moose::ElementNeighbor, vi, vj).zero();


### PR DESCRIPTION
For computing "full" matrix Jacobian, we store the list of blocks we
need to visit. Each block has a pair of unsigned ints identifying its
position the global matrix. When we go over the list, we take the number
and call `SystemBase::getVariable`. In this call we downcast to
MooseVariable and run checks agains NULL.  This is not necessary, since
we can just store `MooseVariable *` in the coupling list and use those
directly.

Motivation behind this: I saw about 2% of runtime being spend in
`Assembly::prepare`. After this patch the time looks like 0.2%.
