### PR TITLE
So adding /framework/ to every build os a bad idea

### DIFF
--- a/framework/scripts/build_coverage.py
+++ b/framework/scripts/build_coverage.py
@@ -14,7 +14,7 @@ def buildCMD(options):
       tmp_cmd.append([options.lcov_command[0],
                       '--capture',
                       '--initial',
-                      '--directory', os.getcwd() + '/' + options.application[0] + '/framework/',
+                      '--directory', os.getcwd() + '/' + options.application[0],
                       '--output-file', os.getcwd() + '/initialize.info'
                       ])
       tmp_cmd[0].extend(tmp_additional_directories)
@@ -22,7 +22,7 @@ def buildCMD(options):
       tmp_cmd.append([options.lcov_command[0],
                       '--capture',
                       '--initial',
-                      '--directory', os.getcwd() + '/' + options.application[0] + '/framework/',
+                      '--directory', os.getcwd() + '/' + options.application[0],
                       '--output-file', os.getcwd() + '/initialize.info'
                       ])
 
@@ -30,7 +30,7 @@ def buildCMD(options):
   if options.mode == 'generate':
     if len(options.application) > 1:
       tmp_cmd.append([options.lcov_command[0],
-                      '--directory', os.getcwd() + '/' + options.application[0] + '/framework/',
+                      '--directory', os.getcwd() + '/' + options.application[0],
                       '--capture',
                       '--ignore-errors', 'gcov,source',
                       '--output-file', os.getcwd() + '/covered.info'
@@ -38,7 +38,7 @@ def buildCMD(options):
       tmp_cmd[0].extend(tmp_additional_directories)
     else:
       tmp_cmd.append([options.lcov_command[0],
-                      '--directory', os.getcwd() + '/' + options.application[0] + '/framework/',
+                      '--directory', os.getcwd() + '/' + options.application[0],
                       '--capture',
                       '--ignore-errors', 'gcov,source',
                       '--output-file', os.getcwd() + '/covered.info'
@@ -52,8 +52,8 @@ def buildCMD(options):
 
     # Build lcov filter command
     tmp_cmd.append([options.lcov_command[0],
-                    '--extract', os.getcwd() + '/combined.info', '*' + options.application[0] + '/framework/src*',
-                    '--extract', os.getcwd() + '/combined.info', '*' + options.application[0] + '/framework/include*',
+                    '--extract', os.getcwd() + '/combined.info', '*' + options.application[0] + '/src*',
+                    '--extract', os.getcwd() + '/combined.info', '*' + options.application[0] + '/include*',
                     '--output-file', options.outfile ])
 
     # Build genhtml command if --generate-html was used

--- a/framework/scripts/timingHTML/timing_html
+++ b/framework/scripts/timingHTML/timing_html
@@ -13,3 +13,4 @@ cp -r moose/scripts/timingHTML/resources html/
 # rsync everything but the svn files
 find html -type d -name ".svn" -depth -exec rm -rf {} \;
 rsync -ro html/* hpcsc:/srv/www/ssl/MOOSE/timing/
+rsync -r html/* moosebuild.com:/var/documents/MOOSE/timing/


### PR DESCRIPTION
Lets update the recipes instead. Also duplicate the rsync command to push out the code coverage to moosebuild.com as well as internally. References #2546
