### PR TITLE
Fix kernel_restartable test for -p > 2

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -694,7 +694,7 @@ class TestHarness:
     parser.add_argument('--dry-run', action='store_true', dest='dry_run', help="Pass --dry-run to print commands to run, but don't actually run them")
 
     outputgroup = parser.add_argument_group('Output Options', 'These options control the output of the test harness. The sep-files options write output to files named test_name.TEST_RESULT.txt. All file output will overwrite old files')
-    outputgroup.add_argument('-v', '--verbose', action='store_true', dest='verbose', help='show the output of every test that fails')
+    outputgroup.add_argument('-v', '--verbose', action='store_true', dest='verbose', help='show the output of every test')
     outputgroup.add_argument('-q', '--quiet', action='store_true', dest='quiet', help='only show the result of every test, don\'t show test output even if it fails')
     outputgroup.add_argument('--show-directory', action='store_true', dest='show_directory', help='Print test directory path in out messages')
     outputgroup.add_argument('-o', '--output-dir', nargs=1, metavar='directory', dest='output_dir', default='', help='Save all output files in the directory, and create it if necessary')

--- a/test/tests/restart/kernel_restartable/tests
+++ b/test/tests/restart/kernel_restartable/tests
@@ -37,6 +37,7 @@
     exodiff = 'kernel_restartable_out.e'
     min_threads = 4
     max_threads = 4
+    max_parallel = 1
     prereq = parallel_error1
     cli_args = 'Outputs/restart/file_base=kernel_restartable_out_threads'
   [../]
@@ -46,7 +47,6 @@
     input = 'kernel_restartable_second.i'
     min_threads = 2
     max_threads = 2
-    max_parallel = 2
     prereq = with_threads
     cli_args = 'Executioner/restart_file_base=kernel_restartable_out_threads_cp/0005'
     expect_err = 'Cannot restart using a different number of threads'


### PR DESCRIPTION
If you run tests using -p with a number greater than two, you'll get a 'FAILED (NO EXPECTED ERR)' on restart/kernel_restartable.threads_error.  The test is expecting an error message about number of threads, but that message is never written because of an error about number of processors.  Removing the `max_parallel` limit gives the correct failure.  (I can't simply remove the `max_parallel` line because `RunException` tests default to `max_parallel = 1`)

I also fixed the `run_test -h` output
