### PR TITLE
Update Darcy tutorial for math bug 

### DIFF
--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -62,7 +62,7 @@ public:
    */
   virtual PropertyValue *init (int size) = 0;
 
-  virtual int size () = 0;
+  virtual unsigned int size () const = 0;
 
   /**
    * Resizes the property to the size n
@@ -147,7 +147,7 @@ public:
    */
   T & operator[](const unsigned int i) { return _value[i]; }
 
-  int size() { return _value.size(); }
+  unsigned int size() const { return _value.size(); }
 
   /**
    * Get element i out of the array.

--- a/modules/heat_conduction/include/HeatConductionTimeDerivative.h
+++ b/modules/heat_conduction/include/HeatConductionTimeDerivative.h
@@ -7,28 +7,71 @@
 #ifndef HEATCONDUCTIONTIMEDERIVATIVE
 #define HEATCONDUCTIONTIMEDERIVATIVE
 
+// MOOSE includes
 #include "TimeDerivative.h"
 #include "Material.h"
 
-//Forward Declarations
+// Forward Declarations
 class HeatConductionTimeDerivative;
 
 template<>
 InputParameters validParams<HeatConductionTimeDerivative>();
 
+/**
+ * A class for defining the time derivative of the heat equation.
+ *
+ * By default this Kernel computes:
+ *   \rho * c_p * \frac{\partial T}{\partial t},
+ * where \rho and c_p are material properties with the names "density" and
+ * "specific_heat", respectively.
+ *
+ * It is also possible to formulate the equation as:
+ *   C_p * \frac{\partial T}{\partial t},
+ * where C_p is a meterial property with the name "heat_capacity". To use
+ * this formulation the parameter, "use_heat_capacity", must be set to true.
+ */
 class HeatConductionTimeDerivative : public TimeDerivative
 {
 public:
 
+  /**
+   * Contructor for Heat Equation time derivative term.
+   */
   HeatConductionTimeDerivative(const std::string & name, InputParameters parameters);
 
 protected:
+
+  /**
+   * Compute the residual of the Heat Equation time derivative.
+   */
   virtual Real computeQpResidual();
 
+  /**
+   * Compute the jacobian of the Heat Equation time derivative.
+   */
   virtual Real computeQpJacobian();
 
+  /**
+   * Setup the material property for the correct formulation of the equation
+   */
+  virtual void initialSetup();
+
 private:
-  const MaterialProperty<Real> & _specific_heat;
-  const MaterialProperty<Real> & _density;
+
+  /// Flag that indicates the type of formulation to utilize
+  bool _use_heat_capacity;
+
+  /// A material property set to unity for setting the desnity equal to one
+  /// This is used when using the heat capcity formulation
+  MaterialProperty<Real> _one;
+
+  ///@{
+  /// Pointers to the specific heat and density properties.
+  /// These are pointers to allow for the adjustment of what properties are used. When
+  /// using the heat capacity formulation, _specific_heat is set the heat capacity and
+  /// density is equal to one.
+  const MaterialProperty<Real> * _specific_heat;
+  const MaterialProperty<Real> * _density;
+  ///@}
 };
 #endif //HEATCONDUCTIONTIMEDERIVATIVE

--- a/modules/heat_conduction/src/HeatConductionTimeDerivative.C
+++ b/modules/heat_conduction/src/HeatConductionTimeDerivative.C
@@ -12,24 +12,50 @@ InputParameters validParams<HeatConductionTimeDerivative>()
   InputParameters params = validParams<TimeDerivative>();
   // Density may be changing with deformation, so we must integrate over current volume
   params.set<bool>("use_displaced_mesh") = true;
+  params.addParam<bool>("use_heat_capacity", false, "Use a single material property, 'heat_capacity', as the coefficient of the time derivative.");
   return params;
 }
 
 
 HeatConductionTimeDerivative::HeatConductionTimeDerivative(const std::string & name, InputParameters parameters)
-  :TimeDerivative(name, parameters),
-   _specific_heat(getMaterialProperty<Real>("specific_heat")),
-   _density(getMaterialProperty<Real>("density"))
-{}
+  : TimeDerivative(name, parameters),
+   _use_heat_capacity(getParam<bool>("use_heat_capacity")),
+   _specific_heat(NULL),
+   _density(NULL)
+{
+}
+
+void
+HeatConductionTimeDerivative::initialSetup()
+{
+  // Initialize the unity material property
+  _one.resize(_fe_problem.getMaxQps());
+  for (unsigned int i = 0; i < _one.size(); ++i)
+    _one[i] = 1;
+
+  // Use the Heat Capcity based formulation
+  if (_use_heat_capacity)
+  {
+    _specific_heat = &getMaterialProperty<Real>("heat_capacity");
+    _density = &_one;
+  }
+
+  // Use the density and specific heat based formulation
+  else
+  {
+    _specific_heat = &getMaterialProperty<Real>("specific_heat");
+    _density = &getMaterialProperty<Real>("density");
+  }
+}
 
 Real
 HeatConductionTimeDerivative::computeQpResidual()
 {
-  return _specific_heat[_qp]*_density[_qp]*TimeDerivative::computeQpResidual();
+  return (*_specific_heat)[_qp] * (*_density)[_qp] * TimeDerivative::computeQpResidual();
 }
 
 Real
 HeatConductionTimeDerivative::computeQpJacobian()
 {
-  return _specific_heat[_qp]*_density[_qp]*TimeDerivative::computeQpJacobian();
+  return (*_specific_heat)[_qp] * (*_density)[_qp] * TimeDerivative::computeQpJacobian();
 }

--- a/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/include/kernels/DarcyConvection.h
@@ -48,11 +48,11 @@ protected:
    * These references will be set by the initialization list so that
    * values can be pulled from the Material system.
    */
-  MaterialProperty<Real> & _permeability;
-  MaterialProperty<Real> & _porosity;
-  MaterialProperty<Real> & _viscosity;
-  MaterialProperty<Real> & _density;
-  MaterialProperty<Real> & _specific_heat;
+  const MaterialProperty<Real> & _permeability;
+  const MaterialProperty<Real> & _porosity;
+  const MaterialProperty<Real> & _viscosity;
+  const MaterialProperty<Real> & _density;
+  const MaterialProperty<Real> & _heat_capacity;
 };
 
 #endif //DARCYCONVECTION_H

--- a/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/include/materials/PackedColumn.h
+++ b/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/include/materials/PackedColumn.h
@@ -60,8 +60,8 @@ protected:
   /// The bulk thermal conductivity
   MaterialProperty<Real> & _thermal_conductivity;
 
-  /// The bulk specific heat
-  MaterialProperty<Real> & _specific_heat;
+  /// The bulk heat capacity
+  MaterialProperty<Real> & _heat_capacity;
 
   /// The bulk density
   MaterialProperty<Real> & _density;

--- a/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/problems/step6a_coupled.i
+++ b/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/problems/step6a_coupled.i
@@ -42,6 +42,7 @@
   [./heat_conduction_time_derivative]
     type = HeatConductionTimeDerivative
     variable = temp
+    use_heat_capacity = true
   [../]
   [./heat_convection]
     type = DarcyConvection
@@ -129,4 +130,3 @@
   print_perf_log = true
   print_linear_residuals = true
 []
-

--- a/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/problems/step6b_transient_inflow.i
+++ b/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/problems/step6b_transient_inflow.i
@@ -42,6 +42,7 @@
   [./heat_conduction_time_derivative]
     type = HeatConductionTimeDerivative
     variable = temp
+    use_heat_capacity = true
   [../]
   [./heat_convection]
     type = DarcyConvection

--- a/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/src/kernels/DarcyConvection.C
+++ b/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/src/kernels/DarcyConvection.C
@@ -38,7 +38,7 @@ DarcyConvection::DarcyConvection(const std::string & name, InputParameters param
     _porosity(getMaterialProperty<Real>("porosity")),
     _viscosity(getMaterialProperty<Real>("viscosity")),
     _density(getMaterialProperty<Real>("density")),
-    _specific_heat(getMaterialProperty<Real>("specific_heat"))
+    _heat_capacity(getMaterialProperty<Real>("heat_capacity"))
 {
 }
 
@@ -47,22 +47,19 @@ DarcyConvection::computeQpResidual()
 {
   // From "The Finite Difference Method For Transient Convection Diffusion", Ewa Majchrzak & Łukasz Turchan, 2012.
   // http://srimcs.im.pcz.pl/2012_1/art_07.pdf
-  Real coefs = _density[_qp]*_specific_heat[_qp];
 
   // http://en.wikipedia.org/wiki/Superficial_velocity
   RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_pressure_gradient[_qp];
 
-  return coefs * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
+  return _heat_capacity[_qp] * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
 }
 
 Real
 DarcyConvection::computeQpJacobian()
 {
-  Real coefs = _density[_qp]*_specific_heat[_qp];
-
   RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_pressure_gradient[_qp];
 
-  return coefs * superficial_velocity * _grad_phi[_j][_qp] * _test[_i][_qp];
+  return _heat_capacity[_qp] * superficial_velocity * _grad_phi[_j][_qp] * _test[_i][_qp];
 }
 
 Real
@@ -70,11 +67,8 @@ DarcyConvection::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _pressure_var)
   {
-    Real coefs = _density[_qp]*_specific_heat[_qp];
-
     RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_grad_phi[_j][_qp];
-
-    return coefs * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
+    return _heat_capacity[_qp] * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
   }
 
   return 0.0;

--- a/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/src/materials/PackedColumn.C
+++ b/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/src/materials/PackedColumn.C
@@ -37,7 +37,7 @@ PackedColumn::PackedColumn(const std::string & name, InputParameters parameters)
     _porosity(declareProperty<Real>("porosity")),
     _viscosity(declareProperty<Real>("viscosity")),
     _thermal_conductivity(declareProperty<Real>("thermal_conductivity")),
-    _specific_heat(declareProperty<Real>("specific_heat")),
+    _heat_capacity(declareProperty<Real>("heat_capacity")),
     _density(declareProperty<Real>("density"))
 {
   // Sigh: Still can't depend on C++11....
@@ -82,6 +82,6 @@ PackedColumn::computeQpProperties()
 
   // Now actually set the value at the quadrature point
   _thermal_conductivity[_qp] = _porosity[_qp]*water_k + (1.0-_porosity[_qp])*steel_k;
-  _specific_heat[_qp] = _porosity[_qp]*water_cp + (1.0-_porosity[_qp])*steel_cp;
   _density[_qp] = _porosity[_qp]*water_rho + (1.0-_porosity[_qp])*steel_rho;
+  _heat_capacity[_qp] = _porosity[_qp]*water_cp*water_rho + (1.0-_porosity[_qp])*steel_cp*steel_rho;
 }

--- a/tutorials/darcy_thermo_mech/step7_adaptivity/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step7_adaptivity/include/kernels/DarcyConvection.h
@@ -52,7 +52,7 @@ protected:
   MaterialProperty<Real> & _porosity;
   MaterialProperty<Real> & _viscosity;
   MaterialProperty<Real> & _density;
-  MaterialProperty<Real> & _specific_heat;
+  MaterialProperty<Real> & _heat_capacity;
 };
 
 #endif //DARCYCONVECTION_H

--- a/tutorials/darcy_thermo_mech/step7_adaptivity/include/materials/PackedColumn.h
+++ b/tutorials/darcy_thermo_mech/step7_adaptivity/include/materials/PackedColumn.h
@@ -60,8 +60,8 @@ protected:
   /// The bulk thermal conductivity
   MaterialProperty<Real> & _thermal_conductivity;
 
-  /// The bulk specific heat
-  MaterialProperty<Real> & _specific_heat;
+  /// The bulk heat capacity
+  MaterialProperty<Real> & _heat_capacity;
 
   /// The bulk density
   MaterialProperty<Real> & _density;

--- a/tutorials/darcy_thermo_mech/step7_adaptivity/problems/step7a_coarse.i
+++ b/tutorials/darcy_thermo_mech/step7_adaptivity/problems/step7a_coarse.i
@@ -42,6 +42,7 @@
   [./heat_conduction_time_derivative]
     type = HeatConductionTimeDerivative
     variable = temp
+    use_heat_capacity = true
   [../]
   [./heat_convection]
     type = DarcyConvection
@@ -129,4 +130,3 @@
   print_perf_log = true
   print_linear_residuals = true
 []
-

--- a/tutorials/darcy_thermo_mech/step7_adaptivity/problems/step7b_fine.i
+++ b/tutorials/darcy_thermo_mech/step7_adaptivity/problems/step7b_fine.i
@@ -43,6 +43,7 @@
   [./heat_conduction_time_derivative]
     type = HeatConductionTimeDerivative
     variable = temp
+    use_heat_capacity = true
   [../]
   [./heat_convection]
     type = DarcyConvection

--- a/tutorials/darcy_thermo_mech/step7_adaptivity/problems/step7c_adapt.i
+++ b/tutorials/darcy_thermo_mech/step7_adaptivity/problems/step7c_adapt.i
@@ -43,6 +43,7 @@
   [./heat_conduction_time_derivative]
     type = HeatConductionTimeDerivative
     variable = temp
+    use_heat_capacity = true
   [../]
   [./heat_convection]
     type = DarcyConvection

--- a/tutorials/darcy_thermo_mech/step7_adaptivity/src/kernels/DarcyConvection.C
+++ b/tutorials/darcy_thermo_mech/step7_adaptivity/src/kernels/DarcyConvection.C
@@ -38,7 +38,7 @@ DarcyConvection::DarcyConvection(const std::string & name, InputParameters param
     _porosity(getMaterialProperty<Real>("porosity")),
     _viscosity(getMaterialProperty<Real>("viscosity")),
     _density(getMaterialProperty<Real>("density")),
-    _specific_heat(getMaterialProperty<Real>("specific_heat"))
+    _heat_capacity(getMaterialProperty<Real>("heat_capacity"))
 {
 }
 
@@ -47,22 +47,19 @@ DarcyConvection::computeQpResidual()
 {
   // From "The Finite Difference Method For Transient Convection Diffusion", Ewa Majchrzak & Łukasz Turchan, 2012.
   // http://srimcs.im.pcz.pl/2012_1/art_07.pdf
-  Real coefs = _density[_qp]*_specific_heat[_qp];
 
   // http://en.wikipedia.org/wiki/Superficial_velocity
   RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_pressure_gradient[_qp];
 
-  return coefs * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
+  return _heat_capacity[_qp] * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
 }
 
 Real
 DarcyConvection::computeQpJacobian()
 {
-  Real coefs = _density[_qp]*_specific_heat[_qp];
-
   RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_pressure_gradient[_qp];
 
-  return coefs * superficial_velocity * _grad_phi[_j][_qp] * _test[_i][_qp];
+  return _heat_capacity[_qp] * superficial_velocity * _grad_phi[_j][_qp] * _test[_i][_qp];
 }
 
 Real
@@ -70,11 +67,9 @@ DarcyConvection::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _pressure_var)
   {
-    Real coefs = _density[_qp]*_specific_heat[_qp];
-
     RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_grad_phi[_j][_qp];
 
-    return coefs * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
+    return _heat_capacity[_qp] * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
   }
 
   return 0.0;

--- a/tutorials/darcy_thermo_mech/step7_adaptivity/src/materials/PackedColumn.C
+++ b/tutorials/darcy_thermo_mech/step7_adaptivity/src/materials/PackedColumn.C
@@ -37,7 +37,7 @@ PackedColumn::PackedColumn(const std::string & name, InputParameters parameters)
     _porosity(declareProperty<Real>("porosity")),
     _viscosity(declareProperty<Real>("viscosity")),
     _thermal_conductivity(declareProperty<Real>("thermal_conductivity")),
-    _specific_heat(declareProperty<Real>("specific_heat")),
+    _heat_capacity(declareProperty<Real>("heat_capacity")),
     _density(declareProperty<Real>("density"))
 {
   // Sigh: Still can't depend on C++11....
@@ -82,6 +82,6 @@ PackedColumn::computeQpProperties()
 
   // Now actually set the value at the quadrature point
   _thermal_conductivity[_qp] = _porosity[_qp]*water_k + (1.0-_porosity[_qp])*steel_k;
-  _specific_heat[_qp] = _porosity[_qp]*water_cp + (1.0-_porosity[_qp])*steel_cp;
   _density[_qp] = _porosity[_qp]*water_rho + (1.0-_porosity[_qp])*steel_rho;
+  _heat_capacity[_qp] = _porosity[_qp]*water_cp*water_rho + (1.0-_porosity[_qp])*steel_cp*steel_rho;
 }

--- a/tutorials/darcy_thermo_mech/step8_postprocessors/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step8_postprocessors/include/kernels/DarcyConvection.h
@@ -48,11 +48,11 @@ protected:
    * These references will be set by the initialization list so that
    * values can be pulled from the Material system.
    */
-  MaterialProperty<Real> & _permeability;
-  MaterialProperty<Real> & _porosity;
-  MaterialProperty<Real> & _viscosity;
-  MaterialProperty<Real> & _density;
-  MaterialProperty<Real> & _specific_heat;
+  const MaterialProperty<Real> & _permeability;
+  const MaterialProperty<Real> & _porosity;
+  const MaterialProperty<Real> & _viscosity;
+  const MaterialProperty<Real> & _density;
+  const MaterialProperty<Real> & _heat_capacity;
 };
 
 #endif //DARCYCONVECTION_H

--- a/tutorials/darcy_thermo_mech/step8_postprocessors/include/materials/PackedColumn.h
+++ b/tutorials/darcy_thermo_mech/step8_postprocessors/include/materials/PackedColumn.h
@@ -61,7 +61,7 @@ protected:
   MaterialProperty<Real> & _thermal_conductivity;
 
   /// The bulk specific heat
-  MaterialProperty<Real> & _specific_heat;
+  MaterialProperty<Real> & _heat_capacity;
 
   /// The bulk density
   MaterialProperty<Real> & _density;

--- a/tutorials/darcy_thermo_mech/step8_postprocessors/problems/step8.i
+++ b/tutorials/darcy_thermo_mech/step8_postprocessors/problems/step8.i
@@ -42,6 +42,7 @@
   [./heat_conduction_time_derivative]
     type = HeatConductionTimeDerivative
     variable = temp
+    use_heat_capacity = true
   [../]
   [./heat_convection]
     type = DarcyConvection
@@ -146,4 +147,3 @@
   print_perf_log = true
   print_linear_residuals = true
 []
-

--- a/tutorials/darcy_thermo_mech/step8_postprocessors/src/kernels/DarcyConvection.C
+++ b/tutorials/darcy_thermo_mech/step8_postprocessors/src/kernels/DarcyConvection.C
@@ -38,7 +38,7 @@ DarcyConvection::DarcyConvection(const std::string & name, InputParameters param
     _porosity(getMaterialProperty<Real>("porosity")),
     _viscosity(getMaterialProperty<Real>("viscosity")),
     _density(getMaterialProperty<Real>("density")),
-    _specific_heat(getMaterialProperty<Real>("specific_heat"))
+    _heat_capacity(getMaterialProperty<Real>("heat_capacity"))
 {
 }
 
@@ -47,22 +47,19 @@ DarcyConvection::computeQpResidual()
 {
   // From "The Finite Difference Method For Transient Convection Diffusion", Ewa Majchrzak & Łukasz Turchan, 2012.
   // http://srimcs.im.pcz.pl/2012_1/art_07.pdf
-  Real coefs = _density[_qp]*_specific_heat[_qp];
 
   // http://en.wikipedia.org/wiki/Superficial_velocity
   RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_pressure_gradient[_qp];
 
-  return coefs * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
+  return _heat_capacity[_qp] * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
 }
 
 Real
 DarcyConvection::computeQpJacobian()
 {
-  Real coefs = _density[_qp]*_specific_heat[_qp];
-
   RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_pressure_gradient[_qp];
 
-  return coefs * superficial_velocity * _grad_phi[_j][_qp] * _test[_i][_qp];
+  return _heat_capacity[_qp] * superficial_velocity * _grad_phi[_j][_qp] * _test[_i][_qp];
 }
 
 Real
@@ -70,11 +67,9 @@ DarcyConvection::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _pressure_var)
   {
-    Real coefs = _density[_qp]*_specific_heat[_qp];
-
     RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_grad_phi[_j][_qp];
 
-    return coefs * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
+    return _heat_capacity[_qp] * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
   }
 
   return 0.0;

--- a/tutorials/darcy_thermo_mech/step8_postprocessors/src/materials/PackedColumn.C
+++ b/tutorials/darcy_thermo_mech/step8_postprocessors/src/materials/PackedColumn.C
@@ -37,7 +37,7 @@ PackedColumn::PackedColumn(const std::string & name, InputParameters parameters)
     _porosity(declareProperty<Real>("porosity")),
     _viscosity(declareProperty<Real>("viscosity")),
     _thermal_conductivity(declareProperty<Real>("thermal_conductivity")),
-    _specific_heat(declareProperty<Real>("specific_heat")),
+    _heat_capacity(declareProperty<Real>("heat_capacity")),
     _density(declareProperty<Real>("density"))
 {
   // Sigh: Still can't depend on C++11....
@@ -82,6 +82,6 @@ PackedColumn::computeQpProperties()
 
   // Now actually set the value at the quadrature point
   _thermal_conductivity[_qp] = _porosity[_qp]*water_k + (1.0-_porosity[_qp])*steel_k;
-  _specific_heat[_qp] = _porosity[_qp]*water_cp + (1.0-_porosity[_qp])*steel_cp;
   _density[_qp] = _porosity[_qp]*water_rho + (1.0-_porosity[_qp])*steel_rho;
+  _heat_capacity[_qp] = _porosity[_qp]*water_cp*water_rho + (1.0-_porosity[_qp])*steel_cp*steel_rho;
 }

--- a/tutorials/darcy_thermo_mech/step9_mechanics/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step9_mechanics/include/kernels/DarcyConvection.h
@@ -48,11 +48,11 @@ protected:
    * These references will be set by the initialization list so that
    * values can be pulled from the Material system.
    */
-  MaterialProperty<Real> & _permeability;
-  MaterialProperty<Real> & _porosity;
-  MaterialProperty<Real> & _viscosity;
-  MaterialProperty<Real> & _density;
-  MaterialProperty<Real> & _specific_heat;
+  const MaterialProperty<Real> & _permeability;
+  const MaterialProperty<Real> & _porosity;
+  const MaterialProperty<Real> & _viscosity;
+  const MaterialProperty<Real> & _density;
+  const MaterialProperty<Real> & _heat_capacity;
 };
 
 #endif //DARCYCONVECTION_H

--- a/tutorials/darcy_thermo_mech/step9_mechanics/include/materials/PackedColumn.h
+++ b/tutorials/darcy_thermo_mech/step9_mechanics/include/materials/PackedColumn.h
@@ -60,8 +60,8 @@ protected:
   /// The bulk thermal conductivity
   MaterialProperty<Real> & _thermal_conductivity;
 
-  /// The bulk specific heat
-  MaterialProperty<Real> & _specific_heat;
+  /// The bulk heat capacity
+  MaterialProperty<Real> & _heat_capacity;
 
   /// The bulk density
   MaterialProperty<Real> & _density;

--- a/tutorials/darcy_thermo_mech/step9_mechanics/problems/step9.i
+++ b/tutorials/darcy_thermo_mech/step9_mechanics/problems/step9.i
@@ -46,6 +46,7 @@
   [./heat_conduction_time_derivative]
     type = HeatConductionTimeDerivative
     variable = temp
+    use_heat_capacity = true
   [../]
   [./heat_convection]
     type = DarcyConvection
@@ -180,4 +181,3 @@
   print_perf_log = true
   print_linear_residuals = true
 []
-

--- a/tutorials/darcy_thermo_mech/step9_mechanics/src/kernels/DarcyConvection.C
+++ b/tutorials/darcy_thermo_mech/step9_mechanics/src/kernels/DarcyConvection.C
@@ -38,7 +38,7 @@ DarcyConvection::DarcyConvection(const std::string & name, InputParameters param
     _porosity(getMaterialProperty<Real>("porosity")),
     _viscosity(getMaterialProperty<Real>("viscosity")),
     _density(getMaterialProperty<Real>("density")),
-    _specific_heat(getMaterialProperty<Real>("specific_heat"))
+    _heat_capacity(getMaterialProperty<Real>("heat_capacity"))
 {
 }
 
@@ -47,22 +47,19 @@ DarcyConvection::computeQpResidual()
 {
   // From "The Finite Difference Method For Transient Convection Diffusion", Ewa Majchrzak & Łukasz Turchan, 2012.
   // http://srimcs.im.pcz.pl/2012_1/art_07.pdf
-  Real coefs = _density[_qp]*_specific_heat[_qp];
-
+  //
   // http://en.wikipedia.org/wiki/Superficial_velocity
   RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_pressure_gradient[_qp];
 
-  return coefs * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
+  return _heat_capacity[_qp] * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
 }
 
 Real
 DarcyConvection::computeQpJacobian()
 {
-  Real coefs = _density[_qp]*_specific_heat[_qp];
-
   RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_pressure_gradient[_qp];
 
-  return coefs * superficial_velocity * _grad_phi[_j][_qp] * _test[_i][_qp];
+  return _heat_capacity[_qp] * superficial_velocity * _grad_phi[_j][_qp] * _test[_i][_qp];
 }
 
 Real
@@ -70,11 +67,9 @@ DarcyConvection::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _pressure_var)
   {
-    Real coefs = _density[_qp]*_specific_heat[_qp];
-
     RealVectorValue superficial_velocity = _porosity[_qp]*-(_permeability[_qp]/_viscosity[_qp])*_grad_phi[_j][_qp];
 
-    return coefs * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
+    return _heat_capacity[_qp] * superficial_velocity * _grad_u[_qp] * _test[_i][_qp];
   }
 
   return 0.0;

--- a/tutorials/darcy_thermo_mech/step9_mechanics/src/materials/PackedColumn.C
+++ b/tutorials/darcy_thermo_mech/step9_mechanics/src/materials/PackedColumn.C
@@ -37,7 +37,7 @@ PackedColumn::PackedColumn(const std::string & name, InputParameters parameters)
     _porosity(declareProperty<Real>("porosity")),
     _viscosity(declareProperty<Real>("viscosity")),
     _thermal_conductivity(declareProperty<Real>("thermal_conductivity")),
-    _specific_heat(declareProperty<Real>("specific_heat")),
+    _heat_capacity(declareProperty<Real>("heat_capacity")),
     _density(declareProperty<Real>("density"))
 {
   // Sigh: Still can't depend on C++11....
@@ -82,6 +82,6 @@ PackedColumn::computeQpProperties()
 
   // Now actually set the value at the quadrature point
   _thermal_conductivity[_qp] = _porosity[_qp]*water_k + (1.0-_porosity[_qp])*steel_k;
-  _specific_heat[_qp] = _porosity[_qp]*water_cp + (1.0-_porosity[_qp])*steel_cp;
   _density[_qp] = _porosity[_qp]*water_rho + (1.0-_porosity[_qp])*steel_rho;
+  _heat_capacity[_qp] = _porosity[_qp]*water_cp*water_rho + (1.0-_porosity[_qp])*steel_cp*steel_rho;
 }


### PR DESCRIPTION
The updates the tutorial to do the proper math for \rho_cp by adding an option the the HeatConductionTimeDerivative to use heat capacity, rather than rho_cp.

(refs #4522)
