### PR TITLE
Deprecate param overzealous warning fix

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -84,6 +84,11 @@ extern PerfLog perf_log;
 extern PerfLog setup_perf_log;
 
 /**
+ * A static list of all the exec types.
+ */
+extern const std::vector<ExecFlagType> exec_types;
+
+/**
  * Variable indicating whether we will enable FPE trapping for this run.
  */
 extern bool _trap_fpe;
@@ -94,9 +99,9 @@ extern bool _trap_fpe;
 extern bool _color_console;
 
 /**
- * A static list of all the exec types.
+ * Variable to toggle any warning into an error
  */
-extern const std::vector<ExecFlagType> exec_types;
+extern bool _warnings_are_errors;
 
 /**
  * Macros for coloring any output stream (_console, std::ostringstream, etc.)

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -67,14 +67,19 @@
 #define mooseWarning(msg)                                                           \
   do                                                                                \
   {                                                                                 \
-    Moose::out                                                                      \
-      << (Moose::_color_console ? YELLOW : "")                                      \
+    if (Moose::_warnings_are_errors)                                                \
+      mooseError(msg);                                                              \
+    else                                                                            \
+    {                                                                               \
+      Moose::out                                                                    \
+        << (Moose::_color_console ? YELLOW : "")                                    \
       << "\n\n*** Warning ***\n"                                                    \
       << msg                                                                        \
       << "\nat " << __FILE__ << ", line " << __LINE__                               \
       << (Moose::_color_console ? DEFAULT : "")                                     \
       << "\n"                                                                       \
       << std::endl;                                                                 \
+    }                                                                               \
   } while (0)
 
 #define mooseDoOnce(do_this) do { static bool did_this_already = false; if (!did_this_already) { did_this_already = true; do_this; } } while (0)

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -483,6 +483,9 @@ private:
   /// The coupled variables set
   std::set<std::string> _coupled_vars;
 
+  /// The list of deprecated params
+  std::map<std::string, std::string> _deprecated_params;
+
   /// The default value for optionally coupled variables
   std::map<std::string, Real> _default_coupled_value;
 
@@ -721,27 +724,27 @@ template <typename T>
 void
 InputParameters::addRequiredDeprecatedParam(const std::string &name, const std::string &doc_string, const std::string &deprecation_message)
 {
-  mooseWarning("The parameter " << name << " is deprecated.\n" << deprecation_message);
-
   addRequiredParam<T>(name, doc_string);
+
+  _deprecated_params.insert(std::make_pair(name, deprecation_message));
 }
 
 template <typename T>
 void
 InputParameters::addDeprecatedParam(const std::string &name, const T &value, const std::string &doc_string, const std::string &deprecation_message)
 {
-  mooseWarning("The parameter " << name << " is deprecated.\n" << deprecation_message);
-
   addParam<T>(name, value, doc_string);
+
+  _deprecated_params.insert(std::make_pair(name, deprecation_message));
 }
 
 template <typename T>
 void
 InputParameters::addDeprecatedParam(const std::string &name, const std::string &doc_string, const std::string &deprecation_message)
 {
-  mooseWarning("The parameter " << name << " is deprecated.\n" << deprecation_message);
-
   addParam<T>(name, doc_string);
+
+  _deprecated_params.insert(std::make_pair(name, deprecation_message));
 }
 
 template <typename T>

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -989,6 +989,9 @@ const std::vector<ExecFlagType> exec_types = populateExecTypes();
 
 PerfLog setup_perf_log("Setup");
 
+/**
+ * Initialize global variables
+ */
 #ifdef DEBUG
 bool _trap_fpe = true;
 #else
@@ -996,5 +999,7 @@ bool _trap_fpe = false;
 #endif
 
 bool _color_console = true;
+
+bool _warnings_are_errors = false;
 
 } // namespace Moose

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -63,6 +63,8 @@ InputParameters validParams<MooseApp>()
   params.addCommandLineParam<bool>("trap_fpe", "--trap-fpe", "Enable Floating Point Exception handling in critical sections of code.  This is enabled automatically in DEBUG mode");
   params.addCommandLineParam<bool>("no_trap_fpe", "--no-trap-fpe", "Disable Floating Point Exception handling in critical sections of code when using DEBUG mode.");
 
+  params.addCommandLineParam<bool>("error", "--error", "Turn all warnings into errors");
+
   params.addCommandLineParam<bool>("timing", "-t --timing", "Enable all performance logging for timing purposes. This will disable all screen output of performance logs for all Console objects.");
 
   params.addPrivateParam<int>("_argc");
@@ -145,6 +147,9 @@ MooseApp::setupOptions()
     setCheckUnusedFlag(true);
   else if (isParamValid("warn_unused"))
     setCheckUnusedFlag(false);
+
+  if (isParamValid("error"))
+    Moose::_warnings_are_errors = true;
 
   if (isParamValid("error_override"))
     setErrorOverridden();

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -72,13 +72,24 @@ InputParameters::addClassDescription(const std::string &doc_string)
 void
 InputParameters::set_attributes(const std::string & name, bool inserted_only)
 {
-  // valid_params don't make sense for MooseEnums
-  if (!inserted_only && !have_parameter<MooseEnum>(name))
-    _valid_params.insert(name);
+  if (!inserted_only)
+  {
+    /**
+     * "_set_by_add_param" and "_deprecated_params" are not populated until after
+     * the default value has already been set in libMesh (first callback to this
+     * method). Therefore if a variable is in/not in one of these sets, you can
+     * be assured it was put there outside of the "addParam*()" calls.
+     */
+    _set_by_add_param.erase(name);
 
-  /* If set_attributes is called then the user has changed it from the default value
-     set by addParam, thus remove if from the list */
-  _set_by_add_param.erase(name);
+    // valid_params don't make sense for MooseEnums
+    if (!have_parameter<MooseEnum>(name))
+      _valid_params.insert(name);
+
+    std::map<std::string, std::string>::const_iterator pos = _deprecated_params.find(name);
+    if (pos != _deprecated_params.end())
+      mooseWarning("The parameter " << name << " is deprecated.\n" << pos->second);
+  }
 }
 
 std::string

--- a/test/include/kernels/NanKernel.h
+++ b/test/include/kernels/NanKernel.h
@@ -24,6 +24,9 @@ protected:
 
 private:
   unsigned int _timestep_to_nan;
+
+  unsigned int _deprecated_default;
+  unsigned int _deprecated_no_default;
 };
 
 #endif //NANKERNEL_H

--- a/test/src/kernels/NanKernel.C
+++ b/test/src/kernels/NanKernel.C
@@ -5,13 +5,19 @@ InputParameters validParams<NanKernel>()
 {
   InputParameters params = validParams<Kernel>();
   params.addParam<unsigned int>("timestep_to_nan", 1, "The timestep number to throw a nan on");
+
+  // Parameters for testing deprecated message
+  params.addDeprecatedParam<unsigned int>("deprecated_default", 100, "Deprecated parameter test", "Set this parameter to trigger a deprecated error (default)");
+  params.addDeprecatedParam<unsigned int>("deprecated_no_default", "Deprecated parameter test", "Set this parameter to trigger a deprecated error (no default)");
   return params;
 }
 
 
 NanKernel::NanKernel(const std::string & name, InputParameters parameters) :
     Kernel(name, parameters),
-    _timestep_to_nan(getParam<unsigned int>("timestep_to_nan"))
+    _timestep_to_nan(getParam<unsigned int>("timestep_to_nan")),
+    _deprecated_default(getParam<unsigned int>("deprecated_default")),
+    _deprecated_no_default(isParamValid("deprecated_no_default") ? getParam<unsigned int>("deprecated_no_default") : 0)
 {
 }
 

--- a/test/tests/misc/check_error/deprecated_param_test.i
+++ b/test/tests/misc/check_error/deprecated_param_test.i
@@ -1,0 +1,47 @@
+[Mesh]
+  file = square.e
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./nan]
+    type = NanKernel
+    variable = u
+    timestep_to_nan = 1000
+  [../]
+[]
+
+[BCs]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  file_base = out
+  output_initial = true
+  exodus = true
+  [./console]
+    type = Console
+    perf_log = true
+    linear_residuals = true
+  [../]
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -84,6 +84,20 @@
     expect_err = "Input file block '\S+' has been deprecated."
   [../]
 
+  [./deprecated_param_default]
+    type = 'RunException'
+    input = 'deprecated_param_test.i'
+    expect_err = "The parameter \w+ is deprecated."
+    cli_args = '--error Kernels/nan/deprecated_default=1'
+  [../]
+
+  [./deprecated_param_no_default]
+    type = 'RunException'
+    input = 'deprecated_param_test.i'
+    expect_err = "The parameter \w+ is deprecated."
+    cli_args = '--error Kernels/nan/deprecated_no_default=1'
+  [../]
+
   [./double_restrict_uo_test]
     type = 'RunException'
     input = 'double_restrict_uo.i'


### PR DESCRIPTION
This PR also exercises the warnings as errors capability added in #3653.
