### PR TITLE
Parameter for timeintegrator 5428

### DIFF
--- a/examples/ex06_transient/ex06.i
+++ b/examples/ex06_transient/ex06.i
@@ -51,7 +51,8 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-
+  scheme = dirk
+  dirk_order = 3
 
   num_steps = 75
   dt = 1

--- a/framework/include/actions/SetupTimeIntegratorAction.h
+++ b/framework/include/actions/SetupTimeIntegratorAction.h
@@ -1,0 +1,42 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef SETUPTIMEINTEGRATORACTION_H
+#define SETUPTIMEINTEGRATORACTION_H
+
+#include "MooseObjectAction.h"
+
+class SetupTimeIntegratorAction;
+
+template<>
+InputParameters validParams<SetupTimeIntegratorAction>();
+
+/**
+ *
+ */
+class SetupTimeIntegratorAction : public MooseObjectAction
+{
+public:
+  SetupTimeIntegratorAction(InputParameters parameters);
+  SetupTimeIntegratorAction(const std::string & deprecated_name, InputParameters parameters); // DEPRECATED CONSTRUCTOR
+  virtual ~SetupTimeIntegratorAction();
+
+  virtual void act();
+
+protected:
+
+};
+
+
+#endif /* SETUPTIMEINTEGRATORACTION_H */

--- a/framework/include/timeintegrators/Dirk.h
+++ b/framework/include/timeintegrators/Dirk.h
@@ -41,6 +41,9 @@ protected:
 
   //! Indicates stage or, if _stage==3, the update step.
   unsigned int _stage;
+  
+  //! Order of the DIRK integrator. @note At the moment, only a second order DIRK is implemented
+  unsigned int _order;
 
   //! Buffer to store non-time residual from first stage solve.
   NumericVector<Number> & _residual_stage1;

--- a/framework/include/timeintegrators/Dirk.h
+++ b/framework/include/timeintegrators/Dirk.h
@@ -41,7 +41,7 @@ protected:
 
   //! Indicates stage or, if _stage==3, the update step.
   unsigned int _stage;
-  
+
   //! Order of the DIRK integrator. @note At the moment, only a second order DIRK is implemented
   unsigned int _order;
 

--- a/framework/src/actions/SetupTimeIntegratorAction.C
+++ b/framework/src/actions/SetupTimeIntegratorAction.C
@@ -1,0 +1,58 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "SetupTimeIntegratorAction.h"
+#include "Transient.h"
+#include "Factory.h"
+#include "TimeStepper.h"
+
+template<>
+InputParameters validParams<SetupTimeIntegratorAction>()
+{
+  InputParameters params = validParams<MooseObjectAction>();
+
+  return params;
+}
+
+SetupTimeIntegratorAction::SetupTimeIntegratorAction(InputParameters parameters) :
+    MooseObjectAction(parameters)
+{
+}
+
+SetupTimeIntegratorAction::~SetupTimeIntegratorAction()
+{
+}
+
+void
+SetupTimeIntegratorAction::act()
+{
+/*  if (_problem->isTransient())
+  {
+    Transient * transient = dynamic_cast<Transient *>(_executioner.get());
+    if (transient == NULL)
+      mooseError("You can setup time stepper only with executioners of transient type.");
+
+    _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
+    _moose_object_pars.set<Transient *>("_executioner") = transient;
+    MooseSharedPointer<TimeStepper> ts = MooseSharedNamespace::static_pointer_cast<TimeStepper>(_factory.create(_type, "TimeStepper", _moose_object_pars));
+    transient->setTimeStepper(ts);
+  }*/
+}
+
+
+// DEPRECATED CONSTRUCTOR
+SetupTimeIntegratorAction::SetupTimeIntegratorAction(const std::string & deprecated_name, InputParameters parameters) :
+    MooseObjectAction(deprecated_name, parameters)
+{
+}

--- a/framework/src/actions/SetupTimeIntegratorAction.C
+++ b/framework/src/actions/SetupTimeIntegratorAction.C
@@ -37,17 +37,6 @@ SetupTimeIntegratorAction::~SetupTimeIntegratorAction()
 void
 SetupTimeIntegratorAction::act()
 {
-/*  if (_problem->isTransient())
-  {
-    Transient * transient = dynamic_cast<Transient *>(_executioner.get());
-    if (transient == NULL)
-      mooseError("You can setup time stepper only with executioners of transient type.");
-
-    _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
-    _moose_object_pars.set<Transient *>("_executioner") = transient;
-    MooseSharedPointer<TimeStepper> ts = MooseSharedNamespace::static_pointer_cast<TimeStepper>(_factory.create(_type, "TimeStepper", _moose_object_pars));
-    transient->setTimeStepper(ts);
-  }*/
 }
 
 

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -789,8 +789,6 @@ addActionTypes(Syntax & syntax)
   registerMooseObjectTask("add_damper",                   Damper,                 false);
   registerMooseObjectTask("setup_predictor",              Predictor,              false);
   registerMooseObjectTask("setup_time_stepper",           TimeStepper,            false);
-
-
   registerMooseObjectTask("setup_time_integrator",        TimeIntegrator,            false);
 
   registerMooseObjectTask("add_preconditioning",          MoosePreconditioner,    false);
@@ -884,6 +882,7 @@ addActionTypes(Syntax & syntax)
 "(create_problem)"
 "(setup_executioner)"
 "(setup_time_stepper)"
+"(setup_time_integrator)"
 "(setup_predictor)"
 "(setup_postprocessor_data)"
 "(setup_time_periods)"

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -789,6 +789,9 @@ addActionTypes(Syntax & syntax)
   registerMooseObjectTask("setup_predictor",              Predictor,              false);
   registerMooseObjectTask("setup_time_stepper",           TimeStepper,            false);
 
+
+  registerMooseObjectTask("setup_time_integrator",        TimeIntegrator,            false);
+
   registerMooseObjectTask("add_preconditioning",          MoosePreconditioner,    false);
   registerMooseObjectTask("add_split",                    Split,                  false);
 

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -363,6 +363,7 @@
 #include "AddTransferAction.h"
 #include "AddNodalNormalsAction.h"
 #include "SetupTimeStepperAction.h"
+#include "SetupTimeIntegratorAction.h"
 #include "SetupPredictorAction.h"
 #include "AddMortarInterfaceAction.h"
 #include "SetupPostprocessorDataAction.h"
@@ -965,6 +966,7 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
   registerAction(AddFunctionAction, "add_function");
   registerAction(CreateExecutionerAction, "setup_executioner");
   registerAction(SetupTimeStepperAction, "setup_time_stepper");
+  registerAction(SetupTimeIntegratorAction, "setup_time_integrator");
   registerAction(SetupTimePeriodsAction, "setup_time_periods");
   registerAction(InitDisplacedProblemAction, "init_displaced_problem");
   registerAction(DetermineSystemType, "determine_system_type");

--- a/framework/src/parser/MooseSyntax.C
+++ b/framework/src/parser/MooseSyntax.C
@@ -95,6 +95,8 @@ void associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("DetermineSystemType", "Executioner");
   syntax.registerActionSyntax("CreateExecutionerAction", "Executioner");
   syntax.registerActionSyntax("SetupTimeStepperAction", "Executioner/TimeStepper");
+  syntax.registerActionSyntax("SetupTimeIntegratorAction", "Executioner/TimeTimeIntegrator");
+
   syntax.registerActionSyntax("SetupTimePeriodsAction", "Executioner/TimePeriods/*");
   syntax.registerActionSyntax("SetupQuadratureAction", "Executioner/Quadrature");
   syntax.registerActionSyntax("SetupPredictorAction", "Executioner/Predictor");

--- a/framework/src/parser/MooseSyntax.C
+++ b/framework/src/parser/MooseSyntax.C
@@ -95,7 +95,7 @@ void associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("DetermineSystemType", "Executioner");
   syntax.registerActionSyntax("CreateExecutionerAction", "Executioner");
   syntax.registerActionSyntax("SetupTimeStepperAction", "Executioner/TimeStepper");
-  syntax.registerActionSyntax("SetupTimeIntegratorAction", "Executioner/TimeTimeIntegrator");
+  syntax.registerActionSyntax("SetupTimeIntegratorAction", "Executioner/TimeIntegrator");
 
   syntax.registerActionSyntax("SetupTimePeriodsAction", "Executioner/TimePeriods/*");
   syntax.registerActionSyntax("SetupQuadratureAction", "Executioner/Quadrature");

--- a/framework/src/timeintegrators/Dirk.C
+++ b/framework/src/timeintegrators/Dirk.C
@@ -21,7 +21,9 @@ template<>
 InputParameters validParams<Dirk>()
 {
   InputParameters params = validParams<TimeIntegrator>();
-
+  // This serves as a test for passing parameter to TimeIntegrators. Later, the implementation of DIRK can be extended to actually provide
+  // DIRK methods of different order
+  params.addParam<unsigned int>("dirk_order", 2, "Order of the DIRK integrator. Default: 2");
   return params;
 }
 
@@ -29,10 +31,12 @@ InputParameters validParams<Dirk>()
 Dirk::Dirk(const InputParameters & parameters) :
     TimeIntegrator(parameters),
     _stage(1),
+    _order(getParam<unsigned int>("dirk_order")),
     _residual_stage1(_nl.addVector("residual_stage1", false, GHOSTED)),
     _residual_stage2(_nl.addVector("residual_stage2", false, GHOSTED)),
     _solution_start(_sys.solutionOld())
 {
+  if (_order != 2) mooseError("Only a second order DIRK method is implemented at the moment");
 }
 
 


### PR DESCRIPTION
Attempt to resolve issue #5428 and add the possibility to define parameters for TimeIntegrator objects. Code is not complete though and I need some help (therefore, I also have not yet squashed the commits).

I essentially mirrored all calls made for parameters for TimeStepper objects in the hope that I could then define parameters for TimeIntegrators the same way. Tests are passed in the current version, but parameters for time integrators are not recognized.

As a test example, I specified the parameter _dirk_order_ in the Dirk time integrator. At the moment, it can only have the value _2_ (which is also the set default), for all other values a MOOSE error is thrown that says that it is not yet implemented. Now, when I add the lines

>   scheme = dirk
>  dirk_order = 3

to the _Executioner_ section of _ex06.i_ in _/examples/ex06_transient_, instead of throwing the error, it runs with the default value of dirk_order=2.
