### PR TITLE
Remove type and add class description to yaml dump

### DIFF
--- a/framework/include/outputs/formatters/InputFileFormatter.h
+++ b/framework/include/outputs/formatters/InputFileFormatter.h
@@ -25,7 +25,7 @@ class InputFileFormatter : public SyntaxTree
 public:
   InputFileFormatter(bool dump_mode);
 
-  virtual std::string printBlockOpen(const std::string &name, short depth, const std::string &type) const;
+  virtual std::string printBlockOpen(const std::string &name, short depth, const std::string & /*doc*/) const;
   virtual std::string printBlockClose(const std::string &name, short depth) const;
   virtual std::string printParams(const std::string &prefix, const std::string &fully_qualified_name, InputParameters &params, short depth, const std::string &search_string, bool &found);
 

--- a/framework/include/outputs/formatters/SyntaxFormatterInterface.h
+++ b/framework/include/outputs/formatters/SyntaxFormatterInterface.h
@@ -57,7 +57,7 @@ public:
    * when opening new blocks.
    * @return - The formatted block open string
    */
-  virtual std::string printBlockOpen(const std::string &name, short depth, const std::string &type) const = 0;
+  virtual std::string printBlockOpen(const std::string &name, short depth, const std::string &doc) const = 0;
 
   /**
    * This method is called at the end of of each Node in the tree.  It is typically used to provide formatting necessary

--- a/framework/include/outputs/formatters/YAMLFormatter.h
+++ b/framework/include/outputs/formatters/YAMLFormatter.h
@@ -30,7 +30,7 @@ public:
   virtual std::string postscript() const;
 
   virtual std::string preTraverse(short depth) const;
-  virtual std::string printBlockOpen(const std::string &name, short depth, const std::string &type) const;
+  virtual std::string printBlockOpen(const std::string &name, short depth, const std::string & doc) const;
   virtual std::string printBlockClose(const std::string &name, short depth) const;
   virtual std::string printParams(const std::string &prefix, const std::string &fully_qualified_name, InputParameters &params, short depth, const std::string &search_string, bool &found);
 

--- a/framework/src/outputs/formatters/InputFileFormatter.C
+++ b/framework/src/outputs/formatters/InputFileFormatter.C
@@ -26,7 +26,7 @@ InputFileFormatter::InputFileFormatter(bool dump_mode) :
 }
 
 std::string
-InputFileFormatter::printBlockOpen(const std::string &name, short depth, const std::string & /*type*/) const
+InputFileFormatter::printBlockOpen(const std::string &name, short depth, const std::string & /*doc*/) const
 {
   std::string indent(depth*2, ' ');
   std::string opening_string;

--- a/framework/src/outputs/formatters/YAMLFormatter.C
+++ b/framework/src/outputs/formatters/YAMLFormatter.C
@@ -127,14 +127,17 @@ YAMLFormatter::preTraverse(short depth) const
 
 
 std::string
-YAMLFormatter::printBlockOpen(const std::string &name, short depth, const std::string &type) const
+YAMLFormatter::printBlockOpen(const std::string &name, short depth, const std::string & doc) const
 {
   std::ostringstream oss;
   std::string indent(depth*2, ' ');
 
-  oss << indent << "- name: " << (name == "*" ? type : name) << "\n";
-  oss << indent << "  description: !!str\n";
-  oss << indent << "  type: " << type << "\n";
+  std::string docEscaped = doc;
+  MooseUtils::escape(docEscaped);
+
+  oss << indent << "- name: " << name << "\n";
+  oss << indent << "  description: |\n"
+      << indent << "    " << docEscaped << "\n";
   oss << indent << "  parameters:\n";
 
   return oss.str();

--- a/framework/src/utils/SyntaxTree.C
+++ b/framework/src/utils/SyntaxTree.C
@@ -136,7 +136,7 @@ SyntaxTree::TreeNode::insertParams(const std::string &action, bool is_action_par
 std::string
 SyntaxTree::TreeNode::print(short depth, const std::string &search_string, bool &found)
 {
-  std::string type;
+  std::string doc;
   std::string long_name(getLongName());
   std::string name(_syntax_tree.isLongNames() ? long_name : _name);
   std::string out;
@@ -155,8 +155,8 @@ SyntaxTree::TreeNode::print(short depth, const std::string &search_string, bool 
   }
 
   // GlobalParamsAction is special - we need to just always print it out
-//  if (_name == "GlobalParamsAction")
-//    found = true;
+  // if (_name == "GlobalParamsAction")
+  //   found = true;
 
   std::string indent((depth+1)*2, ' ');
 
@@ -174,7 +174,12 @@ SyntaxTree::TreeNode::print(short depth, const std::string &search_string, bool 
     else
       local_search_string = search_string;
 
-    local_out += _syntax_tree.printBlockOpen(name, depth, type);
+    if (it != _moose_object_params.end())
+      doc = it->second->getClassDescription();
+    else
+      doc = "";
+
+    local_out += _syntax_tree.printBlockOpen(name, depth, doc);
 
     for (std::multimap<std::string, InputParameters *>::const_iterator a_it = _action_params.begin(); a_it != _action_params.end(); ++a_it)
       if (a_it->first != "EmptyAction")


### PR DESCRIPTION
Make class documentation available in YAML (field was always empty). Remove other unused field.
Closes #5135.

P.S.: I found a peacock bug (try the dropdown for `args` in the `CHParsed` Kernel... weird, but a different issue.)
