### PR TITLE
Add MooseEnum -> MultiMooseEnum constructor

### DIFF
--- a/framework/include/utils/MooseEnum.h
+++ b/framework/include/utils/MooseEnum.h
@@ -44,6 +44,11 @@ public:
    */
   MooseEnum(const MooseEnum & other_enum);
 
+  /**
+   * Named constructor to build a MultiMooseEnum with the names taken from a MooseEnum
+   */
+  static MooseEnum withNamesFrom(const MooseEnumBase & other_enum);
+
   virtual ~MooseEnum();
 
   /**
@@ -98,6 +103,12 @@ private:
    * Private constructor for use by libmesh::Parameters
    */
   MooseEnum();
+
+  /**
+   * Private constructor that can accept a MooseEnumBase for ::withOptionsFrom()
+   * @param other_enum - MooseEnumBase type to copy names and out-of-range data from
+   */
+  MooseEnum(const MooseEnumBase & other_enum);
 
   /// The current id
   int _current_id;

--- a/framework/include/utils/MooseEnum.h
+++ b/framework/include/utils/MooseEnum.h
@@ -45,7 +45,9 @@ public:
   MooseEnum(const MooseEnum & other_enum);
 
   /**
-   * Named constructor to build a MultiMooseEnum with the names taken from a MooseEnum
+   * Named constructor to build an empty MooseEnum with only the valid names
+   * and the allow_out_of_range flag taken from another enumeration
+   * @param other_enum - The other enumeration to copy the validity checking data from
    */
   static MooseEnum withNamesFrom(const MooseEnumBase & other_enum);
 

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -49,7 +49,9 @@ public:
   MultiMooseEnum(const MultiMooseEnum & other_enum);
 
   /**
-   * Named constructor to build a MultiMooseEnum with the names taken from a MooseEnum
+   * Named constructor to build an empty MultiMooseEnum with only the
+   * valid names and the allow_out_of_range flag taken from another enumeration
+   * @param other_enum - The other enumeration to copy the validity checking data from
    */
   static MultiMooseEnum withNamesFrom(const MooseEnumBase & other_enum);
 

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -48,6 +48,11 @@ public:
    */
   MultiMooseEnum(const MultiMooseEnum & other_enum);
 
+  /**
+   * Named constructor to build a MultiMooseEnum with the names taken from a MooseEnum
+   */
+  static MultiMooseEnum withNamesFrom(const MooseEnumBase & other_enum);
+
   virtual ~MultiMooseEnum();
 
   ///@{
@@ -168,6 +173,12 @@ private:
    * Private constructor for use by libmesh::Parameters
    */
   MultiMooseEnum();
+
+  /**
+   * Private constructor that can accept a MooseEnumBase for ::withOptionsFrom()
+   * @param other_enum - MooseEnumBase type to copy names and out-of-range data from
+   */
+  MultiMooseEnum(const MooseEnumBase & other_enum);
 
   /**
    * Helper method for all inserts and assignment operators

--- a/framework/src/utils/MooseEnum.C
+++ b/framework/src/utils/MooseEnum.C
@@ -38,11 +38,22 @@ MooseEnum::MooseEnum(const MooseEnum & other_enum) :
 {
 }
 
+MooseEnum
+MooseEnum::withNamesFrom(const MooseEnumBase & other_enum)
+{
+  return MooseEnum(other_enum);
+}
+
 /**
  * Private constuctor for use by libmesh::Parameters
  */
 MooseEnum::MooseEnum() :
     _current_id(INVALID_ID)
+{
+}
+
+MooseEnum::MooseEnum(const MooseEnumBase & other_enum) :
+    MooseEnumBase(other_enum)
 {
 }
 

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -38,10 +38,21 @@ MultiMooseEnum::MultiMooseEnum(const MultiMooseEnum & other_enum) :
 {
 }
 
+MultiMooseEnum
+MultiMooseEnum::withNamesFrom(const MooseEnumBase & other_enum)
+{
+  return MultiMooseEnum(other_enum);
+}
+
 /**
  * Private constuctor for use by libmesh::Parameters
  */
 MultiMooseEnum::MultiMooseEnum()
+{
+}
+
+MultiMooseEnum::MultiMooseEnum(const MooseEnumBase & other_enum) :
+    MooseEnumBase(other_enum)
 {
 }
 

--- a/unit/include/MooseEnumTest.h
+++ b/unit/include/MooseEnumTest.h
@@ -25,12 +25,14 @@ class MooseEnumTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE( MooseEnumTest );
 
   CPPUNIT_TEST( multiTestOne );
+  CPPUNIT_TEST( withNamesFromTest );
   CPPUNIT_TEST( testErrors );
 
   CPPUNIT_TEST_SUITE_END();
 
 public:
   void multiTestOne();
+  void withNamesFromTest();
   void testErrors();
 };
 

--- a/unit/src/MooseEnumTest.C
+++ b/unit/src/MooseEnumTest.C
@@ -117,6 +117,67 @@ MooseEnumTest::multiTestOne()
 }
 
 void
+MooseEnumTest::withNamesFromTest()
+{
+  //
+  // Construct MultiMooseEnum from MooseEnum
+  //
+  MooseEnum me1("one two three four");
+  MultiMooseEnum mme1 = MultiMooseEnum::withNamesFrom(me1);
+
+  // set in-range values
+  mme1 = "one two";
+  CPPUNIT_ASSERT( mme1.contains("one") == true );
+  CPPUNIT_ASSERT( mme1.contains("two") == true );
+  CPPUNIT_ASSERT( mme1.contains("three") == false );
+  CPPUNIT_ASSERT( mme1.contains("four") == false );
+
+  // set out-of-range values
+  try
+  {
+    mme1 = "five";
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+    CPPUNIT_ASSERT( msg.find("Invalid option") != std::string::npos );
+  }
+
+  // construct mme with out-of-range-allowed
+  MooseEnum me2("one two three four", "", true);
+  MultiMooseEnum mme2 = MultiMooseEnum::withNamesFrom(me2);
+  mme2 = "six";
+  CPPUNIT_ASSERT( mme2.contains("six") == true );
+
+  //
+  // Construct MooseEnum from MultiMooseEnum
+  //
+  MultiMooseEnum mme3("one two three four");
+  MooseEnum me3 = MooseEnum::withNamesFrom(mme3);
+
+  // set in-range values
+  me3 = "one";
+  CPPUNIT_ASSERT( me3 == "one" );
+
+  // set out-of-range values
+  try
+  {
+    me3 = "five";
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+    CPPUNIT_ASSERT( msg.find("Invalid option") != std::string::npos );
+  }
+
+  // construct mme with out-of-range-allowed
+  MultiMooseEnum mme4("one two three four", "", true);
+  MooseEnum me4 = MooseEnum::withNamesFrom(mme4);
+  me4 = "six";
+  CPPUNIT_ASSERT( me4 == "six" );
+}
+
+void
 MooseEnumTest::testErrors()
 {
   // Assign invalid item


### PR DESCRIPTION
The constructor actually takes a MooseEnumBase, which makes the implementation rather simple. The copy constructor is an "overload" for a more derived type, so it should not interfere.
Also added a unit test.

Closes #5214
