### PR TITLE
Also take and sum derivatives w.r.t. AuxVariables

### DIFF
--- a/modules/phase_field/include/materials/FunctionMaterialBase.h
+++ b/modules/phase_field/include/materials/FunctionMaterialBase.h
@@ -39,9 +39,9 @@ protected:
    */
   unsigned int argIndex(unsigned int i_var) const
   {
-    mooseAssert(i_var < _number_of_nl_variables, "Requesting argIndex() for an invalid Moose variable number. Maybe an AuxVariable?");
-    mooseAssert(_arg_numbers[_arg_index[i_var]] == i_var, "Requesting argIndex() for a derivative w.r.t. a variable not coupled to.");
-    return _arg_index[i_var];
+    const unsigned int idx = libMeshVarNumberRemap(i_var);
+    mooseAssert(idx < _arg_index.size() && _arg_numbers[_arg_index[idx]] == i_var, "Requesting argIndex() for a derivative w.r.t. a variable not coupled to.");
+    return _arg_index[idx];
   }
 
   /// Coupled variables for function arguments
@@ -74,10 +74,14 @@ protected:
   /// Material property to store the function value.
   MaterialProperty<Real> * _prop_F;
 
-  /// number of non-linear variables in the problem
-  const unsigned int _number_of_nl_variables;
-
 private:
+  /// map the variable numbers to an even/odd interspersed pattern
+  unsigned int libMeshVarNumberRemap(unsigned int var) const
+  {
+    const int b = static_cast<int>(var);
+    return b >= 0 ? b<<1 : (-b<<1)-1;
+  }
+
   /// Vector to look up the internal coupled variable index into _arg_*  through the libMesh variable number
   std::vector<unsigned int> _arg_index;
 };

--- a/modules/phase_field/src/materials/DerivativeFunctionMaterialBase.C
+++ b/modules/phase_field/src/materials/DerivativeFunctionMaterialBase.C
@@ -43,18 +43,12 @@ DerivativeFunctionMaterialBase::DerivativeFunctionMaterialBase(const InputParame
   // initialize derivatives
   for (unsigned int i = 0; i < _nargs; ++i)
   {
-    // skip all derivatives w.r.t. auxiliary variables
-    if (_arg_numbers[i] >= _number_of_nl_variables) continue;
-
     // first derivatives
     _prop_dF[i] = &declarePropertyDerivative<Real>(_F_name, _arg_names[i]);
 
     // second derivatives
     for (unsigned int j = i; j < _nargs; ++j)
     {
-      // skip all derivatives w.r.t. auxiliary variables
-      if (_arg_numbers[j] >= _number_of_nl_variables) continue;
-
       _prop_d2F[i][j] =
       _prop_d2F[j][i] = &declarePropertyDerivative<Real>(_F_name, _arg_names[i], _arg_names[j]);
 
@@ -63,9 +57,6 @@ DerivativeFunctionMaterialBase::DerivativeFunctionMaterialBase(const InputParame
       {
         for (unsigned int k = j; k < _nargs; ++k)
         {
-          // skip all derivatives w.r.t. auxiliary variables
-          if (_arg_numbers[k] >= _number_of_nl_variables) continue;
-
           // filling all permutations does not cost us much and simplifies access
           // (no need to check i<=j<=k)
           _prop_d3F[i][j][k] =
@@ -156,4 +147,3 @@ DerivativeFunctionMaterialBase::computeProperties()
     }
   }
 }
-

--- a/modules/phase_field/src/materials/DerivativeMultiPhaseBase.C
+++ b/modules/phase_field/src/materials/DerivativeMultiPhaseBase.C
@@ -59,8 +59,7 @@ DerivativeMultiPhaseBase::DerivativeMultiPhaseBase(const InputParameters & param
 
     // for each coupled variable we need to know if it was coupled through "etas"
     // and - if so - which coupled component of "etas" it comes from
-    if (_eta_vars[i] < _number_of_nl_variables)
-      _eta_index[argIndex(_eta_vars[i])] = i;
+    _eta_index[argIndex(_eta_vars[i])] = i;
 
     // barrier function derivatives
     _dg[i] = &getMaterialPropertyDerivative<Real>("g", _eta_names[i]);

--- a/modules/phase_field/src/materials/FunctionMaterialBase.C
+++ b/modules/phase_field/src/materials/FunctionMaterialBase.C
@@ -18,9 +18,7 @@ InputParameters validParams<FunctionMaterialBase>()
 FunctionMaterialBase::FunctionMaterialBase(const InputParameters & parameters) :
     DerivativeMaterialInterface<Material>(parameters),
     _F_name(getParam<std::string>("f_name")),
-    _prop_F(&declareProperty<Real>(_F_name)),
-    _number_of_nl_variables(_fe_problem.getNonlinearSystem().nVariables()),
-    _arg_index(_number_of_nl_variables)
+    _prop_F(&declareProperty<Real>(_F_name))
 {
   // fetch names and numbers of all coupled variables
   _mapping_is_unique = true;
@@ -50,9 +48,12 @@ FunctionMaterialBase::FunctionMaterialBase(const InputParameters & parameters) :
       _arg_numbers.push_back(number);
       _arg_param_names.push_back(*it);
 
-      // populate number -> arg index lookup table skipping aux variables
-      if (number < _number_of_nl_variables)
-        _arg_index[number] = _args.size();
+      // populate number -> arg index lookup table
+      unsigned int idx = libMeshVarNumberRemap(number);
+      if (idx >= _arg_index.size())
+        _arg_index.resize(idx + 1, -1);
+
+      _arg_index[idx] = _args.size();
 
       // get variable value
       _args.push_back(&coupledValue(*it, j));
@@ -61,4 +62,3 @@ FunctionMaterialBase::FunctionMaterialBase(const InputParameters & parameters) :
 
   _nargs = _arg_names.size();
 }
-


### PR DESCRIPTION
It turned out there are legitimate uses for derivatives taken w.r.t. Auxiliary Variables. Some parts of the AD system already did that, this PR makes it more consistent and adds Aux derivatives to the classes that were skipping them.

This breaks one test in MARMOT, I'll modify the test to suppress output of the new derivatives.

Closes #6124
