### PR TITLE
Remove unused members and provide default initialize

### DIFF
--- a/framework/include/userobject/DiscreteElementUserObject.h
+++ b/framework/include/userobject/DiscreteElementUserObject.h
@@ -30,6 +30,8 @@ class DiscreteElementUserObject :
 public:
   DiscreteElementUserObject(const InputParameters & parameters);
 
+  virtual void initialize();
+
   /// @{ Block all methods that are not used in explicitly called UOs
   virtual void execute(); // libmesh_final;
   virtual void finalize(); // libmesh_final;

--- a/framework/src/userobject/DiscreteElementUserObject.C
+++ b/framework/src/userobject/DiscreteElementUserObject.C
@@ -32,6 +32,11 @@ DiscreteElementUserObject::DiscreteElementUserObject(const InputParameters & par
 }
 
 void
+DiscreteElementUserObject::initialize()
+{
+}
+
+void
 DiscreteElementUserObject::execute()
 {
   mooseError("DiscreteElementUserObjects must be called explicitly from Materials");

--- a/modules/tensor_mechanics/include/userobjects/CrystalPlasticityUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/CrystalPlasticityUOBase.h
@@ -22,8 +22,6 @@ class CrystalPlasticityUOBase : public DiscreteElementUserObject
  public:
   CrystalPlasticityUOBase(const InputParameters & parameters);
 
-  void initialize() {}
-
   /// Returns the size of variable
   virtual unsigned int variableSize() const;
 

--- a/modules/tensor_mechanics/include/userobjects/CrystalPlasticityUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/CrystalPlasticityUOBase.h
@@ -22,12 +22,7 @@ class CrystalPlasticityUOBase : public DiscreteElementUserObject
  public:
   CrystalPlasticityUOBase(const InputParameters & parameters);
 
-  virtual ~CrystalPlasticityUOBase() {}
-
   void initialize() {}
-  void execute() {}
-  void finalize() {}
-  void threadJoin(const UserObject &) {}
 
   /// Returns the size of variable
   virtual unsigned int variableSize() const;

--- a/modules/tensor_mechanics/include/userobjects/HEVPEqvPlasticStrain.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPEqvPlasticStrain.h
@@ -22,7 +22,6 @@ class HEVPEqvPlasticStrain : public HEVPInternalVarUOBase
 {
 public:
   HEVPEqvPlasticStrain(const InputParameters & parameters);
-  virtual ~HEVPEqvPlasticStrain() {}
 
   virtual bool computeValue(unsigned int, Real, Real &) const;
   virtual bool computeDerivative(unsigned int, Real, const std::string &, Real &) const;

--- a/modules/tensor_mechanics/include/userobjects/HEVPEqvPlasticStrainRate.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPEqvPlasticStrainRate.h
@@ -22,7 +22,6 @@ class HEVPEqvPlasticStrainRate : public HEVPInternalVarRateUOBase
 {
 public:
   HEVPEqvPlasticStrainRate(const InputParameters & parameters);
-  virtual ~HEVPEqvPlasticStrainRate() {}
 
   virtual bool computeValue(unsigned int, Real &) const;
   virtual bool computeDerivative(unsigned int, const std::string &, Real &) const;

--- a/modules/tensor_mechanics/include/userobjects/HEVPFlowRatePowerLawJ2.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPFlowRatePowerLawJ2.h
@@ -23,7 +23,6 @@ class HEVPFlowRatePowerLawJ2 : public HEVPFlowRateUOBase
 {
 public:
   HEVPFlowRatePowerLawJ2(const InputParameters & parameters);
-  virtual ~HEVPFlowRatePowerLawJ2() {}
 
   virtual bool computeValue(unsigned int, Real &) const;
   virtual bool computeDirection(unsigned int, RankTwoTensor &) const;

--- a/modules/tensor_mechanics/include/userobjects/HEVPFlowRateUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPFlowRateUOBase.h
@@ -24,12 +24,8 @@ class HEVPFlowRateUOBase : public DiscreteElementUserObject
 {
 public:
   HEVPFlowRateUOBase(const InputParameters & parameters);
-  virtual ~HEVPFlowRateUOBase() {}
 
   void initialize() {}
-  void execute() {}
-  void finalize() {}
-  void threadJoin(const UserObject &) {}
 
   virtual bool computeValue(unsigned int, Real &) const = 0;
   virtual bool computeDirection(unsigned int, RankTwoTensor &) const = 0;

--- a/modules/tensor_mechanics/include/userobjects/HEVPFlowRateUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPFlowRateUOBase.h
@@ -25,8 +25,6 @@ class HEVPFlowRateUOBase : public DiscreteElementUserObject
 public:
   HEVPFlowRateUOBase(const InputParameters & parameters);
 
-  void initialize() {}
-
   virtual bool computeValue(unsigned int, Real &) const = 0;
   virtual bool computeDirection(unsigned int, RankTwoTensor &) const = 0;
   virtual bool computeDerivative(unsigned int, const std::string &, Real &) const = 0;

--- a/modules/tensor_mechanics/include/userobjects/HEVPInternalVarRateUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPInternalVarRateUOBase.h
@@ -23,12 +23,8 @@ class HEVPInternalVarRateUOBase : public DiscreteElementUserObject
 {
 public:
   HEVPInternalVarRateUOBase(const InputParameters & parameters);
-  virtual ~HEVPInternalVarRateUOBase() {}
 
   void initialize() {}
-  void execute() {}
-  void finalize() {}
-  void threadJoin(const UserObject &) {}
 
   virtual bool computeValue(unsigned int, Real &) const = 0;
   virtual bool computeDerivative(unsigned int, const std::string &, Real &) const = 0;

--- a/modules/tensor_mechanics/include/userobjects/HEVPInternalVarRateUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPInternalVarRateUOBase.h
@@ -24,8 +24,6 @@ class HEVPInternalVarRateUOBase : public DiscreteElementUserObject
 public:
   HEVPInternalVarRateUOBase(const InputParameters & parameters);
 
-  void initialize() {}
-
   virtual bool computeValue(unsigned int, Real &) const = 0;
   virtual bool computeDerivative(unsigned int, const std::string &, Real &) const = 0;
 

--- a/modules/tensor_mechanics/include/userobjects/HEVPInternalVarUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPInternalVarUOBase.h
@@ -25,8 +25,6 @@ class HEVPInternalVarUOBase : public DiscreteElementUserObject
 public:
   HEVPInternalVarUOBase(const InputParameters & parameters);
 
-  void initialize() {}
-
   virtual bool computeValue(unsigned int, Real, Real &) const = 0;
   virtual bool computeDerivative(unsigned int, Real, const std::string &, Real &) const = 0;
 

--- a/modules/tensor_mechanics/include/userobjects/HEVPInternalVarUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPInternalVarUOBase.h
@@ -24,12 +24,8 @@ class HEVPInternalVarUOBase : public DiscreteElementUserObject
 {
 public:
   HEVPInternalVarUOBase(const InputParameters & parameters);
-  virtual ~HEVPInternalVarUOBase() {}
 
   void initialize() {}
-  void execute() {}
-  void finalize() {}
-  void threadJoin(const UserObject &) {}
 
   virtual bool computeValue(unsigned int, Real, Real &) const = 0;
   virtual bool computeDerivative(unsigned int, Real, const std::string &, Real &) const = 0;

--- a/modules/tensor_mechanics/include/userobjects/HEVPLinearHardening.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPLinearHardening.h
@@ -22,7 +22,6 @@ class HEVPLinearHardening : public HEVPStrengthUOBase
 {
 public:
   HEVPLinearHardening(const InputParameters & parameters);
-  virtual ~HEVPLinearHardening() {}
 
   virtual bool computeValue(unsigned int, Real &) const;
   virtual bool computeDerivative(unsigned int, const std::string &, Real &) const;

--- a/modules/tensor_mechanics/include/userobjects/HEVPRambergOsgoodHardening.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPRambergOsgoodHardening.h
@@ -22,7 +22,6 @@ class HEVPRambergOsgoodHardening : public HEVPStrengthUOBase
 {
 public:
   HEVPRambergOsgoodHardening(const InputParameters & parameters);
-  virtual ~HEVPRambergOsgoodHardening() {}
 
   virtual bool computeValue(unsigned int, Real &) const;
   virtual bool computeDerivative(unsigned int, const std::string &, Real &) const;

--- a/modules/tensor_mechanics/include/userobjects/HEVPStrengthUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPStrengthUOBase.h
@@ -24,8 +24,6 @@ class HEVPStrengthUOBase : public DiscreteElementUserObject
 public:
   HEVPStrengthUOBase(const InputParameters & parameters);
 
-  void initialize() {}
-
   virtual bool computeValue(unsigned int, Real &) const = 0;
   virtual bool computeDerivative(unsigned int, const std::string &, Real &) const = 0;
 

--- a/modules/tensor_mechanics/include/userobjects/HEVPStrengthUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPStrengthUOBase.h
@@ -23,12 +23,8 @@ class HEVPStrengthUOBase : public DiscreteElementUserObject
 {
 public:
   HEVPStrengthUOBase(const InputParameters & parameters);
-  virtual ~HEVPStrengthUOBase() {}
 
   void initialize() {}
-  void execute() {}
-  void finalize() {}
-  void threadJoin(const UserObject &) {}
 
   virtual bool computeValue(unsigned int, Real &) const = 0;
   virtual bool computeDerivative(unsigned int, const std::string &, Real &) const = 0;


### PR DESCRIPTION
This removes members that will be marked as `final` and should _not_ be overwritten.

Closes #6393
