### PR TITLE
Fixing Examples Makefiles problems

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -27,7 +27,7 @@ all:: examples
 # Build the example programs
 examples: $(dirlist)
 
-$(dirlist): $(MOOSE_LIBS)
+$(dirlist): $(moose_LIBS)
 	@$(MAKE) -C $@ $(MAKECMDGOALS) TEST=test_ignore || exit 1
 
 # Rebuild the dependencies for the examples

--- a/examples/ex01_inputfile/Makefile
+++ b/examples/ex01_inputfile/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex01.i,out.e)

--- a/examples/ex02_kernel/Makefile
+++ b/examples/ex02_kernel/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex02.i,out.e)

--- a/examples/ex03_coupling/Makefile
+++ b/examples/ex03_coupling/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all 
 	$(call TEST_exodiff,ex03.i,out.e)

--- a/examples/ex04_bcs/Makefile
+++ b/examples/ex04_bcs/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,7 +36,7 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,dirichlet_bc.i,out_coupled_dirichlet.e)
 	$(call TEST_exodiff,neumann_bc.i,out_coupled_neumann.e)
 	$(call TEST_exodiff,periodic_bc.i,out_pbc.e)

--- a/examples/ex05_amr/Makefile
+++ b/examples/ex05_amr/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex05.i,out.e-s003)

--- a/examples/ex06_transient/Makefile
+++ b/examples/ex06_transient/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex06.i,out.e)

--- a/examples/ex07_ics/Makefile
+++ b/examples/ex07_ics/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,6 +36,6 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,steady.i,steady_out.e)
 	$(call TEST_exodiff,transient.i,transient_out.e)

--- a/examples/ex08_materials/Makefile
+++ b/examples/ex08_materials/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex08.i,out.e)

--- a/examples/ex09_stateful_materials/Makefile
+++ b/examples/ex09_stateful_materials/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex09.i,out.e)

--- a/examples/ex10_aux/Makefile
+++ b/examples/ex10_aux/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex10.i,out.e)

--- a/examples/ex11_prec/Makefile
+++ b/examples/ex11_prec/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,default.i,out.e)

--- a/examples/ex12_pbp/Makefile
+++ b/examples/ex12_pbp/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex12.i,out.e)

--- a/examples/ex13_functions/Makefile
+++ b/examples/ex13_functions/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex13.i,out.e)

--- a/examples/ex14_pps/Makefile
+++ b/examples/ex14_pps/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex14.i,out.e-s006)

--- a/examples/ex15_actions/Makefile
+++ b/examples/ex15_actions/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex15.i,out.e)

--- a/examples/ex16_timestepper/Makefile
+++ b/examples/ex16_timestepper/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex16.i,out.e)

--- a/examples/ex17_dirac/Makefile
+++ b/examples/ex17_dirac/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex17.i,out.e)

--- a/examples/ex18_scalar_kernel/Makefile
+++ b/examples/ex18_scalar_kernel/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex18.i,out.e)

--- a/examples/ex19_dampers/Makefile
+++ b/examples/ex19_dampers/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex19.i,out.e)

--- a/examples/ex20_user_objects/Makefile
+++ b/examples/ex20_user_objects/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	$(call TEST_exodiff,ex20.i,ex20_out.e)

--- a/examples/ex21_debugging/Makefile
+++ b/examples/ex21_debugging/Makefile
@@ -12,6 +12,8 @@ MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+TEST := test_ignore
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
@@ -34,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: $(APPLICATION_NAME)-$(METHOD)
+test: all
 	@echo "ex21 .. N/A"


### PR DESCRIPTION
closes 3751
- The real issue was with the capitalization of the prerequisite in the main Makefile.  That should take care of the race conditions. 
- To get rid of the override error, I simply cheated make.  Each of the Makefiles now have a variable override of "TEST" which is what is used to define the actual test target.  That way I can define what that target does without using double-colon rules or overriding.
