### PR TITLE
[AuxKernels] handles both boundary and block restricted

### DIFF
--- a/framework/include/actions/MaterialOutputAction.h
+++ b/framework/include/actions/MaterialOutputAction.h
@@ -48,7 +48,7 @@ public:
   virtual ~MaterialOutputAction();
 
   /**
-   * Performs the task of adding a AuxVarialbe and AuxKernel for outputting material properites
+   * Performs the task of adding a AuxVariable and AuxKernel for outputting material properties
    */
   virtual void act();
 
@@ -78,7 +78,7 @@ private:
   /**
    * A method for creating an AuxVariable and associated action
    * @param type The action type to create
-   * @param property_name The property name to associated with that actoin
+   * @param property_name The property name to associated with that action
    * @param variable_name The AuxVariable name to create
    * @param material A pointer to the Material object containing the property of interest
    */
@@ -97,10 +97,12 @@ private:
   /// Set of variable names for boundary
   std::set<AuxVariableName> _variable_names;
 
+  /// List of variables for the current Material object
   std::set<AuxVariableName> _material_variable_names;
 
   /// Reference to the OutputWarehouse
   OutputWarehouse & _output_warehouse;
+
 };
 
 template<typename T>

--- a/framework/include/auxkernels/AuxWarehouse.h
+++ b/framework/include/auxkernels/AuxWarehouse.h
@@ -60,13 +60,6 @@ public:
   const std::vector<AuxScalarKernel *> & scalars() { return _scalar_kernels; }
 
   /**
-   * Adds a boundary condition aux kernel
-   * @param boundary_id Boundary ID this kernel works on
-   * @param aux BC kernel being added
-   */
-  void addActiveBC(AuxKernel *aux);
-
-  /**
    * Adds an auxiliary kernel
    * @param aux Kernel being added
    * @param block_ids Set of subdomain this kernel is active on

--- a/framework/include/base/AuxiliarySystem.h
+++ b/framework/include/base/AuxiliarySystem.h
@@ -73,13 +73,6 @@ public:
    * @param parameters Kernel parameters
    */
   void addScalarKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters);
-  /**
-   * Adds an auxiliary boundary condition
-   * @param bc_name The type of the BC
-   * @param name The name of the BC
-   * @param parameters Parameters of the BC
-   */
-  void addBoundaryCondition(const std::string & bc_name, const std::string & name, InputParameters parameters);
 
   virtual void reinitElem(const Elem * elem, THREAD_ID tid);
   virtual void reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid);

--- a/framework/include/base/BoundaryRestrictable.h
+++ b/framework/include/base/BoundaryRestrictable.h
@@ -148,6 +148,11 @@ public:
   template<typename T>
   bool hasBoundaryMaterialProperty(const std::string & name) const;
 
+  bool boundaryRestricted()
+    {
+      return _boundary_restricted;
+    }
+
 private:
 
   /// Pointer to FEProblem
@@ -167,6 +172,8 @@ private:
 
   /// Invalid BoundaryID for case when FEProblem
   const BoundaryID _invalid_boundary_id;
+
+  bool _boundary_restricted;
 
 protected:
 

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -332,7 +332,6 @@ public:
   void addAuxScalarVariable(const std::string & var_name, Order order, Real scale_factor = 1.);
   void addAuxKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters);
   void addAuxScalarKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters);
-  void addAuxBoundaryCondition(const std::string & bc_name, const std::string & name, InputParameters parameters);
 
   AuxiliarySystem & getAuxiliarySystem() { return _aux; }
 

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -29,7 +29,7 @@
  * Any object that needs material properties should inherit this interface.
  * If your object is also restricted to blocks and/or boundaries via the
  * BlockRestrictable and/or BoundaryRestrictable class, then MaterialPropertyInterface
- * must be inherieted following these two classes for the material property checks
+ * must be inherited following these two classes for the material property checks
  * to operate correctly.
  */
 class MaterialPropertyInterface
@@ -111,8 +111,8 @@ public:
 
 protected:
 
-  /// Reference to the materail data class that stores properties
-  MaterialData & _material_data;
+  /// Pointer to the material data class that stores properties
+  MaterialData * _material_data;
 
   /// Reference to the FEProblem class
   FEProblem & _mi_feproblem;
@@ -150,13 +150,13 @@ MaterialPropertyInterface::getMaterialProperty(const std::string & name)
 {
   checkMaterialProperty(name);
 
-  if (!_stateful_allowed && _material_data.getMaterialPropertyStorage().hasStatefulProperties())
+  if (!_stateful_allowed && _material_data->getMaterialPropertyStorage().hasStatefulProperties())
     mooseError("Error: Stateful material properties not allowed for this object.");
 
   // Update the boolean flag.
   _get_material_property_called = true;
 
-  return _material_data.getProperty<T>(name);
+  return _material_data->getProperty<T>(name);
 }
 
 template<typename T>
@@ -166,7 +166,7 @@ MaterialPropertyInterface::getMaterialPropertyOld(const std::string & name)
   if (!_stateful_allowed)
     mooseError("Error: Stateful material properties not allowed for this object.");
 
-  return _material_data.getPropertyOld<T>(name);
+  return _material_data->getPropertyOld<T>(name);
 }
 
 template<typename T>
@@ -176,14 +176,14 @@ MaterialPropertyInterface::getMaterialPropertyOlder(const std::string & name)
   if (!_stateful_allowed)
     mooseError("Error: Stateful material properties not allowed for this object.");
 
-  return _material_data.getPropertyOlder<T>(name);
+  return _material_data->getPropertyOlder<T>(name);
 }
 
 template<typename T>
 bool
 MaterialPropertyInterface::hasMaterialProperty(const std::string & name)
 {
-  return _material_data.haveProperty<T>(name);
+  return _material_data->haveProperty<T>(name);
 }
 
 #endif //MATERIALPROPERTYINTERFACE_H

--- a/framework/src/actions/AddBCAction.C
+++ b/framework/src/actions/AddBCAction.C
@@ -32,8 +32,5 @@ AddBCAction::AddBCAction(const std::string & name, InputParameters params) :
 void
 AddBCAction::act()
 {
-  if (_current_action == "add_bc")
-    _problem->addBoundaryCondition(_type, getShortName(), _moose_object_pars);
-  else
-    _problem->addAuxBoundaryCondition(_type, getShortName(), _moose_object_pars);
+  _problem->addBoundaryCondition(_type, getShortName(), _moose_object_pars);
 }

--- a/framework/src/actions/AddKernelAction.C
+++ b/framework/src/actions/AddKernelAction.C
@@ -32,5 +32,10 @@ AddKernelAction::act()
   if (_current_action == "add_kernel")
     _problem->addKernel(_type, getShortName(), _moose_object_pars);
   else
+  {
+    if (getAllTasks().find("add_aux_bc") != getAllTasks().end())
+      mooseWarning("The [AuxBCs] block is deprecated, all AuxKernels including both block and boundary restricted should be added within the [AuxKernels] block");
+
     _problem->addAuxKernel(_type, getShortName(), _moose_object_pars);
+  }
 }

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -73,8 +73,7 @@ AuxKernel::AuxKernel(const std::string & name, InputParameters parameters) :
 
     _var(_aux_sys.getVariable(_tid, parameters.get<AuxVariableName>("variable"))),
     _nodal(_var.isNodal()),
-
-    _bnd(parameters.get<bool>("_on_boundary")),
+    _bnd(boundaryRestricted()),
 
     _mesh(_subproblem.mesh()),
 
@@ -97,7 +96,6 @@ AuxKernel::AuxKernel(const std::string & name, InputParameters parameters) :
 
     _solution(_aux_sys.solution())
 {
-
   _supplied_vars.insert(parameters.get<AuxVariableName>("variable"));
 
   std::map<std::string, std::vector<MooseVariable *> > coupled_vars = getCoupledVars();

--- a/framework/src/auxkernels/AuxWarehouse.C
+++ b/framework/src/auxkernels/AuxWarehouse.C
@@ -72,28 +72,6 @@ AuxWarehouse::jacobianSetup()
 }
 
 void
-AuxWarehouse::addActiveBC(AuxKernel *aux)
-{
-  // Make certain that the AuxKernel is valid
-  mooseAssert(aux, "Auxkernel is NULL");
-
-  // Add the pointer to the complete and the nodal or elemental lists
-  _all_aux_kernels.push_back(aux);
-  if (!aux->isNodal())
-    _all_elem_bcs.push_back(aux);
-
-  // Populate the elemental and nodal boundary restricted maps
-  const std::set<BoundaryID> & boundary_ids = aux->boundaryIDs();
-  for (std::set<BoundaryID>::const_iterator it = boundary_ids.begin(); it != boundary_ids.end(); ++it)
-  {
-    if (aux->isNodal())
-      _active_nodal_bcs[*it].push_back(aux);
-    else
-      _elem_bcs[*it].push_back(aux);
-  }
-}
-
-void
 AuxWarehouse::addAuxKernel(AuxKernel * aux)
 {
   // Make certain that the AuxKernel is valid
@@ -101,21 +79,45 @@ AuxWarehouse::addAuxKernel(AuxKernel * aux)
 
   // Add the pointer to the complete and the nodal or elemental lists
   _all_aux_kernels.push_back(aux);
-  if (aux->isNodal())
-    _all_nodal_aux_kernels.push_back(aux);
-  else
-    _all_element_aux_kernels.push_back(aux);
 
-  // Get the SubdomainIDs for this object
-  const std::set<SubdomainID> & block_ids(aux->hasBlocks(Moose::ANY_BLOCK_ID) ? aux->meshBlockIDs() : aux->blockIDs()) ;
-
-  // Populate the elemental and nodal block restricted maps
-  for (std::set<SubdomainID>::const_iterator it = block_ids.begin(); it != block_ids.end(); ++it)
+  // Boundary restricted
+  if (aux->boundaryRestricted())
   {
+    // Add to elemental boundary storage
+    if (!aux->isNodal())
+      _all_elem_bcs.push_back(aux);
+
+    // Populate the elemental and nodal boundary restricted maps
+    const std::set<BoundaryID> & boundary_ids = aux->boundaryIDs();
+    for (std::set<BoundaryID>::const_iterator it = boundary_ids.begin(); it != boundary_ids.end(); ++it)
+    {
+      if (aux->isNodal())
+        _active_nodal_bcs[*it].push_back(aux);
+      else
+        _elem_bcs[*it].push_back(aux);
+    }
+  }
+
+  // Block restricted
+  else
+  {
+    // Add to elemental/nodal storage
     if (aux->isNodal())
-      _active_block_nodal_aux_kernels[*it].push_back(aux);
+      _all_nodal_aux_kernels.push_back(aux);
     else
-      _active_block_element_aux_kernels[*it].push_back(aux);
+      _all_element_aux_kernels.push_back(aux);
+
+    // Get the SubdomainIDs for this object
+    const std::set<SubdomainID> & block_ids(aux->hasBlocks(Moose::ANY_BLOCK_ID) ? aux->meshBlockIDs() : aux->blockIDs()) ;
+
+    // Populate the elemental and nodal block restricted maps
+    for (std::set<SubdomainID>::const_iterator it = block_ids.begin(); it != block_ids.end(); ++it)
+    {
+      if (aux->isNodal())
+        _active_block_nodal_aux_kernels[*it].push_back(aux);
+      else
+        _active_block_element_aux_kernels[*it].push_back(aux);
+    }
   }
 }
 

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -121,24 +121,30 @@ AuxiliarySystem::addTimeIntegrator(const std::string & type, const std::string &
 }
 
 void
-AuxiliarySystem::addKernel(const  std::string & kernel_name, const std::string & name, InputParameters parameters)
+AuxiliarySystem::addKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters)
 {
   parameters.set<AuxiliarySystem *>("_aux_sys") = this;
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
     parameters.set<THREAD_ID>("_tid") = tid;
-    parameters.set<MaterialData *>("_material_data") = _mproblem._material_data[tid];
 
     AuxKernel *kernel = static_cast<AuxKernel *>(_factory.create(kernel_name, name, parameters));
     mooseAssert(kernel != NULL, "Not an AuxKernel object");
 
     _auxs(kernel->execFlag())[tid].addAuxKernel(kernel);
     _mproblem._objects_by_name[tid][name].push_back(kernel);
+
+    if (kernel->boundaryRestricted())
+    {
+      const std::set<BoundaryID> & boundary_ids = kernel->boundaryIDs();
+      for (std::set<BoundaryID>::const_iterator it = boundary_ids.begin(); it != boundary_ids.end(); ++it)
+        _vars[tid].addBoundaryVar(*it, &kernel->variable());
+    }
   }
 }
 
 void
-AuxiliarySystem::addScalarKernel(const  std::string & kernel_name, const std::string & name, InputParameters parameters)
+AuxiliarySystem::addScalarKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters)
 {
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
@@ -148,31 +154,8 @@ AuxiliarySystem::addScalarKernel(const  std::string & kernel_name, const std::st
     mooseAssert(kernel != NULL, "Not a AuxScalarKernel object");
 
     _auxs(kernel->execFlag())[tid].addScalarKernel(kernel);
+
     _mproblem._objects_by_name[tid][name].push_back(kernel);
-  }
-}
-
-void
-AuxiliarySystem::addBoundaryCondition(const std::string & bc_name, const std::string & name, InputParameters parameters)
-{
-
-  parameters.set<AuxiliarySystem *>("_aux_sys") = this;
-  parameters.set<bool>("_on_boundary") = true;
-
-  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
-  {
-    parameters.set<THREAD_ID>("_tid") = tid;
-    parameters.set<MaterialData *>("_material_data") = _mproblem._bnd_material_data[tid];
-
-    AuxKernel * kernel = static_cast<AuxKernel *>(_factory.create(bc_name, name, parameters));
-    mooseAssert(kernel != NULL, "Not a boundary restricted AuxAuxKernel object");
-
-    _auxs(kernel->execFlag())[tid].addActiveBC(kernel);
-    _mproblem._objects_by_name[tid][name].push_back(kernel);
-
-    const std::set<BoundaryID> & boundary_ids = kernel->boundaryIDs();
-    for (std::set<BoundaryID>::const_iterator it = boundary_ids.begin(); it != boundary_ids.end(); ++it)
-      _vars[tid].addBoundaryVar(*it, &kernel->variable());
   }
 }
 
@@ -422,7 +405,7 @@ AuxiliarySystem::getMinQuadratureOrder()
 }
 
 bool
-AuxiliarySystem::needMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid)
+AuxiliarySystem::needMaterialOnSide(BoundaryID bnd_id, THREAD_ID /*tid*/)
 {
   for (unsigned int i=0; i < Moose::exec_types.size(); ++i)
     if (!_auxs(Moose::exec_types[i])[0].activeBCs(bnd_id).empty() ||

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -78,33 +78,25 @@ BlockRestrictable::BlockRestrictable(const std::string name, InputParameters & p
     }
   }
 
-  // The 'block' input parameter is undefined
-  else
-  {
-    // If the object contains a variable, set the subdomain ids to those of the variable
-    if (parameters.isParamValid("variable") &&
-        (parameters.have_parameter<NonlinearVariableName>("variable") ||
-         parameters.have_parameter<AuxVariableName>("variable")))
-    {
+  // The 'block' input parameter is undefined, if the object contains a variable, set the subdomain ids to those of the variable
+  else if (parameters.isParamValid("variable") &&
+           (parameters.have_parameter<NonlinearVariableName>("variable") || parameters.have_parameter<AuxVariableName>("variable")))
       _blk_ids = variableSubdomianIDs(parameters);
-    }
-  }
 
   // Produce error if the object is not allowed to be both block and boundary restrictable
-  if (!_blk_dual_restrictable && !_blk_ids.empty())
-    if (parameters.isParamValid("_boundary_ids"))
-    {
-      std::vector<BoundaryID> bnd_ids = parameters.get<std::vector<BoundaryID> >("_boundary_ids");
-      if (!bnd_ids.empty()
-          && std::find(bnd_ids.begin(), bnd_ids.end(), Moose::ANY_BOUNDARY_ID) != bnd_ids.end())
-        mooseError("Attempted to restrict the object '" << name << "' to a block, but the object is already restricted by boundary");
-    }
+  if (!_blk_dual_restrictable && !_blk_ids.empty() && parameters.isParamValid("_boundary_ids"))
+  {
+    std::vector<BoundaryID> bnd_ids = parameters.get<std::vector<BoundaryID> >("_boundary_ids");
+    if (!bnd_ids.empty()
+        && std::find(bnd_ids.begin(), bnd_ids.end(), Moose::ANY_BOUNDARY_ID) != bnd_ids.end())
+      mooseError("Attempted to restrict the object '" << name << "' to a block, but the object is already restricted by boundary");
+  }
 
   // If no blocks were defined above, specify that it is valid on all blocks
   if (_blk_ids.empty())
   {
     _blk_ids.insert(Moose::ANY_BLOCK_ID);
-    _blocks = std::vector<SubdomainName>(1,"ANY_BLOCK_ID");
+    _blocks = std::vector<SubdomainName>(1, "ANY_BLOCK_ID");
   }
 
   // Store the private parameter that contains the set of block ids

--- a/framework/src/base/BoundaryRestrictable.C
+++ b/framework/src/base/BoundaryRestrictable.C
@@ -42,8 +42,8 @@ BoundaryRestrictable::BoundaryRestrictable(const std::string name, InputParamete
     _boundary_names(parameters.get<std::vector<BoundaryName> >("boundary")),
     _bnd_dual_restrictable(parameters.get<bool>("_dual_restrictable")),
     _invalid_boundary_id(Moose::INVALID_BOUNDARY_ID),
+    _boundary_restricted(false),
     _current_boundary_id(_bnd_feproblem == NULL ? _invalid_boundary_id : _bnd_feproblem->getCurrentBoundaryID())
-
 {
 
   // If the mesh pointer is not defined, but FEProblem is, get it from there
@@ -62,20 +62,21 @@ BoundaryRestrictable::BoundaryRestrictable(const std::string name, InputParamete
   }
 
   // Produce error if the object is not allowed to be both block and boundary restrictable
-  if (!_bnd_dual_restrictable && !_bnd_ids.empty())
-    if (parameters.isParamValid("_block_ids"))
-    {
-       std::vector<SubdomainID> blk_ids = parameters.get<std::vector<SubdomainID> >("_block_ids");
-       if (!blk_ids.empty() && blk_ids[0] != Moose::ANY_BLOCK_ID)
-         mooseError("Attempted to restrict the object '" << name << "' to a boundary, but the object is already restricted by block(s)");
-    }
+  if (!_bnd_dual_restrictable && !_bnd_ids.empty() && parameters.isParamValid("_block_ids"))
+  {
+    std::vector<SubdomainID> blk_ids = parameters.get<std::vector<SubdomainID> >("_block_ids");
+    if (!blk_ids.empty() && blk_ids[0] != Moose::ANY_BLOCK_ID)
+      mooseError("Attempted to restrict the object '" << name << "' to a boundary, but the object is already restricted by block(s)");
+  }
 
   // Store ANY_BOUNDARY_ID if empty
   if (_bnd_ids.empty())
   {
     _bnd_ids.insert(Moose::ANY_BOUNDARY_ID);
-    _boundary_names = std::vector<BoundaryName>(1,"ANY_BOUNDARY_ID");
+    _boundary_names = std::vector<BoundaryName>(1, "ANY_BOUNDARY_ID");
   }
+  else
+    _boundary_restricted = true;
 
   // Store the ids in the input parameters
   parameters.set<std::vector<BoundaryID> >("_boundary_ids") = std::vector<BoundaryID>(_bnd_ids.begin(), _bnd_ids.end());

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1313,7 +1313,10 @@ FEProblem::addAuxKernel(const std::string & kernel_name, const std::string & nam
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->auxSys();
     parameters.set<SystemBase *>("_nl_sys") = &_displaced_problem->nlSys();
-    _reinit_displaced_elem = true;
+    if (!parameters.get<std::vector<BoundaryName> >("boundary").empty())
+      _reinit_displaced_face = true;
+    else
+      _reinit_displaced_elem = true;
   }
   else
   {
@@ -1339,26 +1342,6 @@ FEProblem::addAuxScalarKernel(const std::string & kernel_name, const std::string
     parameters.set<SystemBase *>("_sys") = &_aux;
   }
   _aux.addScalarKernel(kernel_name, name, parameters);
-}
-
-void
-FEProblem::addAuxBoundaryCondition(const std::string & bc_name, const std::string & name, InputParameters parameters)
-{
-  parameters.set<FEProblem *>("_fe_problem") = this;
-  if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
-  {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
-    parameters.set<SystemBase *>("_sys") = &_displaced_problem->auxSys();
-    parameters.set<SystemBase *>("_nl_sys") = &_displaced_problem->nlSys();
-    _reinit_displaced_face = true;
-  }
-  else
-  {
-    parameters.set<SubProblem *>("_subproblem") = this;
-    parameters.set<SystemBase *>("_sys") = &_aux;
-    parameters.set<SystemBase *>("_nl_sys") = &_nl;
-  }
-  _aux.addBoundaryCondition(bc_name, name, parameters);
 }
 
 void

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -675,6 +675,7 @@ addActionTypes(Syntax & syntax)
   registerMooseObjectTask("add_aux_kernel",               AuxKernel,              false);
   registerMooseObjectTask("add_elemental_field_variable", AuxKernel,              false);
   registerMooseObjectTask("add_coupled_variable",         AuxKernel,              false);
+  registerMooseObjectTask("add_aux_bc",                   AuxKernel,              false);
 
   registerMooseObjectTask("add_scalar_kernel",            ScalarKernel,           false);
   registerMooseObjectTask("add_aux_scalar_kernel",        AuxScalarKernel,        false);
@@ -890,6 +891,7 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
 
   registerAction(AddKernelAction, "add_kernel");
   registerAction(AddKernelAction, "add_aux_kernel");
+  registerAction(AddKernelAction, "add_aux_bc");
   registerAction(AddScalarKernelAction, "add_scalar_kernel");
   registerAction(AddScalarKernelAction, "add_aux_scalar_kernel");
   registerAction(AddDGKernelAction, "add_dg_kernel");

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -673,7 +673,6 @@ addActionTypes(Syntax & syntax)
   registerMooseObjectTask("add_function",                 Function,               false);
 
   registerMooseObjectTask("add_aux_kernel",               AuxKernel,              false);
-  registerMooseObjectTask("add_aux_bc",                   AuxKernel,              false);
   registerMooseObjectTask("add_elemental_field_variable", AuxKernel,              false);
   registerMooseObjectTask("add_coupled_variable",         AuxKernel,              false);
 
@@ -809,7 +808,7 @@ addActionTypes(Syntax & syntax)
 "(add_vector_postprocessor)"
 "(setup_pps_complete)"
 "(setup_debug)"
-"(add_aux_bc, add_aux_kernel, add_bc, add_damper, add_dirac_kernel, add_kernel, add_dg_kernel, add_scalar_kernel, add_aux_scalar_kernel, add_indicator, add_marker, add_output)"
+"(add_aux_kernel, add_bc, add_damper, add_dirac_kernel, add_kernel, add_dg_kernel, add_scalar_kernel, add_aux_scalar_kernel, add_indicator, add_marker, add_output)"
 "(perf_log_output, check_material_output)"
 "(check_integrity)"
 );
@@ -897,7 +896,6 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
   registerAction(AddBCAction, "add_bc");
   registerAction(EmptyAction, "no_action");  // placeholder
   registerAction(AddPeriodicBCAction, "add_periodic_bc");
-  registerAction(AddBCAction, "add_aux_bc");
   registerAction(AddMaterialAction, "add_material");
   registerAction(AddPostprocessorAction, "add_postprocessor");
   registerAction(AddVectorPostprocessorAction, "add_vector_postprocessor");

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -72,7 +72,6 @@ Material::Material(const std::string & name, InputParameters parameters) :
     _current_elem(_neighbor ? _assembly.neighbor() : _assembly.elem()),
     _current_side(_neighbor ? _assembly.neighborSide() : _assembly.side()),
     _mesh(_subproblem.mesh()),
-//    _dim(_mesh.dimension()),
     _coord_sys(_assembly.coordSystem()),
     _has_stateful_property(false)
 {

--- a/framework/src/parser/MooseSyntax.C
+++ b/framework/src/parser/MooseSyntax.C
@@ -34,6 +34,7 @@ void associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 
   syntax.registerActionSyntax("AddKernelAction", "Kernels/*", "add_kernel");
   syntax.registerActionSyntax("AddKernelAction", "AuxKernels/*", "add_aux_kernel");
+  syntax.registerActionSyntax("AddKernelAction", "AuxBCs/*", "add_aux_bc");
   syntax.registerActionSyntax("AddKernelAction", "Bounds/*", "add_aux_kernel");
 
   syntax.registerActionSyntax("AddScalarKernelAction", "ScalarKernels/*", "add_scalar_kernel");

--- a/framework/src/parser/MooseSyntax.C
+++ b/framework/src/parser/MooseSyntax.C
@@ -40,7 +40,6 @@ void associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("AddScalarKernelAction", "AuxScalarKernels/*", "add_aux_scalar_kernel");
 
   syntax.registerActionSyntax("AddBCAction", "BCs/*", "add_bc");
-  syntax.registerActionSyntax("AddBCAction", "AuxBCs/*", "add_aux_bc");
 
   syntax.registerActionSyntax("CreateProblemAction", "Problem");
   syntax.registerActionSyntax("SetupMeshAction", "Mesh");

--- a/modules/combined/tests/contact/8ElemTensionRelease.i
+++ b/modules/combined/tests/contact/8ElemTensionRelease.i
@@ -55,7 +55,11 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
+  [./pid]
+    type = ProcessorIDAux
+    variable = pid
+  [../]
   [./status]
     type = PenetrationAux
     quantity = mechanical_status
@@ -63,13 +67,6 @@
     boundary = 3
     paired_boundary = 2
     execute_on = timestep
-  [../]
-[]
-
-[AuxKernels]
-  [./pid]
-    type = ProcessorIDAux
-    variable = pid
   [../]
 []
 

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d.i
@@ -51,15 +51,6 @@
   [../]
 []
 
-[AuxBCs]
-  [./penetration]
-    type = PenetrationAux
-    variable = penetration
-    boundary = 3
-    paired_boundary = 2
-  [../]
-[]
-
 [AuxKernels]
   [./zeroslip_x]
     type = ConstantAux
@@ -86,6 +77,12 @@
     variable = accum_slip_y
     accumulate_from_variable = inc_slip_y
     execute_on = timestep
+  [../]
+  [./penetration]
+    type = PenetrationAux
+    variable = penetration
+    boundary = 3
+    paired_boundary = 2
   [../]
 []
 

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_predictor.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_predictor.i
@@ -51,15 +51,6 @@
   [../]
 []
 
-[AuxBCs]
-  [./penetration]
-    type = PenetrationAux
-    variable = penetration
-    boundary = 3
-    paired_boundary = 2
-  [../]
-[]
-
 [AuxKernels]
   [./zeroslip_x]
     type = ConstantAux
@@ -86,6 +77,12 @@
     variable = accum_slip_y
     accumulate_from_variable = inc_slip_y
     execute_on = timestep
+  [../]
+  [./penetration]
+    type = PenetrationAux
+    variable = penetration
+    boundary = 3
+    paired_boundary = 2
   [../]
 []
 

--- a/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
+++ b/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
@@ -75,15 +75,6 @@
   [../]
 []
 
-[AuxBCs]
-  [./penetration]
-    type = PenetrationAux
-    variable = penetration
-    boundary = 3
-    paired_boundary = 2
-  [../]
-[]
-
 [AuxKernels]
   [./zeroslip_x]
     type = ConstantAux
@@ -110,6 +101,12 @@
     variable = accum_slip_y
     accumulate_from_variable = inc_slip_y
     execute_on = timestep
+  [../]
+  [./penetration]
+    type = PenetrationAux
+    variable = penetration
+    boundary = 3
+    paired_boundary = 2
   [../]
 []
 

--- a/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rspherical.i
+++ b/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rspherical.i
@@ -103,7 +103,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./conductance]
     type = MaterialRealAux
     property = gap_conductance

--- a/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rz_test.i
+++ b/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rz_test.i
@@ -102,7 +102,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./conductance]
     type = MaterialRealAux
     property = gap_conductance

--- a/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_test.i
+++ b/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_test.i
@@ -125,7 +125,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./conductance]
     type = MaterialRealAux
     property = gap_conductance

--- a/modules/combined/tests/glued_contact_constraint/glued_contact_constraint.i
+++ b/modules/combined/tests/glued_contact_constraint/glued_contact_constraint.i
@@ -31,7 +31,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetration]
     type = PenetrationAux
     variable = penetration

--- a/modules/combined/tests/incremental_slip/incremental_slip.i
+++ b/modules/combined/tests/incremental_slip/incremental_slip.i
@@ -80,7 +80,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./inc_slip_x]
     type = PenetrationAux
     variable = inc_slip_x

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic.i
@@ -39,15 +39,6 @@
   [../]
 []
 
-[AuxBCs]
-  [./penetration]
-    type = PenetrationAux
-    variable = penetration
-    boundary = 3
-    paired_boundary = 2
-  [../]
-[]
-
 [AuxKernels]
   [./zeroslip_x]
     type = ConstantAux
@@ -74,6 +65,12 @@
     variable = accum_slip_y
     accumulate_from_variable = inc_slip_y
     execute_on = timestep
+  [../]
+  [./penetration]
+    type = PenetrationAux
+    variable = penetration
+    boundary = 3
+    paired_boundary = 2
   [../]
 []
 

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty.i
@@ -39,15 +39,6 @@
   [../]
 []
 
-[AuxBCs]
-  [./penetration]
-    type = PenetrationAux
-    variable = penetration
-    boundary = 3
-    paired_boundary = 2
-  [../]
-[]
-
 [AuxKernels]
   [./zeroslip_x]
     type = ConstantAux
@@ -74,6 +65,12 @@
     variable = accum_slip_y
     accumulate_from_variable = inc_slip_y
     execute_on = timestep
+  [../]
+  [./penetration]
+    type = PenetrationAux
+    variable = penetration
+    boundary = 3
+    paired_boundary = 2
   [../]
 []
 

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic.i
@@ -39,15 +39,6 @@
   [../]
 []
 
-[AuxBCs]
-  [./penetration]
-    type = PenetrationAux
-    variable = penetration
-    boundary = 3
-    paired_boundary = 2
-  [../]
-[]
-
 [AuxKernels]
   [./zeroslip_x]
     type = ConstantAux
@@ -74,6 +65,12 @@
     variable = accum_slip_y
     accumulate_from_variable = inc_slip_y
     execute_on = timestep
+  [../]
+  [./penetration]
+    type = PenetrationAux
+    variable = penetration
+    boundary = 3
+    paired_boundary = 2
   [../]
 []
 

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty.i
@@ -39,15 +39,6 @@
   [../]
 []
 
-[AuxBCs]
-  [./penetration]
-    type = PenetrationAux
-    variable = penetration
-    boundary = 3
-    paired_boundary = 2
-  [../]
-[]
-
 [AuxKernels]
   [./zeroslip_x]
     type = ConstantAux
@@ -74,6 +65,12 @@
     variable = accum_slip_y
     accumulate_from_variable = inc_slip_y
     execute_on = timestep
+  [../]
+  [./penetration]
+    type = PenetrationAux
+    variable = penetration
+    boundary = 3
+    paired_boundary = 2
   [../]
 []
 

--- a/modules/combined/tests/simplest_contact/simplest_contact_skew_test.i
+++ b/modules/combined/tests/simplest_contact/simplest_contact_skew_test.i
@@ -31,7 +31,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetration]
     type = PenetrationAux
     variable = penetration

--- a/modules/combined/tests/simplest_contact/simplest_contact_test.i
+++ b/modules/combined/tests/simplest_contact/simplest_contact_test.i
@@ -31,7 +31,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetration]
     type = PenetrationAux
     variable = penetration

--- a/modules/contact/src/ContactPenetrationAuxAction.C
+++ b/modules/contact/src/ContactPenetrationAuxAction.C
@@ -56,8 +56,6 @@ ContactPenetrationAuxAction::act()
     name << short_name;
     name << "_contact_";
     name << counter++;
-    _problem->addAuxBoundaryCondition("PenetrationAux",
-                                      name.str(),
-                                      params);
+    _problem->addAuxKernel("PenetrationAux", name.str(), params);
   }
 }

--- a/modules/contact/src/ContactPressureAuxAction.C
+++ b/modules/contact/src/ContactPressureAuxAction.C
@@ -61,20 +61,14 @@ ContactPressureAuxAction::act()
     name << counter++;
 
     params.set<MooseEnum>("execute_on") = "jacobian";
-    _problem->addAuxBoundaryCondition("ContactPressureAux",
-                                      name.str(),
-                                      params);
+    _problem->addAuxKernel("ContactPressureAux", name.str(), params);
 
     params.set<MooseEnum>("execute_on") = "timestep";
     name << "_timestep";
-    _problem->addAuxBoundaryCondition("ContactPressureAux",
-                                      name.str(),
-                                      params);
+    _problem->addAuxKernel("ContactPressureAux", name.str(), params);
 
     params.set<MooseEnum>("execute_on") = "timestep_begin";
     name << "_timestep_begin";
-    _problem->addAuxBoundaryCondition("ContactPressureAux",
-                                      name.str(),
-                                      params);
+    _problem->addAuxKernel("ContactPressureAux", name.str(), params);
   }
 }

--- a/modules/contact/src/base/ContactApp.C
+++ b/modules/contact/src/base/ContactApp.C
@@ -83,10 +83,10 @@ ContactApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 
   registerAction(ContactAction, "add_dg_kernel");
 
-  registerAction(ContactPenetrationAuxAction, "add_aux_bc");
+  registerAction(ContactPenetrationAuxAction, "add_aux_kernel");
   registerAction(ContactPenetrationVarAction, "add_aux_variable");
 
-  registerAction(ContactPressureAuxAction, "add_aux_bc");
+  registerAction(ContactPressureAuxAction, "add_aux_kernel");
   registerAction(ContactPressureVarAction, "add_aux_variable");
 
   registerAction(NodalAreaAction, "add_user_object");

--- a/modules/heat_conduction/src/actions/ThermalContactAuxBCsAction.C
+++ b/modules/heat_conduction/src/actions/ThermalContactAuxBCsAction.C
@@ -54,56 +54,45 @@ ThermalContactAuxBCsAction::act()
 
   params.set<MooseEnum>("order") = getParam<MooseEnum>("order");
   if (isParamValid("tangential_tolerance"))
-  {
     params.set<Real>("tangential_tolerance") = getParam<Real>("tangential_tolerance");
-  }
+
   if (isParamValid("normal_smoothing_distance"))
-  {
     params.set<Real>("normal_smoothing_distance") = getParam<Real>("normal_smoothing_distance");
-  }
+
   if (isParamValid("normal_smoothing_method"))
-  {
     params.set<std::string>("normal_smoothing_method") = getParam<std::string>("normal_smoothing_method");
-  }
+
   params.set<bool>("warnings") = getParam<bool>("warnings");
-  _problem->addAuxBoundaryCondition(getParam<std::string>("gap_type"),
-      "gap_value_" + Moose::stringify(n),
-      params);
+  _problem->addAuxKernel(getParam<std::string>("gap_type"), "gap_value_" + Moose::stringify(n), params);
 
   if (quadrature)
   {
     std::vector<BoundaryName> bnds(1, getParam<BoundaryName>("master"));
     params.set<std::vector<BoundaryName> >("boundary") = bnds;
     params.set<BoundaryName>("paired_boundary") = getParam<BoundaryName>("slave");
-    _problem->addAuxBoundaryCondition(getParam<std::string>("gap_type"),
-        "gap_value_master_" + Moose::stringify(n),
-        params);
+    _problem->addAuxKernel(getParam<std::string>("gap_type"), "gap_value_master_" + Moose::stringify(n), params);
+
   }
 
   params = _factory.getValidParams("PenetrationAux");
   std::string penetration_var_name = "penetration";
   if (quadrature)
-  {
     penetration_var_name = "qpoint_penetration";
-  }
+
   params.set<AuxVariableName>("variable") = penetration_var_name;
   params.set<std::vector<BoundaryName> >("boundary") = bnds;
   params.set<BoundaryName>("paired_boundary") = getParam<BoundaryName>("master");
+
   if (isParamValid("tangential_tolerance"))
-  {
     params.set<Real>("tangential_tolerance") = getParam<Real>("tangential_tolerance");
-  }
+
   if (isParamValid("normal_smoothing_distance"))
-  {
     params.set<Real>("normal_smoothing_distance") = getParam<Real>("normal_smoothing_distance");
-  }
+
   if (isParamValid("normal_smoothing_method"))
-  {
     params.set<std::string>("normal_smoothing_method") = getParam<std::string>("normal_smoothing_method");
-  }
-  _problem->addAuxBoundaryCondition("PenetrationAux",
-      "penetration_" + Moose::stringify(n),
-      params);
+
+  _problem->addAuxKernel("PenetrationAux", "penetration_" + Moose::stringify(n), params);
 
   ++n;
 }

--- a/modules/heat_conduction/src/actions/ThermalContactMaterialsAction.C
+++ b/modules/heat_conduction/src/actions/ThermalContactMaterialsAction.C
@@ -75,24 +75,18 @@ ThermalContactMaterialsAction::act()
 
   params.set<Real>("gap_conductivity") = getParam<Real>("gap_conductivity");
   if (isParamValid("gap_conductivity_function"))
-  {
     params.set<FunctionName>("gap_conductivity_function") = getParam<FunctionName>("gap_conductivity_function");
-  }
+
   if (isParamValid("gap_conductivity_function_variable"))
-  {
     params.set<std::vector<VariableName> >("gap_conductivity_function_variable") = std::vector<VariableName>(1, getParam<VariableName>("gap_conductivity_function_variable"));
-  }
 
   std::vector<BoundaryName> bnds(1, getParam<BoundaryName>("slave"));
   params.set<std::vector<BoundaryName> >("boundary") = bnds;
-
   params.set<std::string>("appended_property_name") = getParam<std::string>("appended_property_name");
 
   params.set<std::string>("conductivity_name") = getParam<std::string>("conductivity_name");
 
-  _problem->addMaterial(type,
-    "gap_value_" + Moose::stringify(n),
-    params);
+  _problem->addMaterial(type, "gap_value_" + Moose::stringify(n), params);
 
   if (quadrature)
   {
@@ -103,9 +97,7 @@ ThermalContactMaterialsAction::act()
 
     params.set<std::string>("conductivity_name") = getParam<std::string>("conductivity_master_name");
 
-    _problem->addMaterial(type,
-      "gap_value_master_" + Moose::stringify(n),
-      params);
+    _problem->addMaterial(type, "gap_value_master_" + Moose::stringify(n), params);
   }
 
   ++n;

--- a/test/tests/auxkernels/element_aux_boundary/element_aux_boundary.i
+++ b/test/tests/auxkernels/element_aux_boundary/element_aux_boundary.i
@@ -17,7 +17,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./real_property]
     type = MaterialRealAux
     variable = real_property

--- a/test/tests/auxkernels/element_aux_var/element_aux_var_test.i
+++ b/test/tests/auxkernels/element_aux_var/element_aux_var_test.i
@@ -106,6 +106,12 @@
     grad = '2 0 0'
     coupled = u
   [../]
+  [./five]
+    type = ConstantAux
+    variable = five
+    boundary = '1 2'
+    value = 5
+  [../]
 []
 
 [BCs]
@@ -120,15 +126,6 @@
     variable = u
     boundary = 2
     value = 1
-  [../]
-[]
-
-[AuxBCs]
-  [./five]
-    type = ConstantAux
-    variable = five
-    boundary = '1 2'
-    value = 5
   [../]
 []
 

--- a/test/tests/auxkernels/element_aux_var/elemental_sort_test.i
+++ b/test/tests/auxkernels/element_aux_var/elemental_sort_test.i
@@ -31,6 +31,7 @@
 
 [AuxKernels]
   # Intentionally out of order to test sorting capabiilties
+  active = 'one two'
   [./two]
     variable = two
     type = CoupledAux
@@ -43,6 +44,13 @@
     variable = one
     type = ConstantAux
     value = 1
+  [../]
+
+  [./five]
+    type = ConstantAux
+    variable = five
+    boundary = '1 2'
+    value = 5
   [../]
 []
 
@@ -61,17 +69,6 @@
     variable = u
     boundary = 2
     value = 1
-  [../]
-[]
-
-[AuxBCs]
-  active = ''
-
-  [./five]
-    type = ConstantAux
-    variable = five
-    boundary = '1 2'
-    value = 5
   [../]
 []
 

--- a/test/tests/auxkernels/gap_value/gap_value.i
+++ b/test/tests/auxkernels/gap_value/gap_value.i
@@ -40,7 +40,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./gap_value_aux]
     type = GapValueAux
     variable = gap_value

--- a/test/tests/auxkernels/gap_value/gap_value_subdomain_restricted.i
+++ b/test/tests/auxkernels/gap_value/gap_value_subdomain_restricted.i
@@ -41,7 +41,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./gap_value_aux]
     type = GapValueAux
     variable = gap_value

--- a/test/tests/auxkernels/nearest_node_value/nearest_node_value.i
+++ b/test/tests/auxkernels/nearest_node_value/nearest_node_value.i
@@ -36,7 +36,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./nearest_node_value]
     type = NearestNodeValueAux
     variable = nearest_node_value

--- a/test/tests/auxkernels/nodal_aux_boundary/nodal_aux_boundary.i
+++ b/test/tests/auxkernels/nodal_aux_boundary/nodal_aux_boundary.i
@@ -22,7 +22,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./boundary_aux]
     type = CoupledAux
     variable = aux

--- a/test/tests/auxkernels/nodal_aux_var/nodal_aux_var_test.i
+++ b/test/tests/auxkernels/nodal_aux_var/nodal_aux_var_test.i
@@ -47,8 +47,6 @@
 []
 
 [AuxKernels]
-  active = 'constant coupled'
-
   #Simple Aux Kernel
   [./constant]
     variable = one
@@ -63,6 +61,14 @@
     value = 2
     coupled = u
   [../]
+
+  [./five]
+    type = ConstantAux
+    variable = five
+    boundary = '1 2'
+    value = 5
+  [../]
+
 []
 
 [BCs]
@@ -80,17 +86,6 @@
     variable = u
     boundary = 2
     value = 1
-  [../]
-[]
-
-[AuxBCs]
-  active = 'five'
-
-  [./five]
-    type = ConstantAux
-    variable = five
-    boundary = '1 2'
-    value = 5
   [../]
 []
 

--- a/test/tests/auxkernels/nodal_aux_var/nodal_sort_test.i
+++ b/test/tests/auxkernels/nodal_aux_var/nodal_sort_test.i
@@ -31,6 +31,7 @@
 
 [AuxKernels]
   # Intentionally out of order to test sorting capabiilties
+  active = 'one two'
   [./two]
     variable = two
     type = CoupledAux
@@ -44,6 +45,14 @@
     type = ConstantAux
     value = 1
   [../]
+
+  [./five]
+    type = ConstantAux
+    variable = five
+    boundary = '1 2'
+    value = 5
+  [../]
+
 []
 
 [BCs]
@@ -61,17 +70,6 @@
     variable = u
     boundary = 2
     value = 1
-  [../]
-[]
-
-[AuxBCs]
-  active = ''
-
-  [./five]
-    type = ConstantAux
-    variable = five
-    boundary = '1 2'
-    value = 5
   [../]
 []
 

--- a/test/tests/geomsearch/1d_penetration_locator/1d_penetration_locator.i
+++ b/test/tests/geomsearch/1d_penetration_locator/1d_penetration_locator.i
@@ -36,7 +36,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./distance]
     type = PenetrationAux
     variable = gap_distance

--- a/test/tests/geomsearch/2d_interior_boundary_penetration_locator/2d_interior_boundary_penetration_locator.i
+++ b/test/tests/geomsearch/2d_interior_boundary_penetration_locator/2d_interior_boundary_penetration_locator.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetration]
     type = PenetrationAux
     variable = gap_distance
@@ -71,4 +71,3 @@
     linear_residuals = true
   [../]
 []
-

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test1.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test1.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test1q.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test1q.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test1qtt.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test1qtt.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test1tt.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test1tt.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test2.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test2.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test2q.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test2q.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test2qtt.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test2qtt.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test2tt.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test2tt.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test3.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test3.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test3nns.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test3nns.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test3ns.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test3ns.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test3q.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test3q.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test3qnns.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test3qnns.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test3qns.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test3qns.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test3qtt.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test3qtt.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test3tt.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test3tt.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test4.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test4.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test4nns.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test4nns.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test4ns.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test4ns.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test4q.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test4q.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test4qnns.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test4qnns.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test4qns.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test4qns.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test4qtt.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test4qtt.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/pl_test4tt.i
+++ b/test/tests/geomsearch/2d_moving_penetration/pl_test4tt.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/restart.i
+++ b/test/tests/geomsearch/2d_moving_penetration/restart.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_moving_penetration/restart2.i
+++ b/test/tests/geomsearch/2d_moving_penetration/restart2.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/2d_penetration_locator/2d_penetration_locator_test.i
+++ b/test/tests/geomsearch/2d_penetration_locator/2d_penetration_locator_test.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = penetration

--- a/test/tests/geomsearch/2d_penetration_locator/2d_triangle.i
+++ b/test/tests/geomsearch/2d_penetration_locator/2d_triangle.i
@@ -36,7 +36,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./distance]
     type = PenetrationAux
     variable = gap_distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test1.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test1.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test1q.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test1q.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test1qtt.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test1qtt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test1tt.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test1tt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test2.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test2.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test2q.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test2q.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test2qtt.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test2qtt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test2tt.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test2tt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test3.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test3.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test3q.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test3q.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test3qtt.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test3qtt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test3tt.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test3tt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test4.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test4.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test4q.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test4q.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test4qtt.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test4qtt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration/pl_test4tt.i
+++ b/test/tests/geomsearch/3d_moving_penetration/pl_test4tt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3nns.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3nns.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3nnstt.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3nnstt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3ns.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3ns.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3nstt.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3nstt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3qns.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3qns.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3qnstt.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test3qnstt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4nns.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4nns.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4nnstt.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4nnstt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4ns.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4ns.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4nstt.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4nstt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4qns.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4qns.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4qnstt.i
+++ b/test/tests/geomsearch/3d_moving_penetration_smoothing/pl_test4qnstt.i
@@ -55,7 +55,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetrate]
     type = PenetrationAux
     variable = distance

--- a/test/tests/geomsearch/3d_penetration_locator/3d_penetration_locator_test.i
+++ b/test/tests/geomsearch/3d_penetration_locator/3d_penetration_locator_test.i
@@ -63,7 +63,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
 
   [./penetrate]
     type = PenetrationAux

--- a/test/tests/geomsearch/3d_penetration_locator/3d_tet.i
+++ b/test/tests/geomsearch/3d_penetration_locator/3d_tet.i
@@ -36,7 +36,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./distance]
     type = PenetrationAux
     variable = gap_distance

--- a/test/tests/geomsearch/nearest_node_locator/adapt.i
+++ b/test/tests/geomsearch/nearest_node_locator/adapt.i
@@ -33,7 +33,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./distance]
     type = NearestNodeDistanceAux
     variable = distance

--- a/test/tests/geomsearch/nearest_node_locator/nearest_node_locator.i
+++ b/test/tests/geomsearch/nearest_node_locator/nearest_node_locator.i
@@ -21,7 +21,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./distance]
     type = NearestNodeDistanceAux
     variable = distance

--- a/test/tests/geomsearch/penetration_locator/penetration_locator_test.i
+++ b/test/tests/geomsearch/penetration_locator/penetration_locator_test.i
@@ -27,7 +27,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   active = 'penetrate'
 
   [./penetrate]

--- a/test/tests/geomsearch/quadrature_nearest_node_locator/quadrature_nearest_node_locator.i
+++ b/test/tests/geomsearch/quadrature_nearest_node_locator/quadrature_nearest_node_locator.i
@@ -23,7 +23,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./distance]
     type = NearestNodeDistanceAux
     variable = distance

--- a/test/tests/geomsearch/quadrature_penetration_locator/1d_quadrature_penetration.i
+++ b/test/tests/geomsearch/quadrature_penetration_locator/1d_quadrature_penetration.i
@@ -25,7 +25,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetration]
     type = PenetrationAux
     variable = penetration

--- a/test/tests/geomsearch/quadrature_penetration_locator/quadrature_penetration_locator.i
+++ b/test/tests/geomsearch/quadrature_penetration_locator/quadrature_penetration_locator.i
@@ -23,7 +23,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./penetration]
     type = PenetrationAux
     variable = penetration

--- a/test/tests/materials/material/bnd_material_test.i
+++ b/test/tests/materials/material/bnd_material_test.i
@@ -56,7 +56,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./prop]
     type = MaterialRealAux
     property = matp

--- a/test/tests/userobjects/layered_side_integral/layered_side_average.i
+++ b/test/tests/userobjects/layered_side_integral/layered_side_average.i
@@ -47,7 +47,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./lsia]
     type = SpatialUserObjectAux
     variable = layered_side_average

--- a/test/tests/userobjects/layered_side_integral/layered_side_flux_average.i
+++ b/test/tests/userobjects/layered_side_integral/layered_side_flux_average.i
@@ -47,7 +47,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./lsfa]
     type = SpatialUserObjectAux
     variable = layered_side_flux_average

--- a/test/tests/userobjects/layered_side_integral/layered_side_integral_test.i
+++ b/test/tests/userobjects/layered_side_integral/layered_side_integral_test.i
@@ -47,7 +47,7 @@
   [../]
 []
 
-[AuxBCs]
+[AuxKernels]
   [./liaux]
     type = SpatialUserObjectAux
     variable = layered_integral

--- a/test/tests/variables/block_aux_kernel/block_aux_kernel_test.i
+++ b/test/tests/variables/block_aux_kernel/block_aux_kernel_test.i
@@ -83,11 +83,6 @@
     function = t
     block = 1
   [../]
-[]
-
-[AuxBCs]
-  active = 'gap_distance gap_distance2'
-
   [./gap_distance]
     type = NearestNodeDistanceAux
     variable = distance


### PR DESCRIPTION
This deprecates the [AuxBCs] block, all AuxKernels now will be added in [AuxKernels]. The final commit re-enables the [AuxBCs] block and produces a deprecated warning.
(#3021)

There is still one bug in this commit: combined:gap_heat_transfer_convex.test, which just dies. I have been working on this for some time and could use some fresh eyes if someone has time. I believe that the incorrect `MaterialData` is being stored in some of the objects, but I can't find where this is happening.

```
Time Step  0, time = 0
                dt = 0

Process 3308 stopped
* thread #1: tid = 0x3b3979, 0x0000000100b0bdbd libmoose-oprof.0.dylib`Material::computeProperties() [inlined] std::vector<libMesh::Point, std::allocator<libMesh::Point> >::size() const at stl_vector.h:400, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x28)
    frame #0: 0x0000000100b0bdbd libmoose-oprof.0.dylib`Material::computeProperties() [inlined] std::vector<libMesh::Point, std::allocator<libMesh::Point> >::size() const at stl_vector.h:400
   397        /**  Returns the number of elements in the %vector.  */
   398        size_type
   399        size() const
-> 400        { return size_type(this->_M_impl._M_finish - this->_M_impl._M_start); }
   401  
   402        /**  Returns the size() of the largest possible %vector.  */
   403        size_type
(lldb) bt
* thread #1: tid = 0x3b3979, 0x0000000100b0bdbd libmoose-oprof.0.dylib`Material::computeProperties() [inlined] std::vector<libMesh::Point, std::allocator<libMesh::Point> >::size() const at stl_vector.h:400, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x28)
  * frame #0: 0x0000000100b0bdbd libmoose-oprof.0.dylib`Material::computeProperties() [inlined] std::vector<libMesh::Point, std::allocator<libMesh::Point> >::size() const at stl_vector.h:400
    frame #1: 0x0000000100b0bdbd libmoose-oprof.0.dylib`Material::computeProperties() [inlined] libMesh::QBase::n_points(this=0x0000000000000000) const at quadrature.h:118
    frame #2: 0x0000000100b0bdbd libmoose-oprof.0.dylib`Material::computeProperties(this=0x0000000109836200) + 29 at Material.C:92
    frame #3: 0x0000000100b0e329 libmoose-oprof.0.dylib`MaterialData::reinit(this=<unavailable>, mats=0x000000010970b488) + 25 at MaterialData.C:74
    frame #4: 0x0000000100987181 libmoose-oprof.0.dylib`ComputeResidualThread::onBoundary(this=0x00007fff5fbfe500, elem=<unavailable>, side=<unavailable>, bnd_id=3) + 209 at ComputeResidualThread.C:133
    frame #5: 0x0000000100957506 libmoose-oprof.0.dylib`ThreadedElementLoopBase<libMesh::StoredRange<libMesh::MeshBase::const_element_iterator, libMesh::Elem const*> >::operator(this=0x00007fff5fbfe500, range=0x00000001091c9540, bypass_threading=<unavailable>)(libMesh::StoredRange<libMesh::MeshBase::const_element_iterator, libMesh::Elem const*> const&, bool) + 278 at ThreadedElementLoopBase.h:146
    frame #6: 0x0000000100a45294 libmoose-oprof.0.dylib`NonlinearSystem::computeResidualInternal(Moose::KernelType) [inlined] void libMesh::Threads::parallel_reduce<libMesh::StoredRange<libMesh::MeshBase::const_element_iterator, libMesh::Elem const*>, ComputeResidualThread>(range=<unavailable>, body=0x0000000100e0dac0) + 63 at threads.h:259
    frame #7: 0x0000000100a45255 libmoose-oprof.0.dylib`NonlinearSystem::computeResidualInternal(this=0x00000001091daef0, type=<unavailable>) + 389 at NonlinearSystem.C:1167
    frame #8: 0x0000000100a44de8 libmoose-oprof.0.dylib`NonlinearSystem::computeResidual(this=0x00000001091daef0, residual=0x0000000109701af0, type=<unavailable>) + 312 at NonlinearSystem.C:702
    frame #9: 0x00000001009afca8 libmoose-oprof.0.dylib`FEProblem::computeResidualType(this=0x000000010982e800, soln=<unavailable>, residual=0x0000000109701af0, type=KT_ALL) + 408 at FEProblem.C:3206
    frame #10: 0x0000000100a425a9 libmoose-oprof.0.dylib`NonlinearSystem::solve(this=0x00000001091daef0) + 73 at NonlinearSystem.C:213
    frame #11: 0x00000001009af0aa libmoose-oprof.0.dylib`FEProblem::solve(this=0x000000010982e800) + 154 at FEProblem.C:3038
    frame #12: 0x0000000100c1fca6 libmoose-oprof.0.dylib`TimeStepper::step(this=0x00000001097bc8e0) + 22 at TimeStepper.C:188
    frame #13: 0x0000000100aa50fe libmoose-oprof.0.dylib`Transient::solveStep(this=0x0000000109832000, input_dt=<unavailable>) + 654 at Transient.C:351
    frame #14: 0x0000000100aa4e29 libmoose-oprof.0.dylib`Transient::takeStep(this=0x0000000109832000, input_dt=-1) + 217 at Transient.C:288
    frame #15: 0x0000000100aa4c1d libmoose-oprof.0.dylib`Transient::execute(this=0x0000000109832000) + 93 at Transient.C:239
    frame #16: 0x0000000100001e77 modules-oprof`main(argc=<unavailable>, argv=<unavailable>) + 135 at main.C:31
    frame #17: 0x0000000100001de4 modules-oprof`start + 52
(lldb) 
```
