### PR TITLE
Fixing ambiguous pow function

### DIFF
--- a/framework/src/functions/PiecewiseMultilinear.C
+++ b/framework/src/functions/PiecewiseMultilinear.C
@@ -93,7 +93,7 @@ PiecewiseMultilinear::sample(const std::vector<Real> & pt)
   Real f = 0;
   Real weight;
   std::vector<unsigned int> arg(_dim);
-  for (unsigned int i = 0; i < std::pow(2, _dim); ++i) // number of points in hypercube = 2^_dim
+  for (unsigned int i = 0; i < std::pow(2.0, int(_dim)); ++i) // number of points in hypercube = 2^_dim
   {
     weight = 1;
     for (unsigned int j = 0; j < _dim; ++j)
@@ -154,4 +154,3 @@ PiecewiseMultilinear::getNeighborIndices(std::vector<Real> in_arr, Real x, unsig
       lower_x = upper_x - 1;
   }
 }
-


### PR DESCRIPTION
Fixing ambiguous std::pow call - #2460
