### PR TITLE
Add epsilon to SwitchingFunctionConstraintLagrange

### DIFF
--- a/modules/phase_field/include/kernels/SwitchingFunctionConstraintLagrange.h
+++ b/modules/phase_field/include/kernels/SwitchingFunctionConstraintLagrange.h
@@ -19,7 +19,7 @@ InputParameters validParams<SwitchingFunctionConstraintLagrange>();
 /**
  * SwitchingFunctionConstraintLagrange is a constraint kernel that acts on the
  * lambda lagrange multiplier non-linear variables to
- * enforce \f$ \sum_n h_i(\eta_i) \equiv 1 \f$.
+ * enforce \f$ \sum_n h_i(\eta_i) - \epsilon\lambda \equiv 1 \f$.
  */
 class SwitchingFunctionConstraintLagrange : public DerivativeMaterialInterface<Kernel>
 {
@@ -43,6 +43,9 @@ protected:
 
   /// eta index for the j_vars in the jacobian computation
   std::vector<int> _j_eta;
+
+  /// shift factor
+  Real _epsilon;
 };
 
 #endif //SWITCHINGFUNCTIONCONSTRAINTLAGRANGE_H

--- a/modules/phase_field/tests/MultiPhase/acmultiinterface.i
+++ b/modules/phase_field/tests/MultiPhase/acmultiinterface.i
@@ -141,6 +141,7 @@
     variable = lambda
     etas    = 'eta1 eta2 eta3'
     h_names = 'h1   h2   h3'
+    epsilon = 0
   [../]
 []
 

--- a/modules/phase_field/tests/MultiPhase/acmultiinterface_aux.i
+++ b/modules/phase_field/tests/MultiPhase/acmultiinterface_aux.i
@@ -119,6 +119,7 @@
     variable = lambda
     etas    = 'eta1 eta2 eta3'
     h_names = 'h1   h2   h3'
+    epsilon = 0
   [../]
 []
 

--- a/modules/phase_field/tests/MultiPhase/lagrangemult.i
+++ b/modules/phase_field/tests/MultiPhase/lagrangemult.i
@@ -106,6 +106,7 @@
     variable = lambda
     etas    = 'eta1 eta2'
     h_names = 'h1   h2'
+    epsilon = 0
   [../]
 
   [./c_res]


### PR DESCRIPTION
Together with #4875 this makes `SwitchingFunctionConstraintLagrange` work on multiphase problems. It converges well and provides a tighter enforcement.

Closes #4876.
