### PR TITLE
Adding Soret shape fuction for idaholab/moose#5830

### DIFF
--- a/modules/misc/include/ThermoDiffusion.h
+++ b/modules/misc/include/ThermoDiffusion.h
@@ -9,12 +9,13 @@
 
 #include "Kernel.h"
 #include "Material.h"
+#include "Function.h"
 
 /**
  * @brief Models thermo-diffusion (aka Soret effect, thermophoresis, etc.).
  * The mass flux J due to the thermal gradient is:
  *
- *   J_thermal = - ( D C Qstar / ( R T^2 ) ) * grad( T )
+ *   J_thermal = - ( D C Qstar / ( R T^2 F) ) * grad( T )
  *
  * where D is the mass diffusivity (same as for Fick's law), C is the concentration
  * Qstar is the heat of transport, R is the gas constant, and T is the temperature.
@@ -56,6 +57,7 @@ private:
   const MaterialProperty< Real > & _heat_of_transport;
   const Real _gas_constant;
   const unsigned int _temperature_index;
+  Function * const _f_shape;
 };
 
 template<>

--- a/modules/phase_field/include/kernels/SoretDiffusion.h
+++ b/modules/phase_field/include/kernels/SoretDiffusion.h
@@ -8,6 +8,7 @@
 #define SORETDIFFUSION_H
 
 #include "Kernel.h"
+#include "Function.h"
 
 //Forward Declaration
 class SoretDiffusion;
@@ -16,7 +17,7 @@ template<>
 InputParameters validParams<SoretDiffusion>();
 /**
  * SoretDiffusion adds the soret effect in the split form of the Cahn-Hilliard
- * equation.
+ * equation with added shape function (F) in the denominator.
  */
 class SoretDiffusion : public Kernel
 {
@@ -52,6 +53,9 @@ protected:
 
   /// Boltzmann constant
   const Real _kb;
+
+  /// Shape function
+  Function * const _f_shape;
 };
 
 #endif //SORETDIFFUSION_H


### PR DESCRIPTION
This is in connection with issue idaholab/moose#5830

The default function is equal to 1. This addition will support future FCCI work.
