### PR TITLE
A few changes related to parallel/threading tests

### DIFF
--- a/framework/include/postprocessors/PointValue.h
+++ b/framework/include/postprocessors/PointValue.h
@@ -40,6 +40,7 @@ protected:
   Point _point;
   std::vector<Point> _point_vec;
   Real _value;
+  processor_id_type _root_id;
 };
 
 

--- a/framework/include/userobject/UserObjectWarehouse.h
+++ b/framework/include/userobject/UserObjectWarehouse.h
@@ -204,4 +204,4 @@ protected:
 
 };
 
-#endif // USER_OBJECTWAREHOUSE_Hb
+#endif // USER_OBJECTWAREHOUSE_H

--- a/test/tests/outputs/csv/csv_transient.i
+++ b/test/tests/outputs/csv/csv_transient.i
@@ -88,7 +88,4 @@
   output_initial = true
   csv = true
   output_initial = true
-  [./user]
-    type = Console
-  [../]
 []

--- a/test/tests/outputs/csv/tests
+++ b/test/tests/outputs/csv/tests
@@ -11,7 +11,6 @@
     input = 'csv_transient.i'
     csvdiff = 'csv_transient_out.csv'
     max_threads = 1  # Sometimes fails with threads or in parallel #2899
-#    max_parallel = 1
   [../]
   [./restart_part1]
     # First part of CSV restart test, CSV files should not append

--- a/test/tests/outputs/csv/tests
+++ b/test/tests/outputs/csv/tests
@@ -17,6 +17,7 @@
     type = CSVDiff
     input = csv_restart_part1.i
     csvdiff = 'csv_restart_part1_out.csv'
+    max_threads = 1  # Sometimes fails with threads or in parallel #2899
   [../]
   [./restart_part2]
     # Second part of CSV restart test
@@ -32,6 +33,7 @@
     csvdiff = 'csv_restart_part2_append_out.csv'
     prereq = restart_part2
     cli_args = 'Outputs/csv/file_base=csv_restart_part2_append_out Outputs/csv/append_restart=true'
+    max_threads = 1  # Sometimes fails with threads or in parallel #2899
   [../]
   [./align]
     # Test the alignment, delimiter, and precision settings


### PR DESCRIPTION
- PointValue now utilizes a broadcast, which seems more appropriate.
- The csv restart is also having threading issues, so these tests are being disabled
  (refs #2899)
