### PR TITLE
Inherit params from correct parent

### DIFF
--- a/framework/include/meshmodifiers/SideSetsBetweenSubdomains.h
+++ b/framework/include/meshmodifiers/SideSetsBetweenSubdomains.h
@@ -15,7 +15,7 @@
 #ifndef SIDESETSBETWEENSUBDOMAINS_H
 #define SIDESETSBETWEENSUBDOMAINS_H
 
-#include "AddSideSetsBase.h"
+#include "MeshModifier.h"
 
 class SideSetsBetweenSubdomains;
 

--- a/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
+++ b/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
@@ -19,7 +19,7 @@
 template<>
 InputParameters validParams<SideSetsBetweenSubdomains>()
 {
-  InputParameters params = validParams<AddSideSetsBase>();
+  InputParameters params = validParams<MeshModifier>();
   params.addRequiredParam<SubdomainName>("master_block", "The first block for which to draw a sideset between");
   params.addRequiredParam<SubdomainName>("paired_block", "The second block for which to draw a sideset between");
   params.addParam<std::vector<BoundaryName> >("new_boundary", "The name of the boundary to create");


### PR DESCRIPTION
closes #4367 

I checked and this MeshModifier unlike some of the other closely named modifiers does NOT use the AddSideSetsBase class parameters nor its functionality.  We simply need to fixup which parent we retrieve parameters from.
