### PR TITLE
Make scalar coupleable return the scalar variable order

### DIFF
--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -18,9 +18,6 @@
 #include "MooseVariableBase.h"
 #include "ParallelUniqueId.h"
 
-// libMesh includes
-#include "libmesh/fe_type.h"
-
 // Forward declarations
 class Assembly;
 class SubProblem;
@@ -74,16 +71,6 @@ public:
    * @return true if active on subdomain, false otherwise
    */
   bool activeOnSubdomain(SubdomainID subdomain) const;
-
-  /**
-   * Get the type of finite element object
-   */
-  const FEType feType() const { return _fe_type; }
-
-  /**
-   * Get the order of this variable
-   */
-  Order getOrder() const { return _fe_type.order; }
 
   /**
    * Is this variable nodal
@@ -313,8 +300,6 @@ protected:
 protected:
   /// Thread ID
   THREAD_ID _tid;
-  /// The FEType associated with this variable
-  FEType _fe_type;
 
   /// Quadrature rule for interior
   QBase * & _qrule;

--- a/framework/include/base/MooseVariableBase.h
+++ b/framework/include/base/MooseVariableBase.h
@@ -21,6 +21,7 @@
 // libMesh includes
 #include "libmesh/tensor_value.h"
 #include "libmesh/vector_value.h"
+#include "libmesh/fe_type.h"
 
 // libMesh forward declarations
 namespace libMesh
@@ -49,7 +50,7 @@ class SystemBase;
 class MooseVariableBase
 {
 public:
-  MooseVariableBase(unsigned int var_num, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind);
+  MooseVariableBase(unsigned int var_num, const FEType & fe_type, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind);
   virtual ~MooseVariableBase();
 
   /**
@@ -57,6 +58,11 @@ public:
    * @return the libmesh variable number
    */
   unsigned int number() const { return _var_num; }
+
+  /**
+   * Get the type of finite element object
+   */
+  const FEType & feType() const { return _fe_type; }
 
   /**
    * Get the system this variable is part of.
@@ -85,8 +91,9 @@ public:
 
   /**
    * Get the order of this variable
+   * Note: Order enum can be implicitly converted to unsigned int.
    */
-  unsigned int order() const;
+  Order order() const;
 
   /**
    * The DofMap associated with the system this variable is in.
@@ -106,6 +113,8 @@ public:
 protected:
   /// variable number (from libMesh)
   unsigned int _var_num;
+  /// The FEType associated with this variable
+  FEType _fe_type;
   /// variable number within MOOSE
   unsigned int _index;
   Moose::VarKindType _var_kind;

--- a/framework/include/base/MooseVariableScalar.h
+++ b/framework/include/base/MooseVariableScalar.h
@@ -30,7 +30,7 @@ template <typename T> class NumericVector;
 class MooseVariableScalar : public MooseVariableBase
 {
 public:
-  MooseVariableScalar(unsigned int var_num, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind);
+  MooseVariableScalar(unsigned int var_num, const FEType & fe_type, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind);
   virtual ~MooseVariableScalar();
 
   void reinit();
@@ -58,7 +58,6 @@ public:
   void insert(NumericVector<Number> & soln);
 
 protected:
-  bool _has_value;
   /// The value of scalar variable
   VariableValue _u;
   /// The old value of scalar variable

--- a/framework/include/base/ScalarCoupleable.h
+++ b/framework/include/base/ScalarCoupleable.h
@@ -67,6 +67,14 @@ protected:
   virtual unsigned int coupledScalar(const std::string & var_name, unsigned int comp = 0);
 
   /**
+   * Returns the order for a scalar coupled variable by name
+   * @param var_name Name of coupled variable
+   * @param comp Component number for vector of coupled variables
+   * @return Order of coupled variable
+   */
+  virtual Order coupledScalarOrder(const std::string & var_name, unsigned int comp = 0);
+
+  /**
    * Returns value of a scalar coupled variable
    * @param var_name Name of coupled variable
    * @param comp Component number for vector of coupled variables

--- a/framework/include/base/SystemBase.h
+++ b/framework/include/base/SystemBase.h
@@ -440,6 +440,7 @@ public:
     unsigned int var_num = _sys.add_variable(var_name, type, active_subdomains);
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
     {
+      //FIXME: we cannot refer fetype in libMesh at this point, so we will just make a copy in MooseVariableBase.
       MooseVariable * var = new MooseVariable(var_num, type, *this, _subproblem.assembly(tid), _var_kind);
       var->scalingFactor(scale_factor);
       _vars[tid].add(var_name, var);
@@ -463,7 +464,8 @@ public:
     unsigned int var_num = _sys.add_variable(var_name, type, active_subdomains);
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
     {
-      MooseVariableScalar * var = new MooseVariableScalar(var_num, *this, _subproblem.assembly(tid), _var_kind);
+      //FIXME: we cannot refer fetype in libMesh at this point, so we will just make a copy in MooseVariableBase.
+      MooseVariableScalar * var = new MooseVariableScalar(var_num, type, *this, _subproblem.assembly(tid), _var_kind);
       var->scalingFactor(scale_factor);
       _vars[tid].add(var_name, var);
     }

--- a/framework/src/auxkernels/GapValueAux.C
+++ b/framework/src/auxkernels/GapValueAux.C
@@ -56,7 +56,7 @@ GapValueAux::GapValueAux(const InputParameters & parameters) :
   if (parameters.isParamValid("normal_smoothing_method"))
     _penetration_locator.setNormalSmoothingMethod(parameters.get<std::string>("normal_smoothing_method"));
 
-  Order pairedVarOrder(_moose_var.getOrder());
+  Order pairedVarOrder(_moose_var.order());
   Order gvaOrder(Utility::string_to_enum<Order>(parameters.get<MooseEnum>("order")));
   if (pairedVarOrder != gvaOrder && pairedVarOrder != CONSTANT)
     mooseError("ERROR: specified order for GapValueAux ("<<Utility::enum_to_string<Order>(gvaOrder)

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -28,8 +28,7 @@
 #include "libmesh/dense_vector.h"
 
 MooseVariable::MooseVariable(unsigned int var_num, const FEType & fe_type, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind) :
-    MooseVariableBase(var_num, sys, assembly, var_kind),
-    _fe_type(fe_type),
+    MooseVariableBase(var_num, fe_type, sys, assembly, var_kind),
 
     _qrule(_assembly.qRule()),
     _qrule_face(_assembly.qRuleFace()),

--- a/framework/src/base/MooseVariableBase.C
+++ b/framework/src/base/MooseVariableBase.C
@@ -23,8 +23,9 @@
 #include "libmesh/dof_map.h"
 
 
-MooseVariableBase::MooseVariableBase(unsigned int var_num, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind) :
+MooseVariableBase::MooseVariableBase(unsigned int var_num, const FEType & fe_type, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind) :
     _var_num(var_num),
+    _fe_type(fe_type),
     _var_kind(var_kind),
     _subproblem(sys.subproblem()),
     _sys(sys),
@@ -45,9 +46,9 @@ MooseVariableBase::name() const
   return _sys.system().variable(_var_num).name();
 }
 
-unsigned int
+Order
 MooseVariableBase::order() const
 {
-  return static_cast<unsigned int>(_sys.system().variable_type(_var_num).order);
+  return _fe_type.order;
 }
 

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -24,8 +24,8 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/dof_map.h"
 
-MooseVariableScalar::MooseVariableScalar(unsigned int var_num, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind) :
-    MooseVariableBase(var_num, sys, assembly, var_kind)
+MooseVariableScalar::MooseVariableScalar(unsigned int var_num, const FEType & fe_type, SystemBase & sys, Assembly & assembly, Moose::VarKindType var_kind) :
+    MooseVariableBase(var_num, fe_type, sys, assembly, var_kind)
 {
 }
 

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -75,7 +75,13 @@ ScalarCoupleable::isCoupledScalar(const std::string & var_name, unsigned int i)
   if (it != _coupled_scalar_vars.end())
     return (i < it->second.size());
   else
+  {
+    // Make sure the user originally requested this value in the InputParameter syntax
+    if (!_coupleable_params.hasCoupledValue(var_name))
+      mooseError("The coupled scalar variable \"" << var_name << "\" was never added to this objects's InputParameters, please double-check your spelling");
+
     return false;
+  }
 }
 
 unsigned int

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -90,6 +90,15 @@ ScalarCoupleable::coupledScalar(const std::string & var_name, unsigned int comp)
   return getScalarVar(var_name, comp)->number();
 }
 
+Order
+ScalarCoupleable::coupledScalarOrder(const std::string & var_name, unsigned int comp)
+{
+  if (!isCoupledScalar(var_name, comp))
+    return _sc_fe_problem.getMaxScalarOrder();
+
+  return getScalarVar(var_name, comp)->order();
+}
+
 VariableValue *
 ScalarCoupleable::getDefaultValue(const std::string & var_name)
 {

--- a/framework/src/bcs/DGFunctionDiffusionDirichletBC.C
+++ b/framework/src/bcs/DGFunctionDiffusionDirichletBC.C
@@ -42,7 +42,7 @@ DGFunctionDiffusionDirichletBC::DGFunctionDiffusionDirichletBC(const InputParame
 Real
 DGFunctionDiffusionDirichletBC::computeQpResidual()
 {
-  const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+  const unsigned int elem_b_order = _var.order();
   const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 
   Real fn = _func.value(_t, _q_point[_qp]);
@@ -57,7 +57,7 @@ DGFunctionDiffusionDirichletBC::computeQpResidual()
 Real
 DGFunctionDiffusionDirichletBC::computeQpJacobian()
 {
-  const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+  const unsigned int elem_b_order = _var.order();
   const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 
   Real r = 0;

--- a/framework/src/dgkernels/DGDiffusion.C
+++ b/framework/src/dgkernels/DGDiffusion.C
@@ -38,7 +38,7 @@ DGDiffusion::computeQpResidual(Moose::DGResidualType type)
 {
   Real r = 0;
 
-  const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+  const unsigned int elem_b_order = _var.order();
   const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 
   switch (type)
@@ -66,7 +66,7 @@ DGDiffusion::computeQpJacobian(Moose::DGJacobianType type)
 {
   Real r = 0;
 
-  const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+  const unsigned int elem_b_order = _var.order();
   const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 
   switch (type)

--- a/test/src/auxkernels/CoupledScalarAux.C
+++ b/test/src/auxkernels/CoupledScalarAux.C
@@ -31,6 +31,8 @@ CoupledScalarAux::CoupledScalarAux(const InputParameters & parameters) :
     _coupled_val(coupledScalarValue("coupled")),
     _component(getParam<unsigned int>("component"))
 {
+  if (_component >= coupledScalarOrder("coupled"))
+    mooseError("component is higher than or equal to the scalar variable order");
 }
 
 Real

--- a/test/src/bcs/DGMDDBC.C
+++ b/test/src/bcs/DGMDDBC.C
@@ -41,7 +41,7 @@ DGMDDBC::DGMDDBC(const InputParameters & parameters) :
 Real
 DGMDDBC::computeQpResidual()
 {
-  const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+  const unsigned int elem_b_order = _var.order();
   const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 
   Real fn = _func.value(_t, _q_point[_qp]);
@@ -56,7 +56,7 @@ DGMDDBC::computeQpResidual()
 Real
 DGMDDBC::computeQpJacobian()
 {
-  const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+  const unsigned int elem_b_order = _var.order();
   const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 
   Real r = 0;

--- a/test/src/dgkernels/DGMatDiffusion.C
+++ b/test/src/dgkernels/DGMatDiffusion.C
@@ -42,7 +42,7 @@ DGMatDiffusion::computeQpResidual(Moose::DGResidualType type)
 {
   Real r = 0;
 
-  const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+  const unsigned int elem_b_order = _var.order();
   const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 
   switch (type)
@@ -68,7 +68,7 @@ DGMatDiffusion::computeQpJacobian(Moose::DGJacobianType type)
 {
   Real r = 0;
 
-  const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+  const unsigned int elem_b_order = _var.order();
   const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 
   switch (type)


### PR DESCRIPTION
Close  #6376.

BTW, a new accessor `MooseVariableScalar::getOrder()` is added in line of `MooseVariable`. It is actually duplicating `MooseVariableBase::order()`. But I am not removing the later because I am afraid that it could have impact on the framework or modules or applications which could be using it.
