### PR TITLE
Factor out function parser building into DerivativeParsedMaterialHelper

### DIFF
--- a/modules/phase_field/include/materials/DerivativeParsedMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterial.h
@@ -1,8 +1,7 @@
 #ifndef DERIVATIVEPARSEDMATERIAL_H
 #define DERIVATIVEPARSEDMATERIAL_H
 
-#include "DerivativeBaseMaterial.h"
-#include "libmesh/fparser_ad.hh"
+#include "DerivativeParsedMaterialHelper.h"
 
 // Forward Declarations
 class DerivativeParsedMaterial;
@@ -16,51 +15,14 @@ InputParameters validParams<DerivativeParsedMaterial>();
  * This requires the autodiff patch (https://github.com/libMesh/libmesh/pull/238)
  * to Function Parser in libmesh.
  */
-class DerivativeParsedMaterial : public DerivativeBaseMaterial
+class DerivativeParsedMaterial : public DerivativeParsedMaterialHelper
 {
 public:
   DerivativeParsedMaterial(const std::string & name,
-                    InputParameters parameters);
-
-  virtual ~DerivativeParsedMaterial();
+                           InputParameters parameters);
 
 protected:
   virtual unsigned int expectedNumArgs();
-  virtual void computeProperties();
-
-private:
-  void functionsDerivative();
-  void functionsOptimize();
-
-  /// Shorthand for an autodiff function parser object.
-  typedef FunctionParserADBase<Real> ADFunction;
-
-  /// The undiffed free energy function parser object.
-  ADFunction _func_F;
-
-  /// The first derivatives of the free energy (function parser objects).
-  std::vector<ADFunction *> _func_dF;
-
-  /// The second derivatives of the free energy (function parser objects).
-  std::vector<std::vector<ADFunction *> > _func_d2F;
-
-  /// The third derivatives of the free energy (function parser objects).
-  std::vector<std::vector<std::vector<ADFunction *> > > _func_d3F;
-
-  /// Material properties needed by this free energy
-  std::vector<MaterialProperty<Real> *> _mat_props;
-  unsigned int _nmat_props;
-
-  /// Array to stage the parameters passed to the functions when calling Eval.
-  Real * _func_params;
-
-  /// Tolerance values for all arguments (to protect from log(0)).
-  std::vector<Real> _tol;
-
-  // Dummy implementations
-  virtual Real computeF();
-  virtual Real computeDF(unsigned int);
-  virtual Real computeD2F(unsigned int, unsigned int);
 };
 
 #endif // DERIVATIVEPARSEDMATERIAL_H

--- a/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
@@ -1,0 +1,73 @@
+#ifndef DERIVATIVEPARSEDMATERIALHELPER_H
+#define DERIVATIVEPARSEDMATERIALHELPER_H
+
+#include "DerivativeBaseMaterial.h"
+#include "libmesh/fparser_ad.hh"
+
+// Forward Declarations
+class DerivativeParsedMaterialHelper;
+
+template<>
+InputParameters validParams<DerivativeParsedMaterialHelper>();
+
+/**
+ * Helper class to perform the bulk of the bulk of teh auto derivative taking.
+ */
+class DerivativeParsedMaterialHelper : public DerivativeBaseMaterial
+{
+public:
+  DerivativeParsedMaterialHelper(const std::string & name,
+                                 InputParameters parameters);
+
+  virtual ~DerivativeParsedMaterialHelper();
+
+  void functionParse(const std::string & function_expression);
+  void functionParse(const std::string & function_expression,
+                     const std::vector<std::string> & constant_names,
+                     const std::vector<std::string> & constant_expressions);
+  void functionParse(const std::string & function_expression,
+                     const std::vector<std::string> & constant_names,
+                     const std::vector<std::string> & constant_expressions,
+                     const std::vector<std::string> & mat_prop_names,
+                     const std::vector<std::string> & tol_names,
+                     const std::vector<Real> & tol_values);
+
+protected:
+  virtual void computeProperties();
+
+private:
+  void functionsDerivative();
+  void functionsOptimize();
+
+  /// Shorthand for an autodiff function parser object.
+  typedef FunctionParserADBase<Real> ADFunction;
+
+  /// The undiffed free energy function parser object.
+  ADFunction _func_F;
+
+  /// The first derivatives of the free energy (function parser objects).
+  std::vector<ADFunction *> _func_dF;
+
+  /// The second derivatives of the free energy (function parser objects).
+  std::vector<std::vector<ADFunction *> > _func_d2F;
+
+  /// The third derivatives of the free energy (function parser objects).
+  std::vector<std::vector<std::vector<ADFunction *> > > _func_d3F;
+
+  /// Material properties needed by this free energy
+  std::vector<MaterialProperty<Real> *> _mat_props;
+  unsigned int _nmat_props;
+
+  /// Array to stage the parameters passed to the functions when calling Eval.
+  Real * _func_params;
+
+  /// Tolerance values for all arguments (to protect from log(0)).
+  std::vector<Real> _tol;
+
+  // Dummy implementations
+  virtual Real computeF();
+  virtual Real computeDF(unsigned int);
+  virtual Real computeD2F(unsigned int, unsigned int);
+};
+
+#endif // DERIVATIVEPARSEDMATERIALHELPER_H

--- a/modules/phase_field/src/materials/DerivativeParsedMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterial.C
@@ -3,7 +3,7 @@
 template<>
 InputParameters validParams<DerivativeParsedMaterial>()
 {
-  InputParameters params = validParams<DerivativeBaseMaterial>();
+  InputParameters params = validParams<DerivativeParsedMaterialHelper>();
   params.addClassDescription("Parsed Function Material with automatic derivatives.");
 
   // Constants and their values
@@ -22,213 +22,33 @@ InputParameters validParams<DerivativeParsedMaterial>()
   // Function expression
   params.addRequiredParam<std::string>("function", "FParser function expression for the phase free energy");
 
-  // Just in time compilation for the FParser objects
-#ifdef LIBMESH_HAVE_FPARSER_JIT
-  params.addParam<bool>( "enable_jit", false, "Enable Just In Time compilation of the parsed functions (experimental)");
-#endif
   return params;
 }
 
 DerivativeParsedMaterial::DerivativeParsedMaterial(const std::string & name,
                                                    InputParameters parameters) :
-    DerivativeBaseMaterial(name, parameters)
+    DerivativeParsedMaterialHelper(name, parameters)
 {
   // check number of coupled variables
   if (_arg_names.size() == 0)
     mooseError("Need at least one couple variable for DerivativeParsedMaterial.");
 
-  // get and check constant vectors
+  // get constant vectors
   std::vector<std::string> constant_names = getParam<std::vector<std::string> >("constant_names");
   std::vector<std::string> constant_expressions = getParam<std::vector<std::string> >("constant_expressions");
-  unsigned int nconst = constant_expressions.size();
-  if (nconst != constant_expressions.size())
-    mooseError("The parameter vectors constant_names and constant_values must have equal length.");
 
-  // initialize constants
-  ADFunction *expression;
-  std::vector<Real> constant_values(nconst);
-  for (unsigned int i = 0; i < nconst; ++i)
-  {
-    expression = new ADFunction();
-
-    // add previously evaluated constants
-    for (unsigned int j = 0; j < i; ++j)
-      if (!expression->AddConstant(constant_names[j], constant_values[j]))
-        mooseError("Invalid constant name in DerivativeParsedMaterial");
-
-    // build the temporary comnstant expression function
-    if (expression->Parse(constant_expressions[i], "") >= 0)
-       mooseError(std::string("Invalid constant expression\n" + constant_expressions[i] + "\n in DerivativeParsedMaterial. ") + expression->ErrorMsg());
-
-    constant_values[i] = expression->Eval(NULL);
-
-#ifdef DEBUG
-    _console << "Constant value " << i << ' ' << constant_expressions[i] << " = " << constant_values[i] << std::endl;
-#endif
-
-    if (!_func_F.AddConstant(constant_names[i], constant_values[i]))
-      mooseError("Invalid constant name in DerivativeParsedMaterial");
-
-    delete expression;
-  }
-
-  // get and check tolerance vectors
+  // get tolerance vectors
   std::vector<std::string> tol_names = getParam<std::vector<std::string> >("tol_names");
   std::vector<Real> tol_values = getParam<std::vector<Real> >("tol_values");
 
-  if (tol_names.size() != tol_values.size())
-    mooseError("The parameter vectors tol_names and tol_values must have equal length.");
-
-  // set tolerances
-  _tol.resize(_nargs);
-  for (unsigned int i = 0; i < _nargs; ++i)
-  {
-    _tol[i] = -1.0;
-
-    // for every argument look throug the entire tolerance vector to find a match
-    for (unsigned int j = 0; j < tol_names.size(); ++j)
-      if (_arg_names[i] == tol_names[j])
-      {
-        _tol[i] = tol_values[j];
-        break;
-      }
-  }
-
-  // build 'variables' argument for fparser
-  std::string variables = _arg_names[0];
-  for (unsigned i = 1; i < _arg_names.size(); ++i)
-    variables += "," + _arg_names[i];
-
   // get material property names
   std::vector<std::string> mat_prop_names = getParam<std::vector<std::string> >("material_property_names");
-  _nmat_props = mat_prop_names.size();
 
-  // get all material properties
-  _mat_props.resize(_nmat_props);
-  for (unsigned int i = 0; i < _nmat_props; ++i)
-  {
-    _mat_props[i] = &getMaterialProperty<Real>(mat_prop_names[i]);
-    variables += "," + mat_prop_names[i];
-  }
-
-  // build the base function
-  if (_func_F.Parse(getParam<std::string>("function"), variables) >= 0)
-     mooseError(std::string("Invalid function\n" + getParam<std::string>("function") + "\nin DerivativeParsedMaterial.\n") + _func_F.ErrorMsg());
-
-  // Auto-Derivatives
-  functionsDerivative();
-
-  // Optimization
-  functionsOptimize();
-
-  // create parameter passing buffer
-  _func_params = new Real[_nargs + _nmat_props];
-}
-
-DerivativeParsedMaterial::~DerivativeParsedMaterial()
-{
-  delete[] _func_params;
-}
-
-void DerivativeParsedMaterial::functionsDerivative()
-{
-  unsigned int i, j, k;
-
-  // first derivatives
-  _func_dF.resize(_nargs);
-  _func_d2F.resize(_nargs);
-  _func_d3F.resize(_nargs);
-  for (i = 0; i < _nargs; ++i)
-  {
-    _func_dF[i] = new ADFunction(_func_F);
-    _func_dF[i]->AutoDiff(_arg_names[i]);
-
-    // second derivatives
-    _func_d2F[i].resize(_nargs);
-    _func_d3F[i].resize(_nargs);
-    for (j = i; j < _nargs; ++j)
-    {
-      _func_d2F[i][j] = new ADFunction(*_func_dF[i]);
-      _func_d2F[i][j]->AutoDiff(_arg_names[j]);
-
-      // third derivatives
-      if (_third_derivatives)
-      {
-        _func_d3F[i][j].resize(_nargs);
-        for (k = j; k < _nargs; ++k)
-        {
-          _func_d3F[i][j][k] = new ADFunction(*_func_d2F[i][j]);
-          _func_d3F[i][j][k]->AutoDiff(_arg_names[k]);
-        }
-      }
-    }
-  }
-}
-
-void DerivativeParsedMaterial::functionsOptimize()
-{
-  unsigned int i, j, k;
-
-#ifdef LIBMESH_HAVE_FPARSER_JIT
-  bool enable_jit = getParam<bool>("enable_jit");
-#endif
-
-  // base function
-  _func_F.Optimize();
-#ifdef LIBMESH_HAVE_FPARSER_JIT
-  if (enable_jit) _func_F.JITCompile();
-#endif
-
-  // optimize first derivatives
-  for (i = 0; i < _nargs; ++i)
-  {
-    _func_dF[i]->Optimize();
-#ifdef LIBMESH_HAVE_FPARSER_JIT
-    if (enable_jit) _func_dF[i]->JITCompile();
-#endif
-
-    // if the derivative vanishes set the function back to NULL
-    if (_func_dF[i]->isZero())
-    {
-      delete _func_dF[i];
-      _func_dF[i] = NULL;
-    }
-
-    // optimize second derivatives
-    for (j = i; j < _nargs; ++j)
-    {
-      _func_d2F[i][j]->Optimize();
-#ifdef LIBMESH_HAVE_FPARSER_JIT
-      if (enable_jit) _func_d2F[i][j]->JITCompile();
-#endif
-
-      // if the derivative vanishes set the function back to NULL
-      if (_func_d2F[i][j]->isZero())
-      {
-        delete _func_d2F[i][j];
-        _func_d2F[i][j] = NULL;
-      }
-
-      // optimize third derivatives
-      if (_third_derivatives)
-      {
-        for (k = j; k < _nargs; ++k)
-        {
-          _func_d3F[i][j][k]->Optimize();
-#ifdef LIBMESH_HAVE_FPARSER_JIT
-          if (enable_jit) _func_d3F[i][j][k]->JITCompile();
-#endif
-
-          // if the derivative vanishes set the function back to NULL
-          if (_func_d3F[i][j][k]->isZero())
-          {
-            delete _func_d3F[i][j][k];
-            _func_d3F[i][j][k] = NULL;
-          }
-        }
-      }
-    }
-  }
+  // Build function and derivatives
+  functionParse(getParam<std::string>("function"),
+                constant_names, constant_expressions,
+                mat_prop_names,
+                tol_names, tol_values);
 }
 
 /// Fm(cmg,cmv,T) takes three arguments
@@ -238,58 +58,4 @@ DerivativeParsedMaterial::expectedNumArgs()
   // this alwats returns the number of argumens that was passed in
   // i.e. any number of args is accepted.
   return _nargs;
-}
-
-/// need to implment these virtuals, although they never get called
-Real DerivativeParsedMaterial::computeF() { return 0.0; }
-Real DerivativeParsedMaterial::computeDF(unsigned int) { return 0.0; }
-Real DerivativeParsedMaterial::computeD2F(unsigned int, unsigned int) { return 0.0; }
-
-void
-DerivativeParsedMaterial::computeProperties()
-{
-  unsigned int i, j, k;
-  Real a;
-
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    // fill the parameter vector, apply tolerances
-    for (i = 0; i < _nargs; ++i)
-    {
-      if (_tol[i] < 0.0)
-        _func_params[i] = (*_args[i])[_qp];
-      else
-      {
-        a = (*_args[i])[_qp];
-        _func_params[i] = a < _tol[i] ? _tol[i] : (a > 1.0 - _tol[i] ? 1.0 - _tol[i] : a);
-      }
-    }
-
-    // insert material property values
-    for (i = 0; i < _nmat_props; ++i)
-      _func_params[i + _nargs] = (*_mat_props[i])[_qp];
-
-    // set function value
-    if (_prop_F)
-      (*_prop_F)[_qp] = _func_F.Eval(_func_params);
-
-    for (i = 0; i < _nargs; ++i)
-    {
-      if (_prop_dF[i])
-        (*_prop_dF[i])[_qp] = _func_dF[i]==NULL ? 0.0 : _func_dF[i]->Eval(_func_params);
-
-      // second derivatives
-      for (j = i; j < _nargs; ++j)
-      {
-        if (_prop_d2F[i][j])
-          (*_prop_d2F[i][j])[_qp] = _func_d2F[i][j]==NULL ? 0.0 : _func_d2F[i][j]->Eval(_func_params);
-
-        // third derivatives
-        if (_third_derivatives)
-          for (k = j; k < _nargs; ++k)
-            if (_prop_d3F[i][j][k])
-              (*_prop_d3F[i][j][k])[_qp] = _func_d3F[i][j][k]==NULL ? 0.0 : _func_d3F[i][j][k]->Eval(_func_params);
-      }
-    }
-  }
 }

--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -1,0 +1,289 @@
+#include "DerivativeParsedMaterialHelper.h"
+
+template<>
+InputParameters validParams<DerivativeParsedMaterialHelper>()
+{
+  InputParameters params = validParams<DerivativeBaseMaterial>();
+  params.addClassDescription("Parsed Function Material with automatic derivatives.");
+
+  // Just in time compilation for the FParser objects
+#ifdef LIBMESH_HAVE_FPARSER_JIT
+  params.addParam<bool>( "enable_jit", false, "Enable Just In Time compilation of the parsed functions (experimental)");
+#endif
+  return params;
+}
+
+DerivativeParsedMaterialHelper::DerivativeParsedMaterialHelper(const std::string & name,
+                                                   InputParameters parameters) :
+    DerivativeBaseMaterial(name, parameters),
+    _nmat_props(0)
+{
+}
+
+DerivativeParsedMaterialHelper::~DerivativeParsedMaterialHelper()
+{
+  delete[] _func_params;
+}
+
+void DerivativeParsedMaterialHelper::functionParse(const std::string & function_expression)
+{
+  std::vector<std::string> empty_string_vector;
+  functionParse(function_expression,
+                empty_string_vector, empty_string_vector);
+}
+
+void DerivativeParsedMaterialHelper::functionParse(const std::string & function_expression,
+                                                   const std::vector<std::string> & constant_names,
+                                                   const std::vector<std::string> & constant_expressions)
+{
+  std::vector<std::string> empty_string_vector;
+  std::vector<Real> empty_real_vector;
+  functionParse(function_expression, constant_names, constant_expressions,
+                empty_string_vector, empty_string_vector, empty_real_vector);
+}
+
+void DerivativeParsedMaterialHelper::functionParse(const std::string & function_expression,
+                                                   const std::vector<std::string> & constant_names,
+                                                   const std::vector<std::string> & constant_expressions,
+                                                   const std::vector<std::string> & mat_prop_names,
+                                                   const std::vector<std::string> & tol_names,
+                                                   const std::vector<Real> & tol_values)
+{
+  // check number of coupled variables
+  if (_arg_names.size() == 0)
+    mooseError("Need at least one coupled variable for DerivativeParsedMaterialHelper.");
+
+  // check constant vectors
+  unsigned int nconst = constant_expressions.size();
+  if (nconst != constant_expressions.size())
+    mooseError("The parameter vectors constant_names and constant_values must have equal length.");
+
+  // initialize constants
+  ADFunction *expression;
+  std::vector<Real> constant_values(nconst);
+  for (unsigned int i = 0; i < nconst; ++i)
+  {
+    expression = new ADFunction();
+
+    // add previously evaluated constants
+    for (unsigned int j = 0; j < i; ++j)
+      if (!expression->AddConstant(constant_names[j], constant_values[j]))
+        mooseError("Invalid constant name in DerivativeParsedMaterialHelper");
+
+    // build the temporary comnstant expression function
+    if (expression->Parse(constant_expressions[i], "") >= 0)
+       mooseError(std::string("Invalid constant expression\n" + constant_expressions[i] + "\n in DerivativeParsedMaterialHelper. ") + expression->ErrorMsg());
+
+    constant_values[i] = expression->Eval(NULL);
+
+#ifdef DEBUG
+    _console << "Constant value " << i << ' ' << constant_expressions[i] << " = " << constant_values[i] << std::endl;
+#endif
+
+    if (!_func_F.AddConstant(constant_names[i], constant_values[i]))
+      mooseError("Invalid constant name in DerivativeParsedMaterialHelper");
+
+    delete expression;
+  }
+
+  // tolerance vectors
+  if (tol_names.size() != tol_values.size())
+    mooseError("The parameter vectors tol_names and tol_values must have equal length.");
+
+  // set tolerances
+  _tol.resize(_nargs);
+  for (unsigned int i = 0; i < _nargs; ++i)
+  {
+    _tol[i] = -1.0;
+
+    // for every argument look throug the entire tolerance vector to find a match
+    for (unsigned int j = 0; j < tol_names.size(); ++j)
+      if (_arg_names[i] == tol_names[j])
+      {
+        _tol[i] = tol_values[j];
+        break;
+      }
+  }
+
+  // build 'variables' argument for fparser
+  std::string variables = _arg_names[0];
+  for (unsigned i = 1; i < _arg_names.size(); ++i)
+    variables += "," + _arg_names[i];
+
+  // get all material properties
+  _nmat_props = mat_prop_names.size();
+  _mat_props.resize(_nmat_props);
+  for (unsigned int i = 0; i < _nmat_props; ++i)
+  {
+    _mat_props[i] = &getMaterialProperty<Real>(mat_prop_names[i]);
+    variables += "," + mat_prop_names[i];
+  }
+
+  // build the base function
+  if (_func_F.Parse(function_expression, variables) >= 0)
+     mooseError(std::string("Invalid function\n" + function_expression + "\nin DerivativeParsedMaterialHelper.\n") + _func_F.ErrorMsg());
+
+  // Auto-Derivatives
+  functionsDerivative();
+
+  // Optimization
+  functionsOptimize();
+
+  // create parameter passing buffer
+  _func_params = new Real[_nargs + _nmat_props];
+}
+
+void DerivativeParsedMaterialHelper::functionsDerivative()
+{
+  unsigned int i, j, k;
+
+  // first derivatives
+  _func_dF.resize(_nargs);
+  _func_d2F.resize(_nargs);
+  _func_d3F.resize(_nargs);
+  for (i = 0; i < _nargs; ++i)
+  {
+    _func_dF[i] = new ADFunction(_func_F);
+    _func_dF[i]->AutoDiff(_arg_names[i]);
+
+    // second derivatives
+    _func_d2F[i].resize(_nargs);
+    _func_d3F[i].resize(_nargs);
+    for (j = i; j < _nargs; ++j)
+    {
+      _func_d2F[i][j] = new ADFunction(*_func_dF[i]);
+      _func_d2F[i][j]->AutoDiff(_arg_names[j]);
+
+      // third derivatives
+      if (_third_derivatives)
+      {
+        _func_d3F[i][j].resize(_nargs);
+        for (k = j; k < _nargs; ++k)
+        {
+          _func_d3F[i][j][k] = new ADFunction(*_func_d2F[i][j]);
+          _func_d3F[i][j][k]->AutoDiff(_arg_names[k]);
+        }
+      }
+    }
+  }
+}
+
+void DerivativeParsedMaterialHelper::functionsOptimize()
+{
+  unsigned int i, j, k;
+
+#ifdef LIBMESH_HAVE_FPARSER_JIT
+  bool enable_jit = getParam<bool>("enable_jit");
+#endif
+
+  // base function
+  _func_F.Optimize();
+#ifdef LIBMESH_HAVE_FPARSER_JIT
+  if (enable_jit) _func_F.JITCompile();
+#endif
+
+  // optimize first derivatives
+  for (i = 0; i < _nargs; ++i)
+  {
+    _func_dF[i]->Optimize();
+#ifdef LIBMESH_HAVE_FPARSER_JIT
+    if (enable_jit) _func_dF[i]->JITCompile();
+#endif
+
+    // if the derivative vanishes set the function back to NULL
+    if (_func_dF[i]->isZero())
+    {
+      delete _func_dF[i];
+      _func_dF[i] = NULL;
+    }
+
+    // optimize second derivatives
+    for (j = i; j < _nargs; ++j)
+    {
+      _func_d2F[i][j]->Optimize();
+#ifdef LIBMESH_HAVE_FPARSER_JIT
+      if (enable_jit) _func_d2F[i][j]->JITCompile();
+#endif
+
+      // if the derivative vanishes set the function back to NULL
+      if (_func_d2F[i][j]->isZero())
+      {
+        delete _func_d2F[i][j];
+        _func_d2F[i][j] = NULL;
+      }
+
+      // optimize third derivatives
+      if (_third_derivatives)
+      {
+        for (k = j; k < _nargs; ++k)
+        {
+          _func_d3F[i][j][k]->Optimize();
+#ifdef LIBMESH_HAVE_FPARSER_JIT
+          if (enable_jit) _func_d3F[i][j][k]->JITCompile();
+#endif
+
+          // if the derivative vanishes set the function back to NULL
+          if (_func_d3F[i][j][k]->isZero())
+          {
+            delete _func_d3F[i][j][k];
+            _func_d3F[i][j][k] = NULL;
+          }
+        }
+      }
+    }
+  }
+}
+
+/// need to implment these virtuals, although they never get called
+Real DerivativeParsedMaterialHelper::computeF() { return 0.0; }
+Real DerivativeParsedMaterialHelper::computeDF(unsigned int) { return 0.0; }
+Real DerivativeParsedMaterialHelper::computeD2F(unsigned int, unsigned int) { return 0.0; }
+
+void
+DerivativeParsedMaterialHelper::computeProperties()
+{
+  unsigned int i, j, k;
+  Real a;
+
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+  {
+    // fill the parameter vector, apply tolerances
+    for (i = 0; i < _nargs; ++i)
+    {
+      if (_tol[i] < 0.0)
+        _func_params[i] = (*_args[i])[_qp];
+      else
+      {
+        a = (*_args[i])[_qp];
+        _func_params[i] = a < _tol[i] ? _tol[i] : (a > 1.0 - _tol[i] ? 1.0 - _tol[i] : a);
+      }
+    }
+
+    // insert material property values
+    for (i = 0; i < _nmat_props; ++i)
+      _func_params[i + _nargs] = (*_mat_props[i])[_qp];
+
+    // set function value
+    if (_prop_F)
+      (*_prop_F)[_qp] = _func_F.Eval(_func_params);
+
+    for (i = 0; i < _nargs; ++i)
+    {
+      if (_prop_dF[i])
+        (*_prop_dF[i])[_qp] = _func_dF[i]==NULL ? 0.0 : _func_dF[i]->Eval(_func_params);
+
+      // second derivatives
+      for (j = i; j < _nargs; ++j)
+      {
+        if (_prop_d2F[i][j])
+          (*_prop_d2F[i][j])[_qp] = _func_d2F[i][j]==NULL ? 0.0 : _func_d2F[i][j]->Eval(_func_params);
+
+        // third derivatives
+        if (_third_derivatives)
+          for (k = j; k < _nargs; ++k)
+            if (_prop_d3F[i][j][k])
+              (*_prop_d3F[i][j][k])[_qp] = _func_d3F[i][j][k]==NULL ? 0.0 : _func_d3F[i][j][k]->Eval(_func_params);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Factor out the building (and evaluation) of parsed functions. This allows to cleanly create classes that build parsed functions not from the standard input parameters (e.g. hardcoded function expression strings). Closes #3888 
