### PR TITLE
Fixed valgrind error

### DIFF
--- a/framework/src/actions/AddFEProblemAction.C
+++ b/framework/src/actions/AddFEProblemAction.C
@@ -38,7 +38,5 @@ AddFEProblemAction::act()
 {
   CoupledExecutioner * master_executioner = dynamic_cast<CoupledExecutioner *>(_executioner);
   if (master_executioner != NULL)
-  {
     master_executioner->addFEProblem(getShortName(), _input_filename);
-  }
 }


### PR DESCRIPTION
Let me sum up...

_console is an ConsoleStream object that calls OutputWarehouse::mooseConsole when flushed. In coupled problems a single OutputWarehouse is passed between the Apps. 

So, the call to _console that existed in FEProblem was cached, then the warehouse was swapped. All other calls to _console go the the shared OutputWarehouse stream. Thus, the stream from the FEProblem message wasn't flushed until things were cleaning up. And, _console utilizes references to _time, etc. that where already deleted, so the references were borked.

Long story, short, add a std::endl;  

(closes #3710)
