### PR TITLE
JxW in Assembly class has to come from the surface (closes #3345)

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -294,7 +294,7 @@ public:
   /**
    * Reinitializes the neighbor at the physical coordinates given.
    */
-  void reinitNeighborAtPhysical(const Elem * neighbor, const std::vector<Point> & physical_points);
+  void reinitNeighborAtPhysical(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points);
 
   /**
    * Reinitialize assembly data for a node
@@ -529,12 +529,14 @@ protected:
 
   /// types of finite elements
   std::map<unsigned int, std::map<FEType, FEBase *> > _fe_neighbor;
+  /// Each dimension's helper objects
+  std::map<unsigned int, FEBase **> _holder_fe_neighbor_helper;
 
   /// quadrature rule used on neighbors
   QBase * _current_qrule_neighbor;
   /// Holds arbitrary qrules for each dimension
   std::map<unsigned int, ArbitraryQuadrature *> _holder_qrule_neighbor;
-  /// The current transformed jacobian weights on a neighbor face
+  /// The current transformed jacobian weights on a neighbor's face
   MooseArray<Real> _current_JxW_neighbor;
 
   /// The current "element" we are currently on.
@@ -551,6 +553,8 @@ protected:
   const Elem * _current_neighbor_elem;
   /// The current side of the selected neighboring element (valid only when working with sides)
   unsigned int _current_neighbor_side;
+  /// The current side element of the ncurrent neighbor element
+  const Elem * _current_neighbor_side_elem;
   /// Volume of the current neighbor
   Real _current_neighbor_volume;
   /// The current node we are working with

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -326,10 +326,10 @@ DisplacedProblem::reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID
 }
 
 void
-DisplacedProblem::reinitNeighborPhys(const Elem * neighbor, unsigned int /*neighbor_side*/, const std::vector<Point> & physical_points, THREAD_ID tid)
+DisplacedProblem::reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid)
 {
   // Reinit shape functions
-  _assembly[tid]->reinitNeighborAtPhysical(neighbor, physical_points);
+  _assembly[tid]->reinitNeighborAtPhysical(neighbor, neighbor_side, physical_points);
 
   // Set the neighbor dof indices
   _displaced_nl.prepareNeighbor(tid);

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1011,7 +1011,7 @@ void
 FEProblem::reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid)
 {
   // Reinits shape the functions at the physical points
-  _assembly[tid]->reinitNeighborAtPhysical(neighbor, physical_points);
+  _assembly[tid]->reinitNeighborAtPhysical(neighbor, neighbor_side, physical_points);
 
   // Sets the neighbor dof indices
   _nl.prepareNeighbor(tid);


### PR DESCRIPTION
When integrating over the face surface, transformed jacobian weights
have to come from the surface.  It was incorrectly implemented and JxW
came from the volume. This also fixes the memory leak introduced by
copying a JxW array into another MooseArray.
