### PR TITLE
fix csv transient test in parallel 

### DIFF
--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -270,7 +270,7 @@ MooseVariable::reinitNodes(const std::vector<dof_id_type> & nodes)
     // node is non-local.
     Node * nd = _subproblem.mesh().getMesh().query_node_ptr(nodes[i]);
 
-    if (nd && (_subproblem.mesh().isSemiLocal(nd)))
+    if (nd && (_subproblem.mesh().getMesh().processor_id() == nd->processor_id()))
     {
       if (nd->n_dofs(_sys.number(), _var_num) > 0)
       {

--- a/test/tests/outputs/csv/tests
+++ b/test/tests/outputs/csv/tests
@@ -11,7 +11,7 @@
     input = 'csv_transient.i'
     csvdiff = 'csv_transient_out.csv'
     max_threads = 1  # Sometimes fails with threads or in parallel #2899
-    max_parallel = 1
+#    max_parallel = 1
   [../]
   [./restart_part1]
     # First part of CSV restart test, CSV files should not append


### PR DESCRIPTION
This fixes the csv_transient test in MPI parallel.... but I haven't resolved the threading issue yet.

The problem with MPI was that MooseVariable was checking `isSemiLocal()` for `reinitNodes()` which is wrong because that will be true even for nodes that are not owned by this processor but "border" this processor... leading to double counting in `SumNodalValuesAux`

refs #2899
