### PR TITLE
Adding ability to run tests without libmesh configuration.

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -678,6 +678,7 @@ class TestHarness:
     parser.add_argument('--error', action='store_true', help='Run the tests with warnings as errors')
     parser.add_argument('--cli-args', nargs='?', type=str, dest='cli_args', help='Append the following list of arguments to the command line (Encapsulate the command in quotes)')
     parser.add_argument('--dry-run', action='store_true', dest='dry_run', help="Pass --dry-run to print commands to run, but don't actually run them")
+    parser.add_argument("--ignore-option-errors", action="store_true", dest="ignore_option_errors", help="Ignore errors when determining options")
 
     outputgroup = parser.add_argument_group('Output Options', 'These options control the output of the test harness. The sep-files options write output to files named test_name.TEST_RESULT.txt. All file output will overwrite old files')
     outputgroup.add_argument('-v', '--verbose', action='store_true', dest='verbose', help='show the output of every test that fails')
@@ -752,6 +753,10 @@ class TestHarness:
         if m != None and int(m.group(1)) > largest_serial_num:
           largest_serial_num = int(m.group(1))
       opts.pbs = "pbs_" +  str(largest_serial_num+1).zfill(3)
+
+    #Check if ignoring option errors
+    if self.options.ignore_option_errors:
+      ignoreOptionErrors()
 
   def postRun(self, specs, timing):
     return

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -2,6 +2,8 @@ import os, re
 from subprocess import *
 from time import strftime, gmtime, ctime, localtime, asctime
 
+util_options = {"fail_on_errors": True}
+
 TERM_COLS = 110
 
 LIBMESH_OPTIONS = {
@@ -200,7 +202,8 @@ def getCompilers(libmesh_dir):
 
   else:
     print "Error! Could not find libmesh's config script in any of the usual locations!"
-    exit(1)
+    if util_options["fail_on_errors"]:
+      exit(1)
 
   # Pass the --cxx option to the libmesh-config script, and check the result
   command = libmesh_config + ' --cxx'
@@ -306,7 +309,8 @@ def getLibMeshConfigOption(libmesh_dir, option):
 
   if success == 0:
     print "Error! Could not find libmesh_config.h in any of the usual locations!"
-    exit(1)
+    if util_options["fail_on_errors"]:
+      exit(1)
 
   return option_set
 
@@ -336,7 +340,8 @@ def getSharedOption(libmesh_dir):
 
   else:
     print "Error! Could not find libmesh's libtool script in any of the usual locations!"
-    exit(1)
+    if util_options["fail_on_errors"]:
+      exit(1)
 
   # Now run the libtool script (in the shell) to see if shared libraries were built
   command = libmesh_libtool + " --config | grep build_libtool_libs | cut -d'=' -f2"
@@ -352,6 +357,10 @@ def getSharedOption(libmesh_dir):
   else:
     # Neither no nor yes?  Not possible!
     print "Error! Could not determine whether shared libraries were built."
-    exit(1)
+    if util_options["fail_on_errors"]:
+      exit(1)
 
   return shared_option
+
+def ignoreOptionErrors():
+  util_options["fail_on_errors"] = False


### PR DESCRIPTION
This code adds a way for a code to ignore errors when finding options.
This would solve issue #4153 
If there is a better way to push the option into util.py, I can rewrite that portion.

A code can now do something like:
argv = sys.argv[:]
argv.append('--ignore-option-errors')
TestHarness.buildAndRun(argv, app_name, MOOSE_DIR)

to ignore the option errors.
