### PR TITLE
Fix EBSDReader interfaces that allocate memory.

### DIFF
--- a/modules/phase_field/include/auxkernels/TestEBSDAux.h
+++ b/modules/phase_field/include/auxkernels/TestEBSDAux.h
@@ -35,7 +35,7 @@ protected:
   MooseEnum _data_name;
 
   /// Accessor functor to fetch the selected data field form the EBSD data point
-  EBSDPointDataFunctor * _val;
+  MooseSharedPointer<EBSDPointDataFunctor> _val;
 };
 
 #endif //TESTEBSDAUX_H

--- a/modules/phase_field/include/userobjects/EBSDReader.h
+++ b/modules/phase_field/include/userobjects/EBSDReader.h
@@ -96,9 +96,9 @@ public:
   unsigned int getGlobalID(unsigned int phase, unsigned int local_id) const { return _global_id[phase][local_id]; }
 
   /// Factory function to return a point functor specified by name
-  EBSDPointDataFunctor * getPointDataAccessFunctor(const MooseEnum & field_name) const;
+  MooseSharedPointer<EBSDPointDataFunctor> getPointDataAccessFunctor(const MooseEnum & field_name) const;
   /// Factory function to return a average functor specified by name
-  EBSDAvgDataFunctor * getAvgDataAccessFunctor(const MooseEnum & field_name) const;
+  MooseSharedPointer<EBSDAvgDataFunctor> getAvgDataAccessFunctor(const MooseEnum & field_name) const;
 
   /**
    * Returns a map consisting of the node index followd by

--- a/modules/phase_field/src/auxkernels/TestEBSDAux.C
+++ b/modules/phase_field/src/auxkernels/TestEBSDAux.C
@@ -26,7 +26,6 @@ TestEBSDAux::TestEBSDAux(const InputParameters & parameters) :
 
 TestEBSDAux::~TestEBSDAux()
 {
-  delete _val;
 }
 
 Real

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -331,56 +331,94 @@ EBSDReader::buildNodeWeightMaps()
   }
 }
 
-EBSDAccessFunctors::EBSDPointDataFunctor *
+MooseSharedPointer<EBSDAccessFunctors::EBSDPointDataFunctor>
 EBSDReader::getPointDataAccessFunctor(const MooseEnum & field_name) const
 {
+  EBSDPointDataFunctor * ret_val = NULL;
+
   switch (field_name)
   {
     case 0: // phi1
-      return new EBSDPointDataPhi1();
+      ret_val = new EBSDPointDataPhi1();
+      break;
     case 1: // phi
-      return new EBSDPointDataPhi();
+      ret_val = new EBSDPointDataPhi();
+      break;
     case 2: // phi2
-      return new EBSDPointDataPhi2();
+      ret_val = new EBSDPointDataPhi2();
+      break;
     case 3: // grain
-      return new EBSDPointDataGrain();
+      ret_val = new EBSDPointDataGrain();
+      break;
     case 4: // phase
-      return new EBSDPointDataPhase();
+      ret_val = new EBSDPointDataPhase();
+      break;
     case 5: // symmetry
-      return new EBSDPointDataSymmetry();
+      ret_val = new EBSDPointDataSymmetry();
+      break;
     case 6: // op
-      return new EBSDPointDataOp();
+      ret_val = new EBSDPointDataOp();
+      break;
+    default:
+    {
+      // check for custom columns
+      for (unsigned int i = 0; i < _custom_columns; ++i)
+        if (field_name == "CUSTOM" + Moose::stringify(i))
+        {
+          ret_val = new EBSDPointDataCustom(i);
+          break;
+        }
+    }
   }
 
-  // check for custom columns
-  for (unsigned int i = 0; i < _custom_columns; ++i)
-    if (field_name == "CUSTOM" + Moose::stringify(i))
-      return new EBSDPointDataCustom(i);
+  // If ret_val was not set by any of the above cases, throw an error.
+  if (!ret_val)
+    mooseError("Error:  Please input supported EBSD_param");
 
-  mooseError("Error:  Please input supported EBSD_param");
+  // If we made it here, wrap up the the ret_val in a
+  // MooseSharedPointer and ship it off.
+  return MooseSharedPointer<EBSDPointDataFunctor>(ret_val);
 }
 
-EBSDAccessFunctors::EBSDAvgDataFunctor *
+MooseSharedPointer<EBSDAccessFunctors::EBSDAvgDataFunctor>
 EBSDReader::getAvgDataAccessFunctor(const MooseEnum & field_name) const
 {
+  EBSDAvgDataFunctor * ret_val = NULL;
+
   switch (field_name)
   {
     case 0: // phi1
-      return new EBSDAvgDataPhi1();
+      ret_val = new EBSDAvgDataPhi1();
+      break;
     case 1: // phi
-      return new EBSDAvgDataPhi();
+      ret_val = new EBSDAvgDataPhi();
+      break;
     case 2: // phi2
-      return new EBSDAvgDataPhi2();
+      ret_val = new EBSDAvgDataPhi2();
+      break;
     case 3: // phase
-      return new EBSDAvgDataPhase();
+      ret_val = new EBSDAvgDataPhase();
+      break;
     case 4: // symmetry
-      return new EBSDAvgDataSymmetry();
+      ret_val = new EBSDAvgDataSymmetry();
+      break;
+    default:
+    {
+      // check for custom columns
+      for (unsigned int i = 0; i < _custom_columns; ++i)
+        if (field_name == "CUSTOM" + Moose::stringify(i))
+        {
+          ret_val = new EBSDAvgDataCustom(i);
+          break;
+        }
+    }
   }
 
-  // check for custom columns
-  for (unsigned int i = 0; i < _custom_columns; ++i)
-    if (field_name == "CUSTOM" + Moose::stringify(i))
-      return new EBSDAvgDataCustom(i);
+  // If ret_val was not set by any of the above cases, throw an error.
+  if (!ret_val)
+    mooseError("Error:  Please input supported EBSD_param");
 
-  mooseError("Error:  Please input supported EBSD_param");
+  // If we made it here, wrap up the the ret_val in a
+  // MooseSharedPointer and ship it off.
+  return MooseSharedPointer<EBSDAvgDataFunctor>(ret_val);
 }


### PR DESCRIPTION
getPointDataAccessFunctor() and getAvgDataAccessFunctor() allocate
memory, so it should be managed by a MooseSharedPointer.

Refs #6007.
