### PR TITLE
Protect parameters containing equal signs

### DIFF
--- a/gui/gui/InputFileTextbox.py
+++ b/gui/gui/InputFileTextbox.py
@@ -172,7 +172,7 @@ class InputFileTextbox(QtGui.QTextEdit):
             comment = ' # ' + item.param_comments[param]
 
           param_value = item.table_data[param]
-          if ' ' in param_value:
+          if ' ' in param_value or '=' in param_value:
             param_value = "'"+param_value.strip("'")+"'"
 
           self.the_string += indent_string + '  ' + param + ' = ' + param_value + comment + '\n'


### PR DESCRIPTION
Since I don't see getpot being fixed anytime soon, I suggest this simple fix to get the multiphase field example running under peacock.

Closes #4838.
