### PR TITLE
Bump up exodiff abs tol.  Only the problematic saved_[xy] variables are ...

### DIFF
--- a/modules/combined/tests/normalized_penalty/tests
+++ b/modules/combined/tests/normalized_penalty/tests
@@ -4,22 +4,26 @@
     type = Exodiff
     input = 'normalized_penalty.i'
     exodiff = 'normalized_penalty_out.e'
+    abs_zero = 1e-8
   [../]
   [./Q8]
     type = Exodiff
     input = 'normalized_penalty_Q8.i'
     exodiff = 'normalized_penalty_Q8_out.e'
+    abs_zero = 1e-8
   [../]
 
   [./kin_Q4]
     type = Exodiff
     input = 'normalized_penalty_kin.i'
     exodiff = 'normalized_penalty_kin_out.e'
+    abs_zero = 1e-8
   [../]
   [./kin_Q8]
     type = Exodiff
     input = 'normalized_penalty_kin_Q8.i'
     exodiff = 'normalized_penalty_kin_Q8_out.e'
+    abs_zero = 1e-8
   [../]
 
 []


### PR DESCRIPTION
...affected.  Ref #3581
