### PR TITLE
Fill in _objects_by_name for constraints to enable multi-threaded runs (...

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -572,6 +572,8 @@ NonlinearSystem::addConstraint(const std::string & c_name, const std::string & n
 
   MooseObject * obj = _factory.create(c_name, name, parameters);
   _fe_problem._objects_by_name[0][name].push_back(obj);
+  for (THREAD_ID tid = 1; tid < libMesh::n_threads(); tid++)
+    _fe_problem._objects_by_name[tid][name] = std::vector<MooseObject *>();
 
   NodalConstraint    * nc = dynamic_cast<NodalConstraint *>(obj);
   NodeFaceConstraint * nfc = dynamic_cast<NodeFaceConstraint *>(obj);


### PR DESCRIPTION
...closes #3690)

When a constraint is added, we have to add the MOOSE object pointer into the _objects_by_name array for thread 0 (which we correctly do). But we also have to add an empty array for the given name for threads with TID > 0. That way the call to getObjectsByName() is not broken for calls
with TID > 0.  It mistakenly reports 'no object of a given name', but the object is there, just not for the given thread.
