### PR TITLE
Make get/hasUserObject methods respect tid

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -481,12 +481,12 @@ public:
    * @return Const reference to the user object
    */
   template <class T>
-  const T & getUserObject(const std::string & name)
+  const T & getUserObject(const std::string & name, THREAD_ID tid = 0)
   {
     for (unsigned int i = 0; i < Moose::exec_types.size(); ++i)
-      if (_user_objects(Moose::exec_types[i])[0].hasUserObject(name))
+      if (_user_objects(Moose::exec_types[i])[tid].hasUserObject(name))
       {
-        UserObject * user_object = _user_objects(Moose::exec_types[i])[0].getUserObjectByName(name);
+        UserObject * user_object = _user_objects(Moose::exec_types[i])[tid].getUserObjectByName(name);
         return dynamic_cast<const T &>(*user_object);
       }
 
@@ -497,14 +497,14 @@ public:
    * @param name The name of the user object being retrieved
    * @return Const reference to the user object
    */
-  const UserObject & getUserObjectBase(const std::string & name);
+  const UserObject & getUserObjectBase(const std::string & name, THREAD_ID tid = 0);
 
   /**
    * Check if there if a user object of given name
    * @param name The name of the user object being checked for
    * @return true if the user object exists, false otherwise
    */
-  bool hasUserObject(const std::string & name);
+  bool hasUserObject(const std::string & name, THREAD_ID tid = 0);
 
   /**
    * Check existence of the postprocessor.

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1988,20 +1988,20 @@ FEProblem::addUserObject(std::string user_object_name, const std::string & name,
 }
 
 const UserObject &
-FEProblem::getUserObjectBase(const std::string & name)
+FEProblem::getUserObjectBase(const std::string & name, THREAD_ID tid/*=0*/)
 {
   for (unsigned int i = 0; i < Moose::exec_types.size(); ++i)
-    if (_user_objects(Moose::exec_types[i])[0].hasUserObject(name))
-      return *_user_objects(Moose::exec_types[i])[0].getUserObjectByName(name);
+    if (_user_objects(Moose::exec_types[i])[tid].hasUserObject(name))
+      return *_user_objects(Moose::exec_types[i])[tid].getUserObjectByName(name);
 
   mooseError("Unable to find user object with name '" + name + "'");
 }
 
 bool
-FEProblem::hasUserObject(const std::string & name)
+FEProblem::hasUserObject(const std::string & name, THREAD_ID tid/*=0*/)
 {
   for (unsigned int i = 0; i < Moose::exec_types.size(); i++)
-    if (_user_objects(Moose::exec_types[i])[0].hasUserObject(name))
+    if (_user_objects(Moose::exec_types[i])[tid].hasUserObject(name))
       return true;
   return false;
 }

--- a/framework/src/userobject/UserObjectInterface.C
+++ b/framework/src/userobject/UserObjectInterface.C
@@ -26,11 +26,11 @@ UserObjectInterface::UserObjectInterface(const InputParameters & params) :
 const UserObject &
 UserObjectInterface::getUserObjectBase(const std::string & name)
 {
-  return _uoi_feproblem.getUserObjectBase(_uoi_params.get<UserObjectName>(name));
+  return _uoi_feproblem.getUserObjectBase(_uoi_params.get<UserObjectName>(name), _uoi_tid);
 }
 
 const UserObject &
 UserObjectInterface::getUserObjectBaseByName(const std::string & name)
 {
-  return _uoi_feproblem.getUserObjectBase(name);
+  return _uoi_feproblem.getUserObjectBase(name, _uoi_tid);
 }


### PR DESCRIPTION
This fixes what seems, at least to me, to be bad behavior in the UserObjects. The get methods always return references to the objects on thread zero. So, when running threaded, threaded objects can have references to UserObjects on different threads than they are operating.

However, this breaks [LayeredAverage](http://www.mooseframework.org/docs/doxygen/moose/classLayeredAverage.html), does anyone know why this may be?

(refs #5680)
