### PR TITLE
Make test and modules code work with upcoming const interface changes.

### DIFF
--- a/modules/chemical_reactions/include/auxkernels/AqueousEquilibriumRxnAux.h
+++ b/modules/chemical_reactions/include/auxkernels/AqueousEquilibriumRxnAux.h
@@ -49,7 +49,7 @@ protected:
   std::vector<Real> _sto_v;
 
   /// Coupled primary species
-  std::vector<VariableValue *>  _vals;
+  std::vector<const VariableValue *>  _vals;
 };
 
 #endif //AQUEOUSEQUILIBRIUMRXNAUX_H

--- a/modules/chemical_reactions/include/auxkernels/KineticDisPreConcAux.h
+++ b/modules/chemical_reactions/include/auxkernels/KineticDisPreConcAux.h
@@ -61,7 +61,7 @@ protected:
   std::vector<Real> _sto_v;
 
   /// Coupled primary species concentrations
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
 };
 
 #endif //KINETICDISPRECONCAUX_H

--- a/modules/chemical_reactions/include/auxkernels/KineticDisPreRateAux.h
+++ b/modules/chemical_reactions/include/auxkernels/KineticDisPreRateAux.h
@@ -36,7 +36,7 @@ protected:
   Real _log_k,_r_area,_ref_kconst,_e_act,_gas_const,_ref_temp,_sys_temp;
   std::vector<Real> _sto_v;
 
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
 };
 
 #endif //KINETICDISPRERATEAUX_H

--- a/modules/chemical_reactions/include/kernels/CoupledBEEquilibriumSub.h
+++ b/modules/chemical_reactions/include/kernels/CoupledBEEquilibriumSub.h
@@ -78,10 +78,10 @@ private:
 
   std::vector<unsigned int> _vars;
   /// Coupled primary species concentrations.
-  std::vector<VariableValue *> _v_vals;
+  std::vector<const VariableValue *> _v_vals;
   /// Coupled old values of primary species concentrations.
-  std::vector<VariableValue *> _v_vals_old;
+  std::vector<const VariableValue *> _v_vals_old;
   /// The old values of the primary species concentration.
-  VariableValue & _u_old;
+  const VariableValue & _u_old;
 };
 #endif //COUPLEDBEEQUILIBRIUMSUB_H

--- a/modules/chemical_reactions/include/kernels/CoupledBEKinetic.h
+++ b/modules/chemical_reactions/include/kernels/CoupledBEKinetic.h
@@ -57,8 +57,8 @@ private:
   std::vector<Real> _weight;
 //  std::vector<unsigned int> _vars;
   /// Coupled kinetic mineral concentrations.
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
   /// Coupled old values of kinetic mineral concentrations.
-  std::vector<VariableValue *> _vals_old;
+  std::vector<const VariableValue *> _vals_old;
 };
 #endif //COUPLEDBEKINETIC_H

--- a/modules/chemical_reactions/include/kernels/CoupledConvectionReactionSub.h
+++ b/modules/chemical_reactions/include/kernels/CoupledConvectionReactionSub.h
@@ -85,13 +85,13 @@ private:
   /// Material property of hydraulic conductivity.
   const MaterialProperty<Real> & _cond;
   /// Coupled gradient of hydraulic head.
-  VariableGradient & _grad_p;
+  const VariableGradient & _grad_p;
 
   std::vector<unsigned int> _vars;
   /// Coupled primary species concentrations.
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
   /// Coupled gradients of primary species concentrations.
-  std::vector<VariableGradient *> _grad_vals;
+  std::vector<const VariableGradient *> _grad_vals;
 
 };
 #endif //COUPLEDCONVECTIONREACTIONSUB_H

--- a/modules/chemical_reactions/include/kernels/CoupledDiffusionReactionSub.h
+++ b/modules/chemical_reactions/include/kernels/CoupledDiffusionReactionSub.h
@@ -79,8 +79,8 @@ private:
 
   std::vector<unsigned int> _vars;
   /// Coupled primary species concentrations.
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
   /// Coupled gradients of primary species concentrations.
-  std::vector<VariableGradient *> _grad_vals;
+  std::vector<const VariableGradient *> _grad_vals;
 };
 #endif //COUPLEDDIFFUSIONREACTIONSUB_H

--- a/modules/chemical_reactions/include/kernels/PrimaryConvection.h
+++ b/modules/chemical_reactions/include/kernels/PrimaryConvection.h
@@ -67,7 +67,7 @@ private:
    * constructor!
    */
   /// Coupled gradient of hydraulic head.
-  VariableGradient & _grad_p;
+  const VariableGradient & _grad_p;
 };
 
 #endif //PRIMARYCONVECTION_H

--- a/modules/chemical_reactions/include/materials/LangmuirMaterial.h
+++ b/modules/chemical_reactions/include/materials/LangmuirMaterial.h
@@ -33,10 +33,10 @@ protected:
 private:
 
   /// reciprocal of desorption time constant
-  VariableValue * _one_over_de_time_const;
+  const VariableValue * _one_over_de_time_const;
 
   /// reciprocal of adsorption time constant
-  VariableValue * _one_over_ad_time_const;
+  const VariableValue * _one_over_ad_time_const;
 
   /// langmuir density
   Real _langmuir_dens;
@@ -45,10 +45,10 @@ private:
   Real _langmuir_p;
 
   /// concentration of adsorbed fluid in matrix
-  VariableValue * _conc;
+  const VariableValue * _conc;
 
   /// porespace pressure (or partial pressure if multiphase flow scenario)
-  VariableValue * _pressure;
+  const VariableValue * _pressure;
 
   /// mass flow rate from the matrix = mass flow rate to the porespace
   MaterialProperty<Real> & _mass_rate_from_matrix;

--- a/modules/chemical_reactions/include/materials/MollifiedLangmuirMaterial.h
+++ b/modules/chemical_reactions/include/materials/MollifiedLangmuirMaterial.h
@@ -33,10 +33,10 @@ protected:
 private:
 
   /// reciprocal of desorption time constant
-  VariableValue * _one_over_de_time_const;
+  const VariableValue * _one_over_de_time_const;
 
   /// reciprocal of adsorption time constant
-  VariableValue * _one_over_ad_time_const;
+  const VariableValue * _one_over_ad_time_const;
 
   /// langmuir density
   Real _langmuir_dens;
@@ -45,10 +45,10 @@ private:
   Real _langmuir_p;
 
   /// concentration of adsorbed fluid in matrix
-  VariableValue * _conc;
+  const VariableValue * _conc;
 
   /// porespace pressure (or partial pressure if multiphase flow scenario)
-  VariableValue * _pressure;
+  const VariableValue * _pressure;
 
   /**
    * mollifying parameter.  the time constants are

--- a/modules/chemical_reactions/src/auxkernels/KineticDisPreConcAux.C
+++ b/modules/chemical_reactions/src/auxkernels/KineticDisPreConcAux.C
@@ -53,10 +53,11 @@ KineticDisPreConcAux::computeValue()
   {
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if ((*_vals[i])[_qp] < 0.0) (*_vals[i])[_qp] =0.0;
-      omega *= std::pow((*_vals[i])[_qp],_sto_v[i]);
+      if ((*_vals[i])[_qp] < 0.0)
+        omega *= std::pow(0.0, _sto_v[i]);
+      else
+        omega *= std::pow((*_vals[i])[_qp], _sto_v[i]);
     }
-
   }
 
   Real saturation_SI=omega/std::pow(10.0,_log_k);

--- a/modules/chemical_reactions/src/auxkernels/KineticDisPreRateAux.C
+++ b/modules/chemical_reactions/src/auxkernels/KineticDisPreRateAux.C
@@ -53,8 +53,10 @@ KineticDisPreRateAux::computeValue()
   {
     for (unsigned int i=0; i<_vals.size(); ++i)
     {
-      if ((*_vals[i])[_qp] < 0.0) (*_vals[i])[_qp] =0.0;
-      omega *= std::pow((*_vals[i])[_qp],_sto_v[i]);
+      if ((*_vals[i])[_qp] < 0.0)
+        omega *= std::pow(0.0, _sto_v[i]);
+      else
+        omega *= std::pow((*_vals[i])[_qp], _sto_v[i]);
     }
   }
 

--- a/modules/heat_conduction/include/AnisoHeatConductionMaterial.h
+++ b/modules/heat_conduction/include/AnisoHeatConductionMaterial.h
@@ -25,7 +25,7 @@ protected:
   virtual void computeProperties();
 
   const bool _has_temp;
-  VariableValue & _temperature;
+  const VariableValue & _temperature;
 
   const Real _my_thermal_conductivity_x;
   const Real _my_thermal_conductivity_y;

--- a/modules/heat_conduction/include/CoupledConvectiveFlux.h
+++ b/modules/heat_conduction/include/CoupledConvectiveFlux.h
@@ -20,7 +20,7 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  VariableValue & _T_infinity;
+  const VariableValue & _T_infinity;
   const Real _coefficient;
 };
 

--- a/modules/heat_conduction/include/HeatConductionMaterial.h
+++ b/modules/heat_conduction/include/HeatConductionMaterial.h
@@ -29,7 +29,7 @@ protected:
   virtual void computeProperties();
 
   const bool _has_temp;
-  VariableValue & _temperature;
+  const VariableValue & _temperature;
 
   const Real _my_thermal_conductivity;
   const Real _my_specific_heat;

--- a/modules/linear_elasticity/include/LinearElasticityMaterial.h
+++ b/modules/linear_elasticity/include/LinearElasticityMaterial.h
@@ -24,7 +24,7 @@ protected:
 private:
 
   bool _has_temp;
-  VariableValue & _temp;
+  const VariableValue & _temp;
 
   Real _my_thermal_expansion;
   Real _my_youngs_modulus;

--- a/modules/linear_elasticity/include/SolidMechX.h
+++ b/modules/linear_elasticity/include/SolidMechX.h
@@ -33,11 +33,11 @@ private:
   const unsigned int _mesh_dimension;
 
   unsigned int _y_var;
-  VariableValue  & _y;
-  VariableGradient & _grad_y;
+  const VariableValue & _y;
+  const VariableGradient & _grad_y;
 
   unsigned int _z_var;
-  VariableValue  & _z;
-  VariableGradient & _grad_z;
+  const VariableValue & _z;
+  const VariableGradient & _grad_z;
 };
 #endif //SOLIDMECHX

--- a/modules/linear_elasticity/include/SolidMechY.h
+++ b/modules/linear_elasticity/include/SolidMechY.h
@@ -33,11 +33,11 @@ private:
   const unsigned int _mesh_dimension;
 
   unsigned int _x_var;
-  VariableValue  & _x;
-  VariableGradient & _grad_x;
+  const VariableValue & _x;
+  const VariableGradient & _grad_x;
 
   unsigned int _z_var;
-  VariableValue  & _z;
-  VariableGradient & _grad_z;
+  const VariableValue & _z;
+  const VariableGradient & _grad_z;
 };
 #endif //SOLIDMECHY

--- a/modules/linear_elasticity/include/SolidMechZ.h
+++ b/modules/linear_elasticity/include/SolidMechZ.h
@@ -30,12 +30,12 @@ protected:
 
 private:
   unsigned int _x_var;
-  VariableValue  & _x;
-  VariableGradient & _grad_x;
+  const VariableValue & _x;
+  const VariableGradient & _grad_x;
 
   unsigned int _y_var;
-  VariableValue  & _y;
-  VariableGradient & _grad_y;
+  const VariableValue & _y;
+  const VariableGradient & _grad_y;
 };
 
 #endif //SOLIDMECHZ

--- a/modules/misc/include/BodyForceVoid.h
+++ b/modules/misc/include/BodyForceVoid.h
@@ -28,7 +28,7 @@ protected:
   virtual Real computeQpResidual();
 
   Real _value;
-  MooseArray<Real> & _c;
+  const VariableValue & _c;
   const bool _has_function;
   Function * const _function;
 };

--- a/modules/misc/include/CoupledDirectionalMeshHeightInterpolation.h
+++ b/modules/misc/include/CoupledDirectionalMeshHeightInterpolation.h
@@ -45,7 +45,7 @@ protected:
   virtual Real computeValue();
 
   /// The value of a coupled variable to modulate
-  VariableValue & _coupled_val;
+  const VariableValue & _coupled_val;
 
   /// The direction to interpolate in
   unsigned int _direction;

--- a/modules/misc/include/JouleHeating.h
+++ b/modules/misc/include/JouleHeating.h
@@ -27,7 +27,7 @@ public:
 protected:
   virtual Real computeQpResidual();
 
-  VariableGradient& _grad_potential;
+  const VariableGradient & _grad_potential;
   const MaterialProperty<Real> & _thermal_conductivity;
 };
 

--- a/modules/navier_stokes/include/auxkernels/INSCourant.h
+++ b/modules/navier_stokes/include/auxkernels/INSCourant.h
@@ -29,9 +29,9 @@ protected:
   virtual Real computeValue();
 
   // Velocity
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 };
 
 #endif //VELOCITYAUX_H

--- a/modules/navier_stokes/include/auxkernels/INSDivergenceAux.h
+++ b/modules/navier_stokes/include/auxkernels/INSDivergenceAux.h
@@ -29,9 +29,9 @@ protected:
   virtual Real computeValue();
 
   // Velocity gradients
-  VariableGradient& _grad_u_vel;
-  VariableGradient& _grad_v_vel;
-  VariableGradient& _grad_w_vel;
+  const VariableGradient & _grad_u_vel;
+  const VariableGradient & _grad_v_vel;
+  const VariableGradient & _grad_w_vel;
 };
 
 #endif //VELOCITYAUX_H

--- a/modules/navier_stokes/include/auxkernels/NSEnthalpyAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSEnthalpyAux.h
@@ -40,9 +40,9 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _rho;
-  VariableValue & _rhoe;
-  VariableValue & _pressure;
+  const VariableValue & _rho;
+  const VariableValue & _rhoe;
+  const VariableValue & _pressure;
 
   Real _gamma;
 };

--- a/modules/navier_stokes/include/auxkernels/NSPressureAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSPressureAux.h
@@ -33,11 +33,11 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _rho;
-  VariableValue & _u_vel;
-  VariableValue & _v_vel;
-  VariableValue & _w_vel;
-  VariableValue & _rhoe;
+  const VariableValue & _rho;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
+  const VariableValue & _rhoe;
 
   Real _gamma;
 };

--- a/modules/navier_stokes/include/auxkernels/NSTemperatureAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSTemperatureAux.h
@@ -37,11 +37,11 @@ protected:
   virtual Real computeValue();
 
   // The temperature depends on velocities and total energy
-  VariableValue & _rho;
-  VariableValue & _u_vel;
-  VariableValue & _v_vel;
-  VariableValue & _w_vel;
-  VariableValue & _rhoe;
+  const VariableValue & _rho;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
+  const VariableValue & _rhoe;
 
   // Specific heat at constant volume, treated as a single
   // constant value.

--- a/modules/navier_stokes/include/auxkernels/NSVelocityAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSVelocityAux.h
@@ -33,8 +33,8 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _rho;
-  VariableValue & _momentum;
+  const VariableValue & _rho;
+  const VariableValue & _momentum;
 
 };
 

--- a/modules/navier_stokes/include/bcs/INSMomentumNoBCBC.h
+++ b/modules/navier_stokes/include/bcs/INSMomentumNoBCBC.h
@@ -32,15 +32,15 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled variables
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
-  VariableValue& _p;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
+  const VariableValue & _p;
 
   // Gradients
-  VariableGradient& _grad_u_vel;
-  VariableGradient& _grad_v_vel;
-  VariableGradient& _grad_w_vel;
+  const VariableGradient & _grad_u_vel;
+  const VariableGradient & _grad_v_vel;
+  const VariableGradient & _grad_w_vel;
 
   // Variable numberings
   unsigned _u_vel_var_number;

--- a/modules/navier_stokes/include/bcs/NSEnergyInviscidBC.h
+++ b/modules/navier_stokes/include/bcs/NSEnergyInviscidBC.h
@@ -50,7 +50,7 @@ protected:
 //  virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Aux vars
-  VariableValue& _temperature;
+  const VariableValue & _temperature;
 
   // An object for computing pressure derivatives.
   // Constructed via a reference to ourself

--- a/modules/navier_stokes/include/bcs/NSEnergyInviscidSpecifiedDensityAndVelocityBC.h
+++ b/modules/navier_stokes/include/bcs/NSEnergyInviscidSpecifiedDensityAndVelocityBC.h
@@ -34,7 +34,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Aux Variables
-  VariableValue& _pressure;
+  const VariableValue & _pressure;
 
   // Required parameters
   Real _specified_density;

--- a/modules/navier_stokes/include/bcs/NSEnergyInviscidSpecifiedNormalFlowBC.h
+++ b/modules/navier_stokes/include/bcs/NSEnergyInviscidSpecifiedNormalFlowBC.h
@@ -33,7 +33,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Aux Variables
-  VariableValue& _pressure;
+  const VariableValue & _pressure;
 
   // Required parameters
   Real _un;

--- a/modules/navier_stokes/include/bcs/NSEnergyInviscidUnspecifiedBC.h
+++ b/modules/navier_stokes/include/bcs/NSEnergyInviscidUnspecifiedBC.h
@@ -33,7 +33,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Aux Variables
-  VariableValue& _pressure;
+  const VariableValue & _pressure;
 
 private:
   // Helper Jacobian function

--- a/modules/navier_stokes/include/bcs/NSEnergyViscousBC.h
+++ b/modules/navier_stokes/include/bcs/NSEnergyViscousBC.h
@@ -47,7 +47,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled gradients
-  VariableGradient& _grad_temperature;
+  const VariableGradient & _grad_temperature;
 
   // Material properties
   const MaterialProperty<Real>& _thermal_conductivity;
@@ -70,7 +70,7 @@ protected:
 
   // Single vector to refer to all gradients.  Initialized in
   // the ctor.
-  std::vector<VariableGradient*> _gradU;
+  std::vector<const VariableGradient *> _gradU;
 };
 
 

--- a/modules/navier_stokes/include/bcs/NSImposedVelocityBC.h
+++ b/modules/navier_stokes/include/bcs/NSImposedVelocityBC.h
@@ -36,7 +36,7 @@ protected:
 
   // We need the density, since we are actually setting essential values of
   // *momentum* not essential values of velocity.
-  VariableValue & _rho;
+  const VariableValue & _rho;
 
   // The desired value for the velocity component
   Real _desired_velocity;

--- a/modules/navier_stokes/include/bcs/NSImposedVelocityDirectionBC.h
+++ b/modules/navier_stokes/include/bcs/NSImposedVelocityDirectionBC.h
@@ -56,10 +56,10 @@ protected:
   virtual Real computeQpResidual();
 
   // Coupled variables
-  VariableValue& _rho;
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _rho;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 
   // The desired value for the unit velocity component
   Real _desired_unit_velocity_component;

--- a/modules/navier_stokes/include/bcs/NSIntegratedBC.h
+++ b/modules/navier_stokes/include/bcs/NSIntegratedBC.h
@@ -39,22 +39,22 @@ protected:
   // virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled variables
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 
-  VariableValue& _rho;
-  VariableValue& _rho_u;
-  VariableValue& _rho_v;
-  VariableValue& _rho_w;
-  VariableValue& _rho_e;
+  const VariableValue & _rho;
+  const VariableValue & _rho_u;
+  const VariableValue & _rho_v;
+  const VariableValue & _rho_w;
+  const VariableValue & _rho_e;
 
   // Gradients
-  VariableGradient& _grad_rho;
-  VariableGradient& _grad_rho_u;
-  VariableGradient& _grad_rho_v;
-  VariableGradient& _grad_rho_w;
-  VariableGradient& _grad_rho_e;
+  const VariableGradient & _grad_rho;
+  const VariableGradient & _grad_rho_u;
+  const VariableGradient & _grad_rho_v;
+  const VariableGradient & _grad_rho_w;
+  const VariableGradient & _grad_rho_e;
 
   // Variable numberings
   unsigned _rho_var_number;

--- a/modules/navier_stokes/include/bcs/NSMomentumInviscidSpecifiedNormalFlowBC.h
+++ b/modules/navier_stokes/include/bcs/NSMomentumInviscidSpecifiedNormalFlowBC.h
@@ -34,7 +34,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Aux Variables
-  VariableValue& _pressure;
+  const VariableValue & _pressure;
 
   // Required parameters
   Real _rhou_udotn;

--- a/modules/navier_stokes/include/bcs/NSPressureNeumannBC.h
+++ b/modules/navier_stokes/include/bcs/NSPressureNeumannBC.h
@@ -45,7 +45,7 @@
 //   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 //
 //   // Coupled vars
-//   VariableValue & _pressure;
+//   const VariableValue & _pressure;
 //
 //   // Required parameters
 //   unsigned _component;

--- a/modules/navier_stokes/include/bcs/NSStagnationBC.h
+++ b/modules/navier_stokes/include/bcs/NSStagnationBC.h
@@ -40,11 +40,11 @@ protected:
   // virtual Real computeQpResidual();
 
   // Coupled variables
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 
-  VariableValue& _temperature;
+  const VariableValue & _temperature;
 
   // Required paramters
   Real _gamma;

--- a/modules/navier_stokes/include/bcs/NSStagnationPressureBC.h
+++ b/modules/navier_stokes/include/bcs/NSStagnationPressureBC.h
@@ -40,7 +40,7 @@ protected:
   virtual Real computeQpResidual();
 
   // Coupled variables
-  VariableValue& _pressure;
+  const VariableValue & _pressure;
 
   // Required paramters
   Real _desired_stagnation_pressure;

--- a/modules/navier_stokes/include/bcs/NSThermalBC.h
+++ b/modules/navier_stokes/include/bcs/NSThermalBC.h
@@ -30,7 +30,7 @@ protected:
   virtual Real computeQpResidual();
 
   unsigned int _rho_var;
-  VariableValue & _rho;
+  const VariableValue & _rho;
 
   Real _initial;
   Real _final;

--- a/modules/navier_stokes/include/kernels/INSChorinCorrector.h
+++ b/modules/navier_stokes/include/kernels/INSChorinCorrector.h
@@ -32,12 +32,12 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // "Star" velocity components
-  VariableValue& _u_vel_star;
-  VariableValue& _v_vel_star;
-  VariableValue& _w_vel_star;
+  const VariableValue & _u_vel_star;
+  const VariableValue & _v_vel_star;
+  const VariableValue & _w_vel_star;
 
   // Pressure gradients
-  VariableGradient& _grad_p;
+  const VariableGradient & _grad_p;
 
   // Variable numberings
   unsigned _u_vel_star_var_number;

--- a/modules/navier_stokes/include/kernels/INSChorinPredictor.h
+++ b/modules/navier_stokes/include/kernels/INSChorinPredictor.h
@@ -32,34 +32,34 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Velocity
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 
   // Old Velocity
-  VariableValue& _u_vel_old;
-  VariableValue& _v_vel_old;
-  VariableValue& _w_vel_old;
+  const VariableValue & _u_vel_old;
+  const VariableValue & _v_vel_old;
+  const VariableValue & _w_vel_old;
 
   // Star Velocity
-  VariableValue& _u_vel_star;
-  VariableValue& _v_vel_star;
-  VariableValue& _w_vel_star;
+  const VariableValue & _u_vel_star;
+  const VariableValue & _v_vel_star;
+  const VariableValue & _w_vel_star;
 
   // Velocity Gradients
-  VariableGradient& _grad_u_vel;
-  VariableGradient& _grad_v_vel;
-  VariableGradient& _grad_w_vel;
+  const VariableGradient & _grad_u_vel;
+  const VariableGradient & _grad_v_vel;
+  const VariableGradient & _grad_w_vel;
 
   // Old Velocity Gradients
-  VariableGradient& _grad_u_vel_old;
-  VariableGradient& _grad_v_vel_old;
-  VariableGradient& _grad_w_vel_old;
+  const VariableGradient & _grad_u_vel_old;
+  const VariableGradient & _grad_v_vel_old;
+  const VariableGradient & _grad_w_vel_old;
 
   // Star Velocity Gradients
-  VariableGradient& _grad_u_vel_star;
-  VariableGradient& _grad_v_vel_star;
-  VariableGradient& _grad_w_vel_star;
+  const VariableGradient & _grad_u_vel_star;
+  const VariableGradient & _grad_v_vel_star;
+  const VariableGradient & _grad_w_vel_star;
 
   // Variable numberings
   unsigned _u_vel_var_number;

--- a/modules/navier_stokes/include/kernels/INSChorinPressurePoisson.h
+++ b/modules/navier_stokes/include/kernels/INSChorinPressurePoisson.h
@@ -33,9 +33,9 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Gradients of the "star" velocity
-  VariableGradient& _grad_u_star;
-  VariableGradient& _grad_v_star;
-  VariableGradient& _grad_w_star;
+  const VariableGradient & _grad_u_star;
+  const VariableGradient & _grad_v_star;
+  const VariableGradient & _grad_w_star;
 
   // Variable numberings
   unsigned _u_vel_star_var_number;

--- a/modules/navier_stokes/include/kernels/INSMass.h
+++ b/modules/navier_stokes/include/kernels/INSMass.h
@@ -33,9 +33,9 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled Gradients
-  VariableGradient& _grad_u_vel;
-  VariableGradient& _grad_v_vel;
-  VariableGradient& _grad_w_vel;
+  const VariableGradient & _grad_u_vel;
+  const VariableGradient & _grad_v_vel;
+  const VariableGradient & _grad_w_vel;
 
   // Variable numberings
   unsigned _u_vel_var_number;

--- a/modules/navier_stokes/include/kernels/INSMomentum.h
+++ b/modules/navier_stokes/include/kernels/INSMomentum.h
@@ -33,15 +33,15 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled variables
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
-  VariableValue& _p;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
+  const VariableValue & _p;
 
   // Gradients
-  VariableGradient& _grad_u_vel;
-  VariableGradient& _grad_v_vel;
-  VariableGradient& _grad_w_vel;
+  const VariableGradient & _grad_u_vel;
+  const VariableGradient & _grad_v_vel;
+  const VariableGradient & _grad_w_vel;
 
   // Variable numberings
   unsigned _u_vel_var_number;

--- a/modules/navier_stokes/include/kernels/INSPressurePoisson.h
+++ b/modules/navier_stokes/include/kernels/INSPressurePoisson.h
@@ -35,9 +35,9 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Gradients of the accleration vector, 'a'
-  VariableGradient& _grad_a1;
-  VariableGradient& _grad_a2;
-  VariableGradient& _grad_a3;
+  const VariableGradient & _grad_a1;
+  const VariableGradient & _grad_a2;
+  const VariableGradient & _grad_a3;
 
   // Variable numberings
   unsigned _a1_var_number;

--- a/modules/navier_stokes/include/kernels/INSProjection.h
+++ b/modules/navier_stokes/include/kernels/INSProjection.h
@@ -35,12 +35,12 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled variables
-  VariableValue& _a1;
-  VariableValue& _a2;
-  VariableValue& _a3;
+  const VariableValue & _a1;
+  const VariableValue & _a2;
+  const VariableValue & _a3;
 
   // Gradients
-  VariableGradient& _grad_p;
+  const VariableGradient & _grad_p;
 
   // Variable numberings
   unsigned _a1_var_number;

--- a/modules/navier_stokes/include/kernels/INSSplitMomentum.h
+++ b/modules/navier_stokes/include/kernels/INSSplitMomentum.h
@@ -38,19 +38,19 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled variables
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 
   // Acceleration vector components
-  VariableValue& _a1;
-  VariableValue& _a2;
-  VariableValue& _a3;
+  const VariableValue & _a1;
+  const VariableValue & _a2;
+  const VariableValue & _a3;
 
   // Gradients
-  VariableGradient& _grad_u_vel;
-  VariableGradient& _grad_v_vel;
-  VariableGradient& _grad_w_vel;
+  const VariableGradient & _grad_u_vel;
+  const VariableGradient & _grad_v_vel;
+  const VariableGradient & _grad_w_vel;
 
   // Variable numberings
   unsigned _u_vel_var_number;

--- a/modules/navier_stokes/include/kernels/INSTemperature.h
+++ b/modules/navier_stokes/include/kernels/INSTemperature.h
@@ -32,9 +32,9 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled variables
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 
   // Variable numberings
   unsigned _u_vel_var_number;

--- a/modules/navier_stokes/include/kernels/NSEnergyInviscidFlux.h
+++ b/modules/navier_stokes/include/kernels/NSEnergyInviscidFlux.h
@@ -27,7 +27,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   // Coupled variables
-  VariableValue & _enthalpy;
+  const VariableValue & _enthalpy;
 };
 
 #endif

--- a/modules/navier_stokes/include/kernels/NSEnergyThermalFlux.h
+++ b/modules/navier_stokes/include/kernels/NSEnergyThermalFlux.h
@@ -34,7 +34,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   // Gradients
-  VariableGradient& _grad_temp;
+  const VariableGradient & _grad_temp;
 
   // Material properties
   const MaterialProperty<Real> &_thermal_conductivity;
@@ -61,7 +61,7 @@ private:
   // Single vector to refer to all gradients.  We have to store
   // pointers since you can't have a vector<Foo&>.  Initialized in
   // the ctor.
-  std::vector<VariableGradient*> _gradU;
+  std::vector<const VariableGradient *> _gradU;
 };
 
 

--- a/modules/navier_stokes/include/kernels/NSGravityPower.h
+++ b/modules/navier_stokes/include/kernels/NSGravityPower.h
@@ -27,7 +27,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   unsigned int _momentum_var;
-  VariableValue & _momentum;
+  const VariableValue & _momentum;
 
   Real _acceleration;
 };

--- a/modules/navier_stokes/include/kernels/NSKernel.h
+++ b/modules/navier_stokes/include/kernels/NSKernel.h
@@ -39,22 +39,22 @@ protected:
   // virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Coupled variables
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 
-  VariableValue& _rho;
-  VariableValue& _rho_u;
-  VariableValue& _rho_v;
-  VariableValue& _rho_w;
-  VariableValue& _rho_e;
+  const VariableValue & _rho;
+  const VariableValue & _rho_u;
+  const VariableValue & _rho_v;
+  const VariableValue & _rho_w;
+  const VariableValue & _rho_e;
 
   // Gradients
-  VariableGradient& _grad_rho;
-  VariableGradient& _grad_rho_u;
-  VariableGradient& _grad_rho_v;
-  VariableGradient& _grad_rho_w;
-  VariableGradient& _grad_rho_e;
+  const VariableGradient & _grad_rho;
+  const VariableGradient & _grad_rho_u;
+  const VariableGradient & _grad_rho_v;
+  const VariableGradient & _grad_rho_w;
+  const VariableGradient & _grad_rho_e;
 
   // Variable numberings
   unsigned _rho_var_number;

--- a/modules/navier_stokes/include/kernels/NSMomentumInviscidFlux.h
+++ b/modules/navier_stokes/include/kernels/NSMomentumInviscidFlux.h
@@ -34,7 +34,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   // Coupled variables
-  VariableValue & _pressure;
+  const VariableValue & _pressure;
 
   // Parameters
   unsigned _component;

--- a/modules/navier_stokes/include/kernels/NSMomentumInviscidFluxWithGradP.h
+++ b/modules/navier_stokes/include/kernels/NSMomentumInviscidFluxWithGradP.h
@@ -28,7 +28,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   // Coupled gradients
-  VariableGradient& _grad_p;
+  const VariableGradient & _grad_p;
 
   // Parameters
   int _component;
@@ -41,7 +41,7 @@ private:
   // Single vector to refer to all gradients.  We have to store
   // pointers since you can't have a vector<Foo&>.  Initialized in
   // the ctor.
-  std::vector<VariableGradient*> _gradU;
+  std::vector<const VariableGradient *> _gradU;
 
   // An object for computing pressure derivatives.
   // Constructed via a reference to ourself

--- a/modules/navier_stokes/include/kernels/NSSUPGBase.h
+++ b/modules/navier_stokes/include/kernels/NSSUPGBase.h
@@ -37,9 +37,9 @@ protected:
   //virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   // Material properties
-  const MaterialProperty<RealTensorValue>& _viscous_stress_tensor;
-  const MaterialProperty<Real>& _dynamic_viscosity;
-  const MaterialProperty<Real>& _thermal_conductivity;
+  const MaterialProperty<RealTensorValue> & _viscous_stress_tensor;
+  const MaterialProperty<Real> & _dynamic_viscosity;
+  const MaterialProperty<Real> & _thermal_conductivity;
 
   // SUPG-related material properties.
   const MaterialProperty<Real> & _hsupg;
@@ -58,25 +58,25 @@ protected:
   const MaterialProperty<std::vector<std::vector<RealTensorValue> > >& _calE;
 
   // "Old" (from previous timestep) coupled variable values.
-//  VariableValue& _rho_old;
-//  VariableValue& _rho_u_old;
-//  VariableValue& _rho_v_old;
-//  VariableValue& _rho_w_old;
-//  VariableValue& _rho_e_old;
+  // const VariableValue & _rho_old;
+  // const VariableValue & _rho_u_old;
+  // const VariableValue & _rho_v_old;
+  // const VariableValue & _rho_w_old;
+  // const VariableValue & _rho_e_old;
 
   // The derivative of "udot" wrt u for each of the momentum variables.
   // This is always 1/dt unless you are using BDF2...
-  VariableValue& _d_rhodot_du;
-  VariableValue& _d_rhoudot_du;
-  VariableValue& _d_rhovdot_du;
-  VariableValue& _d_rhowdot_du;
-  VariableValue& _d_rhoedot_du;
+  const VariableValue & _d_rhodot_du;
+  const VariableValue & _d_rhoudot_du;
+  const VariableValue & _d_rhovdot_du;
+  const VariableValue & _d_rhowdot_du;
+  const VariableValue & _d_rhoedot_du;
 
   // Temperature is need to compute speed of sound
-  VariableValue & _temperature;
+  const VariableValue & _temperature;
 
   // Enthalpy aux variable
-  VariableValue& _enthalpy;
+  const VariableValue & _enthalpy;
 };
 
 #endif //  NSSUPGBASE_H

--- a/modules/navier_stokes/include/kernels/NSTemperatureL2.h
+++ b/modules/navier_stokes/include/kernels/NSTemperatureL2.h
@@ -33,19 +33,19 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   unsigned int _p_var;
-  VariableValue & _p;
+  const VariableValue & _p;
 
   unsigned int _pe_var;
-  VariableValue & _pe;
+  const VariableValue & _pe;
 
   unsigned int _u_vel_var;
-  VariableValue & _u_vel;
+  const VariableValue & _u_vel;
 
   unsigned int _v_vel_var;
-  VariableValue & _v_vel;
+  const VariableValue & _v_vel;
 
   unsigned int _w_vel_var;
-  VariableValue & _w_vel;
+  const VariableValue & _w_vel;
 
   const MaterialProperty<Real> & _c_v;
 };

--- a/modules/navier_stokes/include/materials/NavierStokesMaterial.h
+++ b/modules/navier_stokes/include/materials/NavierStokesMaterial.h
@@ -45,9 +45,9 @@ protected:
 
   const unsigned int _mesh_dimension;
 
-  VariableGradient& _grad_u;
-  VariableGradient& _grad_v;
-  VariableGradient& _grad_w;
+  const VariableGradient & _grad_u;
+  const VariableGradient & _grad_v;
+  const VariableGradient & _grad_w;
 
   MaterialProperty<RealTensorValue>& _viscous_stress_tensor;
   MaterialProperty<Real>&            _thermal_conductivity;
@@ -70,7 +70,7 @@ protected:
 
   // Convenient storage for all of the velocity gradient components so
   // we can refer to them in a loop.
-  std::vector<VariableGradient*> _vel_grads;
+  std::vector<const VariableGradient *> _vel_grads;
 
   // Specific heat at constant volume, treated as single
   // constant values.
@@ -80,36 +80,36 @@ protected:
 
   // Coupled values needed to compute strong form residuals
   // for SUPG stabilization...
-  VariableValue& _u_vel;
-  VariableValue& _v_vel;
-  VariableValue& _w_vel;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
 
   // Temperature is needed to compute speed of sound
-  VariableValue& _temperature;
+  const VariableValue & _temperature;
 
   // Enthalpy is needed in computing energy equation strong residuals
-  VariableValue& _enthalpy;
+  const VariableValue & _enthalpy;
 
   // Main solution variables are all needed for computing strong residuals
-  VariableValue& _rho;
-  VariableValue& _rho_u;
-  VariableValue& _rho_v;
-  VariableValue& _rho_w;
-  VariableValue& _rho_e;
+  const VariableValue & _rho;
+  const VariableValue & _rho_u;
+  const VariableValue & _rho_v;
+  const VariableValue & _rho_w;
+  const VariableValue & _rho_e;
 
   // Time derivative values for dependent variables
-  VariableValue& _drho_dt;
-  VariableValue& _drhou_dt;
-  VariableValue& _drhov_dt;
-  VariableValue& _drhow_dt;
-  VariableValue& _drhoe_dt;
+  const VariableValue & _drho_dt;
+  const VariableValue & _drhou_dt;
+  const VariableValue & _drhov_dt;
+  const VariableValue & _drhow_dt;
+  const VariableValue & _drhoe_dt;
 
   // Gradients
-  VariableGradient& _grad_rho;
-  VariableGradient& _grad_rho_u;
-  VariableGradient& _grad_rho_v;
-  VariableGradient& _grad_rho_w;
-  VariableGradient& _grad_rho_e;
+  const VariableGradient & _grad_rho;
+  const VariableGradient & _grad_rho_u;
+  const VariableGradient & _grad_rho_v;
+  const VariableGradient & _grad_rho_w;
+  const VariableGradient & _grad_rho_e;
 
   // The real-valued material properties representing the element stabilization
   // parameters for each of the equations.

--- a/modules/navier_stokes/include/postprocessors/INSExplicitTimestepSelector.h
+++ b/modules/navier_stokes/include/postprocessors/INSExplicitTimestepSelector.h
@@ -34,7 +34,7 @@ protected:
   Real _value;
 
   /// Velocity magnitude.  Hint: Use VectorMagnitudeAux in Moose for this
-  VariableValue& _vel_mag;
+  const VariableValue & _vel_mag;
 
   /// Material properties:  the explicit time scheme limit for the viscous
   /// problem also depends on the kinematic viscosity.

--- a/modules/phase_field/include/auxkernels/BndsCalcAux.h
+++ b/modules/phase_field/include/auxkernels/BndsCalcAux.h
@@ -27,7 +27,7 @@ protected:
   virtual Real computeValue();
 
   unsigned int _ncrys;
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
 };
 
 #endif //BNDSCALCAUX_H

--- a/modules/phase_field/include/auxkernels/PFCEnergyDensity.h
+++ b/modules/phase_field/include/auxkernels/PFCEnergyDensity.h
@@ -17,7 +17,7 @@ public:
 protected:
   virtual Real computeValue();
 
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
   std::vector<const MaterialProperty<Real>* > _coeff;
 
   unsigned int _order;

--- a/modules/phase_field/include/auxkernels/PFCRFFEnergyDensity.h
+++ b/modules/phase_field/include/auxkernels/PFCRFFEnergyDensity.h
@@ -19,7 +19,7 @@ protected:
   virtual Real computeValue();
 
   unsigned int _order;
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
 
   Real _a;
   Real _b;

--- a/modules/phase_field/include/auxkernels/TotalFreeEnergyBase.h
+++ b/modules/phase_field/include/auxkernels/TotalFreeEnergyBase.h
@@ -28,15 +28,15 @@ protected:
 
   /// Coupled interface variables
   unsigned int _nvars;
-  std::vector<VariableValue *> _vars;
-  std::vector<VariableGradient *> _grad_vars;
+  std::vector<const VariableValue *> _vars;
+  std::vector<const VariableGradient *> _grad_vars;
 
   /// Gradient free energy prefactor kappa
   std::vector<MaterialPropertyName> _kappa_names;
   unsigned int _nkappas;
 
   /// Additional free energy contribution
-  VariableValue & _additional_free_energy;
+  const VariableValue & _additional_free_energy;
 };
 
 #endif //TOTALFREEENERGYBASE_H

--- a/modules/phase_field/include/kernels/ACGBPoly.h
+++ b/modules/phase_field/include/kernels/ACGBPoly.h
@@ -24,7 +24,7 @@ protected:
   virtual Real computeDFDOP(PFFunctionType type);
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  VariableValue & _c;
+  const VariableValue & _c;
   unsigned int _c_var;
 
   const MaterialProperty<Real> & _mu;

--- a/modules/phase_field/include/kernels/ACGrGrPoly.h
+++ b/modules/phase_field/include/kernels/ACGrGrPoly.h
@@ -31,14 +31,14 @@ protected:
 
   const unsigned int _ncrys;
 
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
   std::vector<unsigned int> _vals_var;
 
   const MaterialProperty<Real> & _mu;
   const MaterialProperty<Real> & _gamma;
   const MaterialProperty<Real> & _tgrad_corr_mult;
 
-  VariableGradient * _grad_T;
+  const VariableGradient * _grad_T;
 };
 
 #endif //ACGRGRPOLY_H

--- a/modules/phase_field/include/kernels/ACMultiInterface.h
+++ b/modules/phase_field/include/kernels/ACMultiInterface.h
@@ -36,8 +36,8 @@ protected:
 
   /// Order parameters
   unsigned int _num_etas;
-  std::vector<VariableValue *> _eta;
-  std::vector<VariableGradient *> _grad_eta;
+  std::vector<const VariableValue *> _eta;
+  std::vector<const VariableGradient *> _grad_eta;
 
   /// Lookup table from couple variable number into the etas vector
   std::vector<int> _eta_vars;

--- a/modules/phase_field/include/kernels/CHInterfaceBase.h
+++ b/modules/phase_field/include/kernels/CHInterfaceBase.h
@@ -40,9 +40,9 @@ protected:
 
   ///@{
   /// Variables for second order derivatives
-  VariableSecond & _second_u;
-  VariableTestSecond & _second_test;
-  VariablePhiSecond & _second_phi;
+  const VariableSecond & _second_u;
+  const VariableTestSecond & _second_test;
+  const VariablePhiSecond & _second_phi;
   ///@}
 
   ///Number of variables
@@ -56,7 +56,7 @@ protected:
   ///@}
 
   /// Coupled variables used in mobility
-  std::vector<VariableGradient *> _coupled_grad_vars;
+  std::vector<const VariableGradient *> _coupled_grad_vars;
 };
 
 template<typename T>

--- a/modules/phase_field/include/kernels/CHPFCRFF.h
+++ b/modules/phase_field/include/kernels/CHPFCRFF.h
@@ -30,7 +30,7 @@ private:
   MooseEnum _log_approach;
   Real _tol;
   std::vector<unsigned int> _vals_var;
-  std::vector<VariableGradient *> _grad_vals;
+  std::vector<const VariableGradient *> _grad_vals;
   unsigned int _n_exp_terms;
   Real _a;
   Real _b;

--- a/modules/phase_field/include/kernels/CHSplitVar.h
+++ b/modules/phase_field/include/kernels/CHSplitVar.h
@@ -24,7 +24,7 @@ protected:
 
 private:
   Real _var_c;
-  VariableGradient & _grad_c;
+  const VariableGradient & _grad_c;
 };
 
 #endif //CHSPLITVAR_H

--- a/modules/phase_field/include/kernels/CahnHilliardBase.h
+++ b/modules/phase_field/include/kernels/CahnHilliardBase.h
@@ -46,7 +46,7 @@ private:
   std::vector<const MaterialProperty<Real>* > _second_derivatives;
   std::vector<const MaterialProperty<Real>* > _third_derivatives;
   std::vector<std::vector<const MaterialProperty<Real>* > > _third_cross_derivatives;
-  std::vector<VariableGradient *> _grad_vars;
+  std::vector<const VariableGradient *> _grad_vars;
 };
 
 template<typename T>

--- a/modules/phase_field/include/kernels/GradientComponent.h
+++ b/modules/phase_field/include/kernels/GradientComponent.h
@@ -28,7 +28,7 @@ protected:
   unsigned int _v_var;
 
   /// Gradient of the coupled variable
-  VariableGradient & _grad_v;
+  const VariableGradient & _grad_v;
 
   /// Component of the gradient vector to match
   unsigned int _component;

--- a/modules/phase_field/include/kernels/GrainRigidBodyMotionBase.h
+++ b/modules/phase_field/include/kernels/GrainRigidBodyMotionBase.h
@@ -32,15 +32,15 @@ protected:
   unsigned int _c_var;
 
   /// Variable value for the concentration
-  VariableValue & _c;
+  const VariableValue & _c;
 
   /// Variable gradient for the concentration
-  VariableGradient & _grad_c;
+  const VariableGradient & _grad_c;
 
   VariableName _c_name;
   unsigned int _ncrys;
   /// Variable value for the order parameters
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
   std::vector<unsigned int> _vals_var;
 
   /// type of force density material

--- a/modules/phase_field/include/kernels/HHPFCRFF.h
+++ b/modules/phase_field/include/kernels/HHPFCRFF.h
@@ -28,7 +28,7 @@ protected:
   const MaterialProperty<Real> & _prop;
 
   bool _has_coupled_var;
-  VariableValue * _coupled_var;
+  const VariableValue * _coupled_var;
   unsigned int _coupled_var_var;
 };
 

--- a/modules/phase_field/include/kernels/KKSACBulkBase.h
+++ b/modules/phase_field/include/kernels/KKSACBulkBase.h
@@ -60,7 +60,7 @@ protected:
   const MaterialProperty<Real> & _prop_d2h;
 
   /// Gradients for all coupled variables
-  std::vector<VariableGradient*> _grad_args;
+  std::vector<const VariableGradient *> _grad_args;
 };
 
 #endif //KKSACBULKBASE_H

--- a/modules/phase_field/include/kernels/KKSCHBulk.h
+++ b/modules/phase_field/include/kernels/KKSCHBulk.h
@@ -58,7 +58,7 @@ private:
   std::vector<const MaterialProperty<Real> *> _third_derivatives_ca;
 
   /// Gradients for all coupled variables
-  std::vector<VariableGradient *> _grad_args;
+  std::vector<const VariableGradient *> _grad_args;
 
   /// h(eta) material property
   const MaterialProperty<Real> & _prop_h;

--- a/modules/phase_field/include/kernels/KKSPhaseConcentration.h
+++ b/modules/phase_field/include/kernels/KKSPhaseConcentration.h
@@ -40,13 +40,13 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
-  VariableValue & _ca;
+  const VariableValue & _ca;
   unsigned int _ca_var;
 
-  VariableValue & _c;
+  const VariableValue & _c;
   unsigned int _c_var;
 
-  VariableValue & _eta;
+  const VariableValue & _eta;
   unsigned int _eta_var;
 
   /// Switching function \f$ h(\eta) \f$

--- a/modules/phase_field/include/kernels/MatReaction.h
+++ b/modules/phase_field/include/kernels/MatReaction.h
@@ -42,7 +42,7 @@ protected:
    */
 
   std::string _v_name;
-  VariableValue & _v;
+  const VariableValue & _v;
   unsigned int _v_var;
 
   /// Reaction rate

--- a/modules/phase_field/include/kernels/PFFracCoupledInterface.h
+++ b/modules/phase_field/include/kernels/PFFracCoupledInterface.h
@@ -33,8 +33,8 @@ protected:
   virtual RealGradient precomputeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  VariableValue & _c;
-  VariableGradient & _grad_c;
+  const VariableValue & _c;
+  const VariableGradient & _grad_c;
   unsigned int _c_var;
 
 private:

--- a/modules/phase_field/include/kernels/SoretDiffusion.h
+++ b/modules/phase_field/include/kernels/SoretDiffusion.h
@@ -33,10 +33,10 @@ protected:
   unsigned int _T_var;
 
   /// Coupled variable for the temperature
-  VariableValue & _T;
+  const VariableValue & _T;
 
   /// Variable gradient for temperature
-  VariableGradient & _grad_T;
+  const VariableGradient & _grad_T;
 
   /// is the kernel used in a coupled form?
   const bool _is_coupled;
@@ -45,7 +45,7 @@ protected:
   unsigned int _c_var;
 
   /// Variable value for the concentration
-  VariableValue & _c;
+  const VariableValue & _c;
 
   /// Diffusivity material property
   const MaterialProperty<Real> & _D;

--- a/modules/phase_field/include/kernels/SplitCHCRes.h
+++ b/modules/phase_field/include/kernels/SplitCHCRes.h
@@ -28,7 +28,7 @@ protected:
 
   const MaterialProperty<Real> & _kappa;
   unsigned int _w_var;
-  VariableValue & _w;
+  const VariableValue & _w;
 };
 
 #endif //SPLITCHCRES_H

--- a/modules/phase_field/include/kernels/SwitchingFunctionConstraintEta.h
+++ b/modules/phase_field/include/kernels/SwitchingFunctionConstraintEta.h
@@ -39,7 +39,7 @@ protected:
   const MaterialProperty<Real> & _d2h;
 
   /// Lagrange multiplier
-  VariableValue & _lambda;
+  const VariableValue & _lambda;
   unsigned int _lambda_var;
 };
 

--- a/modules/phase_field/include/materials/ComputePolycrystalElasticityTensor.h
+++ b/modules/phase_field/include/materials/ComputePolycrystalElasticityTensor.h
@@ -47,7 +47,7 @@ protected:
   unsigned int _stiffness_buffer;
 
   /// Order parameters
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
 
   /// vector of elasticity tensor material properties
   std::vector< MaterialProperty<ElasticityTensorR4> *> _D_elastic_tensor;

--- a/modules/phase_field/include/materials/CrossTermBarrierFunctionMaterial.h
+++ b/modules/phase_field/include/materials/CrossTermBarrierFunctionMaterial.h
@@ -39,7 +39,7 @@ protected:
 
   /// order parameters
   unsigned int _num_eta;
-  std::vector<VariableValue *> _eta;
+  std::vector<const VariableValue *> _eta;
 
   /// Barrier functions and their drivatives
   MaterialProperty<Real> & _prop_g;

--- a/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
+++ b/modules/phase_field/include/materials/DerivativeTwoPhaseMaterial.h
@@ -35,7 +35,7 @@ protected:
   virtual Real computeD3F(unsigned int i_var, unsigned int j_var, unsigned int k_var);
 
   /// Phase parameter (0=A-phase, 1=B-phase)
-  VariableValue & _eta;
+  const VariableValue & _eta;
 
   /// name of the order parameter variable
   VariableName _eta_name;

--- a/modules/phase_field/include/materials/ExternalForceDensityMaterial.h
+++ b/modules/phase_field/include/materials/ExternalForceDensityMaterial.h
@@ -35,13 +35,13 @@ private:
   Function & _force_z;
 
   /// concentration field considered to be the density of particles
-  VariableValue & _c;
+  const VariableValue & _c;
   VariableName _c_name;
   /// stiffness constant
   Real _k;
 
   unsigned int _ncrys;
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
 
   /// force density material
   MaterialProperty<std::vector<RealGradient> > & _dF;

--- a/modules/phase_field/include/materials/ForceDensityMaterial.h
+++ b/modules/phase_field/include/materials/ForceDensityMaterial.h
@@ -30,7 +30,7 @@ protected:
 
 private:
   /// concentration field considered to be the density of particles
-  VariableValue & _c;
+  const VariableValue & _c;
   VariableName _c_name;
   /// equilibrium density at the grain boundaries
   Real _ceq;
@@ -40,8 +40,8 @@ private:
   Real _k;
 
   unsigned int _ncrys;
-  std::vector<VariableValue *> _vals;
-  std::vector<VariableGradient *> _grad_vals;
+  std::vector<const VariableValue *> _vals;
+  std::vector<const VariableGradient *> _grad_vals;
 
   std::vector<Real> _product_etas;
   std::vector<RealGradient> _sum_grad_etas;

--- a/modules/phase_field/include/materials/FunctionMaterialBase.h
+++ b/modules/phase_field/include/materials/FunctionMaterialBase.h
@@ -45,7 +45,7 @@ protected:
   }
 
   /// Coupled variables for function arguments
-  std::vector<VariableValue *> _args;
+  std::vector<const VariableValue *> _args;
 
   /**
    * Name of the function value material property and used as a base name to

--- a/modules/phase_field/include/materials/GBAnisotropy.h
+++ b/modules/phase_field/include/materials/GBAnisotropy.h
@@ -42,7 +42,7 @@ private:
 
   bool _inclination_anisotropy;
 
-  VariableValue & _T;
+  const VariableValue & _T;
 
   std::vector<std::vector<Real> > _sigma;
   std::vector<std::vector<Real> > _mob;
@@ -66,8 +66,8 @@ private:
 
   unsigned int _ncrys;
 
-  std::vector<VariableValue *> _vals;
-  std::vector<VariableGradient *> _grad_vals;
+  std::vector<const VariableValue *> _vals;
+  std::vector<const VariableGradient *> _grad_vals;
 };
 
 #endif //GBANISOTROPY_H

--- a/modules/phase_field/include/materials/GBEvolution.h
+++ b/modules/phase_field/include/materials/GBEvolution.h
@@ -34,7 +34,7 @@ private:
   Real _GBMobility;
   Real _molar_vol;
 
-  VariableValue & _T;
+  const VariableValue & _T;
 
   MaterialProperty<Real> & _sigma;
   MaterialProperty<Real> & _M_GB;

--- a/modules/phase_field/include/materials/GrainAdvectionVelocity.h
+++ b/modules/phase_field/include/materials/GrainAdvectionVelocity.h
@@ -50,8 +50,8 @@ private:
   Real _mr;
 
   unsigned int _ncrys;
-  std::vector<VariableValue *> _vals;
-  std::vector<VariableGradient *> _grad_vals;
+  std::vector<const VariableValue *> _vals;
+  std::vector<const VariableGradient *> _grad_vals;
   VariableName _c_name;
   /// type of force density material
   std::string _base_name;

--- a/modules/phase_field/include/materials/InterfaceOrientationMaterial.h
+++ b/modules/phase_field/include/materials/InterfaceOrientationMaterial.h
@@ -30,8 +30,8 @@ private:
   MaterialProperty<Real> & _eps;
   MaterialProperty<Real> & _deps;
 
-  VariableValue & _u;
-  VariableGradient & _grad_u;
+  const VariableValue & _u;
+  const VariableGradient & _grad_u;
 };
 
 #endif //INTERFACEORIENTATIONMATERIAL_H

--- a/modules/phase_field/include/materials/KKSXeVacSolidMaterial.h
+++ b/modules/phase_field/include/materials/KKSXeVacSolidMaterial.h
@@ -44,9 +44,9 @@ private:
   /// (TODO: if cmg>cmv consider interstitial Xe)
   const Real _Efg;
 
-  VariableValue & _cmg;
+  const VariableValue & _cmg;
   unsigned int _cmg_var;
-  VariableValue & _cmv;
+  const VariableValue & _cmv;
   unsigned int _cmv_var;
 
   // helper function to return a well defined c*log(c)

--- a/modules/phase_field/include/materials/MathFreeEnergy.h
+++ b/modules/phase_field/include/materials/MathFreeEnergy.h
@@ -32,7 +32,7 @@ protected:
 
 private:
   /// Coupled variable value for the concentration \f$ c \f$.
-  VariableValue & _c;
+  const VariableValue & _c;
   unsigned int _c_var;
 };
 

--- a/modules/phase_field/include/materials/MultiBarrierFunctionMaterial.h
+++ b/modules/phase_field/include/materials/MultiBarrierFunctionMaterial.h
@@ -39,7 +39,7 @@ protected:
 
   /// order parameters
   unsigned int _num_eta;
-  std::vector<VariableValue *> _eta;
+  std::vector<const VariableValue *> _eta;
 
   /// Barrier functions and their drivatives
   MaterialProperty<Real> & _prop_g;

--- a/modules/phase_field/include/materials/PFParamsPolyFreeEnergy.h
+++ b/modules/phase_field/include/materials/PFParamsPolyFreeEnergy.h
@@ -21,8 +21,8 @@ protected:
   virtual void computeQpProperties();
 
   ///Variable values
-  VariableValue & _c;
-  VariableValue & _T;
+  const VariableValue & _c;
+  const VariableValue & _T;
 
   ///Mateiral property declarations
   MaterialProperty<Real> & _M;

--- a/modules/phase_field/include/postprocessors/PFCElementEnergyIntegral.h
+++ b/modules/phase_field/include/postprocessors/PFCElementEnergyIntegral.h
@@ -43,13 +43,13 @@ protected:
   MooseVariable & _var;
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 
   /// Holds the solution derivative at the current quadrature points
-  VariableValue & _u_dot;
+  const VariableValue & _u_dot;
 
   /// Temperature
   const Real _temp;

--- a/modules/phase_field/include/userobjects/ComputeGrainCenterUserObject.h
+++ b/modules/phase_field/include/userobjects/ComputeGrainCenterUserObject.h
@@ -34,7 +34,7 @@ public:
 protected:
   unsigned int _qp;
   unsigned int _ncrys;
-  std::vector<VariableValue *> _vals;
+  std::vector<const VariableValue *> _vals;
   unsigned int _ncomp;
   ///@{ storing volumes and centers of all the grains
   std::vector<Real> _grain_data;

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -825,9 +825,9 @@ GrainTracker::swapSolutionValuesHelper(Node * curr_node, unsigned int curr_var_i
 
     // Swap the values from one variable to the other
     {
-      VariableValue & value = _vars[curr_var_idx]->nodalSln();
-      VariableValue & value_old = _vars[curr_var_idx]->nodalSlnOld();
-      VariableValue & value_older = _vars[curr_var_idx]->nodalSlnOlder();
+      const VariableValue & value = _vars[curr_var_idx]->nodalSln();
+      const VariableValue & value_old = _vars[curr_var_idx]->nodalSlnOld();
+      const VariableValue & value_older = _vars[curr_var_idx]->nodalSlnOlder();
 
       // Copy Value from intersecting variable to new variable
       dof_id_type & dof_index = _vars[new_var_idx]->nodalDofIndex();
@@ -838,9 +838,9 @@ GrainTracker::swapSolutionValuesHelper(Node * curr_node, unsigned int curr_var_i
       solution_older.set(dof_index, value_older[0]);
     }
     {
-      VariableValue & value = _vars[new_var_idx]->nodalSln();
-      VariableValue & value_old = _vars[new_var_idx]->nodalSlnOld();
-      VariableValue & value_older = _vars[new_var_idx]->nodalSlnOlder();
+      const VariableValue & value = _vars[new_var_idx]->nodalSln();
+      const VariableValue & value_old = _vars[new_var_idx]->nodalSlnOld();
+      const VariableValue & value_older = _vars[new_var_idx]->nodalSlnOlder();
 
       // Copy Value from variable to the intersecting variable
       dof_id_type & dof_index = _vars[curr_var_idx]->nodalDofIndex();

--- a/modules/richards/include/auxkernels/DarcyFluxComponent.h
+++ b/modules/richards/include/auxkernels/DarcyFluxComponent.h
@@ -41,7 +41,7 @@ protected:
   virtual Real computeValue();
 
   /// gradient of the pressure
-  VariableGradient & _grad_pp;
+  const VariableGradient & _grad_pp;
 
   /// fluid weight (gravity*density) as a vector pointing downwards, eg '0 0 -10000'
   RealVectorValue _fluid_weight;

--- a/modules/richards/include/auxkernels/RichardsDensityAux.h
+++ b/modules/richards/include/auxkernels/RichardsDensityAux.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeValue();
 
   /// porepressure
-  VariableValue & _pressure_var;
+  const VariableValue & _pressure_var;
 
   /// userobject that defines density as a fcn of porepressure
   const RichardsDensity & _density_UO;

--- a/modules/richards/include/auxkernels/RichardsDensityPrimeAux.h
+++ b/modules/richards/include/auxkernels/RichardsDensityPrimeAux.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeValue();
 
   /// porepressure
-  VariableValue & _pressure_var;
+  const VariableValue & _pressure_var;
 
   /// userobject that defines density as a fcn of porepressure
   const RichardsDensity & _density_UO;

--- a/modules/richards/include/auxkernels/RichardsDensityPrimePrimeAux.h
+++ b/modules/richards/include/auxkernels/RichardsDensityPrimePrimeAux.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeValue();
 
   /// porepressure
-  VariableValue & _pressure_var;
+  const VariableValue & _pressure_var;
 
   /// userobject that defines density as a fcn of porepressure
   const RichardsDensity & _density_UO;

--- a/modules/richards/include/auxkernels/RichardsRelPermAux.h
+++ b/modules/richards/include/auxkernels/RichardsRelPermAux.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeValue();
 
   /// effective saturation
-  VariableValue & _seff_var;
+  const VariableValue & _seff_var;
 
   /// userobject that defines relative permeability function
   const RichardsRelPerm & _relperm_UO;

--- a/modules/richards/include/auxkernels/RichardsRelPermPrimeAux.h
+++ b/modules/richards/include/auxkernels/RichardsRelPermPrimeAux.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeValue();
 
   /// effective saturation
-  VariableValue & _seff_var;
+  const VariableValue & _seff_var;
 
   /// userobject that defines relative permeability function
   const RichardsRelPerm & _relperm_UO;

--- a/modules/richards/include/auxkernels/RichardsRelPermPrimePrimeAux.h
+++ b/modules/richards/include/auxkernels/RichardsRelPermPrimePrimeAux.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeValue();
 
   /// effective saturation
-  VariableValue & _seff_var;
+  const VariableValue & _seff_var;
 
   /// userobject that defines relative permeability function
   const RichardsRelPerm & _relperm_UO;

--- a/modules/richards/include/auxkernels/RichardsSatAux.h
+++ b/modules/richards/include/auxkernels/RichardsSatAux.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeValue();
 
   /// effective saturation
-  VariableValue & _seff_var;
+  const VariableValue & _seff_var;
 
   /// User object defining saturation as a function of effective saturation
   const RichardsSat & _sat_UO;

--- a/modules/richards/include/auxkernels/RichardsSatPrimeAux.h
+++ b/modules/richards/include/auxkernels/RichardsSatPrimeAux.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeValue();
 
   /// effective saturation
-  VariableValue & _seff_var;
+  const VariableValue & _seff_var;
 
   /// User object defining saturation as a function of effective saturation
   const RichardsSat & _sat_UO;

--- a/modules/richards/include/auxkernels/RichardsSeffAux.h
+++ b/modules/richards/include/auxkernels/RichardsSeffAux.h
@@ -42,7 +42,7 @@ protected:
    * where N is the number of arguments that the _seff_UO requires)
    * Eg, for twophase simulations N=2
    */
-  std::vector<VariableValue *> _pressure_vals;
+  std::vector<const VariableValue *> _pressure_vals;
 };
 
 #endif // RICHARDSSEFFAUX_H

--- a/modules/richards/include/auxkernels/RichardsSeffPrimeAux.h
+++ b/modules/richards/include/auxkernels/RichardsSeffPrimeAux.h
@@ -48,7 +48,7 @@ protected:
    * where N is the number of arguments that the _seff_UO requires)
    * Eg, for twophase simulations N=2
    */
-  std::vector<VariableValue *> _pressure_vals;
+  std::vector<const VariableValue *> _pressure_vals;
 
   /// array of derivtives: This auxkernel returns _mat[_wrt1]
   std::vector<Real> _mat;

--- a/modules/richards/include/auxkernels/RichardsSeffPrimePrimeAux.h
+++ b/modules/richards/include/auxkernels/RichardsSeffPrimePrimeAux.h
@@ -54,7 +54,7 @@ protected:
    * where N is the number of arguments that the _seff_UO requires)
    * Eg, for twophase simulations N=2
    */
-  std::vector<VariableValue *> _pressure_vals;
+  std::vector<const VariableValue *> _pressure_vals;
 
   /// matrix of 2nd derivtives: This auxkernel returns _mat[_wrt1][_wrt2];
   std::vector<std::vector<Real> > _mat;

--- a/modules/richards/include/bcs/Q2PPiecewiseLinearSink.h
+++ b/modules/richards/include/bcs/Q2PPiecewiseLinearSink.h
@@ -72,7 +72,7 @@ protected:
   const RichardsRelPerm & _relperm;
 
   /// the other variable in the 2-phase system (this is saturation if Variable=porepressure, and viceversa)
-  VariableValue & _other_var_nodal;
+  const VariableValue & _other_var_nodal;
 
   /// the variable number of the other variable
   unsigned int _other_var_num;

--- a/modules/richards/include/bcs/RichardsPiecewiseLinearSink.h
+++ b/modules/richards/include/bcs/RichardsPiecewiseLinearSink.h
@@ -156,7 +156,7 @@ protected:
    * _ps_at_nodes[_pvar] is a pointer to this variable's nodal porepressure values
    * So: (*_ps_at_nodes[_pvar])[i] = _var.nodalSln()[i] = porepressure of pressure-variable _pvar at node i
    */
-  std::vector<VariableValue *> _ps_at_nodes;
+  std::vector<const VariableValue *> _ps_at_nodes;
 
 
   /// calculates the nodal values of pressure, mobility, and derivatives thereof

--- a/modules/richards/include/dirackernels/Q2PBorehole.h
+++ b/modules/richards/include/dirackernels/Q2PBorehole.h
@@ -85,7 +85,7 @@ protected:
   const RichardsRelPerm & _relperm;
 
   /// the other variable in the 2-phase system (this is saturation if Variable=porepressure, and viceversa)
-  VariableValue & _other_var_nodal;
+  const VariableValue & _other_var_nodal;
 
   /// the variable number of the other variable
   unsigned int _other_var_num;

--- a/modules/richards/include/dirackernels/RichardsBorehole.h
+++ b/modules/richards/include/dirackernels/RichardsBorehole.h
@@ -220,7 +220,7 @@ protected:
    * _ps_at_nodes[_pvar] is a pointer to this variable's nodal porepressure values
    * So: (*_ps_at_nodes[_pvar])[i] = _var.nodalSln()[i] = porepressure of pressure-variable _pvar at node i
    */
-  std::vector<VariableValue *> _ps_at_nodes;
+  std::vector<const VariableValue *> _ps_at_nodes;
 
 
   /// reads a space-separated line of floats from ifs and puts in myvec

--- a/modules/richards/include/kernels/Q2PNegativeNodalMassOld.h
+++ b/modules/richards/include/kernels/Q2PNegativeNodalMassOld.h
@@ -36,7 +36,7 @@ protected:
   const RichardsDensity & _density;
 
   /// old value of the other variable (this is porepressure if the Variable is saturation)
-  VariableValue & _other_var_nodal_old;
+  const VariableValue & _other_var_nodal_old;
 
   /// whether the "other variable" is actually porepressure
   bool _var_is_pp;

--- a/modules/richards/include/kernels/Q2PNodalMass.h
+++ b/modules/richards/include/kernels/Q2PNodalMass.h
@@ -39,7 +39,7 @@ protected:
   const RichardsDensity & _density;
 
   /// the other variable (this is porepressure if the Variable is saturation)
-  VariableValue & _other_var_nodal;
+  const VariableValue & _other_var_nodal;
 
   /// variable number of the other variable
   unsigned int _other_var_num;
@@ -49,7 +49,6 @@ protected:
 
   /// current value of the porosity
   const MaterialProperty<Real> & _porosity;
-
 };
 
 #endif //Q2PNODALMASS

--- a/modules/richards/include/kernels/Q2PPorepressureFlux.h
+++ b/modules/richards/include/kernels/Q2PPorepressureFlux.h
@@ -93,7 +93,7 @@ protected:
   const RichardsDensity & _density;
 
   /// saturation at the nodes
-  VariableValue & _sat;
+  const VariableValue & _sat;
 
   /// variable number of the saturation variable
   unsigned int _sat_var;
@@ -130,7 +130,6 @@ protected:
    * These are used in the jacobian calculations
    */
   std::vector<Real> _dmobility_ds;
-
 };
 
 #endif //Q2PPOREPRESSUREFLUX

--- a/modules/richards/include/kernels/Q2PSaturationDiffusion.h
+++ b/modules/richards/include/kernels/Q2PSaturationDiffusion.h
@@ -47,7 +47,7 @@ protected:
   const RichardsRelPerm & _relperm;
 
   /// porepressure at the quadpoints
-  VariableValue & _pp;
+  const VariableValue & _pp;
 
   /// variable number of the porepressure variable
   unsigned int _pp_var_num;
@@ -59,7 +59,6 @@ protected:
   const MaterialProperty<RealTensorValue> & _permeability;
 
   Real _diffusivity;
-
 };
 
 #endif //Q2PSATURATIONDIFFUSION

--- a/modules/richards/include/kernels/Q2PSaturationFlux.h
+++ b/modules/richards/include/kernels/Q2PSaturationFlux.h
@@ -93,13 +93,13 @@ protected:
   const RichardsDensity & _density;
 
   /// porepressure at the quadpoints
-  VariableValue & _pp;
+  const VariableValue & _pp;
 
   /// grad(porepressure) at the quadpoints
-  VariableGradient & _grad_pp;
+  const VariableGradient & _grad_pp;
 
   /// porepressure at the nodes
-  VariableValue & _pp_nodal;
+  const VariableValue & _pp_nodal;
 
   /// variable number of the porepressure variable
   unsigned int _pp_var;

--- a/modules/richards/include/kernels/RichardsFlux.h
+++ b/modules/richards/include/kernels/RichardsFlux.h
@@ -72,10 +72,10 @@ protected:
 
 
   /// grad_i grad_j porepressure.  This is used in SUPG
-  VariableSecond & _second_u;
+  const VariableSecond & _second_u;
 
   /// interpolation function for the _second_u
-  VariablePhiSecond & _second_phi;
+  const VariablePhiSecond & _second_phi;
 
   /// SUPGtau*SUPGvel (a vector of these if multiphase)
   const MaterialProperty<std::vector<RealVectorValue> >&_tauvel_SUPG;

--- a/modules/richards/include/kernels/RichardsFullyUpwindFlux.h
+++ b/modules/richards/include/kernels/RichardsFullyUpwindFlux.h
@@ -150,9 +150,7 @@ protected:
    * _ps_at_nodes[_pvar] is a pointer to this variable's nodal porepressure values
    * So: (*_ps_at_nodes[_pvar])[i] = _var.nodalSln()[i] = value of porepressure at node i
    */
-  std::vector<VariableValue *> _ps_at_nodes;
-
-
+  std::vector<const VariableValue *> _ps_at_nodes;
 };
 
 #endif //RICHARDSFULLYUPWINDFLUX

--- a/modules/richards/include/kernels/RichardsLumpedMassChange.h
+++ b/modules/richards/include/kernels/RichardsLumpedMassChange.h
@@ -81,10 +81,10 @@ protected:
    * _ps_at_nodes[_pvar] is a pointer to this variable's nodal porepressure values
    * So: (*_ps_at_nodes[_pvar])[i] = _var.nodalSln()[i]
    */
-  std::vector<VariableValue *> _ps_at_nodes;
+  std::vector<const VariableValue *> _ps_at_nodes;
 
   /// Holds the nodal values of pressures at timestep_begin, in same way as _ps_at_nodes
-  std::vector<VariableValue *> _ps_old_at_nodes;
+  std::vector<const VariableValue *> _ps_old_at_nodes;
 
   /// holds nodal values of d(Seff)/dP_i
   std::vector<Real> _dseff;

--- a/modules/richards/include/kernels/RichardsPPenalty.h
+++ b/modules/richards/include/kernels/RichardsPPenalty.h
@@ -39,11 +39,10 @@ private:
   Real _a;
 
   /// Kernel = a*(_lower - variable) for variable<lower and zero otherwise
-  VariableValue & _lower;
+  const VariableValue & _lower;
 
   /// moose variable number of the _lower variable (needed for OffDiagJacobian)
   unsigned int _lower_var_num;
-
 };
 
 #endif //RICHARDSPPENALTY

--- a/modules/richards/include/materials/PoroFullSatMaterial.h
+++ b/modules/richards/include/materials/PoroFullSatMaterial.h
@@ -48,7 +48,7 @@ protected:
   bool _constant_porosity;
 
   /// porepressure variable
-  VariableValue & _porepressure;
+  const VariableValue & _porepressure;
 
   /// name given by user to the porepressure variable
   std::string _porepressure_name;
@@ -57,7 +57,7 @@ protected:
   unsigned int _ndisp;
 
   /// grad(displacement)
-  std::vector<VariableGradient *> _grad_disp;
+  std::vector<const VariableGradient *> _grad_disp;
 
   /// volumetric strain = strain_ii
   MaterialProperty<Real> & _vol_strain;

--- a/modules/richards/include/materials/Q2PMaterial.h
+++ b/modules/richards/include/materials/Q2PMaterial.h
@@ -31,8 +31,8 @@ protected:
   Real _material_por;
 
   /// porosity changes.  if not entered they default to zero
-  VariableValue & _por_change;
-  VariableValue & _por_change_old;
+  const VariableValue & _por_change;
+  const VariableValue & _por_change_old;
 
   /// permeability as entered by the user
   RealTensorValue _material_perm;
@@ -46,7 +46,7 @@ protected:
   MaterialProperty<RealTensorValue> & _permeability;
   MaterialProperty<RealVectorValue> & _gravity;
 
-  std::vector<VariableValue *> _perm_change;
+  std::vector<const VariableValue *> _perm_change;
 
   virtual void computeQpProperties();
 };

--- a/modules/richards/include/materials/RichardsMaterial.h
+++ b/modules/richards/include/materials/RichardsMaterial.h
@@ -35,8 +35,8 @@ protected:
   Real _material_por;
 
   /// porosity changes.  if not entered they default to zero
-  VariableValue & _por_change;
-  VariableValue & _por_change_old;
+  const VariableValue & _por_change;
+  const VariableValue & _por_change_old;
 
   /// permeability as entered by the user
   RealTensorValue _material_perm;
@@ -61,7 +61,7 @@ protected:
   std::vector<const RichardsDensity *> _material_density_UO;
   std::vector<const RichardsSUPG *> _material_SUPG_UO;
 
-  std::vector<VariableValue *> _perm_change;
+  std::vector<const VariableValue *> _perm_change;
 
 
 
@@ -221,9 +221,9 @@ protected:
 
 
 
-  std::vector<VariableValue *> _pressure_vals;
-  std::vector<VariableValue *> _pressure_old_vals;
-  std::vector<VariableGradient *> _grad_p;
+  std::vector<const VariableValue *> _pressure_vals;
+  std::vector<const VariableValue *> _pressure_old_vals;
+  std::vector<const VariableGradient *> _grad_p;
 
 
   /**

--- a/modules/richards/include/postprocessors/NodalMaxVarChange.h
+++ b/modules/richards/include/postprocessors/NodalMaxVarChange.h
@@ -35,7 +35,7 @@ public:
 protected:
 
   /// old variable value at quad points
-  VariableValue & _u_old;
+  const VariableValue & _u_old;
 
   /// max(abs(_u - _u_old))
   Real _value;

--- a/modules/richards/include/postprocessors/Q2PPiecewiseLinearSinkFlux.h
+++ b/modules/richards/include/postprocessors/Q2PPiecewiseLinearSinkFlux.h
@@ -47,7 +47,7 @@ protected:
   Function & _m_func;
 
   /// the porepressure variable
-  VariableValue & _pp;
+  const VariableValue & _pp;
 
   /// whether to include density*permeability_nn/viscosity in the flux
   bool _use_mobility;
@@ -65,7 +65,7 @@ protected:
   const RichardsRelPerm * _relperm;
 
   /// saturation variable, optional
-  VariableValue & _sat;
+  const VariableValue & _sat;
 
   /// medium permeability
   const MaterialProperty<RealTensorValue> & _permeability;

--- a/modules/richards/include/userobjects/RichardsSeff.h
+++ b/modules/richards/include/userobjects/RichardsSeff.h
@@ -35,7 +35,7 @@ public:
    * @param p the porepressure(s).  Eg (*p[0])[qp] is the zeroth pressure evaluated at quadpoint qp
    * @param qp the quad point of the element to evaluate effective saturation at.
    */
-  virtual Real seff(std::vector<VariableValue *> p, unsigned int qp) const = 0;
+  virtual Real seff(std::vector<const VariableValue *> p, unsigned int qp) const = 0;
 
   /**
    * derivative(s) of effective saturation as a function of porepressure(s) at given quadpoint of the element
@@ -44,7 +44,7 @@ public:
    * @param qp the quad point of the element to evaluate the derivative at
    * @param result the derivtives will be placed in this array
    */
-  virtual void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const = 0;
+  virtual void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const = 0;
 
   /**
    * second derivative(s) of effective saturation as a function of porepressure(s) at given quadpoint of the element
@@ -53,8 +53,8 @@ public:
    * @param qp the quad point of the element to evaluate the derivative at
    * @param result the derivtives will be placed in this array
    */
-  //virtual std::vector<std::vector<Real> > d2seff(std::vector<VariableValue *> p, unsigned int qp) const = 0;
-  virtual void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const = 0;
+  //virtual std::vector<std::vector<Real> > d2seff(std::vector<const VariableValue *> p, unsigned int qp) const = 0;
+  virtual void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const = 0;
 
 };
 

--- a/modules/richards/include/userobjects/RichardsSeff1BWsmall.h
+++ b/modules/richards/include/userobjects/RichardsSeff1BWsmall.h
@@ -39,7 +39,7 @@ public:
    * @param p porepressure in the element.  Note that (*p[0])[qp] is the porepressure at quadpoint qp
    * @param qp the quad point to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -47,7 +47,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -55,7 +55,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff1RSC.h
+++ b/modules/richards/include/userobjects/RichardsSeff1RSC.h
@@ -35,7 +35,7 @@ public:
    * @param p porepressures.  Here (*p[0])[qp] is the water pressure at quadpoint qp
    * @param qp the quadpoint to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -43,7 +43,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -51,7 +51,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff1VG.h
+++ b/modules/richards/include/userobjects/RichardsSeff1VG.h
@@ -34,7 +34,7 @@ public:
    * @param p porepressure in the element.  Note that (*p[0])[qp] is the porepressure at quadpoint qp
    * @param qp the quad point to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -42,7 +42,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -50,7 +50,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff1VGcut.h
+++ b/modules/richards/include/userobjects/RichardsSeff1VGcut.h
@@ -41,7 +41,7 @@ public:
    * @param p porepressure in the element.  Note that (*p[0])[qp] is the porepressure at quadpoint qp
    * @param qp the quad point to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -49,7 +49,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -57,7 +57,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff2gasRSC.h
+++ b/modules/richards/include/userobjects/RichardsSeff2gasRSC.h
@@ -35,7 +35,7 @@ public:
    * @param p porepressures.  Here (*p[0])[qp] is the water pressure at quadpoint qp, and (*p[1])[qp] is the gas porepressure
    * @param qp the quadpoint to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -43,7 +43,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -51,7 +51,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff2gasVG.h
+++ b/modules/richards/include/userobjects/RichardsSeff2gasVG.h
@@ -33,7 +33,7 @@ public:
    * @param p porepressures.  Here (*p[0])[qp] is the water pressure at quadpoint qp, and (*p[1])[qp] is the gas porepressure
    * @param qp the quadpoint to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -41,7 +41,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -49,7 +49,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff2gasVGshifted.h
+++ b/modules/richards/include/userobjects/RichardsSeff2gasVGshifted.h
@@ -36,7 +36,7 @@ public:
    * @param p porepressures.  Here (*p[0])[qp] is the water pressure at quadpoint qp, and (*p[1])[qp] is the gas porepressure
    * @param qp the quadpoint to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -44,7 +44,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -52,7 +52,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff2waterRSC.h
+++ b/modules/richards/include/userobjects/RichardsSeff2waterRSC.h
@@ -35,7 +35,7 @@ public:
    * @param p porepressures.  Here (*p[0])[qp] is the water pressure at quadpoint qp, and (*p[1])[qp] is the gas porepressure
    * @param qp the quadpoint to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -43,7 +43,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -51,7 +51,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff2waterVG.h
+++ b/modules/richards/include/userobjects/RichardsSeff2waterVG.h
@@ -33,7 +33,7 @@ public:
    * @param p porepressures.  Here (*p[0])[qp] is the water pressure at quadpoint qp, and (*p[1])[qp] is the gas porepressure
    * @param qp the quadpoint to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -41,7 +41,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -49,7 +49,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsSeff2waterVGshifted.h
+++ b/modules/richards/include/userobjects/RichardsSeff2waterVGshifted.h
@@ -36,7 +36,7 @@ public:
    * @param p porepressures.  Here (*p[0])[qp] is the water pressure at quadpoint qp, and (*p[1])[qp] is the gas porepressure
    * @param qp the quadpoint to evaluate effective saturation at
    */
-  Real seff(std::vector<VariableValue *> p, unsigned int qp) const;
+  Real seff(std::vector<const VariableValue *> p, unsigned int qp) const;
 
   /**
    * derivative of effective saturation as a function of porepressure
@@ -44,7 +44,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
+  void dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const;
 
   /**
    * second derivative of effective saturation as a function of porepressure
@@ -52,7 +52,7 @@ public:
    * @param qp the quad point to evaluate effective saturation at
    * @param result the derivtives will be placed in this array
    */
-  void d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
+  void d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const;
 
 protected:
 

--- a/modules/richards/include/userobjects/RichardsVarNames.h
+++ b/modules/richards/include/userobjects/RichardsVarNames.h
@@ -79,7 +79,7 @@ class RichardsVarNames :
    * (*richards_vals(1))[qp] = pgas evaluated at quadpoint qp
    * Also richards_vals(i) = &coupledValue
    */
-  VariableValue * richards_vals(unsigned int richards_var_num) const;
+  const VariableValue * richards_vals(unsigned int richards_var_num) const;
 
   /**
    * a vector of pointers to old VariableValues
@@ -88,7 +88,7 @@ class RichardsVarNames :
    * (*richards_vals_old(1))[qp] = old pgas evaluated at quadpoint qp
    * Also richards_vals_old(i) = &coupledValueOld
    */
-  VariableValue * richards_vals_old(unsigned int richards_var_num) const;
+  const VariableValue * richards_vals_old(unsigned int richards_var_num) const;
 
   /**
    * a vector of pointers to grad(Variable)
@@ -97,7 +97,7 @@ class RichardsVarNames :
    * (*grad_var(1))[qp] = grad(pgas) evaluated at quadpoint qp
    * Also grad_var(i) = &coupledGradient
    */
-  VariableGradient * grad_var(unsigned int richards_var_num) const;
+  const VariableGradient * grad_var(unsigned int richards_var_num) const;
 
   /**
    * The moose variable for the given richards_var_num
@@ -106,7 +106,7 @@ class RichardsVarNames :
    * used in mass lumping.
    * @param richards_var_num the richards variable number
    */
-  MooseVariable * raw_var(unsigned int richards_var_num) const;
+  const MooseVariable * raw_var(unsigned int richards_var_num) const;
 
   /**
    * The nodal variable values for the given richards_var_num
@@ -114,13 +114,13 @@ class RichardsVarNames :
    * node i, use (*RichardsVarNames.nodal_var(pvar))[i]
    * @param richards_var_num the richards variable number
    */
-  VariableValue * nodal_var(unsigned int richards_var_num) const;
+  const VariableValue * nodal_var(unsigned int richards_var_num) const;
 
   /**
    * The old nodal variable values for the given richards_var_num
    * @param richards_var_num the richards variable number
    */
-  VariableValue * nodal_var_old(unsigned int richards_var_num) const;
+  const VariableValue * nodal_var_old(unsigned int richards_var_num) const;
 
   /// return the _var_types string
   std::string var_types() const;
@@ -144,23 +144,22 @@ class RichardsVarNames :
   std::vector<unsigned int> _ps_var_num;
 
   /// moose_var_value[i] = values of richards variable i
-  std::vector<VariableValue *> _moose_var_value; // this is a vector of pointers to VariableValues
+  std::vector<const VariableValue *> _moose_var_value; // this is a vector of pointers to VariableValues
 
   /// moose_var_value_old[i] = old values of richards variable i
-  std::vector<VariableValue *> _moose_var_value_old;
+  std::vector<const VariableValue *> _moose_var_value_old;
 
   /// moose_var_value[i] = values of richards variable i
-  std::vector<VariableValue *> _moose_nodal_var_value; // this is a vector of pointers to VariableValues
+  std::vector<const VariableValue *> _moose_nodal_var_value; // this is a vector of pointers to VariableValues
 
   /// moose_var_value_old[i] = old values of richards variable i
-  std::vector<VariableValue *> _moose_nodal_var_value_old;
+  std::vector<const VariableValue *> _moose_nodal_var_value_old;
 
   /// moose_grad_var[i] = gradient values of richards variable i
-  std::vector<VariableGradient *> _moose_grad_var;
+  std::vector<const VariableGradient *> _moose_grad_var;
 
   /// _moose_raw_var[i] = getVar of richards variable i
-  std::vector<MooseVariable *> _moose_raw_var;
-
+  std::vector<const MooseVariable *> _moose_raw_var;
 };
 
 #endif // RICHARDSVARNAMES_H

--- a/modules/richards/src/userobjects/RichardsSeff1BWsmall.C
+++ b/modules/richards/src/userobjects/RichardsSeff1BWsmall.C
@@ -113,7 +113,7 @@ RichardsSeff1BWsmall::LambertW(const Real z) const
 }
 
 Real
-RichardsSeff1BWsmall::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff1BWsmall::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   Real pp = (*p[0])[qp];
   if (pp >= 0)
@@ -125,7 +125,7 @@ RichardsSeff1BWsmall::seff(std::vector<VariableValue *> p, unsigned int qp) cons
 }
 
 void
-RichardsSeff1BWsmall::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
+RichardsSeff1BWsmall::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
 {
   result[0] = 0.0;
 
@@ -139,7 +139,7 @@ RichardsSeff1BWsmall::dseff(std::vector<VariableValue *> p, unsigned int qp, std
 }
 
 void
-RichardsSeff1BWsmall::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
+RichardsSeff1BWsmall::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
 {
   result[0][0] = 0.0;
 

--- a/modules/richards/src/userobjects/RichardsSeff1RSC.C
+++ b/modules/richards/src/userobjects/RichardsSeff1RSC.C
@@ -34,21 +34,21 @@ RichardsSeff1RSC::RichardsSeff1RSC(const InputParameters & parameters) :
 {}
 
 Real
-RichardsSeff1RSC::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff1RSC::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   Real pc = -(*p[0])[qp];
   return RichardsSeffRSC::seff(pc, _shift, _scale);
 }
 
 void
-RichardsSeff1RSC::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
+RichardsSeff1RSC::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
 {
   Real pc = -(*p[0])[qp];
   result[0] = -RichardsSeffRSC::dseff(pc, _shift, _scale);
 }
 
 void
-RichardsSeff1RSC::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
+RichardsSeff1RSC::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
 {
   Real pc = -(*p[0])[qp];
   result[0][0] =  RichardsSeffRSC::d2seff(pc, _shift, _scale);

--- a/modules/richards/src/userobjects/RichardsSeff1VG.C
+++ b/modules/richards/src/userobjects/RichardsSeff1VG.C
@@ -29,19 +29,19 @@ RichardsSeff1VG::RichardsSeff1VG(const InputParameters & parameters) :
 
 
 Real
-RichardsSeff1VG::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff1VG::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   return RichardsSeffVG::seff((*p[0])[qp], _al, _m);
 }
 
 void
-RichardsSeff1VG::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const
+RichardsSeff1VG::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const
 {
   result[0] = RichardsSeffVG::dseff((*p[0])[qp], _al, _m);
 }
 
 void
-RichardsSeff1VG::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const
+RichardsSeff1VG::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const
 {
   result[0][0] = RichardsSeffVG::d2seff((*p[0])[qp], _al, _m);
 }

--- a/modules/richards/src/userobjects/RichardsSeff1VGcut.C
+++ b/modules/richards/src/userobjects/RichardsSeff1VGcut.C
@@ -40,7 +40,7 @@ RichardsSeff1VGcut::initialSetup()
 
 
 Real
-RichardsSeff1VGcut::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff1VGcut::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   if ((*p[0])[qp] > _p_cut)
   {
@@ -55,7 +55,7 @@ RichardsSeff1VGcut::seff(std::vector<VariableValue *> p, unsigned int qp) const
 }
 
 void
-RichardsSeff1VGcut::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
+RichardsSeff1VGcut::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
 {
   if ((*p[0])[qp] > _p_cut)
     return RichardsSeff1VG::dseff(p, qp, result);
@@ -64,7 +64,7 @@ RichardsSeff1VGcut::dseff(std::vector<VariableValue *> p, unsigned int qp, std::
 }
 
 void
-RichardsSeff1VGcut::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
+RichardsSeff1VGcut::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
 {
   if ((*p[0])[qp] > _p_cut)
     return RichardsSeff1VG::d2seff(p, qp, result);

--- a/modules/richards/src/userobjects/RichardsSeff2gasRSC.C
+++ b/modules/richards/src/userobjects/RichardsSeff2gasRSC.C
@@ -34,14 +34,14 @@ RichardsSeff2gasRSC::RichardsSeff2gasRSC(const InputParameters & parameters) :
 
 
 Real
-RichardsSeff2gasRSC::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff2gasRSC::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   Real pc = (*p[1])[qp] - (*p[0])[qp];
   return 1 - RichardsSeffRSC::seff(pc, _shift, _scale);
 }
 
 void
-RichardsSeff2gasRSC::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
+RichardsSeff2gasRSC::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
 {
   Real pc = (*p[1])[qp] - (*p[0])[qp];
   result[1] = -RichardsSeffRSC::dseff(pc, _shift, _scale);
@@ -49,7 +49,7 @@ RichardsSeff2gasRSC::dseff(std::vector<VariableValue *> p, unsigned int qp, std:
 }
 
 void
-RichardsSeff2gasRSC::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
+RichardsSeff2gasRSC::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
 {
   Real pc = (*p[1])[qp] - (*p[0])[qp];
   result[1][1] = -RichardsSeffRSC::d2seff(pc, _shift, _scale);

--- a/modules/richards/src/userobjects/RichardsSeff2gasVG.C
+++ b/modules/richards/src/userobjects/RichardsSeff2gasVG.C
@@ -30,14 +30,14 @@ RichardsSeff2gasVG::RichardsSeff2gasVG(const InputParameters & parameters) :
 
 
 Real
-RichardsSeff2gasVG::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff2gasVG::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   return 1 - RichardsSeffVG::seff(negpc, _al, _m);
 }
 
 void
-RichardsSeff2gasVG::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
+RichardsSeff2gasVG::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   result[0] = -RichardsSeffVG::dseff(negpc, _al, _m);
@@ -45,7 +45,7 @@ RichardsSeff2gasVG::dseff(std::vector<VariableValue *> p, unsigned int qp, std::
 }
 
 void
-RichardsSeff2gasVG::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
+RichardsSeff2gasVG::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   result[0][0] = -RichardsSeffVG::d2seff(negpc, _al, _m);

--- a/modules/richards/src/userobjects/RichardsSeff2gasVGshifted.C
+++ b/modules/richards/src/userobjects/RichardsSeff2gasVGshifted.C
@@ -33,7 +33,7 @@ RichardsSeff2gasVGshifted::RichardsSeff2gasVGshifted(const InputParameters & par
 
 
 Real
-RichardsSeff2gasVGshifted::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff2gasVGshifted::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   negpc = negpc - _shift;
@@ -41,7 +41,7 @@ RichardsSeff2gasVGshifted::seff(std::vector<VariableValue *> p, unsigned int qp)
 }
 
 void
-RichardsSeff2gasVGshifted::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const
+RichardsSeff2gasVGshifted::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   negpc = negpc - _shift;
@@ -51,7 +51,7 @@ RichardsSeff2gasVGshifted::dseff(std::vector<VariableValue *> p, unsigned int qp
 
 
 void
-RichardsSeff2gasVGshifted::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const
+RichardsSeff2gasVGshifted::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   negpc = negpc - _shift;

--- a/modules/richards/src/userobjects/RichardsSeff2waterRSC.C
+++ b/modules/richards/src/userobjects/RichardsSeff2waterRSC.C
@@ -34,14 +34,14 @@ RichardsSeff2waterRSC::RichardsSeff2waterRSC(const InputParameters & parameters)
 
 
 Real
-RichardsSeff2waterRSC::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff2waterRSC::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   Real pc = (*p[1])[qp] - (*p[0])[qp];
   return RichardsSeffRSC::seff(pc, _shift, _scale);
 }
 
 void
-RichardsSeff2waterRSC::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const
+RichardsSeff2waterRSC::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const
 {
   Real pc = (*p[1])[qp] - (*p[0])[qp];
   result[1] = RichardsSeffRSC::dseff(pc, _shift, _scale);
@@ -49,7 +49,7 @@ RichardsSeff2waterRSC::dseff(std::vector<VariableValue *> p, unsigned int qp, st
 }
 
 void
-RichardsSeff2waterRSC::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const
+RichardsSeff2waterRSC::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const
 {
   Real pc = (*p[1])[qp] - (*p[0])[qp];
   result[1][1] = RichardsSeffRSC::d2seff(pc, _shift, _scale);

--- a/modules/richards/src/userobjects/RichardsSeff2waterVG.C
+++ b/modules/richards/src/userobjects/RichardsSeff2waterVG.C
@@ -30,14 +30,14 @@ RichardsSeff2waterVG::RichardsSeff2waterVG(const InputParameters & parameters) :
 
 
 Real
-RichardsSeff2waterVG::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff2waterVG::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   return RichardsSeffVG::seff(negpc, _al, _m);
 }
 
 void
-RichardsSeff2waterVG::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
+RichardsSeff2waterVG::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> &result) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   result[0] = RichardsSeffVG::dseff(negpc, _al, _m);
@@ -45,7 +45,7 @@ RichardsSeff2waterVG::dseff(std::vector<VariableValue *> p, unsigned int qp, std
 }
 
 void
-RichardsSeff2waterVG::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
+RichardsSeff2waterVG::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > &result) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   result[0][0] = RichardsSeffVG::d2seff(negpc, _al, _m);

--- a/modules/richards/src/userobjects/RichardsSeff2waterVGshifted.C
+++ b/modules/richards/src/userobjects/RichardsSeff2waterVGshifted.C
@@ -33,7 +33,7 @@ RichardsSeff2waterVGshifted::RichardsSeff2waterVGshifted(const InputParameters &
 
 
 Real
-RichardsSeff2waterVGshifted::seff(std::vector<VariableValue *> p, unsigned int qp) const
+RichardsSeff2waterVGshifted::seff(std::vector<const VariableValue *> p, unsigned int qp) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   negpc = negpc - _shift;
@@ -41,7 +41,7 @@ RichardsSeff2waterVGshifted::seff(std::vector<VariableValue *> p, unsigned int q
 }
 
 void
-RichardsSeff2waterVGshifted::dseff(std::vector<VariableValue *> p, unsigned int qp, std::vector<Real> & result) const
+RichardsSeff2waterVGshifted::dseff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<Real> & result) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   negpc = negpc - _shift;
@@ -50,7 +50,7 @@ RichardsSeff2waterVGshifted::dseff(std::vector<VariableValue *> p, unsigned int 
 }
 
 void
-RichardsSeff2waterVGshifted::d2seff(std::vector<VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const
+RichardsSeff2waterVGshifted::d2seff(std::vector<const VariableValue *> p, unsigned int qp, std::vector<std::vector<Real> > & result) const
 {
   Real negpc = (*p[0])[qp] - (*p[1])[qp];
   negpc = negpc - _shift;

--- a/modules/richards/src/userobjects/RichardsVarNames.C
+++ b/modules/richards/src/userobjects/RichardsVarNames.C
@@ -109,25 +109,25 @@ RichardsVarNames::richards_names() const
   return _the_names;
 }
 
-VariableValue *
+const VariableValue *
 RichardsVarNames::richards_vals(unsigned int richards_var_num) const
 {
   return _moose_var_value[richards_var_num]; // moose_var_value is a vector of pointers to VariableValuees
 }
 
-VariableValue *
+const VariableValue *
 RichardsVarNames::richards_vals_old(unsigned int richards_var_num) const
 {
   return _moose_var_value_old[richards_var_num];
 }
 
-VariableGradient *
+const VariableGradient *
 RichardsVarNames::grad_var(unsigned int richards_var_num) const
 {
   return _moose_grad_var[richards_var_num];
 }
 
-MooseVariable *
+const MooseVariable *
 RichardsVarNames::raw_var(unsigned int richards_var_num) const
 {
   return _moose_raw_var[richards_var_num];
@@ -139,13 +139,13 @@ RichardsVarNames::var_types() const
   return _var_types;
 }
 
-VariableValue *
+const VariableValue *
 RichardsVarNames::nodal_var(unsigned int richards_var_num) const
 {
   return _moose_nodal_var_value[richards_var_num];
 }
 
-VariableValue *
+const VariableValue *
 RichardsVarNames::nodal_var_old(unsigned int richards_var_num) const
 {
   return _moose_nodal_var_value_old[richards_var_num];

--- a/modules/solid_mechanics/include/auxkernels/AccumulateAux.h
+++ b/modules/solid_mechanics/include/auxkernels/AccumulateAux.h
@@ -36,7 +36,7 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _accumulate_from;
+  const VariableValue & _accumulate_from;
 };
 
 #endif //ACCUMULATEAUX_H

--- a/modules/solid_mechanics/include/bcs/DashpotBC.h
+++ b/modules/solid_mechanics/include/bcs/DashpotBC.h
@@ -44,9 +44,9 @@ private:
   unsigned int _disp_y_var;
   unsigned int _disp_z_var;
 
-  VariableValue & _disp_x_dot;
-  VariableValue & _disp_y_dot;
-  VariableValue & _disp_z_dot;
+  const VariableValue & _disp_x_dot;
+  const VariableValue & _disp_y_dot;
+  const VariableValue & _disp_z_dot;
 };
 
 #endif //DASHPOTBC_H

--- a/modules/solid_mechanics/include/kernels/SecondDerivativeImplicitEuler.h
+++ b/modules/solid_mechanics/include/kernels/SecondDerivativeImplicitEuler.h
@@ -26,8 +26,8 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  VariableValue & _u_old;
-  VariableValue & _u_older;
+  const VariableValue & _u_old;
+  const VariableValue & _u_older;
 };
 
 #endif //SECONDDERIVATIVEIMPLICITEULER_H

--- a/modules/solid_mechanics/include/kernels/StressDivergenceTruss.h
+++ b/modules/solid_mechanics/include/kernels/StressDivergenceTruss.h
@@ -50,7 +50,6 @@ private:
 
   const VariableValue & _area;
   const std::vector<RealGradient> * _orientation;
-
 };
 
 template<>

--- a/modules/solid_mechanics/include/materials/AxisymmetricRZ.h
+++ b/modules/solid_mechanics/include/materials/AxisymmetricRZ.h
@@ -32,14 +32,13 @@ protected:
     return 1;
   }
 
-  VariableValue & _disp_r;
-  VariableValue & _disp_z;
+  const VariableValue & _disp_r;
+  const VariableValue & _disp_z;
 
   const bool _large_strain;
 
-  VariableGradient & _grad_disp_r;
-  VariableGradient & _grad_disp_z;
-
+  const VariableGradient & _grad_disp_r;
+  const VariableGradient & _grad_disp_z;
 };
 
 }

--- a/modules/solid_mechanics/include/materials/ConstitutiveModel.h
+++ b/modules/solid_mechanics/include/materials/ConstitutiveModel.h
@@ -48,8 +48,8 @@ public:
 protected:
 
   const bool _has_temp;
-  VariableValue & _temperature;
-  VariableValue & _temperature_old;
+  const VariableValue & _temperature;
+  const VariableValue & _temperature_old;
   const Real _alpha;
   Function * _alpha_function;
   bool _has_stress_free_temp;

--- a/modules/solid_mechanics/include/materials/Linear.h
+++ b/modules/solid_mechanics/include/materials/Linear.h
@@ -30,9 +30,9 @@ protected:
 
   const bool _large_strain;
 
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
-  VariableGradient & _grad_disp_z;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_z;
 
 };
 

--- a/modules/solid_mechanics/include/materials/Nonlinear3D.h
+++ b/modules/solid_mechanics/include/materials/Nonlinear3D.h
@@ -30,12 +30,12 @@ public:
 
 protected:
 
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
-  VariableGradient & _grad_disp_z;
-  VariableGradient & _grad_disp_x_old;
-  VariableGradient & _grad_disp_y_old;
-  VariableGradient & _grad_disp_z_old;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_z;
+  const VariableGradient & _grad_disp_x_old;
+  const VariableGradient & _grad_disp_y_old;
+  const VariableGradient & _grad_disp_z_old;
 
   virtual void computeDeformationGradient( unsigned int qp, ColumnMajorMatrix & F);
 

--- a/modules/solid_mechanics/include/materials/NonlinearPlaneStrain.h
+++ b/modules/solid_mechanics/include/materials/NonlinearPlaneStrain.h
@@ -27,17 +27,17 @@ public:
 
   virtual ~NonlinearPlaneStrain();
 
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
   bool _have_strain_zz;
-  VariableValue & _strain_zz;
+  const VariableValue & _strain_zz;
   bool _have_scalar_strain_zz;
-  VariableValue & _scalar_strain_zz;
+  const VariableValue & _scalar_strain_zz;
 
-  VariableGradient & _grad_disp_x_old;
-  VariableGradient & _grad_disp_y_old;
-  VariableValue & _strain_zz_old;
-  VariableValue & _scalar_strain_zz_old;
+  const VariableGradient & _grad_disp_x_old;
+  const VariableGradient & _grad_disp_y_old;
+  const VariableValue & _strain_zz_old;
+  const VariableValue & _scalar_strain_zz_old;
 
 protected:
 

--- a/modules/solid_mechanics/include/materials/NonlinearRZ.h
+++ b/modules/solid_mechanics/include/materials/NonlinearRZ.h
@@ -24,12 +24,12 @@ public:
 
   virtual ~NonlinearRZ();
 
-  VariableGradient & _grad_disp_r;
-  VariableGradient & _grad_disp_z;
-  VariableGradient & _grad_disp_r_old;
-  VariableGradient & _grad_disp_z_old;
-  VariableValue & _disp_r;
-  VariableValue & _disp_r_old;
+  const VariableGradient & _grad_disp_r;
+  const VariableGradient & _grad_disp_z;
+  const VariableGradient & _grad_disp_r_old;
+  const VariableGradient & _grad_disp_z_old;
+  const VariableValue & _disp_r;
+  const VariableValue & _disp_r_old;
 
 protected:
 
@@ -43,9 +43,6 @@ protected:
   virtual Real volumeRatioOld(unsigned qp) const;
 
   virtual void computeIncrementalDeformationGradient( std::vector<ColumnMajorMatrix> & Fhat);
-
-
-
 };
 
 } // namespace solid_mechanics

--- a/modules/solid_mechanics/include/materials/PlaneStrain.h
+++ b/modules/solid_mechanics/include/materials/PlaneStrain.h
@@ -38,13 +38,12 @@ protected:
 
   const bool _large_strain;
 
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
   bool _have_strain_zz;
-  VariableValue & _strain_zz;
+  const VariableValue & _strain_zz;
   bool _have_scalar_strain_zz;
-  VariableValue & _scalar_strain_zz;
-
+  const VariableValue & _scalar_strain_zz;
 };
 
 }

--- a/modules/solid_mechanics/include/materials/SolidModel.h
+++ b/modules/solid_mechanics/include/materials/SolidModel.h
@@ -96,9 +96,9 @@ protected:
   // std::map<Point, unsigned> _cracked_this_step;
 
   const bool _has_temp;
-  VariableValue & _temperature;
-  VariableValue & _temperature_old;
-  VariableGradient & _temp_grad;
+  const VariableValue & _temperature;
+  const VariableValue & _temperature_old;
+  const VariableGradient & _temp_grad;
   const Real _alpha;
   Function * _alpha_function;
   PiecewiseLinear * _piecewise_linear_alpha_function;

--- a/modules/solid_mechanics/include/materials/SphericalR.h
+++ b/modules/solid_mechanics/include/materials/SphericalR.h
@@ -33,12 +33,11 @@ protected:
     return 2;
   }
 
-  VariableValue & _disp_r;
+  const VariableValue & _disp_r;
 
   const bool _large_strain;
 
-  VariableGradient & _grad_disp_r;
-
+  const VariableGradient & _grad_disp_r;
 };
 
 }

--- a/modules/solid_mechanics/include/materials/abaqus/AbaqusUmatMaterial.h
+++ b/modules/solid_mechanics/include/materials/abaqus/AbaqusUmatMaterial.h
@@ -49,12 +49,12 @@ protected:
   virtual void initQpStatefulProperties();
   virtual void computeStress();
 
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
-  VariableGradient & _grad_disp_z;
-  VariableGradient & _grad_disp_x_old;
-  VariableGradient & _grad_disp_y_old;
-  VariableGradient & _grad_disp_z_old;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_z;
+  const VariableGradient & _grad_disp_x_old;
+  const VariableGradient & _grad_disp_y_old;
+  const VariableGradient & _grad_disp_z_old;
   MaterialProperty<std::vector<Real> > & _state_var;
   MaterialProperty<std::vector<Real> > & _state_var_old;
   MaterialProperty<ColumnMajorMatrix> & _Fbar;

--- a/modules/solid_mechanics/include/materials/total_strain/SolidMechanicsMaterial.h
+++ b/modules/solid_mechanics/include/materials/total_strain/SolidMechanicsMaterial.h
@@ -27,15 +27,15 @@ public:
 
 protected:
   const std::string _appended_property_name;
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
-  VariableGradient & _grad_disp_z;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_z;
 
   bool _has_temp;
-  VariableValue & _temp;
+  const VariableValue & _temp;
 
   bool _has_c;
-  VariableValue & _c;
+  const VariableValue & _c;
 
   std::vector<VolumetricModel*> _volumetric_models;
 

--- a/modules/solid_mechanics/include/materials/total_strain/TrussMaterial.h
+++ b/modules/solid_mechanics/include/materials/total_strain/TrussMaterial.h
@@ -38,10 +38,10 @@ protected:
   MaterialProperty<Real> & _e_over_l;
   Real _youngs_modulus;
   bool _youngs_modulus_coupled;
-  VariableValue & _youngs_modulus_var;
+  const VariableValue & _youngs_modulus_var;
 
   bool _has_temp;
-  VariableValue & _temp;
+  const VariableValue & _temp;
   Real _t_ref;
   Real _alpha;
 

--- a/modules/solid_mechanics/include/postprocessors/HomogenizedElasticConstants.h
+++ b/modules/solid_mechanics/include/postprocessors/HomogenizedElasticConstants.h
@@ -35,29 +35,29 @@ protected:
   virtual Real computeQpIntegral();
 
 private:
-  VariableGradient & _grad_disp_x_xx;
-  VariableGradient & _grad_disp_y_xx;
-  VariableGradient & _grad_disp_z_xx;
+  const VariableGradient & _grad_disp_x_xx;
+  const VariableGradient & _grad_disp_y_xx;
+  const VariableGradient & _grad_disp_z_xx;
 
-  VariableGradient & _grad_disp_x_yy;
-  VariableGradient & _grad_disp_y_yy;
-  VariableGradient & _grad_disp_z_yy;
+  const VariableGradient & _grad_disp_x_yy;
+  const VariableGradient & _grad_disp_y_yy;
+  const VariableGradient & _grad_disp_z_yy;
 
-  VariableGradient & _grad_disp_x_zz;
-  VariableGradient & _grad_disp_y_zz;
-  VariableGradient & _grad_disp_z_zz;
+  const VariableGradient & _grad_disp_x_zz;
+  const VariableGradient & _grad_disp_y_zz;
+  const VariableGradient & _grad_disp_z_zz;
 
-  VariableGradient & _grad_disp_x_xy;
-  VariableGradient & _grad_disp_y_xy;
-  VariableGradient & _grad_disp_z_xy;
+  const VariableGradient & _grad_disp_x_xy;
+  const VariableGradient & _grad_disp_y_xy;
+  const VariableGradient & _grad_disp_z_xy;
 
-  VariableGradient & _grad_disp_x_yz;
-  VariableGradient & _grad_disp_y_yz;
-  VariableGradient & _grad_disp_z_yz;
+  const VariableGradient & _grad_disp_x_yz;
+  const VariableGradient & _grad_disp_y_yz;
+  const VariableGradient & _grad_disp_z_yz;
 
-  VariableGradient & _grad_disp_x_zx;
-  VariableGradient & _grad_disp_y_zx;
-  VariableGradient & _grad_disp_z_zx;
+  const VariableGradient & _grad_disp_x_zx;
+  const VariableGradient & _grad_disp_y_zx;
+  const VariableGradient & _grad_disp_z_zx;
 
   const MaterialProperty<SymmElasticityTensor> & _elasticity_tensor;
   const unsigned int _column, _row;

--- a/modules/solid_mechanics/include/postprocessors/HomogenizedThermalConductivity.h
+++ b/modules/solid_mechanics/include/postprocessors/HomogenizedThermalConductivity.h
@@ -29,9 +29,9 @@ protected:
   virtual Real computeQpIntegral();
 
 private:
-  VariableGradient & _grad_temp_x;
-  VariableGradient & _grad_temp_y;
-  VariableGradient & _grad_temp_z;
+  const VariableGradient & _grad_temp_x;
+  const VariableGradient & _grad_temp_y;
+  const VariableGradient & _grad_temp_z;
   const unsigned int _component;
   const MaterialProperty<Real> & _diffusion_coefficient;
   Real _volume;

--- a/modules/solid_mechanics/include/postprocessors/InteractionIntegral.h
+++ b/modules/solid_mechanics/include/postprocessors/InteractionIntegral.h
@@ -32,7 +32,7 @@ protected:
   virtual void initialSetup();
   virtual Real computeQpIntegral();
   /// The gradient of the scalar q field
-  VariableGradient & _grad_of_scalar_q;
+  const VariableGradient & _grad_of_scalar_q;
   const CrackFrontDefinition * const _crack_front_definition;
   bool _has_crack_front_point_index;
   const unsigned int _crack_front_point_index;
@@ -40,9 +40,9 @@ protected:
   const MaterialProperty<ColumnMajorMatrix> & _Eshelby_tensor;
   const MaterialProperty<SymmTensor> & _stress;
   const MaterialProperty<SymmTensor> & _strain;
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
-  VariableGradient & _grad_disp_z;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_z;
   std::string _aux_stress_name;
   const MaterialProperty<ColumnMajorMatrix> & _aux_stress;
   std::string _aux_grad_disp_name;

--- a/modules/solid_mechanics/include/postprocessors/JIntegral.h
+++ b/modules/solid_mechanics/include/postprocessors/JIntegral.h
@@ -29,9 +29,9 @@ public:
 protected:
   virtual void initialSetup();
   virtual Real computeQpIntegral();
-  VariableValue & _scalar_q;
+  const VariableValue & _scalar_q;
   /// The gradient of the scalar q field
-  VariableGradient & _grad_of_scalar_q;
+  const VariableGradient & _grad_of_scalar_q;
   const CrackFrontDefinition * const _crack_front_definition;
   bool _has_crack_front_point_index;
   const unsigned int _crack_front_point_index;
@@ -42,7 +42,6 @@ protected:
   bool _has_symmetry_plane;
   Real _poissons_ratio;
   Real _youngs_modulus;
-
 };
 
 #endif //JINTEGRAL3D_H

--- a/modules/solid_mechanics/include/postprocessors/TorqueReaction.h
+++ b/modules/solid_mechanics/include/postprocessors/TorqueReaction.h
@@ -37,9 +37,9 @@ protected:
   MooseVariable & _react_y_var;
   MooseVariable & _react_z_var;
 
-  VariableValue & _react_x;
-  VariableValue & _react_y;
-  VariableValue & _react_z;
+  const VariableValue & _react_x;
+  const VariableValue & _react_y;
+  const VariableValue & _react_z;
 
   const Point _axis_origin;
   const Point _axis_direction;

--- a/modules/solid_mechanics/include/userobjects/MaterialTensorOnLine.h
+++ b/modules/solid_mechanics/include/userobjects/MaterialTensorOnLine.h
@@ -47,7 +47,7 @@ protected:
   bool _stream_open;
 
 private:
-  VariableValue & _elem_line_id;
+  const VariableValue & _elem_line_id;
 };
 
 #endif

--- a/modules/solid_mechanics/src/postprocessors/HomogenizedElasticConstants.C
+++ b/modules/solid_mechanics/src/postprocessors/HomogenizedElasticConstants.C
@@ -200,7 +200,7 @@ HomogenizedElasticConstants::computeQpIntegral()
 
     value = 0.0;
 
-    VariableGradient * grad[6][3];
+    const VariableGradient * grad[6][3];
     grad[0][0] = &_grad_disp_x_xx;
     grad[0][1] = &_grad_disp_y_xx;
     grad[0][2] = &_grad_disp_z_xx;

--- a/modules/tensor_mechanics/include/auxkernels/NewmarkAccelAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/NewmarkAccelAux.h
@@ -28,11 +28,10 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _disp_old;
-  VariableValue & _disp;
-  VariableValue & _vel_old;
+  const VariableValue & _disp_old;
+  const VariableValue & _disp;
+  const VariableValue & _vel_old;
   Real _beta;
-
 };
 
 #endif //NEWMARKACCELAUX_H

--- a/modules/tensor_mechanics/include/auxkernels/NewmarkVelAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/NewmarkVelAux.h
@@ -19,8 +19,8 @@ class NewmarkVelAux : public AuxKernel
 public:
 
   /**
-  *Calcualtes velocity using Newmark time integration scheme
-  */
+   * Calcualtes velocity using Newmark time integration scheme
+   */
   NewmarkVelAux(const InputParameters & parameters);
 
   virtual ~NewmarkVelAux() {}
@@ -28,10 +28,9 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _accel_old;
-  VariableValue & _accel;
+  const VariableValue & _accel_old;
+  const VariableValue & _accel;
   Real _gamma;
-
 };
 
 #endif //NEWMARKVELAUX_H

--- a/modules/tensor_mechanics/include/kernels/PoroMechanicsCoupling.h
+++ b/modules/tensor_mechanics/include/kernels/PoroMechanicsCoupling.h
@@ -37,7 +37,7 @@ public:
   /// Biot coefficient
   const MaterialProperty<Real> & _coefficient;
 
-  VariableValue & _porepressure;
+  const VariableValue & _porepressure;
 
   unsigned int _porepressure_var_num;
 

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
@@ -44,15 +44,12 @@ protected:
 
   /// Coupled displacement variables
   unsigned int _ndisp;
-  std::vector<VariableValue *> _disp;
+  std::vector<const VariableValue *> _disp;
   std::vector<unsigned int> _disp_var;
 
   const bool _temp_coupled;
 
   const unsigned int _temp_var;
-
-private:
-
 };
 
 #endif //STRESSDIVERGENCETENSORS_H

--- a/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZFiniteStrain.h
@@ -21,7 +21,7 @@ public:
 
 protected:
   /// the old value of the first component of the displacements vector
-  VariableValue & _disp_old_0;
+  const VariableValue & _disp_old_0;
 
   virtual Real computeDeformGradZZ();
   virtual Real computeDeformGradZZold();

--- a/modules/tensor_mechanics/include/materials/ComputeConcentrationDependentElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeConcentrationDependentElasticityTensor.h
@@ -25,7 +25,7 @@ protected:
   /// Elasticity tensor for phase with concentration 1.
   ElasticityTensorR4 _Cijkl1;
   /// Concentration variable.
-  VariableValue & _c;
+  const VariableValue & _c;
   VariableName _c_name;
 
   /// Derivative of elasticity tensor with respect to concentration.

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
@@ -32,7 +32,7 @@ protected:
   MaterialProperty<RankTwoTensor> & _deformation_gradient_old;
 
   const MaterialProperty<RankTwoTensor> & _stress_free_strain_increment;
-  VariableValue & _T_old;
+  const VariableValue & _T_old;
 };
 
 #endif //COMPUTEFINITESTRAIN_H

--- a/modules/tensor_mechanics/include/materials/ComputeIncrementalSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIncrementalSmallStrain.h
@@ -30,7 +30,7 @@ protected:
   MaterialProperty<RankTwoTensor> & _deformation_gradient;
 
   const MaterialProperty<RankTwoTensor> & _stress_free_strain_increment;
-  VariableValue & _T_old;
+  const VariableValue & _T_old;
 };
 
 #endif //COMPUTEINCREMENTALSMALLSTRAIN_H

--- a/modules/tensor_mechanics/include/materials/ComputeRSphericalFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeRSphericalFiniteStrain.h
@@ -22,7 +22,7 @@ public:
 
 protected:
   /// the old value of the first component of the displacements vector
-  VariableValue & _disp_old_0;
+  const VariableValue & _disp_old_0;
 
   virtual void computeProperties();
 };

--- a/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
@@ -28,11 +28,11 @@ protected:
 
   /// Coupled displacement variables
   unsigned int _ndisp;
-  std::vector<VariableValue *> _disp;
-  std::vector<VariableGradient *> _grad_disp;
-  std::vector<VariableGradient *> _grad_disp_old;
+  std::vector<const VariableValue *> _disp;
+  std::vector<const VariableGradient *> _grad_disp;
+  std::vector<const VariableGradient *> _grad_disp_old;
 
-  VariableValue & _T;
+  const VariableValue & _T;
   const Real _T0;
   const Real _thermal_expansion_coeff;
 

--- a/modules/tensor_mechanics/include/materials/CosseratLinearElasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/CosseratLinearElasticMaterial.h
@@ -44,20 +44,20 @@ protected:
   ElasticityTensorR4 _Bijkl;
 
 private:
-  VariableValue & _T;
+  const VariableValue & _T;
 
   Real _thermal_expansion_coeff;
   const Real _T0;
   std::vector<Real> _applied_strain_vector;
   RankTwoTensor _applied_strain_tensor;
 
-  VariableValue & _wc_x;
-  VariableValue & _wc_y;
-  VariableValue & _wc_z;
+  const VariableValue & _wc_x;
+  const VariableValue & _wc_y;
+  const VariableValue & _wc_z;
 
-  VariableGradient & _grad_wc_x;
-  VariableGradient & _grad_wc_y;
-  VariableGradient & _grad_wc_z;
+  const VariableGradient & _grad_wc_x;
+  const VariableGradient & _grad_wc_y;
+  const VariableGradient & _grad_wc_z;
 
   /// determines the translation from B_ijkl to the Rank-4 tensor
   MooseEnum _fill_method_bending;

--- a/modules/tensor_mechanics/include/materials/EigenStrainBaseMaterial.h
+++ b/modules/tensor_mechanics/include/materials/EigenStrainBaseMaterial.h
@@ -26,7 +26,7 @@ protected:
   virtual void computeEigenStrain() = 0;
   virtual RankTwoTensor computeStressFreeStrain();
 
-  VariableValue & _c;
+  const VariableValue & _c;
   VariableName _c_name;
 
   std::string _eigenstrain_name;

--- a/modules/tensor_mechanics/include/materials/LinearElasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/LinearElasticMaterial.h
@@ -28,7 +28,7 @@ protected:
   virtual RankTwoTensor computeStressFreeStrain();
 
 private:
-  VariableValue & _T;
+  const VariableValue & _T;
 
   const Real _T0;
   Real _thermal_expansion_coeff;

--- a/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
+++ b/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
@@ -40,13 +40,13 @@ protected:
   virtual void computeQpStrain() = 0;
   virtual void computeQpStress() = 0;
 
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
-  VariableGradient & _grad_disp_z;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_z;
 
-  VariableGradient & _grad_disp_x_old;
-  VariableGradient & _grad_disp_y_old;
-  VariableGradient & _grad_disp_z_old;
+  const VariableGradient & _grad_disp_x_old;
+  const VariableGradient & _grad_disp_y_old;
+  const VariableGradient & _grad_disp_z_old;
 
   /// Material property base name to allow for multiple TensorMechanicsMaterial to coexist in the same simulation
   std::string _base_name;

--- a/test/include/auxkernels/CoupledAux.h
+++ b/test/include/auxkernels/CoupledAux.h
@@ -46,7 +46,7 @@ protected:
   MooseEnum _operator;                          ///< Operator being applied on this variable and coupled variable
 
   int _coupled;                                 ///< The number of the coupled variable
-  VariableValue & _coupled_val;                 ///< Coupled variable
+  const VariableValue & _coupled_val;           ///< Coupled variable
 };
 
 #endif //COUPLEDAUX_H

--- a/test/include/auxkernels/CoupledGradAux.h
+++ b/test/include/auxkernels/CoupledGradAux.h
@@ -47,7 +47,7 @@ protected:
   /// The number of coupled variable
   int _coupled;
   /// The value of coupled gradient
-  VariableGradient & _coupled_grad;
+  const VariableGradient & _coupled_grad;
 };
 
 #endif //COUPLEDGRADAUX_H

--- a/test/include/auxkernels/DotCouplingAux.h
+++ b/test/include/auxkernels/DotCouplingAux.h
@@ -34,7 +34,7 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _v_dot;
+  const VariableValue & _v_dot;
 };
 
 #endif /* DOTCOUPLINGAUX_H */

--- a/test/include/auxkernels/FluxAverageAux.h
+++ b/test/include/auxkernels/FluxAverageAux.h
@@ -43,7 +43,7 @@ protected:
   Real _diffusivity;
 
   /// Coupled gradient
-  VariableGradient & _coupled_gradient;
+  const VariableGradient & _coupled_gradient;
 
   /// The variable we're coupled to
   MooseVariable & _coupled_var;

--- a/test/include/auxkernels/MultipleUpdateAux.h
+++ b/test/include/auxkernels/MultipleUpdateAux.h
@@ -35,10 +35,9 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _nl_u;
+  const VariableValue & _nl_u;
   VariableValue & _var1;
   VariableValue & _var2;
-
 };
 
 

--- a/test/include/auxkernels/SumNodalValuesAux.h
+++ b/test/include/auxkernels/SumNodalValuesAux.h
@@ -36,7 +36,7 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _sum_var;
+  const VariableValue & _sum_var;
 };
 
 #endif /* SUMNODALVALUESAUX_H_ */

--- a/test/include/bcs/CoupledDirichletBC.h
+++ b/test/include/bcs/CoupledDirichletBC.h
@@ -40,7 +40,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   // The coupled variable
-  VariableValue & _v;
+  const VariableValue & _v;
 
   /// The id of the coupled variable
   unsigned int _v_num;

--- a/test/include/bcs/CoupledKernelGradBC.h
+++ b/test/include/bcs/CoupledKernelGradBC.h
@@ -33,7 +33,7 @@ protected:
   virtual Real computeQpResidual();
 
   RealVectorValue _beta;
-  VariableValue & _var2;
+  const VariableValue & _var2;
 };
 
 #endif /* COUPLEDKERNELGRADBC_H */

--- a/test/include/bcs/TestLapBC.h
+++ b/test/include/bcs/TestLapBC.h
@@ -41,7 +41,7 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  VariableSecond & _second_u;
+  const VariableSecond & _second_u;
   const VariablePhiSecond & _second_phi;
   const VariableTestSecond & _second_test;
 };

--- a/test/include/dirackernels/NonlinearSource.h
+++ b/test/include/dirackernels/NonlinearSource.h
@@ -40,7 +40,7 @@ public:
 
 protected:
   // A coupled variable this kernel depends on
-  VariableValue & _coupled_var;
+  const VariableValue & _coupled_var;
   unsigned _coupled_var_num;
 
   // A constant factor which controls the strength of the source.

--- a/test/include/ics/MTICMult.h
+++ b/test/include/ics/MTICMult.h
@@ -33,7 +33,7 @@ public:
   virtual Real value(const Point & /*p*/);
 
 protected:
-  VariableValue & _var1;
+  const VariableValue & _var1;
   Real _factor;
 };
 

--- a/test/include/ics/MTICSum.h
+++ b/test/include/ics/MTICSum.h
@@ -33,8 +33,8 @@ public:
   virtual Real value(const Point & /*p*/);
 
 protected:
-  VariableValue & _var1;
-  VariableValue & _var2;
+  const VariableValue & _var1;
+  const VariableValue & _var2;
 };
 
 

--- a/test/include/kernels/CoupledConvection.h
+++ b/test/include/kernels/CoupledConvection.h
@@ -37,7 +37,7 @@ protected:
   virtual Real computeQpJacobian();
 
 private:
-  VariableGradient & _velocity_vector;
+  const VariableGradient & _velocity_vector;
 };
 
 #endif //COUPLEDCONVECTION_H

--- a/test/include/kernels/CoupledEigenKernel.h
+++ b/test/include/kernels/CoupledEigenKernel.h
@@ -30,7 +30,7 @@ public:
 protected:
   virtual Real computeQpResidual();
 
-  VariableValue & _v;
+  const VariableValue & _v;
 };
 
 #endif //COUPLEDEIGENKERNEL_H

--- a/test/include/kernels/CoupledKernelGradTest.h
+++ b/test/include/kernels/CoupledKernelGradTest.h
@@ -34,9 +34,8 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int);
 
   RealVectorValue _beta;
-  VariableValue & _var2;
+  const VariableValue & _var2;
   unsigned int _var2_num;
-
 };
 
 

--- a/test/include/kernels/CoupledKernelValueTest.h
+++ b/test/include/kernels/CoupledKernelValueTest.h
@@ -33,9 +33,8 @@ protected:
   virtual Real precomputeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int);
 
-  VariableValue & _var2;
+  const VariableValue & _var2;
   unsigned int _var2_num;
-
 };
 
 

--- a/test/include/kernels/DotCouplingKernel.h
+++ b/test/include/kernels/DotCouplingKernel.h
@@ -35,8 +35,8 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  VariableValue & _v_dot;
-  VariableValue & _dv_dot_dv;
+  const VariableValue & _v_dot;
+  const VariableValue & _dv_dot_dv;
 };
 
 

--- a/test/include/kernels/FDAdvection.h
+++ b/test/include/kernels/FDAdvection.h
@@ -34,7 +34,7 @@ protected:
 
 private:
 
-  VariableGradient & _grad_advector;
+  const VariableGradient & _grad_advector;
 };
 
 #endif //FDADVECTION_H

--- a/test/include/kernels/MMSImplicitEuler.h
+++ b/test/include/kernels/MMSImplicitEuler.h
@@ -30,7 +30,7 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  VariableValue & _u_old;
+  const VariableValue & _u_old;
 };
 
 #endif //MMSIMPLICITEULER_H_

--- a/test/include/kernels/OptionallyCoupledForce.h
+++ b/test/include/kernels/OptionallyCoupledForce.h
@@ -40,11 +40,11 @@ protected:
 
 private:
   unsigned int _v_var;
-  VariableValue & _v;
-  VariableGradient & _grad_v;
-  VariableSecond & _second_v;
-  VariableValue & _v_dot;
-  VariableValue & _v_dot_du;
+  const VariableValue & _v;
+  const VariableGradient & _grad_v;
+  const VariableSecond & _second_v;
+  const VariableValue & _v_dot;
+  const VariableValue & _v_dot_du;
   bool _v_coupled;
 };
 

--- a/test/include/materials/OutputTestMaterial.h
+++ b/test/include/materials/OutputTestMaterial.h
@@ -49,7 +49,7 @@ protected:
   MaterialProperty<RealVectorValue> & _vector_property;
   MaterialProperty<RealTensorValue> & _tensor_property;
   Real _factor;
-  VariableValue & _variable;
+  const VariableValue & _variable;
 };
 
 #endif //OUTPUTTESTMATERIAL_H

--- a/test/include/materials/VarCouplingMaterial.h
+++ b/test/include/materials/VarCouplingMaterial.h
@@ -32,7 +32,7 @@ public:
 protected:
   virtual void computeQpProperties();
 
-  VariableValue & _var;
+  const VariableValue & _var;
   Real _base;
   Real _coef;
   MaterialProperty<Real> & _diffusion;

--- a/test/include/materials/VarCouplingMaterialEigen.h
+++ b/test/include/materials/VarCouplingMaterialEigen.h
@@ -32,8 +32,8 @@ public:
 protected:
   virtual void computeQpProperties();
 
-  VariableValue & _var;
-  VariableValue & _var_old;
+  const VariableValue & _var;
+  const VariableValue & _var_old;
   std::string _propname;
   MaterialProperty<Real> & _mat;
   MaterialProperty<Real> & _mat_old;

--- a/test/include/postprocessors/ElementL2Diff.h
+++ b/test/include/postprocessors/ElementL2Diff.h
@@ -38,7 +38,7 @@ protected:
 
   virtual Real computeQpIntegral();
 
-  VariableValue & _u_old;
+  const VariableValue & _u_old;
 };
 
 #endif //ELEMENTL2DIFF_H

--- a/test/include/userobjects/BoundaryUserObject.h
+++ b/test/include/userobjects/BoundaryUserObject.h
@@ -39,7 +39,7 @@ public:
   Real getValue() const { return _value; }
 
 protected:
-  VariableValue & _u;
+  const VariableValue & _u;
 
   Real _value;
 

--- a/test/include/userobjects/InsideUserObject.h
+++ b/test/include/userobjects/InsideUserObject.h
@@ -39,8 +39,8 @@ public:
   Real getValue() const { return _value; }
 
 protected:
-  VariableValue & _u;
-  VariableValue & _u_neighbor;
+  const VariableValue & _u;
+  const VariableValue & _u_neighbor;
 
   Real _value;
   const MaterialProperty<Real> & _diffusivity_prop;

--- a/test/include/userobjects/TrackDiracFront.h
+++ b/test/include/userobjects/TrackDiracFront.h
@@ -67,7 +67,7 @@ protected:
 
   std::vector<std::pair<Elem *, Point> > _dirac_points;
 
-  VariableValue & _var_value;
+  const VariableValue & _var_value;
 };
 
 #endif //TRACKDIRACFRONT_H


### PR DESCRIPTION
#### Relevant design information

This patch only catches the references returned by `Coupleable` functions like `coupledValue()`, `coupledGradient()`, etc. as const in the tests and modules -- it does not change any MOOSE interfaces yet.  The overall goal here is to make it more obvious to users that they should not write to the references they get from calling `coupledValue()`, etc. and to make it more clear just from reading the code that these are values _provided by the framework_ and consumed by the user.

All of the major apps and most of the stork forks have already been patched in the same way. I have another patch which will actually implement the changes at the MOOSE level which we can discuss in a separate PR.

Refs #6327.
