### PR TITLE
Validate supplied coupled variables when using material property derivatives

### DIFF
--- a/modules/phase_field/include/kernels/ACBulk.h
+++ b/modules/phase_field/include/kernels/ACBulk.h
@@ -21,6 +21,8 @@ class ACBulk : public DerivativeMaterialInterface<JvarMapInterface<KernelValue> 
 public:
   ACBulk(const InputParameters & parameters);
 
+  virtual void initialSetup();
+
 protected:
 
   /// Enum used with computeDFDOP function

--- a/modules/phase_field/include/kernels/ACInterface.h
+++ b/modules/phase_field/include/kernels/ACInterface.h
@@ -21,6 +21,8 @@ class ACInterface : public DerivativeMaterialInterface<JvarMapInterface<KernelGr
 public:
   ACInterface(const InputParameters & parameters);
 
+  virtual void initialSetup();
+
 protected:
 
   /// Enum of computeDFDOP inputs

--- a/modules/phase_field/include/kernels/ACParsed.h
+++ b/modules/phase_field/include/kernels/ACParsed.h
@@ -25,6 +25,8 @@ class ACParsed : public ACBulk
 public:
   ACParsed(const InputParameters & parameters);
 
+  virtual void initialSetup();
+
 protected:
   virtual Real computeDFDOP(PFFunctionType type);
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);

--- a/modules/phase_field/include/kernels/CahnHilliardBase.h
+++ b/modules/phase_field/include/kernels/CahnHilliardBase.h
@@ -21,6 +21,7 @@ public:
   CahnHilliardBase(const InputParameters & parameters);
 
   static InputParameters validParams();
+  virtual void initialSetup();
 
 protected:
   typedef typename CHBulk<T>::PFFunctionType PFFunctionType;
@@ -75,6 +76,18 @@ CahnHilliardBase<T>::CahnHilliardBase(const InputParameters & parameters) :
 
     _grad_vars[i+1] = &(this->_coupled_moose_vars[i]->gradSln());
   }
+}
+
+template<typename T>
+void
+CahnHilliardBase<T>:: initialSetup()
+{
+  /**
+   * Check if both the non-linear as well as the auxiliary variables variables
+   * are coupled. Derivatives with respect to both types of variables contribute
+   * the residual.
+   */
+  this->template validateCoupling<Real>("f_name", this->_var.name());
 }
 
 template<typename T>

--- a/modules/phase_field/include/kernels/SplitCHParsed.h
+++ b/modules/phase_field/include/kernels/SplitCHParsed.h
@@ -28,6 +28,8 @@ class SplitCHParsed : public DerivativeMaterialInterface<JvarMapInterface<SplitC
 public:
   SplitCHParsed(const InputParameters & parameters);
 
+  virtual void initialSetup();
+
 protected:
   virtual Real computeDFDC(PFFunctionType type);
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);

--- a/modules/phase_field/include/materials/DerivativeMultiPhaseBase.h
+++ b/modules/phase_field/include/materials/DerivativeMultiPhaseBase.h
@@ -26,6 +26,8 @@ class DerivativeMultiPhaseBase : public DerivativeFunctionMaterialBase
 public:
   DerivativeMultiPhaseBase(const InputParameters & parameters);
 
+  virtual void initialSetup();
+
 protected:
   virtual Real computeF();
 

--- a/modules/phase_field/include/materials/DerivativeSumMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeSumMaterial.h
@@ -19,6 +19,8 @@ class DerivativeSumMaterial : public DerivativeFunctionMaterialBase
 public:
   DerivativeSumMaterial(const InputParameters & parameters);
 
+  virtual void initialSetup();
+
 protected:
   virtual void computeProperties();
 

--- a/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
@@ -26,6 +26,8 @@ class DerivativeTwoPhaseMaterial : public DerivativeFunctionMaterialBase
 public:
   DerivativeTwoPhaseMaterial(const InputParameters & parameters);
 
+  virtual void initialSetup();
+
 protected:
   virtual Real computeF();
   virtual Real computeDF(unsigned int);

--- a/modules/phase_field/src/kernels/ACBulk.C
+++ b/modules/phase_field/src/kernels/ACBulk.C
@@ -32,6 +32,12 @@ ACBulk::ACBulk(const InputParameters & parameters) :
     _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", _coupled_moose_vars[i]->name());
 }
 
+void
+ACBulk::initialSetup()
+{
+  validateNonlinearCoupling<Real>("mob_name");
+}
+
 Real
 ACBulk::precomputeQpResidual()
 {
@@ -65,4 +71,3 @@ ACBulk::computeQpOffDiagJacobian(unsigned int jvar)
   // Set off-diagonal Jacobian term from mobility derivatives
   return (*_dLdarg[cvar])[_qp] * _phi[_j][_qp] * computeDFDOP(Residual) * _test[_i][_qp];
 }
-

--- a/modules/phase_field/src/kernels/ACInterface.C
+++ b/modules/phase_field/src/kernels/ACInterface.C
@@ -34,6 +34,12 @@ ACInterface::ACInterface(const InputParameters & parameters) :
     _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", _coupled_moose_vars[i]->name());
 }
 
+void
+ACInterface::initialSetup()
+{
+  validateNonlinearCoupling<Real>("mob_name");
+}
+
 RealGradient
 ACInterface::precomputeQpResidual()
 {
@@ -59,4 +65,3 @@ ACInterface::computeQpOffDiagJacobian(unsigned int jvar)
   // Set off-diagonal jaocbian terms from mobility dependence
   return _kappa[_qp] * (*_dLdarg[cvar])[_qp] * _phi[_j][_qp] * _grad_u[_qp] * _grad_test[_i][_qp];
 }
-

--- a/modules/phase_field/src/kernels/ACParsed.C
+++ b/modules/phase_field/src/kernels/ACParsed.C
@@ -29,6 +29,13 @@ ACParsed::ACParsed(const InputParameters & parameters) :
     _d2FdEtadarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _var.name(), _coupled_moose_vars[i]->name());
 }
 
+void
+ACParsed::initialSetup()
+{
+  ACBulk::initialSetup();
+  validateNonlinearCoupling<Real>("f_name");
+}
+
 Real
 ACParsed::computeDFDOP(PFFunctionType type)
 {
@@ -55,4 +62,3 @@ ACParsed::computeQpOffDiagJacobian(unsigned int jvar)
   return ACBulk::computeQpOffDiagJacobian(jvar) +
          _L[_qp] * (*_d2FdEtadarg[cvar])[_qp] * _phi[_j][_qp] * _test[_i][_qp];
 }
-

--- a/modules/phase_field/src/kernels/SplitCHParsed.C
+++ b/modules/phase_field/src/kernels/SplitCHParsed.C
@@ -30,6 +30,17 @@ SplitCHParsed::SplitCHParsed(const InputParameters & parameters) :
     _d2Fdcdarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _var.name(), _coupled_moose_vars[i]->name());
 }
 
+void
+SplitCHParsed::initialSetup()
+{
+  /**
+   * We are only interested if the necessary non-linear variables are coupled,
+   * as those are thge ones used in constructing the Jacobian. The AuxVariables
+   * do not have Jacobian entries.
+   */
+  validateNonlinearCoupling<Real>("f_name", _var.name());
+}
+
 Real
 SplitCHParsed::computeDFDC(PFFunctionType type)
 {
@@ -58,4 +69,3 @@ SplitCHParsed::computeQpOffDiagJacobian(unsigned int jvar)
 
   return (*_d2Fdcdarg[cvar])[_qp] * _phi[_j][_qp] * _test[_i][_qp];
 }
-

--- a/modules/phase_field/src/materials/DerivativeMultiPhaseBase.C
+++ b/modules/phase_field/src/materials/DerivativeMultiPhaseBase.C
@@ -115,6 +115,13 @@ DerivativeMultiPhaseBase::DerivativeMultiPhaseBase(const InputParameters & param
   }
 }
 
+void
+DerivativeMultiPhaseBase::initialSetup()
+{
+  for (unsigned int n = 0; n < _num_fi; ++n)
+    validateCoupling<Real>(_fi_names[n]);
+}
+
 Real
 DerivativeMultiPhaseBase::computeF()
 {
@@ -123,4 +130,3 @@ DerivativeMultiPhaseBase::computeF()
     F += (*_hi[n])[_qp] * (*_prop_Fi[n])[_qp];
   return F + _W * _g[_qp];
 }
-

--- a/modules/phase_field/src/materials/DerivativeSumMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeSumMaterial.C
@@ -82,6 +82,13 @@ DerivativeSumMaterial::DerivativeSumMaterial(const InputParameters & parameters)
 }
 
 void
+DerivativeSumMaterial::initialSetup()
+{
+  for (unsigned int n = 0; n < _num_materials; ++n)
+    validateCoupling<Real>(_sum_materials[n]);
+}
+
+void
 DerivativeSumMaterial::computeProperties()
 {
   unsigned int i, j, k;
@@ -127,4 +134,3 @@ DerivativeSumMaterial::computeProperties()
     }
   }
 }
-

--- a/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
@@ -87,6 +87,13 @@ DerivativeTwoPhaseMaterial::DerivativeTwoPhaseMaterial(const InputParameters & p
   }
 }
 
+void
+DerivativeTwoPhaseMaterial::initialSetup()
+{
+  validateCoupling<Real>("fa_name");
+  validateCoupling<Real>("fb_name");
+}
+
 Real
 DerivativeTwoPhaseMaterial::computeF()
 {
@@ -148,4 +155,3 @@ DerivativeTwoPhaseMaterial::computeD3F(unsigned int i_var, unsigned int j_var, u
 
   return _h[_qp] * (*_prop_d3Fb[i][j][k])[_qp] + (1.0 - _h[_qp]) * (*_prop_d3Fa[i][j][k])[_qp];
 }
-

--- a/modules/phase_field/tests/MultiPhase/derivativetwophasematerial.i
+++ b/modules/phase_field/tests/MultiPhase/derivativetwophasematerial.i
@@ -52,6 +52,7 @@
   [./ACBulk]
     type = ACParsed
     variable = eta
+    args = c
     f_name = F
   [../]
   [./ACInterface]


### PR DESCRIPTION
This patch makes sure the users couple their Cahn-Hilliard and Allen-Cahn Kernels to the correct set of variables and to not accidentally leave out any dependencies. Doing so would drop derivatives that should contribute to the driving forces. This has been a common source of problems. This has to be a chat at initialSetup time as only then all material properties are present and can be inspected.

Refs. #5595
