### PR TITLE
MaterialUserObject - on-demand recalculatable "material properties"

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -481,12 +481,12 @@ public:
    * @return Const reference to the user object
    */
   template <class T>
-  const T & getUserObject(const std::string & name)
+  const T & getUserObject(const std::string & name, unsigned int tid = 0)
   {
     for (unsigned int i = 0; i < Moose::exec_types.size(); ++i)
-      if (_user_objects(Moose::exec_types[i])[0].hasUserObject(name))
+      if (_user_objects(Moose::exec_types[i])[tid].hasUserObject(name))
       {
-        UserObject * user_object = _user_objects(Moose::exec_types[i])[0].getUserObjectByName(name);
+        UserObject * user_object = _user_objects(Moose::exec_types[i])[tid].getUserObjectByName(name);
         return dynamic_cast<const T &>(*user_object);
       }
 

--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -33,6 +33,7 @@
 #include "MeshChangedInterface.h"
 #include "OutputInterface.h"
 #include "RandomInterface.h"
+#include "MaterialUserObject.h"
 
 #include "MaterialProperty.h"
 
@@ -258,6 +259,25 @@ protected:
    */
   virtual QpData * createData();
 
+  /**
+   * Get a apecial MaterialUserObject which can be explicitly called by the material
+   * during the material property calculation.
+   * @param name The name of the parameter key of the user object to retrieve
+   * @return The user object with name associated with the parameter 'name'
+   */
+  template<class T>
+  const T & getMaterialUserObject(const std::string & name);
+
+  /**
+   * Get a apecial MaterialUserObject which can be explicitly called by the material
+   * during the material property calculation.
+   * This function is most likely not what you want and works only for FunctionElementUserObjects!
+   * @param name The name of the user object to retrieve
+   * @return The user object with the name
+   */
+  template<class T>
+  const T & getMaterialUserObjectByName(const std::string & name);
+
   std::map<unsigned int, std::vector<QpData *> > _qp_prev;
   std::map<unsigned int, std::vector<QpData *> > _qp_curr;
 
@@ -390,6 +410,26 @@ Material::getZeroMaterialProperty(const std::string & prop_name)
     mooseSetToZero<T>(preload_with_zero[qp]);
 
   return preload_with_zero;
+}
+
+template<class T>
+const T &
+Material::getMaterialUserObject(const std::string & name)
+{
+  const T & uo = _fe_problem.getUserObject<T>(_pars.template get<UserObjectName>(name), _tid);
+  if (dynamic_cast<const MaterialUserObject *>(&uo) == NULL)
+    mooseError("Can only fetch thread copies of MaterialUserObject user objects");
+  return uo;
+}
+
+template<class T>
+const T &
+Material::getMaterialUserObjectByName(const std::string & name)
+{
+  const T & uo = _fe_problem.getUserObject<T>(name, _tid);
+  if (dynamic_cast<const MaterialUserObject *>(&uo) == NULL)
+    mooseError("Can only fetch thread copies of MaterialUserObject user objects");
+  return uo;
 }
 
 #endif //MATERIAL_H

--- a/framework/include/userobject/MaterialUserObject.h
+++ b/framework/include/userobject/MaterialUserObject.h
@@ -31,8 +31,10 @@ public:
   MaterialUserObject(const InputParameters & parameters);
 
   /// @{ Block all methods that are not used in explicitly called UOs
-  virtual void execute()
-  virtual void finalize()
-  virtual void threadJoin(const UserObject & uo);
+  virtual void execute();
+  virtual void finalize();
+  virtual void threadJoin(const UserObject &);
   /// @}
 };
+
+#endif //MATERIALUSEROBJECT_H

--- a/framework/include/userobject/MaterialUserObject.h
+++ b/framework/include/userobject/MaterialUserObject.h
@@ -1,0 +1,38 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef MATERIALUSEROBJECT_H
+#define MATERIALUSEROBJECT_H
+
+// MOOSE includes
+#include "ElementUserObject.h"
+
+// Forward Declarations
+class MaterialUserObject;
+
+template<>
+InputParameters validParams<MaterialUserObject>();
+
+class MaterialUserObject :
+  public ElementUserObject
+{
+public:
+  MaterialUserObject(const InputParameters & parameters);
+
+  /// @{ Block all methods that are not used in explicitly called UOs
+  virtual void execute()
+  virtual void finalize()
+  virtual void threadJoin(const UserObject & uo);
+  /// @}
+};

--- a/framework/src/userobject/MaterialUserObject.C
+++ b/framework/src/userobject/MaterialUserObject.C
@@ -39,7 +39,7 @@ MaterialUserObject::finalize()
 }
 
 void
-MaterialUserObject::threadJoin()
+MaterialUserObject::threadJoin(const UserObject &)
 {
   mooseError("MaterialUserObjects must be called explicitly from Materials");
 }

--- a/framework/src/userobject/MaterialUserObject.C
+++ b/framework/src/userobject/MaterialUserObject.C
@@ -18,6 +18,11 @@ template<>
 InputParameters validParams<MaterialUserObject>()
 {
   InputParameters params = validParams<ElementUserObject>();
+
+  // UOs of this type should not be executed by MOOSE, but only called directly by the user
+  params.set<MultiMooseEnum>("execute_on") = "custom";
+  params.suppressParameter<MultiMooseEnum>("execute_on");
+
   return params;
 }
 

--- a/framework/src/userobject/MaterialUserObject.C
+++ b/framework/src/userobject/MaterialUserObject.C
@@ -1,0 +1,45 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "MaterialUserObject.h"
+
+template<>
+InputParameters validParams<MaterialUserObject>()
+{
+  InputParameters params = validParams<ElementUserObject>();
+  return params;
+}
+
+MaterialUserObject::MaterialUserObject(const InputParameters & parameters) :
+    ElementUserObject(parameters)
+{
+}
+
+void
+MaterialUserObject::execute()
+{
+  mooseError("MaterialUserObjects must be called explicitly from Materials");
+}
+
+void
+MaterialUserObject::finalize()
+{
+  mooseError("MaterialUserObjects must be called explicitly from Materials");
+}
+
+void
+MaterialUserObject::threadJoin()
+{
+  mooseError("MaterialUserObjects must be called explicitly from Materials");
+}

--- a/modules/tensor_mechanics/include/userobjects/HEVPFlowRateUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPFlowRateUOBase.h
@@ -7,7 +7,7 @@
 #ifndef HEVPFLOWRATEUOBASE_H
 #define HEVPFLOWRATEUOBASE_H
 
-#include "ElementUserObject.h"
+#include "MaterialUserObject.h"
 #include "RankTwoTensor.h"
 #include "RankFourTensor.h"
 
@@ -20,7 +20,7 @@ InputParameters validParams<HEVPFlowRateUOBase>();
  * This user object is a pure virtual base classs
  * Derived classes computes flow rate, direction and derivatives
  */
-class HEVPFlowRateUOBase : public ElementUserObject
+class HEVPFlowRateUOBase : public MaterialUserObject
 {
 public:
   HEVPFlowRateUOBase(const InputParameters & parameters);

--- a/modules/tensor_mechanics/include/userobjects/HEVPInternalVarRateUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPInternalVarRateUOBase.h
@@ -7,7 +7,7 @@
 #ifndef HEVPINTERNALVARRATEUOBASE_H
 #define HEVPINTERNALVARRATEUOBASE_H
 
-#include "ElementUserObject.h"
+#include "MaterialUserObject.h"
 #include "RankTwoTensor.h"
 
 class HEVPInternalVarRateUOBase;
@@ -19,7 +19,7 @@ InputParameters validParams<HEVPInternalVarRateUOBase>();
  * This user object is a pure virtual base classs
  * Derived classes computes internal variable rate and derivatives
  */
-class HEVPInternalVarRateUOBase : public ElementUserObject
+class HEVPInternalVarRateUOBase : public MaterialUserObject
 {
 public:
   HEVPInternalVarRateUOBase(const InputParameters & parameters);

--- a/modules/tensor_mechanics/include/userobjects/HEVPInternalVarUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPInternalVarUOBase.h
@@ -7,7 +7,7 @@
 #ifndef HEVPINTERNALVARUOBASE_H
 #define HEVPINTERNALVARUOBASE_H
 
-#include "ElementUserObject.h"
+#include "MaterialUserObject.h"
 #include "RankTwoTensor.h"
 
 class HEVPInternalVarUOBase;
@@ -20,7 +20,7 @@ InputParameters validParams<HEVPInternalVarUOBase>();
  * Derived classes integrate internal variables
  * Currently only old state is retrieved to use backward Euler
  */
-class HEVPInternalVarUOBase : public ElementUserObject
+class HEVPInternalVarUOBase : public MaterialUserObject
 {
 public:
   HEVPInternalVarUOBase(const InputParameters & parameters);

--- a/modules/tensor_mechanics/include/userobjects/HEVPStrengthUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPStrengthUOBase.h
@@ -7,7 +7,7 @@
 #ifndef HEVPSTRENGTHUOBASE_H
 #define HEVPSTRENGTHUOBASE_H
 
-#include "ElementUserObject.h"
+#include "MaterialUserObject.h"
 #include "RankTwoTensor.h"
 
 class HEVPStrengthUOBase;
@@ -19,7 +19,7 @@ InputParameters validParams<HEVPStrengthUOBase>();
  * This user object is a pure virtual base classs
  * Derived classes computes material resistances and derivatives
  */
-class HEVPStrengthUOBase : public ElementUserObject
+class HEVPStrengthUOBase : public MaterialUserObject
 {
 public:
   HEVPStrengthUOBase(const InputParameters & parameters);

--- a/modules/tensor_mechanics/src/materials/FiniteStrainHyperElasticViscoPlastic.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainHyperElasticViscoPlastic.C
@@ -109,7 +109,7 @@ FiniteStrainHyperElasticViscoPlastic::initUserObjects(const std::vector<UserObje
     mooseError("Specify atleast one user object of type" << typeid(T).name());
 
   for (unsigned int i = 0; i < uo_num; ++i)
-    uo[i] = &getUserObjectByName<T>(uo_names[i]);
+    uo[i] = &getMaterialUserObjectByName<T>(uo_names[i]);
 }
 
 void

--- a/modules/tensor_mechanics/src/userobjects/HEVPFlowRateUOBase.C
+++ b/modules/tensor_mechanics/src/userobjects/HEVPFlowRateUOBase.C
@@ -9,7 +9,7 @@
 template<>
 InputParameters validParams<HEVPFlowRateUOBase>()
 {
-  InputParameters params = validParams<ElementUserObject>();
+  InputParameters params = validParams<MaterialUserObject>();
   params.addParam<std::string>("strength_prop_name", "Name of strength property: Same as strength user object specified in input file");
   params.addParam<std::string>("base_name", "Base name of tensor properties to fetch");
   params.addClassDescription("User object to evaluate flow rate");
@@ -18,7 +18,7 @@ InputParameters validParams<HEVPFlowRateUOBase>()
 }
 
 HEVPFlowRateUOBase::HEVPFlowRateUOBase(const InputParameters & parameters) :
-    ElementUserObject(parameters),
+    MaterialUserObject(parameters),
     _strength_prop_name(getParam<std::string>("strength_prop_name")),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _strength(getMaterialPropertyByName<Real>(_strength_prop_name)),

--- a/modules/tensor_mechanics/src/userobjects/HEVPInternalVarRateUOBase.C
+++ b/modules/tensor_mechanics/src/userobjects/HEVPInternalVarRateUOBase.C
@@ -9,14 +9,14 @@
 template<>
 InputParameters validParams<HEVPInternalVarRateUOBase>()
 {
-  InputParameters params = validParams<ElementUserObject>();
+  InputParameters params = validParams<MaterialUserObject>();
   params.addParam<std::string>("flow_rate_prop_name", "Name of flow rate property: Same as the flow rate user object name specified in input file");
   params.addClassDescription("User Object");
   return params;
 }
 
 HEVPInternalVarRateUOBase::HEVPInternalVarRateUOBase(const InputParameters & parameters) :
-    ElementUserObject(parameters),
+    MaterialUserObject(parameters),
     _flow_rate_prop_name(getParam<std::string>("flow_rate_prop_name")),
     _flow_rate(getMaterialPropertyByName<Real>(_flow_rate_prop_name))
 {

--- a/modules/tensor_mechanics/src/userobjects/HEVPInternalVarUOBase.C
+++ b/modules/tensor_mechanics/src/userobjects/HEVPInternalVarUOBase.C
@@ -9,14 +9,14 @@
 template<>
 InputParameters validParams<HEVPInternalVarUOBase>()
 {
-  InputParameters params = validParams<ElementUserObject>();
+  InputParameters params = validParams<MaterialUserObject>();
   params.addParam<std::string>("intvar_rate_prop_name", "Name of internal variable property: Same as internal variable rate user object");
   params.addClassDescription("User Object to integrate internal variable");
   return params;
 }
 
 HEVPInternalVarUOBase::HEVPInternalVarUOBase(const InputParameters & parameters) :
-    ElementUserObject(parameters),
+    MaterialUserObject(parameters),
     _intvar_rate_prop_name(getParam<std::string>("intvar_rate_prop_name")),
     _intvar_rate(getMaterialPropertyByName<Real>(_intvar_rate_prop_name)),
     _this_old(getMaterialPropertyOldByName<Real>(_name))

--- a/modules/tensor_mechanics/src/userobjects/HEVPStrengthUOBase.C
+++ b/modules/tensor_mechanics/src/userobjects/HEVPStrengthUOBase.C
@@ -9,14 +9,14 @@
 template<>
 InputParameters validParams<HEVPStrengthUOBase>()
 {
-  InputParameters params = validParams<ElementUserObject>();
+  InputParameters params = validParams<MaterialUserObject>();
   params.addParam<std::string>("intvar_prop_name", "Name of internal variable property to calculate material resistance: Same as internal variable user object");
   params.addClassDescription("User Object to compute material resistance");
   return params;
 }
 
 HEVPStrengthUOBase::HEVPStrengthUOBase(const InputParameters & parameters) :
-    ElementUserObject(parameters),
+    MaterialUserObject(parameters),
     _intvar_prop_name(getParam<std::string>("intvar_prop_name")),
     _intvar(getMaterialPropertyByName<Real>(_intvar_prop_name))
 {


### PR DESCRIPTION
I want to put this idea out here. It is not quite done (needs to override the execute parameter, needs `final`, etc.)

This would allow for a more elegant design of the plasticity system, and will fix the HEVP system. I'm off to ski now.
