### PR TITLE
Explicitly use template argument in initializer list.

### DIFF
--- a/modules/phase_field/src/materials/ParsedMaterial.C
+++ b/modules/phase_field/src/materials/ParsedMaterial.C
@@ -11,7 +11,7 @@ InputParameters validParams<ParsedMaterial>()
 
 ParsedMaterial::ParsedMaterial(const std::string & name,
                                InputParameters parameters) :
-    ParsedMaterialHelper(name, parameters, USE_MOOSE_NAMES),
+    ParsedMaterialHelper<FunctionMaterialBase>(name, parameters, USE_MOOSE_NAMES),
     ParsedMaterialBase(name, parameters)
 {
   // Build function


### PR DESCRIPTION
Intel issues a compiler error for this code while Clang and GCC accept it.  I'm not really sure who's correct, but this change gets the modules compiling with Intel so IMO it's worth it.

Refs #4549
