### PR TITLE
Prevent users from calling normals() for nodal variables

### DIFF
--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -117,7 +117,7 @@ public:
   const VariablePhiGradient & gradPhiFaceNeighbor();
   const VariablePhiSecond & secondPhiFaceNeighbor();
 
-  const MooseArray<Point> & normals() { return _normals; }
+  const MooseArray<Point> & normals();
 
   // damping
   VariableValue & increment() { return _increment; }

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -389,6 +389,14 @@ MooseVariable::secondPhiFaceNeighbor()
   return *_second_phi_face_neighbor;
 }
 
+const MooseArray<Point> &
+MooseVariable::normals()
+{
+  if (_is_nodal)
+    mooseError("Normals are not computed for nodal variables.");
+  return _normals;
+}
+
 VariableValue &
 MooseVariable::nodalValue()
 {


### PR DESCRIPTION
MooseVariable::_normals is only valid for integrated BCs. When this
function is called on a nodal variable it needs to error out.

Closes #5640
