### PR TITLE
Allow overridding LIBMESH_DIR in update_and_rebuild_libmesh.sh

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -2,7 +2,17 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-export LIBMESH_DIR=$SCRIPT_DIR/../libmesh/installed
+if [ ! -z "$LIBMESH_DIR" ]; then
+  echo "INFO: LIBMESH_DIR set - overriding default installed path"
+  echo "INFO: No cleaning will be done in specified path"
+  mkdir -p $LIBMESH_DIR
+else
+  export LIBMESH_DIR=$SCRIPT_DIR/../libmesh/installed
+  cd $SCRIPT_DIR/../libmesh
+  rm -rf installed
+  cd - >/dev/null # Make this quiet
+fi
+
 export METHODS=${METHODS:="opt oprof dbg"}
 
 cd $SCRIPT_DIR/..
@@ -20,7 +30,7 @@ fi
 
 cd $SCRIPT_DIR/../libmesh
 
-rm -rf build installed
+rm -rf build
 mkdir build
 cd build
 


### PR DESCRIPTION
This commit allows the user to set LIBMESH_DIR in their environment and have it honored
when running update_and_rebuild_libmesh.sh. This will allow multiple installed
libmesh versions at the same time. Note that this script will not automatically
delete the contents of LIBMESH_DIR when set for the user's safety.

closes #4431
