### PR TITLE
Enhancing access to Output objects

### DIFF
--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -227,12 +227,3 @@ OutputWarehouse::getSyncTimes()
 {
   return _sync_times;
 }
-
-OutputBase *
-OutputWarehouse::getOutputByName(std::string name)
-{
-  if (!hasOutput(name))
-    mooseError("An outputter with the name " << name << " does not exist.");
-
-  return _object_map[name];
-}

--- a/framework/src/outputs/PetscOutputter.C
+++ b/framework/src/outputs/PetscOutputter.C
@@ -31,8 +31,8 @@ InputParameters validParams<PetscOutputter>()
   params.addParam<bool>("nonlinear_residuals", false, "Specifies whether output occurs on each nonlinear residual evaluation");
 
   // Psuedo time step divisors
-  params.addParam<Real>("nonlinear_residual_dt_divisor", 1000, "Number of divisions applied to time step when outtputting non-linear residuals");
-  params.addParam<Real>("linear_residual_dt_divisor", 1000, "Number of divisions applied to time step when outtputting linear residuals");
+  params.addParam<Real>("nonlinear_residual_dt_divisor", 1000, "Number of divisions applied to time step when outputting non-linear residuals");
+  params.addParam<Real>("linear_residual_dt_divisor", 1000, "Number of divisions applied to time step when outputting linear residuals");
 
   // Start times for residual output
   params.addParam<Real>("linear_residual_start_time", "Specifies a start time to begin output on each linear residual evaluation");

--- a/test/include/outputs/OutputObjectTest.h
+++ b/test/include/outputs/OutputObjectTest.h
@@ -1,0 +1,53 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef OUTPUTOBJECTTEST_H
+#define OUTPUTOBJECTTEST_H
+
+// MOOSE includes
+#include "Console.h"
+
+// Forward declerations
+class OutputObjectTest;
+
+template<>
+InputParameters validParams<OutputObjectTest>();
+
+/**
+ *
+ */
+class OutputObjectTest : public Console
+{
+public:
+
+  /**
+   * Class constructor
+   * @param name
+   * @param InputParameters
+   */
+  OutputObjectTest(const std::string & name, InputParameters parameters);
+
+  /**
+   * Class destructor
+   */
+  virtual ~OutputObjectTest();
+
+  void initialSetup();
+
+private:
+  MooseEnum _type;
+
+};
+
+#endif //OUTPUTOBJECTTEST_H

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -171,6 +171,8 @@
 // From MOOSE
 #include "AddVariableAction.h"
 
+// Outputs
+#include "OutputObjectTest.h"
 
 template<>
 InputParameters validParams<MooseTestApp>()
@@ -370,6 +372,9 @@ MooseTestApp::registerObjects(Factory & factory)
 
   registerProblem(MooseTestProblem);
   registerProblem(FailingProblem);
+
+  // Outputs
+  registerOutput(OutputObjectTest);
 }
 
 void

--- a/test/src/outputs/OutputObjectTest.C
+++ b/test/src/outputs/OutputObjectTest.C
@@ -1,0 +1,76 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "OutputObjectTest.h"
+#include "MooseApp.h"
+#include "Exodus.h"
+
+template<>
+InputParameters validParams<OutputObjectTest>()
+{
+  MooseEnum type("getOutput, getOutputs-names, getOutputs, getOutputNames");
+  InputParameters params = validParams<Console>();
+  params.addRequiredParam<MooseEnum>("test_type", type, "The type of test to execute");
+  return params;
+}
+
+OutputObjectTest::OutputObjectTest(const std::string & name, InputParameters parameters) :
+    Console(name, parameters),
+    _type(getParam<MooseEnum>("test_type"))
+{
+}
+
+OutputObjectTest::~OutputObjectTest()
+{
+}
+
+void
+OutputObjectTest::initialSetup()
+{
+  Console::initialSetup();
+
+  if (_type == "getOutput")
+  {
+    OutputObjectTest * ptr = _app.getOutputWarehouse().getOutput<OutputObjectTest>(_name);
+    if (ptr == this)
+      mooseError("getOutput test passed");
+  }
+
+  else if (_type == "getOutputs")
+  {
+    std::vector<Exodus *> ptrs = _app.getOutputWarehouse().getOutputs<Exodus>();
+    if (ptrs.size() == 2 && ptrs[0]->name().compare("exodus") == 0 && ptrs[1]->name().compare("exodus2") == 0)
+      mooseError("getOutputs test passed");
+  }
+
+  else if (_type == "getOutputs-names")
+  {
+    std::vector<std::string> names;
+    names.push_back("exodus2");
+    names.push_back("exodus");
+    std::vector<Exodus *> ptrs = _app.getOutputWarehouse().getOutputs<Exodus>(names);
+    if (ptrs.size() == 2 && ptrs[0]->name().compare("exodus2") == 0 && ptrs[1]->name().compare("exodus") == 0)
+      mooseError("getOutputs-names test passed");
+  }
+
+  else if (_type == "getOutputNames")
+  {
+    std::vector<std::string> names = _app.getOutputWarehouse().getOutputNames<Exodus>();
+    if (names.size() == 2 && names[0].compare("exodus") == 0 && names[1].compare("exodus2") == 0)
+      mooseError("getOutputsNames test passed");
+  }
+
+  else
+    mooseError("You must specify a 'test_type'");
+}

--- a/test/tests/outputs/misc/tests
+++ b/test/tests/outputs/misc/tests
@@ -1,0 +1,30 @@
+[Tests]
+  [./getOutput]
+    type = RunException
+    input = warehouse_access.i
+    cli_args = 'Outputs/test/test_type=getOutput'
+    expect_err = "getOutput test passed"
+    max_parallel = 1
+  [../]
+  [./getOutputs]
+    type = RunException
+    input = warehouse_access.i
+    cli_args = 'Outputs/test/test_type=getOutputs'
+    expect_err = "getOutputs test passed"
+    max_parallel = 1
+  [../]
+  [./getOutputs_with_names]
+    type = RunException
+    input = warehouse_access.i
+    cli_args = 'Outputs/test/test_type=getOutputs-names'
+    expect_err = "getOutputs-names test passed"
+    max_parallel = 1
+  [../]
+  [./getOutputNames]
+    type = RunException
+    input = warehouse_access.i
+    cli_args = 'Outputs/test/test_type=getOutputNames'
+    expect_err = "getOutputsNames test passed"
+    max_parallel = 1
+  [../]
+[]

--- a/test/tests/outputs/misc/warehouse_access.i
+++ b/test/tests/outputs/misc/warehouse_access.i
@@ -1,0 +1,56 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+  vtk = true
+  [./exodus2]
+    type = Exodus
+    file_base = exodus2
+  [../]
+  [./test]
+    type = OutputObjectTest
+  [../]
+[]


### PR DESCRIPTION
Provides access to the Output objects, which @YaqiWang requested. Nobody commented on the issue after I posted some options, so I just made a few methods that should cover most cases. 

This will break RAVEN, but I have a patch waiting, so don't merge until you speak with @aeslaughter

(closes #2885)
