### PR TITLE
Removed print() from MultiSmoothCircleIC for #3962

### DIFF
--- a/modules/phase_field/src/ics/MultiSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothCircleIC.C
@@ -42,8 +42,6 @@ MultiSmoothCircleIC::initialSetup()
   }
   _range = _top_right - _bottom_left;
 
-  _range.print();
-
   switch (_radius_variation_type)
   {
   case 2: //No variation


### PR DESCRIPTION
I cleaned up MultiSmoothCircleIC by removing a print() for #3962.
