### PR TITLE
Make various user-facing interfaces return const references.

### DIFF
--- a/framework/include/auxkernels/AuxKernel.h
+++ b/framework/include/auxkernels/AuxKernel.h
@@ -114,9 +114,9 @@ public:
   virtual const PostprocessorValue & getPostprocessorValueByName(const PostprocessorName & name);
 
 protected:
-  virtual VariableValue & coupledDot(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledDot(const std::string & var_name, unsigned int comp = 0);
 
-  virtual VariableValue & coupledDotDu(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledDotDu(const std::string & var_name, unsigned int comp = 0);
 
   virtual Real computeValue() = 0;
 
@@ -150,11 +150,11 @@ protected:
   const MooseArray<Real> & _coord;
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
   /// Holds the previous solution at the current quadrature point.
-  VariableValue & _u_old;
+  const VariableValue & _u_old;
   /// Holds the t-2 solution at the current quadrature point.
-  VariableValue & _u_older;
+  const VariableValue & _u_older;
   /// holds the the test functions
   const VariableTestValue & _test;
 

--- a/framework/include/auxkernels/NormalizationAux.h
+++ b/framework/include/auxkernels/NormalizationAux.h
@@ -37,7 +37,7 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _src;
+  const VariableValue & _src;
   const Real & _pp_on_source;
   Real _normal_factor;
 };

--- a/framework/include/auxkernels/ParsedAux.h
+++ b/framework/include/auxkernels/ParsedAux.h
@@ -43,7 +43,7 @@ protected:
 
   /// coupled variables
   unsigned int _nargs;
-  std::vector<VariableValue *> _args;
+  std::vector<const VariableValue *> _args;
 
   /// function parser object for the resudual and on-diagonal Jacobian
   ADFunctionPtr _func_F;

--- a/framework/include/auxkernels/QuotientAux.h
+++ b/framework/include/auxkernels/QuotientAux.h
@@ -39,8 +39,8 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _numerator;
-  VariableValue & _denominator;
+  const VariableValue & _numerator;
+  const VariableValue & _denominator;
 };
 
 #endif // QUOTIENTAUX_H

--- a/framework/include/auxkernels/VariableTimeIntegrationAux.h
+++ b/framework/include/auxkernels/VariableTimeIntegrationAux.h
@@ -37,7 +37,7 @@ protected:
   virtual Real computeValue();
   Real getIntegralValue();
 
-  std::vector<VariableValue *>  _coupled_vars;
+  std::vector<const VariableValue *>  _coupled_vars;
   Real _coef;
   unsigned int _order;
   std::vector<Real> _integration_coef;

--- a/framework/include/auxkernels/VectorMagnitudeAux.h
+++ b/framework/include/auxkernels/VectorMagnitudeAux.h
@@ -22,7 +22,8 @@ template<>
 InputParameters validParams<VectorMagnitudeAux>();
 
 /**
- *
+ * Computes the magnitude of a vector whose components are given by up
+ * to three coupled variables.
  */
 class VectorMagnitudeAux : public AuxKernel
 {
@@ -33,9 +34,9 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _x;
-  VariableValue & _y;
-  VariableValue & _z;
+  const VariableValue & _x;
+  const VariableValue & _y;
+  const VariableValue & _z;
 };
 
 #endif /* VECTORMAGNITUDEAUX_H */

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -86,7 +86,7 @@ protected:
    * @return Reference to a VariableValue for the coupled variable
    * @see Kernel::value
    */
-  virtual VariableValue & coupledValue(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledValue(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns an old value from previous time step  of a coupled variable
@@ -95,7 +95,7 @@ protected:
    * @return Reference to a VariableValue containing the old value of the coupled variable
    * @see Kernel::valueOld
    */
-  virtual VariableValue & coupledValueOld(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledValueOld(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns an old value from two time steps previous of a coupled variable
@@ -104,7 +104,7 @@ protected:
    * @return Reference to a VariableValue containing the older value of the coupled variable
    * @see Kernel::valueOlder
    */
-  virtual VariableValue & coupledValueOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledValueOlder(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns gradient of a coupled variable
@@ -113,7 +113,7 @@ protected:
    * @return Reference to a VariableGradient containing the gradient of the coupled variable
    * @see Kernel::gradient
    */
-  virtual VariableGradient & coupledGradient(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableGradient & coupledGradient(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns an old gradient from previous time step of a coupled variable
@@ -122,7 +122,7 @@ protected:
    * @return Reference to a VariableGradient containing the old gradient of the coupled variable
    * @see Kernel::gradientOld
    */
-  virtual VariableGradient & coupledGradientOld(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableGradient & coupledGradientOld(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns an old gradient from two time steps previous of a coupled variable
@@ -131,7 +131,7 @@ protected:
    * @return Reference to a VariableGradient containing the older gradient of the coupled variable
    * @see Kernel::gradientOlder
    */
-  virtual VariableGradient & coupledGradientOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableGradient & coupledGradientOlder(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns second derivative of a coupled variable
@@ -140,7 +140,7 @@ protected:
    * @return Reference to a VariableSecond containing the second derivative of the coupled variable
    * @see Kernel::second
    */
-  virtual VariableSecond & coupledSecond(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableSecond & coupledSecond(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns an old second derivative from previous time step of a coupled variable
@@ -149,7 +149,7 @@ protected:
    * @return Reference to a VariableSecond containing the old second derivative of the coupled variable
    * @see Kernel::secondOld
    */
-  virtual VariableSecond & coupledSecondOld(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableSecond & coupledSecondOld(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns an old second derivative from two time steps previous of a coupled variable
@@ -158,7 +158,7 @@ protected:
    * @return Reference to a VariableSecond containing the older second derivative of the coupled variable
    * @see Kernel::secondOlder
    */
-  virtual VariableSecond & coupledSecondOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableSecond & coupledSecondOlder(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Time derivative of a coupled variable
@@ -167,7 +167,7 @@ protected:
    * @return Reference to a VariableValue containing the time derivative of the coupled variable
    * @see Kernel::dot
    */
-  virtual VariableValue & coupledDot(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledDot(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Time derivative of a coupled variable with respect to the coefficients
@@ -176,7 +176,7 @@ protected:
    * @return Reference to a VariableValue containing the time derivative of the coupled variable with respect to the coefficients
    * @see Kernel:dotDu
    */
-  virtual VariableValue & coupledDotDu(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledDotDu(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns nodal values of a coupled variable
@@ -184,7 +184,7 @@ protected:
    * @param comp Component number for vector of coupled variables
    * @return Reference to a VariableValue for the coupled variable
    */
-  virtual VariableValue & coupledNodalValue(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledNodalValue(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns an old nodal value from previous time step  of a coupled variable
@@ -192,7 +192,7 @@ protected:
    * @param comp Component number for vector of coupled variables
    * @return Reference to a VariableValue containing the old value of the coupled variable
    */
-  virtual VariableValue & coupledNodalValueOld(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledNodalValueOld(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns an old nodal value from two time steps previous of a coupled variable
@@ -200,7 +200,7 @@ protected:
    * @param comp Component number for vector of coupled variables
    * @return Reference to a VariableValue containing the older value of the coupled variable
    */
-  virtual VariableValue & coupledNodalValueOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledNodalValueOlder(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Nodal values of time derivative of a coupled variable
@@ -208,7 +208,7 @@ protected:
    * @param comp Component number for vector of coupled variables
    * @return Reference to a VariableValue containing the nodal values of time derivative of the coupled variable
    */
-  virtual VariableValue & coupledNodalDot(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledNodalDot(const std::string & var_name, unsigned int comp = 0);
 
 protected:
   // Reference to FEProblem

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -89,6 +89,18 @@ protected:
   virtual const VariableValue & coupledValue(const std::string & var_name, unsigned int comp = 0);
 
   /**
+   * Returns a *writable* reference to a coupled variable.  Note: you
+   * should not have to use this very often (use coupledValue()
+   * instead) but there are situations, such as writing to multiple
+   * AuxVariables from a single AuxKernel, where it is required.
+   * @param var_name Name of coupled variable
+   * @param comp Component number for vector of coupled variables
+   * @return Reference to a VariableValue for the coupled variable
+   * @see Kernel::value
+   */
+  virtual VariableValue & writableCoupledValue(const std::string & var_name, unsigned int comp = 0);
+
+  /**
    * Returns an old value from previous time step  of a coupled variable
    * @param var_name Name of coupled variable
    * @param comp Component number for vector of coupled variables

--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -128,59 +128,59 @@ public:
   // damping
   VariableValue & increment() { return _increment; }
 
-  VariableValue & sln() { return _u; }
-  VariableValue & slnOld() { _need_u_old = true; return _u_old; }
-  VariableValue & slnOlder() { _need_u_older = true;return _u_older; }
-  VariableGradient  & gradSln() { return _grad_u; }
-  VariableGradient  & gradSlnOld() { _need_grad_old = true; return _grad_u_old; }
-  VariableGradient  & gradSlnOlder() { _need_grad_older = true; return _grad_u_older; }
-  VariableSecond & secondSln() { _need_second = true; secondPhi(); secondPhiFace(); return _second_u; }
-  VariableSecond & secondSlnOld() { _need_second_old = true; secondPhi(); secondPhiFace(); return _second_u_old; }
-  VariableSecond & secondSlnOlder() { _need_second_older = true; secondPhi(); secondPhiFace(); return _second_u_older; }
+  const VariableValue & sln() { return _u; }
+  const VariableValue & slnOld() { _need_u_old = true; return _u_old; }
+  const VariableValue & slnOlder() { _need_u_older = true;return _u_older; }
+  const VariableGradient & gradSln() { return _grad_u; }
+  const VariableGradient & gradSlnOld() { _need_grad_old = true; return _grad_u_old; }
+  const VariableGradient & gradSlnOlder() { _need_grad_older = true; return _grad_u_older; }
+  const VariableSecond & secondSln() { _need_second = true; secondPhi(); secondPhiFace(); return _second_u; }
+  const VariableSecond & secondSlnOld() { _need_second_old = true; secondPhi(); secondPhiFace(); return _second_u_old; }
+  const VariableSecond & secondSlnOlder() { _need_second_older = true; secondPhi(); secondPhiFace(); return _second_u_older; }
 
-  VariableValue & uDot() { return _u_dot; }
-  VariableValue & duDotDu() { return _du_dot_du; }
+  const VariableValue & uDot() { return _u_dot; }
+  const VariableValue & duDotDu() { return _du_dot_du; }
 
   const Node * & node() { return _node; }
   dof_id_type & nodalDofIndex() { return _nodal_dof_index; }
   bool isNodalDefined() { return _is_defined; }
-  VariableValue & nodalSln() { return _nodal_u; }
-  VariableValue & nodalSlnOld() { return _nodal_u_old; }
-  VariableValue & nodalSlnOlder() { return _nodal_u_older; }
-  VariableValue & nodalSlnDot() { return _nodal_u_dot; }
-  VariableValue & nodalSlnDuDotDu() { return _nodal_du_dot_du; }
+  const VariableValue & nodalSln() { return _nodal_u; }
+  const VariableValue & nodalSlnOld() { return _nodal_u_old; }
+  const VariableValue & nodalSlnOlder() { return _nodal_u_older; }
+  const VariableValue & nodalSlnDot() { return _nodal_u_dot; }
+  const VariableValue & nodalSlnDuDotDu() { return _nodal_du_dot_du; }
 
-  VariableValue & nodalValue();
-  VariableValue & nodalValueOld();
-  VariableValue & nodalValueOlder();
-  VariableValue & nodalValueDot();
+  const VariableValue & nodalValue();
+  const VariableValue & nodalValueOld();
+  const VariableValue & nodalValueOlder();
+  const VariableValue & nodalValueDot();
 
-  VariableValue & nodalValueNeighbor();
-  VariableValue & nodalValueOldNeighbor();
-  VariableValue & nodalValueOlderNeighbor();
-  VariableValue & nodalValueDotNeighbor();
+  const VariableValue & nodalValueNeighbor();
+  const VariableValue & nodalValueOldNeighbor();
+  const VariableValue & nodalValueOlderNeighbor();
+  const VariableValue & nodalValueDotNeighbor();
 
-  VariableValue & slnNeighbor() { return _u_neighbor; }
-  VariableValue & slnOldNeighbor() { _need_u_old_neighbor = true; return _u_old_neighbor; }
-  VariableValue & slnOlderNeighbor() { _need_u_older_neighbor = true; return _u_older_neighbor; }
-  VariableGradient & gradSlnNeighbor() { return _grad_u_neighbor; }
-  VariableGradient & gradSlnOldNeighbor() { _need_grad_old_neighbor = true; return _grad_u_old_neighbor; }
-  VariableGradient & gradSlnOlderNeighbor() { _need_grad_older_neighbor = true; return _grad_u_older_neighbor; }
-  VariableSecond & secondSlnNeighbor() { _need_second_neighbor = true; secondPhiFaceNeighbor(); return _second_u_neighbor; }
-  VariableSecond & secondSlnOldNeighbor() { _need_second_old_neighbor = true; secondPhiFaceNeighbor(); return _second_u_old_neighbor; }
-  VariableSecond & secondSlnOlderNeighbor() { _need_second_older_neighbor = true; secondPhiFaceNeighbor(); return _second_u_older_neighbor; }
+  const VariableValue & slnNeighbor() { return _u_neighbor; }
+  const VariableValue & slnOldNeighbor() { _need_u_old_neighbor = true; return _u_old_neighbor; }
+  const VariableValue & slnOlderNeighbor() { _need_u_older_neighbor = true; return _u_older_neighbor; }
+  const VariableGradient & gradSlnNeighbor() { return _grad_u_neighbor; }
+  const VariableGradient & gradSlnOldNeighbor() { _need_grad_old_neighbor = true; return _grad_u_old_neighbor; }
+  const VariableGradient & gradSlnOlderNeighbor() { _need_grad_older_neighbor = true; return _grad_u_older_neighbor; }
+  const VariableSecond & secondSlnNeighbor() { _need_second_neighbor = true; secondPhiFaceNeighbor(); return _second_u_neighbor; }
+  const VariableSecond & secondSlnOldNeighbor() { _need_second_old_neighbor = true; secondPhiFaceNeighbor(); return _second_u_old_neighbor; }
+  const VariableSecond & secondSlnOlderNeighbor() { _need_second_older_neighbor = true; secondPhiFaceNeighbor(); return _second_u_older_neighbor; }
 
-  VariableValue & uDotNeighbor() { return _u_dot_neighbor; }
-  VariableValue & duDotDuNeighbor() { return _du_dot_du_neighbor; }
+  const VariableValue & uDotNeighbor() { return _u_dot_neighbor; }
+  const VariableValue & duDotDuNeighbor() { return _du_dot_du_neighbor; }
 
   const Node * & nodeNeighbor() { return _node_neighbor; }
   dof_id_type & nodalDofIndexNeighbor() { return _nodal_dof_index_neighbor; }
   bool isNodalNeighborDefined() { return _is_defined_neighbor; }
-  VariableValue & nodalSlnNeighbor() { return _nodal_u_neighbor; }
-  VariableValue & nodalSlnOldNeighbor() { return _nodal_u_old_neighbor; }
-  VariableValue & nodalSlnOlderNeighbor() { return _nodal_u_older_neighbor; }
-  VariableValue & nodalSlnDotNeighbor() { return _nodal_u_dot_neighbor; }
-  VariableValue & nodalSlnDuDotDuNeighbor() { return _nodal_du_dot_du_neighbor; }
+  const VariableValue & nodalSlnNeighbor() { return _nodal_u_neighbor; }
+  const VariableValue & nodalSlnOldNeighbor() { return _nodal_u_old_neighbor; }
+  const VariableValue & nodalSlnOlderNeighbor() { return _nodal_u_older_neighbor; }
+  const VariableValue & nodalSlnDotNeighbor() { return _nodal_u_dot_neighbor; }
+  const VariableValue & nodalSlnDuDotDuNeighbor() { return _nodal_du_dot_du_neighbor; }
 
   /**
    * Compute values at interior quadrature points

--- a/framework/include/base/MooseVariableInterface.h
+++ b/framework/include/base/MooseVariableInterface.h
@@ -48,28 +48,28 @@ protected:
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableValue & value();
+  virtual const VariableValue & value();
 
   /**
    * The old value of the variable this object is operating on.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableValue & valueOld();
+  virtual const VariableValue & valueOld();
 
   /**
    * The older value of the variable this object is operating on.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableValue & valueOlder();
+  virtual const VariableValue & valueOlder();
 
   /**
    * The time derivative of the variable this object is operating on.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableValue & dot();
+  virtual const VariableValue & dot();
 
   /**
    * The derivative of the time derivative of the variable this object is operating on
@@ -79,7 +79,7 @@ protected:
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableValue & dotDu();
+  virtual const VariableValue & dotDu();
 
   /**
    * The gradient of the variable this object is operating on.
@@ -88,49 +88,49 @@ protected:
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableGradient & gradient();
+  virtual const VariableGradient & gradient();
 
   /**
    * The old gradient of the variable this object is operating on.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableGradient & gradientOld();
+  virtual const VariableGradient & gradientOld();
 
   /**
    * The older gradient of the variable this object is operating on.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableGradient & gradientOlder();
+  virtual const VariableGradient & gradientOlder();
 
   /**
    * The second derivative of the variable this object is operating on.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableSecond & second();
+  virtual const VariableSecond & second();
 
   /**
    * The old second derivative of the variable this object is operating on.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableSecond & secondOld();
+  virtual const VariableSecond & secondOld();
 
   /**
    * The older second derivative of the variable this object is operating on.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableSecond & secondOlder();
+  virtual const VariableSecond & secondOlder();
 
   /**
    * The second derivative of the test function.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableTestSecond & secondTest();
+  virtual const VariableTestSecond & secondTest();
 
   /**
    * The second derivative of the test function on the current face.
@@ -139,14 +139,14 @@ protected:
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableTestSecond & secondTestFace();
+  virtual const VariableTestSecond & secondTestFace();
 
   /**
    * The second derivative of the trial function.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariablePhiSecond & secondPhi();
+  virtual const VariablePhiSecond & secondPhi();
 
   /**
    * The second derivative of the trial function on the current face.
@@ -155,7 +155,7 @@ protected:
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariablePhiSecond & secondPhiFace();
+  virtual const VariablePhiSecond & secondPhiFace();
 
   /// Whether or not this object is acting only at nodes
   bool _nodal;

--- a/framework/include/base/NeighborCoupleable.h
+++ b/framework/include/base/NeighborCoupleable.h
@@ -37,15 +37,15 @@ public:
   virtual ~NeighborCoupleable();
 
   // neighbor
-  virtual VariableValue & coupledNeighborValue(const std::string & var_name, unsigned int comp = 0);
-  virtual VariableValue & coupledNeighborValueOld(const std::string & var_name, unsigned int comp = 0);
-  virtual VariableValue & coupledNeighborValueOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledNeighborValue(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledNeighborValueOld(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableValue & coupledNeighborValueOlder(const std::string & var_name, unsigned int comp = 0);
 
-  virtual VariableGradient & coupledNeighborGradient(const std::string & var_name, unsigned int comp = 0);
-  virtual VariableGradient & coupledNeighborGradientOld(const std::string & var_name, unsigned int comp = 0);
-  virtual VariableGradient & coupledNeighborGradientOlder(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableGradient & coupledNeighborGradient(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableGradient & coupledNeighborGradientOld(const std::string & var_name, unsigned int comp = 0);
+  virtual const VariableGradient & coupledNeighborGradientOlder(const std::string & var_name, unsigned int comp = 0);
 
-  virtual VariableSecond & coupledNeighborSecond(const std::string & var_name, unsigned int i = 0);
+  virtual const VariableSecond & coupledNeighborSecond(const std::string & var_name, unsigned int i = 0);
 
 protected:
   bool _neighbor_nodal;

--- a/framework/include/base/NeighborMooseVariableInterface.h
+++ b/framework/include/base/NeighborMooseVariableInterface.h
@@ -41,78 +41,77 @@ protected:
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableValue & neighborValue();
+  virtual const VariableValue & neighborValue();
 
   /**
    * The old value of the variable this object is operating on evaluated on the "neighbor" element.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableValue & neighborValueOld();
+  virtual const VariableValue & neighborValueOld();
 
   /**
    * The older value of the variable this object is operating on evaluated on the "neighbor" element.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableValue & neighborValueOlder();
+  virtual const VariableValue & neighborValueOlder();
 
   /**
    * The gradient of the variable this object is operating on evaluated on the "neighbor" element.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableGradient & neighborGradient();
+  virtual const VariableGradient & neighborGradient();
 
   /**
    * The old gradient of the variable this object is operating on evaluated on the "neighbor" element.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableGradient & neighborGradientOld();
+  virtual const VariableGradient & neighborGradientOld();
 
   /**
    * The older gradient of the variable this object is operating on evaluated on the "neighbor" element.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableGradient & neighborGradientOlder();
+  virtual const VariableGradient & neighborGradientOlder();
 
   /**
    * The second derivative of the variable this object is operating on evaluated on the "neighbor" element.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableSecond & neighborSecond();
+  virtual const VariableSecond & neighborSecond();
 
   /**
    * The old second derivative of the variable this object is operating on evaluated on the "neighbor" element.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableSecond & neighborSecondOld();
+  virtual const VariableSecond & neighborSecondOld();
 
   /**
    * The older second derivative of the variable this object is operating on evaluated on the "neighbor" element.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableSecond & neighborSecondOlder();
+  virtual const VariableSecond & neighborSecondOlder();
 
   /**
    * The second derivative of the neighbor's test function.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariableTestSecond & neighborSecondTest();
+  virtual const VariableTestSecond & neighborSecondTest();
 
   /**
    * The second derivative of the neighbor's shape function.
    *
    * @return The reference to be stored off and used later.
    */
-  virtual VariablePhiSecond & neighborSecondPhi();
-
+  virtual const VariablePhiSecond & neighborSecondPhi();
 };
 
 #endif /* NEIGHBORMOOSEVARIABLEINTERFACE_H */

--- a/framework/include/bcs/MatchedValueBC.h
+++ b/framework/include/bcs/MatchedValueBC.h
@@ -35,7 +35,7 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  VariableValue & _v;
+  const VariableValue & _v;
 
   /// The id of the coupled variable
   unsigned int _v_num;

--- a/framework/include/bcs/NodalBC.h
+++ b/framework/include/bcs/NodalBC.h
@@ -53,7 +53,7 @@ protected:
   /// Quadrature point index
   unsigned int _qp;
   /// Value of the unknown variable this BC is acting on
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// The aux variables to save the residual contributions to
   bool _has_save_in;

--- a/framework/include/bcs/NodalNormalBC.h
+++ b/framework/include/bcs/NodalNormalBC.h
@@ -36,9 +36,9 @@ public:
   virtual void computeResidual(NumericVector<Number> & residual);
 
 protected:
-  VariableValue & _nx;
-  VariableValue & _ny;
-  VariableValue & _nz;
+  const VariableValue & _nx;
+  const VariableValue & _ny;
+  const VariableValue & _nz;
   /// Normal at the node (it is pre-computed by user object subsystem)
   Point _normal;
 };

--- a/framework/include/constraints/FaceFaceConstraint.h
+++ b/framework/include/constraints/FaceFaceConstraint.h
@@ -111,7 +111,7 @@ protected:
   /**
    * The values of Lagrange multipliers in quadrature points
    */
-  VariableValue & _lambda;
+  const VariableValue & _lambda;
 
   MooseMesh::MortarInterface & _iface;
   PenetrationLocator & _master_penetration_locator;

--- a/framework/include/constraints/NodalConstraint.h
+++ b/framework/include/constraints/NodalConstraint.h
@@ -72,13 +72,13 @@ protected:
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type) = 0;
 
   /// Value of the unknown variable this BC is action on
-  VariableValue & _u_slave;
+  const VariableValue & _u_slave;
   /// node IDs connected to the master node (slave nodes)
   std::vector<dof_id_type> _connected_nodes;
   /// node IDs of the master node
   std::vector<dof_id_type> _master_node_vector;
   /// Holds the current solution at the current quadrature point
-  VariableValue & _u_master;
+  const VariableValue & _u_master;
   /// Specifies formulation type used to apply constraints
   Moose::ConstraintFormulationType _formulation;
   /**

--- a/framework/include/constraints/NodeFaceConstraint.h
+++ b/framework/include/constraints/NodeFaceConstraint.h
@@ -128,26 +128,26 @@ public:
 protected:
   /// coupling interface:
 
-  virtual VariableValue & coupledSlaveValue(const std::string & var_name, unsigned int comp = 0) { return coupledValue(var_name, comp); }
-  virtual VariableValue & coupledSlaveValueOld(const std::string & var_name, unsigned int comp = 0){ return coupledValueOld(var_name, comp); }
-  virtual VariableValue & coupledSlaveValueOlder(const std::string & var_name, unsigned int comp = 0){ return coupledValueOlder(var_name, comp); }
+  virtual const VariableValue & coupledSlaveValue(const std::string & var_name, unsigned int comp = 0) { return coupledValue(var_name, comp); }
+  virtual const VariableValue & coupledSlaveValueOld(const std::string & var_name, unsigned int comp = 0){ return coupledValueOld(var_name, comp); }
+  virtual const VariableValue & coupledSlaveValueOlder(const std::string & var_name, unsigned int comp = 0){ return coupledValueOlder(var_name, comp); }
 
-  virtual VariableGradient & coupledSlaveGradient(const std::string & var_name, unsigned int comp = 0){ return coupledGradient(var_name, comp); }
-  virtual VariableGradient & coupledSlaveGradientOld(const std::string & var_name, unsigned int comp = 0){ return coupledGradientOld(var_name, comp); }
-  virtual VariableGradient & coupledSlaveGradientOlder(const std::string & var_name, unsigned int comp = 0){ return coupledGradientOlder(var_name, comp); }
+  virtual const VariableGradient & coupledSlaveGradient(const std::string & var_name, unsigned int comp = 0){ return coupledGradient(var_name, comp); }
+  virtual const VariableGradient & coupledSlaveGradientOld(const std::string & var_name, unsigned int comp = 0){ return coupledGradientOld(var_name, comp); }
+  virtual const VariableGradient & coupledSlaveGradientOlder(const std::string & var_name, unsigned int comp = 0){ return coupledGradientOlder(var_name, comp); }
 
-  virtual VariableSecond & coupledSlaveSecond(const std::string & var_name, unsigned int comp = 0){ return coupledSecond(var_name, comp); }
+  virtual const VariableSecond & coupledSlaveSecond(const std::string & var_name, unsigned int comp = 0){ return coupledSecond(var_name, comp); }
 
 
-  virtual VariableValue & coupledMasterValue(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborValue(var_name, comp); }
-  virtual VariableValue & coupledMasterValueOld(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborValueOld(var_name, comp); }
-  virtual VariableValue & coupledMasterValueOlder(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborValueOlder(var_name, comp); }
+  virtual const VariableValue & coupledMasterValue(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborValue(var_name, comp); }
+  virtual const VariableValue & coupledMasterValueOld(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborValueOld(var_name, comp); }
+  virtual const VariableValue & coupledMasterValueOlder(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborValueOlder(var_name, comp); }
 
-  virtual VariableGradient & coupledMasterGradient(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborGradient(var_name, comp); }
-  virtual VariableGradient & coupledMasterGradientOld(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborGradientOld(var_name, comp); }
-  virtual VariableGradient & coupledMasterGradientOlder(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborGradientOlder(var_name, comp); }
+  virtual const VariableGradient & coupledMasterGradient(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborGradient(var_name, comp); }
+  virtual const VariableGradient & coupledMasterGradientOld(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborGradientOld(var_name, comp); }
+  virtual const VariableGradient & coupledMasterGradientOlder(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborGradientOlder(var_name, comp); }
 
-  virtual VariableSecond & coupledMasterSecond(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborSecond(var_name, comp); }
+  virtual const VariableSecond & coupledMasterSecond(const std::string & var_name, unsigned int comp = 0){ return coupledNeighborSecond(var_name, comp); }
 
 
   /// Boundary ID for the slave surface
@@ -168,7 +168,7 @@ protected:
   const Elem * & _current_master;
 
   /// Value of the unknown variable this BC is action on
-  VariableValue & _u_slave;
+  const VariableValue & _u_slave;
   /// Shape function on the slave side.  This will always
   VariablePhiValue _phi_slave;
   /// Shape function on the slave side.  This will always only have one entry and that entry will always be "1"
@@ -191,9 +191,9 @@ protected:
   const VariableTestGradient & _grad_test_master;
 
   /// Holds the current solution at the current quadrature point
-  VariableValue & _u_master;
+  const VariableValue & _u_master;
   /// Holds the current solution gradient at the current quadrature point
-  VariableGradient & _grad_u_master;
+  const VariableGradient & _grad_u_master;
 
   /// DOF map
   const DofMap & _dof_map;

--- a/framework/include/dampers/Damper.h
+++ b/framework/include/dampers/Damper.h
@@ -92,9 +92,9 @@ protected:
   /// The current Newton increment
   VariableValue & _u_increment;
   /// Holds the current solution at the current quadrature point
-  VariableValue & _u;
+  const VariableValue & _u;
   /// Holds the current solution gradient at the current quadrature point
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 };
 
 #endif

--- a/framework/include/dgkernels/DGKernel.h
+++ b/framework/include/dgkernels/DGKernel.h
@@ -152,10 +152,10 @@ protected:
   BoundaryID _boundary_id;
 
   /// Holds the current solution at the current quadrature point on the face.
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// Holds the current solution gradient at the current quadrature point on the face.
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
   // shape functions
   const VariablePhiValue & _phi;
   const VariablePhiGradient & _grad_phi;
@@ -179,9 +179,9 @@ protected:
   const VariableTestGradient & _grad_test_neighbor;
 
   /// Holds the current solution at the current quadrature point
-  VariableValue & _u_neighbor;
+  const VariableValue & _u_neighbor;
   /// Holds the current solution gradient at the current quadrature point
-  VariableGradient & _grad_u_neighbor;
+  const VariableGradient & _grad_u_neighbor;
 
   /**
    * This is the virtual that derived classes should override for computing the residual on neighboring element.

--- a/framework/include/dirackernels/DiracKernel.h
+++ b/framework/include/dirackernels/DiracKernel.h
@@ -207,14 +207,14 @@ protected:
   const VariableTestGradient & _grad_test;
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 
   /// Time derivative of the solution
-  VariableValue & _u_dot;
+  const VariableValue & _u_dot;
   /// Derivative of u_dot wrt u
-  VariableValue & _du_dot_du;
+  const VariableValue & _du_dot_du;
 
 private:
   /// Data structure for caching user-defined IDs which can be mapped to

--- a/framework/include/indicators/ElementIndicator.h
+++ b/framework/include/indicators/ElementIndicator.h
@@ -60,20 +60,20 @@ protected:
 
   MooseVariable & _var;
 
-
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
+
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 
   /// Time derivative of u
-  VariableValue & _u_dot;
+  const VariableValue & _u_dot;
+
   /// Derivative of u_dot wrt u
-  VariableValue & _du_dot_du;
+  const VariableValue & _du_dot_du;
 
   /// Holds local indicator entries as their accumulated by this ElementIndicator
   DenseVector<Number> _local_indtr;
-  //  Real _local_indtr;
 };
 
 #endif /* ELEMENTINDICATOR_H */

--- a/framework/include/indicators/InternalSideIndicator.h
+++ b/framework/include/indicators/InternalSideIndicator.h
@@ -83,18 +83,19 @@ protected:
   bool _scale_by_flux_faces;
 
   /// Holds the current solution at the current quadrature point on the face.
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// Holds the current solution gradient at the current quadrature point on the face.
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 
   /// Normal vectors at the quadrature points
   const MooseArray<Point>& _normals;
 
   /// Holds the current solution at the current quadrature point
-  VariableValue & _u_neighbor;
+  const VariableValue & _u_neighbor;
+
   /// Holds the current solution gradient at the current quadrature point
-  VariableGradient & _grad_u_neighbor;
+  const VariableGradient & _grad_u_neighbor;
 
   /**
    * The virtual function you will want to override to compute error contributions.

--- a/framework/include/indicators/LaplacianJumpIndicator.h
+++ b/framework/include/indicators/LaplacianJumpIndicator.h
@@ -33,8 +33,8 @@ protected:
 
   virtual Real computeQpIntegral();
 
-  VariableSecond & _second_u;
-  VariableSecond & _second_u_neighbor;
+  const VariableSecond & _second_u;
+  const VariableSecond & _second_u_neighbor;
 };
 
 #endif /* LAPLACIANJUMPINDICATOR_H */

--- a/framework/include/interfacekernels/InterfaceKernel.h
+++ b/framework/include/interfacekernels/InterfaceKernel.h
@@ -48,8 +48,8 @@ protected:
 
   MooseVariable & _neighbor_var;
 
-  VariableValue & _neighbor_value;
-  VariableGradient & _grad_neighbor_value;
+  const VariableValue & _neighbor_value;
+  const VariableGradient & _grad_neighbor_value;
 };
 
 #endif

--- a/framework/include/kernels/CoupledForce.h
+++ b/framework/include/kernels/CoupledForce.h
@@ -40,7 +40,7 @@ protected:
 
 private:
   unsigned int _v_var;
-  VariableValue & _v;
+  const VariableValue & _v;
 };
 
 #endif //COUPLEDFORCE_H

--- a/framework/include/kernels/CoupledTimeDerivative.h
+++ b/framework/include/kernels/CoupledTimeDerivative.h
@@ -37,8 +37,8 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
-  VariableValue & _v_dot;
-  VariableValue & _dv_dot;
+  const VariableValue & _v_dot;
+  const VariableValue & _dv_dot;
   unsigned int _v_var;
 };
 

--- a/framework/include/kernels/EigenKernel.h
+++ b/framework/include/kernels/EigenKernel.h
@@ -47,10 +47,10 @@ protected:
   virtual Real computeQpJacobian();
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 
   /// flag for as an eigen kernel or a normal kernel
   bool _eigen;

--- a/framework/include/kernels/Kernel.h
+++ b/framework/include/kernels/Kernel.h
@@ -50,16 +50,16 @@ protected:
   virtual void precalculateResidual();
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 
   /// Time derivative of u
-  VariableValue & _u_dot;
+  const VariableValue & _u_dot;
 
   /// Derivative of u_dot with respect to u
-  VariableValue & _du_dot_du;
+  const VariableValue & _du_dot_du;
 };
 
 #endif /* KERNEL_H */

--- a/framework/include/kernels/MassLumpedTimeDerivative.h
+++ b/framework/include/kernels/MassLumpedTimeDerivative.h
@@ -34,7 +34,7 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  VariableValue & _u_dot_nodal;
+  const VariableValue & _u_dot_nodal;
 };
 
 #endif // MASSLUMPEDTIMEDERIVATIVE_H

--- a/framework/include/kernels/NodalEqualValueConstraint.h
+++ b/framework/include/kernels/NodalEqualValueConstraint.h
@@ -41,7 +41,7 @@ public:
 
 protected:
   std::vector<unsigned int> _val_number;
-  std::vector<VariableValue *> _value;
+  std::vector<const VariableValue *> _value;
 };
 
 

--- a/framework/include/markers/ComboMarker.h
+++ b/framework/include/markers/ComboMarker.h
@@ -36,7 +36,7 @@ protected:
 
   std::vector<MarkerName> _names;
 
-  std::vector<VariableValue *> _markers;
+  std::vector<const VariableValue *> _markers;
 };
 
 #endif /* COMBOMARKER_H */

--- a/framework/include/markers/Marker.h
+++ b/framework/include/markers/Marker.h
@@ -103,7 +103,7 @@ protected:
    * @param name The name of the _other_ Marker that you want to have access to.
    * @return A _reference_ that will hold the value of the marker in it's 0 (zeroth) position.
    */
-  VariableValue & getMarkerValue(std::string name);
+  const VariableValue & getMarkerValue(std::string name);
 
   SubProblem & _subproblem;
   FEProblem & _fe_problem;

--- a/framework/include/markers/ValueRangeMarker.h
+++ b/framework/include/markers/ValueRangeMarker.h
@@ -39,7 +39,7 @@ protected:
   MarkerValue _inside;
   MarkerValue _outside;
 
-  VariableValue & _u;
+  const VariableValue & _u;
 };
 
 #endif /* VALUERANGEMARKER_H */

--- a/framework/include/markers/ValueThresholdMarker.h
+++ b/framework/include/markers/ValueThresholdMarker.h
@@ -39,7 +39,7 @@ protected:
   bool _invert;
   MarkerValue _third_state;
 
-  VariableValue & _u;
+  const VariableValue & _u;
 };
 
 #endif /* VALUETHRESHOLDMARKER_H */

--- a/framework/include/nodalkernels/NodalKernel.h
+++ b/framework/include/nodalkernels/NodalKernel.h
@@ -155,13 +155,13 @@ protected:
   unsigned int _qp;
 
   /// Value of the unknown variable this is acting on
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// Time derivative of the variable this is acting on
-  VariableValue & _u_dot;
+  const VariableValue & _u_dot;
 
   /// Derivative of u_dot with respect to u
-  VariableValue & _du_dot_du;
+  const VariableValue & _du_dot_du;
 
   /// The aux variables to save the residual contributions to
   bool _has_save_in;

--- a/framework/include/postprocessors/ElementIntegralVariablePostprocessor.h
+++ b/framework/include/postprocessors/ElementIntegralVariablePostprocessor.h
@@ -41,11 +41,11 @@ protected:
   virtual Real computeQpIntegral();
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
   /// Holds the solution derivative at the current quadrature points
-  VariableValue & _u_dot;
+  const VariableValue & _u_dot;
 };
 
 #endif

--- a/framework/include/postprocessors/ElementL2Difference.h
+++ b/framework/include/postprocessors/ElementL2Difference.h
@@ -44,7 +44,7 @@ protected:
   virtual Real computeQpIntegral();
 
   /// The variable to compare to
-  VariableValue & _other_var;
+  const VariableValue & _other_var;
 };
 
 #endif //ELEMENTL2DIFFERENCE_H

--- a/framework/include/postprocessors/ElementVariablePostprocessor.h
+++ b/framework/include/postprocessors/ElementVariablePostprocessor.h
@@ -40,13 +40,13 @@ protected:
   virtual void computeQpValue() = 0;
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 
   /// Holds the solution derivative at the current quadrature points
-  VariableValue & _u_dot;
+  const VariableValue & _u_dot;
 
   /// The current quadrature point
   unsigned int _qp;

--- a/framework/include/postprocessors/NodalVariablePostprocessor.h
+++ b/framework/include/postprocessors/NodalVariablePostprocessor.h
@@ -38,7 +38,7 @@ public:
 
 protected:
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
 };
 
 #endif

--- a/framework/include/postprocessors/PointValue.h
+++ b/framework/include/postprocessors/PointValue.h
@@ -70,7 +70,7 @@ protected:
   MooseVariable & _var;
 
   /// The value of the desired variable
-  VariableValue & _u;
+  const VariableValue & _u;
 
   /// A convenience reference to the libMesh::MeshBase object
   MeshBase & _mesh;

--- a/framework/include/postprocessors/SideIntegralVariablePostprocessor.h
+++ b/framework/include/postprocessors/SideIntegralVariablePostprocessor.h
@@ -41,9 +41,9 @@ protected:
   virtual Real computeQpIntegral();
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 };
 
 #endif

--- a/framework/include/userobject/ElementIntegralVariableUserObject.h
+++ b/framework/include/userobject/ElementIntegralVariableUserObject.h
@@ -41,9 +41,9 @@ protected:
   virtual Real computeQpIntegral();
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 };
 
 #endif

--- a/framework/include/userobject/SideIntegralVariableUserObject.h
+++ b/framework/include/userobject/SideIntegralVariableUserObject.h
@@ -41,9 +41,9 @@ protected:
   virtual Real computeQpIntegral();
 
   /// Holds the solution at current quadrature points
-  VariableValue & _u;
+  const VariableValue & _u;
   /// Holds the solution gradient at the current quadrature points
-  VariableGradient & _grad_u;
+  const VariableGradient & _grad_u;
 };
 
 #endif

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -218,7 +218,7 @@ AuxKernel::isNodal()
   return _nodal;
 }
 
-VariableValue &
+const VariableValue &
 AuxKernel::coupledDot(const std::string & var_name, unsigned int comp)
 {
   MooseVariable * var = getVar(var_name, comp);
@@ -228,7 +228,7 @@ AuxKernel::coupledDot(const std::string & var_name, unsigned int comp)
   return Coupleable::coupledDot(var_name, comp);
 }
 
-VariableValue &
+const VariableValue &
 AuxKernel::coupledDotDu(const std::string & var_name, unsigned int comp)
 {
   MooseVariable * var = getVar(var_name, comp);

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -152,7 +152,7 @@ Coupleable::getDefaultValue(const std::string & var_name)
   return default_value_it->second;
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledValue(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name))
@@ -177,7 +177,7 @@ Coupleable::coupledValue(const std::string & var_name, unsigned int comp)
   }
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledValueOld(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name))
@@ -203,7 +203,7 @@ Coupleable::coupledValueOld(const std::string & var_name, unsigned int comp)
   }
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledValueOlder(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name))
@@ -250,7 +250,7 @@ Coupleable::coupledValueOlder(const std::string & var_name, unsigned int comp)
 
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledDot(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
@@ -275,7 +275,7 @@ Coupleable::coupledDot(const std::string & var_name, unsigned int comp)
   }
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledDotDu(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
@@ -300,7 +300,7 @@ Coupleable::coupledDotDu(const std::string & var_name, unsigned int comp)
 }
 
 
-VariableGradient &
+const VariableGradient &
 Coupleable::coupledGradient(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
@@ -318,7 +318,7 @@ Coupleable::coupledGradient(const std::string & var_name, unsigned int comp)
     return (_c_is_implicit) ? var->gradSlnNeighbor() : var->gradSlnOldNeighbor();
 }
 
-VariableGradient &
+const VariableGradient &
 Coupleable::coupledGradientOld(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
@@ -337,7 +337,7 @@ Coupleable::coupledGradientOld(const std::string & var_name, unsigned int comp)
     return (_c_is_implicit) ? var->gradSlnOldNeighbor() : var->gradSlnOlderNeighbor();
 }
 
-VariableGradient &
+const VariableGradient &
 Coupleable::coupledGradientOlder(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
@@ -361,7 +361,7 @@ Coupleable::coupledGradientOlder(const std::string & var_name, unsigned int comp
     mooseError("Older values not available for explicit schemes");
 }
 
-VariableSecond &
+const VariableSecond &
 Coupleable::coupledSecond(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
@@ -379,7 +379,7 @@ Coupleable::coupledSecond(const std::string & var_name, unsigned int comp)
     return (_c_is_implicit) ? var->secondSlnNeighbor() : var->secondSlnOlderNeighbor();
 }
 
-VariableSecond &
+const VariableSecond &
 Coupleable::coupledSecondOld(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
@@ -397,7 +397,7 @@ Coupleable::coupledSecondOld(const std::string & var_name, unsigned int comp)
     return (_c_is_implicit) ? var->secondSlnOldNeighbor() : var->secondSlnOlderNeighbor();
 }
 
-VariableSecond &
+const VariableSecond &
 Coupleable::coupledSecondOlder(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0
@@ -420,7 +420,7 @@ Coupleable::coupledSecondOlder(const std::string & var_name, unsigned int comp)
     mooseError("Older values not available for explicit schemes");
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledNodalValue(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name))
@@ -435,7 +435,7 @@ Coupleable::coupledNodalValue(const std::string & var_name, unsigned int comp)
     return (_c_is_implicit) ? var->nodalValueNeighbor() : var->nodalValueOldNeighbor();
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledNodalValueOld(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name))
@@ -451,7 +451,7 @@ Coupleable::coupledNodalValueOld(const std::string & var_name, unsigned int comp
     return (_c_is_implicit) ? var->nodalValueOldNeighbor() : var->nodalValueOlderNeighbor();
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledNodalValueOlder(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name))
@@ -471,7 +471,7 @@ Coupleable::coupledNodalValueOlder(const std::string & var_name, unsigned int co
     mooseError("Older values not available for explicit schemes");
 }
 
-VariableValue &
+const VariableValue &
 Coupleable::coupledNodalDot(const std::string & var_name, unsigned int comp)
 {
   if (!isCoupled(var_name)) // Return default 0

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -177,6 +177,12 @@ Coupleable::coupledValue(const std::string & var_name, unsigned int comp)
   }
 }
 
+VariableValue &
+Coupleable::writableCoupledValue(const std::string & var_name, unsigned int comp)
+{
+  return const_cast<VariableValue &>(coupledValue(var_name, comp));
+}
+
 const VariableValue &
 Coupleable::coupledValueOld(const std::string & var_name, unsigned int comp)
 {

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -411,7 +411,7 @@ MooseVariable::secondPhiFaceNeighbor()
   return *_second_phi_face_neighbor;
 }
 
-VariableValue &
+const VariableValue &
 MooseVariable::nodalValue()
 {
   if (isNodal())
@@ -423,7 +423,7 @@ MooseVariable::nodalValue()
     mooseError("Nodal values can be requested only on nodal variables, variable '" << name() << "' is not nodal.");
 }
 
-VariableValue &
+const VariableValue &
 MooseVariable::nodalValueOld()
 {
   if (isNodal())
@@ -435,7 +435,7 @@ MooseVariable::nodalValueOld()
     mooseError("Nodal values can be requested only on nodal variables, variable '" << name() << "' is not nodal.");
 }
 
-VariableValue &
+const VariableValue &
 MooseVariable::nodalValueOlder()
 {
   if (isNodal())
@@ -447,7 +447,7 @@ MooseVariable::nodalValueOlder()
     mooseError("Nodal values can be requested only on nodal variables, variable '" << name() << "' is not nodal.");
 }
 
-VariableValue &
+const VariableValue &
 MooseVariable::nodalValueDot()
 {
   if (isNodal())
@@ -459,7 +459,7 @@ MooseVariable::nodalValueDot()
     mooseError("Nodal values can be requested only on nodal variables, variable '" << name() << "' is not nodal.");
 }
 
-VariableValue &
+const VariableValue &
 MooseVariable::nodalValueNeighbor()
 {
   if (isNodal())
@@ -471,7 +471,7 @@ MooseVariable::nodalValueNeighbor()
     mooseError("Nodal values can be requested only on nodal variables, variable '" << name() << "' is not nodal.");
 }
 
-VariableValue &
+const VariableValue &
 MooseVariable::nodalValueOldNeighbor()
 {
   if (isNodal())
@@ -483,7 +483,7 @@ MooseVariable::nodalValueOldNeighbor()
     mooseError("Nodal values can be requested only on nodal variables, variable '" << name() << "' is not nodal.");
 }
 
-VariableValue &
+const VariableValue &
 MooseVariable::nodalValueOlderNeighbor()
 {
   if (isNodal())
@@ -495,7 +495,7 @@ MooseVariable::nodalValueOlderNeighbor()
     mooseError("Nodal values can be requested only on nodal variables, variable '" << name() << "' is not nodal.");
 }
 
-VariableValue &
+const VariableValue &
 MooseVariable::nodalValueDotNeighbor()
 {
   if (isNodal())

--- a/framework/src/base/MooseVariableInterface.C
+++ b/framework/src/base/MooseVariableInterface.C
@@ -46,7 +46,7 @@ MooseVariableInterface::mooseVariable()
   return _variable;
 }
 
-VariableValue &
+const VariableValue &
 MooseVariableInterface::value()
 {
   if (_nodal)
@@ -55,7 +55,7 @@ MooseVariableInterface::value()
     return _variable->sln();
 }
 
-VariableValue &
+const VariableValue &
 MooseVariableInterface::valueOld()
 {
   if (_nodal)
@@ -64,7 +64,7 @@ MooseVariableInterface::valueOld()
     return _variable->slnOld();
 }
 
-VariableValue &
+const VariableValue &
 MooseVariableInterface::valueOlder()
 {
   if (_nodal)
@@ -73,7 +73,7 @@ MooseVariableInterface::valueOlder()
     return _variable->slnOlder();
 }
 
-VariableValue &
+const VariableValue &
 MooseVariableInterface::dot()
 {
   if (_nodal)
@@ -82,7 +82,7 @@ MooseVariableInterface::dot()
     return _variable->uDot();
 }
 
-VariableValue &
+const VariableValue &
 MooseVariableInterface::dotDu()
 {
   if (_nodal)
@@ -92,7 +92,7 @@ MooseVariableInterface::dotDu()
 }
 
 
-VariableGradient &
+const VariableGradient &
 MooseVariableInterface::gradient()
 {
   if (_nodal)
@@ -101,7 +101,7 @@ MooseVariableInterface::gradient()
   return _variable->gradSln();
 }
 
-VariableGradient &
+const VariableGradient &
 MooseVariableInterface::gradientOld()
 {
   if (_nodal)
@@ -110,7 +110,7 @@ MooseVariableInterface::gradientOld()
   return _variable->gradSlnOld();
 }
 
-VariableGradient &
+const VariableGradient &
 MooseVariableInterface::gradientOlder()
 {
   if (_nodal)
@@ -119,7 +119,7 @@ MooseVariableInterface::gradientOlder()
   return _variable->gradSlnOlder();
 }
 
-VariableSecond &
+const VariableSecond &
 MooseVariableInterface::second()
 {
   if (_nodal)
@@ -128,7 +128,7 @@ MooseVariableInterface::second()
   return _variable->secondSln();
 }
 
-VariableSecond &
+const VariableSecond &
 MooseVariableInterface::secondOld()
 {
   if (_nodal)
@@ -137,7 +137,7 @@ MooseVariableInterface::secondOld()
   return _variable->secondSlnOld();
 }
 
-VariableSecond &
+const VariableSecond &
 MooseVariableInterface::secondOlder()
 {
   if (_nodal)
@@ -146,39 +146,39 @@ MooseVariableInterface::secondOlder()
   return _variable->secondSlnOlder();
 }
 
-VariableTestSecond &
+const VariableTestSecond &
 MooseVariableInterface::secondTest()
 {
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  return const_cast<VariableTestSecond &>(_variable->secondPhi());
+  return _variable->secondPhi();
 }
 
-VariableTestSecond &
+const VariableTestSecond &
 MooseVariableInterface::secondTestFace()
 {
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  return const_cast<VariableTestSecond &>(_variable->secondPhiFace());
+  return _variable->secondPhiFace();
 }
 
 
-VariablePhiSecond &
+const VariablePhiSecond &
 MooseVariableInterface::secondPhi()
 {
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  return const_cast<VariablePhiSecond &>(_mvi_assembly->secondPhi());
+  return _mvi_assembly->secondPhi();
 }
 
-VariablePhiSecond &
+const VariablePhiSecond &
 MooseVariableInterface::secondPhiFace()
 {
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  return const_cast<VariablePhiSecond &>(_mvi_assembly->secondPhiFace());
+  return _mvi_assembly->secondPhiFace();
 }

--- a/framework/src/base/NeighborCoupleable.C
+++ b/framework/src/base/NeighborCoupleable.C
@@ -28,7 +28,7 @@ NeighborCoupleable::~NeighborCoupleable()
 {
 }
 
-VariableValue &
+const VariableValue &
 NeighborCoupleable::coupledNeighborValue(const std::string & var_name, unsigned int comp)
 {
   MooseVariable * var = getVar(var_name, comp);
@@ -38,7 +38,7 @@ NeighborCoupleable::coupledNeighborValue(const std::string & var_name, unsigned 
     return (_c_is_implicit) ? var->slnNeighbor() : var->slnOldNeighbor();
 }
 
-VariableValue &
+const VariableValue &
 NeighborCoupleable::coupledNeighborValueOld(const std::string & var_name, unsigned int comp)
 {
   validateExecutionerType(var_name);
@@ -50,7 +50,7 @@ NeighborCoupleable::coupledNeighborValueOld(const std::string & var_name, unsign
     return (_c_is_implicit) ? var->slnOldNeighbor() : var->slnOlderNeighbor();
 }
 
-VariableValue &
+const VariableValue &
 NeighborCoupleable::coupledNeighborValueOlder(const std::string & var_name, unsigned int comp)
 {
   validateExecutionerType(var_name);
@@ -72,7 +72,7 @@ NeighborCoupleable::coupledNeighborValueOlder(const std::string & var_name, unsi
   }
 }
 
-VariableGradient &
+const VariableGradient &
 NeighborCoupleable::coupledNeighborGradient(const std::string & var_name, unsigned int comp)
 {
   if (_neighbor_nodal)
@@ -82,7 +82,7 @@ NeighborCoupleable::coupledNeighborGradient(const std::string & var_name, unsign
   return (_c_is_implicit) ? var->gradSlnNeighbor() : var->gradSlnOldNeighbor();
 }
 
-VariableGradient &
+const VariableGradient &
 NeighborCoupleable::coupledNeighborGradientOld(const std::string & var_name, unsigned int comp)
 {
   if (_neighbor_nodal)
@@ -93,7 +93,7 @@ NeighborCoupleable::coupledNeighborGradientOld(const std::string & var_name, uns
   return (_c_is_implicit) ? var->gradSlnOldNeighbor() : var->gradSlnOlderNeighbor();
 }
 
-VariableGradient &
+const VariableGradient &
 NeighborCoupleable::coupledNeighborGradientOlder(const std::string & var_name, unsigned int comp)
 {
   if (_neighbor_nodal)
@@ -107,7 +107,7 @@ NeighborCoupleable::coupledNeighborGradientOlder(const std::string & var_name, u
     mooseError("Older values not available for explicit schemes");
 }
 
-VariableSecond &
+const VariableSecond &
 NeighborCoupleable::coupledNeighborSecond(const std::string & var_name, unsigned int comp)
 {
   if (_neighbor_nodal)

--- a/framework/src/base/NeighborMooseVariableInterface.C
+++ b/framework/src/base/NeighborMooseVariableInterface.C
@@ -28,7 +28,7 @@ NeighborMooseVariableInterface::~NeighborMooseVariableInterface()
 }
 
 
-VariableValue &
+const VariableValue &
 NeighborMooseVariableInterface::neighborValue()
 {
   if (_nodal)
@@ -37,7 +37,7 @@ NeighborMooseVariableInterface::neighborValue()
     return _variable->slnNeighbor();
 }
 
-VariableValue &
+const VariableValue &
 NeighborMooseVariableInterface::neighborValueOld()
 {
   if (_nodal)
@@ -46,7 +46,7 @@ NeighborMooseVariableInterface::neighborValueOld()
     return _variable->slnOldNeighbor();
 }
 
-VariableValue &
+const VariableValue &
 NeighborMooseVariableInterface::neighborValueOlder()
 {
   if (_nodal)
@@ -55,7 +55,7 @@ NeighborMooseVariableInterface::neighborValueOlder()
     return _variable->slnOlderNeighbor();
 }
 
-VariableGradient &
+const VariableGradient &
 NeighborMooseVariableInterface::neighborGradient()
 {
   if (_nodal)
@@ -64,7 +64,7 @@ NeighborMooseVariableInterface::neighborGradient()
   return _variable->gradSlnNeighbor();
 }
 
-VariableGradient &
+const VariableGradient &
 NeighborMooseVariableInterface::neighborGradientOld()
 {
   if (_nodal)
@@ -73,7 +73,7 @@ NeighborMooseVariableInterface::neighborGradientOld()
   return _variable->gradSlnOldNeighbor();
 }
 
-VariableGradient &
+const VariableGradient &
 NeighborMooseVariableInterface::neighborGradientOlder()
 {
   if (_nodal)
@@ -82,7 +82,7 @@ NeighborMooseVariableInterface::neighborGradientOlder()
   return _variable->gradSlnOlderNeighbor();
 }
 
-VariableSecond &
+const VariableSecond &
 NeighborMooseVariableInterface::neighborSecond()
 {
   if (_nodal)
@@ -91,7 +91,7 @@ NeighborMooseVariableInterface::neighborSecond()
   return _variable->secondSlnNeighbor();
 }
 
-VariableSecond &
+const VariableSecond &
 NeighborMooseVariableInterface::neighborSecondOld()
 {
   if (_nodal)
@@ -100,7 +100,7 @@ NeighborMooseVariableInterface::neighborSecondOld()
   return _variable->secondSlnOldNeighbor();
 }
 
-VariableSecond &
+const VariableSecond &
 NeighborMooseVariableInterface::neighborSecondOlder()
 {
   if (_nodal)
@@ -109,20 +109,20 @@ NeighborMooseVariableInterface::neighborSecondOlder()
   return _variable->secondSlnOlderNeighbor();
 }
 
-VariableTestSecond &
+const VariableTestSecond &
 NeighborMooseVariableInterface::neighborSecondTest()
 {
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  return const_cast<VariableTestSecond &>(_variable->secondPhiFaceNeighbor());
+  return _variable->secondPhiFaceNeighbor();
 }
 
-VariablePhiSecond &
+const VariablePhiSecond &
 NeighborMooseVariableInterface::neighborSecondPhi()
 {
   if (_nodal)
     mooseError("Nodal variables do not have second derivatives");
 
-  return const_cast<VariablePhiSecond &>(_mvi_assembly->secondPhiFaceNeighbor());
+  return _mvi_assembly->secondPhiFaceNeighbor();
 }

--- a/framework/src/markers/Marker.C
+++ b/framework/src/markers/Marker.C
@@ -80,7 +80,7 @@ Marker::getErrorVector(std::string indicator)
   return _adaptivity.getErrorVector(indicator);
 }
 
-VariableValue &
+const VariableValue &
 Marker::getMarkerValue(std::string name)
 {
   _depend.insert(name);

--- a/framework/src/postprocessors/ElementalVariableValue.C
+++ b/framework/src/postprocessors/ElementalVariableValue.C
@@ -47,7 +47,7 @@ ElementalVariableValue::getValue()
     _subproblem.reinitElem(_element, _tid);
 
     MooseVariable & var = _subproblem.getVariable(_tid, _var_name);
-    VariableValue & u = var.sln();
+    const VariableValue & u = var.sln();
     unsigned int n = u.size();
     for (unsigned int i = 0; i < n; i++)
       value += u[i];

--- a/test/src/auxkernels/MultipleUpdateAux.C
+++ b/test/src/auxkernels/MultipleUpdateAux.C
@@ -29,8 +29,8 @@ InputParameters validParams<MultipleUpdateAux>()
 MultipleUpdateAux::MultipleUpdateAux(const InputParameters & parameters) :
     AuxKernel(parameters),
     _nl_u(coupledValue("u")),
-    _var1(coupledValue("var1")),
-    _var2(coupledValue("var2"))
+    _var1(const_cast<VariableValue &>(coupledValue("var1"))),
+    _var2(const_cast<VariableValue &>(coupledValue("var2")))
 {
 }
 

--- a/test/src/auxkernels/MultipleUpdateAux.C
+++ b/test/src/auxkernels/MultipleUpdateAux.C
@@ -29,8 +29,8 @@ InputParameters validParams<MultipleUpdateAux>()
 MultipleUpdateAux::MultipleUpdateAux(const InputParameters & parameters) :
     AuxKernel(parameters),
     _nl_u(coupledValue("u")),
-    _var1(const_cast<VariableValue &>(coupledValue("var1"))),
-    _var2(const_cast<VariableValue &>(coupledValue("var2")))
+    _var1(writableCoupledValue("var1")),
+    _var2(writableCoupledValue("var2"))
 {
 }
 


### PR DESCRIPTION
The ham to go with #6398.

This PR actually changes the `Coupleable` and related interfaces in the framework to return const references, so it _may_ break some apps, though I have already updated all the ones I know about.  

I could not come up with a reasonable way to deprecate the old interface, since the new interface differs only in the return type, which you can't overload on.  Fixing apps is trivially easy in most cases: just change every `VariableValue&`, `VariableGradient&`, `VariableSecond&` instance in all of your objects to const.  I'll make a blog post and volunteer to help anyone whose app needs to be updated.
