### PR TITLE
Remove Elk namespace and mentions of Elk in documentation

### DIFF
--- a/modules/contact/include/GluedContactConstraint.h
+++ b/modules/contact/include/GluedContactConstraint.h
@@ -18,7 +18,6 @@
 //MOOSE includes
 #include "SparsityBasedContactConstraint.h"
 
-//ELK includes
 #include "ContactMaster.h"
 
 //Forward Declarations

--- a/modules/contact/include/MechanicalContactConstraint.h
+++ b/modules/contact/include/MechanicalContactConstraint.h
@@ -18,7 +18,6 @@
 //MOOSE includes
 #include "SparsityBasedContactConstraint.h"
 
-//ELK includes
 #include "ContactMaster.h"
 
 //Forward Declarations

--- a/modules/contact/include/MultiDContactConstraint.h
+++ b/modules/contact/include/MultiDContactConstraint.h
@@ -18,7 +18,6 @@
 //MOOSE includes
 #include "NodeFaceConstraint.h"
 
-//ELK includes
 #include "ContactMaster.h"
 
 //Forward Declarations

--- a/modules/solid_mechanics/include/materials/AxisymmetricRZ.h
+++ b/modules/solid_mechanics/include/materials/AxisymmetricRZ.h
@@ -5,8 +5,6 @@
 
 //Forward Declarations
 class SymmElasticityTensor;
-namespace Elk
-{
 namespace SolidMechanics
 {
 
@@ -38,7 +36,6 @@ protected:
 
 };
 
-}
 }
 
 #endif //SOLIDMECHANICSMATERIALRZ_H

--- a/modules/solid_mechanics/include/materials/Element.h
+++ b/modules/solid_mechanics/include/materials/Element.h
@@ -8,13 +8,11 @@
 // Forward declarations
 class SolidModel;
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
 /**
- * Element is the base class for all solid mechanics element formulations in Elk.
+ * Element is the base class for all of this module's solid mechanics element formulations.
  */
 class Element :
     public Coupleable,
@@ -77,7 +75,6 @@ private:
 };
 
 } // namespace solid_mechanics
-} // namespace elk
 
 
 #endif

--- a/modules/solid_mechanics/include/materials/Linear.h
+++ b/modules/solid_mechanics/include/materials/Linear.h
@@ -5,8 +5,7 @@
 
 //Forward Declarations
 class SymmElasticityTensor;
-namespace Elk
-{
+
 namespace SolidMechanics
 {
 
@@ -31,7 +30,6 @@ protected:
 
 };
 
-}
 }
 
 #endif

--- a/modules/solid_mechanics/include/materials/Nonlinear3D.h
+++ b/modules/solid_mechanics/include/materials/Nonlinear3D.h
@@ -7,13 +7,11 @@
 class MaterialModel;
 class VolumetricModel;
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
 /**
- * Nonlinear3D is the base class for all solid mechanics material models in Elk.
+ * Nonlinear3D is the base class for all 3D nonlinear solid mechanics material models.
  */
 class Nonlinear3D : public Element
 {
@@ -86,7 +84,6 @@ protected:
 };
 
 } // namespace solid_mechanics
-} // namespace elk
 
 
 #endif

--- a/modules/solid_mechanics/include/materials/PlaneStrain.h
+++ b/modules/solid_mechanics/include/materials/PlaneStrain.h
@@ -3,8 +3,6 @@
 
 #include "Element.h"
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
@@ -36,7 +34,6 @@ protected:
 
 };
 
-}
 }
 
 #endif //SOLIDMECHANICSMATERIALRZ_H

--- a/modules/solid_mechanics/include/materials/SolidModel.h
+++ b/modules/solid_mechanics/include/materials/SolidModel.h
@@ -9,12 +9,9 @@ class ConstitutiveModel;
 class SolidModel;
 class SymmElasticityTensor;
 class VolumetricModel;
-namespace Elk
-{
 namespace SolidMechanics
 {
 class Element;
-}
 }
 
 
@@ -22,7 +19,7 @@ template<>
 InputParameters validParams<SolidModel>();
 
 /**
- * SolidModel is the base class for all solid mechanics material models in Elk.
+ * SolidModel is the base class for all this module's solid mechanics material models.
  */
 class SolidModel : public Material
 {
@@ -202,7 +199,7 @@ protected:
     return _local_elasticity_tensor;
   }
 
-  const Elk::SolidMechanics::Element * element() const
+  const SolidMechanics::Element * element() const
   {
     return _element;
   }
@@ -247,10 +244,10 @@ private:
 
   void computeCrackStrainAndOrientation( ColumnMajorMatrix & principal_strain );
 
-  Elk::SolidMechanics::Element * createElement( const std::string & name,
-                                                InputParameters & parameters );
+  SolidMechanics::Element * createElement( const std::string & name,
+                                           InputParameters & parameters );
 
-  Elk::SolidMechanics::Element * _element;
+  SolidMechanics::Element * _element;
 
   SymmElasticityTensor * _local_elasticity_tensor;
 

--- a/modules/solid_mechanics/include/materials/SphericalR.h
+++ b/modules/solid_mechanics/include/materials/SphericalR.h
@@ -5,8 +5,7 @@
 
 //Forward Declarations
 class SymmElasticityTensor;
-namespace Elk
-{
+
 namespace SolidMechanics
 {
 
@@ -36,7 +35,6 @@ protected:
 
 };
 
-}
 }
 
 #endif

--- a/modules/solid_mechanics/src/materials/AxisymmetricRZ.C
+++ b/modules/solid_mechanics/src/materials/AxisymmetricRZ.C
@@ -4,8 +4,6 @@
 #include "Problem.h"
 #include "VolumetricModel.h"
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
@@ -52,5 +50,4 @@ AxisymmetricRZ::computeStrain( const unsigned qp,
 }
 
 
-}
 }

--- a/modules/solid_mechanics/src/materials/Element.C
+++ b/modules/solid_mechanics/src/materials/Element.C
@@ -2,8 +2,6 @@
 
 #include "Nonlinear3D.h"
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
@@ -240,4 +238,3 @@ Element::fillMatrix( unsigned int qp,
 
 
 } // namespace solid_mechanics
-} // namespace elk

--- a/modules/solid_mechanics/src/materials/Linear.C
+++ b/modules/solid_mechanics/src/materials/Linear.C
@@ -5,8 +5,6 @@
 #include "VolumetricModel.h"
 
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
@@ -65,5 +63,4 @@ Linear::computeStrain( const unsigned qp,
 }
 
 
-}
 }

--- a/modules/solid_mechanics/src/materials/Nonlinear3D.C
+++ b/modules/solid_mechanics/src/materials/Nonlinear3D.C
@@ -6,8 +6,6 @@
 #include "SymmIsotropicElasticityTensor.h"
 #include "VolumetricModel.h"
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
@@ -360,5 +358,4 @@ Nonlinear3D::init()
 
 ////////////////////////////////////////////////////////////////////////
 
-}
 }

--- a/modules/solid_mechanics/src/materials/PlaneStrain.C
+++ b/modules/solid_mechanics/src/materials/PlaneStrain.C
@@ -1,8 +1,6 @@
 #include "PlaneStrain.h"
 #include "SolidModel.h"
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
@@ -65,5 +63,4 @@ PlaneStrain::computeDeformationGradient( unsigned int qp, ColumnMajorMatrix & F)
 
 
 
-}
 }

--- a/modules/solid_mechanics/src/materials/SolidModel.C
+++ b/modules/solid_mechanics/src/materials/SolidModel.C
@@ -1251,11 +1251,11 @@ SolidModel::getNumKnownCrackDirs() const
   return retVal+fromElement;
 }
 
-Elk::SolidMechanics::Element *
+SolidMechanics::Element *
 SolidModel::createElement( const std::string & name,
                            InputParameters & parameters )
 {
-  Elk::SolidMechanics::Element * element(NULL);
+  SolidMechanics::Element * element(NULL);
 
   std::string formulation = getParam<MooseEnum>("formulation");
   std::transform( formulation.begin(), formulation.end(),
@@ -1276,7 +1276,7 @@ SolidModel::createElement( const std::string & name,
     {
       mooseError("Nonlinear3D formulation requested for coord_type = RZ problem");
     }
-    element = new Elk::SolidMechanics::Nonlinear3D(*this, name, parameters);
+    element = new SolidMechanics::Nonlinear3D(*this, name, parameters);
   }
   else if ( formulation == "axisymmetricrz" )
   {
@@ -1285,7 +1285,7 @@ SolidModel::createElement( const std::string & name,
     {
       mooseError("AxisymmetricRZ must define disp_r and disp_z");
     }
-    element = new Elk::SolidMechanics::AxisymmetricRZ(*this, name, parameters);
+    element = new SolidMechanics::AxisymmetricRZ(*this, name, parameters);
   }
   else if ( formulation == "sphericalr" )
   {
@@ -1293,7 +1293,7 @@ SolidModel::createElement( const std::string & name,
     {
       mooseError("SphericalR must define disp_r");
     }
-    element = new Elk::SolidMechanics::SphericalR(*this, name, parameters);
+    element = new SolidMechanics::SphericalR(*this, name, parameters);
   }
   else if ( formulation == "planestrain" )
   {
@@ -1302,7 +1302,7 @@ SolidModel::createElement( const std::string & name,
     {
       mooseError("PlaneStrain must define disp_x and disp_y");
     }
-    element = new Elk::SolidMechanics::PlaneStrain(*this, name, parameters);
+    element = new SolidMechanics::PlaneStrain(*this, name, parameters);
   }
   else if ( formulation == "linear" )
   {
@@ -1314,7 +1314,7 @@ SolidModel::createElement( const std::string & name,
     {
       mooseError("Linear formulation requested for coord_type = RZ problem");
     }
-    element = new Elk::SolidMechanics::Linear(*this, name, parameters);
+    element = new SolidMechanics::Linear(*this, name, parameters);
   }
   else if ( formulation != "" )
   {
@@ -1330,7 +1330,7 @@ SolidModel::createElement( const std::string & name,
       err += ": RZ coord sys requires disp_r and disp_z for AxisymmetricRZ formulation";
       mooseError(err);
     }
-    element = new Elk::SolidMechanics::AxisymmetricRZ(*this, name, parameters);
+    element = new SolidMechanics::AxisymmetricRZ(*this, name, parameters);
   }
   else if ( !element && _coord_type == Moose::COORD_RSPHERICAL )
   {
@@ -1340,7 +1340,7 @@ SolidModel::createElement( const std::string & name,
       err += ": RSPHERICAL coord sys requires disp_r for SphericalR formulation";
       mooseError(err);
     }
-    element = new Elk::SolidMechanics::SphericalR(*this, name, parameters);
+    element = new SolidMechanics::SphericalR(*this, name, parameters);
   }
 
   if (!element)
@@ -1353,7 +1353,7 @@ SolidModel::createElement( const std::string & name,
       {
         mooseError("Error with displacement specification in material " + name);
       }
-      element = new Elk::SolidMechanics::Nonlinear3D(*this, name, parameters);
+      element = new SolidMechanics::Nonlinear3D(*this, name, parameters);
     }
     else if (isCoupled("disp_x") &&
              isCoupled("disp_y"))
@@ -1362,7 +1362,7 @@ SolidModel::createElement( const std::string & name,
       {
         mooseError("Error with displacement specification in material " + name);
       }
-      element = new Elk::SolidMechanics::PlaneStrain(*this, name, parameters);
+      element = new SolidMechanics::PlaneStrain(*this, name, parameters);
     }
     else if (isCoupled("disp_r") &&
              isCoupled("disp_z"))
@@ -1371,7 +1371,7 @@ SolidModel::createElement( const std::string & name,
       {
         mooseError("RZ coord system not specified, but disp_r and disp_z are");
       }
-      element = new Elk::SolidMechanics::AxisymmetricRZ( *this, name, parameters );
+      element = new SolidMechanics::AxisymmetricRZ( *this, name, parameters );
     }
     else if (isCoupled("disp_r"))
     {
@@ -1379,11 +1379,11 @@ SolidModel::createElement( const std::string & name,
       {
         mooseError("RSPHERICAL coord system not specified, but disp_r is");
       }
-      element = new Elk::SolidMechanics::SphericalR( *this, name, parameters );
+      element = new SolidMechanics::SphericalR( *this, name, parameters );
     }
     else if (isCoupled("disp_x"))
     {
-      element = new Elk::SolidMechanics::Linear( *this, name, parameters );
+      element = new SolidMechanics::Linear( *this, name, parameters );
     }
     else
     {

--- a/modules/solid_mechanics/src/materials/SphericalR.C
+++ b/modules/solid_mechanics/src/materials/SphericalR.C
@@ -4,8 +4,6 @@
 #include "VolumetricModel.h"
 #include "SolidModel.h"
 
-namespace Elk
-{
 namespace SolidMechanics
 {
 
@@ -45,5 +43,4 @@ SphericalR::computeStrain( const unsigned qp,
 }
 
 
-}
 }

--- a/modules/solid_mechanics/src/materials/abaqus/AbaqusUmatMaterial.C
+++ b/modules/solid_mechanics/src/materials/abaqus/AbaqusUmatMaterial.C
@@ -169,7 +169,7 @@ void AbaqusUmatMaterial::initQpStatefulProperties()
 
 void AbaqusUmatMaterial::computeStress()
 {
-  //Calculate deformation gradient - modeled from "/elk/src/solid_mechanics/materials/Nonlinear3D.C"
+  //Calculate deformation gradient - modeled from "solid_mechanics/src/materials/Nonlinear3D.C"
   // Fbar = 1 + grad(u(k))
   ColumnMajorMatrix Fbar;
 

--- a/modules/solid_mechanics/src/materials/total_strain/LinearAnisotropicMaterial.C
+++ b/modules/solid_mechanics/src/materials/total_strain/LinearAnisotropicMaterial.C
@@ -1,6 +1,4 @@
 #include "LinearAnisotropicMaterial.h"
-
-// Elk Includes
 #include "SymmAnisotropicElasticityTensor.h"
 
 template<>

--- a/modules/solid_mechanics/src/materials/total_strain/LinearIsotropicMaterial.C
+++ b/modules/solid_mechanics/src/materials/total_strain/LinearIsotropicMaterial.C
@@ -1,6 +1,4 @@
 #include "LinearIsotropicMaterial.h"
-
-// Elk Includes
 #include "ColumnMajorMatrix.h"
 #include "SolidMechanicsMaterial.h"
 #include "SymmIsotropicElasticityTensor.h"

--- a/modules/solid_mechanics/src/materials/total_strain/TrussMaterial.C
+++ b/modules/solid_mechanics/src/materials/total_strain/TrussMaterial.C
@@ -1,8 +1,6 @@
 #include "TrussMaterial.h"
 
 #include "Material.h"
-
-// Elk Includes
 #include "ColumnMajorMatrix.h"
 #include "SymmIsotropicElasticityTensor.h"
 #include "VolumetricModel.h"

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -24,6 +24,11 @@ ADDITIONAL_LIBS 	:= -L$(CPPUNIT_DIR)/lib -lcppunit
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
+################################## MODULES ####################################
+SOLID_MECHANICS   := yes
+include           $(MOOSE_DIR)/modules/modules.mk
+###############################################################################
+
 APPLICATION_DIR := $(MOOSE_DIR)/unit
 APPLICATION_NAME := moose_unit
 BUILD_EXEC       := yes

--- a/unit/src/IsotropicElasticityTensorTest.C
+++ b/unit/src/IsotropicElasticityTensorTest.C
@@ -12,12 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifdef ELK_TEST
-
 #include <math.h>
 #include "IsotropicElasticityTensorTest.h"
 
-//Moose includes
+// Moose modules includes
 #include "IsotropicElasticityTensor.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION( IsotropicElasticityTensorTest );
@@ -269,5 +267,3 @@ double IsotropicElasticityTensorTest::_eK[9][9] = {
   { 0, 0, 0.433027, 0, 0, 0, 0.433027, 0, 0 },
   { 0, 0, 0, 0, 0, 0.433027, 0, 0.433027, 0 },
   { 2.28132, 0, 0, 0, 2.28132, 0, 0, 0, 3.14737 } };
-
-#endif //ELK_TEST: testing if elk library is included


### PR DESCRIPTION
The first commit cleans up mentions of "Elk" from some of the modules.

The second commit makes the MOOSE unit tests depend on the solid mechanics module so that it can run a solid mechanics unit test.  

Refs #2936.
