### PR TITLE
Moose::out to _console

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -16,6 +16,7 @@
 #define ACTION_H
 
 #include "InputParameters.h"
+#include "ConsoleStreamInterface.h"
 
 #include <string>
 #include <ostream>
@@ -35,7 +36,7 @@ InputParameters validParams<Action>();
 /**
  * Base class for actions.
  */
-class Action
+class Action : public ConsoleStreamInterface
 {
 public:
   Action(const std::string & name, InputParameters params);

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -20,7 +20,9 @@
 #include <map>
 #include <ostream>
 
+// MOOSE includes
 #include "Action.h"
+#include "ConsoleStreamInterface.h"
 
 /// Typedef to hide implementation details
 typedef std::vector<Action *>::iterator ActionIterator;
@@ -33,7 +35,7 @@ class ActionFactory;
 /**
  * Storage for action instances.
  */
-class ActionWarehouse
+class ActionWarehouse : public ConsoleStreamInterface
 {
 public:
   ActionWarehouse(MooseApp & app, Syntax & syntax, ActionFactory & factory);

--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -18,6 +18,7 @@
 #include "Moose.h"
 #include "MooseError.h"
 #include "MooseEnum.h"
+#include "ConsoleStreamInterface.h"
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -38,7 +39,7 @@ class MooseVariable;
  * Takes care of everything related to mesh adaptivity
  *
  */
-class Adaptivity
+class Adaptivity : public ConsoleStreamInterface
 {
 public:
   Adaptivity(FEProblem & subproblem);

--- a/framework/include/base/ConsoleStream.h
+++ b/framework/include/base/ConsoleStream.h
@@ -20,7 +20,8 @@
 #include <sstream>
 
 // MOOSE includes
-#include "OutputWarehouse.h"
+class OutputWarehouse;
+
 
 // this is the type of s t d :: c o u t
 typedef std::basic_ostream<char, std::char_traits<char> > CoutType;
@@ -39,7 +40,7 @@ public:
    * Constructor
    * @param output_warehouse A reference to the OutputWarehouse containing the Console outputs
    *
-   * MooseObject contains an instance of this object, which allows message streams to be
+   * ConsoleStreamInterface contains an instance of this object, which allows message streams to be
    * transferred to Console output objects. This class simply provides an operator<< method
    * that passes the stream to the Console objects. Note, that this class inserts a
    * newline at the beginning of each call, but returns a reference to ConsoleStreamHelper
@@ -51,7 +52,7 @@ public:
    * The output stream operator
    * @param s The data to be output to the Console objects
    *
-   * This allows any MooseObject to uses _console to write to the Console:
+   * This allows any object to uses _console to write to the Console:
    *   _console << "The combination to the air lock is " << 12345 << std::endl;
    */
   template<typename T>
@@ -63,6 +64,7 @@ public:
   const ConsoleStream & operator<<(StandardEndLine manip) const;
 
 private:
+
   /// Reference to the OutputWarhouse that contains the Console output objects
   OutputWarehouse & _output_warehouse;
 

--- a/framework/include/base/ConsoleStreamInterface.h
+++ b/framework/include/base/ConsoleStreamInterface.h
@@ -12,21 +12,31 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-// Moose includes
+#ifndef CONSOLESTREAMINTERFACE_H
+#define CONSOLESTREAMINTERFACE_H
+
+// MOOSE includes
 #include "ConsoleStream.h"
-#include "MooseUtils.h"
 
-ConsoleStream::ConsoleStream(OutputWarehouse & output_warehouse) :
-    _output_warehouse(output_warehouse),
-    _oss(output_warehouse.consoleBuffer())
+// Forward declerations
+class MooseApp;
+
+/**
+ * An inteface for the _console for outputting to the Console object
+ */
+class ConsoleStreamInterface
 {
-}
+public:
 
-const ConsoleStream &
-ConsoleStream::operator<<(StandardEndLine /*manip*/) const
-{
-  _oss << '\n';
-  _output_warehouse.mooseConsole();
+  /**
+   * A class for providing a helper stream object for writting message to
+   * all the Output objects.
+   */
+  ConsoleStreamInterface(MooseApp & app);
 
-  return *this;
-}
+  /// An instance of helper class to write streams to the Console objects
+  const ConsoleStream _console;
+
+};
+
+#endif // CONSOLESTREAMINTERFACE_H

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -364,6 +364,9 @@ protected:
   /// Syntax of the input file
   Syntax _syntax;
 
+  /// An alternate OutputWarehouse object (required for CoupledExecutioner)
+  OutputWarehouse * _alternate_output_warehouse;
+
   /// OutputWarehouse object for this App
   OutputWarehouse * _output_warehouse;
 
@@ -375,6 +378,7 @@ protected:
 
   /// Parser for parsing the input file
   Parser _parser;
+
   /// Pointer to the executioner of this run (typically build by actions)
   Executioner * _executioner;
 
@@ -413,9 +417,6 @@ protected:
 
   /// Map of outputer name and file number (used by MultiApps to propagate file numbers down through the multiapps)
   std::map<std::string, unsigned int> _output_file_numbers;
-
-  /// An alternate OutputWarehouse object (required for CoupledExecutioner)
-  OutputWarehouse * _alternate_output_warehouse;
 
   /// Legacy Uo Aux computation flag
   bool _legacy_uo_aux_computation_default;

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -363,8 +363,13 @@ protected:
 
   /// Syntax of the input file
   Syntax _syntax;
+
+  /// OutputWarehouse object for this App
+  OutputWarehouse * _output_warehouse;
+
   /// The Factory responsible for building Actions
   ActionFactory _action_factory;
+
   /// Where built actions are stored
   ActionWarehouse _action_warehouse;
 
@@ -408,9 +413,6 @@ protected:
 
   /// Map of outputer name and file number (used by MultiApps to propagate file numbers down through the multiapps)
   std::map<std::string, unsigned int> _output_file_numbers;
-
-  /// OutputWarehouse object for this App
-  OutputWarehouse * _output_warehouse;
 
   /// An alternate OutputWarehouse object (required for CoupledExecutioner)
   OutputWarehouse * _alternate_output_warehouse;

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -16,7 +16,7 @@
 #define MOOSEOBJECT_H
 
 #include "InputParameters.h"
-#include "ConsoleStream.h"
+#include "ConsoleStreamInterface.h"
 
 // libMesh includes
 #include "libmesh/parallel_object.h"
@@ -30,7 +30,9 @@ InputParameters validParams<MooseObject>();
 /**
  * Every object that can be built by the factory should be derived from this class.
  */
-class MooseObject : public libMesh::ParallelObject
+class MooseObject :
+  public ConsoleStreamInterface,
+  public libMesh::ParallelObject
 {
 public:
   MooseObject(const std::string & name, InputParameters parameters);
@@ -86,9 +88,6 @@ protected:
 
   /// The MooseApp this object is associated with
   MooseApp & _app;
-
-  /// An instance of helper class to write streams to the Console objects
-  const ConsoleStream _console;
 };
 
 #endif /* MOOSEOBJECT_H*/

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -111,7 +111,7 @@ public:
    *
    * @see Output::initOutputList
    */
-  void  buildMaterialOutputHideList(const std::string & name, std::vector<std::string> & hide);
+  void buildMaterialOutputHideList(const std::string & name, std::vector<std::string> & hide);
 
   /**
    * Calls the setFileNumber method for every FileOutput output object

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -20,6 +20,7 @@
 #include "CommandLine.h"
 #include "MooseEnum.h"
 #include "Syntax.h"
+#include "ConsoleStreamInterface.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -37,7 +38,7 @@ class ActionFactory;
  * Class for parsing input files. This class utilizes the GetPot library for actually tokenizing and parsing files. It is not
  * currently designed for extensibility. If you wish to build your own parser, please contact the MOOSE team for guidance.
  */
-class Parser
+class Parser : public ConsoleStreamInterface
 {
 public:
   enum SyntaxFormatterType

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -35,6 +35,7 @@ InputParameters validParams<Action>()
 }
 
 Action::Action(const std::string & name, InputParameters params) :
+    ConsoleStreamInterface(*params.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     _name(name),
     _pars(params),
     _registered_identifier(isParamValid("registered_identifier") ? getParam<std::string>("registered_identifier") : ""),

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -25,6 +25,7 @@
 #include "InfixIterator.h"
 
 ActionWarehouse::ActionWarehouse(MooseApp & app, Syntax & syntax, ActionFactory & factory) :
+    ConsoleStreamInterface(app),
     _app(app),
     _syntax(syntax),
     _action_factory(factory),
@@ -284,7 +285,7 @@ ActionWarehouse::printActionDependencySets() const
   }
 
   if (_show_actions)
-    Moose::out << oss.str() << std::endl;
+    _console << oss.str() << std::endl;
 }
 
 void
@@ -292,10 +293,10 @@ ActionWarehouse::executeAllActions()
 {
   if (_show_actions)
   {
-    Moose::out << "[DBG][ACT] Action Dependency Sets:\n";
+    _console << "[DBG][ACT] Action Dependency Sets:\n";
     printActionDependencySets();
 
-    Moose::out << "\n[DBG][ACT] Executing actions:" << std::endl;
+    _console << "\n[DBG][ACT] Executing actions:" << std::endl;
   }
 
 
@@ -317,7 +318,7 @@ ActionWarehouse::executeActionsWithAction(const std::string & task)
        ++act_iter)
   {
     if (_show_actions)
-      Moose::out << "[DBG][ACT] " << (*act_iter)->type() << " (" << COLOR_YELLOW << task << COLOR_DEFAULT << ")"  << std::endl;
+      _console << "[DBG][ACT] " << (*act_iter)->type() << " (" << COLOR_YELLOW << task << COLOR_DEFAULT << ")"  << std::endl;
     (*act_iter)->act();
   }
 }

--- a/framework/src/actions/SetupRecoverFileBaseAction.C
+++ b/framework/src/actions/SetupRecoverFileBaseAction.C
@@ -57,7 +57,7 @@ SetupRecoverFileBaseAction::act()
   }
 
   // Set the recover file base in the App
-  Moose::out << "\nUsing " << _app.getRecoverFileBase() << " for recovery.\n" << std::endl;
+  _console << "\nUsing " << _app.getRecoverFileBase() << " for recovery.\n" << std::endl;
 }
 
 std::string

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -31,6 +31,7 @@
 #ifdef LIBMESH_ENABLE_AMR
 
 Adaptivity::Adaptivity(FEProblem & subproblem) :
+    ConsoleStreamInterface(subproblem.getMooseApp()),
     _subproblem(subproblem),
     _mesh(_subproblem.mesh()),
     _mesh_refinement_on(false),
@@ -166,7 +167,7 @@ Adaptivity::adaptMesh()
 
     if (meshChanged && _print_mesh_changed)
     {
-      Moose::out << "\nMesh Changed:\n";
+      _console << "\nMesh Changed:\n";
       _mesh.printInfo();
     }
   }

--- a/framework/src/base/ConsoleStream.C
+++ b/framework/src/base/ConsoleStream.C
@@ -12,22 +12,22 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "MooseObject.h"
-#include "MooseApp.h"
+// Moose includes
+#include "ConsoleStream.h"
+#include "MooseUtils.h"
+#include "OutputWarehouse.h"
 
-template<>
-InputParameters validParams<MooseObject>()
+ConsoleStream::ConsoleStream(OutputWarehouse & output_warehouse) :
+    _output_warehouse(output_warehouse),
+    _oss(output_warehouse.consoleBuffer())
 {
-  InputParameters params;
-  return params;
 }
 
-
-MooseObject::MooseObject(const std::string & name, InputParameters parameters) :
-  ConsoleStreamInterface(*parameters.get<MooseApp *>("_moose_app")), // Can't call getParam before pars is set
-  ParallelObject(*parameters.get<MooseApp *>("_moose_app")), // Can't call getParam before pars is set
-  _name(name),
-  _pars(parameters),
-  _app(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app"))
+const ConsoleStream &
+ConsoleStream::operator<<(StandardEndLine /*manip*/) const
 {
+  _oss << '\n';
+  _output_warehouse.mooseConsole();
+
+  return *this;
 }

--- a/framework/src/base/ConsoleStreamInterface.C
+++ b/framework/src/base/ConsoleStreamInterface.C
@@ -12,22 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "MooseObject.h"
+// Moose includes
+#include "ConsoleStreamInterface.h"
 #include "MooseApp.h"
 
-template<>
-InputParameters validParams<MooseObject>()
-{
-  InputParameters params;
-  return params;
-}
-
-
-MooseObject::MooseObject(const std::string & name, InputParameters parameters) :
-  ConsoleStreamInterface(*parameters.get<MooseApp *>("_moose_app")), // Can't call getParam before pars is set
-  ParallelObject(*parameters.get<MooseApp *>("_moose_app")), // Can't call getParam before pars is set
-  _name(name),
-  _pars(parameters),
-  _app(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app"))
+ConsoleStreamInterface::ConsoleStreamInterface(MooseApp & app) :
+    _console(app.getOutputWarehouse())
 {
 }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -96,6 +96,7 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     _start_time(0.0),
     _global_time_offset(0.0),
     _command_line(NULL),
+    _alternate_output_warehouse(NULL),
     _output_warehouse(new OutputWarehouse),
     _action_factory(*this),
     _action_warehouse(*this, _syntax, _action_factory),
@@ -112,7 +113,6 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     _recover(false),
     _restart(false),
     _half_transient(false),
-    _alternate_output_warehouse(NULL),
     _legacy_uo_aux_computation_default(true),
     _legacy_uo_initialization_default(true)
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -96,6 +96,7 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     _start_time(0.0),
     _global_time_offset(0.0),
     _command_line(NULL),
+    _output_warehouse(new OutputWarehouse),
     _action_factory(*this),
     _action_warehouse(*this, _syntax, _action_factory),
     _parser(*this, _action_warehouse),
@@ -111,7 +112,7 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     _recover(false),
     _restart(false),
     _half_transient(false),
-    _output_warehouse(new OutputWarehouse),
+
     _alternate_output_warehouse(NULL),
     _legacy_uo_aux_computation_default(true),
     _legacy_uo_initialization_default(true)

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -112,7 +112,6 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     _recover(false),
     _restart(false),
     _half_transient(false),
-
     _alternate_output_warehouse(NULL),
     _legacy_uo_aux_computation_default(true),
     _legacy_uo_initialization_default(true)

--- a/framework/src/executioners/CoupledTransientExecutioner.C
+++ b/framework/src/executioners/CoupledTransientExecutioner.C
@@ -80,7 +80,7 @@ CoupledTransientExecutioner::execute()
 
     for (unsigned int i = 0; i < n_problems; i++)
     {
-      Moose::out << "Solving '" << _fep_mapping[_fe_problems[i]] << "'" << std::endl;
+      _console << "Solving '" << _fep_mapping[_fe_problems[i]] << "'" << std::endl;
       trans[i]->takeStep(_dt);
       projectVariables(*_fe_problems[(i + 1) % n_problems]);
     }

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -85,7 +85,7 @@ EigenExecutionerBase::init()
 {
   if (_app.isRecovering())
   {
-    Moose::out<<"\nCannot recover eigenvalue solves!\nExiting...\n"<<std::endl;
+    _console << "\nCannot recover eigenvalue solves!\nExiting...\n" << std::endl;
     return;
   }
 
@@ -155,7 +155,7 @@ EigenExecutionerBase::makeBXConsistent(Real k)
     }
     std::stringstream ss;
     ss << std::fixed << std::setprecision(10) << _source_integral;
-    Moose::out << " |Bx_0| = " << ss.str() << std::endl;
+    _console << " |Bx_0| = " << ss.str() << std::endl;
   }
 }
 
@@ -210,7 +210,6 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
   // so save old and older solutions before they are changed by the power iteration
   _eigen_sys.saveOldSolutions();
 
-  // _es.parameters.print(Moose::out);
   // save solver control parameters to be modified by the power iteration
   Real tol1 = _problem.es().parameters.get<Real> ("linear solver tolerance");
   unsigned int num1 = _problem.es().parameters.get<unsigned int>("nonlinear solver maximum iterations");
@@ -221,9 +220,9 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
 
   if (echo)
   {
-    Moose::out << std::endl;
-    Moose::out << " Power iterations starts" << std::endl;
-    Moose::out << " ________________________________________________________________________________ " << std::endl;
+    _console << std::endl;
+    _console << " Power iterations starts" << std::endl;
+    _console << " ________________________________________________________________________________ " << std::endl;
   }
 
   // some iteration variables
@@ -239,7 +238,8 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
   makeBXConsistent(k);
   while (true)
   {
-    if (echo)  Moose::out << " Power iteration= "<< iter << std::endl;
+    if (echo)
+      _console << " Power iteration= "<< iter << std::endl;
 
     // important: solutions of aux system is also copied
     _problem.advanceState();
@@ -283,42 +283,42 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
       std::streamsize pcs = Moose::out.precision();
       if (_solution_diff)
       {
-        Moose::out << std::endl;
-        Moose::out << " +================+=====================+=====================+\n";
-        Moose::out << " | iteration      | eigenvalue          | solution_difference |\n";
-        Moose::out << " +================+=====================+=====================+\n";
+        _console << std::endl;
+        _console << " +================+=====================+=====================+\n";
+        _console << " | iteration      | eigenvalue          | solution_difference |\n";
+        _console << " +================+=====================+=====================+\n";
         unsigned int j = 0;
         if (keff_history.size()>10)
         {
-          Moose::out << " :                :                     :                     :\n";
+          _console << " :                :                     :                     :\n";
           j = keff_history.size()-10;
         }
         for (; j<keff_history.size(); j++)
-          Moose::out << " | " << std::setw(14) << j
+          _console << " | " << std::setw(14) << j
                      << " | " << std::setw(19) << std::scientific << std::setprecision(8) << keff_history[j]
                      << " | " << std::setw(19) << std::scientific << std::setprecision(8) << diff_history[j]
                      << " |\n";
-        Moose::out << " +================+=====================+=====================+\n" << std::flush;
-        Moose::out << std::endl;
+        _console << " +================+=====================+=====================+\n" << std::flush;
+        _console << std::endl;
       }
       else
       {
-        Moose::out << std::endl;
-        Moose::out << " +================+=====================+\n";
-        Moose::out << " | iteration      | eigenvalue          |\n";
-        Moose::out << " +================+=====================+\n";
+        _console << std::endl;
+        _console << " +================+=====================+\n";
+        _console << " | iteration      | eigenvalue          |\n";
+        _console << " +================+=====================+\n";
         unsigned int j = 0;
         if (keff_history.size()>10)
         {
-          Moose::out << " :                :                     :\n";
+          _console << " :                :                     :\n";
           j = keff_history.size()-10;
         }
         for (; j<keff_history.size(); j++)
-          Moose::out << " | " << std::setw(14) << j
+          _console << " | " << std::setw(14) << j
                      << " | " << std::setw(19) << std::scientific << std::setprecision(8) << keff_history[j]
                      << " |\n";
-        Moose::out << " +================+=====================+\n" << std::flush;
-        Moose::out << std::endl;
+        _console << " +================+=====================+\n" << std::flush;
+        _console << std::endl;
       }
       Moose::out.flags(flg);
       Moose::out.precision(pcs);
@@ -331,11 +331,11 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
     {
       chebyshev(iter);
       if (echo)
-        Moose::out << " Chebyshev step: " << chebyshev_parameters.icheb << std::endl;
+        _console << " Chebyshev step: " << chebyshev_parameters.icheb << std::endl;
     }
 
     if (echo)
-      Moose::out << " ________________________________________________________________________________ "
+      _console << " ________________________________________________________________________________ "
                  << std::endl;
 
     // not perform any convergence check when number of iterations is less than min_iter
@@ -401,14 +401,14 @@ EigenExecutionerBase::postExecute()
   Real s = 1.0;
   if (_norm_execflag==EXEC_CUSTOM)
   {
-    Moose::out << " Cannot let the normalization postprocessor on custom." << std::endl;
-    Moose::out << " Normalization is abandoned!" << std::endl;
+    _console << " Cannot let the normalization postprocessor on custom." << std::endl;
+    _console << " Normalization is abandoned!" << std::endl;
   }
   else
   {
     s = normalizeSolution(_norm_execflag!=EXEC_TIMESTEP && _norm_execflag!=EXEC_RESIDUAL);
     if (std::fabs(s-1.0)>std::numeric_limits<Real>::epsilon())
-      Moose::out << " Solution is rescaled with factor " << s << " for normalization!" << std::endl;
+      _console << " Solution is rescaled with factor " << s << " for normalization!" << std::endl;
   }
 
   if (getParam<bool>("output_on_final") || std::fabs(s-1.0)>std::numeric_limits<Real>::epsilon())
@@ -464,7 +464,7 @@ EigenExecutionerBase::printEigenvalue()
   ss << " Eigenvalue = " << std::fixed << std::setprecision(10) << _eigenvalue << std::endl;
   ss << "******************************************************* " << std::endl;
 
-  Moose::out << ss.str();
+  _console << ss.str();
 }
 
 EigenExecutionerBase::Chebyshev_Parameters::Chebyshev_Parameters ()

--- a/framework/src/executioners/NonlinearEigen.C
+++ b/framework/src/executioners/NonlinearEigen.C
@@ -57,7 +57,7 @@ NonlinearEigen::init()
     _problem.advanceState();
 
     // free power iterations
-    Moose::out << std::endl << " Free power iteration starts"  << std::endl;
+    _console << std::endl << " Free power iteration starts"  << std::endl;
 
     Real initial_res;
     inversePowerIteration(_free_iter, _free_iter, _pfactor, false,
@@ -93,7 +93,7 @@ NonlinearEigen::execute()
 void
 NonlinearEigen::takeStep()
 {
-  Moose::out << " Nonlinear iteration starts"  << std::endl;
+  _console << " Nonlinear iteration starts"  << std::endl;
 
   // nonlinear solve
   _problem.computeUserObjects(EXEC_TIMESTEP_BEGIN, UserObjectWarehouse::PRE_AUX);

--- a/framework/src/geomsearch/PenetrationInfo.C
+++ b/framework/src/geomsearch/PenetrationInfo.C
@@ -35,11 +35,11 @@ dataStore(std::ostream & stream, PenetrationInfo * & pinfo, void * context)
     unsigned int i = 1;
     storeHelper(stream, i, context);
 
-    // Moose::out<<"dataStore<PInfo> Node ptr: "<<pinfo->_node<<std::endl;
-    // Moose::out<<"dataStore<PInfo> Node id: "<<pinfo->_node->id()<<std::endl;
-    // Moose::out<<"dataStore<PInfo> Elem ptr: "<<pinfo->_elem<<std::endl;
-    // Moose::out<<"dataStore<PInfo> Elem id: "<<pinfo->_elem->id()<<std::endl;
-    // Moose::out<<"dataStore<PInfo> Side: "<<pinfo->_side_num<<std::endl;
+    // _console<<"dataStore<PInfo> Node ptr: "<<pinfo->_node<<std::endl;
+    // _console<<"dataStore<PInfo> Node id: "<<pinfo->_node->id()<<std::endl;
+    // _console<<"dataStore<PInfo> Elem ptr: "<<pinfo->_elem<<std::endl;
+    // _console<<"dataStore<PInfo> Elem id: "<<pinfo->_elem->id()<<std::endl;
+    // _console<<"dataStore<PInfo> Side: "<<pinfo->_side_num<<std::endl;
 
     storeHelper(stream, pinfo->_node, context);
     storeHelper(stream, pinfo->_elem, context);
@@ -101,11 +101,11 @@ dataLoad(std::istream & stream, PenetrationInfo * & pinfo, void * context)
     loadHelper(stream, pinfo->_elem, context);
     loadHelper(stream, pinfo->_side_num, context);
 
-    // Moose::out<<"dataLoad<PInfo> Node ptr: "<<pinfo->_node<<std::endl;
-    // Moose::out<<"dataLoad<PInfo> Node id: "<<pinfo->_node->id()<<std::endl;
-    // Moose::out<<"dataLoad<PInfo> Elem ptr: "<<pinfo->_elem<<std::endl;
-    // Moose::out<<"dataLoad<PInfo> Elem id: "<<pinfo->_elem->id()<<std::endl;
-    // Moose::out<<"dataLoad<PInfo> Side: "<<pinfo->_side_num<<std::endl;
+    // _console<<"dataLoad<PInfo> Node ptr: "<<pinfo->_node<<std::endl;
+    // _console<<"dataLoad<PInfo> Node id: "<<pinfo->_node->id()<<std::endl;
+    // _console<<"dataLoad<PInfo> Elem ptr: "<<pinfo->_elem<<std::endl;
+    // _console<<"dataLoad<PInfo> Elem id: "<<pinfo->_elem->id()<<std::endl;
+    // _console<<"dataLoad<PInfo> Side: "<<pinfo->_side_num<<std::endl;
 
     pinfo->_side = pinfo->_elem->build_side(pinfo->_side_num, false).release();
 
@@ -220,4 +220,3 @@ PenetrationInfo::~PenetrationInfo()
 {
   delete _side;
 }
-

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -456,40 +456,33 @@ PenetrationThread::competeInteractions(PenetrationInfo * pi1,
 
   if (pi1->_tangential_distance > _tangential_tolerance &&
       pi2->_tangential_distance > _tangential_tolerance) //out of tol on both faces
-  {
     result=NEITHER_WINS;
-  }
+
   else if (pi1->_tangential_distance == 0.0 &&
       pi2->_tangential_distance > 0.0)                   //on face 1, off face 2
-  {
     result=FIRST_WINS;
-  }
+
   else if (pi2->_tangential_distance == 0.0 &&
            pi1->_tangential_distance > 0.0)              //on face 2, off face 1
-  {
     result=SECOND_WINS;
-  }
+
   else if (pi1->_tangential_distance <= _tangential_tolerance &&
            pi2->_tangential_distance > _tangential_tolerance) //in face 1 tol, out of face 2 tol
-  {
     result=FIRST_WINS;
-  }
+
   else if (pi2->_tangential_distance <= _tangential_tolerance &&
            pi1->_tangential_distance > _tangential_tolerance) //in face 2 tol, out of face 1 tol
-  {
     result=SECOND_WINS;
-  }
+
   else if (pi1->_tangential_distance == 0.0 &&
            pi2->_tangential_distance == 0.0)                  //on both faces
   {
     if (pi1->_distance >= 0.0 && pi2->_distance < 0.0)  //favor face with positive distance (penetrated)
-    {
       result=FIRST_WINS;
-    }
+
     else if (pi2->_distance >= 0.0 && pi1->_distance < 0.0)
-    {
       result=SECOND_WINS;
-    }
+
     else if (std::abs(pi1->_distance) < std::abs(pi2->_distance)) //otherwise, favor the closer face
     {
       //TODO: This could cause an abrupt jump from one face to the other.  Smooth this transition
@@ -507,13 +500,10 @@ PenetrationThread::competeInteractions(PenetrationInfo * pi1,
       //TODO: This could cause an abrupt jump from one face to the other.  Smooth this transition
       //Moose::out<<"Case3:  n: "<<pi1->_node->id()<<" e1: "<<pi1->_elem->id()<<" e2: "<<pi2->_elem->id()<<std::endl;
       if (pi1->_elem->id()<pi2->_elem->id())
-      {
         result=FIRST_WINS;
-      }
+
       else
-      {
         result=SECOND_WINS;
-      }
     }
   }
   else if (pi1->_tangential_distance <= _tangential_tolerance &&
@@ -529,50 +519,38 @@ PenetrationThread::competeInteractions(PenetrationInfo * pi1,
     else if (cer == EDGE_AND_COMMON_NODE) //off side of face, off corner of another face.  Favor the off-side face
     {
       if (pi1->_off_edge_nodes.size() == pi2->_off_edge_nodes.size())
-      {
         mooseError("Invalid off_edge_nodes counts");
-      }
+
       else if (pi1->_off_edge_nodes.size()==2)
-      {
         result=FIRST_WINS;
-      }
+
       else if (pi2->_off_edge_nodes.size()==2)
-      {
         result=SECOND_WINS;
-      }
+
       else
-      {
         mooseError("Invalid off_edge_nodes counts");
-      }
     }
     else //Use the same logic as in the on-face condition (above).  A little copy-paste can't hurt...
     {
       if (pi1->_distance >= 0.0 && pi2->_distance < 0.0)  //favor face with positive distance (penetrated)
-      {
         result=FIRST_WINS;
-      }
+
       else if (pi2->_distance >= 0.0 && pi1->_distance < 0.0)
-      {
         result=SECOND_WINS;
-      }
+
       else if (std::abs(pi1->_distance) < std::abs(pi2->_distance)) //otherwise, favor the closer face
-      {
         result=FIRST_WINS;
-      }
+
       else if (std::abs(pi2->_distance) < std::abs(pi1->_distance)) //otherwise, favor the closer face
-      {
         result=SECOND_WINS;
-      }
+
       else //completely equal.  Favor the one with a smaller element id (for repeatibility)
       {
         if (pi1->_elem->id()<pi2->_elem->id())
-        {
           result=FIRST_WINS;
-        }
+
         else
-        {
           result=SECOND_WINS;
-        }
       }
     }
   }

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -75,7 +75,7 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
   if (_solved)
     return;
 
-  Moose::out << "Fully Solving MultiApp " << _name << std::endl;
+  _console << "Fully Solving MultiApp " << _name << std::endl;
 
   MPI_Comm swapped = Moose::swapLibMeshComm(_my_comm);
 
@@ -95,5 +95,5 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
 
   _solved = true;
 
-  Moose::out << "Finished Solving MultiApp " << _name << std::endl;
+  _console << "Finished Solving MultiApp " << _name << std::endl;
 }

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -517,6 +517,6 @@ MultiApp::globalAppToLocal(unsigned int global_app)
   if (global_app >= _first_local_app && global_app <= _first_local_app + (_my_num_apps-1))
     return global_app-_first_local_app;
 
-  Moose::out << _first_local_app << " " << global_app << '\n';
+  _console << _first_local_app << " " << global_app << '\n';
   mooseError("Invalid global_app!");
 }

--- a/framework/src/outputs/DebugOutput.C
+++ b/framework/src/outputs/DebugOutput.C
@@ -95,8 +95,7 @@ DebugOutput::output()
           << std::left << _sys.variable_name(var_num) + ":" << varResid << "\n";
     }
 
-    Moose::out << oss.str();
-    Moose::out.flush();
+    _console << oss.str() << std::flush;
   }
 }
 

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -36,6 +36,7 @@ OutputWarehouse::OutputWarehouse() :
 
 OutputWarehouse::~OutputWarehouse()
 {
+  // If the output buffer is not empty, it needs to be written
   if (_console_buffer.str().length())
     mooseConsole();
 }
@@ -165,8 +166,8 @@ OutputWarehouse::forceOutput()
 void
 OutputWarehouse::mooseConsole()
 {
+  // Loop through all Console Output objects and pass the current output buffer
   std::vector<Console *> objects = getOutputs<Console>();
-
   if (!objects.empty())
   {
     for (std::vector<Console *>::iterator it = objects.begin(); it != objects.end(); ++it)

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -477,7 +477,8 @@ Parser::buildFullTree(const std::string &search_string)
     }
   }
 
-  _console << _syntax_formatter->print(search_string);
+  // Do not change to _console, we need this printed to the stdout in all cases
+  Moose::out << _syntax_formatter->print(search_string) << std::flush;
 }
 
 

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -46,6 +46,7 @@
 #include "libmesh/getpot.h"
 
 Parser::Parser(MooseApp & app, ActionWarehouse & action_wh) :
+    ConsoleStreamInterface(app),
     _app(app),
     _factory(app.getFactory()),
     _action_wh(action_wh),
@@ -288,7 +289,7 @@ Parser::checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_
     if (error_on_warn)
       mooseError(oss.str());
     else
-      Moose::out << oss.str();
+      _console << oss.str();
   }
 }
 
@@ -316,7 +317,7 @@ Parser::checkOverriddenParams(bool error_on_warn)
     if (error_on_warn)
       mooseError(oss.str());
     else
-      Moose::out << oss.str() << std::flush;
+      _console << oss.str() << std::flush;
   }
 }
 
@@ -476,7 +477,7 @@ Parser::buildFullTree(const std::string &search_string)
     }
   }
 
-  Moose::out << _syntax_formatter->print(search_string);
+  _console << _syntax_formatter->print(search_string);
 }
 
 

--- a/framework/src/predictors/SimplePredictor.C
+++ b/framework/src/predictors/SimplePredictor.C
@@ -40,8 +40,8 @@ SimplePredictor::apply(NumericVector<Number> & sln)
   if (_dt_old > 0)
   {
     std::streamsize cur_precision(Moose::out.precision());
-    Moose::out << "  Applying predictor with scale factor = " << std::fixed << std::setprecision(2) << _scale << std::endl;
-    Moose::out << std::scientific << std::setprecision(cur_precision);
+    _console << "  Applying predictor with scale factor = " << std::fixed << std::setprecision(2) << _scale << std::endl;
+    _console << std::scientific << std::setprecision(cur_precision);
 
     Real dt_adjusted_scale_factor = _scale * _dt / _dt_old;
     if (dt_adjusted_scale_factor != 0.0)

--- a/framework/src/timeintegrators/RungeKutta2.C
+++ b/framework/src/timeintegrators/RungeKutta2.C
@@ -71,7 +71,7 @@ RungeKutta2::solve()
   _fe_problem.advanceState();
 
   // ---------------------------------
-  Moose::out << " 2. stage" << std::endl;
+  _console << " 2. stage" << std::endl;
   _stage = 2;
   _fe_problem.time() = time;
   _fe_problem.timeOld() = time_half;

--- a/framework/src/timesteppers/AB2PredictorCorrector.C
+++ b/framework/src/timesteppers/AB2PredictorCorrector.C
@@ -103,7 +103,7 @@ AB2PredictorCorrector::step()
 
       _infnorm = _u1.linfty_norm();
       _e_max = 1.1 * _e_tol * _infnorm;
-      Moose::out << "Time Error Estimate: " << _error << std::endl;
+      _console << "Time Error Estimate: " << _error << std::endl;
     }
     else
     {
@@ -127,7 +127,7 @@ AB2PredictorCorrector::converged()
   }
   else
   {
-    Moose::out << "Marking last solve not converged " << _error << " " << _e_max << std::endl;
+    _console << "Marking last solve not converged " << _error << " " << _e_max << std::endl;
     _dt_steps_taken = 0;
     return false;
   }

--- a/framework/src/timesteppers/DT2.C
+++ b/framework/src/timesteppers/DT2.C
@@ -107,7 +107,7 @@ DT2::step()
     _aux1->close();
 
     // take two steps with dt/2
-    Moose::out << "Taking two dt/2 time steps" << std::endl;
+    _console << "Taking two dt/2 time steps" << std::endl;
 
     // restore solutions to the original state
     *nl_sys.current_local_solution = *_u_saved;
@@ -123,7 +123,7 @@ DT2::step()
     // Compute Post-Aux User Objects (Timestep begin)
     _fe_problem.computeUserObjects();
 
-    Moose::out << "  - 1. step" << std::endl;
+    _console << "  - 1. step" << std::endl;
     Moose::setSolverDefaults(_fe_problem);
     nl.solve();
     _converged = nl.converged();
@@ -139,7 +139,7 @@ DT2::step()
       _fe_problem.onTimestepBegin();
       _fe_problem.computeUserObjects();
 
-      Moose::out << "  - 2. step" << std::endl;
+      _console << "  - 2. step" << std::endl;
       Moose::setSolverDefaults(_fe_problem);
       nl.solve();
       _converged = nl.converged();
@@ -213,7 +213,7 @@ void
 DT2::rejectStep()
 {
   if (_error >= _e_max)
-    Moose::out << "DT2Transient: Marking last solve not converged since |U2-U1|/max(|U2|,|U1|) = "
+    _console << "DT2Transient: Marking last solve not converged since |U2-U1|/max(|U2|,|U1|) = "
                << _error << " >= e_max." << std::endl;
 
   TransientNonlinearImplicitSystem & nl_sys = _fe_problem.getNonlinearSystem().sys();

--- a/framework/src/timesteppers/IterationAdaptiveDT.C
+++ b/framework/src/timesteppers/IterationAdaptiveDT.C
@@ -208,7 +208,7 @@ IterationAdaptiveDT::computeDT()
   }
 
   if (_verbose)
-    Moose::out << diag.str();
+    _console << diag.str();
 
   return dt;
 }
@@ -245,7 +245,7 @@ IterationAdaptiveDT::constrainStep(Real &dt)
   }
 
   if (_verbose)
-    Moose::out << diag.str();
+    _console << diag.str();
 
   return at_sync_point;
 }
@@ -263,7 +263,7 @@ IterationAdaptiveDT::computeFailedDT()
   }
 
   if (!_verbose)
-    Moose::out << std::endl << "Solve failed, cutting timestep" << std::endl;
+    _console << std::endl << "Solve failed, cutting timestep" << std::endl;
 
   diag << std::endl
        << "Solve failed with dt: "
@@ -287,7 +287,7 @@ IterationAdaptiveDT::computeFailedDT()
        << std::endl;
 
   if (_verbose)
-    Moose::out << diag.str();
+    _console << diag.str();
 
   return dt;
 }
@@ -354,7 +354,7 @@ IterationAdaptiveDT::limitDTByFunction(Real & limitedDT)
   }
 
   if (_verbose)
-    Moose::out << diag.str();
+    _console << diag.str();
 }
 
 void
@@ -413,7 +413,7 @@ IterationAdaptiveDT::computeAdaptiveDT(Real &dt, bool allowToGrow, bool allowToS
   }
 
   if (_verbose)
-    Moose::out << diag.str();
+    _console << diag.str();
 }
 
 void
@@ -443,7 +443,7 @@ IterationAdaptiveDT::computeInterpolationDT(Real & dt)
 
   }
   if (_verbose)
-    Moose::out << diag.str();
+    _console << diag.str();
 }
 
 
@@ -487,7 +487,7 @@ IterationAdaptiveDT::acceptStep()
          << _dt_old
          << std::endl;
     if (_verbose)
-      Moose::out << diag.str();
+      _console << diag.str();
   }
   else
   {

--- a/framework/src/timesteppers/SolutionTimeAdaptiveDT.C
+++ b/framework/src/timesteppers/SolutionTimeAdaptiveDT.C
@@ -111,7 +111,7 @@ SolutionTimeAdaptiveDT::computeDT()
 void
 SolutionTimeAdaptiveDT::rejectStep()
 {
-  Moose::out << "Solve failed... cutting timestep" << std::endl;
+  _console << "Solve failed... cutting timestep" << std::endl;
   if (_adapt_log)
     _adaptive_log << "Solve failed... cutting timestep" << std::endl;
 

--- a/framework/src/timesteppers/TimeStepper.C
+++ b/framework/src/timesteppers/TimeStepper.C
@@ -166,7 +166,7 @@ TimeStepper::constrainStep(Real &dt)
 
     if (dt <= 0.0)
     {
-      Moose::out << diag.str();
+      _console << diag.str();
       mooseError("Adjusting to sync_time resulted in a non-positive time step.  dt: "
                  <<dt<<" sync_time: "<<*_sync_times.begin()<<" time: "<<_time);
     }
@@ -176,7 +176,7 @@ TimeStepper::constrainStep(Real &dt)
 
   if (_verbose)
   {
-    Moose::out << diag.str();
+    _console << diag.str();
   }
 
   return at_sync_point;

--- a/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
@@ -58,21 +58,21 @@ MultiAppDTKUserObjectTransfer::execute()
 
     _src_to_tgt_map = new DataTransferKit::VolumeSourceMap<DataTransferKit::Box, GlobalOrdinal, DataTransferKit::MeshContainer<GlobalOrdinal> >(_comm_default, 3, true);
 
-    Moose::out << "--Setting Up Transfer--" << std::endl;
+    _console << "--Setting Up Transfer--" << std::endl;
     if (_variable->isNodal())
       _src_to_tgt_map->setup(_multi_app_geom, _to_adapter->get_target_coords());
     else
       _src_to_tgt_map->setup(_multi_app_geom, _to_adapter->get_elem_target_coords());
 
-    Moose::out << "--Transfer Setup Complete--" << std::endl;
+    _console << "--Transfer Setup Complete--" << std::endl;
 
     _to_values = _to_adapter->get_values_to_fill(_variable->name());
 
   }
 
-  Moose::out << "--Mapping Values--" << std::endl;
+  _console << "--Mapping Values--" << std::endl;
   _src_to_tgt_map->apply(_field_evaluator, _to_values);
-  Moose::out << "--Finished Mapping--" << std::endl;
+  _console << "--Finished Mapping--" << std::endl;
 
   _to_adapter->update_variable_values(_variable->name(), _src_to_tgt_map->getMissedTargetPoints());
   _multi_app->problem()->es().update();

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -71,7 +71,7 @@ MultiAppInterpolationTransfer::initialSetup()
 void
 MultiAppInterpolationTransfer::execute()
 {
-  Moose::out << "Beginning InterpolationTransfer " << _name << std::endl;
+  _console << "Beginning InterpolationTransfer " << _name << std::endl;
 
   switch (_direction)
   {
@@ -444,7 +444,7 @@ MultiAppInterpolationTransfer::execute()
     }
   }
 
-  Moose::out << "Finished InterpolationTransfer " << _name << std::endl;
+  _console << "Finished InterpolationTransfer " << _name << std::endl;
 }
 
 Node * MultiAppInterpolationTransfer::getNearestNode(const Point & p, Real & distance, const MeshBase::const_node_iterator & nodes_begin, const MeshBase::const_node_iterator & nodes_end)

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -356,5 +356,5 @@ MultiAppMeshFunctionTransfer::execute()
     }
   }
 
-  Moose::out << "Finished MeshFunctionTransfer " << _name << std::endl;
+  _console << "Finished MeshFunctionTransfer " << _name << std::endl;
 }

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -60,7 +60,7 @@ MultiAppNearestNodeTransfer::initialSetup()
 void
 MultiAppNearestNodeTransfer::execute()
 {
-  Moose::out << "Beginning NearestNodeTransfer " << _name << std::endl;
+  _console << "Beginning NearestNodeTransfer " << _name << std::endl;
 
   switch (_direction)
   {
@@ -542,7 +542,7 @@ MultiAppNearestNodeTransfer::execute()
     }
   }
 
-  Moose::out << "Finished NearestNodeTransfer " << _name << std::endl;
+  _console << "Finished NearestNodeTransfer " << _name << std::endl;
 }
 
 Node * MultiAppNearestNodeTransfer::getNearestNode(const Point & p, Real & distance, const MeshBase::const_node_iterator & nodes_begin, const MeshBase::const_node_iterator & nodes_end)

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -320,7 +320,7 @@ MultiAppProjectionTransfer::assembleL2From(EquationSystems & es, const std::stri
 void
 MultiAppProjectionTransfer::execute()
 {
-  Moose::out << "Beginning projection transfer " << _name << std::endl;
+  _console << "Beginning projection transfer " << _name << std::endl;
 
   switch (_direction)
   {
@@ -333,7 +333,7 @@ MultiAppProjectionTransfer::execute()
       break;
   }
 
-  Moose::out << "Finished projection transfer " << _name << std::endl;
+  _console << "Finished projection transfer " << _name << std::endl;
 }
 
 void
@@ -396,7 +396,7 @@ MultiAppProjectionTransfer::projectSolution(FEProblem & to_problem, unsigned int
 void
 MultiAppProjectionTransfer::toMultiApp()
 {
-  Moose::out << "Projecting solution" << std::endl;
+  _console << "Projecting solution" << std::endl;
 
   for (unsigned int app = 0; app < _multi_app->numGlobalApps(); app++)
   {
@@ -412,6 +412,6 @@ MultiAppProjectionTransfer::toMultiApp()
 void
 MultiAppProjectionTransfer::fromMultiApp()
 {
-  Moose::out << "Projecting solution" << std::endl;
+  _console << "Projecting solution" << std::endl;
   projectSolution(*_multi_app->problem(), 0);
 }

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -56,7 +56,7 @@ MultiAppUserObjectTransfer::initialSetup()
 void
 MultiAppUserObjectTransfer::execute()
 {
-  Moose::out << "Beginning MultiAppUserObjectTransfer " << _name << std::endl;
+  _console << "Beginning MultiAppUserObjectTransfer " << _name << std::endl;
 
   switch (_direction)
   {
@@ -165,7 +165,7 @@ MultiAppUserObjectTransfer::execute()
 
       unsigned int to_var_num = to_sys.variable_number(to_var.name());
 
-      Moose::out << "Transferring to: " << to_var.name() << std::endl;
+      _console << "Transferring to: " << to_var.name() << std::endl;
 
       // EquationSystems & to_es = to_sys.get_equation_systems();
 
@@ -251,5 +251,5 @@ MultiAppUserObjectTransfer::execute()
     }
   }
 
-  Moose::out << "Finished MultiAppUserObjectTransfer " << _name << std::endl;
+  _console << "Finished MultiAppUserObjectTransfer " << _name << std::endl;
 }

--- a/modules/chemical_reactions/src/actions/AddCoupledEqSpeciesAuxKernelsAction.C
+++ b/modules/chemical_reactions/src/actions/AddCoupledEqSpeciesAuxKernelsAction.C
@@ -162,7 +162,7 @@ AddCoupledEqSpeciesAuxKernelsAction::act()
         params_eq.set<std::vector<VariableName> >("v") = primary_species_involved[j];
         _problem->addAuxKernel("AqueousEquilibriumRxnAux", "aux_"+eq_species[j], params_eq);
 
-        Moose::out << "aux_"+eq_species[j] << "\n";
+        _console << "aux_"+eq_species[j] << "\n";
         params_eq.print();
       }
 //       else

--- a/modules/chemical_reactions/src/actions/AddCoupledEqSpeciesKernelsAction.C
+++ b/modules/chemical_reactions/src/actions/AddCoupledEqSpeciesKernelsAction.C
@@ -274,5 +274,5 @@ AddCoupledEqSpeciesKernelsAction::act()
     }
   }
   oss << "\n";
-  Moose::out << oss.str();
+  _console << oss.str();
 }

--- a/modules/chemical_reactions/src/actions/AddCoupledSolidKinSpeciesAuxKernelsAction.C
+++ b/modules/chemical_reactions/src/actions/AddCoupledSolidKinSpeciesAuxKernelsAction.C
@@ -65,7 +65,7 @@ AddCoupledSolidKinSpeciesAuxKernelsAction::act()
 
     for (unsigned int k=0; k < tokens.size(); k++)
     {
-      Moose::out << tokens[k] << "\t";
+      _console << tokens[k] << "\t";
       std::vector<std::string> stos_vars;
       MooseUtils::tokenize(tokens[k], stos_vars, 1, "()");
       if (stos_vars.size() == 2)
@@ -97,7 +97,7 @@ AddCoupledSolidKinSpeciesAuxKernelsAction::act()
     params_kin.set<std::vector<VariableName> >("v") = rxn_vars;
     _problem->addAuxKernel("KineticDisPreConcAux", "aux_"+solid_kin_species[j], params_kin);
 
-    Moose::out << "aux_"+solid_kin_species[j] << "\n";
+    _console << "aux_"+solid_kin_species[j] << "\n";
     params_kin.print();
   }
 

--- a/modules/chemical_reactions/src/actions/AddCoupledSolidKinSpeciesKernelsAction.C
+++ b/modules/chemical_reactions/src/actions/AddCoupledSolidKinSpeciesKernelsAction.C
@@ -38,15 +38,13 @@ AddCoupledSolidKinSpeciesKernelsAction::act()
   std::vector<NonlinearVariableName> vars = getParam<std::vector<NonlinearVariableName> >("primary_species");
   std::vector<std::string> reactions = getParam<std::vector<std::string> >("kin_reactions");
 
-  Moose::out<< "Solid kinetic reaction list:" << "\n";
+  _console << "Solid kinetic reaction list:" << "\n";
   for (unsigned int i=0; i < reactions.size(); i++)
-  {
-    Moose::out<< reactions[i] << "\n";
-  }
+    _console << reactions[i] << "\n";
 
   for (unsigned int i=0; i < vars.size(); i++)
   {
-    Moose::out << "primary species - " << vars[i] << "\n";
+    _console << "primary species - " << vars[i] << "\n";
     std::vector<bool> primary_participation(reactions.size(), false);
     std::vector<std::string> solid_kin_species(reactions.size());
     std::vector<Real> weight;
@@ -63,7 +61,7 @@ AddCoupledSolidKinSpeciesKernelsAction::act()
 
       for (unsigned int k=0; k < tokens.size(); k++)
       {
-        Moose::out << tokens[k] << "\t";
+        _console << tokens[k] << "\t";
         std::vector<std::string> stos_vars;
         MooseUtils::tokenize(tokens[k], stos_vars, 1, "()");
         if (stos_vars.size() == 2)
@@ -73,8 +71,8 @@ AddCoupledSolidKinSpeciesKernelsAction::act()
           iss >> coef;
           stos[k] = coef;
           rxn_vars[k] = stos_vars[1];
-          Moose::out << "stochiometric: " << stos[k] << "\t";
-          Moose::out << "reactant: " << rxn_vars[k] << "\n";
+          _console << "stochiometric: " << stos[k] << "\t";
+          _console << "reactant: " << rxn_vars[k] << "\n";
           // Check the participation of primary species
           if (rxn_vars[k] == vars[i]) primary_participation[j] = true;
         }
@@ -84,7 +82,7 @@ AddCoupledSolidKinSpeciesKernelsAction::act()
         }
       }
       // Done parsing, recorded stochiometric and variables into separate arrays
-      Moose::out << "whether primary present (0 is not): " << primary_participation[j] << "\n";
+      _console << "whether primary present (0 is not): " << primary_participation[j] << "\n";
 
 
       if (primary_participation[j])
@@ -95,10 +93,10 @@ AddCoupledSolidKinSpeciesKernelsAction::act()
           if (rxn_vars[m] == vars[i])
           {
             weight.push_back(stos[m]);
-            Moose::out << "weight for " << rxn_vars[m] <<" : " << weight[weight.size()-1] << "\n";
+            _console << "weight for " << rxn_vars[m] <<" : " << weight[weight.size()-1] << "\n";
           }
         }
-        Moose::out << "solid kinetic species: " << solid_kin_species[j] << "\n";
+        _console << "solid kinetic species: " << solid_kin_species[j] << "\n";
 
         std::vector<VariableName> coupled_var(1);
         coupled_var[0] = solid_kin_species[j];
@@ -110,10 +108,10 @@ AddCoupledSolidKinSpeciesKernelsAction::act()
         params_kin.set<std::vector<VariableName> >("v") = coupled_var;
         _problem->addKernel("CoupledBEKinetic", vars[i]+"_"+solid_kin_species[j]+"_kin", params_kin);
 
-        Moose::out << vars[i]+"_"+solid_kin_species[j]+"_kin" << "\n";
+        _console << vars[i]+"_"+solid_kin_species[j]+"_kin" << "\n";
         params_kin.print();
       }
     }
-    Moose::out << "\n";
+    _console << "\n";
   }
 }

--- a/modules/chemical_reactions/src/actions/AddSecondarySpeciesAction.C
+++ b/modules/chemical_reactions/src/actions/AddSecondarySpeciesAction.C
@@ -43,7 +43,7 @@ AddSecondarySpeciesAction::act()
 
     for (unsigned int i=0; i < vars.size(); i++)
     {
-      Moose::out << "aux variables: " << vars[i] << "\t";
+      _console << "aux variables: " << vars[i] << "\t";
       FEType fe_type(Utility::string_to_enum<Order>("first"),
                      Utility::string_to_enum<FEFamily>("lagrange"));
       _problem->addAuxVariable(vars[i], fe_type);
@@ -70,13 +70,13 @@ AddSecondarySpeciesAction::act()
           if (stos_vars.size() == 1)
           {
             kin_species = stos_vars[0];
-            Moose::out << "I'm here and the kin_species is: " << stos_vars[0] << "\n";
+            _console << "I'm here and the kin_species is: " << stos_vars[0] << "\n";
 
           }
 //           else
 //             mooseError("There's no solid kinetic species.");
         }
-        Moose::out << "the " << j+1 << "-th solid kinetic species: " << kin_species << "\n";
+        _console << "the " << j+1 << "-th solid kinetic species: " << kin_species << "\n";
         FEType fe_type(Utility::string_to_enum<Order>("first"),
                        Utility::string_to_enum<FEFamily>("lagrange"));
         _problem->addAuxVariable(kin_species, fe_type);

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -163,7 +163,7 @@ ContactMaster::updateContactSet(bool beginning_of_step)
 
       Real resid( -(pinfo->_normal * pinfo->_contact_force) / area );
 
-      // Moose::out << locked_this_step[slave_node_num] << " " << pinfo->_distance << std::endl;
+      // _console << locked_this_step[slave_node_num] << " " << pinfo->_distance << std::endl;
       const Real distance( pinfo->_normal * (pinfo->_closest_point - _mesh.node(node->id())));
 
       if (hpit != has_penetrated.end() &&
@@ -171,7 +171,7 @@ ContactMaster::updateContactSet(bool beginning_of_step)
           resid < -_tension_release &&
           locked_this_step[slave_node_num] < 2)
       {
-        Moose::out << "Releasing node " << node->id() << " " << resid << " < " << -_tension_release << std::endl;
+        _console << "Releasing node " << node->id() << " " << resid << " < " << -_tension_release << std::endl;
         has_penetrated.erase(hpit);
         pinfo->_contact_force.zero();
         pinfo->_mech_status=PenetrationInfo::MS_NO_CONTACT;
@@ -181,7 +181,7 @@ ContactMaster::updateContactSet(bool beginning_of_step)
       {
         if (hpit == has_penetrated.end())
         {
-          Moose::out << "Capturing node " << node->id() << " " << distance << " " << unlocked_this_step[slave_node_num] <<  std::endl;
+          _console << "Capturing node " << node->id() << " " << distance << " " << unlocked_this_step[slave_node_num] <<  std::endl;
           ++locked_this_step[slave_node_num];
           has_penetrated.insert(slave_node_num);
         }

--- a/modules/contact/src/ReferenceResidualProblem.C
+++ b/modules/contact/src/ReferenceResidualProblem.C
@@ -164,7 +164,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string &msg,
 
   if (_solnVars.size() > 0)
   {
-    Moose::out<<"Solution, reference convergence variable norms:"<<std::endl;
+    _console<<"Solution, reference convergence variable norms:"<<std::endl;
     unsigned int maxwsv=0;
     unsigned int maxwrv=0;
     for (unsigned int i=0; i<_solnVars.size(); ++i)
@@ -177,7 +177,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string &msg,
 
     for (unsigned int i=0; i<_solnVars.size(); ++i)
     {
-      Moose::out<<std::setw(maxwsv+2)<<std::left<<_solnVarNames[i]+":"<<_resid[i]<<"  "<<std::setw(maxwrv+2)<<_refResidVarNames[i]+":"<<_refResid[i]<<std::endl;
+      _console<<std::setw(maxwsv+2)<<std::left<<_solnVarNames[i]+":"<<_resid[i]<<"  "<<std::setw(maxwrv+2)<<_refResidVarNames[i]+":"<<_refResid[i]<<std::endl;
     }
   }
 
@@ -217,7 +217,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string &msg,
         oss << "Converged due to function norm " << " < " << " (acceptable relative tolerance) or (acceptable absolute tolerance) for all solution variables" << std::endl;
       else
         oss << "Converged due to function norm " << fnorm << " < " << " (acceptable relative tolerance)" << std::endl;
-      Moose::out<<"ACCEPTABLE"<<std::endl;
+      _console<<"ACCEPTABLE"<<std::endl;
       reason = MOOSE_CONVERGED_FNORM_RELATIVE;
     }
 
@@ -233,7 +233,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string &msg,
 
   msg = oss.str();
 
-//  Moose::out<<msg<<std::endl; //Print convergence diagnostic message
+//  _console<<msg<<std::endl; //Print convergence diagnostic message
   return(reason);
 }
 

--- a/modules/phase_field/src/postprocessors/NodalFloodCount.C
+++ b/modules/phase_field/src/postprocessors/NodalFloodCount.C
@@ -665,7 +665,7 @@ NodalFloodCount::formatBytesUsed() const
     oss << _name << " Memory Used: " << _bytes_used / Real(1<<10) << " KB\n";
   else
     oss << _name << " Memory Used: " << _bytes_used << " Bytes\n";
-  Moose::out << oss.str() << std::endl;
+  _console << oss.str() << std::endl;
 }
 
 

--- a/modules/phase_field/src/userobjects/SPPARKSUserObject.C
+++ b/modules/phase_field/src/userobjects/SPPARKSUserObject.C
@@ -78,7 +78,7 @@ SPPARKSUserObject::SPPARKSUserObject(const std::string & name,
 
 
 
-  Moose::out << std::endl
+  _console << std::endl
             << ">>>> STARTING SPPARKS <<<<" << std::endl;
   spparks_open( 0, NULL, libMesh::COMM_WORLD, &_spparks );
   if (!_spparks)
@@ -88,7 +88,7 @@ SPPARKSUserObject::SPPARKSUserObject(const std::string & name,
 
   char * file = new char[_file.length()+1];
   std::strcpy( file, _file.c_str() );
-  Moose::out << std::endl
+  _console << std::endl
             << ">>>> RUNNING SPPARKS FILE " << _file << " <<<<" << std::endl;
   spparks_file(_spparks, file);
 
@@ -127,7 +127,7 @@ SPPARKSUserObject::SPPARKSUserObject(const std::string & name,
             << ">>>> SPPARKS XYZ: " << xyz_array << " <<<<" << std::endl;
   // for (unsigned i = 0; i < nlcl; ++i)
   // {
-  //   Moose::out << id_array[i] << "\t"
+  //   _console << id_array[i] << "\t"
   //             << xyz_array[i][0] << " "
   //             << xyz_array[i][1] << " "
   //             << xyz_array[i][2] << std::endl;

--- a/modules/richards/src/dirackernels/RichardsBorehole.C
+++ b/modules/richards/src/dirackernels/RichardsBorehole.C
@@ -136,7 +136,7 @@ RichardsBorehole::RichardsBorehole(const std::string & name, InputParameters par
   // do debugging if AndyWilkins
   if (_debug_things)
   {
-    Moose::out << "Checking rotation matrices" << std::endl;
+    _console << "Checking rotation matrices" << std::endl;
     RealVectorValue zzz(0,0,1);
     RealTensorValue iii;
     iii(0,0) = 1;
@@ -148,7 +148,7 @@ RichardsBorehole::RichardsBorehole(const std::string & name, InputParameters par
     for (unsigned int i=0 ; i<_xs.size()-1; ++i)
     {
       // check rotation matrix does the correct rotation
-      Moose::out << i << std::endl;
+      _console << i << std::endl;
       RealVectorValue v2(_xs[i+1] - _xs[i], _ys[i+1] - _ys[i], _zs[i+1] - _zs[i]);
       v2 /= std::sqrt(v2*v2);
       vec0 = _rot_matrix[i]*v2 - zzz;

--- a/modules/solid_mechanics/src/executioners/AdaptiveTransient.C
+++ b/modules/solid_mechanics/src/executioners/AdaptiveTransient.C
@@ -255,7 +255,7 @@ AdaptiveTransient::takeStep(Real input_dt)
   // Compute TimestepBegin Postprocessors
   _problem.computeUserObjects(EXEC_TIMESTEP_BEGIN);
 
-  Moose::out << "Solving time step ";
+  _console << "Solving time step ";
   {
     std::ostringstream out;
 
@@ -282,7 +282,7 @@ AdaptiveTransient::takeStep(Real input_dt)
         << std::showpoint
         << std::left
         << _dt;
-    Moose::out << out.str() << std::endl;
+    _console << out.str() << std::endl;
   }
 
   preSolve();
@@ -328,7 +328,7 @@ AdaptiveTransient::takeStep(Real input_dt)
       _problem.computeUserObjects();
     }
 
-    Moose::out << std::endl;
+    _console << std::endl;
   }
 }
 
@@ -465,9 +465,7 @@ AdaptiveTransient::computeConstrainedDT()
   }
 
   if (_diag.str().size() > 0)
-  {
-    Moose::out << _diag.str() << std::endl;
-  }
+    _console << _diag.str() << std::endl;
 
   return dt_cur;
 

--- a/modules/solid_mechanics/src/materials/CombinedCreepPlasticity.C
+++ b/modules/solid_mechanics/src/materials/CombinedCreepPlasticity.C
@@ -86,7 +86,7 @@ CombinedCreepPlasticity::computeStress( const Elem & current_elem,
 
   if (_output_iteration_info == true)
   {
-    Moose::out
+    _console
       << std::endl
       << "iteration output for CombinedCreepPlasticity solve:"
       << " time=" <<_t
@@ -137,7 +137,7 @@ CombinedCreepPlasticity::computeStress( const Elem & current_elem,
 
     if (_output_iteration_info == true)
     {
-      Moose::out
+      _console
         << "stress_it=" << counter
         << " rel_delS=" << (0 == first_delS ? 0 : delS/first_delS)
         << " rel_tol="  << _relative_tolerance

--- a/modules/solid_mechanics/src/materials/PLC_LSH.C
+++ b/modules/solid_mechanics/src/materials/PLC_LSH.C
@@ -87,7 +87,7 @@ PLC_LSH::computeStress()
 
   if (_output_iteration_info == true)
   {
-    Moose::out
+    _console
       << std::endl
       << "iteration output for combined creep-plasticity solve:"
       << " time=" <<_t
@@ -140,7 +140,7 @@ PLC_LSH::computeStress()
 
     if (_output_iteration_info == true)
     {
-      Moose::out
+      _console
         << "stress_it=" << counter
         << " rel_delS=" << delS/first_delS
         << " rel_tol="  << _relative_tolerance
@@ -213,7 +213,7 @@ PLC_LSH::computeCreep( const SymmTensor & strain_increment,
 
     if (_output_iteration_info == true)
     {
-      Moose::out
+      _console
       << "crp_it="    << it
       << " trl_strs=" << effective_trial_stress
       << " phi="      << phi
@@ -306,7 +306,7 @@ PLC_LSH::computeLSH( const SymmTensor & strain_increment,
 
       if (_output_iteration_info == true)
       {
-        Moose::out
+        _console
           << "pls_it="    << it
           << " trl_strs=" << effective_trial_stress
           << " del_p="    << scalar_plastic_strain_increment

--- a/modules/solid_mechanics/src/materials/ReturnMappingModel.C
+++ b/modules/solid_mechanics/src/materials/ReturnMappingModel.C
@@ -117,9 +117,8 @@ ReturnMappingModel::computeStress( const Elem & /*current_elem*/, unsigned qp,
   }
 
   if (_output_iteration_info)
-  {
-    Moose::out << iter_output.str();
-  }
+    _console << iter_output.str();
+
 
   if (it == _max_its &&
      norm_residual > _absolute_tolerance &&

--- a/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -653,11 +653,11 @@ CrackFrontDefinition::updateCrackFrontGeometry()
       _rot_matrix.push_back(rot_mat);
     }
 
-    Moose::out<<"Summary of J-Integral crack front geometry:"<<std::endl;
-    Moose::out<<"index   node id   x coord       y coord       z coord       x dir         y dir          z dir        seg length"<<std::endl;
+    _console<<"Summary of J-Integral crack front geometry:"<<std::endl;
+    _console<<"index   node id   x coord       y coord       z coord       x dir         y dir          z dir        seg length"<<std::endl;
     for (unsigned int i=0; i<crack_front_nodes.size(); ++i)
     {
-      Moose::out<<std::left
+      _console<<std::left
                 <<std::setw(8) <<i+1
                 <<std::setw(10)<<crack_front_nodes[i]->id()
                 <<std::setw(14)<<(*crack_front_nodes[i])(0)
@@ -669,7 +669,7 @@ CrackFrontDefinition::updateCrackFrontGeometry()
                 <<std::setw(14)<<(_segment_lengths[i].first+_segment_lengths[i].second)/2.0
                 <<std::endl;
     }
-    Moose::out<<"overall length: "<<_overall_length<<std::endl;
+    _console<<"overall length: "<<_overall_length<<std::endl;
   }
 }
 

--- a/modules/tensor_mechanics/src/materials/FiniteStrainPlasticBase.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainPlasticBase.C
@@ -150,7 +150,7 @@ FiniteStrainPlasticBase::computeQpStress()
 
   if (!return_successful)
   {
-    Moose::out << "After making " << num_subdivisions << " subdivisions of the strain increment with L2norm " << _strain_increment[_qp].L2norm() << " the returnMap algorithm failed\n";
+    _console << "After making " << num_subdivisions << " subdivisions of the strain increment with L2norm " << _strain_increment[_qp].L2norm() << " the returnMap algorithm failed\n";
     _fspb_debug_stress = _stress_old[_qp];
     _fspb_debug_pm.assign(numberOfYieldFunctions(), 1); // this is chosen arbitrarily - please change if a more suitable value occurs to you!
     _fspb_debug_intnl.resize(numberOfInternalParameters());
@@ -738,38 +738,38 @@ FiniteStrainPlasticBase::lineSearch(Real & nr_res2, RankTwoTensor & stress, cons
 void
 FiniteStrainPlasticBase::checkDerivatives()
 {
-  Moose::out << "\n ++++++++++++++ \nChecking the derivatives\n";
+  _console << "\n ++++++++++++++ \nChecking the derivatives\n";
   outputAndCheckDebugParameters();
 
-  Moose::out << "dyieldFunction_dstress.  Relative L2 norms.\n";
+  _console << "dyieldFunction_dstress.  Relative L2 norms.\n";
   std::vector<RankTwoTensor> df_dstress;
   std::vector<RankTwoTensor> fddf_dstress;
   dyieldFunction_dstress(_fspb_debug_stress, _fspb_debug_intnl, df_dstress);
   fddyieldFunction_dstress(_fspb_debug_stress, _fspb_debug_intnl, fddf_dstress);
   for (unsigned alpha = 0 ; alpha < numberOfYieldFunctions() ; ++alpha)
   {
-    Moose::out << "alpha = " << alpha << " Relative L2norm = " << 2*(df_dstress[alpha] - fddf_dstress[alpha]).L2norm()/(df_dstress[alpha] + fddf_dstress[alpha]).L2norm() << "\n";
-    Moose::out << "Coded:\n";
+    _console << "alpha = " << alpha << " Relative L2norm = " << 2*(df_dstress[alpha] - fddf_dstress[alpha]).L2norm()/(df_dstress[alpha] + fddf_dstress[alpha]).L2norm() << "\n";
+    _console << "Coded:\n";
     df_dstress[alpha].print();
-    Moose::out << "Finite difference:\n";
+    _console << "Finite difference:\n";
     fddf_dstress[alpha].print();
   }
 
-  Moose::out << "dflowPotential_dstress.  Relative L2 norms.\n";
+  _console << "dflowPotential_dstress.  Relative L2 norms.\n";
   std::vector<RankFourTensor> dr_dstress;
   std::vector<RankFourTensor> fddr_dstress;
   dflowPotential_dstress(_fspb_debug_stress, _fspb_debug_intnl, dr_dstress);
   fddflowPotential_dstress(_fspb_debug_stress, _fspb_debug_intnl, fddr_dstress);
   for (unsigned alpha = 0 ; alpha < numberOfYieldFunctions() ; ++alpha)
   {
-    Moose::out << "alpha = " << alpha << " Relative L2norm = " << 2*(dr_dstress[alpha] - fddr_dstress[alpha]).L2norm()/(dr_dstress[alpha] + fddr_dstress[alpha]).L2norm() << "\n";
-    Moose::out << "Coded:\n";
+    _console << "alpha = " << alpha << " Relative L2norm = " << 2*(dr_dstress[alpha] - fddr_dstress[alpha]).L2norm()/(dr_dstress[alpha] + fddr_dstress[alpha]).L2norm() << "\n";
+    _console << "Coded:\n";
     dr_dstress[alpha].print();
-    Moose::out << "Finite difference:\n";
+    _console << "Finite difference:\n";
     fddr_dstress[alpha].print();
   }
 
-  Moose::out << "dflowPotential_dintnl.  Relative L2 norms.\n";
+  _console << "dflowPotential_dintnl.  Relative L2 norms.\n";
   std::vector<std::vector<RankTwoTensor> > dr_dintnl;
   std::vector<std::vector<RankTwoTensor> > fddr_dintnl;
   dflowPotential_dintnl(_fspb_debug_stress, _fspb_debug_intnl, dr_dintnl);
@@ -778,10 +778,10 @@ FiniteStrainPlasticBase::checkDerivatives()
   {
     for (unsigned a = 0 ; a < numberOfInternalParameters() ; ++a)
     {
-      Moose::out << "alpha = " << alpha << " a = " << a << " Relative L2norm = " << 2*(dr_dintnl[alpha][a] - fddr_dintnl[alpha][a]).L2norm()/(dr_dintnl[alpha][a] + fddr_dintnl[alpha][a]).L2norm() << "\n";
-      Moose::out << "Coded:\n";
+      _console << "alpha = " << alpha << " a = " << a << " Relative L2norm = " << 2*(dr_dintnl[alpha][a] - fddr_dintnl[alpha][a]).L2norm()/(dr_dintnl[alpha][a] + fddr_dintnl[alpha][a]).L2norm() << "\n";
+      _console << "Coded:\n";
       dr_dintnl[alpha][a].print();
-      Moose::out << "Finite difference:\n";
+      _console << "Finite difference:\n";
       fddr_dintnl[alpha][a].print();
     }
   }
@@ -865,7 +865,7 @@ FiniteStrainPlasticBase::fddflowPotential_dintnl(const RankTwoTensor & stress, c
 void
 FiniteStrainPlasticBase::checkJacobian()
 {
-  Moose::out << "\n ++++++++++++++ \nChecking the Jacobian\n";
+  _console << "\n ++++++++++++++ \nChecking the Jacobian\n";
   outputAndCheckDebugParameters();
 
   RankFourTensor E_inv = _elasticity_tensor[_qp].invSymm();
@@ -877,20 +877,20 @@ FiniteStrainPlasticBase::checkJacobian()
   std::vector<std::vector<Real> > fdjac;
   fdJacobian(_fspb_debug_stress, _intnl_old[_qp], _fspb_debug_intnl, _fspb_debug_pm, delta_dp, E_inv, fdjac);
 
-  Moose::out << "Hand-coded Jacobian:\n";
+  _console << "Hand-coded Jacobian:\n";
   for (unsigned row = 0 ; row < jac.size() ; ++row)
   {
     for (unsigned col = 0 ; col < jac.size() ; ++col)
-      Moose::out << jac[row][col] << " ";
-    Moose::out << "\n";
+      _console << jac[row][col] << " ";
+    _console << "\n";
   }
 
-  Moose::out << "Finite difference Jacobian:\n";
+  _console << "Finite difference Jacobian:\n";
   for (unsigned row = 0 ; row < fdjac.size() ; ++row)
   {
     for (unsigned col = 0 ; col < fdjac.size() ; ++col)
-      Moose::out << fdjac[row][col] << " ";
-    Moose::out << "\n";
+      _console << fdjac[row][col] << " ";
+    _console << "\n";
   }
 }
 
@@ -968,25 +968,25 @@ FiniteStrainPlasticBase::fdJacobian(const RankTwoTensor & stress, const std::vec
 void
 FiniteStrainPlasticBase::outputAndCheckDebugParameters()
 {
-  Moose::out << "stress = \n";
+  _console << "stress = \n";
   _fspb_debug_stress.print();
 
   if (_fspb_debug_pm.size() != numberOfYieldFunctions() || _fspb_debug_intnl.size() != numberOfInternalParameters() || _fspb_debug_pm_change.size() != numberOfYieldFunctions() || _fspb_debug_intnl_change.size() != numberOfInternalParameters())
     mooseError("The debug parameters have the wrong size\n");
 
-  Moose::out << "plastic multipliers =\n";
+  _console << "plastic multipliers =\n";
   for (unsigned alpha = 0 ; alpha < numberOfYieldFunctions() ; ++alpha)
-    Moose::out << _fspb_debug_pm[alpha] << "\n";
+    _console << _fspb_debug_pm[alpha] << "\n";
 
-  Moose::out << "internal parameters =\n";
+  _console << "internal parameters =\n";
   for (unsigned a = 0 ; a < numberOfInternalParameters() ; ++a)
-    Moose::out << _fspb_debug_intnl[a] << "\n";
+    _console << _fspb_debug_intnl[a] << "\n";
 
-  Moose::out << "finite-differencing parameter for stress-changes:\n" << _fspb_debug_stress_change  << "\n";
-  Moose::out << "finite-differencing parameter(s) for plastic-multiplier(s):\n";
+  _console << "finite-differencing parameter for stress-changes:\n" << _fspb_debug_stress_change  << "\n";
+  _console << "finite-differencing parameter(s) for plastic-multiplier(s):\n";
   for (unsigned alpha = 0 ; alpha < numberOfYieldFunctions() ; ++alpha)
-    Moose::out << _fspb_debug_pm_change[alpha] << "\n";
-  Moose::out << "finite-differencing parameter(s) for internal-parameter(s):\n";
+    _console << _fspb_debug_pm_change[alpha] << "\n";
+  _console << "finite-differencing parameter(s) for internal-parameter(s):\n";
   for (unsigned a = 0 ; a < numberOfInternalParameters() ; ++a)
-    Moose::out << _fspb_debug_intnl_change[a] << "\n";
+    _console << _fspb_debug_intnl_change[a] << "\n";
 }

--- a/test/src/auxkernels/PeriodicDistanceAux.C
+++ b/test/src/auxkernels/PeriodicDistanceAux.C
@@ -31,7 +31,7 @@ PeriodicDistanceAux::PeriodicDistanceAux(const std::string & name, InputParamete
   for (unsigned int i=0; i<LIBMESH_DIM; ++i)
     if (_point(i) < _mesh.getMinInDimension(i) || _point(i) > _mesh.getMaxInDimension(i))
     {
-      Moose::out << _mesh.getMinInDimension(i) << "\t" << _mesh.getMaxInDimension(i) << "\n";
+      _console << _mesh.getMinInDimension(i) << "\t" << _mesh.getMaxInDimension(i) << "\n";
       mooseError("\"point\" is outside of the domain.");
     }
 }

--- a/test/src/dirackernels/StatefulPointSource.C
+++ b/test/src/dirackernels/StatefulPointSource.C
@@ -38,10 +38,9 @@ StatefulPointSource::addPoints()
 Real
 StatefulPointSource::computeQpResidual()
 {
-  Moose::out << "Thermal conductivity=" << _value[_qp] << std::endl;
+  _console << "Thermal conductivity=" << _value[_qp] << std::endl;
 
   // This is negative because it's a forcing function that has been
   // brought over to the left side.
   return -_test[_i][_qp]*_value[_qp];
 }
-

--- a/test/src/problems/MooseTestProblem.C
+++ b/test/src/problems/MooseTestProblem.C
@@ -25,11 +25,10 @@ InputParameters validParams<MooseTestProblem>()
 MooseTestProblem::MooseTestProblem(const std::string & name, InputParameters params) :
     FEProblem(name, params)
 {
-  Moose::out << "Hello, I am your FEProblem-derived class and my name is '" << this->name() << "'" << std::endl;
+  _console << "Hello, I am your FEProblem-derived class and my name is '" << this->name() << "'" << std::endl;
 }
 
 MooseTestProblem::~MooseTestProblem()
 {
-  Moose::out << "Goodbye!" << std::endl;
+  _console << "Goodbye!" << std::endl;
 }
-


### PR DESCRIPTION
Putting this patch together indicates to me that we need a _debug_console, because there are crazy amounts of commented Moose::out statements for debugging throughout the framework and modules. See #3808.

(closes #3340)
