### PR TITLE
fixup error message when input file doesn't parse properly

### DIFF
--- a/gui/gui/InputFileWidget.py
+++ b/gui/gui/InputFileWidget.py
@@ -190,7 +190,12 @@ class InputFileWidget(QtGui.QWidget):
       counter+=1
       progress.setValue(counter)
 
-      self.input_file_root_node = readInputFile(file_name)
+      try:
+          self.input_file_root_node = readInputFile(file_name)
+      except Exception as e:
+          print '\nError parsing input file: \n', e.msg, '\n'
+          raise e
+
       self.input_file_getpot_data = GetPotData(self.input_file_root_node, self)
 
       counter+=1

--- a/python/FactorySystem/ParseGetPot.py
+++ b/python/FactorySystem/ParseGetPot.py
@@ -192,7 +192,7 @@ class ParseGetPot:
 
           unique_key = current_node.fullName(True) + '/' + param_name
           if unique_key in self.unique_keys:
-            raise ParseException("DuplicateSymbol", 'Duplicate Section Name "' + os.getcwd() + '/' + self.file_name + ":" + unique_key + '"')
+            raise ParseException("DuplicateSymbol", 'In file: ' + os.getcwd() + '/' + os.path.basename(self.file_name) + " \n Duplicate section name: " + unique_key)
           self.unique_keys.add(unique_key)
 
           current_node.params[param_name] = param_value


### PR DESCRIPTION
Even if the old message would have been printed out (which it wasn't) it would have looked like this:

```
Duplicate Section Name "/Users/gastdr/projects/mit/research/openmc_to_yakxs/problems/first_rattlesnake/rattlesnake//Users/gastdr/projects/mit/research/openmc_to_yakxs/problems/first_rattlesnake/rattlesnake/rattlesnake_pure.i:/Executioner/bx_norm"
```

It now looks like this:

```
Error parsing input file: 
In file: /Users/gastdr/projects/mit/research/openmc_to_yakxs/problems/first_rattlesnake/rattlesnake//Users/gastdr/projects/mit/research/openmc_to_yakxs/problems/first_rattlesnake/rattlesnake/rattlesnake_pure.i 
 Duplicate section name: /Executioner/bx_norm 
```

Arguably, we should actually handle this IN the GUI in Peacock... so I made it reraise the error so we can do that at a later date (it could have a popup box or something).  I don't have time for that for now... and this is at least an improvement.

closes #5122
