### PR TITLE
Pass the current time to the TecplotIO object.

### DIFF
--- a/framework/src/outputs/Tecplot.C
+++ b/framework/src/outputs/Tecplot.C
@@ -58,7 +58,7 @@ Tecplot::Tecplot(const std::string & name, InputParameters parameters) :
 void
 Tecplot::output()
 {
-  TecplotIO out(*_mesh_ptr, _binary);
+  TecplotIO out(*_mesh_ptr, _binary, time() + _app.getGlobalTimeOffset());
   out.write_equation_systems(filename(), *_es_ptr);
   _file_num++;
 }


### PR DESCRIPTION
This is a pretty simple update to the Tecplot Outputter which passes the current time to the TecplotIO object.  I found that if we do this, Tecplot is actually able to animate ASCII files as well as binary files.

Refs #440.
