### PR TITLE
fix self-signed certificate issues

### DIFF
--- a/framework/scripts/distcc/DmakeRC.py
+++ b/framework/scripts/distcc/DmakeRC.py
@@ -1,6 +1,7 @@
 # Load requied packages
 import sys, os, pickle, uuid, platform, urllib2, datetime
 from sets import Set
+import ssl
 
 ## @class DmakeRC
 #  Manages the .dmakrc file, which stores various information mainly for the purpose
@@ -352,6 +353,8 @@ class DmakeRC(object):
                  '&username=' + os.getenv('USER')
 
     try:
+      if hasattr(ssl, '_create_unverified_context'):
+        ssl._create_default_https_context = ssl._create_unverified_context
       fid = urllib2.urlopen(filename, None, 1)
       data = fid.read().split('\n')
       fid.close()


### PR DESCRIPTION
latest version of urllib2 uses verified SSL certificates by default. Turn that feature off for now. Closes #4590
