### PR TITLE
Checking for nodal ownership a different way - closes #2743

### DIFF
--- a/modules/phase_field/include/postprocessors/NodalFloodCount.h
+++ b/modules/phase_field/include/postprocessors/NodalFloodCount.h
@@ -107,12 +107,6 @@ protected:
   void mergeSets();
 
   /**
-   * This routine returns whether or not a nodal value is valid on a particular processor
-   * (i.e. includes values owned by this processor and ghost nodes)
-   */
-  bool isNodeValueValid(unsigned int node_id) const;
-
-  /**
    * This routine adds the periodic node information to our data structure prior to packing the data
    * this makes those periodic neighbors appear much like ghosted nodes in a multiprocessor setting
    */

--- a/modules/phase_field/src/postprocessors/NodalFloodCount.C
+++ b/modules/phase_field/src/postprocessors/NodalFloodCount.C
@@ -512,22 +512,10 @@ NodalFloodCount::flood(const Node *node, int current_idx, unsigned int live_regi
   // Flood neighboring nodes that are also above this threshold with recursion
   for (unsigned int i=0; i<neighbors.size(); ++i)
   {
-    // Only recurse on nodes this processor owns
-    if (isNodeValueValid(neighbors[i]->id()))
-    {
+    // Only recurse on nodes this processor can see
+    if (_mesh.isSemiLocal(const_cast<Node *>(neighbors[i])))
       flood(neighbors[i], current_idx, _bubble_maps[map_num][node_id]);
-    }
   }
-}
-
-bool
-NodalFloodCount::isNodeValueValid(unsigned int node_id) const
-{
-  for (unsigned int j=0; j < _nodes_to_elem_map[node_id].size(); ++j)
-    if (_nodes_to_elem_map[node_id][j]->processor_id() == libMesh::processor_id())
-      return true;
-
-  return false;
 }
 
 unsigned int


### PR DESCRIPTION
This code hasn't changed for several months but it now fails with new libMesh/MOOSE.  At any rate, I'm now checking which nodes to flood based on "isSemiLocal" instead of using extra logic with the _nodes_to_elem_map.  This should fix the seg fault issue.
