### PR TITLE
EulerAngleProvider user object system

### DIFF
--- a/modules/combined/examples/phase_field-mechanics/hex_grain_growth_2D_eldrforce.i
+++ b/modules/combined/examples/phase_field-mechanics/hex_grain_growth_2D_eldrforce.i
@@ -190,8 +190,7 @@
     #reading C_11  C_12  C_13  C_22  C_23  C_33  C_44  C_55  C_66
     Elastic_constants = '1.27e5 0.708e5 0.708e5 1.27e5 0.708e5 1.27e5 0.7355e5 0.7355e5 0.7355e5'
     GrainTracker_object = grain_tracker
-    # Euler_angles_file_name = grn_36_test_2D.tex #One grain will shrink
-    Euler_angles_file_name = grn_36_test2_2D.tex #One grain will grow
+    euler_angle_provider = euler_angle_file
   [../]
   [./strain]
     type = ComputeSmallStrain
@@ -234,6 +233,10 @@
     compute_op_maps = true
     execute_on = 'initial timestep_begin'
     flood_entity_type = ELEMENTAL
+  [../]
+  [./euler_angle_file]
+    type = EulerAngleFileReader
+    file_name = grn_36_test2_2D.tex
   [../]
 []
 

--- a/modules/combined/tests/ACGrGrElasticDrivingForce/bicrystal.i
+++ b/modules/combined/tests/ACGrGrElasticDrivingForce/bicrystal.i
@@ -12,7 +12,6 @@
 [GlobalParams]
   op_num = 2
   var_name_base = gr
-  Euler_angles_file_name = test.tex
 []
 
 [Variables]
@@ -193,6 +192,7 @@
     Elastic_constants = '1.27e5 0.708e5 0.708e5 1.27e5 0.708e5 1.27e5 0.7355e5 0.7355e5 0.7355e5'
     GrainTracker_object = grain_tracker
     grain_num = 2
+    euler_angle_provider = euler_angle_file
   [../]
   [./strain]
     type = ComputeSmallStrain
@@ -217,6 +217,10 @@
     compute_op_maps = true
     execute_on = TIMESTEP_BEGIN
     flood_entity_type = ELEMENTAL
+  [../]
+  [./euler_angle_file]
+    type = EulerAngleFileReader
+    file_name = test.tex
   [../]
 []
 

--- a/modules/phase_field/include/materials/ComputePolycrystalElasticityTensor.h
+++ b/modules/phase_field/include/materials/ComputePolycrystalElasticityTensor.h
@@ -12,6 +12,7 @@
 //Forward Declarations
 class ComputePolycrystalElasticityTensor;
 class GrainTracker;
+class EulerAngleProvider;
 
 /**
  * Compute an evolving elasticity tensor coupled to a grain growth phase field model.
@@ -31,7 +32,8 @@ protected:
   Real _length_scale;
   Real _pressure_scale;
 
-  FileName _Euler_angles_file_name;
+  /// Object providing the Euler angles
+  const EulerAngleProvider & _euler;
 
   /// Grain tracker object
   const GrainTracker & _grain_tracker;

--- a/modules/phase_field/include/userobjects/EBSDReader.h
+++ b/modules/phase_field/include/userobjects/EBSDReader.h
@@ -7,7 +7,7 @@
 #ifndef EBSDREADER_H
 #define EBSDREADER_H
 
-#include "GeneralUserObject.h"
+#include "EulerAngleProvider.h"
 #include "EBSDAccessFunctors.h"
 
 class EBSDReader;
@@ -19,7 +19,7 @@ InputParameters validParams<EBSDReader>();
  * A GeneralUserObject that reads an EBSD file and stores the centroid
  * data in a data structure which indexes on element centroids.
  */
-class EBSDReader : public GeneralUserObject, public EBSDAccessFunctors
+class EBSDReader : public EulerAngleProvider, public EBSDAccessFunctors
 {
 public:
   EBSDReader(const InputParameters & params);
@@ -59,9 +59,14 @@ public:
   const EBSDAvgData &  getAvgData(unsigned int phase, unsigned int grain) const;
 
   /**
+   * EulerAngleProvider interface implementation to fetch a triplet of Euler angles
+   */
+  virtual const EulerAngles & getEulerAngles(unsigned int) const;
+
+  /**
    * Return the total number of grains
    */
-  unsigned int getGrainNum() const;
+  virtual unsigned int getGrainNum() const;
 
   /**
    * Return the number of grains in a given phase
@@ -91,6 +96,9 @@ protected:
 
   /// Averages by feature ID
   std::vector<EBSDAvgData> _avg_data;
+
+  /// Euler Angles by feature ID
+  std::vector<EulerAngles> _avg_angles;
 
   /// feature ID for given phases and grains
   std::vector<std::vector<unsigned int> > _feature_id;

--- a/modules/phase_field/include/utils/EBSDAccessFunctors.h
+++ b/modules/phase_field/include/utils/EBSDAccessFunctors.h
@@ -3,6 +3,7 @@
 
 #include "MooseObject.h"
 #include "MooseEnum.h"
+#include "EulerAngles.h"
 
 /**
  * Mix-in class that adds so called access functors to select a field from
@@ -21,7 +22,7 @@ public:
 
   /// Averaged EBSD data
   struct EBSDAvgData {
-    Real phi1, phi, phi2;
+    EulerAngles * angles;
     unsigned int phase, symmetry, grain, n;
     Point p;
   };
@@ -70,13 +71,13 @@ public:
 
   // List of specialized access functors (one for each field in EBSDAvgData)
   struct EBSDAvgDataPhi1 : EBSDAvgDataFunctor {
-    virtual Real operator () (const EBSDAvgData & a) { return a.phi1; };
+    virtual Real operator () (const EBSDAvgData & a) { return a.angles->phi1; };
   };
   struct EBSDAvgDataPhi : EBSDAvgDataFunctor {
-    virtual Real operator () (const EBSDAvgData & a) { return a.phi; };
+    virtual Real operator () (const EBSDAvgData & a) { return a.angles->Phi; };
   };
   struct EBSDAvgDataPhi2 : EBSDAvgDataFunctor {
-    virtual Real operator () (const EBSDAvgData & a) { return a.phi2; };
+    virtual Real operator () (const EBSDAvgData & a) { return a.angles->phi2; };
   };
   struct EBSDAvgDataPhase : EBSDAvgDataFunctor {
     virtual Real operator () (const EBSDAvgData & a) { return a.phase; };

--- a/modules/phase_field/src/materials/ComputePolycrystalElasticityTensor.C
+++ b/modules/phase_field/src/materials/ComputePolycrystalElasticityTensor.C
@@ -7,6 +7,7 @@
 #include "ComputePolycrystalElasticityTensor.h"
 #include "RotationTensor.h"
 #include "GrainTracker.h"
+#include "EulerAngleProvider.h"
 #include "Conversion.h"
 
 template<>
@@ -14,7 +15,7 @@ InputParameters validParams<ComputePolycrystalElasticityTensor>()
 {
   InputParameters params = validParams<ComputeElasticityTensorBase>();
   params.addClassDescription("Compute an evolving elasticity tensor coupled to a grain growth phase field model.");
-  params.addRequiredParam<FileName>("Euler_angles_file_name", "Name of the file containing the Euler angles");
+  params.addRequiredParam<UserObjectName>("euler_angle_provider", "Name of Euler angle provider user object");
   params.addParam<Real>("length_scale", 1.0e-9, "Lengthscale of the problem, in meters");
   params.addParam<Real>("pressure_scale", 1.0e6, "Pressure scale of the problem, in pa");
   params.addRequiredCoupledVarWithAutoBuild("v", "var_name_base", "op_num", "Array of coupled variables");
@@ -28,11 +29,11 @@ InputParameters validParams<ComputePolycrystalElasticityTensor>()
 
 ComputePolycrystalElasticityTensor::ComputePolycrystalElasticityTensor(const InputParameters & parameters) :
     ComputeElasticityTensorBase(parameters),
-    _C_unrotated(getParam<std::vector<Real> >("Elastic_constants"), (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method")),
+    _C_unrotated(getParam<std::vector<Real> >("Elastic_constants"), (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method")), // TODO: rename to lower case "elastic_constants"
     _length_scale(getParam<Real>("length_scale")),
     _pressure_scale(getParam<Real>("pressure_scale")),
-    _Euler_angles_file_name(getParam<FileName>("Euler_angles_file_name")),
-    _grain_tracker(getUserObject<GrainTracker>("GrainTracker_object")),
+    _euler(getUserObject<EulerAngleProvider>("euler_angle_provider")),
+    _grain_tracker(getUserObject<GrainTracker>("GrainTracker_object")), // TODO: Rename to lower case "grain_tracker"
     _grain_num(getParam<unsigned int>("grain_num")),
     _stiffness_buffer(getParam<unsigned int>("stiffness_buffer")),
     _JtoeV(6.24150974e18), // Joule to eV conversion
@@ -43,27 +44,15 @@ ComputePolycrystalElasticityTensor::ComputePolycrystalElasticityTensor(const Inp
   _D_elastic_tensor.resize(_nop);
   _C_rotated.resize(_grain_num + _stiffness_buffer);
 
-  // Read in Euler angles from "angle_file_name"
-  std::ifstream inFile(_Euler_angles_file_name.c_str());
-
-  if (!inFile)
-    mooseError("Can't open " + _Euler_angles_file_name);
-
-  for (unsigned int i = 0; i < 4; ++i)
-    inFile.ignore(std::numeric_limits<std::streamsize>::max(), '\n'); // ignore line
-
-  Real weight;
+  // Read in Euler angles from the Euler angle provider
+  if (_euler.getGrainNum() < _grain_num)
+    mooseError("Euler angle provider has too few angles.");
 
   // Loop over grains
   for (unsigned int grn = 0; grn < _grain_num; ++grn)
   {
     // Read in Euler angles
-    RealVectorValue Euler_Angles;
-    for (unsigned int j=0; j<3; ++j)
-      inFile >> Euler_Angles(j);
-
-    // Read in weight
-    inFile >> weight;
+    RealVectorValue Euler_Angles = _euler.getEulerAngles(grn);
 
     // Rotate one elasticity tensor for each grain
     RotationTensor R(Euler_Angles);
@@ -76,9 +65,6 @@ ComputePolycrystalElasticityTensor::ComputePolycrystalElasticityTensor(const Inp
       _C_rotated[grn + _grain_num].rotate(R);
     }
   }
-
-  // Close Euler angle file
-  inFile.close();
 
   // Loop over variables (ops)
   for (unsigned int op = 0; op < _nop; ++op)
@@ -110,7 +96,7 @@ ComputePolycrystalElasticityTensor::computeQpElasticityTensor()
 
   unsigned int n_active_ops= active_ops.size();
 
-  if (n_active_ops < 1 && _t_step > 0 )
+  if (n_active_ops < 1 && _t_step > 0)
     mooseError("No active order parameters");
 
   // Calculate elasticity tensor
@@ -168,7 +154,7 @@ ComputePolycrystalElasticityTensor::ComputePolycrystalElasticityTensor(const std
     _C_unrotated(getParam<std::vector<Real> >("Elastic_constants"), (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method")),
     _length_scale(getParam<Real>("length_scale")),
     _pressure_scale(getParam<Real>("pressure_scale")),
-    _Euler_angles_file_name(getParam<FileName>("Euler_angles_file_name")),
+    _euler(getUserObject<EulerAngleProvider>("euler_angle_provider")),
     _grain_tracker(getUserObject<GrainTracker>("GrainTracker_object")),
     _grain_num(getParam<unsigned int>("grain_num")),
     _stiffness_buffer(getParam<unsigned int>("stiffness_buffer")),
@@ -180,27 +166,15 @@ ComputePolycrystalElasticityTensor::ComputePolycrystalElasticityTensor(const std
   _D_elastic_tensor.resize(_nop);
   _C_rotated.resize(_grain_num + _stiffness_buffer);
 
-  // Read in Euler angles from "angle_file_name"
-  std::ifstream inFile(_Euler_angles_file_name.c_str());
-
-  if (!inFile)
-    mooseError("Can't open " + _Euler_angles_file_name);
-
-  for (unsigned int i = 0; i < 4; ++i)
-    inFile.ignore(std::numeric_limits<std::streamsize>::max(), '\n'); // ignore line
-
-  Real weight;
+  // Read in Euler angles from the Euler angle provider
+  if (_euler.getGrainNum() < _grain_num)
+    mooseError("Euler angle provider has too few angles.");
 
   // Loop over grains
   for (unsigned int grn = 0; grn < _grain_num; ++grn)
   {
     // Read in Euler angles
-    RealVectorValue Euler_Angles;
-    for (unsigned int j=0; j<3; ++j)
-      inFile >> Euler_Angles(j);
-
-    // Read in weight
-    inFile >> weight;
+    RealVectorValue Euler_Angles = _euler.getEulerAngles(grn);
 
     // Rotate one elasticity tensor for each grain
     RotationTensor R(Euler_Angles);
@@ -213,9 +187,6 @@ ComputePolycrystalElasticityTensor::ComputePolycrystalElasticityTensor(const std
       _C_rotated[grn + _grain_num].rotate(R);
     }
   }
-
-  // Close Euler angle file
-  inFile.close();
 
   // Loop over variables (ops)
   for (unsigned int op = 0; op < _nop; ++op)

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -11,7 +11,7 @@
 template<>
 InputParameters validParams<EBSDReader>()
 {
-  InputParameters params = validParams<GeneralUserObject>();
+  InputParameters params = validParams<EulerAngleProvider>();
   params.addRequiredParam<unsigned int>("op_num", "Specifies the number of order parameters to create");
   return params;
 }

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -17,7 +17,7 @@ InputParameters validParams<EBSDReader>()
 }
 
 EBSDReader::EBSDReader(const InputParameters & params) :
-    GeneralUserObject(params),
+    EulerAngleProvider(params),
     _mesh(_fe_problem.mesh()),
     _nl(_fe_problem.getNonlinearSystem()),
     _op_num(getParam<unsigned int>("op_num")),
@@ -105,24 +105,29 @@ EBSDReader::initialSetup()
 
   // Resize the variables
   _avg_data.resize(_feature_num);
+  _avg_angles.resize(_feature_num);
 
   // clear the averages
   for (unsigned int i = 0; i < _feature_num; ++i)
   {
     EBSDAvgData & a = _avg_data[i];
-    a.p = a.phi1 = a.phi = a.phi2 = 0.0;
     a.symmetry = a.phase = a.n = 0;
+    a.p = 0.0;
+
+    EulerAngles & b = _avg_angles[i];
+    b.phi1 = b.Phi = b.phi2 = 0.0;
   }
 
   // Iterate through data points to get average variable values for each grain
   for (std::vector<EBSDPointData>::iterator j = _data.begin(); j != _data.end(); ++j)
   {
     EBSDAvgData & a = _avg_data[j->grain];
+    EulerAngles & b = _avg_angles[j->grain];
 
     //use Eigen::Quaternion<Real> here?
-    a.phi1 += j->phi1;
-    a.phi  += j->phi;
-    a.phi2 += j->phi2;
+    b.phi1 += j->phi1;
+    b.Phi  += j->phi;
+    b.phi2 += j->phi2;
 
     if (a.n == 0)
       a.phase = j->phase;
@@ -143,12 +148,16 @@ EBSDReader::initialSetup()
   for (unsigned int i = 0; i < _feature_num; ++i)
   {
     EBSDAvgData & a = _avg_data[i];
+    EulerAngles & b = _avg_angles[i];
 
     if (a.n == 0) continue;
 
-    a.phi1 /= Real(a.n);
-    a.phi  /= Real(a.n);
-    a.phi2 /= Real(a.n);
+    b.phi1 /= Real(a.n);
+    b.Phi  /= Real(a.n);
+    b.phi2 /= Real(a.n);
+
+    // link the EulerAngles into the EBSDAvgData for access via the functors
+    a.angles = &b;
 
     if (a.phase >= _feature_id.size())
       _feature_id.resize(a.phase + 1);
@@ -177,6 +186,12 @@ const EBSDReader::EBSDAvgData &
 EBSDReader::getAvgData(unsigned int var) const
 {
   return _avg_data[indexFromIndex(var)];
+}
+
+const EulerAngles &
+EBSDReader::getEulerAngles(unsigned int var) const
+{
+  return _avg_angles[indexFromIndex(var)];
 }
 
 const EBSDReader::EBSDAvgData &
@@ -287,7 +302,7 @@ EBSDReader::buildNodeToGrainWeightMap()
 
 // DEPRECATED CONSTRUCTOR
 EBSDReader::EBSDReader(const std::string & deprecated_name, InputParameters params) :
-    GeneralUserObject(deprecated_name, params),
+    EulerAngleProvider(deprecated_name, params),
     _mesh(_fe_problem.mesh()),
     _nl(_fe_problem.getNonlinearSystem()),
     _op_num(getParam<unsigned int>("op_num")),

--- a/modules/tensor_mechanics/include/userobjects/EulerAngleFileReader.h
+++ b/modules/tensor_mechanics/include/userobjects/EulerAngleFileReader.h
@@ -1,0 +1,42 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef EULERANGLEFILEREADER_H
+#define EULERANGLEFILEREADER_H
+
+#include "EulerAngleProvider.h"
+#include <vector>
+
+//Forward declaration
+class EulerAngleFileReader;
+
+template<>
+InputParameters validParams<EulerAngleFileReader>();
+
+/**
+ * Read a set of Euler angles from a file
+ */
+class EulerAngleFileReader : public EulerAngleProvider
+{
+public:
+  EulerAngleFileReader(const InputParameters & parameters);
+  EulerAngleFileReader(const std::string & deprecated_name, InputParameters parameters); // DEPRECATED CONSTRUCTOR
+
+  virtual const EulerAngles & getEulerAngles(unsigned int) const;
+  virtual unsigned int getGrainNum() const;
+
+  virtual void initialize() {}
+  virtual void execute() {}
+  virtual void finalize() {}
+
+protected:
+  void readFile();
+
+  FileName _file_name;
+  std::vector<EulerAngles> _angles;
+};
+
+#endif //EULERANGLEFILEREADER_H

--- a/modules/tensor_mechanics/include/userobjects/EulerAngleProvider.h
+++ b/modules/tensor_mechanics/include/userobjects/EulerAngleProvider.h
@@ -1,8 +1,19 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
 #ifndef EULERANGLEPROVIDER_H
 #define EULERANGLEPROVIDER_H
 
 #include "EulerAngles.h"
 #include "GeneralUserObject.h"
+
+class EulerAngleProvider;
+
+template<>
+InputParameters validParams<EulerAngleProvider>();
 
 /**
  * Abstract base class for user objects that implement the Euler Angle provider

--- a/modules/tensor_mechanics/include/userobjects/EulerAngleProvider.h
+++ b/modules/tensor_mechanics/include/userobjects/EulerAngleProvider.h
@@ -1,0 +1,21 @@
+#ifndef EULERANGLEPROVIDER_H
+#define EULERANGLEPROVIDER_H
+
+#include "EulerAngles.h"
+#include "GeneralUserObject.h"
+
+/**
+ * Abstract base class for user objects that implement the Euler Angle provider
+ * interface.
+ */
+class EulerAngleProvider : public GeneralUserObject
+{
+public:
+  EulerAngleProvider(const InputParameters & parameters) : GeneralUserObject(parameters) {}
+  EulerAngleProvider(const std::string & deprecated_name, InputParameters parameters) : GeneralUserObject(deprecated_name, parameters) {}; // DEPRECATED CONSTRUCTOR
+
+  virtual const EulerAngles & getEulerAngles(unsigned int) const = 0;
+  virtual unsigned int getGrainNum() const = 0;
+};
+
+#endif //EULERANGLEPROVIDER_H

--- a/modules/tensor_mechanics/include/utils/EulerAngles.h
+++ b/modules/tensor_mechanics/include/utils/EulerAngles.h
@@ -1,0 +1,15 @@
+#ifndef EULERANGLES_H
+#define EULERANGLES_H
+
+#include "MooseTypes.h"
+
+/**
+ * Euler angle triplet.
+ */
+class EulerAngles
+{
+public:
+  Real phi1, Phi, phi2;
+};
+
+#endif //EULERANGLES_H

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -65,6 +65,7 @@
 #include "HyperElasticStress.h"
 #include "FlowRateModel.h"
 #include "RambergOsgoodHardening.h"
+#include "EulerAngleFileReader.h"
 
 #include "RankTwoAux.h"
 #include "RealTensorValueAux.h"
@@ -178,6 +179,7 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerUserObject(HyperElasticStress);
   registerUserObject(FlowRateModel);
   registerUserObject(RambergOsgoodHardening);
+  registerUserObject(EulerAngleFileReader);
 
   registerAux(RankTwoAux);
   registerAux(RealTensorValueAux);

--- a/modules/tensor_mechanics/src/userobjects/EulerAngleFileReader.C
+++ b/modules/tensor_mechanics/src/userobjects/EulerAngleFileReader.C
@@ -1,0 +1,65 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#include "EulerAngleFileReader.h"
+
+template<>
+InputParameters validParams<EulerAngleFileReader>()
+{
+  InputParameters params = validParams<EulerAngleProvider>();
+  params.addClassDescription("Read Euler angle data from a file and provide it to other objects.");
+  params.addRequiredParam<FileName>("file_name", "Euler angle data file name");
+  return params;
+}
+
+EulerAngleFileReader::EulerAngleFileReader(const InputParameters & params) :
+    EulerAngleProvider(params),
+    _file_name(getParam<FileName>("file_name"))
+{
+  readFile();
+}
+
+unsigned int
+EulerAngleFileReader::getGrainNum() const
+{
+  return _angles.size();
+}
+
+const EulerAngles &
+EulerAngleFileReader::getEulerAngles(unsigned int i) const
+{
+  mooseAssert(i < getGrainNum(), "Requesting Euler angles for an invalid grain id");
+  return _angles[i];
+}
+
+void
+EulerAngleFileReader::readFile()
+{
+  // Read in Euler angles from _file_name
+  std::ifstream inFile(_file_name.c_str());
+  if (!inFile)
+    mooseError("Can't open " << _file_name);
+
+  // Skip first 4 lines
+  for (unsigned int i = 0; i < 4; ++i)
+    inFile.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  // The angle files contain a fourth column with weights that we ignore in this version
+  Real weight;
+
+  // Loop over grains
+  EulerAngles a;
+  while (inFile >> a.phi1 >> a.Phi >> a.phi2 >> weight)
+    _angles.push_back(EulerAngles(a));
+}
+
+// DEPRECATED CONSTRUCTOR
+EulerAngleFileReader::EulerAngleFileReader(const std::string & deprecated_name, InputParameters params) :
+    EulerAngleProvider(deprecated_name, params),
+    _file_name(getParam<FileName>("file_name"))
+{
+  readFile();
+}

--- a/modules/tensor_mechanics/src/userobjects/EulerAngleProvider.C
+++ b/modules/tensor_mechanics/src/userobjects/EulerAngleProvider.C
@@ -4,21 +4,10 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#ifndef EULERANGLES_H
-#define EULERANGLES_H
+#include "EulerAngleProvider.h"
 
-#include "MooseTypes.h"
-#include "libmesh/vector_value.h"
-
-/**
- * Euler angle triplet.
- */
-class EulerAngles
+template<>
+InputParameters validParams<EulerAngleProvider>()
 {
-public:
-  Real phi1, Phi, phi2;
-
-  operator RealVectorValue() const { return RealVectorValue(phi1, Phi, phi2); }
-};
-
-#endif //EULERANGLES_H
+  return validParams<GeneralUserObject>();
+}

--- a/unit/src/EBSDAccessFunctorsTest.C
+++ b/unit/src/EBSDAccessFunctorsTest.C
@@ -16,6 +16,7 @@
 
 //Moose includes
 #include "EBSDAccessFunctors.h"
+#include "EulerAngles.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION( EBSDAccessFunctorsTest );
 
@@ -122,15 +123,17 @@ EBSDAccessFunctorsTest::avgData()
   for (unsigned int i = 0; i < 10; ++i)
   {
     // initialize data
-    d.phi1  = i * offset + 0.4;
-    d.phi   = i * offset + 1.5;
-    d.phi2  = i * offset + 2.6;
+    EulerAngles a;
+    a.phi1  = i * offset + 0.4;
+    a.Phi   = i * offset + 1.5;
+    a.phi2  = i * offset + 2.6;
+    d.angles = &a;
     d.phase = i * offset + 3.7;
     d.symmetry = i * offset + 4.9;
 
     // check functors
     v1 = new EBSDAccessFunctors::EBSDAvgDataPhi1;
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v1)(d), d.phi1, 1e-9 );
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v1)(d), a.phi1, 1e-9 );
     field = "phi1";
     v2 = EBSDAccessFunctors::getAvgDataAccessFunctor(field);
     CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v2)(d), (*v1)(d), 1e-9 );
@@ -138,7 +141,7 @@ EBSDAccessFunctorsTest::avgData()
     delete v1;
 
     v1 = new EBSDAccessFunctors::EBSDAvgDataPhi;
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v1)(d), d.phi, 1e-9 );
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v1)(d), a.Phi, 1e-9 );
     field = "phi";
     v2 = EBSDAccessFunctors::getAvgDataAccessFunctor(field);
     CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v2)(d), (*v1)(d), 1e-9 );
@@ -146,7 +149,7 @@ EBSDAccessFunctorsTest::avgData()
     delete v1;
 
     v1 = new EBSDAccessFunctors::EBSDAvgDataPhi2;
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v1)(d), d.phi2, 1e-9 );
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v1)(d), a.phi2, 1e-9 );
     field = "phi2";
     v2 = EBSDAccessFunctors::getAvgDataAccessFunctor(field);
     CPPUNIT_ASSERT_DOUBLES_EQUAL( (*v2)(d), (*v1)(d), 1e-9 );


### PR DESCRIPTION
This PR introduces the concept of an `EulerAngleProvider`, a user object that can be asked for a number of Euler angles. I implemented an `EulerAngleFileReader` that reads in a text file with a bunch of Euler angles and I have added the same interface to `EBSDReader` so that it can be used interchangeably as an Euler angle source.

I'll be working on fixing the MARMOT tests next, but this PR can be merged already.

Closes #5438
