### PR TITLE
Use parameters to pass legacy flags to MooseApp derived objects

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -69,6 +69,10 @@ InputParameters validParams<MooseApp>()
 
   params.addCommandLineParam<bool>("timing", "-t --timing", false, "Enable all performance logging for timing purposes. This will disable all screen output of performance logs for all Console objects.");
 
+  // Legacy Flags
+  params.addParam<bool>("use_legacy_uo_aux_computation", true, "Set to true to have MOOSE recompute *all* AuxKernel types every time *any* UserObject type is executed.\nThis behavoir is non-intuitive and will be removed late fall 2014, The default is controlled through MooseApp");
+  params.addParam<bool>("use_legacy_uo_initialization", true, "Set to true to have MOOSE compute all UserObjects and Postprocessors during the initial setup phase of the problem recompute *all* AuxKernel types every time *any* UserObject type is executed.\nThis behavoir is non-intuitive and will be removed late fall 2014, The default is controlled through MooseApp");
+
   params.addPrivateParam<int>("_argc");
   params.addPrivateParam<char**>("_argv");
   params.addPrivateParam<MooseSharedPointer<CommandLine> >("_command_line");
@@ -118,9 +122,8 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     _recover(false),
     _restart(false),
     _half_transient(false),
-    _legacy_uo_aux_computation_default(true),
-    _legacy_uo_initialization_default(true)
-
+    _legacy_uo_aux_computation_default(getParam<bool>("use_legacy_uo_aux_computation")),
+    _legacy_uo_initialization_default(getParam<bool>("use_legacy_uo_initialization"))
 {
   if (isParamValid("_argc") && isParamValid("_argv"))
   {

--- a/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
+++ b/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
@@ -32,6 +32,9 @@ template<>
 InputParameters validParams<ChemicalReactionsApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/chemical_reactions/src/main.C
+++ b/modules/chemical_reactions/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/combined/src/base/ModulesApp.C
+++ b/modules/combined/src/base/ModulesApp.C
@@ -25,6 +25,9 @@ template<>
 InputParameters validParams<ModulesApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/combined/src/main.C
+++ b/modules/combined/src/main.C
@@ -26,8 +26,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/contact/src/base/ContactApp.C
+++ b/modules/contact/src/base/ContactApp.C
@@ -26,6 +26,9 @@ template<>
 InputParameters validParams<ContactApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/contact/src/main.C
+++ b/modules/contact/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/fluid_mass_energy_balance/src/base/FluidMassEnergyBalanceApp.C
+++ b/modules/fluid_mass_energy_balance/src/base/FluidMassEnergyBalanceApp.C
@@ -31,6 +31,9 @@ template<>
 InputParameters validParams<FluidMassEnergyBalanceApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/fluid_mass_energy_balance/src/main.C
+++ b/modules/fluid_mass_energy_balance/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/heat_conduction/src/base/HeatConductionApp.C
+++ b/modules/heat_conduction/src/base/HeatConductionApp.C
@@ -27,6 +27,9 @@ template<>
 InputParameters validParams<HeatConductionApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/heat_conduction/src/main.C
+++ b/modules/heat_conduction/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/linear_elasticity/src/base/LinearElasticityApp.C
+++ b/modules/linear_elasticity/src/base/LinearElasticityApp.C
@@ -14,6 +14,9 @@ template<>
 InputParameters validParams<LinearElasticityApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/linear_elasticity/src/main.C
+++ b/modules/linear_elasticity/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/misc/src/base/MiscApp.C
+++ b/modules/misc/src/base/MiscApp.C
@@ -22,6 +22,9 @@ template<>
 InputParameters validParams<MiscApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/misc/src/main.C
+++ b/modules/misc/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/navier_stokes/src/base/NavierStokesApp.C
+++ b/modules/navier_stokes/src/base/NavierStokesApp.C
@@ -76,6 +76,9 @@ template<>
 InputParameters validParams<NavierStokesApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/navier_stokes/src/main.C
+++ b/modules/navier_stokes/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -58,6 +58,9 @@ template<>
 InputParameters validParams<PhaseFieldApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/phase_field/src/main.C
+++ b/modules/phase_field/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/richards/src/base/RichardsApp.C
+++ b/modules/richards/src/base/RichardsApp.C
@@ -87,6 +87,9 @@ template<>
 InputParameters validParams<RichardsApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/richards/src/main.C
+++ b/modules/richards/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -68,6 +68,9 @@ template<>
 InputParameters validParams<SolidMechanicsApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/solid_mechanics/src/main.C
+++ b/modules/solid_mechanics/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -48,6 +48,9 @@ template<>
 InputParameters validParams<TensorMechanicsApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/tensor_mechanics/src/main.C
+++ b/modules/tensor_mechanics/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/modules/water_steam_eos/src/base/WaterSteamEOSApp.C
+++ b/modules/water_steam_eos/src/base/WaterSteamEOSApp.C
@@ -6,6 +6,9 @@ template<>
 InputParameters validParams<WaterSteamEOSApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
+
   return params;
 }
 

--- a/modules/water_steam_eos/src/main.C
+++ b/modules/water_steam_eos/src/main.C
@@ -21,8 +21,6 @@ int main(int argc, char *argv[])
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
 
   // Execute the application
   app->run();

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -201,6 +201,9 @@ template<>
 InputParameters validParams<MooseTestApp>()
 {
   InputParameters params = validParams<MooseApp>();
+
+  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_aux_computation") = false;
   return params;
 }
 

--- a/test/src/main.C
+++ b/test/src/main.C
@@ -17,9 +17,6 @@ int main(int argc, char *argv[])
   // This creates dynamic memory that we're responsible for deleting
   MooseApp * app = AppFactory::createApp("MooseTestApp", argc, argv);
 
-  app->legacyUoInitializationDefault() = true;
-  app->legacyUoAuxComputationDefault() = false;
-
   // Execute the application
   app->run();
 


### PR DESCRIPTION
When setting the flags from main.C we were
missing the case where apps were being
created by the Multiapp system. This
patch simply sets the flags in the params
system to avoid this issue. Overrides are still
possible through the [Problem] block.

closes #4111
