### PR TITLE
Fix warnings from Apple Clang 7.0.0.

### DIFF
--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -738,8 +738,11 @@ Transient::setupTimeIntegrator()
 std::string
 Transient::getTimeStepperName()
 {
-  if (_time_stepper.get())
-    return demangle(typeid(*_time_stepper).name());
+  if (_time_stepper)
+  {
+    TimeStepper & ts = *_time_stepper;
+    return demangle(typeid(ts).name());
+  }
   else
     return std::string();
 }

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -165,7 +165,13 @@ DOFMapOutput::output(const ExecFlagType & /*type*/)
         {
           const std::vector<KernelBase *> & active_kernels = kernels.activeVar(var);
           for (unsigned i = 0; i<active_kernels.size(); ++i)
-            oss << (i>0 ? ", " : "") << "{\"name\": \""<< active_kernels[i]->name() << "\", \"type\": \"" << demangle(typeid(*active_kernels[i]).name()) << "\"}";
+          {
+            KernelBase & kb = *active_kernels[i];
+            oss << (i>0 ? ", " : "")
+                << "{\"name\": \"" << kb.name()
+                << "\", \"type\": \"" << demangle(typeid(kb).name())
+                << "\"}";
+          }
         }
         oss << "], \"dofs\": [";
 


### PR DESCRIPTION
Users/moose/projects/moose/framework/src/executioners/Transient.C:742:28:
warning: expression with side effects will be evaluated despite being
used as an operand to 'typeid' [-Wpotentially-evaluated-expression]
    return demangle(typeid(*_time_stepper).name());
                           ^
1 warning generated.

Refs #1777.
