### PR TITLE
Change name of variable in function prototype

### DIFF
--- a/framework/include/dirackernels/DiracKernelWarehouse.h
+++ b/framework/include/dirackernels/DiracKernelWarehouse.h
@@ -41,10 +41,10 @@ public:
   const std::vector<DiracKernel *> & all() { return _dirac_kernels; }
 
   /**
-   * Adds a dirac kernel
-   * @param DiracKernel Kernel being added
+   * Adds a Dirac kernel
+   * @param kernel The DiracKernel being added
    */
-  void addDiracKernel(DiracKernel *DiracKernel);
+  void addDiracKernel(DiracKernel * kernel);
 
 protected:
   /// All dirac kernels

--- a/framework/src/dirackernels/DiracKernelWarehouse.C
+++ b/framework/src/dirackernels/DiracKernelWarehouse.C
@@ -57,7 +57,7 @@ DiracKernelWarehouse::jacobianSetup()
 
 
 void
-DiracKernelWarehouse::addDiracKernel(DiracKernel *DiracKernel)
+DiracKernelWarehouse::addDiracKernel(DiracKernel * kernel)
 {
-  _dirac_kernels.push_back(DiracKernel);
+  _dirac_kernels.push_back(kernel);
 }


### PR DESCRIPTION
Even though it does work in this case, probably shouldn't name a variable with the same name as a type in general.

Refs #000.
