### PR TITLE
Fixes for parallel exception residual and jacobian tests.

### DIFF
--- a/modules/richards/tests/gravity_head_2/gh03.i
+++ b/modules/richards/tests/gravity_head_2/gh03.i
@@ -263,9 +263,8 @@
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-10 1E-10 10000'
+    petsc_options_iname = '-pc_factor_shift_type'
+    petsc_options_value = 'nonzero'
   [../]
 []
 

--- a/test/include/kernels/ExceptionKernel.h
+++ b/test/include/kernels/ExceptionKernel.h
@@ -40,11 +40,14 @@ protected:
     INITIAL_CONDITION
   } _when;
 
-  /// Counter for the number of computeQpResidual calls
-  unsigned int _call_no;
+  /// True once the residual has thrown
+  bool _res_has_thrown;
 
-  /// Counter for the number of computeQpJacobian calls
-  unsigned int _jac_call_no;
+  /// True once the Jacobian has thrown
+  bool _jac_has_thrown;
+
+  /// Function which returns true if it's time to throw
+  bool time_to_throw();
 };
 
 #endif /* EXCEPTIONKERNEL_H */


### PR DESCRIPTION
Throw exception in the first timestep during the first nonlinear solve
rather than after the Nth call of computeQpJacobian()/computeQpResidual().
This approach should work in both parallel and serial.

Refs #5162.
