### PR TITLE
Cluster Launcher no-file-copy pattern filter

### DIFF
--- a/python/ClusterLauncher/PBSJob.py
+++ b/python/ClusterLauncher/PBSJob.py
@@ -1,7 +1,7 @@
 from FactorySystem import InputParameters
 from Job import Job
 
-import os, sys, subprocess, shutil
+import os, sys, subprocess, shutil, re
 
 class PBSJob(Job):
   def validParams():
@@ -15,6 +15,7 @@ class PBSJob(Job):
     params.addParam('place', 'scatter:excl', "The PBS job placement scheme to use.")
     params.addParam('walltime', '4:00:00', "The requested walltime for this job.")
     params.addParam('no_copy', "A list of files specifically not to copy")
+    params.addParam('no_copy_pattern', "A pattern of files not to copy")
     params.addParam('copy_files', "A list of files specifically to copy")
 
     params.addStringSubParam('pbs_o_workdir', 'PBS_O_WORKDIR', "Move to this directory")
@@ -47,10 +48,20 @@ class PBSJob(Job):
     # Save current location as PBS_O_WORKDIR
     params['pbs_o_workdir'] = os.getcwd()
 
-    # Copy files (unless they are listed in "no_copy"
+    # Create regexp object of no_copy_pattern
+    if params.isValid('no_copy_pattern'):
+      # Match no_copy_pattern value
+      pattern = re.compile(params['no_copy_pattern'])
+    else:
+      # Match nothing if not set. Better way?
+      pattern = re.compile(r'')
+
+    # Copy files (unless they are listed in "no_copy")
     for file in os.listdir('../'):
-      if os.path.isfile('../' + file) and file != job_file and (not params.isValid('no_copy') or file not in params['no_copy']):
-         shutil.copy('../' + file, '.')
+      if os.path.isfile('../' + file) and file != job_file and \
+         (not params.isValid('no_copy') or file not in params['no_copy']) and \
+         (not params.isValid('no_copy_pattern') or pattern.match(file) is None):
+        shutil.copy('../' + file, '.')
 
     # Copy directories
     if params.isValid('copy_files'):

--- a/python/TestHarness/pbs_template.i
+++ b/python/TestHarness/pbs_template.i
@@ -6,8 +6,8 @@
     mpi_procs = <MIN_PARALLEL>
     moose_application = <EXECUTABLE>
     input_file = <INPUT>
-    pbs_stdout = <PBS_STDOUT>
-    pbs_stderr = <PBS_STDERR>
+    <PBS_STDOUT>
+    <PBS_STDERR>
     walltime = <WALLTIME>
     no_copy = <NO_COPY>
     copy_files = gold

--- a/python/TestHarness/pbs_template.i
+++ b/python/TestHarness/pbs_template.i
@@ -10,6 +10,7 @@
     <PBS_STDERR>
     walltime = <WALLTIME>
     no_copy = <NO_COPY>
+    no_copy_pattern = 'pbs_\d+.cluster'
     copy_files = gold
     combine_streams = True
     cli_args = <CLI_ARGS>

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -201,10 +201,12 @@ class RunApp(Tester):
     self.specs['no_copy'] = options.input_file_name
 
     # Are we using the PBS Emulator? Make this param valid if so.
-    # The cluster_launcher will fill in the rest
+    # Add the substitution string here so it is not visable to the user
+    self.specs.addStringSubParam('pbs_stdout', 'PBS_STDOUT', "Save stdout to this location")
+    self.specs.addStringSubParam('pbs_stderr', 'PBS_STDERR', "Save stderr to this location")
     if options.PBSEmulator:
-      self.specs['pbs_stdout'] = 'PBS_EMULATOR'
-      self.specs['pbs_stderr'] = 'PBS_EMULATOR'
+      self.specs['pbs_stdout'] = 'pbs_stdout = PBS_EMULATOR'
+      self.specs['pbs_stderr'] = 'pbs_stderr = PBS_EMULATOR'
 
     # Do all of the replacements for the valid parameters
     for spec in self.specs.valid_keys():


### PR DESCRIPTION
When the TestHarness runs the Cluster Launcher, do not copy any previous pbs_***.cluster files.
Refs #6222
