### PR TITLE
Only compute off-diagonal Jacobian entries if variable has DOFs.

### DIFF
--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -124,16 +124,9 @@ DiracKernel::computeOffDiagJacobian(unsigned int jvar)
     {
       _current_point = _physical_point[_qp];
       if (isActiveAtPoint(_current_elem, _current_point))
-      {
-        // Detect when ke is not properly sized, and don't try to
-        // compute Jacobians in that case.
-        if (ke.m()*ke.n() == 0)
-          return;
-
         for (_i=0; _i<_test.size(); _i++)
           for (_j=0; _j<_phi.size(); _j++)
             ke(_i, _j) += computeQpOffDiagJacobian(jvar);
-      }
     }
   }
 }


### PR DESCRIPTION
This patch does the proper checking at the
ComputeDiracThread::onElement() level rather than the
DiracKernel::computeOffDiagJacobian() level, and undoes the quick fix
I committed earlier.

Refs #668.
