### PR TITLE
Reduce use of "this->" 

### DIFF
--- a/framework/include/auxkernels/MaterialStdVectorAuxBase.h
+++ b/framework/include/auxkernels/MaterialStdVectorAuxBase.h
@@ -40,6 +40,11 @@ public:
 protected:
   /// index of the vecor element
   unsigned int _index;
+
+  // Explicitly declare the origin of the following inherited members
+  // https://isocpp.org/wiki/faq/templates#nondependent-name-lookup-members
+  using MaterialAuxBase<std::vector<T> >::_qp;
+  using MaterialAuxBase<std::vector<T> >::_prop;
 };
 
 template<typename T>
@@ -53,7 +58,7 @@ template<typename T>
 Real
 MaterialStdVectorAuxBase<T>::computeValue()
 {
-  mooseAssert(this->_prop[this->_qp].size() > _index, "MaterialStdVectorRealGradientAux: You chose to extract component " << _index << " but your Material property only has size " << this->_prop[this->_qp].size());
+  mooseAssert(_prop[_qp].size() > _index, "MaterialStdVectorRealGradientAux: You chose to extract component " << _index << " but your Material property only has size " << _prop[_qp].size());
   return MaterialAuxBase<std::vector<T> >::computeValue();
 }
 

--- a/modules/phase_field/src/kernels/KKSCHBulk.C
+++ b/modules/phase_field/src/kernels/KKSCHBulk.C
@@ -41,7 +41,7 @@ KKSCHBulk::KKSCHBulk(const InputParameters & parameters) :
   // Iterate over all coupled variables
   for (unsigned int i = 0; i < _nvar; ++i)
   {
-    MooseVariable *cvar = this->_coupled_moose_vars[i];
+    MooseVariable *cvar = _coupled_moose_vars[i];
 
     // get the second derivative material property (TODO:warn)
     _second_derivatives[i] = &getMaterialPropertyDerivative<Real>("fa_name", _ca_name, cvar->name());


### PR DESCRIPTION
This makes some class templates easier to read, by removing unneeded `this->` and replacing `this->` through `using`.

Closes #5847
