### PR TITLE
Fixing warnings after recent exodiff update.

### DIFF
--- a/framework/contrib/exodiff/check.C
+++ b/framework/contrib/exodiff/check.C
@@ -213,7 +213,7 @@ namespace {
   }
 
   template <typename INT>
-  bool Check_Elmt_Block(ExoII_Read<INT>& file1, ExoII_Read<INT>& file2, bool check_only)
+  bool Check_Elmt_Block(ExoII_Read<INT>& file1, ExoII_Read<INT>& file2, bool /*check_only*/)
   {
     bool is_same = true;
     // Verify that element blocks match in the two files...

--- a/framework/contrib/exodiff/exodiff.C
+++ b/framework/contrib/exodiff/exodiff.C
@@ -1848,8 +1848,8 @@ void do_diffs(ExoII_Read<INT>& file1, ExoII_Read<INT>& file2, int time_step1, Ti
 
 template <typename INT>
 bool diff_element_attributes(ExoII_Read<INT>& file1, ExoII_Read<INT>& file2,
-			     INT* elmt_map, const INT *id_map,
-			     Exo_Block<INT> **blocks2)
+                             INT* /*elmt_map*/, const INT *id_map,
+                             Exo_Block<INT> ** /*blocks2*/)
 {
   bool diff_was_output = false;
   bool diff_flag = false;

--- a/framework/contrib/exodiff/iqsort.C
+++ b/framework/contrib/exodiff/iqsort.C
@@ -160,7 +160,13 @@ void swap_(INT v[], size_t i, size_t j)
 }
 
   template <typename T, typename INT>
-  void check(const T v[], INT iv[], size_t N)
+  void check(
+#if defined(DEBUG_QSORT)
+const T v[], INT iv[], size_t N
+#else
+const T [], INT [], size_t
+#endif
+)
   {
 #if defined(DEBUG_QSORT)
   fprintf(stderr, "Checking sort of %d values\n", N+1);

--- a/framework/contrib/exodiff/smart_assert.h
+++ b/framework/contrib/exodiff/smart_assert.h
@@ -269,14 +269,14 @@ struct Assert {
 
     // in this case, we set the default logger, and make it
     // write everything to this file
-    static void set_log( const char * strFileName) {
+    static void set_log( const char * /*strFileName*/) {
 //        Private::set_default_log_name( strFileName);
 //        logger() = &smart_assert::default_logger;
     }
 
     // in this case, we set the default logger, and make it
     // write everything to this log
-    static void set_log( std::ostream & out) {
+    static void set_log( std::ostream & /*out*/) {
 //        Private::set_default_log_stream( out);
 //        logger() = &smart_assert::default_logger;
     }


### PR DESCRIPTION
Should I just push warnings fixes directly to devel?

Refs #1777.
