### PR TITLE
Change DerivativeMaterialInterface 

### DIFF
--- a/framework/include/materials/DerivativeMaterialInterface.h
+++ b/framework/include/materials/DerivativeMaterialInterface.h
@@ -53,13 +53,26 @@ public:
   MaterialProperty<U> & getDefaultMaterialProperty(const std::string & name);
 
   template<typename U>
-  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1);
+  MaterialProperty<U> & declarePropertyDerivative(const std::string &base, const std::string &c1);
+  template<typename U>
+  MaterialProperty<U> & declarePropertyDerivative(const std::string &base, const std::string &c1, const std::string &c2);
+  template<typename U>
+  MaterialProperty<U> & declarePropertyDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3);
 
   template<typename U>
-  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1, const std::string &c2);
-
+  MaterialProperty<U> & getMaterialPropertyDerivative(const std::string &base, const std::string &c1);
   template<typename U>
-  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3);
+  MaterialProperty<U> & getMaterialPropertyDerivative(const std::string &base, const std::string &c1, const std::string &c2);
+  template<typename U>
+  MaterialProperty<U> & getMaterialPropertyDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3);
+
+  // deprecated methods
+  template<typename U>
+  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1) __attribute__ ((deprecated));
+  template<typename U>
+  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1, const std::string &c2) __attribute__ ((deprecated));
+  template<typename U>
+  MaterialProperty<U> & getDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3) __attribute__ ((deprecated));
 
 private:
   const std::string _constant_zero;
@@ -140,12 +153,62 @@ DerivativeMaterialInterface<T>::getDefaultMaterialProperty(const std::string & n
   }
 }
 
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::declarePropertyDerivative(const std::string &base, const std::string &c1)
+{
+  return this->template declareProperty<U>(propertyNameFirst(base, c1));
+}
 
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::declarePropertyDerivative(const std::string &base, const std::string &c1, const std::string &c2)
+{
+  return this->template declareProperty<U>(propertyNameSecond(base, c1, c2));
+}
+
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::declarePropertyDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3)
+{
+  return this->template declareProperty<U>(propertyNameThird(base, c1, c2, c3));
+}
+
+
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getMaterialPropertyDerivative(const std::string &base, const std::string &c1)
+{
+  return getDefaultMaterialProperty<U>(propertyNameFirst(base, c1));
+}
+
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getMaterialPropertyDerivative(const std::string &base, const std::string &c1, const std::string &c2)
+{
+  return getDefaultMaterialProperty<U>(propertyNameSecond(base, c1, c2));
+}
+
+template<class T>
+template<typename U>
+MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getMaterialPropertyDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3)
+{
+  return getDefaultMaterialProperty<U>(propertyNameThird(base, c1, c2, c3));
+}
+
+// deprecated
 template<class T>
 template<typename U>
 MaterialProperty<U> &
 DerivativeMaterialInterface<T>::getDerivative(const std::string &base, const std::string &c1)
 {
+  mooseDeprecated("getDerivative is being replaced by getMaterialPropertyDerivative (same arguments)");
   return getDefaultMaterialProperty<U>(propertyNameFirst(base, c1));
 }
 
@@ -154,6 +217,7 @@ template<typename U>
 MaterialProperty<U> &
 DerivativeMaterialInterface<T>::getDerivative(const std::string &base, const std::string &c1, const std::string &c2)
 {
+  mooseDeprecated("getDerivative is being replaced by getMaterialPropertyDerivative (same arguments)");
   return getDefaultMaterialProperty<U>(propertyNameSecond(base, c1, c2));
 }
 
@@ -162,6 +226,7 @@ template<typename U>
 MaterialProperty<U> &
 DerivativeMaterialInterface<T>::getDerivative(const std::string &base, const std::string &c1, const std::string &c2, const std::string &c3)
 {
+  mooseDeprecated("getDerivative is being replaced by getMaterialPropertyDerivative (same arguments)");
   return getDefaultMaterialProperty<U>(propertyNameThird(base, c1, c2, c3));
 }
 

--- a/modules/phase_field/src/kernels/ACParsed.C
+++ b/modules/phase_field/src/kernels/ACParsed.C
@@ -10,8 +10,8 @@ InputParameters validParams<ACParsed>()
 
 ACParsed::ACParsed(const std::string & name, InputParameters parameters) :
     DerivativeKernelInterface<ACBulk>(name, parameters),
-    _dFdEta(getDerivative<Real>(_F_name, _var.name())),
-    _d2FdEta2(getDerivative<Real>(_F_name, _var.name(), _var.name()))
+    _dFdEta(getMaterialPropertyDerivative<Real>(_F_name, _var.name())),
+    _d2FdEta2(getMaterialPropertyDerivative<Real>(_F_name, _var.name(), _var.name()))
 {
 }
 

--- a/modules/phase_field/src/kernels/CHParsed.C
+++ b/modules/phase_field/src/kernels/CHParsed.C
@@ -17,15 +17,15 @@ CHParsed::CHParsed(const std::string & name, InputParameters parameters) :
   _grad_vars.resize(_nvar+1);
 
   // derivatives w.r.t. and gradients of the kernel variable
-  _second_derivatives[0] = &getDerivative<Real>(_F_name, _var.name(), _var.name());
-  _third_derivatives[0]  = &getDerivative<Real>(_F_name, _var.name(), _var.name(), _var.name());
+  _second_derivatives[0] = &getMaterialPropertyDerivative<Real>(_F_name, _var.name(), _var.name());
+  _third_derivatives[0]  = &getMaterialPropertyDerivative<Real>(_F_name, _var.name(), _var.name(), _var.name());
   _grad_vars[0] = &(_grad_u);
 
   // Iterate over all coupled variables
   for (unsigned int i = 0; i < _nvar; ++i)
   {
-    _second_derivatives[i+1] = &getDerivative<Real>(_F_name, _var.name(), _coupled_moose_vars[i]->name());
-    _third_derivatives[i+1]  = &getDerivative<Real>(_F_name, _var.name(), _var.name(), _coupled_moose_vars[i]->name());
+    _second_derivatives[i+1] = &getMaterialPropertyDerivative<Real>(_F_name, _var.name(), _coupled_moose_vars[i]->name());
+    _third_derivatives[i+1]  = &getMaterialPropertyDerivative<Real>(_F_name, _var.name(), _var.name(), _coupled_moose_vars[i]->name());
     _grad_vars[i+1] = &(_coupled_moose_vars[i]->gradSln());
   }
 }

--- a/modules/phase_field/src/kernels/SplitCHParsed.C
+++ b/modules/phase_field/src/kernels/SplitCHParsed.C
@@ -9,8 +9,8 @@ InputParameters validParams<SplitCHParsed>()
 
 SplitCHParsed::SplitCHParsed(const std::string & name, InputParameters parameters) :
     DerivativeKernelInterface<SplitCHCRes>(name, parameters),
-    _dFdc(getDerivative<Real>(_F_name, _var.name())),
-    _d2Fdc2(getDerivative<Real>(_F_name, _var.name(), _var.name()))
+    _dFdc(getMaterialPropertyDerivative<Real>(_F_name, _var.name())),
+    _d2Fdc2(getMaterialPropertyDerivative<Real>(_F_name, _var.name(), _var.name()))
 {
 }
 

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -54,16 +54,13 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
     _args[i] = &coupledValue("args", i);
 
     // first derivatives
-    _prop_dF[i] = &declareProperty<Real>(propertyNameFirst(_F_name, _arg_names[i]));
+    _prop_dF[i] = &declarePropertyDerivative<Real>(_F_name, _arg_names[i]);
 
     // second derivatives
     for (j = i; j < _nargs; ++j)
     {
       _prop_d2F[i][j] =
-      _prop_d2F[j][i] =
-        &declareProperty<Real>(
-          propertyNameSecond(_F_name, _arg_names[i], _arg_names[j])
-        );
+      _prop_d2F[j][i] = &declarePropertyDerivative<Real>(_F_name, _arg_names[i], _arg_names[j]);
 
       // third derivatives
       if (_third_derivatives)
@@ -77,10 +74,7 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
           _prop_d3F[j][k][i] =
           _prop_d3F[k][j][i] =
           _prop_d3F[j][i][k] =
-          _prop_d3F[i][k][j] =
-            &declareProperty<Real>(
-              propertyNameThird(_F_name, _arg_names[i], _arg_names[j], _arg_names[k])
-            );
+          _prop_d3F[i][k][j] = &declarePropertyDerivative<Real>(_F_name, _arg_names[i], _arg_names[j], _arg_names[k]);
         }
       }
     }

--- a/test/src/materials/DerivativeMaterialInterfaceTestClient.C
+++ b/test/src/materials/DerivativeMaterialInterfaceTestClient.C
@@ -10,12 +10,12 @@ InputParameters validParams<DerivativeMaterialInterfaceTestClient>()
 DerivativeMaterialInterfaceTestClient::DerivativeMaterialInterfaceTestClient(const std::string & name,
                                                                                  InputParameters parameters) :
     DerivativeMaterialInterface<Material>(name, parameters),
-    _prop0(getDerivative<Real>("prop","c")), // fetch non-existing derivative
-    _prop1(getDerivative<Real>("prop","a")),
-    _prop2(getDerivative<Real>("prop","b")),
-    _prop3(getDerivative<Real>("prop","a", "b")), // fetch alphabetically sorted (but declared unsorted)
-    _prop4(getDerivative<Real>("prop","a", "c")),
-    _prop5(getDerivative<Real>("prop","c", "b", "a")) // fetch unsorted (declared unsorted, but differently unsorted)
+    _prop0(getMaterialPropertyDerivative<Real>("prop","c")), // fetch non-existing derivative
+    _prop1(getMaterialPropertyDerivative<Real>("prop","a")),
+    _prop2(getMaterialPropertyDerivative<Real>("prop","b")),
+    _prop3(getMaterialPropertyDerivative<Real>("prop","a", "b")), // fetch alphabetically sorted (but declared unsorted)
+    _prop4(getMaterialPropertyDerivative<Real>("prop","a", "c")),
+    _prop5(getMaterialPropertyDerivative<Real>("prop","c", "b", "a")) // fetch unsorted (declared unsorted, but differently unsorted)
 {
 }
 

--- a/test/src/materials/DerivativeMaterialInterfaceTestProvider.C
+++ b/test/src/materials/DerivativeMaterialInterfaceTestProvider.C
@@ -10,11 +10,11 @@ InputParameters validParams<DerivativeMaterialInterfaceTestProvider>()
 DerivativeMaterialInterfaceTestProvider::DerivativeMaterialInterfaceTestProvider(const std::string & name,
                                                                                  InputParameters parameters) :
     DerivativeMaterialInterface<Material>(name, parameters),
-    _prop1(declareProperty<Real>(propertyNameFirst("prop","a"))),
-    _prop2(declareProperty<Real>(propertyNameFirst("prop","b"))),
-    _prop3(declareProperty<Real>(propertyNameSecond("prop","b", "a"))),
-    _prop4(declareProperty<Real>(propertyNameSecond("prop","a", "c"))),
-    _prop5(declareProperty<Real>(propertyNameThird("prop","b", "c", "a")))
+    _prop1(declarePropertyDerivative<Real>("prop","a")),
+    _prop2(declarePropertyDerivative<Real>("prop","b")),
+    _prop3(declarePropertyDerivative<Real>("prop","b", "a")),
+    _prop4(declarePropertyDerivative<Real>("prop","a", "c")),
+    _prop5(declarePropertyDerivative<Real>("prop","b", "c", "a"))
 {
 }
 


### PR DESCRIPTION
Per suggestions from @friedmud in #4306. This renames and adds methods (and keeps deprecated old methods, so breakage should not occur in the herd).
