### PR TITLE
Miscellaneous DiracKernel improvements

### DIFF
--- a/framework/include/dirackernels/DiracKernel.h
+++ b/framework/include/dirackernels/DiracKernel.h
@@ -149,11 +149,8 @@ protected:
   /// DiracKernel objects.
   DiracKernelInfo & _dirac_kernel_info;
 
-  /// The list of elements that need distributions
-  std::set<const Elem *> _elements;
-
-  /// The list of physical xyz Points that need to be evaluated in each element
-  std::map<const Elem *, std::set<Point> > _points;
+  /// Place for storing Point/Elem information only for this DiracKernel
+  DiracKernelInfo _local_dirac_kernel_info;
 
   /// The current point
   Point _current_point;

--- a/framework/include/dirackernels/DiracKernelInfo.h
+++ b/framework/include/dirackernels/DiracKernelInfo.h
@@ -25,13 +25,11 @@
 #include <set>
 #include <map>
 
-namespace libMesh
-{
-  template <class T> class NumericVector;
-}
-
 /**
- * TODO
+ * The DiracKernelInfo object is a place where all the Dirac points
+ * added by different DiracKernels are collected.  It is used, for
+ * example, by the FEProblem class to determine if finite element data
+ * needs to be recomputed on a given element.
  */
 class DiracKernelInfo
 {
@@ -42,21 +40,37 @@ public:
 public:
   /**
    * Adds a point source
-   * @param elem Element
-   * @param p Point
+   * @param elem Pointer to the geometric element in which the point is located
+   * @param p The (x,y,z) location of the Dirac point
    */
   void addPoint(const Elem * elem, Point p);
-
-  /// The list of elements that need distributions.
-  std::set<const Elem *> _elements;
-
-  /// The list of physical xyz Points that need to be evaluated in each element.
-  std::map<const Elem *, std::set<Point> > _points;
 
   /**
    * Remove all of the current points and elements.
    */
   void clearPoints();
+
+  /**
+   * Return true if we have Point 'p' in Element 'elem'
+   */
+  bool hasPoint(const Elem * elem, Point p);
+
+  /**
+   * Returns a writeable reference to the _elements container.
+   */
+  std::set<const Elem *> & getElements() { return _elements; }
+
+  /**
+   * Returns a writeable reference to the _points container.
+   */
+  std::map<const Elem *, std::vector<Point> > & getPoints() { return _points; }
+
+protected:
+  /// The list of elements that need distributions.
+  std::set<const Elem *> _elements;
+
+  /// The list of physical xyz Points that need to be evaluated in each element.
+  std::map<const Elem *, std::vector<Point> > _points;
 };
 
 #endif //DIRACKERNELINFO_H

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -233,15 +233,12 @@ DisplacedProblem::prepareAssemblyNeighbor(THREAD_ID tid)
 bool
 DisplacedProblem::reinitDirac(const Elem * elem, THREAD_ID tid)
 {
-  std::set<Point> & points_set = _dirac_kernel_info._points[elem];
+  std::vector<Point> & points = _dirac_kernel_info.getPoints()[elem];
 
-  bool have_points = points_set.size();
+  bool have_points = points.size();
 
   if (have_points)
   {
-    std::vector<Point> points(points_set.size());
-    std::copy(points_set.begin(), points_set.end(), points.begin());
-
     _assembly[tid]->reinitAtPhysical(elem, points);
 
     _displaced_nl.prepare(tid);
@@ -364,7 +361,7 @@ DisplacedProblem::reinitScalars(THREAD_ID tid)
 void
 DisplacedProblem::getDiracElements(std::set<const Elem *> & elems)
 {
-  elems = _dirac_kernel_info._elements;
+  elems = _dirac_kernel_info.getElements();
 }
 
 void

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -835,15 +835,12 @@ FEProblem::sizeZeroes(unsigned int size, THREAD_ID tid)
 bool
 FEProblem::reinitDirac(const Elem * elem, THREAD_ID tid)
 {
-  std::set<Point> & points_set = _dirac_kernel_info._points[elem];
+  std::vector<Point> & points = _dirac_kernel_info.getPoints()[elem];
 
-  bool have_points = points_set.size();
+  bool have_points = points.size();
 
   if (have_points)
   {
-    std::vector<Point> points(points_set.size());
-    std::copy(points_set.begin(), points_set.end(), points.begin());
-
     _assembly[tid]->reinitAtPhysical(elem, points);
 
     _nl.prepare(tid);
@@ -1024,7 +1021,7 @@ void
 FEProblem::getDiracElements(std::set<const Elem *> & elems)
 {
   // First add in the undisplaced elements
-  elems =_dirac_kernel_info._elements;
+  elems = _dirac_kernel_info.getElements();
 
   if (_displaced_problem)
   {

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -122,8 +122,7 @@ DiracKernel::addPoint(const Elem * elem, Point p)
     return;
 
   _dirac_kernel_info.addPoint(elem, p);
-  _elements.insert(elem);
-  _points[elem].insert(p);
+  _local_dirac_kernel_info.addPoint(elem, p);
 }
 
 const Elem *
@@ -138,20 +137,19 @@ DiracKernel::addPoint(Point p)
 bool
 DiracKernel::hasPointsOnElem(const Elem * elem)
 {
-  return _elements.count(_mesh.elem(elem->id())) != 0;
+  return _local_dirac_kernel_info.getElements().count(_mesh.elem(elem->id())) != 0;
 }
 
 bool
 DiracKernel::isActiveAtPoint(const Elem * elem, const Point & p)
 {
-  return _points[elem].count(p) != 0;
+  return _local_dirac_kernel_info.hasPoint(elem, p);
 }
 
 void
 DiracKernel::clearPoints()
 {
-  _elements.clear();
-  _points.clear();
+  _local_dirac_kernel_info.clearPoints();
 }
 
 MooseVariable &

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -26,7 +26,12 @@ void
 DiracKernelInfo::addPoint(const Elem * elem, Point p)
 {
   _elements.insert(elem);
-  _points[elem].insert(p);
+
+  if (!hasPoint(elem, p))
+  {
+    std::vector<Point> & point_list = _points[elem];
+    point_list.push_back(p);
+  }
 }
 
 void
@@ -34,4 +39,27 @@ DiracKernelInfo::clearPoints()
 {
   _elements.clear();
   _points.clear();
+}
+
+
+
+bool
+DiracKernelInfo::hasPoint(const Elem * elem, Point p)
+{
+  std::vector<Point> & point_list = _points[elem];
+
+  std::vector<Point>::iterator
+    it = point_list.begin(),
+    end = point_list.end();
+
+  for (; it != end; ++it)
+  {
+    Real delta = (*it - p).size_sq();
+
+    if (delta < TOLERANCE*TOLERANCE)
+      return true;
+  }
+
+  // If we haven't found it, we don't have it.
+  return false;
 }


### PR DESCRIPTION
- Storing a vector<Point> per Elem rather than a set<Point> for
  DiracKernels.  A std::set<Point> is always somewhat dangerous due to
  the floating point nature of operator< for Points.
- The DiracKernel object now uses two DiracKernelInfo objects to avoid duplicating code.
- Give DiracKernelInfo a more standard interface since it is used in a few more places now...
- Adding DiracKernel::hasPoint()
- Implement DiracKernelInfo::addPoint() in terms of DiracKernelInfo::hasPoint()
- Adding documentation.

Refs #2847.
