### PR TITLE
Fixing moose_unit

### DIFF
--- a/unit/run_tests
+++ b/unit/run_tests
@@ -17,8 +17,12 @@ then
   if [ $? -eq 0 ]
   then
     echo "unit" >> ../test_results.log
+  else
+    exit 1
   fi
 else
   echo "Executable missing!"
   exit 1
 fi
+
+exit 0

--- a/unit/src/EBSDMeshErrorTest.C
+++ b/unit/src/EBSDMeshErrorTest.C
@@ -28,7 +28,7 @@ void
 EBSDMeshErrorTest::setUp()
 {
   const char *argv[2] = { "foo", "\0" };
-  _app = AppFactory::createApp("MarmotUnitApp", 1, (char**)argv);
+  _app = AppFactory::createApp("MooseUnitApp", 1, (char**)argv);
   _factory = &_app->getFactory();
 }
 
@@ -44,7 +44,7 @@ void
 EBSDMeshErrorTest::fileDoesNotExist()
 {
   // generate input parameter set
-  InputParameters params = _factory->getValidParams("EBSDMesh");
+  InputParameters params = validParams<EBSDMesh>();
   params.addPrivateParam("_moose_app", _app);
   params.set<std::string>("name", "EBSD");
 
@@ -89,7 +89,7 @@ void
 EBSDMeshErrorTest::headerErrorHelper(const char * filename, const char * error)
 {
   // generate input parameter set
-  InputParameters params = _factory->getValidParams("EBSDMesh");
+  InputParameters params = validParams<EBSDMesh>();
   params.addPrivateParam("_moose_app", _app);
   params.set<std::string>("name", "EBSD");
 
@@ -136,7 +136,7 @@ EBSDMeshErrorTest::testParam(unsigned int nparam, const char ** param_list)
   for (unsigned int i = 0; i < nparam; ++i)
   {
     // generate input parameter set
-    InputParameters params = _factory->getValidParams("EBSDMesh");
+    InputParameters params = validParams<EBSDMesh>();
     params.addPrivateParam("_moose_app", _app);
     params.set<std::string>("name", "EBSD");
 

--- a/unit/src/ParsedFunctionTest.C
+++ b/unit/src/ParsedFunctionTest.C
@@ -90,6 +90,7 @@ ParsedFunctionTest::advancedConstructor()
   params.set<SubProblem *>("_subproblem") = _fe_problem;
   params.set<std::string>("value") = "x + y + q";
   params.set<std::vector<std::string> >("vars") = one_var;
+  params.set<std::vector<std::string> >("vals") = std::vector<std::string>(1, "-1"); // Dummy value, will be overwritten in test below
   params.set<std::string>("name") = "test";
 
 
@@ -110,6 +111,7 @@ ParsedFunctionTest::advancedConstructor()
   params2.set<SubProblem *>("_subproblem") = _fe_problem;
   params2.set<std::string>("value") = "r*x + y/w + q";
   params2.set<std::vector<std::string> >("vars") = three_vars;
+  params2.set<std::vector<std::string> >("vals") = std::vector<std::string>(3, "-1"); // Dummy values, will be overwritten in test below
   params2.set<std::string>("name") = "test";
 
   MooseParsedFunction f2("test", params2);
@@ -135,17 +137,18 @@ ParsedFunctionTest::advancedConstructor()
   f3.initialSetup();
   CPPUNIT_ASSERT( f3.value(0,2) == 5 );
 
-  //test the constructor with three variables, two that are set
-  std::vector<std::string> two_vals(2);
-  two_vals[0] = "1.5";
-  two_vals[1] = "1";
+  //test the constructor with three variables
+  std::vector<std::string> three_vals(3);
+  three_vals[0] = "1.5";
+  three_vals[1] = "1";
+  three_vals[2] = "0";
 
   InputParameters params4 = _factory->getValidParams("ParsedFunction");
   params4.set<FEProblem *>("_fe_problem") = _fe_problem;
   params4.set<SubProblem *>("_subproblem") = _fe_problem;
   params4.set<std::string>("value") = "q*x + y/r + w";
   params4.set<std::vector<std::string> >("vars") = three_vars;
-  params4.set<std::vector<std::string> >("vals") = two_vals;
+  params4.set<std::vector<std::string> >("vals") = three_vals;
   params4.set<std::string>("name") = "test";
 
   MooseParsedFunction f4("test", params4);
@@ -173,6 +176,7 @@ ParsedFunctionTest::testVariables()
   params.set<SubProblem *>("_subproblem") = _fe_problem;
   params.set<std::string>("value") = "x + y + q";
   params.set<std::vector<std::string> >("vars") = one_var;
+  params.set<std::vector<std::string> >("vals") = std::vector<std::string>(1, "-1"); // Dummy value, will be overwritten in test below
   params.set<std::string>("name") = "test";
 
   MooseParsedFunction f("test", params);
@@ -196,6 +200,7 @@ ParsedFunctionTest::testVariables()
   params2.set<SubProblem *>("_subproblem") = _fe_problem;
   params2.set<std::string>("value") = "r*x + y/w + q";
   params2.set<std::vector<std::string> >("vars") = three_vars;
+  params2.set<std::vector<std::string> >("vals") = std::vector<std::string>(3, "-1"); // Dummy values, will be overwritten in test below
   params2.set<std::string>("name") = "test";
 
   MooseParsedFunction f2("test", params2);


### PR DESCRIPTION
closes #4986 

Adding an "if" statement to the end of the run_tests scripts in 101b743b broke the ability of the script to return the proper exit code on failure. As a result several regressions occured that went unnoticed. This patch fixes the script and repairs all of the regressions.

@dschwen - You have several unit tests for ParsedFunctions that allowed different numbers of var/value pairs. However you removed that ability in fdb2db2e. Please review my changes and let me know which way you'd rather have it.
