### PR TITLE
Add option to specify quadrature order for faces

### DIFF
--- a/framework/include/actions/SetupQuadratureAction.h
+++ b/framework/include/actions/SetupQuadratureAction.h
@@ -39,6 +39,8 @@ protected:
 
   QuadratureType _type;
   Order _order;
+  Order _element_order;
+  Order _side_order;
 };
 
 

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -220,9 +220,9 @@ public:
   const Node * & nodeNeighbor() { return _current_neighbor_node; }
 
   /**
-   * Creates the volume, face and arbitrary qrules based on the Order passed in.
+   * Creates the volume, face and arbitrary qrules based on the orders passed in.
    */
-  void createQRules(QuadratureType type, Order o);
+  void createQRules(QuadratureType type, Order order, Order volume_order, Order face_order);
 
   /**
    * Set the qrule to be used for volume integration.

--- a/framework/include/base/DisplacedProblem.h
+++ b/framework/include/base/DisplacedProblem.h
@@ -49,7 +49,7 @@ public:
   DisplacedSystem & nlSys() { return _displaced_nl; }
   DisplacedSystem & auxSys() { return _displaced_aux; }
 
-  virtual void createQRules(QuadratureType type, Order order);
+  virtual void createQRules(QuadratureType type, Order order, Order volume_order, Order face_order);
 
   /**
    * Whether or not this problem should utilize FE shape function caching.
@@ -147,8 +147,6 @@ public:
    * @return The list
    */
   virtual std::set<dof_id_type> & ghostedElems() { return _mproblem.ghostedElems(); }
-
-  virtual Order getQuadratureOrder();
 
   /**
    * Will make sure that all dofs connected to elem_id are ghosted to this processor

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -217,8 +217,7 @@ public:
    */
   virtual void clearActiveElementalMooseVariables(THREAD_ID tid);
 
-  virtual void createQRules(QuadratureType type, Order order);
-  virtual Order getQuadratureOrder() { return _quadrature_order; }
+  virtual void createQRules(QuadratureType type, Order order, Order volume_order=INVALID_ORDER, Order face_order=INVALID_ORDER);
 
   /**
    * @return The maximum number of quadrature points in use on any element in this problem.
@@ -812,8 +811,6 @@ protected:
   // Dimension of the subspace spanned by the vectors with a given prefix
   std::map<std::string,unsigned int> _subspace_dim;
 
-  // quadrature
-  Order _quadrature_order;                              ///< Quadrature order required by all variables to integrated over them.
   std::vector<Assembly *> _assembly;
 
   /// functions

--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -64,8 +64,6 @@ public:
 
   virtual bool isTransient() const = 0;
 
-  virtual Order getQuadratureOrder() = 0;
-
   // Variables /////
   virtual bool hasVariable(const std::string & var_name) = 0;
   virtual MooseVariable & getVariable(THREAD_ID tid, const std::string & var_name) = 0;

--- a/framework/src/actions/SetupQuadratureAction.C
+++ b/framework/src/actions/SetupQuadratureAction.C
@@ -28,6 +28,8 @@ InputParameters validParams<SetupQuadratureAction>()
 
   params.addParam<MooseEnum>("type", types, "Type of the quadrature rule");
   params.addParam<MooseEnum>("order", order, "Order of the quadrature");
+  params.addParam<MooseEnum>("element_order", order, "Order of the quadrature for elements");
+  params.addParam<MooseEnum>("side_order", order, "Order of the quadrature for sides");
 
   return params;
 }
@@ -35,7 +37,9 @@ InputParameters validParams<SetupQuadratureAction>()
 SetupQuadratureAction::SetupQuadratureAction(const std::string & name, InputParameters parameters) :
     Action(name, parameters),
     _type(Moose::stringToEnum<QuadratureType>(getParam<MooseEnum>("type"))),
-    _order(Moose::stringToEnum<Order>(getParam<MooseEnum>("order")))
+    _order(Moose::stringToEnum<Order>(getParam<MooseEnum>("order"))),
+    _element_order(Moose::stringToEnum<Order>(getParam<MooseEnum>("element_order"))),
+    _side_order(Moose::stringToEnum<Order>(getParam<MooseEnum>("side_order")))
 {
 }
 
@@ -47,5 +51,5 @@ void
 SetupQuadratureAction::act()
 {
   if (_problem != NULL)
-    _problem->createQRules(_type, _order);
+    _problem->createQRules(_type, _order, _element_order, _side_order);
 }

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -190,23 +190,23 @@ Assembly::getFEFaceNeighbor(FEType type, unsigned int dim)
 }
 
 void
-Assembly::createQRules(QuadratureType type, Order o)
+Assembly::createQRules(QuadratureType type, Order order, Order volume_order, Order face_order)
 {
   _holder_qrule_volume.clear();
   for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
-    _holder_qrule_volume[dim] = QBase::build(type, dim, o).release();
+    _holder_qrule_volume[dim] = QBase::build(type, dim, volume_order).release();
 
   _holder_qrule_face.clear();
   for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
-    _holder_qrule_face[dim] = QBase::build(type, dim - 1, o).release();
+    _holder_qrule_face[dim] = QBase::build(type, dim - 1, face_order).release();
 
   _holder_qrule_neighbor.clear();
   for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
-    _holder_qrule_neighbor[dim] = new ArbitraryQuadrature(dim, o);
+    _holder_qrule_neighbor[dim] = new ArbitraryQuadrature(dim, face_order);
 
   _holder_qrule_arbitrary.clear();
   for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
-    _holder_qrule_arbitrary[dim] = new ArbitraryQuadrature(dim, o);
+    _holder_qrule_arbitrary[dim] = new ArbitraryQuadrature(dim, order);
 
 //  setVolumeQRule(_qrule_volume);
 //  setFaceQRule(_qrule_face);

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -50,10 +50,10 @@ DisplacedProblem::~DisplacedProblem()
 }
 
 void
-DisplacedProblem::createQRules(QuadratureType type, Order order)
+DisplacedProblem::createQRules(QuadratureType type, Order order, Order volume_order, Order face_order)
 {
   for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
-    _assembly[tid]->createQRules(type, order);
+    _assembly[tid]->createQRules(type, order, volume_order, face_order);
 }
 
 void
@@ -557,12 +557,6 @@ DisplacedProblem::onTimestepBegin()
 void
 DisplacedProblem::onTimestepEnd()
 {
-}
-
-Order
-DisplacedProblem::getQuadratureOrder()
-{
-  return _mproblem.getQuadratureOrder();
 }
 
 void


### PR DESCRIPTION
This adds a parameter called 'face_order', which if specified overrides the 'order' parameter, which controls the quadrature order for everything else.  For example, you'd specify:

```
  [./Quadrature]
    order = fifth
    face_order = seventh
  [../]
```

to get 5th order quadrature for everything except faces, which get 7th order quadrature.

Questions about this:
1) Do you guys like the name of the parameter?  I'm happy to change it.
2) Should we add options to specify the order of all types of quadrature?  (volume, face, neighbor, arbitrary).  I only care about face and volume for my application.  I'm not really sure what neighbor and arbitrary are for, actually, but I could make them independently settable for consistency.
3) This might cause some confusion if someone were to call FEProblem::getQuadratureOrder(), because that would just return the overall quadrature order, not the face-specific one.  I searched the herd, and couldn't find a single usage of that call.  Should we just get rid of it and the _quadrature_order member variable of FEProblem, which also doesn't seem to be used for anything?
