### PR TITLE
Add --list-constructed-objects command line option

### DIFF
--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -15,6 +15,7 @@
 #ifndef FACTORY_H
 #define FACTORY_H
 
+#include <set>
 #include <vector>
 #include <time.h>
 
@@ -219,6 +220,11 @@ public:
    */
   registeredMooseObjectIterator registeredObjectsEnd() { return _name_to_params_pointer.end(); }
 
+  /**
+   * Get a list of all constructed Moose Object types
+   */
+  std::vector<std::string> getConstructedObjects() const;
+
 protected:
 
   /**
@@ -259,6 +265,9 @@ protected:
 
   /// Object id count
   MooseObjectID _object_count;
+
+  /// Constructed Moose Object types
+  std::set<std::string> _constructed_types;
 };
 
 #endif /* FACTORY_H */

--- a/framework/include/multiapps/MultiAppWarehouse.h
+++ b/framework/include/multiapps/MultiAppWarehouse.h
@@ -25,6 +25,11 @@ class MultiApp;
 class TransientMultiApp;
 
 /**
+ * Typedef for registered Object iterator
+ */
+typedef std::vector<MooseSharedPointer<MultiApp> >::const_iterator MultiAppIter;
+
+/**
  * Holds MultiApps and provides some services
  */
 class MultiAppWarehouse : public Warehouse<MultiApp>
@@ -63,6 +68,16 @@ public:
    * @return A pointer to the MultiApp
    */
   MultiApp * getMultiApp(const std::string & multi_app_name) const;
+
+  /**
+   * Get a const iterator for the first sub app
+   */
+  MultiAppIter subAppsBegin() const { return _all_ptrs.begin(); }
+
+  /**
+   * Get a const iterator for the first sub app
+   */
+  MultiAppIter subAppsEnd() const { return _all_ptrs.end(); }
 
   /**
    * Gets called when the output position has changed for the parent app.

--- a/framework/scripts/moosegrep.sh
+++ b/framework/scripts/moosegrep.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Usage:
+#  moosegrep.sh appexecutable objectname inputfile1.i [inputfile2.i ...]
+#
+
+APP=$1
+OBJ=$2
+
+if [ x$3 == 'x' ]
+then
+  echo "Usage: moosegrep.sh appexecutable objectname inputfile1.i [inputfile2.i ...]"
+  exit 1
+fi
+
+n=0
+for INPUT in $@
+do
+  if [ $n -ge 2 ]
+  then
+    $1 -i $INPUT --list-constructed-objects | sed -e '1,/\*\*START OBJECT DATA\*\*/d' -e '/\*\*END OBJECT DATA\*\*/,$d' | grep '^'$OBJ'$' > /dev/null 2>&1
+    if [ $? -eq 0 ]
+    then
+      echo $INPUT: $OBJ
+    fi
+  fi
+
+  let n=n+1
+done

--- a/framework/scripts/moosegrep.sh
+++ b/framework/scripts/moosegrep.sh
@@ -18,7 +18,9 @@ for INPUT in $@
 do
   if [ $n -ge 2 ]
   then
-    $1 -i $INPUT --list-constructed-objects | sed -e '1,/\*\*START OBJECT DATA\*\*/d' -e '/\*\*END OBJECT DATA\*\*/,$d' | grep '^'$OBJ'$' > /dev/null 2>&1
+    $APP -i $INPUT --list-constructed-objects \
+      | sed -n -e '/\*\*START OBJECT DATA\*\*/,/\*\*END OBJECT DATA\*\*/{//!p}' \
+      | grep '^'$OBJ'$' > /dev/null 2>&1
     if [ $? -eq 0 ]
     then
       echo $INPUT: $OBJ

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -67,6 +67,9 @@ Factory::create(const std::string & obj_name, const std::string & name, InputPar
   // Increment object counter
   _object_count++;
 
+  // register type name as constructed
+  _constructed_types.insert(obj_name);
+
   // Actually call the function pointer.  You can do this in one line,
   // but it's a bit more obvious what's happening if you do it in two...
   buildPtr & func = it->second;
@@ -167,4 +170,13 @@ Factory::reportUnregisteredError(const std::string & obj_name) const
       << "in your input file or exported \"MOOSE_LIBRARY_PATH\".";
 
   mooseError(oss.str());
+}
+
+std::vector<std::string>
+Factory::getConstructedObjects() const
+{
+  std::vector<std::string> list;
+  for (std::set<std::string>::iterator i = _constructed_types.begin(); i != _constructed_types.end(); ++i)
+    list.push_back(*i);
+  return list;
 }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -56,6 +56,7 @@ InputParameters validParams<MooseApp>()
   params.addCommandLineParam<std::string>("yaml", "--yaml", "Dumps input file syntax in YAML format.");
   params.addCommandLineParam<bool>("syntax", "--syntax", false, "Dumps the associated Action syntax paths ONLY");
   params.addCommandLineParam<bool>("check_input", "--check-input", false, "Check the input file (i.e. requires -i <filename>) and quit.");
+  params.addCommandLineParam<bool>("list_constructed_objects", "--list-constructed-objects", false, "List all moose object type names constructed by the master app factory.");
 
   params.addCommandLineParam<unsigned int>("n_threads", "--n-threads=<n>", 1, "Runs the specified number of threads per process");
 
@@ -289,6 +290,21 @@ MooseApp::runInputFile()
 
   _action_warehouse.executeAllActions();
   _executioner = _action_warehouse.executioner();
+
+  if (getParam<bool>("list_constructed_objects"))
+  {
+    // TODO: ask multiapps for their constructed objects
+    std::vector<std::string> obj_list = _factory.getConstructedObjects();
+    Moose::out << "**START OBJECT DATA**\n";
+    for (unsigned int i = 0; i < obj_list.size(); ++i)
+    {
+      Moose::out << obj_list[i] << "\n";
+    }
+    Moose::out << "**END OBJECT DATA**\n" << std::endl;
+    _ready_to_exit = true;
+    return;
+  }
+
 
   bool error_unused = getParam<bool>("error_unused") || _enable_unused_check == ERROR_UNUSED;
   bool warn_unused = getParam<bool>("warn_unused") || _enable_unused_check == WARN_UNUSED;


### PR DESCRIPTION
Example output:

```
moose/modules/tensor_mechanics/examples/bridge]> ../../tensor_mechanics-opt --list-constructed-objects -i bridge.i 
**START OBJECT DATA**
ComputeIsotropicElasticityTensor
ComputeLinearElasticStress
ComputeSmallStrain
Console
ConstantFunction
Exodus
FEProblem
FileMesh
GenericConstantMaterial
GravityTM
PresetBC
PressureTM
RankTwoScalarAux
SMP
Steady
SteadyState
StressDivergenceTensors
**END OBJECT DATA**


 ----------------------------------------------------------------------------------------------------------------------
| Setup Performance: Alive time=3.34957, Active time=3.17556                                                           |
 ----------------------------------------------------------------------------------------------------------------------
| Event                                   nCalls     Total Time  Avg Time    Total Time  Avg Time    % of Active Time  |
|                                                    w/o Sub     w/o Sub     With Sub    With Sub    w/o S    With S   |
|----------------------------------------------------------------------------------------------------------------------|
```

Closes #5184
