### PR TITLE
Additional improvements to moose.mk

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -64,9 +64,11 @@ moose_revision:
 	  $(moose_revision_header) MOOSE)
 
 # libmesh submodule status
-libmesh_status := $(shell git -C $(MOOSE_DIR) submodule status)
+libmesh_status := $(shell git -C $(MOOSE_DIR) submodule status 2>/dev/null)
 ifneq (,$(findstring +,$(libmesh_status)))
-	libmesh_message = "\n***WARNING***\nYour libmesh is out of date.\nYou need to run update_and_rebuild_libmesh.sh in the scripts directory.\n\n"
+  ifneq ($(origin MOOSE_DIR),environment)
+    libmesh_message = "\n***WARNING***\nYour libmesh is out of date.\nYou need to run update_and_rebuild_libmesh.sh in the scripts directory.\n\n"
+  endif
 endif
 libmesh_submodule_status:
 	@if [ x$(libmesh_message) != "x" ]; then echo $(libmesh_message); fi


### PR DESCRIPTION
- Ignore warning on systems where git is too old to understand "-C"
- Don't notify the user if they have MOOSE_DIR set through an environment variable
  closes #5052, refs #4973
