### PR TITLE
Bringing back requiredness of "variable" parameter

### DIFF
--- a/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
@@ -18,7 +18,7 @@ template<>
 InputParameters validParams<ElementIntegralVariablePostprocessor>()
 {
   InputParameters params = validParams<ElementIntegralPostprocessor>();
-  params.addCoupledVar("variable", "The name of the variable that this object operates on");
+  params.addRequiredCoupledVar("variable", "The name of the variable that this object operates on");
   return params;
 }
 
@@ -37,4 +37,3 @@ ElementIntegralVariablePostprocessor::computeQpIntegral()
 {
   return _u[_qp];
 }
-

--- a/framework/src/postprocessors/ElementVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementVariablePostprocessor.C
@@ -24,7 +24,7 @@ template<>
 InputParameters validParams<ElementVariablePostprocessor>()
 {
   InputParameters params = validParams<ElementPostprocessor>();
-  params.addCoupledVar("variable", "The name of the variable that this postprocessor operates on");
+  params.addRequiredCoupledVar("variable", "The name of the variable that this postprocessor operates on");
   return params;
 }
 
@@ -45,4 +45,3 @@ ElementVariablePostprocessor::execute()
   for (_qp=0; _qp<_qrule->n_points(); _qp++)
     computeQpValue();
 }
-

--- a/framework/src/postprocessors/NodalVariablePostprocessor.C
+++ b/framework/src/postprocessors/NodalVariablePostprocessor.C
@@ -21,7 +21,7 @@ template<>
 InputParameters validParams<NodalVariablePostprocessor>()
 {
   InputParameters params = validParams<NodalPostprocessor>();
-  params.addCoupledVar("variable", "The name of the variable that this postprocessor operates on");
+  params.addRequiredCoupledVar("variable", "The name of the variable that this postprocessor operates on");
   return params;
 }
 
@@ -31,4 +31,3 @@ NodalVariablePostprocessor::NodalVariablePostprocessor(const InputParameters & p
     _u(coupledValue("variable"))
 {
 }
-

--- a/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
@@ -18,7 +18,7 @@ template<>
 InputParameters validParams<SideIntegralVariablePostprocessor>()
 {
   InputParameters params = validParams<SideIntegralPostprocessor>();
-  params.addCoupledVar("variable", "The name of the variable that this boundary condition applies to");
+  params.addRequiredCoupledVar("variable", "The name of the variable that this boundary condition applies to");
   return params;
 }
 
@@ -36,4 +36,3 @@ SideIntegralVariablePostprocessor::computeQpIntegral()
 {
   return _u[_qp];
 }
-

--- a/framework/src/userobject/ElementIntegralVariableUserObject.C
+++ b/framework/src/userobject/ElementIntegralVariableUserObject.C
@@ -18,7 +18,7 @@ template<>
 InputParameters validParams<ElementIntegralVariableUserObject>()
 {
   InputParameters params = validParams<ElementIntegralUserObject>();
-  params.addCoupledVar("variable", "The name of the variable that this object operates on");
+  params.addRequiredCoupledVar("variable", "The name of the variable that this object operates on");
   return params;
 }
 
@@ -36,4 +36,3 @@ ElementIntegralVariableUserObject::computeQpIntegral()
 {
   return _u[_qp];
 }
-

--- a/framework/src/userobject/SideIntegralVariableUserObject.C
+++ b/framework/src/userobject/SideIntegralVariableUserObject.C
@@ -18,7 +18,7 @@ template<>
 InputParameters validParams<SideIntegralVariableUserObject>()
 {
   InputParameters params = validParams<SideIntegralUserObject>();
-  params.addCoupledVar("variable", "The name of the variable that this boundary condition applies to");
+  params.addRequiredCoupledVar("variable", "The name of the variable that this boundary condition applies to");
   return params;
 }
 
@@ -36,4 +36,3 @@ SideIntegralVariableUserObject::computeQpIntegral()
 {
   return _u[_qp];
 }
-


### PR DESCRIPTION
The parameter was required, so it should stay required.

Refs #5273
