### PR TITLE
Error checking for MooseParsedFunction parameters

### DIFF
--- a/framework/include/functions/MooseParsedFunctionBase.h
+++ b/framework/include/functions/MooseParsedFunctionBase.h
@@ -73,21 +73,6 @@ protected:
 
   /// Values passed by the user, they may be Reals for Postprocessors
   const std::vector<std::string> _vals;
-
-private:
-  /**
-   * Verifies that the 'vars' variable exists and that pre-defined variables are not used (i.e., x,y,z,t)
-   * @param parameters InputParameters object relevant to this function
-   * @return The variables (i.e., vars)
-   */
-  const std::vector<std::string> verifyVars(const InputParameters & parameters);
-
-  /**
-   * Verifies that the 'vals' variable exists
-   * @param parameters InputParameters object relevant to this function
-   * @return The values (i.e., vals)
-   */
-  const std::vector<std::string> verifyVals(const InputParameters & parameters);
 };
 
 #endif // MOOSEPARSEDFUNCTIONBASE_H

--- a/framework/src/functions/MooseParsedFunctionBase.C
+++ b/framework/src/functions/MooseParsedFunctionBase.C
@@ -34,7 +34,7 @@ InputParameters validParams<MooseParsedFunctionBase>()
 {
   InputParameters params = emptyInputParameters();
   params.addParam<std::vector<std::string> >("vars", "The constant variables (excluding t,x,y,z) in the forcing function.");
-  params.addParam<std::vector<std::string> >("vals", "The initial values of the variables (optional)");
+  params.addParam<std::vector<std::string> >("vals", "Constant numeric values or postprocessor names for vars.");
   return params;
 }
 
@@ -43,6 +43,8 @@ MooseParsedFunctionBase::MooseParsedFunctionBase(const std::string & /*name*/, I
     _vars(verifyVars(parameters)),
     _vals(verifyVals(parameters))
 {
+  if (_vars.size() != _vals.size())
+    mooseError("Number of vars must match the number of vals for a MooseParsedFunction!");
 }
 
 MooseParsedFunctionBase::~MooseParsedFunctionBase()

--- a/framework/src/functions/MooseParsedFunctionBase.C
+++ b/framework/src/functions/MooseParsedFunctionBase.C
@@ -40,11 +40,16 @@ InputParameters validParams<MooseParsedFunctionBase>()
 
 MooseParsedFunctionBase::MooseParsedFunctionBase(const std::string & /*name*/, InputParameters parameters) :
     _pfb_feproblem(*parameters.get<FEProblem *>("_fe_problem")),
-    _vars(verifyVars(parameters)),
-    _vals(verifyVals(parameters))
+    _vars(parameters.get<std::vector<std::string> >("vars")),
+    _vals(parameters.get<std::vector<std::string> >("vals"))
 {
   if (_vars.size() != _vals.size())
     mooseError("Number of vars must match the number of vals for a MooseParsedFunction!");
+
+  // Loop through the variables assigned by the user and give an error if x,y,z,t are used
+  for (unsigned int i = 0; i < _vars.size(); ++i)
+    if (_vars[i].find_first_of("xyzt") != std::string::npos && _vars[i].size() == 1)
+      mooseError("The variables \"x, y, z, and t\" in the ParsedFunction are pre-declared for use and must not be declared in \"vars\"");
 }
 
 MooseParsedFunctionBase::~MooseParsedFunctionBase()
@@ -60,34 +65,4 @@ MooseParsedFunctionBase::verifyFunction(const std::string & function_str)
 
   // Return the input equation (no error)
   return function_str;
-}
-
-const std::vector<std::string>
-MooseParsedFunctionBase::verifyVars(const InputParameters & parameters)
-{
-  // Test the vars is defined
-  if (!parameters.have_parameter<std::vector<std::string> >("vars"))
-      mooseError("An input of std::vector<std::string> named 'vars' must exist.");
-
-  // Get the 'vars' parameter
-  const std::vector<std::string> vars = parameters.get<std::vector<std::string> >("vars");
-
-  // Loop through the variables assigned by the user and give an error if x,y,z,t are used
-  for (unsigned int i=0; i < vars.size(); ++i)
-    if (vars[i].find_first_of("xyzt") != std::string::npos && vars[i].size() == 1)
-      mooseError("The variables \"x, y, z, and t\" in the ParsedFunction are pre-declared for use and must not be declared in \"vars\"");
-
-  // Return the variables (no error)
-  return vars;
-}
-
-const std::vector<std::string>
-MooseParsedFunctionBase::verifyVals(const InputParameters & parameters)
-{
-  // Test the vars is defined
-  if (!parameters.have_parameter<std::vector<std::string> >("vals"))
-      mooseError("An input of std::vector<std::string> named 'vals' must exist.");
-
-  // Return the 'vals' parameter
-  return parameters.get<std::vector<std::string> >("vals");
 }

--- a/test/tests/misc/check_error/bad_parsed_function_vars.i
+++ b/test/tests/misc/check_error/bad_parsed_function_vars.i
@@ -17,6 +17,7 @@
     type = ParsedFunction
     value = sin(y)
     vars = y        # <- This is a bad - you can't specify x, y, z, or t
+    vals = 0
   [../]
 []
 


### PR DESCRIPTION
This removes some IMO unnecessary runtime error checking for the existence of parameters (the default MOOSE error should be enough) and adds necessary error checking to ensure that vars and vals have the same length (at they have corresponding entries by design).
