### PR TITLE
Remove MaterialData::have_property_name*

### DIFF
--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -73,11 +73,6 @@ public:
   template<typename T>
   MaterialProperty<T> & declarePropertyOlder(const std::string & prop_name);
 
-  /* Non-templated property routines */
-  bool have_property_name(const std::string & prop_name) const;
-  bool have_property_name_old(const std::string & prop_name) const;
-  bool have_property_name_older(const std::string & prop_name) const;
-
   // material properties for given element (and possible side)
   void swap(const Elem & elem, unsigned int side = 0);
   // Reinit material properties for given element (and possible side)

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -85,24 +85,6 @@ MaterialData::swapBack(const Elem & elem, unsigned int side/* = 0*/)
 }
 
 bool
-MaterialData::have_property_name(const std::string & prop_name) const
-{
-  return _storage.hasProperty(prop_name);
-}
-
-bool
-MaterialData::have_property_name_old(const std::string & prop_name) const
-{
-  return _storage.hasProperty(prop_name);
-}
-
-bool
-MaterialData::have_property_name_older(const std::string & prop_name) const
-{
-  return _storage.hasProperty(prop_name);
-}
-
-bool
 MaterialData::isSwapped()
 {
   return _swapped;


### PR DESCRIPTION
In the process I noticed they aren't even used.  Maybe we can just remove them?

Refs #2871.
