### PR TITLE
Integration branch (Uniform refine earlier)

### DIFF
--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -119,9 +119,18 @@ public:
   void initialAdaptMesh();
 
   /**
-   * Does 'level' levels of uniform refinements
+   * Performs uniform refinement of the passed Mesh object. The
+   * number of levels of refinement performed is stored in the
+   * MooseMesh object. No solution projection is performed in this
+   * version.
    */
-  void uniformRefine(unsigned int level);
+  static void uniformRefine(MooseMesh *mesh);
+
+  /**
+   * Performs uniform refinement on the meshes in the current
+   * object. Projections are performed of the solution vectors.
+   */
+  void uniformRefineWithProjection();
 
   /**
    * Is adaptivity on?

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -324,13 +324,15 @@ public:
    */
   void update();
 
-#ifdef LIBMESH_ENABLE_AMR
   /**
    * Returns the level of uniform refinement requested (zero if AMR is disabled).
    */
-  unsigned int & uniformRefineLevel();
-  const unsigned int & uniformRefineLevel() const;
-#endif //LIBMESH_ENABLE_AMR
+  unsigned int uniformRefineLevel() const;
+
+  /**
+   * Set uniform refinement level
+   */
+  void setUniformRefineLevel(unsigned int);
 
   /**
    * This will add the boundary ids to be ghosted to this processor

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -302,9 +302,6 @@ ActionWarehouse::executeAllActions()
   for (std::vector<std::string>::iterator it = _ordered_names.begin(); it != _ordered_names.end(); ++it)
   {
     std::string task = *it;
-
-    // Set the current task name
-    _current_task = task;
     executeActionsWithAction(task);
   }
 }
@@ -312,6 +309,9 @@ ActionWarehouse::executeAllActions()
 void
 ActionWarehouse::executeActionsWithAction(const std::string & task)
 {
+  // Set the current task name
+  _current_task = task;
+
   for (ActionIterator act_iter = actionBlocksWithActionBegin(task);
        act_iter != actionBlocksWithActionEnd(task);
        ++act_iter)

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -82,7 +82,7 @@ SetupMeshAction::setupMesh(MooseMesh *mesh)
   // Did they specify extra refinement levels on the command-line?
   level += _app.getParam<unsigned int>("refinements");
 
-  mesh->uniformRefineLevel() = level;
+  mesh->setUniformRefineLevel(level);
 #endif //LIBMESH_ENABLE_AMR
 
   // Add entity names to the mesh

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -42,9 +42,12 @@ InputParameters validParams<SetupMeshAction>()
 
   params.addParam<unsigned int>("uniform_refine", 0, "Specify the level of uniform refinement applied to the initial mesh");
 
+  params.addParam<bool>("skip_partitioning", false, "If true the mesh won't be partitioned. This may cause large load imbalanced but is currently required if you "
+                                                    "have a simulation containing uniform refinement, adaptivity and stateful material properties");
+
   // groups
   params.addParamNamesToGroup("displacements ghosted_boundaries ghosted_boundaries_inflation patch_size", "Advanced");
-  params.addParamNamesToGroup("second_order construct_side_list_from_node_list", "Advanced");
+  params.addParamNamesToGroup("second_order construct_side_list_from_node_list skip_partitioning", "Advanced");
   params.addParamNamesToGroup("block_id block_name boundary_id boundary_name", "Add Names");
 
   return params;
@@ -124,6 +127,10 @@ SetupMeshAction::setupMesh(MooseMesh *mesh)
 
   if (getParam<bool>("construct_side_list_from_node_list"))
     mesh->getMesh().get_boundary_info().build_side_list_from_node_list();
+
+  // Here we can override the partitioning for special cases
+  if (getParam<bool>("skip_partitioning"))
+    mesh->getMesh().skip_partitioning(getParam<bool>("skip_partitioning"));
 }
 
 void

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -208,10 +208,22 @@ Adaptivity::initialAdaptMesh()
 }
 
 void
-Adaptivity::uniformRefine(unsigned int level)
+Adaptivity::uniformRefine(MooseMesh *mesh)
+{
+  mooseAssert(mesh, "Mesh pointer must not be NULL");
+
+  // NOTE: we are using a separate object here, since adaptivity may not be on, but we need to be able to do refinements
+  MeshRefinement mesh_refinement(*mesh);
+  unsigned int level = mesh->uniformRefineLevel();
+  mesh_refinement.uniformly_refine(level);
+}
+
+void
+Adaptivity::uniformRefineWithProjection()
 {
   // NOTE: we are using a separate object here, since adaptivity may not be on, but we need to be able to do refinements
   MeshRefinement mesh_refinement(_mesh);
+  unsigned int level = _mesh.uniformRefineLevel();
   MeshRefinement displaced_mesh_refinement(_displaced_problem ? _displaced_problem->mesh() : _mesh);
 
   // we have to go step by step so EquationSystems::reinit() won't freak out

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -357,11 +357,15 @@ void FEProblem::initialSetup()
 
   if (!_app.isRecovering())
   {
-    // uniform refine
-    if (_mesh.uniformRefineLevel() > 0)
+    /**
+     * If we are not recovering but we are doing restart (_app_setFileRestart() == true) with
+     * additional uniform refinements. We have to delay the refinement until this point
+     * in time so that the equation systems are initialized and projections can be performed.
+     */
+    if (_mesh.uniformRefineLevel() > 0 && _app.setFileRestart())
     {
       Moose::setup_perf_log.push("Uniformly Refine Mesh","Setup");
-      adaptivity().uniformRefine(_mesh.uniformRefineLevel());
+      adaptivity().uniformRefineWithProjection();
       Moose::setup_perf_log.pop("Uniformly Refine Mesh","Setup");
     }
   }

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3656,6 +3656,10 @@ FEProblem::checkProblemIntegrity()
 
       if (n_processors() > 1)
       {
+        if (_mesh.uniformRefineLevel() > 0 && _mesh.getMesh().skip_partitioning() == false)
+          mooseError("This simulation is using uniform refinement on the mesh, with stateful properties and adaptivity. "
+                     "You must skip partitioning to run this case:\nMesh/skip_partitioning=true");
+
         _console << "\nWarning! Mesh re-partitioning is disabled while using stateful material properties!  This can lead to large load imbalances and degraded performance!!\n\n";
         _mesh.getMesh().skip_partitioning(true);
         if (_displaced_problem)

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -763,6 +763,7 @@ addActionTypes(Syntax & syntax)
   registerTask("add_aux_variable", false);
   registerTask("add_variable", false);
 
+  registerTask("uniform_refine_mesh", false);
   registerTask("prepare_mesh", false);
   registerTask("setup_mesh_complete", false);  // calls prepare
 
@@ -821,6 +822,7 @@ addActionTypes(Syntax & syntax)
 "(prepare_mesh)"
 "(add_mesh_modifier)"
 "(add_mortar_interface)"
+"(uniform_refine_mesh)"
 "(setup_mesh_complete)"
 "(determine_system_type)"
 "(create_problem)"
@@ -899,6 +901,7 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
   registerAction(SetupMeshCompleteAction, "prepare_mesh");
   registerAction(AddMeshModifierAction, "add_mesh_modifier");
   registerAction(AddMortarInterfaceAction, "add_mortar_interface");
+  registerAction(SetupMeshCompleteAction, "uniform_refine_mesh");
   registerAction(SetupMeshCompleteAction, "setup_mesh_complete");
 
   registerAction(AddFunctionAction, "add_function");

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -354,12 +354,10 @@ MooseApp::meshOnly(std::string mesh_file_name)
   _action_warehouse.executeActionsWithAction("setup_mesh");
   _action_warehouse.executeActionsWithAction("prepare_mesh");
   _action_warehouse.executeActionsWithAction("add_mesh_modifier");
+  _action_warehouse.executeActionsWithAction("uniform_refine_mesh");
   _action_warehouse.executeActionsWithAction("setup_mesh_complete");
 
-  // uniform refinement
   MooseSharedPointer<MooseMesh> & mesh = _action_warehouse.mesh();
-  MeshRefinement mesh_refinement(mesh->getMesh());
-  mesh_refinement.uniformly_refine(mesh->uniformRefineLevel());
 
   // If no argument specified or if the argument following --mesh-only starts
   // with a dash, try to build an output filename based on the input mesh filename.

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -29,11 +29,6 @@ InputParameters validParams<FileMesh>()
   InputParameters params = validParams<MooseMesh>();
 
   params.addRequiredParam<MeshFileName>("file", "The name of the mesh file to read");
-  params.addParam<bool>("skip_partitioning", false, "If true the mesh won't be partitioned.  Probably not a good idea to use it with a serial mesh!");
-
-  // groups
-  params.addParamNamesToGroup("skip_partitioning", "Partitioning");
-
   return params;
 }
 
@@ -66,7 +61,6 @@ FileMesh::clone() const
 void
 FileMesh::buildMesh()
 {
-//  mooseAssert(_mesh == NULL, "Mesh already exists, and you are trying to read another");
   std::string _file_name = getParam<MeshFileName>("file");
 
   Moose::setup_perf_log.push("Read Mesh","Setup");
@@ -98,8 +92,6 @@ FileMesh::buildMesh()
     else
       getMesh().read(_file_name);
   }
-
-  getMesh().skip_partitioning(getParam<bool>("skip_partitioning"));
 
   Moose::setup_perf_log.pop("Read Mesh","Setup");
 }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1878,17 +1878,17 @@ MooseMesh::setBoundaryToNormalMap(std::map<BoundaryID, RealVectorValue> * bounda
   _boundary_to_normal_map.reset(boundary_map);
 }
 
-#ifdef LIBMESH_ENABLE_AMR
-unsigned int & MooseMesh::uniformRefineLevel()
+unsigned int
+MooseMesh::uniformRefineLevel() const
 {
   return _uniform_refine_level;
 }
 
-const unsigned int & MooseMesh::uniformRefineLevel() const
+void
+MooseMesh::setUniformRefineLevel(unsigned int level)
 {
-  return _uniform_refine_level;
+  _uniform_refine_level = level;
 }
-#endif // LIBMESH_ENABLE_AMR
 
 void
 MooseMesh::addGhostedBoundary(BoundaryID boundary_id)

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -25,7 +25,7 @@ InputParameters validParams<OversampleOutput>()
 
   // Get the parameters from the parent object
   InputParameters params = validParams<FileOutput>();
-  params.addParam<unsigned int>("refinements", 0, "Number of uniform refinements for oversampling");
+  params.addParam<unsigned int>("refinements", 0, "Number of uniform refinements for oversampling (refinement levels beyond any uniform refinements)");
   params.addParam<Point>("position", "Set a positional offset, this vector will get added to the nodal coordinates to move the domain.");
   params.addParam<MeshFileName>("file", "The name of the mesh file to read, for oversampling");
 

--- a/test/tests/materials/stateful_prop/spatial_adaptivity_test.i
+++ b/test/tests/materials/stateful_prop/spatial_adaptivity_test.i
@@ -4,6 +4,8 @@
   nx = 2
   ny = 2
   uniform_refine = 3
+  # This option is necessary if you have uniform refinement + stateful material properties + adaptivity
+  skip_partitioning = true
 []
 
 [Variables]

--- a/test/tests/materials/stateful_prop/stateful_prop_adaptivity_test.i
+++ b/test/tests/materials/stateful_prop/stateful_prop_adaptivity_test.i
@@ -5,6 +5,8 @@
   ny = 2
   nz = 2
   uniform_refine = 2
+  # This option is necessary if you have uniform refinement + stateful material properties + adaptivity
+  skip_partitioning = true
 []
 
 [Variables]

--- a/test/tests/outputs/oversample/oversample_file.i
+++ b/test/tests/outputs/oversample/oversample_file.i
@@ -42,7 +42,7 @@
 [Outputs]
   [./exodus]
     type = Exodus
-    refinements = 2
+    refinements = 1
     file_base = exodus_oversample_custom_name
   [../]
 []


### PR DESCRIPTION
This PR moves the uniform refinement steps up into the mesh setup stage. The original code path remains for the case where restart and uniform refinements are both needed. 

Important note: The definition of what uniform_refinement means has changed for oversampled meshes. Previously that number assumed how many refinements you wanted from the original mesh, now we have defined it to mean the number of refinements to apply after the mesh has been setup which included the initial uniform refinement steps.

Includes a small bug fix for setting _current_task when executing Actions individually. 
