### PR TITLE
Fixing type for "file_base" param in the Output system (refs #1927)

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -21,6 +21,7 @@
 #include <set>
 
 #include "Moose.h"
+#include "MooseTypes.h"
 #include "Parser.h"
 #include "MooseSyntax.h"
 #include "ActionWarehouse.h"
@@ -110,12 +111,12 @@ public:
   /**
    * Override the selection of the output file base name.
    */
-  void setOutputFileBase(std::string output_file_base) { _output_file_base = output_file_base; }
+  void setOutputFileBase(OutFileBase output_file_base) { _output_file_base = output_file_base; }
 
   /**
    * Override the selection of the output file base name.
    */
-  std::string getOutputFileBase();
+  OutFileBase getOutputFileBase();
 
   /**
    * Tell the app to output in a specific position.
@@ -327,7 +328,7 @@ protected:
   std::string _input_filename;
 
   /// The output file basename
-  std::string _output_file_base;
+  OutFileBase _output_file_base;
 
   /// Whether or not an output position has been set for this app
   bool _output_position_set;

--- a/framework/include/outputs/FileOutputter.h
+++ b/framework/include/outputs/FileOutputter.h
@@ -17,6 +17,7 @@
 
 // MOOSE includes
 #include "OutputBase.h"
+#include "MooseTypes.h"
 
 // Forward declerations
 class FileOutputter;
@@ -89,7 +90,7 @@ public:
    *
    * @see CommonOutputAction::setRecoverFileBase()
    */
-  static std::string getOutputFileBase(MooseApp & app);
+  static OutFileBase getOutputFileBase(MooseApp & app);
 
 protected:
 
@@ -101,7 +102,7 @@ protected:
   bool checkFilename();
 
   /// The base filename from the input paramaters
-  std::string _file_base;
+  OutFileBase _file_base;
 
   /// A file number counter, initialized to 0 (this must be controlled by the child class, see Exodus)
   unsigned int & _file_num;

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -52,7 +52,7 @@ InputParameters validParams<CommonOutputAction>()
    // Common parameters
    params.addParam<bool>("output_initial", false,  "Request that the initial condition is output to the solution file");
    params.addParam<bool>("output_final", false, "Force the final timestep to be output, regardless of output interval");
-   params.addParam<std::string>("file_base", "Common file base name to be utilized with all output objects");
+   params.addParam<OutFileBase>("file_base", "Common file base name to be utilized with all output objects");
    params.addParam<std::vector<std::string> >("output_if_base_contains", "If this is supplied then output will only be done in the case that the output base contains one of these strings.  This is helpful in outputing only a subset of outputs when using MultiApps.");
    params.addParam<unsigned int>("interval", 1, "The interval at which timesteps are output to the solution file");
    params.addParam<std::vector<Real> >("sync_times", "Times at which the output and solution is forced to occur");
@@ -253,9 +253,9 @@ CommonOutputAction::getRecoveryDirectory()
   // The TestHarness uses a specific checkpoint outputter and naming
   if (getParam<bool>("auto_recovery_part2"))
   {
-    std::string file_base;
+    OutFileBase file_base;
     if (isParamValid("file_base"))
-      file_base = _pars.get<std::string>("file_base");
+      file_base = _pars.get<OutFileBase>("file_base");
     if (file_base.empty())
       file_base = FileOutputter::getOutputFileBase(_app);
 
@@ -290,12 +290,12 @@ CommonOutputAction::getRecoveryDirectory()
       InputParameters & obj_pars = cp->getObjectParams();
 
       // Get the file base, checking the common and local parameters before using the default.
-      std::string file_base;
+      OutFileBase file_base;
       if (isParamValid("file_base"))
-        file_base = _pars.get<std::string>("file_base");
+        file_base = _pars.get<OutFileBase>("file_base");
 
       if (obj_pars.isParamValid("file_base"))
-        file_base = obj_pars.get<std::string>("file_base");
+        file_base = obj_pars.get<OutFileBase>("file_base");
 
       if (file_base.empty())
         file_base = FileOutputter::getOutputFileBase(_app);

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -230,7 +230,7 @@ MooseApp::setInputFileName(std::string input_filename)
   _input_filename = input_filename;
 }
 
-std::string
+OutFileBase
 MooseApp::getOutputFileBase()
 {
   return _output_file_base;

--- a/framework/src/outputs/FileOutputter.C
+++ b/framework/src/outputs/FileOutputter.C
@@ -24,7 +24,7 @@ InputParameters validParams<FileOutputter>()
 {
   // Create InputParameters object for this stand-alone object
   InputParameters params = validParams<OutputBase>();
-  params.addParam<std::string>("file_base", "The desired solution output name without an extension (Defaults appends '_out' to the input file name)");
+  params.addParam<OutFileBase>("file_base", "The desired solution output name without an extension (Defaults appends '_out' to the input file name)");
   params.addParam<bool>("append_displaced", false, "Append '_displaced' to the output file base");
   params.addParamNamesToGroup("append_displaced", "Displaced");
 
@@ -38,7 +38,7 @@ InputParameters validParams<FileOutputter>()
 
 FileOutputter::FileOutputter(const std::string & name, InputParameters & parameters) :
     OutputBase(name, parameters),
-    _file_base(getParam<std::string>("file_base")),
+    _file_base(getParam<OutFileBase>("file_base")),
     _file_num(declareRecoverableData<unsigned int>("file_num", 0)),
     _padding(getParam<unsigned int>("padding")),
     _output_file(true)
@@ -103,7 +103,7 @@ FileOutputter::outputFinal()
   OutputBase::outputFinal();
 }
 
-std::string
+OutFileBase
 FileOutputter::getOutputFileBase(MooseApp & app)
 {
   // If the App has an outputfile, then use it (MultiApp scenario)

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -503,23 +503,7 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
       }
     }
 
-    if (!found)
-    {
-      // In the case where we have OutFileName but it wasn't actually found in the input filename,
-      // we will populate it with the actual parsed filename which is available here in the parser.
-
-      InputParameters::Parameter<OutFileBase> * scalar_p = dynamic_cast<InputParameters::Parameter<OutFileBase>*>(it->second);
-      if (scalar_p)
-      {
-        std::string input_file_name = getFileName();
-        mooseAssert(input_file_name != "", "Input Filename is NULL");
-        size_t pos = input_file_name.find_last_of('.');
-        mooseAssert(pos != std::string::npos, "Unable to determine suffix of input file name");
-        scalar_p->set() = input_file_name.substr(0,pos) + "_out";
-        p.set_attributes(it->first, false);
-      }
-    }
-    else
+    if (found)
     {
       /**
        * Scalar types


### PR DESCRIPTION
The old system was using OutFileBase type, so should the new system. The
reason is that GUI uses this to open the file open window (IIRC).
