### PR TITLE
Add extra input file checking to Parser

### DIFF
--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -144,6 +144,21 @@ Parser::parse(const std::string &input_filename)
   _getpot_initialized = true;
   _inactive_strings.clear();
 
+  // Check for "unidentified nominuses".  These can indicate a vector
+  // input which the user failed to wrap in quotes e.g.: v = 1 2
+  {
+    std::set<std::string> knowns;
+    std::vector<std::string> ufos = _getpot_file.unidentified_nominuses(knowns);
+    if (!ufos.empty())
+    {
+      Moose::err << "Error: the following \"unidentified nominuses\" were found in your input file:" << std::endl;
+      for (unsigned int i=0; i<ufos.size(); ++i)
+        Moose::err << ufos[i] << std::endl;
+      mooseError("Your input file may have a syntax error, or you may have forgotten to put quotes around a vector, ie. v='1 2'.");
+    }
+  }
+
+
   section_names = _getpot_file.get_section_names();
   appendAndReorderSectionNames(section_names);
 

--- a/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rz_test.i
+++ b/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rz_test.i
@@ -1,4 +1,4 @@
-`#
+#
 # 1-D Gap Heat Transfer Test without mechanics
 #
 # This test exercises 1-D gap heat transfer for a constant conductivity gap.

--- a/modules/combined/tests/heat_convection/heat_convection_rz_tf_test.i
+++ b/modules/combined/tests/heat_convection/heat_convection_rz_tf_test.i
@@ -14,7 +14,7 @@
 #  where
 #    q - heat transfer rate (w)
 #    h - heat transfer coefficient (w/m^2-K)
-    A - surface area (m^2)
+#    A - surface area (m^2)
 #    Tw - surface temperature (K)
 #    Tf - fluid temperature adjacent to the surface (K)
 # The heat transfer coefficient (h) is input as a variable called 'rate'

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -8,7 +8,7 @@
   [./checked_pointer_param_test]
     type = 'RunException'
     input = 'checked_pointer_param_test.i'
-    expect_err = "_fe_problem is NULL."
+    expect_err = "quotes around a vector"
   [../]
 
   [./add_aux_variable_multiple_test]

--- a/test/tests/postprocessors/default_value/default_value.i
+++ b/test/tests/postprocessors/default_value/default_value.i
@@ -35,7 +35,7 @@
     boundary = right
     value = 1
   [../]
-[]g
+[]
 
 [Executioner]
   type = Transient

--- a/test/tests/postprocessors/default_value/real_value_override.i
+++ b/test/tests/postprocessors/default_value/real_value_override.i
@@ -35,7 +35,7 @@
     boundary = right
     value = 1
   [../]
-[]g
+[]
 
 [Executioner]
   type = Transient

--- a/test/tests/postprocessors/pps/nodal_aux_var_value.i
+++ b/test/tests/postprocessors/pps/nodal_aux_var_value.i
@@ -124,4 +124,3 @@
     linear_residuals = true
   [../]
 []
-s

--- a/test/tests/time_steppers/iteration_adaptive/hit_function_knot.i
+++ b/test/tests/time_steppers/iteration_adaptive/hit_function_knot.i
@@ -66,8 +66,8 @@
     type = IterationAdaptiveDT
     dt = 0.9
     optimal_iterations = 10
-    force_step_every_function_point = true                                                                          |
-    max_function_change = 1e20                                                                                      |
+    force_step_every_function_point = true
+    max_function_change = 1e20
     timestep_limiting_function = knot
   [../]
 []


### PR DESCRIPTION
This branch catches vectors which are declared in input files without quotes, eg. v=1 2, but also catches a bunch of other miscellaneous input file syntax bugs.

Refs #3683.
