### PR TITLE
Removed file_base=out to avoid recover conflicts

### DIFF
--- a/test/tests/outputs/format/output_test_gmv.i
+++ b/test/tests/outputs/format/output_test_gmv.i
@@ -53,7 +53,6 @@
 []
 
 [Outputs]
-  file_base = out
   output_initial = true
   gmv = true
   [./console]

--- a/test/tests/outputs/format/output_test_gnuplot.i
+++ b/test/tests/outputs/format/output_test_gnuplot.i
@@ -59,7 +59,6 @@
 []
 
 [Outputs]
-  file_base = out
   output_initial = true
   gnuplot = true
   [./console]

--- a/test/tests/outputs/format/output_test_gnuplot_gif.i
+++ b/test/tests/outputs/format/output_test_gnuplot_gif.i
@@ -59,9 +59,8 @@
 []
 
 [Outputs]
-  file_base = out_gif
   output_initial = true
-  [./gnuplot]
+  [./out]
     type = Gnuplot
     extension = gif
   [../]

--- a/test/tests/outputs/format/output_test_gnuplot_ps.i
+++ b/test/tests/outputs/format/output_test_gnuplot_ps.i
@@ -59,9 +59,8 @@
 []
 
 [Outputs]
-  file_base = out_ps
   output_initial = true
-  [./gnuplot]
+  [./out]
     type = Gnuplot
     extension = ps
   [../]

--- a/test/tests/outputs/format/output_test_sln.i
+++ b/test/tests/outputs/format/output_test_sln.i
@@ -53,7 +53,6 @@
 []
 
 [Outputs]
-  file_base = out
   output_initial = true
   solution_history = true
   [./console]

--- a/test/tests/outputs/format/output_test_tecplot.i
+++ b/test/tests/outputs/format/output_test_tecplot.i
@@ -53,7 +53,6 @@
 []
 
 [Outputs]
-  file_base = out
   output_initial = true
   tecplot = true
   [./console]

--- a/test/tests/outputs/format/output_test_tecplot_binary.i
+++ b/test/tests/outputs/format/output_test_tecplot_binary.i
@@ -53,15 +53,13 @@
 []
 
 [Outputs]
-  file_base = bin_out
   output_initial = true
   [./console]
     type = Console
     perf_log = true
     linear_residuals = true
   [../]
-
-  [./tecplot]
+  [./out]
     type = Tecplot
     binary = true
   [../]

--- a/test/tests/outputs/format/output_test_xdr.i
+++ b/test/tests/outputs/format/output_test_xdr.i
@@ -53,7 +53,6 @@
 []
 
 [Outputs]
-  file_base = out
   output_initial = true
   xdr = true
   [./console]

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -20,7 +20,7 @@
   [./gmv_out_test]
     type = 'CheckFiles'
     input = 'output_test_gmv.i'
-    check_files = 'out_0000.gmv'
+    check_files = 'output_test_gmv_out_0000.gmv'
     recover = false
   [../]
 
@@ -34,20 +34,20 @@
   [./tecplot_out_test]
     type = 'CheckFiles'
     input = 'output_test_tecplot.i'
-    check_files = 'out_0000.dat'
+    check_files = 'output_test_tecplot_out_0000.dat'
   [../]
 
   [./tecplot_bin_test]
     type = 'CheckFiles'
     input = 'output_test_tecplot_binary.i'
-    check_files = 'bin_out_0000.plt'
+    check_files = 'output_test_tecplot_binary_out_0000.plt'
     tecplot = true
   [../]
 
   [./tecplot_bin_test_override]
     type = 'CheckFiles'
     input = 'output_test_tecplot_binary.i'
-    check_files = 'bin_out_0000.dat'
+    check_files = 'output_test_tecplot_binary_out_0000.dat'
     tecplot = false
   [../]
 
@@ -61,20 +61,19 @@
   [./gnuplot_ps_out_test]
     type = 'CheckFiles'
     input = 'output_test_gnuplot_ps.i'
-    check_files = 'out_ps.gp out_ps.dat'
+    check_files = 'output_test_gnuplot_ps_out.gp output_test_gnuplot_ps_out.dat'
   [../]
 
   [./gnuplot_png_out_test]
     type = 'CheckFiles'
     input = 'output_test_gnuplot.i'
-    check_files = 'out_png.gp out_png.dat'
-    cli_args = 'Outputs/file_base=out_png'
+    check_files = 'output_test_gnuplot_out.gp output_test_gnuplot_out.dat'
   [../]
 
   [./gnuplot_gif_out_test]
     type = 'CheckFiles'
     input = 'output_test_gnuplot_gif.i'
-    check_files = 'out_gif.gp out_gif.dat'
+    check_files = 'output_test_gnuplot_gif_out.gp output_test_gnuplot_gif_out.dat'
   [../]
 
   [./pps_screen_out_warn_test]
@@ -95,12 +94,12 @@
   [./sln_out_test]
     type = 'CheckFiles'
     input = 'output_test_sln.i'
-    check_files = 'out.slh'
+    check_files = 'output_test_sln_out.slh'
   [../]
 
   [./xdr_output]
     type = 'CheckFiles'
     input = 'output_test_xdr.i'
-    check_files = 'out_0001.xdr out_0001_mesh.xdr'
+    check_files = 'output_test_xdr_out_0001.xdr output_test_xdr_out_0001_mesh.xdr'
   [../]
 []


### PR DESCRIPTION
Any test with 'file_base=out' will write checkpoint files to 'out_cp' and on recover it will look in this directory and grab the newest file, which can lead to conflicts.

(closes #3845)
