### PR TITLE
Implement compound assignment operators for ExpressionBuilder

### DIFF
--- a/modules/phase_field/include/utils/ExpressionBuilder.h
+++ b/modules/phase_field/include/utils/ExpressionBuilder.h
@@ -305,9 +305,11 @@ public:
     EBTerm(const EBTerm & term) : _root(term.cloneRoot()) {};
     ~EBTerm() { delete _root; };
 
+  private:
     // construct a term from a node
     EBTerm(EBTermNode * root) : _root(root) {};
 
+  public:
     // construct from number or string
     EBTerm(int number) : _root(new EBNumberNode<int>(number)) {}
     EBTerm(Real number) : _root(new EBNumberNode<Real>(number)) {}
@@ -404,10 +406,11 @@ public:
      */
     #define BINARYCOMP_OP_IMPLEMENT(op,OP) \
     EBTerm & operator op (const EBTerm & term) { \
-      if (_root != NULL && term._root != NULL) \
-        _root = new EBBinaryOpTermNode(_root, term.cloneRoot(), EBBinaryOpTermNode::OP); \
-      else if (term._root != NULL) \
-        _root = term.cloneRoot(); \
+      mooseAssert(_root != NULL, "Empty term provided on left side of operator " #op); \
+      mooseAssert(term._root != NULL, "Empty term provided on right side of operator " #op); \
+      if (dynamic_cast<EBTempIDNode *>(_root)) \
+        mooseError("Using compound assignment operator on anonymous term. Set it to 0 first!"); \
+      _root = new EBBinaryOpTermNode(_root, term.cloneRoot(), EBBinaryOpTermNode::OP); \
       return *this; \
     }
     BINARYCOMP_OP_IMPLEMENT(+=,ADD)

--- a/modules/phase_field/include/utils/ExpressionBuilder.h
+++ b/modules/phase_field/include/utils/ExpressionBuilder.h
@@ -399,6 +399,23 @@ public:
     BINARY_OP_IMPLEMENT(==,EQ)
     BINARY_OP_IMPLEMENT(!=,NOTEQ)
 
+    /*
+     * Compound assignment operators
+     */
+    #define BINARYCOMP_OP_IMPLEMENT(op,OP) \
+    EBTerm & operator op (const EBTerm & term) { \
+      if (_root != NULL && term._root != NULL) \
+        _root = new EBBinaryOpTermNode(_root, term.cloneRoot(), EBBinaryOpTermNode::OP); \
+      else if (term._root != NULL) \
+        _root = term.cloneRoot(); \
+      return *this; \
+    }
+    BINARYCOMP_OP_IMPLEMENT(+=,ADD)
+    BINARYCOMP_OP_IMPLEMENT(-=,SUB)
+    BINARYCOMP_OP_IMPLEMENT(*=,MUL)
+    BINARYCOMP_OP_IMPLEMENT(/=,DIV)
+    BINARYCOMP_OP_IMPLEMENT(%=,MOD)
+
     /**
     * @{
      * Binary functions


### PR DESCRIPTION
This adds the `+=`, `-=`, `*=`, `/=`, and `%=` operators to `ExpressionBuilder`. I've also made a constructor private that is only designed for internal use. This should make it impossible for terms to contain null pointers to their root nodes.

Closes #6044
