### PR TITLE
Fixing uninitialized _coord_type (closes #3231)

### DIFF
--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -572,7 +572,8 @@ Assembly::reinitNeighborAtReference(const Elem * neighbor, const std::vector<Poi
   // set the coord transformation
   MooseArray<Real> coord;
   coord.resize(qrule.n_points());
-  switch (_coord_type) // coord type should be the same for the neighbor
+  Moose::CoordinateSystemType coord_type = _sys.subproblem().getCoordSystem(neighbor->subdomain_id());
+  switch (coord_type) // coord type should be the same for the neighbor
   {
   case Moose::COORD_XYZ:
     for (unsigned int qp = 0; qp < qrule.n_points(); qp++)


### PR DESCRIPTION
When using node face constraint and one side is using elements with
different dimension, _coord_type in Assembly::reinitNeighborAtReference
may be uninitialized. The actual problem was that the _coord_type was a
member variable set by previous calls to reinit(). Since all variables
inside reinitNeightborAtReference are local, also _coord_type has to be
local and it has to query the neighbor element to get the right value.
