### PR TITLE
Remove the -mmacosx-version-min=10.7 flag

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -72,12 +72,6 @@ ifeq ($(MOOSE_PRECOMPILED), true)
   endif
 endif
 
-ifneq (,$(filter $(cxx_compiler), clang++))
-  ifneq (,$(findstring darwin,$(libmesh_HOST)))
-	libmesh_CXXFLAGS += -mmacosx-version-min=10.7
-  endif
-endif
-
 all::
 ifdef PRECOMPILED
 #


### PR DESCRIPTION
Remove the -mmacosx-version-min=10.7 flag, it breaks our Clang 3.5.0 builds.

If we still need this flag, it should be passed to the libmesh
configure script so that all source code is compiled with the same
flags.

I believe this flag was originally added to support dmake, so it would
be good if some dmake users could test this for me...

Refs #4024.
