### PR TITLE
Warn if material properties are retrieved after construction time

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -342,6 +342,11 @@ public:
   virtual bool currentlyComputingJacobian() { return _currently_computing_jacobian; }
 
   /**
+   * Returns true if we are in or beyond the initialSetup stage
+   */
+  virtual bool startedInitialSetup() { return _started_initial_setup; }
+
+  /**
    * The relative L2 norm of the difference between solution and old solution vector.
    */
   virtual Real relativeSolutionDifferenceNorm();
@@ -1233,6 +1238,9 @@ private:
 
   /// Whether or not the system is currently computing the Jacobian matrix
   bool _currently_computing_jacobian;
+
+  /// At or beyond initialSteup stage
+  bool _started_initial_setup;
 
   friend class AuxiliarySystem;
   friend class NonlinearSystem;

--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -248,10 +248,11 @@ protected:
 
 
 private:
-  /**
-   * Small helper function to call storeMatPropName
-   */
+  /// Small helper function to call storeMatPropName
   void registerPropName(std::string prop_name, bool is_get, Prop_State state);
+
+  /// Check and throw an error if the execution has progerssed past the construction stage
+  void checkExecutionStage();
 
   bool _has_stateful_property;
 };
@@ -305,6 +306,7 @@ template<typename T>
 const MaterialProperty<T> &
 Material::getMaterialPropertyByName(const std::string & prop_name)
 {
+  checkExecutionStage();
   // The property may not exist yet, so declare it (declare/getMaterialProperty are referencing the same memory)
   _requested_props.insert(prop_name);
   registerPropName(prop_name, true, Material::CURRENT);
@@ -361,6 +363,7 @@ template<typename T>
 const MaterialProperty<T> &
 Material::getZeroMaterialProperty(const std::string & prop_name)
 {
+  checkExecutionStage();
   MaterialProperty<T> & preload_with_zero = _material_data->getProperty<T>(prop_name);
 
   _requested_props.insert(prop_name);

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -97,6 +97,17 @@ public:
   ///@}
 
   /**
+   * Retrieve pointer to a material property with the mesh blocks where it is defined
+   * The name required by this method is the name defined in the input file.
+   * This function can be thought as the combination of getMaterialPropertyByName and getMaterialPropertyBlocks.
+   * It can be called after the action of all actions.
+   * @param name The name of the material property to retrieve
+   * @return Pointer to the material property with the name 'name' and the set of blocks where the property is valid
+   */
+  template<typename T>
+  std::pair<const MaterialProperty<T> *, std::set<SubdomainID> > getBlockMaterialProperty(const MaterialPropertyName & name);
+
+  /**
    * Return a material property that is initialized to zero by default and does
    * not need to (but can) be declared by another material.
    */
@@ -366,6 +377,19 @@ MaterialPropertyInterface::getMaterialPropertyOlderByName(const MaterialProperty
   markMatPropRequested(name);
 
   return _material_data->getPropertyOlder<T>(name);
+}
+
+template<typename T>
+std::pair<const MaterialProperty<T> *, std::set<SubdomainID> >
+MaterialPropertyInterface::getBlockMaterialProperty(const MaterialPropertyName & name)
+{
+  if (_mi_block_ids.empty())
+    mooseError("getBlockMaterialProperty must be called by a block restrictable object");
+
+  if (!hasMaterialPropertyByName<T>(name))
+    return std::pair<const MaterialProperty<T> *, std::set<SubdomainID> >(NULL, std::set<SubdomainID>());
+
+  return std::pair<const MaterialProperty<T> *, std::set<SubdomainID> >(&_material_data->getProperty<T>(name), _mi_feproblem.getMaterialPropertyBlocks(name));
 }
 
 template<typename T>

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -224,10 +224,11 @@ protected:
   std::vector<MooseSharedPointer<MaterialProperty<Real> > > _default_real_properties;
 
 private:
-  /**
-   * An initialization routine needed for dual constructors
-   */
+  /// An initialization routine needed for dual constructors
   void initializeMaterialPropertyInterface(const InputParameters & parameters);
+
+  /// Check and throw an error if the execution has progerssed past the construction stage
+  void checkExecutionStage();
 
   /// Empty sets for referencing when ids is not included
   const std::set<SubdomainID> _empty_block_ids;
@@ -325,6 +326,7 @@ template<typename T>
 const MaterialProperty<T> &
 MaterialPropertyInterface::getMaterialPropertyByName(const MaterialPropertyName & name)
 {
+  checkExecutionStage();
   checkMaterialProperty(name);
 
   if (!_stateful_allowed && _material_data->getMaterialPropertyStorage().hasStatefulProperties())

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -151,7 +151,8 @@ FEProblem::FEProblem(const InputParameters & parameters) :
     _error_on_jacobian_nonzero_reallocation(getParam<bool>("error_on_jacobian_nonzero_reallocation")),
     _force_restart(getParam<bool>("force_restart")),
     _fail_next_linear_convergence_check(false),
-    _currently_computing_jacobian(false)
+    _currently_computing_jacobian(false),
+    _started_initial_setup(false)
 {
 
   _time = 0.0;
@@ -323,6 +324,10 @@ void FEProblem::setAxisymmetricCoordAxis(const MooseEnum & rz_coord_axis)
 void FEProblem::initialSetup()
 {
   Moose::perf_log.push("initialSetup()", "Setup");
+
+  // set state flag indicating that we are in or beyond initialSetup.
+  // This can be used to throw errors in methods that _must_ be called at construction time.
+  _started_initial_setup = true;
 
   // Perform output related setups
   _app.getOutputWarehouse().initialSetup();

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -191,3 +191,10 @@ Material::computePropertiesAtQp(unsigned int qp)
   _qp = qp;
   computeQpProperties();
 }
+
+void
+Material::checkExecutionStage()
+{
+  if (_fe_problem.startedInitialSetup())
+    mooseError("Material properties must be retrieved during material object construction to ensure correct dependency resolution.");
+}

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -235,3 +235,10 @@ MaterialPropertyInterface::getMaterialByName(const std::string & name)
 
   return *discrete;
 }
+
+void
+MaterialPropertyInterface::checkExecutionStage()
+{
+  if (_mi_feproblem.startedInitialSetup())
+    mooseError("Material properties must be retrieved during object construction to ensure correct problem integrity validation.");
+}


### PR DESCRIPTION
Getting material properties after the constructors have run (e.g. in `initialSetup`) bypasses the system consistency check. This PR warns the user about those cases.

Closes #5859 
