### PR TITLE
ColumnMajorMatrix now throws an exception

### DIFF
--- a/framework/src/utils/ColumnMajorMatrix.C
+++ b/framework/src/utils/ColumnMajorMatrix.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "ColumnMajorMatrix.h"
+#include "MooseException.h"
 
 #include "libmesh/petsc_macro.h"
 #include <petscsys.h>
@@ -265,5 +266,5 @@ ColumnMajorMatrix::inverse(ColumnMajorMatrix & invA) const
 #endif
 
   if (return_value)
-    mooseError("error in lapack inverse solve");
+    throw MooseException("Error in LAPACK matrix-inverse calculation");
 }


### PR DESCRIPTION
when it tries to invert a singular matrix, instead of using mooseError

Fixes #5201
