### PR TITLE
Added New Feature #3258 - Variable Material Property Names in chemical_reactions module

### DIFF
--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -11,13 +11,14 @@ InputParameters validParams<CoupledDiffusionReactionSub>()
   params.addParam<Real>("log_k",0.0,"Equilibrium constant of the equilbrium reaction in dissociation form");
   params.addParam<Real>("sto_u",1.0,"Stochiometric coef of the primary species this kernel operates on in the equilibrium reaction");
   params.addRequiredParam<std::vector<Real> >("sto_v","The stochiometric coefficients of coupled primary species");
-  params.addCoupledVar("v", "List of coupled primary species in this equilibrium species");
+  params.addParam<std::string>("diffusivity","diffusivity","The real material property to use as the diffusivity of this particular species");
+  params.addCoupledVar("v","List of coupled primary species in this equilibrium species");
   return params;
 }
 
 CoupledDiffusionReactionSub::CoupledDiffusionReactionSub(const std::string & name, InputParameters parameters)
   :Kernel(name,parameters),
-   _diffusivity(getMaterialProperty<Real>("diffusivity")),
+   _diffusivity(getMaterialProperty<Real>(getParam<std::string>("diffusivity"))),
    _weight(getParam<Real>("weight")),
    _log_k(getParam<Real>("log_k")),
    _sto_u(getParam<Real>("sto_u")),
@@ -48,7 +49,7 @@ Real CoupledDiffusionReactionSub::computeQpResidual()
     }
   }
 
-  RealGradient diff2_sum(0.0,0.0,0.0);
+  RealGradient diff2_sum(0.0, 0.0, 0.0);
 
   Real d_val = std::pow(_u[_qp],_sto_u);
 

--- a/modules/chemical_reactions/src/kernels/PrimaryTimeDerivative.C
+++ b/modules/chemical_reactions/src/kernels/PrimaryTimeDerivative.C
@@ -5,12 +5,13 @@ template<>
 InputParameters validParams<PrimaryTimeDerivative>()
 {
   InputParameters params = validParams<TimeDerivative>();
+  params.addParam<std::string>("porosity","porosity","The real material property (here is it a porosity) to use");
   return params;
 }
 
 PrimaryTimeDerivative::PrimaryTimeDerivative(const std::string & name, InputParameters parameters) :
     TimeDerivative(name, parameters),
-    _porosity(getMaterialProperty<Real>("porosity"))
+    _porosity(getMaterialProperty<Real>(getParam<std::string>("porosity")))
 {}
 
 Real


### PR DESCRIPTION
We wanted to allow multiple species diffusivities in porous media, which was not allowed (or was difficult) with the old implementation where material property names were fixed in the code ("diffusivity," "porosity," etc.). We have changed this to allow the user to specify diffusivities and such in the input file, so the same kernels can be used in the same porous media mesh with multiple diffusing and dissolving species.
