### PR TITLE
Allow parallel mesh in MultiAppNearestNodeTransfer

### DIFF
--- a/framework/include/transfers/MultiAppInterpolationTransfer.h
+++ b/framework/include/transfers/MultiAppInterpolationTransfer.h
@@ -51,13 +51,10 @@ protected:
   AuxVariableName _to_var_name;
   VariableName _from_var_name;
 
-  bool _displaced_source_mesh;
-  bool _displaced_target_mesh;
-
   unsigned int _num_points;
   Real _power;
   MooseEnum _interp_type;
   Real _radius;
 };
 
-#endif /* MULTIAPPVARIABLEVALUESAMPLEPOSTPROCESSORTRANSFER_H */
+#endif /* MULTIAPPINTERPOLATIONTRANSFER_H */

--- a/framework/include/transfers/MultiAppMeshFunctionTransfer.h
+++ b/framework/include/transfers/MultiAppMeshFunctionTransfer.h
@@ -41,9 +41,7 @@ public:
 protected:
   AuxVariableName _to_var_name;
   VariableName _from_var_name;
-  bool _displaced_source_mesh;
-  bool _displaced_target_mesh;
   bool _error_on_miss;
 };
 
-#endif /* MULTIAPPVARIABLEVALUESAMPLEPOSTPROCESSORTRANSFER_H */
+#endif /* MULTIAPPMESHFUNCTIONTRANSFER_H */

--- a/framework/include/transfers/MultiAppNearestNodeTransfer.h
+++ b/framework/include/transfers/MultiAppNearestNodeTransfer.h
@@ -38,9 +38,6 @@ public:
   virtual void execute();
 
 protected:
-  virtual void transferToMultiApp();
-  virtual void transferFromMultiApp();
-
   /**
    * Return the nearest node to the point p.
    * @param p The point you want to find the nearest node to.
@@ -51,11 +48,30 @@ protected:
    */
   Node * getNearestNode(const Point & p, Real & distance, MooseMesh * mesh, bool local);
 
+  /**
+   * Return the distance between the given point and the farthest corner of the
+   * given bounding box.
+   * @param p The point to evaluate all distances from.
+   * @param bbox The bounding box to evaluate the distance to.
+   * @return The maximum distance between the point p and the eight corners of
+   * the bounding box bbox.
+   */
+  Real bboxMaxDistance(Point p, MeshTools::BoundingBox bbox);
+
+  /**
+   * Return the distance between the given point and the nearest corner of the
+   * given bounding box.
+   * @param p The point to evaluate all distances from.
+   * @param bbox The bounding box to evaluate the distance to.
+   * @return The minimum distance between the point p and the eight corners of
+   * the bounding box bbox.
+   */
+  Real bboxMinDistance(Point p, MeshTools::BoundingBox bbox);
+
+  void getLocalNodes(MooseMesh * mesh, std::vector<Node *> & local_nodes);
+
   AuxVariableName _to_var_name;
   VariableName _from_var_name;
-
-  bool _displaced_source_mesh;
-  bool _displaced_target_mesh;
 
   /// If true then node connections will be cached
   bool _fixed_meshes;
@@ -65,6 +81,13 @@ protected:
 
   /// Used to cache distances
   std::map<dof_id_type, Real> _distance_map;
+
+  // These variables allow us to cache nearest node info
+  bool _neighbors_cached;
+  std::vector< std::vector<unsigned int> > _cached_froms;
+  std::vector< std::vector<dof_id_type> > _cached_dof_ids;
+  std::map<unsigned int, unsigned int> _cached_from_inds;
+  std::map<unsigned int, unsigned int> _cached_qp_inds;
 };
 
-#endif /* MULTIAPPVARIABLEVALUESAMPLEPOSTPROCESSORTRANSFER_H */
+#endif /* MULTIAPPNEARESTNODETRANSFER_H */

--- a/framework/include/transfers/MultiAppTransfer.h
+++ b/framework/include/transfers/MultiAppTransfer.h
@@ -65,6 +65,44 @@ protected:
 
   /// Whether we're transferring to or from the MultiApp
   MooseEnum _direction;
+
+  /**
+   * This method will fill information into the convenience member variables
+   * (_to_problems, _from_meshes, etc.)
+   */
+  void getAppInfo();
+
+  std::vector<FEProblem *> _to_problems;
+  std::vector<FEProblem *> _from_problems;
+  std::vector<EquationSystems *> _to_es;
+  std::vector<EquationSystems *> _from_es;
+  std::vector<MooseMesh *> _to_meshes;
+  std::vector<MooseMesh *> _from_meshes;
+  std::vector<Point> _to_positions;
+  std::vector<Point> _from_positions;
+
+  bool _displaced_source_mesh;
+  bool _displaced_target_mesh;
+
+  /**
+   * Return all of the bounding boxes for each processor.
+   */
+  std::vector<MeshTools::BoundingBox> getBboxes();
+
+  /**
+   * Return the number of "from" domains that each processor owns.
+   */
+  std::vector<unsigned int> getFromsPerProc();
+
+  /**
+   * If we are transferring to a multiapp, return the appropriate solution
+   * vector
+   */
+  NumericVector<Real> & getTransferVector(unsigned int i_local, std::string var_name);
+
+private:
+  // Given local app index, returns global app index.
+  std::vector<unsigned int> _local2global_map;
 };
 
 #endif /* MULTIAPPTRANSFER_H */

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -49,8 +49,6 @@ MultiAppInterpolationTransfer::MultiAppInterpolationTransfer(const std::string &
     MultiAppTransfer(name, parameters),
     _to_var_name(getParam<AuxVariableName>("variable")),
     _from_var_name(getParam<VariableName>("source_variable")),
-    _displaced_source_mesh(getParam<bool>("displaced_source_mesh")),
-    _displaced_target_mesh(getParam<bool>("displaced_target_mesh")),
     _num_points(getParam<unsigned int>("num_points")),
     _power(getParam<Real>("power")),
     _interp_type(getParam<MooseEnum>("interp_type")),
@@ -58,6 +56,8 @@ MultiAppInterpolationTransfer::MultiAppInterpolationTransfer(const std::string &
 {
   // This transfer does not work with ParallelMesh
   _fe_problem.mesh().errorIfParallelDistribution("MultiAppInterpolationTransfer");
+  _displaced_source_mesh = getParam<bool>("displaced_source_mesh");
+  _displaced_target_mesh = getParam<bool>("displaced_target_mesh");
 }
 
 void

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -41,12 +41,12 @@ MultiAppMeshFunctionTransfer::MultiAppMeshFunctionTransfer(const std::string & n
     MultiAppTransfer(name, parameters),
     _to_var_name(getParam<AuxVariableName>("variable")),
     _from_var_name(getParam<VariableName>("source_variable")),
-    _displaced_source_mesh(getParam<bool>("displaced_source_mesh")),
-    _displaced_target_mesh(getParam<bool>("displaced_target_mesh")),
     _error_on_miss(getParam<bool>("error_on_miss"))
 {
   // This transfer does not work with ParallelMesh
   _fe_problem.mesh().errorIfParallelDistribution("MultiAppMeshFunctionTransfer");
+  _displaced_source_mesh = getParam<bool>("displaced_source_mesh");
+  _displaced_target_mesh = getParam<bool>("displaced_target_mesh");
 }
 
 void

--- a/test/tests/transfers/multiapp_nearest_node_transfer/boundary_tosub_master.i
+++ b/test/tests/transfers/multiapp_nearest_node_transfer/boundary_tosub_master.i
@@ -1,6 +1,5 @@
 [Mesh]
   file = 2blk.e
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_nearest_node_transfer/fromsub_displaced_master.i
+++ b/test/tests/transfers/multiapp_nearest_node_transfer/fromsub_displaced_master.i
@@ -3,9 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The Transfer system doesn't work quite right with ParallelMesh enabled.
-  # Form more information, see #2126
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_nearest_node_transfer/fromsub_fixed_meshes_master.i
+++ b/test/tests/transfers/multiapp_nearest_node_transfer/fromsub_fixed_meshes_master.i
@@ -3,9 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The Transfer system doesn't work quite right with ParallelMesh enabled.
-  # Form more information, see #2126
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_nearest_node_transfer/fromsub_master.i
+++ b/test/tests/transfers/multiapp_nearest_node_transfer/fromsub_master.i
@@ -3,9 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The Transfer system doesn't work quite right with ParallelMesh enabled.
-  # Form more information, see #2126
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_nearest_node_transfer/tosub_displaced_master.i
+++ b/test/tests/transfers/multiapp_nearest_node_transfer/tosub_displaced_master.i
@@ -3,9 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The Transfer system doesn't work quite right with ParallelMesh enabled.
-  # Form more information, see #2126
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_nearest_node_transfer/tosub_master.i
+++ b/test/tests/transfers/multiapp_nearest_node_transfer/tosub_master.i
@@ -3,9 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The Transfer system doesn't work quite right with ParallelMesh enabled.
-  # Form more information, see #2126
-  distribution = serial
 []
 
 [Variables]


### PR DESCRIPTION
This PR makes a pretty significant overhaul of `MultiAppNearestNodeTransfer`.  From the user's perspective, the only difference is that it now works with parallel meshes.  From our perspective, I hope it's a little cleaner because it now uses `execute()` without very much specialization for to_multiapp/from_multiapp.  It also lays some groundwork for refactoring transfers to use more methods from the `MultiAppTransfer` base class.

The transfer now uses an MPI algorithm very similar to the one in #5260.  It might also offer a performance gain for runs with large meshes and lots of processors because processor bounding boxes are used to narrow down the number of nodes each processor must search.

Also note that `_displaced_source_mesh` and `_displaced_target_mesh` have been moved to `MultiAppTransfer`.  I did that so that `MultiAppTransfer` can make the appropriate meshes available to inherited classes.  But displaced meshes don't make since for all of the sub classes so `displaced_*_mesh` isn't included `MultiAppTransfer`; it's up to the sub classes to make that parameter and adjust the `displaced_*_mesh` variables.
