### PR TITLE
Comment out unused var in LineMaterialSamplerBase 

### DIFF
--- a/framework/include/vectorpostprocessors/LineMaterialSamplerBase.h
+++ b/framework/include/vectorpostprocessors/LineMaterialSamplerBase.h
@@ -188,7 +188,6 @@ template <typename T>
 void
 LineMaterialSamplerBase<T>::threadJoin(const SamplerBase & sb)
 {
-  const LineMaterialSamplerBase<T> & lmsb = static_cast<const LineMaterialSamplerBase<T> &>(sb);
   SamplerBase::threadJoin(sb);
 }
 


### PR DESCRIPTION
Squashes a compiler warning for `METHOD=dbg`. Addresses #1777.
