### PR TITLE
We need to handle gdb and lldb a bit differently

### DIFF
--- a/scripts/memory_logger.py
+++ b/scripts/memory_logger.py
@@ -412,7 +412,10 @@ class Client:
 
       # An agent reported a stop command... so let everyone know where the log was saved, and exit!
       if self.arguments.call_back_host == None:
-        print '\n\nBinary has exited and a log file has been written.\nYou can now attempt to view this file by running the\nmemory_logger with either the --plot or --read arguments:\n\n\t', sys.argv[0], '--plot', self.arguments.outfile[0], '\n\nSee --help for additional viewing options.'
+        print '\n\nBinary has exited and a log file has been written.\nYou can now attempt \
+to view this file by running the\nmemory_logger with either the --plot or --read arguments: \
+\n\n\t', sys.argv[0], '--plot', self.arguments.outfile[0], '\n\nSee --help for additional \
+viewing options.'
 
     # Cancel server operations if ctrl-c was pressed
     except KeyboardInterrupt:
@@ -1053,7 +1056,15 @@ def verifyArgs(args):
           try:
             import lldb
           except ImportError:
-            print '\nUnable to import lldb\n\n\tIF USING MAC OS X; The Python lldb API is now supplied by \n\tXcode but not automatically set in your PYTHONPATH. \n\tPlease search the internet for how to do this if you \n\twish to use --pstack on Mac OS X.\n\n\tNote: If you installed Xcode to the default location of \n\t/Applications, you should only have to perform the following:\n\n\texport PYTHONPATH=/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python:$PYTHONPATH\n\n\t\t###!! IMPORTANT !!###\n\n\tIt may also be necessary to unload the miniconda module.\n\tIf you receive a Fatal Python error about PyThreadState...\n\ttry using your systems version of Python instead.\n\n'
+            print '\nUnable to import lldb\n\n\tIF USING MAC OS X; The Python lldb API is \
+now supplied by\n\tXcode but not automatically set in your PYTHONPATH. \n\tPlease search the \
+internet for how to do this if you \n\twish to use --pstack on Mac OS X.\n\n\tNote: If you \
+installed Xcode to the default location of \n\t/Applications, you should only have to perform \
+the following:\n\n\texport \
+PYTHONPATH=/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python:$PYTHONPATH \
+\n\n\t\t###!! IMPORTANT !!###\n\n\tIt may also be necessary to unload the miniconda module.\n\tIf \
+you receive a Fatal Python error about PyThreadState...\n\ttry using your systems version of \
+Python instead.\n\n'
             sys.exit(1)
         else:
           results = which('lldb')

--- a/scripts/memory_logger.py
+++ b/scripts/memory_logger.py
@@ -69,10 +69,10 @@ class lldbAPI:
 
 class DebugInterpreter:
   """
-Currently, interfacing with LLDB via subprocess is impossible. This is due to lldb not printing
-to stdout, or stderr when displaying the prompt to the user (informing the user, the debugger
-is ready to receive input). However, this class may someday be able to, which is why
-the self.debugger variable is present.
+  Currently, interfacing with LLDB via subprocess is impossible. This is due to lldb not printing
+  to stdout, or stderr when displaying the prompt to the user (informing the user, the debugger
+  is ready to receive input). However, this class may someday be able to, which is why
+  the self.debugger variable is present.
   """
   def __init__(self, arguments):
     self.last_position = 0
@@ -251,7 +251,10 @@ class Server:
     nodes = set(self._PBS_NODEFILE.read().split())
 
     # Print some useful information about our setup
-    print 'Memory Logger running on Host:', self.host, 'Port:', self.port, '\nNodes:', ', '.join(nodes), '\nSample rate (including stdout):', self.arguments.repeat_rate[-1], 's (use --repeat-rate to adjust)\nRemote agents delaying', self.arguments.pbs_delay[-1], 'second/s before tracking. (use --pbs-delay to adjust)\n'
+    print 'Memory Logger running on Host:', self.host, 'Port:', self.port, \
+      '\nNodes:', ', '.join(nodes), \
+      '\nSample rate (including stdout):', self.arguments.repeat_rate[-1], 's (use --repeat-rate to adjust)', \
+      '\nRemote agents delaying', self.arguments.pbs_delay[-1], 'second/s before tracking. (use --pbs-delay to adjust)\n'
 
     # Build our command list based on the PBS_NODEFILE
     command = []
@@ -413,9 +416,9 @@ class Client:
       # An agent reported a stop command... so let everyone know where the log was saved, and exit!
       if self.arguments.call_back_host == None:
         print '\n\nBinary has exited and a log file has been written.\nYou can now attempt \
-to view this file by running the\nmemory_logger with either the --plot or --read arguments: \
-\n\n\t', sys.argv[0], '--plot', self.arguments.outfile[0], '\n\nSee --help for additional \
-viewing options.'
+        to view this file by running the\nmemory_logger with either the --plot or --read arguments: \
+        \n\n\t', sys.argv[0], '--plot', self.arguments.outfile[0], '\n\nSee --help for additional \
+        viewing options.'
 
     # Cancel server operations if ctrl-c was pressed
     except KeyboardInterrupt:
@@ -1057,14 +1060,14 @@ def verifyArgs(args):
             import lldb
           except ImportError:
             print '\nUnable to import lldb\n\n\tIF USING MAC OS X; The Python lldb API is \
-now supplied by\n\tXcode but not automatically set in your PYTHONPATH. \n\tPlease search the \
-internet for how to do this if you \n\twish to use --pstack on Mac OS X.\n\n\tNote: If you \
-installed Xcode to the default location of \n\t/Applications, you should only have to perform \
-the following:\n\n\texport \
-PYTHONPATH=/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python:$PYTHONPATH \
-\n\n\t\t###!! IMPORTANT !!###\n\n\tIt may also be necessary to unload the miniconda module.\n\tIf \
-you receive a Fatal Python error about PyThreadState...\n\ttry using your systems version of \
-Python instead.\n\n'
+            now supplied by\n\tXcode but not automatically set in your PYTHONPATH. \n\tPlease search the \
+            internet for how to do this if you \n\twish to use --pstack on Mac OS X.\n\n\tNote: If you \
+            installed Xcode to the default location of \n\t/Applications, you should only have to perform \
+            the following:\n\n\texport \
+            PYTHONPATH=/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python:$PYTHONPATH \
+            \n\n\t\t###!! IMPORTANT !!###\n\n\tIt may also be necessary to unload the miniconda module.\n\tIf \
+            you receive a Fatal Python error about PyThreadState...\n\ttry using your systems version of \
+            Python instead.\n\n'
             sys.exit(1)
         else:
           results = which('lldb')

--- a/scripts/memory_logger.py
+++ b/scripts/memory_logger.py
@@ -99,7 +99,6 @@ the self.debugger variable is present.
           self.last_position = dbg_stdout.tell()
           return True
       time.sleep(0.01)
-    print 'lost contact with the debugger.\n'
     return False
 
   def getProcess(self, pid):


### PR DESCRIPTION
GDB; do not detach from gdb with every sample! What was I thinking before!? This _vastly_ decreases the time we can sample a back trace. From aprox two seconds down to a hundredth of a second. Not that anyone would need a sample rate this high. Though, this does open up the possibility of implementing a temporary increase to sample rate when certain criteria is triggered (memory spikes?)... sounds cool anyway!

I am not entirely sure what was causing memory_logger to fail gathering back traces, it would work for a consistent amount of time (in the minutes), and then just stop.

LLDB; Unfortunately I have found limitations with Apple's Python API to LLDB. We must continue to detach and reattach to take a sample.

Refs #6408
