### PR TITLE
Increase timestep display width

### DIFF
--- a/gui/vtk/ExodusResultRenderWidget.py
+++ b/gui/vtk/ExodusResultRenderWidget.py
@@ -531,8 +531,8 @@ class ExodusResultRenderWidget(QtGui.QWidget):
 
     self.time_slider_textbox = QtGui.QLineEdit()
     self.time_slider_textbox.setToolTip('Enter a number and press Enter to go to that timestep')
-    self.time_slider_textbox.setMaximumWidth(30)
-    self.time_slider_textbox.setMinimumWidth(30)
+    self.time_slider_textbox.setMaximumWidth(40)
+    self.time_slider_textbox.setMinimumWidth(40)
     self.time_slider_textbox.returnPressed.connect(self._sliderTextboxReturn)
 
     self.time_layout = QtGui.QHBoxLayout()


### PR DESCRIPTION
The timestep counter is working correctly, the textbox is just too small to display above 3 digits. Increase
the width now shows 5 digits.

(closes #5935)
