### PR TITLE
Stateful material problem (DO NOT MERGE)

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -832,6 +832,11 @@ public:
    */
   MaterialWarehouse & getMaterialWarehouse(THREAD_ID tid) { return _materials[tid]; }
 
+  /**
+   * Return a reference to the IndicatorWarehouse
+   */
+  IndicatorWarehouse & getIndicatorWarehouse(THREAD_ID tid) { return _indicators[tid]; }
+
   /*
    * Return a pointer to the MaterialData
    */

--- a/framework/include/indicators/IndicatorWarehouse.h
+++ b/framework/include/indicators/IndicatorWarehouse.h
@@ -44,6 +44,12 @@ public:
   const std::vector<Indicator *> & active() const { return _active_indicators; }
 
   /**
+   * Get the list of all active Indicators on a Subdomain
+   * @ return The list of all active Indicators on the subdomain
+   */
+//  const std::vector<Indicator *> & active(const SubdomainID & id) const { return _block_indicators[id]; }
+
+  /**
    * Get the list of all active Indicators
    * @return The list of all active InternalSideIndicators
    */

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -83,7 +83,7 @@ public:
   // material properties for given element (and possible side)
   void swapBack(const Elem & elem, unsigned int side = 0);
 
-  MaterialProperties & props() { return _props; }
+  MaterialProperties & props() { /*std::cout << "MaterialProperties::_props.size() = " << _props.size() << std::endl;*/ return _props; }
   MaterialProperties & propsOld() { return _props_old; }
   MaterialProperties & propsOlder() { return _props_older; }
 

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -157,7 +157,9 @@ public:
    */
   bool hasOlderProperties() const { return _has_older_prop; }
 
-  HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > & props() { return *_props_elem; }
+  HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > & props() {
+    /*std::cout << "MaterialPropertyStorage::props().size() = " << _props_elem->size() << std::endl;*/
+    return *_props_elem; }
   HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > & propsOld() { return *_props_elem_old; }
   HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > & propsOlder() { return *_props_elem_older; }
 
@@ -171,7 +173,19 @@ public:
 
   unsigned int getPropertyId (const std::string & prop_name);
 
+  /**
+   * Method that dumps the current property data to the screen
+   */
+  void dump() const;
+
+
 protected:
+
+  /**
+   * A helper function for dumping HashMap information
+   */
+  void dumpHelper(const std::string & title, HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > * props) const;
+
   // indexing: [element][side]->material_properties
   HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > * _props_elem;
   HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> > * _props_elem_old;

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -157,13 +157,13 @@ ComputeIndicatorThread::onInternalSide(const Elem *elem, unsigned int side)
       _fe_problem.reinitNeighbor(elem, side, _tid);
 
       _fe_problem.reinitMaterialsFace(elem->subdomain_id(), _tid);
-      _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
+      //_fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
       for (std::vector<Indicator *>::const_iterator it = indicators.begin(); it != indicators.end(); ++it)
         (*it)->computeIndicator();
 
       _fe_problem.swapBackMaterialsFace(_tid);
-      _fe_problem.swapBackMaterialsNeighbor(_tid);
+      //_fe_problem.swapBackMaterialsNeighbor(_tid);
     }
   }
 }

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -135,6 +135,8 @@ ComputeIndicatorThread::onInternalSide(const Elem *elem, unsigned int side)
   if (_finalize) // If finalizing we only do something on the elements
     return;
 
+  _fe_problem.getBndMaterialPropertyStorage().dump();
+
   // Pointer to the neighbor we are currently working on.
   const Elem * neighbor = elem->neighbor(side);
 
@@ -157,13 +159,13 @@ ComputeIndicatorThread::onInternalSide(const Elem *elem, unsigned int side)
       _fe_problem.reinitNeighbor(elem, side, _tid);
 
       _fe_problem.reinitMaterialsFace(elem->subdomain_id(), _tid);
-      //_fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
+      _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
       for (std::vector<Indicator *>::const_iterator it = indicators.begin(); it != indicators.end(); ++it)
         (*it)->computeIndicator();
 
       _fe_problem.swapBackMaterialsFace(_tid);
-      //_fe_problem.swapBackMaterialsNeighbor(_tid);
+      _fe_problem.swapBackMaterialsNeighbor(_tid);
     }
   }
 }

--- a/framework/src/base/ComputeMaterialsObjectThread.C
+++ b/framework/src/base/ComputeMaterialsObjectThread.C
@@ -70,6 +70,7 @@ ComputeMaterialsObjectThread::~ComputeMaterialsObjectThread()
 void
 ComputeMaterialsObjectThread::subdomainChanged()
 {
+  // _fe_problem.getIndicatorWarehouse(_tid).updateActiveIndicators(_subdomain);
   _need_internal_side_material = _fe_problem.needMaterialOnSide(_subdomain, _tid);
   _fe_problem.subdomainSetup(_subdomain, _tid);
 }
@@ -93,7 +94,7 @@ ComputeMaterialsObjectThread::onElement(const Elem *elem)
 void
 ComputeMaterialsObjectThread::onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id)
 {
-  if (_fe_problem.needMaterialOnSide(bnd_id, _tid))
+  //if (_fe_problem.needMaterialOnSide(bnd_id, _tid))
   {
     _fe_problem.setCurrentBoundaryID(bnd_id);
     _assembly[_tid]->reinit(elem, side);
@@ -116,7 +117,16 @@ ComputeMaterialsObjectThread::onBoundary(const Elem *elem, unsigned int side, Bo
 void
 ComputeMaterialsObjectThread::onInternalSide(const Elem *elem, unsigned int side)
 {
-  if (_need_internal_side_material)
+  std::cout << "ComputeMaterialsObjectThread::onInternalSide" << std::endl;
+
+  _fe_problem.getIndicatorWarehouse(_tid).updateActiveIndicators(_subdomain);
+
+  std::cout << "_need_internal_side_material = " << _need_internal_side_material << std::endl;
+  std::cout << "_indicators[tid].active().size() = " << _fe_problem.getIndicatorWarehouse(_tid).active().size() << std::endl;
+  std::cout << "_indicators[tid].all().size() = " << _fe_problem.getIndicatorWarehouse(_tid).all().size() << std::endl;
+
+
+  //if (_need_internal_side_material)
   {
     _assembly[_tid]->reinit(elem, side);
     unsigned int face_n_points = _assembly[_tid]->qRuleFace()->n_points();

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1673,6 +1673,8 @@ FEProblem::getNeighborMaterials(SubdomainID block_id, THREAD_ID tid)
 void
 FEProblem::prepareMaterials(SubdomainID blk_id, THREAD_ID tid)
 {
+
+
   if (_materials[tid].hasMaterials(blk_id))
   {
     std::set<MooseVariable *> needed_moose_vars;

--- a/framework/src/base/ProjectMaterialProperties.C
+++ b/framework/src/base/ProjectMaterialProperties.C
@@ -105,7 +105,7 @@ ProjectMaterialProperties::onElement(const Elem *elem)
 void
 ProjectMaterialProperties::onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id)
 {
-  if (_fe_problem.needMaterialOnSide(bnd_id, _tid))
+  //if (_fe_problem.needMaterialOnSide(bnd_id, _tid))
   {
     // Set the active boundary id so that BoundaryRestrictable::_boundary_id is correct
     _fe_problem.setCurrentBoundaryID(bnd_id);
@@ -145,7 +145,7 @@ ProjectMaterialProperties::onBoundary(const Elem *elem, unsigned int side, Bound
 void
 ProjectMaterialProperties::onInternalSide(const Elem *elem, unsigned int /*side*/)
 {
-  if (_need_internal_side_material && _refine) // If we're refining then we need to also project "internal" child sides.
+  // if (_need_internal_side_material && _refine) // If we're refining then we need to also project "internal" child sides.
   {
     for (unsigned int child=0; child<elem->n_children(); child++)
     {
@@ -156,6 +156,8 @@ ProjectMaterialProperties::onInternalSide(const Elem *elem, unsigned int /*side*
         if (!elem->is_child_on_side(child, side)) // Otherwise we already projected it
         {
           const std::vector<std::vector<QpMap> > & refinement_map  = _mesh.getRefinementMap(*elem, -1, child, side);
+
+//          std::cout << "  on side internal" << std::endl;
 
           _bnd_material_props.prolongStatefulProps(refinement_map,
                                                    *_assembly[_tid]->qRule(),

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -31,6 +31,9 @@ void shallowCopyData(const std::vector<unsigned int> & stateful_prop_ids, Materi
 {
   for (unsigned int i=0; i<stateful_prop_ids.size(); ++i)
   {
+//    if (data_from.size() < stateful_prop_ids[i])
+//      std::cout << "i = " << i << std::endl;
+
     PropertyValue * prop = data[stateful_prop_ids[i]];              // do the look-up just once (OPT)
     PropertyValue * prop_from = data_from[i];                       // do the look-up just once (OPT)
     if (prop != NULL && prop_from != NULL)
@@ -324,6 +327,10 @@ void
 MaterialPropertyStorage::swap(MaterialData & material_data, const Elem & elem, unsigned int side)
 {
   Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+
+
+  //std::cout << _stateful_prop_id_to_prop_id << std::endl;
+  //std::cout << "_prop_name = " << _prop_names[_stateful_prop_id_to_prop_id] << std::endl;
 
   shallowCopyData(_stateful_prop_id_to_prop_id, material_data.props(), props()[&elem][side]);
   shallowCopyData(_stateful_prop_id_to_prop_id, material_data.propsOld(), propsOld()[&elem][side]);

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -29,10 +29,19 @@ std::map<std::string, unsigned int> MaterialPropertyStorage::_prop_ids;
  */
 void shallowCopyData(const std::vector<unsigned int> & stateful_prop_ids, MaterialProperties & data, MaterialProperties & data_from)
 {
+
+  std::cout << "  data.size() = " << data.size() << std::endl;
+  std::cout << "  data_from.size() = " << data_from.size() << std::endl;
+
+  if (data_from.size() == 0)
+    print_trace();
+
   for (unsigned int i=0; i<stateful_prop_ids.size(); ++i)
   {
-//    if (data_from.size() < stateful_prop_ids[i])
-//      std::cout << "i = " << i << std::endl;
+
+    std::cout << "  i = " << i << std::endl;
+
+
 
     PropertyValue * prop = data[stateful_prop_ids[i]];              // do the look-up just once (OPT)
     PropertyValue * prop_from = data_from[i];                       // do the look-up just once (OPT)
@@ -43,6 +52,7 @@ void shallowCopyData(const std::vector<unsigned int> & stateful_prop_ids, Materi
 
 void shallowCopyDataBack(const std::vector<unsigned int> & stateful_prop_ids, MaterialProperties & data, MaterialProperties & data_from)
 {
+
   for (unsigned int i=0; i<stateful_prop_ids.size(); ++i)
   {
     PropertyValue * prop = data[i];                                 // do the look-up just once (OPT)
@@ -329,8 +339,9 @@ MaterialPropertyStorage::swap(MaterialData & material_data, const Elem & elem, u
   Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
 
 
-  //std::cout << _stateful_prop_id_to_prop_id << std::endl;
-  //std::cout << "_prop_name = " << _prop_names[_stateful_prop_id_to_prop_id] << std::endl;
+  std::cout << "Elem: " << elem.id() << std::endl;
+  //std::cout << "  _stateful_prop_id_to_prop_id = " << _stateful_prop_id_to_prop_id << std::endl;
+  // std::cout << "  _prop_name = " << _prop_names[_stateful_prop_id_to_prop_id] << std::endl;
 
   shallowCopyData(_stateful_prop_id_to_prop_id, material_data.props(), props()[&elem][side]);
   shallowCopyData(_stateful_prop_id_to_prop_id, material_data.propsOld(), propsOld()[&elem][side]);

--- a/modules/tensor_mechanics/include/TestStatefulTensor.h
+++ b/modules/tensor_mechanics/include/TestStatefulTensor.h
@@ -1,0 +1,45 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "Material.h"
+
+#ifndef TESTSTATEFULTENSOR_H
+#define TESTSTATEFULTENSOR_H
+
+//Forward Declarations
+class TestStatefulTensor;
+class RankFourTensor;
+
+template<>
+InputParameters validParams<TestStatefulTensor>();
+
+/**
+ * Stateful material class that defines a few properties.
+ */
+class TestStatefulTensor : public Material
+{
+public:
+  TestStatefulTensor(const std::string & name,
+                  InputParameters parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+  virtual void computeQpProperties();
+
+private:
+  MaterialProperty<RankFourTensor> & _tensor;
+  MaterialProperty<RankFourTensor> & _tensor_old;
+};
+
+#endif // TESTSTATEFULTENSOR_H

--- a/modules/tensor_mechanics/src/TestStatefulTensor.C
+++ b/modules/tensor_mechanics/src/TestStatefulTensor.C
@@ -1,0 +1,40 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "TestStatefulTensor.h"
+#include "RankFourTensor.h"
+
+template<>
+InputParameters validParams<TestStatefulTensor>()
+{
+  InputParameters params = validParams<Material>();
+  return params;
+}
+
+TestStatefulTensor::TestStatefulTensor(const std::string & name, InputParameters parameters) : Material(name, parameters),
+   _tensor(declarePropertyDerivative<RankFourTensor>("tensor")),
+   _tensor_old(declarePropertyOld<RankFourTensor>("tensor"))
+{}
+
+void
+TestStatefulTensor::initQpStatefulProperties()
+{
+  _tensor[_qp].fillFromInputVector(std::vector<Real>(81,1), RankFourTensor::general);
+}
+
+void
+TestStatefulTensor::computeQpProperties()
+{
+  _tensor[_qp] = _tensor_old[_qp] * 2;
+}

--- a/modules/tensor_mechanics/src/TestStatefulTensor.C
+++ b/modules/tensor_mechanics/src/TestStatefulTensor.C
@@ -23,8 +23,8 @@ InputParameters validParams<TestStatefulTensor>()
 }
 
 TestStatefulTensor::TestStatefulTensor(const std::string & name, InputParameters parameters) : Material(name, parameters),
-   _tensor(declarePropertyDerivative<RankFourTensor>("tensor")),
-   _tensor_old(declarePropertyOld<RankFourTensor>("tensor"))
+   _tensor(declareProperty<RankFourTensor>("tensor")),
+   _tensor_old(declareProperty<RankFourTensor>("tensor"))
 {}
 
 void

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -36,6 +36,8 @@
 #include "TensorMechanicsHardeningCubic.h"
 #include "ElementPropertyReadFile.h"
 
+#include "TestStatefulTensor.h"
+
 #include "RankTwoAux.h"
 #include "RealTensorValueAux.h"
 #include "RankFourAux.h"
@@ -94,6 +96,7 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerMaterial(ElementPropertyReadFileTest);
   registerMaterial(TwoPhaseStressMaterial);
   registerMaterial(SimpleEigenStrainMaterial);
+  registerMaterial(TestStatefulTensor);
 
   registerUserObject(TensorMechanicsPlasticSimpleTester);
   registerUserObject(TensorMechanicsPlasticTensile);

--- a/modules/tensor_mechanics/tests/tensor_material/stateful_tensor.i
+++ b/modules/tensor_mechanics/tests/tensor_material/stateful_tensor.i
@@ -1,0 +1,61 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Materials]
+  [./stateful_tensor]
+    type = TestStatefulTensor
+    block = 0
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Transient
+  num_steps = 20
+  dt = 0.1
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  output_initial = true
+  exodus = true
+  print_linear_residuals = true
+  print_perf_log = true
+[]

--- a/modules/tensor_mechanics/tests/tensor_material/stateful_tensor.i
+++ b/modules/tensor_mechanics/tests/tensor_material/stateful_tensor.i
@@ -59,3 +59,25 @@
   print_linear_residuals = true
   print_perf_log = true
 []
+
+[Adaptivity]
+
+  marker = errorfrac
+  max_h_level = 4
+
+  [./Indicators]
+    [./error]
+      type = GradientJumpIndicator
+      variable = 'u v void'
+    [../]
+  [../]
+
+  [./Markers]
+    [./errorfrac]
+      type = ErrorFractionMarker
+      refine = 0.6
+      coarsen = 0.1
+      indicator = error
+    [../]
+  [../]
+[]

--- a/test/tests/materials/stateful_prop/stateful_adapt_indicator.i
+++ b/test/tests/materials/stateful_prop/stateful_adapt_indicator.i
@@ -1,0 +1,85 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 1
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Materials]
+  [./stateful_prop]
+    type = StatefulTest
+    block = 0
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = MatDiffusion
+    variable = u
+    prop_name = thermal_conductivity
+    prop_state = old # Use the "Old" value to compute conductivity
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Transient
+  num_steps = 3
+  dt = 0.1
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  output_initial = true
+  exodus = true
+  print_linear_residuals = true
+  print_perf_log = true
+[]
+
+[Adaptivity]
+
+  marker = errorfrac
+  max_h_level = 1
+
+  [./Indicators]
+    [./error]
+      type = GradientJumpIndicator
+      variable = 'u'
+    [../]
+  [../]
+
+  [./Markers]
+    [./errorfrac]
+      type = ErrorFractionMarker
+      refine = 0.6
+      coarsen = 0.1
+      indicator = error
+    [../]xs
+  [../]
+[]

--- a/test/tests/materials/stateful_prop/stateful_adapt_indicator.i
+++ b/test/tests/materials/stateful_prop/stateful_adapt_indicator.i
@@ -63,10 +63,8 @@
 []
 
 [Adaptivity]
-
   marker = errorfrac
-  max_h_level = 1
-
+ max_h_level = 1
   [./Indicators]
     [./error]
       type = GradientJumpIndicator
@@ -77,9 +75,9 @@
   [./Markers]
     [./errorfrac]
       type = ErrorFractionMarker
-      refine = 0.6
-      coarsen = 0.1
+      refine = 1
+      coarsen = 0
       indicator = error
-    [../]xs
+    [../]
   [../]
 []

--- a/test/tests/materials/stateful_prop/tests
+++ b/test/tests/materials/stateful_prop/tests
@@ -73,4 +73,10 @@
     input = 'spatial_adaptivity_test.i'
     exodiff = 'spatial_adaptivity_test_out.e-s003'
   [../]
+
+  [./statful_indicator]
+    type = 'Exodiff'
+    input = 'statful_adapt_indicator.i'
+    exodiff = 'statful_adapt_indicator_out.e-s003'
+  [../]
 []


### PR DESCRIPTION
I am just putting this up for @andrsd to take a look at.

The following shows the MaterialPropertyStorage data just before the seg. fault. I am tracking down.

```
&elem = 0x10b10f060 (3)
4 0x10b10f110
8 0x10b10f7c0
6 0x10b10f270
2 0x10b10efb0
3 0x10b10f060
9 0x10b10f870
0 0x10b04fa80
1 0x10b057b90
7 0x10b10f710
5 0x10b10f1c0
Current:
+-------------------+
| Elem. Side  Size  |
+-------------------+
| 4     0     1     |
| 4     1     1     |
| 4     2     1     |
| 4     3     1     |
+-------------------+
| 8     0     1     |
| 8     1     1     |
| 8     2     1     |  << Why only 3 sides?
+-------------------+
| 6     0     1     |
| 6     1     1     |
| 6     2     1     | << Why only 3 again?
+-------------------+
| 2     0     1     |
| 2     1     1     |
| 2     2     1     |
| 2     3     1     |
+-------------------+
| 3     0     1     |
| 3     1     0     |  << This little guy is the culprit...
| 3     2     1     |
| 3     3     1     |
+-------------------+
| 9     0     1     |
| 9     1     1     |
| 9     2     1     |
| 9     3     1     |
+-------------------+
| 0     0     1     |
| 0     1     1     |
| 0     2     1     |
| 0     3     1     |
+-------------------+
| 1     0     1     |
| 1     1     1     |
| 1     2     1     |
| 1     3     1     |
+-------------------+
| 7     0     1     |
| 7     1     1     |
| 7     2     1     |
| 7     3     1     |
+-------------------+
| 5     0     1     |
| 5     2     1     |
| 5     3     1     | << Again only 3
+-------------------+


Stack frames: 12
0: 0   libmesh_oprof.0.dylib               0x0000000100ff092e libMesh::print_trace(std::__1::basic_ostream<char, std::__1::char_traits<char> >&) + 1070
1: 1   libmoose-oprof.0.dylib              0x00000001006b328b MaterialPropertyStorage::swap(MaterialData&, libMesh::Elem const&, unsigned int) + 315
2: 2   libmoose-oprof.0.dylib              0x00000001006ac1f5 MaterialData::swap(libMesh::Elem const&, unsigned int) + 37
3: 3   libmoose-oprof.0.dylib              0x00000001004aff82 FEProblem::reinitMaterialsFace(unsigned short, unsigned int, bool) + 210
4: 4   libmoose-oprof.0.dylib              0x0000000100484d75 ComputeIndicatorThread::onInternalSide(libMesh::Elem const*, unsigned int) + 725
5: 5   libmoose-oprof.0.dylib              0x0000000100455313 ThreadedElementLoopBase<libMesh::StoredRange<libMesh::MeshBase::const_element_iterator, libMesh::Elem const*> >::operator()(libMesh::StoredRange<libMesh::MeshBase::const_element_iterator, libMesh::Elem const*> const&, bool) + 323
6: 6   libmoose-oprof.0.dylib              0x00000001004b5f5e FEProblem::computeIndicatorsAndMarkers() + 862
7: 7   libmoose-oprof.0.dylib              0x000000010062a622 Transient::endStep(double) + 114
8: 8   libmoose-oprof.0.dylib              0x0000000100629f21 Transient::execute() + 113
9: 9   moose_test-oprof                    0x0000000100001563 main + 115
10: 10  libdyld.dylib                       0x00007fff8a13d5c9 start + 1
11: 11  ???                                 0x0000000000000003 0x0 + 3
Process 66675 stopped
* thread #1: tid = 0x8c4782, 0x00000001006b3344 libmoose-oprof.0.dylib`MaterialPropertyStorage::swap(MaterialData&, libMesh::Elem const&, unsigned int) + 46 at MaterialPropertyStorage.C:44, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00000001006b3344 libmoose-oprof.0.dylib`MaterialPropertyStorage::swap(MaterialData&, libMesh::Elem const&, unsigned int) + 46 at MaterialPropertyStorage.C:44
   41       {
   42   
   43         PropertyValue * prop = data[stateful_prop_ids[i]];              // do the look-up just once (OPT)
-> 44         PropertyValue * prop_from = data_from[i];                       // do the look-up just once (OPT)
   45         if (prop != NULL && prop_from != NULL)
   46           prop->swap(prop_from);
   47       }
```
