### PR TITLE
Console looks for Executioner verbose

### DIFF
--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -211,6 +211,13 @@ Console::~Console()
 void
 Console::initialSetup()
 {
+  // Enable verbose output if Executioner has it enabled
+  if (_app.getExecutioner()->isParamValid("verbose") && _app.getExecutioner()->getParam<bool>("verbose"))
+  {
+    _verbose = true;
+    _pars.set<bool>("verbose") = true;
+  }
+
   // Output the performance log early
   if (getParam<bool>("setup_log_early"))
   {
@@ -274,7 +281,7 @@ Console::timestepSetup()
 
     // Show the old time delta information, if desired
     if (_verbose)
-      oss  << "            old dt = "<< std::left << std::endl;
+      oss  << "            old dt = " << std::left << _dt_old << std::endl;
   }
 
   // Output to the screen


### PR DESCRIPTION
A temporary fix for having two 'verbose' flags, see the discussion in #3202
(closes #3202)
