### PR TITLE
Pass executable explicitly

### DIFF
--- a/python/TestHarness/testers/AnalyzeJacobian.py
+++ b/python/TestHarness/testers/AnalyzeJacobian.py
@@ -33,7 +33,7 @@ class AnalyzeJacobian(Tester):
     if specs['resize_mesh'] :
       mesh_options += ' -r -s %d' % specs['mesh_size']
 
-    command += mesh_options + ' ' + specs['input'] + ' ' + ' '.join(specs['cli_args'])
+    command += mesh_options + ' ' + specs['input'] + ' -e ' + specs['executable'] + ' ' + ' '.join(specs['cli_args'])
 
     return command
 


### PR DESCRIPTION
For some tests the executable detection did not work (if the executable is not up the tree from the current directory). Amends  #4144.
