### PR TITLE
Change assert to error in DebugResidualAux

### DIFF
--- a/framework/src/auxkernels/DebugResidualAux.C
+++ b/framework/src/auxkernels/DebugResidualAux.C
@@ -28,7 +28,8 @@ DebugResidualAux::DebugResidualAux(const InputParameters & parameters) :
     _debug_var(_nl_sys.getVariable(_tid, getParam<NonlinearVariableName>("debug_variable"))),
     _residual_copy(_nl_sys.residualGhosted())
 {
-  mooseAssert(_nodal == true, "Cannot use DebugResidualAux on elemental variables");
+  if (!_nodal)
+    mooseError("Cannot use DebugResidualAux on elemental variables");
 }
 
 DebugResidualAux::~DebugResidualAux()
@@ -41,4 +42,3 @@ DebugResidualAux::computeValue()
   dof_id_type dof = _current_node->dof_number(_nl_sys.number(), _debug_var.number(), 0);
   return _residual_copy(dof);
 }
-


### PR DESCRIPTION
@jbair34, Here's the problem you encountered in #5687. The issue was that an elemental variable was used to report a nodal quantity. It shouldn't have ever worked in serial or parallel but the code was only set to trip an assertion instead of throw an error. Here's a PR that fixes that so that future users don't get stuck on this.
