### PR TITLE
Various minor improvements on the console outputs for multiapps [Adding Magenta]

### DIFF
--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -26,6 +26,7 @@
 // Forward declarations
 class Checkpoint;
 class FEProblem;
+class MooseApp;
 
 /**
  * Class for storing and utilizing output objects
@@ -37,7 +38,7 @@ public:
   /**
    * Class constructor
    */
-  OutputWarehouse();
+  OutputWarehouse(MooseApp & app);
 
   /*
    * Class destructor
@@ -181,6 +182,11 @@ public:
    */
   std::ostringstream & consoleBuffer() { return _console_buffer; }
 
+  /**
+   * Set if the outputs to Console before its construction are to be buffered or to screen directly
+   * @param buffer Ture to buffer
+   */
+  void bufferConsoleOutputsBeforeConstruction(bool buffer) { _buffer_action_console_outputs = buffer; }
 
 private:
 
@@ -283,6 +289,12 @@ private:
    * before buffered content. It is private because people shouldn't be messing with it.
    */
   void flushConsoleBuffer();
+
+  /// MooseApp
+  MooseApp & _app;
+
+  /// True to buffer console outputs in actions
+  bool _buffer_action_console_outputs;
 
   /// A map of the output pointers
   std::map<OutputName, Output *> _object_map;

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -71,6 +71,12 @@ namespace Moose {
   template<>
   std::string stringify(const SolveType & t);
 
+  /**
+   * Convert execution flag type into human readable string
+   */
+  template<>
+  std::string stringify(const ExecFlagType & t);
+
 }
 
 /**

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -324,7 +324,7 @@ ActionWarehouse::executeActionsWithAction(const std::string & task)
       _console << "[DBG][ACT] "
                << "TASK (" << COLOR_YELLOW << std::setw (24) << task << COLOR_DEFAULT << ") "
                << "TYPE (" << COLOR_YELLOW << std::setw (32) << (*act_iter)->type() << COLOR_DEFAULT << ") "
-               << "NAME (" << COLOR_YELLOW << std::setw (16) << (*act_iter)->name() << COLOR_DEFAULT << ") ";
+               << "NAME (" << COLOR_YELLOW << std::setw (16) << (*act_iter)->name() << COLOR_DEFAULT << ") \n";
 
       (*act_iter)->act();
     }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -117,6 +117,7 @@ MooseApp::MooseApp(InputParameters parameters) :
     _start_time_set(false),
     _start_time(0.0),
     _global_time_offset(0.0),
+    _output_warehouse(*this),
     _input_parameter_warehouse(new InputParameterWarehouse()),
     _action_factory(*this),
     _action_warehouse(*this, _syntax, _action_factory),
@@ -136,7 +137,6 @@ MooseApp::MooseApp(InputParameters parameters) :
     _restartable_data(libMesh::n_threads()),
     _multiapp_level(0)
 {
-
   if (isParamValid("_argc") && isParamValid("_argv"))
   {
     int argc = getParam<int>("_argc");

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -149,7 +149,7 @@ EigenExecutionerBase::makeBXConsistent(Real k)
     _problem.execute(EXEC_LINEAR);
     std::stringstream ss;
     ss << std::fixed << std::setprecision(10) << _source_integral;
-    _console << " |Bx_0| = " << ss.str() << std::endl;
+    _console << "\n|Bx| = " << ss.str() << std::endl;
   }
 }
 
@@ -304,7 +304,7 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
         ss << " +================+=====================+\n" << std::flush;
         ss << std::endl;
       }
-      _console << ss.str() << std::endl;
+      _console << ss.str();
     }
 
     // increment iteration number here
@@ -431,7 +431,7 @@ EigenExecutionerBase::printEigenvalue()
   ss << " Eigenvalue = " << std::fixed << std::setprecision(10) << _eigenvalue << std::endl;
   ss << "******************************************************* " << std::endl;
 
-  _console << ss.str();
+  _console << ss.str() << std::flush;
 }
 
 EigenExecutionerBase::Chebyshev_Parameters::Chebyshev_Parameters()

--- a/framework/src/executioners/NonlinearEigen.C
+++ b/framework/src/executioners/NonlinearEigen.C
@@ -58,7 +58,7 @@ NonlinearEigen::init()
     _problem.advanceState();
 
     // free power iterations
-    _console << std::endl << " Free power iteration starts"  << std::endl;
+    _console << " Free power iteration starts"  << std::endl;
 
     Real initial_res;
     inversePowerIteration(_free_iter, _free_iter, _pfactor, false,

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -78,8 +78,6 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
   if (_solved)
     return true;
 
-  _console << "Fully Solving MultiApp " << name() << std::endl;
-
   MPI_Comm swapped = Moose::swapLibMeshComm(_my_comm);
 
   int rank;
@@ -99,8 +97,6 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
   Moose::swapLibMeshComm(swapped);
 
   _solved = true;
-
-  _console << "Finished Solving MultiApp " << name() << std::endl;
 
   return last_solve_converged;
 }

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -124,9 +124,6 @@ MultiApp::MultiApp(const InputParameters & parameters):
 
   mooseAssert(_input_files.size() == 1 || _positions.size() == _input_files.size(), "Number of positions and input files are not the same!");
 
-  // Fill in the _positions vector
-  fillPositions();
-
   if (_move_apps.size() != _move_positions.size())
     mooseError("The number of apps to move and the positions to move them to must be the same for MultiApp " << name());
 

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -587,13 +587,22 @@ Console::write(std::string message, bool indent /*=true*/)
   if (_write_file)
     _file_output_stream << message;
 
+  // Need to strip off the last new line for proper indentation
+  bool has_end_newline = (message[message.size()-1]=='\n');
+  if (has_end_newline)
+    message = message.substr(0, message.size()-1);
+
   // Apply MultiApp indenting
   if (indent && _app.multiAppLevel() > 0)
     MooseUtils::indentMessage(_app.name(), message);
 
   // Write message to the screen
   if (_write_screen)
+  {
     Moose::out << message;
+    if (has_end_newline)
+      Moose::out << "\n";
+  }
 }
 
 void

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -25,8 +25,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-OutputWarehouse::OutputWarehouse() :
+OutputWarehouse::OutputWarehouse(MooseApp & app) :
     Warehouse<Output>(),
+    _app(app),
+    _buffer_action_console_outputs(true),
     _output_exec_flag(EXEC_CUSTOM),
     _force_output(false)
 {
@@ -177,6 +179,19 @@ OutputWarehouse::mooseConsole()
     // Reset
     _console_buffer.clear();
     _console_buffer.str("");
+  }
+  else
+  {
+    if (!_buffer_action_console_outputs)
+    {
+      // this will cause messages to console before its construction immediately flushed and cleared.
+      std::string message = _console_buffer.str();
+      if (_app.multiAppLevel() > 0)
+        MooseUtils::indentMessage(_app.name(), message);
+      Moose::out << message;
+      _console_buffer.clear();
+      _console_buffer.str("");
+    }
   }
 }
 

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -206,6 +206,25 @@ namespace Moose {
     }
     return "";
   }
+
+  template<>
+  std::string stringify(const ExecFlagType & t)
+  {
+    switch (t)
+    {
+    case EXEC_INITIAL:        return "INITIAL";
+    case EXEC_LINEAR:         return "LINEAR";
+    case EXEC_NONLINEAR:      return "NONLINEAR";
+    case EXEC_TIMESTEP_END:   return "TIMESTEP_END";
+    case EXEC_TIMESTEP_BEGIN: return "TIMESTEP_BEGIN";
+    case EXEC_CUSTOM:         return "CUSTOM";
+    case EXEC_FINAL:          return "FINAL";
+    case EXEC_FORCED:         return "FORCED";
+    case EXEC_FAILED:         return "FAILED";
+    case EXEC_NONE:           return "NONE";
+    }
+    return "";
+  }
 }
 
 Point toPoint(const std::vector<Real> & pos)

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -355,8 +355,8 @@ indentMessage(const std::string & prefix, std::string & message, const char* col
   // The colored prefix
   std::string indent = color + prefix + ": " + COLOR_DEFAULT;
 
-  // Indent all lines after the first
-  pcrecpp::RE re("\n(?!\\Z)");
+  // Indent all lines
+  pcrecpp::RE re("\n");
   re.GlobalReplace(std::string("\n") + indent, &message);
 
   // Prepend indent string at the front of the message


### PR DESCRIPTION
This makes the screen cleaner...

I do not know why I need a flush in `EigenExecutionerBase::printEigenvalue()`, otherwise the output is delayed randomly.

Also I make some of print-outs in magenta color to highlight the execution of multiapps.

Referring #5956.
