### PR TITLE
Put capabilities in place to enable automatic differentiation of MaterialProperties

### DIFF
--- a/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
@@ -33,7 +33,6 @@ protected:
   virtual void computeProperties();
 
   virtual void functionsPostParse();
-  virtual void registerMaterialProperties(const std::vector<std::string> & mat_prop_names);
 
   void functionsDerivative();
   void functionsOptimize();
@@ -46,9 +45,6 @@ protected:
 
   /// The third derivatives of the free energy (function parser objects).
   std::vector<std::vector<std::vector<ADFunction *> > > _func_d3F;
-
-  /// material property dependent variables
-  std::vector<std::vector<std::string> > _mat_prop_args;
 };
 
 #endif // DERIVATIVEPARSEDMATERIALHELPER_H

--- a/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/DerivativeParsedMaterialHelper.h
@@ -33,6 +33,7 @@ protected:
   virtual void computeProperties();
 
   virtual void functionsPostParse();
+  virtual void registerMaterialProperties(const std::vector<std::string> & mat_prop_names);
 
   void functionsDerivative();
   void functionsOptimize();
@@ -45,6 +46,9 @@ protected:
 
   /// The third derivatives of the free energy (function parser objects).
   std::vector<std::vector<std::vector<ADFunction *> > > _func_d3F;
+
+  /// material property dependent variables
+  std::vector<std::vector<std::string> > _mat_prop_args;
 };
 
 #endif // DERIVATIVEPARSEDMATERIALHELPER_H

--- a/modules/phase_field/include/materials/ParsedMaterialBase.h
+++ b/modules/phase_field/include/materials/ParsedMaterialBase.h
@@ -36,9 +36,6 @@ protected:
   /// tolerance vectors
   std::vector<std::string> _tol_names;
   std::vector<Real> _tol_values;
-
-  /// material property names
-  std::vector<std::string> _mat_prop_names;
 };
 
 #endif //PARSEDMATERIALBASE_H

--- a/modules/phase_field/include/materials/ParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/ParsedMaterialHelper.h
@@ -129,10 +129,6 @@ void ParsedMaterialHelper<T>::functionParse(const std::string & function_express
                                          const std::vector<std::string> & tol_names,
                                          const std::vector<Real> & tol_values)
 {
-  // check number of coupled variables
-  if (this->_nargs == 0)
-    mooseError("Need at least one coupled variable for ParsedMaterialHelper.");
-
   // build base function object
   _func_F =  new ADFunction();
 
@@ -163,8 +159,7 @@ void ParsedMaterialHelper<T>::functionParse(const std::string & function_express
   switch (_map_mode)
   {
     case USE_MOOSE_NAMES:
-      variables = this->_arg_names[0];
-      for (unsigned i = 1; i < this->_nargs; ++i)
+      for (unsigned i = 0; i < this->_nargs; ++i)
         variables += "," + this->_arg_names[i];
       break;
 
@@ -173,8 +168,7 @@ void ParsedMaterialHelper<T>::functionParse(const std::string & function_express
       if (!this->_mapping_is_unique)
         mooseError("Derivative parsed materials must couple exactly one non-linear variable per coupled variable input parameter.");
 
-      variables = this->_arg_param_names[0];
-      for (unsigned i = 1; i < this->_nargs; ++i)
+      for (unsigned i = 0; i < this->_nargs; ++i)
         variables += "," + this->_arg_param_names[i];
       break;
 
@@ -190,6 +184,9 @@ void ParsedMaterialHelper<T>::functionParse(const std::string & function_express
     _mat_props[i] = &(this->template getMaterialProperty<Real>(mat_prop_names[i]));
     variables += "," + mat_prop_names[i];
   }
+
+  // erase leading comma
+  variables.erase(0,1);
 
   // build the base function
   if (_func_F->Parse(function_expression, variables) >= 0)

--- a/modules/phase_field/src/materials/DerivativeParsedMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterial.C
@@ -23,6 +23,6 @@ DerivativeParsedMaterial::DerivativeParsedMaterial(const std::string & name,
   // Build function, take derivatives, optimize
   functionParse(_function,
                 _constant_names, _constant_expressions,
-                _mat_prop_names,
+                getParam<std::vector<std::string> >("material_property_names"),
                 _tol_names, _tol_values);
 }

--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -45,41 +45,6 @@ void DerivativeParsedMaterialHelper::functionsPostParse()
 }
 
 void
-DerivativeParsedMaterialHelper::registerMaterialProperties(const std::vector<std::string> & mat_prop_names)
-{
-  unsigned int num_mat_prop = mat_prop_names.size();
-
-  _mat_prop_args.clear();
-  _mat_prop_args.resize(num_mat_prop);
-  _mat_prop_names.resize(num_mat_prop);
-
-  // for this material we pass in every material property with its dependent variables as a , separated list in ()
-  for (unsigned int i = 0; i < num_mat_prop; ++i)
-  {
-    // find first '(' and last ')'
-    const std::string & name = mat_prop_names[i];
-    size_t open  = name.find_first_of("(");
-    size_t close = name.find_last_of(")");
-
-    if (open == std::string::npos && close == std::string::npos)
-    {
-      // material property name without arguments
-      _mat_prop_names[i] = name;
-    }
-    else if (open != std::string::npos && close != std::string::npos)
-    {
-      // take material property name before bracket
-      _mat_prop_names.push_back(name.substr(0, open));
-
-      // parse argument list
-      MooseUtils::tokenize(name.substr(open + 1, close - open - 1), _mat_prop_args[i], 0, ",");
-    }
-    else
-      mooseError("Malformed materialproperty name in DerivativeParsedMaterialHelper derived material " << _name);
-  }
-}
-
-void
 DerivativeParsedMaterialHelper::functionsDerivative()
 {
   unsigned int i, j, k;
@@ -203,8 +168,9 @@ DerivativeParsedMaterialHelper::computeProperties()
     }
 
     // insert material property values
-    for (i = 0; i < _nmat_props; ++i)
-      _func_params[i + _nargs] = (*_mat_props[i])[_qp];
+    unsigned int nmat_props = _mat_prop_descriptors.size();
+    for (i = 0; i < nmat_props; ++i)
+      _func_params[i + _nargs] = _mat_prop_descriptors[i].value()[_qp];
 
     // set function value
     if (_prop_F)

--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -44,7 +44,43 @@ void DerivativeParsedMaterialHelper::functionsPostParse()
   functionsOptimize();
 }
 
-void DerivativeParsedMaterialHelper::functionsDerivative()
+void
+DerivativeParsedMaterialHelper::registerMaterialProperties(const std::vector<std::string> & mat_prop_names)
+{
+  unsigned int num_mat_prop = mat_prop_names.size();
+
+  _mat_prop_args.clear();
+  _mat_prop_args.resize(num_mat_prop);
+  _mat_prop_names.resize(num_mat_prop);
+
+  // for this material we pass in every material property with its dependent variables as a , separated list in ()
+  for (unsigned int i = 0; i < num_mat_prop; ++i)
+  {
+    // find first '(' and last ')'
+    const std::string & name = mat_prop_names[i];
+    size_t open  = name.find_first_of("(");
+    size_t close = name.find_last_of(")");
+
+    if (open == std::string::npos && close == std::string::npos)
+    {
+      // material property name without arguments
+      _mat_prop_names[i] = name;
+    }
+    else if (open != std::string::npos && close != std::string::npos)
+    {
+      // take material property name before bracket
+      _mat_prop_names.push_back(name.substr(0, open));
+
+      // parse argument list
+      MooseUtils::tokenize(name.substr(open + 1, close - open - 1), _mat_prop_args[i], 0, ",");
+    }
+    else
+      mooseError("Malformed materialproperty name in DerivativeParsedMaterialHelper derived material " << _name);
+  }
+}
+
+void
+DerivativeParsedMaterialHelper::functionsDerivative()
 {
   unsigned int i, j, k;
 
@@ -85,7 +121,8 @@ void DerivativeParsedMaterialHelper::functionsDerivative()
   }
 }
 
-void DerivativeParsedMaterialHelper::functionsOptimize()
+void
+DerivativeParsedMaterialHelper::functionsOptimize()
 {
   unsigned int i, j, k;
 

--- a/modules/phase_field/src/materials/FunctionMaterialBase.C
+++ b/modules/phase_field/src/materials/FunctionMaterialBase.C
@@ -59,9 +59,6 @@ FunctionMaterialBase::FunctionMaterialBase(const std::string & name,
       _args.push_back(&coupledValue(*it, j));
     }
   }
-  _nargs = _arg_names.size();
 
-  // check number of coupled variables
-  if (_nargs == 0)
-    mooseError("Need at least one coupled variable for Function Material " << name);
+  _nargs = _arg_names.size();
 }

--- a/modules/phase_field/src/materials/ParsedMaterial.C
+++ b/modules/phase_field/src/materials/ParsedMaterial.C
@@ -23,6 +23,6 @@ ParsedMaterial::ParsedMaterial(const std::string & name,
   // Build function and optimize
   functionParse(_function,
                 _constant_names, _constant_expressions,
-                _mat_prop_names,
+                getParam<std::vector<std::string> >("material_property_names"),
                 _tol_names, _tol_values);
 }

--- a/modules/phase_field/src/materials/ParsedMaterialBase.C
+++ b/modules/phase_field/src/materials/ParsedMaterialBase.C
@@ -10,7 +10,7 @@ template<>
 InputParameters validParams<ParsedMaterialBase>()
 {
   InputParameters params = emptyInputParameters();
-  params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
+  params.addCoupledVar("args", "Arguments of F() - use vector coupling");
 
   // Constants and their values
   params.addParam<std::vector<std::string> >("constant_names", std::vector<std::string>(), "Vector of constants used in the parsed function (use this for kB etc.)");
@@ -44,7 +44,4 @@ ParsedMaterialBase::ParsedMaterialBase(const std::string & /* name */,
   // get tolerance vectors
   _tol_names = parameters.get<std::vector<std::string> >("tol_names");
   _tol_values = parameters.get<std::vector<Real> >("tol_values");
-
-  // get material property names
-  _mat_prop_names = parameters.get<std::vector<std::string> >("material_property_names");
 }

--- a/modules/phase_field/src/materials/ParsedMaterialBase.C
+++ b/modules/phase_field/src/materials/ParsedMaterialBase.C
@@ -23,7 +23,7 @@ InputParameters validParams<ParsedMaterialBase>()
   // Material properties
   params.addParam<std::vector<std::string> >(
     "material_property_names", std::vector<std::string>(),
-    "Vector of material properties used in the parsed function (these should have a zero gradient!)");
+    "Vector of material properties used in the parsed function");
 
   // Function expression
   params.addRequiredParam<std::string>("function", "FParser function expression for the phase free energy");

--- a/modules/phase_field/tests/Parsed/matproptest.i
+++ b/modules/phase_field/tests/Parsed/matproptest.i
@@ -1,0 +1,83 @@
+#
+# This test validates the helper materials that generate material properties for
+# the h(eta) switching function and the g(eta) double well function
+#
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 40
+  ny = 5
+  nz = 0
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  zmin = 0
+  zmax = 0
+  elem_type = QUAD4
+[]
+
+[Variables]
+  # order parameter 1
+  [./eta1]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./eta2]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Materials]
+  [./h_eta1]
+    type = SwitchingFunctionMaterial
+    block = 0
+    function_name = h1
+    h_order = SIMPLE
+    eta = eta1
+  [../]
+  [./h_eta2]
+    type = SwitchingFunctionMaterial
+    block = 0
+    function_name = h2
+    h_order = SIMPLE
+    eta = eta2
+  [../]
+  [./penalty]
+    type = DerivativeParsedMaterial
+    block = 0
+    function = '(1-h1-h2)^2'
+    material_property_names = 'h1(eta1) h2(eta1,eta2)'
+    outputs = exodus
+  [../]
+[]
+
+[Kernels]
+  [./eta1diff]
+    type = Diffusion
+    variable = eta1
+  [../]
+  [./eta2diff]
+    type = Diffusion
+    variable = eta2
+  [../]
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  output_initial = false
+  interval = 1
+  exodus = true
+  print_linear_residuals = true
+  print_perf_log = true
+[]


### PR DESCRIPTION
I've been working on this for a while and would like to get this stage merged. This reworks how material properties in parsed functions are handled. 
I've created a class that stores a material property to be used in a parsed function. Alongside the nonlinear variables the material property depends on (important for taking derivatives) as well as the derivatives already applied are stored (this will be more useful later on).
This patch will enable the use of 

```
material_property_names = 'h1(eta1) h2(eta1,eta2)'
```

In `(Derivative)ParsedMaterial` blocks to declare non-linear variable dependencied for material properties. It also allows this syntax

```
material_property_names = 'v:=D[x(t),t]'
```

to access a derivative material property (in this case the _t_ derivative of _x_) and use it under a custom name (in this case _v_), as the actual derivative material property names may not be usable in function parser (the may contain `^` characters and are rather long anyways).

Ping @tonkmr 

Refs #4735
