### PR TITLE
Fixing uses of AutoPtr in MOOSE for upcoming libmesh refactoring.

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -289,7 +289,7 @@ public:
    * Sets the mapping between BoundaryID and normal vector
    * Is called by AddAllSideSetsByNormals
    */
-  void setBoundaryToNormalMap(AutoPtr<std::map<BoundaryID, RealVectorValue> > boundary_map);
+  void setBoundaryToNormalMap(std::map<BoundaryID, RealVectorValue> * boundary_map);
 
   /**
    * Sets the set of BoundaryIDs

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -19,7 +19,7 @@
 #include "libmesh/point_locator_base.h"
 
 DiracKernelInfo::DiracKernelInfo() :
-    _point_locator(NULL)
+    _point_locator()
 {
 }
 

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -1200,7 +1200,7 @@ PenetrationThread::computeSlip(FEBase & fe, PenetrationInfo & info)
   //   original projected position of slave node
   std::vector<Point> points(1);
   points[0] = info._starting_closest_point_ref;
-  libMesh::AutoPtr<Elem> side = (info._starting_elem->build_side(info._starting_side_num,false));
+  AutoPtr<Elem> side = info._starting_elem->build_side(info._starting_side_num, false);
   fe.reinit(side.get(), &points);
   const std::vector<Point> & starting_point = fe.get_xyz();
   info._incremental_slip = info._closest_point - starting_point[0];

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1833,9 +1833,9 @@ MooseMesh::setMeshBoundaryIDs(std::set<BoundaryID> boundary_IDs)
 }
 
 void
-MooseMesh::setBoundaryToNormalMap(AutoPtr<std::map<BoundaryID, RealVectorValue> > boundary_map)
+MooseMesh::setBoundaryToNormalMap(std::map<BoundaryID, RealVectorValue> * boundary_map)
 {
-  _boundary_to_normal_map = boundary_map;
+  _boundary_to_normal_map.reset(boundary_map);
 }
 
 #ifdef LIBMESH_ENABLE_AMR

--- a/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
+++ b/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
@@ -54,7 +54,7 @@ AddAllSideSetsByNormals::modify()
   _mesh_boundary_ids = _mesh_ptr->meshBoundaryIds();
 
   // Create the map object that will be owned by MooseMesh
-  AutoPtr<std::map<BoundaryID, RealVectorValue> > boundary_map(new std::map<BoundaryID, RealVectorValue>());
+  std::map<BoundaryID, RealVectorValue> * boundary_map = new std::map<BoundaryID, RealVectorValue>;
 
   _visited.clear();
 


### PR DESCRIPTION
This patch does not require a libmesh update to work, it only enforces
proper AutoPtr usage.

Refs #3798.
