### PR TITLE
Make PointSamplerBase much more robust in Parallel

### DIFF
--- a/framework/include/vectorpostprocessors/PointSamplerBase.h
+++ b/framework/include/vectorpostprocessors/PointSamplerBase.h
@@ -22,6 +22,15 @@
 //Forward Declarations
 class PointSamplerBase;
 
+// libMesh Forward Declarations
+namespace libMesh
+{
+  namespace MeshTools
+  {
+    class BoundingBox;
+  }
+}
+
 template<>
 InputParameters validParams<PointSamplerBase>();
 
@@ -52,6 +61,11 @@ protected:
    */
   const Elem * getLocalElemContainingPoint(const Point & p, unsigned int /*id*/);
 
+  /**
+   * Gets a processor_bounding_box... and inflates it a bit to handle edge cases
+   */
+  MeshTools::BoundingBox getInflatedProcessorBoundingBox();
+
   /// The Mesh we're using
   MooseMesh & _mesh;
 
@@ -61,8 +75,11 @@ protected:
   /// The ID to use for each point (yes, this is Real on purpose)
   std::vector<Real> _ids;
 
-  /// So we don't have to create and destroy this vector over and over again
-  std::vector<Real> _values;
+  /// Map of _points indices to the values
+  std::map<unsigned int, std::vector<Real> > _values;
+
+  /// Whether or not the Point was found on this processor (int because bool and uint don't work with MPI wrappers)
+  std::vector<int> _found_points;
 
   unsigned int _qp;
 

--- a/framework/src/vectorpostprocessors/PointSamplerBase.C
+++ b/framework/src/vectorpostprocessors/PointSamplerBase.C
@@ -50,12 +50,11 @@ PointSamplerBase::initialize()
 {
   SamplerBase::initialize();
 
-  _found_points.resize(_points.size());
-
   // We do this here just in case it's been destroyed and recreated becaue of mesh adaptivity.
   _pl = _mesh.getMesh().sub_point_locator();
 
   // Reset the _found_points array
+  _found_points.resize(_points.size());
   std::fill(_found_points.begin(), _found_points.end(), false);
 }
 
@@ -115,11 +114,9 @@ PointSamplerBase::finalize()
     // Only do this check on the proc zero because it's the same on every processor
     // _found_points should contain all 1's at this point (ie every point was found by a proc)
     if (pid == 0 && !_found_points[i])
-      mooseError("Sample point not found: " << _points[i]);
+      mooseError("In " << name() << ", sample point not found: " << _points[i]);
 
-    unsigned int id = max_id[i];
-
-    if (id == pid)
+    if (max_id[i] == pid)
       SamplerBase::addSample(_points[i], _ids[i], _values[i]);
   }
 

--- a/framework/src/vectorpostprocessors/PointSamplerBase.C
+++ b/framework/src/vectorpostprocessors/PointSamplerBase.C
@@ -14,6 +14,9 @@
 
 #include "PointSamplerBase.h"
 
+// libMesh includes
+#include "libmesh/mesh_tools.h"
+
 template<>
 InputParameters validParams<PointSamplerBase>()
 {
@@ -34,7 +37,6 @@ PointSamplerBase::PointSamplerBase(const std::string & name, InputParameters par
     _point_vec(1) // Only going to evaluate one point at a time for now
 {
   std::vector<std::string> var_names(_coupled_moose_vars.size());
-  _values.resize(_coupled_moose_vars.size());
 
   for (unsigned int i=0; i<_coupled_moose_vars.size(); i++)
     var_names[i] = _coupled_moose_vars[i]->name();
@@ -48,31 +50,47 @@ PointSamplerBase::initialize()
 {
   SamplerBase::initialize();
 
+  _found_points.resize(_points.size());
+
   // We do this here just in case it's been destroyed and recreated becaue of mesh adaptivity.
   _pl = _mesh.getMesh().sub_point_locator();
+
+  // Reset the _found_points array
+  std::fill(_found_points.begin(), _found_points.end(), false);
 }
 
 void
 PointSamplerBase::execute()
 {
+  MeshTools::BoundingBox bbox = getInflatedProcessorBoundingBox();
+
   for (unsigned int i=0; i<_points.size(); i++)
   {
     Point & p = _points[i];
 
-    // First find the element the hit lands in
-    const Elem * elem = getLocalElemContainingPoint(p, i);
-
-    // We have to pass a vector of points into reinitElemPhys
-    _point_vec[0] = p;
-
-    if (elem)
+    // Do a bounding box check so we're not doing unnecessary PointLocator lookups
+    if (bbox.contains_point(p))
     {
-      _subproblem.reinitElemPhys(elem, _point_vec, 0); // Zero is for tid
+      std::vector<Real> & values = _values[i];
 
-      for (unsigned int j=0; j<_coupled_moose_vars.size(); j++)
-        _values[j] = _coupled_moose_vars[j]->sln()[0]; // The zero is for the "qp"
+      if (values.empty())
+        values.resize(_coupled_moose_vars.size());
 
-      SamplerBase::addSample(p, _ids[i], _values);
+      // First find the element the hit lands in
+      const Elem * elem = getLocalElemContainingPoint(p, i);
+
+      if (elem)
+      {
+        // We have to pass a vector of points into reinitElemPhys
+        _point_vec[0] = p;
+
+        _subproblem.reinitElemPhys(elem, _point_vec, 0); // Zero is for tid
+
+        for (unsigned int j=0; j<_coupled_moose_vars.size(); j++)
+          values[j] = _coupled_moose_vars[j]->sln()[0]; // The zero is for the "qp"
+
+        _found_points[i] = true;
+      }
     }
   }
 }
@@ -80,6 +98,31 @@ PointSamplerBase::execute()
 void
 PointSamplerBase::finalize()
 {
+  // Save off for speed
+  unsigned int pid = processor_id();
+
+  /*
+   * Figure out which processor is actually going "claim" each point.
+   * If multiple processors found the point and computed values what happens is that
+   * maxloc will give us the smallest PID in max_id
+   */
+  std::vector<unsigned int> max_id(_found_points.size());
+
+  _communicator.maxloc(_found_points, max_id);
+
+  for (unsigned int i=0; i<max_id.size(); i++)
+  {
+    // Only do this check on the proc zero because it's the same on every processor
+    // _found_points should contain all 1's at this point (ie every point was found by a proc)
+    if (pid == 0 && !_found_points[i])
+      mooseError("Sample point not found: " << _points[i]);
+
+    unsigned int id = max_id[i];
+
+    if (id == pid)
+      SamplerBase::addSample(_points[i], _ids[i], _values[i]);
+  }
+
   SamplerBase::finalize();
 }
 
@@ -101,4 +144,21 @@ PointSamplerBase::getLocalElemContainingPoint(const Point & p, unsigned int /*id
     return elem;
 
   return NULL;
+}
+
+MeshTools::BoundingBox
+PointSamplerBase::getInflatedProcessorBoundingBox()
+{
+  // Grab a bounding box to speed things up
+  MeshTools::BoundingBox bbox = MeshTools::processor_bounding_box(_mesh, processor_id());
+
+  // Inflate the bbox just a bit to deal with roundoff
+  // Adding 1% of the diagonal size in each direction on each end
+  Real inflation_amount = 0.01 * (bbox.max() - bbox.min()).size();
+  Point inflation(inflation_amount, inflation_amount, inflation_amount);
+
+  bbox.first -= inflation; // min
+  bbox.second += inflation; // max
+
+  return bbox;
 }

--- a/test/tests/vectorpostprocessors/line_value_sampler/tests
+++ b/test/tests/vectorpostprocessors/line_value_sampler/tests
@@ -4,6 +4,14 @@
     input = 'line_value_sampler.i'
     csvdiff = 'line_value_sampler_out_line_sample_0001.csv'
   [../]
+  [./parallel]
+    # This ensures that PointSamplerBase is properly handling unique point finding
+    type = 'CSVDiff'
+    input = 'line_value_sampler.i'
+    csvdiff = 'line_value_sampler_out_line_sample_0001.csv'
+    min_parallel = 3
+    prereq = test
+  [../]
   [./delimiter]
     type = 'CheckFiles'
     input = 'csv_delimiter.i'
@@ -11,4 +19,3 @@
     file_expect_out = 'id u v x y z\n0 0 1\.2346 0 0\.5 0\n0\.1 0\.1 1\.2346 0\.1 0\.5 0\n0\.2 0.2 1\.2346 0\.2 0.5 0'
   [../]
 []
-

--- a/test/tests/vectorpostprocessors/point_value_sampler/not_found.i
+++ b/test/tests/vectorpostprocessors/point_value_sampler/not_found.i
@@ -1,0 +1,77 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./diff_v]
+    type = Diffusion
+    variable = v
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+  [./left_v]
+    type = DirichletBC
+    variable = v
+    boundary = left
+    value = 1
+  [../]
+  [./right_v]
+    type = DirichletBC
+    variable = v
+    boundary = right
+    value = 0
+  [../]
+[]
+
+[VectorPostprocessors]
+  [./point_sample]
+    type = PointValueSampler
+    variable = 'u v'
+    points = '0.1 0.1 0  0.23 0.4 0  0.78 0.2 0 1.2 0.2 0'
+    sort_by = x
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Steady
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  csv = true
+  [./console]
+    type = Console
+    perf_log = true
+    output_on = 'timestep_end failed nonlinear'
+  [../]
+[]

--- a/test/tests/vectorpostprocessors/point_value_sampler/tests
+++ b/test/tests/vectorpostprocessors/point_value_sampler/tests
@@ -4,4 +4,10 @@
     input = 'point_value_sampler.i'
     csvdiff = 'point_value_sampler_out_point_sample_0001.csv'
   [../]
+
+  [./error]
+    type = RunException
+    input = not_found.i
+    expect_err = "sample point not found"
+  [../]
 []


### PR DESCRIPTION
My version of the fix @aeslaughter attempted here: #4468

Ensures that in the end only 1 processor is responsible for each point and that processor will be stable

Also splits the work up in parallel based on the geometric decomposition of the mesh so as you add more processors it will go faster.  Note that the geometric lookup is a loose bounding box.  It's not intended to be perfect...

This also works with ParallelMesh (I verified it) and handles all edge cases (that I can think of).

refs #4455 
