### PR TITLE
Include ScalarCoupleable in inheritance of Function.

### DIFF
--- a/framework/include/functions/Function.h
+++ b/framework/include/functions/Function.h
@@ -22,6 +22,7 @@
 #include "UserObjectInterface.h"
 #include "Restartable.h"
 #include "MeshChangedInterface.h"
+#include "ScalarCoupleable.h"
 
 // libMesh
 #include "libmesh/vector_value.h"
@@ -43,7 +44,8 @@ class Function :
   public PostprocessorInterface,
   public UserObjectInterface,
   public Restartable,
-  public MeshChangedInterface
+  public MeshChangedInterface,
+  public ScalarCoupleable
 {
 public:
   /**

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -22,7 +22,7 @@ ScalarCoupleable::ScalarCoupleable(InputParameters & parameters) :
 
   SubProblem & problem = *parameters.get<SubProblem *>("_subproblem");
 
-  THREAD_ID tid = parameters.get<THREAD_ID>("_tid");
+  THREAD_ID tid = parameters.have_parameter<THREAD_ID>("_tid") ? parameters.get<THREAD_ID>("_tid") : 0;
 
   // Coupling
   for (std::set<std::string>::const_iterator iter = parameters.coupledVarsBegin();

--- a/framework/src/functions/Function.C
+++ b/framework/src/functions/Function.C
@@ -31,7 +31,8 @@ Function::Function(const std::string & name, InputParameters parameters) :
     PostprocessorInterface(parameters),
     UserObjectInterface(parameters),
     Restartable(name, parameters, "Functions"),
-    MeshChangedInterface(parameters)
+    MeshChangedInterface(parameters),
+    ScalarCoupleable(parameters)
 {
 }
 


### PR DESCRIPTION
 Function now inherits from ScalarCoupleable so that scalars can be used in functions. Refs issues #4267
