### PR TITLE
Correct error running moose tests (python re.search pattern, support petsc 3.6.1 )

### DIFF
--- a/python/TestHarness/testers/PetscJacobianTester.py
+++ b/python/TestHarness/testers/PetscJacobianTester.py
@@ -23,7 +23,7 @@ class PetscJacobianTester(RunApp):
     self.specs['cli_args'].append('-snes_type test')
 
   def processResults(self, moose_dir, retcode, options, output):
-    m = re.search("Norm of matrix ratio (\S+) difference (\S+) \(user-defined state\)", output, re.MULTILINE | re.DOTALL);
+    m = re.search("Norm of matrix ratio (\S+), difference (\S+) \(user-defined state\)", output, re.MULTILINE | re.DOTALL);
     if m:
       if float(m.group(1)) < float(self.specs['ratio_tol']) and float(m.group(2)) < float(self.specs['difference_tol']):
         reason = ''

--- a/python/TestHarness/testers/PetscJacobianTester.py
+++ b/python/TestHarness/testers/PetscJacobianTester.py
@@ -23,7 +23,7 @@ class PetscJacobianTester(RunApp):
     self.specs['cli_args'].append('-snes_type test')
 
   def processResults(self, moose_dir, retcode, options, output):
-    m = re.search("Norm of matrix ratio (\S+), difference (\S+) \(user-defined state\)", output, re.MULTILINE | re.DOTALL);
+    m = re.search("Norm of matrix ratio (\S+),? difference (\S+) \(user-defined state\)", output, re.MULTILINE | re.DOTALL);
     if m:
       if float(m.group(1)) < float(self.specs['ratio_tol']) and float(m.group(2)) < float(self.specs['difference_tol']):
         reason = ''


### PR DESCRIPTION
I get the following error running the moose tests.

kernels/coupled_kernel_value.test_coupled_kernel_value_test............................................... OK
Traceback (most recent call last):
  File "./run_tests", line 24, in <module>
    TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
  File "/home/garvct/trunk/falcon-moose-dev-5.7.0-gmvolf-5.5.7/moose/python/TestHarness/TestHarness.py", line 34, in buildAndRun
    harness.findAndRunTests()
  File "/home/garvct/trunk/falcon-moose-dev-5.7.0-gmvolf-5.5.7/moose/python/TestHarness/TestHarness.py", line 195, in findAndRunTests
    self.runner.run(tester, command)
  File "/home/garvct/trunk/falcon-moose-dev-5.7.0-gmvolf-5.5.7/moose/python/TestHarness/RunParallel.py", line 69, in run
    self.spinwait()
  File "/home/garvct/trunk/falcon-moose-dev-5.7.0-gmvolf-5.5.7/moose/python/TestHarness/RunParallel.py", line 159, in spinwait
    self.returnToTestHarness(job_index)
  File "/home/garvct/trunk/falcon-moose-dev-5.7.0-gmvolf-5.5.7/moose/python/TestHarness/RunParallel.py", line 135, in returnToTestHarness
    if not self.harness.testOutputAndFinish(tester, p.returncode, output, time, clock()):
  File "/home/garvct/trunk/falcon-moose-dev-5.7.0-gmvolf-5.5.7/moose/python/TestHarness/TestHarness.py", line 340, in testOutputAndFinish
    (reason, output) = tester.processResults(self.moose_dir, retcode, self.options, output)
  File "/home/garvct/trunk/falcon-moose-dev-5.7.0-gmvolf-5.5.7/moose/python/TestHarness/testers/PetscJacobianTester.py", line 28, in processResults
    if float(m.group(1)) < float(self.specs['ratio_tol']) and float(m.group(2)) < float(self.specs['difference_tol']):
ValueError: invalid literal for float(): 1.00423e-16,

The problem is

   f = float('1.00423e-16,')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for float(): 1.00423e-16,

The output has the line

Norm of matrix ratio 1.00423e-16, difference 4.29988e-16 (user-defined state)

See line 26 (moose/python/TestHarness/testers/PetscJacobianTester.py)

Currently is

m = re.search("Norm of matrix ratio (\S+) difference (\S+) (user-defined state)", output, re.MULTILINE | re.DOTALL);

Should it be?

m = re.search("Norm of matrix ratio (\S+), difference (\S+) (user-defined state)", output, re.MULTILINE | re.DOTALL);

Thanks,
Cormac.
