### PR TITLE
Add TDB to MOOSE free energy exporter

### DIFF
--- a/python/calphad/README.md
+++ b/python/calphad/README.md
@@ -1,0 +1,28 @@
+# CALPHAD Thermodynamic Database free energy extration
+
+The ```free_energy.py``` tool allows users to extract free energy expressions from ```*.tdb```
+thermodynamic database files (ThermoCalc format). The tool exports a list of MOOSE Material blocks
+for each phase (or a user specified subset of phases). The CALPHAD functional expressions are
+implemented using the ```DerivativeParsedMaterial``` class.
+
+It is up to the user to construct a full MOOSE input file around these material blocks and to rename
+the variables used in the exported form to more suitable names.
+
+## Installation
+
+The [pycalphad](https://github.com/richardotis/pycalphad) Python module is required to perform the
+parsing of the ```*.tdb``` files. [SymPy](https://github.com/sympy/sympy) is required to build the
+functional forms of the calphad expressions.
+
+To install and/or upgrade these prerequisites use pip:
+```
+pip install --upgrade sympy
+pip install --upgrade pycalphad
+```
+
+
+## Thermodynamic databases
+
+Database files can be obtained online at
+
+* [Computational Phase Diagram Database](http://cpddb.nims.go.jp/index_en.html/) (CPDDB)

--- a/python/calphad/free_energy.py
+++ b/python/calphad/free_energy.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+"""
+free_energy.py exports free energy expressions from a TDB thermodynamic databse
+to the MOOSE input file format.
+
+Usage:
+  free_energy.py database.tdb [list of phases]
+
+If no list of phases is supplied all phases are exported.
+"""
+
+import sys
+from pycalphad import Database, Model
+from utils.fparser import fparser
+
+# get commandline arguments
+try:
+  db_filename = sys.argv[1]
+except IndexError:
+  print "usage:\n\tfree_energy.py database.tdb [list of phases]"
+  sys.exit(1)
+
+phases = sys.argv[2:]
+
+# open the thermodynamic database file
+try:
+  db = Database(db_filename)
+except IOError, e:
+  print "Error opening database file."
+  print e
+  sys.exit(1)
+
+# compile list of phases to extract
+available_phases = list(db.phases)
+if len(phases) == 0:
+  phases = available_phases
+else:
+  # check that the user specified phases provided in the input file
+  if not set(phases) <= set(available_phases):
+    print "The available phases are:"
+    print available_phases
+    sys.exit(1)
+
+for phase in phases:
+  print '  [./F_%s]' % phase
+  print '    type = DerivativeParsedMaterial'
+  print '    block = 0'
+
+  # get constituents
+  constituents = list(set([i for c in db.phases[phase].constituents for i in c]))
+
+  # create thermodynamic model
+  m = Model(db, constituents, phase)
+
+  # export fparser expression
+  print "    function = '%s'" % fparser(m.ast)[2]
+
+  # print variables
+  print "    args = '%s'" % " ".join([v.name for v in m.variables])
+  print '  [../]'

--- a/python/calphad/utils/fparser.py
+++ b/python/calphad/utils/fparser.py
@@ -1,0 +1,165 @@
+"""
+FParser printer
+
+The FParserPrinter converts single sympy expressions into a single FParser.
+"""
+
+from __future__ import print_function, division
+
+from sympy.core import S, C
+from sympy.core.compatibility import string_types
+from sympy.printing.codeprinter import CodePrinter
+from sympy.printing.precedence import precedence
+
+# dictionary mapping sympy function to (argument_conditions, fparser function).
+# Used in FParserPrinter._print_Function(self)
+known_functions = {
+  "Abs": "abs",
+  "sin": "sin",
+  "cos": "cos",
+  "tan": "tan",
+  "asin": "asin",
+  "acos": "acos",
+  "atan": "atan",
+  "atan2": "atan2",
+  "exp": "exp",
+  "log": "log",
+  "erf": "erf",
+  "sinh": "sinh",
+  "cosh": "cosh",
+  "tanh": "tanh",
+  "asinh": "asinh",
+  "acosh": "acosh",
+  "atanh": "atanh",
+  "floor": "floor",
+  "ceiling": "ceil",
+}
+
+
+class FParserPrinter(CodePrinter):
+  """A printer to convert python expressions to FParser expressions"""
+  printmethod = "_fparser"
+
+  _default_settings = {
+    'order': None,
+    'human': False,
+    'full_prec': 'auto',
+    'precision': 15,
+  }
+
+  # ovewrite some operators (FParser uses single char and/or)
+  _operators = {
+    'and': '&',
+    'or': '|',
+    'not': '!',
+  }
+
+  def __init__(self, settings={}):
+    """Register function mappings supplied by user"""
+    CodePrinter.__init__(self, settings)
+    self.known_functions = dict(known_functions)
+
+  def _rate_index_position(self, p):
+    """function to calculate score based on position among indices
+
+    This method is used to sort loops in an optimized order, see
+    CodePrinter._sort_optimized()
+    """
+    return p*5
+
+  def _format_code(self, lines):
+    return lines
+
+  def _get_statement(self, codestring):
+    return "%s;" % codestring
+
+  def _get_loop_opening_ending(self, indices):
+    return '',''
+    #raise TypeError("FParserPrinter does not support loops")
+
+  def _print_Pow(self, expr):
+    PREC = precedence(expr)
+    if expr.exp == -1:
+      return '1/%s' % (self.parenthesize(expr.base, PREC))
+    elif expr.exp == 0.5:
+      return 'sqrt(%s)' % self._print(expr.base)
+    elif expr.base == 2:
+      return 'exp2(%s)' % self._print(expr.exp)
+    else:
+      return '%s^%s' % (self.parenthesize(expr.base, PREC),
+               self.parenthesize(expr.exp, PREC))
+
+  def _print_Rational(self, expr):
+    p, q = int(expr.p), int(expr.q)
+    return '%d/%d' % (p, q)
+
+  def _print_Indexed(self, expr):
+    raise TypeError("FParserPrinter does not support array indices")
+
+  def _print_Idx(self, expr):
+    raise TypeError("FParserPrinter does not support array indices")
+
+  def _print_Exp1(self, expr):
+    return 'exp(1)'
+
+  def _print_Pi(self, expr):
+    return '3.14159265359'
+
+  # TODO: we need a more elegant way to deal with infinity in FParser
+  def _print_Float(self, expr):
+    if expr == float("inf"):
+      return "1e200"
+    elif expr == float("-inf"):
+      return "-1e200"
+    else:
+      return CodePrinter._print_Float(self, expr)
+
+  def _print_Infinity(self, expr):
+    return '1e200'
+
+  def _print_NegativeInfinity(self, expr):
+    return '-1e200'
+
+  def _print_Piecewise(self, expr):
+    ecpairs = ["if(%s,%s" % (self._print(c), self._print(e))
+          for e, c in expr.args[:-1]]
+
+    if expr.args[-1].cond == True:
+      ecpairs.append("%s" % self._print(expr.args[-1].expr))
+    else:
+      # there is no default value, so we generate an invalid expression
+      # that will fail at runtime
+      ecpairs.append("if(%s,%s,0/0)" %
+              (self._print(expr.args[-1].cond),
+              self._print(expr.args[-1].expr)))
+    return ",".join(ecpairs) + ")" * (len(ecpairs)-1)
+
+
+def fparser(expr, assign_to=None, **settings):
+  r"""Converts an expr to an FParser expression
+
+    Parameters
+    ==========
+
+    expr : sympy.core.Expr
+      a sympy expression to be converted
+    precision : optional
+      the precision for numbers such as pi [default=15]
+
+
+    Examples
+    ========
+
+    >>> from sympy import ccode, symbols, Rational, sin, ceiling, Abs
+    >>> x, tau = symbols(["x", "tau"])
+    >>> ccode((2*tau)**Rational(7,2))
+    '8*sqrt(2)*pow(tau, 7.0L/2.0L)'
+    >>> fparser(sin(x), assign_to="s")
+    's = sin(x);'
+  """
+  return FParserPrinter(settings).doprint(expr, assign_to)
+
+
+def print_fparser(expr, **settings):
+  """Prints an FParser representation of the given expression."""
+  print(ccode(expr, **settings))


### PR DESCRIPTION
This adds an initial version of the free energy exporter using pycalphad. It consists of a main script that reads a tdb file, and prints all (or a user selected subset) of the phases in the database. It uses the fparser SymPy printer in the utils subdir. 

I've verified that the generated FParser expressions are parsable for the AlFe example TDB file supplied with pycalphad.

Refs. #5787
