### PR TITLE
Make sure that we *always* notify the runner of skipped jobs...

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -195,7 +195,7 @@ class TestHarness:
                   else: # This job is skipped - notify the runner
                     if (reason != ''):
                       self.handleTestResult(tester.parameters(), '', reason)
-                      self.runner.jobSkipped(tester.parameters()['test_name'])
+                    self.runner.jobSkipped(tester.parameters()['test_name'])
 
               os.chdir(saved_cwd)
               sys.path.pop()


### PR DESCRIPTION
even when the reason is blank.

which signifies that we don't want to see the job in the status table. This fixes the
issue where the runner doesn't know about a dependency that was prunned due to the use
of a group, re, or other test filter which caused an "Invalid dependency Error".

TL;DR python whitespace fix.

refs #4407
