### PR TITLE
Output on initial to get complete messages

### DIFF
--- a/test/tests/executioners/eigen_executioners/ne.i
+++ b/test/tests/executioners/eigen_executioners/ne.i
@@ -90,6 +90,6 @@
   [./console]
     type = Console
     perf_log = true
-    output_on = 'failed nonlinear linear timestep_end'
+    output_on = 'initial failed nonlinear linear timestep_end'
   [../]
 []


### PR DESCRIPTION
@YaqiWang reported that messages printed to the screen with _console where not being shown. The message in question was in NonlinearEigen::init(). Messages in init() or initialSetup() are wrapped with initial output, so you must enable output on initial.

Perhaps this isn't the desired behavior for _console, but that is a topic for another issue.

(closes #4287)
