### PR TITLE
delete_trailing_whitespace.sh changes

### DIFF
--- a/scripts/delete_trailing_whitespace.sh
+++ b/scripts/delete_trailing_whitespace.sh
@@ -7,5 +7,12 @@ REPO_DIR=${1:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"}
 if [ ! -d "$REPO_DIR" ]; then
   echo "$REPO_DIR directory does not exist";
 else
-  find $REPO_DIR -path ./contrib -prune -o -path ./libmesh -prune -o \( -name "*.[Chi]" -o -name "*.py" \) -type f -print0 | xargs -0 perl -pli -e "s/\s+$//"
+  bad_files=$(find $REPO_DIR -path ./contrib -prune -o -path ./libmesh -prune -o \( -name "*.[Chi]" -o -name "*.py" \) -type f -print0 | xargs -0 grep -l "[[:blank:]]$")
+  if [ "$bad_files" != "" ]; then
+    # do it like this to split on new lines. This preserves files with spaces in their names.
+    while read -r line; do
+      echo "Fixing: $line"
+      perl -pli -e "s/\s+$//" "$line"
+    done <<< "$bad_files"
+  fi
 fi


### PR DESCRIPTION
The 'perl -pli' that we were using essentially rewrote all the files which updated the timestamp
and also "fixed" files with no newline before EOF. Updating the timestamp means that a complete
recompile is required after running the script.
This change makes it only update files that have trailing whitespace.

In reference to #6332, this means delete_trailing_whitespace.sh is at least consistent with the pre check. 
