### PR TITLE
Adding shared pointers to MOOSE in support of multiple execute_on

### DIFF
--- a/framework/include/auxkernels/AuxWarehouse.h
+++ b/framework/include/auxkernels/AuxWarehouse.h
@@ -15,12 +15,13 @@
 #ifndef AUXWAREHOUSE_H
 #define AUXWAREHOUSE_H
 
+#include "MooseTypes.h"
+
 #include <vector>
 #include <map>
 #include <string>
 #include <list>
 #include <set>
-#include "MooseTypes.h"
 
 class AuxKernel;
 class AuxScalarKernel;
@@ -64,13 +65,13 @@ public:
    * @param aux Kernel being added
    * @param block_ids Set of subdomain this kernel is active on
    */
-  void addAuxKernel(AuxKernel *aux);
+  void addAuxKernel(MooseSharedPointer<AuxKernel> aux);
 
   /**
    * Add a scalar kernels
    * @param kernel Scalar kernel being added
    */
-  void addScalarKernel(AuxScalarKernel *kernel);
+  void addScalarKernel(MooseSharedPointer<AuxScalarKernel> kernel);
 
 protected:
   /// all aux kernels
@@ -96,6 +97,15 @@ protected:
   std::vector<AuxScalarKernel *> _scalar_kernels;
 
 private:
+  ///@{
+  /**
+   * We are using MooseSharedPointer to handle the cleanup of the pointers at the end of execution.
+   * This is necessary since several warehouses might be sharing a single instance of a MooseObject.
+   */
+  std::vector<MooseSharedPointer<AuxKernel> > _all_ptrs;
+  std::vector<MooseSharedPointer<AuxScalarKernel> > _all_scalar_ptrs;
+  ///@}
+
   /**
    * This routine uses the Dependency Resolver to sort AuxKernels based on dependencies they
    * might have on coupled values

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -28,6 +28,16 @@
 #include <string>
 #include <vector>
 
+#ifdef LIBMESH_HAVE_CXX11_SHARED_PTR
+#  include <memory>
+#  define MooseSharedPointer std::shared_ptr
+#  define MooseSharedNamespace std
+#else
+#  include "boost/shared_ptr.hpp"
+#  define MooseSharedPointer boost::shared_ptr
+#  define MooseSharedNamespace boost
+#endif
+
 /**
  * MOOSE typedefs
  */

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -128,11 +128,10 @@ AuxiliarySystem::addKernel(const std::string & kernel_name, const std::string & 
   {
     parameters.set<THREAD_ID>("_tid") = tid;
 
-    AuxKernel *kernel = static_cast<AuxKernel *>(_factory.create(kernel_name, name, parameters));
-    mooseAssert(kernel != NULL, "Not an AuxKernel object");
-
+    MooseSharedPointer<AuxKernel> kernel = MooseSharedNamespace::static_pointer_cast<AuxKernel>(_factory.create_shared_ptr(kernel_name, name, parameters));
     _auxs(kernel->execFlag())[tid].addAuxKernel(kernel);
-    _mproblem._objects_by_name[tid][name].push_back(kernel);
+
+    _mproblem._objects_by_name[tid][name].push_back(kernel.get());
 
     if (kernel->boundaryRestricted())
     {
@@ -150,12 +149,11 @@ AuxiliarySystem::addScalarKernel(const std::string & kernel_name, const std::str
   {
     parameters.set<THREAD_ID>("_tid") = tid;
 
-    AuxScalarKernel *kernel = static_cast<AuxScalarKernel *>(_factory.create(kernel_name, name, parameters));
-    mooseAssert(kernel != NULL, "Not a AuxScalarKernel object");
+    MooseSharedPointer<AuxScalarKernel> kernel = MooseSharedNamespace::static_pointer_cast<AuxScalarKernel>(_factory.create_shared_ptr(kernel_name, name, parameters));
 
     _auxs(kernel->execFlag())[tid].addScalarKernel(kernel);
 
-    _mproblem._objects_by_name[tid][name].push_back(kernel);
+    _mproblem._objects_by_name[tid][name].push_back(kernel.get());
   }
 }
 

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -55,6 +55,21 @@ Factory::create(const std::string & obj_name, const std::string & name, InputPar
   return (*_name_to_build_pointer[obj_name])(name, parameters);
 }
 
+MooseObjectPtr
+Factory::create_shared_ptr(const std::string & obj_name, const std::string & name, InputParameters parameters)
+{
+  // Check if the object is registered
+  if (_name_to_build_pointer_shared.find(obj_name) == _name_to_build_pointer_shared.end())
+    mooseError("Object '" + obj_name + "' was not registered.");
+
+  // Print out deprecated message, if it exists
+  deprecatedMessage(obj_name);
+
+  // Check to make sure that all required parameters are supplied
+  parameters.checkParams(name);
+  return (*_name_to_build_pointer_shared[obj_name])(name, parameters);
+}
+
 time_t Factory::parseTime(const std::string t_str)
 {
   // The string must be a certain length to be valid


### PR DESCRIPTION
refs #3446

This patch is the start of using one of the smart pointer classes in MOOSE.  For now, I've created a parallel structure in the Factory so that we can continue to create the old pointers as well as we convert many of our systems over to shared_ptrs.  This patch converts the AuxWarehouse to shared pointers without changing the external interface of that class.  This is done by keeping private shared pointers to all of the objects while maintaining the existing interface using old style pointers.  There's no reason to change the API now or in the future.  This just helps us with the cleanup which will get much harder when the rest of #3446 gets implemented.
