### PR TITLE
Libmesh update

### DIFF
--- a/framework/include/transfers/DTKInterpolationAdapter.h
+++ b/framework/include/transfers/DTKInterpolationAdapter.h
@@ -18,7 +18,7 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "libmesh/dtk_evaluator.h"
 
@@ -97,6 +97,6 @@ protected:
   std::map<std::string, RCP_Evaluator> evaluators;
 };
 
-#endif // #ifdef LIBMESH_HAVE_DTK
+#endif // #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #endif // #define DTKINTERPOLATIONADAPTER_H

--- a/framework/include/transfers/DTKInterpolationEvaluator.h
+++ b/framework/include/transfers/DTKInterpolationEvaluator.h
@@ -17,7 +17,7 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "libmesh/equation_systems.h"
 #include "libmesh/mesh.h"
@@ -60,6 +60,6 @@ protected:
 
 } // namespace libMesh
 
-#endif // #ifdef LIBMESH_HAVE_DTK
+#endif // #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #endif // #define DTKINTERPOLATIONEVALUATOR_H

--- a/framework/include/transfers/DTKInterpolationHelper.h
+++ b/framework/include/transfers/DTKInterpolationHelper.h
@@ -16,7 +16,7 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "libmesh/solution_transfer.h"
 #include "DTKInterpolationAdapter.h"
@@ -63,6 +63,6 @@ protected:
 
 } // namespace libMesh
 
-#endif // #ifdef LIBMESH_HAVE_DTK
+#endif // #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #endif // #define DTKINTERPOLATIONHELPER_H

--- a/framework/include/transfers/MultiAppDTKInterpolationTransfer.h
+++ b/framework/include/transfers/MultiAppDTKInterpolationTransfer.h
@@ -12,7 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #ifndef MULTIAPPDTKINTERPOLATIONTRANSFER_H
 #define MULTIAPPDTKINTERPOLATIONTRANSFER_H
@@ -49,4 +49,4 @@ protected:
 
 #endif /* MULTIAPPDTKINTERPOLATIONTRANSFER_H */
 
-#endif //LIBMESH_HAVE_DTK
+#endif //LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/include/transfers/MultiAppDTKUserObjectEvaluator.h
+++ b/framework/include/transfers/MultiAppDTKUserObjectEvaluator.h
@@ -11,7 +11,7 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #ifndef MULTIAPPDTKUSEROBJECTEVALUATOR_H
 #define MULTIAPPDTKUSEROBJECTEVALUATOR_H
@@ -51,4 +51,4 @@ private:
 
 #endif //MULTIAPPDTKUSEROBJECTEVALUATOR_H
 
-#endif //LIBMESH_HAVE_DTK
+#endif //LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/include/transfers/MultiAppDTKUserObjectTransfer.h
+++ b/framework/include/transfers/MultiAppDTKUserObjectTransfer.h
@@ -12,7 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #ifndef MULTIAPPDTKUSEROBJECTTRANSFER_H
 #define MULTIAPPDTKUSEROBJECTTRANSFER_H
@@ -89,4 +89,4 @@ protected:
 
 #endif /* MULTIAPPDTKUSEROBJECTTRANSFER_H */
 
-#endif //LIBMESH_HAVE_DTK
+#endif //LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -306,7 +306,7 @@
 #include "AutoPositionsMultiApp.h"
 
 // Transfers
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
   #include "MultiAppDTKUserObjectTransfer.h"
   #include "MultiAppDTKInterpolationTransfer.h"
 #endif
@@ -699,7 +699,7 @@ registerObjects(Factory & factory)
   registerPredictor(AdamsPredictor);
 
   // Transfers
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
   registerTransfer(MultiAppDTKUserObjectTransfer);
   registerTransfer(MultiAppDTKInterpolationTransfer);
 #endif

--- a/framework/src/transfers/DTKInterpolationAdapter.C
+++ b/framework/src/transfers/DTKInterpolationAdapter.C
@@ -13,7 +13,7 @@
 /****************************************************************/
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "Moose.h"
 
@@ -329,4 +329,4 @@ DTKInterpolationAdapter::get_semi_local_nodes(std::set<GlobalOrdinal> & semi_loc
   }
 }
 
-#endif // #ifdef LIBMESH_HAVE_DTK
+#endif // #ifdef LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/src/transfers/DTKInterpolationEvaluator.C
+++ b/framework/src/transfers/DTKInterpolationEvaluator.C
@@ -13,7 +13,7 @@
 /****************************************************************/
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "DTKInterpolationEvaluator.h"
 #include "DTKInterpolationHelper.h"
@@ -77,4 +77,4 @@ DTKInterpolationEvaluator::evaluate(const Teuchos::ArrayRCP<GlobalOrdinal>& elem
 
 } // namespace libMesh
 
-#endif
+#endif // LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/src/transfers/DTKInterpolationHelper.C
+++ b/framework/src/transfers/DTKInterpolationHelper.C
@@ -13,7 +13,7 @@
 /****************************************************************/
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 // Moose Includes
 #include "MooseError.h"
@@ -167,4 +167,4 @@ DTKInterpolationHelper::transferWithOffset(unsigned int from, unsigned int to, c
 
 } // namespace libMesh
 
-#endif // #ifdef LIBMESH_HAVE_DTK
+#endif // #ifdef LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/src/transfers/MultiAppDTKInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppDTKInterpolationTransfer.C
@@ -14,7 +14,7 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "MultiAppDTKInterpolationTransfer.h"
 
@@ -86,4 +86,4 @@ MultiAppDTKInterpolationTransfer::execute()
   }
 }
 
-#endif //LIBMESH_HAVE_DTK
+#endif //LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
@@ -14,7 +14,7 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "MultiAppDTKUserObjectEvaluator.h"
 
@@ -93,4 +93,4 @@ MultiAppDTKUserObjectEvaluator::createSourceGeometry( const Teuchos::RCP<const T
 
 }
 
-#endif //LIBMESH_HAVE_DTK
+#endif //LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
@@ -14,7 +14,7 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_HAVE_DTK
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "MultiAppDTKUserObjectTransfer.h"
 
@@ -78,4 +78,4 @@ MultiAppDTKUserObjectTransfer::execute()
   _multi_app->problem()->es().update();
 }
 
-#endif //LIBMESH_HAVE_DTK
+#endif //LIBMESH_TRILINOS_HAVE_DTK

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -22,7 +22,7 @@ LIBMESH_OPTIONS = {
       'FALSE' : '0'
       }
                      },
-  'dtk' :          { 're_option' : r'#define\s+LIBMESH_HAVE_DTK\s+(\d+)',
+  'dtk' :          { 're_option' : r'#define\s+LIBMESH_TRILINOS_HAVE_DTK\s+(\d+)',
                      'default'   : 'FALSE',
                      'options'   :
                        {


### PR DESCRIPTION
Summary of changes:
- Add SolverConfiguration class to simplify setting options for solvers.
- LIBMESH_CHKERRABORT -> LIBMESH_CHKERR.
- LIBMESH_CHKERR now throws an exception instead of MPI_Abort'ing.
- Misc. documentation updates and fixes.
- Misc. refactoring and updates to ParsedFunction classes.
- Add rpath flags for TBB link line.
- Fix ancient warning in Quad4 constructor found by Apple Clang 7.0.
- Fixes for Trilinos support.
- Curl is now disabled by default.  MOOSE will use this default until the ICEUpdater gets fixed.

Refs #000
