### PR TITLE
Cppcheck clean 3745

### DIFF
--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -454,13 +454,12 @@ Node * MultiAppInterpolationTransfer::getNearestNode(const Point & p, Real & dis
 
   for (MeshBase::const_node_iterator node_it = nodes_begin; node_it != nodes_end; ++node_it)
   {
-    Node & node = *(*node_it);
-    Real current_distance = (p-node).size();
+    Real current_distance = (p-*(*node_it)).size();
 
     if (current_distance < distance)
     {
       distance = current_distance;
-      nearest = &node;
+      nearest = *node_it;
     }
   }
 

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -552,13 +552,12 @@ Node * MultiAppNearestNodeTransfer::getNearestNode(const Point & p, Real & dista
 
   for (MeshBase::const_node_iterator node_it = nodes_begin; node_it != nodes_end; ++node_it)
   {
-    Node & node = *(*node_it);
-    Real current_distance = (p-node).size();
+    Real current_distance = (p-*(*node_it)).size();
 
     if (current_distance < distance)
     {
       distance = current_distance;
-      nearest = &node;
+      nearest = *node_it;
     }
   }
 

--- a/test/src/kernels/NanKernel.C
+++ b/test/src/kernels/NanKernel.C
@@ -24,10 +24,9 @@ NanKernel::NanKernel(const std::string & name, InputParameters parameters) :
 Real
 NanKernel::computeQpResidual()
 {
-  Real zero = 0;
-
   if (static_cast<unsigned int>(_t_step) >= _timestep_to_nan)
-    return _grad_u[_qp] * _grad_test[_i][_qp] / zero;
+    //TODO: Once C++11 is fully supported, add "static_assert(std::numeric_limits::has_infinity, some_msg)".
+    return _grad_u[_qp] * _grad_test[_i][_qp] * std::numeric_limits<Real>::infinity();
   else
     return _grad_u[_qp] * _grad_test[_i][_qp];
 }

--- a/unit/src/MemDataTest.C
+++ b/unit/src/MemDataTest.C
@@ -63,5 +63,5 @@ void MemDataTest::test()
   // CPPUNIT_ASSERT( rel_diff < 1.e-2 );
 
   // Clean up the dummy array we created
-  delete dummy_memory;
+  delete[] dummy_memory;
 }


### PR DESCRIPTION
The command

```
cppcheck . -i libmesh -i framework/contrib/ 2> ../cppcheck_errors_clean.txt; 
echo ""; cat ../cppcheck_errors_clean.txt
```

will now show that Moose is cppcheck clean.
