### PR TITLE
Re-factor FEProblem compute calls to a single method.

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -564,9 +564,6 @@ public:
   ExecStore<VectorPostprocessorWarehouse> & getVectorPostprocessorWarehouse();
 
 
-  virtual void computeUserObjects(ExecFlagType type = EXEC_TIMESTEP_END, UserObjectWarehouse::GROUP group = UserObjectWarehouse::ALL);
-  virtual void computeAuxiliaryKernels(ExecFlagType type = EXEC_LINEAR);
-
   // Dampers /////
   void addDamper(std::string damper_name, const std::string & name, InputParameters parameters);
   void setupDampers();
@@ -888,6 +885,16 @@ public:
   /// Returns whether or not this Problem has a TimeIntegrator
   bool hasTimeIntegrator() const { return _has_time_integrator; }
 
+
+  /**
+   * Perform execution of MOOSE systems.
+   */
+  void execute(const ExecFlagType & exec_type);
+
+  virtual void computeUserObjects(ExecFlagType type, UserObjectWarehouse::GROUP group = UserObjectWarehouse::ALL);
+
+  virtual void computeAuxiliaryKernels(ExecFlagType type);
+
 protected:
   MooseMesh & _mesh;
   EquationSystems _eq;
@@ -978,9 +985,8 @@ protected:
   /// Objects to be notified when the mesh changes
   std::vector<MeshChangedInterface *> _notify_when_mesh_changes;
 
-  void computeUserObjectsInternal(ExecFlagType type, UserObjectWarehouse::GROUP group);
-
   void checkUserObjects();
+
 
   /// Verify that there are no element type/coordinate type conflicts
   void checkCoordinateSystems();
@@ -1056,10 +1062,6 @@ protected:
   /// PETSc option storage
   Moose::PetscSupport::PetscOptions _petsc_options;
 #endif //LIBMESH_HAVE_PETSC
-
-public:
-  /// number of instances of FEProblem (to distinguish Systems when coupling problems together)
-  static unsigned int _n;
 
 private:
   bool _use_legacy_uo_aux_computation;

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -885,15 +885,19 @@ public:
   /// Returns whether or not this Problem has a TimeIntegrator
   bool hasTimeIntegrator() const { return _has_time_integrator; }
 
-
   /**
    * Perform execution of MOOSE systems.
    */
   void execute(const ExecFlagType & exec_type);
 
-  virtual void computeUserObjects(ExecFlagType type, UserObjectWarehouse::GROUP group = UserObjectWarehouse::ALL);
-
+  ///@{
+  /**
+   * Deprecated callbacks.
+   */
+  virtual void computeUserObjects(ExecFlagType type, UserObjectWarehouse::GROUP group);
   virtual void computeAuxiliaryKernels(ExecFlagType type);
+  ///@}
+
 
 protected:
   MooseMesh & _mesh;
@@ -987,6 +991,15 @@ protected:
 
   void checkUserObjects();
 
+  /**
+   * Call UserObject execute() methods.
+   */
+  virtual void executeUserObjects(const ExecFlagType & type, const UserObjectWarehouse::GROUP & group);
+
+  /**
+   * Call AuxKernels compute() methods.
+   */
+  virtual void executeAuxiliaryKernels(const ExecFlagType & type);
 
   /// Verify that there are no element type/coordinate type conflicts
   void checkCoordinateSystems();

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -75,7 +75,7 @@ enum ExecFlagType {
   /// Forces execution on failed solve (output only)
   EXEC_FAILED            = 0x80,
   /// For use with custom executioners that want to fire objects at a specific time
-  EXEC_CUSTOM            = 0x100,
+  EXEC_CUSTOM            = 0x100
 };
 
 

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -551,7 +551,7 @@ void FEProblem::initialSetup()
     if (_use_legacy_uo_initialization)
     {
       _aux.compute(EXEC_TIMESTEP_BEGIN);
-      computeUserObjects(EXEC_TIMESTEP_END);
+      computeUserObjects(EXEC_TIMESTEP_END, UserObjectWarehouse::ALL);
     }
 
     // The only user objects that should be computed here are the initial UOs
@@ -559,8 +559,8 @@ void FEProblem::initialSetup()
 
     if (_use_legacy_uo_initialization)
     {
-      computeUserObjects(EXEC_TIMESTEP_BEGIN);
-      computeUserObjects(EXEC_LINEAR);
+      computeUserObjects(EXEC_TIMESTEP_BEGIN, UserObjectWarehouse::ALL);
+      computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::ALL);
     }
     Moose::setup_perf_log.pop("Initial computeUserObjects()","Setup");
   }
@@ -2243,9 +2243,28 @@ FEProblem::execute(const ExecFlagType & exec_type)
 
 }
 
+void
+FEProblem::computeAuxiliaryKernels(ExecFlagType type)
+{
+  mooseDeprecated("computeAuxiliaryKerels method will be removed in future versions of MOOSE, please update your code to use FEProblem::execute()");
+  executeAuxiliaryKernels(type);
+}
 
 void
 FEProblem::computeUserObjects(ExecFlagType type, UserObjectWarehouse::GROUP group)
+{
+  mooseDeprecated("computeUserObjects method will be removed in future versions of MOOSE, please update your code to use FEProblem::execute()");
+  executeUserObjects(type, group);
+}
+
+void
+FEProblem::executeAuxiliaryKernels(const ExecFlagType & type)
+{
+  _aux.compute(type);
+}
+
+void
+FEProblem::executeUserObjects(const ExecFlagType & type, const UserObjectWarehouse::GROUP & group)
 {
   // Perform Residual/Jacobin setups
   switch (type)
@@ -3308,12 +3327,6 @@ FEProblem::onTimestepBegin()
 void
 FEProblem::onTimestepEnd()
 {
-}
-
-void
-FEProblem::computeAuxiliaryKernels(ExecFlagType type)
-{
-  _aux.compute(type);
 }
 
 void

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -74,16 +74,6 @@
 //libmesh Includes
 #include "libmesh/exodusII_io.h"
 
-unsigned int FEProblem::_n = 0;
-
-static
-std::string name_sys(const std::string & name, unsigned int n)
-{
-  std::ostringstream os;
-  os << name << n;
-  return os.str();
-}
-
 Threads::spin_mutex get_function_mutex;
 
 template<>
@@ -117,8 +107,8 @@ FEProblem::FEProblem(const InputParameters & parameters) :
     _dt(declareRestartableData<Real>("dt")),
     _dt_old(declareRestartableData<Real>("dt_old")),
 
-    _nl(getParam<bool>("use_nonlinear") ? *(new NonlinearSystem(*this, name_sys("nl", _n))) : *(new EigenSystem(*this, name_sys("nl", _n)))),
-    _aux(*this, name_sys("aux", _n)),
+    _nl(getParam<bool>("use_nonlinear") ? *(new NonlinearSystem(*this, "nl0")) : *(new EigenSystem(*this, "nl0"))),
+    _aux(*this, "aux0"),
     _coupling(Moose::COUPLING_DIAG),
     _cm(NULL),
     _material_props(declareRestartableDataWithContext<MaterialPropertyStorage>("material_props", &_mesh)),
@@ -151,8 +141,6 @@ FEProblem::FEProblem(const InputParameters & parameters) :
     _error_on_jacobian_nonzero_reallocation(getParam<bool>("error_on_jacobian_nonzero_reallocation")),
     _fail_next_linear_convergence_check(false)
 {
-
-  _n++;
 
   _time = 0.0;
   _time_old = 0.0;
@@ -576,6 +564,7 @@ void FEProblem::initialSetup()
     }
     Moose::setup_perf_log.pop("Initial computeUserObjects()","Setup");
   }
+
 
   // Here we will initialize the stateful properties once more since they may have been updated
   // during initialSetup by calls to computeProperties.
@@ -2217,8 +2206,64 @@ FEProblem::computeIndicatorsAndMarkers()
 }
 
 void
-FEProblem::computeUserObjectsInternal(ExecFlagType type, UserObjectWarehouse::GROUP group)
+FEProblem::execute(const ExecFlagType & exec_type)
 {
+  // Run setup methods
+  /*
+  // Set FEProblem execution flag
+  if (exec_type == EXEC_TIMESTEP_BEGIN)
+    onTimestepBegin();
+
+  else if (exec_type == EXEC_TIMESTEP_END)
+    onTimestepEnd();
+  */
+
+  // Pre-aux UserObjects
+  Moose::perf_log.push("computeUserObjects()", "Solve");
+  computeUserObjects(exec_type, UserObjectWarehouse::PRE_AUX);
+  Moose::perf_log.pop("computeUserObjects()", "Solve");
+
+  // AuxKernels
+  Moose::perf_log.push("computeAuxiliaryKernels()", "Solve");
+  computeAuxiliaryKernels(exec_type);
+  Moose::perf_log.pop("computeAuxiliaryKernels()", "Solve");
+
+  // Post-aux UserObjects
+  Moose::perf_log.push("computeUserObjects()", "Solve");
+  computeUserObjects(exec_type, UserObjectWarehouse::POST_AUX);
+  Moose::perf_log.pop("computeUserObjects()", "Solve");
+
+  // Controls
+
+  // MultiApps
+
+  // Transfers
+
+  // Outputs
+
+}
+
+
+void
+FEProblem::computeUserObjects(ExecFlagType type, UserObjectWarehouse::GROUP group)
+{
+  // Perform Residual/Jacobin setups
+  switch (type)
+  {
+  case EXEC_LINEAR:
+    for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
+      _user_objects(type)[tid].residualSetup();
+    break;
+
+  case EXEC_NONLINEAR:
+    for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
+      _user_objects(type)[tid].jacobianSetup();
+    break;
+
+  default:
+    break;
+  }
+
   std::vector<UserObjectWarehouse> & pps = _user_objects(type);
   if (pps[0].blockIds().size() || pps[0].boundaryIds().size() || pps[0].nodesetIds().size() || pps[0].blockNodalIds().size() || pps[0].internalSideUserObjects(group).size())
   {
@@ -2526,31 +2571,6 @@ FEProblem::computeUserObjectsInternal(ExecFlagType type, UserObjectWarehouse::GR
     if (pp)
       _pps_data.storeValue(name, pp->getValue());
   }
-}
-
-void
-FEProblem::computeUserObjects(ExecFlagType type/* = EXEC_TIMESTEP_END*/, UserObjectWarehouse::GROUP group)
-{
-  Moose::perf_log.push("compute_user_objects()","Solve");
-
-  switch (type)
-  {
-  case EXEC_LINEAR:
-    for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
-      _user_objects(type)[tid].residualSetup();
-    break;
-
-  case EXEC_NONLINEAR:
-    for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
-      _user_objects(type)[tid].jacobianSetup();
-    break;
-
-  default:
-    break;
-  }
-  computeUserObjectsInternal(type, group);
-
-  Moose::perf_log.pop("compute_user_objects()","Solve");
 }
 
 void
@@ -3124,12 +3144,9 @@ FEProblem::solve()
 
   possiblyRebuildGeomSearchPatches();
 
-//  _solve_only_perf_log.push("solve");
-
   if (_solve)
     _nl.solve();
 
-//  _solve_only_perf_log.pop("solve");
   Moose::perf_log.pop("solve()","Solve");
 
   if (_solve)

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -103,12 +103,10 @@ EigenExecutionerBase::init()
 
   // check if _source_integral has been evaluated during initialSetup()
   if ((bx_execflag & EXEC_INITIAL) == EXEC_NONE)
-  {
-    _problem.computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::PRE_AUX);
-    _problem.computeAuxiliaryKernels(EXEC_LINEAR);
-    _problem.computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::POST_AUX);
-  }
-  if (_source_integral==0.0) mooseError("|Bx| = 0!");
+    _problem.execute(EXEC_LINEAR);
+
+  if (_source_integral==0.0)
+    mooseError("|Bx| = 0!");
 
   // normalize solution to make |Bx|=_eigenvalue, _eigenvalue at this point has the initialized value
   makeBXConsistent(_eigenvalue);
@@ -141,9 +139,7 @@ EigenExecutionerBase::makeBXConsistent(Real k)
   {
     // On the first time entering, the _source_integral has been updated properly in FEProblem::initialSetup()
     _eigen_sys.scaleSystemSolution(EigenSystem::EIGEN, k/_source_integral);
-    _problem.computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::PRE_AUX);
-    _problem.computeAuxiliaryKernels(EXEC_LINEAR);
-    _problem.computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::POST_AUX);
+    _problem.execute(EXEC_LINEAR);
     std::stringstream ss;
     ss << std::fixed << std::setprecision(10) << _source_integral;
     _console << " |Bx_0| = " << ss.str() << std::endl;
@@ -385,11 +381,7 @@ Real
 EigenExecutionerBase::normalizeSolution(bool force)
 {
   if (force)
-  {
-    _problem.computeUserObjects(EXEC_INITIAL);
-    _problem.computeAuxiliaryKernels(EXEC_INITIAL);
-    _problem.computeUserObjects(EXEC_INITIAL, UserObjectWarehouse::POST_AUX);
-  }
+    _problem.execute(EXEC_INITIAL);
 
   Real factor;
   if (isParamValid("normal_factor"))
@@ -406,10 +398,10 @@ EigenExecutionerBase::normalizeSolution(bool force)
     for (unsigned int i=0; i<Moose::exec_types.size(); i++)
     {
       // EXEC_CUSTOM is special, should be treated only by specifically designed executioners.
-      if (Moose::exec_types[i]==EXEC_CUSTOM) continue;
-      _problem.computeUserObjects(Moose::exec_types[i], UserObjectWarehouse::PRE_AUX);
-      _problem.computeAuxiliaryKernels(Moose::exec_types[i]);
-      _problem.computeUserObjects(Moose::exec_types[i], UserObjectWarehouse::POST_AUX);
+      if (Moose::exec_types[i]==EXEC_CUSTOM)
+        continue;
+
+      _problem.execute(Moose::exec_types[i]);
     }
   }
   return scaling;
@@ -474,9 +466,7 @@ EigenExecutionerBase::chebyshev(Chebyshev_Parameters & chebyshev_parameters, uns
       coef[0] = alp;
       coef[1] = 1-alp;
       _eigen_sys.combineSystemSolution(EigenSystem::EIGEN, coef);
-      _problem.computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::PRE_AUX);
-      _problem.computeAuxiliaryKernels(EXEC_LINEAR);
-      _problem.computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::POST_AUX);
+      _problem.execute(EXEC_LINEAR);
       _eigenvalue = _source_integral;
     }
   }
@@ -527,9 +517,7 @@ EigenExecutionerBase::chebyshev(Chebyshev_Parameters & chebyshev_parameters, uns
         coef[1] = 1-alp+beta;
         coef[2] = -beta;
         _eigen_sys.combineSystemSolution(EigenSystem::EIGEN, coef);
-        _problem.computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::PRE_AUX);
-        _problem.computeAuxiliaryKernels(EXEC_LINEAR);
-        _problem.computeUserObjects(EXEC_LINEAR, UserObjectWarehouse::POST_AUX);
+        _problem.execute(EXEC_LINEAR);
         _eigenvalue = _source_integral;
       }
 //    }

--- a/framework/src/timesteppers/DT2.C
+++ b/framework/src/timesteppers/DT2.C
@@ -121,7 +121,7 @@ DT2::step()
     // 1. step
     _fe_problem.onTimestepBegin();
     // Compute Post-Aux User Objects (Timestep begin)
-    _fe_problem.computeUserObjects();
+    _fe_problem.computeUserObjects(EXEC_TIMESTEP_BEGIN, UserObjectWarehouse::POST_AUX);
 
     _console << "  - 1. step" << std::endl;
     Moose::setSolverDefaults(_fe_problem);
@@ -137,7 +137,7 @@ DT2::step()
       _time += _dt;
       // 2. step
       _fe_problem.onTimestepBegin();
-      _fe_problem.computeUserObjects();
+      _fe_problem.computeUserObjects(EXEC_TIMESTEP_BEGIN, UserObjectWarehouse::POST_AUX);
 
       _console << "  - 2. step" << std::endl;
       Moose::setSolverDefaults(_fe_problem);
@@ -247,4 +247,3 @@ DT2::converged()
   else
     return false;
 }
-

--- a/test/src/executioners/AdaptAndModify.C
+++ b/test/src/executioners/AdaptAndModify.C
@@ -72,7 +72,7 @@ AdaptAndModify::endStep(Real input_time)
 
 #endif
     }
-    _problem.computeUserObjects(EXEC_CUSTOM);
+    _problem.computeUserObjects(EXEC_CUSTOM, UserObjectWarehouse::ALL);
 
     // Set the time for the next output interval if we're at or beyond an output interval
     if (_time_interval && (_time + _timestep_tolerance >= _next_interval_output_time))


### PR DESCRIPTION
This is the beginning of trying to make a single call to FEProblem::execute(...) rather then a whole bunch of calls. As it stands, the calls to computeUserObjects, AuxKernels, etc. are not super consistent. And rather than add another function `computeControls` that will add to the problem, I am going to attempt to consolidate.
