### PR TITLE
Add solid_mechanics and large strain versions of the bridge example

### DIFF
--- a/modules/solid_mechanics/examples/bridge/bridge.i
+++ b/modules/solid_mechanics/examples/bridge/bridge.i
@@ -1,0 +1,150 @@
+#
+# Bridge linear elasticity example
+#
+# This example models a bridge using linear elasticity.
+# It can be either steel or concrete.
+# Gravity is applied
+# A pressure of 0.5 MPa is also applied
+#
+[GlobalParams]
+  disp_x = disp_x
+  disp_y = disp_y
+  disp_z = disp_z
+[]
+
+[Mesh]
+  displacements = 'disp_x disp_y disp_z' #Define displacements for deformed mesh
+  type = FileMesh #Read in mesh from file
+  file = ../../../tensor_mechanics/examples/bridge/bridge.e
+
+  boundary_id = '1 2 3 4 5 6' #Assign names to boundaries to make things clearer
+  boundary_name = 'top left right bottom1 bottom2 bottom3'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[SolidMechanics]
+  [./solid]
+  [../]
+[]
+
+[Kernels]
+  [./gravity_y]
+    #Gravity is applied to bridge
+    type = Gravity
+    variable = disp_y
+    value = -9.81
+  [../]
+[]
+
+[AuxVariables]
+  [./von_mises]
+    #Dependent variable used to visualize the Von Mises stress
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./von_mises_kernel]
+    #Calculates the von mises stress and assigns it to von_mises
+    type = MaterialTensorAux
+    variable = von_mises
+    tensor = stress
+    execute_on = timestep_end
+    quantity = VonMises
+  [../]
+[]
+
+[BCs]
+  [./Pressure]
+    [./load]
+      #Applies the pressure
+      boundary = top
+      factor = 5e5 # Pa
+    [../]
+  [../]
+  [./anchor_x]
+    #Anchors the bottom and sides against deformation in the x-direction
+    type = PresetBC
+    variable = disp_x
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+  [./anchor_y]
+    #Anchors the bottom and sides against deformation in the y-direction
+    type = PresetBC
+    variable = disp_y
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+  [./anchor_z]
+    #Anchors the bottom and sides against deformation in the z-direction
+    type = PresetBC
+    variable = disp_z
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./steel_elastic]
+    type = Elastic
+    block = 1
+    youngs_modulus = 210e9 #Pa
+    poissons_ratio = 0.3
+    formulation = Linear
+  [../]
+
+  [./density_steel]
+    #Defines the density of steel
+    type = GenericConstantMaterial
+    block = 1
+    prop_names = density
+    prop_values = 7850 # kg/m^3
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    #Creates the entire Jacobian, for the Newton solve
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  #We solve a steady state problem using Newton's iteration
+  type = Steady
+  solve_type = NEWTON
+  nl_rel_tol = 1e-9
+  l_max_its = 30
+  l_tol = 1e-4
+  nl_max_its = 10
+  petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
+  petsc_options_value = 'hypre boomeramg 31'
+[]
+
+[Outputs]
+  print_linear_residuals = true
+  print_perf_log = true
+  output_initial = true
+  [./exodus]
+    #Outputs the result to an exodus file and converts the element stress output to a nodal output
+    type = Exodus
+    elemental_as_nodal = true
+  [../]
+[]

--- a/modules/solid_mechanics/examples/bridge/bridge_large_strain.i
+++ b/modules/solid_mechanics/examples/bridge/bridge_large_strain.i
@@ -1,0 +1,152 @@
+#
+# Bridge linear elasticity example
+#
+# This example models a bridge using linear elasticity.
+# It can be either steel or concrete.
+# Gravity is applied
+# A pressure of 0.5 MPa is also applied
+#
+[GlobalParams]
+  disp_x = disp_x
+  disp_y = disp_y
+  disp_z = disp_z
+[]
+
+[Mesh]
+  displacements = 'disp_x disp_y disp_z' #Define displacements for deformed mesh
+  type = FileMesh #Read in mesh from file
+  file = ../../../tensor_mechanics/examples/bridge/bridge.e
+
+  boundary_id = '1 2 3 4 5 6' #Assign names to boundaries to make things clearer
+  boundary_name = 'top left right bottom1 bottom2 bottom3'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[SolidMechanics]
+  [./solid]
+  [../]
+[]
+
+[Kernels]
+  [./gravity_y]
+    #Gravity is applied to bridge
+    type = Gravity
+    variable = disp_y
+    value = -9.81
+  [../]
+[]
+
+[AuxVariables]
+  [./von_mises]
+    #Dependent variable used to visualize the Von Mises stress
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./von_mises_kernel]
+    #Calculates the von mises stress and assigns it to von_mises
+    type = MaterialTensorAux
+    variable = von_mises
+    tensor = stress
+    execute_on = timestep_end
+    quantity = VonMises
+  [../]
+[]
+
+[BCs]
+  [./Pressure]
+    [./load]
+      #Applies the pressure
+      boundary = top
+      factor = 5e5 # Pa
+    [../]
+  [../]
+  [./anchor_x]
+    #Anchors the bottom and sides against deformation in the x-direction
+    type = PresetBC
+    variable = disp_x
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+  [./anchor_y]
+    #Anchors the bottom and sides against deformation in the y-direction
+    type = PresetBC
+    variable = disp_y
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+  [./anchor_z]
+    #Anchors the bottom and sides against deformation in the z-direction
+    type = PresetBC
+    variable = disp_z
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./steel_elastic]
+    type = Elastic
+    block = 1
+    youngs_modulus = 210e9 #Pa
+    poissons_ratio = 0.3
+    formulation = Nonlinear3D
+  [../]
+
+  [./density_steel]
+    #Defines the density of steel
+    type = GenericConstantMaterial
+    block = 1
+    prop_names = density
+    prop_values = 7850 # kg/m^3
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    #Creates the entire Jacobian, for the Newton solve
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  #We solve a steady state problem using Newton's iteration
+  type = Transient
+  solve_type = NEWTON
+  nl_rel_tol = 1e-9
+  l_max_its = 30
+  l_tol = 1e-4
+  nl_max_its = 10
+  petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
+  petsc_options_value = 'hypre boomeramg 31'
+  dt = 0.1
+  num_steps = 1
+[]
+
+[Outputs]
+  print_linear_residuals = true
+  print_perf_log = true
+  output_initial = true
+  [./exodus]
+    #Outputs the result to an exodus file and converts the element stress output to a nodal output
+    type = Exodus
+    elemental_as_nodal = true
+  [../]
+[]

--- a/modules/tensor_mechanics/examples/bridge/bridge_large_strain.i
+++ b/modules/tensor_mechanics/examples/bridge/bridge_large_strain.i
@@ -1,0 +1,174 @@
+#
+# Bridge linear elasticity example
+#
+# This example models a bridge using linear elasticity.
+# It can be either steel or concrete.
+# Gravity is applied
+# A pressure of 0.5 MPa is also applied
+#
+[GlobalParams]
+  disp_x = disp_x
+  disp_y = disp_y
+  disp_z = disp_z
+[]
+
+[Mesh]
+  displacements = 'disp_x disp_y disp_z' #Define displacements for deformed mesh
+  type = FileMesh #Read in mesh from file
+  file = bridge.e
+
+  boundary_id = '1 2 3 4 5 6' #Assign names to boundaries to make things clearer
+  boundary_name = 'top left right bottom1 bottom2 bottom3'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./gravity_y]
+    #Gravity is applied to bridge
+    type = GravityTM
+    variable = disp_y
+    value = -9.81
+  [../]
+  [./TensorMechanics]
+    #Stress divergence kernels
+  [../]
+[]
+
+[AuxVariables]
+  [./von_mises]
+    #Dependent variable used to visualize the Von Mises stress
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./von_mises_kernel]
+    #Calculates the von mises stress and assigns it to von_mises
+    type = RankTwoScalarAux
+    variable = von_mises
+    rank_two_tensor = stress
+    execute_on = timestep_end
+    scalar_type = VonMisesStress
+  [../]
+[]
+
+[BCs]
+  [./PressureTM]
+    [./load]
+      #Applies the pressure
+      boundary = top
+      factor = 5e5 # Pa
+    [../]
+  [../]
+  [./anchor_x]
+    #Anchors the bottom and sides against deformation in the x-direction
+    type = PresetBC
+    variable = disp_x
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+  [./anchor_y]
+    #Anchors the bottom and sides against deformation in the y-direction
+    type = PresetBC
+    variable = disp_y
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+  [./anchor_z]
+    #Anchors the bottom and sides against deformation in the z-direction
+    type = PresetBC
+    variable = disp_z
+    boundary = 'left right bottom1 bottom2 bottom3'
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  active = 'density_steel stress strain elasticity_tensor_steel'
+  [./elasticity_tensor_steel]
+    #Creates the elasticity tensor using steel parameters
+    youngs_modulus = 210e9 #Pa
+    poissons_ratio = 0.3
+    type = ComputeIsotropicElasticityTensor
+    block = 1
+  [../]
+  [./elasticity_tensor_concrete]
+    #Creates the elasticity tensor using concrete parameters
+    youngs_modulus = 16.5e9 #Pa
+    poissons_ratio = 0.2
+    type = ComputeIsotropicElasticityTensor
+    block = 1
+  [../]
+  [./strain]
+    #Computes the strain, assuming small strains
+    type = ComputeFiniteStrain
+    block = 1
+  [../]
+  [./stress]
+    #Computes the stress, using linear elasticity
+    type = ComputeFiniteStrainElasticStress
+    block = 1
+  [../]
+  [./density_steel]
+    #Defines the density of steel
+    type = GenericConstantMaterial
+    block = 1
+    prop_names = density
+    prop_values = 7850 # kg/m^3
+  [../]
+  [./density_concrete]
+    #Defines the density of concrete
+    type = GenericConstantMaterial
+    block = 1
+    prop_names = density
+    prop_values = 2400 # kg/m^3
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    #Creates the entire Jacobian, for the Newton solve
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  #We solve a steady state problem using Newton's iteration
+  type = Transient
+  solve_type = NEWTON
+  nl_rel_tol = 1e-9
+  l_max_its = 30
+  l_tol = 1e-4
+  nl_max_its = 10
+  petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
+  petsc_options_value = 'hypre boomeramg 31'
+  dt = 0.1
+  num_steps = 1
+[]
+
+[Outputs]
+  print_linear_residuals = true
+  print_perf_log = true
+  output_initial = true
+  [./exodus]
+    #Outputs the result to an exodus file and converts the element stress output to a nodal output
+    type = Exodus
+    elemental_as_nodal = true
+  [../]
+[]


### PR DESCRIPTION
Together with @bwspenc we created a large strain version of the bridge example and converted both versions over to solid_machanics to have a reference system for performance/memory comparison.
## Results
### Small strain

Total run time (1 cpu, macbook pro):
- tensor_mechanics: **35.5s**
- solid_mechanics: **45.1s**

Further analysis with Instruments shows that solid_mechanics uses stateful material properties without needing them in the model, while tensor_mechanics avoids this.
### Large strain

tensor_mechanics and solid_mechanics are head to head here. At a total run time of **~50s** solid_mechanics is about **1%** faster.

Memory use is very similar in both examples (slightly higher peak in solid_mechanics, _and_ larger time integral over the memory usage).
![memory usage graph](http://i.imgur.com/k4utjJD.png)

In conclusion it looks like we do **not** need to spend time on making TM faster (i.e. making tensors symmetry aware). The resulting code would be a complicated monster and as a result we may loose the speed that we get from having trivially vectorizable loops.

Closes #5173

Attn.: @tonkmr, @sapitts, @cpritam, @WilkAndy, @amjokisaari
