### PR TITLE
Get rid of mooseWarnings in some modules tests

### DIFF
--- a/modules/combined/tests/eigenstrain/variable.i
+++ b/modules/combined/tests/eigenstrain/variable.i
@@ -8,6 +8,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./disp_x]
     order = FIRST
@@ -21,8 +25,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 []
 

--- a/modules/combined/tests/eigenstrain/variable_finite.i
+++ b/modules/combined/tests/eigenstrain/variable_finite.i
@@ -8,6 +8,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./disp_x]
     order = FIRST
@@ -51,8 +55,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 []
 

--- a/modules/combined/tests/finite_strain_tensor_mechanics_tests/elastic_rotation_test.i
+++ b/modules/combined/tests/finite_strain_tensor_mechanics_tests/elastic_rotation_test.i
@@ -10,9 +10,10 @@
 #
 
 [Mesh]
-  # Comment
-  # Mesh
   file = rotation_test.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -99,9 +100,6 @@ active = ''
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     use_displaced_mesh = true
   [../]
 []

--- a/modules/combined/tests/finite_strain_tensor_mechanics_tests/finite_strain_elasticity_test.i
+++ b/modules/combined/tests/finite_strain_tensor_mechanics_tests/finite_strain_elasticity_test.i
@@ -22,6 +22,9 @@
   # Comment
   # Mesh
   file = patch_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -105,9 +108,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     use_displaced_mesh = true
   [../]
 []

--- a/modules/combined/tests/linear_elasticity/LinearElasticMaterial_test.i
+++ b/modules/combined/tests/linear_elasticity/LinearElasticMaterial_test.i
@@ -15,6 +15,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./diffused]
     order = FIRST
@@ -70,8 +74,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 
   [./diff]

--- a/modules/combined/tests/linear_elasticity/Tensor_test.i
+++ b/modules/combined/tests/linear_elasticity/Tensor_test.i
@@ -17,6 +17,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./diffused]
     order = FIRST
@@ -178,8 +182,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 
   [./diff]

--- a/modules/combined/tests/linear_elasticity/applied_strain_test.i
+++ b/modules/combined/tests/linear_elasticity/applied_strain_test.i
@@ -15,6 +15,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./disp_x]
     order = FIRST
@@ -44,8 +48,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 []
 

--- a/modules/combined/tests/linear_elasticity/thermal_expansion_test.i
+++ b/modules/combined/tests/linear_elasticity/thermal_expansion_test.i
@@ -18,6 +18,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./disp_x]
     order = FIRST
@@ -47,8 +51,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 []
 

--- a/modules/combined/tests/multiphase_mechanics/elasticenergymaterial.i
+++ b/modules/combined/tests/multiphase_mechanics/elasticenergymaterial.i
@@ -10,6 +10,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./disp_x]
     order = FIRST
@@ -51,8 +55,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
   [./dummy]
     type = MatDiffusion
@@ -63,12 +65,13 @@
 
 [Materials]
   [./eigenstrain]
+    # this material is deprecated
     type = SimpleEigenStrainMaterial
     block = 0
     epsilon0 = 0.05
     c = c
-    disp_y = disp_y
     disp_x = disp_x
+    disp_y = disp_y
     C_ijkl = '3 1 1 3 1 3 1 1 1 '
     fill_method = symmetric9
   [../]

--- a/modules/combined/tests/multiphase_mechanics/multiphasestress.i
+++ b/modules/combined/tests/multiphase_mechanics/multiphasestress.i
@@ -10,6 +10,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./disp_x]
     order = FIRST
@@ -58,13 +62,12 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 []
 
 [Materials]
   [./Anisotropic_A]
+    # this material is deprecated
     type = LinearElasticMaterial
     base_name = A
     block = 0
@@ -75,6 +78,7 @@
     applied_strain_vector = '0.1 0.05 0 0 0 0.01'
   [../]
   [./Anisotropic_B]
+    # this material is deprecated
     type = LinearElasticMaterial
     base_name = B
     block = 0
@@ -85,6 +89,7 @@
     applied_strain_vector = '0.1 0.05 0 0 0 0.01'
   [../]
   [./Anisotropic_C]
+    # this material is deprecated
     type = LinearElasticMaterial
     base_name = C
     block = 0
@@ -119,7 +124,7 @@
     block = 0
     phase_base = 'A  B  C'
     h          = 'h1 h2 h3'
-    outputs = exodus
+    #outputs = exodus
   [../]
 []
 

--- a/modules/combined/tests/multiphase_mechanics/simpleeigenstrain.i
+++ b/modules/combined/tests/multiphase_mechanics/simpleeigenstrain.i
@@ -10,6 +10,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./disp_x]
     order = FIRST
@@ -68,13 +72,12 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 []
 
 [Materials]
   [./eigenstrain]
+    # this material is deprecated
     type = SimpleEigenStrainMaterial
     block = 0
     epsilon0 = 0.05

--- a/modules/combined/tests/multiphase_mechanics/twophasestress.i
+++ b/modules/combined/tests/multiphase_mechanics/twophasestress.i
@@ -10,6 +10,10 @@
   elem_type = QUAD4
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
 [Variables]
   [./disp_x]
     order = FIRST
@@ -46,8 +50,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 []
 
@@ -56,6 +58,7 @@
   active = 'Anisotropic_A Anisotropic_B switching combined'
 
   [./Anisotropic_A]
+    # this material is deprecated
     type = LinearElasticMaterial
     base_name = A
     block = 0
@@ -66,6 +69,7 @@
     applied_strain_vector = '0.1 0.05 0 0 0 0.01'
   [../]
   [./Anisotropic_B]
+    # this material is deprecated
     type = LinearElasticMaterial
     base_name = B
     block = 0
@@ -86,7 +90,7 @@
     block = 0
     base_A = A
     base_B = B
-    outputs = exodus
+    #outputs = exodus
   [../]
 []
 

--- a/modules/phase_field/tests/ClosePackIC/close_pack.i
+++ b/modules/phase_field/tests/ClosePackIC/close_pack.i
@@ -55,7 +55,7 @@
   [./console]
     type = Console
     perf_log = true
-    linear_residuals = true
+    output_linear = true
   [../]
   [./out]
     type = Exodus
@@ -71,4 +71,3 @@
     type = ClosePackIC
   [../]
 []
-

--- a/modules/phase_field/tests/ClosePackIC/close_pack_3d.i
+++ b/modules/phase_field/tests/ClosePackIC/close_pack_3d.i
@@ -58,7 +58,7 @@
   [./console]
     type = Console
     perf_log = true
-    linear_residuals = true
+    output_linear = true
   [../]
   [./out]
     type = Exodus

--- a/modules/phase_field/tests/KKS_system/kks_example.i
+++ b/modules/phase_field/tests/KKS_system/kks_example.i
@@ -228,6 +228,5 @@
     type = Exodus
     refinements = 3
     output_initial = true
-    oversample = true
   [../]
 []

--- a/modules/phase_field/tests/MathFreeEnergy/SplitMathFreeEnergy_test.i
+++ b/modules/phase_field/tests/MathFreeEnergy/SplitMathFreeEnergy_test.i
@@ -42,7 +42,6 @@ active = 'SMP'
 []
 
 [Kernels]
-
   [./cres]
     type = SplitCHParsed
     variable = c
@@ -62,7 +61,6 @@ active = 'SMP'
     variable = w
     v = c
   [../]
-
 []
 
 [BCs]
@@ -82,18 +80,19 @@ active = 'SMP'
 []
 
 [Materials]
-
   [./constant]
     type = GenericConstantMaterial
     prop_names  = 'M kappa_c'
     prop_values = '1.0 2.0'
     block = 0
   [../]
+
   [./free_energy]
     type = MathFreeEnergy
     block = 0
     f_name = F
     c = c
+    derivative_order = 2
   [../]
 []
 

--- a/modules/phase_field/tests/MultiSmoothCircleIC/latticesmoothcircleIC_bounds.i
+++ b/modules/phase_field/tests/MultiSmoothCircleIC/latticesmoothcircleIC_bounds.i
@@ -24,7 +24,7 @@
      invalue = 1.0
      outvalue = 0.0001
      circles_per_side = '2 2'
-     Rnd_variation = 10.0
+     pos_variation = 10.0
      radius = 8.0
      int_width = 5.0
      radius_variation_type = uniform

--- a/modules/phase_field/tests/MultiSmoothCircleIC/latticesmoothcircleIC_normal_test.i
+++ b/modules/phase_field/tests/MultiSmoothCircleIC/latticesmoothcircleIC_normal_test.i
@@ -30,7 +30,7 @@
      invalue = 1.0
      outvalue = 0.0001
      circles_per_side = '3 3 3'
-     Rnd_variation = 10.0
+     pos_variation = 10.0
      radius = 10.0
      int_width = 12.0
      radius_variation = 2

--- a/modules/phase_field/tests/MultiSmoothCircleIC/latticesmoothcircleIC_test.i
+++ b/modules/phase_field/tests/MultiSmoothCircleIC/latticesmoothcircleIC_test.i
@@ -30,7 +30,7 @@
      invalue = 1.0
      outvalue = 0.0001
      circles_per_side = '3 3 3'
-     Rnd_variation = 0.0
+     pos_variation = 0.0
      radius = 10.0
      int_width = 12.0
      radius_variation = 0.2

--- a/modules/phase_field/tests/Parsed/CHParsed_test.i
+++ b/modules/phase_field/tests/Parsed/CHParsed_test.i
@@ -93,6 +93,5 @@
     type = Exodus
     refinements = 1
     output_initial = true
-    oversample = true
   [../]
 []

--- a/modules/solid_mechanics/tests/displacement_about_axis/disp_about_axis.i
+++ b/modules/solid_mechanics/tests/displacement_about_axis/disp_about_axis.i
@@ -62,7 +62,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/interaction_integral/interaction_integral_2d.i
+++ b/modules/solid_mechanics/tests/interaction_integral/interaction_integral_2d.i
@@ -88,7 +88,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/interaction_integral/interaction_integral_2d_rot.i
+++ b/modules/solid_mechanics/tests/interaction_integral/interaction_integral_2d_rot.i
@@ -88,7 +88,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/interaction_integral/interaction_integral_3d.i
+++ b/modules/solid_mechanics/tests/interaction_integral/interaction_integral_3d.i
@@ -93,7 +93,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/interaction_integral/interaction_integral_3d_as_2d.i
+++ b/modules/solid_mechanics/tests/interaction_integral/interaction_integral_3d_as_2d.i
@@ -95,7 +95,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/interaction_integral/interaction_integral_3d_rot.i
+++ b/modules/solid_mechanics/tests/interaction_integral/interaction_integral_3d_rot.i
@@ -93,7 +93,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/j_integral_thermal/j_integral_2d.i
+++ b/modules/solid_mechanics/tests/j_integral_thermal/j_integral_2d.i
@@ -77,7 +77,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/j_integral_thermal/j_integral_2d_ctefunc.i
+++ b/modules/solid_mechanics/tests/j_integral_thermal/j_integral_2d_ctefunc.i
@@ -85,7 +85,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/j_integral_thermal/j_integral_2d_inst_ctefunc.i
+++ b/modules/solid_mechanics/tests/j_integral_thermal/j_integral_2d_inst_ctefunc.i
@@ -95,7 +95,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/j_integral_thermal/j_integral_2d_mean_ctefunc.i
+++ b/modules/solid_mechanics/tests/j_integral_thermal/j_integral_2d_mean_ctefunc.i
@@ -95,7 +95,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm.i
+++ b/modules/solid_mechanics/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm.i
@@ -84,7 +84,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm_cm.i
+++ b/modules/solid_mechanics/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm_cm.i
@@ -86,7 +86,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/solid_mechanics/tests/torque_reaction/torque_reaction.i
+++ b/modules/solid_mechanics/tests/torque_reaction/torque_reaction.i
@@ -75,7 +75,7 @@
     tensor = stress
     variable = stress_xx
     index = 0
-    execute_on = timestep     # for efficiency, only compute at the end of a timestep
+    execute_on = timestep_end     # for efficiency, only compute at the end of a timestep
   [../]
   [./stress_yy]
     type = MaterialTensorAux

--- a/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem.i
+++ b/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem.i
@@ -19,9 +19,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = ux
-    disp_z = uz
-    disp_y = uy
+    displacements = 'ux uy uz'
     use_displaced_mesh = true
   [../]
 []

--- a/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem_multi.i
+++ b/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem_multi.i
@@ -19,9 +19,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = ux
-    disp_z = uz
-    disp_y = uy
+    displacements = 'ux uy uz'
     use_displaced_mesh = true
   [../]
 []

--- a/modules/tensor_mechanics/tests/multi/special_joint1.i
+++ b/modules/tensor_mechanics/tests/multi/special_joint1.i
@@ -299,7 +299,7 @@
   [./console]
     type = Console
     perf_log = true
-    linear_residuals = false
+    output_linear = false
   [../]
   [./csv]
     type = CSV

--- a/modules/tensor_mechanics/tests/poro/vol_expansion_action.i
+++ b/modules/tensor_mechanics/tests/poro/vol_expansion_action.i
@@ -27,9 +27,7 @@
 []
 
 [GlobalParams]
-  disp_x = disp_x
-  disp_y = disp_y
-  disp_z = disp_z
+  displacements = 'disp_x disp_y disp_z'
   block = 0
 []
 
@@ -75,6 +73,9 @@
 [Kernels]
   [./PoroMechanics]
     porepressure = p
+    disp_x = disp_x
+    disp_y = disp_y
+    disp_z = disp_z
   [../]
   [./unimportant_p]
     type = Diffusion

--- a/modules/tensor_mechanics/tests/rank_two_scalar_aux/test.i
+++ b/modules/tensor_mechanics/tests/rank_two_scalar_aux/test.i
@@ -47,9 +47,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
+    displacements = 'disp_x disp_y disp_z'
   [../]
 []
 


### PR DESCRIPTION
I cannot seem to eliminate all of them (we have warnings about negative temperature in heat_conduction, rate cutback in solid_mechanics, and file delete errors in Checkpoint outputs in combined. But this removes a ton of warnings nonetheless.

Refs #5629
