### PR TITLE
changes for VPSC interface

### DIFF
--- a/modules/solid_mechanics/include/auxkernels/MaterialStateVectorAux.h
+++ b/modules/solid_mechanics/include/auxkernels/MaterialStateVectorAux.h
@@ -1,0 +1,43 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef MATERIALSTATEVECTORAUX_H
+#define MATERIALSTATEVECTORAUX_H
+
+#include "AuxKernel.h"
+
+//Forward Declarations
+class MaterialStateVectorAux;
+
+template<>
+InputParameters validParams<MaterialStateVectorAux>();
+
+class MaterialStateVectorAux : public AuxKernel
+{
+public:
+
+  MaterialStateVectorAux(const std::string & name, InputParameters parameters);
+
+protected:
+
+  virtual double computeValue();
+
+  MaterialProperty<std::vector<double> > & _vpStatefulProperty;
+  int _index;
+//  Real _factor;
+ // const double _offset;
+
+};
+
+#endif //MATERIALSTATEVECTORAUX_H

--- a/modules/solid_mechanics/include/auxkernels/MaterialStateVectorAux.h
+++ b/modules/solid_mechanics/include/auxkernels/MaterialStateVectorAux.h
@@ -33,11 +33,8 @@ protected:
 
   virtual double computeValue();
 
-  MaterialProperty<std::vector<double> > & _vpStatefulProperty;
+  MaterialProperty<std::vector<double> > & _vp_stateful_property;
   int _index;
-//  Real _factor;
- // const double _offset;
 
 };
-
 #endif //MATERIALSTATEVECTORAUX_H

--- a/modules/solid_mechanics/src/auxkernels/MaterialStateVectorAux.C
+++ b/modules/solid_mechanics/src/auxkernels/MaterialStateVectorAux.C
@@ -23,14 +23,15 @@ InputParameters validParams<MaterialStateVectorAux>()
   return params;
 }
 
-MaterialStateVectorAux::MaterialStateVectorAux(const std::string & name, InputParameters parameters)
-  :AuxKernel(name, parameters),
-   _vpStatefulProperty(getMaterialProperty<std::vector<double> >("vpStatefulProperty")),
+MaterialStateVectorAux::MaterialStateVectorAux(const std::string & name, 
+                                               InputParameters parameters)
+  :AuxKernel( name, parameters ),
+   _vp_stateful_property( getMaterialProperty<std::vector<double> >("vpStatefulProperty") ),
    _index( getParam<int>("index") )
 {}
 
 double
 MaterialStateVectorAux::computeValue()
 {
-  return _vpStatefulProperty[_qp][_index];
+  return _vp_stateful_property[_qp][_index];
 }

--- a/modules/solid_mechanics/src/auxkernels/MaterialStateVectorAux.C
+++ b/modules/solid_mechanics/src/auxkernels/MaterialStateVectorAux.C
@@ -1,0 +1,36 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "MaterialStateVectorAux.h"
+
+template<>
+InputParameters validParams<MaterialStateVectorAux>()
+{
+  InputParameters params = validParams<AuxKernel>();
+  params.addRequiredParam<std::string>("vpStatefulProperty", "The vector material property name");
+  params.addRequiredParam<int>("index", "The index of a vector material"); 
+  return params;
+}
+
+MaterialStateVectorAux::MaterialStateVectorAux(const std::string & name, InputParameters parameters)
+  :AuxKernel(name, parameters),
+   _vpStatefulProperty(getMaterialProperty<std::vector<double> >("vpStatefulProperty")),
+   _index( getParam<int>("index") )
+{}
+
+double
+MaterialStateVectorAux::computeValue()
+{
+  return _vpStatefulProperty[_qp][_index];
+}

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -27,8 +27,8 @@
 #include "Mass.h"
 #include "JIntegral.h"
 #include "CrackFrontDefinition.h"
-#include "MaterialSymmElasticityTensorAux.h"
 #include "MaterialStateVectorAux.h"
+#include "MaterialSymmElasticityTensorAux.h"
 #include "MaterialTensorAux.h"
 #include "MaterialTensorOnLine.h"
 #include "MaterialVectorAux.h"
@@ -92,8 +92,8 @@ void
 SolidMechanicsApp::registerObjects(Factory & factory)
 {
   registerAux(ElasticEnergyAux);
-  registerAux(MaterialSymmElasticityTensorAux);
   registerAux(MaterialStateVectorAux);
+  registerAux(MaterialSymmElasticityTensorAux);
   registerAux(MaterialTensorAux);
   registerAux(MaterialVectorAux);
   registerAux(AccumulateAux);

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -28,6 +28,7 @@
 #include "JIntegral.h"
 #include "CrackFrontDefinition.h"
 #include "MaterialSymmElasticityTensorAux.h"
+#include "MaterialStateVectorAux.h"
 #include "MaterialTensorAux.h"
 #include "MaterialTensorOnLine.h"
 #include "MaterialVectorAux.h"
@@ -92,6 +93,7 @@ SolidMechanicsApp::registerObjects(Factory & factory)
 {
   registerAux(ElasticEnergyAux);
   registerAux(MaterialSymmElasticityTensorAux);
+  registerAux(MaterialStateVectorAux);
   registerAux(MaterialTensorAux);
   registerAux(MaterialVectorAux);
   registerAux(AccumulateAux);


### PR DESCRIPTION
Added MaterialStateVector auxkernel which is needed for the vpsc interface for Peregrine and Bison.
