### PR TITLE
Add Fillmethod, default to autodetect

### DIFF
--- a/modules/tensor_mechanics/include/utils/RankTwoTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoTensor.h
@@ -59,6 +59,20 @@ public:
   RankTwoTensor(const InitMethod);
 
   /**
+   * To fill up the 9 entries in the 2nd-order tensor, fillFromInputVector
+   * is called with one of the following fill_methods.
+   * See the fill*FromInputVector functions for more details
+   */
+  enum FillMethod
+  {
+    autodetect = 0,
+    isotropic1 = 1,
+    diagonal3  = 3,
+    symmetric6 = 6,
+    general    = 9
+  };
+
+  /**
    * Constructor that takes in 3 vectors and uses them to create rows
    * _vals[0][i] = row1(i), _vals[1][i] = row2(i), _vals[2][i] = row3(i)
    */
@@ -91,6 +105,9 @@ public:
   /// zeroes all _vals components
   void zero();
 
+  /// Static method for use in validParams for getting the "fill_method"
+  static MooseEnum fillMethodEnum();
+
   /**
   * fillFromInputVector takes 6 or 9 inputs to fill in the Rank-2 tensor.
   * If 6 inputs, then symmetry is assumed S_ij = S_ji, and
@@ -102,7 +119,7 @@ public:
   *   _vals[0][1] = input[5]
   * If 9 inputs then input order is [0][0], [1][0], [2][0], [0][1], [1][1], ..., [2][2]
   */
-  void fillFromInputVector(const std::vector<Real> & input);
+  void fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method = autodetect);
 
 public:
   /// returns _vals[r][i], ie, row r, with r = 0, 1, 2

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -19,6 +19,12 @@ void mooseSetToZero<RankTwoTensor>(RankTwoTensor & v)
   v.zero();
 }
 
+MooseEnum
+RankTwoTensor::fillMethodEnum()
+{
+  return MooseEnum("autodetect=0 isotropic1=1 diagonal3=3 symmetric6=6 general=9", "autodetect");
+}
+
 RankTwoTensor::RankTwoTensor()
 {
   mooseAssert(N == 3, "RankTwoTensor is currently only tested for 3 dimensions.");
@@ -116,31 +122,51 @@ RankTwoTensor::zero()
 }
 
 void
-RankTwoTensor::fillFromInputVector(const std::vector<Real> & input)
+RankTwoTensor::fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method)
 {
-  if (input.size() == 6)
+  if (fill_method != autodetect && fill_method != input.size())
+    mooseError("Expected an input vector size of " << fill_method << " to fill the RankTwoTensor");
+
+  switch (input.size())
   {
-    _vals[0][0] = input[0]; //S11
-    _vals[1][1] = input[1]; //S22
-    _vals[2][2] = input[2]; //S33
-    _vals[1][2] = _vals[2][1] = input[3]; //S23
-    _vals[0][2] = _vals[2][0] = input[4]; //S13
-    _vals[0][1] = _vals[1][0] = input[5]; //S12
+    case 1:
+      zero();
+      _vals[0][0] = input[0]; //S11
+      _vals[1][1] = input[0]; //S22
+      _vals[2][2] = input[0]; //S33
+      break;
+
+    case 3:
+      zero();
+      _vals[0][0] = input[0]; //S11
+      _vals[1][1] = input[1]; //S22
+      _vals[2][2] = input[2]; //S33
+      break;
+
+    case 6:
+      _vals[0][0] = input[0]; //S11
+      _vals[1][1] = input[1]; //S22
+      _vals[2][2] = input[2]; //S33
+      _vals[1][2] = _vals[2][1] = input[3]; //S23
+      _vals[0][2] = _vals[2][0] = input[4]; //S13
+      _vals[0][1] = _vals[1][0] = input[5]; //S12
+      break;
+
+    case 9:
+      _vals[0][0] = input[0]; //S11
+      _vals[1][0] = input[1]; //S21
+      _vals[2][0] = input[2]; //S31
+      _vals[0][1] = input[3]; //S12
+      _vals[1][1] = input[4]; //S22
+      _vals[2][1] = input[5]; //S32
+      _vals[0][2] = input[6]; //S13
+      _vals[1][2] = input[7]; //S23
+      _vals[2][2] = input[8]; //S33
+      break;
+
+    default:
+      mooseError("Please check the number of entries in the input vecto for building a RankTwoTensor. It must be 1, 3, 6, or 9");
   }
-  else if (input.size() == 9)
-  {
-    _vals[0][0] = input[0]; //S11
-    _vals[1][0] = input[1]; //S21
-    _vals[2][0] = input[2]; //S31
-    _vals[0][1] = input[3]; //S12
-    _vals[1][1] = input[4]; //S22
-    _vals[2][1] = input[5]; //S32
-    _vals[0][2] = input[6]; //S13
-    _vals[1][2] = input[7]; //S23
-    _vals[2][2] = input[8]; //S33
-  }
-  else
-    mooseError("Please check the number of entries in the eigenstrain input vector.  It must be 6 or 9");
 }
 
 TypeVector<Real>


### PR DESCRIPTION
This allows users to explicitly specify the fill method (and associated input vector size) to allow splitting vector parameters into multiple input vectors to fill a vector of tensors. The default behavior is autodetect, which now accepts size 1 and 3 vectors as well.
Ping @WilkAndy, @tonkmr

Closes #5206
