### PR TITLE
Substitute entire PBS output lines in template file

### DIFF
--- a/python/TestHarness/pbs_template.i
+++ b/python/TestHarness/pbs_template.i
@@ -6,8 +6,8 @@
     mpi_procs = <MIN_PARALLEL>
     moose_application = <EXECUTABLE>
     input_file = <INPUT>
-    pbs_stdout = <PBS_STDOUT>
-    pbs_stderr = <PBS_STDERR>
+    <PBS_STDOUT>
+    <PBS_STDERR>
     walltime = <WALLTIME>
     no_copy = <NO_COPY>
     copy_files = gold

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -21,6 +21,8 @@ class RunApp(Tester):
     params.addParam('walltime',           "The max time as pbs understands it")
     params.addParam('job_name',           "The test name as pbs understands it")
     params.addParam('no_copy',            "The tests file as pbs understands it")
+    params.addStringSubParam('pbs_stdout', 'PBS_STDOUT', "Save stdout to this location")
+    params.addStringSubParam('pbs_stderr', 'PBS_STDERR', "Save stderr to this location")
 
     # Parallel/Thread testing
     params.addParam('max_parallel', 1000, "Maximum number of MPI processes this test can be run with      (Default: 1000)")
@@ -203,8 +205,8 @@ class RunApp(Tester):
     # Are we using the PBS Emulator? Make this param valid if so.
     # The cluster_launcher will fill in the rest
     if options.PBSEmulator:
-      self.specs['pbs_stdout'] = 'PBS_EMULATOR'
-      self.specs['pbs_stderr'] = 'PBS_EMULATOR'
+      self.specs['pbs_stdout'] = 'pbs_stdout = PBS_EMULATOR'
+      self.specs['pbs_stderr'] = 'pbs_stderr = PBS_EMULATOR'
 
     # Do all of the replacements for the valid parameters
     for spec in self.specs.valid_keys():


### PR DESCRIPTION
Use the substitution param in order to replace the entire PBS_STDOUT/ERR line in our template file. This allows for the entire entry to be removed rather than have a key equal an empty value.

Refs #6182
