### PR TITLE
Adding packed range specializations for dataLoad/dataStore

### DIFF
--- a/test/include/userobjects/RestartableTypesChecker.h
+++ b/test/include/userobjects/RestartableTypesChecker.h
@@ -38,6 +38,9 @@ public:
   virtual void initialize() {};
   virtual void execute();
   virtual void finalize() {};
+
+  void checkData();
+  void clearTypes();
 };
 
 

--- a/test/tests/restart/restartable_types/tests
+++ b/test/tests/restart/restartable_types/tests
@@ -12,4 +12,21 @@
     prereq = first
     recover = false
   [../]
+
+  [./first_parallel]
+    type = 'RunApp'
+    input = 'restartable_types.i'
+    recover = false
+    min_parallel = 2
+    prereq = second
+  [../]
+
+  [./second_parallel]
+    # Using RunApp here because the error checking happens _in_ the app
+    type = 'RunApp'
+    input = 'restartable_types2.i'
+    prereq = first_parallel
+    min_parallel = 2
+    recover = false
+  [../]
 []


### PR DESCRIPTION
Adding the std::string specializations so that packed strings
can be communicated and restored using existing MOOSE backup
routines.

closes #6311 

ping @dschwen 
