### PR TITLE
Avoid shadowing members

### DIFF
--- a/modules/tensor_mechanics/include/materials/CosseratLinearElasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/CosseratLinearElasticMaterial.h
@@ -23,15 +23,9 @@ protected:
   virtual void computeQpElasticityTensor();
 
   MaterialProperty<RankTwoTensor> & _eigenstrain;
-  MaterialProperty<ElasticityTensorR4> & _delasticity_tensor_dc;
-  MaterialProperty<ElasticityTensorR4> & _d2elasticity_tensor_dc2;
-  MaterialProperty<RankTwoTensor> & _deigenstrain_dc;
-  MaterialProperty<RankTwoTensor> & _d2eigenstrain_dc2;
-
   MaterialProperty<RankTwoTensor> & _symmetric_strain;
   MaterialProperty<RankTwoTensor> & _antisymmetric_strain;
   MaterialProperty<RankTwoTensor> & _curvature;
-
 
   MaterialProperty<RankTwoTensor> & _symmetric_stress;
   MaterialProperty<RankTwoTensor> & _antisymmetric_stress;

--- a/modules/tensor_mechanics/include/materials/EigenStrainBaseMaterial.h
+++ b/modules/tensor_mechanics/include/materials/EigenStrainBaseMaterial.h
@@ -22,6 +22,11 @@ protected:
   MaterialProperty<RankTwoTensor> & _eigenstrain;
   MaterialProperty<RankTwoTensor> & _deigenstrain_dc;
   MaterialProperty<RankTwoTensor> & _d2eigenstrain_dc2;
+
+  MaterialProperty<ElasticityTensorR4> & _delasticity_tensor_dc;
+  MaterialProperty<ElasticityTensorR4> & _d2elasticity_tensor_dc2;
+
+  VariableValue & _c;
 };
 
 #endif //EIGENSTRAINBASEMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
@@ -284,7 +284,6 @@ protected:
   RankTwoTensor _pk2_tmp;
   Real _accslip_tmp, _accslip_tmp_old;
   std::vector<Real> _gss_tmp;
-
 };
 
 #endif //FINITESTRAINCRYSTALPLASTICITY_H

--- a/modules/tensor_mechanics/include/materials/FiniteStrainMaterial.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainMaterial.h
@@ -33,7 +33,8 @@ protected:
   MaterialProperty<RankTwoTensor> & _elastic_strain_old;
   MaterialProperty<RankTwoTensor> & _stress_old;
   MaterialProperty<RankTwoTensor> & _rotation_increment;
-  MaterialProperty<RankTwoTensor> & _dfgrd;
+
+  MaterialProperty<RankTwoTensor> & _deformation_gradient;
 };
 
 #endif //FINITESTRAINMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/LinearElasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/LinearElasticMaterial.h
@@ -21,14 +21,12 @@ protected:
   virtual void computeQpStress();
   virtual RankTwoTensor computeStressFreeStrain();
 
-  MaterialProperty<ElasticityTensorR4> & _delasticity_tensor_dc;
-  MaterialProperty<ElasticityTensorR4> & _d2elasticity_tensor_dc2;
-
 private:
   VariableValue & _T;
 
-  Real _thermal_expansion_coeff;
   const Real _T0;
+  Real _thermal_expansion_coeff;
+
   std::vector<Real> _applied_strain_vector;
   RankTwoTensor _applied_strain_tensor;
 };

--- a/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
+++ b/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
@@ -48,33 +48,21 @@ protected:
   MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
   MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
 
-  Real _euler_angle_1;
-  Real _euler_angle_2;
-  Real _euler_angle_3;
+  RealVectorValue _Euler_angles;
 
-  // vectors to get the input values
+  /// vectors to get the input values
   std::vector<Real> _Cijkl_vector;
 
   /// Individual material information
   ElasticityTensorR4 _Cijkl;
 
-  // MaterialProperty<RankTwoTensor> & _d_stress_dT;
   RankTwoTensor _strain_increment;
 
-  RealVectorValue _Euler_angles;
-
   /// Current deformation gradient
-  RankTwoTensor _dfgrd;
-
-  bool _has_T;
-  VariableValue * _T; //pointer rather than reference
-
-  /// determines the translation from C_ijkl to the Rank-4 tensor
-  RankFourTensor::FillMethod _fill_method;
+  //RankTwoTensor _dfgrd;
 
   /// initial stress components
   std::vector<Function *> _initial_stress;
-
 };
 
 #endif //TENSORMECHANICSMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
+++ b/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
@@ -50,16 +50,10 @@ protected:
 
   RealVectorValue _Euler_angles;
 
-  /// vectors to get the input values
-  std::vector<Real> _Cijkl_vector;
-
   /// Individual material information
   ElasticityTensorR4 _Cijkl;
 
   RankTwoTensor _strain_increment;
-
-  /// Current deformation gradient
-  //RankTwoTensor _dfgrd;
 
   /// initial stress components
   std::vector<Function *> _initial_stress;

--- a/modules/tensor_mechanics/include/utils/ElasticityTensorR4.h
+++ b/modules/tensor_mechanics/include/utils/ElasticityTensorR4.h
@@ -27,6 +27,9 @@ public:
   /// Copy constructor for RankFourTensor
   ElasticityTensorR4(const RankFourTensor &a);
 
+  // Fill from vector
+  ElasticityTensorR4(const std::vector<Real> & input, FillMethod fill_method) : RankFourTensor(input, fill_method) {}
+
   /**
    * This is used for the standard kernel stress_ij*d(test)/dx_j, when varied wrt u_k
    * Jacobian entry: d(stress_ij*d(test)/dx_j)/du_k = d(C_ijmn*du_m/dx_n*dtest/dx_j)/du_k

--- a/modules/tensor_mechanics/include/utils/RankFourTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankFourTensor.h
@@ -42,11 +42,30 @@ public:
     initIdentityFour
   };
 
+  /**
+   * To fill up the 81 entries in the 4th-order tensor, fillFromInputVector
+   * is called with one of the following fill_methods.
+   * See the fill*FromInputVector functions for more details
+   */
+  enum FillMethod
+  {
+    antisymmetric,
+    symmetric9,
+    symmetric21,
+    general_isotropic,
+    symmetric_isotropic,
+    antisymmetric_isotropic,
+    general
+  };
+
   /// Default constructor; fills to zero
   RankFourTensor();
 
   /// Select specific initialization pattern
   RankFourTensor(const InitMethod);
+
+  /// Fill from vector
+  RankFourTensor(const std::vector<Real> &, FillMethod);
 
   /// Copy constructor
   RankFourTensor(const RankFourTensor &);
@@ -149,22 +168,6 @@ public:
 
   /// Static method for use in validParams for getting the "fill_method"
   static MooseEnum fillMethodEnum();
-
-  /**
-   * To fill up the 81 entries in the 4th-order tensor, fillFromInputVector
-   * is called with one of the following fill_methods.
-   * See the fill*FromInputVector functions for more details
-   */
-  enum FillMethod
-  {
-    antisymmetric,
-    symmetric9,
-    symmetric21,
-    general_isotropic,
-    symmetric_isotropic,
-    antisymmetric_isotropic,
-    general
-  };
 
   /**
    * fillFromInputVector takes some number of inputs to fill

--- a/modules/tensor_mechanics/src/materials/CosseratLinearElasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/CosseratLinearElasticMaterial.C
@@ -12,20 +12,17 @@ template<>
 InputParameters validParams<CosseratLinearElasticMaterial>()
 {
   InputParameters params = validParams<TensorMechanicsMaterial>();
-  params.addParam<Real>("thermal_expansion_coeff",0,"Thermal expansion coefficient in 1/K");
-  params.addParam<Real>("T0",300,"Reference temperature for thermal expansion in K");
+  params.addParam<Real>("thermal_expansion_coeff", 0, "Thermal expansion coefficient in 1/K");
+  params.addParam<Real>("T0", 300, "Reference temperature for thermal expansion in K");
   params.addCoupledVar("T", 300, "Temperature in Kelvin");
   params.addCoupledVar("wc_x", 0, "Cosserat rotation around x axis");
   params.addCoupledVar("wc_y", 0, "Cosserat rotation around y axis");
   params.addCoupledVar("wc_z", 0, "Cosserat rotation around z axis");
-
   params.addRequiredParam<std::vector<Real> >("B_ijkl", "Flexural bending rigidity tensor.  Should have 9 entries.");
-
   params.addParam<std::vector<Real> >("applied_strain_vector","Applied strain: e11, e22, e33, e23, e13, e12");
 
   MooseEnum fm = RankFourTensor::fillMethodEnum();
   fm = "antisymmetric_isotropic";
-
   params.addParam<MooseEnum>("fill_method_bending", fm, "The fill method for the 'bending' tensor.");
 
   return params;
@@ -35,10 +32,6 @@ CosseratLinearElasticMaterial::CosseratLinearElasticMaterial(const std::string &
                                                              InputParameters parameters) :
     TensorMechanicsMaterial(name, parameters),
     _eigenstrain(declareProperty<RankTwoTensor>("eigenstrain")),
-    _delasticity_tensor_dc(declareProperty<ElasticityTensorR4>("delasticity_tensor_dc")),
-    _d2elasticity_tensor_dc2(declareProperty<ElasticityTensorR4>("d2elasticity_tensor_dc2")),
-    _deigenstrain_dc(declareProperty<RankTwoTensor>("deigenstrain_dc")),
-    _d2eigenstrain_dc2(declareProperty<RankTwoTensor>("d2eigenstrain_dc2")),
     _symmetric_strain(declareProperty<RankTwoTensor>("symmetric_strain")),
     _antisymmetric_strain(declareProperty<RankTwoTensor>("antisymmetric_strain")),
     _curvature(declareProperty<RankTwoTensor>("curvature")),
@@ -74,7 +67,7 @@ void
 CosseratLinearElasticMaterial::computeQpStrain()
 {
   //strain = (grad_disp + grad_disp^T)/2
-  RankTwoTensor grad_tensor(_grad_disp_x[_qp],_grad_disp_y[_qp],_grad_disp_z[_qp]);
+  RankTwoTensor grad_tensor(_grad_disp_x[_qp], _grad_disp_y[_qp], _grad_disp_z[_qp]);
   RealVectorValue wc_vector(_wc_x[_qp], _wc_y[_qp], _wc_z[_qp]);
 
   for (unsigned i = 0; i < LIBMESH_DIM; ++i)
@@ -82,11 +75,11 @@ CosseratLinearElasticMaterial::computeQpStrain()
       for (unsigned k = 0; k < LIBMESH_DIM; ++k)
         grad_tensor(i, j) += PermutationTensor::eps(i, j, k) * wc_vector(k);
 
-  _symmetric_strain[_qp] = (grad_tensor + grad_tensor.transpose())/2.0;
-  _antisymmetric_strain[_qp] = (grad_tensor - grad_tensor.transpose())/2.0;
+  _symmetric_strain[_qp] = (grad_tensor + grad_tensor.transpose()) / 2.0;
+  _antisymmetric_strain[_qp] = (grad_tensor - grad_tensor.transpose()) / 2.0;
   _elastic_strain[_qp] = grad_tensor;
 
-  RankTwoTensor wc_grad_tensor(_grad_wc_x[_qp],_grad_wc_y[_qp],_grad_wc_z[_qp]);
+  RankTwoTensor wc_grad_tensor(_grad_wc_x[_qp], _grad_wc_y[_qp], _grad_wc_z[_qp]);
   _curvature[_qp] = wc_grad_tensor;
 }
 
@@ -99,10 +92,10 @@ CosseratLinearElasticMaterial::computeQpStress()
   _elastic_strain[_qp] += stress_free_strain;
 
   // stress = C * e
-  _stress[_qp] = _elasticity_tensor[_qp]*_elastic_strain[_qp];
+  _stress[_qp] = _elasticity_tensor[_qp] * _elastic_strain[_qp];
 
-  _symmetric_stress[_qp] = (_stress[_qp] + _stress[_qp].transpose())/2.0;
-  _antisymmetric_stress[_qp] = (_stress[_qp] - _stress[_qp].transpose())/2.0;
+  _symmetric_stress[_qp] = (_stress[_qp] + _stress[_qp].transpose()) / 2.0;
+  _antisymmetric_stress[_qp] = (_stress[_qp] - _stress[_qp].transpose()) / 2.0;
 
   _stress_couple[_qp] = _elastic_flexural_rigidity_tensor[_qp] * _curvature[_qp];
 }
@@ -112,7 +105,7 @@ CosseratLinearElasticMaterial::computeStressFreeStrain()
 {
   //Apply thermal expansion
   RankTwoTensor stress_free_strain;
-  stress_free_strain.addIa(-_thermal_expansion_coeff*(_T[_qp] - _T0));
+  stress_free_strain.addIa(-_thermal_expansion_coeff * (_T[_qp] - _T0));
 
   //Apply uniform applied strain
   if (_applied_strain_vector.size() == 6)

--- a/modules/tensor_mechanics/src/materials/EigenStrainBaseMaterial.C
+++ b/modules/tensor_mechanics/src/materials/EigenStrainBaseMaterial.C
@@ -4,6 +4,7 @@ template<>
 InputParameters validParams<EigenStrainBaseMaterial>()
 {
   InputParameters params = validParams<LinearElasticMaterial>();
+  params.addRequiredCoupledVar("c", "Concentration");
   return params;
 }
 
@@ -12,7 +13,10 @@ EigenStrainBaseMaterial::EigenStrainBaseMaterial(const std::string & name,
     LinearElasticMaterial(name, parameters),
     _eigenstrain(declareProperty<RankTwoTensor>("eigenstrain")),
     _deigenstrain_dc(declareProperty<RankTwoTensor>("deigenstrain_dc")),
-    _d2eigenstrain_dc2(declareProperty<RankTwoTensor>("d2eigenstrain_dc2"))
+    _d2eigenstrain_dc2(declareProperty<RankTwoTensor>("d2eigenstrain_dc2")),
+    _delasticity_tensor_dc(declareProperty<ElasticityTensorR4>("delasticity_tensor_dc")),
+    _d2elasticity_tensor_dc2(declareProperty<ElasticityTensorR4>("d2elasticity_tensor_dc2")),
+    _c(coupledValue("c"))
 {
 }
 
@@ -26,4 +30,3 @@ RankTwoTensor EigenStrainBaseMaterial::computeStressFreeStrain()
 
   return stress_free_strain;
 }
-

--- a/modules/tensor_mechanics/src/materials/FiniteStrainMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainMaterial.C
@@ -18,7 +18,7 @@ FiniteStrainMaterial::FiniteStrainMaterial(const std::string & name,
     _elastic_strain_old(declarePropertyOld<RankTwoTensor>("elastic_strain")),
     _stress_old(declarePropertyOld<RankTwoTensor>("stress")),
     _rotation_increment(declareProperty<RankTwoTensor>("rotation_increment")),
-    _dfgrd(declareProperty<RankTwoTensor>("deformation gradient"))
+    _deformation_gradient(declareProperty<RankTwoTensor>("deformation gradient"))
 {
 }
 
@@ -50,8 +50,8 @@ FiniteStrainMaterial::computeStrain()
     RankTwoTensor A(_grad_disp_x[_qp], _grad_disp_y[_qp], _grad_disp_z[_qp]); //Deformation gradient
     RankTwoTensor Fbar(_grad_disp_x_old[_qp], _grad_disp_y_old[_qp], _grad_disp_z_old[_qp]); //Old Deformation gradient
 
-    _dfgrd[_qp] = A;
-    _dfgrd[_qp].addIa(1.0);//Gauss point deformation gradient
+    _deformation_gradient[_qp] = A;
+    _deformation_gradient[_qp].addIa(1.0);//Gauss point deformation gradient
 
     A -= Fbar; //A = gradU - gradUold
 
@@ -65,7 +65,7 @@ FiniteStrainMaterial::computeStrain()
     ave_Fhat += Fhat[_qp] * _JxW[_qp];
     volume += _JxW[_qp];
 
-    ave_dfgrd_det += _dfgrd[_qp].det() * _JxW[_qp]; //Average deformation gradient
+    ave_dfgrd_det += _deformation_gradient[_qp].det() * _JxW[_qp]; //Average deformation gradient
   }
 
   ave_Fhat /= volume; //This is needed for volumetric locking correction
@@ -78,8 +78,8 @@ FiniteStrainMaterial::computeStrain()
 
     computeQpStrain(Fhat[_qp]);
 
-    factor = std::pow(ave_dfgrd_det / _dfgrd[_qp].det(), 1.0/3.0);//Volumetric locking correction
-    _dfgrd[_qp] *= factor;//Volumetric locking correction
+    factor = std::pow(ave_dfgrd_det / _deformation_gradient[_qp].det(), 1.0/3.0);//Volumetric locking correction
+    _deformation_gradient[_qp] *= factor;//Volumetric locking correction
   }
 }
 

--- a/modules/tensor_mechanics/src/materials/LinearElasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/LinearElasticMaterial.C
@@ -42,15 +42,6 @@ LinearElasticMaterial::computeQpStrain()
   //strain = (grad_disp + grad_disp^T)/2
   RankTwoTensor grad_tensor(_grad_disp_x[_qp],_grad_disp_y[_qp],_grad_disp_z[_qp]);
 
-  if (_t_step > 1000000)
-  {
-    RankTwoTensor test = grad_tensor;
-    test.addIa(1.0);
-
-    RankTwoTensor eye = test*test.inverse();
-    eye.print();
-  }
-
   _elastic_strain[_qp] = (grad_tensor + grad_tensor.transpose())/2.0;
   _total_strain[_qp] = _elastic_strain[_qp];
 }

--- a/modules/tensor_mechanics/src/materials/LinearElasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/LinearElasticMaterial.C
@@ -22,11 +22,9 @@ InputParameters validParams<LinearElasticMaterial>()
 LinearElasticMaterial::LinearElasticMaterial(const std::string & name,
                                              InputParameters parameters) :
     TensorMechanicsMaterial(name, parameters),
-    _delasticity_tensor_dc(declareProperty<ElasticityTensorR4>("delasticity_tensor_dc")),
-    _d2elasticity_tensor_dc2(declareProperty<ElasticityTensorR4>("d2elasticity_tensor_dc2")),
     _T(coupledValue("T")),
-    _thermal_expansion_coeff(getParam<Real>("thermal_expansion_coeff")),
     _T0(getParam<Real>("T0")),
+    _thermal_expansion_coeff(getParam<Real>("thermal_expansion_coeff")),
     _applied_strain_vector(getParam<std::vector<Real> >("applied_strain_vector"))
 {
   //Initialize applied strain tensor from input vector
@@ -40,9 +38,9 @@ void
 LinearElasticMaterial::computeQpStrain()
 {
   //strain = (grad_disp + grad_disp^T)/2
-  RankTwoTensor grad_tensor(_grad_disp_x[_qp],_grad_disp_y[_qp],_grad_disp_z[_qp]);
+  RankTwoTensor grad_tensor(_grad_disp_x[_qp], _grad_disp_y[_qp], _grad_disp_z[_qp]);
 
-  _elastic_strain[_qp] = (grad_tensor + grad_tensor.transpose())/2.0;
+  _elastic_strain[_qp] = (grad_tensor + grad_tensor.transpose()) / 2.0;
   _total_strain[_qp] = _elastic_strain[_qp];
 }
 
@@ -56,7 +54,7 @@ LinearElasticMaterial::computeQpStress()
   _total_strain[_qp] = _elastic_strain[_qp];
 
   // stress = C * e
-  _stress[_qp] = _elasticity_tensor[_qp]*_elastic_strain[_qp];
+  _stress[_qp] = _elasticity_tensor[_qp] * _elastic_strain[_qp];
 }
 
 RankTwoTensor
@@ -64,7 +62,7 @@ LinearElasticMaterial::computeStressFreeStrain()
 {
   //Apply thermal expansion
   RankTwoTensor stress_free_strain;
-  stress_free_strain.addIa(-_thermal_expansion_coeff*(_T[_qp] - _T0));
+  stress_free_strain.addIa(-_thermal_expansion_coeff * (_T[_qp] - _T0));
 
   //Apply uniform applied strain
   if (_applied_strain_vector.size() == 6)

--- a/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
@@ -33,23 +33,20 @@ TensorMechanicsMaterial::TensorMechanicsMaterial(const std::string & name,
     _elastic_strain(declareProperty<RankTwoTensor>("elastic_strain")),
     _elasticity_tensor(declareProperty<ElasticityTensorR4>("elasticity_tensor")),
     _Jacobian_mult(declareProperty<ElasticityTensorR4>("Jacobian_mult")),
-    // _d_stress_dT(declareProperty<RankTwoTensor>("d_stress_dT")),
-    _euler_angle_1(getParam<Real>("euler_angle_1")),
-    _euler_angle_2(getParam<Real>("euler_angle_2")),
-    _euler_angle_3(getParam<Real>("euler_angle_3")),
+    _Euler_angles(getParam<Real>("euler_angle_1"),
+                  getParam<Real>("euler_angle_2"),
+                  getParam<Real>("euler_angle_3")),
     _Cijkl_vector(getParam<std::vector<Real> >("C_ijkl")),
-    _Cijkl(),
-    _Euler_angles(_euler_angle_1, _euler_angle_2, _euler_angle_3),
-    _has_T(isCoupled("temperature")),
-    _T(_has_T ? &coupledValue("temperature") : NULL),
-    _fill_method((RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method"))
+    _Cijkl()
 {
-  _Cijkl.fillFromInputVector(_Cijkl_vector, _fill_method);
+  _Cijkl.fillFromInputVector(_Cijkl_vector, (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method"));
 
-  const std::vector<FunctionName> & fcn_names( getParam<std::vector<FunctionName> >("initial_stress") );
+  const std::vector<FunctionName> & fcn_names(getParam<std::vector<FunctionName> >("initial_stress"));
   const unsigned num = fcn_names.size();
+
   if (!(num == 0 || num == 3*3))
     mooseError("Either zero or " << 3*3 << " initial stress functions must be provided to TensorMechanicsMaterial.  You supplied " << num << "\n");
+
   _initial_stress.resize(num);
   for (unsigned i = 0 ; i < num ; ++i)
     _initial_stress[i] = &getFunctionByName(fcn_names[i]);

--- a/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
@@ -60,14 +60,13 @@ TensorMechanicsMaterial::initQpStatefulProperties()
 
   _total_strain[_qp].zero();
   _elastic_strain[_qp].zero();
-
 }
-
 
 void
 TensorMechanicsMaterial::computeProperties()
 {
   computeStrain();
+
   for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
   {
     computeQpElasticityTensor();

--- a/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
@@ -36,11 +36,8 @@ TensorMechanicsMaterial::TensorMechanicsMaterial(const std::string & name,
     _Euler_angles(getParam<Real>("euler_angle_1"),
                   getParam<Real>("euler_angle_2"),
                   getParam<Real>("euler_angle_3")),
-    _Cijkl_vector(getParam<std::vector<Real> >("C_ijkl")),
-    _Cijkl()
+    _Cijkl(getParam<std::vector<Real> >("C_ijkl"), (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method"))
 {
-  _Cijkl.fillFromInputVector(_Cijkl_vector, (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method"));
-
   const std::vector<FunctionName> & fcn_names(getParam<std::vector<FunctionName> >("initial_stress"));
   const unsigned num = fcn_names.size();
 

--- a/modules/tensor_mechanics/src/utils/RankFourTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankFourTensor.C
@@ -61,6 +61,11 @@ RankFourTensor::RankFourTensor(const InitMethod init)
   }
 }
 
+RankFourTensor::RankFourTensor(const std::vector<Real> & input, FillMethod fill_method)
+{
+  fillFromInputVector(input, fill_method);
+}
+
 Real &
 RankFourTensor::operator()(unsigned int i, unsigned int j, unsigned int k, unsigned int l)
 {


### PR DESCRIPTION
 Fixes the shadowed _dfgrd property and gets rid of a redundant copy of the Euler angles. Addresses #4300.
