### PR TITLE
Use smart pointer memory management for ActionWarehouse Mesh objects

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -114,8 +114,8 @@ protected:
   /// The current action (even though we have seperate instances for each action)
   const std::string & _current_task;
 
-  MooseMesh * & _mesh;
-  MooseMesh * & _displaced_mesh;
+  MooseSharedPointer<MooseMesh> & _mesh;
+  MooseSharedPointer<MooseMesh> & _displaced_mesh;
   /// Convenience reference to a problem this action works on
 
 public:

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -119,8 +119,15 @@ public:
 
   //// Getters
   Syntax & syntax() { return _syntax; }
-  MooseMesh * & mesh() { return _mesh; }
-  MooseMesh * & displacedMesh() { return _displaced_mesh; }
+
+  // We are not really using the reference counting capabilities of
+  // shared pointers here, just their memory management capability.
+  // Therefore, _mesh is actually being used more like a unique_ptr in
+  // this context.  Since full support for unique_ptr is not quite
+  // available yet, we've implemented it as a MooseSharedPointer.
+  MooseSharedPointer<MooseMesh> & mesh() { return _mesh; }
+  MooseSharedPointer<MooseMesh> & displacedMesh() { return _displaced_mesh; }
+
   FEProblem * & problem() { return _problem; }
   Executioner * & executioner() { return _executioner; }
   MooseApp & mooseApp() { return _app; }
@@ -169,9 +176,11 @@ protected:
   //
 
   /// Mesh class
-  MooseMesh * _mesh;
+  MooseSharedPointer<MooseMesh> _mesh;
+
   /// Possible mesh for displaced problem
-  MooseMesh * _displaced_mesh;
+  MooseSharedPointer<MooseMesh> _displaced_mesh;
+
   /// Problem class
   FEProblem * _problem;
   /// Executioner for the simulation (top-level class, is stored in MooseApp, where it is freed)

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -31,8 +31,6 @@ ActionWarehouse::ActionWarehouse(MooseApp & app, Syntax & syntax, ActionFactory 
     _generator_valid(false),
     _show_actions(false),
     _show_parser(false),
-    _mesh(NULL),
-    _displaced_mesh(NULL),
     _problem(NULL),
     _executioner(NULL)
 {
@@ -63,6 +61,13 @@ ActionWarehouse::clear()
 
   _action_blocks.clear();
   _generator_valid = false;
+
+  // Due to the way ActionWarehouse is cleaned up (see MooseApp's
+  // destructor) we must guarantee that ActionWarehouse::clear()
+  // releases all the resources which have to be released _before_ the
+  // _comm object owned by the MooseApp is destroyed.
+  _mesh.reset();
+  _displaced_mesh.reset();
 }
 
 void

--- a/framework/src/actions/AddMeshModifierAction.C
+++ b/framework/src/actions/AddMeshModifierAction.C
@@ -39,14 +39,14 @@ AddMeshModifierAction::act()
 
   // Add a pointer to the mesh, this is required for this MeshModifier to inheret from the BlockRestrictable,
   // as is the case for SideSetAroundSubdomain
-  _moose_object_pars.set<MooseMesh *>("_mesh") = _mesh;
+  _moose_object_pars.set<MooseMesh *>("_mesh") = _mesh.get();
 
   // Create the modifier object and run it
   MooseSharedPointer<MeshModifier> mesh_modifier = MooseSharedNamespace::static_pointer_cast<MeshModifier>(_factory.create_shared_ptr(_type, getShortName(), _moose_object_pars));
   mooseAssert(_mesh != NULL, "Mesh hasn't been created");
 
   // Run the modifier on the normal mesh
-  mesh_modifier->setMeshPointer(_mesh);
+  mesh_modifier->setMeshPointer(_mesh.get());
   mesh_modifier->modify();
 
   // We'll need to prepare again!
@@ -55,7 +55,7 @@ AddMeshModifierAction::act()
   // Run the modifier on the displaced mesh
   if (_displaced_mesh)
   {
-    mesh_modifier->setMeshPointer(_displaced_mesh);
+    mesh_modifier->setMeshPointer(_displaced_mesh.get());
     mesh_modifier->modify();
     _displaced_mesh->prepared(false);
   }

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -57,7 +57,7 @@ CreateProblemAction::act()
   {
     // build the problem only if we have mesh
     {
-      _moose_object_pars.set<MooseMesh *>("mesh") = _mesh;
+      _moose_object_pars.set<MooseMesh *>("mesh") = _mesh.get();
       _moose_object_pars.set<bool>("use_nonlinear") = _app.useNonlinear();
       _problem = dynamic_cast<FEProblem *>(_factory.create(_type, _problem_name, _moose_object_pars));
       if (_problem == NULL)

--- a/framework/src/actions/InitDisplacedProblemAction.C
+++ b/framework/src/actions/InitDisplacedProblemAction.C
@@ -42,6 +42,6 @@ InitDisplacedProblemAction::act()
   {
     InputParameters params = validParams<DisplacedProblem>();
     params.set<std::vector<std::string> >("displacements") = getParam<std::vector<std::string> >("displacements");
-    _problem->initDisplacedProblem(_displaced_mesh, params);
+    _problem->initDisplacedProblem(_displaced_mesh.get(), params);
   }
 }

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -129,13 +129,13 @@ void
 SetupMeshAction::act()
 {
   // Create the mesh object and tell it to build itself
-  _mesh = dynamic_cast<MooseMesh *>(_factory.create(_type, "mesh", _moose_object_pars));
+  _mesh = MooseSharedNamespace::static_pointer_cast<MooseMesh>(_factory.create_shared_ptr(_type, "mesh", _moose_object_pars));
   _mesh->init();
 
   if (isParamValid("displacements"))
   {
     // Create the displaced mesh
-    _displaced_mesh = dynamic_cast<MooseMesh *>(_factory.create(_type, "displaced_mesh", _moose_object_pars));
+    _displaced_mesh = MooseSharedNamespace::static_pointer_cast<MooseMesh>(_factory.create_shared_ptr(_type, "displaced_mesh", _moose_object_pars));
     _displaced_mesh->init();
 
     std::vector<std::string> displacements = getParam<std::vector<std::string> >("displacements");
@@ -143,8 +143,8 @@ SetupMeshAction::act()
       mooseError("Number of displacements and dimension of mesh MUST be the same!");
   }
 
-  setupMesh(_mesh);
+  setupMesh(_mesh.get());
 
   if (_displaced_mesh)
-    setupMesh(_displaced_mesh);
+    setupMesh(_displaced_mesh.get());
 }

--- a/framework/src/actions/SetupMeshCompleteAction.C
+++ b/framework/src/actions/SetupMeshCompleteAction.C
@@ -49,10 +49,8 @@ SetupMeshCompleteAction::act()
   if (!_mesh)
     mooseError("No mesh file was supplied and no generation block was provided");
 
-  completeSetup(_mesh);
-//  if (completeSetup(_mesh))
-//    _mesh->printInfo();
+  completeSetup(_mesh.get());
 
   if (_displaced_mesh)
-    completeSetup(_displaced_mesh);
+    completeSetup(_displaced_mesh.get());
 }

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -250,8 +250,6 @@ FEProblem::~FEProblem()
       delete it->second;
   }
 
-  delete &_mesh;
-  delete _displaced_mesh;
   delete _displaced_problem;
   delete &_nl;
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -330,7 +330,7 @@ MooseApp::meshOnly(std::string mesh_file_name)
   _action_warehouse.executeActionsWithAction("setup_mesh_complete");
 
   // uniform refinement
-  MooseMesh * mesh = _action_warehouse.mesh();
+  MooseSharedPointer<MooseMesh> & mesh = _action_warehouse.mesh();
   MeshRefinement mesh_refinement(mesh->getMesh());
   mesh_refinement.uniformly_refine(mesh->uniformRefineLevel());
 
@@ -365,11 +365,6 @@ MooseApp::meshOnly(std::string mesh_file_name)
     // Just write the file using the name requested by the user.
     mesh->getMesh().write(mesh_file_name);
   }
-
-  // Since we are not going to create a problem the mesh
-  // will not get cleaned up, so we'll do it here
-  delete mesh;
-  delete _action_warehouse.displacedMesh();
 }
 
 void

--- a/python/TestHarness/suppressions/errors.supp
+++ b/python/TestHarness/suppressions/errors.supp
@@ -48,3 +48,33 @@
    fun:scalable_free
    fun:*
 }
+{
+   openmpi_mpi_init_leak
+   Memcheck:Leak
+   ...
+   fun:ompi_mpi_init
+   ...
+}
+{
+   openmpi_mpi_init_param
+   Memcheck:Param
+   writev(vector[...])
+   ...
+   fun:ompi_mpi_init
+   ...
+}
+{
+   openmpi_opal_event_base_loop
+   Memcheck:Leak
+   ...
+   fun:opal_event_base_loop
+   ...
+}
+{
+   openmpi_attr_create_keyval
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:ompi_attr_create_keyval
+   ...
+}


### PR DESCRIPTION
The `_mesh` and `_displaced_mesh` objects owned by the `ActionWarehouse` were neither created nor destroyed by the `ActionWarehouse`.  This led to a situation where those objects were deleted in more than one place.  Using the memory management capabilities of MooseSharedPointer makes this unnecessary.  Note that we are not using the reference-counting capabilities of MooseSharedPointer since, as far as I could tell, it was not necessary.  So these are actually closer to `unique_ptr`s in spirit, but robust support for those in MOOSE isn't quite ready yet...

I've also run this through valgrind and it's clean.  The branch also adds some suppressions for OpenMPI that I came across, so we can run the valgrind target on OpenMPI-based stacks now too if desired...

Refs #3446, #3547.
