### PR TITLE
Construct tensor mechanics material names using DerivativeMaterialInterface

### DIFF
--- a/modules/tensor_mechanics/include/materials/EigenStrainBaseMaterial.h
+++ b/modules/tensor_mechanics/include/materials/EigenStrainBaseMaterial.h
@@ -2,6 +2,7 @@
 #define EIGENSTRAINBASEMATERIAL_H
 
 #include "LinearElasticMaterial.h"
+#include "DerivativeMaterialInterface.h"
 
 /**
  * EigenStrainBaseMaterial is a base to construct material kernels that represent
@@ -10,7 +11,7 @@
  * order derivatives with respect to c, elasticity_tensor and its 1st and 2nd
  * order derivatives wrt c if it is a function of c instead of a constant.
  */
-class EigenStrainBaseMaterial : public LinearElasticMaterial
+class EigenStrainBaseMaterial : public DerivativeMaterialInterface<LinearElasticMaterial>
 {
 public:
   EigenStrainBaseMaterial(const std:: string & name, InputParameters parameters);
@@ -19,14 +20,16 @@ protected:
   virtual void computeEigenStrain() = 0;
   virtual RankTwoTensor computeStressFreeStrain();
 
+  VariableValue & _c;
+  VariableName _c_name;
+
+  std::string _eigenstrain_name;
   MaterialProperty<RankTwoTensor> & _eigenstrain;
   MaterialProperty<RankTwoTensor> & _deigenstrain_dc;
   MaterialProperty<RankTwoTensor> & _d2eigenstrain_dc2;
 
   MaterialProperty<ElasticityTensorR4> & _delasticity_tensor_dc;
   MaterialProperty<ElasticityTensorR4> & _d2elasticity_tensor_dc2;
-
-  VariableValue & _c;
 };
 
 #endif //EIGENSTRAINBASEMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
+++ b/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
@@ -42,10 +42,16 @@ protected:
   VariableGradient & _grad_disp_y_old;
   VariableGradient & _grad_disp_z_old;
 
+  /// Material property base name to allow for multiple TensorMechanicsMaterial to coexist in the same simulation
+  std::string _base_name;
+
   MaterialProperty<RankTwoTensor> & _stress;
   MaterialProperty<RankTwoTensor> & _total_strain;
   MaterialProperty<RankTwoTensor> & _elastic_strain;
+
+  std::string _elasticity_tensor_name;
   MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+
   MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
 
   RealVectorValue _Euler_angles;

--- a/modules/tensor_mechanics/src/materials/EigenStrainBaseMaterial.C
+++ b/modules/tensor_mechanics/src/materials/EigenStrainBaseMaterial.C
@@ -10,13 +10,18 @@ InputParameters validParams<EigenStrainBaseMaterial>()
 
 EigenStrainBaseMaterial::EigenStrainBaseMaterial(const std::string & name,
                                                  InputParameters parameters) :
-    LinearElasticMaterial(name, parameters),
-    _eigenstrain(declareProperty<RankTwoTensor>("eigenstrain")),
-    _deigenstrain_dc(declareProperty<RankTwoTensor>("deigenstrain_dc")),
-    _d2eigenstrain_dc2(declareProperty<RankTwoTensor>("d2eigenstrain_dc2")),
-    _delasticity_tensor_dc(declareProperty<ElasticityTensorR4>("delasticity_tensor_dc")),
-    _d2elasticity_tensor_dc2(declareProperty<ElasticityTensorR4>("d2elasticity_tensor_dc2")),
-    _c(coupledValue("c"))
+    DerivativeMaterialInterface<LinearElasticMaterial>(name, parameters),
+
+    _c(coupledValue("c")),
+    _c_name(getParam<VariableName>("c")),
+
+    _eigenstrain_name(_base_name + "eigenstrain"),
+    _eigenstrain(declareProperty<RankTwoTensor>(_eigenstrain_name)),
+    _deigenstrain_dc(declarePropertyDerivative<RankTwoTensor>(_eigenstrain_name, _c_name)),
+    _d2eigenstrain_dc2(declarePropertyDerivative<RankTwoTensor>(_eigenstrain_name, _c_name, _c_name)),
+
+    _delasticity_tensor_dc(declarePropertyDerivative<ElasticityTensorR4>(_elasticity_tensor_name, _c_name)),
+    _d2elasticity_tensor_dc2(declarePropertyDerivative<ElasticityTensorR4>(_elasticity_tensor_name, _c_name, _c_name))
 {
 }
 


### PR DESCRIPTION
This improves the naming of tensor_mechanics material properties by introducing a base_name (to enable the use of multiple phases) and the use of the `DerivativeMaterialInterface`. Adresses #4300.

**This needs a corresponding MARMOT (and possibly Hyrax) update** 
