### PR TITLE
Fix ACInterface residuals and Jacobians yet again

### DIFF
--- a/modules/phase_field/include/kernels/ACInterface.h
+++ b/modules/phase_field/include/kernels/ACInterface.h
@@ -39,7 +39,6 @@ protected:
 
   /// Mobility
   const MaterialProperty<Real> & _L;
-
   /// Interfacial parameter
   const MaterialProperty<Real> & _kappa;
 
@@ -51,10 +50,8 @@ protected:
   const MaterialProperty<Real> & _d2Ldop2;
   /// @}
 
-  /// @{ kappa derivatives w.r.t. order parameter
+  /// kappa derivative w.r.t. order parameter
   const MaterialProperty<Real> & _dkappadop;
-  const MaterialProperty<Real> & _d2kappadop2;
-  /// @}
 
   /// number of coupled variables
   unsigned int _nvar;
@@ -65,11 +62,8 @@ protected:
   std::vector<std::vector<const MaterialProperty<Real> *> > _d2Ldarg2;
   /// @}
 
-  /// @{ kappa derivative w.r.t. other coupled variables
+  /// kappa derivative w.r.t. other coupled variables
   std::vector<const MaterialProperty<Real> *> _dkappadarg;
-  std::vector<const MaterialProperty<Real> *> _d2kappadargdop;
-  std::vector<std::vector<const MaterialProperty<Real> *> > _d2kappadarg2;
-  /// @}
 
   /// Gradients for all coupled variables
   std::vector<VariableGradient *> _gradarg;

--- a/modules/phase_field/include/kernels/ACInterface.h
+++ b/modules/phase_field/include/kernels/ACInterface.h
@@ -43,7 +43,7 @@ protected:
   const MaterialProperty<Real> & _kappa;
 
   /// flag set if L is a function of non-linear variables in args
-  bool _variable_L;
+  const bool _variable_L;
 
   /// @{ Mobility derivatives w.r.t. order parameter
   const MaterialProperty<Real> & _dLdop;
@@ -54,7 +54,7 @@ protected:
   const MaterialProperty<Real> & _dkappadop;
 
   /// number of coupled variables
-  unsigned int _nvar;
+  const unsigned int _nvar;
 
   /// @{ Mobility derivative w.r.t. other coupled variables
   std::vector<const MaterialProperty<Real> *> _dLdarg;
@@ -66,7 +66,7 @@ protected:
   std::vector<const MaterialProperty<Real> *> _dkappadarg;
 
   /// Gradients for all coupled variables
-  std::vector<VariableGradient *> _gradarg;
+  std::vector<const VariableGradient *> _gradarg;
 };
 
 #endif //ACInterface_H

--- a/modules/phase_field/include/kernels/ACInterface.h
+++ b/modules/phase_field/include/kernels/ACInterface.h
@@ -17,7 +17,7 @@ template<>
 InputParameters validParams<ACInterface>();
 
 /**
- * Compute the Allen-Cahn interfac term with the weak form residual
+ * Compute the Allen-Cahn interface term with the weak form residual
  * \f$ \left( \kappa_i \nabla\eta_i, \nabla (L_i \psi) \right) \f$
  */
 class ACInterface : public DerivativeMaterialInterface<JvarMapInterface<Kernel> >

--- a/modules/phase_field/include/kernels/ACInterface.h
+++ b/modules/phase_field/include/kernels/ACInterface.h
@@ -16,6 +16,10 @@ class ACInterface;
 template<>
 InputParameters validParams<ACInterface>();
 
+/**
+ * Compute the Allen-Cahn interfac term with the weak form residual
+ * \f$ \left( \kappa_i \nabla\eta_i, \nabla (L_i \psi) \right) \f$
+ */
 class ACInterface : public DerivativeMaterialInterface<JvarMapInterface<Kernel> >
 {
 public:
@@ -30,8 +34,8 @@ protected:
   RealGradient gradL();
   RealGradient gradKappa();
 
-  /// the \f$ \nabla(L\kappa\psi) \f$ term
-  RealGradient nablaLKappaPsi();
+  /// the \f$ \kappa\nabla(L\psi) \f$ term
+  RealGradient kappaNablaLPsi();
 
   /// Mobility
   const MaterialProperty<Real> & _L;
@@ -41,9 +45,6 @@ protected:
 
   /// flag set if L is a function of non-linear variables in args
   bool _variable_L;
-
-  /// flag set if kappa is a function of non-linear variables in args
-  bool _variable_kappa;
 
   /// @{ Mobility derivatives w.r.t. order parameter
   const MaterialProperty<Real> & _dLdop;

--- a/modules/phase_field/src/kernels/ACInterface.C
+++ b/modules/phase_field/src/kernels/ACInterface.C
@@ -26,14 +26,11 @@ ACInterface::ACInterface(const InputParameters & parameters) :
     _dLdop(getMaterialPropertyDerivative<Real>("mob_name", _var.name())),
     _d2Ldop2(getMaterialPropertyDerivative<Real>("mob_name", _var.name(), _var.name())),
     _dkappadop(getMaterialPropertyDerivative<Real>("kappa_name", _var.name())),
-    _d2kappadop2(getMaterialPropertyDerivative<Real>("kappa_name", _var.name(), _var.name())),
     _nvar(_coupled_moose_vars.size()),
     _dLdarg(_nvar),
     _d2Ldargdop(_nvar),
     _d2Ldarg2(_nvar),
     _dkappadarg(_nvar),
-    _d2kappadargdop(_nvar),
-    _d2kappadarg2(_nvar),
     _gradarg(_nvar)
 {
   // Get mobility and kappa derivatives and coupled variable gradients
@@ -45,19 +42,12 @@ ACInterface::ACInterface(const InputParameters & parameters) :
     _dkappadarg[i] = &getMaterialPropertyDerivative<Real>("kappa_name", ivar->name());
 
     _d2Ldargdop[i] = &getMaterialPropertyDerivative<Real>("mob_name", ivar->name(), _var.name());
-    _d2kappadargdop[i] = &getMaterialPropertyDerivative<Real>("kappa_name", ivar->name(), _var.name());
 
     _gradarg[i] = &(ivar->gradSln());
 
     _d2Ldarg2[i].resize(_nvar);
-    _d2kappadarg2[i].resize(_nvar);
     for (unsigned int j = 0; j < _nvar; ++j)
-    {
-      MooseVariable *jvar = _coupled_moose_vars[j];
-
-      _d2Ldarg2[i][j] = &getMaterialPropertyDerivative<Real>("mob_name", ivar->name(), jvar->name());
-      _d2kappadarg2[i][j] = &getMaterialPropertyDerivative<Real>("kappa_name", ivar->name(), jvar->name());
-    }
+      _d2Ldarg2[i][j] = &getMaterialPropertyDerivative<Real>("mob_name", ivar->name(), _coupled_moose_vars[j]->name());
   }
 }
 

--- a/modules/phase_field/src/kernels/ACInterface.C
+++ b/modules/phase_field/src/kernels/ACInterface.C
@@ -14,10 +14,7 @@ InputParameters validParams<ACInterface>()
   params.addParam<MaterialPropertyName>("mob_name", "L", "The mobility used with the kernel");
   params.addParam<MaterialPropertyName>("kappa_name", "kappa_op", "The kappa used with the kernel");
   params.addCoupledVar("args", "Vector of nonlinear variable arguments this object depends on");
-
-  params.addParam<bool>("variable_L", true, "The mobility is a function of any non-linear variable");
-  params.addParam<bool>("variable_kappa", false, "Kappa is a function of any non-linear variable (must use ACInterfaceKappa Kernel along with this option)");
-
+  params.addParam<bool>("variable_L", true, "The mobility is a function of any MOOSE variable (if this is set to false L must be constant over the entire domain!)");
   return params;
 }
 

--- a/modules/phase_field/tests/mobility_derivative/AC_mobility_derivative_coupled_test.i
+++ b/modules/phase_field/tests/mobility_derivative/AC_mobility_derivative_coupled_test.i
@@ -76,7 +76,8 @@
     function = 'l:=0.1+1*(v+op)^2; if(l<0.01, 0.01, l)'
     args = 'op v'
     outputs = exodus
-    derivative_order = 1
+    output_properties = 'L dL/dop dL/dv'
+    derivative_order = 2
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial

--- a/modules/phase_field/tests/mobility_derivative/AC_mobility_derivative_test.i
+++ b/modules/phase_field/tests/mobility_derivative/AC_mobility_derivative_test.i
@@ -50,7 +50,8 @@
     function = 'if(op<0, 0.01, if(op>1, 0.01, 1*op^2*(1-op)^2+0.01))'
     args = 'op'
     outputs = exodus
-    derivative_order = 1
+    output_properties = 'L dL/dop dL/dv'
+    derivative_order = 2
   [../]
   [./free_energy]
     type = DerivativeParsedMaterial


### PR DESCRIPTION
I noticed that the derivation of the `ACInterface` weak form was still not quite correct. The new derivation takes into account that kappa can possibly have a gradient. 

Surprisingly this **simplifies** the weak form considerably. I also fixed up the off diagonal jacobian, which passes the analyzejacobian.py test now. 

The new derivation is up on [the wiki page](http://mooseframework.org/wiki/PhysicsModules/PhaseField/DevelopingModels/). I also derived the terms for variable and variable gradient dependences of kappa. There will be more PRs for those in the future.

Refs #6194 Pink @tonkmr FYI

P.S.: The old `ACInterface` kernel was only guaranteed to work with constant kappas (and variable mobilities), so no tests were broken by this change, nor should any simulation results be invalidated.
