### PR TITLE
Update Functions to use new warehouse

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -1004,7 +1004,7 @@ protected:
   std::vector<Assembly *> _assembly;
 
   /// functions
-  std::vector<std::map<std::string, MooseSharedPointer<Function> > > _functions;
+  MooseObjectWarehouse<Function>_functions;
 
   ///@{
   /// Initial condition storage


### PR DESCRIPTION
This has one drawback, the search goes from a std::map lookup to a linear search through a vector. Considering the `getFunction` method should only be called when objects are constructed, this is probably not a problem.

However, it would be simple to add the map lookup in the MooseObjectWarehouse if others think this will be a problem.

(refs #5680)
