### PR TITLE
Fixup for the intialSetup() fixups

### DIFF
--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -462,11 +462,6 @@ void FEProblem::initialSetup()
 
   // Auxilary variable initialSetup calls
   _aux.initialSetup();
-  if (!_app.isRecovering())
-  {
-    computeUserObjects(EXEC_INITIAL, UserObjectWarehouse::PRE_AUX);
-    _aux.compute(EXEC_INITIAL);
-  }
 
   if (_app.isRestarting() || _app.isRecovering())
   {
@@ -553,6 +548,9 @@ void FEProblem::initialSetup()
     Moose::setup_perf_log.pop("Initial execMultiApps()","Setup");
 
     Moose::setup_perf_log.push("Initial computeUserObjects()","Setup");
+
+    computeUserObjects(EXEC_INITIAL, UserObjectWarehouse::PRE_AUX);
+    _aux.compute(EXEC_INITIAL);
 
     if (_use_legacy_uo_initialization)
     {

--- a/test/tests/transfers/multiapp_userobject_transfer/tosub_displaced_sub.i
+++ b/test/tests/transfers/multiapp_userobject_transfer/tosub_displaced_sub.i
@@ -22,8 +22,10 @@
     family = MONOMIAL
   [../]
   [./disp_x]
+    initial_condition = 0.0
   [../]
   [./disp_y]
+    initial_condition = 0.5
   [../]
 []
 
@@ -47,20 +49,6 @@
     type = UserForcingFunction
     variable = u
     function = axial_force
-  [../]
-[]
-
-[AuxKernels]
-  [./disp_x]
-    type = ConstantAux
-    variable = disp_x
-    execute_on = initial
-  [../]
-  [./disp_y]
-    type = ConstantAux
-    variable = disp_y
-    value = 0.5
-    execute_on = initial
   [../]
 []
 


### PR DESCRIPTION
refs #4915, closes #4926

We need to make sure the displaced mesh is setup before executing any objects, (in #4926 it was UserObjects PRE_AUX)
This PR moves the UserObjects and AuxKernel exeucte_on=INITIAL after all of the initialSetup() methods have been called.
Hopefully this will resolve issues with BISON.

The transfer test was modified because it was expecting the AuxKernel to execute before the first Transfer. I do not believe this is the desired behavior. This test should be using initial conditions instead of relying on AuxKernel to set the displacement for the mesh in this test.
