### PR TITLE
Fixing warnings

### DIFF
--- a/framework/src/splits/SplitWarehouse.C
+++ b/framework/src/splits/SplitWarehouse.C
@@ -32,7 +32,6 @@ SplitWarehouse::addSplit(const std::string& name, MooseSharedPointer<Split> & sp
 Split*
 SplitWarehouse::getSplit(const std::string& name)
 {
-  Split *split = NULL;
   std::map<std::string, MooseSharedPointer<Split> >::iterator it = _all_splits.find(name);
 
   if (it == _all_splits.end())

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -713,7 +713,7 @@ FiniteStrainCrystalPlasticity::getInitSlipSysRes()
     for (unsigned int i = is; i <= ie; ++i)
       _gss[_qp][i-1] = _gprops[ind];
 
-    if (ie == static_cast<int>(_nss))
+    if (ie == _nss)
       break;
 
     ind++;
@@ -788,7 +788,7 @@ FiniteStrainCrystalPlasticity::getFlowRateParams()
       _xm[i-1] = _flowprops[ind+1];
     }
 
-    if (ie == static_cast<int>(_nss))
+    if (ie == _nss)
       break;
 
     ind += _num_slip_sys_flowrate_props;


### PR DESCRIPTION
Remove unused variable after shared ptr updates.

Remove static_casts in FiniteStrainCrystalPlasticity now that things have the right types.

Refs #1777.
