### PR TITLE
Removing MooseVariableBase::index() (closes #3094)

### DIFF
--- a/framework/include/base/MooseVariableBase.h
+++ b/framework/include/base/MooseVariableBase.h
@@ -47,14 +47,6 @@ public:
   virtual ~MooseVariableBase();
 
   /**
-   * Get the variable index.
-   *
-   * Used to index into the vector of residuals, jacobians blocks, etc.
-   * @return The variable index
-   */
-  unsigned int index() const;
-
-  /**
    * Get variable number coming from libMesh
    * @return the libmesh variable number
    */

--- a/framework/src/actions/AdaptivityAction.C
+++ b/framework/src/actions/AdaptivityAction.C
@@ -89,7 +89,7 @@ AdaptivityAction::act()
       std::string name = weight_names[i];
       double value = weight_values[i];
 
-      weights[system.getVariable(0, name).index()] = value;
+      weights[system.getVariable(0, name).number()] = value;
     }
 
     std::vector<FEMNormType> norms(system.nVariables(), H1_SEMINORM);

--- a/framework/src/actions/AddPeriodicBCAction.C
+++ b/framework/src/actions/AddPeriodicBCAction.C
@@ -58,7 +58,7 @@ AddPeriodicBCAction::setPeriodicVars(PeriodicBoundaryBase & p, const std::vector
 
   for (std::vector<VariableName>::const_iterator it = var_names_ptr->begin(); it != var_names_ptr->end(); ++it)
   {
-    unsigned int var_num = nl.getVariable(0, (*it)).index();
+    unsigned int var_num = nl.getVariable(0, (*it)).number();
 
     p.set_variable(var_num);
     _mesh->addPeriodicVariable(var_num, p.myboundary, p.pairedboundary);

--- a/framework/src/auxkernels/DebugResidualAux.C
+++ b/framework/src/auxkernels/DebugResidualAux.C
@@ -38,6 +38,6 @@ DebugResidualAux::~DebugResidualAux()
 Real
 DebugResidualAux::computeValue()
 {
-  dof_id_type dof = _current_node->dof_number(_nl_sys.number(), _debug_var.index(), 0);
+  dof_id_type dof = _current_node->dof_number(_nl_sys.number(), _debug_var.number(), 0);
   return _residual_copy(dof);
 }

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -661,10 +661,10 @@ Assembly::init()
   const std::vector<MooseVariable *> & vars = _sys.getVariables(_tid);
   for (std::vector<MooseVariable *>::const_iterator jt = vars.begin(); jt != vars.end(); ++jt)
   {
-    unsigned int j = (*jt)->index();
+    unsigned int j = (*jt)->number();
     for (std::vector<MooseVariable *>::const_iterator it = vars.begin(); it != vars.end(); ++it)
     {
-      unsigned int i = (*it)->index();
+      unsigned int i = (*it)->number();
       if ((*_cm)(i, j) != 0)
         _cm_entry.push_back(std::pair<MooseVariable *, MooseVariable *>(*it, *jt));
     }
@@ -726,8 +726,8 @@ Assembly::prepare()
     MooseVariable & ivar = *(*it).first;
     MooseVariable & jvar = *(*it).second;
 
-    unsigned int vi = ivar.index();
-    unsigned int vj = jvar.index();
+    unsigned int vi = ivar.number();
+    unsigned int vj = jvar.number();
 
     jacobianBlock(vi, vj).resize(ivar.dofIndices().size(), jvar.dofIndices().size());
     jacobianBlock(vi, vj).zero();
@@ -739,8 +739,8 @@ Assembly::prepare()
     MooseVariable & ivar = *(*it);
     for (unsigned int i = 0; i < _sub_Re.size(); i++)
     {
-      _sub_Re[i][ivar.index()].resize(ivar.dofIndices().size());
-      _sub_Re[i][ivar.index()].zero();
+      _sub_Re[i][ivar.number()].resize(ivar.dofIndices().size());
+      _sub_Re[i][ivar.number()].zero();
     }
   }
 }
@@ -753,10 +753,10 @@ Assembly::prepareVariable(MooseVariable * var)
     MooseVariable & ivar = *(*it).first;
     MooseVariable & jvar = *(*it).second;
 
-    unsigned int vi = ivar.index();
-    unsigned int vj = jvar.index();
+    unsigned int vi = ivar.number();
+    unsigned int vj = jvar.number();
 
-    if (vi == var->index() || vj == var->index())
+    if (vi == var->number() || vj == var->number())
     {
       jacobianBlock(vi,vj).resize(ivar.dofIndices().size(), jvar.dofIndices().size());
     }
@@ -764,8 +764,8 @@ Assembly::prepareVariable(MooseVariable * var)
 
   for (unsigned int i = 0; i < _sub_Re.size(); i++)
   {
-    _sub_Re[i][var->index()].resize(var->dofIndices().size());
-    _sub_Re[i][var->index()].zero();
+    _sub_Re[i][var->number()].resize(var->dofIndices().size());
+    _sub_Re[i][var->number()].zero();
   }
 }
 
@@ -777,8 +777,8 @@ Assembly::prepareNeighbor()
     MooseVariable & ivar = *(*it).first;
     MooseVariable & jvar = *(*it).second;
 
-    unsigned int vi = ivar.index();
-    unsigned int vj = jvar.index();
+    unsigned int vi = ivar.number();
+    unsigned int vj = jvar.number();
 
     jacobianBlockNeighbor(Moose::ElementNeighbor, vi, vj).resize(ivar.dofIndices().size(), jvar.dofIndicesNeighbor().size());
     jacobianBlockNeighbor(Moose::ElementNeighbor, vi, vj).zero();
@@ -796,8 +796,8 @@ Assembly::prepareNeighbor()
     MooseVariable & ivar = *(*it);
     for (unsigned int i = 0; i < _sub_Rn.size(); i++)
     {
-      _sub_Rn[i][ivar.index()].resize(ivar.dofIndicesNeighbor().size());
-      _sub_Rn[i][ivar.index()].zero();
+      _sub_Rn[i][ivar.number()].resize(ivar.dofIndicesNeighbor().size());
+      _sub_Rn[i][ivar.number()].zero();
     }
   }
 }
@@ -826,8 +826,8 @@ Assembly::prepareScalar()
 
     for (unsigned int i = 0; i < _sub_Re.size(); i++)
     {
-      _sub_Re[i][ivar.index()].resize(idofs);
-      _sub_Re[i][ivar.index()].zero();
+      _sub_Re[i][ivar.number()].resize(idofs);
+      _sub_Re[i][ivar.number()].zero();
     }
 
     for (std::vector<MooseVariableScalar *>::const_iterator jt = vars.begin(); jt != vars.end(); ++jt)
@@ -835,8 +835,8 @@ Assembly::prepareScalar()
       MooseVariableScalar & jvar = *(*jt);
       unsigned int jdofs = jvar.dofIndices().size();
 
-      jacobianBlock(ivar.index(), jvar.index()).resize(idofs, jdofs);
-      jacobianBlock(ivar.index(), jvar.index()).zero();
+      jacobianBlock(ivar.number(), jvar.number()).resize(idofs, jdofs);
+      jacobianBlock(ivar.number(), jvar.number()).zero();
     }
   }
 }
@@ -857,11 +857,11 @@ Assembly::prepareOffDiagScalar()
       MooseVariable & jvar = *(*jt);
       unsigned int jdofs = jvar.dofIndices().size();
 
-      jacobianBlock(ivar.index(), jvar.index()).resize(idofs, jdofs);
-      jacobianBlock(ivar.index(), jvar.index()).zero();
+      jacobianBlock(ivar.number(), jvar.number()).resize(idofs, jdofs);
+      jacobianBlock(ivar.number(), jvar.number()).zero();
 
-      jacobianBlock(jvar.index(), ivar.index()).resize(jdofs, idofs);
-      jacobianBlock(jvar.index(), ivar.index()).zero();
+      jacobianBlock(jvar.number(), ivar.number()).resize(jdofs, idofs);
+      jacobianBlock(jvar.number(), ivar.number()).zero();
     }
   }
 }
@@ -963,7 +963,7 @@ Assembly::addResidual(NumericVector<Number> & residual, Moose::KernelType type/*
   for (std::vector<MooseVariable *>::const_iterator it = vars.begin(); it != vars.end(); ++it)
   {
     MooseVariable & var = *(*it);
-    addResidualBlock(residual, _sub_Re[type][var.index()], var.dofIndices(), var.scalingFactor());
+    addResidualBlock(residual, _sub_Re[type][var.number()], var.dofIndices(), var.scalingFactor());
   }
 }
 
@@ -974,7 +974,7 @@ Assembly::addResidualNeighbor(NumericVector<Number> & residual, Moose::KernelTyp
   for (std::vector<MooseVariable *>::const_iterator it = vars.begin(); it != vars.end(); ++it)
   {
     MooseVariable & var = *(*it);
-    addResidualBlock(residual, _sub_Rn[type][var.index()], var.dofIndicesNeighbor(), var.scalingFactor());
+    addResidualBlock(residual, _sub_Rn[type][var.number()], var.dofIndicesNeighbor(), var.scalingFactor());
   }
 }
 
@@ -986,7 +986,7 @@ Assembly::addResidualScalar(NumericVector<Number> & residual, Moose::KernelType 
   for (std::vector<MooseVariableScalar *>::const_iterator it = vars.begin(); it != vars.end(); ++it)
   {
     MooseVariableScalar & var = *(*it);
-    addResidualBlock(residual, _sub_Re[type][var.index()], var.dofIndices(), var.scalingFactor());
+    addResidualBlock(residual, _sub_Re[type][var.number()], var.dofIndices(), var.scalingFactor());
   }
 }
 
@@ -1000,7 +1000,7 @@ Assembly::cacheResidual()
     MooseVariable & var = *(*it);
 
     for (unsigned int i = 0; i < _sub_Re.size(); i++)
-      cacheResidualBlock(_cached_residual_values[i], _cached_residual_rows[i], _sub_Re[i][var.index()], var.dofIndices(), var.scalingFactor());
+      cacheResidualBlock(_cached_residual_values[i], _cached_residual_rows[i], _sub_Re[i][var.number()], var.dofIndices(), var.scalingFactor());
   }
 }
 
@@ -1013,7 +1013,7 @@ Assembly::cacheResidualNeighbor()
     MooseVariable & var = *(*it);
 
     for (unsigned int i = 0; i < _sub_Re.size(); i++)
-      cacheResidualBlock(_cached_residual_values[i], _cached_residual_rows[i], _sub_Rn[i][var.index()], var.dofIndicesNeighbor(), var.scalingFactor());
+      cacheResidualBlock(_cached_residual_values[i], _cached_residual_rows[i], _sub_Rn[i][var.number()], var.dofIndicesNeighbor(), var.scalingFactor());
   }
 }
 
@@ -1069,7 +1069,7 @@ Assembly::setResidual(NumericVector<Number> & residual, Moose::KernelType type/*
   for (std::vector<MooseVariable *>::const_iterator it = vars.begin(); it != vars.end(); ++it)
   {
     MooseVariable & var = *(*it);
-    setResidualBlock(residual, _sub_Re[type][var.index()], var.dofIndices(), var.scalingFactor());
+    setResidualBlock(residual, _sub_Re[type][var.number()], var.dofIndices(), var.scalingFactor());
   }
 }
 
@@ -1080,7 +1080,7 @@ Assembly::setResidualNeighbor(NumericVector<Number> & residual, Moose::KernelTyp
   for (std::vector<MooseVariable *>::const_iterator it = vars.begin(); it != vars.end(); ++it)
   {
     MooseVariable & var = *(*it);
-    setResidualBlock(residual, _sub_Rn[type][var.index()], var.dofIndicesNeighbor(), var.scalingFactor());
+    setResidualBlock(residual, _sub_Rn[type][var.number()], var.dofIndicesNeighbor(), var.scalingFactor());
   }
 }
 
@@ -1177,8 +1177,8 @@ Assembly::addJacobian(SparseMatrix<Number> & jacobian)
     for (std::vector<MooseVariable *>::const_iterator jt = vars.begin(); jt != vars.end(); ++jt)
     {
       MooseVariable & jvar = *(*jt);
-      if ((*_cm)(ivar.index(), jvar.index()) != 0)
-        addJacobianBlock(jacobian, jacobianBlock(ivar.index(), jvar.index()), ivar.dofIndices(), jvar.dofIndices(), ivar.scalingFactor());
+      if ((*_cm)(ivar.number(), jvar.number()) != 0)
+        addJacobianBlock(jacobian, jacobianBlock(ivar.number(), jvar.number()), ivar.dofIndices(), jvar.dofIndices(), ivar.scalingFactor());
     }
   }
 
@@ -1195,8 +1195,8 @@ Assembly::addJacobian(SparseMatrix<Number> & jacobian)
         MooseVariable & jvar = *(*jt);
         // We only add jacobian blocks for d(nl-var)/d(scalar-var) now (these we generated by kernels and BCs)
         // jacobian blocks d(scalar-var)/d(nl-var) are added later with addJacobianScalar
-        addJacobianBlock(jacobian, jacobianBlock(jvar.index(), ivar.index()), jvar.dofIndices(), ivar.dofIndices(), jvar.scalingFactor());
-        addJacobianBlock(jacobian, jacobianBlock(ivar.index(), jvar.index()), ivar.dofIndices(), jvar.dofIndices(), ivar.scalingFactor());
+        addJacobianBlock(jacobian, jacobianBlock(jvar.number(), ivar.number()), jvar.dofIndices(), ivar.dofIndices(), jvar.scalingFactor());
+        addJacobianBlock(jacobian, jacobianBlock(ivar.number(), jvar.number()), ivar.dofIndices(), jvar.dofIndices(), ivar.scalingFactor());
       }
     }
   }
@@ -1212,11 +1212,11 @@ Assembly::addJacobianNeighbor(SparseMatrix<Number> & jacobian)
     for (std::vector<MooseVariable *>::const_iterator jt = vars.begin(); jt != vars.end(); ++jt)
     {
       MooseVariable & jvar = *(*jt);
-      if ((*_cm)(ivar.index(), jvar.index()) != 0)
+      if ((*_cm)(ivar.number(), jvar.number()) != 0)
       {
-        addJacobianBlock(jacobian, jacobianBlockNeighbor(Moose::ElementNeighbor, ivar.index(), jvar.index()), ivar.dofIndices(), jvar.dofIndicesNeighbor(), ivar.scalingFactor());
-        addJacobianBlock(jacobian, jacobianBlockNeighbor(Moose::NeighborElement, ivar.index(), jvar.index()), ivar.dofIndicesNeighbor(), jvar.dofIndices(), ivar.scalingFactor());
-        addJacobianBlock(jacobian, jacobianBlockNeighbor(Moose::NeighborNeighbor, ivar.index(), jvar.index()), ivar.dofIndicesNeighbor(), jvar.dofIndicesNeighbor(), ivar.scalingFactor());
+        addJacobianBlock(jacobian, jacobianBlockNeighbor(Moose::ElementNeighbor, ivar.number(), jvar.number()), ivar.dofIndices(), jvar.dofIndicesNeighbor(), ivar.scalingFactor());
+        addJacobianBlock(jacobian, jacobianBlockNeighbor(Moose::NeighborElement, ivar.number(), jvar.number()), ivar.dofIndicesNeighbor(), jvar.dofIndices(), ivar.scalingFactor());
+        addJacobianBlock(jacobian, jacobianBlockNeighbor(Moose::NeighborNeighbor, ivar.number(), jvar.number()), ivar.dofIndicesNeighbor(), jvar.dofIndicesNeighbor(), ivar.scalingFactor());
       }
     }
   }
@@ -1232,8 +1232,8 @@ Assembly::cacheJacobian()
     for (std::vector<MooseVariable *>::const_iterator jt = vars.begin(); jt != vars.end(); ++jt)
     {
       MooseVariable & jvar = *(*jt);
-      if ((*_cm)(ivar.index(), jvar.index()) != 0)
-        cacheJacobianBlock(jacobianBlock(ivar.index(), jvar.index()), ivar.dofIndices(), jvar.dofIndices(), ivar.scalingFactor());
+      if ((*_cm)(ivar.number(), jvar.number()) != 0)
+        cacheJacobianBlock(jacobianBlock(ivar.number(), jvar.number()), ivar.dofIndices(), jvar.dofIndices(), ivar.scalingFactor());
     }
   }
 }
@@ -1248,11 +1248,11 @@ Assembly::cacheJacobianNeighbor()
     for (std::vector<MooseVariable *>::const_iterator jt = vars.begin(); jt != vars.end(); ++jt)
     {
       MooseVariable & jvar = *(*jt);
-      if ((*_cm)(ivar.index(), jvar.index()) != 0)
+      if ((*_cm)(ivar.number(), jvar.number()) != 0)
       {
-        cacheJacobianBlock(jacobianBlockNeighbor(Moose::ElementNeighbor, ivar.index(), jvar.index()), ivar.dofIndices(), jvar.dofIndicesNeighbor(), ivar.scalingFactor());
-        cacheJacobianBlock(jacobianBlockNeighbor(Moose::NeighborElement, ivar.index(), jvar.index()), ivar.dofIndicesNeighbor(), jvar.dofIndices(), ivar.scalingFactor());
-        cacheJacobianBlock(jacobianBlockNeighbor(Moose::NeighborNeighbor, ivar.index(), jvar.index()), ivar.dofIndicesNeighbor(), jvar.dofIndicesNeighbor(), ivar.scalingFactor());
+        cacheJacobianBlock(jacobianBlockNeighbor(Moose::ElementNeighbor, ivar.number(), jvar.number()), ivar.dofIndices(), jvar.dofIndicesNeighbor(), ivar.scalingFactor());
+        cacheJacobianBlock(jacobianBlockNeighbor(Moose::NeighborElement, ivar.number(), jvar.number()), ivar.dofIndicesNeighbor(), jvar.dofIndices(), ivar.scalingFactor());
+        cacheJacobianBlock(jacobianBlockNeighbor(Moose::NeighborNeighbor, ivar.number(), jvar.number()), ivar.dofIndicesNeighbor(), jvar.dofIndicesNeighbor(), ivar.scalingFactor());
       }
     }
   }
@@ -1327,7 +1327,7 @@ Assembly::addJacobianScalar(SparseMatrix<Number> & jacobian)
     for (std::vector<MooseVariableScalar *>::const_iterator jt = scalar_vars.begin(); jt != scalar_vars.end(); ++jt)
     {
       MooseVariableScalar & jvar = *(*jt);
-      addJacobianBlock(jacobian, jacobianBlock(ivar.index(), jvar.index()), ivar.dofIndices(), jvar.dofIndices(), ivar.scalingFactor());
+      addJacobianBlock(jacobian, jacobianBlock(ivar.number(), jvar.number()), ivar.dofIndices(), jvar.dofIndices(), ivar.scalingFactor());
     }
   }
 }
@@ -1340,6 +1340,6 @@ Assembly::addJacobianOffDiagScalar(SparseMatrix<Number> & jacobian, unsigned int
   for (std::vector<MooseVariable *>::const_iterator jt = vars.begin(); jt != vars.end(); ++jt)
   {
     MooseVariable & var_j = *(*jt);
-    addJacobianBlock(jacobian, jacobianBlock(var_i.index(), var_j.index()), var_i.dofIndices(), var_j.dofIndices(), var_i.scalingFactor());
+    addJacobianBlock(jacobian, jacobianBlock(var_i.number(), var_j.number()), var_i.dofIndices(), var_j.dofIndices(), var_i.scalingFactor());
   }
 }

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -206,7 +206,7 @@ BlockRestrictable::variableSubdomianIDs(InputParameters & parameters) const
     var = &_blk_feproblem->getVariable(tid, parameters.get<AuxVariableName>("variable"));
 
   // Return the block ids for the variable
-  return sys->getSubdomainsForVar(var->index());
+  return sys->getSubdomainsForVar(var->number());
 }
 
 bool

--- a/framework/src/base/ComputeDiracThread.C
+++ b/framework/src/base/ComputeDiracThread.C
@@ -90,7 +90,7 @@ ComputeDiracThread::onElement(const Elem * elem)
           dirac->computeResidual();
         else
         {
-          dirac->subProblem().prepareShapes(dirac->variable().index(), _tid);
+          dirac->subProblem().prepareShapes(dirac->variable().number(), _tid);
           dirac->computeJacobian();
         }
       }

--- a/framework/src/base/ComputeFullJacobianThread.C
+++ b/framework/src/base/ComputeFullJacobianThread.C
@@ -45,8 +45,8 @@ ComputeFullJacobianThread::computeJacobian()
     MooseVariable & ivariable = *(*it).first;
     MooseVariable & jvariable = *(*it).second;
 
-    unsigned int ivar = ivariable.index();
-    unsigned int jvar = jvariable.index();
+    unsigned int ivar = ivariable.number();
+    unsigned int jvar = jvariable.number();
 
     if (ivariable.activeOnSubdomain(_subdomain) && jvariable.activeOnSubdomain(_subdomain))
     {
@@ -55,7 +55,7 @@ ComputeFullJacobianThread::computeJacobian()
       for (std::vector<KernelBase *>::const_iterator kt = kernels.begin(); kt != kernels.end(); ++kt)
       {
         KernelBase * kernel = *kt;
-        if ((kernel->variable().index() == ivar) && kernel->isImplicit())
+        if ((kernel->variable().number() == ivar) && kernel->isImplicit())
         {
           kernel->subProblem().prepareShapes(jvar, _tid);
           kernel->computeOffDiagJacobian(jvar);
@@ -75,7 +75,7 @@ ComputeFullJacobianThread::computeJacobian()
       if (ivar.activeOnSubdomain(_subdomain) > 0)
       {
         // for each variable get the list of active kernels
-        const std::vector<KernelBase *> & kernels = _sys._kernels[_tid].activeVar(ivar.index());
+        const std::vector<KernelBase *> & kernels = _sys._kernels[_tid].activeVar(ivar.number());
         for (std::vector<KernelBase *>::const_iterator kt = kernels.begin(); kt != kernels.end(); ++kt)
         {
           KernelBase * kernel = *kt;
@@ -88,7 +88,7 @@ ComputeFullJacobianThread::computeJacobian()
               MooseVariableScalar & jvar = *(*jt);
               // Do: dvar / dscalar_var
               if (_sys.hasScalarVariable(jvar.name()))              // want to process only nl-variables (not aux ones)
-                kernel->computeOffDiagJacobianScalar(jvar.index());
+                kernel->computeOffDiagJacobianScalar(jvar.number());
             }
           }
         }
@@ -112,10 +112,10 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
       for (std::vector<IntegratedBC *>::iterator jt = bcs.begin(); jt != bcs.end(); ++jt)
       {
         IntegratedBC * bc = *jt;
-        if (bc->shouldApply() && bc->variable().index() == ivar.index() && bc->isImplicit())
+        if (bc->shouldApply() && bc->variable().number() == ivar.number() && bc->isImplicit())
         {
-          bc->subProblem().prepareFaceShapes(jvar.index(), _tid);
-          bc->computeJacobianBlock(jvar.index());
+          bc->subProblem().prepareFaceShapes(jvar.number(), _tid);
+          bc->computeJacobianBlock(jvar.number());
         }
       }
     }
@@ -136,7 +136,7 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
         for (std::vector<IntegratedBC *>::iterator kt = bcs.begin(); kt != bcs.end(); ++kt)
         {
           IntegratedBC * bc = *kt;
-          if (bc->variable().index() == ivar.index() && bc->isImplicit())
+          if (bc->variable().number() == ivar.number() && bc->isImplicit())
           {
             // now, get the list of coupled scalar vars and compute their off-diag jacobians
             const std::vector<MooseVariableScalar *> coupled_scalar_vars = bc->getCoupledMooseScalarVars();
@@ -145,7 +145,7 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
               MooseVariableScalar & jvar = *(*jt);
               // Do: dvar / dscalar_var
               if (_sys.hasScalarVariable(jvar.name()))              // want to process only nl-variables (not aux ones)
-                bc->computeJacobianBlockScalar(jvar.index());
+                bc->computeJacobianBlockScalar(jvar.number());
             }
           }
         }
@@ -166,11 +166,11 @@ ComputeFullJacobianThread::computeInternalFaceJacobian()
     std::vector<DGKernel *> dgks = _sys._dg_kernels[_tid].active();
     for (std::vector<DGKernel *>::iterator dg_it = dgks.begin(); dg_it != dgks.end(); ++dg_it)
     {
-      unsigned int ivar = (*it).first->index();
+      unsigned int ivar = (*it).first->number();
       DGKernel * dg = *dg_it;
-      if (dg->variable().index() == ivar && dg->isImplicit())
+      if (dg->variable().number() == ivar && dg->isImplicit())
       {
-        unsigned int jvar = (*it).second->index();
+        unsigned int jvar = (*it).second->number();
         dg->subProblem().prepareNeighborShapes(jvar, _tid);
         dg->computeOffDiagJacobian(jvar);
       }

--- a/framework/src/base/ComputeJacobianBlockThread.C
+++ b/framework/src/base/ComputeJacobianBlockThread.C
@@ -87,7 +87,7 @@ ComputeJacobianBlockThread::operator() (const ConstElemRange & range, bool bypas
       for (std::vector<KernelBase *>::const_iterator it = kernels.begin(); it != kernels.end(); it++)
       {
         KernelBase * kernel = *it;
-        if (kernel->variable().index() == _ivar)
+        if (kernel->variable().number() == _ivar)
         {
           kernel->subProblem().prepareShapes(_jvar, _tid);
           kernel->computeOffDiagJacobian(_jvar);
@@ -117,7 +117,7 @@ ComputeJacobianBlockThread::operator() (const ConstElemRange & range, bool bypas
               for (std::vector<IntegratedBC *>::iterator it = bcs.begin(); it != bcs.end(); ++it)
               {
                 IntegratedBC * bc = *it;
-                if (bc->variable().index() == _ivar)
+                if (bc->variable().number() == _ivar)
                 {
                   if (bc->shouldApply())
                   {
@@ -156,7 +156,7 @@ ComputeJacobianBlockThread::operator() (const ConstElemRange & range, bool bypas
               for (std::vector<DGKernel *>::iterator it = dgks.begin(); it != dgks.end(); ++it)
               {
                 DGKernel * dg = *it;
-                if (dg->variable().index() == _ivar)
+                if (dg->variable().number() == _ivar)
                 {
                   dg->subProblem().prepareFaceShapes(_jvar, _tid);
                   dg->subProblem().prepareNeighborShapes(_jvar, _tid);

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -52,7 +52,7 @@ ComputeJacobianThread::computeJacobian()
     KernelBase * kernel = *it;
     if (kernel->isImplicit())
     {
-      kernel->subProblem().prepareShapes(kernel->variable().index(), _tid);
+      kernel->subProblem().prepareShapes(kernel->variable().number(), _tid);
       kernel->computeJacobian();
     }
   }
@@ -67,7 +67,7 @@ ComputeJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
     IntegratedBC * bc = *it;
     if (bc->shouldApply() && bc->isImplicit())
     {
-      bc->subProblem().prepareFaceShapes(bc->variable().index(), _tid);
+      bc->subProblem().prepareFaceShapes(bc->variable().number(), _tid);
       bc->computeJacobian();
     }
   }
@@ -82,8 +82,8 @@ ComputeJacobianThread::computeInternalFaceJacobian()
     DGKernel * dg = *it;
     if (dg->isImplicit())
     {
-      dg->subProblem().prepareFaceShapes(dg->variable().index(), _tid);
-      dg->subProblem().prepareNeighborShapes(dg->variable().index(), _tid);
+      dg->subProblem().prepareFaceShapes(dg->variable().number(), _tid);
+      dg->subProblem().prepareNeighborShapes(dg->variable().number(), _tid);
       dg->computeJacobian();
     }
   }

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -123,8 +123,8 @@ Coupleable::coupled(const std::string & var_name, unsigned int comp)
   MooseVariable * var = getVar(var_name, comp);
   switch (var->kind())
   {
-  case Moose::VAR_NONLINEAR: return getVar(var_name, comp)->index();
-  case Moose::VAR_AUXILIARY: return std::numeric_limits<unsigned int>::max() - getVar(var_name, comp)->index();
+  case Moose::VAR_NONLINEAR: return getVar(var_name, comp)->number();
+  case Moose::VAR_AUXILIARY: return std::numeric_limits<unsigned int>::max() - getVar(var_name, comp)->number();
   }
   mooseError("Unknown variable kind. Corrupted binary?");
 }

--- a/framework/src/base/FlagElementsThread.C
+++ b/framework/src/base/FlagElementsThread.C
@@ -33,7 +33,7 @@ FlagElementsThread::FlagElementsThread(FEProblem & fe_problem,
     _system_number(_aux_sys.number()),
     _adaptivity(_fe_problem.adaptivity()),
     _field_var(_adaptivity.getMarkerVariable()),
-    _field_var_number(_field_var.index()),
+    _field_var_number(_field_var.number()),
     _serialized_solution(serialized_solution),
     _max_h_level(max_h_level)
 {

--- a/framework/src/base/MooseVariableBase.C
+++ b/framework/src/base/MooseVariableBase.C
@@ -36,12 +36,6 @@ MooseVariableBase::~MooseVariableBase()
 }
 
 unsigned int
-MooseVariableBase::index() const
-{
-  return _var_num;
-}
-
-unsigned int
 MooseVariableBase::number() const
 {
   return _var_num;

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1461,8 +1461,8 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
               {
                 constraints_applied = true;
 
-                nfc->subProblem().prepareShapes(nfc->variable().index(), 0);
-                nfc->subProblem().prepareNeighborShapes(nfc->variable().index(), 0);
+                nfc->subProblem().prepareShapes(nfc->variable().number(), 0);
+                nfc->subProblem().prepareNeighborShapes(nfc->variable().number(), 0);
 
                 nfc->computeJacobian();
 
@@ -1573,7 +1573,7 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
         for (std::vector<FaceFaceConstraint *>::iterator fc_it = face_constraints.begin(); fc_it != face_constraints.end(); ++fc_it)
         {
           FaceFaceConstraint * ffc = *fc_it;
-          ffc->subProblem().prepareShapes(ffc->variable().index(), tid);
+          ffc->subProblem().prepareShapes(ffc->variable().number(), tid);
           ffc->computeJacobian(jacobian);
         }
       }
@@ -1599,7 +1599,7 @@ NonlinearSystem::computeScalarKernelsJacobians(SparseMatrix<Number> & jacobian)
 
       kernel->reinit();
       kernel->computeJacobian();
-      _fe_problem.addJacobianOffDiagScalar(jacobian, kernel->variable().index());
+      _fe_problem.addJacobianOffDiagScalar(jacobian, kernel->variable().number());
     }
     _fe_problem.addJacobianScalar(jacobian);
   }
@@ -1836,7 +1836,7 @@ NonlinearSystem::computeJacobianBlock(SparseMatrix<Number> & jacobian, libMesh::
           for (std::vector<NodalBC *>::iterator it = bcs.begin(); it != bcs.end(); ++it)
           {
             NodalBC * bc = *it;
-            if (bc->variable().index() == ivar && bc->shouldApply())
+            if (bc->variable().number() == ivar && bc->shouldApply())
             {
               //The first zero is for the variable number... there is only one variable in each mini-system
               //The second zero only works with Lagrange elements!

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -74,7 +74,7 @@ ScalarCoupleable::isCoupledScalar(const std::string & var_name, unsigned int i)
 unsigned int
 ScalarCoupleable::coupledScalar(const std::string & var_name, unsigned int comp)
 {
-  return getScalarVar(var_name, comp)->index();
+  return getScalarVar(var_name, comp)->number();
 }
 
 

--- a/framework/src/base/UpdateErrorVectorsThread.C
+++ b/framework/src/base/UpdateErrorVectorsThread.C
@@ -35,7 +35,7 @@ UpdateErrorVectorsThread::UpdateErrorVectorsThread(FEProblem & fe_problem, std::
       it != _indicator_field_to_error_vector.end();
       ++it)
   {
-    unsigned int var_num = _aux_sys.getVariable(0, it->first).index();
+    unsigned int var_num = _aux_sys.getVariable(0, it->first).number();
     _indicator_field_number_to_error_vector[var_num] = it->second;
   }
 }

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -101,7 +101,7 @@ IntegratedBC::~IntegratedBC()
 void
 IntegratedBC::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   _local_re.resize(re.size());
   _local_re.zero();
 
@@ -122,7 +122,7 @@ IntegratedBC::computeResidual()
 void
 IntegratedBC::computeJacobian()
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
   _local_ke.resize(ke.m(), ke.n());
   _local_ke.zero();
 
@@ -151,13 +151,13 @@ IntegratedBC::computeJacobianBlock(unsigned int jvar)
 {
 //  Moose::perf_log.push("computeJacobianBlock()","IntegratedBC");
 
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), jvar);
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
 
   for (_qp=0; _qp<_qrule->n_points(); _qp++)
     for (_i=0; _i<_test.size(); _i++)
       for (_j=0; _j<_phi.size(); _j++)
       {
-        if (_var.index() == jvar)
+        if (_var.number() == jvar)
           ke(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpJacobian();
         else
           ke(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpOffDiagJacobian(jvar);
@@ -169,7 +169,7 @@ IntegratedBC::computeJacobianBlock(unsigned int jvar)
 void
 IntegratedBC::computeJacobianBlockScalar(unsigned int jvar)
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), jvar);
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
 
   MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)

--- a/framework/src/constraints/FaceFaceConstraint.C
+++ b/framework/src/constraints/FaceFaceConstraint.C
@@ -100,7 +100,7 @@ FaceFaceConstraint::reinit()
 void
 FaceFaceConstraint::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     for (_i = 0; _i < _test.size(); _i++)
       re(_i) += _JxW_lm[_qp] * _coord[_qp] * computeQpResidual();
@@ -116,7 +116,7 @@ FaceFaceConstraint::computeResidualSide()
     _assembly.prepare();
     _assembly.reinitAtPhysical(_elem_master, _phys_points_master);
 
-    DenseVector<Number> & re_master = _assembly.residualBlock(_master_var.index());
+    DenseVector<Number> & re_master = _assembly.residualBlock(_master_var.number());
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     {
       for (_i = 0; _i < _test_master.size(); _i++)
@@ -132,7 +132,7 @@ FaceFaceConstraint::computeResidualSide()
     _assembly.prepare();
     _assembly.reinitAtPhysical(_elem_slave, _phys_points_slave);
 
-    DenseVector<Number> & re_slave = _assembly.residualBlock(_slave_var.index());
+    DenseVector<Number> & re_slave = _assembly.residualBlock(_slave_var.number());
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     {
       for (_i = 0; _i < _test_slave.size(); _i++)
@@ -175,7 +175,7 @@ FaceFaceConstraint::computeJacobian(SparseMatrix<Number> & jacobian)
 
   // fill in the diagonal block
   {
-    DenseMatrix<Number> & Kee = _assembly.jacobianBlock(_var.index(), _var.index());
+    DenseMatrix<Number> & Kee = _assembly.jacobianBlock(_var.number(), _var.number());
 
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
       for (_i = 0; _i < _test.size(); _i++)
@@ -191,8 +191,8 @@ FaceFaceConstraint::computeJacobian(SparseMatrix<Number> & jacobian)
     _assembly.prepare();
     _assembly.reinitAtPhysical(_elem_master, _phys_points_master);
 
-    DenseMatrix<Number> & Ken_master = _assembly.jacobianBlock(_var.index(), _master_var.index());
-    DenseMatrix<Number> & Kne_master = _assembly.jacobianBlock(_master_var.index(), _var.index());
+    DenseMatrix<Number> & Ken_master = _assembly.jacobianBlock(_var.number(), _master_var.number());
+    DenseMatrix<Number> & Kne_master = _assembly.jacobianBlock(_master_var.number(), _var.number());
 
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
       for (_i = 0; _i < _test_master.size(); _i++)
@@ -213,8 +213,8 @@ FaceFaceConstraint::computeJacobian(SparseMatrix<Number> & jacobian)
     _assembly.prepare();
     _assembly.reinitAtPhysical(_elem_slave, _phys_points_slave);
 
-    DenseMatrix<Number> & Ken_slave = _assembly.jacobianBlock(_var.index(), _slave_var.index());
-    DenseMatrix<Number> & Kne_slave = _assembly.jacobianBlock(_slave_var.index(), _var.index());
+    DenseMatrix<Number> & Ken_slave = _assembly.jacobianBlock(_var.number(), _slave_var.number());
+    DenseMatrix<Number> & Kne_slave = _assembly.jacobianBlock(_slave_var.number(), _var.number());
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
       for (_i = 0; _i < _test_slave.size(); _i++)
       {

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -100,8 +100,8 @@ NodeFaceConstraint::computeSlaveValue(NumericVector<Number> & current_solution)
 void
 NodeFaceConstraint::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
-  DenseVector<Number> & neighbor_re = _assembly.residualBlockNeighbor(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
+  DenseVector<Number> & neighbor_re = _assembly.residualBlockNeighbor(_var.number());
 
   _qp=0;
 
@@ -119,10 +119,10 @@ NodeFaceConstraint::computeJacobian()
   getConnectedDofIndices();
 
   //  DenseMatrix<Number> & Kee = _assembly.jacobianBlock(_var.number(), _var.number());
-  DenseMatrix<Number> & Ken = _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.index(), _var.index());
+  DenseMatrix<Number> & Ken = _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), _var.number());
 
   //  DenseMatrix<Number> & Kne = _assembly.jacobianBlockNeighbor(Moose::NeighborElement, _var.number(), _var.number());
-  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _var.index(), _var.index());
+  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _var.number(), _var.number());
 
   _Kee.resize(_test_slave.size(), _connected_dof_indices.size());
   _Kne.resize(_test_master.size(), _connected_dof_indices.size());

--- a/framework/src/constraints/TiedValueConstraint.C
+++ b/framework/src/constraints/TiedValueConstraint.C
@@ -48,7 +48,7 @@ TiedValueConstraint::computeQpResidual(Moose::ConstraintType type)
     retVal = (_u_slave[_qp] - _u_master[_qp])*_test_slave[_i][_qp]*_scaling;
     break;
   case Moose::Master:
-    slave_resid = _residual_copy(_current_node->dof_number(0, _var.index(), 0)) / scaling_factor;
+    slave_resid = _residual_copy(_current_node->dof_number(0, _var.number(), 0)) / scaling_factor;
     retVal = slave_resid*_test_master[_i][_qp];
     break;
   default:
@@ -72,7 +72,7 @@ TiedValueConstraint::computeQpJacobian(Moose::ConstraintJacobianType type)
     retVal = -_phi_master[_j][_qp]*_test_slave[_i][_qp]*_scaling;
     break;
   case Moose::MasterSlave:
-    slave_jac = (*_jacobian)(_current_node->dof_number(0, _var.index(), 0), _connected_dof_indices[_j]);
+    slave_jac = (*_jacobian)(_current_node->dof_number(0, _var.number(), 0), _connected_dof_indices[_j]);
     retVal = slave_jac*_test_master[_i][_qp] / scaling_factor;
     break;
   case Moose::MasterMaster:

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -109,8 +109,8 @@ DGKernel::computeResidual()
 {
 //  Moose::perf_log.push("computeResidual()","DGKernel");
 
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
-  DenseVector<Number> & neighbor_re = _assembly.residualBlockNeighbor(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
+  DenseVector<Number> & neighbor_re = _assembly.residualBlockNeighbor(_var.number());
 
   for (_qp=0; _qp<_qrule->n_points(); _qp++)
   {
@@ -129,11 +129,11 @@ DGKernel::computeJacobian()
 {
 //  Moose::perf_log.push("computeJacobian()","DGKernel");
 
-  DenseMatrix<Number> & Kee = _assembly.jacobianBlock(_var.index(), _var.index());
-  DenseMatrix<Number> & Ken = _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.index(), _var.index());
+  DenseMatrix<Number> & Kee = _assembly.jacobianBlock(_var.number(), _var.number());
+  DenseMatrix<Number> & Ken = _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), _var.number());
 
-  DenseMatrix<Number> & Kne = _assembly.jacobianBlockNeighbor(Moose::NeighborElement, _var.index(), _var.index());
-  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _var.index(), _var.index());
+  DenseMatrix<Number> & Kne = _assembly.jacobianBlockNeighbor(Moose::NeighborElement, _var.number(), _var.number());
+  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _var.number(), _var.number());
 
   for (_qp=0; _qp<_qrule->n_points(); _qp++)
   {
@@ -162,18 +162,18 @@ DGKernel::computeOffDiagJacobian(unsigned int jvar)
 {
 //  Moose::perf_log.push("computeOffDiagJacobian()","DGKernel");
 
-  DenseMatrix<Number> & Kee = _assembly.jacobianBlock(_var.index(), jvar);
-  DenseMatrix<Number> & Ken = _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.index(), jvar);
+  DenseMatrix<Number> & Kee = _assembly.jacobianBlock(_var.number(), jvar);
+  DenseMatrix<Number> & Ken = _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar);
 
-  DenseMatrix<Number> & Kne = _assembly.jacobianBlockNeighbor(Moose::NeighborElement, _var.index(), jvar);
-  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _var.index(), jvar);
+  DenseMatrix<Number> & Kne = _assembly.jacobianBlockNeighbor(Moose::NeighborElement, _var.number(), jvar);
+  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _var.number(), jvar);
 
   for (_qp=0; _qp<_qrule->n_points(); _qp++)
   {
     for (_i=0; _i<_test.size(); _i++)
       for (_j=0; _j<_phi.size(); _j++)
       {
-        if (jvar == _var.index())
+        if (jvar == _var.number())
           Kee(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpJacobian(Moose::ElementElement);
         else
           Kee(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpOffDiagJacobian(Moose::ElementElement, jvar);
@@ -182,7 +182,7 @@ DGKernel::computeOffDiagJacobian(unsigned int jvar)
     for (_i=0; _i<_test.size(); _i++)
       for (_j=0; _j<_phi_neighbor.size(); _j++)
       {
-        if (jvar == _var.index())
+        if (jvar == _var.number())
           Ken(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpJacobian(Moose::ElementNeighbor);
         else
           Ken(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpOffDiagJacobian(Moose::ElementNeighbor, jvar);
@@ -191,7 +191,7 @@ DGKernel::computeOffDiagJacobian(unsigned int jvar)
     for (_i=0; _i<_test_neighbor.size(); _i++)
       for (_j=0; _j<_phi.size(); _j++)
       {
-        if (jvar == _var.index())
+        if (jvar == _var.number())
           Kne(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpJacobian(Moose::NeighborElement);
         else
           Kne(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpOffDiagJacobian(Moose::NeighborElement, jvar);
@@ -200,7 +200,7 @@ DGKernel::computeOffDiagJacobian(unsigned int jvar)
     for (_i=0; _i<_test_neighbor.size(); _i++)
       for (_j=0; _j<_phi_neighbor.size(); _j++)
       {
-        if (jvar == _var.index())
+        if (jvar == _var.number())
           Knn(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpJacobian(Moose::NeighborNeighbor);
         else
           Knn(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpOffDiagJacobian(Moose::NeighborNeighbor, jvar);

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -79,7 +79,7 @@ DiracKernel::DiracKernel(const std::string & name, InputParameters parameters) :
 void
 DiracKernel::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
 
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {
@@ -95,7 +95,7 @@ DiracKernel::computeResidual()
 void
 DiracKernel::computeJacobian()
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
 
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -52,7 +52,7 @@ EigenKernel::EigenKernel(const std::string & name, InputParameters parameters) :
 void
 EigenKernel::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   _local_re.resize(re.size());
   _local_re.zero();
 
@@ -77,7 +77,7 @@ EigenKernel::computeJacobian()
 {
   if (!_is_implicit) return;
 
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
   _local_ke.resize(ke.m(), ke.n());
   _local_ke.zero();
 

--- a/framework/src/kernels/FDKernel.C
+++ b/framework/src/kernels/FDKernel.C
@@ -58,21 +58,21 @@ FDKernel::perturbedResidual(unsigned int varnum, unsigned int perturbationj, Rea
 void
 FDKernel::computeJacobian()
 {
-  computeOffDiagJacobian(_var.index());
+  computeOffDiagJacobian(_var.number());
 }
 
 void
 FDKernel::computeOffDiagJacobian(unsigned int jvar_index)
 {
 
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), jvar_index);
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar_index);
   DenseMatrix<Number> local_ke;
   local_ke.resize(ke.m(), ke.n());
   local_ke.zero();
 
   // FIXME: pull out the already computed element residual instead of recomputing it
   Real h;
-  DenseVector<Number> re = perturbedResidual(_var.index(),0,0.0,h);
+  DenseVector<Number> re = perturbedResidual(_var.number(),0,0.0,h);
   for (_j = 0; _j < _phi.size(); _j++) {
     DenseVector<Number> p_re = perturbedResidual(jvar_index,_j,_scale,h);
     for(_i = 0; _i < _test.size(); _i++) {
@@ -81,7 +81,7 @@ FDKernel::computeOffDiagJacobian(unsigned int jvar_index)
   }
   ke += local_ke;
 
-  if (jvar_index == _var.index()) {
+  if (jvar_index == _var.number()) {
     _local_ke = local_ke;
     if (_has_diag_save_in) {
       unsigned int rows = ke.m();
@@ -101,7 +101,7 @@ FDKernel::computeOffDiagJacobianScalar(unsigned int /*jvar*/)
 {
   // FIXME: implement me.
   /*
-    DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), jvar);
+    DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
     MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
 
     for (_i = 0; _i < _test.size(); _i++)

--- a/framework/src/kernels/Kernel.C
+++ b/framework/src/kernels/Kernel.C
@@ -46,7 +46,7 @@ Kernel::~Kernel()
 void
 Kernel::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   _local_re.resize(re.size());
   _local_re.zero();
 
@@ -68,7 +68,7 @@ Kernel::computeResidual()
 void
 Kernel::computeJacobian()
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
   _local_ke.resize(ke.m(), ke.n());
   _local_ke.zero();
 
@@ -95,11 +95,11 @@ Kernel::computeJacobian()
 void
 Kernel::computeOffDiagJacobian(unsigned int jvar)
 {
-  if (jvar == _var.index())
+  if (jvar == _var.number())
     computeJacobian();
   else
   {
-    DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), jvar);
+    DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
 
     for (_i=0; _i<_test.size(); _i++)
       for (_j=0; _j<_phi.size(); _j++)
@@ -113,7 +113,7 @@ Kernel::computeOffDiagJacobian(unsigned int jvar)
 void
 Kernel::computeOffDiagJacobianScalar(unsigned int jvar)
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), jvar);
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
   MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
 
   for (_i = 0; _i < _test.size(); _i++)

--- a/framework/src/kernels/KernelGrad.C
+++ b/framework/src/kernels/KernelGrad.C
@@ -38,7 +38,7 @@ KernelGrad::computeResidual()
 {
 //  Moose::perf_log.push("computeResidual()","KernelGrad");
 
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   _local_re.resize(re.size());
   _local_re.zero();
 
@@ -70,7 +70,7 @@ KernelGrad::computeResidual()
 void
 KernelGrad::computeJacobian()
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
   _local_ke.resize(ke.m(), ke.n());
   _local_ke.zero();
 
@@ -112,12 +112,12 @@ KernelGrad::computeOffDiagJacobian(unsigned int jvar)
 {
 //  Moose::perf_log.push("computeOffDiagJacobian()",_name);
 
-  DenseMatrix<Number> & Ke = _assembly.jacobianBlock(_var.index(), jvar);
+  DenseMatrix<Number> & Ke = _assembly.jacobianBlock(_var.number(), jvar);
 
   unsigned int n_qp = _qrule->n_points();
   unsigned int n_phi = _phi.size();
   unsigned int n_test = _test.size();
-  unsigned int var_num = _var.index();
+  unsigned int var_num = _var.number();
 
   for (_j=0; _j<n_phi; _j++)
     for (_qp=0; _qp<n_qp; _qp++)

--- a/framework/src/kernels/KernelValue.C
+++ b/framework/src/kernels/KernelValue.C
@@ -36,7 +36,7 @@ KernelValue::~KernelValue()
 void
 KernelValue::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   _local_re.resize(re.size());
   _local_re.zero();
 
@@ -60,7 +60,7 @@ KernelValue::computeResidual()
 void
 KernelValue::computeJacobian()
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
   _local_ke.resize(ke.m(), ke.n());
   _local_ke.zero();
 
@@ -95,12 +95,12 @@ KernelValue::computeOffDiagJacobian(unsigned int jvar)
 {
 //  Moose::perf_log.push("computeOffDiagJacobian()",_name);
 
-  DenseMatrix<Number> & Ke = _assembly.jacobianBlock(_var.index(), jvar);
+  DenseMatrix<Number> & Ke = _assembly.jacobianBlock(_var.number(), jvar);
 
   for (_j=0; _j<_phi.size(); _j++)
     for (_qp=0; _qp<_qrule->n_points(); _qp++)
     {
-      if (jvar == _var.index())
+      if (jvar == _var.number())
       {
         _value = _coord[_qp]*precomputeQpJacobian();
         for (_i=0; _i<_test.size(); _i++)

--- a/framework/src/kernels/KernelWarehouse.C
+++ b/framework/src/kernels/KernelWarehouse.C
@@ -112,7 +112,7 @@ KernelWarehouse::updateActiveKernels(unsigned int subdomain_id)
     {
       _time_kernels.push_back(kernel);
       _active_kernels.push_back(kernel);
-      _active_var_kernels[kernel->variable().index()].push_back(kernel);
+      _active_var_kernels[kernel->variable().number()].push_back(kernel);
     }
   }
   for (std::vector<KernelBase *>::const_iterator it = _nontime_global_kernels.begin(); it != _nontime_global_kernels.end(); ++it)
@@ -122,7 +122,7 @@ KernelWarehouse::updateActiveKernels(unsigned int subdomain_id)
     {
       _non_time_kernels.push_back(kernel);
       _active_kernels.push_back(kernel);
-      _active_var_kernels[kernel->variable().index()].push_back(kernel);
+      _active_var_kernels[kernel->variable().number()].push_back(kernel);
     }
   }
   // then kernels that live on a specified block
@@ -133,7 +133,7 @@ KernelWarehouse::updateActiveKernels(unsigned int subdomain_id)
     {
       _time_kernels.push_back(kernel);
       _active_kernels.push_back(kernel);
-      _active_var_kernels[kernel->variable().index()].push_back(kernel);
+      _active_var_kernels[kernel->variable().number()].push_back(kernel);
     }
   }
 
@@ -144,7 +144,7 @@ KernelWarehouse::updateActiveKernels(unsigned int subdomain_id)
     {
       _non_time_kernels.push_back(kernel);
       _active_kernels.push_back(kernel);
-      _active_var_kernels[kernel->variable().index()].push_back(kernel);
+      _active_var_kernels[kernel->variable().number()].push_back(kernel);
     }
   }
 }

--- a/framework/src/kernels/NodalScalarKernel.C
+++ b/framework/src/kernels/NodalScalarKernel.C
@@ -49,6 +49,6 @@ NodalScalarKernel::reinit()
 void
 NodalScalarKernel::computeOffDiagJacobian(unsigned int jvar)
 {
-  if (jvar == _var.index())
+  if (jvar == _var.number())
     computeJacobian();
 }

--- a/framework/src/kernels/ODEKernel.C
+++ b/framework/src/kernels/ODEKernel.C
@@ -39,7 +39,7 @@ ODEKernel::reinit()
 void
 ODEKernel::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   for (_i = 0; _i < _var.order(); _i++)
     re(_i) += computeQpResidual();
 }
@@ -47,7 +47,7 @@ ODEKernel::computeResidual()
 void
 ODEKernel::computeJacobian()
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
 
   for (_i = 0; _i < _var.order(); _i++)
     for (_j = 0; _j < _var.order(); _j++)
@@ -55,26 +55,26 @@ ODEKernel::computeJacobian()
       if (_i == _j)
         ke(_i, _j) += computeQpJacobian();
       else
-        ke(_i, _j) += computeQpOffDiagJacobian(_var.index());
+        ke(_i, _j) += computeQpOffDiagJacobian(_var.number());
     }
 }
 
 void
 ODEKernel::computeOffDiagJacobian(unsigned int jvar)
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), jvar);
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
   if (_sys.isScalarVariable(jvar))
   {
     MooseVariableScalar & var_j = _sys.getScalarVariable(_tid, jvar);
     for (_i = 0; _i < _var.order(); _i++)
       for (_j = 0; _j < var_j.order(); _j++)
       {
-        if (jvar == _var.index())
+        if (jvar == _var.number())
         {
           if (_i == _j)
             ke(_i, _j) += computeQpJacobian();
           else
-            ke(_i, _j) += computeQpOffDiagJacobian(_var.index());
+            ke(_i, _j) += computeQpOffDiagJacobian(_var.number());
         }
         else
           ke(_i, _j) += computeQpOffDiagJacobian(jvar);

--- a/framework/src/kernels/TimeDerivative.C
+++ b/framework/src/kernels/TimeDerivative.C
@@ -45,7 +45,7 @@ TimeDerivative::computeJacobian()
 {
   if (_lumping)
   {
-    DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+    DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
 
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < _phi.size(); _j++)

--- a/framework/src/kernels/TimeKernel.C
+++ b/framework/src/kernels/TimeKernel.C
@@ -33,7 +33,7 @@ TimeKernel::~TimeKernel()
 void
 TimeKernel::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index(), Moose::KT_TIME);
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number(), Moose::KT_TIME);
   _local_re.resize(re.size());
   _local_re.zero();
 

--- a/framework/src/preconditioners/FiniteDifferencePreconditioner.C
+++ b/framework/src/preconditioners/FiniteDifferencePreconditioner.C
@@ -53,8 +53,8 @@ FiniteDifferencePreconditioner::FiniteDifferencePreconditioner(const std::string
     std::vector<std::vector<unsigned int> > off_diag(n_vars);
     for (unsigned int i = 0; i < getParam<std::vector<std::string> >("off_diag_row").size(); i++)
     {
-      unsigned int row = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_row")[i]).index();
-      unsigned int column = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_column")[i]).index();
+      unsigned int row = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_row")[i]).number();
+      unsigned int column = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_column")[i]).number();
       (*cm)(row, column) = 1;
     }
 

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -75,8 +75,8 @@ PhysicsBasedPreconditioner::PhysicsBasedPreconditioner (const std::string & name
       std::vector<std::vector<unsigned int> > off_diag(n_vars);
       for (unsigned int i = 0; i < getParam<std::vector<std::string> >("off_diag_row").size(); i++)
       {
-        unsigned int row = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_row")[i]).index();
-        unsigned int column = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_column")[i]).index();
+        unsigned int row = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_row")[i]).number();
+        unsigned int column = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_column")[i]).number();
         (*cm)(row, column) = 1;
       }
 

--- a/framework/src/preconditioners/SingleMatrixPreconditioner.C
+++ b/framework/src/preconditioners/SingleMatrixPreconditioner.C
@@ -47,8 +47,8 @@ SingleMatrixPreconditioner::SingleMatrixPreconditioner(const std::string & name,
     std::vector<std::vector<unsigned int> > off_diag(n_vars);
     for(unsigned int i = 0; i < getParam<std::vector<std::string> >("off_diag_row").size(); i++)
     {
-      unsigned int row = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_row")[i]).index();
-      unsigned int column = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_column")[i]).index();
+      unsigned int row = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_row")[i]).number();
+      unsigned int column = nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_column")[i]).number();
       (*cm)(row, column) = 1;
     }
   }

--- a/framework/src/preconditioners/SplitBasedPreconditioner.C
+++ b/framework/src/preconditioners/SplitBasedPreconditioner.C
@@ -52,8 +52,8 @@ SplitBasedPreconditioner::SplitBasedPreconditioner (const std::string & name, In
     std::vector<std::vector<unsigned int> > off_diag(n_vars);
     for(unsigned int i = 0; i < getParam<std::vector<std::string> >("off_diag_row").size(); i++)
     {
-      unsigned int row = _nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_row")[i]).index();
-      unsigned int column = _nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_column")[i]).index();
+      unsigned int row = _nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_row")[i]).number();
+      unsigned int column = _nl.getVariable(0, getParam<std::vector<std::string> >("off_diag_column")[i]).number();
       (*cm)(row, column) = 1;
     }
   }

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -161,7 +161,7 @@ ContactMaster::updateContactSet(bool beginning_of_step)
     {
       const Node * node = pinfo->_node;
 
-      unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->index(), 0);
+      unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
 
       Real area = (*_aux_solution)( dof );
       if (area == 0)
@@ -205,7 +205,7 @@ ContactMaster::updateContactSet(bool beginning_of_step)
       {
         const Node * node = pinfo->_node;
 
-        unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->index(), 0);
+        unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
 
         Real area = (*_aux_solution)( dof );
         if (area == 0)

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -362,9 +362,9 @@ FrictionalContactProblem::enforceRateConstraint(NumericVector<Number>& vec_solut
 //              Moose::out<<"Slave node: "<<slave_node_num<<std::endl;
               const Node * node = info._node;
 
-              VectorValue<unsigned int> solution_dofs(node->dof_number(nonlinear_sys.number(), disp_x_var->index(), 0),
-                                                      node->dof_number(nonlinear_sys.number(), disp_y_var->index(), 0),
-                                                      (disp_z_var ? node->dof_number(nonlinear_sys.number(), disp_z_var->index(), 0) : 0));
+              VectorValue<unsigned int> solution_dofs(node->dof_number(nonlinear_sys.number(), disp_x_var->number(), 0),
+                                                      node->dof_number(nonlinear_sys.number(), disp_y_var->number(), 0),
+                                                      (disp_z_var ? node->dof_number(nonlinear_sys.number(), disp_z_var->number(), 0) : 0));
 
               //Get old parametric coords from info
               //get old element from info
@@ -504,17 +504,17 @@ FrictionalContactProblem::calculateSlip(const NumericVector<Number>& ghosted_sol
               {
                 _num_contact_nodes++;
 
-                VectorValue<unsigned int> residual_dofs(node->dof_number(aux_sys.number(), residual_x_var->index(), 0),
-                                                        node->dof_number(aux_sys.number(), residual_y_var->index(), 0),
-                                                        (residual_z_var ? node->dof_number(aux_sys.number(), residual_z_var->index(), 0) : 0));
+                VectorValue<unsigned int> residual_dofs(node->dof_number(aux_sys.number(), residual_x_var->number(), 0),
+                                                        node->dof_number(aux_sys.number(), residual_y_var->number(), 0),
+                                                        (residual_z_var ? node->dof_number(aux_sys.number(), residual_z_var->number(), 0) : 0));
 
-                VectorValue<unsigned int> diag_stiff_dofs(node->dof_number(aux_sys.number(), diag_stiff_x_var->index(), 0),
-                                                          node->dof_number(aux_sys.number(), diag_stiff_y_var->index(), 0),
-                                                          (diag_stiff_z_var ? node->dof_number(aux_sys.number(), diag_stiff_z_var->index(), 0) : 0));
+                VectorValue<unsigned int> diag_stiff_dofs(node->dof_number(aux_sys.number(), diag_stiff_x_var->number(), 0),
+                                                          node->dof_number(aux_sys.number(), diag_stiff_y_var->number(), 0),
+                                                          (diag_stiff_z_var ? node->dof_number(aux_sys.number(), diag_stiff_z_var->number(), 0) : 0));
 
-                VectorValue<unsigned int> inc_slip_dofs(node->dof_number(aux_sys.number(), inc_slip_x_var->index(), 0),
-                                                        node->dof_number(aux_sys.number(), inc_slip_y_var->index(), 0),
-                                                        (inc_slip_z_var ? node->dof_number(aux_sys.number(), inc_slip_z_var->index(), 0) : 0));
+                VectorValue<unsigned int> inc_slip_dofs(node->dof_number(aux_sys.number(), inc_slip_x_var->number(), 0),
+                                                        node->dof_number(aux_sys.number(), inc_slip_y_var->number(), 0),
+                                                        (inc_slip_z_var ? node->dof_number(aux_sys.number(), inc_slip_z_var->number(), 0) : 0));
 
                 RealVectorValue res_vec;
                 RealVectorValue stiff_vec;
@@ -720,8 +720,8 @@ FrictionalContactProblem::applySlip(NumericVector<Number>& vec_solution,
       inc_slip_var = inc_slip_z_var;
     }
 
-    unsigned int solution_dof = node->dof_number(nonlinear_sys.number(), disp_var->index(), 0);
-    unsigned int inc_slip_dof = node->dof_number(aux_sys.number(), inc_slip_var->index(), 0);
+    unsigned int solution_dof = node->dof_number(nonlinear_sys.number(), disp_var->number(), 0);
+    unsigned int inc_slip_dof = node->dof_number(aux_sys.number(), inc_slip_var->number(), 0);
 
     vec_solution.add(solution_dof, slip);
     aux_solution.add(inc_slip_dof, slip);
@@ -962,9 +962,9 @@ FrictionalContactProblem::updateIncrementalSlip()
           if(hpit != has_penetrated.end())
           {
             const Node * node = info._node;
-            VectorValue<unsigned int> inc_slip_dofs(node->dof_number(aux_sys.number(), inc_slip_x_var->index(), 0),
-                                                    node->dof_number(aux_sys.number(), inc_slip_y_var->index(), 0),
-                                                    (inc_slip_z_var ? node->dof_number(aux_sys.number(), inc_slip_z_var->index(), 0) : 0));
+            VectorValue<unsigned int> inc_slip_dofs(node->dof_number(aux_sys.number(), inc_slip_x_var->number(), 0),
+                                                    node->dof_number(aux_sys.number(), inc_slip_y_var->number(), 0),
+                                                    (inc_slip_z_var ? node->dof_number(aux_sys.number(), inc_slip_z_var->number(), 0) : 0));
 
             RealVectorValue inc_slip = info._incremental_slip;
 

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -145,7 +145,7 @@ MechanicalContactConstraint::updateContactSet(bool beginning_of_step)
     }
 
     const Node * node = pinfo->_node;
-    unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->index(), 0);
+    unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
     Real area = (*_aux_solution)( dof );
     if (area == 0)
     {

--- a/modules/contact/src/MultiDContactConstraint.C
+++ b/modules/contact/src/MultiDContactConstraint.C
@@ -245,7 +245,7 @@ MultiDContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType type)
     {
     case CM_FRICTIONLESS:
 
-      slave_jac = pinfo->_normal(_component) * pinfo->_normal(_component) * ( _penalty*_phi_slave[_j][_qp] - (*_jacobian)(_current_node->dof_number(0, _var.index(), 0), _connected_dof_indices[_j]) );
+      slave_jac = pinfo->_normal(_component) * pinfo->_normal(_component) * ( _penalty*_phi_slave[_j][_qp] - (*_jacobian)(_current_node->dof_number(0, _var.number(), 0), _connected_dof_indices[_j]) );
       break;
 
     case CM_GLUED:
@@ -285,7 +285,7 @@ MultiDContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType type)
     }
     return _test_slave[_i][_qp] * slave_jac;
   case Moose::MasterSlave:
-    slave_jac = (*_jacobian)(_current_node->dof_number(0, _var.index(), 0), _connected_dof_indices[_j]);
+    slave_jac = (*_jacobian)(_current_node->dof_number(0, _var.number(), 0), _connected_dof_indices[_j]);
     return slave_jac*_test_master[_i][_qp];
   case Moose::MasterMaster:
     return 0;

--- a/modules/contact/src/NodalArea.C
+++ b/modules/contact/src/NodalArea.C
@@ -78,7 +78,7 @@ NodalArea::finalize()
   for ( std::map<const Node *, Real>::iterator it = _node_areas.begin(); it != it_end; ++it )
   {
     const Node * const node = it->first;
-    unsigned int dof = node->dof_number(_system.number(), _variable->index(), 0);
+    unsigned int dof = node->dof_number(_system.number(), _variable->number(), 0);
     _aux_solution.set( dof, 0 );
   }
   _aux_solution.close();
@@ -86,7 +86,7 @@ NodalArea::finalize()
   for ( std::map<const Node *, Real>::iterator it = _node_areas.begin(); it != it_end; ++it )
   {
     const Node * const node = it->first;
-    unsigned int dof = node->dof_number(_system.number(), _variable->index(), 0);
+    unsigned int dof = node->dof_number(_system.number(), _variable->number(), 0);
     _aux_solution.add( dof, it->second );
   }
   _aux_solution.close();

--- a/modules/contact/src/OneDContactConstraint.C
+++ b/modules/contact/src/OneDContactConstraint.C
@@ -103,7 +103,7 @@ OneDContactConstraint::computeQpResidual(Moose::ConstraintType type)
     // return (_u_slave[_qp] - _u_master[_qp])*_test_slave[_i][_qp];
     return ((*_current_node)(0) - pinfo->_closest_point(0)) * _test_slave[_i][_qp];
   case Moose::Master:
-    double slave_resid = _residual_copy(_current_node->dof_number(0, _var.index(), 0));
+    double slave_resid = _residual_copy(_current_node->dof_number(0, _var.number(), 0));
     return slave_resid*_test_master[_i][_qp];
   }
   return 0;
@@ -120,7 +120,7 @@ OneDContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType type)
   case Moose::SlaveMaster:
     return -_phi_master[_j][_qp]*_test_slave[_i][_qp];
   case Moose::MasterSlave:
-    slave_jac = (*_jacobian)(_current_node->dof_number(0, _var.index(), 0), _connected_dof_indices[_j]);
+    slave_jac = (*_jacobian)(_current_node->dof_number(0, _var.number(), 0), _connected_dof_indices[_j]);
     return slave_jac*_test_master[_i][_qp];
   case Moose::MasterMaster:
     return 0;

--- a/modules/heat_conduction/src/GapConductance.C
+++ b/modules/heat_conduction/src/GapConductance.C
@@ -225,7 +225,7 @@ GapConductance::computeGapValues()
       std::vector<std::vector<Real> > & slave_side_phi = pinfo->_side_phi;
       std::vector<unsigned int> slave_side_dof_indices;
 
-      _dof_map->dof_indices(slave_side, slave_side_dof_indices, _temp_var->index());
+      _dof_map->dof_indices(slave_side, slave_side_dof_indices, _temp_var->number());
 
       for(unsigned int i=0; i<slave_side_dof_indices.size(); ++i)
       {

--- a/modules/heat_conduction/src/GapHeatPointSourceMaster.C
+++ b/modules/heat_conduction/src/GapHeatPointSourceMaster.C
@@ -67,7 +67,7 @@ GapHeatPointSourceMaster::computeQpResidual()
 {
   PenetrationInfo * pinfo = point_to_info[_current_point];
   const Node * node = pinfo->_node;
-  long int dof_number = node->dof_number(_sys.number(), _var.index(), 0);
+  long int dof_number = node->dof_number(_sys.number(), _var.number(), 0);
 
   return -_test[_i][_qp] * _slave_flux(dof_number);
 }

--- a/modules/phase_field/include/userobjects/SPPARKSUserObject.h
+++ b/modules/phase_field/include/userobjects/SPPARKSUserObject.h
@@ -239,7 +239,7 @@ protected:
     for ( ConstNodeRange::const_iterator i = node_range.begin(); i < node_range.end(); ++i )
     {
       // Get data
-      const Real value = aux_solution( (*i)->dof_number(aux_sys.number(), aux_var.index(), 0) );
+      const Real value = aux_solution( (*i)->dof_number(aux_sys.number(), aux_var.number(), 0) );
 
       elk_data[(*i)->id()] = value;
 

--- a/modules/richards/src/base/RichardsMultiphaseProblem.C
+++ b/modules/richards/src/base/RichardsMultiphaseProblem.C
@@ -47,8 +47,8 @@ RichardsMultiphaseProblem::initialSetup()
     mooseError("Both the bounded and lower variables must have the same order (eg FIRST) in RichardsMultiphaseProblem");
 
   // extract the required info
-  _bounded_var_num = bounded.index();
-  _lower_var_num = lower.index();
+  _bounded_var_num = bounded.number();
+  _lower_var_num = lower.number();
   /*
   Moose::out << "bounded_var_num = " << _bounded_var_num << "\n";
   Moose::out << "lower_var_num = " << _lower_var_num << "\n";

--- a/modules/richards/src/bcs/RichardsPiecewiseLinearSink.C
+++ b/modules/richards/src/bcs/RichardsPiecewiseLinearSink.C
@@ -31,7 +31,7 @@ RichardsPiecewiseLinearSink::RichardsPiecewiseLinearSink(const std::string & nam
     _m_func(getFunction("multiplying_fcn")),
 
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     _viscosity(getMaterialProperty<std::vector<Real> >("viscosity")),
     _permeability(getMaterialProperty<RealTensorValue>("permeability")),

--- a/modules/richards/src/dirackernels/RichardsBorehole.C
+++ b/modules/richards/src/dirackernels/RichardsBorehole.C
@@ -40,7 +40,7 @@ RichardsBorehole::RichardsBorehole(const std::string & name, InputParameters par
     _ddensity_val(&coupledValue("ddensity_var")),
 
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     _character(getFunction("character")),
     _p_bot(getParam<Real>("bottom_pressure")),

--- a/modules/richards/src/indicators/RichardsFluxJumpIndicator.C
+++ b/modules/richards/src/indicators/RichardsFluxJumpIndicator.C
@@ -19,7 +19,7 @@ RichardsFluxJumpIndicator::RichardsFluxJumpIndicator(const std::string & name, I
     JumpIndicator(name, parameters),
 
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     _density(getMaterialProperty<std::vector<Real> >("density")),
     _rel_perm(getMaterialProperty<std::vector<Real> >("rel_perm")),

--- a/modules/richards/src/kernels/RichardsFlux.C
+++ b/modules/richards/src/kernels/RichardsFlux.C
@@ -22,7 +22,7 @@ RichardsFlux::RichardsFlux(const std::string & name,
                                              InputParameters parameters) :
     Kernel(name,parameters),
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     // This kernel gets lots of things from the material
     _viscosity(getMaterialProperty<std::vector<Real> >("viscosity")),

--- a/modules/richards/src/kernels/RichardsLumpedMassChange.C
+++ b/modules/richards/src/kernels/RichardsLumpedMassChange.C
@@ -24,7 +24,7 @@ RichardsLumpedMassChange::RichardsLumpedMassChange(const std::string & name,
     TimeKernel(name,parameters),
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
     _num_p(_pp_name_UO.num_pp()),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     _porosity(getMaterialProperty<Real>("porosity")),
     _porosity_old(getMaterialProperty<Real>("porosity_old")),

--- a/modules/richards/src/kernels/RichardsMassChange.C
+++ b/modules/richards/src/kernels/RichardsMassChange.C
@@ -22,7 +22,7 @@ RichardsMassChange::RichardsMassChange(const std::string & name,
                                              InputParameters parameters) :
     TimeDerivative(name,parameters),
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     _use_supg(getParam<bool>("use_supg")),
     // This kernel expects input parameters named "bulk_mod", etc

--- a/modules/richards/src/postprocessors/RichardsExcavFlow.C
+++ b/modules/richards/src/postprocessors/RichardsExcavFlow.C
@@ -22,7 +22,7 @@ RichardsExcavFlow::RichardsExcavFlow(const std::string & name, InputParameters p
     FunctionInterface(parameters),
 
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     _viscosity(getMaterialProperty<std::vector<Real> >("viscosity")),
     _gravity(getMaterialProperty<RealVectorValue>("gravity")),

--- a/modules/richards/src/postprocessors/RichardsMass.C
+++ b/modules/richards/src/postprocessors/RichardsMass.C
@@ -21,7 +21,7 @@ RichardsMass::RichardsMass(const std::string & name, InputParameters parameters)
     ElementIntegralVariablePostprocessor(name, parameters),
 
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     _porosity(getMaterialProperty<Real>("porosity")),
     _sat(getMaterialProperty<std::vector<Real> >("sat")),

--- a/modules/richards/src/postprocessors/RichardsPiecewiseLinearSinkFlux.C
+++ b/modules/richards/src/postprocessors/RichardsPiecewiseLinearSinkFlux.C
@@ -33,7 +33,7 @@ RichardsPiecewiseLinearSinkFlux::RichardsPiecewiseLinearSinkFlux(const std::stri
     _m_func(getFunction("multiplying_fcn")),
 
     _pp_name_UO(getUserObject<RichardsPorepressureNames>("porepressureNames_UO")),
-    _pvar(_pp_name_UO.pressure_var_num(_var.index())),
+    _pvar(_pp_name_UO.pressure_var_num(_var.number())),
 
     _viscosity(getMaterialProperty<std::vector<Real> >("viscosity")),
     _permeability(getMaterialProperty<RealTensorValue>("permeability")),

--- a/modules/solid_mechanics/src/kernels/StressDivergenceTruss.C
+++ b/modules/solid_mechanics/src/kernels/StressDivergenceTruss.C
@@ -48,7 +48,7 @@ StressDivergenceTruss::initialSetup()
 void
 StressDivergenceTruss::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   mooseAssert(re.size() == 2, "Truss elements must have two nodes");
   _local_re.resize(re.size());
   _local_re.zero();
@@ -112,7 +112,7 @@ void
 StressDivergenceTruss::computeJacobian()
 {
 
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
   _local_ke.resize(ke.m(), ke.n());
   _local_ke.zero();
 
@@ -146,7 +146,7 @@ StressDivergenceTruss::computeJacobian()
 void
 StressDivergenceTruss::computeOffDiagJacobian(unsigned int jvar)
 {
-  if (jvar == _var.index())
+  if (jvar == _var.number())
   {
     computeJacobian();
   }
@@ -172,7 +172,7 @@ StressDivergenceTruss::computeOffDiagJacobian(unsigned int jvar)
       active = true;
     }
 
-    DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), jvar);
+    DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
 
     if (active)
     {

--- a/modules/solid_mechanics/src/materials/total_strain/TrussMaterial.C
+++ b/modules/solid_mechanics/src/materials/total_strain/TrussMaterial.C
@@ -102,12 +102,12 @@ TrussMaterial::computeProperties()
   NonlinearSystem & nonlinear_sys = _fe_problem.getNonlinearSystem();
   const NumericVector<Number>& ghosted_solution = *nonlinear_sys.currentSolution();
 
-  VectorValue<unsigned int> disp_dofs0(node0->dof_number(nonlinear_sys.number(), _disp_x_var->index(), 0),
-                                       (_disp_y_var ? node0->dof_number(nonlinear_sys.number(), _disp_y_var->index(), 0) : 0),
-                                       (_disp_z_var ? node0->dof_number(nonlinear_sys.number(), _disp_z_var->index(), 0) : 0));
-  VectorValue<unsigned int> disp_dofs1(node1->dof_number(nonlinear_sys.number(), _disp_x_var->index(), 0),
-                                       (_disp_y_var ? node1->dof_number(nonlinear_sys.number(), _disp_y_var->index(), 0) : 0),
-                                       (_disp_z_var ? node1->dof_number(nonlinear_sys.number(), _disp_z_var->index(), 0) : 0));
+  VectorValue<unsigned int> disp_dofs0(node0->dof_number(nonlinear_sys.number(), _disp_x_var->number(), 0),
+                                       (_disp_y_var ? node0->dof_number(nonlinear_sys.number(), _disp_y_var->number(), 0) : 0),
+                                       (_disp_z_var ? node0->dof_number(nonlinear_sys.number(), _disp_z_var->number(), 0) : 0));
+  VectorValue<unsigned int> disp_dofs1(node1->dof_number(nonlinear_sys.number(), _disp_x_var->number(), 0),
+                                       (_disp_y_var ? node1->dof_number(nonlinear_sys.number(), _disp_y_var->number(), 0) : 0),
+                                       (_disp_z_var ? node1->dof_number(nonlinear_sys.number(), _disp_z_var->number(), 0) : 0));
 
   RealVectorValue disp_vec0;
   RealVectorValue disp_vec1;

--- a/test/src/kernels/ForcingFn.C
+++ b/test/src/kernels/ForcingFn.C
@@ -19,7 +19,7 @@ ForcingFn::funcValue()
   Point pt = _q_point[_qp];
 
 //  return (pt(0)*pt(0) + pt(1)*pt(1));
-  if (_var.index() == 0)
+  if (_var.number() == 0)
     return (pt(0)*pt(0) + pt(1)*pt(1));
   else
     return -4;

--- a/test/src/kernels/ScalarLagrangeMultiplier.C
+++ b/test/src/kernels/ScalarLagrangeMultiplier.C
@@ -29,8 +29,8 @@ ScalarLagrangeMultiplier::computeQpResidual()
 void
 ScalarLagrangeMultiplier::computeOffDiagJacobianScalar(unsigned int jvar)
 {
-  DenseMatrix<Number> & ken = _assembly.jacobianBlock(_var.index(), jvar);
-  DenseMatrix<Number> & kne = _assembly.jacobianBlock(jvar, _var.index());
+  DenseMatrix<Number> & ken = _assembly.jacobianBlock(_var.number(), jvar);
+  DenseMatrix<Number> & kne = _assembly.jacobianBlock(jvar, _var.number());
   MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
 
   for (_i = 0; _i < _test.size(); _i++)

--- a/test/src/scalarkernels/AlphaCED.C
+++ b/test/src/scalarkernels/AlphaCED.C
@@ -41,7 +41,7 @@ AlphaCED::reinit()
 void
 AlphaCED::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   for (_i = 0; _i < re.size(); _i++)
     re(_i) += computeQpResidual();
 }
@@ -55,7 +55,7 @@ AlphaCED::computeQpResidual()
 void
 AlphaCED::computeJacobian()
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
   for (_i = 0; _i < ke.m(); _i++)
     ke(_i, _i) += computeQpJacobian();
 }

--- a/test/src/scalarkernels/PostprocessorCED.C
+++ b/test/src/scalarkernels/PostprocessorCED.C
@@ -29,7 +29,7 @@ PostprocessorCED::reinit()
 void
 PostprocessorCED::computeResidual()
 {
-  DenseVector<Number> & re = _assembly.residualBlock(_var.index());
+  DenseVector<Number> & re = _assembly.residualBlock(_var.number());
   for (_i = 0; _i < re.size(); _i++)
     re(_i) += computeQpResidual();
 }
@@ -43,7 +43,7 @@ PostprocessorCED::computeQpResidual()
 void
 PostprocessorCED::computeJacobian()
 {
-  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.index(), _var.index());
+  DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), _var.number());
   for (_i = 0; _i < ke.m(); _i++)
     ke(_i, _i) += computeQpJacobian();
 }


### PR DESCRIPTION
It is not needed, since it returns the variable number which is the
task done by number().
