### PR TITLE
Simplified logic in output type toggles

### DIFF
--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -234,7 +234,7 @@ public:
   /**
    * A method controlling which types of outputs are supported by the Output object
    * @param names (optional) Space seperated of output type names that are supported by this Output object,
-   *              if this is ommited all outputs types will be supported. The list of aviable output
+   *              if this is ommited all outputs types will be un-supported. The list of aviable output
    *              types is given below.
    *
    * Output objects vary widely in what type of outputs they support (e.g., elemental variables,
@@ -261,17 +261,6 @@ public:
    *
    */
   static InputParameters enableOutputTypes(const std::string & names = std::string());
-
-  /**
-   * A method for disabling all individual output type control
-   * @param names (optional) Space seperated of output type names that are un-supported by this Output object,
-   *              if this is ommited all outputs types will be un-supported.
-   *
-   * This method acts in the opposite manner for Output::enableOutputTypes().
-   *
-   * @see Output::enableOutputTypes() Checkpoint
-   */
-  static InputParameters disableOutputTypes(const std::string & names = std::string());
 
 
 protected:

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -29,7 +29,7 @@ InputParameters validParams<Checkpoint>()
 {
   // Get the parameters from the base classes
   InputParameters params = validParams<FileOutput>();
-  params += Output::disableOutputTypes(); // Checkpoint acts like a honey badger, it does what it wants; disable individual controls
+  params += Output::enableOutputTypes(); // Checkpoint acts like a honey badger, it does what it wants; disable all individual controls
 
   // Typical checkpoint options
   params.addParam<unsigned int>("num_files", 2, "Number of the restart files to save");

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -25,7 +25,7 @@ InputParameters validParams<Exodus>()
 {
   // Get the base class parameters
   InputParameters params = validParams<OversampleOutput>();
-  params += Output::disableOutputTypes("vector_postprocessor system_information");
+  params += Output::enableOutputTypes("nodal elemental scalar postprocessor input");
 
   // Set the default padding to 3
   params.set<unsigned int>("padding") = 3;

--- a/framework/src/outputs/GMVOutput.C
+++ b/framework/src/outputs/GMVOutput.C
@@ -23,7 +23,7 @@ InputParameters validParams<GMVOutput>()
 {
   // Get the base class parameters
   InputParameters params = validParams<OversampleOutput>();
-  params += Output::disableOutputTypes();
+  params += Output::enableOutputTypes(); // No input, means enable nothing
 
   // Advanced file options
   params.addParam<bool>("binary", true, "Output the file in binary format");

--- a/framework/src/outputs/MaterialPropertyDebugOutput.C
+++ b/framework/src/outputs/MaterialPropertyDebugOutput.C
@@ -26,7 +26,7 @@ template<>
 InputParameters validParams<MaterialPropertyDebugOutput>()
 {
   InputParameters params = validParams<PetscOutput>();
-  params += Output::disableOutputTypes();
+  params += Output::enableOutputTypes(); // No-input means enable nothing
 
   // Create parameters for allowing debug outputter to be defined within the [Outputs] block
   params.addParam<bool>("show_var_residual_norms", false, "Print the residual norms of the individual solution variables at each nonlinear iteration");

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -90,7 +90,7 @@ Output::enableOutputTypes(const std::string & names)
 
   // Update the enum of output types to append
   if (names.empty())
-    output_types = output_types.getRawNames();
+    output_types = "";
   else
     output_types = names;
 
@@ -98,29 +98,6 @@ Output::enableOutputTypes(const std::string & names)
   Output::addValidParams(params, output_types);
   return params;
 }
-
-InputParameters
-Output::disableOutputTypes(const std::string & names)
-{
-  // The parameters object that will be returned
-  InputParameters params = emptyInputParameters();
-
-  // Set private parameter indicating that this method was called
-  params.addPrivateParam("_output_valid_params_was_called", true);
-
-  // If names is empty() don't add anything
-  if (!names.empty())
-  {
-    // Define the MultMooseEnum with the desired output types, by removing the type provided
-    MultiMooseEnum output_types = Output::getOutputTypes();
-    output_types = output_types.getRawNames();
-    output_types.erase(names);
-    Output::addValidParams(params, output_types);
-  }
-
-  return params;
-}
-
 
 Output::Output(const std::string & name, InputParameters & parameters) :
     MooseObject(name, parameters),
@@ -162,7 +139,7 @@ Output::init()
 {
   // Check that enable[disable]OutputTypes was called
   if (!isParamValid("_output_valid_params_was_called"))
-    mooseError("The static method Output::enableOutputTypes or Output::disableOutputTypes must be called inside the validParams function for this object to properly define the input parameters for the output object named '" << _name << "'");
+    mooseError("The static method Output::enableOutputTypes must be called inside the validParams function for this object to properly define the input parameters for the output object named '" << _name << "'");
 
   // Do not initialize more than once
   /* This check is needed for YAK which calls Executioners from within Executioners */

--- a/framework/src/outputs/SolutionHistory.C
+++ b/framework/src/outputs/SolutionHistory.C
@@ -22,7 +22,7 @@ InputParameters validParams<SolutionHistory>()
 {
   // Get the parameters from the parent object
   InputParameters params = validParams<FileOutput>();
-  params += Output::disableOutputTypes();
+  params += Output::enableOutputTypes(); // No-input means enable nothing
 
   // Return the parameters
   return params;

--- a/framework/src/outputs/Tecplot.C
+++ b/framework/src/outputs/Tecplot.C
@@ -25,7 +25,7 @@ InputParameters validParams<Tecplot>()
 {
   // Get the base class parameters
   InputParameters params = validParams<OversampleOutput>();
-  params += Output::disableOutputTypes();
+  params += Output::enableOutputTypes(); // No-input means enable nothing
 
   // Add binary toggle
   params.addParam<bool>("binary", false, "Set Tecplot files to output in binary format");

--- a/framework/src/outputs/TopResidualDebugOutput.C
+++ b/framework/src/outputs/TopResidualDebugOutput.C
@@ -26,7 +26,7 @@ template<>
 InputParameters validParams<TopResidualDebugOutput>()
 {
   InputParameters params = validParams<PetscOutput>();
-  params += Output::disableOutputTypes();
+  params += Output::enableOutputTypes(); // No-input means enable nothing
 
   // Create parameters for allowing debug outputter to be defined within the [Outputs] block
   params.addParam<unsigned int>("num_residuals", 0, "The number of top residuals to print out (0 = no output)");

--- a/framework/src/outputs/VariableResidualNormsDebugOutput.C
+++ b/framework/src/outputs/VariableResidualNormsDebugOutput.C
@@ -26,7 +26,7 @@ template<>
 InputParameters validParams<VariableResidualNormsDebugOutput>()
 {
   InputParameters params = validParams<PetscOutput>();
-  params += Output::disableOutputTypes();
+  params += Output::enableOutputTypes(); // No-input means enable nothing
   return params;
 }
 

--- a/framework/src/outputs/XDA.C
+++ b/framework/src/outputs/XDA.C
@@ -22,7 +22,7 @@ InputParameters validParams<XDA>()
 {
   // Get the base class parameters
   InputParameters params = validParams<OversampleOutput>();
-  params += Output::disableOutputTypes(); // Output is handled explicitly, disable everything
+  params += Output::enableOutputTypes(); // Output is handled explicitly, enable nothing
 
   // Add description for the XDA class
   params.addClassDescription("Object for outputting data in the XDA/XDR format");

--- a/test/tests/vectorpostprocessors/line_value_sampler/csv_delimiter.i
+++ b/test/tests/vectorpostprocessors/line_value_sampler/csv_delimiter.i
@@ -58,6 +58,7 @@
 []
 
 [Outputs]
+  exodus = true
   [./csv]
     type = CSV
     delimiter = ' '


### PR DESCRIPTION
This is a quick fix to the issue; I am working on a much different approach for issue #3847 that will make creating simple outputs easier by having two base classes for the users to inherit from: basic and advanced. I But, I still have some work to do on this, so for now we need this. 

 (closes #3945)
