### PR TITLE
Fixing double dump of Executioner parameters

### DIFF
--- a/framework/src/actions/DetermineSystemType.C
+++ b/framework/src/actions/DetermineSystemType.C
@@ -19,6 +19,7 @@ template<>
 InputParameters validParams<DetermineSystemType>()
 {
   InputParameters params = validParams<MooseObjectAction>();
+  params.mooseObjectSyntaxVisibility(false);
   return params;
 }
 


### PR DESCRIPTION
As @friedmud pointed out, this code that was added during the EigenKernel enhancement caused a bug in the --dump and --yaml options.  This action needs to be a MooseObjectAction to get access to all of the registered Executioners even thought it's not responsible for building them.  Being associated with the same block, it causes the double dump problem.  Suppressing the syntax for this Action remedies the problem.

closes #2855
