### PR TITLE
Include scalar variables in TopResidualDebugOutput

### DIFF
--- a/framework/include/outputs/TopResidualDebugOutput.h
+++ b/framework/include/outputs/TopResidualDebugOutput.h
@@ -35,14 +35,17 @@ struct TopResidualDebugOutputTopResidualData
   unsigned int _var;
   unsigned int _nd;
   Real _residual;
+  bool _is_scalar;
 
-  TopResidualDebugOutputTopResidualData() { _var = 0; _nd = 0; _residual = 0.; }
 
-  TopResidualDebugOutputTopResidualData(unsigned int var, unsigned int nd, Real residual)
+  TopResidualDebugOutputTopResidualData() { _var = 0; _nd = 0; _residual = 0.; _is_scalar = false; }
+
+  TopResidualDebugOutputTopResidualData(unsigned int var, unsigned int nd, Real residual, bool is_scalar = false)
   {
     _var = var;
     _nd = nd;
     _residual = residual;
+    _is_scalar = is_scalar;
   }
 };
 

--- a/test/tests/outputs/debug/show_top_residuals_scalar.i
+++ b/test/tests/outputs/debug/show_top_residuals_scalar.i
@@ -1,0 +1,42 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./lambda]
+    order=FIRST
+    family=SCALAR
+  [../]
+[]
+
+[ScalarKernels]
+  [./alpha]
+    type = AlphaCED
+    variable = lambda
+    value = 0.123
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  output_initial = true
+  exodus = true
+  [./console]
+    type = Console
+    perf_log = true
+    linear_residuals = true
+  [../]
+  [./debug]
+    type = TopResidualDebugOutput
+    num_residuals = 1
+  [../]
+[]

--- a/test/tests/outputs/debug/show_top_residuals_scalar_debug.i
+++ b/test/tests/outputs/debug/show_top_residuals_scalar_debug.i
@@ -1,0 +1,42 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./lambda]
+    order=FIRST
+    family=SCALAR
+  [../]
+[]
+
+[ScalarKernels]
+  [./alpha]
+    type = AlphaCED
+    variable = lambda
+    value = 0.123
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  output_initial = true
+  exodus = true
+  [./console]
+    type = Console
+    perf_log = true
+    linear_residuals = true
+  [../]
+[]
+
+[Debug]
+  show_top_residuals = 1
+[]

--- a/test/tests/outputs/debug/tests
+++ b/test/tests/outputs/debug/tests
@@ -28,23 +28,38 @@
    [../]
 
    [./show_top_residuals]
-     # Test that top residauls are displayed using DebugOutput object via Outputs block
+     # Test that top residuals are displayed using DebugOutput object via Outputs block
      type = RunApp
      input = show_top_residuals.i
      expect_out = "\[DBG\]\[0\].*'u'.*at node"
    [../]
 
    [./show_top_residuals_debug]
-     # Test that top residauls are displayed using DebugOutput object via Debug block
+     # Test that top residuals are displayed using DebugOutput object via Debug block
      type = RunApp
      input = show_top_residuals_debug.i
      expect_out = "\[DBG\]\[0\].*'u'.*at node"
    [../]
 
    [./show_top_residuals_nonlinear_only]
-     # Test that top residauls may be limited to nonlinear iterations only
+     # Test that top residuals may be limited to nonlinear iterations only
      type = RunApp
      input = show_top_residuals.i Outputs/debug/linear_residuals=false
      expect_out = "0 Linear[^\n]*\n[^\n]*1 Linear"
    [../]
+
+   [./show_top_residuals_scalar]
+     # Test that top residuals of scalar variables are displayed using DebugOutput object via Outputs block
+     type = RunApp
+     input = show_top_residuals_scalar.i
+     expect_out = "\[DBG\]\[0\].*'lambda' \(SCALAR\)"
+   [../]
+
+   [./show_top_residuals_scalar_debug]
+     # Test that top residuals of scalar variables are displayed using DebugOutput object via Debug block
+     type = RunApp
+     input = show_top_residuals_scalar_debug.i
+     expect_out = "\[DBG\]\[0\].*'lambda' \(SCALAR\)"
+   [../]
+
 []


### PR DESCRIPTION
Without this fix, TopResidualDebugOutput simply ignored scalar variables, which can be nasty since for example as Lagrange multipliers they can contribute the largest part of the total residual (see example below).
This PR includes scalar variables into the list of top residuals. To this end, after visiting all nodes to find the element-resolved residual contribution of all non-scalar variables, it loops over all scalar variables and adds their residual contribution to the list that is sorted and printed to the output afterwards.
Finally, the output reads

```
     Time Step  1, time = 0.1
                        dt = 0.1
        [DBG][0] Max 5 residuals
        [DBG][0] 2.05196549453295 'hydrostatic_pressure' (SCALAR)
        [DBG][0] 8.41950749570775e-19 'dispx' at node 425
        [DBG][0] -7.86046575051991e-19 'dispz' at node 442
        [DBG][0] 7.6232965252887e-19 'dispy' at node 825
        [DBG][0] 7.58941520739853e-19 'dispz' at node 537
      0 Nonlinear |R| = 2.051965e+00
```

Appropriate regression tests are included.
This is my first `moose`-PR :blush: - Please let me know if anything is missing or inappropriate. :smiley:
