### PR TITLE
Cosmetic changes in the phasesfield module #2951

### DIFF
--- a/modules/phase_field/include/action/BicrystalBoundingBoxICAction.h
+++ b/modules/phase_field/include/action/BicrystalBoundingBoxICAction.h
@@ -3,10 +3,10 @@
 
 #include "InputParameters.h"
 #include "Action.h"
+
 /**
  * Automatically generates all variables to model a polycrystal with crys_num orderparameters
  */
-
 class BicrystalBoundingBoxICAction: public Action
 {
 public:

--- a/modules/phase_field/include/action/BicrystalCircleGrainICAction.h
+++ b/modules/phase_field/include/action/BicrystalCircleGrainICAction.h
@@ -3,10 +3,10 @@
 
 #include "InputParameters.h"
 #include "Action.h"
+
 /**
  * Automatically generates all variables to model a polycrystal with crys_num orderparameters
  */
-
 class BicrystalCircleGrainICAction: public Action
 {
 public:

--- a/modules/phase_field/include/action/PolycrystalHexGrainICAction.h
+++ b/modules/phase_field/include/action/PolycrystalHexGrainICAction.h
@@ -3,10 +3,10 @@
 
 #include "InputParameters.h"
 #include "Action.h"
+
 /**
  * Automatically generates ic for polycrystal hexagonal grain structure. Must have squared number of grains and periodic BCs.
  */
-
 class PolycrystalHexGrainICAction: public Action
 {
 public:

--- a/modules/phase_field/include/action/PolycrystalKernelAction.h
+++ b/modules/phase_field/include/action/PolycrystalKernelAction.h
@@ -16,7 +16,6 @@ private:
   VariableName _c;
   bool _implicit;
   VariableName _T;
-
 };
 
 template<>

--- a/modules/phase_field/include/action/PolycrystalRandomICAction.h
+++ b/modules/phase_field/include/action/PolycrystalRandomICAction.h
@@ -3,10 +3,10 @@
 
 #include "InputParameters.h"
 #include "Action.h"
+
 /**
  * Automatically generates all variables to model a polycrystal with crys_num orderparameters
  */
-
 class PolycrystalRandomICAction: public Action
 {
 public:
@@ -21,7 +21,6 @@ private:
   //unsigned int _grain_num;
   std::string _var_name_base;
   MooseEnum _random_type;
-
 };
 
 template<>

--- a/modules/phase_field/include/action/PolycrystalVariablesAction.h
+++ b/modules/phase_field/include/action/PolycrystalVariablesAction.h
@@ -3,10 +3,10 @@
 
 #include "InputParameters.h"
 #include "Action.h"
+
 /**
  * Automatically generates all variables to model a polycrystal with crys_num orderparameters
  */
-
 class PolycrystalVariablesAction: public Action
 {
 public:

--- a/modules/phase_field/include/action/PolycrystalVoronoiICAction.h
+++ b/modules/phase_field/include/action/PolycrystalVoronoiICAction.h
@@ -3,10 +3,10 @@
 
 #include "InputParameters.h"
 #include "Action.h"
+
 /**
  * Automatically generates all variables to model a polycrystal with crys_num orderparameters
  */
-
 class PolycrystalVoronoiICAction: public Action
 {
 public:

--- a/modules/phase_field/include/action/Tricrystal2CircleGrainsICAction.h
+++ b/modules/phase_field/include/action/Tricrystal2CircleGrainsICAction.h
@@ -3,10 +3,10 @@
 
 #include "InputParameters.h"
 #include "Action.h"
+
 /**
  * Automatically generates all variables to model a polycrystal with crys_num orderparameters
  */
-
 class Tricrystal2CircleGrainsICAction: public Action
 {
 public:

--- a/modules/phase_field/include/auxkernels/BndsCalcAux.h
+++ b/modules/phase_field/include/auxkernels/BndsCalcAux.h
@@ -20,6 +20,6 @@ protected:
 
   std::vector<VariableValue *> _vals;
   unsigned int _ncrys;
-
 };
+
 #endif //BndsCalcAux_H

--- a/modules/phase_field/include/auxkernels/SPPARKSAux.h
+++ b/modules/phase_field/include/auxkernels/SPPARKSAux.h
@@ -22,7 +22,6 @@ protected:
   const SPPARKSUserObject & _spparks;
   const int _ivar;
   const int _dvar;
-
 };
 
 template<>

--- a/modules/phase_field/include/ics/C1ICBase.h
+++ b/modules/phase_field/include/ics/C1ICBase.h
@@ -37,7 +37,6 @@ InputParameters validParams<C1ICBase>();
 class C1ICBase : public InitialCondition
 {
 public:
-
   /**
    * Constructor
    *

--- a/modules/phase_field/include/ics/CrossIC.h
+++ b/modules/phase_field/include/ics/CrossIC.h
@@ -39,7 +39,6 @@ InputParameters validParams<CrossIC>();
 class CrossIC : public C1ICBase
 {
 public:
-
   /**
    * Constructor
    *

--- a/modules/phase_field/include/ics/HexPolycrystalIC.h
+++ b/modules/phase_field/include/ics/HexPolycrystalIC.h
@@ -20,7 +20,6 @@ InputParameters validParams<HexPolycrystalIC>();
 class HexPolycrystalIC : public PolycrystalReducedIC
 {
 public:
-
   /**
    * Constructor
    *

--- a/modules/phase_field/include/ics/LatticeSmoothCircleIC.h
+++ b/modules/phase_field/include/ics/LatticeSmoothCircleIC.h
@@ -20,7 +20,6 @@ InputParameters validParams<LatticeSmoothCircleIC>();
 class LatticeSmoothCircleIC : public MultiSmoothCircleIC
 {
 public:
-
   /**
    * Constructor
    *
@@ -36,9 +35,6 @@ public:
 protected:
   Real _Rnd_variation;
   std::vector<unsigned int> _circles_per_side;
-
-// private:
-
 };
 
 #endif //LATTICESMOOTHCIRCLEIC_H

--- a/modules/phase_field/include/ics/MultiSmoothCircleIC.h
+++ b/modules/phase_field/include/ics/MultiSmoothCircleIC.h
@@ -20,7 +20,6 @@ InputParameters validParams<MultiSmoothCircleIC>();
 class MultiSmoothCircleIC : public SmoothCircleIC
 {
 public:
-
   /**
    * Constructor
    *
@@ -48,10 +47,6 @@ protected:
 
   std::vector<Point> _bubcent;
   std::vector<Real> _bubradi;
-
-
-// private:
-
 };
 
 #endif //MULTISMOOTHCIRCLEIC_H

--- a/modules/phase_field/include/ics/PolycrystalRandomIC.h
+++ b/modules/phase_field/include/ics/PolycrystalRandomIC.h
@@ -19,7 +19,6 @@ InputParameters validParams<PolycrystalRandomIC>();
 class PolycrystalRandomIC : public InitialCondition
 {
 public:
-
   /**
    * Constructor
    *
@@ -38,11 +37,9 @@ public:
   virtual Real value(const Point & p);
 
 private:
-
   unsigned int _crys_num;
   unsigned int _crys_index;
   unsigned int _typ;
-
 };
 
 #endif //POLYCRYSTALRANDOMIC_H

--- a/modules/phase_field/include/ics/PolycrystalReducedIC.h
+++ b/modules/phase_field/include/ics/PolycrystalReducedIC.h
@@ -22,7 +22,6 @@ InputParameters validParams<PolycrystalReducedIC>();
 class PolycrystalReducedIC : public InitialCondition
 {
 public:
-
   /**
    * Constructor
    *
@@ -62,7 +61,6 @@ public:
 
   std::vector<Point> _centerpoints;
   std::vector<Real> _assigned_op;
-
 };
 
 #endif //POLYCRYSTALREDUCEDIC_H

--- a/modules/phase_field/include/ics/RndBoundingBoxIC.h
+++ b/modules/phase_field/include/ics/RndBoundingBoxIC.h
@@ -25,7 +25,6 @@ InputParameters validParams<RndBoundingBoxIC>();
 class RndBoundingBoxIC : public InitialCondition
 {
 public:
-
   /**
    * Constructor
    *

--- a/modules/phase_field/include/ics/RndSmoothCircleIC.h
+++ b/modules/phase_field/include/ics/RndSmoothCircleIC.h
@@ -20,7 +20,6 @@ InputParameters validParams<RndSmoothCircleIC>();
 class RndSmoothCircleIC : public InitialCondition
 {
 public:
-
   /**
    * Constructor
    *
@@ -51,7 +50,6 @@ private:
   Real _radius;
 
   Point _center;
-
 };
 
 #endif //SMOOTHCIRCLEIC_H

--- a/modules/phase_field/include/ics/SmoothCircleIC.h
+++ b/modules/phase_field/include/ics/SmoothCircleIC.h
@@ -21,7 +21,6 @@ InputParameters validParams<SmoothCircleIC>();
 class SmoothCircleIC : public InitialCondition
 {
 public:
-
   /**
    * Constructor
    *
@@ -55,7 +54,6 @@ protected:
   Point _center;
 
   unsigned int _num_dim;
-
 };
 
 #endif //SMOOTHCIRCLEIC_H

--- a/modules/phase_field/include/ics/SpecifiedSmoothCircleIC.h
+++ b/modules/phase_field/include/ics/SpecifiedSmoothCircleIC.h
@@ -20,7 +20,6 @@ InputParameters validParams<SpecifiedSmoothCircleIC>();
 class SpecifiedSmoothCircleIC : public MultiSmoothCircleIC
 {
 public:
-
   /**
    * Constructor
    *
@@ -38,10 +37,6 @@ protected:
   std::vector<Real> _y_positions;
   std::vector<Real> _z_positions;
   std::vector<Real> _radii;
-
-
-// private:
-
 };
 
 #endif //SPECIFIEDSMOOTHCIRCLEIC_H

--- a/modules/phase_field/include/ics/ThumbIC.h
+++ b/modules/phase_field/include/ics/ThumbIC.h
@@ -19,7 +19,6 @@ InputParameters validParams<ThumbIC>();
 class ThumbIC : public InitialCondition
 {
 public:
-
   /**
    * Constructor
    *
@@ -38,13 +37,11 @@ public:
   virtual Real value(const Point & p);
 
 protected:
-
   Real _xcoord;
   Real _width;
   Real _height;
   Real _invalue;
   Real _outvalue;
-
 };
 
 #endif //THUMBIC_H

--- a/modules/phase_field/include/ics/Tricrystal2CircleGrainsIC.h
+++ b/modules/phase_field/include/ics/Tricrystal2CircleGrainsIC.h
@@ -19,7 +19,6 @@ InputParameters validParams<Tricrystal2CircleGrainsIC>();
 class Tricrystal2CircleGrainsIC : public InitialCondition
 {
 public:
-
   /**
    * Constructor
    *
@@ -48,7 +47,6 @@ protected:
   Point _bottom_left;
   Point _top_right;
   Point _range;
-
 };
 
 #endif //TRICRYSTAL2CIRCLEGRAINSIC_H

--- a/modules/phase_field/include/kernels/ACBulk.h
+++ b/modules/phase_field/include/kernels/ACBulk.h
@@ -1,5 +1,5 @@
-#ifndef ACBulk_H
-#define ACBulk_H
+#ifndef ACBULK_H
+#define ACBULK_H
 
 #include "KernelValue.h"
 
@@ -12,7 +12,6 @@ InputParameters validParams<ACBulk>();
 class ACBulk : public KernelValue
 {
 public:
-
   ACBulk(const std::string & name, InputParameters parameters);
 
 protected:
@@ -21,15 +20,13 @@ protected:
     Jacobian,
     Residual
   };
+
   virtual Real precomputeQpResidual();
   virtual Real precomputeQpJacobian();
   virtual Real computeDFDOP(PFFunctionType type) = 0;
+
   std::string _mob_name;
   MaterialProperty<Real> & _L;
-
-
-private:
-
-
 };
-#endif //ACBulk_H
+
+#endif //ACBULK_H

--- a/modules/phase_field/include/kernels/ACGBPoly.h
+++ b/modules/phase_field/include/kernels/ACGBPoly.h
@@ -12,7 +12,6 @@ InputParameters validParams<ACGBPoly>();
 class ACGBPoly : public ACBulk
 {
 public:
-
   ACGBPoly(const std::string & name, InputParameters parameters);
 
 protected:
@@ -26,12 +25,13 @@ private:
    * Since this is a reference it MUST be set in the Initialization List of the
    * constructor!
    */
-
   VariableValue & _c;
   unsigned int _c_var;
+
   MaterialProperty<Real> & _mu;
   MaterialProperty<Real> & _gamma;
-  Real _en_ratio;
 
+  Real _en_ratio;
 };
+
 #endif //ACGBPOLY_H

--- a/modules/phase_field/include/kernels/ACGrGrPoly.h
+++ b/modules/phase_field/include/kernels/ACGrGrPoly.h
@@ -9,12 +9,14 @@ class ACGrGrPoly;
 template<>
 InputParameters validParams<ACGrGrPoly>();
 
-/**This kernel calculates the residual for grain growth.  It calculates the residual of the ith order parameter, and the values of all other order parameters are coupled variables and are stored in vals
-**/
+/**
+ * This kernel calculates the residual for grain growth.
+ * It calculates the residual of the ith order parameter, and the values of
+ * all other order parameters are coupled variables and are stored in vals.
+ */
 class ACGrGrPoly : public ACBulk
 {
 public:
-
   ACGrGrPoly(const std::string & name, InputParameters parameters);
 
 protected:
@@ -22,13 +24,6 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
-  /**
-   * Coupled things come through as std::vector _refernces_.
-   *
-   * Since this is a reference it MUST be set in the Initialization List of the
-   * constructor!
-   */
-
   std::vector<VariableValue *> _vals;
   std::vector<unsigned int> _vals_var;
 
@@ -40,8 +35,7 @@ private:
   VariableGradient * _grad_T;
 
   unsigned int _ncrys;
-
-//  Real _gamma;
-
+  // Real _gamma;
 };
+
 #endif //ACGRGRPOLY_H

--- a/modules/phase_field/include/kernels/ACInterface.h
+++ b/modules/phase_field/include/kernels/ACInterface.h
@@ -12,7 +12,6 @@ InputParameters validParams<ACInterface>();
 class ACInterface : public KernelGrad
 {
 public:
-
   ACInterface(const std::string & name, InputParameters parameters);
 
 protected:
@@ -28,9 +27,8 @@ protected:
 
 
 private:
-
   MaterialProperty<Real> & _kappa;
   MaterialProperty<Real> & _L;
-
 };
+
 #endif //ACInterface_H

--- a/modules/phase_field/include/kernels/CHBulk.h
+++ b/modules/phase_field/include/kernels/CHBulk.h
@@ -1,5 +1,5 @@
-#ifndef CHBulk_H
-#define CHBulk_H
+#ifndef CHBULK_H
+#define CHBULK_H
 
 #include "KernelGrad.h"
 
@@ -39,4 +39,5 @@ private:
   bool _has_MJac;
   MaterialProperty<Real> * _DM;
 };
-#endif //CHBulk_H
+
+#endif //CHBULK_H

--- a/modules/phase_field/include/kernels/CHInterface.h
+++ b/modules/phase_field/include/kernels/CHInterface.h
@@ -1,5 +1,5 @@
-#ifndef CHInterface_H
-#define CHInterface_H
+#ifndef CHINTERFACE_H
+#define CHINTERFACE_H
 
 #include "Kernel.h"
 #include "Material.h"
@@ -9,14 +9,14 @@ class CHInterface;
 
 template<>
 InputParameters validParams<CHInterface>();
-/** This is the Cahn-Hilliard equation base class that implements the interfacial or gradient energy term of the equation.
- *  See M.R. Tonks et al. / Computational Materials Science 51 (2012) 20–29 for more information.
- **/
 
+/**
+ * This is the Cahn-Hilliard equation base class that implements the interfacial or gradient energy term of the equation.
+ * See M.R. Tonks et al. / Computational Materials Science 51 (2012) 20–29 for more information.
+ */
 class CHInterface : public Kernel
 {
 public:
-
   CHInterface(const std::string & name, InputParameters parameters);
 
 protected:
@@ -24,7 +24,6 @@ protected:
   virtual Real computeQpJacobian();
 
 private:
-
   std::string _kappa_name;
   std::string _mob_name;
   std::string _Dmob_name;
@@ -42,4 +41,5 @@ private:
   VariableTestSecond & _second_test;
   VariablePhiSecond & _second_phi;
 };
-#endif //CHInterface_H
+
+#endif //CHINTERFACE_H

--- a/modules/phase_field/include/kernels/CHMath.h
+++ b/modules/phase_field/include/kernels/CHMath.h
@@ -1,5 +1,5 @@
-#ifndef CHMath_H
-#define CHMath_H
+#ifndef CHMATH_H
+#define CHMATH_H
 
 #include "CHBulk.h"
 
@@ -8,23 +8,19 @@ class CHMath;
 
 template<>
 InputParameters validParams<CHMath>();
+
 /**Cahn-Hilliard Kernel implementing the free energy f = 1/4(1-c^2)^2, such that grad df/dc = (3 c^2 -1) grad_c.
  * Most of the Cahn-Hilliard equation is implemented in CHBulk and CHInterface.  This kernel inherents from CHBulk
  * and implements a simple polynomial double well to model spinodal decomposition.
  * See M.R. Tonks et al. / Computational Materials Science 51 (2012) 20–29, Eqs 11 and 12.
  **/
-
 class CHMath : public CHBulk
 {
 public:
-
   CHMath(const std::string & name, InputParameters parameters);
 
 protected:
-
   virtual RealGradient computeGradDFDCons(PFFunctionType type);
-
-private:
-
 };
-#endif //CHMath_H
+
+#endif //CHMATH_H

--- a/modules/phase_field/include/kernels/CoupledImplicitEuler.h
+++ b/modules/phase_field/include/kernels/CoupledImplicitEuler.h
@@ -1,5 +1,5 @@
-#ifndef COUPLEDIMPLICITEULER
-#define COUPLEDIMPLICITEULER
+#ifndef COUPLEDIMPLICITEULER_H
+#define COUPLEDIMPLICITEULER_H
 
 #include "Kernel.h"
 
@@ -8,13 +8,13 @@ class CoupledImplicitEuler;
 
 template<>
 InputParameters validParams<CoupledImplicitEuler>();
+
 /**
  * This calculates the time derivative for a coupled variable
  **/
 class CoupledImplicitEuler : public Kernel
 {
 public:
-
   CoupledImplicitEuler(const std::string & name, InputParameters parameters);
 
 protected:
@@ -26,7 +26,6 @@ private:
   VariableValue & _v_dot;
   VariableValue & _dv_dot;
   unsigned int _v_var;
-
-
 };
-#endif //IMPLICITEULER
+
+#endif //COUPLEDIMPLICITEULER_H

--- a/modules/phase_field/include/kernels/DoubleWellPotential.h
+++ b/modules/phase_field/include/kernels/DoubleWellPotential.h
@@ -1,7 +1,5 @@
-#ifndef DoubleWellPotential_H
-#define DoubleWellPotential_H
-
-// Algebraic double well potential.
+#ifndef DOUBLEWELLPOTENTIAL_H
+#define DOUBLEWELLPOTENTIAL_H
 
 #include "ACBulk.h"
 
@@ -11,18 +9,16 @@ class DoubleWellPotential;
 template<>
 InputParameters validParams<DoubleWellPotential>();
 
+/**
+ * Algebraic double well potential.
+ */
 class DoubleWellPotential : public ACBulk
 {
 public:
-
   DoubleWellPotential(const std::string & name, InputParameters parameters);
 
 protected:
-
   virtual Real computeDFDOP(PFFunctionType type);
-
-private:
-
-
 };
-#endif //DoubleWellPotential_H
+
+#endif //DOUBLEWELLPOTENTIAL_H

--- a/modules/phase_field/include/kernels/MatDiffusion.h
+++ b/modules/phase_field/include/kernels/MatDiffusion.h
@@ -1,5 +1,5 @@
 #ifndef MATDIFFUSION_H
-#define MATFDIFFUSION_H
+#define MATDIFFUSION_H
 
 #include "Diffusion.h"
 #include "Material.h"
@@ -13,12 +13,10 @@ InputParameters validParams<MatDiffusion>();
 class MatDiffusion : public Diffusion
 {
 public:
-
   MatDiffusion(const std::string & name, InputParameters parameters);
 
 protected:
   virtual Real computeQpResidual();
-
   virtual Real computeQpJacobian();
 
 private:
@@ -26,4 +24,5 @@ private:
 
   MaterialProperty<Real> & _D;
 };
-#endif //COEFDIFFUSION_H
+
+#endif //MATDIFFUSION_H

--- a/modules/phase_field/include/kernels/SplitCHBase.h
+++ b/modules/phase_field/include/kernels/SplitCHBase.h
@@ -1,5 +1,5 @@
-#ifndef SPLITCHBase_H
-#define SPLITCHBase_H
+#ifndef SPLITCHBASE_H
+#define SPLITCHBASE_H
 
 #include "Kernel.h"
 
@@ -13,7 +13,6 @@ InputParameters validParams<SplitCHBase>();
 class SplitCHBase : public Kernel
 {
 public:
-
   SplitCHBase(const std::string & name, InputParameters parameters);
 
 protected:
@@ -27,8 +26,6 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
   virtual Real computeDFDC(PFFunctionType type);
   virtual Real computeDEDC(PFFunctionType type);
-
-private:
-
 };
-#endif //SPLITCHBase_H
+
+#endif //SPLITCHBASE_H

--- a/modules/phase_field/include/kernels/SplitCHCRes.h
+++ b/modules/phase_field/include/kernels/SplitCHCRes.h
@@ -1,5 +1,5 @@
-#ifndef SPLITCHCRes_H
-#define SPLITCHCRes_H
+#ifndef SPLITCHCRES_H
+#define SPLITCHCRES_H
 
 #include "SplitCHBase.h"
 
@@ -13,7 +13,6 @@ InputParameters validParams<SplitCHCRes>();
 class SplitCHCRes : public SplitCHBase
 {
 public:
-
   SplitCHCRes(const std::string & name, InputParameters parameters);
 
 protected:
@@ -27,6 +26,6 @@ private:
   unsigned int _w_var;
   VariableValue & _w;
   VariableGradient & _grad_w;
-
 };
-#endif //SPLITCHCRes_H
+
+#endif //SPLITCHCRES_H

--- a/modules/phase_field/include/kernels/SplitCHMath.h
+++ b/modules/phase_field/include/kernels/SplitCHMath.h
@@ -1,5 +1,5 @@
-#ifndef SPLITCHMath_H
-#define SPLITCHMath_H
+#ifndef SPLITCHMATH_H
+#define SPLITCHMATH_H
 
 #include "SplitCHCRes.h"
 
@@ -13,13 +13,10 @@ InputParameters validParams<SplitCHMath>();
 class SplitCHMath : public SplitCHCRes
 {
 public:
-
   SplitCHMath(const std::string & name, InputParameters parameters);
 
 protected:
   virtual Real computeDFDC(PFFunctionType type);
-
-private:
-
 };
-#endif //SPLITCHMath_H
+
+#endif //SPLITCHMATH_H

--- a/modules/phase_field/include/kernels/SplitCHWRes.h
+++ b/modules/phase_field/include/kernels/SplitCHWRes.h
@@ -1,5 +1,5 @@
-#ifndef SPLITCHWRes_H
-#define SPLITCHWRes_H
+#ifndef SPLITCHWRES_H
+#define SPLITCHWRES_H
 
 #include "Kernel.h"
 
@@ -13,17 +13,18 @@ InputParameters validParams<SplitCHWRes>();
 class SplitCHWRes : public Kernel
 {
 public:
-
   SplitCHWRes(const std::string & name, InputParameters parameters);
 
 protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
 private:
   std::string _mob_name;
   MaterialProperty<Real> & _mob;
   unsigned int _c_var;
   VariableValue & _c;
 };
-#endif //SPLITCHWRes_H
+
+#endif //SPLITCHWRES_H

--- a/modules/phase_field/include/materials/GBEvolution.h
+++ b/modules/phase_field/include/materials/GBEvolution.h
@@ -12,16 +12,13 @@ InputParameters validParams<GBEvolution>();
 class GBEvolution : public Material
 {
 public:
-
   GBEvolution(const std::string & name,
-          InputParameters parameters);
+              InputParameters parameters);
 
 protected:
   virtual void computeProperties();
 
 private:
-  //VariableValue & _cg;
-
   Real _temp;
   Real _f0s;
   Real _wGB;
@@ -35,6 +32,7 @@ private:
   Real _molar_vol;
 
   VariableValue * _T; //pointer rather than reference
+  //VariableValue & _cg;
 
   MaterialProperty<Real> & _sigma;
   MaterialProperty<Real> & _M_GB;
@@ -48,8 +46,7 @@ private:
   MaterialProperty<Real> & _act_wGB;
   MaterialProperty<Real> & _tgrad_corr_mult;
 
-  Real _kb;
-
+  const Real _kb;
 };
 
 #endif //GBEVOLUTION_H

--- a/modules/phase_field/include/materials/PFMobility.h
+++ b/modules/phase_field/include/materials/PFMobility.h
@@ -1,5 +1,5 @@
-#ifndef PFMobility_H
-#define PFMobility_H
+#ifndef PFMOBILITY_H
+#define PFMOBILITY_H
 
 #include "Material.h"
 
@@ -13,21 +13,18 @@ class PFMobility : public Material
 {
 public:
   PFMobility(const std::string & name,
-          InputParameters parameters);
+             InputParameters parameters);
 
 protected:
   virtual void computeProperties();
 
 private:
-
   MaterialProperty<Real> & _M;
   MaterialProperty<RealGradient> & _grad_M;
   MaterialProperty<Real> & _kappa_c;
 
   Real _mob;
   Real _kappa;
-
-
 };
 
-#endif //PFMobility_H
+#endif //PFMOBILITY_H

--- a/modules/phase_field/include/postprocessors/NodalFloodCount.h
+++ b/modules/phase_field/include/postprocessors/NodalFloodCount.h
@@ -27,6 +27,7 @@
 #include <iterator>
 
 #include "libmesh/periodic_boundaries.h"
+
 //Forward Declarations
 class NodalFloodCount;
 class MooseMesh;
@@ -73,7 +74,7 @@ protected:
     BubbleData(std::set<unsigned int> & nodes, unsigned int var_idx) :
         _nodes(nodes),
         _var_idx(var_idx)
-      {}
+    {}
 
     std::set<unsigned int> _nodes;
     unsigned int _var_idx;
@@ -298,4 +299,4 @@ NodalFloodCount::writeCSVFile(const std::string file_name, const std::vector<T> 
 }
 
 
-#endif
+#endif //NODALFLOODCOUNT_H

--- a/modules/phase_field/include/postprocessors/NodalVolumeFraction.h
+++ b/modules/phase_field/include/postprocessors/NodalVolumeFraction.h
@@ -38,11 +38,9 @@ public:
   Real calculateAvramiValue();
 
 protected:
-
   const PostprocessorValue & _mesh_volume;
   Real _volume_fraction;
   Real _equil_fraction;
 };
 
 #endif //NODALVOLUMEFRACTION_H
-

--- a/modules/phase_field/include/utils/AddV.h
+++ b/modules/phase_field/include/utils/AddV.h
@@ -5,5 +5,4 @@
 
 InputParameters & AddV(InputParameters & parameters, const std::string & var_name = "v");
 
-
 #endif //ADDV_H

--- a/modules/phase_field/src/action/BicrystalBoundingBoxICAction.C
+++ b/modules/phase_field/src/action/BicrystalBoundingBoxICAction.C
@@ -34,16 +34,16 @@ InputParameters validParams<BicrystalBoundingBoxICAction>()
   return params;
 }
 
-BicrystalBoundingBoxICAction::BicrystalBoundingBoxICAction(const std::string & name, InputParameters params)
-  :Action(name, params),
-   _var_name_base(getParam<std::string>("var_name_base")),
-   _crys_num(getParam<unsigned int>("crys_num")),
-  _x1(getParam<Real>("x1")),
-  _y1(getParam<Real>("y1")),
-  _z1(getParam<Real>("z1")),
-  _x2(getParam<Real>("x2")),
-  _y2(getParam<Real>("y2")),
-  _z2(getParam<Real>("z2"))
+BicrystalBoundingBoxICAction::BicrystalBoundingBoxICAction(const std::string & name, InputParameters params) :
+    Action(name, params),
+    _var_name_base(getParam<std::string>("var_name_base")),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _x1(getParam<Real>("x1")),
+    _y1(getParam<Real>("y1")),
+    _z1(getParam<Real>("z1")),
+    _x2(getParam<Real>("x2")),
+    _y2(getParam<Real>("y2")),
+    _z2(getParam<Real>("z2"))
 {
   if (_crys_num != 2)
     mooseError("crys_num must equal 2 for bicrystal ICs");
@@ -56,9 +56,8 @@ BicrystalBoundingBoxICAction::act()
   Moose::err << "Inside the BicrystalBoundingBoxICAction Object\n";
 #endif
 
-// Loop through the number of order parameters
-
-  for (unsigned int crys = 0; crys<_crys_num; crys++)
+  // Loop through the number of order parameters
+  for (unsigned int crys = 0; crys < _crys_num; crys++)
   {
     //Create variable names
     std::string var_name = _var_name_base;
@@ -90,8 +89,5 @@ BicrystalBoundingBoxICAction::act()
 
     //Add initial condition
     _problem->addInitialCondition("BoundingBoxIC", "InitialCondition", poly_params);
-
-
   }
-
 }

--- a/modules/phase_field/src/action/BicrystalCircleGrainICAction.C
+++ b/modules/phase_field/src/action/BicrystalCircleGrainICAction.C
@@ -21,29 +21,29 @@ InputParameters validParams<BicrystalCircleGrainICAction>()
 {
   InputParameters params = validParams<Action>();
 
-  params.addRequiredParam<std::string>("var_name_base","specifies the base name of the variables");
-  params.addRequiredParam<unsigned int>("crys_num","Number of grains, should be 2");
-  params.addRequiredParam<Real>("radius","Void radius");
-  params.addRequiredParam<Real>("x","The x coordinate of the circle grain center");
-  params.addRequiredParam<Real>("y","The y coordinate of the circle grain center");
-  params.addParam<Real>("z",0.0, "The z coordinate of the circle grain center");
-  params.addParam<Real>("int_width",0.0,"The interfacial width of the void surface.  Defaults to sharp interface");
+  params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
+  params.addRequiredParam<unsigned int>("crys_num", "Number of grains, should be 2");
+  params.addRequiredParam<Real>("radius", "Void radius");
+  params.addRequiredParam<Real>("x", "The x coordinate of the circle grain center");
+  params.addRequiredParam<Real>("y", "The y coordinate of the circle grain center");
+  params.addParam<Real>("z", 0.0, "The z coordinate of the circle grain center");
+  params.addParam<Real>("int_width", 0.0, "The interfacial width of the void surface.  Defaults to sharp interface");
 
-  params.addParam<bool>("3D_sphere",true,"in 3D, whether the smaller grain is a spheres or columnar grain");
+  params.addParam<bool>("3D_sphere", true, "in 3D, whether the smaller grain is a spheres or columnar grain");
 
   return params;
 }
 
-BicrystalCircleGrainICAction::BicrystalCircleGrainICAction(const std::string & name, InputParameters params)
-  :Action(name, params),
-   _var_name_base(getParam<std::string>("var_name_base")),
-   _crys_num(getParam<unsigned int>("crys_num")),
-   _radius(getParam<Real>("radius")),
-   _x(getParam<Real>("x")),
-   _y(getParam<Real>("y")),
-   _z(getParam<Real>("z")),
-   _int_width(getParam<Real>("int_width")),
-   _3D_sphere(getParam<bool>("3D_sphere"))
+BicrystalCircleGrainICAction::BicrystalCircleGrainICAction(const std::string & name, InputParameters params) :
+    Action(name, params),
+    _var_name_base(getParam<std::string>("var_name_base")),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _radius(getParam<Real>("radius")),
+    _x(getParam<Real>("x")),
+    _y(getParam<Real>("y")),
+    _z(getParam<Real>("z")),
+    _int_width(getParam<Real>("int_width")),
+    _3D_sphere(getParam<bool>("3D_sphere"))
 {
   if (_crys_num != 2)
     mooseError("crys_num must equal 2 for bicrystal ICs");
@@ -56,9 +56,8 @@ BicrystalCircleGrainICAction::act()
   Moose::err << "Inside the BicrystalCircleGrainICAction Object\n";
 #endif
 
-// Loop through the number of order parameters
-
-  for (unsigned int crys = 0; crys<_crys_num; crys++)
+  // Loop through the number of order parameters
+  for (unsigned int crys = 0; crys < _crys_num; crys++)
   {
     //Create variable names
     std::string var_name = _var_name_base;
@@ -90,8 +89,5 @@ BicrystalCircleGrainICAction::act()
 
     //Add initial condition
     _problem->addInitialCondition("SmoothCircleIC", "InitialCondition", poly_params);
-
-
   }
-
 }

--- a/modules/phase_field/src/action/PolycrystalHexGrainICAction.C
+++ b/modules/phase_field/src/action/PolycrystalHexGrainICAction.C
@@ -21,10 +21,10 @@ InputParameters validParams<PolycrystalHexGrainICAction>()
 {
   InputParameters params = validParams<Action>();
 
-  params.addRequiredParam<std::string>("var_name_base","specifies the base name of the variables");
-  params.addRequiredParam<unsigned int>("crys_num","Number of order parameters");
-  params.addRequiredParam<unsigned int>("grain_num","Number of grains, must be a square (4, 9, 16, etc)");
-  params.addParam<unsigned int>("rand_seed",12444,"The random seed");
+  params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
+  params.addRequiredParam<unsigned int>("crys_num", "Number of order parameters");
+  params.addRequiredParam<unsigned int>("grain_num", "Number of grains, must be a square (4, 9, 16, etc)");
+  params.addParam<unsigned int>("rand_seed", 12444, "The random seed");
   params.addParam<Real>("perturbation_percent", 0.0, "The percent to randomly perturbate centers of grains relative to the size of the grain");
 
   params.addParam<Real>("x_offset", 0.5, "Specifies offset of hexagon grid in x-direction");
@@ -32,13 +32,13 @@ InputParameters validParams<PolycrystalHexGrainICAction>()
   return params;
 }
 
-PolycrystalHexGrainICAction::PolycrystalHexGrainICAction(const std::string & name, InputParameters params)
-  :Action(name, params),
-   _var_name_base(getParam<std::string>("var_name_base")),
-   _crys_num(getParam<unsigned int>("crys_num")),
-   _grain_num(getParam<unsigned int>("grain_num")),
-   _x_offset(getParam<Real>("x_offset")),
-   _perturbation_percent(getParam<Real>("perturbation_percent"))
+PolycrystalHexGrainICAction::PolycrystalHexGrainICAction(const std::string & name, InputParameters params) :
+    Action(name, params),
+    _var_name_base(getParam<std::string>("var_name_base")),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _grain_num(getParam<unsigned int>("grain_num")),
+    _x_offset(getParam<Real>("x_offset")),
+    _perturbation_percent(getParam<Real>("perturbation_percent"))
 {}
 
 void
@@ -48,9 +48,8 @@ PolycrystalHexGrainICAction::act()
   Moose::err << "Inside the PolycrystalHexGrainICAction Object\n";
 #endif
 
-// Loop through the number of order parameters
-
-  for (unsigned int crys = 0; crys<_crys_num; crys++)
+  // Loop through the number of order parameters
+  for (unsigned int crys = 0; crys < _crys_num; crys++)
   {
     //Create variable names
     std::string var_name = _var_name_base;
@@ -70,8 +69,5 @@ PolycrystalHexGrainICAction::act()
 
     //Add initial condition
     _problem->addInitialCondition("HexPolycrystalIC", "InitialCondition", poly_params);
-
-
   }
-
 }

--- a/modules/phase_field/src/action/PolycrystalKernelAction.C
+++ b/modules/phase_field/src/action/PolycrystalKernelAction.C
@@ -10,21 +10,21 @@ InputParameters validParams<PolycrystalKernelAction>()
 
   params.addRequiredParam<unsigned int>("crys_num", "specifies the number of grains to create");
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
-  params.addParam<VariableName>("c","NONE","Name of coupled concentration variable");
-  params.addParam<Real>("en_ratio",1.0,"Ratio of surface to GB energy");
-  params.addParam<bool>("implicit",true,"Whether kernels are implicit or not");
-  params.addParam<VariableName>("T","Name of temperature variable");
+  params.addParam<VariableName>("c", "NONE", "Name of coupled concentration variable");
+  params.addParam<Real>("en_ratio", 1.0, "Ratio of surface to GB energy");
+  params.addParam<bool>("implicit", true, "Whether kernels are implicit or not");
+  params.addParam<VariableName>("T", "Name of temperature variable");
 
   return params;
 }
 
-PolycrystalKernelAction::PolycrystalKernelAction(const std::string & name, InputParameters params)
-  :Action(name, params),
-   _crys_num(getParam<unsigned int>("crys_num")),
-   _var_name_base(getParam<std::string>("var_name_base")),
-   _c(getParam<VariableName>("c")),
-   _implicit(getParam<bool>("implicit")),
-   _T(getParam<VariableName>("T"))
+PolycrystalKernelAction::PolycrystalKernelAction(const std::string & name, InputParameters params) :
+    Action(name, params),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _var_name_base(getParam<std::string>("var_name_base")),
+    _c(getParam<VariableName>("c")),
+    _implicit(getParam<bool>("implicit")),
+    _T(getParam<VariableName>("T"))
 {}
 
 void
@@ -36,8 +36,7 @@ PolycrystalKernelAction::act()
 #endif
   // Moose::out << "Implicit = " << _implicit << Moose::out;
 
-
-  for (unsigned int crys = 0; crys<_crys_num; crys++)
+  for (unsigned int crys = 0; crys < _crys_num; crys++)
   {
     //Create variable names
     std::string var_name = _var_name_base;
@@ -50,9 +49,8 @@ PolycrystalKernelAction::act()
 
     unsigned int ind = 0;
 
-    for (unsigned int j = 0; j<_crys_num; j++)
+    for (unsigned int j = 0; j < _crys_num; j++)
     {
-
       if (j != crys)
       {
         std::string coupled_var_name = _var_name_base;
@@ -111,6 +109,4 @@ PolycrystalKernelAction::act()
       _problem->addKernel("ACGBPoly", kernel_name, poly_params);
     }
   }
-
-
 }

--- a/modules/phase_field/src/action/PolycrystalRandomICAction.C
+++ b/modules/phase_field/src/action/PolycrystalRandomICAction.C
@@ -21,18 +21,18 @@ InputParameters validParams<PolycrystalRandomICAction>()
 {
   InputParameters params = validParams<Action>();
   params.addRequiredParam<unsigned int>("crys_num", "number of order parameters to create");
-  params.addRequiredParam<std::string>("var_name_base","specifies the base name of the variables");
+  params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
   MooseEnum typ_options("continuous, discrete");
-  params.addParam<MooseEnum>("random_type",typ_options,"The type of random polycrystal initial condition. Whether one order parameter is chosen to be 1 at each node or if each order parameter continuously varies from 0 to 1");
+  params.addParam<MooseEnum>("random_type", typ_options, "The type of random polycrystal initial condition. Whether one order parameter is chosen to be 1 at each node or if each order parameter continuously varies from 0 to 1");
 
   return params;
 }
 
-PolycrystalRandomICAction::PolycrystalRandomICAction(const std::string & name, InputParameters params)
-  :Action(name, params),
-   _crys_num(getParam<unsigned int>("crys_num")),
-   _var_name_base(getParam<std::string>("var_name_base")),
-   _random_type(getParam<MooseEnum>("random_type"))
+PolycrystalRandomICAction::PolycrystalRandomICAction(const std::string & name, InputParameters params) :
+    Action(name, params),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _var_name_base(getParam<std::string>("var_name_base")),
+    _random_type(getParam<MooseEnum>("random_type"))
 {}
 
 void
@@ -42,10 +42,8 @@ PolycrystalRandomICAction::act()
   Moose::err << "Inside the PolycrystalRandomICAction Object\n";
 #endif
 
-// Loop through the number of order parameters
-
-
-  for (unsigned int crys = 0; crys<_crys_num; crys++)
+  // Loop through the number of order parameters
+  for (unsigned int crys = 0; crys < _crys_num; crys++)
   {
     //Create variable names
     std::string var_name = _var_name_base;
@@ -60,9 +58,7 @@ PolycrystalRandomICAction::act()
     poly_params.set<unsigned int>("crys_index") = crys;
     poly_params.set<unsigned int>("typ") = _random_type;
 
-
     //Add initial condition
     _problem->addInitialCondition("PolycrystalRandomIC", "InitialCondition", poly_params);
   }
-
 }

--- a/modules/phase_field/src/action/PolycrystalVariablesAction.C
+++ b/modules/phase_field/src/action/PolycrystalVariablesAction.C
@@ -21,33 +21,32 @@ InputParameters validParams<PolycrystalVariablesAction>()
 {
   InputParameters params = validParams<Action>();
   params.addParam<std::string>("family", "LAGRANGE", "Specifies the family of FE shape functions to use for this variable");
-  params.addParam<std::string>("order", "FIRST",  "Specifies the order of the FE shape function to use for this variable");
+  params.addParam<std::string>("order", "FIRST", "Specifies the order of the FE shape function to use for this variable");
   params.addParam<Real>("scaling", 1.0, "Specifies a scaling factor to apply to this variable");
   params.addRequiredParam<unsigned int>("crys_num", "specifies the number of order parameters to create");
-  params.addRequiredParam<std::string>("var_name_base","specifies the base name of the variables");
+  params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
 
   return params;
 }
 
-PolycrystalVariablesAction::PolycrystalVariablesAction(const std::string & name, InputParameters params)
-  :Action(name, params),
-   _crys_num(getParam<unsigned int>("crys_num")),
-   _var_name_base(getParam<std::string>("var_name_base"))
+PolycrystalVariablesAction::PolycrystalVariablesAction(const std::string & name, InputParameters params) :
+    Action(name, params),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _var_name_base(getParam<std::string>("var_name_base"))
 {}
 
 void
 PolycrystalVariablesAction::act()
 {
 #ifdef DEBUG
-  Moose::err << "Inside the PolycrystalVariablesAction Object\n";
-  Moose::err << "VariableBase: " << _var_name_base
-            << "\torder: " << getParam<std::string>("order")
-            << "\tfamily: " << getParam<std::string>("family") << std::endl;
+  Moose::err << "Inside the PolycrystalVariablesAction Object\n"
+             << "VariableBase: " << _var_name_base
+             << "\torder: " << getParam<std::string>("order")
+             << "\tfamily: " << getParam<std::string>("family") << std::endl;
 #endif
 
-// Loop through the number of order parameters
-
-  for (unsigned int crys = 0; crys<_crys_num; crys++)
+  // Loop through the number of order parameters
+  for (unsigned int crys = 0; crys < _crys_num; crys++)
   {
     //Create variable names
     std::string var_name = _var_name_base;

--- a/modules/phase_field/src/action/PolycrystalVoronoiICAction.C
+++ b/modules/phase_field/src/action/PolycrystalVoronoiICAction.C
@@ -22,22 +22,21 @@ InputParameters validParams<PolycrystalVoronoiICAction>()
   InputParameters params = validParams<Action>();
   params.addRequiredParam<unsigned int>("crys_num", "number of order parameters to create");
   params.addRequiredParam<unsigned int>("grain_num", "number of grains to create, if it is going to greater than crys_num");
-  params.addRequiredParam<std::string>("var_name_base","specifies the base name of the variables");
-  params.addParam<unsigned int>("rand_seed",12444,"The random seed");
+  params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
+  params.addParam<unsigned int>("rand_seed", 12444, "The random seed");
 
-  params.addParam<bool>("cody_test",false,"Use set grain center points for Cody's test. Grain num MUST equal 10");
+  params.addParam<bool>("cody_test", false, "Use set grain center points for Cody's test. Grain num MUST equal 10");
 
-  params.addParam<bool>("columnar_3D",false,"3D microstructure will be columnar in the z-direction?");
-
+  params.addParam<bool>("columnar_3D", false, "3D microstructure will be columnar in the z-direction?");
 
   return params;
 }
 
-PolycrystalVoronoiICAction::PolycrystalVoronoiICAction(const std::string & name, InputParameters params)
-  :Action(name, params),
-   _crys_num(getParam<unsigned int>("crys_num")),
-   _grain_num(getParam<unsigned int>("grain_num")),
-   _var_name_base(getParam<std::string>("var_name_base"))
+PolycrystalVoronoiICAction::PolycrystalVoronoiICAction(const std::string & name, InputParameters params) :
+    Action(name, params),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _grain_num(getParam<unsigned int>("grain_num")),
+    _var_name_base(getParam<std::string>("var_name_base"))
 {}
 
 void
@@ -47,10 +46,8 @@ PolycrystalVoronoiICAction::act()
   Moose::err << "Inside the PolycrystalVoronoiICAction Object\n";
 #endif
 
-// Loop through the number of order parameters
-
-
-  for (unsigned int crys = 0; crys<_crys_num; crys++)
+  // Loop through the number of order parameters
+  for (unsigned int crys = 0; crys < _crys_num; crys++)
   {
     //Create variable names
     std::string var_name = _var_name_base;
@@ -68,9 +65,7 @@ PolycrystalVoronoiICAction::act()
     poly_params.set<bool>("cody_test") = getParam<bool>("cody_test");
     poly_params.set<bool>("columnar_3D") = getParam<bool>("columnar_3D");
 
-
     //Add initial condition
     _problem->addInitialCondition("PolycrystalReducedIC", "InitialCondition", poly_params);
   }
-
 }

--- a/modules/phase_field/src/action/Tricrystal2CircleGrainsICAction.C
+++ b/modules/phase_field/src/action/Tricrystal2CircleGrainsICAction.C
@@ -21,15 +21,15 @@ InputParameters validParams<Tricrystal2CircleGrainsICAction>()
 {
   InputParameters params = validParams<Action>();
   params.addRequiredParam<unsigned int>("crys_num", "number of order parameters to create");
-  params.addRequiredParam<std::string>("var_name_base","specifies the base name of the variables");
+  params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
 
   return params;
 }
 
-Tricrystal2CircleGrainsICAction::Tricrystal2CircleGrainsICAction(const std::string & name, InputParameters params)
-  :Action(name, params),
-   _var_name_base(getParam<std::string>("var_name_base")),
-   _crys_num(getParam<unsigned int>("crys_num"))
+Tricrystal2CircleGrainsICAction::Tricrystal2CircleGrainsICAction(const std::string & name, InputParameters params) :
+    Action(name, params),
+    _var_name_base(getParam<std::string>("var_name_base")),
+    _crys_num(getParam<unsigned int>("crys_num"))
 {}
 
 void
@@ -39,10 +39,8 @@ Tricrystal2CircleGrainsICAction::act()
   Moose::err << "Inside the Tricrystal2CircleGrainsICAction Object\n";
 #endif
 
-// Loop through the number of order parameters
-
-
-  for (unsigned int crys = 0; crys<_crys_num; crys++)
+  // Loop through the number of order parameters
+  for (unsigned int crys = 0; crys < _crys_num; crys++)
   {
     //Create variable names
     std::string var_name = _var_name_base;
@@ -60,5 +58,4 @@ Tricrystal2CircleGrainsICAction::act()
     //Add initial condition
     _problem->addInitialCondition("Tricrystal2CircleGrainsIC", "InitialCondition", poly_params);
   }
-
 }

--- a/modules/phase_field/src/auxkernels/BndsCalcAux.C
+++ b/modules/phase_field/src/auxkernels/BndsCalcAux.C
@@ -6,20 +6,19 @@ InputParameters validParams<BndsCalcAux>()
 {
   InputParameters params = validParams<AuxKernel>();
   params.addCoupledVar("v", "Array of coupled variables");
-  params.addRequiredParam<unsigned int>("crys_num","number of grains");
-  params.addRequiredParam<std::string>("var_name_base","base for variable names");
+  params.addRequiredParam<unsigned int>("crys_num", "number of grains");
+  params.addRequiredParam<std::string>("var_name_base", "base for variable names");
 
   return params;
 }
 
-BndsCalcAux::BndsCalcAux(const std::string & name, InputParameters parameters)
-    :AuxKernel(name, AddV(parameters) )
+BndsCalcAux::BndsCalcAux(const std::string & name, InputParameters parameters) :
+    AuxKernel(name, AddV(parameters) )
 {
   _ncrys = coupledComponents("v");
-
   _vals.resize(_ncrys);
 
-  for (unsigned int i=0; i<_ncrys; ++i)
+  for (unsigned int i=0; i < _ncrys; ++i)
     _vals[i] = &coupledValue("v", i);
 }
 
@@ -28,7 +27,7 @@ BndsCalcAux::computeValue()
 {
   Real value = 0;
 
-  for (unsigned int i=0; i<_ncrys; ++i)
+  for (unsigned int i=0; i < _ncrys; ++i)
     value += (*_vals[i])[_qp]*(*_vals[i])[_qp];
 
   return value;

--- a/modules/phase_field/src/auxkernels/NodalFloodCountAux.C
+++ b/modules/phase_field/src/auxkernels/NodalFloodCountAux.C
@@ -54,7 +54,6 @@ NodalFloodCountAux::computeValue()
   case 0:  // UNIQUE_REGION
   case 1:  // VARIABLE_COLORING
     return _flood_counter.getNodalValue(_current_node->id(), _var_idx, _var_coloring);
-    break;
   case 2:  // ACTIVE_BOUNDS
     if (isNodal())
       return _flood_counter.getNodalValues(_current_node->id()).size();
@@ -67,10 +66,8 @@ NodalFloodCountAux::computeValue()
         size += values[i].size();
       return size;
     }
-    break;
   case 3:  // CENTROID
     return _flood_counter.getElementalValue(_current_elem->id());
-    break;
   }
 
   return 0;

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -98,9 +98,9 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerUserObject(NodalFloodCount);
   registerAux(NodalFloodCountAux);
   registerAux(BndsCalcAux);
-//  registerAux(SPPARKSAux);
+  // registerAux(SPPARKSAux);
   registerUserObject(NodalVolumeFraction);
-//  registerUserObject(SPPARKSUserObject);
+  // registerUserObject(SPPARKSUserObject);
 }
 
 void

--- a/modules/phase_field/src/ics/C1ICBase.C
+++ b/modules/phase_field/src/ics/C1ICBase.C
@@ -34,14 +34,14 @@ InputParameters validParams<C1ICBase>()
 }
 
 C1ICBase::C1ICBase(const std::string & name,
-                   InputParameters parameters)
-  :InitialCondition(name, parameters),
-   _average(parameters.get<Real>("average")),
-   _amplitude(parameters.get<Real>("amplitude")),
-   _length(parameters.get<Real>("length")),
-   _width(parameters.get<Real>("width")),
-   _buffer(parameters.get<Real>("buffer")),
-   _interface(parameters.get<Real>("interface"))
+                   InputParameters parameters) :
+    InitialCondition(name, parameters),
+    _average(parameters.get<Real>("average")),
+    _amplitude(parameters.get<Real>("amplitude")),
+    _length(parameters.get<Real>("length")),
+    _width(parameters.get<Real>("width")),
+    _buffer(parameters.get<Real>("buffer")),
+    _interface(parameters.get<Real>("interface"))
 {}
 
 Number
@@ -49,10 +49,10 @@ C1ICBase::interfaceValue(Real r)
 {
   Real x = (r - _buffer) / _interface;
 
-  if (x < 0.) return (_average + _amplitude);
-  if (x > 1.) return (_average - _amplitude);
+  if (x < 0.0) return (_average + _amplitude);
+  if (x > 1.0) return (_average - _amplitude);
 
-  return ((1. + 4.*x*x*x - 6.*x*x) * _amplitude +
+  return ((1.0 + 4.0*x*x*x - 6.0*x*x) * _amplitude +
           _average);
 }
 
@@ -61,11 +61,8 @@ C1ICBase::interfaceDerivative(Real r)
 {
   Real x = (r - _buffer) / _interface;
 
-  if (x < 0.) return 0.;
-  if (x > 1.) return 0.;
+  if (x < 0.0) return 0.0;
+  if (x > 1.0) return 0.0;
 
-  return ((12.*x*x - 12.*x) * _amplitude);
+  return ((12.0*x*x - 12.0*x) * _amplitude);
 }
-
-
-

--- a/modules/phase_field/src/ics/CrossIC.C
+++ b/modules/phase_field/src/ics/CrossIC.C
@@ -32,12 +32,12 @@ InputParameters validParams<CrossIC>()
 }
 
 CrossIC::CrossIC(const std::string & name,
-                 InputParameters parameters)
-  :C1ICBase(name, parameters),
-   _x1(parameters.get<Real>("x1")),
-   _y1(parameters.get<Real>("y1")),
-   _x2(parameters.get<Real>("x2")),
-   _y2(parameters.get<Real>("y2"))
+                 InputParameters parameters) :
+    C1ICBase(name, parameters),
+    _x1(parameters.get<Real>("x1")),
+    _y1(parameters.get<Real>("y1")),
+    _x2(parameters.get<Real>("x2")),
+    _y2(parameters.get<Real>("y2"))
 {}
 
 Real
@@ -221,7 +221,7 @@ CrossIC::value(const Point & p)
     {
       Real xd = x - (.5 - _width/2.);
       Real yd = y - (.5 - _length/2.);
-      Real r = std::sqrt(xd*xd+yd*yd);
+      Real r = std::sqrt(xd*xd + yd*yd);
       return interfaceValue(r);
     }
     else
@@ -271,9 +271,9 @@ CrossIC::value(const Point & p)
     }
     else if (y > .5 - _width/2. - _buffer - _interface)
     {
-      Real xd = x - (.5 - _length/2.);
-      Real yd = y - .5 + _width/2.;
-      Real r = std::sqrt(xd*xd+yd*yd);
+      Real xd = x - (.5 - _length / 2.);
+      Real yd = y - .5 + _width / 2.;
+      Real r = std::sqrt(xd*xd + yd*yd);
       return interfaceValue(r);
     }
     else
@@ -294,10 +294,12 @@ RealGradient CrossIC::gradient(const Point & p)
   pyminus(1) -= TOLERANCE;
   pxplus(0)  += TOLERANCE;
   pyplus(1)  += TOLERANCE;
+
   Number uxminus = value(pxminus),
-    uxplus  = value(pxplus),
-    uyminus = value(pyminus),
-    uyplus  = value(pyplus);
-  return Gradient((uxplus-uxminus)/2./TOLERANCE,
-                  (uyplus-uyminus)/2./TOLERANCE);
+         uxplus  = value(pxplus),
+         uyminus = value(pyminus),
+         uyplus  = value(pyplus);
+
+  return Gradient((uxplus - uxminus) / 2.0 / TOLERANCE,
+                  (uyplus - uyminus) / 2.0 / TOLERANCE);
 }

--- a/modules/phase_field/src/ics/HexPolycrystalIC.C
+++ b/modules/phase_field/src/ics/HexPolycrystalIC.C
@@ -11,7 +11,7 @@ InputParameters validParams<HexPolycrystalIC>()
   params.addParam<Real>("x_offset", 0.5, "Specifies offset of hexagon grid in x-direction");
   params.addParam<Real>("perturbation_percent", 0.0, "The percent to randomly perturbate centers of grains relative to the size of the grain");
 
-  params.addParam<unsigned int>("rand_seed",12444,"The random seed");
+  params.addParam<unsigned int>("rand_seed", 12444, "The random seed");
 
   params.set<int>("typ") = 1;
 
@@ -19,10 +19,10 @@ InputParameters validParams<HexPolycrystalIC>()
 }
 
 HexPolycrystalIC::HexPolycrystalIC(const std::string & name,
-                             InputParameters parameters)
-  :PolycrystalReducedIC(name, parameters),
-   _x_offset(getParam<Real>("x_offset")),
-   _perturbation_percent(getParam<Real>("perturbation_percent"))
+                                   InputParameters parameters) :
+    PolycrystalReducedIC(name, parameters),
+    _x_offset(getParam<Real>("x_offset")),
+    _perturbation_percent(getParam<Real>("perturbation_percent"))
 {
   if (_perturbation_percent < 0.0 || _perturbation_percent > 1.0)
     mooseError("perturbation_percent out of range");
@@ -45,7 +45,7 @@ HexPolycrystalIC::initialSetup()
   unsigned int third_dimension_iterations = _mesh.dimension() == 3 ? root : 1;
   Real ndist = 1.0/root;
 
- //Set up domain bounds with mesh tools
+  // Set up domain bounds with mesh tools
   for (unsigned int i = 0; i < LIBMESH_DIM; i++)
   {
     _bottom_left(i) = _mesh.getMinInDimension(i);
@@ -63,15 +63,15 @@ HexPolycrystalIC::initialSetup()
   std::vector<Point> holder(_grain_num);
 
   unsigned int count = 0;
-  //Assign the relative center points positions, defining the grains according to a hexagonal pattern
-  for (unsigned int k = 0; k<third_dimension_iterations; ++k)
-    for (unsigned int j = 0; j<root; ++j)
-      for (unsigned int i = 0; i<root; ++i)
+  // Assign the relative center points positions, defining the grains according to a hexagonal pattern
+  for (unsigned int k = 0; k < third_dimension_iterations; ++k)
+    for (unsigned int j = 0; j < root; ++j)
+      for (unsigned int i = 0; i < root; ++i)
       {
-        //Set x-coordinate
+        // set x-coordinate
         holder[count](0) = i*ndist + (0.5*ndist*(j%2)) + _x_offset*ndist;
 
-        //set y-coordinate
+        // set y-coordinate
         holder[count](1) = j*ndist + (0.5*ndist*(k%2));
 
         // set z-coordinate
@@ -81,9 +81,9 @@ HexPolycrystalIC::initialSetup()
         count++;
       }
 
-  //Assign center point values
-  for (unsigned int grain=0; grain<_grain_num; grain++)
-    for (unsigned int i = 0; i<LIBMESH_DIM; i++)
+  // Assign center point values
+  for (unsigned int grain=0; grain < _grain_num; grain++)
+    for (unsigned int i = 0; i < LIBMESH_DIM; i++)
     {
       if (_range(i) == 0)
         continue;
@@ -118,7 +118,7 @@ HexPolycrystalIC::initialSetup()
       }
     }
 
-    //Assign the current center point to the order parameter that is furthest away.
+    // Assign the current center point to the order parameter that is furthest away.
     Real mx;
     if (grain < _op_num)
       _assigned_op[grain] = grain;
@@ -134,6 +134,7 @@ HexPolycrystalIC::initialSetup()
         }
       _assigned_op[grain] = mx_ind;
     }
+
     //Moose::out << "For grain " << grain << ", center point = " << _centerpoints[grain](0) << " " << _centerpoints[grain](1) << "\n";
     //Moose::out << "Max index is " << _assigned_op[grain] << ", with a max distance of " << mx << "\n";
   }

--- a/modules/phase_field/src/ics/LatticeSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/LatticeSmoothCircleIC.C
@@ -5,8 +5,8 @@ template<>
 InputParameters validParams<LatticeSmoothCircleIC>()
 {
   InputParameters params = validParams<MultiSmoothCircleIC>();
-  params.addParam<Real>("Rnd_variation",0.0, "Variation from central lattice position");
-  params.addRequiredParam<std::vector<unsigned int> >("circles_per_side","Vector containing the number of bubbles along each side");
+  params.addParam<Real>("Rnd_variation", 0.0, "Variation from central lattice position");
+  params.addRequiredParam<std::vector<unsigned int> >("circles_per_side", "Vector containing the number of bubbles along each side");
   params.set<unsigned int>("numbub") = 0;
   params.set<Real>("bubspac") = 0.0;
   params.set<Real>("x1") = 0.0;
@@ -16,10 +16,10 @@ InputParameters validParams<LatticeSmoothCircleIC>()
 }
 
 LatticeSmoothCircleIC::LatticeSmoothCircleIC(const std::string & name,
-                                               InputParameters parameters)
-  :MultiSmoothCircleIC(name, parameters),
-   _Rnd_variation(getParam<Real>("Rnd_variation")),
-   _circles_per_side(getParam<std::vector<unsigned int> >("circles_per_side"))
+                                             InputParameters parameters) :
+    MultiSmoothCircleIC(name, parameters),
+    _Rnd_variation(getParam<Real>("Rnd_variation")),
+    _circles_per_side(getParam<std::vector<unsigned int> >("circles_per_side"))
 {
 }
 
@@ -30,7 +30,6 @@ LatticeSmoothCircleIC::initialSetup()
 
   /*std::vector<unsigned int> circles_per_side;
   circles_per_side.resize(3);
-
 
   for (unsigned int i = 0; i<3; ++i)
   circles_per_side[i] = _circles_per_side;*/
@@ -53,11 +52,11 @@ LatticeSmoothCircleIC::initialSetup()
   if (_Lz == 0.0)
   {
     _circles_per_side[2] = 0;
-    _numbub = _circles_per_side[0]*_circles_per_side[1];
+    _numbub = _circles_per_side[0] * _circles_per_side[1];
   }
   else
   {
-    _numbub = _circles_per_side[0]*_circles_per_side[1]*_circles_per_side[2];
+    _numbub = _circles_per_side[0] * _circles_per_side[1] * _circles_per_side[2];
     /*if (_Lz < _Lx) //For non-uniform domain.  This needs to be changed
       circles_per_side[2] = _circles_per_side[0]*_Lz/_Lx;*/
   }
@@ -68,65 +67,60 @@ LatticeSmoothCircleIC::initialSetup()
 
   MooseRandom::seed(_rnd_seed);
 
-  Real x_sep = _Lx/(_circles_per_side[0]);
-  Real y_sep = _Ly/(_circles_per_side[1]);
+  Real x_sep = _Lx / _circles_per_side[0];
+  Real y_sep = _Ly / _circles_per_side[1];
 
   Real z_sep = 0.0;
   unsigned int z_num = 1.0;
 
   if (_Lz > 0.0)
   {
-    z_sep = _Lz/(_circles_per_side[2]);
+    z_sep = _Lz / _circles_per_side[2];
     z_num = _circles_per_side[2];
   }
 
-
   unsigned int cnt = 0;
-
-  for(unsigned int i=0; i<_circles_per_side[0]; i++)
-    for (unsigned int j=0; j<_circles_per_side[1]; j++)
-      for (unsigned int k=0; k<z_num; k++)
+  for (unsigned int i = 0; i < _circles_per_side[0]; i++)
+    for (unsigned int j = 0; j < _circles_per_side[1]; j++)
+      for (unsigned int k = 0; k < z_num; k++)
       {
-        //Vary circle radius
-       _bubradi[cnt] = _radius*(1.0 + (1.0 - 2.0*MooseRandom::rand())*_radius_variation);
+         //Vary circle radius
+        _bubradi[cnt] = _radius*(1.0 + (1.0 - 2.0*MooseRandom::rand())*_radius_variation);
 
-       if (_bubradi[cnt] < 0.0)
-         _bubradi[cnt] = 0.0;
+        if (_bubradi[cnt]<0.0) _bubradi[cnt] = 0.0;
 
         Real xx = x_sep/2.0 + i*x_sep;
         Real yy = y_sep/2.0 + j*y_sep;
         Real zz = z_sep/2.0 + k*z_sep;
 
         //Vary circle position
-        xx = xx + (1.0 - 2.0*MooseRandom::rand())*_Rnd_variation;
-        yy = yy + (1.0 - 2.0*MooseRandom::rand())*_Rnd_variation;
+        xx = xx + (1.0 - 2.0*MooseRandom::rand()) * _Rnd_variation;
+        yy = yy + (1.0 - 2.0*MooseRandom::rand()) * _Rnd_variation;
 
         if (_Lz != 0.0)
-          zz = zz + (1.0 - 2.0*MooseRandom::rand())*_Rnd_variation;
+          zz = zz + (1.0 - 2.0*MooseRandom::rand()) * _Rnd_variation;
 
         //Verify not out of bounds
-        if (xx < _bubradi[cnt]+_int_width)
+        if (xx < _bubradi[cnt] + _int_width)
           xx = _bubradi[cnt] + _int_width;
         if (xx > _Lx - (_bubradi[cnt] + _int_width))
           xx = _Lx - (_bubradi[cnt] + _int_width);
-        if (yy < _bubradi[cnt]+_int_width)
-          yy = _bubradi[cnt]+_int_width;
-        if (yy > _Ly - (_bubradi[cnt]+_int_width))
-          yy = _Ly - (_bubradi[cnt]+_int_width);
+        if (yy < _bubradi[cnt] + _int_width)
+          yy = _bubradi[cnt] + _int_width;
+        if (yy > _Ly - (_bubradi[cnt] + _int_width))
+          yy = _Ly - (_bubradi[cnt] + _int_width);
         if (_Lz != 0.0)
         {
-          if (zz < _bubradi[cnt]+_int_width)
-            zz = _bubradi[cnt]+_int_width;
-          if (zz > _Lz - (_bubradi[cnt]+_int_width))
-            zz = _Lz - (_bubradi[cnt]+_int_width);
+          if (zz < _bubradi[cnt] + _int_width)
+            zz = _bubradi[cnt] + _int_width;
+          if (zz > _Lz - (_bubradi[cnt] + _int_width))
+            zz = _Lz - (_bubradi[cnt] + _int_width);
         }
-
 
         _bubcent[cnt](0) = xx;
         _bubcent[cnt](1) = yy;
         _bubcent[cnt](2) = zz;
 
         cnt++;
-
       }
 }

--- a/modules/phase_field/src/ics/MultiSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothCircleIC.C
@@ -9,96 +9,88 @@ InputParameters validParams<MultiSmoothCircleIC>()
   params.addRequiredParam<Real>("bubspac", "minimum spacing of bubbles, measured from center to center");
   params.addRequiredParam<Real>("Lx", "length of simulation domain in x-direction");
   params.addRequiredParam<Real>("Ly", "length of simulation domain in y-direction");
-  params.addParam<Real>("Lz",0.0,"length of simulation domain in z-direction");
-  params.addParam<unsigned int>("rand_seed",2000,"random seed");
-  params.addParam<unsigned int>("numtries", 1000,"The number of tries");
-  params.addParam<Real>("radius_variation",0.0,"Plus or minus Percent of random variation in the bubble radius");
+  params.addParam<Real>("Lz", 0.0, "length of simulation domain in z-direction");
+  params.addParam<unsigned int>("rand_seed", 2000, "random seed");
+  params.addParam<unsigned int>("numtries", 1000, "The number of tries");
+  params.addParam<Real>("radius_variation", 0.0, "Plus or minus Percent of random variation in the bubble radius");
   //These are SmoothCircleIC inputs that are not needed here.
   params.set<Real>("x1") = 0.0;
   params.set<Real>("y1") = 0.0;
-
   return params;
 }
 
 MultiSmoothCircleIC::MultiSmoothCircleIC(const std::string & name,
-                                               InputParameters parameters)
-  :SmoothCircleIC(name, parameters),
-   _numbub(getParam<unsigned int>("numbub")),
-   _bubspac(getParam<Real>("bubspac")),
-   _Lx(getParam<Real>("Lx")),
-   _Ly(getParam<Real>("Ly")),
-   _Lz(getParam<Real>("Lz")),
-   _rnd_seed(getParam<unsigned int>("rand_seed")),
-   _numtries(getParam<unsigned int>("numtries")),
-   _radius_variation(getParam<Real>("radius_variation"))
+                                         InputParameters parameters) :
+    SmoothCircleIC(name, parameters),
+    _numbub(getParam<unsigned int>("numbub")),
+    _bubspac(getParam<Real>("bubspac")),
+    _Lx(getParam<Real>("Lx")),
+    _Ly(getParam<Real>("Ly")),
+    _Lz(getParam<Real>("Lz")),
+    _rnd_seed(getParam<unsigned int>("rand_seed")),
+    _numtries(getParam<unsigned int>("numtries")),
+    _radius_variation(getParam<Real>("radius_variation"))
 {
 }
 
 void
 MultiSmoothCircleIC::initialSetup()
 {
-   _bubcent.resize(_numbub);
-   _bubradi.resize(_numbub);
+  _bubcent.resize(_numbub);
+  _bubradi.resize(_numbub);
 
-   MooseRandom::seed(_rnd_seed);
-   for(unsigned int i=0; i<_numbub; i++)
-     {
-       //Vary bubble radius
-       _bubradi[i] = _radius*(1.0 + (1.0 - 2.0*MooseRandom::rand())*_radius_variation);
-       if (_bubradi[i] < 0.0)
-         _bubradi[i] = 0.0;
+  MooseRandom::seed(_rnd_seed);
+  for (unsigned int i = 0; i < _numbub; i++)
+  {
+    //Vary bubble radius
+    _bubradi[i] = _radius * (1.0 + (1.0 - 2.0*MooseRandom::rand()) * _radius_variation);
+    if (_bubradi[i] < 0.0) _bubradi[i] = 0.0;
 
-       //Vary circle positions
-       unsigned int num_tries = 0;
+    //Vary circle positions
+    unsigned int num_tries = 0;
 
-       Real rr = 0.0;
-       Real xx, yy, zz;
+    Real rr = 0.0;
+    Real xx, yy, zz;
 
-       while (rr < _bubspac && num_tries < _numtries)
-       {
-         num_tries++;
-         //Moose::out<<"num_tries: "<<num_tries<<std::endl;
+    while (rr < _bubspac && num_tries < _numtries)
+    {
+      num_tries++;
+      //Moose::out<<"num_tries: "<<num_tries<<std::endl;
 
-         Real ran1 = MooseRandom::rand();
-         Real ran2 = MooseRandom::rand();
-         Real ran3 = MooseRandom::rand();
+      Real ran1 = MooseRandom::rand();
+      Real ran2 = MooseRandom::rand();
+      Real ran3 = MooseRandom::rand();
 
-         xx = ran1*(_Lx - _bubspac) + 0.5*_bubspac;
-         yy = ran2*(_Ly - _bubspac) + 0.5*_bubspac;
+      xx = ran1*(_Lx - _bubspac) + 0.5*_bubspac;
+      yy = ran2*(_Ly - _bubspac) + 0.5*_bubspac;
 
-         if (_Lz == 0.0)
-           zz = 0.0;
-         else
-           zz = ran3*(_Lz - _bubspac) + 0.5*_bubspac;
+      if (_Lz == 0.0)
+        zz = 0.0;
+      else
+        zz = ran3*(_Lz - _bubspac) + 0.5*_bubspac;
 
-         for(unsigned int j=0; j<i; j++)
-         {
-           if (j==0)
-             rr = 1000.0;
+      for (unsigned int j = 0; j < i; j++)
+      {
+        if (j == 0) rr = 1000.0;
 
-           Real rx = abs(xx-_bubcent[j](0));
-           Real ry = abs(yy-_bubcent[j](1));
-           Real rz = abs(zz-_bubcent[j](2));
-           Real tmp_rr = std::sqrt(rx*rx + ry*ry + rz*rz);
-           if (tmp_rr < rr)
-             rr = tmp_rr;
-         }
-         if (i==0)
-           rr = _Lx;
+        Real rx = abs(xx-_bubcent[j](0));
+        Real ry = abs(yy-_bubcent[j](1));
+        Real rz = abs(zz-_bubcent[j](2));
+        Real tmp_rr = std::sqrt(rx*rx + ry*ry + rz*rz);
+        if (tmp_rr < rr)
+          rr = tmp_rr;
+      }
 
-       }
+      if (i == 0) rr = _Lx;
+    }
 
-       if (num_tries == _numtries)
-       {
-         Moose::out<<"Too many tries in MultiSmoothCircle IC "<<std::endl;
-         mooseError("Toom many tried in MultiSmoothCircleIC");
-       }
+    if (num_tries == _numtries)
+      mooseError("Toom many tries in MultiSmoothCircleIC");
 
-
-       _bubcent[i](0) =   xx;
-       _bubcent[i](1) =   yy;
-       _bubcent[i](2) =   zz;
-     }
+    _bubcent[i](0) = xx;
+    _bubcent[i](1) = yy;
+    _bubcent[i](2) = zz;
+  }
 }
 
 Real
@@ -106,38 +98,39 @@ MultiSmoothCircleIC::value(const Point & p)
 {
   Real val = _outvalue;
   Real val2 = 0.0;
-  for(unsigned int i=0; i<_numbub; i++)
-    {
-      _radius = _bubradi[i];
-      _center = _bubcent[i];
 
-      if((p-_center).size() < _radius + _int_width/2.0)
-      {
-        val2 = SmoothCircleIC::value(p);
-        if (val2 > val)
-          val = val2;
-      }
+  for (unsigned int i = 0; i < _numbub; i++)
+  {
+    _radius = _bubradi[i];
+    _center = _bubcent[i];
+
+    if ((p-_center).size() < _radius + _int_width/2.0)
+    {
+      val2 = SmoothCircleIC::value(p);
+      if (val2 > val) val = val2;
     }
+  }
+
   return val;
 }
 
 RealGradient
 MultiSmoothCircleIC::gradient(const Point & p)
 {
-  RealGradient grad = Gradient(0.0,0.0,0.0);
+  RealGradient grad = Gradient(0.0, 0.0, 0.0);
   RealGradient grad2;
 
-  for(unsigned int i=0; i<_numbub; i++)
+  for (unsigned int i = 0; i < _numbub; i++)
+  {
+    _radius = _bubradi[i];
+    _center = _bubcent[i];
+    if ((p-_center).size() < _radius + _int_width/2.0)
     {
-      _radius = _bubradi[i];
-      _center = _bubcent[i];
-      if((p-_center).size() < _radius + _int_width/2.0)
-      {
-        grad2 = SmoothCircleIC::gradient(p)/_numbub;
-        //if (grad.size() < grad2.size())
-          grad = grad2;
-      }
+      grad2 = SmoothCircleIC::gradient(p)/_numbub;
+      //if (grad.size() < grad2.size())
+      grad = grad2;
     }
+  }
 
   return grad;
 }

--- a/modules/phase_field/src/ics/PolycrystalRandomIC.C
+++ b/modules/phase_field/src/ics/PolycrystalRandomIC.C
@@ -5,55 +5,42 @@ template<>
 InputParameters validParams<PolycrystalRandomIC>()
 {
   InputParameters params = validParams<InitialCondition>();
-  params.addRequiredParam<unsigned int>("crys_num","Number of order parameters");
+  params.addRequiredParam<unsigned int>("crys_num", "Number of order parameters");
   params.addRequiredParam<unsigned int>("crys_index", "The index for the current order parameter");
 
-  params.addRequiredParam<unsigned int>("typ","Type of random grain structure");
+  params.addRequiredParam<unsigned int>("typ", "Type of random grain structure");
 
   return params;
 }
 
 PolycrystalRandomIC::PolycrystalRandomIC(const std::string & name,
-                             InputParameters parameters)
-  :InitialCondition(name, parameters),
-   _crys_num(getParam<unsigned int>("crys_num")),
-   _crys_index(getParam<unsigned int>("crys_index")),
-   _typ(getParam<unsigned int>("typ"))
+                             InputParameters parameters) :
+    InitialCondition(name, parameters),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _crys_index(getParam<unsigned int>("crys_index")),
+    _typ(getParam<unsigned int>("typ"))
 {}
 
 Real PolycrystalRandomIC::value(const Point & p)
- {
+{
+  Point cur_pos = p;
+  Real val =  MooseRandom::rand();
 
-   Point cur_pos = p;
+  switch(_typ)
+  {
+    case 0: //Continuously random
+      return val;
 
-   Real val =  MooseRandom::rand();
+    case 1: //Discretely random
+    {
+      unsigned int rndind = _crys_num * val;
 
-   switch(_typ)
-   {
-   case 0: //Continuously random
-     return val;
-     break;
+      if (rndind == _crys_index)
+        return 1.0;
+      else
+        return 0.0;
+    }
+  }
 
-   case 1: //Discretely random
-   {
-     unsigned int rndind = _crys_num*val;
-     if (rndind == _crys_index)
-       return 1.0;
-     else
-       return 0.0;
-
-     break;
-   }
-
-   }
-
-   mooseError("Bad case passed in PolycrystalRandomIC");
-   return 0.0;
-
- }
-
-
-
-
-
-
+  mooseError("Bad case passed in PolycrystalRandomIC");
+}

--- a/modules/phase_field/src/ics/RndBoundingBoxIC.C
+++ b/modules/phase_field/src/ics/RndBoundingBoxIC.C
@@ -22,22 +22,22 @@ InputParameters validParams<RndBoundingBoxIC>()
 }
 
 RndBoundingBoxIC::RndBoundingBoxIC(const std::string & name,
-                             InputParameters parameters)
-  :InitialCondition(name, parameters),
-   _x1(parameters.get<Real>("x1")),
-   _y1(parameters.get<Real>("y1")),
-   _z1(parameters.get<Real>("z1")),
-   _x2(parameters.get<Real>("x2")),
-   _y2(parameters.get<Real>("y2")),
-   _z2(parameters.get<Real>("z2")),
-   _mx_invalue(parameters.get<Real>("mx_invalue")),
-   _mx_outvalue(parameters.get<Real>("mx_outvalue")),
-   _mn_invalue(parameters.get<Real>("mn_invalue")),
-   _mn_outvalue(parameters.get<Real>("mn_outvalue")),
-   _range_invalue(_mx_invalue - _mn_invalue),
-   _range_outvalue(_mx_outvalue - _mn_outvalue),
-   _bottom_left(_x1,_y1,_z1),
-   _top_right(_x2,_y2,_z2)
+                                   InputParameters parameters) :
+    InitialCondition(name, parameters),
+    _x1(parameters.get<Real>("x1")),
+    _y1(parameters.get<Real>("y1")),
+    _z1(parameters.get<Real>("z1")),
+    _x2(parameters.get<Real>("x2")),
+    _y2(parameters.get<Real>("y2")),
+    _z2(parameters.get<Real>("z2")),
+    _mx_invalue(parameters.get<Real>("mx_invalue")),
+    _mx_outvalue(parameters.get<Real>("mx_outvalue")),
+    _mn_invalue(parameters.get<Real>("mn_invalue")),
+    _mn_outvalue(parameters.get<Real>("mn_outvalue")),
+    _range_invalue(_mx_invalue - _mn_invalue),
+    _range_outvalue(_mx_outvalue - _mn_outvalue),
+    _bottom_left(_x1,_y1,_z1),
+    _top_right(_x2,_y2,_z2)
 {
   mooseAssert(_range_invalue >= 0.0, "Inside Min > Inside Max for RandomIC!");
   mooseAssert(_range_outvalue >= 0.0, "Outside Min > Outside Max for RandomIC!");
@@ -49,14 +49,9 @@ RndBoundingBoxIC::value(const Point & p)
   //Random number between 0 and 1
   Real rand_num = MooseRandom::rand();
 
-  for(unsigned int i=0; i<LIBMESH_DIM; i++)
-    if(p(i) < _bottom_left(i) || p(i) > _top_right(i))
-      return rand_num*_range_outvalue + _mn_outvalue;
+  for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
+    if (p(i) < _bottom_left(i) || p(i) > _top_right(i))
+      return rand_num * _range_outvalue + _mn_outvalue;
 
-  return rand_num*_range_invalue + _mn_invalue;
+  return rand_num * _range_invalue + _mn_invalue;
 }
-
-
-
-
-

--- a/modules/phase_field/src/ics/RndSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/RndSmoothCircleIC.C
@@ -20,19 +20,19 @@ InputParameters validParams<RndSmoothCircleIC>()
 }
 
 RndSmoothCircleIC::RndSmoothCircleIC(const std::string & name,
-                               InputParameters parameters)
-  :InitialCondition(name, parameters),
-   _x1(parameters.get<Real>("x1")),
-   _y1(parameters.get<Real>("y1")),
-   _z1(parameters.get<Real>("z1")),
-   _mx_invalue(parameters.get<Real>("mx_invalue")),
-   _mn_invalue(parameters.get<Real>("mn_invalue")),
-   _mx_outvalue(parameters.get<Real>("mx_outvalue")),
-   _mn_outvalue(parameters.get<Real>("mn_outvalue")),
-   _range_invalue(_mx_invalue - _mn_invalue),
-   _range_outvalue(_mx_outvalue - _mn_outvalue),
-   _radius(parameters.get<Real>("radius")),
-   _center(_x1,_y1,_z1)
+                               InputParameters parameters) :
+    InitialCondition(name, parameters),
+    _x1(parameters.get<Real>("x1")),
+    _y1(parameters.get<Real>("y1")),
+    _z1(parameters.get<Real>("z1")),
+    _mx_invalue(parameters.get<Real>("mx_invalue")),
+    _mn_invalue(parameters.get<Real>("mn_invalue")),
+    _mx_outvalue(parameters.get<Real>("mx_outvalue")),
+    _mn_outvalue(parameters.get<Real>("mn_outvalue")),
+    _range_invalue(_mx_invalue - _mn_invalue),
+    _range_outvalue(_mx_outvalue - _mn_outvalue),
+    _radius(parameters.get<Real>("radius")),
+    _center(_x1,_y1,_z1)
 {
   mooseAssert(_range_invalue >= 0.0, "Inside Min > Max for RndSmoothCircleIC!");
   mooseAssert(_range_outvalue >= 0.0, "Outside Min > Max for RndSmoothCircleIC!");
@@ -43,10 +43,9 @@ Real
 RndSmoothCircleIC::value(const Point & p)
 {
   Real value = 0.0;
-
   Real rad = 0.0;
 
-  for(unsigned int i=0; i<LIBMESH_DIM; i++)
+  for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     rad += (p(i)-_center(i)) * (p(i)-_center(i));
 
   rad = sqrt(rad);
@@ -56,20 +55,15 @@ RndSmoothCircleIC::value(const Point & p)
 
   if (rad <= _radius)
     value = _mn_invalue + rand_num*(_range_invalue);
-  else if (rad < 1.5*_radius)
+  else if (rad < 1.5 * _radius)
   {
-    Real av_invalue = (_mn_invalue + _mx_invalue)/2.0;
-    Real av_outvalue = (_mn_outvalue + _mx_outvalue)/2.0;
-    value = av_outvalue + (av_invalue-av_outvalue)*(1+cos((rad-_radius)/_radius*2.0*3.14159))/2.0;
+    Real av_invalue = (_mn_invalue + _mx_invalue) / 2.0;
+    Real av_outvalue = (_mn_outvalue + _mx_outvalue) / 2.0;
+    //value = av_outvalue + (av_invalue-av_outvalue) * (1.0 + cos((rad - _radius) / _radius * 2.0 * libMesh::pi)) / 2.0;
+    value = av_outvalue + (av_invalue-av_outvalue) * (1.0 + cos((rad - _radius) / _radius * 2.0 * 3.14159)) / 2.0;
   }
   else
-    value = _mx_outvalue + rand_num*(_range_outvalue);
+    value = _mx_outvalue + rand_num * (_range_outvalue);
 
   return value;
-
 }
-
-
-
-
-

--- a/modules/phase_field/src/ics/SmoothCircleIC.C
+++ b/modules/phase_field/src/ics/SmoothCircleIC.C
@@ -11,27 +11,27 @@ InputParameters validParams<SmoothCircleIC>()
   params.addRequiredParam<Real>("invalue", "The variable value inside the circle");
   params.addRequiredParam<Real>("outvalue", "The variable value outside the circle");
   params.addRequiredParam<Real>("radius", "The radius of a circle");
-  params.addParam<Real>("int_width",0.0,"The interfacial width of the void surface.  Defaults to sharp interface");
+  params.addParam<Real>("int_width", 0.0, "The interfacial width of the void surface.  Defaults to sharp interface");
 
-  params.addParam<bool>("3D_spheres",true,"in 3D, whether the objects are spheres or columns");
+  params.addParam<bool>("3D_spheres", true, "in 3D, whether the objects are spheres or columns");
 
   return params;
 }
 
 SmoothCircleIC::SmoothCircleIC(const std::string & name,
-                               InputParameters parameters)
-  :InitialCondition(name, parameters),
-   _mesh(_fe_problem.mesh()),
-   _x1(parameters.get<Real>("x1")),
-   _y1(parameters.get<Real>("y1")),
-   _z1(parameters.get<Real>("z1")),
-   _invalue(parameters.get<Real>("invalue")),
-   _outvalue(parameters.get<Real>("outvalue")),
-   _radius(parameters.get<Real>("radius")),
-   _int_width(parameters.get<Real>("int_width")),
-   _3D_spheres(parameters.get<bool>("3D_spheres")),
-   _center(_x1,_y1,_z1),
-   _num_dim(_3D_spheres ? 3 : 2)
+                               InputParameters parameters) :
+    InitialCondition(name, parameters),
+    _mesh(_fe_problem.mesh()),
+    _x1(parameters.get<Real>("x1")),
+    _y1(parameters.get<Real>("y1")),
+    _z1(parameters.get<Real>("z1")),
+    _invalue(parameters.get<Real>("invalue")),
+    _outvalue(parameters.get<Real>("outvalue")),
+    _radius(parameters.get<Real>("radius")),
+    _int_width(parameters.get<Real>("int_width")),
+    _3D_spheres(parameters.get<bool>("3D_spheres")),
+    _center(_x1, _y1, _z1),
+    _num_dim(_3D_spheres ? 3 : 2)
 {
 }
 
@@ -51,8 +51,9 @@ SmoothCircleIC::value(const Point & p)
     p2(2) = 0.0;
     center2(2) = 0.0;
   }
-  Real rad = _mesh.minPeriodicDistance(_var.number(),p2,center2);
+
   //Set value for outside the circle, inside the circle, and on the smooth interface
+  Real rad = _mesh.minPeriodicDistance(_var.number(),p2,center2);
   if (rad <= _radius - _int_width/2.0) //Inside circle
     value = _invalue;
   else if (rad < _radius + _int_width/2.0) //Smooth interface
@@ -64,7 +65,6 @@ SmoothCircleIC::value(const Point & p)
     value = _outvalue;
 
   return value;
-
 }
 
 
@@ -81,20 +81,21 @@ SmoothCircleIC::gradient(const Point & p)
     p2(2) = 0.0;
     center2(2) = 0.0;
   }
-  Real rad = _mesh.minPeriodicDistance(_var.number(),p2,center2);
+
   //Determine derivative values over the smooth interface
+  Real rad = _mesh.minPeriodicDistance(_var.number(), p2, center2);
   if (rad < _radius + _int_width/2.0 && rad > _radius - _int_width/2.0)
   {
-    Real int_pos = (rad - _radius + _int_width/2.0)/_int_width;
-    Real Dint_posDr = 1.0/_int_width;
-    DvalueDr = Dint_posDr*(_invalue-_outvalue)*(-sin(int_pos*libMesh::pi)*libMesh::pi)/2.0;
+    Real int_pos = (rad - _radius + _int_width / 2.0) / _int_width;
+    Real Dint_posDr = 1.0 / _int_width;
+    DvalueDr = Dint_posDr * (_invalue - _outvalue) * (-sin(int_pos * libMesh::pi) * libMesh::pi) / 2.0;
   }
   //Set gradient over the smooth interface
-  if (rad != 0)
-    return Gradient((p(0) - _center(0))*DvalueDr/rad,
-                    (p(1) - _center(1))*DvalueDr/rad,
-                    (p(2) - _center(2))*DvalueDr/rad);
+  if (rad != 0) {
+    return Gradient((p(0) - _center(0)) * DvalueDr / rad,
+                    (p(1) - _center(1)) * DvalueDr / rad,
+                    (p(2) - _center(2)) * DvalueDr / rad);
+  }
   else
-    return Gradient(0.0,0.0,0.0);
-
+    return Gradient(0.0, 0.0, 0.0);
 }

--- a/modules/phase_field/src/ics/SpecifiedSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/SpecifiedSmoothCircleIC.C
@@ -5,8 +5,8 @@ template<>
 InputParameters validParams<SpecifiedSmoothCircleIC>()
 {
   InputParameters params = validParams<MultiSmoothCircleIC>();
-  params.addRequiredParam<std::vector<Real> >("x_positions","The x-coordinate for each circle center");
-  params.addRequiredParam<std::vector<Real> >("y_positions","The y-coordinate for each circle center");
+  params.addRequiredParam<std::vector<Real> >("x_positions", "The x-coordinate for each circle center");
+  params.addRequiredParam<std::vector<Real> >("y_positions", "The y-coordinate for each circle center");
   params.addRequiredParam<std::vector<Real> >("z_positions", "The z-coordinate for each circle center");
   params.addRequiredParam<std::vector<Real> >("radii", "The radius for each circle");
   //These are MultiSmoothCircleIC inputs that are not needed here.
@@ -20,12 +20,12 @@ InputParameters validParams<SpecifiedSmoothCircleIC>()
 }
 
 SpecifiedSmoothCircleIC::SpecifiedSmoothCircleIC(const std::string & name,
-                                               InputParameters parameters)
-  :MultiSmoothCircleIC(name, parameters),
-   _x_positions(getParam<std::vector<Real> >("x_positions")),
-   _y_positions(getParam<std::vector<Real> >("y_positions")),
-   _z_positions(getParam<std::vector<Real> >("z_positions")),
-   _radii(getParam<std::vector<Real> >("radii"))
+                                               InputParameters parameters) :
+    MultiSmoothCircleIC(name, parameters),
+    _x_positions(getParam<std::vector<Real> >("x_positions")),
+    _y_positions(getParam<std::vector<Real> >("y_positions")),
+    _z_positions(getParam<std::vector<Real> >("z_positions")),
+    _radii(getParam<std::vector<Real> >("radii"))
 {
 }
 
@@ -42,17 +42,17 @@ SpecifiedSmoothCircleIC::initialSetup()
   radii_size = _radii.size();
 
   // check to make sure the input file is set up correctly
-  if((_numbub != y_size)||(_numbub != z_size)||(_numbub != radii_size))
+  if (_numbub != y_size || _numbub != z_size || _numbub != radii_size)
     mooseError("Please match the number of radii to the size of the position vectors.");
 
   //Moose::out << "check 2" << "\n";
 
   //resize the vector of Points
-   _bubcent.resize(_numbub);
-   _bubradi.resize(_numbub);
+  _bubcent.resize(_numbub);
+  _bubradi.resize(_numbub);
 
   // fill in the vector of center points
-  for(unsigned int i=0; i<_numbub; i++)
+  for (unsigned int i = 0; i < _numbub; i++)
   {
     _bubcent[i](0) = _x_positions[i];
     _bubcent[i](1) = _y_positions[i];

--- a/modules/phase_field/src/ics/ThumbIC.C
+++ b/modules/phase_field/src/ics/ThumbIC.C
@@ -14,13 +14,13 @@ InputParameters validParams<ThumbIC>()
 }
 
 ThumbIC::ThumbIC(const std::string & name,
-                               InputParameters parameters)
-  :InitialCondition(name, parameters),
-   _xcoord(parameters.get<Real>("xcoord")),
-   _width(parameters.get<Real>("width")),
-   _height(parameters.get<Real>("height")),
-   _invalue(parameters.get<Real>("invalue")),
-   _outvalue(parameters.get<Real>("outvalue"))
+                 InputParameters parameters) :
+    InitialCondition(name, parameters),
+    _xcoord(parameters.get<Real>("xcoord")),
+    _width(parameters.get<Real>("width")),
+    _height(parameters.get<Real>("height")),
+    _invalue(parameters.get<Real>("invalue")),
+    _outvalue(parameters.get<Real>("outvalue"))
 {}
 
 Real
@@ -32,8 +32,8 @@ ThumbIC::value(const Point & p)
   {
     Real rad = 0.0;
     Point center(_xcoord,_height,0.0);
-    for(unsigned int i=0; i<2; i++)
-      rad += (p(i)-center(i)) * (p(i)-center(i));
+    for (unsigned int i=0; i<2; ++i)
+      rad += (p(i) - center(i)) * (p(i) - center(i));
 
     rad = sqrt(rad);
 
@@ -43,12 +43,12 @@ ThumbIC::value(const Point & p)
       value = _outvalue;
   }
   else
+  {
     if (p(0) > _xcoord - _width/2.0 && p(0) < _xcoord + _width/2.0)
       value = _invalue;
     else
       value = _outvalue;
+  }
 
   return value;
-
 }
-

--- a/modules/phase_field/src/ics/Tricrystal2CircleGrainsIC.C
+++ b/modules/phase_field/src/ics/Tricrystal2CircleGrainsIC.C
@@ -5,19 +5,19 @@ template<>
 InputParameters validParams<Tricrystal2CircleGrainsIC>()
 {
   InputParameters params = validParams<InitialCondition>();
-  params.addRequiredParam<unsigned int>("crys_num","Number of crystals");
+  params.addRequiredParam<unsigned int>("crys_num", "Number of crystals");
   params.addRequiredParam<unsigned int>("crys_index", "The index for the current crystal");
 
   return params;
 }
 
 Tricrystal2CircleGrainsIC::Tricrystal2CircleGrainsIC(const std::string & name,
-                             InputParameters parameters)
-  :InitialCondition(name, parameters),
-   _mesh(_fe_problem.mesh()),
-   _nl(_fe_problem.getNonlinearSystem()),
-   _crys_num(getParam<unsigned int>("crys_num")),
-   _crys_index(getParam<unsigned int>("crys_index"))
+                                                     InputParameters parameters) :
+    InitialCondition(name, parameters),
+    _mesh(_fe_problem.mesh()),
+    _nl(_fe_problem.getNonlinearSystem()),
+    _crys_num(getParam<unsigned int>("crys_num")),
+    _crys_index(getParam<unsigned int>("crys_index"))
 {
   if (_crys_num != 3)
     mooseError("Tricrystal ICs must have crys_num = 3");
@@ -34,7 +34,6 @@ Tricrystal2CircleGrainsIC::Tricrystal2CircleGrainsIC(const std::string & name,
 Real
 Tricrystal2CircleGrainsIC::value(const Point & p)
 {
-
   Point grain_center_left;
   grain_center_left(0) = _bottom_left(0) + _range(0)/4.0;
   grain_center_left(1) = _bottom_left(1) + _range(1)/2.0;
@@ -53,5 +52,4 @@ Tricrystal2CircleGrainsIC::value(const Point & p)
     return 1.0;
   else
     return 0.0;
-
 }

--- a/modules/phase_field/src/kernels/ACBulk.C
+++ b/modules/phase_field/src/kernels/ACBulk.C
@@ -4,15 +4,15 @@ template<>
 InputParameters validParams<ACBulk>()
 {
   InputParameters params = validParams<KernelValue>();
-  params.addParam<std::string>("mob_name","L","The mobility used with the kernel");
+  params.addParam<std::string>("mob_name", "L", "The mobility used with the kernel");
 
   return params;
 }
 
-ACBulk::ACBulk(const std::string & name, InputParameters parameters)
-  :KernelValue(name, parameters),
-   _mob_name(getParam<std::string>("mob_name")),
-   _L(getMaterialProperty<Real>(_mob_name))
+ACBulk::ACBulk(const std::string & name, InputParameters parameters) :
+    KernelValue(name, parameters),
+    _mob_name(getParam<std::string>("mob_name")),
+    _L(getMaterialProperty<Real>(_mob_name))
 {
 }
 
@@ -36,7 +36,7 @@ ACBulk::precomputeQpResidual()
 {
   Real dFdeta = computeDFDOP(Residual);
 
-  return  _L[_qp]*(dFdeta) ;
+  return  _L[_qp] * (dFdeta) ;
 }
 
 Real
@@ -44,5 +44,5 @@ ACBulk::precomputeQpJacobian()
 {
   Real dFdeta = computeDFDOP(Jacobian);
 
-  return _L[_qp]*(dFdeta);
+  return _L[_qp] * (dFdeta);
 }

--- a/modules/phase_field/src/kernels/ACGBPoly.C
+++ b/modules/phase_field/src/kernels/ACGBPoly.C
@@ -6,19 +6,18 @@ template<>
 InputParameters validParams<ACGBPoly>()
 {
   InputParameters params = validParams<ACBulk>();
-
   params.addRequiredCoupledVar("c", "Other species concentration");
-  params.addParam<Real>("en_ratio",1.0,"Ratio of surface energy to GB energy");
+  params.addParam<Real>("en_ratio", 1.0, "Ratio of surface energy to GB energy");
   return params;
 }
 
-ACGBPoly::ACGBPoly(const std::string & name, InputParameters parameters)
-  :ACBulk(name,parameters),
-   _c(coupledValue("c")),
-   _c_var(coupled("c")),
-   _mu(getMaterialProperty<Real>("mu")),
-   _gamma(getMaterialProperty<Real>("gamma_asymm")),
-   _en_ratio(getParam<Real>("en_ratio"))
+ACGBPoly::ACGBPoly(const std::string & name, InputParameters parameters) :
+    ACBulk(name,parameters),
+    _c(coupledValue("c")),
+    _c_var(coupled("c")),
+    _mu(getMaterialProperty<Real>("mu")),
+    _gamma(getMaterialProperty<Real>("gamma_asymm")),
+    _en_ratio(getParam<Real>("en_ratio"))
 {
 }
 
@@ -35,13 +34,11 @@ ACGBPoly::computeDFDOP(PFFunctionType type)
 
   switch (type)
   {
-  case Residual:
+    case Residual:
+      return mult*_u[_qp]*c*c;
 
-    return mult*_u[_qp]*c*c;
-
-  case Jacobian:
-
-    return mult*_phi[_j][_qp]*c*c;
+    case Jacobian:
+      return mult*_phi[_j][_qp]*c*c;
   }
 
   mooseError("Invalid type passed in");
@@ -56,11 +53,10 @@ ACGBPoly::computeQpOffDiagJacobian(unsigned int jvar)
   if (c > 1.0)
     c = 1.0;
 
-  if(jvar == _c_var)
+  if (jvar == _c_var)
   {
-    Real mult = 2.0*_en_ratio*_mu[_qp]*_gamma[_qp];
-
-    Real dDFDOP = 2.0*mult*_u[_qp]*c*_phi[_j][_qp];
+    Real mult = 2.0 * _en_ratio * _mu[_qp] * _gamma[_qp];
+    Real dDFDOP = 2.0 * mult * _u[_qp] * c * _phi[_j][_qp];
 
     return _L[_qp]*_test[_i][_qp]*dDFDOP;
   }

--- a/modules/phase_field/src/kernels/ACGrGrPoly.C
+++ b/modules/phase_field/src/kernels/ACGrGrPoly.C
@@ -6,30 +6,29 @@ template<>
 InputParameters validParams<ACGrGrPoly>()
 {
   InputParameters params = validParams<ACBulk>();
-
   params.addRequiredCoupledVar("v", "Array of coupled variable names");
-  params.addCoupledVar("T","temperature");
-
+  params.addCoupledVar("T", "temperature");
   return params;
 }
 
-ACGrGrPoly::ACGrGrPoly(const std::string & name, InputParameters parameters)
-  :ACBulk(name,parameters),
-   _mu(getMaterialProperty<Real>("mu")),
-   _gamma(getMaterialProperty<Real>("gamma_asymm")),
-   _tgrad_corr_mult(getMaterialProperty<Real>("tgrad_corr_mult")),
-   _has_T(isCoupled("T")),
-   _grad_T(_has_T ? &coupledGradient("T") : NULL)
+ACGrGrPoly::ACGrGrPoly(const std::string & name, InputParameters parameters) :
+    ACBulk(name,parameters),
+    _mu(getMaterialProperty<Real>("mu")),
+    _gamma(getMaterialProperty<Real>("gamma_asymm")),
+    _tgrad_corr_mult(getMaterialProperty<Real>("tgrad_corr_mult")),
+    _has_T(isCoupled("T")),
+    _grad_T(_has_T ? &coupledGradient("T") : NULL)
 {
-  //Array of coupled variables is created in the constructor
+  // Array of coupled variables is created in the constructor
   _ncrys = coupledComponents("v"); //determine number of grains from the number of names passed in.  Note this is the actual number -1
   _vals.resize(_ncrys); //Size variable arrays
   _vals_var.resize(_ncrys);
-//  _gamma = 1.5;
 
-  for (unsigned int i=0; i<_ncrys; ++i)
+  // _gamma = 1.5;
+
+  //Loop through grains and load coupled variables into the arrays
+  for (unsigned int i = 0; i < _ncrys; ++i)
   {
-    //Loop through grains and load coupled variables into the arrays
     _vals[i] = &coupledValue("v", i);
     _vals_var[i] = coupled("v",i);
   }
@@ -39,30 +38,23 @@ Real
 ACGrGrPoly::computeDFDOP(PFFunctionType type)
 {
   Real SumEtaj = 0.0;
-    for (unsigned int i=0; i<_ncrys; ++i)
-      SumEtaj += (*_vals[i])[_qp]*(*_vals[i])[_qp]; //Sum all other order parameters
+  for (unsigned int i=0; i<_ncrys; ++i)
+    SumEtaj += (*_vals[i])[_qp]*(*_vals[i])[_qp]; //Sum all other order parameters
 
   Real tgrad_correction = 0.0;
 
   //Calcualte either the residual or jacobian of the grain growth free energy
   switch (type)
   {
-  case Residual:
-  {
-    if (_has_T)
-      tgrad_correction = _tgrad_corr_mult[_qp]*_grad_u[_qp]*(*_grad_T)[_qp];
+    case Residual:
+      if (_has_T)
+        tgrad_correction = _tgrad_corr_mult[_qp]*_grad_u[_qp]*(*_grad_T)[_qp];
+      return _mu[_qp]*(_u[_qp]*_u[_qp]*_u[_qp] - _u[_qp] + 2.0*_gamma[_qp]*_u[_qp]*SumEtaj) + tgrad_correction;
 
-    return _mu[_qp]*(_u[_qp]*_u[_qp]*_u[_qp] - _u[_qp] + 2.0*_gamma[_qp]*_u[_qp]*SumEtaj) + tgrad_correction;
-  }
-
-  case Jacobian:
-  {
-    if (_has_T)
-      tgrad_correction = _tgrad_corr_mult[_qp]*_grad_phi[_j][_qp]*(*_grad_T)[_qp];
-
-    return _mu[_qp]*(_phi[_j][_qp]*(3*_u[_qp]*_u[_qp] - 1.0 + 2.0*_gamma[_qp]*SumEtaj)) + tgrad_correction;
-  }
-
+    case Jacobian:
+      if (_has_T)
+        tgrad_correction = _tgrad_corr_mult[_qp]*_grad_phi[_j][_qp]*(*_grad_T)[_qp];
+      return _mu[_qp]*(_phi[_j][_qp]*(3*_u[_qp]*_u[_qp] - 1.0 + 2.0*_gamma[_qp]*SumEtaj)) + tgrad_correction;
   }
 
   mooseError("Invalid type passed in");
@@ -71,15 +63,16 @@ ACGrGrPoly::computeDFDOP(PFFunctionType type)
 Real
 ACGrGrPoly::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  for (unsigned int i=0; i<_ncrys; ++i)
-    if(jvar == _vals_var[i])
+  for (unsigned int i = 0; i < _ncrys; ++i)
+  {
+    if (jvar == _vals_var[i])
     {
-      Real dSumEtaj = 2.0*(*_vals[i])[_qp]*_phi[_j][_qp]; //Derivative of SumEtaj
+      Real dSumEtaj = 2.0 * (*_vals[i])[_qp] * _phi[_j][_qp]; //Derivative of SumEtaj
+      Real dDFDOP = _mu[_qp] * 2.0 * _gamma[_qp] * _u[_qp] * dSumEtaj;
 
-      Real dDFDOP = _mu[_qp]*2.0*_gamma[_qp]*_u[_qp]*dSumEtaj;
-
-      return _L[_qp]*_test[_i][_qp]*dDFDOP;
+      return _L[_qp] * _test[_i][_qp] * dDFDOP;
     }
+  }
 
   return 0.0;
 }

--- a/modules/phase_field/src/kernels/ACInterface.C
+++ b/modules/phase_field/src/kernels/ACInterface.C
@@ -4,29 +4,28 @@ template<>
 InputParameters validParams<ACInterface>()
 {
   InputParameters params = validParams<KernelGrad>();
-  params.addParam<std::string>("mob_name","L","The mobility used with the kernel");
-  params.addParam<std::string>("kappa_name","kappa_op","The kappa used with the kernel");
-
+  params.addParam<std::string>("mob_name", "L", "The mobility used with the kernel");
+  params.addParam<std::string>("kappa_name", "kappa_op", "The kappa used with the kernel");
   return params;
 }
 
-ACInterface::ACInterface(const std::string & name, InputParameters parameters)
-  :KernelGrad(name, parameters),
-   _mob_name(getParam<std::string>("mob_name")),
-   _kappa_name(getParam<std::string>("kappa_name")),
-   _kappa(getMaterialProperty<Real>(_kappa_name)),
-   _L(getMaterialProperty<Real>(_mob_name))
+ACInterface::ACInterface(const std::string & name, InputParameters parameters) :
+    KernelGrad(name, parameters),
+    _mob_name(getParam<std::string>("mob_name")),
+    _kappa_name(getParam<std::string>("kappa_name")),
+    _kappa(getMaterialProperty<Real>(_kappa_name)),
+    _L(getMaterialProperty<Real>(_mob_name))
 {
 }
 
 RealGradient
 ACInterface::precomputeQpResidual()
 {
-  return  _kappa[_qp]*_L[_qp]*( _grad_u[_qp] );
+  return _kappa[_qp] * _L[_qp] * _grad_u[_qp];
 }
 
 RealGradient
 ACInterface::precomputeQpJacobian()
 {
-  return _kappa[_qp]*_L[_qp]*( _grad_phi[_j][_qp] );
+  return _kappa[_qp] * _L[_qp] * _grad_phi[_j][_qp];
 }

--- a/modules/phase_field/src/kernels/CHBulk.C
+++ b/modules/phase_field/src/kernels/CHBulk.C
@@ -11,13 +11,13 @@ InputParameters validParams<CHBulk>()
   return params;
 }
 
-CHBulk::CHBulk(const std::string & name, InputParameters parameters)
-  :KernelGrad(name, parameters),
-   _mob_name(getParam<std::string>("mob_name")),
-   _Dmob_name(getParam<std::string>("Dmob_name")),
-   _M(getMaterialProperty<Real>(_mob_name)),
-   _has_MJac(getParam<bool>("has_MJac")),
-   _DM(_has_MJac ? &getMaterialProperty<Real>(_Dmob_name) : NULL)
+CHBulk::CHBulk(const std::string & name, InputParameters parameters) :
+    KernelGrad(name, parameters),
+    _mob_name(getParam<std::string>("mob_name")),
+    _Dmob_name(getParam<std::string>("Dmob_name")),
+    _M(getMaterialProperty<Real>(_mob_name)),
+    _has_MJac(getParam<bool>("has_MJac")),
+    _DM(_has_MJac ? &getMaterialProperty<Real>(_Dmob_name) : NULL)
 {
 }
 
@@ -37,9 +37,8 @@ CHBulk::precomputeQpJacobian()
     if (_has_MJac)
     {
       Real DMqp = (*_DM)[_qp];
-      grad_value += DMqp*_phi[_j][_qp]*computeGradDFDCons(Residual);
+      grad_value += DMqp*_phi[_j][_qp] * computeGradDFDCons(Residual);
     }
-
   }
 
   return grad_value; //Return jacobian

--- a/modules/phase_field/src/kernels/CHInterface.C
+++ b/modules/phase_field/src/kernels/CHInterface.C
@@ -4,38 +4,38 @@ template<>
 InputParameters validParams<CHInterface>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addRequiredParam<std::string>("kappa_name","The kappa used with the kernel");
-  params.addRequiredParam<std::string>("mob_name","The mobility used with the kernel");
-  params.addParam<std::string>("Dmob_name","DM","The D mobility used with the kernel");
-  params.addRequiredParam<std::string>("grad_mob_name","The gradient of the mobility used with the kernel");
-  params.addParam<bool>("has_MJac",false,"Jacobian information for the mobility is defined");
+  params.addRequiredParam<std::string>("kappa_name", "The kappa used with the kernel");
+  params.addRequiredParam<std::string>("mob_name", "The mobility used with the kernel");
+  params.addParam<std::string>("Dmob_name", "DM", "The D mobility used with the kernel");
+  params.addRequiredParam<std::string>("grad_mob_name", "The gradient of the mobility used with the kernel");
+  params.addParam<bool>("has_MJac", false, "Jacobian information for the mobility is defined");
 
   return params;
 }
 
-CHInterface::CHInterface(const std::string & name, InputParameters parameters)
-  :Kernel(name, parameters),
-   _kappa_name(getParam<std::string>("kappa_name")),
-   _mob_name(getParam<std::string>("mob_name")),
-   _Dmob_name(getParam<std::string>("Dmob_name")),
-   _grad_mob_name(getParam<std::string>("grad_mob_name")),
-   _kappa(getMaterialProperty<Real>(_kappa_name)),
-   _M(getMaterialProperty<Real>(_mob_name)),
-   _has_MJac(getParam<bool>("has_MJac")),
-   _DM(_has_MJac ? &getMaterialProperty<Real>(_Dmob_name) : NULL),
-   _grad_M(getMaterialProperty<RealGradient>(_grad_mob_name)),
-   _Dgrad_Mnp(_has_MJac ? &getMaterialProperty<RealGradient>("Dgrad_Mnp") : NULL),
-   _Dgrad_Mngp(_has_MJac ? &getMaterialProperty<Real>("Dgrad_Mngp") : NULL),
-   _second_u(second()),
-   _second_test(secondTest()),
-   _second_phi(secondPhi())
+CHInterface::CHInterface(const std::string & name, InputParameters parameters) :
+    Kernel(name, parameters),
+    _kappa_name(getParam<std::string>("kappa_name")),
+    _mob_name(getParam<std::string>("mob_name")),
+    _Dmob_name(getParam<std::string>("Dmob_name")),
+    _grad_mob_name(getParam<std::string>("grad_mob_name")),
+    _kappa(getMaterialProperty<Real>(_kappa_name)),
+    _M(getMaterialProperty<Real>(_mob_name)),
+    _has_MJac(getParam<bool>("has_MJac")),
+    _DM(_has_MJac ? &getMaterialProperty<Real>(_Dmob_name) : NULL),
+    _grad_M(getMaterialProperty<RealGradient>(_grad_mob_name)),
+    _Dgrad_Mnp(_has_MJac ? &getMaterialProperty<RealGradient>("Dgrad_Mnp") : NULL),
+    _Dgrad_Mngp(_has_MJac ? &getMaterialProperty<Real>("Dgrad_Mngp") : NULL),
+    _second_u(second()),
+    _second_test(secondTest()),
+    _second_phi(secondPhi())
 {
 }
 
 Real
 CHInterface::computeQpResidual()
 {
-  return _kappa[_qp]*_second_u[_qp].tr()*(_M[_qp]*_second_test[_i][_qp].tr() + _grad_M[_qp]*_grad_test[_i][_qp]);
+  return _kappa[_qp] * _second_u[_qp].tr() * (_M[_qp] * _second_test[_i][_qp].tr() + _grad_M[_qp] * _grad_test[_i][_qp]);
 }
 
 Real
@@ -46,12 +46,12 @@ CHInterface::computeQpJacobian()
 
   if (isImplicit())
   {
-    value = _kappa[_qp]*_second_phi[_j][_qp].tr()*(_M[_qp]*_second_test[_i][_qp].tr() + _grad_M[_qp]*_grad_test[_i][_qp]);
+    value = _kappa[_qp] * _second_phi[_j][_qp].tr() * (_M[_qp] * _second_test[_i][_qp].tr() + _grad_M[_qp]*_grad_test[_i][_qp]);
 
     if (_has_MJac)
     {
-      RealGradient full_Dgrad_M = _grad_phi[_j][_qp]*(*_Dgrad_Mngp)[_qp] + _phi[_j][_qp]*(*_Dgrad_Mnp)[_qp];
-      value += _kappa[_qp]*_second_u[_qp].tr()*((*_DM)[_qp]*_phi[_j][_qp]*_second_test[_i][_qp].tr() + full_Dgrad_M*_grad_test[_i][_qp]);
+      RealGradient full_Dgrad_M = _grad_phi[_j][_qp] * (*_Dgrad_Mngp)[_qp] + _phi[_j][_qp] * (*_Dgrad_Mnp)[_qp];
+      value += _kappa[_qp] * _second_u[_qp].tr() * ((*_DM)[_qp] * _phi[_j][_qp] * _second_test[_i][_qp].tr() + full_Dgrad_M * _grad_test[_i][_qp]);
     }
   }
 

--- a/modules/phase_field/src/kernels/CHMath.C
+++ b/modules/phase_field/src/kernels/CHMath.C
@@ -8,8 +8,8 @@ InputParameters validParams<CHMath>()
   return params;
 }
 
-CHMath::CHMath(const std::string & name, InputParameters parameters)
-  :CHBulk(name, parameters)
+CHMath::CHMath(const std::string & name, InputParameters parameters) :
+    CHBulk(name, parameters)
 {
 }
 
@@ -18,18 +18,12 @@ CHMath::computeGradDFDCons(PFFunctionType type)
 {
   switch (type)
   {
-  case Residual:
-    return 3*_u[_qp]*_u[_qp]*_grad_u[_qp] - _grad_u[_qp]; // return Residual value
-    break;
+    case Residual:
+      return 3*_u[_qp]*_u[_qp]*_grad_u[_qp] - _grad_u[_qp]; // return Residual value
 
-  case Jacobian:
-    return 6*_u[_qp]*_phi[_j][_qp]*_grad_u[_qp] + 3*_u[_qp]*_u[_qp]*_grad_phi[_j][_qp] - _grad_phi[_j][_qp]; //return Jacobian value
-    break;
-
-  default:
-    mooseError("Invalid type passed in");
-    break;
+    case Jacobian:
+      return 6*_u[_qp]*_phi[_j][_qp]*_grad_u[_qp] + 3*_u[_qp]*_u[_qp]*_grad_phi[_j][_qp] - _grad_phi[_j][_qp]; //return Jacobian value
   }
 
-  return 0.0;
+  mooseError("Invalid type passed in");
 }

--- a/modules/phase_field/src/kernels/CoupledImplicitEuler.C
+++ b/modules/phase_field/src/kernels/CoupledImplicitEuler.C
@@ -4,23 +4,21 @@ template<>
 InputParameters validParams<CoupledImplicitEuler>()
 {
   InputParameters params = validParams<Kernel>();
-
-  params.addRequiredCoupledVar("v","Coupled variable");
-
+  params.addRequiredCoupledVar("v", "Coupled variable");
   return params;
 }
 
-CoupledImplicitEuler::CoupledImplicitEuler(const std::string & name, InputParameters parameters)
-  :Kernel(name, parameters),
-   _v_dot(coupledDot("v")),
-   _dv_dot(coupledDotDu("v")),
-   _v_var(coupled("v"))
+CoupledImplicitEuler::CoupledImplicitEuler(const std::string & name, InputParameters parameters) :
+    Kernel(name, parameters),
+    _v_dot(coupledDot("v")),
+    _dv_dot(coupledDotDu("v")),
+    _v_var(coupled("v"))
 {}
 
 Real
 CoupledImplicitEuler::computeQpResidual()
 {
-  return _test[_i][_qp]*_v_dot[_qp];
+  return _test[_i][_qp] * _v_dot[_qp];
 }
 
 Real
@@ -33,7 +31,7 @@ Real
 CoupledImplicitEuler::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _v_var)
-    return _test[_i][_qp]*_phi[_j][_qp]*_dv_dot[_qp];
+    return _test[_i][_qp] * _phi[_j][_qp] * _dv_dot[_qp];
 
   return 0.0;
 }

--- a/modules/phase_field/src/kernels/DoubleWellPotential.C
+++ b/modules/phase_field/src/kernels/DoubleWellPotential.C
@@ -12,7 +12,7 @@ InputParameters validParams<DoubleWellPotential>()
 }
 
 DoubleWellPotential::DoubleWellPotential(const std::string & name, InputParameters parameters) :
-  ACBulk( name, parameters )
+    ACBulk( name, parameters )
 {
 }
 
@@ -21,15 +21,12 @@ DoubleWellPotential::computeDFDOP(PFFunctionType type)
 {
   switch (type)
   {
-  case Residual:
-    return _u[_qp]*_u[_qp]*_u[_qp] - _u[_qp] ;
+    case Residual:
+      return _u[_qp]*_u[_qp]*_u[_qp] - _u[_qp] ;
 
-  case Jacobian:
-    return _phi[_j][_qp]*(3*_u[_qp]*_u[_qp] - 1. );
+    case Jacobian:
+      return _phi[_j][_qp]*(3*_u[_qp]*_u[_qp] - 1. );
   }
 
   mooseError("Invalid type passed in");
-
 }
-
-

--- a/modules/phase_field/src/kernels/MatDiffusion.C
+++ b/modules/phase_field/src/kernels/MatDiffusion.C
@@ -5,26 +5,24 @@ template<>
 InputParameters validParams<MatDiffusion>()
 {
   InputParameters params = validParams<Diffusion>();
-  params.addParam<std::string>("D_name","D","The name of the diffusivity");
-
+  params.addParam<std::string>("D_name", "D", "The name of the diffusivity");
   return params;
 }
 
-MatDiffusion::MatDiffusion(const std::string & name, InputParameters parameters)
-  :Diffusion(name, parameters),
-   _D_name(getParam<std::string>("D_name")),
-   _D(getMaterialProperty<Real>(_D_name))
+MatDiffusion::MatDiffusion(const std::string & name, InputParameters parameters) :
+    Diffusion(name, parameters),
+    _D_name(getParam<std::string>("D_name")),
+    _D(getMaterialProperty<Real>(_D_name))
 {}
 
 Real
 MatDiffusion::computeQpResidual()
 {
-  return _D[_qp]*_grad_test[_i][_qp]*_grad_u[_qp];
-
+  return _D[_qp] * _grad_test[_i][_qp] * _grad_u[_qp];
 }
 
 Real
 MatDiffusion::computeQpJacobian()
 {
-  return _D[_qp]*_grad_test[_i][_qp]*_grad_phi[_j][_qp];
+  return _D[_qp] * _grad_test[_i][_qp] * _grad_phi[_j][_qp];
 }

--- a/modules/phase_field/src/kernels/SplitCHBase.C
+++ b/modules/phase_field/src/kernels/SplitCHBase.C
@@ -8,8 +8,8 @@ InputParameters validParams<SplitCHBase>()
   return params;
 }
 
-SplitCHBase::SplitCHBase(const std::string & name, InputParameters parameters)
-  :Kernel(name, parameters)
+SplitCHBase::SplitCHBase(const std::string & name, InputParameters parameters) :
+    Kernel(name, parameters)
 {
 }
 
@@ -38,7 +38,6 @@ SplitCHBase::computeQpResidual()
   Real residual = (f_prime_zero + e_prime) *_test[_i][_qp];
 
   return residual;
-
 }
 
 Real
@@ -50,13 +49,11 @@ SplitCHBase::computeQpJacobian()
   Real jacobian = (df_prime_zero_dc + de_prime_dc) *_test[_i][_qp];
 
   return jacobian;
-
 }
 
 Real
 SplitCHBase::computeQpOffDiagJacobian(unsigned int /*jvar*/)
 {
-
   return 0.0;
 }
 
@@ -71,4 +68,3 @@ SplitCHBase::computeDEDC(PFFunctionType /*type*/)
 {
   return 0.0;
 }
-

--- a/modules/phase_field/src/kernels/SplitCHCRes.C
+++ b/modules/phase_field/src/kernels/SplitCHCRes.C
@@ -5,19 +5,19 @@ InputParameters validParams<SplitCHCRes>()
 {
   InputParameters params = validParams<SplitCHBase>();
 
-  params.addRequiredCoupledVar("w","chem poten");
-  params.addRequiredParam<std::string>("kappa_name","The kappa used with the kernel");
+  params.addRequiredCoupledVar("w", "chem poten");
+  params.addRequiredParam<std::string>("kappa_name", "The kappa used with the kernel");
 
   return params;
 }
 
-SplitCHCRes::SplitCHCRes(const std::string & name, InputParameters parameters)
-  :SplitCHBase(name, parameters),
-   _kappa_name(getParam<std::string>("kappa_name")),
-   _kappa(getMaterialProperty<Real>(_kappa_name)),
-   _w_var(coupled("w")),
-   _w(coupledValue("w")),
-   _grad_w(coupledGradient("w"))
+SplitCHCRes::SplitCHCRes(const std::string & name, InputParameters parameters) :
+    SplitCHBase(name, parameters),
+    _kappa_name(getParam<std::string>("kappa_name")),
+    _kappa(getMaterialProperty<Real>(_kappa_name)),
+    _w_var(coupled("w")),
+    _w(coupledValue("w")),
+    _grad_w(coupledGradient("w"))
 {
 }
 
@@ -42,12 +42,10 @@ SplitCHCRes::computeQpResidual()
 {
   Real residual = SplitCHBase::computeQpResidual(); //(f_prime_zero+e_prime)*_test[_i][_qp] from SplitCHBase
 
-  residual += -_w[_qp]*_test[_i][_qp];
-
-  residual += _kappa[_qp]*_grad_u[_qp]*_grad_test[_i][_qp];
+  residual += -_w[_qp] * _test[_i][_qp];
+  residual += _kappa[_qp] * _grad_u[_qp] * _grad_test[_i][_qp];
 
   return residual;
-
 }
 
 Real
@@ -55,25 +53,18 @@ SplitCHCRes::computeQpJacobian()
 {
   Real jacobian = SplitCHBase::computeQpJacobian(); //(df_prime_zero_dc+de_prime_dc)*_test[_i][_qp]; from SplitCHBase
 
-  jacobian += _kappa[_qp]*_grad_phi[_j][_qp]*_grad_test[_i][_qp];
+  jacobian += _kappa[_qp] * _grad_phi[_j][_qp] * _grad_test[_i][_qp];
 
   return jacobian;
-
 }
 
 Real
 SplitCHCRes::computeQpOffDiagJacobian(unsigned int jvar)
 {
-
-  if(jvar == _w_var)
+  if (jvar == _w_var)
   {
-
-
-   return -_phi[_j][_qp] * _test[_i][_qp];
-
-
+    return -_phi[_j][_qp] * _test[_i][_qp];
   }
 
   return 0.0;
 }
-

--- a/modules/phase_field/src/kernels/SplitCHMath.C
+++ b/modules/phase_field/src/kernels/SplitCHMath.C
@@ -8,8 +8,8 @@ InputParameters validParams<SplitCHMath>()
   return params;
 }
 
-SplitCHMath::SplitCHMath(const std::string & name, InputParameters parameters)
-  :SplitCHCRes(name, parameters)
+SplitCHMath::SplitCHMath(const std::string & name, InputParameters parameters) :
+    SplitCHCRes(name, parameters)
 {
 }
 
@@ -18,14 +18,12 @@ SplitCHMath::computeDFDC(PFFunctionType type)
 {
   switch (type)
   {
-  case Residual:
-    return _u[_qp]*_u[_qp]*_u[_qp] - _u[_qp]; // return Residual value
+    case Residual:
+      return _u[_qp]*_u[_qp]*_u[_qp] - _u[_qp]; // return Residual value
 
-  case Jacobian:
-    return (3.0*_u[_qp]*_u[_qp] - 1.0)*_phi[_j][_qp]; //return Jacobian value
-  default:
-    mooseError("Invalid type passed in");
-    break;
+    case Jacobian:
+      return (3.0*_u[_qp]*_u[_qp] - 1.0) * _phi[_j][_qp]; //return Jacobian value
   }
-  return 0;
+
+  mooseError("Invalid type passed in");
 }

--- a/modules/phase_field/src/kernels/SplitCHWRes.C
+++ b/modules/phase_field/src/kernels/SplitCHWRes.C
@@ -3,45 +3,39 @@ template<>
 InputParameters validParams<SplitCHWRes>()
 {
   InputParameters params = validParams<Kernel>();
-
-    params.addRequiredCoupledVar("c","intermediate parameter--concentration");
-    params.addParam<std::string>("mob_name","mobtemp","The mobility used with the kernel");
-
+  params.addRequiredCoupledVar("c", "intermediate parameter--concentration");
+  params.addParam<std::string>("mob_name", "mobtemp", "The mobility used with the kernel");
   return params;
 }
 
-SplitCHWRes::SplitCHWRes(const std::string & name, InputParameters parameters)
-  :Kernel(name, parameters),
-   _mob_name(getParam<std::string>("mob_name")),
-   _mob(getMaterialProperty<Real>(_mob_name)),
-//  This _c_var is needed to compute off-diagonal Jacobian.
-   _c_var(coupled("c")),
-   _c(coupledValue("c"))
+SplitCHWRes::SplitCHWRes(const std::string & name, InputParameters parameters) :
+    Kernel(name, parameters),
+    _mob_name(getParam<std::string>("mob_name")),
+    _mob(getMaterialProperty<Real>(_mob_name)),
+    // This _c_var is needed to compute off-diagonal Jacobian.
+    _c_var(coupled("c")),
+    _c(coupledValue("c"))
 {}
 
 Real
 SplitCHWRes::computeQpResidual()
 {
-  return  _mob[_qp]*_grad_u[_qp] * _grad_test[_i][_qp];
+  return _mob[_qp] * _grad_u[_qp] * _grad_test[_i][_qp];
 }
 
 Real
 SplitCHWRes::computeQpJacobian()
 {
-  return _mob[_qp]*_grad_phi[_j][_qp] * _grad_test[_i][_qp];
+  return _mob[_qp] * _grad_phi[_j][_qp] * _grad_test[_i][_qp];
 }
 
 Real
 SplitCHWRes::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if(jvar == _c_var)
+  if (jvar == _c_var)
   {
-
-   return 0.0;
-
+    return 0.0;
   }
 
   return 0.0;
 }
-
-

--- a/modules/phase_field/src/materials/GBEvolution.C
+++ b/modules/phase_field/src/materials/GBEvolution.C
@@ -5,50 +5,50 @@ InputParameters validParams<GBEvolution>()
 {
   InputParameters params = validParams<Material>();
 
-  params.addParam<Real>("temp", 300,"Constant temperature in Kelvin");
+  params.addParam<Real>("temp", 300, "Constant temperature in Kelvin");
   params.addCoupledVar("T", "Temperature in Kelvin");
-  params.addParam<Real>("f0s", 0.125,"The GB energy constant ");
-  params.addRequiredParam<Real>("wGB","Diffuse GB width in nm ");
-  params.addParam<Real>("length_scale",1.0e-9,"Length scale in m, where default is nm");
-  params.addParam<Real>("time_scale", 1.0e-9,"Time scale in s, where default is ns");
-  params.addParam<Real>("GBMobility",-1,"GB mobility input in m^4/(J*s), that overrides the temperature dependent calculation");
-  params.addParam<Real>("GBmob0",0,"Grain boundary mobility prefactor in m^4/(J*s)");
-  params.addParam<Real>("Q",0,"Grain boundary migration activation energy in eV");
-  params.addRequiredParam<Real>("GBenergy","Grain boundary energy in J/m^2");
-  params.addParam<Real>("molar_volume",24.62e-6,"Molar volume in m^3/mol, needed for temperature gradient driving force");
+  params.addParam<Real>("f0s", 0.125, "The GB energy constant ");
+  params.addRequiredParam<Real>("wGB", "Diffuse GB width in nm ");
+  params.addParam<Real>("length_scale", 1.0e-9, "Length scale in m, where default is nm");
+  params.addParam<Real>("time_scale", 1.0e-9, "Time scale in s, where default is ns");
+  params.addParam<Real>("GBMobility", -1, "GB mobility input in m^4/(J*s), that overrides the temperature dependent calculation");
+  params.addParam<Real>("GBmob0", 0, "Grain boundary mobility prefactor in m^4/(J*s)");
+  params.addParam<Real>("Q", 0, "Grain boundary migration activation energy in eV");
+  params.addRequiredParam<Real>("GBenergy", "Grain boundary energy in J/m^2");
+  params.addParam<Real>("molar_volume", 24.62e-6, "Molar volume in m^3/mol, needed for temperature gradient driving force");
 
   return params;
 }
 
 
 GBEvolution::GBEvolution(const std::string & name,
-                 InputParameters parameters)
-    :Material(name, parameters),
-   _temp(getParam<Real>("temp")),
-   //_cg(coupledValue("cg")),
-   _f0s(getParam<Real>("f0s")),
-   _wGB(getParam<Real>("wGB")),
-   _length_scale(getParam<Real>("length_scale")),
-   _time_scale(getParam<Real>("time_scale")),
-   _GBmob0(getParam<Real>("GBmob0")),
-   _Q(getParam<Real>("Q")),
-   _GBenergy(getParam<Real>("GBenergy")),
-   _has_T(isCoupled("T")),
-   _GBMobility(getParam<Real>("GBMobility")),
-   _molar_vol(getParam<Real>("molar_volume")),
-   _T(_has_T ? &coupledValue("T") : NULL),
-   _sigma(declareProperty<Real>("sigma")),
-   _M_GB(declareProperty<Real>("M_GB")),
-   _kappa(declareProperty<Real>("kappa_op")),
-   _gamma(declareProperty<Real>("gamma_asymm")),
-   _L(declareProperty<Real>("L")),
-   _l_GB(declareProperty<Real>("l_GB")),
-   _mu(declareProperty<Real>("mu")),
-   _entropy_diff(declareProperty<Real>("entropy_diff")),
-   _molar_volume(declareProperty<Real>("molar_volume")),
-   _act_wGB(declareProperty<Real>("act_wGB")),
-   _tgrad_corr_mult(declareProperty<Real>("tgrad_corr_mult")),
-   _kb(8.617343e-5) //Boltzmann constant in eV/K
+                         InputParameters parameters) :
+    Material(name, parameters),
+    _temp(getParam<Real>("temp")),
+    _f0s(getParam<Real>("f0s")),
+    _wGB(getParam<Real>("wGB")),
+    _length_scale(getParam<Real>("length_scale")),
+    _time_scale(getParam<Real>("time_scale")),
+    _GBmob0(getParam<Real>("GBmob0")),
+    _Q(getParam<Real>("Q")),
+    _GBenergy(getParam<Real>("GBenergy")),
+    _has_T(isCoupled("T")),
+    _GBMobility(getParam<Real>("GBMobility")),
+    _molar_vol(getParam<Real>("molar_volume")),
+    //_cg(coupledValue("cg")),
+    _T(_has_T ? &coupledValue("T") : NULL),
+    _sigma(declareProperty<Real>("sigma")),
+    _M_GB(declareProperty<Real>("M_GB")),
+    _kappa(declareProperty<Real>("kappa_op")),
+    _gamma(declareProperty<Real>("gamma_asymm")),
+    _L(declareProperty<Real>("L")),
+    _l_GB(declareProperty<Real>("l_GB")),
+    _mu(declareProperty<Real>("mu")),
+    _entropy_diff(declareProperty<Real>("entropy_diff")),
+    _molar_volume(declareProperty<Real>("molar_volume")),
+    _act_wGB(declareProperty<Real>("act_wGB")),
+    _tgrad_corr_mult(declareProperty<Real>("tgrad_corr_mult")),
+    _kb(8.617343e-5) //Boltzmann constant in eV/K
 {
   //Moose::out << "GB mob = " << _GBMobility << ", GBmob0 = " << _GBmob0 << std::endl;
 
@@ -60,14 +60,12 @@ void
 GBEvolution::computeProperties()
 {
   Real M0 = _GBmob0;
-
   Real JtoeV = 6.24150974e18;// joule to eV conversion
-
   Real T = 0.0;
 
   M0 *= _time_scale/(JtoeV*(_length_scale*_length_scale*_length_scale*_length_scale));//Convert to lengthscale^4/(eV*timescale);
 
-  for(unsigned int qp=0; qp<_qrule->n_points(); qp++)
+  for (unsigned int qp = 0; qp < _qrule->n_points(); qp++)
   {
     if (_has_T)
       T = (*_T)[qp];
@@ -82,22 +80,13 @@ GBEvolution::computeProperties()
       _M_GB[qp] = _GBMobility*_time_scale/(JtoeV*(_length_scale*_length_scale*_length_scale*_length_scale)); //Convert to lengthscale^4/(eV*timescale)
 
     _l_GB[qp] = _wGB; //in the length scale of the system
-
     _L[qp] = 4.0/3.0*_M_GB[qp]/_l_GB[qp];
-
     _kappa[qp] = 3.0/4.0*_sigma[qp]*_l_GB[qp];
-
     _gamma[qp] = 1.5;
-
     _mu[qp] = 3.0/4.0*1/_f0s*_sigma[qp]/_l_GB[qp];
-
     _entropy_diff[qp] = 8.0e3*JtoeV; //J/(K mol) converted to eV(K mol)
-
     _molar_volume[qp] = _molar_vol/(_length_scale*_length_scale*_length_scale); //m^3/mol converted to ls^3/mol
-
     _act_wGB[qp] = 0.5e-9/_length_scale;
-
     _tgrad_corr_mult[qp] = _mu[qp]*9.0/8.0;
-
   }
 }

--- a/modules/phase_field/src/materials/PFMobility.C
+++ b/modules/phase_field/src/materials/PFMobility.C
@@ -4,31 +4,28 @@ template<>
 InputParameters validParams<PFMobility>()
 {
   InputParameters params = validParams<Material>();
-
   params.addRequiredParam<Real>("mob", "The mobility value");
-  params.addParam<Real>("kappa",1.0, "The kappa parameter for the vacancy concentration");
-
+  params.addParam<Real>("kappa", 1.0, "The kappa parameter for the vacancy concentration");
   return params;
 }
 
 PFMobility::PFMobility(const std::string & name,
-                 InputParameters parameters)
-  :Material(name, parameters),
-   _M(declareProperty<Real>("M")),
-   _grad_M(declareProperty<RealGradient>("grad_M")),
-   _kappa_c(declareProperty<Real>("kappa_c")),
-   _mob(getParam<Real>("mob")),
-   _kappa(getParam<Real>("kappa"))
+                       InputParameters parameters) :
+    Material(name, parameters),
+    _M(declareProperty<Real>("M")),
+    _grad_M(declareProperty<RealGradient>("grad_M")),
+    _kappa_c(declareProperty<Real>("kappa_c")),
+    _mob(getParam<Real>("mob")),
+    _kappa(getParam<Real>("kappa"))
 {}
 
 void
 PFMobility::computeProperties()
 {
-  for(unsigned int qp=0; qp<_qrule->n_points(); qp++)
+  for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
   {
     _M[qp] = _mob;
     _grad_M[qp] = 0.0;
     _kappa_c[qp] = _kappa;
   }
 }
-

--- a/modules/phase_field/src/postprocessors/NodalFloodCount.C
+++ b/modules/phase_field/src/postprocessors/NodalFloodCount.C
@@ -59,13 +59,13 @@ NodalFloodCount::NodalFloodCount(const std::string & name, InputParameters param
     _var_number(_vars[0]->number()),
     _single_map_mode(getParam<bool>("use_single_map")),
     _condense_map_info(getParam<bool>("condense_map_info")),
-  _global_numbering(getParam<bool>("use_global_numbering")),
-  _var_index_mode(getParam<bool>("enable_var_coloring")),
-  _maps_size(_single_map_mode ? 1 : _vars.size()),
-  _pbs(NULL),
-  _element_average_value(parameters.isParamValid("elem_avg_value") ? getPostprocessorValue("elem_avg_value") : _real_zero),
-  _track_memory(getParam<bool>("track_memory_usage"))
-  //   _bubble_volume_file_name(parameters.isParamValid("bubble_volume_file") ? getParam<FileName>("bubble_volume_file") : "")
+    _global_numbering(getParam<bool>("use_global_numbering")),
+    _var_index_mode(getParam<bool>("enable_var_coloring")),
+    _maps_size(_single_map_mode ? 1 : _vars.size()),
+    _pbs(NULL),
+    _element_average_value(parameters.isParamValid("elem_avg_value") ? getPostprocessorValue("elem_avg_value") : _real_zero),
+    _track_memory(getParam<bool>("track_memory_usage"))
+    // _bubble_volume_file_name(parameters.isParamValid("bubble_volume_file") ? getParam<FileName>("bubble_volume_file") : "")
 {
   // Size the data structures to hold the correct number of maps
   _bubble_maps.resize(_maps_size);
@@ -98,7 +98,7 @@ NodalFloodCount::initialize()
   _pbs = dynamic_cast<FEProblem *>(&_subproblem)->getNonlinearSystem().dofMap().get_periodic_boundaries();
 
   // Clear the bubble marking maps and region counters and other data structures
-  for (unsigned int map_num=0; map_num < _maps_size; ++map_num)
+  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
   {
     _bubble_maps[map_num].clear();
     _bubble_sets[map_num].clear();
@@ -108,7 +108,9 @@ NodalFloodCount::initialize()
     if (_var_index_mode)
       _var_index_maps[map_num].clear();
   }
-  for (unsigned int var_num=0; var_num < _vars.size(); ++var_num)
+
+  // TODO: use iterator
+  for (unsigned int var_num = 0; var_num < _vars.size(); ++var_num)
     _nodes_visited[var_num].clear();
 
   // Clear the packed data structure
@@ -192,7 +194,7 @@ NodalFloodCount::getValue()
 {
   unsigned int count = 0;
 
-  for (unsigned int map_num=0; map_num < _maps_size; ++map_num)
+  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
     count += _bubble_sets[map_num].size();
 
   return count;
@@ -328,7 +330,7 @@ NodalFloodCount::pack(std::vector<unsigned int> & packed_data, bool merge_period
       mooseAssert(data[map_num][0].empty(), "We have nodes marked with zeros - something is not correct");
       // Note: The zeroth "region" is everything outside of a bubble - we don't want to put
       // that into our packed data structure so start at 1 here!
-      for (unsigned int i=1 /* Yes - start at 1 */; i<=_region_counts[map_num]; ++i)
+      for (unsigned int i = 1 /* Yes - start at 1 */; i <= _region_counts[map_num]; ++i)
       {
         partial_packed_data[current_idx++] = data[map_num][i].size();     // The number of nodes in the current region
 
@@ -361,7 +363,7 @@ NodalFloodCount::unpack(const std::vector<unsigned int> & packed_data)
   unsigned int curr_var_idx = std::numeric_limits<unsigned int>::max();
 
   _region_to_var_idx.clear();
-  for (unsigned int i=0; i<packed_data.size(); ++i)
+  for (unsigned int i = 0; i < packed_data.size(); ++i)
   {
     if (start_next_set)
     {
@@ -574,7 +576,7 @@ NodalFloodCount::calculateBubbleVolumes()
     unsigned int elem_n_nodes = elem->n_nodes();
     Real curr_volume = elem->volume();
 
-    for (unsigned int map_num=0; map_num < _maps_size; ++map_num)
+    for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
     {
       unsigned int bubble_counter = 0;
       std::list<BubbleData>::const_iterator end = _bubble_sets[map_num].end();
@@ -598,7 +600,7 @@ NodalFloodCount::calculateBubbleVolumes()
   }
 
   // Stick all the partial bubble volumes in one long single vector to be gathered on the root processor
-  for (unsigned int map_num=0; map_num < _maps_size; ++map_num)
+  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
     _all_bubble_volumes.insert(_all_bubble_volumes.end(), bubble_volumes[map_num].begin(), bubble_volumes[map_num].end());
 
   Parallel::sum(_all_bubble_volumes); //do all the sums!

--- a/modules/phase_field/src/userobjects/SPPARKSUserObject.C
+++ b/modules/phase_field/src/userobjects/SPPARKSUserObject.C
@@ -32,22 +32,23 @@ InputParameters validParams<SPPARKSUserObject>()
   return params;
 }
 
-SPPARKSUserObject::SPPARKSUserObject(const std::string & name, InputParameters params)
-  :GeneralUserObject(name, params),
-   _spparks(NULL),
-   _file(getParam<std::string>("file")),
-   _spparks_only(getParam<bool>("spparks_only")),
-   _from_ivar(isParamValid("from_ivar") ? getParam<std::vector<unsigned> >("from_ivar") : std::vector<unsigned>()),
-   _from_dvar(isParamValid("from_dvar") ? getParam<std::vector<unsigned> >("from_dvar") : std::vector<unsigned>()),
-   _to_ivar(isParamValid("to_ivar") ? getParam<std::vector<unsigned> >("to_ivar") : std::vector<unsigned>()),
-   _to_dvar(isParamValid("to_dvar") ? getParam<std::vector<unsigned> >("to_dvar") : std::vector<unsigned>()),
-   _xmin(getParam<Real>("xmin")),
-   _ymin(getParam<Real>("ymin")),
-   _zmin(getParam<Real>("zmin")),
-   _xmax(getParam<Real>("xmax")),
-   _ymax(getParam<Real>("ymax")),
-   _zmax(getParam<Real>("zmax")),
-   _last_time(std::numeric_limits<Real>::min())
+SPPARKSUserObject::SPPARKSUserObject(const std::string & name,
+                                     InputParameters params) :
+    GeneralUserObject(name, params),
+    _spparks(NULL),
+    _file(getParam<std::string>("file")),
+    _spparks_only(getParam<bool>("spparks_only")),
+    _from_ivar(isParamValid("from_ivar") ? getParam<std::vector<unsigned> >("from_ivar") : std::vector<unsigned>()),
+    _from_dvar(isParamValid("from_dvar") ? getParam<std::vector<unsigned> >("from_dvar") : std::vector<unsigned>()),
+    _to_ivar(isParamValid("to_ivar") ? getParam<std::vector<unsigned> >("to_ivar") : std::vector<unsigned>()),
+    _to_dvar(isParamValid("to_dvar") ? getParam<std::vector<unsigned> >("to_dvar") : std::vector<unsigned>()),
+    _xmin(getParam<Real>("xmin")),
+    _ymin(getParam<Real>("ymin")),
+    _zmin(getParam<Real>("zmin")),
+    _xmax(getParam<Real>("xmax")),
+    _ymax(getParam<Real>("ymax")),
+    _zmax(getParam<Real>("zmax")),
+    _last_time(std::numeric_limits<Real>::min())
 {
 
   if (isParamValid("int_aux_vars"))

--- a/modules/phase_field/src/utils/AddV.C
+++ b/modules/phase_field/src/utils/AddV.C
@@ -12,18 +12,18 @@ AddV(InputParameters & parameters, const std::string & var_name)
 
   if (crys_num > 0)
   {
-    for (unsigned int crys = 0; crys<crys_num; crys++)
+    for (unsigned int crys = 0; crys < crys_num; crys++)
     {
       std::string coupled_var_name = var_name_base;
       std::stringstream out;
       out << crys;
       coupled_var_name.append(out.str());
-      v[crys]=coupled_var_name;
+      v[crys] = coupled_var_name;
     }
+
     parameters.remove(var_name);
     parameters.set<std::vector<VariableName> >(var_name) = v;
   }
-
 
   return parameters;
 }


### PR DESCRIPTION
This patch touches almost every source and header file in the phasefield module to fix wrong indentation, whitespace around operators, after if/for, after commas, etc.
Other fixes include cleanup of switch statements (rm break after return, unreachable code after mooseError etc.) 

Can we leave this issue open for now? I'm sure I didn't catch everything. But since this touches so many files, it might be best to merge early.
