### PR TITLE
Allow users to supply parameters on the CLI that aren't already in the input file

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -115,6 +115,8 @@ public:
    */
   void showActions(bool state = true) { _show_actions = state; }
 
+  void showParser(bool state = true) { _show_parser = state; }
+
   //// Getters
   Syntax & syntax() { return _syntax; }
   MooseMesh * & mesh() { return _mesh; }
@@ -156,6 +158,7 @@ protected:
 
   // DEBUGGING
   bool _show_actions;
+  bool _show_parser;
 
   // When executing the actions in the warehouse, this string will always contain
   // the current task name

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -126,6 +126,9 @@ protected:
   /// Reference to an object that defines input file syntax
   Syntax & _syntax;
 
+  /// Appends sections from the CLI Reorders section names so that Debugging options can be enabled before parsing begins
+  void appendAndReorderSectionNames(std::vector<std::string> & section_names);
+
   /**
    * Helper functions for setting parameters of arbitrary types - bodies are in the .C file
    * since they are called only from this Object

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -30,6 +30,7 @@ ActionWarehouse::ActionWarehouse(MooseApp & app, Syntax & syntax, ActionFactory 
     _action_factory(factory),
     _generator_valid(false),
     _show_actions(false),
+    _show_parser(false),
     _mesh(NULL),
     _displaced_mesh(NULL),
     _problem(NULL),
@@ -77,12 +78,11 @@ ActionWarehouse::addActionBlock(Action * action)
   std::string registered_identifier = action->getParams().get<std::string>("registered_identifier");
   std::set<std::string> tasks;
 
-# if DEBUG_PARSER
-  Moose::err << COLOR_DEFAULT << "Parsing Syntax:        " << GREEN   << action->name() << '\n'
-             << COLOR_DEFAULT << "Building Action:       " << DEFAULT << action->type() << '\n'
-             << COLOR_DEFAULT << "Registered Identifier: " << GREEN   << registered_identifier << '\n'
-             << COLOR_DEFAULT << "Specific Task:         " << CYAN    << action->specificTaskName() << '\n';
-# endif
+  if (_show_parser)
+    Moose::err << COLOR_DEFAULT << "Parsing Syntax:        " << GREEN   << action->name() << '\n'
+               << COLOR_DEFAULT << "Building Action:       " << COLOR_DEFAULT << action->type() << '\n'
+               << COLOR_DEFAULT << "Registered Identifier: " << GREEN   << registered_identifier << '\n'
+               << COLOR_DEFAULT << "Specific Task:         " << CYAN    << action->specificTaskName() << '\n';
 
   /**
    * We need to see if the current Action satisfies multiple tasks. There are a few cases to consider:
@@ -143,17 +143,15 @@ ActionWarehouse::addActionBlock(Action * action)
     // Add the current task to current action
     action->appendTask(*it);
 
-#   if DEBUG_PARSER
-    Moose::err << YELLOW << "Adding Action:         " << COLOR_DEFAULT << action->type() << " (" << YELLOW << *it << COLOR_DEFAULT << ")\n";
-#   endif
+    if (_show_parser)
+      Moose::err << YELLOW << "Adding Action:         " << COLOR_DEFAULT << action->type() << " (" << YELLOW << *it << COLOR_DEFAULT << ")\n";
 
     // Add it to the warehouse
     _action_blocks[*it].push_back(action);
   }
-# if DEBUG_PARSER
-  Moose::err << std::endl;
-# endif
 
+  if (_show_parser)
+    Moose::err << std::endl;
 }
 
 ActionIterator

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -24,6 +24,7 @@ InputParameters validParams<SetupDebugAction>()
   params.addParam<unsigned int>("show_top_residuals", 0, "The number of top residuals to print out (0 = no output)");
   params.addParam<bool>("show_var_residual_norms", false, "Print the residual norms of the individual solution variables at each nonlinear iteration");
   params.addParam<bool>("show_actions", false, "Print out the actions being executed");
+  params.addParam<bool>("show_parser", false, "Shows parser block extraction and debugging information");
   params.addParam<bool>("show_material_props", false, "Print out the material properties supplied for each block, face, neighbor, and/or sideset");
   return params;
 }
@@ -33,6 +34,7 @@ SetupDebugAction::SetupDebugAction(const std::string & name, InputParameters par
     _top_residuals(getParam<unsigned int>("show_top_residuals"))
 {
   _awh.showActions(getParam<bool>("show_actions"));
+  _awh.showParser(getParam<bool>("show_parser"));
 }
 
 SetupDebugAction::~SetupDebugAction()
@@ -50,5 +52,3 @@ SetupDebugAction::act()
       _problem->printMaterialMap();
   }
 }
-
-

--- a/modules/combined/tests/chemical_reactions/tests
+++ b/modules/combined/tests/chemical_reactions/tests
@@ -2,21 +2,18 @@
   [./langmuir_jac1]
     type = 'PetscJacobianTester'
     input = 'langmuir_jac1.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-6
     difference_tol = 1E10
   [../]
   [./langmuir_jac2]
     type = 'PetscJacobianTester'
     input = 'langmuir_jac2.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-6
     difference_tol = 1E10
   [../]
   [./langmuir_jac3]
     type = 'PetscJacobianTester'
     input = 'langmuir_jac3.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-6
     difference_tol = 1E10
   [../]

--- a/modules/richards/tests/jacobian_1/tests
+++ b/modules/richards/tests/jacobian_1/tests
@@ -2,112 +2,96 @@
   [./jn01]
     type = 'PetscJacobianTester'
     input = 'jn01.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn02]
     type = 'PetscJacobianTester'
     input = 'jn02.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn03]
     type = 'PetscJacobianTester'
     input = 'jn03.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn04]
     type = 'PetscJacobianTester'
     input = 'jn04.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn05]
     type = 'PetscJacobianTester'
     input = 'jn05.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn06]
     type = 'PetscJacobianTester'
     input = 'jn06.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn07]
     type = 'PetscJacobianTester'
     input = 'jn07.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn08]
     type = 'PetscJacobianTester'
     input = 'jn08.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn09]
     type = 'PetscJacobianTester'
     input = 'jn09.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn10]
     type = 'PetscJacobianTester'
     input = 'jn10.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn11]
     type = 'PetscJacobianTester'
     input = 'jn11.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn12]
     type = 'PetscJacobianTester'
     input = 'jn12.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn13]
     type = 'PetscJacobianTester'
     input = 'jn13.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn14]
     type = 'PetscJacobianTester'
     input = 'jn14.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn15]
     type = 'PetscJacobianTester'
     input = 'jn15.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn16]
     type = 'PetscJacobianTester'
     input = 'jn16.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
@@ -115,7 +99,6 @@
   [./jn20]
     type = 'PetscJacobianTester'
     input = 'jn20.i'
-    cli_args = 'Output/exodus=false'
     # can't make too tight as finite-difference constant state bums out due to precision loss
     ratio_tol = 1E-5 
     difference_tol = 1E10
@@ -123,7 +106,6 @@
   [./jn21]
     type = 'PetscJacobianTester'
     input = 'jn21.i'
-    cli_args = 'Output/exodus=false'
     # can't make too tight as finite-difference constant state bums out due to precision loss
     ratio_tol = 1E-5
     difference_tol = 1E10
@@ -131,7 +113,6 @@
   [./jn22]
     type = 'PetscJacobianTester'
     input = 'jn22.i'
-    cli_args = 'Output/exodus=false'
     # can't make too tight as finite-difference constant state bums out due to precision loss
     ratio_tol = 1E-6
     difference_tol = 1E10
@@ -140,7 +121,6 @@
   [./jn30]
     type = 'PetscJacobianTester'
     input = 'jn30.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7 
     difference_tol = 1E10
     skip = 'snes test incorrect with Dirac - see ticket2379'
@@ -149,7 +129,6 @@
   [./jn40]
     type = 'PetscJacobianTester'
     input = 'jn40.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7 
     difference_tol = 1E10
   [../]

--- a/modules/richards/tests/jacobian_2/tests
+++ b/modules/richards/tests/jacobian_2/tests
@@ -2,56 +2,48 @@
   [./jn01]
     type = 'PetscJacobianTester'
     input = 'jn01.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn02]
     type = 'PetscJacobianTester'
     input = 'jn02.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn03]
     type = 'PetscJacobianTester'
     input = 'jn03.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn04]
     type = 'PetscJacobianTester'
     input = 'jn04.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn05]
     type = 'PetscJacobianTester'
     input = 'jn05.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn06]
     type = 'PetscJacobianTester'
     input = 'jn06.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn07]
     type = 'PetscJacobianTester'
     input = 'jn07.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn08]
     type = 'PetscJacobianTester'
     input = 'jn08.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
@@ -59,14 +51,12 @@
   [./jn17]
     type = 'PetscJacobianTester'
     input = 'jn17.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
   [./jn18]
     type = 'PetscJacobianTester'
     input = 'jn18.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
@@ -74,7 +64,6 @@
   [./jn22]
     type = 'PetscJacobianTester'
     input = 'jn22.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
@@ -82,7 +71,6 @@
   [./jn38]
     type = 'PetscJacobianTester'
     input = 'jn38.i'
-    cli_args = 'Output/exodus=false'
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]

--- a/test/tests/output/output_format/output_test_gnuplot_gif.i
+++ b/test/tests/output/output_format/output_test_gnuplot_gif.i
@@ -1,0 +1,74 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  nz = 0
+  zmin = 0
+  zmax = 0
+  elem_type = QUAD4
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  active = 'diff'
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  active = 'left right'
+
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 3
+    value = 1
+  [../]
+[]
+
+[Postprocessors]
+  [./dofs]
+    type = NumDOFs
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  file_base = out_gif
+  output_initial = true
+  [./gnuplot]
+    type = GNUPlot
+    extension = gif
+  [../]
+
+  [./console]
+    type = Console
+    linear_residuals = true
+    perf_log = true
+  [../]
+[]

--- a/test/tests/output/output_format/output_test_gnuplot_ps.i
+++ b/test/tests/output/output_format/output_test_gnuplot_ps.i
@@ -1,0 +1,74 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  nz = 0
+  zmin = 0
+  zmax = 0
+  elem_type = QUAD4
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  active = 'diff'
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  active = 'left right'
+
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 3
+    value = 1
+  [../]
+[]
+
+[Postprocessors]
+  [./dofs]
+    type = NumDOFs
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  file_base = out_ps
+  output_initial = true
+  [./gnuplot]
+    type = GNUPlot
+    extension = ps
+  [../]
+
+  [./console]
+    type = Console
+    linear_residuals = true
+    perf_log = true
+  [../]
+[]

--- a/test/tests/output/output_format/tests
+++ b/test/tests/output/output_format/tests
@@ -45,9 +45,8 @@
 
   [./gnuplot_ps_out_test]
     type = 'CheckFiles'
-    input = 'output_test_gnuplot.i'
+    input = 'output_test_gnuplot_ps.i'
     check_files = 'out_ps.gp out_ps.dat'
-    cli_args = 'Outputs/gnuplot/extension=ps Outputs/file_base=out_ps'
   [../]
 
   [./gnuplot_png_out_test]
@@ -55,15 +54,12 @@
     input = 'output_test_gnuplot.i'
     check_files = 'out_png.gp out_png.dat'
     cli_args = 'Outputs/file_base=out_png'
-    prereq = 'gnuplot_ps_out_test'
   [../]
 
  [./gnuplot_gif_out_test]
     type = 'CheckFiles'
-    input = 'output_test_gnuplot.i'
+    input = 'output_test_gnuplot_gif.i'
     check_files = 'out_gif.gp out_gif.dat'
-    cli_args = 'Outputs/gnuplot/extension=gif Outputs/file_base=out_gif'
-    prereq = 'gnuplot_png_out_test'
   [../]
 
   [./pps_screen_out_warn_test]


### PR DESCRIPTION
This patch allows users to supply parameters that don't already exist in the input file.  This is most useful for the Debug block where you can turn on debugging parameters now on the CLI. 

Closes #2701
