### PR TITLE
Re-factored CSV related FormattedTables for restart/recover

### DIFF
--- a/framework/include/outputs/TableOutput.h
+++ b/framework/include/outputs/TableOutput.h
@@ -80,16 +80,19 @@ protected:
    */
   virtual void outputVectorPostprocessors();
 
-  /// Table containing postprocessor data (restartable)
+  /// Flag for allowing all table data to become restartable
+  bool _tables_restartable;
+
+  /// Table containing postprocessor data
   FormattedTable & _postprocessor_table;
 
   /// Formatted tables for outputting vector postprocessor data.  One per VectorPostprocessor
   std::map<std::string, FormattedTable> _vector_postprocessor_tables;
 
-  /// Table containing scalar aux variables (restartable)
+  /// Table containing scalar aux variables
   FormattedTable & _scalar_table;
 
-  /// Table containing postprocessor values and scalar aux variables (restartable)
+  /// Table containing postprocessor values and scalar aux variables
   FormattedTable & _all_data_table;
 
 };

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -204,6 +204,7 @@ private:
   friend class FileOutput;
   friend class FEProblem;
   friend class Transient;
+  friend class TableOutput;
 };
 
 template<typename T>

--- a/framework/src/outputs/CSV.C
+++ b/framework/src/outputs/CSV.C
@@ -23,9 +23,6 @@ InputParameters validParams<CSV>()
   // Get the parameters from the parent object
   InputParameters params = validParams<TableOutput>();
 
-  // Add option for appending file on restart
-  params.addParam<bool>("append_restart", false, "Append existing file on restart");
-
   // Options for aligning csv output with whitespace padding
   params.addParam<bool>("align", false, "Align the outputted csv data by padding the numbers with trailing whitespace");
   params.addParam<std::string>("delimiter", "Assign the delimiter (default is ','"); // default not included because peacock didn't parse ','
@@ -50,10 +47,7 @@ CSV::~CSV()
 void
 CSV::initialSetup()
 {
-  if (_app.isRestarting() && !getParam<bool>("append_restart"))
-    _all_data_table.clear();
-
-  // Set the delimiter
+// Set the delimiter
   if (isParamValid("delimiter"))
     _all_data_table.setDelimiter(getParam<std::string>("delimiter"));
 

--- a/framework/src/outputs/TableOutput.C
+++ b/framework/src/outputs/TableOutput.C
@@ -40,14 +40,18 @@ InputParameters validParams<TableOutput>()
   params.suppressParameter<bool>("scalar_as_nodal");
   params.suppressParameter<bool>("output_input");
 
+  // Add option for appending file on restart
+  params.addParam<bool>("append_restart", false, "Append existing file on restart");
+
   return params;
 }
 
 TableOutput::TableOutput(const std::string & name, InputParameters parameters) :
     PetscOutput(name, parameters),
-    _postprocessor_table(declareRestartableData<FormattedTable>("postprocessor_table")),
-    _scalar_table(declareRestartableData<FormattedTable>("scalar_table")),
-    _all_data_table(declareRestartableData<FormattedTable>("all_data_table"))
+    _tables_restartable(getParam<bool>("append_restart")),
+    _postprocessor_table(_tables_restartable ? declareRestartableData<FormattedTable>("postprocessor_table") : declareRecoverableData<FormattedTable>("postprocessor_table")),
+    _scalar_table(_tables_restartable ? declareRestartableData<FormattedTable>("scalar_table") : declareRecoverableData<FormattedTable>("scalar_table")),
+    _all_data_table(_tables_restartable ? declareRestartableData<FormattedTable>("all_data_table") : declareRecoverableData<FormattedTable>("all_data_table"))
 {
 }
 

--- a/test/tests/outputs/csv/tests
+++ b/test/tests/outputs/csv/tests
@@ -31,7 +31,7 @@
     type = CSVDiff
     input = csv_restart_part2.i
     csvdiff = 'csv_restart_part2_append_out.csv'
-    prereq = restart_part1
+    prereq = restart_part2
     cli_args = 'Outputs/csv/file_base=csv_restart_part2_append_out Outputs/csv/append_restart=true'
   [../]
   [./align]


### PR DESCRIPTION
The logic for restarting vs. recovering CSV files, which utilizes FormattedTable was incorrect, they now behave as follows:
1. When restarting FormattedTable data is not loaded unless you specify a special input parameter.
2. When recovering FormattedTable data is loaded.

This should get the --recover tests going again.
(#3151)
