### PR TITLE
Generalizing material properties to use in chemical_reactions module

### DIFF
--- a/modules/chemical_reactions/include/kernels/CoupledDiffusionReactionSub.h
+++ b/modules/chemical_reactions/include/kernels/CoupledDiffusionReactionSub.h
@@ -60,6 +60,8 @@ private:
    * constructor!
    */
   /// Material property of dispersion-diffusion coefficient.
+  bool _has_diff;
+  std::string _prop_name;
   MaterialProperty<Real> & _diffusivity;
 
   /// Weight of the equilibrium species concentration in the total primary species concentration.

--- a/modules/chemical_reactions/include/kernels/PrimaryTimeDerivative.h
+++ b/modules/chemical_reactions/include/kernels/PrimaryTimeDerivative.h
@@ -50,6 +50,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// Material property of porosity
+  std::string _prop_name;
   MaterialProperty<Real> & _porosity;
 };
 

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -11,13 +11,16 @@ InputParameters validParams<CoupledDiffusionReactionSub>()
   params.addParam<Real>("log_k",0.0,"Equilibrium constant of the equilbrium reaction in dissociation form");
   params.addParam<Real>("sto_u",1.0,"Stochiometric coef of the primary species this kernel operates on in the equilibrium reaction");
   params.addRequiredParam<std::vector<Real> >("sto_v","The stochiometric coefficients of coupled primary species");
+ params.addParam<std::string>("diffusivity","The real material property (here is it a diffusivity) to use in this boundary condition");
   params.addCoupledVar("v", "List of coupled primary species in this equilibrium species");
   return params;
 }
 
 CoupledDiffusionReactionSub::CoupledDiffusionReactionSub(const std::string & name, InputParameters parameters)
   :Kernel(name,parameters),
-   _diffusivity(getMaterialProperty<Real>("diffusivity")),
+   _has_diff(isParamValid("diffusivity")),
+   _prop_name(_has_diff? getParam<std::string>("diffusivity"): "diffusivity"),
+   _diffusivity(getMaterialProperty<Real>(_prop_name)),
    _weight(getParam<Real>("weight")),
    _log_k(getParam<Real>("log_k")),
    _sto_u(getParam<Real>("sto_u")),
@@ -125,7 +128,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (jvar == _vars[i])
+      if(jvar == _vars[i])
       {
         diff1 *= _sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_phi[_j][_qp];
       }
@@ -143,7 +146,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (jvar == _vars[i])
+      if(jvar == _vars[i])
       {
         diff2_1 = _sto_v[i]*(_sto_v[i]-1.0)*std::pow((*_vals[i])[_qp],_sto_v[i]-2.0)*_phi[_j][_qp]*(*_grad_vals[i])[_qp];
         diff2_2 = _sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_grad_phi[_j][_qp];
@@ -154,7 +157,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (jvar != _vars[i])
+      if(jvar != _vars[i])
       {
         diff2 *= std::pow((*_vals[i])[_qp],_sto_v[i]);
       }
@@ -170,7 +173,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (jvar == _vars[i])
+      if(jvar == _vars[i])
       {
         var = i;
         val_jvar = val_u*_sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_phi[_j][_qp];
@@ -179,7 +182,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (i != var)
+      if(i != var)
       {
         diff3 = val_jvar*_sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*(*_grad_vals[i])[_qp];
 

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -128,7 +128,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(jvar == _vars[i])
+      if (jvar == _vars[i])
       {
         diff1 *= _sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_phi[_j][_qp];
       }
@@ -146,7 +146,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(jvar == _vars[i])
+      if (jvar == _vars[i])
       {
         diff2_1 = _sto_v[i]*(_sto_v[i]-1.0)*std::pow((*_vals[i])[_qp],_sto_v[i]-2.0)*_phi[_j][_qp]*(*_grad_vals[i])[_qp];
         diff2_2 = _sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_grad_phi[_j][_qp];
@@ -157,7 +157,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(jvar != _vars[i])
+      if (jvar != _vars[i])
       {
         diff2 *= std::pow((*_vals[i])[_qp],_sto_v[i]);
       }
@@ -173,7 +173,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(jvar == _vars[i])
+      if (jvar == _vars[i])
       {
         var = i;
         val_jvar = val_u*_sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_phi[_j][_qp];
@@ -182,7 +182,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(i != var)
+      if (i != var)
       {
         diff3 = val_jvar*_sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*(*_grad_vals[i])[_qp];
 

--- a/modules/chemical_reactions/src/kernels/PrimaryTimeDerivative.C
+++ b/modules/chemical_reactions/src/kernels/PrimaryTimeDerivative.C
@@ -5,12 +5,14 @@ template<>
 InputParameters validParams<PrimaryTimeDerivative>()
 {
   InputParameters params = validParams<TimeDerivative>();
+  params.addParam<std::string>("porosity","porosity","The real material property (here is it a diffusivity) to use in this boundary condition");
   return params;
 }
 
 PrimaryTimeDerivative::PrimaryTimeDerivative(const std::string & name, InputParameters parameters) :
     TimeDerivative(name, parameters),
-    _porosity(getMaterialProperty<Real>("porosity"))
+    _prop_name(getParam<std::string>("porosity")),
+    _porosity(getMaterialProperty<Real>(_prop_name))
 {}
 
 Real


### PR DESCRIPTION
Miaomiao Jin (Mike Short's student) has generalized two kernels in the chemical_reactions module to accept variable strings for material properties, instead of fixed material properties called "diffusivity" and "porosity." This allows users to use the same kernels multiple times, with multiple material properties. For example, let's say we had a material with two diffusing species, with properties called "diffusivity_A" and "diffusivity_B". In the old way, we would have had to construct two material files, each with a material property called "diffusivity," to make this work. Now we don't have to.
