### PR TITLE
Use DerivativeParsedMaterial for CHParsed and SplitCHParsed

### DIFF
--- a/modules/phase_field/include/kernels/CHParsed.h
+++ b/modules/phase_field/include/kernels/CHParsed.h
@@ -2,7 +2,7 @@
 #define CHPARSED_H
 
 #include "CHBulk.h"
-#include "ParsedFreeEnergyInterface.h"
+#include "DerivativeKernelInterface.h"
 
 //Forward Declarations
 class CHParsed;
@@ -11,18 +11,22 @@ template<>
 InputParameters validParams<CHParsed>();
 
 /**
- * CHParsed allows a free energy functionals to be provided as a parsed
- * expression in the input file. It uses automatic differentiation
- * to generate the necessary derivative.
+ * CHParsed uses the Free Energy function and derivatives
+ * provided by a DerivativeParsedMaterial.
  * \see SplitCHParsed
  */
-class CHParsed : public ParsedFreeEnergyInterface<CHBulk>
+class CHParsed : public DerivativeKernelInterface<CHBulk>
 {
 public:
   CHParsed(const std::string & name, InputParameters parameters);
 
 protected:
   virtual RealGradient computeGradDFDCons(PFFunctionType type);
+
+private:
+  std::vector<MaterialProperty<Real>* > _second_derivatives;
+  std::vector<MaterialProperty<Real>* > _third_derivatives;
+  std::vector<VariableGradient *> _grad_vars;
 };
 
 #endif // CHPARSED_H

--- a/modules/phase_field/include/kernels/SplitCHParsed.h
+++ b/modules/phase_field/include/kernels/SplitCHParsed.h
@@ -2,7 +2,7 @@
 #define SPLITCHPARSED_H
 
 #include "SplitCHCRes.h"
-#include "ParsedFreeEnergyInterface.h"
+#include "DerivativeKernelInterface.h"
 
 //Forward Declarations
 class SplitCHParsed;
@@ -11,18 +11,22 @@ template<>
 InputParameters validParams<SplitCHParsed>();
 
 /**
- * SplitCHParsed allows a free energy functionals to be provided as a parsed
- * expression in the input file. It uses automatic differentiation
- * to generate the necessary derivative. This is the split operator variant.
- * \see SplitCHParsed
+ * CHParsed uses the Free Energy function and derivatives
+ * provided by a DerivativeParsedMaterial.
+ * This is the split operator variant.
+ * \see CHParsed
  */
-class SplitCHParsed : public ParsedFreeEnergyInterface<SplitCHCRes>
+class SplitCHParsed : public DerivativeKernelInterface<SplitCHCRes>
 {
 public:
   SplitCHParsed(const std::string & name, InputParameters parameters);
 
 protected:
   virtual Real computeDFDC(PFFunctionType type);
+
+private:
+  MaterialProperty<Real> & _dFdc;
+  MaterialProperty<Real> & _d2Fdc2;
 };
 
 #endif // SPLITCHPARSED_H

--- a/modules/phase_field/include/materials/DerivativeBaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeBaseMaterial.h
@@ -1,0 +1,123 @@
+#ifndef DERIVATIVEBASEMATERIAL_H
+#define DERIVATIVEBASEMATERIAL_H
+
+#include "Material.h"
+#include "DerivativeMaterialInterface.h"
+
+// Forward Declarations
+class DerivativeBaseMaterial;
+
+template<>
+InputParameters validParams<DerivativeBaseMaterial>();
+
+/**
+ * %Material base class central to compute the a phase free energy and
+ * its derivatives. Classes derived from this base class are central to
+ * the KKS system. The calculation of free energies is centralized here
+ * as the results are used in multiple kernels (KKSPhaseChemicalPotential
+ * and \ref KKSCHBulk).
+ *
+ * A DerivativeBaseMaterial provides numerous material properties which contain
+ * the free energy and its derivatives. The material property names are
+ * constructed dynamically by the helper functions propertyNameFirst(),
+ * propertyNameSecond(), and propertyNameThird() in DerivativeMaterialInterface.
+ *
+ * A derived class needs to implement the computeF(), computeDF(),
+ * computeD2F(), and (optionally) computeD3F() methods.
+ *
+ * Note that DerivativeParsedMaterial provides a material for which a mathematical
+ * free energy expression can be provided in the input file (with the
+ * derivatives being calculated automatically).
+ *
+ * \see KKSPhaseChemicalPotential
+ * \see KKSCHBulk
+ * \see DerivativeParsedMaterial
+ * \see DerivativeMaterialInterface
+ */
+class DerivativeBaseMaterial : public DerivativeMaterialInterface<Material>
+{
+public:
+  DerivativeBaseMaterial(const std::string & name, InputParameters parameters);
+
+protected:
+  virtual void computeProperties();
+
+  /**
+   * Override this to return the number of arguments this function expects
+   * (i.e. the number of coupled components)
+   */
+  virtual unsigned int expectedNumArgs() = 0;
+
+  /**
+   * Check if we got the right number of components in the 'args' coupled
+   * variable vector.
+   */
+  virtual void initialSetup();
+
+  /**
+   * Override this method to provide the free energy function.
+   */
+  virtual Real computeF() = 0;
+
+  /**
+   * Override this method for calculating the first derivatives
+   *
+   * @param arg The index of the function argument the derivative is taken of
+   */
+  virtual Real computeDF(unsigned int arg) = 0;
+
+  /**
+   * Override this method to calculate the second derivatives.
+   *
+   * \f$ \frac{d^2F}{dc_{arg1} dc_{arg2}} \f$
+   *
+   * @param arg1 The index of the function argument the first derivative is taken of
+   * @param arg2 The index of the function argument the second derivative is taken of
+   * @Note arg1<=arg2 is guaranteed (deriviatives are symmetric)!
+   */
+  virtual Real computeD2F(unsigned int arg1, unsigned int arg2) = 0;
+
+  /**
+   * Override this method to calculate the third derivatives.
+   *
+   * @Note arg1<=arg2<=arg3 is guaranteed!
+   * @Note The implementation of this method is optional. It is only evaluated when
+   *       the 'third_derivatives' parameter is set to true.
+   */
+  virtual Real computeD3F(unsigned int arg1, unsigned int arg2, unsigned int arg3);
+
+  /// Coupled variables for function arguments
+  std::vector<VariableValue *> _args;
+
+  /**
+   * Name of the function value material property and used as a base name to
+   * concatenate the material property names for the derivatives.
+   */
+  std::string _F_name;
+
+  /**
+   * Number of coupled arguments.
+   * This value is expected to match the the return value of expectedNumArgs()
+   */
+  unsigned int _nargs;
+
+  /// String vector of all argument names.
+  std::vector<std::string> _arg_name;
+
+  /// Calculate (and allocate memory for) the third derivatives of the free energy.
+  bool _third_derivatives;
+
+  /// Material property to store the function value.
+  MaterialProperty<Real> * _prop_F;
+
+  /// Material properties to store the derivatives of f with respect to arg[i]
+  std::vector<MaterialProperty<Real> *> _prop_dF;
+
+  /// Material properties to store the second derivatives.
+  std::vector<std::vector<MaterialProperty<Real> *> > _prop_d2F;
+
+  /// Material properties to store the third derivatives.
+  std::vector<std::vector<std::vector<MaterialProperty<Real> *> > > _prop_d3F;
+};
+
+#endif //DERIVATIVEBASEMATERIAL_H

--- a/modules/phase_field/include/materials/DerivativeBaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeBaseMaterial.h
@@ -102,7 +102,7 @@ protected:
   unsigned int _nargs;
 
   /// String vector of all argument names.
-  std::vector<std::string> _arg_name;
+  std::vector<std::string> _arg_names;
 
   /// Calculate (and allocate memory for) the third derivatives of the free energy.
   bool _third_derivatives;

--- a/modules/phase_field/include/materials/DerivativeParsedMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterial.h
@@ -1,0 +1,65 @@
+#ifndef DERIVATIVEPARSEDMATERIAL_H
+#define DERIVATIVEPARSEDMATERIAL_H
+
+#include "DerivativeBaseMaterial.h"
+#include "libmesh/fparser_ad.hh"
+
+// Forward Declarations
+class DerivativeParsedMaterial;
+
+template<>
+InputParameters validParams<DerivativeParsedMaterial>();
+
+/**
+ * DerivativeBaseMaterial child class to evaluate a parsed function for the
+ * free energy and automatically provide all derivatives.
+ * This requires the autodiff patch (https://github.com/libMesh/libmesh/pull/238)
+ * to Function Parser in libmesh.
+ */
+class DerivativeParsedMaterial : public DerivativeBaseMaterial
+{
+public:
+  DerivativeParsedMaterial(const std::string & name,
+                    InputParameters parameters);
+
+  virtual ~DerivativeParsedMaterial();
+
+protected:
+  virtual unsigned int expectedNumArgs();
+  virtual void computeProperties();
+
+private:
+  void functionsDerivative();
+  void functionsOptimize();
+
+  /// Shorthand for an autodiff function parser object.
+  typedef FunctionParserADBase<Real> ADFunction;
+
+  /// The undiffed free energy function parser object.
+  ADFunction _func_F;
+
+  /// The first derivatives of the free energy (function parser objects).
+  std::vector<ADFunction *> _func_dF;
+
+  /// The second derivatives of the free energy (function parser objects).
+  std::vector<std::vector<ADFunction *> > _func_d2F;
+
+  /// The third derivatives of the free energy (function parser objects).
+  std::vector<std::vector<std::vector<ADFunction *> > > _func_d3F;
+
+  /// Material properties needed by this free energy
+  // std::vector<MaterialProperty<Real> *> _mat_prop;
+
+  /// Array to stage the parameters passed to the functions when calling Eval.
+  Real * _func_params;
+
+  /// Tolerance values for all arguments (to protect from log(0)).
+  std::vector<Real> _tol;
+
+  // Dummy implementations
+  virtual Real computeF();
+  virtual Real computeDF(unsigned int);
+  virtual Real computeD2F(unsigned int, unsigned int);
+};
+
+#endif // DERIVATIVEPARSEDMATERIAL_H

--- a/modules/phase_field/include/materials/DerivativeParsedMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterial.h
@@ -48,7 +48,8 @@ private:
   std::vector<std::vector<std::vector<ADFunction *> > > _func_d3F;
 
   /// Material properties needed by this free energy
-  // std::vector<MaterialProperty<Real> *> _mat_prop;
+  std::vector<MaterialProperty<Real> *> _mat_props;
+  unsigned int _nmat_props;
 
   /// Array to stage the parameters passed to the functions when calling Eval.
   Real * _func_params;

--- a/modules/phase_field/include/utils/DerivativeKernelInterface.h
+++ b/modules/phase_field/include/utils/DerivativeKernelInterface.h
@@ -1,0 +1,41 @@
+#ifndef DERIVATIVEKERNELINTERFACE_H
+#define DERIVATIVEKERNELINTERFACE_H
+
+#include "DerivativeMaterialInterface.h"
+
+/**
+ * Interface class ("Veneer") to provide generator methods for derivative
+ * material property names, and guarded getMaterialPropertyPointer calls
+ */
+template<class T>
+class DerivativeKernelInterface : public DerivativeMaterialInterface<T>
+{
+public:
+  DerivativeKernelInterface(const std::string & name, InputParameters parameters);
+
+  /// as partial template specialization is not allowed in C++ we have to implement this as a static method
+  static InputParameters validParams();
+
+protected:
+  unsigned int _nvar;
+  std::string _F_name;
+};
+
+template<class T>
+DerivativeKernelInterface<T>::DerivativeKernelInterface(const std::string & name, InputParameters parameters) :
+    DerivativeMaterialInterface<T>(name, parameters),
+    _nvar(this->_coupled_moose_vars.size()),
+    _F_name(this->template getParam<std::string>("f_name"))
+{
+}
+
+template<class T>
+InputParameters
+DerivativeKernelInterface<T>::validParams()
+{
+  InputParameters params = ::validParams<T>();
+  params.addRequiredParam<std::string>("f_name", "Base name of the free energy function F defined in a DerivativeParsedMaterial");
+  return params;
+}
+
+#endif //DERIVATIVEKERNELINTERFACE_H

--- a/modules/phase_field/include/utils/DerivativeMaterialInterface.h
+++ b/modules/phase_field/include/utils/DerivativeMaterialInterface.h
@@ -1,0 +1,168 @@
+#ifndef DERIVATIVEMATERIALINTERFACE_H
+#define DERIVATIVEMATERIALINTERFACE_H
+
+#include "MaterialProperty.h"
+
+/**
+ * Interface class ("Veneer") to provide generator methods for derivative
+ * material property names, and guarded getMaterialPropertyPointer calls
+ */
+template<class T>
+class DerivativeMaterialInterface : public T
+{
+public:
+  DerivativeMaterialInterface(const std::string & name, InputParameters parameters);
+
+  /**
+   * Helper functions to generate the material property names for the
+   * first derivatives.
+   */
+  const std::string propertyNameFirst(const std::string &base,
+    const std::string &c1) const;
+
+  /**
+   * Helper functions to generate the material property names for the
+   * second derivatives.
+   */
+  const std::string propertyNameSecond(const std::string &base,
+    const std::string &c1, const std::string &c2) const;
+
+  /**
+   * Helper functions to generate the material property names for the
+   * third derivatives.
+   */
+  const std::string propertyNameThird(const std::string &base,
+    const std::string &c1, const std::string &c2, const std::string &c3) const;
+
+  // Interface style (1)
+  // return null pointers for non-existing material properties
+
+  /**
+   * Fetch a pointer to a material property if it exists, otherwise return null
+   */
+  template<typename U>
+  MaterialProperty<U> * getMaterialPropertyPointer(const std::string & name);
+
+  // Interface style (2)
+  // return references to a zero material property for non-existing material properties
+
+  /**
+   * Fetch a material property if it exists, otherwise return the 'constant_zero' property
+   */
+  template<typename U>
+  MaterialProperty<U> & getDefaultMaterialProperty(const std::string & name);
+
+  template<typename U>
+  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1);
+
+  template<typename U>
+  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1, const std::string &c2);
+
+  template<typename U>
+  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3);
+
+private:
+  const std::string _constant_zero;
+};
+
+
+template<class T>
+DerivativeMaterialInterface<T>::DerivativeMaterialInterface(const std::string & name, InputParameters parameters) :
+    T(name, parameters),
+    _constant_zero("constant_zero")
+{
+}
+
+template<class T>
+const std::string
+DerivativeMaterialInterface<T>::propertyNameFirst(const std::string &base, const std::string &c1) const
+{
+  return "d" + base + "/d" + c1;
+}
+
+template<class T>
+const std::string
+DerivativeMaterialInterface<T>::propertyNameSecond(const std::string &base, const std::string &c1, const std::string &c2) const
+{
+  if (c1 == c2)
+    return "d^2" + base + "/d" + c1 + "^2";
+  else if (c1 < c2)
+    return "d^2" + base + "/d" + c1 + "d" + c2;
+  else
+    return "d^2" + base + "/d" + c2 + "d" + c1;
+}
+
+template<class T>
+const std::string
+DerivativeMaterialInterface<T>::propertyNameThird(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3) const
+{
+  // to obtain well defined names we sort alphabetically
+  std::vector<std::string> c(3);
+  c[0] = c1;
+  c[1] = c2;
+  c[2] = c3;
+  std::sort(c.begin(), c.end());
+
+  std::string ret = "d^3" + base + "/d" + c[0];
+
+  // this generates 'pretty' names with exponents rather than repeat multiplication
+  if (c[0] == c[1] && c[1] == c[2])
+    return ret + "^3";
+  else if (c[0] == c[1])
+    return ret + "^2d" + c[2];
+  else if (c[1] == c[2])
+    return ret + "d" + c[1] + "^2";
+  else
+    return ret + "d" + c[1] + "d" + c[2];
+}
+
+template<class T>
+template<typename U>
+MaterialProperty<U> *
+DerivativeMaterialInterface<T>::getMaterialPropertyPointer(const std::string & name)
+{
+  return this->template hasMaterialProperty<U>(name) ? &(this->template getMaterialProperty<U>(name)) : NULL;
+}
+
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getDefaultMaterialProperty(const std::string & name)
+{
+  if (this->template hasMaterialProperty<U>(name))
+    return this->template getMaterialProperty<U>(name);
+  else
+  {
+    if (this->template hasMaterialProperty<U>(_constant_zero))
+      return this->template getMaterialProperty<U>(_constant_zero);
+    else
+      mooseError("In your input file declare a 'GenericConstantMaterial' with property named '" + _constant_zero + "' set to 0.");
+  }
+}
+
+
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getDerivative(const std::string &base, const std::string &c1)
+{
+  return getDefaultMaterialProperty<U>(propertyNameFirst(base, c1));
+}
+
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getDerivative(const std::string &base, const std::string &c1, const std::string &c2)
+{
+  return getDefaultMaterialProperty<U>(propertyNameSecond(base, c1, c2));
+}
+
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3)
+{
+  return getDefaultMaterialProperty<U>(propertyNameThird(base, c1, c2, c3));
+}
+
+#endif //DERIVATIVEMATERIALINTERFACE_H

--- a/modules/phase_field/include/utils/JvarMapInterface.h
+++ b/modules/phase_field/include/utils/JvarMapInterface.h
@@ -4,7 +4,7 @@
 #include "MooseVariable.h"
 
 /**
- * Interface class ("Veneer") to provide a mapping from 'jvar' in 
+ * Interface class ("Veneer") to provide a mapping from 'jvar' in
  * computeQpOffDiagJacobian into the _coupled_moose_vars array
  */
 template <class T>

--- a/modules/phase_field/include/utils/JvarMapInterface.h
+++ b/modules/phase_field/include/utils/JvarMapInterface.h
@@ -1,0 +1,53 @@
+#ifndef JVARMAPINTERFACE_H
+#define JVARMAPINTERFACE_H
+
+#include "MooseVariable.h"
+
+/**
+ * Interface class ("Veneer") to provide a mapping from 'jvar' in 
+ * computeQpOffDiagJacobian into the _coupled_moose_vars array
+ */
+template <class T>
+class JvarMapInterface : public T
+{
+public:
+  JvarMapInterface(const std::string & name, InputParameters parameters);
+
+  /// Set the cvar value to the mapped jvar value and return true if the mapping exists.
+  /// Otherwise return false
+  bool mapJvarToCvar(unsigned int jvar, unsigned int & cvar);
+
+protected:
+  /// map type for brevity
+  typedef std::map<unsigned int, unsigned int> JvarMap;
+
+  /// look-up table to determine the _coupled_moose_vars index for the jvar parameter
+  JvarMap _jvar_map;
+};
+
+
+template<class T>
+JvarMapInterface<T>::JvarMapInterface(const std::string & name, InputParameters parameters) :
+    T(name, parameters)
+{
+  unsigned int nvar = this->_coupled_moose_vars.size();
+
+  // populate map;
+  for (unsigned int i = 0; i < nvar; ++i)
+    _jvar_map[this->_coupled_moose_vars[i]->number()] = i;
+}
+
+template<class T>
+bool
+JvarMapInterface<T>::mapJvarToCvar(unsigned int jvar, unsigned int & cvar)
+{
+  JvarMap::iterator cit = _jvar_map.find(jvar);
+
+  if (cit == _jvar_map.end())
+    return false;
+
+  cvar = cit->second;
+  return true;
+}
+
+#endif //JVARMAPINTERFACE_H

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -19,6 +19,7 @@
 #include "SpecifiedSmoothCircleIC.h"
 #include "RndBoundingBoxIC.h"
 #include "PFMobility.h"
+#include "DerivativeParsedMaterial.h"
 #include "NodalFloodCount.h"
 #include "NodalFloodCountAux.h"
 #include "NodalVolumeFraction.h"
@@ -99,6 +100,7 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerInitialCondition(Tricrystal2CircleGrainsIC);
   registerMaterial(PFMobility);
   registerMaterial(GBEvolution);
+  registerMaterial(DerivativeParsedMaterial);
   registerUserObject(NodalFloodCount);
   registerAux(NodalFloodCountAux);
   registerAux(BndsCalcAux);

--- a/modules/phase_field/src/kernels/SplitCHParsed.C
+++ b/modules/phase_field/src/kernels/SplitCHParsed.C
@@ -3,27 +3,27 @@
 template<>
 InputParameters validParams<SplitCHParsed>()
 {
-  InputParameters params = ParsedFreeEnergyInterface<SplitCHCRes>::validParams();
+  InputParameters params = DerivativeKernelInterface<SplitCHCRes>::validParams();
   return params;
 }
 
 SplitCHParsed::SplitCHParsed(const std::string & name, InputParameters parameters) :
-    ParsedFreeEnergyInterface<SplitCHCRes>(name, parameters)
+    DerivativeKernelInterface<SplitCHCRes>(name, parameters),
+    _dFdc(getDerivative<Real>(_F_name, _var.name())),
+    _d2Fdc2(getDerivative<Real>(_F_name, _var.name(), _var.name()))
 {
 }
 
 Real
 SplitCHParsed::computeDFDC(PFFunctionType type)
 {
-  updateFuncParams();
-
   switch (type)
   {
     case Residual:
-      return firstDerivative(0);
+      return _dFdc[_qp];
 
     case Jacobian:
-      return secondDerivative(0) * _phi[_j][_qp];
+      return _d2Fdc2[_qp] * _phi[_j][_qp];
   }
 
   mooseError("Internal error");

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -43,9 +43,9 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
   }
 
   // fetch names of variables in args
-  _arg_name.resize(_nargs);
+  _arg_names.resize(_nargs);
   for (i = 0; i < _nargs; ++i)
-    _arg_name[i] = getVar("args", i)->name();
+    _arg_names[i] = getVar("args", i)->name();
 
   // initialize derivatives
   for (i = 0; i < _nargs; ++i)
@@ -54,7 +54,7 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
     _args[i] = &coupledValue("args", i);
 
     // first derivatives
-    _prop_dF[i] = &declareProperty<Real>(propertyNameFirst(_F_name, _arg_name[i]));
+    _prop_dF[i] = &declareProperty<Real>(propertyNameFirst(_F_name, _arg_names[i]));
 
     // second derivatives
     for (j = i; j < _nargs; ++j)
@@ -62,7 +62,7 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
       _prop_d2F[i][j] =
       _prop_d2F[j][i] =
         &declareProperty<Real>(
-          propertyNameSecond(_F_name, _arg_name[i], _arg_name[j])
+          propertyNameSecond(_F_name, _arg_names[i], _arg_names[j])
         );
 
       // third derivatives
@@ -79,7 +79,7 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
           _prop_d3F[j][i][k] =
           _prop_d3F[i][k][j] =
             &declareProperty<Real>(
-              propertyNameThird(_F_name, _arg_name[i], _arg_name[j], _arg_name[k])
+              propertyNameThird(_F_name, _arg_names[i], _arg_names[j], _arg_names[k])
             );
         }
       }
@@ -103,13 +103,13 @@ DerivativeBaseMaterial::initialSetup()
 
   for (i = 0; i < _nargs; ++i)
   {
-    if (!_fe_problem.isMatPropRequested(propertyNameFirst(_F_name, _arg_name[i])))
+    if (!_fe_problem.isMatPropRequested(propertyNameFirst(_F_name, _arg_names[i])))
       _prop_dF[i] = NULL;
 
     // second derivatives
     for (j = i; j < _nargs; ++j)
     {
-      if (!_fe_problem.isMatPropRequested(propertyNameSecond(_F_name, _arg_name[i], _arg_name[j])))
+      if (!_fe_problem.isMatPropRequested(propertyNameSecond(_F_name, _arg_names[i], _arg_names[j])))
         _prop_d2F[i][j] =
         _prop_d2F[j][i] = NULL;
 
@@ -118,7 +118,7 @@ DerivativeBaseMaterial::initialSetup()
       {
         for (k = j; k < _nargs; ++k)
         {
-          if (!_fe_problem.isMatPropRequested(propertyNameThird(_F_name, _arg_name[i], _arg_name[j], _arg_name[k])))
+          if (!_fe_problem.isMatPropRequested(propertyNameThird(_F_name, _arg_names[i], _arg_names[j], _arg_names[k])))
             _prop_d3F[i][j][k] =
             _prop_d3F[k][i][j] =
             _prop_d3F[j][k][i] =

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -1,0 +1,179 @@
+#include "DerivativeBaseMaterial.h"
+
+template<>
+InputParameters validParams<DerivativeBaseMaterial>()
+{
+  InputParameters params = validParams<Material>();
+  params.addClassDescription("KKS model helper material to provide the free energy and its first and second derivatives");
+  params.addParam<std::string>("f_name", "F", "Base name of the free energy function (used to name the material properties)");
+  params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
+  params.addParam<bool>("third_derivatives", true, "Calculate third derivatoves of the free energy");
+  return params;
+}
+
+DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
+                                               InputParameters parameters) :
+    DerivativeMaterialInterface<Material>(name, parameters),
+    _F_name(getParam<std::string>("f_name")),
+    _nargs(coupledComponents("args")),
+    _third_derivatives(getParam<bool>("third_derivatives")),
+    _prop_F(&declareProperty<Real>(_F_name))
+{
+  // loop counters
+  unsigned int i, j, k;
+
+  // coupled variables
+  _args.resize(_nargs);
+
+  // reserve space for material properties
+  _prop_dF.resize(_nargs);
+  _prop_d2F.resize(_nargs);
+  _prop_d3F.resize(_nargs);
+  for (i = 0; i < _nargs; ++i)
+  {
+    _prop_d2F[i].resize(_nargs);
+
+    // TODO: maybe we should reserve and initialize to NULL...
+    if (_third_derivatives) {
+      _prop_d3F[i].resize(_nargs);
+
+      for (unsigned int j = 0; j < _nargs; ++j)
+        _prop_d3F[i][j].resize(_nargs);
+    }
+  }
+
+  // fetch names of variables in args
+  _arg_name.resize(_nargs);
+  for (i = 0; i < _nargs; ++i)
+    _arg_name[i] = getVar("args", i)->name();
+
+  // initialize derivatives
+  for (i = 0; i < _nargs; ++i)
+  {
+    // get the coupled variable to use as function arguments
+    _args[i] = &coupledValue("args", i);
+
+    // first derivatives
+    _prop_dF[i] = &declareProperty<Real>(propertyNameFirst(_F_name, _arg_name[i]));
+
+    // second derivatives
+    for (j = i; j < _nargs; ++j)
+    {
+      _prop_d2F[i][j] =
+      _prop_d2F[j][i] =
+        &declareProperty<Real>(
+          propertyNameSecond(_F_name, _arg_name[i], _arg_name[j])
+        );
+
+      // third derivatives
+      if (_third_derivatives)
+      {
+        for (k = j; k < _nargs; ++k)
+        {
+          // filling all permutations does not cost us much and simplifies access
+          // (no need to check i<=j<=k)
+          _prop_d3F[i][j][k] =
+          _prop_d3F[k][i][j] =
+          _prop_d3F[j][k][i] =
+          _prop_d3F[k][j][i] =
+          _prop_d3F[j][i][k] =
+          _prop_d3F[i][k][j] =
+            &declareProperty<Real>(
+              propertyNameThird(_F_name, _arg_name[i], _arg_name[j], _arg_name[k])
+            );
+        }
+      }
+    }
+  }
+}
+
+void
+DerivativeBaseMaterial::initialSetup()
+{
+  if (_nargs != expectedNumArgs()) {
+    mooseError("Wrong number of arguments supplied for DerivativeBaseMaterial " + _F_name);
+  }
+
+  // set the _prop_* pointers of all material poroperties that are not beeing used back to NULL
+  unsigned int i, j, k;
+  bool needs_third_derivatives = false;
+
+  if (!_fe_problem.isMatPropRequested(_F_name))
+    _prop_F = NULL;
+
+  for (i = 0; i < _nargs; ++i)
+  {
+    if (!_fe_problem.isMatPropRequested(propertyNameFirst(_F_name, _arg_name[i])))
+      _prop_dF[i] = NULL;
+
+    // second derivatives
+    for (j = i; j < _nargs; ++j)
+    {
+      if (!_fe_problem.isMatPropRequested(propertyNameSecond(_F_name, _arg_name[i], _arg_name[j])))
+        _prop_d2F[i][j] =
+        _prop_d2F[j][i] = NULL;
+
+      // third derivatives
+      if (_third_derivatives)
+      {
+        for (k = j; k < _nargs; ++k)
+        {
+          if (!_fe_problem.isMatPropRequested(propertyNameThird(_F_name, _arg_name[i], _arg_name[j], _arg_name[k])))
+            _prop_d3F[i][j][k] =
+            _prop_d3F[k][i][j] =
+            _prop_d3F[j][k][i] =
+            _prop_d3F[k][j][i] =
+            _prop_d3F[j][i][k] =
+            _prop_d3F[i][k][j] = NULL;
+          else
+            needs_third_derivatives = true;
+        }
+
+        if (!needs_third_derivatives)
+          mooseWarning("This simulation does not actually need the third derivatives of DerivativeBaseMaterial " + _name);
+      }
+    }
+  }
+}
+
+// implementing this in the derived class is optional (not really, but we'l have to check what is needed for the residuals!)
+Real
+DerivativeBaseMaterial::computeD3F(unsigned int /*arg1*/, unsigned int /*arg2*/, unsigned int /*arg3*/)
+{
+  return 0.0;
+}
+
+void
+DerivativeBaseMaterial::computeProperties()
+{
+  unsigned int i, j, k;
+
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+  {
+    // set function value
+    if (_prop_F)
+      (*_prop_F)[_qp] = computeF();
+
+    for (i = 0; i < _nargs; ++i)
+    {
+      // set first derivatives
+      if (_prop_dF[i])
+        (*_prop_dF[i])[_qp] = computeDF(i);
+
+      // second derivatives
+      for (j = i; j < _nargs; ++j)
+      {
+        if (_prop_d2F[i][j])
+          (*_prop_d2F[i][j])[_qp] = computeD2F(i, j);
+
+        // third derivatives
+        if (_third_derivatives)
+        {
+          for (k = j; k < _nargs; ++k)
+            if (_prop_d3F[i][j][k])
+              (*_prop_d3F[i][j][k])[_qp] = computeD3F(i, j, k);
+        }
+      }
+    }
+  }
+}

--- a/modules/phase_field/src/materials/DerivativeParsedMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterial.C
@@ -52,7 +52,9 @@ DerivativeParsedMaterial::DerivativeParsedMaterial(const std::string & name,
 
     constant_values[i] = expression->Eval(NULL);
 
-    std::cout << "Constant value " << i << ' ' << constant_expressions[i] << " = " << constant_values[i] << std::endl;
+#ifdef DEBUG
+    _console << "Constant value " << i << ' ' << constant_expressions[i] << " = " << constant_values[i] << std::endl;
+#endif
 
     if (!_func_F.AddConstant(constant_names[i], constant_values[i]))
       mooseError("Invalid constant name in DerivativeParsedMaterial");
@@ -148,18 +150,11 @@ void DerivativeParsedMaterial::functionsOptimize()
 
   // base function
   _func_F.Optimize();
-#ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
-  //_func_F.PrintByteCode(std::cout);
-#endif
 
   // optimize first derivatives
   for (i = 0; i < _nargs; ++i)
   {
     _func_dF[i]->Optimize();
-#ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
-    std::cout << propertyNameFirst(_F_name, _arg_name[i]) << "\n";
-    //_func_dF[i]->PrintByteCode(std::cout);
-#endif
 
     // if the derivative vanishes set the function back to NULL
     if (_func_dF[i]->isZero())
@@ -172,10 +167,6 @@ void DerivativeParsedMaterial::functionsOptimize()
     for (j = i; j < _nargs; ++j)
     {
       _func_d2F[i][j]->Optimize();
-#ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
-      std::cout << propertyNameSecond(_F_name, _arg_name[i], _arg_name[j]) << "\n";
-      //_func_d2F[i][j]->PrintByteCode(std::cout);
-#endif
 
       // if the derivative vanishes set the function back to NULL
       if (_func_d2F[i][j]->isZero())
@@ -190,10 +181,6 @@ void DerivativeParsedMaterial::functionsOptimize()
         for (k = j; k < _nargs; ++k)
         {
           _func_d3F[i][j][k]->Optimize();
-#ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
-          std::cout << propertyNameThird(_F_name, _arg_name[i], _arg_name[j], _arg_name[k]) << "\n";
-          //_func_d3F[i][j][k]->PrintByteCode(std::cout);
-#endif
 
           // if the derivative vanishes set the function back to NULL
           if (_func_d3F[i][j][k]->isZero())

--- a/modules/phase_field/src/materials/DerivativeParsedMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterial.C
@@ -1,0 +1,267 @@
+#include "DerivativeParsedMaterial.h"
+
+template<>
+InputParameters validParams<DerivativeParsedMaterial>()
+{
+  InputParameters params = validParams<DerivativeBaseMaterial>();
+  params.addClassDescription("Parsed Function Material with automatic derivatives.");
+
+  // Constants and their values
+  params.addParam<std::vector<std::string> >("constant_names", std::vector<std::string>(), "Vector of constants used in the parsed function (use this for kB etc.)");
+  params.addParam<std::vector<std::string> >( "constant_expressions", std::vector<std::string>(), "Vector of values for the constants in constant_names (can be an FParser expression)");
+
+  // Variables with applied tolerances and their tolerance values
+  params.addParam<std::vector<std::string> >("tol_names", std::vector<std::string>(), "Vector of variable names to be protected from being 0 or 1 within a tolerance (needed for log(c) and log(1-c) terms)");
+  params.addParam<std::vector<Real> >( "tol_values", std::vector<Real>(), "Vector of tolerance values for the variables in tol_names");
+
+  // Material properties
+  /* params.addParam<std::vector<std::string> >("material_property_names", std::vector<std::string>(), "Vector of material properties used in the parsed function (this currently is only for constant material properties, i.e. no derivatives of those properties are calculated!)"); */
+
+  // Function expression
+  params.addRequiredParam<std::string>("function", "FParser function expression for the phase free energy");
+  return params;
+}
+
+DerivativeParsedMaterial::DerivativeParsedMaterial(const std::string & name,
+                                                   InputParameters parameters) :
+    DerivativeBaseMaterial(name, parameters)
+{
+  // get and check constant vectors
+  std::vector<std::string> constant_names = getParam<std::vector<std::string> >("constant_names");
+  std::vector<std::string> constant_expressions = getParam<std::vector<std::string> >("constant_expressions");
+  unsigned int nconst = constant_expressions.size();
+
+  if (nconst != constant_expressions.size())
+    mooseError("The parameter vectors constant_names and constant_values must have equal length.");
+
+  // initialize constants
+  ADFunction *expression;
+  std::vector<Real> constant_values(nconst);
+  for (unsigned int i = 0; i < nconst; ++i)
+  {
+    expression = new ADFunction();
+
+    // add previously evaluated constants
+    for (unsigned int j = 0; j < i; ++j)
+      if (!expression->AddConstant(constant_names[j], constant_values[j]))
+        mooseError("Invalid constant name in DerivativeParsedMaterial");
+
+    // build the temporary comnstant expression function
+    if (expression->Parse(constant_expressions[i], "") >= 0)
+       mooseError(std::string("Invalid constant expression\n" + constant_expressions[i] + "\n in DerivativeParsedMaterial. ") + expression->ErrorMsg());
+
+    constant_values[i] = expression->Eval(NULL);
+
+    std::cout << "Constant value " << i << ' ' << constant_expressions[i] << " = " << constant_values[i] << std::endl;
+
+    if (!_func_F.AddConstant(constant_names[i], constant_values[i]))
+      mooseError("Invalid constant name in DerivativeParsedMaterial");
+
+    delete expression;
+  }
+
+  // get and check tolerance vectors
+  std::vector<std::string> tol_names = getParam<std::vector<std::string> >("tol_names");
+  std::vector<Real> tol_values = getParam<std::vector<Real> >("tol_values");
+
+  if (tol_names.size() != tol_values.size())
+    mooseError("The parameter vectors tol_names and tol_values must have equal length.");
+
+  // set tolerances
+  _tol.resize(_nargs);
+  for (unsigned int i = 0; i < _nargs; ++i)
+  {
+    _tol[i] = -1.0;
+
+    // for every argument look throug the entire tolerance vector to find a match
+    for (unsigned int j = 0; j < tol_names.size(); ++j)
+      if (_arg_name[i] == tol_names[j])
+      {
+        _tol[i] = tol_values[j];
+        break;
+      }
+  }
+
+  // build 'variables' argument for fparser
+  std::stringstream  s;
+  std::copy(_arg_name.begin(), _arg_name.end(), std::ostream_iterator<std::string>(s, ","));
+  std::string vars = s.str();
+  vars.erase(vars.size() - 1); // trim trailing ','
+
+  // build the base function
+  if (_func_F.Parse(getParam<std::string>("function"), vars) >= 0)
+     mooseError(std::string("Invalid function\n" + getParam<std::string>("function") + "\nin DerivativeParsedMaterial.\n") + _func_F.ErrorMsg());
+
+  // Auto-Derivatives
+  functionsDerivative();
+
+  // Optimization
+  functionsOptimize();
+
+  // create parameter passing buffer
+  _func_params = new Real[_nargs];
+}
+
+DerivativeParsedMaterial::~DerivativeParsedMaterial()
+{
+  delete[] _func_params;
+}
+
+void DerivativeParsedMaterial::functionsDerivative()
+{
+  unsigned int i, j, k;
+
+  // first derivatives
+  _func_dF.resize(_nargs);
+  _func_d2F.resize(_nargs);
+  _func_d3F.resize(_nargs);
+  for (i = 0; i < _nargs; ++i)
+  {
+    _func_dF[i] = new ADFunction(_func_F);
+    _func_dF[i]->AutoDiff(_arg_name[i]);
+
+    // second derivatives
+    _func_d2F[i].resize(_nargs);
+    _func_d3F[i].resize(_nargs);
+    for (j = i; j < _nargs; ++j)
+    {
+      _func_d2F[i][j] = new ADFunction(*_func_dF[i]);
+      _func_d2F[i][j]->AutoDiff(_arg_name[j]);
+
+      // third derivatives
+      if (_third_derivatives)
+      {
+        _func_d3F[i][j].resize(_nargs);
+        for (k = j; k < _nargs; ++k)
+        {
+          _func_d3F[i][j][k] = new ADFunction(*_func_d2F[i][j]);
+          _func_d3F[i][j][k]->AutoDiff(_arg_name[k]);
+        }
+      }
+    }
+  }
+}
+
+void DerivativeParsedMaterial::functionsOptimize()
+{
+  unsigned int i, j, k;
+
+  // base function
+  _func_F.Optimize();
+#ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
+  //_func_F.PrintByteCode(std::cout);
+#endif
+
+  // optimize first derivatives
+  for (i = 0; i < _nargs; ++i)
+  {
+    _func_dF[i]->Optimize();
+#ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
+    std::cout << propertyNameFirst(_F_name, _arg_name[i]) << "\n";
+    //_func_dF[i]->PrintByteCode(std::cout);
+#endif
+
+    // if the derivative vanishes set the function back to NULL
+    if (_func_dF[i]->isZero())
+    {
+      delete _func_dF[i];
+      _func_dF[i] = NULL;
+    }
+
+    // optimize second derivatives
+    for (j = i; j < _nargs; ++j)
+    {
+      _func_d2F[i][j]->Optimize();
+#ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
+      std::cout << propertyNameSecond(_F_name, _arg_name[i], _arg_name[j]) << "\n";
+      //_func_d2F[i][j]->PrintByteCode(std::cout);
+#endif
+
+      // if the derivative vanishes set the function back to NULL
+      if (_func_d2F[i][j]->isZero())
+      {
+        delete _func_d2F[i][j];
+        _func_d2F[i][j] = NULL;
+      }
+
+      // optimize third derivatives
+      if (_third_derivatives)
+      {
+        for (k = j; k < _nargs; ++k)
+        {
+          _func_d3F[i][j][k]->Optimize();
+#ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
+          std::cout << propertyNameThird(_F_name, _arg_name[i], _arg_name[j], _arg_name[k]) << "\n";
+          //_func_d3F[i][j][k]->PrintByteCode(std::cout);
+#endif
+
+          // if the derivative vanishes set the function back to NULL
+          if (_func_d3F[i][j][k]->isZero())
+          {
+            delete _func_d3F[i][j][k];
+            _func_d3F[i][j][k] = NULL;
+          }
+        }
+      }
+    }
+  }
+}
+
+/// Fm(cmg,cmv,T) takes three arguments
+unsigned int
+DerivativeParsedMaterial::expectedNumArgs()
+{
+  // this alwats returns the number of argumens that was passed in
+  // i.e. any number of args is accepted.
+  return _nargs;
+}
+
+/// need to implment these virtuals, although they never get called
+Real DerivativeParsedMaterial::computeF() { return 0.0; }
+Real DerivativeParsedMaterial::computeDF(unsigned int) { return 0.0; }
+Real DerivativeParsedMaterial::computeD2F(unsigned int, unsigned int) { return 0.0; }
+
+void
+DerivativeParsedMaterial::computeProperties()
+{
+  unsigned int i, j, k;
+  Real a;
+
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+  {
+    // fill the parameter vector, apply tolerances
+    for (i = 0; i < _nargs; ++i)
+    {
+      if (_tol[i] < 0.0)
+        _func_params[i] = (*_args[i])[_qp];
+      else
+      {
+        a = (*_args[i])[_qp];
+        _func_params[i] = a < _tol[i] ? _tol[i] : (a > 1.0 - _tol[i] ? 1.0 - _tol[i] : a);
+      }
+    }
+
+    // set function value
+    if (_prop_F)
+      (*_prop_F)[_qp] = _func_F.Eval(_func_params);
+
+    for (i = 0; i < _nargs; ++i)
+    {
+      if (_prop_dF[i])
+        (*_prop_dF[i])[_qp] = _func_dF[i]==NULL ? 0.0 : _func_dF[i]->Eval(_func_params);
+
+      // second derivatives
+      for (j = i; j < _nargs; ++j)
+      {
+        if (_prop_d2F[i][j])
+          (*_prop_d2F[i][j])[_qp] = _func_d2F[i][j]==NULL ? 0.0 : _func_d2F[i][j]->Eval(_func_params);
+
+        // third derivatives
+        if (_third_derivatives)
+          for (k = j; k < _nargs; ++k)
+            if (_prop_d3F[i][j][k])
+              (*_prop_d3F[i][j][k])[_qp] = _func_d3F[i][j][k]==NULL ? 0.0 : _func_d3F[i][j][k]->Eval(_func_params);
+      }
+    }
+  }
+}

--- a/modules/phase_field/tests/CHParsed/CHParsed_test.i
+++ b/modules/phase_field/tests/CHParsed/CHParsed_test.i
@@ -47,17 +47,8 @@
   [./CHSolid]
     type = CHParsed
     variable = cv
+    f_name = F
     mob_name = M
-
-    # Either define constants here...
-    constant_names  = 'barr_height  cv_eq'
-    constant_values = '0.1         1.0e-2'
-
-    # ...or use material properties declared here.
-    #material_property_names = 'barr_height cv_eq'
-
-    # Equivalent to CHPoly with order=4
-    function = 16*barr_height*(cv-cv_eq)^2*(1-cv_eq-cv)^2
   [../]
 
   [./CHInterface]
@@ -75,6 +66,16 @@
     block = 0
     kappa = 0.1
     mob = 1e-3
+  [../]
+
+  [./free_energy]
+    type = DerivativeParsedMaterial
+    block = 0
+    f_name = F
+    args = 'cv'
+    constant_names       = 'barr_height  cv_eq'
+    constant_expressions = '0.1          1.0e-2'
+    function = 16*barr_height*(cv-cv_eq)^2*(1-cv_eq-cv)^2
   [../]
 []
 

--- a/modules/phase_field/tests/CHParsed/SplitCHParsed_test.i
+++ b/modules/phase_field/tests/CHParsed/SplitCHParsed_test.i
@@ -44,18 +44,9 @@
   [./c_res]
     type = SplitCHParsed
     variable = c
+    f_name = F
     kappa_name = kappa_c
     w = w
-
-    # Either define constants here...
-    constant_names  = 'barr_height  cv_eq'
-    constant_values = '0.1         1.0e-2'
-
-    # ...or use material properties declared here.
-    #material_property_names = 'barr_height cv_eq'
-
-    # Equivalent to SplitCHPoly with order=4
-    function = 16*barr_height*(c-cv_eq)^2*(1-cv_eq-c)^2
   [../]
   [./w_res]
     type = SplitCHWRes
@@ -75,6 +66,16 @@
     block = 0
     kappa = 0.1
     mob = 1e-3
+  [../]
+
+  [./free_energy]
+    type = DerivativeParsedMaterial
+    block = 0
+    f_name = F
+    args = 'c'
+    constant_names       = 'barr_height  cv_eq'
+    constant_expressions = '0.1          1.0e-2'
+    function = 16*barr_height*(c-cv_eq)^2*(1-cv_eq-c)^2
   [../]
 []
 


### PR DESCRIPTION
This moves the `DerivativeParsedMaterial` (formerly `KKSParsedMaterial`) from Marmot into MOOSE-PF. Adresses  #3522, please keep issue open for follow-up work.

**This change needs a corresponding Marmot update.**
