### PR TITLE
Recompute Jacobian if dt changes in an explicit scheme

### DIFF
--- a/framework/include/timeintegrators/ExplicitEuler.h
+++ b/framework/include/timeintegrators/ExplicitEuler.h
@@ -31,6 +31,7 @@ public:
   ExplicitEuler(const InputParameters & parameters);
   virtual ~ExplicitEuler();
 
+  virtual void preSolve();
   virtual int order() { return 1; }
   virtual void computeTimeDerivatives();
   virtual void postStep(NumericVector<Number> & residual);

--- a/framework/src/timeintegrators/ExplicitEuler.C
+++ b/framework/src/timeintegrators/ExplicitEuler.C
@@ -27,11 +27,19 @@ InputParameters validParams<ExplicitEuler>()
 ExplicitEuler::ExplicitEuler(const InputParameters & parameters) :
     TimeIntegrator(parameters)
 {
-  _fe_problem.setConstJacobian(true);
 }
 
 ExplicitEuler::~ExplicitEuler()
 {
+}
+
+void
+ExplicitEuler::preSolve()
+{
+  if (_dt == _dt_old)
+    _fe_problem.setConstJacobian(true);
+  else
+    _fe_problem.setConstJacobian(false);
 }
 
 void

--- a/framework/src/timeintegrators/RungeKutta2.C
+++ b/framework/src/timeintegrators/RungeKutta2.C
@@ -29,7 +29,6 @@ RungeKutta2::RungeKutta2(const InputParameters & parameters) :
     TimeIntegrator(parameters),
     _stage(0)
 {
-  _fe_problem.setConstJacobian(true);
 }
 
 RungeKutta2::~RungeKutta2()
@@ -39,6 +38,10 @@ RungeKutta2::~RungeKutta2()
 void
 RungeKutta2::preSolve()
 {
+  if (_dt == _dt_old)
+    _fe_problem.setConstJacobian(true);
+  else
+    _fe_problem.setConstJacobian(false);
 }
 
 void


### PR DESCRIPTION
We need to recompute the Jacobian if dt changes. We assumed constant
dt for explicit solves so we set _const_jacobian flag to true. This can
be done only if dt_old and dt are the same. It saves Jacobian
evaluation, which is what we want in an explicit scheme.

Closes #5591
