### PR TITLE
Ignore temp_print_trace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@
 *.spl
 *.idx
 traceout*.txt
+temp_print_trace.*
 *.xda
 *.xda.*
 *.xdr


### PR DESCRIPTION
This resolves issue #4238
https://github.com/idaholab/moose/issues/4238
