### PR TITLE
Packed Range Fixup

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2004,7 +2004,7 @@ namespace // Anonymous namespace for helper
   {
     extra_ghost_elem_inserter(ParallelMesh& m) : mesh(m) {}
 
-    void operator=(Elem* e) { mesh.add_extra_ghost_elem(e); }
+    void operator=(const Elem* e) { mesh.add_extra_ghost_elem(const_cast<Elem *>(e)); }
 
     void operator=(Node* n) { mesh.add_node(n); }
 


### PR DESCRIPTION
The current code seems to run fine while receiving a iterator to a container
containing const Elem \* and then subsequently using it without the constness.
The new packed range refactor however does not allow this. This explicit
const was added (and immediately cast away) to allow for the proper
type inference.

closes #6226
