### PR TITLE
Multiapp restart 2

### DIFF
--- a/framework/include/multiapps/FullSolveMultiApp.h
+++ b/framework/include/multiapps/FullSolveMultiApp.h
@@ -37,7 +37,7 @@ public:
 
   virtual ~FullSolveMultiApp();
 
-  virtual void init();
+  virtual void initialSetup();
 
   /**
    * Completely solve all of the Apps

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -51,7 +51,7 @@ public:
 
   virtual ~MultiApp();
 
-  virtual void init();
+  virtual void initialSetup();
 
   /**
    * Gets called just before transfers are done _to_ the MultiApp

--- a/framework/include/multiapps/MultiAppWarehouse.h
+++ b/framework/include/multiapps/MultiAppWarehouse.h
@@ -71,6 +71,11 @@ public:
    */
   void parentOutputPositionChanged();
 
+  /**
+   * Calls the initialSetup() function for all Multiapps in the Warehouse
+   */
+  void initialSetup();
+
 protected:
   std::vector<TransientMultiApp *> _transient_multi_apps;
 

--- a/framework/include/multiapps/TransientMultiApp.h
+++ b/framework/include/multiapps/TransientMultiApp.h
@@ -48,7 +48,7 @@ public:
    */
   virtual NumericVector<Number> & appTransferVector(unsigned int app, std::string var_name);
 
-  virtual void init();
+  virtual void initialSetup();
 
   /**
    * Advance all of the apps one timestep.

--- a/framework/src/actions/SetupRecoverFileBaseAction.C
+++ b/framework/src/actions/SetupRecoverFileBaseAction.C
@@ -119,7 +119,6 @@ SetupRecoverFileBaseAction::getRecoveryFileBase(const std::set<std::string> chec
 void
 SetupRecoverFileBaseAction::getCheckpointFiles(std::set<std::string> & files)
 {
-
   // Extract the CommonOutputAction
   const Action* common = _awh.getActionsByName("common_output")[0];
 
@@ -129,10 +128,12 @@ SetupRecoverFileBaseAction::getCheckpointFiles(std::set<std::string> & files)
   // If file_base is set in CommonOutputAction, add this file to the list of potential checkpoint files
   if (common->isParamValid("file_base"))
     checkpoint_dirs.insert(common->getParam<std::string>("file_base") + "_cp");
-
-  // If file_base is not set use the default <filename>_out_cp location
-  else
+  // Case for normal application or master in a Multiapp setting
+  else if (_app.getOutputFileBase().empty())
     checkpoint_dirs.insert(FileOutput::getOutputFileBase(_app, "_out_cp"));
+  // Case for a sub app in a Multiapp setting
+  else
+    checkpoint_dirs.insert(_app.getOutputFileBase() + "_cp");
 
   // Add the directories from any existing checkpoint objects
   const std::vector<Action *> actions = _awh.getActionsByName("add_output");

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -515,6 +515,14 @@ void FEProblem::initialSetup()
        ++it)
     it->second->updateSeeds(EXEC_INITIAL);
 
+  // Call init on the MultiApps
+  _multi_apps(EXEC_LINEAR)[0].initialSetup();
+  _multi_apps(EXEC_NONLINEAR)[0].initialSetup();
+  _multi_apps(EXEC_TIMESTEP_END)[0].initialSetup();
+  _multi_apps(EXEC_TIMESTEP_BEGIN)[0].initialSetup();
+  _multi_apps(EXEC_INITIAL)[0].initialSetup();
+  _multi_apps(EXEC_CUSTOM)[0].initialSetup();
+
   // Call initial setup on the transfers
   _transfers(EXEC_LINEAR)[0].initialSetup();
   _transfers(EXEC_NONLINEAR)[0].initialSetup();
@@ -2708,7 +2716,7 @@ FEProblem::addMultiApp(const std::string & multi_app_name, const std::string & n
     _multi_apps(exec_flags[i])[0].addMultiApp(multi_app);
 
   // TODO: Is this really the right spot to init a multiapp?
-  multi_app->init();
+//  multi_app->init();
 }
 
 MultiApp *

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -225,16 +225,14 @@ MooseApp::setupOptions()
     Moose::out << "**END SYNTAX DATA**\n" << std::endl;
     _ready_to_exit = true;
   }
-  else if (_input_filename != "") // They already specified an input filename
+  else if (_input_filename != "" || isParamValid("input_file")) // They already specified an input filename
   {
-    _parser.parse(_input_filename);
-    _action_warehouse.build();
-    return;
-  }
-  else if (isParamValid("input_file"))
-  {
+    if (_input_filename == "")
+      _input_filename = getParam<std::string>("input_file");
+
     if (isParamValid("recover"))
     {
+      // We need to set the flag manually here since the recover parameter is a string type (takes an optional filename)
       _recover = true;
 
       // Get command line argument following --recover on command line
@@ -246,7 +244,6 @@ MooseApp::setupOptions()
         _recover_base = recover_following_arg;
     }
 
-    _input_filename = getParam<std::string>("input_file");
     _parser.parse(_input_filename);
     _action_warehouse.build();
   }

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -37,9 +37,9 @@ FullSolveMultiApp::~FullSolveMultiApp()
 }
 
 void
-FullSolveMultiApp::init()
+FullSolveMultiApp::initialSetup()
 {
-  MultiApp::init();
+  MultiApp::initialSetup();
 
   if (_has_an_app)
   {

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -133,7 +133,7 @@ MultiApp::~MultiApp()
 }
 
 void
-MultiApp::init()
+MultiApp::initialSetup()
 {
   // Fill in the _positions vector
   fillPositions();

--- a/framework/src/multiapps/MultiAppWarehouse.C
+++ b/framework/src/multiapps/MultiAppWarehouse.C
@@ -70,3 +70,10 @@ MultiAppWarehouse::parentOutputPositionChanged()
   for (unsigned int i=0; i<_all_objects.size(); i++)
     _all_objects[i]->parentOutputPositionChanged();
 }
+
+void
+MultiAppWarehouse::initialSetup()
+{
+  for (std::vector<MultiApp *>::iterator i = _all_objects.begin(); i != _all_objects.end(); ++i)
+    (*i)->initialSetup();
+}

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -104,9 +104,9 @@ TransientMultiApp::appTransferVector(unsigned int app, std::string var_name)
 }
 
 void
-TransientMultiApp::init()
+TransientMultiApp::initialSetup()
 {
-  MultiApp::init();
+  MultiApp::initialSetup();
 
   if (!_has_an_app)
     return;

--- a/test/tests/multiapps/detect_steady_state/tests
+++ b/test/tests/multiapps/detect_steady_state/tests
@@ -3,6 +3,5 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out.e master_out_sub0.e'
-    recover = false
   [../]
 []

--- a/test/tests/multiapps/multilevel/tests
+++ b/test/tests/multiapps/multilevel/tests
@@ -3,26 +3,22 @@
     type = 'Exodiff'
     input = 'dt_from_master_master.i'
     exodiff = 'dt_from_master_master_out.e dt_from_master_master_out_sub0.e dt_from_master_master_out_sub0_sub0.e dt_from_master_master_out_sub0_sub1.e dt_from_master_master_out_sub1.e dt_from_master_master_out_sub1_sub0.e dt_from_master_master_out_sub1_sub1.e'
-    recover = false
   [../]
   [./time_dt_from_master]
     type = 'Exodiff'
     input = 'time_dt_from_master_master.i'
     exodiff = 'time_dt_from_master_master_out.e time_dt_from_master_master_out_sub0.e time_dt_from_master_master_out_sub0_sub0.e time_dt_from_master_master_out_sub0_sub1.e time_dt_from_master_master_out_sub1.e time_dt_from_master_master_out_sub1_sub0.e time_dt_from_master_master_out_sub1_sub1.e'
     abs_zero = 5e-7
-    recover = false
   [../]
   [./dt_from_sub]
     type = 'Exodiff'
     input = 'dt_from_sub_master.i'
     exodiff = 'dt_from_sub_master_out.e dt_from_sub_master_out_sub0.e dt_from_sub_master_out_sub0_sub0.e dt_from_sub_master_out_sub0_sub1.e dt_from_sub_master_out_sub1.e dt_from_sub_master_out_sub1_sub0.e dt_from_sub_master_out_sub1_sub1.e'
-    recover = false
   [../]
   [./console_to_file]
     type = 'CheckFiles'
     input = 'time_dt_from_master_master.i'
     check_files = 'time_dt_from_master_master_out.txt time_dt_from_master_master_out_sub0.txt time_dt_from_master_master_out_sub0_sub0.txt time_dt_from_master_master_out_sub0_sub1.txt time_dt_from_master_master_out_sub1.txt time_dt_from_master_master_out_sub1_sub0.txt time_dt_from_master_master_out_sub1_sub1.txt'
     prereq = time_dt_from_master
-    recover = false
   [../]
 []

--- a/test/tests/multiapps/output_in_position/tests
+++ b/test/tests/multiapps/output_in_position/tests
@@ -3,13 +3,11 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out_sub0.e'
-    recover = false
   [../]
 
   [./multilevel]
     type = 'Exodiff'
     input = 'multilevel_master.i'
     exodiff = 'multilevel_master_out_sub0_sub0.e'
-    recover = false
   [../]
 []

--- a/test/tests/multiapps/petsc_options/tests
+++ b/test/tests/multiapps/petsc_options/tests
@@ -4,6 +4,5 @@
     input = 'master.i'
     exodiff = 'master_out.e master_out_sub0.e'
     expect_out = '8 Linear'
-    recover = false
   [../]
 []

--- a/test/tests/multiapps/positions_from_file/tests
+++ b/test/tests/multiapps/positions_from_file/tests
@@ -3,6 +3,5 @@
     type = 'Exodiff'
     input = 'dt_from_multi.i'
     exodiff = 'dt_from_multi_out_sub_app0.e dt_from_multi_out_sub_app1.e dt_from_multi_out_sub_app2.e dt_from_multi_out_sub_app3.e'
-    recover = false
   [../]
 []

--- a/test/tests/multiapps/sub_cycling/tests
+++ b/test/tests/multiapps/sub_cycling/tests
@@ -3,13 +3,11 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out.e master_out_sub0.e'
-    recover = false
   [../]
   [./test_sub_cycle_output]
     # Run the same test as above, but test for sub-cycle output
     type = 'Exodiff'
     input = 'master_sub_output.i'
     exodiff = 'master_sub_output_out.e master_sub_output_out_sub0.e'
-    recover = false
   [../]
 []

--- a/test/tests/multiapps/transient_multiapp/dt_from_master.i
+++ b/test/tests/multiapps/transient_multiapp/dt_from_master.i
@@ -52,6 +52,7 @@
   output_initial = true
   exodus = true
   print_perf_log = true
+  checkpoint = true
 []
 
 [MultiApps]

--- a/test/tests/multiapps/transient_multiapp/dt_from_master_sub.i
+++ b/test/tests/multiapps/transient_multiapp/dt_from_master_sub.i
@@ -52,4 +52,5 @@
   output_initial = true
   exodus = true
   print_perf_log = true
+  checkpoint = true
 []

--- a/test/tests/multiapps/transient_multiapp/tests
+++ b/test/tests/multiapps/transient_multiapp/tests
@@ -3,13 +3,11 @@
     type = 'Exodiff'
     input = 'dt_from_multi.i'
     exodiff = 'dt_from_multi_out_sub_app0.e dt_from_multi_out_sub_app1.e dt_from_multi_out_sub_app2.e dt_from_multi_out_sub_app3.e'
-    recover = false
   [../]
 
   [./dt_from_master]
     type = 'Exodiff'
     input = 'dt_from_master.i'
     exodiff = 'dt_from_master_out_sub_app0.e dt_from_master_out_sub_app1.e dt_from_master_out_sub_app2.e dt_from_master_out_sub_app3.e'
-    recover = false
   [../]
 []


### PR DESCRIPTION
This PR will enable restart for Multiapps that have one to one timesteps. Additionally it also cleans up the way we initialize Multiapps. We are now initializing them in FEProblem::initialSetup() instead of in the Action::act() method (which was always a bad idea).
