### PR TITLE
Add --disable-maintainer-mode to update_and_rebuild_libmesh.sh

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -57,6 +57,7 @@ cd build
              --disable-cxx11 \
              --enable-unique-ptr \
              --enable-openmp \
+             --disable-maintainer-mode \
              $DISABLE_TIMESTAMPS $*
 
 # let LIBMESH_JOBS be either MOOSE_JOBS, or 1 if MOOSE_JOBS


### PR DESCRIPTION
As discussed in libMesh/libmesh#717, this might allow us to avoid
issues with upgrading the versions of autotools used by libmesh, and
shouldn't adversely affect developers who are just using libmesh as a
submodule in MOOSE.

If this PR passes the CI system, I'd like to re-run
libMesh/libmesh#717 and see if we can get that automake update merged.
