### PR TITLE
Add plog() and a nifty new substitution system

### DIFF
--- a/modules/phase_field/include/utils/ExpressionBuilder.h
+++ b/modules/phase_field/include/utils/ExpressionBuilder.h
@@ -168,7 +168,7 @@ public:
   class EBBinaryFuncTermNode : public EBBinaryTermNode
   {
   public:
-    enum NodeType { MIN, MAX, ATAN2, HYPOT } type;
+    enum NodeType { MIN, MAX, ATAN2, HYPOT, PLOG } type;
 
     EBBinaryFuncTermNode(EBTermNode * _left, EBTermNode * _right, NodeType _type) :
       EBBinaryTermNode(_left, _right), type(_type) {};
@@ -282,6 +282,7 @@ public:
     template<typename T> friend EBTerm pow(const EBTerm &, T exponent);
     friend EBTerm atan2(const EBTerm &, const EBTerm &);
     friend EBTerm hypot(const EBTerm &, const EBTerm &);
+    friend EBTerm plog(const EBTerm &, const EBTerm &);
   };
 
   // User facing host object for a function. This combines a term with an argument list.

--- a/modules/phase_field/src/utils/ExpressionBuilder.C
+++ b/modules/phase_field/src/utils/ExpressionBuilder.C
@@ -315,3 +315,33 @@ ExpressionBuilder::EBTerm::substitute(const EBTermList & find, const EBTermList 
 
   return root->substitute(find_str, replace_terms);
 }
+
+template<class Node_T>
+ExpressionBuilder::EBTermNode * ExpressionBuilder::EBSubstitutionRule<Node_T>::operator() (const ExpressionBuilder::EBTermNode * node)
+{
+  Node_T * match_node = dynamic_cast<Node_T *>(node);
+  if (match_node == NULL)
+    return NULL;
+  else
+    return substitute(*match_node);
+}
+
+ExpressionBuilder::EBTermSubstitution::EBTermSubstitution(const EBTerm & _find, const EBTerm & _replace) :
+    replace(_replace.getRoot()->clone())
+{
+  const EBSymbolNode * find_root = dynamic_cast<const EBSymbolNode *>(_find.getRoot());
+  if (find_root == NULL)
+    mooseError("Function arguments must be pure symbols.");
+  find = find_root->clone();
+}
+
+ExpressionBuilder::EBTermNode *
+ExpressionBuilder::EBLogPlogSubstitution::substitute(const EBUnaryFuncTermNode & node)
+{
+  if (node.type == EBUnaryFuncTermNode::LOG)
+  {
+    return new EBBinaryFuncTermNode(node.getSubnode()->clone(), epsilon->clone(), EBBinaryFuncTermNode::PLOG);
+  }
+  else
+    return NULL;
+}

--- a/modules/phase_field/src/utils/ExpressionBuilder.C
+++ b/modules/phase_field/src/utils/ExpressionBuilder.C
@@ -70,7 +70,7 @@ ExpressionBuilder::EBUnaryOpTermNode::stringify() const
 std::string
 ExpressionBuilder::EBBinaryFuncTermNode::stringify() const
 {
-  const char * bfunc[] = { "min", "max", "atan2", "hypot" };
+  const char * bfunc[] = { "min", "max", "atan2", "hypot", "plog" };
   std::ostringstream s;
   s << bfunc[type] << '(' << *left << ',' << *right << ')';
   return s.str();
@@ -214,6 +214,7 @@ BINARY_FUNC_IMPLEMENT(min,MIN)
 BINARY_FUNC_IMPLEMENT(max,MAX)
 BINARY_FUNC_IMPLEMENT(atan2,ATAN2)
 BINARY_FUNC_IMPLEMENT(hypot,HYPOT)
+BINARY_FUNC_IMPLEMENT(plog,PLOG)
 
 // this is a function in ExpressionBuilder (pow) but an operator in FParser (^)
 ExpressionBuilder::EBTerm pow(const ExpressionBuilder::EBTerm & left, const ExpressionBuilder::EBTerm & right) {


### PR DESCRIPTION
This adds the `plog()` function to `ExpressionBuilder` per #4047. With it I'm revamping the substitution system to allow for more powerful substitutions. Apart from replacing a symbol with a term (now done using the `EBTermSubstitution` rule) it is now super easy to rewrite terms in an expression. The `EBLogPlogSubstitution` rule is such an example. It replaces every occurrence of `log(*)` with `plog(*,epsilon)` (with a given `epsilon`).
