### PR TITLE
Skip PenetrationInfo in loop when DOF does not exist.

### DIFF
--- a/framework/src/auxkernels/PenetrationAux.C
+++ b/framework/src/auxkernels/PenetrationAux.C
@@ -98,19 +98,16 @@ PenetrationAux::timestepSetup()
     for ( PenetrationMap::iterator it = begin; it != end; ++it )
     {
       PenetrationInfo * pinfo = it->second;
-      if ( ! pinfo )
+
+      // Make sure this node actually has a DOF for this variable. It may not have a DOF if, for
+      // example, the mesh is 2nd order but the variables are 1st order.
+      if ( ! pinfo || pinfo->_node->n_comp(_sys.number(),_var.number()) < 1 )
         continue;
 
       // We have to re-get the node here because getNodalValueOld asserts isSemiLocal based on a
       // pointer to the node rather than the node's ID. So we need a reference to the actual node
       // held by the mesh rather than the displaced copy of the node stored in the pinfo.
       Node & node = displaced_problem.refMesh().node( pinfo->_node->id() );
-
-      // Now make sure this node actually has a DOF for this variable. It may not have a DOF if, for
-      // example, the mesh is 2nd order but the variables are 1st order.
-      if ( node.n_dofs(_sys.number(), _var.number()) == 0 )
-        continue;
-
       Real old_value = _var.getNodalValueOld(node);
 
       switch (_quantity)

--- a/modules/contact/include/ContactMaster.h
+++ b/modules/contact/include/ContactMaster.h
@@ -70,7 +70,7 @@ protected:
 
   const unsigned int _mesh_dimension;
 
-  RealVectorValue _vars;
+  VectorValue<unsigned> _vars;
 
   MooseVariable * _nodal_area_var;
   SystemBase & _aux_system;

--- a/modules/contact/include/GluedContactConstraint.h
+++ b/modules/contact/include/GluedContactConstraint.h
@@ -67,7 +67,7 @@ protected:
   unsigned int _y_var;
   unsigned int _z_var;
 
-  RealVectorValue _vars;
+  VectorValue<unsigned> _vars;
 
   MooseVariable * _nodal_area_var;
   SystemBase & _aux_system;

--- a/modules/contact/include/MultiDContactConstraint.h
+++ b/modules/contact/include/MultiDContactConstraint.h
@@ -59,7 +59,7 @@ protected:
 
   const unsigned int _mesh_dimension;
 
-  RealVectorValue _vars;
+  VectorValue<unsigned> _vars;
 };
 
 #endif

--- a/modules/contact/include/SlaveConstraint.h
+++ b/modules/contact/include/SlaveConstraint.h
@@ -49,7 +49,7 @@ protected:
   const unsigned int _y_var;
   const unsigned int _z_var;
 
-  const RealVectorValue _vars;
+  const VectorValue<unsigned> _vars;
 
   const unsigned int _mesh_dimension;
 

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -139,13 +139,8 @@ ContactMaster::updateContactSet(bool beginning_of_step)
   {
     PenetrationInfo * pinfo = it->second;
 
-    if (!pinfo)
-    {
-      continue;
-    }
-
-    // Skip this pinfo if there are no displacement DOFs on this node.
-    if ( pinfo->_node->n_dofs(_sys.number(), _vars(_component)) == 0 )
+    // Skip this pinfo if there are no DOFs on this node.
+    if ( ! pinfo || pinfo->_node->n_comp(_sys.number(), _vars(_component)) < 1 )
       continue;
 
     Real area = nodalArea(*pinfo);
@@ -259,11 +254,8 @@ ContactMaster::addPoints()
   {
     PenetrationInfo * pinfo = it->second;
 
-    if (!pinfo)
-      continue;
-
-    // Skip this pinfo if there are no displacement DOFs on this node.
-    if ( pinfo->_node->n_dofs(_sys.number(), _vars(_component)) == 0 )
+    // Skip this pinfo if there are no DOFs on this node.
+    if ( ! pinfo || pinfo->_node->n_comp(_sys.number(), _vars(_component)) < 1 )
       continue;
 
     dof_id_type slave_node_num = it->first;

--- a/modules/contact/src/GluedContactConstraint.C
+++ b/modules/contact/src/GluedContactConstraint.C
@@ -123,13 +123,8 @@ GluedContactConstraint::updateContactSet(bool beginning_of_step)
   {
     PenetrationInfo * pinfo = it->second;
 
-    if (!pinfo)
-    {
-      continue;
-    }
-
-    // Skip this pinfo if there are no displacement DOFs on this node.
-    if ( pinfo->_node->n_dofs(_sys.number(), _vars(_component)) == 0 )
+    // Skip this pinfo if there are no DOFs on this node.
+    if ( ! pinfo || pinfo->_node->n_comp(_sys.number(), _vars(_component)) < 1 )
       continue;
 
     const dof_id_type slave_node_num = it->first;

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -133,14 +133,12 @@ MechanicalContactConstraint::updateContactSet(bool beginning_of_step)
   for (; it!=end; ++it)
   {
     PenetrationInfo * pinfo = it->second;
-    if (!pinfo)
+
+    // Skip this pinfo if there are no DOFs on this node.
+    if ( ! pinfo || pinfo->_node->n_comp(_sys.number(), _vars(_component)) < 1 )
       continue;
 
     const Node * node = pinfo->_node;
-
-    // Skip this pinfo if there are no displacement DOFs on this node.
-    if ( node->n_dofs(_sys.number(), _vars(_component)) == 0 )
-      continue;
 
     const dof_id_type slave_node_num = it->first;
     std::set<dof_id_type>::iterator hpit = has_penetrated.find(slave_node_num);

--- a/modules/contact/src/MultiDContactConstraint.C
+++ b/modules/contact/src/MultiDContactConstraint.C
@@ -81,10 +81,9 @@ MultiDContactConstraint::updateContactSet()
   {
     PenetrationInfo * pinfo = it->second;
 
-    if (!pinfo)
-    {
+    // Skip this pinfo if there are no DOFs on this node.
+    if ( ! pinfo || pinfo->_node->n_comp(_sys.number(), _vars(_component)) < 1 )
       continue;
-    }
 
     const Node * node = pinfo->_node;
 

--- a/modules/contact/src/OneDContactConstraint.C
+++ b/modules/contact/src/OneDContactConstraint.C
@@ -54,10 +54,9 @@ OneDContactConstraint::updateContactSet()
   {
     PenetrationInfo * pinfo = it->second;
 
-    if (!pinfo)
-    {
+    // Skip this pinfo if there are no DOFs on this node.
+    if ( ! pinfo || pinfo->_node->n_comp(_sys.number(), _var.number()) < 1 )
       continue;
-    }
 
     if (pinfo->_distance > 0)
     {

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -89,13 +89,8 @@ SlaveConstraint::addPoints()
   {
     PenetrationInfo * pinfo = it->second;
 
-    if (!pinfo)
-    {
-      continue;
-    }
-
-    // Skip this pinfo if there are no displacement DOFs on this node.
-    if ( pinfo->_node->n_dofs(_sys.number(), _vars(_component)) == 0 )
+    // Skip this pinfo if there are no DOFs on this node.
+    if ( ! pinfo || pinfo->_node->n_comp(_sys.number(), _vars(_component)) < 1 )
       continue;
 
     dof_id_type slave_node_num = it->first;

--- a/modules/heat_conduction/src/GapHeatPointSourceMaster.C
+++ b/modules/heat_conduction/src/GapHeatPointSourceMaster.C
@@ -61,7 +61,8 @@ GapHeatPointSourceMaster::addPoints()
   {
     PenetrationInfo * pinfo = it->second;
 
-    if (!pinfo)
+    // Skip this pinfo if there are no DOFs on this node.
+    if ( ! pinfo || pinfo->_node->n_comp(_sys.number(), _var.number()) < 1 )
       continue;
 
     addPoint(pinfo->_elem, pinfo->_closest_point);


### PR DESCRIPTION
Refs #4997. Fixes an issue where some of the contact objects attempt
to loop over PenetrationInfos when there is no relevant DOF for
contact. This happens when the mesh has quadratic elements but the
contact is using linear elements.
