### PR TITLE
Set the network variable via enviroment variable (closes #3488)

### DIFF
--- a/framework/scripts/distcc/Machine.py
+++ b/framework/scripts/distcc/Machine.py
@@ -126,11 +126,14 @@ class Machine(object):
     self.use_threads = self.threads
 
     # Set the network
-    if self.address.find('204.') != -1:
-      self.network = 'fn'
+    if 'DMAKE_NETWORK' in os.environ:
+      self.network = os.environ['DMAKE_NETWORK']
     else:
-      self.network = 'inl'
-      os.environ['no_proxy'] = '.inl.gov'
+      if self.address.find('204.') != -1:
+        self.network = 'fn'
+      else:
+        self.network = 'inl'
+        os.environ['no_proxy'] = '.inl.gov'
 
     # Set the description, if the remote or local file is read this will be updated with the user supplied
     # description. This is not done here for speed purposed if a local only build is performed


### PR DESCRIPTION
If the environment variable 'DMAKE_NETWORK' is set, use it instead of
guessing the network. Fixes problems with FN network.
