### PR TITLE
Making sure that we have symmetry in computing depend UOs 

### DIFF
--- a/framework/src/executioners/Steady.C
+++ b/framework/src/executioners/Steady.C
@@ -92,6 +92,7 @@ Steady::execute()
     _problem.computeUserObjects(EXEC_TIMESTEP_BEGIN, UserObjectWarehouse::PRE_AUX);
     preSolve();
     _problem.timestepSetup();
+    _problem.computeAuxiliaryKernels(EXEC_TIMESTEP_BEGIN);
     _problem.computeUserObjects(EXEC_TIMESTEP_BEGIN, UserObjectWarehouse::POST_AUX);
     _problem.solve();
     postSolve();


### PR DESCRIPTION
This fixes the steady timestep begin case. I'm not aware of any tests or applications that would need this. This capability makes more sense in transient runs.

closes #4675
