### PR TITLE
Always build version headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ traceout*.txt
 *.tif
 *.html
 *.xyz
+*_revision.h
 
 # Allow .e files in gold directories (7 levels)
 !/gold/*.e

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -167,8 +167,9 @@ clobber:: clean
 
 # cleanall runs 'make clean' in all dependent application directories
 cleanall:: clean
+	@echo "Cleaning in:"
 	@for dir in $(app_DIRS); do \
-          echo "Cleaning in $$dir" ; \
+          echo \ $$dir; \
           make -C $$dir clean ; \
         done
 

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -132,7 +132,7 @@ app_deps := $(moose_deps)
 # .) Calling 'make clean' in an app should not remove MOOSE object
 #    files, libraries, etc.
 clean::
-	@rm -rf $(app_LIB) $(app_EXEC) $(app_objects) $(app_deps)
+	@rm -rf $(app_LIB) $(app_EXEC) $(app_objects) $(app_deps) $(app_HEADER)
 
 # The clobber target does 'make clean' and then uses 'find' to clean a
 # bunch more stuff.  We have to write this target as though it could


### PR DESCRIPTION
closes #4026 

Instead of building revision headers sometimes, we'll build them all the time.  This will make it so that applications containing several submodules will be able to access versions of all of those submodules without having additional targets in their own Makefile.

This change is backwards compatible with BISON.

@shanestafford you may want to review this
