### PR TITLE
Refactor MultiAppMeshFunctionTransfer

### DIFF
--- a/framework/include/transfers/MultiAppTransfer.h
+++ b/framework/include/transfers/MultiAppTransfer.h
@@ -102,7 +102,6 @@ protected:
    */
   NumericVector<Real> & getTransferVector(unsigned int i_local, std::string var_name);
 
-private:
   // Given local app index, returns global app index.
   std::vector<unsigned int> _local2global_map;
 };

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -24,6 +24,7 @@
 #include "libmesh/system.h"
 #include "libmesh/mesh_function.h"
 #include "libmesh/mesh_tools.h"
+#include "libmesh/parallel_algebra.h"
 
 template<>
 InputParameters validParams<MultiAppMeshFunctionTransfer>()
@@ -43,8 +44,6 @@ MultiAppMeshFunctionTransfer::MultiAppMeshFunctionTransfer(const InputParameters
     _from_var_name(getParam<VariableName>("source_variable")),
     _error_on_miss(getParam<bool>("error_on_miss"))
 {
-  // This transfer does not work with ParallelMesh
-  _fe_problem.mesh().errorIfParallelDistribution("MultiAppMeshFunctionTransfer");
   _displaced_source_mesh = getParam<bool>("displaced_source_mesh");
   _displaced_target_mesh = getParam<bool>("displaced_target_mesh");
 }
@@ -63,288 +62,346 @@ MultiAppMeshFunctionTransfer::execute()
 {
   Moose::out << "Beginning MeshFunctionTransfer " << name() << std::endl;
 
-  switch (_direction)
+  getAppInfo();
+
+  ////////////////////
+  // For every combination of global "from" problem and local "to" problem, find
+  // which "from" bounding boxes overlap with which "to" elements.  Keep track
+  // of which processors own bounding boxes that overlap with which elements.
+  // Build vectors of node locations/element centroids to send to other
+  // processors for mesh function evaluations.
+  ////////////////////
+
+  // Get the bounding boxes for the "from" domains.
+  std::vector<MeshTools::BoundingBox> bboxes = getFromBoundingBoxes();
+
+  // Figure out how many "from" domains each processor owns.
+  std::vector<unsigned int> froms_per_proc = getFromsPerProc();
+
+  std::vector<std::vector<Point> > outgoing_points(n_processors());
+  std::vector<std::map<std::pair<unsigned int, unsigned int>, unsigned int> > point_index_map(n_processors());
+  // point_index_map[i_to, element_id] = index
+  // outgoing_points[index] is the first quadrature point in element
+
+  for (unsigned int i_to = 0; i_to < _to_problems.size(); i_to++)
   {
-    case TO_MULTIAPP:
+    System * to_sys = find_sys(*_to_es[i_to], _to_var_name);
+    unsigned int sys_num = to_sys->number();
+    unsigned int var_num = to_sys->variable_number(_to_var_name);
+    MeshBase * to_mesh = & _to_meshes[i_to]->getMesh();
+    bool is_nodal = to_sys->variable_type(var_num).family == LAGRANGE;
+
+    if (is_nodal)
     {
-      // TODO: This doesn't work with the master app being displaced see #3424
-      if (_displaced_source_mesh)
-        mooseError("displaced_source_mesh is not yet implemented for transferring 'to_multiapp'");
+      MeshBase::const_node_iterator node_it = to_mesh->local_nodes_begin();
+      MeshBase::const_node_iterator node_end = to_mesh->local_nodes_end();
 
-      FEProblem & from_problem = *_multi_app->problem();
-      MooseVariable & from_var = from_problem.getVariable(0, _from_var_name);
-
-      SystemBase & from_system_base = from_var.sys();
-
-      System & from_sys = from_system_base.system();
-
-      // Only works with a serialized mesh to transfer from!
-      mooseAssert(from_sys.get_mesh().is_serial(), "MultiAppMeshFunctionTransfer only works with SerialMesh!");
-
-      unsigned int from_var_num = from_sys.variable_number(from_var.name());
-
-      EquationSystems * tmp_es = NULL;
-
-      if (_displaced_source_mesh && from_problem.getDisplacedProblem())
-        tmp_es = &from_problem.getDisplacedProblem()->es();
-      else
-        tmp_es = &from_problem.es();
-
-      EquationSystems & from_es = *tmp_es;
-
-      //Create a serialized version of the solution vector
-      NumericVector<Number> * serialized_solution = NumericVector<Number>::build(from_sys.comm()).release();
-      serialized_solution->init(from_sys.n_dofs(), false, SERIAL);
-
-      // Need to pull down a full copy of this vector on every processor so we can get values in parallel
-      from_sys.solution->localize(*serialized_solution);
-
-      MeshFunction from_func(from_es, *serialized_solution, from_sys.get_dof_map(), from_var_num);
-      from_func.init(Trees::ELEMENTS);
-      from_func.enable_out_of_mesh_mode(OutOfMeshValue);
-
-      for (unsigned int i=0; i<_multi_app->numGlobalApps(); i++)
+      for (; node_it != node_end; ++node_it)
       {
-        if (_multi_app->hasLocalApp(i))
-        {
-          MPI_Comm swapped = Moose::swapLibMeshComm(_multi_app->comm());
+        Node * node = *node_it;
 
-          // Loop over the master nodes and set the value of the variable
-          System * to_sys = find_sys(_multi_app->appProblem(i)->es(), _to_var_name);
-
-          unsigned int sys_num = to_sys->number();
-          unsigned int var_num = to_sys->variable_number(_to_var_name);
-          NumericVector<Real> & solution = _multi_app->appTransferVector(i, _to_var_name);
-
-          MeshBase * tmp_mesh = NULL;
-
-          if (_displaced_target_mesh && _multi_app->appProblem(i)->getDisplacedProblem())
-            tmp_mesh = &_multi_app->appProblem(i)->getDisplacedProblem()->mesh().getMesh();
-          else
-            tmp_mesh = &_multi_app->appProblem(i)->mesh().getMesh();
-
-          MeshBase & mesh = *tmp_mesh;
-
-          bool is_nodal = to_sys->variable_type(var_num).family == LAGRANGE;
-
-          if (is_nodal)
-          {
-            MeshBase::const_node_iterator node_it = mesh.local_nodes_begin();
-            MeshBase::const_node_iterator node_end = mesh.local_nodes_end();
-
-            for (; node_it != node_end; ++node_it)
-            {
-              Node * node = *node_it;
-
-              if (node->n_dofs(sys_num, var_num) > 0) // If this variable has dofs at this node
-              {
-                // The zero only works for LAGRANGE!
-                dof_id_type dof = node->dof_number(sys_num, var_num, 0);
-
-                // Swap back
-                Moose::swapLibMeshComm(swapped);
-                Real from_value = from_func(*node+_multi_app->position(i));
-                // Swap again
-                swapped = Moose::swapLibMeshComm(_multi_app->comm());
-
-                if (from_value != OutOfMeshValue)
-                  solution.set(dof, from_value);
-                else if (_error_on_miss)
-                  mooseError("Point not found! " << *node+_multi_app->position(i) << std::endl);
-              }
-            }
-          }
-          else // Elemental
-          {
-            MeshBase::const_element_iterator elem_it = mesh.local_elements_begin();
-            MeshBase::const_element_iterator elem_end = mesh.local_elements_end();
-
-            for (; elem_it != elem_end; ++elem_it)
-            {
-              Elem * elem = *elem_it;
-
-              Point centroid = elem->centroid();
-
-              if (elem->n_dofs(sys_num, var_num) > 0) // If this variable has dofs at this elem
-              {
-                // The zero only works for LAGRANGE!
-                dof_id_type dof = elem->dof_number(sys_num, var_num, 0);
-
-                // Swap back
-                Moose::swapLibMeshComm(swapped);
-                Real from_value = from_func(centroid+_multi_app->position(i));
-                // Swap again
-                swapped = Moose::swapLibMeshComm(_multi_app->comm());
-
-                if (from_value != OutOfMeshValue)
-                  solution.set(dof, from_value);
-                else if (_error_on_miss)
-                  mooseError("Point not found! " << centroid+_multi_app->position(i) << std::endl);
-              }
-            }
-          }
-
-          solution.close();
-          to_sys->update();
-
-          // Swap back
-          Moose::swapLibMeshComm(swapped);
-        }
-      }
-
-      delete serialized_solution;
-
-      break;
-    }
-    case FROM_MULTIAPP:
-    {
-      // TODO: This doesn't work with the master app being displaced see #3424
-      if (_displaced_target_mesh)
-        mooseError("displaced_target_mesh is not yet implemented for transferring 'from_multiapp'");
-
-      FEProblem & to_problem = *_multi_app->problem();
-      MooseVariable & to_var = to_problem.getVariable(0, _to_var_name);
-      SystemBase & to_system_base = to_var.sys();
-
-      System & to_sys = to_system_base.system();
-
-      unsigned int to_sys_num = to_sys.number();
-
-      // Only works with a serialized mesh to transfer to!
-      mooseAssert(to_sys.get_mesh().is_serial(), "MultiAppMeshFunctionTransfer only works with SerialMesh!");
-
-      unsigned int to_var_num = to_sys.variable_number(to_var.name());
-
-      NumericVector<Number> * to_solution = to_sys.solution.get();
-
-      MeshBase * tmp_to_mesh = NULL;
-
-      if (_displaced_target_mesh && to_problem.getDisplacedProblem())
-        tmp_to_mesh = &to_problem.getDisplacedProblem()->mesh().getMesh();
-      else
-        tmp_to_mesh = &to_problem.mesh().getMesh();
-
-      MeshBase & to_mesh = *tmp_to_mesh;
-
-      bool is_nodal = to_sys.variable_type(to_var_num).family == LAGRANGE;
-
-      for (unsigned int i=0; i<_multi_app->numGlobalApps(); i++)
-      {
-        if (!_multi_app->hasLocalApp(i))
+        // Skip this node if the variable has no dofs at it.
+        if (node->n_dofs(sys_num, var_num) < 1)
           continue;
 
-        MPI_Comm swapped = Moose::swapLibMeshComm(_multi_app->comm());
-        FEProblem & from_problem = *_multi_app->appProblem(i);
-        MooseVariable & from_var = from_problem.getVariable(0, _from_var_name);
-        SystemBase & from_system_base = from_var.sys();
-
-        System & from_sys = from_system_base.system();
-
-        // Only works with a serialized mesh to transfer from!
-        mooseAssert(from_sys.get_mesh().is_serial(), "MultiAppMeshFunctionTransfer only works with SerialMesh!");
-
-        unsigned int from_var_num = from_sys.variable_number(from_var.name());
-
-        EquationSystems * tmp_es = NULL;
-
-        if (_displaced_source_mesh && from_problem.getDisplacedProblem())
-          tmp_es = &from_problem.getDisplacedProblem()->es();
-        else
-          tmp_es = &from_problem.es();
-
-        EquationSystems & from_es = *tmp_es;
-
-        //Create a serialized version of the solution vector
-        NumericVector<Number> * serialized_from_solution = NumericVector<Number>::build(from_sys.comm()).release();
-        serialized_from_solution->init(from_sys.n_dofs(), false, SERIAL);
-
-        // Need to pull down a full copy of this vector on every processor so we can get values in parallel
-        from_sys.solution->localize(*serialized_from_solution);
-
-        MeshBase * from_mesh = NULL;
-
-        if (_displaced_source_mesh && from_problem.getDisplacedProblem())
-          from_mesh = &from_problem.getDisplacedProblem()->mesh().getMesh();
-        else
-          from_mesh = &from_problem.mesh().getMesh();
-
-        MeshTools::BoundingBox app_box = MeshTools::processor_bounding_box(*from_mesh, from_mesh->processor_id());
-        Point app_position = _multi_app->position(i);
-
-        MeshFunction from_func(from_es, *serialized_from_solution, from_sys.get_dof_map(), from_var_num);
-        from_func.init(Trees::ELEMENTS);
-        from_func.enable_out_of_mesh_mode(OutOfMeshValue);
-        Moose::swapLibMeshComm(swapped);
-
-        if (is_nodal)
+        // Loop over the "froms" on processor i_proc.  If the node is found in
+        // any of the "froms", add that node to the vector that will be sent to
+        // i_proc.
+        unsigned int from0 = 0;
+        for (processor_id_type i_proc = 0;
+             i_proc < n_processors();
+             from0 += froms_per_proc[i_proc], i_proc++)
         {
-          MeshBase::const_node_iterator node_it = to_mesh.nodes_begin();
-          MeshBase::const_node_iterator node_end = to_mesh.nodes_end();
-
-          for (; node_it != node_end; ++node_it)
+          bool point_found = false;
+          for (unsigned int i_from = from0; i_from < from0 + froms_per_proc[i_proc] && ! point_found; i_from++)
           {
-            Node * node = *node_it;
-
-            if (node->n_dofs(to_sys_num, to_var_num) > 0) // If this variable has dofs at this node
+            if (bboxes[i_from].contains_point(*node + _to_positions[i_to]))
             {
-              // See if this node falls in this bounding box
-              if (app_box.contains_point(*node-app_position))
-              {
-                // The zero only works for LAGRANGE!
-                dof_id_type dof = node->dof_number(to_sys_num, to_var_num, 0);
-
-                MPI_Comm swapped = Moose::swapLibMeshComm(_multi_app->comm());
-                Real from_value = from_func(*node-app_position);
-                Moose::swapLibMeshComm(swapped);
-
-                if (from_value != OutOfMeshValue)
-                  to_solution->set(dof, from_value);
-                else if (_error_on_miss)
-                  mooseError("Point not found! " << *node-app_position <<std::endl);
-              }
+              std::pair<unsigned int, unsigned int> key(i_to, node->id());
+              point_index_map[i_proc][key] = outgoing_points[i_proc].size();
+              outgoing_points[i_proc].push_back(*node + _to_positions[i_to]);
+              point_found = true;
             }
           }
         }
-        else // Elemental
-        {
-          MeshBase::const_element_iterator elem_it = to_mesh.elements_begin();
-          MeshBase::const_element_iterator elem_end = to_mesh.elements_end();
-
-          for (; elem_it != elem_end; ++elem_it)
-          {
-            Elem * elem = *elem_it;
-
-            if (elem->n_dofs(to_sys_num, to_var_num) > 0) // If this variable has dofs at this elem
-            {
-              Point centroid = elem->centroid();
-
-              // See if this elem falls in this bounding box
-              if (app_box.contains_point(centroid-app_position))
-              {
-                // The zero only works for LAGRANGE!
-                dof_id_type dof = elem->dof_number(to_sys_num, to_var_num, 0);
-
-                MPI_Comm swapped = Moose::swapLibMeshComm(_multi_app->comm());
-                Real from_value = from_func(centroid-app_position);
-                Moose::swapLibMeshComm(swapped);
-
-                if (from_value != OutOfMeshValue)
-                  to_solution->set(dof, from_value);
-                else if (_error_on_miss)
-                  mooseError("Point not found! " << centroid-app_position << std::endl);
-              }
-            }
-          }
-        }
-        delete serialized_from_solution;
       }
+    }
+    else // Elemental
+    {
+      MeshBase::const_element_iterator elem_it = to_mesh->local_elements_begin();
+      MeshBase::const_element_iterator elem_end = to_mesh->local_elements_end();
 
-      to_solution->close();
-      to_sys.update();
+      for (; elem_it != elem_end; ++elem_it)
+      {
+        Elem * elem = *elem_it;
 
-      break;
+        Point centroid = elem->centroid();
+
+        // Skip this element if the variable has no dofs at it.
+        if (elem->n_dofs(sys_num, var_num) < 1)
+          continue;
+
+        // Loop over the "froms" on processor i_proc.  If the elem is found in
+        // any of the "froms", add that elem to the vector that will be sent to
+        // i_proc.
+        unsigned int from0 = 0;
+        for (processor_id_type i_proc = 0;
+             i_proc < n_processors();
+             from0 += froms_per_proc[i_proc], i_proc++)
+        {
+          bool point_found = false;
+          for (unsigned int i_from = from0; i_from < from0 + froms_per_proc[i_proc] && ! point_found; i_from++)
+          {
+            if (bboxes[i_from].contains_point(centroid + _to_positions[i_to]))
+            {
+              std::pair<unsigned int, unsigned int> key(i_to, elem->id());
+              point_index_map[i_proc][key] = outgoing_points[i_proc].size();
+              outgoing_points[i_proc].push_back(centroid + _to_positions[i_to]);
+              point_found = true;
+            }
+          }
+        }
+      }
     }
   }
+
+  ////////////////////
+  // Request point evaluations from other processors and handle requests sent to
+  // this processor.
+  ////////////////////
+
+  // Get the local bounding boxes.
+  std::vector<MeshTools::BoundingBox> local_bboxes(froms_per_proc[processor_id()]);
+  {
+    // Find the index to the first of this processor's local bounding boxes.
+    unsigned int local_start = 0;
+    for (processor_id_type i_proc = 0;
+         i_proc < n_processors() && i_proc != processor_id();
+         i_proc++)
+    {
+      local_start += froms_per_proc[i_proc];
+    }
+
+    // Extract the local bounding boxes.
+    for (unsigned int i_from = 0; i_from < froms_per_proc[processor_id()]; i_from++)
+    {
+      local_bboxes[i_from] = bboxes[local_start + i_from];
+    }
+  }
+
+  // Setup the local mesh functions.
+  std::vector<MeshFunction *> local_meshfuns(_from_problems.size(), NULL);
+  for (unsigned int i_from = 0; i_from < _from_problems.size(); i_from++)
+  {
+    FEProblem & from_problem = *_from_problems[i_from];
+    MooseVariable & from_var = from_problem.getVariable(0, _from_var_name);
+    System & from_sys = from_var.sys().system();
+    unsigned int from_var_num = from_sys.variable_number(from_var.name());
+
+    MeshFunction * from_func;
+    //TODO: make MultiAppTransfer give me the right es
+    if (_displaced_source_mesh && from_problem.getDisplacedProblem())
+      from_func = new MeshFunction(from_problem.getDisplacedProblem()->es(),
+           *from_sys.current_local_solution, from_sys.get_dof_map(), from_var_num);
+    else
+      from_func = new MeshFunction(from_problem.es(),
+           *from_sys.current_local_solution, from_sys.get_dof_map(), from_var_num);
+    from_func->init(Trees::ELEMENTS);
+    from_func->enable_out_of_mesh_mode(OutOfMeshValue);
+    local_meshfuns[i_from] = from_func;
+  }
+
+  // Send points to other processors.
+  std::vector<std::vector<Real> > incoming_evals(n_processors());
+  std::vector<std::vector<unsigned int> > incoming_app_ids(n_processors());
+  for (processor_id_type i_proc = 0; i_proc < n_processors(); i_proc++)
+  {
+    if (i_proc == processor_id())
+      continue;
+    _communicator.send(i_proc, outgoing_points[i_proc]);
+  }
+
+  // Recieve points from other processors, evaluate mesh frunctions at those
+  // points, and send the values back.
+  for (processor_id_type i_proc = 0; i_proc < n_processors(); i_proc++)
+  {
+    std::vector<Point> incoming_points;
+    if (i_proc == processor_id())
+      incoming_points = outgoing_points[i_proc];
+    else
+      _communicator.receive(i_proc, incoming_points);
+
+    std::vector<Real> outgoing_evals(incoming_points.size(), OutOfMeshValue);
+    std::vector<unsigned int> outgoing_ids(incoming_points.size(), -1); // -1 = largest unsigned int
+    for (unsigned int i_pt = 0; i_pt < incoming_points.size(); i_pt++)
+    {
+      Point pt = incoming_points[i_pt];
+
+      // Loop until we've found the lowest-ranked app that actually contains
+      // the quadrature point.
+      for (unsigned int i_from = 0; i_from < _from_problems.size() && outgoing_evals[i_pt] == OutOfMeshValue; i_from++)
+      {
+        if (local_bboxes[i_from].contains_point(pt))
+        {
+          outgoing_evals[i_pt] = (* local_meshfuns[i_from])(pt - _from_positions[i_from]);
+          if (_direction == FROM_MULTIAPP)
+            outgoing_ids[i_pt] = _local2global_map[i_from];
+        }
+      }
+    }
+
+    if (i_proc == processor_id())
+    {
+      incoming_evals[i_proc] = outgoing_evals;
+      if (_direction == FROM_MULTIAPP)
+        incoming_app_ids[i_proc] = outgoing_ids;
+    }
+    else
+    {
+      _communicator.send(i_proc, outgoing_evals);
+      if (_direction == FROM_MULTIAPP)
+        _communicator.send(i_proc, outgoing_ids);
+    }
+  }
+
+  ////////////////////
+  // Gather all of the evaluations, pick out the best ones for each point, and
+  // apply them to the solution vector.  When we are transferring from
+  // multiapps, there may be multiple overlapping apps for a particular point.
+  // In that case, we'll try to use the value from the app with the lowest id.
+  ////////////////////
+  for (processor_id_type i_proc = 0; i_proc < n_processors(); i_proc++)
+  {
+    if (i_proc == processor_id())
+      continue;
+
+    _communicator.receive(i_proc, incoming_evals[i_proc]);
+    if (_direction == FROM_MULTIAPP)
+      _communicator.receive(i_proc, incoming_app_ids[i_proc]);
+  }
+
+  for (unsigned int i_to = 0; i_to < _to_problems.size(); i_to++)
+  {
+    System * to_sys = find_sys(*_to_es[i_to], _to_var_name);
+
+    unsigned int sys_num = to_sys->number();
+    unsigned int var_num = to_sys->variable_number(_to_var_name);
+
+    NumericVector<Real> * solution;
+    switch (_direction)
+    {
+      case TO_MULTIAPP:
+        solution = & getTransferVector(i_to, _to_var_name);
+        break;
+      case FROM_MULTIAPP:
+        solution = to_sys->solution.get();
+        break;
+    }
+
+    MeshBase * to_mesh = & _to_meshes[i_to]->getMesh();
+
+    bool is_nodal = to_sys->variable_type(var_num).family == LAGRANGE;
+
+    if (is_nodal)
+    {
+      MeshBase::const_node_iterator node_it = to_mesh->local_nodes_begin();
+      MeshBase::const_node_iterator node_end = to_mesh->local_nodes_end();
+
+      for (; node_it != node_end; ++node_it)
+      {
+        Node * node = *node_it;
+
+        // Skip this node if the variable has no dofs at it.
+        if (node->n_dofs(sys_num, var_num) < 1)
+          continue;
+
+        unsigned int lowest_app_rank = -1; // -1 = largest unsigned int
+        Real best_val = 0.;
+        bool point_found = false;
+        for (unsigned int i_proc = 0; i_proc < incoming_evals.size(); i_proc++)
+        {
+          // Skip this proc if the node wasn't in it's bounding boxes.
+          std::pair<unsigned int, unsigned int> key(i_to, node->id());
+          if (point_index_map[i_proc].find(key) == point_index_map[i_proc].end())
+            continue;
+          unsigned int i_pt = point_index_map[i_proc][key];
+
+          // Ignore this proc if it's app has a higher rank than the
+          // previously found lowest app rank.
+          if (_direction == FROM_MULTIAPP)
+          {
+            if (incoming_app_ids[i_proc][i_pt] >= lowest_app_rank)
+              continue;
+          }
+
+          // Ignore this proc if the point was actually outside its meshes.
+          if (incoming_evals[i_proc][i_pt] == OutOfMeshValue)
+            continue;
+
+          best_val = incoming_evals[i_proc][i_pt];
+          point_found = true;
+        }
+
+        if (_error_on_miss && ~ point_found)
+          mooseError("Point not found! " << *node + _to_positions[i_to]);
+
+        dof_id_type dof = node->dof_number(sys_num, var_num, 0);
+        solution->set(dof, best_val);
+      }
+    }
+    else // Elemental
+    {
+      MeshBase::const_element_iterator elem_it = to_mesh->local_elements_begin();
+      MeshBase::const_element_iterator elem_end = to_mesh->local_elements_end();
+
+      for (; elem_it != elem_end; ++elem_it)
+      {
+        Elem * elem = *elem_it;
+
+        // Skip this element if the variable has no dofs at it.
+        if (elem->n_dofs(sys_num, var_num) < 1)
+          continue;
+
+        unsigned int lowest_app_rank = -1; // -1 = largest unsigned int
+        Real best_val = 0;
+        bool point_found = false;
+        for (unsigned int i_proc = 0; i_proc < incoming_evals.size(); i_proc++)
+        {
+          // Skip this proc if the elem wasn't in it's bounding boxes.
+          std::pair<unsigned int, unsigned int> key(i_to, elem->id());
+          if (point_index_map[i_proc].find(key) == point_index_map[i_proc].end())
+            continue;
+          unsigned int i_pt = point_index_map[i_proc][key];
+
+          // Ignore this proc if it's app has a higher rank than the
+          // previously found lowest app rank.
+          if (_direction == FROM_MULTIAPP)
+          {
+            if (incoming_app_ids[i_proc][i_pt] >= lowest_app_rank)
+              continue;
+          }
+
+          // Ignore this proc if the point was actually outside its meshes.
+          if (incoming_evals[i_proc][i_pt] == OutOfMeshValue)
+            continue;
+
+          best_val = incoming_evals[i_proc][i_pt];
+          point_found = true;
+        }
+
+        if (_error_on_miss && ~ point_found)
+          mooseError("Point not found! " << elem->centroid() + _to_positions[i_to]);
+
+        dof_id_type dof = elem->dof_number(sys_num, var_num, 0);
+        solution->set(dof, best_val);
+      }
+    }
+    solution->close();
+    to_sys->update();
+  }
+
+  for (unsigned int i = 0; i < _from_problems.size(); i++)
+    delete local_meshfuns[i];
 
   _console << "Finished MeshFunctionTransfer " << name() << std::endl;
 }

--- a/test/tests/transfers/multiapp_mesh_function_transfer/exec_on_mismatch.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/exec_on_mismatch.i
@@ -3,9 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The MultiAppMeshFunctionTransfer doesn't work with ParallelMesh.
-  # See tosub_master.i and #2145 for more information.
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_mesh_function_transfer/master.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/master.i
@@ -3,9 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The MultiAppMeshFunctionTransfer doesn't work with ParallelMesh.
-  # See tosub_master.i and #2145 for more information.
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_mesh_function_transfer/master_source_displaced.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/master_source_displaced.i
@@ -1,11 +1,8 @@
 [Mesh]
-  # The MultiAppMeshFunctionTransfer doesn't work with ParallelMesh.
-  # 2145 for more information.
   type = GeneratedMesh
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_mesh_function_transfer/missing_master.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/missing_master.i
@@ -3,9 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The MultiAppMeshFunctionTransfer doesn't work with ParallelMesh.
-  # See tosub_master.i and #2145 for more information.
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_mesh_function_transfer/tosub_master.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/tosub_master.i
@@ -3,13 +3,6 @@
   dim = 2
   nx = 10
   ny = 10
-  # The MultiAppMeshFunctionTransfer doesn't work with ParallelMesh.
-  # To start debugging this issue, you can add 'error_on_miss = true'
-  # to the 'to_sub' and 'elemental_to_sub' blocks below, and you should
-  # get an error message like:
-  # Point not found! (x,y,z)=(    0.62,      0.6,        0)
-  # See also #2145.
-  distribution = serial
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_mesh_function_transfer/tosub_master_target_displaced.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/tosub_master_target_displaced.i
@@ -1,15 +1,8 @@
 [Mesh]
-  # The MultiAppMeshFunctionTransfer doesn't work with ParallelMesh.
-  # To start debugging this issue, you can add 'error_on_miss = true'
-  # to the 'to_sub' and 'elemental_to_sub' blocks below, and you should
-  # get an error message like:
-  # Point not found! (x,y,z)=(    0.62,      0.6,        0)
-  # 2145.
   type = GeneratedMesh
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
 []
 
 [Variables]


### PR DESCRIPTION
`MultiAppMeshFunctionTransfer` is the latest on the chopping block.  It no longer requires solution serialization and it works with parallel mesh.  I'm getting all passes with any number of procs between 1 and 12 (inclusive).  See:

```
for i in `seq 1 12`; do ./run_tests --re "multiapp_mesh_function" -p $i --cli-args="--parallel-mesh"; echo $i; done
```

Large sections of this are copy-pasted from `NearestNodeTransfer` and the #5425 version of `MultiAppProjectionTransfer` so I think there is some room for consolidating functionality into a base class.  That said, I would rather leave such consolidation out of this PR because I expect it to take a non-trivial amount of time to design, and it'll be more useful after #5425 is merged in anyway.

Closes #2145.
