### PR TITLE
Fix MooseArray::resize(size,default_value)

### DIFF
--- a/framework/include/utils/MooseArray.h
+++ b/framework/include/utils/MooseArray.h
@@ -223,9 +223,7 @@ inline
 void
 MooseArray<T>::resize(const unsigned int size, const T & default_value)
 {
-  if (size <= _allocated_size)
-    _size = size;
-  else
+  if (size > _allocated_size)
   {
     T * new_pointer = new T[size];
     mooseAssert(new_pointer, "Failed to allocate MooseArray memory!");
@@ -236,14 +234,15 @@ MooseArray<T>::resize(const unsigned int size, const T & default_value)
         new_pointer[i] = _data[i];
       delete [] _data;
     }
+
     _data = new_pointer;
-
-    for (unsigned int i=_size; i<size; i++)
-      _data[i] = default_value;
-
     _allocated_size = size;
-    _size = size;
   }
+
+  for (unsigned int i=_size; i<size; i++)
+    _data[i] = default_value;
+
+  _size = size;
 }
 
 template<typename T>


### PR DESCRIPTION
My proposed fix for https://github.com/idaholab/moose/issues/4243
