### PR TITLE
Fix possible multiple throw condition in ExceptionKernel

### DIFF
--- a/test/include/kernels/ExceptionKernel.h
+++ b/test/include/kernels/ExceptionKernel.h
@@ -40,11 +40,11 @@ protected:
     INITIAL_CONDITION
   } _when;
 
-  /// True once the residual has thrown
-  bool _res_has_thrown;
+  /// True once the residual has thrown on any thread
+  static bool _res_has_thrown;
 
-  /// True once the Jacobian has thrown
-  bool _jac_has_thrown;
+  /// True once the Jacobian has thrown on any thread
+  static bool _jac_has_thrown;
 
   /// Function which returns true if it's time to throw
   bool time_to_throw();


### PR DESCRIPTION
closes #6167 

I know @friedmud hates statics, but this use is documented, it is only in a test class, and the behavior is well understood. I like this test kernel version better than only throwing on one thread. Comments welcome.
