### PR TITLE
Allow for default arguments in certain parsed materials 

### DIFF
--- a/modules/phase_field/include/materials/FunctionMaterialBase.h
+++ b/modules/phase_field/include/materials/FunctionMaterialBase.h
@@ -68,6 +68,9 @@ protected:
   /// String vector of the input file coupling parameter name for each argument.
   std::vector<std::string> _arg_param_names;
 
+  /// coupled variables with default values
+  std::vector<std::string> _arg_constant_defaults;
+
   /// Calculate (and allocate memory for) the third derivatives of the free energy.
   bool _third_derivatives;
 

--- a/modules/phase_field/src/materials/FunctionMaterialBase.C
+++ b/modules/phase_field/src/materials/FunctionMaterialBase.C
@@ -26,11 +26,18 @@ FunctionMaterialBase::FunctionMaterialBase(const InputParameters & parameters) :
   _mapping_is_unique = true;
   for (std::set<std::string>::const_iterator it = _pars.coupledVarsBegin(); it != _pars.coupledVarsEnd(); ++it)
   {
+    // find the variable in the list of coupled variables
     std::map<std::string, std::vector<MooseVariable *> >::iterator vars = _coupled_vars.find(*it);
 
-    // no MOOSE variable was provided for this coupling, skip derivatives w.r.t. this variable
+    // no MOOSE variable was provided for this coupling, add to a list of variables set to constant default values
     if (vars == _coupled_vars.end())
+    {
+      // check if a default value was provided
+      std::map<std::string, VariableValue *>::iterator default_value_it = Coupleable::_default_value.find(*it);
+      if (default_value_it != Coupleable::_default_value.end())
+        _arg_constant_defaults.push_back(*it);
       continue;
+    }
 
     // check if we have a 1:1 mapping between parameters and variables
     if (vars->second.size() != 1)
@@ -61,4 +68,3 @@ FunctionMaterialBase::FunctionMaterialBase(const InputParameters & parameters) :
 
   _nargs = _arg_names.size();
 }
-

--- a/modules/phase_field/src/materials/ParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/ParsedMaterialHelper.C
@@ -63,6 +63,11 @@ ParsedMaterialHelper::functionParse(const std::string & function_expression,
   // initialize constants
   addFParserConstants(_func_F, constant_names, constant_expressions);
 
+  // add further constants coming from default value coupling
+  for (std::vector<std::string>::iterator it = _arg_constant_defaults.begin(); it != _arg_constant_defaults.end(); ++it)
+    if (!_func_F->AddConstant(*it, _pars.defaultCoupledValue(*it)))
+      mooseError("Invalid constant name in parsed function object");
+
   // set variable names based on map_mode
   switch (_map_mode)
   {


### PR DESCRIPTION
Fixes passing in _numbers_ (default values) for coupled variables for ExpressionBuilder based material classes.

Closes #6170
