### PR TITLE
MultiAppProjectionTransfer fixup

### DIFF
--- a/framework/include/transfers/MultiAppProjectionTransfer.h
+++ b/framework/include/transfers/MultiAppProjectionTransfer.h
@@ -31,6 +31,8 @@ public:
   MultiAppProjectionTransfer(const std::string & name, InputParameters parameters);
   virtual ~MultiAppProjectionTransfer();
 
+  virtual void initialSetup();
+
   virtual void execute();
 
 protected:

--- a/framework/include/transfers/MultiAppProjectionTransfer.h
+++ b/framework/include/transfers/MultiAppProjectionTransfer.h
@@ -59,6 +59,8 @@ protected:
   friend void assemble_l2_from(EquationSystems & es, const std::string & system_name);
   friend void assemble_l2_to(EquationSystems & es, const std::string & system_name);
 
+  NumericVector<Number> * _serialized_master_solution;
+
 };
 
 

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -14,7 +14,6 @@
 #include "MultiAppProjectionTransfer.h"
 #include "FEProblem.h"
 #include "AddVariableAction.h"
-#include "MooseError.h"
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/mesh_function.h"
@@ -88,7 +87,6 @@ MultiAppProjectionTransfer::initialSetup()
             FEProblem & to_problem = *_multi_app->appProblem(app);
             FEType fe_type(Utility::string_to_enum<Order>(getParam<MooseEnum>("order")),
                            Utility::string_to_enum<FEFamily>(getParam<MooseEnum>("family")));
-            //to_problem.addAuxVariable(_to_var_name, fe_type, NULL);
 
             EquationSystems & to_es = to_problem.es();
             LinearImplicitSystem & proj_sys = to_es.add_system<LinearImplicitSystem>(
@@ -106,8 +104,6 @@ MultiAppProjectionTransfer::initialSetup()
             // We'll defer to_es.reinit() so we don't do it multiple
             // times even if we add multiple new systems
             augmented_es.insert(&to_es);
-
-            //to_problem.hideVariableFromOutput("var");           // hide the auxiliary projection variable
           }
         }
 
@@ -129,7 +125,6 @@ MultiAppProjectionTransfer::initialSetup()
         FEProblem & to_problem = *_multi_app->problem();
         FEType fe_type(Utility::string_to_enum<Order>(getParam<MooseEnum>("order")),
                        Utility::string_to_enum<FEFamily>(getParam<MooseEnum>("family")));
-        //to_problem.addAuxVariable(_to_var_name, fe_type, NULL);
 
         EquationSystems & to_es = to_problem.es();
         LinearImplicitSystem & proj_sys = to_es.add_system<LinearImplicitSystem>(
@@ -144,7 +139,6 @@ MultiAppProjectionTransfer::initialSetup()
 
         _proj_sys[0] = &proj_sys;
 
-        // to_problem.hideVariableFromOutput("var");           // hide the auxiliary projection variable
         to_es.reinit();
       }
       break;

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -322,7 +322,7 @@ MultiAppProjectionTransfer::assembleL2From(EquationSystems & es, const std::stri
   fe->attach_quadrature_rule(&qrule);
   const std::vector<Point> & xyz = fe->get_xyz();
   std::vector<std::vector<Point> > outgoing_qps(n_processors());
-  std::vector< std::unordered_map<unsigned int, unsigned int> > element_index_map(n_processors());
+  std::vector< std::map<unsigned int, unsigned int> > element_index_map(n_processors());
   // element_index_map[element.id] = index
   // outgoing_qps[index] is the first quadrature point in element
 
@@ -464,7 +464,7 @@ MultiAppProjectionTransfer::assembleL2From(EquationSystems & es, const std::stri
       {
         // Ignore the selected processor if the element wasn't found in it's
         // bounding box.
-        std::unordered_map<unsigned int, unsigned int> & map = element_index_map[i_proc];
+        std::map<unsigned int, unsigned int> & map = element_index_map[i_proc];
         if (map.find(elem->id()) == map.end())
           continue;
         unsigned int qp0 = map[elem->id()];

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -97,6 +97,10 @@ MultiAppProjectionTransfer::initialSetup()
             _proj_var_num = proj_sys.add_variable("var", fe_type);
             proj_sys.attach_assemble_function(assemble_l2_to);
 
+            // Prevent the projection system from being written to checkpoint
+            // files.  (This makes recover/restart easier)
+            proj_sys.hide_output() = true;
+
             _proj_sys[app] = &proj_sys;
 
             // We'll defer to_es.reinit() so we don't do it multiple
@@ -133,6 +137,10 @@ MultiAppProjectionTransfer::initialSetup()
              + "-" + Utility::enum_to_string<Order>(fe_type.order) + "-" + name());
         _proj_var_num = proj_sys.add_variable("var", fe_type);
         proj_sys.attach_assemble_function(assemble_l2_from);
+
+        // Prevent the projection system from being written to checkpoint
+        // files.  (This makes recover/restart easier)
+        proj_sys.hide_output() = true;
 
         _proj_sys[0] = &proj_sys;
 

--- a/test/tests/transfers/multiapp_projection_transfer/fromsub_master.i
+++ b/test/tests/transfers/multiapp_projection_transfer/fromsub_master.i
@@ -14,6 +14,21 @@
   [../]
 []
 
+[AuxVariables]
+  [./v_nodal]
+  [../]
+  [./v_elemental]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./x_nodal]
+  [../]
+  [./x_elemental]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
 [Kernels]
   [./diff]
     type = Diffusion

--- a/test/tests/transfers/multiapp_projection_transfer/tests
+++ b/test/tests/transfers/multiapp_projection_transfer/tests
@@ -3,7 +3,7 @@
     type = 'Exodiff'
     input = 'tosub_master.i'
     exodiff = 'tosub_master_out_sub0.e tosub_master_out_sub1.e'
-    deleted = 'Need to finish implementaiton - refs #1913'
+    #deleted = 'Need to finish implementaiton - refs #1913'
   [../]
 
   [./fromsub]

--- a/test/tests/transfers/multiapp_projection_transfer/tosub_master.i
+++ b/test/tests/transfers/multiapp_projection_transfer/tosub_master.i
@@ -65,7 +65,6 @@
   dt = 1
 
   solve_type = 'NEWTON'
-  print_linear_residuals = true
 []
 
 [Outputs]

--- a/test/tests/transfers/multiapp_projection_transfer/tosub_sub.i
+++ b/test/tests/transfers/multiapp_projection_transfer/tosub_sub.i
@@ -14,20 +14,20 @@
   [../]
 []
 
-#[AuxVariables]
-#  [./u_nodal]
-#  [../]
-#  [./u_elemental]
-#    order = CONSTANT
-#    family = MONOMIAL
-#  [../]
-#  [./x_elemental]
-#    order = CONSTANT
-#    family = MONOMIAL
-#  [../]
-#  [./x_nodal]
-#  [../]
-#[]
+[AuxVariables]
+  [./u_nodal]
+  [../]
+  [./u_elemental]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./x_elemental]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./x_nodal]
+  [../]
+[]
 
 [Kernels]
   [./diff]
@@ -57,12 +57,13 @@
   dt = 1
 
   solve_type = 'NEWTON'
-  print_linear_residuals = true
 []
 
 [Outputs]
   output_initial = true
-  exodus = true
-  print_linear_residuals = true
   print_perf_log = true
+  [./out]
+    type = Exodus
+    elemental_as_nodal = true
+  [../]
 []


### PR DESCRIPTION
This PR gets the projection transfer working again with a few new bells and whistles.  The primary changes are:
- The "tosub" test has been turned back on.  (Happily, the old gold standard is still good.)
- The projection system setup has been moved from the constructor to the `initialSetup` method (avoids bugs).
- Solution serialization has been moved so that projections to subapps now work when there isn't a balanced number of apps per processor.
- Some MPI communication has been added so that projections from the subapps now work in parallel.
- As a bonus, projections from subapps work with parallel meshes (with either master or sub meshes in parallel or both).

If you want to try this out with more test cases than we have in the testing directory, you can borrow my tests from http://web.mit.edu/smharper/Public/moose-projects/projection_transfer/.

Note that projections to subapps don't work with parallel meshes, but I'd prefer to see how this PR fares before tackling that problem because I'll probably use the same MPI scheme.  I haven't tested this at all with displaced meshes, and I doubt they will work, but I'd also like to leave that project for later.
