### PR TITLE
Disable GDB backtraces in Test Harness

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -71,7 +71,7 @@ ifneq (,$(findstring +,$(libmesh_status)))
   endif
 endif
 libmesh_submodule_status:
-	@if [ x$(libmesh_message) != "x" ]; then echo $(libmesh_message); fi
+	@if [ x$(libmesh_message) != "x" ]; then echo -e $(libmesh_message); fi
 
 moose: $(moose_LIB)
 

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -92,6 +92,10 @@ class RunApp(Tester):
     if options.scaling and specs['scale_refine'] > 0:
       specs['cli_args'].insert(0, ' -r ' + str(specs['scale_refine']))
 
+    # The test harness should never use GDB backtraces: they don't
+    # work well when dozens of expect_err jobs run at the same time.
+    specs['cli_args'].append('--no-gdb-backtrace')
+
     # Raise the floor
     ncpus = max(default_ncpus, int(specs['min_parallel']))
     # Lower the ceiling


### PR DESCRIPTION
This can be merged now, but won't actually do anything until libmesh/libmesh@c1687ff is merged in libmesh and a libmesh update in MOOSE is performed.

Refs #4201.
