### PR TITLE
Factor out coupling to MooseVariable * 

### DIFF
--- a/framework/include/auxkernels/AuxKernel.h
+++ b/framework/include/auxkernels/AuxKernel.h
@@ -89,7 +89,7 @@ public:
 
   const std::set<std::string> & getDependObjects() const { return _depend_uo; }
 
-  void coupledCallback(const std::string & var_name, bool is_old);
+  void coupledCallback(MooseVariable * var, bool is_old);
 
   virtual const std::set<std::string> & getRequestedItems();
 

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -67,7 +67,7 @@ protected:
    */
   unsigned int coupledComponents(const std::string & var_name);
 
-  virtual void coupledCallback(const std::string & var_name, bool is_old);
+  virtual void coupledCallback(MooseVariable * var, bool is_old);
 
   /**
    * Returns the index for a coupled variable by name
@@ -95,6 +95,7 @@ protected:
    * @see Kernel::valueOld
    */
   virtual VariableValue & coupledValueOld(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledValueOld(MooseVariable * var);
 
   /**
    * Returns an old value from two time steps previous of a coupled variable
@@ -104,6 +105,7 @@ protected:
    * @see Kernel::valueOlder
    */
   virtual VariableValue & coupledValueOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledValueOlder(MooseVariable * var);
 
   /**
    * Returns gradient of a coupled variable
@@ -113,6 +115,7 @@ protected:
    * @see Kernel::gradient
    */
   virtual VariableGradient & coupledGradient(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableGradient & coupledGradient(MooseVariable * var);
 
   /**
    * Returns an old gradient from previous time step of a coupled variable
@@ -122,6 +125,7 @@ protected:
    * @see Kernel::gradientOld
    */
   virtual VariableGradient & coupledGradientOld(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableGradient & coupledGradientOld(MooseVariable * var);
 
   /**
    * Returns an old gradient from two time steps previous of a coupled variable
@@ -131,6 +135,7 @@ protected:
    * @see Kernel::gradientOlder
    */
   virtual VariableGradient & coupledGradientOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableGradient & coupledGradientOlder(MooseVariable * var);
 
   /**
    * Returns second derivative of a coupled variable
@@ -140,6 +145,7 @@ protected:
    * @see Kernel::second
    */
   virtual VariableSecond & coupledSecond(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableSecond & coupledSecond(MooseVariable * var);
 
   /**
    * Returns an old second derivative from previous time step of a coupled variable
@@ -149,6 +155,7 @@ protected:
    * @see Kernel::secondOld
    */
   virtual VariableSecond & coupledSecondOld(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableSecond & coupledSecondOld(MooseVariable * var);
 
   /**
    * Returns an old second derivative from two time steps previous of a coupled variable
@@ -158,6 +165,7 @@ protected:
    * @see Kernel::secondOlder
    */
   virtual VariableSecond & coupledSecondOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableSecond & coupledSecondOlder(MooseVariable * var);
 
   /**
    * Time derivative of a coupled variable
@@ -167,6 +175,7 @@ protected:
    * @see Kernel::dot
    */
   virtual VariableValue & coupledDot(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledDot(MooseVariable * var);
 
   /**
    * Time derivative of a coupled variable with respect to the coefficients
@@ -176,6 +185,7 @@ protected:
    * @see Kernel:dotDu
    */
   virtual VariableValue & coupledDotDu(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledDotDu(MooseVariable * var);
 
   /**
    * Returns nodal values of a coupled variable
@@ -184,6 +194,7 @@ protected:
    * @return Reference to a VariableValue for the coupled variable
    */
   virtual VariableValue & coupledNodalValue(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledNodalValue(MooseVariable * var);
 
   /**
    * Returns an old nodal value from previous time step  of a coupled variable
@@ -192,6 +203,7 @@ protected:
    * @return Reference to a VariableValue containing the old value of the coupled variable
    */
   virtual VariableValue & coupledNodalValueOld(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledNodalValueOld(MooseVariable * var);
 
   /**
    * Returns an old nodal value from two time steps previous of a coupled variable
@@ -200,6 +212,7 @@ protected:
    * @return Reference to a VariableValue containing the older value of the coupled variable
    */
   virtual VariableValue & coupledNodalValueOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledNodalValueOlder(MooseVariable * var);
 
 protected:
   // Reference to FEProblem
@@ -245,7 +258,7 @@ protected:
    * are coupled in.
    * @param name the name of the variable
    */
-  void validateExecutionerType(const std::string & name) const;
+  void validateExecutionerType(MooseVariable * var) const;
 
 private:
   /// Maximum qps for any element in this system

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -85,6 +85,7 @@ protected:
    * @see Kernel::value
    */
   virtual VariableValue & coupledValue(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledValue(MooseVariable * var);
 
   /**
    * Returns an old value from previous time step  of a coupled variable

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -145,14 +145,10 @@ AuxKernel::getPostprocessorValueByName(const PostprocessorName & name)
 }
 
 void
-AuxKernel::coupledCallback(const std::string & var_name, bool is_old)
+AuxKernel::coupledCallback(MooseVariable * var, bool is_old)
 {
   if (is_old)
-  {
-    std::vector<VariableName> var_names = getParam<std::vector<VariableName> >(var_name);
-    for (std::vector<VariableName>::const_iterator it = var_names.begin(); it != var_names.end(); ++it)
-      _depend_vars.erase(*it);
-  }
+    _depend_vars.erase(var->name());
 }
 
 void

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -144,7 +144,12 @@ Coupleable::coupledValue(const std::string & var_name, unsigned int comp)
   }
 
   coupledCallback(var_name, false);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledValue(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledValue(MooseVariable * var)
+{
   if (_nodal)
     return (_c_is_implicit) ? var->nodalSln() : var->nodalSlnOld();
   else

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -75,7 +75,7 @@ Coupleable::~Coupleable()
 }
 
 void
-Coupleable::coupledCallback(const std::string & /*var_name*/, bool /*is_old*/)
+Coupleable::coupledCallback(MooseVariable * /*var*/, bool /*is_old*/)
 {
 }
 
@@ -143,13 +143,14 @@ Coupleable::coupledValue(const std::string & var_name, unsigned int comp)
     return *_default_value[var_name];
   }
 
-  coupledCallback(var_name, false);
   return coupledValue(getVar(var_name, comp));
 }
 
 VariableValue &
 Coupleable::coupledValue(MooseVariable * var)
 {
+  coupledCallback(var, false);
+
   if (_nodal)
     return (_c_is_implicit) ? var->nodalSln() : var->nodalSlnOld();
   else
@@ -170,9 +171,15 @@ Coupleable::coupledValueOld(const std::string & var_name, unsigned int comp)
     return *_default_value[var_name];
   }
 
-  validateExecutionerType(var_name);
-  coupledCallback(var_name, true);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledValueOld(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledValueOld(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     return (_c_is_implicit) ? var->nodalSlnOld() : var->nodalSlnOlder();
   else
@@ -193,9 +200,15 @@ Coupleable::coupledValueOlder(const std::string & var_name, unsigned int comp)
     return *_default_value[var_name];
   }
 
-  validateExecutionerType(var_name);
-  coupledCallback(var_name, true);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledValueOlder(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledValueOlder(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
   {
     if (_c_is_implicit)
@@ -212,14 +225,19 @@ Coupleable::coupledValueOlder(const std::string & var_name, unsigned int comp)
   }
 }
 
+
 VariableValue &
 Coupleable::coupledDot(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledDot(getVar(var_name, comp));
+}
 
+VariableValue &
+Coupleable::coupledDot(MooseVariable * var)
+{
   if (_nodal)
     return var->nodalSlnDot();
   else
@@ -232,8 +250,12 @@ Coupleable::coupledDotDu(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledDotDu(getVar(var_name, comp));
+}
 
+VariableValue &
+Coupleable::coupledDotDu(MooseVariable * var)
+{
   if (_nodal)
     return var->nodalSlnDuDotDu();
   else
@@ -247,11 +269,17 @@ Coupleable::coupledGradient(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_gradient;
 
-  coupledCallback(var_name, false);
+  return coupledGradient(getVar(var_name, comp));
+}
+
+VariableGradient &
+Coupleable::coupledGradient(MooseVariable * var)
+{
+  coupledCallback(var, false);
+
   if (_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->gradSln() : var->gradSlnOld();
 }
 
@@ -260,13 +288,18 @@ Coupleable::coupledGradientOld(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
     return _default_gradient;
+  return coupledGradientOld(getVar(var_name, comp));
+}
 
-  coupledCallback(var_name, true);
+VariableGradient &
+Coupleable::coupledGradientOld(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
-  MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->gradSlnOld() : var->gradSlnOlder();
 }
 
@@ -276,17 +309,24 @@ Coupleable::coupledGradientOlder(const std::string & var_name, unsigned int comp
   if (!isCoupled(var_name)) // Return default 0
     return _default_gradient;
 
-  coupledCallback(var_name, true);
+  return coupledGradientOlder(getVar(var_name, comp));
+}
+
+VariableGradient &
+Coupleable::coupledGradientOlder(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
-  MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
     return var->gradSlnOlder();
   else
     mooseError("Older values not available for explicit schemes");
 }
+
 
 VariableSecond &
 Coupleable::coupledSecond(const std::string & var_name, unsigned int comp)
@@ -294,11 +334,17 @@ Coupleable::coupledSecond(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_second;
 
-  coupledCallback(var_name, false);
+  return coupledSecond(getVar(var_name, comp));
+}
+
+VariableSecond &
+Coupleable::coupledSecond(MooseVariable * var)
+{
+  coupledCallback(var, false);
+
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->secondSln() : var->secondSlnOlder();
 }
 
@@ -308,12 +354,18 @@ Coupleable::coupledSecondOld(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_second;
 
-  coupledCallback(var_name, true);
+  return coupledSecondOld(getVar(var_name, comp));
+}
+
+VariableSecond &
+Coupleable::coupledSecondOld(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  validateExecutionerType(var_name);
-  MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->secondSlnOld() : var->secondSlnOlder();
 }
 
@@ -323,17 +375,24 @@ Coupleable::coupledSecondOlder(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_second;
 
-  coupledCallback(var_name, true);
+  return coupledSecondOlder(getVar(var_name, comp));
+}
+
+VariableSecond &
+Coupleable::coupledSecondOlder(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  validateExecutionerType(var_name);
-  MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
     return var->secondSlnOlder();
   else
     mooseError("Older values not available for explicit schemes");
 }
+
 
 VariableValue &
 Coupleable::coupledNodalValue(const std::string & var_name, unsigned int comp)
@@ -349,8 +408,13 @@ Coupleable::coupledNodalValue(const std::string & var_name, unsigned int comp)
     return *_default_value[var_name];
   }
 
-  coupledCallback(var_name, false);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledNodalValue(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledNodalValue(MooseVariable * var)
+{
+  coupledCallback(var, false);
   return (_c_is_implicit) ? var->nodalValue() : var->nodalValueOld();
 }
 
@@ -368,9 +432,14 @@ Coupleable::coupledNodalValueOld(const std::string & var_name, unsigned int comp
     return *_default_value[var_name];
   }
 
-  validateExecutionerType(var_name);
-  coupledCallback(var_name, true);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledNodalValueOld(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledNodalValueOld(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
   return (_c_is_implicit) ? var->nodalValueOld() : var->nodalValueOlder();
 }
 
@@ -388,9 +457,15 @@ Coupleable::coupledNodalValueOlder(const std::string & var_name, unsigned int co
     return *_default_value[var_name];
   }
 
-  validateExecutionerType(var_name);
-  coupledCallback(var_name, true);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledNodalValueOlder(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledNodalValueOlder(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_c_is_implicit)
     return var->nodalValueOlder();
   else
@@ -398,8 +473,8 @@ Coupleable::coupledNodalValueOlder(const std::string & var_name, unsigned int co
 }
 
 void
-Coupleable::validateExecutionerType(const std::string & name) const
+Coupleable::validateExecutionerType(MooseVariable * var) const
 {
   if (!_c_fe_problem.isTransient())
-    mooseError("You may not couple in old or older values of \"" << name << "\" when using a \"Steady\" executioner.");
+    mooseError("You may not couple in old or older values of \"" << var->name() << "\" when using a \"Steady\" executioner.");
 }

--- a/framework/src/base/NeighborCoupleable.C
+++ b/framework/src/base/NeighborCoupleable.C
@@ -41,9 +41,9 @@ NeighborCoupleable::coupledNeighborValue(const std::string & var_name, unsigned 
 VariableValue &
 NeighborCoupleable::coupledNeighborValueOld(const std::string & var_name, unsigned int comp)
 {
-  validateExecutionerType(var_name);
-
   MooseVariable * var = getVar(var_name, comp);
+  validateExecutionerType(var);
+
   if (_neighbor_nodal)
     return (_c_is_implicit) ? var->nodalSlnOldNeighbor() : var->nodalSlnOlderNeighbor();
   else
@@ -53,9 +53,9 @@ NeighborCoupleable::coupledNeighborValueOld(const std::string & var_name, unsign
 VariableValue &
 NeighborCoupleable::coupledNeighborValueOlder(const std::string & var_name, unsigned int comp)
 {
-  validateExecutionerType(var_name);
-
   MooseVariable * var = getVar(var_name, comp);
+  validateExecutionerType(var);
+
   if (_neighbor_nodal)
   {
     if (_c_is_implicit)
@@ -88,8 +88,8 @@ NeighborCoupleable::coupledNeighborGradientOld(const std::string & var_name, uns
   if (_neighbor_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
   MooseVariable * var = getVar(var_name, comp);
+  validateExecutionerType(var);
   return (_c_is_implicit) ? var->gradSlnOldNeighbor() : var->gradSlnOlderNeighbor();
 }
 
@@ -99,8 +99,8 @@ NeighborCoupleable::coupledNeighborGradientOlder(const std::string & var_name, u
   if (_neighbor_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
   MooseVariable * var = getVar(var_name, comp);
+  validateExecutionerType(var);
   if (_c_is_implicit)
     return var->gradSlnOlderNeighbor();
   else


### PR DESCRIPTION
Addresses the "high risk" part of #4441.

Mostly this change just adds an additional API call to couple to a variable by providing a ``MooseVariable *` rather than an _input parameter name_ and a _coupling component_.

The main behavioural change is in the `coupledCallback` for `AuxKernel`, which now just decouples the variable we are coupling to _now_, not _all_ coupled components. This is how it should be IMO.
