### PR TITLE
Remove Density from tests that don't need it

### DIFF
--- a/modules/solid_mechanics/tests/j_integral/j_integral_2d.i
+++ b/modules/solid_mechanics/tests/j_integral/j_integral_2d.i
@@ -154,12 +154,6 @@
     formulation = PlaneStrain
     compute_JIntegral = true
   [../]
-
-  [./density]
-    type = Density
-    block = '1'
-    density = 8000.0
-  [../]
 []
 
 

--- a/modules/solid_mechanics/tests/j_integral/j_integral_2d_mouth_dir.i
+++ b/modules/solid_mechanics/tests/j_integral/j_integral_2d_mouth_dir.i
@@ -155,12 +155,6 @@
     formulation = PlaneStrain
     compute_JIntegral = true
   [../]
-
-  [./density]
-    type = Density
-    block = '1'
-    density = 8000.0
-  [../]
 []
 
 

--- a/modules/solid_mechanics/tests/j_integral/j_integral_3d.i
+++ b/modules/solid_mechanics/tests/j_integral/j_integral_3d.i
@@ -205,12 +205,6 @@
     thermal_expansion = 1e-5
     compute_JIntegral = true
   [../]
-
-  [./density]
-    type = Density
-    block = '1'
-    density = 8000.0
-  [../]
 []
 
 

--- a/modules/solid_mechanics/tests/j_integral/j_integral_3d_as_2d.i
+++ b/modules/solid_mechanics/tests/j_integral/j_integral_3d_as_2d.i
@@ -201,12 +201,6 @@
     thermal_expansion = 1e-5
     compute_JIntegral = true
   [../]
-
-  [./density]
-    type = Density
-    block = '1'
-    density = 8000.0
-  [../]
 []
 
 

--- a/modules/solid_mechanics/tests/j_integral/j_integral_3d_mouth_dir.i
+++ b/modules/solid_mechanics/tests/j_integral/j_integral_3d_mouth_dir.i
@@ -206,12 +206,6 @@
     thermal_expansion = 1e-5
     compute_JIntegral = true
   [../]
-
-  [./density]
-    type = Density
-    block = '1'
-    density = 8000.0
-  [../]
 []
 
 

--- a/modules/solid_mechanics/tests/j_integral/j_integral_3d_mouth_dir_end_dir_vec.i
+++ b/modules/solid_mechanics/tests/j_integral/j_integral_3d_mouth_dir_end_dir_vec.i
@@ -209,12 +209,6 @@
     thermal_expansion = 1e-5
     compute_JIntegral = true
   [../]
-
-  [./density]
-    type = Density
-    block = '1'
-    density = 8000.0
-  [../]
 []
 
 

--- a/modules/solid_mechanics/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm.i
+++ b/modules/solid_mechanics/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm.i
@@ -155,12 +155,6 @@
     thermal_expansion = 1e-5
     compute_JIntegral = true
   [../]
-
-  [./density]
-    type = Density
-    block = '1'
-    density = 1.0
-  [../]
 []
 
 

--- a/modules/solid_mechanics/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm_cm.i
+++ b/modules/solid_mechanics/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm_cm.i
@@ -156,12 +156,6 @@
     thermal_expansion = 1e-5
     compute_JIntegral = true
   [../]
-
-  [./density]
-    type = Density
-    block = '1'
-    density = 1.0
-  [../]
 []
 
 

--- a/modules/solid_mechanics/tests/spherical_shell/1D-SPH_test.i
+++ b/modules/solid_mechanics/tests/spherical_shell/1D-SPH_test.i
@@ -41,7 +41,6 @@
 # refined.
 
 [GlobalParams]
-  density = 10800.0          # kg/m^3
   order = SECOND
   family = LAGRANGE
   disp_x = disp_x
@@ -111,12 +110,6 @@
     youngs_modulus = 1e10
     poissons_ratio = .345
     thermal_expansion = 0
-  [../]
-
-  [./fuel_den]
-    type = Density
-    block = 1
-    disp_r = disp_x
   [../]
 []
 

--- a/modules/solid_mechanics/tests/spherical_shell/2D-RZ_test.i
+++ b/modules/solid_mechanics/tests/spherical_shell/2D-RZ_test.i
@@ -41,7 +41,6 @@
 # refined.
 
 [GlobalParams]
-  density = 10800.0          # kg/m^3
   order = SECOND
   family = LAGRANGE
   disp_x = disp_x
@@ -151,13 +150,6 @@
     youngs_modulus = 1e10
     poissons_ratio = .345
     thermal_expansion = 0
-  [../]
-
-  [./fuel_den]
-    type = Density
-    block = 1
-    disp_r = disp_x
-    disp_z = disp_y
   [../]
 []
 

--- a/modules/solid_mechanics/tests/spherical_shell/3D_test.i
+++ b/modules/solid_mechanics/tests/spherical_shell/3D_test.i
@@ -41,7 +41,6 @@
 # refined.
 
 [GlobalParams]
-  density = 10800.0          # kg/m^3
   order = SECOND
   family = LAGRANGE
   disp_x = disp_x
@@ -174,13 +173,6 @@
     youngs_modulus = 1e10
     poissons_ratio = .345
     thermal_expansion = 0
-  [../]
-
-  [./fuel_den]
-    type = Density
-    block = 1
-    disp_r = disp_x
-    disp_z = disp_y
   [../]
 []
 


### PR DESCRIPTION
This fixes all but one of the tests that I broke because they depended on stuff outside solid_mechanics
