### PR TITLE
SNESGetFunctionDomainError was added in PETSc 3.3

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -325,10 +325,10 @@ PetscErrorCode petscNonlinearConverged(SNES snes, PetscInt it, PetscReal xnorm, 
   ierr = SNESGetNumberFunctionEvals(snes, &nfuncs);
   CHKERRABORT(problem.comm().get(),ierr);
 
-  // See if SNESSetFunctionDomainError() has been called.  We guard
-  // this for pre-3.0.0 versions of PETSc in other parts of the code,
-  // so we'll do the same here.
-#if !PETSC_VERSION_LESS_THAN(3,0,0)
+  // See if SNESSetFunctionDomainError() has been called.  Note:
+  // SNESSetFunctionDomainError() and SNESGetFunctionDomainError()
+  // were added in different releases of PETSc.
+#if !PETSC_VERSION_LESS_THAN(3,3,0)
   PetscBool domainerror;
   ierr = SNESGetFunctionDomainError(snes, &domainerror);
   CHKERRABORT(problem.comm().get(),ierr);


### PR DESCRIPTION
Note: to figure out when functions were first added to PETSc, first find the first commit that added them with 'git log -S' then run:

git tag --contains <hash>

to figure out which releases contain that hash. For SNESGetFunctionDomainError, the relevant commit in the PETSc repo is 6a388c361ff.
