### PR TITLE
FiniteStrainMultiPlasticity optimized in the following way:

### DIFF
--- a/modules/tensor_mechanics/tests/multi/eight_surface14.i
+++ b/modules/tensor_mechanics/tests/multi/eight_surface14.i
@@ -504,7 +504,7 @@
     plastic_models = 'simple0 simple1 simple2 simple3 simple4 simple5 simple6 simple7'
     deactivation_scheme = optimized_to_safe
     max_NR_iterations = 4
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'

--- a/modules/tensor_mechanics/tests/multi/four_surface14.i
+++ b/modules/tensor_mechanics/tests/multi/four_surface14.i
@@ -343,7 +343,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2 simple3'
     max_NR_iterations = 4
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'

--- a/modules/tensor_mechanics/tests/multi/four_surface24.i
+++ b/modules/tensor_mechanics/tests/multi/four_surface24.i
@@ -344,7 +344,7 @@
     plastic_models = 'simple0 simple1 simple2 simple3'
     deactivation_scheme = 'optimized_to_safe'
     max_NR_iterations = 4
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'

--- a/modules/tensor_mechanics/tests/multi/rock1.i
+++ b/modules/tensor_mechanics/tests/multi/rock1.i
@@ -366,7 +366,7 @@
     plastic_models = 'mc tensile wps wpt'
     deactivation_scheme = 'optimized_to_safe_to_dumb'
     max_NR_iterations = 10
-    max_subdivisions = 10000
+    min_stepsize = 1E-4
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1 1'

--- a/modules/tensor_mechanics/tests/multi/six_surface14.i
+++ b/modules/tensor_mechanics/tests/multi/six_surface14.i
@@ -423,7 +423,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2 simple3 simple4 simple5'
     max_NR_iterations = 4
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface00.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface00.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface01.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface01.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface02.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface02.i
@@ -305,7 +305,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface03.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface03.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface04.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface04.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface05.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface05.i
@@ -306,7 +306,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface06.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface06.i
@@ -306,7 +306,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface07.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface07.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface08.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface08.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface09.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface09.i
@@ -305,7 +305,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface10.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface10.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface11.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface11.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface12.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface12.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface13.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface13.i
@@ -303,7 +303,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface14.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface14.i
@@ -316,7 +316,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 4
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface15.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface15.i
@@ -304,7 +304,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 4
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface16.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface16.i
@@ -304,7 +304,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 4
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface20.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface20.i
@@ -306,7 +306,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface21.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface21.i
@@ -307,7 +307,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/three_surface22.i
+++ b/modules/tensor_mechanics/tests/multi/three_surface22.i
@@ -306,7 +306,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple0 simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/two_surface01.i
+++ b/modules/tensor_mechanics/tests/multi/two_surface01.i
@@ -262,7 +262,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/two_surface02.i
+++ b/modules/tensor_mechanics/tests/multi/two_surface02.i
@@ -263,7 +263,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/two_surface03.i
+++ b/modules/tensor_mechanics/tests/multi/two_surface03.i
@@ -265,7 +265,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/two_surface04.i
+++ b/modules/tensor_mechanics/tests/multi/two_surface04.i
@@ -265,7 +265,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/multi/two_surface05.i
+++ b/modules/tensor_mechanics/tests/multi/two_surface05.i
@@ -263,7 +263,7 @@
     ep_plastic_tolerance = 1E-9
     plastic_models = 'simple1 simple2'
     max_NR_iterations = 2
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1'

--- a/modules/tensor_mechanics/tests/weak_plane_shear/small_deform_harden2.i
+++ b/modules/tensor_mechanics/tests/weak_plane_shear/small_deform_harden2.i
@@ -203,7 +203,7 @@
     transverse_direction = '0 0 1'
     ep_plastic_tolerance = 1E-3
     max_NR_iterations = 100
-    max_subdivisions = 1
+    min_stepsize = 1
     debug_fspb = 1
   [../]
 []

--- a/modules/tensor_mechanics/tests/weak_plane_tensile/small_deform1a_uo.i
+++ b/modules/tensor_mechanics/tests/weak_plane_tensile/small_deform1a_uo.i
@@ -184,7 +184,7 @@
     C_ijkl = '0 1E6'
     plastic_models = wpt
     ep_plastic_tolerance = 1E-5
-    max_subdivisions = 1
+    min_stepsize = 1
     max_NR_iterations = 10
   [../]
 []


### PR DESCRIPTION
purely elastic calculations now don't use much of the plastic machinery

the "dumb" deactivation scheme does not attempt to activate constraints
that are initially < 0

timestepping is much cleverer - the stepsize can now increase after >= 2
successful returns, and the best admissible state is repeatedly saved
during substepping so the algorithm doesn't have to go back to the beginning
when stepsizes are cut.  Replaced max_numsubsteps by min_stepsize, which
meants lots of .i files had to be changed

Added ignore_failures flag, which might be useful in PJFNK calculations where
the residual doens't have to be perfectly calculated

Some refactoring and cleaning of logic was done.

Fixes $4060
