### PR TITLE
Fix DiracKernels computeQpOffDiagJacobian()

### DIFF
--- a/framework/src/base/ComputeDiracThread.C
+++ b/framework/src/base/ComputeDiracThread.C
@@ -133,7 +133,8 @@ ComputeDiracThread::onElement(const Elem * elem)
               // only want to call computeOffDiagJacobian() if both
               // variables are active on this subdomain, and the
               // off-diagonal variable actually has dofs.
-              if (ivariable->activeOnSubdomain(_subdomain)
+              if (dirac_kernel->variable().number() == ivariable->number()
+                  && ivariable->activeOnSubdomain(_subdomain)
                   && jvariable->activeOnSubdomain(_subdomain)
                   && (jvariable->numberOfDofs() > 0))
               {

--- a/test/include/dirackernels/NonlinearSource.h
+++ b/test/include/dirackernels/NonlinearSource.h
@@ -36,9 +36,6 @@ public:
   virtual void addPoints();
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
-
-  // The off-diagonal Jacobian stuff is not currently implemented in
-  // DiracKernel.h... so this will not be called
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 protected:

--- a/test/tests/dirackernels/nonlinear_source/nonlinear_source.i
+++ b/test/tests/dirackernels/nonlinear_source/nonlinear_source.i
@@ -92,17 +92,23 @@
     # called.  If you comment this out, you should see that this test
     # requires more linear and nonlinear iterations.
     full = true
+
+    # Added to test Jacobian contributions for Dirac Kernels
+    # Options that do not seem to do anything for this problem? -snes_check_jacobian -snes_check_jacobian_view
+    # petsc_options = '-snes_test_display' # print out all the matrix entries
+    # petsc_options_iname = '-snes_type'
+    # petsc_options_value = 'test'
   [../]
 []
 
 [Executioner]
   type = Transient
-  solve_type = 'PJFNK'
+  solve_type = 'NEWTON' # NEWTON provides a more stringent test of off-diagonal Jacobians
   num_steps = 5
   dt = 1
+  dtmin = 1
   l_max_its = 100
   nl_max_its = 6
-  dtmin = 1.e-3
   nl_abs_tol = 1.e-13
 []
 


### PR DESCRIPTION
Was getting called n times, where n is the number of variables in the system.  Should now be called the correct number of times.  The test has also been updated to use `NEWTON` to more stringently test the Jacobians, I think I didn't notice this before since it was using `PJFNK`.

Refs #5316.
