### PR TITLE
Expose information on whether a material property has been requested.

### DIFF
--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -217,6 +217,16 @@ public:
   virtual void checkBoundaryMatProps();
 
   /**
+   * Helper method for isMatPropRequested to factor out block and boundary checking
+   */
+  virtual bool checkMatPropRequested(std::map<unsigned int, std::multimap<std::string, std::string> > &, const std::string &);
+
+  /**
+   * Find out if a material property has been requested by any object
+   */
+  virtual bool isMatPropRequested(const std::string & prop_name);
+
+  /**
    * Will make sure that all dofs connected to elem_id are ghosted to this processor
    */
   virtual void addGhostedElem(unsigned int elem_id) = 0;

--- a/framework/src/base/SubProblem.C
+++ b/framework/src/base/SubProblem.C
@@ -185,6 +185,32 @@ SubProblem::checkBoundaryMatProps()
   checkMatProps(_map_boundary_material_props, _map_boundary_material_props_check, "boundary");
 }
 
+bool
+SubProblem::checkMatPropRequested(std::map<unsigned int, std::multimap<std::string, std::string> > & check_props, const std::string & prop_name)
+{
+  // Loop through the properties to check
+  for (std::map<unsigned int, std::multimap<std::string, std::string> >::const_iterator check_it = check_props.begin();
+       check_it != check_props.end(); ++check_it)
+  {
+    // Loop through all the stored properties
+    for (std::multimap<std::string, std::string>::const_iterator prop_it = check_it->second.begin(); prop_it != check_it->second.end(); ++prop_it)
+    {
+      // return success as soon as the queried property name has been found
+      if (prop_it->second == prop_name)
+        return true;
+    }
+  }
+
+  return false;
+}
+
+bool
+SubProblem::isMatPropRequested(const std::string & prop_name)
+{
+  return checkMatPropRequested(_map_block_material_props_check, prop_name) ||
+         checkMatPropRequested(_map_boundary_material_props_check, prop_name);
+}
+
 
 DiracKernelInfo &
 SubProblem::diracKernelInfo()


### PR DESCRIPTION
Addressing issue #3470 this attempts to expose if a certain material property has been requested by any object in the FEProblem. 

Example (to go in `initialSetup()`):

``` C++
_compute_cvac = _fe_problem.isMatPropRequested("cvac");
```
