### PR TITLE
Fix comment, rm unneeded property

### DIFF
--- a/framework/include/materials/DerivativeMaterialInterface.h
+++ b/framework/include/materials/DerivativeMaterialInterface.h
@@ -69,7 +69,7 @@ public:
   // return references to a zero material property for non-existing material properties
 
   /**
-   * Fetch a material property if it exists, otherwise return the 'constant_zero' property
+   * Fetch a material property if it exists, otherwise return a constant zero property
    */
   template<typename U>
   const MaterialProperty<U> & getDefaultMaterialProperty(const std::string & name);

--- a/test/tests/materials/derivativematerialinterface/test.i
+++ b/test/tests/materials/derivativematerialinterface/test.i
@@ -6,12 +6,6 @@
 []
 
 [Materials]
-  [./const]
-    type = GenericConstantMaterial
-    block = 0
-    prop_names  = 'constant_zero'
-    prop_values = '0.0'
-  [../]
   [./provider]
     type = DerivativeMaterialInterfaceTestProvider
     block = 0


### PR DESCRIPTION
Some minor cleanup. Fixing a comment and removing an now unneeded explicitly defined material property. Addresses #4311.
