### PR TITLE
Make copy constructor and assignment operator private

### DIFF
--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -109,6 +109,9 @@ template <typename T>
 class MaterialProperty : public PropertyValue
 {
 public:
+  /// Explicitly declare a public constructor because we made the copy constructor private
+  MaterialProperty() : PropertyValue() { /* */ }
+
   virtual ~MaterialProperty()
   {
     _value.release();
@@ -195,6 +198,11 @@ public:
   PropertyValue *_init_helper(int size, PropertyValue *prop, const std::vector<P>* the_type);
 
 private:
+  /// private copy constructor to avoid shallow copying of material properties
+  MaterialProperty(const MaterialProperty<T> & src) { mooseError("Material properties must be assigned to references (missing '&')"); }
+
+  /// private assignment operator to avoid shallow copying of material properties
+  MaterialProperty<T> & operator = (const MaterialProperty<T> & rhs) { mooseError("Material properties must be assigned to references (missing '&')"); }
 
   /// Stored parameter value.
   MooseArray<T> _value;


### PR DESCRIPTION
To prevent shallow copies of Material Properties (#3225) we make the necessary ctors and the = operator _private_. We have to explicitly add an empty public constructor as the compiler won't create a default ctor set anymore now.

MOOSE and Marmot compile fine with this patch. If shallow copies should ever be needed by the framework  (which I don't quite see why) there is still the possibility of using `friend` declarations.
