### PR TITLE
Adding ability to append to Tecplot ASCII files. (REQUIRES LIBMESH UPDATE)

### DIFF
--- a/framework/include/outputs/Tecplot.h
+++ b/framework/include/outputs/Tecplot.h
@@ -65,6 +65,9 @@ private:
 
   /// Flag for binary output
   bool _binary;
+
+  /// Flag for turning on appending to ASCII files
+  bool _ascii_append;
 };
 
 #endif /* TECPLOT_H */

--- a/test/tests/outputs/tecplot/tecplot_append.i
+++ b/test/tests/outputs/tecplot/tecplot_append.i
@@ -1,0 +1,48 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  output_initial = true
+  [./Tecplot]
+    type = Tecplot
+    ascii_append = true
+  [../]
+[]

--- a/test/tests/outputs/tecplot/tests
+++ b/test/tests/outputs/tecplot/tests
@@ -6,6 +6,12 @@
     check_files = 'tecplot_out_0000.dat tecplot_out_0001.dat'
   [../]
 
+  [./test_append]
+    type = 'CheckFiles'
+    input = 'tecplot_append.i'
+    check_files = 'tecplot_append_out.dat'
+  [../]
+
   [./test_binary]
     # Tests the for existence of binary tecplot files.  This requires libmesh
     # to be configured with --enable-tecplot or --enable-tecio.


### PR DESCRIPTION
Also adding a test for this capability.

This feature basically consists of writing multiple Tecplot ASCII
files into the same file using std::ofstream::app, which Tecplot is
indeed able to read.  The drawback is that the Mesh is written to the
file each time. I have a question in to Tecplot support to see if it
would be possible to have only one copy of the Mesh in the file,
similar to the way the Exodus file format works.

Appending is not currently supported for binary files, if you have
selected the binary output format for Tecplot, the ascii_append flag
will be ignored.  I'm also investigating appending to binary files, so
this interface may be updated in the future.

Refs #440.
