### PR TITLE
Add debugging and fix KKS test for PETSc >= 3.6.0

### DIFF
--- a/framework/include/materials/DerivativeMaterialInterface.h
+++ b/framework/include/materials/DerivativeMaterialInterface.h
@@ -145,13 +145,17 @@ DerivativeMaterialInterface<Material>::getZeroMaterialProperty(const std::string
   for (unsigned int qp = 0; qp < nqp; ++qp)
     mooseSetToZero<U>(preload_with_zero[qp]);
 
+#ifdef DEBUG
+  this->_console << "DerivativeMaterialInterface<Material>(" << this->_name << ") returning ZERO for " << prop_name << '\n';
+#endif
+
   return preload_with_zero;
 }
 
 template<class T>
 template<typename U>
 const MaterialProperty<U> &
-DerivativeMaterialInterface<T>::getZeroMaterialProperty(const std::string & /* prop_name */)
+DerivativeMaterialInterface<T>::getZeroMaterialProperty(const std::string & prop_name)
 {
   static MaterialProperty<U> _zero;
 
@@ -166,6 +170,10 @@ DerivativeMaterialInterface<T>::getZeroMaterialProperty(const std::string & /* p
     for (unsigned int qp = 0; qp < nqp; ++qp)
       mooseSetToZero<U>(_zero[qp]);
   }
+
+#ifdef DEBUG
+  this->_console << "DerivativeMaterialInterface<T>(" << this->_name << ") returning ZERO for " << prop_name << '\n';
+#endif
 
   // return a reference to a static zero property
   return _zero;
@@ -269,6 +277,10 @@ DerivativeMaterialInterface<T>::getMaterialPropertyDerivative(const std::string 
 {
   // get the base property name
   std::string prop_name = this->deducePropertyName(base);
+
+#ifdef DEBUG
+  this->_console << "DerivativeMaterialInterface<T> getMaterialPropertyDerivative " << base << '=' << prop_name<< ',' << c1 << ',' << c2 << ',' << c3 << '\n';
+#endif
 
   /**
    * Check if base is a default property and shortcut to returning zero, as

--- a/modules/phase_field/include/kernels/KKSACBulkC.h
+++ b/modules/phase_field/include/kernels/KKSACBulkC.h
@@ -34,12 +34,12 @@ protected:
   /// phase a concentration
   std::string _ca_name;
   unsigned int _ca_var;
-  VariableValue & _ca;
+  const VariableValue & _ca;
 
   /// phase b concentration
   std::string _cb_name;
   unsigned int _cb_var;
-  VariableValue & _cb;
+  const VariableValue & _cb;
 
   /// Value of the switching function \f$ h(\eta) \f$
   const MaterialProperty<Real> & _prop_h;

--- a/modules/phase_field/include/kernels/KKSSplitCHCRes.h
+++ b/modules/phase_field/include/kernels/KKSSplitCHCRes.h
@@ -68,7 +68,7 @@ private:
 
   /// Chemical potential
   unsigned int _w_var;
-  VariableValue & _w;
+  const VariableValue & _w;
 };
 
 #endif //KKSSPLITCHCRES_H

--- a/modules/phase_field/include/materials/OrderParameterFunctionMaterial.h
+++ b/modules/phase_field/include/materials/OrderParameterFunctionMaterial.h
@@ -29,9 +29,9 @@ public:
 
 protected:
   /// Coupled variable value for the order parameter \f$ \eta \f$.
-  VariableValue & _eta;
+  const VariableValue & _eta;
   unsigned int _eta_var;
-  std::string _eta_name;
+  VariableName _eta_name;
 
   /// name of the function of eta (used to generate the material property names)
   std::string _function_name;

--- a/modules/phase_field/src/kernels/KKSACBulkBase.C
+++ b/modules/phase_field/src/kernels/KKSACBulkBase.C
@@ -14,7 +14,6 @@ InputParameters validParams<KKSACBulkBase>()
   params.addRequiredParam<MaterialPropertyName>("fa_name", "Base name of the free energy function F (f_base in the corresponding KKSBaseMaterial)");
   params.addRequiredParam<MaterialPropertyName>("fb_name", "Base name of the free energy function F (f_base in the corresponding KKSBaseMaterial)");
   params.addParam<MaterialPropertyName>("h_name", "h", "Base name for the switching function h(eta)");
-  params.addCoupledVar("args", "coupled variables i.e. concentrations");
   return params;
 }
 
@@ -27,8 +26,8 @@ KKSACBulkBase::KKSACBulkBase(const std::string & name, InputParameters parameter
     _prop_Fb(getMaterialProperty<Real>("fb_name")),
     _prop_dFa(getMaterialPropertyDerivative<Real>("fa_name", _eta_name)),
     _prop_dFb(getMaterialPropertyDerivative<Real>("fb_name", _eta_name)),
-    _prop_dh(getMaterialPropertyDerivative<Real>("h", _eta_name)),
-    _prop_d2h(getMaterialPropertyDerivative<Real>("h", _eta_name, _eta_name))
+    _prop_dh(getMaterialPropertyDerivative<Real>("h_name", _eta_name)),
+    _prop_d2h(getMaterialPropertyDerivative<Real>("h_name", _eta_name, _eta_name))
 {
   // reserve space for derivatives
   _derivatives_Fa.resize(_nvar);

--- a/modules/phase_field/src/kernels/KKSACBulkF.C
+++ b/modules/phase_field/src/kernels/KKSACBulkF.C
@@ -12,15 +12,15 @@ InputParameters validParams<KKSACBulkF>()
   InputParameters params = validParams<KKSACBulkBase>();
   // params.addClassDescription("KKS model kernel for the Bulk Allen-Cahn. This operates on the order parameter 'eta' as the non-linear variable");
   params.addRequiredParam<Real>("w", "Double well height parameter");
-  params.addParam<std::string>("g_name", "g", "Base name for the double well function g(eta)");
+  params.addParam<MaterialPropertyName>("g_name", "g", "Base name for the double well function g(eta)");
   return params;
 }
 
 KKSACBulkF::KKSACBulkF(const std::string & name, InputParameters parameters) :
     KKSACBulkBase(name, parameters),
     _w(getParam<Real>("w")),
-    _prop_dg(getMaterialPropertyDerivative<Real>("g", _eta_name)),
-    _prop_d2g(getMaterialPropertyDerivative<Real>("g", _eta_name, _eta_name))
+    _prop_dg(getMaterialPropertyDerivative<Real>("g_name", _eta_name)),
+    _prop_d2g(getMaterialPropertyDerivative<Real>("g_name", _eta_name, _eta_name))
 {
 }
 
@@ -37,7 +37,7 @@ KKSACBulkF::computeDFDOP(PFFunctionType type)
 
     case Jacobian:
     {
-      res =   _prop_d2h[_qp] * A1
+      res =  -_prop_d2h[_qp] * A1
             + _w * _prop_d2g[_qp];
 
       // the -\frac{dh}{d\eta}\left(\frac{dF_a}{d\eta}-\frac{dF_b}{d\eta}\right)

--- a/modules/phase_field/src/kernels/KKSPhaseChemicalPotential.C
+++ b/modules/phase_field/src/kernels/KKSPhaseChemicalPotential.C
@@ -37,7 +37,9 @@ KKSPhaseChemicalPotential::KKSPhaseChemicalPotential(const std::string & name,
   MooseVariable *arg;
   unsigned int i;
 
-  _console << "DEBUG " << name << ' ' << _var.name() << ' ' << _cb_name << '\n';
+#ifdef DEBUG
+  _console << "KKSPhaseChemicalPotential(" << name << ") " << _var.name() << ' ' << _cb_name << '\n';
+#endif
 
   unsigned int nvar = _coupled_moose_vars.size();
   _off_diag_a.resize(nvar);

--- a/modules/phase_field/tests/KKS_system/kks_example_split.i
+++ b/modules/phase_field/tests/KKS_system/kks_example_split.i
@@ -224,6 +224,8 @@
 [Executioner]
   type = Transient
   solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_factor_shift_type'
+  petsc_options_value = 'nonzero'
 
   l_max_its = 100
   nl_max_its = 100

--- a/modules/phase_field/tests/KKS_system/kks_example_split.i
+++ b/modules/phase_field/tests/KKS_system/kks_example_split.i
@@ -31,14 +31,14 @@
     family = LAGRANGE
   [../]
 
-  # chemical potential
-  [./w]
+  # hydrogen concentration
+  [./c]
     order = FIRST
     family = LAGRANGE
   [../]
 
-  # hydrogen concentration
-  [./c]
+  # chemical potential
+  [./w]
     order = FIRST
     family = LAGRANGE
   [../]


### PR DESCRIPTION
The outcome solve/fail of a test in the phase field module depends on the order two nonlinear variables are declared in the `[Variables]` block. The previous order worked. I have switched it to the failing order to see what moose build makes of it.
