### PR TITLE
Limits tests to opt and oprof

### DIFF
--- a/test/tests/mesh/mesh_only/tests
+++ b/test/tests/mesh/mesh_only/tests
@@ -5,5 +5,6 @@
     cli_args = '--mesh-only 3d_chimney.e'
     exodiff = '3d_chimney.e'
     recover = false
+    method = 'opt oprof'
   [../]
 []

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -375,6 +375,7 @@
     type = 'RunException'
     input = 'wrong_moose_object_test.i'
     expect_err = "Task \w+ is not registered to build \w+ derived objects"
+    method = 'opt oprof'
   [../]
 
   [./wrong_object_test2]


### PR DESCRIPTION
Closes #2653 
- `mesh_only_test` is timing out in debug on multiple systems, so the test is being limited to `opt` and `oprof`
- `wrong_object_test` is printing a `[` in debug mode, otherwise the error is correct, so limiting to `opt` and `oprof`
