### PR TITLE
Enable derived classes to call a single function to get the gap distance...

### DIFF
--- a/modules/heat_conduction/include/GapConductance.h
+++ b/modules/heat_conduction/include/GapConductance.h
@@ -15,7 +15,9 @@ public:
 
   virtual ~GapConductance(){}
 
-  static Real gapLength(Real distance, Real min_gap, Real max_gap);
+  static Real gapLength(const Moose::CoordinateSystemType & system, Real radius, Real r1, Real r2, Real min_gap, Real max_gap);
+
+  static Real gapRect(Real distance, Real min_gap, Real max_gap);
 
   static Real gapCyl( Real radius, Real r1, Real r2, Real min_denom, Real max_denom);
 
@@ -67,8 +69,6 @@ protected:
 
   Real _min_gap;
   Real _max_gap;
-  Real _min_denom;
-  Real _max_denom;
 
   MooseVariable * _temp_var;
   PenetrationLocator * _penetration_locator;

--- a/modules/heat_conduction/include/GapHeatTransfer.h
+++ b/modules/heat_conduction/include/GapHeatTransfer.h
@@ -32,6 +32,8 @@ protected:
 
   virtual void computeGapValues();
 
+  const Moose::CoordinateSystemType & _coord_sys;
+
   bool _quadrature;
 
   NumericVector<Number> * _slave_flux;
@@ -44,6 +46,9 @@ protected:
 
   Real _gap_temp;
   Real _gap_distance;
+  Real _radius;
+  Real _r1;
+  Real _r2;
 
   //This is a factor that is used to gradually taper down the conductance if the
   //contact point is off the face and tangential_tolerance is nonzero.


### PR DESCRIPTION
... and hide the coordinate differences.  Ref #4562.

This will break BISON, but I have  BISON commit ready to fix things up.
