### PR TITLE
Keep output syntax consistent

### DIFF
--- a/examples/ex18_scalar_kernel/ex18.i
+++ b/examples/ex18_scalar_kernel/ex18.i
@@ -93,18 +93,18 @@
   [./x]
     type = ScalarVariable
     variable = x
-    execute_on = timestep
+    execute_on = timestep_end
   [../]
   [./y]
     type = ScalarVariable
     variable = y
-    execute_on = timestep
+    execute_on = timestep_end
   [../]
 
   [./exact_x]
     type = PlotFunction
     function = exact_x_fn
-    execute_on = timestep
+    execute_on = timestep_end
   [../]
   # measure the error from exact solution in L2 norm
   [./l2err_x]

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -52,6 +52,7 @@ InputParameters validParams<CommonOutputAction>()
    params.addParam<bool>("dofmap", false, "Create the dof map .json output file");
 
    // Common parameters
+
    // Note: Be sure that objects that share these parameters utilize the same defaults
    params.addParam<bool>("color", true, "Set to false to turn off all coloring in all outputs");
    params.addParam<std::string>("file_base", "Common file base name to be utilized with all output objects");

--- a/framework/src/outputs/PetscOutput.C
+++ b/framework/src/outputs/PetscOutput.C
@@ -27,12 +27,14 @@ InputParameters validParams<PetscOutput>()
 
   // Toggled for outputting nonlinear and linear residuals, only if we have PETSc
 #ifdef LIBMESH_HAVE_PETSC
+  params.addParam<bool>("output_linear", false, "Specifies whether output occurs on each linear residual evaluation");
+  params.addParam<bool>("output_nonlinear", false, "Specifies whether output occurs on each nonlinear residual evaluation");
 
   // **** DEPRECATED PARAMETERS ****
   params.addDeprecatedParam<bool>("linear_residuals", false, "Specifies whether output occurs on each linear residual evaluation",
-                                  "Please include 'linear' in the 'output_on' execution list to get this behavior.");
+                                  "Please use 'output_linear' to get this behavior.");
   params.addDeprecatedParam<bool>("nonlinear_residuals", false, "Specifies whether output occurs on each nonlinear residual evaluation",
-                                  "Please include 'nonlinear' in the 'output_on' execution list to get this behavior.");
+                                  "Please use 'output_nonlinear' to get this behavior.");
   // Psuedo time step divisors
   params.addParam<Real>("nonlinear_residual_dt_divisor", 1000, "Number of divisions applied to time step when outputting non-linear residuals");
   params.addParam<Real>("linear_residual_dt_divisor", 1000, "Number of divisions applied to time step when outputting linear residuals");
@@ -65,6 +67,12 @@ PetscOutput::PetscOutput(const std::string & name, InputParameters & parameters)
     _nonlinear_end_time(std::numeric_limits<Real>::max()),
     _linear_end_time(std::numeric_limits<Real>::max())
 {
+  // Output toggle support
+  if (getParam<bool>("output_linear"))
+    _output_on.push_back("linear");
+  if (getParam<bool>("output_nonlinear"))
+    _output_on.push_back("nonlinear");
+
   // **** DEPRECATED PARAMETER SUPPORT ****
   if (getParam<bool>("linear_residuals"))
     _output_on.push_back("linear");

--- a/modules/combined/tests/elastic_thermal_patch/elastic_thermal_jacobian_rz_smp_test.i
+++ b/modules/combined/tests/elastic_thermal_patch/elastic_thermal_jacobian_rz_smp_test.i
@@ -248,7 +248,7 @@
   [./exodus]
     type = Exodus
     elemental_as_nodal = true
-    nonlinear_residuals = true
+    output_nonlinear = true
     nonlinear_residual_dt_divisor = 100
   [../]
 [] # Outputs

--- a/modules/combined/tests/elastic_thermal_patch/elastic_thermal_patch_rz_smp_test.i
+++ b/modules/combined/tests/elastic_thermal_patch/elastic_thermal_patch_rz_smp_test.i
@@ -287,7 +287,7 @@
   [./exodus]
     type = Exodus
     elemental_as_nodal = true
-    nonlinear_residuals = true
+    output_nonlinear = true
     nonlinear_residual_dt_divisor = 100
   [../]
 [] # Outputs

--- a/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_it_plot_test.i
+++ b/modules/combined/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_it_plot_test.i
@@ -161,7 +161,7 @@
   print_perf_log = true
   [./exodus]
     type = Exodus
-    nonlinear_residuals = true
+    output_nonlinear = true
     nonlinear_residual_dt_divisor = 100
   [../]
 []

--- a/modules/combined/tests/simple_contact/merged_rz.i
+++ b/modules/combined/tests/simple_contact/merged_rz.i
@@ -177,7 +177,7 @@
 [] # Executioner
 
 [Outputs]
-  linear_residuals = true
+  output_linear = true
   file_base = merged_rz_out
   output_initial = true
   print_linear_residuals = true

--- a/modules/combined/tests/thermo_mech/thermo_mech_smp_test.i
+++ b/modules/combined/tests/thermo_mech/thermo_mech_smp_test.i
@@ -137,7 +137,7 @@
   print_perf_log = true
   [./exodus]
     type = Exodus
-    nonlinear_residuals = true
+    output_nonlinear = true
     nonlinear_residual_dt_divisor = 100
   [../]
 []

--- a/modules/phase_field/examples/cahn-hilliard/Parsed_CH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Parsed_CH.i
@@ -68,7 +68,7 @@
     f_name = fbulk
     interfacial_vars = c
     kappa_names = kappa_c
-    execute_on = timestep
+    execute_on = timestep_end
   [../]
 []
 

--- a/modules/phase_field/examples/cahn-hilliard/Parsed_SplitCH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Parsed_SplitCH.i
@@ -63,7 +63,7 @@
     f_name = fbulk
     interfacial_vars = c
     kappa_names = kappa_c
-    execute_on = timestep
+    execute_on = timestep_end
   [../]
 []
 

--- a/modules/solid_mechanics/tests/HHT_time_integrator/one_element_b_0_3025_g_0_6_cubic.i
+++ b/modules/solid_mechanics/tests/HHT_time_integrator/one_element_b_0_3025_g_0_6_cubic.i
@@ -302,6 +302,6 @@
   [./console]
     type = Console
     perf_log = true
-    linear_residuals = true
+    output_linear = true
   [../]
 []

--- a/test/tests/misc/check_error/checked_pointer_param_test.i
+++ b/test/tests/misc/check_error/checked_pointer_param_test.i
@@ -54,6 +54,6 @@ x[Mesh]
   [./console]
     type = Console
     perf_log = true
-    linear_residuals = true
+    output_linear = true
   [../]
 []

--- a/test/tests/misc/check_error/missing_req_par_action_obj_test.i
+++ b/test/tests/misc/check_error/missing_req_par_action_obj_test.i
@@ -54,6 +54,6 @@
   [./console]
     type = Console
     perf_log = true
-    linear_residuals = true
+    output_linear = true
   [../]
 []

--- a/test/tests/misc/check_error/override_name_variable_test.i
+++ b/test/tests/misc/check_error/override_name_variable_test.i
@@ -66,6 +66,6 @@
   [./console]
     type = Console
     perf_log = true
-    linear_residuals = true
+    output_linear = true
   [../]
 []

--- a/test/tests/time_steppers/iteration_adaptive/adapt_tstep_grow_init_dt.i
+++ b/test/tests/time_steppers/iteration_adaptive/adapt_tstep_grow_init_dt.i
@@ -79,7 +79,7 @@
     type = Console
     output_postprocessors_on = none
     output_on = 'timestep_end failed nonlinear linear'
-    linear_residuals = true
+    output_linear = true
     output_postprocessors = false
   [../]
 []

--- a/test/tests/variables/fe_hermite/hermite-3-2d.i
+++ b/test/tests/variables/fe_hermite/hermite-3-2d.i
@@ -134,6 +134,6 @@
   [./console]
     type = Console
     perf_log = true
-    linear_residuals = true
+    output_linear = true
   [../]
 []


### PR DESCRIPTION
- "linear_residuals" to "output_linear"
- "nonlinear_residuals" to "output_nonlinear"
- cleans up remaining deprecated syntax
