### PR TITLE
Ignore .json files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ temp_print_trace.*
 *.html
 *.xyz
 *Revision.h
+*.json
 
 # Allow .e files in gold directories (7 levels)
 !/gold/*.e


### PR DESCRIPTION
Ignore files that are generated by the DOFMap output used in the AnalyzeJacobian tester. Closes #4256.
