### PR TITLE
Fixing the list of involved variables in off-diagonal Jacobians for N…

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1983,10 +1983,13 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
 
           const std::vector<MooseVariable *> & coupled_moose_vars = bc->getCoupledMooseVars();
 
-          // Create the set of "involved" MOOSE vars, which includes all coupled vars and the BC's own variable
+          // Create the set of "involved" MOOSE nonlinear vars, which includes all coupled vars and the BC's own variable
           std::set<unsigned int> & var_set = bc_involved_vars[bc->name()];
           for (unsigned int var = 0; var < coupled_moose_vars.size(); ++var)
-            var_set.insert(coupled_moose_vars[var]->number());
+          {
+            if (coupled_moose_vars[var]->kind() == Moose::VAR_NONLINEAR)
+              var_set.insert(coupled_moose_vars[var]->number());
+          }
 
           var_set.insert(bc->variable().number());
         }


### PR DESCRIPTION
…odalBC.

We only need to add the non-linear variables and ignore the aux ones. Otherwise
we would be taking the derivative wrt an incorrect variable whose index belongs
to the aux variable, but is interpreted as an index of a non-linear variable.

Refs #656
