### PR TITLE
Enforce input file order of MeshModifiers using depends_on.

### DIFF
--- a/test/tests/mesh_modifiers/rename_block/except.i
+++ b/test/tests/mesh_modifiers/rename_block/except.i
@@ -26,31 +26,37 @@
     type = RenameBlock
     old_block_id = '0'
     new_block_id = '2 3'
+    depends_on = sbb0
   [../]
   [./old_id_and_name]
     type = RenameBlock
     old_block_id = '0 1'
     old_block_name = 'zero one'
     new_block_id = '2 3'
+    depends_on = sbb0
   [../]
   [./no_old_id]
     type = RenameBlock
     new_block_id = '2 3'
+    depends_on = sbb0
   [../]
   [./too_many_old]
     type = RenameBlock
     old_block_id = '1 2 3'
     new_block_name = 'two three'
+    depends_on = sbb0
   [../]
   [./new_id_and_name]
     type = RenameBlock
     old_block_id = '1 2 3'
     new_block_id = '5 6 7'
     new_block_name = 'five six seven'
+    depends_on = sbb0
   [../]
   [./no_new]
     type = RenameBlock
     old_block_id = '1 2 3'
+    depends_on = sbb0
   [../]
 
 []

--- a/test/tests/mesh_modifiers/rename_block/rename1.i
+++ b/test/tests/mesh_modifiers/rename_block/rename1.i
@@ -25,41 +25,49 @@
     type = RenameBlock
     old_block_id = '0 1'
     new_block_id = '2 3'
+    depends_on = sbb0
   [../]
-  [./ename_no_effect]
+  [./rename_no_effect]
     type = RenameBlock
     old_block_id = '5 0 1'
     new_block_name = 'five zero one'
+    depends_on = re_id
   [../]
   [./rename]
     type = RenameBlock
     old_block_id = '2'
     new_block_name = 'two_was_zero'
+    depends_on = rename_no_effect
   [../]
   [./rename_block2]
     type = RenameBlock
     old_block_name = 'two_was_zero'
     new_block_name = 'simply_two'
+    depends_on = rename
   [../]
   [./rename_blockID_3]
     type = RenameBlock
     old_block_id = '3'
     new_block_name = 'three'
+    depends_on = rename_block2
   [../]
   [./three_to_4]
     type = RenameBlock
     old_block_name = 'three'
     new_block_id = 4
+    depends_on = rename_blockID_3
   [../]
   [./another_no_effect]
     type = RenameBlock
     old_block_id = 3
     new_block_name = 'there_is_no_block_id_3_now'
+    depends_on = three_to_4
   [../]
   [./should_not_do_anything]
     type = RenameBlock
     old_block_name = 'five'
     new_block_id = '4'
+    depends_on = another_no_effect
   [../]
 []
 

--- a/test/tests/mesh_modifiers/transform/rotate_and_scale.i
+++ b/test/tests/mesh_modifiers/transform/rotate_and_scale.i
@@ -13,6 +13,7 @@
     type = Transform
     transform = SCALE
     vector_value = '1e2 1e2 1e2'
+    depends_on = rotate
   [../]
 []
 


### PR DESCRIPTION
This fixes an issue with the new MeshModifier dependency resolution,
which no longer worked for this example.

Refs #5627.
