### PR TITLE
Fixing up override warning in examples Makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,3 +1,23 @@
+###############################################################################
+################### MOOSE Application Standard Makefile #######################
+###############################################################################
+#
+# Optional Environment variables
+# MOOSE_DIR     - Root directory of the MOOSE project
+# FRAMEWORK_DIR - Location of the MOOSE framework
+#
+###############################################################################
+EXAMPLE_DIR        ?= $(pwd)
+MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
+FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+###############################################################################
+
+TEST := test_ignore
+
+# framework
+include $(FRAMEWORK_DIR)/build.mk
+include $(FRAMEWORK_DIR)/moose.mk
+
 ## Moose Examples
 all:: examples
 
@@ -7,42 +27,37 @@ dirlist := $(wildcard ex*/)
 # Build the example programs
 examples: $(dirlist)
 
-$(dirlist):
-	@$(MAKE) -C $@ $(MAKECMDGOALS)||exit 1
+$(dirlist): $(MOOSE_LIBS)
+	@$(MAKE) -C $@ $(MAKECMDGOALS) TEST=test_ignore || exit 1
 
 
 .PHONY: clean clobber distclean link run .depend test subdirs $(dirlist)
 
 #
 # Clean up the example programs
-clean:
-	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS)||exit 1; done
+#clean::#
+#	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS) TEST=test_ignore || exit 1; done
 
 #
 # Really clean up the example programs
-clobber:
-	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS)||exit 1; done
+#clobber::
+#	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS) TEST=test_ignore || exit 1; done
 
 # Make the example program directories look
 # like a clean distribution
-distclean:
-	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS)||exit 1; done
+#distclean::
+#	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS) TEST=test_ignore || exit 1; done
 
 # Link the example programs
-link: $(wildcard examples/ex*/*.C)
-	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" all||exit 1; done
-
-#
-# Run the example programs to see if shared lib's get properly loaded
-run: $(wildcard examples/ex*/*.C)
-	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS)||exit 1; done
+link:: $(wildcard examples/ex*/*.C)
+	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" all TEST=test_ignore || exit 1; done
 
 #
 # Rebuild the dependencies for the examples
 .depend: $(wildcard examples/ex*/*.C)
-	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS)||exit 1; done
+	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS) TEST=test_ignore || exit 1; done
 
 test:
-	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS)||exit 1; done
+	@for dir in $(dirlist); do $(MAKE) -C "$${dir}" $(MAKECMDGOALS) TEST=test_ignore || exit 1; done
 
 

--- a/examples/test.mk
+++ b/examples/test.mk
@@ -1,6 +1,5 @@
-.PHONY: test
 TEST_exodiff = \
-	@./$(APPLICATION_NAME)-$(METHOD) -i $(1) &> /dev/null ; \
-	$(FRAMEWORK_DIR)/contrib/exodiff/exodiff -F 1e-8 -t 5.5E-6 $(2) gold/$(2) | grep -q \(different\|ERROR\|command\ not\ found\) && \
+	@! ./$(APPLICATION_NAME)-$(METHOD) -i $(1) &> /dev/null && \
+	! $(FRAMEWORK_DIR)/contrib/exodiff/exodiff -F 1e-8 -t 5.5E-6 $(2) gold/$(2) | grep -q \(different\|ERROR\|command\ not\ found\) && \
 	echo $(APPLICATION_NAME) ... FAILED || \
-	echo $(APPLICATION_NAME) ... OK 
+	echo $(APPLICATION_NAME) ... OK

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -277,7 +277,9 @@ endif
 	@echo "MOOSE Compiling Fortan Plugin (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_F90) $(libmesh_FFLAGS) -shared -fPIC $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
 
-test:	all
+# Define the "test" target, we'll use a variable name so that we can override it without warnings if needed
+TEST ?= test
+$(TEST): all
 	@echo ======================================================
 	@echo Testing $(CURRENT_APP)
 	@echo ======================================================


### PR DESCRIPTION
Also fixing a longstanding bug where we get false-positive passes in test.mk.

closes #3058
