### PR TITLE
Enhancing range checked parameters:

### DIFF
--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -108,7 +108,7 @@ public:
 
   /**
    * This function checks to see if there were any overridden parameters in the input file.
-   * (i.e. suplied more than once)
+   * (i.e. supplied more than once)
    * @param error_on_warn a Boolean that will trigger an error if this case is detected
    */
   void checkOverriddenParams(bool error_on_warn);
@@ -180,6 +180,9 @@ protected:
 
   /// The current parameter object for which parameters are being extracted
   InputParameters * _current_params;
+
+  /// The current stream object used for capturing errors during extraction
+  std::ostringstream * _current_error_stream;
 };
 
 

--- a/framework/src/markers/ErrorFractionMarker.C
+++ b/framework/src/markers/ErrorFractionMarker.C
@@ -18,8 +18,10 @@ template<>
 InputParameters validParams<ErrorFractionMarker>()
 {
   InputParameters params = validParams<IndicatorMarker>();
-  params.addParam<Real>("coarsen", 0, "Elements within this percentage of the min error will be coarsened.  Must be between 0 and 1!");
-  params.addParam<Real>("refine", 0, "Elements within this percentage of the max error will be refined.  Must be between 0 and 1!");
+  params.addRangeCheckedParam<Real>("coarsen", 0, "coarsen>=0 & coarsen<=1",
+                                    "Elements within this percentage of the min error will be coarsened.  Must be between 0 and 1!");
+  params.addRangeCheckedParam<Real>("refine", 0, "refine>=0 & refine<=1",
+                                    "Elements within this percentage of the max error will be refined.  Must be between 0 and 1!");
   return params;
 }
 
@@ -29,10 +31,6 @@ ErrorFractionMarker::ErrorFractionMarker(const std::string & name, InputParamete
     _coarsen(parameters.get<Real>("coarsen")),
     _refine(parameters.get<Real>("refine"))
 {
-  mooseAssert(_coarsen <= 1, "coarsen amount in " + _name + " not less than 1!");
-  mooseAssert(_coarsen >= 0, "coarsen amount in " + _name + " not greater than 0!");
-  mooseAssert(_refine <= 1, "refine amount in " + _name + " not less than 1!");
-  mooseAssert(_refine >= 0, "refine amount in " + _name + " not greater than 0!");
 }
 
 void
@@ -65,4 +63,3 @@ ErrorFractionMarker::computeElementMarker()
 
   return DO_NOTHING;
 }
-

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -268,25 +268,25 @@
   [./missing_req_par_action_obj_test]
     type = 'RunException'
     input = 'missing_req_par_action_obj_test.i'
-    expect_err = "The required parameter '\S+' is missing"
+    expect_err = "The following required parameters are missing:"
   [../]
 
   [./missing_req_par_mesh_block_test]
     type = 'RunException'
     input = 'missing_req_par_mesh_block_test.i'
-    expect_err = "The required parameter '\S+' is missing"
+    expect_err = "The following required parameters are missing:"
   [../]
 
   [./missing_req_par_moose_obj_test]
     type = 'RunException'
     input = 'missing_req_par_moose_obj_test.i'
-    expect_err = "The required parameter '\S+' is missing"
+    expect_err = "The following required parameters are missing:"
   [../]
 
   [./missing_required_coupled_test]
     type = 'RunException'
     input = 'missing_required_coupled.i'
-    expect_err = "The required parameter '\S+' is missing"
+    expect_err = "The following required parameters are missing:"
   [../]
 
   [./multi_precond_test]
@@ -400,7 +400,7 @@
   [./ics_missing_variable]
     type = 'RunException'
     input = 'ic_variable_not_specified.i'
-    expect_err = "The required parameter '\S+' is missing."
+    expect_err = "The following required parameters are missing:"
   [../]
 
   [./ic_bnd_for_non_nodal]


### PR DESCRIPTION
- Parameters are checked in groups instead of failing on just the first missing required or out of range parameter
- "meta-parameters" are checked, those that are set manually, not through the parser
- Better error handling in usage of fparser
  refs #2244
