### PR TITLE
Add DOFMap output class

### DIFF
--- a/framework/include/outputs/DOFMapOutput.h
+++ b/framework/include/outputs/DOFMapOutput.h
@@ -1,0 +1,114 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef DOFMAPOUTPUT_H
+#define DOFMAPOUTPUT_H
+
+// MOOSE includes
+#include "FileOutput.h"
+
+// Forward declarations
+class DOFMapOutput;
+
+template<>
+InputParameters validParams<DOFMapOutput>();
+
+/**
+ * An output object for writing the DOF map of the system in a machine parsable format
+ */
+class DOFMapOutput :
+  public FileOutput
+{
+public:
+  DOFMapOutput(const std::string & name, InputParameters);
+  virtual ~DOFMapOutput();
+
+  /**
+   * Initial setup function
+   * Prints the DOF map information, this is done here so that the system information
+   * is printed prior to any PETSc solve information
+   */
+  virtual void initialSetup();
+
+  /**
+   * Creates the output file name
+   * Appends the user-supplied 'file_base' input parameter with a '.txt' extension
+   * @return A string containing the output filename
+   */
+  virtual std::string filename();
+
+  /**
+   * Display the system information
+   */
+  void outputSystemInformation();
+
+protected:
+
+  /**
+   * Write message to screen and/or file
+   * @param message The desired message
+   * @param indent True if multiapp indenting is desired
+   */
+  void write(std::string message);
+
+  /**
+   * Apply indentation to newlines in the supplied stream
+   * @param message Reference to the message being changed
+   */
+  void indentMessage(std::string & message);
+
+  /**
+   * Write the file stream to the file
+   * @param append Toggle for appending the file
+   *
+   * This helper function writes the _file_output_stream to the file and clears the
+   * stream, by default the file is appended. This does nothing if 'output_file' is
+   * false.
+   */
+  void writeStreamToFile(bool append = true);
+
+  /// Flag for controlling outputting console information to a file
+  bool _write_file;
+
+  /// Flag for controlling outputting console information to screen
+  bool _write_screen;
+
+  /// Stream for storing information to be written to a file
+  std::stringstream _file_output_stream;
+
+  std::string _system_name;
+
+  MooseMesh & _mesh;
+
+private:
+
+  /**
+   * Add a message to the output streams
+   * @param message The message to add to the output streams
+   *
+   * Any call to this method will write the supplied message to the screen and/or file,
+   * following the same restrictions as outputStep and outputInitial.
+   *
+   * Calls to this method should be made via OutputWarehouse::mooseDOFMapOutput so that the
+   * output stream buffer is cleaned up correctly. Thus, it is a private method.
+   */
+  void mooseConsoleOutput(const std::string & message);
+
+  /// Reference to cached messages from calls to _console
+  const std::ostringstream & _console_buffer;
+
+  friend class OutputWarehouse;
+};
+
+#endif /* DOFMAPOUTPUT_H */

--- a/framework/include/outputs/DOFMapOutput.h
+++ b/framework/include/outputs/DOFMapOutput.h
@@ -62,6 +62,9 @@ protected:
    */
   void write(std::string message);
 
+  template<typename T>
+  std::string join(const std::vector<T> & elements, const char* const delim);
+
   /**
    * Apply indentation to newlines in the supplied stream
    * @param message Reference to the message being changed

--- a/framework/include/outputs/DOFMapOutput.h
+++ b/framework/include/outputs/DOFMapOutput.h
@@ -81,6 +81,11 @@ protected:
    */
   void writeStreamToFile(bool append = true);
 
+  /**
+   * Try to demangle type name
+   */
+  std::string demangle(const std::string & name);
+
   /// Flag for controlling outputting console information to a file
   bool _write_file;
 

--- a/framework/include/outputs/DOFMapOutput.h
+++ b/framework/include/outputs/DOFMapOutput.h
@@ -63,7 +63,7 @@ protected:
   void write(std::string message);
 
   template<typename T>
-  std::string join(const std::vector<T> & elements, const char* const delim);
+  std::string join(const T & begin, const T & end, const char* const delim);
 
   /**
    * Apply indentation to newlines in the supplied stream

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -363,6 +363,7 @@
 #include "MaterialPropertyDebugOutput.h"
 #include "VariableResidualNormsDebugOutput.h"
 #include "TopResidualDebugOutput.h"
+#include "DOFMapOutput.h"
 
 namespace Moose {
 
@@ -662,6 +663,7 @@ registerObjects(Factory & factory)
   registerOutput(MaterialPropertyDebugOutput);
   registerOutput(VariableResidualNormsDebugOutput);
   registerOutput(TopResidualDebugOutput);
+  registerNamedOutput(DOFMapOutput, "DOFMap");
 
   registered = true;
 }

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -1,0 +1,184 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+// MOOSE includes
+#include "DOFMapOutput.h"
+#include "FEProblem.h"
+#include "Postprocessor.h"
+#include "MooseApp.h"
+#include "Moose.h"
+
+// libMesh includes
+#include "libmesh/fe.h"
+
+template<>
+InputParameters validParams<DOFMapOutput>()
+{
+  // Get the parameters from the base class
+  InputParameters params = validParams<FileOutput>();
+  params += Output::enableOutputTypes("system_information");
+
+  // Screen and file output toggles
+  params.addParam<bool>("output_screen", false, "Output to the screen");
+  params.addParam<bool>("output_file", true, "Output to the file");
+  params.addParam<std::string>("system_name", "nl0", "System to output");
+  return params;
+}
+
+DOFMapOutput::DOFMapOutput(const std::string & name, InputParameters parameters) :
+    FileOutput(name, parameters),
+    _write_file(getParam<bool>("output_file")),
+    _write_screen(getParam<bool>("output_screen")),
+    _system_name(getParam<std::string>("system_name")),
+    _mesh(_mci_feproblem.mesh()),
+    _console_buffer(_app.getOutputWarehouse().consoleBuffer())
+{
+  // Set output coloring
+  if (Moose::_color_console)
+  {
+    char * term_env = getenv("TERM");
+    if (term_env)
+    {
+      std::string term(term_env);
+      if (term != "xterm-256color" && term != "xterm")
+        Moose::_color_console = false;
+    }
+  }
+}
+
+DOFMapOutput::~DOFMapOutput()
+{
+  // Write the file output stream
+  writeStreamToFile();
+}
+
+void
+DOFMapOutput::initialSetup()
+{
+  // If file output is desired, wipe out the existing file if not recovering
+  if (!_app.isRecovering())
+    writeStreamToFile(false);
+
+  // Output the system information
+  if (_system_information && _allow_output)
+    outputSystemInformation();
+}
+
+std::string
+DOFMapOutput::filename()
+{
+  return _file_base + ".json";
+}
+
+void
+DOFMapOutput::writeStreamToFile(bool append)
+{
+  if (!_write_file)
+    return;
+
+  // Create the stream
+  std::ofstream output;
+
+  // Open the file
+  if (append)
+    output.open(filename().c_str(), std::ios::app | std::ios::out);
+  else
+    output.open(filename().c_str(), std::ios::trunc);
+
+  // Write contents of file output stream and close the file
+  output << _file_output_stream.str();
+  output.close();
+
+  // Clear the file output stream
+  _file_output_stream.str("");
+}
+
+void
+DOFMapOutput::write(std::string message)
+{
+  // Do nothing if the message is empty, writing empty strings messes with multiapp indenting
+  if (message.empty())
+    return;
+
+  // Write the message to file
+  if (_write_file)
+    _file_output_stream << message << std::endl;
+
+  // Write message to the screen
+  if (_write_screen)
+    Moose::out << message;
+}
+
+void
+DOFMapOutput::mooseConsoleOutput(const std::string & message)
+{
+  // Write the messages
+  write(message);
+
+  // Flush the stream to the screen
+  Moose::out << std::flush;
+}
+
+void
+DOFMapOutput::outputSystemInformation()
+{
+  // Don't build this information if nothing is to be written
+  if (!_write_screen && !_write_file)
+    return;
+
+  std::stringstream oss;
+
+  // Get the DOF Map through the equation system
+  const System & sys = _problem_ptr->es().get_system(_system_name); // TransientNonlinearImplicit
+  const DofMap & dof_map = sys.get_dof_map();
+
+  // fetch the KernelWarehouse through the NonlinearSystem
+  NonlinearSystem & nl = _problem_ptr->getNonlinearSystem();
+  const KernelWarehouse & kernels = nl.getKernelWarehouse(0);
+
+  bool first = true;
+  oss << '[';
+  for (unsigned int vg = 0; vg < dof_map.n_variable_groups(); ++vg)
+  {
+    const VariableGroup &vg_description (dof_map.variable_group(vg));
+    for (unsigned int vn = 0; vn < vg_description.n_variables(); ++vn)
+    {
+      unsigned int var = vg_description.number(vn);
+
+      if (!first)
+        oss << ", ";
+      first = false;
+
+      // get the list of DOFs for this variable
+      std::vector<dof_id_type> idx;
+      dof_map.local_variable_indices(idx, _mesh, var);
+
+      oss << "{\"name\": \"" << vg_description.name(vn) << "\", \"kernels\": [";
+      if (kernels.hasActiveKernels(var))
+      {
+        const std::vector<KernelBase *> & active_kernels = kernels.activeVar(var);
+        oss << active_kernels.size();
+      }
+
+      oss << "], \"doflist\": [";
+      for (unsigned i = 0; i<idx.size(); ++i)
+        oss << (i>0 ? ", " : "") << idx[i] << ' ';
+      oss << "]}";
+    }
+  }
+  oss << "]\n";
+
+  // Output the information
+  write(oss.str());
+}

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -161,7 +161,7 @@ DOFMapOutput::outputSystemInformation()
   const std::set<SubdomainID> & subdomains = _mesh.meshSubdomains();
 
   bool first = true;
-  oss << '[';
+  oss << "{\"ndof\": " << sys.n_dofs() << ", \"vars\": [";
   for (unsigned int vg = 0; vg < dof_map.n_variable_groups(); ++vg)
   {
     const VariableGroup &vg_description (dof_map.variable_group(vg));
@@ -200,7 +200,7 @@ DOFMapOutput::outputSystemInformation()
       oss << "]}";
     }
   }
-  oss << "]\n";
+  oss << "]}\n";
 
   // Output the information
   write(oss.str());

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -87,18 +87,14 @@ DOFMapOutput::filename()
 std::string
 DOFMapOutput::demangle(const std::string & name)
 {
-#ifdef HAVE_CXA_DEMANGLE
-  // user compiler ABI to demangle
-  int status = -1;
-  char * result = abi::__cxa_demangle (name.c_str(), NULL, NULL, &status);
-  std::string demangled(result);
-  free(result);
-  return (status==0) ? demangled : name;
+#if defined(LIBMESH_HAVE_GCC_ABI_DEMANGLE)
+  return libMesh::demangle(name.c_str());
 #else
   // at least remove leading digits
   std::string demangled(name);
   while (demangled.length() && demangled[0] >= '0' && demangled[0] <= '9')
     demangled.erase(0,1);
+
   return demangled;
 #endif
 }

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -180,7 +180,7 @@ DOFMapOutput::outputSystemInformation()
 
   bool first = true;
   oss << "{\"ndof\": " << sys.n_dofs() << ", \"demangled\": ";
-#ifdef HAVE_CXA_DEMANGLE
+#if defined(LIBMESH_HAVE_GCC_ABI_DEMANGLE)
   oss << "true";
 #else
   oss << "false";

--- a/test/tests/outputs/dofmap/simple.i
+++ b/test/tests/outputs/dofmap/simple.i
@@ -1,0 +1,62 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+  [./v]
+  [../]
+[]
+
+[AuxVariables]
+  [./w]
+  [../]
+[]
+
+[Kernels]
+  [./diffu]
+    type = Diffusion
+    variable = u
+  [../]
+  [./diffv]
+    type = Diffusion
+    variable = v
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  #output_initial = true
+  [./dofmap]
+    type = DOFMap
+  [../]
+[]


### PR DESCRIPTION
As described in #4155 this output module dumps the degrees-of-freedom map in JSON format to a file and/or the screen. JSON is a widely supported text based serialization format. 

Besides the raw DOF data I'm also outputting active kernels for every subdomain (names and type names!). 
