### PR TITLE
Fixes valgrind error

### DIFF
--- a/framework/include/utils/RandomInterface.h
+++ b/framework/include/utils/RandomInterface.h
@@ -75,7 +75,7 @@ private:
   MooseRandom *_generator;
 
   FEProblem & _ri_problem;
-  const std::string & _ri_name;
+  const std::string _ri_name;
 
   unsigned int _master_seed;
   bool _is_nodal;


### PR DESCRIPTION
We cannot rely on InputParameters reference remaining valid, not yet at least.

(refs #4606)
