### PR TITLE
Add ParsedODEKernel

### DIFF
--- a/examples/ex18_scalar_kernel/Makefile
+++ b/examples/ex18_scalar_kernel/Makefile
@@ -38,3 +38,4 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 
 test: all
 	$(call TEST_exodiff,ex18.i,out.e)
+	$(call TEST_exodiff,ex18_parsed.i,out.e)

--- a/examples/ex18_scalar_kernel/ex18_parsed.i
+++ b/examples/ex18_scalar_kernel/ex18_parsed.i
@@ -1,0 +1,138 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  nx = 10
+  ny = 10
+  elem_type = QUAD4
+[]
+
+[Functions]
+  # ODEs
+  [./exact_x_fn]
+    type = ParsedFunction
+    value = (-1/3)*exp(-t)+(4/3)*exp(5*t)
+  [../]
+[]
+
+[Variables]
+  [./diffused]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+
+  # ODE variables
+  [./x]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 1
+  [../]
+  [./y]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 2
+  [../]
+
+[]
+
+[Kernels]
+  [./td]
+    type = TimeDerivative
+    variable = diffused
+  [../]
+  [./diff]
+    type = Diffusion
+    variable = diffused
+  [../]
+[]
+
+[ScalarKernels]
+  [./td1]
+    type = ODETimeDerivative
+    variable = x
+  [../]
+  [./ode1]
+    type = ParsedODEKernel
+    function = '-3*x - 2*y'
+    variable = x
+    args = y
+  [../]
+
+  [./td2]
+    type = ODETimeDerivative
+    variable = y
+  [../]
+  [./ode2]
+    type = ParsedODEKernel
+    function = '-4*x - y'
+    variable = y
+    args = x
+  [../]
+[]
+
+
+[BCs]
+  [./left]
+    type = ScalarDirichletBC
+    variable = diffused
+    boundary = 1
+    scalar_var = x
+  [../]
+
+  [./right]
+    type = ScalarDirichletBC
+    variable = diffused
+    boundary = 3
+    scalar_var = y
+  [../]
+[]
+
+[Postprocessors]
+  # to print the values of x, y into a file so we can plot it
+  [./x]
+    type = ScalarVariable
+    variable = x
+    execute_on = timestep_end
+  [../]
+  [./y]
+    type = ScalarVariable
+    variable = y
+    execute_on = timestep_end
+  [../]
+
+  [./exact_x]
+    type = PlotFunction
+    function = exact_x_fn
+    execute_on = timestep_end
+  [../]
+  # measure the error from exact solution in L2 norm
+  [./l2err_x]
+    type = ScalarL2Error
+    variable = x
+    function = exact_x_fn
+  [../]
+[]
+
+
+[Executioner]
+  type = Transient
+  start_time = 0
+  dt = 0.01
+  num_steps = 10
+
+  #Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+
+[]
+
+[Outputs]
+  file_base = out
+  output_initial = true
+  exodus = true
+  print_linear_residuals = true
+  print_perf_log = true
+[]

--- a/examples/ex18_scalar_kernel/ex18_parsed.i
+++ b/examples/ex18_scalar_kernel/ex18_parsed.i
@@ -1,3 +1,13 @@
+#
+# Example 18 modified to use parsed ODE kernels.
+#
+# The ParsedODEKernel takes function expressions in the input file and computes
+# Jacobian entries via automatic differentiation. It allows for rapid development
+# of new models without the need for code recompilation.
+#
+# This input file should produce the exact same result as ex18.i
+#
+
 [Mesh]
   type = GeneratedMesh
   dim = 2
@@ -54,6 +64,15 @@
     type = ODETimeDerivative
     variable = x
   [../]
+
+  #
+  # This parsed expression ODE Kernel behaves exactly as the ImplicitODEx kernel
+  # in the main example. Checkout ImplicitODEx::computeQpResidual() in the
+  # source code file ImplicitODEx.C to see the matching residual function.
+  #
+  # The ParsedODEKernel automaticaly generates the On- and Off-Diagonal Jacobian
+  # entries.
+  #
   [./ode1]
     type = ParsedODEKernel
     function = '-3*x - 2*y'
@@ -65,6 +84,11 @@
     type = ODETimeDerivative
     variable = y
   [../]
+
+  #
+  # This parsed expression ODE Kernel behaves exactly as the ImplicitODEy Kernel
+  # in the main example.
+  #
   [./ode2]
     type = ParsedODEKernel
     function = '-4*x - y'

--- a/framework/include/kernels/ParsedODEKernel.h
+++ b/framework/include/kernels/ParsedODEKernel.h
@@ -1,0 +1,70 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef PARSEDODEKERNEL_H
+#define PARSEDODEKERNEL_H
+
+#include "ODEKernel.h"
+#include "FunctionParserUtils.h"
+#include "libmesh/fparser_ad.hh"
+
+//Forward Declarations
+class ParsedODEKernel;
+
+template<>
+InputParameters validParams<ODEKernel>();
+
+/**
+ *
+ */
+class ParsedODEKernel :
+  public ODEKernel,
+  public FunctionParserUtils
+{
+public:
+  ParsedODEKernel(const std::string & name, InputParameters parameters);
+  virtual ~ParsedODEKernel();
+
+protected:
+  void updateParams();
+
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
+  /// function expression
+  std::string _function;
+
+  /// coupled variables
+  unsigned int _nargs;
+  std::vector<VariableValue *> _args;
+  std::vector<std::string> _arg_names;
+
+  /// function parser object for the resudual and on-diagonal Jacobian
+  ADFunction * _func_F;
+  ADFunction * _func_dFdu;
+
+  /// function parser objects for the Jacobian
+  std::vector<ADFunction *> _func_dFdarg;
+
+  /// number of non-linear variables in the problem
+  const unsigned int _number_of_nl_variables;
+
+private:
+  /// Vector to look up the internal coupled variable index into _arg_*  through the libMesh variable number
+  std::vector<unsigned int> _arg_index;
+};
+
+
+#endif /* PARSEDODEKERNEL_H */

--- a/framework/include/utils/FunctionParserUtils.h
+++ b/framework/include/utils/FunctionParserUtils.h
@@ -1,3 +1,17 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef FUNCTIONPARSERUTILS_H
 #define FUNCTIONPARSERUTILS_H
 

--- a/framework/include/utils/FunctionParserUtils.h
+++ b/framework/include/utils/FunctionParserUtils.h
@@ -1,0 +1,39 @@
+#ifndef FUNCTIONPARSERUTILS_H
+#define FUNCTIONPARSERUTILS_H
+
+#include "InputParameters.h"
+
+// Forward declartions
+class FunctionParserUtils;
+
+template<>
+InputParameters validParams<FunctionParserUtils>();
+
+class FunctionParserUtils
+{
+public:
+  FunctionParserUtils(const std::string & name, InputParameters parameters);
+
+  /// Shorthand for an autodiff function parser object.
+  typedef FunctionParserADBase<Real> ADFunction;
+
+protected:
+  /// Evaluate FParser object and check EvalError
+  Real evaluate(ADFunction *);
+
+  /// feature flags
+  bool _enable_jit;
+  bool _disable_fpoptimizer;
+  bool _fail_on_evalerror;
+
+  /// appropriate not a number value to return
+  const Real _nan;
+
+  /// table of FParser eval error codes
+  static const char * _eval_error_msg[];
+
+  /// Array to stage the parameters passed to the functions when calling Eval.
+  Real * _func_params;
+};
+
+#endif //FUNCTIONPARSERUTILS_H

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -243,6 +243,7 @@
 #include "ODETimeDerivative.h"
 #include "FunctionScalarAux.h"
 #include "NodalEqualValueConstraint.h"
+#include "ParsedODEKernel.h"
 
 // indicators
 #include "AnalyticalIndicator.h"
@@ -603,6 +604,7 @@ registerObjects(Factory & factory)
   // Scalar kernels
   registerScalarKernel(ODETimeDerivative);
   registerScalarKernel(NodalEqualValueConstraint);
+  registerScalarKernel(ParsedODEKernel);
 
   // indicators
   registerIndicator(AnalyticalIndicator);

--- a/framework/src/kernels/ParsedODEKernel.C
+++ b/framework/src/kernels/ParsedODEKernel.C
@@ -1,0 +1,133 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ParsedODEKernel.h"
+
+template<>
+InputParameters validParams<ParsedODEKernel>()
+{
+  InputParameters params = validParams<ODEKernel>();
+  params += validParams<FunctionParserUtils>();
+
+  params.addRequiredParam<std::string>("function", "function expression");
+  params.addCoupledVar("args", "additional coupled variables");
+
+  return params;
+}
+
+ParsedODEKernel::ParsedODEKernel(const std::string & name, InputParameters parameters) :
+    ODEKernel(name, parameters),
+    FunctionParserUtils(name, parameters),
+    _function(getParam<std::string>("function")),
+    _nargs(coupledScalarComponents("args")),
+    _args(_nargs),
+    _arg_names(_nargs),
+    _func_dFdarg(_nargs),
+    _number_of_nl_variables(_sys.nVariables()),
+    _arg_index(_number_of_nl_variables, -1)
+{
+  // build variables argument (start with variable the kernel is operating on)
+  std::string variables = _var.name();
+
+  // add additional coupled variables
+  for (unsigned int i = 0; i < _nargs; ++i)
+  {
+    _arg_names[i] = getScalarVar("args", i)->name();
+    variables += "," + _arg_names[i];
+    _args[i] = &coupledScalarValue("args", i);
+
+    // populate number -> arg index lookup table skipping aux variables
+    unsigned int number = coupledScalar("args", i);
+    if (number < _number_of_nl_variables)
+      _arg_index[number] = i;
+  }
+
+  // parse function
+  _func_F =  new ADFunction();
+  if (_func_F->Parse(_function, variables) >= 0)
+     mooseError("Invalid function\n" << _function << "\nin ParsedODEKernel " << name << ".\n" << _func_F->ErrorMsg());
+
+  // on-diagonal derivative
+  _func_dFdu = new ADFunction(*_func_F);
+  if (_func_dFdu->AutoDiff(_var.name()) != -1)
+    mooseError("Failed to take first derivative w.r.t. " << _var.name());
+
+  // off-diagonal derivatives
+  for (unsigned int i = 0; i < _nargs; ++i)
+  {
+    _func_dFdarg[i] = new ADFunction(*_func_F);
+    if (_func_dFdarg[i]->AutoDiff(_arg_names[i]) != -1)
+      mooseError("Failed to take first derivative w.r.t. " << _arg_names[i]);
+  }
+
+  // optimize
+  if (!_disable_fpoptimizer)
+  {
+    _func_F->Optimize();
+    _func_dFdu->Optimize();
+    for (unsigned int i = 0; i < _nargs; ++i)
+      _func_dFdarg[i]->Optimize();
+  }
+
+  // just-in-time compile
+  if (_enable_jit)
+  {
+    _func_F->JITCompile();
+    _func_dFdu->JITCompile();
+    for (unsigned int i = 0; i < _nargs; ++i)
+      _func_dFdarg[i]->JITCompile();
+  }
+
+  // reserve storage for parameter passing bufefr
+  _func_params = new Real[_nargs + 1];
+}
+
+ParsedODEKernel::~ParsedODEKernel()
+{
+  delete[] _func_params;
+}
+
+void
+ParsedODEKernel::updateParams()
+{
+  _func_params[0] = _u[_i];
+
+  for (unsigned int j = 0; j < _nargs; ++j)
+    _func_params[j + 1] = (*_args[j])[_i];
+}
+
+Real
+ParsedODEKernel::computeQpResidual()
+{
+  updateParams();
+  return evaluate(_func_F);
+}
+
+Real
+ParsedODEKernel::computeQpJacobian()
+{
+  updateParams();
+  return evaluate(_func_dFdu);
+}
+
+Real
+ParsedODEKernel::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  int i = _arg_index[jvar];
+  if (i < 0)
+    return 0.0;
+
+  updateParams();
+  return evaluate(_func_dFdarg[i]);
+}

--- a/framework/src/utils/FunctionParserUtils.C
+++ b/framework/src/utils/FunctionParserUtils.C
@@ -1,3 +1,17 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #include "FunctionParserUtils.h"
 
 template<>
@@ -24,7 +38,7 @@ const char * FunctionParserUtils::_eval_error_msg[] = {
 };
 
 FunctionParserUtils::FunctionParserUtils(const std::string & name,
-                                          InputParameters parameters) :
+                                         InputParameters parameters) :
     _enable_jit(parameters.isParamValid("enable_jit") &&
                 parameters.get<bool>("enable_jit")),
     _disable_fpoptimizer(parameters.get<bool>("disable_fpoptimizer")),

--- a/framework/src/utils/FunctionParserUtils.C
+++ b/framework/src/utils/FunctionParserUtils.C
@@ -1,0 +1,58 @@
+#include "FunctionParserUtils.h"
+
+template<>
+InputParameters validParams<FunctionParserUtils>()
+{
+  InputParameters params = emptyInputParameters();
+
+#ifdef LIBMESH_HAVE_FPARSER_JIT
+  params.addParam<bool>("enable_jit", true, "enable just-in-time compilation of function expressions for faster evaluation");
+#endif
+  params.addParam<bool>( "disable_fpoptimizer", false, "Disable the function parser algebraic optimizer");
+  params.addParam<bool>( "fail_on_evalerror", false, "Fail fatally if a function evaluation returns an error code (otherwise just pass on NaN)");
+
+  return params;
+}
+
+const char * FunctionParserUtils::_eval_error_msg[] = {
+  "Unknown",
+  "Division by zero",
+  "Square root of a negative value",
+  "Logarithm of negative value",
+  "Trigonometric error (asin or acos of illegal value)",
+  "Maximum recursion level reached"
+};
+
+FunctionParserUtils::FunctionParserUtils(const std::string & name,
+                                          InputParameters parameters) :
+    _enable_jit(parameters.isParamValid("enable_jit") &&
+                parameters.get<bool>("enable_jit")),
+    _disable_fpoptimizer(parameters.get<bool>("disable_fpoptimizer")),
+    _fail_on_evalerror(parameters.get<bool>("fail_on_evalerror")),
+    _nan(std::numeric_limits<Real>::quiet_NaN())
+{
+}
+
+Real
+FunctionParserUtils::evaluate(ADFunction * parser)
+{
+  // null pointer is a shortcut for vanishing derivatives, see functionsOptimize()
+  if (parser == NULL) return 0.0;
+
+  // evaluate expression
+  Real result = parser->Eval(_func_params);
+
+  // fetch fparser evaluation error
+  int error_code = parser->EvalError();
+
+  // no error
+  if (error_code == 0)
+    return result;
+
+  // hard fail or return not a number
+  if (_fail_on_evalerror)
+    mooseError("DerivativeParsedMaterial function evaluation encountered an error: "
+               << _eval_error_msg[(error_code < 0 || error_code > 5) ? 0 : error_code]);
+
+  return _nan;
+}

--- a/modules/phase_field/include/materials/ParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/ParsedMaterialHelper.h
@@ -63,9 +63,6 @@ protected:
   std::vector<MaterialProperty<Real> *> _mat_props;
   unsigned int _nmat_props;
 
-  /// Array to stage the parameters passed to the functions when calling Eval.
-  Real * _func_params;
-
   /// Tolerance values for all arguments (to protect from log(0)).
   std::vector<Real> _tol;
 

--- a/modules/phase_field/include/materials/ParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/ParsedMaterialHelper.h
@@ -8,6 +8,7 @@
 #define PARSEDMATERIALHELPER_H
 
 #include "Material.h"
+#include "FunctionParserUtils.h"
 #include "libmesh/fparser_ad.hh"
 
 /**
@@ -15,7 +16,9 @@
  * function expression.
  */
 template<class T>
-class ParsedMaterialHelper : public T
+class ParsedMaterialHelper :
+  public T,
+  public FunctionParserUtils
 {
 public:
   enum VariableNameMappingMode {
@@ -50,12 +53,6 @@ protected:
   // run FPOptimizer on the parsed function
   virtual void functionsOptimize();
 
-  /// Shorthand for an autodiff function parser object.
-  typedef FunctionParserADBase<Real> ADFunction;
-
-  /// Evaluate FParser object and check EvalError
-  Real evaluate(ADFunction *);
-
   /// The undiffed free energy function parser object.
   ADFunction * _func_F;
 
@@ -66,11 +63,6 @@ protected:
   /// Tolerance values for all arguments (to protect from log(0)).
   std::vector<Real> _tol;
 
-  /// feature flags
-  bool _enable_jit;
-  bool _disable_fpoptimizer;
-  bool _fail_on_evalerror;
-
   /**
    * Flag to indicate if MOOSE nonlinear variable names should be used as FParser variable names.
    * This should be true only for DerivativeParsedMaterial. If set to false, this class looks up the
@@ -78,31 +70,18 @@ protected:
    * parsing the FParser expression.
    */
   const VariableNameMappingMode _map_mode;
-
-  /// appropriate not a number value to return
-  const Real _nan;
-
-  /// table of FParser eval error codes
-  static const char * _eval_error_msg[];
 };
 
 
 template<class T>
 ParsedMaterialHelper<T>::ParsedMaterialHelper(const std::string & name,
-                                           InputParameters parameters,
-                                           VariableNameMappingMode map_mode) :
+                                              InputParameters parameters,
+                                              VariableNameMappingMode map_mode) :
     T(name, parameters),
+    FunctionParserUtils(name, parameters),
     _func_F(NULL),
     _nmat_props(0),
-#ifdef LIBMESH_HAVE_FPARSER_JIT
-    _enable_jit(parameters.get<bool>("enable_jit")),
-#else
-    _enable_jit(false),
-#endif
-    _disable_fpoptimizer(parameters.get<bool>("disable_fpoptimizer")),
-    _fail_on_evalerror(parameters.get<bool>("fail_on_evalerror")),
-    _map_mode(map_mode),
-    _nan(std::numeric_limits<Real>::quiet_NaN())
+    _map_mode(map_mode)
 {
 }
 
@@ -117,26 +96,10 @@ InputParameters
 ParsedMaterialHelper<T>::validParams()
 {
   InputParameters params = ::validParams<T>();
+  params += ::validParams<FunctionParserUtils>();
   params.addClassDescription("Parsed Function Material.");
-
-  // Just in time compilation for the FParser objects
-#ifdef LIBMESH_HAVE_FPARSER_JIT
-  params.addParam<bool>( "enable_jit", false, "Enable Just In Time compilation of the parsed functions");
-#endif
-  params.addParam<bool>( "disable_fpoptimizer", false, "Disable the function parser algebraic optimizer");
-  params.addParam<bool>( "fail_on_evalerror", false, "Fail fatally if a function evaluation returns an error code (otherwise just pass on NaN)");
   return params;
 }
-
-template<class T>
-const char * ParsedMaterialHelper<T>::_eval_error_msg[] = {
-  "Unknown",
-  "Division by zero",
-  "Square root of a negative value",
-  "Logarithm of negative value",
-  "Trigonometric error (asin or acos of illegal value)",
-  "Maximum recursion level reached"
-};
 
 template<class T>
 void ParsedMaterialHelper<T>::functionParse(const std::string & function_expression)
@@ -282,31 +245,6 @@ void ParsedMaterialHelper<T>::functionsOptimize()
     _func_F->Optimize();
   if (_enable_jit && !_func_F->JITCompile())
     mooseWarning("Failed to JIT compile expression, falling back to byte code interpretation.");
-}
-
-template<class T>
-Real
-ParsedMaterialHelper<T>::evaluate(ADFunction * parser)
-{
-  // null pointer is a shortcut for vanishing derivatives, see functionsOptimize()
-  if (parser == NULL) return 0.0;
-
-  // evaluate expression
-  Real result = parser->Eval(_func_params);
-
-  // fetch fparser evaluation error
-  int error_code = parser->EvalError();
-
-  // no error
-  if (error_code == 0)
-    return result;
-
-  // hard fail or return not a number
-  if (_fail_on_evalerror)
-    mooseError("DerivativeParsedMaterial function evaluation encountered an error: "
-               << _eval_error_msg[(error_code < 0 || error_code > 5) ? 0 : error_code]);
-
-  return _nan;
 }
 
 template<class T>

--- a/test/tests/kernels/ode/parsedode_sys_impl_test.i
+++ b/test/tests/kernels/ode/parsedode_sys_impl_test.i
@@ -1,0 +1,143 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  nx = 2
+  ny = 2
+  elem_type = QUAD4
+[]
+
+[Functions]
+  [./f_fn]
+    type = ParsedFunction
+    value = -4
+  [../]
+  [./bc_all_fn]
+    type = ParsedFunction
+    value = x*x+y*y
+  [../]
+
+  # ODEs
+  [./exact_x_fn]
+    type = ParsedFunction
+    value = (-1/3)*exp(-t)+(4/3)*exp(5*t)
+  [../]
+[]
+
+# NL
+
+[Variables]
+  [./u]
+    family = LAGRANGE
+    order = FIRST
+  [../]
+
+  # ODE variables
+  [./x]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 1
+  [../]
+  [./y]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 2
+  [../]
+[]
+
+[Kernels]
+  [./td]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./uff]
+    type = UserForcingFunction
+    variable = u
+    function = f_fn
+  [../]
+[]
+
+[ScalarKernels]
+  [./td1]
+    type = ODETimeDerivative
+    variable = x
+  [../]
+  [./ode1]
+    type = ParsedODEKernel
+    function = '-3*x - 2*y'
+    variable = x
+    args = y
+  [../]
+
+  [./td2]
+    type = ODETimeDerivative
+    variable = y
+  [../]
+  [./ode2]
+    type = ParsedODEKernel
+    function = '-4*x - y'
+    variable = y
+    args = x
+  [../]
+[]
+
+[BCs]
+  [./all]
+    type = FunctionDirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    function = bc_all_fn
+  [../]
+[]
+
+[Postprocessors]
+  active = 'exact_x l2err_x x y'
+
+  [./x]
+    type = ScalarVariable
+    variable = x
+    execute_on = timestep_end
+  [../]
+  [./y]
+    type = ScalarVariable
+    variable = y
+    execute_on = timestep_end
+  [../]
+
+  [./exact_x]
+    type = PlotFunction
+    function = exact_x_fn
+    execute_on = timestep_end
+    point = '0 0 0'
+  [../]
+
+  [./l2err_x]
+    type = ScalarL2Error
+    variable = x
+    function = exact_x_fn
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  start_time = 0
+  dt = 0.01
+  num_steps = 100
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  file_base = ode_sys_impl_test_out
+  output_initial = true
+  exodus = true
+  print_perf_log = true
+[]

--- a/test/tests/kernels/ode/tests
+++ b/test/tests/kernels/ode/tests
@@ -12,4 +12,14 @@
     max_parallel = 2
 		max_threads = 2
   [../]
+
+  [./test_parsed_sys_impl]
+    # uses the same gold file as the previous test
+    prereq = 'test_sys_impl'
+    type = 'Exodiff'
+    input = 'parsedode_sys_impl_test.i'
+    exodiff = 'ode_sys_impl_test_out.e'
+    max_parallel = 2
+		max_threads = 2
+  [../]
 []


### PR DESCRIPTION
This adds a first version of a `ParsedODEKernel` to MOOSE. I factored out  `FunctionParserUtils` class to avoid code duplication between this and the parsed materials system. A test is added and a _parsed_ version of Example 18 is added as well. Both the test and the example give identical results to the corresponding inputs using the `ImplicitODEx` and `ImplicitODEy` test kernels (the test even uses the same gold file).

Addresses #4708 

In a next step I'll add the constant expression support that parsed materials already have (via putting it into `FunctionParserUtils`)
