### PR TITLE
Convert NS kernels to use default coupling system

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -923,6 +923,19 @@ public:
    */
   virtual void computeAuxiliaryKernels(const ExecFlagType & type);
 
+public:
+
+  ///@{
+  /**
+   * Convenience zeros
+   * @see ZeroInterface
+   */
+  std::vector<Real> _real_zero;
+  std::vector<VariableValue> _zero;
+  std::vector<VariableGradient> _grad_zero;
+  std::vector<VariableSecond> _second_zero;
+  std::vector<VariablePhiSecond> _second_phi_zero;
+  ///@}
 
 protected:
   MooseMesh & _mesh;

--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -295,16 +295,6 @@ public:
    */
   virtual void registerRestartableData(std::string name, RestartableDataValue * data, THREAD_ID tid);
 
-public:
-  /**
-   * Convenience zeros
-   */
-  std::vector<Real> _real_zero;
-  std::vector<VariableValue> _zero;
-  std::vector<VariableGradient> _grad_zero;
-  std::vector<VariableSecond> _second_zero;
-  std::vector<VariablePhiSecond> _second_phi_zero;
-
 protected:
   /// The Factory for building objects
   Factory & _factory;

--- a/framework/include/base/ZeroInterface.h
+++ b/framework/include/base/ZeroInterface.h
@@ -20,7 +20,7 @@
 #include "ParallelUniqueId.h"
 #include "libmesh/libmesh_common.h"
 
-class SubProblem;
+class FEProblem;
 
 /**
  * Interface to bring zero values inside objects
@@ -38,7 +38,7 @@ public:
   ZeroInterface(const InputParameters & parameters);
 
 protected:
-  SubProblem & _zi_subproblem;
+  FEProblem & _zi_feproblem;
   THREAD_ID _zi_tid;
   const Real & _real_zero;
   VariableValue & _zero;

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -267,23 +267,6 @@ DisplacedProblem::reinitDirac(const Elem * elem, THREAD_ID tid)
 
   if (n_points)
   {
-    unsigned int max_qps = _mproblem.getMaxQps();
-
-    if (n_points > max_qps)
-    {
-      /**
-       * The maximum number of qps can rise if several Dirac points are added to a single element.
-       * In that case we need to resize the zeros to compensate.
-       */
-      for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
-      {
-        _zero[tid].resize(max_qps, 0);
-        _grad_zero[tid].resize(max_qps, 0);
-        _second_zero[tid].resize(max_qps, RealTensor(0.));
-        _second_phi_zero[tid].resize(max_qps, std::vector<RealTensor>(_mproblem.getMaxShapeFunctions(), RealTensor(0.)));
-      }
-    }
-
     _assembly[tid]->reinitAtPhysical(elem, points);
 
     _displaced_nl.prepare(tid);

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -155,6 +155,12 @@ FEProblem::FEProblem(const InputParameters & parameters) :
 
   unsigned int n_threads = libMesh::n_threads();
 
+  _real_zero.resize(n_threads, 0.);
+  _zero.resize(n_threads);
+  _grad_zero.resize(n_threads);
+  _second_zero.resize(n_threads);
+  _second_phi_zero.resize(n_threads);
+
   _assembly.resize(n_threads);
   for (unsigned int i = 0; i < n_threads; ++i)
     _assembly[i] = new Assembly(_nl, couplingMatrix(), i);
@@ -228,6 +234,11 @@ FEProblem::~FEProblem()
     delete _material_data[i];
     delete _bnd_material_data[i];
     delete _neighbor_material_data[i];
+
+    _zero[i].release();
+    _grad_zero[i].release();
+    _second_zero[i].release();
+    _second_phi_zero[i].release();
   }
 
   delete &_nl;
@@ -924,7 +935,7 @@ FEProblem::reinitDirac(const Elem * elem, THREAD_ID tid)
       for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
       {
         _zero[tid].resize(getMaxQps(), 0);
-        _grad_zero[tid].resize(getMaxQps(), 0);
+        _grad_zero[tid].resize(getMaxQps(), RealGradient(0.));
         _second_zero[tid].resize(getMaxQps(), RealTensor(0.));
         _second_phi_zero[tid].resize(getMaxQps(), std::vector<RealTensor>(getMaxShapeFunctions(), RealTensor(0.)));
       }
@@ -3066,7 +3077,7 @@ FEProblem::createQRules(QuadratureType type, Order order, Order volume_order, Or
   for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
   {
     _zero[tid].resize(getMaxQps(), 0);
-    _grad_zero[tid].resize(getMaxQps(), 0);
+    _grad_zero[tid].resize(getMaxQps(), RealGradient(0.));
     _second_zero[tid].resize(getMaxQps(), RealTensor(0.));
     _second_phi_zero[tid].resize(getMaxQps(), std::vector<RealTensor>(getMaxShapeFunctions(), RealTensor(0.)));
   }

--- a/framework/src/base/SubProblem.C
+++ b/framework/src/base/SubProblem.C
@@ -36,25 +36,12 @@ SubProblem::SubProblem(const InputParameters & parameters) :
     _rz_coord_axis(1) // default to RZ rotation around y-axis
 {
   unsigned int n_threads = libMesh::n_threads();
-  _real_zero.resize(n_threads, 0.);
-  _zero.resize(n_threads);
-  _grad_zero.resize(n_threads);
-  _second_zero.resize(n_threads);
-  _second_phi_zero.resize(n_threads);
   _active_elemental_moose_variables.resize(n_threads);
   _has_active_elemental_moose_variables.resize(n_threads);
 }
 
 SubProblem::~SubProblem()
 {
-  unsigned int n_threads = libMesh::n_threads();
-  for (unsigned int i = 0; i < n_threads; i++)
-  {
-    _zero[i].release();
-    _grad_zero[i].release();
-    _second_zero[i].release();
-    _second_phi_zero[i].release();
-  }
 }
 
 void

--- a/framework/src/base/ZeroInterface.C
+++ b/framework/src/base/ZeroInterface.C
@@ -13,15 +13,15 @@
 /****************************************************************/
 
 #include "ZeroInterface.h"
-#include "SubProblem.h"
+#include "FEProblem.h"
 
 ZeroInterface::ZeroInterface(const InputParameters & parameters) :
-    _zi_subproblem(*parameters.get<SubProblem *>("_subproblem")),
+    _zi_feproblem(*parameters.get<FEProblem *>("_fe_problem")),
     _zi_tid(parameters.get<THREAD_ID>("_tid")),
-    _real_zero(_zi_subproblem._real_zero[_zi_tid]),
-    _zero(_zi_subproblem._zero[_zi_tid]),
-    _grad_zero(_zi_subproblem._grad_zero[_zi_tid]),
-    _second_zero(_zi_subproblem._second_zero[_zi_tid]),
-    _second_phi_zero(_zi_subproblem._second_phi_zero[_zi_tid])
+    _real_zero(_zi_feproblem._real_zero[_zi_tid]),
+    _zero(_zi_feproblem._zero[_zi_tid]),
+    _grad_zero(_zi_feproblem._grad_zero[_zi_tid]),
+    _second_zero(_zi_feproblem._second_zero[_zi_tid]),
+    _second_phi_zero(_zi_feproblem._second_phi_zero[_zi_tid])
 {
 }

--- a/modules/navier_stokes/src/kernels/INSMass.C
+++ b/modules/navier_stokes/src/kernels/INSMass.C
@@ -13,8 +13,8 @@ InputParameters validParams<INSMass>()
 
   // Coupled variables
   params.addRequiredCoupledVar("u", "x-velocity");
-  params.addCoupledVar("v", "y-velocity"); // only required in 2D and 3D
-  params.addCoupledVar("w", "z-velocity"); // only required in 3D
+  params.addCoupledVar("v", 0, "y-velocity"); // only required in 2D and 3D
+  params.addCoupledVar("w", 0, "z-velocity"); // only required in 3D
   params.addRequiredCoupledVar("p", "pressure");
 
   return params;
@@ -27,13 +27,13 @@ INSMass::INSMass(const InputParameters & parameters) :
 
   // Gradients
   _grad_u_vel(coupledGradient("u")),
-  _grad_v_vel(_mesh.dimension() >= 2 ? coupledGradient("v") : _grad_zero),
-  _grad_w_vel(_mesh.dimension() == 3 ? coupledGradient("w") : _grad_zero),
+  _grad_v_vel(coupledGradient("v")),
+  _grad_w_vel(coupledGradient("w")),
 
   // Variable numberings
   _u_vel_var_number(coupled("u")),
-  _v_vel_var_number(_mesh.dimension() >= 2 ? coupled("v") : libMesh::invalid_uint),
-  _w_vel_var_number(_mesh.dimension() == 3 ? coupled("w") : libMesh::invalid_uint),
+  _v_vel_var_number(coupled("v")),
+  _w_vel_var_number(coupled("w")),
   _p_var_number(coupled("p"))
 {
 }
@@ -73,4 +73,3 @@ Real INSMass::computeQpOffDiagJacobian(unsigned jvar)
   else
     return 0;
 }
-

--- a/modules/navier_stokes/src/kernels/INSMomentum.C
+++ b/modules/navier_stokes/src/kernels/INSMomentum.C
@@ -13,8 +13,8 @@ InputParameters validParams<INSMomentum>()
 
   // Coupled variables
   params.addRequiredCoupledVar("u", "x-velocity");
-  params.addCoupledVar("v", "y-velocity"); // only required in 2D and 3D
-  params.addCoupledVar("w", "z-velocity"); // only required in 3D
+  params.addCoupledVar("v", 0, "y-velocity"); // only required in 2D and 3D
+  params.addCoupledVar("w", 0, "z-velocity"); // only required in 3D
   params.addRequiredCoupledVar("p", "pressure");
 
   // Required parameters
@@ -33,19 +33,19 @@ INSMomentum::INSMomentum(const InputParameters & parameters) :
 
   // Coupled variables
   _u_vel(coupledValue("u")),
-  _v_vel(_mesh.dimension() >= 2 ? coupledValue("v") : _zero),
-  _w_vel(_mesh.dimension() == 3 ? coupledValue("w") : _zero),
+  _v_vel(coupledValue("v")),
+  _w_vel(coupledValue("w")),
   _p(coupledValue("p")),
 
   // Gradients
   _grad_u_vel(coupledGradient("u")),
-  _grad_v_vel(_mesh.dimension() >= 2 ? coupledGradient("v") : _grad_zero),
-  _grad_w_vel(_mesh.dimension() == 3 ? coupledGradient("w") : _grad_zero),
+  _grad_v_vel(coupledGradient("v")),
+  _grad_w_vel(coupledGradient("w")),
 
   // Variable numberings
   _u_vel_var_number(coupled("u")),
-  _v_vel_var_number(_mesh.dimension() >= 2 ? coupled("v") : libMesh::invalid_uint),
-  _w_vel_var_number(_mesh.dimension() == 3 ? coupled("w") : libMesh::invalid_uint),
+  _v_vel_var_number(coupled("v")),
+  _w_vel_var_number(coupled("w")),
   _p_var_number(coupled("p")),
 
   // Required parameters
@@ -171,4 +171,3 @@ Real INSMomentum::computeQpOffDiagJacobian(unsigned jvar)
   else
     return 0;
 }
-


### PR DESCRIPTION
Without this change these kerenls seg. fault in 2D, the _grad_w_vel is not size properly with _qp (_grad_w_vel.size() = 0). I am not sure why this happens, but using the default system fixes the problem.

(closes #5959)
