### PR TITLE
Warehouse fixes

### DIFF
--- a/framework/src/constraints/ConstraintWarehouse.C
+++ b/framework/src/constraints/ConstraintWarehouse.C
@@ -105,6 +105,7 @@ ConstraintWarehouse::jacobianSetup()
 void
 ConstraintWarehouse::addNodalConstraint(MooseSharedPointer<NodalConstraint> nc)
 {
+  _all_objects.push_back(nc.get());
   _all_ptrs.push_back(nc);
   _nodal_constraints.push_back(nc.get());
 }
@@ -112,6 +113,7 @@ ConstraintWarehouse::addNodalConstraint(MooseSharedPointer<NodalConstraint> nc)
 void
 ConstraintWarehouse::addNodeFaceConstraint(unsigned int slave, unsigned int /*master*/, MooseSharedPointer<NodeFaceConstraint> nfc)
 {
+  _all_objects.push_back(nfc.get());
   _all_ptrs.push_back(nfc);
 
   bool displaced = nfc->parameters().have_parameter<bool>("use_displaced_mesh") && nfc->getParam<bool>("use_displaced_mesh");
@@ -125,6 +127,7 @@ ConstraintWarehouse::addNodeFaceConstraint(unsigned int slave, unsigned int /*ma
 void
 ConstraintWarehouse::addFaceFaceConstraint(const std::string & name, MooseSharedPointer<FaceFaceConstraint> ffc)
 {
+  _all_objects.push_back(ffc.get());
   _all_ptrs.push_back(ffc);
   _face_face_constraints[name].push_back(ffc.get());
 }

--- a/framework/src/ics/InitialConditionWarehouse.C
+++ b/framework/src/ics/InitialConditionWarehouse.C
@@ -95,6 +95,7 @@ InitialConditionWarehouse::addInitialCondition(const std::string & var_name, Sub
 
   _ics[var_name][blockid] = ic;
   _all_ics[blockid].push_back(ic.get());
+  _all_objects.push_back(ic.get());
 }
 
 void
@@ -104,6 +105,7 @@ InitialConditionWarehouse::addBoundaryInitialCondition(const std::string & var_n
   {
     _boundary_ics[var_name][boundary_id] = ic;
     _active_boundary_ics[boundary_id].push_back(ic.get());
+    _all_objects.push_back(ic.get());
   }
   else
     mooseError("Initial condition '" << _boundary_ics[var_name][boundary_id]->name() << "' and '" << ic->name() << "' are both defined on the same block.");


### PR DESCRIPTION
This is a follow-on to #4354, making sure that the `_all_objects` vector actually has all the objects...  I think the rest of the Warehouses already properly do this.
