### PR TITLE
Fix warnings

### DIFF
--- a/modules/tensor_mechanics/include/materials/FiniteStrainRatePlasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainRatePlasticMaterial.h
@@ -19,6 +19,10 @@ protected:
   virtual void computeQpStress();
   virtual void initQpStatefulProperties();
 
+  // Avoid warnings about hidden overloaded virtual function
+  using FiniteStrainPlasticMaterial::returnMap;
+  using FiniteStrainPlasticMaterial::getJac;
+
   virtual void returnMap(const RankTwoTensor &, const RankTwoTensor &, const RankFourTensor &, RankTwoTensor &, RankTwoTensor &);
   void getJac(const RankTwoTensor &, const RankFourTensor &, Real, Real, RankFourTensor &);
   void getFlowTensor(const RankTwoTensor &, Real, RankTwoTensor &);

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -78,7 +78,7 @@ void FiniteStrainCrystalPlasticity::initQpStatefulProperties()
     is = data[ind++];
     ie = data[ind++];
 
-    for (unsigned int i = is; i <= ie; ++i)
+    for (int i = is; i <= ie; ++i)
       _gss[_qp][i-1] = _gprops[ind];
 
     if (ie == _nss)

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -274,7 +274,7 @@ void
 FiniteStrainCrystalPlasticity::getSlipSystems()
 {
   unsigned int i, j, k;
-  Real sd[3*_nss], sn[3*_nss];
+  std::vector<Real> sd(3*_nss), sn(3*_nss);
   Real vec[3];
   std::ifstream fileslipsys;
 

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -52,7 +52,6 @@ void FiniteStrainCrystalPlasticity::initQpStatefulProperties()
 {
   unsigned int ind;
   int is, ie;
-  Real *data;
   RealTensorValue rot;
 
   _stress[_qp].zero();
@@ -70,13 +69,11 @@ void FiniteStrainCrystalPlasticity::initQpStatefulProperties()
   _a0.resize(_nss);
   _xm.resize(_nss);
 
-  data = _gprops.data();
-
   ind = 0;
   while (true)
   {
-    is = data[ind++];
-    ie = data[ind++];
+    is = _gprops[ind++];
+    ie = _gprops[ind++];
 
     for (int i = is; i <= ie; ++i)
       _gss[_qp][i-1] = _gprops[ind];
@@ -87,20 +84,16 @@ void FiniteStrainCrystalPlasticity::initQpStatefulProperties()
     ind++;
   }
 
-  data = _hprops.data();
-
-  _r = data[0];
-  _h0 = data[1];
-  _tau_init = data[2];
-  _tau_sat = data[3];
-
-  data = _flowprops.data();
+  _r = _hprops[0];
+  _h0 = _hprops[1];
+  _tau_init = _hprops[2];
+  _tau_sat = _hprops[3];
 
   ind = 0;
   while (true)
   {
-    is = data[ind++];
-    ie = data[ind++];
+    is = _flowprops[ind++];
+    ie = _flowprops[ind++];
 
     for (unsigned int i = is; i <= ie; ++i)
     {

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -78,7 +78,7 @@ void FiniteStrainCrystalPlasticity::initQpStatefulProperties()
     for (int i = is; i <= ie; ++i)
       _gss[_qp][i-1] = _gprops[ind];
 
-    if (ie == _nss)
+    if (ie == static_cast<int>(_nss))
       break;
 
     ind++;
@@ -95,13 +95,13 @@ void FiniteStrainCrystalPlasticity::initQpStatefulProperties()
     is = _flowprops[ind++];
     ie = _flowprops[ind++];
 
-    for (unsigned int i = is; i <= ie; ++i)
+    for (int i = is; i <= ie; ++i)
     {
       _a0[i-1] = _flowprops[ind];
       _xm[i-1] = _flowprops[ind+1];
     }
 
-    if (ie == _nss)
+    if (ie == static_cast<int>(_nss))
       break;
 
     ind += 3;
@@ -328,10 +328,8 @@ FiniteStrainCrystalPlasticity::updateGss(std::vector<Real> & slip_incr)
   unsigned int i, j;
   std::vector<Real> hb(_nss);
   Real qab,val;
-  Real *data; //Kalidindi
 
-  data=_hprops.data(); //Kalidindi
-  Real a=data[4]; //Kalidindi
+  Real a = _hprops[4]; //Kalidindi
 
   _acc_slip[_qp]=_acc_slip_old[_qp];
   for (i=0; i < _nss; i++)

--- a/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
@@ -359,7 +359,7 @@ FiniteStrainPlasticMaterial::deltaFunc(const unsigned int i, const unsigned int 
 Real
 FiniteStrainPlasticMaterial::getYieldStress(const Real eqpe)
 {
-  int nsize;
+  unsigned nsize;
   Real *data;
 
   nsize = _yield_stress_vector.size();
@@ -393,7 +393,7 @@ FiniteStrainPlasticMaterial::getYieldStress(const Real eqpe)
 Real
 FiniteStrainPlasticMaterial::getdYieldStressdPlasticStrain(const Real eqpe)
 {
-  int nsize;
+  unsigned nsize;
   Real *data;
 
   nsize = _yield_stress_vector.size();

--- a/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
@@ -360,12 +360,10 @@ Real
 FiniteStrainPlasticMaterial::getYieldStress(const Real eqpe)
 {
   unsigned nsize;
-  Real *data;
 
   nsize = _yield_stress_vector.size();
-  data = _yield_stress_vector.data();
 
-  if (data[0] > 0.0 || nsize % 2 > 0)//Error check for input inconsitency
+  if (_yield_stress_vector[0] > 0.0 || nsize % 2 > 0)//Error check for input inconsitency
     mooseError("Error in yield stress input: Should be a vector with eqv plastic strain and yield stress pair values.\n");
 
   unsigned int ind = 0;
@@ -373,16 +371,19 @@ FiniteStrainPlasticMaterial::getYieldStress(const Real eqpe)
 
   while (ind<nsize)
   {
-    if (std::abs(eqpe - data[ind]) < tol)
-      return data[ind+1];
+    if (std::abs(eqpe - _yield_stress_vector[ind]) < tol)
+      return _yield_stress_vector[ind+1];
 
     if (ind + 2 < nsize)
     {
-      if (eqpe > data[ind] && eqpe < data[ind+2])
-        return data[ind+1]+(eqpe-data[ind])/(data[ind+2]-data[ind])*(data[ind+3]-data[ind+1]);
+      if (eqpe > _yield_stress_vector[ind] && eqpe < _yield_stress_vector[ind+2])
+        return _yield_stress_vector[ind+1] +
+          (eqpe - _yield_stress_vector[ind]) /
+          (_yield_stress_vector[ind+2] - _yield_stress_vector[ind]) *
+          (_yield_stress_vector[ind+3] - _yield_stress_vector[ind+1]);
     }
     else
-      return data[nsize-1];
+      return _yield_stress_vector[nsize-1];
 
     ind += 2;
   }
@@ -394,12 +395,10 @@ Real
 FiniteStrainPlasticMaterial::getdYieldStressdPlasticStrain(const Real eqpe)
 {
   unsigned nsize;
-  Real *data;
 
   nsize = _yield_stress_vector.size();
-  data = _yield_stress_vector.data();
 
-  if (data[0] > 0.0 || nsize % 2 > 0)//Error check for input inconsitency
+  if (_yield_stress_vector[0] > 0.0 || nsize % 2 > 0)//Error check for input inconsitency
     mooseError("Error in yield stress input: Should be a vector with eqv plastic strain and yield stress pair values.\n");
 
   unsigned int ind = 0;
@@ -408,13 +407,15 @@ FiniteStrainPlasticMaterial::getdYieldStressdPlasticStrain(const Real eqpe)
   {
     if (ind + 2 < nsize)
     {
-      if (eqpe >= data[ind] && eqpe < data[ind+2])
-        return (data[ind+3]-data[ind+1])/(data[ind+2]-data[ind]);
+      if (eqpe >= _yield_stress_vector[ind] && eqpe < _yield_stress_vector[ind+2])
+        return
+          (_yield_stress_vector[ind+3] - _yield_stress_vector[ind+1]) /
+          (_yield_stress_vector[ind+2] - _yield_stress_vector[ind]);
     }
     else
       return 0.0;
 
-    ind+=2;;
+    ind += 2;
   }
 
   return 0.0;

--- a/modules/tensor_mechanics/src/materials/FiniteStrainWeakPlaneShear.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainWeakPlaneShear.C
@@ -165,7 +165,7 @@ FiniteStrainWeakPlaneShear::returnMap(const RankTwoTensor & sig_old, const RankT
     nr_res2 = 0.5*(std::pow(f/_f_tol, 2) + std::pow(resid.L2norm()/_r_tol, 2));
 
 
-    while (nr_res2 > 0.5 && iter < _max_iter)
+    while (nr_res2 > 0.5 && iter < static_cast<unsigned>(_max_iter))
     {
       iter++;
 
@@ -284,7 +284,7 @@ FiniteStrainWeakPlaneShear::returnMap(const RankTwoTensor & sig_old, const RankT
       //sig.print();
     }
 
-    if (iter >= _max_iter)
+    if (iter >= static_cast<unsigned>(_max_iter))
     {
       sig = sig_old;
       _console << "Too many iterations in Weak Plane Shear.  f = " << f << ", |resid| = " << resid.L2norm() << ", condition = " << std::abs(f)/_f_tol + resid.L2norm()/_r_tol << "\n";

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -500,9 +500,8 @@ RankTwoTensor::symmetricEigenvalues(std::vector<Real> & eigvals)
   int nd = N;
   int lwork = 66*nd;
   int info;
-  double a[nd*nd];
-  double w[nd];
-  double work[lwork];
+  std::vector<double> a(nd*nd);
+  std::vector<double> work(lwork);
 
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
@@ -510,7 +509,7 @@ RankTwoTensor::symmetricEigenvalues(std::vector<Real> & eigvals)
 
   // compute the eigenvalues only (first "N")
   // assume upper trianlge of a is stored (second "U")
-  LAPACKsyev_("N", "U", &nd, a, &nd, &eigvals[0], work, &lwork, &info);
+  LAPACKsyev_("N", "U", &nd, &a[0], &nd, &eigvals[0], &work[0], &lwork, &info);
 
   if (info != 0)
     mooseError("In computing the eigenvalues of a rank-2 tensor, the PETSC LAPACK syev routine returned error code " << info);


### PR DESCRIPTION
This branch fixes several warnings, and removes the dubious use of the C++11 function std::vector::data().

Refs #1777.
