### PR TITLE
Resize jacobian sub-blocks while assembling node-to-face constraints

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1468,6 +1468,7 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
             _fe_problem.reinitNodeFace(&slave_node, slave_boundary, 0);
 
             _fe_problem.prepareAssembly(0);
+            _fe_problem.reinitOffDiagScalars(0);
 
             std::vector<Point> points;
             points.push_back(info._closest_point);


### PR DESCRIPTION
Closes #4601

This will fix the non-convergence in RELAP-7
