### PR TITLE
Clean up switch block

### DIFF
--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -129,8 +129,10 @@ Coupleable::coupled(const std::string & var_name, unsigned int comp)
   MooseVariable * var = getVar(var_name, comp);
   switch (var->kind())
   {
-  case Moose::VAR_NONLINEAR: return getVar(var_name, comp)->number();
-  case Moose::VAR_AUXILIARY: return std::numeric_limits<unsigned int>::max() - getVar(var_name, comp)->number();
+    case Moose::VAR_NONLINEAR:
+      return var->number();
+    case Moose::VAR_AUXILIARY:
+      return std::numeric_limits<unsigned int>::max() - var->number();
   }
   mooseError("Unknown variable kind. Corrupted binary?");
 }


### PR DESCRIPTION
Small tweak to a switch statement in `Coupleable`. No need to call `getVar()` again.

Refs #1504
