### PR TITLE
Improvements to InputParameters

### DIFF
--- a/framework/include/actions/CreateDisplacedProblemAction.h
+++ b/framework/include/actions/CreateDisplacedProblemAction.h
@@ -12,24 +12,24 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef INITDISPLACEDPROBLEMACTION_H
-#define INITDISPLACEDPROBLEMACTION_H
+#ifndef CREATEDISPLACEDPROBLEMACTION_H
+#define CREATEDISPLACEDPROBLEMACTION_H
 
 #include "Action.h"
 
-class InitDisplacedProblemAction;
+class CreateDisplacedProblemAction;
 
 template<>
-InputParameters validParams<InitDisplacedProblemAction>();
+InputParameters validParams<CreateDisplacedProblemAction>();
 
 /**
  *
  */
-class InitDisplacedProblemAction : public Action
+class CreateDisplacedProblemAction : public Action
 {
 public:
-  InitDisplacedProblemAction(InputParameters parameters);
-  virtual ~InitDisplacedProblemAction();
+  CreateDisplacedProblemAction(InputParameters parameters);
+  virtual ~CreateDisplacedProblemAction();
 
   virtual void act();
 
@@ -37,4 +37,4 @@ protected:
 
 };
 
-#endif /* INITDISPLACEDPROBLEMACTION_H */
+#endif /* CREATEDISPLACEDPROBLEMACTION_H */

--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -19,6 +19,7 @@
 #include "MooseError.h"
 #include "MooseEnum.h"
 #include "ConsoleStreamInterface.h"
+#include "MooseTypes.h"
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -210,7 +211,8 @@ protected:
   /// Error vector for use with the error estimator.
   ErrorVector * _error;
 
-  DisplacedProblem * & _displaced_problem;
+  MooseSharedPointer<DisplacedProblem> _displaced_problem;
+
   /// A mesh refinement object for displaced mesh
   MeshRefinement * _displaced_mesh_refinement;
 

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -224,7 +224,7 @@ protected:
   bool _c_is_implicit;
 
   /// Local InputParameters
-  InputParameters _coupleable_params;
+  const InputParameters & _coupleable_params;
 
   /// Will hold the default value for optional coupled variables.
   std::map<std::string, VariableValue *> _default_value;

--- a/framework/include/base/DisplacedProblem.h
+++ b/framework/include/base/DisplacedProblem.h
@@ -39,7 +39,7 @@ InputParameters validParams<DisplacedProblem>();
 class DisplacedProblem : public SubProblem
 {
 public:
-  DisplacedProblem(FEProblem & mproblem, MooseMesh & displaced_mesh, InputParameters params);
+  DisplacedProblem(const InputParameters & parameters);
   virtual ~DisplacedProblem();
 
   virtual EquationSystems & es() { return _eq; }

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -738,8 +738,8 @@ public:
   virtual void prepareNeighborShapes(unsigned int var, THREAD_ID tid);
 
   // Displaced problem /////
-  virtual void initDisplacedProblem(MooseMesh * displaced_mesh, InputParameters & params);
-  virtual DisplacedProblem * & getDisplacedProblem() { return _displaced_problem; }
+  virtual void addDisplacedProblem(MooseSharedPointer<DisplacedProblem> displaced_problem);
+  virtual MooseSharedPointer<DisplacedProblem> getDisplacedProblem() { return _displaced_problem; }
 
   virtual void updateGeomSearch(GeometricSearchData::GeometricSearchType type = GeometricSearchData::ALL);
 
@@ -990,7 +990,7 @@ protected:
 
   // Displaced mesh /////
   MooseMesh * _displaced_mesh;
-  DisplacedProblem * _displaced_problem;
+  MooseSharedPointer<DisplacedProblem> _displaced_problem;
   GeometricSearchData _geometric_search_data;
 
   bool _reinit_displaced_elem;

--- a/framework/include/base/FlagElementsThread.h
+++ b/framework/include/base/FlagElementsThread.h
@@ -27,7 +27,7 @@ class DisplacedProblem;
 class FlagElementsThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  FlagElementsThread(FEProblem & fe_problem, std::vector<Number> & serialized_solution, DisplacedProblem * displaced_problem, unsigned int max_h_level);
+  FlagElementsThread(FEProblem & fe_problem, std::vector<Number> & serialized_solution, unsigned int max_h_level);
 
   // Splitting Constructor
   FlagElementsThread(FlagElementsThread & x, Threads::split split);
@@ -38,7 +38,7 @@ public:
 
 protected:
   FEProblem & _fe_problem;
-  DisplacedProblem * _displaced_problem;
+  MooseSharedPointer<DisplacedProblem> _displaced_problem;
   AuxiliarySystem & _aux_sys;
   unsigned int _system_number;
   Adaptivity & _adaptivity;

--- a/framework/include/base/ScalarCoupleable.h
+++ b/framework/include/base/ScalarCoupleable.h
@@ -115,7 +115,7 @@ protected:
   bool _sc_is_implicit;
 
   /// Local InputParameters
-  InputParameters _coupleable_params;
+  const InputParameters & _coupleable_params;
 
   /**
    * Helper method to return (and insert if necessary) the default value

--- a/framework/include/functions/FunctionInterface.h
+++ b/framework/include/functions/FunctionInterface.h
@@ -61,7 +61,7 @@ private:
   THREAD_ID _fni_tid;
 
   /// Parameters of the object with this interface
-  InputParameters _fni_params;
+  const InputParameters &_fni_params;
 };
 
 #endif //FUNCTIONINTERFACE_H

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -218,7 +218,7 @@ private:
   const std::set<BoundaryID> _mi_boundary_ids;
 
   /// Parameters of the object with this interface
-  InputParameters _mi_params;
+  const InputParameters & _mi_params;
 };
 
 template<typename T>

--- a/framework/include/postprocessors/PostprocessorInterface.h
+++ b/framework/include/postprocessors/PostprocessorInterface.h
@@ -104,7 +104,7 @@ private:
   THREAD_ID _pi_tid;
 
   /// PostprocessorInterface Parameters
-  InputParameters _ppi_params;
+  const InputParameters & _ppi_params;
 };
 
 #endif //POSTPROCESSORINTERFACE_H

--- a/framework/include/userobject/LayeredBase.h
+++ b/framework/include/userobject/LayeredBase.h
@@ -78,7 +78,7 @@ protected:
   std::string _layered_base_name;
 
   /// Params for this object
-  InputParameters _layered_base_params;
+  const InputParameters & _layered_base_params;
 
   /// The MooseEnum direction the layers are going in
   MooseEnum _direction_enum;

--- a/framework/include/userobject/UserObjectInterface.h
+++ b/framework/include/userobject/UserObjectInterface.h
@@ -72,7 +72,7 @@ private:
   THREAD_ID _uoi_tid;
 
   /// Parameters of the object with this interface
-  InputParameters _uoi_params;
+  const InputParameters & _uoi_params;
 };
 
 

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -506,16 +506,18 @@ public:
   const std::vector<T> & getParamHelper(const std::string & name, const InputParameters & pars, const std::vector<T>* the_type);
   ///@}
 
-  // These are the only objects allowed to _create_ InputParameters
-  friend InputParameters validParams<MooseObject>();
-  friend InputParameters validParams<Action>();
-  friend InputParameters validParams<Problem>();
-  friend InputParameters emptyInputParameters();
-  friend InputParameters validParams<MooseApp>();
-
 private:
   // Private constructor so that InputParameters can only be created in certain places.
   InputParameters();
+
+  /**
+   * Toggle the availability of the copy constructor
+   *
+   * When MooseObject is created via the Factory this flag is set to false, so when a MooseObject is created if
+   * the constructor is not a const reference an error is produced. This method allows the InputParameterWarehouse
+   * to disable copying.
+   */
+  void allowCopy(bool status){ _allow_copy = status; }
 
   /// This method is called when adding a Parameter with a default value, can be specialized for non-matching types
   template <typename T, typename S>
@@ -580,6 +582,17 @@ private:
 
   /// Flag for disabling deprecated parameters message, this is used by applyParameters to avoid dumping messages
   bool _show_deprecated_message;
+
+  /// A flag for toggling the error message in the copy constructor
+  bool _allow_copy;
+
+  // These are the only objects allowed to _create_ InputParameters
+  friend InputParameters validParams<MooseObject>();
+  friend InputParameters validParams<Action>();
+  friend InputParameters validParams<Problem>();
+  friend InputParameters emptyInputParameters();
+  friend InputParameters validParams<MooseApp>();
+  friend class InputParameterWarehouse;
 };
 
 // Template and inline function implementations

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -44,7 +44,6 @@ class Action;
 class Parser;
 class Problem;
 class MooseApp;
-
 class InputParameters;
 
 template<class T>

--- a/framework/include/vectorpostprocessors/SamplerBase.h
+++ b/framework/include/vectorpostprocessors/SamplerBase.h
@@ -82,7 +82,7 @@ protected:
   virtual void threadJoin(const SamplerBase & y);
 
   /// The child params
-  InputParameters _sampler_params;
+  const InputParameters & _sampler_params;
 
   /// The child VectorPostprocessor
   VectorPostprocessor * _vpp;

--- a/framework/include/vectorpostprocessors/VectorPostprocessorInterface.h
+++ b/framework/include/vectorpostprocessors/VectorPostprocessorInterface.h
@@ -114,7 +114,7 @@ private:
   THREAD_ID _vpi_tid;
 
   /// VectorPostprocessorInterface Parameters
-  const InputParameters _vpi_params;
+  const InputParameters & _vpi_params;
 };
 
 #endif //VECTORPOSTPROCESSORINTERFACE_H

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -130,7 +130,7 @@ ActionWarehouse::addActionBlock(MooseSharedPointer<Action> action)
     MooseSharedPointer<MooseObjectAction> moa = MooseSharedNamespace::dynamic_pointer_cast<MooseObjectAction>(action);
     if (moa.get())
     {
-      InputParameters mparams = moa->getObjectParams();
+      const InputParameters & mparams = moa->getObjectParams();
 
       if (mparams.have_parameter<std::string>("_moose_base"))
       {

--- a/framework/src/actions/CreateDisplacedProblemAction.C
+++ b/framework/src/actions/CreateDisplacedProblemAction.C
@@ -12,13 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "InitDisplacedProblemAction.h"
+#include "CreateDisplacedProblemAction.h"
 #include "MooseApp.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
 
 template<>
-InputParameters validParams<InitDisplacedProblemAction>()
+InputParameters validParams<CreateDisplacedProblemAction>()
 {
   InputParameters params = validParams<Action>();
   params.addParam<std::vector<std::string> >("displacements", "The variables corresponding to the x y z displacements of the mesh.  If this is provided then the displacements will be taken into account during the computation.");
@@ -26,29 +26,28 @@ InputParameters validParams<InitDisplacedProblemAction>()
   return params;
 }
 
-InitDisplacedProblemAction::InitDisplacedProblemAction(InputParameters parameters) :
+CreateDisplacedProblemAction::CreateDisplacedProblemAction(InputParameters parameters) :
     Action(parameters)
 {
 }
 
-InitDisplacedProblemAction::~InitDisplacedProblemAction()
+CreateDisplacedProblemAction::~CreateDisplacedProblemAction()
 {
 }
 
 void
-InitDisplacedProblemAction::act()
+CreateDisplacedProblemAction::act()
 {
   if (isParamValid("displacements"))
   {
     if (!_displaced_mesh)
       mooseError("displacements were set but a displaced mesh wasn't created!");
 
-    Moose::setup_perf_log.push("Create DisplacedProblem","Setup");
+    Moose::setup_perf_log.push("Create DisplacedProblem", "Setup");
 
     // Define the parameters
     InputParameters object_params = _factory.getValidParams("DisplacedProblem");
     object_params.set<std::vector<std::string> >("displacements") = getParam<std::vector<std::string> >("displacements");
-    // object_params += _problem->parameters();
     object_params.set<MooseMesh *>("mesh") = _displaced_mesh.get();
     object_params.set<FEProblem *>("_fe_problem") = _problem.get();
 

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -38,7 +38,6 @@ Adaptivity::Adaptivity(FEProblem & subproblem) :
     _mesh_refinement(NULL),
     _error_estimator(NULL),
     _error(NULL),
-    _displaced_problem(_subproblem.getDisplacedProblem()),
     _displaced_mesh_refinement(NULL),
     _initial_steps(0),
     _steps(0),
@@ -70,6 +69,10 @@ Adaptivity::~Adaptivity()
 void
 Adaptivity::init(unsigned int steps, unsigned int initial_steps)
 {
+  // Get the pointer to the DisplacedProblem, this cannot be done at construction because DisplacedProblem
+  // does not exist at that point.
+  _displaced_problem = _subproblem.getDisplacedProblem();
+
   if (!_mesh_refinement)
     _mesh_refinement = new MeshRefinement(_mesh);
 
@@ -140,7 +143,7 @@ Adaptivity::adaptMesh()
         _subproblem.getAuxiliarySystem().solution().close();
         _subproblem.getAuxiliarySystem().solution().localize(serialized_solution);
 
-        FlagElementsThread fet(_subproblem, serialized_solution, _displaced_problem, _max_h_level);
+        FlagElementsThread fet(_subproblem, serialized_solution, _max_h_level);
         ConstElemRange all_elems(_subproblem.mesh().getMesh().active_elements_begin(),
                                  _subproblem.mesh().getMesh().active_elements_end(), 1);
         Threads::parallel_reduce(all_elems, fet);

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -26,13 +26,13 @@ InputParameters validParams<DisplacedProblem>()
   return params;
 }
 
-DisplacedProblem::DisplacedProblem(FEProblem & mproblem, MooseMesh & displaced_mesh, InputParameters params) :
-    SubProblem(params),
-    _mproblem(mproblem),
-    _mesh(displaced_mesh),
-    _eq(displaced_mesh),
+DisplacedProblem::DisplacedProblem(const InputParameters & parameters) :
+    SubProblem(parameters),
+    _mproblem(*getParam<FEProblem *>("_fe_problem")),
+    _mesh(*getParam<MooseMesh *>("mesh")),
+    _eq(_mesh),
     _ref_mesh(_mproblem.mesh()),
-    _displacements(params.get<std::vector<std::string> >("displacements")),
+    _displacements(getParam<std::vector<std::string> >("displacements")),
     _displaced_nl(*this, _mproblem.getNonlinearSystem(), _mproblem.getNonlinearSystem().name() + "_displaced", Moose::VAR_NONLINEAR),
     _displaced_aux(*this, _mproblem.getAuxiliarySystem(), _mproblem.getAuxiliarySystem().name() + "_displaced", Moose::VAR_AUXILIARY),
     _geometric_search_data(_mproblem, _mesh)

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -127,7 +127,6 @@ FEProblem::FEProblem(const InputParameters & parameters) :
     _adaptivity(*this),
 #endif
     _displaced_mesh(NULL),
-    _displaced_problem(NULL),
     _geometric_search_data(*this, _mesh),
     _reinit_displaced_elem(false),
     _reinit_displaced_face(false),
@@ -241,7 +240,6 @@ FEProblem::~FEProblem()
     delete _neighbor_material_data[i];
   }
 
-  delete _displaced_problem;
   delete &_nl;
 
   for (unsigned int i=0; i<n_threads; i++)
@@ -1253,7 +1251,7 @@ FEProblem::addKernel(const std::string & kernel_name, const std::string & name, 
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->nlSys();
     _reinit_displaced_elem = true;
   }
@@ -1271,7 +1269,7 @@ FEProblem::addScalarKernel(const std::string & kernel_name, const std::string & 
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->nlSys();
   }
   else
@@ -1288,7 +1286,7 @@ FEProblem::addBoundaryCondition(const std::string & bc_name, const std::string &
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->nlSys();
     _reinit_displaced_face = true;
   }
@@ -1308,7 +1306,7 @@ FEProblem::addConstraint(const std::string & c_name, const std::string & name, I
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->nlSys();
     _reinit_displaced_face = true;
   }
@@ -1358,7 +1356,7 @@ FEProblem::addAuxKernel(const std::string & kernel_name, const std::string & nam
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->auxSys();
     parameters.set<SystemBase *>("_nl_sys") = &_displaced_problem->nlSys();
     if (!parameters.get<std::vector<BoundaryName> >("boundary").empty())
@@ -1381,7 +1379,7 @@ FEProblem::addAuxScalarKernel(const std::string & kernel_name, const std::string
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->auxSys();
   }
   else
@@ -1398,7 +1396,7 @@ FEProblem::addDiracKernel(const std::string & kernel_name, const std::string & n
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->nlSys();
     _reinit_displaced_elem = true;
   }
@@ -1418,7 +1416,7 @@ FEProblem::addDGKernel(const std::string & dg_kernel_name, const std::string & n
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->nlSys();
     _reinit_displaced_face = true;
   }
@@ -1571,7 +1569,7 @@ FEProblem::addMaterial(const std::string & mat_name, const std::string & name, I
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     _reinit_displaced_elem = true;
   }
   else
@@ -1834,7 +1832,7 @@ FEProblem::addPostprocessor(std::string pp_name, const std::string & name, Input
 {
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
   else
     parameters.set<SubProblem *>("_subproblem") = this;
 
@@ -1942,7 +1940,7 @@ FEProblem::addVectorPostprocessor(std::string pp_name, const std::string & name,
 {
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
   else
     parameters.set<SubProblem *>("_subproblem") = this;
 
@@ -1998,7 +1996,7 @@ FEProblem::addUserObject(std::string user_object_name, const std::string & name,
 {
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
   else
     parameters.set<SubProblem *>("_subproblem") = this;
 
@@ -2576,7 +2574,7 @@ FEProblem::addIndicator(std::string indicator_name, const std::string & name, In
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->auxSys();
     _reinit_displaced_elem = true;
   }
@@ -2606,7 +2604,7 @@ FEProblem::addMarker(std::string marker_name, const std::string & name, InputPar
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->auxSys();
     _reinit_displaced_elem = true;
   }
@@ -2636,7 +2634,7 @@ FEProblem::addMultiApp(const std::string & multi_app_name, const std::string & n
 
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->auxSys();
     _reinit_displaced_elem = true;
   }
@@ -2834,7 +2832,7 @@ FEProblem::addTransfer(const std::string & transfer_name, const std::string & na
   parameters.set<FEProblem *>("_fe_problem") = this;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
-    parameters.set<SubProblem *>("_subproblem") = _displaced_problem;
+    parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
     parameters.set<SystemBase *>("_sys") = &_displaced_problem->auxSys();
     _reinit_displaced_elem = true;
   }
@@ -3628,16 +3626,10 @@ FEProblem::predictorCleanup(NumericVector<Number>& /*ghosted_solution*/)
 }
 
 void
-FEProblem::initDisplacedProblem(MooseMesh * displaced_mesh, InputParameters & params)
+FEProblem::addDisplacedProblem(MooseSharedPointer<DisplacedProblem> displaced_problem)
 {
-  if (displaced_mesh == NULL)
-    mooseError("Trying to set displaced mesh to NULL");
-  _displaced_mesh = displaced_mesh;
-
-  Moose::setup_perf_log.push("Create DisplacedProblem","Setup");
-  params += parameters();
-  _displaced_problem = new DisplacedProblem(*this, *_displaced_mesh, params);
-  Moose::setup_perf_log.pop("Create DisplacedProblem","Setup");
+  _displaced_mesh = &displaced_problem->mesh();
+  _displaced_problem = displaced_problem;
 }
 
 void

--- a/framework/src/base/FlagElementsThread.C
+++ b/framework/src/base/FlagElementsThread.C
@@ -24,11 +24,10 @@
 
 FlagElementsThread::FlagElementsThread(FEProblem & fe_problem,
                                        std::vector<Number> & serialized_solution,
-                                       DisplacedProblem * displaced_problem,
                                        unsigned int max_h_level) :
     ThreadedElementLoop<ConstElemRange>(fe_problem, fe_problem.getAuxiliarySystem()),
     _fe_problem(fe_problem),
-    _displaced_problem(displaced_problem),
+    _displaced_problem(_fe_problem.getDisplacedProblem()),
     _aux_sys(fe_problem.getAuxiliarySystem()),
     _system_number(_aux_sys.number()),
     _adaptivity(_fe_problem.adaptivity()),

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -352,7 +352,7 @@
 #include "SetupResidualDebugAction.h"
 #include "DeprecatedBlockAction.h"
 #include "AddConstraintAction.h"
-#include "InitDisplacedProblemAction.h"
+#include "CreateDisplacedProblemAction.h"
 #include "CreateProblemAction.h"
 #include "DynamicObjectRegistrationAction.h"
 #include "AddUserObjectAction.h"
@@ -946,7 +946,7 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
   registerAction(SetupTimeStepperAction, "setup_time_stepper");
   registerAction(SetupTimeIntegratorAction, "setup_time_integrator");
   registerAction(SetupTimePeriodsAction, "setup_time_periods");
-  registerAction(InitDisplacedProblemAction, "init_displaced_problem");
+  registerAction(CreateDisplacedProblemAction, "init_displaced_problem");
   registerAction(DetermineSystemType, "determine_system_type");
   registerAction(CreateProblemAction, "create_problem");
   registerAction(DynamicObjectRegistrationAction, "dynamic_object_registration");

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -44,6 +44,7 @@
 
 // problems
 #include "FEProblem.h"
+#include "DisplacedProblem.h"
 
 // kernels
 #include "TimeDerivative.h"
@@ -418,6 +419,7 @@ registerObjects(Factory & factory)
 
   // problems
   registerProblem(FEProblem);
+  registerProblem(DisplacedProblem);
 
   // kernels
   registerKernel(TimeDerivative);

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -213,7 +213,8 @@ OversampleOutput::cloneMesh()
   // Create the new mesh from a file
   if (isParamValid("file"))
   {
-    InputParameters mesh_params = _problem_ptr->mesh().parameters();
+    InputParameters mesh_params = emptyInputParameters();
+    mesh_params += _problem_ptr->mesh().parameters();
     mesh_params.set<MeshFileName>("file") = getParam<MeshFileName>("file");
     mesh_params.set<bool>("nemesis") = false;
     mesh_params.set<bool>("skip_partitioning") = false;
@@ -234,4 +235,3 @@ OversampleOutput::cloneMesh()
     _mesh_ptr= &(_problem_ptr->mesh().clone());
   }
 }
-

--- a/framework/src/parser/MooseSyntax.C
+++ b/framework/src/parser/MooseSyntax.C
@@ -47,7 +47,7 @@ void associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("SetupMeshCompleteAction", "Mesh");
 //  syntax.registerActionSyntax("SetupMeshCompleteAction", "Mesh", "prepare_mesh");
 //  syntax.registerActionSyntax("SetupMeshCompleteAction", "Mesh", "setup_mesh_complete");
-  syntax.registerActionSyntax("InitDisplacedProblemAction", "Mesh");
+  syntax.registerActionSyntax("CreateDisplacedProblemAction", "Mesh");
   syntax.registerActionSyntax("AddMeshModifierAction", "MeshModifiers/*");
   syntax.registerActionSyntax("AddMortarInterfaceAction", "Mesh/MortarInterfaces/*");
 

--- a/framework/src/utils/InputParameterWarehouse.C
+++ b/framework/src/utils/InputParameterWarehouse.C
@@ -38,7 +38,7 @@ InputParameterWarehouse::addInputParameters(const std::string & name, InputParam
   // Set the name and tid parameters
   ptr->addParam<std::string>("name", name, "The complete name of the object");
   ptr->addPrivateParam<THREAD_ID>("_tid", tid);
-  ptr->addPrivateParam<bool>("_allow_parameter_copy", false);  // no more copies allowed
+  ptr->allowCopy(false);  // no more copies allowed
 
   // Store the object in the warehouse
   _name_to_shared_pointer[tid].insert(std::pair<std::string, MooseSharedPointer<InputParameters> >(name, ptr));

--- a/framework/src/utils/InputParameterWarehouse.C
+++ b/framework/src/utils/InputParameterWarehouse.C
@@ -38,6 +38,7 @@ InputParameterWarehouse::addInputParameters(const std::string & name, InputParam
   // Set the name and tid parameters
   ptr->addParam<std::string>("name", name, "The complete name of the object");
   ptr->addPrivateParam<THREAD_ID>("_tid", tid);
+  ptr->addPrivateParam<bool>("_allow_parameter_copy", false);  // no more copies allowed
 
   // Store the object in the warehouse
   _name_to_shared_pointer[tid].insert(std::pair<std::string, MooseSharedPointer<InputParameters> >(name, ptr));

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -28,20 +28,23 @@ InputParameters::InputParameters() :
     Parameters(),
     _collapse_nesting(false),
     _moose_object_syntax_visibility(true),
-    _show_deprecated_message(true)
+    _show_deprecated_message(true),
+    _allow_copy(true)
 {
 }
 
 InputParameters::InputParameters(const InputParameters &rhs) :
     Parameters(),
-    _show_deprecated_message(true)
+    _show_deprecated_message(true),
+    _allow_copy(true)
 
 {
   *this = rhs;
 }
 
 InputParameters::InputParameters(const Parameters &rhs) :
-    _show_deprecated_message(true)
+    _show_deprecated_message(true),
+    _allow_copy(true)
 {
   Parameters::operator=(rhs);
   _collapse_nesting = false;
@@ -71,6 +74,7 @@ InputParameters::clear()
   _collapse_nesting = false;
   _moose_object_syntax_visibility = true;
   _show_deprecated_message = true;
+  _allow_copy = true;
 }
 
 void
@@ -119,7 +123,7 @@ InputParameters &
 InputParameters::operator=(const InputParameters &rhs)
 {
   // An error to help minimize the segmentation faults that occure when MooseObjects do not have the correct constructor
-  if (rhs.have_parameter<bool>("_allow_parameter_copy") && !rhs.get<bool>("_allow_parameter_copy"))
+  if (!rhs._allow_copy)
   {
     const std::string & name = rhs.get<std::string>("name"); // If _allow_parameter_copy is set then so is name (see InputParameterWarehouse::addInputParameters)
     mooseError("Copying of the InputParameters object for the " << name << " object is not allowed.\n\nThe likely cause for this error "
@@ -145,6 +149,7 @@ InputParameters::operator=(const InputParameters &rhs)
   _default_coupled_value = rhs._default_coupled_value;
   _default_postprocessor_value = rhs._default_postprocessor_value;
   _set_by_add_param = rhs._set_by_add_param;
+  _allow_copy = rhs._allow_copy;
 
   return *this;
 }
@@ -169,7 +174,6 @@ InputParameters::operator+=(const InputParameters &rhs)
   _default_coupled_value.insert(rhs._default_coupled_value.begin(), rhs._default_coupled_value.end());
   _default_postprocessor_value.insert(rhs._default_postprocessor_value.begin(), rhs._default_postprocessor_value.end());
   _set_by_add_param.insert(rhs._set_by_add_param.begin(), rhs._set_by_add_param.end());
-
   return *this;
 }
 

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -118,6 +118,15 @@ InputParameters::getClassDescription() const
 InputParameters &
 InputParameters::operator=(const InputParameters &rhs)
 {
+  // An error to help minimize the segmentation faults that occure when MooseObjects do not have the correct constructor
+  if (rhs.have_parameter<bool>("_allow_parameter_copy") && !rhs.get<bool>("_allow_parameter_copy"))
+  {
+    const std::string & name = rhs.get<std::string>("name"); // If _allow_parameter_copy is set then so is name (see InputParameterWarehouse::addInputParameters)
+    mooseError("Copying of the InputParameters object for the " << name << " object is not allowed.\n\nThe likely cause for this error "
+               << "is having a constructor that does not use a const reference, all constructors\nfor MooseObject based classes should be as follows:\n\n"
+               << "    MyObject::MyObject(const InputParameters & parameters);");
+  }
+
   Parameters::operator=(rhs);
 
   _doc_string = rhs._doc_string;

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -507,7 +507,7 @@ static PetscErrorCode DMMooseGetEmbedding_Private(DM dm, IS *embedding)
       PetscBool displaced = (*dmm->contact_displaced)[it->second];
       PenetrationLocator *locator;
       if (displaced) {
-        DisplacedProblem *displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
+        MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
         if (!displaced_problem) {
     std::ostringstream err;
     err << "Cannot use a displaced contact (" << it->second.first << "," << it->second.second << ") with an undisplaced problem";
@@ -534,7 +534,7 @@ static PetscErrorCode DMMooseGetEmbedding_Private(DM dm, IS *embedding)
       PetscBool displaced = (*dmm->uncontact_displaced)[it->second];
       PenetrationLocator *locator;
       if (displaced) {
-        DisplacedProblem *displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
+        MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
         if (!displaced_problem) {
     std::ostringstream err;
     err << "Cannot use a displaced uncontact (" << it->second.first << "," << it->second.second << ") with an undisplaced problem";
@@ -1470,7 +1470,7 @@ PetscErrorCode  DMSetFromOptions_Moose(DM dm)
   }
   ierr = PetscFree(sides);CHKERRQ(ierr);
   PetscInt maxcontacts = dmm->nl->_fe_problem.geomSearchData()._penetration_locators.size();
-  DisplacedProblem *displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
+  MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
   if (displaced_problem) {
     maxcontacts = PetscMax(maxcontacts,(PetscInt)displaced_problem->geomSearchData()._penetration_locators.size());
   }

--- a/modules/richards/include/kernels/DarcyFlux.h
+++ b/modules/richards/include/kernels/DarcyFlux.h
@@ -25,7 +25,7 @@ class DarcyFlux : public Kernel
 {
 public:
 
-  DarcyFlux(InputParameters parameters);
+  DarcyFlux(const InputParameters & parameters);
 
 
 protected:

--- a/modules/richards/src/kernels/DarcyFlux.C
+++ b/modules/richards/src/kernels/DarcyFlux.C
@@ -20,7 +20,7 @@ InputParameters validParams<DarcyFlux>()
   return params;
 }
 
-DarcyFlux::DarcyFlux(InputParameters parameters) :
+DarcyFlux::DarcyFlux(const InputParameters & parameters) :
     Kernel(parameters),
     _fluid_weight(getParam<RealVectorValue>("fluid_weight")),
     _fluid_viscosity(getParam<Real>("fluid_viscosity")),

--- a/modules/solid_mechanics/include/materials/AxisymmetricRZ.h
+++ b/modules/solid_mechanics/include/materials/AxisymmetricRZ.h
@@ -17,7 +17,7 @@ namespace SolidMechanics
 class AxisymmetricRZ : public Element
 {
 public:
-  AxisymmetricRZ(SolidModel & solid_model, const std::string & name, InputParameters parameters);
+  AxisymmetricRZ(SolidModel & solid_model, const std::string & name, const InputParameters & parameters);
   virtual ~AxisymmetricRZ();
 
 protected:

--- a/modules/solid_mechanics/include/materials/Element.h
+++ b/modules/solid_mechanics/include/materials/Element.h
@@ -27,7 +27,7 @@ class Element :
 public:
   Element( SolidModel & solid_model,
            const std::string & name,
-           InputParameters parameters );
+           const InputParameters & parameters );
   virtual ~Element();
 
   static Real detMatrix( const ColumnMajorMatrix & A );

--- a/modules/solid_mechanics/include/materials/Linear.h
+++ b/modules/solid_mechanics/include/materials/Linear.h
@@ -18,7 +18,7 @@ namespace SolidMechanics
 class Linear : public Element
 {
 public:
-  Linear(SolidModel & solid_model, const std::string & name, InputParameters parameters);
+  Linear(SolidModel & solid_model, const std::string & name, const InputParameters & parameters);
   virtual ~Linear();
 
 protected:

--- a/modules/solid_mechanics/include/materials/Nonlinear.h
+++ b/modules/solid_mechanics/include/materials/Nonlinear.h
@@ -24,7 +24,7 @@ class Nonlinear : public Element
 public:
   Nonlinear( SolidModel & solid_model,
              const std::string & name,
-             InputParameters parameters );
+             const InputParameters & parameters );
 
   virtual ~Nonlinear();
 

--- a/modules/solid_mechanics/include/materials/Nonlinear3D.h
+++ b/modules/solid_mechanics/include/materials/Nonlinear3D.h
@@ -24,7 +24,7 @@ class Nonlinear3D : public Nonlinear
 public:
   Nonlinear3D( SolidModel & solid_model,
                const std::string & name,
-               InputParameters parameters );
+               const InputParameters & parameters );
 
   virtual ~Nonlinear3D();
 

--- a/modules/solid_mechanics/include/materials/NonlinearPlaneStrain.h
+++ b/modules/solid_mechanics/include/materials/NonlinearPlaneStrain.h
@@ -23,7 +23,7 @@ class NonlinearPlaneStrain :
 public:
   NonlinearPlaneStrain( SolidModel & solid_model,
                         const std::string & name,
-                        InputParameters parameters );
+                        const InputParameters & parameters );
 
   virtual ~NonlinearPlaneStrain();
 

--- a/modules/solid_mechanics/include/materials/NonlinearRZ.h
+++ b/modules/solid_mechanics/include/materials/NonlinearRZ.h
@@ -20,7 +20,7 @@ class NonlinearRZ : public Nonlinear
 public:
   NonlinearRZ( SolidModel & solid_model,
                const std::string & name,
-               InputParameters parameters );
+               const InputParameters & parameters );
 
   virtual ~NonlinearRZ();
 

--- a/modules/solid_mechanics/include/materials/PlaneStrain.h
+++ b/modules/solid_mechanics/include/materials/PlaneStrain.h
@@ -18,7 +18,7 @@ class PlaneStrain :
   public ScalarCoupleable
 {
 public:
-  PlaneStrain(SolidModel & solid_model, const std::string & name, InputParameters parameters);
+  PlaneStrain(SolidModel & solid_model, const std::string & name, const InputParameters & parameters);
   virtual ~PlaneStrain();
 
 protected:

--- a/modules/solid_mechanics/include/materials/SolidModel.h
+++ b/modules/solid_mechanics/include/materials/SolidModel.h
@@ -257,15 +257,14 @@ protected:
   /// Compute the stress (sigma += deltaSigma)
   virtual void computeConstitutiveModelStress();
 
-  void createConstitutiveModel(const std::string & cm_name, const InputParameters & params);
+  void createConstitutiveModel(const std::string & cm_name);
 
 
 private:
 
   void computeCrackStrainAndOrientation( ColumnMajorMatrix & principal_strain );
 
-  SolidMechanics::Element * createElement( const std::string & name,
-                                           const InputParameters & parameters );
+  SolidMechanics::Element * createElement();
 
   SolidMechanics::Element * _element;
 

--- a/modules/solid_mechanics/include/materials/SphericalR.h
+++ b/modules/solid_mechanics/include/materials/SphericalR.h
@@ -18,7 +18,7 @@ namespace SolidMechanics
 class SphericalR : public Element
 {
 public:
-  SphericalR(SolidModel & solid_model, const std::string & name, InputParameters parameters);
+  SphericalR(SolidModel & solid_model, const std::string & name, const InputParameters & parameters);
   virtual ~SphericalR();
 
 protected:

--- a/modules/solid_mechanics/src/materials/AxisymmetricRZ.C
+++ b/modules/solid_mechanics/src/materials/AxisymmetricRZ.C
@@ -14,7 +14,7 @@ namespace SolidMechanics
 
 AxisymmetricRZ::AxisymmetricRZ(SolidModel & solid_model,
                                const std::string & name,
-                               InputParameters parameters)
+                               const InputParameters & parameters)
   :Element(solid_model, name, parameters),
    _disp_r(coupledValue("disp_r")),
    _disp_z(coupledValue("disp_z")),

--- a/modules/solid_mechanics/src/materials/CLSHPlasticMaterial.C
+++ b/modules/solid_mechanics/src/materials/CLSHPlasticMaterial.C
@@ -26,6 +26,6 @@ CLSHPlasticMaterial::CLSHPlasticMaterial(const InputParameters & parameters)
   :SolidModel(parameters)
 {
 
-  createConstitutiveModel("CLSHPlasticModel", parameters);
+  createConstitutiveModel("CLSHPlasticModel");
 
 }

--- a/modules/solid_mechanics/src/materials/Elastic.C
+++ b/modules/solid_mechanics/src/materials/Elastic.C
@@ -17,7 +17,7 @@ Elastic::Elastic( const InputParameters & parameters)
   :SolidModel(parameters)
 {
 
-  createConstitutiveModel("ElasticModel", parameters);
+  createConstitutiveModel("ElasticModel");
 
 }
 
@@ -28,4 +28,3 @@ Elastic::~Elastic()
 }
 
 ////////////////////////////////////////////////////////////////////////
-

--- a/modules/solid_mechanics/src/materials/Element.C
+++ b/modules/solid_mechanics/src/materials/Element.C
@@ -14,7 +14,7 @@ namespace SolidMechanics
 
 Element::Element( SolidModel & solid_model,
                   const std::string & /*name*/,
-                  InputParameters parameters ) :
+                  const InputParameters & parameters ) :
   Coupleable(parameters, false),
   ZeroInterface(parameters),
   _solid_model( solid_model )

--- a/modules/solid_mechanics/src/materials/Linear.C
+++ b/modules/solid_mechanics/src/materials/Linear.C
@@ -15,7 +15,7 @@ namespace SolidMechanics
 
 Linear::Linear(SolidModel & solid_model,
                const std::string & name,
-               InputParameters parameters)
+               const InputParameters & parameters)
   :Element(solid_model, name, parameters),
    _large_strain(solid_model.getParam<bool>("large_strain")),
    _grad_disp_x(coupledGradient("disp_x")),

--- a/modules/solid_mechanics/src/materials/LinearStrainHardening.C
+++ b/modules/solid_mechanics/src/materials/LinearStrainHardening.C
@@ -31,7 +31,6 @@ LinearStrainHardening::LinearStrainHardening( const InputParameters & parameters
   :SolidModel(parameters)
 {
 
-  createConstitutiveModel("IsotropicPlasticity", parameters);
+  createConstitutiveModel("IsotropicPlasticity");
 
 }
-

--- a/modules/solid_mechanics/src/materials/Nonlinear.C
+++ b/modules/solid_mechanics/src/materials/Nonlinear.C
@@ -16,7 +16,7 @@ namespace SolidMechanics
 
 Nonlinear::Nonlinear( SolidModel & solid_model,
                           const std::string & name,
-                          InputParameters parameters )
+                          const InputParameters & parameters )
   :Element( solid_model, name, parameters ),
    _decomp_method( RashidApprox ),
    _incremental_rotation(3,3),

--- a/modules/solid_mechanics/src/materials/Nonlinear3D.C
+++ b/modules/solid_mechanics/src/materials/Nonlinear3D.C
@@ -16,7 +16,7 @@ namespace SolidMechanics
 
 Nonlinear3D::Nonlinear3D( SolidModel & solid_model,
                           const std::string & name,
-                          InputParameters parameters )
+                          const InputParameters & parameters )
   :Nonlinear( solid_model, name, parameters ),
    _grad_disp_x(coupledGradient("disp_x")),
    _grad_disp_y(coupledGradient("disp_y")),

--- a/modules/solid_mechanics/src/materials/NonlinearPlaneStrain.C
+++ b/modules/solid_mechanics/src/materials/NonlinearPlaneStrain.C
@@ -16,7 +16,7 @@ namespace SolidMechanics
 
 NonlinearPlaneStrain::NonlinearPlaneStrain( SolidModel & solid_model,
                                             const std::string & name,
-                                            InputParameters parameters )
+                                            const InputParameters & parameters )
   :Nonlinear( solid_model, name, parameters ),
    ScalarCoupleable(parameters),
    _grad_disp_x(coupledGradient("disp_x")),

--- a/modules/solid_mechanics/src/materials/NonlinearRZ.C
+++ b/modules/solid_mechanics/src/materials/NonlinearRZ.C
@@ -16,7 +16,7 @@ namespace SolidMechanics
 
 NonlinearRZ::NonlinearRZ( SolidModel & solid_model,
                           const std::string & name,
-                          InputParameters parameters )
+                          const InputParameters & parameters )
   :Nonlinear( solid_model, name, parameters ),
    _grad_disp_r(coupledGradient("disp_r")),
    _grad_disp_z(coupledGradient("disp_z")),

--- a/modules/solid_mechanics/src/materials/PlaneStrain.C
+++ b/modules/solid_mechanics/src/materials/PlaneStrain.C
@@ -12,7 +12,7 @@ namespace SolidMechanics
 
 PlaneStrain::PlaneStrain(SolidModel & solid_model,
                          const std::string & name,
-                         InputParameters parameters)
+                         const InputParameters & parameters)
   :Element(solid_model, name, parameters),
    ScalarCoupleable(parameters),
    _large_strain(solid_model.getParam<bool>("large_strain")),

--- a/modules/solid_mechanics/src/materials/PowerLawCreep.C
+++ b/modules/solid_mechanics/src/materials/PowerLawCreep.C
@@ -34,7 +34,6 @@ PowerLawCreep::PowerLawCreep( const InputParameters & parameters)
   :SolidModel(parameters)
 {
 
-  createConstitutiveModel( "PowerLawCreepModel", parameters );
+  createConstitutiveModel("PowerLawCreepModel");
 
 }
-

--- a/modules/solid_mechanics/src/materials/SolidModel.C
+++ b/modules/solid_mechanics/src/materials/SolidModel.C
@@ -166,7 +166,7 @@ SolidModel::SolidModel( const InputParameters & parameters) :
     mooseError("Material '" << name() << "' was specified on multiple blocks that do not have the same coordinate system");
   // Use the first block to figure out the coordinate system (the above check ensures that they are the same)
   _coord_type = _subproblem.getCoordSystem(_block_id[0]);
-  _element = createElement(name(), parameters);
+  _element = createElement();
 
   const std::vector<std::string> & dmp = getParam<std::vector<std::string> >("dep_matl_props");
   _dep_matl_props.insert(dmp.begin(), dmp.end());
@@ -1346,9 +1346,12 @@ SolidModel::getNumKnownCrackDirs() const
 }
 
 SolidMechanics::Element *
-SolidModel::createElement( const std::string & mat_name,
-                           const InputParameters & parameters )
+SolidModel::createElement()
 {
+  std::string mat_name = name();
+  InputParameters parameters = emptyInputParameters();
+  parameters += this->parameters();
+
   SolidMechanics::Element * element(NULL);
 
   std::string formulation = getParam<MooseEnum>("formulation");
@@ -1471,10 +1474,12 @@ SolidModel::createElement( const std::string & mat_name,
 }
 
 void
-SolidModel::createConstitutiveModel(const std::string & cm_name, const InputParameters & params)
+SolidModel::createConstitutiveModel(const std::string & cm_name)
 {
 
   Factory & factory = _app.getFactory();
+  InputParameters params = factory.getValidParams(cm_name);
+  params += parameters();
   MooseSharedPointer<ConstitutiveModel> cm = MooseSharedNamespace::dynamic_pointer_cast<ConstitutiveModel>(factory.create(cm_name, name()+"Model", params, _tid));
 
   if (!cm.get())
@@ -1555,4 +1560,3 @@ SolidModel::computeThermalJvec()
     }
   }
 }
-

--- a/modules/solid_mechanics/src/materials/SphericalR.C
+++ b/modules/solid_mechanics/src/materials/SphericalR.C
@@ -14,7 +14,7 @@ namespace SolidMechanics
 
 SphericalR::SphericalR(SolidModel & solid_model,
                        const std::string & name,
-                       InputParameters parameters)
+                       const InputParameters & parameters)
   :Element(solid_model, name, parameters),
    _disp_r(coupledValue("disp_r")),
    _large_strain(solid_model.getParam<bool>("large_strain")),

--- a/test/include/kernels/DoNotCopyParametersKernel.h
+++ b/test/include/kernels/DoNotCopyParametersKernel.h
@@ -1,0 +1,36 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#ifndef DONOTCOPYPARAMETESKERNEL_H
+#define DONOTCOPYPARAMETESKERNEL_H
+
+#include "Kernel.h"
+
+//Forward Declarations
+class DoNotCopyParametersKernel;
+
+template<>
+InputParameters validParams<DoNotCopyParametersKernel>();
+
+class DoNotCopyParametersKernel : public Kernel
+{
+public:
+  // This is the wrong constructor, don't to this!
+  DoNotCopyParametersKernel(InputParameters parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+};
+
+#endif //DONOTCOPYPARAMETESKERNEL_H

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -70,7 +70,7 @@
 #include "ConsoleMessageKernel.h"
 #include "WrongJacobianDiffusion.h"
 #include "DefaultMatPropConsumerKernel.h"
-
+#include "DoNotCopyParametersKernel.h"
 #include "CoupledAux.h"
 #include "CoupledScalarAux.h"
 #include "CoupledGradAux.h"
@@ -306,6 +306,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerKernel(ConsoleMessageKernel);
   registerKernel(WrongJacobianDiffusion);
   registerKernel(DefaultMatPropConsumerKernel);
+  registerKernel(DoNotCopyParametersKernel);
 
   // Aux kernels
   registerAux(CoupledAux);

--- a/test/src/kernels/DoNotCopyParametersKernel.C
+++ b/test/src/kernels/DoNotCopyParametersKernel.C
@@ -1,0 +1,40 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#include "DoNotCopyParametersKernel.h"
+
+template<>
+InputParameters validParams<DoNotCopyParametersKernel>()
+{
+  InputParameters params = validParams<Kernel>();
+  return params;
+}
+
+// This is the wrong constructor, don't to this!
+DoNotCopyParametersKernel::DoNotCopyParametersKernel(InputParameters parameters) :
+    Kernel(parameters)
+{
+}
+
+Real
+DoNotCopyParametersKernel::computeQpResidual()
+{
+  getParam<std::string>("name"); // This will cause a segmentation fault
+  return 0.0;
+}
+
+Real
+DoNotCopyParametersKernel::computeQpJacobian()
+{
+  return 0.0;
+}

--- a/test/tests/utils/copy_input_parameters/do_not_copy_parameters.i
+++ b/test/tests/utils/copy_input_parameters/do_not_copy_parameters.i
@@ -1,0 +1,41 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = DoNotCopyParametersKernel
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+[]

--- a/test/tests/utils/copy_input_parameters/tests
+++ b/test/tests/utils/copy_input_parameters/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./test]
+    type = 'RunException'
+    input = 'do_not_copy_parameters.i'
+    expect_err = 'Copying of the InputParameters object for the Kernels/diff object is not allowed.'
+  [../]
+[]


### PR DESCRIPTION
- Interfaces now use `const` references to `InputParameters`
- Developed a scheme for error with MooseObject based object constructors do not used references for InputParameters
- Re-factored DisplacedProblem to operate more like a MooseObject, which it is, on creation
- Fixes some parameter copying that will lead to seg. faults in solid_mechanics

(closes #5439)
