### PR TITLE
Add the ability to deprecate an enumeration

### DIFF
--- a/framework/include/utils/MooseEnum.h
+++ b/framework/include/utils/MooseEnum.h
@@ -99,6 +99,10 @@ public:
   /// Operator for printing to iostreams
   friend std::ostream & operator<<(std::ostream & out, const MooseEnum & obj) { out << obj._current_name_preserved; return out; }
 
+protected:
+  /// Check whether the current value is deprecated when called
+  virtual void checkDeprecated() const;
+
 private:
 
   /**

--- a/framework/include/utils/MooseEnumBase.h
+++ b/framework/include/utils/MooseEnumBase.h
@@ -46,6 +46,13 @@ public:
   virtual ~MooseEnumBase();
 
   /**
+   * Deprecates various options in the MOOSE enum. For each deprecated option,
+   * you may supply an option new option that will be used in a message telling
+   * the user which new option replaces the old one.
+   */
+  void deprecate(const std::string & name, const std::string & new_name="");
+
+  /**
    * Method for returning a vector of all valid enumeration names for this instance
    * @return a vector of names
    */
@@ -73,6 +80,14 @@ protected:
    */
   void fillNames(std::string names, std::string option_delim=" ");
 
+  // The method that must be implemented to check derived class values against the _deprecated_names list
+  virtual void checkDeprecated() const = 0;
+
+  /**
+   * Check and warn deprecated values
+   */
+  void checkDeprecatedBase(const std::string & name_upper) const;
+
   /// The vector of enumeration names
   std::vector<std::string> _names;
 
@@ -81,6 +96,9 @@ protected:
 
   /// The map of names to enumeration constants
   std::map<std::string, int> _name_to_id;
+
+  /// The map of deprecated names and optional replacements
+  std::map<std::string, std::string> _deprecated_names;
 
   /**
    * The index of values assigned that are NOT values in this enum.  If this index is 0 (false) then

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -169,6 +169,10 @@ public:
   /// Operator for printing to iostreams
   friend std::ostream & operator<<(std::ostream & out, const MultiMooseEnum & obj);
 
+protected:
+  /// Check whether any of the current values are deprecated when called
+  virtual void checkDeprecated() const;
+
 private:
 
   /**

--- a/framework/src/utils/MooseEnum.C
+++ b/framework/src/utils/MooseEnum.C
@@ -78,6 +78,8 @@ MooseEnum::operator=(const std::string & name)
   _current_name = upper;
   _current_name_preserved = name;
 
+  checkDeprecatedBase(upper);
+
   if (std::find(_names.begin(), _names.end(), upper) == _names.end())
   {
     if (_out_of_range_index == 0)     // Are out of range values allowed?
@@ -129,17 +131,26 @@ MooseEnum::operator==(unsigned short value) const
   return value == _current_id;
 }
 
-bool MooseEnum::operator!=(unsigned short value) const
+bool
+MooseEnum::operator!=(unsigned short value) const
 {
   return value != _current_id;
 }
 
-bool MooseEnum::operator==(const MooseEnum & value) const
+bool
+MooseEnum::operator==(const MooseEnum & value) const
 {
   return value._current_name == _current_name;
 }
 
-bool MooseEnum::operator!=(const MooseEnum & value) const
+bool
+MooseEnum::operator!=(const MooseEnum & value) const
 {
   return value._current_name != _current_name;
+}
+
+void
+MooseEnum::checkDeprecated() const
+{
+  checkDeprecatedBase(_current_name);
 }

--- a/framework/src/utils/MooseEnumBase.C
+++ b/framework/src/utils/MooseEnumBase.C
@@ -41,6 +41,7 @@ MooseEnumBase::MooseEnumBase(const MooseEnumBase & other_enum) :
     _names(other_enum._names),
     _raw_names(other_enum._raw_names),
     _name_to_id(other_enum._name_to_id),
+    _deprecated_names(other_enum._deprecated_names),
     _out_of_range_index(other_enum._out_of_range_index)
 {
 }
@@ -54,6 +55,20 @@ MooseEnumBase::MooseEnumBase()
 
 MooseEnumBase::~MooseEnumBase()
 {
+}
+
+void
+MooseEnumBase::deprecate(const std::string & name, const std::string & new_name)
+{
+  std::string upper(name);
+  std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
+
+  std::string upper_new(new_name);
+  std::transform(upper_new.begin(), upper_new.end(), upper_new.begin(), ::toupper);
+
+  _deprecated_names[upper] = upper_new;
+
+  checkDeprecated();
 }
 
 void
@@ -98,5 +113,19 @@ MooseEnumBase::fillNames(std::string names, std::string option_delim)
     // populate internal datastructures
     _names[i] = upper;
     _name_to_id[upper] = value++;
+  }
+}
+
+void
+MooseEnumBase::checkDeprecatedBase(const std::string & name_upper) const
+{
+  std::map<std::string, std::string>::const_iterator it = _deprecated_names.find(name_upper);
+
+  if (it != _deprecated_names.end())
+  {
+    if (it->second != "")
+      mooseWarning(name_upper + " is deprecated, consider using " + it->second);
+    else
+      mooseWarning(name_upper + " is deprecated");
   }
 }

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -204,6 +204,8 @@ MultiMooseEnum::assign(InputIterator first, InputIterator last, bool append)
     std::string upper(*it);
     std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
 
+    checkDeprecatedBase(upper);
+
     _current_names.insert(upper);
 
     if (std::find(_names.begin(), _names.end(), upper) == _names.end())
@@ -267,6 +269,13 @@ MultiMooseEnum::unique_items_size() const
 {
   std::set<int> unique_ids(_current_ids.begin(), _current_ids.end());
   return unique_ids.size();
+}
+
+void
+MultiMooseEnum::checkDeprecated() const
+{
+  for (std::set<std::string>::const_iterator it = _current_names.begin(); it != _current_names.end(); ++it)
+    checkDeprecatedBase(*it);
 }
 
 std::ostream &

--- a/unit/include/MooseEnumTest.h
+++ b/unit/include/MooseEnumTest.h
@@ -26,6 +26,7 @@ class MooseEnumTest : public CppUnit::TestFixture
 
   CPPUNIT_TEST( multiTestOne );
   CPPUNIT_TEST( withNamesFromTest );
+  CPPUNIT_TEST( testDeprecate );
   CPPUNIT_TEST( testErrors );
 
   CPPUNIT_TEST_SUITE_END();
@@ -33,6 +34,7 @@ class MooseEnumTest : public CppUnit::TestFixture
 public:
   void multiTestOne();
   void withNamesFromTest();
+  void testDeprecate();
   void testErrors();
 };
 

--- a/unit/src/MooseEnumTest.C
+++ b/unit/src/MooseEnumTest.C
@@ -178,6 +178,58 @@ MooseEnumTest::withNamesFromTest()
 }
 
 void
+MooseEnumTest::testDeprecate()
+{
+  // Intentionally misspelling
+  MooseEnum me1("one too three four", "too");
+
+  try
+  {
+    me1.deprecate("too", "two");
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+
+    CPPUNIT_ASSERT( msg.find("is deprecated, consider using") != std::string::npos );
+  }
+
+  me1 = "one";
+  try
+  {
+    me1 = "too";
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+    CPPUNIT_ASSERT( msg.find("is deprecated, consider using") != std::string::npos );
+  }
+
+  MultiMooseEnum mme1("one too three four");
+  mme1.deprecate("too", "two");
+
+  mme1.push_back("one");
+  try
+  {
+    me1 = "too";
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+    CPPUNIT_ASSERT( msg.find("is deprecated, consider using") != std::string::npos );
+  }
+}
+
+void
 MooseEnumTest::testErrors()
 {
   // Assign invalid item
@@ -185,6 +237,9 @@ MooseEnumTest::testErrors()
   {
     MultiMooseEnum error_check("one two three");
     error_check = "four";
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
   }
   catch(const std::exception & e)
   {
@@ -196,6 +251,9 @@ MooseEnumTest::testErrors()
   try
   {
     MultiMooseEnum error_check("one= 1 two three");
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
   }
   catch(const std::exception & e)
   {
@@ -209,6 +267,9 @@ MooseEnumTest::testErrors()
   {
     MultiMooseEnum error_check("one two three");
     std::string invalid = error_check[3];
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
   }
   catch(const std::exception & e)
   {
@@ -221,6 +282,9 @@ MooseEnumTest::testErrors()
   {
     MultiMooseEnum error_check("one two three");
     unsigned int invalid = error_check.get(3);
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
   }
   catch(const std::exception & e)
   {


### PR DESCRIPTION
closes #5368 

Second attempt at deprecation in MooseEnum. `deprecate(...)` is a separate public API that when called will deprecate the option specified optionally allowing the user to provide a message indicating which new option to use. Additionally the current Enum is checked to see if it's currently selected option is deprecated. Any subsequent assignments will also trigger the warning.
Also see #5369 
