### PR TITLE
Addresses issue #3009 .  gh_bounded_17 test previously failed in dbg mod...

### DIFF
--- a/modules/richards/tests/gravity_head_2/gh_bounded_17.i
+++ b/modules/richards/tests/gravity_head_2/gh_bounded_17.i
@@ -183,10 +183,6 @@
     type = PlotFunction
     function = fcn_mass_error_w
   [../]
-  [./mass_error_gas]
-    type = PlotFunction
-    function = fcn_mass_error_g
-  [../]
 
   [./pw_left]
     type = PointValue
@@ -212,12 +208,6 @@
     value = 'abs(0.5*(mi-mf)/(mi+mf))'
     vars = 'mi mf'
     vals = 'mwater_init mwater_fin'
-  [../]
-  [./fcn_mass_error_g]
-    type = ParsedFunction
-    value = 'abs(0.5*(mi-mf)/(mi+mf))'
-    vars = 'mi mf'
-    vals = 'mgas_init mgas_fin'
   [../]
   [./fcn_error_water]
     type = ParsedFunction

--- a/modules/richards/tests/gravity_head_2/gold/gh_bounded_17.csv
+++ b/modules/richards/tests/gravity_head_2/gold/gh_bounded_17.csv
@@ -1,3 +1,3 @@
-time,error_water,mass_error_gas,mass_error_water
-1e+06,6.9243212725568e-08,0.5,6.096431971733e-09
+time,error_water,mass_error_water
+1e+06,6.9243212725568e-08,6.096431971733e-09
 


### PR DESCRIPTION
...e due to a division by zero since there was zero gas present, so a mass balance for gas did not make sense
