### PR TITLE
Make tokenize more flexible

### DIFF
--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -34,27 +34,20 @@ class MaterialProperties;
 namespace MooseUtils
 {
   /**
-   * This function will split the passed in string on a set of delimiters appending the substrings
-   * to the passed in vector.  The delimiters default to "/" but may be supplied as well.  In addition
-   * if min_len is supplied, the minimum token length will be greater than the supplied value.
-   */
-  void tokenize(const std::string &str, std::vector<std::string> & elements, unsigned int min_len = 1, const std::string &delims = "/");
-
-  /**
    * This function will escape all of the standard C++ escape characters so that they can be printed.  The
    * passed in parameter is modified in place
    */
-  void escape(std::string &str);
+  void escape(std::string & str);
 
   /**
    * Standard scripting language trim function
    */
-  std::string trim(std::string str, const std::string &white_space = " \t\n\v\f\r");
+  std::string trim(std::string str, const std::string & white_space = " \t\n\v\f\r");
 
   /**
    * This function tokenizes a path and checks to see if it contains the string to look for
    */
-  bool pathContains(const std::string &expression, const std::string &string_to_find, const std::string &delims = "/");
+  bool pathContains(const std::string & expression, const std::string & string_to_find, const std::string & delims = "/");
 
   /**
    * Checks to see if a file is readable (exists and permissions)
@@ -228,6 +221,31 @@ namespace MooseUtils
    * that may be overloaded to dump the type using template specialization.
    */
   void MaterialPropertyStorageDump(const HashMap<const libMesh::Elem *, HashMap<unsigned int, MaterialProperties> > & props);
+
+  /**
+   * This function will split the passed in string on a set of delimiters appending the substrings
+   * to the passed in vector.  The delimiters default to "/" but may be supplied as well.  In addition
+   * if min_len is supplied, the minimum token length will be greater than the supplied value.
+   * T should be std::string or a MOOSE derivied string class.
+   */
+  template<typename T>
+  void
+  tokenize(const std::string & str, std::vector<T> & elements, unsigned int min_len = 1, const std::string & delims = "/")
+  {
+    elements.clear();
+
+    std::string::size_type last_pos = str.find_first_not_of(delims, 0);
+    std::string::size_type pos = str.find_first_of(delims, std::min(last_pos + min_len, str.size()));
+
+    while (last_pos != std::string::npos)
+    {
+      elements.push_back(str.substr(last_pos, pos - last_pos));
+      // skip delims between tokens
+      last_pos = str.find_first_not_of(delims, pos);
+      if (last_pos == std::string::npos) break;
+      pos = str.find_first_of(delims, std::min(last_pos + min_len, str.size()));
+    }
+  }
 }
 
 #endif //MOOSEUTILS_H

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -23,6 +23,7 @@
 #include <iterator>
 
 // MOOSE includes
+#include "MooseUtils.h"
 #include "MooseError.h"
 #include "MaterialProperty.h"
 
@@ -33,25 +34,7 @@ namespace MooseUtils
 {
 
 void
-tokenize(const std::string &str, std::vector<std::string> &elements, unsigned int min_len, const std::string &delims)
-{
-  elements.clear();
-
-  std::string::size_type last_pos = str.find_first_not_of(delims, 0);
-  std::string::size_type pos = str.find_first_of(delims, std::min(last_pos + min_len, str.size()));
-
-  while (last_pos != std::string::npos)
-  {
-    elements.push_back(str.substr(last_pos, pos - last_pos));
-    // skip delims between tokens
-    last_pos = str.find_first_not_of(delims, pos);
-    if (last_pos == std::string::npos) break;
-    pos = str.find_first_of(delims, std::min(last_pos + min_len, str.size()));
-  }
-}
-
-void
-escape(std::string &str)
+escape(std::string & str)
 {
   std::map<char, std::string> escapes;
   escapes['\a'] = "\\a";
@@ -69,18 +52,17 @@ escape(std::string &str)
 
 
 std::string
-trim(std::string str, const std::string &white_space)
+trim(std::string str, const std::string & white_space)
 {
   std::string r = str.erase(str.find_last_not_of(white_space)+1);
   return r.erase(0,r.find_first_not_of(white_space));
 }
 
-bool pathContains(const std::string &expression,
-                          const std::string &string_to_find,
-                          const std::string &delims)
+bool pathContains(const std::string & expression,
+                  const std::string & string_to_find,
+                  const std::string & delims)
 {
   std::vector<std::string> elements;
-
   tokenize(expression, elements, 0, delims);
 
   std::vector<std::string>::iterator found_it = std::find(elements.begin(), elements.end(), string_to_find);
@@ -130,8 +112,6 @@ checkFileWriteable(const std::string & filename, bool throw_on_unwritable)
     else
       return false;
   }
-
-
 
   out.close();
 


### PR DESCRIPTION
This makes `MooseUtils::tokenize` a function template that automagically works with vectors of derived string classes. This should help making it easier to use derived string classes throughout the code. My usecase is parsing a list of variable names into a `std::vector<VariableName>`.

Closes #5431
