### PR TITLE
Make SolutionTimeAdaptive only time the solve

### DIFF
--- a/framework/include/timesteppers/SolutionTimeAdaptiveDT.h
+++ b/framework/include/timesteppers/SolutionTimeAdaptiveDT.h
@@ -33,8 +33,7 @@ public:
   SolutionTimeAdaptiveDT(const std::string & name, InputParameters parameters);
   virtual ~SolutionTimeAdaptiveDT();
 
-  virtual void preSolve();
-  virtual void postSolve();
+  virtual void step();
 
   virtual void rejectStep();
 

--- a/framework/src/timesteppers/SolutionTimeAdaptiveDT.C
+++ b/framework/src/timesteppers/SolutionTimeAdaptiveDT.C
@@ -50,14 +50,12 @@ SolutionTimeAdaptiveDT::~SolutionTimeAdaptiveDT()
 }
 
 void
-SolutionTimeAdaptiveDT::preSolve()
+SolutionTimeAdaptiveDT::step()
 {
   gettimeofday(&_solve_start, NULL);
-}
 
-void
-SolutionTimeAdaptiveDT::postSolve()
-{
+  TimeStepper::step();
+
   if (converged())
   {
     gettimeofday (&_solve_end, NULL);


### PR DESCRIPTION
refs #3944 

This should fix the SolutionTimeAdaptive problem.  I need someone to test this though.  We don't have any tests that make use of this right now due to the issue with system loading - however I have an idea for that...
