### PR TITLE
Renamed [Outputs] related items

### DIFF
--- a/framework/include/actions/AddOutputAction.h
+++ b/framework/include/actions/AddOutputAction.h
@@ -28,7 +28,7 @@
 // Forward declerations
 class AddOutputAction;
 class OutputWarehouse;
-class OutputBase;
+class Output;
 
 template<>
 InputParameters validParams<AddOutputAction>();

--- a/framework/include/outputs/CSV.h
+++ b/framework/include/outputs/CSV.h
@@ -16,7 +16,7 @@
 #define CSV_H
 
 // MOOSE includes
-#include "TableOutputter.h"
+#include "TableOutput.h"
 
 // Forward declarations
 class CSV;
@@ -30,7 +30,7 @@ InputParameters validParams<CSV>();
  * @see Exodus
  */
 class CSV :
-  public TableOutputter
+  public TableOutput
 {
 public:
 

--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -16,7 +16,7 @@
 #define CHECKPOINT_H
 
 // MOOSE includes
-#include "FileOutputter.h"
+#include "FileOutput.h"
 #include "MaterialPropertyStorage.h"
 #include "RestartableData.h"
 #include "MaterialPropertyIO.h"
@@ -51,7 +51,7 @@ struct CheckpointFileNames
  *
  */
 class Checkpoint:
-  public FileOutputter
+  public FileOutput
 {
 public:
 

--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -16,7 +16,7 @@
 #define CONSOLE_H
 
 // MOOSE includes
-#include "TableOutputter.h"
+#include "TableOutput.h"
 #include "FormattedTable.h"
 #include "Conversion.h"
 
@@ -33,7 +33,7 @@ InputParameters validParams<Console>();
  * An output object for writing to the console (screen)
  */
 class Console :
-  public TableOutputter
+  public TableOutput
 {
 public:
 

--- a/framework/include/outputs/DebugOutput.h
+++ b/framework/include/outputs/DebugOutput.h
@@ -12,77 +12,61 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef VTK_H
-#define VTK_H
+#ifndef DEBUGOUTPUT_H
+#define DEBUGOUTPUT_H
 
 // MOOSE includes
-#include "OversampleOutputter.h"
-
-// libMesh includes
-#include "libmesh/vtk_io.h"
+#include "PetscOutput.h"
+#include "FEProblem.h"
 
 // Forward declerations
-class VTKOutputter;
+class DebugOutput;
 
 template<>
-InputParameters validParams<VTKOutputter>();
+InputParameters validParams<DebugOutput>();
 
 /**
  *
  */
-class VTKOutputter :
-  public OversampleOutputter
+class DebugOutput : public PetscOutput
 {
 public:
 
   /**
    * Class constructor
-   * @param name Object name
-   * @param parameters Object parameters
+   * @param name
+   * @param parameters
    */
-  VTKOutputter(const std::string & name, InputParameters & parameters);
+  DebugOutput(const std::string & name, InputParameters & parameters);
 
   /**
    * Class destructor
    */
-  virtual ~VTKOutputter();
-
-  /**
-   * Creates the libMes::VTKIO object for outputting the current timestep
-   */
-  virtual void outputSetup();
-
+  virtual ~DebugOutput();
 
 protected:
 
   /**
-   * Perform the output of VTK
+   * Perform the debugging output
    */
   virtual void output();
 
-  /**
-   * Return the file name with the *.vtk extension
-   */
-  std::string filename();
-
   //@{
   /**
-   * Individual component output is not currently supported for VTK
+   * Individual component output is not supported for DebugOutput
    */
+  std::string filename();
   virtual void outputNodalVariables();
   virtual void outputElementalVariables();
   virtual void outputPostprocessors();
   virtual void outputScalarVariables();
   //@}
 
-private:
+  /// Flag for outputting variable norms
+  bool _show_var_residual_norms;
 
-  /// Pointer to libMesh::VTKIO object
-  VTKIO * _vtk_io_ptr;
-
-  /// Flag for using binary compression
-  bool _binary;
-
+  // Reference to libMesh system
+  TransientNonlinearImplicitSystem & _sys;
 };
 
-#endif //VTK_H
+#endif //DEBUGOUTPUT_H

--- a/framework/include/outputs/Exodus.h
+++ b/framework/include/outputs/Exodus.h
@@ -16,7 +16,7 @@
 #define EXODUS_H
 
 // MOOSE includes
-#include "OversampleOutputter.h"
+#include "OversampleOutput.h"
 
 // libMesh includes
 #include "libmesh/exodusII.h"
@@ -32,7 +32,7 @@ InputParameters validParams<Exodus>();
  * Class for output data to the ExodusII format
  */
 class Exodus :
-  public OversampleOutputter
+  public OversampleOutput
 {
 public:
 

--- a/framework/include/outputs/FileOutput.h
+++ b/framework/include/outputs/FileOutput.h
@@ -12,36 +12,36 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef FILEOUTPUTTER_H
-#define FILEOUTPUTTER_H
+#ifndef FILEOUTPUT_H
+#define FILEOUTPUT_H
 
 // MOOSE includes
-#include "OutputBase.h"
+#include "Output.h"
 
 // Forward declerations
-class FileOutputter;
+class FileOutput;
 
 template<>
-InputParameters validParams<FileOutputter>();
+InputParameters validParams<FileOutput>();
 
 /**
  * An outputter with filename support
  *
  * @see Exodus
  */
-class FileOutputter : public OutputBase
+class FileOutput : public Output
 {
 public:
 
   /**
    * Class constructor
    */
-  FileOutputter(const std::string & name, InputParameters & parameters);
+  FileOutput(const std::string & name, InputParameters & parameters);
 
   /**
    * Class destructor
    */
-  virtual ~FileOutputter();
+  virtual ~FileOutput();
 
   /**
    * The filename for the output file
@@ -116,4 +116,4 @@ protected:
   friend class OutputWarehouse;
 };
 
-#endif /* FILEOUTPUTTER_H */
+#endif /* FILEOUTPUT_H */

--- a/framework/include/outputs/GMVOutput.h
+++ b/framework/include/outputs/GMVOutput.h
@@ -12,35 +12,35 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef GMVOUTPUTTER_H
-#define GMVOUTPUTTER_H
+#ifndef GMVOUTPUT_H
+#define GMVOUTPUT_H
 
 // MOOSE includes
-#include "OversampleOutputter.h"
+#include "OversampleOutput.h"
 
 // Forward declarations
-class GMVOutputter;
+class GMVOutput;
 
 template<>
-InputParameters validParams<GMVOutputter>();
+InputParameters validParams<GMVOutput>();
 
 /**
- * Class for output data to the GMVOutputterII format
+ * Class for output data to the GMVOutputII format
  */
-class GMVOutputter :
-  public OversampleOutputter
+class GMVOutput :
+  public OversampleOutput
 {
 public:
 
   /**
    * Class constructor
    */
-  GMVOutputter(const std::string & name, InputParameters);
+  GMVOutput(const std::string & name, InputParameters);
 
 protected:
 
   /**
-   * Overload the OutputBase::output method, this is required for GMVOutputter
+   * Overload the Output::output method, this is required for GMVOutput
    * output due to the method utilized for outputing
    */
   virtual void output();
@@ -53,7 +53,7 @@ protected:
 
   //@{
   /**
-   * Individual component output is not supported for GMVOutputter
+   * Individual component output is not supported for GMVOutput
    */
   virtual void outputNodalVariables();
   virtual void outputElementalVariables();
@@ -67,4 +67,4 @@ private:
   bool _binary;
 };
 
-#endif /* GMVOUTPUTTER_H */
+#endif /* GMVOUTPUT_H */

--- a/framework/include/outputs/GNUPlot.h
+++ b/framework/include/outputs/GNUPlot.h
@@ -16,7 +16,7 @@
 #define GNUPLOT_H
 
 // MOOSE includes
-#include "TableOutputter.h"
+#include "TableOutput.h"
 
 // Forward declarations
 class GNUPlot;
@@ -30,7 +30,7 @@ InputParameters validParams<GNUPlot>();
  * @see Exodus
  */
 class GNUPlot :
-  public TableOutputter
+  public TableOutput
 {
 public:
 

--- a/framework/include/outputs/Nemesis.h
+++ b/framework/include/outputs/Nemesis.h
@@ -16,7 +16,7 @@
 #define NEMESIS_H
 
 // MOOSE includes
-#include "OversampleOutputter.h"
+#include "OversampleOutput.h"
 
 // libMesh includes
 #include "libmesh/nemesis_io.h"
@@ -32,7 +32,7 @@ InputParameters validParams<Nemesis>();
  * Class for output data to the Nemesis format
  */
 class Nemesis :
-  public OversampleOutputter
+  public OversampleOutput
 {
 public:
 
@@ -47,7 +47,7 @@ public:
   virtual ~Nemesis();
 
   /**
-   * Overload the OutputBase::output method, this is required for Nemesis
+   * Overload the Output::output method, this is required for Nemesis
    * output due to the method utilized for outputing single/global parameters
    */
   virtual void output();

--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -28,10 +28,10 @@
 
 // Forward declarations
 class Problem;
-class OutputBase;
+class Output;
 
 template<>
-InputParameters validParams<OutputBase>();
+InputParameters validParams<Output>();
 
 /**
  * A structure for storing the various lists that contain
@@ -62,7 +62,7 @@ struct OutputData
  *
  * @see Exodus Console CSV
  */
-class OutputBase :
+class Output :
   public MooseObject,
   public Restartable
 {
@@ -76,12 +76,12 @@ public:
    *
    * @see initAvailable init separate
    */
-  OutputBase(const std::string & name, InputParameters & parameters);
+  Output(const std::string & name, InputParameters & parameters);
 
   /**
    * Class destructor
    */
-  virtual ~OutputBase();
+  virtual ~Output();
 
   /**
    * Returns true if any of the other has methods return true.
@@ -394,7 +394,7 @@ private:
    * just prior to timestepSetup(). This method is meant for internal use only.
    * This method is called by FEProblem::timestepSetup via the OutputWarhouse.
    *
-   * @see PetscOutputter
+   * @see PetscOutput
    */
   virtual void timestepSetupInternal();
 
@@ -464,9 +464,9 @@ private:
 
   // Allow complete access
   friend class OutputWarehouse;
-  friend class FileOutputter;
-  friend class OversampleOutputter;
-  friend class PetscOutputter;
+  friend class FileOutput;
+  friend class OversampleOutput;
+  friend class PetscOutput;
   friend class TransientMultiApp;
 };
 

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -22,7 +22,7 @@
 #include "InputParameters.h"
 
 // Forward declarations
-class OutputBase;
+class Output;
 class Checkpoint;
 class FEProblem;
 
@@ -50,13 +50,13 @@ public:
    * It is the responsibility of the OutputWarehouse to delete the output objects
    * add using this method
    */
-  void addOutput(OutputBase * output);
+  void addOutput(Output * output);
 
   /**
    * Get a complete list of all output objects
    * @return A vector of pointers to each of the output objects
    */
-  const std::vector<OutputBase *> & getOutputs() const;
+  const std::vector<Output *> & getOutputs() const;
 
   /**
    * Returns true if the output object exists
@@ -100,7 +100,7 @@ public:
   void forceOutput();
 
   /**
-   * Calls the setFileNumber method for every FileOutputter output object
+   * Calls the setFileNumber method for every FileOutput output object
    */
   void setFileNumbers(std::map<std::string, unsigned int> input, unsigned int offset = 0);
 
@@ -192,10 +192,10 @@ private:
   void timestepSetup();
 
   /// The list of all output objects
-  std::vector<OutputBase *> _object_ptrs;
+  std::vector<Output *> _object_ptrs;
 
   /// A map of the output pointers
-  std::map<std::string, OutputBase *> _object_map;
+  std::map<std::string, Output *> _object_map;
 
   /// List of object names
   std::set<OutFileBase> _filenames;
@@ -258,7 +258,7 @@ OutputWarehouse::getOutputs()
   std::vector<T *> outputs;
 
   // Populate the vector
-  for (std::map<std::string, OutputBase *>::iterator it = _object_map.begin(); it != _object_map.end(); ++it)
+  for (std::map<std::string, Output *>::iterator it = _object_map.begin(); it != _object_map.end(); ++it)
   {
     T * output = dynamic_cast<T*>(it->second);
     if (output != NULL)
@@ -282,7 +282,7 @@ OutputWarehouse::getOutputNames()
   std::vector<std::string> names;
 
   // Loop through the objects and store the name if the type cast succeeds
-  for (std::map<std::string, OutputBase *>::iterator it = _object_map.begin(); it != _object_map.end(); ++it)
+  for (std::map<std::string, Output *>::iterator it = _object_map.begin(); it != _object_map.end(); ++it)
   {
     T * output = dynamic_cast<T*>(it->second);
     if (output != NULL)

--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -12,11 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef OVERSAMPLEOUTPUTTER_H
-#define OVERSAMPLEOUTPUTTER_H
+#ifndef OVERSAMPLEOUTPUT_H
+#define OVERSAMPLEOUTPUT_H
 
 // MOOSE includes
-#include "PetscOutputter.h"
+#include "PetscOutput.h"
 
 // libMesh
 #include "libmesh/equation_systems.h"
@@ -25,10 +25,10 @@
 #include "libmesh/mesh_function.h"
 
 // Forward declerations
-class OversampleOutputter;
+class OversampleOutput;
 
 template<>
-InputParameters validParams<OversampleOutputter>();
+InputParameters validParams<OversampleOutput>();
 
 /**
  * Based class for providing re-positioning and oversampling support to output objects
@@ -45,8 +45,8 @@ InputParameters validParams<OversampleOutputter>();
  *
  * @see Exodus
  */
-class OversampleOutputter :
-  public PetscOutputter
+class OversampleOutput :
+  public PetscOutput
 {
 public:
 
@@ -57,7 +57,7 @@ public:
    * required for oversampling.
    * @see initOversample()
    */
-  OversampleOutputter(const std::string & name, InputParameters & parameters);
+  OversampleOutput(const std::string & name, InputParameters & parameters);
 
   /**
    * Class destructor
@@ -65,7 +65,7 @@ public:
    * Cleans up the various objects associated with the oversample EquationsSystem and Mesh
    * objects.
    */
-  virtual ~OversampleOutputter();
+  virtual ~OversampleOutput();
 
   /**
    * Performs the initial output, including the creation of the oversampled solution vector
@@ -135,4 +135,4 @@ private:
 
 };
 
-#endif // OVERSAMPLEBSE_H
+#endif // OVERSAMPLEOUTPUT_H

--- a/framework/include/outputs/PetscOutput.h
+++ b/framework/include/outputs/PetscOutput.h
@@ -12,22 +12,22 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef PETSCOUTPUTTER_H
-#define PETSCOUTPUTTER_H
+#ifndef PETSCOUTPUT_H
+#define PETSCOUTPUT_H
 
 // MOOSE includes
-#include "FileOutputter.h"
+#include "FileOutput.h"
 
 // Forward declerations
-class PetscOutputter;
+class PetscOutput;
 
 template<>
-InputParameters validParams<PetscOutputter>();
+InputParameters validParams<PetscOutput>();
 
 /**
  * Adds the ability to output on every nonlinear and/or linear residual
  */
-class PetscOutputter : public FileOutputter
+class PetscOutput : public FileOutput
 {
 public:
 
@@ -36,12 +36,12 @@ public:
    * @param name Outputter name
    * @param parameters Outputter input file parameters
    */
-  PetscOutputter(const std::string & name, InputParameters & parameters);
+  PetscOutput(const std::string & name, InputParameters & parameters);
 
   /**
    * Class destructor
    */
-  virtual ~PetscOutputter();
+  virtual ~PetscOutput();
 
   /**
    * Linear residual output status
@@ -139,4 +139,4 @@ private:
   /// Linear residual output end time
   Real _linear_end_time;
 };
-#endif //PETSCOUTPUTTER_H
+#endif //PETSCOUTPUT_H

--- a/framework/include/outputs/SolutionHistory.h
+++ b/framework/include/outputs/SolutionHistory.h
@@ -16,7 +16,7 @@
 #define SOLUTIONHISTORY_H
 
 // MOOSE includes
-#include "FileOutputter.h"
+#include "FileOutput.h"
 
 // Forward declerations
 class SolutionHistory;
@@ -30,7 +30,7 @@ InputParameters validParams<SolutionHistory>();
  * @see Exodus
  */
 class SolutionHistory :
-  public FileOutputter
+  public FileOutput
 {
 public:
 

--- a/framework/include/outputs/TableOutput.h
+++ b/framework/include/outputs/TableOutput.h
@@ -16,13 +16,13 @@
 #define TABLESOUTPUTBASE_H
 
 // MOOSE includes
-#include "PetscOutputter.h"
+#include "PetscOutput.h"
 #include "FormattedTable.h"
 
-class TableOutputter;
+class TableOutput;
 
 template<>
-InputParameters validParams<TableOutputter>();
+InputParameters validParams<TableOutput>();
 
 /**
  * Base class for scalar variables and postprocessors output objects
@@ -35,20 +35,20 @@ InputParameters validParams<TableOutputter>();
  *
  * @see CSV Console
  */
-class TableOutputter :
-  public PetscOutputter
+class TableOutput :
+  public PetscOutput
 {
 public:
 
   /**
    * Class constructor.
    */
-  TableOutputter(const std::string & name, InputParameters);
+  TableOutput(const std::string & name, InputParameters);
 
   /**
    * Destructor
    */
-  virtual ~TableOutputter();
+  virtual ~TableOutput();
 
 protected:
 
@@ -86,4 +86,4 @@ protected:
 
 };
 
-#endif /* TABLEOUTPUTTER_H */
+#endif /* TABLEOUTPUT_H */

--- a/framework/include/outputs/Tecplot.h
+++ b/framework/include/outputs/Tecplot.h
@@ -16,7 +16,7 @@
 #define TECPLOT_H
 
 // MOOSE includes
-#include "OversampleOutputter.h"
+#include "OversampleOutput.h"
 
 // Forward declarations
 class Tecplot;
@@ -28,7 +28,7 @@ InputParameters validParams<Tecplot>();
  * Class for output data to the TecplotII format
  */
 class Tecplot :
-  public OversampleOutputter
+  public OversampleOutput
 {
 public:
 
@@ -40,7 +40,7 @@ public:
 protected:
 
   /**
-   * Overload the OutputBase::output method, this is required for Tecplot
+   * Overload the Output::output method, this is required for Tecplot
    * output due to the method utilized for outputing single/global parameters
    */
   virtual void output();

--- a/framework/include/outputs/VTKOutput.h
+++ b/framework/include/outputs/VTKOutput.h
@@ -12,61 +12,77 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef DEBUGOUTPUTTER_H
-#define DEBUGOUTPUTTER_H
+#ifndef VTKOUTPUT_H
+#define VTKOUTPUT_H
 
 // MOOSE includes
-#include "PetscOutputter.h"
-#include "FEProblem.h"
+#include "OversampleOutput.h"
+
+// libMesh includes
+#include "libmesh/vtk_io.h"
 
 // Forward declerations
-class DebugOutputter;
+class VTKOutput;
 
 template<>
-InputParameters validParams<DebugOutputter>();
+InputParameters validParams<VTKOutput>();
 
 /**
  *
  */
-class DebugOutputter : public PetscOutputter
+class VTKOutput :
+  public OversampleOutput
 {
 public:
 
   /**
    * Class constructor
-   * @param name
-   * @param parameters
+   * @param name Object name
+   * @param parameters Object parameters
    */
-  DebugOutputter(const std::string & name, InputParameters & parameters);
+  VTKOutput(const std::string & name, InputParameters & parameters);
 
   /**
    * Class destructor
    */
-  virtual ~DebugOutputter();
+  virtual ~VTKOutput();
+
+  /**
+   * Creates the libMes::VTKOutputIO object for outputting the current timestep
+   */
+  virtual void outputSetup();
+
 
 protected:
 
   /**
-   * Perform the debugging output
+   * Perform the output of VTKOutput
    */
   virtual void output();
 
-  //@{
   /**
-   * Individual component output is not supported for DebugOutputter
+   * Return the file name with the *.vtk extension
    */
   std::string filename();
+
+  //@{
+  /**
+   * Individual component output is not currently supported for VTKOutput
+   */
   virtual void outputNodalVariables();
   virtual void outputElementalVariables();
   virtual void outputPostprocessors();
   virtual void outputScalarVariables();
   //@}
 
-  /// Flag for outputting variable norms
-  bool _show_var_residual_norms;
+private:
 
-  // Reference to libMesh system
-  TransientNonlinearImplicitSystem & _sys;
+  /// Pointer to libMesh::VTKIO object
+  VTKIO * _vtk_io_ptr;
+
+  /// Flag for using binary compression
+  bool _binary;
+
 };
 
-#endif //DEBUGOUTPUTTER_H
+#endif //VTKOUTPUT_H

--- a/framework/include/outputs/XDA.h
+++ b/framework/include/outputs/XDA.h
@@ -16,7 +16,7 @@
 #define XDA_H
 
 // MOOSE includes
-#include "OversampleOutputter.h"
+#include "OversampleOutput.h"
 
 // Forward declearations
 class XDA;
@@ -28,7 +28,7 @@ InputParameters validParams<XDA>();
  * Class for output data to the XDAII format
  */
 class XDA :
-  public OversampleOutputter
+  public OversampleOutput
 {
 public:
 
@@ -40,7 +40,7 @@ public:
 protected:
 
   /**
-   * Overload the OutputBase::output method, this is required for XDA
+   * Overload the Output::output method, this is required for XDA
    * output due to the method utlized for outputing single/global parameters
    */
   virtual void output();

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -200,8 +200,7 @@ private:
   friend class PostprocessorData;
   friend class NearestNodeLocator;
   friend class ReportableData;
-  friend class ExodusOutput;
-  friend class FileOutputter;
+  friend class FileOutput;
 };
 
 template<typename T>

--- a/framework/src/actions/AddOutputAction.C
+++ b/framework/src/actions/AddOutputAction.C
@@ -17,7 +17,7 @@
 #include "FEProblem.h"
 #include "Factory.h"
 #include "OutputWarehouse.h"
-#include "OutputBase.h"
+#include "Output.h"
 #include "MooseApp.h"
 #include "FileMesh.h"
 #include "MooseApp.h"
@@ -79,6 +79,6 @@ AddOutputAction::act()
     _moose_object_pars.set<std::string>("suffix") = "auto_recovery";
 
   // Create the object and add it to the warehouse
-  OutputBase * output = static_cast<OutputBase *>(_factory.create(_type, object_name, _moose_object_pars));
+  Output * output = static_cast<Output *>(_factory.create(_type, object_name, _moose_object_pars));
   output_warehouse.addOutput(output);
 }

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -20,7 +20,7 @@
 #include "ActionFactory.h"
 #include "Exodus.h"
 #include "OutputWarehouse.h"
-#include "FileOutputter.h"
+#include "FileOutput.h"
 
 // Extrnal includes
 #include "tinydir.h"
@@ -40,7 +40,7 @@ InputParameters validParams<CommonOutputAction>()
    params.addParam<bool>("nemesis", false, "Output the results using the default settings for Nemesis output");
    params.addParam<bool>("console", false, "Output the results using the default settings for Console output");
    params.addParam<bool>("csv", false, "Output the scalar variable and postprocessors to a *.csv file using the default CSV output.");
-   params.addParam<bool>("vtk", false, "Output the results using the default settings for VTK output");
+   params.addParam<bool>("vtk", false, "Output the results using the default settings for VTKOutput output");
    params.addParam<bool>("xda", false, "Output the results using the default settings for XDA/XDR output (ascii)");
    params.addParam<bool>("xdr", false, "Output the results using the default settings for XDA/XDR output (binary)");
    params.addParam<bool>("checkpoint", false, "Create checkpoint files using the default options.");
@@ -257,7 +257,7 @@ CommonOutputAction::getRecoveryDirectory()
     if (isParamValid("file_base"))
       file_base = _pars.get<std::string>("file_base");
     if (file_base.empty())
-      file_base = FileOutputter::getOutputFileBase(_app);
+      file_base = FileOutput::getOutputFileBase(_app);
 
     // Build and return the complete name for the recovery directory
     return file_base + "_auto_recovery";
@@ -298,7 +298,7 @@ CommonOutputAction::getRecoveryDirectory()
         file_base = obj_pars.get<std::string>("file_base");
 
       if (file_base.empty())
-        file_base = FileOutputter::getOutputFileBase(_app);
+        file_base = FileOutput::getOutputFileBase(_app);
 
       // Build the complete name for the recovery directory
       full_name = file_base + "_" + cp->getObjectParams().get<std::string>("suffix");

--- a/framework/src/actions/PerfLogOutputAction.C
+++ b/framework/src/actions/PerfLogOutputAction.C
@@ -14,7 +14,7 @@
 
 // MOOSE includes
 #include "PerfLogOutputAction.h"
-#include "OutputBase.h"
+#include "Output.h"
 #include "Console.h"
 #include "MooseApp.h"
 
@@ -40,8 +40,8 @@ PerfLogOutputAction::act()
 
   // Search for the existence of a Console outputter
   bool has_console = false;
-  const std::vector<OutputBase *> & ptrs = _app.getOutputWarehouse().getOutputs();
-  for (std::vector<OutputBase *>::const_iterator it = ptrs.begin(); it != ptrs.end(); ++it)
+  const std::vector<Output *> & ptrs = _app.getOutputWarehouse().getOutputs();
+  for (std::vector<Output *>::const_iterator it = ptrs.begin(); it != ptrs.end(); ++it)
   {
     Console * c_ptr = dynamic_cast<Console *>(*it);
     if (c_ptr != NULL)

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -16,7 +16,7 @@
 #include "FEProblem.h"
 #include "ActionWarehouse.h"
 #include "Factory.h"
-#include "OutputBase.h"
+#include "Output.h"
 #include "MooseApp.h"
 #include "MooseObjectAction.h"
 
@@ -55,10 +55,10 @@ SetupDebugAction::act()
   if (_pars.get<bool>("show_var_residual_norms"))
   {
     // Set the 'type =' parameters for the desired object
-    _action_params.set<std::string>("type") = "DebugOutputter";
+    _action_params.set<std::string>("type") = "DebugOutput";
 
     // Create the action
-    MooseObjectAction * action = static_cast<MooseObjectAction *>(_action_factory.create("AddOutputAction", "Outputs/moose_debug_outputter", _action_params));
+    MooseObjectAction * action = static_cast<MooseObjectAction *>(_action_factory.create("AddOutputAction", "Outputs/moose_debug_output", _action_params));
 
     // Add the action to the warehouse
     _awh.addActionBlock(action);

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -327,14 +327,14 @@
 #include "Nemesis.h"
 #include "Console.h"
 #include "CSV.h"
-#include "VTK.h"
+#include "VTKOutput.h"
 #include "Checkpoint.h"
 #include "XDA.h"
-#include "GMVOutputter.h"
+#include "GMVOutput.h"
 #include "Tecplot.h"
 #include "GNUPlot.h"
 #include "SolutionHistory.h"
-#include "DebugOutputter.h"
+#include "DebugOutput.h"
 
 namespace Moose {
 
@@ -595,15 +595,15 @@ registerObjects(Factory & factory)
   registerOutput(Nemesis);
   registerOutput(Console);
   registerOutput(CSV);
-  registerNamedOutput(VTKOutputter, "VTK");
+  registerNamedOutput(VTKOutput, "VTK");
   registerOutput(Checkpoint);
   registerNamedOutput(XDA, "XDR");
   registerOutput(XDA);
-  registerNamedOutput(GMVOutputter, "GMV");
+  registerNamedOutput(GMVOutput, "GMV");
   registerOutput(Tecplot);
   registerOutput(GNUPlot);
   registerOutput(SolutionHistory);
-  registerOutput(DebugOutputter);
+  registerOutput(DebugOutput);
 
   registered = true;
 }
@@ -672,7 +672,7 @@ addActionTypes(Syntax & syntax)
   registerMooseObjectTask("add_multi_app",                MultiApp,               false);
   registerMooseObjectTask("add_transfer",                 Transfer,               false);
 
-  registerMooseObjectTask("add_output",                   OutputBase,             false);
+  registerMooseObjectTask("add_output",                   Output,             false);
 
   registerTask("add_feproblem", false);
   registerTask("add_bounds_vectors", false);

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -17,7 +17,7 @@
 #include "LayeredSideFluxAverage.h"
 #include "AllLocalDofIndicesThread.h"
 
-#include "OutputBase.h"
+#include "Output.h"
 
 // libMesh
 #include "libmesh/mesh_tools.h"

--- a/framework/src/outputs/CSV.C
+++ b/framework/src/outputs/CSV.C
@@ -19,7 +19,7 @@ template<>
 InputParameters validParams<CSV>()
 {
   // Get the parameters from the parent object
-  InputParameters params = validParams<TableOutputter>();
+  InputParameters params = validParams<TableOutput>();
 
   // Suppress unused parameters
   params.suppressParameter<unsigned int>("padding");
@@ -28,7 +28,7 @@ InputParameters validParams<CSV>()
 }
 
 CSV::CSV(const std::string & name, InputParameters & parameters) :
-    TableOutputter(name, parameters)
+    TableOutput(name, parameters)
 {
 }
 
@@ -46,7 +46,7 @@ void
 CSV::output()
 {
   // Call the base class output (populates tables)
-  TableOutputter::output();
+  TableOutput::output();
 
   // Print the table containing all the data to a file
   if (!_all_data_table.empty())

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -28,7 +28,7 @@ template<>
 InputParameters validParams<Checkpoint>()
 {
   // Get the parameters from the base classes
-  InputParameters params = validParams<FileOutputter>();
+  InputParameters params = validParams<FileOutput>();
 
   // Typical checkpoint options
   params.addParam<unsigned int>("num_files", 2, "Number of the restart files to save");
@@ -48,7 +48,7 @@ InputParameters validParams<Checkpoint>()
 }
 
 Checkpoint::Checkpoint(const std::string & name, InputParameters & parameters) :
-    FileOutputter(name, parameters),
+    FileOutput(name, parameters),
     _num_files(getParam<unsigned int>("num_files")),
     _suffix(getParam<std::string>("suffix")),
     _binary(getParam<bool>("binary")),

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -27,7 +27,7 @@ InputParameters validParams<Console>()
   MooseEnum pps_fit_mode(FormattedTable::getWidthModes());
 
   // Get the parameters from the base class
-  InputParameters params = validParams<TableOutputter>();
+  InputParameters params = validParams<TableOutput>();
 
   // Screen and file output toggles
   params.addParam<bool>("output_screen", true, "Output to the screen");
@@ -88,7 +88,7 @@ InputParameters validParams<Console>()
 }
 
 Console::Console(const std::string & name, InputParameters parameters) :
-    TableOutputter(name, parameters),
+    TableOutput(name, parameters),
     _max_rows(getParam<unsigned int>("max_rows")),
     _fit_mode(getParam<MooseEnum>("fit_mode")),
     _use_color(false),
@@ -339,7 +339,7 @@ Console::output()
   else
   {
     writeVariableNorms();
-    TableOutputter::output();
+    TableOutput::output();
   }
 
   // Write the file
@@ -457,7 +457,7 @@ Console::insertNewline(std::stringstream &oss, std::streampos &begin, std::strea
 void
 Console::outputPostprocessors()
 {
-  TableOutputter::outputPostprocessors();
+  TableOutput::outputPostprocessors();
 
   if (!_postprocessor_table.empty())
   {
@@ -477,7 +477,7 @@ Console::outputPostprocessors()
 void
 Console::outputScalarVariables()
 {
-  TableOutputter::outputScalarVariables();
+  TableOutput::outputScalarVariables();
 
   if (!_scalar_table.empty())
   {

--- a/framework/src/outputs/DebugOutput.C
+++ b/framework/src/outputs/DebugOutput.C
@@ -13,7 +13,7 @@
 /****************************************************************/
 
 // MOOSE includes
-#include "DebugOutputter.h"
+#include "DebugOutput.h"
 #include "FEProblem.h"
 #include "MooseApp.h"
 //#include "Actions.h"
@@ -21,9 +21,9 @@
 
 
 template<>
-InputParameters validParams<DebugOutputter>()
+InputParameters validParams<DebugOutput>()
 {
-  InputParameters params = validParams<PetscOutputter>();
+  InputParameters params = validParams<PetscOutput>();
 
   // Suppress unnecessary parameters
   params.suppressParameter<bool>("output_scalar_variables");
@@ -42,8 +42,8 @@ InputParameters validParams<DebugOutputter>()
   return params;
 }
 
-DebugOutputter::DebugOutputter(const std::string & name, InputParameters & parameters) :
-    PetscOutputter(name, parameters),
+DebugOutput::DebugOutput(const std::string & name, InputParameters & parameters) :
+    PetscOutput(name, parameters),
     _show_var_residual_norms(getParam<bool>("show_var_residual_norms")),
     _sys(_problem_ptr->getNonlinearSystem().sys())
 {
@@ -51,7 +51,7 @@ DebugOutputter::DebugOutputter(const std::string & name, InputParameters & param
   _output_nonlinear = true;
 
   // Check the name of the object to see if was created by SetupDebugAction
-  if (name.compare("moose_debug_outputter") == 0)
+  if (name.compare("moose_debug_output") == 0)
   {
     // Extract the SetupDebugAction object
     std::vector<Action *> actions = _app.actionWarehouse().getActionsByName("setup_debug");
@@ -63,12 +63,12 @@ DebugOutputter::DebugOutputter(const std::string & name, InputParameters & param
   }
 }
 
-DebugOutputter::~DebugOutputter()
+DebugOutput::~DebugOutput()
 {
 }
 
 void
-DebugOutputter::output()
+DebugOutput::output()
 {
   if (_show_var_residual_norms && onNonlinearResidual())
   {
@@ -99,31 +99,31 @@ DebugOutputter::output()
 }
 
 std::string
-DebugOutputter::filename()
+DebugOutput::filename()
 {
   return std::string();
 }
 
 void
-DebugOutputter::outputNodalVariables()
+DebugOutput::outputNodalVariables()
 {
   mooseError("Individual output of nodal variables is not support for Debug output");
 }
 
 void
-DebugOutputter::outputElementalVariables()
+DebugOutput::outputElementalVariables()
 {
   mooseError("Individual output of elemental variables is not support for Debug output");
 }
 
 void
-DebugOutputter::outputPostprocessors()
+DebugOutput::outputPostprocessors()
 {
   mooseError("Individual output of postprocessors is not support for Debug output");
 }
 
 void
-DebugOutputter::outputScalarVariables()
+DebugOutput::outputScalarVariables()
 {
   mooseError("Individual output of scalars is not support for Debug output");
 }

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -24,7 +24,7 @@ template<>
 InputParameters validParams<Exodus>()
 {
   // Get the base class parameters
-  InputParameters params = validParams<OversampleOutputter>();
+  InputParameters params = validParams<OversampleOutput>();
 
   // Set the default padding to 3
   params.set<unsigned int>("padding") = 3;
@@ -37,7 +37,7 @@ InputParameters validParams<Exodus>()
 }
 
 Exodus::Exodus(const std::string & name, InputParameters parameters) :
-    OversampleOutputter(name, parameters),
+    OversampleOutput(name, parameters),
     _exodus_io_ptr(NULL),
     _exodus_initialized(false),
     _exodus_num(declareRestartableData<unsigned int>("exodus_num", 0)),
@@ -196,7 +196,7 @@ Exodus::output()
   _global_values.clear();
 
   // Call the output methods
-  OversampleOutputter::output();
+  OversampleOutput::output();
 
   // Write the global variables (populated by the output methods)
   if (!_global_values.empty())

--- a/framework/src/outputs/FileOutput.C
+++ b/framework/src/outputs/FileOutput.C
@@ -13,17 +13,17 @@
 /****************************************************************/
 
 // MOOSE includes
-#include "FileOutputter.h"
+#include "FileOutput.h"
 #include "MooseApp.h"
 #include "FEProblem.h"
 
 #include <unistd.h>
 
 template<>
-InputParameters validParams<FileOutputter>()
+InputParameters validParams<FileOutput>()
 {
   // Create InputParameters object for this stand-alone object
-  InputParameters params = validParams<OutputBase>();
+  InputParameters params = validParams<Output>();
   params.addParam<std::string>("file_base", "The desired solution output name without an extension (Defaults appends '_out' to the input file name)");
   params.addParam<bool>("append_displaced", false, "Append '_displaced' to the output file base");
   params.addParamNamesToGroup("append_displaced", "Displaced");
@@ -36,8 +36,8 @@ InputParameters validParams<FileOutputter>()
   return params;
 }
 
-FileOutputter::FileOutputter(const std::string & name, InputParameters & parameters) :
-    OutputBase(name, parameters),
+FileOutput::FileOutput(const std::string & name, InputParameters & parameters) :
+    Output(name, parameters),
     _file_base(getParam<std::string>("file_base")),
     _file_num(declareRecoverableData<unsigned int>("file_num", 0)),
     _padding(getParam<unsigned int>("padding")),
@@ -66,45 +66,45 @@ FileOutputter::FileOutputter(const std::string & name, InputParameters & paramet
   _output_file = checkFilename();
 }
 
-FileOutputter::~FileOutputter()
+FileOutput::~FileOutput()
 {
 }
 
 void
-FileOutputter::outputInitial()
+FileOutput::outputInitial()
 {
   // Perform filename check
   if (!_output_file)
     return;
 
   // Call the initial output method
-  OutputBase::outputInitial();
+  Output::outputInitial();
 }
 
 void
-FileOutputter::outputStep()
+FileOutput::outputStep()
 {
   // Perform filename check
   if (!_output_file)
     return;
 
   // Call the step output method
-  OutputBase::outputStep();
+  Output::outputStep();
 }
 
 void
-FileOutputter::outputFinal()
+FileOutput::outputFinal()
 {
   // Perform filename check
   if (!_output_file)
     return;
 
   // Call the final output methods
-  OutputBase::outputFinal();
+  Output::outputFinal();
 }
 
 std::string
-FileOutputter::getOutputFileBase(MooseApp & app)
+FileOutput::getOutputFileBase(MooseApp & app)
 {
   // If the App has an outputfile, then use it (MultiApp scenario)
   if (!app.getOutputFileBase().empty())
@@ -129,7 +129,7 @@ FileOutputter::getOutputFileBase(MooseApp & app)
 }
 
 bool
-FileOutputter::checkFilename()
+FileOutput::checkFilename()
 {
   // Return true if 'output_if_base_contains' is not utilized
   if (!isParamValid("output_if_base_contains"))
@@ -162,13 +162,13 @@ FileOutputter::checkFilename()
 
 
 void
-FileOutputter::setFileNumber(unsigned int num)
+FileOutput::setFileNumber(unsigned int num)
 {
   _file_num = num;
 }
 
 unsigned int
-FileOutputter::getFileNumber()
+FileOutput::getFileNumber()
 {
   return _file_num;
 }

--- a/framework/src/outputs/GMVOutput.C
+++ b/framework/src/outputs/GMVOutput.C
@@ -13,17 +13,17 @@
 /****************************************************************/
 
 // Moose includes
-#include "GMVOutputter.h"
+#include "GMVOutput.h"
 
 // libMesh includes
 #include "libmesh/gmv_io.h"
 
 template<>
-InputParameters validParams<GMVOutputter>()
+InputParameters validParams<GMVOutput>()
 {
   // Get the base class parameters
 
-  InputParameters params = validParams<OversampleOutputter>();
+  InputParameters params = validParams<OversampleOutput>();
 
   // Suppress unavailable parameters
   params.suppressParameter<bool>("output_scalar_variables");
@@ -35,15 +35,15 @@ InputParameters validParams<GMVOutputter>()
   params.addParam<bool>("binary", true, "Output the file in binary format");
   params.addParamNamesToGroup("binary", "Advanced");
 
-  // Add description for the GMVOutputter class
-  params.addClassDescription("Object for outputting data in the GMVOutputter format");
+  // Add description for the GMVOutput class
+  params.addClassDescription("Object for outputting data in the GMVOutput format");
 
   // Return the InputParameters
   return params;
 }
 
-GMVOutputter::GMVOutputter(const std::string & name, InputParameters parameters) :
-    OversampleOutputter(name, parameters),
+GMVOutput::GMVOutput(const std::string & name, InputParameters parameters) :
+    OversampleOutput(name, parameters),
     _binary(getParam<bool>("binary"))
 {
   // Force sequence output
@@ -53,7 +53,7 @@ GMVOutputter::GMVOutputter(const std::string & name, InputParameters parameters)
 }
 
 void
-GMVOutputter::output()
+GMVOutput::output()
 {
   GMVIO out(_es_ptr->get_mesh());
   out.write_equation_systems(filename(), *_es_ptr);
@@ -61,31 +61,31 @@ GMVOutputter::output()
 }
 
 void
-GMVOutputter::outputNodalVariables()
+GMVOutput::outputNodalVariables()
 {
   mooseError("Individual output of nodal variables is not support for GMV output");
 }
 
 void
-GMVOutputter::outputElementalVariables()
+GMVOutput::outputElementalVariables()
 {
   mooseError("Individual output of elemental variables is not support for GMV output");
 }
 
 void
-GMVOutputter::outputPostprocessors()
+GMVOutput::outputPostprocessors()
 {
   mooseError("Individual output of postprocessors is not support for GMV output");
 }
 
 void
-GMVOutputter::outputScalarVariables()
+GMVOutput::outputScalarVariables()
 {
   mooseError("Individual output of scalars is not support for GMV output");
 }
 
 std::string
-GMVOutputter::filename()
+GMVOutput::filename()
 {
   // Append the padded time step to the file base
   std::ostringstream output;

--- a/framework/src/outputs/GNUPlot.C
+++ b/framework/src/outputs/GNUPlot.C
@@ -19,7 +19,7 @@ template<>
 InputParameters validParams<GNUPlot>()
 {
   // Get the parameters from the parent object
-  InputParameters params = validParams<TableOutputter>();
+  InputParameters params = validParams<TableOutput>();
 
   // Set an enum for the possible file extensions
   MooseEnum ext("png ps gif", "png", "GNU plot file extension");
@@ -32,7 +32,7 @@ InputParameters validParams<GNUPlot>()
 }
 
 GNUPlot::GNUPlot(const std::string & name, InputParameters & parameters) :
-    TableOutputter(name, parameters),
+    TableOutput(name, parameters),
     _extension(getParam<MooseEnum>("extension"))
 {
 }
@@ -51,7 +51,7 @@ void
 GNUPlot::output()
 {
   // Call the base class output (populates tables)
-  TableOutputter::output();
+  TableOutput::output();
 
   // Print the table containing all the data to a file
   if (!_all_data_table.empty())

--- a/framework/src/outputs/Nemesis.C
+++ b/framework/src/outputs/Nemesis.C
@@ -21,7 +21,7 @@ template<>
 InputParameters validParams<Nemesis>()
 {
   // Get the base class parameters
-  InputParameters params = validParams<OversampleOutputter>();
+  InputParameters params = validParams<OversampleOutput>();
 
   // Add description for the Nemesis class
   params.addClassDescription("Object for output data in the Nemesis format");
@@ -31,7 +31,7 @@ InputParameters validParams<Nemesis>()
 }
 
 Nemesis::Nemesis(const std::string & name, InputParameters parameters) :
-    OversampleOutputter(name, parameters),
+    OversampleOutput(name, parameters),
     _nemesis_io_ptr(NULL),
     _file_num(0),
     _nemesis_num(0)
@@ -134,7 +134,7 @@ Nemesis::output()
   _global_values.clear();
 
   // Call the output methods
-  OversampleOutputter::output();
+  OversampleOutput::output();
 
   // Write the data
   _nemesis_io_ptr->write_timestep(filename(), *_es_ptr, _nemesis_num, time() + _app.getGlobalTimeOffset());

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -16,7 +16,7 @@
 #include <math.h>
 
 // MOOSE includes
-#include "OutputBase.h"
+#include "Output.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
 #include "MooseApp.h"
@@ -26,7 +26,7 @@
 #include "CoupledExecutioner.h"
 
 template<>
-InputParameters validParams<OutputBase>()
+InputParameters validParams<Output>()
 {
   /* NOTE:
    * The validParams from each output object is merged with the valdParams from CommonOutputAction. In order for the
@@ -80,13 +80,13 @@ InputParameters validParams<OutputBase>()
   params.addParamNamesToGroup("hide show output_nonlinear_variables output_postprocessors output_scalar_variables output_elemental_variables output_nodal_variables scalar_as_nodal elemental_as_nodal", "Variables");
 
   // Register this class as base class
-  params.registerBase("OutputBase");
+  params.registerBase("Output");
   return params;
 }
 
-OutputBase::OutputBase(const std::string & name, InputParameters & parameters) :
+Output::Output(const std::string & name, InputParameters & parameters) :
     MooseObject(name, parameters),
-    Restartable(name, parameters, "OutputBase"),
+    Restartable(name, parameters, "Output"),
     _problem_ptr(getParam<FEProblem *>("_fe_problem")),
     _transient(_problem_ptr->isTransient()),
     _use_displaced(getParam<bool>("use_displaced")),
@@ -123,7 +123,7 @@ OutputBase::OutputBase(const std::string & name, InputParameters & parameters) :
 }
 
 void
-OutputBase::init()
+Output::init()
 {
   // Do not initialize more than once
   /* This check is needed for YAK which calls Executioners from within Executioners */
@@ -191,32 +191,32 @@ OutputBase::init()
   _initialized = true;
 }
 
-OutputBase::~OutputBase()
+Output::~Output()
 {
 }
 
 void
-OutputBase::outputSetup()
+Output::outputSetup()
 {
 }
 
 void
-OutputBase::initialSetup()
+Output::initialSetup()
 {
 }
 
 void
-OutputBase::timestepSetup()
+Output::timestepSetup()
 {
 }
 
 void
-OutputBase::timestepSetupInternal()
+Output::timestepSetupInternal()
 {
 }
 
 void
-OutputBase::outputInitial()
+Output::outputInitial()
 {
   // Do Nothing if output is not forced or if output is disallowed
   if (!_force_output && !_allow_output)
@@ -253,14 +253,14 @@ OutputBase::outputInitial()
 }
 
 void
-OutputBase::outputFailedStep()
+Output::outputFailedStep()
 {
   if (_output_failed)
     outputStep();
 }
 
 void
-OutputBase::outputStep()
+Output::outputStep()
 {
   // Do nothing if intermediate steps are disable
   if (!_output_intermediate)
@@ -298,7 +298,7 @@ OutputBase::outputStep()
 }
 
 void
-OutputBase::outputFinal()
+Output::outputFinal()
 {
   // If the intermediate steps are being output and the final time step is on an interval it will already have benn output by outputStep, so do nothing
   if (checkInterval() && _output_intermediate)
@@ -327,7 +327,7 @@ OutputBase::outputFinal()
 }
 
 void
-OutputBase::output()
+Output::output()
 {
   // Call the various output types, if data exists
   if (hasNodalVariableOutput())
@@ -344,13 +344,13 @@ OutputBase::output()
 }
 
 void
-OutputBase::forceOutput()
+Output::forceOutput()
 {
   _force_output = true;
 }
 
 bool
-OutputBase::hasOutput()
+Output::hasOutput()
 {
   // Test all the possible output formats, return true if any of them are true
   if (hasNodalVariableOutput() || hasElementalVariableOutput() ||
@@ -361,87 +361,87 @@ OutputBase::hasOutput()
 }
 
 void
-OutputBase::outputInput()
+Output::outputInput()
 {
   // Empty function
 }
 
 void
-OutputBase::outputSystemInformation()
+Output::outputSystemInformation()
 {
   // Empty function
 }
 
 bool
-OutputBase::hasNodalVariableOutput()
+Output::hasNodalVariableOutput()
 {
   return !_nonlinear_nodal.output.empty();
 }
 
 const std::vector<std::string> &
-OutputBase::getNodalVariableOutput()
+Output::getNodalVariableOutput()
 {
   return _nonlinear_nodal.output;
 }
 
 bool
-OutputBase::hasElementalVariableOutput()
+Output::hasElementalVariableOutput()
 {
   return !_nonlinear_elemental.output.empty();
 }
 
 const std::vector<std::string> &
-OutputBase::getElementalVariableOutput()
+Output::getElementalVariableOutput()
 {
   return _nonlinear_elemental.output;
 }
 
 
 bool
-OutputBase::hasScalarOutput()
+Output::hasScalarOutput()
 {
   return !_scalar.output.empty();
 }
 
 const std::vector<std::string> &
-OutputBase::getScalarOutput()
+Output::getScalarOutput()
 {
   return _scalar.output;
 }
 
 bool
-OutputBase::hasPostprocessorOutput()
+Output::hasPostprocessorOutput()
 {
   return !_postprocessor.output.empty();
 }
 
 const std::vector<std::string> &
-OutputBase::getPostprocessorOutput()
+Output::getPostprocessorOutput()
 {
   return _postprocessor.output;
 }
 
 void
-OutputBase::meshChanged()
+Output::meshChanged()
 {
   _mesh_changed = true;
 }
 
 void
-OutputBase::allowOutput(bool state)
+Output::allowOutput(bool state)
 {
   _allow_output = state;
 }
 
 
 void
-OutputBase::sequence(bool state)
+Output::sequence(bool state)
 {
   _sequence = state;
 }
 
 bool
-OutputBase::checkInterval()
+Output::checkInterval()
 {
   // The output flag to return
   bool output = false;
@@ -463,7 +463,7 @@ OutputBase::checkInterval()
 }
 
 void
-OutputBase::initAvailableLists()
+Output::initAvailableLists()
 {
   /* This flag is set to true if any postprocessor has the 'outputs' parameter set, it is then used
      to produce an warning if postprocessor output is disabled*/
@@ -532,7 +532,7 @@ OutputBase::initAvailableLists()
 }
 
 void
-OutputBase::initShowHideLists(const std::vector<VariableName> & show, const std::vector<VariableName> & hide)
+Output::initShowHideLists(const std::vector<VariableName> & show, const std::vector<VariableName> & hide)
 {
 
   // Storage for user-supplied input that is unknown as a variable or postprocessor
@@ -590,7 +590,7 @@ OutputBase::initShowHideLists(const std::vector<VariableName> & show, const std:
 }
 
 void
-OutputBase::initOutputList(OutputData & data)
+Output::initOutputList(OutputData & data)
 {
   // References to the vectors of variable names
   std::vector<std::string> & hide  = data.hide;

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -14,9 +14,9 @@
 
 // MOOSE includes
 #include "OutputWarehouse.h"
-#include "OutputBase.h"
+#include "Output.h"
 #include "Console.h"
-#include "FileOutputter.h"
+#include "FileOutput.h"
 #include "Checkpoint.h"
 #include "FEProblem.h"
 
@@ -36,14 +36,14 @@ OutputWarehouse::OutputWarehouse() :
 
 OutputWarehouse::~OutputWarehouse()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     delete *it;
 }
 
 void
 OutputWarehouse::initialSetup()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->initialSetup();
 }
 
@@ -51,14 +51,14 @@ OutputWarehouse::initialSetup()
 void
 OutputWarehouse::init()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->init();
 }
 
 void
 OutputWarehouse::timestepSetup()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
   {
     (*it)->timestepSetupInternal();
     (*it)->timestepSetup();
@@ -66,7 +66,7 @@ OutputWarehouse::timestepSetup()
 }
 
 void
-OutputWarehouse::addOutput(OutputBase * output)
+OutputWarehouse::addOutput(Output * output)
 {
   // Add the object to the warehouse storage, Checkpoint placed at end so they are called last
   Checkpoint * cp = dynamic_cast<Checkpoint *>(output);
@@ -78,8 +78,8 @@ OutputWarehouse::addOutput(OutputBase * output)
   // Store the name and pointer in map
   _object_map[output->name()] = output;
 
-  // If the output object is a FileOutputBase then store the output filename
-  FileOutputter * ptr = dynamic_cast<FileOutputter *>(output);
+  // If the output object is a FileOutput then store the output filename
+  FileOutput * ptr = dynamic_cast<FileOutput *>(output);
   if (ptr != NULL)
     addOutputFilename(ptr->filename());
 
@@ -109,7 +109,7 @@ OutputWarehouse::hasOutput(std::string name)
   return _object_map.find(name) != _object_map.end();
 }
 
-const std::vector<OutputBase *> &
+const std::vector<Output *> &
 OutputWarehouse::getOutputs() const
 {
   return _object_ptrs;
@@ -127,58 +127,58 @@ OutputWarehouse::addOutputFilename(OutFileBase filename)
 void
 OutputWarehouse::outputInitial()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->outputInitial();
 }
 
 void
 OutputWarehouse::outputFailedStep()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->outputFailedStep();
 }
 
 void
 OutputWarehouse::outputStep()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->outputStep();
 }
 
 void
 OutputWarehouse::outputFinal()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->outputFinal();
 }
 
 void
 OutputWarehouse::meshChanged()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->meshChanged();
 }
 
 void
 OutputWarehouse::allowOutput(bool state)
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->allowOutput(state);
 }
 
 void
 OutputWarehouse::forceOutput()
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
     (*it)->forceOutput();
 }
 
 void
 OutputWarehouse::setFileNumbers(std::map<std::string, unsigned int> input, unsigned int offset)
 {
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
   {
-    FileOutputter * ptr = dynamic_cast<FileOutputter *>(*it);
+    FileOutput * ptr = dynamic_cast<FileOutput *>(*it);
     if (ptr != NULL)
     {
       std::map<std::string, unsigned int>::const_iterator it = input.find(ptr->name());
@@ -198,9 +198,9 @@ std::map<std::string, unsigned int>
 OutputWarehouse::getFileNumbers()
 {
   std::map<std::string, unsigned int> output;
-  for (std::vector<OutputBase *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
+  for (std::vector<Output *>::const_iterator it = _object_ptrs.begin(); it != _object_ptrs.end(); ++it)
   {
-    FileOutputter * ptr = dynamic_cast<FileOutputter *>(*it);
+    FileOutput * ptr = dynamic_cast<FileOutput *>(*it);
     if (ptr != NULL)
       output[ptr->name()] = ptr->getFileNumber();
   }

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -13,18 +13,18 @@
 /****************************************************************/
 
 // MOOSE includes
-#include "OversampleOutputter.h"
+#include "OversampleOutput.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
 #include "FileMesh.h"
 #include "MooseApp.h"
 
 template<>
-InputParameters validParams<OversampleOutputter>()
+InputParameters validParams<OversampleOutput>()
 {
 
   // Get the parameters from the parent object
-  InputParameters params = validParams<PetscOutputter>();
+  InputParameters params = validParams<PetscOutput>();
 
   params.addParam<bool>("oversample", false, "Set to true to enable oversampling");
   params.addParam<unsigned int>("refinements", 0, "Number of uniform refinements for oversampling");
@@ -38,8 +38,8 @@ InputParameters validParams<OversampleOutputter>()
   return params;
 }
 
-OversampleOutputter::OversampleOutputter(const std::string & name, InputParameters & parameters) :
-    PetscOutputter(name, parameters),
+OversampleOutput::OversampleOutput(const std::string & name, InputParameters & parameters) :
+    PetscOutput(name, parameters),
     _mesh_ptr(getParam<bool>("use_displaced") ?
               &_problem_ptr->getDisplacedProblem()->mesh() : &_problem_ptr->mesh()),
     _oversample(getParam<bool>("oversample")),
@@ -55,7 +55,7 @@ OversampleOutputter::OversampleOutputter(const std::string & name, InputParamete
     _file_base = _file_base + "_oversample";
 }
 
-OversampleOutputter::~OversampleOutputter()
+OversampleOutput::~OversampleOutput()
 {
   // When the Oversample::initOversample() is called it creates new objects for the _mesh_ptr and _es_ptr
   // that contain the refined mesh and variables. Also, the _mesh_functions vector and _serialized_solution
@@ -76,7 +76,7 @@ OversampleOutputter::~OversampleOutputter()
 }
 
 void
-OversampleOutputter::outputInitial()
+OversampleOutput::outputInitial()
 {
   // Perform filename check
   if (!_output_file)
@@ -90,11 +90,11 @@ OversampleOutputter::outputInitial()
   }
 
   // Call the initial output method
-  OutputBase::outputInitial();
+  Output::outputInitial();
 }
 
 void
-OversampleOutputter::outputStep()
+OversampleOutput::outputStep()
 {
   // Perform filename check
   if (!_output_file)
@@ -108,11 +108,11 @@ OversampleOutputter::outputStep()
   }
 
   // Call the step output method
-  OutputBase::outputStep();
+  Output::outputStep();
 }
 
 void
-OversampleOutputter::outputFinal()
+OversampleOutput::outputFinal()
 {
   // Perform filename check
   if (!_output_file)
@@ -126,11 +126,11 @@ OversampleOutputter::outputFinal()
   }
 
   // Call the final output methods
-  OutputBase::outputFinal();
+  Output::outputFinal();
 }
 
 void
-OversampleOutputter::initOversample()
+OversampleOutput::initOversample()
 {
   // Perform the mesh cloning, if needed
   if (_change_position || _oversample)
@@ -196,7 +196,7 @@ OversampleOutputter::initOversample()
 }
 
 void
-OversampleOutputter::update()
+OversampleOutput::update()
 {
   // Get a reference to actual equation system
   EquationSystems & source_es = _problem_ptr->es();
@@ -233,7 +233,7 @@ OversampleOutputter::update()
 }
 
 void
-OversampleOutputter::cloneMesh()
+OversampleOutput::cloneMesh()
 {
   // Create the new mesh from a file
   if (isParamValid("file"))

--- a/framework/src/outputs/PetscOutput.C
+++ b/framework/src/outputs/PetscOutput.C
@@ -13,7 +13,7 @@
 /****************************************************************/
 
 // MOOSE includes
-#include "PetscOutputter.h"
+#include "PetscOutput.h"
 #include "FEProblem.h"
 
 // libMesh includes
@@ -21,9 +21,9 @@
 #include "libmesh/petsc_nonlinear_solver.h"
 
 template<>
-InputParameters validParams<PetscOutputter>()
+InputParameters validParams<PetscOutput>()
 {
-  InputParameters params = validParams<FileOutputter>();
+  InputParameters params = validParams<FileOutput>();
 
   // Toggled for outputting nonlinear and linear residuals, only if we have PETSc
 #ifdef LIBMESH_HAVE_PETSC
@@ -49,8 +49,8 @@ InputParameters validParams<PetscOutputter>()
   return params;
 }
 
-PetscOutputter::PetscOutputter(const std::string & name, InputParameters & parameters) :
-    FileOutputter(name, parameters),
+PetscOutput::PetscOutput(const std::string & name, InputParameters & parameters) :
+    FileOutput(name, parameters),
     _nonlinear_iter(0),
     _linear_iter(0),
     _output_nonlinear(getParam<bool>("nonlinear_residuals")),
@@ -88,12 +88,12 @@ PetscOutputter::PetscOutputter(const std::string & name, InputParameters & param
     _linear_end_time = getParam<Real>("linear_residual_end_time");
 }
 
-PetscOutputter::~PetscOutputter()
+PetscOutput::~PetscOutput()
 {
 }
 
 void
-PetscOutputter::timestepSetupInternal()
+PetscOutput::timestepSetupInternal()
 {
 // Only execute if PETSc exists
 #ifdef LIBMESH_HAVE_PETSC
@@ -128,10 +128,10 @@ PetscOutputter::timestepSetupInternal()
 // Only define the monitor functions if PETSc exists
 #ifdef LIBMESH_HAVE_PETSC
 PetscErrorCode
-PetscOutputter::petscNonlinearOutput(SNES, PetscInt its, PetscReal norm, void * void_ptr)
+PetscOutput::petscNonlinearOutput(SNES, PetscInt its, PetscReal norm, void * void_ptr)
 {
   // Get the outputter object
-  PetscOutputter * ptr = static_cast<PetscOutputter *>(void_ptr);
+  PetscOutput * ptr = static_cast<PetscOutput *>(void_ptr);
 
   // Update the pseudo times
   ptr->_nonlinear_time += ptr->_nonlinear_dt;
@@ -155,10 +155,10 @@ PetscOutputter::petscNonlinearOutput(SNES, PetscInt its, PetscReal norm, void * 
 }
 
 PetscErrorCode
-PetscOutputter::petscLinearOutput(KSP, PetscInt its, PetscReal norm, void * void_ptr)
+PetscOutput::petscLinearOutput(KSP, PetscInt its, PetscReal norm, void * void_ptr)
 {
   // Get the Outputter object
-  PetscOutputter * ptr = static_cast<PetscOutputter *>(void_ptr);
+  PetscOutput * ptr = static_cast<PetscOutput *>(void_ptr);
 
   // Update the pseudo time
   ptr->_linear_time += ptr->_linear_dt;
@@ -182,7 +182,7 @@ PetscOutputter::petscLinearOutput(KSP, PetscInt its, PetscReal norm, void * void
 #endif
 
 Real
-PetscOutputter::time()
+PetscOutput::time()
 {
   if (_on_nonlinear_residual)
     return _nonlinear_time;

--- a/framework/src/outputs/SolutionHistory.C
+++ b/framework/src/outputs/SolutionHistory.C
@@ -21,7 +21,7 @@ template<>
 InputParameters validParams<SolutionHistory>()
 {
   // Get the parameters from the parent object
-  InputParameters params = validParams<FileOutputter>();
+  InputParameters params = validParams<FileOutput>();
 
   // Suppress unused parameters
   params.suppressParameter<unsigned int>("padding");
@@ -37,7 +37,7 @@ InputParameters validParams<SolutionHistory>()
 }
 
 SolutionHistory::SolutionHistory(const std::string & name, InputParameters & parameters) :
-    FileOutputter(name, parameters)
+    FileOutput(name, parameters)
 {
 }
 

--- a/framework/src/outputs/TableOutput.C
+++ b/framework/src/outputs/TableOutput.C
@@ -13,7 +13,7 @@
 /****************************************************************/
 
 // MOOSE includes
-#include "TableOutputter.h"
+#include "TableOutput.h"
 #include "FEProblem.h"
 #include "Postprocessor.h"
 #include "PetscSupport.h"
@@ -25,13 +25,13 @@
 #include "libmesh/string_to_enum.h"
 
 template<>
-InputParameters validParams<TableOutputter>()
+InputParameters validParams<TableOutput>()
 {
   // Fit mode selection Enum
   MooseEnum pps_fit_mode(FormattedTable::getWidthModes());
 
   // Base class parameters
-  InputParameters params = validParams<PetscOutputter>();
+  InputParameters params = validParams<PetscOutput>();
 
   // Suppressing the output of nodal and elemental variables disables this type of output
   params.suppressParameter<bool>("output_elemental_variables");
@@ -43,32 +43,32 @@ InputParameters validParams<TableOutputter>()
   return params;
 }
 
-TableOutputter::TableOutputter(const std::string & name, InputParameters parameters) :
-    PetscOutputter(name, parameters),
+TableOutput::TableOutput(const std::string & name, InputParameters parameters) :
+    PetscOutput(name, parameters),
     _postprocessor_table(declareRestartableData<FormattedTable>("postprocessor_table")),
     _scalar_table(declareRestartableData<FormattedTable>("scalar_table")),
     _all_data_table(declareRestartableData<FormattedTable>("all_data_table"))
 {
 }
 
-TableOutputter::~TableOutputter()
+TableOutput::~TableOutput()
 {
 }
 
 void
-TableOutputter::outputNodalVariables()
+TableOutput::outputNodalVariables()
 {
-  mooseError("Nodal nonlinear variable output not supported by TableOutputter output class");
+  mooseError("Nodal nonlinear variable output not supported by TableOutput output class");
 }
 
 void
-TableOutputter::outputElementalVariables()
+TableOutput::outputElementalVariables()
 {
-  mooseError("Elemental nonlinear variable output not supported by TableOutputter output class");
+  mooseError("Elemental nonlinear variable output not supported by TableOutput output class");
 }
 
 void
-TableOutputter::outputPostprocessors()
+TableOutput::outputPostprocessors()
 {
   // List of names of the postprocessors to output
   const std::vector<std::string> & out = getPostprocessorOutput();
@@ -83,7 +83,7 @@ TableOutputter::outputPostprocessors()
 }
 
 void
-TableOutputter::outputScalarVariables()
+TableOutput::outputScalarVariables()
 {
   // List of scalar variables
   const std::vector<std::string> & out = getScalarOutput();

--- a/framework/src/outputs/Tecplot.C
+++ b/framework/src/outputs/Tecplot.C
@@ -24,7 +24,7 @@ template<>
 InputParameters validParams<Tecplot>()
 {
   // Get the base class parameters
-  InputParameters params = validParams<OversampleOutputter>();
+  InputParameters params = validParams<OversampleOutput>();
 
   // Suppress unavailable and meaningless parameters for this object
   params.suppressParameter<bool>("output_nodal_variables");
@@ -49,7 +49,7 @@ InputParameters validParams<Tecplot>()
 }
 
 Tecplot::Tecplot(const std::string & name, InputParameters parameters) :
-    OversampleOutputter(name, parameters),
+    OversampleOutput(name, parameters),
     _binary(getParam<bool>("binary")),
     _ascii_append(getParam<bool>("ascii_append")),
     _first_time(declareRestartableData<bool>("first_time", true))

--- a/framework/src/outputs/VTKOutput.C
+++ b/framework/src/outputs/VTKOutput.C
@@ -12,12 +12,12 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "VTK.h"
+#include "VTKOutput.h"
 
 template<>
-InputParameters validParams<VTKOutputter>()
+InputParameters validParams<VTKOutput>()
 {
-  InputParameters params = validParams<OversampleOutputter>();
+  InputParameters params = validParams<OversampleOutput>();
 
   // Supress un-available parameters
   params.suppressParameter<bool>("output_scalar_variables");
@@ -29,61 +29,61 @@ InputParameters validParams<VTKOutputter>()
   params.set<unsigned int>("padding") = 3;
 
   // Add binary toggle
-  params.addParam<bool>("binary", false, "Set VTK files to output in binary format");
+  params.addParam<bool>("binary", false, "Set VTKOutput files to output in binary format");
   params.addParamNamesToGroup("binary", "Advanced");
 
   return params;
 }
 
-VTKOutputter::VTKOutputter(const std::string & name, InputParameters & parameters) :
-    OversampleOutputter(name, parameters),
+VTKOutput::VTKOutput(const std::string & name, InputParameters & parameters) :
+    OversampleOutput(name, parameters),
     _vtk_io_ptr(NULL),
     _binary(getParam<bool>("binary"))
 {
-  // VTK files must be written in sequence
+  // VTKOutput files must be written in sequence
   sequence(true);
 }
 
-VTKOutputter::~VTKOutputter()
+VTKOutput::~VTKOutput()
 {
   delete _vtk_io_ptr;
 }
 
 void
-VTKOutputter::outputSetup()
+VTKOutput::outputSetup()
 {
-  // The libMesh::ExodusII_IO will fail when it is closed if the object is created but
+  // The libMesh::VTK_IO will fail when it is closed if the object is created but
   // nothing is written to the file. This checks that at least something will be written.
   if (!hasOutput())
-    mooseError("The current settings result in nothing being output to the VTKOutputter file.");
+    mooseError("The current settings result in nothing being output to the VTKOutput file.");
 
-  // Delete existing VTKIO objects
+  // Delete existing VTKOutputIO objects
   if (_vtk_io_ptr != NULL)
     delete _vtk_io_ptr;
 
 #ifdef LIBMESH_HAVE_VTK
-  // Create the new VTKOutputter object and set compression
+  // Create the new VTKOutput object and set compression
   _vtk_io_ptr = new VTKIO(_es_ptr->get_mesh());
   _vtk_io_ptr->set_compression(_binary);
 #else
-  mooseError("libMesh not configured with VTK");
+  mooseError("libMesh not configured with VTKOutput");
 #endif
 }
 
 void
-VTKOutputter::output()
+VTKOutput::output()
 {
 #ifdef LIBMESH_HAVE_VTK
   // Write the data
   _vtk_io_ptr->write_equation_systems(filename(), *_es_ptr);
   _file_num++;
 #else
-  mooseError("libMesh not configured with VTK");
+  mooseError("libMesh not configured with VTKOutput");
 #endif
 }
 
 std::string
-VTKOutputter::filename()
+VTKOutput::filename()
 {
   // Append the .e extension on the base file name
   std::ostringstream output;
@@ -103,25 +103,25 @@ VTKOutputter::filename()
 }
 
 void
-VTKOutputter::outputNodalVariables()
+VTKOutput::outputNodalVariables()
 {
-  mooseError("Individual output of nodal variables is not support for VTK output");
+  mooseError("Individual output of nodal variables is not support for VTKOutput output");
 }
 
 void
-VTKOutputter::outputElementalVariables()
+VTKOutput::outputElementalVariables()
 {
-  mooseError("Individual output of elemental variables is not support for VTK output");
+  mooseError("Individual output of elemental variables is not support for VTKOutput output");
 }
 
 void
-VTKOutputter::outputPostprocessors()
+VTKOutput::outputPostprocessors()
 {
-  mooseError("Individual output of postprocessors is not support for VTK output");
+  mooseError("Individual output of postprocessors is not support for VTKOutput output");
 }
 
 void
-VTKOutputter::outputScalarVariables()
+VTKOutput::outputScalarVariables()
 {
-  mooseError("Individual output of scalars is not support for VTK output");
+  mooseError("Individual output of scalars is not support for VTKOutput output");
 }

--- a/framework/src/outputs/XDA.C
+++ b/framework/src/outputs/XDA.C
@@ -22,7 +22,7 @@ InputParameters validParams<XDA>()
 {
   // Get the base class parameters
 
-  InputParameters params = validParams<OversampleOutputter>();
+  InputParameters params = validParams<OversampleOutput>();
 
   // Supress un-available parameters
   params.suppressParameter<bool>("output_nodal_variables");
@@ -44,7 +44,7 @@ InputParameters validParams<XDA>()
 }
 
 XDA::XDA(const std::string & name, InputParameters parameters) :
-    OversampleOutputter(name, parameters),
+    OversampleOutput(name, parameters),
     _binary(getParam<bool>("_binary"))
 {
   // Force sequence output

--- a/test/tests/outputs/debug/show_var_residual_norms.i
+++ b/test/tests/outputs/debug/show_var_residual_norms.i
@@ -210,7 +210,7 @@
     perf_log = true
   [../]
   [./debug]
-    type = DebugOutputter
+    type = DebugOutput
     show_var_residual_norms = true
   [../]
 []

--- a/test/tests/outputs/debug/show_var_residual_norms_block.i
+++ b/test/tests/outputs/debug/show_var_residual_norms_block.i
@@ -210,7 +210,7 @@
     perf_log = true
   [../]
   [./debug]
-    type = DebugOutputter
+    type = DebugOutput
     show_var_residual_norms = true
   [../]
 []


### PR DESCRIPTION
**This will break R7, I have a patch waiting, so just tell @aeslaughter when you merge.**
- `OutputBase` -> `Output`
- `Outputter` to `Output`

(closes #2875)
