### PR TITLE
Temporarily disable parallel runs of the DTK tests due to identified issues

### DIFF
--- a/test/tests/transfers/multiapp_dtk_interpolation_transfer/tests
+++ b/test/tests/transfers/multiapp_dtk_interpolation_transfer/tests
@@ -6,6 +6,9 @@
     dtk = True
     method = 'OPT OPROF'
     recover = false
+
+    # Currently fails in parallel #5995
+    max_parallel = 1
   [../]
 
   [./tosub]
@@ -24,5 +27,8 @@
     dtk = True
     method = 'OPT OPROF'
     recover = false
+
+    # Currently fails in parallel #5995
+    max_parallel = 1
   [../]
 []


### PR DESCRIPTION
refs #5995 

Roger has identified the problem with these, but we are still waiting on a fix. For now, I'm going to disable them so we don't see these failures with each merge into master.
