### PR TITLE
Changing warnings to use output stream instead of error stream

### DIFF
--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -31,7 +31,7 @@
 #define mooseAssert(asserted, msg)  do { if (!(asserted)) { Moose::err << "\n\nAssertion `" #asserted "' failed\n" << msg << "\nat " << __FILE__ << ", line " << __LINE__ << std::endl; if (libMesh::n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::COMM_WORLD,1); exit(1); } } while(0)
 #endif
 
-#define mooseWarning(msg) do { Moose::err << "\n\n*** Warning ***\n" << msg << "\nat " << __FILE__ << ", line " << __LINE__ << "\n" << std::endl; } while(0)
+#define mooseWarning(msg) do { Moose::out << "\n\n*** Warning ***\n" << msg << "\nat " << __FILE__ << ", line " << __LINE__ << "\n" << std::endl; } while(0)
 
 #define mooseDoOnce(do_this) do { static bool did_this_already = false; if (!did_this_already) { did_this_already = true; do_this; } } while (0)
 


### PR DESCRIPTION
closes #2422
