### PR TITLE
Allow users to override compiler settings

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -24,10 +24,10 @@ endif
 # Instead of using Make.common, use libmesh-config to get any libmesh
 # make variables we might need.  Be sure to pass METHOD along to libmesh-config
 # so that it can use the right one!
-libmesh_CXX      := $(shell METHOD=$(METHOD) $(libmesh_config) --cxx)
-libmesh_CC       := $(shell METHOD=$(METHOD) $(libmesh_config) --cc)
-libmesh_F77      := $(shell METHOD=$(METHOD) $(libmesh_config) --fc)
-libmesh_F90      := $(shell METHOD=$(METHOD) $(libmesh_config) --fc)
+libmesh_CXX      ?= $(shell METHOD=$(METHOD) $(libmesh_config) --cxx)
+libmesh_CC       ?= $(shell METHOD=$(METHOD) $(libmesh_config) --cc)
+libmesh_F77      ?= $(shell METHOD=$(METHOD) $(libmesh_config) --fc)
+libmesh_F90      ?= $(shell METHOD=$(METHOD) $(libmesh_config) --fc)
 libmesh_INCLUDE  := $(shell METHOD=$(METHOD) $(libmesh_config) --include)
 libmesh_CPPFLAGS := $(shell METHOD=$(METHOD) $(libmesh_config) --cppflags)
 libmesh_CXXFLAGS := $(shell METHOD=$(METHOD) $(libmesh_config) --cxxflags)


### PR DESCRIPTION
This is helpful when one uses distcc. If you configure libmesh with
CXX='mpicxx' and then you want to use distcc, you have to go back and
reconfigure libmesh. This allows people to supply the libmesh_CXX, libmesh_CC,
libmesh_F77 and libmesh_F90 variables, thus using distcc without libmesh
reconfigure.

Closes #4171
