### PR TITLE
Make TestHarness check nl_rel_tol

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -4,9 +4,7 @@ import path_tool
 path_tool.activate_module('FactorySystem')
 path_tool.activate_module('argparse')
 
-from ParseGetPot import ParseGetPot
 from socket import gethostname
-#from options import *
 from util import *
 from RunParallel import RunParallel
 from CSVDiffer import CSVDiffer
@@ -17,6 +15,7 @@ from InputParameters import InputParameters
 from Factory import Factory
 from Parser import Parser
 from Warehouse import Warehouse
+from RunApp import RunApp
 
 import argparse
 from optparse import OptionParser, OptionGroup, Values
@@ -341,6 +340,12 @@ class TestHarness:
 
     if self.options.scaling and test['scale_refine']:
       caveats.append('scaled')
+
+    # Make sure nl_rel_tol met the maximum
+    if reason == '':
+      if isinstance(tester, RunApp):
+        if not tester.checkNlRelTol():
+          reason = 'NL_REL_TOL_TOO_LARGE'
 
     did_pass = True
     if reason == '':

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -1,6 +1,7 @@
 import re, os, sys
 from Tester import Tester
 from RunParallel import RunParallel # For TIMEOUT value
+from ParseGetPot import ParseGetPot, ParseException
 
 class RunApp(Tester):
 
@@ -57,6 +58,30 @@ class RunApp(Tester):
       return (False, reason)
 
     return (True, '')
+
+
+
+  def checkNlRelTol(self):
+    """Parse the input file and make sure nl_rel_tol is below the maximum."""
+    abs_path = os.path.join(self.specs['test_dir'].strip(), self.specs['input'].strip())
+    print abs_path
+    try:
+      p = ParseGetPot(abs_path)
+      root = p.root_node
+      if 'Executioner' in root.children:
+        executioner = root.children['Executioner']
+        if 'nl_rel_tol' in executioner.params:
+          tol = float(executioner.params['nl_rel_tol'])
+          if tol > 1e-8:
+            return False
+      return True
+    # There are a bunch of possible errors that should be handled by MOOSE (bad
+    # GetPot, non-existant input file).  If we got one of these exceptions we
+    # probably don't care about solver tolerance.
+    except ParseException:
+      return True
+    except IOError:
+      return True
 
 
 


### PR DESCRIPTION
This addresses #1643.  With this PR, after a test has been run, the `TestHarness` will parse the input file and look for `nl_rel_tol`.  If that's greater than 1e-8, it will fail the test.

I haven't actually updated any tests so we should see some example fails on @moosebuild's tests.  Hopefully those tests won't be too difficult to get in spec...
