### PR TITLE
Converting "Problem" to a shared_ptr

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -127,7 +127,7 @@ protected:
   /// Convenience reference to a problem this action works on
 
 public:
-  FEProblem * & _problem;
+  MooseSharedPointer<FEProblem> & _problem;
   /// Convenience reference to an executioner
   Executioner * & _executioner;
 };

--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -129,7 +129,7 @@ protected:
 public:
   MooseSharedPointer<FEProblem> & _problem;
   /// Convenience reference to an executioner
-  Executioner * & _executioner;
+  MooseSharedPointer<Executioner> & _executioner;
 };
 
 template <typename T>

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -133,7 +133,7 @@ public:
   MooseSharedPointer<MooseMesh> & mesh() { return _mesh; }
   MooseSharedPointer<MooseMesh> & displacedMesh() { return _displaced_mesh; }
 
-  FEProblem * & problem() { return _problem; }
+  MooseSharedPointer<FEProblem> & problem() { return _problem; }
   Executioner * & executioner() { return _executioner; }
   MooseApp & mooseApp() { return _app; }
   const std::string & getCurrentTaskName() const { return _current_task; }
@@ -189,7 +189,7 @@ protected:
   MooseSharedPointer<MooseMesh> _displaced_mesh;
 
   /// Problem class
-  FEProblem * _problem;
+  MooseSharedPointer<FEProblem> _problem;
   /// Executioner for the simulation (top-level class, is stored in MooseApp, where it is freed)
   Executioner * _executioner;
 };

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -134,7 +134,7 @@ public:
   MooseSharedPointer<MooseMesh> & displacedMesh() { return _displaced_mesh; }
 
   MooseSharedPointer<FEProblem> & problem() { return _problem; }
-  Executioner * & executioner() { return _executioner; }
+  MooseSharedPointer<Executioner> & executioner() { return _executioner; }
   MooseApp & mooseApp() { return _app; }
   const std::string & getCurrentTaskName() const { return _current_task; }
 
@@ -190,8 +190,9 @@ protected:
 
   /// Problem class
   MooseSharedPointer<FEProblem> _problem;
+
   /// Executioner for the simulation (top-level class, is stored in MooseApp, where it is freed)
-  Executioner * _executioner;
+  MooseSharedPointer<Executioner> _executioner;
 };
 
 #endif // ACTIONWAREHOUSE_H

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -198,7 +198,7 @@ public:
   /**
    * Retrieve the Executioner for this App.
    */
-  Executioner * getExecutioner() { return _executioner; }
+  Executioner * getExecutioner() { return _executioner.get(); }
 
   /**
    * Set a Boolean indicating whether this app will use a Nonlinear or Eigen System.
@@ -377,7 +377,7 @@ protected:
   Parser _parser;
 
   /// Pointer to the executioner of this run (typically build by actions)
-  Executioner * _executioner;
+  MooseSharedPointer<Executioner> _executioner;
 
   /// Boolean to indicate whether to use a Nonlinear or EigenSystem (inspected by actions)
   bool _use_nonlinear;

--- a/framework/include/executioners/CoupledExecutioner.h
+++ b/framework/include/executioners/CoupledExecutioner.h
@@ -87,7 +87,7 @@ protected:
   /// Parsers for creating the actions (have to keep them around since some actions are accessing them when executed)
   std::vector<Parser *> _parsers;
   /// Executioners build from input files
-  std::vector<Executioner *> _executioners;
+  std::vector<MooseSharedPointer<Executioner> > _executioners;
   /// FE problems build from input files
   std::vector<FEProblem *> _fe_problems;
   /// Variable mapping: problem name -> list variables that needs to be projected

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -33,7 +33,6 @@ ActionWarehouse::ActionWarehouse(MooseApp & app, Syntax & syntax, ActionFactory 
     _generator_valid(false),
     _show_actions(false),
     _show_parser(false),
-    _problem(NULL),
     _executioner(NULL)
 {
 }
@@ -65,6 +64,8 @@ ActionWarehouse::clear()
   // _comm object owned by the MooseApp is destroyed.
   _mesh.reset();
   _displaced_mesh.reset();
+
+  _problem.reset();
 }
 
 void

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -32,8 +32,7 @@ ActionWarehouse::ActionWarehouse(MooseApp & app, Syntax & syntax, ActionFactory 
     _action_factory(factory),
     _generator_valid(false),
     _show_actions(false),
-    _show_parser(false),
-    _executioner(NULL)
+    _show_parser(false)
 {
 }
 
@@ -66,6 +65,7 @@ ActionWarehouse::clear()
   _displaced_mesh.reset();
 
   _problem.reset();
+  _executioner.reset();
 }
 
 void

--- a/framework/src/actions/AddCoupledVariableAction.C
+++ b/framework/src/actions/AddCoupledVariableAction.C
@@ -40,7 +40,7 @@ AddCoupledVariableAction::~AddCoupledVariableAction()
 void
 AddCoupledVariableAction::act()
 {
-  CoupledExecutioner * master_executioner = dynamic_cast<CoupledExecutioner *>(_executioner);
+  CoupledExecutioner * master_executioner = dynamic_cast<CoupledExecutioner *>(_executioner.get());
   if (master_executioner != NULL)
   {
     std::vector<std::string> parts;

--- a/framework/src/actions/AddFEProblemAction.C
+++ b/framework/src/actions/AddFEProblemAction.C
@@ -36,7 +36,7 @@ AddFEProblemAction::~AddFEProblemAction()
 void
 AddFEProblemAction::act()
 {
-  CoupledExecutioner * master_executioner = dynamic_cast<CoupledExecutioner *>(_executioner);
+  CoupledExecutioner * master_executioner = dynamic_cast<CoupledExecutioner *>(_executioner.get());
   if (master_executioner != NULL)
     master_executioner->addFEProblem(getShortName(), _input_filename);
 }

--- a/framework/src/actions/AddOutputAction.C
+++ b/framework/src/actions/AddOutputAction.C
@@ -62,7 +62,7 @@ AddOutputAction::act()
     mooseError("The output object named '" << object_name << "' already exists");
 
   // Add a pointer to the FEProblem class
-  _moose_object_pars.addPrivateParam<FEProblem *>("_fe_problem",  _problem);
+  _moose_object_pars.addPrivateParam<FEProblem *>("_fe_problem",  _problem.get());
 
   // Apply the common parameters
   InputParameters * common = output_warehouse.getCommonParameters();

--- a/framework/src/actions/AddSplitAction.C
+++ b/framework/src/actions/AddSplitAction.C
@@ -32,6 +32,6 @@ AddSplitAction::AddSplitAction(const std::string & name, InputParameters params)
 void
 AddSplitAction::act()
 {
-  _moose_object_pars.set<FEProblem*>("_fe_problem") = _problem;
+  _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
   _problem->getNonlinearSystem().addSplit(_type, getShortName(), _moose_object_pars);
 }

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -92,7 +92,7 @@ CreateExecutionerAction::act()
   // is held in the child block Adaptivity and needs to be pulled early
 
   Moose::setup_perf_log.push("Create Executioner","Setup");
-  _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem;
+  _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
   Executioner * executioner = static_cast<Executioner *>(_factory.create(_type, "Executioner", _moose_object_pars));
   Moose::setup_perf_log.pop("Create Executioner","Setup");
 

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -93,7 +93,7 @@ CreateExecutionerAction::act()
 
   Moose::setup_perf_log.push("Create Executioner","Setup");
   _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
-  Executioner * executioner = static_cast<Executioner *>(_factory.create(_type, "Executioner", _moose_object_pars));
+  MooseSharedPointer<Executioner> executioner = MooseSharedNamespace::static_pointer_cast<Executioner>(_factory.create_shared_ptr(_type, "Executioner", _moose_object_pars));
   Moose::setup_perf_log.pop("Create Executioner","Setup");
 
   if (_problem != NULL)

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -58,8 +58,8 @@ CreateProblemAction::act()
     {
       _moose_object_pars.set<MooseMesh *>("mesh") = _mesh.get();
       _moose_object_pars.set<bool>("use_nonlinear") = _app.useNonlinear();
-      _problem = dynamic_cast<FEProblem *>(_factory.create(_type, _problem_name, _moose_object_pars));
-      if (_problem == NULL)
+      _problem = MooseSharedNamespace::dynamic_pointer_cast<FEProblem>(_factory.create_shared_ptr(_type, _problem_name, _moose_object_pars));
+      if (!_problem.get())
         mooseError("Problem has to be of a FEProblem type");
     }
     // set up the problem

--- a/framework/src/actions/InitProblemAction.C
+++ b/framework/src/actions/InitProblemAction.C
@@ -38,7 +38,7 @@ InitProblemAction::act()
   {
     // init_problem is a mandatory action, we have an executioner at this point and all FEProblems are
     // already added, we build the coupled system
-    CoupledExecutioner * ex = dynamic_cast<CoupledExecutioner *>(_executioner);
+    CoupledExecutioner * ex = dynamic_cast<CoupledExecutioner *>(_executioner.get());
     if (ex != NULL)
       ex->build();
   }

--- a/framework/src/actions/MaterialOutputAction.C
+++ b/framework/src/actions/MaterialOutputAction.C
@@ -65,7 +65,7 @@ MaterialOutputAction::act()
 
   // Build on the problem for this action, this is what should happend for everything except coupled problems
   else
-    buildMaterialOutputObjects(_problem);
+    buildMaterialOutputObjects(_problem.get());
 }
 
 void

--- a/framework/src/actions/MaterialOutputAction.C
+++ b/framework/src/actions/MaterialOutputAction.C
@@ -51,7 +51,7 @@ void
 MaterialOutputAction::act()
 {
   // If running a coupled problem, loop through all the FEProblem objects
-  CoupledExecutioner * exec_ptr = dynamic_cast<CoupledExecutioner *>(_executioner);
+  CoupledExecutioner * exec_ptr = dynamic_cast<CoupledExecutioner *>(_executioner.get());
   if (exec_ptr != NULL)
   {
     std::vector<FEProblem *> & problems = exec_ptr->getProblems();

--- a/framework/src/actions/SetupPreconditionerAction.C
+++ b/framework/src/actions/SetupPreconditionerAction.C
@@ -41,7 +41,7 @@ SetupPreconditionerAction::act()
   if (_problem != NULL)
   {
     // build the preconditioner
-    _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem;
+    _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
     MooseSharedPointer<MoosePreconditioner> pc = MooseSharedNamespace::static_pointer_cast<MoosePreconditioner>(_factory.create_shared_ptr(_type, getShortName(), _moose_object_pars));
     if (!pc.get())
       mooseError("Failed to build the preconditioner.");

--- a/framework/src/actions/SetupPredictorAction.C
+++ b/framework/src/actions/SetupPredictorAction.C
@@ -42,7 +42,7 @@ SetupPredictorAction::act()
     if (transient == NULL)
       mooseError("You can setup time stepper only with executioners of transient type.");
 
-    _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem;
+    _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
     _moose_object_pars.set<Transient *>("_executioner") = transient;
     MooseSharedPointer<Predictor> predictor = MooseSharedNamespace::static_pointer_cast<Predictor>(_factory.create_shared_ptr(_type, "Predictor", _moose_object_pars));
     _problem->getNonlinearSystem().setPredictor(predictor);

--- a/framework/src/actions/SetupPredictorAction.C
+++ b/framework/src/actions/SetupPredictorAction.C
@@ -38,7 +38,7 @@ SetupPredictorAction::act()
 {
   if (_problem->isTransient())
   {
-    Transient * transient = dynamic_cast<Transient *>(_executioner);
+    Transient * transient = dynamic_cast<Transient *>(_executioner.get());
     if (transient == NULL)
       mooseError("You can setup time stepper only with executioners of transient type.");
 

--- a/framework/src/actions/SetupTimeStepperAction.C
+++ b/framework/src/actions/SetupTimeStepperAction.C
@@ -43,7 +43,7 @@ SetupTimeStepperAction::act()
     if (transient == NULL)
       mooseError("You can setup time stepper only with executioners of transient type.");
 
-    _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem;
+    _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
     _moose_object_pars.set<Transient *>("_executioner") = transient;
     MooseSharedPointer<TimeStepper> ts = MooseSharedNamespace::static_pointer_cast<TimeStepper>(_factory.create_shared_ptr(_type, "TimeStepper", _moose_object_pars));
     transient->setTimeStepper(ts);

--- a/framework/src/actions/SetupTimeStepperAction.C
+++ b/framework/src/actions/SetupTimeStepperAction.C
@@ -39,7 +39,7 @@ SetupTimeStepperAction::act()
 {
   if (_problem->isTransient())
   {
-    Transient * transient = dynamic_cast<Transient *>(_executioner);
+    Transient * transient = dynamic_cast<Transient *>(_executioner.get());
     if (transient == NULL)
       mooseError("You can setup time stepper only with executioners of transient type.");
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -102,7 +102,6 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     _action_factory(*this),
     _action_warehouse(*this, _syntax, _action_factory),
     _parser(*this, _action_warehouse),
-    _executioner(NULL),
     _use_nonlinear(true),
     _sys_info(NULL),
     _enable_unused_check(WARN_UNUSED),
@@ -133,7 +132,6 @@ MooseApp::~MooseApp()
 {
   delete _command_line;
   delete _sys_info;
-  delete _executioner;
   _action_warehouse.clear();
 
   // MUST be deleted before _comm is destroyed!

--- a/framework/src/executioners/CoupledExecutioner.C
+++ b/framework/src/executioners/CoupledExecutioner.C
@@ -49,7 +49,6 @@ CoupledExecutioner::~CoupledExecutioner()
     _awhs[i]->clear();
     delete _awhs[i];
     delete _parsers[i];
-    delete _executioners[i];
     delete _owhs[i];
     // Note: _fe_problems are destroyed by executioners' destructors
   }
@@ -235,5 +234,5 @@ Executioner *
 CoupledExecutioner::getExecutionerByName(const std::string & name)
 {
   unsigned int i = _name_index[name];
-  return _executioners[i];
+  return _executioners[i].get();
 }

--- a/framework/src/executioners/CoupledExecutioner.C
+++ b/framework/src/executioners/CoupledExecutioner.C
@@ -44,7 +44,6 @@ CoupledExecutioner::CoupledExecutioner(const std::string & name, InputParameters
 
 CoupledExecutioner::~CoupledExecutioner()
 {
-  delete _problem;
   for (unsigned int i = 0; i < _awhs.size(); i++)
   {
     _awhs[i]->clear();
@@ -171,7 +170,7 @@ CoupledExecutioner::build()
     _awhs[i]->executeAllActions();
     _owhs[i]->init();
     _executioners[i] = _awhs[i]->executioner();
-    _fe_problems[i] = _awhs[i]->problem();
+    _fe_problems[i] = _awhs[i]->problem().get();
   }
 
   // build an inverse map (problem ptr -> name)

--- a/framework/src/executioners/CoupledTransientExecutioner.C
+++ b/framework/src/executioners/CoupledTransientExecutioner.C
@@ -54,7 +54,7 @@ CoupledTransientExecutioner::execute()
   std::vector<Transient *> trans(n_problems);
   for (unsigned int i = 0; i < n_problems; i++)
   {
-    Transient * exec = dynamic_cast<Transient *>(_executioners[i]);
+    Transient * exec = dynamic_cast<Transient *>(_executioners[i].get());
     if (exec == NULL)
       mooseError("Executioner for problem '" << _fe_problems[i]->name() << "' has to be of a transient type.");
     trans[i] = exec;

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -76,8 +76,6 @@ EigenExecutionerBase::EigenExecutionerBase(const std::string & name, InputParame
 
 EigenExecutionerBase::~EigenExecutionerBase()
 {
-  // This problem was built by the Factory and needs to be released by this destructor
-  delete &_problem;
 }
 
 void

--- a/framework/src/executioners/PetscTSExecutioner.C
+++ b/framework/src/executioners/PetscTSExecutioner.C
@@ -268,8 +268,6 @@ PetscTSExecutioner::PetscTSExecutioner(const std::string & name, InputParameters
 
 PetscTSExecutioner::~PetscTSExecutioner()
 {
-  // This problem was built by the Factory and needs to be released by this destructor
-  delete &_fe_problem;
   delete _time_stepper;
 }
 

--- a/framework/src/executioners/Steady.C
+++ b/framework/src/executioners/Steady.C
@@ -45,8 +45,6 @@ Steady::Steady(const std::string & name, InputParameters parameters) :
 
 Steady::~Steady()
 {
-  // This problem was built by the Factory and needs to be released by this destructor
-  delete &_problem;
 }
 
 Problem &

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -165,8 +165,6 @@ Transient::Transient(const std::string & name, InputParameters parameters) :
 
 Transient::~Transient()
 {
-  // This problem was built by the Factory and needs to be released by this destructor
-  delete &_problem;
 }
 
 void


### PR DESCRIPTION
refs #4009, #3698 

Note that I had to add a problem.reset() in the ActionWarehouse destructor to avoid problems with late cleanup due to OutputWarehouse.  Hopefully we can eventually resolve these destruction order issues.

The cleanup of the destructors in the Executioners is very nice.
