### PR TITLE
Allowing multiple matches on a single line in peacocks input file parser, fixes #4491.

### DIFF
--- a/python/FactorySystem/ParseGetPot.py
+++ b/python/FactorySystem/ParseGetPot.py
@@ -105,25 +105,40 @@ class ParseGetPot:
 
     self.section_end_re = re.compile(r"\s*\[\s*(\.\./)?\s*\]")
 
-    self.parameter_re = re.compile(r"\s*(\w+)\s*=\s*([^#\n]+?)\s*(#.*)?\n")
+    self.parameter_res = [re.compile(r"\s*([\w\-]+)\s*=\s*'([^\n]+)'"),  # parameter value in two single ticks
+                          re.compile(r'\s*([\w\-]+)\s*=\s*"([^\n]+)"'),  # parameter value in two double ticks
+                          re.compile(r"\s*([\w\-]+)\s*=\s*'([^'\n]+)"),   # parameter value with a single single tick
+                          re.compile(r'\s*([\w\-]+)\s*=\s*"([^"\n]+)'),   # parameter value with a single double tick
+                          re.compile(r"\s*(\w+)\s*=\s*([^#'""\n\[\]\s]+)")] # parameter value with no double/single tick
 
-    self.parameter_in_single_quotes_re = re.compile(r"\s*([\w\-]+)\s*=\s*'([^\n]+?)'\s*(#.*)?\n")
+    self.comment_re = re.compile(r"\s*(?:'.*')?\s*#\s*(.*)")
 
-    self.comment_re = re.compile(r"[^']*(?:'.*')?\s*#\s*(.*)")
-
-    self.unmatched_single_tick_re = re.compile(r"[^']*'[^']*\n")
-
-    self.independent_data_re = re.compile(r"\s*([^'\n]+)")
+    self.unmatched_ticks_re = [[re.compile(r"[^']*'[^']*\n"), re.compile(r"\s*([^'\n]+)"), "'"],   # unmatched single tick and appropriate data re
+                               [re.compile(r'[^"]*"[^"]*\n'), re.compile(r'\s*([^"\n]+)'), '"']]   # unmatched double tick and appropriate data re
 
     self._parseFile()
 
-  def _recursiveParseFile(self, current_node, lines, current_position):
-    while current_position < len(lines):
-      if current_position == None:
-        return len(lines)
-      line = lines[current_position]
+  def _recursiveParseFile(self, current_node, lines, current_line, current_position):
+    param_name = '' # We need to store the name of the last parameter that has been identified to
+                    # properly assign comments. If param_name=='', we assign them to the section.
+    while current_line < len(lines):
+      if current_position >= len(lines[current_line]) or current_position == -1:
+        # reached end of current line
+        current_line += 1
+        current_position = 0
+        param_name = '' # comments that are not preceded by any parameter belong to the section
+
+      if current_line == len(lines):
+        # file traversal finished
+        return len(lines), len(lines[-1])
+
+      # we are only interested in any part of the line that has not been parsed yet
+      line = lines[current_line][current_position:]
+      #print current_line, current_position, 'of', len(lines[current_line]), line
+
       m = self.section_begin_re.match(line)
       if m:
+        current_position += m.end()
         child_name = m.group(2)
 
         if child_name in current_node.children:
@@ -133,83 +148,85 @@ class ParseGetPot:
           current_node.children[child_name] = child
           current_node.children_list.append(child_name)
 
-        # See if there are any comments after the beginning of the block
-        m = self.comment_re.match(line)
-        if m:
-          child.comments.append(m.group(1))
-
-        current_position += 1
-        current_position = self._recursiveParseFile(child, lines, current_position)
-
+        current_line, current_position = self._recursiveParseFile(child, lines, current_line, current_position)
         continue
 
       # Look for a parameter on this line
-      m = self.parameter_in_single_quotes_re.match(line)
+      for re_param in self.parameter_res:
+        m = re_param.match(line)
 
-      if not m:
-        m = self.parameter_re.match(line)
+        if m:
+          current_position += m.end()
+          param_name = m.group(1)
+          param_value = m.group(2)
+
+          # See if the value of this parameter has an unmatched single tick
+          for re_tick in self.unmatched_ticks_re:
+            # Only look at the part before the comment (if there is one)
+            m_tick = re_tick[0].match(line.partition('#')[0])
+            if m_tick:
+              current_line += 1
+              current_position = 0
+              found_it = False
+              # in case of a multiline parameter, we have to remove the leading single/double tick
+              param_value = param_value.lstrip(re_tick[2])
+              # Keep eating lines until we find its mate
+              while current_line < len(lines):
+                line = lines[current_line]
+
+                # While we're eating lines keep appending data to the value for this parameter
+                m_data = re_tick[1].match(line)
+                if m_data:
+                  param_value += ' ' + m_data.group(1)
+
+                m_tick = re_tick[0].match(line.partition('#')[0]) # Don't include the comment
+                if m_tick:
+                  found_it = True
+                  break
+
+                current_line += 1
+              if not found_it:
+                raise ParseException("SyntaxError", "Unmatched token in Parser")
+
+              break # do not continue searching for unmatched ticks
+
+          unique_key = current_node.fullName(True) + '/' + param_name
+          if unique_key in self.unique_keys:
+            raise ParseException("DuplicateSymbol", 'Duplicate Section Name "' + os.getcwd() + '/' + self.file_name + ":" + unique_key + '"')
+          self.unique_keys.add(unique_key)
+
+          current_node.params[param_name] = param_value
+          current_node.params_list.append(param_name)
+
+          break
 
       if m:
-        param_name = m.group(1)
-        param_value = m.group(2)
+        continue # with outer loop since we found a parameter and have to remove it from the current line before continuing
 
-        # See if the value of this parameter has an unmatched single tick
-        # Only look at the part before the comment (if there is one)
-        m = self.unmatched_single_tick_re.match(line.partition('#')[0])
-        if m:
-          current_position += 1
-          found_it = False
-          # Keep eating lines until we find its mate
-          while current_position < len(lines):
-            line = lines[current_position]
-
-            # While we're eating lines keep appending data to the value for this parameter
-            m = self.independent_data_re.match(line)
-            if m:
-              param_value += ' ' + m.group(1)
-
-            m = self.unmatched_single_tick_re.match(line.partition('#')[0]) # Don't include the comment
-            if m:
-              found_it = True
-              break
-
-            current_position += 1
-          if not found_it:
-            raise ParseException("SyntaxError", "Unmatched token in Parser")
-
-        unique_key = current_node.fullName(True) + '/' + param_name
-        if unique_key in self.unique_keys:
-          raise ParseException("DuplicateSymbol", 'Duplicate Section Name "' + os.getcwd() + '/' + self.file_name + ":" + unique_key + '"')
-        self.unique_keys.add(unique_key)
-
-        current_node.params[param_name] = param_value.strip("'")
-        current_node.params_list.append(param_name)
-
-        # See if this parameter has a comment after it
-        m = self.comment_re.match(line)
-        if m:
-          current_node.param_comments[param_name] = m.group(1)
-
-        current_position += 1
-
-        continue
-
-      # Comment in the block (not after a parameter)
+      # Comment in the block (not after a parameter or section header)
       m = self.comment_re.match(line)
       if m:
-        current_node.comments.append(m.group(1))
+        current_position = -1 # remainder of line ignored
+        if param_name=='':
+          current_node.comments.append(m.group(1))
+        else:
+          current_node.param_comments[param_name] = m.group(1)
+        continue
 
       # Is this section over?
       m = self.section_end_re.match(line)
       if m:
-        current_position += 1
-        return current_position
+        current_position += m.end()
+        return current_line, current_position
 
-      current_position += 1
+      # did not find anything else in this line
+      current_position = -1
+
+    return current_line, current_position
 
   def _parseFile(self):
     lines = self.file.readlines()
-    self._recursiveParseFile(self.root_node, lines, 0)
+    self._recursiveParseFile(self.root_node, lines, 0, 0)
 
 def readInputFile(file_name):
   pgp = ParseGetPot(file_name)
@@ -218,7 +235,11 @@ def readInputFile(file_name):
 
 
 if __name__ == '__main__':
-  pgp = ParseGetPot('2d_diffusion_test.i')
-#  pgp = ParseGetPot('input.i')
+  if (len(sys.argv) > 1):
+    filename = sys.argv[1]
+  else:
+    filename = '2d_diffusion_test.i'
+
+  pgp = ParseGetPot(filename)
   print 'Printing tree'
   pgp.root_node.Print()

--- a/test/tests/parser/vector_range_checking/tests
+++ b/test/tests/parser/vector_range_checking/tests
@@ -3,54 +3,54 @@
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Range check failed for parameter Materials/vecrangecheck/rv3"
-    cli_args = Materials/vecrangecheck/rv3="1.0 2.0"
+    cli_args = 'Materials/vecrangecheck/rv3="1.0 2.0"'
   [../]
   [./intvectorlength]
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Range check failed for parameter Materials/vecrangecheck/iv3"
-    cli_args = Materials/vecrangecheck/iv3="1 2"
+    cli_args = 'Materials/vecrangecheck/iv3="1 2"'
   [../]
   [./allelementcheck]
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Range check failed for parameter Materials/vecrangecheck/rvp\n\tExpression: rvp > 0\n\t Component: 1"
-    cli_args = Materials/vecrangecheck/rvp="1.0 -2.0 3.0"
+    cli_args = 'Materials/vecrangecheck/rvp="1.0 -2.0 3.0"'
   [../]
   [./elementcompare_unsigned_int]
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Range check failed for parameter Materials/vecrangecheck/uvg"
-    cli_args = Materials/vecrangecheck/uvg="1 2"
+    cli_args = 'Materials/vecrangecheck/uvg="1 2"'
   [../]
   [./elementcompare_long]
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Range check failed for parameter Materials/vecrangecheck/lvg"
-    cli_args = Materials/vecrangecheck/lvg="1 2"
+    cli_args = 'Materials/vecrangecheck/lvg="1 2"'
   [../]
   [./elementcompare_int]
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Range check failed for parameter Materials/vecrangecheck/ivg"
-    cli_args = Materials/vecrangecheck/ivg="1 2"
+    cli_args = 'Materials/vecrangecheck/ivg="1 2"'
   [../]
   [./elementcompare_real]
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Range check failed for parameter Materials/vecrangecheck/rvg"
-    cli_args = Materials/vecrangecheck/rvg="1.0 2.0"
+    cli_args = 'Materials/vecrangecheck/rvg="1.0 2.0"'
   [../]
   [./outofbounds]
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Error parsing expression: rvl_10 > 0\nOut of range variable rvl_10"
-    cli_args = Materials/vecrangecheck/rvl="1.0 2.0"
+    cli_args = 'Materials/vecrangecheck/rvl="1.0 2.0"'
   [../]
   [./checkempty]
     type = 'RunException'
     input = 'all_pass.i'
     expect_err = "Range checking empty vector: rvp > 0"
-    cli_args = Materials/vecrangecheck/rvp=""
+    cli_args = 'Materials/vecrangecheck/rvp=""'
   [../]
 []

--- a/test/tests/time_steppers/iteration_adaptive/tests
+++ b/test/tests/time_steppers/iteration_adaptive/tests
@@ -21,7 +21,7 @@
     input = 'adapt_tstep_grow_init_dt_restart2.i'
     exodiff = 'adapt_tstep_grow_init_dt_restart2_out.e'
     #exodiff_opts = -TM
-    exodiff_opts = -steps last
+    exodiff_opts = '-steps last'
 
     prereq = 'test_grow_init_dt test_grow_init_dt_restart1'
   [../]


### PR DESCRIPTION
This PR fixes #4491. The essential changes are explained in my comment to the issue.

Since there is no systematic testing for peacock available yet, I manually tried a number of different input files that I am having around and ensured they are working correctly.

If you find any case that is broken due to the patch, it might be best to add it as a comment to this PR. Besides the opportunity of fixing, these might also be a good starting point for a regression test suite for peacock in future.
