### PR TITLE
Correct use of total_strain, mechanical_strain. 

### DIFF
--- a/modules/combined/tests/eigenstrain/variable_finite.i
+++ b/modules/combined/tests/eigenstrain/variable_finite.i
@@ -61,14 +61,14 @@
 [AuxKernels]
   [./strain11]
     type = RankTwoAux
-    rank_two_tensor = total_strain
+    rank_two_tensor = mechanical_strain
     index_i = 0
     index_j = 0
     variable = strain11
   [../]
   [./stress11]
     type = RankTwoAux
-    rank_two_tensor = total_strain
+    rank_two_tensor = mechanical_strain
     index_i = 1
     index_j = 1
     variable = stress11

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
@@ -24,6 +24,7 @@ protected:
 
   MaterialProperty<RankTwoTensor> & _strain_rate;
   MaterialProperty<RankTwoTensor> & _strain_increment;
+  MaterialProperty<RankTwoTensor> & _mechanical_strain_old;
   MaterialProperty<RankTwoTensor> & _total_strain_old;
   MaterialProperty<RankTwoTensor> & _rotation_increment;
 

--- a/modules/tensor_mechanics/include/materials/ComputeIncrementalSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIncrementalSmallStrain.h
@@ -23,6 +23,7 @@ protected:
 
   MaterialProperty<RankTwoTensor> & _strain_rate;
   MaterialProperty<RankTwoTensor> & _strain_increment;
+  MaterialProperty<RankTwoTensor> & _mechanical_strain_old;
   MaterialProperty<RankTwoTensor> & _total_strain_old;
   MaterialProperty<RankTwoTensor> & _rotation_increment;
 

--- a/modules/tensor_mechanics/include/materials/ComputeLinearElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeLinearElasticStress.h
@@ -20,7 +20,7 @@ public:
 protected:
   virtual void computeQpStress();
 
-  const MaterialProperty<RankTwoTensor> & _total_strain;
+  const MaterialProperty<RankTwoTensor> & _mechanical_strain;
   const bool _is_finite_strain;
 };
 

--- a/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
@@ -38,6 +38,8 @@ protected:
 
   std::string _base_name;
 
+  MaterialProperty<RankTwoTensor> & _mechanical_strain;
+
   MaterialProperty<RankTwoTensor> & _total_strain;
 
   const bool _stateful_displacements;

--- a/modules/tensor_mechanics/include/materials/ComputeStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStressBase.h
@@ -28,7 +28,7 @@ protected:
 
   std::string _base_name;
 
-  const MaterialProperty<RankTwoTensor> & _total_strain;
+  const MaterialProperty<RankTwoTensor> & _mechanical_strain;
   MaterialProperty<RankTwoTensor> & _stress;
   MaterialProperty<RankTwoTensor> & _elastic_strain;
   const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;

--- a/modules/tensor_mechanics/src/materials/Compute2DSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/Compute2DSmallStrain.C
@@ -30,11 +30,12 @@ Compute2DSmallStrain::computeProperties()
     _total_strain[_qp](1,0) = _total_strain[_qp](0,1);  //force the symmetrical strain tensor
     _total_strain[_qp](2,2) = computeStrainZZ();
 
+    _mechanical_strain[_qp] = _total_strain[_qp];
+
     //Remove thermal expansion
-    _total_strain[_qp].addIa(-_thermal_expansion_coeff*( _T[_qp] - _T0 ));
+    _mechanical_strain[_qp].addIa(-_thermal_expansion_coeff*( _T[_qp] - _T0 ));
 
     //Remove the Eigen strain
-    _total_strain[_qp] -= _stress_free_strain[_qp];
+    _mechanical_strain[_qp] -= _stress_free_strain[_qp];
   }
 }
-

--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
@@ -19,6 +19,7 @@ ComputeFiniteStrain::ComputeFiniteStrain(const InputParameters & parameters) :
     ComputeStrainBase(parameters),
     _strain_rate(declareProperty<RankTwoTensor>(_base_name + "strain_rate")),
     _strain_increment(declareProperty<RankTwoTensor>(_base_name + "strain_increment")),
+    _mechanical_strain_old(declarePropertyOld<RankTwoTensor>("mechanical_strain")),
     _total_strain_old(declarePropertyOld<RankTwoTensor>("total_strain")),
     _rotation_increment(declareProperty<RankTwoTensor>(_base_name + "rotation_increment")),
     _deformation_gradient(declareProperty<RankTwoTensor>(_base_name + "deformation_gradient")),
@@ -31,12 +32,15 @@ ComputeFiniteStrain::ComputeFiniteStrain(const InputParameters & parameters) :
 void
 ComputeFiniteStrain::initQpStatefulProperties()
 {
+  ComputeStrainBase::initQpStatefulProperties();
+
   _strain_rate[_qp].zero();
   _strain_increment[_qp].zero();
   _rotation_increment[_qp].zero();
   _deformation_gradient[_qp].zero();
   _deformation_gradient[_qp].addIa(1.0);
   _deformation_gradient_old[_qp] = _deformation_gradient[_qp];
+  _mechanical_strain_old[_qp] = _mechanical_strain[_qp];
   _total_strain_old[_qp] = _total_strain[_qp];
 }
 
@@ -101,7 +105,9 @@ ComputeFiniteStrain::computeQpStrain(const RankTwoTensor & Fhat)
   RankTwoTensor Cinv_I = A*A.transpose() - A - A.transpose();
 
   //strain rate D from Taylor expansion, Chat = (-1/2(Chat^-1 - I) + 1/4*(Chat^-1 - I)^2 + ...
-  _strain_increment[_qp] = -Cinv_I*0.5 + Cinv_I*Cinv_I*0.25;
+  RankTwoTensor total_strain_increment = -Cinv_I*0.5 + Cinv_I*Cinv_I*0.25;
+
+  _strain_increment[_qp] = total_strain_increment;
 
   //Remove thermal expansion
   _strain_increment[_qp].addIa(-_thermal_expansion_coeff*( _T[_qp] - _T_old[_qp]));
@@ -148,8 +154,10 @@ ComputeFiniteStrain::computeQpStrain(const RankTwoTensor & Fhat)
   _rotation_increment[_qp] = R_incr.transpose();
 
   //Update strain in intermediate configuration
-  _total_strain[_qp] = _total_strain_old[_qp] + _strain_increment[_qp];
+  _mechanical_strain[_qp] = _mechanical_strain_old[_qp] + _strain_increment[_qp];
+  _total_strain[_qp] = _total_strain_old[_qp] + total_strain_increment;
 
   //Rotate strain to current configuration
+  _mechanical_strain[_qp] = _rotation_increment[_qp] * _mechanical_strain[_qp] * _rotation_increment[_qp].transpose();
   _total_strain[_qp] = _rotation_increment[_qp] * _total_strain[_qp] * _rotation_increment[_qp].transpose();
 }

--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrainElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrainElasticStress.C
@@ -39,10 +39,9 @@ ComputeFiniteStrainElasticStress::computeQpStress()
   //Rotate the stress to the current configuration
   _stress[_qp] = _rotation_increment[_qp]*intermediate_stress*_rotation_increment[_qp].transpose();
 
-  //Assign value for elastic strain, which is equal to the total strain
-  _elastic_strain[_qp] = _total_strain[_qp];
+  //Assign value for elastic strain, which is equal to the mechanical strain
+  _elastic_strain[_qp] = _mechanical_strain[_qp];
 
   //Compute dstress_dstrain
   _Jacobian_mult[_qp] = _elasticity_tensor[_qp]; //This is NOT the exact jacobian
 }
-

--- a/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress.C
@@ -16,7 +16,7 @@ InputParameters validParams<ComputeLinearElasticStress>()
 
 ComputeLinearElasticStress::ComputeLinearElasticStress(const InputParameters & parameters) :
     ComputeStressBase(parameters),
-    _total_strain(getMaterialPropertyByName<RankTwoTensor>(_base_name + "total_strain")),
+    _mechanical_strain(getMaterialPropertyByName<RankTwoTensor>(_base_name + "mechanical_strain")),
     _is_finite_strain(hasMaterialProperty<RankTwoTensor>(_base_name + "strain_increment"))
 {
   if (_is_finite_strain)
@@ -27,12 +27,11 @@ void
 ComputeLinearElasticStress::computeQpStress()
 {
   // stress = C * e
-  _stress[_qp] = _elasticity_tensor[_qp]*_total_strain[_qp];
+  _stress[_qp] = _elasticity_tensor[_qp]*_mechanical_strain[_qp];
 
-  //Assign value for elastic strain, which is equal to the total strain
-  _elastic_strain[_qp] = _total_strain[_qp];
+  //Assign value for elastic strain, which is equal to the mechanical strain
+  _elastic_strain[_qp] = _mechanical_strain[_qp];
 
   //Compute dstress_dstrain
   _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
 }
-

--- a/modules/tensor_mechanics/src/materials/ComputeSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeSmallStrain.C
@@ -33,10 +33,12 @@ ComputeSmallStrain::computeProperties()
 
     _total_strain[_qp] = ( grad_tensor + grad_tensor.transpose() )/2.0;
 
+    _mechanical_strain[_qp] = _total_strain[_qp];
+
     //Remove thermal expansion
-    _total_strain[_qp].addIa(-_thermal_expansion_coeff*( _T[_qp] - _T0 ));
+    _mechanical_strain[_qp].addIa(-_thermal_expansion_coeff*( _T[_qp] - _T0 ));
 
     //Remove the Eigen strain
-    _total_strain[_qp] -= _stress_free_strain[_qp];
+    _mechanical_strain[_qp] -= _stress_free_strain[_qp];
   }
 }

--- a/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
@@ -29,6 +29,7 @@ ComputeStrainBase::ComputeStrainBase(const InputParameters & parameters) :
     _T0(getParam<Real>("temperature_ref")),
     _thermal_expansion_coeff(getParam<Real>("thermal_expansion_coeff")),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "" ),
+    _mechanical_strain(declareProperty<RankTwoTensor>(_base_name + "mechanical_strain")),
     _total_strain(declareProperty<RankTwoTensor>(_base_name + "total_strain")),
     _stateful_displacements(getParam<bool>("stateful_displacements") && _fe_problem.isTransient())
 {
@@ -60,5 +61,6 @@ ComputeStrainBase::ComputeStrainBase(const InputParameters & parameters) :
 void
 ComputeStrainBase::initQpStatefulProperties()
 {
+  _mechanical_strain[_qp].zero();
   _total_strain[_qp].zero();
 }

--- a/modules/tensor_mechanics/src/materials/ComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStressBase.C
@@ -19,7 +19,7 @@ InputParameters validParams<ComputeStressBase>()
 ComputeStressBase::ComputeStressBase(const InputParameters & parameters) :
     DerivativeMaterialInterface<Material>(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "" ),
-    _total_strain(getMaterialPropertyByName<RankTwoTensor>(_base_name + "total_strain")),
+    _mechanical_strain(getMaterialPropertyByName<RankTwoTensor>(_base_name + "mechanical_strain")),
     _stress(declareProperty<RankTwoTensor>(_base_name + "stress")),
     _elastic_strain(declareProperty<RankTwoTensor>(_base_name + "elastic_strain")),
     _elasticity_tensor(getMaterialPropertyByName<ElasticityTensorR4>(_base_name + "elasticity_tensor")),
@@ -65,4 +65,3 @@ ComputeStressBase::computeQpProperties()
   //Add in extra stress
   _stress[_qp] += _extra_stress[_qp];
 }
-

--- a/modules/tensor_mechanics/src/materials/LinearIsoElasticPFDamage.C
+++ b/modules/tensor_mechanics/src/materials/LinearIsoElasticPFDamage.C
@@ -46,7 +46,7 @@ LinearIsoElasticPFDamage::updateVar()
   Real c = _c[_qp];
   Real xfac = std::pow(1.0-c,2.0) + _kdamage;
 
-  _total_strain[_qp].symmetricEigenvaluesEigenvectors(_eigval, _eigvec);
+  _mechanical_strain[_qp].symmetricEigenvaluesEigenvectors(_eigval, _eigvec);
 
   //Tensors of outerproduct of eigen vectors
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)


### PR DESCRIPTION
This commit changes total_strain to be the strain associated with the displacement, as is the convention.  This is required to begin to use tensor_mechanics in place of solid_mechanics.

Closes #5906
