### PR TITLE
Check whether crack front node exists in CrackFrontData

### DIFF
--- a/modules/solid_mechanics/include/postprocessors/CrackFrontData.h
+++ b/modules/solid_mechanics/include/postprocessors/CrackFrontData.h
@@ -33,7 +33,7 @@ class CrackFrontData : public GeneralPostprocessor
 public:
   CrackFrontData(const std::string & name, InputParameters parameters);
 
-  virtual void initialize() {}
+  virtual void initialize();
   virtual void execute() {}
 
 

--- a/modules/solid_mechanics/include/userobjects/CrackFrontDefinition.h
+++ b/modules/solid_mechanics/include/userobjects/CrackFrontDefinition.h
@@ -35,6 +35,7 @@ public:
   Real getCrackFrontForwardSegmentLength(const unsigned int node_index) const;
   Real getCrackFrontBackwardSegmentLength(const unsigned int node_index) const;
   const RealVectorValue & getCrackDirection(const unsigned int node_index) const;
+  unsigned int getNumCrackFrontNodes() const;
   bool treatAs2D() const {return _treat_as_2d;}
   RealVectorValue rotateToCrackFrontCoords(const RealVectorValue vector, const unsigned int node_index) const;
   ColumnMajorMatrix rotateToCrackFrontCoords(const SymmTensor tensor, const unsigned int node_index) const;

--- a/modules/solid_mechanics/src/postprocessors/CrackFrontData.C
+++ b/modules/solid_mechanics/src/postprocessors/CrackFrontData.C
@@ -41,12 +41,18 @@ CrackFrontData::CrackFrontData(const std::string & name, InputParameters paramet
 {
 }
 
+void
+CrackFrontData::initialize()
+{
+  if (!(_crack_front_node_index < _crack_front_definition->getNumCrackFrontNodes()))
+    mooseError("crack_front_node_index out of range in CrackFrontData");
+
+  _crack_front_node = _crack_front_definition->getCrackFrontNodePtr(_crack_front_node_index);
+}
+
 Real
 CrackFrontData::getValue()
 {
-  if (! _crack_front_node)
-    _crack_front_node = _crack_front_definition->getCrackFrontNodePtr(_crack_front_node_index);
-
   Real value = 0;
 
   if (_crack_front_node->processor_id() == processor_id())

--- a/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -322,7 +322,7 @@ CrackFrontDefinition::orderCrackFrontNodes(std::set<unsigned int> &nodes)
         for (unsigned int j=0; j<curr_line_elem.size(); ++j)
         {
           unsigned int line_elem_node = curr_line_elem[j];
-          if (last_node == end_nodes[0] && line_elem_node == end_nodes[1]) //wrong direction around closed loop
+          if (_closed_loop && (last_node == end_nodes[0] && line_elem_node == end_nodes[1])) //wrong direction around closed loop
             continue;
           if (line_elem_node != last_node &&
               line_elem_node != second_last_node)
@@ -820,10 +820,8 @@ CrackFrontDefinition::calculateCrackFrontDirection(const Node* crack_front_node,
 const Node *
 CrackFrontDefinition::getCrackFrontNodePtr(const unsigned int node_index) const
 {
-  Node * node_ptr = NULL;
-  if (node_index < _ordered_crack_front_nodes.size())
-    node_ptr = _mesh.nodePtr(_ordered_crack_front_nodes[node_index]);
-  return node_ptr;
+  mooseAssert(node_index < _ordered_crack_front_nodes.size(),"node_index out of range");
+  return _mesh.nodePtr(_ordered_crack_front_nodes[node_index]);
 }
 
 const RealVectorValue &
@@ -849,6 +847,12 @@ const RealVectorValue &
 CrackFrontDefinition::getCrackDirection(const unsigned int node_index) const
 {
   return _crack_directions[node_index];
+}
+
+unsigned int
+CrackFrontDefinition::getNumCrackFrontNodes() const
+{
+  return _ordered_crack_front_nodes.size();
 }
 
 RealVectorValue


### PR DESCRIPTION
closes #4161

I had this problem while using CrackFrontData as a separate postprocessor instead of through the DomainIntegralAction, which is not the normal way of using it, but an extra check probably doesn't hurt.

Unrelated to this, I found that a crack with only two crack front nodes (e.g. a one element thick plate) leads to an infinite loop inside CrackFrontDefinition. This adds a fix for that too.

@bwspenc
