### PR TITLE
Add a scaling parameter for all element integral postprocessors

### DIFF
--- a/framework/include/postprocessors/ElementIntegralPostprocessor.h
+++ b/framework/include/postprocessors/ElementIntegralPostprocessor.h
@@ -43,6 +43,8 @@ protected:
   virtual Real computeQpIntegral() = 0;
   virtual Real computeIntegral();
 
+  Real _scaling;
+
   unsigned int _qp;
 
   Real _integral_value;

--- a/framework/src/postprocessors/ElementH1SemiError.C
+++ b/framework/src/postprocessors/ElementH1SemiError.C
@@ -32,7 +32,8 @@ ElementH1SemiError::ElementH1SemiError(const InputParameters & parameters) :
 Real
 ElementH1SemiError::getValue()
 {
-  return std::sqrt(ElementIntegralVariablePostprocessor::getValue());
+  gatherSum(_integral_value);
+  return _scaling * std::sqrt(_integral_value);
 }
 
 Real

--- a/framework/src/postprocessors/ElementIntegralPostprocessor.C
+++ b/framework/src/postprocessors/ElementIntegralPostprocessor.C
@@ -21,11 +21,13 @@ template<>
 InputParameters validParams<ElementIntegralPostprocessor>()
 {
   InputParameters params = validParams<ElementPostprocessor>();
+  params.addParam<Real>("scaling", 1.0, "A simple scaling factor applied to the postprocessor");
   return params;
 }
 
 ElementIntegralPostprocessor::ElementIntegralPostprocessor(const InputParameters & parameters) :
     ElementPostprocessor(parameters),
+    _scaling(getParam<Real>("scaling")),
     _qp(0),
     _integral_value(0)
 {}
@@ -46,7 +48,7 @@ Real
 ElementIntegralPostprocessor::getValue()
 {
   gatherSum(_integral_value);
-  return _integral_value;
+  return _scaling * _integral_value;
 }
 
 void

--- a/framework/src/postprocessors/ElementL2Difference.C
+++ b/framework/src/postprocessors/ElementL2Difference.C
@@ -32,7 +32,8 @@ ElementL2Difference::ElementL2Difference(const InputParameters & parameters) :
 Real
 ElementL2Difference::getValue()
 {
-  return std::sqrt(ElementIntegralPostprocessor::getValue());
+  gatherSum(_integral_value);
+  return _scaling * std::sqrt(_integral_value);
 }
 
 Real

--- a/framework/src/postprocessors/ElementL2Error.C
+++ b/framework/src/postprocessors/ElementL2Error.C
@@ -32,7 +32,8 @@ ElementL2Error::ElementL2Error(const InputParameters & parameters) :
 Real
 ElementL2Error::getValue()
 {
-  return std::sqrt(ElementIntegralPostprocessor::getValue());
+  gatherSum(_integral_value);
+  return _scaling * std::sqrt(_integral_value);
 }
 
 Real

--- a/framework/src/postprocessors/ElementL2Norm.C
+++ b/framework/src/postprocessors/ElementL2Norm.C
@@ -29,7 +29,8 @@ ElementL2Norm::ElementL2Norm(const InputParameters & parameters) :
 Real
 ElementL2Norm::getValue()
 {
-  return std::sqrt(ElementIntegralVariablePostprocessor::getValue());
+  gatherSum(_integral_value);
+  return _scaling * std::sqrt(_integral_value);
 }
 
 Real

--- a/framework/src/postprocessors/ElementVectorL2Error.C
+++ b/framework/src/postprocessors/ElementVectorL2Error.C
@@ -42,7 +42,8 @@ ElementVectorL2Error::ElementVectorL2Error(const InputParameters & parameters) :
 Real
 ElementVectorL2Error::getValue()
 {
-  return std::sqrt(ElementIntegralPostprocessor::getValue());
+  gatherSum(_integral_value);
+  return _scaling * std::sqrt(_integral_value);
 }
 
 Real

--- a/framework/src/postprocessors/ElementW1pError.C
+++ b/framework/src/postprocessors/ElementW1pError.C
@@ -34,7 +34,8 @@ ElementW1pError::ElementW1pError(const InputParameters & parameters) :
 Real
 ElementW1pError::getValue()
 {
-  return std::pow(ElementIntegralPostprocessor::getValue(), 1./_p);
+  gatherSum(_integral_value);
+  return _scaling * std::pow(_integral_value, 1./_p);
 }
 
 Real


### PR DESCRIPTION
I am sending this PR because I found it is quite complicated to add a scaling factor for a postprocessor, similar like the issue I reported in  #5954. This PR will be a quick solution for me although it can be solved by #5954. I still think this can be useful by itself. Merge it or not as your wish. Thanks.
