### PR TITLE
Run tests with identical input files in order

### DIFF
--- a/test/tests/utils/random/tests
+++ b/test/tests/utils/random/tests
@@ -25,6 +25,18 @@
     min_threads = 2
   [../]
 
+  # Parallel Mesh Tests
+  # AuxKernel Tests
+  [./test_par_mesh]
+    type = 'Exodiff'
+    input = 'random.i'
+    exodiff = 'parallel_mesh_out.e'
+    min_parallel = 2
+    max_parallel = 2
+    cli_args = 'Mesh/distribution=PARALLEL Outputs/file_base=parallel_mesh_out'
+    prereq = 'threads_verification'
+  [../]
+
   # User Object Tests
   [./test_uo]
     type = 'Exodiff'
@@ -50,18 +62,6 @@
     min_threads = 2
   [../]
 
-  # Parallel Mesh Tests
-  # AuxKernel Tests
-  [./test_par_mesh]
-    type = 'Exodiff'
-    input = 'random.i'
-    exodiff = 'parallel_mesh_out.e'
-    min_parallel = 2
-    max_parallel = 2
-    cli_args = 'Mesh/distribution=PARALLEL Outputs/file_base=parallel_mesh_out'
-    prereq = 'test'
-  [../]
-
   # User Object Tests
   [./test_uo_par_mesh]
     type = 'Exodiff'
@@ -70,6 +70,6 @@
     min_parallel = 2
     max_parallel = 2
     cli_args = 'Mesh/distribution=PARALLEL Outputs/file_base=parallel_mesh_uo_out'
-    prereq = 'test'
+    prereq = 'threads_verification_uo'
   [../]
 []


### PR DESCRIPTION
The changes to the Checkpoint file base for --recover automatically searches in the input_file_name_out_cp directory, with four tests all using the same input file it seems like one could read the wrong directory when running in --recover. I was only able to reproduce the reported error a few times, so I am not sure this is the fix, but I am hopeful.

(closes #3486)
