### PR TITLE
Removing mesh dimension restriction from PenetrationLocator (closes #309...

### DIFF
--- a/framework/include/geomsearch/PenetrationLocator.h
+++ b/framework/include/geomsearch/PenetrationLocator.h
@@ -99,8 +99,8 @@ public:
 
   FEType _fe_type;
 
-  // One FE for each thread
-  std::vector<FEBase * > _fe;
+  // One FE for each thread and for each dimension
+  std::vector<std::vector<FEBase *> > _fe;
 
   NearestNodeLocator & _nearest_node;
 

--- a/framework/include/geomsearch/PenetrationThread.h
+++ b/framework/include/geomsearch/PenetrationThread.h
@@ -33,7 +33,7 @@ public:
                     bool do_normal_smoothing,
                     Real normal_smoothing_distance,
                     PenetrationLocator::NORMAL_SMOOTHING_METHOD normal_smoothing_method,
-                    std::vector<FEBase * > & fes,
+                    std::vector<std::vector<FEBase *> > & fes,
                     FEType & fe_type,
                     NearestNodeLocator & nearest_node,
                     std::map<unsigned int, std::vector<unsigned int> > & node_to_elem_map,
@@ -67,7 +67,7 @@ protected:
   MooseVariable * _nodal_normal_y;
   MooseVariable * _nodal_normal_z;
 
-  std::vector<FEBase * > & _fes;
+  std::vector<std::vector<FEBase *> > & _fes;
 
   FEType & _fe_type;
 


### PR DESCRIPTION
...9)

When having a higher dimensional mesh and using lower-dimensional
elements, PenetrationLocator cannot deal with it, since it assumes that
all elements have dimension equal to the mesh dimension.
