### PR TITLE
TestHarness fixes:

### DIFF
--- a/python/TestHarness/RunParallel.py
+++ b/python/TestHarness/RunParallel.py
@@ -115,8 +115,9 @@ class RunParallel:
     log( 'Command %d done:    %s' % (job_index, command) )
     did_pass = True
 
+    output = 'Working Directory: ' + tester.specs['test_dir'] + '\nRunning command: ' + command + '\n'
+    output += self.readOutput(f)
     if p.poll() == None: # process has not completed, it timed out
-      output = self.readOutput(f)
       output += '\n' + "#"*80 + '\nProcess terminated by test harness. Max time exceeded (' + str(tester.specs['max_time']) + ' seconds)\n' + "#"*80 + '\n'
       f.close()
       os.kill(p.pid, SIGTERM)        # Python 2.4 compatibility
@@ -125,8 +126,6 @@ class RunParallel:
       if not self.harness.testOutputAndFinish(tester, RunParallel.TIMEOUT, output, time, clock()):
         did_pass = False
     else:
-      output = 'Working Directory: ' + tester.specs['test_dir'] + '\nRunning command: ' + command + '\n'
-      output += self.readOutput(f)
       f.close()
 
       if tester in self.reported_jobs:

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -563,7 +563,7 @@ class TestHarness:
       else:
         color = 'GREEN'
       test_name = colorText(specs['test_name']  + ": ", color, colored=self.options.colored, code=self.options.code)
-      output = ("\n" + test_name).join(lines)
+      output = test_name + ("\n" + test_name).join(lines)
       print output
 
       # Print result line again at the bottom of the output for failed tests


### PR DESCRIPTION
- This patch fixes the case where the working directory and command
  are not printed out when the TestHarness is forced to terminate
  the process due to a timeout.
- Additionally, the working directory is now properly indented with
  the rest of the output text when printing the test's output stream.

closes #5875
