### PR TITLE
Add valgrind option at Tester level since it is used by checkRunnableBase()

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -23,6 +23,8 @@ class Tester(MooseObject):
 
     params.addParam('cli_args',       [], "Additional arguments to be passed to the test.")
 
+    params.addParam('valgrind', 'NONE', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
+
     # Test Filters
     params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")
     params.addParam('compiler',      ['ALL'], "A list of compilers for which this test is valid on. ('ALL', 'GCC', 'INTEL', 'CLANG')")


### PR DESCRIPTION
closes #4265
