### PR TITLE
Do not divide by zero

### DIFF
--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -222,7 +222,8 @@ findContactPoint(PenetrationInfo & p_info,
   else
   {
     p_info._normal = RealGradient(dxyz_dxi[0](1),-dxyz_dxi[0](0));
-    p_info._normal /= p_info._normal.size();
+    if (std::fabs(p_info._normal.size()) > 1e-15)
+      p_info._normal /= p_info._normal.size();
   }
 
   // If the point has not penetrated the face, make the distance negative


### PR DESCRIPTION
When having both 1D mesh and 2D mesh in 3D space and when we use the
"projection" from the 2D side onto 1D mesh and the meshes are
aligned in z-direction, then the normal in PenetrationInfo will end
by with zero size. So when the normal is normalized, there is a
division by zero (caught by an assert statement in libMesh).

Closes #6179
