### PR TITLE
A first hack to show that restart/recover works for eigensolves (#5356)

### DIFF
--- a/framework/include/executioners/EigenExecutionerBase.h
+++ b/framework/include/executioners/EigenExecutionerBase.h
@@ -129,7 +129,7 @@ protected:
   EigenSystem & _eigen_sys;
 
   /// Storage for the eigenvalue computed by the executioner
-  Real _eigenvalue;
+  Real & _eigenvalue;
 
   // postprocessor for eigenvalue
   const Real & _source_integral;

--- a/framework/include/executioners/InversePowerMethod.h
+++ b/framework/include/executioners/InversePowerMethod.h
@@ -29,6 +29,7 @@ public:
 
   InversePowerMethod(const std::string & name, InputParameters parameters);
 
+  virtual void init();
   virtual void execute();
 
 protected:

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -39,12 +39,11 @@ EigenExecutionerBase::EigenExecutionerBase(const std::string & name, InputParame
     Executioner(name, parameters),
      _problem(*parameters.getCheckedPointerParam<FEProblem *>("_fe_problem", "This might happen if you don't have a mesh")),
      _eigen_sys(static_cast<EigenSystem &>(_problem.getNonlinearSystem())),
-     _eigenvalue(1.0),
+     _eigenvalue(declareRestartableData("eigenvalue", 1.0)),
      _source_integral(getPostprocessorValue("bx_norm")),
      _normalization(isParamValid("normalization") ? getPostprocessorValue("normalization")
                     : getPostprocessorValue("bx_norm")) // use |Bx| for normalization by default
 {
-
   //FIXME: currently we have to use old and older solution vectors for power iteration.
   //       We will need 'step' in the future.
   _problem.transient(true);
@@ -76,12 +75,6 @@ EigenExecutionerBase::~EigenExecutionerBase()
 void
 EigenExecutionerBase::init()
 {
-  if (_app.isRecovering())
-  {
-    _console << "\nCannot recover eigenvalue solves!\nExiting...\n" << std::endl;
-    return;
-  }
-
   checkIntegrity();
   _eigen_sys.buildSystemDoFIndices(EigenSystem::EIGEN);
 

--- a/framework/src/executioners/InversePowerMethod.C
+++ b/framework/src/executioners/InversePowerMethod.C
@@ -39,12 +39,26 @@ InversePowerMethod::InversePowerMethod(const std::string & name, InputParameters
     _pfactor(getParam<Real>("pfactor")),
     _cheb_on(getParam<bool>("Chebyshev_acceleration_on"))
 {
-  _eigenvalue = getParam<Real>("k0");
+  if (!_app.isRecovering() && ! _app.isRestarting())
+    _eigenvalue = getParam<Real>("k0");
+
   addAttributeReporter("eigenvalue", _eigenvalue, "initial timestep_end");
 
   if (_max_iter<_min_iter) mooseError("max_power_iterations<min_power_iterations!");
   if (_eig_check_tol<0.0) mooseError("eig_check_tol<0!");
   if (_pfactor<0.0) mooseError("pfactor<0!");
+}
+
+void
+InversePowerMethod::init()
+{
+  if (_app.isRecovering())
+  {
+    _console << "\nCannot recover InversePowerMethod solves!\nExiting...\n" << std::endl;
+    return;
+  }
+
+  EigenExecutionerBase::init();
 }
 
 void

--- a/framework/src/executioners/NonlinearEigen.C
+++ b/framework/src/executioners/NonlinearEigen.C
@@ -36,13 +36,21 @@ NonlinearEigen::NonlinearEigen(const std::string & name, InputParameters paramet
      _pfactor(getParam<Real>("pfactor")),
      _output_after_pi(getParam<bool>("output_after_power_iterations"))
 {
-  _eigenvalue = getParam<Real>("k0");
+  if (!_app.isRecovering() && ! _app.isRestarting())
+    _eigenvalue = getParam<Real>("k0");
+
   addAttributeReporter("eigenvalue", _eigenvalue, "initial timestep_end");
 }
 
 void
 NonlinearEigen::init()
 {
+  if (_app.isRecovering())
+  {
+    _console << "\nCannot recover NonlinearEigen solves!\nExiting...\n" << std::endl;
+    return;
+  }
+
   EigenExecutionerBase::init();
 
   if (_free_iter>0)


### PR DESCRIPTION
@YaqiWang @aeslaughter @gleicher27 @jortensi @friedmud 

Looks like it should be relatively straight forward to make eigen solves restartable.

Run the new input with and without recover:

../../../moose_test-opt -i ipm_restart.i

then 

../../../moose_test-opt -i ipm_restart.i --recover

Reads eigenvalue from file and cuts iteration count. 
