### PR TITLE
Add phase field mechanics coupling examples

### DIFF
--- a/modules/combined/examples/phase_field-mechanics/Conserved.i
+++ b/modules/combined/examples/phase_field-mechanics/Conserved.i
@@ -1,0 +1,233 @@
+#
+# Example 1
+# Illustrating the coupling between chemical and mechanical (elastic) driving forces.
+# An oversized precipitate deforms under a uniaxial compressive stress
+# Check the file below for comments and suggestions for parameter modifications.
+#
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 40
+  ny = 40
+  nz = 0
+  xmin = 0
+  xmax = 50
+  ymin = 0
+  ymax = 50
+  zmin = 0
+  zmax = 0
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [./c]
+    order = FIRST
+    family = LAGRANGE
+    [./InitialCondition]
+      type = SmoothCircleIC
+      x1 = 0
+      y1 = 0
+      radius = 25.0
+      invalue = 1.0
+      outvalue = 0.0
+      int_width = 50.0
+    [../]
+  [../]
+  [./w]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+    disp_x = disp_x
+    disp_y = disp_y
+  [../]
+
+  [./c_res]
+    type = SplitCHParsed
+    variable = c
+    f_name = F
+    kappa_name = kappa_c
+    w = w
+  [../]
+  [./w_res]
+    type = SplitCHWRes
+    variable = w
+    mob_name = M
+  [../]
+  [./time]
+    type = CoupledImplicitEuler
+    variable = w
+    v = c
+  [../]
+[]
+
+#
+# The AuxVariables and AuxKernels below are added to visualize the xx and yy stress tensor components
+#
+[AuxVariables]
+  [./e11_aux]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./e22_aux]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+[AuxKernels]
+  [./matl_e11]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    index_i = 0
+    index_j = 0
+    variable = e11_aux
+  [../]
+  [./matl_e22]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    index_i = 1
+    index_j = 1
+    variable = e22_aux
+  [../]
+[]
+
+[Materials]
+  [./pfmobility]
+    type = PFMobility
+    block = 0
+    #kappa = 0.1
+    kappa = 5
+    #mob = 1e-3
+    mob = 1
+  [../]
+
+  # simple chemical free energy with a miscibility gap
+  [./chemical_free_energy]
+    type = DerivativeParsedMaterial
+    block = 0
+    f_name = Fc
+    args = 'c'
+    constant_names       = 'barr_height  cv_eq'
+    constant_expressions = '0.1          1.0e-2'
+    function = 16*barr_height*(c-cv_eq)^2*(1-cv_eq-c)^2
+    enable_jit = true
+    third_derivatives = false
+  [../]
+
+  # undersized solute (voidlike)
+  [./eigenstrain]
+    type = SimpleEigenStrainMaterial
+    block = 0
+
+    # eigenstrain coefficient
+    # -0.1 will result in an undersized precipiutate
+    #  0.1 will result in an oversized precipitate
+    epsilon0 = 0.1
+
+    c = c
+    disp_y = disp_y
+    disp_x = disp_x
+
+    # Stiffness tensor lambda, mu values
+    # '15 15' results in a high stiffness (the elastic free energy will dominate)
+    # '7 7' results in a low stiffness (the chemical free energy will dominate)
+    C_ijkl = '7 7'
+
+    fill_method = symmetric_isotropic
+  [../]
+  [./elastic_free_energy]
+    type = ElasticEnergyMaterial
+    f_name = Fe
+    block = 0
+    args = 'c'
+    third_derivatives = false
+  [../]
+
+  # Sum up chemical and elastic contributions
+  [./free_energy]
+    type = DerivativeSumMaterial
+    block = 0
+    f_name = F
+    sum_materials = 'Fc Fe'
+    args = 'c'
+    third_derivatives = false
+  [../]
+[]
+
+[BCs]
+  [./bottom_y]
+    type = PresetBC
+    variable = disp_y
+    boundary = 'bottom'
+    value = 0
+  [../]
+  [./top_y]
+    type = PresetBC
+    variable = disp_y
+    boundary = 'top'
+
+    # prescribed displacement
+    # -5 will result in a compressive stress
+    #  5 will result in a tensile stress
+    value = -5
+  [../]
+  [./left_x]
+    type = PresetBC
+    variable = disp_x
+    boundary = 'left'
+    value = 0
+  [../]
+[]
+
+[Preconditioning]
+  # active = ' '
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  scheme = bdf2
+
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -ksp_grmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
+  petsc_options_value = 'asm         101   preonly   lu      1'
+
+  l_max_its = 30
+  nl_max_its = 10
+  l_tol = 1.0e-4
+  nl_rel_tol = 1.0e-8
+  nl_abs_tol = 1.0e-10
+  start_time = 0.0
+  num_steps = 200
+
+  [./TimeStepper]
+    type = SolutionTimeAdaptiveDT
+    dt = 1
+  [../]
+[]
+
+[Outputs]
+  interval = 1
+  exodus = true
+  output_on = 'timestep_end'
+  [./console]
+    type = Console
+    perf_log = true
+    output_on = 'timestep_end failed nonlinear'
+  [../]
+[]

--- a/modules/combined/examples/phase_field-mechanics/Nonconserved.i
+++ b/modules/combined/examples/phase_field-mechanics/Nonconserved.i
@@ -1,0 +1,224 @@
+#
+# Example 2
+# Phase change driven by a mechanical (elastic) driving force.
+# An oversized phase inclusion grows under a uniaxial tensile stress.
+# Check the file below for comments and suggestions for parameter modifications.
+#
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 40
+  ny = 40
+  nz = 0
+  xmin = 0
+  xmax = 50
+  ymin = 0
+  ymax = 50
+  zmin = 0
+  zmax = 0
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [./eta]
+    order = FIRST
+    family = LAGRANGE
+    [./InitialCondition]
+      type = SmoothCircleIC
+      x1 = 0
+      y1 = 0
+      radius = 30.0
+      invalue = 1.0
+      outvalue = 0.0
+      int_width = 10.0
+    [../]
+  [../]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+    disp_x = disp_x
+    disp_y = disp_y
+  [../]
+
+  [./eta_bulk]
+    type = ACParsed
+    variable = eta
+    f_name = F
+  [../]
+  [./eta_interface]
+    type = ACInterface
+    variable = eta
+    kappa_name = kappa
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = eta
+  [../]
+[]
+
+#
+# Try visualizing the strees tensor components as done in Conserved.i
+#
+
+[Materials]
+  [./consts]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names  = 'L kappa'
+    prop_values = '1 1'
+  [../]
+
+  # matrix phase
+  [./eigenstrain_a]
+    type = LinearElasticMaterial
+    base_name = phasea
+    block = 0
+    disp_y = disp_y
+    disp_x = disp_x
+    # Stiffness tensor lambda, mu values
+    C_ijkl = '7 7'
+    fill_method = symmetric_isotropic
+  [../]
+  [./elastic_free_energy_a]
+    type = ElasticEnergyMaterial
+    base_name = phasea
+    f_name = Fea
+    block = 0
+    args = ''
+  [../]
+
+  # oversized phase (simulated using thermal expansion)
+  [./eigenstrain_b]
+    type = LinearElasticMaterial
+    base_name = phaseb
+    block = 0
+
+    # we use thermal expansion with a constant temperature to achieve a 10% oversize
+    # commenting out the following 3 lines will switch off the oversize effect
+    thermal_expansion_coeff = 0.1
+    T0 = 0
+    T = 1
+
+    disp_y = disp_y
+    disp_x = disp_x
+
+    # Stiffness tensor lambda, mu values
+    # Note that the two phases could have different stiffnesses.
+    # Try reducing the precipitate stiffness (to '1 1') rather than making it oversized
+    C_ijkl = '7 7'
+    fill_method = symmetric_isotropic
+  [../]
+  [./elastic_free_energy_b]
+    type = ElasticEnergyMaterial
+    base_name = phaseb
+    f_name = Feb
+    block = 0
+    args = ''
+  [../]
+
+  # Generate the global free energy from the phase free energies
+  [./switching]
+    type = SwitchingFunctionMaterial
+    block = 0
+    eta = eta
+    h_order = SIMPLE
+  [../]
+  [./barrier]
+    type = BarrierFunctionMaterial
+    block = 0
+    eta = eta
+    g_order = SIMPLE
+  [../]
+  [./free_energy]
+    type = DerivativeTwoPhaseMaterial
+    block = 0
+    f_name = F
+    fa_name = Fea
+    fb_name = Feb
+    eta = eta
+    args = ''
+    W = 0.1
+    third_derivatives = false
+  [../]
+
+  # Generate the global stress from the phase stresses
+  [./global_stress]
+    type = TwoPhaseStressMaterial
+    block = 0
+    base_A = phasea
+    base_B = phaseb
+  [../]
+[]
+
+[BCs]
+  [./bottom_y]
+    type = PresetBC
+    variable = disp_y
+    boundary = 'bottom'
+    value = 0
+  [../]
+  [./top_y]
+    type = PresetBC
+    variable = disp_y
+    boundary = 'top'
+    value = 5
+  [../]
+  [./left_x]
+    type = PresetBC
+    variable = disp_x
+    boundary = 'left'
+    value = 0
+  [../]
+[]
+
+[Preconditioning]
+  # active = ' '
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  scheme = bdf2
+
+  # this gives best performance on 4 cores
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -ksp_grmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
+  petsc_options_value = 'asm         101   preonly   lu      1'
+
+  l_max_its = 30
+  nl_max_its = 10
+  l_tol = 1.0e-4
+  nl_rel_tol = 1.0e-8
+  nl_abs_tol = 1.0e-10
+  start_time = 0.0
+  num_steps = 200
+
+  [./TimeStepper]
+    type = SolutionTimeAdaptiveDT
+    dt = 0.2
+  [../]
+[]
+
+[Outputs]
+  interval = 1
+  exodus = true
+  output_on = 'timestep_end'
+  [./console]
+    type = Console
+    perf_log = true
+    output_on = 'timestep_end failed nonlinear'
+  [../]
+[]

--- a/modules/tensor_mechanics/src/materials/TwoPhaseStressMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TwoPhaseStressMaterial.C
@@ -9,7 +9,7 @@ InputParameters validParams<TwoPhaseStressMaterial>()
   params.addParam<std::string>("h", "h", "Switching Function Material that provides h(eta)");
   params.addRequiredParam<std::string>("base_A", "Base name for the Phase A strain.");
   params.addRequiredParam<std::string>("base_B", "Base name for the Phase B strain.");
-  params.addParam<std::string>("base_name", "Base name for the Phase B strain.");
+  params.addParam<std::string>("base_name", "Base name for the computed global stress (optional).");
   return params;
 }
 


### PR DESCRIPTION
Add two examples
1. `Conserved.i`, a precipitate with a concentration dependent Eigenstrain. The oversized precipitate changes shape under applied uniaxial compressive stress and is partially put in solution.
2. `Nonconserved.i` an oversized phase inclusion shrinks through transformation into a lower volume phase and disappears.

These two simple examples show off how to use `DerivativeSumMaterial`, `DerivativeTwoPhaseMaterial`, `TwoPhaseStessMaterial`, and others to achieve phase field mechanics coupling and model multiphase systems.

Also fix param docs. Closes #4502
