### PR TITLE
Spherical or cylindrical gap geometry with higher dimensionality mode…

### DIFF
--- a/modules/heat_conduction/include/GapConductance.h
+++ b/modules/heat_conduction/include/GapConductance.h
@@ -16,18 +16,40 @@ class GapConductance :
   public Material
 {
 public:
+  enum GAP_GEOMETRY
+  {
+    PLATE,
+    CYLINDER,
+    SPHERE
+  };
 
   GapConductance(const InputParameters & parameters);
 
   virtual ~GapConductance(){}
 
-  static Real gapLength(const Moose::CoordinateSystemType & system, Real radius, Real r1, Real r2, Real min_gap, Real max_gap);
+  static Real gapLength(const GAP_GEOMETRY & gap_geom, Real radius, Real r1, Real r2, Real min_gap, Real max_gap);
 
   static Real gapRect(Real distance, Real min_gap, Real max_gap);
 
   static Real gapCyl( Real radius, Real r1, Real r2, Real min_denom, Real max_denom);
 
   static Real gapSphere( Real radius, Real r1, Real r2, Real min_denom, Real max_denom);
+
+  static void setGapGeometryParameters(const InputParameters & params,
+                                       const Moose::CoordinateSystemType coord_sys,
+                                       GAP_GEOMETRY & gap_geometry_type,
+                                       Point & p1,
+                                       Point & p2);
+
+  static void computeGapRadii(const GAP_GEOMETRY gap_geometry_type,
+                              const Point & current_point,
+                              const Point & p1,
+                              const Point & p2,
+                              const Real & gap_distance,
+                              const Point & current_normal,
+                              Real & r1,
+                              Real & r2,
+                              Real & radius);
 
 protected:
 
@@ -52,8 +74,8 @@ protected:
 
   const VariableValue & _temp;
 
-  bool _gap_type_set;
-  Moose::CoordinateSystemType _gap_type;
+  bool _gap_geometry_params_set;
+  GAP_GEOMETRY _gap_geometry_type;
 
   bool _quadrature;
 
@@ -85,6 +107,9 @@ protected:
   const NumericVector<Number> * * _serialized_solution;
   DofMap * _dof_map;
   const bool _warnings;
+
+  Point _p1;
+  Point _p2;
 };
 
 template<>

--- a/modules/heat_conduction/include/GapHeatTransfer.h
+++ b/modules/heat_conduction/include/GapHeatTransfer.h
@@ -8,6 +8,7 @@
 #define GAPHEATTRANSFER_H
 
 #include "IntegratedBC.h"
+#include "GapConductance.h"
 
 //Forward Declarations
 class GapHeatTransfer;
@@ -39,8 +40,8 @@ protected:
 
   virtual void computeGapValues();
 
-  bool _gap_type_set;
-  Moose::CoordinateSystemType _gap_type;
+  bool _gap_geometry_params_set;
+  GapConductance::GAP_GEOMETRY _gap_geometry_type;
 
   bool _quadrature;
 
@@ -77,6 +78,9 @@ protected:
 
   PenetrationLocator * _penetration_locator;
   const bool _warnings;
+
+  Point _p1;
+  Point _p2;
 };
 
 #endif //GAPHEATTRANSFER_H

--- a/modules/heat_conduction/src/GapConductance.C
+++ b/modules/heat_conduction/src/GapConductance.C
@@ -42,12 +42,21 @@ InputParameters validParams<GapConductance>()
   params.addRangeCheckedParam<Real>("min_gap", 1e-6, "min_gap>=0", "A minimum gap (denominator) size");
   params.addRangeCheckedParam<Real>("max_gap", 1e6, "max_gap>=0", "A maximum gap (denominator) size");
 
-  MooseEnum coord_types("default XYZ", "default");
-  params.addParam<MooseEnum>("coord_type", coord_types, "Gap calculation type (default or XYZ).");
+  //Deprecated parameter
+  MooseEnum coord_types("default XYZ");
+  params.addDeprecatedParam<MooseEnum>("coord_type", coord_types, "Gap calculation type (default or XYZ).","The functionality of this parameter is replaced by 'gap_geometry_type'.");
+
+  MooseEnum gap_geom_types("PLATE CYLINDER SPHERE");
+  params.addParam<MooseEnum>("gap_geometry_type", gap_geom_types, "Gap calculation type. Choices are: "+gap_geom_types.getRawNames());
+
+  params.addParam<RealVectorValue>("cylinder_axis_point_1", "Start point for line defining cylindrical axis");
+  params.addParam<RealVectorValue>("cylinder_axis_point_2", "End point for line defining cylindrical axis");
+  params.addParam<RealVectorValue>("sphere_origin", "Origin for sphere geometry");
 
   params.addParam<Real>("stefan_boltzmann", 5.669e-8, "The Stefan-Boltzmann constant");
   params.addRangeCheckedParam<Real>("emissivity_1", 0.0, "emissivity_1>=0 & emissivity_1<=1", "The emissivity of the fuel surface");
   params.addRangeCheckedParam<Real>("emissivity_2", 0.0, "emissivity_2>=0 & emissivity_2<=1", "The emissivity of the cladding surface");
+
 
   params.addParam<bool>("use_displaced_mesh", true, "Whether or not this object should use the displaced mesh for computation.  Note that in the case this is true but no displacements are provided in the Mesh block the undisplaced mesh will still be used.");
 
@@ -58,8 +67,8 @@ GapConductance::GapConductance(const InputParameters & parameters)
   :Material(parameters),
    _appended_property_name( getParam<std::string>("appended_property_name") ),
    _temp(coupledValue("variable")),
-   _gap_type_set(false),
-   _gap_type(Moose::COORD_XYZ),
+   _gap_geometry_params_set(false),
+   _gap_geometry_type(GapConductance::PLATE),
    _quadrature(getParam<bool>("quadrature")),
    _gap_temp(0),
    _gap_distance(88888),
@@ -109,22 +118,91 @@ GapConductance::GapConductance(const InputParameters & parameters)
 
 }
 
+void GapConductance::setGapGeometryParameters(const InputParameters & params,
+                                              const Moose::CoordinateSystemType coord_sys,
+                                              GAP_GEOMETRY & gap_geometry_type,
+                                              Point & p1,
+                                              Point & p2)
+{
+  if (params.isParamValid("gap_geometry_type"))
+  {
+    gap_geometry_type = GapConductance::GAP_GEOMETRY(int(params.get<MooseEnum>("gap_geometry_type")));
+    if (params.isParamValid("coord_type"))
+      mooseError("Deprecated parameter 'coord_type' cannot be used together with 'gap_geometry_type' in GapConductance");
+  }
+  else if (params.isParamValid("coord_type"))
+  {
+    mooseWarning("Parameter 'coord_type' in GapConductance is deprecated.  Use 'gap_geometry_type' instead.");
+    if (params.get<MooseEnum>("coord_type") == "XYZ")
+      gap_geometry_type = GapConductance::PLATE;
+    else
+    {
+      if (coord_sys == Moose::COORD_XYZ)
+        gap_geometry_type = GapConductance::PLATE;
+      else if (coord_sys == Moose::COORD_RZ)
+        gap_geometry_type = GapConductance::CYLINDER;
+      else if (coord_sys == Moose::COORD_RSPHERICAL)
+        gap_geometry_type = GapConductance::SPHERE;
+    }
+  }
+  else
+  {
+    if (coord_sys == Moose::COORD_XYZ)
+      gap_geometry_type = GapConductance::PLATE;
+    else if (coord_sys == Moose::COORD_RZ)
+      gap_geometry_type = GapConductance::CYLINDER;
+    else if (coord_sys == Moose::COORD_RSPHERICAL)
+      gap_geometry_type = GapConductance::SPHERE;
+  }
+
+  if (gap_geometry_type == GapConductance::PLATE)
+  {
+    if (coord_sys == Moose::COORD_RSPHERICAL)
+      mooseError("'gap_geometry_type = PLATE' cannot be used with models having a spherical coordinate system.");
+  }
+  else if (gap_geometry_type == GapConductance::CYLINDER)
+  {
+    if (coord_sys == Moose::COORD_XYZ)
+    {
+      if (!params.isParamValid("cylinder_axis_point_1") || !params.isParamValid("cylinder_axis_point_2"))
+        mooseError("For 'gap_geometry_type = CYLINDER' to be used with a Cartesian model, 'cylinder_axis_point_1' and 'cylinder_axis_point_2' must be specified.");
+      p1 = params.get<RealVectorValue>("cylinder_axis_point_1");
+      p2 = params.get<RealVectorValue>("cylinder_axis_point_2");
+    }
+    else if (coord_sys == Moose::COORD_RZ)
+    {
+      if (params.isParamValid("cylinder_axis_point_1") || params.isParamValid("cylinder_axis_point_2"))
+        mooseError("The 'cylinder_axis_point_1' and 'cylinder_axis_point_2' cannot be specified with axisymmetric models.  The y-axis is used as the cylindrical axis of symmetry.");
+      p1 = Point(0,0,0);
+      p2 = Point(0,1,0);
+    }
+    else if (coord_sys == Moose::COORD_RSPHERICAL)
+      mooseError("'gap_geometry_type = CYLINDER' cannot be used with models having a spherical coordinate system.");
+  }
+  else if (gap_geometry_type == GapConductance::SPHERE)
+  {
+    if (coord_sys == Moose::COORD_XYZ || coord_sys == Moose::COORD_RZ)
+    {
+      if (!params.isParamValid("sphere_origin"))
+        mooseError("For 'gap_geometry_type = SPHERE' to be used with a Cartesian or axisymmetric model, 'sphere_origin' must be specified.");
+      p1 = params.get<RealVectorValue>("sphere_origin");
+    }
+    else if (coord_sys == Moose::COORD_RSPHERICAL)
+    {
+      if (params.isParamValid("sphere_origin"))
+        mooseError("The 'sphere_origin' cannot be specified with spherical models.  x=0 is used as the spherical origin.");
+      p1 = Point(0,0,0);
+    }
+  }
+}
+
 void
 GapConductance::computeProperties()
 {
-  if (!_gap_type_set)
+  if (!_gap_geometry_params_set)
   {
-    _gap_type_set = true;
-    if (getParam<MooseEnum>("coord_type") == "XYZ")
-    {
-      _gap_type = Moose::COORD_XYZ;
-    }
-    else
-    {
-      _gap_type = _coord_sys;
-    }
-    if (_gap_type == Moose::COORD_XYZ && _coord_sys == Moose::COORD_RSPHERICAL)
-      mooseError("The 'XYZ' coord_type and a spherical coordinate system are not compatible.");
+    _gap_geometry_params_set = true;
+    setGapGeometryParameters(_pars, _coord_sys, _gap_geometry_type, _p1, _p2);
   }
 
   Material::computeProperties();
@@ -155,7 +233,7 @@ GapConductance::computeQpConductance()
 Real
 GapConductance::h_conduction()
 {
-  return gapK() / gapLength(_gap_type, _radius, _r1, _r2, _min_gap, _max_gap);
+  return gapK() / gapLength(_gap_geometry_type, _radius, _r1, _r2, _min_gap, _max_gap);
 }
 
 
@@ -208,12 +286,12 @@ GapConductance::dh_radiation()
 }
 
 Real
-GapConductance::gapLength(const Moose::CoordinateSystemType & system,
+GapConductance::gapLength(const GapConductance::GAP_GEOMETRY & gap_geom,
                           Real radius, Real r1, Real r2, Real min_gap, Real max_gap)
 {
-  if (system == Moose::COORD_RZ)
+  if (gap_geom == GapConductance::CYLINDER)
     return gapCyl(radius, r1, r2, min_gap, max_gap);
-  else if (system == Moose::COORD_RSPHERICAL)
+  else if (gap_geom == GapConductance::SPHERE)
     return gapSphere(radius, r1, r2, min_gap, max_gap);
   else
     return gapRect(r2-r1, min_gap, max_gap);
@@ -329,28 +407,75 @@ GapConductance::computeGapValues()
     }
   }
 
-  if (_gap_type == Moose::COORD_RZ || _gap_type == Moose::COORD_RSPHERICAL)
+  Point current_point(_q_point[_qp]);
+  computeGapRadii(_gap_geometry_type, current_point, _p1, _p2, _gap_distance, _normals[_qp], _r1, _r2, _radius);
+}
+
+void
+GapConductance::computeGapRadii(const GapConductance::GAP_GEOMETRY gap_geometry_type,
+                                const Point & current_point,
+                                const Point & p1,
+                                const Point & p2,
+                                const Real & gap_distance,
+                                const Point & current_normal,
+                                Real & r1,
+                                Real & r2,
+                                Real & radius)
+{
+  if (gap_geometry_type == GapConductance::CYLINDER)
   {
-    if (_normals[_qp](0) > 0)
+    // The vector _p1 + t*(_p2-_p1) defines the cylindrical axis.  The point along this
+    // axis closest to current_point is found by the following for t:
+    const Point p2p1( p2 - p1 );
+    const Point p1pc( p1 - current_point );
+    const Real t( -(p1pc*p2p1)/p2p1.size_sq() );
+    // The nearest point on the cylindrical axis to current_point is p.
+    const Point p( p1 + t * p2p1 );
+    Point rad_vec( current_point - p );
+    Real rad = rad_vec.size();
+    rad_vec /= rad;
+    Real rad_dot_norm = rad_vec * current_normal;
+
+    if (rad_dot_norm > 0)
     {
-      _r1 = _q_point[_qp](0);
-      _r2 = _q_point[_qp](0) - _gap_distance; // note, _gap_distance is negative
-      _radius = _r1;
+      r1 = rad;
+      r2 = rad - gap_distance; // note, gap_distance is negative
+      radius = r1;
     }
-    else if (_normals[_qp](0) < 0)
+    else if (rad_dot_norm < 0)
     {
-      _r1 = _q_point[_qp](0) + _gap_distance;
-      _r2 = _q_point[_qp](0);
-      _radius = _r2;
+      r1 = rad + gap_distance;
+      r2 = rad;
+      radius = r2;
     }
     else
-      mooseError( "Issue with cylindrical or spherical flux calc. normals. \n");
+      mooseError( "Issue with cylindrical flux calc. normals.\n");
+
+  }
+  else if (gap_geometry_type == GapConductance::SPHERE)
+  {
+    const Point origin_to_curr_point( current_point - p1 );
+    const Real normal_dot = origin_to_curr_point * current_normal;
+    const Real curr_point_radius = origin_to_curr_point.size();
+    if (normal_dot > 0) // on inside surface
+    {
+      r1 = curr_point_radius;
+      r2 = curr_point_radius - gap_distance; // gap_distance is negative
+      radius = r1;
+    }
+    else if (normal_dot < 0) // on outside surface
+    {
+      r1 = curr_point_radius + gap_distance; // gap_distance is negative
+      r2 = curr_point_radius;
+      radius = r2;
+    }
+    else
+      mooseError( "Issue with spherical flux calc. normals. \n");
   }
   else
   {
-    _r2 = -_gap_distance;
-    _r1 = 0;
-    _radius = 0;
+    r2 = -gap_distance;
+    r1 = 0;
+    radius = 0;
   }
 }
-


### PR DESCRIPTION
…ls ref #6161

Before this commit, the default behavior in MOOSE was to use the spherical
equations for 1d spherical models and cylindrical equations for 2d cylindrical
models. A higher-dimensionality model of a cylinder or sphere could only
use the flat plate equations for conductance.

This commit deprecates the 'coord_type' option that was previously used only
to override the default behavior on axisymmetric models.  It adds the following
new parameters:

gap_geometry_type = PLATE | CYLINDER | SPHERE
cylinder_axis_point_1
cylinder_axis_point_2
sphere_origin

With these options, the gap conductance model can now be specified independently
of the underlying coordinate system of the model, so these models can be used
for cylinders or spheres meshed in 2D (planar or axisymmetric) or 3D coordinate
systems. For those cases, the user must specify the points to define the geometry
of the cylinder or sphere.

This does not change any default behavior. It also consolidates previously
duplicated code.

Steve is working on an expanded set of tests for the new options enabled by this,
and will submit a pull request for that shortly after this is merged.
