### PR TITLE
How about we use --no-color with peacock?

### DIFF
--- a/gui/gui/ExecuteWidget.py
+++ b/gui/gui/ExecuteWidget.py
@@ -307,7 +307,7 @@ class ExecuteWidget(QtGui.QWidget):
     if self.thread_proc != '':
       _command = _command + self.thread_command + self.thread_proc
     if self.postprocessor_csv.checkState() == QtCore.Qt.Checked:
-      _command += ' Outputs/csv=true '
+      _command += ' --no-color Outputs/csv=true '
 
     _command += ' ' + self.other_options
 


### PR DESCRIPTION
closes #3457

The peacock term isn't flowing through the QtProcess.  Probably best just to just be explicit anyway...
