### PR TITLE
Add missing static

### DIFF
--- a/framework/include/utils/MooseRandom.h
+++ b/framework/include/utils/MooseRandom.h
@@ -74,7 +74,7 @@ public:
   /**
    * Return next random number drawn from a standard distribution.
    */
-  inline double randNormal() {
+  static inline double randNormal() {
     return randNormal(0.0, 1.0);
   }
 


### PR DESCRIPTION
This method is meant to be static... Fixes an oversight in #3575.
