### PR TITLE
Single-plasticity cases now can only use the "safe" deactivation.

### DIFF
--- a/modules/tensor_mechanics/include/materials/FiniteStrainMultiPlasticity.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainMultiPlasticity.h
@@ -34,6 +34,9 @@ protected:
   /// Minimum fraction of applied strain that may be applied during adaptive stepsizing
   Real _min_stepsize;
 
+  /// "dumb" deactivation will only be used if the stepsize falls below this quantity
+  Real _max_stepsize_for_dumb;
+
   /// Even if the returnMap fails, return the best values found for stress and internal parameters
   bool _ignore_failures;
 
@@ -308,9 +311,10 @@ protected:
    * @param strain_increment   The applied strain increment
    * @param f  (output) All the yield functions after returning to the yield surface
    * @param iter (output) The number of Newton-Raphson iterations used
+   * @param can_revert_to_dumb  If the _deactivation_scheme is set to revert to dumb, it will only be allowed to do so if this parameter is true
    * @return true if the stress was successfully returned to the yield surface
    */
-  virtual bool returnMap(const RankTwoTensor & stress_old, RankTwoTensor & stress, const std::vector<Real> & intnl_old, std::vector<Real> & intnl, const RankTwoTensor & plastic_strain_old, RankTwoTensor & plastic_strain, const RankFourTensor & E_ijkl, const RankTwoTensor & strain_increment, std::vector<Real> & f, unsigned int & iter);
+  virtual bool returnMap(const RankTwoTensor & stress_old, RankTwoTensor & stress, const std::vector<Real> & intnl_old, std::vector<Real> & intnl, const RankTwoTensor & plastic_strain_old, RankTwoTensor & plastic_strain, const RankFourTensor & E_ijkl, const RankTwoTensor & strain_increment, std::vector<Real> & f, unsigned int & iter, const bool & can_revert_to_dumb);
 
   /**
    * Performs one Newton-Raphson step.  The purpose here is to find the

--- a/modules/tensor_mechanics/tests/multi/rock1.i
+++ b/modules/tensor_mechanics/tests/multi/rock1.i
@@ -365,8 +365,9 @@
     ep_plastic_tolerance = 1E-7
     plastic_models = 'mc tensile wps wpt'
     deactivation_scheme = 'optimized_to_safe_to_dumb'
-    max_NR_iterations = 10
+    max_NR_iterations = 20
     min_stepsize = 1E-4
+    max_stepsize_for_dumb = 1E-3
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1 1'


### PR DESCRIPTION
That means they never try to switch deactivation schemes and waste
time in copying arrays and so on.

Dumb deactivation/reactivation now only occurs if the stepsize
is less than max_stepsize_for_dumb.  This is to prevent "dumb"
consuming resources on situations where a stepsize cut is needed.

Fixes #4073
