### PR TITLE
Add registerInterfaceKernel in Factory.h

### DIFF
--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -47,6 +47,7 @@
 #define registerDamper(name)                        registerObject(name)
 #define registerDiracKernel(name)                   registerObject(name)
 #define registerDGKernel(name)                      registerObject(name)
+#define registerInterfaceKernel(name)               registerObject(name)
 #define registerExecutioner(name)                   registerObject(name)
 #define registerFunction(name)                      registerObject(name)
 #define registerMesh(name)                          registerObject(name)

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -352,7 +352,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerDGKernel(DGAdvection);
 
   // Interface kernels
-  registerDGKernel(InterfaceDiffusion);
+  registerInterfaceKernel(InterfaceDiffusion);
 
   // Boundary Conditions
   registerBoundaryCondition(RobinBC);


### PR DESCRIPTION
Makes the registration of interface kernels consistent with other base classes

Closes #6434
