### PR TITLE
Fixes for 64bit indices

### DIFF
--- a/framework/include/auxkernels/AuxNodalScalarKernel.h
+++ b/framework/include/auxkernels/AuxNodalScalarKernel.h
@@ -43,7 +43,7 @@ public:
 
 protected:
   /// List of node IDs
-  std::vector<unsigned int> _node_ids;
+  std::vector<dof_id_type> _node_ids;
 };
 
 #endif /* AUXNODALSCALARKERNEL_H */

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -438,9 +438,13 @@ protected:
   void reinitFEFace(const Elem * elem, unsigned int side);
 
   void addResidualBlock(NumericVector<Number> & residual, DenseVector<Number> & res_block, const std::vector<dof_id_type> & dof_indices, Real scaling_factor);
-  void cacheResidualBlock(std::vector<Real> & cached_residual_values, std::vector<unsigned int> & cached_residual_rows, DenseVector<Number> & res_block, std::vector<dof_id_type> & dof_indices, Real scaling_factor);
+  void cacheResidualBlock(std::vector<Real> & cached_residual_values,
+                          std::vector<dof_id_type> & cached_residual_rows,
+                          DenseVector<Number> & res_block,
+                          std::vector<dof_id_type> & dof_indices,
+                          Real scaling_factor);
 
-  void setResidualBlock(NumericVector<Number> & residual, DenseVector<Number> & res_block, std::vector<unsigned int> & dof_indices, Real scaling_factor);
+  void setResidualBlock(NumericVector<Number> & residual, DenseVector<Number> & res_block, std::vector<dof_id_type> & dof_indices, Real scaling_factor);
 
   void addJacobianBlock(SparseMatrix<Number> & jacobian, DenseMatrix<Number> & jac_block, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices, Real scaling_factor);
 
@@ -650,7 +654,7 @@ protected:
   std::vector<std::vector<Real> > _cached_residual_values;
 
   /// Where the cached values should go (the first vector is for TIME vs NONTIME)
-  std::vector<std::vector<unsigned int> > _cached_residual_rows;
+  std::vector<std::vector<dof_id_type> > _cached_residual_rows;
 
   unsigned int _max_cached_residuals;
 

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -637,7 +637,7 @@ protected:
   };
 
   /// Cached shape function values stored by element
-  std::map<unsigned int, ElementFEShapeData * > _element_fe_shape_data_cache;
+  std::map<dof_id_type, ElementFEShapeData * > _element_fe_shape_data_cache;
 
   /// Whether or not fe cache should be built at all
   bool _should_use_fe_cache;
@@ -661,9 +661,9 @@ protected:
   /// Values cached by calling cacheJacobian()
   std::vector<Real> _cached_jacobian_values;
   /// Row where the corresponding cached value should go
-  std::vector<unsigned int> _cached_jacobian_rows;
+  std::vector<dof_id_type> _cached_jacobian_rows;
   /// Column where the corresponding cached value should go
-  std::vector<unsigned int> _cached_jacobian_cols;
+  std::vector<dof_id_type> _cached_jacobian_cols;
 
   unsigned int _max_cached_jacobians;
 

--- a/framework/include/base/AuxiliarySystem.h
+++ b/framework/include/base/AuxiliarySystem.h
@@ -86,8 +86,8 @@ public:
 
   // This is an empty function since the Aux system doesn't have a matrix!
   virtual void augmentSparsity(SparsityPattern::Graph & /*sparsity*/,
-                               std::vector<unsigned int> & /*n_nz*/,
-                               std::vector<unsigned int> & /*n_oz*/);
+                               std::vector<dof_id_type> & /*n_nz*/,
+                               std::vector<dof_id_type> & /*n_oz*/);
 
   /**
    * Compute auxiliary variables

--- a/framework/include/base/DisplacedProblem.h
+++ b/framework/include/base/DisplacedProblem.h
@@ -96,7 +96,7 @@ public:
   virtual void reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid);
   virtual void reinitNode(const Node * node, THREAD_ID tid);
   virtual void reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID tid);
-  virtual void reinitNodes(const std::vector<unsigned int> & nodes, THREAD_ID tid);
+  virtual void reinitNodes(const std::vector<dof_id_type> & nodes, THREAD_ID tid);
   virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid);
   virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid);
   virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid);
@@ -151,7 +151,7 @@ public:
   /**
    * Will make sure that all dofs connected to elem_id are ghosted to this processor
    */
-  virtual void addGhostedElem(unsigned int elem_id);
+  virtual void addGhostedElem(dof_id_type elem_id);
 
   /**
    * Will make sure that all necessary elements from boundary_id are ghosted to this processor

--- a/framework/include/base/DisplacedSystem.h
+++ b/framework/include/base/DisplacedSystem.h
@@ -49,15 +49,15 @@ public:
   virtual NumericVector<Number> & residualCopy() { return _undisplaced_system.residualCopy(); }
   virtual NumericVector<Number> & residualGhosted() { return _undisplaced_system.residualGhosted(); }
 
-  virtual void augmentSendList(std::vector<unsigned int> & send_list){ _undisplaced_system.augmentSendList(send_list); }
+  virtual void augmentSendList(std::vector<dof_id_type> & send_list){ _undisplaced_system.augmentSendList(send_list); }
 
   /**
    * This is an empty function since the displaced system doesn't have a matrix!
    * All sparsity pattern modification will be taken care of by the undisplaced system directly
    */
   virtual void augmentSparsity(SparsityPattern::Graph & /*sparsity*/,
-                               std::vector<unsigned int> & /*n_nz*/,
-                               std::vector<unsigned int> & /*n_oz*/)
+                               std::vector<dof_id_type> & /*n_nz*/,
+                               std::vector<dof_id_type> & /*n_oz*/)
     {}
 
   /**

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -148,15 +148,15 @@ public:
    * @param div_threshold  Maximum value of residual before triggering divergence check
    */
   virtual MooseNonlinearConvergenceReason checkNonlinearConvergence(std::string &msg,
-                                                                    const int it,
+                                                                    const PetscInt it,
                                                                     const Real xnorm,
                                                                     const Real snorm,
                                                                     const Real fnorm,
                                                                     const Real rtol,
                                                                     const Real stol,
                                                                     const Real abstol,
-                                                                    const int nfuncs,
-                                                                    const int max_funcs,
+                                                                    const PetscInt nfuncs,
+                                                                    const PetscInt max_funcs,
                                                                     const Real ref_resid,
                                                                     const Real div_threshold);
 
@@ -171,12 +171,12 @@ public:
    * @param maxits         Maximum number of linear iterations allowed
    */
   virtual MooseLinearConvergenceReason checkLinearConvergence(std::string &msg,
-                                                              const int n,
+                                                              const PetscInt n,
                                                               const Real rnorm,
                                                               const Real rtol,
                                                               const Real atol,
                                                               const Real dtol,
-                                                              const int maxits);
+                                                              const PetscInt maxits);
 
 #ifdef LIBMESH_HAVE_PETSC
   void storePetscOptions(const MultiMooseEnum & petsc_options,

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -243,7 +243,7 @@ public:
 
   virtual void prepareAssembly(THREAD_ID tid);
 
-  virtual void addGhostedElem(unsigned int elem_id);
+  virtual void addGhostedElem(dof_id_type elem_id);
   virtual void addGhostedBoundary(BoundaryID boundary_id);
   virtual void ghostGhostedBoundaries();
 
@@ -254,7 +254,7 @@ public:
   virtual void reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid);
   virtual void reinitNode(const Node * node, THREAD_ID tid);
   virtual void reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID tid);
-  virtual void reinitNodes(const std::vector<unsigned int> & nodes, THREAD_ID tid);
+  virtual void reinitNodes(const std::vector<dof_id_type> & nodes, THREAD_ID tid);
   virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid);
   virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid);
   virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid);

--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -199,7 +199,8 @@ public:
   /**
    * Finds the implicit sparsity graph between geometrically related dofs.
    */
-  void findImplicitGeometricCouplingEntries(GeometricSearchData & geom_search_data, std::map<unsigned int, std::vector<unsigned int> > & graph);
+  void findImplicitGeometricCouplingEntries(GeometricSearchData & geom_search_data,
+                                            std::map<dof_id_type, std::vector<dof_id_type> > & graph);
 
   /**
    * Adds entries to the Jacobian in the correct positions for couplings coming from dofs being coupled that
@@ -270,8 +271,8 @@ public:
   virtual NumericVector<Number> & residualGhosted();
 
   virtual void augmentSparsity(SparsityPattern::Graph & sparsity,
-                               std::vector<unsigned int> & n_nz,
-                               std::vector<unsigned int> & n_oz);
+                               std::vector<dof_id_type> & n_nz,
+                               std::vector<dof_id_type> & n_oz);
 
   /**
    * Sets a preconditioner

--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -140,7 +140,7 @@ public:
   virtual void reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid) = 0;
   virtual void reinitNode(const Node * node, THREAD_ID tid) = 0;
   virtual void reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID tid) = 0;
-  virtual void reinitNodes(const std::vector<unsigned int> & nodes, THREAD_ID tid) = 0;
+  virtual void reinitNodes(const std::vector<dof_id_type> & nodes, THREAD_ID tid) = 0;
   virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid) = 0;
   virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid) = 0;
   virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid) = 0;
@@ -229,7 +229,7 @@ public:
   /**
    * Will make sure that all dofs connected to elem_id are ghosted to this processor
    */
-  virtual void addGhostedElem(unsigned int elem_id) = 0;
+  virtual void addGhostedElem(dof_id_type elem_id) = 0;
 
   /**
    * Will make sure that all necessary elements from boundary_id are ghosted to this processor

--- a/framework/include/base/SystemBase.h
+++ b/framework/include/base/SystemBase.h
@@ -48,8 +48,8 @@ void extraSendList(std::vector<dof_id_type> & send_list, void * context);
  * Free function used for a libMesh callback
  */
 void extraSparsity(SparsityPattern::Graph & sparsity,
-                   std::vector<unsigned int> & n_nz,
-                   std::vector<unsigned int> & n_oz,
+                   std::vector<dof_id_type> & n_nz,
+                   std::vector<dof_id_type> & n_oz,
                    void * context);
 
 /**
@@ -140,8 +140,8 @@ public:
    * Will modify the sparsity pattern to add logical geometric connections
    */
   virtual void augmentSparsity(SparsityPattern::Graph & sparsity,
-                               std::vector<unsigned int> & n_nz,
-                               std::vector<unsigned int> & n_oz) = 0;
+                               std::vector<dof_id_type> & n_nz,
+                               std::vector<dof_id_type> & n_oz) = 0;
 
   /**
    * Returns true if we are currently computing Jacobian

--- a/framework/include/constraints/NodalConstraint.h
+++ b/framework/include/constraints/NodalConstraint.h
@@ -43,7 +43,7 @@ public:
    * Get the list of connected slave nodes
    * @return list of slave node IDs
    */
-  std::vector<unsigned int> & getSlaveNodeId() { return _connected_nodes; }
+  std::vector<dof_id_type> & getSlaveNodeId() { return _connected_nodes; }
 
   /**
    * Built the connectivity for this constraint
@@ -81,7 +81,7 @@ protected:
   /// Value of the unknown variable this BC is action on
   VariableValue & _u_slave;
   /// node IDs connected to the master node (slave nodes)
-  std::vector<unsigned int> _connected_nodes;
+  std::vector<dof_id_type> _connected_nodes;
 
   /// Holds the current solution at the current quadrature point
   VariableValue & _u_master;

--- a/framework/include/geomsearch/NearestNodeLocator.h
+++ b/framework/include/geomsearch/NearestNodeLocator.h
@@ -55,12 +55,12 @@ public:
   /**
    * Valid to call this after findNodes() has been called to get the distance to the nearest node.
    */
-  Real distance(unsigned int node_id);
+  Real distance(dof_id_type node_id);
 
   /**
    * Valid to call this after findNodes() has been called to get a pointer to the nearest node.
    */
-  const Node * nearestNode(unsigned int node_id);
+  const Node * nearestNode(dof_id_type node_id);
 
   /**
    * Returns the list of slave nodes this Locator is tracking.
@@ -93,7 +93,7 @@ protected:
   NodeIdRange * _slave_node_range;
 
 public:
-  std::map<unsigned int, NearestNodeInfo> _nearest_node_info;
+  std::map<dof_id_type, NearestNodeInfo> _nearest_node_info;
 
   BoundaryID _boundary1;
   BoundaryID _boundary2;

--- a/framework/include/geomsearch/NearestNodeLocator.h
+++ b/framework/include/geomsearch/NearestNodeLocator.h
@@ -65,7 +65,7 @@ public:
   /**
    * Returns the list of slave nodes this Locator is tracking.
    */
-  std::vector<unsigned int> & slaveNodes() { return _slave_nodes; }
+  std::vector<dof_id_type> & slaveNodes() { return _slave_nodes; }
 
   /**
    * Returns the NodeIdRange of slave nodes to be used for calling threaded
@@ -99,9 +99,9 @@ public:
   BoundaryID _boundary2;
 
   bool _first;
-  std::vector<unsigned int> _slave_nodes;
+  std::vector<dof_id_type> _slave_nodes;
 
-  std::map<unsigned int, std::vector<unsigned int> > _neighbor_nodes;
+  std::map<dof_id_type, std::vector<dof_id_type> > _neighbor_nodes;
 
   // The following parameter controls the patch size that is searched for each nearest neighbor
   static const unsigned int _patch_size;

--- a/framework/include/geomsearch/NearestNodeThread.h
+++ b/framework/include/geomsearch/NearestNodeThread.h
@@ -21,7 +21,7 @@ class NearestNodeThread
 {
 public:
   NearestNodeThread(const MooseMesh & mesh,
-                    std::map<unsigned int, std::vector<unsigned int> > & neighbor_nodes);
+                    std::map<dof_id_type, std::vector<dof_id_type> > & neighbor_nodes);
 
   // Splitting Constructor
   NearestNodeThread(NearestNodeThread & x, Threads::split split);
@@ -41,7 +41,7 @@ protected:
   const MooseMesh & _mesh;
 
   // The neighborhood nodes associated with each node
-  std::map<unsigned int, std::vector<unsigned int> > & _neighbor_nodes;
+  std::map<dof_id_type, std::vector<dof_id_type> > & _neighbor_nodes;
 };
 
 #endif //NEARESTNODETHREAD_H

--- a/framework/include/geomsearch/NearestNodeThread.h
+++ b/framework/include/geomsearch/NearestNodeThread.h
@@ -31,7 +31,7 @@ public:
   void join(const NearestNodeThread & other);
 
   // This is the info map we're actually filling here
-  std::map<unsigned int, NearestNodeLocator::NearestNodeInfo> _nearest_node_info;
+  std::map<dof_id_type, NearestNodeLocator::NearestNodeInfo> _nearest_node_info;
 
   // The furthest percentage through the patch that had to be searched (indicative of needing to rebuild the patch)
   Real _max_patch_percentage;

--- a/framework/include/geomsearch/PenetrationLocator.h
+++ b/framework/include/geomsearch/PenetrationLocator.h
@@ -42,10 +42,10 @@ class GeometricSearchData;
  */
 template<>
 inline void
-dataLoad(std::istream & stream, std::map<unsigned int, PenetrationInfo *> & m, void * context)
+dataLoad(std::istream & stream, std::map<dof_id_type, PenetrationInfo *> & m, void * context)
 {
-  std::map<unsigned int, PenetrationInfo *>::iterator it = m.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = m.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator it = m.begin();
+  std::map<dof_id_type, PenetrationInfo *>::iterator end = m.end();
 
   for (; it != end; ++it)
     delete it->second;
@@ -58,7 +58,7 @@ dataLoad(std::istream & stream, std::map<unsigned int, PenetrationInfo *> & m, v
 
   for (unsigned int i = 0; i < size; i++)
   {
-    unsigned int key;
+    dof_id_type key;
     loadHelper(stream, key, context);
     loadHelper(stream, m[key], context);
   }
@@ -77,8 +77,8 @@ public:
    */
   void reinit();
 
-  Real penetrationDistance(unsigned int node_id);
-  RealVectorValue penetrationNormal(unsigned int node_id);
+  Real penetrationDistance(dof_id_type node_id);
+  RealVectorValue penetrationNormal(dof_id_type node_id);
 
   enum NORMAL_SMOOTHING_METHOD
   {
@@ -105,12 +105,12 @@ public:
   NearestNodeLocator & _nearest_node;
 
   /// Data structure of nodes and their associated penetration information
-  std::map<unsigned int, PenetrationInfo *> & _penetration_info;
+  std::map<dof_id_type, PenetrationInfo *> & _penetration_info;
 
-  std::set<unsigned int> & _has_penetrated;
-  std::map<unsigned int, unsigned> & _locked_this_step;
-  std::map<unsigned int, unsigned> & _unlocked_this_step;
-  std::map<unsigned int, Real> & _lagrange_multiplier;
+  std::set<dof_id_type> & _has_penetrated;
+  std::map<dof_id_type, unsigned int> & _locked_this_step;
+  std::map<dof_id_type, unsigned int> & _unlocked_this_step;
+  std::map<dof_id_type, Real> & _lagrange_multiplier;
 
   void setUpdate(bool update);
   void setTangentialTolerance(Real tangential_tolerance);

--- a/framework/include/geomsearch/PenetrationThread.h
+++ b/framework/include/geomsearch/PenetrationThread.h
@@ -27,7 +27,7 @@ public:
                     const MooseMesh & mesh,
                     BoundaryID master_boundary,
                     BoundaryID slave_boundary,
-                    std::map<unsigned int, PenetrationInfo *> & penetration_info,
+                    std::map<dof_id_type, PenetrationInfo *> & penetration_info,
                     bool update_location,
                     Real tangential_tolerance,
                     bool do_normal_smoothing,
@@ -56,7 +56,7 @@ protected:
   BoundaryID _slave_boundary;
 
   // This is the info map we're actually filling here
-  std::map<unsigned int, PenetrationInfo *> & _penetration_info;
+  std::map<dof_id_type, PenetrationInfo *> & _penetration_info;
 
   bool _update_location;
   Real _tangential_tolerance;
@@ -155,7 +155,7 @@ protected:
 
   void
   getInfoForFacesWithCommonNodes(const Node* slave_node,
-                                 const std::set<unsigned int> &elems_to_exclude,
+                                 const std::set<dof_id_type> &elems_to_exclude,
                                  const std::vector<const Node*> edge_nodes,
                                  std::vector<PenetrationInfo*> &face_info_comm_edge,
                                  std::vector<PenetrationInfo*> & p_info);

--- a/framework/include/geomsearch/PenetrationThread.h
+++ b/framework/include/geomsearch/PenetrationThread.h
@@ -36,10 +36,10 @@ public:
                     std::vector<std::vector<FEBase *> > & fes,
                     FEType & fe_type,
                     NearestNodeLocator & nearest_node,
-                    std::map<unsigned int, std::vector<unsigned int> > & node_to_elem_map,
-                    std::vector< unsigned int > & elem_list,
-                    std::vector< unsigned short int > & side_list,
-                    std::vector< short int > & id_list);
+                    std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
+                    std::vector<dof_id_type> & elem_list,
+                    std::vector<unsigned short int> & side_list,
+                    std::vector<boundary_id_type> & id_list);
 
   // Splitting Constructor
   PenetrationThread(PenetrationThread & x, Threads::split split);
@@ -73,11 +73,11 @@ protected:
 
   NearestNodeLocator & _nearest_node;
 
-  std::map<unsigned int, std::vector<unsigned int> > & _node_to_elem_map;
+  std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map;
 
-  std::vector< unsigned int > & _elem_list;
-  std::vector< unsigned short int > & _side_list;
-  std::vector< short int > & _id_list;
+  std::vector<dof_id_type> & _elem_list;
+  std::vector<unsigned short int> & _side_list;
+  std::vector<boundary_id_type> & _id_list;
 
   unsigned int _n_elems;
 

--- a/framework/include/geomsearch/SlaveNeighborhoodThread.h
+++ b/framework/include/geomsearch/SlaveNeighborhoodThread.h
@@ -26,8 +26,8 @@ class SlaveNeighborhoodThread
 {
 public:
   SlaveNeighborhoodThread(const MooseMesh & mesh,
-                          const std::vector<unsigned int> & trial_master_nodes,
-                          std::map<unsigned int, std::vector<unsigned int> > & node_to_elem_map,
+                          const std::vector<dof_id_type> & trial_master_nodes,
+                          std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
                           const unsigned int patch_size);
 
 
@@ -39,23 +39,23 @@ public:
   void join(const SlaveNeighborhoodThread & other);
 
   /// List of the slave nodes we're actually going to keep track of
-  std::vector<unsigned int> _slave_nodes;
+  std::vector<dof_id_type> _slave_nodes;
 
   /// The neighborhood nodes associated with each node
-  std::map<unsigned int, std::vector<unsigned int> > _neighbor_nodes;
+  std::map<dof_id_type, std::vector<dof_id_type> > _neighbor_nodes;
 
   /// Elements that we need to ghost
-  std::set<unsigned int> _ghosted_elems;
+  std::set<dof_id_type> _ghosted_elems;
 
 protected:
   /// The Mesh
   const MooseMesh & _mesh;
 
   /// Nodes to search against
-  const std::vector<unsigned int> & _trial_master_nodes;
+  const std::vector<dof_id_type> & _trial_master_nodes;
 
   /// Node to elem map
-  std::map<unsigned int, std::vector<unsigned int> > & _node_to_elem_map;
+  std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map;
 
   /// The number of nodes to keep
   unsigned int _patch_size;

--- a/framework/include/kernels/NodalScalarKernel.h
+++ b/framework/include/kernels/NodalScalarKernel.h
@@ -41,7 +41,7 @@ public:
 
 protected:
   /// List of node IDs
-  std::vector<unsigned int> _node_ids;
+  std::vector<dof_id_type> _node_ids;
 };
 
 #endif /* NODALSCALARKERNEL_H */

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -188,22 +188,22 @@ public:
   /**
    * Calls n_nodes/elem() on the underlying libMesh mesh object.
    */
-  virtual unsigned int nNodes() const;
-  virtual unsigned int nElem() const;
+  virtual dof_id_type nNodes() const;
+  virtual dof_id_type nElem() const;
 
   /**
    * Various accessors (pointers/references) for Node "i".
    */
-  virtual const Node & node (const unsigned int i) const;
-  virtual Node & node (const unsigned int i);
-  virtual const Node* nodePtr(const unsigned int i) const;
-  virtual Node* nodePtr(const unsigned int i);
+  virtual const Node & node (const dof_id_type i) const;
+  virtual Node & node (const dof_id_type i);
+  virtual const Node* nodePtr(const dof_id_type i) const;
+  virtual Node* nodePtr(const dof_id_type i);
 
   /**
    * Various accessors (pointers/references) for Elem "i".
    */
-  virtual Elem * elem(const unsigned int i);
-  virtual const Elem * elem(const unsigned int i) const;
+  virtual Elem * elem(const dof_id_type i);
+  virtual const Elem * elem(const dof_id_type i) const;
 
   /**
    * Setter/getter for the _is_changed flag.
@@ -405,7 +405,7 @@ public:
    * Return a writable reference to a vector of node IDs that belong
    * to nodeset_id.
    */
-  std::vector<unsigned int> & getNodeList(boundary_id_type nodeset_id);
+  std::vector<dof_id_type> & getNodeList(boundary_id_type nodeset_id);
 
   /**
    * Add a new node to the mesh.  If there is already a node located at the point passed
@@ -491,12 +491,12 @@ public:
    * in the system.  It does this only for active local elements so the list will not be globally complete when
    * run in parallel!
    */
-  void buildPeriodicNodeMap(std::multimap<unsigned int, unsigned int> & periodic_node_map, unsigned int var_number, PeriodicBoundaries *pbs) const;
+  void buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & periodic_node_map, unsigned int var_number, PeriodicBoundaries *pbs) const;
 
   /**
    * This routine builds a datastructure of node ids organized by periodic boundary ids
    */
-  void buildPeriodicNodeSets(std::map<BoundaryID, std::set<unsigned int> > & periodic_node_sets, unsigned int var_number, PeriodicBoundaries *pbs) const;
+  void buildPeriodicNodeSets(std::map<BoundaryID, std::set<dof_id_type> > & periodic_node_sets, unsigned int var_number, PeriodicBoundaries *pbs) const;
 
   /**
    * Returns the width of the requested dimension
@@ -607,25 +607,25 @@ public:
    * Returns true if the requested node is in the list of boundary
    * nodes, false otherwise.
    */
-  bool isBoundaryNode(unsigned int node_id);
+  bool isBoundaryNode(dof_id_type node_id);
 
   /**
    * Returns true if the requested node is in the list of boundary
    * nodes for the specified boundary, false otherwise.
    */
-  bool isBoundaryNode(unsigned int node_id, BoundaryID bnd_id);
+  bool isBoundaryNode(dof_id_type node_id, BoundaryID bnd_id);
 
   /**
    * Returns true if the requested element is in the list of boundary
    * elements, false otherwise.
    */
-  bool isBoundaryElem(unsigned int elem_id);
+  bool isBoundaryElem(dof_id_type elem_id);
 
   /**
    * Returns true if the requested element is in the list of boundary
    * elements for the specified boundary, false otherwise.
    */
-  bool isBoundaryElem(unsigned int elem_id, BoundaryID bnd_id);
+  bool isBoundaryElem(dof_id_type elem_id, BoundaryID bnd_id);
 
   /**
    * Generate a unified error message if the underlying libMesh mesh
@@ -780,24 +780,24 @@ protected:
   typedef std::vector<BndNode *>::iterator             bnd_node_iterator_imp;
   typedef std::vector<BndNode *>::const_iterator const_bnd_node_iterator_imp;
   /// Map of sets of node IDs in each boundary
-  std::map<boundary_id_type, std::set<unsigned int> > _bnd_node_ids;
+  std::map<boundary_id_type, std::set<dof_id_type> > _bnd_node_ids;
 
   /// array of boundary elems
   std::vector<BndElement *> _bnd_elems;
   typedef std::vector<BndElement *>::iterator             bnd_elem_iterator_imp;
   typedef std::vector<BndElement *>::const_iterator const_bnd_elem_iterator_imp;
   /// Map of set of elem IDs connected to each boundary
-  std::map<boundary_id_type, std::set<unsigned int> > _bnd_elem_ids;
+  std::map<boundary_id_type, std::set<dof_id_type> > _bnd_elem_ids;
 
-  std::map<unsigned int, Node *> _quadrature_nodes;
-  std::map<unsigned int, std::map<unsigned int, std::map<unsigned int, Node *> > > _elem_to_side_to_qp_to_quadrature_nodes;
+  std::map<dof_id_type, Node *> _quadrature_nodes;
+  std::map<dof_id_type, std::map<unsigned int, std::map<dof_id_type, Node *> > > _elem_to_side_to_qp_to_quadrature_nodes;
   std::vector<BndNode> _extra_bnd_nodes;
 
   /// list of nodes that belongs to a specified block (domain)
-  std::map<unsigned int, std::set<SubdomainID> > _block_node_list;
+  std::map<dof_id_type, std::set<SubdomainID> > _block_node_list;
 
   /// list of nodes that belongs to a specified nodeset: indexing [nodeset_id] -> [array of node ids]
-  std::map<boundary_id_type, std::vector<unsigned int> > _node_set_nodes;
+  std::map<boundary_id_type, std::vector<dof_id_type> > _node_set_nodes;
 
   std::set<unsigned int> _ghosted_boundaries;
   std::vector<Real> _ghosted_boundaries_inflation;

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -133,7 +133,7 @@ public:
    * If not already created, creates a map from every node to all
    * elements to which they are created.
    */
-  std::map<unsigned int, std::vector<unsigned int> > & nodeToElemMap();
+  std::map<dof_id_type, std::vector<dof_id_type> > & nodeToElemMap();
 
   /**
    * These structs are required so that the bndNodes{Begin,End} and
@@ -166,7 +166,7 @@ public:
    * Calls BoundaryInfo::build_side_list().
    * Fills in the three passed vectors with list logical (element, side, id) tuples.
    */
-  void buildSideList(std::vector<unsigned int> & el, std::vector<unsigned short int> & sl, std::vector<boundary_id_type> & il);
+  void buildSideList(std::vector<dof_id_type> & el, std::vector<unsigned short int> & sl, std::vector<boundary_id_type> & il);
 
   /**
    * Calls BoundaryInfo::side_with_boundary_id().
@@ -263,7 +263,7 @@ public:
    * Clears the "semi-local" node list and rebuilds it.  Semi-local nodes
    * consist of all nodes that belong to local and ghost elements.
    */
-  void updateActiveSemiLocalNodeRange(std::set<unsigned int> & ghosted_elems);
+  void updateActiveSemiLocalNodeRange(std::set<dof_id_type> & ghosted_elems);
 
   /**
    * Returns true if the node is semi-local
@@ -754,7 +754,7 @@ protected:
   StoredRange<MooseMesh::const_bnd_elem_iterator, const BndElement*> * _bnd_elem_range;
 
   /// A map of all of the current nodes to the elements that they are connected to.
-  std::map<unsigned int, std::vector<unsigned int> > _node_to_elem_map;
+  std::map<dof_id_type, std::vector<dof_id_type> > _node_to_elem_map;
   bool _node_to_elem_map_built;
 
   /**

--- a/framework/include/outputs/PetscOutput.h
+++ b/framework/include/outputs/PetscOutput.h
@@ -57,10 +57,10 @@ protected:
   Real _norm;
 
   /// Current non-linear iteration returned from PETSc
-  int _nonlinear_iter;
+  PetscInt _nonlinear_iter;
 
   /// Current linear iteration returned from PETSc
-  int _linear_iter;
+  PetscInt _linear_iter;
 
 private:
 

--- a/framework/include/outputs/TopResidualDebugOutput.h
+++ b/framework/include/outputs/TopResidualDebugOutput.h
@@ -34,20 +34,23 @@ InputParameters validParams<TopResidualDebugOutput>();
 struct TopResidualDebugOutputTopResidualData
 {
   unsigned int _var;
-  unsigned int _nd;
+  dof_id_type _nd;
   Real _residual;
   bool _is_scalar;
 
+  TopResidualDebugOutputTopResidualData() :
+      _var(0),
+      _nd(0),
+      _residual(0.),
+      _is_scalar(false)
+    {}
 
-  TopResidualDebugOutputTopResidualData() { _var = 0; _nd = 0; _residual = 0.; _is_scalar = false; }
-
-  TopResidualDebugOutputTopResidualData(unsigned int var, unsigned int nd, Real residual, bool is_scalar = false)
-  {
-    _var = var;
-    _nd = nd;
-    _residual = residual;
-    _is_scalar = is_scalar;
-  }
+  TopResidualDebugOutputTopResidualData(unsigned int var, dof_id_type nd, Real residual, bool is_scalar = false) :
+      _var(var),
+      _nd(nd),
+      _residual(residual),
+      _is_scalar(is_scalar)
+    {}
 };
 
 /**

--- a/framework/include/postprocessors/NodalProxyMaxValue.h
+++ b/framework/include/postprocessors/NodalProxyMaxValue.h
@@ -39,7 +39,7 @@ public:
 protected:
 
   Real _value;
-  unsigned int _node_id;
+  dof_id_type _node_id;
 };
 
 #endif //NODALPROXYMAXVALUE_H

--- a/framework/include/transfers/MultiAppNearestNodeTransfer.h
+++ b/framework/include/transfers/MultiAppNearestNodeTransfer.h
@@ -58,10 +58,10 @@ protected:
   bool _fixed_meshes;
 
   /// Used to cache nodes
-  std::map<unsigned int, Node *> _node_map;
+  std::map<dof_id_type, Node *> _node_map;
 
   /// Used to cache distances
-  std::map<unsigned int, Real> _distance_map;
+  std::map<dof_id_type, Real> _distance_map;
 };
 
 #endif /* MULTIAPPVARIABLEVALUESAMPLEPOSTPROCESSORTRANSFER_H */

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -46,7 +46,7 @@ typedef std::vector<Real>        VectorPostprocessorValue;
 typedef boundary_id_type         BoundaryID;
 typedef subdomain_id_type        SubdomainID;
 
-typedef StoredRange<std::vector<unsigned int>::iterator, unsigned int> NodeIdRange;
+typedef StoredRange<std::vector<dof_id_type>::iterator, dof_id_type> NodeIdRange;
 typedef StoredRange<std::vector<const Elem *>::iterator, const Elem *> ConstElemPointerRange;
 
 namespace Moose

--- a/framework/src/auxkernels/AuxNodalScalarKernel.C
+++ b/framework/src/auxkernels/AuxNodalScalarKernel.C
@@ -19,7 +19,7 @@ template<>
 InputParameters validParams<AuxNodalScalarKernel>()
 {
   InputParameters params = validParams<AuxScalarKernel>();
-  params.addRequiredParam<std::vector<unsigned int> >("nodes", "Node ids");
+  params.addRequiredParam<std::vector<dof_id_type> >("nodes", "Node ids");
   return params;
 }
 
@@ -27,7 +27,7 @@ AuxNodalScalarKernel::AuxNodalScalarKernel(const std::string & name, InputParame
     AuxScalarKernel(name, parameters),
     Coupleable(parameters, true),
     MooseVariableDependencyInterface(),
-    _node_ids(getParam<std::vector<unsigned int> >("nodes"))
+    _node_ids(getParam<std::vector<dof_id_type> >("nodes"))
 {
   // Fill in the MooseVariable dependencies
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -954,7 +954,11 @@ Assembly::addResidualBlock(NumericVector<Number> & residual, DenseVector<Number>
 }
 
 void
-Assembly::cacheResidualBlock(std::vector<Real> & cached_residual_values, std::vector<unsigned int> & cached_residual_rows, DenseVector<Number> & res_block, std::vector<dof_id_type> & dof_indices, Real scaling_factor)
+Assembly::cacheResidualBlock(std::vector<Real> & cached_residual_values,
+                             std::vector<dof_id_type> & cached_residual_rows,
+                             DenseVector<Number> & res_block,
+                             std::vector<dof_id_type> & dof_indices,
+                             Real scaling_factor)
 {
   if (dof_indices.size() > 0 && res_block.size())
   {
@@ -1051,7 +1055,7 @@ void
 Assembly::addCachedResidual(NumericVector<Number> & residual, Moose::KernelType type)
 {
   std::vector<Real> & cached_residual_values = _cached_residual_values[type];
-  std::vector<unsigned int> & cached_residual_rows = _cached_residual_rows[type];
+  std::vector<dof_id_type> & cached_residual_rows = _cached_residual_rows[type];
 
   mooseAssert(cached_residual_values.size() == cached_residual_rows.size(), "Number of cached residuals and number of rows must match!");
 

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -245,8 +245,9 @@ Assembly::setNeighborQRule(QBase * qrule, unsigned int dim)
 void
 Assembly::invalidateCache()
 {
-  std::map<unsigned int, ElementFEShapeData * >::iterator it = _element_fe_shape_data_cache.begin();
-  std::map<unsigned int, ElementFEShapeData * >::iterator end = _element_fe_shape_data_cache.end();
+  std::map<dof_id_type, ElementFEShapeData * >::iterator
+    it  = _element_fe_shape_data_cache.begin(),
+    end = _element_fe_shape_data_cache.end();
 
   for (; it!=end; ++it)
     it->second->_invalidated = true;

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -388,8 +388,8 @@ AuxiliarySystem::computeElementalVars(ExecFlagType type)
 
 void
 AuxiliarySystem::augmentSparsity(SparsityPattern::Graph & /*sparsity*/,
-                                 std::vector<unsigned int> & /*n_nz*/,
-                                 std::vector<unsigned int> & /*n_oz*/)
+                                 std::vector<dof_id_type> & /*n_nz*/,
+                                 std::vector<dof_id_type> & /*n_oz*/)
 {
 }
 

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -139,8 +139,9 @@ ComputeIndicatorThread::onInternalSide(const Elem *elem, unsigned int side)
   const Elem * neighbor = elem->neighbor(side);
 
   // Get the global id of the element and the neighbor
-  const unsigned int elem_id = elem->id();
-  const unsigned int neighbor_id = neighbor->id();
+  const dof_id_type
+    elem_id = elem->id(),
+    neighbor_id = neighbor->id();
 
   if ((neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) || (neighbor->level() < elem->level()))
   {

--- a/framework/src/base/ComputeJacobianBlocksThread.C
+++ b/framework/src/base/ComputeJacobianBlocksThread.C
@@ -42,7 +42,7 @@ ComputeJacobianBlocksThread::~ComputeJacobianBlocksThread()
 void
 ComputeJacobianBlocksThread::postElement(const Elem * elem)
 {
-  std::vector<unsigned int> dof_indices; // Do this out here to avoid creating and destroying it thousands of times
+  std::vector<dof_id_type> dof_indices; // Do this out here to avoid creating and destroying it thousands of times
 
   Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
 

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -198,8 +198,9 @@ ComputeJacobianThread::onInternalSide(const Elem *elem, unsigned int side)
   const Elem * neighbor = elem->neighbor(side);
 
   // Get the global id of the element and the neighbor
-  const unsigned int elem_id = elem->id();
-  const unsigned int neighbor_id = neighbor->id();
+  const dof_id_type
+    elem_id = elem->id(),
+    neighbor_id = neighbor->id();
 
   if ((neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) || (neighbor->level() < elem->level()))
   {

--- a/framework/src/base/ComputeMaterialsObjectThread.C
+++ b/framework/src/base/ComputeMaterialsObjectThread.C
@@ -130,8 +130,9 @@ ComputeMaterialsObjectThread::onInternalSide(const Elem *elem, unsigned int side
 
     const Elem * neighbor = elem->neighbor(side);
     unsigned int neighbor_side = neighbor->which_neighbor_am_i(_assembly[_tid]->elem());
-    const unsigned int elem_id = elem->id();
-    const unsigned int neighbor_id = neighbor->id();
+    const dof_id_type
+      elem_id = elem->id(),
+      neighbor_id = neighbor->id();
 
     if (_has_bnd_stateful_props && ((neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) || (neighbor->level() < elem->level())))
     {

--- a/framework/src/base/ComputeResidualThread.C
+++ b/framework/src/base/ComputeResidualThread.C
@@ -160,8 +160,9 @@ ComputeResidualThread::onInternalSide(const Elem *elem, unsigned int side)
   const Elem * neighbor = elem->neighbor(side);
 
   // Get the global id of the element and the neighbor
-  const unsigned int elem_id = elem->id();
-  const unsigned int neighbor_id = neighbor->id();
+  const dof_id_type
+    elem_id = elem->id(),
+    neighbor_id = neighbor->id();
 
   if ((neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) || (neighbor->level() < elem->level()))
   {

--- a/framework/src/base/ComputeUserObjectsThread.C
+++ b/framework/src/base/ComputeUserObjectsThread.C
@@ -214,8 +214,9 @@ ComputeUserObjectsThread::onInternalSide(const Elem *elem, unsigned int side)
   const Elem * neighbor = elem->neighbor(side);
 
   // Get the global id of the element and the neighbor
-  const unsigned int elem_id = elem->id();
-  const unsigned int neighbor_id = neighbor->id();
+  const dof_id_type
+    elem_id = elem->id(),
+    neighbor_id = neighbor->id();
 
   // Only perform execute if there are objects
   if (global_uo.size() > 0 || block_uo.size() > 0)

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -302,7 +302,7 @@ DisplacedProblem::reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID
 }
 
 void
-DisplacedProblem::reinitNodes(const std::vector<unsigned int> & nodes, THREAD_ID tid)
+DisplacedProblem::reinitNodes(const std::vector<dof_id_type> & nodes, THREAD_ID tid)
 {
   _displaced_nl.reinitNodes(nodes, tid);
   _displaced_aux.reinitNodes(nodes, tid);

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3769,15 +3769,15 @@ FEProblem::getVariableNames()
 
 MooseNonlinearConvergenceReason
 FEProblem::checkNonlinearConvergence(std::string &msg,
-                                     const int it,
+                                     const PetscInt it,
                                      const Real xnorm,
                                      const Real snorm,
                                      const Real fnorm,
                                      const Real rtol,
                                      const Real stol,
                                      const Real abstol,
-                                     const int nfuncs,
-                                     const int max_funcs,
+                                     const PetscInt nfuncs,
+                                     const PetscInt max_funcs,
                                      const Real ref_resid,
                                      const Real div_threshold)
 {
@@ -3823,7 +3823,7 @@ FEProblem::checkNonlinearConvergence(std::string &msg,
   }
 
   system._last_nl_rnorm = fnorm;
-  system._current_nl_its = it;
+  system._current_nl_its = static_cast<unsigned int>(it);
 
   msg = oss.str();
 
@@ -3834,12 +3834,12 @@ FEProblem::checkNonlinearConvergence(std::string &msg,
 
 MooseLinearConvergenceReason
 FEProblem::checkLinearConvergence(std::string & /*msg*/,
-                                  const int n,
+                                  const PetscInt n,
                                   const Real rnorm,
                                   const Real /*rtol*/,
                                   const Real /*atol*/,
                                   const Real /*dtol*/,
-                                  const int maxits)
+                                  const PetscInt maxits)
 {
   // We initialize the reason to something that basically means MOOSE
   // has not made a decision on convergence yet.
@@ -3870,7 +3870,7 @@ FEProblem::checkLinearConvergence(std::string & /*msg*/,
   // If either of our convergence criteria is met, store the number of linear
   // iterations in the System.
   if (reason == MOOSE_CONVERGED_ITS || reason == MOOSE_CONVERGED_RTOL)
-    system._current_l_its.push_back(n);
+    system._current_l_its.push_back(static_cast<unsigned int>(n));
 
   return reason;
 }

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -1142,7 +1142,7 @@ MooseVariable::computeNeighborValues()
   RealGradient dphi_local;
   RealTensor d2phi_local;
 
-  for (dof_id_type i=0; i < num_dofs; ++i)
+  for (unsigned int i=0; i < num_dofs; ++i)
   {
     idx = _dof_indices_neighbor[i];
     soln_local = current_solution(idx);

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -48,7 +48,7 @@ MooseVariableScalar::reinit()
 
   _dof_map.SCALAR_dof_indices(_dof_indices, _var_num);
 
-  dof_id_type n = _dof_indices.size();
+  unsigned int n = _dof_indices.size();
   _u.resize(n);
   _u_old.resize(n);
   _u_older.resize(n);

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1269,7 +1269,7 @@ NonlinearSystem::getNodeDofs(unsigned int node_id, std::vector<dof_id_type> & do
 }
 
 void
-NonlinearSystem::findImplicitGeometricCouplingEntries(GeometricSearchData & geom_search_data, std::map<unsigned int, std::vector<unsigned int> > & graph)
+NonlinearSystem::findImplicitGeometricCouplingEntries(GeometricSearchData & geom_search_data, std::map<dof_id_type, std::vector<dof_id_type> > & graph)
 {
   std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *> & nearest_node_locators = geom_search_data._nearest_node_locators;
 
@@ -2023,8 +2023,8 @@ NonlinearSystem::residualGhosted()
 
 void
 NonlinearSystem::augmentSparsity(SparsityPattern::Graph & sparsity,
-                                 std::vector<unsigned int> & n_nz,
-                                 std::vector<unsigned int> & n_oz)
+                                 std::vector<dof_id_type> & n_nz,
+                                 std::vector<dof_id_type> & n_oz)
 {
 
   if (_add_implicit_geometric_coupling_entries_to_jacobian)

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1351,16 +1351,16 @@ NonlinearSystem::findImplicitGeometricCouplingEntries(GeometricSearchData & geom
     getNodeDofs(master_node_id, master_dofs);
 
     std::vector<dof_id_type> slave_dofs;
-    std::vector<unsigned int> & slave_node_ids = nc->getSlaveNodeId();
-    for (std::vector<unsigned int>::iterator si = slave_node_ids.begin(); si != slave_node_ids.end(); si++)
+    std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
+    for (std::vector<dof_id_type>::iterator si = slave_node_ids.begin(); si != slave_node_ids.end(); si++)
       getNodeDofs(*si, slave_dofs);
 
-    for (std::vector<unsigned int>::iterator mi = master_dofs.begin(); mi != master_dofs.end(); mi++)
+    for (std::vector<dof_id_type>::iterator mi = master_dofs.begin(); mi != master_dofs.end(); mi++)
     {
-      unsigned int master_id = *mi;
-      for (std::vector<unsigned int>::iterator si = slave_dofs.begin(); si != slave_dofs.end(); si++)
+      dof_id_type master_id = *mi;
+      for (std::vector<dof_id_type>::iterator si = slave_dofs.begin(); si != slave_dofs.end(); si++)
       {
-        unsigned int slave_id = *si;
+        dof_id_type slave_id = *si;
         graph[master_id].push_back(slave_id);
         graph[slave_id].push_back(master_id);
       }

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -35,8 +35,8 @@ void extraSendList(std::vector<dof_id_type> & send_list, void * context)
 
 /// Free function used for a libMesh callback
 void extraSparsity(SparsityPattern::Graph & sparsity,
-                   std::vector<unsigned int> & n_nz,
-                   std::vector<unsigned int> & n_oz,
+                   std::vector<dof_id_type> & n_nz,
+                   std::vector<dof_id_type> & n_oz,
                    void * context)
 {
   SystemBase * sys = static_cast<SystemBase *>(context);

--- a/framework/src/executioners/CoupledExecutioner.C
+++ b/framework/src/executioners/CoupledExecutioner.C
@@ -199,21 +199,21 @@ CoupledExecutioner::projectVariables(FEProblem & fep)
 
     // get dof indices for source variable
     unsigned int src_vn = src_sys.system().variable_number(src_mv.name());
-    std::set<unsigned int> src_var_indices;
+    std::set<dof_id_type> src_var_indices;
     src_sys.system().local_dof_indices(src_vn, src_var_indices);
 
     // get dof indices for destination variable
     unsigned int dest_vn = dest_sys.system().variable_number(dest_mv.name());
-    std::set<unsigned int> dest_var_indices;
+    std::set<dof_id_type> dest_var_indices;
     dest_sys.system().local_dof_indices(dest_vn, dest_var_indices);
 
     // NOTE: this is not very robust code. It relies on the same node numbering and that inserting values in the set in the same order will result
     // in a std::set with the same ordering, i.e. items in src_var_indices and dest_var_indices correspond to each other.
 
     // copy the values from src solution vector to dest solution vector
-    std::set<unsigned int>::iterator src_it = src_var_indices.begin();
-    std::set<unsigned int>::iterator src_it_end = src_var_indices.end();
-    std::set<unsigned int>::iterator dest_it = dest_var_indices.begin();
+    std::set<dof_id_type>::iterator src_it = src_var_indices.begin();
+    std::set<dof_id_type>::iterator src_it_end = src_var_indices.end();
+    std::set<dof_id_type>::iterator dest_it = dest_var_indices.begin();
     for (; src_it != src_it_end; ++src_it, ++dest_it)
       dest_sys.solution().set(*dest_it, src_sys.solution()(*src_it));
 

--- a/framework/src/functions/PiecewiseMultilinear.C
+++ b/framework/src/functions/PiecewiseMultilinear.C
@@ -146,8 +146,13 @@ PiecewiseMultilinear::getNeighborIndices(std::vector<Real> in_arr, Real x, unsig
   }
   else
   {
-    std::vector<double>::iterator up = std::lower_bound(in_arr.begin(), in_arr.end(), x); // returns up which points at the first element in inArr that is not less than x
-    upper_x = std::distance(in_arr.begin(), up);
+    // returns up which points at the first element in inArr that is not less than x
+    std::vector<double>::iterator up = std::lower_bound(in_arr.begin(), in_arr.end(), x);
+
+    // std::distance returns std::difference_type, which can be negative in theory, but
+    // in this context will always be >=0.  Therefore the explicit cast is just to shut
+    // the compiler up.
+    upper_x = static_cast<unsigned int>(std::distance(in_arr.begin(), up));
     if (in_arr[upper_x] == x)
       lower_x = upper_x;
     else

--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -118,7 +118,7 @@ NearestNodeLocator::findNodes()
     {
       const BndNode * bnode = *nd;
       BoundaryID boundary_id = bnode->_bnd_id;
-      unsigned int node_id = bnode->_node->id();
+      dof_id_type node_id = bnode->_node->id();
 
       // If we have a BB only consider saving this node if it's in our inflated BB
       if (!my_inflated_box || (my_inflated_box->contains_point(*bnode->_node)))
@@ -184,14 +184,14 @@ NearestNodeLocator::reinit()
 }
 
 Real
-NearestNodeLocator::distance(unsigned int node_id)
+NearestNodeLocator::distance(dof_id_type node_id)
 {
   return _nearest_node_info[node_id]._distance;
 }
 
 
 const Node *
-NearestNodeLocator::nearestNode(unsigned int node_id)
+NearestNodeLocator::nearestNode(dof_id_type node_id)
 {
   return _nearest_node_info[node_id]._nearest_node;
 }

--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -78,8 +78,8 @@ NearestNodeLocator::findNodes()
     // We only keep the ones that are either on this processor or are likely
     // to interact with elements on this processor (ie nodes owned by this processor
     // are in the "neighborhood" of the slave node
-    std::vector<unsigned int> trial_slave_nodes;
-    std::vector<unsigned int> trial_master_nodes;
+    std::vector<dof_id_type> trial_slave_nodes;
+    std::vector<dof_id_type> trial_master_nodes;
 
 
     // Build a bounding box.  No reason to consider nodes outside of our inflated BB
@@ -133,7 +133,7 @@ NearestNodeLocator::findNodes()
     // don't need the BB anymore
     delete my_inflated_box;
 
-    std::map<unsigned int, std::vector<unsigned int> > & node_to_elem_map = _mesh.nodeToElemMap();
+    std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToElemMap();
 
     NodeIdRange trial_slave_node_range(trial_slave_nodes.begin(), trial_slave_nodes.end(), 1);
 
@@ -144,7 +144,7 @@ NearestNodeLocator::findNodes()
     _slave_nodes = snt._slave_nodes;
     _neighbor_nodes = snt._neighbor_nodes;
 
-    for (std::set<unsigned int>::iterator it = snt._ghosted_elems.begin();
+    for (std::set<dof_id_type>::iterator it = snt._ghosted_elems.begin();
         it != snt._ghosted_elems.end();
         ++it)
       _subproblem.addGhostedElem(*it);

--- a/framework/src/geomsearch/NearestNodeThread.C
+++ b/framework/src/geomsearch/NearestNodeThread.C
@@ -43,7 +43,7 @@ NearestNodeThread::operator() (const NodeIdRange & range)
 {
   for (NodeIdRange::const_iterator nd = range.begin() ; nd != range.end(); ++nd)
   {
-    unsigned int node_id = *nd;
+    dof_id_type node_id = *nd;
 
     const Node & node = _mesh.node(node_id);
 

--- a/framework/src/geomsearch/NearestNodeThread.C
+++ b/framework/src/geomsearch/NearestNodeThread.C
@@ -18,7 +18,7 @@
 #include "libmesh/threads.h"
 
 NearestNodeThread::NearestNodeThread(const MooseMesh & mesh,
-                                     std::map<unsigned int, std::vector<unsigned int> > & neighbor_nodes) :
+                                     std::map<dof_id_type, std::vector<dof_id_type> > & neighbor_nodes) :
   _max_patch_percentage(0.0),
   _mesh(mesh),
   _neighbor_nodes(neighbor_nodes)
@@ -50,7 +50,7 @@ NearestNodeThread::operator() (const NodeIdRange & range)
     const Node * closest_node = NULL;
     Real closest_distance = std::numeric_limits<Real>::max();
 
-    const std::vector<unsigned int> & neighbor_nodes = _neighbor_nodes[node_id];
+    const std::vector<dof_id_type> & neighbor_nodes = _neighbor_nodes[node_id];
 
     unsigned int n_neighbor_nodes = neighbor_nodes.size();
 

--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -88,9 +88,9 @@ PenetrationLocator::detectPenetration()
   Moose::perf_log.push("detectPenetration()","Solve");
 
   // Data structures to hold the element boundary information
-  std::vector< unsigned int > elem_list;
-  std::vector< unsigned short int > side_list;
-  std::vector< short int > id_list;
+  std::vector<dof_id_type> elem_list;
+  std::vector<unsigned short int> side_list;
+  std::vector<boundary_id_type> id_list;
 
   // Retrieve the Element Boundary data structures from the mesh
   _mesh.buildSideList(elem_list, side_list, id_list);

--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -39,11 +39,11 @@ PenetrationLocator::PenetrationLocator(SubProblem & subproblem, GeometricSearchD
     _slave_boundary(slave_id),
     _fe_type(order),
     _nearest_node(nearest_node),
-    _penetration_info(declareRestartableDataWithContext<std::map<unsigned int, PenetrationInfo *> >("penetration_info", &_mesh)),
-    _has_penetrated(declareRestartableData<std::set<unsigned int> >("has_penetrated")),
-    _locked_this_step(declareRestartableData<std::map<unsigned int, unsigned> >("locked_this_step")),
-    _unlocked_this_step(declareRestartableData<std::map<unsigned int, unsigned> >("unlocked_this_step")),
-    _lagrange_multiplier(declareRestartableData<std::map<unsigned int, Real> >("lagrange_multiplier")),
+    _penetration_info(declareRestartableDataWithContext<std::map<dof_id_type, PenetrationInfo *> >("penetration_info", &_mesh)),
+    _has_penetrated(declareRestartableData<std::set<dof_id_type> >("has_penetrated")),
+    _locked_this_step(declareRestartableData<std::map<dof_id_type, unsigned int> >("locked_this_step")),
+    _unlocked_this_step(declareRestartableData<std::map<dof_id_type, unsigned int> >("unlocked_this_step")),
+    _lagrange_multiplier(declareRestartableData<std::map<dof_id_type, Real> >("lagrange_multiplier")),
     _update_location(declareRestartableData<bool>("update_location", true)),
     _tangential_tolerance(0.0),
     _do_normal_smoothing(false),
@@ -78,7 +78,7 @@ PenetrationLocator::~PenetrationLocator()
     for (unsigned int dim = 0; dim < _fe[i].size(); dim++)
       delete _fe[i][dim];
 
-  for (std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_info.begin(); it != _penetration_info.end(); ++it)
+  for (std::map<dof_id_type, PenetrationInfo *>::iterator it = _penetration_info.begin(); it != _penetration_info.end(); ++it)
     delete it->second;
 }
 
@@ -134,7 +134,7 @@ PenetrationLocator::reinit()
 }
 
 Real
-PenetrationLocator::penetrationDistance(unsigned int node_id)
+PenetrationLocator::penetrationDistance(dof_id_type node_id)
 {
   PenetrationInfo * info = _penetration_info[node_id];
 
@@ -146,9 +146,9 @@ PenetrationLocator::penetrationDistance(unsigned int node_id)
 
 
 RealVectorValue
-PenetrationLocator::penetrationNormal(unsigned int node_id)
+PenetrationLocator::penetrationNormal(dof_id_type node_id)
 {
-  std::map<unsigned int, PenetrationInfo *>::const_iterator found_it( _penetration_info.find(node_id) );
+  std::map<dof_id_type, PenetrationInfo *>::const_iterator found_it = _penetration_info.find(node_id);
 
   if (found_it != _penetration_info.end())
     return found_it->second->_normal;
@@ -191,8 +191,8 @@ PenetrationLocator::setNormalSmoothingMethod(std::string nsmString)
 void
 PenetrationLocator::saveContactStateVars()
 {
-  std::map<unsigned int, PenetrationInfo *>::iterator it( _penetration_info.begin() );
-  const std::map<unsigned int, PenetrationInfo *>::iterator it_end( _penetration_info.end() );
+  std::map<dof_id_type, PenetrationInfo *>::iterator it = _penetration_info.begin();
+  const std::map<dof_id_type, PenetrationInfo *>::iterator it_end = _penetration_info.end();
   for ( ; it != it_end; ++it )
   {
     if (it->second != NULL)

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -31,7 +31,7 @@ PenetrationThread::PenetrationThread(SubProblem & subproblem,
                                      const MooseMesh & mesh,
                                      BoundaryID master_boundary,
                                      BoundaryID slave_boundary,
-                                     std::map<unsigned int, PenetrationInfo *> & penetration_info,
+                                     std::map<dof_id_type, PenetrationInfo *> & penetration_info,
                                      bool update_location,
                                      Real tangential_tolerance,
                                      bool do_normal_smoothing,
@@ -181,7 +181,7 @@ PenetrationThread::operator() (const NodeIdRange & range)
 
       for (unsigned int j=0; j<closest_elems.size(); j++)
       {
-        unsigned int elem_id = closest_elems[j];
+        dof_id_type elem_id = closest_elems[j];
         const Elem * elem = _mesh.elem(elem_id);
 
         std::vector<PenetrationInfo*> thisElemInfo;
@@ -1257,7 +1257,7 @@ PenetrationThread::getSmoothingFacesAndWeights(PenetrationInfo* info,
 {
   const Elem* side = info->_side;
   const Point& p=info->_closest_point_ref;
-  std::set<unsigned int> elems_to_exclude;
+  std::set<dof_id_type> elems_to_exclude;
   elems_to_exclude.insert(info->_elem->id());
   const Node* slave_node = info->_node;
 
@@ -1483,7 +1483,7 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
 
 void
 PenetrationThread::getInfoForFacesWithCommonNodes(const Node *slave_node,
-                                                  const std::set<unsigned int> &elems_to_exclude,
+                                                  const std::set<dof_id_type> &elems_to_exclude,
                                                   const std::vector<const Node*> edge_nodes,
                                                   std::vector<PenetrationInfo*> &face_info_comm_edge,
                                                   std::vector<PenetrationInfo*> & p_info)

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -40,10 +40,10 @@ PenetrationThread::PenetrationThread(SubProblem & subproblem,
                                      std::vector<std::vector<FEBase *> > & fes,
                                      FEType & fe_type,
                                      NearestNodeLocator & nearest_node,
-                                     std::map<unsigned int, std::vector<unsigned int> > & node_to_elem_map,
-                                     std::vector< unsigned int > & elem_list,
-                                     std::vector< unsigned short int > & side_list,
-                                     std::vector< short int > & id_list) :
+                                     std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
+                                     std::vector<dof_id_type> & elem_list,
+                                     std::vector<unsigned short int> & side_list,
+                                     std::vector<boundary_id_type> & id_list) :
   _subproblem(subproblem),
   _mesh(mesh),
   _master_boundary(master_boundary),
@@ -177,7 +177,7 @@ PenetrationThread::operator() (const NodeIdRange & range)
     if (!info_set)
     {
       const Node * closest_node = _nearest_node.nearestNode(node.id());
-      std::vector<unsigned int> & closest_elems = _node_to_elem_map[closest_node->id()];
+      std::vector<dof_id_type> & closest_elems = _node_to_elem_map[closest_node->id()];
 
       for (unsigned int j=0; j<closest_elems.size(); j++)
       {
@@ -766,7 +766,7 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
   for (unsigned int i(0); i<edge_nodes.size(); ++i)
   {
     unsigned int local_index = side->get_node_index(edge_nodes[i]);
-    if (local_index == Node::invalid_id)
+    if (local_index == libMesh::invalid_uint)
       mooseError("Side does not contain node");
     local_node_indices.push_back(local_index);
   }
@@ -1489,7 +1489,7 @@ PenetrationThread::getInfoForFacesWithCommonNodes(const Node *slave_node,
                                                   std::vector<PenetrationInfo*> & p_info)
 {
   //elems connected to a node on this edge, find one that has the same corners as this, and is not the current elem
-  std::vector<unsigned int> & elems_connected_to_node = _node_to_elem_map[edge_nodes[0]->id()]; //just need one of the nodes
+  std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[edge_nodes[0]->id()]; //just need one of the nodes
 
   std::vector<const Elem*> elems_connected_to_edge;
 

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -68,7 +68,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
 
   for (NodeIdRange::const_iterator nd = range.begin() ; nd != range.end(); ++nd)
   {
-    unsigned int node_id = *nd;
+    dof_id_type node_id = *nd;
 
     const Node & node = *_mesh.nodePtr(node_id);
 
@@ -79,7 +79,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
     // Get a list, in descending order of distance, of master nodes in relation to this node
     for (unsigned int k=0; k<n_master_nodes; k++)
     {
-      unsigned int master_id = _trial_master_nodes[k];
+      dof_id_type master_id = _trial_master_nodes[k];
       const Node * cur_node = &_mesh.node(master_id);
       Real distance = ((*cur_node) - node).size();
 
@@ -129,7 +129,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       { // Now check the neighbor nodes to see if we own any of them
         for (unsigned int neighbor_it=0; neighbor_it < neighbor_nodes.size(); neighbor_it++)
         {
-          unsigned int neighbor_node_id = neighbor_nodes[neighbor_it];
+          dof_id_type neighbor_node_id = neighbor_nodes[neighbor_it];
 
           if (_mesh.node(neighbor_node_id).processor_id() == processor_id)
             need_to_track = true;

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -37,8 +37,8 @@ public:
 };
 
 SlaveNeighborhoodThread::SlaveNeighborhoodThread(const MooseMesh & mesh,
-                                                 const std::vector<unsigned int> & trial_master_nodes,
-                                                 std::map<unsigned int, std::vector<unsigned int> > & node_to_elem_map,
+                                                 const std::vector<dof_id_type> & trial_master_nodes,
+                                                 std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
                                                  const unsigned int patch_size) :
   _mesh(mesh),
   _trial_master_nodes(trial_master_nodes),
@@ -86,7 +86,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       neighbors.push(std::make_pair(master_id, distance));
     }
 
-    std::vector<unsigned int> neighbor_nodes;
+    std::vector<dof_id_type> neighbor_nodes;
 
     unsigned int patch_size = std::min(_patch_size, static_cast<unsigned int>(neighbors.size()));
     neighbor_nodes.resize(patch_size);
@@ -115,7 +115,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
     else
     {
       { // See if we own any of the elements connected to the slave node
-        const std::vector<unsigned int> & elems_connected_to_node = _node_to_elem_map[node_id];
+        const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[node_id];
 
         for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
           if (_mesh.elem(elems_connected_to_node[elem_id_it])->processor_id() == processor_id)
@@ -135,7 +135,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
             need_to_track = true;
           else // Now see if we own any of the elements connected to the neighbor nodes
           {
-            const std::vector<unsigned int> & elems_connected_to_node = _node_to_elem_map[neighbor_node_id];
+            const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[neighbor_node_id];
 
             for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
               if (_mesh.elem(elems_connected_to_node[elem_id_it])->processor_id() == processor_id)
@@ -160,7 +160,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       _neighbor_nodes[node_id] = neighbor_nodes;
 
       { // Add the elements connected to the slave node to the ghosted list
-        const std::vector<unsigned int> & elems_connected_to_node = _node_to_elem_map[node_id];
+        const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[node_id];
 
         for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
           _ghosted_elems.insert(elems_connected_to_node[elem_id_it]);
@@ -169,7 +169,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       // Now add elements connected to the neighbor nodes to the ghosted list
       for (unsigned int neighbor_it=0; neighbor_it < neighbor_nodes.size(); neighbor_it++)
       {
-        const std::vector<unsigned int> & elems_connected_to_node = _node_to_elem_map[neighbor_nodes[neighbor_it]];
+        const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[neighbor_nodes[neighbor_it]];
 
         for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
           _ghosted_elems.insert(elems_connected_to_node[elem_id_it]);

--- a/framework/src/ics/InitialCondition.C
+++ b/framework/src/ics/InitialCondition.C
@@ -104,7 +104,7 @@ InitialCondition::compute()
   // The global DOF indices
   std::vector<dof_id_type> dof_indices;
   // Side/edge DOF indices
-  std::vector<dof_id_type> side_dofs;
+  std::vector<unsigned int> side_dofs;
 
   // Get FE objects of the appropriate type
   // We cannot use the FE object in Assembly, since the following code is messing with the quadrature rules

--- a/framework/src/ics/InitialCondition.C
+++ b/framework/src/ics/InitialCondition.C
@@ -150,7 +150,8 @@ InitialCondition::compute()
   std::vector<int> free_dof(n_dofs, 0);
 
   // Zero the interpolated values
-  Ue.resize (n_dofs); Ue.zero();
+  Ue.resize (n_dofs);
+  Ue.zero();
 
   // In general, we need a series of
   // projections to ensure a unique and continuous
@@ -162,12 +163,12 @@ InitialCondition::compute()
   _fe_problem.sizeZeroes(n_nodes, _tid);
 
   // Interpolate node values first
-  dof_id_type current_dof = 0;
+  unsigned int current_dof = 0;
   for (unsigned int n = 0; n != n_nodes; ++n)
   {
     // FIXME: this should go through the DofMap,
     // not duplicate dof_indices code badly!
-    const dof_id_type nc = FEInterface::n_dofs_at_node (dim, fe_type, elem_type, n);
+    const unsigned int nc = FEInterface::n_dofs_at_node (dim, fe_type, elem_type, n);
     if (!_current_elem->is_vertex(n))
     {
       current_dof += nc;
@@ -326,13 +327,13 @@ InitialCondition::compute()
         // Form edge projection matrix
         for (unsigned int sidei = 0, freei = 0; sidei != side_dofs.size(); ++sidei)
         {
-          dof_id_type i = side_dofs[sidei];
+          unsigned int i = side_dofs[sidei];
           // fixed DoFs aren't test functions
           if (dof_is_fixed[i])
             continue;
           for (unsigned int sidej = 0, freej = 0; sidej != side_dofs.size(); ++sidej)
           {
-            dof_id_type j = side_dofs[sidej];
+            unsigned int j = side_dofs[sidej];
             if (dof_is_fixed[j])
               Fe(freei) -= phi[i][qp] * phi[j][qp] * JxW[qp] * Ue(j);
             else
@@ -407,13 +408,13 @@ InitialCondition::compute()
         // Form side projection matrix
         for (unsigned int sidei = 0, freei = 0; sidei != side_dofs.size(); ++sidei)
         {
-          dof_id_type i = side_dofs[sidei];
+          unsigned int i = side_dofs[sidei];
           // fixed DoFs aren't test functions
           if (dof_is_fixed[i])
             continue;
           for (unsigned int sidej = 0, freej = 0; sidej != side_dofs.size(); ++sidej)
           {
-            dof_id_type j = side_dofs[sidej];
+            unsigned int j = side_dofs[sidej];
             if (dof_is_fixed[j])
               Fe(freei) -= phi[i][qp] * phi[j][qp] * JxW[qp] * Ue(j);
             else

--- a/framework/src/kernels/NodalEqualValueConstraint.C
+++ b/framework/src/kernels/NodalEqualValueConstraint.C
@@ -26,7 +26,7 @@ NodalEqualValueConstraint::NodalEqualValueConstraint(const std::string & name, I
     NodalScalarKernel(name, parameters)
 {
   if (_node_ids.size() != 2)
-    mooseError(name << ": The number of nodes has to be 2.");
+    mooseError(name << ": The number of nodes has to be 2, but it is " << _node_ids.size() << ".");
 
   unsigned int n = coupledComponents("var");
   _value.resize(n);

--- a/framework/src/kernels/NodalScalarKernel.C
+++ b/framework/src/kernels/NodalScalarKernel.C
@@ -19,7 +19,7 @@ template<>
 InputParameters validParams<NodalScalarKernel>()
 {
   InputParameters params = validParams<ScalarKernel>();
-  params.addRequiredParam<std::vector<unsigned int> >("nodes", "Node ids");
+  params.addRequiredParam<std::vector<dof_id_type> >("nodes", "Node ids");
   return params;
 }
 
@@ -27,7 +27,7 @@ NodalScalarKernel::NodalScalarKernel(const std::string & name, InputParameters p
     ScalarKernel(name, parameters),
     Coupleable(parameters, true),
     MooseVariableDependencyInterface(),
-    _node_ids(getParam<std::vector<unsigned int> >("nodes"))
+    _node_ids(getParam<std::vector<dof_id_type> >("nodes"))
 {
   // Fill in the MooseVariable dependencies
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -283,10 +283,10 @@ MooseMesh::freeBndNodes()
   for (std::vector<BndNode *>::iterator it = _bnd_nodes.begin(); it != _bnd_nodes.end(); ++it)
     delete (*it);
 
-  for (std::map<boundary_id_type, std::vector<unsigned int> >::iterator it = _node_set_nodes.begin(); it != _node_set_nodes.end(); ++it)
+  for (std::map<boundary_id_type, std::vector<dof_id_type> >::iterator it = _node_set_nodes.begin(); it != _node_set_nodes.end(); ++it)
     it->second.clear();
   _node_set_nodes.clear();
-  for (std::map<boundary_id_type, std::set<unsigned int> >::iterator it = _bnd_node_ids.begin(); it != _bnd_node_ids.end(); ++it)
+  for (std::map<boundary_id_type, std::set<dof_id_type> >::iterator it = _bnd_node_ids.begin(); it != _bnd_node_ids.end(); ++it)
     it->second.clear();
   _bnd_node_ids.clear();
 }
@@ -297,7 +297,7 @@ MooseMesh::freeBndElems()
   // free memory
   for (std::vector<BndElement *>::iterator it = _bnd_elems.begin(); it != _bnd_elems.end(); ++it)
     delete (*it);
-  for (std::map<boundary_id_type, std::set<unsigned int> >::iterator it = _bnd_elem_ids.begin(); it != _bnd_elem_ids.end(); ++it)
+  for (std::map<boundary_id_type, std::set<dof_id_type> >::iterator it = _bnd_elem_ids.begin(); it != _bnd_elem_ids.end(); ++it)
     it->second.clear();
   _bnd_elem_ids.clear();
 }
@@ -380,7 +380,7 @@ MooseMesh::update()
 }
 
 const Node &
-MooseMesh::node(const unsigned int i) const
+MooseMesh::node(const dof_id_type i) const
 {
   if (i > getMesh().max_node_id())
     return *(*_quadrature_nodes.find(i)).second;
@@ -389,7 +389,7 @@ MooseMesh::node(const unsigned int i) const
 }
 
 Node &
-MooseMesh::node(const unsigned int i)
+MooseMesh::node(const dof_id_type i)
 {
   if (i > getMesh().max_node_id())
     return *_quadrature_nodes[i];
@@ -398,7 +398,7 @@ MooseMesh::node(const unsigned int i)
 }
 
 const Node*
-MooseMesh::nodePtr(const unsigned int i) const
+MooseMesh::nodePtr(const dof_id_type i) const
 {
   if (i > getMesh().max_node_id())
     return (*_quadrature_nodes.find(i)).second;
@@ -407,7 +407,7 @@ MooseMesh::nodePtr(const unsigned int i) const
 }
 
 Node*
-MooseMesh::nodePtr(const unsigned int i)
+MooseMesh::nodePtr(const dof_id_type i)
 {
   if (i > getMesh().max_node_id())
     return _quadrature_nodes[i];
@@ -851,8 +851,13 @@ MooseMesh::addQuadratureNode(const Elem * elem, const unsigned short int side, c
   {
     // Create a new node id starting from the max node id and counting down.  This will be the least
     // likely to collide with an existing node id.
-    unsigned int max_id = std::numeric_limits<unsigned int>::max()-100;
-    unsigned int new_id = max_id - _quadrature_nodes.size();
+    // Note that we are using numeric_limits<unsigned>::max even
+    // though max_id is stored as a dof_id_type.  I tried this with
+    // numeric_limits<dof_id_type>::max and it broke several tests in
+    // MOOSE.  So, this is some kind of a magic number that we will
+    // just continue to use...
+    dof_id_type max_id = std::numeric_limits<unsigned int>::max()-100;
+    dof_id_type new_id = max_id - _quadrature_nodes.size();
 
     if (new_id <= getMesh().max_node_id())
       mooseError("Quadrature node id collides with existing node id!");
@@ -895,8 +900,9 @@ void
 MooseMesh::clearQuadratureNodes()
 {
   { // Delete all the quadrature nodes
-    std::map<unsigned int, Node *>::iterator it = _quadrature_nodes.begin();
-    std::map<unsigned int, Node *>::iterator end = _quadrature_nodes.end();
+    std::map<dof_id_type, Node *>::iterator
+      it  = _quadrature_nodes.begin(),
+      end = _quadrature_nodes.end();
 
     for (; it != end; ++it)
       delete it->second;
@@ -1031,7 +1037,7 @@ MooseMesh::setBoundaryName(BoundaryID boundary_id, BoundaryName name)
 }
 
 void
-MooseMesh::buildPeriodicNodeMap(std::multimap<unsigned int, unsigned int> & periodic_node_map, unsigned int var_number, PeriodicBoundaries *pbs) const
+MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & periodic_node_map, unsigned int var_number, PeriodicBoundaries *pbs) const
 {
   mooseAssert(!Threads::in_threads, "This function should only be called outside of a threaded region due to the use of PointLocator");
 
@@ -1043,6 +1049,9 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<unsigned int, unsigned int> & peri
 
   // Get a const reference to the BoundaryInfo object that we will use several times below...
   const BoundaryInfo & boundary_info = getMesh().get_boundary_info();
+
+  // A typedef makes the code below easier to read...
+  typedef std::multimap<dof_id_type, dof_id_type>::iterator IterType;
 
   for (; it != it_end; ++it)
   {
@@ -1076,10 +1085,10 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<unsigned int, unsigned int> & peri
               if (master_point.absolute_fuzzy_equals(*slave_node))
               {
                 // Avoid inserting any duplicates
-                std::pair<std::multimap<unsigned int, unsigned int>::iterator, std::multimap<unsigned int, unsigned int>::iterator> iters =
+                std::pair<IterType, IterType> iters =
                   periodic_node_map.equal_range(master_node->id());
                 bool found = false;
-                for (std::multimap<unsigned int, unsigned int>::iterator map_it = iters.first; map_it != iters.second; ++map_it)
+                for (IterType map_it = iters.first; map_it != iters.second; ++map_it)
                   if (map_it->second == slave_node->id())
                     found = true;
                 if (!found)
@@ -1094,7 +1103,9 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<unsigned int, unsigned int> & peri
 }
 
 void
-MooseMesh::buildPeriodicNodeSets(std::map<BoundaryID, std::set<unsigned int> > & periodic_node_sets, unsigned int var_number, PeriodicBoundaries *pbs) const
+MooseMesh::buildPeriodicNodeSets(std::map<BoundaryID, std::set<dof_id_type> > & periodic_node_sets,
+                                 unsigned int var_number,
+                                 PeriodicBoundaries *pbs) const
 {
   periodic_node_sets.clear();
 
@@ -1795,26 +1806,26 @@ MooseMesh::activeLocalElementsEnd()
   return getMesh().active_local_elements_end();
 }
 
-unsigned int
+dof_id_type
 MooseMesh::nNodes() const
 {
   return getMesh().n_nodes();
 }
 
-unsigned int
+dof_id_type
 MooseMesh::nElem() const
 {
   return getMesh().n_elem();
 }
 
 Elem *
-MooseMesh::elem(const unsigned int i)
+MooseMesh::elem(const dof_id_type i)
 {
   return getMesh().elem(i);
 }
 
 const Elem *
-MooseMesh::elem(const unsigned int i) const
+MooseMesh::elem(const dof_id_type i) const
 {
   return getMesh().elem(i);
 }
@@ -2057,7 +2068,7 @@ void MooseMesh::printInfo(std::ostream &os)
   getMesh().print_info(os);
 }
 
-std::vector<unsigned int> &
+std::vector<dof_id_type> &
 MooseMesh::getNodeList(boundary_id_type nodeset_id)
 {
   return _node_set_nodes[nodeset_id];
@@ -2070,10 +2081,10 @@ MooseMesh::getSubdomainBoundaryIds(unsigned int subdomain_id)
 }
 
 bool
-MooseMesh::isBoundaryNode(unsigned int node_id)
+MooseMesh::isBoundaryNode(dof_id_type node_id)
 {
   bool found_node = false;
-  for (std::map<boundary_id_type, std::set<unsigned int> >::iterator it = _bnd_node_ids.begin(); it != _bnd_node_ids.end(); ++it)
+  for (std::map<boundary_id_type, std::set<dof_id_type> >::iterator it = _bnd_node_ids.begin(); it != _bnd_node_ids.end(); ++it)
   {
     if (it->second.find(node_id) != it->second.end())
     {
@@ -2085,10 +2096,10 @@ MooseMesh::isBoundaryNode(unsigned int node_id)
 }
 
 bool
-MooseMesh::isBoundaryNode(unsigned int node_id, BoundaryID bnd_id)
+MooseMesh::isBoundaryNode(dof_id_type node_id, BoundaryID bnd_id)
 {
   bool found_node = false;
-  std::map<boundary_id_type, std::set<unsigned int> >::iterator it = _bnd_node_ids.find(bnd_id);
+  std::map<boundary_id_type, std::set<dof_id_type> >::iterator it = _bnd_node_ids.find(bnd_id);
   if (it != _bnd_node_ids.end())
     if (it->second.find(node_id) != it->second.end())
       found_node = true;
@@ -2096,10 +2107,10 @@ MooseMesh::isBoundaryNode(unsigned int node_id, BoundaryID bnd_id)
 }
 
 bool
-MooseMesh::isBoundaryElem(unsigned int elem_id)
+MooseMesh::isBoundaryElem(dof_id_type elem_id)
 {
   bool found_elem = false;
-  for (std::map<boundary_id_type, std::set<unsigned int> >::iterator it = _bnd_elem_ids.begin(); it != _bnd_elem_ids.end(); ++it)
+  for (std::map<boundary_id_type, std::set<dof_id_type> >::iterator it = _bnd_elem_ids.begin(); it != _bnd_elem_ids.end(); ++it)
   {
     if (it->second.find(elem_id) != it->second.end())
     {
@@ -2111,10 +2122,10 @@ MooseMesh::isBoundaryElem(unsigned int elem_id)
 }
 
 bool
-MooseMesh::isBoundaryElem(unsigned int elem_id, BoundaryID bnd_id)
+MooseMesh::isBoundaryElem(dof_id_type elem_id, BoundaryID bnd_id)
 {
   bool found_elem = false;
-  std::map<boundary_id_type, std::set<unsigned int> >::iterator it = _bnd_elem_ids.find(bnd_id);
+  std::map<boundary_id_type, std::set<dof_id_type> >::iterator it = _bnd_elem_ids.find(bnd_id);
   if (it != _bnd_elem_ids.end())
     if (it->second.find(elem_id) != it->second.end())
       found_elem = true;

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -500,7 +500,7 @@ MooseMesh::coarsenedElementChildren(const Elem * elem)
 }
 
 void
-MooseMesh::updateActiveSemiLocalNodeRange(std::set<unsigned int> & ghosted_elems)
+MooseMesh::updateActiveSemiLocalNodeRange(std::set<dof_id_type> & ghosted_elems)
 {
   _semilocal_node_list.clear();
 
@@ -520,7 +520,7 @@ MooseMesh::updateActiveSemiLocalNodeRange(std::set<unsigned int> & ghosted_elems
   }
 
   // Now add the nodes connected to ghosted_elems
-  for (std::set<unsigned int>::iterator it=ghosted_elems.begin();
+  for (std::set<dof_id_type>::iterator it=ghosted_elems.begin();
       it!=ghosted_elems.end();
       ++it)
   {
@@ -578,7 +578,7 @@ MooseMesh::buildNodeList()
   freeBndNodes();
 
   /// Boundary node list (node ids and corresponding side-set ids, arrays always have the same length)
-  std::vector<unsigned int> nodes;
+  std::vector<dof_id_type> nodes;
   std::vector<boundary_id_type> ids;
   getMesh().get_boundary_info().build_node_list(nodes, ids);
 
@@ -611,7 +611,7 @@ MooseMesh::buildBndElemList()
   freeBndElems();
 
   /// Boundary node list (node ids and corresponding side-set ids, arrays always have the same length)
-  std::vector<unsigned int> elems;
+  std::vector<dof_id_type> elems;
   std::vector<unsigned short int> sides;
   std::vector<boundary_id_type> ids;
   getMesh().get_boundary_info().build_active_side_list(elems, sides, ids);
@@ -625,7 +625,7 @@ MooseMesh::buildBndElemList()
   }
 }
 
-std::map<unsigned int, std::vector<unsigned int> > &
+std::map<dof_id_type, std::vector<dof_id_type> > &
 MooseMesh::nodeToElemMap()
 {
   if (!_node_to_elem_map_built) // Guard the creation with a double checked lock
@@ -1098,7 +1098,7 @@ MooseMesh::buildPeriodicNodeSets(std::map<BoundaryID, std::set<unsigned int> > &
 {
   periodic_node_sets.clear();
 
-  std::vector<unsigned int> nl;
+  std::vector<dof_id_type> nl;
   std::vector<boundary_id_type> il;
 
   getMesh().get_boundary_info().build_node_list(nl, il);
@@ -1760,7 +1760,7 @@ MooseMesh::buildNodeListFromSideList()
 }
 
 void
-MooseMesh::buildSideList(std::vector<unsigned int> & el, std::vector<unsigned short int> & sl, std::vector<boundary_id_type> & il)
+MooseMesh::buildSideList(std::vector<dof_id_type> & el, std::vector<unsigned short int> & sl, std::vector<boundary_id_type> & il)
 {
   getMesh().get_boundary_info().build_side_list(el, sl, il);
 }
@@ -1953,7 +1953,7 @@ MooseMesh::ghostGhostedBoundaries()
 
   Moose::perf_log.push("ghostGhostedBoundaries()","MooseMesh");
 
-  std::vector<unsigned int> elems;
+  std::vector<dof_id_type> elems;
   std::vector<unsigned short int> sides;
   std::vector<boundary_id_type> ids;
 

--- a/framework/src/multiapps/AutoPositionsMultiApp.C
+++ b/framework/src/multiapps/AutoPositionsMultiApp.C
@@ -51,7 +51,7 @@ AutoPositionsMultiApp::fillPositions()
     BoundaryID boundary_id = *bid_it;
 
     // Grab the nodes on the boundary ID and add a Sub-App at each one.
-    std::vector<unsigned int> & boundary_node_ids = master_mesh.getNodeList(boundary_id);
+    std::vector<dof_id_type> & boundary_node_ids = master_mesh.getNodeList(boundary_id);
 
     for (unsigned int i=0; i<boundary_node_ids.size(); i++)
     {

--- a/framework/src/outputs/formatters/InputFileFormatter.C
+++ b/framework/src/outputs/formatters/InputFileFormatter.C
@@ -114,7 +114,8 @@ InputFileFormatter::printParams(const std::string & /*prefix*/, const std::strin
 
       found = true;
       oss << spacing << "  " << std::left << std::setw(offset) << iter->first << " = ";
-      size_t l_offset = 30;
+      // std::setw() takes an int
+      int l_offset = 30;
 
       if (!_dump_mode || value != "INVALID")
       {

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -679,6 +679,16 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
       dynamicCastAndExtractVector(int                   , it->second, full_name, it->first, in_global, global_params_block);
       dynamicCastAndExtractVector(long                  , it->second, full_name, it->first, in_global, global_params_block);
       dynamicCastAndExtractVector(unsigned int          , it->second, full_name, it->first, in_global, global_params_block);
+      // We need to be able to parse 8-byte unsigned types when
+      // libmesh is configured --with-dof-id-bytes=8.  Officially,
+      // libmesh uses uint64_t in that scenario, which is usually
+      // equivalent to 'unsigned long long'.  Note that 'long long'
+      // has been around since C99 so most C++ compilers support it,
+      // but presumably uint64_t is the "most standard" way to get a
+      // 64-bit unsigned type, so we'll stick with that here.
+#if LIBMESH_DOF_ID_BYTES == 8
+      dynamicCastAndExtractVector(uint64_t              , it->second, full_name, it->first, in_global, global_params_block);
+#endif
 
       // Moose Vectors
       dynamicCastAndExtractVector(SubdomainID           , it->second, full_name, it->first, in_global, global_params_block);

--- a/framework/src/predictors/SimplePredictor.C
+++ b/framework/src/predictors/SimplePredictor.C
@@ -39,9 +39,13 @@ SimplePredictor::apply(NumericVector<Number> & sln)
 {
   if (_dt_old > 0)
   {
-    std::streamsize cur_precision(Moose::out.precision());
+    // Save the original stream flags
+    std::ios_base::fmtflags out_flags = Moose::out.flags();
+
     _console << "  Applying predictor with scale factor = " << std::fixed << std::setprecision(2) << _scale << std::endl;
-    _console << std::scientific << std::setprecision(cur_precision);
+
+    // Restore the flags
+    Moose::out.flags(out_flags);
 
     Real dt_adjusted_scale_factor = _scale * _dt / _dt_old;
     if (dt_adjusted_scale_factor != 0.0)

--- a/framework/src/restart/RestartableDataIO.C
+++ b/framework/src/restart/RestartableDataIO.C
@@ -100,13 +100,13 @@ RestartableDataIO::writeRestartableData(std::string base_file_name, const Restar
         it->second->store(data);
 
         // Store the size of the data then the data
-        unsigned int data_size = data.tellp();
+        unsigned int data_size = static_cast<unsigned int>(data.tellp());
         data_blk.write((const char *) &data_size, sizeof(data_size));
         data_blk << data.str();
       }
 
       // Write out this proc's block size
-      unsigned int data_blk_size = data_blk.tellp();
+      unsigned int data_blk_size = static_cast<unsigned int>(data_blk.tellp());
       out.write((const char *) &data_blk_size, sizeof(data_blk_size));
 
       // Write out the values

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -342,7 +342,7 @@ MultiAppNearestNodeTransfer::execute()
           for (; to_node_it != to_node_end; ++to_node_it)
           {
             Node * to_node = *to_node_it;
-            unsigned int to_node_id = to_node->id();
+            dof_id_type to_node_id = to_node->id();
 
             Real current_distance = 0;
 
@@ -390,7 +390,7 @@ MultiAppNearestNodeTransfer::execute()
           for (; to_elem_it != to_elem_end; ++to_elem_it)
           {
             Elem * to_elem = *to_elem_it;
-            unsigned int to_elem_id = to_elem->id();
+            dof_id_type to_elem_id = to_elem->id();
 
             Point actual_position = to_elem->centroid()-app_position;
 

--- a/framework/src/userobject/LayeredBase.C
+++ b/framework/src/userobject/LayeredBase.C
@@ -246,13 +246,13 @@ LayeredBase::getLayer(Point p) const
 
     if (one_higher == _layer_bounds.end())
     {
-      return _layer_bounds.size() - 2; // Just return the last layer.  -2 because layers are "in-between" bounds
+      return static_cast<unsigned int>(_layer_bounds.size() - 2); // Just return the last layer.  -2 because layers are "in-between" bounds
     }
     else if (one_higher == _layer_bounds.begin())
       return 0; // Return the first layer
     else
       // The -1 is because the interval that we fall in is just _before_ the number that is bigger (which is what we found
-      return std::distance(_layer_bounds.begin(), one_higher-1);
+      return static_cast<unsigned int>(std::distance(_layer_bounds.begin(), one_higher-1));
   }
 }
 

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -982,7 +982,7 @@ static PetscErrorCode DMCreateMatrix_Moose(DM dm, const MatType type, Mat *A)
   MPI_Comm comm;
   M = dof_map.n_dofs();
   N = M;
-  m = dof_map.n_dofs_on_processor(dmm->nl->sys().processor_id());
+  m = static_cast<PetscInt>(dof_map.n_dofs_on_processor(dmm->nl->sys().processor_id()));
   n = m;
   ierr = PetscObjectGetComm((PetscObject)dm,&comm);CHKERRQ(ierr);
   ierr = MatCreate(comm, A);CHKERRQ(ierr);

--- a/framework/src/utils/RandomData.C
+++ b/framework/src/utils/RandomData.C
@@ -17,7 +17,7 @@
 #include "MooseMesh.h"
 #include "RandomInterface.h"
 
-const unsigned int MASTER = std::numeric_limits<dof_id_type>::max();
+const unsigned int MASTER = std::numeric_limits<unsigned int>::max();
 
 RandomData::RandomData(FEProblem &problem, const RandomInterface & random_interface) :
     _rd_problem(problem),
@@ -106,7 +106,7 @@ RandomData::updateGenerators()
       _seeds[id] = _generator.randl(MASTER);
 
       // Update the individual dof object generators
-      _generator.seed(id, _seeds[id]);
+      _generator.seed(static_cast<unsigned int>(id), _seeds[id]);
     }
   }
   else
@@ -120,7 +120,7 @@ RandomData::updateGenerators()
       _seeds[id] = _generator.randl(MASTER);
 
       // Update the individual dof object generators
-      _generator.seed(id, _seeds[id]);
+      _generator.seed(static_cast<unsigned int>(id), _seeds[id]);
     }
   }
 

--- a/framework/src/utils/RandomInterface.C
+++ b/framework/src/utils/RandomInterface.C
@@ -79,7 +79,7 @@ RandomInterface::getRandomLong()
   else
     id = _curr_element->id();
 
-  return _generator->randl(id);
+  return _generator->randl(static_cast<unsigned int>(id));
 }
 
 Real
@@ -93,5 +93,5 @@ RandomInterface::getRandomReal()
   else
     id = _curr_element->id();
 
-  return _generator->rand(id);
+  return _generator->rand(static_cast<unsigned int>(id));
 }

--- a/framework/src/vectorpostprocessors/SamplerBase.C
+++ b/framework/src/vectorpostprocessors/SamplerBase.C
@@ -122,7 +122,7 @@ SamplerBase::finalize()
 
   for (unsigned int i=0; i<sorted_indices.size(); i++)
   {
-    unsigned int index = sorted_indices[i];
+    size_t index = sorted_indices[i];
 
     _x[i] = _x_tmp[index];
     _y[i] = _y_tmp[index];

--- a/modules/contact/include/FrictionalContactProblem.h
+++ b/modules/contact/include/FrictionalContactProblem.h
@@ -81,15 +81,15 @@ public:
   unsigned int numLocalFrictionalConstraints();
   void updateContactReferenceResidual();
   virtual MooseNonlinearConvergenceReason checkNonlinearConvergence(std::string &msg,
-                                                                    const int it,
+                                                                    const PetscInt it,
                                                                     const Real xnorm,
                                                                     const Real snorm,
                                                                     const Real fnorm,
                                                                     const Real rtol,
                                                                     const Real stol,
                                                                     const Real abstol,
-                                                                    const int nfuncs,
-                                                                    const int max_funcs,
+                                                                    const PetscInt nfuncs,
+                                                                    const PetscInt max_funcs,
                                                                     const Real ref_resid,
                                                                     const Real div_threshold);
   void updateContactPoints(NumericVector<Number>& ghosted_solution,

--- a/modules/contact/include/ReferenceResidualProblem.h
+++ b/modules/contact/include/ReferenceResidualProblem.h
@@ -35,15 +35,15 @@ public:
   virtual void timestepSetup();
   void updateReferenceResidual();
   virtual MooseNonlinearConvergenceReason checkNonlinearConvergence(std::string &msg,
-                                                                    const int it,
+                                                                    const PetscInt it,
                                                                     const Real xnorm,
                                                                     const Real snorm,
                                                                     const Real fnorm,
                                                                     const Real rtol,
                                                                     const Real stol,
                                                                     const Real abstol,
-                                                                    const int nfuncs,
-                                                                    const int max_funcs,
+                                                                    const PetscInt nfuncs,
+                                                                    const PetscInt max_funcs,
                                                                     const Real ref_resid,
                                                                     const Real div_threshold);
 

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -121,13 +121,14 @@ ContactMaster::timestepSetup()
 void
 ContactMaster::updateContactSet(bool beginning_of_step)
 {
-  std::set<unsigned int> & has_penetrated = _penetration_locator._has_penetrated;
-  std::map<unsigned int, unsigned> & unlocked_this_step = _penetration_locator._unlocked_this_step;
-  std::map<unsigned int, unsigned> & locked_this_step = _penetration_locator._locked_this_step;
-  std::map<unsigned int, Real> & lagrange_multiplier = _penetration_locator._lagrange_multiplier;
+  std::set<dof_id_type> & has_penetrated = _penetration_locator._has_penetrated;
+  std::map<dof_id_type, unsigned int> & unlocked_this_step = _penetration_locator._unlocked_this_step;
+  std::map<dof_id_type, unsigned int> & locked_this_step = _penetration_locator._locked_this_step;
+  std::map<dof_id_type, Real> & lagrange_multiplier = _penetration_locator._lagrange_multiplier;
 
-  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator
+    it  = _penetration_locator._penetration_info.begin(),
+    end = _penetration_locator._penetration_info.end();
 
   for (; it!=end; ++it)
   {
@@ -140,8 +141,8 @@ ContactMaster::updateContactSet(bool beginning_of_step)
 
     Real area = nodalArea(*pinfo);
 
-    const unsigned int slave_node_num = it->first;
-    std::set<unsigned int>::iterator hpit = has_penetrated.find(slave_node_num);
+    const dof_id_type slave_node_num = it->first;
+    std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
     if (beginning_of_step)
     {
@@ -239,10 +240,11 @@ ContactMaster::addPoints()
 {
   _point_to_info.clear();
 
-  std::set<unsigned int> & has_penetrated = _penetration_locator._has_penetrated;
+  std::set<dof_id_type> & has_penetrated = _penetration_locator._has_penetrated;
 
-  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator
+    it  = _penetration_locator._penetration_info.begin(),
+    end = _penetration_locator._penetration_info.end();
 
   for (; it!=end; ++it)
   {
@@ -252,9 +254,9 @@ ContactMaster::addPoints()
       continue;
 
 
-    unsigned int slave_node_num = it->first;
+    dof_id_type slave_node_num = it->first;
 
-    std::set<unsigned int>::iterator hpit = has_penetrated.find(slave_node_num);
+    std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
     if ( hpit != has_penetrated.end() )
     {
@@ -268,14 +270,14 @@ ContactMaster::addPoints()
 void
 ContactMaster::computeContactForce(PenetrationInfo * pinfo)
 {
-  std::map<unsigned int, Real> & lagrange_multiplier = _penetration_locator._lagrange_multiplier;
+  std::map<dof_id_type, Real> & lagrange_multiplier = _penetration_locator._lagrange_multiplier;
   const Node * node = pinfo->_node;
 
   RealVectorValue res_vec;
   // Build up residual vector
   for (unsigned int i=0; i<_mesh_dimension; ++i)
   {
-    long int dof_number = node->dof_number(0, _vars(i), 0);
+    dof_id_type dof_number = node->dof_number(0, _vars(i), 0);
     res_vec(i) = _residual_copy(dof_number);
   }
 
@@ -506,7 +508,7 @@ ContactMaster::nodalArea(PenetrationInfo & pinfo)
 {
   const Node * node = pinfo._node;
 
-  unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
+  dof_id_type dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
 
   Real area = (*_aux_solution)( dof );
   if (area == 0)

--- a/modules/contact/src/ContactPressureAux.C
+++ b/modules/contact/src/ContactPressureAux.C
@@ -33,7 +33,7 @@ ContactPressureAux::computeValue()
   const Real area = _nodal_area[_qp];
   const PenetrationInfo * pinfo(NULL);
 
-  const std::map<unsigned int, PenetrationInfo*>::const_iterator it = _penetration_locator._penetration_info.find( _current_node->id() );
+  const std::map<dof_id_type, PenetrationInfo*>::const_iterator it = _penetration_locator._penetration_info.find( _current_node->id() );
   if (it != _penetration_locator._penetration_info.end())
   {
     pinfo = it->second;

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -332,7 +332,7 @@ FrictionalContactProblem::enforceRateConstraint(NumericVector<Number>& vec_solut
         ++plit)
     {
       PenetrationLocator & pen_loc = *plit->second;
-      std::set<unsigned int> & has_penetrated = pen_loc._has_penetrated;
+      std::set<dof_id_type> & has_penetrated = pen_loc._has_penetrated;
 
       bool frictional_contact_this_interaction = false;
 
@@ -355,16 +355,16 @@ FrictionalContactProblem::enforceRateConstraint(NumericVector<Number>& vec_solut
           {
             PenetrationInfo & info = *pen_loc._penetration_info[slave_node_num];
 
-            std::set<unsigned int>::iterator hpit( has_penetrated.find( slave_node_num ) );
+            std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
             if (hpit != has_penetrated.end())
             {
 //              _console<<"Slave node: "<<slave_node_num<<std::endl;
               const Node * node = info._node;
 
-              VectorValue<unsigned int> solution_dofs(node->dof_number(nonlinear_sys.number(), disp_x_var->number(), 0),
-                                                      node->dof_number(nonlinear_sys.number(), disp_y_var->number(), 0),
-                                                      (disp_z_var ? node->dof_number(nonlinear_sys.number(), disp_z_var->number(), 0) : 0));
+              VectorValue<dof_id_type> solution_dofs(node->dof_number(nonlinear_sys.number(), disp_x_var->number(), 0),
+                                                     node->dof_number(nonlinear_sys.number(), disp_y_var->number(), 0),
+                                                     (disp_z_var ? node->dof_number(nonlinear_sys.number(), disp_z_var->number(), 0) : 0));
 
               //Get old parametric coords from info
               //get old element from info
@@ -465,7 +465,7 @@ FrictionalContactProblem::calculateSlip(const NumericVector<Number>& ghosted_sol
       ++plit)
     {
       PenetrationLocator & pen_loc = *plit->second;
-      std::set<unsigned int> & has_penetrated = pen_loc._has_penetrated;
+      std::set<dof_id_type> & has_penetrated = pen_loc._has_penetrated;
 
       bool frictional_contact_this_interaction = false;
 
@@ -498,23 +498,23 @@ FrictionalContactProblem::calculateSlip(const NumericVector<Number>& ghosted_sol
             if (node->processor_id() == processor_id())
             {
 
-              std::set<unsigned int>::iterator hpit( has_penetrated.find( slave_node_num ) );
+              std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
               if (hpit != has_penetrated.end())
               {
                 _num_contact_nodes++;
 
-                VectorValue<unsigned int> residual_dofs(node->dof_number(aux_sys.number(), residual_x_var->number(), 0),
-                                                        node->dof_number(aux_sys.number(), residual_y_var->number(), 0),
-                                                        (residual_z_var ? node->dof_number(aux_sys.number(), residual_z_var->number(), 0) : 0));
+                VectorValue<dof_id_type> residual_dofs(node->dof_number(aux_sys.number(), residual_x_var->number(), 0),
+                                                       node->dof_number(aux_sys.number(), residual_y_var->number(), 0),
+                                                       (residual_z_var ? node->dof_number(aux_sys.number(), residual_z_var->number(), 0) : 0));
 
-                VectorValue<unsigned int> diag_stiff_dofs(node->dof_number(aux_sys.number(), diag_stiff_x_var->number(), 0),
-                                                          node->dof_number(aux_sys.number(), diag_stiff_y_var->number(), 0),
-                                                          (diag_stiff_z_var ? node->dof_number(aux_sys.number(), diag_stiff_z_var->number(), 0) : 0));
+                VectorValue<dof_id_type> diag_stiff_dofs(node->dof_number(aux_sys.number(), diag_stiff_x_var->number(), 0),
+                                                         node->dof_number(aux_sys.number(), diag_stiff_y_var->number(), 0),
+                                                         (diag_stiff_z_var ? node->dof_number(aux_sys.number(), diag_stiff_z_var->number(), 0) : 0));
 
-                VectorValue<unsigned int> inc_slip_dofs(node->dof_number(aux_sys.number(), inc_slip_x_var->number(), 0),
-                                                        node->dof_number(aux_sys.number(), inc_slip_y_var->number(), 0),
-                                                        (inc_slip_z_var ? node->dof_number(aux_sys.number(), inc_slip_z_var->number(), 0) : 0));
+                VectorValue<dof_id_type> inc_slip_dofs(node->dof_number(aux_sys.number(), inc_slip_x_var->number(), 0),
+                                                       node->dof_number(aux_sys.number(), inc_slip_y_var->number(), 0),
+                                                       (inc_slip_z_var ? node->dof_number(aux_sys.number(), inc_slip_z_var->number(), 0) : 0));
 
                 RealVectorValue res_vec;
                 RealVectorValue stiff_vec;
@@ -720,8 +720,9 @@ FrictionalContactProblem::applySlip(NumericVector<Number>& vec_solution,
       inc_slip_var = inc_slip_z_var;
     }
 
-    unsigned int solution_dof = node->dof_number(nonlinear_sys.number(), disp_var->number(), 0);
-    unsigned int inc_slip_dof = node->dof_number(aux_sys.number(), inc_slip_var->number(), 0);
+    dof_id_type
+      solution_dof = node->dof_number(nonlinear_sys.number(), disp_var->number(), 0),
+      inc_slip_dof = node->dof_number(aux_sys.number(), inc_slip_var->number(), 0);
 
     vec_solution.add(solution_dof, slip);
     aux_solution.add(inc_slip_dof, slip);
@@ -766,7 +767,7 @@ FrictionalContactProblem::numLocalFrictionalConstraints()
 
     if (frictional_contact_this_interaction)
     {
-      std::set<unsigned int> & has_penetrated = pen_loc._has_penetrated;
+      std::set<dof_id_type> & has_penetrated = pen_loc._has_penetrated;
 
       std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
@@ -776,7 +777,7 @@ FrictionalContactProblem::numLocalFrictionalConstraints()
 
         if (pen_loc._penetration_info[slave_node_num])
         {
-          std::set<unsigned int>::iterator hpit( has_penetrated.find( slave_node_num ) );
+          std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
           if (hpit != has_penetrated.end())
           {
@@ -791,15 +792,15 @@ FrictionalContactProblem::numLocalFrictionalConstraints()
 
 MooseNonlinearConvergenceReason
 FrictionalContactProblem::checkNonlinearConvergence(std::string &msg,
-                                                    const int it,
+                                                    const PetscInt it,
                                                     const Real xnorm,
                                                     const Real snorm,
                                                     const Real fnorm,
                                                     const Real rtol,
                                                     const Real stol,
                                                     const Real abstol,
-                                                    const int nfuncs,
-                                                    const int /*max_funcs*/,
+                                                    const PetscInt nfuncs,
+                                                    const PetscInt /*max_funcs*/,
                                                     const Real ref_resid,
                                                     const Real /*div_threshold*/)
 {
@@ -945,7 +946,7 @@ FrictionalContactProblem::updateIncrementalSlip()
 
     if (frictional_contact_this_interaction)
     {
-      std::set<unsigned int> & has_penetrated = pen_loc._has_penetrated;
+      std::set<dof_id_type> & has_penetrated = pen_loc._has_penetrated;
 
       std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
@@ -957,14 +958,14 @@ FrictionalContactProblem::updateIncrementalSlip()
         {
           PenetrationInfo & info = *pen_loc._penetration_info[slave_node_num];
 
-          std::set<unsigned int>::iterator hpit( has_penetrated.find( slave_node_num ) );
+          std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
           if (hpit != has_penetrated.end())
           {
             const Node * node = info._node;
-            VectorValue<unsigned int> inc_slip_dofs(node->dof_number(aux_sys.number(), inc_slip_x_var->number(), 0),
-                                                    node->dof_number(aux_sys.number(), inc_slip_y_var->number(), 0),
-                                                    (inc_slip_z_var ? node->dof_number(aux_sys.number(), inc_slip_z_var->number(), 0) : 0));
+            VectorValue<dof_id_type> inc_slip_dofs(node->dof_number(aux_sys.number(), inc_slip_x_var->number(), 0),
+                                                   node->dof_number(aux_sys.number(), inc_slip_y_var->number(), 0),
+                                                   (inc_slip_z_var ? node->dof_number(aux_sys.number(), inc_slip_z_var->number(), 0) : 0));
 
             RealVectorValue inc_slip = info._incremental_slip;
 

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -345,11 +345,11 @@ FrictionalContactProblem::enforceRateConstraint(NumericVector<Number>& vec_solut
 
       if (frictional_contact_this_interaction)
       {
-        std::vector<unsigned int> & slave_nodes = pen_loc._nearest_node._slave_nodes;
+        std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
         for (unsigned int i=0; i<slave_nodes.size(); i++)
         {
-          unsigned int slave_node_num = slave_nodes[i];
+          dof_id_type slave_node_num = slave_nodes[i];
 
           if (pen_loc._penetration_info[slave_node_num])
           {
@@ -484,11 +484,11 @@ FrictionalContactProblem::calculateSlip(const NumericVector<Number>& ghosted_sol
         Real friction_coefficient = interaction_params._friction_coefficient;
 
 
-        std::vector<unsigned int> & slave_nodes = pen_loc._nearest_node._slave_nodes;
+        std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
         for (unsigned int i=0; i<slave_nodes.size(); i++)
         {
-          unsigned int slave_node_num = slave_nodes[i];
+          dof_id_type slave_node_num = slave_nodes[i];
 
           if (pen_loc._penetration_info[slave_node_num])
           {
@@ -768,11 +768,11 @@ FrictionalContactProblem::numLocalFrictionalConstraints()
     {
       std::set<unsigned int> & has_penetrated = pen_loc._has_penetrated;
 
-      std::vector<unsigned int> & slave_nodes = pen_loc._nearest_node._slave_nodes;
+      std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
-        unsigned int slave_node_num = slave_nodes[i];
+        dof_id_type slave_node_num = slave_nodes[i];
 
         if (pen_loc._penetration_info[slave_node_num])
         {
@@ -947,11 +947,11 @@ FrictionalContactProblem::updateIncrementalSlip()
     {
       std::set<unsigned int> & has_penetrated = pen_loc._has_penetrated;
 
-      std::vector<unsigned int> & slave_nodes = pen_loc._nearest_node._slave_nodes;
+      std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
-        unsigned int slave_node_num = slave_nodes[i];
+        dof_id_type slave_node_num = slave_nodes[i];
 
         if (pen_loc._penetration_info[slave_node_num])
         {

--- a/modules/contact/src/GluedContactConstraint.C
+++ b/modules/contact/src/GluedContactConstraint.C
@@ -120,10 +120,11 @@ GluedContactConstraint::jacobianSetup()
 void
 GluedContactConstraint::updateContactSet(bool beginning_of_step)
 {
-  std::set<unsigned int> & has_penetrated = _penetration_locator._has_penetrated;
+  std::set<dof_id_type> & has_penetrated = _penetration_locator._has_penetrated;
 
-  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator
+    it  = _penetration_locator._penetration_info.begin(),
+    end = _penetration_locator._penetration_info.end();
 
   for (; it!=end; ++it)
   {
@@ -134,8 +135,8 @@ GluedContactConstraint::updateContactSet(bool beginning_of_step)
       continue;
     }
 
-    const unsigned int slave_node_num = it->first;
-    std::set<unsigned int>::iterator hpit = has_penetrated.find(slave_node_num);
+    const dof_id_type slave_node_num = it->first;
+    std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
     if (beginning_of_step)
     {
@@ -158,7 +159,7 @@ GluedContactConstraint::updateContactSet(bool beginning_of_step)
 bool
 GluedContactConstraint::shouldApply()
 {
-  std::set<unsigned int>::iterator hpit = _penetration_locator._has_penetrated.find(_current_node->id());
+  std::set<dof_id_type>::iterator hpit = _penetration_locator._has_penetrated.find(_current_node->id());
   return (hpit != _penetration_locator._has_penetrated.end());
 }
 
@@ -189,7 +190,7 @@ GluedContactConstraint::computeQpResidual(Moose::ConstraintType type)
     {
       PenetrationInfo * pinfo = _penetration_locator._penetration_info[_current_node->id()];
 
-      long int dof_number = _current_node->dof_number(0, _vars(_component), 0);
+      dof_id_type dof_number = _current_node->dof_number(0, _vars(_component), 0);
       Real resid = _residual_copy(dof_number);
 
       pinfo->_contact_force(_component) = -resid;

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -128,13 +128,14 @@ MechanicalContactConstraint::jacobianSetup()
 void
 MechanicalContactConstraint::updateContactSet(bool beginning_of_step)
 {
-  std::set<unsigned int> & has_penetrated = _penetration_locator._has_penetrated;
-  std::map<unsigned int, unsigned> & unlocked_this_step = _penetration_locator._unlocked_this_step;
-  std::map<unsigned int, unsigned> & locked_this_step = _penetration_locator._locked_this_step;
-  std::map<unsigned int, Real> & lagrange_multiplier = _penetration_locator._lagrange_multiplier;
+  std::set<dof_id_type> & has_penetrated = _penetration_locator._has_penetrated;
+  std::map<dof_id_type, unsigned int> & unlocked_this_step = _penetration_locator._unlocked_this_step;
+  std::map<dof_id_type, unsigned int> & locked_this_step = _penetration_locator._locked_this_step;
+  std::map<dof_id_type, Real> & lagrange_multiplier = _penetration_locator._lagrange_multiplier;
 
-  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator
+    it  = _penetration_locator._penetration_info.begin(),
+    end = _penetration_locator._penetration_info.end();
 
   for (; it!=end; ++it)
   {
@@ -142,8 +143,8 @@ MechanicalContactConstraint::updateContactSet(bool beginning_of_step)
     if (!pinfo)
       continue;
 
-    const unsigned int slave_node_num = it->first;
-    std::set<unsigned int>::iterator hpit = has_penetrated.find(slave_node_num);
+    const dof_id_type slave_node_num = it->first;
+    std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
     if (beginning_of_step)
     {
@@ -238,10 +239,10 @@ MechanicalContactConstraint::shouldApply()
 
 //  _point_to_info.clear();
 //
-//  std::set<unsigned int> & has_penetrated = _penetration_locator._has_penetrated;
+//  std::set<dof_id_type> & has_penetrated = _penetration_locator._has_penetrated;
 //
-//  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-//  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+//  std::map<dof_id_type, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
+//  std::map<dof_id_type, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
 //
 //  for (; it!=end; ++it)
 //  {
@@ -250,9 +251,9 @@ MechanicalContactConstraint::shouldApply()
 //    if (!pinfo)
 //      continue;
 //
-//    unsigned int slave_node_num = it->first;
+//    dof_id_type slave_node_num = it->first;
 //
-//    std::set<unsigned int>::iterator hpit = has_penetrated.find(slave_node_num);
+//    std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 //
 //    if ( hpit != has_penetrated.end() )
 //    {
@@ -262,21 +263,21 @@ MechanicalContactConstraint::shouldApply()
 //    }
 //  }
 
-  std::set<unsigned int>::iterator hpit = _penetration_locator._has_penetrated.find(_current_node->id());
+  std::set<dof_id_type>::iterator hpit = _penetration_locator._has_penetrated.find(_current_node->id());
   return (hpit != _penetration_locator._has_penetrated.end());
 }
 
 void
 MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
 {
-  std::map<unsigned int, Real> & lagrange_multiplier = _penetration_locator._lagrange_multiplier;
+  std::map<dof_id_type, Real> & lagrange_multiplier = _penetration_locator._lagrange_multiplier;
   const Node * node = pinfo->_node;
 
   RealVectorValue res_vec;
   // Build up residual vector
   for (unsigned int i=0; i<_mesh_dimension; ++i)
   {
-    long int dof_number = node->dof_number(0, _vars(i), 0);
+    dof_id_type dof_number = node->dof_number(0, _vars(i), 0);
     res_vec(i) = _residual_copy(dof_number);
   }
   RealVectorValue distance_vec(_mesh.node(node->id()) - pinfo->_closest_point);
@@ -429,7 +430,7 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
               RealVectorValue jac_vec;
               for (unsigned int i=0; i<_mesh_dimension; ++i)
               {
-                long int dof_number = _current_node->dof_number(0, _vars(i), 0);
+                dof_id_type dof_number = _current_node->dof_number(0, _vars(i), 0);
                 jac_vec(i) = (*_jacobian)(dof_number, _connected_dof_indices[_j]);
               }
               return -pinfo->_normal(_component) * (pinfo->_normal*jac_vec) + (_phi_slave[_j][_qp] * penalty * _test_slave[_i][_qp]) * pinfo->_normal(_component) * pinfo->_normal(_component);
@@ -472,7 +473,7 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
               RealVectorValue jac_vec;
               for (unsigned int i=0; i<_mesh_dimension; ++i)
               {
-                long int dof_number = _current_node->dof_number(0, _vars(i), 0);
+                dof_id_type dof_number = _current_node->dof_number(0, _vars(i), 0);
                 jac_vec(i) = (*_jacobian)(dof_number, curr_master_node->dof_number(0, _vars(_component), 0));
               }
               return -pinfo->_normal(_component)*(pinfo->_normal*jac_vec) - (_phi_master[_j][_qp] * penalty * _test_slave[_i][_qp]) * pinfo->_normal(_component) * pinfo->_normal(_component);
@@ -514,7 +515,7 @@ MechanicalContactConstraint::computeQpJacobian(Moose::ConstraintJacobianType typ
               RealVectorValue jac_vec;
               for (unsigned int i=0; i<_mesh_dimension; ++i)
               {
-                long int dof_number = _current_node->dof_number(0, _vars(i), 0);
+                dof_id_type dof_number = _current_node->dof_number(0, _vars(i), 0);
                 jac_vec(i) = (*_jacobian)(dof_number, _connected_dof_indices[_j]);
               }
               return pinfo->_normal(_component)*(pinfo->_normal*jac_vec) * _test_master[_i][_qp];
@@ -604,7 +605,7 @@ MechanicalContactConstraint::computeQpOffDiagJacobian(Moose::ConstraintJacobianT
               RealVectorValue jac_vec;
               for (unsigned int i=0; i<_mesh_dimension; ++i)
               {
-                long int dof_number = _current_node->dof_number(0, _vars(i), 0);
+                dof_id_type dof_number = _current_node->dof_number(0, _vars(i), 0);
                 jac_vec(i) = (*_jacobian)(dof_number, _connected_dof_indices[_j]);
               }
               return -pinfo->_normal(_component) * (pinfo->_normal*jac_vec) + (_phi_slave[_j][_qp] * penalty * _test_slave[_i][_qp]) * pinfo->_normal(_component) * normal_component_in_coupled_var_dir;
@@ -638,7 +639,7 @@ MechanicalContactConstraint::computeQpOffDiagJacobian(Moose::ConstraintJacobianT
               RealVectorValue jac_vec;
               for (unsigned int i=0; i<_mesh_dimension; ++i)
               {
-                long int dof_number = _current_node->dof_number(0, _vars(i), 0);
+                dof_id_type dof_number = _current_node->dof_number(0, _vars(i), 0);
                 jac_vec(i) = (*_jacobian)(dof_number, curr_master_node->dof_number(0, _vars(_component), 0));
               }
               return -pinfo->_normal(_component)*(pinfo->_normal*jac_vec) - (_phi_master[_j][_qp] * penalty * _test_slave[_i][_qp]) * pinfo->_normal(_component) * normal_component_in_coupled_var_dir;
@@ -667,7 +668,7 @@ MechanicalContactConstraint::computeQpOffDiagJacobian(Moose::ConstraintJacobianT
               RealVectorValue jac_vec;
               for (unsigned int i=0; i<_mesh_dimension; ++i)
               {
-                long int dof_number = _current_node->dof_number(0, _vars(i), 0);
+                dof_id_type dof_number = _current_node->dof_number(0, _vars(i), 0);
                 jac_vec(i) = (*_jacobian)(dof_number, _connected_dof_indices[_j]);
               }
               return pinfo->_normal(_component)*(pinfo->_normal*jac_vec) * _test_master[_i][_qp];
@@ -727,7 +728,7 @@ MechanicalContactConstraint::nodalArea(PenetrationInfo & pinfo)
 {
   const Node * node = pinfo._node;
 
-  unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
+  dof_id_type dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
 
   Real area = (*_aux_solution)( dof );
   if (area == 0)

--- a/modules/contact/src/MultiDContactConstraint.C
+++ b/modules/contact/src/MultiDContactConstraint.C
@@ -76,12 +76,12 @@ MultiDContactConstraint::jacobianSetup()
 void
 MultiDContactConstraint::updateContactSet()
 {
-  std::set<unsigned int> & has_penetrated = _penetration_locator._has_penetrated;
-//  std::map<unsigned int, unsigned> & unlocked_this_step = _penetration_locator._unlocked_this_step;
-  std::map<unsigned int, unsigned> & locked_this_step = _penetration_locator._unlocked_this_step;
+  std::set<dof_id_type> & has_penetrated = _penetration_locator._has_penetrated;
+  std::map<dof_id_type, unsigned int> & locked_this_step = _penetration_locator._unlocked_this_step;
 
-  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator
+    it  = _penetration_locator._penetration_info.begin(),
+    end = _penetration_locator._penetration_info.end();
 
   for (; it!=end; ++it)
   {
@@ -94,14 +94,14 @@ MultiDContactConstraint::updateContactSet()
 
     const Node * node = pinfo->_node;
 
-    unsigned int slave_node_num = it->first;
-    std::set<unsigned int>::iterator hpit = has_penetrated.find(slave_node_num);
+    dof_id_type slave_node_num = it->first;
+    std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
 
     RealVectorValue res_vec;
     // Build up residual vector
     for (unsigned int i=0; i<_mesh_dimension; ++i)
     {
-      int dof_number = node->dof_number(0, _vars(i), 0);
+      dof_id_type dof_number = node->dof_number(0, _vars(i), 0);
       res_vec(i) = _residual_copy(dof_number);
     }
 
@@ -147,7 +147,7 @@ MultiDContactConstraint::updateContactSet()
 bool
 MultiDContactConstraint::shouldApply()
 {
-  std::set<unsigned int>::iterator hpit = _penetration_locator._has_penetrated.find(_current_node->id());
+  std::set<dof_id_type>::iterator hpit = _penetration_locator._has_penetrated.find(_current_node->id());
   return (hpit != _penetration_locator._has_penetrated.end());
 }
 
@@ -177,7 +177,7 @@ MultiDContactConstraint::computeQpResidual(Moose::ConstraintType type)
   // Build up residual vector
   for (unsigned int i=0; i<_mesh_dimension; ++i)
   {
-    int dof_number = node->dof_number(0, _vars(i), 0);
+    dof_id_type dof_number = node->dof_number(0, _vars(i), 0);
     res_vec(i) = _residual_copy(dof_number);
   }
 

--- a/modules/contact/src/NodalArea.C
+++ b/modules/contact/src/NodalArea.C
@@ -77,7 +77,7 @@ NodalArea::finalize()
   for ( std::map<const Node *, Real>::iterator it = _node_areas.begin(); it != it_end; ++it )
   {
     const Node * const node = it->first;
-    unsigned int dof = node->dof_number(_system.number(), _variable->number(), 0);
+    dof_id_type dof = node->dof_number(_system.number(), _variable->number(), 0);
     _aux_solution.set( dof, 0 );
   }
   _aux_solution.close();
@@ -85,7 +85,7 @@ NodalArea::finalize()
   for ( std::map<const Node *, Real>::iterator it = _node_areas.begin(); it != it_end; ++it )
   {
     const Node * const node = it->first;
-    unsigned int dof = node->dof_number(_system.number(), _variable->number(), 0);
+    dof_id_type dof = node->dof_number(_system.number(), _variable->number(), 0);
     _aux_solution.add( dof, it->second );
   }
   _aux_solution.close();

--- a/modules/contact/src/OneDContactConstraint.C
+++ b/modules/contact/src/OneDContactConstraint.C
@@ -50,10 +50,11 @@ OneDContactConstraint::jacobianSetup()
 void
 OneDContactConstraint::updateContactSet()
 {
-  std::set<unsigned int> & has_penetrated = _penetration_locator._has_penetrated;
+  std::set<dof_id_type> & has_penetrated = _penetration_locator._has_penetrated;
 
-  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator
+    it  = _penetration_locator._penetration_info.begin(),
+    end = _penetration_locator._penetration_info.end();
 
   for (; it!=end; ++it)
   {
@@ -66,7 +67,7 @@ OneDContactConstraint::updateContactSet()
 
     if (pinfo->_distance > 0)
     {
-      unsigned int slave_node_num = it->first;
+      dof_id_type slave_node_num = it->first;
       has_penetrated.insert(slave_node_num);
     }
   }
@@ -75,7 +76,7 @@ OneDContactConstraint::updateContactSet()
 bool
 OneDContactConstraint::shouldApply()
 {
-  std::set<unsigned int>::iterator hpit = _penetration_locator._has_penetrated.find(_current_node->id());
+  std::set<dof_id_type>::iterator hpit = _penetration_locator._has_penetrated.find(_current_node->id());
   return (hpit != _penetration_locator._has_penetrated.end());
 }
 

--- a/modules/contact/src/ReferenceResidualProblem.C
+++ b/modules/contact/src/ReferenceResidualProblem.C
@@ -148,15 +148,15 @@ ReferenceResidualProblem::updateReferenceResidual()
 
 MooseNonlinearConvergenceReason
 ReferenceResidualProblem::checkNonlinearConvergence(std::string &msg,
-                                                    const int it,
+                                                    const PetscInt it,
                                                     const Real xnorm,
                                                     const Real snorm,
                                                     const Real fnorm,
                                                     const Real rtol,
                                                     const Real stol,
                                                     const Real abstol,
-                                                    const int nfuncs,
-                                                    const int max_funcs,
+                                                    const PetscInt nfuncs,
+                                                    const PetscInt max_funcs,
                                                     const Real ref_resid,
                                                     const Real /*div_threshold*/)
 {
@@ -229,7 +229,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string &msg,
   }
 
   system._last_nl_rnorm = fnorm;
-  system._current_nl_its = it;
+  system._current_nl_its = static_cast<unsigned int>(it);
 
   msg = oss.str();
 

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -74,10 +74,11 @@ SlaveConstraint::addPoints()
 {
   _point_to_info.clear();
 
-  std::set<unsigned int> & has_penetrated = _penetration_locator._has_penetrated;
+  std::set<dof_id_type> & has_penetrated = _penetration_locator._has_penetrated;
 
-  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator
+    it  = _penetration_locator._penetration_info.begin(),
+    end = _penetration_locator._penetration_info.end();
   for (; it!=end; ++it)
   {
     PenetrationInfo * pinfo = it->second;
@@ -87,11 +88,11 @@ SlaveConstraint::addPoints()
       continue;
     }
 
-    unsigned int slave_node_num = it->first;
+    dof_id_type slave_node_num = it->first;
 
     const Node * node = pinfo->_node;
 
-    std::set<unsigned int>::iterator hpit( has_penetrated.find( slave_node_num ) );
+    std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);
     if (hpit != has_penetrated.end() && node->processor_id() == processor_id())
     {
       // Find an element that is connected to this node that and that is also on this processor
@@ -273,7 +274,7 @@ SlaveConstraint::nodalArea(PenetrationInfo & pinfo)
 {
   const Node * node = pinfo._node;
 
-  unsigned int dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
+  dof_id_type dof = node->dof_number(_aux_system.number(), _nodal_area_var->number(), 0);
 
   Real area = (*_aux_solution)( dof );
   if (area == 0)

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -96,7 +96,7 @@ SlaveConstraint::addPoints()
     {
       // Find an element that is connected to this node that and that is also on this processor
 
-      std::vector<unsigned int> & connected_elems = _mesh.nodeToElemMap()[slave_node_num];
+      std::vector<dof_id_type> & connected_elems = _mesh.nodeToElemMap()[slave_node_num];
 
       Elem * elem = NULL;
 

--- a/modules/contact/src/SparsityBasedContactConstraint.C
+++ b/modules/contact/src/SparsityBasedContactConstraint.C
@@ -42,7 +42,12 @@ SparsityBasedContactConstraint::getConnectedDofIndices()
   PetscErrorCode ierr;
   PetscInt ncols;
   const PetscInt *cols;
-  ierr = MatGetRow(jac,_var.nodalDofIndex(),&ncols,&cols,PETSC_NULL);CHKERRABORT(_communicator.get(), ierr);
+  ierr = MatGetRow(jac,
+                   static_cast<PetscInt>(_var.nodalDofIndex()),
+                   &ncols,
+                   &cols,
+                   PETSC_NULL);
+  CHKERRABORT(_communicator.get(), ierr);
   bool debug = false;
   if (debug) {
     libMesh::out << "_connected_dof_indices: adding " << ncols << " dofs from Jacobian row[" << _var.nodalDofIndex() << "] = [";
@@ -56,7 +61,12 @@ SparsityBasedContactConstraint::getConnectedDofIndices()
   if (debug) {
     libMesh::out << "]\n";
   }
-  ierr = MatRestoreRow(jac,_var.nodalDofIndex(),&ncols,&cols,PETSC_NULL);CHKERRABORT(_communicator.get(), ierr);
+  ierr = MatRestoreRow(jac,
+                       static_cast<PetscInt>(_var.nodalDofIndex()),
+                       &ncols,
+                       &cols,
+                       PETSC_NULL);
+  CHKERRABORT(_communicator.get(), ierr);
 #else
   NodeFaceConstraint::getConnectedDofIndices();
 #endif

--- a/modules/heat_conduction/src/GapConductance.C
+++ b/modules/heat_conduction/src/GapConductance.C
@@ -251,7 +251,7 @@ GapConductance::computeGapValues()
 
       Elem * slave_side = pinfo->_side;
       std::vector<std::vector<Real> > & slave_side_phi = pinfo->_side_phi;
-      std::vector<unsigned int> slave_side_dof_indices;
+      std::vector<dof_id_type> slave_side_dof_indices;
 
       _dof_map->dof_indices(slave_side, slave_side_dof_indices, _temp_var->number());
 

--- a/modules/heat_conduction/src/GapHeatPointSourceMaster.C
+++ b/modules/heat_conduction/src/GapHeatPointSourceMaster.C
@@ -47,8 +47,9 @@ GapHeatPointSourceMaster::addPoints()
 
   _slave_flux.close();
 
-  std::map<unsigned int, PenetrationInfo *>::iterator it = _penetration_locator._penetration_info.begin();
-  std::map<unsigned int, PenetrationInfo *>::iterator end = _penetration_locator._penetration_info.end();
+  std::map<dof_id_type, PenetrationInfo *>::iterator
+    it  = _penetration_locator._penetration_info.begin(),
+    end = _penetration_locator._penetration_info.end();
 
   for (; it!=end; ++it)
   {

--- a/modules/phase_field/include/postprocessors/NodalFloodCount.h
+++ b/modules/phase_field/include/postprocessors/NodalFloodCount.h
@@ -61,11 +61,11 @@ public:
   virtual Real getValue();
 
   // Retrieve field information
-  virtual Real getNodalValue(unsigned int node_id, unsigned int var_idx=0, bool show_var_coloring=false) const;
-  virtual Real getElementalValue(unsigned int element_id) const;
+  virtual Real getNodalValue(dof_id_type node_id, unsigned int var_idx=0, bool show_var_coloring=false) const;
+  virtual Real getElementalValue(dof_id_type element_id) const;
 
-  virtual const std::vector<std::pair<unsigned int, unsigned int> > & getNodalValues(unsigned int /*node_id*/) const;
-  virtual std::vector<std::vector<std::pair<unsigned int, unsigned int> > > getElementalValues(unsigned int /*elem_id*/) const;
+  virtual const std::vector<std::pair<unsigned int, unsigned int> > & getNodalValues(dof_id_type /*node_id*/) const;
+  virtual std::vector<std::vector<std::pair<unsigned int, unsigned int> > > getElementalValues(dof_id_type /*elem_id*/) const;
 
 protected:
   class BubbleData
@@ -113,7 +113,7 @@ protected:
    * This routine adds the periodic node information to our data structure prior to packing the data
    * this makes those periodic neighbors appear much like ghosted nodes in a multiprocessor setting
    */
-  unsigned int appendPeriodicNeighborNodes(std::set<unsigned int> & data) const;
+  unsigned int appendPeriodicNeighborNodes(std::set<dof_id_type> & data) const;
 
   /**
    * This routine updates the _region_offsets variable which is useful for quickly determining
@@ -212,20 +212,20 @@ protected:
    * for this since we don't want to explicitly store data for all the unmarked nodes in a serialized datastructures.
    * This keeps our overhead down since this variable never needs to be communicated.
    */
-  std::vector<std::map<unsigned int, bool> > _nodes_visited;
+  std::vector<std::map<dof_id_type, bool> > _nodes_visited;
 
   /**
    * The bubble maps contain the raw flooded node information and eventually the unique grain numbers.  We have a vector
    * of them so we can create one per variable if that level of detail is desired.
    */
-  std::vector<std::map<unsigned int, int> > _bubble_maps;
+  std::vector<std::map<dof_id_type, int> > _bubble_maps;
 
   /**
    * This map keeps track of which variables own which nodes.  We need a vector of them for multimap mode where
    * multiple variables can own a single mode.  Note: This map is only populated when "show_var_coloring" is set
    * to true.
    */
-  std::vector<std::map<unsigned int, int> > _var_index_maps;
+  std::vector<std::map<dof_id_type, int> > _var_index_maps;
 
   /// The data structure used to marshall the data between processes and/or threads
   std::vector<unsigned int> _packed_data;
@@ -258,7 +258,7 @@ protected:
    * The data structure which is a list of nodes that are constrained to other nodes
    * based on the imposed periodic boundary conditions.
    */
-  std::multimap<unsigned int, unsigned int> _periodic_node_map;
+  std::multimap<dof_id_type, dof_id_type> _periodic_node_map;
 
   /**
    * The filename and filehandle used if bubble volumes are being recorded to a file.

--- a/modules/phase_field/include/postprocessors/NodalFloodCount.h
+++ b/modules/phase_field/include/postprocessors/NodalFloodCount.h
@@ -71,13 +71,13 @@ protected:
   class BubbleData
   {
   public:
-    BubbleData(std::set<unsigned int> & nodes, unsigned int var_idx) :
+    BubbleData(std::set<dof_id_type> & nodes, unsigned int var_idx) :
         _nodes(nodes),
         _var_idx(var_idx),
         _intersects_boundary(false)
     {}
 
-    std::set<unsigned int> _nodes;
+    std::set<dof_id_type> _nodes;
     unsigned int _var_idx;
     bool _intersects_boundary;
   };

--- a/modules/phase_field/src/postprocessors/NodalFloodCount.C
+++ b/modules/phase_field/src/postprocessors/NodalFloodCount.C
@@ -369,7 +369,7 @@ NodalFloodCount::unpack(const std::vector<unsigned int> & packed_data)
   bool has_data_to_save = false;
 
   unsigned int curr_set_length = 0;
-  std::set<unsigned int> curr_set;
+  std::set<dof_id_type> curr_set;
   unsigned int curr_var_idx = std::numeric_limits<unsigned int>::max();
 
   _region_to_var_idx.clear();
@@ -420,8 +420,8 @@ void
 NodalFloodCount::mergeSets()
 {
   Moose::perf_log.push("mergeSets()", "NodalFloodCount");
-  std::set<unsigned int> set_union;
-  std::insert_iterator<std::set<unsigned int> > set_union_inserter(set_union, set_union.begin());
+  std::set<dof_id_type> set_union;
+  std::insert_iterator<std::set<dof_id_type> > set_union_inserter(set_union, set_union.begin());
 
   for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
   {
@@ -471,7 +471,7 @@ NodalFloodCount::updateFieldInfo()
     unsigned int counter = 1;
     for (std::list<BubbleData>::iterator it1 = _bubble_sets[map_num].begin(); it1 != _bubble_sets[map_num].end(); ++it1)
     {
-      for (std::set<unsigned int>::iterator it2 = it1->_nodes.begin(); it2 != it1->_nodes.end(); ++it2)
+      for (std::set<dof_id_type>::iterator it2 = it1->_nodes.begin(); it2 != it1->_nodes.end(); ++it2)
       {
         // Color the bubble map with a unique region
         _bubble_maps[map_num][*it2] = counter;

--- a/modules/richards/src/base/RichardsMultiphaseProblem.C
+++ b/modules/richards/src/base/RichardsMultiphaseProblem.C
@@ -78,7 +78,7 @@ RichardsMultiphaseProblem::updateSolution(NumericVector<Number>& vec_solution, N
 
     // dofs[0] is the dof number of the bounded variable at this node
     // dofs[1] is the dof number of the lower variable at this node
-    std::vector<unsigned int> dofs(2);
+    std::vector<dof_id_type> dofs(2);
     dofs[0] = node.dof_number(sys_num, _bounded_var_num, 0);
     dofs[1] = node.dof_number(sys_num, _lower_var_num, 0);
 

--- a/modules/solid_mechanics/include/userobjects/CrackFrontDefinition.h
+++ b/modules/solid_mechanics/include/userobjects/CrackFrontDefinition.h
@@ -90,13 +90,13 @@ protected:
   bool _closed_loop;
   unsigned int _axis_2d;
 
-  void getCrackFrontNodes(std::set<unsigned int>& nodes);
-  void orderCrackFrontNodes(std::set<unsigned int>& nodes);
-  void orderEndNodes(std::vector<unsigned int> &end_nodes);
-  void pickLoopCrackEndNodes(std::vector<unsigned int> &end_nodes,
-                             std::set<unsigned int> &nodes,
-                             std::map<unsigned int, std::vector<unsigned int> > &node_to_line_elem_map,
-                             std::vector<std::vector<unsigned int> > &line_elems);
+  void getCrackFrontNodes(std::set<dof_id_type>& nodes);
+  void orderCrackFrontNodes(std::set<dof_id_type>& nodes);
+  void orderEndNodes(std::vector<dof_id_type> &end_nodes);
+  void pickLoopCrackEndNodes(std::vector<dof_id_type> &end_nodes,
+                             std::set<dof_id_type> &nodes,
+                             std::map<dof_id_type, std::vector<dof_id_type> > &node_to_line_elem_map,
+                             std::vector<std::vector<dof_id_type> > &line_elems);
   unsigned int maxNodeCoor(std::vector<Node *>& nodes, unsigned int dir0=0);
   void updateCrackFrontGeometry();
   void updateDataForCrackDirection();

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -83,6 +83,7 @@ class TestHarness:
       self.checks['unique_ids'] = set(['ALL'])
       self.checks['vtk'] = set(['ALL'])
       self.checks['tecplot'] = set(['ALL'])
+      self.checks['dof_id_bytes'] = set(['ALL'])
     else:
       self.checks['compiler'] = getCompilers(self.libmesh_dir)
       self.checks['petsc_version'] = getPetscVersion(self.libmesh_dir)
@@ -92,6 +93,7 @@ class TestHarness:
       self.checks['unique_ids'] = getLibMeshConfigOption(self.libmesh_dir, 'unique_ids')
       self.checks['vtk'] =  getLibMeshConfigOption(self.libmesh_dir, 'vtk')
       self.checks['tecplot'] =  getLibMeshConfigOption(self.libmesh_dir, 'tecplot')
+      self.checks['dof_id_bytes'] = getLibMeshConfigOption(self.libmesh_dir, 'dof_id_bytes')
 
     # Override the MESH_MODE option if using '--parallel-mesh' option
     if self.options.parallel_mesh == True or \

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -37,6 +37,7 @@ class Tester(MooseObject):
     params.addParam('recover',       True,    "A test that runs with '--recover' mode enabled")
     params.addParam('vtk',           ['ALL'], "A test that runs only if VTK is detected ('ALL', 'TRUE', 'FALSE')")
     params.addParam('tecplot',       ['ALL'], "A test that runs only if Tecplot is detected ('ALL', 'TRUE', 'FALSE')")
+    params.addParam('dof_id_bytes',  ['ALL'], "A test that runs only if libmesh is configured --with-dof-id-bytes = a specific number, e.g. '4', '8'")
 
     return params
 
@@ -172,6 +173,11 @@ class Tester(MooseObject):
     # Check for positive scale refine values when using store timing options
     if self.specs['scale_refine'] == 0 and options.store_time:
       return (False, reason)
+
+    # There should only be one entry in self.specs['dof_id_bytes']
+    for x in self.specs['dof_id_bytes']:
+      if x != 'ALL' and not x in checks['dof_id_bytes']:
+        return (False, 'skipped (--with-dof-id-bytes!=' + x + ')')
 
     # Check the return values of the derived classes
     return self.checkRunnable(options)

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -51,6 +51,9 @@ LIBMESH_OPTIONS = {
   'petsc_minor' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_PETSC_VERSION_MINOR\s+(\d+)',
                      'default'   : '1'
                    },
+  'dof_id_bytes' : { 're_option' : r'#define\s+LIBMESH_DOF_ID_BYTES\s+(\d+)',
+                     'default'   : '4'
+                   },
 }
 
 

--- a/test/src/userobjects/TrackDiracFront.C
+++ b/test/src/userobjects/TrackDiracFront.C
@@ -65,11 +65,11 @@ TrackDiracFront::finalize()
 Elem *
 TrackDiracFront::localElementConnectedToCurrentNode()
 {
-  std::map< unsigned int, std::vector< unsigned int > > & _node_to_elem_map = _mesh.nodeToElemMap();
+  std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map = _mesh.nodeToElemMap();
 
   dof_id_type id = _current_node->id();
 
-  const std::vector< unsigned int > & connected_elems = _node_to_elem_map.at(id);
+  const std::vector<dof_id_type> & connected_elems = _node_to_elem_map.at(id);
 
   unsigned int pid = processor_id(); // This processor id
 

--- a/test/tests/auxkernels/solution_aux/tests
+++ b/test/tests/auxkernels/solution_aux/tests
@@ -131,6 +131,10 @@
     exodiff = 'aux_nonlinear_solution_xdr_out.e'
     prereq = aux_nonlinear_solution
     max_threads = 1 # ticket 2283
+    # This test reads a binary file that was written with 4-byte dof
+    # ids.  At this time, it is only possible to read it back in with
+    # a libmesh that also uses 4-byte dof ids.
+    dof_id_bytes = 4
   [../]
 
   [./aux_nonlinear_solution_adapt]


### PR DESCRIPTION
This branch gets MOOSE compiling and running when PETSc is configured with `--with-64-bit-indices=1`, and libmesh is configured with `--with-dof-id-bytes=8`.

This commit _shouldn't_ break anything for anyone using 32-bit indices, it's basically enforcing consistent use of `dof_id_type` over `unsigned int` where necessary.  By the same token, new invalid uses of `unsigned int` will probably continue to creep into the code unless we're really vigilant, so it might be worth creating a "big indices" build target going forward...

Refs #4321.
