### PR TITLE
Rewrite of variable coupling in Derivative Material System

### DIFF
--- a/modules/phase_field/include/materials/DerivativeBaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeBaseMaterial.h
@@ -92,10 +92,7 @@ protected:
   /// Flag that indicates if exactly one linear variable is coupled per input file coupling parameter
   bool _mapping_is_unique;
 
-  /**
-   * Number of coupled arguments.
-   * This value is expected to match the the return value of expectedNumArgs()
-   */
+  /// Number of coupled arguments.
   unsigned int _nargs;
 
   /// String vector of all argument names.

--- a/modules/phase_field/include/materials/DerivativeBaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeBaseMaterial.h
@@ -43,12 +43,6 @@ protected:
   virtual void computeProperties();
 
   /**
-   * Override this to return the number of arguments this function expects
-   * (i.e. the number of coupled components)
-   */
-  virtual unsigned int expectedNumArgs() = 0;
-
-  /**
    * Check if we got the right number of components in the 'args' coupled
    * variable vector.
    */
@@ -95,6 +89,9 @@ protected:
    */
   std::string _F_name;
 
+  /// Flag that indicates if exactly one linear variable is coupled per input file coupling parameter
+  bool _mapping_is_unique;
+
   /**
    * Number of coupled arguments.
    * This value is expected to match the the return value of expectedNumArgs()
@@ -103,6 +100,12 @@ protected:
 
   /// String vector of all argument names.
   std::vector<std::string> _arg_names;
+
+  /// String vector of all argument MOOSE variable numbers.
+  std::vector<int> _arg_numbers;
+
+  /// String vector of the input file coupling parameter name for each argument.
+  std::vector<std::string> _arg_param_names;
 
   /// Calculate (and allocate memory for) the third derivatives of the free energy.
   bool _third_derivatives;

--- a/modules/phase_field/include/materials/DerivativeParsedMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterial.h
@@ -20,9 +20,6 @@ class DerivativeParsedMaterial : public DerivativeParsedMaterialHelper
 public:
   DerivativeParsedMaterial(const std::string & name,
                            InputParameters parameters);
-
-protected:
-  virtual unsigned int expectedNumArgs();
 };
 
 #endif // DERIVATIVEPARSEDMATERIAL_H

--- a/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
@@ -16,8 +16,13 @@ InputParameters validParams<DerivativeParsedMaterialHelper>();
 class DerivativeParsedMaterialHelper : public DerivativeBaseMaterial
 {
 public:
+  enum VariableNameMappingMode {
+    USE_MOOSE_NAMES, USE_PARAM_NAMES
+  };
+
   DerivativeParsedMaterialHelper(const std::string & name,
-                                 InputParameters parameters);
+                                 InputParameters parameters,
+                                 VariableNameMappingMode map_mode = USE_PARAM_NAMES);
 
   virtual ~DerivativeParsedMaterialHelper();
 
@@ -70,6 +75,14 @@ protected:
   bool _enable_jit;
   bool _disable_fpoptimizer;
   bool _fail_on_evalerror;
+
+  /**
+   * Flag to indicate if MOOSE nonlinear variable names should be used as FParser variable names.
+   * This should be true only for DerivativeParsedMaterial. If set to false, this class looks up the
+   * input parameter name for each coupled variable and uses it as the FParser parameter name when
+   * parsing the FParser expression.
+   */
+  const VariableNameMappingMode _map_mode;
 
   /// appropriate not a number value to return
   const Real _nan;

--- a/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
@@ -24,8 +24,6 @@ public:
 protected:
   static InputParameters addPhiToArgs(InputParameters);
 
-  virtual unsigned int expectedNumArgs();
-
   virtual Real computeF();
   virtual Real computeDF(unsigned int);
   virtual Real computeD2F(unsigned int, unsigned int);

--- a/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
@@ -36,9 +36,8 @@ protected:
   /// name of the order parameter variable
   VariableName _eta_name;
 
-  /// index of the phi in _args (after it is appended by addPhiToArgs())
-  unsigned int _eta_id;
-  unsigned int _nfargs;
+  /// libMesh variable number for eta
+  unsigned int _eta_var;
 
   /// A-phase derivative material name
   std::string _fa_name;

--- a/modules/phase_field/include/materials/ElasticEnergyMaterial.h
+++ b/modules/phase_field/include/materials/ElasticEnergyMaterial.h
@@ -24,9 +24,6 @@ protected:
   virtual Real computeDF(unsigned int);
   virtual Real computeD2F(unsigned int, unsigned int);
 
-  /// any number of args is accepted.
-  virtual unsigned int expectedNumArgs() { return _nargs; }
-
   std::string _base_name;
 
   /// Stress tensor

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -15,7 +15,7 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
                                                InputParameters parameters) :
     DerivativeMaterialInterface<Material>(name, parameters),
     _F_name(getParam<std::string>("f_name")),
-    _nargs(coupledComponents("args")),
+    _nargs(_coupled_moose_vars.size()),
     _third_derivatives(getParam<bool>("third_derivatives")),
     _prop_F(&declareProperty<Real>(_F_name))
 {
@@ -45,13 +45,13 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
   // fetch names of variables in args
   _arg_names.resize(_nargs);
   for (i = 0; i < _nargs; ++i)
-    _arg_names[i] = getVar("args", i)->name();
+    _arg_names[i] = _coupled_moose_vars[i]->name();
 
   // initialize derivatives
   for (i = 0; i < _nargs; ++i)
   {
     // get the coupled variable to use as function arguments
-    _args[i] = &coupledValue("args", i);
+    _args[i] = &coupledValue(_coupled_moose_vars[i]);
 
     // first derivatives
     _prop_dF[i] = &declarePropertyDerivative<Real>(_F_name, _arg_names[i]);

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -6,7 +6,6 @@ InputParameters validParams<DerivativeBaseMaterial>()
   InputParameters params = validParams<Material>();
   params.addClassDescription("KKS model helper material to provide the free energy and its first and second derivatives");
   params.addParam<std::string>("f_name", "F", "Base name of the free energy function (used to name the material properties)");
-  params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
   params.addParam<bool>("third_derivatives", true, "Calculate third derivatoves of the free energy");
   return params;
 }
@@ -15,15 +14,43 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
                                                InputParameters parameters) :
     DerivativeMaterialInterface<Material>(name, parameters),
     _F_name(getParam<std::string>("f_name")),
-    _nargs(_coupled_moose_vars.size()),
     _third_derivatives(getParam<bool>("third_derivatives")),
     _prop_F(&declareProperty<Real>(_F_name))
 {
   // loop counters
   unsigned int i, j, k;
 
-  // coupled variables
-  _args.resize(_nargs);
+  // fetch names and numbers of all coupled variables
+  _mapping_is_unique = true;
+  for (std::set<std::string>::const_iterator it = _pars.coupledVarsBegin(); it != _pars.coupledVarsEnd(); ++it)
+  {
+    std::map<std::string, std::vector<MooseVariable *> >::iterator vars = _coupled_vars.find(*it);
+
+    // no MOOSE variable was provided for this coupling
+    if (vars == _coupled_vars.end())
+      mooseError("Derivative parsed materials do not work with optional/default coupling yet. Please use addRequiredCoupledVar and provide coupling for all variables.");
+
+    // check if we have a 1:1 mapping between parameters and variables
+    if (vars->second.size() != 1)
+      _mapping_is_unique = false;
+
+    // iterate over all components
+    for (unsigned int j = 0; j < vars->second.size(); ++j)
+    {
+      // make sure each nonlinear variable is coupled in only once
+      if (std::find(_arg_names.begin(), _arg_names.end(), vars->second[j]->name()) != _arg_names.end())
+        mooseError("A nonlinear variable can only be coupled in once.");
+
+      // insert the map values
+      _arg_names.push_back(vars->second[j]->name());
+      _arg_numbers.push_back(vars->second[j]->number());
+      _arg_param_names.push_back(*it);
+
+      // get variable value
+      _args.push_back(&coupledValue(*it, j));
+    }
+  }
+  _nargs = _arg_names.size();
 
   // reserve space for material properties
   _prop_dF.resize(_nargs);
@@ -42,17 +69,9 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
     }
   }
 
-  // fetch names of variables in args
-  _arg_names.resize(_nargs);
-  for (i = 0; i < _nargs; ++i)
-    _arg_names[i] = _coupled_moose_vars[i]->name();
-
   // initialize derivatives
   for (i = 0; i < _nargs; ++i)
   {
-    // get the coupled variable to use as function arguments
-    _args[i] = &coupledValue(_coupled_moose_vars[i]);
-
     // first derivatives
     _prop_dF[i] = &declarePropertyDerivative<Real>(_F_name, _arg_names[i]);
 
@@ -84,10 +103,6 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
 void
 DerivativeBaseMaterial::initialSetup()
 {
-  if (_nargs != expectedNumArgs()) {
-    mooseError("Wrong number of arguments supplied for DerivativeBaseMaterial " + _F_name);
-  }
-
   // set the _prop_* pointers of all material poroperties that are not beeing used back to NULL
   unsigned int i, j, k;
   bool needs_third_derivatives = false;

--- a/modules/phase_field/src/materials/DerivativeParsedMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterial.C
@@ -51,12 +51,3 @@ DerivativeParsedMaterial::DerivativeParsedMaterial(const std::string & name,
                 mat_prop_names,
                 tol_names, tol_values);
 }
-
-/// Fm(cmg,cmv,T) takes three arguments
-unsigned int
-DerivativeParsedMaterial::expectedNumArgs()
-{
-  // this always returns the number of arguments that was passed in
-  // i.e. any number of args is accepted.
-  return _nargs;
-}

--- a/modules/phase_field/src/materials/DerivativeParsedMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterial.C
@@ -5,6 +5,7 @@ InputParameters validParams<DerivativeParsedMaterial>()
 {
   InputParameters params = validParams<DerivativeParsedMaterialHelper>();
   params.addClassDescription("Parsed Function Material with automatic derivatives.");
+  params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
 
   // Constants and their values
   params.addParam<std::vector<std::string> >("constant_names", std::vector<std::string>(), "Vector of constants used in the parsed function (use this for kB etc.)");
@@ -27,7 +28,7 @@ InputParameters validParams<DerivativeParsedMaterial>()
 
 DerivativeParsedMaterial::DerivativeParsedMaterial(const std::string & name,
                                                    InputParameters parameters) :
-    DerivativeParsedMaterialHelper(name, parameters)
+    DerivativeParsedMaterialHelper(name, parameters, USE_MOOSE_NAMES)
 {
   // check number of coupled variables
   if (_arg_names.size() == 0)

--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -185,7 +185,8 @@ void DerivativeParsedMaterialHelper::functionsDerivative()
   {
     _func_dF[i] = new ADFunction(*_func_F);
     if (_func_dF[i]->AutoDiff(_arg_names[i]) != -1)
-      mooseError("Failed to take first derivative.");
+      mooseError("Failed to take first derivative w.r.t. "
+                 << _arg_names[i]);
 
     // second derivatives
     _func_d2F[i].resize(_nargs);
@@ -194,7 +195,8 @@ void DerivativeParsedMaterialHelper::functionsDerivative()
     {
       _func_d2F[i][j] = new ADFunction(*_func_dF[i]);
       if (_func_d2F[i][j]->AutoDiff(_arg_names[j]) != -1)
-        mooseError("Failed to take second derivative.");
+        mooseError("Failed to take second derivative w.r.t. "
+                   << _arg_names[i] << " and " << _arg_names[j]);
 
       // third derivatives
       if (_third_derivatives)
@@ -204,7 +206,8 @@ void DerivativeParsedMaterialHelper::functionsDerivative()
         {
           _func_d3F[i][j][k] = new ADFunction(*_func_d2F[i][j]);
           if (_func_d3F[i][j][k]->AutoDiff(_arg_names[k]) != -1)
-            mooseError("Failed to take third derivative.");
+            mooseError("Failed to take third derivative w.r.t. "
+                       << _arg_names[i] << ", " << _arg_names[j] << ", and " << _arg_names[k]);
         }
       }
     }

--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -25,13 +25,15 @@ const char * DerivativeParsedMaterialHelper::_eval_error_msg[] = {
 };
 
 DerivativeParsedMaterialHelper::DerivativeParsedMaterialHelper(const std::string & name,
-                                                   InputParameters parameters) :
+                                                               InputParameters parameters,
+                                                               VariableNameMappingMode map_mode) :
     DerivativeBaseMaterial(name, parameters),
     _func_F(NULL),
     _nmat_props(0),
     _enable_jit(isParamValid("enable_jit") && getParam<bool>("enable_jit")),
     _disable_fpoptimizer(getParam<bool>("disable_fpoptimizer")),
     _fail_on_evalerror(getParam<bool>("fail_on_evalerror")),
+    _map_mode(map_mode),
     _nan(std::numeric_limits<Real>::quiet_NaN())
 {
 }
@@ -66,7 +68,7 @@ void DerivativeParsedMaterialHelper::functionParse(const std::string & function_
                                                    const std::vector<Real> & tol_values)
 {
   // check number of coupled variables
-  if (_arg_names.size() == 0)
+  if (_nargs == 0)
     mooseError("Need at least one coupled variable for DerivativeParsedMaterialHelper.");
 
   // check constant vectors
@@ -125,9 +127,28 @@ void DerivativeParsedMaterialHelper::functionParse(const std::string & function_
   }
 
   // build 'variables' argument for fparser
-  std::string variables = _arg_names[0];
-  for (unsigned i = 1; i < _arg_names.size(); ++i)
-    variables += "," + _arg_names[i];
+  std::string variables;
+  switch (_map_mode)
+  {
+    case USE_MOOSE_NAMES:
+      variables = _arg_names[0];
+      for (unsigned i = 1; i < _nargs; ++i)
+        variables += "," + _arg_names[i];
+      break;
+
+    case USE_PARAM_NAMES:
+      // we do not allow vector coupling in this mode
+      if (!_mapping_is_unique)
+        mooseError("Derivative parsed materials must couple exactly one non-linear variable per coupled variable input parameter.");
+
+      variables = _arg_param_names[0];
+      for (unsigned i = 1; i < _nargs; ++i)
+        variables += "," + _arg_param_names[i];
+      break;
+
+    default:
+      mooseError("Unnknown variable mapping mode.");
+  }
 
   // get all material properties
   _nmat_props = mat_prop_names.size();
@@ -275,7 +296,8 @@ DerivativeParsedMaterialHelper::evaluate(ADFunction * parser)
 
   // hard fail or return not a number
   if (_fail_on_evalerror)
-    mooseError("DerivativeParsedMaterial function evaluation encountered an error: " << _eval_error_msg[(error_code < 0 || error_code > 5) ? 0 : error_code]);
+    mooseError("DerivativeParsedMaterial function evaluation encountered an error: "
+               << _eval_error_msg[(error_code < 0 || error_code > 5) ? 0 : error_code]);
 
   return _nan;
 }

--- a/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
@@ -85,15 +85,6 @@ DerivativeTwoPhaseMaterial::DerivativeTwoPhaseMaterial(const std::string & name,
   }
 }
 
-/// Fm(cmg,cmv,T) takes three arguments
-unsigned int
-DerivativeTwoPhaseMaterial::expectedNumArgs()
-{
-  // this always returns the number of arguments that was passed in
-  // i.e. any number of args is accepted.
-  return _nargs;
-}
-
 Real
 DerivativeTwoPhaseMaterial::computeF()
 {

--- a/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
@@ -16,7 +16,7 @@ InputParameters validParams<DerivativeTwoPhaseMaterial>()
   params.addRequiredCoupledVar("args", "Arguments of fa and fb - use vector coupling");
 
   // Order parameter which determines the phase
-  params.addCoupledVar("eta", "Order parameter");
+  params.addRequiredCoupledVar("eta", "Order parameter");
 
   // Variables with applied tolerances and their tolerance values
   params.addParam<Real>("W", 0.0, "Energy barrier for the phase transformation from A to B");

--- a/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
@@ -12,6 +12,9 @@ InputParameters validParams<DerivativeTwoPhaseMaterial>()
   params.addParam<std::string>("h", "h", "Switching Function Material that provides h(eta)");
   params.addParam<std::string>("g", "g", "Barrier Function Material that provides g(eta)");
 
+  // All arguments to the phase free energies
+  params.addRequiredCoupledVar("args", "Arguments of fa and fb - use vector coupling");
+
   // Order parameter which determines the phase
   params.addCoupledVar("eta", "Order parameter");
 
@@ -22,20 +25,12 @@ InputParameters validParams<DerivativeTwoPhaseMaterial>()
   return params;
 }
 
-InputParameters
-DerivativeTwoPhaseMaterial::addPhiToArgs(InputParameters params)
-{
-  VariableName eta = params.set<std::vector<VariableName> >("eta")[0];
-  params.set<std::vector<VariableName> >("args").push_back(eta);
-  return params;
-}
-
 DerivativeTwoPhaseMaterial::DerivativeTwoPhaseMaterial(const std::string & name,
                                                        InputParameters parameters) :
-    DerivativeBaseMaterial(name, addPhiToArgs(parameters)),
+    DerivativeBaseMaterial(name, parameters),
     _eta(coupledValue("eta")),
     _eta_name(getVar("eta", 0)->name()),
-    _eta_id(_nargs - 1),
+    _eta_var(coupled("eta")),
     _fa_name(getParam<std::string>("fa_name")),
     _fb_name(getParam<std::string>("fb_name")),
     _h_name(getParam<std::string>("h")),
@@ -50,42 +45,37 @@ DerivativeTwoPhaseMaterial::DerivativeTwoPhaseMaterial(const std::string & name,
     _prop_Fa(getMaterialProperty<Real>(_fa_name)),
     _prop_Fb(getMaterialProperty<Real>(_fb_name))
 {
-  // eta is appended to args to have the base class add all the derivative material properties containing eta
-  // however we treat derivatives w.r.t. eta differently. They are computed from the composite form only, as
-  // Fa and Fb are not functions of eta.
-  _nfargs = _nargs - 1;
-
   // reserve space for phase A and B material properties
-  _prop_dFa.resize(_nfargs);
-  _prop_d2Fa.resize(_nfargs);
-  _prop_d3Fa.resize(_nfargs);
-  _prop_dFb.resize(_nfargs);
-  _prop_d2Fb.resize(_nfargs);
-  _prop_d3Fb.resize(_nfargs);
-  for (unsigned int i = 0; i < _nfargs; ++i)
+  _prop_dFa.resize(_nargs);
+  _prop_d2Fa.resize(_nargs);
+  _prop_d3Fa.resize(_nargs);
+  _prop_dFb.resize(_nargs);
+  _prop_d2Fb.resize(_nargs);
+  _prop_d3Fb.resize(_nargs);
+  for (unsigned int i = 0; i < _nargs; ++i)
   {
     _prop_dFa[i] = &getMaterialPropertyDerivative<Real>(_fa_name, _arg_names[i]);
     _prop_dFb[i] = &getMaterialPropertyDerivative<Real>(_fb_name, _arg_names[i]);
 
-    _prop_d2Fa[i].resize(_nfargs);
-    _prop_d2Fb[i].resize(_nfargs);
+    _prop_d2Fa[i].resize(_nargs);
+    _prop_d2Fb[i].resize(_nargs);
 
     // TODO: maybe we should reserve and initialize to NULL...
     if (_third_derivatives) {
-      _prop_d3Fa[i].resize(_nfargs);
-      _prop_d3Fb[i].resize(_nfargs);
+      _prop_d3Fa[i].resize(_nargs);
+      _prop_d3Fb[i].resize(_nargs);
     }
 
-    for (unsigned int j = 0; j < _nfargs; ++j)
+    for (unsigned int j = 0; j < _nargs; ++j)
     {
       _prop_d2Fa[i][j] = &getMaterialPropertyDerivative<Real>(_fa_name, _arg_names[i], _arg_names[j]);
       _prop_d2Fb[i][j] = &getMaterialPropertyDerivative<Real>(_fb_name, _arg_names[i], _arg_names[j]);
 
       if (_third_derivatives) {
-        _prop_d3Fa[i][j].resize(_nfargs);
-        _prop_d3Fb[i][j].resize(_nfargs);
+        _prop_d3Fa[i][j].resize(_nargs);
+        _prop_d3Fb[i][j].resize(_nargs);
 
-        for (unsigned int k = 0; k < _nfargs; ++k)
+        for (unsigned int k = 0; k < _nargs; ++k)
         {
           _prop_d3Fa[i][j][k] = &getMaterialPropertyDerivative<Real>(_fa_name, _arg_names[i], _arg_names[j], _arg_names[k]);
           _prop_d3Fb[i][j][k] = &getMaterialPropertyDerivative<Real>(_fb_name, _arg_names[i], _arg_names[j], _arg_names[k]);
@@ -113,7 +103,7 @@ DerivativeTwoPhaseMaterial::computeF()
 Real
 DerivativeTwoPhaseMaterial::computeDF(unsigned int i)
 {
-  if (i == _eta_id)
+  if (_arg_numbers[i] == _eta_var)
     return _dh[_qp] * (_prop_Fb[_qp] - _prop_Fa[_qp]) + _W * _dg[_qp];
   else
     return _h[_qp] * (*_prop_dFb[i])[_qp] + (1.0 - _h[_qp]) * (*_prop_dFa[i])[_qp];
@@ -122,12 +112,12 @@ DerivativeTwoPhaseMaterial::computeDF(unsigned int i)
 Real
 DerivativeTwoPhaseMaterial::computeD2F(unsigned int i, unsigned int j)
 {
-  if (i == _eta_id && j == _eta_id)
+  if (_arg_numbers[i] == _eta_var && _arg_numbers[j] == _eta_var)
     return _d2h[_qp] * (_prop_Fb[_qp] - _prop_Fa[_qp]) + _W * _d2g[_qp];
 
-  if (i == _eta_id)
+  if (_arg_numbers[i] == _eta_var)
     return _dh[_qp] * ((*_prop_dFb[j])[_qp] - (*_prop_dFa[j])[_qp]);
-  if (j == _eta_id)
+  if (_arg_numbers[j] == _eta_var)
     return _dh[_qp] * ((*_prop_dFb[i])[_qp] - (*_prop_dFa[i])[_qp]);
 
   return _h[_qp] * (*_prop_d2Fb[i][j])[_qp] + (1.0 - _h[_qp]) * (*_prop_d2Fa[i][j])[_qp];

--- a/modules/phase_field/src/materials/ElasticEnergyMaterial.C
+++ b/modules/phase_field/src/materials/ElasticEnergyMaterial.C
@@ -8,6 +8,7 @@ InputParameters validParams<ElasticEnergyMaterial>()
   InputParameters params = validParams<DerivativeBaseMaterial>();
   params.addClassDescription("Free energy material for the elastic energy contributions.");
   params.addParam<std::string>("base_name", "Material property base name");
+  params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
   return params;
 }
 

--- a/modules/phase_field/tests/Parsed/tests
+++ b/modules/phase_field/tests/Parsed/tests
@@ -24,6 +24,6 @@
     expect_out = '\nNo errors detected. :-\)\n'
     resize_mesh = true
     recover = false
-    skip = 'see #3847'
+    #skip = 'see #3847'
 [../]
 []


### PR DESCRIPTION
This is the alternative rewrite of the Derivative Material system, that does not need the framework change #4466 @friedmud is 1000% opposed to. 

Closes #4441. Requires application patch (Grizzly and Marmot).

This PR implements a new method for mapping MOOSE variables to FParser Expression variables in parsed materials, and improves the coupling semantics to `DerivativeBaseMaterial` descendants.

Previously the variable names in Function Parser expressions and ExpressionBuilder materials had to be _identical_ to the actual MOOSE variable names in a simulation. This is contrary to what the user expects, as in other materials the mapping of a non-linear variable to the meaning it has to the material is done in the input file:

```
concentration = c
```

We retain this identity mapping for the `DerivativeParsedMaterial` (where the free energy expression is given in the input file), but add a new mapping for all other materials that will require separate `addRequiredCoupledVariable` entries for each coupled variable. The material (e.g. `ExpressionBuilder` based material) will use the input parameter name for each coupling as the variable name.

To achieve this we moved the catch-all `args` vector coupling out of the base class. Every derived class now has to add required coupled variables to its own input parameters. This gives us better control and error checking.

The base class `DerivativeBaseMaterial` still needs to know about _all_ coupled variables to set up all derivative material properties. It gets those by iterating from  `_pars.coupledVarsBegin()` to `_pars.coupledVarsEnd()` and inspecting `_coupled_vars`.

We also provide a convenience vector `_arg_numbers` that holds the libMesh variable number for each of the coupled variables. Check `DerivativeTwoPhaseMaterial.C` for an example on how to single out a specific derivative (in this case the eta derivative).
