### PR TITLE
ICEUpdater requires a reasonably new version of TBB

### DIFF
--- a/framework/contrib/ice_updater/include/Updater.h
+++ b/framework/contrib/ice_updater/include/Updater.h
@@ -43,6 +43,7 @@
 #include "MooseError.h"
 
 #ifdef LIBMESH_HAVE_TBB_API
+#if !TBB_VERSION_LESS_THAN(4,0)
 #include <tbb/mutex.h>
 #include <tbb/concurrent_queue.h>
 
@@ -375,6 +376,7 @@ public:
   void updateProgress(int) {}
 };
 
+#endif // #if !TBB_VERSION_LESS_THAN(4,0)
 #endif // LIBMESH_HAVE_TBB_API
 
 #endif

--- a/framework/contrib/ice_updater/src/Updater.cpp
+++ b/framework/contrib/ice_updater/src/Updater.cpp
@@ -37,6 +37,7 @@
 #include "LibcurlUtils.h"
 
 #ifdef LIBMESH_HAVE_TBB_API
+#if !TBB_VERSION_LESS_THAN(4,0)
 #include <tbb/tick_count.h>
 #include <tbb/tbb_thread.h>
 
@@ -602,4 +603,5 @@ void Updater::initialize(std::string propertyString)
     errorLoggerPtr->dumpErrors();
 }
 
+#endif // #if !TBB_VERSION_LESS_THAN(4,0)
 #endif // LIBMESH_HAVE_TBB_API

--- a/framework/include/outputs/ICEUpdater.h
+++ b/framework/include/outputs/ICEUpdater.h
@@ -23,6 +23,7 @@
 
 // Currently the ICE Updater requires TBB
 #ifdef LIBMESH_HAVE_TBB_API
+#if !TBB_VERSION_LESS_THAN(4,0)
 
 // Forward declarations
 class ICEUpdater;
@@ -71,4 +72,5 @@ protected:
 
 #endif
 
+#endif // #if !TBB_VERSION_LESS_THAN(4,0)
 #endif // LIBMESH_HAVE_TBB_API

--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -180,7 +180,6 @@ private:
 
   /// Create a console stream object for this helper class
   ConsoleStream _is_console;
-
 };
 
 #endif // IMAGESAMPLER_H

--- a/framework/src/outputs/ICEUpdater.C
+++ b/framework/src/outputs/ICEUpdater.C
@@ -20,6 +20,7 @@
 
 // Currently the ICE Updater requires TBB
 #ifdef LIBMESH_HAVE_TBB_API
+#if !TBB_VERSION_LESS_THAN(4,0)
 
 template<>
 InputParameters validParams<ICEUpdater>()
@@ -100,4 +101,5 @@ void ICEUpdater::outputPostprocessors()
   }
 }
 
+#endif // #if !TBB_VERSION_LESS_THAN(4,0)
 #endif // LIBMESH_HAVE_TBB_API

--- a/framework/src/utils/ImageSampler.C
+++ b/framework/src/utils/ImageSampler.C
@@ -72,6 +72,10 @@ ImageSampler::~ImageSampler()
 void
 ImageSampler::setupImageSampler(MooseMesh & mesh)
 {
+  // Don't warn that mesh or _is_pars are unused when VTK is not enabled.
+  libmesh_ignore(mesh);
+  libmesh_ignore(_is_pars);
+
 #ifdef LIBMESH_HAVE_VTK
   // Get access to the Mesh object
   MeshTools::BoundingBox bbox = MeshTools::bounding_box(mesh.getMesh());

--- a/framework/src/utils/RayTracing.C
+++ b/framework/src/utils/RayTracing.C
@@ -176,7 +176,7 @@ void recursivelyFindElementsIntersectedByLine(const LineSegment & line_segment, 
   return;
 }
 
-void elementsIntersectedByLine(const Point & p0, const Point & p1, const MeshBase & mesh, MooseSharedPointer<PointLocatorBase> & point_locator, std::vector<Elem *> & intersected_elems, std::vector<LineSegment> & segments)
+void elementsIntersectedByLine(const Point & p0, const Point & p1, const MeshBase & /*mesh*/, MooseSharedPointer<PointLocatorBase> & point_locator, std::vector<Elem *> & intersected_elems, std::vector<LineSegment> & segments)
 {
   // Make sure our list is clear
   intersected_elems.clear();


### PR DESCRIPTION
Based on this [mailing list discussion](https://groups.google.com/d/msgid/moose-users/CALB3W8EajfemukSoKWqoQAqk6AGknv%2B%3D9OzWfftJVvGhR%2BCHdg%40mail.gmail.com?utm_medium=email&utm_source=footer), we know that the ICEUpdater fails to compile with TBB 2.2 (released in August, 2009) so we need to guard it from being compiled with older TBBs.  This in turn requires a libmesh update, since we were never looking for TBB versions in libmesh in the past.

The following is a brief summary of changes in this libmesh update:
- Extract TBB_VERSION_{MAJOR,MINOR} from tbb_stddef.h.
- Fix bug in DenseMatrix::svd().
- Fix 64-bit indices regression.
- Brought historical libmesh commits into the current repo.
- Use C++11 "override" feature when possible.
- Remove ancient quadrature/quadrature_rules.h and geom/elem_type.h
- Fix "infinite recursion" warning in GetPot.
- Fixes for non-standard VTK installs (arch linux).
- Allow refinement "between" higher/lower-order elements.
- Allow "if (foo)" syntax for AutoPtr when --disable-unique-ptr.
- Use full precision on all ASCII XDA output.
