### PR TITLE
Clean up Split Cahn-Hilliard kernels

### DIFF
--- a/modules/phase_field/include/kernels/SplitCHCRes.h
+++ b/modules/phase_field/include/kernels/SplitCHCRes.h
@@ -25,7 +25,6 @@ private:
   MaterialProperty<Real> & _kappa;
   unsigned int _w_var;
   VariableValue & _w;
-  VariableGradient & _grad_w;
 };
 
 #endif //SPLITCHCRES_H

--- a/modules/phase_field/include/kernels/SplitCHMath.h
+++ b/modules/phase_field/include/kernels/SplitCHMath.h
@@ -3,7 +3,6 @@
 
 #include "SplitCHCRes.h"
 
-
 //Forward Declarations
 class SplitCHMath;
 

--- a/modules/phase_field/include/kernels/SplitCHWRes.h
+++ b/modules/phase_field/include/kernels/SplitCHWRes.h
@@ -18,13 +18,10 @@ public:
 protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
   std::string _mob_name;
   MaterialProperty<Real> & _mob;
-  unsigned int _c_var;
-  VariableValue & _c;
 };
 
 #endif //SPLITCHWRES_H

--- a/modules/phase_field/src/kernels/SplitCHBase.C
+++ b/modules/phase_field/src/kernels/SplitCHBase.C
@@ -27,7 +27,7 @@ SplitCHBase::computeDFDC(PFFunctionType type)
   }
 
   mooseError("Invalid type passed in");
-  }*/
+}*/
 
 Real
 SplitCHBase::computeQpResidual()

--- a/modules/phase_field/src/kernels/SplitCHCRes.C
+++ b/modules/phase_field/src/kernels/SplitCHCRes.C
@@ -16,8 +16,7 @@ SplitCHCRes::SplitCHCRes(const std::string & name, InputParameters parameters) :
     _kappa_name(getParam<std::string>("kappa_name")),
     _kappa(getMaterialProperty<Real>(_kappa_name)),
     _w_var(coupled("w")),
-    _w(coupledValue("w")),
-    _grad_w(coupledGradient("w"))
+    _w(coupledValue("w"))
 {
 }
 
@@ -35,7 +34,7 @@ SplitCHCRes::computeDFDC(PFFunctionType type)
   }
 
   mooseError("Invalid type passed in");
-  }*/
+}*/
 
 Real
 SplitCHCRes::computeQpResidual()

--- a/modules/phase_field/src/kernels/SplitCHMath.C
+++ b/modules/phase_field/src/kernels/SplitCHMath.C
@@ -1,4 +1,5 @@
 #include "SplitCHMath.h"
+
 // The couple, SplitCHMath and SplitCHWRes, splits the CH equation by replacing chemical potential with 'w'.
 template<>
 InputParameters validParams<SplitCHMath>()

--- a/modules/phase_field/src/kernels/SplitCHWRes.C
+++ b/modules/phase_field/src/kernels/SplitCHWRes.C
@@ -11,11 +11,9 @@ InputParameters validParams<SplitCHWRes>()
 SplitCHWRes::SplitCHWRes(const std::string & name, InputParameters parameters) :
     Kernel(name, parameters),
     _mob_name(getParam<std::string>("mob_name")),
-    _mob(getMaterialProperty<Real>(_mob_name)),
-    // This _c_var is needed to compute off-diagonal Jacobian.
-    _c_var(coupled("c")),
-    _c(coupledValue("c"))
-{}
+    _mob(getMaterialProperty<Real>(_mob_name))
+{
+}
 
 Real
 SplitCHWRes::computeQpResidual()
@@ -27,15 +25,4 @@ Real
 SplitCHWRes::computeQpJacobian()
 {
   return _mob[_qp] * _grad_phi[_j][_qp] * _grad_test[_i][_qp];
-}
-
-Real
-SplitCHWRes::computeQpOffDiagJacobian(unsigned int jvar)
-{
-  if (jvar == _c_var)
-  {
-    return 0.0;
-  }
-
-  return 0.0;
 }


### PR DESCRIPTION
This should close #3341 by removing unused couplings from the Split Cahn-Hilliard Kernels.
