### PR TITLE
Enable correct handling of periodic boundary conditions in MultiSmoothCircleIC  #2953

### DIFF
--- a/modules/phase_field/include/ics/SmoothCircleIC.h
+++ b/modules/phase_field/include/ics/SmoothCircleIC.h
@@ -41,8 +41,8 @@ public:
   virtual RealGradient gradient(const Point & p);
 
 protected:
-
   MooseMesh & _mesh;
+
   Real _x1;
   Real _y1;
   Real _z1;

--- a/modules/phase_field/src/ics/MultiSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothCircleIC.C
@@ -104,11 +104,8 @@ MultiSmoothCircleIC::value(const Point & p)
     _radius = _bubradi[i];
     _center = _bubcent[i];
 
-    if ((p-_center).size() < _radius + _int_width/2.0)
-    {
-      val2 = SmoothCircleIC::value(p);
-      if (val2 > val) val = val2;
-    }
+    val2 = SmoothCircleIC::value(p);
+    if (val2 > val) val = val2;
   }
 
   return val;
@@ -124,12 +121,9 @@ MultiSmoothCircleIC::gradient(const Point & p)
   {
     _radius = _bubradi[i];
     _center = _bubcent[i];
-    if ((p-_center).size() < _radius + _int_width/2.0)
-    {
-      grad2 = SmoothCircleIC::gradient(p)/_numbub;
-      //if (grad.size() < grad2.size())
-      grad = grad2;
-    }
+
+    grad2 = SmoothCircleIC::gradient(p)/_numbub;
+    if (grad.size() < grad2.size()) grad = grad2;
   }
 
   return grad;

--- a/modules/phase_field/src/ics/SmoothCircleIC.C
+++ b/modules/phase_field/src/ics/SmoothCircleIC.C
@@ -53,13 +53,13 @@ SmoothCircleIC::value(const Point & p)
   }
 
   //Set value for outside the circle, inside the circle, and on the smooth interface
-  Real rad = _mesh.minPeriodicDistance(_var.number(),p2,center2);
+  Real rad = _mesh.minPeriodicDistance(_var.number(), p2, center2);
   if (rad <= _radius - _int_width/2.0) //Inside circle
     value = _invalue;
   else if (rad < _radius + _int_width/2.0) //Smooth interface
   {
     Real int_pos = (rad - _radius + _int_width/2.0)/_int_width;
-    value = _outvalue + (_invalue-_outvalue)*(1+cos(int_pos*libMesh::pi))/2.0;
+    value = _outvalue + (_invalue - _outvalue) * (1.0 + cos(int_pos * libMesh::pi)) / 2.0;
   }
   else //Outside circle
     value = _outvalue;
@@ -91,7 +91,7 @@ SmoothCircleIC::gradient(const Point & p)
     DvalueDr = Dint_posDr * (_invalue - _outvalue) * (-sin(int_pos * libMesh::pi) * libMesh::pi) / 2.0;
   }
   //Set gradient over the smooth interface
-  if (rad != 0) {
+  if (rad != 0.0) {
     return Gradient((p(0) - _center(0)) * DvalueDr / rad,
                     (p(1) - _center(1)) * DvalueDr / rad,
                     (p(2) - _center(2)) * DvalueDr / rad);


### PR DESCRIPTION
Handling of periodicity is done by the base class.
