### PR TITLE
Contact 3529

### DIFF
--- a/modules/combined/tests/catch_release/catch_release.i
+++ b/modules/combined/tests/catch_release/catch_release.i
@@ -65,7 +65,7 @@
     disp_y = disp_y
     disp_z = disp_z
     penalty = 1e6
-    model = experimental
+    model = frictionless
   [../]
 []
 

--- a/modules/combined/tests/contact/4ElemTensionRelease.i
+++ b/modules/combined/tests/contact/4ElemTensionRelease.i
@@ -37,7 +37,7 @@
     disp_x = disp_x
     disp_y = disp_y
     penalty = 1e6
-    model = experimental
+    model = frictionless
     tangential_tolerance = 0.01
   [../]
 []
@@ -127,7 +127,7 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
+#    perf_log = true
     linear_residuals = true
   [../]
 [] # Outputs

--- a/modules/combined/tests/contact/4ElemTensionRelease_mechanical_constraint.i
+++ b/modules/combined/tests/contact/4ElemTensionRelease_mechanical_constraint.i
@@ -38,7 +38,7 @@
     disp_x = disp_x
     disp_y = disp_y
     penalty = 1e6
-    model = experimental
+    model = frictionless
     tangential_tolerance = 0.01
     system = constraint
   [../]

--- a/modules/combined/tests/contact/8ElemTensionRelease.i
+++ b/modules/combined/tests/contact/8ElemTensionRelease.i
@@ -50,7 +50,7 @@
     disp_x = disp_x
     disp_y = disp_y
     penalty = 1e6
-    model = experimental
+    model = frictionless
     tangential_tolerance = 0.01
   [../]
 []

--- a/modules/combined/tests/contact/pressurePenalty.i
+++ b/modules/combined/tests/contact/pressurePenalty.i
@@ -49,6 +49,7 @@
     formulation = penalty
 #    model = glued
     tangential_tolerance = 1e-3
+    tension_release = -1
   [../]
 []
 

--- a/modules/combined/tests/contact/pressurePenalty_mechanical_constraint.i
+++ b/modules/combined/tests/contact/pressurePenalty_mechanical_constraint.i
@@ -50,6 +50,7 @@
 #    model = glued
     tangential_tolerance = 1e-3
     system = constraint
+    tension_release = -1
   [../]
 []
 

--- a/modules/combined/tests/nodal_area/nodal_area_Hex20.i
+++ b/modules/combined/tests/nodal_area/nodal_area_Hex20.i
@@ -108,7 +108,6 @@
     disp_x = displ_x
     disp_y = displ_y
     disp_z = displ_z
-#    model = experimental
     penalty = 1e7
     order = SECOND
     tangential_tolerance = 1e-5

--- a/modules/combined/tests/nodal_area/nodal_area_Hex20_2.i
+++ b/modules/combined/tests/nodal_area/nodal_area_Hex20_2.i
@@ -108,7 +108,7 @@
     disp_x = displ_x
     disp_y = displ_y
     disp_z = displ_z
-    model = experimental
+    model = frictionless
     penalty = 1e7
     order = SECOND
     tangential_tolerance = 1e-5

--- a/modules/combined/tests/nodal_area/nodal_area_Hex20_3.i
+++ b/modules/combined/tests/nodal_area/nodal_area_Hex20_3.i
@@ -108,7 +108,6 @@
     disp_x = displ_x
     disp_y = displ_y
     disp_z = displ_z
-#    model = experimental
     formulation = penalty
     penalty = 1e9
     order = SECOND

--- a/modules/combined/tests/nodal_area/nodal_area_Hex27.i
+++ b/modules/combined/tests/nodal_area/nodal_area_Hex27.i
@@ -108,7 +108,6 @@
     disp_x = displ_x
     disp_y = displ_y
     disp_z = displ_z
-#    model = experimental
     penalty = 1e8
     order = SECOND
     tangential_tolerance = 1e-4

--- a/modules/combined/tests/ring_contact/ring_contact.i
+++ b/modules/combined/tests/ring_contact/ring_contact.i
@@ -51,6 +51,7 @@
     disp_y = disp_y
     disp_z = disp_z
     penalty = 1e3
+    tension_release = -1
   [../]
 []
 

--- a/modules/combined/tests/simple_contact/simple_contact_rspherical.i
+++ b/modules/combined/tests/simple_contact/simple_contact_rspherical.i
@@ -131,7 +131,7 @@
   line_search = 'none'
 
 
-  nl_abs_tol = 1e-10
+  nl_abs_tol = 1e-7
   nl_rel_tol = 1e-11
 
 
@@ -148,7 +148,7 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
+#    perf_log = true
     linear_residuals = true
   [../]
 [] # Outputs

--- a/modules/contact/include/ContactMaster.h
+++ b/modules/contact/include/ContactMaster.h
@@ -11,8 +11,7 @@ enum ContactModel
   CM_INVALID,
   CM_FRICTIONLESS,
   CM_GLUED,
-  CM_COULOMB,
-  CM_TIED
+  CM_COULOMB
 };
 
 enum ContactFormulation

--- a/modules/contact/include/ContactMaster.h
+++ b/modules/contact/include/ContactMaster.h
@@ -12,8 +12,7 @@ enum ContactModel
   CM_FRICTIONLESS,
   CM_GLUED,
   CM_COULOMB,
-  CM_TIED,
-  CM_EXPERIMENTAL
+  CM_TIED
 };
 
 enum ContactFormulation

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -152,7 +152,7 @@ ContactMaster::updateContactSet(bool beginning_of_step)
       pinfo->_starting_closest_point_ref = it->second->_closest_point_ref;
     }
 
-    if (_model == CM_EXPERIMENTAL ||
+    if (_model == CM_FRICTIONLESS ||
         (_model == CM_COULOMB && _formulation == CF_DEFAULT))
     {
       const Node * node = pinfo->_node;
@@ -307,8 +307,7 @@ ContactMaster::computeContactForce(PenetrationInfo * pinfo)
   RealVectorValue pen_force(_penalty * distance_vec);
   RealVectorValue tan_residual(0,0,0);
 
-  if (_model == CM_FRICTIONLESS ||
-      _model == CM_EXPERIMENTAL)
+  if (_model == CM_FRICTIONLESS)
   {
     switch (_formulation)
     {
@@ -401,7 +400,6 @@ ContactMaster::computeQpJacobian()
   switch (_model)
   {
   case CM_FRICTIONLESS:
-  case CM_EXPERIMENTAL:
     switch (_formulation)
     {
     case CF_DEFAULT:
@@ -484,7 +482,8 @@ contactModel(const std::string & the_name)
   }
   else if ("experimental" == name)
   {
-    model = CM_EXPERIMENTAL;
+    model = CM_FRICTIONLESS;
+    mooseWarning("Use of contact model \"experimental\" is deprecated.  Use \"frictionless\" instead.");
   }
   else
   {

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -356,7 +356,6 @@ ContactMaster::computeContactForce(PenetrationInfo * pinfo)
     }
   }
   else if (_model == CM_GLUED ||
-           _model == CM_TIED ||
            (_model == CM_COULOMB && _formulation == CF_DEFAULT))
   {
     switch (_formulation)
@@ -416,7 +415,6 @@ ContactMaster::computeQpJacobian()
     break;
   case CM_GLUED:
   case CM_COULOMB:
-  case CM_TIED:
     switch (_formulation)
     {
     case CF_DEFAULT:
@@ -475,10 +473,6 @@ contactModel(const std::string & the_name)
   else if ("coulomb" == name)
   {
     model = CM_COULOMB;
-  }
-  else if ("tied" == name)
-  {
-    model = CM_TIED;
   }
   else if ("experimental" == name)
   {

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -345,7 +345,6 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
       }
       break;
     case CM_GLUED:
-    case CM_TIED:
       switch (_formulation)
       {
         case CF_DEFAULT:
@@ -396,7 +395,7 @@ MechanicalContactConstraint::computeQpResidual(Moose::ConstraintType type)
         if (_model == CM_FRICTIONLESS)
           resid += pinfo->_normal(_component) * pinfo->_normal * pen_force;
 
-        else if (_model == CM_GLUED || _model == CM_TIED || _model == CM_COULOMB)
+        else if (_model == CM_GLUED || _model == CM_COULOMB)
           resid += pen_force(_component);
 
       }
@@ -436,7 +435,6 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
           }
         case CM_COULOMB:
         case CM_GLUED:
-        case CM_TIED:
           switch (_formulation)
           {
             case CF_DEFAULT:
@@ -476,7 +474,6 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
           }
         case CM_COULOMB:
         case CM_GLUED:
-        case CM_TIED:
           switch (_formulation)
           {
             case CF_DEFAULT:
@@ -518,7 +515,6 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
           }
         case CM_COULOMB:
         case CM_GLUED:
-        case CM_TIED:
           switch (_formulation)
           {
             case CF_DEFAULT:
@@ -553,7 +549,6 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
           }
         case CM_COULOMB:
         case CM_GLUED:
-        case CM_TIED:
           switch (_formulation)
           {
             case CF_DEFAULT:

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -42,7 +42,7 @@ InputParameters validParams<MechanicalContactConstraint>()
   params.addParam<std::string>("normal_smoothing_method","Method to use to smooth normals (edge_based|nodal_normal_based)");
   params.addParam<MooseEnum>("order", orders, "The finite element order");
 
-  params.addParam<Real>("tension_release", 0.0, "Tension release threshold.  A node in contact will not be released if its tensile load is below this value.  Must be positive.");
+  params.addParam<Real>("tension_release", 0.0, "Tension release threshold.  A node in contact will not be released if its tensile load is below this value.  No tension release if negative.");
 
   params.addParam<std::string>("formulation", "default", "The contact formulation");
   return params;
@@ -82,9 +82,6 @@ MechanicalContactConstraint::MechanicalContactConstraint(const std::string & nam
   if (_model == CM_GLUED ||
       (_model == CM_COULOMB && _formulation == CF_DEFAULT))
     _penetration_locator.setUpdate(false);
-
-  if (_tension_release < 0)
-    mooseError("The parameter 'tension_release' must be non-negative");
 
   if (_friction_coefficient < 0)
     mooseError("The friction coefficient must be nonnegative");
@@ -163,7 +160,7 @@ MechanicalContactConstraint::updateContactSet(bool beginning_of_step)
         area = 1; // Avoid divide by zero during initialization
     }
 
-    if (_model == CM_EXPERIMENTAL ||
+    if (_model == CM_FRICTIONLESS ||
         (_model == CM_COULOMB && _formulation == CF_DEFAULT))
     {
 
@@ -172,7 +169,10 @@ MechanicalContactConstraint::updateContactSet(bool beginning_of_step)
       // Moose::out << locked_this_step[slave_node_num] << " " << pinfo->_distance << std::endl;
       const Real distance( pinfo->_normal * (pinfo->_closest_point - _mesh.node(node->id())));
 
-      if (hpit != has_penetrated.end() && resid < -_tension_release && locked_this_step[slave_node_num] < 2)
+      if (hpit != has_penetrated.end() &&
+          _tension_release >= 0 &&
+          resid < -_tension_release &&
+          locked_this_step[slave_node_num] < 2)
       {
         //Moose::out << "Releasing node " << node->id() << " " << resid << " < " << -_tension_release << std::endl;
         has_penetrated.erase(hpit);
@@ -284,7 +284,6 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
   switch (_model)
   {
     case CM_FRICTIONLESS:
-    case CM_EXPERIMENTAL:
       switch (_formulation)
       {
         case CF_DEFAULT:
@@ -394,7 +393,7 @@ MechanicalContactConstraint::computeQpResidual(Moose::ConstraintType type)
         RealVectorValue distance_vec(*_current_node - pinfo->_closest_point);
         RealVectorValue pen_force(_penalty * distance_vec);
 
-        if (_model == CM_FRICTIONLESS || _model == CM_EXPERIMENTAL)
+        if (_model == CM_FRICTIONLESS)
           resid += pinfo->_normal(_component) * pinfo->_normal * pen_force;
 
         else if (_model == CM_GLUED || _model == CM_TIED || _model == CM_COULOMB)
@@ -420,7 +419,6 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
       switch (_model)
       {
         case CM_FRICTIONLESS:
-        case CM_EXPERIMENTAL:
           switch (_formulation)
           {
             case CF_DEFAULT:
@@ -460,7 +458,6 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
       switch (_model)
       {
         case CM_FRICTIONLESS:
-        case CM_EXPERIMENTAL:
           switch (_formulation)
           {
             case CF_DEFAULT:
@@ -502,7 +499,6 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
       switch (_model)
       {
         case CM_FRICTIONLESS:
-        case CM_EXPERIMENTAL:
           switch (_formulation)
           {
             case CF_DEFAULT:
@@ -544,7 +540,6 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
       switch (_model)
       {
         case CM_FRICTIONLESS:
-        case CM_EXPERIMENTAL:
           switch (_formulation)
           {
             case CF_DEFAULT:

--- a/modules/contact/src/MultiDContactConstraint.C
+++ b/modules/contact/src/MultiDContactConstraint.C
@@ -114,7 +114,6 @@ MultiDContactConstraint::updateContactSet()
       break;
 
     case CM_GLUED:
-    case CM_TIED:
 
 //      resid = pinfo->_normal * res_vec;
       break;
@@ -197,7 +196,6 @@ MultiDContactConstraint::computeQpResidual(Moose::ConstraintType type)
       break;
 
     case CM_GLUED:
-    case CM_TIED:
 
       resid = pen_force(_component)
         - res_vec(_component)
@@ -219,7 +217,6 @@ MultiDContactConstraint::computeQpResidual(Moose::ConstraintType type)
       break;
 
     case CM_GLUED:
-    case CM_TIED:
       resid = res_vec(_component);
       break;
 
@@ -249,7 +246,6 @@ MultiDContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType type)
       break;
 
     case CM_GLUED:
-    case CM_TIED:
 /*
       resid = pen_force(_component)
         - res_vec(_component)
@@ -271,7 +267,6 @@ MultiDContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType type)
       break;
 
     case CM_GLUED:
-    case CM_TIED:
 /*
       resid = pen_force(_component)
         - res_vec(_component)

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -126,7 +126,7 @@ SlaveConstraint::computeQpResidual()
     {
       resid += pinfo->_normal(_component) * pinfo->_normal * pen_force;
     }
-    else if (_model == CM_GLUED || _model == CM_TIED || _model == CM_COULOMB)
+    else if (_model == CM_GLUED || _model == CM_COULOMB)
     {
       resid += pen_force(_component);
     }
@@ -245,7 +245,6 @@ SlaveConstraint::computeQpJacobian()
     }
   }
   else if ( CM_GLUED == _model ||
-            CM_TIED == _model ||
             CM_COULOMB == _model )
   {
     normal.zero();

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -122,7 +122,7 @@ SlaveConstraint::computeQpResidual()
     RealVectorValue distance_vec(_mesh.node(node->id()) - pinfo->_closest_point);
     RealVectorValue pen_force(_penalty * distance_vec);
 
-    if (_model == CM_FRICTIONLESS || _model == CM_EXPERIMENTAL)
+    if (_model == CM_FRICTIONLESS)
     {
       resid += pinfo->_normal(_component) * pinfo->_normal * pen_force;
     }
@@ -171,8 +171,7 @@ SlaveConstraint::computeQpJacobian()
 
   Real term(0);
 
-  if ( CM_FRICTIONLESS == _model ||
-       CM_EXPERIMENTAL == _model )
+  if ( CM_FRICTIONLESS == _model )
   {
 
     const Real nnTDiag = normal(_component) * normal(_component);


### PR DESCRIPTION
Eliminate the experimental contact option since it is no longer experimental but our standard option.  It is frictionless with tension release.

Adjust tension release to allow no tension release with a negative parameter.

Eliminate the tied option since it was supposed to be the same as glued but was wrong.
