### PR TITLE
Adding ScalarCoupleable interface to ElementUserObjct (closes #3265)

### DIFF
--- a/framework/include/userobject/ElementUserObject.h
+++ b/framework/include/userobject/ElementUserObject.h
@@ -19,6 +19,7 @@
 #include "UserObject.h"
 #include "UserObjectInterface.h"
 #include "Coupleable.h"
+#include "ScalarCoupleable.h"
 #include "MooseVariableDependencyInterface.h"
 #include "TransientInterface.h"
 #include "PostprocessorInterface.h"
@@ -42,6 +43,7 @@ class ElementUserObject :
   public MaterialPropertyInterface,
   public UserObjectInterface,
   public Coupleable,
+  public ScalarCoupleable,
   public MooseVariableDependencyInterface,
   public TransientInterface,
   protected PostprocessorInterface,

--- a/framework/src/userobject/ElementUserObject.C
+++ b/framework/src/userobject/ElementUserObject.C
@@ -32,6 +32,7 @@ ElementUserObject::ElementUserObject(const std::string & name, InputParameters p
     MaterialPropertyInterface(parameters),
     UserObjectInterface(parameters),
     Coupleable(parameters, false),
+    ScalarCoupleable(parameters),
     MooseVariableDependencyInterface(),
     TransientInterface(parameters, name, "element_user_objects"),
     PostprocessorInterface(parameters),


### PR DESCRIPTION
It was not able to use scalar variables in anythong derived from
ElementUserObject, because it was missing ScalarCoupleable interface.
