### PR TITLE
Ignore shared objects with suffixes on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.csv
 *.dylib
 *.so
+*.so.*
 *.gitignore*
 *.vrb
 *.jou


### PR DESCRIPTION
closes #2809
