### PR TITLE
Move getMaterialProperty calls into constructor 

### DIFF
--- a/modules/heat_conduction/src/HeatConductionTimeDerivative.C
+++ b/modules/heat_conduction/src/HeatConductionTimeDerivative.C
@@ -40,16 +40,6 @@ HeatConductionTimeDerivative::HeatConductionTimeDerivative(const InputParameters
    _specific_heat(NULL),
    _density(NULL)
 {
-}
-
-void
-HeatConductionTimeDerivative::initialSetup()
-{
-  // Initialize the unity material property
-  _one.resize(_fe_problem.getMaxQps());
-  for (unsigned int i = 0; i < _one.size(); ++i)
-    _one[i] = 1;
-
   // Use the Heat Capacity based formulation
   if (_use_heat_capacity)
   {
@@ -63,6 +53,15 @@ HeatConductionTimeDerivative::initialSetup()
     _specific_heat = &getMaterialProperty<Real>("specific_heat_name");
     _density = &getMaterialProperty<Real>("density_name");
   }
+}
+
+void
+HeatConductionTimeDerivative::initialSetup()
+{
+  // Initialize the unity material property
+  _one.resize(_fe_problem.getMaxQps());
+  for (unsigned int i = 0; i < _one.size(); ++i)
+    _one[i] = 1;
 }
 
 Real


### PR DESCRIPTION
Material property existence checks are not triggered for material properties that are not gotten at construction time (e.g. pointers are fetched in `initialSetup()`). This fixes one Kernel. I'll check if there are other cases.

Refs #5859
