### PR TITLE
Create nodeToActiveSemilocalElemMap and use it in EBSDReader

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -135,9 +135,18 @@ public:
 
   /**
    * If not already created, creates a map from every node to all
-   * elements to which they are created.
+   * elements to which they are connected.
    */
   std::map<dof_id_type, std::vector<dof_id_type> > & nodeToElemMap();
+
+  /**
+   * If not already created, creates a map from every node to all
+   * _active_ _semilocal_ elements to which they are connected.
+   * Semilocal elements include local elements and elements that share at least
+   * one node with a local element.
+   * \note Extra ghosted elements are not included in this map!
+   */
+  std::map<dof_id_type, std::vector<dof_id_type> > & nodeToActiveSemilocalElemMap();
 
   /**
    * These structs are required so that the bndNodes{Begin,End} and
@@ -775,6 +784,10 @@ protected:
   /// A map of all of the current nodes to the elements that they are connected to.
   std::map<dof_id_type, std::vector<dof_id_type> > _node_to_elem_map;
   bool _node_to_elem_map_built;
+
+  /// A map of all of the current nodes to the active elements that they are connected to.
+  std::map<dof_id_type, std::vector<dof_id_type> > _node_to_active_semilocal_elem_map;
+  bool _node_to_active_semilocal_elem_map_built;
 
   /**
    * A set of subdomain IDs currently present in the mesh.

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -306,7 +306,7 @@ EBSDReader::buildNodeWeightMaps()
 {
   // Import nodeToElemMap from MooseMesh for current node
   // This map consists of the node index followed by a vector of element indices that are associated with that node
-  std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToElemMap();
+  std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToActiveSemilocalElemMap();
   libMesh::MeshBase &mesh = _mesh.getMesh();
 
   // Loop through each node in mesh and calculate eta values for each grain associated with the node


### PR DESCRIPTION
I confirmed that this also fixes the IC issues with refined meshes and ReconVarIC.

This PR is mutually exclusive with #6032 
Refs #6016, #6031 
