### PR TITLE
Fixing compiler detection in test harness

### DIFF
--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -174,12 +174,10 @@ def getPlatforms():
   return platforms
 
 def getCompilers(libmesh_dir):
-  # We'll use the GXX-VERSION string from LIBMESH's Make.common
-  # to figure this out
   # Supported compilers are GCC, INTEL or ALL
   compilers = set(['ALL'])
 
-  mpicxx_cmd = getLibToolConfigOption(libmesh_dir, ' --cxx')
+  mpicxx_cmd = getLibMeshConfig(libmesh_dir, ' --cxx')
 
   # Account for useage of distcc
   if "distcc" in mpicxx_cmd:
@@ -188,7 +186,7 @@ def getCompilers(libmesh_dir):
 
   # If mpi ic on the command, run -show to get the compiler
   if "mpi" in mpicxx_cmd:
-    raw_compiler = runCommand(mpicxx-cmd + " -show")
+    raw_compiler = runCommand(mpicxx_cmd + " -show")
   else:
     raw_compiler = mpicxx_cmd
 
@@ -281,6 +279,28 @@ def getLibMeshConfigOption(libmesh_dir, option):
     exit(1)
 
   return option_set
+
+def getLibMeshConfig(libmesh_dir, command):
+  # Installed location of libmesh config script
+  libmesh_config_installed   = libmesh_dir + '/bin/libmesh-config'
+
+  # Uninstalled location of libmesh libtool script
+  libmesh_config_uninstalled = libmesh_dir + '/libmesh-config'
+
+  # The eventual variable we will use to refer to libmesh's libtool script
+  libmesh_config = ''
+
+  if os.path.exists(libmesh_config_installed):
+    libmesh_config = libmesh_config_installed
+
+  elif os.path.exists(libmesh_config_uninstalled):
+    libmesh_config = libmesh_config_uninstalled
+
+  else:
+    print "Error! Could not find libmesh's config script in any of the usual locations!"
+    exit(1)
+
+  return runCommand(libmesh_config + command).rstrip()
 
 def getLibToolConfigOption(libmesh_dir, command):
   # MOOSE no longer relies on Make.common being present.  This gives us the

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -173,11 +173,34 @@ def getPlatforms():
     platforms.add(raw_uname[0].upper())
   return platforms
 
+def runExecutable(libmesh_dir, location, bin, args):
+  # Installed location of libmesh executable
+  libmesh_installed   = libmesh_dir + '/' + location + '/' + bin
+
+  # Uninstalled location of libmesh executable
+  libmesh_uninstalled = libmesh_dir + '/' + bin
+
+  # The eventual variable we will use to refer to libmesh's executable
+  libmesh_exe = ''
+
+  if os.path.exists(libmesh_installed):
+    libmesh_exe = libmesh_installed
+
+  elif os.path.exists(libmesh_uninstalled):
+    libmesh_exe = libmesh_uninstalled
+
+  else:
+    print "Error! Could not find '" + bin + "' in any of the usual libmesh's locations!"
+    exit(1)
+
+  return runCommand(libmesh_exe + " " + args).rstrip()
+
+
 def getCompilers(libmesh_dir):
   # Supported compilers are GCC, INTEL or ALL
   compilers = set(['ALL'])
 
-  mpicxx_cmd = getLibMeshConfig(libmesh_dir, ' --cxx')
+  mpicxx_cmd = runExecutable(libmesh_dir, "bin", "libmesh-config", "--cxx")
 
   # Account for useage of distcc
   if "distcc" in mpicxx_cmd:
@@ -280,59 +303,12 @@ def getLibMeshConfigOption(libmesh_dir, option):
 
   return option_set
 
-def getLibMeshConfig(libmesh_dir, command):
-  # Installed location of libmesh config script
-  libmesh_config_installed   = libmesh_dir + '/bin/libmesh-config'
-
-  # Uninstalled location of libmesh libtool script
-  libmesh_config_uninstalled = libmesh_dir + '/libmesh-config'
-
-  # The eventual variable we will use to refer to libmesh's libtool script
-  libmesh_config = ''
-
-  if os.path.exists(libmesh_config_installed):
-    libmesh_config = libmesh_config_installed
-
-  elif os.path.exists(libmesh_config_uninstalled):
-    libmesh_config = libmesh_config_uninstalled
-
-  else:
-    print "Error! Could not find libmesh's config script in any of the usual locations!"
-    exit(1)
-
-  return runCommand(libmesh_config + command).rstrip()
-
-def getLibToolConfigOption(libmesh_dir, command):
-  # MOOSE no longer relies on Make.common being present.  This gives us the
-  # potential to work with "uninstalled" libmesh trees, for example.
-
-  # Installed location of libmesh libtool script
-  libmesh_libtool_installed   = libmesh_dir + '/contrib/bin/libtool'
-
-  # Uninstalled location of libmesh libtool script
-  libmesh_libtool_uninstalled = libmesh_dir + '/libtool'
-
-  # The eventual variable we will use to refer to libmesh's libtool script
-  libmesh_libtool = ''
-
-  if os.path.exists(libmesh_libtool_installed):
-    libmesh_libtool = libmesh_libtool_installed
-
-  elif os.path.exists(libmesh_libtool_uninstalled):
-    libmesh_libtool = libmesh_libtool_uninstalled
-
-  else:
-    print "Error! Could not find libmesh's libtool script in any of the usual locations!"
-    exit(1)
-
-  return runCommand(libmesh_libtool + command)
-
 def getSharedOption(libmesh_dir):
   # Some tests may only run properly with shared libraries on/off
   # We need to detect this condition
   shared_option = set(['ALL'])
 
-  result = getLibToolConfigOption(libmesh_dir, " --config | grep build_libtool_libs | cut -d'=' -f2")
+  result = runExecutable(libmesh_dir, "contrib/bin", "libtool", "--config | grep build_libtool_libs | cut -d'=' -f2")
 
   if re.search('yes', result) != None:
     shared_option.add('DYNAMIC')


### PR DESCRIPTION
The test harness was using the 'libtool --cxx' to detect the compiler.
However, this is not a valid option. We have to use
'libmesh-config --cxx' for this.

Closes #4321
