### PR TITLE
Add missing class descriptions to the phase field module

### DIFF
--- a/modules/phase_field/include/kernels/ACGBPoly.h
+++ b/modules/phase_field/include/kernels/ACGBPoly.h
@@ -24,13 +24,6 @@ protected:
   virtual Real computeDFDOP(PFFunctionType type);
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-private:
-  /**
-   * Coupled things come through as std::vector _refernces_.
-   *
-   * Since this is a reference it MUST be set in the Initialization List of the
-   * constructor!
-   */
   VariableValue & _c;
   unsigned int _c_var;
 

--- a/modules/phase_field/include/kernels/PFFracCoupledInterface.h
+++ b/modules/phase_field/include/kernels/PFFracCoupledInterface.h
@@ -11,7 +11,7 @@
 
 /**
  * Phase-field fracture model
- * This class computes the contribution to residual and jacobian of the auxiliary variable beta
+ * This class computes the contribution to residual and jacobian of the variable beta
  * by the grad of c (damage variable)
  * Refer to formulation: Miehe et. al., Int. J. Num. Methods Engg., 2010, 83. 1273-1311 Equation 63
  */

--- a/modules/phase_field/src/action/PolycrystalVariablesAction.C
+++ b/modules/phase_field/src/action/PolycrystalVariablesAction.C
@@ -26,12 +26,12 @@ template<>
 InputParameters validParams<PolycrystalVariablesAction>()
 {
   InputParameters params = validParams<Action>();
+  params.addClassDescription("Set up order parameter variables for a polycrystal sample");
   params.addParam<std::string>("family", "LAGRANGE", "Specifies the family of FE shape functions to use for this variable");
   params.addParam<std::string>("order", "FIRST", "Specifies the order of the FE shape function to use for this variable");
   params.addParam<Real>("scaling", 1.0, "Specifies a scaling factor to apply to this variable");
   params.addRequiredParam<unsigned int>("op_num", "specifies the number of order parameters to create");
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
-
   return params;
 }
 

--- a/modules/phase_field/src/action/PolycrystalVoronoiICAction.C
+++ b/modules/phase_field/src/action/PolycrystalVoronoiICAction.C
@@ -26,15 +26,13 @@ template<>
 InputParameters validParams<PolycrystalVoronoiICAction>()
 {
   InputParameters params = validParams<Action>();
+  params.addClassDescription("Random Voronoi tesselation polycrystal action");
   params.addRequiredParam<unsigned int>("op_num", "number of order parameters to create");
   params.addRequiredParam<unsigned int>("grain_num", "number of grains to create, if it is going to greater than op_num");
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
   params.addParam<unsigned int>("rand_seed", 12444, "The random seed");
-
   params.addParam<bool>("cody_test", false, "Use set grain center points for Cody's test. Grain num MUST equal 10");
-
   params.addParam<bool>("columnar_3D", false, "3D microstructure will be columnar in the z-direction?");
-
   return params;
 }
 

--- a/modules/phase_field/src/auxkernels/BndsCalcAux.C
+++ b/modules/phase_field/src/auxkernels/BndsCalcAux.C
@@ -11,6 +11,7 @@ template<>
 InputParameters validParams<BndsCalcAux>()
 {
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Calculate location of grain boundaries in a polycrystalline sample");
   params.addCoupledVar("v", "Array of coupled variables");
   params.addRequiredParam<unsigned int>("op_num", "number of grains");
   params.addRequiredParam<std::string>("var_name_base", "base for variable names");

--- a/modules/phase_field/src/auxkernels/CrossTermGradientFreeEnergy.C
+++ b/modules/phase_field/src/auxkernels/CrossTermGradientFreeEnergy.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<CrossTermGradientFreeEnergy>()
 {
   InputParameters params = validParams<TotalFreeEnergyBase>();
+  params.addClassDescription("Free energy contribution from the cross terms in ACMultiInetrface");
   params.addRequiredParam< std::vector<std::string> >("kappa_names", "Matrix of kappa names with rows and columns corresponding to each variable name in interfacial_vars in the same order (should be symmetric).");
   return params;
 }

--- a/modules/phase_field/src/auxkernels/FeatureFloodCountAux.C
+++ b/modules/phase_field/src/auxkernels/FeatureFloodCountAux.C
@@ -11,11 +11,11 @@
 template<>
 InputParameters validParams<FeatureFloodCountAux>()
 {
-  MooseEnum field_display("UNIQUE_REGION VARIABLE_COLORING ACTIVE_BOUNDS CENTROID", "UNIQUE_REGION");
-
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Feature detection by connectivity analysis");
   params.addRequiredParam<UserObjectName>("bubble_object", "The FeatureFloodCount UserObject to get values from.");
   params.addParam<unsigned int>("map_index", 0, "The index of which map to retrieve values from when using FeatureFloodCount with multiple maps.");
+  MooseEnum field_display("UNIQUE_REGION VARIABLE_COLORING ACTIVE_BOUNDS CENTROID", "UNIQUE_REGION");
   params.addParam<MooseEnum>("field_display", field_display, "Determines how the auxilary field should be colored. (UNIQUE_REGION and VARIABLE_COLORING are nodal, CENTROID is elemental, default: UNIQUE_REGION)");
   return params;
 }

--- a/modules/phase_field/src/auxkernels/TotalFreeEnergy.C
+++ b/modules/phase_field/src/auxkernels/TotalFreeEnergy.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<TotalFreeEnergy>()
 {
   InputParameters params = validParams<TotalFreeEnergyBase>();
+  params.addClassDescription("Total free energy (both the bulk and gradient parts), where the bulk free energy has been defined in a material");
   params.addParam<std::string>("f_name", "F"," Base name of the free energy function");
   params.addParam< std::vector<std::string> >("kappa_names", std::vector<std::string>(), "Vector of kappa names corresponding to each variable name in interfacial_vars in the same order.");
   return params;

--- a/modules/phase_field/src/functions/ImageFunction.C
+++ b/modules/phase_field/src/functions/ImageFunction.C
@@ -14,6 +14,7 @@ InputParameters validParams<ImageFunction>()
 {
   // Define the general parameters
   InputParameters params = validParams<Function>();
+  params.addClassDescription("Function with values sampled from a given image stack");
 
   // Add parameters associated with file ranges
   addFileRangeParams(params);

--- a/modules/phase_field/src/ics/ClosePackIC.C
+++ b/modules/phase_field/src/ics/ClosePackIC.C
@@ -13,6 +13,7 @@ template<>
 InputParameters validParams<ClosePackIC>()
 {
   InputParameters params = validParams<SmoothCircleBaseIC>();
+  params.addClassDescription("Close packed arrangement of smooth circles");
   params.addRequiredParam<Real>("radius", "The radius of a circle");
   return params;
 }

--- a/modules/phase_field/src/ics/CrossIC.C
+++ b/modules/phase_field/src/ics/CrossIC.C
@@ -28,6 +28,7 @@ template<>
 InputParameters validParams<CrossIC>()
 {
   InputParameters params = validParams<C1ICBase>();
+  params.addClassDescription("Cross-shaped initial condition");
   params.addParam<Real>("x1", 0.0, "The x coordinate of the lower left-hand corner of the box");
   params.addParam<Real>("y1", 0.0, "The y coordinate of the lower left-hand corner of the box");
 

--- a/modules/phase_field/src/ics/HexPolycrystalIC.C
+++ b/modules/phase_field/src/ics/HexPolycrystalIC.C
@@ -13,6 +13,7 @@ template<>
 InputParameters validParams<HexPolycrystalIC>()
 {
   InputParameters params = validParams<PolycrystalReducedIC>();
+  params.addClassDescription("Perturbed hexagonal polycrystal");
 
   params.addParam<Real>("x_offset", 0.5, "Specifies offset of hexagon grid in x-direction");
   params.addParam<Real>("perturbation_percent", 0.0, "The percent to randomly perturbate centers of grains relative to the size of the grain");

--- a/modules/phase_field/src/ics/LatticeSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/LatticeSmoothCircleIC.C
@@ -11,6 +11,7 @@ template<>
 InputParameters validParams<LatticeSmoothCircleIC>()
 {
   InputParameters params = validParams<SmoothCircleBaseIC>();
+  params.addClassDescription("Perturbed square lattice of smooth circles");
   params.addParam<Real>("Rnd_variation", 0.0, "Variation from central lattice position");
   params.addRequiredParam<std::vector<unsigned int> >("circles_per_side", "Vector containing the number of bubbles along each side");
   params.addParam<unsigned int>("rand_seed", 2000, "random seed");

--- a/modules/phase_field/src/ics/MultiSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothCircleIC.C
@@ -11,7 +11,8 @@ template<>
 InputParameters validParams<MultiSmoothCircleIC>()
 {
   InputParameters params = validParams<SmoothCircleBaseIC>();
-  params.addRequiredParam<unsigned int>("numbub", "The number of bubbles to be placed on GB");
+  params.addClassDescription("Random distribution of smooth circles with given minimum spacing");
+  params.addRequiredParam<unsigned int>("numbub", "The number of bubbles to place");
   params.addRequiredParam<Real>("bubspac", "minimum spacing of bubbles, measured from center to center");
   params.addParam<unsigned int>("rand_seed", 2000, "random seed");
   params.addParam<unsigned int>("numtries", 1000, "The number of tries");
@@ -19,7 +20,6 @@ InputParameters validParams<MultiSmoothCircleIC>()
   params.addParam<Real>("radius_variation", 0.0, "Plus or minus fraction of random variation in the bubble radius for uniform, standard deviation for normal");
   MooseEnum rand_options("uniform normal none","none");
   params.addParam<MooseEnum>("radius_variation_type", rand_options, "Type of distribution that random circle radii will follow");
-
   return params;
 }
 

--- a/modules/phase_field/src/ics/PolycrystalRandomIC.C
+++ b/modules/phase_field/src/ics/PolycrystalRandomIC.C
@@ -13,9 +13,7 @@ InputParameters validParams<PolycrystalRandomIC>()
   InputParameters params = validParams<InitialCondition>();
   params.addRequiredParam<unsigned int>("op_num", "Number of order parameters");
   params.addRequiredParam<unsigned int>("op_index", "The index for the current order parameter");
-
-  params.addRequiredParam<unsigned int>("typ", "Type of random grain structure");
-
+  params.addRequiredParam<unsigned int>("typ", "Type of random grain structure"); //TODO: this should be called "type"!
   return params;
 }
 

--- a/modules/phase_field/src/ics/PolycrystalReducedIC.C
+++ b/modules/phase_field/src/ics/PolycrystalReducedIC.C
@@ -12,16 +12,13 @@ template<>
 InputParameters validParams<PolycrystalReducedIC>()
 {
   InputParameters params = validParams<InitialCondition>();
+  params.addClassDescription("Random Voronoi tesselation polycrystal (used by PolycrystalVoronoiICAction)");
   params.addRequiredParam<unsigned int>("op_num", "Number of order parameters");
   params.addRequiredParam<unsigned int>("grain_num", "Number of grains being represented by the order parameters");
   params.addRequiredParam<unsigned int>("op_index", "The index for the current order parameter");
-
   params.addParam<unsigned int>("rand_seed", 12444, "The random seed");
-
   params.addParam<bool>("cody_test", false, "Use set grain center points for Cody's test. Grain num MUST equal 10");
-
   params.addParam<bool>("columnar_3D", false, "3D microstructure will be columnar in the z-direction?");
-
   return params;
 }
 
@@ -63,7 +60,6 @@ PolycrystalReducedIC::initialSetup()
   _centerpoints.resize(_grain_num);
   _assigned_op.resize(_grain_num);
   std::vector<Real> distances(_grain_num);
-
 
   std::vector<Point> holder;
 

--- a/modules/phase_field/src/ics/RndBoundingBoxIC.C
+++ b/modules/phase_field/src/ics/RndBoundingBoxIC.C
@@ -11,6 +11,8 @@ template<>
 InputParameters validParams<RndBoundingBoxIC>()
 {
   InputParameters params = validParams<InitialCondition>();
+  params.addClassDescription("Random noise with different min/max inside/outside of a bounding box");
+
   params.addRequiredParam<Real>("x1", "The x coordinate of the lower left-hand corner of the box");
   params.addRequiredParam<Real>("y1", "The y coordinate of the lower left-hand corner of the box");
   params.addParam<Real>("z1", 0.0, "The z coordinate of the lower left-hand corner of the box");

--- a/modules/phase_field/src/ics/RndSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/RndSmoothCircleIC.C
@@ -11,9 +11,10 @@ template<>
 InputParameters validParams<RndSmoothCircleIC>()
 {
   InputParameters params = validParams<SmoothCircleIC>();
+  params.addClassDescription("Random noise with different min/max inside/outside of a smooth circle");
+
   params.addRequiredParam<Real>("variation_invalue", "Plus or minus this amount on the invalue");
   params.addRequiredParam<Real>("variation_outvalue", "Plus or minus this amount on the outvalue");
-
   params.addParam<unsigned int>("rand_seed", 12345, "Seed value for the random number generator");
   return params;
 }

--- a/modules/phase_field/src/ics/SmoothCircleIC.C
+++ b/modules/phase_field/src/ics/SmoothCircleIC.C
@@ -10,12 +10,11 @@ template<>
 InputParameters validParams<SmoothCircleIC>()
 {
   InputParameters params = validParams<SmoothCircleBaseIC>();
+  params.addClassDescription("Circle with a smooth interface");
   params.addRequiredParam<Real>("x1", "The x coordinate of the circle center");
   params.addRequiredParam<Real>("y1", "The y coordinate of the circle center");
   params.addParam<Real>("z1", 0.0, "The z coordinate of the circle center");
-
   params.addRequiredParam<Real>("radius", "The radius of a circle");
-
   return params;
 }
 

--- a/modules/phase_field/src/ics/SpecifiedSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/SpecifiedSmoothCircleIC.C
@@ -11,6 +11,7 @@ template<>
 InputParameters validParams<SpecifiedSmoothCircleIC>()
 {
   InputParameters params = validParams<SmoothCircleBaseIC>();
+  params.addClassDescription("Multiple smooth circles with manually specified radii and center points");
   params.addRequiredParam<std::vector<Real> >("x_positions", "The x-coordinate for each circle center");
   params.addRequiredParam<std::vector<Real> >("y_positions", "The y-coordinate for each circle center");
   params.addRequiredParam<std::vector<Real> >("z_positions", "The z-coordinate for each circle center");

--- a/modules/phase_field/src/ics/ThumbIC.C
+++ b/modules/phase_field/src/ics/ThumbIC.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<ThumbIC>()
 {
   InputParameters params = validParams<InitialCondition>();
+  params.addClassDescription("Thumb shaped bicrystal for grain boundary mobility tests");
   params.addRequiredParam<Real>("xcoord", "The x coordinate of the circle center");
   params.addRequiredParam<Real>("width", "The y coordinate of the circle center");
   params.addRequiredParam<Real>("height", "The z coordinate of the circle center");

--- a/modules/phase_field/src/ics/Tricrystal2CircleGrainsIC.C
+++ b/modules/phase_field/src/ics/Tricrystal2CircleGrainsIC.C
@@ -11,9 +11,9 @@ template<>
 InputParameters validParams<Tricrystal2CircleGrainsIC>()
 {
   InputParameters params = validParams<InitialCondition>();
+  params.addClassDescription("Tricrystal with two circles/bubbles");
   params.addRequiredParam<unsigned int>("op_num", "Number of grain order parameters");
   params.addRequiredParam<unsigned int>("op_index", "Index for the current grain order parameter");
-
   return params;
 }
 

--- a/modules/phase_field/src/kernels/ACBulk.C
+++ b/modules/phase_field/src/kernels/ACBulk.C
@@ -10,8 +10,8 @@ template<>
 InputParameters validParams<ACBulk>()
 {
   InputParameters params = validParams<KernelValue>();
+  params.addClassDescription("Allen-Cahn Kernel");
   params.addParam<std::string>("mob_name", "L", "The mobility used with the kernel");
-
   return params;
 }
 

--- a/modules/phase_field/src/kernels/ACGBPoly.C
+++ b/modules/phase_field/src/kernels/ACGBPoly.C
@@ -11,6 +11,7 @@ template<>
 InputParameters validParams<ACGBPoly>()
 {
   InputParameters params = validParams<ACBulk>();
+  params.addClassDescription("Grain-Boundary model concentration dependent residual");
   params.addRequiredCoupledVar("c", "Other species concentration");
   params.addParam<Real>("en_ratio", 1.0, "Ratio of surface energy to GB energy");
   return params;

--- a/modules/phase_field/src/kernels/ACGrGrPoly.C
+++ b/modules/phase_field/src/kernels/ACGrGrPoly.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<ACGrGrPoly>()
 {
   InputParameters params = validParams<ACBulk>();
+  params.addClassDescription("Grain-Boundary model poly crystaline interface Allen-Cahn Kernel");
   params.addRequiredCoupledVar("v", "Array of coupled variable names");
   params.addCoupledVar("T", "temperature");
   return params;

--- a/modules/phase_field/src/kernels/ACInterface.C
+++ b/modules/phase_field/src/kernels/ACInterface.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<ACInterface>()
 {
   InputParameters params = validParams<KernelGrad>();
+  params.addClassDescription("Gradient energy Allen-Cahn Kernel");
   params.addParam<std::string>("mob_name", "L", "The mobility used with the kernel");
   params.addParam<std::string>("kappa_name", "kappa_op", "The kappa used with the kernel");
   return params;

--- a/modules/phase_field/src/kernels/ACMultiInterface.C
+++ b/modules/phase_field/src/kernels/ACMultiInterface.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<ACMultiInterface>()
 {
   InputParameters params = validParams<Kernel>();
+  params.addClassDescription("Gradient energy Allen-Cahn Kernel with cross terms");
   params.addRequiredCoupledVar("etas", "All eta_i order parameters of the multiphase problem");
   params.addRequiredParam<std::vector<std::string> >("kappa_names", "The kappa used with the kernel");
   params.addParam<std::string>("mob_name", "L", "The mobility used with the kernel");

--- a/modules/phase_field/src/kernels/ACParsed.C
+++ b/modules/phase_field/src/kernels/ACParsed.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<ACParsed>()
 {
   InputParameters params = DerivativeKernelInterface<ACBulk>::validParams();
+  params.addClassDescription("Allen-Cahn Kernel that uses a DerivativeMaterial Free Energy");
   params.addCoupledVar("args", "Vector of additional arguments to F");
   return params;
 }

--- a/modules/phase_field/src/kernels/CHBulk.C
+++ b/modules/phase_field/src/kernels/CHBulk.C
@@ -10,10 +10,10 @@ template<>
 InputParameters validParams<CHBulk>()
 {
   InputParameters params = validParams<KernelGrad>();
+  params.addClassDescription("Cahn-Hilliard Kernel");
   params.addParam<std::string>("mob_name", "M", "The mobility used with the kernel");
   params.addParam<std::string>("Dmob_name", "DM", "The D mobility used with the kernel");
   params.addParam<bool>("has_MJac", false, "Jacobian information for the mobility is defined");
-
   return params;
 }
 

--- a/modules/phase_field/src/kernels/CHInterface.C
+++ b/modules/phase_field/src/kernels/CHInterface.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<CHInterface>()
 {
   InputParameters params = validParams<Kernel>();
+  params.addClassDescription("Gradient energy Cahn-Hilliard Kernel");
   params.addRequiredParam<std::string>("kappa_name", "The kappa used with the kernel");
   params.addRequiredParam<std::string>("mob_name", "The mobility used with the kernel");
   params.addParam<std::string>("Dmob_name", "DM", "The D mobility used with the kernel");

--- a/modules/phase_field/src/kernels/CHMath.C
+++ b/modules/phase_field/src/kernels/CHMath.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<CHMath>()
 {
   InputParameters params = validParams<CHBulk>();
+  params.addClassDescription("Simple demonstration Cahn-Hilliard Kernel using an algebraic double-well potential");
   return params;
 }
 

--- a/modules/phase_field/src/kernels/CHParsed.C
+++ b/modules/phase_field/src/kernels/CHParsed.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<CHParsed>()
 {
   InputParameters params = DerivativeKernelInterface<CHBulk>::validParams();
+  params.addClassDescription("Cahn-Hilliard Kernel that uses a DerivativeMaterial Free Energy");
   params.addCoupledVar("args", "Vector of additional arguments to F");
   return params;
 }

--- a/modules/phase_field/src/kernels/ConservedLangevinNoise.C
+++ b/modules/phase_field/src/kernels/ConservedLangevinNoise.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<ConservedLangevinNoise>()
 {
   InputParameters params = validParams<LangevinNoise>();
+  params.addClassDescription("Source term for noise from a ConservativeNoise userobject");
   params.addRequiredParam<UserObjectName>("noise", "ConservativeNoise userobject that produces the random numbers");
   return params;
 }

--- a/modules/phase_field/src/kernels/CoupledImplicitEuler.C
+++ b/modules/phase_field/src/kernels/CoupledImplicitEuler.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<CoupledImplicitEuler>()
 {
   InputParameters params = validParams<Kernel>();
+  params.addClassDescription("Time derivative Kernel that acts on a coupled variable");
   params.addRequiredCoupledVar("v", "Coupled variable");
   return params;
 }

--- a/modules/phase_field/src/kernels/DoubleWellPotential.C
+++ b/modules/phase_field/src/kernels/DoubleWellPotential.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<DoubleWellPotential>()
 {
   InputParameters params = validParams<KernelValue>();
+  params.addClassDescription("Simple demonstration Allen-Cahn Kernel using an algebraic double-well potential");
   params.addParam<std::string>("mob_name", "L", "The mobility used with the kernel");
 
   return params;

--- a/modules/phase_field/src/kernels/LangevinNoise.C
+++ b/modules/phase_field/src/kernels/LangevinNoise.C
@@ -11,6 +11,7 @@ template<>
 InputParameters validParams<LangevinNoise>()
 {
   InputParameters params = validParams<Kernel>();
+  params.addClassDescription("Source term for non-conserved Langevin noise");
   params.addRequiredParam<Real>("amplitude", "Amplitude"); // per sqrt(time)");
   params.addParam<std::string>("multiplier", "Material property to multiply the random numbers with (defaults to 1.0 if omitted)");
   return params;

--- a/modules/phase_field/src/kernels/MatDiffusion.C
+++ b/modules/phase_field/src/kernels/MatDiffusion.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<MatDiffusion>()
 {
   InputParameters params = validParams<Diffusion>();
+  params.addClassDescription("Diffusion equation Kernel that takes teh Diffusivity from a material property");
   params.addParam<std::string>("D_name", "D", "The name of the diffusivity");
   return params;
 }

--- a/modules/phase_field/src/kernels/PFFracBulkRate.C
+++ b/modules/phase_field/src/kernels/PFFracBulkRate.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<PFFracBulkRate>()
 {
   InputParameters params = validParams<KernelValue>();
+  params.addClassDescription("Phase field based fracture model c residual for bulk free energy contribution");
   params.addRequiredParam<Real>("l","Interface width");
   params.addRequiredParam<Real>("visco","Viscosity parameter");
   params.addRequiredCoupledVar("beta", "Auxiliary variable");

--- a/modules/phase_field/src/kernels/PFFracBulkRate.C
+++ b/modules/phase_field/src/kernels/PFFracBulkRate.C
@@ -10,14 +10,13 @@ template<>
 InputParameters validParams<PFFracBulkRate>()
 {
   InputParameters params = validParams<KernelValue>();
-  params.addClassDescription("Phase field based fracture model c residual for bulk free energy contribution");
+  params.addClassDescription("Kernel to compute bulk energy contribution to damage order parameter residual equation");
   params.addRequiredParam<Real>("l","Interface width");
   params.addRequiredParam<Real>("visco","Viscosity parameter");
   params.addRequiredCoupledVar("beta", "Auxiliary variable");
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");
-  params.addClassDescription("Kernel to compute bulk energy contribution to damage order parameter residual equation");
 
   return params;
 }

--- a/modules/phase_field/src/kernels/PFFracBulkRate.C
+++ b/modules/phase_field/src/kernels/PFFracBulkRate.C
@@ -17,6 +17,7 @@ InputParameters validParams<PFFracBulkRate>()
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");
+  params.addClassDescription("Kernel to compute bulk energy contribution to damage order parameter residual equation");
 
   return params;
 }

--- a/modules/phase_field/src/kernels/PFFracCoupledInterface.C
+++ b/modules/phase_field/src/kernels/PFFracCoupledInterface.C
@@ -10,9 +10,8 @@ template<>
 InputParameters validParams<PFFracCoupledInterface>()
 {
   InputParameters params = validParams<KernelGrad>();
-  params.addClassDescription("Phase-field fracture residual for beta");
-  params.addRequiredCoupledVar("c", "Order parameter for damage");
   params.addClassDescription("Phase-field fracture residual for beta variable: Contribution from gradient of damage order parameter");
+  params.addRequiredCoupledVar("c", "Order parameter for damage");
 
   return params;
 }

--- a/modules/phase_field/src/kernels/PFFracCoupledInterface.C
+++ b/modules/phase_field/src/kernels/PFFracCoupledInterface.C
@@ -12,6 +12,8 @@ InputParameters validParams<PFFracCoupledInterface>()
   InputParameters params = validParams<KernelGrad>();
   params.addClassDescription("Phase-field fracture residual for beta");
   params.addRequiredCoupledVar("c", "Order parameter for damage");
+  params.addClassDescription("Phase-field fracture residual for beta variable: Contribution from gradient of damage order parameter");
+
   return params;
 }
 

--- a/modules/phase_field/src/kernels/PFFracCoupledInterface.C
+++ b/modules/phase_field/src/kernels/PFFracCoupledInterface.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<PFFracCoupledInterface>()
 {
   InputParameters params = validParams<KernelGrad>();
+  params.addClassDescription("Phase-field fracture residual for beta");
   params.addRequiredCoupledVar("c", "Order parameter for damage");
   return params;
 }
@@ -36,7 +37,7 @@ PFFracCoupledInterface::precomputeQpJacobian()
 }
 /**
  * Contributes only to the off-diagonal Jacobian term
- * for auxiliary variable beta
+ * for variable beta
  */
 Real
 PFFracCoupledInterface::computeQpOffDiagJacobian(unsigned int jvar)

--- a/modules/phase_field/src/kernels/PFFracIntVar.C
+++ b/modules/phase_field/src/kernels/PFFracIntVar.C
@@ -10,6 +10,8 @@ template<>
 InputParameters validParams<PFFracIntVar>()
 {
   InputParameters params = validParams<KernelValue>();
+  params.addClassDescription("Phase-field fracture residual for beta variable: Contribution from beta");
+
   return params;
 }
 

--- a/modules/phase_field/src/kernels/SplitCHCRes.C
+++ b/modules/phase_field/src/kernels/SplitCHCRes.C
@@ -10,10 +10,9 @@ template<>
 InputParameters validParams<SplitCHCRes>()
 {
   InputParameters params = validParams<SplitCHBase>();
-
+  params.addClassDescription("Split formulation Cahn-Hilliard Kernel");
   params.addRequiredCoupledVar("w", "chem poten");
   params.addRequiredParam<std::string>("kappa_name", "The kappa used with the kernel");
-
   return params;
 }
 

--- a/modules/phase_field/src/kernels/SplitCHMath.C
+++ b/modules/phase_field/src/kernels/SplitCHMath.C
@@ -10,7 +10,7 @@ template<>
 InputParameters validParams<SplitCHMath>()
 {
   InputParameters params = validParams<SplitCHCRes>();
-
+  params.addClassDescription("Simple demonstration split formulation Cahn-Hilliard Kernel using an algebraic double-well potential");
   return params;
 }
 

--- a/modules/phase_field/src/kernels/SplitCHParsed.C
+++ b/modules/phase_field/src/kernels/SplitCHParsed.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<SplitCHParsed>()
 {
   InputParameters params = DerivativeKernelInterface<SplitCHCRes>::validParams();
+  params.addClassDescription("Split formulation Cahn-Hilliard Kernel that uses a DerivativeMaterial Free Energy");
   params.addCoupledVar("args", "Vector of additional arguments to F");
   return params;
 }

--- a/modules/phase_field/src/kernels/SplitCHWRes.C
+++ b/modules/phase_field/src/kernels/SplitCHWRes.C
@@ -9,6 +9,7 @@ template<>
 InputParameters validParams<SplitCHWRes>()
 {
   InputParameters params = validParams<Kernel>();
+  params.addClassDescription("Split formulation Cahn-Hilliard Kernel for the chemical potential variable");
   params.addParam<std::string>("mob_name", "mobtemp", "The mobility used with the kernel");
   params.addCoupledVar("args", "Vector of arguments to mobility");
   return params;

--- a/modules/phase_field/src/materials/LinearIsoElasticPFDamage.C
+++ b/modules/phase_field/src/materials/LinearIsoElasticPFDamage.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<LinearIsoElasticPFDamage>()
 {
   InputParameters params = validParams<LinearElasticMaterial>();
+  params.addClassDescription("Phase-field fracture model energy contribution to damage growth");
   params.addRequiredCoupledVar("c","Order parameter for damage");
   params.addParam<Real>("kdamage",1e-6,"Stiffness of damaged matrix");
   return params;

--- a/modules/phase_field/src/materials/LinearIsoElasticPFDamage.C
+++ b/modules/phase_field/src/materials/LinearIsoElasticPFDamage.C
@@ -13,6 +13,8 @@ InputParameters validParams<LinearIsoElasticPFDamage>()
   params.addClassDescription("Phase-field fracture model energy contribution to damage growth");
   params.addRequiredCoupledVar("c","Order parameter for damage");
   params.addParam<Real>("kdamage",1e-6,"Stiffness of damaged matrix");
+  params.addClassDescription("Strain energy density in damaged isotropic elastic material - undamaged stress under compressive strain");
+
   return params;
 }
 

--- a/modules/phase_field/src/materials/LinearIsoElasticPFDamage.C
+++ b/modules/phase_field/src/materials/LinearIsoElasticPFDamage.C
@@ -10,10 +10,9 @@ template<>
 InputParameters validParams<LinearIsoElasticPFDamage>()
 {
   InputParameters params = validParams<LinearElasticMaterial>();
-  params.addClassDescription("Phase-field fracture model energy contribution to damage growth");
+  params.addClassDescription("Phase-field fracture model energy contribution to damage growth-isotropic elasticity and undamaged stress under compressive strain");
   params.addRequiredCoupledVar("c","Order parameter for damage");
   params.addParam<Real>("kdamage",1e-6,"Stiffness of damaged matrix");
-  params.addClassDescription("Strain energy density in damaged isotropic elastic material - undamaged stress under compressive strain");
 
   return params;
 }

--- a/modules/phase_field/src/materials/PFFracBulkRateMaterial.C
+++ b/modules/phase_field/src/materials/PFFracBulkRateMaterial.C
@@ -10,9 +10,9 @@ template<>
 InputParameters validParams<PFFracBulkRateMaterial>()
 {
   InputParameters params = validParams<Material>();
+  params.addClassDescription("Material properties used in phase-field fracture damage evolution kernel");
   params.addParam<FunctionName>("function", "", "Function describing energy release rate type parameter distribution");
   params.addParam<Real>("gc", 1.0, "Energy release rate type parameter");
-  params.addClassDescription("Material properties used in phase-field fracture damage parameter kernel");
 
   return params;
 }

--- a/modules/phase_field/src/materials/PFFracBulkRateMaterial.C
+++ b/modules/phase_field/src/materials/PFFracBulkRateMaterial.C
@@ -12,6 +12,7 @@ InputParameters validParams<PFFracBulkRateMaterial>()
   InputParameters params = validParams<Material>();
   params.addParam<FunctionName>("function", "", "Function describing energy release rate type parameter distribution");
   params.addParam<Real>("gc", 1.0, "Energy release rate type parameter");
+  params.addClassDescription("Material properties used in phase-field fracture damage parameter kernel");
 
   return params;
 }

--- a/modules/phase_field/src/mesh/EBSDMesh.C
+++ b/modules/phase_field/src/mesh/EBSDMesh.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<EBSDMesh>()
 {
   InputParameters params = validParams<GeneratedMesh>();
+  params.addClassDescription("Mesh generated from a specified EBSD data file");
   params.addRequiredParam<FileName>("filename", "The name of the file containing the EBSD data");
   params.addParam<unsigned int>("uniform_refine", 0, "Number of coarsening levels available in adaptive mesh refinement.");
 

--- a/modules/phase_field/src/mesh/ImageMesh.C
+++ b/modules/phase_field/src/mesh/ImageMesh.C
@@ -16,6 +16,7 @@ template<>
 InputParameters validParams<ImageMesh>()
 {
   InputParameters params = validParams<GeneratedMesh>();
+  params.addClassDescription("Generated mesh with the aspect ratio of a given image stack");
 
   // Add parameters associated with file ranges
   addFileRangeParams(params);

--- a/modules/tensor_mechanics/src/actions/PressureActionTM.C
+++ b/modules/tensor_mechanics/src/actions/PressureActionTM.C
@@ -14,6 +14,8 @@ template<>
 InputParameters validParams<PressureActionTM>()
 {
   InputParameters params = validParams<Action>();
+  params.addClassDescription("Set up PressureTM boundary conditions");
+
   params.addRequiredParam<std::vector<BoundaryName> >("boundary", "The list of boundary IDs from the mesh where the pressure will be applied");
   params.addRequiredParam<NonlinearVariableName>("disp_x", "The x displacement");
   params.addParam<NonlinearVariableName>("disp_y", "", "The y displacement");

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
@@ -14,6 +14,7 @@ template<>
 InputParameters validParams<TensorMechanicsAction>()
 {
   InputParameters params = validParams<Action>();
+  params.addClassDescription("Set up stress divergence kernels");
   params.addRequiredParam<NonlinearVariableName>("disp_x", "The x displacement");
   params.addParam<NonlinearVariableName>("disp_y", "The y displacement");
   params.addParam<NonlinearVariableName>("disp_z", "The z displacement");

--- a/modules/tensor_mechanics/src/auxkernels/CrystalPlasticityRotationOutAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/CrystalPlasticityRotationOutAux.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<CrystalPlasticityRotationOutAux>()
 {
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Access a component of a slip system vector property");
   params.addParam<FileName>("rotout_file_name", "rot.out", "Name of rotation output file: Default rot.out");
   params.addParam<unsigned int>("output_frequency", 1, "Frequency of Output");
   return params;

--- a/modules/tensor_mechanics/src/auxkernels/CrystalPlasticityRotationOutAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/CrystalPlasticityRotationOutAux.C
@@ -10,7 +10,7 @@ template<>
 InputParameters validParams<CrystalPlasticityRotationOutAux>()
 {
   InputParameters params = validParams<AuxKernel>();
-  params.addClassDescription("Access a component of a slip system vector property");
+  params.addClassDescription("Output updated rotation tensor to a file: Use for stereographic plots");
   params.addParam<FileName>("rotout_file_name", "rot.out", "Name of rotation output file: Default rot.out");
   params.addParam<unsigned int>("output_frequency", 1, "Frequency of Output");
   return params;

--- a/modules/tensor_mechanics/src/auxkernels/CrystalPlasticitySlipSysAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/CrystalPlasticitySlipSysAux.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<CrystalPlasticitySlipSysAux>()
 {
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Access a component of a slip system vector property");
   params.addRequiredParam<std::string>("slipsysvar", "The slip system variable name");
   params.addRequiredRangeCheckedParam<unsigned int>("index_i", "index_i != 0", "The slip system i");
   return params;

--- a/modules/tensor_mechanics/src/auxkernels/RankFourAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankFourAux.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<RankFourAux>()
 {
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Access a component of a RankFourTensor");
 
   //add stuff here
   params.addRequiredParam<std::string>("rank_four_tensor", "The rank four material tensor name");

--- a/modules/tensor_mechanics/src/auxkernels/RankTwoAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankTwoAux.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<RankTwoAux>()
 {
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Access a component of a RankTwoTensor");
   params.addRequiredParam<std::string>("rank_two_tensor", "The rank two material tensor name");
   params.addRequiredRangeCheckedParam<unsigned int>("index_i", "index_i >= 0 & index_i <= 2", "The index i of ij for the tensor to output (0, 1, 2)");
   params.addRequiredRangeCheckedParam<unsigned int>("index_j", "index_j >= 0 & index_j <= 2", "The index j of ij for the tensor to output (0, 1, 2)");

--- a/modules/tensor_mechanics/src/auxkernels/RankTwoScalarAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankTwoScalarAux.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<RankTwoScalarAux>()
 {
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Compute a scalar property of a RankTwoTensor");
   params.addRequiredParam<std::string>("rank_two_tensor", "The rank two material tensor name");
   MooseEnum scalar_options("VonMisesStress EquivalentPlasticStrain Hydrostatic L2norm");
   params.addParam<MooseEnum>("scalar_type", scalar_options, "Type of scalar output");

--- a/modules/tensor_mechanics/src/auxkernels/RankTwoScalarAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankTwoScalarAux.C
@@ -13,6 +13,7 @@ InputParameters validParams<RankTwoScalarAux>()
   params.addRequiredParam<std::string>("rank_two_tensor", "The rank two material tensor name");
   MooseEnum scalar_options("VonMisesStress EquivalentPlasticStrain Hydrostatic L2norm");
   params.addParam<MooseEnum>("scalar_type", scalar_options, "Type of scalar output");
+  params.addClassDescription("Auxkernel to evaluate scalar norms of Rank Two Tensors");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/auxkernels/RankTwoScalarAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankTwoScalarAux.C
@@ -14,7 +14,6 @@ InputParameters validParams<RankTwoScalarAux>()
   params.addRequiredParam<std::string>("rank_two_tensor", "The rank two material tensor name");
   MooseEnum scalar_options("VonMisesStress EquivalentPlasticStrain Hydrostatic L2norm");
   params.addParam<MooseEnum>("scalar_type", scalar_options, "Type of scalar output");
-  params.addClassDescription("Auxkernel to evaluate scalar norms of Rank Two Tensors");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/auxkernels/RealTensorValueAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RealTensorValueAux.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<RealTensorValueAux>()
 {
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Access a component of a RealTensorValue");
   params.addRequiredParam<std::string>("tensor", "The material tensor name");
   params.addRequiredRangeCheckedParam<unsigned int>("index_i", "index_i >= 0 & index_i <= 2", "The index i of ij for the tensor to output (0, 1, 2)");
   params.addRequiredRangeCheckedParam<unsigned int>("index_j", "index_j >= 0 & index_j <= 2", "The index j of ij for the tensor to output (0, 1, 2)");

--- a/modules/tensor_mechanics/src/auxkernels/TensorElasticEnergyAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/TensorElasticEnergyAux.C
@@ -10,6 +10,7 @@ template<>
 InputParameters validParams<TensorElasticEnergyAux>()
 {
   InputParameters params = validParams<AuxKernel>();
+  params.addClassDescription("Compute the local elastic energy");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
@@ -7,6 +7,7 @@ InputParameters validParams<StressDivergencePFFracTensors>()
   InputParameters params = validParams<StressDivergenceTensors>();
   params.addCoupledVar("c", "Phase field damage variable: Used to indicate calculation of Off Diagonal Jacobian term");
   params.addParam<std::string>("pff_jac_prop_name","","Name of property variable containing d_stress_d_c");
+  params.addClassDescription("Stress divergence kernel for phase-field fracture that additionally computes off diagonal damage dependent Jacobian components");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
@@ -6,7 +6,6 @@ InputParameters validParams<StressDivergencePFFracTensors>()
 {
   InputParameters params = validParams<StressDivergenceTensors>();
   params.addClassDescription("Stress divergence kernel for phase-field fracture: Additionally computes off diagonal damage dependent Jacobian components");
-  params.addClassDescription("Phase field fracture model stress divergence kernel");
   params.addCoupledVar("c", "Phase field damage variable: Used to indicate calculation of Off Diagonal Jacobian term");
   params.addParam<std::string>("pff_jac_prop_name","","Name of property variable containing d_stress_d_c");
 

--- a/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
@@ -5,10 +5,10 @@ template<>
 InputParameters validParams<StressDivergencePFFracTensors>()
 {
   InputParameters params = validParams<StressDivergenceTensors>();
+  params.addClassDescription("Stress divergence kernel for phase-field fracture: Additionally computes off diagonal damage dependent Jacobian components");
   params.addClassDescription("Phase field fracture model stress divergence kernel");
   params.addCoupledVar("c", "Phase field damage variable: Used to indicate calculation of Off Diagonal Jacobian term");
   params.addParam<std::string>("pff_jac_prop_name","","Name of property variable containing d_stress_d_c");
-  params.addClassDescription("Stress divergence kernel for phase-field fracture that additionally computes off diagonal damage dependent Jacobian components");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
@@ -5,6 +5,7 @@ template<>
 InputParameters validParams<StressDivergencePFFracTensors>()
 {
   InputParameters params = validParams<StressDivergenceTensors>();
+  params.addClassDescription("Phase field fracture model stress divergence kernel");
   params.addCoupledVar("c", "Phase field damage variable: Used to indicate calculation of Off Diagonal Jacobian term");
   params.addParam<std::string>("pff_jac_prop_name","","Name of property variable containing d_stress_d_c");
   params.addClassDescription("Stress divergence kernel for phase-field fracture that additionally computes off diagonal damage dependent Jacobian components");

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
@@ -12,6 +12,7 @@ template<>
 InputParameters validParams<StressDivergenceTensors>()
 {
   InputParameters params = validParams<Kernel>();
+  params.addClassDescription("Stress divergence kernel (used by the TensorMechanics action)");
   params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction the variable this kernel acts in. (0 for x, 1 for y, 2 for z)");
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");

--- a/modules/tensor_mechanics/src/materials/ElementPropertyReadFileTest.C
+++ b/modules/tensor_mechanics/src/materials/ElementPropertyReadFileTest.C
@@ -11,9 +11,9 @@ template<>
 InputParameters validParams<ElementPropertyReadFileTest>()
 {
   InputParameters params = validParams<FiniteStrainElasticMaterial>();
-  params.addParam<UserObjectName>("read_prop_user_object","The ElementReadPropertyFile GeneralUserObject to read element specific property values from file");
   params.addClassDescription("Material class to test ElementPropertyReadFile User Object");
-
+  params.addParam<UserObjectName>("read_prop_user_object","The ElementReadPropertyFile GeneralUserObject to read element specific property values from file");
+  
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ElementPropertyReadFileTest.C
+++ b/modules/tensor_mechanics/src/materials/ElementPropertyReadFileTest.C
@@ -13,7 +13,7 @@ InputParameters validParams<ElementPropertyReadFileTest>()
   InputParameters params = validParams<FiniteStrainElasticMaterial>();
   params.addClassDescription("Material class to test ElementPropertyReadFile User Object");
   params.addParam<UserObjectName>("read_prop_user_object","The ElementReadPropertyFile GeneralUserObject to read element specific property values from file");
-  
+
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ElementPropertyReadFileTest.C
+++ b/modules/tensor_mechanics/src/materials/ElementPropertyReadFileTest.C
@@ -12,6 +12,8 @@ InputParameters validParams<ElementPropertyReadFileTest>()
 {
   InputParameters params = validParams<FiniteStrainElasticMaterial>();
   params.addParam<UserObjectName>("read_prop_user_object","The ElementReadPropertyFile GeneralUserObject to read element specific property values from file");
+  params.addClassDescription("Material class to test ElementPropertyReadFile User Object");
+
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -11,7 +11,7 @@ template<>
 InputParameters validParams<FiniteStrainCrystalPlasticity>()
 {
   InputParameters params = validParams<FiniteStrainMaterial>();
-
+  params.addClassDescription("Crystal Plasticity base class: FCC system with power law flow rule implemented");
   params.addRequiredParam<int >("nss", "Number of slip systems");
   params.addParam<std::vector<Real> >("gprops", "Initial values of slip system resistances");
   params.addParam<std::vector<Real> >("hprops", "Hardening properties");
@@ -38,7 +38,6 @@ InputParameters validParams<FiniteStrainCrystalPlasticity>()
   params.addParam<Real>("random_scaling_var", 1e9, "Random scaling variable: Large value can cause non-positive definiteness");
   params.addParam<unsigned int>("random_seed", 2000, "Random integer used to generate random stress when constitutive failure occurs");
   params.addParam<unsigned int>("maximum_substep_iteration", 1, "Maximum number of substep iteration");
-  params.addClassDescription("Crystal Plasticity base class: FCC system with power law flow rule implemented");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -38,6 +38,7 @@ InputParameters validParams<FiniteStrainCrystalPlasticity>()
   params.addParam<Real>("random_scaling_var", 1e9, "Random scaling variable: Large value can cause non-positive definiteness");
   params.addParam<unsigned int>("random_seed", 2000, "Random integer used to generate random stress when constitutive failure occurs");
   params.addParam<unsigned int>("maximum_substep_iteration", 1, "Maximum number of substep iteration");
+  params.addClassDescription("Crystal Plasticity base class: FCC system with power law flow rule implemented");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/materials/FiniteStrainMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainMaterial.C
@@ -12,6 +12,7 @@ template<>
 InputParameters validParams<FiniteStrainMaterial>()
 {
   InputParameters params = validParams<TensorMechanicsMaterial>();
+  params.addClassDescription("Computes incremental strain and deformation gradient for finite deformation");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/FiniteStrainRatePlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainRatePlasticMaterial.C
@@ -22,7 +22,7 @@ InputParameters validParams<FiniteStrainRatePlasticMaterial>()
   params.addClassDescription("Associative rate dependent J2 plasticity with isotropic hardening: Overstress based on Perzyna model");
   params.addRequiredParam< Real >("ref_pe_rate", "Reference plastic strain rate parameter for rate dependent plasticity (Overstress model)");
   params.addRequiredParam< Real >("exponent", "Exponent for rate dependent plasticity (Perzyna)");
-  
+
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/FiniteStrainRatePlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainRatePlasticMaterial.C
@@ -22,6 +22,7 @@ InputParameters validParams<FiniteStrainRatePlasticMaterial>()
 
   params.addRequiredParam< Real >("ref_pe_rate", "Reference plastic strain rate parameter for rate dependent plasticity (Overstress model)");
   params.addRequiredParam< Real >("exponent", "Exponent for rate dependent plasticity (Perzyna)");
+  params.addClassDescription("Associative rate dependent J2 plasticity with isotropic hardening: Overstress based on Perzyna model");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/materials/FiniteStrainRatePlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainRatePlasticMaterial.C
@@ -19,11 +19,10 @@ template<>
 InputParameters validParams<FiniteStrainRatePlasticMaterial>()
 {
   InputParameters params = validParams<FiniteStrainPlasticMaterial>();
-
+  params.addClassDescription("Associative rate dependent J2 plasticity with isotropic hardening: Overstress based on Perzyna model");
   params.addRequiredParam< Real >("ref_pe_rate", "Reference plastic strain rate parameter for rate dependent plasticity (Overstress model)");
   params.addRequiredParam< Real >("exponent", "Exponent for rate dependent plasticity (Perzyna)");
-  params.addClassDescription("Associative rate dependent J2 plasticity with isotropic hardening: Overstress based on Perzyna model");
-
+  
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/MultiPhaseStressMaterial.C
+++ b/modules/tensor_mechanics/src/materials/MultiPhaseStressMaterial.C
@@ -12,9 +12,10 @@ template<>
 InputParameters validParams<MultiPhaseStressMaterial>()
 {
   InputParameters params = validParams<Material>();
+  params.addClassDescription("Compute a global stress form multiple phase stresses");
   params.addParam<std::vector<std::string> >("h", "Switching Function Materials that provide h(eta_i)");
-  params.addRequiredParam<std::vector<std::string> >("phase_base", "Base names for the Phase strains.");
-  params.addParam<std::string>("base_name", "Base name for the computed global stress (optional).");
+  params.addRequiredParam<std::vector<std::string> >("phase_base", "Base names for the Phase strains");
+  params.addParam<std::string>("base_name", "Base name for the computed global stress (optional)");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/SimpleEigenStrainMaterial.C
+++ b/modules/tensor_mechanics/src/materials/SimpleEigenStrainMaterial.C
@@ -12,6 +12,7 @@ template<>
 InputParameters validParams<SimpleEigenStrainMaterial>()
 {
   InputParameters params = validParams<EigenStrainBaseMaterial>();
+  params.addClassDescription("Compute a concentration dependent isotropic Eigenstrain");
   params.addRequiredParam<Real>("epsilon0", "Initial eigen strain value");
   params.addParam<Real>("c0", 0.0, "Initial concentration value");
   params.addRequiredCoupledVar("c", "Concentration");

--- a/modules/tensor_mechanics/src/materials/TwoPhaseStressMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TwoPhaseStressMaterial.C
@@ -12,6 +12,7 @@ template<>
 InputParameters validParams<TwoPhaseStressMaterial>()
 {
   InputParameters params = validParams<Material>();
+  params.addClassDescription("Compute a global stress in a two phase model");
   params.addParam<std::string>("h", "h", "Switching Function Material that provides h(eta)");
   params.addRequiredParam<std::string>("base_A", "Base name for the Phase A strain.");
   params.addRequiredParam<std::string>("base_B", "Base name for the Phase B strain.");

--- a/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
+++ b/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
@@ -19,6 +19,7 @@ InputParameters validParams<ElementPropertyReadFile>()
   params.addParam<unsigned int>("rand_seed", 2000, "random seed");
   MooseEnum rve_options("periodic none","none");
   params.addParam<MooseEnum>("rve_type",rve_options , "Periodic or non-periodic grain distribution: Default is non-periodic");
+  params.addClassDescription("User Object to read property data from an external file and assign to elements: Works only for Rectangular geometry (2D-3D)");
 
   return params;
 }
@@ -33,9 +34,6 @@ ElementPropertyReadFile::ElementPropertyReadFile(const std::string & name, Input
     _rve_type(getParam<MooseEnum>("rve_type")),
     _mesh(_fe_problem.mesh())
 {
-
-  mooseWarning("Works only for Rectangular geometry (2D-3D)");
-
   _nelem = _mesh.nElem();
 
   for (unsigned int i = 0; i < LIBMESH_DIM; i++)

--- a/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
+++ b/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
@@ -15,13 +15,9 @@ InputParameters validParams<ElementPropertyReadFile>()
   params.addParam<std::string>("prop_file_name", "", "Name of the property file name");
   params.addRequiredParam<unsigned int>("nprop", "Number of tabulated property values");
   params.addParam<unsigned int>("ngrain", 0, "Number of grains");
-  MooseEnum read_options("element grain none", "none");
-  params.addParam<MooseEnum>("read_type", read_options, "Type of property distribution: element:element by element property variation; grain:voronoi grain structure");
+  params.addParam<MooseEnum>("read_type", MooseEnum("element grain none", "none"), "Type of property distribution: element:element by element property variation; grain:voronoi grain structure");
   params.addParam<unsigned int>("rand_seed", 2000, "random seed");
-  MooseEnum rve_options("periodic none","none");
-  params.addParam<MooseEnum>("rve_type",rve_options , "Periodic or non-periodic grain distribution: Default is non-periodic");
-  MooseEnum rve_options("periodic none", "none");
-  params.addParam<MooseEnum>("rve_type", rve_options, "Periodic or non-periodic grain distribution: Default is non-periodic");
+  params.addParam<MooseEnum>("rve_type", MooseEnum("periodic none", "none"), "Periodic or non-periodic grain distribution: Default is non-periodic");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
+++ b/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
@@ -11,16 +11,17 @@ template<>
 InputParameters validParams<ElementPropertyReadFile>()
 {
   InputParameters params = validParams<GeneralUserObject>();
+  params.addClassDescription("User Object to read property data from an external file and assign to elements: Works only for Rectangular geometry (2D-3D)");
   params.addParam<std::string>("prop_file_name", "", "Name of the property file name");
   params.addRequiredParam<unsigned int>("nprop", "Number of tabulated property values");
-  params.addParam<unsigned int>("ngrain",0,"Number of grains");
-  MooseEnum read_options("element grain none","none");
+  params.addParam<unsigned int>("ngrain", 0, "Number of grains");
+  MooseEnum read_options("element grain none", "none");
   params.addParam<MooseEnum>("read_type", read_options, "Type of property distribution: element:element by element property variation; grain:voronoi grain structure");
   params.addParam<unsigned int>("rand_seed", 2000, "random seed");
   MooseEnum rve_options("periodic none","none");
   params.addParam<MooseEnum>("rve_type",rve_options , "Periodic or non-periodic grain distribution: Default is non-periodic");
-  params.addClassDescription("User Object to read property data from an external file and assign to elements: Works only for Rectangular geometry (2D-3D)");
-
+  MooseEnum rve_options("periodic none", "none");
+  params.addParam<MooseEnum>("rve_type", rve_options, "Periodic or non-periodic grain distribution: Default is non-periodic");
   return params;
 }
 
@@ -44,34 +45,27 @@ ElementPropertyReadFile::ElementPropertyReadFile(const std::string & name, Input
   }
 
   for (unsigned int i = 1; i < LIBMESH_DIM; i++)
-    if ( _range(i) > _max_range )
+    if (_range(i) > _max_range)
       _max_range = _range(i);
-
 
   switch (_read_type)
   {
+    case 0:
+      readElementData();
+      break;
 
-  case 0:
-    readElementData();
-    break;
-  case 1:
-    readGrainData();
-    break;
-  default:
-    mooseError("Error ElementPropertyReadFile: Provide valid read type");
+    case 1:
+      readGrainData();
+      break;
 
-
+    default:
+      mooseError("Error ElementPropertyReadFile: Provide valid read type");
   }
-
-
-
 }
-
 
 void
 ElementPropertyReadFile::readElementData()
 {
-
   _data.resize(_nprop * _nelem);
 
   MooseUtils::checkFileReadable(_prop_file_name);
@@ -79,25 +73,21 @@ ElementPropertyReadFile::readElementData()
   std::ifstream file_prop;
   file_prop.open(_prop_file_name.c_str());
 
-  for ( unsigned int i=0; i < _nelem; i++)
+  for ( unsigned int i = 0; i < _nelem; i++)
     for ( unsigned int j = 0; j < _nprop; j++ )
-      if (!(file_prop >> _data[ i * _nprop + j]))
+      if (!(file_prop >> _data[i*_nprop + j]))
         mooseError("Error ElementPropertyReadFile: Premature end of file");
 
   file_prop.close();
-
 }
-
 
 void
 ElementPropertyReadFile::readGrainData()
 {
   mooseAssert( _ngrain > 0, "Error ElementPropertyReadFile: Provide non-zero number of grains" );
-
   _data.resize(_nprop * _ngrain);
 
   MooseUtils::checkFileReadable(_prop_file_name);
-
   std::ifstream file_prop;
   file_prop.open(_prop_file_name.c_str());
 
@@ -107,136 +97,92 @@ ElementPropertyReadFile::readGrainData()
         mooseError("Error ElementPropertyReadFile: Premature end of file");
 
   file_prop.close();
-
-
   initGrainCenterPoints();
-
-
 }
-
 
 void
 ElementPropertyReadFile::initGrainCenterPoints()
 {
-
   _center.resize(_ngrain);
-
   MooseRandom::seed(_rand_seed);
-
-    for ( unsigned int i = 0; i < _ngrain; i++ )
-      for ( unsigned int j = 0; j < LIBMESH_DIM; j++ )
-        _center[i](j) = _bottom_left(j) + MooseRandom::rand()*_range(j);
-
+  for ( unsigned int i = 0; i < _ngrain; i++ )
+    for ( unsigned int j = 0; j < LIBMESH_DIM; j++ )
+      _center[i](j) = _bottom_left(j) + MooseRandom::rand()*_range(j);
 }
-
 
 Real
 ElementPropertyReadFile::getData( const Elem * elem , unsigned int prop_num ) const
 {
-
-  Real val = 0.0;
-
   switch (_read_type)
   {
+    case 0:
+      return getElementData(elem , prop_num);
 
-  case 0:
-    val =  getElementData(elem , prop_num);
-    break;
-  case 1:
-    val =  getGrainData(elem, prop_num);
-    break;
-  default:
-    mooseError("Error ElementPropertyReadFile: Provide valid read type");
-
-
+    case 1:
+      return getGrainData(elem, prop_num);
   }
-
-  return val;
-
+  mooseError("Error ElementPropertyReadFile: Provide valid read type");
 }
-
 
 Real
 ElementPropertyReadFile::getElementData(const Elem * elem , unsigned int prop_num) const
 {
-
   unsigned int jelem = elem->id();
-
   mooseAssert( jelem < _nelem , "Error ElementPropertyReadFile: Element " << jelem << " greater than than total number of element in mesh " << _nelem );
   mooseAssert( prop_num < _nprop , "Error ElementPropertyReadFile: Property number " << prop_num << " greater than than total number of properties " << _nprop );
-
   return _data[ jelem * _nprop + prop_num ];
-
 }
-
 
 Real
 ElementPropertyReadFile::getGrainData(const Elem * elem , unsigned int prop_num) const
 {
-
   mooseAssert( prop_num < _nprop , "Error ElementPropertyReadFile: Property number " << prop_num << " greater than than total number of properties " << _nprop << "\n");
 
   Point centroid = elem->centroid();
-
   Real min_dist = _max_range;
   unsigned int igrain = 0;
 
-  for ( unsigned int i = 0; i < _ngrain; i++ )
+  for (unsigned int i = 0; i < _ngrain; ++i)
   {
-
-    Point center = _center[i];
     Real dist = 0.0;
-
     switch ( _rve_type )
     {
-    case 0:
-      //Calculates minimum periodic distance when "periodic" is specified
-      //for rve_type
-      dist = minPeriodicDistance( _center[i], centroid);
-      break;
-    default:
-      //Calculates minimum distance when nothing is specified
-      //for rve_type
-      Point dist_vec = _center[i] - centroid;
-      dist = dist_vec.size();
+      case 0:
+        //Calculates minimum periodic distance when "periodic" is specified
+        //for rve_type
+        dist = minPeriodicDistance(_center[i], centroid);
+        break;
+
+      default:
+        //Calculates minimum distance when nothing is specified
+        //for rve_type
+        Point dist_vec = _center[i] - centroid;
+        dist = dist_vec.size();
     }
 
-    if ( dist < min_dist )
+    if (dist < min_dist)
     {
       min_dist = dist;
       igrain = i;
-
     }
-
-
-
   }
 
-
-  return _data[ igrain * _nprop + prop_num ];
-
+  return _data[igrain * _nprop + prop_num];
 }
 
+// TODO: this should probably use the built-in min periodic distance!
 Real
 ElementPropertyReadFile::minPeriodicDistance(Point c, Point p) const
 {
-
   Point dist_vec = c - p;
   Real min_dist = dist_vec.size();
 
-  Real fac[3];
-  fac[0] = -1.0;
-  fac[1] = 0.0;
-  fac[2] = 1.0;
-
-  Point p1;
-
+  Real fac[3] = {-1.0, 0.0, 1.0};
   for ( unsigned int i = 0; i < 3; i++ )
     for ( unsigned int j = 0; j < 3; j++ )
       for ( unsigned int k = 0; k < 3; k++ )
       {
         Point p1;
-
         p1(0) = p(0) + fac[i] * _range(0);
         p1(1) = p(1) + fac[j] * _range(1);
         p1(2) = p(2) + fac[k] * _range(2);
@@ -245,9 +191,7 @@ ElementPropertyReadFile::minPeriodicDistance(Point c, Point p) const
         Real dist = dist_vec.size();
 
         if ( dist < min_dist ) min_dist = dist;
-
       }
 
   return min_dist;
-
 }


### PR DESCRIPTION
This adds missing class descriptions to the phase field module. I'll look at tensor mechanics next...

Refs #5195
