### PR TITLE
fixed uninitialized iterators in ComputeNodalKernelJacobiansThread.C and ComputeNodalKernelBCJacobiansThread.C

### DIFF
--- a/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
@@ -90,7 +90,7 @@ ComputeNodalKernelBCJacobiansThread::onNode(ConstBndNodeRange::const_iterator & 
 
         // See if this NodalKernel is coupled to the jvar
         const std::vector<MooseVariable *> & coupled_vars = (*nodal_kernel_it)->getCoupledMooseVars();
-        for (std::vector<MooseVariable *>::iterator var_it; var_it != coupled_vars.end(); ++var_it)
+        for (std::vector<MooseVariable *>::const_iterator var_it = coupled_vars.begin(); var_it != coupled_vars.end(); ++var_it)
         {
           if ( (*var_it)->number() == jvar )
           {

--- a/framework/src/base/ComputeNodalKernelJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelJacobiansThread.C
@@ -90,7 +90,7 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
 
         // See if this NodalKernel is coupled to the jvar
         const std::vector<MooseVariable *> & coupled_vars = (*nodal_kernel_it)->getCoupledMooseVars();
-        for (std::vector<MooseVariable *>::iterator var_it; var_it != coupled_vars.end(); ++var_it)
+        for (std::vector<MooseVariable *>::const_iterator var_it = coupled_vars.begin(); var_it != coupled_vars.end(); ++var_it)
         {
           if ( (*var_it)->number() == jvar )
           {


### PR DESCRIPTION
Fixed the uninitialized iterators

Closes #6294
