### PR TITLE
Fix variable mapping in parsed materials

### DIFF
--- a/modules/phase_field/include/materials/ParsedMaterialHelper.h
+++ b/modules/phase_field/include/materials/ParsedMaterialHelper.h
@@ -61,6 +61,9 @@ protected:
   /// The undiffed free energy function parser object.
   ADFunction * _func_F;
 
+  /// variable names used in the expression (depends on the map_mode)
+  std::vector<std::string> _variable_names;
+
   /// Material property descriptors (obtained by parsing _mat_prop_expressions)
   std::vector<FunctionMaterialPropertyDescriptor> _mat_prop_descriptors;
 

--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -64,7 +64,7 @@ DerivativeParsedMaterialHelper::assembleDerivatives()
     unsigned int first = current._dargs.empty() ? 0 : current._dargs.back();
 
     // add necessary derivative stepos
-    for (int i = first; i < _nargs; ++i)
+    for (unsigned int i = first; i < _nargs; ++i)
     {
       // here we will eventually check if we need to create more variables to hold material property derivatives
       // if material property derivative needed)
@@ -83,7 +83,7 @@ DerivativeParsedMaterialHelper::assembleDerivatives()
 
       // build derivative
       newitem._F = new ADFunction(*current._F);
-      if (newitem._F->AutoDiff(_arg_names[i]) != -1)
+      if (newitem._F->AutoDiff(_variable_names[i]) != -1)
         mooseError("Failed to take order " << newitem._dargs.size() << " derivative in material " << _name);
 
       // optimize and compile
@@ -95,7 +95,7 @@ DerivativeParsedMaterialHelper::assembleDerivatives()
       // generate material property argument vector
       std::vector<std::string> darg_names(0);
       for (unsigned int j = 0; j < newitem._dargs.size(); ++j)
-        darg_names.push_back(_arg_names[newitem._dargs[j]]);
+        darg_names.push_back(_variable_names[newitem._dargs[j]]);
 
       // append to list of derivatives if the derivative is non-vanishing
       if (!newitem._F->isZero())
@@ -117,26 +117,23 @@ DerivativeParsedMaterialHelper::assembleDerivatives()
 void
 DerivativeParsedMaterialHelper::computeProperties()
 {
-  unsigned int i, j, k;
-  Real a;
-
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {
     // fill the parameter vector, apply tolerances
-    for (i = 0; i < _nargs; ++i)
+    for (unsigned int i = 0; i < _nargs; ++i)
     {
       if (_tol[i] < 0.0)
         _func_params[i] = (*_args[i])[_qp];
       else
       {
-        a = (*_args[i])[_qp];
+        Real a = (*_args[i])[_qp];
         _func_params[i] = a < _tol[i] ? _tol[i] : (a > 1.0 - _tol[i] ? 1.0 - _tol[i] : a);
       }
     }
 
     // insert material property values
     unsigned int nmat_props = _mat_prop_descriptors.size();
-    for (i = 0; i < nmat_props; ++i)
+    for (unsigned int i = 0; i < nmat_props; ++i)
       _func_params[i + _nargs] = _mat_prop_descriptors[i].value()[_qp];
 
     // set function value
@@ -144,7 +141,7 @@ DerivativeParsedMaterialHelper::computeProperties()
       (*_prop_F)[_qp] = evaluate(_func_F);
 
     // set derivatives
-    for (i = 0; i < _derivatives.size(); ++i)
+    for (unsigned int i = 0; i < _derivatives.size(); ++i)
       (*_derivatives[i].first)[_qp] = evaluate(_derivatives[i].second);
   }
 }


### PR DESCRIPTION
Use the correct fparser variable names for each mapping mode.
Closes #5108
