### PR TITLE
Improved performance log control

### DIFF
--- a/framework/include/actions/PerfLogOutputAction.h
+++ b/framework/include/actions/PerfLogOutputAction.h
@@ -1,0 +1,56 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef PERFLOGOUTPUTACTION_H
+#define PERFLOGOUTPUTACTION_H
+
+// MOOSE includes
+#include "Action.h"
+
+// Forward declerations
+class PerfLogOutputAction;
+
+template<>
+InputParameters validParams<PerfLogOutputAction>();
+
+/**
+ * In general the Console output object controls all aspects of toggling performance logging.
+ * However, there are two scenarios where additional control is needed:
+ *   (1) If there is no Console object the logging must be disabled
+ *   (2) If --timing is used from the command-line all logs are enabled, overriding whatever
+ *       the Console object(s) are doing
+ */
+class PerfLogOutputAction : public Action
+{
+public:
+
+  /**
+   * Class constructor
+   * @param name The action name
+   * @param params The action parameters
+   */
+  PerfLogOutputAction(const std::string & name, InputParameters params);
+
+  /**
+   * Class destructor
+   */
+  virtual ~PerfLogOutputAction();
+
+  /**
+   * Set the appropriate state for the performance logs given the outputs and use of --timing
+   */
+  virtual void act();
+};
+
+#endif //PERFLOGOUTPUTACTION_H

--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -157,6 +157,11 @@ protected:
   /// State for setup performance log
   bool _setup_log;
 
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  /// Control the display libMesh performance log
+  bool _libmesh_log;
+#endif
+
   /// State for early setup log printing
   bool _setup_log_early;
 
@@ -177,6 +182,11 @@ protected:
 
   /// Line length for printing simulation information
   static const unsigned int _line_length = 100;
+
+private:
+
+  /// State of the --timing command line argument from MooseApp
+  bool _timing;
 };
 
 #endif /* CONSOLE_H */

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -52,6 +52,12 @@ public:
   void addOutput(OutputBase * output);
 
   /**
+   * Get a complete list of all output objects
+   * @return A vector of pointers to each of the output objects
+   */
+  const std::vector<OutputBase *> & getOutputs();
+
+  /**
    * Returns true if the output object exists
    * @param name The name of the output object for which to test for existence within the warehouse
    */

--- a/framework/src/actions/PerfLogOutputAction.C
+++ b/framework/src/actions/PerfLogOutputAction.C
@@ -1,0 +1,74 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+// MOOSE includes
+#include "PerfLogOutputAction.h"
+#include "OutputBase.h"
+#include "Console.h"
+#include "MooseApp.h"
+
+template<>
+InputParameters validParams<PerfLogOutputAction>()
+{
+  InputParameters params = validParams<Action>();
+  return params;
+}
+
+PerfLogOutputAction::PerfLogOutputAction(const std::string & name, InputParameters params) :
+  Action(name, params)
+{
+}
+
+PerfLogOutputAction::~PerfLogOutputAction()
+{
+}
+
+void
+PerfLogOutputAction::act()
+{
+
+  // Search for the existence of a Console outputter
+  bool has_console = false;
+  const std::vector<OutputBase *> & ptrs = _app.getOutputWarehouse().getOutputs();
+  for (std::vector<OutputBase *>::const_iterator it = ptrs.begin(); it != ptrs.end(); ++it)
+  {
+    Console * c_ptr = dynamic_cast<Console *>(*it);
+    if (c_ptr != NULL)
+    {
+      has_console = true;
+      break;
+    }
+  }
+
+  /* If a Console outputter is found then all the correct handling of performance logs are
+     handled within the object(s), so do nothing */
+  if (!has_console)
+  {
+    Moose::perf_log.disable_logging();
+    Moose::setup_perf_log.disable_logging();
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+    libMesh::perflog.disable_logging();
+#endif
+  }
+
+  // If the --timing option is used from the command-line, enable all logging
+  if (_app.getParam<bool>("timing"))
+  {
+    Moose::perf_log.enable_logging();
+    Moose::setup_perf_log.enable_logging();
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+    libMesh::perflog.enable_logging();
+#endif
+  }
+}

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -316,7 +316,7 @@
 #include "SetupPredictorAction.h"
 #include "AddMortarInterfaceAction.h"
 #include "SetupPostprocessorDataAction.h"
-
+#include "PerfLogOutputAction.h"
 
 // Outputs
 #include "Exodus.h"
@@ -701,6 +701,8 @@ addActionTypes(Syntax & syntax)
   registerTask("ready_to_init", true);
   registerTask("setup_pps_complete", false);
 
+  registerTask("perf_log_output", true);
+
   /**************************/
   /****** Dependencies ******/
   /**************************/
@@ -756,6 +758,7 @@ addActionTypes(Syntax & syntax)
 "(add_postprocessor)"
 "(setup_pps_complete)"
 "(add_aux_bc, add_aux_kernel, add_bc, add_damper, add_dirac_kernel, add_kernel, add_dg_kernel, add_scalar_kernel, add_aux_scalar_kernel, add_indicator, add_marker, add_output)"
+"(perf_log_output)"
 "(setup_output)"
 "(setup_oversampling)"
 "(setup_debug)"
@@ -766,8 +769,7 @@ addActionTypes(Syntax & syntax)
 
 /**
  * Multiple Action class can be associated with a single input file section, in which case all associated Actions
- * will be created and "acted" on when the associated input file section is seen.
- *
+ * will be created and "acted" on when the associated input file section is seen.b *
  * Example:
  *  "setup_mesh" <-----------> SetupMeshAction <---------
  *                                                        \
@@ -815,6 +817,10 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
   registerAction(CommonOutputAction, "meta_action");
   registerAction(GlobalParamsAction, "set_global_params");
   registerAction(SetupPredictorAction, "setup_predictor");
+
+  /* The display of performance long is controlled by the Console outputter, if there is not one present
+     logging must be disable externally from the object, this action does this */
+  registerAction(PerfLogOutputAction, "perf_log_output");
 
   /// Variable/AuxVariable Actions
   registerAction(AddVariableAction, "add_variable");

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -61,6 +61,8 @@ InputParameters validParams<MooseApp>()
 
   params.addCommandLineParam<bool>("trap_fpe", "--trap-fpe", "Enable Floating Point Exception handling in critical sections of code.  This is enabled automatically in DEBUG mode");
 
+  params.addCommandLineParam<bool>("timing", "-t --timing", "Enable all performance logging for timing purposes. This will disable all screen output of performance logs for all Console objects.");
+
   params.addPrivateParam<int>("_argc");
   params.addPrivateParam<char**>("_argv");
 
@@ -137,6 +139,9 @@ MooseApp::setupOptions()
 
   if (isParamValid("half_transient"))
     _half_transient = true;
+
+  if (isParamValid("timing"))
+    _pars.set<bool>("timing") = true;
 
   if (isParamValid("trap_fpe"))
     // Seting Global Variable

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -54,7 +54,6 @@ OutputWarehouse::timestepSetup()
     (*it)->timestepSetupInternal();
     (*it)->timestepSetup();
   }
-
 }
 
 void
@@ -100,6 +99,12 @@ bool
 OutputWarehouse::hasOutput(std::string name)
 {
   return _output_names.find(name) != _output_names.end();
+}
+
+const std::vector<OutputBase *> &
+OutputWarehouse::getOutputs()
+{
+  return _object_ptrs;
 }
 
 void

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -64,6 +64,13 @@
     input = 'console.i'
     cli_args = 'Outputs/screen/all_variable_norms=true'
     expect_out = 'Variable Residual Norms:'
-    #expect_out = 'Variable Residual Norms:\n\s*u:\s.*\n\s*v:'
   [../]
+  [./timing]
+    # Tests that the --timing enables all logs
+    type = RunApp
+    input = 'console.i'
+    cli_args = 'Outputs/screen/perf_log=false --timing'
+    expect_out = 'Moose\sTest\sPerformance:'
+  [../]
+
 []


### PR DESCRIPTION
The patch does two things:
1. Adds the ability, if --enable-perflog is used in libMesh, to control the output of the libMesh log from the `Console` object (closes #2721)
2. Adds a `-t` or `--timing` command-line argument added to executable that will force all-logging to be enabled (closes #2722)
