### PR TITLE
Autodetect ccache and disable timestamps in libmesh

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -28,6 +28,21 @@ if [[ $? == 0 && "x$git_dir" == "x" ]]; then
   fi
 fi
 
+# check if the user has ccache configured
+DISABLE_TIMESTAMPS=""
+echo $CXX | cut -d ' ' -f1 | grep '^ccache$' > /dev/null
+if [ $? == 0 ]; then
+  echo -n "ccache detected - "
+  # check if timestamps are explicitly enabled
+  echo "$* " | grep -- '--enable-timestamps ' > /dev/null
+  if [ $? == 0 ]; then
+    echo "warning: setting --enable-timestamps explicitly will negatively impact the ccache performance"
+  else
+    echo "configuring limbesh with --disable-timestamps to improve cache hit rate"
+    DISABLE_TIMESTAMPS="--disable-timestamps"
+  fi
+fi
+
 cd $SCRIPT_DIR/../libmesh
 
 rm -rf build
@@ -41,7 +56,8 @@ cd build
              --disable-warnings \
              --disable-cxx11 \
              --enable-unique-ptr \
-             --enable-openmp $*
+             --enable-openmp \
+             $DISABLE_TIMESTAMPS $*
 
 # let LIBMESH_JOBS be either MOOSE_JOBS, or 1 if MOOSE_JOBS
 # is not set (not using our package). Make will then build


### PR DESCRIPTION
Detect if the user has configured the environment according to http://mooseframework.org/wiki/ccache/ to utilize ccache and disable libmesh timestamps automatically. This can be prevented by explicitly passing the `--enable-timestamps` option to `update_and_rebuild_libmesh.sh`.

Closes #4976.
