### PR TITLE
Special ic 4507

### DIFF
--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticModel.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticModel.h
@@ -121,15 +121,18 @@ class TensorMechanicsPlasticModel : public GeneralUserObject
    * The active yield surfaces, given a vector of yield functions.
    * This is used by FiniteStrainMultiPlasticity to determine the initial
    * set of active constraints at the trial (stress, intnl) configuration.
-   * It is not absolutely necessary to get this perfect (indeed, it is impossible
-   * since the elasticity tensor is unknown), but setting reasonable values
-   * will help the return-map process.
+   * It is up to you (the coder) to determine how accurate you want the
+   * returned_stress to be.  Currently it is only used by FiniteStrainMultiPlasticity
+   * to estimate a good starting value for the Newton-Rahson procedure,
+   * so currently it may not need to be super perfect.
    * @param f values of the yield functions
    * @param stress stress tensor
    * @param intnl internal parameter
+   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
    * @param act (output) act[i] = true if the i_th yield function is active
+   * @param returned_stress (output) Approximate value of the returned stress
    */
-  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, std::vector<bool> & act) const;
+  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const;
 
   /// Returns the model name (eg "MohrCoulom")
   virtual std::string modelName() const;

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMohrCoulombMulti.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMohrCoulombMulti.h
@@ -76,15 +76,18 @@ class TensorMechanicsPlasticMohrCoulombMulti : public TensorMechanicsPlasticMode
    * The active yield surfaces, given a vector of yield functions.
    * This is used by FiniteStrainMultiPlasticity to determine the initial
    * set of active constraints at the trial (stress, intnl) configuration.
-   * It is not absolutely necessary to get this perfect (indeed, it is impossible
-   * since the elasticity tensor is unknown), but setting reasonable values
-   * will help the return-map process.
+   * It is up to you (the coder) to determine how accurate you want the
+   * returned_stress to be.  Currently it is only used by FiniteStrainMultiPlasticity
+   * to estimate a good starting value for the Newton-Rahson procedure,
+   * so currently it may not need to be super perfect.
    * @param f values of the yield functions
    * @param stress stress tensor
    * @param intnl internal parameter
+   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
    * @param act (output) act[i] = true if the i_th yield function is active
+   * @param returned_stress (output) Approximate value of the returned stress
    */
-  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, std::vector<bool> & act) const;
+  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const;
 
   /// Returns the model name (MohrCoulombMulti)
   virtual std::string modelName() const;
@@ -142,6 +145,9 @@ class TensorMechanicsPlasticMohrCoulombMulti : public TensorMechanicsPlasticMode
 
   /// dot product of two 3-dimensional vectors
   Real dot(const std::vector<Real> & a, const std::vector<Real> & b) const;
+
+  /// cross product of two 3-dimensional vectors.  c = axb
+  void cross(const std::vector<Real> & a, const std::vector<Real> & b, std::vector<Real> & c) const;
 
   /// triple product of three 3-dimensional vectors
   Real triple(const std::vector<Real> & a, const std::vector<Real> & b, const std::vector<Real> & c) const;

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticTensileMulti.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticTensileMulti.h
@@ -72,6 +72,23 @@ class TensorMechanicsPlasticTensileMulti : public TensorMechanicsPlasticModel
    */
   virtual void dflowPotential_dintnlV(const RankTwoTensor & stress, const Real & intnl, std::vector<RankTwoTensor> & dr_dintnl) const;
 
+  /**
+   * The active yield surfaces, given a vector of yield functions.
+   * This is used by FiniteStrainMultiPlasticity to determine the initial
+   * set of active constraints at the trial (stress, intnl) configuration.
+   * It is up to you (the coder) to determine how accurate you want the
+   * returned_stress to be.  Currently it is only used by FiniteStrainMultiPlasticity
+   * to estimate a good starting value for the Newton-Rahson procedure,
+   * so currently it may not need to be super perfect.
+   * @param f values of the yield functions
+   * @param stress stress tensor
+   * @param intnl internal parameter
+   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
+   * @param act (output) act[i] = true if the i_th yield function is active
+   * @param returned_stress (output) Approximate value of the returned stress
+   */
+  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const;
+
   /// Returns the model name (TensileMulti)
   virtual std::string modelName() const;
 
@@ -88,6 +105,11 @@ class TensorMechanicsPlasticTensileMulti : public TensorMechanicsPlasticModel
   /// d(tensile strength)/d(internal_param) as a function of residual value, rate, and internal_param
   virtual Real dtensile_strength(const Real internal_param) const;
 
+  /// dot product of two 3-dimensional vectors
+  Real dot(const std::vector<Real> & a, const std::vector<Real> & b) const;
+
+  /// triple product of three 3-dimensional vectors
+  Real triple(const std::vector<Real> & a, const std::vector<Real> & b, const std::vector<Real> & c) const;
 
 };
 

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticWeakPlaneShear.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticWeakPlaneShear.h
@@ -20,6 +20,23 @@ class TensorMechanicsPlasticWeakPlaneShear : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticWeakPlaneShear(const std::string & name, InputParameters parameters);
 
+  /**
+   * The active yield surfaces, given a vector of yield functions.
+   * This is used by FiniteStrainMultiPlasticity to determine the initial
+   * set of active constraints at the trial (stress, intnl) configuration.
+   * It is up to you (the coder) to determine how accurate you want the
+   * returned_stress to be.  Currently it is only used by FiniteStrainMultiPlasticity
+   * to estimate a good starting value for the Newton-Rahson procedure,
+   * so currently it may not need to be super perfect.
+   * @param f values of the yield functions
+   * @param stress stress tensor
+   * @param intnl internal parameter
+   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
+   * @param act (output) act[i] = true if the i_th yield function is active
+   * @param returned_stress (output) Approximate value of the returned stress
+   */
+  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const;
+
   /// Returns the model name (WeakPlaneShear)
   virtual std::string modelName() const;
 

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticWeakPlaneTensile.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticWeakPlaneTensile.h
@@ -20,6 +20,23 @@ class TensorMechanicsPlasticWeakPlaneTensile : public TensorMechanicsPlasticMode
  public:
   TensorMechanicsPlasticWeakPlaneTensile(const std::string & name, InputParameters parameters);
 
+  /**
+   * The active yield surfaces, given a vector of yield functions.
+   * This is used by FiniteStrainMultiPlasticity to determine the initial
+   * set of active constraints at the trial (stress, intnl) configuration.
+   * It is up to you (the coder) to determine how accurate you want the
+   * returned_stress to be.  Currently it is only used by FiniteStrainMultiPlasticity
+   * to estimate a good starting value for the Newton-Rahson procedure,
+   * so currently it may not need to be super perfect.
+   * @param f values of the yield functions
+   * @param stress stress tensor
+   * @param intnl internal parameter
+   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
+   * @param act (output) act[i] = true if the i_th yield function is active
+   * @param returned_stress (output) Approximate value of the returned stress
+   */
+  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const;
+
   /// Returns the model name (WeakPlaneTensile)
   virtual std::string modelName() const;
 

--- a/modules/tensor_mechanics/include/utils/MultiPlasticityRawComponentAssembler.h
+++ b/modules/tensor_mechanics/include/utils/MultiPlasticityRawComponentAssembler.h
@@ -48,6 +48,9 @@ protected:
    */
   unsigned int _num_surfaces;
 
+  /// Allows initial set of active constraints to be chosen optimally
+  MooseEnum _specialIC;
+
   /// User objects that define the yield functions, flow potentials, etc
   std::vector<const TensorMechanicsPlasticModel *> _f;
 
@@ -152,9 +155,10 @@ protected:
    * @param f yield functions (should be _num_surfaces of these)
    * @param stress stress tensor
    * @param intnl internal parameters
+   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
    * @param act (output) the set of active constraints (will be resized to _num_surfaces)
    */
-  virtual void buildActiveConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const std::vector<Real> & intnl, std::vector<bool> & act);
+  virtual void buildActiveConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const std::vector<Real> & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act);
 
   /// returns the model number, given the surface number
   unsigned int modelNumber(unsigned int surface);
@@ -190,6 +194,32 @@ protected:
 
   /// _surfaces_given_model[model_number] = vector of surface numbers for this model
   std::vector<std::vector<unsigned int> > _surfaces_given_model;
+
+  /**
+   * "Rock" version
+   * Constructs a set of active constraints, given the yield functions, f.
+   * This uses TensorMechanicsPlasticModel::activeConstraints to identify the active
+   * constraints for each model.
+   * @param f yield functions (should be _num_surfaces of these)
+   * @param stress stress tensor
+   * @param intnl internal parameters
+   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
+   * @param act (output) the set of active constraints (will be resized to _num_surfaces)
+   */
+  void buildActiveConstraintsRock(const std::vector<Real> & f, const RankTwoTensor & stress, const std::vector<Real> & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act);
+
+  /**
+   * "Joint" version
+   * Constructs a set of active constraints, given the yield functions, f.
+   * This uses TensorMechanicsPlasticModel::activeConstraints to identify the active
+   * constraints for each model.
+   * @param f yield functions (should be _num_surfaces of these)
+   * @param stress stress tensor
+   * @param intnl internal parameters
+   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
+   * @param act (output) the set of active constraints (will be resized to _num_surfaces)
+   */
+  void buildActiveConstraintsJoint(const std::vector<Real> & f, const RankTwoTensor & stress, const std::vector<Real> & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act);
 
 };
 

--- a/modules/tensor_mechanics/include/utils/RankTwoTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoTensor.h
@@ -286,6 +286,13 @@ public:
   void symmetricEigenvalues(std::vector<Real> & eigvals) const;
 
   /**
+   * computes eigenvalues and eigenvectors, assuming tens is symmetric, and places them
+   * in ascending order in eigvals.  eigvecs is a matrix with the first column
+   * being the first eigenvector, the second column being the second, etc.
+   */
+  void symmetricEigenvaluesEigenvectors(std::vector<Real> & eigvals, RankTwoTensor & eigvecs) const;
+
+  /**
    * computes eigenvalues, and their symmetric derivatives wrt vals,
    * assuming tens is symmetric
    * @param eigvals are the eigenvalues of the matrix, in ascending order

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticModel.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticModel.C
@@ -151,7 +151,7 @@ TensorMechanicsPlasticModel::dhardPotential_dintnlV(const RankTwoTensor & stress
 
 
 void
-TensorMechanicsPlasticModel::activeConstraints(const std::vector<Real> & f, const RankTwoTensor & /*stress*/, const Real & /*intnl*/, std::vector<bool> & act) const
+TensorMechanicsPlasticModel::activeConstraints(const std::vector<Real> & f, const RankTwoTensor & /*stress*/, const Real & /*intnl*/, const RankFourTensor & /*Eijkl*/, std::vector<bool> & act, RankTwoTensor & /*returned_stress*/) const
 {
   mooseAssert(f.size() == numberSurfaces(), "f incorrectly sized at " << f.size() << " in activeConstraints");
   act.resize(numberSurfaces());

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulombMulti.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulombMulti.C
@@ -249,7 +249,7 @@ TensorMechanicsPlasticMohrCoulombMulti::activeConstraints(const std::vector<Real
     n[ys].assign(3, 0);
     for (unsigned i = 0 ; i < 3 ; ++i)
       for (unsigned j = 0 ; j < 3 ; ++j)
-	n[ys][i] += Eijkl(i,i,j,j)*norm[ys][j];
+        n[ys][i] += Eijkl(i,i,j,j)*norm[ys][j];
   }
 
 

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulombMulti.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulombMulti.C
@@ -11,7 +11,7 @@ InputParameters validParams<TensorMechanicsPlasticMohrCoulombMulti>()
   params.addRequiredParam<UserObjectName>("cohesion", "A TensorMechanicsHardening UserObject that defines hardening of the cohesion");
   params.addRequiredParam<UserObjectName>("friction_angle", "A TensorMechanicsHardening UserObject that defines hardening of the friction angle (in radians)");
   params.addRequiredParam<UserObjectName>("dilation_angle", "A TensorMechanicsHardening UserObject that defines hardening of the dilation angle (in radians)");
-  params.addParam<Real>("shift", "Yield surface is shifted by this amount to avoid problems with defining derivatives when eigenvalues are equal.  If this is larger than f_tol, a warning will be issued.  Default = 0.1*f_tol.");
+  params.addParam<Real>("shift", "Yield surface is shifted by this amount to avoid problems with defining derivatives when eigenvalues are equal.  If this is larger than f_tol, a warning will be issued.  Default = f_tol.");
 
   return params;
 }
@@ -22,7 +22,7 @@ TensorMechanicsPlasticMohrCoulombMulti::TensorMechanicsPlasticMohrCoulombMulti(c
     _cohesion(getUserObject<TensorMechanicsHardeningModel>("cohesion")),
     _phi(getUserObject<TensorMechanicsHardeningModel>("friction_angle")),
     _psi(getUserObject<TensorMechanicsHardeningModel>("dilation_angle")),
-    _shift(parameters.isParamValid("shift") ? getParam<Real>("shift") : 0.1*_f_tol)
+    _shift(parameters.isParamValid("shift") ? getParam<Real>("shift") : _f_tol)
 {
   if (_shift < 0)
     mooseError("Value of 'shift' in TensorMechanicsPlasticMohrCoulombMulti must not be negative\n");
@@ -175,12 +175,22 @@ TensorMechanicsPlasticMohrCoulombMulti::dflowPotential_dintnlV(const RankTwoTens
 
 
 void
-TensorMechanicsPlasticMohrCoulombMulti::activeConstraints(const std::vector<Real> & /*f*/, const RankTwoTensor & stress, const Real & intnl, std::vector<bool> & act) const
+TensorMechanicsPlasticMohrCoulombMulti::activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const
 {
   act.assign(6, false);
 
+  if (f[0] <= _f_tol && f[1] <= _f_tol && f[2] <= _f_tol && f[3] <= _f_tol && f[4] <= _f_tol && f[5] <= _f_tol)
+  {
+    returned_stress = stress;
+    return;
+  }
+
+
+  returned_stress = RankTwoTensor();
+
   std::vector<Real> eigvals;
-  stress.symmetricEigenvalues(eigvals);
+  RankTwoTensor eigvecs;
+  stress.symmetricEigenvaluesEigenvectors(eigvals, eigvecs);
   eigvals[0] += _shift;
   eigvals[2] -= _shift;
 
@@ -209,23 +219,39 @@ TensorMechanicsPlasticMohrCoulombMulti::activeConstraints(const std::vector<Real
   // FiniteStrainMultiPlasticity, in about 0.001% of cases,
   // but these are not work checking.
 
-  // these are the normals to the 6 yield surfaces (flow directions)
-  std::vector<std::vector<Real> > n(6);
+  // these are the normals to the 6 yield surfaces
+  std::vector<std::vector<Real> > norm(6);
   Real sinpsi = std::sin(psi(intnl));
   Real oneminus = 1 - sinpsi;
   Real oneplus = 1 + sinpsi;
-  n[0].resize(3);
-  n[0][0] = oneplus ; n[0][1] = -oneminus ; n[0][2] = 0;
-  n[1].resize(3);
-  n[1][0] = -oneminus ; n[1][1] = oneplus ; n[1][2] = 0;
-  n[2].resize(3);
-  n[2][0] = oneplus ; n[2][1] = 0 ; n[2][2] = -oneminus;
-  n[3].resize(3);
-  n[3][0] = -oneminus ; n[3][1] = 0 ; n[3][2] = oneplus;
-  n[4].resize(3);
-  n[4][0] = 0 ; n[4][1] = oneplus ; n[4][2] = -oneminus;
-  n[5].resize(3);
-  n[5][0] = 0 ; n[5][1] = -oneminus ; n[5][2] = oneplus;
+  norm[0].resize(3);
+  norm[0][0] = oneplus ; norm[0][1] = -oneminus ; norm[0][2] = 0;
+  norm[1].resize(3);
+  norm[1][0] = -oneminus ; norm[1][1] = oneplus ; norm[1][2] = 0;
+  norm[2].resize(3);
+  norm[2][0] = oneplus ; norm[2][1] = 0 ; norm[2][2] = -oneminus;
+  norm[3].resize(3);
+  norm[3][0] = -oneminus ; norm[3][1] = 0 ; norm[3][2] = oneplus;
+  norm[4].resize(3);
+  norm[4][0] = 0 ; norm[4][1] = oneplus ; norm[4][2] = -oneminus;
+  norm[5].resize(3);
+  norm[5][0] = 0 ; norm[5][1] = -oneminus ; norm[5][2] = oneplus;
+
+  // the flow directions are these norm multiplied by Eijkl.
+  // I call the flow directions "n".
+  // In the following I assume that the Eijkl is
+  // for an isotropic situation.  Then I don't have to
+  // rotate to the principal-stress frame, and i don't
+  // have to worry about strange off-diagonal things
+  std::vector<std::vector<Real> > n(6);
+  for (unsigned ys = 0 ; ys < 6 ; ++ys)
+  {
+    n[ys].assign(3, 0);
+    for (unsigned i = 0 ; i < 3 ; ++i)
+      for (unsigned j = 0 ; j < 3 ; ++j)
+	n[ys][i] += Eijkl(i,i,j,j)*norm[ys][j];
+  }
+
 
   // Check for return to the tip.
   // For tip-return to satisfy Kuhn-Tucker we need
@@ -240,6 +266,8 @@ TensorMechanicsPlasticMohrCoulombMulti::activeConstraints(const std::vector<Real
   if (triple(v, n[0], n[1])/denom >= 0 && triple(v, n[1], n[3])/denom >= 0 && triple(v, n[3], n[0])/denom >= 0)
   {
     act[0] = act[1] = act[3] = true;
+    returned_stress(0, 0) = returned_stress(1, 1) = returned_stress(2, 2) = cohcot;
+    returned_stress = eigvecs*returned_stress*(eigvecs.transpose());
     return;
   }
 
@@ -248,61 +276,79 @@ TensorMechanicsPlasticMohrCoulombMulti::activeConstraints(const std::vector<Real
   if (triple(v, n[1], n[3])/denom >= 0 && triple(v, n[3], n[5])/denom >= 0 && triple(v, n[5], n[1])/denom >= 0)
   {
     act[1] = act[3] = act[5] = true;
+    returned_stress(0, 0) = returned_stress(1, 1) = returned_stress(2, 2) = cohcot;
+    returned_stress = eigvecs*returned_stress*(eigvecs.transpose());
     return;
   }
 
+
   // the following are tangents to the 1, 3, and 5 yield surfaces
   // used below.
-  std::vector<Real> t1(3);
-  t1[0] = oneplus ; t1[1] = oneminus ; t1[2] = 0;
-  std::vector<Real> t3(3);
-  t3[0] = oneplus ; t3[1] = 0 ; t3[2] = oneminus;
-  std::vector<Real> t5(3);
-  t5[0] = 0 ; t5[1] = oneplus ; t5[2] = oneminus;
+  std::vector<Real> n1xn3(3);
+  cross(n[1], n[3], n1xn3);
+  std::vector<Real> n1xn5(3);
+  cross(n[1], n[5], n1xn5);
+  std::vector<Real> n3xn5(3);
+  cross(n[3], n[5], n3xn5);
+
 
 
   // 010100 (edge)
-  std::vector<Real> n1xn3(3);
-  n1xn3[0] = oneplus ; n1xn3[1] = oneminus ; n1xn3[2] = oneminus;
   // work out the point to which we would return, "a".  It is defined by
   // f1 = 0 = f3, and that (p - a).(n1 x n3) = 0, where "p" is the
   // starting position (p = eigvals).
-  // In the following a = (lam0, lam2, lam2)
+  // In the following a = (lam0, lam1, lam1)
   Real pdotn1xn3 = dot(eigvals, n1xn3);
-  Real lam0 = pdotn1xn3 - 4*coh*cosphi*oneminus/(1 + sinphi);
-  lam0 /= oneplus + 2*oneminus*(1 - sinphi)/(1 + sinphi);
+  //Real lam0 = pdotn1xn3 - 4*coh*cosphi*oneminus/(1 + sinphi);
+  Real lam0 = pdotn1xn3 - 2*coh*cosphi*(n1xn3[1] + n1xn3[2])/(1 + sinphi);
+  //lam0 /= oneplus + 2*oneminus*(1 - sinphi)/(1 + sinphi);
+  lam0 /= n1xn3[0] + (n1xn3[1] + n1xn3[2])*(1 - sinphi)/(1 + sinphi);
   Real lam1 = lam0*(1 - sinphi)/(1 + sinphi) + 2*coh*cosphi/(1 + sinphi);
   std::vector<Real> pminusa(3);
   pminusa[0] = eigvals[0] - lam0;
   pminusa[1] = eigvals[1] - lam1;
   pminusa[2] = eigvals[2] - lam1;
-  if (dot(pminusa, t3)/dot(n[1], t3) >= 0 && dot(pminusa, t1)/dot(n[3], t1) >= 0)
+  // p = a + alpha*n1 + beta*n3, and for Kuhn-Tucker we need alpha and beta non-negative
+  if (dot(pminusa, n3xn5)/dot(n[1], n3xn5) >= 0 && dot(pminusa, n1xn5)/dot(n[3], n1xn5) >= 0)
   {
+    returned_stress(0, 0) = lam0;
+    returned_stress(1, 1) = returned_stress(2, 2) = lam1;
+    returned_stress = eigvecs*returned_stress*(eigvecs.transpose());
     act[1] = act[3] = true;
     return;
   }
 
   // 000101 (edge)
-  std::vector<Real> n3xn5(3);
-  n3xn5[0] = oneplus ; n3xn5[1] = oneplus ; n3xn5[2] = oneminus;
   // work out the point to which we would return, "a".  It is defined by
   // f3 = 0 = f5, and that (p - a).(n3 x n5) = 0, where "p" is the
   // starting position (p = eigvals).
-  // In the following a = (lam0, lam2, lam2)
+  // In the following a = (lam1, lam1, lam2)
   Real pdotn3xn5 = dot(eigvals, n3xn5);
-  Real lam2 = pdotn3xn5 + 4*coh*cosphi*oneplus/(1 - sinphi);
-  lam2 /= oneminus + 2*oneplus*(1 + sinphi)/(1 - sinphi);
+  Real lam2 = pdotn3xn5 + 2*coh*cosphi*(n3xn5[0] + n3xn5[1])/(1 - sinphi);
+  lam2 /= n3xn5[2] + (n3xn5[0] + n3xn5[1])*(1 + sinphi)/(1 - sinphi);
   lam1 = lam2*(1 + sinphi)/(1 - sinphi) - 2*coh*cosphi/(1 - sinphi);
   pminusa[0] = eigvals[0] - lam1;
   pminusa[1] = eigvals[1] - lam1;
   pminusa[2] = eigvals[2] - lam2;
-  if (dot(pminusa, t5)/dot(n[3], t5) >= 0 && dot(pminusa, t3)/dot(n[5], t3) >= 0)
+  // p = a + alpha*n3 + beta*n5, and for Kuhn-Tucker we need alpha and beta non-negative
+  if (dot(pminusa, n1xn5)/dot(n[3], n1xn5) >= 0 && dot(pminusa, n1xn3)/dot(n[5], n1xn3) >= 0)
   {
+    returned_stress(0, 0) = returned_stress(1, 1) = lam1;
+    returned_stress(2, 2) = lam2;
+    returned_stress = eigvecs*returned_stress*(eigvecs.transpose());
     act[3] = act[5] = true;
     return;
   }
 
   // 000100 (plane)
+  // the returned point, "a" is defined by f3=0 and
+  // a = p - alpha*n3
+  Real alpha = 0.5*eigvals[2]*(1 + sinphi) + 0.5*eigvals[0]*(-1 + sinphi) - coh*cosphi;
+  alpha /= 0.5*n[3][2]*(1 + sinphi) + 0.5*n[3][0]*(-1 + sinphi);
+  returned_stress(0, 0) = eigvals[0] - alpha*n[3][0];
+  returned_stress(1, 1) = eigvals[1] - alpha*n[3][1];
+  returned_stress(2, 2) = eigvals[2] - alpha*n[3][2];
+  returned_stress = eigvecs*returned_stress*(eigvecs.transpose());
   act[3] = true;
   return;
 }
@@ -312,6 +358,16 @@ TensorMechanicsPlasticMohrCoulombMulti::dot(const std::vector<Real> & a, const s
 {
   return a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
 }
+
+void
+TensorMechanicsPlasticMohrCoulombMulti::cross(const std::vector<Real> & a, const std::vector<Real> & b, std::vector<Real> & c) const
+{
+  c.resize(3);
+  c[0] = a[1]*b[2] - a[2]*b[1];
+  c[1] = a[2]*b[0] - a[0]*b[2];
+  c[2] = a[0]*b[1] - a[1]*b[0];
+}
+
 
 Real
 TensorMechanicsPlasticMohrCoulombMulti::triple(const std::vector<Real> & a, const std::vector<Real> & b, const std::vector<Real> & c) const

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticTensileMulti.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticTensileMulti.C
@@ -9,7 +9,7 @@ InputParameters validParams<TensorMechanicsPlasticTensileMulti>()
   InputParameters params = validParams<TensorMechanicsPlasticModel>();
   params.addClassDescription("Associative tensile plasticity with hardening/softening");
   params.addRequiredParam<UserObjectName>("tensile_strength", "A TensorMechanicsHardening UserObject that defines hardening of the tensile strength");
-  params.addParam<Real>("shift", "Yield surface is shifted by this amount to avoid problems with defining derivatives when eigenvalues are equal.  If this is larger than f_tol, a warning will be issued.  Default = 0.1*f_tol.");
+  params.addParam<Real>("shift", "Yield surface is shifted by this amount to avoid problems with defining derivatives when eigenvalues are equal.  If this is larger than f_tol, a warning will be issued.  Default = f_tol.");
   return params;
 }
 
@@ -17,7 +17,7 @@ TensorMechanicsPlasticTensileMulti::TensorMechanicsPlasticTensileMulti(const std
                                                          InputParameters parameters) :
     TensorMechanicsPlasticModel(name, parameters),
     _strength(getUserObject<TensorMechanicsHardeningModel>("tensile_strength")),
-    _shift(parameters.isParamValid("shift") ? getParam<Real>("shift") : 0.1*_f_tol)
+    _shift(parameters.isParamValid("shift") ? getParam<Real>("shift") : _f_tol)
 {
   if (_shift < 0)
     mooseError("Value of 'shift' in TensorMechanicsPlasticTensileMulti must not be negative\n");
@@ -110,6 +110,120 @@ Real
 TensorMechanicsPlasticTensileMulti::dtensile_strength(const Real internal_param) const
 {
   return _strength.derivative(internal_param);
+}
+
+
+void
+TensorMechanicsPlasticTensileMulti::activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const Real & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const
+{
+  act.assign(3, false);
+
+  if (f[0] <= _f_tol && f[1] <= _f_tol && f[2] <= _f_tol)
+  {
+    returned_stress = stress;
+    return;
+  }
+
+  returned_stress = RankTwoTensor();
+
+  std::vector<Real> eigvals;
+  RankTwoTensor eigvecs;
+  stress.symmetricEigenvaluesEigenvectors(eigvals, eigvecs);
+  eigvals[0] += _shift;
+  eigvals[2] -= _shift;
+
+  Real str = tensile_strength(intnl);
+  std::vector<Real> v(3);
+  v[0] = eigvals[0] - str;
+  v[1] = eigvals[1] - str;
+  v[2] = eigvals[2] - str;
+
+  // these are the normals to the 3 yield surfaces
+  std::vector<std::vector<Real> > n(3);
+  n[0].resize(3);
+  n[0][0] = 1 ; n[0][1] = 0 ; n[0][2] = 0;
+  n[1].resize(3);
+  n[1][0] = 0 ; n[1][1] = 1 ; n[1][2] = 0;
+  n[2].resize(3);
+  n[2][0] = 0 ; n[2][1] = 0 ; n[2][2] = 1;
+
+  // the flow directions are these n multiplied by Eijkl.
+  // I re-use the name "n" for the flow directions
+  // In the following I assume that the Eijkl is
+  // for an isotropic situation.  This is the most
+  // common when using TensileMulti, and remember
+  // that the returned_stress need not be perfect
+  // anyway.
+  // I divide by E(0,0,0,0) so the n remain of order 1
+  Real ratio = Eijkl(1,1,0,0)/Eijkl(0,0,0,0);
+  n[0][1] = n[0][2] = ratio;
+  n[1][0] = n[1][2] = ratio;
+  n[2][0] = n[2][1] = ratio;
+
+
+  // 111 (tip)
+  // For tip-return to satisfy Kuhn-Tucker, we need
+  // v = alpha*n[0] + beta*n[1] * gamma*n[2]
+  // with alpha, beta, and gamma all being non-negative (they are
+  // the plasticity multipliers)
+  Real denom = triple(n[0], n[1], n[2]);
+  if (triple(v, n[0], n[1])/denom >= 0 && triple(v, n[1], n[2])/denom >= 0 && triple(v, n[2], n[0])/denom >= 0)
+  {
+    act[0] = act[1] = act[2] = true;
+    returned_stress(0, 0) = returned_stress(1, 1) = returned_stress(2, 2) = str;
+    returned_stress = eigvecs*returned_stress*(eigvecs.transpose());
+    return;
+  }
+
+  // 011 (edge)
+  std::vector<Real> n1xn2(3);
+  n1xn2[0] = n[1][1]*n[2][2] - n[1][2]*n[2][1];
+  n1xn2[1] = n[1][2]*n[2][0] - n[1][0]*n[2][2];
+  n1xn2[2] = n[1][0]*n[2][1] - n[1][1]*n[2][0];
+  // work out the point to which we would return, "a".  It is defined by
+  // f1 = 0 = f2, and that (p - a).(n1 x n2) = 0, where "p" is the
+  // starting position (p = eigvals).
+  // In the following a = (a0, str, str)
+  Real pdotn1xn2 = dot(eigvals, n1xn2);
+  Real a0 = (-str*n1xn2[1] - str*n1xn2[2] + pdotn1xn2)/n1xn2[0];
+  // we need p - a = alpha*n1 + beta*n2, where alpha and beta are non-negative
+  // for Kuhn-Tucker to be satisfied
+  std::vector<Real> pminusa(3);
+  pminusa[0] = eigvals[0] - a0;
+  pminusa[1] = v[1];
+  pminusa[2] = v[2];
+  if ((pminusa[2] - pminusa[0])/(1.0 - ratio) >= 0 && (pminusa[1] - pminusa[0])/(1.0 - ratio) >= 0)
+  {
+    returned_stress(0, 0) = a0;
+    returned_stress(1, 1) = str;
+    returned_stress(2, 2) = str;
+    returned_stress = eigvecs*returned_stress*(eigvecs.transpose());
+    act[1] = act[2] = true;
+    return;
+  }
+
+  // 001 (plane)
+  // the returned point, "a", is defined by f2=0 and
+  // a = p - alpha*n2
+  Real alpha = (eigvals[2] - str)/n[2][2];
+  act[2] = true;
+  returned_stress(0, 0) = eigvals[0] - alpha*n[2][0];
+  returned_stress(1, 1) = eigvals[1] - alpha*n[2][1];
+  returned_stress(2, 2) = str;
+  returned_stress = eigvecs*returned_stress*(eigvecs.transpose());
+  return;
+}
+
+Real
+TensorMechanicsPlasticTensileMulti::dot(const std::vector<Real> & a, const std::vector<Real> & b) const
+{
+  return a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
+}
+
+Real
+TensorMechanicsPlasticTensileMulti::triple(const std::vector<Real> & a, const std::vector<Real> & b, const std::vector<Real> & c) const
+{
+  return a[0]*(b[1]*c[2] - b[2]*c[1]) - a[1]*(b[0]*c[2] - b[2]*c[0]) + a[2]*(b[0]*c[1] - b[1]*c[0]);
 }
 
 std::string

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticWeakPlaneShear.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticWeakPlaneShear.C
@@ -251,6 +251,12 @@ TensorMechanicsPlasticWeakPlaneShear::activeConstraints(const std::vector<Real> 
     norm[0] = 0.25*(stress(0, 2)+stress(2,0))/tau;
     norm[1] = 0.25*(stress(1, 2)+stress(2,1))/tau;
   }
+  else
+  {
+    returned_stress(2, 2) = cohesion(intnl)/tanphi;
+    act[0] = true;
+    return;
+  }
   norm[2] = tanpsi;
 
   // to get the flow directions, we have to multiply norm by Eijkl.
@@ -264,16 +270,19 @@ TensorMechanicsPlasticWeakPlaneShear::activeConstraints(const std::vector<Real> 
 
   if (1 - alpha*Eijkl(0,2,0,2)/tau >= 0)
   {
-    // returning to the "edge" of the cone
+    // returning to the "surface" of the cone
     returned_stress(2, 2) = stress(2, 2) - alpha*Eijkl(2, 2, 2, 2)*norm[2];
     returned_stress(0, 2) = returned_stress(2, 0) = stress(0, 2) - alpha*2*Eijkl(0, 2, 0, 2)*norm[0];
     returned_stress(1, 2) = returned_stress(2, 1) = stress(1, 2) - alpha*2*Eijkl(1, 2, 1, 2)*norm[1];
   }
   else
   {
+    // returning to the "tip" of the cone
     returned_stress(2, 2) = cohesion(intnl)/tanphi;
     returned_stress(0, 2) = returned_stress(2, 0) = returned_stress(1, 2) = returned_stress(2, 1) = 0;
   }
+  returned_stress(0, 0) = stress(0, 0) - Eijkl(0, 0, 2, 2)*(stress(2, 2) - returned_stress(2, 2))/Eijkl(2, 2, 2, 2);
+  returned_stress(1, 1) = stress(1, 1) - Eijkl(1, 1, 2, 2)*(stress(2, 2) - returned_stress(2, 2))/Eijkl(2, 2, 2, 2);
 
   act[0] = true;
 }

--- a/modules/tensor_mechanics/src/utils/MultiPlasticityRawComponentAssembler.C
+++ b/modules/tensor_mechanics/src/utils/MultiPlasticityRawComponentAssembler.C
@@ -4,6 +4,8 @@ template<>
 InputParameters validParams<MultiPlasticityRawComponentAssembler>()
 {
   InputParameters params = emptyInputParameters();
+  MooseEnum specialIC("none rock joint", "none");
+  params.addParam<MooseEnum>("specialIC", specialIC, "For certain combinations of plastic models, the set of active constraints can be initialized optimally.  'none': no special initialization is performed.  For all other choices, the plastic_models must be chosen to have the following types.  'rock': 'TensileMulti MohrCoulombMulti'.  'joint': 'WeakPlaneTensile WeakPlaneShear'.");
   params.addRequiredParam<std::vector<UserObjectName> >("plastic_models", "List of names of user objects that define the plastic models that could be active for this material.");
   params.addClassDescription("RawComponentAssembler class to calculate yield functions, etc, used in multi-surface finite-strain plasticity");
   return params;
@@ -12,7 +14,8 @@ InputParameters validParams<MultiPlasticityRawComponentAssembler>()
 MultiPlasticityRawComponentAssembler::MultiPlasticityRawComponentAssembler(const std::string & /*name*/,
                                          InputParameters parameters):
   _num_models(parameters.get<std::vector<UserObjectName> >("plastic_models").size()),
-  _num_surfaces(0)
+  _num_surfaces(0),
+  _specialIC(parameters.get<MooseEnum>("specialIC"))
 {
   _f.resize(_num_models);
   UserObjectInterface uoi(parameters); // this comes via TensorMechanicsPlasticModel.  i haven't derived this class from UserObjectInterface because i'm worried about diamond inheritance when using this in FiniteStrainMultiPlasticity
@@ -40,6 +43,22 @@ MultiPlasticityRawComponentAssembler::MultiPlasticityRawComponentAssembler(const
     _surfaces_given_model[model].resize(_f[model]->numberSurfaces());
     for (unsigned model_surface = 0 ; model_surface < _f[model]->numberSurfaces() ; ++model_surface)
       _surfaces_given_model[model][model_surface] = surface++;
+  }
+
+  // check the plastic_models for specialIC
+  if (_specialIC == "rock")
+  {
+    if (_num_models != 2)
+      mooseError("Choosing specialIC=rock, you must have plasticity models of type 'TensileMulti MohrCoulombMulti'\n");
+    if (!(_f[0]->modelName().compare("TensileMulti") == 0 && _f[1]->modelName().compare("MohrCoulombMulti") == 0))
+      mooseError("Choosing specialIC=rock, you must have plasticity models of type 'TensileMulti MohrCoulombMulti'\n");
+  }
+  if (_specialIC == "joint")
+  {
+    if (_num_models != 2)
+      mooseError("Choosing specialIC=joint, you must have plasticity models of type 'WeakPlaneTensile WeakPlaneShear'\n");
+    if (!(_f[0]->modelName().compare("WeakPlaneTensile") == 0 && _f[1]->modelName().compare("WeakPlaneShear") == 0))
+      mooseError("Choosing specialIC=joint, you must have plasticity models of type 'WeakPlaneTensile WeakPlaneShear'\n");
   }
 }
 
@@ -244,23 +263,194 @@ MultiPlasticityRawComponentAssembler::dhardPotential_dintnl(const RankTwoTensor 
 
 
 void
-MultiPlasticityRawComponentAssembler::buildActiveConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const std::vector<Real> & intnl, std::vector<bool> & act)
+MultiPlasticityRawComponentAssembler::buildActiveConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, const std::vector<Real> & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act)
 {
   mooseAssert(f.size() == _num_surfaces, "buildActiveConstraints called with f.size = " << f.size() << " while there are " << _num_surfaces << " surfaces");
   mooseAssert(intnl.size() == _num_models, "buildActiveConstraints called with intnl.size = " << intnl.size() << " while there are " << _num_models << " models");
-  act.resize(0);
-  unsigned ind = 0;
-  for (unsigned model = 0 ; model < _num_models ; ++model)
+
+  if (_specialIC == "rock")
+    buildActiveConstraintsRock(f, stress, intnl, Eijkl, act);
+  else if (_specialIC == "joint")
+    buildActiveConstraintsJoint(f, stress, intnl, Eijkl, act);
+  else // no specialIC
   {
-    std::vector<Real> model_f(0);
-    for (unsigned model_surface = 0 ; model_surface < _f[model]->numberSurfaces() ; ++model_surface)
-      model_f.push_back(f[ind++]);
-    std::vector<bool> model_act;
-    _f[model]->activeConstraints(model_f, stress, intnl[model], model_act);
-    for (unsigned model_surface = 0 ; model_surface < _f[model]->numberSurfaces() ; ++model_surface)
-      act.push_back(model_act[model_surface]);
+    act.resize(0);
+    unsigned ind = 0;
+    for (unsigned model = 0 ; model < _num_models ; ++model)
+    {
+      std::vector<Real> model_f(0);
+      for (unsigned model_surface = 0 ; model_surface < _f[model]->numberSurfaces() ; ++model_surface)
+        model_f.push_back(f[ind++]);
+      std::vector<bool> model_act;
+      RankTwoTensor returned_stress;
+      _f[model]->activeConstraints(model_f, stress, intnl[model], Eijkl, model_act, returned_stress);
+      for (unsigned model_surface = 0 ; model_surface < _f[model]->numberSurfaces() ; ++model_surface)
+        act.push_back(model_act[model_surface]);
+    }
   }
 }
+
+void
+MultiPlasticityRawComponentAssembler::buildActiveConstraintsJoint(const std::vector<Real> & f, const RankTwoTensor & stress, const std::vector<Real> & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act)
+{
+  act.assign(2, false);
+
+  RankTwoTensor returned_stress;
+  std::vector<bool> active_tensile;
+  std::vector<bool> active_shear;
+  std::vector<Real> f_single;
+
+  // first try tensile alone
+  f_single.assign(1, 0);
+  f_single[0] = f[0];
+  _f[0]->activeConstraints(f_single, stress, intnl[0], Eijkl, active_tensile, returned_stress);
+  _f[1]->yieldFunctionV(returned_stress, intnl[1], f_single);
+  //Moose::out << "prediction: tensile act = " << active_tensile[0] << "\n";
+  if (f_single[0] <= _f[1]->_f_tol)
+  {
+    //Moose::out << "tensile alone\n";
+    act[0] = active_tensile[0];
+    return;
+  }
+
+  // next try shear alone
+  f_single.assign(1, 0);
+  f_single[0] = f[1];
+  _f[1]->activeConstraints(f_single, stress, intnl[1], Eijkl, active_shear, returned_stress);
+  _f[0]->yieldFunctionV(returned_stress, intnl[0], f_single);
+  //Moose::out << "prediction: shear act = " << active_shear[0] << "\n";
+  if (f_single[0] <= _f[0]->_f_tol)
+  {
+    //Moose::out << "shear alone\n";
+    act[1] = active_shear[0];
+    return;
+  }
+
+  // must be mixed
+  act[0] = act[1] = true;
+  return;
+}
+
+
+void
+MultiPlasticityRawComponentAssembler::buildActiveConstraintsRock(const std::vector<Real> & f, const RankTwoTensor & stress, const std::vector<Real> & intnl, const RankFourTensor & Eijkl, std::vector<bool> & act)
+{
+  act.assign(9, false);
+
+  RankTwoTensor returned_stress;
+  std::vector<bool> active_tensile;
+  std::vector<bool> active_MC;
+  std::vector<Real> f_single;
+
+  // first try tensile alone
+  f_single.assign(3, 0);
+  f_single[0] = f[0];
+  f_single[1] = f[1];
+  f_single[2] = f[2];
+  _f[0]->activeConstraints(f_single, stress, intnl[0], Eijkl, active_tensile, returned_stress);
+  _f[1]->yieldFunctionV(returned_stress, intnl[1], f_single);
+  //Moose::out << "prediction: tensile act = " << active_tensile[0] << active_tensile[1] << active_tensile[2] << "\n";
+  if (f_single[0] <= _f[1]->_f_tol && f_single[1] <= _f[1]->_f_tol && f_single[2] <= _f[1]->_f_tol && f_single[3] <= _f[1]->_f_tol && f_single[4] <= _f[1]->_f_tol && f_single[5] <= _f[1]->_f_tol)
+  {
+    act[0] = active_tensile[0];
+    act[1] = active_tensile[1];
+    act[2] = active_tensile[2];
+    return;
+  }
+
+  // next try MC alone
+  f_single.assign(6, 0);
+  f_single[0] = f[3];
+  f_single[1] = f[4];
+  f_single[2] = f[5];
+  f_single[3] = f[6];
+  f_single[4] = f[7];
+  f_single[5] = f[8];
+  _f[1]->activeConstraints(f_single, stress, intnl[1], Eijkl, active_MC, returned_stress);
+  _f[0]->yieldFunctionV(returned_stress, intnl[0], f_single);
+  //Moose::out << "prediction: MC act = " << active_MC[0] << active_MC[1] << active_MC[2]  << active_MC[3] << active_MC[4] << active_MC[5] << "\n";
+  if (f_single[0] <= _f[0]->_f_tol && f_single[1] <= _f[0]->_f_tol && f_single[2] <= _f[0]->_f_tol)
+  {
+    act[3] = active_MC[0];
+    act[4] = active_MC[1];
+    act[5] = active_MC[2];
+    act[6] = active_MC[3];
+    act[7] = active_MC[4];
+    act[8] = active_MC[5];
+    return;
+  }
+
+  // must be a mix.
+  // The possibilities are enumerated below.
+
+  // tensile=edge, MC=tip (two possibilities)
+  if (active_tensile[0] == false && active_tensile[1] == true && active_tensile[2] == true && active_MC[0] == true && active_MC[1] == true && active_MC[2] == false && active_MC[3] == true && active_MC[4] == false && active_MC[5] == false)
+  {
+    act[1] = act[2] = act[6] = true;
+    act[4] = true;
+    return;
+  }
+  if (active_tensile[0] == false && active_tensile[1] == true && active_tensile[2] == true && active_MC[0] == false && active_MC[1] == true && active_MC[2] == false && active_MC[3] == true && active_MC[4] == false && active_MC[5] == true)
+  {
+    act[1] = act[2] = act[6] = true;  // i don't think act[4] is necessary, is it?!
+    return;
+  }
+
+  // tensile = edge, MC=edge (two possibilities)
+  if (active_tensile[0] == false && active_tensile[1] == true && active_tensile[2] == true && active_MC[0] == false && active_MC[1] == true && active_MC[2] == false && active_MC[3] == true && active_MC[4] == false && active_MC[5] == false)
+  {
+    act[1] = act[2] = act[4] = act[6] = true;
+    return;
+  }
+  if (active_tensile[0] == false && active_tensile[1] == true && active_tensile[2] == true && active_MC[0] == false && active_MC[1] == false && active_MC[2] == false && active_MC[3] == true && active_MC[4] == false && active_MC[5] == true)
+  {
+    act[1] = act[2] = act[4] = act[6] = true;
+    return;
+  }
+
+  // tensile = edge, MC=face
+  if (active_tensile[0] == false && active_tensile[1] == true && active_tensile[2] == true && active_MC[0] == false && active_MC[1] == false && active_MC[2] == false && active_MC[3] == true && active_MC[4] == false && active_MC[5] == false)
+  {
+    act[1] = act[2] = act[6] = true;
+    return;
+  }
+
+  // tensile = face, MC=tip (two possibilities)
+  if (active_tensile[0] == false && active_tensile[1] == false && active_tensile[2] == true && active_MC[0] == true && active_MC[1] == true && active_MC[2] == false && active_MC[3] == true && active_MC[4] == false && active_MC[5] == false)
+  {
+    act[2] = act[6] = true;
+    act[4] = true;
+    act[8] = true;
+    return;
+  }
+  if (active_tensile[0] == false && active_tensile[1] == false && active_tensile[2] == true && active_MC[0] == false && active_MC[1] == true && active_MC[2] == false && active_MC[3] == true && active_MC[4] == false && active_MC[5] == true)
+  {
+    act[2] = act[6] = true;
+    act[8] = true;
+    return;
+  }
+
+
+  // tensile = face, MC=face
+  if (active_tensile[0] == false && active_tensile[1] == false && active_tensile[2] == true && active_MC[0] == false && active_MC[1] == false && active_MC[2] == false && active_MC[3] == true && active_MC[4] == false && active_MC[5] == false)
+  {
+    act[1] = act[2] = act[6] = true;
+    return;
+  }
+
+
+  // tensile = face, MC=edge (two possibilites).
+  act[2] = true; // tensile face
+  act[3] = active_MC[0];
+  act[4] = active_MC[1];
+  act[5] = active_MC[2];
+  act[6] = active_MC[3];
+  act[7] = active_MC[4];
+  act[8] = active_MC[5];
+  return;
+
+}
+
 
 
 unsigned int

--- a/modules/tensor_mechanics/src/utils/MultiPlasticityRawComponentAssembler.C
+++ b/modules/tensor_mechanics/src/utils/MultiPlasticityRawComponentAssembler.C
@@ -305,10 +305,8 @@ MultiPlasticityRawComponentAssembler::buildActiveConstraintsJoint(const std::vec
   f_single[0] = f[0];
   _f[0]->activeConstraints(f_single, stress, intnl[0], Eijkl, active_tensile, returned_stress);
   _f[1]->yieldFunctionV(returned_stress, intnl[1], f_single);
-  //Moose::out << "prediction: tensile act = " << active_tensile[0] << "\n";
   if (f_single[0] <= _f[1]->_f_tol)
   {
-    //Moose::out << "tensile alone\n";
     act[0] = active_tensile[0];
     return;
   }
@@ -318,10 +316,8 @@ MultiPlasticityRawComponentAssembler::buildActiveConstraintsJoint(const std::vec
   f_single[0] = f[1];
   _f[1]->activeConstraints(f_single, stress, intnl[1], Eijkl, active_shear, returned_stress);
   _f[0]->yieldFunctionV(returned_stress, intnl[0], f_single);
-  //Moose::out << "prediction: shear act = " << active_shear[0] << "\n";
   if (f_single[0] <= _f[0]->_f_tol)
   {
-    //Moose::out << "shear alone\n";
     act[1] = active_shear[0];
     return;
   }
@@ -349,7 +345,6 @@ MultiPlasticityRawComponentAssembler::buildActiveConstraintsRock(const std::vect
   f_single[2] = f[2];
   _f[0]->activeConstraints(f_single, stress, intnl[0], Eijkl, active_tensile, returned_stress);
   _f[1]->yieldFunctionV(returned_stress, intnl[1], f_single);
-  //Moose::out << "prediction: tensile act = " << active_tensile[0] << active_tensile[1] << active_tensile[2] << "\n";
   if (f_single[0] <= _f[1]->_f_tol && f_single[1] <= _f[1]->_f_tol && f_single[2] <= _f[1]->_f_tol && f_single[3] <= _f[1]->_f_tol && f_single[4] <= _f[1]->_f_tol && f_single[5] <= _f[1]->_f_tol)
   {
     act[0] = active_tensile[0];
@@ -368,7 +363,6 @@ MultiPlasticityRawComponentAssembler::buildActiveConstraintsRock(const std::vect
   f_single[5] = f[8];
   _f[1]->activeConstraints(f_single, stress, intnl[1], Eijkl, active_MC, returned_stress);
   _f[0]->yieldFunctionV(returned_stress, intnl[0], f_single);
-  //Moose::out << "prediction: MC act = " << active_MC[0] << active_MC[1] << active_MC[2]  << active_MC[3] << active_MC[4] << active_MC[5] << "\n";
   if (f_single[0] <= _f[0]->_f_tol && f_single[1] <= _f[0]->_f_tol && f_single[2] <= _f[0]->_f_tol)
   {
     act[3] = active_MC[0];

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -763,6 +763,17 @@ RankTwoTensor::symmetricEigenvalues(std::vector<Real> & eigvals) const
 }
 
 void
+RankTwoTensor::symmetricEigenvaluesEigenvectors(std::vector<Real> & eigvals, RankTwoTensor & eigvecs) const
+{
+  std::vector<PetscScalar> a;
+  syev("V", eigvals, a);
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      eigvecs(j, i) = a[i*N + j];
+}
+
+void
 RankTwoTensor::dsymmetricEigenvalues(std::vector<Real> & eigvals, std::vector<RankTwoTensor> & deigvals) const
 {
   deigvals.resize(N);

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -114,7 +114,6 @@ RankTwoTensor::fillFromInputVector(const std::vector<Real> & input)
 {
   if (input.size() == 6)
   {
-    // Moose::out << "Rank 2 tensor input size =" << input.size() << std::endl;
     _vals[0][0] = input[0]; //S11
     _vals[1][1] = input[1]; //S22
     _vals[2][2] = input[2]; //S33
@@ -124,7 +123,6 @@ RankTwoTensor::fillFromInputVector(const std::vector<Real> & input)
   }
   else if (input.size() == 9)
   {
-    // Moose::out << "Rank 2 tensor input size =" << input.size() << std::endl;
     _vals[0][0] = input[0]; //S11
     _vals[1][0] = input[1]; //S21
     _vals[2][0] = input[2]; //S31

--- a/modules/tensor_mechanics/tests/mohr_coulomb/planar1.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/planar1.i
@@ -211,6 +211,7 @@
     friction_angle = phi
     dilation_angle = psi
     yield_function_tolerance = 1E-3
+    shift = 1E-4
     internal_constraint_tolerance = 1E-9
   [../]
 []

--- a/modules/tensor_mechanics/tests/mohr_coulomb/planar3.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/planar3.i
@@ -209,6 +209,7 @@
     friction_angle = phi
     dilation_angle = psi
     yield_function_tolerance = 1E-8
+    shift = 1E-8
     internal_constraint_tolerance = 1E-9
   [../]
 []

--- a/modules/tensor_mechanics/tests/mohr_coulomb/random.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/random.i
@@ -6,12 +6,12 @@
   type = GeneratedMesh
   dim = 3
   nx = 1000
-  ny = 1234
+  ny = 125
   nz = 1
   xmin = 0
   xmax = 1000
   ymin = 0
-  ymax = 1234
+  ymax = 125
   zmin = 0
   zmax = 1
 []
@@ -82,6 +82,10 @@
     order = CONSTANT
     family = MONOMIAL
   [../]
+  [./iter]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
 []
 
 [AuxKernels]
@@ -90,6 +94,11 @@
     index = 0
     property = plastic_yield_function
     variable = yield_fcn
+  [../]
+  [./iter]
+    type = MaterialRealAux
+    property = plastic_NR_iterations
+    variable = iter
   [../]
 []
 
@@ -103,6 +112,11 @@
   [./should_be_zero]
     type = PlotFunction
     function = should_be_zero_fcn
+  [../]
+  [./av_iter]
+    type = ElementAverageValue
+    variable = iter
+    outputs = 'console'
   [../]
 []
 
@@ -136,7 +150,7 @@
     friction_angle = mc_phi
     dilation_angle = mc_psi
     mc_tip_smoother = 0.1E3
-    mc_edge_smoother = 10
+    mc_edge_smoother = 25
     yield_function_tolerance = 1E-3
     internal_constraint_tolerance = 1E-6
   [../]
@@ -150,7 +164,8 @@
     disp_y = disp_y
     disp_z = disp_z
     fill_method = symmetric_isotropic
-    C_ijkl = '0 1E7'
+    #C_ijkl = '0 1E7'
+    C_ijkl = '0.7E7 1E7'
     max_NR_iterations = 1000
     ep_plastic_tolerance = 1E-6
     min_stepsize = 1E-3

--- a/modules/tensor_mechanics/tests/mohr_coulomb/random_planar.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/random_planar.i
@@ -6,12 +6,12 @@
   type = GeneratedMesh
   dim = 3
   nx = 1000
-  ny = 1234
+  ny = 125
   nz = 1
   xmin = 0
   xmax = 1000
   ymin = 0
-  ymax = 1234
+  ymax = 125
   zmin = 0
   zmax = 1
 []
@@ -82,6 +82,10 @@
     order = CONSTANT
     family = MONOMIAL
   [../]
+  [./iter]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
 []
 
 [AuxKernels]
@@ -90,6 +94,11 @@
     index = 0
     property = plastic_yield_function
     variable = yield_fcn
+  [../]
+  [./iter]
+    type = MaterialRealAux
+    property = plastic_NR_iterations
+    variable = iter
   [../]
 []
 
@@ -103,6 +112,11 @@
   [./should_be_zero]
     type = PlotFunction
     function = should_be_zero_fcn
+  [../]
+  [./av_iter]
+    type = ElementAverageValue
+    variable = iter
+    outputs = 'console'
   [../]
 []
 
@@ -136,6 +150,7 @@
     friction_angle = phi
     dilation_angle = psi
     yield_function_tolerance = 1E-3
+    shift = 1E-3
     internal_constraint_tolerance = 1E-6
   [../]
 []
@@ -148,12 +163,13 @@
     disp_y = disp_y
     disp_z = disp_z
     fill_method = symmetric_isotropic
-    C_ijkl = '0 1E7'
-    max_NR_iterations = 100
+    #C_ijkl = '0 1E7'
+    C_ijkl = '0.7E7 1E7'
+    max_NR_iterations = 10
     ep_plastic_tolerance = 1E-6
     plastic_models = mc
     debug_fspb = 1
-    deactivation_scheme = safe_to_dumb
+    deactivation_scheme = optimized_to_dumb
     min_stepsize = 1
     max_stepsize_for_dumb = 1
   [../]

--- a/modules/tensor_mechanics/tests/mohr_coulomb/uni_axial2_planar.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/uni_axial2_planar.i
@@ -201,6 +201,7 @@
     friction_angle = fric
     dilation_angle = dil
     yield_function_tolerance = 1.0 # THIS IS HIGHER THAN THE SMOOTH CASE TO AVOID PRECISION-LOSS PROBLEMS!
+    shift = 1.0
     internal_constraint_tolerance = 1E-9
   [../]
 []

--- a/modules/tensor_mechanics/tests/mohr_coulomb/uni_axial3_planar.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/uni_axial3_planar.i
@@ -201,6 +201,7 @@
     friction_angle = fric
     dilation_angle = dil
     yield_function_tolerance = 1.0 # THIS IS HIGHER THAN THE SMOOTH CASE TO AVOID PRECISION-LOSS PROBLEMS!
+    shift =  1.0
     internal_constraint_tolerance = 1E-9
   [../]
 []

--- a/modules/tensor_mechanics/tests/multi/gold/paper3.csv
+++ b/modules/tensor_mechanics/tests/multi/gold/paper3.csv
@@ -1,0 +1,4 @@
+time,av_constr_added,av_iter,av_ld,av_linesearch
+0,0,0,0,0
+1,0.39583333333333,63.5625,0,0.47916666666667
+

--- a/modules/tensor_mechanics/tests/multi/gold/special_joint1.csv
+++ b/modules/tensor_mechanics/tests/multi/gold/special_joint1.csv
@@ -1,0 +1,4 @@
+time,av_constr_added,av_iter,av_ld,av_linesearch
+0,0,0,0,0
+1,0,0.861,0,0
+

--- a/modules/tensor_mechanics/tests/multi/gold/special_rock1.csv
+++ b/modules/tensor_mechanics/tests/multi/gold/special_rock1.csv
@@ -1,0 +1,4 @@
+time,av_constr_added,av_iter,av_ld,av_linesearch
+0,0,0,0,0
+1,0,1.278,0.276,0
+

--- a/modules/tensor_mechanics/tests/multi/paper1.i
+++ b/modules/tensor_mechanics/tests/multi/paper1.i
@@ -1,0 +1,309 @@
+# This runs the models mentioned in the first example of the Multi-Surface paper
+#
+# Plasticity models:
+# SimpleTester with a = 1 and b = 0 and strength = 1E9  (only does elasticity)
+# SimpleTester with a = 1 and b = 0 and strength = 0
+# SimpleTester with a = 1 and b = 0 and strength = 1E-3
+#
+# Lame lambda = 0 (Poisson=0).  Lame mu = 0.5E6
+#
+# A line of elements is perturbed randomly, and return to the yield surface at each quadpoint is checked
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1
+  ny = 125
+  nz = 1
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 125
+  zmin = 0
+  zmax = 1
+[]
+
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+  [../]
+[]
+
+
+[ICs]
+  [./x]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_x
+  [../]
+  [./y]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_y
+  [../]
+  [./z]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_z
+  [../]
+[]
+
+[BCs]
+  [./x]
+    type = FunctionPresetBC
+    variable = disp_x
+    boundary = 'front back'
+    function = '0'
+  [../]
+  [./y]
+    type = FunctionPresetBC
+    variable = disp_y
+    boundary = 'front back'
+    function = '0'
+  [../]
+  [./z]
+    type = FunctionPresetBC
+    variable = disp_z
+    boundary = 'front back'
+    function = '0'
+  [../]
+[]
+
+[AuxVariables]
+  [./stress_xx]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_zz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./linesearch]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./ld]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./constr_added]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./iter]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./stress_xx]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xx
+    index_i = 0
+    index_j = 0
+  [../]
+  [./stress_xy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xy
+    index_i = 0
+    index_j = 1
+  [../]
+  [./stress_xz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xz
+    index_i = 0
+    index_j = 2
+  [../]
+  [./stress_yy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yy
+    index_i = 1
+    index_j = 1
+  [../]
+  [./stress_yz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yz
+    index_i = 1
+    index_j = 2
+  [../]
+  [./stress_zz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_zz
+    index_i = 2
+    index_j = 2
+  [../]
+  [./linesearch]
+    type = MaterialRealAux
+    property = plastic_linesearch_needed
+    variable = linesearch
+  [../]
+  [./ld]
+    type = MaterialRealAux
+    property = plastic_linear_dependence_encountered
+    variable = ld
+  [../]
+  [./constr_added]
+    type = MaterialRealAux
+    property = plastic_constraints_added
+    variable = constr_added
+  [../]
+  [./iter]
+    type = MaterialRealAux
+    property = plastic_NR_iterations
+    variable = iter
+  [../]
+[]
+
+[Postprocessors]
+  [./max_iter]
+    type = ElementExtremeValue
+    variable = iter
+    outputs = console
+  [../]
+  [./av_linesearch]
+    type = ElementAverageValue
+    variable = linesearch
+    outputs = console
+  [../]
+  [./av_ld]
+    type = ElementAverageValue
+    variable = ld
+    outputs = console
+  [../]
+  [./av_constr_added]
+    type = ElementAverageValue
+    variable = constr_added
+    outputs = console
+  [../]
+  [./av_iter]
+    type = ElementAverageValue
+    variable = iter
+    outputs = console
+  [../]
+[]
+
+
+[UserObjects]
+  [./simple0]
+    type = TensorMechanicsPlasticSimpleTester
+    a = 1
+    b = 0
+    strength = 1E9
+    yield_function_tolerance = 1.0E-6
+    internal_constraint_tolerance = 1.0E-6
+  [../]
+  [./simple1]
+    type = TensorMechanicsPlasticSimpleTester
+    a = 1
+    b = 0
+    strength = 0
+    yield_function_tolerance = 1.0E-6
+    internal_constraint_tolerance = 1.0E-6
+  [../]
+  [./simple2]
+    type = TensorMechanicsPlasticSimpleTester
+    a = 1
+    b = 0
+    strength = 1E-3
+    yield_function_tolerance = 1.0E-6
+    internal_constraint_tolerance = 1.0E-6
+  [../]
+[]
+
+[Materials]
+  active = 'single'
+  [./elastic_model]
+    type = FiniteStrainMultiPlasticity
+    block = 0
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+    fill_method = symmetric_isotropic
+    C_ijkl = '0 0.5E6'
+    ep_plastic_tolerance = 1E-7
+    plastic_models = 'simple0'
+  [../]
+  [./single]
+    type = FiniteStrainMultiPlasticity
+    block = 0
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+    fill_method = symmetric_isotropic
+    C_ijkl = '0 0.5E6'
+    ep_plastic_tolerance = 1E-7
+    plastic_models = 'simple1'
+  [../]
+  [./double]
+    type = FiniteStrainMultiPlasticity
+    block = 0
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+    fill_method = symmetric_isotropic
+    C_ijkl = '0 0.5E6'
+    ep_plastic_tolerance = 1E-7
+    plastic_models = 'simple1 simple2'
+  [../]
+[]
+
+
+[Executioner]
+  end_time = 1
+  dt = 1
+  type = Transient
+[]
+
+
+[Outputs]
+  file_base = paper1
+  exodus = false
+  output_on = 'initial timestep_end'
+  [./console]
+    type = Console
+    perf_log = true
+    linear_residuals = false
+  [../]
+  [./csv]
+    type = CSV
+    interval = 1
+  [../]
+[]

--- a/modules/tensor_mechanics/tests/multi/paper3.i
+++ b/modules/tensor_mechanics/tests/multi/paper3.i
@@ -1,0 +1,444 @@
+# This runs the third example models described in the 'MultiSurface' plasticity paper
+# Just change the deactivation_scheme
+#
+# Plasticity models:
+# Mohr-Coulomb with cohesion = 40MPa, friction angle = 35deg, dilation angle = 5deg
+# Tensile with strength = 1MPa
+# WeakPlaneTensile with strength = 1000Pa
+# WeakPlaneShear with cohesion = 0.1MPa and friction angle = 25, dilation angle = 5deg
+#
+# Lame lambda = 1.2GPa.  Lame mu = 1.2GPa (Young = 3GPa, poisson = 0.5)
+#
+# A line of elements is perturbed randomly, and return to the yield surface at each quadpoint is checked
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1000
+  ny = 125
+  nz = 1
+  xmin = 0
+  xmax = 1000
+  ymin = 0
+  ymax = 125
+  zmin = 0
+  zmax = 1
+[]
+
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+  [../]
+[]
+
+
+[ICs]
+  [./x]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_x
+  [../]
+  [./y]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_y
+  [../]
+  [./z]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_z
+  [../]
+[]
+
+[BCs]
+  [./x]
+    type = FunctionPresetBC
+    variable = disp_x
+    boundary = 'front back'
+    function = '0'
+  [../]
+  [./y]
+    type = FunctionPresetBC
+    variable = disp_y
+    boundary = 'front back'
+    function = '0'
+  [../]
+  [./z]
+    type = FunctionPresetBC
+    variable = disp_z
+    boundary = 'front back'
+    function = '0'
+  [../]
+[]
+
+[AuxVariables]
+  [./stress_xx]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_zz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./linesearch]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./ld]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./constr_added]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./iter]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./stress_xx]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xx
+    index_i = 0
+    index_j = 0
+  [../]
+  [./stress_xy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xy
+    index_i = 0
+    index_j = 1
+  [../]
+  [./stress_xz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xz
+    index_i = 0
+    index_j = 2
+  [../]
+  [./stress_yy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yy
+    index_i = 1
+    index_j = 1
+  [../]
+  [./stress_yz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yz
+    index_i = 1
+    index_j = 2
+  [../]
+  [./stress_zz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_zz
+    index_i = 2
+    index_j = 2
+  [../]
+  [./linesearch]
+    type = MaterialRealAux
+    property = plastic_linesearch_needed
+    variable = linesearch
+  [../]
+  [./ld]
+    type = MaterialRealAux
+    property = plastic_linear_dependence_encountered
+    variable = ld
+  [../]
+  [./constr_added]
+    type = MaterialRealAux
+    property = plastic_constraints_added
+    variable = constr_added
+  [../]
+  [./iter]
+    type = MaterialRealAux
+    property = plastic_NR_iterations
+    variable = iter
+  [../]
+[]
+
+[Postprocessors]
+  [./max_iter]
+    type = ElementExtremeValue
+    variable = iter
+    outputs = console
+  [../]
+  [./av_iter]
+    type = ElementAverageValue
+    variable = iter
+    outputs = 'console csv'
+  [../]
+  [./av_linesearch]
+    type = ElementAverageValue
+    variable = linesearch
+    outputs = 'console csv'
+  [../]
+  [./av_ld]
+    type = ElementAverageValue
+    variable = ld
+    outputs = 'console csv'
+  [../]
+  [./av_constr_added]
+    type = ElementAverageValue
+    variable = constr_added
+    outputs = 'console csv'
+  [../]
+[]
+
+[UserObjects]
+  [./mc_coh]
+    type = TensorMechanicsHardeningConstant
+    value = 4E7
+  [../]
+  [./mc_phi]
+    type = TensorMechanicsHardeningConstant
+    value = 35
+    convert_to_radians = true
+  [../]
+  [./mc_psi]
+    type = TensorMechanicsHardeningConstant
+    value = 5
+    convert_to_radians = true
+  [../]
+  [./mc]
+    type = TensorMechanicsPlasticMohrCoulombMulti
+    cohesion = mc_coh
+    friction_angle = mc_phi
+    dilation_angle = mc_psi
+    yield_function_tolerance = 1.0
+    shift = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+  [./mc_smooth]
+    type = TensorMechanicsPlasticMohrCoulomb
+    cohesion = mc_coh
+    friction_angle = mc_phi
+    dilation_angle = mc_psi
+    mc_tip_smoother = 4E6
+    yield_function_tolerance = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+
+  [./ts]
+    type = TensorMechanicsHardeningConstant
+    value = 1E6
+  [../]
+  [./tensile]
+    type = TensorMechanicsPlasticTensileMulti
+    tensile_strength = ts
+    yield_function_tolerance = 1.0
+    shift = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+  [./tensile_smooth]
+    type = TensorMechanicsPlasticTensile
+    tensile_strength = ts
+    tensile_tip_smoother = 1E5
+    yield_function_tolerance = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+
+  [./wpt_str]
+    type = TensorMechanicsHardeningConstant
+    value = 1.0E3
+  [../]
+  [./wpt]
+    type = TensorMechanicsPlasticWeakPlaneTensile
+    tensile_strength = wpt_str
+    yield_function_tolerance = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+
+  [./wps_c]
+    type = TensorMechanicsHardeningConstant
+    value = 1.0E5
+  [../]
+  [./wps_tan_phi]
+    type = TensorMechanicsHardeningConstant
+    value = 0.466
+  [../]
+  [./wps_tan_psi]
+    type = TensorMechanicsHardeningConstant
+    value = 0.087
+  [../]
+  [./wps]
+    type = TensorMechanicsPlasticWeakPlaneShear
+    cohesion = wps_c
+    tan_friction_angle = wps_tan_phi
+    tan_dilation_angle = wps_tan_psi
+    smoother = 1.0E4
+    yield_function_tolerance = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+[]
+
+[Materials]
+  [./multi]
+    type = FiniteStrainMultiPlasticity
+    block = 0
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+    fill_method = symmetric_isotropic
+    C_ijkl = '1.2E9 1.2E9'
+    ep_plastic_tolerance = 1E-7
+
+    plastic_models = 'tensile_smooth mc_smooth wpt wps'
+    #
+    # following is for optimized_to_safe_to_dumb
+    # with min_stepsize = 1E-5 and max_stepsize_for_dumb = 1E-5
+    # max_NR time(s) timestepcuts mintimestep
+    # 100    26.98   3024         0.00263
+    # 50     25.75   3045         0.00263
+    # 40     25.57   3057         0.00263
+    # 30     26.85   3147         0.00263
+    # 20     27.87   3549         0.00039
+    # 15     27.51   4188         0.00039
+    # 10     27.7    5793         0.00039
+    #
+    # following is for safe_to_dumb
+    # with min_stepsize = 1E-5 and max_stepsize_for_dumb = 1E-5
+    # max_NR time(s) timestepcuts mintimestep
+    # 100    28.19   1794         0.00195
+    # 50     24.66   1848         0.00195
+    # 40     24.36   1971         0.00195
+    # 30     24.20   2169         0.00195
+    # 20     25.82   3207         0.00195
+    # 15     31.16   5196         0.00195
+    # 10     30.68   8733         0.00195
+    # for ten-times bigger system (10k quadpoints)
+    # 30     207.04   19077         0.00175
+    #
+    # following is for safe_to_dumb
+    # with min_stepsize = 1E-5 and max_stepsize_for_dumb = 1E-2
+    # max_NR time(s) timestepcuts mintimestep
+    # 100    28.34   1794         0.00195
+    # 50     25.00   1845         0.00195
+    # 40     25.67   1968         0.00195
+    # 30     24.50   2166         0.00195
+    # 20     27.40   3240         0.00195
+    # 15     35.67   5394         0.00195
+    # 10     37.60   9195         0.00195
+    #
+    # following is for safe_to_dumb
+    # with min_stepsize = 1E-5 and max_stepsize_for_dumb = 1
+    # max_NR time(s) timestepcuts mintimestep
+    # 100    47.07   1077         0.00195
+    # 50     42.31   1095         0.00195
+    # 40     41.44   1113         0.00195
+    # 30     45.08   1260         0.00195
+    # 20     50.71   1629         0.00195
+    # 15     61.05   2430         0.00195
+    # 10     79.68   4677         0.00195
+    #
+    # following is for optimized
+    # with min_stepsize = 1E-6 and max_stepsize_for_dumb = 1E-6
+    # max_NR time(s) timestepcuts mintimestep
+    # 100    19.95   6114         0.00263
+    # 50     19.94   6114         0.00263
+    # 40     18.72   6114         3.14866e-05
+    # 30     18.58   6213         3.14866e-05
+    # 20     19.18   6213         3.14866e-05
+    # 15     18.53   6381         3.14866e-05
+    # 10     18.79   7308         3.14866e-05
+    # for ten-times bigger system (10k quadpoints)
+    # 30     150.27   51129         1.52588e-05
+    # for hundred-times bigger system (100k quadpoints)
+    # 30     1440.45  484776         ??
+    #
+    # following is for optimized_to_dumb
+    # with min_stepsize = 1E-6 and max_stepsize_for_dumb = 1
+    # max_NR time(s) timestepcuts mintimestep
+    # 100    48.52   978          0.00675
+    # 50     43.57   996          0.00675
+    # 40     41.40   1014         0.00675
+    # 30     46.58   1161         0.00675
+    # 20     54.31   1524         0.00675
+    # 15     62.19   2256         0.00675
+    # 10     75.79   4146         0.00390625
+    #
+    # following is for optimized_to_dumb
+    # with min_stepsize = 1E-6 and max_stepsize_for_dumb = 1E-2
+    # max_NR time(s) timestepcuts mintimestep
+    # 100    42.00   7074
+    # 50     40.83   7074
+    # 40     42.41   7074
+    # 30     39.75   7083
+    # 20     37.52   7176
+    # 15     37.77   7347
+    # 10     40.92   8436
+    #
+    max_NR_iterations = 30
+    specialIC = 'none'
+    deactivation_scheme = 'optimized'
+    min_stepsize = 1E-6
+    max_stepsize_for_dumb = 1E-2
+
+    debug_fspb = 1
+    debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
+    debug_jac_at_pm = '1 1 1 1'
+    debug_jac_at_intnl = '1 1 1 1'
+    debug_stress_change = 1E1
+    debug_pm_change = '1E-6 1E-6 1E-6 1E-6'
+    debug_intnl_change = '1E-6 1E-6 1E-6 1E-6'
+  [../]
+[]
+
+
+[Executioner]
+  end_time = 1
+  dt = 1
+  type = Transient
+[]
+
+
+[Outputs]
+  file_base = paper3
+  exodus = false
+  output_on = 'initial timestep_end'
+  [./console]
+    type = Console
+    perf_log = true
+  [../]
+  [./csv]
+    type = CSV
+    interval = 1
+  [../]
+[]

--- a/modules/tensor_mechanics/tests/multi/special_joint1.i
+++ b/modules/tensor_mechanics/tests/multi/special_joint1.i
@@ -1,0 +1,304 @@
+# Plasticity models:
+# WeakPlaneTensile with strength = 1000Pa
+# WeakPlaneShear with cohesion = 0.1MPa and friction angle = 25
+#
+# Lame lambda = 1GPa.  Lame mu = 1.3GPa
+#
+# A line of elements is perturbed randomly, and return to the yield surface at each quadpoint is checked
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1000
+  ny = 125
+  nz = 1
+  xmin = 0
+  xmax = 1000
+  ymin = 0
+  ymax = 125
+  zmin = 0
+  zmax = 1
+[]
+
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+  [../]
+[]
+
+
+[ICs]
+  [./x]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_x
+  [../]
+  [./y]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_y
+  [../]
+  [./z]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_z
+  [../]
+[]
+
+[BCs]
+  [./x]
+    type = FunctionPresetBC
+    variable = disp_x
+    boundary = 'front back'
+    function = '0'
+  [../]
+  [./y]
+    type = FunctionPresetBC
+    variable = disp_y
+    boundary = 'front back'
+    function = '0'
+  [../]
+  [./z]
+    type = FunctionPresetBC
+    variable = disp_z
+    boundary = 'front back'
+    function = '0'
+  [../]
+[]
+
+[AuxVariables]
+  [./stress_xx]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_zz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./linesearch]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./ld]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./constr_added]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./iter]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./stress_xx]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xx
+    index_i = 0
+    index_j = 0
+  [../]
+  [./stress_xy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xy
+    index_i = 0
+    index_j = 1
+  [../]
+  [./stress_xz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xz
+    index_i = 0
+    index_j = 2
+  [../]
+  [./stress_yy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yy
+    index_i = 1
+    index_j = 1
+  [../]
+  [./stress_yz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yz
+    index_i = 1
+    index_j = 2
+  [../]
+  [./stress_zz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_zz
+    index_i = 2
+    index_j = 2
+  [../]
+  [./linesearch]
+    type = MaterialRealAux
+    property = plastic_linesearch_needed
+    variable = linesearch
+  [../]
+  [./ld]
+    type = MaterialRealAux
+    property = plastic_linear_dependence_encountered
+    variable = ld
+  [../]
+  [./constr_added]
+    type = MaterialRealAux
+    property = plastic_constraints_added
+    variable = constr_added
+  [../]
+  [./iter]
+    type = MaterialRealAux
+    property = plastic_NR_iterations
+    variable = iter
+  [../]
+[]
+
+[Postprocessors]
+  [./max_iter]
+    type = ElementExtremeValue
+    variable = iter
+    outputs = console
+  [../]
+  [./av_linesearch]
+    type = ElementAverageValue
+    variable = linesearch
+    outputs = 'console csv'
+  [../]
+  [./av_ld]
+    type = ElementAverageValue
+    variable = ld
+    outputs = 'console csv'
+  [../]
+  [./av_constr_added]
+    type = ElementAverageValue
+    variable = constr_added
+    outputs = 'console csv'
+  [../]
+  [./av_iter]
+    type = ElementAverageValue
+    variable = iter
+    outputs = 'console csv'
+  [../]
+[]
+
+[UserObjects]
+  [./wpt_str]
+    type = TensorMechanicsHardeningConstant
+    value = 1000
+  [../]
+  [./wpt]
+    type = TensorMechanicsPlasticWeakPlaneTensile
+    tensile_strength = wpt_str
+    yield_function_tolerance = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+
+  [./wps_c]
+    type = TensorMechanicsHardeningConstant
+    value = 1.0E5
+  [../]
+  [./wps_tan_phi]
+    type = TensorMechanicsHardeningConstant
+    value = 0.466
+  [../]
+  [./wps_tan_psi]
+    type = TensorMechanicsHardeningConstant
+    value = 0.087
+  [../]
+  [./wps]
+    type = TensorMechanicsPlasticWeakPlaneShear
+    cohesion = wps_c
+    tan_friction_angle = wps_tan_phi
+    tan_dilation_angle = wps_tan_psi
+    smoother = 0
+    yield_function_tolerance = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+[]
+
+[Materials]
+  [./multi]
+    type = FiniteStrainMultiPlasticity
+    block = 0
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+    fill_method = symmetric_isotropic
+    C_ijkl = '1.0E9 1.3E9'
+    ep_plastic_tolerance = 1E-7
+
+    plastic_models = 'wpt wps'
+    max_NR_iterations = 5
+    specialIC = 'joint'
+    deactivation_scheme = 'safe'
+    min_stepsize = 1
+    max_stepsize_for_dumb = 1
+
+    debug_fspb = 1
+    debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
+    debug_jac_at_pm = '1 1 1 1'
+    debug_jac_at_intnl = '1 1 1 1'
+    debug_stress_change = 1E1
+    debug_pm_change = '1E-6 1E-6 1E-6 1E-6'
+    debug_intnl_change = '1E-6 1E-6 1E-6 1E-6'
+  [../]
+[]
+
+
+[Executioner]
+  end_time = 1
+  dt = 1
+  type = Transient
+[]
+
+
+[Outputs]
+  file_base = special_joint1
+  exodus = false
+  output_on = 'initial timestep_end'
+  [./console]
+    type = Console
+    perf_log = true
+    linear_residuals = false
+  [../]
+  [./csv]
+    type = CSV
+    interval = 1
+  [../]
+[]

--- a/modules/tensor_mechanics/tests/multi/special_rock1.i
+++ b/modules/tensor_mechanics/tests/multi/special_rock1.i
@@ -1,0 +1,330 @@
+# Plasticity models:
+# Mohr-Coulomb with cohesion = 40MPa, friction angle = 35deg, dilation angle = 5deg
+# Tensile with strength = 1MPa
+#
+# Lame lambda = 1GPa.  Lame mu = 1.3GPa
+#
+# A line of elements is perturbed randomly, and return to the yield surface at each quadpoint is checked
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1000
+  ny = 125
+  nz = 1
+  xmin = 0
+  xmax = 1000
+  ymin = 0
+  ymax = 125
+  zmin = 0
+  zmax = 1
+[]
+
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+  [../]
+[]
+
+
+[ICs]
+  [./x]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_x
+  [../]
+  [./y]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_y
+  [../]
+  [./z]
+    type = RandomIC
+    min = -0.1
+    max = 0.1
+    variable = disp_z
+  [../]
+[]
+
+[BCs]
+  [./x]
+    type = FunctionPresetBC
+    variable = disp_x
+    boundary = 'front back'
+    function = '0'
+  [../]
+  [./y]
+    type = FunctionPresetBC
+    variable = disp_y
+    boundary = 'front back'
+    function = '0'
+  [../]
+  [./z]
+    type = FunctionPresetBC
+    variable = disp_z
+    boundary = 'front back'
+    function = '0'
+  [../]
+[]
+
+[AuxVariables]
+  [./stress_xx]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_zz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./linesearch]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./ld]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./constr_added]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./iter]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./stress_xx]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xx
+    index_i = 0
+    index_j = 0
+  [../]
+  [./stress_xy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xy
+    index_i = 0
+    index_j = 1
+  [../]
+  [./stress_xz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xz
+    index_i = 0
+    index_j = 2
+  [../]
+  [./stress_yy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yy
+    index_i = 1
+    index_j = 1
+  [../]
+  [./stress_yz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yz
+    index_i = 1
+    index_j = 2
+  [../]
+  [./stress_zz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_zz
+    index_i = 2
+    index_j = 2
+  [../]
+  [./linesearch]
+    type = MaterialRealAux
+    property = plastic_linesearch_needed
+    variable = linesearch
+  [../]
+  [./ld]
+    type = MaterialRealAux
+    property = plastic_linear_dependence_encountered
+    variable = ld
+  [../]
+  [./constr_added]
+    type = MaterialRealAux
+    property = plastic_constraints_added
+    variable = constr_added
+  [../]
+  [./iter]
+    type = MaterialRealAux
+    property = plastic_NR_iterations
+    variable = iter
+  [../]
+[]
+
+[Postprocessors]
+  [./max_iter]
+    type = ElementExtremeValue
+    variable = iter
+    outputs = console
+  [../]
+  [./av_linesearch]
+    type = ElementAverageValue
+    variable = linesearch
+    outputs = 'console csv'
+  [../]
+  [./av_ld]
+    type = ElementAverageValue
+    variable = ld
+    outputs = 'console csv'
+  [../]
+  [./av_constr_added]
+    type = ElementAverageValue
+    variable = constr_added
+    outputs = 'console csv'
+  [../]
+  [./av_iter]
+    type = ElementAverageValue
+    variable = iter
+    outputs = 'console csv'
+  [../]
+[]
+
+
+[UserObjects]
+  [./mc_coh]
+    type = TensorMechanicsHardeningConstant
+    value = 4E7
+  [../]
+  [./mc_phi]
+    type = TensorMechanicsHardeningConstant
+    value = 35
+    convert_to_radians = true
+  [../]
+  [./mc_psi]
+    type = TensorMechanicsHardeningConstant
+    value = 5
+    convert_to_radians = true
+  [../]
+  [./mc]
+    type = TensorMechanicsPlasticMohrCoulombMulti
+    cohesion = mc_coh
+    friction_angle = mc_phi
+    dilation_angle = mc_psi
+    yield_function_tolerance = 1.0
+    shift = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+  [./mc_smooth]
+    type = TensorMechanicsPlasticMohrCoulomb
+    cohesion = mc_coh
+    friction_angle = mc_phi
+    dilation_angle = mc_psi
+    mc_tip_smoother = 4E6
+    yield_function_tolerance = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+
+  [./ts]
+    type = TensorMechanicsHardeningConstant
+    value = 1E6
+  [../]
+  [./tensile]
+    type = TensorMechanicsPlasticTensileMulti
+    tensile_strength = ts
+    yield_function_tolerance = 1.0
+    shift = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+  [./tensile_smooth]
+    type = TensorMechanicsPlasticTensile
+    tensile_strength = ts
+    tensile_tip_smoother = 1E5
+    yield_function_tolerance = 1.0
+    internal_constraint_tolerance = 1.0E-7
+  [../]
+[]
+
+[Materials]
+  [./multi]
+    type = FiniteStrainMultiPlasticity
+    block = 0
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
+    fill_method = symmetric_isotropic
+    C_ijkl = '1.0E9 1.3E9'
+    ep_plastic_tolerance = 1E-7
+
+    #plastic_models = 'tensile_smooth mc_smooth'
+    #max_NR_iterations = 30
+    #specialIC = 'none'
+    #deactivation_scheme = 'optimized_to_dumb'
+    #min_stepsize = 1E-5
+    #max_stepsize_for_dumb = 1E-5
+
+    plastic_models = 'tensile mc'
+    max_NR_iterations = 5
+    specialIC = 'rock'
+    deactivation_scheme = 'safe'
+    min_stepsize = 1
+    max_stepsize_for_dumb = 1
+
+    debug_fspb = 1
+    debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
+    debug_jac_at_pm = '1 1 1 1'
+    debug_jac_at_intnl = '1 1 1 1'
+    debug_stress_change = 1E1
+    debug_pm_change = '1E-6 1E-6 1E-6 1E-6'
+    debug_intnl_change = '1E-6 1E-6 1E-6 1E-6'
+  [../]
+[]
+
+
+[Executioner]
+  end_time = 1
+  dt = 1
+  type = Transient
+[]
+
+
+[Outputs]
+  file_base = special_rock1
+  exodus = false
+  output_on = 'initial timestep_end'
+  [./console]
+    type = Console
+    perf_log = true
+  [../]
+  [./csv]
+    type = CSV
+    interval = 1
+  [../]
+[]

--- a/modules/tensor_mechanics/tests/multi/tests
+++ b/modules/tensor_mechanics/tests/multi/tests
@@ -255,5 +255,31 @@
     heavy = true
     cli_args = '--no-trap-fpe Mesh/nx=20 Mesh/ny=10 Mesh/xmax=20 Mesh/ymax=10'
   [../]
+
+  [./paper3]
+    type = CSVDiff
+    input = 'paper3.i'
+    csvdiff = 'paper3.csv'
+    rel_err = 1.0E-4
+    abs_zero = 1.0E-4
+    cli_args = '--no-trap-fpe Mesh/nx=1 Mesh/ny=12 Mesh/xmax=1 Mesh/ymax=12'
+  [../]
+
+  [./special_rock1]
+    type = CSVDiff
+    input = 'special_rock1.i'
+    csvdiff = 'special_rock1.csv'
+    rel_err = 1.0E-4
+    abs_zero = 1.0E-4
+    cli_args = '--no-trap-fpe Mesh/nx=1 Mesh/ny=125 Mesh/xmax=1 Mesh/ymax=125'
+  [../]
+  [./special_joint1]
+    type = CSVDiff
+    input = 'special_joint1.i'
+    csvdiff = 'special_joint1.csv'
+    rel_err = 1.0E-4
+    abs_zero = 1.0E-4
+    cli_args = '--no-trap-fpe Mesh/nx=1 Mesh/ny=125 Mesh/xmax=1 Mesh/ymax=125'
+  [../]
     
 []

--- a/modules/tensor_mechanics/tests/tensile/random_planar.i
+++ b/modules/tensor_mechanics/tests/tensile/random_planar.i
@@ -9,12 +9,12 @@
   type = GeneratedMesh
   dim = 3
   nx = 1000
-  ny = 1234
+  ny = 1250
   nz = 1
   xmin = 0
   xmax = 1000
   ymin = 0
-  ymax = 1234
+  ymax = 1250
   zmin = 0
   zmax = 1
 []
@@ -272,6 +272,7 @@
     type = TensorMechanicsPlasticTensileMulti
     tensile_strength = hard
     yield_function_tolerance = 1.0E-1
+    shift = 1.0E-1
     internal_constraint_tolerance = 1.0E-7
   [../]
 []
@@ -285,11 +286,13 @@
     disp_z = disp_z
     fill_method = symmetric_isotropic
     C_ijkl = '1E9 1.3E9'
+    #C_ijkl = '0 1.3E9'
+    deactivation_scheme = 'safe_to_dumb'
     ep_plastic_tolerance = 1E-7
     plastic_models = 'tensile'
-    max_NR_iterations = 20
-    min_stepsize = 1E-4
-    max_stepsize_for_dumb = 1E-3
+    max_NR_iterations = 5
+    min_stepsize = 1E-3
+    max_stepsize_for_dumb = 1
     debug_fspb = 1
     debug_jac_at_stress = '10 0 0 0 10 0 0 0 10'
     debug_jac_at_pm = '1 1 1'


### PR DESCRIPTION
The coder can now designate certain combinations of plasticity models as 'special'. These combinations can then be given special algorithms to determine the set of initially active constraints. This can help markedly in the convergence of the return-map algorithm, just like choosing a good initial condition for a Newton-Raphson procedure.
