### PR TITLE
Let derived classes decide if strain needs to be stateful 

### DIFF
--- a/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZFiniteStrain.h
@@ -20,6 +20,9 @@ public:
   ComputeAxisymmetricRZFiniteStrain(const InputParameters & parameters);
 
 protected:
+  /// the old value of the first component of the displacements vector
+  VariableValue & _disp_old_0;
+
   virtual Real computeDeformGradZZ();
   virtual Real computeDeformGradZZold();
 };

--- a/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
@@ -29,7 +29,6 @@ protected:
   /// Coupled displacement variables
   unsigned int _ndisp;
   std::vector<VariableValue *> _disp;
-  std::vector<VariableValue *> _disp_old;
   std::vector<VariableGradient *> _grad_disp;
   std::vector<VariableGradient *> _grad_disp_old;
 

--- a/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
@@ -40,6 +40,8 @@ protected:
   std::string _base_name;
 
   MaterialProperty<RankTwoTensor> & _total_strain;
+
+  const bool _stateful_displacements;
 };
 
 #endif //COMPUTESTRAINBASE_H

--- a/modules/tensor_mechanics/src/auxkernels/NewmarkAccelAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/NewmarkAccelAux.C
@@ -34,6 +34,8 @@ NewmarkAccelAux::computeValue()
   Real accel_old = _u_old[_qp];
   if (_dt == 0)
     return accel_old;
+
   //Calculates acceeleration using Newmark time integration method
-  return 1/_beta*(((_disp[_qp]-_disp_old[_qp])/(_dt*_dt)) - _vel_old[_qp]/_dt - accel_old*(0.5-_beta));
+  return 1.0 / _beta * (  (_disp[_qp] - _disp_old[_qp]) / (_dt * _dt)
+                        - _vel_old[_qp] / _dt - accel_old * (0.5 - _beta));
 }

--- a/modules/tensor_mechanics/src/materials/ComputeAxisymmetricRZFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeAxisymmetricRZFiniteStrain.C
@@ -15,7 +15,8 @@ InputParameters validParams<ComputeAxisymmetricRZFiniteStrain>()
 }
 
 ComputeAxisymmetricRZFiniteStrain::ComputeAxisymmetricRZFiniteStrain(const InputParameters & parameters) :
-    Compute2DFiniteStrain(parameters)
+    Compute2DFiniteStrain(parameters),
+    _disp_old_0(coupledValueOld("displacements", 0))
 {
 }
 
@@ -36,7 +37,7 @@ Real
 ComputeAxisymmetricRZFiniteStrain::computeDeformGradZZold()
 {
   if (_q_point[_qp](0) != 0.0)
-    return (*_disp_old[0])[_qp] / _q_point[_qp](0);
+    return _disp_old_0[_qp] / _q_point[_qp](0);
 
   else
     return 0.0;

--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
@@ -11,6 +11,7 @@ InputParameters validParams<ComputeFiniteStrain>()
 {
   InputParameters params = validParams<ComputeStrainBase>();
   params.addClassDescription("Compute a strain increment and rotation increment for finite strains.");
+  params.set<bool>("stateful_displacements") = true;
   return params;
 }
 
@@ -152,4 +153,3 @@ ComputeFiniteStrain::computeQpStrain(const RankTwoTensor & Fhat)
   //Rotate strain to current configuration
   _total_strain[_qp] = _rotation_increment[_qp] * _total_strain[_qp] * _rotation_increment[_qp].transpose();
 }
-

--- a/modules/tensor_mechanics/src/materials/ComputeIncrementalSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIncrementalSmallStrain.C
@@ -11,6 +11,7 @@ InputParameters validParams<ComputeIncrementalSmallStrain>()
 {
   InputParameters params = validParams<ComputeSmallStrain>();
   params.addClassDescription("Compute a strain increment and rotation increment for small strains.");
+  params.set<bool>("stateful_displacements") = true;
   return params;
 }
 
@@ -69,4 +70,3 @@ ComputeIncrementalSmallStrain::computeProperties()
     _total_strain[_qp] = _total_strain_old[_qp] + _strain_increment[_qp];
   }
 }
-

--- a/modules/tensor_mechanics/src/materials/ComputeSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeSmallStrain.C
@@ -40,4 +40,3 @@ ComputeSmallStrain::computeProperties()
     _total_strain[_qp] -= _stress_free_strain[_qp];
   }
 }
-

--- a/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
@@ -23,7 +23,6 @@ ComputeStrainBase::ComputeStrainBase(const InputParameters & parameters) :
     DerivativeMaterialInterface<Material>(parameters),
     _ndisp(coupledComponents("displacements")),
     _disp(3),
-    _disp_old(3),
     _grad_disp(3),
     _grad_disp_old(3),
     _T(coupledValue("temperature")),
@@ -44,22 +43,15 @@ ComputeStrainBase::ComputeStrainBase(const InputParameters & parameters) :
     _grad_disp[i] = &coupledGradient("displacements", i);
 
     if (_stateful_displacements)
-    {
-      _disp_old[i] = &coupledValueOld("displacements", i);
       _grad_disp_old[i] = &coupledGradientOld("displacements" ,i);
-    }
     else
-    {
-      _disp_old[i] = &_zero;
       _grad_disp_old[i] = &_grad_zero;
-    }
   }
 
   // set unused dimensions to zero
   for (unsigned i = _ndisp; i < 3; ++i)
   {
     _disp[i] = &_zero;
-    _disp_old[i] = &_zero;
     _grad_disp[i] = &_grad_zero;
     _grad_disp_old[i] = &_grad_zero;
   }


### PR DESCRIPTION
Use a private param to let derived classes communicate to the base class if the displacements need to be stateful. Ping @tonkmr 

Closes #5642
