### PR TITLE
Calculate gradient normal direction wrt PBCs.

### DIFF
--- a/modules/phase_field/include/ics/PolycrystalReducedIC.h
+++ b/modules/phase_field/include/ics/PolycrystalReducedIC.h
@@ -58,7 +58,6 @@ public:
   Point _top_right;
   Point _range;
 
-
   std::vector<Point> _centerpoints;
   std::vector<Real> _assigned_op;
 };

--- a/modules/phase_field/src/action/BicrystalBoundingBoxICAction.C
+++ b/modules/phase_field/src/action/BicrystalBoundingBoxICAction.C
@@ -21,8 +21,8 @@ InputParameters validParams<BicrystalBoundingBoxICAction>()
 {
   InputParameters params = validParams<Action>();
 
-  params.addRequiredParam<std::string>("var_name_base","specifies the base name of the variables");
-  params.addRequiredParam<unsigned int>("crys_num","Number of grains, should be 2");
+  params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
+  params.addRequiredParam<unsigned int>("crys_num", "Number of grains, should be 2");
   params.addRequiredParam<Real>("x1", "The x coordinate of the lower left-hand corner of the box");
   params.addRequiredParam<Real>("y1", "The y coordinate of the lower left-hand corner of the box");
   params.addParam<Real>("z1", 0.0, "The z coordinate of the lower left-hand corner of the box");

--- a/modules/phase_field/src/auxkernels/NodalFloodCountAux.C
+++ b/modules/phase_field/src/auxkernels/NodalFloodCountAux.C
@@ -62,7 +62,7 @@ NodalFloodCountAux::computeValue()
       size_t size=0;
       std::vector<std::vector<std::pair<unsigned int, unsigned int> > > values = _flood_counter.getElementalValues(_current_elem->id());
 
-      for (unsigned int i=0; i<values.size(); ++i)
+      for (unsigned int i = 0; i < values.size(); ++i)
         size += values[i].size();
       return size;
     }

--- a/modules/phase_field/src/ics/HexPolycrystalIC.C
+++ b/modules/phase_field/src/ics/HexPolycrystalIC.C
@@ -97,7 +97,7 @@ HexPolycrystalIC::initialSetup()
         _centerpoints[grain](i) = _bottom_left(i);
     }
 
-  for (unsigned int grain=0; grain<_grain_num; grain++) //Assign grains to specific order parameters in a way that maximized the distance
+  for (unsigned int grain = 0; grain < _grain_num; grain++) //Assign grains to specific order parameters in a way that maximized the distance
   {
     std::vector<int> min_op_ind;
     std::vector<Real> min_op_dist;
@@ -107,7 +107,7 @@ HexPolycrystalIC::initialSetup()
     if (grain >= _op_num)
     {
       std::fill(min_op_dist.begin() , min_op_dist.end(), _range.size());
-      for (unsigned int i=0; i<grain; i++)
+      for (unsigned int i = 0; i < grain; i++)
       {
         Real dist =  _mesh.minPeriodicDistance(_var.number(), _centerpoints[grain], _centerpoints[i]);
         if (min_op_dist[_assigned_op[i]] > dist)

--- a/modules/phase_field/src/ics/LatticeSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/LatticeSmoothCircleIC.C
@@ -31,7 +31,7 @@ LatticeSmoothCircleIC::initialSetup()
   /*std::vector<unsigned int> circles_per_side;
   circles_per_side.resize(3);
 
-  for (unsigned int i = 0; i<3; ++i)
+  for (unsigned int i = 0; i < 3; ++i)
   circles_per_side[i] = _circles_per_side;*/
 
   //Moose::out << "1: "<< _circles_per_side[0] << " 2: "<< _circles_per_side[1] << " 3: " << _circles_per_side[2] << std::endl;
@@ -87,7 +87,7 @@ LatticeSmoothCircleIC::initialSetup()
          //Vary circle radius
         _bubradi[cnt] = _radius*(1.0 + (1.0 - 2.0*MooseRandom::rand())*_radius_variation);
 
-        if (_bubradi[cnt]<0.0) _bubradi[cnt] = 0.0;
+        if (_bubradi[cnt] < 0.0) _bubradi[cnt] = 0.0;
 
         Real xx = x_sep/2.0 + i*x_sep;
         Real yy = y_sep/2.0 + j*y_sep;

--- a/modules/phase_field/src/ics/PolycrystalReducedIC.C
+++ b/modules/phase_field/src/ics/PolycrystalReducedIC.C
@@ -64,19 +64,19 @@ PolycrystalReducedIC::initialSetup()
   if (_cody_test)
   {
     holder.resize(_grain_num);
-    holder[0] = Point(0.2,0.85,0.0);
-    holder[1] = Point(0.50,0.85,0.0);
-    holder[2] = Point(0.8,0.85,0.0);
+    holder[0] = Point(0.2, 0.85, 0.0);
+    holder[1] = Point(0.5, 0.85, 0.0);
+    holder[2] = Point(0.8, 0.85, 0.0);
 
-    holder[3] = Point(0.2,0.5,0.0);
-    holder[4] = Point(0.50,0.5,0.0);
-    holder[5] = Point(0.8,0.5,0.0);
+    holder[3] = Point(0.2, 0.5, 0.0);
+    holder[4] = Point(0.5, 0.5, 0.0);
+    holder[5] = Point(0.8, 0.5, 0.0);
 
-    holder[6] = Point(0.1,0.1,0.0);
-    holder[7] = Point(0.50,0.05,0.0);
-    holder[8] = Point(0.9,0.1,0.0);
+    holder[6] = Point(0.1, 0.1, 0.0);
+    holder[7] = Point(0.5, 0.05, 0.0);
+    holder[8] = Point(0.9, 0.1, 0.0);
 
-    holder[9] = Point(0.50,0.1,0.0);
+    holder[9] = Point(0.5, 0.1, 0.0);
   }
 
   //Assign actual center point positions
@@ -96,16 +96,16 @@ PolycrystalReducedIC::initialSetup()
   //Assign grains to each order parameter
   if (_cody_test)
   {
-    _assigned_op[0] = 0;
-    _assigned_op[1] = 0;
-    _assigned_op[2] = 0;
-    _assigned_op[3] = 1;
-    _assigned_op[4] = 1;
-    _assigned_op[5] = 1;
-    _assigned_op[6] = 2;
-    _assigned_op[7] = 3;
-    _assigned_op[8] = 2;
-    _assigned_op[9] = 4;
+    _assigned_op[0] = 0.0;
+    _assigned_op[1] = 0.0;
+    _assigned_op[2] = 0.0;
+    _assigned_op[3] = 1.0;
+    _assigned_op[4] = 1.0;
+    _assigned_op[5] = 1.0;
+    _assigned_op[6] = 2.0;
+    _assigned_op[7] = 3.0;
+    _assigned_op[8] = 2.0;
+    _assigned_op[9] = 4.0;
   }
   else
   {
@@ -163,7 +163,7 @@ PolycrystalReducedIC::value(const Point & p)
   Real val = 0.0;
   unsigned int min_index = _grain_num + 100;
   //Loops through all of the grain centers and finds the center that is closest to the point p
-  for (unsigned int grain=0; grain<_grain_num; grain++)
+  for (unsigned int grain = 0; grain < _grain_num; grain++)
   {
     Real distance = _mesh.minPeriodicDistance(_var.number(), _centerpoints[grain], p);
 

--- a/modules/phase_field/src/ics/RndBoundingBoxIC.C
+++ b/modules/phase_field/src/ics/RndBoundingBoxIC.C
@@ -36,8 +36,8 @@ RndBoundingBoxIC::RndBoundingBoxIC(const std::string & name,
     _mn_outvalue(parameters.get<Real>("mn_outvalue")),
     _range_invalue(_mx_invalue - _mn_invalue),
     _range_outvalue(_mx_outvalue - _mn_outvalue),
-    _bottom_left(_x1,_y1,_z1),
-    _top_right(_x2,_y2,_z2)
+    _bottom_left(_x1, _y1, _z1),
+    _top_right(_x2, _y2, _z2)
 {
   mooseAssert(_range_invalue >= 0.0, "Inside Min > Inside Max for RandomIC!");
   mooseAssert(_range_outvalue >= 0.0, "Outside Min > Outside Max for RandomIC!");

--- a/modules/phase_field/src/ics/RndSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/RndSmoothCircleIC.C
@@ -20,7 +20,7 @@ InputParameters validParams<RndSmoothCircleIC>()
 }
 
 RndSmoothCircleIC::RndSmoothCircleIC(const std::string & name,
-                               InputParameters parameters) :
+                                     InputParameters parameters) :
     InitialCondition(name, parameters),
     _x1(parameters.get<Real>("x1")),
     _y1(parameters.get<Real>("y1")),
@@ -32,7 +32,7 @@ RndSmoothCircleIC::RndSmoothCircleIC(const std::string & name,
     _range_invalue(_mx_invalue - _mn_invalue),
     _range_outvalue(_mx_outvalue - _mn_outvalue),
     _radius(parameters.get<Real>("radius")),
-    _center(_x1,_y1,_z1)
+    _center(_x1, _y1, _z1)
 {
   mooseAssert(_range_invalue >= 0.0, "Inside Min > Max for RndSmoothCircleIC!");
   mooseAssert(_range_outvalue >= 0.0, "Outside Min > Max for RndSmoothCircleIC!");

--- a/modules/phase_field/src/ics/SmoothCircleIC.C
+++ b/modules/phase_field/src/ics/SmoothCircleIC.C
@@ -90,12 +90,10 @@ SmoothCircleIC::gradient(const Point & p)
     Real Dint_posDr = 1.0 / _int_width;
     DvalueDr = Dint_posDr * (_invalue - _outvalue) * (-std::sin(int_pos * libMesh::pi) * libMesh::pi) / 2.0;
   }
+
   //Set gradient over the smooth interface
-  if (rad != 0.0) {
-    return Gradient((p(0) - _center(0)) * DvalueDr / rad,
-                    (p(1) - _center(1)) * DvalueDr / rad,
-                    (p(2) - _center(2)) * DvalueDr / rad);
-  }
+  if (rad != 0.0)
+    return _mesh.minPeriodicVector(_var.number(), _center, p) * (DvalueDr / rad);
   else
     return Gradient(0.0, 0.0, 0.0);
 }

--- a/modules/phase_field/src/ics/SmoothCircleIC.C
+++ b/modules/phase_field/src/ics/SmoothCircleIC.C
@@ -59,7 +59,7 @@ SmoothCircleIC::value(const Point & p)
   else if (rad < _radius + _int_width/2.0) //Smooth interface
   {
     Real int_pos = (rad - _radius + _int_width/2.0)/_int_width;
-    value = _outvalue + (_invalue - _outvalue) * (1.0 + cos(int_pos * libMesh::pi)) / 2.0;
+    value = _outvalue + (_invalue - _outvalue) * (1.0 + std::cos(int_pos * libMesh::pi)) / 2.0;
   }
   else //Outside circle
     value = _outvalue;
@@ -88,7 +88,7 @@ SmoothCircleIC::gradient(const Point & p)
   {
     Real int_pos = (rad - _radius + _int_width / 2.0) / _int_width;
     Real Dint_posDr = 1.0 / _int_width;
-    DvalueDr = Dint_posDr * (_invalue - _outvalue) * (-sin(int_pos * libMesh::pi) * libMesh::pi) / 2.0;
+    DvalueDr = Dint_posDr * (_invalue - _outvalue) * (-std::sin(int_pos * libMesh::pi) * libMesh::pi) / 2.0;
   }
   //Set gradient over the smooth interface
   if (rad != 0.0) {

--- a/modules/phase_field/src/ics/ThumbIC.C
+++ b/modules/phase_field/src/ics/ThumbIC.C
@@ -31,8 +31,8 @@ ThumbIC::value(const Point & p)
   if (p(1) > _height)
   {
     Real rad = 0.0;
-    Point center(_xcoord,_height,0.0);
-    for (unsigned int i=0; i<2; ++i)
+    Point center(_xcoord, _height, 0.0);
+    for (unsigned int i = 0; i < 2; ++i)
       rad += (p(i) - center(i)) * (p(i) - center(i));
 
     rad = sqrt(rad);

--- a/modules/phase_field/src/kernels/ACGrGrPoly.C
+++ b/modules/phase_field/src/kernels/ACGrGrPoly.C
@@ -30,7 +30,7 @@ ACGrGrPoly::ACGrGrPoly(const std::string & name, InputParameters parameters) :
   for (unsigned int i = 0; i < _ncrys; ++i)
   {
     _vals[i] = &coupledValue("v", i);
-    _vals_var[i] = coupled("v",i);
+    _vals_var[i] = coupled("v", i);
   }
 }
 
@@ -38,7 +38,7 @@ Real
 ACGrGrPoly::computeDFDOP(PFFunctionType type)
 {
   Real SumEtaj = 0.0;
-  for (unsigned int i=0; i<_ncrys; ++i)
+  for (unsigned int i = 0; i < _ncrys; ++i)
     SumEtaj += (*_vals[i])[_qp]*(*_vals[i])[_qp]; //Sum all other order parameters
 
   Real tgrad_correction = 0.0;

--- a/modules/phase_field/src/kernels/CHBulk.C
+++ b/modules/phase_field/src/kernels/CHBulk.C
@@ -4,9 +4,9 @@ template<>
 InputParameters validParams<CHBulk>()
 {
   InputParameters params = validParams<KernelGrad>();
-  params.addParam<std::string>("mob_name","M","The mobility used with the kernel");
-  params.addParam<std::string>("Dmob_name","DM","The D mobility used with the kernel");
-  params.addParam<bool>("has_MJac",false,"Jacobian information for the mobility is defined");
+  params.addParam<std::string>("mob_name", "M", "The mobility used with the kernel");
+  params.addParam<std::string>("Dmob_name", "DM", "The D mobility used with the kernel");
+  params.addParam<bool>("has_MJac", false, "Jacobian information for the mobility is defined");
 
   return params;
 }

--- a/modules/phase_field/src/kernels/DoubleWellPotential.C
+++ b/modules/phase_field/src/kernels/DoubleWellPotential.C
@@ -6,7 +6,7 @@ template<>
 InputParameters validParams<DoubleWellPotential>()
 {
   InputParameters params = validParams<KernelValue>();
-  params.addParam<std::string>("mob_name","L","The mobility used with the kernel");
+  params.addParam<std::string>("mob_name", "L", "The mobility used with the kernel");
 
   return params;
 }
@@ -25,7 +25,7 @@ DoubleWellPotential::computeDFDOP(PFFunctionType type)
       return _u[_qp]*_u[_qp]*_u[_qp] - _u[_qp] ;
 
     case Jacobian:
-      return _phi[_j][_qp]*(3*_u[_qp]*_u[_qp] - 1. );
+      return _phi[_j][_qp]*(3.0*_u[_qp]*_u[_qp] - 1.0);
   }
 
   mooseError("Invalid type passed in");

--- a/modules/phase_field/src/postprocessors/NodalFloodCount.C
+++ b/modules/phase_field/src/postprocessors/NodalFloodCount.C
@@ -143,11 +143,11 @@ NodalFloodCount::execute()
   {
     Elem *current_elem = *el;
     unsigned int n_nodes = current_elem->n_vertices();
-    for (unsigned int i=0; i < n_nodes; ++i)
+    for (unsigned int i = 0; i < n_nodes; ++i)
     {
       const Node *node = current_elem->get_node(i);
 
-      for (unsigned int var_num=0; var_num<_vars.size(); ++var_num)
+      for (unsigned int var_num = 0; var_num < _vars.size(); ++var_num)
         flood(node, var_num, 0);
     }
   }
@@ -288,7 +288,7 @@ NodalFloodCount::pack(std::vector<unsigned int> & packed_data, bool merge_period
    **/
   std::vector<std::vector<std::set<unsigned int> > > data(_maps_size);
 
-  for (unsigned int map_num=0; map_num < _maps_size; ++map_num)
+  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
   {
     data[map_num].resize(_region_counts[map_num]+1);
 
@@ -358,7 +358,7 @@ NodalFloodCount::unpack(const std::vector<unsigned int> & packed_data)
   bool start_next_set = true;
   bool has_data_to_save = false;
 
-  unsigned int curr_set_length=0;
+  unsigned int curr_set_length = 0;
   std::set<unsigned int> curr_set;
   unsigned int curr_var_idx = std::numeric_limits<unsigned int>::max();
 
@@ -409,11 +409,11 @@ NodalFloodCount::unpack(const std::vector<unsigned int> & packed_data)
 void
 NodalFloodCount::mergeSets()
 {
-  Moose::perf_log.push("mergeSets()","NodalFloodCount");
+  Moose::perf_log.push("mergeSets()", "NodalFloodCount");
   std::set<unsigned int> set_union;
   std::insert_iterator<std::set<unsigned int> > set_union_inserter(set_union, set_union.begin());
 
-  for (unsigned int map_num=0; map_num < _maps_size; ++map_num)
+  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
   {
     std::list<BubbleData>::iterator end = _bubble_sets[map_num].end();
     for (std::list<BubbleData>::iterator it1 = _bubble_sets[map_num].begin(); it1 != end; /* No increment */)
@@ -446,7 +446,7 @@ NodalFloodCount::mergeSets()
         ++it1;
     }
   }
-  Moose::perf_log.pop("mergeSets()","NodalFloodCount");
+  Moose::perf_log.pop("mergeSets()", "NodalFloodCount");
 }
 
 void
@@ -456,7 +456,7 @@ NodalFloodCount::updateFieldInfo()
   _region_to_var_idx.resize(_bubble_sets[0].size());
 
   // Finally update the original bubble map with field data from the merged sets
-  for (unsigned int map_num=0; map_num < _maps_size; ++map_num)
+  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
   {
     unsigned int counter = 1;
     for (std::list<BubbleData>::iterator it1 = _bubble_sets[map_num].begin(); it1 != _bubble_sets[map_num].end(); ++it1)
@@ -512,7 +512,7 @@ NodalFloodCount::flood(const Node *node, int current_idx, unsigned int live_regi
   std::vector< const Node * > neighbors;
   MeshTools::find_nodal_neighbors(_mesh.getMesh(), *node, _nodes_to_elem_map, neighbors);
   // Flood neighboring nodes that are also above this threshold with recursion
-  for (unsigned int i=0; i<neighbors.size(); ++i)
+  for (unsigned int i = 0; i < neighbors.size(); ++i)
   {
     // Only recurse on nodes this processor can see
     if (_mesh.isSemiLocal(const_cast<Node *>(neighbors[i])))
@@ -559,11 +559,11 @@ NodalFloodCount::updateRegionOffsets()
 void
 NodalFloodCount::calculateBubbleVolumes()
 {
-  Moose::perf_log.push("calculateBubbleVolume()","NodalFloodCount");
+  Moose::perf_log.push("calculateBubbleVolume()", "NodalFloodCount");
 
   // Size our temporary data structure
   std::vector<std::vector<Real> > bubble_volumes(_maps_size);
-  for (unsigned int map_num=0; map_num < _maps_size; ++map_num)
+  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
   {
     bubble_volumes[map_num].resize(_bubble_sets[map_num].size());
   }
@@ -583,7 +583,7 @@ NodalFloodCount::calculateBubbleVolumes()
       for (std::list<BubbleData>::const_iterator bubble_it1 = _bubble_sets[map_num].begin(); bubble_it1 != end; ++bubble_it1)
       {
         unsigned int flooded_nodes = 0;
-        for (unsigned int node = 0; node<elem_n_nodes; ++node)
+        for (unsigned int node = 0; node < elem_n_nodes; ++node)
         {
           unsigned int node_id = elem->node(node);
           if (bubble_it1->_nodes.find(node_id) != bubble_it1->_nodes.end())
@@ -607,7 +607,7 @@ NodalFloodCount::calculateBubbleVolumes()
 
   std::sort(_all_bubble_volumes.begin(), _all_bubble_volumes.end(), std::greater<Real>());
 
-  Moose::perf_log.pop("calculateBubbleVolume()","NodalFloodCount");
+  Moose::perf_log.pop("calculateBubbleVolume()", "NodalFloodCount");
 }
 
 template<>


### PR DESCRIPTION
Calculate gradient normal direction wrt PBCs to fix another problem related to #2965 (fixes the baseclass that was already supposed to fully support PBCs) by using the new minPeriodicVector. The meat is in 3637b54. The other patches contain whitespace crap and missing std:: ns prefixes.
