### PR TITLE
Fixed path issues keeping cluster_launcher from running

### DIFF
--- a/python/ClusterLauncher/Job.py
+++ b/python/ClusterLauncher/Job.py
@@ -9,7 +9,7 @@ else:
   pathname = os.path.abspath(pathname)
 
 # Add the utilities/python_getpot directory
-MOOSE_DIR = os.path.abspath(os.path.join(pathname, '../../'))
+MOOSE_DIR = os.path.abspath(os.path.join(pathname, '../'))
 FRAMEWORK_DIR = os.path.abspath(os.path.join(pathname, '../../', 'framework'))
 #### See if MOOSE_DIR is already in the environment instead
 if os.environ.has_key("MOOSE_DIR"):

--- a/scripts/cluster_launcher.py
+++ b/scripts/cluster_launcher.py
@@ -7,7 +7,7 @@ MOOSE_PYTHON_DIR = None
 if os.environ.has_key('MOOSE_DIR'):
   MOOSE_PYTHON_DIR = os.path.join(os.environ['MOOSE_DIR'], 'python')
 else:
-  MOOSE_PYTHON_DIR = os.path.join(os.environ['HOME'], 'projects', 'moose', 'python')
+  MOOSE_PYTHON_DIR = os.path.join(os.path.split(os.path.dirname(os.path.abspath(__file__)))[0], 'python')
 
 # Add moose/python to path
 if os.path.exists(MOOSE_PYTHON_DIR):


### PR DESCRIPTION
Tested with MOOSE_DIR being set, and otherwise. Also tested this with MOOSE as a submodule (in Bison). Refs #5533
