### PR TITLE
MultiMooseEnum enhancments

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -49,6 +49,7 @@ class NonlinearSystem;
 class RandomInterface;
 class RandomData;
 class MeshChangedInterface;
+class MultiMooseEnum;
 
 template<>
 InputParameters validParams<FEProblem>();
@@ -178,7 +179,7 @@ public:
                                                               const int maxits);
 
 #ifdef LIBMESH_HAVE_PETSC
-  void storePetscOptions(const std::vector<MooseEnum> & petsc_options,
+  void storePetscOptions(const MultiMooseEnum & petsc_options,
                          const std::vector<std::string> & petsc_options_inames,
                          const std::vector<std::string> & petsc_options_values);
 #endif

--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -104,6 +104,12 @@ extern bool _color_console;
 extern bool _warnings_are_errors;
 
 /**
+ * Variable to turn on exceptions during mooseError() and mooseWarning(), should
+ * only be used with MOOSE unit.
+ */
+extern bool _throw_on_error;
+
+/**
  * Macros for coloring any output stream (_console, std::ostringstream, etc.)
  */
 #define COLOR_BLACK   (Moose::_color_console ? BLACK : "")

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -18,7 +18,6 @@
 #include "GlobalParamsAction.h"
 #include "MooseSyntax.h"
 #include "CommandLine.h"
-#include "MooseEnum.h"
 #include "Syntax.h"
 
 // libMesh

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -27,6 +27,7 @@
 #include "MooseError.h"
 #include "MooseTypes.h"
 #include "MooseEnum.h"
+#include "MultiMooseEnum.h"
 #include "MooseUtils.h"
 
 #ifdef LIBMESH_HAVE_FPARSER
@@ -106,7 +107,7 @@ public:
   void addRequiredParam(const std::string &name, const std::string &doc_string);
 
   /**
-   * This version of addRequiredParam is here for a consistent use with MooseEnum.  Use of
+   * This version of addRequiredParam is here for a consistent use with MooseEnums.  Use of
    * this function for any other type will throw an error.
    */
   template <typename T>
@@ -472,7 +473,7 @@ private:
 
   /**
    * The set of parameters either explicitly set or provided a default value when added
-   * Note: We do not store MooseEnum names in valid params, instead we asked MooseEnums whether
+   * Note: We do not store MooseEnum names in valid params, instead we ask MooseEnums whether
    *       they are valid or not.
    */
   std::set<std::string> _valid_params;
@@ -767,6 +768,16 @@ InputParameters::addRequiredParam<MooseEnum>(const std::string &name, const Moos
 template <>
 inline
 void
+InputParameters::addRequiredParam<MultiMooseEnum>(const std::string &name, const MultiMooseEnum &moose_enum, const std::string &doc_string)
+{
+  InputParameters::set<MultiMooseEnum>(name) = moose_enum;               // valid parameter is set by set_attributes
+  _required_params.insert(name);
+  _doc_string[name] = doc_string;
+}
+
+template <>
+inline
+void
 InputParameters::addRequiredParam<std::vector<MooseEnum> >(const std::string &name, const std::vector<MooseEnum> &moose_enums, const std::string &doc_string)
 {
   InputParameters::set<std::vector<MooseEnum> >(name) = moose_enums;    // valid parameter is set by set_attributes
@@ -780,6 +791,14 @@ void
 InputParameters::addParam<MooseEnum>(const std::string & /*name*/, const std::string & /*doc_string*/)
 {
   mooseError("You must supply a MooseEnum object when using addParam, even if the parameter is not required!");
+}
+
+template <>
+inline
+void
+InputParameters::addParam<MultiMooseEnum>(const std::string & /*name*/, const std::string & /*doc_string*/)
+{
+  mooseError("You must supply a MultiMooseEnum object when using addParam, even if the parameter is not required!");
 }
 
 template <>

--- a/framework/include/utils/MooseEnum.h
+++ b/framework/include/utils/MooseEnum.h
@@ -44,6 +44,8 @@ public:
    */
   MooseEnum(const MooseEnum & other_enum);
 
+  virtual ~MooseEnum();
+
   /**
    * Cast operators to make this object behave as value_types and std::string
    * these methods can be used so that this class behaves more like a normal value_type enumeration

--- a/framework/include/utils/MooseEnumBase.h
+++ b/framework/include/utils/MooseEnumBase.h
@@ -40,6 +40,9 @@ public:
    */
   MooseEnumBase(const MooseEnumBase & other_enum);
 
+  /// Destructor
+  virtual ~MooseEnumBase();
+
   /**
    * Method for returning a vector of all valid enumeration names for this instance
    * @return a vector of names

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -92,17 +92,14 @@ public:
   void push_back(const std::set<std::string> & names);
   ///@}
 
-  ///@{
   /**
-   * Indexing operators
-   * Operator to retrieve an item from the MultiMooseEnum. The reference may be used to change
+   * Indexing operator
+   * Operator to retrieve an item from the MultiMooseEnum. The reference may not be used to change
    * the item.
    * @param i index
    * @returns a read/read-write reference to the item.
    */
-  std::string & operator[](unsigned int i);
   const std::string & operator[](unsigned int i) const;
-  ///@}
 
   ///@{
   /**

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -21,7 +21,7 @@
 
 #include <set>
 
-typedef std::set<std::string>::const_iterator MooseEnumIterator;
+typedef std::vector<std::string>::const_iterator MooseEnumIterator;
 
 /**
  * This is a "smart" enum class intended to replace many of the shortcomings in the C++ enum type
@@ -83,13 +83,25 @@ public:
   ///@{
   /**
    * Insert operators
-   * Operator to insert values into the enum. Existing values are preserved and
-   * duplicates are discarded.
+   * Operator to insert (push_back) values into the enum. Existing values are preserved and
+   * duplicates are stored.
    * @param names - a string, set, or vector representing one of the enumeration values.
    */
-  void insert(const std::string & names);
-  void insert(const std::vector<std::string> & names);
-  void insert(const std::set<std::string> & names);
+  void push_back(const std::string & names);
+  void push_back(const std::vector<std::string> & names);
+  void push_back(const std::set<std::string> & names);
+  ///@}
+
+  ///@{
+  /**
+   * Indexing operators
+   * Operator to retrieve an item from the MultiMooseEnum. The reference may be used to change
+   * the item.
+   * @param i index
+   * @returns a read/read-write reference to the item.
+   */
+  std::string & operator[](unsigned int i);
+  const std::string & operator[](unsigned int i) const;
   ///@}
 
   ///@{
@@ -108,9 +120,14 @@ public:
   void clear();
 
   /**
-   * Return the number of items in the MooseEnum
+   * Return the number of items in the MultiMooseEnum
    */
-  unsigned int size() const { return _current_ids.size(); }
+  unsigned int size() const;
+
+  /**
+   * Returns the number of unique items in the MultiMooseEnum
+   */
+  unsigned int unique_items_size() const;
 
   /**
    * IsValid
@@ -132,14 +149,18 @@ private:
    */
   MultiMooseEnum();
 
-  MultiMooseEnum & assign(const std::set<std::string> &names, bool append);
+  /**
+   * Helper method for all inserts and assignment operators
+   */
+  template<typename InputIterator>
+  MultiMooseEnum & assign(InputIterator first, InputIterator last, bool append);
 
   /// The current id
-  std::set<int> _current_ids;
+  std::vector<int> _current_ids;
 
   /// The corresponding name
-  std::set<std::string> _current_names;
-  std::set<std::string> _current_names_preserved;
+  std::vector<std::string> _current_names;
+  std::vector<std::string> _current_names_preserved;
 };
 
 #endif //VECTORMOOSEENUM_H

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -48,6 +48,8 @@ public:
    */
   MultiMooseEnum(const MultiMooseEnum & other_enum);
 
+  virtual ~MultiMooseEnum();
+
   /**
    * Comparison operators for comparing with character constants, MultiMooseEnums
    * or integer values

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -21,6 +21,7 @@
 #include "FEProblem.h"
 #include "ActionWarehouse.h"
 #include "MooseEnum.h"
+#include "MultiMooseEnum.h"
 
 template<>
 InputParameters validParams<CreateExecutionerAction>()
@@ -71,10 +72,9 @@ CreateExecutionerAction::populateCommonExecutionerParams(InputParameters & param
   params.addParam<MooseEnum>   ("line_search",     line_search, "Specifies the line search type" + addtl_doc_str);
 
 #ifdef LIBMESH_HAVE_PETSC
-  MooseEnum common_petsc_options("", "", true);
-  std::vector<MooseEnum> common_petsc_options_vec(1, common_petsc_options);
+  MultiMooseEnum common_petsc_options("", "", true);
 
-  params.addParam<std::vector<MooseEnum> >("petsc_options", common_petsc_options_vec, "Singleton PETSc options");
+  params.addParam<MultiMooseEnum>("petsc_options", common_petsc_options, "Singleton PETSc options");
   params.addParam<std::vector<std::string> >("petsc_options_iname", "Names of PETSc name/value pairs");
   params.addParam<std::vector<std::string> >("petsc_options_value", "Values of PETSc name/value pairs (must correspond with \"petsc_options_iname\"");
 #endif //LIBMESH_HAVE_PETSC
@@ -155,7 +155,7 @@ CreateExecutionerAction::storeCommonExecutionerParams(FEProblem & fe_problem, In
     fe_problem.solverParams()._line_search = Moose::stringToEnum<Moose::LineSearchType>(line_search);
 
 #ifdef LIBMESH_HAVE_PETSC
-  std::vector<MooseEnum>   petsc_options       = params.get<std::vector<MooseEnum> >  ("petsc_options");
+  MultiMooseEnum           petsc_options       = params.get<MultiMooseEnum>("petsc_options");
   std::vector<std::string> petsc_options_iname = params.get<std::vector<std::string> >("petsc_options_iname");
   std::vector<std::string> petsc_options_value = params.get<std::vector<std::string> >("petsc_options_value");
 

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3861,7 +3861,7 @@ FEProblem::storePetscOptions(const MultiMooseEnum & petsc_options,
     }
 
     if (find(po.begin(), po.end(), *it) == po.end())
-      po.insert(*it);
+      po.push_back(*it);
   }
 
   std::vector<std::string> & pn = parameters().set<std::vector<std::string> >("petsc_inames");         // set because we need a writable reference

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -1013,4 +1013,6 @@ bool _color_console = true;
 
 bool _warnings_are_errors = false;
 
+bool _throw_on_error = false;
+
 } // namespace Moose

--- a/framework/src/outputs/formatters/YAMLFormatter.C
+++ b/framework/src/outputs/formatters/YAMLFormatter.C
@@ -100,6 +100,11 @@ YAMLFormatter::printParams(const std::string &prefix, const std::string & /*full
         oss << "\n" << indent << "    options: " << enum_type->get().getRawNames();
     }
     {
+      InputParameters::Parameter<MultiMooseEnum> * enum_type = dynamic_cast<InputParameters::Parameter<MultiMooseEnum>*>(iter->second);
+      if (enum_type)
+        oss << "\n" << indent << "    options: " << enum_type->get().getRawNames();
+    }
+    {
       InputParameters::Parameter<std::vector<MooseEnum> > * enum_type = dynamic_cast<InputParameters::Parameter<std::vector<MooseEnum> >*>(iter->second);
       if (enum_type)
         oss << "\n" << indent << "    options: " << (enum_type->get())[0].getRawNames();

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -83,7 +83,7 @@ InputParameters::set_attributes(const std::string & name, bool inserted_only)
     _set_by_add_param.erase(name);
 
     // valid_params don't make sense for MooseEnums
-    if (!have_parameter<MooseEnum>(name))
+    if (!have_parameter<MooseEnum>(name) && !have_parameter<MultiMooseEnum>(name))
       _valid_params.insert(name);
 
     std::map<std::string, std::string>::const_iterator pos = _deprecated_params.find(name);
@@ -201,6 +201,8 @@ InputParameters::isParamValid(const std::string &name) const
 {
   if (have_parameter<MooseEnum>(name))
     return get<MooseEnum>(name).isValid();
+  else if (have_parameter<MultiMooseEnum>(name))
+    return get<MultiMooseEnum>(name).isValid();
   else
     return _valid_params.find(name) != _valid_params.end();
 }

--- a/framework/src/utils/MooseEnum.C
+++ b/framework/src/utils/MooseEnum.C
@@ -46,6 +46,10 @@ MooseEnum::MooseEnum() :
 {
 }
 
+MooseEnum::~MooseEnum()
+{
+}
+
 MooseEnum &
 MooseEnum::operator=(const std::string & name)
 {

--- a/framework/src/utils/MooseEnumBase.C
+++ b/framework/src/utils/MooseEnumBase.C
@@ -52,6 +52,10 @@ MooseEnumBase::MooseEnumBase()
 {
 }
 
+MooseEnumBase::~MooseEnumBase()
+{
+}
+
 void
 MooseEnumBase::fillNames(std::string names, std::string option_delim)
 {

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -44,6 +44,10 @@ MultiMooseEnum::MultiMooseEnum()
 {
 }
 
+MultiMooseEnum::~MultiMooseEnum()
+{
+}
+
 MultiMooseEnum &
 MultiMooseEnum::operator=(const std::string & names)
 {

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -128,18 +128,10 @@ MultiMooseEnum::push_back(const std::set<std::string> & names)
   assign(names.begin(), names.end(), true);
 }
 
-std::string &
-MultiMooseEnum::operator[](unsigned int i)
-{
-  mooseAssert(i < _current_names.size(), "Access out of bounds in MultiMooseEnum (i: " << i << " size: " << _current_names.size() << ")");
-
-  return _current_names[i];
-}
-
 const std::string &
 MultiMooseEnum::operator[](unsigned int i) const
 {
-  mooseAssert(i < _current_names.size(), "Access out of bounds in MultiMooseEnum (i: " << i << " size: " << _current_names.size() << ")");
+  mooseAssert(i >= _current_names.size(), "Access out of bounds in MultiMooseEnum (i: " << i << " size: " << _current_names.size() << ")");
 
   return _current_names[i];
 }

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -28,6 +28,7 @@
 #include "MooseUtils.h"
 #include "CommandLine.h"
 #include "Console.h"
+#include "MultiMooseEnum.h"
 
 //libMesh Includes
 #include "libmesh/libmesh_common.h"
@@ -163,7 +164,7 @@ void petscSetupDM (NonlinearSystem & nl) {
 void
 petscSetOptions(FEProblem & problem)
 {
-        std::vector<MooseEnum>     petsc_options = problem.parameters().get<std::vector<MooseEnum> >("petsc_options");
+        MultiMooseEnum             petsc_options = problem.parameters().get<MultiMooseEnum>("petsc_options");
   const std::vector<std::string> & petsc_options_inames = problem.parameters().get<std::vector<std::string> >("petsc_inames");
   const std::vector<std::string> & petsc_options_values = problem.parameters().get<std::vector<std::string> >("petsc_values");
 
@@ -182,9 +183,9 @@ petscSetOptions(FEProblem & problem)
 
   setSolverOptions(problem.solverParams());
 
-  // Add any additional options specified in the input fible
-  for (unsigned int i=0; i<petsc_options.size(); ++i)
-    PetscOptionsSetValue(std::string(petsc_options[i]).c_str(), PETSC_NULL);
+  // Add any additional options specified in the input file
+  for (MooseEnumIterator it = petsc_options.begin(); it != petsc_options.end(); ++it)
+    PetscOptionsSetValue(it->c_str(), PETSC_NULL);
   for (unsigned int i=0; i<petsc_options_inames.size(); ++i)
     PetscOptionsSetValue(petsc_options_inames[i].c_str(), petsc_options_values[i].c_str());
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -30,7 +30,7 @@ TENSOR_MECHANICS  := yes
 include           $(MOOSE_DIR)/modules/modules.mk
 ###############################################################################
 
-APPLICATION_DIR := $(MOOSE_DIR)/unit
+APPLICATION_DIR  := $(MOOSE_DIR)/unit
 APPLICATION_NAME := moose_unit
 BUILD_EXEC       := yes
 DEP_APPS    ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))

--- a/unit/include/MooseEnumTest.h
+++ b/unit/include/MooseEnumTest.h
@@ -25,11 +25,13 @@ class MooseEnumTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE( MooseEnumTest );
 
   CPPUNIT_TEST( multiTestOne );
+  CPPUNIT_TEST( testErrors );
 
   CPPUNIT_TEST_SUITE_END();
 
 public:
   void multiTestOne();
+  void testErrors();
 };
 
 #endif  // MOOSEENUMTEST_H

--- a/unit/run_tests
+++ b/unit/run_tests
@@ -8,14 +8,14 @@ fi
 
 if [ -e ./unit/moose_unit-$METHOD ]
 then
-  ./unit/moose_unit-$METHOD
+  ./unit/moose_unit-$METHOD --throw-on-error
   if [ $? -eq 0 ]
   then
     echo $app_name >> test_results.log
   fi
 elif [ -e ./moose_unit-$METHOD ]
 then
-  ./moose_unit-$METHOD
+  ./moose_unit-$METHOD --throw-on-error
   if [ $? -eq 0 ]
   then
     echo $app_name >> ../test_results.log

--- a/unit/src/MooseEnumTest.C
+++ b/unit/src/MooseEnumTest.C
@@ -28,7 +28,7 @@ MooseEnumTest::multiTestOne()
   CPPUNIT_ASSERT( mme.contains("three") == false );
   CPPUNIT_ASSERT( mme.contains("four") == false );
 
-  mme.insert("four");
+  mme.push_back("four");
   CPPUNIT_ASSERT( mme.contains("one") == false );
   CPPUNIT_ASSERT( mme.contains("two") == true );
   CPPUNIT_ASSERT( mme.contains("three") == false );
@@ -40,7 +40,7 @@ MooseEnumTest::multiTestOne()
   mme.clear();
   CPPUNIT_ASSERT ( mme.isValid() == false );
 
-  mme.insert("one three");
+  mme.push_back("one three");
   CPPUNIT_ASSERT( mme.contains("one") == true );
   CPPUNIT_ASSERT( mme.contains("two") == false );
   CPPUNIT_ASSERT( mme.contains("three") == true );
@@ -68,7 +68,7 @@ MooseEnumTest::multiTestOne()
   CPPUNIT_ASSERT( mme.contains("four") == false );
 
   // Insert
-  mme.insert(mvec);
+  mme.push_back(mvec);
   CPPUNIT_ASSERT( mme.contains("one") == true );
   CPPUNIT_ASSERT( mme.contains("two") == true );
   CPPUNIT_ASSERT( mme.contains("three") == true );
@@ -81,14 +81,15 @@ MooseEnumTest::multiTestOne()
   CPPUNIT_ASSERT( mme.contains("three") == false );
   CPPUNIT_ASSERT( mme.contains("four") == true );
 
-  mme.insert("three four");
+  mme.push_back("three four");
   CPPUNIT_ASSERT( mme.contains("one") == true );
   CPPUNIT_ASSERT( mme.contains("two") == false );
   CPPUNIT_ASSERT( mme.contains("three") == true );
   CPPUNIT_ASSERT( mme.contains("four") == true );
 
   // Size
-  CPPUNIT_ASSERT( mme.size() == 3 );
+  CPPUNIT_ASSERT( mme.size() == 4 );
+  CPPUNIT_ASSERT( mme.unique_items_size() == 3 );
 
   // All but "two" should be in the Enum
   std::set<std::string> compare_set, return_set, difference;
@@ -98,6 +99,7 @@ MooseEnumTest::multiTestOne()
   compare_set.insert("ONE");
   compare_set.insert("THREE");
   compare_set.insert("FOUR");
+
 
   std::set_symmetric_difference(return_set.begin(), return_set.end(),
                                 compare_set.begin(), compare_set.end(),

--- a/unit/src/MooseEnumTest.C
+++ b/unit/src/MooseEnumTest.C
@@ -105,6 +105,15 @@ MooseEnumTest::multiTestOne()
                                 compare_set.begin(), compare_set.end(),
                                 std::inserter(difference, difference.end()));
   CPPUNIT_ASSERT( difference.size() == 0 );
+
+  // Order and indexing
+  mme.clear();
+  mme = "one two four";
+  CPPUNIT_ASSERT( mme.contains("three") == false );
+
+  CPPUNIT_ASSERT( mme[0] == "ONE" );
+  CPPUNIT_ASSERT( mme[1] == "TWO" );
+  CPPUNIT_ASSERT( mme[2] == "FOUR" );
 }
 
 void
@@ -132,4 +141,18 @@ MooseEnumTest::testErrors()
     std::string msg(e.what());
     CPPUNIT_ASSERT( msg.find("You cannot place whitespace around the '=' character") != std::string::npos );
   }
+
+#ifndef NDEBUG
+  // Out of bounds access
+  try
+  {
+    MultiMooseEnum error_check("one two three");
+    std::string invalid = error_check[3];
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+    CPPUNIT_ASSERT( msg.find("Access out of bounds") != std::string::npos );
+  }
+#endif
 }

--- a/unit/src/MooseEnumTest.C
+++ b/unit/src/MooseEnumTest.C
@@ -104,3 +104,30 @@ MooseEnumTest::multiTestOne()
                                 std::inserter(difference, difference.end()));
   CPPUNIT_ASSERT( difference.size() == 0 );
 }
+
+void
+MooseEnumTest::testErrors()
+{
+  // Assign invalid item
+  try
+  {
+    MultiMooseEnum error_check("one two three");
+    error_check = "four";
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+    CPPUNIT_ASSERT( msg.find("Invalid option") != std::string::npos );
+  }
+
+  // Whitespace around equals sign
+  try
+  {
+    MultiMooseEnum error_check("one= 1 two three");
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+    CPPUNIT_ASSERT( msg.find("You cannot place whitespace around the '=' character") != std::string::npos );
+  }
+}

--- a/unit/src/main.C
+++ b/unit/src/main.C
@@ -36,6 +36,9 @@ int main(int argc, char **argv)
 
   registerApp(MooseUnitApp);
 
+  // Set the throw_on_error variable for unit tests
+  Moose::_throw_on_error = true;
+
   CppUnit::Test *suite = CppUnit::TestFactoryRegistry::getRegistry().makeTest();
 
   CppUnit::TextTestRunner runner;


### PR DESCRIPTION
- Adding more implementation to the framework for MultiMooseEnum
- Switching petsc_options to MultiMooseEnum

One issue that I see with this implementation is it appears that order may be important for some of these MooseEnums.  There are already two places in MOOSE where we rely on order "coords" and "transforms".  In the former case we need to be able to read in a list of coords and have them correspond with a separate parameter.  In the later case, we need to apply several transforms in series.

I plan to preserve order for this case and will update #3688 to reflect this.  The PR however can be merged since it is dealing with a non-order dependent parameter, petsc_options.
