### PR TITLE
Massive brain-damage that *is* causing the remapping to give up too early

### DIFF
--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -607,7 +607,7 @@ GrainTracker::remapGrains()
   bool variables_remapped;
   do
   {
-    Moose::out << "Remap Loop: " << ++times_through_loop << std::endl;
+    Moose::out << "Remap Loop: " << times_through_loop << std::endl;
 
     variables_remapped = false;
     for (std::map<unsigned int, UniqueGrain *>::iterator grain_it1 = _unique_grains.begin();
@@ -639,7 +639,7 @@ GrainTracker::remapGrains()
       }
     }
 
-    if (times_through_loop >= 5)
+    if (++times_through_loop >= 5)
       mooseError(COLOR_RED << "Five passes through the remapping loop and grains are still being remapped, perhaps you need more op variables?" << COLOR_DEFAULT);
 
   } while (variables_remapped);


### PR DESCRIPTION
closes #4890

The issue is that the loop counter is also being passed to the `swapSolutionValues()` method where it is used to select the ith best match. By adding the print statement and incrementing earlier, I have effectively skipped the first match which is usually the best and sometimes the only one.
