### PR TITLE
Improve eigen system 2902

### DIFF
--- a/framework/include/executioners/EigenExecutionerBase.h
+++ b/framework/include/executioners/EigenExecutionerBase.h
@@ -51,6 +51,11 @@ public:
   virtual void init();
 
   /**
+   * Normalize solution so that |Bx| = k
+   */
+  virtual void makeBXConsistent(Real k);
+
+  /**
    * Make sure time kernel is not presented
    */
   virtual void checkIntegrity();
@@ -191,9 +196,6 @@ protected:
   };
   Chebyshev_Parameters  chebyshev_parameters;
   void chebyshev(unsigned int iter);
-
-private:
-  const Real _consistency_tolerance;
 };
 
 #endif //EIGENEXECUTIONERBASE_H

--- a/framework/src/base/EigenSystem.C
+++ b/framework/src/base/EigenSystem.C
@@ -50,7 +50,7 @@ EigenSystem::addKernel(const std::string & kernel_name, const std::string & name
         parameters.set<bool>("implicit") = true;
         EigenKernel *ekernel = static_cast<EigenKernel *>(_factory.create(kernel_name, name, parameters));
         mooseAssert(ekernel != NULL, "Not an EigenKernel object");
-        markEigenVariable(parameters.get<NonlinearVariableName>("variable"));
+        if (parameters.get<bool>("eigen")) markEigenVariable(parameters.get<NonlinearVariableName>("variable"));
         // Extract the SubdomainIDs from the object (via BlockRestrictable class)
         std::set<SubdomainID> blk_ids = ekernel->blockIDs();
         _kernels[tid].addKernel(ekernel, blk_ids);

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -42,7 +42,10 @@ EigenKernel::EigenKernel(const std::string & name, InputParameters parameters) :
       _eigenvalue = &getPostprocessorValueOldByName(_eigen_pp);
   }
   else
-    mooseAssert(_is_implicit, "EigenKernel on source problem should be implicit always");
+  {
+    _fe_problem.parameters().set<Real>("eigenvalue") = 1.0;
+    _eigenvalue = &_fe_problem.parameters().get<Real>("eigenvalue");
+  }
 }
 
 void
@@ -53,7 +56,7 @@ EigenKernel::computeResidual()
   _local_re.zero();
 
   Real one_over_eigen = 1.0;
-  if (_eigen) one_over_eigen /= *_eigenvalue;
+  one_over_eigen /= *_eigenvalue;
   for (_i = 0; _i < _test.size(); _i++)
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
       _local_re(_i) += _JxW[_qp] * _coord[_qp] * one_over_eigen * computeQpResidual();
@@ -78,7 +81,7 @@ EigenKernel::computeJacobian()
   _local_ke.zero();
 
   Real one_over_eigen = 1.0;
-  if (_eigen) one_over_eigen /= *_eigenvalue;
+  one_over_eigen /= *_eigenvalue;
   for (_i = 0; _i < _test.size(); _i++)
     for (_j = 0; _j < _phi.size(); _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)


### PR DESCRIPTION
With few things:
1. fix a logic error when marking eigen variables;
2. allows k being changed for EigenKernels with 'eigen=false';
3. better |Bx|=k check.
