### PR TITLE
Delete the threads_verification_uo test.

### DIFF
--- a/test/tests/utils/random/tests
+++ b/test/tests/utils/random/tests
@@ -60,6 +60,9 @@
     exodiff = 'random_uo_out.e'
     prereq = 'parallel_verification_uo'
     min_threads = 2
+    # This test fails, well, randomly, and needs to be fixed before it
+    # can be trusted as a reliable regression test.
+    deleted = '#2088'
   [../]
 
   # User Object Tests


### PR DESCRIPTION
This test needs to be fixed so that it runs reliably before we
re-enable it in the testing suite.  There's not much more annoying
than having your entire PR "fail" due to this one test failing...

Refs #2088.
