### PR TITLE
Call libMesh::write_traceout() in mooseError(), mooseAssert()

### DIFF
--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -48,6 +48,8 @@
       Moose::err << _error_oss_.str() << std::flush;                                \
       if (libMesh::global_n_processors() == 1)                                      \
         print_trace();                                                              \
+      else                                                                          \
+        libMesh::write_traceout();                                                  \
       libmesh_here();                                                               \
       MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1);                                      \
       exit(1);                                                                      \
@@ -72,6 +74,8 @@
         << std::endl;                                                               \
      if (libMesh::global_n_processors() == 1)                                       \
        print_trace();                                                               \
+     else                                                                           \
+       libMesh::write_traceout();                                                   \
      libmesh_here();                                                                \
      MPI_Abort(libMesh::GLOBAL_COMM_WORLD,1);                                       \
      exit(1);                                                                       \


### PR DESCRIPTION
This is a no-op unless you configure libmesh with --enable-tracefiles.
Without this, you don't get a stack trace from mooseError/Assert() in
parallel.

Refs #4398
