### PR TITLE
Comment out unused parameter 

### DIFF
--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -364,7 +364,7 @@ MaterialPropertyInterface::hasMaterialPropertyByName(const std::string & name)
 
 template<typename T>
 const MaterialProperty<T> &
-MaterialPropertyInterface::getZeroMaterialProperty(const std::string & prop_name)
+MaterialPropertyInterface::getZeroMaterialProperty(const std::string & /*prop_name*/)
 {
   // static zero property storage
   static MaterialProperty<T> zero;


### PR DESCRIPTION
I added an unused parameter warning with #6067. This fixes it.

Refs #1777 
