### PR TITLE
Rewrite isMatPropRequested

### DIFF
--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -217,14 +217,14 @@ public:
   virtual void checkBoundaryMatProps();
 
   /**
-   * Helper method for isMatPropRequested to factor out block and boundary checking
+   * Helper method for adding a material property name to the _material_property_requested set
    */
-  virtual bool checkMatPropRequested(std::map<unsigned int, std::multimap<std::string, std::string> > &, const std::string &);
+  virtual void markMatPropRequested(const std::string &);
 
   /**
    * Find out if a material property has been requested by any object
    */
-  virtual bool isMatPropRequested(const std::string & prop_name);
+  virtual bool isMatPropRequested(const std::string & prop_name) const;
 
   /**
    * Will make sure that all dofs connected to elem_id are ghosted to this processor
@@ -307,6 +307,9 @@ protected:
 
   /// Map for boundary material properties (boundary_id -> list of properties)
   std::map<unsigned int, std::set<std::string> > _map_boundary_material_props;
+
+  /// set containing all material property names that have been requested by getMaterialProperty*
+  std::set<std::string> _material_property_requested;
 
   ///@{
   /**

--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -232,6 +232,7 @@ Material::getMaterialProperty(const std::string & prop_name)
   // The property may not exist yet, so declare it (declare/getMaterialProperty are referencing the same memory)
   _depend_props.insert(prop_name);
   registerPropName(prop_name, true, Material::CURRENT);
+  _fe_problem.markMatPropRequested(prop_name);
   return _material_data.getProperty<T>(prop_name);
 }
 
@@ -241,6 +242,7 @@ Material::getMaterialPropertyOld(const std::string & prop_name)
 {
   _depend_props.insert(prop_name);
   registerPropName(prop_name, true, Material::OLD);
+  _fe_problem.markMatPropRequested(prop_name);
   return _material_data.getPropertyOld<T>(prop_name);
 }
 
@@ -250,6 +252,7 @@ Material::getMaterialPropertyOlder(const std::string & prop_name)
 {
   _depend_props.insert(prop_name);
   registerPropName(prop_name, true, Material::OLDER);
+  _fe_problem.markMatPropRequested(prop_name);
   return _material_data.getPropertyOlder<T>(prop_name);
 }
 

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -133,6 +133,11 @@ protected:
   void checkMaterialProperty(const std::string & name);
 
   /**
+   * A proxy method for _mi_feproblem.markMatPropRequested(name)
+   */
+  void markMatPropRequested(const std::string &);
+
+  /**
    * True by default. If false, this class throws an error if any of
    * the stateful material properties interfaces are used.
    */
@@ -155,6 +160,9 @@ MaterialPropertyInterface::getMaterialProperty(const std::string & name)
   if (!_stateful_allowed && _material_data->getMaterialPropertyStorage().hasStatefulProperties())
     mooseError("Error: Stateful material properties not allowed for this object.");
 
+  // mark property as requested
+  markMatPropRequested(name);
+
   // Update the boolean flag.
   _get_material_property_called = true;
 
@@ -168,6 +176,9 @@ MaterialPropertyInterface::getMaterialPropertyOld(const std::string & name)
   if (!_stateful_allowed)
     mooseError("Error: Stateful material properties not allowed for this object.");
 
+  // mark property as requested
+  markMatPropRequested(name);
+
   return _material_data->getPropertyOld<T>(name);
 }
 
@@ -177,6 +188,9 @@ MaterialPropertyInterface::getMaterialPropertyOlder(const std::string & name)
 {
   if (!_stateful_allowed)
     mooseError("Error: Stateful material properties not allowed for this object.");
+
+  // mark property as requested
+  markMatPropRequested(name);
 
   return _material_data->getPropertyOlder<T>(name);
 }

--- a/framework/src/base/SubProblem.C
+++ b/framework/src/base/SubProblem.C
@@ -185,32 +185,17 @@ SubProblem::checkBoundaryMatProps()
   checkMatProps(_map_boundary_material_props, _map_boundary_material_props_check, "boundary");
 }
 
-bool
-SubProblem::checkMatPropRequested(std::map<unsigned int, std::multimap<std::string, std::string> > & check_props, const std::string & prop_name)
+void
+SubProblem::markMatPropRequested(const std::string & prop_name)
 {
-  // Loop through the properties to check
-  for (std::map<unsigned int, std::multimap<std::string, std::string> >::const_iterator check_it = check_props.begin();
-       check_it != check_props.end(); ++check_it)
-  {
-    // Loop through all the stored properties
-    for (std::multimap<std::string, std::string>::const_iterator prop_it = check_it->second.begin(); prop_it != check_it->second.end(); ++prop_it)
-    {
-      // return success as soon as the queried property name has been found
-      if (prop_it->second == prop_name)
-        return true;
-    }
-  }
-
-  return false;
+  _material_property_requested.insert(prop_name);
 }
 
 bool
-SubProblem::isMatPropRequested(const std::string & prop_name)
+SubProblem::isMatPropRequested(const std::string & prop_name) const
 {
-  return checkMatPropRequested(_map_block_material_props_check, prop_name) ||
-         checkMatPropRequested(_map_boundary_material_props_check, prop_name);
+  return _material_property_requested.find(prop_name) != _material_property_requested.end();
 }
-
 
 DiracKernelInfo &
 SubProblem::diracKernelInfo()

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -86,6 +86,12 @@ MaterialPropertyInterface::checkMaterialProperty(const std::string & name)
 }
 
 void
+MaterialPropertyInterface::markMatPropRequested(const std::string & name)
+{
+  _mi_feproblem.markMatPropRequested(name);
+}
+
+void
 MaterialPropertyInterface::statefulPropertiesAllowed(bool stateful_allowed)
 {
   _stateful_allowed = stateful_allowed;


### PR DESCRIPTION
The new version uses a separate `std::set` to which all material properties are added when then are requested via `getMaterialProperty` or `getMaterialPropertyOld` or `getMaterialPropertyOlder`. This should fix and close #4323.
