### PR TITLE
Rework Peacock visualization tab

### DIFF
--- a/gui/peacock
+++ b/gui/peacock
@@ -75,11 +75,13 @@ class UiBox(QtGui.QMainWindow):
     self.main_ui = QtGui.QWidget(self)
     self.main_ui.setObjectName(_fromUtf8("Dialog"))
     self.main_layout = QtGui.QVBoxLayout()
+    self.main_layout.setContentsMargins(0,0,0,0)
     self.setCentralWidget(self.main_ui)
 
     self.tabs = self.application.tabs(self)
 
     self.tab_widget = QtGui.QTabWidget()
+    self.tab_widget.setDocumentMode(True)
 
     for tab in self.tabs:
       self.tab_widget.addTab(tab, tab.name())

--- a/gui/peacock
+++ b/gui/peacock
@@ -81,7 +81,6 @@ class UiBox(QtGui.QMainWindow):
     self.tabs = self.application.tabs(self)
 
     self.tab_widget = QtGui.QTabWidget()
-    self.tab_widget.setDocumentMode(True)
 
     for tab in self.tabs:
       self.tab_widget.addTab(tab, tab.name())

--- a/gui/vtk/ExodusResultRenderWidget.py
+++ b/gui/vtk/ExodusResultRenderWidget.py
@@ -256,9 +256,10 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.displace_checkbox.toggled[bool].connect(self._displaceToggled)
 
     self.displace_magnitude_label = QtGui.QLabel("Multiplier: ")
-    self.displace_magnitude_text = QtGui.QLineEdit("1.0")
+    self.displace_magnitude_text = QtGui.QDoubleSpinBox()
+    self.displace_magnitude_text.setValue(self.current_displacement_magnitude)
     self.displace_magnitude_text.setMinimumWidth(10)
-    self.displace_magnitude_text.returnPressed.connect(self._displaceMagnitudeTextReturn)
+    self.displace_magnitude_text.valueChanged.connect(self._displaceMagnitudeChanged)
 
     self.displace_layout.addWidget(self.displace_checkbox)
     self.displace_layout.addSpacing(10)
@@ -337,7 +338,6 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.clip_plane_combobox.addItem('z')
     self.clip_plane_combobox.currentIndexChanged[str].connect(self._clipNormalChanged)
     self.clip_layout.addWidget(self.clip_plane_combobox)
-    self.scale_layout.addSpacing(5)
 
     self.clip_plane_slider = QtGui.QSlider(QtCore.Qt.Horizontal)
     self.clip_plane_slider.setToolTip('Slide to change plane position')
@@ -421,6 +421,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
 
     self.min_custom_layout = QtGui.QHBoxLayout()
     self.min_custom_layout.setContentsMargins(0,0,0,0)
+    self.min_custom_layout.setSpacing(5)
     self.min_custom_radio = QtGui.QRadioButton()
     self.min_custom_radio.toggled.connect(self._updateContours)
     self.min_custom_text = QtGui.QLineEdit()
@@ -454,7 +455,8 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.max_radio_layout.addWidget(self.max_current_radio)
 
     self.max_custom_layout = QtGui.QHBoxLayout()
-    self.max_custom_layout.setSpacing(0)
+    self.max_custom_layout.setContentsMargins(0,0,0,0)
+    self.max_custom_layout.setSpacing(5)
     self.max_custom_radio = QtGui.QRadioButton()
     self.max_custom_radio.toggled.connect(self._updateContours)
     self.max_custom_text = QtGui.QLineEdit()
@@ -705,8 +707,8 @@ class ExodusResultRenderWidget(QtGui.QWidget):
   def _scaleToggled(self, value):
     self._timeSliderReleased()
 
-  def _displaceMagnitudeTextReturn(self):
-    self.current_displacement_magnitude = float(self.displace_magnitude_text.text())
+  def _displaceMagnitudeChanged(self):
+    self.current_displacement_magnitude = self.displace_magnitude_text.value()
     self._timeSliderReleased()
 
   def _scaleMagnitudeChanged(self):

--- a/gui/vtk/ExodusResultRenderWidget.py
+++ b/gui/vtk/ExodusResultRenderWidget.py
@@ -287,23 +287,29 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.scale_layout.addStretch()
 
     self.scale_x_label = QtGui.QLabel(" x:")
-    self.scale_x_text = QtGui.QLineEdit("1.0")
+    self.scale_x_text = QtGui.QDoubleSpinBox()
+    self.scale_x_text.setValue(1.0)
+    self.scale_x_text.setSingleStep(0.1)
     self.scale_x_text.setMinimumWidth(10)
     self.scale_x_text.setMaximumWidth(50)
 
     self.scale_y_label = QtGui.QLabel(" y:")
-    self.scale_y_text = QtGui.QLineEdit("1.0")
+    self.scale_y_text = QtGui.QDoubleSpinBox()
+    self.scale_y_text.setValue(1.0)
+    self.scale_y_text.setSingleStep(0.1)
     self.scale_y_text.setMinimumWidth(10)
     self.scale_y_text.setMaximumWidth(50)
 
     self.scale_z_label = QtGui.QLabel(" z:")
-    self.scale_z_text = QtGui.QLineEdit("1.0")
+    self.scale_z_text = QtGui.QDoubleSpinBox()
+    self.scale_z_text.setValue(1.0)
+    self.scale_z_text.setSingleStep(0.1)
     self.scale_z_text.setMinimumWidth(10)
     self.scale_z_text.setMaximumWidth(50)
 
-    self.scale_x_text.returnPressed.connect(self._scaleMagnitudeTextReturn)
-    self.scale_y_text.returnPressed.connect(self._scaleMagnitudeTextReturn)
-    self.scale_z_text.returnPressed.connect(self._scaleMagnitudeTextReturn)
+    self.scale_x_text.valueChanged.connect(self._scaleMagnitudeChanged)
+    self.scale_y_text.valueChanged.connect(self._scaleMagnitudeChanged)
+    self.scale_z_text.valueChanged.connect(self._scaleMagnitudeChanged)
 
     self.scale_layout.addWidget(self.scale_x_label, alignment=QtCore.Qt.AlignRight)
     self.scale_layout.addWidget(self.scale_x_text, alignment=QtCore.Qt.AlignLeft)
@@ -725,10 +731,10 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.current_displacement_magnitude = float(self.displace_magnitude_text.text())
     self._timeSliderReleased()
 
-  def _scaleMagnitudeTextReturn(self):
-    self.current_scale_x_magnitude = float(self.scale_x_text.text())
-    self.current_scale_y_magnitude = float(self.scale_y_text.text())
-    self.current_scale_z_magnitude = float(self.scale_z_text.text())
+  def _scaleMagnitudeChanged(self):
+    self.current_scale_x_magnitude = self.scale_x_text.value()
+    self.current_scale_y_magnitude = self.scale_y_text.value()
+    self.current_scale_z_magnitude = self.scale_z_text.value()
     self._timeSliderReleased()
 
   def _drawEdgesChanged(self, value):

--- a/gui/vtk/ExodusResultRenderWidget.py
+++ b/gui/vtk/ExodusResultRenderWidget.py
@@ -524,7 +524,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.time_slider_label = QtGui.QLabel("Timestep:")
     self.time_slider = QtGui.QSlider(QtCore.Qt.Horizontal)
     self.time_slider.setToolTip('Slide to select a timestep to display')
-#    self.time_slider.setMaximumWidth(600)
+    self.time_slider.setMinimumWidth(50)
 
     self.time_slider.valueChanged.connect(self._timeSliderChanged)
     self.time_slider.sliderReleased.connect(self._timeSliderReleased)
@@ -546,6 +546,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.time_layout.addWidget(self.time_slider_label, alignment=QtCore.Qt.AlignRight)
     self.time_layout.addWidget(self.time_slider)
     self.time_layout.addWidget(self.time_slider_textbox, alignment=QtCore.Qt.AlignLeft)
+    self.time_layout.addSpacing(10)
 
     # add time controls in the right pane under the render view
     self.right_layout.addLayout(self.time_layout)

--- a/gui/vtk/ExodusResultRenderWidget.py
+++ b/gui/vtk/ExodusResultRenderWidget.py
@@ -216,9 +216,11 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     # min line
     self.min_layout = QtGui.QHBoxLayout()
     self.min_layout.setContentsMargins(0,0,0,0)
+    self.min_widget = QtGui.QWidget()
+    self.min_widget.setLayout(self.min_layout)
 
     self.min_radio_layout = QtGui.QVBoxLayout()
-    self.min_radio_layout.setContentsMargins(0,0,0,0)
+
     self.min_current_radio = QtGui.QRadioButton('Current')
     self.min_current_radio.setChecked(QtCore.Qt.Checked)
     self.min_current_radio.toggled.connect(self._updateContours)
@@ -246,14 +248,15 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.min_layout.setStretchFactor(self.min_custom_layout, 1)
 
     # add min line
-    self.contour_layout.addLayout(self.min_layout)
+    self.contour_layout.addWidget(self.min_widget)
 
     # max line
     self.max_layout = QtGui.QHBoxLayout()
     self.max_layout.setContentsMargins(0,0,0,0)
+    self.max_widget = QtGui.QWidget()
+    self.max_widget.setLayout(self.max_layout)
 
     self.max_radio_layout = QtGui.QVBoxLayout()
-
     self.max_current_radio = QtGui.QRadioButton('Current')
     self.max_current_radio.setChecked(QtCore.Qt.Checked)
     self.max_current_radio.toggled.connect(self._updateContours)
@@ -281,7 +284,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.max_layout.setStretchFactor(self.max_custom_layout, 1)
 
     # add max line
-    self.contour_layout.addLayout(self.max_layout)
+    self.contour_layout.addWidget(self.max_widget)
 
     self.color_scheme_label = QtGui.QLabel("Color Scheme:")
     self.color_scheme_component = QtGui.QComboBox()

--- a/gui/vtk/ExodusResultRenderWidget.py
+++ b/gui/vtk/ExodusResultRenderWidget.py
@@ -68,6 +68,8 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.execution_widget.timestep_end.connect(self._timestepEnd)
 
     self.main_layout = QtGui.QHBoxLayout()
+    self.main_layout.setContentsMargins(0,0,0,0)
+
 #    self.main_layout.setSpacing(0)
 
     self.right_layout = QtGui.QVBoxLayout()
@@ -156,7 +158,9 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     ### Output selection controls ###
     # Create the box, layout, and control
     self.output_control_group_box = QtGui.QGroupBox("Select Output") # adds a box for storing widget
+    self.output_control_group_box.setFlat(True)
     self.output_control_layout = QtGui.QVBoxLayout() # creates a layout
+    self.output_control_layout.setContentsMargins(0,0,0,0)
     self.output_control = QtGui.QComboBox() # adds the actual dropdown menu
 
     # Set-up the control
@@ -171,10 +175,12 @@ class ExodusResultRenderWidget(QtGui.QWidget):
 
 
     self.block_view_group_box = QtGui.QGroupBox('Show Blocks')
-#    self.block_view_group_box.setMaximumWidth(200)
-#    self.block_view_group_box.setMaximumHeight(200)
+    #  self.block_view_group_box.setMaximumWidth(200)
+    #  self.block_view_group_box.setMaximumHeight(200)
 
     self.block_view_layout = QtGui.QVBoxLayout()
+    self.block_view_layout.setContentsMargins(0,0,0,0)
+
     self.block_view_list = QtGui.QListView()
     self.block_view_model = QtGui.QStandardItemModel()
     self.block_view_model.itemChanged.connect(self._blockViewItemChanged)
@@ -204,9 +210,10 @@ class ExodusResultRenderWidget(QtGui.QWidget):
 
     # Create the View Mesh toggle
     self.toggle_groupbox = QtGui.QGroupBox("View")
+    self.toggle_groupbox.setFlat(True)
     self.toggle_groupbox.setMaximumHeight(70)
     self.toggle_layout = QtGui.QHBoxLayout()
-    self.toggle_groupbox.setMaximumHeight(70)
+    self.toggle_layout.setContentsMargins(0,0,0,0)
     self.draw_edges_checkbox = QtGui.QCheckBox("View Mesh")
     self.draw_edges_checkbox.setToolTip('Show mesh elements')
     self.draw_edges_checkbox.stateChanged[int].connect(self._drawEdgesChanged)
@@ -231,6 +238,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.reset_layout.addWidget(self.toggle_groupbox)
 
     self.displace_groupbox = QtGui.QGroupBox("Displace")
+    self.displace_groupbox.setFlat(True)
     self.displace_groupbox.setCheckable(True)
     self.displace_groupbox.setChecked(True)
     self.displace_groupbox.setDisabled(True)
@@ -238,6 +246,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.displace_groupbox.toggled[bool].connect(self._displaceToggled)
     self.displace_layout = QtGui.QHBoxLayout()
     self.displace_layout.setSpacing(0)
+    self.displace_layout.setContentsMargins(0,0,0,0)
     self.displace_groupbox.setLayout(self.displace_layout)
 
     self.displace_magnitude_label = QtGui.QLabel("Multiplier: ")
@@ -255,10 +264,12 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.scale_groupbox.setCheckable(True)
     self.scale_groupbox.setChecked(False)
     self.scale_groupbox.setDisabled(False)
+    self.scale_groupbox.setFlat(True)
     self.scale_groupbox.setMaximumHeight(70)
     self.scale_groupbox.toggled[bool].connect(self._scaleToggled)
     self.scale_layout = QtGui.QHBoxLayout()
     self.scale_layout.setSpacing(0)
+    self.scale_layout.setContentsMargins(0,0,0,0)
     self.scale_groupbox.setLayout(self.scale_layout)
 
     self.scale_x_label = QtGui.QLabel("x: ")
@@ -296,6 +307,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.clip_groupbox.setCheckable(True)
     self.clip_groupbox.setChecked(False)
     self.clip_groupbox.setMaximumHeight(70)
+    self.clip_groupbox.setFlat(True)
     self.clip_groupbox.toggled[bool].connect(self._clippingToggled)
     clip_layout = QtGui.QHBoxLayout()
 
@@ -315,7 +327,8 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.clip_plane_slider.sliderReleased.connect(self._clipSliderReleased)
     self.clip_plane_slider.sliderMoved[int].connect(self._clipSliderMoved)
     clip_layout.addWidget(self.clip_plane_slider)
-#     vbox->addStretch(1);
+    # vbox->addStretch(1);
+    clip_layout.setContentsMargins(0,0,0,0)
     self.clip_groupbox.setLayout(clip_layout)
 
     self.reset_layout.addWidget(self.clip_groupbox)
@@ -348,11 +361,13 @@ class ExodusResultRenderWidget(QtGui.QWidget):
 
 
     self.contour_groupbox = QtGui.QGroupBox("Contour")
+    self.contour_groupbox.setFlat(True)
 #    self.contour_groupbox.setMaximumHeight(10)
 #    self.contour_groupbox.setMaximumHeight(70)
 #    contour_groupbox_policy = QtGui.QSizePolicy()
     self.contour_groupbox.setSizePolicy(QtGui.QSizePolicy.Fixed,QtGui.QSizePolicy.Fixed)
     self.contour_layout = QtGui.QVBoxLayout()
+    self.contour_layout.setContentsMargins(0,0,0,0)
     self.contour_groupbox.setLayout(self.contour_layout)
 
     self.variable_contour_layout = QtGui.QHBoxLayout()
@@ -381,6 +396,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
 
     self.min_groupbox = QtGui.QGroupBox("Min")
     self.min_layout = QtGui.QHBoxLayout()
+    self.min_layout.setContentsMargins(0,0,0,0)
     self.min_groupbox.setLayout(self.min_layout)
 
     self.min_radio_layout = QtGui.QVBoxLayout()
@@ -414,6 +430,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
 
     self.max_groupbox = QtGui.QGroupBox("Max")
     self.max_layout = QtGui.QHBoxLayout()
+    self.min_layout.setContentsMargins(0,0,0,0)
     self.max_groupbox.setLayout(self.max_layout)
 
     self.max_radio_layout = QtGui.QVBoxLayout()

--- a/gui/vtk/ExodusResultRenderWidget.py
+++ b/gui/vtk/ExodusResultRenderWidget.py
@@ -264,6 +264,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.displace_magnitude_text.returnPressed.connect(self._displaceMagnitudeTextReturn)
 
     self.displace_layout.addWidget(self.displace_checkbox)
+    self.displace_layout.addStretch()
     self.displace_layout.addWidget(self.displace_magnitude_label, alignment=QtCore.Qt.AlignRight)
     self.displace_layout.addWidget(self.displace_magnitude_text, alignment=QtCore.Qt.AlignLeft)
 
@@ -280,6 +281,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.scale_checkbox.setChecked(False)
     self.scale_checkbox.toggled[bool].connect(self._scaleToggled)
     self.scale_layout.addWidget(self.scale_checkbox)
+    self.scale_layout.addStretch()
 
     self.scale_x_label = QtGui.QLabel("x: ")
     self.scale_x_text = QtGui.QLineEdit("1.0")
@@ -322,6 +324,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.clip_checkbox.setChecked(False)
     self.clip_checkbox.toggled[bool].connect(self._clippingToggled)
     self.clip_layout.addWidget(self.clip_checkbox)
+    self.clip_layout.addStretch(1)
 
     self.clip_plane_combobox = QtGui.QComboBox()
     self.clip_plane_combobox.setToolTip('Direction of the normal for the clip plane')
@@ -337,7 +340,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.clip_plane_slider.setSliderPosition(50)
     self.clip_plane_slider.sliderReleased.connect(self._clipSliderReleased)
     self.clip_plane_slider.sliderMoved[int].connect(self._clipSliderMoved)
-    self.clip_layout.addWidget(self.clip_plane_slider)
+    self.clip_layout.addWidget(self.clip_plane_slider, 5)
 
     self.clip_line = QtGui.QWidget()
     self.clip_line.setLayout(self.clip_layout)
@@ -401,11 +404,10 @@ class ExodusResultRenderWidget(QtGui.QWidget):
 #    self.variable_contour_layout.addLayout(self.component_layout)
     self.variable_contour_layout.addWidget(self.variable_component, alignment=QtCore.Qt.AlignHCenter)
 
-
     self.minmax_contour_layout = QtGui.QVBoxLayout()
     self.contour_layout.addLayout(self.minmax_contour_layout)
 
-    self.min_groupbox = QtGui.QGroupBox("Min")
+    self.min_groupbox = QtGui.QWidget()
     self.min_layout = QtGui.QHBoxLayout()
     self.min_layout.setContentsMargins(0,0,0,0)
     self.min_groupbox.setLayout(self.min_layout)
@@ -432,16 +434,16 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.min_custom_layout.addWidget(self.min_custom_text, alignment=QtCore.Qt.AlignLeft)
     self.min_custom_layout.addStretch()
 
+    self.min_layout.addWidget(QtGui.QLabel("Min"))
+    self.min_layout.addStretch()
     self.min_layout.addLayout(self.min_radio_layout)
     self.min_layout.addLayout(self.min_custom_layout)
 
     self.minmax_contour_layout.addWidget(self.min_groupbox)
 
-
-
-    self.max_groupbox = QtGui.QGroupBox("Max")
+    self.max_groupbox = QtGui.QWidget()
     self.max_layout = QtGui.QHBoxLayout()
-    self.min_layout.setContentsMargins(0,0,0,0)
+    self.max_layout.setContentsMargins(0,0,0,0)
     self.max_groupbox.setLayout(self.max_layout)
 
     self.max_radio_layout = QtGui.QVBoxLayout()
@@ -466,6 +468,8 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.max_custom_layout.addWidget(self.max_custom_text, alignment=QtCore.Qt.AlignLeft)
     self.max_custom_layout.addStretch()
 
+    self.max_layout.addWidget(QtGui.QLabel("Max"))
+    self.max_layout.addStretch()
     self.max_layout.addLayout(self.max_radio_layout)
     self.max_layout.addLayout(self.max_custom_layout)
 

--- a/gui/vtk/ExodusResultRenderWidget.py
+++ b/gui/vtk/ExodusResultRenderWidget.py
@@ -237,17 +237,25 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.reset_layout = QtGui.QVBoxLayout()
     self.reset_layout.addWidget(self.toggle_groupbox)
 
-    self.displace_groupbox = QtGui.QGroupBox("Displace")
-    self.displace_groupbox.setFlat(True)
-    self.displace_groupbox.setCheckable(True)
-    self.displace_groupbox.setChecked(True)
-    self.displace_groupbox.setDisabled(True)
-    self.displace_groupbox.setMaximumHeight(70)
-    self.displace_groupbox.toggled[bool].connect(self._displaceToggled)
+    #
+    # mesh display options displace/scale/clip
+    #
+    self.mesh_groupbox = QtGui.QGroupBox("Mesh")
+    self.mesh_groupbox.setFlat(True)
+    self.mesh_groupbox.setMaximumHeight(140)
+
+    self.mesh_layout = QtGui.QVBoxLayout()
+    self.mesh_layout.setSpacing(0)
+    self.mesh_layout.setContentsMargins(0,0,0,0)
+    self.mesh_groupbox.setLayout(self.mesh_layout)
+
     self.displace_layout = QtGui.QHBoxLayout()
     self.displace_layout.setSpacing(0)
     self.displace_layout.setContentsMargins(0,0,0,0)
-    self.displace_groupbox.setLayout(self.displace_layout)
+
+    self.displace_checkbox = QtGui.QCheckBox("Displace")
+    self.displace_checkbox.setChecked(True)
+    self.displace_checkbox.toggled[bool].connect(self._displaceToggled)
 
     self.displace_magnitude_label = QtGui.QLabel("Multiplier: ")
     self.displace_magnitude_text = QtGui.QLineEdit("1.0")
@@ -255,22 +263,23 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.displace_magnitude_text.setMinimumWidth(10)
     self.displace_magnitude_text.returnPressed.connect(self._displaceMagnitudeTextReturn)
 
+    self.displace_layout.addWidget(self.displace_checkbox)
     self.displace_layout.addWidget(self.displace_magnitude_label, alignment=QtCore.Qt.AlignRight)
     self.displace_layout.addWidget(self.displace_magnitude_text, alignment=QtCore.Qt.AlignLeft)
 
-    self.reset_layout.addWidget(self.displace_groupbox)
+    self.displace_line = QtGui.QWidget()
+    self.displace_line.setLayout(self.displace_layout)
+    self.mesh_layout.addWidget(self.displace_line)
 
-    self.scale_groupbox = QtGui.QGroupBox("Scale")
-    self.scale_groupbox.setCheckable(True)
-    self.scale_groupbox.setChecked(False)
-    self.scale_groupbox.setDisabled(False)
-    self.scale_groupbox.setFlat(True)
-    self.scale_groupbox.setMaximumHeight(70)
-    self.scale_groupbox.toggled[bool].connect(self._scaleToggled)
+    # Scale line
     self.scale_layout = QtGui.QHBoxLayout()
     self.scale_layout.setSpacing(0)
     self.scale_layout.setContentsMargins(0,0,0,0)
-    self.scale_groupbox.setLayout(self.scale_layout)
+
+    self.scale_checkbox = QtGui.QCheckBox("Scale")
+    self.scale_checkbox.setChecked(False)
+    self.scale_checkbox.toggled[bool].connect(self._scaleToggled)
+    self.scale_layout.addWidget(self.scale_checkbox)
 
     self.scale_x_label = QtGui.QLabel("x: ")
     self.scale_x_text = QtGui.QLineEdit("1.0")
@@ -300,16 +309,19 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.scale_layout.addWidget(self.scale_z_label, alignment=QtCore.Qt.AlignRight)
     self.scale_layout.addWidget(self.scale_z_text, alignment=QtCore.Qt.AlignLeft)
 
-    self.reset_layout.addWidget(self.scale_groupbox)
+    self.scale_line = QtGui.QWidget()
+    self.scale_line.setLayout(self.scale_layout)
+    self.mesh_layout.addWidget(self.scale_line)
 
-    self.clip_groupbox = QtGui.QGroupBox("Clip")
-    self.clip_groupbox.setToolTip('Toggle clipping mode where the solution can be sliced open')
-    self.clip_groupbox.setCheckable(True)
-    self.clip_groupbox.setChecked(False)
-    self.clip_groupbox.setMaximumHeight(70)
-    self.clip_groupbox.setFlat(True)
-    self.clip_groupbox.toggled[bool].connect(self._clippingToggled)
-    clip_layout = QtGui.QHBoxLayout()
+    # Clip line
+    self.clip_layout = QtGui.QHBoxLayout()
+    self.clip_layout.setContentsMargins(0,0,0,0)
+
+    self.clip_checkbox = QtGui.QCheckBox("Clip")
+    self.clip_checkbox.setToolTip('Toggle clipping mode where the solution can be sliced open')
+    self.clip_checkbox.setChecked(False)
+    self.clip_checkbox.toggled[bool].connect(self._clippingToggled)
+    self.clip_layout.addWidget(self.clip_checkbox)
 
     self.clip_plane_combobox = QtGui.QComboBox()
     self.clip_plane_combobox.setToolTip('Direction of the normal for the clip plane')
@@ -317,8 +329,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.clip_plane_combobox.addItem('y')
     self.clip_plane_combobox.addItem('z')
     self.clip_plane_combobox.currentIndexChanged[str].connect(self._clipNormalChanged)
-
-    clip_layout.addWidget(self.clip_plane_combobox)
+    self.clip_layout.addWidget(self.clip_plane_combobox)
 
     self.clip_plane_slider = QtGui.QSlider(QtCore.Qt.Horizontal)
     self.clip_plane_slider.setToolTip('Slide to change plane position')
@@ -326,13 +337,13 @@ class ExodusResultRenderWidget(QtGui.QWidget):
     self.clip_plane_slider.setSliderPosition(50)
     self.clip_plane_slider.sliderReleased.connect(self._clipSliderReleased)
     self.clip_plane_slider.sliderMoved[int].connect(self._clipSliderMoved)
-    clip_layout.addWidget(self.clip_plane_slider)
-    # vbox->addStretch(1);
-    clip_layout.setContentsMargins(0,0,0,0)
-    self.clip_groupbox.setLayout(clip_layout)
+    self.clip_layout.addWidget(self.clip_plane_slider)
 
-    self.reset_layout.addWidget(self.clip_groupbox)
+    self.clip_line = QtGui.QWidget()
+    self.clip_line.setLayout(self.clip_layout)
+    self.mesh_layout.addWidget(self.clip_line)
 
+    self.reset_layout.addWidget(self.mesh_groupbox)
 
 
     self.view_layout = QtGui.QHBoxLayout()
@@ -576,7 +587,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
           self.has_displacements = True
 
     if self.has_displacements:
-      self.displace_groupbox.setDisabled(False)
+      self.displace_checkbox.setDisabled(False)
 
     self.block_view_model.clear()
     for block in self.exodus_result.blocks:
@@ -833,7 +844,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
       self.exodus_result.lut.SetVectorModeToComponent()
       self.exodus_result.lut.SetVectorComponent(2)
 
-    if self.clip_groupbox.isChecked():
+    if self.clip_checkbox.isChecked():
       self.exodus_result.clipper.Modified()
       self.exodus_result.clipper.Update()
       self.exodus_result.clip_geom.Update()
@@ -1035,7 +1046,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
         self.renderer.RemoveActor(actor)
       self.exodus_result = self.timestep_to_exodus_result[int(textbox_string)]
 
-      if self.clip_groupbox.isChecked():
+      if self.clip_checkbox.isChecked():
         self.renderer.AddActor(self.exodus_result.clip_actor)
         if self.draw_edges_checkbox.checkState() == QtCore.Qt.Checked:
           self.exodus_result.clip_actor.GetProperty().EdgeVisibilityOn()
@@ -1056,13 +1067,13 @@ class ExodusResultRenderWidget(QtGui.QWidget):
         else:
           self.exodus_result.hideBlock(item.exodus_block)
 
-      if self.has_displacements and self.displace_groupbox.isChecked():
+      if self.has_displacements and self.displace_checkbox.isChecked():
         self.exodus_result.reader.SetApplyDisplacements(1)
         self.exodus_result.reader.SetDisplacementMagnitude(float(self.current_displacement_magnitude))
       else:
         self.exodus_result.reader.SetApplyDisplacements(0)
 
-      if self.scale_groupbox.isChecked():
+      if self.scale_checkbox.isChecked():
         self.exodus_result.actor.SetScale(self.current_scale_x_magnitude, self.current_scale_y_magnitude, self.current_scale_z_magnitude)
       else:
         self.exodus_result.actor.SetScale(1.0, 1.0, 1.0)
@@ -1136,7 +1147,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
           # Avoid z-buffer fighting
           vtk.vtkPolyDataMapper().SetResolveCoincidentTopologyToPolygonOffset()
 
-          if self.clip_groupbox.isChecked():
+          if self.clip_checkbox.isChecked():
             _clippingToggled(True)
 
           self.vtkwidget.repaint()
@@ -1156,7 +1167,7 @@ class ExodusResultRenderWidget(QtGui.QWidget):
         self.time_slider.setMaximum(self.current_max_timestep)
         self.time_slider.setSliderPosition(self.current_max_timestep)
         self._timeSliderReleased()
-        if self.clip_groupbox.isChecked():
+        if self.clip_checkbox.isChecked():
           self._clipSliderReleased()
         self.vtkwidget.repaint()
       else:

--- a/modules/combined/examples/phase_field-mechanics/Pattern1.i
+++ b/modules/combined/examples/phase_field-mechanics/Pattern1.i
@@ -253,7 +253,7 @@
     block = 0
     f_name = phase
     args = 'eta2 eta3'
-    function = 'eta3-eta2'
+    function = 'if(eta3>0.5,1,0)-if(eta2>0.5,1,0)'
     outputs = exodus
   [../]
 


### PR DESCRIPTION
This makes peacock usable on smaller screens, simplifies the layout hierarchy, improves the widget scaling, uses double spinner boxes where appropriate, adds a "White background" option, and adds a draggable splitter between render view and options (this allows the user to collapse the options completely).

Screenshot shows the widget scaling by dragging the options wide.

![peacock_scale](https://cloud.githubusercontent.com/assets/202302/7071754/b8ab62e8-dea4-11e4-9a02-e077da74d1dd.png)

Adresses #4907.
