### PR TITLE
Rename and fix if/conditional in ExpressionBuilder 

### DIFF
--- a/modules/phase_field/include/utils/ExpressionBuilder.h
+++ b/modules/phase_field/include/utils/ExpressionBuilder.h
@@ -200,7 +200,7 @@ public:
   class EBTernaryFuncTermNode : public EBTernaryTermNode
   {
   public:
-    enum NodeType { IFEXPR } type;
+    enum NodeType { CONDITIONAL } type;
 
     EBTernaryFuncTermNode(EBTermNode * _left, EBTermNode * _middle, EBTermNode * _right, NodeType _type) :
       EBTernaryTermNode(_left, _middle, _right), type(_type) {};
@@ -357,7 +357,7 @@ public:
     /**
      * Ternary functions
      */
-    friend EBTerm ifexpr(const EBTerm &, const EBTerm &, const EBTerm &);
+    friend EBTerm conditional(const EBTerm &, const EBTerm &, const EBTerm &);
   };
 
   // User facing host object for a function. This combines a term with an argument list.

--- a/modules/phase_field/src/utils/ExpressionBuilder.C
+++ b/modules/phase_field/src/utils/ExpressionBuilder.C
@@ -128,7 +128,7 @@ ExpressionBuilder::EBBinaryOpTermNode::precedence() const
 std::string
 ExpressionBuilder::EBTernaryFuncTermNode::stringify() const
 {
-  const char * name[] = { "ifexpr" };
+  const char * name[] = { "if" };
   std::ostringstream s;
   s << name[type] << '(' << *left << ',' << *middle << ',' << *right << ')';
   return s.str();
@@ -272,7 +272,7 @@ ExpressionBuilder::EBTerm op (const ExpressionBuilder::EBTerm & left, const Expr
     new ExpressionBuilder::EBTernaryFuncTermNode(left.root->clone(), middle.root->clone(), right.root->clone(), ExpressionBuilder::EBTernaryFuncTermNode::OP) \
   ); \
 }
-TERNARY_FUNC_IMPLEMENT(ifexpr,IFEXPR)
+TERNARY_FUNC_IMPLEMENT(conditional,CONDITIONAL)
 
 unsigned int
 ExpressionBuilder::EBUnaryTermNode::substitute(const EBSubstitutionRuleList & rules)

--- a/unit/src/ExpressionBuilderTest.C
+++ b/unit/src/ExpressionBuilderTest.C
@@ -73,6 +73,6 @@ void ExpressionBuilderTest::test()
   CPPUNIT_ASSERT( std::string(comp3) == "(x=y)+(x!=y)" );
 
   // test ifexpr
-  EBTerm if1 = ifexpr(x < 2 * y, x*x + y, y*y +x);
-  CPPUNIT_ASSERT( std::string(if1) == "ifexpr(x<2*y,x*x+y,y*y+x)" );
+  EBTerm if1 = conditional(x < 2 * y, x*x + y, y*y +x);
+  CPPUNIT_ASSERT( std::string(if1) == "if(x<2*y,x*x+y,y*y+x)" );
 }

--- a/unit/src/ExpressionBuilderTest.C
+++ b/unit/src/ExpressionBuilderTest.C
@@ -74,5 +74,5 @@ void ExpressionBuilderTest::test()
 
   // test ifexpr
   EBTerm if1 = conditional(x < 2 * y, x*x + y, y*y +x);
-  CPPUNIT_ASSERT( std::string(if1) == "if(x<2*y,x*x+y,y*y+x)" );
+  CPPUNIT_ASSERT( std::string(if1) == "if" "(x<2*y,x*x+y,y*y+x)" );
 }


### PR DESCRIPTION
This is a minor change that renames and fixes a previously badly named and _broken_ feature of `ExpressionBuilder`. Closes #4470.
