### PR TITLE
Update libmesh, make MOOSE compile with libmesh configured with --enable-unique-ptr

### DIFF
--- a/framework/include/bcs/FunctionPeriodicBoundary.h
+++ b/framework/include/bcs/FunctionPeriodicBoundary.h
@@ -55,7 +55,7 @@ public:
   /**
    * Required interface, this class must be able to clone itself
    */
-  virtual AutoPtr<PeriodicBoundaryBase> clone(TransformationType t) const;
+  virtual UniquePtr<PeriodicBoundaryBase> clone(TransformationType t) const;
 
 protected:
 //  /// The dimension of the problem (says which _tr_XYZ member variables are active)

--- a/framework/include/dirackernels/DiracKernelInfo.h
+++ b/framework/include/dirackernels/DiracKernelInfo.h
@@ -91,7 +91,7 @@ protected:
   /// by all DiracKernels to find Points.  It needs to be centrally managed and it
   /// also needs to be rebuilt in FEProblem::meshChanged() to work with Mesh
   /// adaptivity.
-  AutoPtr<PointLocatorBase> _point_locator;
+  UniquePtr<PointLocatorBase> _point_locator;
 };
 
 #endif //DIRACKERNELINFO_H

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -774,7 +774,7 @@ protected:
   std::set<BoundaryID> _mesh_boundary_ids;
 
   /// The boundary to normal map - valid only when AddAllSideSetsByNormals is active
-  AutoPtr<std::map<BoundaryID, RealVectorValue> > _boundary_to_normal_map;
+  UniquePtr<std::map<BoundaryID, RealVectorValue> > _boundary_to_normal_map;
 
   /// array of boundary nodes
   std::vector<BndNode *> _bnd_nodes;

--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -129,7 +129,7 @@ private:
   /* Each of the MeshFunctions keeps a reference to this vector, the vector is updated for the current system
    * and variable before the MeshFunction is applied. This allows for the same MeshFunction object to be
    * re-used, unless the mesh has changed due to adaptivity */
-  AutoPtr<NumericVector<Number> > _serialized_solution;
+  UniquePtr<NumericVector<Number> > _serialized_solution;
 };
 
 #endif // OVERSAMPLEOUTPUT_H

--- a/framework/include/vectorpostprocessors/PointSamplerBase.h
+++ b/framework/include/vectorpostprocessors/PointSamplerBase.h
@@ -86,7 +86,7 @@ protected:
   /// So we don't have to create and destroy this
   std::vector<Point> _point_vec;
 
-  AutoPtr<PointLocatorBase> _pl;
+  UniquePtr<PointLocatorBase> _pl;
 };
 
 #endif

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -568,7 +568,7 @@ Assembly::reinitNeighborAtReference(const Elem * neighbor, const std::vector<Poi
   // Calculate the volume of the neighbor
 
   FEType fe_type (neighbor->default_order() , LAGRANGE);
-  AutoPtr<FEBase> fe (FEBase::build(neighbor->dim(), fe_type));
+  UniquePtr<FEBase> fe (FEBase::build(neighbor->dim(), fe_type));
 
   const std::vector<Real> & JxW = fe->get_JxW();
   const std::vector<Point> & q_points = fe->get_xyz();

--- a/framework/src/bcs/FunctionPeriodicBoundary.C
+++ b/framework/src/bcs/FunctionPeriodicBoundary.C
@@ -69,12 +69,12 @@ FunctionPeriodicBoundary::get_corresponding_pos(const Point & pt) const
   return pt;
 }
 
-AutoPtr<PeriodicBoundaryBase> FunctionPeriodicBoundary::clone(TransformationType t) const
+UniquePtr<PeriodicBoundaryBase> FunctionPeriodicBoundary::clone(TransformationType t) const
 {
   if (t==INVERSE)
     mooseError("No way to automatically clone() an inverse FunctionPeriodicBoundary object");
 
-  return AutoPtr<PeriodicBoundaryBase>(new FunctionPeriodicBoundary(*this));
+  return UniquePtr<PeriodicBoundaryBase>(new FunctionPeriodicBoundary(*this));
 }
 
 void

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -1178,7 +1178,7 @@ PenetrationThread::computeSlip(FEBase & fe, PenetrationInfo & info)
   //   original projected position of slave node
   std::vector<Point> points(1);
   points[0] = info._starting_closest_point_ref;
-  AutoPtr<Elem> side = info._starting_elem->build_side(info._starting_side_num, false);
+  UniquePtr<Elem> side = info._starting_elem->build_side(info._starting_side_num, false);
   fe.reinit(side.get(), &points);
   const std::vector<Point> & starting_point = fe.get_xyz();
   info._incremental_slip = info._closest_point - starting_point[0];

--- a/framework/src/ics/InitialCondition.C
+++ b/framework/src/ics/InitialCondition.C
@@ -110,12 +110,12 @@ InitialCondition::compute()
   // We cannot use the FE object in Assembly, since the following code is messing with the quadrature rules
   // for projections and would screw it up. However, if we implement projections from one mesh to another,
   // this code should use that implementation.
-  AutoPtr<FEBase> fe (FEBase::build(dim, fe_type));
+  UniquePtr<FEBase> fe (FEBase::build(dim, fe_type));
 
   // Prepare variables for projection
-  AutoPtr<QBase> qrule     (fe_type.default_quadrature_rule(dim));
-  AutoPtr<QBase> qedgerule (fe_type.default_quadrature_rule(1));
-  AutoPtr<QBase> qsiderule (fe_type.default_quadrature_rule(dim-1));
+  UniquePtr<QBase> qrule     (fe_type.default_quadrature_rule(dim));
+  UniquePtr<QBase> qedgerule (fe_type.default_quadrature_rule(1));
+  UniquePtr<QBase> qsiderule (fe_type.default_quadrature_rule(dim-1));
 
   // The values of the shape functions at the quadrature points
   const std::vector<std::vector<Real> > & phi = fe->get_phi();

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -174,7 +174,7 @@ MooseMesh::MooseMesh(const std::string & name, InputParameters parameters) :
     break;
 
   case 0: // linear
-    getMesh().partitioner() = AutoPtr<Partitioner>(new LinearPartitioner);
+    getMesh().partitioner().reset(new LinearPartitioner);
     break;
   case 1: // centroid
   {
@@ -184,20 +184,20 @@ MooseMesh::MooseMesh(const std::string & name, InputParameters parameters) :
     MooseEnum direction = getParam<MooseEnum>("centroid_partitioner_direction");
 
     if (direction == "x")
-      getMesh().partitioner() = AutoPtr<Partitioner>(new CentroidPartitioner(CentroidPartitioner::X));
+      getMesh().partitioner().reset(new CentroidPartitioner(CentroidPartitioner::X));
     else if (direction == "y")
-      getMesh().partitioner() = AutoPtr<Partitioner>(new CentroidPartitioner(CentroidPartitioner::Y));
+      getMesh().partitioner().reset(new CentroidPartitioner(CentroidPartitioner::Y));
     else if (direction == "z")
-      getMesh().partitioner() = AutoPtr<Partitioner>(new CentroidPartitioner(CentroidPartitioner::Z));
+      getMesh().partitioner().reset(new CentroidPartitioner(CentroidPartitioner::Z));
     else if (direction == "radial")
-      getMesh().partitioner() = AutoPtr<Partitioner>(new CentroidPartitioner(CentroidPartitioner::RADIAL));
+      getMesh().partitioner().reset(new CentroidPartitioner(CentroidPartitioner::RADIAL));
     break;
   }
   case 2: // hilbert_sfc
-    getMesh().partitioner() = AutoPtr<Partitioner>(new HilbertSFCPartitioner);
+    getMesh().partitioner().reset(new HilbertSFCPartitioner);
     break;
   case 3: // morton_sfc
-    getMesh().partitioner() = AutoPtr<Partitioner>(new MortonSFCPartitioner);
+    getMesh().partitioner().reset(new MortonSFCPartitioner);
     break;
   }
 }
@@ -1045,7 +1045,7 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
 
   MeshBase::const_element_iterator it = getMesh().active_elements_begin();
   MeshBase::const_element_iterator it_end = getMesh().active_elements_end();
-  AutoPtr<PointLocatorBase> point_locator = getMesh().sub_point_locator();
+  UniquePtr<PointLocatorBase> point_locator = getMesh().sub_point_locator();
 
   // Get a const reference to the BoundaryInfo object that we will use several times below...
   const BoundaryInfo & boundary_info = getMesh().get_boundary_info();
@@ -1071,8 +1071,8 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
           const Elem* neigh = pbs->neighbor(boundary_id, *point_locator, elem, s);
           unsigned int s_neigh = boundary_info.side_with_boundary_id (neigh, periodic->pairedboundary);
 
-          AutoPtr<Elem> elem_side = elem->build_side(s);
-          AutoPtr<Elem> neigh_side = neigh->build_side(s_neigh);
+          UniquePtr<Elem> elem_side = elem->build_side(s);
+          UniquePtr<Elem> neigh_side = neigh->build_side(s_neigh);
 
           // At this point we have matching sides - lets find matching nodes
           for (unsigned int i=0; i<elem_side->n_nodes(); ++i)
@@ -1586,11 +1586,11 @@ MooseMesh::findAdaptivityQpMaps(const Elem * template_elem,
   for (unsigned int i=0; i<template_elem->n_nodes(); i++)
     elem->set_node(i) = mesh.node_ptr(i);
 
-  AutoPtr<FEBase> fe (FEBase::build(dim, FEType()));
+  UniquePtr<FEBase> fe (FEBase::build(dim, FEType()));
   fe->get_phi();
   const std::vector<Point>& q_points_volume = fe->get_xyz();
 
-  AutoPtr<FEBase> fe_face (FEBase::build(dim, FEType()));
+  UniquePtr<FEBase> fe_face (FEBase::build(dim, FEType()));
   fe_face->get_phi();
   const std::vector<Point>& q_points_face = fe_face->get_xyz();
 

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -107,7 +107,7 @@ TiledMesh::buildMesh()
     BoundaryID back = getBoundaryID(getParam<BoundaryName>("back_boundary"));
 
     {
-      AutoPtr<MeshBase> clone = serial_mesh->clone();
+      UniquePtr<MeshBase> clone = serial_mesh->clone();
 
       // Build X Tiles
       for (unsigned int i=1; i<getParam<unsigned int>("x_tiles"); ++i)
@@ -117,7 +117,7 @@ TiledMesh::buildMesh()
       }
     }
     {
-      AutoPtr<MeshBase> clone = serial_mesh->clone();
+      UniquePtr<MeshBase> clone = serial_mesh->clone();
 
       // Build Y Tiles
       for (unsigned int i=1; i<getParam<unsigned int>("y_tiles"); ++i)
@@ -127,7 +127,7 @@ TiledMesh::buildMesh()
       }
     }
     {
-      AutoPtr<MeshBase> clone = serial_mesh->clone();
+      UniquePtr<MeshBase> clone = serial_mesh->clone();
 
       // Build Z Tiles
       for (unsigned int i=1; i<getParam<unsigned int>("z_tiles"); ++i)

--- a/framework/src/meshmodifiers/SideSetsFromPoints.C
+++ b/framework/src/meshmodifiers/SideSetsFromPoints.C
@@ -62,7 +62,7 @@ SideSetsFromPoints::modify()
 
   _visited.clear();
 
-  AutoPtr<PointLocatorBase> pl = PointLocatorBase::build(TREE, *_mesh_ptr);
+  UniquePtr<PointLocatorBase> pl = PointLocatorBase::build(TREE, *_mesh_ptr);
 
   for (unsigned int i=0; i< boundary_ids.size(); ++i)
   {
@@ -74,7 +74,7 @@ SideSetsFromPoints::modify()
         continue;
 
       // See if this point is on this side
-      AutoPtr<Elem> elem_side = elem->side(side);
+      UniquePtr<Elem> elem_side = elem->side(side);
 
       if (elem_side->contains_point(_points[i]))
       {

--- a/framework/src/postprocessors/PointValue.C
+++ b/framework/src/postprocessors/PointValue.C
@@ -42,7 +42,7 @@ PointValue::execute()
 {
   // Locate the element and store the id
   // We can't store the actual Element pointer here b/c PointLocatorBase returns a const Elem *
-  AutoPtr<PointLocatorBase> pl = _mesh.sub_point_locator();
+  UniquePtr<PointLocatorBase> pl = _mesh.sub_point_locator();
   const Elem * elem = (*pl)(_point_vec[0]);
 
   // Error if the element cannot be located

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -147,7 +147,7 @@ MultiAppProjectionTransfer::assembleL2To(EquationSystems & es, const std::string
   LinearImplicitSystem & system = es.get_system<LinearImplicitSystem>(system_name);
 
   FEType fe_type = system.variable_type(0);
-  AutoPtr<FEBase> fe(FEBase::build(dim, fe_type));
+  UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
   QGauss qrule(dim, fe_type.default_quadrature_order());
   fe->attach_quadrature_rule(&qrule);
   const std::vector<Real> & JxW = fe->get_JxW();
@@ -246,7 +246,7 @@ MultiAppProjectionTransfer::assembleL2From(EquationSystems & es, const std::stri
   LinearImplicitSystem & system = es.get_system<LinearImplicitSystem>(system_name);
 
   FEType fe_type = system.variable_type(0);
-  AutoPtr<FEBase> fe(FEBase::build(dim, fe_type));
+  UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
   QGauss qrule(dim, fe_type.default_quadrature_order());
   fe->attach_quadrature_rule(&qrule);
   const std::vector<Real> & JxW = fe->get_JxW();

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -52,7 +52,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::execute()
 
       MooseMesh & from_mesh = from_problem.mesh();
 
-      AutoPtr<PointLocatorBase> pl = from_mesh.getMesh().sub_point_locator();
+      UniquePtr<PointLocatorBase> pl = from_mesh.getMesh().sub_point_locator();
 
       for (unsigned int i=0; i<_multi_app->numGlobalApps(); i++)
       {

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -58,7 +58,7 @@ MultiAppVariableValueSampleTransfer::execute()
 
       MooseMesh & from_mesh = from_problem.mesh();
 
-      AutoPtr<PointLocatorBase> pl = from_mesh.getMesh().sub_point_locator();
+      UniquePtr<PointLocatorBase> pl = from_mesh.getMesh().sub_point_locator();
 
       for (unsigned int i=0; i<_multi_app->numGlobalApps(); i++)
       {

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -426,8 +426,8 @@ PetscErrorCode dampedCheck(SNES /*snes*/, Vec x, Vec y, Vec w, void *lsctx, Pets
 
     // Create new NumericVectors with the right ghosting - note: these will be destroyed
     // when this function exits, so nobody better hold pointers to them any more!
-    AutoPtr<NumericVector<Number> > ghosted_y_aptr( cls.zero_clone() );
-    AutoPtr<NumericVector<Number> > ghosted_w_aptr( cls.zero_clone() );
+    UniquePtr<NumericVector<Number> > ghosted_y_aptr( cls.zero_clone() );
+    UniquePtr<NumericVector<Number> > ghosted_w_aptr( cls.zero_clone() );
 
     // Create PetscVector wrappers around the Vecs.
     PetscVector<Number> ghosted_y( static_cast<PetscVector<Number> *>(ghosted_y_aptr.get())->vec(), problem.comm());

--- a/framework/src/utils/RayTracing.C
+++ b/framework/src/utils/RayTracing.C
@@ -51,7 +51,7 @@ int sideIntersectedByLine(const Elem * elem, int not_side, const LineSegment & l
       continue;
 
     // Get a simplified side element
-    AutoPtr<Elem> side_elem = elem->side(i);
+    UniquePtr<Elem> side_elem = elem->side(i);
 
     if (dim == 3)
     {

--- a/test/src/userobjects/RandomHitSolutionModifier.C
+++ b/test/src/userobjects/RandomHitSolutionModifier.C
@@ -37,7 +37,7 @@ RandomHitSolutionModifier::RandomHitSolutionModifier(const std::string & name, I
 void
 RandomHitSolutionModifier::execute()
 {
-  AutoPtr<PointLocatorBase> pl = _mesh.getMesh().sub_point_locator();
+  UniquePtr<PointLocatorBase> pl = _mesh.getMesh().sub_point_locator();
 
   const std::vector<Point> & hits = _random_hits.hits();
 


### PR DESCRIPTION
Although we don't yet build libmesh with `unique_ptr` enabled by default, this PR makes it possible to compile MOOSE with such a libmesh.  This PR also updates the libmesh submodule in MOOSE.  The following is a brief summary of changes since the last libmesh update.
- Various TopologyMap bugfixes/enhancements.
- Fixed bug in Tree code for 2D meshes not lying in the xy-plane.
- Fixed bug where report_error() could call report_error() recursively.
- Fixed bug where --with-metis=PETSc was still using libmesh's METIS header files.
- Misc. --with-dof-id-bytes=8 fixes in examples.
- Make METIS/ParMETIS' integer and real types consistent with libmesh's Real and dof_id_type.
- Added Mesh::bid_nodes_{begin,end} and Mesh::bnd_nodes_{begin,end} for iterating over boundary nodes.
- Added new example, systems_of_equations_ex8.
- Refactored solution projection code to be more generic.
- Support linking against VTK-6.2.
- Properly compute shape function second derivatives on non-affine elements.
- Added ErrorEstimatorType enum.
- Replace libMesh::AutoPtr with C++03/C++11 unique_ptr types when configuring with --enable-unique-ptr.

Refs libmesh/libmesh#537
