### PR TITLE
PETSc 3.6 fixes

### DIFF
--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -21,7 +21,11 @@
 
 // PETSc includes
 #include <petscerror.h>
-#include <petsc-private/dmimpl.h>
+#if !PETSC_RELEASE_LESS_THAN(3,6,0)
+# include <petsc/private/dmimpl.h>
+#else
+# include <petsc-private/dmimpl.h>
+#endif
 
 // libMesh Includes
 #include "libmesh/nonlinear_implicit_system.h"
@@ -1380,7 +1384,11 @@ static PetscErrorCode  DMSetUp_Moose(DM dm)
 
 #undef __FUNCT__
 #define __FUNCT__ "DMSetFromOptions_Moose"
+#if !PETSC_RELEASE_LESS_THAN(3,6,0)
+PetscErrorCode  DMSetFromOptions_Moose(PetscOptions * options, DM dm)
+#else
 PetscErrorCode  DMSetFromOptions_Moose(DM dm)
+#endif
 {
   PetscErrorCode ierr;
   PetscBool      ismoose;

--- a/modules/combined/tests/multiphase_mechanics/elasticenergymaterial.i
+++ b/modules/combined/tests/multiphase_mechanics/elasticenergymaterial.i
@@ -90,6 +90,9 @@
   solve_type = 'PJFNK'
   nl_abs_tol = 1e-10
   num_steps = 1
+
+  petsc_options_iname = '-pc_factor_shift_type'
+  petsc_options_value = 'nonzero'
 []
 
 [Outputs]

--- a/modules/phase_field/tests/KKS_system/kks_example.i
+++ b/modules/phase_field/tests/KKS_system/kks_example.i
@@ -194,6 +194,9 @@
   type = Transient
   solve_type = 'PJFNK'
 
+  petsc_options_iname = '-pc_factor_shift_type'
+  petsc_options_value = 'nonzero'
+
   l_max_its = 100
   nl_max_its = 100
   nl_rel_tol = 1e-4
@@ -201,6 +204,7 @@
   num_steps = 1
 
   dt = 0.01
+  dtmin = 0.01
 []
 
 #

--- a/modules/richards/tests/buckley_leverett/bl20_lumped.i
+++ b/modules/richards/tests/buckley_leverett/bl20_lumped.i
@@ -194,17 +194,15 @@
   # must use --use-petsc-dm command line argument
     type = SMP
     full = true
-    petsc_options = '-snes_converged_reason'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type -ksp_rtol -ksp_atol'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 50 vinewtonssls 1E-20 1E-20'
+    petsc_options_iname = '-snes_type   -pc_factor_shift_type'
+    petsc_options_value = 'vinewtonssls nonzero'
   [../]
 
   [./standard]
     type = SMP
     full = true
-    petsc_options = '-snes_converged_reason'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -ksp_rtol -ksp_atol'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 2000 1E-20 1E-20'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 
 []
@@ -213,6 +211,9 @@
   type = Transient
   solve_type = NEWTON
   end_time = 50
+
+  nl_rel_tol = 1.e-9
+  nl_max_its = 10
 
   [./TimeStepper]
     type = FunctionDT

--- a/modules/richards/tests/buckley_leverett/bl20_lumped_fu.i
+++ b/modules/richards/tests/buckley_leverett/bl20_lumped_fu.i
@@ -194,17 +194,15 @@
   # must use --use-petsc-dm command line argument
     type = SMP
     full = true
-    petsc_options = '-snes_converged_reason'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type -ksp_rtol -ksp_atol'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 50 vinewtonssls 1E-20 1E-20'
+    petsc_options_iname = '-snes_type -pc_factor_shift_type'
+    petsc_options_value = 'vinewtonssls nonzero'
   [../]
 
   [./standard]
     type = SMP
     full = true
-    petsc_options = '-snes_converged_reason'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -ksp_rtol -ksp_atol'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 2000 1E-20 1E-20'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 
 []
@@ -213,6 +211,9 @@
   type = Transient
   solve_type = NEWTON
   end_time = 50
+
+  nl_rel_tol = 1.e-9
+  nl_max_its = 10
 
   [./TimeStepper]
     type = FunctionDT

--- a/modules/richards/tests/gravity_head_2/gh_bounded_17.i
+++ b/modules/richards/tests/gravity_head_2/gh_bounded_17.i
@@ -233,9 +233,8 @@
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-15 1E-15 10000'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 
@@ -244,7 +243,10 @@
   solve_type = Newton
   end_time = 1E6
   dt = 1E6
+  dtmin = 1E6
 
+  nl_rel_tol = 1.e-6
+  nl_max_its = 10
   #[./TimeStepper]
   #  type = FunctionDT
   #  time_dt = '1E-2 1E-1 1E0 1E1 1E3 1E4 1E5 1E6 1E7'

--- a/modules/richards/tests/gravity_head_2/gh_fu_01.i
+++ b/modules/richards/tests/gravity_head_2/gh_fu_01.i
@@ -261,15 +261,16 @@
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 10000'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 
 [Executioner]
   type = Steady
   solve_type = Newton
+  nl_rel_tol = 1.e-10
+  nl_max_its = 10
 []
 
 [Outputs]

--- a/modules/richards/tests/pressure_pulse/pp21.i
+++ b/modules/richards/tests/pressure_pulse/pp21.i
@@ -172,15 +172,16 @@
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 100'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 
 [Executioner]
   type = Steady
   solve_type = Newton
+  nl_rel_tol = 1.e-10
+  nl_max_its = 10
 []
 
 [Outputs]

--- a/modules/richards/tests/pressure_pulse/pp22.i
+++ b/modules/richards/tests/pressure_pulse/pp22.i
@@ -172,9 +172,8 @@
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 100'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 
@@ -182,6 +181,9 @@
   type = Transient
   solve_type = Newton
   dt = 1E3
+  dtmin = 1E3
+  nl_rel_tol=1.e-10
+  nl_max_its=20
   end_time = 1E4
 []
 

--- a/modules/richards/tests/pressure_pulse/pp_fu_21.i
+++ b/modules/richards/tests/pressure_pulse/pp_fu_21.i
@@ -172,15 +172,16 @@
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 100'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 
 [Executioner]
   type = Steady
   solve_type = Newton
+  nl_rel_tol = 1.e-10
+  nl_max_its = 10
 []
 
 [Outputs]

--- a/modules/richards/tests/pressure_pulse/pp_fu_22.i
+++ b/modules/richards/tests/pressure_pulse/pp_fu_22.i
@@ -172,16 +172,18 @@
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-13 1E-13 100'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 
 [Executioner]
   type = Transient
   solve_type = Newton
+  nl_rel_tol = 1.e-9
+  nl_max_its = 20
   dt = 1E3
+  dtmin = 1E3
   end_time = 1E4
 []
 

--- a/modules/richards/tests/pressure_pulse/pp_fu_lumped_22.i
+++ b/modules/richards/tests/pressure_pulse/pp_fu_lumped_22.i
@@ -173,8 +173,8 @@
     type = SMP
     full = true
     petsc_options = '-snes_monitor -snes_linesearch_monitor'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -ksp_atol -ksp_rtol -ksp_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-13 1E-13 100 1E-20 1E-50 20'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 
@@ -182,7 +182,13 @@
   type = Transient
   solve_type = Newton
   dt = 1E3
+  dtmin = 1E3
   end_time = 1E4
+  l_tol = 1.e-4
+  nl_rel_tol = 1.e-7
+  nl_max_its = 10
+  l_max_its = 20
+  line_search = 'none'
 []
 
 [Outputs]

--- a/modules/richards/tests/pressure_pulse/pp_lumped_22.i
+++ b/modules/richards/tests/pressure_pulse/pp_lumped_22.i
@@ -172,9 +172,8 @@
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 100'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 
@@ -182,6 +181,9 @@
   type = Transient
   solve_type = Newton
   dt = 1E3
+  dtmin = 1E3
+  nl_rel_tol = 1.e-9
+  nl_max_its = 10
   end_time = 1E4
 []
 

--- a/modules/richards/tests/pressure_pulse/tests
+++ b/modules/richards/tests/pressure_pulse/tests
@@ -26,7 +26,7 @@
     type = 'Exodiff'
     input = 'pp21.i'
     exodiff = 'pp21.e'
-    rel_err = 1E-8
+    rel_err = 1E-7
     use_old_floor = True
     max_parallel = 1
   [../]
@@ -66,7 +66,7 @@
     type = 'Exodiff'
     input = 'pp_fu_21.i'
     exodiff = 'pp_fu_21.e'
-    rel_err = 1E-8
+    rel_err = 1E-7
     use_old_floor = True
     max_parallel = 1
   [../]

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp_cutback.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp_cutback.i
@@ -197,11 +197,11 @@
   type = Transient
   dt = 1.0
 
-  #Preconditioned JFNK (default)
+  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = -pc_hypre_type
-  petsc_options_value = boomerang
+  petsc_options_iname = '-pc_factor_shift_type'
+  petsc_options_value = 'nonzero'
   nl_abs_tol = 1e-10
   nl_rel_step_tol = 1e-10
   dtmax = 10.0

--- a/test/tests/time_integrators/implicit-euler/tests
+++ b/test/tests/time_integrators/implicit-euler/tests
@@ -16,8 +16,8 @@
   [./monomials]
     type = 'PetscJacobianTester'
     input = 'ie-monomials.i'
-    ratio_tol = 1e-9
-    difference_tol = 1e7
+    ratio_tol = 1e-7
+    difference_tol = 1e-6
     recover = false
   [../]
 []


### PR DESCRIPTION
The biggest issue with upgrading to PETSc 3.6 was that the default value of `-pc_factor_shift_type` is now `none`, and several of the tests in the modules require `-pc_factor_shift_type nonzero`.  This branch adds that flag where necessary, and also generally cleans up the PETSc options in the input files for the tests that weren't working.

Refs #5162.
