### PR TITLE
RichardsMaterial substantially tidied up and derivatives are now

### DIFF
--- a/modules/richards/include/kernels/RichardsFlux.h
+++ b/modules/richards/include/kernels/RichardsFlux.h
@@ -78,11 +78,19 @@ protected:
   /// SUPGtau*SUPGvel (a vector of these if multiphase)
   MaterialProperty<std::vector<RealVectorValue> >&_tauvel_SUPG;
 
-  /// derivative of SUPGtau*SUPGvel wrt grad(variable)
-  MaterialProperty<std::vector<RealTensorValue> >&_dtauvel_SUPG_dgradv;
+  /// derivative of SUPGtau*SUPGvel_i wrt grad(variable_j)
+  MaterialProperty<std::vector<std::vector<RealTensorValue> > >&_dtauvel_SUPG_dgradv;
 
-  /// derivative of SUPGtau*SUPGvel wrt variable
-  MaterialProperty<std::vector<RealVectorValue> >&_dtauvel_SUPG_dv;
+  /// derivative of SUPGtau*SUPGvel_i wrt variable_j
+  MaterialProperty<std::vector<std::vector<RealVectorValue> > >&_dtauvel_SUPG_dv;
+
+  /**
+   * Computes diagonal and off-diagonal jacobian entries.
+   * Since the code is almost identical for both cases it's
+   * better to use just one function
+   * @param wrt_num take the derivative of the residual wrt this richards variable
+   */
+  Real computeQpJac(unsigned int wrt_num);
 };
 
 #endif //RICHARDSFLUX

--- a/modules/richards/include/kernels/RichardsMassChange.h
+++ b/modules/richards/include/kernels/RichardsMassChange.h
@@ -61,10 +61,17 @@ protected:
   MaterialProperty<std::vector<RealVectorValue> >&_tauvel_SUPG;
 
   /// derivative of tau_SUPG wrt grad(variable)
-  MaterialProperty<std::vector<RealTensorValue> >&_dtauvel_SUPG_dgradv;
+  MaterialProperty<std::vector<std::vector<RealTensorValue> > >&_dtauvel_SUPG_dgradv;
 
   /// deriv of tau_SUPG wrt variable
-  MaterialProperty<std::vector<RealVectorValue> >&_dtauvel_SUPG_dv;
+  MaterialProperty<std::vector<std::vector<RealVectorValue> > >&_dtauvel_SUPG_dv;
+
+  /**
+   * Derivative of residual with respect to wrt_num Richards variable
+   * This is used by both computeQpJacobian and computeQpOffDiagJacobian
+   * @param wrt_num take the derivative of the residual wrt this Richards variable
+   */
+  Real computeQpJac(unsigned int wrt_num);
 
 };
 

--- a/modules/richards/include/userobjects/RichardsSUPG.h
+++ b/modules/richards/include/userobjects/RichardsSUPG.h
@@ -111,6 +111,13 @@ class RichardsSUPG : public GeneralUserObject
    * @param db2_dp derivative of b*b wrt porepressure
    */
   virtual Real dtauSUPG_dp(RealVectorValue vel, RealVectorValue dvel_dp, Real traceperm, RealVectorValue b, Real db2_dp) const = 0;
+
+  /**
+   * Returns true if SUPG is trivial.
+   * This may used for optimization since typically
+   * SUPG stuff is quite expensive to calculate
+   */
+  virtual bool SUPG_trivial() const = 0;
 };
 
 #endif // RICHARDSSUPG_H

--- a/modules/richards/include/userobjects/RichardsSUPGnone.h
+++ b/modules/richards/include/userobjects/RichardsSUPGnone.h
@@ -50,6 +50,8 @@ class RichardsSUPGnone : public RichardsSUPG
   /// derivative of tau SUPG parameter wrt porepressure = zero
   Real dtauSUPG_dp(RealVectorValue /*vel*/, RealVectorValue /*dvel_dp*/, Real /*traceperm*/, RealVectorValue /*b*/, Real /*db2_dp*/) const;
 
+  bool SUPG_trivial() const;
+
 };
 
 #endif // RICHARDSSUPGnone_H

--- a/modules/richards/include/userobjects/RichardsSUPGstandard.h
+++ b/modules/richards/include/userobjects/RichardsSUPGstandard.h
@@ -108,6 +108,9 @@ class RichardsSUPGstandard : public RichardsSUPG
    */
   Real dtauSUPG_dp(RealVectorValue vel, RealVectorValue dvel_dp, Real traceperm, RealVectorValue b, Real db2_dp) const;
 
+  /// returns false in this case since everything is trivial
+  bool SUPG_trivial() const;
+
  protected:
 
   /**

--- a/modules/richards/include/userobjects/RichardsVarNames.h
+++ b/modules/richards/include/userobjects/RichardsVarNames.h
@@ -105,6 +105,10 @@ class RichardsVarNames :
    */
   MooseVariable * raw_var(unsigned int richards_var_num) const;
 
+  /// return the _var_types string
+  std::string var_types() const;
+
+
  protected:
 
   /// number of richards variables
@@ -112,6 +116,9 @@ class RichardsVarNames :
 
   /// space-separated string of names of porepressure variables
   std::string _the_names;
+
+  /// physical meaning of the variables.  Eg 'pppp' means 'all variables are pressure variables'
+  MooseEnum _var_types;
 
   /// _moose_var_num[i] = the moose variable number corresponding to richards variable i
   std::vector<unsigned int> _moose_var_num;

--- a/modules/richards/src/materials/RichardsMaterial.C
+++ b/modules/richards/src/materials/RichardsMaterial.C
@@ -27,7 +27,6 @@ InputParameters validParams<RichardsMaterial>()
   params.addRequiredParam<RealVectorValue>("gravity", "Gravitational acceleration (m/s^2) as a vector pointing downwards.  Eg (0,0,-10)");
   //params.addRequiredCoupledVar("pressure_vars", "List of variables that represent the pressure");
   params.addParam<bool>("linear_shape_fcns", true, "If you are using second-order Lagrange shape functions you need to set this to false.");
-
   return params;
 }
 
@@ -47,8 +46,6 @@ RichardsMaterial::RichardsMaterial(const std::string & name,
 
     _material_gravity(getParam<RealVectorValue>("gravity")),
 
-    // Declare that this material is going to provide a Real
-    // valued property named "porosity", etc, that Kernels can use.
     _porosity_old(declareProperty<Real>("porosity_old")),
     _porosity(declareProperty<Real>("porosity")),
     _permeability(declareProperty<RealTensorValue>("permeability")),
@@ -60,6 +57,7 @@ RichardsMaterial::RichardsMaterial(const std::string & name,
     _pp_old(declareProperty<std::vector<Real> >("porepressure_old")),
     _pp(declareProperty<std::vector<Real> >("porepressure")),
     _dpp_dv(declareProperty<std::vector<std::vector<Real> > >("dporepressure_dv")),
+    _d2pp_dv(declareProperty<std::vector<std::vector<std::vector<Real> > > >("d2porepressure_dvdv")),
 
     _viscosity(declareProperty<std::vector<Real> >("viscosity")),
 
@@ -70,6 +68,7 @@ RichardsMaterial::RichardsMaterial(const std::string & name,
     _seff_old(declareProperty<std::vector<Real> >("s_eff_old")),
     _seff(declareProperty<std::vector<Real> >("s_eff")),
     _dseff_dv(declareProperty<std::vector<std::vector<Real> > >("ds_eff_dv")),
+    _d2seff_dv(declareProperty<std::vector<std::vector<std::vector<Real> > > >("d2s_eff_dvdv")),
 
     _sat_old(declareProperty<std::vector<Real> >("sat_old")),
     _sat(declareProperty<std::vector<Real> >("sat")),
@@ -94,8 +93,8 @@ RichardsMaterial::RichardsMaterial(const std::string & name,
     _d2flux_dvdgradv(declareProperty<std::vector<std::vector<std::vector<RealTensorValue> > > >("d2flux_dvdgradv")),
 
     _tauvel_SUPG(declareProperty<std::vector<RealVectorValue> >("tauvel_SUPG")),
-    _dtauvel_SUPG_dgradp(declareProperty<std::vector<RealTensorValue> >("dtauvel_SUPG_dgradv")),
-    _dtauvel_SUPG_dp(declareProperty<std::vector<RealVectorValue> >("dtauvel_SUPG_dv"))
+    _dtauvel_SUPG_dgradp(declareProperty<std::vector<std::vector<RealTensorValue> > >("dtauvel_SUPG_dgradv")),
+    _dtauvel_SUPG_dp(declareProperty<std::vector<std::vector<RealVectorValue> > >("dtauvel_SUPG_dv"))
 
 {
 
@@ -117,7 +116,6 @@ RichardsMaterial::RichardsMaterial(const std::string & name,
     _perm_change[i] = (isCoupled("perm_change")? &coupledValue("perm_change", i) : &_zero); // coupledValue returns a reference (an alias) to a VariableValue, and the & turns it into a pointer
 
   _d2density.resize(_num_p);
-  _d2seff.resize(_num_p);
   _d2rel_perm_dv.resize(_num_p);
   _pressure_vals.resize(_num_p);
   _pressure_old_vals.resize(_num_p);
@@ -136,10 +134,6 @@ RichardsMaterial::RichardsMaterial(const std::string & name,
     //_pressure_old_vals[i] = (_is_transient ? &coupledValueOld("pressure_vars", i) : &_zero);
     //_grad_p[i] = &coupledGradient("pressure_vars", i);
 
-    _pressure_vals[i] = _richards_name_UO.richards_vals(i);
-    _pressure_old_vals[i] = _richards_name_UO.richards_vals_old(i);
-    _grad_p[i] = _richards_name_UO.grad_var(i);
-
     // in the following.  first get the userobject names that were inputted, then get the i_th one of these, then get the actual userobject that this corresponds to, then finally & gives pointer to RichardsRelPerm object.
     _material_relperm_UO[i] = &getUserObjectByName<RichardsRelPerm>(getParam<std::vector<UserObjectName> >("relperm_UO")[i]);
     _material_seff_UO[i] = &getUserObjectByName<RichardsSeff>(getParam<std::vector<UserObjectName> >("seff_UO")[i]);
@@ -150,24 +144,272 @@ RichardsMaterial::RichardsMaterial(const std::string & name,
 
 }
 
-/*
-  void
-  RichardsMaterial::computeQpProperties()
-  {
-  _porosity[qp] = _material_por;
-  _permeability[qp] = _material_perm;
-
-  _viscosity[qp].resize(_num_p);
-  _viscosity[qp] = _material_viscosity;
-
-  _gravity[qp] = _material_gravity;
-
-  for (unsigned int i=0 ; i<_num_p; ++i)
-  }
-*/
 
 void
-RichardsMaterial::computeProperties()
+RichardsMaterial::computePandSeff()
+{
+  // Get the pressure and effective saturation at each quadpoint
+  // From these we will build the relative permeability, density, flux, etc
+  if (_richards_name_UO.var_types() == "pppp")
+  {
+    for (unsigned int i=0 ; i<_num_p; ++i)
+    {
+      _pressure_vals[i] = _richards_name_UO.richards_vals(i);
+      _pressure_old_vals[i] = _richards_name_UO.richards_vals_old(i);
+      _grad_p[i] = _richards_name_UO.grad_var(i);
+    }
+  }
+
+
+  for (unsigned int qp=0; qp<_qrule->n_points(); qp++)
+  {
+    _pp_old[qp].resize(_num_p);
+    _pp[qp].resize(_num_p);
+    _dpp_dv[qp].resize(_num_p);
+    _d2pp_dv[qp].resize(_num_p);
+
+    _seff_old[qp].resize(_num_p);
+    _seff[qp].resize(_num_p);
+    _dseff_dv[qp].resize(_num_p);
+    _d2seff_dv[qp].resize(_num_p);
+
+    if (_richards_name_UO.var_types() == "pppp")
+    {
+      for (unsigned int i=0 ; i<_num_p; ++i)
+      {
+        _pp_old[qp][i] = (*_pressure_old_vals[i])[qp];
+        _pp[qp][i] = (*_pressure_vals[i])[qp];
+
+        _dpp_dv[qp][i].assign(_num_p, 0);
+        _dpp_dv[qp][i][i] = 1;
+
+        _d2pp_dv[qp][i].resize(_num_p);
+        for (unsigned int j=0 ; j<_num_p; ++j)
+          _d2pp_dv[qp][i][j].assign(_num_p, 0);
+
+        _seff_old[qp][i] = (*_material_seff_UO[i]).seff(_pressure_old_vals, qp);
+        _seff[qp][i] = (*_material_seff_UO[i]).seff(_pressure_vals, qp);
+
+        _dseff_dv[qp][i].resize(_num_p);
+        _dseff_dv[qp][i] = (*_material_seff_UO[i]).dseff(_pressure_vals, qp);
+
+        _d2seff_dv[qp][i].resize(_num_p);
+        for (unsigned int j=0 ; j<_num_p; ++j)
+          _d2seff_dv[qp][i][j].resize(_num_p);
+        _d2seff_dv[qp][i] = (*_material_seff_UO[i]).d2seff(_pressure_vals, qp);
+
+      }
+    }
+    else
+      mooseError("RichardsMaterial not yet defined for the variable types " << _richards_name_UO.var_types() << " defined in your VarNames UserObject");
+  }
+}
+
+
+void
+RichardsMaterial::computeDerivedQuantities(unsigned int qp)
+{
+  // fluid viscosity
+  _viscosity[qp].resize(_num_p);
+  for (unsigned int i=0 ; i<_num_p; ++i)
+    _viscosity[qp][i] = _material_viscosity[i];
+
+
+  // fluid saturation
+  _sat_old[qp].resize(_num_p);
+  _sat[qp].resize(_num_p);
+  _dsat_dv[qp].resize(_num_p);
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    _sat_old[qp][i] = (*_material_sat_UO[i]).sat(_seff_old[qp][i]);
+    _sat[qp][i] = (*_material_sat_UO[i]).sat(_seff[qp][i]);
+    _dsat_dv[qp][i].assign(_num_p, (*_material_sat_UO[i]).dsat(_seff[qp][i]));
+    for (unsigned int j=0 ; j<_num_p; ++j)
+      _dsat_dv[qp][i][j] *= _dseff_dv[qp][i][j];
+  }
+
+
+  // fluid density
+  _density_old[qp].resize(_num_p);
+  _density[qp].resize(_num_p);
+  _ddensity_dv[qp].resize(_num_p);
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    _density_old[qp][i] = (*_material_density_UO[i]).density(_pp_old[qp][i]);
+    _density[qp][i] = (*_material_density_UO[i]).density(_pp[qp][i]);
+    _ddensity_dv[qp][i].assign(_num_p, (*_material_density_UO[i]).ddensity(_pp[qp][i]));
+    for (unsigned int j=0 ; j<_num_p; ++j)
+      _ddensity_dv[qp][i][j] *= _dpp_dv[qp][i][j];
+  }
+
+
+  // relative permeability
+  _rel_perm[qp].resize(_num_p);
+  _drel_perm_dv[qp].resize(_num_p);
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    _rel_perm[qp][i] = (*_material_relperm_UO[i]).relperm(_seff[qp][i]);
+    _drel_perm_dv[qp][i].assign(_num_p, (*_material_relperm_UO[i]).drelperm(_seff[qp][i]));
+    for (unsigned int j=0 ; j<_num_p; ++j)
+      _drel_perm_dv[qp][i][j] *= _dseff_dv[qp][i][j];
+  }
+
+
+  // fluid mass
+  _mass_old[qp].resize(_num_p);
+  _mass[qp].resize(_num_p);
+  _dmass[qp].resize(_num_p);
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    _mass_old[qp][i] = _porosity_old[qp]*_density_old[qp][i]*_sat_old[qp][i];
+    _mass[qp][i] = _porosity[qp]*_density[qp][i]*_sat[qp][i];
+    _dmass[qp][i].resize(_num_p);
+    for (unsigned int j=0 ; j<_num_p; ++j)
+      _dmass[qp][i][j] = _porosity[qp]*(_ddensity_dv[qp][i][j]*_sat[qp][i] + _density[qp][i]*_dsat_dv[qp][i][j]);
+  }
+
+
+  // flux without the mobility part
+  _flux_no_mob[qp].resize(_num_p);
+  _dflux_no_mob_dv[qp].resize(_num_p);
+  _dflux_no_mob_dgradv[qp].resize(_num_p);
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    _flux_no_mob[qp][i] = _permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]);
+
+    _dflux_no_mob_dv[qp][i].resize(_num_p);
+    for (unsigned int j=0 ; j<_num_p; ++j)
+      _dflux_no_mob_dv[qp][i][j] = _permeability[qp]*(- _ddensity_dv[qp][i][j]*_gravity[qp]);
+
+    _dflux_no_mob_dgradv[qp][i].resize(_num_p);
+    for (unsigned int j=0 ; j<_num_p; ++j)
+      _dflux_no_mob_dgradv[qp][i][j] = _permeability[qp]*_dpp_dv[qp][i][j];
+  }
+
+
+  // flux
+  _flux[qp].resize(_num_p);
+  _dflux_dv[qp].resize(_num_p);
+  _dflux_dgradv[qp].resize(_num_p);
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    _flux[qp][i] = _density[qp][i]*_rel_perm[qp][i]*_flux_no_mob[qp][i]/_viscosity[qp][i];
+
+    _dflux_dv[qp][i].resize(_num_p);
+    for (unsigned int j=0 ; j<_num_p; ++j)
+    {
+      _dflux_dv[qp][i][j] = _density[qp][i]*_rel_perm[qp][i]*_dflux_no_mob_dv[qp][i][j]/_viscosity[qp][i];
+      _dflux_dv[qp][i][j] += (_ddensity_dv[qp][i][j]*_rel_perm[qp][i] + _density[qp][i]*_drel_perm_dv[qp][i][j])*_flux_no_mob[qp][i]/_viscosity[qp][i];
+    }
+
+    _dflux_dgradv[qp][i].resize(_num_p);
+    for (unsigned int j=0 ; j<_num_p; ++j)
+      _dflux_dgradv[qp][i][j] = _density[qp][i]*_rel_perm[qp][i]*_dflux_no_mob_dgradv[qp][i][j]/_viscosity[qp][i];
+  }
+}
+
+
+void
+RichardsMaterial::zero2ndDerivedQuantities(unsigned int qp)
+{
+  _d2flux_dvdv[qp].resize(_num_p);
+  _d2flux_dgradvdv[qp].resize(_num_p);
+  _d2flux_dvdgradv[qp].resize(_num_p);
+
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    _d2flux_dvdv[qp][i].resize(_num_p);
+    _d2flux_dgradvdv[qp][i].resize(_num_p);
+    _d2flux_dvdgradv[qp][i].resize(_num_p);
+    for (unsigned int j=0 ; j<_num_p; ++j)
+    {
+      _d2flux_dvdv[qp][i][j].assign(_num_p, RealVectorValue());
+      _d2flux_dgradvdv[qp][i][j].assign(_num_p, RealTensorValue());
+      _d2flux_dvdgradv[qp][i][j].assign(_num_p, RealTensorValue());
+    }
+  }
+}
+
+
+void
+RichardsMaterial::compute2ndDerivedQuantities(unsigned int qp)
+{
+  zero2ndDerivedQuantities(qp);
+
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    if ((*_material_SUPG_UO[i]).SUPG_trivial())
+      continue; // as the derivatives won't be needed
+
+    // second derivative of density
+    _d2density[i].resize(_num_p);
+    Real ddens = (*_material_density_UO[i]).ddensity(_pp[qp][i]);
+    Real d2dens = (*_material_density_UO[i]).d2density(_pp[qp][i]);
+    for (unsigned int j=0 ; j<_num_p; ++j)
+    {
+      _d2density[i][j].resize(_num_p);
+      for (unsigned int k=0 ; k<_num_p; ++k)
+        _d2density[i][j][k] = d2dens*_dpp_dv[qp][i][j]*_dpp_dv[qp][i][k] + ddens*_d2pp_dv[qp][i][j][k];
+    }
+
+    // second derivative of relative permeability
+    _d2rel_perm_dv[i].resize(_num_p);
+    Real drel = (*_material_relperm_UO[i]).drelperm(_seff[qp][i]);
+    Real d2rel = (*_material_relperm_UO[i]).d2relperm(_seff[qp][i]);
+    for (unsigned int j=0 ; j<_num_p; ++j)
+    {
+      _d2rel_perm_dv[i][j].resize(_num_p);
+      for (unsigned int k=0 ; k<_num_p; ++k)
+        _d2rel_perm_dv[i][j][k] = d2rel*_dseff_dv[qp][i][j]*_dseff_dv[qp][i][k] + drel*_d2seff_dv[qp][i][j][k];
+    }
+
+
+      // now compute the second derivs of the fluxes
+    for (unsigned int j=0 ; j<_num_p; ++j)
+    {
+      for (unsigned int k=0 ; k<_num_p; ++k)
+      {
+        _d2flux_dvdv[qp][i][j][k] = _d2density[i][j][k]*_rel_perm[qp][i]*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]));
+        _d2flux_dvdv[qp][i][j][k] += (_ddensity_dv[qp][i][j]*_drel_perm_dv[qp][i][k] + _ddensity_dv[qp][i][k]*_drel_perm_dv[qp][i][j])*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]));
+        _d2flux_dvdv[qp][i][j][k] += _density[qp][i]*_d2rel_perm_dv[i][j][k]*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]));
+        _d2flux_dvdv[qp][i][j][k] += (_ddensity_dv[qp][i][j]*_rel_perm[qp][i] + _density[qp][i]*_drel_perm_dv[qp][i][j])*(_permeability[qp]*(- _ddensity_dv[qp][i][k]*_gravity[qp]));
+        _d2flux_dvdv[qp][i][j][k] += (_ddensity_dv[qp][i][k]*_rel_perm[qp][i] + _density[qp][i]*_drel_perm_dv[qp][i][k])*(_permeability[qp]*(- _ddensity_dv[qp][i][j]*_gravity[qp]));
+        _d2flux_dvdv[qp][i][j][k] += _density[qp][i]*_rel_perm[qp][i]*(_permeability[qp]*(- _d2density[i][j][k]*_gravity[qp]));
+      }
+    }
+    for (unsigned int j=0 ; j<_num_p; ++j)
+      for (unsigned int k=0 ; k<_num_p; ++k)
+        _d2flux_dvdv[qp][i][j][k] /= _viscosity[qp][i];
+
+
+    for (unsigned int j=0 ; j<_num_p; ++j)
+    {
+      for (unsigned int k=0 ; k<_num_p; ++k)
+      {
+        _d2flux_dgradvdv[qp][i][j][k] = (_ddensity_dv[qp][i][k]*_rel_perm[qp][i] + _density[qp][i]*_drel_perm_dv[qp][i][k])*_permeability[qp]*_dpp_dv[qp][i][j]/_viscosity[qp][i];
+        _d2flux_dvdgradv[qp][i][k][j] = _d2flux_dgradvdv[qp][i][j][k];
+      }
+    }
+  }
+}
+
+
+void
+RichardsMaterial::zeroSUPG(unsigned int qp)
+{
+  _tauvel_SUPG[qp].assign(_num_p, RealVectorValue());
+  _dtauvel_SUPG_dgradp[qp].resize(_num_p);
+  _dtauvel_SUPG_dp[qp].resize(_num_p);
+  for (unsigned int i=0 ; i<_num_p; ++i)
+  {
+    _dtauvel_SUPG_dp[qp][i].assign(_num_p, RealVectorValue());
+    _dtauvel_SUPG_dgradp[qp][i].assign(_num_p, RealTensorValue());
+  }
+}
+
+
+void
+RichardsMaterial::computeSUPG()
 {
   // Grab reference to linear Lagrange finite element object pointer,
   // currently this is always a linear Lagrange element, so this might need to
@@ -185,202 +427,8 @@ RichardsMaterial::computeProperties()
   const std::vector<Real>& dzetady(fe->get_dzetady());
   const std::vector<Real>& dzetadz(fe->get_dzetadz());
 
-  // this gets run for each element
   for (unsigned int qp=0; qp<_qrule->n_points(); qp++)
   {
-
-    _porosity[qp] = _material_por + (*_por_change)[qp];
-    _porosity_old[qp] = _material_por + (*_por_change_old)[qp];
-
-    _permeability[qp] = _material_perm;
-    for (unsigned int i=0; i<3; i++)
-      for (unsigned int j=0; j<3; j++)
-        _permeability[qp](i,j) *= std::pow(10,(*_perm_change[3*i+j])[qp]);
-
-    _gravity[qp] = _material_gravity;
-
-    _pp_old[qp].resize(_num_p);
-    _pp[qp].resize(_num_p);
-    _dpp_dv[qp].resize(_num_p);
-
-    _viscosity[qp].resize(_num_p);
-
-    _density_old[qp].resize(_num_p);
-    _density[qp].resize(_num_p);
-    _ddensity_dv[qp].resize(_num_p);
-
-    _rel_perm[qp].resize(_num_p);
-    _drel_perm_dv[qp].resize(_num_p);
-
-    _mass_old[qp].resize(_num_p);
-    _mass[qp].resize(_num_p);
-    _dmass[qp].resize(_num_p);
-
-    _flux_no_mob[qp].resize(_num_p);
-    _dflux_no_mob_dv[qp].resize(_num_p);
-    _dflux_no_mob_dgradv[qp].resize(_num_p);
-
-    _flux[qp].resize(_num_p);
-    _dflux_dv[qp].resize(_num_p);
-    _dflux_dgradv[qp].resize(_num_p);
-    _d2flux_dvdv[qp].resize(_num_p);
-    _d2flux_dgradvdv[qp].resize(_num_p);
-    _d2flux_dvdgradv[qp].resize(_num_p);
-
-    _seff_old[qp].resize(_num_p);
-    _seff[qp].resize(_num_p);
-    _dseff_dv[qp].resize(_num_p);
-
-    _sat_old[qp].resize(_num_p);
-    _sat[qp].resize(_num_p);
-    _dsat_dv[qp].resize(_num_p);
-
-
-    for (unsigned int i=0 ; i<_num_p; ++i)
-    {
-      _pp_old[qp][i] = (*_pressure_old_vals[i])[qp];
-      _pp[qp][i] = (*_pressure_vals[i])[qp];
-      _dpp_dv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _dpp_dv[qp][i][j] = 0;
-      _dpp_dv[qp][i][i] = 1;
-
-
-      _viscosity[qp][i] = _material_viscosity[i];
-
-      _density_old[qp][i] = (*_material_density_UO[i]).density((*_pressure_old_vals[i])[qp]);
-      _density[qp][i] = (*_material_density_UO[i]).density((*_pressure_vals[i])[qp]);
-      _ddensity_dv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _ddensity_dv[qp][i][j] = 0;
-      _ddensity_dv[qp][i][i] = (*_material_density_UO[i]).ddensity((*_pressure_vals[i])[qp]);
-
-      _d2density[i] = (*_material_density_UO[i]).d2density((*_pressure_vals[i])[qp]);
-
-      _seff_old[qp][i] = (*_material_seff_UO[i]).seff(_pressure_old_vals, qp);
-      _seff[qp][i] = (*_material_seff_UO[i]).seff(_pressure_vals, qp);
-
-      _dseff_dv[qp][i].resize(_num_p);
-      _dseff_dv[qp][i] = (*_material_seff_UO[i]).dseff(_pressure_vals, qp);
-
-      _d2seff[i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _d2seff[i][j].resize(_num_p);
-      _d2seff[i] = (*_material_seff_UO[i]).d2seff(_pressure_vals, qp);
-
-      _sat_old[qp][i] = (*_material_sat_UO[i]).sat(_seff_old[qp][i]);
-      _sat[qp][i] = (*_material_sat_UO[i]).sat(_seff[qp][i]);
-
-      _dsat_dv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _dsat_dv[qp][i][j] = (*_material_sat_UO[i]).dsat(_seff[qp][i])*_dseff_dv[qp][i][j]; // could optimise
-
-
-      _rel_perm[qp][i] = (*_material_relperm_UO[i]).relperm(_seff[qp][i]);
-      _drel_perm_dv[qp][i].resize(_num_p);
-      _d2rel_perm_dv[i].resize(_num_p);
-      Real drel;
-      Real d2rel;
-      for (unsigned int j=0 ; j<_num_p; ++j)
-      {
-        drel = (*_material_relperm_UO[i]).drelperm(_seff[qp][i]);
-        d2rel = (* _material_relperm_UO[i]).d2relperm(_seff[qp][i]);
-        _drel_perm_dv[qp][i][j] = drel*_dseff_dv[qp][i][j];
-        _d2rel_perm_dv[i][j].resize(_num_p);
-        for (unsigned int k=0 ; k<_num_p; ++k)
-          _d2rel_perm_dv[i][j][k] = d2rel*_dseff_dv[qp][i][j]*_dseff_dv[qp][i][k] + drel*_d2seff[i][j][k];
-      }
-
-      _mass[qp][i] = _porosity[qp]*_density[qp][i]*_sat[qp][i];
-
-      _dmass[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _dmass[qp][i][j] = _porosity[qp]*_density[qp][i]*_dsat_dv[qp][i][j];
-      _dmass[qp][i][i] += _porosity[qp]*_ddensity_dv[qp][i][i]*_sat[qp][i];
-
-      _mass_old[qp][i] = _porosity_old[qp]*_density_old[qp][i]*_sat_old[qp][i];
-
-
-      _flux_no_mob[qp][i] = _permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]);
-
-      _dflux_no_mob_dv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _dflux_no_mob_dv[qp][i][j] = 0.0;
-      _dflux_no_mob_dv[qp][i][i] = _permeability[qp]*(- _ddensity_dv[qp][i][i]*_gravity[qp]);
-
-      _dflux_no_mob_dgradv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _dflux_no_mob_dgradv[qp][i][j] = 0;
-      _dflux_no_mob_dgradv[qp][i][i] += _permeability[qp];
-
-
-      _flux[qp][i] = _density[qp][i]*_rel_perm[qp][i]*_flux_no_mob[qp][i]/_viscosity[qp][i];
-
-      _dflux_dv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _dflux_dv[qp][i][j] = _density[qp][i]*_drel_perm_dv[qp][i][j]*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]))/_viscosity[qp][i];
-      _dflux_dv[qp][i][i] += _ddensity_dv[qp][i][i]*_rel_perm[qp][i]*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]))/_viscosity[qp][i];
-      _dflux_dv[qp][i][i] += _density[qp][i]*_rel_perm[qp][i]*(_permeability[qp]*(- _ddensity_dv[qp][i][i]*_gravity[qp]))/_viscosity[qp][i];
-
-
-      _dflux_dgradv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _dflux_dgradv[qp][i][j] = 0;
-      _dflux_dgradv[qp][i][i] += _density[qp][i]*_rel_perm[qp][i]*_permeability[qp]/_viscosity[qp][i];
-
-
-      _d2flux_dvdv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-      {
-        _d2flux_dvdv[qp][i][j].resize(_num_p);
-        for (unsigned int k=0 ; k<_num_p; ++k)
-          _d2flux_dvdv[qp][i][j][k] = _density[qp][i]*_d2rel_perm_dv[i][j][k]*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]));
-        _d2flux_dvdv[qp][i][j][i] += _ddensity_dv[qp][i][i]*_drel_perm_dv[qp][i][j]*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]));
-        _d2flux_dvdv[qp][i][j][i] += _density[qp][i]*_drel_perm_dv[qp][i][j]*(_permeability[qp]*(- _ddensity_dv[qp][i][i]*_gravity[qp]));
-      }
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _d2flux_dvdv[qp][i][i][j] += _ddensity_dv[qp][i][i]*_drel_perm_dv[qp][i][j]*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]));
-      _d2flux_dvdv[qp][i][i][i] += _d2density[i]*_rel_perm[qp][i]*(_permeability[qp]*((*_grad_p[i])[qp] - _density[qp][i]*_gravity[qp]));
-      _d2flux_dvdv[qp][i][i][i] += _ddensity_dv[qp][i][i]*_rel_perm[qp][i]*(_permeability[qp]*(- _ddensity_dv[qp][i][i]*_gravity[qp]));
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _d2flux_dvdv[qp][i][i][j] += _density[qp][i]*_drel_perm_dv[qp][i][j]*(_permeability[qp]*(- _ddensity_dv[qp][i][i]*_gravity[qp]));
-      _d2flux_dvdv[qp][i][i][i] += _ddensity_dv[qp][i][i]*_rel_perm[qp][i]*(_permeability[qp]*(- _ddensity_dv[qp][i][i]*_gravity[qp]));
-      _d2flux_dvdv[qp][i][i][i] += _density[qp][i]*_rel_perm[qp][i]*(_permeability[qp]*(- _d2density[i]*_gravity[qp]));
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        for (unsigned int k=0 ; k<_num_p; ++k)
-          _d2flux_dvdv[qp][i][j][k] /= _viscosity[qp][i];
-
-
-      _d2flux_dgradvdv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-      {
-        _d2flux_dgradvdv[qp][i][j].resize(_num_p);
-        for (unsigned int k=0 ; k<_num_p; ++k)
-          _d2flux_dgradvdv[qp][i][j][k] = 0;
-      }
-      for (unsigned int j=0 ; j<_num_p; ++j)
-        _d2flux_dgradvdv[qp][i][i][j] += _density[qp][i]*_drel_perm_dv[qp][i][j]*_permeability[qp]/_viscosity[qp][i];
-      _d2flux_dgradvdv[qp][i][i][i] += _ddensity_dv[qp][i][i]*_rel_perm[qp][i]*_permeability[qp]/_viscosity[qp][i];
-
-
-      _d2flux_dvdgradv[qp][i].resize(_num_p);
-      for (unsigned int j=0 ; j<_num_p; ++j)
-      {
-        _d2flux_dvdgradv[qp][i][j].resize(_num_p);
-        for (unsigned int k=0 ; k<_num_p; ++k)
-          _d2flux_dvdgradv[qp][i][j][k] = 0;
-        _d2flux_dvdgradv[qp][i][j][i] += _density[qp][i]*_drel_perm_dv[qp][i][j]*_permeability[qp]/_viscosity[qp][i];
-      }
-      _d2flux_dvdgradv[qp][i][i][i] += _ddensity_dv[qp][i][i]*_rel_perm[qp][i]*_permeability[qp]/_viscosity[qp][i];
-
-
-    }
-
-
-    // Now SUPG stuff
-    _tauvel_SUPG[qp].resize(_num_p);
-    _dtauvel_SUPG_dgradp[qp].resize(_num_p);
-    _dtauvel_SUPG_dp[qp].resize(_num_p);
 
     // Bounds checking on element data and putting into vector form
     mooseAssert(qp < dxidx.size(), "Insufficient data in dxidx array!");
@@ -415,6 +463,7 @@ RichardsMaterial::computeProperties()
       zeta_prime(2) = dzetadz[qp];
     }
 
+    _trace_perm = _permeability[qp].tr();
     for (unsigned int i=0 ; i<_num_p; ++i)
     {
       RealVectorValue vel = (*_material_SUPG_UO[i]).velSUPG(_permeability[qp], (*_grad_p[i])[qp], _density[qp][i], _gravity[qp]);
@@ -429,12 +478,65 @@ RichardsMaterial::computeProperties()
 
       _tauvel_SUPG[qp][i] = tau*vel;
 
-      _dtauvel_SUPG_dgradp[qp][i] = tau*dvel_dgradp;
+      RealTensorValue dtauvel_dgradp = tau*dvel_dgradp;
       for (unsigned int j=0 ; j<3; ++j)
         for (unsigned int k=0 ; k<3; ++k)
-          _dtauvel_SUPG_dgradp[qp][i](j,k) += dtau_dgradp(j)*vel(k); // this is outerproduct - maybe libmesh can do it better?
+          dtauvel_dgradp(j, k) += dtau_dgradp(j)*vel(k); // this is outerproduct - maybe libmesh can do it better?
+      for (unsigned int j=0 ; j<_num_p; ++j)
+        _dtauvel_SUPG_dgradp[qp][i][j] = dtauvel_dgradp*_dpp_dv[qp][i][j];
 
-      _dtauvel_SUPG_dp[qp][i] = dtau_dp*vel + tau*dvel_dp;
+      RealVectorValue dtauvel_dp = dtau_dp*vel + tau*dvel_dp;
+      for (unsigned int j=0 ; j<_num_p; ++j)
+        _dtauvel_SUPG_dp[qp][i][j] = dtauvel_dp*_dpp_dv[qp][i][j];
     }
   }
+}
+
+void
+RichardsMaterial::computeProperties()
+{
+  // compute porepressures and effective saturations
+  // with algorithms depending on the _richards_name_UO.var_types()
+  computePandSeff();
+
+
+  // porosity, permeability, and gravity
+  for (unsigned int qp=0; qp<_qrule->n_points(); qp++)
+  {
+    _porosity[qp] = _material_por + (*_por_change)[qp];
+    _porosity_old[qp] = _material_por + (*_por_change_old)[qp];
+
+    _permeability[qp] = _material_perm;
+    for (unsigned int i=0; i<3; i++)
+      for (unsigned int j=0; j<3; j++)
+        _permeability[qp](i,j) *= std::pow(10,(*_perm_change[3*i+j])[qp]);
+
+    _gravity[qp] = _material_gravity;
+  }
+
+
+  // compute "derived" quantities -- those that depend on P and Seff --- such as density, relperm
+  for (unsigned int qp=0; qp<_qrule->n_points(); qp++)
+    computeDerivedQuantities(qp);
+
+
+  // compute certain second derivatives of the derived quantities
+  // These are needed in Jacobian calculations if doing SUPG
+  for (unsigned int qp=0; qp<_qrule->n_points(); qp++)
+    compute2ndDerivedQuantities(qp);
+
+
+  // Now for SUPG itself
+  for (unsigned int qp=0; qp<_qrule->n_points(); qp++)
+    zeroSUPG(qp);
+
+  // the following saves computational effort if all SUPG is trivial
+  bool trivial_supg = true;
+  for (unsigned int i=0 ; i<_num_p; ++i)
+    trivial_supg = trivial_supg && (*_material_SUPG_UO[i]).SUPG_trivial();
+  if (trivial_supg)
+    return;
+  else
+    computeSUPG();
+
 }

--- a/modules/richards/src/userobjects/RichardsSUPGnone.C
+++ b/modules/richards/src/userobjects/RichardsSUPGnone.C
@@ -77,3 +77,10 @@ RichardsSUPGnone::dtauSUPG_dp(RealVectorValue /*vel*/, RealVectorValue /*dvel_dp
 {
   return 0;
 }
+
+bool
+RichardsSUPGnone::SUPG_trivial() const
+{
+  return true;
+}
+

--- a/modules/richards/src/userobjects/RichardsSUPGstandard.C
+++ b/modules/richards/src/userobjects/RichardsSUPGstandard.C
@@ -170,3 +170,11 @@ RichardsSUPGstandard::dtauSUPG_dp(RealVectorValue vel, RealVectorValue dvel_dp, 
 
   return tau_dp;
 }
+
+
+bool
+RichardsSUPGstandard::SUPG_trivial() const
+{
+  return false;
+}
+

--- a/modules/richards/src/userobjects/RichardsVarNames.C
+++ b/modules/richards/src/userobjects/RichardsVarNames.C
@@ -13,6 +13,9 @@ InputParameters validParams<RichardsVarNames>()
   InputParameters params = validParams<GeneralUserObject>();
   params.addClassDescription("Holds information on the porepressure variable names");
   params.addRequiredCoupledVar("richards_vars", "List of variables that represent the porepressures or (porepressure, saturations).  In single-phase models you will just have one (eg \'pressure\'), in two-phase models you will have two (eg \'p_water p_gas\', or \'p_water s_water\', etc.  These names must also be used in your kernels and material.");
+  MooseEnum var_types("pppp", "pppp");
+  params.addParam<MooseEnum>("var_types", var_types, "Variable types for the problem.  Eg, 'pppp' means all the variables are pressure variables");
+
   return params;
 }
 
@@ -21,7 +24,8 @@ RichardsVarNames::RichardsVarNames(const std::string & name, InputParameters par
   Coupleable(parameters, false),
   ZeroInterface(parameters),
   _num_v(coupledComponents("richards_vars")),
-  _the_names(std::string())
+  _the_names(std::string()),
+  _var_types(getParam<MooseEnum>("var_types"))
 
 {
   unsigned int max_moose_var_num_seen(0);
@@ -121,6 +125,12 @@ MooseVariable *
 RichardsVarNames::raw_var(unsigned int richards_var_num) const
 {
   return _moose_raw_var[richards_var_num];
+}
+
+std::string
+RichardsVarNames::var_types() const
+{
+  return _var_types;
 }
 
 

--- a/modules/richards/tests/gravity_head_1/gh23.i
+++ b/modules/richards/tests/gravity_head_1/gh23.i
@@ -130,6 +130,7 @@
   interval = 10000
   exodus = true
   [./console]
+    interval = 1
     type = Console
     perf_log = true
   [../]

--- a/modules/richards/tests/gravity_head_2/gh18.i
+++ b/modules/richards/tests/gravity_head_2/gh18.i
@@ -286,5 +286,6 @@
   [./console]
     type = Console
     perf_log = true
+    interval = 1
   [../]
 []


### PR DESCRIPTION
calculated wrt general variables rather than just porepressures

Also, some optimisation has been included with not calculating
SUPG things if no SUPG is used

Kernels have been updated to use these more general derivatives

RichardsSUPG now provdes a "trivial" function indicating
whether SUPG is trivial or not

RichardsVarNames now has a MooseEnum that describes what the
variables correspond to physically.  However, only the PPPP formulation
is actually coded in RichardsMaterial.

Sometime in the future I or someone else might be interested
in implementing the PSS material in full, and these changes will
make that far easier.  However, this changeset does NOT actually
implement this capability.  I have added a long essay to
issue #3241 why this is so.

Fixes #3241
