### PR TITLE
SideSetsAroundSubdomain should work with ParallelMesh

### DIFF
--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -57,9 +57,6 @@ SideSetsAroundSubdomain::modify()
   if (!_mesh_ptr)
     mooseError("_mesh_ptr must be initialized before calling SideSetsAroundSubdomain::modify()!");
 
-  // We can't call this in the constructor, it appears that _mesh_ptr is always NULL there.
-  _mesh_ptr->errorIfParallelDistribution("SideSetsAroundSubdomain");
-
   // Reference the the libMesh::MeshBase
   MeshBase & mesh = _mesh_ptr->getMesh();
 

--- a/test/tests/mesh_modifiers/sidesets_around_subdomain/tests
+++ b/test/tests/mesh_modifiers/sidesets_around_subdomain/tests
@@ -13,6 +13,5 @@
     cli_args = '--mesh-only'
     exodiff = 'around_normals_in.e'
     recover = false
-    mesh_mode = 'SERIAL'
   [../]
 []


### PR DESCRIPTION
Forces this test to use SerialMesh.  Maybe we should also put

```
mesh_mode = 'SERIAL'
```

in the tests file so these types of tests are actually skipped in parmesh builds?

Refs #2129.
