### PR TITLE
setOutputPosition() -> parentOutputPositionChanged()

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -690,9 +690,9 @@ public:
   const BoundaryID & getCurrentBoundaryID(){ return _current_boundary_id; }
 
   /**
-   * Set the output position for the app and sub-apps
+   * Calls parentOutputPositionChanged() on all sub apps.
    */
-  void setOutputPosition(const Point & p);
+  void parentOutputPositionChanged();
 
   /**
    * Enable printing of top residuals

--- a/framework/include/executioners/Executioner.h
+++ b/framework/include/executioners/Executioner.h
@@ -100,9 +100,10 @@ public:
   void outputInitial(bool out_init);
 
   /**
-   * Set (or reset) the output position of the application.
+   * Can be used by subsclasses to call parentOutputPositionChanged()
+   * on the underlying FEProblem.
    */
-  virtual void setOutputPosition(const Point & /* p */) {}
+  virtual void parentOutputPositionChanged() {}
 
 protected:
 

--- a/framework/include/executioners/Transient.h
+++ b/framework/include/executioners/Transient.h
@@ -199,10 +199,7 @@ public:
    */
   Real unconstrainedDT() { return _unconstrained_dt; }
 
-  void setOutputPosition(const Point & p)
-    {
-      _problem.setOutputPosition(p);
-    }
+  void parentOutputPositionChanged() { _problem.parentOutputPositionChanged(); }
 
 
 protected:

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1927,7 +1927,7 @@ FEProblem::getPostprocessorValueOld(const std::string & name, THREAD_ID tid)
 }
 
 void
-FEProblem::setOutputPosition(const Point & p)
+FEProblem::parentOutputPositionChanged()
 {
   for (unsigned int i = 0; i < Moose::exec_types.size(); i++)
     _multi_apps(Moose::exec_types[i])[0].parentOutputPositionChanged();

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -378,7 +378,7 @@ MooseApp::setOutputPosition(Point p)
   _output_warehouse.meshChanged();
 
   if (_executioner != NULL)
-    _executioner->setOutputPosition(p);
+    _executioner->parentOutputPositionChanged();
 }
 
 std::string


### PR DESCRIPTION
This function (on both FEProblem and Executioner) no longer sets the
output position, it just calls parentOutputPositionChanged(), so it no
longer needs to take a Point, and I'm changing the name in both
FEProblem and Executioner.

Refs #2912.
