### PR TITLE
Fix logic/clean up repo version script

### DIFF
--- a/framework/scripts/get_repo_revision.py
+++ b/framework/scripts/get_repo_revision.py
@@ -12,12 +12,15 @@ def findRepoRevision(moose_dir):
 
   # Locate the .build_apps file
   found_it = False
-  apps_dir = os.getcwd() + "/"
+  apps_dir = os.getcwd()
+
+  # Search at most 4 directories up from where we are located
   for i in range(4):
-    apps_dir += "../"
-    if os.path.exists(apps_dir + apps_file):
+    if os.path.exists(os.path.join(apps_dir, apps_file)):
       found_it = True
       break
+    apps_dir = os.path.join(apps_dir, '..')
+
   if not found_it:
     # We need to see if we are in a git repo
     p = subprocess.Popen('git rev-parse --show-cdup', stdout=subprocess.PIPE, stderr=None, shell=True)


### PR DESCRIPTION
closes #3998 

This script failed to find the base of the repo if you were in the base of the repo.  Also several delimiters have been removed in favor of os.path.join()
