### PR TITLE
No comm world

### DIFF
--- a/framework/include/base/AppFactory.h
+++ b/framework/include/base/AppFactory.h
@@ -97,7 +97,7 @@ public:
    * @param parameters Parameters this object should have
    * @return The created object
    */
-  virtual MooseApp *create(const std::string & obj_name, const std::string & name, InputParameters parameters);
+  virtual MooseApp *create(const std::string & obj_name, const std::string & name, InputParameters parameters, MPI_Comm COMM_WORLD_IN);
 
   registeredMooseAppIterator registeredObjectsBegin() { return _name_to_params_pointer.begin(); }
   registeredMooseAppIterator registeredObjectsEnd() { return _name_to_params_pointer.end(); }

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -393,7 +393,7 @@ protected:
   std::map<std::string, unsigned int> _output_file_numbers;
 
   /// OutputWarehouse object for this App
-  OutputWarehouse _output_warehouse;
+  OutputWarehouse * _output_warehouse;
 
   /// An alternate OutputWarehouse object (required for CoupledExecutioner)
   OutputWarehouse * _alternate_output_warehouse;

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -29,6 +29,9 @@
 #include "ActionFactory.h"
 #include "OutputWarehouse.h"
 
+// libMesh includes
+#include "libmesh/parallel_object.h"
+
 class Executioner;
 class MooseApp;
 class RecoverBaseAction;
@@ -46,7 +49,7 @@ InputParameters validParams<MooseApp>();
  *
  * Each application should register its own objects and register its own special syntax
  */
-class MooseApp
+class MooseApp : public libMesh::ParallelObject
 {
 public:
   virtual ~MooseApp();
@@ -316,6 +319,9 @@ protected:
 
   /// Parameters of this object
   InputParameters _pars;
+
+  /// The MPI communicator this App is going to use
+  const Parallel::Communicator * _comm;
 
   /// Input file name used
   std::string _input_filename;

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -23,12 +23,12 @@
 /**
  * MOOSE wrapped versions of useful libMesh macros (see libmesh_common.h)
  */
-#define mooseError(msg) do { Moose::err << "\n\n" << msg << "\n\n"; if (libMesh::n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::COMM_WORLD,1); exit(1); } while(0)
+#define mooseError(msg) do { Moose::err << "\n\n" << msg << "\n\n"; if (libMesh::global_n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1); exit(1); } while(0)
 
 #ifdef NDEBUG
 #define mooseAssert(asserted, msg)
 #else
-#define mooseAssert(asserted, msg)  do { if (!(asserted)) { Moose::err << "\n\nAssertion `" #asserted "' failed\n" << msg << "\nat " << __FILE__ << ", line " << __LINE__ << std::endl; if (libMesh::n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::COMM_WORLD,1); exit(1); } } while(0)
+#define mooseAssert(asserted, msg)  do { if (!(asserted)) { Moose::err << "\n\nAssertion `" #asserted "' failed\n" << msg << "\nat " << __FILE__ << ", line " << __LINE__ << std::endl; if (libMesh::global_n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1); exit(1); } } while(0)
 #endif
 
 #define mooseWarning(msg) do { Moose::out << "\n\n*** Warning ***\n" << msg << "\nat " << __FILE__ << ", line " << __LINE__ << "\n" << std::endl; } while(0)
@@ -37,6 +37,6 @@
 
 #define mooseDeprecated() mooseDoOnce( Moose::out << "*** Warning, This code is deprecated, and likely to be removed in future library versions! " << __FILE__ << ", line " << __LINE__ << ", compiled " << __DATE__ << " at " << __TIME__ << " ***" << std::endl;)
 
-#define mooseCheckMPIErr(err) do { if (err != MPI_SUCCESS) { if (libMesh::n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::COMM_WORLD,1); exit(1); } } while(0)
+#define mooseCheckMPIErr(err) do { if (err != MPI_SUCCESS) { if (libMesh::global_n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1); exit(1); } } while(0)
 
 #endif /* MOOSEERRORS_H */

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -17,6 +17,9 @@
 
 #include "InputParameters.h"
 
+// libMesh includes
+#include "libmesh/parallel_object.h"
+
 class MooseApp;
 class MooseObject;
 
@@ -26,7 +29,7 @@ InputParameters validParams<MooseObject>();
 /**
  * Every object that can be built by the factory should be derived from this class.
  */
-class MooseObject
+class MooseObject : public libMesh::ParallelObject
 {
 public:
   MooseObject(const std::string & name, InputParameters parameters);

--- a/framework/include/base/SystemBase.h
+++ b/framework/include/base/SystemBase.h
@@ -24,6 +24,7 @@
 #include "SubProblem.h"
 #include "MooseVariableScalar.h"
 #include "MooseException.h"
+
 // libMesh
 #include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
@@ -31,6 +32,7 @@
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/point.h"
+#include "libmesh/parallel_object.h"
 
 class Factory;
 class MooseApp;
@@ -54,7 +56,7 @@ void extraSparsity(SparsityPattern::Graph & sparsity,
  * Base class for a system (of equations)
  *
  */
-class SystemBase
+class SystemBase : public libMesh::ParallelObject
 {
 public:
   SystemBase(SubProblem & subproblem, const std::string & name);
@@ -600,7 +602,7 @@ protected:
     _exception = e;                                                                     \
   }                                                                                     \
   {                                                                                     \
-    Parallel::max<MooseException>(_exception);                                          \
+    _communicator.max<MooseException>(_exception);                                          \
     if (_exception > 0)                                                                 \
       throw _exception;                                                                 \
   }
@@ -611,7 +613,7 @@ protected:
     _exception = e;                                                                     \
   }                                                                                     \
   {                                                                                     \
-    Parallel::max<MooseException>(_exception);                                          \
+    _communicator.max<MooseException>(_exception);                                          \
     if (_exception > 0)                                                                 \
       throw _exception;                                                                 \
   }

--- a/framework/include/userobject/UserObject.h
+++ b/framework/include/userobject/UserObject.h
@@ -88,27 +88,27 @@ public:
   template <typename T>
   void gatherSum(T & value)
   {
-    Parallel::sum(value);
+    _communicator.sum(value);
   }
 
   template <typename T>
   void gatherMax(T & value)
   {
-    Parallel::max(value);
+    _communicator.max(value);
   }
 
   template <typename T>
   void gatherMin(T & value)
   {
-    Parallel::min(value);
+    _communicator.min(value);
   }
 
   template <typename T1, typename T2>
   void gatherProxyValueMax(T1 & value, T2 & proxy)
   {
     unsigned int rank;
-    Parallel::maxloc(value, rank);
-    Parallel::broadcast(proxy, rank);
+    _communicator.maxloc(value, rank);
+    _communicator.broadcast(proxy, rank);
   }
 
 protected:

--- a/framework/include/utils/FormattedTable.h
+++ b/framework/include/utils/FormattedTable.h
@@ -69,6 +69,8 @@ public:
    * a filename is supplied opening and closing of the file is properly handled.  In the
    * screen version of the method, an optional parameters can be passed to print only the last
    * "n" entries.  A value of zero means don't skip any rows
+   *
+   * Note: Only call these from processor 0!
    */
   void printTable(std::ostream & out, unsigned int last_n_entries=0);
   void printTable(std::ostream & out, unsigned int last_n_entries, const MooseEnum & suggested_term_width);
@@ -76,6 +78,8 @@ public:
 
   /**
    * Method for dumping the table to a csv file - opening and closing the file handle is handled
+   *
+   * Note: Only call this on processor 0!
    */
   void printCSV(const std::string & file_name, int interval=1);
 

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -20,6 +20,10 @@
 #include <sstream>
 
 #include "XTermConstants.h"
+
+// libMesh includes
+#include "libmesh/parallel.h"
+
 namespace MooseUtils
 {
   /**
@@ -62,7 +66,7 @@ namespace MooseUtils
    * This function implements a parallel barrier function but writes progress
    * to stdout.
    */
-  void parallelBarrierNotify();
+  void parallelBarrierNotify(const Parallel::Communicator & comm);
 
   /**
    * Function tests if the supplied filename as the desired extension

--- a/framework/src/auxkernels/GapValueAux.C
+++ b/framework/src/auxkernels/GapValueAux.C
@@ -102,7 +102,7 @@ GapValueAux::computeValue()
       msg << "No gap value information found for node ";
       msg << current_node->id();
       msg << " on processor ";
-      msg << libMesh::processor_id();
+      msg << processor_id();
       mooseWarning( msg.str() );
     }
   }

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -273,7 +273,7 @@ Adaptivity::updateErrorVectors()
   for(std::map<std::string, ErrorVector *>::iterator it=_indicator_field_to_error_vector.begin();
       it != _indicator_field_to_error_vector.end();
       ++it)
-    Parallel::sum((std::vector<float>&)*(it->second));
+    _subproblem.comm().sum((std::vector<float>&)*(it->second));
 }
 
 #endif //LIBMESH_ENABLE_AMR

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -34,7 +34,7 @@
 AuxiliarySystem::AuxiliarySystem(FEProblem & subproblem, const std::string & name) :
     SystemTempl<TransientExplicitSystem>(subproblem, name, Moose::VAR_AUXILIARY),
     _mproblem(subproblem),
-    _serialized_solution(*NumericVector<Number>::build().release()),
+    _serialized_solution(*NumericVector<Number>::build(_mproblem.comm()).release()),
     _need_serialized_solution(false)
 {
   _nodal_vars.resize(libMesh::n_threads());

--- a/framework/src/base/ComputeBoundaryInitialConditionThread.C
+++ b/framework/src/base/ComputeBoundaryInitialConditionThread.C
@@ -48,7 +48,7 @@ ComputeBoundaryInitialConditionThread::operator() (const ConstBndNodeRange & ran
     for (std::vector<InitialCondition *>::const_iterator it = ics.begin(); it != ics.end(); ++it)
     {
       InitialCondition * ic = (*it);
-      if (node->processor_id() == libMesh::processor_id())
+      if (node->processor_id() == _fe_problem.processor_id())
       {
         MooseVariable & var = ic->variable();
         var.reinitNode();

--- a/framework/src/base/ComputeElemAuxBcsThread.C
+++ b/framework/src/base/ComputeElemAuxBcsThread.C
@@ -51,7 +51,7 @@ ComputeElemAuxBcsThread::operator() (const ConstBndElemRange & range)
     unsigned short int side = belem->_side;
     BoundaryID boundary_id = belem->_bnd_id;
 
-    if (elem->processor_id() == libMesh::processor_id())
+    if (elem->processor_id() == _problem.processor_id())
     {
       // prepare variables
       for (std::map<std::string, MooseVariable *>::iterator it = _sys._elem_vars[_tid].begin(); it != _sys._elem_vars[_tid].end(); ++it)

--- a/framework/src/base/ComputeNodalAuxBcsThread.C
+++ b/framework/src/base/ComputeNodalAuxBcsThread.C
@@ -64,7 +64,7 @@ ComputeNodalAuxBcsThread::operator() (const ConstBndNodeRange & range)
 //      if (unlikely(_calculate_element_time))
 //        startNodeTiming(node.id());
 
-      if (node->processor_id() == libMesh::processor_id())
+      if (node->processor_id() == _fe_problem.processor_id())
       {
         _fe_problem.reinitNodeFace(node, boundary_id, _tid);
 

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -920,25 +920,11 @@ setSolverDefaults(FEProblem & problem)
 MPI_Comm
 swapLibMeshComm(MPI_Comm new_comm)
 {
-  int ierr;
-
-  MPI_Comm old_comm = libMesh::COMM_WORLD;
-  libMesh::COMM_WORLD = new_comm;
-  libMesh::CommWorld = new_comm;
 #ifdef LIBMESH_HAVE_PETSC
+  MPI_Comm old_comm = PETSC_COMM_WORLD;
   PETSC_COMM_WORLD = new_comm;
-#endif //LIBMESH_HAVE_PETSC
-
-  int pid;
-  ierr = MPI_Comm_rank(new_comm, &pid); mooseCheckMPIErr(ierr);
-
-  int n_procs;
-  ierr = MPI_Comm_size(new_comm, &n_procs); mooseCheckMPIErr(ierr);
-
-  libMesh::libMeshPrivateData::_processor_id = pid;
-  libMesh::libMeshPrivateData::_n_processors = n_procs;
-
   return old_comm;
+#endif //LIBMESH_HAVE_PETSC
 }
 
 void

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -81,8 +81,10 @@ void insertNewline(std::stringstream &oss, std::streampos &begin, std::streampos
 }
 
 MooseApp::MooseApp(const std::string & name, InputParameters parameters):
+    ParallelObject(*parameters.get<Parallel::Communicator *>("_comm")), // Can't call getParam() before pars is set
     _name(name),
     _pars(parameters),
+    _comm(getParam<Parallel::Communicator *>("_comm")),
     _output_position_set(false),
     _start_time_set(false),
     _start_time(0.0),
@@ -121,6 +123,9 @@ MooseApp::~MooseApp()
   delete _sys_info;
   delete _executioner;
   _action_warehouse.clear();
+
+  // Note: Communicator MUST be destroyed last because everything else is using it!
+  delete _comm;
 }
 
 void

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -104,6 +104,7 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters):
     _parallel_mesh_on_command_line(false),
     _recover(false),
     _half_transient(false),
+    _output_warehouse(new OutputWarehouse),
     _alternate_output_warehouse(NULL)
 {
   if (isParamValid("_argc") && isParamValid("_argv"))
@@ -123,6 +124,9 @@ MooseApp::~MooseApp()
   delete _sys_info;
   delete _executioner;
   _action_warehouse.clear();
+
+  // MUST be deleted before _comm is destroyed!
+  delete _output_warehouse;
 
   // Note: Communicator MUST be destroyed last because everything else is using it!
   delete _comm;
@@ -380,7 +384,7 @@ MooseApp::setOutputPosition(Point p)
 
   _output_position_set = true;
   _output_position = p;
-  _output_warehouse.meshChanged();
+  _output_warehouse->meshChanged();
 
   if (_executioner != NULL)
     _executioner->parentOutputPositionChanged();
@@ -396,7 +400,7 @@ OutputWarehouse &
 MooseApp::getOutputWarehouse()
 {
   if (_alternate_output_warehouse == NULL)
-    return _output_warehouse;
+    return *_output_warehouse;
   else
     return *_alternate_output_warehouse;
 }

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -14,6 +14,8 @@
 
 #include "MooseObject.h"
 
+#include "MooseApp.h"
+
 template<>
 InputParameters validParams<MooseObject>()
 {
@@ -23,8 +25,9 @@ InputParameters validParams<MooseObject>()
 
 
 MooseObject::MooseObject(const std::string & name, InputParameters parameters) :
-    _name(name),
-    _pars(parameters),
-    _app(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app"))
+  ParallelObject(*parameters.get<MooseApp *>("_moose_app")), // Can't call getParam before pars is set
+  _name(name),
+  _pars(parameters),
+  _app(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app"))
 {
 }

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -44,6 +44,7 @@ void extraSparsity(SparsityPattern::Graph & sparsity,
 }
 
 SystemBase::SystemBase(SubProblem & subproblem, const std::string & name) :
+    libMesh::ParallelObject(subproblem),
     _subproblem(subproblem),
     _app(subproblem.getMooseApp()),
     _factory(_app.getFactory()),

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -118,7 +118,7 @@ DiracKernel::computeQpJacobian()
 void
 DiracKernel::addPoint(const Elem * elem, Point p)
 {
-  if (!elem || (elem->processor_id() != libMesh::processor_id()))
+  if (!elem || (elem->processor_id() != processor_id()))
     return;
 
   _dirac_kernel_info.addPoint(elem, p);

--- a/framework/src/geomsearch/GeometricSearchData.C
+++ b/framework/src/geomsearch/GeometricSearchData.C
@@ -284,7 +284,7 @@ GeometricSearchData::generateQuadratureNodes(unsigned int slave_id, unsigned int
     unsigned short int side = belem->_side;
     BoundaryID boundary_id = belem->_bnd_id;
 
-    if (elem->processor_id() == libMesh::processor_id())
+    if (elem->processor_id() == _subproblem.processor_id())
     {
       if (boundary_id == (BoundaryID)slave_id)
       {
@@ -371,7 +371,7 @@ GeometricSearchData::updateQuadratureNodes(unsigned int slave_id)
     unsigned short int side = belem->_side;
     BoundaryID boundary_id = belem->_bnd_id;
 
-    if (elem->processor_id() == libMesh::processor_id())
+    if (elem->processor_id() == _subproblem.processor_id())
     {
       if (boundary_id == (BoundaryID)slave_id)
       {

--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -90,7 +90,7 @@ NearestNodeLocator::findNodes()
     // This means there was a user specified inflation... so we can build a BB
     if (inflation.size() > 0)
     {
-      MeshTools::BoundingBox my_box = MeshTools::processor_bounding_box(_mesh, libMesh::processor_id());
+      MeshTools::BoundingBox my_box = MeshTools::processor_bounding_box(_mesh, _mesh.processor_id());
 
       Real distance_x = 0;
       Real distance_y = 0;

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -64,7 +64,7 @@ SlaveNeighborhoodThread::SlaveNeighborhoodThread(SlaveNeighborhoodThread & x, Th
 void
 SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
 {
-  processor_id_type processor_id = libMesh::processor_id();
+  processor_id_type processor_id = _mesh.processor_id();
 
   for (NodeIdRange::const_iterator nd = range.begin() ; nd != range.end(); ++nd)
   {

--- a/framework/src/materials/MaterialPropertyIO.C
+++ b/framework/src/materials/MaterialPropertyIO.C
@@ -44,7 +44,7 @@ MaterialPropertyIO::~MaterialPropertyIO()
 void
 MaterialPropertyIO::write(const std::string & file_name)
 {
-  processor_id_type proc_id = libMesh::processor_id();
+  processor_id_type proc_id = _fe_problem.processor_id();
 
   HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > & props = _material_props.props();
   HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > & propsOld = _material_props.propsOld();
@@ -83,7 +83,7 @@ MaterialPropertyIO::write(const std::string & file_name)
 void
 MaterialPropertyIO::read(const std::string & file_name)
 {
-  processor_id_type proc_id = libMesh::processor_id();
+  processor_id_type proc_id = _fe_problem.processor_id();
 
   HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > & props = _material_props.props();
   HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > & propsOld = _material_props.propsOld();

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -142,7 +142,7 @@ MooseMesh::MooseMesh(const std::string & name, InputParameters parameters) :
 
   if (_use_parallel_mesh)
   {
-    _mesh = new ParallelMesh(dim);
+    _mesh = new ParallelMesh(_communicator, dim);
     if (_partitioner_name != "default" && _partitioner_name != "parmetis")
     {
       _partitioner_name = "parmetis";
@@ -151,7 +151,7 @@ MooseMesh::MooseMesh(const std::string & name, InputParameters parameters) :
   }
   else
   {
-    _mesh = new SerialMesh(dim);
+    _mesh = new SerialMesh(_communicator, dim);
   }
 
   // Set the partitioner
@@ -328,7 +328,7 @@ MooseMesh::prepare(bool force)
                                                     _mesh_subdomains.end());
 
     // Gather them all into an enlarged vector
-    Parallel::allgather(mesh_subdomains_vector);
+    _communicator.allgather(mesh_subdomains_vector);
 
     // Attempt to insert any new IDs into the set (any existing ones will be skipped)
     _mesh_subdomains.insert(mesh_subdomains_vector.begin(),
@@ -339,7 +339,7 @@ MooseMesh::prepare(bool force)
                                                      _mesh_boundary_ids.end());
 
     // Gather them all into an enlarged vector
-    Parallel::allgather(mesh_boundary_ids_vector);
+    _communicator.allgather(mesh_boundary_ids_vector);
 
     // Attempt to insert any new IDs into the set (any existing ones will be skipped)
     _mesh_boundary_ids.insert(mesh_boundary_ids_vector.begin(),
@@ -1510,7 +1510,7 @@ MooseMesh::findAdaptivityQpMaps(const Elem * template_elem,
                                 int child,
                                 int child_side)
 {
-  SerialMesh mesh;
+  SerialMesh mesh(_communicator);
   mesh.skip_partitioning(true);
 
   unsigned int dim = template_elem->dim();

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -133,7 +133,7 @@ MultiApp::init()
   else if (isParamValid("positions_file"))
   {
     // Read the file on the root processor then broadcast it
-    if (libMesh::processor_id() == 0)
+    if (processor_id() == 0)
     {
       std::string positions_file = getParam<FileName>("positions_file");
       MooseUtils::checkFileReadable(positions_file);
@@ -144,11 +144,11 @@ MultiApp::init()
     }
     unsigned int num_values = _positions_vec.size();
 
-    Parallel::broadcast(num_values);
+    _communicator.broadcast(num_values);
 
     _positions_vec.resize(num_values);
 
-    Parallel::broadcast(_positions_vec);
+    _communicator.broadcast(_positions_vec);
 
     mooseAssert(num_values % LIBMESH_DIM == 0, "Wrong number of entries in 'positions'");
 
@@ -362,7 +362,7 @@ MultiApp::createApp(unsigned int i, Real start_time)
 {
   InputParameters app_params = AppFactory::instance().getValidParams(_app_type);
   app_params.set<FEProblem *>("_parent_fep") = _fe_problem;
-  MooseApp * app = AppFactory::instance().create(_app_type, "multi_app", app_params);
+  MooseApp * app = AppFactory::instance().create(_app_type, "multi_app", app_params, _my_comm);
   _apps[i] = app;
 
   std::string input_file = "";

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -417,7 +417,7 @@ TransientMultiApp::computeDT()
     return std::numeric_limits<Real>::max();
 
 
-  Parallel::min(smallest_dt);
+  _communicator.min(smallest_dt);
   return smallest_dt;
 }
 

--- a/framework/src/outputs/CSV.C
+++ b/framework/src/outputs/CSV.C
@@ -49,6 +49,6 @@ CSV::output()
   TableOutput::output();
 
   // Print the table containing all the data to a file
-  if (!_all_data_table.empty())
+  if (!_all_data_table.empty() && processor_id() == 0)
     _all_data_table.printCSV(filename());
 }

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -159,7 +159,7 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
     _file_names.erase(_file_names.begin());
 
     // Get thread and proc information
-    processor_id_type proc_id = libMesh::processor_id();
+    processor_id_type proc_id = processor_id();
 
     // Delete checkpoint files (_mesh.cpr)
     remove(delete_files.checkpoint.c_str());

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -483,7 +483,8 @@ Console::outputScalarVariables()
   {
     std::stringstream oss;
     oss << "\nScalar Variable Values:\n";
-    _scalar_table.printTable(oss, _max_rows, _fit_mode);
+    if(processor_id() == 0)
+      _scalar_table.printTable(oss, _max_rows, _fit_mode);
     oss << std::endl;
 
     if (_write_screen)
@@ -506,8 +507,8 @@ Console::outputSystemInformation()
 
   oss << std::left << "\n"
       << "Parallelism:\n"
-      << std::setw(_field_width) << "  Num Processors: "       << static_cast<std::size_t>(libMesh::n_processors()) << '\n'
-      << std::setw(_field_width) << "  Num Threads: "         << static_cast<std::size_t>(libMesh::n_threads()) << '\n'
+      << std::setw(_field_width) << "  Num Processors: "       << static_cast<std::size_t>(n_processors()) << '\n'
+      << std::setw(_field_width) << "  Num Threads: "         << static_cast<std::size_t>(n_threads()) << '\n'
       << '\n';
 
   MooseMesh & moose_mesh = _problem_ptr->mesh();
@@ -525,7 +526,7 @@ Console::outputSystemInformation()
       << std::setw(_field_width) << "    Local:" << mesh.n_local_elem() << '\n'
       << std::setw(_field_width) << "  Num Subdomains: "       << static_cast<std::size_t>(mesh.n_subdomains()) << '\n'
       << std::setw(_field_width) << "  Num Partitions: "       << static_cast<std::size_t>(mesh.n_partitions()) << '\n';
-  if (libMesh::n_processors() > 1 && moose_mesh.partitionerName() != "")
+  if (n_processors() > 1 && moose_mesh.partitionerName() != "")
     oss << std::setw(_field_width) << "  Partitioner: "       << moose_mesh.partitionerName()
         << (moose_mesh.isPartitionerForced() ? " (forced) " : "")
         << '\n';

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -174,7 +174,7 @@ OversampleOutput::initOversample()
     if (num_vars > 0)
     {
       _mesh_functions[sys_num].resize(num_vars);
-      AutoPtr<NumericVector<Number> > serialized_solution = NumericVector<Number>::build();
+      AutoPtr<NumericVector<Number> > serialized_solution = NumericVector<Number>::build(_communicator);
       serialized_solution->init(source_sys.n_dofs(), false, SERIAL);
 
       // Need to pull down a full copy of this vector on every processor so we can get values in parallel
@@ -211,7 +211,7 @@ OversampleOutput::update()
       System & dest_sys = _es_ptr->get_system(sys_num);
 
       // Update the solution for the oversampled mesh
-      AutoPtr<NumericVector<Number> > serialized_solution = NumericVector<Number>::build();
+      AutoPtr<NumericVector<Number> > serialized_solution = NumericVector<Number>::build(_communicator);
       serialized_solution->init(source_sys.n_dofs(), false, SERIAL);
       source_sys.solution->localize(*serialized_solution);
 

--- a/framework/src/outputs/PetscOutput.C
+++ b/framework/src/outputs/PetscOutput.C
@@ -114,13 +114,13 @@ PetscOutput::timestepSetupInternal()
   if (_output_nonlinear || (_time >= _nonlinear_start_time - _t_tol && _time <= _nonlinear_end_time + _t_tol) )
   {
     PetscErrorCode ierr = SNESMonitorSet(snes, petscNonlinearOutput, this, PETSC_NULL);
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
   }
 
   if (_output_linear || (_time >= _linear_start_time - _t_tol && _time <= _linear_end_time + _t_tol) )
   {
     PetscErrorCode ierr = KSPMonitorSet(ksp, petscLinearOutput, this, PETSC_NULL);
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
   }
 #endif
 }

--- a/framework/src/postprocessors/ElementalVariableValue.C
+++ b/framework/src/postprocessors/ElementalVariableValue.C
@@ -44,7 +44,7 @@ ElementalVariableValue::getValue()
 {
   Real value = 0;
 
-  if (_element && (_element->processor_id() == libMesh::processor_id()))
+  if (_element && (_element->processor_id() == processor_id()))
   {
     _subproblem.prepare(_element, _tid);
     _subproblem.reinitElem(_element, _tid);

--- a/framework/src/postprocessors/NodalVariableValue.C
+++ b/framework/src/postprocessors/NodalVariableValue.C
@@ -47,7 +47,7 @@ NodalVariableValue::getValue()
 {
   Real value = 0;
 
-  if (_node_ptr->processor_id() == libMesh::processor_id())
+  if (_node_ptr->processor_id() == processor_id())
     value = _subproblem.getVariable(_tid, _var_name).getNodalValue(*_node_ptr);
 
   gatherSum(value);

--- a/framework/src/postprocessors/PointValue.C
+++ b/framework/src/postprocessors/PointValue.C
@@ -53,7 +53,7 @@ PointValue::execute()
   // First find the element the hit lands in
   const Elem * elem = (*pl)(_point);
 
-  if (elem && elem->processor_id() == libMesh::processor_id())
+  if (elem && elem->processor_id() == processor_id())
   {
     _subproblem.reinitElemPhys(elem, _point_vec, 0);
 

--- a/framework/src/preconditioners/FiniteDifferencePreconditioner.C
+++ b/framework/src/preconditioners/FiniteDifferencePreconditioner.C
@@ -33,7 +33,7 @@ InputParameters validParams<FiniteDifferencePreconditioner>()
 FiniteDifferencePreconditioner::FiniteDifferencePreconditioner(const std::string & name, InputParameters params) :
     MoosePreconditioner(name, params)
 {
-  if (libMesh::n_processors() > 1)
+  if (n_processors() > 1)
     mooseError("Can't use the Finite Difference Preconditioner in parallel yet!");
 
   NonlinearSystem & nl = _fe_problem.getNonlinearSystem();
@@ -80,4 +80,3 @@ FiniteDifferencePreconditioner::FiniteDifferencePreconditioner(const std::string
 FiniteDifferencePreconditioner::~FiniteDifferencePreconditioner()
 {
 }
-

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -46,7 +46,7 @@ InputParameters validParams<PhysicsBasedPreconditioner>()
 
 PhysicsBasedPreconditioner::PhysicsBasedPreconditioner (const std::string & name, InputParameters params) :
     MoosePreconditioner(name, params),
-    Preconditioner<Number>(libMesh::CommWorld),
+    Preconditioner<Number>(MoosePreconditioner::_communicator),
     _nl(_fe_problem.getNonlinearSystem())
 {
   unsigned int num_systems = _nl.sys().n_vars();
@@ -184,7 +184,7 @@ PhysicsBasedPreconditioner::init ()
     LinearImplicitSystem & u_system = *_systems[system_var];
 
     if (!_preconditioners[system_var])
-      _preconditioners[system_var] = Preconditioner<Number>::build(libMesh::CommWorld);
+      _preconditioners[system_var] = Preconditioner<Number>::build(MoosePreconditioner::_communicator);
 
     // we have to explicitly set the matrix in the preconditioner, because h-adaptivity could have changed it and we have to work with the current one
     Preconditioner<Number> * preconditioner = _preconditioners[system_var];

--- a/framework/src/restart/RestartableDataIO.C
+++ b/framework/src/restart/RestartableDataIO.C
@@ -29,8 +29,8 @@ void
 RestartableDataIO::writeRestartableData(std::string base_file_name, const RestartableDatas & restartable_datas, std::set<std::string> & /*_recoverable_data*/)
 {
   unsigned int n_threads = libMesh::n_threads();
-  processor_id_type n_procs = libMesh::n_processors();
-  processor_id_type proc_id = libMesh::processor_id();
+  processor_id_type n_procs = _fe_problem.n_processors();
+  processor_id_type proc_id = _fe_problem.processor_id();
 
   for(unsigned int tid=0; tid<n_threads; tid++)
   {
@@ -117,8 +117,8 @@ RestartableDataIO::readRestartableData(std::string base_file_name, RestartableDa
   bool recovering = _fe_problem.getMooseApp().isRecovering();
 
   unsigned int n_threads = libMesh::n_threads();
-  processor_id_type n_procs = libMesh::n_processors();
-  processor_id_type proc_id = libMesh::processor_id();
+  processor_id_type n_procs = _fe_problem.n_processors();
+  processor_id_type proc_id = _fe_problem.processor_id();
 
   std::vector<std::string> ignored_data;
 

--- a/framework/src/splits/ContactSplit.C
+++ b/framework/src/splits/ContactSplit.C
@@ -78,19 +78,19 @@ ContactSplit::setup(const std::string& prefix)
       val  =  oval.str();
     }
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
     for (unsigned int j = 0;  j < _contact_master.size(); ++j) {
       std::ostringstream oopt;
       oopt << dmprefix << "contact_" << j;
       opt = oopt.str();
       val = _contact_master[j]+","+_contact_slave[j];
       ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-      CHKERRABORT(libMesh::COMM_WORLD,ierr);
+      CHKERRABORT(_communicator.get(),ierr);
       if (_contact_displaced[j]) {
   opt = opt + "_displaced";
   val = "yes";
   ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-  CHKERRABORT(libMesh::COMM_WORLD,ierr);
+  CHKERRABORT(_communicator.get(),ierr);
       }
     }
   }
@@ -103,19 +103,19 @@ ContactSplit::setup(const std::string& prefix)
       val  =  oval.str();
     }
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
     for (unsigned int j = 0;  j < _uncontact_master.size(); ++j) {
       std::ostringstream oopt;
       oopt << dmprefix << "uncontact_" << j;
       opt = oopt.str();
       val = _uncontact_master[j]+","+_uncontact_slave[j];
       ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-      CHKERRABORT(libMesh::COMM_WORLD,ierr);
+      CHKERRABORT(_communicator.get(),ierr);
       if (_uncontact_displaced[j]) {
   opt = opt + "_displaced";
   val = "yes";
   ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-  CHKERRABORT(libMesh::COMM_WORLD,ierr);
+  CHKERRABORT(_communicator.get(),ierr);
       }
     }
   }

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -70,7 +70,7 @@ Split::setup(const std::string& prefix)
       val += _vars[j];
     }
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
   }
   // block options
   if (_blocks.size()) {
@@ -81,7 +81,7 @@ Split::setup(const std::string& prefix)
       val += _blocks[j];
     }
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
   }
   // side options
   if (_sides.size()) {
@@ -92,7 +92,7 @@ Split::setup(const std::string& prefix)
       val += _sides[j];
     }
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
   }
   // unside options
   if (_unsides.size()) {
@@ -103,7 +103,7 @@ Split::setup(const std::string& prefix)
       val += _unsides[j];
     }
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
   }
 
   if (_splitting.size()) {
@@ -112,28 +112,28 @@ Split::setup(const std::string& prefix)
     opt = prefix+"pc_type";
     val = "fieldsplit";
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
 
     SplittingType dtype = getSplittingType(_splitting_type,val);
     opt = prefix+"pc_fieldsplit_type";
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
 
     if (dtype == SplittingTypeSchur) {
       getSchurType(_schur_type,val); // validation
       opt = prefix+"pc_fieldsplit_schur_fact_type";
       ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-      CHKERRABORT(libMesh::COMM_WORLD,ierr);
+      CHKERRABORT(_communicator.get(),ierr);
 
       getSchurPre(_schur_pre,val); // validation
       opt = prefix+"pc_fieldsplit_schur_precondition";
       ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-      CHKERRABORT(libMesh::COMM_WORLD,ierr);
+      CHKERRABORT(_communicator.get(),ierr);
 
       getSchurAinv(_schur_ainv,val);
       opt = prefix+"mat_schur_complement_ainv_type";
       ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-      CHKERRABORT(libMesh::COMM_WORLD,ierr);
+      CHKERRABORT(_communicator.get(),ierr);
 
     }
     // FIXME: How would we support the user-provided Pmat?
@@ -142,14 +142,14 @@ Split::setup(const std::string& prefix)
     opt = dmprefix+"nfieldsplits";
     {std::ostringstream sval; sval << _splitting.size(); val = sval.str();}
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
     opt = dmprefix+"fieldsplit_names";
     val = "";
     for (unsigned int i = 0; i < _splitting.size(); ++i) {
       if (i) val += ","; val += _splitting[i];
     }
     ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
 
     // Finally, recursively configure the splits contained within this split.
     for (unsigned int i = 0; i < _splitting.size(); ++i) {
@@ -170,7 +170,7 @@ Split::setup(const std::string& prefix)
     }
     std::string opt = prefix+op.substr(1);
     ierr = PetscOptionsSetValue(opt.c_str(),PETSC_NULL);
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
   }
   for (unsigned j = 0; j < _petsc_options_iname.size(); ++j) {
     // Need to prepend the prefix and strip off the leading '-' on the option name.
@@ -182,7 +182,7 @@ Split::setup(const std::string& prefix)
     }
     std::string opt = prefix+op.substr(1);
     ierr = PetscOptionsSetValue(opt.c_str(),_petsc_options_value[j].c_str());
-    CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    CHKERRABORT(_communicator.get(),ierr);
   }
 }
 

--- a/framework/src/timesteppers/SolutionTimeAdaptiveDT.C
+++ b/framework/src/timesteppers/SolutionTimeAdaptiveDT.C
@@ -37,7 +37,7 @@ SolutionTimeAdaptiveDT::SolutionTimeAdaptiveDT(const std::string & name, InputPa
     _sol_time_vs_dt(std::numeric_limits<Real>::max()),
     _adapt_log(getParam<bool>("adapt_log"))
 {
-  if ((_adapt_log) && (libMesh::processor_id() == 0))
+  if ((_adapt_log) && (processor_id() == 0))
   {
     _adaptive_log.open("adaptive_log");
     _adaptive_log<<"Adaptive Times Step Log"<<std::endl;
@@ -92,7 +92,7 @@ SolutionTimeAdaptiveDT::computeDT()
 //  if (_t_step > 1)
   Real local_dt =  _dt + _dt * _percent_change*_direction;
 
-  if ((_adapt_log) && (libMesh::processor_id() == 0))
+  if ((_adapt_log) && (processor_id() == 0))
   {
     Real out_dt = getCurrentDT();
     if (out_dt > _dt_max)

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -98,10 +98,10 @@ MultiAppInterpolationTransfer::execute()
       switch(_interp_type)
       {
         case 0:
-          idi = new InverseDistanceInterpolation<LIBMESH_DIM>(libMesh::CommWorld, _num_points, _power);
+          idi = new InverseDistanceInterpolation<LIBMESH_DIM>(from_sys.comm(), _num_points, _power);
           break;
         case 1:
-          idi = new RadialBasisInterpolation<LIBMESH_DIM>(libMesh::CommWorld, _radius);
+          idi = new RadialBasisInterpolation<LIBMESH_DIM>(from_sys.comm(), _radius);
           break;
         default:
           mooseError("Unknown interpolation type!");
@@ -284,10 +284,10 @@ MultiAppInterpolationTransfer::execute()
       switch(_interp_type)
       {
         case 0:
-          idi = new InverseDistanceInterpolation<LIBMESH_DIM>(libMesh::CommWorld, _num_points, _power);
+          idi = new InverseDistanceInterpolation<LIBMESH_DIM>(to_sys.comm(), _num_points, _power);
           break;
         case 1:
-          idi = new RadialBasisInterpolation<LIBMESH_DIM>(libMesh::CommWorld, _radius);
+          idi = new RadialBasisInterpolation<LIBMESH_DIM>(to_sys.comm(), _radius);
           break;
         default:
           mooseError("Unknown interpolation type!");
@@ -463,4 +463,3 @@ Node * MultiAppInterpolationTransfer::getNearestNode(const Point & p, Real & dis
 
   return nearest;
 }
-

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -69,7 +69,7 @@ MultiAppMeshFunctionTransfer::execute()
       EquationSystems & from_es = from_sys.get_equation_systems();
 
       //Create a serialized version of the solution vector
-      NumericVector<Number> * serialized_solution = NumericVector<Number>::build().release();
+      NumericVector<Number> * serialized_solution = NumericVector<Number>::build(from_sys.comm()).release();
       serialized_solution->init(from_sys.n_dofs(), false, SERIAL);
 
       // Need to pull down a full copy of this vector on every processor so we can get values in parallel
@@ -210,14 +210,14 @@ MultiAppMeshFunctionTransfer::execute()
         EquationSystems & from_es = from_sys.get_equation_systems();
 
         //Create a serialized version of the solution vector
-        NumericVector<Number> * serialized_from_solution = NumericVector<Number>::build().release();
+        NumericVector<Number> * serialized_from_solution = NumericVector<Number>::build(from_sys.comm()).release();
         serialized_from_solution->init(from_sys.n_dofs(), false, SERIAL);
 
         // Need to pull down a full copy of this vector on every processor so we can get values in parallel
         from_sys.solution->localize(*serialized_from_solution);
 
         MeshBase & from_mesh = from_es.get_mesh();
-        MeshTools::BoundingBox app_box = MeshTools::processor_bounding_box(from_mesh, libMesh::processor_id());
+        MeshTools::BoundingBox app_box = MeshTools::processor_bounding_box(from_mesh, from_mesh.processor_id());
         Point app_position = _multi_app->position(i);
 
         MeshFunction from_func(from_es, *serialized_from_solution, from_sys.get_dof_map(), from_var_num);
@@ -297,4 +297,3 @@ MultiAppMeshFunctionTransfer::execute()
 
   Moose::out << "Finished MeshFunctionTransfer " << _name << std::endl;
 }
-

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -69,10 +69,10 @@ MultiAppPostprocessorInterpolationTransfer::execute()
       switch(_interp_type)
       {
         case 0:
-          idi = new InverseDistanceInterpolation<LIBMESH_DIM>(libMesh::CommWorld, _num_points, _power);
+          idi = new InverseDistanceInterpolation<LIBMESH_DIM>(_communicator, _num_points, _power);
           break;
         case 1:
-          idi = new RadialBasisInterpolation<LIBMESH_DIM>(libMesh::CommWorld, _radius);
+          idi = new RadialBasisInterpolation<LIBMESH_DIM>(_communicator, _radius);
           break;
         default:
           mooseError("Unknown interpolation type!");

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -132,7 +132,7 @@ MultiAppProjectionTransfer::assembleL2To(EquationSystems & es, const std::string
   System & from_sys = from_var.sys().system();
   unsigned int from_var_num = from_sys.variable_number(from_var.name());
 
-  NumericVector<Number> * serialized_from_solution = NumericVector<Number>::build().release();
+  NumericVector<Number> * serialized_from_solution = NumericVector<Number>::build(from_sys.comm()).release();
   serialized_from_solution->init(from_sys.n_dofs(), false, SERIAL);
   // Need to pull down a full copy of this vector on every processor so we can get values in parallel
   from_sys.solution->localize(*serialized_from_solution);
@@ -219,14 +219,14 @@ MultiAppProjectionTransfer::assembleL2From(EquationSystems & es, const std::stri
     FEProblem & from_problem = *_multi_app->appProblem(i);
     EquationSystems & from_es = from_problem.es();
     MeshBase & from_mesh = from_es.get_mesh();
-    MeshTools::BoundingBox * app_box = new MeshTools::BoundingBox(MeshTools::processor_bounding_box(from_mesh, libMesh::processor_id()));
+    MeshTools::BoundingBox * app_box = new MeshTools::BoundingBox(MeshTools::processor_bounding_box(from_mesh, from_mesh.processor_id()));
     from_bbs[i] = app_box;
 
     MooseVariable & from_var = from_problem.getVariable(0, _from_var_name);
     System & from_sys = from_var.sys().system();
     unsigned int from_var_num = from_sys.variable_number(from_var.name());
 
-    NumericVector<Number> * serialized_from_solution = NumericVector<Number>::build().release();
+    NumericVector<Number> * serialized_from_solution = NumericVector<Number>::build(from_sys.comm()).release();
     serialized_from_solution->init(from_sys.n_dofs(), false, SERIAL);
     // Need to pull down a full copy of this vector on every processor so we can get values in parallel
     from_sys.solution->localize(*serialized_from_solution);

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -67,7 +67,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::execute()
           // First find the element the hit lands in
           const Elem * elem = (*pl)(multi_app_position);
 
-          if (elem && elem->processor_id() == libMesh::processor_id())
+          if (elem && elem->processor_id() == from_mesh.processor_id())
           {
             from_sub_problem.reinitElemPhys(elem, point_vec, 0);
 
@@ -75,7 +75,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::execute()
             value = from_var.sln()[0];
           }
 
-          libMesh::Parallel::max(value);
+          _communicator.max(value);
         }
 
         if (_multi_app->hasLocalApp(i))

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -67,7 +67,7 @@ MultiAppVariableValueSampleTransfer::execute()
           // First find the element the hit lands in
           const Elem * elem = (*pl)(multi_app_position);
 
-          if (elem && elem->processor_id() == libMesh::processor_id())
+          if (elem && elem->processor_id() == from_mesh.processor_id())
           {
             from_sub_problem.reinitElemPhys(elem, point_vec, 0);
 
@@ -75,7 +75,7 @@ MultiAppVariableValueSampleTransfer::execute()
             value = from_var.sln()[0];
           }
 
-          libMesh::Parallel::max(value);
+          _communicator.max(value);
         }
 
         if (_multi_app->hasLocalApp(i))

--- a/framework/src/userobject/LayeredBase.C
+++ b/framework/src/userobject/LayeredBase.C
@@ -184,8 +184,8 @@ LayeredBase::initialize()
 void
 LayeredBase::finalize()
 {
-  Parallel::sum(_layer_values);
-  Parallel::max(_layer_has_value);
+  _layered_base_subproblem.comm().sum(_layer_values);
+  _layered_base_subproblem.comm().max(_layer_has_value);
 }
 
 void

--- a/framework/src/userobject/NodalNormalsEvaluator.C
+++ b/framework/src/userobject/NodalNormalsEvaluator.C
@@ -37,7 +37,7 @@ NodalNormalsEvaluator::~NodalNormalsEvaluator()
 void
 NodalNormalsEvaluator::execute()
 {
-  if (_current_node->processor_id() == libMesh::processor_id())
+  if (_current_node->processor_id() == processor_id())
   {
     if (_current_node->n_dofs(_aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_x").number()) > 0)
     {

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -224,7 +224,7 @@ SolutionUserObject::readExodusII()
     _system2->get_all_variable_numbers(var_num2);
 
     // Need to pull down a full copy of this vector on every processor so we can get values in parallel
-    _serialized_solution2 = NumericVector<Number>::build().release();
+    _serialized_solution2 = NumericVector<Number>::build(_communicator).release();
     _serialized_solution2->init(_system2->n_dofs(), false, SERIAL);
     _system2->solution->localize(*_serialized_solution2);
 
@@ -318,7 +318,7 @@ SolutionUserObject::initialSetup()
   // Create a libmesh::Mesh object for storing the loaded data.  Since
   // SolutionUserObject is restricted to only work with SerialMesh
   // (see above) we can force the Mesh used here to be a SerialMesh.
-  _mesh = new SerialMesh;
+  _mesh = new SerialMesh(_communicator);
 
   // ExodusII mesh file supplied
   if (MooseUtils::hasExtension(_mesh_file, "e"))
@@ -339,7 +339,7 @@ SolutionUserObject::initialSetup()
     mooseError("In SolutionUserObject, invalid file type (only .xda and .e supported)");
 
   // Intilize the serial solution vector
-  _serialized_solution = NumericVector<Number>::build().release();
+  _serialized_solution = NumericVector<Number>::build(_communicator).release();
   _serialized_solution->init(_system->n_dofs(), false, SERIAL);
 
   // Pull down a full copy of this vector on every processor so we can get values in parallel

--- a/framework/src/userobject/VerifyElementUniqueID.C
+++ b/framework/src/userobject/VerifyElementUniqueID.C
@@ -60,7 +60,7 @@ VerifyElementUniqueID::finalize()
 {
   // On Parallel Mesh we have to look at all the ids over all the processors
   if (_subproblem.mesh().isParallelMesh())
-    Parallel::allgather(_all_ids);
+    _communicator.allgather(_all_ids);
 
   std::sort(_all_ids.begin(), _all_ids.end());
   std::vector<dof_id_type>::iterator it_end = std::unique(_all_ids.begin(), _all_ids.end());

--- a/framework/src/userobject/VerifyNodalUniqueID.C
+++ b/framework/src/userobject/VerifyNodalUniqueID.C
@@ -60,15 +60,10 @@ VerifyNodalUniqueID::finalize()
 {
   // On Parallel Mesh we have to look at all the ids over all the processors
   if (_subproblem.mesh().isParallelMesh())
-    Parallel::allgather(_all_ids);
+    _communicator.allgather(_all_ids);
 
   std::sort(_all_ids.begin(), _all_ids.end());
   std::vector<dof_id_type>::iterator it_end = std::unique(_all_ids.begin(), _all_ids.end());
   if (it_end != _all_ids.end())
     mooseError("Duplicate unique_ids found!");
 }
-
-
-
-
-

--- a/framework/src/utils/FormattedTable.C
+++ b/framework/src/utils/FormattedTable.C
@@ -141,10 +141,6 @@ FormattedTable::printNoDataRow(char intersect_char, char fill_char,
 void
 FormattedTable::printTable(const std::string & file_name)
 {
-  // We only want to do file I/O on processor zero
-  if (libMesh::processor_id() != 0)
-    return;
-
   if (!_stream_open)
   {
     _output_file.open(file_name.c_str(), std::ios::trunc);
@@ -261,10 +257,6 @@ FormattedTable::printCSV(const std::string & file_name, int interval)
 {
   std::map<Real, std::map<std::string, Real> >::iterator i;
   std::set<std::string>::iterator header;
-
-  // We only want to do file I/O on processor zero
-  if (libMesh::processor_id() != 0)
-    return;
 
   if (!_stream_open)
   {

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -116,27 +116,27 @@ checkFileWriteable(const std::string & filename)
 }
 
 void
-parallelBarrierNotify()
+parallelBarrierNotify(const Parallel::Communicator & comm)
 {
   processor_id_type slave_processor_id;
 
-  if (libMesh::processor_id() == 0)
+  if (comm.rank() == 0)
   {
     // The master process is already through, so report it
-    Moose::out << "Jobs complete: 1/" << libMesh::n_processors() << "\r" << std::flush;
-    for (unsigned int i=2; i<=libMesh::n_processors(); ++i)
+    Moose::out << "Jobs complete: 1/" << comm.size() << "\r" << std::flush;
+    for (unsigned int i=2; i<=comm.size(); ++i)
     {
-      Parallel::receive(MPI_ANY_SOURCE, slave_processor_id);
-      Moose::out << "Jobs complete: " << i << "/" << libMesh::n_processors() << (i == libMesh::n_processors() ? "\n" : "\r") << std::flush;
+      comm.receive(MPI_ANY_SOURCE, slave_processor_id);
+      Moose::out << "Jobs complete: " << i << "/" << comm.size() << (i == comm.size() ? "\n" : "\r") << std::flush;
     }
   }
   else
   {
-    slave_processor_id = libMesh::processor_id();
-    Parallel::send(0, slave_processor_id);
+    slave_processor_id = comm.rank();
+    comm.send(0, slave_processor_id);
   }
 
-  Parallel::barrier();
+  comm.barrier();
 }
 
 bool

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1103,7 +1103,7 @@ static PetscErrorCode  DMMooseGetMeshBlocks_Private(DM dm, std::set<subdomain_id
   const MeshBase& mesh = dmm->nl->sys().get_mesh();
   /* The following effectively is a verbatim copy of MeshBase::n_subdomains(). */
   // This requires an inspection on every processor
-  parallel_only();
+  libmesh_parallel_only(mesh.comm());
   MeshBase::const_element_iterator       el  = mesh.active_elements_begin();
   const MeshBase::const_element_iterator end = mesh.active_elements_end();
   for (; el!=end; ++el)

--- a/framework/src/utils/RandomData.C
+++ b/framework/src/utils/RandomData.C
@@ -86,8 +86,8 @@ RandomData::updateGenerators()
   if (_rd_mesh.isParallelMesh())
   {
     unsigned int parallel_seed;
-    for (processor_id_type proc_id = 0; proc_id < libMesh::n_processors(); ++proc_id)
-      if (proc_id == libMesh::processor_id())
+    for (processor_id_type proc_id = 0; proc_id < _rd_problem.n_processors(); ++proc_id)
+      if (proc_id == _rd_problem.processor_id())
         parallel_seed = _generator.randl(MASTER);
       else
         _generator.randl(MASTER); // Generate but throw away numbers that aren't mine
@@ -125,4 +125,3 @@ RandomData::updateGenerators()
   }
 
 }
-

--- a/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
+++ b/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
@@ -37,7 +37,7 @@ InputParameters validParams<ChemicalReactionsApp>()
 ChemicalReactionsApp::ChemicalReactionsApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   ChemicalReactionsApp::registerObjects(_factory);

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -402,7 +402,7 @@ FrictionalContactProblem::enforceRateConstraint(NumericVector<Number>& vec_solut
 
     vec_solution.close();
 
-    Parallel::max(updatedSolution);
+    _communicator.max(updatedSolution);
 
     if (updatedSolution)
     {
@@ -495,7 +495,7 @@ FrictionalContactProblem::calculateSlip(const NumericVector<Number>& ghosted_sol
             PenetrationInfo & info = *pen_loc._penetration_info[slave_node_num];
             const Node * node = info._node;
 
-            if (node->processor_id() == libMesh::processor_id())
+            if (node->processor_id() == processor_id())
             {
 
               std::set<unsigned int>::iterator hpit( has_penetrated.find( slave_node_num ) );
@@ -557,14 +557,14 @@ FrictionalContactProblem::calculateSlip(const NumericVector<Number>& ghosted_sol
       }
     }
 
-    Parallel::sum(_num_contact_nodes);
-    Parallel::sum(_num_slipping);
-    Parallel::sum(_num_slipped_too_far);
-    Parallel::sum(_slip_residual);
+    _communicator.sum(_num_contact_nodes);
+    _communicator.sum(_num_slipping);
+    _communicator.sum(_num_slipped_too_far);
+    _communicator.sum(_slip_residual);
     _slip_residual = std::sqrt(_slip_residual);
-    Parallel::sum(_it_slip_norm);
+    _communicator.sum(_it_slip_norm);
     _it_slip_norm = std::sqrt(_it_slip_norm);
-    Parallel::sum(_inc_slip_norm);
+    _communicator.sum(_inc_slip_norm);
     _inc_slip_norm = std::sqrt(_inc_slip_norm);
     if (_num_slipping > 0)
       updatedSolution = true;
@@ -730,7 +730,7 @@ FrictionalContactProblem::applySlip(NumericVector<Number>& vec_solution,
   aux_solution.close();
   vec_solution.close();
   unsigned int num_slipping_nodes = iterative_slip.size();
-  Parallel::sum(num_slipping_nodes);
+  _communicator.sum(num_slipping_nodes);
   if (num_slipping_nodes > 0)
   {
     ghosted_solution = vec_solution;

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -86,7 +86,7 @@ SlaveConstraint::addPoints()
     const Node * node = pinfo->_node;
 
     std::set<unsigned int>::iterator hpit( has_penetrated.find( slave_node_num ) );
-    if(hpit != has_penetrated.end() && node->processor_id() == libMesh::processor_id())
+    if(hpit != has_penetrated.end() && node->processor_id() == processor_id())
     {
       // Find an element that is connected to this node that and that is also on this processor
 
@@ -97,7 +97,7 @@ SlaveConstraint::addPoints()
       for(unsigned int i=0; i<connected_elems.size() && !elem; ++i)
       {
         Elem * cur_elem = _mesh.elem(connected_elems[i]);
-        if(cur_elem->processor_id() == libMesh::processor_id())
+        if(cur_elem->processor_id() == processor_id())
           elem = cur_elem;
       }
 

--- a/modules/contact/src/SparsityBasedContactConstraint.C
+++ b/modules/contact/src/SparsityBasedContactConstraint.C
@@ -42,7 +42,7 @@ SparsityBasedContactConstraint::getConnectedDofIndices()
   PetscErrorCode ierr;
   PetscInt ncols;
   const PetscInt *cols;
-  ierr = MatGetRow(jac,_var.nodalDofIndex(),&ncols,&cols,PETSC_NULL);CHKERRABORT(libMesh::COMM_WORLD, ierr);
+  ierr = MatGetRow(jac,_var.nodalDofIndex(),&ncols,&cols,PETSC_NULL);CHKERRABORT(_communicator.get(), ierr);
   bool debug = false;
   if(debug) {
     libMesh::out << "_connected_dof_indices: adding " << ncols << " dofs from Jacobian row[" << _var.nodalDofIndex() << "] = [";
@@ -56,9 +56,8 @@ SparsityBasedContactConstraint::getConnectedDofIndices()
   if (debug) {
     libMesh::out << "]\n";
   }
-  ierr = MatRestoreRow(jac,_var.nodalDofIndex(),&ncols,&cols,PETSC_NULL);CHKERRABORT(libMesh::COMM_WORLD, ierr);
+  ierr = MatRestoreRow(jac,_var.nodalDofIndex(),&ncols,&cols,PETSC_NULL);CHKERRABORT(_communicator.get(), ierr);
 #else
   NodeFaceConstraint::getConnectedDofIndices();
 #endif
 }
-

--- a/modules/contact/src/base/ContactApp.C
+++ b/modules/contact/src/base/ContactApp.C
@@ -31,7 +31,7 @@ InputParameters validParams<ContactApp>()
 ContactApp::ContactApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   ContactApp::registerObjects(_factory);

--- a/modules/fluid_mass_energy_balance/src/base/FluidMassEnergyBalanceApp.C
+++ b/modules/fluid_mass_energy_balance/src/base/FluidMassEnergyBalanceApp.C
@@ -37,7 +37,7 @@ InputParameters validParams<FluidMassEnergyBalanceApp>()
 FluidMassEnergyBalanceApp::FluidMassEnergyBalanceApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   FluidMassEnergyBalanceApp::registerObjects(_factory);

--- a/modules/heat_conduction/src/GapConductance.C
+++ b/modules/heat_conduction/src/GapConductance.C
@@ -241,7 +241,7 @@ GapConductance::computeGapValues()
         msg << "No gap value information found for node ";
         msg << qnode->id();
         msg << " on processor ";
-        msg << libMesh::processor_id();
+        msg << processor_id();
         mooseWarning( msg.str() );
       }
     }

--- a/modules/heat_conduction/src/GapHeatTransfer.C
+++ b/modules/heat_conduction/src/GapHeatTransfer.C
@@ -251,7 +251,7 @@ GapHeatTransfer::computeGapValues()
         msg << "No gap value information found for node ";
         msg << qnode->id();
         msg << " on processor ";
-        msg << libMesh::processor_id();
+        msg << processor_id();
         mooseWarning( msg.str() );
       }
     }

--- a/modules/heat_conduction/src/base/HeatConductionApp.C
+++ b/modules/heat_conduction/src/base/HeatConductionApp.C
@@ -34,7 +34,7 @@ InputParameters validParams<HeatConductionApp>()
 HeatConductionApp::HeatConductionApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   HeatConductionApp::registerObjects(_factory);

--- a/modules/linear_elasticity/src/base/LinearElasticityApp.C
+++ b/modules/linear_elasticity/src/base/LinearElasticityApp.C
@@ -20,7 +20,7 @@ InputParameters validParams<LinearElasticityApp>()
 LinearElasticityApp::LinearElasticityApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   LinearElasticityApp::registerObjects(_factory);

--- a/modules/misc/src/base/MiscApp.C
+++ b/modules/misc/src/base/MiscApp.C
@@ -27,7 +27,7 @@ InputParameters validParams<MiscApp>()
 MiscApp::MiscApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   MiscApp::registerObjects(_factory);

--- a/modules/navier_stokes/src/base/NavierStokesApp.C
+++ b/modules/navier_stokes/src/base/NavierStokesApp.C
@@ -82,7 +82,7 @@ InputParameters validParams<NavierStokesApp>()
 NavierStokesApp::NavierStokesApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   NavierStokesApp::registerObjects(_factory);

--- a/modules/navier_stokes/src/postprocessors/INSExplicitTimestepSelector.C
+++ b/modules/navier_stokes/src/postprocessors/INSExplicitTimestepSelector.C
@@ -89,7 +89,7 @@ INSExplicitTimestepSelector::execute()
 Real
 INSExplicitTimestepSelector::getValue()
 {
-  Parallel::min(_value);
+  _communicator.min(_value);
   return _value;
 }
 

--- a/modules/phase_field/include/postprocessors/NodalFloodCount.h
+++ b/modules/phase_field/include/postprocessors/NodalFloodCount.h
@@ -281,7 +281,7 @@ template <class T>
 void
 NodalFloodCount::writeCSVFile(const std::string file_name, const std::vector<T> data)
 {
-  if (libMesh::processor_id() == 0)
+  if (processor_id() == 0)
   {
     std::map<std::string, std::ofstream *>::iterator handle_it = _file_handles.find(file_name);
     if (handle_it == _file_handles.end())

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -50,7 +50,7 @@ InputParameters validParams<PhaseFieldApp>()
 PhaseFieldApp::PhaseFieldApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   PhaseFieldApp::registerObjects(_factory);

--- a/modules/phase_field/src/postprocessors/NodalFloodCount.C
+++ b/modules/phase_field/src/postprocessors/NodalFloodCount.C
@@ -158,7 +158,7 @@ NodalFloodCount::finalize()
 {
   // Exchange data in parallel
   pack(_packed_data);
-  Parallel::allgather(_packed_data, false);
+  _communicator.allgather(_packed_data, false);
   unpack(_packed_data);
 
   mergeSets();
@@ -184,7 +184,7 @@ NodalFloodCount::finalize()
   if (_track_memory)
   {
     _bytes_used += calculateUsage();
-    Parallel::sum(_bytes_used);
+    _communicator.sum(_bytes_used);
     formatBytesUsed();
   }
 }
@@ -603,7 +603,7 @@ NodalFloodCount::calculateBubbleVolumes()
   for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
     _all_bubble_volumes.insert(_all_bubble_volumes.end(), bubble_volumes[map_num].begin(), bubble_volumes[map_num].end());
 
-  Parallel::sum(_all_bubble_volumes); //do all the sums!
+  _communicator.sum(_all_bubble_volumes); //do all the sums!
 
   std::sort(_all_bubble_volumes.begin(), _all_bubble_volumes.end(), std::greater<Real>());
 

--- a/modules/richards/src/base/RichardsApp.C
+++ b/modules/richards/src/base/RichardsApp.C
@@ -96,7 +96,7 @@ InputParameters validParams<RichardsApp>()
 RichardsApp::RichardsApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   RichardsApp::registerObjects(_factory);

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -69,7 +69,7 @@ InputParameters validParams<SolidMechanicsApp>()
 SolidMechanicsApp::SolidMechanicsApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   SolidMechanicsApp::registerObjects(_factory);

--- a/modules/solid_mechanics/src/userobjects/MaterialTensorOnLine.C
+++ b/modules/solid_mechanics/src/userobjects/MaterialTensorOnLine.C
@@ -34,7 +34,7 @@ MaterialTensorOnLine :: MaterialTensorOnLine(const std::string & name, InputPara
   _elem_line_id(coupledValue("element_line_id"))
 {
 
-  if (!_stream_open && libMesh::processor_id() == 0)
+  if (!_stream_open && processor_id() == 0)
   {
     _output_file.open(_file_name.c_str(), std::ios::trunc | std::ios::out);
     _stream_open = true;
@@ -44,7 +44,7 @@ MaterialTensorOnLine :: MaterialTensorOnLine(const std::string & name, InputPara
 
 MaterialTensorOnLine::~MaterialTensorOnLine()
 {
-  if (_stream_open && libMesh::processor_id() == 0)
+  if (_stream_open && processor_id() == 0)
   {
     _output_file.close();
     _stream_open = false;
@@ -119,10 +119,10 @@ void
 MaterialTensorOnLine::finalize()
 {
 
-    Parallel::set_union(_dist);
-    Parallel::set_union(_value);
+    _communicator.set_union(_dist);
+    _communicator.set_union(_value);
 
-   if (libMesh::processor_id() == 0)
+   if (processor_id() == 0)
    {
      std::vector<std::pair<Real, Real> > table;
 //     std::map<unsigned int, Real>::iterator id(_dist.begin());
@@ -149,4 +149,3 @@ MaterialTensorOnLine::finalize()
    }
 
 }
-

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -27,7 +27,7 @@ InputParameters validParams<TensorMechanicsApp>()
 TensorMechanicsApp::TensorMechanicsApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   TensorMechanicsApp::registerObjects(_factory);

--- a/modules/water_steam_eos/src/base/WaterSteamEOSApp.C
+++ b/modules/water_steam_eos/src/base/WaterSteamEOSApp.C
@@ -12,7 +12,7 @@ InputParameters validParams<WaterSteamEOSApp>()
 WaterSteamEOSApp::WaterSteamEOSApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   WaterSteamEOSApp::registerObjects(_factory);

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -26,13 +26,12 @@ cd build
 
 ../configure --with-methods="${METHODS}" \
              --prefix=$LIBMESH_DIR \
-             --enable-default-comm-world \
              --enable-silent-rules \
              --enable-unique-id \
              --disable-warnings \
              --enable-openmp $*
 
-# let LIBMESH_JOBS be either MOOSE_JOBS, or 1 if MOOSE_JOBS 
+# let LIBMESH_JOBS be either MOOSE_JOBS, or 1 if MOOSE_JOBS
 # is not set (not using our package). Make will then build
 # with either JOBS if set, or LIBMESH_JOBS.
 LIBMESH_JOBS=${MOOSE_JOBS:-1}

--- a/test/src/auxkernels/SumNodalValuesAux.C
+++ b/test/src/auxkernels/SumNodalValuesAux.C
@@ -40,7 +40,7 @@ SumNodalValuesAux::compute()
   for (_i = 0; _i < _var.order(); ++_i)
   {
     Real value = computeValue();
-    libMesh::Parallel::sum(value);
+    _communicator.sum(value);
     _var.setValue(_i, value);                  // update variable data, which is referenced by other kernels, so the value is up-to-date
   }
 }

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -187,7 +187,7 @@ InputParameters validParams<MooseTestApp>()
 MooseTestApp::MooseTestApp(const std::string & name, InputParameters parameters):
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   MooseTestApp::registerObjects(_factory);

--- a/test/src/userobjects/RandomElementalUserObject.C
+++ b/test/src/userobjects/RandomElementalUserObject.C
@@ -54,7 +54,7 @@ RandomElementalUserObject::execute()
 void
 RandomElementalUserObject::finalize()
 {
-  Parallel::set_union(_random_data);
+  _communicator.set_union(_random_data);
 }
 
 void

--- a/test/src/userobjects/RandomHitSolutionModifier.C
+++ b/test/src/userobjects/RandomHitSolutionModifier.C
@@ -51,7 +51,7 @@ RandomHitSolutionModifier::execute()
     // First find the element the hit lands in
     const Elem * elem = (*pl)(hit);
 
-    if (elem && (elem->processor_id() == libMesh::processor_id()))
+    if (elem && (elem->processor_id() == processor_id()))
     {
       Real closest_distance = std::numeric_limits<unsigned int>::max();
       Node * closest_node = NULL;

--- a/test/src/userobjects/TrackDiracFront.C
+++ b/test/src/userobjects/TrackDiracFront.C
@@ -71,7 +71,7 @@ TrackDiracFront::localElementConnectedToCurrentNode()
 
   const std::vector< unsigned int > & connected_elems = _node_to_elem_map.at(id);
 
-  unsigned int pid = libMesh::processor_id(); // This processor id
+  unsigned int pid = processor_id(); // This processor id
 
   // Look through all of the elements connected to this node and find one owned by the local processor
   for(unsigned int i=0; i<connected_elems.size(); i++)
@@ -84,4 +84,3 @@ TrackDiracFront::localElementConnectedToCurrentNode()
 
   mooseError("Unable to locate a local element connected to this node!");
 }
-

--- a/unit/src/MooseUnitApp.C
+++ b/unit/src/MooseUnitApp.C
@@ -11,7 +11,7 @@ InputParameters validParams<MooseUnitApp>()
 MooseUnitApp::MooseUnitApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  srand(libMesh::processor_id());
+  srand(processor_id());
 
   Moose::registerObjects(_factory);
   Moose::associateSyntax(_syntax, _action_factory);
@@ -20,4 +20,3 @@ MooseUnitApp::MooseUnitApp(const std::string & name, InputParameters parameters)
 MooseUnitApp::~MooseUnitApp()
 {
 }
-


### PR DESCRIPTION
Don't merge just yet as I need to go through all the apps (which I'll do tomorrow) and make them compatible.

This PR allows MOOSE to build without needing `--enable-default-comm-world` with libMesh.  This also simplifies some of the gymnastics required for MultiApp related stuff to work.

The basic idea was to have `MooseObject` inherit from `libMesh::ParallelObject`.  This means that every object throughout MOOSE now has a `_communicator` member variable and also gains `n_processors()` and `processor_id()`.  This way we can create objects that are working on subset communicators and they will automatically call the correct MPI functions.

refs #2943 #2941
