### PR TITLE
Removing defaults in FEProblem compute methods

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -564,9 +564,6 @@ public:
   ExecStore<VectorPostprocessorWarehouse> & getVectorPostprocessorWarehouse();
 
 
-  virtual void computeUserObjects(ExecFlagType type = EXEC_TIMESTEP_END, UserObjectWarehouse::GROUP group = UserObjectWarehouse::ALL);
-  virtual void computeAuxiliaryKernels(ExecFlagType type = EXEC_LINEAR);
-
   // Dampers /////
   void addDamper(std::string damper_name, const std::string & name, InputParameters parameters);
   void setupDampers();
@@ -888,6 +885,16 @@ public:
   /// Returns whether or not this Problem has a TimeIntegrator
   bool hasTimeIntegrator() const { return _has_time_integrator; }
 
+
+  /**
+   * Perform execution of MOOSE systems
+   */
+  void execute(const ExecFlagType & exec_type);
+
+  virtual void computeUserObjects(ExecFlagType type, UserObjectWarehouse::GROUP group = UserObjectWarehouse::ALL);
+
+  virtual void computeAuxiliaryKernels(ExecFlagType type);
+
 protected:
   MooseMesh & _mesh;
   EquationSystems _eq;
@@ -978,9 +985,8 @@ protected:
   /// Objects to be notified when the mesh changes
   std::vector<MeshChangedInterface *> _notify_when_mesh_changes;
 
-  void computeUserObjectsInternal(ExecFlagType type, UserObjectWarehouse::GROUP group);
-
   void checkUserObjects();
+
 
   /// Verify that there are no element type/coordinate type conflicts
   void checkCoordinateSystems();
@@ -1056,10 +1062,6 @@ protected:
   /// PETSc option storage
   Moose::PetscSupport::PetscOptions _petsc_options;
 #endif //LIBMESH_HAVE_PETSC
-
-public:
-  /// number of instances of FEProblem (to distinguish Systems when coupling problems together)
-  static unsigned int _n;
 
 private:
   bool _use_legacy_uo_aux_computation;

--- a/framework/src/timesteppers/DT2.C
+++ b/framework/src/timesteppers/DT2.C
@@ -121,7 +121,7 @@ DT2::step()
     // 1. step
     _fe_problem.onTimestepBegin();
     // Compute Post-Aux User Objects (Timestep begin)
-    _fe_problem.computeUserObjects();
+    _fe_problem.computeUserObjects(EXEC_TIMESTEP_BEGIN, UserObjectWarehouse::POST_AUX);
 
     _console << "  - 1. step" << std::endl;
     Moose::setSolverDefaults(_fe_problem);
@@ -137,7 +137,7 @@ DT2::step()
       _time += _dt;
       // 2. step
       _fe_problem.onTimestepBegin();
-      _fe_problem.computeUserObjects();
+      _fe_problem.computeUserObjects(EXEC_TIMESTEP_BEGIN, UserObjectWarehouse::POST_AUX);
 
       _console << "  - 2. step" << std::endl;
       Moose::setSolverDefaults(_fe_problem);
@@ -247,4 +247,3 @@ DT2::converged()
   else
     return false;
 }
-


### PR DESCRIPTION
This is the first step that attempts to clean-up the inconsistent
calls to the various execute methods be createing a single FEProblem::execute
method.

(refs #5860)
