### PR TITLE
Fixing du_dot_du for non-nodal FEs (closes #3784)

### DIFF
--- a/framework/include/base/AuxiliarySystem.h
+++ b/framework/include/base/AuxiliarySystem.h
@@ -80,7 +80,6 @@ public:
   virtual const NumericVector<Number> * & currentSolution() { _current_solution = _sys.current_local_solution.get(); return _current_solution; }
 
   virtual NumericVector<Number> & solutionUDot();
-  virtual NumericVector<Number> & solutionDuDotDu();
 
   virtual void serializeSolution();
   virtual NumericVector<Number> & serializedSolution();
@@ -141,8 +140,6 @@ protected:
   TimeIntegrator * _time_integrator;
   /// solution vector for u^dot
   NumericVector<Number> & _u_dot;
-  /// solution vector for \f$ {du^dot}\over{du} \f$
-  NumericVector<Number> & _du_dot_du;
 
   /// Whether or not a copy of the residual needs to be made
   bool _need_serialized_solution;

--- a/framework/include/base/DisplacedSystem.h
+++ b/framework/include/base/DisplacedSystem.h
@@ -40,7 +40,7 @@ public:
   virtual NumericVector<Number> & solution() { return _undisplaced_system.solution(); }
 
   virtual NumericVector<Number> & solutionUDot() { return _undisplaced_system.solutionUDot(); }
-  virtual NumericVector<Number> & solutionDuDotDu() { return _undisplaced_system.solutionDuDotDu(); }
+  virtual Number & duDotDu() { return _undisplaced_system.duDotDu(); }
 
   /**
    * Return the residual copy from the NonlinearSystem

--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -258,16 +258,7 @@ public:
    */
   virtual void setSolutionUDot(const NumericVector<Number> & udot);
 
-  /**
-   * Set multiplier of udot for Jacobian evaluation.
-   * @param shift temporal shift for Jacobian
-   * @note If the residual is G(u,udot) = 0, the Jacobian is dG/du + shift*dG/dudot
-   * @note If the calling sequence for residual evaluation was changed, this could become an explicit argument.
-   */
-  virtual void setSolutionDuDotDu(Real shift);
-
   virtual NumericVector<Number> & solutionUDot();
-  virtual NumericVector<Number> & solutionDuDotDu();
   virtual NumericVector<Number> & residualVector(Moose::KernelType type);
 
   virtual const NumericVector<Number> * & currentSolution() { return _current_solution; }
@@ -479,8 +470,8 @@ protected:
   MooseSharedPointer<TimeIntegrator> _time_integrator;
   /// solution vector for u^dot
   NumericVector<Number> & _u_dot;
-  /// solution vector for \f$ {du^dot}\over{du} \f$
-  NumericVector<Number> & _du_dot_du;
+  /// \f$ {du^dot}\over{du} \f$
+  Number _du_dot_du;
   /// residual vector for time contributions
   NumericVector<Number> & _Re_time;
   /// residual vector for non-time contributions

--- a/framework/include/base/SystemBase.h
+++ b/framework/include/base/SystemBase.h
@@ -111,7 +111,7 @@ public:
   virtual NumericVector<Number> & solutionOlder() = 0;
 
   virtual NumericVector<Number> & solutionUDot() = 0;
-  virtual NumericVector<Number> & solutionDuDotDu() = 0;
+  virtual Number & duDotDu() = 0;
 
   /**
    * Check if the named vector exists in the system.
@@ -483,7 +483,7 @@ public:
   virtual NumericVector<Number> & solutionOlder() { return _solution_older; }
 
   virtual NumericVector<Number> & solutionUDot() { return *_dummy_vec; }
-  virtual NumericVector<Number> & solutionDuDotDu() { return *_dummy_vec; }
+  virtual Number & duDotDu() { return _du_dot_du; }
 
   virtual bool hasVector(std::string name) { return _sys.have_vector(name); }
   virtual NumericVector<Number> & getVector(std::string name) { return _sys.get_vector(name); }
@@ -579,6 +579,7 @@ protected:
   NumericVector<Number> & _solution;
   NumericVector<Number> & _solution_old;
   NumericVector<Number> & _solution_older;
+  Real _du_dot_du;
 
   NumericVector<Number> * _dummy_vec;                     // to satisfy the interface
 

--- a/framework/include/timeintegrators/TimeIntegrator.h
+++ b/framework/include/timeintegrators/TimeIntegrator.h
@@ -63,7 +63,7 @@ protected:
   /// solution vector for u^dot
   NumericVector<Number> & _u_dot;
   /// solution vector for \f$ {du^dot}\over{du} \f$
-  NumericVector<Number> & _du_dot_du;
+  Real & _du_dot_du;
   /// solution vectors
   const NumericVector<Number> * & _solution;
   const NumericVector<Number> & _solution_old;

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -37,7 +37,6 @@ AuxiliarySystem::AuxiliarySystem(FEProblem & subproblem, const std::string & nam
     _serialized_solution(*NumericVector<Number>::build(_mproblem.comm()).release()),
     _time_integrator(NULL),
     _u_dot(addVector("u_dot", true, GHOSTED)),
-    _du_dot_du(addVector("du_dot_du", true, GHOSTED)),
     _need_serialized_solution(false)
 {
   _nodal_vars.resize(libMesh::n_threads());
@@ -207,12 +206,6 @@ NumericVector<Number> &
 AuxiliarySystem::solutionUDot()
 {
   return _u_dot;
-}
-
-NumericVector<Number> &
-AuxiliarySystem::solutionDuDotDu()
-{
-  return _du_dot_du;
 }
 
 NumericVector<Number> &

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3313,7 +3313,7 @@ FEProblem::computeTransientImplicitJacobian(Real time, const NumericVector<Numbe
   { // The current interface guarantees that the residual is called before Jacobian, thus udot has already been set
     _nl.setSolutionUDot(udot);
   }
-  _nl.setSolutionDuDotDu(shift);
+  _nl.duDotDu() = shift;
   NonlinearImplicitSystem &sys = _nl.sys();
   _time = time;
   computeJacobian(sys,u,jacobian);

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -467,14 +467,13 @@ MooseVariable::computePerturbedElemValues(unsigned int perturbation_idx, Real pe
   const NumericVector<Real> & solution_old     = _sys.solutionOld();
   const NumericVector<Real> & solution_older   = _sys.solutionOlder();
   const NumericVector<Real> & u_dot            = _sys.solutionUDot();
-  const NumericVector<Real> & du_dot_du        = _sys.solutionDuDotDu();
+  const Real & du_dot_du                       = _sys.duDotDu();
 
   dof_id_type idx = 0;
   Real soln_local = 0;
   Real soln_old_local = 0;
   Real soln_older_local = 0;
   Real u_dot_local = 0;
-  Real du_dot_du_local = 0;
 
   Real phi_local = 0;
   const RealGradient * dphi_qp = NULL;
@@ -514,7 +513,6 @@ MooseVariable::computePerturbedElemValues(unsigned int perturbation_idx, Real pe
         soln_older_local = solution_older(idx);
 
       u_dot_local        = u_dot(idx);
-      du_dot_du_local    = du_dot_du(idx);
     }
 
     for (unsigned int qp=0; qp < nqp; qp++)
@@ -560,7 +558,7 @@ MooseVariable::computePerturbedElemValues(unsigned int perturbation_idx, Real pe
       if (is_transient)
       {
         _u_dot[qp]        += phi_local * u_dot_local;
-        _du_dot_du[qp]    += phi_local * du_dot_du_local;
+        _du_dot_du[qp]    = du_dot_du;
 
         if (_need_u_old)
           _u_old[qp]        += phi_local * soln_old_local;
@@ -694,14 +692,13 @@ MooseVariable::computeElemValues()
   const NumericVector<Real> & solution_old     = _sys.solutionOld();
   const NumericVector<Real> & solution_older   = _sys.solutionOlder();
   const NumericVector<Real> & u_dot            = _sys.solutionUDot();
-  const NumericVector<Real> & du_dot_du        = _sys.solutionDuDotDu();
+  const Real & du_dot_du                       = _sys.duDotDu();
 
   dof_id_type idx = 0;
   Real soln_local = 0;
   Real soln_old_local = 0;
   Real soln_older_local = 0;
   Real u_dot_local = 0;
-  Real du_dot_du_local = 0;
 
   Real phi_local = 0;
   const RealGradient * dphi_qp = NULL;
@@ -731,7 +728,6 @@ MooseVariable::computeElemValues()
         soln_older_local = solution_older(idx);
 
       u_dot_local        = u_dot(idx);
-      du_dot_du_local    = du_dot_du(idx);
     }
 
     for (unsigned int qp=0; qp < nqp; qp++)
@@ -777,7 +773,7 @@ MooseVariable::computeElemValues()
       if (is_transient)
       {
         _u_dot[qp]        += phi_local * u_dot_local;
-        _du_dot_du[qp]    += phi_local * du_dot_du_local;
+        _du_dot_du[qp]    = du_dot_du;
 
         if (_need_u_old)
           _u_old[qp]        += phi_local * soln_old_local;
@@ -875,14 +871,13 @@ MooseVariable::computeElemValuesFace()
   const NumericVector<Real> & solution_old     = _sys.solutionOld();
   const NumericVector<Real> & solution_older   = _sys.solutionOlder();
   const NumericVector<Real> & u_dot            = _sys.solutionUDot();
-  const NumericVector<Real> & du_dot_du        = _sys.solutionDuDotDu();
+  const Real & du_dot_du                       = _sys.duDotDu();
 
   dof_id_type idx;
   Real soln_local;
-  Real soln_old_local=0;
-  Real soln_older_local=0;
-//  Real u_dot_local;
-//  Real du_dot_du_local;
+  Real soln_old_local = 0;
+  Real soln_older_local = 0;
+  Real u_dot_local = 0;
 
   Real phi_local;
   RealGradient dphi_local;
@@ -900,6 +895,8 @@ MooseVariable::computeElemValuesFace()
 
       if (_need_u_older || _need_grad_older || _need_second_older)
         soln_older_local = solution_older(idx);
+
+      u_dot_local = u_dot(idx);
     }
 
     for (unsigned int qp=0; qp < nqp; ++qp)
@@ -918,8 +915,8 @@ MooseVariable::computeElemValuesFace()
 
       if (is_transient)
       {
-        _u_dot[qp]        += phi_local * u_dot(idx);
-        _du_dot_du[qp]    += phi_local * du_dot_du(idx);
+        _u_dot[qp]        += phi_local * u_dot_local;
+        _du_dot_du[qp]    = du_dot_du;
 
         if (_need_u_old)
           _u_old[qp]        += phi_local * soln_old_local;
@@ -1226,7 +1223,7 @@ MooseVariable::computeNodalValues()
         _nodal_u_older[i] = _sys.solutionOlder()(_dof_indices[i]);
 
         _nodal_u_dot[i] = _sys.solutionUDot()(_dof_indices[i]);
-        _nodal_du_dot_du[i] = _sys.solutionDuDotDu()(_dof_indices[i]);
+        _nodal_du_dot_du[i] = _sys.duDotDu();
       }
     }
   }

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -44,7 +44,7 @@ MooseVariableScalar::reinit()
   const NumericVector<Real> & solution_old     = _sys.solutionOld();
   const NumericVector<Real> & solution_older   = _sys.solutionOlder();
   const NumericVector<Real> & u_dot            = _sys.solutionUDot();
-  const NumericVector<Real> & du_dot_du        = _sys.solutionDuDotDu();
+  const Real & du_dot_du                       = _sys.duDotDu();
 
   _dof_map.SCALAR_dof_indices(_dof_indices, _var_num);
 
@@ -63,7 +63,7 @@ MooseVariableScalar::reinit()
     _u_older[i] = solution_older(idx);
 
     _u_dot[i]        = u_dot(idx);
-    _du_dot_du[i]    = du_dot_du(idx);
+    _du_dot_du[i]    = du_dot_du;
   }
 }
 

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -119,7 +119,6 @@ NonlinearSystem::NonlinearSystem(FEProblem & fe_problem, const std::string & nam
     _serialized_solution(*NumericVector<Number>::build(_communicator).release()),
     _residual_copy(*NumericVector<Number>::build(_communicator).release()),
     _u_dot(addVector("u_dot", true, GHOSTED)),
-    _du_dot_du(addVector("du_dot_du", true, GHOSTED)),
     _Re_time(addVector("Re_time", false, GHOSTED)),
     _Re_non_time(addVector("Re_non_time", false, GHOSTED)),
     _increment_vec(NULL),
@@ -792,12 +791,6 @@ NumericVector<Number> &
 NonlinearSystem::solutionUDot()
 {
   return _u_dot;
-}
-
-NumericVector<Number> &
-NonlinearSystem::solutionDuDotDu()
-{
-  return _du_dot_du;
 }
 
 NumericVector<Number> &
@@ -2062,12 +2055,6 @@ void
 NonlinearSystem::setSolutionUDot(const NumericVector<Number> & udot)
 {
   _u_dot = udot;
-}
-
-void
-NonlinearSystem::setSolutionDuDotDu(Real value)
-{
-  _du_dot_du = value;
 }
 
 NumericVector<Number> &

--- a/framework/src/timeintegrators/BDF2.C
+++ b/framework/src/timeintegrators/BDF2.C
@@ -57,7 +57,6 @@ BDF2::computeTimeDerivatives()
     _u_dot.close();
 
     _du_dot_du = 1.0 / _dt;
-    _du_dot_du.close();
   }
   else
   {
@@ -69,7 +68,6 @@ BDF2::computeTimeDerivatives()
     _u_dot.close();
 
     _du_dot_du = _weight[0] / _dt;
-    _du_dot_du.close();
   }
 }
 

--- a/framework/src/timeintegrators/CrankNicolson.C
+++ b/framework/src/timeintegrators/CrankNicolson.C
@@ -43,7 +43,6 @@ CrankNicolson::computeTimeDerivatives()
   _u_dot.close();
 
   _du_dot_du = 2. / _dt;
-  _du_dot_du.close();
 }
 
 void
@@ -55,8 +54,7 @@ CrankNicolson::preSolve()
     _u_dot.zero();
     _u_dot.close();
 
-    _du_dot_du.zero();
-    _du_dot_du.close();
+    _du_dot_du = 0;
 
     // for the first time step, compute residual for the old time step
     _fe_problem.computeResidualType(_solution_old, *_nl.sys().rhs, Moose::KT_NONTIME);

--- a/framework/src/timeintegrators/ExplicitEuler.C
+++ b/framework/src/timeintegrators/ExplicitEuler.C
@@ -43,7 +43,6 @@ ExplicitEuler::computeTimeDerivatives()
   _u_dot.close();
 
   _du_dot_du = 1.0 / _dt;
-  _du_dot_du.close();
 }
 
 void

--- a/framework/src/timeintegrators/ImplicitEuler.C
+++ b/framework/src/timeintegrators/ImplicitEuler.C
@@ -41,7 +41,6 @@ ImplicitEuler::computeTimeDerivatives()
   _u_dot.close();
 
   _du_dot_du = 1.0 / _dt;
-  _du_dot_du.close();
 }
 
 void

--- a/framework/src/timeintegrators/RungeKutta2.C
+++ b/framework/src/timeintegrators/RungeKutta2.C
@@ -54,7 +54,6 @@ RungeKutta2::computeTimeDerivatives()
   _du_dot_du = 1. / _dt;
 
   _u_dot.close();
-  _du_dot_du.close();
 }
 
 void

--- a/framework/src/timeintegrators/SteadyState.C
+++ b/framework/src/timeintegrators/SteadyState.C
@@ -37,8 +37,7 @@ SteadyState::computeTimeDerivatives()
   _u_dot.zero();
   _u_dot.close();
 
-  _du_dot_du.zero();
-  _du_dot_du.close();
+  _du_dot_du = 0;
 }
 
 void

--- a/framework/src/timeintegrators/TimeIntegrator.C
+++ b/framework/src/timeintegrators/TimeIntegrator.C
@@ -32,7 +32,7 @@ TimeIntegrator::TimeIntegrator(const std::string & name, InputParameters paramet
     _sys(*parameters.getCheckedPointerParam<SystemBase *>("_sys")),
     _nl(_fe_problem.getNonlinearSystem()),
     _u_dot(_sys.solutionUDot()),
-    _du_dot_du(_sys.solutionDuDotDu()),
+    _du_dot_du(_sys.duDotDu()),
     _solution(_sys.currentSolution()),
     _solution_old(_sys.solutionOld()),
     _solution_older(_sys.solutionOlder()),

--- a/test/tests/time_integrators/implicit-euler/ie-monomials.i
+++ b/test/tests/time_integrators/implicit-euler/ie-monomials.i
@@ -1,0 +1,105 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = MONOMIAL
+  [../]
+[]
+
+[ICs]
+  [./u_ic]
+    type = ConstantIC
+    variable = u
+    value = 1
+  [../]
+[]
+
+[Functions]
+  active = 'forcing_fn exact_fn'
+
+  [./forcing_fn]
+    type = ParsedFunction
+    value = 2*pow(e,-x-(y*y))*(1-2*y*y)
+  [../]
+
+  [./exact_fn]
+    type = ParsedGradFunction
+    value = pow(e,-x-(y*y))
+    grad_x = -pow(e,-x-(y*y))
+    grad_y = -2*y*pow(e,-x-(y*y))
+  [../]
+[]
+
+[Kernels]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+
+  [./abs]          # u * v
+    type = Reaction
+    variable = u
+  [../]
+
+  [./forcing]
+    type = UserForcingFunction
+    variable = u
+    function = forcing_fn
+  [../]
+[]
+
+[DGKernels]
+  [./dg_diff]
+    type = DGDiffusion
+    variable = u
+    epsilon = -1
+    sigma = 6
+  [../]
+[]
+
+[BCs]
+  [./all]
+    type = DGFunctionDiffusionDirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    function = exact_fn
+    epsilon = -1
+    sigma = 6
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
+    solve_type = 'NEWTON'
+
+    petsc_options_iname = '-snes_type'
+    petsc_options_value = 'test'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  nl_rel_tol = 1e-10
+[]
+
+[Outputs]
+  console = true
+[]

--- a/test/tests/time_integrators/implicit-euler/tests
+++ b/test/tests/time_integrators/implicit-euler/tests
@@ -12,4 +12,12 @@
     exodiff = 'ie_out.e'
     max_parallel = 1
   [../]
+
+  [./monomials]
+    type = 'PetscJacobianTester'
+    input = 'ie-monomials.i'
+    ratio_tol = 1e-9
+    difference_tol = 1e7
+    recover = false
+  [../]
 []


### PR DESCRIPTION
The computation of du_dot_du assumed nodal FE and was putting the
computed value into each quad-point. This did not work for non-nodal FEs
like monomials. Those require the "function" to be projected into the
space.  Fortunately, all of our time scheme have du_dot_du as a scalar
value, thus, we do not need the solution vector and we can store it as a
single value.

Also, adding a test case that will check the Jacobian by FDing it (on
monomial FEs).
