### PR TITLE
Show the user a better value

### DIFF
--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -27,13 +27,26 @@ InputParameters validParams<MultiAppTransfer>()
   params.addRequiredParam<MooseEnum>("direction", MultiAppTransfer::directions(), "Whether this Transfer will be 'to' or 'from' a MultiApp.");
 
   // MultiAppTransfers by default will execute with their associated MultiApp. These flags will be added by FEProblem when the transfer is added.
-  params.set<MultiMooseEnum>("execute_on").clear();
+  MultiMooseEnum multi_transfer_execute_on(params.get<MultiMooseEnum>("execute_on").getRawNames() + " same_as_multiapp", "same_as_multiapp");
+  params.set<MultiMooseEnum>("execute_on") = multi_transfer_execute_on;
 
   return params;
 }
 
+// Free function to clear special execute_on option before initializing SetupInterface
+InputParameters & removeSpecialOption(InputParameters & params)
+{
+  params.set<MultiMooseEnum>("execute_on").erase("SAME_AS_MULTIAPP");
+  return params;
+}
+
 MultiAppTransfer::MultiAppTransfer(const std::string & name, InputParameters parameters) :
-    Transfer(name, parameters),
+    /**
+     * Here we need to remove the special option that indicates to the user that this object will follow it's associated
+     * Multiapp execute_on. This non-standard option is not understood by SetupInterface. In the absence of any execute_on
+     * parameters, FEProblem will populate the execute_on MultiMooseEnum with the values from the associated MultiApp.
+     */
+    Transfer(name, removeSpecialOption(parameters)),
     _multi_app(_fe_problem.getMultiApp(getParam<MultiAppName>("multi_app"))),
     _direction(getParam<MooseEnum>("direction"))
 {


### PR DESCRIPTION
closes #4121 

This PR adds another pseudo option to the normal execute_on options just so the user can either specify it explicitly or they'll see it in a GUI application as the default "same_as_multiapp".  This option is removed just prior to object construction so as not to confuse the SetupInterface.
