### PR TITLE
Disabling test in recover

### DIFF
--- a/test/tests/materials/output/tests
+++ b/test/tests/materials/output/tests
@@ -3,6 +3,7 @@
     type = 'Exodiff'
     input = 'output.i'
     exodiff = 'output_out.e'
+    recover = false # see 3082
   [../]
   [./block]
     type = 'Exodiff'


### PR DESCRIPTION
I am not sure the reason for this problem, especially since all the other similar tests are working with recovery. So, for now, I am disabling this test in recover.

 (#3082)
