### PR TITLE
Refactoring Zeros

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -224,6 +224,11 @@ public:
   unsigned int getMaxQps() const;
 
   /**
+   * @return The maximum number of quadrature points in use on any element in this problem.
+   */
+  unsigned int getMaxShapeFunctions() const;
+
+  /**
    * @return The maximum order for all scalar variables in this problem's systems.
    */
   Order getMaxScalarOrder() const;
@@ -1027,6 +1032,9 @@ protected:
 
   /// Maximum number of quadrature points used in the problem
   unsigned int _max_qps;
+
+  /// Maximum number of shape functions on any element in the problem
+  unsigned int _max_shape_funcs;
 
   /// Maximum scalar variable order
   Order _max_scalar_order;

--- a/framework/include/base/MaxQpsThread.h
+++ b/framework/include/base/MaxQpsThread.h
@@ -26,7 +26,9 @@
 class FEProblem;
 
 /**
- * Grab all the local dof indices for the variables passed in, in the system passed in.
+ * This class determines the maximum number of Quadrature Points and Shape Functions
+ * used for a given simulation based on the variable discretizations, and quadrature
+ * rules used for all variables in the system.
  */
 class MaxQpsThread
 {
@@ -40,7 +42,9 @@ public:
 
   void join(const MaxQpsThread & y);
 
-  unsigned int max() { return _max; }
+  unsigned int max() const { return _max; }
+
+  unsigned int max_shape_funcs() const { return _max_shape_funcs; }
 
 protected:
   FEProblem & _fe_problem;
@@ -53,6 +57,9 @@ protected:
 
   /// Maximum number of qps encountered
   unsigned int _max;
+
+  /// Maximum number of shape functions encountered
+  unsigned int _max_shape_funcs;
 };
 
 #endif //MAXQPSTHREAD_H

--- a/framework/src/ics/InitialCondition.C
+++ b/framework/src/ics/InitialCondition.C
@@ -161,8 +161,6 @@ InitialCondition::compute()
   // hold those fixed and project faces, then
   // hold those fixed and project interiors
 
-  _fe_problem.sizeZeroes(n_nodes, _tid);
-
   // Interpolate node values first
   unsigned int current_dof = 0;
   for (unsigned int n = 0; n != n_nodes; ++n)
@@ -319,7 +317,6 @@ InitialCondition::compute()
       fe->attach_quadrature_rule (qedgerule.get());
       fe->edge_reinit (_current_elem, e);
       const unsigned int n_qp = qedgerule->n_points();
-      _fe_problem.sizeZeroes(n_qp, _tid);
 
       // Loop over the quadrature points
       for (unsigned int qp = 0; qp < n_qp; qp++)
@@ -400,7 +397,6 @@ InitialCondition::compute()
       fe->attach_quadrature_rule (qsiderule.get());
       fe->reinit (_current_elem, s);
       const unsigned int n_qp = qsiderule->n_points();
-      _fe_problem.sizeZeroes(n_qp, _tid);
 
       // Loop over the quadrature points
       for (unsigned int qp = 0; qp < n_qp; qp++)
@@ -476,7 +472,6 @@ InitialCondition::compute()
     fe->attach_quadrature_rule (qrule.get());
     fe->reinit (_current_elem);
     const unsigned int n_qp = qrule->n_points();
-    _fe_problem.sizeZeroes(n_qp, _tid);
 
     // Loop over the quadrature points
     for (unsigned int qp=0; qp<n_qp; qp++)
@@ -562,4 +557,3 @@ InitialCondition::compute()
       }
   }
 }
-

--- a/modules/richards/src/kernels/RichardsFlux.C
+++ b/modules/richards/src/kernels/RichardsFlux.C
@@ -104,4 +104,3 @@ RichardsFlux::computeQpOffDiagJacobian(unsigned int jvar)
   unsigned int dvar = _richards_name_UO.richards_var_num(jvar);
   return computeQpJac(dvar);
 }
-

--- a/modules/richards/src/kernels/RichardsFlux.C
+++ b/modules/richards/src/kernels/RichardsFlux.C
@@ -83,7 +83,7 @@ RichardsFlux::computeQpJac(unsigned int wrt_num)
     supg_kernel_prime = -(_d2flux_dvdv[_qp][_pvar][_pvar][wrt_num]*_phi[_j][_qp]*_grad_u[_qp] + _phi[_j][_qp]*(_d2flux_dgradvdv[_qp][_pvar][_pvar][wrt_num]*_second_u[_qp]).tr() + (_d2flux_dvdgradv[_qp][_pvar][_pvar][wrt_num]*_grad_u[_qp])*_grad_phi[_j][_qp]);
     if (wrt_num == _pvar)
       supg_kernel_prime -= _dflux_dv[_qp][_pvar][_pvar]*_grad_phi[_j][_qp];
-    //supg_kernel_prime -= (_dflux_dgradv[_qp][_pvar][_pvar]*_second_phi[_j][_qp]).tr(); // crashes because _second_phi_zero is not done correctly
+    supg_kernel_prime -= (_dflux_dgradv[_qp][_pvar][_pvar]*_second_phi[_j][_qp]).tr();
   }
 
   return flux_prime + supg_test_prime*supg_kernel + supg_test*supg_kernel_prime;


### PR DESCRIPTION
This commit moves the zeros from SubProblem to FEProblem. The reason I am doing this
is so that we can change when and how we resize them based on information that is not
available at construction time. To resize any of the shape function based zeros, we
need to know the max number of DOFs for any element in the problem which is calculated
later. I plan to refactor the resizing code in a subsequent PR after I'm sure that
nobody else is abusing the public exposure of these zeros.

refs #5700
