### PR TITLE
Various Utility classes cleaned up

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -65,7 +65,6 @@ extern PerfLog perf_log;
  * PerfLog to be used during setup.  This log will get printed just before the first solve. */
 extern PerfLog setup_perf_log;
 
-
 /**
  * Variable indicating whether we will enable FPE trapping for this run.
  */

--- a/framework/include/functions/Piecewise.h
+++ b/framework/include/functions/Piecewise.h
@@ -34,7 +34,7 @@ public:
 
 protected:
   const Real _scale_factor;
-  LinearInterpolation * _linear_interp;
+  MooseSharedPointer<LinearInterpolation> _linear_interp;
   int _axis;
   bool _has_axis;
 private:

--- a/framework/include/functions/PiecewiseBilinear.h
+++ b/framework/include/functions/PiecewiseBilinear.h
@@ -15,6 +15,7 @@
 #ifndef PIECEWISEBILINEAR_H
 #define PIECEWISEBILINEAR_H
 
+#include "MooseTypes.h"
 #include "Function.h"
 #include "BilinearInterpolation.h"
 #include "ColumnMajorMatrix.h"
@@ -42,7 +43,7 @@ public:
 
 
 private:
-  BilinearInterpolation * _bilinear_interp;
+  MooseSharedPointer<BilinearInterpolation> _bilinear_interp;
   const std::string _data_file_name;
   const int _axis;
   const int _yaxis;

--- a/framework/include/utils/BilinearInterpolation.h
+++ b/framework/include/utils/BilinearInterpolation.h
@@ -19,7 +19,9 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+
 #include "ColumnMajorMatrix.h"
+#include "Moose.h"
 
 
 /**

--- a/framework/include/utils/LinearInterpolation.h
+++ b/framework/include/utils/LinearInterpolation.h
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <string>
 
+#include "Moose.h"
 
 /**
  * This class interpolates values given a set of data pairs and an abscissa.
@@ -32,11 +33,11 @@ public:
    * independent variable while the other should be of the dependent variable.  These values should
    * correspond to one and other in the same position.
    */
-  LinearInterpolation(const std::vector<double> & X,
-                      const std::vector<double> & Y);
+  LinearInterpolation(const std::vector<Real> & X,
+                      const std::vector<Real> & Y);
   LinearInterpolation() :
-    _x(std::vector<double>()),
-    _y(std::vector<double>()) {}
+    _x(std::vector<Real>()),
+    _y(std::vector<Real>()) {}
 
   virtual ~LinearInterpolation()
     {}
@@ -44,7 +45,7 @@ public:
   /**
    * Set the x and y values.
    */
-  void setData(const std::vector<double> & X, const std::vector<double> & Y)
+  void setData(const std::vector<Real> & X, const std::vector<Real> & Y)
   {
     _x = X;
     _y = Y;
@@ -57,19 +58,19 @@ public:
    * This function will take an independent variable input and will return the dependent variable
    * based on the generated fit
    */
-  double sample(double x) const;
+  Real sample(Real x) const;
 
   /**
    * This function will take an independent variable input and will return the derivative of the dependent variable
    * with respect to the independent variable based on the generated fit
    */
-  double sampleDerivative(double x) const;
+  Real sampleDerivative(Real x) const;
 
   /**
    * This function will dump GNUPLOT input files that can be run to show the data points and
    * function fits
    */
-  void dumpSampleFile(std::string base_name, std::string x_label="X", std::string y_label="Y", float xmin=0, float xmax=0, float ymin=0, float ymax=0);
+  void dumpSampleFile(std::string base_name, std::string x_label="X", std::string y_label="Y", Real xmin=0, Real xmax=0, Real ymin=0, Real ymax=0);
 
   /**
    * This function returns the size of the array holding the points, i.e. the number of sample points
@@ -79,15 +80,15 @@ public:
   /**
    * This function returns the integral of the function
    */
-  double integrate();
+  Real integrate();
 
-  double domain(int i) const;
-  double range(int i) const;
+  Real domain(int i) const;
+  Real range(int i) const;
 
 private:
 
-  std::vector<double> _x;
-  std::vector<double> _y;
+  std::vector<Real> _x;
+  std::vector<Real> _y;
 
   static int _file_number;
 };

--- a/framework/include/utils/PolynomialFit.h
+++ b/framework/include/utils/PolynomialFit.h
@@ -15,15 +15,12 @@
 #ifndef POLYNOMIALFIT_H
 #define POLYNOMIALFIT_H
 
-#include "Moose.h"
-
-//libMesh
-#include "libmesh/libmesh_common.h"
-
 #include <vector>
 #include <fstream>
 #include <sstream>
 #include <string>
+
+#include "Moose.h"
 
 /**
  * This class applies the Least Squares algorithm to a set of points to provide a smooth curve for

--- a/framework/src/functions/Piecewise.C
+++ b/framework/src/functions/Piecewise.C
@@ -31,7 +31,6 @@ InputParameters validParams<Piecewise>()
 Piecewise::Piecewise(const InputParameters & parameters) :
     Function(parameters),
     _scale_factor(getParam<Real>("scale_factor")),
-    _linear_interp( NULL ),
     _has_axis(false),
     _data_file_name(getParam<FileName>("data_file"))
 {
@@ -44,7 +43,7 @@ Piecewise::Piecewise(const InputParameters & parameters) :
         (parameters.isParamValid("y")) ||
         (parameters.isParamValid("xy_data")))
     {
-      mooseError("In Piecewise: Cannot specify 'data_file' and 'x', 'y', or 'xy_data' together.");
+      mooseError("In Piecewise " << _name << ": Cannot specify 'data_file' and 'x', 'y', or 'xy_data' together.");
     }
     std::string format = getParam<std::string>("format");
     if (format.compare(0, 4, "rows")==0)
@@ -57,7 +56,7 @@ Piecewise::Piecewise(const InputParameters & parameters) :
     }
     else
     {
-      mooseError("Invalid option for format: "+format+" in "+name()+".  Valid options are 'rows' and 'columns'.");
+      mooseError("In Piecewise " << _name << ": Invalid option for format: "+format+" in "+name()+".  Valid options are 'rows' and 'columns'.");
     }
   }
   else if ((parameters.isParamValid("x")) ||
@@ -66,11 +65,11 @@ Piecewise::Piecewise(const InputParameters & parameters) :
     if (! ((parameters.isParamValid("x")) &&
            (parameters.isParamValid("y"))))
     {
-      mooseError("In Piecewise: Both 'x' and 'y' must be specified if either one is specified.");
+      mooseError("In Piecewise " << _name << ": Both 'x' and 'y' must be specified if either one is specified.");
     }
     if (parameters.isParamValid("xy_data"))
     {
-      mooseError("In Piecewise: Cannot specify 'x', 'y', and 'xy_data' together.");
+      mooseError("In Piecewise " << _name << ": Cannot specify 'x', 'y', and 'xy_data' together.");
     }
     x = getParam<std::vector<Real> >("x");
     y = getParam<std::vector<Real> >("y");
@@ -81,7 +80,7 @@ Piecewise::Piecewise(const InputParameters & parameters) :
     unsigned int xy_size = xy.size();
     if (xy_size % 2 != 0)
     {
-      mooseError("In Piecewise: Length of data provided in 'xy_data' must be a multiple of 2.");
+      mooseError("In Piecewise " << _name << ": Length of data provided in 'xy_data' must be a multiple of 2.");
     }
     unsigned int x_size = xy_size/2;
     x.reserve(x_size);
@@ -94,24 +93,29 @@ Piecewise::Piecewise(const InputParameters & parameters) :
   }
   else
   {
-    mooseError("In Piecewise: Either 'data_file', 'x' and 'y', or 'xy_data' must be specified.");
+    mooseError("In Piecewise " << _name << ": Either 'data_file', 'x' and 'y', or 'xy_data' must be specified.");
   }
 
-  _linear_interp = new LinearInterpolation( x, y );
-
+  try
+  {
+    _linear_interp.reset(new LinearInterpolation(x, y));
+  }
+  catch (std::domain_error & e)
+  {
+    mooseError("In Piecewise " << _name << ": " << e.what());
+  }
 
   if (parameters.isParamValid("axis"))
   {
     _axis=parameters.get<int>("axis");
     if (_axis < 0 || _axis > 2)
-      mooseError("In Piecewise function axis="<<_axis<<" outside allowable range (0-2).");
+      mooseError("In Piecewise " << _name << ": axis="<<_axis<<" outside allowable range (0-2).");
     _has_axis = true;
   }
 }
 
 Piecewise::~Piecewise()
 {
-  delete _linear_interp;
 }
 
 Real
@@ -166,7 +170,7 @@ Piecewise::parseRows( std::vector<Real> & x, std::vector<Real> & y )
 {
   std::ifstream file(_data_file_name.c_str());
   if (!file.good())
-    mooseError("Error opening file '" + _data_file_name + "' from Piecewise function.");
+    mooseError("In Piecewise " << _name << ": Error opening file '" + _data_file_name + "'.");
   std::string line;
 
   while (parseNextLineReals(file, x))
@@ -176,7 +180,7 @@ Piecewise::parseRows( std::vector<Real> & x, std::vector<Real> & y )
   }
 
   if (x.size() == 0)
-    mooseError("File '" + _data_file_name + "' contains no data for Piecewise function.");
+    mooseError("In Piecewise " << _name << ": '" + _data_file_name + "' contains no data.");
 
   while (parseNextLineReals(file, y))
   {
@@ -185,14 +189,14 @@ Piecewise::parseRows( std::vector<Real> & x, std::vector<Real> & y )
   }
 
   if (y.size() == 0)
-    mooseError("File '" + _data_file_name + "' contains no y data for Piecewise function.");
+    mooseError("In Piecewise " << _name << ": File '" + _data_file_name + "' contains no y data.");
   else if (y.size() != x.size())
-    mooseError("Lengths of x and y data do not match in file '" + _data_file_name + "' for Piecewise function.");
+    mooseError("In Piecewise " << _name << ": Lengths of x and y data do not match in file '" + _data_file_name + "'.");
 
   std::vector<Real> scratch;
   while (parseNextLineReals(file, scratch)){
     if (scratch.size() > 0)
-      mooseError("Read more than two rows of data from file '" + _data_file_name + "' for Piecewise function.  Did you mean to use \"format = columns\"?");
+      mooseError("In Piecewise " << _name << ": Read more than two rows of data from file '" + _data_file_name + "'.  Did you mean to use \"format = columns\"?");
   }
 
 }
@@ -202,7 +206,7 @@ Piecewise::parseColumns( std::vector<Real> & x, std::vector<Real> & y )
 {
   std::ifstream file(_data_file_name.c_str());
   if (!file.good())
-    mooseError("Error opening file '" + _data_file_name + "' from Piecewise function.");
+    mooseError("In Piecewise " << _name << ": Error opening file '" + _data_file_name + "'.");
   std::string line;
 
   std::vector<Real> scratch;
@@ -210,7 +214,7 @@ Piecewise::parseColumns( std::vector<Real> & x, std::vector<Real> & y )
   {
     if (scratch.size() > 0){
       if (scratch.size() != 2)
-        mooseError("Read more than 2 columns of data from file '" + _data_file_name + "' for Piecewise function.  Did you mean to use \"format = rows\"?");
+        mooseError("In Piecewise " << _name << ": Read more than 2 columns of data from file '" + _data_file_name + "'.  Did you mean to use \"format = rows\"?");
       x.push_back(scratch[0]);
       y.push_back(scratch[1]);
     }

--- a/framework/src/utils/BilinearInterpolation.C
+++ b/framework/src/utils/BilinearInterpolation.C
@@ -28,7 +28,6 @@
  */
 
 #include "BilinearInterpolation.h"
-#include "libmesh/libmesh_common.h"
 
 int BilinearInterpolation::_file_number = 0;
 
@@ -74,33 +73,37 @@ Real BilinearInterpolation::sample(Real xcoord, Real ycoord)
   //first find 4 neighboring points
   int lx=0; //index of x coordinate of adjacent grid point to left of P
   int ux=0; //index of x coordinate of adjacent grid point to right of P
-  getNeighborIndices( _xAxis, xcoord, lx, ux);
+  getNeighborIndices(_xAxis, xcoord, lx, ux);
+
   int ly=0; //index of y coordinate of adjacent grid point below P
   int uy=0; //index of y coordinate of adjacent grid point above P
-  getNeighborIndices( _yAxis, ycoord, ly, uy);
+  getNeighborIndices(_yAxis, ycoord, ly, uy);
+
   Real fQ11 = _zSurface(ly, lx);
   Real fQ21 = _zSurface(ly, ux);
   Real fQ12 = _zSurface(uy, lx);
   Real fQ22 = _zSurface(uy, ux);
-  //if point exactly found on a node do not interpolate
+
+  // if point exactly found on a node do not interpolate
   if ((lx == ux) && (ly == uy))
     return fQ11;
+
   Real x = xcoord;
   Real y = ycoord;
   Real x1 = _xAxis[lx];
   Real x2 = _xAxis[ux];
   Real y1 = _yAxis[ly];
   Real y2 = _yAxis[uy];
-  //if xcoord lies exactly on an xAxis node do linear interpolation
+
+  // if xcoord lies exactly on an xAxis node do linear interpolation
   if (lx == ux)
-  {
     return fQ11 + (fQ12 - fQ11) * (y - y1) / (y2 - y1);
-  }
-  //if ycoord lies exactly on an yAxis node do linear interpolation
+
+  // if ycoord lies exactly on an yAxis node do linear interpolation
+
   if (ly == uy)
-  {
     return fQ11 + (fQ21 - fQ11) * (x - x1) / (x2 - x1);
-  }
+
   Real fxy = fQ11 * (x2 - x) * (y2 - y);
   fxy += fQ21 * (x - x1) * (y2 - y);
   fxy += fQ12 * (x2 - x) * (y - y1);

--- a/framework/src/utils/PolynomialFit.C
+++ b/framework/src/utils/PolynomialFit.C
@@ -13,8 +13,6 @@
 /****************************************************************/
 
 #include "PolynomialFit.h"
-#include "MooseError.h"
-#include "libmesh/libmesh_common.h"
 
 extern "C" void FORTRAN_CALL(dgels) ( ... );
 
@@ -40,7 +38,7 @@ PolynomialFit::PolynomialFit(std::vector<Real> x, std::vector<Real> y, unsigned 
 
   }
   else if (_x.size() < order)
-    mooseError("Polynomial Fit requires an order less than the size of the input vector\n");
+    throw std::domain_error("Polynomial Fit requires an order less than the size of the input vector");
 }
 
 void
@@ -87,7 +85,7 @@ PolynomialFit::doLeastSquares()
 
   FORTRAN_CALL(dgels)(&mode, &num_rows, &num_coeff, &num_rhs, &_matrix[0], &num_rows, &rhs[0], &num_rows, &opt_buffer_size, &buffer_size, &return_value);
   if (return_value)
-    mooseError("");
+    throw std::runtime_error("Call to Fortran routine 'dgels' returned non-zero exit code");
 
   buffer_size = (int) opt_buffer_size;
 
@@ -96,7 +94,7 @@ PolynomialFit::doLeastSquares()
   delete [] buffer;
 
   if (return_value)
-    mooseError("");
+    throw std::runtime_error("Call to Fortran routine 'dgels' returned non-zero exit code");
 
   _coeffs.resize(num_coeff);
   for (int i=0; i<num_coeff; ++i)

--- a/test/src/materials/LinearInterpolationMaterial.C
+++ b/test/src/materials/LinearInterpolationMaterial.C
@@ -50,8 +50,16 @@ LinearInterpolationMaterial::LinearInterpolationMaterial(const InputParameters &
   }
   else
   {
-    _linear_interp = new LinearInterpolation(getParam<std::vector<Real> >("independent_vals"),
-                                             getParam<std::vector<Real> >("dependent_vals"));
+    try
+    {
+
+      _linear_interp = new LinearInterpolation(getParam<std::vector<Real> >("independent_vals"),
+                                               getParam<std::vector<Real> >("dependent_vals"));
+    }
+    catch (std::domain_error & e)
+    {
+      mooseError("In LinearInterpolationMaterial " << _name << ": " << e.what());
+    }
 
     _linear_interp->dumpSampleFile(getParam<std::string>("prop_name"),
                                    "X position",

--- a/test/tests/misc/check_error/linear_interp_not_increasing.i
+++ b/test/tests/misc/check_error/linear_interp_not_increasing.i
@@ -1,0 +1,72 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  nz = 0
+  zmin = 0
+  zmax = 0
+  elem_type = QUAD4
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  active = 'diff'
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  active = 'left right'
+
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 3
+    value = 1
+  [../]
+[]
+
+[Materials]
+  [./linear_interp]
+    type = LinearInterpolationMaterial
+    prop_name = 'diffusivity'
+    independent_vals = '0 0.2 0.2 0.4 0.6 0.8 1.0'
+    dependent_vals = '16 8 4 2 1 0.5 1'
+
+    # Note the following line gets enabled by the tester
+    #use_poly_fit = true
+
+    block = 0
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  file_base = out
+  gmv = true
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -128,22 +128,28 @@
     expect_err = "The following dynamic boundary name is not unique: \w+"
   [../]
 
+  [./linear_interp_material_check]
+    type = 'RunException'
+    input = 'linear_interp_not_increasing.i'
+    expect_err = "In LinearInterpolationMaterial \S+: x-values are not strictly increasing"
+  [../]
+
   [./function_file_test1]
     type = 'RunException'
     input = 'function_file_test1.i'
-    expect_err = "Read more than two rows of data from file '\S+' for Piecewise function.  Did you mean to use \"format = columns\"?"
+    expect_err = "In Piecewise \S+: Read more than two rows of data from file '\S+'.  Did you mean to use \"format = columns\"?"
   [../]
 
   [./function_file_test2]
     type = 'RunException'
     input = 'function_file_test2.i'
-    expect_err = "Read more than 2 columns of data from file '\S+' for Piecewise function.  Did you mean to use \"format = rows\"?"
+    expect_err = "In Piecewise \S+: Read more than 2 columns of data from file '\S+'.  Did you mean to use \"format = rows\"?"
   [../]
 
   [./function_file_test3]
     type = 'RunException'
     input = 'function_file_test3.i'
-    expect_err = "Lengths of x and y data do not match in file '\S+' for Piecewise function."
+    expect_err = "In Piecewise \S+: Lengths of x and y data do not match in file '\S+'."
   [../]
 
   [./function_file_test4]
@@ -155,37 +161,37 @@
   [./function_file_test5]
     type = 'RunException'
     input = 'function_file_test5.i'
-    expect_err = "In Piecewise: Cannot specify 'data_file' and 'x', 'y', or 'xy_data' together."
+    expect_err = "In Piecewise \S+: Cannot specify 'data_file' and 'x', 'y', or 'xy_data' together."
   [../]
 
   [./function_file_test6]
     type = 'RunException'
     input = 'function_file_test6.i'
-    expect_err = "In Piecewise: Cannot specify 'x', 'y', and 'xy_data' together."
+    expect_err = "In Piecewise \S+: Cannot specify 'x', 'y', and 'xy_data' together."
   [../]
 
   [./function_file_test7]
     type = 'RunException'
     input = 'function_file_test7.i'
-    expect_err = "In Piecewise: Both 'x' and 'y' must be specified if either one is specified."
+    expect_err = "In Piecewise \S+: Both 'x' and 'y' must be specified if either one is specified."
   [../]
 
   [./function_file_test8]
     type = 'RunException'
     input = 'function_file_test8.i'
-    expect_err = "In Piecewise: Length of data provided in 'xy_data' must be a multiple of 2."
+    expect_err = "In Piecewise \S+: Length of data provided in 'xy_data' must be a multiple of 2."
   [../]
 
   [./function_file_test9]
     type = 'RunException'
     input = 'function_file_test9.i'
-    expect_err = "In Piecewise: Either 'data_file', 'x' and 'y', or 'xy_data' must be specified."
+    expect_err = "In Piecewise \S+: Either 'data_file', 'x' and 'y', or 'xy_data' must be specified."
   [../]
 
   [./function_file_test10]
     type = 'RunException'
     input = 'function_file_test10.i'
-    expect_err = "In Piecewise function axis=3 outside allowable range \(0-2\)."
+    expect_err = "In Piecewise \S+: axis=3 outside allowable range \(0-2\)."
   [../]
 
   [./incomplete_kernel_block_coverage_test]
@@ -233,7 +239,7 @@
   [./missing_function_file_test]
     type = 'RunException'
     input = 'missing_function_file_test.i'
-    expect_err = "Error opening file \S+ from Piecewise function"
+    expect_err = "In Piecewise \S+: Error opening file '\S+'"
   [../]
 
   [./missing_function_test]


### PR DESCRIPTION
- Use consistent error messages that include the name of the object
- Provided case where values of non-increasing vector are displayed
- Several formatting fixes
- Use of MooseSharedPointer
  closes #5880 

Note that several "Real" types were also changed to "double". These utility classes do not require MOOSE at all to operate so I have removed all headers.
