### PR TITLE
Deprecate PFMobility

### DIFF
--- a/modules/combined/examples/phase_field-mechanics/Conserved.i
+++ b/modules/combined/examples/phase_field-mechanics/Conserved.i
@@ -105,12 +105,12 @@
 
 [Materials]
   [./pfmobility]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1 5'
     block = 0
     #kappa = 0.1
-    kappa = 5
     #mob = 1e-3
-    mob = 1
   [../]
 
   # simple chemical free energy with a miscibility gap

--- a/modules/misc/tests/dynamic_loading/dynamic_load_multiapp/phase_field_slave.i
+++ b/modules/misc/tests/dynamic_loading/dynamic_load_multiapp/phase_field_slave.i
@@ -57,10 +57,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
 []
 

--- a/modules/misc/tests/dynamic_loading/dynamic_load_multiapp/phase_field_slave.i
+++ b/modules/misc/tests/dynamic_loading/dynamic_load_multiapp/phase_field_slave.i
@@ -44,7 +44,6 @@
     variable = c
     kappa_name = kappa_c
     mob_name = M
-    grad_mob_name = grad_M
   [../]
 []
 

--- a/modules/misc/tests/dynamic_loading/dynamic_obj_registration/dynamic_objects.i
+++ b/modules/misc/tests/dynamic_loading/dynamic_obj_registration/dynamic_objects.i
@@ -58,10 +58,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
 []
 

--- a/modules/misc/tests/dynamic_loading/dynamic_obj_registration/dynamic_wrong_lib.i
+++ b/modules/misc/tests/dynamic_loading/dynamic_obj_registration/dynamic_wrong_lib.i
@@ -57,10 +57,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
 []
 

--- a/modules/misc/tests/dynamic_loading/dynamic_obj_registration/dynamic_wrong_lib.i
+++ b/modules/misc/tests/dynamic_loading/dynamic_obj_registration/dynamic_wrong_lib.i
@@ -44,7 +44,6 @@
     variable = c
     kappa_name = kappa_c
     mob_name = M
-    grad_mob_name = grad_M
   [../]
 []
 

--- a/modules/misc/tests/dynamic_loading/dynamic_obj_registration/tests
+++ b/modules/misc/tests/dynamic_loading/dynamic_obj_registration/tests
@@ -24,7 +24,7 @@
     input = 'dynamic_objects.i'
     exodiff = 'dynamic_objects_out.e'
     # Register only some of the objects necessary for running this test
-    cli_args = "Problem/object_names='CHMath CHInterface PFMobility'"
+    cli_args = "Problem/object_names='CHMath CHInterface'"
     library_mode = 'DYNAMIC'
     prereq = 'dynamic_object_loading'
 
@@ -37,7 +37,7 @@
     input = 'dynamic_objects.i'
     expect_err = "A '\w+' is not a registered object"
     # Register only some of the objects necessary, not enough for running this test
-    cli_args = "Problem/object_names='CHMath CHInterface'"
+    cli_args = "Problem/object_names='CHMath'"
     library_mode = 'DYNAMIC'
     prereq = 'dynamic_object_restrict'
 

--- a/modules/phase_field/examples/cahn-hilliard/Math_CH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Math_CH.i
@@ -47,10 +47,10 @@
 
 [Materials]
   [./mat]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 0.5'
     block = 0
-    mob = 1.0
-    kappa = 0.5
   [../]
 []
 

--- a/modules/phase_field/examples/cahn-hilliard/Math_CH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Math_CH.i
@@ -34,7 +34,6 @@
     variable = c
     mob_name = M
     kappa_name = kappa_c
-    grad_mob_name = grad_M
   [../]
 []
 
@@ -87,4 +86,3 @@
   print_linear_residuals = true
   print_perf_log = true
 []
-

--- a/modules/phase_field/examples/cahn-hilliard/Parsed_CH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Parsed_CH.i
@@ -81,10 +81,10 @@
 
 [Materials]
   [./mat]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 0.5'
     block = 0
-    mob = 1.0
-    kappa = 0.5
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial

--- a/modules/phase_field/examples/cahn-hilliard/Parsed_CH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Parsed_CH.i
@@ -57,7 +57,6 @@
     variable = c
     mob_name = M
     kappa_name = kappa_c
-    grad_mob_name = grad_M
   [../]
 []
 
@@ -131,4 +130,3 @@
   print_linear_residuals = true
   print_perf_log = true
 []
-

--- a/modules/phase_field/examples/cahn-hilliard/Parsed_SplitCH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Parsed_SplitCH.i
@@ -77,10 +77,10 @@
 
 [Materials]
   [./mat]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 0.5'
     block = 0
-    mob = 1.0
-    kappa = 0.5
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial

--- a/modules/phase_field/examples/nucleation/cahn_hilliard.i
+++ b/modules/phase_field/examples/nucleation/cahn_hilliard.i
@@ -56,10 +56,10 @@
 
 [Materials]
   [./pfmobility]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1 25'
     block = 0
-    kappa = 25
-    mob = 1
   [../]
 
   [./chemical_free_energy]

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -299,11 +299,11 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerMaterial(PFCRFFMaterial);
   registerMaterial(PFCTradMaterial);
   registerMaterial(PFFracBulkRateMaterial);
-  registerMaterial(PFMobility);
   registerMaterial(PFParamsPolyFreeEnergy);
   registerMaterial(PolynomialFreeEnergy);
   registerMaterial(SwitchingFunctionMaterial);
   registerMaterial(CrossTermBarrierFunctionMaterial);
+  registerDeprecatedObjectName(PFMobility, "PFMobility", "09/26/2015 00:00");
 
   registerPostprocessor(FeatureFloodCount);
   registerPostprocessor(GrainTracker);

--- a/modules/phase_field/tests/CH_IC/CH_BndingBoxIC_test.i
+++ b/modules/phase_field/tests/CH_IC/CH_BndingBoxIC_test.i
@@ -57,10 +57,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
 []
 

--- a/modules/phase_field/tests/CH_IC/CH_CircleIC_test.i
+++ b/modules/phase_field/tests/CH_IC/CH_CircleIC_test.i
@@ -56,10 +56,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
 []
 

--- a/modules/phase_field/tests/CH_IC/CH_CrossIC_test.i
+++ b/modules/phase_field/tests/CH_IC/CH_CrossIC_test.i
@@ -54,10 +54,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 2.0'
     block = 0
-    mob = 1.0
-    kappa = 2.0
   [../]
 []
 

--- a/modules/phase_field/tests/CH_IC/CH_GradBoxIC_test.i
+++ b/modules/phase_field/tests/CH_IC/CH_GradBoxIC_test.i
@@ -54,7 +54,6 @@
     variable = c
     kappa_name = kappa_c
     mob_name = M
-    grad_mob_name = grad_M
   [../]
 []
 
@@ -121,5 +120,3 @@ active = 'Periodic'
   print_linear_residuals = true
   print_perf_log = true
 []
-
-

--- a/modules/phase_field/tests/CH_IC/CH_GradBoxIC_test.i
+++ b/modules/phase_field/tests/CH_IC/CH_GradBoxIC_test.i
@@ -77,10 +77,10 @@ active = 'Periodic'
 [Materials]
 
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
 []
 

--- a/modules/phase_field/tests/CH_IC/CH_RndBndingBoxIC_test.i
+++ b/modules/phase_field/tests/CH_IC/CH_RndBndingBoxIC_test.i
@@ -58,10 +58,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
 []
 

--- a/modules/phase_field/tests/CH_IC/CH_RndCircleIC_test.i
+++ b/modules/phase_field/tests/CH_IC/CH_RndCircleIC_test.i
@@ -58,10 +58,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
 []
 

--- a/modules/phase_field/tests/MathEBFreeEnergy/MathEBFreeEnergy_test.i
+++ b/modules/phase_field/tests/MathEBFreeEnergy/MathEBFreeEnergy_test.i
@@ -57,10 +57,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
   [./free_energy]
     type = MathEBFreeEnergy

--- a/modules/phase_field/tests/MathEBFreeEnergy/SplitMathEBFreeEnergy_test.i
+++ b/modules/phase_field/tests/MathEBFreeEnergy/SplitMathEBFreeEnergy_test.i
@@ -84,10 +84,10 @@ active = 'SMP'
 [Materials]
 
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 2.0'
     block = 0
-    mob = 1.0
-    kappa = 2.0
   [../]
   [./free_energy]
     type = MathEBFreeEnergy

--- a/modules/phase_field/tests/MathFreeEnergy/MathFreeEnergy_test.i
+++ b/modules/phase_field/tests/MathFreeEnergy/MathFreeEnergy_test.i
@@ -57,10 +57,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.0'
     block = 0
-    mob = 1.0
-    kappa = 1.0
   [../]
   [./free_energy]
     type = MathFreeEnergy

--- a/modules/phase_field/tests/MathFreeEnergy/SplitMathFreeEnergy_test.i
+++ b/modules/phase_field/tests/MathFreeEnergy/SplitMathFreeEnergy_test.i
@@ -84,10 +84,10 @@ active = 'SMP'
 [Materials]
 
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 2.0'
     block = 0
-    mob = 1.0
-    kappa = 2.0
   [../]
   [./free_energy]
     type = MathFreeEnergy

--- a/modules/phase_field/tests/MultiPhase/derivativetwophasematerial.i
+++ b/modules/phase_field/tests/MultiPhase/derivativetwophasematerial.i
@@ -96,10 +96,10 @@
     prop_values = '1 1        '
   [../]
   [./consts2]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1 1'
     block = 0
-    kappa = 1
-    mob = 1
   [../]
 
   [./switching]

--- a/modules/phase_field/tests/MultiPhase/lagrangemult.i
+++ b/modules/phase_field/tests/MultiPhase/lagrangemult.i
@@ -145,10 +145,10 @@
     prop_values = '1 1        '
   [../]
   [./consts2]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1 1'
     block = 0
-    kappa = 1
-    mob = 1
   [../]
 
   [./switching1]

--- a/modules/phase_field/tests/MultiPhase/penalty.i
+++ b/modules/phase_field/tests/MultiPhase/penalty.i
@@ -135,10 +135,10 @@
     prop_values = '1 1        '
   [../]
   [./consts2]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1 1'
     block = 0
-    kappa = 1
-    mob = 1
   [../]
 
   [./hsum]

--- a/modules/phase_field/tests/MultiSmoothCircleIC/latticesmoothcircleIC_small_invalue_test.i
+++ b/modules/phase_field/tests/MultiSmoothCircleIC/latticesmoothcircleIC_small_invalue_test.i
@@ -57,10 +57,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 1.5'
     block = 0
-    mob = 1.0
-    kappa = 1.5
   [../]
 []
 

--- a/modules/phase_field/tests/Parsed/CHParsed_test.i
+++ b/modules/phase_field/tests/Parsed/CHParsed_test.i
@@ -54,10 +54,10 @@
 
 [Materials]
   [./consts]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1 0.1'
     block = 0
-    kappa = 0.1
-    mob = 1
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial

--- a/modules/phase_field/tests/Parsed/SplitCHParsed_test.i
+++ b/modules/phase_field/tests/Parsed/SplitCHParsed_test.i
@@ -62,10 +62,10 @@
 
 [Materials]
   [./pfmobility]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1e-3 0.1'
     block = 0
-    kappa = 0.1
-    mob = 1e-3
   [../]
 
   [./free_energy]

--- a/modules/phase_field/tests/SplitCH/split_math_test.i
+++ b/modules/phase_field/tests/SplitCH/split_math_test.i
@@ -92,10 +92,10 @@ active = 'SMP'
 [Materials]
 
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 2.0'
     block = 0
-    mob = 1.0
-    kappa = 2.0
   [../]
 []
 

--- a/modules/phase_field/tests/TotalFreeEnergy/TotalFreeEnergy_test.i
+++ b/modules/phase_field/tests/TotalFreeEnergy/TotalFreeEnergy_test.i
@@ -75,10 +75,10 @@
 
 [Materials]
   [./pfmobility]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1e-3 0.1'
     block = 0
-    kappa = 0.1
-    mob = 1e-3
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial

--- a/modules/phase_field/tests/conserved_noise/integral.i
+++ b/modules/phase_field/tests/conserved_noise/integral.i
@@ -70,10 +70,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 2.0'
     block = 0
-    mob = 1.0
-    kappa = 2.0
   [../]
 []
 

--- a/modules/phase_field/tests/conserved_noise/normal.i
+++ b/modules/phase_field/tests/conserved_noise/normal.i
@@ -70,10 +70,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 2.0'
     block = 0
-    mob = 1.0
-    kappa = 2.0
   [../]
 []
 

--- a/modules/phase_field/tests/conserved_noise/uniform.i
+++ b/modules/phase_field/tests/conserved_noise/uniform.i
@@ -70,10 +70,10 @@
 
 [Materials]
   [./constant]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1.0 2.0'
     block = 0
-    mob = 1.0
-    kappa = 2.0
   [../]
 []
 

--- a/modules/phase_field/tests/rigidbodymotion/grain_advection_constforce.i
+++ b/modules/phase_field/tests/rigidbodymotion/grain_advection_constforce.i
@@ -56,10 +56,10 @@
 
 [Materials]
   [./pfmobility]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1e-3 0.1'
     block = 0
-    kappa = 0.1
-    mob = 1e-3
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial

--- a/modules/phase_field/tests/rigidbodymotion/grain_center.i
+++ b/modules/phase_field/tests/rigidbodymotion/grain_center.i
@@ -56,10 +56,10 @@
 
 [Materials]
   [./pfmobility]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1e-3 0.1'
     block = 0
-    kappa = 0.1
-    mob = 1e-3
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial

--- a/modules/phase_field/tests/rigidbodymotion/grain_constforce.i
+++ b/modules/phase_field/tests/rigidbodymotion/grain_constforce.i
@@ -56,10 +56,10 @@
 
 [Materials]
   [./pfmobility]
-    type = PFMobility
+    type = GenericConstantMaterial
+    prop_names  = 'M kappa_c'
+    prop_values = '1e-3 0.1'
     block = 0
-    kappa = 0.1
-    mob = 1e-3
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial


### PR DESCRIPTION
We do not need the `grad_M` material property anymore as we build it on the fly using derivative material properties. That means `GenericConstantMaterial` can do the same job.

Closes #5597
