### PR TITLE
As per #3284

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -286,12 +286,6 @@ public:
   const std::set<BoundaryID> & meshBoundaryIds() const;
 
   /**
-   * Returns a not-read-only reference to the set of subdomains currently
-   * present in the Mesh.
-   */
-  std::set<BoundaryID> & meshBoundaryIds();
-
-  /**
    * Sets the mapping between BoundaryID and normal vector
    * Is called by AddAllSideSetsByNormals
    */

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -286,6 +286,24 @@ public:
   const std::set<BoundaryID> & meshBoundaryIds() const;
 
   /**
+   * Returns a not-read-only reference to the set of subdomains currently
+   * present in the Mesh.
+   */
+  std::set<BoundaryID> & meshBoundaryIds();
+
+  /**
+   * Sets the mapping between BoundaryID and normal vector
+   * Is called by AddAllSideSetsByNormals
+   */
+  void setBoundaryToNormalMap(AutoPtr<std::map<BoundaryID, RealVectorValue> > boundary_map);
+
+  /**
+   * Sets the set of BoundaryIDs
+   * Is called by AddAllSideSetsByNormals
+   */
+  void setMeshBoundaryIDs(std::set<BoundaryID> boundary_IDs);
+
+  /**
    * Returns the normal vector associated with a given BoundaryID.
    * It's only valid to call this when AddAllSideSetsByNormals is active.
    */
@@ -735,9 +753,6 @@ protected:
    * In serial, this is equivalent to the values returned
    * by _mesh.boundary_info->get_boundary_ids().  In parallel,
    * it will contain off-processor boundary IDs as well.
-   *
-   * Note: This datastructure is directly accessed
-   * and modified by the friend "AddAllSideSetsByNormals".
    */
   std::set<BoundaryID> _mesh_boundary_ids;
 
@@ -898,8 +913,6 @@ private:
 
   /// Whether or not this Mesh is allowed to read a recovery file
   bool _allow_recovery;
-
-  friend class AddAllSideSetsByNormals;
 };
 
 #endif /* MOOSEMESH_H */

--- a/framework/include/meshmodifiers/AddAllSideSetsByNormals.h
+++ b/framework/include/meshmodifiers/AddAllSideSetsByNormals.h
@@ -45,7 +45,7 @@ protected:
    * A pointer to the Mesh's boundary set, this datastructure will be modified
    * through this modifier.
    */
-  std::set<BoundaryID> *_mesh_boundary_ids;
+  std::set<BoundaryID> _mesh_boundary_ids;
 };
 
 #endif /* ADDALLSIDESETS_H */

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1828,12 +1828,6 @@ MooseMesh::meshBoundaryIds() const
   return _mesh_boundary_ids;
 }
 
-std::set<BoundaryID> &
-MooseMesh::meshBoundaryIds()
-{
-  return _mesh_boundary_ids;
-}
-
 void
 MooseMesh::setMeshBoundaryIDs(std::set<BoundaryID> boundary_IDs)
 {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1828,6 +1828,24 @@ MooseMesh::meshBoundaryIds() const
   return _mesh_boundary_ids;
 }
 
+std::set<BoundaryID> &
+MooseMesh::meshBoundaryIds()
+{
+  return _mesh_boundary_ids;
+}
+
+void
+MooseMesh::setMeshBoundaryIDs(std::set<BoundaryID> boundary_IDs)
+{
+  _mesh_boundary_ids = boundary_IDs;
+}
+
+void
+MooseMesh::setBoundaryToNormalMap(AutoPtr<std::map<BoundaryID, RealVectorValue> > boundary_map)
+{
+  _boundary_to_normal_map = boundary_map;
+}
+
 #ifdef LIBMESH_ENABLE_AMR
 unsigned int & MooseMesh::uniformRefineLevel()
 {

--- a/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
+++ b/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
@@ -51,7 +51,7 @@ AddAllSideSetsByNormals::modify()
   _mesh_ptr->errorIfParallelDistribution("AddAllSideSetsByNormals");
 
   // Get the current list of boundaries so we can generate new ones that won't conflict
-  _mesh_boundary_ids = &_mesh_ptr->_mesh_boundary_ids;
+  _mesh_boundary_ids = &(_mesh_ptr->meshBoundaryIds());
 
   // Create the map object that will be owned by MooseMesh
   AutoPtr<std::map<BoundaryID, RealVectorValue> > boundary_map(new std::map<BoundaryID, RealVectorValue>());
@@ -98,8 +98,9 @@ AddAllSideSetsByNormals::modify()
 
   finalize();
 
-  // Transfer owndership of the boundary map.
-  _mesh_ptr->_boundary_to_normal_map = boundary_map;
+  // Transfer ownership of the boundary map and boundary ID set.
+  _mesh_ptr->setBoundaryToNormalMap(boundary_map);
+  _mesh_ptr->setMeshBoundaryIDs(*_mesh_boundary_ids);
 }
 
 BoundaryID

--- a/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
+++ b/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
@@ -51,7 +51,7 @@ AddAllSideSetsByNormals::modify()
   _mesh_ptr->errorIfParallelDistribution("AddAllSideSetsByNormals");
 
   // Get the current list of boundaries so we can generate new ones that won't conflict
-  _mesh_boundary_ids = &(_mesh_ptr->meshBoundaryIds());
+  _mesh_boundary_ids = _mesh_ptr->meshBoundaryIds();
 
   // Create the map object that will be owned by MooseMesh
   AutoPtr<std::map<BoundaryID, RealVectorValue> > boundary_map(new std::map<BoundaryID, RealVectorValue>());
@@ -100,7 +100,7 @@ AddAllSideSetsByNormals::modify()
 
   // Transfer ownership of the boundary map and boundary ID set.
   _mesh_ptr->setBoundaryToNormalMap(boundary_map);
-  _mesh_ptr->setMeshBoundaryIDs(*_mesh_boundary_ids);
+  _mesh_ptr->setMeshBoundaryIDs(_mesh_boundary_ids);
 }
 
 BoundaryID
@@ -109,10 +109,10 @@ AddAllSideSetsByNormals::getNextBoundaryID()
   std::set<BoundaryID>::iterator it;
   BoundaryID next_id = 1;
 
-  while ((it = _mesh_boundary_ids->find(next_id)) != _mesh_boundary_ids->end())
+  while ((it = _mesh_boundary_ids.find(next_id)) != _mesh_boundary_ids.end())
     ++next_id;
 
-  _mesh_boundary_ids->insert(next_id);
+  _mesh_boundary_ids.insert(next_id);
 
   return next_id;
 }


### PR DESCRIPTION
Modify MooseMesh to handle boundary normals without making the individual MeshModifiers friend classes
