### PR TITLE
More fixes suggested by cppclean

### DIFF
--- a/examples/ex01_inputfile/src/base/ExampleApp.C
+++ b/examples/ex01_inputfile/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 template<>
 InputParameters validParams<ExampleApp>()

--- a/examples/ex02_kernel/src/base/ExampleApp.C
+++ b/examples/ex02_kernel/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 2 Includes
 #include "ExampleConvection.h"           // <- New include for our custom kernel

--- a/examples/ex03_coupling/src/base/ExampleApp.C
+++ b/examples/ex03_coupling/src/base/ExampleApp.C
@@ -14,6 +14,7 @@
 #include "ExampleApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 3 Includes
 #include "ExampleConvection.h"

--- a/examples/ex04_bcs/src/base/ExampleApp.C
+++ b/examples/ex04_bcs/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 4 Includes
 #include "ExampleConvection.h"

--- a/examples/ex05_amr/src/base/ExampleApp.C
+++ b/examples/ex05_amr/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 5 Registration
 #include "ExampleConvection.h"

--- a/examples/ex06_transient/src/base/ExampleApp.C
+++ b/examples/ex06_transient/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 6 Includes
 #include "ExampleDiffusion.h"

--- a/examples/ex07_ics/src/base/ExampleApp.C
+++ b/examples/ex07_ics/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 7 Includes
 #include "ExampleIC.h"

--- a/examples/ex08_materials/src/base/ExampleApp.C
+++ b/examples/ex08_materials/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 8 Includes
 #include "ExampleDiffusion.h"

--- a/examples/ex09_stateful_materials/src/base/ExampleApp.C
+++ b/examples/ex09_stateful_materials/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 9 Includes
 #include "ExampleDiffusion.h"

--- a/examples/ex10_aux/src/base/ExampleApp.C
+++ b/examples/ex10_aux/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 10 Includes
 #include "ExampleAux.h"

--- a/examples/ex11_prec/src/base/ExampleApp.C
+++ b/examples/ex11_prec/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 template<>
 InputParameters validParams<ExampleApp>()

--- a/examples/ex12_pbp/src/base/ExampleApp.C
+++ b/examples/ex12_pbp/src/base/ExampleApp.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 #include "ExampleApp.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 template<>
 InputParameters validParams<ExampleApp>()

--- a/examples/ex13_functions/src/base/ExampleApp.C
+++ b/examples/ex13_functions/src/base/ExampleApp.C
@@ -14,6 +14,7 @@
 #include "ExampleApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 13 Includes
 #include "ExampleFunction.h"

--- a/examples/ex14_pps/src/base/ExampleApp.C
+++ b/examples/ex14_pps/src/base/ExampleApp.C
@@ -14,6 +14,7 @@
 #include "ExampleApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 14 Includes
 #include "ExampleFunction.h"

--- a/examples/ex15_actions/src/base/ExampleApp.C
+++ b/examples/ex15_actions/src/base/ExampleApp.C
@@ -16,6 +16,7 @@
 #include "AppFactory.h"
 #include "ActionFactory.h"  // <- Actions are special (they have their own factory)
 #include "Syntax.h"
+#include "MooseSyntax.h"
 
 // Example 15 Includes
 #include "ExampleConvection.h"

--- a/examples/ex16_timestepper/src/base/ExampleApp.C
+++ b/examples/ex16_timestepper/src/base/ExampleApp.C
@@ -14,6 +14,7 @@
 #include "ExampleApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 16 Includes
 #include "TransientHalf.h"

--- a/examples/ex17_dirac/src/base/ExampleApp.C
+++ b/examples/ex17_dirac/src/base/ExampleApp.C
@@ -13,9 +13,9 @@
 /****************************************************************/
 #include "ExampleApp.h"
 #include "Moose.h"
-
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "ExampleConvection.h"
 #include "ExampleDirac.h"

--- a/examples/ex18_scalar_kernel/src/base/ExampleApp.C
+++ b/examples/ex18_scalar_kernel/src/base/ExampleApp.C
@@ -14,6 +14,7 @@
 #include "ExampleApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 18 Includes
 #include "ScalarDirichletBC.h"

--- a/examples/ex19_dampers/src/base/ExampleApp.C
+++ b/examples/ex19_dampers/src/base/ExampleApp.C
@@ -14,6 +14,7 @@
 #include "ExampleApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 template<>
 InputParameters validParams<ExampleApp>()

--- a/examples/ex20_user_objects/src/base/ExampleApp.C
+++ b/examples/ex20_user_objects/src/base/ExampleApp.C
@@ -14,6 +14,7 @@
 #include "ExampleApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example Includes
 #include "BlockAverageDiffusionMaterial.h"

--- a/examples/ex20_user_objects/src/userobjects/BlockAverageValue.C
+++ b/examples/ex20_user_objects/src/userobjects/BlockAverageValue.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "BlockAverageValue.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/mesh_tools.h"

--- a/examples/ex21_debugging/src/base/ExampleApp.C
+++ b/examples/ex21_debugging/src/base/ExampleApp.C
@@ -15,6 +15,7 @@
 #include "Moose.h"
 #include "Factory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // Example 21 Includes
 #include "ExampleDiffusion.h"

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -15,6 +15,7 @@
 #ifndef FEPROBLEM_H
 #define FEPROBLEM_H
 
+// MOOSE includes
 #include "SubProblem.h"
 #include "AuxiliarySystem.h"
 #include "GeometricSearchData.h"
@@ -32,6 +33,7 @@
 #include "Restartable.h"
 #include "SolverParams.h"
 #include "PetscSupport.h"
+#include "MooseApp.h"
 
 // libMesh includes
 #include "libmesh/enum_quadrature_type.h"
@@ -51,6 +53,7 @@ class VectorPostprocessorData;
 class MooseEnum;
 class Resurrector;
 class Assembly;
+class JacobianBlock;
 
 // libMesh forward declarations
 namespace libMesh
@@ -316,11 +319,10 @@ public:
   virtual void checkExceptionAndStopSolve();
 
   virtual bool converged();
-  virtual unsigned int nNonlinearIterations() { return _nl.nNonlinearIterations(); }
-  virtual unsigned int nLinearIterations() { return _nl.nLinearIterations(); }
-  virtual Real finalNonlinearResidual() { return _nl.finalNonlinearResidual(); }
-
-  virtual bool computingInitialResidual() { return _nl.computingInitialResidual(); }
+  virtual unsigned int nNonlinearIterations();
+  virtual unsigned int nLinearIterations();
+  virtual Real finalNonlinearResidual();
+  virtual bool computingInitialResidual();
 
   /**
    * Returns true if we are currently computing Jacobian

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -15,12 +15,7 @@
 #ifndef MOOSEAPP_H
 #define MOOSEAPP_H
 
-#include <iostream>
-#include <vector>
-#include <list>
-#include <map>
-#include <set>
-
+// MOOSE includes
 #include "Moose.h"
 #include "Parser.h"
 #include "ActionWarehouse.h"
@@ -33,6 +28,12 @@
 // libMesh includes
 #include "libmesh/parallel_object.h"
 
+// C++ includes
+#include <list>
+#include <map>
+#include <set>
+
+// Forward declarations
 class Executioner;
 class MooseApp;
 class Backup;
@@ -40,6 +41,7 @@ class FEProblem;
 class MeshModifier;
 class InputParameterWarehouse;
 class SystemInfo;
+class CommandLine;
 
 template<>
 InputParameters validParams<MooseApp>();

--- a/framework/include/base/SystemBase.h
+++ b/framework/include/base/SystemBase.h
@@ -29,6 +29,7 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/equation_systems.h"
+#include "libmesh/numeric_vector.h"
 
 // Forward declarations
 class Factory;

--- a/framework/include/constraints/FaceFaceConstraint.h
+++ b/framework/include/constraints/FaceFaceConstraint.h
@@ -15,10 +15,12 @@
 #ifndef FACEFACECONSTRAINT_H
 #define FACEFACECONSTRAINT_H
 
+// MOOSE includes
 #include "Constraint.h"
 #include "CoupleableMooseVariableDependencyIntermediateInterface.h"
+#include "MooseMesh.h"
 
-//Forward Declarations
+// Forward Declarations
 class FaceFaceConstraint;
 class FEProblem;
 

--- a/framework/include/constraints/LinearNodalConstraint.h
+++ b/framework/include/constraints/LinearNodalConstraint.h
@@ -22,6 +22,13 @@ class LinearNodalConstraint;
 template<>
 InputParameters validParams<LinearNodalConstraint>();
 
+/**
+ * The slave node variable is programmed as a linear combination of
+ * the master node variables (i.e, slave_var = a_1*master_var_1+
+ * a_2*master_var_2+... + a_n*master_var_n).  The master nodes ids and
+ * corresponding weights are required as input.  The same linear
+ * combination applies to all slave nodes.
+ */
 class LinearNodalConstraint : public NodalConstraint
 {
 public:

--- a/framework/include/geomsearch/NearestNodeLocator.h
+++ b/framework/include/geomsearch/NearestNodeLocator.h
@@ -20,6 +20,7 @@
 
 // Forward declarations
 class SubProblem;
+class MooseMesh;
 
 /**
  * Finds the nearest node to each node in boundary1 to each node in boundary2 and the other way around.

--- a/framework/include/materials/DerivativeMaterialInterface.h
+++ b/framework/include/materials/DerivativeMaterialInterface.h
@@ -20,6 +20,7 @@
 #include "BlockRestrictable.h"
 #include "BoundaryRestrictable.h"
 #include "DerivativeMaterialPropertyNameInterface.h"
+#include "NonlinearSystem.h"
 
 // Forward declarations
 class FEProblem;

--- a/framework/include/outputs/AdvancedOutput.h
+++ b/framework/include/outputs/AdvancedOutput.h
@@ -16,19 +16,16 @@
 #define ADVANCEDOUTPUT_H
 
 // MOOSE includes
-#include "OversampleOutput.h"
-#include "MooseObject.h"
-#include "Restartable.h"
+#include "AdvancedOutputUtils.h" // OutputDataWarehouse
 #include "MooseTypes.h"
-#include "MooseMesh.h"
-#include "MeshChangedInterface.h"
-#include "MooseApp.h"
-#include "AdvancedOutputUtils.h"
 
-// libMesh
-#include "libmesh/equation_systems.h"
-#include "libmesh/numeric_vector.h"
-#include "libmesh/mesh_function.h"
+// Forward declarations
+class OutputWarehouse;
+class FileOutput;
+class OversampleOutput;
+class PetscOutput;
+class Console;
+class TransientMultiApp;
 
 /**
  * Based class for output objects

--- a/framework/include/outputs/AdvancedOutputUtils.h
+++ b/framework/include/outputs/AdvancedOutputUtils.h
@@ -18,12 +18,9 @@
 // MOOSE includes
 #include "MooseError.h"
 #include "MultiMooseEnum.h"
-#include "InputParameters.h"
 
-// STL includes
-#include <vector>
-#include <string>
-#include <map>
+// Forward declarations
+class InputParameters;
 
 /**
  * A structure for storing the various lists that contain

--- a/framework/include/outputs/BasicOutput.h
+++ b/framework/include/outputs/BasicOutput.h
@@ -16,7 +16,10 @@
 #define BASICOUTPUT_H
 
 // MOOSE includes
-#include "OversampleOutput.h"
+#include "MooseTypes.h"
+
+// Forward declarations
+class InputParameters;
 
 /**
  * Based class for output objects

--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -18,15 +18,13 @@
 // MOOSE includes
 #include "BasicOutput.h"
 #include "FileOutput.h"
-#include "MaterialPropertyStorage.h"
-#include "RestartableData.h"
 #include "RestartableDataIO.h"
 
 #include <deque>
 
 // Forward declarations
 class Checkpoint;
-struct CheckpointFileNames;
+class MaterialPropertyStorage;
 
 template<>
 InputParameters validParams<Checkpoint>();

--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -17,7 +17,6 @@
 
 // MOOSE includes
 #include "TableOutput.h"
-#include "FormattedTable.h"
 
 // Forward declarations
 class Console;

--- a/framework/include/outputs/ConsoleUtils.h
+++ b/framework/include/outputs/ConsoleUtils.h
@@ -16,12 +16,17 @@
 #define CONSOLEUTILS_H
 
 // MOOSE includes
-#include "NonlinearSystem.h"
-#include "AuxiliarySystem.h"
+#include "Moose.h"
 
 // Forward declarations
 class MooseApp;
 class FEProblem;
+
+// libMesh forward declarations
+namespace libMesh
+{
+class System;
+}
 
 namespace ConsoleUtils
 {

--- a/framework/include/outputs/DOFMapOutput.h
+++ b/framework/include/outputs/DOFMapOutput.h
@@ -21,6 +21,7 @@
 
 // Forward declarations
 class DOFMapOutput;
+class MooseMesh;
 
 template<>
 InputParameters validParams<DOFMapOutput>();

--- a/framework/include/outputs/Exodus.h
+++ b/framework/include/outputs/Exodus.h
@@ -19,12 +19,14 @@
 #include "AdvancedOutput.h"
 #include "OversampleOutput.h"
 
-// libMesh includes
-#include "libmesh/exodusII.h"
-#include "libmesh/exodusII_io.h"
-
 // Forward declarations
 class Exodus;
+
+// libMesh forward declarations
+namespace libMesh
+{
+class ExodusII_IO;
+}
 
 template<>
 InputParameters validParams<Exodus>();

--- a/framework/include/outputs/ICEUpdater.h
+++ b/framework/include/outputs/ICEUpdater.h
@@ -19,7 +19,9 @@
 #include "AdvancedOutput.h"
 #include "Output.h"
 #include "InputParameters.h"
-#include "Updater.h"
+
+// Forward declarations
+class Updater;
 
 // Currently the ICE Updater requires TBB
 #ifdef LIBMESH_HAVE_TBB_API

--- a/framework/include/outputs/MaterialPropertyDebugOutput.h
+++ b/framework/include/outputs/MaterialPropertyDebugOutput.h
@@ -18,10 +18,10 @@
 // MOOSE includes
 #include "BasicOutput.h"
 #include "Output.h"
-#include "FEProblem.h"
 
 // Forward declerations
 class MaterialPropertyDebugOutput;
+class Material;
 
 template<>
 InputParameters validParams<MaterialPropertyDebugOutput>();

--- a/framework/include/outputs/Nemesis.h
+++ b/framework/include/outputs/Nemesis.h
@@ -19,12 +19,14 @@
 #include "AdvancedOutput.h"
 #include "OversampleOutput.h"
 
-// libMesh includes
-#include "libmesh/nemesis_io.h"
-#include "libmesh/parallel_mesh.h"
-
 // Forward declarations
 class Nemesis;
+
+// libMesh forward declarations
+namespace libMesh
+{
+class Nemesis_IO;
+}
 
 template<>
 InputParameters validParams<Nemesis>();

--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -18,20 +18,18 @@
 // MOOSE includes
 #include "MooseObject.h"
 #include "Restartable.h"
-#include "MooseTypes.h"
-#include "MooseMesh.h"
 #include "MeshChangedInterface.h"
 #include "SetupInterface.h"
 #include "AdvancedOutputUtils.h"
 
-// libMesh
-#include "libmesh/equation_systems.h"
-#include "libmesh/numeric_vector.h"
-#include "libmesh/mesh_function.h"
-
 // Forward declarations
-class Problem;
 class Output;
+
+// libMesh forward declarations
+namespace libMesh
+{
+class EquationSystems;
+}
 
 template<>
 InputParameters validParams<Output>();

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -15,17 +15,13 @@
 #ifndef OUTPUTWAREHOUSE_H
 #define OUTPUTWAREHOUSE_H
 
-// Standard includes
-#include <vector>
-
 // MOOSE includes
 #include "Output.h"
 #include "Warehouse.h"
-#include "InputParameters.h"
 
 // Forward declarations
-class Checkpoint;
 class FEProblem;
+class InputParameters;
 
 /**
  * Class for storing and utilizing output objects

--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -18,14 +18,17 @@
 // MOOSE includes
 #include "FileOutput.h"
 
-// libMesh
-#include "libmesh/equation_systems.h"
-#include "libmesh/equation_systems.h"
-#include "libmesh/numeric_vector.h"
-#include "libmesh/mesh_function.h"
-
 // Forward declerations
 class OversampleOutput;
+class MooseMesh;
+
+// libMesh forward declarations
+namespace libMesh
+{
+template <typename T> class NumericVector;
+class MeshFunction;
+}
+
 
 template<>
 InputParameters validParams<OversampleOutput>();

--- a/framework/include/outputs/TopResidualDebugOutput.h
+++ b/framework/include/outputs/TopResidualDebugOutput.h
@@ -18,7 +18,9 @@
 // MOOSE includes
 #include "BasicOutput.h"
 #include "PetscOutput.h"
-#include "FEProblem.h"
+
+// libMesh includes
+#include "libmesh/transient_system.h" // TransientNonlinearImplicitSystem typedef
 
 // Forward declerations
 class TopResidualDebugOutput;
@@ -98,7 +100,6 @@ protected:
 
   /// Reference to libMesh system
   TransientNonlinearImplicitSystem & _sys;
-
 };
 
 #endif // TOPRESIDUALDEBUGOUTPUT_H

--- a/framework/include/outputs/VTKOutput.h
+++ b/framework/include/outputs/VTKOutput.h
@@ -19,9 +19,6 @@
 #include "BasicOutput.h"
 #include "OversampleOutput.h"
 
-// libMesh includes
-#include "libmesh/vtk_io.h"
-
 // Forward declerations
 class VTKOutput;
 

--- a/framework/include/outputs/VariableResidualNormsDebugOutput.h
+++ b/framework/include/outputs/VariableResidualNormsDebugOutput.h
@@ -18,7 +18,9 @@
 // MOOSE includes
 #include "BasicOutput.h"
 #include "PetscOutput.h"
-#include "FEProblem.h"
+
+// libMesh includes
+#include "libmesh/transient_system.h" // TransientNonlinearImplicitSystem typedef
 
 // Forward declerations
 class VariableResidualNormsDebugOutput;
@@ -55,7 +57,6 @@ protected:
 
   /// Reference to libMesh system
   TransientNonlinearImplicitSystem & _sys;
-
 };
 
 #endif // VARIABLERESIDUALNORMSDEBUGOUTPUT_H

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -16,18 +16,24 @@
 #define COMMANDLINE_H
 
 // Moose Includes
-#include "InputParameters.h"
 #include "MooseError.h"
 
+// libMesh includes
+#include "libmesh/getpot.h"
+
+// C++ includes
 #include <vector>
 #include <string>
 #include <map>
 #include <set>
-#include "libmesh/getpot.h"
 
 // Forward Declaration
-class Parser;
+class InputParameters;
 
+/**
+ * This class wraps a GetPot object associated with the command line
+ * used to run the code.
+ */
 class CommandLine
 {
 public:

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -15,23 +15,22 @@
 #ifndef PARSER_H
 #define PARSER_H
 
-#include "GlobalParamsAction.h"
-#include "MooseSyntax.h"
-#include "CommandLine.h"
-#include "Syntax.h"
+// MOOSE includes
 #include "ConsoleStreamInterface.h"
+#include "MooseTypes.h"
+#include "InputParameters.h"
+#include "Syntax.h"
 
-// libMesh
+// libMesh include
 #include "libmesh/getpot.h"
-#include "libmesh/exodusII_io.h"
-#include "libmesh/vector_value.h"
-#include "libmesh/tensor_value.h"
 
+// Forward declarations
 class ActionWarehouse;
 class SyntaxTree;
 class MooseApp;
 class Factory;
 class ActionFactory;
+class GlobalParamsAction;
 
 /**
  * Class for parsing input files. This class utilizes the GetPot library for actually tokenizing and parsing files. It is not
@@ -127,16 +126,16 @@ protected:
   /// Template method for setting any scalar type parameter read from the input file or command line
   template<typename T>
   void setScalarParameter(const std::string & full_name, const std::string & short_name,
-                          InputParameters::Parameter<T>* param, bool in_global, GlobalParamsAction *global_block);
+                          InputParameters::Parameter<T> * param, bool in_global, GlobalParamsAction * global_block);
 
   template<typename T, typename UP_T>
   void setScalarValueTypeParameter(const std::string & full_name, const std::string & short_name,
-                                   InputParameters::Parameter<T>* param, bool in_global, GlobalParamsAction *global_block);
+                                   InputParameters::Parameter<T>* param, bool in_global, GlobalParamsAction * global_block);
 
   /// Template method for setting any vector type parameter read from the input file or command line
   template<typename T>
   void setVectorParameter(const std::string & full_name, const std::string & short_name,
-                          InputParameters::Parameter<std::vector<T> >* param, bool in_global, GlobalParamsAction *global_block);
+                          InputParameters::Parameter<std::vector<T> >* param, bool in_global, GlobalParamsAction * global_block);
 
   /// Template method for setting any multivalue "scalar" type parameter read from the input file or command line.  Examples include "Point" and "RealVectorValue"
   template<typename T>

--- a/framework/include/partitioner/MoosePartitioner.h
+++ b/framework/include/partitioner/MoosePartitioner.h
@@ -15,17 +15,14 @@
 #ifndef MOOSEPARTITIONER_H
 #define MOOSEPARTITIONER_H
 
+// MOOSE includes
 #include "MooseObject.h"
 #include "Restartable.h"
 
+// libMesh includes
 #include "libmesh/partitioner.h"
 
-//Forward declarations
-namespace libMesh
-{
-  class MeshBase;
-}
-
+// Forward declarations
 class MoosePartitioner;
 
 template<>
@@ -35,7 +32,7 @@ InputParameters validParams<MoosePartitioner>();
  * Base class for MOOSE partitioner
  */
 class MoosePartitioner :
-  public Partitioner,
+  public libMesh::Partitioner,
   public MooseObject,
   public Restartable
 {

--- a/framework/include/postprocessors/AverageNodalVariableValue.h
+++ b/framework/include/postprocessors/AverageNodalVariableValue.h
@@ -17,9 +17,8 @@
 
 #include "NodalVariablePostprocessor.h"
 
-//Forward Declarations
+// Forward Declarations
 class AverageNodalVariableValue;
-class MooseMesh;
 
 template<>
 InputParameters validParams<AverageNodalVariableValue>();

--- a/framework/include/postprocessors/ElementH1Error.h
+++ b/framework/include/postprocessors/ElementH1Error.h
@@ -17,9 +17,7 @@
 
 #include "ElementW1pError.h"
 
-class Function;
-
-//Forward Declarations
+// Forward Declarations
 class ElementH1Error;
 
 template<>

--- a/framework/include/postprocessors/ElementL2Difference.h
+++ b/framework/include/postprocessors/ElementL2Difference.h
@@ -17,9 +17,7 @@
 
 #include "ElementIntegralVariablePostprocessor.h"
 
-class Function;
-
-//Forward Declarations
+// Forward Declarations
 class ElementL2Difference;
 
 template<>

--- a/framework/include/postprocessors/ElementVariablePostprocessor.h
+++ b/framework/include/postprocessors/ElementVariablePostprocessor.h
@@ -18,9 +18,7 @@
 #include "ElementPostprocessor.h"
 #include "MooseVariableInterface.h"
 
-class MooseVariable;
-
-//Forward Declarations
+// Forward Declarations
 class ElementVariablePostprocessor;
 
 template<>

--- a/framework/include/postprocessors/ElementalVariableValue.h
+++ b/framework/include/postprocessors/ElementalVariableValue.h
@@ -15,14 +15,17 @@
 #ifndef ELEMENTALVARIABLEVALUE_H
 #define ELEMENTALVARIABLEVALUE_H
 
+// MOOSE includes
 #include "GeneralPostprocessor.h"
-// libMesh
-#include "libmesh/elem.h"
 
+// Forward Declarations
+class ElementalVariableValue;
 class MooseMesh;
 
-//Forward Declarations
-class ElementalVariableValue;
+namespace libMesh
+{
+class Elem;
+}
 
 template<>
 InputParameters validParams<ElementalVariableValue>();

--- a/framework/include/postprocessors/ExecutionerAttributeReporter.h
+++ b/framework/include/postprocessors/ExecutionerAttributeReporter.h
@@ -20,7 +20,6 @@
 
 // Forward declarations
 class ExecutionerAttributeReporter;
-class EigenExecutionerBase;
 
 template<>
 InputParameters validParams<ExecutionerAttributeReporter>();

--- a/framework/include/postprocessors/FunctionSideIntegral.h
+++ b/framework/include/postprocessors/FunctionSideIntegral.h
@@ -15,11 +15,11 @@
 #ifndef FUNCTIONSIDEINTEGRAL_H
 #define FUNCTIONSIDEINTEGRAL_H
 
-#include "Function.h"
 #include "SideIntegralPostprocessor.h"
 
-//Forward Declarations
+// Forward Declarations
 class FunctionSideIntegral;
+class Function;
 
 template<>
 InputParameters validParams<FunctionSideIntegral>();
@@ -38,8 +38,6 @@ protected:
 
   /// The function
   Function & _func;
-
-
 };
 
 #endif //FUNCTIONSIDEINTEGRAL_H

--- a/framework/include/postprocessors/GeneralPostprocessor.h
+++ b/framework/include/postprocessors/GeneralPostprocessor.h
@@ -15,16 +15,11 @@
 #ifndef GENERALPOSTPROCESSOR_H
 #define GENERALPOSTPROCESSOR_H
 
+// MOOSE includes
 #include "Postprocessor.h"
 #include "GeneralUserObject.h"
-#include "TransientInterface.h"
-#include "FunctionInterface.h"
-#include "UserObjectInterface.h"
-#include "PostprocessorInterface.h"
-#include "Problem.h"
 
-
-//Forward Declarations
+// Forward Declarations
 class GeneralPostprocessor;
 
 template<>

--- a/framework/include/postprocessors/NodalL2Norm.h
+++ b/framework/include/postprocessors/NodalL2Norm.h
@@ -17,14 +17,17 @@
 
 #include "NodalVariablePostprocessor.h"
 
-class MooseVariable;
-
-//Forward Declarations
+// Forward Declarations
 class NodalL2Norm;
 
 template<>
 InputParameters validParams<NodalL2Norm>();
 
+/**
+ * Computes the "nodal" L2-norm of the coupled variable, which is
+ * defined by summing the square of its value at every node and taking
+ * the square root.
+ */
 class NodalL2Norm : public NodalVariablePostprocessor
 {
 public:

--- a/framework/include/postprocessors/NodalMaxValue.h
+++ b/framework/include/postprocessors/NodalMaxValue.h
@@ -17,14 +17,16 @@
 
 #include "NodalVariablePostprocessor.h"
 
-class MooseVariable;
-
-//Forward Declarations
+// Forward Declarations
 class NodalMaxValue;
 
 template<>
 InputParameters validParams<NodalMaxValue>();
 
+/**
+ * This class computes a maximum (over all the nodal values) of the
+ * coupled variable.
+ */
 class NodalMaxValue : public NodalVariablePostprocessor
 {
 public:

--- a/framework/include/postprocessors/NodalPostprocessor.h
+++ b/framework/include/postprocessors/NodalPostprocessor.h
@@ -15,12 +15,11 @@
 #ifndef NODALPOSTPROCESSOR_H
 #define NODALPOSTPROCESSOR_H
 
+// MOOSE includes
 #include "Postprocessor.h"
 #include "NodalUserObject.h"
 
-class MooseVariable;
-
-//Forward Declarations
+// Forward Declarations
 class NodalPostprocessor;
 
 template<>
@@ -34,7 +33,9 @@ public:
   NodalPostprocessor(const InputParameters & parameters);
 
   /**
-   * Finalize.  This is called _after_ execute() and _after_ threadJoin()!  This is probably where you want to do MPI communication!
+   * Finalize.  This is called _after_ execute() and _after_
+   * threadJoin()!  This is probably where you want to do MPI
+   * communication!
    */
   virtual void finalize(){}
 };

--- a/framework/include/postprocessors/NodalProxyMaxValue.h
+++ b/framework/include/postprocessors/NodalProxyMaxValue.h
@@ -17,13 +17,16 @@
 
 #include "NodalVariablePostprocessor.h"
 
-//Forward Declarations
+// Forward Declarations
 class NodalProxyMaxValue;
-class MooseMesh;
 
 template<>
 InputParameters validParams<NodalProxyMaxValue>();
 
+/**
+ * Computes the max value at a node and broadcasts it to all
+ * processors.
+ */
 class NodalProxyMaxValue : public NodalVariablePostprocessor
 {
 public:

--- a/framework/include/postprocessors/NodalSum.h
+++ b/framework/include/postprocessors/NodalSum.h
@@ -17,13 +17,15 @@
 
 #include "NodalVariablePostprocessor.h"
 
-//Forward Declarations
+// Forward Declarations
 class NodalSum;
-class MooseMesh;
 
 template<>
 InputParameters validParams<NodalSum>();
 
+/**
+ * Computes a sum of the nodal values of the coupled variable.
+ */
 class NodalSum : public NodalVariablePostprocessor
 {
 public:

--- a/framework/include/postprocessors/NodalVariablePostprocessor.h
+++ b/framework/include/postprocessors/NodalVariablePostprocessor.h
@@ -15,16 +15,20 @@
 #ifndef NODALVARIABLEPOSTPROCESSOR_H
 #define NODALVARIABLEPOSTPROCESSOR_H
 
+// MOOSE includes
 #include "NodalPostprocessor.h"
+#include "MooseVariableInterface.h"
 
-class MooseVariable;
-
-//Forward Declarations
+// Forward Declarations
 class NodalVariablePostprocessor;
 
 template<>
 InputParameters validParams<NodalVariablePostprocessor>();
 
+/**
+ * This is a base class for other classes which compute post-processed
+ * values based on nodal solution values of _u.
+ */
 class NodalVariablePostprocessor :
   public NodalPostprocessor,
   public MooseVariableInterface

--- a/framework/include/postprocessors/NodalVariableValue.h
+++ b/framework/include/postprocessors/NodalVariableValue.h
@@ -16,17 +16,23 @@
 #define NODALVARIABLEVALUE_H
 
 #include "GeneralPostprocessor.h"
-// libMesh
-#include "libmesh/node.h"
 
+// Forward Declarations
+class NodalVariableValue;
 class MooseMesh;
 
-//Forward Declarations
-class NodalVariableValue;
+namespace libMesh
+{
+class Node;
+}
 
 template<>
 InputParameters validParams<NodalVariableValue>();
 
+/**
+ * Sums a nodal value across all processors and multiplies the result
+ * by a scale factor.
+ */
 class NodalVariableValue : public GeneralPostprocessor
 {
 public:
@@ -34,7 +40,6 @@ public:
 
   virtual void initialize() {}
   virtual void execute() {}
-
 
   /**
    * This will return the degrees of freedom in the system.

--- a/framework/include/postprocessors/NodalVariableVectorPostprocessor.h
+++ b/framework/include/postprocessors/NodalVariableVectorPostprocessor.h
@@ -16,16 +16,16 @@
 #define NODALVARIABLEVECTORPOSTPROCESSOR_H
 
 #include "NodalVectorPostprocessor.h"
-#include "Coupleable.h"
 
-class MooseVariable;
-
-//Forward Declarations
+// Forward Declarations
 class NodalVariableVectorPostprocessor;
 
 template<>
 InputParameters validParams<NodalVariableVectorPostprocessor>();
 
+/**
+ * Base class VectorPostprocessors operating on nodal variables.
+ */
 class NodalVariableVectorPostprocessor : public NodalVectorPostprocessor
 {
 public:

--- a/framework/include/postprocessors/NumPicardIterations.h
+++ b/framework/include/postprocessors/NumPicardIterations.h
@@ -15,15 +15,20 @@
 #ifndef NUMPICARDITERATIONS_H
 #define NUMPICARDITERATIONS_H
 
+// MOOSE includes
 #include "GeneralPostprocessor.h"
-#include "Transient.h"
 
-//Forward Declarations
+// Forward Declarations
 class NumPicardIterations;
+class Transient;
 
 template<>
 InputParameters validParams<NumPicardIterations>();
 
+/**
+ * Returns the number of Picard iterations taken by the underlying
+ * Transient Executioner as a Postprocessor.
+ */
 class NumPicardIterations : public GeneralPostprocessor
 {
 public:
@@ -36,6 +41,7 @@ public:
    * This will return the degrees of freedom in the system.
    */
   virtual Real getValue();
+
 protected:
   Transient * _transient_executioner;
 };

--- a/framework/include/postprocessors/Postprocessor.h
+++ b/framework/include/postprocessors/Postprocessor.h
@@ -15,22 +15,23 @@
 #ifndef POSTPROCESSOR_H
 #define POSTPROCESSOR_H
 
-#include <string>
-
 // MOOSE includes
-#include "InputParameters.h"
-#include "Restartable.h"
 #include "OutputInterface.h"
 
 // libMesh
 #include "libmesh/parallel.h"
 
+// Forward declarations
 class Postprocessor;
 
 template<>
 InputParameters validParams<Postprocessor>();
 
-
+/**
+ * Base class for all Postprocessors.  Defines a name and sets up the
+ * virtual getValue() interface which must be overridden by derived
+ * classes.
+ */
 class Postprocessor : public OutputInterface
 {
 public:

--- a/framework/include/postprocessors/PostprocessorInterface.h
+++ b/framework/include/postprocessors/PostprocessorInterface.h
@@ -16,17 +16,20 @@
 #define POSTPROCESSORINTERFACE_H
 
 // Standard includes
-#include <map>
 #include <string>
 
 // MOOSE includes
-#include "InputParameters.h"
-#include "ParallelUniqueId.h"
-#include "PostprocessorData.h"
+#include "MooseTypes.h"
 
 // Forward Declarations
 class FEProblem;
+class InputParameters;
+class PostprocessorName;
 
+/**
+ * Interface class for classes which interact with Postprocessors.
+ * Provides the getPostprocessorValueXYZ() and related interfaces.
+ */
 class PostprocessorInterface
 {
 public:

--- a/framework/include/postprocessors/PostprocessorWarehouse.h
+++ b/framework/include/postprocessors/PostprocessorWarehouse.h
@@ -15,14 +15,17 @@
 #ifndef POSTPROCESSORWAREHOUSE_H
 #define POSTPROCESSORWAREHOUSE_H
 
+// MOOSE includes
+#include "Warehouse.h"
+#include "MooseTypes.h"
+#include "Postprocessor.h"
+
+// C++ includes
 #include <vector>
 #include <map>
 #include <set>
 
-#include "Warehouse.h"
-#include "MooseTypes.h"
-
-class Postprocessor;
+// Forward declarations
 class ElementPostprocessor;
 class InternalSidePostprocessor;
 class NodalPostprocessor;

--- a/framework/include/postprocessors/ScalarL2Error.h
+++ b/framework/include/postprocessors/ScalarL2Error.h
@@ -15,19 +15,22 @@
 #ifndef SCALARL2ERROR_H
 #define SCALARL2ERROR_H
 
+// MOOSE includes
 #include "GeneralPostprocessor.h"
-#include "FunctionInterface.h"
 
+// Forward Declarations
 class Function;
-
-//Forward Declarations
 class ScalarL2Error;
+class MooseVariableScalar;
 
 template<>
 InputParameters validParams<ScalarL2Error>();
 
-class ScalarL2Error :
-  public GeneralPostprocessor
+/**
+ * Postprocessor for computing the error in a scalar value relative to
+ * a known Function's value.
+ */
+class ScalarL2Error : public GeneralPostprocessor
 {
 public:
   ScalarL2Error(const InputParameters & parameters);

--- a/framework/include/postprocessors/SideFluxIntegral.h
+++ b/framework/include/postprocessors/SideFluxIntegral.h
@@ -15,10 +15,10 @@
 #ifndef SIDEFLUXINTEGRAL_H
 #define SIDEFLUXINTEGRAL_H
 
+// MOOSE includes
 #include "SideIntegralVariablePostprocessor.h"
-#include "MaterialPropertyInterface.h"
 
-//Forward Declarations
+// Forward Declarations
 class SideFluxIntegral;
 
 template<>

--- a/framework/include/preconditioners/MoosePreconditioner.h
+++ b/framework/include/preconditioners/MoosePreconditioner.h
@@ -15,27 +15,25 @@
 #ifndef MOOSEPRECONDITIONER_H
 #define MOOSEPRECONDITIONER_H
 
+// MOOSE includes
 #include "MooseObject.h"
 #include "Restartable.h"
 
-// libMesh include
-#include "libmesh/numeric_vector.h"
-
-//Forward declarations
-namespace libMesh
-{
-  class MeshBase;
-}
-
+// Forward declarations
 class FEProblem;
 class MoosePreconditioner;
 
+namespace libMesh
+{
+class MeshBase;
+template <typename T> class NumericVector;
+}
 
 template<>
 InputParameters validParams<MoosePreconditioner>();
 
 /**
- * Base class for MOOSE preconditioners
+ * Base class for MOOSE preconditioners.
  */
 class MoosePreconditioner :
   public MooseObject,
@@ -46,11 +44,12 @@ public:
   virtual ~MoosePreconditioner();
 
   /**
-   * Helper function for copying values associated with variables in vectors from two different systems.
+   * Helper function for copying values associated with variables in
+   * vectors from two different systems.
    */
   static void copyVarValues(MeshBase & mesh,
-                     const unsigned int from_system, const unsigned int from_var, const NumericVector<Number> & from_vector,
-                     const unsigned int to_system, const unsigned int to_var, NumericVector<Number> & to_vector);
+                            const unsigned int from_system, const unsigned int from_var, const NumericVector<Number> & from_vector,
+                            const unsigned int to_system, const unsigned int to_var, NumericVector<Number> & to_vector);
 
 protected:
   /// Subproblem this preconditioner is part of

--- a/framework/include/preconditioners/PhysicsBasedPreconditioner.h
+++ b/framework/include/preconditioners/PhysicsBasedPreconditioner.h
@@ -15,17 +15,17 @@
 #ifndef PHYSICSBASEDPRECONDITIONER_H
 #define PHYSICSBASEDPRECONDITIONER_H
 
-//Global includes
-#include <vector>
 // MOOSE includes
 #include "MoosePreconditioner.h"
-//libMesh includes
+
+// libMesh includes
 #include "libmesh/preconditioner.h"
-#include "libmesh/system.h"
 #include "libmesh/linear_implicit_system.h"
 
+// C++ includes
+#include <vector>
 
-class FEProblem;
+// Forward declarations
 class NonlinearSystem;
 class PhysicsBasedPreconditioner;
 

--- a/framework/include/preconditioners/SplitBasedPreconditioner.h
+++ b/framework/include/preconditioners/SplitBasedPreconditioner.h
@@ -15,19 +15,10 @@
 #ifndef SPLITBASEDPRECONDITIONER_H
 #define SPLITBASEDPRECONDITIONER_H
 
-#include "libmesh/petsc_macro.h"
-
-//Global includes
-#include <vector>
 // MOOSE includes
 #include "MoosePreconditioner.h"
-//libMesh includes
-#include "libmesh/preconditioner.h"
-#include "libmesh/system.h"
-#include "libmesh/linear_implicit_system.h"
 
-
-class FEProblem;
+// Forward declarations
 class NonlinearSystem;
 class SplitBasedPreconditioner;
 
@@ -50,16 +41,14 @@ public:
    */
   virtual ~SplitBasedPreconditioner(){};
 
-
   /**
    * Sets up internals.
-   *
    */
   void setup();
 
 protected:
   /// The nonlinear system this FSP is associated with (convenience reference)
   NonlinearSystem & _nl;
-
 };
+
 #endif //SPLITBASEDPRECONDITIONER_H

--- a/framework/include/predictors/AdamsPredictor.h
+++ b/framework/include/predictors/AdamsPredictor.h
@@ -15,16 +15,23 @@
 #ifndef ADAMSPREDICTOR_H
 #define ADAMSPREDICTOR_H
 
+// MOOSE includes
 #include "Predictor.h"
-#include "libmesh/numeric_vector.h"
 
+// Forward declarations
 class AdamsPredictor;
+
+namespace libMesh
+{
+template <typename T> class NumericVector;
+}
 
 template<>
 InputParameters validParams<AdamsPredictor>();
 
 /**
- *
+ * Implements an explicit Adams predictor based on two old solution
+ * vectors.
  */
 class AdamsPredictor : public Predictor
 {

--- a/framework/include/predictors/Predictor.h
+++ b/framework/include/predictors/Predictor.h
@@ -15,20 +15,25 @@
 #ifndef PREDICTOR_H
 #define PREDICTOR_H
 
+// MOOSE includes
 #include "MooseObject.h"
 #include "Restartable.h"
-#include "libmesh/numeric_vector.h"
 
+// Forward declarations
 class Predictor;
 class FEProblem;
 class NonlinearSystem;
+
+namespace libMesh
+{
+template <typename T> class NumericVector;
+}
 
 template<>
 InputParameters validParams<Predictor>();
 
 /**
- * Base class for predictors
- *
+ * Base class for predictors.
  */
 class Predictor :
   public MooseObject,
@@ -55,7 +60,7 @@ protected:
   NumericVector<Number> & _solution_older;
   NumericVector<Number> & _solution_predictor;
 
-  ///
+  /// Amount by which to scale the predicted value.  Must be in [0,1].
   Real _scale;
 };
 

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -15,25 +15,30 @@
 #ifndef DATAIO_H
 #define DATAIO_H
 
-#include "Moose.h"
-#include "ColumnMajorMatrix.h"
+// MOOSE includes
 #include "MooseTypes.h"
 #include "HashMap.h"
+#include "MooseError.h"
 
-//libMesh
-#include "libmesh/dense_matrix.h"
+// libMesh includes
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_value.h"
-#include "libmesh/elem.h"
-#include "libmesh/numeric_vector.h"
 
+// C++ includes
 #include <string>
 #include <vector>
 #include <iostream>
-#include <fstream>
+#include <map>
 
-class MooseMesh;
-class FEProblem;
+// Forward declarations
+class ColumnMajorMatrix;
+namespace libMesh
+{
+template <typename T> class NumericVector;
+template <typename T> class DenseMatrix;
+template <typename T> class DenseVector;
+class Elem;
+}
 
 /**
  * Scalar helper routine

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -15,16 +15,18 @@
 #ifndef RESTARTABLE_H
 #define RESTARTABLE_H
 
-#include "InputParameters.h"
+// MOOSE includes
 #include "MooseTypes.h"
 #include "RestartableData.h"
 #include "ParallelUniqueId.h"
 
+// Forward declarations
 class PostprocessorData;
 class SubProblem;
+class InputParameters;
 
 /**
- * A  class for creating restricted objects
+ * A class for creating restricted objects
  * \see BlockRestartable BoundaryRestartable
  */
 class Restartable

--- a/framework/include/restart/RestartableData.h
+++ b/framework/include/restart/RestartableData.h
@@ -15,15 +15,13 @@
 #ifndef RESTARTABLEDATA_H
 #define RESTARTABLEDATA_H
 
-#include <vector>
-
-#include "ColumnMajorMatrix.h"
+// MOOSE includes
 #include "DataIO.h"
 
-#include "libmesh/libmesh_common.h"
-#include "libmesh/tensor_value.h"
-#include "libmesh/vector_value.h"
+// C++ includes
+#include <vector>
 
+// Forward declarations
 class RestartableDataValue;
 
 /**

--- a/framework/include/restart/RestartableDataIO.h
+++ b/framework/include/restart/RestartableDataIO.h
@@ -15,16 +15,17 @@
 #ifndef RESTARTABLEDATAIO_H
 #define RESTARTABLEDATAIO_H
 
-#include "Moose.h"
+// MOOSE includes
 #include "DataIO.h"
 
+// C++ includes
 #include <sstream>
 #include <string>
 #include <list>
 
+// Forward declarations
 class RestartableDatas;
 class RestartableDataValue;
-
 class FEProblem;
 
 /**

--- a/framework/include/restart/Resurrector.h
+++ b/framework/include/restart/Resurrector.h
@@ -15,12 +15,13 @@
 #ifndef RESURRECTOR_H
 #define RESURRECTOR_H
 
-#include "Moose.h"
+// MOOSE includes
 #include "RestartableDataIO.h"
 
+// C++ includes
 #include <string>
-#include <list>
 
+// Forward declarations
 class FEProblem;
 
 /**

--- a/framework/include/splits/ContactSplit.h
+++ b/framework/include/splits/ContactSplit.h
@@ -14,11 +14,15 @@
 
 #ifndef CONTACTSPLIT_H
 #define CONTACTSPLIT_H
-#include <vector>
-#include "libmesh/petsc_macro.h"
+
+// MOOSE includes
 #include "Split.h"
 
-class ContactSplit : public Split {
+/**
+ * Split-based preconditioner for contact problems.
+ */
+class ContactSplit : public Split
+{
  public:
   ContactSplit(const InputParameters & params);
   virtual void setup(const std::string& prefix = "-");

--- a/framework/include/splits/Split.h
+++ b/framework/include/splits/Split.h
@@ -14,11 +14,18 @@
 
 #ifndef SPLIT_H
 #define SPLIT_H
-#include <vector>
-#include "libmesh/petsc_macro.h"
-#include "FEProblem.h"
-#include "Restartable.h"
 
+// MOOSE includes
+#include "Restartable.h"
+#include "MooseObject.h"
+#include "PetscSupport.h"
+
+// Forward declarations
+class FEProblem;
+
+/**
+ * Base class for split-based preconditioners.
+ */
 class Split :
   public MooseObject,
   public Restartable

--- a/framework/include/splits/SplitWarehouse.h
+++ b/framework/include/splits/SplitWarehouse.h
@@ -15,13 +15,14 @@
 #ifndef SPLITWAREHOUSE_H
 #define SPLITWAREHOUSE_H
 
-#include <vector>
+// C++ includes
 #include <map>
-#include <set>
 
+// MOOSE includes
 #include "Warehouse.h"
 #include "MooseTypes.h"
 
+// Forward declarations
 class Split;
 
 /**

--- a/framework/include/timeintegrators/TimeIntegrator.h
+++ b/framework/include/timeintegrators/TimeIntegrator.h
@@ -15,14 +15,20 @@
 #ifndef TIMEINTEGRATOR_H
 #define TIMEINTEGRATOR_H
 
+// MOOSE includes
 #include "MooseObject.h"
-#include "libmesh/numeric_vector.h"
 #include "Restartable.h"
 
+// Forward declarations
 class TimeIntegrator;
 class FEProblem;
 class SystemBase;
 class NonlinearSystem;
+
+namespace libMesh
+{
+template <typename T> class NumericVector;
+}
 
 template<>
 InputParameters validParams<TimeIntegrator>();

--- a/framework/include/timesteppers/AB2PredictorCorrector.h
+++ b/framework/include/timesteppers/AB2PredictorCorrector.h
@@ -15,22 +15,27 @@
 #ifndef AB2PREDICTORCORRECTOR_H
 #define AB2PREDICTORCORRECTOR_H
 
+// MOOSE includes
 #include "TimeStepper.h"
-#include <iostream>
-#include <fstream>
-#include "libmesh/numeric_vector.h"
 
-// System includes
-#include <string>
+// C++ includes
+#include <fstream>
 
 // Forward Declarations
 class AB2PredictorCorrector;
+
+namespace libMesh
+{
+template <typename T> class NumericVector;
+}
 
 template<>
 InputParameters validParams<AB2PredictorCorrector>();
 
 /**
- *
+ * A TimeStepper based on the AB2 method.  Increases the timestep if
+ * the difference between the actual and AB2-predicted solutions is
+ * small enough.
  */
 class AB2PredictorCorrector : public TimeStepper
 {

--- a/framework/include/timesteppers/DT2.h
+++ b/framework/include/timesteppers/DT2.h
@@ -15,16 +15,25 @@
 #ifndef DT2_H_
 #define DT2_H_
 
+// MOOSE includes
 #include "TimeStepper.h"
-#include "libmesh/numeric_vector.h"
 
+// Forward declarations
 class DT2;
+
+namespace libMesh
+{
+template <typename T> class NumericVector;
+}
+
 
 template<>
 InputParameters validParams<DT2>();
 
 /**
- *
+ * An adaptive timestepper that compares the solution obtained from a
+ * single step of size dt with two steps of size dt/2 and adjusts the
+ * next timestep accordingly.
  */
 class DT2 : public TimeStepper
 {

--- a/framework/include/transfers/DTKInterpolationAdapter.h
+++ b/framework/include/transfers/DTKInterpolationAdapter.h
@@ -11,17 +11,15 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #ifndef DTKINTERPOLATIONADAPTER_H
 #define DTKINTERPOLATIONADAPTER_H
-
-#include "Moose.h"
 
 #include "libmesh/libmesh_config.h"
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
-#include "libmesh/dtk_evaluator.h"
-
+// DTK includes
 #include <DTK_MeshManager.hpp>
 #include <DTK_MeshContainer.hpp>
 #include <DTK_MeshTraits.hpp>
@@ -30,6 +28,7 @@
 #include <DTK_FieldContainer.hpp>
 #include <DTK_FieldEvaluator.hpp>
 
+// Trilinos includes
 #include <Teuchos_RCP.hpp>
 #include <Teuchos_ArrayRCP.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
@@ -39,7 +38,7 @@ class DTKInterpolationAdapter
 public:
   DTKInterpolationAdapter(Teuchos::RCP<const Teuchos::MpiComm<int> > in_comm, EquationSystems & in_es, const Point & offset, unsigned int from_dim);
 
-  typedef DataTransferKit::MeshContainer<long unsigned int>                                  MeshContainerType;
+  typedef DataTransferKit::MeshContainer<long unsigned int>                    MeshContainerType;
   typedef DataTransferKit::FieldContainer<double>                              FieldContainerType;
   typedef DataTransferKit::MeshTraits<MeshContainerType>::global_ordinal_type  GlobalOrdinal;
   typedef DataTransferKit::FieldEvaluator<GlobalOrdinal,FieldContainerType>    EvaluatorType;

--- a/framework/include/transfers/DTKInterpolationEvaluator.h
+++ b/framework/include/transfers/DTKInterpolationEvaluator.h
@@ -19,32 +19,36 @@
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
-#include "libmesh/equation_systems.h"
-#include "libmesh/mesh.h"
-#include "libmesh/system.h"
-
+// DTK includes
 #include <DTK_MeshContainer.hpp>
 #include <DTK_FieldEvaluator.hpp>
 #include <DTK_FieldContainer.hpp>
 
+// Trilinos includes
 #include <Teuchos_RCP.hpp>
 #include <Teuchos_ArrayRCP.hpp>
 
-#include <string>
+namespace libMesh
+{
 
-namespace libMesh {
+class System;
+class EquationSystems;
+class MeshBase;
 
+/**
+ * A class for performing interplation transfers via DTK.
+ */
 class DTKInterpolationEvaluator : public DataTransferKit::FieldEvaluator<long unsigned int,DataTransferKit::FieldContainer<double> >
 {
 public:
-  typedef DataTransferKit::MeshContainer<long unsigned int>        MeshContainerType;
-  typedef DataTransferKit::FieldContainer<Number>     FieldContainerType;
+  typedef DataTransferKit::MeshContainer<long unsigned int>                    MeshContainerType;
+  typedef DataTransferKit::FieldContainer<Number>                              FieldContainerType;
   typedef DataTransferKit::MeshTraits<MeshContainerType>::global_ordinal_type  GlobalOrdinal;
 
   DTKInterpolationEvaluator(System & in_sys, std::string var_name, const Point & offset);
 
-  FieldContainerType evaluate( const Teuchos::ArrayRCP<GlobalOrdinal>& elements,
-                               const Teuchos::ArrayRCP<double>& coords );
+  FieldContainerType evaluate(const Teuchos::ArrayRCP<GlobalOrdinal>& elements,
+                              const Teuchos::ArrayRCP<double>& coords);
 
 protected:
   System & sys;

--- a/framework/include/transfers/DTKInterpolationHelper.h
+++ b/framework/include/transfers/DTKInterpolationHelper.h
@@ -11,6 +11,7 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #ifndef DTKINTERPOLATIONHELPER_H
 #define DTKINTERPOLATIONHELPER_H
 
@@ -18,15 +19,14 @@
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
-#include "libmesh/solution_transfer.h"
+// MOOSE includes
 #include "DTKInterpolationAdapter.h"
 
-// DTK
+// DTK includes
 #include <DTK_SharedDomainMap.hpp>
 
-#include <string>
-
-namespace libMesh {
+namespace libMesh
+{
 
 /**
  * Helper object that uses DTK to interpolate between two libMesh based systems
@@ -49,7 +49,14 @@ public:
    * @param from_mpi_comm The MPI communicator the source domain lives on.  If NULL then this particular processor doesn't contain the source domain.
    * @param to_mpi_comm The MPI communicator the destination domain lives on.  If NULL then this particular processor doesn't contain the destination domain.
    */
-  void transferWithOffset(unsigned int from, unsigned int to, const Variable * from_var, const Variable * to_var, const Point & from_offset, const Point & to_offset, MPI_Comm * from_mpi_comm, MPI_Comm * to_mpi_comm);
+  void transferWithOffset(unsigned int from,
+                          unsigned int to,
+                          const Variable * from_var,
+                          const Variable * to_var,
+                          const Point & from_offset,
+                          const Point & to_offset,
+                          MPI_Comm * from_mpi_comm,
+                          MPI_Comm * to_mpi_comm);
 
 protected:
   typedef DataTransferKit::SharedDomainMap<DTKInterpolationAdapter::MeshContainerType,DTKInterpolationAdapter::MeshContainerType> shared_domain_map_type;

--- a/framework/include/transfers/MultiAppCopyTransfer.h
+++ b/framework/include/transfers/MultiAppCopyTransfer.h
@@ -17,7 +17,7 @@
 
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppCopyTransfer;
 
 template<>

--- a/framework/include/transfers/MultiAppDTKInterpolationTransfer.h
+++ b/framework/include/transfers/MultiAppDTKInterpolationTransfer.h
@@ -12,16 +12,17 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifdef LIBMESH_TRILINOS_HAVE_DTK
-
 #ifndef MULTIAPPDTKINTERPOLATIONTRANSFER_H
 #define MULTIAPPDTKINTERPOLATIONTRANSFER_H
 
+#include "libmesh/libmesh_config.h"
+
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
+
 #include "MultiAppTransfer.h"
-#include "MooseVariableInterface.h"
 #include "DTKInterpolationHelper.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppDTKInterpolationTransfer;
 
 template<>
@@ -47,6 +48,5 @@ protected:
   Point _master_position;
 };
 
-#endif /* MULTIAPPDTKINTERPOLATIONTRANSFER_H */
-
-#endif //LIBMESH_TRILINOS_HAVE_DTK
+#endif // LIBMESH_TRILINOS_HAVE_DTK
+#endif // MULTIAPPDTKINTERPOLATIONTRANSFER_H

--- a/framework/include/transfers/MultiAppDTKUserObjectEvaluator.h
+++ b/framework/include/transfers/MultiAppDTKUserObjectEvaluator.h
@@ -11,20 +11,28 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
-#ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #ifndef MULTIAPPDTKUSEROBJECTEVALUATOR_H
 #define MULTIAPPDTKUSEROBJECTEVALUATOR_H
 
-#include "MultiApp.h"
+#include "libmesh/libmesh_config.h"
 
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
+
+// Forward declarations
+class MultiApp;
+
+// DTK includes
 #include <DTK_FieldEvaluator.hpp>
 #include <DTK_FieldContainer.hpp>
 #include <DTK_GeometryManager.hpp>
 #include <DTK_Box.hpp>
 
-class MultiAppDTKUserObjectEvaluator: public DataTransferKit::FieldEvaluator<
-  long unsigned int, DataTransferKit::FieldContainer<double> >
+/**
+ * Evaluates the specified UserObject and returns the result in a DTK FieldContainer.
+ */
+class MultiAppDTKUserObjectEvaluator :
+  public DataTransferKit::FieldEvaluator<long unsigned int, DataTransferKit::FieldContainer<double> >
 {
 public:
   MultiAppDTKUserObjectEvaluator(MultiApp & multi_app, const std::string & user_object_name);
@@ -49,6 +57,5 @@ private:
 };
 
 
-#endif //MULTIAPPDTKUSEROBJECTEVALUATOR_H
-
 #endif //LIBMESH_TRILINOS_HAVE_DTK
+#endif //MULTIAPPDTKUSEROBJECTEVALUATOR_H

--- a/framework/include/transfers/MultiAppDTKUserObjectTransfer.h
+++ b/framework/include/transfers/MultiAppDTKUserObjectTransfer.h
@@ -12,17 +12,19 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifdef LIBMESH_TRILINOS_HAVE_DTK
-
 #ifndef MULTIAPPDTKUSEROBJECTTRANSFER_H
 #define MULTIAPPDTKUSEROBJECTTRANSFER_H
 
+#include "libmesh/libmesh_config.h"
+
+#ifdef LIBMESH_TRILINOS_HAVE_DTK
+
+// MOOSE includes
 #include "MultiAppTransfer.h"
 #include "MooseVariableInterface.h"
 #include "MultiAppDTKUserObjectEvaluator.h"
-#include "DTKInterpolationAdapter.h"
 
-// DTK Includes
+// DTK includes
 #include <DTK_VolumeSourceMap.hpp>
 #include <DTK_MeshManager.hpp>
 #include <DTK_MeshContainer.hpp>
@@ -35,6 +37,8 @@
 #include <DTK_CommTools.hpp>
 #include <DTK_GeometryManager.hpp>
 #include <DTK_Box.hpp>
+
+// Trilinos includes
 #include <Teuchos_RCP.hpp>
 #include <Teuchos_ArrayRCP.hpp>
 #include <Teuchos_CommHelpers.hpp>
@@ -42,12 +46,9 @@
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_Ptr.hpp>
 
-
-// libMesh Includes
-#include "libmesh/dtk_solution_transfer.h"
-
-class MooseVariable;
+// Forward declarations
 class MultiAppDTKUserObjectTransfer;
+class DTKInterpolationAdapter;
 
 template<>
 InputParameters validParams<MultiAppDTKUserObjectTransfer>();
@@ -87,6 +88,6 @@ protected:
   Teuchos::RCP<DataTransferKit::FieldManager<DTKAdapter::FieldContainerType> > _to_values;
 };
 
-#endif /* MULTIAPPDTKUSEROBJECTTRANSFER_H */
 
-#endif //LIBMESH_TRILINOS_HAVE_DTK
+#endif // LIBMESH_TRILINOS_HAVE_DTK
+#endif // MULTIAPPDTKUSEROBJECTTRANSFER_H

--- a/framework/include/transfers/MultiAppInterpolationTransfer.h
+++ b/framework/include/transfers/MultiAppInterpolationTransfer.h
@@ -15,9 +15,10 @@
 #ifndef MULTIAPPINTERPOLATIONTRANSFER_H
 #define MULTIAPPINTERPOLATIONTRANSFER_H
 
+// MOOSE includes
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppInterpolationTransfer;
 
 template<>

--- a/framework/include/transfers/MultiAppMeshFunctionTransfer.h
+++ b/framework/include/transfers/MultiAppMeshFunctionTransfer.h
@@ -17,15 +17,16 @@
 
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppMeshFunctionTransfer;
 
 template<>
 InputParameters validParams<MultiAppMeshFunctionTransfer>();
 
 /**
- * Samples a variable's value in the Master domain at the point where the MultiApp is.
- * Copies that value into a postprocessor in the MultiApp.
+ * Samples a variable's value in the Master domain at the point where
+ * the MultiApp is.  Copies that value into a postprocessor in the
+ * MultiApp.
  */
 class MultiAppMeshFunctionTransfer :
   public MultiAppTransfer

--- a/framework/include/transfers/MultiAppNearestNodeTransfer.h
+++ b/framework/include/transfers/MultiAppNearestNodeTransfer.h
@@ -15,9 +15,10 @@
 #ifndef MULTIAPPNEARESTNODETRANSFER_H
 #define MULTIAPPNEARESTNODETRANSFER_H
 
+// MOOSE includes
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppNearestNodeTransfer;
 
 template<>

--- a/framework/include/transfers/MultiAppPostprocessorInterpolationTransfer.h
+++ b/framework/include/transfers/MultiAppPostprocessorInterpolationTransfer.h
@@ -15,9 +15,10 @@
 #ifndef MULTIAPPPOSTPROCESSORINTERPOLATIONTRANSFER_H
 #define MULTIAPPPOSTPROCESSORINTERPOLATIONTRANSFER_H
 
+// MOOSE includes
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppPostprocessorInterpolationTransfer;
 
 template<>

--- a/framework/include/transfers/MultiAppPostprocessorToAuxScalarTransfer.h
+++ b/framework/include/transfers/MultiAppPostprocessorToAuxScalarTransfer.h
@@ -19,7 +19,6 @@
 #include "MultiAppTransfer.h"
 
 // Forward declerations
-class MooseVariable;
 class MultiAppPostprocessorToAuxScalarTransfer;
 
 template<>

--- a/framework/include/transfers/MultiAppPostprocessorTransfer.h
+++ b/framework/include/transfers/MultiAppPostprocessorTransfer.h
@@ -17,14 +17,14 @@
 
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppPostprocessorTransfer;
 
 template<>
 InputParameters validParams<MultiAppPostprocessorTransfer>();
 
 /**
- * Copies the value of a Postprocessor from the Master to a MultiApp
+ * Copies the value of a Postprocessor from the Master to a MultiApp.
  */
 class MultiAppPostprocessorTransfer :
   public MultiAppTransfer

--- a/framework/include/transfers/MultiAppTransfer.h
+++ b/framework/include/transfers/MultiAppTransfer.h
@@ -15,12 +15,17 @@
 #ifndef MULTIAPPTRANSFER_H
 #define MULTIAPPTRANSFER_H
 
+// MOOSE includes
 #include "Transfer.h"
-#include "MultiApp.h"
 #include "MooseEnum.h"
-#include "MooseTypes.h"
 
+// libMesh includes
+#include "libmesh/mesh_tools.h"
+
+// Forward declarations
 class MultiAppTransfer;
+class MooseMesh;
+class MultiApp;
 
 template<>
 InputParameters validParams<MultiAppTransfer>();
@@ -28,10 +33,11 @@ InputParameters validParams<MultiAppTransfer>();
 /**
  * Base class for all MultiAppTransfer objects.
  *
- * MultiAppTransfers are objects that push and pull values to and from MultiApp objects
- * from and to the main (master) system.
+ * MultiAppTransfers are objects that push and pull values to and from
+ * MultiApp objects from and to the main (master) system.
  *
- * Classes that inherit from this class still need to override the execute() method from Transfer.
+ * Classes that inherit from this class still need to override the
+ * execute() method from Transfer.
  */
 class MultiAppTransfer : public Transfer
 {

--- a/framework/include/transfers/MultiAppUserObjectTransfer.h
+++ b/framework/include/transfers/MultiAppUserObjectTransfer.h
@@ -15,17 +15,19 @@
 #ifndef MULTIAPPUSEROBJECTTRANSFER_H
 #define MULTIAPPUSEROBJECTTRANSFER_H
 
+// MOOSE includes
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppUserObjectTransfer;
 
 template<>
 InputParameters validParams<MultiAppUserObjectTransfer>();
 
 /**
- * Samples a variable's value in the Master domain at the point where the MultiApp is.
- * Copies that value into a postprocessor in the MultiApp.
+ * Samples a variable's value in the Master domain at the point where
+ * the MultiApp is.  Copies that value into a postprocessor in the
+ * MultiApp.
  */
 class MultiAppUserObjectTransfer :
   public MultiAppTransfer
@@ -45,4 +47,4 @@ protected:
   bool _displaced_target_mesh;
 };
 
-#endif /* MULTIAPPVARIABLEVALUESAMPLEPOSTPROCESSORTRANSFER_H */
+#endif // MULTIAPPVARIABLEVALUESAMPLEPOSTPROCESSORTRANSFER_H

--- a/framework/include/transfers/MultiAppVariableValueSamplePostprocessorTransfer.h
+++ b/framework/include/transfers/MultiAppVariableValueSamplePostprocessorTransfer.h
@@ -17,15 +17,16 @@
 
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppVariableValueSamplePostprocessorTransfer;
 
 template<>
 InputParameters validParams<MultiAppVariableValueSamplePostprocessorTransfer>();
 
 /**
- * Samples a variable's value in the Master domain at the point where the MultiApp is.
- * Copies that value into a postprocessor in the MultiApp.
+ * Samples a variable's value in the Master domain at the point where
+ * the MultiApp is.  Copies that value into a postprocessor in the
+ * MultiApp.
  */
 class MultiAppVariableValueSamplePostprocessorTransfer :
   public MultiAppTransfer
@@ -41,4 +42,4 @@ protected:
   PostprocessorName _from_var_name;
 };
 
-#endif /* MULTIAPPVARIABLEVALUESAMPLEPOSTPROCESSORTRANSFER_H */
+#endif // MULTIAPPVARIABLEVALUESAMPLEPOSTPROCESSORTRANSFER_H

--- a/framework/include/transfers/MultiAppVariableValueSampleTransfer.h
+++ b/framework/include/transfers/MultiAppVariableValueSampleTransfer.h
@@ -15,17 +15,18 @@
 #ifndef MULTIAPPVARIABLEVALUESAMPLETRANSFER_H
 #define MULTIAPPVARIABLEVALUESAMPLETRANSFER_H
 
+// MOOSE includes
 #include "MultiAppTransfer.h"
 
-class MooseVariable;
+// Forward declarations
 class MultiAppVariableValueSampleTransfer;
 
 template<>
 InputParameters validParams<MultiAppVariableValueSampleTransfer>();
 
 /**
- * Samples a variable's value in the Master domain at the point where the MultiApp is.
- * Copies that value into a field in the MultiApp.
+ * Samples a variable's value in the Master domain at the point where
+ * the MultiApp is.  Copies that value into a field in the MultiApp.
  */
 class MultiAppVariableValueSampleTransfer :
   public MultiAppTransfer

--- a/framework/include/transfers/Transfer.h
+++ b/framework/include/transfers/Transfer.h
@@ -18,18 +18,20 @@
 // Moose
 #include "ParallelUniqueId.h"
 #include "MooseObject.h"
-#include "InputParameters.h"
 #include "SetupInterface.h"
-#include "MooseEnum.h"
 #include "Restartable.h"
 
-// libMesh
-#include "libmesh/system.h"
-
+// Forward declarations
 class Transfer;
 class SubProblem;
 class FEProblem;
 class SystemBase;
+
+namespace libMesh
+{
+class System;
+class EquationSystems;
+}
 
 template<>
 InputParameters validParams<Transfer>();

--- a/framework/include/transfers/TransferWarehouse.h
+++ b/framework/include/transfers/TransferWarehouse.h
@@ -15,18 +15,16 @@
 #ifndef TRANSFERWAREHOUSE_H
 #define TRANSFERWAREHOUSE_H
 
-#include <vector>
-#include <map>
-#include <set>
-
+// MOOSE includes
 #include "Warehouse.h"
 #include "MooseTypes.h"
 
+// Forward declarations
 class Transfer;
 class MultiAppTransfer;
 
 /**
- * Holds Transfers and provides some services
+ * Holds Transfers and provides some services.
  */
 class TransferWarehouse : public Warehouse<Transfer>
 {

--- a/framework/include/userobject/ElementIntegralUserObject.h
+++ b/framework/include/userobject/ElementIntegralUserObject.h
@@ -15,19 +15,21 @@
 #ifndef ELEMENTINTEGRALUSEROBJECT_H
 #define ELEMENTINTEGRALUSEROBJECT_H
 
-#include "ElementPostprocessor.h"
+// MOOSE includes
+#include "ElementUserObject.h"
 
-//Forward Declarations
+// Forward Declarations
 class ElementIntegralUserObject;
 
 template<>
 InputParameters validParams<ElementIntegralUserObject>();
 
 /**
- * This postprocessor computes a volume integral of the specified variable.
+ * This postprocessor computes a volume integral of the specified
+ * variable.
  *
- * Note that specializations of this integral are possible by deriving from this
- * class and overriding computeQpIntegral().
+ * Note that specializations of this integral are possible by deriving
+ * from this class and overriding computeQpIntegral().
  */
 class ElementIntegralUserObject : public ElementUserObject
 {

--- a/framework/include/userobject/ElementUserObject.h
+++ b/framework/include/userobject/ElementUserObject.h
@@ -15,24 +15,27 @@
 #ifndef ELEMENTUSEROBJECT_H
 #define ELEMENTUSEROBJECT_H
 
-#include "MooseVariable.h"
+// MOOSE includes
 #include "UserObject.h"
+#include "BlockRestrictable.h"
+#include "MaterialPropertyInterface.h"
 #include "UserObjectInterface.h"
 #include "Coupleable.h"
 #include "ScalarCoupleable.h"
 #include "MooseVariableDependencyInterface.h"
 #include "TransientInterface.h"
 #include "PostprocessorInterface.h"
-#include "BlockRestrictable.h"
-#include "MaterialPropertyInterface.h"
 #include "RandomInterface.h"
 #include "ZeroInterface.h"
-// libMesh
-#include "libmesh/elem.h"
-#include "MooseTypes.h"
 
-//Forward Declarations
+// Forward Declarations
 class ElementUserObject;
+
+namespace libMesh
+{
+class Elem;
+class QBase;
+}
 
 template<>
 InputParameters validParams<ElementUserObject>();
@@ -54,9 +57,10 @@ public:
   ElementUserObject(const InputParameters & parameters);
 
   /**
-   * This function will get called on each geometric object this postprocessor acts on
-   * (ie Elements, Sides or Nodes).  This will most likely get called multiple times
-   * before getValue() is called.
+   * This function will get called on each geometric object this
+   * postprocessor acts on (ie Elements, Sides or Nodes).  This will
+   * most likely get called multiple times before getValue() is
+   * called.
    *
    * Someone somewhere has to override this.
    */

--- a/framework/include/userobject/GeneralUserObject.h
+++ b/framework/include/userobject/GeneralUserObject.h
@@ -15,17 +15,16 @@
 #ifndef GENERALUSEROBJECT_H
 #define GENERALUSEROBJECT_H
 
+// MOOSE includes
 #include "UserObject.h"
+#include "MaterialPropertyInterface.h"
 #include "TransientInterface.h"
 #include "DependencyResolverInterface.h"
 #include "UserObjectInterface.h"
 #include "PostprocessorInterface.h"
 #include "VectorPostprocessorInterface.h"
-#include "MaterialPropertyInterface.h"
-#include "Problem.h"
 
-
-//Forward Declarations
+// Forward Declarations
 class GeneralUserObject;
 
 template<>

--- a/framework/include/userobject/LayeredAverage.h
+++ b/framework/include/userobject/LayeredAverage.h
@@ -17,17 +17,15 @@
 
 #include "LayeredIntegral.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
-//Forward Declarations
+// Forward Declarations
 class LayeredAverage;
 
 template<>
 InputParameters validParams<LayeredAverage>();
 
 /**
- * This UserObject computes  averages of a variable storing partial sums for the specified number of intervals in a direction (x,y,z).c
+ * This UserObject computes averages of a variable storing partial
+ * sums for the specified number of intervals in a direction (x,y,z).
  */
 class LayeredAverage : public LayeredIntegral
 {

--- a/framework/include/userobject/LayeredBase.h
+++ b/framework/include/userobject/LayeredBase.h
@@ -15,25 +15,31 @@
 #ifndef LAYEREDBASE_H
 #define LAYEREDBASE_H
 
+// MOOSE includes
 #include "InputParameters.h"
-#include "UserObject.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
-//Forward Declarations
+// Forward Declarations
 class LayeredBase;
+class UserObject;
+class SubProblem;
 
 template<>
 InputParameters validParams<LayeredBase>();
 
 /**
- * This UserObject computes volume integrals of a variable storing partial sums for the specified number of intervals in a direction (x,y,z).c
+ * This UserObject computes volume integrals of a variable storing
+ * partial sums for the specified number of intervals in a direction
+ * (x,y,z).
  */
 class LayeredBase
 {
 public:
   LayeredBase(const InputParameters & parameters);
+
+  /**
+   * Class with virtual methods needs a virtual destructor.
+   */
+  virtual ~LayeredBase() {}
 
   /**
    * Given a Point return the integral value associated with the layer that point falls in.
@@ -61,7 +67,6 @@ public:
   virtual void threadJoin(const UserObject & y);
 
 protected:
-
   /**
    * Set the value for a particular layer
    * @param layer The layer you are setting the value for
@@ -103,6 +108,7 @@ protected:
 
   Real _direction_min;
   Real _direction_max;
+
 private:
   /// Value of the integral for each layer
   std::vector<Real> _layer_values;

--- a/framework/include/userobject/LayeredIntegral.h
+++ b/framework/include/userobject/LayeredIntegral.h
@@ -15,12 +15,9 @@
 #ifndef LAYEREDINTEGRAL_H
 #define LAYEREDINTEGRAL_H
 
+// MOOSE includes
 #include "ElementIntegralVariableUserObject.h"
-
 #include "LayeredBase.h"
-
-// libmesh includes
-#include "libmesh/mesh_tools.h"
 
 //Forward Declarations
 class LayeredIntegral;

--- a/framework/include/userobject/LayeredSideAverage.h
+++ b/framework/include/userobject/LayeredSideAverage.h
@@ -15,12 +15,10 @@
 #ifndef LAYEREDSIDEAVERAGE_H
 #define LAYEREDSIDEAVERAGE_H
 
+// MOOSE includes
 #include "LayeredSideIntegral.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
-//Forward Declarations
+// Forward Declarations
 class LayeredSideAverage;
 
 template<>

--- a/framework/include/userobject/LayeredSideFluxAverage.h
+++ b/framework/include/userobject/LayeredSideFluxAverage.h
@@ -15,19 +15,18 @@
 #ifndef LAYEREDSIDEFLUXAVERAGE_H
 #define LAYEREDSIDEFLUXAVERAGE_H
 
+// MOOSE includes
 #include "LayeredSideAverage.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
-//Forward Declarations
+// Forward Declarations
 class LayeredSideFluxAverage;
 
 template<>
 InputParameters validParams<LayeredSideFluxAverage>();
 
 /**
- * This UserObject computes side averages of a flux storing partial sums for the specified number of intervals in a direction (x,y,z).
+ * This UserObject computes side averages of a flux storing partial
+ * sums for the specified number of intervals in a direction (x,y,z).
  */
 class LayeredSideFluxAverage : public LayeredSideAverage
 {

--- a/framework/include/userobject/LayeredSideIntegral.h
+++ b/framework/include/userobject/LayeredSideIntegral.h
@@ -15,21 +15,20 @@
 #ifndef LAYEREDSIDEINTEGRAL_H
 #define LAYEREDSIDEINTEGRAL_H
 
+// MOOSE includes
 #include "SideIntegralVariableUserObject.h"
-
 #include "LayeredBase.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
-//Forward Declarations
+// Forward Declarations
 class LayeredSideIntegral;
 
 template<>
 InputParameters validParams<LayeredSideIntegral>();
 
 /**
- * This UserObject computes volume integrals of a variable storing partial sums for the specified number of intervals in a direction (x,y,z).c
+ * This UserObject computes volume integrals of a variable storing
+ * partial sums for the specified number of intervals in a direction
+ * (x,y,z).
  */
 class LayeredSideIntegral : public SideIntegralVariableUserObject, public LayeredBase
 {

--- a/framework/include/userobject/NearestPointLayeredAverage.h
+++ b/framework/include/userobject/NearestPointLayeredAverage.h
@@ -15,22 +15,22 @@
 #ifndef NEARESTPOINTLAYEREDAVERAGE_H
 #define NEARESTPOINTLAYEREDAVERAGE_H
 
+// MOOSE includes
 #include "ElementIntegralVariableUserObject.h"
-#include "LayeredAverage.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
-//Forward Declarations
+// Forward Declarations
 class NearestPointLayeredAverage;
+class LayeredAverage;
 
 template<>
 InputParameters validParams<NearestPointLayeredAverage>();
 
 /**
- * This UserObject computes  averages of a variable storing partial sums for the specified number of intervals in a direction (x,y,z).
+ * This UserObject computes averages of a variable storing partial
+ * sums for the specified number of intervals in a direction (x,y,z).
  *
- * Given a list of points this object computes the layered average closest to each one of those points.
+ * Given a list of points this object computes the layered average
+ * closest to each one of those points.
  */
 class NearestPointLayeredAverage : public ElementIntegralVariableUserObject
 {
@@ -44,11 +44,13 @@ public:
   virtual void threadJoin(const UserObject & y);
 
   /**
-   * Given a Point return the integral value associated with the layer that point falls in for the layered average closest to that point.
+   * Given a Point return the integral value associated with the layer
+   * that point falls in for the layered average closest to that
+   * point.
    *
    * @param p The point to look for in the layers.
    */
-  virtual Real spatialValue(const Point & p) const { return nearestLayeredAverage(p)->integralValue(p); }
+  virtual Real spatialValue(const Point & p) const;
 
 protected:
   /**

--- a/framework/include/userobject/NodalNormalsPreprocessor.h
+++ b/framework/include/userobject/NodalNormalsPreprocessor.h
@@ -15,11 +15,14 @@
 #ifndef NODALNORMALSPREPROCESSOR_H
 #define NODALNORMALSPREPROCESSOR_H
 
+// MOOSE includes
 #include "ElementUserObject.h"
-#include "SideUserObject.h"
 #include "BoundaryRestrictable.h"
-#include "libmesh/fe.h"
 
+// libMesh includes
+#include "libmesh/fe_type.h"
+
+// Forward declarations
 class NodalNormalsPreprocessor;
 class AuxiliarySystem;
 
@@ -27,7 +30,8 @@ template<>
 InputParameters validParams<NodalNormalsPreprocessor>();
 
 /**
- *
+ * An ElementUserObject that prepares MOOSE for computing nodal
+ * normals.
  */
 class NodalNormalsPreprocessor :
   public ElementUserObject,

--- a/framework/include/userobject/NodalUserObject.h
+++ b/framework/include/userobject/NodalUserObject.h
@@ -15,26 +15,30 @@
 #ifndef NODALUSEROBJECT_H
 #define NODALUSEROBJECT_H
 
+// MOOSE includes
 #include "UserObject.h"
-#include "CoupleableMooseVariableDependencyIntermediateInterface.h"
-#include "UserObjectInterface.h"
-#include "MooseVariable.h"
-#include "TransientInterface.h"
-#include "PostprocessorInterface.h"
 #include "BlockRestrictable.h"
 #include "BoundaryRestrictable.h"
 #include "MaterialPropertyInterface.h"
+#include "UserObjectInterface.h"
+#include "Coupleable.h"
+#include "ScalarCoupleable.h"
+#include "MooseVariableDependencyInterface.h"
+#include "TransientInterface.h"
+#include "PostprocessorInterface.h"
 #include "RandomInterface.h"
 #include "ZeroInterface.h"
 
-class MooseVariable;
-
-//Forward Declarations
+// Forward Declarations
 class NodalUserObject;
 
 template<>
 InputParameters validParams<NodalUserObject>();
 
+/**
+ * A user object that runs over all the nodes and does an aggregation
+ * step to compute a single value.
+ */
 class NodalUserObject :
   public UserObject,
   public BlockRestrictable,

--- a/framework/include/userobject/SideIntegralUserObject.h
+++ b/framework/include/userobject/SideIntegralUserObject.h
@@ -15,9 +15,10 @@
 #ifndef SIDEINTEGRALUSEROBJECT_H
 #define SIDEINTEGRALUSEROBJECT_H
 
-#include "SidePostprocessor.h"
+// MOOSE includes
+#include "SideUserObject.h"
 
-//Forward Declarations
+// Forward Declarations
 class SideIntegralUserObject;
 
 template<>

--- a/framework/include/userobject/SideUserObject.h
+++ b/framework/include/userobject/SideUserObject.h
@@ -15,18 +15,18 @@
 #ifndef SIDEUSEROBJECT_H
 #define SIDEUSEROBJECT_H
 
+// MOOSE includes
 #include "UserObject.h"
+#include "BoundaryRestrictable.h"
+#include "MaterialPropertyInterface.h"
 #include "Coupleable.h"
 #include "MooseVariableDependencyInterface.h"
-#include "MooseVariable.h"
-#include "MaterialPropertyInterface.h"
-#include "TransientInterface.h"
 #include "UserObjectInterface.h"
+#include "TransientInterface.h"
 #include "PostprocessorInterface.h"
-#include "BoundaryRestrictable.h"
 #include "ZeroInterface.h"
 
-//Forward Declarations
+// Forward Declarations
 class SideUserObject;
 
 template<>

--- a/framework/include/userobject/SolutionUserObject.h
+++ b/framework/include/userobject/SolutionUserObject.h
@@ -11,28 +11,33 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #ifndef SOLUTIONUSEROBJECT_H
 #define SOLUTIONUSEROBJECT_H
 
+// MOOSE includes
 #include "GeneralUserObject.h"
-#include "libmesh/exodusII_io.h"
-#include "MooseUtils.h"
 
-// Forward Declarations
+// Forward declarations
 namespace libMesh
 {
-  class Mesh;
-  class EquationSystems;
-  class System;
-  class MeshFunction;
-  template<class T> class NumericVector;
+class ExodusII_IO;
+class EquationSystems;
+class System;
+class MeshFunction;
+template<class T> class NumericVector;
 }
 
+// Forward declarations
 class SolutionUserObject;
 
 template<>
 InputParameters validParams<SolutionUserObject>();
 
+/**
+ * User object that reads an existing solution from an input file and
+ * uses it in the current simulation.
+ */
 class SolutionUserObject : public GeneralUserObject
 {
 public:

--- a/framework/include/userobject/UserObject.h
+++ b/framework/include/userobject/UserObject.h
@@ -15,22 +15,22 @@
 #ifndef USEROBJECT_H
 #define USEROBJECT_H
 
-//MOOSE includes
+// MOOSE includes
 #include "MooseObject.h"
 #include "SetupInterface.h"
 #include "FunctionInterface.h"
-#include "ParallelUniqueId.h"
-#include "SubProblem.h"
 #include "Restartable.h"
-#include "MooseMesh.h"
 #include "MeshChangedInterface.h"
+#include "ParallelUniqueId.h"
 
-//libMesh includes
-#include "libmesh/libmesh_common.h"
+// libMesh includes
 #include "libmesh/parallel.h"
 
+// Forward declarations
 class UserObject;
 class FEProblem;
+class SubProblem;
+class Assembly;
 
 template<>
 InputParameters validParams<UserObject>();

--- a/framework/include/userobject/UserObjectIO.h
+++ b/framework/include/userobject/UserObjectIO.h
@@ -15,7 +15,11 @@
 #ifndef USEROBJECTIO_H
 #define USEROBJECTIO_H
 
-#include "UserObjectWarehouse.h"
+// C++ includes
+#include <string>
+
+// Forward declarations
+class UserObjectWarehouse;
 
 class UserObjectIO
 {

--- a/framework/include/userobject/UserObjectInterface.h
+++ b/framework/include/userobject/UserObjectInterface.h
@@ -15,13 +15,15 @@
 #ifndef USEROBJECTINTERFACE_H
 #define USEROBJECTINTERFACE_H
 
-#include "InputParameters.h"
+// MOOSE includes
 #include "ParallelUniqueId.h"
-#include "MooseTypes.h"
 #include "FEProblem.h"
 
+// Forward declarations
+class InputParameters;
+
 /**
- * Interface for objects that need to use user objects
+ * Interface for objects that need to use UserObjects.
  */
 class UserObjectInterface
 {

--- a/framework/include/userobject/VerifyElementUniqueID.h
+++ b/framework/include/userobject/VerifyElementUniqueID.h
@@ -15,10 +15,10 @@
 #ifndef VERIFYELEMENTUNIQUEID_H
 #define VERIFYELEMENTUNIQUEID_H
 
+// MOOSE includes
 #include "ElementUserObject.h"
-#include "libmesh/id_types.h"
 
-//Forward Declarations
+// Forward Declarations
 class VerifyElementUniqueID;
 
 template<>

--- a/framework/include/userobject/VerifyNodalUniqueID.h
+++ b/framework/include/userobject/VerifyNodalUniqueID.h
@@ -15,10 +15,10 @@
 #ifndef VERIFYNODALUNIQUEID_H
 #define VERIFYNODALUNIQUEID_H
 
+// MOOSE includes
 #include "NodalUserObject.h"
-#include "libmesh/id_types.h"
 
-//Forward Declarations
+// Forward Declarations
 class VerifyNodalUniqueID;
 
 template<>

--- a/framework/include/utils/ArbitraryQuadrature.h
+++ b/framework/include/utils/ArbitraryQuadrature.h
@@ -15,13 +15,14 @@
 #ifndef ARBITRARYQUADRATURE_H
 #define ARBITRARYQUADRATURE_H
 
-#include "Moose.h"
+// MOOSE includes
+#include "Moose.h" // using namespace libMesh
 
-//libMesh
+// libMesh includes
 #include "libmesh/quadrature.h"
 
 /**
- * Implements a fake quadrature rule where you can specify the points
+ * Implements a fake quadrature rule where you can specify the locations
  * (in the reference domain) of the quadrature points.
  */
 class ArbitraryQuadrature : public QBase

--- a/framework/include/utils/BilinearInterpolation.h
+++ b/framework/include/utils/BilinearInterpolation.h
@@ -15,46 +15,56 @@
 #ifndef BILINEARINTERPOLATION_H
 #define BILINEARINTERPOLATION_H
 
-#include <vector>
-#include <fstream>
-#include <sstream>
-#include <string>
-
+// MOOSE includes
 #include "ColumnMajorMatrix.h"
-#include "Moose.h"
 
+// C++ includes
+#include <vector>
 
 /**
- * This class applies the Least Squares algorithm to a set of points to provide a smooth curve for
- * sampling values.
+ * This class applies the Least Squares algorithm to a set of points
+ * to provide a smooth curve for sampling values.
+ * BilinearInterpolation is designed to linearly interpolate a
+ * function of two values e.g. z(x,y).  Supply Bilinearlinear with a
+ * vector of x and a vector of y and a ColumnMajorMatrix of function
+ * values, z, that correspond to the values in the vectors x and
+ * y...and also a sample point (xcoord and ycoord), and
+ * BilinearInterpolation will return the value of the function at the
+ * sample point.  A simple example:
  *
- * Requires: LAPACK
+ * x = [1 2], y = [1 2],
+ *
+ * z = [1 2]
+ *     [3 4]
+ *
+ * with xcoord = 1.5 and ycoord = 1.5 returns a value of 2.5.
  */
 class BilinearInterpolation
 {
 public:
 
-  /* Constructor, Takes two vectors of points for which to apply the fit.  One should be of the
-   * independent variable while the other should be of the dependent variable.  These values should
+  /**
+   *  Constructor, Takes two vectors of points for which to apply the
+   * fit.  One should be of the independent variable while the other
+   * should be of the dependent variable.  These values should
    * correspond to one and other in the same position.
    */
   BilinearInterpolation(const std::vector<Real> & XAXIS,
                         const std::vector<Real> & YAXIS,
-                        const ColumnMajorMatrix  & ZSURFACE);
+                        const ColumnMajorMatrix & ZSURFACE);
 
   virtual ~BilinearInterpolation()
     {}
 
   /**
-   * This function will take an independent variable input and will return the dependent variable
-   * based on the generated fit
+   * This function will take an independent variable input and will
+   * return the dependent variable based on the generated fit.
    */
   Real sample(Real xcoord, Real ycoord);
 
   void getNeighborIndices(const std::vector<Real> & inArr, Real x ,int& lowerX ,int& upperX );
 
 private:
-
   std::vector<Real> _xAxis;
   std::vector<Real> _yAxis;
   ColumnMajorMatrix _zSurface;

--- a/framework/include/utils/ColumnMajorMatrix.h
+++ b/framework/include/utils/ColumnMajorMatrix.h
@@ -15,21 +15,22 @@
 #ifndef COLUMNMAJORMATRIX_H
 #define COLUMNMAJORMATRIX_H
 
-#include "Moose.h"
-#include "MooseError.h"
+// MOOSE includes
+#include "Moose.h" // using namespace libMesh
+#include "MooseError.h" // mooseAssert
 
-//libMesh
+// libMesh includes
 #include "libmesh/type_tensor.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 
-#include <vector>
+// C++ includes
 #include <iomanip>
 
 /**
- * This class defines a Tensor that can change it's shape.
- * This means a 3x3x3x3 Tensor can be represented as a 9x9 or an 81x1.
- * Further, the values of this tensor are _COLUMN_ major ordered!
+ * This class defines a Tensor that can change its shape.  This means
+ * a 3x3x3x3 Tensor can be represented as a 9x9 or an 81x1.  Further,
+ * the values of this tensor are _COLUMN_ major ordered!
  */
 class ColumnMajorMatrix
 {
@@ -44,7 +45,7 @@ public:
   /**
    * Copy Constructor defined in terms of operator=()
    */
-  ColumnMajorMatrix(const ColumnMajorMatrix &rhs);
+  ColumnMajorMatrix(const ColumnMajorMatrix & rhs);
 
   /**
    * Constructor that fills in the ColumnMajorMatrix with values from a libMesh TypeTensor
@@ -53,10 +54,10 @@ public:
   ColumnMajorMatrix(const TypeTensor<Real> & tensor);
 
   explicit
-  ColumnMajorMatrix(const DenseMatrix<Real> &rhs);
+  ColumnMajorMatrix(const DenseMatrix<Real> & rhs);
 
   explicit
-  ColumnMajorMatrix(const DenseVector<Real> &rhs);
+  ColumnMajorMatrix(const DenseVector<Real> & rhs);
 
   /**
    * Constructor that takes in 3 vectors and uses them to create columns
@@ -94,13 +95,10 @@ public:
    */
   void print();
 
-
   /**
    * Prints to file
    */
-
   void print_scientific(std::ostream & os);
-
 
   /**
    * Fills the passed in tensor with the values from this tensor.
@@ -112,12 +110,10 @@ public:
    */
   void fill(DenseMatrix<Real> & rhs);
 
-
   /**
    * Fills the passed in dense vector with the values from this tensor.
    */
   void fill(DenseVector<Real> & rhs);
-
 
   /**
    * Returns a matrix that is the transpose of the matrix this
@@ -125,18 +121,17 @@ public:
    */
   ColumnMajorMatrix transpose() const;
 
-    /**
+  /**
    * Returns a matrix that is the deviatoric of the matrix this
    * was called on.
    */
   ColumnMajorMatrix deviatoric();
 
-     /**
+  /**
    * Returns a matrix that is the absolute value of the matrix this
    * was called on.
    */
   ColumnMajorMatrix abs();
-
 
   /**
    * Set the value of each of the diagonals to the passed in value.
@@ -375,7 +370,7 @@ ColumnMajorMatrix::print()
   for (unsigned int i=0; i<_n_rows; i++)
   {
     for (unsigned int j=0; j<_n_cols; j++)
-      Moose::out << std::setw(15) <<s(i,j)<<" ";
+      Moose::out << std::setw(15) << s(i,j) << " ";
 
     Moose::out <<std::endl;
   }
@@ -401,8 +396,8 @@ ColumnMajorMatrix::fill(TypeTensor<Real> & tensor)
 {
   mooseAssert(LIBMESH_DIM*LIBMESH_DIM == _n_entries, "Cannot fill tensor!  The ColumnMajorMatrix doesn't have the same number of entries!");
 
-  for (unsigned int j(0), index(0); j < LIBMESH_DIM; ++j)
-    for (unsigned int i(0); i < LIBMESH_DIM; ++i, ++index)
+  for (unsigned int j=0, index=0; j < LIBMESH_DIM; ++j)
+    for (unsigned int i=0; i < LIBMESH_DIM; ++i, ++index)
       tensor(i,j) = _values[index];
 }
 
@@ -412,8 +407,8 @@ ColumnMajorMatrix::fill(DenseMatrix<Real> &rhs)
 {
   mooseAssert(rhs.n()*rhs.m() == _n_entries, "Cannot fill dense matrix!  The ColumnMajorMatrix doesn't have the same number of entries!");
 
-  for (unsigned int j(0), index(0); j < rhs.m(); ++j)
-    for (unsigned int i(0); i < rhs.n(); ++i, ++index)
+  for (unsigned int j=0, index=0; j < rhs.m(); ++j)
+    for (unsigned int i=0; i < rhs.n(); ++i, ++index)
       rhs(i,j) = _values[index];
 }
 
@@ -424,10 +419,8 @@ ColumnMajorMatrix::fill(DenseVector<Real> &rhs)
 {
   mooseAssert(_n_rows == rhs.size(), "Vectors must be the same shape for a fill!");
 
-
-    for (unsigned int i=0; i<_n_rows; ++i)
-      rhs(i) = (*this)(i);
-
+  for (unsigned int i=0; i<_n_rows; ++i)
+    rhs(i) = (*this)(i);
 }
 
 
@@ -450,32 +443,32 @@ ColumnMajorMatrix::transpose() const
 inline ColumnMajorMatrix
 ColumnMajorMatrix::deviatoric()
 {
-    ColumnMajorMatrix & s = (*this);
+  ColumnMajorMatrix & s = (*this);
 
-    ColumnMajorMatrix ret_matrix(_n_rows, _n_cols), I(_n_rows, _n_cols);
+  ColumnMajorMatrix ret_matrix(_n_rows, _n_cols), I(_n_rows, _n_cols);
 
-    I.identity();
+  I.identity();
 
-    for (unsigned int i=0; i<_n_rows; i++)
-      for (unsigned int j=0; j<_n_cols; j++)
-        ret_matrix(i,j) = s(i,j) - I(i,j) * (s.tr()/3.0);
+  for (unsigned int i=0; i<_n_rows; i++)
+    for (unsigned int j=0; j<_n_cols; j++)
+      ret_matrix(i,j) = s(i,j) - I(i,j) * (s.tr()/3.0);
 
-    return ret_matrix;
+  return ret_matrix;
 }
 
 
 inline ColumnMajorMatrix
 ColumnMajorMatrix::abs()
 {
-    ColumnMajorMatrix & s = (*this);
+  ColumnMajorMatrix & s = (*this);
 
-    ColumnMajorMatrix ret_matrix(_n_rows, _n_cols);
+  ColumnMajorMatrix ret_matrix(_n_rows, _n_cols);
 
-    for (unsigned int j=0; j<_n_cols; j++)
-      for (unsigned int i=0; i<_n_rows; i++)
-        ret_matrix(i,j) = std::abs(s(i,j));
+  for (unsigned int j=0; j<_n_cols; j++)
+    for (unsigned int i=0; i<_n_rows; i++)
+      ret_matrix(i,j) = std::abs(s(i,j));
 
-    return ret_matrix;
+  return ret_matrix;
 }
 
 
@@ -707,13 +700,9 @@ ColumnMajorMatrix::operator+=(const TypeTensor<Real> & rhs)
 {
   mooseAssert((_n_rows == LIBMESH_DIM) && (_n_cols == LIBMESH_DIM), "Cannot perform matrix addition and assignment!  The shapes of the two operands are not compatible!");
 
-  for (unsigned int j(0); j < LIBMESH_DIM; ++j)
-  {
-    for (unsigned int i(0); i < LIBMESH_DIM; ++i)
-    {
+  for (unsigned int j=0; j < LIBMESH_DIM; ++j)
+    for (unsigned int i=0; i < LIBMESH_DIM; ++i)
       (*this)(i,j) += rhs(i,j);
-    }
-  }
 
   return *this;
 }

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -15,17 +15,19 @@
 #ifndef CONVERSION_H
 #define CONVERSION_H
 
-#include "ExecStore.h"
+// MOOSE includes
 #include "MooseTypes.h"
-#include "MultiMooseEnum.h"
 
 // libMesh
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_quadrature_type.h"
 #include "libmesh/point.h"
 
-namespace Moose {
+// Forward declarations
+class MultiMooseEnum;
 
+namespace Moose
+{
   // Scalar conversions
   template<typename T>
   T stringToEnum(const std::string & s);
@@ -70,7 +72,6 @@ namespace Moose {
    */
   template<>
   std::string stringify(const SolveType & t);
-
 }
 
 /**

--- a/framework/include/utils/DependencyResolver.h
+++ b/framework/include/utils/DependencyResolver.h
@@ -15,9 +15,11 @@
 #ifndef DEPENDENCYRESOLVER_H
 #define DEPENDENCYRESOLVER_H
 
+// MOOSE includes
 #include "Moose.h"
 #include "MooseError.h"
 
+// C++ includes
 #include <map>
 #include <set>
 #include <string>

--- a/framework/include/utils/FormattedTable.h
+++ b/framework/include/utils/FormattedTable.h
@@ -15,24 +15,27 @@
 #ifndef FORMATTEDTABLE_H
 #define FORMATTEDTABLE_H
 
+// MOOSE includes
 #include "Moose.h"
 #include "MooseEnum.h"
 #include "DataIO.h"
 
-#include "libmesh/libmesh_common.h"
-#include "libmesh/exodusII_io.h"
-
-#include <string>
-#include <map>
-#include <set>
-#include <ostream>
+// C++ includes
 #include <fstream>
 
+// Forward declarations
 class FormattedTable;
+namespace libMesh
+{
+class ExodusII_IO;
+}
 
 template<> void dataStore(std::ostream & stream, FormattedTable & table, void * context);
 template<> void dataLoad(std::istream & stream, FormattedTable & v, void * context);
 
+/**
+ * This class is used for building, formatting, and outputting tables of numbers.
+ */
 class FormattedTable
 {
 public:

--- a/framework/include/utils/GriddedData.h
+++ b/framework/include/utils/GriddedData.h
@@ -15,30 +15,30 @@
 #ifndef GRIDDEDDATA_H
 #define GRIDDEDDATA_H
 
+// C++ includes
 #include <vector>
 #include <fstream>
 #include <sstream>
 #include <string>
 
-#include "MooseError.h"
+// libMesh includes
+#include "libmesh/libmesh_common.h" // Real
 
 /**
- * Container for holding a function defined on a grid of arbitrary dimension
+ * Container for holding a function defined on a grid of arbitrary dimension.
  *
- * Information is read from a file.
- * The file contains the grid, which has dimension _dim, and consists
- *   of _dim vectors of Reals.
- * The file also contains the function values at each grid point.
- * The file also contains information on how to embed the grid
- *   into a MOOSE simulation.  This is achieved through specifying the
- *   MOOSE direction that each grid axis corresponds to.  For instance,
- *   the first grid axis might correspond to the MOOSE "y" direction,
- *   the second grid axis might correspond to the MOOSE "t" direction, etc.
+ * Information is read from a file.  The file contains the grid, which
+ * has dimension _dim, and consists of _dim vectors of Reals.  The
+ * file also contains the function values at each grid point.  The
+ * file also contains information on how to embed the grid into a
+ * MOOSE simulation.  This is achieved through specifying the MOOSE
+ * direction that each grid axis corresponds to.  For instance, the
+ * first grid axis might correspond to the MOOSE "y" direction, the
+ * second grid axis might correspond to the MOOSE "t" direction, etc.
  */
 class GriddedData
 {
 public:
-
   /**
    * Construct with a file name
    */
@@ -49,9 +49,10 @@ public:
 
   /**
    * Returns the dimensionality of the grid.
-   * This may have nothing to do with the dimensionality of
-   * the simulation.  Eg, a 2D grid with axes (Y,Z) (so dim=2)
-   * be used in a 3D simulation
+   *
+   * This may have nothing to do with the dimensionality of the
+   * simulation.  Eg, a 2D grid with axes (Y,Z) (so dim=2) be used in
+   * a 3D simulation.
    */
   unsigned int getDim();
 
@@ -66,24 +67,22 @@ public:
 
   /**
    * Yields the grid.
-   * grid[i] = a vector of Reals that define the i_th axis of the grid
+   * grid[i] = a vector of Reals that define the i_th axis of the grid.
    */
   void getGrid(std::vector<std::vector<Real> > & grid);
 
   /**
-   * Yields the values defined at the grid points
+   * Yields the values defined at the grid points.
    */
   void getFcn(std::vector<Real> & fcn);
 
   /**
-   * Evaluates the function at a given grid point
-   * for instance evaluateFcn({n,m}) = value at (grid[0][n], grid[1][m]), for a function defined on a 2D grid
+   * Evaluates the function at a given grid point.
+   * For instance, evaluateFcn({n,m}) = value at (grid[0][n], grid[1][m]), for a function defined on a 2D grid
    */
   Real evaluateFcn(const std::vector<unsigned int> & ijk);
 
-
 private:
-
   unsigned int _dim;
   std::vector<int> _axes;
   std::vector<std::vector<Real> > _grid;

--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -180,7 +180,6 @@ private:
 
   /// Create a console stream object for this helper class
   ConsoleStream _is_console;
-
 };
 
 #endif // IMAGESAMPLER_H

--- a/framework/include/utils/InputParameterWarehouse.h
+++ b/framework/include/utils/InputParameterWarehouse.h
@@ -23,7 +23,6 @@
 
 // Forward declarations
 class InputParameters;
-class MooseApp;
 
 /**
  * Storage container for all InputParamter objects.

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -15,48 +15,48 @@
 #ifndef INPUTPARAMETERS_H
 #define INPUTPARAMETERS_H
 
-#include <vector>
-#include <set>
-#include <map>
-#include <sstream>
-
-// libMesh
-#include "libmesh/parameters.h"
-#include "libmesh/parsed_function.h"
-
+// MOOSE includes
 #include "MooseError.h"
 #include "MooseTypes.h"
 #include "MooseEnum.h"
 #include "MultiMooseEnum.h"
 #include "MooseUtils.h"
 
+// libMesh includes
+#include "libmesh/parameters.h"
+#include "libmesh/parsed_function.h"
+
 #ifdef LIBMESH_HAVE_FPARSER
-#include "libmesh/fparser.hh"
+#  include "libmesh/fparser.hh"
 #else
 template <typename T>
 class FunctionParserBase
 {};
 #endif
 
+// Forward declarations
 class MooseObject;
-class GlobalParamsAction;
 class Action;
-class Parser;
 class Problem;
 class MooseApp;
 class InputParameters;
 
+/**
+ * This is the templated validParams() function that every
+ * MooseObject-derived class is required to specialize.
+ */
 template<class T>
 InputParameters validParams();
 
 /**
- *
+ * The main MOOSE class responsible for handling user-defined
+ * parameters in almost every MOOSE system.
  */
 class InputParameters : public Parameters
 {
 public:
-  InputParameters(const InputParameters &rhs);
-  InputParameters(const Parameters &rhs);
+  InputParameters(const InputParameters & rhs);
+  InputParameters(const Parameters & rhs);
 
   virtual ~InputParameters();
 

--- a/framework/include/utils/LineSegment.h
+++ b/framework/include/utils/LineSegment.h
@@ -15,21 +15,25 @@
 #ifndef LINESEGMENT_H
 #define LINESEGMENT_H
 
-#include "Moose.h"
+// MOOSE includes
+#include "Moose.h" // using namespace libMesh
 
 // libMesh includes
 #include "libmesh/point.h"
 
-// forward declares
-namespace libMesh {
+// forward declarations
+namespace libMesh
+{
   class Plane;
 }
 
-
+/**
+ * The LineSegment class is used by the LineMaterialSamplerBase class
+ * and for some ray tracing stuff.
+ */
 class LineSegment
 {
- public:
-
+public:
   LineSegment (const Point & p0, const Point & p1);
 
   virtual ~LineSegment();
@@ -72,7 +76,7 @@ class LineSegment
    */
   Real length() const { return (_p0 - _p1).size(); }
 
- private:
+private:
   bool closest_point(const Point & p, bool clamp_to_segment, Point & closest_p) const;
 
   Point _p0, _p1;

--- a/framework/include/utils/MooseEnum.h
+++ b/framework/include/utils/MooseEnum.h
@@ -15,16 +15,24 @@
 #ifndef MOOSEENUM_H
 #define MOOSEENUM_H
 
+// MOOSE includes
 #include "MooseEnumBase.h"
 
-#include "libmesh/parameters.h"
+// Forward declarations
+namespace libMesh
+{
+class Parameters;
+}
 
 /**
- * This is a "smart" enum class intended to replace many of the shortcomings in the C++ enum type
- * It should be initialized with a space-delimited list of strings which become the enum values.
- * You may also optionally supply numeric ints for one or more values similar to a C++ enum.  This
- * is done with the "=" sign (no spaces). It can be used any place where an integer (switch statements), const char*
- * or std::string is expected. In addition the InputParameters system has full support for this Enum type
+ * This is a "smart" enum class intended to replace many of the
+ * shortcomings in the C++ enum type It should be initialized with a
+ * space-delimited list of strings which become the enum values.  You
+ * may also optionally supply numeric ints for one or more values
+ * similar to a C++ enum.  This is done with the "=" sign (no
+ * spaces). It can be used any place where an integer (switch
+ * statements), const char* or std::string is expected. In addition
+ * the InputParameters system has full support for this Enum type
  */
 class MooseEnum : public MooseEnumBase
 {

--- a/framework/include/utils/MooseEnumBase.h
+++ b/framework/include/utils/MooseEnumBase.h
@@ -15,18 +15,20 @@
 #ifndef MOOSEENUMBASE_H
 #define MOOSEENUMBASE_H
 
-#include "libmesh/parameters.h"
-
+// C++ includes
 #include <string>
 #include <vector>
 #include <map>
-#include <ostream>
 
+/**
+ * The base class for both the MooseEnum and MultiMooseEnum classes.
+ */
 class MooseEnumBase
 {
 public:
   /**
-   * Constructor that takes a list of enumeration values, and a separate string to set a default for this instance
+   * Constructor that takes a list of enumeration values, and a
+   * separate string to set a default for this instance.
    * @param names - a list of names for this enumeration
    * @param allow_out_of_range - determines whether this enumeration will accept values outside of it's range of
    *                       defined values.

--- a/framework/include/utils/MooseRandom.h
+++ b/framework/include/utils/MooseRandom.h
@@ -15,12 +15,16 @@
 #ifndef MOOSERANDOM_H
 #define MOOSERANDOM_H
 
-#include "randistrs.h"
-
+// MOOSE includes
 #include "MooseError.h"
 
+// libMesh includes
 #include "libmesh/libmesh_config.h"
 #include LIBMESH_INCLUDE_UNORDERED_MAP
+
+// External library includes
+#include "randistrs.h"
+
 
 /**
  * This class encapsulates a useful, consistent, cross-platform random number generator
@@ -74,7 +78,8 @@ public:
   /**
    * Return next random number drawn from a standard distribution.
    */
-  static inline double randNormal() {
+  static inline double randNormal()
+  {
     return randNormal(0.0, 1.0);
   }
 
@@ -125,7 +130,8 @@ public:
   /**
    * Return next random number drawn from a standard distribution.
    */
-  inline double randNormal(unsigned int i) {
+  inline double randNormal(unsigned int i)
+  {
     return randNormal(i, 0.0, 1.0);
   }
 

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -14,24 +14,24 @@
 #ifndef MOOSEUTILS_H
 #define MOOSEUTILS_H
 
-// STL includes
+// MOOSE includes
+#include "HashMap.h"
+#include "MaterialProperty.h" // MaterialProperties
+
+// libMesh includes
+#include "libmesh/parallel.h"
+
+// C++ includes
 #include <string>
 #include <vector>
 #include <map>
 #include <list>
-#include <sstream>
-#include <algorithm>
-
-// MOOSE includes
-#include "HashMap.h"
-#include "Moose.h"
-
-// libMesh includes
-#include "libmesh/parallel.h"
-#include "libmesh/elem.h"
 
 // Forward Declarations
-class MaterialProperties;
+namespace libMesh
+{
+class Elem;
+}
 
 namespace MooseUtils
 {

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -12,23 +12,32 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef VECTORMOOSEENUM_H
-#define VECTORMOOSEENUM_H
+#ifndef MULTIMOOSEENUM_H
+#define MULTIMOOSEENUM_H
 
+// MOOSE includes
 #include "MooseEnumBase.h"
 
-#include "libmesh/parameters.h"
-
+// C++ includes
 #include <set>
+
+// Forward declarations
+namespace libMesh
+{
+class Parameters;
+}
 
 typedef std::set<std::string>::const_iterator MooseEnumIterator;
 
 /**
- * This is a "smart" enum class intended to replace many of the shortcomings in the C++ enum type
- * It should be initialized with a comma-separated list of strings which become the enum values.
- * You may also optionally supply numeric ints for one or more values similar to a C++ enum.  This
- * is done with the "=" sign. It can be used any place where an integer (switch statements), const char*
- * or std::string is expected.  In addition the InputParameters system has full support for this Enum type
+ * This is a "smart" enum class intended to replace many of the
+ * shortcomings in the C++ enum type It should be initialized with a
+ * comma-separated list of strings which become the enum values.  You
+ * may also optionally supply numeric ints for one or more values
+ * similar to a C++ enum.  This is done with the "=" sign. It can be
+ * used any place where an integer (switch statements), const char* or
+ * std::string is expected.  In addition the InputParameters system
+ * has full support for this Enum type
  */
 class MultiMooseEnum : public MooseEnumBase
 {
@@ -206,4 +215,4 @@ private:
   std::vector<std::string> _current_names_preserved;
 };
 
-#endif //VECTORMOOSEENUM_H
+#endif // MULTIMOOSEENUM_H

--- a/framework/include/utils/PetscDMMoose.h
+++ b/framework/include/utils/PetscDMMoose.h
@@ -11,20 +11,26 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #ifndef PETSCDMMOOSE_H
 #define PETSCDMMOOSE_H
 
-#include "libmesh/petsc_macro.h"
 // This only works with petsc-3.3 and above.
+#include "libmesh/petsc_macro.h"
 
 #if defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)
-#include "NonlinearSystem.h"
-#include <map>
+
+// PETSc includes
+#include <petscdm.h>
+#define DMMOOSE "moose"
+
+// C++ includes
+#include <vector>
 #include <set>
 #include <string>
 
-#include <petscdm.h>
-#define DMMOOSE "moose"
+// Forward declarations
+class NonlinearSystem;
 
 extern PetscErrorCode DMMooseRegisterAll();
 extern PetscErrorCode DMCreateMoose(MPI_Comm,NonlinearSystem&,DM*);

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -15,20 +15,22 @@
 #ifndef PETSCSUPPORT_H
 #define PETSCSUPPORT_H
 
-#include "libmesh/libmesh.h"
+#include "libmesh/libmesh.h" // Real, LIBMESH_HAVE_PETSC
 
 #ifdef LIBMESH_HAVE_PETSC
 
-// Moose includes
-#include "Problem.h"
-#include "NonlinearSystem.h"
-#include "CommandLine.h"
-#include "Console.h"
+// MOOSE includes
+#include "MultiMooseEnum.h"
+#include "InputParameters.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/petsc_nonlinear_solver.h"
+#include "libmesh/petsc_macro.h"
 
+// Forward declarations
 class FEProblem;
+class NonlinearSystem;
+class CommandLine;
 
 namespace Moose
 {
@@ -75,7 +77,7 @@ PetscErrorCode petscSetupOutput(CommandLine * cmd_line);
 /**
  * Helper function for outputing the norm values with/without color
  */
-void outputNorm(Real old_norm, Real norm, bool use_color = false);
+void outputNorm(libMesh::Real old_norm, libMesh::Real norm, bool use_color = false);
 
 /**
  * Helper function for displaying the linear residual during PETSC solve

--- a/framework/include/vectorpostprocessors/GeneralVectorPostprocessor.h
+++ b/framework/include/vectorpostprocessors/GeneralVectorPostprocessor.h
@@ -15,23 +15,21 @@
 #ifndef GENERALVECTORPOSTPROCESSOR_H
 #define GENERALVECTORPOSTPROCESSOR_H
 
+// MOOSE includes
 #include "VectorPostprocessor.h"
 #include "GeneralUserObject.h"
-#include "TransientInterface.h"
-#include "FunctionInterface.h"
-#include "UserObjectInterface.h"
-#include "VectorPostprocessorInterface.h"
-#include "Problem.h"
 
-
-//Forward Declarations
+// Forward Declarations
 class GeneralVectorPostprocessor;
 
 template<>
 InputParameters validParams<GeneralVectorPostprocessor>();
 
-/* This class is here to combine the VectorPostprocessor interface and the
- * base class VectorPostprocessor object along with adding MooseObject to the inheritance tree*/
+/**
+ * This class is here to combine the VectorPostprocessor interface and
+ * the base class VectorPostprocessor object along with adding
+ * MooseObject to the inheritance tree.
+ */
 class GeneralVectorPostprocessor :
   public GeneralUserObject,
   public VectorPostprocessor
@@ -42,7 +40,9 @@ public:
   virtual ~GeneralVectorPostprocessor() {}
 
   /**
-   * Finalize.  This is called _after_ execute() and _after_ threadJoin()!  This is probably where you want to do MPI communication!
+   * Finalize.  This is called _after_ execute() and _after_
+   * threadJoin()!  This is probably where you want to do MPI
+   * communication!
    */
   virtual void finalize(){}
 };

--- a/framework/include/vectorpostprocessors/LineMaterialRealSampler.h
+++ b/framework/include/vectorpostprocessors/LineMaterialRealSampler.h
@@ -15,9 +15,10 @@
 #ifndef LINEMATERIALREALSAMPLER_H
 #define LINEMATERIALREALSAMPLER_H
 
+// MOOSE includes
 #include "LineMaterialSamplerBase.h"
 
-//Forward Declarations
+// Forward Declarations
 class LineMaterialRealSampler;
 
 template<>

--- a/framework/include/vectorpostprocessors/LineMaterialSamplerBase.h
+++ b/framework/include/vectorpostprocessors/LineMaterialSamplerBase.h
@@ -15,30 +15,32 @@
 #ifndef LINEMATERIALSAMPLERBASE_H
 #define LINEMATERIALSAMPLERBASE_H
 
+// MOOSE includes
 #include "GeneralVectorPostprocessor.h"
-#include "RayTracing.h"
 #include "SamplerBase.h"
-#include "FEProblem.h"
-#include "InputParameters.h"
 #include "BlockRestrictable.h"
-#include "Assembly.h"
+#include "LineSegment.h"
+#include "RayTracing.h" // Moose::elementsIntersectedByLine()
+#include "Assembly.h" // Assembly::qRule()
+#include "MooseMesh.h" // MooseMesh::getMesh()
 
-// libmesh includes
-#include "libmesh/quadrature.h"
+// libMesh includes
+#include "libmesh/quadrature.h" // _qrule->n_points()
 
-//Forward Declarations
-template<typename T>
-class LineMaterialSamplerBase;
+// Forward Declarations
+class MooseMesh;
+template<typename T> class LineMaterialSamplerBase;
 
 template<>
 InputParameters validParams<LineMaterialSamplerBase<Real> >();
 
 /**
- * This is a base class for sampling material properties for the integration points
- * in all elements that are intersected by a user-defined line.  The positions of
- * those points are output in x, y, z coordinates, as well as in terms of the projected
- * positions of those points along the line.  Derived classes can be created to sample
- * arbitrary types of material properties.
+ * This is a base class for sampling material properties for the
+ * integration points in all elements that are intersected by a
+ * user-defined line.  The positions of those points are output in x,
+ * y, z coordinates, as well as in terms of the projected positions of
+ * those points along the line.  Derived classes can be created to
+ * sample arbitrary types of material properties.
  */
 template<typename T>
 class LineMaterialSamplerBase :

--- a/framework/include/vectorpostprocessors/LineValueSampler.h
+++ b/framework/include/vectorpostprocessors/LineValueSampler.h
@@ -15,10 +15,10 @@
 #ifndef LINEVALUESAMPLER_H
 #define LINEVALUESAMPLER_H
 
-#include "GeneralVectorPostprocessor.h"
+// MOOSE includes
 #include "PointSamplerBase.h"
 
-//Forward Declarations
+// Forward Declarations
 class LineValueSampler;
 
 template<>

--- a/framework/include/vectorpostprocessors/NodalVectorPostprocessor.h
+++ b/framework/include/vectorpostprocessors/NodalVectorPostprocessor.h
@@ -15,12 +15,11 @@
 #ifndef NODALVECTORPOSTPROCESSOR_H
 #define NODALVECTORPOSTPROCESSOR_H
 
-#include "VectorPostprocessor.h"
+// MOOSE includes
 #include "NodalUserObject.h"
+#include "VectorPostprocessor.h"
 
-class MooseVariable;
-
-//Forward Declarations
+// Forward Declarations
 class NodalVectorPostprocessor;
 
 template<>

--- a/framework/include/vectorpostprocessors/PointSamplerBase.h
+++ b/framework/include/vectorpostprocessors/PointSamplerBase.h
@@ -15,21 +15,13 @@
 #ifndef POINTSAMPLERBASE_H
 #define POINTSAMPLERBASE_H
 
+// MOOSE includes
 #include "GeneralVectorPostprocessor.h"
-#include "SamplerBase.h"
 #include "CoupleableMooseVariableDependencyIntermediateInterface.h"
+#include "SamplerBase.h"
 
-//Forward Declarations
+// Forward Declarations
 class PointSamplerBase;
-
-// libMesh Forward Declarations
-namespace libMesh
-{
-  namespace MeshTools
-  {
-    class BoundingBox;
-  }
-}
 
 template<>
 InputParameters validParams<PointSamplerBase>();

--- a/framework/include/vectorpostprocessors/PointValueSampler.h
+++ b/framework/include/vectorpostprocessors/PointValueSampler.h
@@ -15,10 +15,10 @@
 #ifndef POINTVALUESAMPLER_H
 #define POINTVALUESAMPLER_H
 
-#include "GeneralVectorPostprocessor.h"
+// MOOSE includes
 #include "PointSamplerBase.h"
 
-//Forward Declarations
+// Forward Declarations
 class PointValueSampler;
 
 template<>

--- a/framework/include/vectorpostprocessors/SamplerBase.h
+++ b/framework/include/vectorpostprocessors/SamplerBase.h
@@ -15,16 +15,19 @@
 #ifndef SAMPLERBASE_H
 #define SAMPLERBASE_H
 
-#include "NodalVariableVectorPostprocessor.h"
+// MOOSE includes
+#include "InputParameters.h"
 
-//Forward Declarations
+// Forward Declarations
 class SamplerBase;
+class VectorPostprocessor;
 
 template<>
 InputParameters validParams<SamplerBase>();
 
 /**
- * Base class for VectorPostprocessors that need to do "sampling" of values in the domain.
+ * Base class for VectorPostprocessors that need to do "sampling" of
+ * values in the domain.
  */
 class SamplerBase
 {

--- a/framework/include/vectorpostprocessors/VectorPostprocessor.h
+++ b/framework/include/vectorpostprocessors/VectorPostprocessor.h
@@ -15,23 +15,24 @@
 #ifndef VECTORPOSTPROCESSOR_H
 #define VECTORPOSTPROCESSOR_H
 
-#include <string>
 // MOOSE includes
 #include "InputParameters.h"
-#include "Restartable.h"
-#include "VectorPostprocessorData.h"
+#include "MooseTypes.h"
 
 // libMesh
 #include "libmesh/parallel.h"
 
+// Forward declarations
 class SamplerBase;
-
 class VectorPostprocessor;
+class VectorPostprocessorData;
 
 template<>
 InputParameters validParams<VectorPostprocessor>();
 
-
+/**
+ * Base class for Postprocessors that produce a vector of values.
+ */
 class VectorPostprocessor
 {
 public:

--- a/framework/include/vectorpostprocessors/VectorPostprocessorInterface.h
+++ b/framework/include/vectorpostprocessors/VectorPostprocessorInterface.h
@@ -15,14 +15,9 @@
 #ifndef VECTORPOSTPROCESSORINTERFACE_H
 #define VECTORPOSTPROCESSORINTERFACE_H
 
-// Standard includes
-#include <map>
-#include <string>
-
 // MOOSE includes
 #include "InputParameters.h"
 #include "ParallelUniqueId.h"
-#include "VectorPostprocessorData.h"
 
 // Forward Declarations
 class FEProblem;
@@ -31,6 +26,11 @@ class VectorPostprocessorInterface
 {
 public:
   VectorPostprocessorInterface(const InputParameters & parameters);
+
+  /**
+   * This class has virtual methods, so it needs a virtual dtor.
+   */
+  virtual ~VectorPostprocessorInterface() {}
 
   /**
    * Retrieve the value of a VectorPostprocessor

--- a/framework/include/vectorpostprocessors/VectorPostprocessorWarehouse.h
+++ b/framework/include/vectorpostprocessors/VectorPostprocessorWarehouse.h
@@ -15,13 +15,11 @@
 #ifndef VECTORPOSTPROCESSORWAREHOUSE_H
 #define VECTORPOSTPROCESSORWAREHOUSE_H
 
-#include <vector>
-#include <map>
-#include <set>
-
+// MOOSE includes
 #include "Warehouse.h"
 #include "MooseTypes.h"
 
+// Forward declarations
 class VectorPostprocessor;
 class ElementVectorPostprocessor;
 class InternalSideVectorPostprocessor;

--- a/framework/src/actions/AddBoundsVectorsAction.C
+++ b/framework/src/actions/AddBoundsVectorsAction.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "AddBoundsVectorsAction.h"
 #include "FEProblem.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<AddBoundsVectorsAction>()

--- a/framework/src/actions/AddElementalFieldAction.C
+++ b/framework/src/actions/AddElementalFieldAction.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "AddElementalFieldAction.h"
 #include "FEProblem.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/fe.h"

--- a/framework/src/actions/AddMortarInterfaceAction.C
+++ b/framework/src/actions/AddMortarInterfaceAction.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "AddMortarInterfaceAction.h"
 #include "FEProblem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<AddMortarInterfaceAction>()

--- a/framework/src/actions/AddSplitAction.C
+++ b/framework/src/actions/AddSplitAction.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "AddSplitAction.h"
 #include "FEProblem.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<AddSplitAction>()

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -23,6 +23,7 @@
 #include "MooseEnum.h"
 #include "EigenSystem.h"
 #include "MooseObjectAction.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/libmesh.h"

--- a/framework/src/actions/CopyNodalVarsAction.C
+++ b/framework/src/actions/CopyNodalVarsAction.C
@@ -12,10 +12,12 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "CopyNodalVarsAction.h"
 #include "FEProblem.h"
 #include "ActionWarehouse.h"
 #include "MooseApp.h"
+#include "NonlinearSystem.h"
 
 #include <map>
 

--- a/framework/src/actions/PartitionerAction.C
+++ b/framework/src/actions/PartitionerAction.C
@@ -12,10 +12,12 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "PartitionerAction.h"
 #include "MoosePartitioner.h"
 #include "FEProblem.h"
 #include "MooseEnum.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<PartitionerAction>()

--- a/framework/src/actions/SetupPreconditionerAction.C
+++ b/framework/src/actions/SetupPreconditionerAction.C
@@ -12,12 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "SetupPreconditionerAction.h"
 #include "Factory.h"
 #include "PetscSupport.h"
 #include "MoosePreconditioner.h"
 #include "FEProblem.h"
 #include "CreateExecutionerAction.h"
+#include "NonlinearSystem.h"
 
 unsigned int SetupPreconditionerAction::_count = 0;
 

--- a/framework/src/actions/SetupPredictorAction.C
+++ b/framework/src/actions/SetupPredictorAction.C
@@ -11,10 +11,13 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
+// MOOSE includes
 #include "SetupPredictorAction.h"
 #include "Transient.h"
 #include "Predictor.h"
 #include "Factory.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<SetupPredictorAction>()

--- a/framework/src/actions/SetupResidualDebugAction.C
+++ b/framework/src/actions/SetupResidualDebugAction.C
@@ -12,10 +12,12 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "SetupResidualDebugAction.h"
 #include "FEProblem.h"
 #include "ActionWarehouse.h"
 #include "Factory.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<SetupResidualDebugAction>()

--- a/framework/src/auxkernels/NearestNodeDistanceAux.C
+++ b/framework/src/auxkernels/NearestNodeDistanceAux.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NearestNodeDistanceAux.h"
 #include "NearestNodeLocator.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NearestNodeDistanceAux>()

--- a/framework/src/auxkernels/PenetrationAux.C
+++ b/framework/src/auxkernels/PenetrationAux.C
@@ -12,11 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "PenetrationAux.h"
-
 #include "DisplacedProblem.h"
 #include "MooseEnum.h"
+#include "MooseMesh.h"
 
+// libMesh includes
 #include "libmesh/string_to_enum.h"
 
 const Real PenetrationAux::NotPenetrated = -999999;

--- a/framework/src/auxkernels/VectorMagnitudeAux.C
+++ b/framework/src/auxkernels/VectorMagnitudeAux.C
@@ -11,7 +11,10 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
+// MOOSE includes
 #include "VectorMagnitudeAux.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<VectorMagnitudeAux>()

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -16,6 +16,7 @@
 #include "BlockRestrictable.h"
 #include "Material.h"
 #include "FEProblem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<BlockRestrictable>()

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -12,6 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "DisplacedProblem.h"
 #include "Problem.h"
 #include "SubProblem.h"
@@ -21,6 +22,7 @@
 #include "MooseMesh.h"
 #include "Assembly.h"
 #include "FEProblem.h"
+#include "NonlinearSystem.h"
 
 // libMesh includes
 #include "libmesh/numeric_vector.h"

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3272,6 +3272,30 @@ FEProblem::converged()
     return true;
 }
 
+unsigned int
+FEProblem::nNonlinearIterations()
+{
+  return _nl.nNonlinearIterations();
+}
+
+unsigned int
+FEProblem::nLinearIterations()
+{
+  return _nl.nLinearIterations();
+}
+
+Real
+FEProblem::finalNonlinearResidual()
+{
+  return _nl.finalNonlinearResidual();
+}
+
+bool
+FEProblem::computingInitialResidual()
+{
+  return _nl.computingInitialResidual();
+}
+
 void
 FEProblem::copySolutionsBackwards()
 {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -32,6 +32,8 @@
 #include "InputParameterWarehouse.h"
 #include "SystemInfo.h"
 #include "RestartableDataIO.h"
+#include "MooseMesh.h"
+#include "FileOutput.h"
 
 // Regular expression includes
 #include "pcrecpp.h"

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -24,6 +24,7 @@
 #include "InitialCondition.h"
 #include "ScalarInitialCondition.h"
 #include "Assembly.h"
+#include "MooseMesh.h"
 
 /// Free function used for a libMesh callback
 void extraSendList(std::vector<dof_id_type> & send_list, void * context)

--- a/framework/src/bcs/FunctionPeriodicBoundary.C
+++ b/framework/src/bcs/FunctionPeriodicBoundary.C
@@ -12,9 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "FunctionPeriodicBoundary.h"
 #include "FEProblem.h"
 #include "Function.h"
+#include "MooseMesh.h"
 
 FunctionPeriodicBoundary::FunctionPeriodicBoundary(FEProblem & feproblem, std::vector<std::string> fn_names) :
     _dim(fn_names.size()),

--- a/framework/src/constraints/EqualValueBoundaryConstraint.C
+++ b/framework/src/constraints/EqualValueBoundaryConstraint.C
@@ -12,7 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "EqualValueBoundaryConstraint.h"
+#include "MooseMesh.h"
+
+// C++ includes
 #include <limits.h>
 
 template<>

--- a/framework/src/constraints/LinearNodalConstraint.C
+++ b/framework/src/constraints/LinearNodalConstraint.C
@@ -12,15 +12,9 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "LinearNodalConstraint.h"
-#include <limits.h>
-
-/**
-* The slave node variable is programmed as a linear combination of the master node variables
-* (i.e, slave_var = a_1*master_var_1+ a_2*master_var_2+... + a_n*master_var_n).
-* The master nodes ids and corresponding weights are required as input.
-* The same linear combination applies to all slave nodes.
-**/
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<LinearNodalConstraint>()

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -17,6 +17,7 @@
 #include "PenetrationLocator.h"
 #include "MooseEnum.h"
 #include "Assembly.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/string_to_enum.h"

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -17,6 +17,7 @@
 #include "Assembly.h"
 #include "SystemBase.h"
 #include "Problem.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/quadrature.h"

--- a/framework/src/executioners/Executioner.C
+++ b/framework/src/executioners/Executioner.C
@@ -12,12 +12,12 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "Executioner.h"
-
 // Moose includes
+#include "Executioner.h"
 #include "MooseMesh.h"
 #include "FEProblem.h"
 #include "MooseApp.h"
+#include "NonlinearSystem.h"
 
 // C++ includes
 #include <vector>

--- a/framework/src/executioners/Steady.C
+++ b/framework/src/executioners/Steady.C
@@ -12,10 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "Steady.h"
 #include "FEProblem.h"
 #include "Factory.h"
 #include "MooseApp.h"
+#include "NonlinearSystem.h"
+
+// libMesh includes
 #include "libmesh/equation_systems.h"
 
 template<>

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -14,7 +14,7 @@
 
 #include "Transient.h"
 
-//Moose includes
+// MOOSE includes
 #include "Factory.h"
 #include "SubProblem.h"
 #include "TimePeriod.h"
@@ -22,8 +22,9 @@
 #include "MooseApp.h"
 #include "Conversion.h"
 #include "FEProblem.h"
+#include "NonlinearSystem.h"
 
-//libMesh includes
+// libMesh includes
 #include "libmesh/implicit_system.h"
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/transient_system.h"

--- a/framework/src/indicators/LaplacianJumpIndicator.C
+++ b/framework/src/indicators/LaplacianJumpIndicator.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "LaplacianJumpIndicator.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<LaplacianJumpIndicator>()

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -19,6 +19,7 @@
 // libMesh includes
 #include "libmesh/mesh_modification.h"
 #include "libmesh/serial_mesh.h"
+#include "libmesh/exodusII_io.h"
 
 template<>
 InputParameters validParams<TiledMesh>()

--- a/framework/src/multiapps/AutoPositionsMultiApp.C
+++ b/framework/src/multiapps/AutoPositionsMultiApp.C
@@ -11,7 +11,10 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
+// MOOSE includes
 #include "AutoPositionsMultiApp.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<AutoPositionsMultiApp>()

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -11,9 +11,9 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
-#include "MultiApp.h"
 
-// Moose
+// MOOSE includes
+#include "MultiApp.h"
 #include "AppFactory.h"
 #include "SetupInterface.h"
 #include "Executioner.h"
@@ -24,17 +24,16 @@
 #include "MooseUtils.h"
 #include "Console.h"
 #include "RestartableDataIO.h"
+#include "MooseMesh.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/mesh_tools.h"
 #include "libmesh/numeric_vector.h"
 
-#include <iostream>
+// C++ includes
 #include <fstream>
 #include <iomanip>
 #include <iterator>
-#include <fstream>
-#include <vector>
 #include <algorithm>
 
 // Call to "uname"

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -20,6 +20,7 @@
 #include "Output.h"
 #include "Console.h"
 #include "Transient.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/mesh_tools.h"

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -25,6 +25,10 @@
 #include "VectorPostprocessor.h"
 #include "MooseUtils.h"
 #include "InfixIterator.h"
+#include "MooseApp.h"
+#include "PetscOutput.h"
+#include "FileOutput.h"
+#include "OversampleOutput.h"
 
 // A function, only available in this file, for adding the AdvancedOutput parameters. This is
 // used to eliminate code duplication between the difference specializations of the validParams function.

--- a/framework/src/outputs/AdvancedOutputUtils.C
+++ b/framework/src/outputs/AdvancedOutputUtils.C
@@ -15,6 +15,7 @@
 // MOOSE includes
 #include "AdvancedOutputUtils.h"
 #include "Output.h"
+#include "InputParameters.h"
 
 // Constructor of OutputOnWarehouse; initializes the MultiMooseEnums for all available output types
 OutputOnWarehouse::OutputOnWarehouse(const MultiMooseEnum & execute_on, const InputParameters & parameters) : OutputMapWrapper<MultiMooseEnum>()

--- a/framework/src/outputs/BasicOutput.C
+++ b/framework/src/outputs/BasicOutput.C
@@ -18,6 +18,7 @@
 // MOOSE includes
 #include "BasicOutput.h"
 #include "MooseApp.h"
+#include "OversampleOutput.h"
 
 // Define the four possible validParams methods
 template<>

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -19,6 +19,8 @@
 #include "Checkpoint.h"
 #include "FEProblem.h"
 #include "MooseApp.h"
+#include "MaterialPropertyStorage.h"
+#include "RestartableData.h"
 
 // libMesh includes
 #include "libmesh/checkpoint_io.h"

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -21,6 +21,8 @@
 #include "Executioner.h"
 #include "MooseApp.h"
 #include "Moose.h"
+#include "FormattedTable.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<Console>()

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -12,9 +12,6 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-// STL includes
-#include <ostream>
-
 // MOOSE includes
 #include "ConsoleUtils.h"
 #include "MooseApp.h"
@@ -23,6 +20,8 @@
 #include "Executioner.h"
 #include "Conversion.h"
 #include "OutputWarehouse.h"
+#include "MooseMesh.h"
+#include "NonlinearSystem.h"
 
 // libMesh includes
 #include "libmesh/string_to_enum.h"

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -19,6 +19,8 @@
 #include "MooseApp.h"
 #include "Moose.h"
 #include "Conversion.h"
+#include "MooseMesh.h"
+#include "NonlinearSystem.h"
 
 // libMesh includes
 #include "libmesh/fe.h"

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -20,6 +20,9 @@
 #include "ExodusFormatter.h"
 #include "FileMesh.h"
 
+// libMesh includes
+#include "libmesh/exodusII_io.h"
+
 template<>
 InputParameters validParams<Exodus>()
 {

--- a/framework/src/outputs/GMVOutput.C
+++ b/framework/src/outputs/GMVOutput.C
@@ -16,6 +16,7 @@
 #include "GMVOutput.h"
 
 // libMesh includes
+#include "libmesh/equation_systems.h"
 #include "libmesh/gmv_io.h"
 
 template<>

--- a/framework/src/outputs/ICEUpdater.C
+++ b/framework/src/outputs/ICEUpdater.C
@@ -13,10 +13,12 @@
 /****************************************************************/
 
 #include "ICEUpdater.h"
-#include <sstream>
 #include "FEProblem.h"
 #include "PostprocessorWarehouse.h"
 #include "Postprocessor.h"
+#include "Updater.h"
+
+#include <sstream>
 
 // Currently the ICE Updater requires TBB
 #ifdef LIBMESH_HAVE_TBB_API

--- a/framework/src/outputs/MaterialPropertyDebugOutput.C
+++ b/framework/src/outputs/MaterialPropertyDebugOutput.C
@@ -19,7 +19,7 @@
 #include "Material.h"
 #include "ConsoleUtils.h"
 
-// libMesh includesx
+// libMesh includes
 #include "libmesh/transient_system.h"
 
 template<>

--- a/framework/src/outputs/Nemesis.C
+++ b/framework/src/outputs/Nemesis.C
@@ -12,10 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-// Moose includes
+// MOOSE includes
 #include "Nemesis.h"
 #include "MooseApp.h"
 #include "FEProblem.h"
+#include "MooseMesh.h"
+
+// libMesh includes
+#include "libmesh/nemesis_io.h"
 
 template<>
 InputParameters validParams<Nemesis>()

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -25,6 +25,9 @@
 #include "FileMesh.h"
 #include "MooseUtils.h"
 
+// libMesh includes
+#include "libmesh/equation_systems.h"
+
 
 template<>
 InputParameters validParams<Output>()

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -19,6 +19,11 @@
 #include "FileMesh.h"
 #include "MooseApp.h"
 
+// libMesh includes
+#include "libmesh/equation_systems.h"
+#include "libmesh/mesh_function.h"
+
+
 template<>
 InputParameters validParams<OversampleOutput>()
 {

--- a/framework/src/outputs/PetscOutput.C
+++ b/framework/src/outputs/PetscOutput.C
@@ -15,6 +15,7 @@
 // MOOSE includes
 #include "PetscOutput.h"
 #include "FEProblem.h"
+#include "NonlinearSystem.h"
 
 // libMesh includes
 #include "libmesh/libmesh_common.h"

--- a/framework/src/outputs/Tecplot.C
+++ b/framework/src/outputs/Tecplot.C
@@ -16,6 +16,7 @@
 #include "Tecplot.h"
 #include "MooseApp.h"
 #include "FEProblem.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/tecplot_io.h"

--- a/framework/src/outputs/TopResidualDebugOutput.C
+++ b/framework/src/outputs/TopResidualDebugOutput.C
@@ -18,6 +18,9 @@
 #include "MooseApp.h"
 #include "Material.h"
 #include "Console.h"
+#include "Action.h"
+#include "MooseMesh.h"
+#include "NonlinearSystem.h"
 
 // libMesh includes
 #include "libmesh/transient_system.h"

--- a/framework/src/outputs/VTKOutput.C
+++ b/framework/src/outputs/VTKOutput.C
@@ -14,6 +14,10 @@
 
 #include "VTKOutput.h"
 
+// libMesh includes
+#include "libmesh/vtk_io.h"
+#include "libmesh/equation_systems.h"
+
 template<>
 InputParameters validParams<VTKOutput>()
 {

--- a/framework/src/outputs/VariableResidualNormsDebugOutput.C
+++ b/framework/src/outputs/VariableResidualNormsDebugOutput.C
@@ -17,8 +17,9 @@
 #include "FEProblem.h"
 #include "MooseApp.h"
 #include "Material.h"
+#include "NonlinearSystem.h"
 
-// libMesh includesx
+// libMesh includes
 #include "libmesh/transient_system.h"
 
 template<>

--- a/framework/src/outputs/XDA.C
+++ b/framework/src/outputs/XDA.C
@@ -12,10 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-// Moose includes
+// MOOSE includes
 #include "XDA.h"
 #include "MooseApp.h"
 #include "FEProblem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<XDA>()

--- a/framework/src/outputs/formatters/ExodusFormatter.C
+++ b/framework/src/outputs/formatters/ExodusFormatter.C
@@ -12,12 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "ExodusFormatter.h"
 #include "Parser.h"
 #include "MooseApp.h"
 #include "SystemInfo.h"
+#include "CommandLine.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/exodusII.h"
 
 // C++

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -12,12 +12,16 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include <iomanip>
 
+// MOOSE includes
 #include "CommandLine.h"
 #include "MooseInit.h"
 #include "MooseUtils.h"
 #include "InputParameters.h"
+
+// C++ includes
+#include <iomanip>
+
 
 CommandLine::CommandLine(int argc, char *argv[]) :
     _get_pot(new GetPot(argc, argv)),

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -12,23 +12,16 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include <string>
-#include <map>
-#include <fstream>
-#include <iomanip>
-#include <algorithm>
-
+// MOOSE includes
 #include "MooseUtils.h"
 #include "MooseInit.h"
 #include "InputParameters.h"
-
 #include "ActionFactory.h"
 #include "Action.h"
 #include "Factory.h"
 #include "MooseObjectAction.h"
 #include "ActionWarehouse.h"
 #include "EmptyAction.h"
-
 #include "FEProblem.h"
 #include "MooseMesh.h"
 #include "Executioner.h"
@@ -36,20 +29,25 @@
 #include "MooseEnum.h"
 #include "MultiMooseEnum.h"
 #include "MultiApp.h"
-
 #include "GlobalParamsAction.h"
-
 #include "SyntaxTree.h"
 #include "InputFileFormatter.h"
 #include "YAMLFormatter.h"
-
 #include "MooseTypes.h"
+#include "CommandLine.h"
+
+// libMesh includes
+#include "libmesh/getpot.h"
 
 // Regular expression includes
 #include "pcrecpp.h"
 
-// libMesh
-#include "libmesh/getpot.h"
+// C++ includes
+#include <string>
+#include <map>
+#include <fstream>
+#include <iomanip>
+#include <algorithm>
 
 // Free function for removing cli flags
 bool isFlag(const std::string s)

--- a/framework/src/postprocessors/ExecutionerAttributeReporter.C
+++ b/framework/src/postprocessors/ExecutionerAttributeReporter.C
@@ -14,7 +14,6 @@
 
 // MOOSE includes
 #include "ExecutionerAttributeReporter.h"
-#include "EigenExecutionerBase.h"
 #include "MooseApp.h"
 
 template<>

--- a/framework/src/postprocessors/FunctionSideIntegral.C
+++ b/framework/src/postprocessors/FunctionSideIntegral.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "FunctionSideIntegral.h"
+#include "Function.h"
 
 template<>
 InputParameters validParams<FunctionSideIntegral>()

--- a/framework/src/postprocessors/NodalL2Norm.C
+++ b/framework/src/postprocessors/NodalL2Norm.C
@@ -14,9 +14,6 @@
 
 #include "NodalL2Norm.h"
 
-#include <algorithm>
-#include <limits>
-
 template<>
 InputParameters validParams<NodalL2Norm>()
 {

--- a/framework/src/postprocessors/NodalVariableValue.C
+++ b/framework/src/postprocessors/NodalVariableValue.C
@@ -16,13 +16,16 @@
 #include "MooseMesh.h"
 #include "SubProblem.h"
 
+// libMesh
+#include "libmesh/node.h"
+
 template<>
 InputParameters validParams<NodalVariableValue>()
 {
   InputParameters params = validParams<GeneralPostprocessor>();
   params.addRequiredParam<VariableName>("variable", "The variable to be monitored");
   params.addRequiredParam<unsigned int>("nodeid", "The ID of the node where we monitor");
-  params.addParam<Real>("scale_factor",1, "A scale factor to be applied to the variable");
+  params.addParam<Real>("scale_factor", 1, "A scale factor to be applied to the variable");
   return params;
 }
 

--- a/framework/src/postprocessors/NumElems.C
+++ b/framework/src/postprocessors/NumElems.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NumElems.h"
 #include "SubProblem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NumElems>()

--- a/framework/src/postprocessors/NumNodes.C
+++ b/framework/src/postprocessors/NumNodes.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NumNodes.h"
 #include "SubProblem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NumNodes>()

--- a/framework/src/postprocessors/NumPicardIterations.C
+++ b/framework/src/postprocessors/NumPicardIterations.C
@@ -12,12 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NumPicardIterations.h"
-
-#include "FEProblem.h"
-#include "SubProblem.h"
+#include "Transient.h"
 #include "MooseApp.h"
-#include <iostream>
 
 template<>
 InputParameters validParams<NumPicardIterations>()

--- a/framework/src/postprocessors/NumResidualEvaluations.C
+++ b/framework/src/postprocessors/NumResidualEvaluations.C
@@ -12,10 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NumResidualEvaluations.h"
-
 #include "FEProblem.h"
 #include "SubProblem.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<NumResidualEvaluations>()

--- a/framework/src/postprocessors/NumVars.C
+++ b/framework/src/postprocessors/NumVars.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NumVars.h"
 #include "SubProblem.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<NumVars>()

--- a/framework/src/postprocessors/PointValue.C
+++ b/framework/src/postprocessors/PointValue.C
@@ -12,9 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "PointValue.h"
 #include "Function.h"
 #include "SubProblem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<PointValue>()

--- a/framework/src/preconditioners/MoosePreconditioner.C
+++ b/framework/src/preconditioners/MoosePreconditioner.C
@@ -12,9 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MoosePreconditioner.h"
 #include "FEProblem.h"
 #include "PetscSupport.h"
+#include "NonlinearSystem.h"
+
+// libMesh includes
+#include "libmesh/numeric_vector.h"
 
 template<>
 InputParameters validParams<MoosePreconditioner>()

--- a/framework/src/predictors/AdamsPredictor.C
+++ b/framework/src/predictors/AdamsPredictor.C
@@ -15,6 +15,9 @@
 #include "AdamsPredictor.h"
 #include "NonlinearSystem.h"
 
+// libMesh includes
+#include "libmesh/numeric_vector.h"
+
 template<>
 InputParameters validParams<AdamsPredictor>()
 {

--- a/framework/src/predictors/Predictor.C
+++ b/framework/src/predictors/Predictor.C
@@ -12,9 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "Predictor.h"
 #include "NonlinearSystem.h"
 #include "FEProblem.h"
+
+// libMesh includes
+#include "libmesh/numeric_vector.h"
 
 template<>
 InputParameters validParams<Predictor>()

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -14,6 +14,12 @@
 
 #include "DataIO.h"
 #include "MooseMesh.h"
+#include "ColumnMajorMatrix.h"
+
+// libMesh includes
+#include "libmesh/numeric_vector.h"
+#include "libmesh/dense_matrix.h"
+#include "libmesh/elem.h"
 
 template<>
 void

--- a/framework/src/restart/Restartable.C
+++ b/framework/src/restart/Restartable.C
@@ -12,6 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+#include "InputParameters.h"
 #include "Restartable.h"
 #include "SubProblem.h"
 

--- a/framework/src/restart/RestartableDataIO.C
+++ b/framework/src/restart/RestartableDataIO.C
@@ -12,11 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "RestartableDataIO.h"
 #include "MooseUtils.h"
 #include "RestartableData.h"
 #include "FEProblem.h"
 #include "MooseApp.h"
+#include "NonlinearSystem.h"
 
 #include <stdio.h>
 

--- a/framework/src/restart/Resurrector.C
+++ b/framework/src/restart/Resurrector.C
@@ -12,10 +12,12 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "Resurrector.h"
 #include "FEProblem.h"
 #include "MooseUtils.h"
 #include "MooseApp.h"
+#include "NonlinearSystem.h"
 
 #include <stdio.h>
 #include <sys/stat.h>

--- a/framework/src/splits/ContactSplit.C
+++ b/framework/src/splits/ContactSplit.C
@@ -14,6 +14,7 @@
 
 #include "ContactSplit.h"
 #include "InputParameters.h"
+
 #if defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)
 template<>
 InputParameters validParams<ContactSplit>()

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -12,12 +12,15 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "Split.h"
 #include "InputParameters.h"
 #include "PetscSupport.h"
+#include "FEProblem.h"
+#include "NonlinearSystem.h"
 
-#if defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)
 // petsc 3.3.0 or later needed
+#if defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)
 
 template<>
 InputParameters validParams<Split>()

--- a/framework/src/timeintegrators/SteadyState.C
+++ b/framework/src/timeintegrators/SteadyState.C
@@ -14,6 +14,9 @@
 
 #include "SteadyState.h"
 
+// libMesh includes
+#include "libmesh/numeric_vector.h"
+
 template<>
 InputParameters validParams<SteadyState>()
 {

--- a/framework/src/timesteppers/AB2PredictorCorrector.C
+++ b/framework/src/timesteppers/AB2PredictorCorrector.C
@@ -23,6 +23,7 @@
 
 //libMesh includes
 #include "libmesh/nonlinear_solver.h"
+#include "libmesh/numeric_vector.h"
 
 // C++ Includes
 #include <iomanip>

--- a/framework/src/timesteppers/DT2.C
+++ b/framework/src/timesteppers/DT2.C
@@ -12,15 +12,18 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "DT2.h"
 #include "FEProblem.h"
 #include "TimeIntegrator.h"
+#include "NonlinearSystem.h"
 
 //libMesh includes
 #include "libmesh/implicit_system.h"
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/transient_system.h"
+#include "libmesh/numeric_vector.h"
 
 // C++ Includes
 #include <iomanip>

--- a/framework/src/timesteppers/IterationAdaptiveDT.C
+++ b/framework/src/timesteppers/IterationAdaptiveDT.C
@@ -11,11 +11,13 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
-#include "IterationAdaptiveDT.h"
 
+// MOOSE includes
+#include "IterationAdaptiveDT.h"
 #include "Function.h"
 #include "Piecewise.h"
 #include "Transient.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<IterationAdaptiveDT>()

--- a/framework/src/transfers/DTKInterpolationAdapter.C
+++ b/framework/src/transfers/DTKInterpolationAdapter.C
@@ -11,23 +11,24 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #include "libmesh/libmesh_config.h"
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
+// MOOSE includes
 #include "Moose.h"
-
 #include "DTKInterpolationEvaluator.h"
 #include "DTKInterpolationAdapter.h"
 #include "Transfer.h"
 
+// libMesh includes
 #include "libmesh/mesh.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/elem.h"
 
+// DTK includes
 #include <DTK_MeshTypes.hpp>
-
-#include <vector>
 
 DTKInterpolationAdapter::DTKInterpolationAdapter(Teuchos::RCP<const Teuchos::MpiComm<int> > in_comm, EquationSystems & in_es, const Point & offset, unsigned int from_dim):
     comm(in_comm),

--- a/framework/src/transfers/DTKInterpolationEvaluator.C
+++ b/framework/src/transfers/DTKInterpolationEvaluator.C
@@ -15,17 +15,21 @@
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
+// DTK includes
 #include "DTKInterpolationEvaluator.h"
 #include "DTKInterpolationHelper.h"
 
+// libMesh includes
 #include "libmesh/dof_map.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_compute_data.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/mesh.h"
+#include "libmesh/system.h"
 
-#include <string>
-
-namespace libMesh {
+namespace libMesh
+{
 
 DTKInterpolationEvaluator::DTKInterpolationEvaluator(System & in_sys, std::string var_name, const Point & offset):
     sys(in_sys),

--- a/framework/src/transfers/DTKInterpolationHelper.C
+++ b/framework/src/transfers/DTKInterpolationHelper.C
@@ -17,9 +17,9 @@
 
 // Moose Includes
 #include "MooseError.h"
-
 #include "DTKInterpolationHelper.h"
 
+// libMesh includes
 #include "libmesh/system.h"
 
 // Trilinos Includes
@@ -37,7 +37,8 @@
 #include <DTK_CommTools.hpp>
 #include <DTK_CommIndexer.hpp>
 
-namespace libMesh {
+namespace libMesh
+{
 
 DTKInterpolationHelper::DTKInterpolationHelper()
 {}
@@ -56,7 +57,14 @@ DTKInterpolationHelper::~DTKInterpolationHelper()
 }
 
 void
-DTKInterpolationHelper::transferWithOffset(unsigned int from, unsigned int to, const Variable * from_var, const Variable * to_var, const Point & from_offset, const Point & to_offset, MPI_Comm * from_mpi_comm, MPI_Comm * to_mpi_comm)
+DTKInterpolationHelper::transferWithOffset(unsigned int from,
+                                           unsigned int to,
+                                           const Variable * from_var,
+                                           const Variable * to_var,
+                                           const Point & from_offset,
+                                           const Point & to_offset,
+                                           MPI_Comm * from_mpi_comm,
+                                           MPI_Comm * to_mpi_comm)
 {
   Teuchos::RCP<const Teuchos::MpiComm<int> > from_comm;
   Teuchos::RCP<const Teuchos::MpiComm<int> > to_comm;

--- a/framework/src/transfers/MultiAppCopyTransfer.C
+++ b/framework/src/transfers/MultiAppCopyTransfer.C
@@ -12,14 +12,15 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppCopyTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/system.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/id_types.h"

--- a/framework/src/transfers/MultiAppDTKInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppDTKInterpolationTransfer.C
@@ -16,11 +16,12 @@
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
+// MOOSE includes
 #include "MultiAppDTKInterpolationTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MultiAppDTKInterpolationTransfer>()

--- a/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
@@ -16,15 +16,17 @@
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
+// MOOSE includes
 #include "MultiAppDTKUserObjectEvaluator.h"
-
-// Moose
 #include "UserObject.h"
 #include "Executioner.h"
 #include "FEProblem.h"
-#include "libmesh/mesh_tools.h"
-
+#include "MultiApp.h"
 #include "MooseTypes.h"
+#include "MooseMesh.h"
+
+// libMesh includes
+#include "libmesh/mesh_tools.h"
 
 MultiAppDTKUserObjectEvaluator::MultiAppDTKUserObjectEvaluator(MultiApp & multi_app, const std::string & user_object_name):
     _multi_app(multi_app),
@@ -58,7 +60,7 @@ MultiAppDTKUserObjectEvaluator::evaluate(const Teuchos::ArrayRCP<GlobalOrdinal>&
       for (unsigned int j=0; j<dim; j++)
         p(j) = coords[(j*num_values)+i];
 
-      evaluated_data[i] = _multi_app.appUserObjectBase(app, _user_object_name).spatialValue(p - _multi_app.position(app) );
+      evaluated_data[i] = _multi_app.appUserObjectBase(app, _user_object_name).spatialValue(p - _multi_app.position(app));
     }
     else
       evaluated_data[i] = 0.0;
@@ -90,8 +92,7 @@ MultiAppDTKUserObjectEvaluator::createSourceGeometry( const Teuchos::RCP<const T
     _box_ids[app] = global_app;
   }
 
-  return Teuchos::rcp( new DataTransferKit::GeometryManager<DataTransferKit::Box,GlobalOrdinal>(_boxes, _box_ids, comm, 3));
-
+  return Teuchos::rcp(new DataTransferKit::GeometryManager<DataTransferKit::Box,GlobalOrdinal>(_boxes, _box_ids, comm, 3));
 }
 
 #endif //LIBMESH_TRILINOS_HAVE_DTK

--- a/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
@@ -17,6 +17,8 @@
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
 #include "MultiAppDTKUserObjectTransfer.h"
+#include "DTKInterpolationAdapter.h"
+#include "MultiApp.h"
 
 // Moose Includes
 #include "MooseTypes.h"

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -12,14 +12,15 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppInterpolationTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/meshfree_interpolation.h"
 #include "libmesh/system.h"
 #include "libmesh/radial_basis_interpolation.h"

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -12,15 +12,15 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppMeshFunctionTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
 #include "MooseTypes.h" // for MooseSharedPointer
+#include "MooseMesh.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/meshfree_interpolation.h"
 #include "libmesh/system.h"
 #include "libmesh/mesh_function.h"

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -12,14 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppNearestNodeTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
+#include "MooseMesh.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/system.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/id_types.h"

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -12,13 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppPostprocessorInterpolationTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/meshfree_interpolation.h"
 #include "libmesh/system.h"
 #include "libmesh/radial_basis_interpolation.h"

--- a/framework/src/transfers/MultiAppPostprocessorToAuxScalarTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorToAuxScalarTransfer.C
@@ -14,11 +14,12 @@
 
 #include "MultiAppPostprocessorToAuxScalarTransfer.h"
 
-// Moose
+// MOOSE includes
 #include "MooseTypes.h"
 #include "FEProblem.h"
+#include "MultiApp.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/meshfree_interpolation.h"
 #include "libmesh/system.h"
 

--- a/framework/src/transfers/MultiAppPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorTransfer.C
@@ -14,9 +14,10 @@
 
 #include "MultiAppPostprocessorTransfer.h"
 
-// Moose
+// MOOSE includes
 #include "MooseTypes.h"
 #include "FEProblem.h"
+#include "MultiApp.h"
 
 // libMesh
 #include "libmesh/meshfree_interpolation.h"

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -12,9 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppProjectionTransfer.h"
 #include "FEProblem.h"
 #include "AddVariableAction.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/quadrature_gauss.h"

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -12,13 +12,16 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppTransfer.h"
-
 #include "Transfer.h"
 #include "MooseTypes.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
 
+// libMesh includes
 #include "libmesh/parallel_algebra.h"
 #include "libmesh/mesh_tools.h"
 

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -12,12 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppUserObjectTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
 
 // libMesh
 #include "libmesh/meshfree_interpolation.h"

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -12,13 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppVariableValueSamplePostprocessorTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/meshfree_interpolation.h"
 #include "libmesh/system.h"
 

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -12,13 +12,14 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiAppVariableValueSampleTransfer.h"
-
-// Moose
 #include "MooseTypes.h"
 #include "FEProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
 
-// libMesh
+// libMesh includes
 #include "libmesh/meshfree_interpolation.h"
 #include "libmesh/system.h"
 

--- a/framework/src/transfers/Transfer.C
+++ b/framework/src/transfers/Transfer.C
@@ -12,11 +12,17 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "Transfer.h"
 #include "FEProblem.h"
 #include "MooseMesh.h"
 #include "Assembly.h"
 #include "MooseVariable.h"
+#include "MooseEnum.h"
+#include "InputParameters.h"
+
+// libMesh
+#include "libmesh/system.h"
 
 const Number Transfer::OutOfMeshValue = -999999;
 

--- a/framework/src/userobject/ElementIntegralUserObject.C
+++ b/framework/src/userobject/ElementIntegralUserObject.C
@@ -12,6 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "ElementIntegralUserObject.h"
 
 // libmesh includes

--- a/framework/src/userobject/ElementUserObject.C
+++ b/framework/src/userobject/ElementUserObject.C
@@ -17,6 +17,9 @@
 #include "SubProblem.h"
 #include "Assembly.h"
 
+// libMesh includes
+#include "libmesh/elem.h"
+
 template<>
 InputParameters validParams<ElementUserObject>()
 {

--- a/framework/src/userobject/LayeredAverage.C
+++ b/framework/src/userobject/LayeredAverage.C
@@ -14,9 +14,6 @@
 
 #include "LayeredAverage.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
 template<>
 InputParameters validParams<LayeredAverage>()
 {

--- a/framework/src/userobject/LayeredBase.C
+++ b/framework/src/userobject/LayeredBase.C
@@ -12,7 +12,11 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "LayeredBase.h"
+#include "UserObject.h"
+#include "SubProblem.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/mesh_tools.h"

--- a/framework/src/userobject/LayeredSideAverage.C
+++ b/framework/src/userobject/LayeredSideAverage.C
@@ -14,9 +14,6 @@
 
 #include "LayeredSideAverage.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
 template<>
 InputParameters validParams<LayeredSideAverage>()
 {

--- a/framework/src/userobject/LayeredSideFluxAverage.C
+++ b/framework/src/userobject/LayeredSideFluxAverage.C
@@ -14,9 +14,6 @@
 
 #include "LayeredSideFluxAverage.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
 template<>
 InputParameters validParams<LayeredSideFluxAverage>()
 {

--- a/framework/src/userobject/LayeredSideIntegral.C
+++ b/framework/src/userobject/LayeredSideIntegral.C
@@ -14,9 +14,6 @@
 
 #include "LayeredSideIntegral.h"
 
-// libmesh includes
-#include "libmesh/mesh_tools.h"
-
 template<>
 InputParameters validParams<LayeredSideIntegral>()
 {

--- a/framework/src/userobject/NearestPointLayeredAverage.C
+++ b/framework/src/userobject/NearestPointLayeredAverage.C
@@ -12,10 +12,9 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NearestPointLayeredAverage.h"
-
-// libmesh includes
-#include "libmesh/mesh_tools.h"
+#include "LayeredAverage.h"
 
 template<>
 InputParameters validParams<NearestPointLayeredAverage>()
@@ -86,6 +85,12 @@ NearestPointLayeredAverage::threadJoin(const UserObject & y)
 
   for (unsigned int i=0; i<_layered_averages.size(); i++)
     _layered_averages[i]->threadJoin(*npla._layered_averages[i]);
+}
+
+Real
+NearestPointLayeredAverage::spatialValue(const Point & p) const
+{
+  return nearestLayeredAverage(p)->integralValue(p);
 }
 
 LayeredAverage *

--- a/framework/src/userobject/NodalNormalsCorner.C
+++ b/framework/src/userobject/NodalNormalsCorner.C
@@ -12,7 +12,9 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NodalNormalsCorner.h"
+#include "MooseMesh.h"
 
 Threads::spin_mutex nodal_normals_corner_mutex;
 

--- a/framework/src/userobject/NodalNormalsPreprocessor.C
+++ b/framework/src/userobject/NodalNormalsPreprocessor.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "NodalNormalsPreprocessor.h"
 #include "Assembly.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/quadrature.h"

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -11,10 +11,13 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 // MOOSE includes
 #include "MooseError.h"
 #include "SolutionUserObject.h"
 #include "RotationMatrix.h"
+#include "MooseUtils.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/equation_systems.h"
@@ -24,6 +27,7 @@
 #include "libmesh/transient_system.h"
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/serial_mesh.h"
+#include "libmesh/exodusII_io.h"
 
 template<>
 InputParameters validParams<SolutionUserObject>()

--- a/framework/src/userobject/UserObjectIO.C
+++ b/framework/src/userobject/UserObjectIO.C
@@ -12,8 +12,12 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
+#include "UserObjectWarehouse.h"
 #include "UserObjectIO.h"
 #include "UserObject.h"
+
+// C++ includes
 #include <vector>
 #include <cstring>
 

--- a/framework/src/userobject/UserObjectInterface.C
+++ b/framework/src/userobject/UserObjectInterface.C
@@ -12,8 +12,9 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "UserObjectInterface.h"
-#include "FEProblem.h"
+#include "InputParameters.h"
 
 UserObjectInterface::UserObjectInterface(const InputParameters & params) :
     _uoi_feproblem(*params.get<FEProblem *>("_fe_problem")),

--- a/framework/src/userobject/VerifyElementUniqueID.C
+++ b/framework/src/userobject/VerifyElementUniqueID.C
@@ -12,10 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "VerifyElementUniqueID.h"
 #include "SubProblem.h"
-
-#include <algorithm>
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<VerifyElementUniqueID>()

--- a/framework/src/userobject/VerifyNodalUniqueID.C
+++ b/framework/src/userobject/VerifyNodalUniqueID.C
@@ -12,10 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "VerifyNodalUniqueID.h"
 #include "SubProblem.h"
-
-#include <algorithm>
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<VerifyNodalUniqueID>()

--- a/framework/src/utils/BilinearInterpolation.C
+++ b/framework/src/utils/BilinearInterpolation.C
@@ -12,30 +12,23 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-/* BilinearInterpolation is designed to linearly interpolate a function of
- * two values e.g. z(x,y).  Supply Bilinearlinear with a vector of x and a
- * vector of y and a ColumnMajorMatrix of function values, z, that correspond
- * to the values in the vectors x and y...and also a sample point
- * (xcoord and ycoord), and BilinearInterpolation will return the value of the
- * function at the sample point.  A simple example:
- *
- * x = [1 2], y = [1 2],
- *
- * z = [1 2]
- *     [3 4]
- *
- * with xcoord = 1.5 and ycoord = 1.5 returns a value of 2.5
- */
-
 #include "BilinearInterpolation.h"
 
 int BilinearInterpolation::_file_number = 0;
 
-BilinearInterpolation::BilinearInterpolation(const std::vector<Real> & x, const std::vector<Real> & y, const ColumnMajorMatrix & z): _xAxis(x), _yAxis(y), _zSurface(z)
+BilinearInterpolation::BilinearInterpolation(const std::vector<Real> & x,
+                                             const std::vector<Real> & y,
+                                             const ColumnMajorMatrix & z) :
+    _xAxis(x),
+    _yAxis(y),
+    _zSurface(z)
 {
 }
 
-void BilinearInterpolation::getNeighborIndices(const std::vector<Real> & inArr, Real x ,int& lowerX ,int& upperX )
+void BilinearInterpolation::getNeighborIndices(const std::vector<Real> & inArr,
+                                               Real x,
+                                               int & lowerX,
+                                               int & upperX)
 {
   int N = inArr.size();
   if (x <= inArr[0])
@@ -50,7 +43,7 @@ void BilinearInterpolation::getNeighborIndices(const std::vector<Real> & inArr, 
   }
   else
   {
-    for (int i(1); i < N; ++i)
+    for (int i = 1; i < N; ++i)
     {
       if (x < inArr[i] )
       {
@@ -70,13 +63,13 @@ void BilinearInterpolation::getNeighborIndices(const std::vector<Real> & inArr, 
 
 Real BilinearInterpolation::sample(Real xcoord, Real ycoord)
 {
-  //first find 4 neighboring points
-  int lx=0; //index of x coordinate of adjacent grid point to left of P
-  int ux=0; //index of x coordinate of adjacent grid point to right of P
+  // first find 4 neighboring points
+  int lx = 0; // index of x coordinate of adjacent grid point to left of P
+  int ux = 0; // index of x coordinate of adjacent grid point to right of P
   getNeighborIndices(_xAxis, xcoord, lx, ux);
 
-  int ly=0; //index of y coordinate of adjacent grid point below P
-  int uy=0; //index of y coordinate of adjacent grid point above P
+  int ly = 0; // index of y coordinate of adjacent grid point below P
+  int uy = 0; // index of y coordinate of adjacent grid point above P
   getNeighborIndices(_yAxis, ycoord, ly, uy);
 
   Real fQ11 = _zSurface(ly, lx);

--- a/framework/src/utils/ColumnMajorMatrix.C
+++ b/framework/src/utils/ColumnMajorMatrix.C
@@ -12,9 +12,13 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "ColumnMajorMatrix.h"
 
+// libMesh includes
 #include "libmesh/petsc_macro.h"
+
+// PETSc includes
 #include <petscsys.h>
 #include <petscblaslapack.h>
 

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -12,16 +12,16 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "Conversion.h"
 #include "MooseError.h"
+#include "MultiMooseEnum.h"
 
-#include <map>
-#include <algorithm>
-
+// libMesh includes
 #include "libmesh/string_to_enum.h"
 
-namespace Moose {
-
+namespace Moose
+{
   std::map<std::string, ExecFlagType> execstore_type_to_enum;
   std::map<std::string, QuadratureType> quadrature_type_to_enum;
   std::map<std::string, CoordinateSystemType> coordinate_system_type_to_enum;

--- a/framework/src/utils/FormattedTable.C
+++ b/framework/src/utils/FormattedTable.C
@@ -16,6 +16,9 @@
 #include "MooseError.h"
 #include "InfixIterator.h"
 
+// libMesh includes
+#include "libmesh/exodusII_io.h"
+
 #include <iomanip>
 #include <iterator>
 

--- a/framework/src/utils/GriddedData.C
+++ b/framework/src/utils/GriddedData.C
@@ -12,6 +12,8 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
+#include "MooseError.h"
 #include "GriddedData.h"
 
 /**

--- a/framework/src/utils/ImageSampler.C
+++ b/framework/src/utils/ImageSampler.C
@@ -72,6 +72,10 @@ ImageSampler::~ImageSampler()
 void
 ImageSampler::setupImageSampler(MooseMesh & mesh)
 {
+  // Don't warn that mesh or _is_pars are unused when VTK is not enabled.
+  libmesh_ignore(mesh);
+  libmesh_ignore(_is_pars);
+
 #ifdef LIBMESH_HAVE_VTK
   // Get access to the Mesh object
   MeshTools::BoundingBox bbox = MeshTools::bounding_box(mesh.getMesh());

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -12,24 +12,26 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-// STL includes
-#include <iostream>
-#include <fstream>
-#include <istream>
-#include <iterator>
-
-// Standard Library
-#include <sys/stat.h>
-
 // MOOSE includes
 #include "MooseUtils.h"
 #include "MooseError.h"
 #include "MaterialProperty.h"
 
+// libMesh includes
+#include "libmesh/elem.h"
+
 // External includes
 #include "pcrecpp.h"
 #include "tinydir.h"
 
+// C++ includes
+#include <iostream>
+#include <fstream>
+#include <istream>
+#include <iterator>
+
+// System includes
+#include <sys/stat.h>
 
 namespace MooseUtils
 {

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -11,11 +11,13 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
-#include "libmesh/petsc_macro.h"
+
 // This only works with petsc-3.3 and above.
+#include "libmesh/petsc_macro.h"
 
 #if defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)
-/* Inside these guards we can use PETSC_VERSION_LT, which need not be modified upon transition from dev to a release. */
+// Inside these guards we can use PETSC_VERSION_LT, which need not be
+// modified upon transition from dev to a release.
 
 #include "PetscDMMoose.h"
 
@@ -27,19 +29,22 @@
 # include <petsc-private/dmimpl.h>
 #endif
 
-// libMesh Includes
+// MOOSE includes
+#include "PenetrationLocator.h"
+#include "NearestNodeLocator.h"
+#include "GeometricSearchData.h"
+#include "FEProblem.h"
+#include "DisplacedProblem.h"
+#include "MooseMesh.h"
+#include "NonlinearSystem.h"
+
+// libMesh includes
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/preconditioner.h"
-
-#include "PenetrationLocator.h"
-#include "NearestNodeLocator.h"
-#include "GeometricSearchData.h"
-#include "FEProblem.h"
-#include "DisplacedProblem.h"
 
 struct DM_Moose
 {

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -16,7 +16,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
-// Moose includes
+// MOOSE includes
 #include "MooseApp.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
@@ -31,8 +31,9 @@
 #include "MultiMooseEnum.h"
 #include "Conversion.h"
 #include "Executioner.h"
+#include "MooseMesh.h"
 
-//libMesh Includes
+// libMesh includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/nonlinear_implicit_system.h"
@@ -44,7 +45,7 @@
 #include "libmesh/petsc_preconditioner.h"
 #include "libmesh/getpot.h"
 
-//PETSc includes
+// PETSc includes
 #include <petsc.h>
 #include <petscsnes.h>
 #include <petscksp.h>

--- a/framework/src/utils/RayTracing.C
+++ b/framework/src/utils/RayTracing.C
@@ -176,7 +176,7 @@ void recursivelyFindElementsIntersectedByLine(const LineSegment & line_segment, 
   return;
 }
 
-void elementsIntersectedByLine(const Point & p0, const Point & p1, const MeshBase & mesh, MooseSharedPointer<PointLocatorBase> & point_locator, std::vector<Elem *> & intersected_elems, std::vector<LineSegment> & segments)
+void elementsIntersectedByLine(const Point & p0, const Point & p1, const MeshBase & /*mesh*/, MooseSharedPointer<PointLocatorBase> & point_locator, std::vector<Elem *> & intersected_elems, std::vector<LineSegment> & segments)
 {
   // Make sure our list is clear
   intersected_elems.clear();

--- a/framework/src/vectorpostprocessors/ElementsAlongLine.C
+++ b/framework/src/vectorpostprocessors/ElementsAlongLine.C
@@ -12,9 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "ElementsAlongLine.h"
-
 #include "RayTracing.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<ElementsAlongLine>()

--- a/framework/src/vectorpostprocessors/IntersectionPointsAlongLine.C
+++ b/framework/src/vectorpostprocessors/IntersectionPointsAlongLine.C
@@ -12,9 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "IntersectionPointsAlongLine.h"
-
 #include "RayTracing.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<IntersectionPointsAlongLine>()

--- a/framework/src/vectorpostprocessors/LineMaterialRealSampler.C
+++ b/framework/src/vectorpostprocessors/LineMaterialRealSampler.C
@@ -12,6 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "LineMaterialRealSampler.h"
 
 template<>

--- a/framework/src/vectorpostprocessors/PointSamplerBase.C
+++ b/framework/src/vectorpostprocessors/PointSamplerBase.C
@@ -12,7 +12,9 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "PointSamplerBase.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/mesh_tools.h"

--- a/framework/src/vectorpostprocessors/SamplerBase.C
+++ b/framework/src/vectorpostprocessors/SamplerBase.C
@@ -12,8 +12,10 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "SamplerBase.h"
 #include "IndirectSort.h"
+#include "VectorPostprocessor.h"
 
 template<>
 InputParameters validParams<SamplerBase>()

--- a/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
+++ b/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
@@ -4,9 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "ChemicalReactionsApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "PrimaryTimeDerivative.h"
 #include "PrimaryConvection.h"

--- a/modules/combined/src/base/ModulesApp.C
+++ b/modules/combined/src/base/ModulesApp.C
@@ -4,10 +4,12 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "ModulesApp.h"
 #include "Factory.h"
 #include "ActionFactory.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 /************************************************************
  * New Module Step 1.                                       *

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -4,12 +4,14 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "ContactMaster.h"
 
+// MOOSE includes
+#include "ContactMaster.h"
 #include "FrictionalContactProblem.h"
 #include "NodalArea.h"
 #include "SystemBase.h"
 #include "PenetrationInfo.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/sparse_matrix.h"

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -6,13 +6,14 @@
 /****************************************************************/
 
 
+// MOOSE includes
 #include "FrictionalContactProblem.h"
-
 #include "NonlinearSystem.h"
 #include "DisplacedProblem.h"
 #include "PenetrationLocator.h"
 #include "NearestNodeLocator.h"
 #include "MooseApp.h"
+#include "MooseMesh.h"
 
 #include <limits>
 

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -5,10 +5,12 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
+// MOOSE includes
 #include "MechanicalContactConstraint.h"
 #include "SystemBase.h"
 #include "PenetrationLocator.h"
 #include "Assembly.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/string_to_enum.h"

--- a/modules/contact/src/MultiDContactConstraint.C
+++ b/modules/contact/src/MultiDContactConstraint.C
@@ -5,10 +5,11 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
+// MOOSE includes
 #include "MultiDContactConstraint.h"
-
 #include "SystemBase.h"
 #include "PenetrationLocator.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/string_to_enum.h"

--- a/modules/contact/src/ReferenceResidualProblem.C
+++ b/modules/contact/src/ReferenceResidualProblem.C
@@ -5,11 +5,11 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
-
+// MOOSE includes
 #include "ReferenceResidualProblem.h"
-
 #include "MooseApp.h"
-#include <sstream>
+#include "MooseMesh.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<ReferenceResidualProblem>()

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -4,11 +4,13 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "SlaveConstraint.h"
 #include "FrictionalContactProblem.h"
 
 // Moose includes
 #include "SystemBase.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/plane.h"

--- a/modules/contact/src/base/ContactApp.C
+++ b/modules/contact/src/base/ContactApp.C
@@ -7,6 +7,7 @@
 #include "ContactApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "ContactAction.h"
 #include "ContactMaster.h"

--- a/modules/heat_conduction/src/AnisoHeatConduction.C
+++ b/modules/heat_conduction/src/AnisoHeatConduction.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "AnisoHeatConduction.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<AnisoHeatConduction>()

--- a/modules/heat_conduction/src/AnisoHeatConductionMaterial.C
+++ b/modules/heat_conduction/src/AnisoHeatConductionMaterial.C
@@ -7,6 +7,7 @@
 
 #include "AnisoHeatConductionMaterial.h"
 #include "Function.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/quadrature.h"

--- a/modules/heat_conduction/src/GapConductance.C
+++ b/modules/heat_conduction/src/GapConductance.C
@@ -5,13 +5,13 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
+// MOOSE includes
 #include "GapConductance.h"
-
-// Moose Includes
 #include "PenetrationLocator.h"
 #include "Function.h"
+#include "MooseMesh.h"
 
-// libMesh Includes
+// libMesh includes
 #include "libmesh/string_to_enum.h"
 
 template<>

--- a/modules/heat_conduction/src/GapHeatPointSourceMaster.C
+++ b/modules/heat_conduction/src/GapHeatPointSourceMaster.C
@@ -4,9 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "GapHeatPointSourceMaster.h"
 #include "SystemBase.h"
 #include "PenetrationInfo.h"
+#include "MooseMesh.h"
 
 #include "libmesh/string_to_enum.h"
 

--- a/modules/heat_conduction/src/GapHeatTransfer.C
+++ b/modules/heat_conduction/src/GapHeatTransfer.C
@@ -5,13 +5,15 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
+// MOOSE includes
 #include "GapHeatTransfer.h"
 #include "GapConductance.h"
 #include "PenetrationLocator.h"
 #include "SystemBase.h"
 #include "Assembly.h"
+#include "MooseMesh.h"
 
-// libmesh
+// libMesh includes
 #include "libmesh/string_to_enum.h"
 
 Threads::spin_mutex slave_flux_mutex;

--- a/modules/heat_conduction/src/HeatConduction.C
+++ b/modules/heat_conduction/src/HeatConduction.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "HeatConduction.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<HeatConductionKernel>()

--- a/modules/heat_conduction/src/actions/AddSlaveFluxVectorAction.C
+++ b/modules/heat_conduction/src/actions/AddSlaveFluxVectorAction.C
@@ -4,9 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "AddSlaveFluxVectorAction.h"
 #include "Parser.h"
 #include "FEProblem.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<AddSlaveFluxVectorAction>()

--- a/modules/heat_conduction/src/base/HeatConductionApp.C
+++ b/modules/heat_conduction/src/base/HeatConductionApp.C
@@ -7,6 +7,7 @@
 #include "HeatConductionApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "AddSlaveFluxVectorAction.h"
 #include "ConvectiveFluxFunction.h"

--- a/modules/linear_elasticity/src/SolidMechTempCouple.C
+++ b/modules/linear_elasticity/src/SolidMechTempCouple.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "SolidMechTempCouple.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<SolidMechTempCouple>()

--- a/modules/linear_elasticity/src/SolidMechX.C
+++ b/modules/linear_elasticity/src/SolidMechX.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "SolidMechX.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<SolidMechX>()

--- a/modules/linear_elasticity/src/SolidMechY.C
+++ b/modules/linear_elasticity/src/SolidMechY.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "SolidMechY.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<SolidMechY>()

--- a/modules/linear_elasticity/src/base/LinearElasticityApp.C
+++ b/modules/linear_elasticity/src/base/LinearElasticityApp.C
@@ -7,6 +7,7 @@
 #include "LinearElasticityApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "LinearElasticityMaterial.h"
 #include "SolidMechX.h"

--- a/modules/misc/src/CoupledDirectionalMeshHeightInterpolation.C
+++ b/modules/misc/src/CoupledDirectionalMeshHeightInterpolation.C
@@ -5,8 +5,8 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
-
 #include "CoupledDirectionalMeshHeightInterpolation.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/mesh_tools.h"

--- a/modules/misc/src/RigidBodyModes3D.C
+++ b/modules/misc/src/RigidBodyModes3D.C
@@ -5,8 +5,8 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
-
 #include "RigidBodyModes3D.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<RigidBodyModes3D>()

--- a/modules/misc/src/RigidBodyModesRZ.C
+++ b/modules/misc/src/RigidBodyModesRZ.C
@@ -5,8 +5,8 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
-
 #include "RigidBodyModesRZ.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<RigidBodyModesRZ>()

--- a/modules/misc/src/base/MiscApp.C
+++ b/modules/misc/src/base/MiscApp.C
@@ -7,6 +7,7 @@
 #include "MiscApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "BodyForceVoid.h"
 #include "CoefDiffusion.h"

--- a/modules/navier_stokes/src/auxkernels/INSCourant.C
+++ b/modules/navier_stokes/src/auxkernels/INSCourant.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSCourant.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSCourant>()

--- a/modules/navier_stokes/src/auxkernels/INSDivergenceAux.C
+++ b/modules/navier_stokes/src/auxkernels/INSDivergenceAux.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSDivergenceAux.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSDivergenceAux>()

--- a/modules/navier_stokes/src/auxkernels/NSPressureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSPressureAux.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSPressureAux.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NSPressureAux>()

--- a/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSTemperatureAux.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NSTemperatureAux>()

--- a/modules/navier_stokes/src/base/NavierStokesApp.C
+++ b/modules/navier_stokes/src/base/NavierStokesApp.C
@@ -7,6 +7,7 @@
 #include "NavierStokesApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "NSMassInviscidFlux.h"
 #include "NSMomentumInviscidFlux.h"

--- a/modules/navier_stokes/src/bcs/INSMomentumNoBCBC.C
+++ b/modules/navier_stokes/src/bcs/INSMomentumNoBCBC.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSMomentumNoBCBC.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSMomentumNoBCBC>()

--- a/modules/navier_stokes/src/bcs/NSImposedVelocityDirectionBC.C
+++ b/modules/navier_stokes/src/bcs/NSImposedVelocityDirectionBC.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSImposedVelocityDirectionBC.h"
+#include "MooseMesh.h"
 
 // Full specialization of the validParams function for this object
 template<>

--- a/modules/navier_stokes/src/bcs/NSIntegratedBC.C
+++ b/modules/navier_stokes/src/bcs/NSIntegratedBC.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSIntegratedBC.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NSIntegratedBC>()

--- a/modules/navier_stokes/src/bcs/NSStagnationBC.C
+++ b/modules/navier_stokes/src/bcs/NSStagnationBC.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSStagnationBC.h"
+#include "MooseMesh.h"
 
 // Full specialization of the validParams function for this object
 template<>

--- a/modules/navier_stokes/src/kernels/INSChorinCorrector.C
+++ b/modules/navier_stokes/src/kernels/INSChorinCorrector.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSChorinCorrector.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSChorinCorrector>()

--- a/modules/navier_stokes/src/kernels/INSChorinPredictor.C
+++ b/modules/navier_stokes/src/kernels/INSChorinPredictor.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSChorinPredictor.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSChorinPredictor>()

--- a/modules/navier_stokes/src/kernels/INSChorinPressurePoisson.C
+++ b/modules/navier_stokes/src/kernels/INSChorinPressurePoisson.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSChorinPressurePoisson.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSChorinPressurePoisson>()

--- a/modules/navier_stokes/src/kernels/INSPressurePoisson.C
+++ b/modules/navier_stokes/src/kernels/INSPressurePoisson.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSPressurePoisson.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSPressurePoisson>()

--- a/modules/navier_stokes/src/kernels/INSProjection.C
+++ b/modules/navier_stokes/src/kernels/INSProjection.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSProjection.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSProjection>()

--- a/modules/navier_stokes/src/kernels/INSSplitMomentum.C
+++ b/modules/navier_stokes/src/kernels/INSSplitMomentum.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSSplitMomentum.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSSplitMomentum>()

--- a/modules/navier_stokes/src/kernels/INSTemperature.C
+++ b/modules/navier_stokes/src/kernels/INSTemperature.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "INSTemperature.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<INSTemperature>()

--- a/modules/navier_stokes/src/kernels/NSKernel.C
+++ b/modules/navier_stokes/src/kernels/NSKernel.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSKernel.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NSKernel>()

--- a/modules/navier_stokes/src/kernels/NSSUPGBase.C
+++ b/modules/navier_stokes/src/kernels/NSSUPGBase.C
@@ -4,8 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "NSSUPGBase.h"
 
+#include "NSSUPGBase.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NSSUPGBase>()

--- a/modules/navier_stokes/src/kernels/NSTemperatureL2.C
+++ b/modules/navier_stokes/src/kernels/NSTemperatureL2.C
@@ -4,8 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "NSTemperatureL2.h"
 
+#include "NSTemperatureL2.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NSTemperatureL2>()

--- a/modules/navier_stokes/src/materials/NavierStokesMaterial.C
+++ b/modules/navier_stokes/src/materials/NavierStokesMaterial.C
@@ -7,6 +7,7 @@
 
 #include "NavierStokesMaterial.h"
 #include "Assembly.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/quadrature.h"

--- a/modules/phase_field/include/utils/JvarMapInterface.h
+++ b/modules/phase_field/include/utils/JvarMapInterface.h
@@ -8,6 +8,7 @@
 #define JVARMAPINTERFACE_H
 
 #include "MooseVariable.h"
+#include "NonlinearSystem.h"
 
 /**
  * Interface class ("Veneer") to provide a mapping from 'jvar' in

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -7,6 +7,7 @@
 #include "PhaseFieldApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 /*
  * Kernels

--- a/modules/phase_field/src/ics/ClosePackIC.C
+++ b/modules/phase_field/src/ics/ClosePackIC.C
@@ -6,8 +6,12 @@
 /****************************************************************/
 
 
-#include "libmesh/mesh_tools.h"
+// MOOSE includes
 #include "ClosePackIC.h"
+#include "MooseMesh.h"
+
+// libMesh includes
+#include "libmesh/mesh_tools.h"
 
 template<>
 InputParameters validParams<ClosePackIC>()

--- a/modules/phase_field/src/ics/HexPolycrystalIC.C
+++ b/modules/phase_field/src/ics/HexPolycrystalIC.C
@@ -4,8 +4,10 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "HexPolycrystalIC.h"
 #include "MooseRandom.h"
+#include "MooseMesh.h"
 
 #include <cmath>
 

--- a/modules/phase_field/src/ics/LatticeSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/LatticeSmoothCircleIC.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "LatticeSmoothCircleIC.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<LatticeSmoothCircleIC>()

--- a/modules/phase_field/src/ics/MultiSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothCircleIC.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "MultiSmoothCircleIC.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MultiSmoothCircleIC>()

--- a/modules/phase_field/src/ics/PolycrystalReducedIC.C
+++ b/modules/phase_field/src/ics/PolycrystalReducedIC.C
@@ -4,9 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "PolycrystalReducedIC.h"
 #include "IndirectSort.h"
 #include "MooseRandom.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<PolycrystalReducedIC>()

--- a/modules/phase_field/src/ics/RndSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/RndSmoothCircleIC.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "RndSmoothCircleIC.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<RndSmoothCircleIC>()

--- a/modules/phase_field/src/ics/SmoothCircleBaseIC.C
+++ b/modules/phase_field/src/ics/SmoothCircleBaseIC.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "SmoothCircleBaseIC.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<SmoothCircleBaseIC>()

--- a/modules/phase_field/src/ics/Tricrystal2CircleGrainsIC.C
+++ b/modules/phase_field/src/ics/Tricrystal2CircleGrainsIC.C
@@ -4,8 +4,10 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "Tricrystal2CircleGrainsIC.h"
 #include "MooseRandom.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<Tricrystal2CircleGrainsIC>()

--- a/modules/phase_field/src/kernels/ACMultiInterface.C
+++ b/modules/phase_field/src/kernels/ACMultiInterface.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "ACMultiInterface.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<ACMultiInterface>()

--- a/modules/phase_field/src/materials/GBAnisotropy.C
+++ b/modules/phase_field/src/materials/GBAnisotropy.C
@@ -6,6 +6,7 @@
 /****************************************************************/
 
 #include "GBAnisotropy.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/quadrature.h"

--- a/modules/phase_field/src/materials/InterfaceOrientationMaterial.C
+++ b/modules/phase_field/src/materials/InterfaceOrientationMaterial.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "InterfaceOrientationMaterial.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<InterfaceOrientationMaterial>()

--- a/modules/phase_field/src/postprocessors/FauxGrainTracker.C
+++ b/modules/phase_field/src/postprocessors/FauxGrainTracker.C
@@ -6,6 +6,7 @@
 /****************************************************************/
 
 #include "FauxGrainTracker.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<FauxGrainTracker>()

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -5,10 +5,12 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
+// MOOSE includes
 #include "GrainTracker.h"
 #include "MooseMesh.h"
 #include "GeneratedMesh.h"
 #include "EBSDReader.h"
+#include "NonlinearSystem.h"
 
 // LibMesh includes
 #include "libmesh/periodic_boundary_base.h"

--- a/modules/phase_field/src/userobjects/DiscreteNucleationMap.C
+++ b/modules/phase_field/src/userobjects/DiscreteNucleationMap.C
@@ -6,6 +6,7 @@
 /****************************************************************/
 
 #include "DiscreteNucleationMap.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/quadrature.h"

--- a/modules/phase_field/src/utils/PolycrystalICTools.C
+++ b/modules/phase_field/src/utils/PolycrystalICTools.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "PolycrystalICTools.h"
+#include "MooseMesh.h"
 
 std::vector<Real>
 PolycrystalICTools::assignPointsToVariables(const std::vector<Point> centerpoints, const Real op_num, const MooseMesh & mesh, const MooseVariable & var)

--- a/modules/richards/src/base/RichardsApp.C
+++ b/modules/richards/src/base/RichardsApp.C
@@ -9,6 +9,7 @@
 #include "RichardsApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 // UserObjects
 #include "RichardsVarNames.h"

--- a/modules/richards/src/base/RichardsMultiphaseProblem.C
+++ b/modules/richards/src/base/RichardsMultiphaseProblem.C
@@ -5,10 +5,9 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
-
 #include "RichardsMultiphaseProblem.h"
-
-//#include "NonlinearSystem.h"
+#include "NonlinearSystem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<RichardsMultiphaseProblem>()

--- a/modules/richards/src/materials/RichardsMaterial.C
+++ b/modules/richards/src/materials/RichardsMaterial.C
@@ -7,6 +7,7 @@
 
 #include "RichardsMaterial.h"
 #include "Assembly.h"
+#include "MooseMesh.h"
 
 #include <cmath> // std::sinh and std::cosh
 

--- a/modules/solid_mechanics/src/actions/DomainIntegralAction.C
+++ b/modules/solid_mechanics/src/actions/DomainIntegralAction.C
@@ -4,14 +4,18 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "DomainIntegralAction.h"
 
+// MOOSE includes
+#include "DomainIntegralAction.h"
 #include "Factory.h"
 #include "FEProblem.h"
 #include "Parser.h"
-#include "libmesh/string_to_enum.h"
 #include "CrackFrontDefinition.h"
 #include "InteractionIntegralAuxFields.h"
+#include "MooseMesh.h"
+
+// libMesh includes
+#include "libmesh/string_to_enum.h"
 
 template<>
 InputParameters validParams<DomainIntegralAction>()

--- a/modules/solid_mechanics/src/actions/SolidMechanicsAction.C
+++ b/modules/solid_mechanics/src/actions/SolidMechanicsAction.C
@@ -4,11 +4,12 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "SolidMechanicsAction.h"
 
+#include "SolidMechanicsAction.h"
 #include "Factory.h"
 #include "FEProblem.h"
 #include "Parser.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<SolidMechanicsAction>()

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -7,6 +7,7 @@
 #include "SolidMechanicsApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "AbaqusCreepMaterial.h"
 #include "AbaqusUmatMaterial.h"

--- a/modules/solid_mechanics/src/materials/Linear.C
+++ b/modules/solid_mechanics/src/materials/Linear.C
@@ -4,11 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "Linear.h"
 #include "SolidModel.h"
-
 #include "Problem.h"
-
+#include "MooseMesh.h"
 
 namespace SolidMechanics
 {

--- a/modules/solid_mechanics/src/materials/abaqus/AbaqusUmatMaterial.C
+++ b/modules/solid_mechanics/src/materials/abaqus/AbaqusUmatMaterial.C
@@ -4,9 +4,10 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "AbaqusUmatMaterial.h"
 
+#include "AbaqusUmatMaterial.h"
 #include "Factory.h"
+#include "MooseMesh.h"
 
 #include <dlfcn.h>
 #define QUOTE(macro) stringifyName(macro)

--- a/modules/solid_mechanics/src/materials/total_strain/SolidMechanicsMaterial.C
+++ b/modules/solid_mechanics/src/materials/total_strain/SolidMechanicsMaterial.C
@@ -4,10 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "SolidMechanicsMaterial.h"
 #include "Problem.h"
-
 #include "VolumetricModel.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<SolidMechanicsMaterial>()

--- a/modules/solid_mechanics/src/materials/total_strain/TrussMaterial.C
+++ b/modules/solid_mechanics/src/materials/total_strain/TrussMaterial.C
@@ -10,6 +10,7 @@
 #include "ColumnMajorMatrix.h"
 #include "SymmIsotropicElasticityTensor.h"
 #include "VolumetricModel.h"
+#include "NonlinearSystem.h"
 
 // libmesh includes
 #include "libmesh/quadrature.h"

--- a/modules/solid_mechanics/src/postprocessors/HomogenizedElasticConstants.C
+++ b/modules/solid_mechanics/src/postprocessors/HomogenizedElasticConstants.C
@@ -4,10 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "HomogenizedElasticConstants.h"
 #include "SymmElasticityTensor.h"
-
 #include "SubProblem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<HomogenizedElasticConstants>()

--- a/modules/solid_mechanics/src/postprocessors/HomogenizedThermalConductivity.C
+++ b/modules/solid_mechanics/src/postprocessors/HomogenizedThermalConductivity.C
@@ -4,10 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "HomogenizedThermalConductivity.h"
 #include "SymmElasticityTensor.h"
-
 #include "SubProblem.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<HomogenizedThermalConductivity>()

--- a/modules/solid_mechanics/src/postprocessors/InteractionIntegral.C
+++ b/modules/solid_mechanics/src/postprocessors/InteractionIntegral.C
@@ -7,6 +7,7 @@
 //  This post processor returns the Interaction Integral
 //
 #include "InteractionIntegral.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<InteractionIntegral>()

--- a/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -4,9 +4,12 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
+// MOOSE includes
 #include "CrackFrontDefinition.h"
-#include <map>
-#include <vector>
+#include "MooseMesh.h"
+
+// libMesh includes
 #include "libmesh/mesh_tools.h"
 
 template<>

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -7,6 +7,7 @@
 #include "TensorMechanicsApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 #include "TensorMechanicsAction.h"
 #include "DynamicTensorMechanicsAction.h"

--- a/modules/tensor_mechanics/src/kernels/CosseratStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/CosseratStressDivergenceTensors.C
@@ -4,11 +4,12 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "CosseratStressDivergenceTensors.h"
 
+#include "CosseratStressDivergenceTensors.h"
 #include "Material.h"
 #include "ElasticityTensorR4.h"
 #include "RankTwoTensor.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<CosseratStressDivergenceTensors>()

--- a/modules/tensor_mechanics/src/kernels/PoroMechanicsCoupling.C
+++ b/modules/tensor_mechanics/src/kernels/PoroMechanicsCoupling.C
@@ -4,8 +4,10 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "PoroMechanicsCoupling.h"
 #include "Function.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<PoroMechanicsCoupling>()

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
@@ -4,9 +4,10 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "StressDivergenceTensors.h"
 
+#include "StressDivergenceTensors.h"
 #include "Material.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<StressDivergenceTensors>()

--- a/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
@@ -4,7 +4,9 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "ComputeStrainBase.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<ComputeStrainBase>()

--- a/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
@@ -8,6 +8,7 @@
 
 #include "TensorMechanicsMaterial.h"
 #include "Function.h"
+#include "MooseMesh.h"
 
 // libmesh includes
 #include "libmesh/quadrature.h"

--- a/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
+++ b/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
@@ -4,8 +4,10 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "ElementPropertyReadFile.h"
 #include "MooseRandom.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<ElementPropertyReadFile>()

--- a/modules/water_steam_eos/src/base/WaterSteamEOSApp.C
+++ b/modules/water_steam_eos/src/base/WaterSteamEOSApp.C
@@ -4,9 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "WaterSteamEOSApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 
 template<>
 InputParameters validParams<WaterSteamEOSApp>()

--- a/test/src/actions/AddLotsOfAuxVariablesAction.C
+++ b/test/src/actions/AddLotsOfAuxVariablesAction.C
@@ -12,6 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+// MOOSE includes
 #include "AddLotsOfAuxVariablesAction.h"
 #include "Parser.h"
 #include "FEProblem.h"
@@ -19,9 +20,7 @@
 #include "MooseEnum.h"
 #include "AddVariableAction.h"
 #include "Conversion.h"
-
-#include <sstream>
-#include <stdexcept>
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/libmesh.h"
@@ -31,6 +30,10 @@
 #include "libmesh/explicit_system.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/fe.h"
+
+// System includes
+#include <sstream>
+#include <stdexcept>
 
 // class static initialization
 const Real AddLotsOfAuxVariablesAction::_abs_zero_tol = 1e-12;

--- a/test/src/auxkernels/MMSConstantAux.C
+++ b/test/src/auxkernels/MMSConstantAux.C
@@ -11,7 +11,9 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #include "MMSConstantAux.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MMSConstantAux>()

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -14,6 +14,8 @@
 #include "MooseTestApp.h"
 #include "Moose.h"
 #include "Factory.h"
+#include "MooseSyntax.h"
+
 #include "ActionFactory.h"
 #include "AppFactory.h"
 

--- a/test/src/bcs/MMSCoupledDirichletBC.C
+++ b/test/src/bcs/MMSCoupledDirichletBC.C
@@ -11,7 +11,9 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #include "MMSCoupledDirichletBC.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MMSCoupledDirichletBC>()

--- a/test/src/kernels/ExceptionKernel.C
+++ b/test/src/kernels/ExceptionKernel.C
@@ -11,8 +11,10 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #include "ExceptionKernel.h"
 #include "MooseException.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<ExceptionKernel>()

--- a/test/src/kernels/MMSDiffusion.C
+++ b/test/src/kernels/MMSDiffusion.C
@@ -11,7 +11,9 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #include "MMSDiffusion.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MMSDiffusion>()

--- a/test/src/kernels/MMSForcing.C
+++ b/test/src/kernels/MMSForcing.C
@@ -11,7 +11,9 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #include "MMSForcing.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MMSForcing>()

--- a/test/src/kernels/MMSReaction.C
+++ b/test/src/kernels/MMSReaction.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "MMSReaction.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MMSReaction>()

--- a/test/src/postprocessors/TestCopyInitialSolution.C
+++ b/test/src/postprocessors/TestCopyInitialSolution.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "TestCopyInitialSolution.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<TestCopyInitialSolution>()

--- a/test/src/userobjects/MaterialCopyUserObject.C
+++ b/test/src/userobjects/MaterialCopyUserObject.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "MaterialCopyUserObject.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MaterialCopyUserObject>()

--- a/test/src/userobjects/MaterialPropertyUserObject.C
+++ b/test/src/userobjects/MaterialPropertyUserObject.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "MaterialPropertyUserObject.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<MaterialPropertyUserObject>()

--- a/test/src/userobjects/RandomHitSolutionModifier.C
+++ b/test/src/userobjects/RandomHitSolutionModifier.C
@@ -13,8 +13,8 @@
 /****************************************************************/
 
 #include "RandomHitSolutionModifier.h"
-
 #include "RandomHitUserObject.h"
+#include "NonlinearSystem.h"
 
 template<>
 InputParameters validParams<RandomHitSolutionModifier>()

--- a/test/src/userobjects/TrackDiracFront.C
+++ b/test/src/userobjects/TrackDiracFront.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "TrackDiracFront.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<TrackDiracFront>()

--- a/tutorials/darcy_thermo_mech/step01_diffusion/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 template<>
@@ -50,11 +51,11 @@ DarcyThermoMechApp::registerApps()
 }
 
 void
-DarcyThermoMechApp::registerObjects(Factory & factory)
+DarcyThermoMechApp::registerObjects(Factory & /*factory*/)
 {
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step02_darcy_pressure/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step02_darcy_pressure/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -59,6 +60,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -63,6 +64,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -67,6 +68,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -71,6 +72,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -74,6 +75,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -74,6 +75,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -74,6 +75,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step09_mechanics/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -74,6 +75,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/tutorials/darcy_thermo_mech/step10_multiapps/src/auxkernels/RandomCorrosion.C
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/src/auxkernels/RandomCorrosion.C
@@ -14,6 +14,7 @@
 
 // MOOSE includes
 #include "RandomCorrosion.h"
+#include "MooseMesh.h"
 
 // libMesh includes
 #include "libmesh/mesh_tools.h"

--- a/tutorials/darcy_thermo_mech/step10_multiapps/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/src/base/DarcyThermoMechApp.C
@@ -14,6 +14,7 @@
 #include "DarcyThermoMechApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
+#include "MooseSyntax.h"
 #include "ModulesApp.h"
 
 // Kernels
@@ -76,6 +77,6 @@ DarcyThermoMechApp::registerObjects(Factory & factory)
 }
 
 void
-DarcyThermoMechApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
+DarcyThermoMechApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
 {
 }

--- a/unit/src/MooseEnumTest.C
+++ b/unit/src/MooseEnumTest.C
@@ -16,6 +16,8 @@
 #include "MooseEnum.h"
 #include "MultiMooseEnum.h"
 
+#include <algorithm> // std::set_symmetric_difference
+
 CPPUNIT_TEST_SUITE_REGISTRATION( MooseEnumTest );
 
 void

--- a/unit/src/MooseUnitApp.C
+++ b/unit/src/MooseUnitApp.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 #include "MooseUnitApp.h"
 #include "Moose.h"
+#include "MooseSyntax.h"
 
 template<>
 InputParameters validParams<MooseUnitApp>()


### PR DESCRIPTION
The main decoupling in this round is that including FEProblem.h no longer includes NonlinearSystem.h, and including UserObject.h no longer includes MooseMesh.h.  This required new #includes to be added to some source files in apps, but those should all be taken care of.

Refs #5917.
