### PR TITLE
Updates to Tecplot Outputter:

### DIFF
--- a/framework/scripts/TestHarness/TestHarness.py
+++ b/framework/scripts/TestHarness/TestHarness.py
@@ -49,6 +49,7 @@ class TestHarness:
     self.checks['library_mode'] = getSharedOption(self.libmesh_dir)
     self.checks['unique_ids'] = getLibMeshConfigOption(self.libmesh_dir, 'unique_ids')
     self.checks['vtk'] =  getLibMeshConfigOption(self.libmesh_dir, 'vtk')
+    self.checks['tecplot'] =  getLibMeshConfigOption(self.libmesh_dir, 'tecplot')
 
     # Override the MESH_MODE option if using '--parallel-mesh' option
     if self.options.parallel_mesh == True or \

--- a/framework/scripts/TestHarness/testers/Tester.py
+++ b/framework/scripts/TestHarness/testers/Tester.py
@@ -29,6 +29,7 @@ class Tester(object):
     params.addParam('unique_ids',    ['ALL'], "A test that runs only if UNIQUE_IDs are enabled ('ALL', 'TRUE', 'FALSE')")
     params.addParam('recover',       True,    "A test that runs with '--recover' mode enabled")
     params.addParam('vtk',           ['ALL'], "A test that runs only if VTK is detected ('ALL', 'TRUE', 'FALSE')")
+    params.addParam('tecplot',       ['ALL'], "A test that runs only if Tecplot is detected ('ALL', 'TRUE', 'FALSE')")
 
     return params
   getValidParams = staticmethod(getValidParams)
@@ -130,7 +131,7 @@ class Tester(object):
       return (False, reason)
 
     # PETSc is being explicitly checked above
-    local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk']
+    local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot']
     for check in local_checks:
       test_platforms = set()
       for x in self.specs[check]:

--- a/framework/scripts/TestHarness/util.py
+++ b/framework/scripts/TestHarness/util.py
@@ -36,6 +36,14 @@ LIBMESH_OPTIONS = {
       'TRUE'  : '1',
       'FALSE' : '0'
       }
+                     },
+  'tecplot' :      { 're_option' : r'#define\s+LIBMESH_HAVE_TECPLOT_API\s+(\d+)',
+                     'default'   : 'FALSE',
+                     'options'   :
+                       {
+      'TRUE'  : '1',
+      'FALSE' : '0'
+      }
                      }
   }
 

--- a/framework/src/outputs/Tecplot.C
+++ b/framework/src/outputs/Tecplot.C
@@ -35,7 +35,7 @@ InputParameters validParams<Tecplot>()
   params.suppressParameter<bool>("sequence");
 
   // Add binary toggle
-  params.addParam<bool>("binary", false, "Set VTK files to output in binary format");
+  params.addParam<bool>("binary", false, "Set Tecplot files to output in binary format");
   params.addParamNamesToGroup("binary", "Advanced");
 
   // Add description for the Tecplot class
@@ -99,5 +99,11 @@ Tecplot::filename()
          << std::setfill('0')
          << std::right
          << _file_num;
-  return output.str() + ".plt";
+
+  // .plt extension is for binary files
+  // .dat extension is for ASCII files
+  if (_binary)
+    return output.str() + ".plt";
+  else
+    return output.str() + ".dat";
 }

--- a/test/tests/output/output_format/tests
+++ b/test/tests/output/output_format/tests
@@ -33,7 +33,7 @@
   [./tecplot_out_test]
     type = 'CheckFiles'
     input = 'output_test_tecplot.i'
-    check_files = 'out_0000.plt'
+    check_files = 'out_0000.dat'
   [../]
 
   [./dump_test]

--- a/test/tests/outputs/tecplot/tecplot_binary.i
+++ b/test/tests/outputs/tecplot/tecplot_binary.i
@@ -1,0 +1,48 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  output_initial = true
+  [./Tecplot]
+    type = Tecplot
+    binary = true
+  [../]
+[]

--- a/test/tests/outputs/tecplot/tests
+++ b/test/tests/outputs/tecplot/tests
@@ -1,9 +1,17 @@
 [Tests]
   [./test]
-    # Tests the for existence of tecplot files
+    # Tests the for existence of ASCII tecplot files
     type = 'CheckFiles'
     input = 'tecplot.i'
-    check_files = 'tecplot_out_0000.plt tecplot_out_0001.plt'
+    check_files = 'tecplot_out_0000.dat tecplot_out_0001.dat'
   [../]
 
+  [./test_binary]
+    # Tests the for existence of binary tecplot files.  This requires libmesh
+    # to be configured with --enable-tecplot or --enable-tecio.
+    type = 'CheckFiles'
+    input = 'tecplot_binary.i'
+    check_files = 'tecplot_binary_out_0000.plt tecplot_binary_out_0001.plt'
+    tecplot = true
+  [../]
 []


### PR DESCRIPTION
- Tecplot Outputter now writes binary files with .plt extension, ASCII
  files with .dat.  ASCII .dat files are written by default and don't
  require libmesh to be configured with --enable-tecplot to do so.
- Adding a test of binary tecplot ouput. This test requires libmesh to
  be built with --enable-tecplot to work properly.
- Updating test harness to check for libmesh's Tecplot API configuration status.

Refs #440.
