### PR TITLE
Checkpoint fix

### DIFF
--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -188,20 +188,11 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
     // Remove material property files
     if (_material_property_storage.hasStatefulProperties() || _bnd_material_property_storage.hasStatefulProperties())
     {
-      ret = remove(delete_files.material.c_str());
+      std::ostringstream oss;
+      oss << delete_files.material << '-' << proc_id;
+      ret = remove(oss.str().c_str());
       if (ret != 0)
-        mooseWarning("Error during the deletion of file '" << delete_files.material << "': " << ret);
-
-      for (THREAD_ID tid = 0; tid < n_threads; tid++)
-      {
-        std::ostringstream oss;
-        oss << delete_files.material << '-' << proc_id;
-        if (n_threads > 1)
-          oss << "-" << tid;
-        ret = remove(oss.str().c_str());
-        if (ret != 0)
-          mooseWarning("Error during the deletion of file '" << oss.str().c_str() << "': " << ret);
-      }
+        mooseWarning("Error during the deletion of file '" << oss.str().c_str() << "': " << ret);
     }
 
     // Remove the restart files (rd)

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -94,15 +94,20 @@ class RunApp(Tester):
     #Set number of threads to be used upper bound
     nthreads = min(nthreads, int(specs['max_threads']))
 
+    caveats = []
     if nthreads > options.nthreads:
-      self.specs['caveats'] = ['min_threads=' + str(nthreads)]
+      caveats.append('min_threads=' + str(nthreads))
     elif nthreads < options.nthreads:
-      self.specs['caveats'] = ['max_threads=' + str(nthreads)]
+      caveats.append('max_threads=' + str(nthreads))
     # TODO: Refactor this caveats business
     if ncpus > default_ncpus:
-      self.specs['caveats'] = ['min_cpus=' + str(ncpus)]
+      caveats.append('min_cpus=' + str(ncpus))
     elif ncpus < default_ncpus:
-      self.specs['caveats'] = ['max_cpus=' + str(ncpus)]
+      caveats.append('max_cpus=' + str(ncpus))
+
+    if len(caveats) > 0:
+      self.specs['caveats'] = caveats
+
     if self.force_mpi or options.parallel or ncpus > 1 or nthreads > 1:
       command = self.mpi_command + ' -n ' + str(ncpus) + ' ' + specs['executable'] + ' --n-threads=' + str(nthreads) + ' ' + specs['input_switch'] + ' ' + specs['input'] + ' ' +  ' '.join(specs['cli_args'])
     elif options.valgrind_mode == specs['valgrind'] or options.valgrind_mode == 'HEAVY' and specs[VALGRIND] == 'NORMAL':

--- a/test/tests/materials/stateful_prop/tests
+++ b/test/tests/materials/stateful_prop/tests
@@ -25,6 +25,15 @@
     exodiff = 'out_older.e'
   [../]
 
+  [./test_older_mpi_threads]
+    type = 'Exodiff'
+    input = 'stateful_prop_test_older.i'
+    exodiff = 'out_older.e'
+    min_parallel = 2
+    min_threads = 2
+    prereq = 'test_older test_older_csv'
+  [../]
+
   [./spatial_test]
     type = 'Exodiff'
     input = 'stateful_prop_spatial_test.i'


### PR DESCRIPTION
- We don't create thread copies of the stateful materials property file so don't attempt to remove thread copies of that file.
- Small printing fix in the TestHarness caveats included with new test.

closes #4268 
