### PR TITLE
Turn off the other legacy flag in moose_test

### DIFF
--- a/framework/src/actions/AddNodalNormalsAction.C
+++ b/framework/src/actions/AddNodalNormalsAction.C
@@ -65,7 +65,7 @@ AddNodalNormalsAction::act()
 
   // Set the execute options
   MultiMooseEnum execute_options(SetupInterface::getExecuteOptions());
-  execute_options = "timestep_begin";
+  execute_options = "initial timestep_begin";
 
   // Create the NodalNormalsPreprocessor UserObject
   if (_current_task == "add_postprocessor")

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -218,7 +218,7 @@ InputParameters validParams<MooseTestApp>()
 {
   InputParameters params = validParams<MooseApp>();
 
-  params.set<bool>("use_legacy_uo_initialization") = true;
+  params.set<bool>("use_legacy_uo_initialization") = false;
   params.set<bool>("use_legacy_uo_aux_computation") = false;
   return params;
 }

--- a/test/tests/auxkernels/constant_scalar_aux/constant_scalar_aux.i
+++ b/test/tests/auxkernels/constant_scalar_aux/constant_scalar_aux.i
@@ -93,11 +93,13 @@
     type = ElementL2Error
     variable = u
     function = exact_fn
+    execute_on = 'initial timestep_end'
   [../]
 
   [./x]
     type = ScalarVariable
     variable = x
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/auxkernels/element_aux_var/element_high_order_aux_test.i
+++ b/test/tests/auxkernels/element_aux_var/element_high_order_aux_test.i
@@ -76,18 +76,22 @@
  [./int2_u]
    type = ElementL2Norm
    variable = u
+   execute_on = 'initial timestep_end'
  [../]
  [./int2_ho]
    type = ElementL2Norm
    variable = high_order
+   execute_on = 'initial timestep_end'
  [../]
  [./int_u]
    type = ElementIntegralVariablePostprocessor
    variable = u
+   execute_on = 'initial timestep_end'
  [../]
  [./int_ho]
    type = ElementIntegralVariablePostprocessor
    variable = high_order
+   execute_on = 'initial timestep_end'
  [../]
 []
 

--- a/test/tests/auxkernels/element_aux_var/l2_element_aux_var_test.i
+++ b/test/tests/auxkernels/element_aux_var/l2_element_aux_var_test.i
@@ -89,26 +89,32 @@
  [./int2_u]
    type = ElementL2Norm
    variable = u
+   execute_on = 'initial timestep_end'
  [../]
  [./int2_l2_lagrange]
    type = ElementL2Norm
    variable = l2_lagrange
+   execute_on = 'initial timestep_end'
  [../]
  [./int2_l2_hierarchic]
    type = ElementL2Norm
    variable = l2_hierarchic
+   execute_on = 'initial timestep_end'
  [../]
  [./int_u]
    type = ElementIntegralVariablePostprocessor
    variable = u
+   execute_on = 'initial timestep_end'
  [../]
  [./int_l2_lagrange]
    type = ElementIntegralVariablePostprocessor
    variable = l2_lagrange
+   execute_on = 'initial timestep_end'
  [../]
  [./int_l2_hierarchic]
    type = ElementIntegralVariablePostprocessor
    variable = l2_hierarchic
+   execute_on = 'initial timestep_end'
  [../]
 []
 

--- a/test/tests/auxkernels/normalization_aux/normalization_aux.i
+++ b/test/tests/auxkernels/normalization_aux/normalization_aux.i
@@ -65,12 +65,12 @@
   [./unorm]
     type = ElementIntegralVariablePostprocessor
     variable = u
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
   [./u_normalized_norm]
     type = ElementIntegralVariablePostprocessor
     variable = u_normalized
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/dgkernels/3d_diffusion_dg/3d_diffusion_dg_test.i
+++ b/test/tests/dgkernels/3d_diffusion_dg/3d_diffusion_dg_test.i
@@ -101,16 +101,19 @@
   [./h]
     type = AverageElementSize
     variable = u
+    execute_on = 'initial timestep_end'
   [../]
 
   [./dofs]
     type = NumDOFs
+    execute_on = 'initial timestep_end'
   [../]
 
   [./l2_err]
     type = ElementL2Error
     variable = u
     function = exact_fn
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/dirackernels/aux_scalar_variable/aux_scalar_variable.i
+++ b/test/tests/dirackernels/aux_scalar_variable/aux_scalar_variable.i
@@ -44,6 +44,7 @@
   [./source_value]
     type = ScalarVariable
     variable = shared
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/executioners/adapt_and_modify/adapt_and_modify.i
+++ b/test/tests/executioners/adapt_and_modify/adapt_and_modify.i
@@ -39,12 +39,12 @@
 [UserObjects]
   [./rh_uo]
     type = RandomHitUserObject
-    execute_on = timestep_begin
+    execute_on = 'initial timestep_begin'
     num_hits = 1
   [../]
   [./rhsm]
     type = RandomHitSolutionModifier
-    execute_on = custom
+    execute_on = 'custom'
     modify = u
     random_hits = rh_uo
     amount = 1000

--- a/test/tests/functions/parsed/mms_transient_coupled.i
+++ b/test/tests/functions/parsed/mms_transient_coupled.i
@@ -131,21 +131,25 @@
     type = PointValue
     variable = u
     point = '0.5 0.5 0'
+    execute_on = 'initial timestep_end'
   [../]
   [./u_midpoint_exact]
     type = PlotFunction
     function = u_exact
     point = '0.5 0.5 0.0'
+    execute_on = 'initial timestep_end'
   [../]
   [./u_error]
     type = ElementL2Error
     variable = u
     function = u_exact
+    execute_on = 'initial timestep_end'
   [../]
   [./v_error]
     type = ElementL2Error
     variable = v
     function = v_exact
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/ics/component_ic/component_ic.i
+++ b/test/tests/ics/component_ic/component_ic.i
@@ -78,22 +78,26 @@
     type = ScalarVariable
     variable = v
     component = 0
+    execute_on = 'initial timestep_end'
   [../]
   [./v2]
     type = ScalarVariable
     variable = v
     component = 1
+    execute_on = 'initial timestep_end'
   [../]
 
   [./a1]
     type = ScalarVariable
     variable = a
     component = 0
+    execute_on = 'initial timestep_end'
   [../]
   [./a2]
     type = ScalarVariable
     variable = a
     component = 1
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/kernels/ode/ode_expl_test.i
+++ b/test/tests/kernels/ode/ode_expl_test.i
@@ -76,6 +76,7 @@
   [./y]
     type = ScalarVariable
     variable = y
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/kernels/ode/ode_sys_impl_test.i
+++ b/test/tests/kernels/ode/ode_sys_impl_test.i
@@ -101,18 +101,18 @@
   [./x]
     type = ScalarVariable
     variable = x
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
   [./y]
     type = ScalarVariable
     variable = y
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
 
   [./exact_x]
     type = PlotFunction
     function = exact_x_fn
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
     point = '0 0 0'
   [../]
 
@@ -120,6 +120,7 @@
     type = ScalarL2Error
     variable = x
     function = exact_x_fn
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/kernels/ode/parsedode_sys_impl_test.i
+++ b/test/tests/kernels/ode/parsedode_sys_impl_test.i
@@ -103,18 +103,18 @@
   [./x]
     type = ScalarVariable
     variable = x
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
   [./y]
     type = ScalarVariable
     variable = y
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
 
   [./exact_x]
     type = PlotFunction
     function = exact_x_fn
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
     point = '0 0 0'
   [../]
 
@@ -122,6 +122,7 @@
     type = ScalarL2Error
     variable = x
     function = exact_x_fn
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/kernels/scalar_constraint/scalar_constraint_kernel.i
+++ b/test/tests/kernels/scalar_constraint/scalar_constraint_kernel.i
@@ -121,6 +121,7 @@
     type = ElementL2Error
     variable = u
     function = exact_fn
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/materials/stateful_internal_side_uo/internal_side_uo_stateful.i
+++ b/test/tests/materials/stateful_internal_side_uo/internal_side_uo_stateful.i
@@ -27,6 +27,7 @@
     type = InsideUserObject
     variable = u
     diffusivity = diffusivity
+    execute_on = 'initial timestep_end'
 #    use_old_prop = true # Access a stateful material on an internal side
   [../]
 []
@@ -69,6 +70,7 @@
   [./value]
     type = InsideValuePPS
     user_object = isuo
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/materials/stateful_prop/stateful_prop_test.i
+++ b/test/tests/materials/stateful_prop/stateful_prop_test.i
@@ -71,6 +71,7 @@
   [./integral]
     type = ElementAverageValue
     variable = prop1
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/materials/stateful_prop/stateful_prop_test_older.i
+++ b/test/tests/materials/stateful_prop/stateful_prop_test_older.i
@@ -73,6 +73,7 @@
   [./integral]
     type = ElementAverageValue
     variable = prop1
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/materials/var_coupling/var_coupling.i
+++ b/test/tests/materials/var_coupling/var_coupling.i
@@ -54,6 +54,7 @@
   [./aux1_integral]
     type = ElementIntegralVariablePostprocessor
     variable = aux1
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/mesh/named_entities/named_entities_test.i
+++ b/test/tests/mesh/named_entities/named_entities_test.i
@@ -83,12 +83,14 @@
     type = ElementAverageValue
     variable = u
     block = 'center_block'
+    execute_on = 'initial timestep_end'
   [../]
 
   [./side_average]
     type = SideAverageValue
     variable = u
     boundary = 'right_side'
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/mesh/named_entities/named_entities_test_xda.i
+++ b/test/tests/mesh/named_entities/named_entities_test_xda.i
@@ -83,12 +83,14 @@
     type = ElementAverageValue
     variable = u
     block = 'center_block'
+    execute_on = 'initial timestep_end'
   [../]
 
   [./side_average]
     type = SideAverageValue
     variable = u
     boundary = 'right_side'
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/misc/serialized_solution/serialized_solution.i
+++ b/test/tests/misc/serialized_solution/serialized_solution.i
@@ -42,10 +42,12 @@
   [./aux]
     type = TestSerializedSolution
     system = aux
+    execute_on = 'initial timestep_end'
   [../]
   [./nl]
     type = TestSerializedSolution
     system = nl
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/misc/serialized_solution/uniform_refine.i
+++ b/test/tests/misc/serialized_solution/uniform_refine.i
@@ -43,10 +43,12 @@
   [./aux]
     type = TestSerializedSolution
     system = aux
+    execute_on = 'initial timestep_end'
   [../]
   [./nl]
     type = TestSerializedSolution
     system = nl
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/mortar/2d/conforming-2nd-order.i
+++ b/test/tests/mortar/2d/conforming-2nd-order.i
@@ -77,6 +77,7 @@
     variable = u
     function = exact_sln
     block = '1 2'
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/mortar/2d/conforming.i
+++ b/test/tests/mortar/2d/conforming.i
@@ -77,6 +77,7 @@
     variable = u
     function = exact_sln
     block = '1 2'
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/mortar/2d/conforming_two_var.i
+++ b/test/tests/mortar/2d/conforming_two_var.i
@@ -105,11 +105,13 @@
     variable = u
     function = exact_sln
     block = '1 2'
+    execute_on = 'initial timestep_end'
   [../]
   [./l2_v]
     type = ElementL2Norm
     variable = v
     block = '1 2'
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/multiapps/picard/picard_master.i
+++ b/test/tests/multiapps/picard/picard_master.i
@@ -51,6 +51,7 @@
 [Postprocessors]
   [./picard_its]
     type = NumPicardIterations
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/outputs/variables/output_vars_test.i
+++ b/test/tests/outputs/variables/output_vars_test.i
@@ -163,12 +163,12 @@
   [./x]
     type = ScalarVariable
     variable = x
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
   [./y]
     type = ScalarVariable
     variable = y
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/all_print_pps/all_print_pps_test.i
+++ b/test/tests/postprocessors/all_print_pps/all_print_pps_test.i
@@ -60,18 +60,22 @@
 [Postprocessors]
   [./nodes]
     type = NumNodes
+    execute_on = 'initial timestep_end'
   [../]
 
   [./elements]
     type = NumElems
+    execute_on = 'initial timestep_end'
   [../]
 
   [./dofs]
     type = NumDOFs
+    execute_on = 'initial timestep_end'
   [../]
 
   [./residuals]
     type = NumResidualEvaluations
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/area_pp/area_pp.i
+++ b/test/tests/postprocessors/area_pp/area_pp.i
@@ -37,6 +37,7 @@
   [./right]
     type = AreaPostprocessor
     boundary = 1
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/difference_pps/difference_depend_check.i
+++ b/test/tests/postprocessors/difference_pps/difference_depend_check.i
@@ -33,12 +33,15 @@
     type = DifferencePostprocessor
     value1 = nodes
     value2 = elems
+    execute_on = 'initial timestep_end'
   [../]
   [./nodes]
     type = NumNodes
+    execute_on = 'initial timestep_end'
   [../]
   [./elems]
     type = NumElems
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/difference_pps/difference_pps.i
+++ b/test/tests/postprocessors/difference_pps/difference_pps.i
@@ -62,17 +62,20 @@
   [./u_avg]
     type = ElementAverageValue
     variable = u
+    execute_on = 'initial timestep_end'
   [../]
 
   [./v_avg]
     type = ElementAverageValue
     variable = v
+    execute_on = 'initial timestep_end'
   [../]
 
   [./diff]
     type = DifferencePostprocessor
     value1 = v_avg
     value2 = u_avg
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/element_h1_error_pps/element_h1_error_pp_test.i
+++ b/test/tests/postprocessors/element_h1_error_pps/element_h1_error_pp_test.i
@@ -91,24 +91,28 @@
 [Postprocessors]
   [./dofs]
     type = NumDOFs
+    execute_on = 'initial timestep_end'
   [../]
 
   [./h1_error]
     type = ElementH1Error
     variable = u
     function = u_func
+    execute_on = 'initial timestep_end'
   [../]
 
   [./h1_semi]
     type = ElementH1SemiError
     variable = u
     function = u_func
+    execute_on = 'initial timestep_end'
   [../]
 
   [./l2_error]
     type = ElementL2Error
     variable = u
     function = u_func
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/element_integral_material_property/element_integral_material_property.i
+++ b/test/tests/postprocessors/element_integral_material_property/element_integral_material_property.i
@@ -47,6 +47,7 @@
   [./prop_integral]
     type = ElementIntegralMaterialProperty
     mat_prop = prop
+    execute_on = 'initial timestep_end'
   [../]
 []
 
@@ -64,4 +65,3 @@
   print_linear_residuals = true
   print_perf_log = true
 []
-

--- a/test/tests/postprocessors/element_integral_var_pps/pps_old_value.i
+++ b/test/tests/postprocessors/element_integral_var_pps/pps_old_value.i
@@ -61,11 +61,13 @@
   [./a]
     type = ElementIntegralVariablePostprocessor
     variable = u
+    execute_on = 'initial timestep_end'
   [../]
 
   [./total_a]
     type = TotalVariableValue
     value = a
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/element_l2_error_pps/element_l2_error_pp_test.i
+++ b/test/tests/postprocessors/element_l2_error_pps/element_l2_error_pp_test.i
@@ -89,6 +89,7 @@
     type = ElementL2Error
     variable = u
     function = u_func
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/element_vec_l2_error_pps/element_vec_l2_error.i
+++ b/test/tests/postprocessors/element_vec_l2_error_pps/element_vec_l2_error.i
@@ -119,6 +119,7 @@
 [Postprocessors]
   [./dofs]
     type = NumDOFs
+    execute_on = 'initial timestep_end'
   [../]
 
   [./integral]
@@ -127,6 +128,7 @@
     var_y = v
     function_x = bc_u
     function_y = bc_v
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/mms_sine/2_d_mms_sine_postprocessor_test.i
+++ b/test/tests/postprocessors/mms_sine/2_d_mms_sine_postprocessor_test.i
@@ -108,10 +108,12 @@
     type = ElementL2Error
     variable = u
     function = solution
+    execute_on = 'initial timestep_end'
   [../]
 
   [./dofs]
     type = NumDOFs
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/mms_sine/3_d_mms_sine_postprocessor_test.i
+++ b/test/tests/postprocessors/mms_sine/3_d_mms_sine_postprocessor_test.i
@@ -112,10 +112,12 @@
     type = ElementL2Error
     variable = u
     function = solution
+    execute_on = 'initial timestep_end'
   [../]
 
   [./dofs]
     type = NumDOFs
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/postprocessors/volume/sphere1D.i
+++ b/test/tests/postprocessors/volume/sphere1D.i
@@ -100,18 +100,22 @@
     type = ElementAverageValue
     block = 1
     variable = constantVar
+    execute_on = 'initial timestep_end'
   [../]
   [./volume1]
     type = VolumePostprocessor
     block = 1
+    execute_on = 'initial timestep_end'
   [../]
   [./volume2]
     type = VolumePostprocessor
     block = 2
+    execute_on = 'initial timestep_end'
   [../]
   [./volume3]
     type = VolumePostprocessor
     block = 3
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/problems/mixed_coord/mixed_coord_test.i
+++ b/test/tests/problems/mixed_coord/mixed_coord_test.i
@@ -53,6 +53,7 @@
   [./volume]
     type = ElementIntegralVariablePostprocessor
     variable = one
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/restrictable/internal_side_user_object/internal_side_user_object.i
+++ b/test/tests/restrictable/internal_side_user_object/internal_side_user_object.i
@@ -34,14 +34,17 @@
 [Postprocessors]
   [./all_pp]
     type = NumInternalSides
+    execute_on = 'initial timestep_end'
    [../]
   [./block_1_pp]
     type = NumInternalSides
     block = 1
+    execute_on = 'initial timestep_end'
   [../]
   [./block_2_pp]
     type = NumInternalSides
     block = 2
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/time_steppers/postprocessor_dt/postprocessor_dt.i
+++ b/test/tests/time_steppers/postprocessor_dt/postprocessor_dt.i
@@ -69,13 +69,14 @@
     type = ElementL2Error
     variable = u
     function = exact_fn
+    execute_on = 'initial timestep_end'
   [../]
 
   # Just use some postprocessor that gives values good enough for time stepping ;-)
   [./dt]
     type = ElementAverageValue
     variable = u
-    execute_on = timestep_end
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/userobjects/Terminator/terminator.i
+++ b/test/tests/userobjects/Terminator/terminator.i
@@ -22,6 +22,7 @@
   [./max_c]
     type = NodalMaxValue
     variable = c
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/utils/spline_interpolation/spline_interpolation.i
+++ b/test/tests/utils/spline_interpolation/spline_interpolation.i
@@ -49,6 +49,7 @@
     type = ElementL2Error
     variable = u
     function = spline_fn
+    execute_on = 'initial timestep_end'
   [../]
 []
 

--- a/test/tests/variables/high_order_monomial/high_order_monomial.i
+++ b/test/tests/variables/high_order_monomial/high_order_monomial.i
@@ -87,16 +87,19 @@
     type = ElementL2Error
     variable = first
     function = first
+    execute_on = 'initial timestep_end'
   [../]
   [./second_error]
     type = ElementL2Error
     variable = second
     function = second
+    execute_on = 'initial timestep_end'
   [../]
   [./third_error]
     type = ElementL2Error
     variable = third
     function = third
+    execute_on = 'initial timestep_end'
   [../]
 []
 


### PR DESCRIPTION
refs #3613

For the most part we are just requiring users to explicitly execute UOs and PPs on `initial` instead of doing it for them. To maintain the current behavior of all tests, I added the necessary 'initial' option to several.
