### PR TITLE
Adding option to TestHarness for depend files

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -56,6 +56,7 @@ class TestHarness:
     self.num_pending = 0
     self.host_name = gethostname()
     self.moose_dir = moose_dir
+    self.base_dir = os.getcwd()
     self.run_tests_dir = os.path.abspath('.')
     self.code = '2d2d6769726c2d6d6f6465'
     self.error_code = 0x0
@@ -133,10 +134,10 @@ class TestHarness:
         self.processPBSResults()
       else:
         self.options.processingPBS = False
-        base_dir = os.getcwd()
-        for dirpath, dirnames, filenames in os.walk(base_dir, followlinks=True):
+        self.base_dir = os.getcwd()
+        for dirpath, dirnames, filenames in os.walk(self.base_dir, followlinks=True):
           # Prune submdule paths when searching for tests
-          if base_dir != dirpath and os.path.exists(os.path.join(dirpath, '.git')):
+          if self.base_dir != dirpath and os.path.exists(os.path.join(dirpath, '.git')):
             dirnames[:] = []
 
           # walk into directories that aren't contrib directories
@@ -293,6 +294,7 @@ class TestHarness:
     params['executable'] = self.executable
     params['hostname'] = self.host_name
     params['moose_dir'] = self.moose_dir
+    params['base_dir'] = self.base_dir
 
     if params.isValid('prereq'):
       if type(params['prereq']) != list:

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -42,6 +42,8 @@ class Tester(MooseObject):
     params.addParam('curl',          ['ALL'], "A test that runs only if CURL is detected ('ALL', 'TRUE', 'FALSE')")
     params.addParam('tbb',           ['ALL'], "A test that runs only if TBB is available ('ALL', 'TRUE', 'FALSE')")
 
+    params.addParam('depend_files',  [], "A test that only runs if all depend files exist (files listed are expected to be relative to the base directory, not the test directory")
+
     return params
 
   def __init__(self, name, params):
@@ -181,6 +183,12 @@ class Tester(MooseObject):
     for x in self.specs['dof_id_bytes']:
       if x != 'ALL' and not x in checks['dof_id_bytes']:
         return (False, 'skipped (--with-dof-id-bytes!=' + x + ')')
+
+    # Check to make sure depend files exist
+    for file in self.specs['depend_files']:
+      if not os.path.isfile(os.path.join(self.specs['base_dir'], file)):
+        reason = 'skipped (DEPEND FILES)'
+        return (False, reason)
 
     # Check the return values of the derived classes
     return self.checkRunnable(options)


### PR DESCRIPTION
This should satisfy users that need to look for a library or
other file dependencies prior to running a test

closes #6073

For BISON, we'll be able to add a line like this to the relevant test files:

```
    # Depends on Thermochimica
    depend_files = '../thermochimica/src/Thermochimica.f90'
```
