### PR TITLE
Logic updates for find_dep_app.py

### DIFF
--- a/framework/scripts/find_dep_apps.py
+++ b/framework/scripts/find_dep_apps.py
@@ -10,54 +10,64 @@ def findDepApps(dep_names):
   dep_name = dep_names.split('~')[0]
 
   app_dirs = []
-  apps = ['framework', 'moose', 'test', 'unit', 'modules']
+  moose_apps = ['framework', 'moose', 'test', 'unit', 'modules', 'examples']
+  apps = moose_apps[:]
 
   # First see if we are in a git repo
   p = subprocess.Popen('git rev-parse --show-cdup', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
   p.wait()
   if p.returncode == 0:
     git_dir = p.communicate()[0]
-    app_dirs.append(os.path.abspath(os.path.join(os.getcwd(), git_dir)).rstrip())
+    root_dir = os.path.abspath(os.path.join(os.getcwd(), git_dir)).rstrip()
+    app_dirs.append(os.path.abspath(os.path.join(root_dir, '..')))
 
   # Now see if we can find .build_apps which exists in the herd repo
   apps_file = '.build_apps'
-  found_it = False
+  apps_file_path = ''
   apps_dir = os.getcwd()
   for i in range(4):
     apps_dir = os.path.join(apps_dir, "..")
-    if os.path.exists(os.path.join(apps_dir, apps_file)):
-      found_it = True
+    if os.path.isfile(os.path.join(apps_dir, apps_file)):
+      apps_file_path = os.path.join(apps_dir, apps_file)
       break
-  if found_it:
-    app_dirs.append(os.path.abspath(apps_dir))
+  if apps_file_path != '':
+    app_dirs.append(os.path.abspath(os.path.join(apps_dir, '..')))
 
   # Finally see if HERD_TRUNK_DIR is defined
   herd_trunk = os.environ.get('HERD_TRUNK_DIR')
   if herd_trunk != None:
     app_dirs.append(herd_trunk)
+    if os.path.isfile(os.path.join(herd_trunk, apps_file)):
+      apps_file_path = os.path.join(herd_trunk, apps_file)
+
 
   # Make sure that we found at least one directory to search
   if len(app_dirs) == 0:
     return ''
-
-#  print '\n'.join(app_dirs)
-
-#  # Are we just looking for the ROOT?
-#  if dep_name == 'ROOT':
-#    return apps_dir
 
   # unique paths to search
   unique_dirs = set()
   for dir in app_dirs:
     unique_dirs.add(os.path.abspath(dir))
 
-  for dir in unique_dirs:
-    app_file = os.path.join(dir, apps_file)
-    if os.path.isfile(app_file):
-      # Read list of all apps
-      f = open(app_file)
-      apps.extend(f.read().splitlines())
-      f.close()
+  remove_dirs = set()
+  # now strip common paths
+  for dir1 in unique_dirs:
+    for dir2 in unique_dirs:
+      if dir1 == dir2:
+        continue
+
+      if dir1 in dir2:
+        remove_dirs.add(dir2)
+      elif dir2 in dir1:
+        remove_dirs.add(dir1)
+  # set difference
+  unique_dirs = unique_dirs - remove_dirs
+
+  if apps_file_path != '':
+    f = open(apps_file_path)
+    apps.extend(f.read().splitlines())
+    f.close()
 
   # See which apps in this file are children or dependents of this app
   dep_apps = set()
@@ -73,28 +83,44 @@ def findDepApps(dep_names):
   else:
     dep_app_re=re.compile(r"^\s*APPLICATION_NAME\s*:=\s*"+dep_name,re.MULTILINE)
 
-  ignores = ['.git', '.svn', '.libs', 'gold', 'src', 'include', 'contrib', 'tests']
+  ignores = ['.git', '.svn', '.libs', 'gold', 'src', 'include', 'contrib', 'tests', 'bak']
   for dir in unique_dirs:
-    for dirpath, dirnames, filenames in os.walk(dir):
+    startinglevel = dir.count(os.sep)
+    for dirpath, dirnames, filenames in os.walk(dir, topdown=True):
+      # Don't traverse too deep!
+      if dirpath.count(os.sep) - startinglevel >= 3: # 2 levels outta be enough for anybody
+        dirnames[:] = []
 
       # Don't traverse into ignored directories
       for ignore in ignores:
         if ignore in dirnames:
           dirnames.remove(ignore)
 
+      # Honor user ignored directories
+      if os.path.isfile(os.path.join(dirpath, '.moose_ignore')):
+        dirnames[:] = []
+        continue
+
       potential_makefile = os.path.join(dirpath, 'Makefile')
 
-      if os.path.exists(potential_makefile):
+      if os.path.isfile(potential_makefile):
         f = open(potential_makefile)
         lines = f.read()
         f.close()
 
         # We only want to build certain applications, look at the path to make a decision
+        # If we are in trunk, we will honor .build_apps.  If we aren't, then we'll add it
         eligible_app = dirpath.split('/')[-1]
-        if dep_app_re.search(lines) and eligible_app in apps and eligible_app not in dep_apps:
+        if dep_app_re.search(lines) and (eligible_app in apps or '/trunk/' not in dirpath):
           dep_apps.add(eligible_app)
           dep_dirs.add(dirpath)
 
+          # Don't traverse once we've found a dependency
+          dirnames[:] = []
+
+
+  # Now we need to filter out duplicate moose apps
+  moose_dir = os.environ.get('MOOSE_DIR')
   return '\n'.join(dep_dirs)
 
 if __name__ == '__main__':


### PR DESCRIPTION
closes #3397

For now we are going to look one directory up from HERD_TRUNK_DIR and the base of MOOSE's directory and traverse from there.  There are several new pieces of logic here.  First we are going to limit the search depth to speed things up.  Also we are going to ignore directories containing a file named ".ignore".

Finally there is new logic for figuring out which version of MOOSE to use.  
1) We prefer MOOSE_DIR first
2) If in trunk we prefer stable moose
3) if not in trunk we prefer github moose (not trunk)
