### PR TITLE
FunctionMaterialBase objects do the right thing automatically

### DIFF
--- a/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
@@ -24,6 +24,8 @@ public:
 protected:
   virtual void computeProperties();
 
+  virtual void functionsPostParse();
+
   void functionsDerivative();
   void functionsOptimize();
 

--- a/modules/phase_field/include/materials/ParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/ParsedMaterialHelper.h
@@ -38,6 +38,9 @@ public:
 protected:
   virtual void computeProperties();
 
+  // tasks to perform after parsing the primary function
+  virtual void functionsPostParse();
+
   // run FPOptimizer on the parsed function
   virtual void functionsOptimize();
 
@@ -257,6 +260,15 @@ void ParsedMaterialHelper<T>::functionParse(const std::string & function_express
 
   // create parameter passing buffer
   _func_params = new Real[this->_nargs + _nmat_props];
+
+  // perform next steps (either optimize or take derivatives and then optimize)
+  functionsPostParse();
+}
+
+template<class T>
+void ParsedMaterialHelper<T>::functionsPostParse()
+{
+  functionsOptimize();
 }
 
 template<class T>

--- a/modules/phase_field/include/materials/ParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/ParsedMaterialHelper.h
@@ -18,7 +18,7 @@ public:
 
   ParsedMaterialHelper(const std::string & name,
                        InputParameters parameters,
-                       VariableNameMappingMode map_mode = USE_PARAM_NAMES);
+                       VariableNameMappingMode map_mode);
 
   virtual ~ParsedMaterialHelper();
 

--- a/modules/phase_field/src/materials/DerivativeParsedMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterial.C
@@ -14,15 +14,9 @@ DerivativeParsedMaterial::DerivativeParsedMaterial(const std::string & name,
     DerivativeParsedMaterialHelper(name, parameters, USE_MOOSE_NAMES),
     ParsedMaterialBase(name, parameters)
 {
-  // Build function
+  // Build function, take derivatives, optimize
   functionParse(_function,
                 _constant_names, _constant_expressions,
                 _mat_prop_names,
                 _tol_names, _tol_values);
-
-  // Take derivatives
-  functionsDerivative();
-
-  // Optimize
-  functionsOptimize();
 }

--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -15,6 +15,12 @@ DerivativeParsedMaterialHelper::DerivativeParsedMaterialHelper(const std::string
 {
 }
 
+void DerivativeParsedMaterialHelper::functionsPostParse()
+{
+  functionsDerivative();
+  functionsOptimize();
+}
+
 void DerivativeParsedMaterialHelper::functionsDerivative()
 {
   unsigned int i, j, k;

--- a/modules/phase_field/src/materials/FunctionMaterialBase.C
+++ b/modules/phase_field/src/materials/FunctionMaterialBase.C
@@ -17,9 +17,6 @@ FunctionMaterialBase::FunctionMaterialBase(const std::string & name,
     _number_of_nl_variables(_fe_problem.getNonlinearSystem().nVariables()),
     _arg_index(_number_of_nl_variables)
 {
-  // loop counters
-  unsigned int i, j, k;
-
   // fetch names and numbers of all coupled variables
   _mapping_is_unique = true;
   for (std::set<std::string>::const_iterator it = _pars.coupledVarsBegin(); it != _pars.coupledVarsEnd(); ++it)

--- a/modules/phase_field/src/materials/FunctionMaterialBase.C
+++ b/modules/phase_field/src/materials/FunctionMaterialBase.C
@@ -60,5 +60,5 @@ FunctionMaterialBase::FunctionMaterialBase(const std::string & name,
 
   // check number of coupled variables
   if (_nargs == 0)
-    mooseError("Need at least one couple variable for Function Materials.");
+    mooseError("Need at least one coupled variable for Function Material " << name);
 }

--- a/modules/phase_field/src/materials/ParsedMaterial.C
+++ b/modules/phase_field/src/materials/ParsedMaterial.C
@@ -14,12 +14,9 @@ ParsedMaterial::ParsedMaterial(const std::string & name,
     ParsedMaterialHelper<FunctionMaterialBase>(name, parameters, USE_MOOSE_NAMES),
     ParsedMaterialBase(name, parameters)
 {
-  // Build function
+  // Build function and optimize
   functionParse(_function,
                 _constant_names, _constant_expressions,
                 _mat_prop_names,
                 _tol_names, _tol_values);
-
-  // Optimize
-  functionsOptimize();
 }


### PR DESCRIPTION
When `functionParse(...)` is called by a material derived from  `(Derivative)FunctionMaterialBase` it now automatically does the right things (such as taking derivatives and optimization). The user does not have to explicitly call the functionsDerivative method.

Closes #4713 
