### PR TITLE
PETSC_VERSION_LT is not valid before PETSc 3.3

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -358,8 +358,7 @@ NonlinearSystem::setupFiniteDifferencedPreconditioner()
   // PETSc 3.2.x
   ierr = MatGetColoring(petsc_mat->mat(), MATCOLORING_LF, &iscoloring);
   CHKERRABORT(libMesh::COMM_WORLD,ierr);
-// else we have >= petsc-3.3, hence can use PETSC_VERSION_LT, which handles non-release dev versions correctly
-#elif PETSC_VERSION_LT(3,5,0)
+#elif PETSC_VERSION_LESS_THAN(3,5,0)
   // PETSc 3.3.x, 3.4.x
   ierr = MatGetColoring(petsc_mat->mat(), MATCOLORINGLF, &iscoloring);
   CHKERRABORT(_communicator.get(),ierr);


### PR DESCRIPTION
Refs #5162.
