### PR TITLE
Adjust Abaqus creep model #5104

### DIFF
--- a/modules/solid_mechanics/src/materials/abaqus/AbaqusCreepMaterial.C
+++ b/modules/solid_mechanics/src/materials/abaqus/AbaqusCreepMaterial.C
@@ -15,7 +15,7 @@
 template<>
 InputParameters validParams<AbaqusCreepMaterial>()
 {
-  InputParameters params = validParams<VolumetricModel>();
+  InputParameters params = validParams<SolidModel>();
   params.addRequiredParam<FileName>("plugin", "The path to the compiled dynamic library for the plugin you want to use (without -opt.plugin or -dbg.plugin)");
   params.addRequiredParam<Real>("youngs_modulus", "Young's Modulus");
   params.addRequiredParam<Real>("poissons_ratio", "Poissons Ratio");
@@ -271,6 +271,25 @@ void AbaqusCreepMaterial::computeStress()
 
   // Modify strain increment
   _strain_increment += total_effects;
+
+  _stress_component[0] =
+    (_elasticity_tensor[0]*_strain_increment.component(0)) +
+    (_elasticity_tensor[1]*_strain_increment.component(1)) +
+    (_elasticity_tensor[1]*_strain_increment.component(2));
+
+  _stress_component[1] =
+    (_elasticity_tensor[1]*_strain_increment.component(0)) +
+    (_elasticity_tensor[0]*_strain_increment.component(1)) +
+    (_elasticity_tensor[1]*_strain_increment.component(2));
+
+  _stress_component[2] =
+    (_elasticity_tensor[1]*_strain_increment.component(0)) +
+    (_elasticity_tensor[1]*_strain_increment.component(1)) +
+    (_elasticity_tensor[0]*_strain_increment.component(2));
+
+  _stress_component[3] = (_elasticity_tensor[2]*_strain_increment.component(3));
+  _stress_component[4] = (_elasticity_tensor[2]*_strain_increment.component(4));
+  _stress_component[5] = (_elasticity_tensor[2]*_strain_increment.component(5));
 
   // Update Stress
   SymmTensor stressnew(_stress_component[0], _stress_component[1], _stress_component[2],

--- a/modules/solid_mechanics/tests/abaqus_creep_swelling/abaqus_creep_swelling.i
+++ b/modules/solid_mechanics/tests/abaqus_creep_swelling/abaqus_creep_swelling.i
@@ -125,16 +125,19 @@
     num_state_vars = 0
     youngs_modulus = 209000
     solve_definition = 1
-  [../]
-  [./solid]
-    type = Elastic
-    block = 0
     disp_x = disp_x
     disp_y = disp_y
     disp_z = disp_z
-    youngs_modulus = 209000
-    poissons_ratio = 0.3
   [../]
+  # [./solid]
+  #   type = Elastic
+  #   block = 0
+  #   disp_x = disp_x
+  #   disp_y = disp_y
+  #   disp_z = disp_z
+  #   youngs_modulus = 209000
+  #   poissons_ratio = 0.3
+  # [../]
 []
 
 [Executioner]
@@ -165,4 +168,3 @@
     elemental_as_nodal = true
   [../]
 []
-


### PR DESCRIPTION
The test computes non-zeros and is close to running like it used to with this change.  I still think the code has issues.  If the test diffs, we can re-gold it.
