### PR TITLE
Refactor params in Executioner

### DIFF
--- a/framework/include/executioners/EigenExecutionerBase.h
+++ b/framework/include/executioners/EigenExecutionerBase.h
@@ -42,8 +42,6 @@ public:
 
   virtual ~EigenExecutionerBase();
 
-  virtual Problem & problem() { return _problem; }
-
   /**
    * Initialization
    */

--- a/framework/include/executioners/Executioner.h
+++ b/framework/include/executioners/Executioner.h
@@ -32,13 +32,6 @@ template<>
 InputParameters validParams<Executioner>();
 
 /**
- * A helper function for creating execution related parameters, these are needed by
- * both Preconditioners and Executioners.
- */
-InputParameters commonExecutionParameters();
-
-
-/**
  * Executioners are objects that do the actual work of solving your problem.
  *
  * In general there are two "sets" of Executioners: Steady and Transient.
@@ -94,7 +87,16 @@ public:
    */
   virtual void postSolve();
 
-  virtual Problem & problem() = 0;
+  /**
+   * Deprecated:
+   * Return a reference to this Executioner's Problem instance
+   */
+  virtual Problem & problem();
+
+  /**
+   * Return a reference to this Executioner's FEProblem instance
+   */
+  FEProblem & feProblem();
 
   /** The name of the TimeStepper
    * This is an empty string for non-Transient executioners
@@ -117,6 +119,8 @@ protected:
    * @param execute_on When to execute the postprocessor that is created
    */
   virtual void addAttributeReporter(const std::string & name, Real & attribute, const std::string execute_on = "");
+
+  FEProblem & _fe_problem;
 
   /// Initial Residual Variables
   Real _initial_residual_norm;

--- a/framework/include/executioners/PetscTSExecutioner.h
+++ b/framework/include/executioners/PetscTSExecutioner.h
@@ -61,10 +61,7 @@ public:
 
   virtual void execute();
 
-  virtual Problem & problem();
-
 protected:
-  FEProblem & _fe_problem;
   TimeStepper *_time_stepper;
   bool keepGoing(TimeStepperStatus status, Real time) const;
 };

--- a/framework/include/executioners/Steady.h
+++ b/framework/include/executioners/Steady.h
@@ -51,8 +51,6 @@ public:
    */
   virtual void execute();
 
-  virtual Problem & problem();
-
   virtual void checkIntegrity();
 
 protected:

--- a/framework/include/executioners/Transient.h
+++ b/framework/include/executioners/Transient.h
@@ -49,8 +49,6 @@ public:
   Transient(const InputParameters & parameters);
   virtual ~Transient();
 
-  virtual Problem & problem();
-
   /**
    * Initialize executioner
    */
@@ -202,7 +200,7 @@ public:
    */
   Real unconstrainedDT() { return _unconstrained_dt; }
 
-  void parentOutputPositionChanged() { _problem.parentOutputPositionChanged(); }
+  void parentOutputPositionChanged() { _fe_problem.parentOutputPositionChanged(); }
 
   /**
    * Get the number of Picard iterations performed
@@ -219,6 +217,7 @@ protected:
    */
   virtual void solveStep(Real input_dt = -1.0);
 
+  /// Here for backward compatibility
   FEProblem & _problem;
 
   MooseEnum _time_scheme;

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -15,37 +15,13 @@
 #include "CreateExecutionerAction.h"
 #include "Factory.h"
 #include "PetscSupport.h"
-#include "Conversion.h"
 #include "MooseApp.h"
 #include "Executioner.h"
-#include "FEProblem.h"
-#include "ActionWarehouse.h"
-#include "MooseEnum.h"
-#include "MultiMooseEnum.h"
 
 template<>
 InputParameters validParams<CreateExecutionerAction>()
 {
   InputParameters params = validParams<MooseObjectAction>();
-  params.addParam<Real>        ("l_tol",           1.0e-5,   "Linear Tolerance");
-  params.addParam<Real>        ("l_abs_step_tol",  -1,       "Linear Absolute Step Tolerance");
-  params.addParam<unsigned int>("l_max_its",       10000,    "Max Linear Iterations");
-  params.addParam<unsigned int>("nl_max_its",      50,       "Max Nonlinear Iterations");
-  params.addParam<unsigned int>("nl_max_funcs",    10000,    "Max Nonlinear solver function evaluations");
-  params.addParam<Real>        ("nl_abs_tol",      1.0e-50,  "Nonlinear Absolute Tolerance");
-  params.addParam<Real>        ("nl_rel_tol",      1.0e-8,   "Nonlinear Relative Tolerance");
-  params.addParam<Real>        ("nl_abs_step_tol", 1.0e-50,  "Nonlinear Absolute step Tolerance");
-  params.addParam<Real>        ("nl_rel_step_tol", 1.0e-50,  "Nonlinear Relative step Tolerance");
-  params.addParam<bool>        ("no_fe_reinit",    false,    "Specifies whether or not to reinitialize FEs");
-  params.addParam<bool>        ("compute_initial_residual_before_preset_bcs", false,
-                                "Use the residual norm computed *before* PresetBCs are imposed in relative convergence check");
-
-  // Adds the PETSc related options to the Executioner block
-  params += Moose::PetscSupport::getPetscValidParams();
-
-  params.addParamNamesToGroup("l_tol l_abs_step_tol l_max_its nl_max_its nl_max_funcs "
-                              "nl_abs_tol nl_rel_tol nl_abs_step_tol nl_rel_step_tol compute_initial_residual_before_preset_bcs", "Solver");
-  params.addParamNamesToGroup("no_fe_reinit", "Advanced");
 
   return params;
 }
@@ -59,51 +35,6 @@ CreateExecutionerAction::CreateExecutionerAction(InputParameters params) :
 void
 CreateExecutionerAction::act()
 {
-  // Steady and derived Executioners need to know the number of adaptivity steps to take.  This parameter
-  // is held in the child block Adaptivity and needs to be pulled early
-  if (_problem.get() != NULL)
-  {
-    // Extract and store PETSc related settings on FEProblem
-#ifdef LIBMESH_HAVE_PETSC
-    Moose::PetscSupport::storePetscOptions(*_problem, _pars);
-#endif //LIBMESH_HAVE_PETSC
-
-    // solver params
-    EquationSystems & es = _problem->es();
-    es.parameters.set<Real> ("linear solver tolerance")
-      = getParam<Real>("l_tol");
-
-    es.parameters.set<Real> ("linear solver absolute step tolerance")
-      = getParam<Real>("l_abs_step_tol");
-
-    es.parameters.set<unsigned int> ("linear solver maximum iterations")
-      = getParam<unsigned int>("l_max_its");
-
-    es.parameters.set<unsigned int> ("nonlinear solver maximum iterations")
-      = getParam<unsigned int>("nl_max_its");
-
-    es.parameters.set<unsigned int> ("nonlinear solver maximum function evaluations")
-      = getParam<unsigned int>("nl_max_funcs");
-
-    es.parameters.set<Real> ("nonlinear solver absolute residual tolerance")
-      = getParam<Real>("nl_abs_tol");
-
-    es.parameters.set<Real> ("nonlinear solver relative residual tolerance")
-      = getParam<Real>("nl_rel_tol");
-
-    es.parameters.set<Real> ("nonlinear solver absolute step tolerance")
-      = getParam<Real>("nl_abs_step_tol");
-
-    es.parameters.set<Real> ("nonlinear solver relative step tolerance")
-      = getParam<Real>("nl_rel_step_tol");
-
-#ifdef LIBMESH_HAVE_PETSC
-    _problem->getNonlinearSystem()._l_abs_step_tol = getParam<Real>("l_abs_step_tol");
-#endif
-
-    _problem->getNonlinearSystem()._compute_initial_residual_before_preset_bcs = getParam<bool>("compute_initial_residual_before_preset_bcs");
-  }
-
   Moose::setup_perf_log.push("Create Executioner","Setup");
   _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
   MooseSharedPointer<Executioner> executioner = MooseSharedNamespace::static_pointer_cast<Executioner>(_factory.create(_type, "Executioner", _moose_object_pars));

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -41,7 +41,7 @@ InputParameters validParams<EigenExecutionerBase>()
 
 EigenExecutionerBase::EigenExecutionerBase(const InputParameters & parameters) :
     Executioner(parameters),
-    _problem(*parameters.getCheckedPointerParam<FEProblem *>("_fe_problem", "This might happen if you don't have a mesh")),
+    _problem(_fe_problem),
      _eigen_sys(static_cast<EigenSystem &>(_problem.getNonlinearSystem())),
      _eigenvalue(declareRestartableData("eigenvalue", 1.0)),
      _source_integral(getPostprocessorValue("bx_norm")),
@@ -564,4 +564,3 @@ EigenExecutionerBase::nonlinearSolve(Real rel_tol, Real abs_tol, Real pfactor, R
   _problem.es().parameters.set<Real> ("linear solver tolerance") = tol2;
   _problem.es().parameters.set<Real> ("nonlinear solver relative residual tolerance") = tol3;
 }
-

--- a/framework/src/executioners/Executioner.C
+++ b/framework/src/executioners/Executioner.C
@@ -35,45 +35,27 @@ InputParameters validParams<Executioner>()
 
   params.addParam<std::vector<std::string> >("splitting", "Top-level splitting defining a hierarchical decomposition into subsystems to help the solver.");
 
+  // Default Solver Behavior
 #ifdef LIBMESH_HAVE_PETSC
-  params += commonExecutionParameters();
+  params += Moose::PetscSupport::getPetscValidParams();
 #endif //LIBMESH_HAVE_PETSC
+  params.addParam<Real>        ("l_tol",           1.0e-5,   "Linear Tolerance");
+  params.addParam<Real>        ("l_abs_step_tol",  -1,       "Linear Absolute Step Tolerance");
+  params.addParam<unsigned int>("l_max_its",       10000,    "Max Linear Iterations");
+  params.addParam<unsigned int>("nl_max_its",      50,       "Max Nonlinear Iterations");
+  params.addParam<unsigned int>("nl_max_funcs",    10000,    "Max Nonlinear solver function evaluations");
+  params.addParam<Real>        ("nl_abs_tol",      1.0e-50,  "Nonlinear Absolute Tolerance");
+  params.addParam<Real>        ("nl_rel_tol",      1.0e-8,   "Nonlinear Relative Tolerance");
+  params.addParam<Real>        ("nl_abs_step_tol", 1.0e-50,  "Nonlinear Absolute step Tolerance");
+  params.addParam<Real>        ("nl_rel_step_tol", 1.0e-50,  "Nonlinear Relative step Tolerance");
+  params.addParam<bool>        ("no_fe_reinit",    false,    "Specifies whether or not to reinitialize FEs");
+  params.addParam<bool>        ("compute_initial_residual_before_preset_bcs", false,
+                                "Use the residual norm computed *before* PresetBCs are imposed in relative convergence check");
 
-  return params;
-}
+  params.addParamNamesToGroup("l_tol l_abs_step_tol l_max_its nl_max_its nl_max_funcs "
+                              "nl_abs_tol nl_rel_tol nl_abs_step_tol nl_rel_step_tol compute_initial_residual_before_preset_bcs", "Solver");
+  params.addParamNamesToGroup("no_fe_reinit", "Advanced");
 
-InputParameters commonExecutionParameters()
-{
-  InputParameters params = emptyInputParameters();
-  MooseEnum solve_type("PJFNK JFNK NEWTON FD LINEAR");
-  params.addParam<MooseEnum>   ("solve_type",      solve_type,
-                                "PJFNK: Preconditioned Jacobian-Free Newton Krylov "
-                                "JFNK: Jacobian-Free Newton Krylov "
-                                "NEWTON: Full Newton Solve "
-                                "FD: Use finite differences to compute Jacobian "
-                                "LINEAR: Solving a linear problem");
-
-  // Line Search Options
-#ifdef LIBMESH_HAVE_PETSC
-#if PETSC_VERSION_LESS_THAN(3,3,0)
-  MooseEnum line_search("default cubic quadratic none basic basicnonorms", "default");
-#else
-  MooseEnum line_search("default shell none basic l2 bt cp", "default");
-#endif
-  std::string addtl_doc_str(" (Note: none = basic)");
-#else
-  MooseEnum line_search("default", "default");
-  std::string addtl_doc_str("");
-#endif
-  params.addParam<MooseEnum>   ("line_search",     line_search, "Specifies the line search type" + addtl_doc_str);
-
-#ifdef LIBMESH_HAVE_PETSC
-  MultiMooseEnum common_petsc_options("", "", true);
-
-  params.addParam<MultiMooseEnum>("petsc_options", common_petsc_options, "Singleton PETSc options");
-  params.addParam<std::vector<std::string> >("petsc_options_iname", "Names of PETSc name/value pairs");
-  params.addParam<std::vector<std::string> >("petsc_options_value", "Values of PETSc name/value pairs (must correspond with \"petsc_options_iname\"");
-#endif //LIBMESH_HAVE_PETSC
   return params;
 }
 
@@ -82,11 +64,49 @@ Executioner::Executioner(const InputParameters & parameters) :
     UserObjectInterface(parameters),
     PostprocessorInterface(parameters),
     Restartable(parameters, "Executioners"),
+    _fe_problem(*parameters.getCheckedPointerParam<FEProblem *>("_fe_problem", "This might happen if you don't have a mesh")),
     _initial_residual_norm(std::numeric_limits<Real>::max()),
     _old_initial_residual_norm(std::numeric_limits<Real>::max()),
     _restart_file_base(getParam<FileNameNoExtension>("restart_file_base")),
     _splitting(getParam<std::vector<std::string> >("splitting"))
 {
+  // Extract and store PETSc related settings on FEProblem
+#ifdef LIBMESH_HAVE_PETSC
+  Moose::PetscSupport::storePetscOptions(_fe_problem, _pars);
+#endif //LIBMESH_HAVE_PETSC
+
+  // solver params
+  EquationSystems & es = _fe_problem.es();
+  es.parameters.set<Real> ("linear solver tolerance")
+    = getParam<Real>("l_tol");
+
+  es.parameters.set<Real> ("linear solver absolute step tolerance")
+    = getParam<Real>("l_abs_step_tol");
+
+  es.parameters.set<unsigned int> ("linear solver maximum iterations")
+    = getParam<unsigned int>("l_max_its");
+
+  es.parameters.set<unsigned int> ("nonlinear solver maximum iterations")
+    = getParam<unsigned int>("nl_max_its");
+
+  es.parameters.set<unsigned int> ("nonlinear solver maximum function evaluations")
+    = getParam<unsigned int>("nl_max_funcs");
+
+  es.parameters.set<Real> ("nonlinear solver absolute residual tolerance")
+    = getParam<Real>("nl_abs_tol");
+
+  es.parameters.set<Real> ("nonlinear solver relative residual tolerance")
+    = getParam<Real>("nl_rel_tol");
+
+  es.parameters.set<Real> ("nonlinear solver absolute step tolerance")
+    = getParam<Real>("nl_abs_step_tol");
+
+  es.parameters.set<Real> ("nonlinear solver relative step tolerance")
+    = getParam<Real>("nl_rel_step_tol");
+
+  _fe_problem.getNonlinearSystem()._compute_initial_residual_before_preset_bcs = getParam<bool>("compute_initial_residual_before_preset_bcs");
+
+  _fe_problem.getNonlinearSystem()._l_abs_step_tol = getParam<Real>("l_abs_step_tol");
 }
 
 Executioner::~Executioner()
@@ -118,6 +138,19 @@ Executioner::postSolve()
 {
 }
 
+Problem &
+Executioner::problem()
+{
+  mooseDoOnce(mooseWarning("This method is deprecated, use feProblem() instead"));
+  return _fe_problem;
+}
+
+FEProblem &
+Executioner::feProblem()
+{
+  return _fe_problem;
+}
+
 std::string
 Executioner::getTimeStepperName()
 {
@@ -135,4 +168,3 @@ Executioner::addAttributeReporter(const std::string & name, Real & attribute, co
     params.set<MultiMooseEnum>("execute_on") = execute_on;
   problem->addPostprocessor("ExecutionerAttributeReporter", name, params);
 }
-

--- a/framework/src/executioners/PetscTSExecutioner.C
+++ b/framework/src/executioners/PetscTSExecutioner.C
@@ -239,7 +239,6 @@ TimeStepper *createTimeStepper(Moose::TimeSteppingScheme scheme, FEProblem &fe_p
 
 PetscTSExecutioner::PetscTSExecutioner(const InputParameters & parameters) :
   Executioner(parameters),
-  _fe_problem(*parameterss.getCheckedPointerParam<FEProblem *>("_fe_problem")),
   _time_stepper(NULL)
 {
   if (!_restart_file_base.empty())

--- a/framework/src/executioners/Steady.C
+++ b/framework/src/executioners/Steady.C
@@ -27,7 +27,7 @@ InputParameters validParams<Steady>()
 
 Steady::Steady(const InputParameters & parameters) :
     Executioner(parameters),
-    _problem(*parameters.getCheckedPointerParam<FEProblem *>("_fe_problem", "This might happen if you don't have a mesh")),
+    _problem(_fe_problem),
     _time_step(_problem.timeStep()),
     _time(_problem.time())
 {
@@ -45,12 +45,6 @@ Steady::Steady(const InputParameters & parameters) :
 
 Steady::~Steady()
 {
-}
-
-Problem &
-Steady::problem()
-{
-  return _problem;
 }
 
 void
@@ -135,4 +129,3 @@ Steady::checkIntegrity()
   if (_problem.getNonlinearSystem().containsTimeKernel())
     mooseError("You have specified time kernels in your steady state simulation");
 }
-

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -86,7 +86,7 @@ InputParameters validParams<Transient>()
 
 Transient::Transient(const InputParameters & parameters) :
     Executioner(parameters),
-    _problem(*parameters.getCheckedPointerParam<FEProblem *>("_fe_problem", "This might happen if you don't have a mesh")),
+    _problem(_fe_problem),
     _time_scheme(getParam<MooseEnum>("scheme")),
     _t_step(_problem.timeStep()),
     _time(_problem.time()),
@@ -697,12 +697,6 @@ void
 Transient::postExecute()
 {
   _time_stepper->postExecute();
-}
-
-Problem &
-Transient::problem()
-{
-  return _problem;
 }
 
 void

--- a/framework/src/preconditioners/MoosePreconditioner.C
+++ b/framework/src/preconditioners/MoosePreconditioner.C
@@ -14,7 +14,7 @@
 
 #include "MoosePreconditioner.h"
 #include "FEProblem.h"
-#include "Executioner.h" // for common parameters, see validParams below
+#include "PetscSupport.h"
 
 template<>
 InputParameters validParams<MoosePreconditioner>()
@@ -27,7 +27,7 @@ InputParameters validParams<MoosePreconditioner>()
   params.registerBase("MoosePreconditioner");
 
 #ifdef LIBMESH_HAVE_PETSC
-  params += commonExecutionParameters();
+  params += Moose::PetscSupport::getPetscValidParams();
 #endif //LIBMESH_HAVE_PETSC
 
   return params;
@@ -96,4 +96,3 @@ MoosePreconditioner::copyVarValues(MeshBase & mesh,
     }
   }
 }
-

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -602,11 +602,9 @@ getPetscValidParams()
 #endif
   params.addParam<MooseEnum>   ("line_search",     line_search, "Specifies the line search type" + addtl_doc_str);
 
-#ifdef LIBMESH_HAVE_PETSC
   params.addParam<MultiMooseEnum>("petsc_options", getCommonPetscFlags(), "Singleton PETSc options");
   params.addParam<MultiMooseEnum>("petsc_options_iname", getCommonPetscKeys(), "Names of PETSc name/value pairs");
   params.addParam<std::vector<std::string> >("petsc_options_value", "Values of PETSc name/value pairs (must correspond with \"petsc_options_iname\"");
-#endif //LIBMESH_HAVE_PETSC
 
   return params;
 }


### PR DESCRIPTION
closes #5818 

I'm dropping the CommonExecutionerParameters because those parameters appear to have been duplicated in 9deb4b0d39efff96a42b651e5a68702fc7eddd60. Additionally we cannot set several parameters in derived Executioners because they are clobbered by `CreateExecutionerAction::act()`. This PR moves all of the parameters into the `Executioner` base class so they can be adjusted as necessary by derived classes. 

Additionally, I also added a new member to the executioner base class `_fe_problem`. It is always available for all of our executioners so it should be in the base class. At a later date, we'll be able to remove the existing `_problem` variable from most of the derived classes.
