### PR TITLE
Refactoring performance logging

### DIFF
--- a/framework/src/actions/CreateDisplacedProblemAction.C
+++ b/framework/src/actions/CreateDisplacedProblemAction.C
@@ -43,8 +43,6 @@ CreateDisplacedProblemAction::act()
     if (!_displaced_mesh)
       mooseError("displacements were set but a displaced mesh wasn't created!");
 
-    Moose::setup_perf_log.push("Create DisplacedProblem", "Setup");
-
     // Define the parameters
     InputParameters object_params = _factory.getValidParams("DisplacedProblem");
     object_params.set<std::vector<std::string> >("displacements") = getParam<std::vector<std::string> >("displacements");
@@ -56,7 +54,5 @@ CreateDisplacedProblemAction::act()
 
     // Add the Displaced Problem to FEProblem
     _problem->addDisplacedProblem(disp_problem);
-
-    Moose::setup_perf_log.pop("Create DisplacedProblem","Setup");
   }
 }

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -35,10 +35,8 @@ CreateExecutionerAction::CreateExecutionerAction(InputParameters params) :
 void
 CreateExecutionerAction::act()
 {
-  Moose::setup_perf_log.push("Create Executioner","Setup");
   _moose_object_pars.set<FEProblem *>("_fe_problem") = _problem.get();
   MooseSharedPointer<Executioner> executioner = MooseSharedNamespace::static_pointer_cast<Executioner>(_factory.create(_type, "Executioner", _moose_object_pars));
-  Moose::setup_perf_log.pop("Create Executioner","Setup");
 
   _app.executioner() = executioner;
 }

--- a/framework/src/actions/SetupMeshCompleteAction.C
+++ b/framework/src/actions/SetupMeshCompleteAction.C
@@ -36,11 +36,7 @@ SetupMeshCompleteAction::completeSetup(MooseMesh *mesh)
   bool prepared = mesh->prepared();
 
   if (!prepared)
-  {
-    Moose::setup_perf_log.push("Prepare Mesh","Setup");
     mesh->prepare();
-    Moose::setup_perf_log.pop("Prepare Mesh","Setup");
-  }
 
   // Clear the modifiers, they are not used again during the simulation after the mesh has been completed
   _app.clearMeshModifiers();

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -318,7 +318,7 @@ AuxiliarySystem::addVector(const std::string & vector_name, const bool project, 
 void
 AuxiliarySystem::computeScalarVars(ExecFlagType type)
 {
-  Moose::perf_log.push("update_aux_vars_scalar()","Solve");
+  Moose::perf_log.push("update_aux_vars_scalar()", "Execution");
 
   // Reference to the current storage container
   const MooseObjectWarehouse<AuxScalarKernel> & storage = _aux_scalar_storage[type];
@@ -344,7 +344,7 @@ AuxiliarySystem::computeScalarVars(ExecFlagType type)
     }
   }
   PARALLEL_CATCH;
-  Moose::perf_log.pop("update_aux_vars_scalar()","Solve");
+  Moose::perf_log.pop("update_aux_vars_scalar()", "Execution");
 
   solution().close();
   _sys.update();
@@ -353,7 +353,7 @@ AuxiliarySystem::computeScalarVars(ExecFlagType type)
 void
 AuxiliarySystem::computeNodalVars(ExecFlagType type)
 {
-  Moose::perf_log.push("update_aux_vars_nodal()","Solve");
+  Moose::perf_log.push("update_aux_vars_nodal()", "Execution");
 
   // Reference to the Nodal AuxKernel storage
   const MooseObjectWarehouse<AuxKernel> & nodal = _nodal_aux_storage[type];
@@ -371,10 +371,10 @@ AuxiliarySystem::computeNodalVars(ExecFlagType type)
     }
   }
   PARALLEL_CATCH;
-  Moose::perf_log.pop("update_aux_vars_nodal()","Solve");
+  Moose::perf_log.pop("update_aux_vars_nodal()", "Execution");
 
   // Boundary Nodal AuxKernels
-  Moose::perf_log.push("update_aux_vars_nodal_bcs()","Solve");
+  Moose::perf_log.push("update_aux_vars_nodal_bcs()", "Execution");
   PARALLEL_TRY {
     if (nodal.hasActiveBoundaryObjects())
     {
@@ -388,13 +388,13 @@ AuxiliarySystem::computeNodalVars(ExecFlagType type)
   }
   PARALLEL_CATCH;
 
-  Moose::perf_log.pop("update_aux_vars_nodal_bcs()","Solve");
+  Moose::perf_log.pop("update_aux_vars_nodal_bcs()", "Execution");
 }
 
 void
 AuxiliarySystem::computeElementalVars(ExecFlagType type)
 {
-  Moose::perf_log.push("update_aux_vars_elemental()","Solve");
+  Moose::perf_log.push("update_aux_vars_elemental()", "Execution");
 
   // Reference to the Nodal AuxKernel storage
   const MooseObjectWarehouse<AuxKernel> & elemental = _elemental_aux_storage[type];
@@ -424,7 +424,7 @@ AuxiliarySystem::computeElementalVars(ExecFlagType type)
 
   }
   PARALLEL_CATCH;
-  Moose::perf_log.pop("update_aux_vars_elemental()","Solve");
+  Moose::perf_log.pop("update_aux_vars_elemental()", "Execution");
 }
 
 void

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -104,13 +104,13 @@ DisplacedProblem::init()
   _displaced_nl.init();
   _displaced_aux.init();
 
-  Moose::setup_perf_log.push("DisplacedProblem::init::eq.init()","Setup");
+  Moose::perf_log.push("DisplacedProblem::init::eq.init()", "Setup");
   _eq.init();
-  Moose::setup_perf_log.pop("DisplacedProblem::init::eq.init()","Setup");
+  Moose::perf_log.pop("DisplacedProblem::init::eq.init()", "Setup");
 
-  Moose::setup_perf_log.push("DisplacedProblem::init::meshChanged()","Setup");
+  Moose::perf_log.push("DisplacedProblem::init::meshChanged()", "Setup");
   _mesh.meshChanged();
-  Moose::setup_perf_log.pop("DisplacedProblem::init::meshChanged()","Setup");
+  Moose::perf_log.pop("DisplacedProblem::init::meshChanged()", "Setup");
 }
 
 void
@@ -128,7 +128,7 @@ DisplacedProblem::syncSolutions(const NumericVector<Number> & soln, const Numeri
 void
 DisplacedProblem::updateMesh(const NumericVector<Number> & soln, const NumericVector<Number> & aux_soln)
 {
-  Moose::perf_log.push("updateDisplacedMesh()","Solve");
+  Moose::perf_log.push("updateDisplacedMesh()", "Execution");
 
   unsigned int n_threads = libMesh::n_threads();
 
@@ -150,7 +150,7 @@ DisplacedProblem::updateMesh(const NumericVector<Number> & soln, const NumericVe
   // Since the Mesh changed, update the PointLocator object used by DiracKernels.
   _dirac_kernel_info.updatePointLocator(_mesh);
 
-  Moose::perf_log.pop("updateDisplacedMesh()","Solve");
+  Moose::perf_log.pop("updateDisplacedMesh()", "Execution");
 }
 
 bool

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -1126,7 +1126,6 @@ enableFPE(bool on)
     libMesh::enableFPE(on);
 }
 
-
 PerfLog setup_perf_log("Setup");
 
 /**

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -512,9 +512,15 @@ MooseApp::legacyUoInitializationDefault()
 void
 MooseApp::run()
 {
+  Moose::perf_log.push("Full Runtime", "Application");
+
+  Moose::perf_log.push("Application Setup", "Setup");
   setupOptions();
   runInputFile();
+  Moose::perf_log.pop("Application Setup", "Setup");
+
   executeExecutioner();
+  Moose::perf_log.pop("Full Runtime", "Application");
 }
 
 void

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -209,23 +209,19 @@ NonlinearSystem::~NonlinearSystem()
 void
 NonlinearSystem::init()
 {
+  Moose::setup_perf_log.push("NonlinerSystem::init()", "Setup");
+
   setupDampers();
 
   _current_solution = _sys.current_local_solution.get();
 
   if (_need_serialized_solution)
-  {
-    Moose::setup_perf_log.push("Init serialized_solution","Setup");
     _serialized_solution.init(_sys.n_dofs(), false, SERIAL);
-    Moose::setup_perf_log.pop("Init serialized_solution","Setup");
-  }
 
   if (_need_residual_copy)
-  {
-    Moose::setup_perf_log.push("Init residual_copy","Setup");
     _residual_copy.init(_sys.n_dofs(), false, SERIAL);
-    Moose::setup_perf_log.pop("Init residual_copy","Setup");
-  }
+
+  Moose::setup_perf_log.pop("NonlinerSystem::init()", "Setup");
 }
 
 void
@@ -714,7 +710,7 @@ NonlinearSystem::addVector(const std::string & vector_name, const bool project, 
 void
 NonlinearSystem::computeResidual(NumericVector<Number> & residual, Moose::KernelType type)
 {
-  Moose::perf_log.push("compute_residual()","Solve");
+  Moose::perf_log.push("compute_residual()", "Execution");
 
   _n_residual_evaluations++;
 
@@ -763,7 +759,7 @@ NonlinearSystem::computeResidual(NumericVector<Number> & residual, Moose::Kernel
 
   Moose::enableFPE(false);
 
-  Moose::perf_log.pop("compute_residual()","Solve");
+  Moose::perf_log.pop("compute_residual()", "Execution");
 }
 
 
@@ -1202,9 +1198,7 @@ NonlinearSystem::computeResidualInternal(Moose::KernelType type)
     ConstElemRange & elem_range = *_mesh.getActiveLocalElementRange();
     ComputeResidualThread cr(_fe_problem, *this, type);
 
-    Moose::perf_log.push("ComputeResidualThread", "Solve");
     Threads::parallel_reduce(elem_range, cr);
-    Moose::perf_log.pop("ComputeResidualThread", "Solve");
 
     unsigned int n_threads = libMesh::n_threads();
     for (unsigned int i=0; i<n_threads; i++) // Add any cached residuals that might be hanging around
@@ -1268,17 +1262,13 @@ NonlinearSystem::computeResidualInternal(Moose::KernelType type)
 
   if (_need_residual_copy)
   {
-    Moose::perf_log.push("residual.close1()","Solve");
     residualVector(Moose::KT_NONTIME).close();
-    Moose::perf_log.pop("residual.close1()","Solve");
     residualVector(Moose::KT_NONTIME).localize(_residual_copy);
   }
 
   if (_need_residual_ghosted)
   {
-    Moose::perf_log.push("residual.close2()","Solve");
     residualVector(Moose::KT_NONTIME).close();
-    Moose::perf_log.pop("residual.close2()","Solve");
     _residual_ghosted = residualVector(Moose::KT_NONTIME);
     _residual_ghosted.close();
   }
@@ -1346,11 +1336,9 @@ NonlinearSystem::computeNodalBCs(NumericVector<Number> & residual)
   }
   PARALLEL_CATCH;
 
-  Moose::perf_log.push("residual.close4()","Solve");
   residual.close();
   residualVector(Moose::KT_TIME).close();
   residualVector(Moose::KT_NONTIME).close();
-  Moose::perf_log.pop("residual.close4()","Solve");
 }
 
 void
@@ -2033,7 +2021,7 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
 void
 NonlinearSystem::computeJacobian(SparseMatrix<Number> & jacobian)
 {
-  Moose::perf_log.push("compute_jacobian()","Solve");
+  Moose::perf_log.push("compute_jacobian()", "Execution");
 
   Moose::enableFPE();
 
@@ -2050,13 +2038,13 @@ NonlinearSystem::computeJacobian(SparseMatrix<Number> & jacobian)
 
   Moose::enableFPE(false);
 
-  Moose::perf_log.pop("compute_jacobian()","Solve");
+  Moose::perf_log.pop("compute_jacobian()", "Execution");
 }
 
 void
 NonlinearSystem::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks)
 {
-  Moose::perf_log.push("compute_jacobian_block()","Solve");
+  Moose::perf_log.push("compute_jacobian_block()", "Execution");
 
   Moose::enableFPE();
 
@@ -2160,7 +2148,7 @@ NonlinearSystem::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks)
 
   Moose::enableFPE(false);
 
-  Moose::perf_log.pop("compute_jacobian_block()","Solve");
+  Moose::perf_log.pop("compute_jacobian_block()", "Execution");
 }
 
 void
@@ -2183,7 +2171,7 @@ NonlinearSystem::updateActive(THREAD_ID tid)
 Real
 NonlinearSystem::computeDamping(const NumericVector<Number>& update)
 {
-  Moose::perf_log.push("compute_dampers()", "Solve");
+  Moose::perf_log.push("compute_dampers()", "Execution");
 
   // Default to no damping
   Real damping = 1.0;
@@ -2198,7 +2186,7 @@ NonlinearSystem::computeDamping(const NumericVector<Number>& update)
 
   _communicator.min(damping);
 
-  Moose::perf_log.pop("compute_dampers()", "Solve");
+  Moose::perf_log.pop("compute_dampers()", "Execution");
 
   return damping;
 }
@@ -2206,7 +2194,7 @@ NonlinearSystem::computeDamping(const NumericVector<Number>& update)
 void
 NonlinearSystem::computeDiracContributions(SparseMatrix<Number> * jacobian)
 {
-  Moose::perf_log.push("computeDiracContributions()","Solve");
+  Moose::perf_log.push("computeDiracContributions()", "Execution");
 
   _fe_problem.clearDiracInfo();
 
@@ -2239,14 +2227,10 @@ NonlinearSystem::computeDiracContributions(SparseMatrix<Number> * jacobian)
     cd(range);
   }
 
-  Moose::perf_log.pop("computeDiracContributions()","Solve");
-
   if (jacobian == NULL)
-  {
-    Moose::perf_log.push("residual.close3()","Solve");
     residualVector(Moose::KT_NONTIME).close();
-    Moose::perf_log.pop("residual.close3()","Solve");
-  }
+
+  Moose::perf_log.pop("computeDiracContributions()", "Execution");
 }
 
 NumericVector<Number> &

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -156,8 +156,6 @@ IntegratedBC::computeJacobian()
 void
 IntegratedBC::computeJacobianBlock(unsigned int jvar)
 {
-//  Moose::perf_log.push("computeJacobianBlock()","IntegratedBC");
-
   DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
 
   for (_qp=0; _qp<_qrule->n_points(); _qp++)
@@ -169,8 +167,6 @@ IntegratedBC::computeJacobianBlock(unsigned int jvar)
         else
           ke(_i,_j) += _JxW[_qp]*_coord[_qp]*computeQpOffDiagJacobian(jvar);
       }
-
-//  Moose::perf_log.pop("computeJacobianBlock()","IntegratedBC");
 }
 
 void

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -133,15 +133,11 @@ DGKernel::computeElemNeighResidual(Moose::DGResidualType type)
 void
 DGKernel::computeResidual()
 {
-//  Moose::perf_log.push("computeResidual()","DGKernel");
-
   // Compute the residual for this element
   computeElemNeighResidual(Moose::Element);
 
   // Compute the residual for the neighbor
   computeElemNeighResidual(Moose::Neighbor);
-
-//  Moose::perf_log.pop("computeResidual()","DGKernel");
 }
 
 void
@@ -166,8 +162,6 @@ DGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
 void
 DGKernel::computeJacobian()
 {
-//  Moose::perf_log.push("computeJacobian()","DGKernel");
-
   // Compute element-element Jacobian
   computeElemNeighJacobian(Moose::ElementElement);
 
@@ -179,8 +173,6 @@ DGKernel::computeJacobian()
 
   // Compute neighbor-neighbor Jacobian
   computeElemNeighJacobian(Moose::NeighborNeighbor);
-
-//  Moose::perf_log.pop("computeJacobian()","DGKernel");
 }
 
 void

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -123,8 +123,6 @@ EigenExecutionerBase::init()
   /* a time step check point */
   _problem.onTimestepEnd();
 
-  Moose::setup_perf_log.push("Output Initial Condition","Setup");
-
   // Write the initial.
   // Note: We need to tempararily change the system time to make the output system work properly.
   _problem.timeStep() = 0;
@@ -132,7 +130,6 @@ EigenExecutionerBase::init()
   _problem.time() = _problem.timeStep();
   _problem.outputStep(EXEC_INITIAL);
   _problem.time() = t;
-  Moose::setup_perf_log.pop("Output Initial Condition","Setup");
 }
 
 void

--- a/framework/src/executioners/Steady.C
+++ b/framework/src/executioners/Steady.C
@@ -63,9 +63,7 @@ Steady::init()
   checkIntegrity();
   _problem.initialSetup();
 
-  Moose::setup_perf_log.push("Output Initial Condition","Setup");
   _problem.outputStep(EXEC_INITIAL);
-  Moose::setup_perf_log.pop("Output Initial Condition","Setup");
 }
 
 void

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -189,9 +189,7 @@ Transient::init()
   if (_app.isRestarting())
     _time_old = _time;
 
-  Moose::setup_perf_log.push("Output Initial Condition","Setup");
   _problem.outputStep(EXEC_INITIAL);
-  Moose::setup_perf_log.pop("Output Initial Condition","Setup");
 
   // If this is the first step
   if (_t_step == 0)

--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -66,7 +66,7 @@ NearestNodeLocator::~NearestNodeLocator()
 void
 NearestNodeLocator::findNodes()
 {
-  Moose::perf_log.push("NearestNodeLocator::findNodes()","Solve");
+  Moose::perf_log.push("NearestNodeLocator::findNodes()", "Execution");
 
   /**
    * If this is the first time through we're going to build up a "neighborhood" of nodes
@@ -165,7 +165,7 @@ NearestNodeLocator::findNodes()
 
   _nearest_node_info = nnt._nearest_node_info;
 
-  Moose::perf_log.pop("NearestNodeLocator::findNodes()","Solve");
+  Moose::perf_log.pop("NearestNodeLocator::findNodes()", "Execution");
 }
 
 void

--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -75,7 +75,7 @@ PenetrationLocator::~PenetrationLocator()
 void
 PenetrationLocator::detectPenetration()
 {
-  Moose::perf_log.push("detectPenetration()","Solve");
+  Moose::perf_log.push("detectPenetration()", "Execution");
 
   // Data structures to hold the element boundary information
   std::vector<dof_id_type> elem_list;
@@ -109,7 +109,7 @@ PenetrationLocator::detectPenetration()
 
   Threads::parallel_reduce(slave_node_range, pt);
 
-  Moose::perf_log.pop("detectPenetration()","Solve");
+  Moose::perf_log.pop("detectPenetration()", "Execution");
 }
 
 void

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -63,7 +63,7 @@ FileMesh::buildMesh()
 {
   std::string _file_name = getParam<MeshFileName>("file");
 
-  Moose::setup_perf_log.push("Read Mesh","Setup");
+  Moose::perf_log.push("Read Mesh", "Setup");
   if (_is_nemesis)
   {
     // Nemesis_IO only takes a reference to ParallelMesh, so we can't be quite so short here.
@@ -100,7 +100,7 @@ FileMesh::buildMesh()
       getMesh().read(_file_name);
   }
 
-  Moose::setup_perf_log.pop("Read Mesh","Setup");
+  Moose::perf_log.pop("Read Mesh", "Setup");
 }
 
 void

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2038,8 +2038,6 @@ MooseMesh::ghostGhostedBoundaries()
   if (!_use_parallel_mesh)
     return;
 
-  Moose::perf_log.push("ghostGhostedBoundaries()","MooseMesh");
-
   std::vector<dof_id_type> elems;
   std::vector<unsigned short int> sides;
   std::vector<boundary_id_type> ids;
@@ -2081,8 +2079,6 @@ MooseMesh::ghostGhostedBoundaries()
 
   mesh.comm().allgather_packed_range(&mesh, connected_nodes_to_ghost.begin(), connected_nodes_to_ghost.end(), extra_ghost_elem_inserter<Node>(mesh));
   mesh.comm().allgather_packed_range(&mesh, boundary_elems_to_ghost.begin(), boundary_elems_to_ghost.end(), extra_ghost_elem_inserter<Elem>(mesh));
-
-  Moose::perf_log.pop("ghostGhostedBoundaries()","MooseMesh");
 }
 
 void

--- a/framework/src/outputs/CSV.C
+++ b/framework/src/outputs/CSV.C
@@ -90,6 +90,9 @@ CSV::outputVectorPostprocessors()
 void
 CSV::output(const ExecFlagType & type)
 {
+  // Start the performance log
+  Moose::perf_log.push("CSV::output()", "Output");
+
   // Call the base class output (populates tables)
   TableOutput::output(type);
 
@@ -114,4 +117,6 @@ CSV::output(const ExecFlagType & type)
   // Re-set write flags
   _write_all_table = false;
   _write_vector_table = false;
+
+  Moose::perf_log.pop("CSV::output()", "Output");
 }

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -84,7 +84,7 @@ void
 Checkpoint::output(const ExecFlagType & /*type*/)
 {
   // Start the performance log
-  Moose::perf_log.push("output()", "Checkpoint");
+  Moose::perf_log.push("Checkpoint::output()", "Output");
 
   // Create the output directory
   std::string cp_dir = directory();
@@ -129,7 +129,7 @@ Checkpoint::output(const ExecFlagType & /*type*/)
   updateCheckpointFiles(current_file_struct);
 
   // Stop the logging
-  Moose::perf_log.pop("output()", "Checkpoint");
+  Moose::perf_log.pop("Checkpoint::output()", "Output");
 }
 
 void

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -282,7 +282,7 @@ Exodus::output(const ExecFlagType & type)
     return;
 
   // Start the performance log
-  Moose::perf_log.push("output()", "Exodus");
+  Moose::perf_log.push("Exodus::output()", "Output");
 
   // Prepare the ExodusII_IO object
   outputSetup();
@@ -317,7 +317,7 @@ Exodus::output(const ExecFlagType & type)
   _exodus_mesh_changed = false;
 
   // Stop the logging
-  Moose::perf_log.pop("output()", "Exodus");
+  Moose::perf_log.pop("Exodus::output()", "Output");
 }
 
 std::string

--- a/framework/src/postprocessors/PerformanceData.C
+++ b/framework/src/postprocessors/PerformanceData.C
@@ -39,7 +39,7 @@ PerformanceData::PerformanceData(const InputParameters & parameters) :
 Real
 PerformanceData::getValue()
 {
-  PerfData perf_data = Moose::perf_log.get_perf_data(_event, "Solve");
+  PerfData perf_data = Moose::perf_log.get_perf_data(_event, "Execution");
   double total_time = Moose::perf_log.get_active_time();
 
   if (perf_data.count == 0)
@@ -62,4 +62,3 @@ PerformanceData::getValue()
 
   mooseError("Invalid column!");
 }
-

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -165,7 +165,7 @@ PhysicsBasedPreconditioner::addSystem(unsigned int var, std::vector<unsigned int
 void
 PhysicsBasedPreconditioner::init ()
 {
-  Moose::perf_log.push("init()","PhysicsBasedPreconditioner");
+  Moose::perf_log.push("init()", "PhysicsBasedPreconditioner");
 
   // Tell libMesh that this is initialized!
   _is_initialized = true;
@@ -196,7 +196,7 @@ PhysicsBasedPreconditioner::init ()
     preconditioner->init();
   }
 
-  Moose::perf_log.pop("init()","PhysicsBasedPreconditioner");
+  Moose::perf_log.pop("init()", "PhysicsBasedPreconditioner");
 }
 
 void
@@ -236,7 +236,7 @@ PhysicsBasedPreconditioner::setup()
 void
 PhysicsBasedPreconditioner::apply(const NumericVector<Number> & x, NumericVector<Number> & y)
 {
-  Moose::perf_log.push("apply()","PhysicsBasedPreconditioner");
+  Moose::perf_log.push("apply()", "PhysicsBasedPreconditioner");
 
   const unsigned int num_systems = _systems.size();
 
@@ -297,11 +297,10 @@ PhysicsBasedPreconditioner::apply(const NumericVector<Number> & x, NumericVector
 
   y.close();
 
-  Moose::perf_log.pop("apply()","PhysicsBasedPreconditioner");
+  Moose::perf_log.pop("apply()", "PhysicsBasedPreconditioner");
 }
 
 void
 PhysicsBasedPreconditioner::clear ()
 {
 }
-

--- a/framework/src/restart/Resurrector.C
+++ b/framework/src/restart/Resurrector.C
@@ -44,19 +44,19 @@ Resurrector::setRestartFile(const std::string & file_base)
 void
 Resurrector::restartFromFile()
 {
-  Moose::setup_perf_log.push("restartFromFile()","Resurrector");
+  Moose::perf_log.push("restartFromFile()", "Setup");
   std::string file_name(_restart_file_base + ".xdr");
   MooseUtils::checkFileReadable(file_name);
   _restartable.readRestartableDataHeader(_restart_file_base + RESTARTABLE_DATA_EXT);
   _fe_problem._eq.read(file_name, DECODE, EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA, _fe_problem.adaptivity().isOn());
   _fe_problem._nl.update();
-  Moose::setup_perf_log.pop("restartFromFile()","Resurrector");
+  Moose::perf_log.pop("restartFromFile()", "Setup");
 }
 
 void
 Resurrector::restartRestartableData()
 {
-  Moose::setup_perf_log.push("restartRestartableData()","Resurrector");
+  Moose::perf_log.push("restartRestartableData()", "Setup");
   _restartable.readRestartableData(_fe_problem.getMooseApp().getRestartableData(), _fe_problem.getMooseApp().getRecoverableData());
-  Moose::setup_perf_log.pop("restartRestartableData()","Resurrector");
+  Moose::perf_log.pop("restartRestartableData()", "Setup");
 }

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -63,15 +63,6 @@
     file_expect_out = 'Moose\sTest\sPerformance:'
     recover = false
   [../]
-  [./file_setup_log]
-    # Test that file contains regex
-    type = CheckFiles
-    input = 'console.i'
-    cli_args = 'Outputs/screen/output_file=true Outputs/screen/setup_log=true Outputs/screen/file_base=console_file_setup_log_out'
-    check_files = 'console_file_setup_log_out.txt'
-    file_expect_out = 'Setup\sPerformance:'
-    recover = false
-  [../]
   [./norms]
     # Test that the variable norms are being output
     type = RunApp


### PR DESCRIPTION
refs #6300 

This first cut at this does several things. First, it does away with the setup log. I really don't think it's useful to use two logs. If we really want the ability to print the perf_log early we can simply print the contents of the regular log early. In fact this might be a useful feature. I often run long simulations that I kill before they reach the end so I don't get a perf_log. It would be handy to have a feature for printing the perf_log every <n> iterations. I'll open a ticket for that but the setup log should be killed.

Next I try to categorize the events into fewer main categories: "Setup and Execution". Almost every operation should fit into one of those two general categories. There's also an "Application" category which currently has a single entry called "Full Runtime". This should basically capture nearly all of the runtime of the simulation as it completely wraps the main entry call `MooseApp::run()`. There will be other categories like "Utility" and maybe even named objects "GrainTracker" for breaking down the runtime of heavy objects. The former "solve" event is still there and you can see that even for simple diffusion it doesn't even capture the full runtime. It's time to be honest with ourselves about the full cost of running MOOSE. It's how we'll get better.

Here is a sample log from running simple diffusion with four refinements:

```
 -------------------------------------------------------------------------------------------------------------------------
| Moose Test Performance: Alive time=21.6534, Active time=21.5612                                                         |
 -------------------------------------------------------------------------------------------------------------------------
| Event                                      nCalls     Total Time  Avg Time    Total Time  Avg Time    % of Active Time  |
|                                                       w/o Sub     w/o Sub     With Sub    With Sub    w/o S    With S   |
|-------------------------------------------------------------------------------------------------------------------------|
|                                                                                                                         |
|                                                                                                                         |
| Application                                                                                                             |
|   Full Runtime                             1          0.2820      0.282008    21.5612     21.561228   1.31     100.00   |
|                                                                                                                         |
| Execution                                                                                                               |
|   computeAuxiliaryKernels()                2          0.0000      0.000002    0.0000      0.000002    0.00     0.00     |
|   computeControls()                        2          0.0000      0.000004    0.0000      0.000004    0.00     0.00     |
|   computeDiracContributions()              18         0.0007      0.000037    0.0007      0.000037    0.00     0.00     |
|   computeUserObjects()                     4          0.0000      0.000003    0.0000      0.000003    0.00     0.00     |
|   compute_jacobian()                       2          2.3852      1.192620    2.3853      1.192627    11.06    11.06    |
|   compute_residual()                       16         14.9632     0.935203    14.9639     0.935245    69.40    69.40    |
|   solve()                                  1          0.0907      0.090683    17.4399     17.439857   0.42     80.89    |
|                                                                                                                         |
| Output                                                                                                                  |
|   Exodus::output()                         2          0.6537      0.326832    0.6537      0.326832    3.03     3.03     |
|                                                                                                                         |
| Setup                                                                                                                   |
|   Application Setup                        1          1.0670      1.066983    2.3424      2.342363    4.95     10.86    |
|   FEProblem::init::meshChanged()           1          0.0983      0.098294    0.0983      0.098294    0.46     0.46     |
|   Initial updateActiveSemiLocalNodeRange() 1          0.0270      0.027044    0.0270      0.027044    0.13     0.13     |
|   Initial updateGeomSearch()               2          0.0000      0.000005    0.0000      0.000005    0.00     0.00     |
|   NonlinearSystem::update()                1          0.0001      0.000085    0.0001      0.000085    0.00     0.00     |
|   eq.init()                                1          1.1770      1.177001    1.1770      1.177001    5.46     5.46     |
|   execMultiApps()                          1          0.0000      0.000013    0.0000      0.000013    0.00     0.00     |
|   execTransfers()                          1          0.0000      0.000003    0.0000      0.000003    0.00     0.00     |
|   initial adaptivity                       1          0.0000      0.000003    0.0000      0.000003    0.00     0.00     |
|   initialSetup()                           1          0.1354      0.135360    0.8433      0.843308    0.63     3.91     |
|   reinit() after updateGeomSearch()        1          0.0000      0.000003    0.0000      0.000003    0.00     0.00     |
|                                                                                                                         |
| Utility                                                                                                                 |
|   projectSolution()                        1          0.6809      0.680868    0.6809      0.680868    3.16     3.16     |
 -------------------------------------------------------------------------------------------------------------------------
| Totals:                                    61         21.5612                                         100.00            |
 -------------------------------------------------------------------------------------------------------------------------
```

@idaholab/moose-developers, I'd like some feed back on this. 
