### PR TITLE
Clean up coupling in the Derivative Material System

### DIFF
--- a/framework/include/auxkernels/AuxKernel.h
+++ b/framework/include/auxkernels/AuxKernel.h
@@ -89,7 +89,7 @@ public:
 
   const std::set<std::string> & getDependObjects() const { return _depend_uo; }
 
-  void coupledCallback(const std::string & var_name, bool is_old);
+  void coupledCallback(MooseVariable * var, bool is_old);
 
   virtual const std::set<std::string> & getRequestedItems();
 

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -67,7 +67,7 @@ protected:
    */
   unsigned int coupledComponents(const std::string & var_name);
 
-  virtual void coupledCallback(const std::string & var_name, bool is_old);
+  virtual void coupledCallback(MooseVariable * var, bool is_old);
 
   /**
    * Returns the index for a coupled variable by name
@@ -95,6 +95,7 @@ protected:
    * @see Kernel::valueOld
    */
   virtual VariableValue & coupledValueOld(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledValueOld(MooseVariable * var);
 
   /**
    * Returns an old value from two time steps previous of a coupled variable
@@ -104,6 +105,7 @@ protected:
    * @see Kernel::valueOlder
    */
   virtual VariableValue & coupledValueOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledValueOlder(MooseVariable * var);
 
   /**
    * Returns gradient of a coupled variable
@@ -113,6 +115,7 @@ protected:
    * @see Kernel::gradient
    */
   virtual VariableGradient & coupledGradient(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableGradient & coupledGradient(MooseVariable * var);
 
   /**
    * Returns an old gradient from previous time step of a coupled variable
@@ -122,6 +125,7 @@ protected:
    * @see Kernel::gradientOld
    */
   virtual VariableGradient & coupledGradientOld(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableGradient & coupledGradientOld(MooseVariable * var);
 
   /**
    * Returns an old gradient from two time steps previous of a coupled variable
@@ -131,6 +135,7 @@ protected:
    * @see Kernel::gradientOlder
    */
   virtual VariableGradient & coupledGradientOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableGradient & coupledGradientOlder(MooseVariable * var);
 
   /**
    * Returns second derivative of a coupled variable
@@ -140,6 +145,7 @@ protected:
    * @see Kernel::second
    */
   virtual VariableSecond & coupledSecond(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableSecond & coupledSecond(MooseVariable * var);
 
   /**
    * Returns an old second derivative from previous time step of a coupled variable
@@ -149,6 +155,7 @@ protected:
    * @see Kernel::secondOld
    */
   virtual VariableSecond & coupledSecondOld(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableSecond & coupledSecondOld(MooseVariable * var);
 
   /**
    * Returns an old second derivative from two time steps previous of a coupled variable
@@ -158,6 +165,7 @@ protected:
    * @see Kernel::secondOlder
    */
   virtual VariableSecond & coupledSecondOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableSecond & coupledSecondOlder(MooseVariable * var);
 
   /**
    * Time derivative of a coupled variable
@@ -167,6 +175,7 @@ protected:
    * @see Kernel::dot
    */
   virtual VariableValue & coupledDot(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledDot(MooseVariable * var);
 
   /**
    * Time derivative of a coupled variable with respect to the coefficients
@@ -176,6 +185,7 @@ protected:
    * @see Kernel:dotDu
    */
   virtual VariableValue & coupledDotDu(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledDotDu(MooseVariable * var);
 
   /**
    * Returns nodal values of a coupled variable
@@ -184,6 +194,7 @@ protected:
    * @return Reference to a VariableValue for the coupled variable
    */
   virtual VariableValue & coupledNodalValue(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledNodalValue(MooseVariable * var);
 
   /**
    * Returns an old nodal value from previous time step  of a coupled variable
@@ -192,6 +203,7 @@ protected:
    * @return Reference to a VariableValue containing the old value of the coupled variable
    */
   virtual VariableValue & coupledNodalValueOld(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledNodalValueOld(MooseVariable * var);
 
   /**
    * Returns an old nodal value from two time steps previous of a coupled variable
@@ -200,6 +212,7 @@ protected:
    * @return Reference to a VariableValue containing the older value of the coupled variable
    */
   virtual VariableValue & coupledNodalValueOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledNodalValueOlder(MooseVariable * var);
 
 protected:
   // Reference to FEProblem
@@ -245,7 +258,7 @@ protected:
    * are coupled in.
    * @param name the name of the variable
    */
-  void validateExecutionerType(const std::string & name) const;
+  void validateExecutionerType(MooseVariable * var) const;
 
 private:
   /// Maximum qps for any element in this system

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -85,6 +85,7 @@ protected:
    * @see Kernel::value
    */
   virtual VariableValue & coupledValue(const std::string & var_name, unsigned int comp = 0);
+  virtual VariableValue & coupledValue(MooseVariable * var);
 
   /**
    * Returns an old value from previous time step  of a coupled variable

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -145,14 +145,10 @@ AuxKernel::getPostprocessorValueByName(const PostprocessorName & name)
 }
 
 void
-AuxKernel::coupledCallback(const std::string & var_name, bool is_old)
+AuxKernel::coupledCallback(MooseVariable * var, bool is_old)
 {
   if (is_old)
-  {
-    std::vector<VariableName> var_names = getParam<std::vector<VariableName> >(var_name);
-    for (std::vector<VariableName>::const_iterator it = var_names.begin(); it != var_names.end(); ++it)
-      _depend_vars.erase(*it);
-  }
+    _depend_vars.erase(var->name());
 }
 
 void

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -144,7 +144,12 @@ Coupleable::coupledValue(const std::string & var_name, unsigned int comp)
   }
 
   coupledCallback(var_name, false);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledValue(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledValue(MooseVariable * var)
+{
   if (_nodal)
     return (_c_is_implicit) ? var->nodalSln() : var->nodalSlnOld();
   else

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -75,7 +75,7 @@ Coupleable::~Coupleable()
 }
 
 void
-Coupleable::coupledCallback(const std::string & /*var_name*/, bool /*is_old*/)
+Coupleable::coupledCallback(MooseVariable * /*var*/, bool /*is_old*/)
 {
 }
 
@@ -143,13 +143,14 @@ Coupleable::coupledValue(const std::string & var_name, unsigned int comp)
     return *_default_value[var_name];
   }
 
-  coupledCallback(var_name, false);
   return coupledValue(getVar(var_name, comp));
 }
 
 VariableValue &
 Coupleable::coupledValue(MooseVariable * var)
 {
+  coupledCallback(var, false);
+
   if (_nodal)
     return (_c_is_implicit) ? var->nodalSln() : var->nodalSlnOld();
   else
@@ -170,9 +171,15 @@ Coupleable::coupledValueOld(const std::string & var_name, unsigned int comp)
     return *_default_value[var_name];
   }
 
-  validateExecutionerType(var_name);
-  coupledCallback(var_name, true);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledValueOld(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledValueOld(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     return (_c_is_implicit) ? var->nodalSlnOld() : var->nodalSlnOlder();
   else
@@ -193,9 +200,15 @@ Coupleable::coupledValueOlder(const std::string & var_name, unsigned int comp)
     return *_default_value[var_name];
   }
 
-  validateExecutionerType(var_name);
-  coupledCallback(var_name, true);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledValueOlder(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledValueOlder(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
   {
     if (_c_is_implicit)
@@ -212,14 +225,19 @@ Coupleable::coupledValueOlder(const std::string & var_name, unsigned int comp)
   }
 }
 
+
 VariableValue &
 Coupleable::coupledDot(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledDot(getVar(var_name, comp));
+}
 
+VariableValue &
+Coupleable::coupledDot(MooseVariable * var)
+{
   if (_nodal)
     return var->nodalSlnDot();
   else
@@ -232,8 +250,12 @@ Coupleable::coupledDotDu(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledDotDu(getVar(var_name, comp));
+}
 
+VariableValue &
+Coupleable::coupledDotDu(MooseVariable * var)
+{
   if (_nodal)
     return var->nodalSlnDuDotDu();
   else
@@ -247,11 +269,17 @@ Coupleable::coupledGradient(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_gradient;
 
-  coupledCallback(var_name, false);
+  return coupledGradient(getVar(var_name, comp));
+}
+
+VariableGradient &
+Coupleable::coupledGradient(MooseVariable * var)
+{
+  coupledCallback(var, false);
+
   if (_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->gradSln() : var->gradSlnOld();
 }
 
@@ -260,13 +288,18 @@ Coupleable::coupledGradientOld(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
     return _default_gradient;
+  return coupledGradientOld(getVar(var_name, comp));
+}
 
-  coupledCallback(var_name, true);
+VariableGradient &
+Coupleable::coupledGradientOld(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
-  MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->gradSlnOld() : var->gradSlnOlder();
 }
 
@@ -276,17 +309,24 @@ Coupleable::coupledGradientOlder(const std::string & var_name, unsigned int comp
   if (!isCoupled(var_name)) // Return default 0
     return _default_gradient;
 
-  coupledCallback(var_name, true);
+  return coupledGradientOlder(getVar(var_name, comp));
+}
+
+VariableGradient &
+Coupleable::coupledGradientOlder(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
-  MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
     return var->gradSlnOlder();
   else
     mooseError("Older values not available for explicit schemes");
 }
+
 
 VariableSecond &
 Coupleable::coupledSecond(const std::string & var_name, unsigned int comp)
@@ -294,11 +334,17 @@ Coupleable::coupledSecond(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_second;
 
-  coupledCallback(var_name, false);
+  return coupledSecond(getVar(var_name, comp));
+}
+
+VariableSecond &
+Coupleable::coupledSecond(MooseVariable * var)
+{
+  coupledCallback(var, false);
+
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->secondSln() : var->secondSlnOlder();
 }
 
@@ -308,12 +354,18 @@ Coupleable::coupledSecondOld(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_second;
 
-  coupledCallback(var_name, true);
+  return coupledSecondOld(getVar(var_name, comp));
+}
+
+VariableSecond &
+Coupleable::coupledSecondOld(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  validateExecutionerType(var_name);
-  MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->secondSlnOld() : var->secondSlnOlder();
 }
 
@@ -323,17 +375,24 @@ Coupleable::coupledSecondOlder(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_second;
 
-  coupledCallback(var_name, true);
+  return coupledSecondOlder(getVar(var_name, comp));
+}
+
+VariableSecond &
+Coupleable::coupledSecondOlder(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  validateExecutionerType(var_name);
-  MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
     return var->secondSlnOlder();
   else
     mooseError("Older values not available for explicit schemes");
 }
+
 
 VariableValue &
 Coupleable::coupledNodalValue(const std::string & var_name, unsigned int comp)
@@ -349,8 +408,13 @@ Coupleable::coupledNodalValue(const std::string & var_name, unsigned int comp)
     return *_default_value[var_name];
   }
 
-  coupledCallback(var_name, false);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledNodalValue(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledNodalValue(MooseVariable * var)
+{
+  coupledCallback(var, false);
   return (_c_is_implicit) ? var->nodalValue() : var->nodalValueOld();
 }
 
@@ -368,9 +432,14 @@ Coupleable::coupledNodalValueOld(const std::string & var_name, unsigned int comp
     return *_default_value[var_name];
   }
 
-  validateExecutionerType(var_name);
-  coupledCallback(var_name, true);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledNodalValueOld(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledNodalValueOld(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
   return (_c_is_implicit) ? var->nodalValueOld() : var->nodalValueOlder();
 }
 
@@ -388,9 +457,15 @@ Coupleable::coupledNodalValueOlder(const std::string & var_name, unsigned int co
     return *_default_value[var_name];
   }
 
-  validateExecutionerType(var_name);
-  coupledCallback(var_name, true);
-  MooseVariable * var = getVar(var_name, comp);
+  return coupledNodalValueOlder(getVar(var_name, comp));
+}
+
+VariableValue &
+Coupleable::coupledNodalValueOlder(MooseVariable * var)
+{
+  validateExecutionerType(var);
+  coupledCallback(var, true);
+
   if (_c_is_implicit)
     return var->nodalValueOlder();
   else
@@ -398,8 +473,8 @@ Coupleable::coupledNodalValueOlder(const std::string & var_name, unsigned int co
 }
 
 void
-Coupleable::validateExecutionerType(const std::string & name) const
+Coupleable::validateExecutionerType(MooseVariable * var) const
 {
   if (!_c_fe_problem.isTransient())
-    mooseError("You may not couple in old or older values of \"" << name << "\" when using a \"Steady\" executioner.");
+    mooseError("You may not couple in old or older values of \"" << var->name() << "\" when using a \"Steady\" executioner.");
 }

--- a/framework/src/base/NeighborCoupleable.C
+++ b/framework/src/base/NeighborCoupleable.C
@@ -41,9 +41,9 @@ NeighborCoupleable::coupledNeighborValue(const std::string & var_name, unsigned 
 VariableValue &
 NeighborCoupleable::coupledNeighborValueOld(const std::string & var_name, unsigned int comp)
 {
-  validateExecutionerType(var_name);
-
   MooseVariable * var = getVar(var_name, comp);
+  validateExecutionerType(var);
+
   if (_neighbor_nodal)
     return (_c_is_implicit) ? var->nodalSlnOldNeighbor() : var->nodalSlnOlderNeighbor();
   else
@@ -53,9 +53,9 @@ NeighborCoupleable::coupledNeighborValueOld(const std::string & var_name, unsign
 VariableValue &
 NeighborCoupleable::coupledNeighborValueOlder(const std::string & var_name, unsigned int comp)
 {
-  validateExecutionerType(var_name);
-
   MooseVariable * var = getVar(var_name, comp);
+  validateExecutionerType(var);
+
   if (_neighbor_nodal)
   {
     if (_c_is_implicit)
@@ -88,8 +88,8 @@ NeighborCoupleable::coupledNeighborGradientOld(const std::string & var_name, uns
   if (_neighbor_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
   MooseVariable * var = getVar(var_name, comp);
+  validateExecutionerType(var);
   return (_c_is_implicit) ? var->gradSlnOldNeighbor() : var->gradSlnOlderNeighbor();
 }
 
@@ -99,8 +99,8 @@ NeighborCoupleable::coupledNeighborGradientOlder(const std::string & var_name, u
   if (_neighbor_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
   MooseVariable * var = getVar(var_name, comp);
+  validateExecutionerType(var);
   if (_c_is_implicit)
     return var->gradSlnOlderNeighbor();
   else

--- a/modules/phase_field/include/materials/DerivativeBaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeBaseMaterial.h
@@ -104,6 +104,9 @@ protected:
   /// String vector of all argument names.
   std::vector<std::string> _arg_names;
 
+  /// String vector of all argument MOOSE variable numbers.
+  std::vector<int> _arg_numbers;
+
   /// Calculate (and allocate memory for) the third derivatives of the free energy.
   bool _third_derivatives;
 

--- a/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
@@ -17,7 +17,8 @@ class DerivativeParsedMaterialHelper : public DerivativeBaseMaterial
 {
 public:
   DerivativeParsedMaterialHelper(const std::string & name,
-                                 InputParameters parameters);
+                                 InputParameters parameters,
+                                 bool use_variable_names_verbatim = false);
 
   virtual ~DerivativeParsedMaterialHelper();
 
@@ -70,6 +71,14 @@ protected:
   bool _enable_jit;
   bool _disable_fpoptimizer;
   bool _fail_on_evalerror;
+
+  /**
+   * Flag to indicate if MOOSE nonlinear variable names should be uses as FParser variable names.
+   * This should be true only for DerivativeParsedMaterial. If set to false, this class looks up the
+   * input parameter name for each coupled variable and uses it as the FParser parameter name when
+   * parsing the FParser expression.
+   */
+  const bool _use_variable_names_verbatim;
 
   /// appropriate not a number value to return
   const Real _nan;

--- a/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
@@ -36,9 +36,8 @@ protected:
   /// name of the order parameter variable
   VariableName _eta_name;
 
-  /// index of the phi in _args (after it is appended by addPhiToArgs())
-  unsigned int _eta_id;
-  unsigned int _nfargs;
+  /// libMesh variable number for eta
+  unsigned int _eta_var;
 
   /// A-phase derivative material name
   std::string _fa_name;

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -6,7 +6,6 @@ InputParameters validParams<DerivativeBaseMaterial>()
   InputParameters params = validParams<Material>();
   params.addClassDescription("KKS model helper material to provide the free energy and its first and second derivatives");
   params.addParam<std::string>("f_name", "F", "Base name of the free energy function (used to name the material properties)");
-  params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
   params.addParam<bool>("third_derivatives", true, "Calculate third derivatoves of the free energy");
   return params;
 }
@@ -42,10 +41,13 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
     }
   }
 
-  // fetch names of variables in args
+  // fetch names and numbers of all coupled variables
   _arg_names.resize(_nargs);
-  for (i = 0; i < _nargs; ++i)
+  _arg_numbers.resize(_nargs);
+  for (i = 0; i < _nargs; ++i) {
     _arg_names[i] = _coupled_moose_vars[i]->name();
+    _arg_numbers[i] = _coupled_moose_vars[i]->number();
+  }
 
   // initialize derivatives
   for (i = 0; i < _nargs; ++i)

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -15,7 +15,7 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
                                                InputParameters parameters) :
     DerivativeMaterialInterface<Material>(name, parameters),
     _F_name(getParam<std::string>("f_name")),
-    _nargs(coupledComponents("args")),
+    _nargs(_coupled_moose_vars.size()),
     _third_derivatives(getParam<bool>("third_derivatives")),
     _prop_F(&declareProperty<Real>(_F_name))
 {
@@ -45,13 +45,13 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
   // fetch names of variables in args
   _arg_names.resize(_nargs);
   for (i = 0; i < _nargs; ++i)
-    _arg_names[i] = getVar("args", i)->name();
+    _arg_names[i] = _coupled_moose_vars[i]->name();
 
   // initialize derivatives
   for (i = 0; i < _nargs; ++i)
   {
     // get the coupled variable to use as function arguments
-    _args[i] = &coupledValue("args", i);
+    _args[i] = &coupledValue(_coupled_moose_vars[i]);
 
     // first derivatives
     _prop_dF[i] = &declarePropertyDerivative<Real>(_F_name, _arg_names[i]);

--- a/modules/phase_field/src/materials/DerivativeParsedMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterial.C
@@ -5,6 +5,7 @@ InputParameters validParams<DerivativeParsedMaterial>()
 {
   InputParameters params = validParams<DerivativeParsedMaterialHelper>();
   params.addClassDescription("Parsed Function Material with automatic derivatives.");
+  params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
 
   // Constants and their values
   params.addParam<std::vector<std::string> >("constant_names", std::vector<std::string>(), "Vector of constants used in the parsed function (use this for kB etc.)");
@@ -27,7 +28,7 @@ InputParameters validParams<DerivativeParsedMaterial>()
 
 DerivativeParsedMaterial::DerivativeParsedMaterial(const std::string & name,
                                                    InputParameters parameters) :
-    DerivativeParsedMaterialHelper(name, parameters)
+    DerivativeParsedMaterialHelper(name, parameters, true)
 {
   // check number of coupled variables
   if (_arg_names.size() == 0)

--- a/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
@@ -12,6 +12,9 @@ InputParameters validParams<DerivativeTwoPhaseMaterial>()
   params.addParam<std::string>("h", "h", "Switching Function Material that provides h(eta)");
   params.addParam<std::string>("g", "g", "Barrier Function Material that provides g(eta)");
 
+  // All arguments to the phase free energies
+  params.addRequiredCoupledVar("args", "Arguments of fa and fb - use vector coupling");
+
   // Order parameter which determines the phase
   params.addCoupledVar("eta", "Order parameter");
 
@@ -22,20 +25,12 @@ InputParameters validParams<DerivativeTwoPhaseMaterial>()
   return params;
 }
 
-InputParameters
-DerivativeTwoPhaseMaterial::addPhiToArgs(InputParameters params)
-{
-  VariableName eta = params.set<std::vector<VariableName> >("eta")[0];
-  params.set<std::vector<VariableName> >("args").push_back(eta);
-  return params;
-}
-
 DerivativeTwoPhaseMaterial::DerivativeTwoPhaseMaterial(const std::string & name,
                                                        InputParameters parameters) :
-    DerivativeBaseMaterial(name, addPhiToArgs(parameters)),
+    DerivativeBaseMaterial(name, parameters),
     _eta(coupledValue("eta")),
     _eta_name(getVar("eta", 0)->name()),
-    _eta_id(_nargs - 1),
+    _eta_var(coupled("eta")),
     _fa_name(getParam<std::string>("fa_name")),
     _fb_name(getParam<std::string>("fb_name")),
     _h_name(getParam<std::string>("h")),
@@ -50,42 +45,37 @@ DerivativeTwoPhaseMaterial::DerivativeTwoPhaseMaterial(const std::string & name,
     _prop_Fa(getMaterialProperty<Real>(_fa_name)),
     _prop_Fb(getMaterialProperty<Real>(_fb_name))
 {
-  // eta is appended to args to have the base class add all the derivative material properties containing eta
-  // however we treat derivatives w.r.t. eta differently. They are computed from the composite form only, as
-  // Fa and Fb are not functions of eta.
-  _nfargs = _nargs - 1;
-
   // reserve space for phase A and B material properties
-  _prop_dFa.resize(_nfargs);
-  _prop_d2Fa.resize(_nfargs);
-  _prop_d3Fa.resize(_nfargs);
-  _prop_dFb.resize(_nfargs);
-  _prop_d2Fb.resize(_nfargs);
-  _prop_d3Fb.resize(_nfargs);
-  for (unsigned int i = 0; i < _nfargs; ++i)
+  _prop_dFa.resize(_nargs);
+  _prop_d2Fa.resize(_nargs);
+  _prop_d3Fa.resize(_nargs);
+  _prop_dFb.resize(_nargs);
+  _prop_d2Fb.resize(_nargs);
+  _prop_d3Fb.resize(_nargs);
+  for (unsigned int i = 0; i < _nargs; ++i)
   {
     _prop_dFa[i] = &getMaterialPropertyDerivative<Real>(_fa_name, _arg_names[i]);
     _prop_dFb[i] = &getMaterialPropertyDerivative<Real>(_fb_name, _arg_names[i]);
 
-    _prop_d2Fa[i].resize(_nfargs);
-    _prop_d2Fb[i].resize(_nfargs);
+    _prop_d2Fa[i].resize(_nargs);
+    _prop_d2Fb[i].resize(_nargs);
 
     // TODO: maybe we should reserve and initialize to NULL...
     if (_third_derivatives) {
-      _prop_d3Fa[i].resize(_nfargs);
-      _prop_d3Fb[i].resize(_nfargs);
+      _prop_d3Fa[i].resize(_nargs);
+      _prop_d3Fb[i].resize(_nargs);
     }
 
-    for (unsigned int j = 0; j < _nfargs; ++j)
+    for (unsigned int j = 0; j < _nargs; ++j)
     {
       _prop_d2Fa[i][j] = &getMaterialPropertyDerivative<Real>(_fa_name, _arg_names[i], _arg_names[j]);
       _prop_d2Fb[i][j] = &getMaterialPropertyDerivative<Real>(_fb_name, _arg_names[i], _arg_names[j]);
 
       if (_third_derivatives) {
-        _prop_d3Fa[i][j].resize(_nfargs);
-        _prop_d3Fb[i][j].resize(_nfargs);
+        _prop_d3Fa[i][j].resize(_nargs);
+        _prop_d3Fb[i][j].resize(_nargs);
 
-        for (unsigned int k = 0; k < _nfargs; ++k)
+        for (unsigned int k = 0; k < _nargs; ++k)
         {
           _prop_d3Fa[i][j][k] = &getMaterialPropertyDerivative<Real>(_fa_name, _arg_names[i], _arg_names[j], _arg_names[k]);
           _prop_d3Fb[i][j][k] = &getMaterialPropertyDerivative<Real>(_fb_name, _arg_names[i], _arg_names[j], _arg_names[k]);
@@ -113,7 +103,7 @@ DerivativeTwoPhaseMaterial::computeF()
 Real
 DerivativeTwoPhaseMaterial::computeDF(unsigned int i)
 {
-  if (i == _eta_id)
+  if (_arg_numbers[i] == _eta_var)
     return _dh[_qp] * (_prop_Fb[_qp] - _prop_Fa[_qp]) + _W * _dg[_qp];
   else
     return _h[_qp] * (*_prop_dFb[i])[_qp] + (1.0 - _h[_qp]) * (*_prop_dFa[i])[_qp];
@@ -122,12 +112,12 @@ DerivativeTwoPhaseMaterial::computeDF(unsigned int i)
 Real
 DerivativeTwoPhaseMaterial::computeD2F(unsigned int i, unsigned int j)
 {
-  if (i == _eta_id && j == _eta_id)
+  if (_arg_numbers[i] == _eta_var && _arg_numbers[j] == _eta_var)
     return _d2h[_qp] * (_prop_Fb[_qp] - _prop_Fa[_qp]) + _W * _d2g[_qp];
 
-  if (i == _eta_id)
+  if (_arg_numbers[i] == _eta_var)
     return _dh[_qp] * ((*_prop_dFb[j])[_qp] - (*_prop_dFa[j])[_qp]);
-  if (j == _eta_id)
+  if (_arg_numbers[j] == _eta_var)
     return _dh[_qp] * ((*_prop_dFb[i])[_qp] - (*_prop_dFa[i])[_qp]);
 
   return _h[_qp] * (*_prop_d2Fb[i][j])[_qp] + (1.0 - _h[_qp]) * (*_prop_d2Fa[i][j])[_qp];

--- a/modules/phase_field/src/materials/ElasticEnergyMaterial.C
+++ b/modules/phase_field/src/materials/ElasticEnergyMaterial.C
@@ -8,6 +8,7 @@ InputParameters validParams<ElasticEnergyMaterial>()
   InputParameters params = validParams<DerivativeBaseMaterial>();
   params.addClassDescription("Free energy material for the elastic energy contributions.");
   params.addParam<std::string>("base_name", "Material property base name");
+  params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
   return params;
 }
 


### PR DESCRIPTION
Depends on #4466. Closes #4441. Requires application patch.

This PR implements a new method for mapping MOOSE variables to FParser Expression variables in parsed materials, and improves the coupling semantics to `DerivativeBaseMaterial` descendants.

Previously the variable names in Function Parser expressions and ExpressionBuilder materials had to be _identical_ to the actual MOOSE variable names in a simulation. This is contrary to what the user expects, as in other materials the mapping of a non-linear variable to the meaning it has to the material is done in the input file:

```
concentration = c
```

We retain this identity mapping for the `DerivativeParsedMaterial` (where the free energy expression is given in the input file), but add a new mapping for all other materials that will require separate `addRequiredCoupledVariable` entries for each coupled variable. The material (e.g. `ExpressionBuilder` based material) will use the input parameter name for each coupling as the variable name.

To achieve this we moved the catch-all `args` vector coupling out of the base class. Every derived class now has to add required coupled variables to its own input parameters. This gives us better control and error checking.

The base class `DerivativeBaseMaterial` still needs to know about _all_ coupled variables to set up all derivative material properties. It gets those from `_coupled_moose_vars`.

We also provide a convenience vector `_arg_numbers` that holds the libMesh variable number for each of the `_coupled_moose_vars`. Check `DerivativeTwoPhaseMaterial.C` for an example on how to single out a specific derivative (in this case the eta derivative).
