### PR TITLE
Update libMesh, re-enable parallel PointLocator tests

### DIFF
--- a/test/tests/vectorpostprocessors/line_value_sampler/tests
+++ b/test/tests/vectorpostprocessors/line_value_sampler/tests
@@ -3,7 +3,6 @@
     type = 'CSVDiff'
     input = 'line_value_sampler.i'
     csvdiff = 'line_value_sampler_out_line_sample_0001.csv'
-    max_parallel = 1 # "libmesh #432"
   [../]
   [./parallel]
     # This ensures that PointSamplerBase is properly handling unique point finding
@@ -12,7 +11,6 @@
     csvdiff = 'line_value_sampler_out_line_sample_0001.csv'
     min_parallel = 3
     prereq = test
-    deleted = "libmesh #432"
   [../]
   [./delimiter]
     type = 'CheckFiles'


### PR DESCRIPTION
@permcody suggested that Moose is currently overdue for a libMesh submodule update, and getting more test coverage on the recent PointLocatorTree fixes in https://github.com/libMesh/libmesh/pull/451 sounds like a good excuse for doing it now.

The downside to this commit is that the parallel line_value_sampler test failures were _intermittent_ - it's entirely possible that MooseBuild will be happy here but we'll see false positives when it fails in the future.
