### PR TITLE
Better language

### DIFF
--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -24,7 +24,7 @@ InputParameters validParams<SideSetsAroundSubdomain>()
 {
   InputParameters params = validParams<MeshModifier>();
   params += validParams<BlockRestrictable>();
-  params.addParam<std::vector<BoundaryName> >("boundary", "The list of boundary IDs from the mesh where this object is to be applied");
+  params.addParam<std::vector<BoundaryName> >("boundary", "The list of boundary IDs to create on the supplied subdomain");
   return params;
 }
 


### PR DESCRIPTION
- Proposing some better language for the "boundary" parameter.
- I do believe that `SideSetsAroundSubdomain` **should** be block restrictable, but is there a reason that this is limited a single block?
  (#2908)
