### PR TITLE
Use relative path #2709

### DIFF
--- a/framework/scripts/TestHarness/TestHarness.py
+++ b/framework/scripts/TestHarness/TestHarness.py
@@ -78,7 +78,7 @@ class TestHarness:
     else:
       self.options.processingPBS = False
       for dirpath, dirnames, filenames in os.walk(os.getcwd(), followlinks=True):
-        if (self.test_match.search(dirpath) and "contrib" not in dirpath):
+        if (self.test_match.search(dirpath) and "contrib" not in os.path.relpath(dirpath, os.getcwd())):
           for file in filenames:
             # set cluster_handle to be None initially (happens for each test)
             self.options.cluster_handle = None


### PR DESCRIPTION
This will allow run_tests script to run properly when the app directory contains 'contrib'.
