### PR TITLE
Stop calling Threads::pthread_unique_id()

### DIFF
--- a/framework/src/utils/ParallelUniqueId.C
+++ b/framework/src/utils/ParallelUniqueId.C
@@ -14,8 +14,11 @@
 
 #include "ParallelUniqueId.h"
 
-#ifdef LIBMESH_HAVE_TBB_API
-tbb::concurrent_bounded_queue<unsigned int> ParallelUniqueId::ids;
-#endif
+bool ParallelUniqueId::_initialized = false;
 
-bool ParallelUniqueId::initialized = false;
+#ifdef LIBMESH_HAVE_TBB_API
+tbb::concurrent_bounded_queue<unsigned int> ParallelUniqueId::_ids;
+#elif LIBMESH_HAVE_PTHREAD
+std::queue<unsigned int> ParallelUniqueId::_ids;
+Threads::spin_mutex ParallelUniqueId::_pthread_id_mutex;
+#endif


### PR DESCRIPTION
This PR is the first of several threading fixups in the framework.
This first avoids calling the broken pthread_unique_id() method
in libMesh and hands out IDs based on a properly protected queue
instead.

refs #6245
