### PR TITLE
Minor RankFourTensor cleanup for style consistency (#4300)

### DIFF
--- a/modules/tensor_mechanics/include/utils/RankFourTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankFourTensor.h
@@ -48,7 +48,7 @@ void mooseSetToZero<RankFourTensor>(RankFourTensor & v);
 class RankFourTensor
 {
 public:
-  // Select initialization
+  /// Initialization method
   enum InitMethod
   {
     initNone,
@@ -92,10 +92,8 @@ public:
   static RankFourTensor Identity() { return RankFourTensor(initIdentity); }
   static RankFourTensor IdentityFour() { return RankFourTensor(initIdentityFour); };
 
-//private:
   /// Gets the value for the index specified.  Takes index = 0,1,2
   Real & operator()(unsigned int i, unsigned int j, unsigned int k, unsigned int l);
-public:
 
   /**
    * Gets the value for the index specified.  Takes index = 0,1,2
@@ -173,12 +171,12 @@ public:
    * Fills the tensor entries ignoring the last dimension (ie, C_ijkl=0 if any of i, j, k, or l = 3).
    * Fill method depends on size of input
    * Input size = 2.  Then C_1111 = C_2222 = input[0], and C_1122 = input[1], and C_1212 = (input[0] + input[1])/2,
-                      and C_ijkl = C_jikl = C_ijlk = C_klij, and C_1211 = C_1222 = 0.
+   *                  and C_ijkl = C_jikl = C_ijlk = C_klij, and C_1211 = C_1222 = 0.
    * Input size = 9.  Then C_1111 = input[0], C_1112 = input[1], C_1122 = input[3],
-                           C_1212 = input[4], C_1222 = input[5], C_1211 = input[6]
-                           C_2211 = input[7], C_2212 = input[8], C_2222 = input[9]
-                           and C_ijkl = C_jikl = C_ijlk
-  */
+   *                       C_1212 = input[4], C_1222 = input[5], C_1211 = input[6]
+   *                       C_2211 = input[7], C_2212 = input[8], C_2222 = input[9]
+   *                       and C_ijkl = C_jikl = C_ijlk
+   */
   virtual void surfaceFillFromInputVector(const std::vector<Real> & input);
 
   /// Static method for use in validParams for getting the "fill_method"
@@ -195,13 +193,12 @@ public:
    *             general_isotropic (use fillGeneralIsotropicFrominputVector)
    *             symmetric_isotropic (use fillSymmetricIsotropicFromInputVector)
    *             antisymmetric_isotropic (use fillAntisymmetricIsotropicFromInputVector)
-   *             AxisymmetricRZ (use fillAxisymmetricRZFromInputVector)
+   *             axisymmetric_rz (use fillAxisymmetricRZFromInputVector)
    *             general (use fillGeneralFromInputVector)
    */
   void fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method);
 
 protected:
-
   /// Dimensionality of rank-four tensor
   static const unsigned int N = LIBMESH_DIM;
 
@@ -221,11 +218,11 @@ protected:
   * the Rank-4 tensor with the appropriate crystal symmetries maintained. I.e., C_ijkl = C_klij,
   * C_ijkl = C_ijlk, C_ijkl = C_jikl
   * @param input If all==true then this is
-                   C1111 C1122 C1133 C2222 C2233 C3333 C2323 C1313 C1212
-                   In the isotropic case this is (la is first Lame constant, mu is second (shear) Lame constant)
-                   la+2mu la la la+2mu la la+2mu mu mu mu
-                 If all==false then this is
-                   C1111 C1122 C1133 C1123 C1113 C1112 C2222 C2233 C2223 C2213 C2212 C3333 C3323 C3313 C3312 C2323 C2313 C2312 C1313 C1312 C1212
+  *                C1111 C1122 C1133 C2222 C2233 C3333 C2323 C1313 C1212
+  *                In the isotropic case this is (la is first Lame constant, mu is second (shear) Lame constant)
+  *                la+2mu la la la+2mu la la+2mu mu mu mu
+  *              If all==false then this is
+  *                C1111 C1122 C1133 C1123 C1113 C1112 C2222 C2233 C2223 C2213 C2212 C3333 C3323 C3313 C3312 C2323 C2313 C2312 C1313 C1312 C1212
   */
   void fillSymmetricFromInputVector(const std::vector<Real> & input, bool all);
 
@@ -269,21 +266,16 @@ protected:
    * No symmetries are explicitly maintained
    * @param input  C[i][j][k][l] = input[i*N*N*N + j*N*N + k*N + l]
    */
-
   void fillAxisymmetricRZFromInputVector(const std::vector<Real> & input);
 
   /**
-  fillAxisymmetricRZFromInputVector takes 5 inputs to fill the axisymmetric
-  Rank-4 tensor with the appropriate symmetries maintatined for use with
-  axisymmetric problems using coord_type = RZ.
-  I.e. C1111 = C2222, C1133 = C2233, C2323 = C3131 and C1212 = 0.5*(C1111-C1122)
-  @param input this is C1111, C1122, C1133, C3333, C2323.
+   * fillAxisymmetricRZFromInputVector takes 5 inputs to fill the axisymmetric
+   * Rank-4 tensor with the appropriate symmetries maintatined for use with
+   * axisymmetric problems using coord_type = RZ.
+   * I.e. C1111 = C2222, C1133 = C2233, C2323 = C3131 and C1212 = 0.5*(C1111-C1122)
+   * @param input this is C1111, C1122, C1133, C3333, C2323.
    */
-
   void fillGeneralFromInputVector(const std::vector<Real> & input);
-
-private:
-
 };
 
 inline RankFourTensor operator*(Real a, const RankFourTensor & b) { return b * a; }

--- a/modules/tensor_mechanics/src/utils/RankFourTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankFourTensor.C
@@ -164,7 +164,7 @@ RankFourTensor::operator*=(const Real a)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
-          _vals[i][j][k][l] = _vals[i][j][k][l] * a;
+          _vals[i][j][k][l] *= a;
 
   return *this;
 }
@@ -380,23 +380,15 @@ RankFourTensor::invSymm() const
         for (unsigned int l = 0; l < N; ++l)
         {
           if (i==j)
-          {
-            if (k==l)
-              mat[i*ntens+k] = a(i,j,k,l);
-            else
-              mat[i*ntens+nskip+k+l] += a(i,j,k,l);
-          }
+            mat[k==l ? i*ntens+k
+                     : i*ntens+k+nskip+l] = a(i,j,k,l);
           else // i!=j
-          {
-            if (k==l)
-              mat[(nskip+i+j)*ntens+k] = a(i,j,k,l);
-            else
-              mat[(nskip+i+j)*ntens+nskip+k+l] += a(i,j,k,l); // note the +=, which results in double-counting and is rectified below
-          }
+            mat[k==l ? (nskip+i+j)*ntens+k
+                     : (nskip+i+j)*ntens+k+nskip+l] += a(i,j,k,l); // note the +=, which results in double-counting and is rectified below
         }
 
-  for (unsigned int i = 3; i < ntens; i++)
-    for (unsigned int j = 3; j < ntens; j++)
+  for (unsigned int i = 3; i < ntens; ++i)
+    for (unsigned int j = 3; j < ntens; ++j)
       mat[i*ntens+j] /= 2.0; // because of double-counting above
 
   // use LAPACK to find the inverse
@@ -412,19 +404,11 @@ RankFourTensor::invSymm() const
         for (unsigned int l = 0; l < N; ++l)
         {
           if (i==j)
-          {
-            if (k==l)
-              result(i,j,k,l) = mat[i*ntens+k];
-            else
-              result(i,j,k,l) = mat[i*ntens+nskip+k+l]/2.0;
-          }
+            result(i,j,k,l) = k==l ? mat[i*ntens+k]
+                                   : mat[i*ntens+k+nskip+l]/2.0;
           else // i!=j
-          {
-            if (k==l)
-              result(i,j,k,l) = mat[(nskip+i+j)*ntens+k];
-            else
-              result(i,j,k,l) = mat[(nskip+i+j)*ntens+nskip+k+l]/2.0;
-          }
+            result(i,j,k,l) = k==l ? mat[(nskip+i+j)*ntens+k]
+                                   : mat[(nskip+i+j)*ntens+k+nskip+l]/2.0;
         }
 
   return result;
@@ -433,7 +417,6 @@ RankFourTensor::invSymm() const
 void
 RankFourTensor::rotate(RealTensorValue & R)
 {
-  Real temp;
   RankFourTensor old = *this;
 
   for (unsigned int i = 0; i < N; ++i)
@@ -441,14 +424,14 @@ RankFourTensor::rotate(RealTensorValue & R)
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
         {
-          temp = 0.0;
+          Real sum = 0.0;
           for (unsigned int m = 0; m < N; ++m)
             for (unsigned int n = 0; n < N; ++n)
               for (unsigned int o = 0; o < N; ++o)
                 for (unsigned int p = 0; p < N; ++p)
-                  temp += R(i,m) * R(j,n) * R(k,o) * R(l,p) * old._vals[m][n][o][p];
+                  sum += R(i,m) * R(j,n) * R(k,o) * R(l,p) * old(m,n,o,p);
 
-          _vals[i][j][k][l] = temp;
+          _vals[i][j][k][l] = sum;
         }
 }
 
@@ -460,13 +443,13 @@ RankFourTensor::print() const
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
     {
-      Moose::out << "i = " << i << " j = " << j << std::endl;
+      Moose::out << "i = " << i << " j = " << j << '\n';
       for (unsigned int k = 0; k < N; ++k)
       {
         for (unsigned int l = 0; l < N; ++l)
           Moose::out << std::setw(15) << a(i,j,k,l) << " ";
 
-        Moose::out << std::endl;
+        Moose::out << '\n';
       }
     }
 }
@@ -596,7 +579,7 @@ RankFourTensor::matrixInversion(std::vector<PetscScalar> & A, int n) const
 void
 RankFourTensor::fillSymmetricFromInputVector(const std::vector<Real> & input, bool all)
 {
-  if ((all == true && input.size() != 21) || (all == false && input.size() != 9 ))
+  if ((all == true && input.size() != 21) || (all == false && input.size() != 9))
     mooseError("Please check the number of entries in the stiffness input vector.");
 
   zero();
@@ -724,10 +707,10 @@ RankFourTensor::fillAntisymmetricIsotropicFromInputVector(const std::vector<Real
 {
   if (input.size() != 1)
     mooseError("To use fillAntisymmetricIsotropicFromInputVector, your input must have size 1. Yours has size " << input.size());
-  std::vector<Real> input3;
-  input3.push_back(0);
-  input3.push_back(0);
-  input3.push_back(input[0]);
+  std::vector<Real> input3(3);
+  input3[0] = 0.0;
+  input3[1] = 0.0;
+  input3[2] = input[0];
   fillGeneralIsotropicFromInputVector(input3);
 }
 
@@ -736,10 +719,10 @@ RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> & 
 {
   if (input.size() != 2)
     mooseError("To use fillSymmetricIsotropicFromInputVector, your input must have size 2. Yours has size " << input.size());
-  std::vector<Real> input3;
-  input3.push_back(input[0]);
-  input3.push_back(input[1]);
-  input3.push_back(0);
+  std::vector<Real> input3(3);
+  input3[0] = input[0];
+  input3[1] = input[1];
+  input3[2] = 0.0;
   fillGeneralIsotropicFromInputVector(input3);
 }
 


### PR DESCRIPTION
Small changes for style consistency. We should always use () to read from a tensor object (in case we ever want to make this operator more complex).
Refs #4300
