### PR TITLE
AuxKernel provides _current_node from the correct mesh

### DIFF
--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -98,7 +98,7 @@ AuxKernel::AuxKernel(const InputParameters & parameters) :
     _current_elem_volume(_assembly.elemVolume()),
     _current_side_volume(_assembly.sideElemVolume()),
 
-    _current_node(_var.node()),
+    _current_node(_assembly.node()),
 
     _solution(_aux_sys.solution())
 {


### PR DESCRIPTION
Current node was coming from _var, which was always the non-displaced
version.  It is now coming from Assembly, which respects the displaced
non-displaced variant.

Closes #6086
