### PR TITLE
Fix RELAP-7/RAVEN mesh output hack in peacock.

### DIFF
--- a/gui/gui/InputFileTreeWidget.py
+++ b/gui/gui/InputFileTreeWidget.py
@@ -186,6 +186,7 @@ class InputFileTreeWidget(QtGui.QTreeWidget):
     # FIXME: Hack to make raven and r7 work for now
     if 'raven' in self.input_file_widget.app_path or 'r7' in self.input_file_widget.app_path:
       output_file_names = [common_file_base + '_displaced.e']
+      output_block_names = ['']
 
     # Return the list of file and block names
     return [output_file_names, output_block_names]


### PR DESCRIPTION
Fixes #2945: Return value modified to return an empty block name when an output file name is forced for r7_moose/raven (because return value type changed).
