### PR TITLE
Remove old id entirely when calling changeBoundaryId().

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1718,6 +1718,12 @@ MooseMesh::changeBoundaryId(const boundary_id_type old_id, const boundary_id_typ
       }
     }
   }
+
+  // Remove any remaining references to the old ID from the
+  // BoundaryInfo object.  This prevents things like empty sidesets
+  // from showing up when printing information, etc.
+  if (delete_prev)
+    boundary_info.remove_id(old_id);
 }
 
 const RealVectorValue &


### PR DESCRIPTION
This fixes @YaqiWang's issue with MeshExtruder leaving behind empty
sidesets.

Refs #3554.
