### PR TITLE
Fix epsilon default value 

### DIFF
--- a/modules/phase_field/src/kernels/SwitchingFunctionConstraintLagrange.C
+++ b/modules/phase_field/src/kernels/SwitchingFunctionConstraintLagrange.C
@@ -13,7 +13,7 @@ InputParameters validParams<SwitchingFunctionConstraintLagrange>()
   params.addClassDescription("Lagrange multiplier kernel to constrain the sum of all switching functions in a multiphase system. This kernel acts on the lagrange multiplier variable.");
   params.addParam<std::vector<std::string> >("h_names", "Switching Function Materials that provide h(eta_i)");
   params.addRequiredCoupledVar("etas", "eta_i order parameters, one for each h");
-  params.addParam<Real>("epsilon", 1e9, "Shift factor to avoid a zero pivot");
+  params.addParam<Real>("epsilon", 1e-9, "Shift factor to avoid a zero pivot");
   return params;
 }
 


### PR DESCRIPTION
The sign on the exponent for the default value of the Jacobian fill factor is wrong. This factor needs to be tiny in order to not perturb the constraint enforcement too much.

Refs. #4876
