### PR TITLE
getParam with no default and validity check

### DIFF
--- a/modules/phase_field/src/action/PolycrystalKernelAction.C
+++ b/modules/phase_field/src/action/PolycrystalKernelAction.C
@@ -13,7 +13,7 @@ InputParameters validParams<PolycrystalKernelAction>()
   params.addParam<VariableName>("c", "NONE", "Name of coupled concentration variable");
   params.addParam<Real>("en_ratio", 1.0, "Ratio of surface to GB energy");
   params.addParam<bool>("implicit", true, "Whether kernels are implicit or not");
-  params.addParam<VariableName>("T", "Name of temperature variable");
+  params.addParam<VariableName>("T", "", "Name of temperature variable");
 
   return params;
 }
@@ -25,7 +25,8 @@ PolycrystalKernelAction::PolycrystalKernelAction(const std::string & name, Input
     _c(getParam<VariableName>("c")),
     _implicit(getParam<bool>("implicit")),
     _T(getParam<VariableName>("T"))
-{}
+{
+}
 
 void
 PolycrystalKernelAction::act()

--- a/modules/phase_field/src/utils/AddV.C
+++ b/modules/phase_field/src/utils/AddV.C
@@ -4,7 +4,6 @@ InputParameters &
 AddV(InputParameters & parameters, const std::string & var_name)
 {
   unsigned int op_num = parameters.get<unsigned int>("op_num");
-  std::string var_name_base = parameters.get<std::string>("var_name_base");
 
   //Create variable names
   std::vector<VariableName> v;
@@ -12,6 +11,11 @@ AddV(InputParameters & parameters, const std::string & var_name)
 
   if (op_num > 0)
   {
+    if (!parameters.isParamValid("var_name_base"))
+      mooseError("Must specify the var_name_base parameter if op_num > 0.");
+
+    std::string var_name_base = parameters.get<std::string>("var_name_base");
+
     for (unsigned int op = 0; op < op_num; op++)
     {
       std::string coupled_var_name = var_name_base;


### PR DESCRIPTION
The default for the `std::string` type parameter `T` is probably not necessary, but the check in `AddV.C` should be there to avoid accidentally empty prefixes. Adresses #3934.
