### PR TITLE
Get rid of the duplicate object 'PlotFunction'

### DIFF
--- a/examples/ex18_scalar_kernel/ex18.i
+++ b/examples/ex18_scalar_kernel/ex18.i
@@ -102,7 +102,7 @@
   [../]
 
   [./exact_x]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = exact_x_fn
     execute_on = timestep_end
     point = '0 0 0'

--- a/examples/ex18_scalar_kernel/ex18_parsed.i
+++ b/examples/ex18_scalar_kernel/ex18_parsed.i
@@ -128,7 +128,7 @@
   [../]
 
   [./exact_x]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = exact_x_fn
     execute_on = timestep_end
   [../]

--- a/framework/include/postprocessors/FunctionValuePostprocessor.h
+++ b/framework/include/postprocessors/FunctionValuePostprocessor.h
@@ -36,10 +36,11 @@ public:
   virtual void initialize();
   virtual void execute();
   virtual PostprocessorValue getValue();
-  virtual void threadJoin(const UserObject & uo);
 
 protected:
   Function & _function;
+  const Point & _point;
+  const Real _scale_factor;
 };
 
 #endif /* FUNCTIONVALUEPOSTPROCESSOR_H */

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -548,7 +548,7 @@ registerObjects(Factory & factory)
   registerPostprocessor(ScalarVariable);
   registerPostprocessor(NumVars);
   registerPostprocessor(NumResidualEvaluations);
-  registerPostprocessor(PlotFunction);
+  registerDeprecatedObjectName(FunctionValuePostprocessor, "PlotFunction", "09/18/2015 12:00");
   registerPostprocessor(Receiver);
   registerPostprocessor(SideAverageValue);
   registerPostprocessor(SideFluxIntegral);

--- a/framework/src/postprocessors/FunctionValuePostprocessor.C
+++ b/framework/src/postprocessors/FunctionValuePostprocessor.C
@@ -19,13 +19,17 @@ InputParameters validParams<FunctionValuePostprocessor>()
 {
   InputParameters params = validParams<GeneralPostprocessor>();
   params.addRequiredParam<FunctionName>("function", "The function which supplies the postprocessor value.");
+  params.addParam<Point>("point", Point(), "A point in space to be given to the function Default: (0, 0, 0)");
+  params.addParam<Real>("scale_factor", 1, "A scale factor to be applied to the function");
 
   return params;
 }
 
 FunctionValuePostprocessor::FunctionValuePostprocessor(const InputParameters & parameters) :
     GeneralPostprocessor(parameters),
-    _function(getFunction("function"))
+    _function(getFunction("function")),
+    _point(getParam<Point>("point")),
+    _scale_factor(getParam<Real>("scale_factor"))
 {
 }
 
@@ -46,12 +50,5 @@ FunctionValuePostprocessor::execute()
 PostprocessorValue
 FunctionValuePostprocessor::getValue()
 {
-  return _function.value(_t, 0);         //Pass 0 instead of Point(0,0,0) because postprocessors return a single scalar value.
+  return _scale_factor * _function.value(_t, _point);
 }
-
-void
-FunctionValuePostprocessor::threadJoin(const UserObject & /*uo*/)
-{
-  // nothing to do here, general PPS do not run threaded
-}
-

--- a/modules/chemical_reactions/tests/desorption/langmuir_desorption.i
+++ b/modules/chemical_reactions/tests/desorption/langmuir_desorption.i
@@ -65,7 +65,7 @@
     execute_on = 'initial timestep_end'
   [../]
   [./mass_tot]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_fcn
     execute_on = 'initial timestep_end'
   [../]

--- a/modules/chemical_reactions/tests/desorption/mollified_langmuir_desorption.i
+++ b/modules/chemical_reactions/tests/desorption/mollified_langmuir_desorption.i
@@ -65,7 +65,7 @@
     execute_on = 'initial timestep_end'
   [../]
   [./mass_tot]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_fcn
     execute_on = 'initial timestep_end'
   [../]

--- a/modules/combined/doc/richards/user/excav/ex01.i
+++ b/modules/combined/doc/richards/user/excav/ex01.i
@@ -104,7 +104,7 @@
 
 # mass_bal just outputs the result to screen
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/combined/examples/phase_field-mechanics/Nonconserved.i
+++ b/modules/combined/examples/phase_field-mechanics/Nonconserved.i
@@ -67,7 +67,7 @@
 []
 
 #
-# Try visualizing the strees tensor components as done in Conserved.i
+# Try visualizing the stress tensor components as done in Conserved.i
 #
 
 [Materials]

--- a/modules/combined/tests/heat_conduction_ortho/heat_conduction_ortho.i
+++ b/modules/combined/tests/heat_conduction_ortho/heat_conduction_ortho.i
@@ -118,19 +118,19 @@
 
 [Postprocessors]
   [./tcx]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = 1000
     outputs = none
     execute_on = 'initial timestep_end'
   [../]
   [./tcy]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = 100
     outputs = none
     execute_on = 'initial timestep_end'
   [../]
   [./tcz]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = 10
     outputs = none
     execute_on = 'initial timestep_end'

--- a/modules/combined/tests/poro_mechanics/borehole_highres.i
+++ b/modules/combined/tests/poro_mechanics/borehole_highres.i
@@ -681,7 +681,7 @@
   [../]
 
   [./dt]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     outputs = console
     function = 2*t
   [../]

--- a/modules/combined/tests/poro_mechanics/borehole_lowres.i
+++ b/modules/combined/tests/poro_mechanics/borehole_lowres.i
@@ -682,7 +682,7 @@
   [../]
 
   [./dt]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     outputs = console
     function = 2*t
   [../]

--- a/modules/combined/tests/poro_mechanics/mandel.i
+++ b/modules/combined/tests/poro_mechanics/mandel.i
@@ -300,7 +300,7 @@
      variable = tot_force
   [../]
   [./dt]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     outputs = console
     function = if(0.15*t<0.01,0.15*t,0.01)
   [../]

--- a/modules/combined/tests/poro_mechanics/terzaghi.i
+++ b/modules/combined/tests/poro_mechanics/terzaghi.i
@@ -253,7 +253,7 @@
     variable = disp_z
   [../]
   [./dt]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     outputs = console
     function = if(0.5*t<0.1,0.5*t,0.1)
   [../]

--- a/modules/richards/tests/dirac/bh02.i
+++ b/modules/richards/tests/dirac/bh02.i
@@ -121,7 +121,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/dirac/bh03.i
+++ b/modules/richards/tests/dirac/bh03.i
@@ -121,7 +121,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/dirac/bh04.i
+++ b/modules/richards/tests/dirac/bh04.i
@@ -121,7 +121,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/dirac/bh05.i
+++ b/modules/richards/tests/dirac/bh05.i
@@ -121,7 +121,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/dirac/bh_fu_02.i
+++ b/modules/richards/tests/dirac/bh_fu_02.i
@@ -128,7 +128,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/dirac/bh_fu_03.i
+++ b/modules/richards/tests/dirac/bh_fu_03.i
@@ -128,7 +128,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/dirac/bh_fu_04.i
+++ b/modules/richards/tests/dirac/bh_fu_04.i
@@ -128,7 +128,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/dirac/bh_fu_05.i
+++ b/modules/richards/tests/dirac/bh_fu_05.i
@@ -128,7 +128,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/dirac/st01.i
+++ b/modules/richards/tests/dirac/st01.i
@@ -119,7 +119,7 @@
   [../]
 
   [./zmass_error]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
     execute_on = timestep_end
   [../]

--- a/modules/richards/tests/excav/ex01.i
+++ b/modules/richards/tests/excav/ex01.i
@@ -105,7 +105,7 @@
 
 # mass_bal just outputs the result to screen
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/richards/tests/excav/ex02.i
+++ b/modules/richards/tests/excav/ex02.i
@@ -105,7 +105,7 @@
 
 # mass_bal just outputs the result to screen
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh01.i
+++ b/modules/richards/tests/gravity_head_2/gh01.i
@@ -166,12 +166,12 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
     outputs = none # no reason why mass should be conserved
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
     outputs = none # no reason why mass should be conserved
   [../]
@@ -189,7 +189,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -206,7 +206,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh02.i
+++ b/modules/richards/tests/gravity_head_2/gh02.i
@@ -165,12 +165,12 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
     outputs = none # no reason why mass should be conserved
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
     outputs = none # no reason why mass should be conserved
   [../]
@@ -188,7 +188,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -205,7 +205,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh03.i
+++ b/modules/richards/tests/gravity_head_2/gh03.i
@@ -168,12 +168,12 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
     outputs = none # no reason why mass should be conserved
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
     outputs = none # no reason why mass should be conserved
   [../]
@@ -191,7 +191,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -208,7 +208,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh04.i
+++ b/modules/richards/tests/gravity_head_2/gh04.i
@@ -154,7 +154,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -171,7 +171,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh05.i
+++ b/modules/richards/tests/gravity_head_2/gh05.i
@@ -166,11 +166,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -187,7 +187,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -204,7 +204,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh06.i
+++ b/modules/richards/tests/gravity_head_2/gh06.i
@@ -164,11 +164,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -185,7 +185,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -202,7 +202,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh07.i
+++ b/modules/richards/tests/gravity_head_2/gh07.i
@@ -168,11 +168,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -189,7 +189,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -206,7 +206,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh08.i
+++ b/modules/richards/tests/gravity_head_2/gh08.i
@@ -166,11 +166,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -187,7 +187,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -204,7 +204,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh16.i
+++ b/modules/richards/tests/gravity_head_2/gh16.i
@@ -166,11 +166,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -187,7 +187,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -204,7 +204,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh17.i
+++ b/modules/richards/tests/gravity_head_2/gh17.i
@@ -166,11 +166,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -187,7 +187,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh18.i
+++ b/modules/richards/tests/gravity_head_2/gh18.i
@@ -167,11 +167,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -188,7 +188,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -205,7 +205,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_bounded_17.i
+++ b/modules/richards/tests/gravity_head_2/gh_bounded_17.i
@@ -180,7 +180,7 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
 
@@ -197,7 +197,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_fu_01.i
+++ b/modules/richards/tests/gravity_head_2/gh_fu_01.i
@@ -171,12 +171,12 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
     outputs = none # no reason why mass should be conserved
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
     outputs = none # no reason why mass should be conserved
   [../]
@@ -194,7 +194,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -211,7 +211,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_fu_02.i
+++ b/modules/richards/tests/gravity_head_2/gh_fu_02.i
@@ -170,12 +170,12 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
     outputs = none # no reason why mass should be conserved
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
     outputs = none # no reason why mass should be conserved
   [../]
@@ -193,7 +193,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -210,7 +210,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_fu_05.i
+++ b/modules/richards/tests/gravity_head_2/gh_fu_05.i
@@ -171,11 +171,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -192,7 +192,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -209,7 +209,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_fu_06.i
+++ b/modules/richards/tests/gravity_head_2/gh_fu_06.i
@@ -169,11 +169,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -190,7 +190,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -207,7 +207,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_fu_17.i
+++ b/modules/richards/tests/gravity_head_2/gh_fu_17.i
@@ -171,11 +171,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -192,7 +192,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_fu_18.i
+++ b/modules/richards/tests/gravity_head_2/gh_fu_18.i
@@ -172,11 +172,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -193,7 +193,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -210,7 +210,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_lumped_07.i
+++ b/modules/richards/tests/gravity_head_2/gh_lumped_07.i
@@ -176,11 +176,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -197,7 +197,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -214,7 +214,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_lumped_08.i
+++ b/modules/richards/tests/gravity_head_2/gh_lumped_08.i
@@ -174,11 +174,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -195,7 +195,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -212,7 +212,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_lumped_17.i
+++ b/modules/richards/tests/gravity_head_2/gh_lumped_17.i
@@ -174,11 +174,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -195,7 +195,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 []

--- a/modules/richards/tests/gravity_head_2/gh_lumped_18.i
+++ b/modules/richards/tests/gravity_head_2/gh_lumped_18.i
@@ -175,11 +175,11 @@
   [../]
 
   [./mass_error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_w
   [../]
   [./mass_error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_mass_error_g
   [../]
 
@@ -196,7 +196,7 @@
     outputs = none
   [../]
   [./error_water]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_water
   [../]
 
@@ -213,7 +213,7 @@
     outputs = none
   [../]
   [./error_gas]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = fcn_error_gas
   [../]
 []

--- a/modules/richards/tests/sinks/s01.i
+++ b/modules/richards/tests/sinks/s01.i
@@ -105,7 +105,7 @@
     variable = pressure
   [../]
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/richards/tests/sinks/s02.i
+++ b/modules/richards/tests/sinks/s02.i
@@ -103,7 +103,7 @@
     variable = pressure
   [../]
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/richards/tests/sinks/s03.i
+++ b/modules/richards/tests/sinks/s03.i
@@ -116,7 +116,7 @@
     variable = seff
   [../]
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/richards/tests/sinks/s05.i
+++ b/modules/richards/tests/sinks/s05.i
@@ -107,7 +107,7 @@
     variable = pressure
   [../]
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/richards/tests/sinks/s_fu_01.i
+++ b/modules/richards/tests/sinks/s_fu_01.i
@@ -112,7 +112,7 @@
     variable = pressure
   [../]
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/richards/tests/sinks/s_fu_03.i
+++ b/modules/richards/tests/sinks/s_fu_03.i
@@ -123,7 +123,7 @@
     variable = seff
   [../]
   [./mass_bal]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = mass_bal_fcn
   [../]
 []

--- a/modules/tensor_mechanics/tests/mohr_coulomb/many_deforms_cap.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/many_deforms_cap.i
@@ -97,7 +97,7 @@
     outputs = 'console'
   [../]
   [./should_be_zero]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero_fcn
   [../]
 []

--- a/modules/tensor_mechanics/tests/mohr_coulomb/random.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/random.i
@@ -108,7 +108,7 @@
     outputs = 'console'
   [../]
   [./should_be_zero]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero_fcn
   [../]
   [./av_iter]

--- a/modules/tensor_mechanics/tests/mohr_coulomb/random_planar.i
+++ b/modules/tensor_mechanics/tests/mohr_coulomb/random_planar.i
@@ -108,7 +108,7 @@
     outputs = 'console'
   [../]
   [./should_be_zero]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero_fcn
   [../]
   [./av_iter]

--- a/modules/tensor_mechanics/tests/multi/rock1.i
+++ b/modules/tensor_mechanics/tests/multi/rock1.i
@@ -273,19 +273,19 @@
     outputs = console
   [../]
   [./f0]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero0_fcn
   [../]
   [./f1]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero1_fcn
   [../]
   [./f2]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero2_fcn
   [../]
   [./f3]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero3_fcn
   [../]
 []

--- a/modules/tensor_mechanics/tests/tensile/random_planar.i
+++ b/modules/tensor_mechanics/tests/tensile/random_planar.i
@@ -227,15 +227,15 @@
     outputs = console
   [../]
   [./f0]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero0_fcn
   [../]
   [./f1]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero1_fcn
   [../]
   [./f2]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero2_fcn
   [../]
 []

--- a/modules/tensor_mechanics/tests/tensile/random_smoothed.i
+++ b/modules/tensor_mechanics/tests/tensile/random_smoothed.i
@@ -197,7 +197,7 @@
     outputs = console
   [../]
   [./f0]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero0_fcn
   [../]
 []

--- a/modules/tensor_mechanics/tests/weak_plane_shear/large_deform3.i
+++ b/modules/tensor_mechanics/tests/weak_plane_shear/large_deform3.i
@@ -104,7 +104,7 @@
     outputs = 'console'
   [../]
   [./should_be_zero]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero_fcn
   [../]
 []

--- a/modules/tensor_mechanics/tests/weak_plane_shear/large_deform4.i
+++ b/modules/tensor_mechanics/tests/weak_plane_shear/large_deform4.i
@@ -105,7 +105,7 @@
     outputs = 'console'
   [../]
   [./should_be_zero]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero_fcn
   [../]
 []

--- a/modules/tensor_mechanics/tests/weak_plane_shear/large_deform_harden3.i
+++ b/modules/tensor_mechanics/tests/weak_plane_shear/large_deform_harden3.i
@@ -120,7 +120,7 @@
     outputs = 'console'
   [../]
   [./should_be_zero]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero_fcn
   [../]
 []

--- a/modules/tensor_mechanics/tests/weak_plane_shear/small_deform3.i
+++ b/modules/tensor_mechanics/tests/weak_plane_shear/small_deform3.i
@@ -103,7 +103,7 @@
     outputs = 'console'
   [../]
   [./should_be_zero]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = should_be_zero_fcn
   [../]
 []

--- a/test/tests/auxkernels/pp_depend/pp_depend.i
+++ b/test/tests/auxkernels/pp_depend/pp_depend.i
@@ -56,7 +56,7 @@
 
 [Postprocessors]
   [./t_pp]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = t_func
   [../]
 []
@@ -82,4 +82,3 @@
   print_linear_residuals = true
   print_perf_log = true
 []
-

--- a/test/tests/functions/parsed/mms_transient_coupled.i
+++ b/test/tests/functions/parsed/mms_transient_coupled.i
@@ -134,7 +134,7 @@
     execute_on = 'initial timestep_end'
   [../]
   [./u_midpoint_exact]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = u_exact
     point = '0.5 0.5 0.0'
     execute_on = 'initial timestep_end'

--- a/test/tests/kernels/ode/ode_sys_impl_test.i
+++ b/test/tests/kernels/ode/ode_sys_impl_test.i
@@ -110,7 +110,7 @@
   [../]
 
   [./exact_x]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = exact_x_fn
     execute_on = 'initial timestep_end'
     point = '0 0 0'

--- a/test/tests/kernels/ode/parsedode_sys_impl_test.i
+++ b/test/tests/kernels/ode/parsedode_sys_impl_test.i
@@ -112,7 +112,7 @@
   [../]
 
   [./exact_x]
-    type = PlotFunction
+    type = FunctionValuePostprocessor
     function = exact_x_fn
     execute_on = 'initial timestep_end'
     point = '0 0 0'


### PR DESCRIPTION
PlotFunction -> FunctionValuePostprocessor
refs #5248

Applications should be patched to get rid of the deprecated warning error
