### PR TITLE
Temporarily disabling test - see #5741

### DIFF
--- a/python/TestHarness/testers/ICEUpdaterTester.py
+++ b/python/TestHarness/testers/ICEUpdaterTester.py
@@ -25,23 +25,12 @@ class ICEUpdaterTester(RunApp):
        self.nPosts = self.getParam('nPosts')
        self.port = int(self.getParam('port'))
 
-    self.httpServer = SimpleHttpServer("localhost", self.port)
-    self.httpServer.start()
-
   # This method is called prior to running the test.  It can be used to cleanup files
   # or do other preparations before the tester is run
   def prepare(self):
+    self.httpServer = SimpleHttpServer("localhost", self.port)
+    self.httpServer.start()
     return
-
-  # This method is called to return the commands (list) used for processing results
-  def processResultsCommand(self, moose_dir, options):
-    commands = []
-    return commands
-
-  # This method should return the executable command that will be executed by the tester
-  def getCommand(self, options):
-    command = RunApp.getCommand(self, options)
-    return command
 
   # This method will be called to process the results of running the test.  Any post-test
   # processing should happen in this method

--- a/test/tests/outputs/iceupdater/tests
+++ b/test/tests/outputs/iceupdater/tests
@@ -12,5 +12,7 @@
     # both TBB and curl enabled.
     curl = true
     tbb = true
+
+    deleted = '#5741'
   [../]
 []


### PR DESCRIPTION
@amccaskey - We may have to disable this test for now until the bugs in #5741 are addressed. Here are a few commands you can use to test in parallel and with threads

```
# Run with two processes
./run_tests --re=iceupdater -v -p 2

# Run with two threads
./run_tests --re=iceupdater -v --n-threads=2
```

Note that if we merge this PR that disables the test, you'll need to remove the `deleted` tag in the `tests` specification before the commands above will actually run your test.
