### PR TITLE
Add a script that prints monthly lines added/deleted

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -26,3 +26,4 @@ Pritam Chakraborty <chakp@fn426624.fn.inl.gov>
 Ziyu Zhang <buaazhangziyu@gmail.com>
 Scott A. Schoen <schosa@dd8cd9ef-2931-0410-98ca-75ad22d19dd1>
 Cristian Rabiti <crisr@dd8cd9ef-2931-0410-98ca-75ad22d19dd1>
+Lei Zhao <leizhao987@gmail.com>

--- a/framework/scripts/git_stats.sh
+++ b/framework/scripts/git_stats.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Monthly intervals, starting from the open source date, March 10th.
+dates=(
+2014-03-10
+2014-04-10
+2014-05-10
+2014-06-10
+2014-07-10
+2014-08-10
+2014-09-10
+2014-10-10
+2014-11-10
+2014-12-10
+)
+
+# Get abbreviated hash for the first commit older than the given date
+hashes=()
+for ((i=0; i<${#dates[@]}; i++));
+do
+  hashes+=(`git log -n1 --pretty="format:%h" --before=${dates[$i]}`)
+done
+
+# Report *cumulative* number of unique authors since open source inception.
+echo -e "\nCumulative unique author count (since open sourcing)"
+for ((i=1; i<${#hashes[@]}; i++));
+do
+  # The 'tr' command deletes the whitespaces inserted by wc
+  n_authors=`git shortlog -s ${hashes[0]}..${hashes[$i]} | wc -l | tr -d ' '`
+  echo "${dates[0]}..${dates[$i]}, $n_authors"
+done
+
+# We are going to log changes for all files from the top level of the git repository
+toplevel=`git rev-parse --show-toplevel`
+
+# Regular expressions defining classes of files to get line change stats for
+regexes=(
+"*.[Ch]"
+"*.py"
+)
+
+for ((r=0; r<${#regexes[@]}; r++));
+do
+    echo -e "\nLines of ${regexes[$r]} files added/deleted:"
+    for ((i=1; i<${#hashes[@]}; i++));
+    do
+        hash1=${hashes[$[$i-1]]}
+        hash2=${hashes[$i]}
+
+        # Need to use xargs to limit the length of the argument list to git
+        n_lines=`find $toplevel -name "${regexes[$r]}" | xargs git log --numstat --pretty="%H" $hash1..$hash2 | awk 'NF==3 {plus+=$1; minus+=$2} END {printf("+%d, -%d\n", plus, minus)}'`
+        echo "${dates[$[$i-1]]}..${dates[$i]}, $n_lines"
+    done
+done
+
+# Local Variables:
+# truncate-lines: t
+# End:


### PR DESCRIPTION
Script currently prints:

```
Cumulative unique author count (since open sourcing)
2014-03-10..2014-04-10, 11
2014-03-10..2014-05-10, 17
2014-03-10..2014-06-10, 23
2014-03-10..2014-07-10, 24
2014-03-10..2014-08-10, 28
2014-03-10..2014-09-10, 30
2014-03-10..2014-10-10, 30
2014-03-10..2014-11-10, 31
2014-03-10..2014-12-10, 35

Lines of *.[Ch] files added/deleted:
2014-03-10..2014-04-10, +5277, -2105
2014-04-10..2014-05-10, +14488, -5982
2014-05-10..2014-06-10, +19025, -5778
2014-06-10..2014-07-10, +6390, -3711
2014-07-10..2014-08-10, +8146, -2248
2014-08-10..2014-09-10, +8629, -1936
2014-09-10..2014-10-10, +7457, -3405
2014-10-10..2014-11-10, +3274, -2208
2014-11-10..2014-12-10, +10295, -3927

Lines of *.py files added/deleted:
2014-03-10..2014-04-10, +461, -270
2014-04-10..2014-05-10, +99, -75
2014-05-10..2014-06-10, +6274, -390
2014-06-10..2014-07-10, +186, -35
2014-07-10..2014-08-10, +129, -46
2014-08-10..2014-09-10, +76, -37
2014-09-10..2014-10-10, +7215, -7196
2014-10-10..2014-11-10, +378, -236
2014-11-10..2014-12-10, +2408, -383
```
