### PR TITLE
Add off-diagonal entries for CHParsed and additional derivatives for DerivativeMultiPhaseBase

### DIFF
--- a/modules/phase_field/include/kernels/CHParsed.h
+++ b/modules/phase_field/include/kernels/CHParsed.h
@@ -9,6 +9,7 @@
 
 #include "CHBulk.h"
 #include "DerivativeKernelInterface.h"
+#include "JvarMapInterface.h"
 
 //Forward Declarations
 class CHParsed;
@@ -21,17 +22,19 @@ InputParameters validParams<CHParsed>();
  * provided by a DerivativeParsedMaterial.
  * \see SplitCHParsed
  */
-class CHParsed : public DerivativeKernelInterface<CHBulk>
+class CHParsed : public DerivativeKernelInterface<JvarMapInterface<CHBulk> >
 {
 public:
   CHParsed(const std::string & name, InputParameters parameters);
 
 protected:
   virtual RealGradient computeGradDFDCons(PFFunctionType type);
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
   std::vector<const MaterialProperty<Real>* > _second_derivatives;
   std::vector<const MaterialProperty<Real>* > _third_derivatives;
+  std::vector<std::vector<const MaterialProperty<Real>* > > _third_cross_derivatives;
   std::vector<VariableGradient *> _grad_vars;
 };
 

--- a/modules/phase_field/include/materials/DerivativeMultiPhaseBase.h
+++ b/modules/phase_field/include/materials/DerivativeMultiPhaseBase.h
@@ -76,6 +76,7 @@ protected:
   /// Barrier function derivatives.
   std::vector<const MaterialProperty<Real> *> _dg;
   std::vector<std::vector<const MaterialProperty<Real> *> > _d2g;
+  std::vector<std::vector<std::vector<const MaterialProperty<Real> *> > > _d3g;
 
   /// Phase transformation energy barrier
   Real _W;

--- a/modules/phase_field/include/materials/DerivativeMultiPhaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeMultiPhaseMaterial.h
@@ -28,9 +28,10 @@ public:
 protected:
   virtual Real computeDF(unsigned int);
   virtual Real computeD2F(unsigned int, unsigned int);
+  virtual Real computeD3F(unsigned int, unsigned int, unsigned int);
 
   /// Function value of the i phase.
-  std::vector<const MaterialProperty<Real> *> _dhi, _d2hi;
+  std::vector<const MaterialProperty<Real> *> _dhi, _d2hi, _d3hi;
 };
 
 #endif // DERIVATIVEMULTIPHASEMATERIAL_H

--- a/modules/phase_field/src/materials/DerivativeMultiPhaseBase.C
+++ b/modules/phase_field/src/materials/DerivativeMultiPhaseBase.C
@@ -45,6 +45,7 @@ DerivativeMultiPhaseBase::DerivativeMultiPhaseBase(const std::string & name,
     _g(getMaterialProperty<Real>(_g_name)),
     _dg(_num_etas),
     _d2g(_num_etas),
+    _d3g(_num_etas),
     _W(getParam<Real>("W"))
 {
   // check passed in parameter vectors
@@ -65,8 +66,20 @@ DerivativeMultiPhaseBase::DerivativeMultiPhaseBase(const std::string & name,
     // barrier function derivatives
     _dg[i] = &getMaterialPropertyDerivative<Real>(_g_name, _eta_names[i]);
     _d2g[i].resize(_num_etas);
+    if (_third_derivatives)
+      _d3g[i].resize(_num_etas);
+
     for (unsigned int j = 0; j < _num_etas; ++j)
+    {
       _d2g[i][j] = &getMaterialPropertyDerivative<Real>(_g_name, _eta_names[i], _eta_names[j]);
+
+      if (_third_derivatives)
+      {
+        _d3g[i][j].resize(_num_etas);
+        for (unsigned int k = 0; k < _num_etas; ++k)
+          _d3g[i][j][k] = &getMaterialPropertyDerivative<Real>(_g_name, _eta_names[i], _eta_names[j], _eta_names[k]);
+      }
+    }
   }
 
   // reserve space and set phase material properties

--- a/modules/phase_field/src/materials/DerivativeMultiPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeMultiPhaseMaterial.C
@@ -19,7 +19,8 @@ DerivativeMultiPhaseMaterial::DerivativeMultiPhaseMaterial(const std::string & n
                                                                                InputParameters parameters) :
     DerivativeMultiPhaseBase(name, parameters),
     _dhi(_num_etas),
-    _d2hi(_num_etas)
+    _d2hi(_num_etas),
+    _d3hi(_num_etas)
 {
   // verify that the user supplied one less eta than the number of phases
   if (_num_hi != _num_etas)
@@ -29,6 +30,9 @@ DerivativeMultiPhaseMaterial::DerivativeMultiPhaseMaterial(const std::string & n
   {
     _dhi[i] = &getMaterialPropertyDerivative<Real>(_hi_names[i], _eta_names[i]);
     _d2hi[i] = &getMaterialPropertyDerivative<Real>(_hi_names[i], _eta_names[i], _eta_names[i]);
+
+    if (_third_derivatives)
+      _d3hi[i] = &getMaterialPropertyDerivative<Real>(_hi_names[i], _eta_names[i], _eta_names[i], _eta_names[i]);
   }
 }
 
@@ -57,6 +61,8 @@ DerivativeMultiPhaseMaterial::computeD2F(unsigned int i_var, unsigned int j_var)
   const unsigned int j = argIndex(j_var);
   const int j_eta = _eta_index[j];
 
+  // all arguments are eta-variables
+
   if (i_eta >= 0 && j_eta >= 0)
   {
     // if the derivatives are taken w.r.t. a single eta the d2hi term for eta_i appears, otherwise it drops out
@@ -66,14 +72,69 @@ DerivativeMultiPhaseMaterial::computeD2F(unsigned int i_var, unsigned int j_var)
     return  d2F + _W * (*_d2g[i_eta][j_eta])[_qp];
   }
 
+  // one argument is an eta-variable
+
   if (i_eta >= 0)
     return (*_dhi[i_eta])[_qp] * (*_prop_dFi[i_eta][j])[_qp];
 
   if (j_eta >= 0)
     return (*_dhi[j_eta])[_qp] * (*_prop_dFi[j_eta][i])[_qp];
 
+  // no arguments are eta-variables
+
   Real d2F = 0.0;
   for (unsigned n = 0; n < _num_fi; ++n)
     d2F += (*_hi[n])[_qp] * (*_prop_d2Fi[n][i][j])[_qp];
   return d2F;
+}
+
+Real
+DerivativeMultiPhaseMaterial::computeD3F(unsigned int i_var, unsigned int j_var, unsigned int k_var)
+{
+  const unsigned int i = argIndex(i_var);
+  const int i_eta = _eta_index[i];
+  const unsigned int j = argIndex(j_var);
+  const int j_eta = _eta_index[j];
+  const unsigned int k = argIndex(k_var);
+  const int k_eta = _eta_index[k];
+
+  // all arguments are eta-variables
+
+  if (i_eta >= 0 && j_eta >= 0 && k_eta >= 0)
+  {
+    // if the derivatives are taken w.r.t. a single eta the d3hi term for eta_i appears, otherwise it drops out
+    // because we assume that hi _only_ depends on eta_i
+    Real d3F = (i_eta == j_eta && j_eta == k_eta) ? (*_d3hi[i_eta])[_qp] * (*_prop_Fi[i_eta])[_qp] : 0.0;
+
+    return  d3F + _W * (*_d3g[i_eta][j_eta][k_eta])[_qp];
+  }
+
+  // two arguments are eta-variables
+
+  if (i_eta >= 0 && j_eta >= 0)
+    return (i_eta == j_eta) ? (*_d2hi[i_eta])[_qp] * (*_prop_dFi[i_eta][k])[_qp] : 0.0;
+
+  if (j_eta >= 0 && k_eta >= 0)
+    return (j_eta == k_eta) ? (*_d2hi[j_eta])[_qp] * (*_prop_dFi[j_eta][i])[_qp] : 0.0;
+
+  if (k_eta >= 0 && i_eta >= 0)
+    return (k_eta == i_eta) ? (*_d2hi[k_eta])[_qp] * (*_prop_dFi[k_eta][j])[_qp] : 0.0;
+
+  // one argument is an eta-variable
+
+  if (i_eta >= 0)
+    return (*_dhi[i_eta])[_qp] * (*_prop_d2Fi[i_eta][j][k])[_qp];
+
+  if (j_eta >= 0)
+    return (*_dhi[j_eta])[_qp] * (*_prop_d2Fi[j_eta][i][k])[_qp];
+
+  if (k_eta >= 0)
+    return (*_dhi[k_eta])[_qp] * (*_prop_d2Fi[k_eta][i][j])[_qp];
+
+  // no arguments are eta-variables
+
+  Real d3F = 0.0;
+  for (unsigned n = 0; n < _num_fi; ++n)
+    d3F += (*_hi[n])[_qp] * (*_prop_d3Fi[n][i][j][k])[_qp];
+  return d3F;
 }


### PR DESCRIPTION
This adds missing off-diagonal Jacobian entries for the direct solve derivative material Cahn-Hilliard kernel. In the process I remembered to add the necessary 3rd derivatives to the DerivativeMultiPhaseBase class.

Closes #4872.
