### PR TITLE
Add common PETSc option names

### DIFF
--- a/framework/include/actions/CreateExecutionerAction.h
+++ b/framework/include/actions/CreateExecutionerAction.h
@@ -31,6 +31,7 @@ public:
   virtual void act();
 
   static MultiMooseEnum getCommonPetscOptions();
+  static MultiMooseEnum getCommonPetscOptionsIname();
 
   static void populateCommonExecutionerParams(InputParameters & params);
   static void    storeCommonExecutionerParams(FEProblem & problem, InputParameters & params);

--- a/framework/include/actions/CreateExecutionerAction.h
+++ b/framework/include/actions/CreateExecutionerAction.h
@@ -30,6 +30,8 @@ public:
 
   virtual void act();
 
+  static MultiMooseEnum getCommonPetscOptions();
+
   static void populateCommonExecutionerParams(InputParameters & params);
   static void    storeCommonExecutionerParams(FEProblem & problem, InputParameters & params);
 };

--- a/framework/include/actions/CreateExecutionerAction.h
+++ b/framework/include/actions/CreateExecutionerAction.h
@@ -30,9 +30,6 @@ public:
 
   virtual void act();
 
-  static MultiMooseEnum getCommonPetscOptions();
-  static MultiMooseEnum getCommonPetscOptionsIname();
-
   static void populateCommonExecutionerParams(InputParameters & params);
   static void    storeCommonExecutionerParams(FEProblem & problem, InputParameters & params);
 };

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -182,7 +182,7 @@ public:
 
 #ifdef LIBMESH_HAVE_PETSC
   void storePetscOptions(const MultiMooseEnum & petsc_options,
-                         const std::vector<std::string> & petsc_options_inames,
+                         const MultiMooseEnum & petsc_options_inames,
                          const std::vector<std::string> & petsc_options_values);
 #endif
 

--- a/framework/include/splits/Split.h
+++ b/framework/include/splits/Split.h
@@ -62,8 +62,8 @@ class Split :
 
   ///@{
   /// Additional PETSc options
-  std::vector<std::string> _petsc_options;
-  std::vector<std::string> _petsc_options_iname;
+  MultiMooseEnum _petsc_options;
+  MultiMooseEnum _petsc_options_iname;
   std::vector<std::string> _petsc_options_value;
   ///@}
 #endif // defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -54,6 +54,11 @@ void outputNorm(Real old_norm, Real norm, bool use_color = false);
  */
 PetscErrorCode petscLinearMonitor(KSP /*ksp*/, PetscInt its, PetscReal rnorm, void *void_ptr);
 
+/// construct a MultiMooseEnum with commonly used PETSc options
+MultiMooseEnum getCommonPetscOptions();
+
+/// construct a MultiMooseEnum with commonly used PETSc iname options (keys in key-value pairs)
+MultiMooseEnum getCommonPetscOptionsIname();
 }
 }
 

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -76,7 +76,7 @@ CreateExecutionerAction::populateCommonExecutionerParams(InputParameters & param
 
 #ifdef LIBMESH_HAVE_PETSC
   params.addParam<MultiMooseEnum>("petsc_options", getCommonPetscOptions(), "Singleton PETSc options");
-  params.addParam<std::vector<std::string> >("petsc_options_iname", "Names of PETSc name/value pairs");
+  params.addParam<MultiMooseEnum>("petsc_options_iname", getCommonPetscOptionsIname(), "Names of PETSc name/value pairs");
   params.addParam<std::vector<std::string> >("petsc_options_value", "Values of PETSc name/value pairs (must correspond with \"petsc_options_iname\"");
 #endif //LIBMESH_HAVE_PETSC
 }
@@ -90,10 +90,21 @@ MultiMooseEnum
 CreateExecutionerAction::getCommonPetscOptions()
 {
   return MultiMooseEnum(
-    "-dm_moose_print_embedding -dm_view -ksp_converged_reason -ksp_gmres_modifiedgramschmidt"
-    "-ksp_monitor -ksp_monitor_snes_lg-snes_ksp_ew -ksp_snes_ew -snes_converged_reason"
-    "-snes_ksp -snes_ksp_ew -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor"
+    "-dm_moose_print_embedding -dm_view -ksp_converged_reason -ksp_gmres_modifiedgramschmidt "
+    "-ksp_monitor -ksp_monitor_snes_lg-snes_ksp_ew -ksp_snes_ew -snes_converged_reason "
+    "-snes_ksp -snes_ksp_ew -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor "
     "-snes_test_display -snes_view -snew_ksp_ew", "", true);
+}
+
+MultiMooseEnum
+CreateExecutionerAction::getCommonPetscOptionsIname()
+{
+  return MultiMooseEnum(
+    "-ksp_atol -ksp_gmres_restart -ksp_grmres_restart -ksp_max_it -ksp_pc_side -ksp_rtol "
+    "-ksp_type -mat_fd_coloring_err -mat_fd_type -mat_mffd_type -pc_asm_overlap -pc_factor_levels "
+    "-pc_factor_mat_ordering_type -pc_hypre_boomeramg_grid_sweeps_all -pc_hypre_boomeramg_max_iter "
+    "-pc_hypre_boomeramg_strong_threshold -pc_hypre_type -pc_type -snes_atol -snes_linesearch_type "
+    "-snes_ls -snes_max_it -snes_rtol -snes_type -sub_ksp_type -sub_pc_type", "", true);
 }
 
 void
@@ -168,7 +179,7 @@ CreateExecutionerAction::storeCommonExecutionerParams(FEProblem & fe_problem, In
 
 #ifdef LIBMESH_HAVE_PETSC
   MultiMooseEnum           petsc_options       = params.get<MultiMooseEnum>("petsc_options");
-  std::vector<std::string> petsc_options_iname = params.get<std::vector<std::string> >("petsc_options_iname");
+  MultiMooseEnum           petsc_options_iname = params.get<MultiMooseEnum>("petsc_options_iname");
   std::vector<std::string> petsc_options_value = params.get<std::vector<std::string> >("petsc_options_value");
 
   fe_problem.storePetscOptions(petsc_options, petsc_options_iname, petsc_options_value);

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -75,9 +75,7 @@ CreateExecutionerAction::populateCommonExecutionerParams(InputParameters & param
   params.addParam<MooseEnum>   ("line_search",     line_search, "Specifies the line search type" + addtl_doc_str);
 
 #ifdef LIBMESH_HAVE_PETSC
-  MultiMooseEnum common_petsc_options("", "", true);
-
-  params.addParam<MultiMooseEnum>("petsc_options", common_petsc_options, "Singleton PETSc options");
+  params.addParam<MultiMooseEnum>("petsc_options", getCommonPetscOptions(), "Singleton PETSc options");
   params.addParam<std::vector<std::string> >("petsc_options_iname", "Names of PETSc name/value pairs");
   params.addParam<std::vector<std::string> >("petsc_options_value", "Values of PETSc name/value pairs (must correspond with \"petsc_options_iname\"");
 #endif //LIBMESH_HAVE_PETSC
@@ -86,6 +84,16 @@ CreateExecutionerAction::populateCommonExecutionerParams(InputParameters & param
 CreateExecutionerAction::CreateExecutionerAction(const std::string & name, InputParameters params) :
     MooseObjectAction(name, params)
 {
+}
+
+MultiMooseEnum
+CreateExecutionerAction::getCommonPetscOptions()
+{
+  return MultiMooseEnum(
+    "-dm_moose_print_embedding -dm_view -ksp_converged_reason -ksp_gmres_modifiedgramschmidt"
+    "-ksp_monitor -ksp_monitor_snes_lg-snes_ksp_ew -ksp_snes_ew -snes_converged_reason"
+    "-snes_ksp -snes_ksp_ew -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor"
+    "-snes_test_display -snes_view -snew_ksp_ew", "", true);
 }
 
 void

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -75,8 +75,8 @@ CreateExecutionerAction::populateCommonExecutionerParams(InputParameters & param
   params.addParam<MooseEnum>   ("line_search",     line_search, "Specifies the line search type" + addtl_doc_str);
 
 #ifdef LIBMESH_HAVE_PETSC
-  params.addParam<MultiMooseEnum>("petsc_options", getCommonPetscOptions(), "Singleton PETSc options");
-  params.addParam<MultiMooseEnum>("petsc_options_iname", getCommonPetscOptionsIname(), "Names of PETSc name/value pairs");
+  params.addParam<MultiMooseEnum>("petsc_options", Moose::PetscSupport::getCommonPetscOptions(), "Singleton PETSc options");
+  params.addParam<MultiMooseEnum>("petsc_options_iname", Moose::PetscSupport::getCommonPetscOptionsIname(), "Names of PETSc name/value pairs");
   params.addParam<std::vector<std::string> >("petsc_options_value", "Values of PETSc name/value pairs (must correspond with \"petsc_options_iname\"");
 #endif //LIBMESH_HAVE_PETSC
 }
@@ -84,27 +84,6 @@ CreateExecutionerAction::populateCommonExecutionerParams(InputParameters & param
 CreateExecutionerAction::CreateExecutionerAction(const std::string & name, InputParameters params) :
     MooseObjectAction(name, params)
 {
-}
-
-MultiMooseEnum
-CreateExecutionerAction::getCommonPetscOptions()
-{
-  return MultiMooseEnum(
-    "-dm_moose_print_embedding -dm_view -ksp_converged_reason -ksp_gmres_modifiedgramschmidt "
-    "-ksp_monitor -ksp_monitor_snes_lg-snes_ksp_ew -ksp_snes_ew -snes_converged_reason "
-    "-snes_ksp -snes_ksp_ew -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor "
-    "-snes_test_display -snes_view -snew_ksp_ew", "", true);
-}
-
-MultiMooseEnum
-CreateExecutionerAction::getCommonPetscOptionsIname()
-{
-  return MultiMooseEnum(
-    "-ksp_atol -ksp_gmres_restart -ksp_grmres_restart -ksp_max_it -ksp_pc_side -ksp_rtol "
-    "-ksp_type -mat_fd_coloring_err -mat_fd_type -mat_mffd_type -pc_asm_overlap -pc_factor_levels "
-    "-pc_factor_mat_ordering_type -pc_hypre_boomeramg_grid_sweeps_all -pc_hypre_boomeramg_max_iter "
-    "-pc_hypre_boomeramg_strong_threshold -pc_hypre_type -pc_type -snes_atol -snes_linesearch_type "
-    "-snes_ls -snes_max_it -snes_rtol -snes_type -sub_ksp_type -sub_pc_type", "", true);
 }
 
 void
@@ -160,7 +139,6 @@ CreateExecutionerAction::act()
 
   _awh.executioner() = executioner;
 }
-
 
 void
 CreateExecutionerAction::storeCommonExecutionerParams(FEProblem & fe_problem, InputParameters & params)

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -155,7 +155,7 @@ FEProblem::FEProblem(const std::string & name, InputParameters parameters) :
 #ifdef LIBMESH_HAVE_PETSC
   // put in empty arrays for PETSc options
   this->parameters().set<MultiMooseEnum>("petsc_options") = MultiMooseEnum("", "", true);
-  this->parameters().set<std::vector<std::string> >("petsc_inames") = std::vector<std::string>();
+  this->parameters().set<MultiMooseEnum>("petsc_inames") = MultiMooseEnum("", "", true);
   this->parameters().set<std::vector<std::string> >("petsc_values") = std::vector<std::string>();
 #endif
 
@@ -3944,7 +3944,7 @@ FEProblem::checkLinearConvergence(std::string & /*msg*/,
 #ifdef LIBMESH_HAVE_PETSC
 void
 FEProblem::storePetscOptions(const MultiMooseEnum & petsc_options,
-                             const std::vector<std::string> & petsc_options_inames,
+                             const MultiMooseEnum & petsc_options_inames,
                              const std::vector<std::string> & petsc_options_values)
 {
   MultiMooseEnum & po = parameters().set<MultiMooseEnum>("petsc_options");         // set because we need a writable reference
@@ -3975,7 +3975,7 @@ FEProblem::storePetscOptions(const MultiMooseEnum & petsc_options,
       po.push_back(*it);
   }
 
-  std::vector<std::string> & pn = parameters().set<std::vector<std::string> >("petsc_inames");         // set because we need a writable reference
+  MultiMooseEnum & pn           = parameters().set<MultiMooseEnum>("petsc_inames");                    // set because we need a writable reference
   std::vector<std::string> & pv = parameters().set<std::vector<std::string> >("petsc_values");         // set because we need a writable reference
 
   if (petsc_options_inames.size() != petsc_options_values.size())

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -14,7 +14,7 @@
 
 #include "Split.h"
 #include "InputParameters.h"
-#include "CreateExecutionerAction.h"
+#include "PetscSupport.h"
 
 #if defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)
 // petsc 3.3.0 or later needed
@@ -47,8 +47,8 @@ InputParameters validParams<Split>()
   MooseEnum SchurAInvEnum("diag lump", "diag");
   params.addParam<MooseEnum>("schur_ainv", SchurAInvEnum, "Type of approximation to inv(A) used when forming S = D - C inv(A) B");
 
-  params.addParam<MultiMooseEnum>("petsc_options", CreateExecutionerAction::getCommonPetscOptions(), "PETSc flags for the FieldSplit solver");
-  params.addParam<MultiMooseEnum>("petsc_options_iname", CreateExecutionerAction::getCommonPetscOptionsIname(), "PETSc option names for the FieldSplit solver");
+  params.addParam<MultiMooseEnum>("petsc_options", Moose::PetscSupport::getCommonPetscOptions(), "PETSc flags for the FieldSplit solver");
+  params.addParam<MultiMooseEnum>("petsc_options_iname", Moose::PetscSupport::getCommonPetscOptionsIname(), "PETSc option names for the FieldSplit solver");
   params.addParam<std::vector<std::string> >("petsc_options_value", "PETSc option values for the FieldSplit solver");
 
   params.registerBase("Split");

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -14,6 +14,7 @@
 
 #include "Split.h"
 #include "InputParameters.h"
+#include "CreateExecutionerAction.h"
 
 #if defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)
 // petsc 3.3.0 or later needed
@@ -46,8 +47,8 @@ InputParameters validParams<Split>()
   MooseEnum SchurAInvEnum("diag lump", "diag");
   params.addParam<MooseEnum>("schur_ainv", SchurAInvEnum, "Type of approximation to inv(A) used when forming S = D - C inv(A) B");
 
-  params.addParam<std::vector<std::string> >("petsc_options", "PETSc flags for the FieldSplit solver");
-  params.addParam<std::vector<std::string> >("petsc_options_iname", "PETSc option names for the FieldSplit solver");
+  params.addParam<MultiMooseEnum>("petsc_options", CreateExecutionerAction::getCommonPetscOptions(), "PETSc flags for the FieldSplit solver");
+  params.addParam<MultiMooseEnum>("petsc_options_iname", CreateExecutionerAction::getCommonPetscOptionsIname(), "PETSc option names for the FieldSplit solver");
   params.addParam<std::vector<std::string> >("petsc_options_value", "PETSc option values for the FieldSplit solver");
 
   params.registerBase("Split");
@@ -67,8 +68,8 @@ Split::Split(const std::string & name, InputParameters params) :
     _schur_type(getParam<MooseEnum>("schur_type")),
     _schur_pre(getParam<MooseEnum>("schur_pre")),
     _schur_ainv(getParam<MooseEnum>("schur_ainv")),
-    _petsc_options(getParam<std::vector<std::string> >("petsc_options")),
-    _petsc_options_iname(getParam<std::vector<std::string> >("petsc_options_iname")),
+    _petsc_options(getParam<MultiMooseEnum>("petsc_options")),
+    _petsc_options_iname(getParam<MultiMooseEnum>("petsc_options_iname")),
     _petsc_options_value(getParam<std::vector<std::string> >("petsc_options_value"))
 {
 }

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -546,6 +546,27 @@ void petscSetDefaults(FEProblem & problem)
   }
 #endif
 }
+
+MultiMooseEnum
+getCommonPetscOptions()
+{
+  return MultiMooseEnum(
+    "-dm_moose_print_embedding -dm_view -ksp_converged_reason -ksp_gmres_modifiedgramschmidt "
+    "-ksp_monitor -ksp_monitor_snes_lg-snes_ksp_ew -ksp_snes_ew -snes_converged_reason "
+    "-snes_ksp -snes_ksp_ew -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor "
+    "-snes_test_display -snes_view -snew_ksp_ew", "", true);
+}
+
+MultiMooseEnum
+getCommonPetscOptionsIname()
+{
+  return MultiMooseEnum(
+    "-ksp_atol -ksp_gmres_restart -ksp_grmres_restart -ksp_max_it -ksp_pc_side -ksp_rtol "
+    "-ksp_type -mat_fd_coloring_err -mat_fd_type -mat_mffd_type -pc_asm_overlap -pc_factor_levels "
+    "-pc_factor_mat_ordering_type -pc_hypre_boomeramg_grid_sweeps_all -pc_hypre_boomeramg_max_iter "
+    "-pc_hypre_boomeramg_strong_threshold -pc_hypre_type -pc_type -snes_atol -snes_linesearch_type "
+    "-snes_ls -snes_max_it -snes_rtol -snes_type -sub_ksp_type -sub_pc_type", "", true);
+}
 } // Namespace PetscSupport
 } // Namespace MOOSE
 

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -164,8 +164,8 @@ void petscSetupDM (NonlinearSystem & nl) {
 void
 petscSetOptions(FEProblem & problem)
 {
-        MultiMooseEnum             petsc_options = problem.parameters().get<MultiMooseEnum>("petsc_options");
-  const std::vector<std::string> & petsc_options_inames = problem.parameters().get<std::vector<std::string> >("petsc_inames");
+  MultiMooseEnum                   petsc_options = problem.parameters().get<MultiMooseEnum>("petsc_options");
+  MultiMooseEnum                   petsc_options_inames = problem.parameters().get<MultiMooseEnum>("petsc_inames");
   const std::vector<std::string> & petsc_options_values = problem.parameters().get<std::vector<std::string> >("petsc_values");
 
   if (petsc_options_inames.size() != petsc_options_values.size())


### PR DESCRIPTION
This should add little bit of "self documentation" by making use of the `MultiMooseEnum` options set. `Split` uses these options as well now.

Closes #5152
