### PR TITLE
Move contact force into aux var (refs #4850).

### DIFF
--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -197,7 +197,7 @@ PenetrationLocator::saveContactStateVars()
   {
     if (it->second != NULL)
     {
-      it->second->_contact_force_old = it->second->_contact_force;
+//      it->second->_contact_force_old = it->second->_contact_force;
       it->second->_accumulated_slip_old = it->second->_accumulated_slip;
       it->second->_frictional_energy_old = it->second->_frictional_energy;
     }

--- a/modules/combined/tests/contact/4ElemTensionRelease_mechanical_constraint.i
+++ b/modules/combined/tests/contact/4ElemTensionRelease_mechanical_constraint.i
@@ -118,10 +118,10 @@
   dt = 0.1
   num_steps = 30
 
-  [./Predictor]
-    type = SimplePredictor
-    scale = 1.0
-  [../]
+#   [./Predictor]
+#     type = SimplePredictor
+#     scale = 1.0
+#   [../]
 [] # Executioner
 
 [Outputs]
@@ -129,4 +129,5 @@
   exodus = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1'
 [] # Outputs

--- a/modules/combined/tests/fdp_geometric_coupling/fdp_geometric_coupling_test.i
+++ b/modules/combined/tests/fdp_geometric_coupling/fdp_geometric_coupling_test.i
@@ -211,4 +211,5 @@
   exodus = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1 dummy_name_contact_force_2'
 [] # Outputs

--- a/modules/combined/tests/glued_contact/glued_contact_mechanical_constraint_test.i
+++ b/modules/combined/tests/glued_contact/glued_contact_mechanical_constraint_test.i
@@ -165,4 +165,5 @@
   exodus = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1 dummy_name_contact_force_2'
 [] # Outputs

--- a/modules/combined/tests/glued_contact/glued_contact_test.i
+++ b/modules/combined/tests/glued_contact/glued_contact_test.i
@@ -163,4 +163,5 @@
   exodus = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1 dummy_name_contact_force_2'
 [] # Outputs

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic.i
@@ -152,6 +152,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'leftright_contact_force_0 leftright_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic_dirac.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic_dirac.i
@@ -153,6 +153,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'leftright_contact_force_0 leftright_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty.i
@@ -152,6 +152,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'leftright_contact_force_0 leftright_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty_dirac.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty_dirac.i
@@ -153,6 +153,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'leftright_contact_force_0 leftright_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic.i
@@ -152,6 +152,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'leftright_contact_force_0 leftright_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic_dirac.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic_dirac.i
@@ -153,6 +153,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'leftright_contact_force_0 leftright_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty.i
@@ -152,6 +152,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'leftright_contact_force_0 leftright_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty_dirac.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty_dirac.i
@@ -153,6 +153,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'leftright_contact_force_0 leftright_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/normalized_penalty/normalized_penalty.i
+++ b/modules/combined/tests/normalized_penalty/normalized_penalty.i
@@ -144,4 +144,5 @@
   output_initial = true
   exodus = true
   print_linear_residuals = true
+  hide = 'm3_s2_contact_force_0 m3_s2_contact_force_1'
 [] # Output

--- a/modules/combined/tests/normalized_penalty/normalized_penalty_Q8.i
+++ b/modules/combined/tests/normalized_penalty/normalized_penalty_Q8.i
@@ -138,4 +138,5 @@
   output_initial = true
   exodus = true
   print_linear_residuals = true
+  hide = 'm3_s2_contact_force_0 m3_s2_contact_force_1'
 [] # Output

--- a/modules/combined/tests/normalized_penalty/normalized_penalty_kin.i
+++ b/modules/combined/tests/normalized_penalty/normalized_penalty_kin.i
@@ -143,4 +143,5 @@
   output_initial = true
   exodus = true
   print_linear_residuals = true
+  hide = 'm3_s2_contact_force_0 m3_s2_contact_force_1'
 [] # Output

--- a/modules/combined/tests/normalized_penalty/normalized_penalty_kin_Q8.i
+++ b/modules/combined/tests/normalized_penalty/normalized_penalty_kin_Q8.i
@@ -137,4 +137,5 @@
   output_initial = true
   exodus = true
   print_linear_residuals = true
+  hide = 'm3_s2_contact_force_0 m3_s2_contact_force_1'
 [] # Output

--- a/modules/combined/tests/ring_contact/ring_contact.i
+++ b/modules/combined/tests/ring_contact/ring_contact.i
@@ -170,4 +170,5 @@
   exodus = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1 dummy_name_contact_force_2'
 [] # Outputs

--- a/modules/combined/tests/simple_contact/simple_contact_mechanical_constraint2.i
+++ b/modules/combined/tests/simple_contact/simple_contact_mechanical_constraint2.i
@@ -159,4 +159,5 @@
   exodus = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1 dummy_name_contact_force_2'
 [] # Outputs

--- a/modules/combined/tests/simple_contact/simple_contact_mechanical_constraint_test.i
+++ b/modules/combined/tests/simple_contact/simple_contact_mechanical_constraint_test.i
@@ -160,6 +160,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1 dummy_name_contact_force_2'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/simple_contact/simple_contact_rspherical.i
+++ b/modules/combined/tests/simple_contact/simple_contact_rspherical.i
@@ -147,4 +147,5 @@
   output_initial = true
   exodus = true
   print_linear_residuals = true
+  hide = 'fred_contact_force_0'
 [] # Outputs

--- a/modules/combined/tests/simple_contact/simple_contact_rz_test.i
+++ b/modules/combined/tests/simple_contact/simple_contact_rz_test.i
@@ -202,6 +202,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/tests/simple_contact/simple_contact_test.i
+++ b/modules/combined/tests/simple_contact/simple_contact_test.i
@@ -158,6 +158,7 @@
   output_initial = true
   print_linear_residuals = true
   print_perf_log = true
+  hide = 'dummy_name_contact_force_0 dummy_name_contact_force_1 dummy_name_contact_force_2'
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/contact/include/MechanicalContactConstraint.h
+++ b/modules/contact/include/MechanicalContactConstraint.h
@@ -92,7 +92,6 @@ protected:
   const ContactModel _model;
   const ContactFormulation _formulation;
   const bool _normalize_penalty;
-
   const Real _penalty;
   const Real _friction_coefficient;
   const Real _tension_release;
@@ -112,7 +111,8 @@ protected:
 
   MooseVariable * _nodal_area_var;
   SystemBase & _aux_system;
-  const NumericVector<Number> * _aux_solution;
+
+  libMesh::VectorValue<unsigned> _contact_force_var;
 
   /// Whether to include coupling between the master and slave nodes in the Jacobian
   const bool _master_slave_jacobian;
@@ -120,6 +120,10 @@ protected:
   const bool _connected_slave_nodes_jacobian;
   /// Whether to include coupling terms with non-displacement variables in the Jacobian
   const bool _non_displacement_vars_jacobian;
+
+private:
+  void copyContactForceFromAuxVars();
+  void copyContactForceToAuxVars();
 };
 
 #endif

--- a/modules/contact/src/ContactAction.C
+++ b/modules/contact/src/ContactAction.C
@@ -11,8 +11,7 @@
 #include "Parser.h"
 #include "MooseApp.h"
 #include "Conversion.h"
-
-static unsigned int counter = 0;
+#include "libmesh/string_to_enum.h"
 
 template<>
 InputParameters validParams<ContactAction>()
@@ -75,72 +74,35 @@ ContactAction::act()
   // Chop off "Contact/"
   short_name.erase(0, 8);
 
-  std::vector<NonlinearVariableName> vars;
-  vars.push_back(_disp_x);
-  vars.push_back(_disp_y);
-  vars.push_back(_disp_z);
-
-  if (_system == "Constraint")
+  std::vector<std::string> contact_force_param_name(dim);
+  std::vector<std::string> contact_force_var_name(dim);
+  for ( unsigned i = 0; i < dim; ++i )
   {
-    InputParameters params = _factory.getValidParams("MechanicalContactConstraint");
+    contact_force_param_name[i] = "contact_force_" + Moose::stringify(i);
+    contact_force_var_name[i] = short_name + "_" + contact_force_param_name[i];
+  }
 
-    // Extract global params
-    _app.parser().extractParams(_name, params);
-
-    // Create master objects
-    params.set<std::string>("model") = _model;
-    params.set<std::string>("formulation") = _formulation;
-    params.set<MooseEnum>("order") = _order;
-    params.set<BoundaryName>("boundary") = _master;
-    params.set<BoundaryName>("slave") = _slave;
-    params.set<Real>("penalty") = _penalty;
-    params.set<Real>("friction_coefficient") = _friction_coefficient;
-    params.set<Real>("tension_release") = _tension_release;
-    params.addRequiredCoupledVar("nodal_area", "The nodal area");
-    params.set<std::vector<VariableName> >("nodal_area") = std::vector<VariableName>(1, "nodal_area_"+short_name);
-
-    if (isParamValid("tangential_tolerance"))
-      params.set<Real>("tangential_tolerance") = getParam<Real>("tangential_tolerance");
-
-    if (isParamValid("normal_smoothing_distance"))
-      params.set<Real>("normal_smoothing_distance") = getParam<Real>("normal_smoothing_distance");
-
-    if (isParamValid("normal_smoothing_method"))
-      params.set<std::string>("normal_smoothing_method") = getParam<std::string>("normal_smoothing_method");
-
-    params.addCoupledVar("disp_x", "The x displacement");
-    params.set<std::vector<VariableName> >("disp_x") = std::vector<VariableName>(1, _disp_x);
-
-    params.addCoupledVar("disp_y", "The y displacement");
-    if (dim > 1)
-      params.set<std::vector<VariableName> >("disp_y") = std::vector<VariableName>(1, _disp_y);
-
-    params.addCoupledVar("disp_z", "The z displacement");
-    if (dim == 3)
-      params.set<std::vector<VariableName> >("disp_z") = std::vector<VariableName>(1, _disp_z);
-
-    params.set<bool>("use_displaced_mesh") = true;
-
-    for (unsigned int i(0); i < dim; ++i)
+  if ( _current_task == "add_aux_variable" )
+  {
+    for ( unsigned i = 0; i < dim; ++i )
     {
-      std::stringstream name;
-      name << short_name;
-      name << "_constraint_";
-      name << i;
-
-      params.set<unsigned int>("component") = i;
-      params.set<NonlinearVariableName>("variable") = vars[i];
-      params.set<std::vector<VariableName> >("master_variable") = std::vector<VariableName>(1,vars[i]);
-
-      _problem->addConstraint("MechanicalContactConstraint",
-                              name.str(),
-                              params);
+      _problem->addAuxVariable(
+        contact_force_var_name[i],
+        FEType(Utility::string_to_enum<Order>(getParam<MooseEnum>("order")),
+        Utility::string_to_enum<FEFamily>("LAGRANGE")));
     }
   }
-  else if (_system == "DiracKernel")
+
+  if ( _current_task == "add_dg_kernel" )
   {
+    std::vector<NonlinearVariableName> vars;
+    vars.push_back(_disp_x);
+    vars.push_back(_disp_y);
+    vars.push_back(_disp_z);
+
+    if (_system == "Constraint")
     {
-      InputParameters params = _factory.getValidParams("ContactMaster");
+      InputParameters params = _factory.getValidParams("MechanicalContactConstraint");
 
       // Extract global params
       _app.parser().extractParams(_name, params);
@@ -179,78 +141,127 @@ ContactAction::act()
 
       params.set<bool>("use_displaced_mesh") = true;
 
+      for ( unsigned i = 0; i < dim; ++i )
+        params.set<AuxVariableName>(contact_force_param_name[i]) = contact_force_var_name[i];
+
       for (unsigned int i(0); i < dim; ++i)
       {
-        std::stringstream name;
-        name << short_name;
-        name << "_master_";
-        name << i;
-
+        std::string name = short_name + "_constraint_" + Moose::stringify(i);
         params.set<unsigned int>("component") = i;
         params.set<NonlinearVariableName>("variable") = vars[i];
+        params.set<std::vector<VariableName> >("master_variable") = std::vector<VariableName>(1,vars[i]);
 
-        _problem->addDiracKernel("ContactMaster",
-                                 name.str(),
-                                 params);
+        _problem->addConstraint("MechanicalContactConstraint",
+                                name,
+                                params);
+
       }
     }
-
+    else if (_system == "DiracKernel")
     {
-      InputParameters params = _factory.getValidParams("SlaveConstraint");
-
-      // Extract global params
-      _app.parser().extractParams(_name, params);
-
-      // Create slave objects
-      params.set<std::string>("model") = _model;
-      params.set<std::string>("formulation") = _formulation;
-      params.set<MooseEnum>("order") = _order;
-      params.set<BoundaryName>("boundary") = _slave;
-      params.set<BoundaryName>("master") = _master;
-      params.set<Real>("penalty") = _penalty;
-      params.set<Real>("friction_coefficient") = _friction_coefficient;
-      params.addRequiredCoupledVar("nodal_area", "The nodal area");
-      params.set<std::vector<VariableName> >("nodal_area") = std::vector<VariableName>(1, "nodal_area_"+short_name);
-      if (isParamValid("tangential_tolerance"))
-        params.set<Real>("tangential_tolerance") = getParam<Real>("tangential_tolerance");
-
-      if (isParamValid("normal_smoothing_distance"))
-        params.set<Real>("normal_smoothing_distance") = getParam<Real>("normal_smoothing_distance");
-
-      if (isParamValid("normal_smoothing_method"))
-        params.set<std::string>("normal_smoothing_method") = getParam<std::string>("normal_smoothing_method");
-
-      params.addCoupledVar("disp_x", "The x displacement");
-      params.set<std::vector<VariableName> >("disp_x") = std::vector<VariableName>(1, _disp_x);
-
-      params.addCoupledVar("disp_y", "The y displacement");
-      if (dim > 1)
-        params.set<std::vector<VariableName> >("disp_y") = std::vector<VariableName>(1, _disp_y);
-
-      params.addCoupledVar("disp_z", "The z displacement");
-      if (dim == 3)
-        params.set<std::vector<VariableName> >("disp_z") = std::vector<VariableName>(1, _disp_z);
-
-      params.set<bool>("use_displaced_mesh") = true;
-
-      for (unsigned int i(0); i < dim; ++i)
       {
-        std::stringstream name;
-        name << short_name;
-        name << "_slave_";
-        name << i;
+        InputParameters params = _factory.getValidParams("ContactMaster");
 
-        params.set<unsigned int>("component") = i;
-        params.set<NonlinearVariableName>("variable") = vars[i];
+        // Extract global params
+        _app.parser().extractParams(_name, params);
 
-        _problem->addDiracKernel("SlaveConstraint",
-                                 name.str(),
-                                 params);
+        // Create master objects
+        params.set<std::string>("model") = _model;
+        params.set<std::string>("formulation") = _formulation;
+        params.set<MooseEnum>("order") = _order;
+        params.set<BoundaryName>("boundary") = _master;
+        params.set<BoundaryName>("slave") = _slave;
+        params.set<Real>("penalty") = _penalty;
+        params.set<Real>("friction_coefficient") = _friction_coefficient;
+        params.set<Real>("tension_release") = _tension_release;
+        params.addRequiredCoupledVar("nodal_area", "The nodal area");
+        params.set<std::vector<VariableName> >("nodal_area") = std::vector<VariableName>(1, "nodal_area_"+short_name);
+
+        if (isParamValid("tangential_tolerance"))
+          params.set<Real>("tangential_tolerance") = getParam<Real>("tangential_tolerance");
+
+        if (isParamValid("normal_smoothing_distance"))
+          params.set<Real>("normal_smoothing_distance") = getParam<Real>("normal_smoothing_distance");
+
+        if (isParamValid("normal_smoothing_method"))
+          params.set<std::string>("normal_smoothing_method") = getParam<std::string>("normal_smoothing_method");
+
+        params.addCoupledVar("disp_x", "The x displacement");
+        params.set<std::vector<VariableName> >("disp_x") = std::vector<VariableName>(1, _disp_x);
+
+        params.addCoupledVar("disp_y", "The y displacement");
+        if (dim > 1)
+          params.set<std::vector<VariableName> >("disp_y") = std::vector<VariableName>(1, _disp_y);
+
+        params.addCoupledVar("disp_z", "The z displacement");
+        if (dim == 3)
+          params.set<std::vector<VariableName> >("disp_z") = std::vector<VariableName>(1, _disp_z);
+
+        params.set<bool>("use_displaced_mesh") = true;
+
+        for (unsigned int i(0); i < dim; ++i)
+        {
+          std::string name = short_name + "_master_" + Moose::stringify(i);
+          params.set<unsigned int>("component") = i;
+          params.set<NonlinearVariableName>("variable") = vars[i];
+
+          _problem->addDiracKernel("ContactMaster",
+                                   name,
+                                   params);
+        }
+      }
+
+      {
+        InputParameters params = _factory.getValidParams("SlaveConstraint");
+
+        // Extract global params
+        _app.parser().extractParams(_name, params);
+
+        // Create slave objects
+        params.set<std::string>("model") = _model;
+        params.set<std::string>("formulation") = _formulation;
+        params.set<MooseEnum>("order") = _order;
+        params.set<BoundaryName>("boundary") = _slave;
+        params.set<BoundaryName>("master") = _master;
+        params.set<Real>("penalty") = _penalty;
+        params.set<Real>("friction_coefficient") = _friction_coefficient;
+        params.addRequiredCoupledVar("nodal_area", "The nodal area");
+        params.set<std::vector<VariableName> >("nodal_area") = std::vector<VariableName>(1, "nodal_area_"+short_name);
+        if (isParamValid("tangential_tolerance"))
+          params.set<Real>("tangential_tolerance") = getParam<Real>("tangential_tolerance");
+
+        if (isParamValid("normal_smoothing_distance"))
+          params.set<Real>("normal_smoothing_distance") = getParam<Real>("normal_smoothing_distance");
+
+        if (isParamValid("normal_smoothing_method"))
+          params.set<std::string>("normal_smoothing_method") = getParam<std::string>("normal_smoothing_method");
+
+        params.addCoupledVar("disp_x", "The x displacement");
+        params.set<std::vector<VariableName> >("disp_x") = std::vector<VariableName>(1, _disp_x);
+
+        params.addCoupledVar("disp_y", "The y displacement");
+        if (dim > 1)
+          params.set<std::vector<VariableName> >("disp_y") = std::vector<VariableName>(1, _disp_y);
+
+        params.addCoupledVar("disp_z", "The z displacement");
+        if (dim == 3)
+          params.set<std::vector<VariableName> >("disp_z") = std::vector<VariableName>(1, _disp_z);
+
+        params.set<bool>("use_displaced_mesh") = true;
+
+        for (unsigned int i(0); i < dim; ++i)
+        {
+          std::string name = short_name + "_slave_" + Moose::stringify(i);
+          params.set<unsigned int>("component") = i;
+          params.set<NonlinearVariableName>("variable") = vars[i];
+
+          _problem->addDiracKernel("SlaveConstraint",
+                                   name,
+                                   params);
+        }
       }
     }
+    else
+      mooseError("Invalid system for contact constraint enforcement: "<<_system);
   }
-  else
-    mooseError("Invalid system for contact constraint enforcement: "<<_system);
-
-  ++counter;
 }

--- a/modules/contact/src/base/ContactApp.C
+++ b/modules/contact/src/base/ContactApp.C
@@ -90,6 +90,7 @@ ContactApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("NodalAreaAction", "Contact/*");
   syntax.registerActionSyntax("NodalAreaVarAction", "Contact/*");
 
+  registerAction(ContactAction, "add_aux_variable");
   registerAction(ContactAction, "add_dg_kernel");
 
   registerAction(ContactPenetrationAuxAction, "add_aux_kernel");


### PR DESCRIPTION
Moves the saved states of PenetrationInfo::_contact_force and _contact_force_old into a set of aux variables. The members still exist in PenetrationInfo, but they are set/saved from aux variables that are setup by the ContactAction.

No effort was made to update Dirac contact since it should be going away once constraint-based contact is working well.
