### PR TITLE
Re-factored SideSetsAroundSubdomain

### DIFF
--- a/framework/include/meshmodifiers/SideSetsAroundSubdomain.h
+++ b/framework/include/meshmodifiers/SideSetsAroundSubdomain.h
@@ -17,7 +17,6 @@
 
 #include "AddSideSetsBase.h"
 #include "BlockRestrictable.h"
-#include "BoundaryRestrictableRequired.h"
 
 class SideSetsAroundSubdomain;
 
@@ -26,8 +25,7 @@ InputParameters validParams<SideSetsAroundSubdomain>();
 
 class SideSetsAroundSubdomain :
   public MeshModifier,
-  public BlockRestrictable,
-  public BoundaryRestrictableRequired
+  public BlockRestrictable
 {
 public:
   SideSetsAroundSubdomain(const std::string & name, InputParameters parameters);
@@ -37,6 +35,8 @@ public:
   virtual void modify();
 
 protected:
+
+  std::vector<BoundaryName> _boundary_names;
 
 };
 

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -21,7 +21,7 @@ InputParameters validParams<BlockRestrictable>()
   InputParameters params = emptyInputParameters();
 
   // Add the user-facing 'block' input parameter
-  params.addParam<std::vector<SubdomainName> >("block", "The list of ids of the blocks (SubdomainID) that this kernel will be applied to");
+  params.addParam<std::vector<SubdomainName> >("block", "The list of block ids (SubdomainID) that this object will be applied");
 
   // Add the private parameter that is populated by this class that contains valid block ids for the
   // object inheriting from this class
@@ -49,7 +49,7 @@ BlockRestrictable::BlockRestrictable(const std::string name, InputParameters & p
 
   // Check that the mesh pointer was defined, it is required for this class to operate
   if (_blk_mesh == NULL)
-    mooseError("The input paramters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'");
+    mooseError("The input parameters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'");
 
   // The 'block' input is defined
   if (parameters.isParamValid("block"))

--- a/framework/src/base/BoundaryRestrictable.C
+++ b/framework/src/base/BoundaryRestrictable.C
@@ -52,7 +52,7 @@ BoundaryRestrictable::BoundaryRestrictable(const std::string name, InputParamete
 
   // Check that the mesh pointer was defined, it is required for this class to operate
   if (_bnd_mesh == NULL)
-    mooseError("The input paramters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'");
+    mooseError("The input parameters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'");
 
   // If the user supplies boundary IDs
   if (!_boundary_names.empty())

--- a/test/tests/restrictable/check_error/tests
+++ b/test/tests/restrictable/check_error/tests
@@ -3,12 +3,12 @@
     type = 'RunException'
     input = 'check_error.i'
 	  cli_args = "Kernels/diff/test=fe_problem_null"
-    expect_err = "The input paramters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'"
+    expect_err = "The input parameters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'"
   [../]
 
 	[./mesh_null]
     type = 'RunException'
     input = 'check_error.i'
 		cli_args = "Kernels/diff/test=mesh_null"
-    expect_err = "The input paramters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'"
+    expect_err = "The input parameters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'"
   [../]


### PR DESCRIPTION
- Re-worded parameters in `BlockRestrictable` and removed typo
- Re-factored `SideSetsAroundSubdomain` to remove `BoundaryRestrictable` (closes #2844)

This PR is in response to comments by @friedmud in #2844 and is intended to get discussion started again so we can wrap this issue up.
