### PR TITLE
Utilize Coupleable where available

### DIFF
--- a/framework/include/postprocessors/ElementIntegralVariablePostprocessor.h
+++ b/framework/include/postprocessors/ElementIntegralVariablePostprocessor.h
@@ -40,8 +40,6 @@ public:
 protected:
   virtual Real computeQpIntegral();
 
-  MooseVariable & _var;
-
   /// Holds the solution at current quadrature points
   VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points

--- a/framework/include/postprocessors/ElementVariablePostprocessor.h
+++ b/framework/include/postprocessors/ElementVariablePostprocessor.h
@@ -41,9 +41,6 @@ protected:
   /// This is what derived classes should override to do something on every quadrature point on every element
   virtual void computeQpValue() = 0;
 
-  /// The MooseVariable the object is acting on
-  MooseVariable & _var;
-
   /// Holds the solution at current quadrature points
   VariableValue & _u;
 

--- a/framework/include/postprocessors/NodalVariablePostprocessor.h
+++ b/framework/include/postprocessors/NodalVariablePostprocessor.h
@@ -33,8 +33,6 @@ public:
   NodalVariablePostprocessor(const std::string & name, InputParameters parameters);
 
 protected:
-  MooseVariable & _var;
-
   /// Holds the solution at current quadrature points
   VariableValue & _u;
 };

--- a/framework/include/postprocessors/PointValue.h
+++ b/framework/include/postprocessors/PointValue.h
@@ -87,7 +87,6 @@ protected:
 
   /// The element that contains the located point
   dof_id_type _elem_id;
-
 };
 
 #endif /* POINTVALUE_H */

--- a/framework/include/postprocessors/SideIntegralVariablePostprocessor.h
+++ b/framework/include/postprocessors/SideIntegralVariablePostprocessor.h
@@ -40,8 +40,6 @@ public:
 protected:
   virtual Real computeQpIntegral();
 
-  MooseVariable & _var;
-
   /// Holds the solution at current quadrature points
   VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points

--- a/framework/include/userobject/ElementIntegralVariableUserObject.h
+++ b/framework/include/userobject/ElementIntegralVariableUserObject.h
@@ -40,8 +40,6 @@ public:
 protected:
   virtual Real computeQpIntegral();
 
-  MooseVariable & _var;
-
   /// Holds the solution at current quadrature points
   VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points

--- a/framework/include/userobject/SideIntegralVariableUserObject.h
+++ b/framework/include/userobject/SideIntegralVariableUserObject.h
@@ -40,8 +40,6 @@ public:
 protected:
   virtual Real computeQpIntegral();
 
-  MooseVariable & _var;
-
   /// Holds the solution at current quadrature points
   VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points

--- a/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
@@ -18,17 +18,16 @@ template<>
 InputParameters validParams<ElementIntegralVariablePostprocessor>()
 {
   InputParameters params = validParams<ElementIntegralPostprocessor>();
-  params.addRequiredParam<VariableName>("variable", "The name of the variable that this object operates on");
+  params.addCoupledVar("variable", "The name of the variable that this object operates on");
   return params;
 }
 
 ElementIntegralVariablePostprocessor::ElementIntegralVariablePostprocessor(const std::string & name, InputParameters parameters) :
     ElementIntegralPostprocessor(name, parameters),
     MooseVariableInterface(parameters, false),
-    _var(_subproblem.getVariable(_tid, parameters.get<VariableName>("variable"))),
-    _u(_var.sln()),
-    _grad_u(_var.gradSln()),
-    _u_dot(_var.uDot())
+    _u(coupledValue("variable")),
+    _grad_u(coupledGradient("variable")),
+    _u_dot(coupledDot("variable"))
 {
   addMooseVariableDependency(mooseVariable());
 }

--- a/framework/src/postprocessors/ElementVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementVariablePostprocessor.C
@@ -21,17 +21,16 @@ template<>
 InputParameters validParams<ElementVariablePostprocessor>()
 {
   InputParameters params = validParams<ElementPostprocessor>();
-  params.addRequiredParam<VariableName>("variable", "The name of the variable that this postprocessor operates on");
+  params.addCoupledVar("variable", "The name of the variable that this postprocessor operates on");
   return params;
 }
 
 ElementVariablePostprocessor::ElementVariablePostprocessor(const std::string & name, InputParameters parameters) :
     ElementPostprocessor(name, parameters),
     MooseVariableInterface(parameters, false),
-    _var(_subproblem.getVariable(_tid, parameters.get<VariableName>("variable"))),
-    _u(_var.sln()),
-    _grad_u(_var.gradSln()),
-    _u_dot(_var.uDot()),
+    _u(coupledValue("variable")),
+    _grad_u(coupledGradient("variable")),
+    _u_dot(coupledDot("variable")),
     _qp(0)
 {
   addMooseVariableDependency(mooseVariable());

--- a/framework/src/postprocessors/NodalVariablePostprocessor.C
+++ b/framework/src/postprocessors/NodalVariablePostprocessor.C
@@ -21,14 +21,13 @@ template<>
 InputParameters validParams<NodalVariablePostprocessor>()
 {
   InputParameters params = validParams<NodalPostprocessor>();
-  params.addRequiredParam<VariableName>("variable", "The name of the variable that this postprocessor operates on");
+  params.addCoupledVar("variable", "The name of the variable that this postprocessor operates on");
   return params;
 }
 
 NodalVariablePostprocessor::NodalVariablePostprocessor(const std::string & name, InputParameters parameters) :
     NodalPostprocessor(name, parameters),
     MooseVariableInterface(parameters, true),
-    _var(_subproblem.getVariable(_tid, parameters.get<VariableName>("variable"))),
-    _u(_var.nodalSln())
+    _u(coupledValue("variable"))
 {
 }

--- a/framework/src/postprocessors/PointValue.C
+++ b/framework/src/postprocessors/PointValue.C
@@ -57,7 +57,7 @@ PointValue::execute()
 void
 PointValue::finalize()
 {
-  // Gather a consist id for broadcasting the computed value
+  // Gather a consistent id for broadcasting the computed value
   gatherMin(_root_id);
 
   // Compute the value at the point

--- a/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
@@ -18,16 +18,15 @@ template<>
 InputParameters validParams<SideIntegralVariablePostprocessor>()
 {
   InputParameters params = validParams<SideIntegralPostprocessor>();
-  params.addRequiredParam<VariableName>("variable", "The name of the variable that this boundary condition applies to");
+  params.addCoupledVar("variable", "The name of the variable that this boundary condition applies to");
   return params;
 }
 
 SideIntegralVariablePostprocessor::SideIntegralVariablePostprocessor(const std::string & name, InputParameters parameters) :
     SideIntegralPostprocessor(name, parameters),
     MooseVariableInterface(parameters, false),
-    _var(_subproblem.getVariable(_tid, parameters.get<VariableName>("variable"))),
-    _u(_var.sln()),
-    _grad_u(_var.gradSln())
+    _u(coupledValue("variable")),
+    _grad_u(coupledGradient("variable"))
 {
   addMooseVariableDependency(mooseVariable());
 }

--- a/framework/src/userobject/ElementIntegralVariableUserObject.C
+++ b/framework/src/userobject/ElementIntegralVariableUserObject.C
@@ -18,16 +18,15 @@ template<>
 InputParameters validParams<ElementIntegralVariableUserObject>()
 {
   InputParameters params = validParams<ElementIntegralUserObject>();
-  params.addRequiredParam<VariableName>("variable", "The name of the variable that this object operates on");
+  params.addCoupledVar("variable", "The name of the variable that this object operates on");
   return params;
 }
 
 ElementIntegralVariableUserObject::ElementIntegralVariableUserObject(const std::string & name, InputParameters parameters) :
     ElementIntegralUserObject(name, parameters),
     MooseVariableInterface(parameters, false),
-    _var(_subproblem.getVariable(_tid, parameters.get<VariableName>("variable"))),
-    _u(_var.sln()),
-    _grad_u(_var.gradSln())
+    _u(coupledValue("variable")),
+    _grad_u(coupledGradient("variable"))
 {
   addMooseVariableDependency(mooseVariable());
 }

--- a/framework/src/userobject/SideIntegralVariableUserObject.C
+++ b/framework/src/userobject/SideIntegralVariableUserObject.C
@@ -18,16 +18,15 @@ template<>
 InputParameters validParams<SideIntegralVariableUserObject>()
 {
   InputParameters params = validParams<SideIntegralUserObject>();
-  params.addRequiredParam<VariableName>("variable", "The name of the variable that this boundary condition applies to");
+  params.addCoupledVar("variable", "The name of the variable that this boundary condition applies to");
   return params;
 }
 
 SideIntegralVariableUserObject::SideIntegralVariableUserObject(const std::string & name, InputParameters parameters) :
     SideIntegralUserObject(name, parameters),
     MooseVariableInterface(parameters, false),
-    _var(_subproblem.getVariable(_tid, parameters.get<VariableName>("variable"))),
-    _u(_var.sln()),
-    _grad_u(_var.gradSln())
+    _u(coupledValue("variable")),
+    _grad_u(coupledGradient("variable"))
 {
   addMooseVariableDependency(mooseVariable());
 }

--- a/modules/contact/src/NodalArea.C
+++ b/modules/contact/src/NodalArea.C
@@ -17,11 +17,9 @@ InputParameters validParams<NodalArea>()
   return params;
 }
 
-
-
 NodalArea::NodalArea(const std::string & name, InputParameters parameters) :
     SideIntegralVariableUserObject(name, parameters),
-    _phi( _var.phiFace() ),
+    _phi(getCoupledVars().find("variable")->second[0]->phiFace()),
     _system( _variable->sys() ),
     _aux_solution( _system.solution() )
 {}

--- a/modules/contact/src/NodalAreaAction.C
+++ b/modules/contact/src/NodalAreaAction.C
@@ -39,8 +39,8 @@ NodalAreaAction::act()
   // Chop off "Contact/"
   short_name.erase(0, 8);
 
-  _moose_object_pars.set<std::vector<BoundaryName> >("boundary") = std::vector<BoundaryName>(1,getParam<BoundaryName>("slave"));
-  _moose_object_pars.set<VariableName>("variable") = "nodal_area_"+short_name;
+  _moose_object_pars.set<std::vector<BoundaryName> >("boundary") = std::vector<BoundaryName>(1, getParam<BoundaryName>("slave"));
+  _moose_object_pars.set<std::vector<VariableName> >("variable") = std::vector<VariableName>(1, "nodal_area_" + short_name);
 
   mooseAssert(_problem, "Problem pointer is NULL");
   if (_problem->legacyUoInitialization())

--- a/modules/richards/src/postprocessors/NodalMaxVarChange.C
+++ b/modules/richards/src/postprocessors/NodalMaxVarChange.C
@@ -22,7 +22,7 @@ InputParameters validParams<NodalMaxVarChange>()
 
 NodalMaxVarChange::NodalMaxVarChange(const std::string & name, InputParameters parameters) :
     NodalVariablePostprocessor(name, parameters),
-    _u_old(_var.nodalSlnOld()),
+    _u_old(coupledValueOld("variable")),
     _value(-std::numeric_limits<Real>::max())
 {
 }

--- a/modules/richards/src/postprocessors/RichardsExcavFlow.C
+++ b/modules/richards/src/postprocessors/RichardsExcavFlow.C
@@ -24,7 +24,7 @@ RichardsExcavFlow::RichardsExcavFlow(const std::string & name, InputParameters p
     SideIntegralVariablePostprocessor(name, parameters),
 
     _richards_name_UO(getUserObject<RichardsVarNames>("richardsVarNames_UO")),
-    _pvar(_richards_name_UO.richards_var_num(_var.number())),
+    _pvar(_richards_name_UO.richards_var_num(coupled("variable"))),
 
     _flux(getMaterialProperty<std::vector<RealVectorValue> >("flux")),
 

--- a/modules/richards/src/postprocessors/RichardsHalfGaussianSinkFlux.C
+++ b/modules/richards/src/postprocessors/RichardsHalfGaussianSinkFlux.C
@@ -30,7 +30,7 @@ RichardsHalfGaussianSinkFlux::RichardsHalfGaussianSinkFlux(const std::string & n
     _sd(getParam<Real>("sd")),
     _centre(getParam<Real>("centre")),
     _richards_name_UO(getUserObject<RichardsVarNames>("richardsVarNames_UO")),
-    _pvar(_richards_name_UO.richards_var_num(_var.number())),
+    _pvar(_richards_name_UO.richards_var_num(coupled("variable"))),
     _m_func(getFunction("multiplying_fcn")),
     _pp(getMaterialProperty<std::vector<Real> >("porepressure"))
 {}

--- a/modules/richards/src/postprocessors/RichardsMass.C
+++ b/modules/richards/src/postprocessors/RichardsMass.C
@@ -24,7 +24,7 @@ RichardsMass::RichardsMass(const std::string & name, InputParameters parameters)
     ElementIntegralVariablePostprocessor(name, parameters),
 
     _richards_name_UO(getUserObject<RichardsVarNames>("richardsVarNames_UO")),
-    _pvar(_richards_name_UO.richards_var_num(_var.number())),
+    _pvar(_richards_name_UO.richards_var_num(coupled("variable"))),
 
     _mass(getMaterialProperty<std::vector<Real> >("mass"))
 {

--- a/modules/richards/src/postprocessors/RichardsPiecewiseLinearSinkFlux.C
+++ b/modules/richards/src/postprocessors/RichardsPiecewiseLinearSinkFlux.C
@@ -35,7 +35,7 @@ RichardsPiecewiseLinearSinkFlux::RichardsPiecewiseLinearSinkFlux(const std::stri
     _m_func(getFunction("multiplying_fcn")),
 
     _richards_name_UO(getUserObject<RichardsVarNames>("richardsVarNames_UO")),
-    _pvar(_richards_name_UO.richards_var_num(_var.number())),
+    _pvar(_richards_name_UO.richards_var_num(coupled("variable"))),
 
     _pp(getMaterialProperty<std::vector<Real> >("porepressure")),
 


### PR DESCRIPTION
This removes some legacy code that uses `SubProblem::getVariable` and switches over to the cleaner Coupleable interface methods. A confused intern pointed this out to me :-)

Closes #5273
