### PR TITLE
Relax the need for libMesh configuration in TestHarness

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -71,28 +71,37 @@ class TestHarness:
 
     self.checks = {}
     self.checks['platform'] = getPlatforms()
-    self.checks['compiler'] = getCompilers(self.libmesh_dir)
-    self.checks['petsc_version'] = getPetscVersion(self.libmesh_dir)
-    self.checks['mesh_mode'] = getLibMeshConfigOption(self.libmesh_dir, 'mesh_mode')
-    self.checks['dtk'] =  getLibMeshConfigOption(self.libmesh_dir, 'dtk')
-    self.checks['library_mode'] = getSharedOption(self.libmesh_dir)
-    self.checks['unique_ids'] = getLibMeshConfigOption(self.libmesh_dir, 'unique_ids')
-    self.checks['vtk'] =  getLibMeshConfigOption(self.libmesh_dir, 'vtk')
-    self.checks['tecplot'] =  getLibMeshConfigOption(self.libmesh_dir, 'tecplot')
+
+    # The TestHarness doesn't strictly require the existance of libMesh in order to run. Here we allow the user
+    # to select whether they want to probe for libMesh configuration options.
+    if self.options.skip_config_checks:
+      self.checks['compiler'] = set(['ALL'])
+      self.checks['petsc_version'] = 'N/A'
+      self.checks['library_mode'] = set(['ALL'])
+      self.checks['mesh_mode'] = set(['ALL'])
+      self.checks['dtk'] = set(['ALL'])
+      self.checks['unique_ids'] = set(['ALL'])
+      self.checks['vtk'] = set(['ALL'])
+      self.checks['tecplot'] = set(['ALL'])
+    else:
+      self.checks['compiler'] = getCompilers(self.libmesh_dir)
+      self.checks['petsc_version'] = getPetscVersion(self.libmesh_dir)
+      self.checks['library_mode'] = getSharedOption(self.libmesh_dir)
+      self.checks['mesh_mode'] = getLibMeshConfigOption(self.libmesh_dir, 'mesh_mode')
+      self.checks['dtk'] =  getLibMeshConfigOption(self.libmesh_dir, 'dtk')
+      self.checks['unique_ids'] = getLibMeshConfigOption(self.libmesh_dir, 'unique_ids')
+      self.checks['vtk'] =  getLibMeshConfigOption(self.libmesh_dir, 'vtk')
+      self.checks['tecplot'] =  getLibMeshConfigOption(self.libmesh_dir, 'tecplot')
 
     # Override the MESH_MODE option if using '--parallel-mesh' option
     if self.options.parallel_mesh == True or \
           (self.options.cli_args != None and \
           self.options.cli_args.find('--parallel-mesh') != -1):
 
-      option_set = set()
-      option_set.add('ALL')
-      option_set.add('PARALLEL')
+      option_set = set(['ALL', 'PARALLEL'])
       self.checks['mesh_mode'] = option_set
 
-    method = set()
-    method.add('ALL')
-    method.add(self.options.method.upper())
+    method = set(['ALL', self.options.method.upper()])
     self.checks['method'] = method
 
     self.initialize(argv, app_name)
@@ -663,6 +672,7 @@ class TestHarness:
     parser.add_argument('-s', '--scale', action='store_true', dest='scaling', help='Scale problems that have SCALE_REFINE set')
     parser.add_argument('-i', nargs=1, action='store', type=str, dest='input_file_name', default='tests', help='The default test specification file to look for (default="tests").')
     parser.add_argument('--libmesh_dir', nargs=1, action='store', type=str, dest='libmesh_dir', help='Currently only needed for bitten code coverage')
+    parser.add_argument('--skip-config-checks', action='store_true', dest='skip_config_checks', help='Skip configuration checks (all tests will run regardless of restrictions)')
     parser.add_argument('--parallel', '-p', nargs='?', action='store', type=int, dest='parallel', const=1, help='Number of processors to use when running mpiexec')
     parser.add_argument('--n-threads', nargs=1, action='store', type=int, dest='nthreads', default=1, help='Number of threads to use when running mpiexec')
     parser.add_argument('-d', action='store_true', dest='debug_harness', help='Turn on Test Harness debugging')

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -158,16 +158,17 @@ def colorText(str, options, color, html=False):
 
 def getPlatforms():
   # We'll use uname to figure this out
-  # Supported platforms are LINUX, DARWIN, SL, LION or ALL
-  platforms = set()
-  platforms.add('ALL')
+  # Supported platforms are LINUX, DARWIN, ML, MAVERICKS, YOSEMITE, or ALL
+  platforms = set(['ALL'])
   raw_uname = os.uname()
   if raw_uname[0].upper() == 'DARWIN':
     platforms.add('DARWIN')
-    if re.match("10\.", raw_uname[2]):
-      platforms.add('SL')
-    if re.match("11\.", raw_uname[2]):
-      platforms.add("LION")
+    if re.match("12\.", raw_uname[2]):
+      platforms.add('ML')
+    if re.match("13\.", raw_uname[2]):
+      platforms.add("MAVERICKS")
+    if re.match("14\.", raw_uname[2]):
+      platforms.add("YOSEMITE")
   else:
     platforms.add(raw_uname[0].upper())
   return platforms
@@ -176,36 +177,9 @@ def getCompilers(libmesh_dir):
   # We'll use the GXX-VERSION string from LIBMESH's Make.common
   # to figure this out
   # Supported compilers are GCC, INTEL or ALL
-  compilers = set()
-  compilers.add('ALL')
+  compilers = set(['ALL'])
 
-  # Get the gxx compiler.  Note that the libmesh-config script
-  # can live in different places depending on whether libmesh is
-  # "installed" or not.
-
-  # Installed location of libmesh-config script
-  libmesh_config_installed   = libmesh_dir + '/bin/libmesh-config'
-
-  # Uninstalled location of libmesh-config script
-  libmesh_config_uninstalled = libmesh_dir + '/contrib/bin/libmesh-config'
-
-  # The eventual variable we will use to refer to libmesh's configure script
-  libmesh_config = ''
-
-  if os.path.exists(libmesh_config_installed):
-    libmesh_config = libmesh_config_installed
-
-  elif os.path.exists(libmesh_config_uninstalled):
-    libmesh_config = libmesh_config_uninstalled
-
-  else:
-    print "Error! Could not find libmesh's config script in any of the usual locations!"
-    exit(1)
-
-  # Pass the --cxx option to the libmesh-config script, and check the result
-  command = libmesh_config + ' --cxx'
-  p = Popen(command, shell=True, stdout=PIPE)
-  mpicxx_cmd = p.communicate()[0].strip()
+  mpicxx_cmd = getLibToolConfigOption(libmesh_dir, ' --cxx')
 
   # Account for useage of distcc
   if "distcc" in mpicxx_cmd:
@@ -214,8 +188,7 @@ def getCompilers(libmesh_dir):
 
   # If mpi ic on the command, run -show to get the compiler
   if "mpi" in mpicxx_cmd:
-    p = Popen(mpicxx_cmd + " -show", shell=True, stdout=PIPE)
-    raw_compiler = p.communicate()[0]
+    raw_compiler = runCommand(mpicxx-cmd + " -show")
   else:
     raw_compiler = mpicxx_cmd
 
@@ -267,8 +240,7 @@ def checkPetscVersion(checks, test):
 def getLibMeshConfigOption(libmesh_dir, option):
   # Some tests work differently with parallel mesh enabled
   # We need to detect this condition
-  option_set = set()
-  option_set.add('ALL')
+  option_set = set(['ALL'])
 
   filenames = [
     libmesh_dir + '/include/base/libmesh_config.h',   # Old location
@@ -310,12 +282,7 @@ def getLibMeshConfigOption(libmesh_dir, option):
 
   return option_set
 
-def getSharedOption(libmesh_dir):
-  # Some tests may only run properly with shared libraries on/off
-  # We need to detect this condition
-  shared_option = set()
-  shared_option.add('ALL')
-
+def getLibToolConfigOption(libmesh_dir, command):
   # MOOSE no longer relies on Make.common being present.  This gives us the
   # potential to work with "uninstalled" libmesh trees, for example.
 
@@ -338,12 +305,14 @@ def getSharedOption(libmesh_dir):
     print "Error! Could not find libmesh's libtool script in any of the usual locations!"
     exit(1)
 
-  # Now run the libtool script (in the shell) to see if shared libraries were built
-  command = libmesh_libtool + " --config | grep build_libtool_libs | cut -d'=' -f2"
+  return runCommand(libmesh_libtool + command)
 
-  # Note: the strip() command removes the trailing newline
-  p = Popen(command, shell=True, stdout=PIPE)
-  result = p.communicate()[0].strip()
+def getSharedOption(libmesh_dir):
+  # Some tests may only run properly with shared libraries on/off
+  # We need to detect this condition
+  shared_option = set(['ALL'])
+
+  result = getLibToolConfigOption(libmesh_dir, " --config | grep build_libtool_libs | cut -d'=' -f2")
 
   if re.search('yes', result) != None:
     shared_option.add('DYNAMIC')


### PR DESCRIPTION
closes #4154 
- adds `--skip-config-checks` option to skip libMesh configuration checks
- cleanup numerous set() initializations
- factor-out common libtool code check into separate subroutine in util.py
