### PR TITLE
Added scientific notation to time/dt

### DIFF
--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -97,13 +97,13 @@ protected:
   virtual void outputPostprocessors();
 
   /**
-   * A helper function for outputing norms in color
+   * A helper function for outputting norms in color
    * @param old_norm The old residual norm to compare against
    * @param norm The current residual norm
    */
   std::string outputNorm(Real old_norm, Real norm);
 
-  /** Helper function function for stringstream formating
+  /** Helper function function for stringstream formatting
    * @see outputSimulationInformation()
    */
   void insertNewline(std::stringstream &oss, std::streampos &begin, std::streampos &curr);
@@ -130,10 +130,13 @@ protected:
   /// Toggle for controlling the use of color output
   bool _use_color;
 
-  /// Flag for controlling outputing console information to a file
+  /// Toggle for outputting time in time and dt in scientific notation
+  bool _scientific_time;
+
+  /// Flag for controlling outputting console information to a file
   bool _write_file;
 
-  /// Flag for controlling outputing console information to screen
+  /// Flag for controlling outputting console information to screen
   bool _write_screen;
 
   /// Flag for writing detailed time step information

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -89,14 +89,23 @@ namespace MooseUtils
    * color. The list of color constants is available in XTermConstants.h
    * @param color (from XTermConstants.h)
    * @param text The output to be converted to text and colored
+   * @param use_color A convenience flag using or not using color (see src/outputs/Console.C)
    */
   template <typename T>
   std::string
-  colorText(std::string color, T text)
+  colorText(std::string color, T text, bool use_color = true)
   {
+    // Define a stream to output
     std::ostringstream oss;
     oss << std::scientific;
-    oss << color << text << COLOR_DEFAULT;
+
+    // Output the value to the stream
+    if (use_color)
+      oss << color << text << COLOR_DEFAULT;
+    else
+      oss << text;
+
+    // Return string
     return oss.str();
   }
 

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -2059,7 +2059,7 @@ NonlinearSystem::printVarNorms()
       other_var_norms[s.variable_name(var_num)] = var_norm;
   }
 
-  if (outlier_var_norms.size())
+  if (outlier_var_norms.size() && _app.hasLegacyOutput())
   {
     Moose::out << "Outlier Variable Residual Norms:\n";
     for(std::map<std::string, Real>::iterator it = outlier_var_norms.begin();
@@ -2076,7 +2076,7 @@ NonlinearSystem::printVarNorms()
     }
   }
 
-  if (_print_all_var_norms)
+  if (_print_all_var_norms && _app.hasLegacyOutput())
   {
     Moose::out << "Variable Residual Norms:\n";
     for(std::map<std::string, Real>::iterator it = other_var_norms.begin();

--- a/test/tests/kernels/simple_transient_diffusion/simple_transient_diffusion.i
+++ b/test/tests/kernels/simple_transient_diffusion/simple_transient_diffusion.i
@@ -55,7 +55,5 @@
     perf_log = true
     nonlinear_residuals = true
     linear_residuals = true
-    start_time = 1
-    end_time = 1.5
   [../]
 []


### PR DESCRIPTION
This PR makes various improvements to Console output:
1. Implements 'scientific_time' parameter for time/dt (closes #2763)
2. Fixes color output for variable norm printing
3. Fixes nonlinear/linear residual printing in scientific notation
