### PR TITLE
Reworked debugging stuff in FiniteStrainMultiPlasticity

### DIFF
--- a/modules/tensor_mechanics/include/materials/FiniteStrainMultiPlasticity.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainMultiPlasticity.h
@@ -262,9 +262,10 @@ protected:
    * @param ic internal constraint(s)
    * @param rhs (output) the rhs
    * @param active the active constraints
+   * @param eliminate_ld Check for linear dependence of constraints and put the results into deactivated_due_to_ld.  Usually this should be true, but for certain debug operations it should be false
    * @param deactivated_due_to_ld (output) constraints deactivated due to linear-dependence of flow directions
    */
-  virtual void calculateRHS(const RankTwoTensor & stress, const std::vector<Real> & intnl_old, const std::vector<Real> & intnl, const std::vector<Real> & pm, const RankTwoTensor & delta_dp, std::vector<Real> & rhs, const std::vector<bool> & active, std::vector<bool> & deactivated_due_to_ld);
+  virtual void calculateRHS(const RankTwoTensor & stress, const std::vector<Real> & intnl_old, const std::vector<Real> & intnl, const std::vector<Real> & pm, const RankTwoTensor & delta_dp, std::vector<Real> & rhs, const std::vector<bool> & active, bool eliminate_ld, std::vector<bool> & deactivated_due_to_ld);
 
   /**
    * The residual-squared
@@ -408,6 +409,14 @@ protected:
   void fddyieldFunction_dstress(const RankTwoTensor & stress, const std::vector<Real> & intnl, std::vector<RankTwoTensor> & df_dstress);
 
   /**
+   * The finite-difference derivative of yield function(s) with respect to internal parameter(s)
+   * @param stress the stress at which to calculate the yield function
+   * @param intnl vector of internal parameters
+   * @param df_dintnl (output) the derivative (or derivatives in the case of multisurface plasticity).  df_dintnl[alpha] = dyieldFunction[alpha]/dintnl[alpha]
+   */
+  void fddyieldFunction_dintnl(const RankTwoTensor & stress, const std::vector<Real> & intnl, std::vector<Real> & df_dintnl);
+
+  /**
    * The finite-difference derivative of the flow potential(s) with respect to stress
    * @param stress the stress at which to calculate the flow potential
    * @param intnl vector of internal parameters
@@ -440,15 +449,24 @@ protected:
    * @param pm the plasticity multipliers at which to calculate the Jacobian
    * @param delta_dp plastic_strain - plastic_strain_old (Jacobian is independent of this, but it is needed to do the finite-differencing cleanly)
    * @param E_inv inverse of the elasticity tensor
+   * @param eliminate_ld only calculate the Jacobian for the linearly independent constraints
    * @param jac (output) the finite-difference Jacobian
    */
-  virtual void fdJacobian(const RankTwoTensor & stress, const std::vector<Real> & intnl_old, const std::vector<Real> & intnl, const std::vector<Real> & pm, const RankTwoTensor & delta_dp, const RankFourTensor & E_inv, std::vector<std::vector<Real> > & jac);
+  virtual void fdJacobian(const RankTwoTensor & stress, const std::vector<Real> & intnl_old, const std::vector<Real> & intnl, const std::vector<Real> & pm, const RankTwoTensor & delta_dp, const RankFourTensor & E_inv, bool eliminate_ld, std::vector<std::vector<Real> > & jac);
+
+  bool dof_included(unsigned int dof, const std::vector<bool> & deactivated_due_to_ld);
 
   /**
    * Outputs the debug parameters: _fspb_debug_stress, _fspd_debug_pm, etc
    * and checks that they are sized correctly
    */
   void outputAndCheckDebugParameters();
+
+  /**
+   * Checks that Ax does equal b in the NR procedure
+   */
+  void checkSolution();
+
 
 };
 

--- a/modules/tensor_mechanics/tests/mohr_coulomb/small_deform_hard1.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/small_deform_hard1.i
@@ -221,12 +221,12 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = mc
     debug_fspb = 1
-    debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
+    debug_jac_at_stress = '10 1 2 1 10 3 2 3 10'
     debug_jac_at_pm = 1
-    debug_jac_at_intnl = 1
+    debug_jac_at_intnl = 1E-4
     debug_stress_change = 1E-5
     debug_pm_change = 1E-6
-    debug_intnl_change = 1E-6
+    debug_intnl_change = 1E-8
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/mohr_coulomb/small_deform_hard2.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/small_deform_hard2.i
@@ -223,9 +223,9 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = mc
     debug_fspb = 1
-    debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
+    debug_jac_at_stress = '10 1 2 1 10 3 2 3 10'
     debug_jac_at_pm = 1
-    debug_jac_at_intnl = 1
+    debug_jac_at_intnl = 1E-3
     debug_stress_change = 1E-5
     debug_pm_change = 1E-6
     debug_intnl_change = 1E-6

--- a/modules/tensor_mechanics/tests/mohr_coulomb/small_deform_hard3.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/small_deform_hard3.i
@@ -226,7 +226,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = mc
     debug_fspb = 1
-    debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
+    debug_jac_at_stress = '10 1 2 1 11 -3 2 -3 8'
     debug_jac_at_pm = 1
     debug_jac_at_intnl = 1
     debug_stress_change = 1E-5

--- a/modules/tensor_mechanics/tests/multi/three_surface00.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface00.i
@@ -306,11 +306,11 @@
     max_subdivisions = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
-    debug_jac_at_pm = '1 1'
-    debug_jac_at_intnl = '1 1'
+    debug_jac_at_pm = '1 1 1'
+    debug_jac_at_intnl = '1 1 1'
     debug_stress_change = 1E-5
-    debug_pm_change = '1E-6 1E-6'
-    debug_intnl_change = '1E-6 1E-6'
+    debug_pm_change = '1E-6 1E-6 1E-6'
+    debug_intnl_change = '1E-6 1E-6 1E-6'
   [../]
 []
 


### PR DESCRIPTION
Note that this stuff is for developers' use, and is irrelevant for ordinary users.

Included finite-difference check of dyieldFunction_dintnl

Included an explicit check that Ax=b for the solution "x" returned by the BLAS routine.
This is quite nontrivial as with linearly-dependent constraints there could have
been subtle coding bugs (but there weren't).  Also it gives developers an idea
how errors in their jacobians could propagate through to errors in return direction.

The tests haven't really changed - i've just included more appropriate finite-differencing
parameters in them to guide future developers.

Fixes #3924
