### PR TITLE
Added derivative of eigenvalues of symmetric rank2.  Fixes #3563

### DIFF
--- a/modules/tensor_mechanics/include/utils/RankTwoTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoTensor.h
@@ -202,12 +202,37 @@ public:
    */
   void symmetricEigenvalues(std::vector<Real> & eigvals);
 
+  /**
+   * computes eigenvalues, and their symmetric derivatives wrt _vals,
+   * assuming _vals is symmetric
+   * @param eigvals are the eigenvalues of the matrix, in ascending order
+   * @param deigvals Here digvals[i](j,k) = (1/2)*(d(eigvals[i])/dA_jk + d(eigvals[i]/dA_kj))
+   * Note the explicit symmeterisation here.
+   * For equal eigenvalues, these derivatives are not gauranteed to
+   * be the ones you expect, since the derivatives in this case are
+   * often defined by continuation from the un-equal case, and that is
+   * too sophisticated for this routine.
+   */
+  void dsymmetricEigenvalues(std::vector<Real> & eigvals, std::vector<RankTwoTensor> & deigvals);
+
 protected:
 
 private:
   static const unsigned int N = 3;
 
   Real _vals[N][N];
+
+  /**
+   * Uses the petscblaslapack.h LAPACKsyev_ routine to find, for symmetric _vals:
+   *  (1) the eigenvalues (if calculation_type == "N")
+   *  (2) the eigenvalues and eigenvectors (if calculation_type == "V")
+   * @param calculation_type If "N" then calculation eigenvalues only
+   * @param eigvals Eigenvalues are placed in this array, in ascending order
+   * @param a Eigenvectors are placed in this array if calculation_type == "V".
+   * See code in dsymmetricEigenvalues for extracting eigenvectors from the a output.
+   */
+  void syev(const char * calculation_type, std::vector<Real> & eigvals, std::vector<double> & a);
+
 };
 
 inline RankTwoTensor operator*(Real a, const RankTwoTensor & b) { return b * a; }

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -491,26 +491,60 @@ RankTwoTensor::surfaceFillFromInputVector(const std::vector<Real> & input)
     mooseError("please provide correct number of values for surface RankTwoTensor initialization.");
 }
 
+
 void
-RankTwoTensor::symmetricEigenvalues(std::vector<Real> & eigvals)
+RankTwoTensor::syev(const char * calculation_type, std::vector<Real> & eigvals, std::vector<double> & a)
 {
   eigvals.resize(N);
+  a.resize(N*N);
 
-  // prepare data for the dsyev routine
+  // prepare data for the LAPACKsyev_ routine (which comes from petscblaslapack.h)
   int nd = N;
   int lwork = 66*nd;
   int info;
-  std::vector<double> a(nd*nd);
   std::vector<double> work(lwork);
 
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
-      a[i*N + j] = _vals[i][j]; // a is destroyed by dsyev
+      a[i*N + j] = _vals[i][j]; // a is destroyed by dsyev, and if calculation_type == "V" then eigenvectors are placed there
 
-  // compute the eigenvalues only (first "N")
-  // assume upper trianlge of a is stored (second "U")
-  LAPACKsyev_("N", "U", &nd, &a[0], &nd, &eigvals[0], &work[0], &lwork, &info);
+  // compute the eigenvalues only (if calculation_type == "N"),
+  // or both the eigenvalues and eigenvectors (if calculation_type == "V")
+  // assume upper triangle of a is stored (second "U")
+  LAPACKsyev_(calculation_type, "U", &nd, &a[0], &nd, &eigvals[0], &work[0], &lwork, &info);
 
   if (info != 0)
-    mooseError("In computing the eigenvalues of a rank-2 tensor, the PETSC LAPACK syev routine returned error code " << info);
+    mooseError("In computing the eigenvalues and eigenvectors of a symmetric rank-2 tensor, the PETSC LAPACK syev routine returned error code " << info);
+}
+
+
+void
+RankTwoTensor::symmetricEigenvalues(std::vector<Real> & eigvals)
+{
+  std::vector<double> a;
+  syev("N", eigvals, a);
+}
+
+void
+RankTwoTensor::dsymmetricEigenvalues(std::vector<Real> & eigvals, std::vector<RankTwoTensor> & deigvals)
+{
+  deigvals.resize(N);
+
+  std::vector<double> a;
+  syev("V", eigvals, a);
+
+  // now a contains the eigenvetors
+  // extract these and place appropriately in deigvals
+  std::vector<Real> eig_vec;
+  eig_vec.resize(N);
+
+  for (unsigned int i = 0; i < N; ++i)
+  {
+    for (unsigned int j = 0; j < N; ++j)
+      eig_vec[j] = a[i*N + j];
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        deigvals[i](j, k) = eig_vec[j]*eig_vec[k];
+  }
+
 }

--- a/unit/include/RankTwoTensorTest.h
+++ b/unit/include/RankTwoTensorTest.h
@@ -39,6 +39,7 @@ class RankTwoTensorTest : public CppUnit::TestFixture
   CPPUNIT_TEST( dtraceTest );
   CPPUNIT_TEST( dsecondInvariantTest );
   CPPUNIT_TEST( ddetTest );
+  CPPUNIT_TEST( dsymmetricEigenvaluesTest );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -59,6 +60,7 @@ public:
   void dtraceTest();
   void dsecondInvariantTest();
   void ddetTest();
+  void dsymmetricEigenvaluesTest();
 
  private:
   RankTwoTensor _m0;

--- a/unit/src/RankTwoTensorTest.C
+++ b/unit/src/RankTwoTensorTest.C
@@ -194,3 +194,47 @@ RankTwoTensorTest::ddetTest()
     }
 }
 
+void
+RankTwoTensorTest::dsymmetricEigenvaluesTest()
+{
+  // this derivative is less trivial than dtrace and dsecondInvariant,
+  // so let's check with a finite-difference approximation
+  Real ep = 1E-5; // small finite-difference parameter
+
+  std::vector<Real> eigvals; // eigenvalues in ascending order provided by RankTwoTensor
+  std::vector<RankTwoTensor> deriv; // derivatives of these eigenvalues provided by RankTwoTensor
+
+  RankTwoTensor mep; // the RankTwoTensor with successive entries shifted by ep
+  std::vector<Real> eigvalsep; // eigenvalues of mep in ascending order
+
+  _m2.dsymmetricEigenvalues(eigvals, deriv);
+  mep = _m2;
+  for (unsigned i = 0 ; i < 3 ; ++i)
+    for (unsigned j = 0 ; j < 3 ; ++j)
+    {
+      // note the explicit symmeterisation here
+      mep(i, j) += ep/2;
+      mep(j, i) += ep/2;
+      mep.symmetricEigenvalues(eigvalsep);
+      for (unsigned k = 0 ; k < 3 ; ++k)
+        CPPUNIT_ASSERT_DOUBLES_EQUAL((eigvalsep[k] - eigvals[k])/ep, deriv[k](i, j), ep);
+      mep(i, j) -= ep/2;
+      mep(j, i) -= ep/2;
+    }
+
+  _m3.dsymmetricEigenvalues(eigvals, deriv);
+  mep = _m3;
+  for (unsigned i = 0 ; i < 3 ; ++i)
+    for (unsigned j = 0 ; j < 3 ; ++j)
+    {
+      // note the explicit symmeterisation here
+      mep(i, j) += ep/2;
+      mep(j, i) += ep/2;
+      mep.symmetricEigenvalues(eigvalsep);
+      for (unsigned k = 0 ; k < 3 ; ++k)
+        CPPUNIT_ASSERT_DOUBLES_EQUAL((eigvalsep[k] - eigvals[k])/ep, deriv[k](i, j), ep);
+      mep(i, j) -= ep/2;
+      mep(j, i) -= ep/2;
+    }
+}
+


### PR DESCRIPTION
Made a private "syev" function that gets called by both the
eigenvalue and derivative routines.  Also the compiler shouldn't
complain about variable-length arrays.

(This is a continuation of @WilkAndy's PR #3566, rebased and with conflicts fixed.)
