### PR TITLE
Guarantee cwd for unit app, update naming scheme to stork standard

### DIFF
--- a/unit/Makefile
+++ b/unit/Makefile
@@ -31,7 +31,7 @@ include           $(MOOSE_DIR)/modules/modules.mk
 ###############################################################################
 
 APPLICATION_DIR  := $(MOOSE_DIR)/unit
-APPLICATION_NAME := moose_unit
+APPLICATION_NAME := moose-unit
 BUILD_EXEC       := yes
 DEP_APPS    ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
 include $(FRAMEWORK_DIR)/app.mk

--- a/unit/run_tests
+++ b/unit/run_tests
@@ -1,25 +1,17 @@
 #!/bin/bash
-app_name='unit'
 
+APPLICATION_NAME=moose
 # If $METHOD is not set, use opt
 if [ -z $METHOD ]; then
   export METHOD=opt
 fi
 
-if [ -e ./unit/moose_unit-$METHOD ]
+# set the cwd to the directory run_tests is in
+cd `dirname $0` > /dev/null
+
+if [ -e ./$APPLICATION_NAME-unit-$METHOD ]
 then
-  ./unit/moose_unit-$METHOD --throw-on-error
-  if [ $? -eq 0 ]
-  then
-    echo $app_name >> test_results.log
-  fi
-elif [ -e ./moose_unit-$METHOD ]
-then
-  ./moose_unit-$METHOD --throw-on-error
-  if [ $? -eq 0 ]
-  then
-    echo $app_name >> ../test_results.log
-  fi
+  ./$APPLICATION_NAME-unit-$METHOD
 else
   echo "Executable missing!"
   exit 1


### PR DESCRIPTION
cd into the directory of the `run_tests` script. I'm bringing this script to where the stork script is. Do you need the 

```
echo $app_name >> test_results.log
```

 Line? It seems of little use to me. I've also dropped the `--throw-on-error` cmd line option, as this seems to be set in the executable. The unit tests run fine without it.
