### PR TITLE
Reinit mat exec on 3443

### DIFF
--- a/framework/include/base/AuxiliarySystem.h
+++ b/framework/include/base/AuxiliarySystem.h
@@ -127,9 +127,9 @@ public:
   bool needMaterialOnSide(BoundaryID bnd_id);
 
 protected:
-  void computeScalarVars(std::vector<AuxWarehouse> & auxs);
-  void computeNodalVars(std::vector<AuxWarehouse> & auxs);
-  void computeElementalVars(std::vector<AuxWarehouse> & auxs);
+  void computeScalarVars(ExecFlagType type);
+  void computeNodalVars(ExecFlagType type);
+  void computeElementalVars(ExecFlagType type);
 
   FEProblem & _mproblem;
 

--- a/framework/include/base/ComputeElemAuxBcsThread.h
+++ b/framework/include/base/ComputeElemAuxBcsThread.h
@@ -27,7 +27,7 @@ class AuxiliarySystem;
 class ComputeElemAuxBcsThread
 {
 public:
-  ComputeElemAuxBcsThread(FEProblem & problem, AuxiliarySystem & sys, std::vector<AuxWarehouse> & auxs);
+  ComputeElemAuxBcsThread(FEProblem & problem, AuxiliarySystem & sys, std::vector<AuxWarehouse> & auxs, bool need_materials);
   // Splitting Constructor
   ComputeElemAuxBcsThread(ComputeElemAuxBcsThread & x, Threads::split split);
 
@@ -41,6 +41,7 @@ protected:
   THREAD_ID _tid;
 
   std::vector<AuxWarehouse> & _auxs;
+  bool _need_materials;
 };
 
 #endif //COMPUTEELEMAUXBCSTHREAD_H

--- a/framework/include/base/ComputeElemAuxVarsThread.h
+++ b/framework/include/base/ComputeElemAuxVarsThread.h
@@ -27,7 +27,7 @@ class AuxiliarySystem;
 class ComputeElemAuxVarsThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  ComputeElemAuxVarsThread(FEProblem & problem, AuxiliarySystem & sys, std::vector<AuxWarehouse> & auxs);
+  ComputeElemAuxVarsThread(FEProblem & problem, AuxiliarySystem & sys, std::vector<AuxWarehouse> & auxs, bool need_materials);
   // Splitting Constructor
   ComputeElemAuxVarsThread(ComputeElemAuxVarsThread & x, Threads::split split);
 
@@ -42,6 +42,7 @@ public:
 protected:
   AuxiliarySystem & _aux_sys;
   std::vector<AuxWarehouse> & _auxs;
+  bool _need_materials;
 };
 
 #endif //COMPUTEELEMAUXVARSTHREAD_H

--- a/framework/include/base/ComputeMaterialsObjectThread.h
+++ b/framework/include/base/ComputeMaterialsObjectThread.h
@@ -57,6 +57,9 @@ protected:
   std::vector<MaterialWarehouse> & _materials;
   std::vector<Assembly *> & _assembly;
   bool _need_internal_side_material;
+
+  const bool _has_stateful_props;
+  const bool _has_bnd_stateful_props;
 };
 
 #endif //COMPUTERESIDUALTHREAD_H

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -233,12 +233,12 @@ void
 AuxiliarySystem::compute(ExecFlagType type/* = EXEC_RESIDUAL*/)
 {
   if (_vars[0].scalars().size() > 0)
-    computeScalarVars(_auxs(type));
+    computeScalarVars(type);
 
   if (_vars[0].variables().size() > 0)
   {
-    computeNodalVars(_auxs(type));
-    computeElementalVars(_auxs(type));
+    computeNodalVars(type);
+    computeElementalVars(type);
 
     if (_need_serialized_solution)
       serializeSolution();
@@ -276,9 +276,11 @@ AuxiliarySystem::addVector(const std::string & vector_name, const bool project, 
 }
 
 void
-AuxiliarySystem::computeScalarVars(std::vector<AuxWarehouse> & auxs)
+AuxiliarySystem::computeScalarVars(ExecFlagType type)
 {
   Moose::perf_log.push("update_aux_vars_scalar()","Solve");
+
+  std::vector<AuxWarehouse> & auxs = _auxs(type);
   PARALLEL_TRY {
     // FIXME: run multi-threaded
     THREAD_ID tid = 0;
@@ -309,8 +311,10 @@ AuxiliarySystem::computeScalarVars(std::vector<AuxWarehouse> & auxs)
 }
 
 void
-AuxiliarySystem::computeNodalVars(std::vector<AuxWarehouse> & auxs)
+AuxiliarySystem::computeNodalVars(ExecFlagType type)
 {
+  std::vector<AuxWarehouse> & auxs = _auxs(type);
+
   // Do we have some kernels to evaluate?
   bool have_block_kernels = false;
   for (std::set<SubdomainID>::const_iterator subdomain_it = _mesh.meshSubdomains().begin();
@@ -351,9 +355,13 @@ AuxiliarySystem::computeNodalVars(std::vector<AuxWarehouse> & auxs)
 }
 
 void
-AuxiliarySystem::computeElementalVars(std::vector<AuxWarehouse> & auxs)
+AuxiliarySystem::computeElementalVars(ExecFlagType type)
 {
   Moose::perf_log.push("update_aux_vars_elemental()","Solve");
+
+  std::vector<AuxWarehouse> & auxs = _auxs(type);
+  bool need_materials = true; //type != EXEC_INITIAL;
+
   PARALLEL_TRY {
     bool element_auxs_to_compute = false;
 
@@ -363,7 +371,7 @@ AuxiliarySystem::computeElementalVars(std::vector<AuxWarehouse> & auxs)
     if (element_auxs_to_compute)
     {
       ConstElemRange & range = *_mesh.getActiveLocalElementRange();
-      ComputeElemAuxVarsThread eavt(_mproblem, *this, auxs);
+      ComputeElemAuxVarsThread eavt(_mproblem, *this, auxs, need_materials);
       Threads::parallel_reduce(range, eavt);
 
       solution().close();
@@ -376,7 +384,7 @@ AuxiliarySystem::computeElementalVars(std::vector<AuxWarehouse> & auxs)
     if (bnd_auxs_to_compute)
     {
       ConstBndElemRange & bnd_elems = *_mesh.getBoundaryElementRange();
-      ComputeElemAuxBcsThread eabt(_mproblem, *this, auxs);
+      ComputeElemAuxBcsThread eabt(_mproblem, *this, auxs, need_materials);
       Threads::parallel_reduce(bnd_elems, eabt);
 
       solution().close();

--- a/framework/src/base/ComputeElemAuxBcsThread.C
+++ b/framework/src/base/ComputeElemAuxBcsThread.C
@@ -22,10 +22,12 @@
 
 ComputeElemAuxBcsThread::ComputeElemAuxBcsThread(FEProblem & problem,
                                                  AuxiliarySystem & sys,
-                                                 std::vector<AuxWarehouse> & auxs) :
+                                                 std::vector<AuxWarehouse> & auxs,
+                                                 bool need_materials) :
     _problem(problem),
     _sys(sys),
-    _auxs(auxs)
+    _auxs(auxs),
+    _need_materials(need_materials)
 {
 }
 
@@ -33,7 +35,8 @@ ComputeElemAuxBcsThread::ComputeElemAuxBcsThread(FEProblem & problem,
 ComputeElemAuxBcsThread::ComputeElemAuxBcsThread(ComputeElemAuxBcsThread & x, Threads::split /*split*/) :
     _problem(x._problem),
     _sys(x._sys),
-    _auxs(x._auxs)
+    _auxs(x._auxs),
+    _need_materials(x._need_materials)
 {
 }
 
@@ -64,13 +67,15 @@ ComputeElemAuxBcsThread::operator() (const ConstBndElemRange & range)
       {
         _problem.prepare(elem, _tid);
         _problem.reinitElemFace(elem, side, boundary_id, _tid);
-        _problem.reinitMaterialsBoundary(boundary_id, _tid);
+        if (_need_materials)
+          _problem.reinitMaterialsBoundary(boundary_id, _tid);
 
         const std::vector<AuxKernel*> & bcs = _auxs[_tid].elementalBCs(boundary_id);
         for (std::vector<AuxKernel*>::const_iterator element_bc_it = bcs.begin(); element_bc_it != bcs.end(); ++element_bc_it)
             (*element_bc_it)->compute();
 
-        _problem.swapBackMaterialsFace(_tid);
+        if (_need_materials)
+          _problem.swapBackMaterialsFace(_tid);
       }
 
       // update the solution vector

--- a/framework/src/base/ComputeElemAuxVarsThread.C
+++ b/framework/src/base/ComputeElemAuxVarsThread.C
@@ -20,10 +20,11 @@
 #include "libmesh/threads.h"
 
 
-ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(FEProblem & problem, AuxiliarySystem & sys, std::vector<AuxWarehouse> & auxs) :
+ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(FEProblem & problem, AuxiliarySystem & sys, std::vector<AuxWarehouse> & auxs, bool need_materials) :
     ThreadedElementLoop<ConstElemRange>(problem, sys),
     _aux_sys(sys),
-    _auxs(auxs)
+    _auxs(auxs),
+    _need_materials(need_materials)
 {
 }
 
@@ -31,7 +32,8 @@ ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(FEProblem & problem, Auxiliar
 ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(ComputeElemAuxVarsThread & x, Threads::split /*split*/) :
     ThreadedElementLoop<ConstElemRange>(x._fe_problem, x._system),
     _aux_sys(x._aux_sys),
-    _auxs(x._auxs)
+    _auxs(x._auxs),
+    _need_materials(x._need_materials)
 {
 }
 
@@ -76,13 +78,16 @@ ComputeElemAuxVarsThread::onElement(const Elem * elem)
   {
     _fe_problem.prepare(elem, _tid);
     _fe_problem.reinitElem(elem, _tid);
-    _fe_problem.reinitMaterials(elem->subdomain_id(), _tid);
+
+    if (_need_materials)
+      _fe_problem.reinitMaterials(elem->subdomain_id(), _tid);
 
     for (std::vector<AuxKernel*>::const_iterator block_element_aux_it = _auxs[_tid].activeBlockElementKernels(_subdomain).begin();
         block_element_aux_it != _auxs[_tid].activeBlockElementKernels(_subdomain).end(); ++block_element_aux_it)
       (*block_element_aux_it)->compute();
 
-    _fe_problem.swapBackMaterials(_tid);
+    if (_need_materials)
+      _fe_problem.swapBackMaterials(_tid);
 
     // update the solution vector
     {

--- a/framework/src/base/ComputeMaterialsObjectThread.C
+++ b/framework/src/base/ComputeMaterialsObjectThread.C
@@ -39,7 +39,9 @@ ThreadedElementLoop<ConstElemRange>(fe_problem, sys),
   _bnd_material_props(bnd_material_props),
   _materials(materials),
   _assembly(assembly),
-  _need_internal_side_material(false)
+  _need_internal_side_material(false),
+  _has_stateful_props(_material_props.hasStatefulProperties()),
+  _has_bnd_stateful_props(_bnd_material_props.hasStatefulProperties())
 {
 }
 
@@ -55,7 +57,9 @@ ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(ComputeMaterialsObjec
     _bnd_material_props(x._bnd_material_props),
     _materials(x._materials),
     _assembly(x._assembly),
-    _need_internal_side_material(x._need_internal_side_material)
+    _need_internal_side_material(x._need_internal_side_material),
+    _has_stateful_props(_material_props.hasStatefulProperties()),
+    _has_bnd_stateful_props(_bnd_material_props.hasStatefulProperties())
 {
 }
 
@@ -78,7 +82,11 @@ ComputeMaterialsObjectThread::onElement(const Elem *elem)
     _assembly[_tid]->reinit(elem);
 
     unsigned int n_points = _assembly[_tid]->qRule()->n_points();
-    _material_props.initStatefulProps(*_material_data[_tid], _materials[_tid].getMaterials(_subdomain), n_points, *elem);
+    if (_material_data[_tid]->nQPoints() != n_points)
+      _material_data[_tid]->size(n_points);
+
+    if (_has_stateful_props)
+      _material_props.initStatefulProps(*_material_data[_tid], _materials[_tid].getMaterials(_subdomain), n_points, *elem);
   }
 }
 
@@ -89,13 +97,17 @@ ComputeMaterialsObjectThread::onBoundary(const Elem *elem, unsigned int side, Bo
   {
     _fe_problem.setCurrentBoundaryID(bnd_id);
     _assembly[_tid]->reinit(elem, side);
-    unsigned int n_points = _assembly[_tid]->qRuleFace()->n_points();
+    unsigned int face_n_points = _assembly[_tid]->qRuleFace()->n_points();
+
+    if (_bnd_material_data[_tid]->nQPoints() != face_n_points)
+      _bnd_material_data[_tid]->size(face_n_points);
+
     // Face Materials
-    if (_materials[_tid].hasFaceMaterials(_subdomain))
-      _bnd_material_props.initStatefulProps(*_bnd_material_data[_tid], _materials[_tid].getFaceMaterials(_subdomain), n_points, *elem, side);
+    if (_materials[_tid].hasFaceMaterials(_subdomain) && _has_bnd_stateful_props)
+      _bnd_material_props.initStatefulProps(*_bnd_material_data[_tid], _materials[_tid].getFaceMaterials(_subdomain), face_n_points, *elem, side);
     // Boundary Materials
-    if (_materials[_tid].hasBoundaryMaterials(bnd_id))
-      _bnd_material_props.initStatefulProps(*_bnd_material_data[_tid], _materials[_tid].getBoundaryMaterials(bnd_id), n_points, *elem, side);
+    if (_materials[_tid].hasBoundaryMaterials(bnd_id) && _has_bnd_stateful_props)
+      _bnd_material_props.initStatefulProps(*_bnd_material_data[_tid], _materials[_tid].getBoundaryMaterials(bnd_id), face_n_points, *elem, side);
 
     _fe_problem.setCurrentBoundaryID(Moose::INVALID_BOUNDARY_ID);
   }
@@ -108,13 +120,20 @@ ComputeMaterialsObjectThread::onInternalSide(const Elem *elem, unsigned int side
   {
     _assembly[_tid]->reinit(elem, side);
     unsigned int face_n_points = _assembly[_tid]->qRuleFace()->n_points();
-    _bnd_material_props.initStatefulProps(*_bnd_material_data[_tid], _materials[_tid].getFaceMaterials(_subdomain), face_n_points, *elem, side);
+    if (_bnd_material_data[_tid]->nQPoints() != face_n_points)
+      _bnd_material_data[_tid]->size(face_n_points);
+    if (_neighbor_material_data[_tid]->nQPoints() != face_n_points)
+      _neighbor_material_data[_tid]->size(face_n_points);
+
+    if (_has_bnd_stateful_props)
+      _bnd_material_props.initStatefulProps(*_bnd_material_data[_tid], _materials[_tid].getFaceMaterials(_subdomain), face_n_points, *elem, side);
 
     const Elem * neighbor = elem->neighbor(side);
     unsigned int neighbor_side = neighbor->which_neighbor_am_i(_assembly[_tid]->elem());
     const unsigned int elem_id = elem->id();
     const unsigned int neighbor_id = neighbor->id();
-    if ((neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) || (neighbor->level() < elem->level()))
+
+    if (_has_bnd_stateful_props && ((neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) || (neighbor->level() < elem->level())))
     {
       _assembly[_tid]->reinitElemAndNeighbor(elem, side, neighbor, neighbor_side);
       // Face Materials


### PR DESCRIPTION
My current PR for #3443 is very complicated and I'm still failing several tests internally. I'm going to split it up into multiple pieces so that I can narrow the diffs down.  These changesets allow on the fly stateful property initialization based on what kinds of stateful properties are needed for the simulation.  Also there is support for not allowing material property calculations during the initial condition projection.
