### PR TITLE
Adding a .mailmap file to help organize the output of 'git shortlog'

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+Andy Wilkins <andrew.wilkins@csiro.au>
+Andrew E. Slaughter <andrew.slaughter@inl.gov>
+Andrew E. Slaughter <slaughter98@gmail.com>
+Andrew E. Slaughter <andrew.slaughter@inl.gov>
+Derek Gaston <derek.gaston@inl.gov>
+Derek Gaston <friedmud@gmail.com>
+Derek Gaston <derek.gaston@gmail.com>
+John W. Peterson <jwpeterson@gmail.com>
+John W. Peterson <jw.peterson@inl.gov>
+Shane Stafford <shane.stafford@inl.gov>
+Jason M. Miller <Jason.Miller@inl.gov>
+Jason M. Miller <milljm@inl426606.local>
+Jason M. Miller <milljm@inl426607.inl.gov>
+Jason M. Miller <jason.miller@inl.gov>
+David Andrs <andrsd@fn600015.local>
+David Andrs <david.andrs@inl.gov>
+Jacob Peterson <peterson.jake@tamu.edu>
+Yaqi Wang <YaqiWang@users.noreply.github.com>
+Yaqi Wang <Yaqi.Wang@inl.gov>
+Yaqi Wang <yaqi.wang@inl.gov>
+Chandana Jayasundara <chandana.jayasundara@csiro.au>
+Micah Johnson <micah.johnson150@gmail.com>
+Jason D. Hales <jason.hales@inl.gov>
+Pritam Chakraborty <pritam.chakraborty@inl.gov>
+Pritam Chakraborty <chakp@fn426624.fn.inl.gov>
+Ziyu Zhang <buaazhangziyu@gmail.com>
+Scott A. Schoen <schosa@dd8cd9ef-2931-0410-98ca-75ad22d19dd1>
+Cristian Rabiti <crisr@dd8cd9ef-2931-0410-98ca-75ad22d19dd1>


### PR DESCRIPTION
This commit just adds a .mailmap file to the top level of the MOOSE repository.  It is used by git to organize the output of `git shortlog` by attributing commits coming from multiple email addresses to a single author.

Refs #000
