### PR TITLE
MultiApp Recovery

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -266,17 +266,17 @@ public:
   /**
    * Whether or not this is a "recover" calculation.
    */
-  bool isRecovering() const { return _recover; }
+  bool isRecovering() const;
 
   /**
    * Whether or not this is a "recover" calculation.
    */
-  bool isRestarting() const { return _restart; }
+  bool isRestarting() const;
 
   /**
    * Return true if the recovery file base is set
    */
-  bool hasRecoverFileBase() { return !_recover_base.empty(); }
+  bool hasRecoverFileBase();
 
   /**
    * The file_base for the recovery file.
@@ -400,10 +400,21 @@ public:
   virtual std::string header() const;
 
   /**
-   * The multiapp level
-   * @return A writable reference to the current number of levels from the master app
+   * The MultiApp Level
+   * @return The current number of levels from the master app
    */
-  unsigned int & multiappLevel() { return _multiapp_level; }
+  unsigned int multiAppLevel() const { return _multiapp_level; }
+
+  /**
+   * Set the MultiApp Level
+   * @param level The level to assign to this app.
+   */
+  void setMultiAppLevel(const unsigned int level) { _multiapp_level = level; }
+
+  /**
+   * Whether or not this app is the ultimate master app. (ie level == 0)
+   */
+  bool isUltimateMaster() { return !_multiapp_level; }
 
   /**
    * Add a Mesh modifier that will act on the meshes in the system

--- a/framework/include/transfers/MultiAppNearestNodeTransfer.h
+++ b/framework/include/transfers/MultiAppNearestNodeTransfer.h
@@ -77,17 +77,17 @@ protected:
   bool _fixed_meshes;
 
   /// Used to cache nodes
-  std::map<dof_id_type, Node *> _node_map;
+  std::map<dof_id_type, Node *> & _node_map;
 
   /// Used to cache distances
-  std::map<dof_id_type, Real> _distance_map;
+  std::map<dof_id_type, Real> & _distance_map;
 
   // These variables allow us to cache nearest node info
-  bool _neighbors_cached;
-  std::vector< std::vector<unsigned int> > _cached_froms;
-  std::vector< std::vector<dof_id_type> > _cached_dof_ids;
-  std::map<unsigned int, unsigned int> _cached_from_inds;
-  std::map<unsigned int, unsigned int> _cached_qp_inds;
+  bool & _neighbors_cached;
+  std::vector< std::vector<unsigned int> > & _cached_froms;
+  std::vector< std::vector<dof_id_type> > & _cached_dof_ids;
+  std::map<unsigned int, unsigned int> & _cached_from_inds;
+  std::map<unsigned int, unsigned int> & _cached_qp_inds;
 };
 
 #endif /* MULTIAPPNEARESTNODETRANSFER_H */

--- a/framework/src/actions/SetupRecoverFileBaseAction.C
+++ b/framework/src/actions/SetupRecoverFileBaseAction.C
@@ -43,7 +43,8 @@ void
 SetupRecoverFileBaseAction::act()
 {
   // Do nothing if the App is not recovering
-  if (!_app.isRecovering())
+  // Don't look for a checkpoint file unless we're the ultimate master app
+  if (!_app.isRecovering() || !_app.isUltimateMaster())
     return;
 
   // Build the list of all possible checkpoint files for recover
@@ -179,4 +180,3 @@ SetupRecoverFileBaseAction::getCheckpointFiles(std::set<std::string> & files)
     tinydir_close(&dir);
   }
 }
-

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -173,7 +173,7 @@ MooseApp::setupOptions()
 {
   // Print the header, this is as early as possible
   std::string hdr = header();
-  if (multiappLevel() > 0)
+  if (multiAppLevel() > 0)
     MooseUtils::indentMessage(_name, hdr);
   Moose::out << hdr << std::endl;
 
@@ -425,6 +425,26 @@ MooseApp::executeExecutioner()
   }
   else
     mooseError("No executioner was specified (go fix your input file)");
+}
+
+bool
+MooseApp::isRecovering() const
+{
+  // We never "recover" a sub-app... they just get their state "pushed" to them from  above
+  return _recover;
+}
+
+bool
+MooseApp::isRestarting() const
+{
+  // We never "restart" a sub-app... they just get their state "pushed" to them from  above
+  return _restart;
+}
+
+bool
+MooseApp::hasRecoverFileBase()
+{
+  return !_recover_base.empty();
 }
 
 void

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -282,6 +282,13 @@ Transient::incrementStepOrReject()
     _t_step++;
 
     _problem.advanceState();
+
+    // Advance (and Output) MultiApps if we were doing Picard iterations
+    if (_picard_max_its > 1)
+    {
+      _problem.advanceMultiApps(EXEC_TIMESTEP_BEGIN);
+      _problem.advanceMultiApps(EXEC_TIMESTEP_END);
+    }
   }
   else
   {
@@ -459,13 +466,6 @@ Transient::endStep(Real input_time)
 
     // Perform the output of the current time step
     _problem.outputStep(EXEC_TIMESTEP_END);
-
-    // Output MultiApps if we were doing Picard iterations
-    if (_picard_max_its > 1)
-    {
-      _problem.advanceMultiApps(EXEC_TIMESTEP_BEGIN);
-      _problem.advanceMultiApps(EXEC_TIMESTEP_END);
-    }
 
     //output
     if (_time_interval && (_time + _timestep_tolerance >= _next_interval_output_time))
@@ -747,4 +747,3 @@ Transient::getTimeStepperName()
   else
     return std::string();
 }
-

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1743,10 +1743,11 @@ MooseMesh::getNormalByBoundaryID(BoundaryID id) const
 void
 MooseMesh::init()
 {
-  if (!_app.isRecovering() || !_allow_recovery)
-    buildMesh();
-  else // When recovering just read the CPR file
+  if (_app.isRecovering() && _allow_recovery && _app.isUltimateMaster())
+    // For now, only read the recovery mesh on the Ultimate Master.. sub-apps need to just build their mesh like normal
     getMesh().read(_app.getRecoverFileBase() + "_mesh.cpr");
+  else // Normally just build the mesh
+    buildMesh();
 }
 
 unsigned int

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -247,6 +247,8 @@ MultiApp::backup()
 void
 MultiApp::restore()
 {
+  std::cout<<"Restoring apps in "<<name()<<std::endl;
+
   for (unsigned int i=0; i<_my_num_apps; i++)
     _apps[i]->restore(_backups[i]);
 }
@@ -411,7 +413,7 @@ MultiApp::createApp(unsigned int i, Real start_time)
            << std::setprecision(0) << std::setfill('0') << std::right << _first_local_app + i;
 
   // Only add parent name if it the parent is not the main app
-  if (_app.multiappLevel() > 0)
+  if (_app.multiAppLevel() > 0)
     full_name = _app.name() + "_" + multiapp_name.str();
   else
     full_name = multiapp_name.str();
@@ -452,7 +454,7 @@ MultiApp::createApp(unsigned int i, Real start_time)
     app->setOutputPosition(_app.getOutputPosition() + _positions[_first_local_app + i]);
 
   // Update the MultiApp level for the app that was just created
-  app->multiappLevel() = _app.multiappLevel() + 1;
+  app->setMultiAppLevel(_app.multiAppLevel() + 1);
   app->setupOptions();
   app->runInputFile();
 }

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -247,8 +247,6 @@ MultiApp::backup()
 void
 MultiApp::restore()
 {
-  std::cout<<"Restoring apps in "<<name()<<std::endl;
-
   for (unsigned int i=0; i<_my_num_apps; i++)
     _apps[i]->restore(_backups[i]);
 }

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -238,7 +238,7 @@ Console::initialSetup()
     _verbose = true;
 
   // Display a message to indicate the application is running (useful for MultiApps)
-  if (_problem_ptr->hasMultiApps() || _app.multiappLevel() > 0)
+  if (_problem_ptr->hasMultiApps() || _app.multiAppLevel() > 0)
     write(std::string("\nRunning App: ") + _app.name() + "\n");
 
   // Output the performance log early
@@ -562,7 +562,7 @@ Console::write(std::string message, bool indent /*=true*/)
     _file_output_stream << message;
 
   // Apply MultiApp indenting
-  if (indent && _app.multiappLevel() > 0)
+  if (indent && _app.multiAppLevel() > 0)
     MooseUtils::indentMessage(_app.name(), message);
 
   // Write message to the screen

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -45,7 +45,13 @@ MultiAppNearestNodeTransfer::MultiAppNearestNodeTransfer(const InputParameters &
     _to_var_name(getParam<AuxVariableName>("variable")),
     _from_var_name(getParam<VariableName>("source_variable")),
     _fixed_meshes(getParam<bool>("fixed_meshes")),
-    _neighbors_cached(false)
+    _node_map(declareRestartableData<std::map<dof_id_type, Node *> >("node_map")),
+    _distance_map(declareRestartableData<std::map<dof_id_type, Real> >("distance_map")),
+    _neighbors_cached(declareRestartableData<bool>("neighbors_cached", false)),
+    _cached_froms(declareRestartableData<std::vector< std::vector<unsigned int> > >("cached_froms")),
+    _cached_dof_ids(declareRestartableData<std::vector< std::vector<dof_id_type> > >("cached_dof_ids")),
+    _cached_from_inds(declareRestartableData<std::map<unsigned int, unsigned int> >("cached_from_ids")),
+    _cached_qp_inds(declareRestartableData<std::map<unsigned int, unsigned int> >("cached_qp_inds"))
 {
   // This transfer does not work with ParallelMesh
   _displaced_source_mesh = getParam<bool>("displaced_source_mesh");

--- a/test/tests/multiapps/picard_multilevel/tests
+++ b/test/tests/multiapps/picard_multilevel/tests
@@ -3,6 +3,5 @@
     type = 'Exodiff'
     input = 'picard_master.i'
     exodiff = 'picard_master_out.e picard_master_out_sub10.e picard_master_out_sub10_sub20.e'
-    recover = false # Refs #5353
   [../]
 []

--- a/test/tests/multiapps/picard_sub_cycling/tests
+++ b/test/tests/multiapps/picard_sub_cycling/tests
@@ -3,6 +3,5 @@
     type = 'Exodiff'
     input = 'picard_master.i'
     exodiff = 'picard_master_out.e'
-    recover = false # Refs #5353
   [../]
 []

--- a/test/tests/multiapps/transient_multiapp/dt_from_master.i
+++ b/test/tests/multiapps/transient_multiapp/dt_from_master.i
@@ -50,7 +50,6 @@
 
 [Outputs]
   exodus = true
-  checkpoint = true
 []
 
 [MultiApps]

--- a/test/tests/multiapps/transient_multiapp/dt_from_master_sub.i
+++ b/test/tests/multiapps/transient_multiapp/dt_from_master_sub.i
@@ -50,5 +50,4 @@
 
 [Outputs]
   exodus = true
-  checkpoint = true
 []

--- a/test/tests/transfers/multiapp_interpolation_transfer/tests
+++ b/test/tests/transfers/multiapp_interpolation_transfer/tests
@@ -3,13 +3,11 @@
     type = 'Exodiff'
     input = 'tosub_master.i'
     exodiff = 'tosub_master_out_sub0.e'
-    recover = false
   [../]
 
   [./fromsub]
     type = 'Exodiff'
     input = 'fromsub_master.i'
     exodiff = 'fromsub_master_out.e'
-    recover = false
   [../]
 []

--- a/test/tests/transfers/multiapp_nearest_node_transfer/tests
+++ b/test/tests/transfers/multiapp_nearest_node_transfer/tests
@@ -3,21 +3,18 @@
     type = 'Exodiff'
     input = 'tosub_master.i'
     exodiff = 'tosub_master_out_sub0.e'
-    recover = false
   [../]
 
   [./fromsub]
     type = 'Exodiff'
     input = 'fromsub_master.i'
     exodiff = 'fromsub_master_out.e'
-    recover = false
   [../]
 
   [./fromsub_displaced]
     type = 'Exodiff'
     input = 'fromsub_displaced_master.i'
     exodiff = 'fromsub_displaced_master_out.e'
-    recover = false
   [../]
 
   [./tosub_displaced]
@@ -25,21 +22,18 @@
     input = 'tosub_displaced_master.i'
     exodiff = 'tosub_displaced_master_out_sub0.e'
     deleted = 'Not yet implemented properly!'
-    recover = false
   [../]
 
   [./fromsub_fixed_meshes]
     type = 'Exodiff'
     input = 'fromsub_fixed_meshes_master.i'
     exodiff = 'fromsub_fixed_meshes_master_out.e'
-    recover = false
   [../]
 
   [./boundary_tosub]
     type = 'Exodiff'
     input = 'boundary_tosub_master.i'
     exodiff = 'boundary_tosub_master_out_sub0.e'
-    recover = false
   [../]
 
   [./two_way_many_apps]

--- a/test/tests/transfers/multiapp_postprocessor_interpolation_transfer/tests
+++ b/test/tests/transfers/multiapp_postprocessor_interpolation_transfer/tests
@@ -3,7 +3,6 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out.e'
-    recover = false
   [../]
 
   [./test_error]
@@ -18,25 +17,21 @@
     type = 'Exodiff'
     input = 'radial_master.i'
     exodiff = 'radial_master_out.e'
-    recover = false
   [../]
 
   [./multilevel]
     type = 'Exodiff'
     input = 'multilevel_master.i'
     exodiff = 'multilevel_master_out.e multilevel_master_out_sub0.e multilevel_master_out_sub0_sub0.e multilevel_master_out_sub0_sub1.e multilevel_master_out_sub1.e multilevel_master_out_sub1_sub0.e multilevel_master_out_sub1_sub1.e'
-    recover = false
   [../]
   [./pp_to_master]
     type = 'Exodiff'
     input = 'master_quad.i'
     exodiff = 'master_quad_out.e'
-    recover = false
   [../]
   [./pp_to_master_single_sub_file]
     type = 'Exodiff'
     input = 'master2_quad.i'
     exodiff = 'master2_quad_out.e'
-    recover = false
   [../]
 []

--- a/test/tests/transfers/multiapp_postprocessor_to_scalar/tests
+++ b/test/tests/transfers/multiapp_postprocessor_to_scalar/tests
@@ -3,7 +3,6 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out_pp_sub0.e master_out_pp_sub1.e'
-    recover = false
     max_threads = 1  # Diffs with threads
   [../]
 
@@ -11,7 +10,6 @@
     type = 'Exodiff'
     input = 'master2.i'
     exodiff = 'master2_out.e'
-    recover = false
     max_threads = 1  # Diffs with threads
   [../]
 

--- a/test/tests/transfers/multiapp_postprocessor_transfer/tests
+++ b/test/tests/transfers/multiapp_postprocessor_transfer/tests
@@ -3,19 +3,16 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out_pp_sub0.e master_out_pp_sub1.e master_out.e'
-    recover = false
   [../]
   [./test_from_multiapp]
     type = 'Exodiff'
     input = 'master_from_multiapp.i'
     exodiff = 'master_from_multiapp_out_sub0.e master_from_multiapp_out_sub1.e master_from_multiapp_out.e'
-    recover = false
   [../]
   [./from_one_sub]
     # We need this test to make sure everything is working when n_procs > n_apps
     type = 'Exodiff'
     input = 'from_one_sub_master.i'
     exodiff = 'from_one_sub_master_out.e from_one_sub_master_out_sub0.e'
-    recover = false
   [../]
 []

--- a/test/tests/transfers/multiapp_userobject_transfer/tests
+++ b/test/tests/transfers/multiapp_userobject_transfer/tests
@@ -3,20 +3,17 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out.e master_out_sub_app0.e master_out_sub_app1.e'
-    recover = false
   [../]
 
   [./tosub]
     type = 'Exodiff'
     input = 'tosub_master.i'
     exodiff = 'tosub_master_out.e tosub_master_out_sub_app0.e tosub_master_out_sub_app1.e'
-    recover = false
   [../]
 
   [./tosub_displaced]
     type = 'Exodiff'
     input = 'tosub_displaced_master.i'
     exodiff = 'tosub_displaced_master_out.e tosub_displaced_master_out_sub_app0.e'
-    recover = false
   [../]
 []

--- a/test/tests/transfers/multiapp_variable_value_sample_transfer/tests
+++ b/test/tests/transfers/multiapp_variable_value_sample_transfer/tests
@@ -3,20 +3,17 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out_sub0.e master_out_sub1.e'
-    recover = false
   [../]
 
   [./pp_test]
     type = 'Exodiff'
     input = 'pp_master.i'
     exodiff = 'pp_master_out_pp_sub0.e pp_master_out_pp_sub1.e'
-    recover = false
   [../]
 
   [./monomial_to_sub_pp]
     type = 'Exodiff'
     input = 'master_quad.i'
     exodiff = 'master_quad_out.e master_quad_out_quad0.e master_quad_out_quad1.e master_quad_out_quad2.e master_quad_out_quad3.e'
-    recover = false
   [../]
 []

--- a/test/tests/transfers/transfer_interpolation/tests
+++ b/test/tests/transfers/transfer_interpolation/tests
@@ -5,6 +5,5 @@
     exodiff = 'master_out_sub0.e'
     use_old_floor = True
     rel_err = 3.8e-05
-    recover = false
   [../]
 []


### PR DESCRIPTION
This implements MultiApp recovery by just using all the data in the (ultimate) master app's checkpoint file.

The "Ultimate" part of "Ultimate Master" means that it is the _original_ master app.. i.e. the app that goes with the original input file.  In code this means that it's `multiapp_level` is `0`

Basically - only the input file that you actually pass as `-i` needs to output a checkpoint file... and the data for all sub-apps (and even their sub-apps, and turtles all the way down) are contained in that one checkpoint file.

When `--recover` is used or a `restart_file_base` is set the ultimate master is recovered/restarted like usual... and then the sub-app data is unpacked and pushed down through the MultiApp levels.

This is all working to the point where I was able to re-enable recovery testing for lots of multiapp tests and for lots of transfer tests.

There are a few things that aren't currently possible:
1.  Adaptive mesh in the sub-apps.  Currently, the mesh is NOT saved in the checkpoint file... so there is no way to "push" that down to the sub-apps.  I'll find a way around this eventually.  For now, I've capture this here: #5690
2.  Similarly, this doesn't support many of the things "restart" does in MOOSE.  In particular, you can't adapt or uniformly refine a sub-app mesh on restart.  I've captured that here: #5691
3.  Continuing with that trend, I haven't tried it yet, but I suspect that adding a variable (NL or Aux) to a sub-app during restart is NOT going to work.  This has to do with the rigid way that solution vector data is stored in Checkpoint files.  To fix this, we would need to store something a bit more flexible (something closer to the XDA/R files).  Captured that one here: #5692

I'm sure there is more that we'll find as we actually try to use this capability.

Oh yeah... this is all for #4941
