### PR TITLE
Revise clobber target

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -170,12 +170,14 @@ clean::
 #    dependency and object files when you upgrade OSX versions or as
 #    source files are deleted over time.
 clobber:: clean
-	$(shell find $(CURDIR) \( -path $(CURDIR)/moose -or -path $(CURDIR)/.git -or -path $(CURDIR)/.svn \) -prune -or \
-          \( -name "*~" -or -name "*.lo" -or -name "*.la" -or -name "*.dylib" -or -name "*.so*" -or -name "*.a" \
-          -or -name "*-opt" -or -name "*-dbg" -or -name "*-oprof" \
-          -or -name "*.d" -or -name "*.pyc" -or -name "*.plugin" -or -name "*.mod" -or -name "*.plist" \
-          -or -name "*.gcda" -or -name "*.gcno" -or -name "*.gcov" -or -name "*.gch" -or -name .libs -or -path "*/.libs/*" \) \
-          -delete)
+	@find $(CURDIR) \( -path $(CURDIR)/moose -or -path $(CURDIR)/.git -or -path $(CURDIR)/.svn \) \
+        -prune -or \( -type d -and -path "*/.libs" \) | xargs rm -rf --
+	@find $(CURDIR) \( -path $(CURDIR)/moose -or -path $(CURDIR)/.git -or -path $(CURDIR)/.svn \) \
+        -prune \
+        -or -name "*~" -or -name "*.lo" -or -name "*.la" -or -name "*.dylib" -or -name "*.so*" -or -name "*.a" \
+        -or -name "*-opt" -or -name "*-dbg" -or -name "*-oprof" \
+        -or -name "*.d" -or -name "*.pyc" -or -name "*.plugin" -or -name "*.mod" -or -name "*.plist" \
+        -or -name "*.gcda" -or -name "*.gcno" -or -name "*.gcov" -or -name "*.gch" | xargs rm -f --
 
 # cleanall runs 'make clean' in all dependent application directories
 cleanall:: clean


### PR DESCRIPTION
Second (or third) try at fixing the clobber target. This works for me, but if somebody else tested it, that'd be great. It aggressively removes the `.libs` directories and then looks for remaining _files_ which it deletes without the `-rf` options. This should fix the broken prune command in the second find.

Closes #6274
