### PR TITLE
WIP: Need prepare for use

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -231,6 +231,13 @@ public:
   void prepared(bool state);
 
   /**
+   * If this method is called, we will call libMesh's prepare_for_use method when we
+   * call Moose's prepare method. This should only be set when the mesh structure is changed
+   * by MeshModifiers (i.e. Element deletion).
+   */
+  void needsPrepareForUse();
+
+  /**
    * Declares that the MooseMesh has changed, invalidates cached data
    * and rebuilds caches.  Sets a flag so that clients of the
    * MooseMesh also know when it has changed.
@@ -756,6 +763,9 @@ protected:
 
   /// True if prepare has been called on the mesh
   bool _is_prepared;
+
+  /// True if prepare_for_use should be called when Mesh is prepared
+  bool _needs_prepare_for_use;
 
   /// The elements that were just refined.
   ConstElemPointerRange * _refined_elements;

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -108,6 +108,7 @@ MooseMesh::MooseMesh(const InputParameters & parameters) :
     _is_changed(false),
     _is_nemesis(getParam<bool>("nemesis")),
     _is_prepared(false),
+    _needs_prepare_for_use(false),
     _refined_elements(NULL),
     _coarsened_elements(NULL),
     _active_local_elem_range(NULL),
@@ -176,6 +177,7 @@ MooseMesh::MooseMesh(const MooseMesh & other_mesh) :
     _is_changed(false),
     _is_nemesis(false),
     _is_prepared(false),
+    _needs_prepare_for_use(false),
     _refined_elements(NULL),
     _coarsened_elements(NULL),
     _active_local_elem_range(NULL),
@@ -270,14 +272,14 @@ MooseMesh::prepare(bool force)
   {
     // Call prepare_for_use() and allow renumbering
     getMesh().allow_renumbering(true);
-    if (force)
+    if (force || _needs_prepare_for_use)
       getMesh().prepare_for_use();
   }
   else
   {
     // Call prepare_for_use() and DO NOT allow renumbering
     getMesh().allow_renumbering(false);
-    if (force)
+    if (force || _needs_prepare_for_use)
       getMesh().prepare_for_use();
   }
 
@@ -323,6 +325,7 @@ MooseMesh::prepare(bool force)
 
   // Prepared has been called
   _is_prepared = true;
+  _needs_prepare_for_use = false;
 }
 
 void
@@ -1902,6 +1905,12 @@ void
 MooseMesh::prepared(bool state)
 {
   _is_prepared = state;
+}
+
+void
+MooseMesh::needsPrepareForUse()
+{
+  _needs_prepare_for_use = true;
 }
 
 const std::set<SubdomainID> &


### PR DESCRIPTION
refs #3080 

@jwpeterson - Take a look at this. If we set this flag then our existing `SetupMeshComplete` will re-prepare the underlying mesh. I'm not exactly sure if we'll need this or not, but it seems like a better solution then calling force.
