### PR TITLE
Move another tensor product into the tensor classes

### DIFF
--- a/modules/tensor_mechanics/include/auxkernels/RankFourAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/RankFourAux.h
@@ -25,7 +25,8 @@ public:
 protected:
   virtual Real computeValue();
 
-private:  MaterialProperty<ElasticityTensorR4> & _tensor;
+private:
+  const MaterialProperty<ElasticityTensorR4> & _tensor;
   const unsigned int _i;
   const unsigned int _j;
   const unsigned int _k;

--- a/modules/tensor_mechanics/include/materials/FiniteStrainPlasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainPlasticMaterial.h
@@ -36,6 +36,9 @@ protected:
   Real _ftol;
   Real _eptol;
 
+  // outer and mixed product of teh delta function tensors
+  RankFourTensor _deltaOuter, _deltaMixed;
+
   /**
    * Implements the return map
    * @param sig_old  The stress at the previous "time" step
@@ -98,10 +101,6 @@ protected:
    * @param dresid_dsig the required derivative (this is an output variable)
    */
   virtual void getJac(const RankTwoTensor & sig, const RankFourTensor & E_ijkl, Real flow_incr, RankFourTensor & dresid_dsig);
-
-
-  /// returns unity if i==j, otherwise zero
-  Real deltaFunc(unsigned int i, unsigned int j);
 
   /**
    * yield stress as a function of equivalent plastic strain.

--- a/modules/tensor_mechanics/include/utils/RankFourTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankFourTensor.h
@@ -34,18 +34,34 @@ class RankTwoTensor;
 class RankFourTensor
 {
 public:
+  // Select initialization
+  enum InitMethod
+  {
+    initNone,
+    initIdentity,
+    initIdentityFour
+  };
 
   /// Default constructor; fills to zero
   RankFourTensor();
 
+  /// Select specific initialization pattern
+  RankFourTensor(const InitMethod);
+
   /// Copy constructor
-  RankFourTensor(const RankFourTensor & a);
+  RankFourTensor(const RankFourTensor &);
 
   /// Destructor
   ~RankFourTensor() {}
 
+  // Named constructors
+  static RankFourTensor Identity() { return RankFourTensor(initIdentity); }
+  static RankFourTensor IdentityFour() { return RankFourTensor(initIdentityFour); };
+
+//private:
   /// Gets the value for the index specified.  Takes index = 0,1,2
   Real & operator()(unsigned int i, unsigned int j, unsigned int k, unsigned int l);
+public:
 
   /**
    * Gets the value for the index specified.  Takes index = 0,1,2

--- a/modules/tensor_mechanics/include/utils/RankTwoTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoTensor.h
@@ -29,9 +29,18 @@
 class RankTwoTensor
 {
 public:
+  // Select initialization
+  enum InitMethod
+  {
+    initNone,
+    initIdentity
+  };
 
   /// Default constructor; fills to zero
   RankTwoTensor();
+
+  /// Select specific initialization pattern
+  RankTwoTensor(const InitMethod);
 
   /**
    * Constructor that takes in 3 vectors and uses them to create rows
@@ -53,6 +62,9 @@ public:
 
   /// Copy constructor from RealTensorValue
   RankTwoTensor(const TypeTensor<Real> & a);
+
+  // Named constructors
+  static RankTwoTensor Identity() { return RankTwoTensor(initIdentity); }
 
   /// Gets the value for the index specified.  Takes index = 0,1,2
   Real & operator()(unsigned int i, unsigned int j);
@@ -150,6 +162,9 @@ public:
 
   /// returns C_ijkl = a_ij * b_kl
   RankFourTensor outerProduct(const RankTwoTensor & a) const;
+
+  /// returns C_ijkl = a_ik * b_jl
+  RankFourTensor mixedProductIkJl(const RankTwoTensor & a) const;
 
   /// returns A_ij - de_ij*tr(A)/3, where A are the _vals
   RankTwoTensor deviatoric() const;

--- a/modules/tensor_mechanics/src/materials/FiniteStrainRatePlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainRatePlasticMaterial.C
@@ -195,7 +195,7 @@ FiniteStrainRatePlasticMaterial::getJac(const RankTwoTensor & sig, const RankFou
   unsigned i, j, k ,l;
   RankTwoTensor sig_dev, flow_tensor, flow_dirn,fij;
   RankTwoTensor dfi_dft;
-  RankFourTensor dft_dsig, dfd_dft, dfd_dsig, dfi_dsig;
+  RankFourTensor dfd_dft, dfd_dsig, dfi_dsig;
   Real sig_eqv;
   Real f1, f2, f3;
   Real dfi_dseqv;
@@ -208,11 +208,7 @@ FiniteStrainRatePlasticMaterial::getJac(const RankTwoTensor & sig, const RankFou
   flow_dirn = flow_tensor;
   dfi_dseqv = _ref_pe_rate * _dt * _exponent * std::pow(macaulayBracket(sig_eqv / yield_stress - 1.0), _exponent - 1.0) / yield_stress;
 
-  for (i = 0; i < 3; ++i)
-    for (j = 0; j < 3; ++j)
-      for (k = 0; k < 3; ++k)
-        for (l = 0; l < 3; ++l)
-          dfi_dsig(i,j,k,l) = flow_dirn(i,j) * flow_dirn(k,l) * dfi_dseqv; //d_flow_increment/d_sig
+  dfi_dsig = flow_dirn.outerProduct(flow_dirn) * dfi_dseqv; //d_flow_increment/d_sig
 
   f1 = 0.0;
   f2 = 0.0;
@@ -225,14 +221,10 @@ FiniteStrainRatePlasticMaterial::getJac(const RankTwoTensor & sig, const RankFou
     f3 = 9.0 / (4.0 * std::pow(sig_eqv, 3.0));
   }
 
-  for (i = 0; i < 3; ++i)
-    for (j = 0; j < 3; ++j)
-      for (k = 0; k < 3; ++k)
-        for (l = 0; l < 3; ++l)
-          dft_dsig(i,j,k,l) = f1 * deltaFunc(i,k) * deltaFunc(j,l) - f2 * deltaFunc(i,j) * deltaFunc(k,l) - f3 * sig_dev(i,j) * sig_dev(k,l); //d_flow_dirn/d_sig - 2nd part
+  dfd_dsig = f1 * _deltaMixed - f2 * _deltaOuter - f3 * sig_dev.outerProduct(sig_dev); //d_flow_dirn/d_sig - 2nd part
 
-  dfd_dsig = dft_dsig; //d_flow_dirn/d_sig
-  dresid_dsig = E_ijkl.invSymm() + dfd_dsig * flow_incr + dfi_dsig; //Jacobian
+  //Jacobian
+  dresid_dsig = E_ijkl.invSymm() + dfd_dsig * flow_incr + dfi_dsig;
 }
 
 //Macaulay Bracket used in Perzyna Model

--- a/modules/tensor_mechanics/src/utils/RankFourTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankFourTensor.C
@@ -31,6 +31,36 @@ RankFourTensor::RankFourTensor(const RankFourTensor & a)
   *this = a;
 }
 
+RankFourTensor::RankFourTensor(const InitMethod init)
+{
+  switch (init)
+  {
+    case initNone:
+      break;
+
+    case initIdentity:
+      for (unsigned int i = 0; i < N; ++i)
+        for (unsigned int j = 0; j < N; ++j)
+          for (unsigned int k = 0; k < N; ++k)
+            for (unsigned int l = 0; l < N; ++l)
+              _vals[i][j][k][l] = 0.0;
+      for (unsigned int i = 0; i < N; ++i)
+        _vals[i][i][i][i] = 1.0;
+      break;
+
+    case initIdentityFour:
+      for (unsigned int i = 0; i < N; ++i)
+        for (unsigned int j = 0; j < N; ++j)
+          for (unsigned int k = 0; k < N; ++k)
+            for (unsigned int l = 0; l < N; ++l)
+              _vals[i][j][k][l] = (i==k) && (j==l);
+      break;
+
+    default:
+      mooseError("Unknown RankFourTensor initialization pattern.");
+  }
+}
+
 Real &
 RankFourTensor::operator()(unsigned int i, unsigned int j, unsigned int k, unsigned int l)
 {

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -16,6 +16,24 @@ RankTwoTensor::RankTwoTensor()
       _vals[i][j] = 0.0;
 }
 
+RankTwoTensor::RankTwoTensor(const InitMethod init)
+{
+  switch (init)
+  {
+    case initNone:
+      break;
+
+    case initIdentity:
+      for (unsigned int i = 0; i < N; ++i)
+        for (unsigned int j = 0; j < N; ++j)
+          _vals[i][j] = (i==j);
+      break;
+
+    default:
+      mooseError("Unknown RankTwoTensor initialization pattern.");
+  }
+}
+
 RankTwoTensor::RankTwoTensor(const TypeVector<Real> & row1, const TypeVector<Real> & row2, const TypeVector<Real> & row3)
 {
   // Initialize the Tensor matrix from the passed in vectors
@@ -362,6 +380,20 @@ RankTwoTensor::outerProduct(const RankTwoTensor & a) const
   return result;
 }
 
+RankFourTensor
+RankTwoTensor::mixedProductIkJl(const RankTwoTensor & a) const
+{
+  RankFourTensor result;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        for (unsigned int l = 0; l < N; ++l)
+          result(i,j,k,l) = _vals[i][k] * a(j,l);
+
+  return result;
+}
+
 RankTwoTensor
 RankTwoTensor::deviatoric() const
 {
@@ -401,12 +433,10 @@ RankTwoTensor::d2secondInvariant() const
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
-          result(i, j, k, l) = 0.5*(i==k)*(j==l) + 0.5*(i==l)*(j==k) - (1.0/3.0)*(i==j)*(k==l);
+          result(i,j,k,l) = 0.5*(i==k)*(j==l) + 0.5*(i==l)*(j==k) - (1.0/3.0)*(i==j)*(k==l);
 
   return result;
 }
-
-
 
 Real
 RankTwoTensor::trace() const


### PR DESCRIPTION
Depends on #4289, adresses #4183. Adds some named constructors to R2T and R4T, moves a mixed product into the tensor class (and out of the crystal plasticity classes).

The next steps will involve adding a _nosymmetry_ base class to R2T and R4T. So I'd prefer to get this stuff merged first.
