### PR TITLE
Correct aux exec machinery 2172

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -713,6 +713,10 @@ public:
 
   void setKernelCoverageCheck(bool flag) { _kernel_coverage_check = flag; }
 
+  bool & legacyUoAuxComputation() { return _use_legacy_uo_aux_computation; }
+
+  bool & legacyUoInitialization() { return _use_legacy_uo_initialization; }
+
   /**
    * Updates the active boundary id
    * @param id The BoundaryID to set as active
@@ -945,6 +949,9 @@ public:
   static unsigned int _n;
 
 private:
+  bool _use_legacy_uo_aux_computation;
+  bool _use_legacy_uo_initialization;
+
   /**
    * NOTE: This is an internal function meant for MOOSE use only!
    *

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -881,7 +881,7 @@ protected:
   /// Objects to be notified when the mesh changes
   std::vector<MeshChangedInterface *> _notify_when_mesh_changes;
 
-  void computeUserObjectsInternal(std::vector<UserObjectWarehouse> & user_objects, UserObjectWarehouse::GROUP group);
+  void computeUserObjectsInternal(ExecFlagType type, UserObjectWarehouse::GROUP group);
 
 protected:
   void checkUserObjects();

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -189,6 +189,16 @@ public:
   void disableCheckUnusedFlag();
 
   /**
+   * Tell MOOSE to compute all aux kernels when any user objects are computed - deprecated behavior
+   */
+  bool & legacyUoAuxComputationDefault();
+
+  /**
+   * Tell MOOSE to compute all aux kernels when any user objects are computed - deprecated behavior
+   */
+  bool & legacyUoInitializationDefault();
+
+  /**
    * Retrieve the Executioner for this App.
    */
   Executioner * getExecutioner() { return _executioner; }
@@ -404,6 +414,12 @@ protected:
 
   /// An alternate OutputWarehouse object (required for CoupledExecutioner)
   OutputWarehouse * _alternate_output_warehouse;
+
+  /// Legacy Uo Aux computation flag
+  bool _legacy_uo_aux_computation_default;
+
+  /// Legacy Uo Initialization flag
+  bool _legacy_uo_initialization_default;
 
 private:
 

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -32,6 +32,11 @@ InputParameters validParams<CreateProblemAction>()
   params.addParam<bool>("fe_cache", false, "Whether or not to turn on the finite element shape function caching system.  This can increase speed with an associated memory cost.");
 
   params.addParam<bool>("kernel_coverage_check", true, "Set to false to disable kernel->subdomain kernel coverage check");
+
+  params.addParam<bool>("use_legacy_uo_aux_computation", "Set to true to have MOOSE recompute *all* AuxKernel types every time *any* UserObject type is executed.\nThis behavoir is non-intuitive and will be removed late fall 2014, The default is controlled through MooseApp");
+  params.addParam<bool>("use_legacy_uo_initialization", "Set to true to have MOOSE compute all UserObjects and Postprocessors during the initial setup phase of the problem recompute *all* AuxKernel types every time *any* UserObject type is executed.\nThis behavoir is non-intuitive and will be removed late fall 2014, The default is controlled through MooseApp");
+
+
   return params;
 }
 
@@ -62,5 +67,7 @@ CreateProblemAction::act()
     _problem->setCoordSystem(_blocks, _coord_sys);
     _problem->useFECache(_fe_cache);
     _problem->setKernelCoverageCheck(getParam<bool>("kernel_coverage_check"));
+    _problem->legacyUoAuxComputation() = _pars.isParamValid("use_legacy_uo_aux_computation") ? getParam<bool>("use_legacy_uo_aux_computation") : _app.legacyUoAuxComputationDefault();
+    _problem->legacyUoInitialization() = _pars.isParamValid("use_legacy_uo_initialization") ? getParam<bool>("use_legacy_uo_aux_computation") : _app.legacyUoInitializationDefault();
   }
 }

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -2175,11 +2175,11 @@ FEProblem::computeIndicatorsAndMarkers()
 }
 
 void
-FEProblem::computeUserObjectsInternal(std::vector<UserObjectWarehouse> & pps, UserObjectWarehouse::GROUP group)
+FEProblem::computeUserObjectsInternal(ExecFlagType type, UserObjectWarehouse::GROUP group)
 {
-  if (pps[0].blockIds().size() > 0 || pps[0].boundaryIds().size() > 0 || pps[0].nodesetIds().size() > 0 || pps[0].blockNodalIds().size() > 0)
+  std::vector<UserObjectWarehouse> & pps = _user_objects(type);
+  if (pps[0].blockIds().size() || pps[0].boundaryIds().size() || pps[0].nodesetIds().size() || pps[0].blockNodalIds().size() || pps[0].internalSideUserObjects(group).size())
   {
-
     /* Note: The fact that we compute the aux system when we compute the user_objects
      * is a very bad behavior that some of our applications have come to rely on.  This
      * needs to be fixed.  For now we cannot easily change this behavior without
@@ -2193,7 +2193,7 @@ FEProblem::computeUserObjectsInternal(std::vector<UserObjectWarehouse> & pps, Us
       if (_displaced_problem != NULL)
         _displaced_problem->updateMesh(*_nl.currentSolution(), *_aux.currentSolution());
 
-      _aux.compute();
+      _aux.compute(type);
     }
 
     // init
@@ -2541,7 +2541,7 @@ FEProblem::computeUserObjects(ExecFlagType type/* = EXEC_TIMESTEP*/, UserObjectW
   default:
     break;
   }
-  computeUserObjectsInternal(_user_objects(type), group);
+  computeUserObjectsInternal(type, group);
 
   Moose::perf_log.pop("compute_user_objects()","Solve");
 }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -81,7 +81,7 @@ void insertNewline(std::stringstream &oss, std::streampos &begin, std::streampos
   }
 }
 
-MooseApp::MooseApp(const std::string & name, InputParameters parameters):
+MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     ParallelObject(*parameters.get<Parallel::Communicator *>("_comm")), // Can't call getParam() before pars is set
     _name(name),
     _pars(parameters),
@@ -107,7 +107,10 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters):
     _restart(false),
     _half_transient(false),
     _output_warehouse(new OutputWarehouse),
-    _alternate_output_warehouse(NULL)
+    _alternate_output_warehouse(NULL),
+    _legacy_uo_aux_computation_default(true),
+    _legacy_uo_initialization_default(true)
+
 {
   if (isParamValid("_argc") && isParamValid("_argv"))
   {
@@ -385,6 +388,18 @@ void
 MooseApp::setErrorOverridden()
 {
   _error_overridden = true;
+}
+
+bool &
+MooseApp::legacyUoAuxComputationDefault()
+{
+  return _legacy_uo_aux_computation_default;
+}
+
+bool &
+MooseApp::legacyUoInitializationDefault()
+{
+  return _legacy_uo_initialization_default;
 }
 
 void

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -550,6 +550,15 @@ Console::outputSystemInformation()
   if (_app.getSystemInfo() != NULL)
     oss << _app.getSystemInfo()->getInfo();
 
+  if (_problem_ptr->legacyUoAuxComputation() || _problem_ptr->legacyUoInitialization())
+  {
+    oss << "LEGACY MODES ENABLED:\n";
+    if (_problem_ptr->legacyUoAuxComputation())
+      oss << "  Computing all AuxKernel types when any UserObject type is executed.\n";
+    if (_problem_ptr->legacyUoInitialization())
+      oss << "  Computing all UserObjects during initial setup.\n";
+  }
+
   oss << std::left << '\n'
       << "Parallelism:\n"
       << std::setw(_field_width) << "  Num Processors: " << static_cast<std::size_t>(n_processors()) << '\n'


### PR DESCRIPTION
This patch repairs two big issues in MOOSE and provides legacy flags to maintain existing behavior while we update and fixup the herd:
1. (#2172) We compute the EXEC_RESDIUAL aux kernels whenever we compute _any_ UOs.  See FEProblem.C:2205.  We should be executing matching types (i.e. EXEC_TIMESTEP <=> EXEC_TIMESTEP, etc.)
2. We compute all UOs during initialSetup() regardless of type. This includes Postprocessors.  While this doesn't sound too bad, the new execute_on system allows finer control over this behavior.  Users that have Postprocessors that need to run during the simulation but should also run up front can now accomplish that with `execute_on = 'initial timestep'` or something similar.  

Both of these changes can be controlled at the application level by making an explicit call through main.C or on a test by test basis through an input file parameter.  For now, all applications are defaulting to "true" for both of these legacy flags, meaning that we can fix the applications one by one. 
