### PR TITLE
Console improvements

### DIFF
--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -33,7 +33,7 @@ public:
   /**
    * Class constructor
    */
-  OutputWarehouse();
+  OutputWarehouse(MooseApp & app);
 
   /*
    * Class destructor
@@ -177,6 +177,11 @@ public:
    */
   std::ostringstream & consoleBuffer() { return _console_buffer; }
 
+  /**
+   * Set if the outputs to Console before its construction are to be buffered or to screen directly
+   * @param buffer Ture to buffer
+   */
+  void bufferConsoleOutputsBeforeConstruction(bool buffer) { _buffer_action_console_outputs = buffer; }
 
 private:
 
@@ -279,6 +284,12 @@ private:
    * before buffered content. It is private because people shouldn't be messing with it.
    */
   void flushConsoleBuffer();
+
+  /// MooseApp
+  MooseApp & _app;
+
+  /// True to buffer console outputs in actions
+  bool _buffer_action_console_outputs;
 
   /// A map of the output pointers
   std::map<OutputName, Output *> _object_map;

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -324,7 +324,7 @@ ActionWarehouse::executeActionsWithAction(const std::string & task)
       _console << "[DBG][ACT] "
                << "TASK (" << COLOR_YELLOW << std::setw (24) << task << COLOR_DEFAULT << ") "
                << "TYPE (" << COLOR_YELLOW << std::setw (32) << (*act_iter)->type() << COLOR_DEFAULT << ") "
-               << "NAME (" << COLOR_YELLOW << std::setw (16) << (*act_iter)->name() << COLOR_DEFAULT << ") ";
+               << "NAME (" << COLOR_YELLOW << std::setw (16) << (*act_iter)->name() << COLOR_DEFAULT << ") \n";
 
       (*act_iter)->act();
     }

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -516,7 +516,7 @@ void FEProblem::initialSetup()
 
   // Call initialSetup on the MultiApps
   if (_has_multiapps)
-    _console << COLOR_MAGENTA << "Initializing MultiApps" << COLOR_DEFAULT << std::endl;
+    _console << COLOR_CYAN << "Initializing MultiApps" << COLOR_DEFAULT << std::endl;
   _multi_apps(EXEC_LINEAR)[0].initialSetup();
   _multi_apps(EXEC_NONLINEAR)[0].initialSetup();
   _multi_apps(EXEC_TIMESTEP_END)[0].initialSetup();
@@ -524,7 +524,7 @@ void FEProblem::initialSetup()
   _multi_apps(EXEC_INITIAL)[0].initialSetup();
   _multi_apps(EXEC_CUSTOM)[0].initialSetup();
   if (_has_multiapps)
-    _console << COLOR_MAGENTA << "Finished Initializing MultiApps" << COLOR_DEFAULT << std::endl;
+    _console << COLOR_CYAN << "Finished Initializing MultiApps" << COLOR_DEFAULT << std::endl;
 
   // Call initialSetup on the transfers
   _transfers(EXEC_LINEAR)[0].initialSetup();
@@ -2785,7 +2785,7 @@ FEProblem::execMultiApps(ExecFlagType type, bool auto_advance)
     std::vector<Transfer *> transfers = _to_multi_app_transfers(type)[0].all();
     if (transfers.size())
     {
-      _console << COLOR_MAGENTA << "Starting Transfers on " <<  Moose::stringify(type) << " To MultiApps" << COLOR_DEFAULT << std::endl;
+      _console << COLOR_CYAN << "Starting Transfers on " <<  Moose::stringify(type) << " To MultiApps" << COLOR_DEFAULT << std::endl;
       for (unsigned int i=0; i<transfers.size(); i++)
       {
         Moose::perf_log.push(transfers[i]->name(), "Transfers");
@@ -2793,28 +2793,28 @@ FEProblem::execMultiApps(ExecFlagType type, bool auto_advance)
         Moose::perf_log.pop(transfers[i]->name(), "Transfers");
       }
 
-      _console << "Waiting For Transfers To Finish" << std::endl;
+      _console << "Waiting For Transfers To Finish" << '\n';
       MooseUtils::parallelBarrierNotify(_communicator);
 
-      _console << COLOR_MAGENTA << "Transfers on " <<  Moose::stringify(type) << " Are Finished" << COLOR_DEFAULT << std::endl;
+      _console << COLOR_CYAN << "Transfers on " <<  Moose::stringify(type) << " Are Finished" << COLOR_DEFAULT << std::endl;
     }
     else
     {
       if (multi_apps.size())
-        _console << COLOR_MAGENTA << "No Transfers on " <<  Moose::stringify(type) << " To MultiApps" << COLOR_DEFAULT << std::endl;
+        _console << COLOR_CYAN << "No Transfers on " <<  Moose::stringify(type) << " To MultiApps" << COLOR_DEFAULT << std::endl;
     }
   }
 
   if (multi_apps.size())
   {
-    _console << COLOR_MAGENTA << "Executing MultiApps on " <<  Moose::stringify(type) << COLOR_DEFAULT << std::endl;
+    _console << COLOR_CYAN << "Executing MultiApps on " <<  Moose::stringify(type) << COLOR_DEFAULT << std::endl;
 
     bool success = true;
 
     for (unsigned int i=0; success && i<multi_apps.size(); i++)
       success = multi_apps[i]->solveStep(_dt, _time, auto_advance);
 
-    _console << "Waiting For Other Processors To Finish" << std::endl;
+    _console << "Waiting For Other Processors To Finish" << '\n';
     MooseUtils::parallelBarrierNotify(_communicator);
 
     _communicator.max(success);
@@ -2822,7 +2822,7 @@ FEProblem::execMultiApps(ExecFlagType type, bool auto_advance)
     if (!success)
       return false;
 
-    _console << COLOR_MAGENTA << "Finished Executing MultiApps on " <<  Moose::stringify(type) << COLOR_DEFAULT << std::endl;
+    _console << COLOR_CYAN << "Finished Executing MultiApps on " <<  Moose::stringify(type) << COLOR_DEFAULT << std::endl;
   }
 
   // Execute Transfers _from_ MultiApps
@@ -2830,7 +2830,7 @@ FEProblem::execMultiApps(ExecFlagType type, bool auto_advance)
     std::vector<Transfer *> transfers = _from_multi_app_transfers(type)[0].all();
     if (transfers.size())
     {
-      _console << COLOR_MAGENTA << "Starting Transfers on " <<  Moose::stringify(type) << " From MultiApps" << COLOR_DEFAULT << std::endl;
+      _console << COLOR_CYAN << "Starting Transfers on " <<  Moose::stringify(type) << " From MultiApps" << COLOR_DEFAULT << std::endl;
       for (unsigned int i=0; i<transfers.size(); i++)
       {
         Moose::perf_log.push(transfers[i]->name(), "Transfers");
@@ -2838,16 +2838,13 @@ FEProblem::execMultiApps(ExecFlagType type, bool auto_advance)
         Moose::perf_log.pop(transfers[i]->name(), "Transfers");
       }
 
-      _console << "Waiting For Transfers To Finish" << std::endl;
+      _console << "Waiting For Transfers To Finish" << '\n';
       MooseUtils::parallelBarrierNotify(_communicator);
 
-      _console << COLOR_MAGENTA << "Transfers " << Moose::stringify(type) << " Are Finished" << COLOR_DEFAULT << std::endl;
+      _console << COLOR_CYAN << "Transfers " << Moose::stringify(type) << " Are Finished" << COLOR_DEFAULT << std::endl;
     }
-    else
-    {
-      if (multi_apps.size())
-        _console << COLOR_MAGENTA << "No Transfers on " <<  Moose::stringify(type) << " From MultiApps" << COLOR_DEFAULT << std::endl;
-    }
+    else if (multi_apps.size())
+      _console << COLOR_CYAN << "No Transfers on " <<  Moose::stringify(type) << " From MultiApps" << COLOR_DEFAULT << std::endl;
   }
 
   // If we made it here then everything passed

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -119,6 +119,7 @@ MooseApp::MooseApp(InputParameters parameters) :
     _start_time_set(false),
     _start_time(0.0),
     _global_time_offset(0.0),
+    _output_warehouse(*this),
     _input_parameter_warehouse(new InputParameterWarehouse()),
     _action_factory(*this),
     _action_warehouse(*this, _syntax, _action_factory),
@@ -138,7 +139,6 @@ MooseApp::MooseApp(InputParameters parameters) :
     _restartable_data(libMesh::n_threads()),
     _multiapp_level(0)
 {
-
   if (isParamValid("_argc") && isParamValid("_argv"))
   {
     int argc = getParam<int>("_argc");

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -170,10 +170,10 @@ void
 MooseApp::setupOptions()
 {
   // Print the header, this is as early as possible
-  std::string hdr = header();
+  std::string hdr(header() + "\n");
   if (multiAppLevel() > 0)
     MooseUtils::indentMessage(_name, hdr);
-  Moose::out << hdr << std::endl;
+  Moose::out << hdr << std::flush;
 
   if (getParam<bool>("error_unused"))
     setCheckUnusedFlag(true);

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -149,7 +149,7 @@ EigenExecutionerBase::makeBXConsistent(Real k)
     _problem.execute(EXEC_LINEAR);
     std::stringstream ss;
     ss << std::fixed << std::setprecision(10) << _source_integral;
-    _console << " |Bx_0| = " << ss.str() << std::endl;
+    _console << "\n|Bx| = " << ss.str() << std::endl;
   }
 }
 
@@ -304,7 +304,7 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
         ss << " +================+=====================+\n" << std::flush;
         ss << std::endl;
       }
-      _console << ss.str() << std::endl;
+      _console << ss.str();
     }
 
     // increment iteration number here
@@ -431,7 +431,7 @@ EigenExecutionerBase::printEigenvalue()
   ss << " Eigenvalue = " << std::fixed << std::setprecision(10) << _eigenvalue << std::endl;
   ss << "******************************************************* " << std::endl;
 
-  _console << ss.str();
+  _console << ss.str() << std::flush;
 }
 
 EigenExecutionerBase::Chebyshev_Parameters::Chebyshev_Parameters()

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -213,8 +213,8 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
 
   if (echo)
   {
-    _console << std::endl;
-    _console << " Power iterations starts" << std::endl;
+    _console << '\n';
+    _console << " Power iterations starts\n";
     _console << " ________________________________________________________________________________ " << std::endl;
   }
 
@@ -268,7 +268,7 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
       std::stringstream ss;
       if (solution_diff)
       {
-        ss << std::endl;
+        ss << '\n';
         ss << " +================+=====================+=====================+\n";
         ss << " | iteration      | eigenvalue          | solution_difference |\n";
         ss << " +================+=====================+=====================+\n";
@@ -287,7 +287,7 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
       }
       else
       {
-        ss << std::endl;
+        ss << '\n';
         ss << " +================+=====================+\n";
         ss << " | iteration      | eigenvalue          |\n";
         ss << " +================+=====================+\n";
@@ -373,7 +373,7 @@ EigenExecutionerBase::postExecute()
   Real s = 1.0;
   if (_norm_execflag & EXEC_CUSTOM)
   {
-    _console << " Cannot let the normalization postprocessor on custom." << std::endl;
+    _console << " Cannot let the normalization postprocessor on custom.\n";
     _console << " Normalization is abandoned!" << std::endl;
   }
   else
@@ -426,12 +426,12 @@ void
 EigenExecutionerBase::printEigenvalue()
 {
   std::ostringstream ss;
-  ss << std::endl;
-  ss << "******************************************************* " << std::endl;
-  ss << " Eigenvalue = " << std::fixed << std::setprecision(10) << _eigenvalue << std::endl;
-  ss << "******************************************************* " << std::endl;
+  ss << '\n';
+  ss << "*******************************************************\n";
+  ss << " Eigenvalue = " << std::fixed << std::setprecision(10) << _eigenvalue << '\n';
+  ss << "*******************************************************";
 
-  _console << ss.str() << std::flush;
+  _console << ss.str() << std::endl;
 }
 
 EigenExecutionerBase::Chebyshev_Parameters::Chebyshev_Parameters()

--- a/framework/src/executioners/NonlinearEigen.C
+++ b/framework/src/executioners/NonlinearEigen.C
@@ -58,7 +58,7 @@ NonlinearEigen::init()
     _problem.advanceState();
 
     // free power iterations
-    _console << std::endl << " Free power iteration starts"  << std::endl;
+    _console << " Free power iteration starts"  << std::endl;
 
     Real initial_res;
     inversePowerIteration(_free_iter, _free_iter, _pfactor, false,

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -78,8 +78,6 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
   if (_solved)
     return true;
 
-  _console << "Fully Solving MultiApp " << name() << std::endl;
-
   MPI_Comm swapped = Moose::swapLibMeshComm(_my_comm);
 
   int rank;
@@ -99,8 +97,6 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
   Moose::swapLibMeshComm(swapped);
 
   _solved = true;
-
-  _console << "Finished Solving MultiApp " << name() << std::endl;
 
   return last_solve_converged;
 }

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -123,9 +123,6 @@ MultiApp::MultiApp(const InputParameters & parameters):
 
   mooseAssert(_input_files.size() == 1 || _positions.size() == _input_files.size(), "Number of positions and input files are not the same!");
 
-  // Fill in the _positions vector
-  fillPositions();
-
   if (_move_apps.size() != _move_positions.size())
     mooseError("The number of apps to move and the positions to move them to must be the same for MultiApp " << name());
 

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -114,7 +114,7 @@ MultiApp::MultiApp(const InputParameters & parameters):
     _backups(declareRestartableDataWithContext<SubAppBackups>("backups", this))
 {
   if (_move_apps.size() != _move_positions.size())
-    mooseError("The number of apps to move and the positions to move them to must be the same for MultiApp "<<_name);
+    mooseError("The number of apps to move and the positions to move them to must be the same for MultiApp " << _name);
 
   // Fill in the _positions vector
   fillPositions();
@@ -122,9 +122,6 @@ MultiApp::MultiApp(const InputParameters & parameters):
   _total_num_apps = _positions.size();
 
   mooseAssert(_input_files.size() == 1 || _positions.size() == _input_files.size(), "Number of positions and input files are not the same!");
-
-  if (_move_apps.size() != _move_positions.size())
-    mooseError("The number of apps to move and the positions to move them to must be the same for MultiApp " << name());
 
   /// Set up our Comm and set the number of apps we're going to be working on
   buildComm();

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -589,13 +589,22 @@ Console::write(std::string message, bool indent /*=true*/)
   if (_write_file)
     _file_output_stream << message;
 
+  // Need to strip off the last new line for proper indentation
+  bool has_end_newline = (message[message.size()-1]=='\n');
+  if (has_end_newline)
+    message = message.substr(0, message.size()-1);
+
   // Apply MultiApp indenting
   if (indent && _app.multiAppLevel() > 0)
     MooseUtils::indentMessage(_app.name(), message);
 
   // Write message to the screen
   if (_write_screen)
+  {
     Moose::out << message;
+    if (has_end_newline)
+      Moose::out << "\n";
+  }
 }
 
 void

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -589,22 +589,13 @@ Console::write(std::string message, bool indent /*=true*/)
   if (_write_file)
     _file_output_stream << message;
 
-  // Need to strip off the last new line for proper indentation
-  bool has_end_newline = (message[message.size()-1]=='\n');
-  if (has_end_newline)
-    message = message.substr(0, message.size()-1);
-
   // Apply MultiApp indenting
   if (indent && _app.multiAppLevel() > 0)
     MooseUtils::indentMessage(_app.name(), message);
 
   // Write message to the screen
   if (_write_screen)
-  {
     Moose::out << message;
-    if (has_end_newline)
-      Moose::out << "\n";
-  }
 }
 
 void

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -25,8 +25,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-OutputWarehouse::OutputWarehouse() :
+OutputWarehouse::OutputWarehouse(MooseApp & app) :
     Warehouse<Output>(),
+    _app(app),
+    _buffer_action_console_outputs(true),
     _output_exec_flag(EXEC_CUSTOM),
     _force_output(false)
 {
@@ -177,6 +179,19 @@ OutputWarehouse::mooseConsole()
     // Reset
     _console_buffer.clear();
     _console_buffer.str("");
+  }
+  else
+  {
+    if (!_buffer_action_console_outputs)
+    {
+      // this will cause messages to console before its construction immediately flushed and cleared.
+      std::string message = _console_buffer.str();
+      if (_app.multiAppLevel() > 0)
+        MooseUtils::indentMessage(_app.name(), message);
+      Moose::out << message;
+      _console_buffer.clear();
+      _console_buffer.str("");
+    }
   }
 }
 

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -206,6 +206,25 @@ namespace Moose
     }
     return "";
   }
+
+  template<>
+  std::string stringify(const ExecFlagType & t)
+  {
+    switch (t)
+    {
+    case EXEC_INITIAL:        return "INITIAL";
+    case EXEC_LINEAR:         return "LINEAR";
+    case EXEC_NONLINEAR:      return "NONLINEAR";
+    case EXEC_TIMESTEP_END:   return "TIMESTEP_END";
+    case EXEC_TIMESTEP_BEGIN: return "TIMESTEP_BEGIN";
+    case EXEC_CUSTOM:         return "CUSTOM";
+    case EXEC_FINAL:          return "FINAL";
+    case EXEC_FORCED:         return "FORCED";
+    case EXEC_FAILED:         return "FAILED";
+    case EXEC_NONE:           return "NONE";
+    }
+    return "";
+  }
 }
 
 Point toPoint(const std::vector<Real> & pos)

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -357,8 +357,8 @@ indentMessage(const std::string & prefix, std::string & message, const char* col
   // The colored prefix
   std::string indent = color + prefix + ": " + COLOR_DEFAULT;
 
-  // Indent all lines after the first
-  pcrecpp::RE re("\n(?!\\Z)");
+  // Indent all lines
+  pcrecpp::RE re("\n");
   re.GlobalReplace(std::string("\n") + indent, &message);
 
   // Prepend indent string at the front of the message

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -358,7 +358,7 @@ indentMessage(const std::string & prefix, std::string & message, const char* col
   std::string indent = color + prefix + ": " + COLOR_DEFAULT;
 
   // Indent all the lines until the final newline is encountered
-  pcrecpp::RE re("\n(?=.*\n)");
+  pcrecpp::RE re("\n(?=.*\n)"); //(?=.*\n)
   re.GlobalReplace(std::string("\n") + indent, &message);
 
   // Prepend indent string at the front of the message

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -357,8 +357,8 @@ indentMessage(const std::string & prefix, std::string & message, const char* col
   // The colored prefix
   std::string indent = color + prefix + ": " + COLOR_DEFAULT;
 
-  // Indent all lines
-  pcrecpp::RE re("\n");
+  // Indent all the lines until the final newline is encountered
+  pcrecpp::RE re("\n(?=.*\n)");
   re.GlobalReplace(std::string("\n") + indent, &message);
 
   // Prepend indent string at the front of the message


### PR DESCRIPTION
This supplants #5958. 
- Improves the Console indentation regex so that we don't need all the hackery of stripping and re-adding the newline
- Cleans up unnecessary buffer flushes in the EigenExecutioners
- Removes the last piece of duplicated logic in Multiapp.C from a8a56e49 (Why are you always fillingPositions @friedmud :wink:)
