### PR TITLE
Add a few more exception cases to python parser

### DIFF
--- a/python/FactorySystem/ParseGetPot.py
+++ b/python/FactorySystem/ParseGetPot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import sys, re
+import sys, os, re
 
 class GPNode:
   def __init__(self, name, parent):
@@ -30,11 +30,14 @@ class GPNode:
     for child in self.children_list:
       self.children[child].Print(prefix + self.name + '/')
 
-  def fullName(self):
+  def fullName(self, no_root=False):
     if self.parent == None:
-      return self.name
+      if no_root and self.name == 'root':
+        return ''
+      else:
+        return self.name
     else:
-      return self.parent.fullName() + '/' + self.name
+      return self.parent.fullName(no_root) + '/' + self.name
 
 
 class ParseException(Exception):
@@ -79,6 +82,9 @@ class ParseGetPot:
         if m:
           child.comments.append(m.group(1))
 
+        if child_name in current_node.children:
+          raise ParseException("DuplicateSymbol", 'Duplicate Section Name "' + os.getcwd() + '/' + self.file_name + ":" + current_node.fullName(True) + '/' + child_name + '"')
+
         current_node.children[child_name] = child
         current_node.children_list.append(child_name)
 
@@ -119,7 +125,10 @@ class ParseGetPot:
 
             current_position += 1
           if not found_it:
-            raise ParseException("TODO", "TODO")
+            raise ParseException("SyntaxError", "Unmatched token in Parser")
+
+        if param_name in current_node.params:
+          raise ParseException("DuplicateSymbol", 'Duplicate Parameter Name "' + os.getcwd() + '/' + self.file_name + ":" + current_node.fullName(True) + '/' + param_name + '"')
 
         current_node.params[param_name] = param_value.strip("'")
         current_node.params_list.append(param_name)

--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -29,8 +29,8 @@ class Parser:
 
     try:
       root = ParseGetPot.readInputFile(filename)
-    except:
-      print "Parse Error: " + filename
+    except ParseGetPot.ParseException, ex:
+      print "Parse Error in " + filename + ": " + ex.msg
       return 0x01 # Parse Error
 
     error_code = self._parseNode(filename, root)

--- a/test/tests/bcs/periodic/tests
+++ b/test/tests/bcs/periodic/tests
@@ -65,7 +65,6 @@
     type = 'Exodiff'
     input = 'periodic_level_1_test.i'
     exodiff = 'level1.e level1.e-s005 level1.e-s010'
-    group = 'periodic'
     group = 'adaptive  periodic'
     valgrind = 'HEAVY'
     abs_zero = 1e-6


### PR DESCRIPTION
This patch will catch common duplicate input file errors: both duplicate section and duplicate parameter errors.

closes #3155
