### PR TITLE
Change or deprecate  setValue and getValue in RankTwoTensor

### DIFF
--- a/modules/combined/tests/finite_strain_tensor_mechanics_tests/finite_strain_elasticity_test.i
+++ b/modules/combined/tests/finite_strain_tensor_mechanics_tests/finite_strain_elasticity_test.i
@@ -117,43 +117,43 @@
     type = RankTwoAux
     rank_two_tensor = stress
     variable = stress_xx
-    index_i = 1
-    index_j = 1
+    index_i = 0
+    index_j = 0
   [../]
   [./stress_yy]
     type = RankTwoAux
     rank_two_tensor = stress
     variable = stress_yy
-    index_i = 2
-    index_j = 2
+    index_i = 1
+    index_j = 1
   [../]
   [./stress_zz]
     type = RankTwoAux
     rank_two_tensor = stress
     variable = stress_zz
-    index_i = 3
-    index_j = 3
+    index_i = 2
+    index_j = 2
   [../]
   [./stress_xy]
     type = RankTwoAux
     rank_two_tensor = stress
     variable = stress_xy
-    index_i = 1
-    index_j = 2
+    index_i = 0
+    index_j = 1
   [../]
   [./stress_yz]
     type = RankTwoAux
     rank_two_tensor = stress
     variable = stress_yz
-    index_i = 2
-    index_j = 3
+    index_i = 1
+    index_j = 2
   [../]
   [./stress_zx]
     type = RankTwoAux
     rank_two_tensor = stress
     variable = stress_zx
-    index_i = 3
-    index_j = 1
+    index_i = 2
+    index_j = 0
   [../]
 []
 

--- a/modules/combined/tests/linear_elasticity/LinearElasticMaterial_test.i
+++ b/modules/combined/tests/linear_elasticity/LinearElasticMaterial_test.i
@@ -87,48 +87,48 @@
   [./matl_s11]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 1
+    index_i = 0
+    index_j = 0
     variable = s11_aux
   [../]
 
  [./matl_s12]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 2
+    index_i = 0
+    index_j = 1
     variable = s12_aux
   [../]
 
   [./matl_s13]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 3
+    index_i = 0
+    index_j = 2
     variable = s13_aux
   [../]
 
   [./matl_s22]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 2
-    index_j = 2
+    index_i = 1
+    index_j = 1
     variable = s22_aux
   [../]
 
   [./matl_s23]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 2
-    index_j = 3
+    index_i = 1
+    index_j = 2
     variable = s23_aux
   [../]
 
   [./matl_s33]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 3
-    index_j = 3
+    index_i = 2
+    index_j = 2
     variable = s33_aux
   [../]
 []

--- a/modules/combined/tests/linear_elasticity/Tensor_test.i
+++ b/modules/combined/tests/linear_elasticity/Tensor_test.i
@@ -194,258 +194,258 @@
   [./matl_C1111]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 1
-    index_k = 1
-    index_l = 1
+    index_i = 0
+    index_j = 0
+    index_k = 0
+    index_l = 0
     variable = C1111_aux
   [../]
 
    [./matl_C1122]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 1
-    index_k = 2
-    index_l = 2
+    index_i = 0
+    index_j = 0
+    index_k = 1
+    index_l = 1
     variable = C1122_aux
   [../]
 
   [./matl_C1133]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 1
-    index_k = 3
-    index_l = 3
+    index_i = 0
+    index_j = 0
+    index_k = 2
+    index_l = 2
     variable = C1133_aux
   [../]
 
   [./matl_C1123]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 1
-    index_k = 2
-    index_l = 3
+    index_i = 0
+    index_j = 0
+    index_k = 1
+    index_l = 2
     variable = C1123_aux
   [../]
 
   [./matl_C1113]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 1
-    index_k = 1
-    index_l = 3
+    index_i = 0
+    index_j = 0
+    index_k = 0
+    index_l = 2
     variable = C1113_aux
   [../]
 
   [./matl_C1112]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 1
-    index_k = 1
-    index_l = 2
+    index_i = 0
+    index_j = 0
+    index_k = 0
+    index_l = 1
     variable = C1112_aux
   [../]
 
   [./matl_C2222]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 2
-    index_j = 2
-    index_k = 2
-    index_l = 2
+    index_i = 1
+    index_j = 1
+    index_k = 1
+    index_l = 1
     variable = C2222_aux
   [../]
 
   [./matl_C2233]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 2
-    index_j = 2
-    index_k = 3
-    index_l = 3
+    index_i = 1
+    index_j = 1
+    index_k = 2
+    index_l = 2
     variable = C2233_aux
   [../]
 
   [./matl_C2223]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 2
-    index_j = 2
-    index_k = 2
-    index_l = 3
+    index_i = 1
+    index_j = 1
+    index_k = 1
+    index_l = 2
     variable = C2223_aux
   [../]
 
   [./matl_C2213]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 2
-    index_j = 2
-    index_k = 1
-    index_l = 3
+    index_i = 1
+    index_j = 1
+    index_k = 0
+    index_l = 2
     variable = C2213_aux
   [../]
 
   [./matl_C2212]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 2
-    index_j = 2
-    index_k = 1
-    index_l = 2
+    index_i = 1
+    index_j = 1
+    index_k = 0
+    index_l = 1
     variable = C2212_aux
   [../]
 
  [./matl_C3333]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 3
-    index_j = 3
-    index_k = 3
-    index_l = 3
+    index_i = 2
+    index_j = 2
+    index_k = 2
+    index_l = 2
     variable = C3333_aux
   [../]
 
   [./matl_C3323]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 3
-    index_j = 3
-    index_k = 2
-    index_l = 3
+    index_i = 2
+    index_j = 2
+    index_k = 1
+    index_l = 2
     variable = C3323_aux
   [../]
 
   [./matl_C3313]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 3
-    index_j = 3
-    index_k = 1
-    index_l = 3
+    index_i = 2
+    index_j = 2
+    index_k = 0
+    index_l = 2
     variable = C3313_aux
   [../]
 
   [./matl_C3312]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 3
-    index_j = 3
-    index_k = 1
-    index_l = 2
+    index_i = 2
+    index_j = 2
+    index_k = 0
+    index_l = 1
     variable = C3312_aux
   [../]
 
   [./matl_C2323]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 2
-    index_j = 3
-    index_k = 2
-    index_l = 3
+    index_i = 1
+    index_j = 2
+    index_k = 1
+    index_l = 2
     variable = C2323_aux
   [../]
 
   [./matl_C2313]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 2
-    index_j = 3
-    index_k = 1
-    index_l = 3
+    index_i = 1
+    index_j = 2
+    index_k = 0
+    index_l = 2
     variable = C2313_aux
   [../]
 
   [./matl_C2312]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 2
-    index_j = 3
-    index_k = 1
-    index_l = 2
+    index_i = 1
+    index_j = 2
+    index_k = 0
+    index_l = 1
     variable = C2312_aux
   [../]
 
   [./matl_C1313]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 3
-    index_k = 1
-    index_l = 3
+    index_i = 0
+    index_j = 2
+    index_k = 0
+    index_l = 2
     variable = C1313_aux
   [../]
 
   [./matl_C1312]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 3
-    index_k = 1
-    index_l = 2
+    index_i = 0
+    index_j = 2
+    index_k = 0
+    index_l = 1
     variable = C1312_aux
   [../]
 
   [./matl_C1212]
     type = RankFourAux
     rank_four_tensor = elasticity_tensor
-    index_i = 1
-    index_j = 2
-    index_k = 1
-    index_l = 2
+    index_i = 0
+    index_j = 1
+    index_k = 0
+    index_l = 1
     variable = C1212_aux
   [../]
 
   [./matl_s11]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 1
+    index_i = 0
+    index_j = 0
     variable = s11_aux
   [../]
 
  [./matl_s12]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 2
+    index_i = 0
+    index_j = 1
     variable = s12_aux
   [../]
 
   [./matl_s13]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 3
+    index_i = 0
+    index_j = 2
     variable = s13_aux
   [../]
 
   [./matl_s22]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 2
-    index_j = 2
+    index_i = 1
+    index_j = 1
     variable = s22_aux
   [../]
 
   [./matl_s23]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 2
-    index_j = 3
+    index_i = 1
+    index_j = 2
     variable = s23_aux
   [../]
 
   [./matl_s33]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 3
-    index_j = 3
+    index_i = 2
+    index_j = 2
     variable = s33_aux
   [../]
 []
@@ -458,7 +458,7 @@
     disp_y = disp_y
 
     fill_method = symmetric21
-   C_ijkl ='1111 1122 1133 1123 1113 1112 2222 2233 2223 2213 2212 3333 3323 3313 3312 2323 2313 2312 1313 1312 1212'
+    C_ijkl ='1111 1122 1133 1123 1113 1112 2222 2233 2223 2213 2212 3333 3323 3313 3312 2323 2313 2312 1313 1312 1212'
   [../]
 []
 
@@ -511,7 +511,6 @@
 
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
 
   nl_rel_tol = 1e-10
 []

--- a/modules/combined/tests/linear_elasticity/applied_strain_test.i
+++ b/modules/combined/tests/linear_elasticity/applied_strain_test.i
@@ -53,22 +53,22 @@
   [./matl_e11]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 1
+    index_i = 0
+    index_j = 0
     variable = e11_aux
   [../]
   [./matl_e12]
     type = RankTwoAux
     rank_two_tensor = elastic_strain
-    index_i = 1
-    index_j = 2
+    index_i = 0
+    index_j = 1
     variable = e12_aux
   [../]
   [./matl_e22]
     type = RankTwoAux
     rank_two_tensor = elastic_strain
-    index_i = 2
-    index_j = 2
+    index_i = 1
+    index_j = 1
     variable = e22_aux
   [../]
 []

--- a/modules/combined/tests/linear_elasticity/thermal_expansion_test.i
+++ b/modules/combined/tests/linear_elasticity/thermal_expansion_test.i
@@ -56,22 +56,22 @@
   [./matl_s11]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 1
+    index_i = 0
+    index_j = 0
     variable = s11_aux
   [../]
   [./matl_s12]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 1
-    index_j = 2
+    index_i = 0
+    index_j = 1
     variable = s12_aux
   [../]
   [./matl_s22]
     type = RankTwoAux
     rank_two_tensor = stress
-    index_i = 2
-    index_j = 2
+    index_i = 1
+    index_j = 1
     variable = s22_aux
   [../]
 []

--- a/modules/combined/tests/tensor_mechanics_crystal_plasticity/crysp.i
+++ b/modules/combined/tests/tensor_mechanics_crystal_plasticity/crysp.i
@@ -56,8 +56,8 @@
     type = RankTwoAux
     variable = stress_zz
     rank_two_tensor = stress
-    index_j = 3
-    index_i = 3
+    index_j = 2
+    index_i = 2
     execute_on = timestep
     block = 0
   [../]
@@ -65,8 +65,8 @@
     type = RankTwoAux
     variable = fp_zz
     rank_two_tensor = fp
-    index_j = 3
-    index_i = 3
+    index_j = 2
+    index_i = 2
     execute_on = timestep
     block = 0
   [../]
@@ -74,8 +74,8 @@
     type = RankTwoAux
     variable = e_zz
     rank_two_tensor = lage
-    index_j = 3
-    index_i = 3
+    index_j = 2
+    index_i = 2
     execute_on = timestep
     block = 0
   [../]

--- a/modules/combined/tests/tensor_mechanics_rate_plasticity/tensor_mechanics_rate_plasticity.i
+++ b/modules/combined/tests/tensor_mechanics_rate_plasticity/tensor_mechanics_rate_plasticity.i
@@ -153,29 +153,29 @@
     type = RankTwoAux
     rank_two_tensor = stress
     variable = stress_zz
-    index_i = 3
-    index_j = 3
+    index_i = 2
+    index_j = 2
   [../]
   [./pe11]
     type = RankTwoAux
     rank_two_tensor = plastic_strain
     variable = pe11
-    index_i = 1
-    index_j = 1
+    index_i = 0
+    index_j = 0
   [../]
     [./pe22]
     type = RankTwoAux
     rank_two_tensor = plastic_strain
     variable = pe22
-    index_i = 2
-    index_j = 2
+    index_i = 1
+    index_j = 1
   [../]
   [./pe33]
     type = RankTwoAux
     rank_two_tensor = plastic_strain
     variable = pe33
-    index_i = 3
-    index_j = 3
+    index_i = 2
+    index_j = 2
   [../]
   [./eqv_plastic_strain]
     type = FiniteStrainPlasticAux

--- a/modules/tensor_mechanics/include/auxkernels/RankTwoAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/RankTwoAux.h
@@ -19,8 +19,7 @@ class RankTwoAux : public AuxKernel
 {
 public:
   RankTwoAux(const std::string & name, InputParameters parameters);
-
-  virtual ~ RankTwoAux() {}
+  virtual ~RankTwoAux() {}
 
 protected:
   virtual Real computeValue();

--- a/modules/tensor_mechanics/include/materials/FiniteStrainPlasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainPlasticMaterial.h
@@ -49,7 +49,9 @@ protected:
    * Note that this algorithm doesn't do any rotations.  In order to find the
    * final stress and plastic_strain, sig and plastic_strain must be rotated using _rotation_increment.
    */
-  virtual void returnMap(const RankTwoTensor &sig_old, const Real eqvpstrain_old, const RankTwoTensor &plastic_strain_old, const RankTwoTensor &delta_d, const RankFourTensor &E_ijkl, RankTwoTensor &sig, Real &eqvpstrain, RankTwoTensor &plastic_strain);
+  virtual void returnMap(const RankTwoTensor & sig_old, const Real eqvpstrain_old, const RankTwoTensor & plastic_strain_old,
+                         const RankTwoTensor & delta_d, const RankFourTensor & E_ijkl, RankTwoTensor & sig,
+                         Real & eqvpstrain, RankTwoTensor & plastic_strain);
 
   /**
    * Calculates the yield function
@@ -57,13 +59,13 @@ protected:
    * @param yield_stress the current value of the yield stress
    * @return equivalentstress - yield_stress
    */
-  virtual Real yieldFunction(const RankTwoTensor &stress, const Real yield_stress);
+  virtual Real yieldFunction(const RankTwoTensor & stress, const Real yield_stress);
 
 
   /**
    * Derivative of yieldFunction with respect to the stress
    */
-  virtual RankTwoTensor dyieldFunction_dstress(const RankTwoTensor &stress);
+  virtual RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress);
 
   /**
    * Derivative of yieldFunction with respect to the equivalent plastic strain
@@ -75,7 +77,7 @@ protected:
    * because we are doing associative flow, and hence does not depend
    * on the internal hardening parameter equivalent_plastic_strain
    */
-  virtual RankTwoTensor flowPotential(const RankTwoTensor &stress);
+  virtual RankTwoTensor flowPotential(const RankTwoTensor & stress);
 
   /**
    * The internal potential.  For associative J2 plasticity this is just -1
@@ -85,7 +87,7 @@ protected:
   /**
    * Equivalent stress
    */
-  Real getSigEqv(const RankTwoTensor &stress);
+  Real getSigEqv(const RankTwoTensor & stress);
 
   /**
    * Evaluates the derivative d(resid_ij)/d(sig_kl), where
@@ -95,7 +97,7 @@ protected:
    * @param flow_incr consistency parameter
    * @param dresid_dsig the required derivative (this is an output variable)
    */
-  virtual void getJac(const RankTwoTensor &sig, const RankFourTensor &E_ijkl, Real flow_incr, RankFourTensor &dresid_dsig);
+  virtual void getJac(const RankTwoTensor & sig, const RankFourTensor & E_ijkl, Real flow_incr, RankFourTensor & dresid_dsig);
 
 
   /// returns unity if i==j, otherwise zero

--- a/modules/tensor_mechanics/include/utils/RankFourTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankFourTensor.h
@@ -123,7 +123,7 @@ public:
                            C_2211 = input[7], C_2212 = input[8], C_2222 = input[9]
                            and C_ijkl = C_jikl = C_ijlk
   */
-  virtual void surfaceFillFromInputVector(const std::vector<Real> input);
+  virtual void surfaceFillFromInputVector(const std::vector<Real> &input);
 
 
   /// Static method for use in validParams for getting the "fill_method"
@@ -159,7 +159,7 @@ public:
    *             antisymmetric_isotropic (use fillAntisymmetricIsotropicFromInputVector)
    *             general (use fillGeneralFromInputVector)
    */
-  void fillFromInputVector(const std::vector<Real> input, FillMethod fill_method);
+  void fillFromInputVector(const std::vector<Real> &input, FillMethod fill_method);
 
 protected:
 
@@ -188,7 +188,7 @@ protected:
                  If all==false then this is
                    C1111 C1122 C1133 C1123 C1113 C1112 C2222 C2233 C2223 C2213 C2212 C3333 C3323 C3313 C3312 C2323 C2313 C2312 C1313 C1312 C1212
   */
-  void fillSymmetricFromInputVector(const std::vector<Real> input, bool all);
+  void fillSymmetricFromInputVector(const std::vector<Real> &input, bool all);
 
   /**
    * fillAntisymmetricFromInputVector takes 6 inputs to fill the
@@ -196,7 +196,7 @@ protected:
    * I.e., B_ijkl = -B_jikl = -B_ijlk = B_klij
    * @param input this is B1212, B1213, B1223, B1313, B1323, B2323.
    */
-  void fillAntisymmetricFromInputVector(const std::vector<Real> input);
+  void fillAntisymmetricFromInputVector(const std::vector<Real> &input);
 
   /**
    * fillGeneralIsotropicFromInputVector takes 3 inputs to fill the
@@ -206,7 +206,7 @@ protected:
    * and a is the antisymmetric shear modulus, and ep is the permutation tensor
    * @param input this is la, mu, a in the above formula
    */
-  void fillGeneralIsotropicFromInputVector(const std::vector<Real> input);
+  void fillGeneralIsotropicFromInputVector(const std::vector<Real> &input);
 
   /**
    * fillAntisymmetricIsotropicFromInputVector takes 1 inputs to fill the
@@ -214,7 +214,7 @@ protected:
    * I.e., C_ijkl = a * ep_ijm * ep_klm, where epsilon is the permutation tensor (and sum on m)
    * @param input this is a in the above formula
    */
-  void fillAntisymmetricIsotropicFromInputVector(const std::vector<Real> input);
+  void fillAntisymmetricIsotropicFromInputVector(const std::vector<Real> &input);
 
   /**
    * fillSymmetricIsotropicFromInputVector takes 2 inputs to fill the
@@ -223,14 +223,14 @@ protected:
    * where la is the first Lame modulus, mu is the second (shear) Lame modulus,
    * @param input this is la and mu in the above formula
    */
-  void fillSymmetricIsotropicFromInputVector(const std::vector<Real> input);
+  void fillSymmetricIsotropicFromInputVector(const std::vector<Real> &input);
 
   /**
    * fillGeneralFromInputVector takes 81 inputs to fill the Rank-4 tensor
    * No symmetries are explicitly maintained
    * @param input  C[i][j][k][l] = input[i*N*N*N + j*N*N + k*N + l]
    */
-  void fillGeneralFromInputVector(const std::vector<Real> input);
+  void fillGeneralFromInputVector(const std::vector<Real> &input);
 
 
 private:

--- a/modules/tensor_mechanics/include/utils/RankFourTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankFourTensor.h
@@ -43,18 +43,11 @@ public:
   /// Gets the value for the index specified.  Takes index = 0,1,2
   Real & operator()(unsigned int i, unsigned int j, unsigned int k, unsigned int l);
 
-
   /**
    * Gets the value for the index specified.  Takes index = 0,1,2
    * used for const
    */
   Real operator()(unsigned int i, unsigned int j, unsigned int k, unsigned int l) const;
-
-  ///Sets the value for the index specified.  Indices = 0, 1, 2
-  void setValue(Real val, unsigned int i, unsigned int j, unsigned int k, unsigned int l);
-
-  /// Gets the value for the index specified.  Takes index = 1,2,3
-  Real getValue(unsigned int i, unsigned int j, unsigned int k, unsigned int l) const;
 
   /// Zeros out the tensor.
   void zero();

--- a/modules/tensor_mechanics/include/utils/RankFourTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankFourTensor.h
@@ -35,7 +35,7 @@ public:
   RankFourTensor();
 
   /// Copy constructor
-  RankFourTensor(const RankFourTensor &a);
+  RankFourTensor(const RankFourTensor & a);
 
   /// Destructor
   ~RankFourTensor() {}
@@ -53,43 +53,43 @@ public:
   void zero();
 
   /// copies values from a into this tensor
-  RankFourTensor & operator= (const RankFourTensor &a);
+  RankFourTensor & operator= (const RankFourTensor & a);
 
   /// C_ijkl*a_kl
-  RankTwoTensor operator* (const RankTwoTensor &a) const;
+  RankTwoTensor operator* (const RankTwoTensor & a) const;
 
   /// C_ijkl*a_kl
-  RealTensorValue operator* (const RealTensorValue &a) const;
+  RealTensorValue operator* (const RealTensorValue & a) const;
 
   /// C_ijkl*a
-  RankFourTensor operator* (const Real &a) const;
+  RankFourTensor operator* (const Real & a) const;
 
   /// C_ijkl *= a
-  RankFourTensor & operator*= (const Real &a);
+  RankFourTensor & operator*= (const Real & a);
 
   /// C_ijkl/a
-  RankFourTensor operator/ (const Real &a) const;
+  RankFourTensor operator/ (const Real & a) const;
 
   /// C_ijkl /= a  for all i, j, k, l
-  RankFourTensor & operator/= (const Real &a);
+  RankFourTensor & operator/= (const Real & a);
 
   /// C_ijkl += a_ijkl  for all i, j, k, l
-  RankFourTensor & operator+= (const RankFourTensor &a);
+  RankFourTensor & operator+= (const RankFourTensor & a);
 
   /// C_ijkl + a_ijkl
-  RankFourTensor operator+ (const RankFourTensor &a) const;
+  RankFourTensor operator+ (const RankFourTensor & a) const;
 
   /// C_ijkl -= a_ijkl
-  RankFourTensor & operator-= (const RankFourTensor &a);
+  RankFourTensor & operator-= (const RankFourTensor & a);
 
   /// C_ijkl - a_ijkl
-  RankFourTensor operator- (const RankFourTensor &a) const;
+  RankFourTensor operator- (const RankFourTensor & a) const;
 
   /// -C_ijkl
   RankFourTensor operator- () const;
 
   /// C_ijpq*a_pqkl
-  RankFourTensor operator* (const RankFourTensor &a) const;
+  RankFourTensor operator* (const RankFourTensor & a) const;
 
   /**
    * This returns A_ijkl such that C_ijkl*A_klmn = 0.5*(de_im de_jn + de_in de_jm)
@@ -101,7 +101,7 @@ public:
    * Rotate the tensor using
    * C_ijkl = R_im R_in R_ko R_lp C_mnop
    */
-  virtual void rotate(RealTensorValue &R);
+  virtual void rotate(RealTensorValue & R);
 
   /// Print tensor using nice formatting and Moose::out
   void print() const;
@@ -123,7 +123,7 @@ public:
                            C_2211 = input[7], C_2212 = input[8], C_2222 = input[9]
                            and C_ijkl = C_jikl = C_ijlk
   */
-  virtual void surfaceFillFromInputVector(const std::vector<Real> &input);
+  virtual void surfaceFillFromInputVector(const std::vector<Real> & input);
 
 
   /// Static method for use in validParams for getting the "fill_method"
@@ -159,7 +159,7 @@ public:
    *             antisymmetric_isotropic (use fillAntisymmetricIsotropicFromInputVector)
    *             general (use fillGeneralFromInputVector)
    */
-  void fillFromInputVector(const std::vector<Real> &input, FillMethod fill_method);
+  void fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method);
 
 protected:
 
@@ -188,7 +188,7 @@ protected:
                  If all==false then this is
                    C1111 C1122 C1133 C1123 C1113 C1112 C2222 C2233 C2223 C2213 C2212 C3333 C3323 C3313 C3312 C2323 C2313 C2312 C1313 C1312 C1212
   */
-  void fillSymmetricFromInputVector(const std::vector<Real> &input, bool all);
+  void fillSymmetricFromInputVector(const std::vector<Real> & input, bool all);
 
   /**
    * fillAntisymmetricFromInputVector takes 6 inputs to fill the
@@ -196,7 +196,7 @@ protected:
    * I.e., B_ijkl = -B_jikl = -B_ijlk = B_klij
    * @param input this is B1212, B1213, B1223, B1313, B1323, B2323.
    */
-  void fillAntisymmetricFromInputVector(const std::vector<Real> &input);
+  void fillAntisymmetricFromInputVector(const std::vector<Real> & input);
 
   /**
    * fillGeneralIsotropicFromInputVector takes 3 inputs to fill the
@@ -206,7 +206,7 @@ protected:
    * and a is the antisymmetric shear modulus, and ep is the permutation tensor
    * @param input this is la, mu, a in the above formula
    */
-  void fillGeneralIsotropicFromInputVector(const std::vector<Real> &input);
+  void fillGeneralIsotropicFromInputVector(const std::vector<Real> & input);
 
   /**
    * fillAntisymmetricIsotropicFromInputVector takes 1 inputs to fill the
@@ -214,7 +214,7 @@ protected:
    * I.e., C_ijkl = a * ep_ijm * ep_klm, where epsilon is the permutation tensor (and sum on m)
    * @param input this is a in the above formula
    */
-  void fillAntisymmetricIsotropicFromInputVector(const std::vector<Real> &input);
+  void fillAntisymmetricIsotropicFromInputVector(const std::vector<Real> & input);
 
   /**
    * fillSymmetricIsotropicFromInputVector takes 2 inputs to fill the
@@ -223,14 +223,14 @@ protected:
    * where la is the first Lame modulus, mu is the second (shear) Lame modulus,
    * @param input this is la and mu in the above formula
    */
-  void fillSymmetricIsotropicFromInputVector(const std::vector<Real> &input);
+  void fillSymmetricIsotropicFromInputVector(const std::vector<Real> & input);
 
   /**
    * fillGeneralFromInputVector takes 81 inputs to fill the Rank-4 tensor
    * No symmetries are explicitly maintained
    * @param input  C[i][j][k][l] = input[i*N*N*N + j*N*N + k*N + l]
    */
-  void fillGeneralFromInputVector(const std::vector<Real> &input);
+  void fillGeneralFromInputVector(const std::vector<Real> & input);
 
 
 private:

--- a/modules/tensor_mechanics/include/utils/RankTwoTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoTensor.h
@@ -69,17 +69,6 @@ public:
   */
   void fillFromInputVector(const std::vector<Real> &input);
 
-private:
-  /// Sets the value for the index specified.  Takes index = 1, 2, 3 (not 0, 1, 2)
-  void setValue(Real val, unsigned int i, unsigned int j);
-
-  /**
-   * @param i 1, 2, or 3
-   * @param j 1, 2, or 3
-   * @return Value for the index specified. Takes index = 1,2,3
-   */
-  Real getValue(unsigned int i, unsigned int j) const;
-
 public:
   /// returns _vals[r][i], ie, row r, with r = 0, 1, 2
   TypeVector<Real> row(const unsigned int r) const;

--- a/modules/tensor_mechanics/include/utils/RankTwoTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoTensor.h
@@ -33,7 +33,7 @@ public:
   RankTwoTensor(const TypeVector<Real> & row1, const TypeVector<Real> & row2, const TypeVector<Real> & row3);
 
   /// Constructor that proxies the fillFromInputVector method
-  RankTwoTensor(const std::vector<Real> &input) { this->fillFromInputVector(input); };
+  RankTwoTensor(const std::vector<Real> & input) { this->fillFromInputVector(input); };
 
   /// Initialization list replacement constructors, 6 arguments
   RankTwoTensor(Real S11, Real S22, Real S33, Real S23, Real S13, Real S12);
@@ -42,10 +42,10 @@ public:
   RankTwoTensor(Real S11, Real S21, Real S31, Real S12, Real S22, Real S32, Real S13, Real S23, Real S33);
 
   /// Copy constructor from RankTwoTensor
-  RankTwoTensor(const RankTwoTensor &a);
+  RankTwoTensor(const RankTwoTensor & a);
 
   /// Copy constructor from RealTensorValue
-  RankTwoTensor(const TypeTensor<Real> &a);
+  RankTwoTensor(const TypeTensor<Real> & a);
 
   /// Gets the value for the index specified.  Takes index = 0,1,2
   Real & operator()(unsigned int i, unsigned int j);
@@ -67,7 +67,7 @@ public:
   *   _vals[0][1] = input[5]
   * If 9 inputs then input order is [0][0], [1][0], [2][0], [0][1], [1][1], ..., [2][2]
   */
-  void fillFromInputVector(const std::vector<Real> &input);
+  void fillFromInputVector(const std::vector<Real> & input);
 
 public:
   /// returns _vals[r][i], ie, row r, with r = 0, 1, 2
@@ -78,14 +78,14 @@ public:
    * _vals[i][j] = R_ij * R_jl * _vals[k][l]
    * @param R rotation matrix as a RealTensorValue
    */
-  virtual void rotate(RealTensorValue &R);
+  virtual void rotate(RealTensorValue & R);
 
   /**
    * rotates the tensor data given a rank two tensor rotation tensor
    * _vals[i][j] = R_ij * R_jl * _vals[k][l]
    * @param R rotation matrix as a RankTwoTensor
    */
-  virtual void rotate(RankTwoTensor &R);
+  virtual void rotate(RankTwoTensor & R);
 
   /**
    * rotates the tensor data anticlockwise around the z-axis
@@ -100,46 +100,46 @@ public:
   RankTwoTensor transpose() const;
 
   /// sets _vals to a, and returns _vals
-  RankTwoTensor & operator= (const RankTwoTensor &a);
+  RankTwoTensor & operator= (const RankTwoTensor & a);
 
   /// adds a to _vals
-  RankTwoTensor & operator+= (const RankTwoTensor &a);
+  RankTwoTensor & operator+= (const RankTwoTensor & a);
 
   /// returns _vals + a
-  RankTwoTensor operator+ (const RankTwoTensor &a) const;
+  RankTwoTensor operator+ (const RankTwoTensor & a) const;
 
   /// sets _vals -= a and returns vals
-  RankTwoTensor & operator-= (const RankTwoTensor &a);
+  RankTwoTensor & operator-= (const RankTwoTensor & a);
 
   /// returns _vals - a
-  RankTwoTensor operator- (const RankTwoTensor &a) const;
+  RankTwoTensor operator- (const RankTwoTensor & a) const;
 
   /// returns -_vals
   RankTwoTensor operator - () const;
 
   /// performs _vals *= a
-  RankTwoTensor & operator*= (const Real &a);
+  RankTwoTensor & operator*= (const Real & a);
 
   /// returns _vals*a
-  RankTwoTensor operator* (const Real &a) const;
+  RankTwoTensor operator* (const Real & a) const;
 
   /// performs _vals /= a
-  RankTwoTensor & operator/= (const Real &a);
+  RankTwoTensor & operator/= (const Real & a);
 
   /// returns _vals/a
-  RankTwoTensor operator/ (const Real &a) const;
+  RankTwoTensor operator/ (const Real & a) const;
 
   /// performs _vals *= a (component by component) and returns the result
-  RankTwoTensor & operator*= (const RankTwoTensor &a);
+  RankTwoTensor & operator*= (const RankTwoTensor & a);
 
   /// Defines multiplication with another RankTwoTensor
-  RankTwoTensor operator* (const RankTwoTensor &a) const;
+  RankTwoTensor operator* (const RankTwoTensor & a) const;
 
   /// Defines multiplication with a TypeTensor<Real>
-  RankTwoTensor operator* (const TypeTensor<Real> &a) const;
+  RankTwoTensor operator* (const TypeTensor<Real> & a) const;
 
   /// returns _vals_ij * a_ij (sum on i, j)
-  Real doubleContraction(const RankTwoTensor &a);
+  Real doubleContraction(const RankTwoTensor & a);
 
   /**
    * Denote the _vals[i][j] by A_ij, then
@@ -173,7 +173,7 @@ public:
   void print() const;
 
   /// Add identity times a to _vals
-  void addIa(const Real &a);
+  void addIa(const Real & a);
 
   /// Sqrt(_vals[i][j]*_vals[i][j])
   Real L2norm() const;
@@ -182,7 +182,7 @@ public:
    * sets _vals[0][0], _vals[0][1], _vals[1][0], _vals[1][1] to input,
    * and the remainder to zero
    */
-  void surfaceFillFromInputVector(const std::vector<Real> &input);
+  void surfaceFillFromInputVector(const std::vector<Real> & input);
 
 protected:
 

--- a/modules/tensor_mechanics/include/utils/RankTwoTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoTensor.h
@@ -69,6 +69,7 @@ public:
   */
   void fillFromInputVector(const std::vector<Real> &input);
 
+private:
   /// Sets the value for the index specified.  Takes index = 1, 2, 3 (not 0, 1, 2)
   void setValue(Real val, unsigned int i, unsigned int j);
 
@@ -79,6 +80,7 @@ public:
    */
   Real getValue(unsigned int i, unsigned int j) const;
 
+public:
   /// returns _vals[r][i], ie, row r, with r = 0, 1, 2
   TypeVector<Real> row(const unsigned int r) const;
 

--- a/modules/tensor_mechanics/src/auxkernels/RankFourAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankFourAux.C
@@ -7,10 +7,10 @@ InputParameters validParams<RankFourAux>()
 
   //add stuff here
   params.addRequiredParam<std::string>("rank_four_tensor", "The rank four material tensor name");
-  params.addRequiredRangeCheckedParam<unsigned int>("index_i", "index_i >= 1 & index_i <= 3", "The index i of ijkl for the tensor to output (1, 2, 3)");
-  params.addRequiredRangeCheckedParam<unsigned int>("index_j", "index_j >= 1 & index_j <= 3", "The index j of ijkl for the tensor to output (1, 2, 3)");
-  params.addRequiredRangeCheckedParam<unsigned int>("index_k", "index_k >= 1 & index_k <= 3", "The index k of ijkl for the tensor to output (1, 2, 3)");
-  params.addRequiredRangeCheckedParam<unsigned int>("index_l", "index_l >= 1 & index_l <= 3", "The index l of ijkl for the tensor to output (1, 2, 3)");
+  params.addRequiredRangeCheckedParam<unsigned int>("index_i", "index_i >= 0 & index_i <= 2", "The index i of ijkl for the tensor to output (0, 1, 2)");
+  params.addRequiredRangeCheckedParam<unsigned int>("index_j", "index_j >= 0 & index_j <= 2", "The index j of ijkl for the tensor to output (0, 1, 2)");
+  params.addRequiredRangeCheckedParam<unsigned int>("index_k", "index_k >= 0 & index_k <= 2", "The index k of ijkl for the tensor to output (0, 1, 2)");
+  params.addRequiredRangeCheckedParam<unsigned int>("index_l", "index_l >= 0 & index_l <= 2", "The index l of ijkl for the tensor to output (0, 1, 2)");
 
   return params;
 }
@@ -28,5 +28,5 @@ RankFourAux::RankFourAux(const std::string & name, InputParameters parameters) :
 Real
 RankFourAux::computeValue()
 {
-  return _tensor[_qp].getValue(_i, _j, _k, _l);
+  return _tensor[_qp](_i, _j, _k, _l);
 }

--- a/modules/tensor_mechanics/src/auxkernels/RankTwoAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankTwoAux.C
@@ -21,5 +21,5 @@ RankTwoAux::RankTwoAux(const std::string & name, InputParameters parameters) :
 Real
 RankTwoAux::computeValue()
 {
-  return _tensor[_qp].getValue(_i, _j);
+  return _tensor[_qp](_i-1, _j-1);
 }

--- a/modules/tensor_mechanics/src/auxkernels/RankTwoAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankTwoAux.C
@@ -5,8 +5,8 @@ InputParameters validParams<RankTwoAux>()
 {
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredParam<std::string>("rank_two_tensor", "The rank two material tensor name");
-  params.addRequiredRangeCheckedParam<unsigned int>("index_i", "index_i >= 1 & index_i <= 3", "The index i of ij for the tensor to output (1, 2, 3)");
-  params.addRequiredRangeCheckedParam<unsigned int>("index_j", "index_j >= 1 & index_j <= 3", "The index j of ij for the tensor to output (1, 2, 3)");
+  params.addRequiredRangeCheckedParam<unsigned int>("index_i", "index_i >= 0 & index_i <= 2", "The index i of ij for the tensor to output (0, 1, 2)");
+  params.addRequiredRangeCheckedParam<unsigned int>("index_j", "index_j >= 0 & index_j <= 2", "The index j of ij for the tensor to output (0, 1, 2)");
   return params;
 }
 
@@ -21,5 +21,5 @@ RankTwoAux::RankTwoAux(const std::string & name, InputParameters parameters) :
 Real
 RankTwoAux::computeValue()
 {
-  return _tensor[_qp](_i-1, _j-1);
+  return _tensor[_qp](_i, _j);
 }

--- a/modules/tensor_mechanics/src/auxkernels/RealTensorValueAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RealTensorValueAux.C
@@ -5,8 +5,8 @@ InputParameters validParams<RealTensorValueAux>()
 {
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredParam<std::string>("tensor", "The material tensor name");
-  params.addRequiredParam<unsigned int>("index_i", "The index i of ij for the tensor to output (0,1,2)");
-  params.addRequiredParam<unsigned int>("index_j", "The index j of ij for the tensor to output (0,1,2)");
+  params.addRequiredRangeCheckedParam<unsigned int>("index_i", "index_i >= 0 & index_i <= 2", "The index i of ij for the tensor to output (0, 1, 2)");
+  params.addRequiredRangeCheckedParam<unsigned int>("index_j", "index_j >= 0 & index_j <= 2", "The index j of ij for the tensor to output (0, 1, 2)");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
@@ -114,7 +114,9 @@ void FiniteStrainPlasticMaterial::computeQpStress()
  *     internalPotential = -1 in the "rep" equation.
  */
 void
-FiniteStrainPlasticMaterial::returnMap(const RankTwoTensor & sig_old, const Real eqvpstrain_old, const RankTwoTensor &plastic_strain_old, const RankTwoTensor & delta_d, const RankFourTensor & E_ijkl, RankTwoTensor & sig, Real & eqvpstrain, RankTwoTensor &plastic_strain)
+FiniteStrainPlasticMaterial::returnMap(const RankTwoTensor & sig_old, const Real eqvpstrain_old, const RankTwoTensor & plastic_strain_old,
+                                       const RankTwoTensor & delta_d, const RankFourTensor & E_ijkl, RankTwoTensor & sig,
+                                       Real & eqvpstrain, RankTwoTensor & plastic_strain)
 {
   // the yield function, must be non-positive
   // Newton-Raphson sets this to zero if trial stress enters inadmissible region
@@ -268,7 +270,7 @@ FiniteStrainPlasticMaterial::returnMap(const RankTwoTensor & sig_old, const Real
 
 
 Real
-FiniteStrainPlasticMaterial::yieldFunction(const RankTwoTensor &stress, const Real yield_stress)
+FiniteStrainPlasticMaterial::yieldFunction(const RankTwoTensor & stress, const Real yield_stress)
 {
   return getSigEqv(stress) - yield_stress;
 }
@@ -304,7 +306,7 @@ FiniteStrainPlasticMaterial::internalPotential()
 
 
 Real
-FiniteStrainPlasticMaterial::getSigEqv(const RankTwoTensor &stress)
+FiniteStrainPlasticMaterial::getSigEqv(const RankTwoTensor & stress)
 {
   return std::pow(3*stress.secondInvariant(), 0.5);
 }

--- a/modules/tensor_mechanics/src/utils/RankFourTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankFourTensor.C
@@ -28,7 +28,7 @@ RankFourTensor::RankFourTensor()
           _vals[i][j][k][l] = 0.0;
 }
 
-RankFourTensor::RankFourTensor(const RankFourTensor &a)
+RankFourTensor::RankFourTensor(const RankFourTensor & a)
 {
   *this = a;
 }
@@ -56,7 +56,7 @@ RankFourTensor::zero()
 }
 
 RankFourTensor &
-RankFourTensor::operator=(const RankFourTensor &a)
+RankFourTensor::operator=(const RankFourTensor & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -68,7 +68,7 @@ RankFourTensor::operator=(const RankFourTensor &a)
 }
 
 RankTwoTensor
-RankFourTensor::operator*(const RankTwoTensor &a) const
+RankFourTensor::operator*(const RankTwoTensor & a) const
 {
   RealTensorValue result;
 
@@ -82,7 +82,7 @@ RankFourTensor::operator*(const RankTwoTensor &a) const
 }
 
 RealTensorValue
-RankFourTensor::operator*(const RealTensorValue &a) const
+RankFourTensor::operator*(const RealTensorValue & a) const
 {
   RealTensorValue result;
 
@@ -96,7 +96,7 @@ RankFourTensor::operator*(const RealTensorValue &a) const
 }
 
 RankFourTensor
-RankFourTensor::operator*(const Real &a) const
+RankFourTensor::operator*(const Real & a) const
 {
   RankFourTensor result;
 
@@ -110,7 +110,7 @@ RankFourTensor::operator*(const Real &a) const
 }
 
 RankFourTensor &
-RankFourTensor::operator*=(const Real &a)
+RankFourTensor::operator*=(const Real & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -122,7 +122,7 @@ RankFourTensor::operator*=(const Real &a)
 }
 
 RankFourTensor
-RankFourTensor::operator/(const Real &a) const
+RankFourTensor::operator/(const Real & a) const
 {
   RankFourTensor result;
 
@@ -136,7 +136,7 @@ RankFourTensor::operator/(const Real &a) const
 }
 
 RankFourTensor &
-RankFourTensor::operator/=(const Real &a)
+RankFourTensor::operator/=(const Real & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -148,7 +148,7 @@ RankFourTensor::operator/=(const Real &a)
 }
 
 RankFourTensor &
-RankFourTensor::operator+=(const RankFourTensor &a)
+RankFourTensor::operator+=(const RankFourTensor & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -160,7 +160,7 @@ RankFourTensor::operator+=(const RankFourTensor &a)
 }
 
 RankFourTensor
-RankFourTensor::operator+(const RankFourTensor &a) const
+RankFourTensor::operator+(const RankFourTensor & a) const
 {
   RankFourTensor result;
 
@@ -174,7 +174,7 @@ RankFourTensor::operator+(const RankFourTensor &a) const
 }
 
 RankFourTensor &
-RankFourTensor::operator-=(const RankFourTensor &a)
+RankFourTensor::operator-=(const RankFourTensor & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -186,7 +186,7 @@ RankFourTensor::operator-=(const RankFourTensor &a)
 }
 
 RankFourTensor
-RankFourTensor::operator-(const RankFourTensor &a) const
+RankFourTensor::operator-(const RankFourTensor & a) const
 {
   RankFourTensor result;
 
@@ -214,7 +214,7 @@ RankFourTensor::operator-() const
 }
 
 RankFourTensor
-RankFourTensor::operator*(const RankFourTensor &a) const
+RankFourTensor::operator*(const RankFourTensor & a) const
 {
   RankFourTensor result;
 
@@ -365,7 +365,7 @@ RankFourTensor::invSymm() const
 }
 
 void
-RankFourTensor::rotate(RealTensorValue &R)
+RankFourTensor::rotate(RealTensorValue & R)
 {
   Real temp;
   RankFourTensor old = *this;
@@ -420,7 +420,7 @@ RankFourTensor::transposeMajor() const
 }
 
 void
-RankFourTensor::surfaceFillFromInputVector(const std::vector<Real> &input)
+RankFourTensor::surfaceFillFromInputVector(const std::vector<Real> & input)
 {
   zero();
 
@@ -464,7 +464,7 @@ RankFourTensor::surfaceFillFromInputVector(const std::vector<Real> &input)
 }
 
 void
-RankFourTensor::fillFromInputVector(const std::vector<Real> &input, FillMethod fill_method)
+RankFourTensor::fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method)
 {
   zero();
 
@@ -529,7 +529,7 @@ RankFourTensor::MatrixInversion(double* A, int n) const
 }
 
 void
-RankFourTensor::fillSymmetricFromInputVector(const std::vector<Real> &input, bool all)
+RankFourTensor::fillSymmetricFromInputVector(const std::vector<Real> & input, bool all)
 {
   if ((all == true && input.size() != 21) || (all == false && input.size() != 9 ))
     mooseError("Please check the number of entries in the stiffness input vector.");
@@ -593,7 +593,7 @@ RankFourTensor::fillSymmetricFromInputVector(const std::vector<Real> &input, boo
 }
 
 void
-RankFourTensor::fillAntisymmetricFromInputVector(const std::vector<Real> &input)
+RankFourTensor::fillAntisymmetricFromInputVector(const std::vector<Real> & input)
 {
   if (input.size() != 6)
     mooseError("To use fillAntisymmetricFromInputVector, your input must have size 6.  Yours has size " << input.size());
@@ -636,7 +636,7 @@ RankFourTensor::fillAntisymmetricFromInputVector(const std::vector<Real> &input)
 }
 
 void
-RankFourTensor::fillGeneralIsotropicFromInputVector(const std::vector<Real> &input)
+RankFourTensor::fillGeneralIsotropicFromInputVector(const std::vector<Real> & input)
 {
   if (input.size() != 3)
     mooseError("To use fillGeneralIsotropicFromInputVector, your input must have size 3.  Yours has size " << input.size());
@@ -655,7 +655,7 @@ RankFourTensor::fillGeneralIsotropicFromInputVector(const std::vector<Real> &inp
 }
 
 void
-RankFourTensor::fillAntisymmetricIsotropicFromInputVector(const std::vector<Real> &input)
+RankFourTensor::fillAntisymmetricIsotropicFromInputVector(const std::vector<Real> & input)
 {
   if (input.size() != 1)
     mooseError("To use fillAntisymmetricIsotropicFromInputVector, your input must have size 1. Yours has size " << input.size());
@@ -667,7 +667,7 @@ RankFourTensor::fillAntisymmetricIsotropicFromInputVector(const std::vector<Real
 }
 
 void
-RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> &input)
+RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> & input)
 {
   if (input.size() != 2)
     mooseError("To use fillSymmetricIsotropicFromInputVector, your input must have size 2. Yours has size " << input.size());
@@ -679,7 +679,7 @@ RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> &i
 }
 
 void
-RankFourTensor::fillGeneralFromInputVector(const std::vector<Real> &input)
+RankFourTensor::fillGeneralFromInputVector(const std::vector<Real> & input)
 {
   if (input.size() != 81)
     mooseError("To use fillGeneralFromInputVector, your input must have size 81. Yours has size " << input.size());

--- a/modules/tensor_mechanics/src/utils/RankFourTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankFourTensor.C
@@ -21,10 +21,10 @@ RankFourTensor::fillMethodEnum()
 
 RankFourTensor::RankFourTensor()
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           _vals[i][j][k][l] = 0.0;
 }
 
@@ -56,7 +56,7 @@ RankFourTensor::zero()
 }
 
 RankFourTensor &
-RankFourTensor::operator= (const RankFourTensor &a)
+RankFourTensor::operator=(const RankFourTensor &a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -68,7 +68,7 @@ RankFourTensor::operator= (const RankFourTensor &a)
 }
 
 RankTwoTensor
-RankFourTensor::operator* (const RankTwoTensor &a) const
+RankFourTensor::operator*(const RankTwoTensor &a) const
 {
   RealTensorValue result;
 
@@ -82,7 +82,7 @@ RankFourTensor::operator* (const RankTwoTensor &a) const
 }
 
 RealTensorValue
-RankFourTensor::operator* (const RealTensorValue &a) const
+RankFourTensor::operator*(const RealTensorValue &a) const
 {
   RealTensorValue result;
 
@@ -96,7 +96,7 @@ RankFourTensor::operator* (const RealTensorValue &a) const
 }
 
 RankFourTensor
-RankFourTensor::operator* (const Real &a) const
+RankFourTensor::operator*(const Real &a) const
 {
   RankFourTensor result;
 
@@ -110,7 +110,7 @@ RankFourTensor::operator* (const Real &a) const
 }
 
 RankFourTensor &
-RankFourTensor::operator*= (const Real &a)
+RankFourTensor::operator*=(const Real &a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -122,7 +122,7 @@ RankFourTensor::operator*= (const Real &a)
 }
 
 RankFourTensor
-RankFourTensor::operator/ (const Real &a) const
+RankFourTensor::operator/(const Real &a) const
 {
   RankFourTensor result;
 
@@ -142,7 +142,7 @@ RankFourTensor::operator/=(const Real &a)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
-          _vals[i][j][k][l] = _vals[i][j][k][l] / a;
+          _vals[i][j][k][l] /= a;
 
   return *this;
 }
@@ -154,7 +154,7 @@ RankFourTensor::operator+=(const RankFourTensor &a)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
-          _vals[i][j][k][l] = _vals[i][j][k][l] + a(i,j,k,l);
+          _vals[i][j][k][l] += a(i,j,k,l);
 
   return *this;
 }
@@ -180,7 +180,7 @@ RankFourTensor::operator-=(const RankFourTensor &a)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
-          _vals[i][j][k][l] = _vals[i][j][k][l] - a(i,j,k,l);
+          _vals[i][j][k][l] -= a(i,j,k,l);
 
   return *this;
 }
@@ -238,7 +238,7 @@ RankFourTensor::invSymm() const
 
   RankFourTensor result;
 
-  unsigned int ntens = N*(N+1)/2;
+  unsigned int ntens = N * (N+1) / 2;
   int nskip = N-1;
 
   // We use the LAPACK matrix inversion routine here.  Form the matrix
@@ -306,7 +306,7 @@ RankFourTensor::invSymm() const
   // mat[33] = C(1,2,0,1)*2
   // mat[34] = C(1,2,0,2)*2
   // mat[35] = C(1,2,1,2)*2
-  mat=(double*)calloc(ntens*ntens, sizeof(double));
+  mat=(double*)calloc(ntens * ntens, sizeof(double));
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
@@ -327,16 +327,15 @@ RankFourTensor::invSymm() const
               mat[(nskip+i+j)*ntens+nskip+k+l] += _vals[i][j][k][l]; // note the +=, which results in double-counting and is rectified below
           }
         }
+
   for (unsigned int i = 3; i < ntens; i++)
     for (unsigned int j = 3; j < ntens; j++)
       mat[i*ntens+j] /= 2.0; // because of double-counting above
-
 
   // use LAPACK to find the inverse
   error = MatrixInversion(mat, ntens);
   if (error != 0)
     mooseError("Error in Matrix  Inversion in RankFourTensor");
-
 
   // build the resulting rank-four tensor
   // using the inverse of the above algorithm
@@ -369,8 +368,7 @@ void
 RankFourTensor::rotate(RealTensorValue &R)
 {
   Real temp;
-  RankFourTensor old;
-  old=*this;
+  RankFourTensor old = *this;
 
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -382,7 +380,7 @@ RankFourTensor::rotate(RealTensorValue &R)
             for (unsigned int n = 0; n < N; ++n)
               for (unsigned int o = 0; o < N; ++o)
                 for (unsigned int p = 0; p < N; ++p)
-                  temp += R(i,m)*R(j,n)*R(k,o)*R(l,p)*old._vals[m][n][o][p];
+                  temp += R(i,m) * R(j,n) * R(k,o) * R(l,p) * old._vals[m][n][o][p];
 
           _vals[i][j][k][l] = temp;
         }
@@ -391,21 +389,20 @@ RankFourTensor::rotate(RealTensorValue &R)
 void
 RankFourTensor::print() const
 {
-  const RankFourTensor & s = (*this);
+  const RankFourTensor & s = *this;
 
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
     {
       Moose::out << "i = " << i << " j = " << j << std::endl;
-      for (unsigned int k=0; k<N; k++)
+      for (unsigned int k = 0; k < N; ++k)
       {
-        for (unsigned int l=0; l<N; l++)
+        for (unsigned int l = 0; l < N; ++l)
           Moose::out << std::setw(15) << s(i,j,k,l) << " ";
 
-        Moose::out <<std::endl;
+        Moose::out << std::endl;
       }
     }
-
 }
 
 RankFourTensor
@@ -417,18 +414,18 @@ RankFourTensor::transposeMajor() const
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
-          result(i,j,k,l)=_vals[k][l][i][j];
+          result(i,j,k,l) = _vals[k][l][i][j];
 
   return result;
 }
 
 void
-RankFourTensor::surfaceFillFromInputVector(const std::vector<Real> input)
+RankFourTensor::surfaceFillFromInputVector(const std::vector<Real> &input)
 {
+  zero();
+
   if (input.size() == 9)
   {
-    this->zero();
-
     //then fill from vector C_1111, C_1112, C_1122, C_1212, C_1222, C_1211, C_2211, C_2212, C_2222
     _vals[0][0][0][0] = input[0];
     _vals[0][0][0][1] = input[1];
@@ -449,27 +446,25 @@ RankFourTensor::surfaceFillFromInputVector(const std::vector<Real> input)
     _vals[1][0][0][0] = _vals[0][1][0][0];
     _vals[1][1][1][0] = _vals[1][1][0][1];
   }
+  else if (input.size() == 2)
+  {
+    // only two independent constants, C_1111 and C_1122
+    _vals[0][0][0][0] = input[0];
+    _vals[0][0][1][1] = input[1];
+    //use symmetries
+    _vals[1][1][1][1] = _vals[0][0][0][0];
+    _vals[1][1][0][0] = _vals[0][0][1][1];
+    _vals[0][1][0][1] = 0.5 * (_vals[0][0][0][0] - _vals[0][0][1][1]);
+    _vals[1][0][0][1] = _vals[0][1][0][1];
+    _vals[0][1][1][0] = _vals[0][1][0][1];
+    _vals[1][0][1][0] = _vals[0][1][0][1];
+  }
   else
-    if (input.size() == 2)
-    {
-      this ->zero();
-      // only two independent constants, C_1111 and C_1122
-      _vals[0][0][0][0] = input[0];
-      _vals[0][0][1][1] = input[1];
-      //use symmetries
-      _vals[1][1][1][1] = _vals[0][0][0][0];
-      _vals[1][1][0][0] = _vals[0][0][1][1];
-      _vals[0][1][0][1] = 0.5 * (_vals[0][0][0][0] - _vals[0][0][1][1]);
-      _vals[1][0][0][1] = _vals[0][1][0][1];
-      _vals[0][1][1][0] = _vals[0][1][0][1];
-      _vals[1][0][1][0] = _vals[0][1][0][1];
-    }
-    else
-      mooseError("Please provide correct number of inputs for surface RankFourTensor initialization.");
+    mooseError("Please provide correct number of inputs for surface RankFourTensor initialization.");
 }
 
 void
-RankFourTensor::fillFromInputVector(const std::vector<Real> input, FillMethod fill_method)
+RankFourTensor::fillFromInputVector(const std::vector<Real> &input, FillMethod fill_method)
 {
   zero();
 
@@ -505,9 +500,9 @@ int
 RankFourTensor::MatrixInversion(double* A, int n) const
 {
   int return_value, buffer_size;
-  int *ipiv,*buffer;
+  int *ipiv, *buffer;
 
-  buffer_size=n*64;
+  buffer_size = n * 64;
 
   ipiv = (int*)calloc(n, sizeof(int));
   buffer = (int*)calloc(buffer_size, sizeof(int));
@@ -534,7 +529,7 @@ RankFourTensor::MatrixInversion(double* A, int n) const
 }
 
 void
-RankFourTensor::fillSymmetricFromInputVector(const std::vector<Real> input, bool all)
+RankFourTensor::fillSymmetricFromInputVector(const std::vector<Real> &input, bool all)
 {
   if ((all == true && input.size() != 21) || (all == false && input.size() != 9 ))
     mooseError("Please check the number of entries in the stiffness input vector.");
@@ -589,16 +584,16 @@ RankFourTensor::fillSymmetricFromInputVector(const std::vector<Real> input, bool
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
           _vals[i][j][l][k] =
-            _vals[j][i][k][l] =
-            _vals[j][i][l][k] =
-            _vals[k][l][i][j] =
-            _vals[l][k][j][i] =
-            _vals[k][l][j][i] =
-            _vals[l][k][i][j] = _vals[i][j][k][l];
+          _vals[j][i][k][l] =
+          _vals[j][i][l][k] =
+          _vals[k][l][i][j] =
+          _vals[l][k][j][i] =
+          _vals[k][l][j][i] =
+          _vals[l][k][i][j] = _vals[i][j][k][l];
 }
 
 void
-RankFourTensor::fillAntisymmetricFromInputVector(const std::vector<Real> input)
+RankFourTensor::fillAntisymmetricFromInputVector(const std::vector<Real> &input)
 {
   if (input.size() != 6)
     mooseError("To use fillAntisymmetricFromInputVector, your input must have size 6.  Yours has size " << input.size());
@@ -641,7 +636,7 @@ RankFourTensor::fillAntisymmetricFromInputVector(const std::vector<Real> input)
 }
 
 void
-RankFourTensor::fillGeneralIsotropicFromInputVector(const std::vector<Real> input)
+RankFourTensor::fillGeneralIsotropicFromInputVector(const std::vector<Real> &input)
 {
   if (input.size() != 3)
     mooseError("To use fillGeneralIsotropicFromInputVector, your input must have size 3.  Yours has size " << input.size());
@@ -653,17 +648,17 @@ RankFourTensor::fillGeneralIsotropicFromInputVector(const std::vector<Real> inpu
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
         {
-          _vals[i][j][k][l] = input[0]*(i==j)*(k==l) + input[1]*(i==k)*(j==l) + input[1]*(i==l)*(j==k);
-          for (unsigned int m = 0 ; m < N ; m++)
-            _vals[i][j][k][l] += input[2]*PermutationTensor::eps(i, j, m)*PermutationTensor::eps(k, l, m);
+          _vals[i][j][k][l] = input[0] * (i==j) * (k==l) + input[1] * (i==k) * (j==l) + input[1] * (i==l) * (j==k);
+          for (unsigned int m = 0 ; m < N ; ++m)
+            _vals[i][j][k][l] += input[2] * PermutationTensor::eps(i, j, m) * PermutationTensor::eps(k, l, m);
         }
 }
 
 void
-RankFourTensor::fillAntisymmetricIsotropicFromInputVector(const std::vector<Real> input)
+RankFourTensor::fillAntisymmetricIsotropicFromInputVector(const std::vector<Real> &input)
 {
   if (input.size() != 1)
-    mooseError("To use fillAntisymmetricIsotropicFromInputVector, your input must have size 1.  Yours has size " << input.size());
+    mooseError("To use fillAntisymmetricIsotropicFromInputVector, your input must have size 1. Yours has size " << input.size());
   std::vector<Real> input3;
   input3.push_back(0);
   input3.push_back(0);
@@ -672,10 +667,10 @@ RankFourTensor::fillAntisymmetricIsotropicFromInputVector(const std::vector<Real
 }
 
 void
-RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> input)
+RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> &input)
 {
   if (input.size() != 2)
-    mooseError("To use fillSymmetricIsotropicFromInputVector, your input must have size 2.  Yours has size " << input.size());
+    mooseError("To use fillSymmetricIsotropicFromInputVector, your input must have size 2. Yours has size " << input.size());
   std::vector<Real> input3;
   input3.push_back(input[0]);
   input3.push_back(input[1]);
@@ -684,10 +679,10 @@ RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> in
 }
 
 void
-RankFourTensor::fillGeneralFromInputVector(const std::vector<Real> input)
+RankFourTensor::fillGeneralFromInputVector(const std::vector<Real> &input)
 {
   if (input.size() != 81)
-    mooseError("To use fillGeneralFromInputVector, your input must have size 81.  Yours has size " << input.size());
+    mooseError("To use fillGeneralFromInputVector, your input must have size 81. Yours has size " << input.size());
 
   zero();
 
@@ -697,7 +692,7 @@ RankFourTensor::fillGeneralFromInputVector(const std::vector<Real> input)
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
         {
-          ind = i*N*N*N + j*N*N + k*N + l;
+          ind = i * N*N*N + j * N*N + k * N + l;
           _vals[i][j][k][l] = input[ind];
         }
 }

--- a/modules/tensor_mechanics/src/utils/RankFourTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankFourTensor.C
@@ -46,34 +46,22 @@ RankFourTensor::operator()(unsigned int i, unsigned int j, unsigned int k, unsig
 }
 
 void
-RankFourTensor::setValue(Real val, unsigned int i, unsigned int j, unsigned int k, unsigned int l)
-{
-  _vals[i-1][j-1][k-1][l-1] = val; //Note, indcies go from 1 to 3
-}
-
-Real
-RankFourTensor::getValue(unsigned int i, unsigned int j, unsigned int k, unsigned int l) const
-{
-  return _vals[i-1][j-1][k-1][l-1];//Note, indcies go from 1 to 3
-}
-
-void
 RankFourTensor::zero()
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           _vals[i][j][k][l] = 0.0;
 }
 
 RankFourTensor &
 RankFourTensor::operator= (const RankFourTensor &a)
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           _vals[i][j][k][l] = a._vals[i][j][k][l];
 
   return *this;
@@ -84,11 +72,11 @@ RankFourTensor::operator* (const RankTwoTensor &a) const
 {
   RealTensorValue result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
-          result(i,j) += _vals[i][j][k][l]*a(k,l);
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
+          result(i,j) += _vals[i][j][k][l] * a(k,l);
 
   return result;
 }
@@ -98,11 +86,11 @@ RankFourTensor::operator* (const RealTensorValue &a) const
 {
   RealTensorValue result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
-          result(i,j) += _vals[i][j][k][l]*a(k,l);
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
+          result(i,j) += _vals[i][j][k][l] * a(k,l);
 
   return result;
 }
@@ -112,11 +100,11 @@ RankFourTensor::operator* (const Real &a) const
 {
   RankFourTensor result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
-          result(i,j,k,l) = _vals[i][j][k][l]*a;
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
+          result(i,j,k,l) = _vals[i][j][k][l] * a;
 
   return result;
 }
@@ -124,11 +112,11 @@ RankFourTensor::operator* (const Real &a) const
 RankFourTensor &
 RankFourTensor::operator*= (const Real &a)
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
-          _vals[i][j][k][l] = _vals[i][j][k][l]*a;
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
+          _vals[i][j][k][l] = _vals[i][j][k][l] * a;
 
   return *this;
 }
@@ -138,11 +126,11 @@ RankFourTensor::operator/ (const Real &a) const
 {
   RankFourTensor result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
-          result(i,j,k,l) = _vals[i][j][k][l]/a;
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
+          result(i,j,k,l) = _vals[i][j][k][l] / a;
 
   return result;
 }
@@ -150,11 +138,11 @@ RankFourTensor::operator/ (const Real &a) const
 RankFourTensor &
 RankFourTensor::operator/=(const Real &a)
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
-          _vals[i][j][k][l] = _vals[i][j][k][l]/a;
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
+          _vals[i][j][k][l] = _vals[i][j][k][l] / a;
 
   return *this;
 }
@@ -162,10 +150,10 @@ RankFourTensor::operator/=(const Real &a)
 RankFourTensor &
 RankFourTensor::operator+=(const RankFourTensor &a)
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           _vals[i][j][k][l] = _vals[i][j][k][l] + a(i,j,k,l);
 
   return *this;
@@ -176,10 +164,10 @@ RankFourTensor::operator+(const RankFourTensor &a) const
 {
   RankFourTensor result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           result(i,j,k,l) = _vals[i][j][k][l] + a(i,j,k,l);
 
   return result;
@@ -188,10 +176,10 @@ RankFourTensor::operator+(const RankFourTensor &a) const
 RankFourTensor &
 RankFourTensor::operator-=(const RankFourTensor &a)
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           _vals[i][j][k][l] = _vals[i][j][k][l] - a(i,j,k,l);
 
   return *this;
@@ -202,10 +190,10 @@ RankFourTensor::operator-(const RankFourTensor &a) const
 {
   RankFourTensor result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           result(i,j,k,l) = _vals[i][j][k][l] - a(i,j,k,l);
 
   return result;
@@ -216,10 +204,10 @@ RankFourTensor::operator-() const
 {
   RankFourTensor result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N;k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           result(i,j,k,l) = -_vals[i][j][k][l];
 
   return result;
@@ -231,13 +219,13 @@ RankFourTensor::operator*(const RankFourTensor &a) const
   RankFourTensor result;
 
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
-          for (unsigned int p(0); p<N; p++)
-            for (unsigned int q(0); q<N; q++)
-              result(i,j,k,l) += _vals[i][j][p][q]*a(p,q,k,l);
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
+          for (unsigned int p = 0; p < N; ++p)
+            for (unsigned int q = 0; q < N; ++q)
+              result(i,j,k,l) += _vals[i][j][p][q] * a(p,q,k,l);
 
   return result;
 }
@@ -319,10 +307,10 @@ RankFourTensor::invSymm() const
   // mat[34] = C(1,2,0,2)*2
   // mat[35] = C(1,2,1,2)*2
   mat=(double*)calloc(ntens*ntens, sizeof(double));
-  for (unsigned int i = 0; i < N; i++)
-    for (unsigned int j = 0; j < N; j++)
-      for (unsigned int k = 0; k < N; k++)
-        for (unsigned int l = 0; l < N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
         {
           if (i==j)
           {
@@ -352,10 +340,10 @@ RankFourTensor::invSymm() const
 
   // build the resulting rank-four tensor
   // using the inverse of the above algorithm
-  for (unsigned int i = 0; i < N; i++)
-    for (unsigned int j = 0; j < N; j++)
-      for (unsigned int k = 0; k < N; k++)
-        for (unsigned int l = 0; l < N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
         {
           if (i==j)
           {
@@ -384,16 +372,16 @@ RankFourTensor::rotate(RealTensorValue &R)
   RankFourTensor old;
   old=*this;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
         {
           temp = 0.0;
-          for (unsigned int m(0); m<N; m++)
-            for (unsigned int n(0); n<N; n++)
-              for (unsigned int o(0); o<N; o++)
-                for (unsigned int p(0); p<N; p++)
+          for (unsigned int m = 0; m < N; ++m)
+            for (unsigned int n = 0; n < N; ++n)
+              for (unsigned int o = 0; o < N; ++o)
+                for (unsigned int p = 0; p < N; ++p)
                   temp += R(i,m)*R(j,n)*R(k,o)*R(l,p)*old._vals[m][n][o][p];
 
           _vals[i][j][k][l] = temp;
@@ -405,8 +393,8 @@ RankFourTensor::print() const
 {
   const RankFourTensor & s = (*this);
 
-  for (unsigned int i=0; i<N; i++)
-    for (unsigned int j=0; j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
     {
       Moose::out << "i = " << i << " j = " << j << std::endl;
       for (unsigned int k=0; k<N; k++)
@@ -425,10 +413,10 @@ RankFourTensor::transposeMajor() const
 {
   RankFourTensor result;
 
-  for (unsigned int i = 0; i < 3; i++)
-    for (unsigned int j = 0; j < 3; j++)
-      for (unsigned int k = 0; k < 3; k++)
-        for (unsigned int l = 0; l < 3; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           result(i,j,k,l)=_vals[k][l][i][j];
 
   return result;
@@ -442,39 +430,39 @@ RankFourTensor::surfaceFillFromInputVector(const std::vector<Real> input)
     this->zero();
 
     //then fill from vector C_1111, C_1112, C_1122, C_1212, C_1222, C_1211, C_2211, C_2212, C_2222
-    _vals[0][0][0][0]=input[0];
-    _vals[0][0][0][1]=input[1];
-    _vals[0][0][1][1]=input[2];
-    _vals[0][1][0][1]=input[3];
-    _vals[0][1][1][1]=input[4];
-    _vals[0][1][0][0]=input[5];
-    _vals[1][1][0][0]=input[6];
-    _vals[1][1][0][1]=input[7];
-    _vals[1][1][1][1]=input[8];
+    _vals[0][0][0][0] = input[0];
+    _vals[0][0][0][1] = input[1];
+    _vals[0][0][1][1] = input[2];
+    _vals[0][1][0][1] = input[3];
+    _vals[0][1][1][1] = input[4];
+    _vals[0][1][0][0] = input[5];
+    _vals[1][1][0][0] = input[6];
+    _vals[1][1][0][1] = input[7];
+    _vals[1][1][1][1] = input[8];
 
     // fill in remainders from C_ijkl = C_ijlk = C_jikl
-    _vals[0][0][1][0]=_vals[0][0][0][1];
-    _vals[0][1][1][0]=_vals[0][1][0][1];
-    _vals[1][0][0][0]=_vals[0][1][0][0];
-    _vals[1][0][0][1]=_vals[0][1][0][1];
-    _vals[1][0][1][1]=_vals[0][1][1][1];
-    _vals[1][0][0][0]=_vals[0][1][0][0];
-    _vals[1][1][1][0]=_vals[1][1][0][1];
+    _vals[0][0][1][0] = _vals[0][0][0][1];
+    _vals[0][1][1][0] = _vals[0][1][0][1];
+    _vals[1][0][0][0] = _vals[0][1][0][0];
+    _vals[1][0][0][1] = _vals[0][1][0][1];
+    _vals[1][0][1][1] = _vals[0][1][1][1];
+    _vals[1][0][0][0] = _vals[0][1][0][0];
+    _vals[1][1][1][0] = _vals[1][1][0][1];
   }
   else
     if (input.size() == 2)
     {
       this ->zero();
       // only two independent constants, C_1111 and C_1122
-      _vals[0][0][0][0]=input[0];
-      _vals[0][0][1][1]=input[1];
+      _vals[0][0][0][0] = input[0];
+      _vals[0][0][1][1] = input[1];
       //use symmetries
-      _vals[1][1][1][1]=_vals[0][0][0][0];
-      _vals[1][1][0][0]=_vals[0][0][1][1];
-      _vals[0][1][0][1]=0.5*(_vals[0][0][0][0]-_vals[0][0][1][1]);
-      _vals[1][0][0][1]=_vals[0][1][0][1];
-      _vals[0][1][1][0]=_vals[0][1][0][1];
-      _vals[1][0][1][0]=_vals[0][1][0][1];
+      _vals[1][1][1][1] = _vals[0][0][0][0];
+      _vals[1][1][0][0] = _vals[0][0][1][1];
+      _vals[0][1][0][1] = 0.5 * (_vals[0][0][0][0] - _vals[0][0][1][1]);
+      _vals[1][0][0][1] = _vals[0][1][0][1];
+      _vals[0][1][1][0] = _vals[0][1][0][1];
+      _vals[1][0][1][0] = _vals[0][1][0][1];
     }
     else
       mooseError("Please provide correct number of inputs for surface RankFourTensor initialization.");
@@ -596,10 +584,10 @@ RankFourTensor::fillSymmetricFromInputVector(const std::vector<Real> input, bool
   }
 
   //fill in from symmetry relations
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        for (unsigned int l(0); l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
           _vals[i][j][l][k] =
             _vals[j][i][k][l] =
             _vals[j][i][l][k] =
@@ -633,8 +621,8 @@ RankFourTensor::fillAntisymmetricFromInputVector(const std::vector<Real> input)
   // have now got the upper parts of vals[0][1], vals[0][2] and vals[1][2]
 
   // fill in from antisymmetry relations
-  for (unsigned int i = 0; i < N - 1 ; i++)
-    for (unsigned int j = i + 1 ; j < N ; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
     {
       _vals[0][1][j][i] = -_vals[0][1][i][j];
       _vals[0][2][j][i] = -_vals[0][2][i][j];
@@ -643,8 +631,8 @@ RankFourTensor::fillAntisymmetricFromInputVector(const std::vector<Real> input)
   // have now got all of vals[0][1], vals[0][2] and vals[1][2]
 
   // fill in from antisymmetry relations
-  for (unsigned int i = 0; i < N ; i++)
-    for (unsigned int j = 0 ; j < N ; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
     {
       _vals[1][0][i][j] = -_vals[0][1][i][j];
       _vals[2][0][i][j] = -_vals[0][2][i][j];
@@ -660,10 +648,10 @@ RankFourTensor::fillGeneralIsotropicFromInputVector(const std::vector<Real> inpu
 
   zero();
 
-  for (unsigned int i=0; i<N; i++)
-    for (unsigned int j=0; j<N; j++)
-      for (unsigned int k=0; k<N; k++)
-        for (unsigned int l=0; l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
         {
           _vals[i][j][k][l] = input[0]*(i==j)*(k==l) + input[1]*(i==k)*(j==l) + input[1]*(i==l)*(j==k);
           for (unsigned int m = 0 ; m < N ; m++)
@@ -704,10 +692,10 @@ RankFourTensor::fillGeneralFromInputVector(const std::vector<Real> input)
   zero();
 
   int ind;
-  for (unsigned int i=0; i<N; i++)
-    for (unsigned int j=0; j<N; j++)
-      for (unsigned int k=0; k<N; k++)
-        for (unsigned int l=0; l<N; l++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
         {
           ind = i*N*N*N + j*N*N + k*N + l;
           _vals[i][j][k][l] = input[ind];

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -113,25 +113,14 @@ RankTwoTensor::fillFromInputVector(const std::vector<Real> & input)
     mooseError("Please check the number of entries in the eigenstrain input vector.  It must be 6 or 9");
 }
 
-void
-RankTwoTensor::setValue(Real val, unsigned int i, unsigned int j)
-{
-  _vals[i-1][j-1] = val;
-}
-
-Real
-RankTwoTensor::getValue(unsigned int i, unsigned int j) const
-{
-  return _vals[i-1][j-1];
-}
-
-
 TypeVector<Real>
 RankTwoTensor::row(const unsigned int r) const
 {
   RealVectorValue result;
+
   for (unsigned int i = 0; i < N; i++)
     result(i) = _vals[r][i];
+
   return result;
 }
 
@@ -160,9 +149,9 @@ RankTwoTensor::rotate(RankTwoTensor &R)
       temp = 0.0;
       for (unsigned int k = 0; k < N; k++)
         for (unsigned int l = 0; l < N; l++)
-          temp += R(i,k)*R(j,l)*_vals[k][l];
+          temp += R(i,k) * R(j,l) * _vals[k][l];
       _vals[i][j] = temp;
- }
+    }
 }
 
 RankTwoTensor
@@ -174,17 +163,11 @@ RankTwoTensor::rotateXyPlane(Real a)
   Real y = _vals[0][0]*s*s + _vals[1][1]*c*c - 2.0*_vals[0][1]*c*s;
   Real xy = (_vals[1][1] - _vals[0][0])*c*s + _vals[0][1]*(c*c - s*s);
 
-  RankTwoTensor b;
+  RankTwoTensor b(*this);
 
-  b.setValue(x, 1, 1);
-  b.setValue(y, 2, 2);
-  b.setValue(xy, 1, 2);
-  b.setValue(xy, 2, 1);
-  b.setValue(_vals[0][2], 1, 3);
-  b.setValue(_vals[2][0], 3, 1);
-  b.setValue(_vals[1][2], 2, 3);
-  b.setValue(_vals[2][1], 3, 2);
-  b.setValue(_vals[2][2], 3, 3);
+  b(0,0) = x;
+  b(1,1) = y;
+  b(1,0) = b(0,1) = xy;
 
   return b;
 }
@@ -193,27 +176,31 @@ RankTwoTensor
 RankTwoTensor::transpose() const
 {
   RankTwoTensor result;
-  for (unsigned int i=0; i<N; i++)
-    for (unsigned int j=0; j<N; j++)
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       result(i,j) = _vals[j][i];
+
   return result;
 }
 
 RankTwoTensor &
 RankTwoTensor::operator= (const RankTwoTensor &a)
 {
-  for (unsigned int i(0); i<N; i++)
-      for (unsigned int j(0); j<N; j++)
-        _vals[i][j] = a._vals[i][j];
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      _vals[i][j] = a._vals[i][j];
+
   return *this;
 }
 
 RankTwoTensor &
 RankTwoTensor::operator+=(const RankTwoTensor &a)
 {
-   for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       _vals[i][j] += a(i,j);
+
   return *this;
 }
 
@@ -221,18 +208,21 @@ RankTwoTensor
 RankTwoTensor::operator+ (const RankTwoTensor &a) const
 {
   RankTwoTensor result;
-   for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       result(i,j) = _vals[i][j] + a(i,j);
-   return result;
+
+  return result;
 }
 
 RankTwoTensor &
 RankTwoTensor::operator-=(const RankTwoTensor &a)
 {
-   for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       _vals[i][j] -= a(i,j);
+
   return *this;
 }
 
@@ -241,19 +231,19 @@ RankTwoTensor::operator- (const RankTwoTensor &a) const
 {
   RankTwoTensor result;
 
-   for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       result(i,j) = _vals[i][j] - a(i,j);
-   return result;
+
+  return result;
 }
 
 RankTwoTensor
 RankTwoTensor::operator - () const
 {
   RankTwoTensor result;
-
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       result(i,j) = -_vals[i][j];
 
   return result;
@@ -262,8 +252,8 @@ RankTwoTensor::operator - () const
 RankTwoTensor &
 RankTwoTensor::operator*=(const Real &a)
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       _vals[i][j] *= a;
 
   return *this;
@@ -274,8 +264,8 @@ RankTwoTensor::operator*(const Real &a) const
 {
   RankTwoTensor result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       result(i,j) = _vals[i][j]*a;
 
   return result;
@@ -284,8 +274,8 @@ RankTwoTensor::operator*(const Real &a) const
 RankTwoTensor &
 RankTwoTensor::operator/=(const Real &a)
 {
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       _vals[i][j] /= a;
 
   return *this;
@@ -296,9 +286,9 @@ RankTwoTensor::operator/(const Real &a) const
 {
   RankTwoTensor result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      result(i,j) = _vals[i][j]/a;
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      result(i,j) = _vals[i][j] / a;
 
   return result;
 }
@@ -306,12 +296,13 @@ RankTwoTensor::operator/(const Real &a) const
 RankTwoTensor &
 RankTwoTensor::operator*=(const RankTwoTensor &a)
 {
-  RankTwoTensor & s = (*this);
+  RankTwoTensor s(*this);
+  this->zero();
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        _vals[i][j] += s(i,j)*a(j,k);
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        _vals[i][k] += s(i,j) * a(j,k);
 
   return *this;
 }
@@ -320,12 +311,10 @@ RankTwoTensor
 RankTwoTensor::operator*(const RankTwoTensor &a) const
 {
   RankTwoTensor result;
-
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        result(i,k) += _vals[i][j]*a(j,k);
-
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        result(i,k) += _vals[i][j] * a(j,k);
   return result;
 }
 
@@ -334,10 +323,10 @@ RankTwoTensor::operator*(const TypeTensor<Real> &a) const
 {
   RankTwoTensor result;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
-      for (unsigned int k(0); k<N; k++)
-        result(i,k) += _vals[i][j]*a(j,k);
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        result(i,k) += _vals[i][j] * a(j,k);
 
   return result;
 }
@@ -345,10 +334,10 @@ RankTwoTensor::operator*(const TypeTensor<Real> &a) const
 Real
 RankTwoTensor::doubleContraction(const RankTwoTensor &a)
 {
-  Real result(0.0);
+  Real result = 0.0;
 
-  for (unsigned int i(0); i<N; i++)
-    for (unsigned int j(0); j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       result += _vals[i][j]* a(i,j);
 
   return result;
@@ -365,7 +354,7 @@ RankTwoTensor::deviatoric() const
 Real
 RankTwoTensor::secondInvariant() const
 {
-  Real result(0.0);
+  Real result = 0.0;
   RankTwoTensor deviatoric(*this);
   deviatoric.addIa(-1.0/3.0 * trace()); // actually construct deviatoric part
   result = 0.5 * deviatoric.doubleContraction(deviatoric);
@@ -382,20 +371,22 @@ RankTwoTensor::dsecondInvariant() const
 Real
 RankTwoTensor::trace() const
 {
-  Real result(0.0);
-  for (unsigned int i(0); i<N; i++)
+  Real result = 0.0;
+
+  for (unsigned int i = 0; i < N; ++i)
       result += _vals[i][i];
+
   return result;
 }
 
 Real
 RankTwoTensor::det() const
 {
-  Real result(0.0);
+  Real result = 0.0;
 
-  result = _vals[0][0]*(_vals[1][1]*_vals[2][2] - _vals[2][1]*_vals[1][2]);
-  result -= _vals[1][0]*(_vals[0][1]*_vals[2][2] - _vals[2][1]*_vals[0][2]);
-  result += _vals[2][0]*(_vals[0][1]*_vals[1][2] - _vals[1][1]*_vals[0][2]);
+  result =  _vals[0][0] * (_vals[1][1] * _vals[2][2] - _vals[2][1] * _vals[1][2]);
+  result -= _vals[1][0] * (_vals[0][1] * _vals[2][2] - _vals[2][1] * _vals[0][2]);
+  result += _vals[2][0] * (_vals[0][1] * _vals[1][2] - _vals[1][1] * _vals[0][2]);
 
   return result;
 }
@@ -405,15 +396,15 @@ RankTwoTensor::inverse() const
 {
   RankTwoTensor result;
 
-  result(0,0) = _vals[1][1]*_vals[2][2] - _vals[2][1]*_vals[1][2];
-  result(0,1) = _vals[0][2]*_vals[2][1] - _vals[0][1]*_vals[2][2];
-  result(0,2) = _vals[0][1]*_vals[1][2] - _vals[0][2]*_vals[1][1];
-  result(1,0) = _vals[1][2]*_vals[2][0] - _vals[1][0]*_vals[2][2];
-  result(1,1) = _vals[0][0]*_vals[2][2] - _vals[0][2]*_vals[2][0];
-  result(1,2) = _vals[0][2]*_vals[1][0] - _vals[0][0]*_vals[1][2];
-  result(2,0) = _vals[1][0]*_vals[2][1] - _vals[1][1]*_vals[2][0];
-  result(2,1) = _vals[0][1]*_vals[2][0] - _vals[0][0]*_vals[2][1];
-  result(2,2) = _vals[0][0]*_vals[1][1] - _vals[0][1]*_vals[1][0];
+  result(0,0) = _vals[1][1] * _vals[2][2] - _vals[2][1] * _vals[1][2];
+  result(0,1) = _vals[0][2] * _vals[2][1] - _vals[0][1] * _vals[2][2];
+  result(0,2) = _vals[0][1] * _vals[1][2] - _vals[0][2] * _vals[1][1];
+  result(1,0) = _vals[1][2] * _vals[2][0] - _vals[1][0] * _vals[2][2];
+  result(1,1) = _vals[0][0] * _vals[2][2] - _vals[0][2] * _vals[2][0];
+  result(1,2) = _vals[0][2] * _vals[1][0] - _vals[0][0] * _vals[1][2];
+  result(2,0) = _vals[1][0] * _vals[2][1] - _vals[1][1] * _vals[2][0];
+  result(2,1) = _vals[0][1] * _vals[2][0] - _vals[0][0] * _vals[2][1];
+  result(2,2) = _vals[0][0] * _vals[1][1] - _vals[0][1] * _vals[1][0];
 
   Real det = (*this).det();
 
@@ -428,10 +419,10 @@ RankTwoTensor::inverse() const
 void
 RankTwoTensor::print() const
 {
-  for (unsigned int i=0; i<N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j=0; j<N; j++)
-      Moose::out << std::setw(15) <<_vals[i][j]<<" ";
+    for (unsigned int j = 0; j < N; ++j)
+      Moose::out << std::setw(15) << _vals[i][j] << ' ';
     Moose::out <<std::endl;
   }
 }
@@ -439,7 +430,7 @@ RankTwoTensor::print() const
 void
 RankTwoTensor::addIa(const Real &a)
 {
-  for (unsigned int i=0; i<N; i++)
+  for (unsigned int i = 0; i < N; ++i)
     _vals[i][i] += a;
 }
 
@@ -448,8 +439,8 @@ RankTwoTensor::L2norm() const
 {
   Real norm = 0.0;
 
-  for (unsigned int i=0; i<N; i++)
-    for (unsigned int j=0; j<N; j++)
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
       norm += _vals[i][j] * _vals[i][j];
 
   norm = std::sqrt(norm);

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -27,12 +27,12 @@ RankTwoTensor::RankTwoTensor(const TypeVector<Real> & row1, const TypeVector<Rea
     _vals[2][i] = row3(i);
 }
 
-RankTwoTensor::RankTwoTensor(const RankTwoTensor &a)
+RankTwoTensor::RankTwoTensor(const RankTwoTensor & a)
 {
   *this = a;
 }
 
-RankTwoTensor::RankTwoTensor(const TypeTensor<Real> &a)
+RankTwoTensor::RankTwoTensor(const TypeTensor<Real> & a)
 {
   for (unsigned int i(0); i<N; i++)
     for (unsigned int j(0); j<N; j++)
@@ -125,7 +125,7 @@ RankTwoTensor::row(const unsigned int r) const
 }
 
 void
-RankTwoTensor::rotate(RealTensorValue &R)
+RankTwoTensor::rotate(RealTensorValue & R)
 {
   Real temp;
   for (unsigned int i = 0; i < N; i++)
@@ -140,7 +140,7 @@ RankTwoTensor::rotate(RealTensorValue &R)
 }
 
 void
-RankTwoTensor::rotate(RankTwoTensor &R)
+RankTwoTensor::rotate(RankTwoTensor & R)
 {
   Real temp;
   for (unsigned int i = 0; i < N; i++)
@@ -185,7 +185,7 @@ RankTwoTensor::transpose() const
 }
 
 RankTwoTensor &
-RankTwoTensor::operator= (const RankTwoTensor &a)
+RankTwoTensor::operator= (const RankTwoTensor & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -195,7 +195,7 @@ RankTwoTensor::operator= (const RankTwoTensor &a)
 }
 
 RankTwoTensor &
-RankTwoTensor::operator+=(const RankTwoTensor &a)
+RankTwoTensor::operator+=(const RankTwoTensor & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -205,7 +205,7 @@ RankTwoTensor::operator+=(const RankTwoTensor &a)
 }
 
 RankTwoTensor
-RankTwoTensor::operator+ (const RankTwoTensor &a) const
+RankTwoTensor::operator+ (const RankTwoTensor & a) const
 {
   RankTwoTensor result;
 
@@ -217,7 +217,7 @@ RankTwoTensor::operator+ (const RankTwoTensor &a) const
 }
 
 RankTwoTensor &
-RankTwoTensor::operator-=(const RankTwoTensor &a)
+RankTwoTensor::operator-=(const RankTwoTensor & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -227,7 +227,7 @@ RankTwoTensor::operator-=(const RankTwoTensor &a)
 }
 
 RankTwoTensor
-RankTwoTensor::operator- (const RankTwoTensor &a) const
+RankTwoTensor::operator- (const RankTwoTensor & a) const
 {
   RankTwoTensor result;
 
@@ -250,7 +250,7 @@ RankTwoTensor::operator - () const
 }
 
 RankTwoTensor &
-RankTwoTensor::operator*=(const Real &a)
+RankTwoTensor::operator*=(const Real & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -260,7 +260,7 @@ RankTwoTensor::operator*=(const Real &a)
 }
 
 RankTwoTensor
-RankTwoTensor::operator*(const Real &a) const
+RankTwoTensor::operator*(const Real & a) const
 {
   RankTwoTensor result;
 
@@ -272,7 +272,7 @@ RankTwoTensor::operator*(const Real &a) const
 }
 
 RankTwoTensor &
-RankTwoTensor::operator/=(const Real &a)
+RankTwoTensor::operator/=(const Real & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -282,7 +282,7 @@ RankTwoTensor::operator/=(const Real &a)
 }
 
 RankTwoTensor
-RankTwoTensor::operator/(const Real &a) const
+RankTwoTensor::operator/(const Real & a) const
 {
   RankTwoTensor result;
 
@@ -294,7 +294,7 @@ RankTwoTensor::operator/(const Real &a) const
 }
 
 RankTwoTensor &
-RankTwoTensor::operator*=(const RankTwoTensor &a)
+RankTwoTensor::operator*=(const RankTwoTensor & a)
 {
   RankTwoTensor s(*this);
   this->zero();
@@ -308,7 +308,7 @@ RankTwoTensor::operator*=(const RankTwoTensor &a)
 }
 
 RankTwoTensor
-RankTwoTensor::operator*(const RankTwoTensor &a) const
+RankTwoTensor::operator*(const RankTwoTensor & a) const
 {
   RankTwoTensor result;
   for (unsigned int i = 0; i < N; ++i)
@@ -319,7 +319,7 @@ RankTwoTensor::operator*(const RankTwoTensor &a) const
 }
 
 RankTwoTensor
-RankTwoTensor::operator*(const TypeTensor<Real> &a) const
+RankTwoTensor::operator*(const TypeTensor<Real> & a) const
 {
   RankTwoTensor result;
 
@@ -332,7 +332,7 @@ RankTwoTensor::operator*(const TypeTensor<Real> &a) const
 }
 
 Real
-RankTwoTensor::doubleContraction(const RankTwoTensor &a)
+RankTwoTensor::doubleContraction(const RankTwoTensor & a)
 {
   Real result = 0.0;
 
@@ -428,7 +428,7 @@ RankTwoTensor::print() const
 }
 
 void
-RankTwoTensor::addIa(const Real &a)
+RankTwoTensor::addIa(const Real & a)
 {
   for (unsigned int i = 0; i < N; ++i)
     _vals[i][i] += a;
@@ -448,7 +448,7 @@ RankTwoTensor::L2norm() const
 }
 
 void
-RankTwoTensor::surfaceFillFromInputVector(const std::vector<Real> &input)
+RankTwoTensor::surfaceFillFromInputVector(const std::vector<Real> & input)
 {
   if (input.size() == 4)
   {

--- a/modules/tensor_mechanics/tests/j2_plasticity/tensor_mechanics_j2plasticity.i
+++ b/modules/tensor_mechanics/tests/j2_plasticity/tensor_mechanics_j2plasticity.i
@@ -151,29 +151,29 @@
     type = RankTwoAux
     rank_two_tensor = stress
     variable = stress_zz
-    index_i = 3
-    index_j = 3
+    index_i = 2
+    index_j = 2
   [../]
   [./pe11]
     type = RankTwoAux
     rank_two_tensor = plastic_strain
     variable = pe11
-    index_i = 1
-    index_j = 1
+    index_i = 0
+    index_j = 0
   [../]
     [./pe22]
     type = RankTwoAux
     rank_two_tensor = plastic_strain
     variable = pe22
-    index_i = 2
-    index_j = 2
+    index_i = 1
+    index_j = 1
   [../]
   [./pe33]
     type = RankTwoAux
     rank_two_tensor = plastic_strain
     variable = pe33
-    index_i = 3
-    index_j = 3
+    index_i = 2
+    index_j = 2
   [../]
   [./eqv_plastic_strain]
     type = FiniteStrainPlasticAux


### PR DESCRIPTION
This PR deals with the non standard signature of `setValue` and the non-standard one-based indexing (also in `getValue`) as reported in #3485.

Just changing the signature would probably lead to warnings only (switching `Real` and `unsigned int`). So the first step is making these methods private and see what errors pop up.
