### PR TITLE
AdaptivityAction didn't get a deprecated constructor.

### DIFF
--- a/framework/src/actions/AdaptivityAction.C
+++ b/framework/src/actions/AdaptivityAction.C
@@ -105,4 +105,10 @@ AdaptivityAction::act()
   adapt.setTimeActive(getParam<Real>("start_time"), getParam<Real>("stop_time"));
 }
 
+// DEPRECATED CONSTRUCTOR
+AdaptivityAction::AdaptivityAction(const std::string & deprecated_name, InputParameters params) :
+    Action(deprecated_name, params)
+{
+}
+
 #endif //LIBMESH_ENABLE_AMR


### PR DESCRIPTION
Somehow, nothing complained except RELAP-7.

Refs #4606.
