### PR TITLE
Better error messages for MooseEnum types

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1001,6 +1001,17 @@ template <>
 void
 InputParameters::addParam<std::vector<MooseEnum> >(const std::string & /*name*/, const std::string & /*doc_string*/);
 
+template <>
+void
+InputParameters::addDeprecatedParam<MooseEnum>(const std::string &name, const std::string &doc_string, const std::string &deprecation_message);
+
+template <>
+void
+InputParameters::addDeprecatedParam<MultiMooseEnum>(const std::string &name, const std::string &doc_string, const std::string &deprecation_message);
+
+template <>
+void
+InputParameters::addDeprecatedParam<std::vector<MooseEnum> >(const std::string &name, const std::string &doc_string, const std::string &deprecation_message);
 
 // Forward declare specializations for setParamHelper
 template<>

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -704,6 +704,26 @@ InputParameters::addParam<std::vector<MooseEnum> >(const std::string & /*name*/,
   mooseError("You must supply a vector of MooseEnum object(s) when using addParam, even if the parameter is not required!");
 }
 
+template <>
+void
+InputParameters::addDeprecatedParam<MooseEnum>(const std::string &name, const std::string &doc_string, const std::string &deprecation_message)
+{
+  mooseError("You must supply a MooseEnum object and the deprecation string when using addDeprecatedParam, even if the parameter is not required!");
+}
+
+template <>
+void
+InputParameters::addDeprecatedParam<MultiMooseEnum>(const std::string &name, const std::string &doc_string, const std::string &deprecation_message)
+{
+  mooseError("You must supply a MultiMooseEnum object and the deprecation string when using addDeprecatedParam, even if the parameter is not required!");
+}
+
+template <>
+void
+InputParameters::addDeprecatedParam<std::vector<MooseEnum> >(const std::string &name, const std::string &doc_string, const std::string &deprecation_message)
+{
+  mooseError("You must supply a vector of MooseEnum object(s) and the deprecation string when using addDeprecatedParam, even if the parameter is not required!");
+}
 
 template<>
 void


### PR DESCRIPTION
I'm adding several template specializations to provide better error messages to
users who fail to pass the correct set of parameters when using
addDeprecatedParam() methods with Moose*Enum types.

closes #6163
