### PR TITLE
Remove vector<bool> specialization in Parser

### DIFF
--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -677,7 +677,6 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
       dynamicCastAndExtractVector(int                   , it->second, full_name, it->first, in_global, global_params_block);
       dynamicCastAndExtractVector(long                  , it->second, full_name, it->first, in_global, global_params_block);
       dynamicCastAndExtractVector(unsigned int          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(bool                  , it->second, full_name, it->first, in_global, global_params_block);
 
       // Moose Vectors
       dynamicCastAndExtractVector(SubdomainID           , it->second, full_name, it->first, in_global, global_params_block);


### PR DESCRIPTION
This fixes an error Jason and I were seeing in Clang 3.5.0.  It appears that nothing uses this specialization... if it does we should be able to work around it, since `vector<bool>` is a weird thing anyway.

Refs #4024.
