### PR TITLE
Feature #3259 - Variable mateiral property names in chemical_reactions module

### DIFF
--- a/modules/chemical_reactions/include/kernels/CoupledDiffusionReactionSub.h
+++ b/modules/chemical_reactions/include/kernels/CoupledDiffusionReactionSub.h
@@ -60,6 +60,8 @@ private:
    * constructor!
    */
   /// Material property of dispersion-diffusion coefficient.
+  bool _has_diff;
+  std::string _prop_name;
   MaterialProperty<Real> & _diffusivity;
 
   /// Weight of the equilibrium species concentration in the total primary species concentration.

--- a/modules/chemical_reactions/include/kernels/PrimaryTimeDerivative.h
+++ b/modules/chemical_reactions/include/kernels/PrimaryTimeDerivative.h
@@ -50,6 +50,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// Material property of porosity
+  std::string _prop_name;
   MaterialProperty<Real> & _porosity;
 };
 

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -10,21 +10,21 @@ InputParameters validParams<CoupledDiffusionReactionSub>()
   params.addParam<Real>("weight",1.0,"Weight of equilibrium species concentration in the primary species concentration");
   params.addParam<Real>("log_k",0.0,"Equilibrium constant of the equilbrium reaction in dissociation form");
   params.addParam<Real>("sto_u",1.0,"Stochiometric coef of the primary species this kernel operates on in the equilibrium reaction");
-  params.addRequiredParam<std::vector<Real> >("sto_v","The stochiometric coefficients of coupled primary species");
- params.addParam<std::string>("diffusivity","The real material property (here is it a diffusivity) to use in this boundary condition");
-  params.addCoupledVar("v", "List of coupled primary species in this equilibrium species");
+  params.addRequiredParam<std::vector<Real>>("sto_v","The stochiometric coefficients of coupled primary species");
+  params.addParam<std::string>("diffusivity","The real material property (here is it a diffusivity) to use in this boundary condition");
+  params.addCoupledVar("v","List of coupled primary species in this equilibrium species");
   return params;
 }
 
 CoupledDiffusionReactionSub::CoupledDiffusionReactionSub(const std::string & name, InputParameters parameters)
   :Kernel(name,parameters),
    _has_diff(isParamValid("diffusivity")),
-   _prop_name(_has_diff? getParam<std::string>("diffusivity"): "diffusivity"),
+   _prop_name(_has_diff ? getParam<std::string>("diffusivity") : "diffusivity"),
    _diffusivity(getMaterialProperty<Real>(_prop_name)),
    _weight(getParam<Real>("weight")),
    _log_k(getParam<Real>("log_k")),
    _sto_u(getParam<Real>("sto_u")),
-   _sto_v(getParam<std::vector<Real> >("sto_v"))
+   _sto_v(getParam<std::vector<Real>>("sto_v"))
 {
   int n = coupledComponents("v");
   _vars.resize(n);
@@ -51,7 +51,7 @@ Real CoupledDiffusionReactionSub::computeQpResidual()
     }
   }
 
-  RealGradient diff2_sum(0.0,0.0,0.0);
+  RealGradient diff2_sum(0.0, 0.0, 0.0);
 
   Real d_val = std::pow(_u[_qp],_sto_u);
 

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -11,13 +11,16 @@ InputParameters validParams<CoupledDiffusionReactionSub>()
   params.addParam<Real>("log_k",0.0,"Equilibrium constant of the equilbrium reaction in dissociation form");
   params.addParam<Real>("sto_u",1.0,"Stochiometric coef of the primary species this kernel operates on in the equilibrium reaction");
   params.addRequiredParam<std::vector<Real> >("sto_v","The stochiometric coefficients of coupled primary species");
+ params.addParam<std::string>("diffusivity","The real material property (here is it a diffusivity) to use in this boundary condition");
   params.addCoupledVar("v", "List of coupled primary species in this equilibrium species");
   return params;
 }
 
 CoupledDiffusionReactionSub::CoupledDiffusionReactionSub(const std::string & name, InputParameters parameters)
   :Kernel(name,parameters),
-   _diffusivity(getMaterialProperty<Real>("diffusivity")),
+   _has_diff(isParamValid("diffusivity")),
+   _prop_name(_has_diff? getParam<std::string>("diffusivity"): "diffusivity"),
+   _diffusivity(getMaterialProperty<Real>(_prop_name)),
    _weight(getParam<Real>("weight")),
    _log_k(getParam<Real>("log_k")),
    _sto_u(getParam<Real>("sto_u")),
@@ -125,7 +128,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (jvar == _vars[i])
+      if(jvar == _vars[i])
       {
         diff1 *= _sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_phi[_j][_qp];
       }
@@ -143,7 +146,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (jvar == _vars[i])
+      if(jvar == _vars[i])
       {
         diff2_1 = _sto_v[i]*(_sto_v[i]-1.0)*std::pow((*_vals[i])[_qp],_sto_v[i]-2.0)*_phi[_j][_qp]*(*_grad_vals[i])[_qp];
         diff2_2 = _sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_grad_phi[_j][_qp];
@@ -154,7 +157,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (jvar != _vars[i])
+      if(jvar != _vars[i])
       {
         diff2 *= std::pow((*_vals[i])[_qp],_sto_v[i]);
       }
@@ -170,7 +173,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (jvar == _vars[i])
+      if(jvar == _vars[i])
       {
         var = i;
         val_jvar = val_u*_sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_phi[_j][_qp];
@@ -179,7 +182,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if (i != var)
+      if(i != var)
       {
         diff3 = val_jvar*_sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*(*_grad_vals[i])[_qp];
 

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -10,7 +10,7 @@ InputParameters validParams<CoupledDiffusionReactionSub>()
   params.addParam<Real>("weight",1.0,"Weight of equilibrium species concentration in the primary species concentration");
   params.addParam<Real>("log_k",0.0,"Equilibrium constant of the equilbrium reaction in dissociation form");
   params.addParam<Real>("sto_u",1.0,"Stochiometric coef of the primary species this kernel operates on in the equilibrium reaction");
-  params.addRequiredParam<std::vector<Real>>("sto_v","The stochiometric coefficients of coupled primary species");
+  params.addRequiredParam<std::vector<Real> >("sto_v","The stochiometric coefficients of coupled primary species");
   params.addParam<std::string>("diffusivity","The real material property (here is it a diffusivity) to use in this boundary condition");
   params.addCoupledVar("v","List of coupled primary species in this equilibrium species");
   return params;
@@ -24,7 +24,7 @@ CoupledDiffusionReactionSub::CoupledDiffusionReactionSub(const std::string & nam
    _weight(getParam<Real>("weight")),
    _log_k(getParam<Real>("log_k")),
    _sto_u(getParam<Real>("sto_u")),
-   _sto_v(getParam<std::vector<Real>>("sto_v"))
+   _sto_v(getParam<std::vector<Real> >("sto_v"))
 {
   int n = coupledComponents("v");
   _vars.resize(n);

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -128,7 +128,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(jvar == _vars[i])
+      if (jvar == _vars[i])
       {
         diff1 *= _sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_phi[_j][_qp];
       }
@@ -146,7 +146,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(jvar == _vars[i])
+      if (jvar == _vars[i])
       {
         diff2_1 = _sto_v[i]*(_sto_v[i]-1.0)*std::pow((*_vals[i])[_qp],_sto_v[i]-2.0)*_phi[_j][_qp]*(*_grad_vals[i])[_qp];
         diff2_2 = _sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_grad_phi[_j][_qp];
@@ -157,7 +157,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(jvar != _vars[i])
+      if (jvar != _vars[i])
       {
         diff2 *= std::pow((*_vals[i])[_qp],_sto_v[i]);
       }
@@ -173,7 +173,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(jvar == _vars[i])
+      if (jvar == _vars[i])
       {
         var = i;
         val_jvar = val_u*_sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*_phi[_j][_qp];
@@ -182,7 +182,7 @@ Real CoupledDiffusionReactionSub::computeQpOffDiagJacobian(unsigned int jvar)
 
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if(i != var)
+      if (i != var)
       {
         diff3 = val_jvar*_sto_v[i]*std::pow((*_vals[i])[_qp],_sto_v[i]-1.0)*(*_grad_vals[i])[_qp];
 

--- a/modules/chemical_reactions/src/kernels/PrimaryTimeDerivative.C
+++ b/modules/chemical_reactions/src/kernels/PrimaryTimeDerivative.C
@@ -5,12 +5,14 @@ template<>
 InputParameters validParams<PrimaryTimeDerivative>()
 {
   InputParameters params = validParams<TimeDerivative>();
+  params.addParam<std::string>("porosity","porosity","The real material property (here is it a diffusivity) to use in this boundary condition");
   return params;
 }
 
 PrimaryTimeDerivative::PrimaryTimeDerivative(const std::string & name, InputParameters parameters) :
     TimeDerivative(name, parameters),
-    _porosity(getMaterialProperty<Real>("porosity"))
+    _prop_name(getParam<std::string>("porosity")),
+    _porosity(getMaterialProperty<Real>(_prop_name))
 {}
 
 Real


### PR DESCRIPTION
We wanted to allow multiple species diffusivities in porous media, which was not allowed (or was difficult) with the old implementation where material property names were fixed in the code ("diffusivity," "porosity," etc.). We have changed this to allow the user to specify diffusivities and such in the input file, so the same kernels can be used in the same porous media mesh with multiple diffusing and dissolving species.

This new ticket also fixes some whitespace issues having to do with C++003 compliance per moose dev team request.
