### PR TITLE
When appending, make the Tecplot Outputter overwrite file first time

### DIFF
--- a/framework/include/outputs/Tecplot.h
+++ b/framework/include/outputs/Tecplot.h
@@ -68,6 +68,15 @@ private:
 
   /// Flag for turning on appending to ASCII files
   bool _ascii_append;
+
+  /// True if this is the first time the file has been written to,
+  /// gets set to false after the first call to output().  If the user
+  /// has set _ascii_append but _first_time==true, we won't actually
+  /// append.  This prevents old data files in a directory from being
+  /// appended to.  Declared as a reference so it can be restartable
+  /// data, that way if we restart, we don't think it's the first time
+  /// again.
+  bool & _first_time;
 };
 
 #endif /* TECPLOT_H */

--- a/framework/src/outputs/Tecplot.C
+++ b/framework/src/outputs/Tecplot.C
@@ -51,20 +51,25 @@ InputParameters validParams<Tecplot>()
 Tecplot::Tecplot(const std::string & name, InputParameters parameters) :
     OversampleOutputter(name, parameters),
     _binary(getParam<bool>("binary")),
-    _ascii_append(getParam<bool>("ascii_append"))
+    _ascii_append(getParam<bool>("ascii_append")),
+    _first_time(declareRestartableData<bool>("first_time", true))
 {
-  // Force sequence output
-  /* Note: This does not change the behavior for this object b/c outputSetup() is empty, but it is
-   * place here for consistency */
+  // Force sequence output Note: This does not change the behavior for
+  // this object b/c outputSetup() is empty, but it is placed here for
+  // consistency.
   sequence(true);
 }
+
+
 
 void
 Tecplot::output()
 {
   TecplotIO out(*_mesh_ptr, _binary, time() + _app.getGlobalTimeOffset());
 
-  if (_ascii_append)
+  // Only set the append flag on the TecplotIO object if the user has
+  // asked for it, and this is not the first time we called output().
+  if (_ascii_append && !_first_time)
     out.ascii_append() = true;
 
   out.write_equation_systems(filename(), *_es_ptr);
@@ -73,31 +78,46 @@ Tecplot::output()
   // we'll use the same filename each time.
   if (_binary || !_ascii_append)
     _file_num++;
+
+  // If this was the first time we called output(), the next time will not be
+  // the first time.
+  if (_first_time)
+    _first_time = false;
 }
+
+
 
 void
 Tecplot::outputNodalVariables()
 {
-  mooseError("Individual output of nodal variables is not support for Tecplot output");
+  mooseError("Individual output of nodal variables is not supported for Tecplot output");
 }
+
+
 
 void
 Tecplot::outputElementalVariables()
 {
-  mooseError("Individual output of elemental variables is not support for Tecplot output");
+  mooseError("Individual output of elemental variables is not supported for Tecplot output");
 }
+
+
 
 void
 Tecplot::outputPostprocessors()
 {
-  mooseError("Individual output of postprocessors is not support for Tecplot output");
+  mooseError("Individual output of postprocessors is not supported for Tecplot output");
 }
+
+
 
 void
 Tecplot::outputScalarVariables()
 {
-  mooseError("Individual output of scalars is not support for Tecplot output");
+  mooseError("Individual output of scalars is not supported for Tecplot output");
 }
+
+
 
 std::string
 Tecplot::filename()


### PR DESCRIPTION
This prevents multiple runs in the same directory from appending to
an old data file and giving misleading results.

Refs #440.
