### PR TITLE
Stop using "name" so carelessly as a parameter.

### DIFF
--- a/framework/include/actions/ActionFactory.h
+++ b/framework/include/actions/ActionFactory.h
@@ -85,7 +85,7 @@ public:
 
   std::string getTaskName(const std::string & action);
 
-  MooseSharedPointer<Action> create(const std::string & action, const std::string & name, InputParameters parameters);
+  MooseSharedPointer<Action> create(const std::string & action, const std::string & parsing_syntax, InputParameters parameters);
 
   InputParameters getValidParams(const std::string & name);
 

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -407,7 +407,7 @@ public:
    *   Required parameters are verified as valid meaning that they were either initialized when
    *   they were created, or were read from an input file or some other valid source
    */
-  void checkParams(const std::string & prefix);
+  void checkParams(const std::string & parsing_syntax);
 
   /**
    * Methods returning iterators to the coupled variables names stored in this

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -37,7 +37,7 @@ InputParameters validParams<Action>()
 Action::Action(InputParameters parameters) :
     ConsoleStreamInterface(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     _pars(parameters),
-    _name(getParam<std::string>("name")),
+    _name(getParam<std::string>("_parsing_syntax")),
     _short_name(MooseUtils::shortName(_name)),
     _registered_identifier(isParamValid("registered_identifier") ? getParam<std::string>("registered_identifier") : ""),
     _action_type(getParam<std::string>("action_type")),

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -28,7 +28,7 @@ ActionFactory::~ActionFactory()
 }
 
 MooseSharedPointer<Action>
-ActionFactory::create(const std::string & action, const std::string & name, InputParameters parameters)
+ActionFactory::create(const std::string & action, const std::string & parsing_syntax, InputParameters parameters)
 {
   parameters.addPrivateParam("_moose_app", &_app);
   parameters.addPrivateParam("action_type", action);
@@ -36,7 +36,7 @@ ActionFactory::create(const std::string & action, const std::string & name, Inpu
   BuildInfo *build_info = NULL;
 
   // Check to make sure that all required parameters are supplied
-  parameters.checkParams(name);
+  parameters.checkParams(parsing_syntax);
 
   iters = _name_to_build_info.equal_range(action);
 
@@ -57,10 +57,10 @@ ActionFactory::create(const std::string & action, const std::string & name, Inpu
     build_info = &(iters.first->second);
 
   if (!build_info)
-    mooseError(std::string("Unable to find buildable Action from supplied InputParameters Object for ") + name);
+    mooseError(std::string("Unable to find buildable Action from supplied InputParameters Object for ") + parsing_syntax);
 
   // Add the name to the parameters and create the object
-  parameters.addParam<std::string>("name", name, "The complete name of the object");
+  parameters.addParam<std::string>("_parsing_syntax", parsing_syntax, "The Parsed Syntax where this object was created or blank if it was AutoBuilt");
   MooseSharedPointer<Action> action_obj = (*build_info->_build_pointer)(parameters);
 
   if (parameters.get<std::string>("task") == "")

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -351,9 +351,9 @@ InputParameters::mooseObjectSyntaxVisibility() const
     mooseError("Parameter '" << name << "' cannot be marked as controllable because its type (" << this->type(name) << ") is not controllable.")
 
 void
-InputParameters::checkParams(const std::string & prefix)
+InputParameters::checkParams(const std::string & parsing_syntax)
 {
-  std::string l_prefix = this->have_parameter<std::string>("name") ? this->get<std::string>("name") : prefix;
+  std::string l_prefix = this->have_parameter<std::string>("name") ? this->get<std::string>("name") : parsing_syntax;
 
   std::ostringstream oss;
   // Required parameters

--- a/test/tests/restart/kernel_restartable/kernel_restartable_second.i
+++ b/test/tests/restart/kernel_restartable/kernel_restartable_second.i
@@ -51,3 +51,7 @@
 [Outputs]
   exodus = true
 []
+
+[Problem]
+  # This is here to make sure we can restart with a Problem block
+[]


### PR DESCRIPTION
Switch from using the meaningless word "name" to what the identifier actually
is, i.e. "parsing syntax". This fixes the bizarre restart problem we were seeing
with adding the [Problem] block.

closes #5808
