### PR TITLE
Make examples const correct.

### DIFF
--- a/examples/ex03_coupling/include/kernels/ExampleConvection.h
+++ b/examples/ex03_coupling/include/kernels/ExampleConvection.h
@@ -36,7 +36,7 @@ protected:
 
 private:
 
-  VariableGradient & _grad_some_variable;
+  const VariableGradient & _grad_some_variable;
 };
 
 #endif //EXAMPLECONVECTION_H

--- a/examples/ex04_bcs/include/bcs/CoupledDirichletBC.h
+++ b/examples/ex04_bcs/include/bcs/CoupledDirichletBC.h
@@ -49,7 +49,7 @@ private:
    * Holds the values at the quadrature points
    * of a coupled variable.
    */
-  VariableValue & _some_var_val;
+  const VariableValue & _some_var_val;
 };
 
 #endif //COUPLEDDIRICHLETBC_H

--- a/examples/ex04_bcs/include/bcs/CoupledNeumannBC.h
+++ b/examples/ex04_bcs/include/bcs/CoupledNeumannBC.h
@@ -50,7 +50,7 @@ private:
    * Holds the values at the quadrature points
    * of a coupled variable.
    */
-  VariableValue & _some_var_val;
+  const VariableValue & _some_var_val;
 };
 
 #endif //COUPLEDNEUMANNBC_H

--- a/examples/ex04_bcs/include/kernels/ExampleConvection.h
+++ b/examples/ex04_bcs/include/kernels/ExampleConvection.h
@@ -36,7 +36,7 @@ protected:
 
 private:
 
-  VariableGradient & _some_variable;
+  const VariableGradient & _some_variable;
 };
 
 #endif //EXAMPLECONVECTION_H

--- a/examples/ex05_amr/include/kernels/ExampleConvection.h
+++ b/examples/ex05_amr/include/kernels/ExampleConvection.h
@@ -36,7 +36,7 @@ protected:
 
 private:
 
-  VariableGradient & _some_variable;
+  const VariableGradient & _some_variable;
 };
 
 #endif //EXAMPLECONVECTION_H

--- a/examples/ex06_transient/include/kernels/ExampleConvection.h
+++ b/examples/ex06_transient/include/kernels/ExampleConvection.h
@@ -36,7 +36,7 @@ protected:
 
 private:
 
-  VariableGradient & _some_variable;
+  const VariableGradient & _some_variable;
 };
 
 #endif //EXAMPLECONVECTION_H

--- a/examples/ex08_materials/include/materials/ExampleMaterial.h
+++ b/examples/ex08_materials/include/materials/ExampleMaterial.h
@@ -51,7 +51,7 @@ private:
    * This is the member reference that will hold the gradient
    * of the coupled variable
    */
-  VariableGradient & _diffusion_gradient;
+  const VariableGradient & _diffusion_gradient;
 
   /**
    * This object returns a piecewise linear function based an a series

--- a/examples/ex09_stateful_materials/include/kernels/ExampleConvection.h
+++ b/examples/ex09_stateful_materials/include/kernels/ExampleConvection.h
@@ -36,7 +36,7 @@ protected:
 
 private:
 
-  VariableGradient & _some_variable;
+  const VariableGradient & _some_variable;
 };
 
 #endif //EXAMPLECONVECTION_H

--- a/examples/ex10_aux/include/auxkernels/ExampleAux.h
+++ b/examples/ex10_aux/include/auxkernels/ExampleAux.h
@@ -40,7 +40,7 @@ public:
 protected:
   virtual Real computeValue();
 
-  VariableValue & _coupled_val;
+  const VariableValue & _coupled_val;
 
   Real _value;
 };

--- a/examples/ex15_actions/include/kernels/ExampleConvection.h
+++ b/examples/ex15_actions/include/kernels/ExampleConvection.h
@@ -36,7 +36,7 @@ protected:
 
 private:
 
-  VariableGradient & _some_variable;
+  const VariableGradient & _some_variable;
 };
 
 #endif //EXAMPLECONVECTION_H

--- a/examples/ex16_timestepper/include/kernels/ExampleConvection.h
+++ b/examples/ex16_timestepper/include/kernels/ExampleConvection.h
@@ -36,7 +36,7 @@ protected:
 
 private:
 
-  VariableGradient & _some_variable;
+  const VariableGradient & _some_variable;
 };
 
 #endif //EXAMPLECONVECTION_H

--- a/examples/ex18_scalar_kernel/include/bcs/ScalarDirichletBC.h
+++ b/examples/ex18_scalar_kernel/include/bcs/ScalarDirichletBC.h
@@ -42,7 +42,7 @@ protected:
   /**
    * Holds the values of a coupled scalar variable.
    */
-  VariableValue & _scalar_val;
+  const VariableValue & _scalar_val;
 };
 
 #endif // SCALARDIRICHLETBC_H

--- a/examples/ex18_scalar_kernel/include/scalarkernels/ImplicitODEx.h
+++ b/examples/ex18_scalar_kernel/include/scalarkernels/ImplicitODEx.h
@@ -79,7 +79,7 @@ protected:
   /**
    * Coupled scalar variable values
    */
-  VariableValue & _y;
+  const VariableValue & _y;
 };
 
 

--- a/examples/ex18_scalar_kernel/include/scalarkernels/ImplicitODEy.h
+++ b/examples/ex18_scalar_kernel/include/scalarkernels/ImplicitODEy.h
@@ -77,7 +77,7 @@ protected:
   /**
    * Coupled scalar variable values
    */
-  VariableValue & _x;
+  const VariableValue & _x;
 };
 
 

--- a/examples/ex21_debugging/include/materials/ExampleMaterial.h
+++ b/examples/ex21_debugging/include/materials/ExampleMaterial.h
@@ -51,7 +51,7 @@ private:
    * This is the member reference that will hold the gradient
    * of the coupled variable
    */
-  VariableGradient & _diffusion_gradient;
+  const VariableGradient & _diffusion_gradient;
 
   /**
    * This object returns a piecewise linear function based an a series

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/include/auxkernels/DarcyVelocity.h
@@ -45,7 +45,7 @@ protected:
   int _component;
 
   /// The gradient of a coupled variable
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Holds the permeability and viscosity from the material system
   const MaterialProperty<Real> & _permeability;

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/include/auxkernels/DarcyVelocity.h
@@ -45,7 +45,7 @@ protected:
   int _component;
 
   /// The gradient of a coupled variable
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Holds the permeability and viscosity from the material system
   const MaterialProperty<Real> & _permeability;

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/include/auxkernels/DarcyVelocity.h
@@ -45,7 +45,7 @@ protected:
   int _component;
 
   /// The gradient of a coupled variable
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Holds the permeability and viscosity from the material system
   const MaterialProperty<Real> & _permeability;

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/include/kernels/DarcyConvection.h
@@ -41,7 +41,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// The gradient of pressure
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Coupling identifier for the pressure.  This is used to uniquely
   /// identify a coupled variable

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/include/auxkernels/DarcyVelocity.h
@@ -45,7 +45,7 @@ protected:
   int _component;
 
   /// The gradient of a coupled variable
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Holds the permeability and viscosity from the material system
   const MaterialProperty<Real> & _permeability;

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/include/kernels/DarcyConvection.h
@@ -39,7 +39,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// The gradient of pressure
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Coupling identifier for the pressure.  This is used to uniquely identify a coupled variable
   unsigned int _pressure_var;

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/include/auxkernels/DarcyVelocity.h
@@ -45,7 +45,7 @@ protected:
   int _component;
 
   /// The gradient of a coupled variable
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Holds the permeability and viscosity from the material system
   const MaterialProperty<Real> & _permeability;

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/include/kernels/DarcyConvection.h
@@ -39,7 +39,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// The gradient of pressure
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Coupling identifier for the pressure.  This is used to uniquely identify a coupled variable
   unsigned int _pressure_var;

--- a/tutorials/darcy_thermo_mech/step09_mechanics/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/include/auxkernels/DarcyVelocity.h
@@ -45,7 +45,7 @@ protected:
   int _component;
 
   /// The gradient of a coupled variable
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Holds the permeability and viscosity from the material system
   const MaterialProperty<Real> & _permeability;

--- a/tutorials/darcy_thermo_mech/step09_mechanics/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/include/kernels/DarcyConvection.h
@@ -39,7 +39,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// The gradient of pressure
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Coupling identifier for the pressure.  This is used to uniquely identify a coupled variable
   unsigned int _pressure_var;

--- a/tutorials/darcy_thermo_mech/step10_multiapps/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/include/auxkernels/DarcyVelocity.h
@@ -45,7 +45,7 @@ protected:
   int _component;
 
   /// The gradient of a coupled variable
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Holds the permeability and viscosity from the material system
   const MaterialProperty<Real> & _permeability;

--- a/tutorials/darcy_thermo_mech/step10_multiapps/include/kernels/DarcyConvection.h
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/include/kernels/DarcyConvection.h
@@ -39,7 +39,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// The gradient of pressure
-  VariableGradient & _pressure_gradient;
+  const VariableGradient & _pressure_gradient;
 
   /// Coupling identifier for the pressure.  This is used to uniquely identify a coupled variable
   unsigned int _pressure_var;


### PR DESCRIPTION
I forgot to update the examples for const-correctness.  Luckily, the master merge tests for this now!

Refs #6400.
