### PR TITLE
Dynamic obj registration part1

### DIFF
--- a/examples/ex01_inputfile/src/base/ExampleApp.C
+++ b/examples/ex01_inputfile/src/base/ExampleApp.C
@@ -28,8 +28,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex02_kernel/src/base/ExampleApp.C
+++ b/examples/ex02_kernel/src/base/ExampleApp.C
@@ -31,8 +31,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex03_coupling/src/base/ExampleApp.C
+++ b/examples/ex03_coupling/src/base/ExampleApp.C
@@ -30,8 +30,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex04_bcs/src/base/ExampleApp.C
+++ b/examples/ex04_bcs/src/base/ExampleApp.C
@@ -34,8 +34,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex05_amr/src/base/ExampleApp.C
+++ b/examples/ex05_amr/src/base/ExampleApp.C
@@ -32,8 +32,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex06_transient/src/base/ExampleApp.C
+++ b/examples/ex06_transient/src/base/ExampleApp.C
@@ -33,8 +33,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex07_ics/src/base/ExampleApp.C
+++ b/examples/ex07_ics/src/base/ExampleApp.C
@@ -31,8 +31,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex08_materials/src/base/ExampleApp.C
+++ b/examples/ex08_materials/src/base/ExampleApp.C
@@ -33,8 +33,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex09_stateful_materials/src/base/ExampleApp.C
+++ b/examples/ex09_stateful_materials/src/base/ExampleApp.C
@@ -33,8 +33,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex10_aux/src/base/ExampleApp.C
+++ b/examples/ex10_aux/src/base/ExampleApp.C
@@ -31,8 +31,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex11_prec/src/base/ExampleApp.C
+++ b/examples/ex11_prec/src/base/ExampleApp.C
@@ -28,8 +28,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex12_pbp/src/base/ExampleApp.C
+++ b/examples/ex12_pbp/src/base/ExampleApp.C
@@ -26,8 +26,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex13_functions/src/base/ExampleApp.C
+++ b/examples/ex13_functions/src/base/ExampleApp.C
@@ -30,8 +30,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex14_pps/src/base/ExampleApp.C
+++ b/examples/ex14_pps/src/base/ExampleApp.C
@@ -30,8 +30,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex15_actions/src/base/ExampleApp.C
+++ b/examples/ex15_actions/src/base/ExampleApp.C
@@ -33,8 +33,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex16_timestepper/src/base/ExampleApp.C
+++ b/examples/ex16_timestepper/src/base/ExampleApp.C
@@ -34,8 +34,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex17_dirac/src/base/ExampleApp.C
+++ b/examples/ex17_dirac/src/base/ExampleApp.C
@@ -32,8 +32,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex18_scalar_kernel/src/base/ExampleApp.C
+++ b/examples/ex18_scalar_kernel/src/base/ExampleApp.C
@@ -32,8 +32,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex19_dampers/src/base/ExampleApp.C
+++ b/examples/ex19_dampers/src/base/ExampleApp.C
@@ -27,8 +27,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex20_user_objects/src/base/ExampleApp.C
+++ b/examples/ex20_user_objects/src/base/ExampleApp.C
@@ -32,8 +32,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/examples/ex21_debugging/src/base/ExampleApp.C
+++ b/examples/ex21_debugging/src/base/ExampleApp.C
@@ -33,8 +33,8 @@ ExampleApp::ExampleApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ExampleApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ExampleApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ExampleApp::associateSyntax(_syntax, _action_factory);

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -388,7 +388,11 @@ protected:
   /// Indicates whether warnings, errors, or no output is displayed when unused parameters are detected
   enum UNUSED_CHECK { OFF, WARN_UNUSED, ERROR_UNUSED } _enable_unused_check;
 
+  /// The factory used to construct all MooseObjects (unique instance for this
   Factory _factory;
+
+  /// Pointer to the factory, necessary for migrating to a new shared factory model while maintaining backwards compatibility
+  Factory * _shared_factory;
 
   /// Indicates whether warnings or errors are displayed when overridden parameters are detected
   bool _error_overridden;

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -104,6 +104,7 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     _use_nonlinear(true),
     _enable_unused_check(WARN_UNUSED),
     _factory(*this),
+    _shared_factory(&_factory),
     _error_overridden(false),
     _ready_to_exit(false),
     _initial_from_file(false),

--- a/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
+++ b/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
@@ -49,8 +49,8 @@ ChemicalReactionsApp::ChemicalReactionsApp(const std::string & name, InputParame
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ChemicalReactionsApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ChemicalReactionsApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ChemicalReactionsApp::associateSyntax(_syntax, _action_factory);

--- a/modules/combined/src/base/ModulesApp.C
+++ b/modules/combined/src/base/ModulesApp.C
@@ -39,8 +39,8 @@ InputParameters validParams<ModulesApp>()
 ModulesApp::ModulesApp(const std::string & name, InputParameters parameters) :
     MooseApp(name, parameters)
 {
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/modules/contact/src/base/ContactApp.C
+++ b/modules/contact/src/base/ContactApp.C
@@ -43,8 +43,8 @@ ContactApp::ContactApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ContactApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ContactApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ContactApp::associateSyntax(_syntax, _action_factory);

--- a/modules/heat_conduction/src/base/HeatConductionApp.C
+++ b/modules/heat_conduction/src/base/HeatConductionApp.C
@@ -44,8 +44,8 @@ HeatConductionApp::HeatConductionApp(const std::string & name, InputParameters p
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  HeatConductionApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  HeatConductionApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   HeatConductionApp::associateSyntax(_syntax, _action_factory);

--- a/modules/linear_elasticity/src/base/LinearElasticityApp.C
+++ b/modules/linear_elasticity/src/base/LinearElasticityApp.C
@@ -31,8 +31,8 @@ LinearElasticityApp::LinearElasticityApp(const std::string & name, InputParamete
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  LinearElasticityApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  LinearElasticityApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   LinearElasticityApp::associateSyntax(_syntax, _action_factory);

--- a/modules/misc/src/base/MiscApp.C
+++ b/modules/misc/src/base/MiscApp.C
@@ -39,8 +39,8 @@ MiscApp::MiscApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  MiscApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  MiscApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   MiscApp::associateSyntax(_syntax, _action_factory);

--- a/modules/navier_stokes/src/base/NavierStokesApp.C
+++ b/modules/navier_stokes/src/base/NavierStokesApp.C
@@ -93,8 +93,8 @@ NavierStokesApp::NavierStokesApp(const std::string & name, InputParameters param
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  NavierStokesApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  NavierStokesApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   NavierStokesApp::associateSyntax(_syntax, _action_factory);

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -143,8 +143,8 @@ PhaseFieldApp::PhaseFieldApp(const std::string & name, InputParameters parameter
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  PhaseFieldApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  PhaseFieldApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   PhaseFieldApp::associateSyntax(_syntax, _action_factory);

--- a/modules/richards/src/base/RichardsApp.C
+++ b/modules/richards/src/base/RichardsApp.C
@@ -100,8 +100,8 @@ RichardsApp::RichardsApp(const std::string & name, InputParameters parameters) :
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  RichardsApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  RichardsApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   RichardsApp::associateSyntax(_syntax, _action_factory);

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -90,8 +90,8 @@ SolidMechanicsApp::SolidMechanicsApp(const std::string & name, InputParameters p
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  SolidMechanicsApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  SolidMechanicsApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   SolidMechanicsApp::associateSyntax(_syntax, _action_factory);

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -80,8 +80,8 @@ TensorMechanicsApp::TensorMechanicsApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  TensorMechanicsApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  TensorMechanicsApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   TensorMechanicsApp::associateSyntax(_syntax, _action_factory);

--- a/modules/water_steam_eos/src/base/WaterSteamEOSApp.C
+++ b/modules/water_steam_eos/src/base/WaterSteamEOSApp.C
@@ -23,8 +23,8 @@ WaterSteamEOSApp::WaterSteamEOSApp(const std::string & name, InputParameters par
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  WaterSteamEOSApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  WaterSteamEOSApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   WaterSteamEOSApp::associateSyntax(_syntax, _action_factory);

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -229,8 +229,8 @@ MooseTestApp::MooseTestApp(const std::string & name, InputParameters parameters)
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  MooseTestApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  MooseTestApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   MooseTestApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step1_diffusion/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step1_diffusion/src/base/DarcyThermoMechApp.C
@@ -31,9 +31,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step2_darcy_pressure/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step2_darcy_pressure/src/base/DarcyThermoMechApp.C
@@ -34,9 +34,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step3_darcy_material/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step3_darcy_material/src/base/DarcyThermoMechApp.C
@@ -37,9 +37,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step4_velocity_aux/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step4_velocity_aux/src/base/DarcyThermoMechApp.C
@@ -40,9 +40,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step5_heat_conduction/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step5_heat_conduction/src/base/DarcyThermoMechApp.C
@@ -43,9 +43,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step6_coupled_darcy_heat_conduction/src/base/DarcyThermoMechApp.C
@@ -44,9 +44,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step7_adaptivity/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step7_adaptivity/src/base/DarcyThermoMechApp.C
@@ -44,9 +44,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step8_postprocessors/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step8_postprocessors/src/base/DarcyThermoMechApp.C
@@ -44,9 +44,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/tutorials/darcy_thermo_mech/step9_mechanics/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step9_mechanics/src/base/DarcyThermoMechApp.C
@@ -44,9 +44,9 @@ DarcyThermoMechApp::DarcyThermoMechApp(const std::string & name, InputParameters
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  DarcyThermoMechApp::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
+  ModulesApp::registerObjects(*_shared_factory);
+  DarcyThermoMechApp::registerObjects(*_shared_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
   ModulesApp::associateSyntax(_syntax, _action_factory);

--- a/unit/src/MooseUnitApp.C
+++ b/unit/src/MooseUnitApp.C
@@ -26,7 +26,7 @@ MooseUnitApp::MooseUnitApp(const std::string & name, InputParameters parameters)
 {
   srand(processor_id());
 
-  Moose::registerObjects(_factory);
+  Moose::registerObjects(*_shared_factory);
   Moose::associateSyntax(_syntax, _action_factory);
 }
 


### PR DESCRIPTION
This commit is here to enable the transition from a factory per application to a shared factory for several applications. All this PR does is add a redundant pointer to MooseApp that references the existing factory, but it also switches over the registration method to use the pointer. A follow-on PR will remove the factory altogether and use a shared factory only constructed outside of the object.
