### PR TITLE
move eigen option

### DIFF
--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -51,7 +51,7 @@ InputParameters validParams<AddVariableAction>()
 
   // Advanced input options
   params.addParam<Real>("scaling", 1.0, "Specifies a scaling factor to apply to this variable");
-  params.addParamNamesToGroup("scaling", "Advanced");
+  params.addParamNamesToGroup("scaling eigen", "Advanced");
 
   return params;
 }


### PR DESCRIPTION
Put the `eigen` option for Variables in the 'Advanced' group

closes #4250
