### PR TITLE
Fixing un-initialized value

### DIFF
--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -59,7 +59,7 @@ time_t Factory::parseTime(const std::string t_str)
 {
   // The string must be a certain length to be valid
   if (t_str.size() != 16)
-    mooseError("The deprected time not formatted correctly; it must be given as mm/dd/yyyy HH:MM");
+    mooseError("The deprecated time not formatted correctly; it must be given as mm/dd/yyyy HH:MM");
 
   // Store the time, the time must be specified as: mm/dd/yyyy HH:MM
   time_t t_end;

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -140,8 +140,11 @@ MooseApp::setupOptions()
   if (isParamValid("half_transient"))
     _half_transient = true;
 
+  // Set the timing parameter (see src/outputs/Console.C)
   if (isParamValid("timing"))
     _pars.set<bool>("timing") = true;
+  else
+    _pars.set<bool>("timing") = false;
 
   if (isParamValid("trap_fpe"))
     // Seting Global Variable

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -76,7 +76,7 @@ Exodus::outputSetup()
     // Set the recovering flag to false so that this special case is not triggered again
     _recovering = false;
 
-    // Set the append flag to true b/c on revover the file is being appended
+    // Set the append flag to true b/c on recover the file is being appended
     _exodus_io_ptr->append(true);
   }
   else

--- a/framework/src/outputs/OversampleOutputter.C
+++ b/framework/src/outputs/OversampleOutputter.C
@@ -28,7 +28,7 @@ InputParameters validParams<OversampleOutputter>()
 
   params.addParam<bool>("oversample", false, "Set to true to enable oversampling");
   params.addParam<unsigned int>("refinements", 0, "Number of uniform refinements for oversampling");
-  params.addParam<Point>("position", "Set a positional offset, this vector will get added to the nodal cooardinates to move the domain.");
+  params.addParam<Point>("position", "Set a positional offset, this vector will get added to the nodal coordinates to move the domain.");
   params.addParam<bool>("append_oversample", false, "Append '_oversample' to the output file base");
   params.addParam<MeshFileName>("file", "The name of the mesh file to read, for oversampling");
 
@@ -57,7 +57,7 @@ OversampleOutputter::OversampleOutputter(const std::string & name, InputParamete
 
 OversampleOutputter::~OversampleOutputter()
 {
-  // When the Oversamle::initOversample() is called it creates new objects for the _mesh_ptr and _es_ptr
+  // When the Oversample::initOversample() is called it creates new objects for the _mesh_ptr and _es_ptr
   // that contain the refined mesh and variables. Also, the _mesh_functions vector and _serialized_solution
   // pointer are populated. In this case, it is the responsibility of the output object to clean these things
   // up. If oversampling is not being used then you must not delete the _mesh_ptr and _es_ptr because


### PR DESCRIPTION
Could someone else try to run with this patch through valgrind, I am currently getting a huge number of failing tests with the following (I am using rod with gcc on current libMesh):

```
kernels/adv_diff_reaction_transient.test: ==31725== LEAK SUMMARY:
kernels/adv_diff_reaction_transient.test: ==31725==    definitely lost: 42,763 bytes in 40 blocks
kernels/adv_diff_reaction_transient.test: ==31725==    indirectly lost: 11,278 bytes in 38 blocks
kernels/adv_diff_reaction_transient.test: ==31725==      possibly lost: 0 bytes in 0 blocks
kernels/adv_diff_reaction_transient.test: ==31725==    still reachable: 313,759 bytes in 1,583 blocks
kernels/adv_diff_reaction_transient.test: ==31725==         suppressed: 60 bytes in 1 blocks
kernels/adv_diff_reaction_transient.test: ==31725== Reachable blocks (those to which a pointer was found) are not shown.
kernels/adv_diff_reaction_transient.test: ==31725== To see them, rerun with: --leak-check=full --show-reachable=yes
kernels/adv_diff_reaction_transient.test: ==31725== 
kernels/adv_diff_reaction_transient.test: ==31725== ERROR SUMMARY: 39 errors from 39 contexts (suppressed: 32 from 4)
kernels/adv_diff_reaction_transient.test: ==31725== 
kernels/adv_diff_reaction_transient.test: ==31725== 1 errors in context 1 of 39:
kernels/adv_diff_reaction_transient.test: ==31725== Syscall param writev(vector[...]) points to uninitialised byte(s)
kernels/adv_diff_reaction_transient.test: ==31725==    at 0x8206D4B: writev (writev.c:51)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x109C6932: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x109C76BC: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x109CAB16: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x103B5834: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x103B5D7F: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x10DD6167: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7AD7EB9: ompi_mpi_init (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7AEE9AA: PMPI_Init (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x676B9EB: libMesh::LibMeshInit::LibMeshInit(int, char const* const*, ompi_communicator_t*) (libmesh.C:372)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x59303F4: MooseInit::MooseInit(int, char**, ompi_communicator_t*) (MooseInit.C:32)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x40C055: main (main.C:12)
kernels/adv_diff_reaction_transient.test: ==31725==  Address 0x138c5751 is 161 bytes inside a block of size 256 alloc'd
kernels/adv_diff_reaction_transient.test: ==31725==    at 0x4C2B7B2: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B632F6: opal_dss_buffer_extend (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B63605: opal_dss_copy_payload (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B3AFC6: orte_grpcomm_base_pack_modex_entries (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x10DD6032: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7AD7EB9: ompi_mpi_init (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7AEE9AA: PMPI_Init (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x676B9EB: libMesh::LibMeshInit::LibMeshInit(int, char const* const*, ompi_communicator_t*) (libmesh.C:372)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x59303F4: MooseInit::MooseInit(int, char**, ompi_communicator_t*) (MooseInit.C:32)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x40C055: main (main.C:12)
kernels/adv_diff_reaction_transient.test: ==31725==  Uninitialised value was created by a heap allocation
kernels/adv_diff_reaction_transient.test: ==31725==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B6B293: opal_ifinit.part.0 (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B6B974: opal_ifcount (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x109C51AA: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B45ED2: mca_oob_base_init (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x103B3C2F: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B511C3: orte_rml_base_select (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B36C04: orte_ess_base_app_setup (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x107BCB13: ???
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7B17669: orte_init (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7AD7BD0: ompi_mpi_init (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725==    by 0x7AEE9AA: PMPI_Init (in /opt/moose/openmpi/openmpi-1.6.5/gcc-opt/lib/libmpi.so.1.0.8)
kernels/adv_diff_reaction_transient.test: ==31725== 
kernels/adv_diff_reaction_transient.test: --31725-- 
kernels/adv_diff_reaction_transient.test: --31725-- used_suppression:      1 getpwuid
kernels/adv_diff_reaction_transient.test: --31725-- used_suppression:     29 OpenMPI1
kernels/adv_diff_reaction_transient.test: --31725-- used_suppression:      2 dl-hack3-cond-1
kernels/adv_diff_reaction_transient.test: ==31725== 
kernels/adv_diff_reaction_transient.test: ==31725== ERROR SUMMARY: 39 errors from 39 contexts (suppressed: 32 from 4)
```
