### PR TITLE
Add beginning/finished messages to some transfers

### DIFF
--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -55,6 +55,8 @@ MultiAppPostprocessorInterpolationTransfer::MultiAppPostprocessorInterpolationTr
 void
 MultiAppPostprocessorInterpolationTransfer::execute()
 {
+  _console << "Beginning PostprocessorInterpolationTransfer " << name() << std::endl;
+
   switch (_direction)
   {
     case TO_MULTIAPP:
@@ -151,6 +153,8 @@ MultiAppPostprocessorInterpolationTransfer::execute()
       break;
     }
   }
+
+  _console << "Finished PostprocessorInterpolationTransfer " << name() << std::endl;
 }
 
 

--- a/framework/src/transfers/MultiAppPostprocessorToAuxScalarTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorToAuxScalarTransfer.C
@@ -42,6 +42,8 @@ MultiAppPostprocessorToAuxScalarTransfer::MultiAppPostprocessorToAuxScalarTransf
 void
 MultiAppPostprocessorToAuxScalarTransfer::execute()
 {
+  _console << "Beginning PostprocessorToAuxScalarTransfer " << name() << std::endl;
+
   // Perform action based on the transfer direction
   switch (_direction)
   {
@@ -101,6 +103,8 @@ MultiAppPostprocessorToAuxScalarTransfer::execute()
       break;
     }
   }
+
+  _console << "Finished PostprocessorToAuxScalarTransfer " << name() << std::endl;
 }
 
 

--- a/framework/src/transfers/MultiAppPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorTransfer.C
@@ -47,6 +47,8 @@ MultiAppPostprocessorTransfer::MultiAppPostprocessorTransfer(const InputParamete
 void
 MultiAppPostprocessorTransfer::execute()
 {
+  _console << "Beginning PostprocessorTransfer " << name() << std::endl;
+
   switch (_direction)
   {
     case TO_MULTIAPP:
@@ -136,6 +138,8 @@ MultiAppPostprocessorTransfer::execute()
       break;
     }
   }
+
+  _console << "Finished PostprocessorTransfer " << name() << std::endl;
 }
 
 

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -41,6 +41,8 @@ MultiAppVariableValueSamplePostprocessorTransfer::MultiAppVariableValueSamplePos
 void
 MultiAppVariableValueSamplePostprocessorTransfer::execute()
 {
+  _console << "Beginning VariableValueSamplePostprocessorTransfer " << name() << std::endl;
+
   switch (_direction)
   {
     case TO_MULTIAPP:
@@ -90,6 +92,8 @@ MultiAppVariableValueSamplePostprocessorTransfer::execute()
       break;
     }
   }
+
+  _console << "Finished VariableValueSamplePostprocessorTransfer " << name() << std::endl;
 }
 
 

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -47,6 +47,8 @@ MultiAppVariableValueSampleTransfer::initialSetup()
 void
 MultiAppVariableValueSampleTransfer::execute()
 {
+  _console << "Beginning VariableValueSampleTransfer " << name() << std::endl;
+
   switch (_direction)
   {
     case TO_MULTIAPP:
@@ -132,6 +134,8 @@ MultiAppVariableValueSampleTransfer::execute()
       break;
     }
   }
+
+  _console << "Finished VariableValueSampleTransfer " << name() << std::endl;
 }
 
 


### PR DESCRIPTION
This brings the postprocessor transfers in line with most of the other transfers which tell the console when they begin and finish their work.
