### PR TITLE
Consistent output for serial case

### DIFF
--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -126,7 +126,7 @@ parallelBarrierNotify(const Parallel::Communicator & comm)
   if (comm.rank() == 0)
   {
     // The master process is already through, so report it
-    Moose::out << "Jobs complete: 1/" << comm.size() << "\r" << std::flush;
+    Moose::out << "Jobs complete: 1/" << comm.size() << (1 == comm.size() ? "\n" : "\r") << std::flush;
     for (unsigned int i=2; i<=comm.size(); ++i)
     {
       comm.receive(MPI_ANY_SOURCE, slave_processor_id);


### PR DESCRIPTION
If you're running in serial, now you'll get the first line (1/1), with a newline.

In parallel, if you direct to a file, you'll still get one of these lines output followed by a carriage return for each processor before the final processor is output.
