### PR TITLE
Parallelize the mergeSets() routine in FeatureFloodCount.

### DIFF
--- a/modules/phase_field/examples/grain_growth/grain_growth_2D_graintracker.i
+++ b/modules/phase_field/examples/grain_growth/grain_growth_2D_graintracker.i
@@ -149,6 +149,10 @@
   [../]
 []
 
+[Problem]
+  use_legacy_uo_initialization = false
+[]
+
 [Outputs]
   file_base = tracker_2D # Output base file name.  Note the output will be saved in the "output" directory, that MUST be created before you run the simulation
   output_initial = true # Output initial condition

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -107,6 +107,15 @@ protected:
   void mergeSets(bool use_periodic_boundary_info);
 
   /**
+   * This routine broadcasts a std::list<BubbleData> to other ranks. It includes both the
+   * serialization and de-serialization routines.
+   * @param list the list to broadcast
+   * @owner_id the rank initiating the broadcast
+   * @map_num the number in the _bubble_sets datastructure that will be replaced by the results of the broadcast
+   */
+  void communicateOneList(std::list<BubbleData> & list, unsigned int owner_id, unsigned int map_num);
+
+  /**
    * This routine adds the periodic node information to our data structure prior to packing the data
    * this makes those periodic neighbors appear much like ghosted nodes in a multiprocessor setting
    */


### PR DESCRIPTION
Initial run on the Falcon cluster show an improvement of around 10x for a 180x180x180 problem. However there is a new (smaller) cost added through the `communicateOneList()` routine. Additional improvements will be incorporated later.
refs #5077 

Before

```
| FeatureFloodCount                                                                                          |
|   calculateBubbleVolume()     2          116.1557    58.077862   116.1557    58.077862   20.00    20.00    |
|   mergeSets()                 4          112.1271    28.031787   112.1271    28.031787   19.31    19.31    |
|                                                                                                            |
| GrainTracker                                                                                               |
|   buildspheres()              2          2.9104      1.455213    2.9104      1.455213    0.50     0.50     |
|   finalize()                  2          22.6230     11.311506   141.0292    70.514620   3.90     24.29    |
|   remapGrains()               2          2.9214      1.460695    2.9214      1.460695    0.50     0.50     |
|   trackGrains()               2          0.4473      0.223633    0.4473      0.223633    0.08     0.08     |
```

After

```
| FeatureFloodCount                                                                                          |
|   calculateBubbleVolume()     2          125.3027    62.651345   125.3027    62.651345   25.82    25.82    |
|   communicateOneList()        140        9.0842      0.064887    9.0842      0.064887    1.87     1.87     |
|   mergeSets()                 4          3.2358      0.808962    12.3201     3.080023    0.67     2.54     |
|                                                                                                            |
| GrainTracker                                                                                               |
|   buildspheres()              2          1.9173      0.958640    1.9173      0.958640    0.40     0.40     |
|   finalize()                  2          21.5269     10.763451   37.1717     18.585853   4.44     7.66     |
|   remapGrains()               2          1.0973      0.548632    1.0973      0.548632    0.23     0.23     |
|   trackGrains()               2          0.3102      0.155085    0.3102      0.155085    0.06     0.06     |
```
