### PR TITLE
Fixup color/no-color capability in MOOSE - better API for users

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -19,6 +19,7 @@
 #include "libmesh/perf_log.h"
 #include "libmesh/parallel.h"
 #include "libmesh/libmesh_common.h"
+#include "XTermConstants.h"
 
 #include <string>
 
@@ -88,9 +89,27 @@ extern PerfLog setup_perf_log;
 extern bool __trap_fpe;
 
 /**
+ * Variable indicating whether Console coloring will be turned on (default: true).
+ */
+extern bool __color_console;
+
+/**
  * A static list of all the exec types.
  */
 extern const std::vector<ExecFlagType> exec_types;
+
+/**
+ * Macros for coloring any output stream (_console, std::ostringstream, etc.)
+ */
+#define COLOR_BLACK   (Moose::__color_console ? BLACK : "")
+#define COLOR_RED     (Moose::__color_console ? RED : "")
+#define COLOR_GREEN   (Moose::__color_console ? GREEN : "")
+#define COLOR_YELLOW  (Moose::__color_console ? YELLOW : "")
+#define COLOR_BLUE    (Moose::__color_console ? BLUE : "")
+#define COLOR_MAGENTA (Moose::__color_console ? MAGENTA : "")
+#define COLOR_CYAN    (Moose::__color_console ? CYAN : "")
+#define COLOR_WHITE   (Moose::__color_console ? WHITE : "")
+#define COLOR_DEFAULT (Moose::__color_console ? DEFAULT : "")
 
 /**
  * Import libMesh::out, and libMesh::err for use in MOOSE.

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -23,19 +23,72 @@
 /**
  * MOOSE wrapped versions of useful libMesh macros (see libmesh_common.h)
  */
-#define mooseError(msg) do { Moose::err << "\n\n" << msg << "\n\n"; if (libMesh::global_n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1); exit(1); } while (0)
+#define mooseError(msg)                                                             \
+  do                                                                                \
+  {                                                                                 \
+    Moose::err << "\n\n"                                                            \
+               << (Moose::__color_console ? RED : "")                               \
+               << "\n\n*** ERROR ***\n"                                             \
+               << msg                                                               \
+               << (Moose::__color_console ? DEFAULT : "")                           \
+               << "\n\n";                                                           \
+    if (libMesh::global_n_processors() == 1)                                        \
+      print_trace();                                                                \
+    libmesh_here();                                                                 \
+    MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1);                                        \
+    exit(1);                                                                        \
+  } while (0)
 
 #ifdef NDEBUG
 #define mooseAssert(asserted, msg)
 #else
-#define mooseAssert(asserted, msg)  do { if (!(asserted)) { Moose::err << "\n\nAssertion `" #asserted "' failed\n" << msg << "\nat " << __FILE__ << ", line " << __LINE__ << std::endl; if (libMesh::global_n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1); exit(1); } } while (0)
+#define mooseAssert(asserted, msg)                                                  \
+  do                                                                                \
+  {                                                                                 \
+    if (!(asserted))                                                                \
+    {                                                                               \
+      Moose::err                                                                    \
+        << (Moose::__color_console ? RED : "")                                      \
+        << "\n\nAssertion `" #asserted "' failed\n"                                 \
+        << msg                                                                      \
+        << "\nat "                                                                  \
+        << __FILE__ << ", line " << __LINE__                                        \
+        << (Moose::__color_console ? DEFAULT : "")                                  \
+        << std::endl;                                                               \
+     if (libMesh::global_n_processors() == 1)                                       \
+       print_trace();                                                               \
+     libmesh_here();                                                                \
+     MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1);                                       \
+     exit(1);                                                                       \
+    }                                                                               \
+  } while (0)
 #endif
 
-#define mooseWarning(msg) do { Moose::out << "\n\n*** Warning ***\n" << msg << "\nat " << __FILE__ << ", line " << __LINE__ << "\n" << std::endl; } while (0)
+#define mooseWarning(msg)                                                           \
+  do                                                                                \
+  {                                                                                 \
+    Moose::out                                                                      \
+      << (Moose::__color_console ? YELLOW : "")                                     \
+      << "\n\n*** Warning ***\n"                                                    \
+      << msg                                                                        \
+      << "\nat " << __FILE__ << ", line " << __LINE__                               \
+      << (Moose::__color_console ? DEFAULT : "")                                    \
+      << "\n"                                                                       \
+      << std::endl;                                                                 \
+  } while (0)
 
 #define mooseDoOnce(do_this) do { static bool did_this_already = false; if (!did_this_already) { did_this_already = true; do_this; } } while (0)
 
-#define mooseDeprecated() mooseDoOnce( Moose::out << "*** Warning, This code is deprecated, and likely to be removed in future library versions! " << __FILE__ << ", line " << __LINE__ << ", compiled " << __DATE__ << " at " << __TIME__ << " ***" << std::endl;)
+#define mooseDeprecated()                                                                              \
+    mooseDoOnce(                                                                                       \
+      Moose::out                                                                                       \
+      << (Moose::__color_console ? YELLOW : "")                                                        \
+      << "*** Warning, This code is deprecated, and likely to be removed in future library versions! " \
+      << __FILE__ << ", line " << __LINE__ << ", compiled "                                            \
+      << __DATE__ << " at " << __TIME__ << " ***"                                                      \
+      << (Moose::__color_console ? DEFAULT : "")                                                       \
+      << std::endl;                                                                                    \
+      )
 
 #define mooseCheckMPIErr(err) do { if (err != MPI_SUCCESS) { if (libMesh::global_n_processors() == 1) print_trace(); libmesh_here(); MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1); exit(1); } } while (0)
 

--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -152,9 +152,6 @@ protected:
   /// The FormattedTable fit mode
   MooseEnum _fit_mode;
 
-  /// Toggle for controlling the use of color output
-  bool _use_color;
-
   /// Toggle for outputting time in time and dt in scientific notation
   bool _scientific_time;
 

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -20,8 +20,6 @@
 #include <sstream>
 #include <algorithm>
 
-#include "XTermConstants.h"
-
 // libMesh includes
 #include "libmesh/parallel.h"
 
@@ -87,31 +85,6 @@ namespace MooseUtils
       if (iter->second == value)
         return true;
     return false;
-  }
-
-  /**
-   * Returns a character string to produce a specific color in terminals supporting
-   * color. The list of color constants is available in XTermConstants.h
-   * @param color (from XTermConstants.h)
-   * @param text The output to be converted to text and colored
-   * @param use_color A convenience flag using or not using color (see src/outputs/Console.C)
-   */
-  template <typename T>
-  std::string
-  colorText(std::string color, T text, bool use_color = true)
-  {
-    // Define a stream to output
-    std::ostringstream oss;
-    oss << std::scientific;
-
-    // Output the value to the stream
-    if (use_color)
-      oss << color << text << COLOR_DEFAULT;
-    else
-      oss << text;
-
-    // Return string
-    return oss.str();
   }
 }
 

--- a/framework/include/utils/XTermConstants.h
+++ b/framework/include/utils/XTermConstants.h
@@ -23,6 +23,6 @@
 #define MAGENTA  "\33[35m"
 #define CYAN     "\33[36m"
 #define WHITE    "\33[37m"
-#define COLOR_DEFAULT  "\33[39m"
+#define DEFAULT  "\33[39m"
 
 #endif

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -79,10 +79,10 @@ ActionWarehouse::addActionBlock(Action * action)
   std::set<std::string> tasks;
 
   if (_show_parser)
-    Moose::err << COLOR_DEFAULT << "Parsing Syntax:        " << GREEN   << action->name() << '\n'
+    Moose::err << COLOR_DEFAULT << "Parsing Syntax:        " << COLOR_GREEN   << action->name() << '\n'
                << COLOR_DEFAULT << "Building Action:       " << COLOR_DEFAULT << action->type() << '\n'
-               << COLOR_DEFAULT << "Registered Identifier: " << GREEN   << registered_identifier << '\n'
-               << COLOR_DEFAULT << "Specific Task:         " << CYAN    << action->specificTaskName() << '\n';
+               << COLOR_DEFAULT << "Registered Identifier: " << COLOR_GREEN   << registered_identifier << '\n'
+               << COLOR_DEFAULT << "Specific Task:         " << COLOR_CYAN    << action->specificTaskName() << '\n';
 
   /**
    * We need to see if the current Action satisfies multiple tasks. There are a few cases to consider:
@@ -144,7 +144,7 @@ ActionWarehouse::addActionBlock(Action * action)
     action->appendTask(*it);
 
     if (_show_parser)
-      Moose::err << YELLOW << "Adding Action:         " << COLOR_DEFAULT << action->type() << " (" << YELLOW << *it << COLOR_DEFAULT << ")\n";
+      Moose::err << COLOR_YELLOW << "Adding Action:         " << COLOR_DEFAULT << action->type() << " (" << COLOR_YELLOW << *it << COLOR_DEFAULT << ")\n";
 
     // Add it to the warehouse
     _action_blocks[*it].push_back(action);
@@ -239,7 +239,7 @@ ActionWarehouse::printActionDependencySets() const
   const std::vector<std::set<std::string> > & ordered_names = _syntax.getSortedTaskSet();
   for (std::vector<std::set<std::string> >::const_iterator i = ordered_names.begin(); i != ordered_names.end(); ++i)
   {
-    oss << "[DBG][ACT] (" << YELLOW;
+    oss << "[DBG][ACT] (" << COLOR_YELLOW;
     std::copy(i->begin(), i->end(), infix_ostream_iterator<std::string>(oss, ", "));
     oss << COLOR_DEFAULT << ")\n";
 
@@ -252,7 +252,7 @@ ActionWarehouse::printActionDependencySets() const
 
         // The Syntax of the Action if it exists
         if ((*k)->name() != "")
-          oss << "[DBG][ACT]\t" << GREEN << (*k)->name() << COLOR_DEFAULT << '\n';
+          oss << "[DBG][ACT]\t" << COLOR_GREEN << (*k)->name() << COLOR_DEFAULT << '\n';
 
         // The task sets
         oss << "[DBG][ACT]\t" << act->type();
@@ -267,9 +267,9 @@ ActionWarehouse::printActionDependencySets() const
           std::set_difference(tasks.begin(), tasks.end(), intersection.begin(), intersection.end(),
                               std::inserter(difference, difference.end()));
 
-          oss << CYAN;
+          oss << COLOR_CYAN;
           std::copy(intersection.begin(), intersection.end(), infix_ostream_iterator<std::string>(oss, ", "));
-          oss << MAGENTA << (difference.empty() ? "" : ", ");
+          oss << COLOR_MAGENTA << (difference.empty() ? "" : ", ");
           std::copy(difference.begin(), difference.end(), infix_ostream_iterator<std::string>(oss, ", "));
           oss << COLOR_DEFAULT << ")";
         }
@@ -312,7 +312,7 @@ ActionWarehouse::executeActionsWithAction(const std::string & task)
        ++act_iter)
   {
     if (_show_actions)
-      Moose::out << "[DBG][ACT] " << (*act_iter)->type() << " (" << YELLOW << task << COLOR_DEFAULT << ")"  << std::endl;
+      Moose::out << "[DBG][ACT] " << (*act_iter)->type() << " (" << COLOR_YELLOW << task << COLOR_DEFAULT << ")"  << std::endl;
     (*act_iter)->act();
   }
 }

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -994,4 +994,6 @@ PerfLog setup_perf_log("Setup");
 
 bool __trap_fpe = false;
 
+bool __color_console = true;
+
 } // namespace Moose

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -38,6 +38,7 @@ InputParameters validParams<MooseApp>()
   params.addCommandLineParam<std::string>("mesh_only", "--mesh-only", "Setup and Output the input mesh only.");
 
   params.addCommandLineParam<bool>("show_input", "--show-input", "Shows the parsed input file before running the simulation.");
+  params.addCommandLineParam<bool>("no_color", "--no-color", "Disable coloring of all Console outputs.");
 
   params.addCommandLineParam<bool>("help", "-h --help", "Displays CLI usage statement.");
 
@@ -149,6 +150,9 @@ MooseApp::setupOptions()
 
   if (isParamValid("half_transient"))
     _half_transient = true;
+
+  if (isParamValid("no_color"))
+    Moose::__color_console = false;
 
   // Set the timing parameter (see src/outputs/Console.C)
   if (isParamValid("timing"))

--- a/framework/src/outputs/ConsoleStream.C
+++ b/framework/src/outputs/ConsoleStream.C
@@ -14,9 +14,7 @@
 
 // Moose includes
 #include "ConsoleStream.h"
-
-// One stream fits all
-//std::ostringstream ConsoleStream::_oss;
+#include "MooseUtils.h"
 
 ConsoleStream::ConsoleStream(OutputWarehouse & output_warehouse) :
     _output_warehouse(output_warehouse),

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -244,7 +244,8 @@ void
 Parser::checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_on_warn)
 {
   std::set<std::string> difference;
-  std::string message_indicator(error_on_warn ? "*** ERROR" : "*** WARNING");
+  std::string message_indicator = error_on_warn ? "*** ERROR" : "*** WARNING";
+  std::string color = error_on_warn ? COLOR_RED : COLOR_YELLOW;
 
   std::sort(all_vars.begin(), all_vars.end());
 
@@ -264,10 +265,10 @@ Parser::checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_
   {
     std::ostringstream oss;
 
-    oss << "\n" << message_indicator << ": The following parameters were unused in your input file:\n";
+    oss << color << message_indicator << ": The following parameters were unused in your input file:\n";
     for (std::set<std::string>::iterator i=difference.begin(); i != difference.end(); ++i)
       oss << *i << "\n";
-    oss << message_indicator << "\n";
+    oss << message_indicator << "\n\n" << COLOR_DEFAULT;
 
     if (error_on_warn)
       mooseError(oss.str());
@@ -284,17 +285,18 @@ Parser::checkOverriddenParams(bool error_on_warn)
     mooseError("No parsing has been done, so checking for overridden parameters is not possible");
 
   std::set<std::string> overridden_vars = _getpot_file.get_overridden_variables();
-  std::string message_indicator(error_on_warn ? "*** ERROR" : "*** WARNING");
+  std::string message_indicator = error_on_warn ? "*** ERROR" : "*** WARNING";
+  std::string color = error_on_warn ? COLOR_RED : COLOR_YELLOW;
 
   if (!overridden_vars.empty())
   {
     std::ostringstream oss;
 
-    oss << message_indicator << ": The following variables were overridden or supplied multiple times:\n";
+    oss << color << message_indicator << ": The following variables were overridden or supplied multiple times:\n";
     for (std::set<std::string>::const_iterator i=overridden_vars.begin();
          i != overridden_vars.end(); ++i)
       oss << *i << "\n";
-    oss << message_indicator << "\n\n";
+    oss << message_indicator << "\n\n" << COLOR_DEFAULT;
 
     if (error_on_warn)
       mooseError(oss.str());
@@ -337,7 +339,7 @@ Parser::appendAndReorderSectionNames(std::vector<std::string> & section_names)
    *                     It must be parsed early since it must exist during subsequent parameter extraction.
    *
    * Note: I realize that doing inserts and deletes in a vector are "slow".  Swapping is not an option due to the
-   *       way that active_lists are constucted.  These are small vectors ;)
+   *       way that active_lists are constructed.  These are small vectors ;)
    */
   // Locate the global params section
   std::string global_syntax = _syntax.getSyntaxByAction("GlobalParamsAction", "set_global_params");

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -72,6 +72,9 @@ class RunApp(Tester):
     if options.timing:
       specs['cli_args'].append('--timing')
 
+    if options.colored == False:
+      specs['cli_args'].append('--no-color')
+
     # Raise the floor
     ncpus = max(default_ncpus, int(specs['min_parallel']))
     # Lower the ceiling


### PR DESCRIPTION
- Add/Restore --no-color to MOOSE and pass through from TestHarness
- Much better mechanism for adding color to any stream using a macro
  e.g. somestream << COLOR_FOO << "stuff" << COLOR_DEFAULT;

closes #3384
