### PR TITLE
Make c coupling optional and default to variable 

### DIFF
--- a/modules/phase_field/include/kernels/SoretDiffusion.h
+++ b/modules/phase_field/include/kernels/SoretDiffusion.h
@@ -38,6 +38,9 @@ protected:
   /// Variable gradient for temperature
   VariableGradient & _grad_T;
 
+  /// is the kernel used in a coupled form?
+  const bool _is_coupled;
+
   /// int label for the Concentration
   unsigned int _c_var;
 
@@ -51,7 +54,7 @@ protected:
   const MaterialProperty<Real> & _Q;
 
   /// Boltzmann constant
-  const Real _kb;
+  const Real _kB;
 };
 
 #endif //SORETDIFFUSION_H

--- a/modules/phase_field/src/kernels/SoretDiffusion.C
+++ b/modules/phase_field/src/kernels/SoretDiffusion.C
@@ -11,7 +11,7 @@ InputParameters validParams<SoretDiffusion>()
   InputParameters params = validParams<Kernel>();
   params.addClassDescription("Add Soret effect to Split formulation Cahn-Hilliard Kernel");
   params.addRequiredCoupledVar("T", "Temperature");
-  params.addRequiredCoupledVar("c", "Concentration");
+  params.addCoupledVar("c", "Concentration");
   params.addRequiredParam<MaterialPropertyName>("diff_name", "The diffusivity used with the kernel");
   params.addParam<MaterialPropertyName>("Q_name", "Qheat", "The material name for the heat of transport");
   return params;
@@ -22,39 +22,39 @@ SoretDiffusion::SoretDiffusion(const InputParameters & parameters) :
     _T_var(coupled("T")),
     _T(coupledValue("T")),
     _grad_T(coupledGradient("T")),
-    _c_var(coupled("c")),
-    _c(coupledValue("c")),
+    _is_coupled(isCoupled("c")),
+    _c_var(_is_coupled ? coupled("c") : _var.number()),
+    _c(_is_coupled ? coupledValue("c") : _u),
     _D(getMaterialProperty<Real>("diff_name")),
     _Q(getMaterialProperty<Real>("Q_name")),
-    _kb(8.617343e-5) // Boltzmann constant in eV/K
+    _kB(8.617343e-5) // Boltzmann constant in eV/K
 {
 }
 
 Real
 SoretDiffusion::computeQpResidual()
 {
-  Real T_term = _D[_qp] * _Q[_qp] * _c[_qp] / (_kb * _T[_qp] * _T[_qp]);
-
+  const Real T_term = _D[_qp] * _Q[_qp] * _c[_qp] / (_kB * _T[_qp] * _T[_qp]);
   return T_term * _grad_T[_qp] * _grad_test[_i][_qp];
 }
 
 Real
 SoretDiffusion::computeQpJacobian()
 {
-  if (_c_var == _var.number()) //Requires c jacobian
-    return computeQpCJacobian();
-
-  return 0.0;
+  return _is_coupled ? 0.0 : computeQpCJacobian();
 }
 
 Real
 SoretDiffusion::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if (_c_var == jvar) //Requires c jacobian
+  // c Off-Diagonal Jacobian
+  if (_c_var == jvar)
     return computeQpCJacobian();
-  else if (_T_var == jvar) //Requires T jacobian
+
+  // T Off-Diagonal Jacobian
+  if (_T_var == jvar)
     return _D[_qp] * _Q[_qp] * _c[_qp] * _grad_test[_i][_qp] *
-           (_grad_phi[_j][_qp]/(_kb * _T[_qp] * _T[_qp]) - 2.0 * _grad_T[_qp] * _phi[_j][_qp] / (_kb * _T[_qp] * _T[_qp] * _T[_qp]));
+           (_grad_phi[_j][_qp] - 2.0 * _grad_T[_qp] * _phi[_j][_qp] / _T[_qp]) / (_kB * _T[_qp] * _T[_qp]);
 
   return 0.0;
 }
@@ -62,7 +62,6 @@ SoretDiffusion::computeQpOffDiagJacobian(unsigned int jvar)
 Real
 SoretDiffusion::computeQpCJacobian()
 {
-  //Calculate the Jacobian for the c variable
-  return _D[_qp] * _Q[_qp] * _phi[_j][_qp] * _grad_T[_qp] / (_kb * _T[_qp] * _T[_qp]) * _grad_test[_i][_qp];
+  // Calculate the Jacobian for the c variable
+  return _D[_qp] * _Q[_qp] * _phi[_j][_qp] * _grad_T[_qp] / (_kB * _T[_qp] * _T[_qp]) * _grad_test[_i][_qp];
 }
-

--- a/modules/phase_field/tests/SoretDiffusion/direct.i
+++ b/modules/phase_field/tests/SoretDiffusion/direct.i
@@ -50,7 +50,6 @@
   [./c_soret]
     type = SoretDiffusion
     variable = c
-    c = c
     T = T
     diff_name = D
     Q_name = Qstar

--- a/modules/phase_field/tests/SoretDiffusion/direct_temp.i
+++ b/modules/phase_field/tests/SoretDiffusion/direct_temp.i
@@ -50,7 +50,6 @@
   [./c_soret]
     type = SoretDiffusion
     variable = c
-    c = c
     T = T
     diff_name = D
     Q_name = Qstar


### PR DESCRIPTION
The coupled variable `c` is now optional and defaults to the kernel variable. This makes the syntax slightly simpler for the direct solve.

Closes #6239
