### PR TITLE
Add off-diagonal Jacobian entries for GluedContactConstraint

### DIFF
--- a/modules/contact/include/GluedContactConstraint.h
+++ b/modules/contact/include/GluedContactConstraint.h
@@ -47,6 +47,14 @@ public:
 
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type);
 
+  /**
+   * Compute off-diagonal Jacobian entries
+   * @param type The type of coupling
+   * @param jvar The index of the coupled variable
+   */
+  virtual Real computeQpOffDiagJacobian(Moose::ConstraintJacobianType type,
+                                        unsigned int jvar);
+
   bool shouldApply();
 protected:
   const unsigned int _component;

--- a/modules/contact/src/GluedContactConstraint.C
+++ b/modules/contact/src/GluedContactConstraint.C
@@ -226,3 +226,27 @@ GluedContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType type)
 
   return 0;
 }
+
+Real
+GluedContactConstraint::computeQpOffDiagJacobian(Moose::ConstraintJacobianType type, unsigned int /*jvar*/)
+{
+  Real retVal = 0;
+
+  switch (type)
+  {
+    case Moose::SlaveSlave:
+      break;
+    case Moose::SlaveMaster:
+      break;
+    case Moose::MasterSlave:
+    {
+      double slave_jac = (*_jacobian)(_current_node->dof_number(0, _vars(_component), 0), _connected_dof_indices[_j]);
+      retVal =  slave_jac*_test_master[_i][_qp];
+      break;
+    }
+    case Moose::MasterMaster:
+    break;
+  }
+
+  return retVal;
+}


### PR DESCRIPTION
ref #4720
This addresses only part of the issue -- another commit is in the works for MechanicalContactConstraint
