### PR TITLE
Rebuild node maps on mesh change

### DIFF
--- a/modules/phase_field/include/userobjects/EBSDReader.h
+++ b/modules/phase_field/include/userobjects/EBSDReader.h
@@ -112,6 +112,9 @@ public:
    */
   const std::map<dof_id_type, std::vector<Real> > & getNodeToPhaseWeightMap() const;
 
+  /// Maps need to be updated when the mesh changes
+  void meshChanged();
+
 protected:
   // MooseMesh Variables
   MooseMesh & _mesh;
@@ -146,6 +149,9 @@ protected:
 
   /// Map of phase weights per node
   std::map<dof_id_type, std::vector<Real> > _node_to_phase_weight_map;
+
+  /// current timestep. Maps are only rebuild on mesh change during time step zero
+  const int & _time_step;
 
   /// Dimension of the problem domain
   unsigned int _mesh_dimension;

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -23,6 +23,7 @@ EBSDReader::EBSDReader(const InputParameters & params) :
     _nl(_fe_problem.getNonlinearSystem()),
     _feature_num(0),
     _custom_columns(getParam<unsigned int>("custom_columns")),
+    _time_step(_fe_problem.timeStep()),
     _mesh_dimension(_mesh.dimension()),
     _nx(0),
     _ny(0),
@@ -291,6 +292,14 @@ EBSDReader::getNodeToPhaseWeightMap() const
 {
   return _node_to_phase_weight_map;
 }
+
+void
+EBSDReader::meshChanged()
+{
+  // maps are only rebuild for use in initial conditions, which happens in time step zero
+  if (_time_step == 0)
+    buildNodeWeightMaps();
+};
 
 void
 EBSDReader::buildNodeWeightMaps()


### PR DESCRIPTION
This fixes the utter brokenness of nodal weight maps in simulations with initial refinement.
Ping @frombs.

Closes #6016.
