### PR TITLE
Fixing seg fault in #380

### DIFF
--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -177,6 +177,8 @@ protected:
   virtual VariableValue & coupledDotDu(const std::string & var_name, unsigned int comp = 0);
 
 protected:
+  // Reference to FEProblem
+  FEProblem & _c_fe_problem;
 
   /// Coupled vars whose values we provide
   std::map<std::string, std::vector<MooseVariable *> > _coupled_vars;
@@ -202,7 +204,6 @@ protected:
   /// This will always be zero because the default values for optionally coupled variables is always constant
   VariableSecond _default_second;
 
-
   /**
    * Extract pointer to a coupled variable
    * @param var_name Name of parameter desired
@@ -211,9 +212,14 @@ protected:
    */
   MooseVariable *getVar(const std::string & var_name, unsigned int comp);
 
+  /**
+   * Checks to make sure that the current Executioner has set "_it_transient" when old/older values
+   * are coupled in.
+   * @param name the name of the varaible
+   */
+  void validateExecutionerType(const std::string & name) const;
 
 private:
-
   /// Maximum qps for any element in this system
   unsigned int _coupleable_max_qps;
 

--- a/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
@@ -32,9 +32,9 @@ TensorMechanicsMaterial::TensorMechanicsMaterial(const std::string & name,
       _grad_disp_x(coupledGradient("disp_x")),
       _grad_disp_y(coupledGradient("disp_y")),
       _grad_disp_z(_mesh.dimension() == 3 ? coupledGradient("disp_z") : _grad_zero),
-      _grad_disp_x_old(coupledGradientOld("disp_x")),
-      _grad_disp_y_old(coupledGradientOld("disp_y")),
-      _grad_disp_z_old(_mesh.dimension() == 3 ? coupledGradientOld("disp_z") : _grad_zero),
+      _grad_disp_x_old(_fe_problem.isTransient() ? coupledGradientOld("disp_x") : _grad_zero),
+      _grad_disp_y_old(_fe_problem.isTransient() ? coupledGradientOld("disp_y") : _grad_zero),
+      _grad_disp_z_old(_fe_problem.isTransient() && _mesh.dimension() == 3 ? coupledGradientOld("disp_z") : _grad_zero),
       _stress(declareProperty<RankTwoTensor>("stress")),
       _elastic_strain(declareProperty<RankTwoTensor>("elastic_strain")),
       _elasticity_tensor(declareProperty<ElasticityTensorR4>("elasticity_tensor")),
@@ -80,4 +80,3 @@ void TensorMechanicsMaterial::computeStrain()
     computeQpStrain();
 
 }
-

--- a/test/src/kernels/CoupledConvection.C
+++ b/test/src/kernels/CoupledConvection.C
@@ -5,12 +5,13 @@ InputParameters validParams<CoupledConvection>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredCoupledVar("velocity_vector", "Velocity Vector for the Convection Kernel");
+  params.addParam<bool>("lag_coupling", false, "Tells the object to use the old velocity vector instead of the current vector");
   return params;
 }
 
 CoupledConvection::CoupledConvection(const std::string & name, InputParameters parameters) :
   Kernel(name, parameters),
-  _velocity_vector(coupledGradient("velocity_vector"))
+  _velocity_vector(getParam<bool>("lag_coupling") ? coupledGradientOld("velocity_vector") : coupledGradient("velocity_vector"))
 {}
 
 Real

--- a/test/tests/misc/check_error/old_integrity_check.i
+++ b/test/tests/misc/check_error/old_integrity_check.i
@@ -1,0 +1,80 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = -1
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  nx = 20
+  ny = 10
+  elem_type = QUAD9
+[]
+
+[Functions]
+  [./bc_fn_v]
+    type = ParsedFunction
+    value = (x*x+y*y)
+  [../]
+[]
+
+[Variables]
+  [./v]
+    family = LAGRANGE
+    order = SECOND
+  [../]
+
+  [./u]
+    family = LAGRANGE
+    order = SECOND
+  [../]
+[]
+
+[Kernels]
+  # V equation
+  [./td_v]
+    type = TimeDerivative
+    variable = v
+  [../]
+  [./diff_v]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.5
+  [../]
+  [./conv_v]
+    type = CoupledConvection
+    variable = v
+    velocity_vector = u
+    lag_coupling = true    # Here we are asking for an old value but this is a steady test!
+  [../]
+[]
+
+[BCs]
+  [./top_v]
+    type = FunctionDirichletBC
+    variable = v
+    boundary = top
+    function = bc_fn_v
+  [../]
+
+  [./left_u]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right_u]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  output_initial = false
+  exodus = true
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -402,4 +402,10 @@
     input = 'ic_bnd_for_non_nodal.i'
     expect_err = "You are trying to set a boundary restricted variable on non-nodal variable.  That is not allowed."
   [../]
+
+  [./old_integrity_check]
+    type = 'RunException'
+    input = 'old_integrity_check.i'
+    expect_err = 'You may not couple in old or older values of \S+ when using a \"Steady\" executioner.'
+  [../]
 []


### PR DESCRIPTION
This is a simple integrity check that has been missing from MOOSE since nearly the beginning!  All we are doing is checking whether we are using old or older values when we have a Steady executioner.  Currently this causes a seg fault in MOOSE if unchecked.

The problem is that this PR breaks about 5 tests in Yak.  
@YaqiWang and @friedmud have differing opinions on how to resolve this.  The issue is over what "isTransient()" means: to @friedmud this means the machinery in MOOSE that enables "transient" old/older storage, to @YaqiWang this means a calculation that takes place over several timesteps (well, that's one of the meanings that those Neutronics guys use).  

I think the best way to resolve this is to give each party a SuperSoaker and to send them outside... We'll see :)
