### PR TITLE
We need to have quotes around the arguments to -name when calling find.

### DIFF
--- a/scripts/delete_trailing_whitespace.sh
+++ b/scripts/delete_trailing_whitespace.sh
@@ -2,5 +2,4 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd $SCRIPT_DIR/..
-find . \( -name *.[Chi] -or -name *.py -or \( -name "contrib" -or -name "libmesh" \) -prune -and -type f \) -print0 | xargs -0 perl -pli -e "s/\s+$//"
+find $SCRIPT_DIR/.. \( -name "*.[Chi]" -or -name "*.py" -or \( -name "contrib" -or -name "libmesh" \) -prune -and -type f \) -print0 | xargs -0 perl -pli -e "s/\s+$//"


### PR DESCRIPTION
The 'find foo/bar/..' part is fine.

Refs #2566.
