### PR TITLE
Add clang_complete target 

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -191,6 +191,15 @@ clobberall:: clobber
           make -C $$dir clobber ; \
         done
 
+# clang_complete builds a clang configuration file for various clang-based autocompletion plugins
+clang_complete:
+	@echo "Building .clang_complete file"
+	@echo "-xc++" > .clang_complete
+	@echo "-std=c++11" >> .clang_complete
+	@for item in $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES); do \
+          echo $$item >> .clang_complete;  \
+        done
+
 # Debugging stuff
 echo_include:
 	@echo $(app_INCLUDES) $(libmesh_INCLUDE)

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Required Environment variables (one of the following)
-# PACKAGE_DIR   - Location of the MOOSE redistributable package 
+# PACKAGES_DIR  - Location of the MOOSE redistributable package 
 # CPPUNIT_DIR   - Location of CPPUNIT
 #
 # Optional Environment variables


### PR DESCRIPTION
Works for me and does not add any overhead unless used. Besides the atom.io plugin there are vim and emacs plugins that could use this config file as well. 

Closes #5102
