### PR TITLE
Restore DMlibMesh compatibility.  Refs. #3814.

### DIFF
--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -25,7 +25,7 @@
 
 // libMesh Includes
 #include "libmesh/nonlinear_implicit_system.h"
-#include "libmesh/petsc_dm_nonlinear_solver.h"
+#include "libmesh/nonlinear_solver.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/dof_map.h"


### PR DESCRIPTION
Removed the spurious solver-specific include (petsc_dm_nonlinear_solver.h).
In particular, fixed a compilation error due to PetscDMNonlinearSolver being removed from libMesh.
#3814
