### PR TITLE
libMesh update

### DIFF
--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -150,7 +150,33 @@ Exodus::outputSetup()
     _exodus_io_ptr->use_mesh_dimension_instead_of_spatial_dimension(getParam<bool>("use_problem_dimension"));
   else
   {
-    // Utilize the spatial dimensions
+    // If the spatial_dimension is 1 (this can only happen in recent
+    // versions of libmesh where the meaning of spatial_dimension has
+    // changed), then force the Exodus file to be written with
+    // num_dim==3.
+    //
+    // This works around an issue in Paraview where 1D meshes cannot
+    // not be visualized correctly.  Note: the mesh_dimension() should
+    // get changed back to 1 the next time MeshBase::prepare_for_use()
+    // is called.
+    if (_es_ptr->get_mesh().spatial_dimension() == 1)
+      _exodus_io_ptr->write_as_dimension(3);
+
+    // If the spatial_dimension is 2 (again, only possible in recent
+    // versions of libmesh), then we need to be careful as this mesh
+    // would not have been written with num_dim==2 in the past.
+    //
+    // We *can't* simply write it with num_dim==mesh_dimension,
+    // because mesh_dimension might be 1, and as discussed above, we
+    // don't allow num_dim==1 Exodus files.  Therefore, in this
+    // particular case, we force writing with num_dim==3.  Note: the
+    // humor of writing a mesh of 1D elements which lives in 2D space
+    // as num_dim==3 is not lost on me.
+    if (_es_ptr->get_mesh().spatial_dimension() == 2 && _es_ptr->get_mesh().mesh_dimension() == 1)
+      _exodus_io_ptr->write_as_dimension(3);
+
+    // Utilize the spatial dimension.  This value of this flag is
+    // superseded by the value passed to write_as_dimension(), if any.
     if (_es_ptr->get_mesh().mesh_dimension() != 1)
       _exodus_io_ptr->use_mesh_dimension_instead_of_spatial_dimension(true);
   }

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/tests
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/tests
@@ -10,6 +10,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -22,6 +23,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -38,6 +40,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -54,6 +57,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -70,6 +74,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_0_kin]
     type = 'CSVDiff'
@@ -84,6 +89,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -98,6 +104,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_1_0_kin]
     type = 'CSVDiff'
@@ -111,6 +118,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_0_pen]
     type = 'CSVDiff'
@@ -124,6 +132,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -138,6 +147,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_1_0_pen]
     type = 'CSVDiff'
@@ -151,5 +161,6 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/tests
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/tests
@@ -10,6 +10,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -22,6 +23,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -38,6 +40,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -54,6 +57,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -70,6 +74,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_0_kin]
     type = 'CSVDiff'
@@ -83,6 +88,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -98,6 +104,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_1_0_kin]
     type = 'CSVDiff'
@@ -113,6 +120,7 @@
     max_parallel = 1
     heavy = true
     deleted = '#6139'
+    superlu = true
   [../]
   [./mu_0_pen]
     type = 'CSVDiff'
@@ -126,6 +134,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -140,6 +149,7 @@
     abs_zero = 1e-5
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_1_0_pen]
     type = 'CSVDiff'
@@ -153,5 +163,6 @@
     abs_zero = 1e-6
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q4/tests
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q4/tests
@@ -8,6 +8,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -18,6 +19,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -28,6 +30,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -38,6 +41,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -48,6 +52,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_1_0_kin]
     type = 'CSVDiff'
@@ -57,5 +62,6 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/tests
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/tests
@@ -8,6 +8,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -18,6 +19,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -28,6 +30,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -38,6 +41,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -48,6 +52,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
   [./mu_1_0_kin]
     type = 'CSVDiff'
@@ -57,5 +62,6 @@
     abs_zero = 1e-8
     max_parallel = 1
     heavy = true
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_1/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_1/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_2/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_2/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_4/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_4/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_1/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_1/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -50,6 +55,7 @@
     csvdiff = 'cyl1_mu_0_2_kin_check.csv cyl1_mu_0_2_kin_check_cont_press_0001.csv cyl1_mu_0_2_kin_check_x_disp_0001.csv'
     rel_err = 1e-5
     abs_zero = 1e-6
+    superlu = true
     max_parallel = 1
   [../]
   [./mu_0_2_pen]
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_2/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_2/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_4/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_4/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_1/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_1/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_2/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_2/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_4/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_4/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_1/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_1/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_2/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_2/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_4/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_4/tests
@@ -7,6 +7,7 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'
@@ -25,6 +27,7 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -34,6 +37,7 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./frictionless_aug]
     type = 'CSVDiff'
@@ -43,6 +47,7 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_kin]
     type = 'CSVDiff'
@@ -51,6 +56,7 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -59,5 +65,6 @@
     rel_err = 1e-5
     abs_zero = 1e-6
     max_parallel = 1
+    superlu = true
   [../]
 []

--- a/modules/combined/tests/generalized_plane_strain_tm_contact/generalized_plane_strain_tm_contact_field.i
+++ b/modules/combined/tests/generalized_plane_strain_tm_contact/generalized_plane_strain_tm_contact_field.i
@@ -260,9 +260,6 @@
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu       superlu_dist'
-#  petsc_options_iname = '-pc_type'
-#  petsc_options_value = 'lu'
-
 
 # controls for linear iterations
   l_max_its = 100

--- a/modules/combined/tests/generalized_plane_strain_tm_contact/tests
+++ b/modules/combined/tests/generalized_plane_strain_tm_contact/tests
@@ -5,5 +5,6 @@
    exodiff = 'generalized_plane_strain_tm_contact_field_out.e'
    min_parallel = 2
    custom_cmp = 'generalized.exodiff'
+   superlu = true
  [../]
 []

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -301,7 +301,7 @@ GrainTracker::buildBoundingSpheres()
         else
           p_ptr = mesh.query_node_ptr(*it2);
         if (p_ptr)
-          for (unsigned int i = 0; i < mesh.spatial_dimension(); ++i)
+          for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
           {
             min_points[set_counter*3+i] = std::min(min_points[set_counter*3+i], (*p_ptr)(i));
             max_points[set_counter*3+i] = std::max(max_points[set_counter*3+i], (*p_ptr)(i));

--- a/modules/phase_field/tests/phase_field_crystal/PFCRFF_split/PFCRFF_split_test_sub.i
+++ b/modules/phase_field/tests/phase_field_crystal/PFCRFF_split/PFCRFF_split_test_sub.i
@@ -64,13 +64,6 @@
 []
 
 [Executioner]
-  # petsc_options = '-snes_mf_operator -ksp_monitor'
-  # petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
-  # petsc_options_value = 'hypre boomeramg 31'
-  # petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
-  # petsc_options_value = 'asm         101   preonly   lu      1'
-  # petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  # petsc_options_value = 'lu superlu_dist'
   type = Transient
   num_steps = 1
   dt = 0.1

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -88,6 +88,7 @@ class TestHarness:
       self.checks['petsc_debug'] = set(['ALL'])
       self.checks['curl'] = set(['ALL'])
       self.checks['tbb'] = set(['ALL'])
+      self.checks['superlu'] = set(['ALL'])
     else:
       self.checks['compiler'] = getCompilers(self.libmesh_dir)
       self.checks['petsc_version'] = getPetscVersion(self.libmesh_dir)
@@ -101,6 +102,7 @@ class TestHarness:
       self.checks['petsc_debug'] = getLibMeshConfigOption(self.libmesh_dir, 'petsc_debug')
       self.checks['curl'] =  getLibMeshConfigOption(self.libmesh_dir, 'curl')
       self.checks['tbb'] =  getLibMeshConfigOption(self.libmesh_dir, 'tbb')
+      self.checks['superlu'] =  getLibMeshConfigOption(self.libmesh_dir, 'superlu')
 
     # Override the MESH_MODE option if using '--parallel-mesh' option
     if self.options.parallel_mesh == True or \

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -41,6 +41,7 @@ class Tester(MooseObject):
     params.addParam('petsc_debug',   ['ALL'], "{False,True} -> test only runs when PETSc is configured with --with-debugging={0,1}, otherwise test always runs.")
     params.addParam('curl',          ['ALL'], "A test that runs only if CURL is detected ('ALL', 'TRUE', 'FALSE')")
     params.addParam('tbb',           ['ALL'], "A test that runs only if TBB is available ('ALL', 'TRUE', 'FALSE')")
+    params.addParam('superlu',       ['ALL'], "A test that runs only if SuperLU is available via PETSc ('ALL', 'TRUE', 'FALSE')")
 
     params.addParam('depend_files',  [], "A test that only runs if all depend files exist (files listed are expected to be relative to the base directory, not the test directory")
 
@@ -157,7 +158,7 @@ class Tester(MooseObject):
       return (False, reason)
 
     # PETSc is being explicitly checked above
-    local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot', 'petsc_debug', 'curl', 'tbb']
+    local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot', 'petsc_debug', 'curl', 'tbb', 'superlu']
     for check in local_checks:
       test_platforms = set()
       for x in self.specs[check]:

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -67,6 +67,10 @@ LIBMESH_OPTIONS = {
                      'default'   : 'FALSE',
                      'options'   : {'TRUE' : '1', 'FALSE' : '0'}
                    },
+  'superlu' :      { 're_option' : r'#define\s+LIBMESH_PETSC_HAVE_SUPERLU_DIST\s+(\d+)',
+                     'default'   : 'FALSE',
+                     'options'   : {'TRUE' : '1', 'FALSE' : '0'}
+                   },
 }
 
 

--- a/test/tests/multiapps/sub_cycling_failure/tests
+++ b/test/tests/multiapps/sub_cycling_failure/tests
@@ -14,5 +14,6 @@
     max_time = 60
     min_parallel = 2
     prereq = test_failure
+    superlu = true
   [../]
 []


### PR DESCRIPTION
Summary of changes with this libmesh update
- The meaning of MeshBase::spatial_dimension() has changed.
- Fix an issue building with GCC 5.2.0 on OSX with C++11 disabled.
- Revert system_projection changes from master which cause performance (and worse) regressions.
- Detect when PETSc has been built with SuperLU and/or MUMPS.
- Previously deprecated quadrature_rules.h and elem_type.h removed.
- Fix operator<< compilation issue with std::pair<Hilbert,unique_id>.

Refs libMesh/libmesh#761, Refs #6172.
