### PR TITLE
Fix trailing space issue

### DIFF
--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -149,12 +149,12 @@ hasExtension(const std::string & filename, std::string ext, bool strip_exodus_ex
   std::string file_ext;
   if (strip_exodus_ext)
   {
-    pcrecpp::RE re(".*\\.([^\\.]*?)(?:-s\\d+)?$"); // capture the complete extension, ignoring -s*
+    pcrecpp::RE re(".*\\.([^\\.]*?)(?:-s\\d+)?\\s*$"); // capture the complete extension, ignoring -s*
     re.FullMatch(filename, &file_ext);
   }
   else
   {
-    pcrecpp::RE re(".*\\.([^\\.]*)$"); // capture the complete extension
+    pcrecpp::RE re(".*\\.([^\\.]*?)\\s*$"); // capture the complete extension
     re.FullMatch(filename, &file_ext);
   }
 


### PR DESCRIPTION
While this fixes the specific RegEx so that you can have spaces at the end, I wasn't able to replicated your exact problem.  Getpot strips the space for you so I'm no exactly sure how this tripped you up.  I tried several variations of spacing after the filename with both single and double quotes and everything worked as expected.  

I tested this particular regular expression by hardcoding a few examples right above and making sure that they still functioned as intended.

closes #3810
