### PR TITLE
Providing a simplified syntax for common output related actions

### DIFF
--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -227,7 +227,7 @@ private:
    * @param message The message to add to the output streams
    *
    * Any call to this method will write the supplied message to the screen and/or file,
-   * following the same restrictions as outputStep and outputInitial.
+   * following the same restrictions as outputStep.
    *
    * Calls to this method should be made via OutputWarehouse::mooseConsole so that the
    * output stream buffer is cleaned up correctly. Thus, it is a private method.

--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -94,7 +94,18 @@ public:
   virtual int timeStep();
 
   /**
+   * Get the output interval
+   */
+  const unsigned int & interval() const;
+
+  /**
+   * Get the current 'output_on' selections
+   */
+  std::string outputOn() const;
+
+  /**
    * Return the support output execution times
+   * @param default_type The default MultiMooseEnum option
    */
   static MultiMooseEnum getExecuteOptions(std::string default_type = "");
 
@@ -128,6 +139,12 @@ protected:
    */
   bool onInterval();
 
+  /**
+   * Initialization method.
+   * This populates the various data structures needed to control the output
+   */
+  virtual void init();
+
   /// Pointer the the FEProblem object for output object (use this)
   FEProblem * _problem_ptr;
 
@@ -145,14 +162,6 @@ protected:
 
   /// The common Execution types; this is used as the default execution type for everything except system information and input
   MultiMooseEnum _output_on;
-
-//private:
-
-  /**
-   * Initialization method.
-   * This populates the various data structures needed to control the output
-   */
-  virtual void init();
 
   /// The current time for output purposes
   Real & _time;
@@ -194,7 +203,6 @@ protected:
   bool _initialized;
 
   friend class OutputWarehouse;
-
 };
 
 #endif /* OUTPUT_H */

--- a/framework/src/actions/AddOutputAction.C
+++ b/framework/src/actions/AddOutputAction.C
@@ -64,19 +64,24 @@ AddOutputAction::act()
   // Add a pointer to the FEProblem class
   _moose_object_pars.addPrivateParam<FEProblem *>("_fe_problem",  _problem.get());
 
+  // Create common parameter exclude list
+  std::vector<std::string> exclude;
+  if (_type == "Console")
+    exclude.push_back("output_on");
+
   // Apply the common parameters
   InputParameters * common = output_warehouse.getCommonParameters();
   if (common != NULL)
-    _moose_object_pars.applyParameters(*common);
+    _moose_object_pars.applyParameters(*common, exclude);
 
   // Set the correct value for the binary flag for XDA/XDR output
-  if (_type.compare("XDR") == 0)
+  if (_type == "XDR")
     _moose_object_pars.set<bool>("_binary") = true;
-  else if (_type.compare("XDA") == 0)
+  else if (_type == "XDA")
     _moose_object_pars.set<bool>("_binary") = false;
 
   // Adjust the checkpoint suffix if auto recovery was enabled
-  if (object_name.compare("auto_recovery_checkpoint") == 0)
+  if (object_name == "auto_recovery_checkpoint")
     _moose_object_pars.set<std::string>("suffix") = "auto_recovery";
 
   // Create the object and add it to the warehouse

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -65,16 +65,19 @@ InputParameters validParams<CommonOutputAction>()
   // Add the 'output_on' input parameter
   params.addParam<MultiMooseEnum>("output_on", Output::getExecuteOptions("timestep_end"), "Set to (initial|linear|nonlinear|timestep_end|timestep_begin|final|failed|custom) to execute only at that moment (default: timestep_end)");
 
-  // **** DEPRECATED PARAMETERS ***
-  params.addDeprecatedParam<bool>("output_initial", false, "Request that the initial condition is output to the solution file",
-                                  "replace by adding 'initial' to the 'output_on' option");
+  // Add common output toggles
+  params.addParam<bool>("output_initial", false, "Request that the initial condition is output to the solution file");
+  params.addParam<bool>("output_timestep_end", true, "Request that data be output at the end of the timestep");
   params.addDeprecatedParam<bool>("output_intermediate", true, "Request that all intermediate steps (not initial or final) are output",
                                   "replace by adding 'timestep_end' to the 'output_on' option");
-  params.addDeprecatedParam<bool>("output_final", false, "Force the final time step to be output, regardless of output interval",
-                                  "replace by adding 'final' to the 'output_on' option");
+  params.addParam<bool>("output_final", false, "Force the final time step to be output, regardless of output interval");
 
-   // Return object
-   return params;
+  // Add special Console flags
+  params.addParam<bool>("print_linear_residuals", false, "Enable printing of linear residuals to the screen (Console)");
+  params.addParam<bool>("print_perf_log", false, "Enable printing of the performance log to the screen (Console)");
+
+  // Return object
+  return params;
 }
 
 CommonOutputAction::CommonOutputAction(const std::string & name, InputParameters params) :
@@ -84,14 +87,18 @@ CommonOutputAction::CommonOutputAction(const std::string & name, InputParameters
   // Set the ActionWarehouse pointer in the parameters that will be passed to the actions created with this action
   _action_params.set<ActionWarehouse *>("awh") = &_awh;
 
-  // **** DEPRECATED PARAMETER SUPPORT ****
+  // Support quick output toggles
   MultiMooseEnum & output_on = _pars.set<MultiMooseEnum>("output_on");
   if (getParam<bool>("output_initial"))
     output_on.push_back("initial");
-  if (getParam<bool>("output_intermediate"))
+  if (getParam<bool>("output_timestep_end"))
     output_on.push_back("timestep_end");
   if (getParam<bool>("output_final"))
     output_on.push_back("final");
+
+  // **** DEPRECATED PARAMETER SUPPORT ****
+  if (getParam<bool>("output_intermediate"))
+    output_on.push_back("timestep_end");
 }
 
 void

--- a/test/tests/outputs/console/additional_output_on.i
+++ b/test/tests/outputs/console/additional_output_on.i
@@ -12,7 +12,12 @@
 
 [Kernels]
   [./diff]
-    type = Diffusion
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+  [./time]
+    type = TimeDerivative
     variable = u
   [../]
 []
@@ -33,19 +38,19 @@
 []
 
 [Executioner]
-  type = Steady
-
   # Preconditioned JFNK (default)
-  solve_type = 'PJFNK'
-
-
+  type = Transient
+  num_steps = 20
+  dt = 0.1
+  solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
 []
 
 [Outputs]
-  exodus = true
-  output_initial = true
-  print_linear_residuals = true
-  print_perf_log = true
+  [./console]
+    type = Console
+    perf_log = true
+    additional_output_on = 'initial'
+  [../]
 []

--- a/test/tests/outputs/console/console_print_toggles.i
+++ b/test/tests/outputs/console/console_print_toggles.i
@@ -34,18 +34,14 @@
 
 [Executioner]
   type = Steady
-
-  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
 []
 
 [Outputs]
-  exodus = true
-  output_initial = true
-  print_linear_residuals = true
-  print_perf_log = true
+  # This block is needed so cli_args in the tests files is available
+  [./console]
+    type = Console
+  [../]
 []

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -94,7 +94,7 @@
     # Test the used of MooseObject::_console method
     type = RunApp
     input = 'moose_console.i'
-    expect_out = 'ConsoleMessageKernel::timestepSetup - time = 0.4; t_step = 4'
+    expect_out = 'ConsoleMessageKernel::timestepSetup - time = 0\.4; t_step = 4'
   [../]
   [./_console_const]
     # Test the used of MooseObject::_console method from a constant method
@@ -107,6 +107,41 @@
     type = RunApp
     input = 'console.i'
     cli_args = '--show-input'
-    expect_out = '[./screen]'
+    expect_out = '\[\./screen\]'
+  [../]
+  [./print_linear_residuals]
+    # Tests that flag is working to show linear residuals from the top level
+    type = RunApp
+    input = 'console_print_toggles.i'
+    expect_out = '0\sLinear'
+    cli_args = 'Outputs/print_linear_residuals=true'
+  [../]
+  [./print_linear_residuals_disable]
+    # Tests that using 'output_on' inside console disables flag to show linear residuals
+    type = RunApp
+    input = 'console_print_toggles.i'
+    expect_out = '\s*0\sNonlinear.*?\n\s*1\sNonlinear'
+    cli_args = "Outputs/print_linear_residuals=true Outputs/console/output_on='nonlinear final failed timestep_end'"
+  [../]
+  [./print_pref_log]
+    # Tests that flag is working to show performace log from the top level
+    type = RunApp
+    input = 'console_print_toggles.i'
+    expect_out = 'Moose Test Performance'
+    cli_args = 'Outputs/print_perf_log=true'
+  [../]
+  [./print_pref_log_disable]
+    # Tests that perf log is disabled flag when console level flag is set to false
+    type = RunApp
+    input = 'console_print_toggles.i'
+    expect_out = '\s*2\sNonlinear.*?\n\s*\n\Z'
+    cli_args = 'Outputs/print_perf_log=true Outputs/console/perf_log=false'
+    method = 'opt oprof' # debug prints some extra stuff at the end that messes up the regex
+  [../]
+  [./additional_output_on]
+    # Test use of 'additional_output_on' parameter
+    type = RunApp
+    input = 'additional_output_on.i'
+    expect_out = 'Time\sStep\s*0'
   [../]
 []


### PR DESCRIPTION
This patch implements:
- `Console` no-longer inherits "output_on" parameter
- Added convenience parameters ("print_perf_log" and "print_linear_residuals")
- Adds parameter for appending output on settings: "addditional_output_on"
- Adds display of output_on settings for each output object to header

(closes #4497)
