### PR TITLE
Need to calculate boundary materials in boundary user objects/pps

### DIFF
--- a/framework/src/base/ComputeUserObjectsThread.C
+++ b/framework/src/base/ComputeUserObjectsThread.C
@@ -188,6 +188,7 @@ ComputeUserObjectsThread::onBoundary(const Elem *elem, unsigned int side, Bounda
   {
     _fe_problem.reinitElemFace(elem, side, bnd_id, _tid);
     _fe_problem.reinitMaterialsFace(_subdomain, _tid);
+    _fe_problem.reinitMaterialsBoundary(bnd_id, _tid);
 
     for (std::vector<SideUserObject *>::const_iterator side_UserObject_it = _user_objects[_tid].sideUserObjects(bnd_id, _group).begin();
          side_UserObject_it != _user_objects[_tid].sideUserObjects(bnd_id, _group).end();

--- a/test/tests/postprocessors/misc_pps/misc_pps_test.i
+++ b/test/tests/postprocessors/misc_pps/misc_pps_test.i
@@ -108,7 +108,7 @@
 []
 
 [Materials]
-  [./constant]
+  [./constant_block]
     type = GenericConstantMaterial
     prop_names = diffusivity
     prop_values = 1

--- a/test/tests/postprocessors/side_flux_average/side_flux_average.i
+++ b/test/tests/postprocessors/side_flux_average/side_flux_average.i
@@ -45,6 +45,13 @@
     type = GenericConstantMaterial
     block = 0
     prop_names = diffusivity
+    prop_values = 2
+  [../]
+
+  [./mat_props_bnd]
+    type = GenericConstantMaterial
+    boundary = right
+    prop_names = diffusivity
     prop_values = 1
   [../]
 []


### PR DESCRIPTION
refs #3322, #2192

Still need to refactor the check to handle the case when we have a boundary overriding a face material property.
