### PR TITLE
Reworking the boundary element and node iterators in MooseMesh.

### DIFF
--- a/framework/include/base/ComputeBoundaryInitialConditionThread.h
+++ b/framework/include/base/ComputeBoundaryInitialConditionThread.h
@@ -17,7 +17,7 @@
 
 #include "Moose.h"
 #include "ParallelUniqueId.h"
-#include "BndNode.h"
+#include "MooseMesh.h"
 // libmesh
 #include "libmesh/elem_range.h"
 #include "libmesh/numeric_vector.h"

--- a/framework/include/base/ComputeElemAuxBcsThread.h
+++ b/framework/include/base/ComputeElemAuxBcsThread.h
@@ -18,7 +18,7 @@
 
 #include "ParallelUniqueId.h"
 #include "AuxWarehouse.h"
-#include "BndElement.h"
+#include "MooseMesh.h"
 
 class FEProblem;
 class AuxiliarySystem;

--- a/framework/include/base/ComputeNodalAuxBcsThread.h
+++ b/framework/include/base/ComputeNodalAuxBcsThread.h
@@ -17,7 +17,7 @@
 
 #include "ParallelUniqueId.h"
 #include "AuxWarehouse.h"
-#include "BndNode.h"
+#include "MooseMesh.h"
 
 class FEProblem;
 class AuxiliarySystem;

--- a/framework/include/mesh/BndElement.h
+++ b/framework/include/mesh/BndElement.h
@@ -16,9 +16,6 @@
 #define BNDELEMENT_H
 
 #include "libmesh/elem.h"
-#include "libmesh/mesh_base.h"
-#include "libmesh/stored_range.h"
-#include "libmesh/variant_filter_iterator.h"
 
 struct BndElement
 {
@@ -36,65 +33,5 @@ struct BndElement
   /// boundary id for the node
   BoundaryID _bnd_id;
 };
-
-/**
- * The definition of the element_iterator struct.
- */
-struct
-bnd_elem_iterator :
-variant_filter_iterator<MeshBase::Predicate,
-                        BndElement*>
-{
-  // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
-  template <typename PredType, typename IterType>
-  bnd_elem_iterator (const IterType& d,
-                     const IterType& e,
-                     const PredType& p ) :
-    variant_filter_iterator<MeshBase::Predicate,
-                            BndElement*>(d,e,p) {}
-};
-
-
-
-
-/**
- * The definition of the const_element_iterator struct.  It is similar to the regular
- * iterator above, but also provides an additional conversion-to-const ctor.
- */
-struct
-const_bnd_elem_iterator :
-variant_filter_iterator<MeshBase::Predicate,
-                        BndElement* const,
-                        BndElement* const&,
-                        BndElement* const*>
-{
-  // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
-  template <typename PredType, typename IterType>
-  const_bnd_elem_iterator (const IterType& d,
-                           const IterType& e,
-                           const PredType& p ) :
-    variant_filter_iterator<MeshBase::Predicate,
-                            BndElement* const,
-                            BndElement* const&,
-                            BndElement* const*>(d,e,p)  {}
-
-
-  // The conversion-to-const ctor.  Takes a regular iterator and calls the appropriate
-  // variant_filter_iterator copy constructor.  Note that this one is *not* templated!
-  const_bnd_elem_iterator (const bnd_elem_iterator& rhs) :
-    variant_filter_iterator<MeshBase::Predicate,
-                            BndElement* const,
-                            BndElement* const&,
-                            BndElement* const*>(rhs)
-  {
-    // libMesh::out << "Called element_iterator conversion-to-const ctor." << std::endl;
-  }
-};
-
-
-typedef StoredRange<bnd_elem_iterator,             BndElement*>      BndElemRange;
-typedef StoredRange<const_bnd_elem_iterator, const BndElement*> ConstBndElemRange;
-
-
 
 #endif /* BNDELEMENT_H */

--- a/framework/include/mesh/BndNode.h
+++ b/framework/include/mesh/BndNode.h
@@ -17,9 +17,6 @@
 
 #include "MooseTypes.h"
 #include "libmesh/node.h"
-#include "libmesh/mesh_base.h"
-#include "libmesh/stored_range.h"
-#include "libmesh/variant_filter_iterator.h"
 
 struct BndNode
 {
@@ -34,65 +31,5 @@ struct BndNode
   /// boundary id for the node
   BoundaryID _bnd_id;
 };
-
-/**
- * The definition of the element_iterator struct.
- */
-struct
-bnd_node_iterator :
-variant_filter_iterator<MeshBase::Predicate,
-                        BndNode*>
-{
-  // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
-  template <typename PredType, typename IterType>
-  bnd_node_iterator (const IterType& d,
-                    const IterType& e,
-                    const PredType& p ) :
-    variant_filter_iterator<MeshBase::Predicate,
-                            BndNode*>(d,e,p) {}
-};
-
-
-
-
-/**
- * The definition of the const_element_iterator struct.  It is similar to the regular
- * iterator above, but also provides an additional conversion-to-const ctor.
- */
-struct
-const_bnd_node_iterator :
-variant_filter_iterator<MeshBase::Predicate,
-                        BndNode* const,
-                        BndNode* const&,
-                        BndNode* const*>
-{
-  // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
-  template <typename PredType, typename IterType>
-  const_bnd_node_iterator (const IterType& d,
-                           const IterType& e,
-                           const PredType& p ) :
-    variant_filter_iterator<MeshBase::Predicate,
-                            BndNode* const,
-                            BndNode* const&,
-                            BndNode* const*>(d,e,p)  {}
-
-
-  // The conversion-to-const ctor.  Takes a regular iterator and calls the appropriate
-  // variant_filter_iterator copy constructor.  Note that this one is *not* templated!
-  const_bnd_node_iterator (const bnd_node_iterator& rhs) :
-    variant_filter_iterator<MeshBase::Predicate,
-                            BndNode* const,
-                            BndNode* const&,
-                            BndNode* const*>(rhs)
-  {
-    // libMesh::out << "Called element_iterator conversion-to-const ctor." << std::endl;
-  }
-};
-
-
-typedef StoredRange<bnd_node_iterator,             BndNode*>      BndNodeRange;
-typedef StoredRange<const_bnd_node_iterator, const BndNode*> ConstBndNodeRange;
-
-
 
 #endif /* BNDNODE_H */

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -136,6 +136,16 @@ public:
   std::map<unsigned int, std::vector<unsigned int> > & nodeToElemMap();
 
   /**
+   * These structs are required so that the bndNodes{Begin,End} and
+   * bndElems{Begin,End} functions work...
+   */
+  struct bnd_node_iterator;
+  struct const_bnd_node_iterator;
+
+  struct bnd_elem_iterator;
+  struct const_bnd_elem_iterator;
+
+  /**
    * Return iterators to the beginning/end of the boundary nodes list.
    */
   virtual bnd_node_iterator bndNodesBegin();
@@ -270,8 +280,8 @@ public:
   NodeRange * getActiveNodeRange();
   SemiLocalNodeRange * getActiveSemiLocalNodeRange();
   ConstNodeRange * getLocalNodeRange();
-  ConstBndNodeRange * getBoundaryNodeRange();
-  ConstBndElemRange * getBoundaryElementRange();
+  StoredRange<MooseMesh::const_bnd_node_iterator, const BndNode*> * getBoundaryNodeRange();
+  StoredRange<MooseMesh::const_bnd_elem_iterator, const BndElement*> * getBoundaryElementRange();
 
   /**
    * Returns a read-only reference to the set of subdomains currently
@@ -740,8 +750,8 @@ protected:
   SemiLocalNodeRange * _active_semilocal_node_range;
   NodeRange * _active_node_range;
   ConstNodeRange * _local_node_range;
-  ConstBndNodeRange * _bnd_node_range;
-  ConstBndElemRange * _bnd_elem_range;
+  StoredRange<MooseMesh::const_bnd_node_iterator, const BndNode*> * _bnd_node_range;
+  StoredRange<MooseMesh::const_bnd_elem_iterator, const BndElement*> * _bnd_elem_range;
 
   /// A map of all of the current nodes to the elements that they are connected to.
   std::map<unsigned int, std::vector<unsigned int> > _node_to_elem_map;
@@ -923,5 +933,122 @@ private:
   /// Whether or not this Mesh is allowed to read a recovery file
   bool _allow_recovery;
 };
+
+
+
+/**
+ * The definition of the bnd_node_iterator struct.
+ */
+struct
+MooseMesh::bnd_node_iterator :
+variant_filter_iterator<MeshBase::Predicate,
+                        BndNode*>
+{
+  // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
+  template <typename PredType, typename IterType>
+  bnd_node_iterator (const IterType& d,
+                     const IterType& e,
+                     const PredType& p ) :
+      variant_filter_iterator<MeshBase::Predicate,
+                              BndNode*>(d,e,p) {}
+};
+
+
+
+/**
+ * The definition of the const_bnd_node_iterator struct.  It is similar to the
+ * iterator above, but also provides an additional conversion-to-const ctor.
+ */
+struct
+MooseMesh::const_bnd_node_iterator :
+variant_filter_iterator<MeshBase::Predicate,
+                        BndNode* const,
+                        BndNode* const&,
+                        BndNode* const*>
+{
+  // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
+  template <typename PredType, typename IterType>
+  const_bnd_node_iterator (const IterType& d,
+                           const IterType& e,
+                           const PredType& p ) :
+    variant_filter_iterator<MeshBase::Predicate,
+                            BndNode* const,
+                            BndNode* const&,
+                            BndNode* const*>(d,e,p)  {}
+
+
+  // The conversion-to-const ctor.  Takes a regular iterator and calls the appropriate
+  // variant_filter_iterator copy constructor.  Note that this one is *not* templated!
+  const_bnd_node_iterator (const MooseMesh::bnd_node_iterator& rhs) :
+    variant_filter_iterator<MeshBase::Predicate,
+                            BndNode* const,
+                            BndNode* const&,
+                            BndNode* const*>(rhs)
+  {
+  }
+};
+
+
+
+/**
+ * The definition of the bnd_elem_iterator struct.
+ */
+struct
+MooseMesh::bnd_elem_iterator :
+variant_filter_iterator<MeshBase::Predicate,
+                        BndElement*>
+{
+  // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
+  template <typename PredType, typename IterType>
+  bnd_elem_iterator (const IterType& d,
+                     const IterType& e,
+                     const PredType& p ) :
+      variant_filter_iterator<MeshBase::Predicate,
+                              BndElement*>(d,e,p) {}
+};
+
+
+
+/**
+ * The definition of the const_bnd_elem_iterator struct.  It is similar to the regular
+ * iterator above, but also provides an additional conversion-to-const ctor.
+ */
+struct
+MooseMesh::const_bnd_elem_iterator :
+variant_filter_iterator<MeshBase::Predicate,
+                        BndElement* const,
+                        BndElement* const&,
+                        BndElement* const*>
+{
+  // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
+  template <typename PredType, typename IterType>
+  const_bnd_elem_iterator (const IterType& d,
+                           const IterType& e,
+                           const PredType& p ) :
+    variant_filter_iterator<MeshBase::Predicate,
+                            BndElement* const,
+                            BndElement* const&,
+                            BndElement* const*>(d,e,p)  {}
+
+
+  // The conversion-to-const ctor.  Takes a regular iterator and calls the appropriate
+  // variant_filter_iterator copy constructor.  Note that this one is *not* templated!
+  const_bnd_elem_iterator (const bnd_elem_iterator& rhs) :
+    variant_filter_iterator<MeshBase::Predicate,
+                            BndElement* const,
+                            BndElement* const&,
+                            BndElement* const*>(rhs)
+  {
+  }
+};
+
+
+
+/**
+ * Some useful StoredRange typedefs.  These are defined *outside* the
+ * MooseMesh class to mimic the Const{Node,Elem}Range classes in libmesh.
+ */
+typedef StoredRange<MooseMesh::const_bnd_node_iterator, const BndNode*> ConstBndNodeRange;
+typedef StoredRange<MooseMesh::const_bnd_elem_iterator, const BndElement*> ConstBndElemRange;
 
 #endif /* MOOSEMESH_H */

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -756,7 +756,7 @@ MooseMesh::getNodeBlockIds(const Node & node)
 
 
 // default begin() accessor
-bnd_node_iterator
+MooseMesh::bnd_node_iterator
 MooseMesh::bndNodesBegin ()
 {
   Predicates::NotNull<bnd_node_iterator_imp> p;
@@ -764,7 +764,7 @@ MooseMesh::bndNodesBegin ()
 }
 
 // default end() accessor
-bnd_node_iterator
+MooseMesh::bnd_node_iterator
 MooseMesh::bndNodesEnd ()
 {
   Predicates::NotNull<bnd_node_iterator_imp> p;
@@ -772,7 +772,7 @@ MooseMesh::bndNodesEnd ()
 }
 
 // default begin() accessor
-bnd_elem_iterator
+MooseMesh::bnd_elem_iterator
 MooseMesh::bndElemsBegin ()
 {
   Predicates::NotNull<bnd_elem_iterator_imp> p;
@@ -780,7 +780,7 @@ MooseMesh::bndElemsBegin ()
 }
 
 // default end() accessor
-bnd_elem_iterator
+MooseMesh::bnd_elem_iterator
 MooseMesh::bndElemsEnd ()
 {
   Predicates::NotNull<bnd_elem_iterator_imp> p;

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -471,7 +471,7 @@ static PetscErrorCode DMMooseGetEmbedding_Private(DM dm, IS *embedding)
     //  const Node& node = dmm->nl->sys().get_mesh().node(snodes[i]);
     //  // determine v's dof on node and insert into indices
     // }
-     ConstBndNodeRange & bnodes = *dmm->nl->mesh().getBoundaryNodeRange();
+    ConstBndNodeRange & bnodes = *dmm->nl->mesh().getBoundaryNodeRange();
     for (ConstBndNodeRange::const_iterator bnodeit = bnodes.begin(); bnodeit != bnodes.end(); ++bnodeit) {
       const BndNode * bnode = *bnodeit;
       BoundaryID      boundary_id = bnode->_bnd_id;


### PR DESCRIPTION
This makes it so the following line of code compiles:
MooseMesh::bnd_node_iterator boundary_nodes_it  = _mesh.bndNodesBegin();

Note that there is an interesting issue with the ConstBnd{Node,Elem}Range typedefs.
Since they depend on the MooseMesh::const_bnd_{node,elem}_iterator types, they have
to be defined after them, but they should not be defined inside MooseMesh if we want
to continue to mimic the Const{Node,Elem}Range classes from libmesh and avoid changing
any interfaces.  Therefore, these typedefs are now immediately after the MooseMesh
class declaration.

Refs #3969.
