### PR TITLE
Allow turning off trap_fpe in debug mode

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -86,12 +86,12 @@ extern PerfLog setup_perf_log;
 /**
  * Variable indicating whether we will enable FPE trapping for this run.
  */
-extern bool __trap_fpe;
+extern bool _trap_fpe;
 
 /**
  * Variable indicating whether Console coloring will be turned on (default: true).
  */
-extern bool __color_console;
+extern bool _color_console;
 
 /**
  * A static list of all the exec types.
@@ -101,15 +101,15 @@ extern const std::vector<ExecFlagType> exec_types;
 /**
  * Macros for coloring any output stream (_console, std::ostringstream, etc.)
  */
-#define COLOR_BLACK   (Moose::__color_console ? BLACK : "")
-#define COLOR_RED     (Moose::__color_console ? RED : "")
-#define COLOR_GREEN   (Moose::__color_console ? GREEN : "")
-#define COLOR_YELLOW  (Moose::__color_console ? YELLOW : "")
-#define COLOR_BLUE    (Moose::__color_console ? BLUE : "")
-#define COLOR_MAGENTA (Moose::__color_console ? MAGENTA : "")
-#define COLOR_CYAN    (Moose::__color_console ? CYAN : "")
-#define COLOR_WHITE   (Moose::__color_console ? WHITE : "")
-#define COLOR_DEFAULT (Moose::__color_console ? DEFAULT : "")
+#define COLOR_BLACK   (Moose::_color_console ? BLACK : "")
+#define COLOR_RED     (Moose::_color_console ? RED : "")
+#define COLOR_GREEN   (Moose::_color_console ? GREEN : "")
+#define COLOR_YELLOW  (Moose::_color_console ? YELLOW : "")
+#define COLOR_BLUE    (Moose::_color_console ? BLUE : "")
+#define COLOR_MAGENTA (Moose::_color_console ? MAGENTA : "")
+#define COLOR_CYAN    (Moose::_color_console ? CYAN : "")
+#define COLOR_WHITE   (Moose::_color_console ? WHITE : "")
+#define COLOR_DEFAULT (Moose::_color_console ? DEFAULT : "")
 
 /**
  * Import libMesh::out, and libMesh::err for use in MOOSE.

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -27,10 +27,10 @@
   do                                                                                \
   {                                                                                 \
     Moose::err << "\n\n"                                                            \
-               << (Moose::__color_console ? RED : "")                               \
+               << (Moose::_color_console ? RED : "")                                \
                << "\n\n*** ERROR ***\n"                                             \
                << msg                                                               \
-               << (Moose::__color_console ? DEFAULT : "")                           \
+               << (Moose::_color_console ? DEFAULT : "")                            \
                << "\n\n";                                                           \
     if (libMesh::global_n_processors() == 1)                                        \
       print_trace();                                                                \
@@ -48,12 +48,12 @@
     if (!(asserted))                                                                \
     {                                                                               \
       Moose::err                                                                    \
-        << (Moose::__color_console ? RED : "")                                      \
+        << (Moose::_color_console ? RED : "")                                       \
         << "\n\nAssertion `" #asserted "' failed\n"                                 \
         << msg                                                                      \
         << "\nat "                                                                  \
         << __FILE__ << ", line " << __LINE__                                        \
-        << (Moose::__color_console ? DEFAULT : "")                                  \
+        << (Moose::_color_console ? DEFAULT : "")                                   \
         << std::endl;                                                               \
      if (libMesh::global_n_processors() == 1)                                       \
        print_trace();                                                               \
@@ -68,11 +68,11 @@
   do                                                                                \
   {                                                                                 \
     Moose::out                                                                      \
-      << (Moose::__color_console ? YELLOW : "")                                     \
+      << (Moose::_color_console ? YELLOW : "")                                      \
       << "\n\n*** Warning ***\n"                                                    \
       << msg                                                                        \
       << "\nat " << __FILE__ << ", line " << __LINE__                               \
-      << (Moose::__color_console ? DEFAULT : "")                                    \
+      << (Moose::_color_console ? DEFAULT : "")                                     \
       << "\n"                                                                       \
       << std::endl;                                                                 \
   } while (0)
@@ -82,11 +82,11 @@
 #define mooseDeprecated()                                                                              \
     mooseDoOnce(                                                                                       \
       Moose::out                                                                                       \
-      << (Moose::__color_console ? YELLOW : "")                                                        \
+      << (Moose::_color_console ? YELLOW : "")                                                         \
       << "*** Warning, This code is deprecated, and likely to be removed in future library versions! " \
       << __FILE__ << ", line " << __LINE__ << ", compiled "                                            \
       << __DATE__ << " at " << __TIME__ << " ***"                                                      \
-      << (Moose::__color_console ? DEFAULT : "")                                                       \
+      << (Moose::_color_console ? DEFAULT : "")                                                        \
       << std::endl;                                                                                    \
       )
 

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -136,7 +136,7 @@ CommonOutputAction::act()
     create("SolutionHistory");
 
   if (!getParam<bool>("color"))
-    Moose::__color_console = false;
+    Moose::_color_console = false;
 }
 
 void

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -967,7 +967,7 @@ swapLibMeshComm(MPI_Comm new_comm)
 void
 enableFPE(bool on)
 {
-  if (__trap_fpe)
+  if (_trap_fpe)
     libMesh::enableFPE(on);
 }
 
@@ -990,11 +990,11 @@ const std::vector<ExecFlagType> exec_types = populateExecTypes();
 PerfLog setup_perf_log("Setup");
 
 #ifdef DEBUG
-bool __trap_fpe = true;
+bool _trap_fpe = true;
 #else
-bool __trap_fpe = false;
+bool _trap_fpe = false;
 #endif
 
-bool __color_console = true;
+bool _color_console = true;
 
 } // namespace Moose

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -967,12 +967,8 @@ swapLibMeshComm(MPI_Comm new_comm)
 void
 enableFPE(bool on)
 {
-#ifdef DEBUG
-  libMesh::enableFPE(on);
-#else
   if (__trap_fpe)
     libMesh::enableFPE(on);
-#endif
 }
 
 // Currently there are 6 exec types (See Moose.h)
@@ -993,7 +989,11 @@ const std::vector<ExecFlagType> exec_types = populateExecTypes();
 
 PerfLog setup_perf_log("Setup");
 
+#ifdef DEBUG
+bool __trap_fpe = true;
+#else
 bool __trap_fpe = false;
+#endif
 
 bool __color_console = true;
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -61,6 +61,7 @@ InputParameters validParams<MooseApp>()
   params.addCommandLineParam<bool>("half_transient", "--half-transient", "When true the simulation will only run half of its specified transient (ie half the timesteps).  This is useful for testing recovery and restart");
 
   params.addCommandLineParam<bool>("trap_fpe", "--trap-fpe", "Enable Floating Point Exception handling in critical sections of code.  This is enabled automatically in DEBUG mode");
+  params.addCommandLineParam<bool>("no_trap_fpe", "--no-trap-fpe", "Disable Floating Point Exception handling in critical sections of code when using DEBUG mode.");
 
   params.addCommandLineParam<bool>("timing", "-t --timing", "Enable all performance logging for timing purposes. This will disable all screen output of performance logs for all Console objects.");
 
@@ -163,9 +164,16 @@ MooseApp::setupOptions()
   else
     _pars.set<bool>("timing") = false;
 
+  if (isParamValid("trap_fpe") && isParamValid("no_trap_fpe"))
+    mooseError("Cannot use both \"--trap-fpe\" and \"--no-trap-fpe\" flags.");
+
   if (isParamValid("trap_fpe"))
     // Setting Global Variable
     Moose::__trap_fpe = true;
+
+  if (isParamValid("no_trap_fpe"))
+    // Setting Global Variable
+    Moose::__trap_fpe = false;
 
   if (isParamValid("help"))
   {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -156,7 +156,7 @@ MooseApp::setupOptions()
     _half_transient = true;
 
   if (isParamValid("no_color"))
-    Moose::__color_console = false;
+    Moose::_color_console = false;
 
   // Set the timing parameter (see src/outputs/Console.C)
   if (isParamValid("timing"))
@@ -169,11 +169,11 @@ MooseApp::setupOptions()
 
   if (isParamValid("trap_fpe"))
     // Setting Global Variable
-    Moose::__trap_fpe = true;
+    Moose::_trap_fpe = true;
 
   if (isParamValid("no_trap_fpe"))
     // Setting Global Variable
-    Moose::__trap_fpe = false;
+    Moose::_trap_fpe = false;
 
   if (isParamValid("help"))
   {

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -135,14 +135,14 @@ Console::Console(const std::string & name, InputParameters parameters) :
   }
 
   // Set output coloring
-  if (Moose::__color_console)
+  if (Moose::_color_console)
   {
     char * term_env = getenv("TERM");
     if (term_env)
     {
       std::string term(term_env);
       if (term != "xterm-256color" && term != "xterm")
-        Moose::__color_console = false;
+        Moose::_color_console = false;
     }
   }
 }


### PR DESCRIPTION
closes #3595

@shanestafford this should enable you to use FP_INFINITY in your tests, just make sure that you using the cli_args option if you create a test that will run in debug mode to pass the --no-trap-fpe flag.
