### PR TITLE
Added short-cut flags to advanced execution times

### DIFF
--- a/framework/include/outputs/AdvancedOutput.h
+++ b/framework/include/outputs/AdvancedOutput.h
@@ -77,7 +77,7 @@ public:
   OutputMapWrapper(){};
 
   /**
-   * An map assessor that errors if the key is not found
+   * A map accessor that errors if the key is not found
    */
   T & operator[](const std::string & name)
   {
@@ -95,6 +95,9 @@ public:
   typename std::map<std::string, T>::iterator begin() { return _map.begin(); }
   typename std::map<std::string, T>::iterator end() { return _map.end(); }
   typename std::map<std::string, T>::iterator find(const std::string & name) { return _map.find(name); }
+  typename std::map<std::string, T>::const_iterator begin() const { return _map.begin(); }
+  typename std::map<std::string, T>::const_iterator end() const { return _map.end(); } const
+  typename std::map<std::string, T>::const_iterator find(const std::string & name) const { return _map.find(name); }
   ///@}
 
   /**
@@ -135,7 +138,7 @@ public:
 
   /**
    * Constructor
-   * @param output_on The general "output_on" settings for the object
+   * @param output_on The general "output_on" settings for the object.
    */
   OutputOnWarehouse(const MultiMooseEnum & output_on, const InputParameters & params);
 };
@@ -306,6 +309,10 @@ public:
    */
   static InputParameters enableOutputTypes(const std::string & names = std::string());
 
+  /**
+   * Get the current advanced 'output_on' selections for display
+   */
+  const OutputOnWarehouse & advancedOutputOn() const;
 
 protected:
 
@@ -371,6 +378,7 @@ protected:
    * By default this method does nothing and is not called by output()
    */
   virtual void outputSystemInformation();
+
 
 private:
 

--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -88,7 +88,7 @@ public:
   static void insertNewline(std::stringstream &oss, std::streampos &begin, std::streampos &curr);
 
   /// Width used for printing simulation information
-  static const unsigned int _field_width = 25;
+  static const unsigned int _field_width = 27;
 
   /// Line length for printing simulation information
   static const unsigned int _line_length = 100;
@@ -213,6 +213,9 @@ protected:
 
   /// Number of significant digits
   unsigned int _precision;
+
+  /// Toggle for displaying output_on stuff in system information
+  bool _show_output_on_info;
 
 private:
 

--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -99,9 +99,9 @@ public:
   const unsigned int & interval() const;
 
   /**
-   * Get the current 'output_on' selections
+   * Get the current 'output_on' selections for display
    */
-  std::string outputOn() const;
+  const MultiMooseEnum & outputOn() const;
 
   /**
    * Return the support output execution times
@@ -144,6 +144,12 @@ protected:
    * This populates the various data structures needed to control the output
    */
   virtual void init();
+
+  /**
+   * A method for modifying "output_on" MultiMooseEnums with the short-cut flag options
+   * @param input A reference to the enum to modifiy
+   */
+  void applyOutputOnShortCutFlags(MultiMooseEnum & input);
 
   /// Pointer the the FEProblem object for output object (use this)
   FEProblem * _problem_ptr;

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -50,6 +50,7 @@ public:
 
   virtual ~MultiMooseEnum();
 
+  ///@{
   /**
    * Comparison operators for comparing with character constants, MultiMooseEnums
    * or integer values
@@ -57,6 +58,8 @@ public:
    * @return bool - the truth value for the comparison
    */
   bool operator==(const MultiMooseEnum & value) const;
+  bool operator!=(const MultiMooseEnum & value) const;
+  ///@}
 
   ///@{
   /**

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -39,6 +39,8 @@ InputParameters validParams<MooseApp>()
   params.addCommandLineParam<std::string>("mesh_only", "--mesh-only", "Setup and Output the input mesh only.");
 
   params.addCommandLineParam<bool>("show_input", "--show-input", false, "Shows the parsed input file before running the simulation.");
+  params.addCommandLineParam<bool>("show_outputs", "--show-outputs", false, "Shows the output execution time information.");
+
   params.addCommandLineParam<bool>("no_color", "--no-color", false, "Disable coloring of all Console outputs.");
 
   params.addCommandLineParam<bool>("help", "-h --help", false, "Displays CLI usage statement.");

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -526,11 +526,17 @@ AdvancedOutput<OutputBase>::initExecutionTypes(const std::string & name, MultiMo
 
   // The parameters exists and has been set by the user
   if (OutputBase::_pars.template have_parameter<MultiMooseEnum>(param_name) && OutputBase::isParamValid(param_name))
+  {
     input = OutputBase::template getParam<MultiMooseEnum>(param_name);
 
-  // If the parameter does not exists; set it to a state where no valid entires exists so nothing gets executed
+    if (name != "system_information" && name != "input")
+      OutputBase::applyOutputOnShortCutFlags(input);
+  }
+
+  // If the parameter does not exists; set it to a state where no valid entries exists so nothing gets executed
   else if (!OutputBase::_pars. template have_parameter<MultiMooseEnum>(param_name))
     input = AdvancedOutput<OutputBase>::getExecuteOptions();
+
 }
 
 template<class OutputBase>
@@ -780,7 +786,14 @@ AdvancedOutput<OutputBase>::getVectorPostprocessorOutput()
   return _output_data["vector_postprocessors"].output;
 }
 
-// Instatiate the four possible template classes
+template<class OutputBase>
+const OutputOnWarehouse &
+AdvancedOutput<OutputBase>::advancedOutputOn() const
+{
+  return _advanced_output_on;
+}
+
+// Instantiate the four possible template classes
 template class AdvancedOutput<Output>;
 template class AdvancedOutput<PetscOutput>;
 template class AdvancedOutput<FileOutput>;

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -105,12 +105,7 @@ Output::Output(const std::string & name, InputParameters & parameters) :
 {
 
   // Handle the short-cut output flags
-  if (getParam<bool>("output_initial"))
-    _output_on.push_back("initial");
-  if (getParam<bool>("output_final"))
-    _output_on.push_back("final");
-  if (getParam<bool>("output_failed"))
-    _output_on.push_back("failed");
+  applyOutputOnShortCutFlags(_output_on);
 
   // Apply the additional output flags
   MultiMooseEnum add = getParam<MultiMooseEnum>("additional_output_on");
@@ -205,16 +200,35 @@ Output::timeStep()
   return _t_step;
 }
 
-std::string
+const MultiMooseEnum &
 Output::outputOn() const
 {
-  std::ostringstream oss;
-  for (MooseEnumIterator it = _output_on.begin(); it != _output_on.end(); ++it)
-  {
-    if (it == _output_on.begin())
-      oss << *it;
-    else
-      oss << " " << *it;
-  }
-  return oss.str();
+  return _output_on;
+}
+
+void
+Output::
+applyOutputOnShortCutFlags(MultiMooseEnum & input)
+{
+  /*
+   * output_initial/final/failed are false by default
+   * If they are enabled, then update the output_on
+   * to include this execution time.
+   */
+  if (getParam<bool>("output_initial"))
+    input.push_back("initial");
+
+  if (getParam<bool>("output_final"))
+    input.push_back("final");
+
+  if (getParam<bool>("output_failed"))
+    input.push_back("failed");
+
+  /*
+   * output_timestep_end is true by default
+   * If it is disabled, then update the output_on
+   * by removing it from the execution time.
+   */
+  if (!getParam<bool>("output_timestep_end"))
+    input.erase("timestep_end");
 }

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -15,6 +15,7 @@
 #include "MultiMooseEnum.h"
 #include "MooseUtils.h"
 #include "MooseError.h"
+#include "InfixIterator.h"
 
 #include <sstream>
 #include <algorithm>
@@ -51,8 +52,23 @@ MultiMooseEnum::~MultiMooseEnum()
 bool
 MultiMooseEnum::operator==(const MultiMooseEnum & value) const
 {
-  return std::equal(value._current_ids.begin(), value._current_ids.end(),
-                    _current_ids.begin());
+  // Not the same if the lengths are different
+  if (value.size() != size())
+    return false;
+
+  // Return false if this enum does not contain an item from the other
+  for (MooseEnumIterator it = value.begin(); it != value.end(); ++it)
+    if (!contains(*it))
+      return false;
+
+  // If you get here, they must be the same
+  return true;
+}
+
+bool
+MultiMooseEnum::operator!=(const MultiMooseEnum & value) const
+{
+  return !(*this == value);
 }
 
 bool
@@ -245,6 +261,6 @@ MultiMooseEnum::unique_items_size() const
 std::ostream &
 operator<<(std::ostream & out, const MultiMooseEnum & obj)
 {
-  std::copy(obj._current_names_preserved.begin(), obj._current_names_preserved.end(), std::ostream_iterator<std::string>(out, " "));
+  std::copy(obj._current_names.begin(), obj._current_names.end(), infix_ostream_iterator<std::string>(out, " "));
   return out;
 }


### PR DESCRIPTION
The main purpose of this was to fix the use of short-cut flags (e.g., output_initial) that where not getting passed down to the advanced output on execution.
- AdvancedOutput.C:532 is what fixes this issue.

This patch also added additional information regarding when outputs are being executed to the system information.
- This info is off by default and can be enabled via the `Console` option or with the --show-outputs command line parameter

MultiMooseEnum also needed some improvements:
- The operator== was using std::equal, which turns out to be rubbish.
- The operator<< needed some tweaks to get the unique names printed

(closes #4654)
