### PR TITLE
Fix test harness on systems where python3 is the default

### DIFF
--- a/test/run_tests
+++ b/test/run_tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os, inspect
 
 # Set the current working directory to the directory where this script is located


### PR DESCRIPTION
Just a quick patch to make the test harness run on machines where
python3 is the default system Python (I built on Arch Linux). This shouldn't cause any issues on supported platforms as far as I know (it's recommended practice if your script is dependent on a specific version of Python).
