### PR TITLE
Fixing explicit use of /usr/bin/python

### DIFF
--- a/python/jacobiandebug/analyzejacobian.py
+++ b/python/jacobiandebug/analyzejacobian.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import fileinput
 import sys
 import os


### PR DESCRIPTION
Our older cluster machines still use python 2.4 at /usr/bin/python. Use environment's current python instead. Closes #4352
