### PR TITLE
Use -path to prune entire paths in delete_trailing_whitespace.sh

### DIFF
--- a/scripts/delete_trailing_whitespace.sh
+++ b/scripts/delete_trailing_whitespace.sh
@@ -7,5 +7,5 @@ REPO_DIR=${1:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"}
 if [ ! -d "$REPO_DIR" ]; then
   echo "$REPO_DIR directory does not exist";
 else
-  find $REPO_DIR \( -name "*.[Chi]" -or -name "*.py" -or \( -name "contrib" -or -name "libmesh" \) -prune -and -type f \) -print0 | xargs -0 perl -pli -e "s/\s+$//"
+  find $REPO_DIR -path ./contrib -prune -o -path ./libmesh -prune -o -name "*.[Chi]" -o -name "*.py" -type f -print0 | xargs -0 perl -pli -e "s/\s+$//"
 fi


### PR DESCRIPTION
This fixes the error reported in #5440 where a symbolic link was
incorrectly changed by this script.

This needs some more testing but it seems to fix the original issue reported in #5440.
