### PR TITLE
Removing warnings in checkpoint system

### DIFF
--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -42,9 +42,6 @@ struct CheckpointFileNames
   /// Filename for EquationsSystems::write
   std::string system;
 
-  /// Filename for stateful material property file
-  std::string material;
-
   /// Filename for restartable data filename
   std::string restart;
 };

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -113,7 +113,6 @@ Checkpoint::output(const ExecFlagType & /*type*/)
     current_file_struct.system = current_file + ".xda";
   }
   current_file_struct.restart = current_file + ".rd";
-  current_file_struct.material = current_file + ".msmp";
 
   // Write the checkpoint file
   io.write(current_file_struct.checkpoint);
@@ -178,16 +177,6 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
     }
 
     unsigned int n_threads = libMesh::n_threads();
-
-    // Remove material property files
-    if (_material_property_storage.hasStatefulProperties() || _bnd_material_property_storage.hasStatefulProperties())
-    {
-      std::ostringstream oss;
-      oss << delete_files.material << '-' << proc_id;
-      ret = remove(oss.str().c_str());
-      if (ret != 0)
-        mooseWarning("Error during the deletion of file '" << oss.str().c_str() << "': " << ret);
-    }
 
     // Remove the restart files (rd)
     {

--- a/test/tests/materials/stateful_prop/tests
+++ b/test/tests/materials/stateful_prop/tests
@@ -8,7 +8,7 @@
   [./test_csv]
     type = 'CSVDiff'
     input = 'stateful_prop_test.i'
-	  cli_args = 'Outputs/csv=true'
+    cli_args = 'Outputs/csv=true'
     csvdiff = 'out.csv'
     prereq = 'test'
   [../]
@@ -38,12 +38,14 @@
     type = 'Exodiff'
     input = 'stateful_prop_spatial_test.i'
     exodiff = 'out_spatial.e'
+    cli_args = '--error'
   [../]
 
   [./spatial_bnd_only]
     type = 'Exodiff'
     input = 'stateful_prop_on_bnd_only.i'
     exodiff = 'out_bnd_only.e'
+    cli_args = '--error'
   [../]
 
   [./stateful_copy]
@@ -51,13 +53,14 @@
     input = 'stateful_prop_copy_test.i'
     exodiff = 'out_stateful_copy.e'
     max_parallel = 1
+    cli_args = '--error'
   [../]
 
   [./test_older_csv]
     type = 'CSVDiff'
     input = 'stateful_prop_test_older.i'
     csvdiff = 'out_older.csv'
-    cli_args = 'Outputs/csv=true'
+    cli_args = 'Outputs/csv=true --error'
     max_parallel = 1
     prereq = 'test_older'
   [../]
@@ -66,11 +69,13 @@
     type = 'Exodiff'
     input = 'stateful_prop_adaptivity_test.i'
     exodiff = 'stateful_prop_adaptivity_test_out.e-s003'
+    cli_args = '--error'
   [../]
 
   [./spatial_adaptivity]
     type = 'Exodiff'
     input = 'spatial_adaptivity_test.i'
     exodiff = 'spatial_adaptivity_test_out.e-s003'
+    cli_args = '--error'
   [../]
 []


### PR DESCRIPTION
closes #5653 

This removes the logic for deleting the separate material props file that was removed during the 2015 Tiger team. Since there isn't an easy way right now to enable "--error" for all tests in moose_test, the best way to test this so we don't see another regression is to manually add `--error` to select tests that will produce errors for this case.
