### PR TITLE
Add zero gradient option to SmoothCircleBaseIC

### DIFF
--- a/modules/phase_field/include/ics/SmoothCircleBaseIC.h
+++ b/modules/phase_field/include/ics/SmoothCircleBaseIC.h
@@ -48,6 +48,7 @@ protected:
   Real _outvalue;
   Real _int_width;
   bool _3D_spheres;
+  bool _zero_gradient;
 
   unsigned int _num_dim;
 
@@ -62,7 +63,7 @@ protected:
 
   virtual Real computeCircleValue(const Point & p, const Point & center, const Real & radius);
 
-  virtual Point computeCircleGradient(const Point & p, const Point & center, const Real & radius);
+  virtual RealGradient computeCircleGradient(const Point & p, const Point & center, const Real & radius);
 
   virtual void computeCircleRadii() = 0;
 


### PR DESCRIPTION
Allow setting the gradient to zero in higher order shape functions. This makes the IC a bit jagged, but avoids abrupt gradient jumps that cause numerical issues.

Closes #5349
