### PR TITLE
Remove old ID entirely when calling MooseMesh::changeBoundaryId()

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1715,6 +1715,12 @@ MooseMesh::changeBoundaryId(const boundary_id_type old_id, const boundary_id_typ
       }
     }
   }
+
+  // Remove any remaining references to the old ID from the
+  // BoundaryInfo object.  This prevents things like empty sidesets
+  // from showing up when printing information, etc.
+  if (delete_prev)
+    boundary_info.remove_id(old_id);
 }
 
 const RealVectorValue &


### PR DESCRIPTION
@YaqiWang doesn't want there to be empty sidesets hanging around after the MeshExtruder runs...

Refs #3554
