### PR TITLE
Axisym 5142:  Addition of axisymmetricRZ tensor to RankFourTensor

### DIFF
--- a/modules/tensor_mechanics/include/utils/RankFourTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankFourTensor.h
@@ -69,6 +69,7 @@ public:
     general_isotropic,
     symmetric_isotropic,
     antisymmetric_isotropic,
+    axisymmetric_rz,
     general
   };
 
@@ -194,6 +195,7 @@ public:
    *             general_isotropic (use fillGeneralIsotropicFrominputVector)
    *             symmetric_isotropic (use fillSymmetricIsotropicFromInputVector)
    *             antisymmetric_isotropic (use fillAntisymmetricIsotropicFromInputVector)
+   *             AxisymmetricRZ (use fillAxisymmetricRZFromInputVector)
    *             general (use fillGeneralFromInputVector)
    */
   void fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method);
@@ -267,6 +269,17 @@ protected:
    * No symmetries are explicitly maintained
    * @param input  C[i][j][k][l] = input[i*N*N*N + j*N*N + k*N + l]
    */
+
+  void fillAxisymmetricRZFromInputVector(const std::vector<Real> & input);
+
+  /**
+  fillAxisymmetricRZFromInputVector takes 5 inputs to fill the axisymmetric
+  Rank-4 tensor with the appropriate symmetries maintatined for use with
+  axisymmetric problems using coord_type = RZ.
+  I.e. C1111 = C2222, C1133 = C2233, C2323 = C3131 and C1212 = 0.5*(C1111-C1122)
+  @param input this is C1111, C1122, C1133, C3333, C2323.
+   */
+
   void fillGeneralFromInputVector(const std::vector<Real> & input);
 
 private:

--- a/modules/tensor_mechanics/src/materials/ComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStressBase.C
@@ -56,4 +56,3 @@ ComputeStressBase::computeQpProperties()
   //Add in extra stress
   _stress[_qp] += _extra_stress[_qp];
 }
-

--- a/modules/tensor_mechanics/src/utils/RankFourTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankFourTensor.C
@@ -24,7 +24,7 @@ void mooseSetToZero<RankFourTensor>(RankFourTensor & v)
 MooseEnum
 RankFourTensor::fillMethodEnum()
 {
-  return MooseEnum("antisymmetric symmetric9 symmetric21 general_isotropic symmetric_isotropic antisymmetric_isotropic general");
+  return MooseEnum("antisymmetric symmetric9 symmetric21 general_isotropic symmetric_isotropic antisymmetric_isotropic axisymmetric_rz general");
 }
 
 RankFourTensor::RankFourTensor()
@@ -555,6 +555,9 @@ RankFourTensor::fillFromInputVector(const std::vector<Real> & input, FillMethod 
     case antisymmetric_isotropic:
       fillAntisymmetricIsotropicFromInputVector(input);
       break;
+    case axisymmetric_rz:
+      fillAxisymmetricRZFromInputVector(input);
+      break;
     case general:
       fillGeneralFromInputVector(input);
       break;
@@ -738,6 +741,24 @@ RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> & 
   input3.push_back(input[1]);
   input3.push_back(0);
   fillGeneralIsotropicFromInputVector(input3);
+}
+
+void
+RankFourTensor::fillAxisymmetricRZFromInputVector(const std::vector<Real> & input)
+{
+  if (input.size() != 5)
+    mooseError("To use fillAxisymmetricRZFromInputVector, your input must have size 5.  Your vector has size " << input.size());
+  std::vector<Real> input9(9);
+  input9[0] = input[0];  // C1111
+  input9[1] = input[1];  // C1122
+  input9[2] = input[2];  // C1133
+  input9[3] = input[0];  // C2222
+  input9[4] = input[2];  // C2233 = C1133
+  input9[5] = input[3];  // C3333
+  input9[6] = input[4];  // C2323
+  input9[7] = input[4];  // C3131 = C2323
+  input9[8] = (input[0]-input[1])*0.5;  // C1212
+  fillSymmetricFromInputVector(input9, false);
 }
 
 void


### PR DESCRIPTION
As part of addressing Issue #5142 this commit is of additional lines to the RankFourTensor util in the tensor mechanics module to create an Axisymmetric C_{ijkl} tensor.  Redo of PR 5143.

The axisymmetric elasticity tensor includes five independent quantities (ref: Slaughter, W.S. The Linearized Theory of Elasticity, pg. 209).  Following the procedure used for the symmetric and antisymmetric cases, the fillAxisymmetricRZFromInputVector reads in an input vector of size 5, creates a vector of size 9, and passes that new input vector to fillSymmetricFromInputVector.
