### PR TITLE
Add type to MooseApp

### DIFF
--- a/framework/include/base/AppFactory.h
+++ b/framework/include/base/AppFactory.h
@@ -96,7 +96,7 @@ public:
    * @param parameters Parameters this object should have
    * @return The created object
    */
-  virtual MooseApp *create(const std::string & obj_name, const std::string & name, InputParameters parameters, MPI_Comm COMM_WORLD_IN);
+  MooseApp *create(const std::string & app_type, const std::string & name, InputParameters parameters, MPI_Comm COMM_WORLD_IN);
 
   ///@{
   /**

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -66,6 +66,12 @@ public:
    */
   InputParameters & parameters() { return _pars; }
 
+  /**
+   * Get the type of this object as a string
+   * @return The the type of the object
+   */
+  const std::string & type() const { return _type; }
+
   ///@{
   /**
    * Retrieve a parameter for the object
@@ -330,6 +336,9 @@ protected:
 
   /// Parameters of this object
   InputParameters _pars;
+
+  /// The string representation of the type of this object as registered (see registerApp(AppName))
+  const std::string _type;
 
   /// The MPI communicator this App is going to use
   const MooseSharedPointer<Parallel::Communicator> _comm;

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -51,10 +51,13 @@ AppFactory::getValidParams(const std::string & name)
 }
 
 MooseApp *
-AppFactory::create(const std::string & obj_name, const std::string & name, InputParameters parameters, MPI_Comm COMM_WORLD_IN)
+AppFactory::create(const std::string & app_type, const std::string & name, InputParameters parameters, MPI_Comm COMM_WORLD_IN)
 {
-  if (_name_to_build_pointer.find(obj_name) == _name_to_build_pointer.end())
-    mooseError("Object '" + obj_name + "' was not registered.");
+  if (_name_to_build_pointer.find(app_type) == _name_to_build_pointer.end())
+    mooseError("Object '" + app_type + "' was not registered.");
+
+  // Take the app_type and add it to the parameters so that it can be retrieved in the Application
+  parameters.set<std::string>("_type") = app_type;
 
   // Check to make sure that all required parameters are supplied
   parameters.checkParams("");
@@ -70,7 +73,7 @@ AppFactory::create(const std::string & obj_name, const std::string & name, Input
   command_line->addCommandLineOptionsFromParams(parameters);
   command_line->populateInputParams(parameters);
 
-  return (*_name_to_build_pointer[obj_name])(name, parameters);
+  return (*_name_to_build_pointer[app_type])(name, parameters);
 }
 
 bool

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -73,6 +73,7 @@ InputParameters validParams<MooseApp>()
   params.addParam<bool>("use_legacy_uo_aux_computation", true, "Set to true to have MOOSE recompute *all* AuxKernel types every time *any* UserObject type is executed.\nThis behavoir is non-intuitive and will be removed late fall 2014, The default is controlled through MooseApp");
   params.addParam<bool>("use_legacy_uo_initialization", true, "Set to true to have MOOSE compute all UserObjects and Postprocessors during the initial setup phase of the problem recompute *all* AuxKernel types every time *any* UserObject type is executed.\nThis behavoir is non-intuitive and will be removed late fall 2014, The default is controlled through MooseApp");
 
+  params.addPrivateParam<std::string>("_type");
   params.addPrivateParam<int>("_argc");
   params.addPrivateParam<char**>("_argv");
   params.addPrivateParam<MooseSharedPointer<CommandLine> >("_command_line");
@@ -91,6 +92,7 @@ MooseApp::MooseApp(const std::string & name, InputParameters parameters) :
     ParallelObject(*parameters.get<MooseSharedPointer<Parallel::Communicator> >("_comm")), // Can't call getParam() before pars is set
     _name(name),
     _pars(parameters),
+    _type(getParam<std::string>("_type")),
     _comm(getParam<MooseSharedPointer<Parallel::Communicator> >("_comm")),
     _output_position_set(false),
     _start_time_set(false),


### PR DESCRIPTION
Adding "type" to MooseApp. We may add this to the standard header in the future.

Note: Also renamed obj_name -> app_type in the AppFactory.
