### PR TITLE
Check AutoDiff return code 

### DIFF
--- a/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
@@ -35,7 +35,6 @@ public:
 protected:
   virtual void computeProperties();
 
-private:
   void functionsDerivative();
   void functionsOptimize();
 

--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -144,7 +144,8 @@ void DerivativeParsedMaterialHelper::functionsDerivative()
   for (i = 0; i < _nargs; ++i)
   {
     _func_dF[i] = new ADFunction(_func_F);
-    _func_dF[i]->AutoDiff(_arg_names[i]);
+    if (_func_dF[i]->AutoDiff(_arg_names[i]) != -1)
+      mooseError("Failed to take first derivative.");
 
     // second derivatives
     _func_d2F[i].resize(_nargs);
@@ -152,7 +153,8 @@ void DerivativeParsedMaterialHelper::functionsDerivative()
     for (j = i; j < _nargs; ++j)
     {
       _func_d2F[i][j] = new ADFunction(*_func_dF[i]);
-      _func_d2F[i][j]->AutoDiff(_arg_names[j]);
+      if (_func_d2F[i][j]->AutoDiff(_arg_names[j]) != -1)
+        mooseError("Failed to take second derivative.");
 
       // third derivatives
       if (_third_derivatives)
@@ -161,7 +163,8 @@ void DerivativeParsedMaterialHelper::functionsDerivative()
         for (k = j; k < _nargs; ++k)
         {
           _func_d3F[i][j][k] = new ADFunction(*_func_d2F[i][j]);
-          _func_d3F[i][j][k]->AutoDiff(_arg_names[k]);
+          if (_func_d3F[i][j][k]->AutoDiff(_arg_names[k]) != -1)
+            mooseError("Failed to take third derivative.");
         }
       }
     }

--- a/modules/phase_field/tests/Parsed/SplitCHParsed_test.i
+++ b/modules/phase_field/tests/Parsed/SplitCHParsed_test.i
@@ -76,6 +76,7 @@
     constant_names       = 'barr_height  cv_eq'
     constant_expressions = '0.1          1.0e-2'
     function = 16*barr_height*(c-cv_eq)^2*(1-cv_eq-c)^2
+    third_derivatives = false
   [../]
 []
 


### PR DESCRIPTION
Fail fatally if automatic differentiation returns an error. Closes #4058.
