### PR TITLE
AuxKernel creation uses restrictable interfaces

### DIFF
--- a/framework/include/auxkernels/AuxWarehouse.h
+++ b/framework/include/auxkernels/AuxWarehouse.h
@@ -64,14 +64,14 @@ public:
    * @param boundary_id Boundary ID this kernel works on
    * @param aux BC kernel being added
    */
-  void addActiveBC(BoundaryID boundary_id, AuxKernel *aux);
+  void addActiveBC(AuxKernel *aux);
 
   /**
    * Adds an auxiliary kernel
    * @param aux Kernel being added
    * @param block_ids Set of subdomain this kernel is active on
    */
-  void addAuxKernel(AuxKernel *aux, std::set<SubdomainID> block_ids);
+  void addAuxKernel(AuxKernel *aux);
 
   /**
    * Add a scalar kernels

--- a/framework/include/base/BlockRestrictable.h
+++ b/framework/include/base/BlockRestrictable.h
@@ -152,6 +152,12 @@ public:
    */
   bool hasBlockMaterialProperty(const std::string & name) const;
 
+  /**
+   * Return all of the SubdomainIDs for the mesh
+   * @return A set of all subdomians for the entire domain
+   */
+  const std::set<SubdomainID> & meshBlockIDs();
+
 private:
 
   /// Set of block ids supplied by the user via the input file
@@ -176,6 +182,5 @@ private:
   std::set<SubdomainID> variableSubdomianIDs(InputParameters & parameters) const;
 
 };
-
 
 #endif // BLOCKRESTRICTABLE_H

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -40,6 +40,9 @@ InputParameters validParams<AuxKernel>()
   params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the displaced mesh for computation.  Note that in the case this is true but no displacements are provided in the Mesh block the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
+  // This flag is set to true if the AuxKernel is being used on a boundary
+  params.addPrivateParam<bool>("_on_boundary", false);
+
   params.registerBase("AuxKernel");
 
   return params;
@@ -71,10 +74,9 @@ AuxKernel::AuxKernel(const std::string & name, InputParameters parameters) :
     _var(_aux_sys.getVariable(_tid, parameters.get<AuxVariableName>("variable"))),
     _nodal(_var.isNodal()),
 
-    _bnd(parameters.have_parameter<BoundaryID>("_boundary_id")),
+    _bnd(parameters.get<bool>("_on_boundary")),
 
     _mesh(_subproblem.mesh()),
-//    _dim(_mesh.dimension()),
 
     _q_point(_bnd ? _assembly.qPointsFace() : _assembly.qPoints()),
     _qrule(_bnd ? _assembly.qRuleFace() : _assembly.qRule()),

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -222,3 +222,9 @@ BlockRestrictable::hasBlockMaterialProperty(const std::string & name) const
   else
     return isBlockSubset(mat_blk);
 }
+
+const std::set<SubdomainID> &
+BlockRestrictable::meshBlockIDs()
+{
+  return _blk_mesh->meshSubdomains();
+}


### PR DESCRIPTION
This was needed to make removing AuxBCs easier, which is next. 
(closes #3014)
