### PR TITLE
Add option to disable FPOptimizer

### DIFF
--- a/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
@@ -68,6 +68,7 @@ protected:
 
   /// feature flags
   bool _enable_jit;
+  bool _disable_fpoptimizer;
   bool _fail_on_evalerror;
 
   /// appropriate not a number value to return


### PR DESCRIPTION
Add the `disable_fpoptimizer` to `DerivativeParsedMaterialHelper`. Defaults to `false` and is mostly useful for debugging (to check if the functions optimize correctly). Closes #4444.
