### PR TITLE
Use libMesh variable numbers in DerivativeBaseMaterial

### DIFF
--- a/modules/phase_field/include/materials/DerivativeBaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeBaseMaterial.h
@@ -54,7 +54,9 @@ protected:
   virtual Real computeF() = 0;
 
   /**
-   * Override this method for calculating the first derivatives
+   * Override this method for calculating the first derivatives.
+   * The parameter is the libMesh variable number of the coupled variable.
+   * These numbers can be obtained using the coupled() method for each coupled variable.
    *
    * @param arg The index of the function argument the derivative is taken of
    */
@@ -78,6 +80,18 @@ protected:
    */
   virtual Real computeD3F(unsigned int, unsigned int, unsigned int);
 
+  /**
+   * DerivativeBaseMaterial keeps an internal list of all the variables the derivatives are taken w.r.t.
+   * We provide the MOOSE variable bames in _arg_names, the libMesh variable numbers in _arg_numbers, and the
+   * input file parameter names in _arg_param_names. All are indexed by the argument index.
+   * This method returns the argument index for a given the libMesh variable number.
+   *
+   * This mapping is necessary for internal classes which maintain lists of derivatives indexed by argument index
+   * and need to pull from those lists from the computeDF, computeD2F, and computeD3F methods, which receive
+   * libMesh variable numbers as parameters.
+   */
+  unsigned int argIndex(unsigned int) const;
+
   /// Coupled variables for function arguments
   std::vector<VariableValue *> _args;
 
@@ -99,9 +113,6 @@ protected:
   /// Vector of all argument MOOSE variable numbers.
   std::vector<unsigned int> _arg_numbers;
 
-  /// Vector to look up the internal coupled variable index into _arg_*  through the libMesh variable number
-  std::vector<unsigned int> _arg_index;
-
   /// String vector of the input file coupling parameter name for each argument.
   std::vector<std::string> _arg_param_names;
 
@@ -119,6 +130,11 @@ protected:
 
   /// Material properties to store the third derivatives.
   std::vector<std::vector<std::vector<MaterialProperty<Real> *> > > _prop_d3F;
+
+private:
+  /// Vector to look up the internal coupled variable index into _arg_*  through the libMesh variable number
+  /// this can be queried through the argIndex() method
+  std::vector<unsigned int> _arg_index;
 };
 
 #endif //DERIVATIVEBASEMATERIAL_H

--- a/modules/phase_field/include/materials/DerivativeBaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeBaseMaterial.h
@@ -96,8 +96,11 @@ protected:
   /// String vector of all argument names.
   std::vector<std::string> _arg_names;
 
-  /// String vector of all argument MOOSE variable numbers.
-  std::vector<int> _arg_numbers;
+  /// Vector of all argument MOOSE variable numbers.
+  std::vector<unsigned int> _arg_numbers;
+
+  /// Vector to look up the internal coupled variable index into _arg_*  through the libMesh variable number
+  std::vector<unsigned int> _arg_index;
 
   /// String vector of the input file coupling parameter name for each argument.
   std::vector<std::string> _arg_param_names;

--- a/modules/phase_field/include/materials/DerivativeBaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeBaseMaterial.h
@@ -65,16 +65,14 @@ protected:
    *
    * \f$ \frac{d^2F}{dc_{arg1} dc_{arg2}} \f$
    *
-   * @param arg1 The index of the function argument the first derivative is taken of
-   * @param arg2 The index of the function argument the second derivative is taken of
-   * @Note arg1<=arg2 is guaranteed (deriviatives are symmetric)!
+   * @param arg1 The variable the first derivative is taken of
+   * @param arg2 The variable the second derivative is taken of
    */
   virtual Real computeD2F(unsigned int, unsigned int) = 0;
 
   /**
    * Override this method to calculate the third derivatives.
    *
-   * @Note arg1<=arg2<=arg3 is guaranteed!
    * @Note The implementation of this method is optional. It is only evaluated when
    *       the 'third_derivatives' parameter is set to true.
    */

--- a/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
@@ -22,8 +22,6 @@ public:
                              InputParameters parameters);
 
 protected:
-  static InputParameters addPhiToArgs(InputParameters);
-
   virtual Real computeF();
   virtual Real computeDF(unsigned int);
   virtual Real computeD2F(unsigned int, unsigned int);

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -27,9 +27,9 @@ DerivativeBaseMaterial::DerivativeBaseMaterial(const std::string & name,
   {
     std::map<std::string, std::vector<MooseVariable *> >::iterator vars = _coupled_vars.find(*it);
 
-    // no MOOSE variable was provided for this coupling
+    // no MOOSE variable was provided for this coupling, skip derivatives w.r.t. this variable
     if (vars == _coupled_vars.end())
-      mooseError("Derivative parsed materials do not work with optional/default coupling yet. Please use addRequiredCoupledVar and provide coupling for all variables.");
+      continue;
 
     // check if we have a 1:1 mapping between parameters and variables
     if (vars->second.size() != 1)
@@ -163,6 +163,13 @@ Real
 DerivativeBaseMaterial::computeD3F(unsigned int /*arg1*/, unsigned int /*arg2*/, unsigned int /*arg3*/)
 {
   return 0.0;
+}
+
+unsigned int
+DerivativeBaseMaterial::argIndex(unsigned int i_var) const
+{
+  mooseAssert(_arg_number[_arg_index[i_var]] == i_var, "Requesting argIndex() of for a derivative w.r.t. a variable not coupled to.");
+  return _arg_index[i_var];
 }
 
 void

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -168,20 +168,20 @@ DerivativeBaseMaterial::computeProperties()
     {
       // set first derivatives
       if (_prop_dF[i])
-        (*_prop_dF[i])[_qp] = computeDF(i);
+        (*_prop_dF[i])[_qp] = computeDF(_arg_numbers[i]);
 
       // second derivatives
       for (j = i; j < _nargs; ++j)
       {
         if (_prop_d2F[i][j])
-          (*_prop_d2F[i][j])[_qp] = computeD2F(i, j);
+          (*_prop_d2F[i][j])[_qp] = computeD2F(_arg_numbers[i], _arg_numbers[j]);
 
         // third derivatives
         if (_third_derivatives)
         {
           for (k = j; k < _nargs; ++k)
             if (_prop_d3F[i][j][k])
-              (*_prop_d3F[i][j][k])[_qp] = computeD3F(i, j, k);
+              (*_prop_d3F[i][j][k])[_qp] = computeD3F(_arg_numbers[i], _arg_numbers[j], _arg_numbers[k]);
         }
       }
     }

--- a/modules/phase_field/src/materials/DerivativeBaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeBaseMaterial.C
@@ -168,7 +168,7 @@ DerivativeBaseMaterial::computeD3F(unsigned int /*arg1*/, unsigned int /*arg2*/,
 unsigned int
 DerivativeBaseMaterial::argIndex(unsigned int i_var) const
 {
-  mooseAssert(_arg_number[_arg_index[i_var]] == i_var, "Requesting argIndex() of for a derivative w.r.t. a variable not coupled to.");
+  mooseAssert(_arg_numbers[_arg_index[i_var]] == i_var, "Requesting argIndex() of for a derivative w.r.t. a variable not coupled to.");
   return _arg_index[i_var];
 }
 

--- a/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
@@ -98,7 +98,7 @@ DerivativeTwoPhaseMaterial::computeDF(unsigned int i_var)
     return _dh[_qp] * (_prop_Fb[_qp] - _prop_Fa[_qp]) + _W * _dg[_qp];
   else
   {
-    unsigned int i = _arg_index[i_var];
+    unsigned int i = argIndex(i_var);
     return _h[_qp] * (*_prop_dFb[i])[_qp] + (1.0 - _h[_qp]) * (*_prop_dFa[i])[_qp];
   }
 }
@@ -109,8 +109,8 @@ DerivativeTwoPhaseMaterial::computeD2F(unsigned int i_var, unsigned int j_var)
   if (i_var == _eta_var && j_var == _eta_var)
     return _d2h[_qp] * (_prop_Fb[_qp] - _prop_Fa[_qp]) + _W * _d2g[_qp];
 
-  unsigned int i = _arg_index[i_var];
-  unsigned int j = _arg_index[j_var];
+  unsigned int i = argIndex(i_var);
+  unsigned int j = argIndex(j_var);
 
   if (i_var == _eta_var)
     return _dh[_qp] * ((*_prop_dFb[j])[_qp] - (*_prop_dFa[j])[_qp]);

--- a/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
@@ -92,23 +92,29 @@ DerivativeTwoPhaseMaterial::computeF()
 }
 
 Real
-DerivativeTwoPhaseMaterial::computeDF(unsigned int i)
+DerivativeTwoPhaseMaterial::computeDF(unsigned int i_var)
 {
-  if (_arg_numbers[i] == _eta_var)
+  if (i_var == _eta_var)
     return _dh[_qp] * (_prop_Fb[_qp] - _prop_Fa[_qp]) + _W * _dg[_qp];
   else
+  {
+    unsigned int i = _arg_index[i_var];
     return _h[_qp] * (*_prop_dFb[i])[_qp] + (1.0 - _h[_qp]) * (*_prop_dFa[i])[_qp];
+  }
 }
 
 Real
-DerivativeTwoPhaseMaterial::computeD2F(unsigned int i, unsigned int j)
+DerivativeTwoPhaseMaterial::computeD2F(unsigned int i_var, unsigned int j_var)
 {
-  if (_arg_numbers[i] == _eta_var && _arg_numbers[j] == _eta_var)
+  if (i_var == _eta_var && j_var == _eta_var)
     return _d2h[_qp] * (_prop_Fb[_qp] - _prop_Fa[_qp]) + _W * _d2g[_qp];
 
-  if (_arg_numbers[i] == _eta_var)
+  unsigned int i = _arg_index[i_var];
+  unsigned int j = _arg_index[j_var];
+
+  if (i_var == _eta_var)
     return _dh[_qp] * ((*_prop_dFb[j])[_qp] - (*_prop_dFa[j])[_qp]);
-  if (_arg_numbers[j] == _eta_var)
+  if (j_var == _eta_var)
     return _dh[_qp] * ((*_prop_dFb[i])[_qp] - (*_prop_dFa[i])[_qp]);
 
   return _h[_qp] * (*_prop_d2Fb[i][j])[_qp] + (1.0 - _h[_qp]) * (*_prop_d2Fa[i][j])[_qp];

--- a/modules/phase_field/src/materials/ElasticEnergyMaterial.C
+++ b/modules/phase_field/src/materials/ElasticEnergyMaterial.C
@@ -51,7 +51,7 @@ ElasticEnergyMaterial::computeF()
 Real
 ElasticEnergyMaterial::computeDF(unsigned int i_var)
 {
-  unsigned int i = _arg_index[i_var];
+  unsigned int i = argIndex(i_var);
 
   // product rule d/di computeF
   return 0.5 * (
@@ -67,8 +67,8 @@ ElasticEnergyMaterial::computeDF(unsigned int i_var)
 Real
 ElasticEnergyMaterial::computeD2F(unsigned int i_var, unsigned int j_var)
 {
-  unsigned int i = _arg_index[i_var];
-  unsigned int j = _arg_index[j_var];
+  unsigned int i = argIndex(i_var);
+  unsigned int j = argIndex(j_var);
 
   // product rule d/dj computeDF
   return 0.5 * (

--- a/modules/phase_field/src/materials/ElasticEnergyMaterial.C
+++ b/modules/phase_field/src/materials/ElasticEnergyMaterial.C
@@ -49,8 +49,10 @@ ElasticEnergyMaterial::computeF()
 }
 
 Real
-ElasticEnergyMaterial::computeDF(unsigned int i)
+ElasticEnergyMaterial::computeDF(unsigned int i_var)
 {
+  unsigned int i = _arg_index[i_var];
+
   // product rule d/di computeF
   return 0.5 * (
     ( // dstress/di
@@ -63,8 +65,11 @@ ElasticEnergyMaterial::computeDF(unsigned int i)
 }
 
 Real
-ElasticEnergyMaterial::computeD2F(unsigned int i, unsigned int j)
+ElasticEnergyMaterial::computeD2F(unsigned int i_var, unsigned int j_var)
 {
+  unsigned int i = _arg_index[i_var];
+  unsigned int j = _arg_index[j_var];
+
   // product rule d/dj computeDF
   return 0.5 * (
     (


### PR DESCRIPTION
Use libMesh variable numbers in `DerivativeBaseMaterial::computeD*F()` methods. 

Closes #4478. Closes #4481.
