### PR TITLE
Temporarily disabling recover for the material output stuff

### DIFF
--- a/test/tests/materials/output/tests
+++ b/test/tests/materials/output/tests
@@ -9,6 +9,7 @@
     type = 'Exodiff'
     input = 'output_block.i'
     exodiff = 'output_block_out.e'
+    recover = false
   [../]
   [./boundary]
     type = 'Exodiff'


### PR DESCRIPTION
This patch temporarily disables a test in recover mode.

Refs #3082 
Refs #3129.
