### PR TITLE
Add missing assignment operator overload 

### DIFF
--- a/modules/phase_field/include/utils/ExpressionBuilder.h
+++ b/modules/phase_field/include/utils/ExpressionBuilder.h
@@ -306,7 +306,8 @@ public:
     operator std::string() const;
 
     // function definition (assignment)
-    EBFunction & operator= (const EBTerm & arg);
+    EBFunction & operator= (const EBTerm &);
+    EBFunction & operator= (const EBFunction &);
 
     // get the list of arguments and check if they are all symbols
     std::string args();

--- a/modules/phase_field/src/utils/ExpressionBuilder.C
+++ b/modules/phase_field/src/utils/ExpressionBuilder.C
@@ -137,7 +137,15 @@ ExpressionBuilder::EBFunction &
 ExpressionBuilder::EBFunction::operator= (const ExpressionBuilder::EBTerm & term)
 {
   this->arguments = this->eval_arguments;
-  this->term = EBTerm(term);
+  this->term = term;
+  return *this;
+}
+
+ExpressionBuilder::EBFunction &
+ExpressionBuilder::EBFunction::operator= (const ExpressionBuilder::EBFunction & func)
+{
+  this->arguments = this->eval_arguments;
+  this->term = EBTerm(func);
   return *this;
 }
 


### PR DESCRIPTION
This assignement operator overload is needed to avoid falling back to the copy constructor, which will make the lhs function identical to the rhs function rather than the rhs function with the appropriate parameters substituted in. (closes #3971)
