### PR TITLE
Fix broken link on generated test timing web page

### DIFF
--- a/framework/scripts/timingHTML/index.html
+++ b/framework/scripts/timingHTML/index.html
@@ -3,7 +3,7 @@
  <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Moose Test Timing</title>
-    <br><a href="https://hpcsc.inl.gov/moose">Back to MOOSE wiki</a><br>
+    <br><a href="https://mooseframework.org">mooseframework.org</a><br>
     <link href="resources/jquery.css" rel="stylesheet" type="text/css">
     <!--[if IE]><script language="javascript" type="text/javascript" src="resources/excanvas.min.js"></script><![endif]-->
     <script language="javascript" type="text/javascript" src="resources/jquery.min.js"></script>


### PR DESCRIPTION
Link to the correct web address. References #4097
