### PR TITLE
switch from check_output to Popen

### DIFF
--- a/gui/utils/GenSyntax.py
+++ b/gui/utils/GenSyntax.py
@@ -131,7 +131,7 @@ class GenSyntax():
 
     if not self.use_cached_syntax:
       try:
-        data = subprocess.check_output([self.app_path, '--yaml'])
+        data = subprocess.Popen([self.app_path, '--yaml'], stdout=subprocess.PIPE).communicate()[0]
       except:
         print '\n\nPeacock: Error executing ' + self.app_path + '\nPlease make sure your application is built and able to execute with the "--yaml" flag'
         sys.exit(1)


### PR DESCRIPTION
Looks like subprocess.check_output is not available on python 2.6(something). closes #3725
