### PR TITLE
Added vector prefactor to DerivativeSumMaterial

### DIFF
--- a/modules/phase_field/include/materials/DerivativeSumMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeSumMaterial.h
@@ -26,7 +26,7 @@ protected:
   unsigned int _num_materials;
 
   /// arguments to construct a sum of the form \f$ c+\gamma\sum_iF_i \f$
-  Real _prefactor;
+  std::vector<Real> _prefactor;
   Real _constant;
 
   /// Function values of the summands.

--- a/modules/phase_field/src/materials/DerivativeSumMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeSumMaterial.C
@@ -38,11 +38,12 @@ DerivativeSumMaterial::DerivativeSumMaterial(const std::string & name,
     mooseError("Please supply at least one material to sum in DerivativeSumMaterial " << name);
 
   // get prefactor values if not 1.0
-    std::vector<Real> p = getParam<std::vector<Real> >("prefactor");
+  std::vector<Real> p = getParam<std::vector<Real> >("prefactor");
+  
   // if prefactor is used we need the same number of prefactors as sum materials
-  if (_num_materials != p.size())
-      _prefactor = p;
-    else if (p.size() != 0)
+  if (_num_materials == p.size())
+    _prefactor = p;
+  else if (p.size() != 0)
     mooseError("Supply the same nummber of sum materials and prefactors.");
 
   // reserve space for summand material properties

--- a/modules/phase_field/src/materials/DerivativeSumMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeSumMaterial.C
@@ -18,7 +18,7 @@ InputParameters validParams<DerivativeSumMaterial>()
   params.addRequiredCoupledVar("args", "Arguments of the free energy functions being summed - use vector coupling");
 
   // Advanced arguments to construct a sum of the form \f$ c+\gamma\sum_iF_i \f$
-  params.addParam<Real>("prefactor", 1.0, "Prefactor to multiply the sum term with.");
+  params.addParam<std::vector<Real> >("prefactor", "Prefactor to multiply the sum term with.");
   params.addParam<Real>("constant", 0.0, "Constant to be added to the prefactor multiplied sum.");
   params.addParamNamesToGroup("prefactor constant", "Advanced");
 
@@ -30,12 +30,20 @@ DerivativeSumMaterial::DerivativeSumMaterial(const std::string & name,
     DerivativeFunctionMaterialBase(name, parameters),
     _sum_materials(getParam<std::vector<std::string> >("sum_materials")),
     _num_materials(_sum_materials.size()),
-    _prefactor(getParam<Real>("prefactor")),
+    _prefactor(_num_materials, 1.0),
     _constant(getParam<Real>("constant"))
   {
   // we need at least one material in the sum
   if (_num_materials == 0)
     mooseError("Please supply at least one material to sum in DerivativeSumMaterial " << name);
+
+  // get prefactor values if not 1.0
+    std::vector<Real> p = getParam<std::vector<Real> >("prefactor");
+  // if prefactor is used we need the same number of prefactors as sum materials
+  if (_num_materials != p.size())
+      _prefactor = p;
+    else if (p.size() != 0)
+    mooseError("Supply the same nummber of sum materials and prefactors.");
 
   // reserve space for summand material properties
   _summand_F.resize(_num_materials);
@@ -82,27 +90,27 @@ DerivativeSumMaterial::computeProperties()
   {
     // set function value
     if (_prop_F) {
-      (*_prop_F)[_qp] = (*_summand_F[0])[_qp];
+      (*_prop_F)[_qp] = (*_summand_F[0])[_qp] * _prefactor[0];
       for (unsigned int n = 1; n < _num_materials; ++n)
-        (*_prop_F)[_qp] += (*_summand_F[n])[_qp];
+        (*_prop_F)[_qp] += (*_summand_F[n])[_qp] * _prefactor[n];
     }
 
     for (i = 0; i < _nargs; ++i)
     {
       // set first derivatives
       if (_prop_dF[i]) {
-        (*_prop_dF[i])[_qp] =  (*_summand_dF[0][i])[_qp];
+        (*_prop_dF[i])[_qp] =  (*_summand_dF[0][i])[_qp] * _prefactor[0];
         for (unsigned int n = 1; n < _num_materials; ++n)
-          (*_prop_dF[i])[_qp] += (*_summand_dF[n][i])[_qp];
+          (*_prop_dF[i])[_qp] += (*_summand_dF[n][i])[_qp] * _prefactor[n];
       }
 
       // second derivatives
       for (j = i; j < _nargs; ++j)
       {
         if (_prop_d2F[i][j]) {
-          (*_prop_d2F[i][j])[_qp] =  (*_summand_d2F[0][i][j])[_qp];
+          (*_prop_d2F[i][j])[_qp] =  (*_summand_d2F[0][i][j])[_qp] * _prefactor[0];
           for (unsigned int n = 1; n < _num_materials; ++n)
-            (*_prop_d2F[i][j])[_qp] += (*_summand_d2F[n][i][j])[_qp];
+            (*_prop_d2F[i][j])[_qp] += (*_summand_d2F[n][i][j])[_qp] * _prefactor[n];
           }
 
         // third derivatives
@@ -110,9 +118,9 @@ DerivativeSumMaterial::computeProperties()
         {
           for (k = j; k < _nargs; ++k)
             if (_prop_d3F[i][j][k]) {
-              (*_prop_d3F[i][j][k])[_qp] =  (*_summand_d3F[0][i][j][k])[_qp];
+              (*_prop_d3F[i][j][k])[_qp] =  (*_summand_d3F[0][i][j][k])[_qp] * _prefactor[0];
               for (unsigned int n = 1; n < _num_materials; ++n)
-                (*_prop_d3F[i][j][k])[_qp] += (*_summand_d3F[n][i][j][k])[_qp];
+                (*_prop_d3F[i][j][k])[_qp] += (*_summand_d3F[n][i][j][k])[_qp] * _prefactor[n];
             }
         }
       }

--- a/modules/phase_field/src/materials/DerivativeSumMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeSumMaterial.C
@@ -39,7 +39,7 @@ DerivativeSumMaterial::DerivativeSumMaterial(const std::string & name,
 
   // get prefactor values if not 1.0
   std::vector<Real> p = getParam<std::vector<Real> >("prefactor");
-  
+
   // if prefactor is used we need the same number of prefactors as sum materials
   if (_num_materials == p.size())
     _prefactor = p;


### PR DESCRIPTION
The prefactor option in DerivativeSumMaterial previously did nothing. It has been updated to receive a vector equal in size to the number of materials to be summed giving the option to apply different prefactors to different portions of the derivative sum material. The default value of 1 has been applied in the event that no prefactors are provided.
