### PR TITLE
Fixing s_fu_04 test in Richard's

### DIFF
--- a/modules/richards/tests/sinks/tests
+++ b/modules/richards/tests/sinks/tests
@@ -62,6 +62,7 @@
     input = 's_fu_04.i'
     cli_args = 'BCs/left_flux/area_pp=0'
     expect_err = 'RichardsPiecewiseLinearSink: flux is nonzero, but area is zero!'
+    prereq = 's_fu_04'
   [../]
 
 []


### PR DESCRIPTION
closes #6029 

Oh @WilkAndy - It looks like you forgot to protect this test from overwriting the other test when running tests in parallel. Simple fix.

Make sure you look over any of the other `RunException` tests you've submitted for similar bugs, we will too.
