### PR TITLE
Update from deprecated TypeVector::size() -> norm().

### DIFF
--- a/framework/include/utils/LineSegment.h
+++ b/framework/include/utils/LineSegment.h
@@ -74,7 +74,7 @@ public:
   /**
    * Length of segment
    */
-  Real length() const { return (_p0 - _p1).size(); }
+  Real length() const { return (_p0 - _p1).norm(); }
 
 private:
   bool closest_point(const Point & p, bool clamp_to_segment, Point & closest_p) const;

--- a/framework/include/vectorpostprocessors/LineMaterialSamplerBase.h
+++ b/framework/include/vectorpostprocessors/LineMaterialSamplerBase.h
@@ -155,7 +155,7 @@ LineMaterialSamplerBase<T>::execute()
   Moose::elementsIntersectedByLine(_start, _end, _fe_problem.mesh(), plb, intersected_elems, segments);
 
   const RealVectorValue line_vec = _end - _start;
-  const Real line_length(line_vec.size());
+  const Real line_length(line_vec.norm());
   const RealVectorValue line_unit_vec = line_vec / line_length;
   std::vector<Real> values(_material_properties.size());
 

--- a/framework/src/auxkernels/PenetrationAux.C
+++ b/framework/src/auxkernels/PenetrationAux.C
@@ -118,7 +118,7 @@ PenetrationAux::computeValue()
       case PA_SIDE:
         retVal = static_cast<Real>(pinfo->_side_num); break;
       case PA_INCREMENTAL_SLIP_MAG:
-        retVal = pinfo->isCaptured() ? pinfo->_incremental_slip.size() : 0; break;
+        retVal = pinfo->isCaptured() ? pinfo->_incremental_slip.norm() : 0; break;
       case PA_INCREMENTAL_SLIP_X:
         retVal = pinfo->isCaptured() ? pinfo->_incremental_slip(0) : 0; break;
       case PA_INCREMENTAL_SLIP_Y:
@@ -145,7 +145,7 @@ PenetrationAux::computeValue()
       {
         RealVectorValue contact_force_normal( (pinfo->_contact_force*pinfo->_normal) * pinfo->_normal );
         RealVectorValue contact_force_tangential( pinfo->_contact_force - contact_force_normal );
-        retVal = contact_force_tangential.size();
+        retVal = contact_force_tangential.norm();
         break;
       }
       case PA_TANGENTIAL_FORCE_X:

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -60,7 +60,7 @@ DiracKernelInfo::hasPoint(const Elem * elem, Point p)
 
   for (; it != end; ++it)
   {
-    Real delta = (*it - p).size_sq();
+    Real delta = (*it - p).norm_sq();
 
     if (delta < TOLERANCE*TOLERANCE)
       return true;

--- a/framework/src/functions/Axisymmetric2D3DSolutionFunction.C
+++ b/framework/src/functions/Axisymmetric2D3DSolutionFunction.C
@@ -127,7 +127,7 @@ Axisymmetric2D3DSolutionFunction::value(Real t, const Point & p)
     z_dir_2d(1) = 1;
     r_dir_3d = p;
     r_dir_3d(1) = 0;
-    Real r = r_dir_3d.size();
+    Real r = r_dir_3d.norm();
     if (MooseUtils::absoluteFuzzyGreaterThan(r,0.0))
     {
       r_gt_zero = true;
@@ -141,12 +141,12 @@ Axisymmetric2D3DSolutionFunction::value(Real t, const Point & p)
   {
     //Find the r, z coordinates of the point in the 3D model relative to the 3D axis
     z_dir_3d =  _3d_axis_point2 - _3d_axis_point1;
-    z_dir_3d /= z_dir_3d.size();
+    z_dir_3d /= z_dir_3d.norm();
     Point v3dp1p(p - _3d_axis_point1);
     Real z = z_dir_3d * v3dp1p;
     Point axis_proj = _3d_axis_point1 + z*z_dir_3d;  //projection of point onto axis
     Point axis_proj_to_p = p - axis_proj;
-    Real r = axis_proj_to_p.size();
+    Real r = axis_proj_to_p.norm();
     if (MooseUtils::absoluteFuzzyGreaterThan(r,0.0))
     {
       r_gt_zero = true;
@@ -155,10 +155,10 @@ Axisymmetric2D3DSolutionFunction::value(Real t, const Point & p)
 
     //Convert point in r, z coordinates into x, y coordinates
     z_dir_2d = _2d_axis_point2 - _2d_axis_point1;
-    z_dir_2d /= z_dir_2d.size();
+    z_dir_2d /= z_dir_2d.norm();
     Point out_of_plane_vec(0,0,1);
     r_dir_2d = z_dir_2d.cross(out_of_plane_vec);
-    r_dir_2d /= r_dir_2d.size();  //size should be 1, maybe this isn't necessary
+    r_dir_2d /= r_dir_2d.norm();  //size should be 1, maybe this isn't necessary
     xypoint = _2d_axis_point1 + z/_axial_dim_ratio * z_dir_2d + r * r_dir_2d;
   }
 

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -212,18 +212,18 @@ findContactPoint(PenetrationInfo & p_info,
 
   p_info._closest_point_ref = ref_point;
   p_info._closest_point = phys_point[0];
-  p_info._distance = d.size();
+  p_info._distance = d.norm();
 
   if (dim-1 == 2)
   {
     p_info._normal = dxyz_dxi[0].cross(dxyz_deta[0]);
-    p_info._normal /= p_info._normal.size();
+    p_info._normal /= p_info._normal.norm();
   }
   else
   {
     p_info._normal = RealGradient(dxyz_dxi[0](1),-dxyz_dxi[0](0));
-    if (std::fabs(p_info._normal.size()) > 1e-15)
-      p_info._normal /= p_info._normal.size();
+    if (std::fabs(p_info._normal.norm()) > 1e-15)
+      p_info._normal /= p_info._normal.norm();
   }
 
   // If the point has not penetrated the face, make the distance negative
@@ -245,7 +245,7 @@ findContactPoint(PenetrationInfo & p_info,
     Point closest_point_on_face(phys_point[0]);
 
     RealGradient off_face = closest_point_on_face - p_info._closest_point;
-    Real tangential_distance = off_face.size();
+    Real tangential_distance = off_face.norm();
     p_info._tangential_distance = tangential_distance;
     if (tangential_distance <= tangential_tolerance)
     {

--- a/framework/src/geomsearch/NearestNodeThread.C
+++ b/framework/src/geomsearch/NearestNodeThread.C
@@ -58,7 +58,7 @@ NearestNodeThread::operator() (const NodeIdRange & range)
     for (unsigned int k=0; k<n_neighbor_nodes; k++)
     {
       const Node * cur_node = &_mesh.node(neighbor_nodes[k]);
-      Real distance = ((*cur_node) - node).size();
+      Real distance = ((*cur_node) - node).norm();
 
       if (distance < closest_distance)
       {

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -273,21 +273,21 @@ PenetrationThread::operator() (const NodeIdRange & range)
                 {
                   ridgeSetDataVec[i]._closest_coor = ridgeSetDataVec[i]._ridge_data_vec[0]._closest_coor;
                   Point contact_point_vec = node - ridgeSetDataVec[i]._closest_coor;
-                  ridgeSetDataVec[i]._distance = contact_point_vec.size();
+                  ridgeSetDataVec[i]._distance = contact_point_vec.norm();
                 }
               }
               else //several ridges join at common node to make peak.  The common node is the contact point
               {
                 ridgeSetDataVec[i]._closest_coor = *ridgeSetDataVec[i]._closest_node;
                 Point contact_point_vec = node - ridgeSetDataVec[i]._closest_coor;
-                ridgeSetDataVec[i]._distance = contact_point_vec.size();
+                ridgeSetDataVec[i]._distance = contact_point_vec.norm();
               }
             }
             else //on a single ridge
             {
               ridgeSetDataVec[i]._closest_coor = ridgeSetDataVec[i]._ridge_data_vec[0]._closest_coor;
               Point contact_point_vec = node - ridgeSetDataVec[i]._closest_coor;
-              ridgeSetDataVec[i]._distance = contact_point_vec.size();
+              ridgeSetDataVec[i]._distance = contact_point_vec.norm();
             }
           }
           //Find the set of ridges closest to us.
@@ -323,7 +323,7 @@ PenetrationThread::operator() (const NodeIdRange & range)
             if (!_do_normal_smoothing)
             {
               Point normal(closest_point - node);
-              const Real len(normal.size());
+              const Real len(normal.norm());
               if (len > 0)
               {
                 normal /= len;
@@ -714,7 +714,7 @@ PenetrationThread::findRidgeContactPoint(Point &contact_point,
       closest_node = closest_node1;
 
       RealGradient off_face = *closest_node1 - contact_point;
-      tangential_distance = off_face.size();
+      tangential_distance = off_face.norm();
     }
   }
 
@@ -1162,18 +1162,18 @@ PenetrationThread::isFaceReasonableCandidate(const Elem * master_elem,
   {
     return true;
   }
-  normal /= normal.size();
+  normal /= normal.norm();
 
   const Real dot(d * normal);
 
   const RealGradient normcomp = dot*normal;
   const RealGradient tangcomp = d - normcomp;
 
-  const Real tangdist = tangcomp.size();
+  const Real tangdist = tangcomp.norm();
 
   //Increase the size of the zone that we consider if the vector from the face
   //to the node has a larger normal component
-  const Real faceExpansionFactor = 2.0 * (1.0 + normcomp.size()/d.size());
+  const Real faceExpansionFactor = 2.0 * (1.0 + normcomp.norm()/d.norm());
 
   bool isReasonableCandidate = true;
   if (tangdist > faceExpansionFactor*max_face_length)
@@ -1197,7 +1197,7 @@ PenetrationThread::computeSlip(FEBase & fe, PenetrationInfo & info)
   if (info.isCaptured())
   {
     info._frictional_energy = info._frictional_energy_old + info._contact_force*info._incremental_slip;
-    info._accumulated_slip = info._accumulated_slip_old + info._incremental_slip.size();
+    info._accumulated_slip = info._accumulated_slip_old + info._incremental_slip.norm();
   }
 }
 
@@ -1236,7 +1236,7 @@ PenetrationThread::smoothNormal(PenetrationInfo* info,
         mooseAssert(this_face_weight >= (0.25-1e-8),"Sum of weights of other faces shouldn't exceed 0.75");
         new_normal += info->_normal * this_face_weight;
 
-        const Real len(new_normal.size());
+        const Real len(new_normal.norm());
         if (len > 0)
         {
           new_normal /= len;
@@ -1252,7 +1252,7 @@ PenetrationThread::smoothNormal(PenetrationInfo* info,
       info->_normal(0) = _nodal_normal_x->getValue(info->_side,info->_side_phi);
       info->_normal(1) = _nodal_normal_y->getValue(info->_side,info->_side_phi);
       info->_normal(2) = _nodal_normal_z->getValue(info->_side,info->_side_phi);
-      const Real len(info->_normal.size());
+      const Real len(info->_normal.norm());
       if (len > 0)
       {
         info->_normal /= len;

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -82,7 +82,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
     {
       dof_id_type master_id = _trial_master_nodes[k];
       const Node * cur_node = &_mesh.node(master_id);
-      Real distance = ((*cur_node) - node).size();
+      Real distance = ((*cur_node) - node).norm();
 
       neighbors.push(std::make_pair(master_id, distance));
     }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1350,7 +1350,7 @@ MooseMesh::minPeriodicVector(unsigned int nonlinear_var_num, Point p, Point q) c
 Real
 MooseMesh::minPeriodicDistance(unsigned int nonlinear_var_num, Point p, Point q) const
 {
-  return minPeriodicVector(nonlinear_var_num, p, q).size();
+  return minPeriodicVector(nonlinear_var_num, p, q).norm();
 }
 
 std::pair<BoundaryID, BoundaryID> *
@@ -1546,7 +1546,7 @@ MooseMesh::mapPoints(const std::vector<Point> & from, const std::vector<Point> &
     for (unsigned int j=0; j<n_to; j++)
     {
       const Point & to_point = to[j];
-      Real distance = (from_point - to_point).size();
+      Real distance = (from_point - to_point).norm();
 
       if (distance < current_map._distance)
       {
@@ -2113,7 +2113,7 @@ MooseMesh::getInflatedProcessorBoundingBox(Real inflation_multiplier) const
 
   // Inflate the bbox just a bit to deal with roundoff
   // Adding 1% of the diagonal size in each direction on each end
-  Real inflation_amount = inflation_multiplier * (bbox.max() - bbox.min()).size();
+  Real inflation_amount = inflation_multiplier * (bbox.max() - bbox.min()).norm();
   Point inflation(inflation_amount, inflation_amount, inflation_amount);
 
   bbox.first -= inflation; // min

--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -44,8 +44,8 @@ SideSetsAroundSubdomain::SideSetsAroundSubdomain(const InputParameters & paramet
   if (_using_normal)
   {
     // normalize
-    mooseAssert(_normal.size() >= 1E-5, "Normal is zero");
-    _normal /= _normal.size();
+    mooseAssert(_normal.norm() >= 1E-5, "Normal is zero");
+    _normal /= _normal.norm();
   }
 }
 

--- a/framework/src/meshmodifiers/SideSetsFromNormals.C
+++ b/framework/src/meshmodifiers/SideSetsFromNormals.C
@@ -48,8 +48,8 @@ SideSetsFromNormals::SideSetsFromNormals(const InputParameters & parameters):
   // Make sure that the normals are normalized
   for (std::vector<Point>::iterator normal_it = _normals.begin(); normal_it != _normals.end(); ++normal_it)
   {
-    mooseAssert(normal_it->size() >= 1e-5, "Normal is zero");
-    *normal_it /= normal_it->size();
+    mooseAssert(normal_it->norm() >= 1e-5, "Normal is zero");
+    *normal_it /= normal_it->norm();
   }
 }
 

--- a/framework/src/postprocessors/ElementVectorL2Error.C
+++ b/framework/src/postprocessors/ElementVectorL2Error.C
@@ -60,6 +60,6 @@ ElementVectorL2Error::computeQpIntegral()
   func_val(1) = _funcy.value(_t, _q_point[_qp]);
   func_val(2) = _funcz.value(_t, _q_point[_qp]);
 
-  return (sol_val - func_val).size_sq(); // dot product of difference vector
+  return (sol_val - func_val).norm_sq(); // dot product of difference vector
 }
 

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -456,7 +456,7 @@ Node * MultiAppInterpolationTransfer::getNearestNode(const Point & p, Real & dis
 
   for (MeshBase::const_node_iterator node_it = nodes_begin; node_it != nodes_end; ++node_it)
   {
-    Real current_distance = (p-*(*node_it)).size();
+    Real current_distance = (p-*(*node_it)).norm();
 
     if (current_distance < distance)
     {

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -286,7 +286,7 @@ MultiAppNearestNodeTransfer::execute()
 
           for (unsigned int i_node = 0; i_node < local_nodes[i_local_from].size(); i_node++)
           {
-            Real current_distance = (qpt - *(local_nodes[i_local_from][i_node]) - _from_positions[i_local_from]).size();
+            Real current_distance = (qpt - *(local_nodes[i_local_from][i_node]) - _from_positions[i_local_from]).norm();
             if (current_distance < outgoing_evals[2*qp])
             {
               // Assuming LAGRANGE!
@@ -523,7 +523,7 @@ MultiAppNearestNodeTransfer::getNearestNode(const Point & p, Real & distance, Mo
       if (bnode->_bnd_id == src_bnd_id)
       {
         Node * node = bnode->_node;
-        Real current_distance = (p - *node).size();
+        Real current_distance = (p - *node).norm();
 
         if (current_distance < distance)
         {
@@ -540,7 +540,7 @@ MultiAppNearestNodeTransfer::getNearestNode(const Point & p, Real & distance, Mo
 
     for (MeshBase::const_node_iterator node_it = nodes_begin; node_it != nodes_end; ++node_it)
     {
-      Real current_distance = (p - *(*node_it)).size();
+      Real current_distance = (p - *(*node_it)).norm();
 
       if (current_distance < distance)
       {
@@ -576,7 +576,7 @@ MultiAppNearestNodeTransfer::bboxMaxDistance(Point p, MeshTools::BoundingBox bbo
 
   for (unsigned int i = 0; i < 8; i++)
   {
-    Real distance = (p - all_points[i]).size();
+    Real distance = (p - all_points[i]).norm();
     if (distance > max_distance)
       max_distance = distance;
   }
@@ -606,7 +606,7 @@ MultiAppNearestNodeTransfer::bboxMinDistance(Point p, MeshTools::BoundingBox bbo
 
   for (unsigned int i = 0; i < 8; i++)
   {
-    Real distance = (p - all_points[i]).size();
+    Real distance = (p - all_points[i]).norm();
     if (distance < min_distance)
       min_distance = distance;
   }

--- a/framework/src/userobject/NearestPointLayeredAverage.C
+++ b/framework/src/userobject/NearestPointLayeredAverage.C
@@ -103,7 +103,7 @@ NearestPointLayeredAverage::nearestLayeredAverage(const Point & p) const
   {
     const Point & current_point = _points[i];
 
-    Real current_distance = (p - current_point).size();
+    Real current_distance = (p - current_point).norm();
 
     if (current_distance < closest_distance)
     {

--- a/framework/src/utils/LineSegment.C
+++ b/framework/src/utils/LineSegment.C
@@ -32,7 +32,7 @@ LineSegment::closest_point (const Point & p, bool clamp_to_segment, Point & clos
 {
   Point p0_p  = p - _p0;
   Point p0_p1 = _p1 - _p0;
-  Real p0_p1_2 = p0_p1.size_sq();
+  Real p0_p1_2 = p0_p1.norm_sq();
   Real perp = p0_p(0)*p0_p1(0) + p0_p(1)*p0_p1(1) + p0_p(2)*p0_p1(2);
   Real t = perp / p0_p1_2;
   bool on_segment = true;
@@ -111,7 +111,7 @@ LineSegment::intersect (const Plane & pl, Point & intersect_p) const
   Real d = numerator / denominator;
 
   // Make sure we haven't moved off the line segment!
-  if (d + libMesh::TOLERANCE < 0 || d - libMesh::TOLERANCE > (_p1-_p0).size())
+  if (d + libMesh::TOLERANCE < 0 || d - libMesh::TOLERANCE > (_p1-_p0).norm())
     return false;
 
   intersect_p = d*I + _p0;
@@ -150,7 +150,7 @@ LineSegment::intersect (const LineSegment & l, Point & intersect_p) const
   RealVectorValue v = a.cross(b);
 
   // Check for parallel lines
-  if (std::abs(v.size()) < 1.e-10 && std::abs(c.cross(a).size()) < 1.e-10)
+  if (std::abs(v.norm()) < 1.e-10 && std::abs(c.cross(a).norm()) < 1.e-10)
   {
     // TODO: The lines are co-linear but more work is needed to determine and intersection point
     //       it could be the case that the line segments don't lie on the same line or overlap only

--- a/framework/src/vectorpostprocessors/LineValueSampler.C
+++ b/framework/src/vectorpostprocessors/LineValueSampler.C
@@ -47,11 +47,11 @@ LineValueSampler::LineValueSampler(const InputParameters & parameters) :
     Point p = start_point + (i * delta);
 
     _points[i] = p;
-    _ids[i] = (p - start_point).size(); // The ID is the distance along the line
+    _ids[i] = (p - start_point).norm(); // The ID is the distance along the line
   }
 
   // Add the end point explicitly
   _points[num_points-1] = end_point;
-  _ids[num_points-1] = (end_point - start_point).size();
+  _ids[num_points-1] = (end_point - start_point).norm();
 }
 

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -256,7 +256,7 @@ ContactMaster::computeContactForce(PenetrationInfo * pinfo)
     RealVectorValue contact_force_tangential( pinfo->_contact_force - contact_force_normal );
 
     // Tangential magnitude of elastic predictor
-    const Real tan_mag( contact_force_tangential.size() );
+    const Real tan_mag( contact_force_tangential.norm() );
 
     if ( tan_mag > capacity )
     {
@@ -281,7 +281,7 @@ ContactMaster::computeContactForce(PenetrationInfo * pinfo)
       break;
     case CF_AUGMENTED_LAGRANGE:
       pinfo->_contact_force = pen_force +
-                              pinfo->_lagrange_multiplier*distance_vec/distance_vec.size();
+                              pinfo->_lagrange_multiplier*distance_vec/distance_vec.norm();
       break;
     default:
       mooseError("Invalid contact formulation");

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -573,7 +573,7 @@ FrictionalContactProblem::calculateInteractionSlip(RealVectorValue &slip,
   ContactState state = STICKING;
 
   RealVectorValue normal_residual = normal * (normal * residual);
-  Real normal_force = normal_residual.size();
+  Real normal_force = normal_residual.norm();
 
 //  _console << "normal=" << info._normal << std::endl;
 //  _console << "normal_force=" << normal_force << std::endl;
@@ -581,13 +581,13 @@ FrictionalContactProblem::calculateInteractionSlip(RealVectorValue &slip,
 //  _console << "stiffness=" << stiff_vec << std::endl;
 
   RealVectorValue tangential_force = normal_residual - residual ; // swap sign to make the code more manageable
-  Real tangential_force_magnitude = tangential_force.size();
+  Real tangential_force_magnitude = tangential_force.norm();
 
   Real capacity = normal_force * friction_coefficient;
   if (capacity < 0.0)
     capacity = 0.0;
 
-  Real slip_inc = incremental_slip.size();
+  Real slip_inc = incremental_slip.norm();
 
   slip(0)=0.0;
   slip(1)=0.0;
@@ -637,7 +637,7 @@ FrictionalContactProblem::calculateInteractionSlip(RealVectorValue &slip,
   else if (excess_force > 0)
   {
     state = SLIPPING;
-    Real tangential_force_magnitude = tangential_force.size();
+    Real tangential_force_magnitude = tangential_force.norm();
     slip_residual = excess_force;
 
     RealVectorValue tangential_direction = tangential_force / tangential_force_magnitude;

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -249,7 +249,7 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
           RealVectorValue contact_force_tangential( pinfo->_contact_force - contact_force_normal );
 
           // Tangential magnitude of elastic predictor
-          const Real tan_mag( contact_force_tangential.size() );
+          const Real tan_mag( contact_force_tangential.norm() );
 
           if ( tan_mag > capacity )
           {
@@ -262,7 +262,7 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
         }
         case CF_AUGMENTED_LAGRANGE:
           pinfo->_contact_force = pen_force +
-                                  pinfo->_lagrange_multiplier*distance_vec/distance_vec.size();
+                                  pinfo->_lagrange_multiplier*distance_vec/distance_vec.norm();
           break;
         default:
           mooseError("Invalid contact formulation");
@@ -280,7 +280,7 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
           break;
         case CF_AUGMENTED_LAGRANGE:
           pinfo->_contact_force = pen_force +
-                                  pinfo->_lagrange_multiplier*distance_vec/distance_vec.size();
+                                  pinfo->_lagrange_multiplier*distance_vec/distance_vec.norm();
           break;
         default:
           mooseError("Invalid contact formulation");
@@ -786,7 +786,7 @@ MechanicalContactConstraint::getCoupledVarComponent(unsigned int var_num,
 {
   component = std::numeric_limits<unsigned int>::max();
   bool coupled_var_is_disp_var = false;
-  for (unsigned int i=0; i<_vars.size(); ++i)
+  for (unsigned int i=0; i<LIBMESH_DIM; ++i)
   {
     if (var_num == _vars(i))
     {

--- a/modules/heat_conduction/src/GapConductance.C
+++ b/modules/heat_conduction/src/GapConductance.C
@@ -427,11 +427,11 @@ GapConductance::computeGapRadii(const GapConductance::GAP_GEOMETRY gap_geometry_
     // axis closest to current_point is found by the following for t:
     const Point p2p1( p2 - p1 );
     const Point p1pc( p1 - current_point );
-    const Real t( -(p1pc*p2p1)/p2p1.size_sq() );
+    const Real t( -(p1pc*p2p1)/p2p1.norm_sq() );
     // The nearest point on the cylindrical axis to current_point is p.
     const Point p( p1 + t * p2p1 );
     Point rad_vec( current_point - p );
-    Real rad = rad_vec.size();
+    Real rad = rad_vec.norm();
     rad_vec /= rad;
     Real rad_dot_norm = rad_vec * current_normal;
 
@@ -455,7 +455,7 @@ GapConductance::computeGapRadii(const GapConductance::GAP_GEOMETRY gap_geometry_
   {
     const Point origin_to_curr_point( current_point - p1 );
     const Real normal_dot = origin_to_curr_point * current_normal;
-    const Real curr_point_radius = origin_to_curr_point.size();
+    const Real curr_point_radius = origin_to_curr_point.norm();
     if (normal_dot > 0) // on inside surface
     {
       r1 = curr_point_radius;

--- a/modules/misc/src/SharpInterfaceForcing.C
+++ b/modules/misc/src/SharpInterfaceForcing.C
@@ -28,7 +28,7 @@ Real
 SharpInterfaceForcing::computeQpResidual()
 {
   Point current_point = _q_point[_qp];
-  Real distance = (current_point - Point(_x_center.value(_t, _q_point[_qp]), _y_center.value(_t, _q_point[_qp]), 0.0)).size();
+  Real distance = (current_point - Point(_x_center.value(_t, _q_point[_qp]), _y_center.value(_t, _q_point[_qp]), 0.0)).norm();
 
   if (distance <= 0.1)
     return -_amplitude*_test[_i][_qp];

--- a/modules/navier_stokes/src/auxkernels/INSCourant.C
+++ b/modules/navier_stokes/src/auxkernels/INSCourant.C
@@ -33,7 +33,7 @@ INSCourant::computeValue()
 {
   RealVectorValue U(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
-  Real vel_mag = U.size();
+  Real vel_mag = U.norm();
 
   // Don't divide by zero...
   vel_mag = std::max(vel_mag, std::numeric_limits<Real>::epsilon());

--- a/modules/navier_stokes/src/bcs/NSEnergyInviscidBC.C
+++ b/modules/navier_stokes/src/bcs/NSEnergyInviscidBC.C
@@ -43,12 +43,12 @@ Real NSEnergyInviscidBC::qp_residual(Real pressure, Real un)
 
 Real NSEnergyInviscidBC::qp_residual(Real rho, RealVectorValue u, Real /*pressure*/)
 {
-  // return (rho*(cv*_temperature[_qp] + 0.5*u.size_sq()) + pressure) * (u*_normals[_qp]) * _test[_i][_qp];
+  // return (rho*(cv*_temperature[_qp] + 0.5*u.norm_sq()) + pressure) * (u*_normals[_qp]) * _test[_i][_qp];
 
   // We can also expand pressure in terms of rho... does this make a difference?
   // Then we don't use the input pressure value.
   Real cv = _R / (_gamma-1.);
-  return rho * (_gamma * cv * _temperature[_qp] + 0.5*u.size_sq()) * (u*_normals[_qp]) * _test[_i][_qp];
+  return rho * (_gamma * cv * _temperature[_qp] + 0.5*u.norm_sq()) * (u*_normals[_qp]) * _test[_i][_qp];
 }
 
 

--- a/modules/navier_stokes/src/bcs/NSImposedVelocityDirectionBC.C
+++ b/modules/navier_stokes/src/bcs/NSImposedVelocityDirectionBC.C
@@ -52,7 +52,7 @@ Real NSImposedVelocityDirectionBC::computeQpResidual()
   RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
   // Specify desired velocity component
-  return _u[_qp] - _rho[_qp] * _desired_unit_velocity_component * vel.size();
+  return _u[_qp] - _rho[_qp] * _desired_unit_velocity_component * vel.norm();
 }
 
 

--- a/modules/navier_stokes/src/bcs/NSStagnationPressureBC.C
+++ b/modules/navier_stokes/src/bcs/NSStagnationPressureBC.C
@@ -45,7 +45,7 @@ Real NSStagnationPressureBC::computeQpResidual()
   RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
   // Mach number, squared
-  Real M2 = vel.size_sq() / (_gamma * _R * _temperature[_qp]);
+  Real M2 = vel.norm_sq() / (_gamma * _R * _temperature[_qp]);
 
   // p_0 = p*(1 + 0.5*(gam-1)*M^2)^(gam/(gam-1))
   Real computed_stagnation_pressure = _pressure[_qp] * std::pow(1. + 0.5*(_gamma-1.)*M2, _gamma/(_gamma-1.));

--- a/modules/navier_stokes/src/bcs/NSStagnationTemperatureBC.C
+++ b/modules/navier_stokes/src/bcs/NSStagnationTemperatureBC.C
@@ -39,7 +39,7 @@ Real NSStagnationTemperatureBC::computeQpResidual()
   RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
   // Mach number, squared
-  Real M2 = vel.size_sq() / (_gamma * _R * _temperature[_qp]);
+  Real M2 = vel.norm_sq() / (_gamma * _R * _temperature[_qp]);
 
   // T_0 = T*(1 + 0.5*(gam-1)*M^2)
   Real computed_stagnation_temperature = _temperature[_qp] * (1. + 0.5*(_gamma-1.)*M2);

--- a/modules/navier_stokes/src/kernels/NSEnergyInviscidFlux.C
+++ b/modules/navier_stokes/src/kernels/NSEnergyInviscidFlux.C
@@ -64,7 +64,7 @@ Real
 NSEnergyInviscidFlux::computeQpOffDiagJacobian(unsigned int jvar)
 {
   RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
-  Real V2 = vel.size_sq();
+  Real V2 = vel.norm_sq();
 
   // Derivative wrt density
   if (jvar == _rho_var_number)

--- a/modules/navier_stokes/src/kernels/NSMomentumInviscidFlux.C
+++ b/modules/navier_stokes/src/kernels/NSMomentumInviscidFlux.C
@@ -89,7 +89,7 @@ Real NSMomentumInviscidFlux::compute_jacobian(unsigned m)
   {
   case 0: // density
   {
-    Real V2 = vel.size_sq();
+    Real V2 = vel.norm_sq();
 
     return vel(_component) * (vel*_grad_test[_i][_qp]) - 0.5 * (_gamma-1.) * V2 * _grad_test[_i][_qp](_component);
   }

--- a/modules/navier_stokes/src/kernels/NSSUPGEnergy.C
+++ b/modules/navier_stokes/src/kernels/NSSUPGEnergy.C
@@ -39,7 +39,7 @@ Real NSSUPGEnergy::computeQpResidual()
     RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
     // Velocity vector magnitude squared
-    Real velmag2 = vel.size_sq();
+    Real velmag2 = vel.norm_sq();
 
     // Velocity vector, dotted with the test function gradient
     Real U_grad_phi = vel*_grad_test[_i][_qp];
@@ -99,7 +99,7 @@ Real NSSUPGEnergy::compute_jacobian(unsigned var)
   RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
   // Velocity vector magnitude squared
-  Real velmag2 = vel.size_sq();
+  Real velmag2 = vel.norm_sq();
 
   // Shortcuts for shape function gradients at current qp.
   RealVectorValue grad_test_i = _grad_test[_i][_qp];

--- a/modules/navier_stokes/src/kernels/NSSUPGMomentum.C
+++ b/modules/navier_stokes/src/kernels/NSSUPGMomentum.C
@@ -42,7 +42,7 @@ Real NSSUPGMomentum::computeQpResidual()
     RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
     // Velocity vector magnitude squared
-    Real velmag2 = vel.size_sq();
+    Real velmag2 = vel.norm_sq();
 
     // Velocity vector, dotted with the test function gradient
     Real U_grad_phi = vel*_grad_test[_i][_qp];
@@ -117,7 +117,7 @@ Real NSSUPGMomentum::compute_jacobian(unsigned var)
   RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
   // Velocity vector magnitude squared
-  Real velmag2 = vel.size_sq();
+  Real velmag2 = vel.norm_sq();
 
   // Shortcuts for shape function gradients at current qp.
   RealVectorValue grad_test_i = _grad_test[_i][_qp];

--- a/modules/navier_stokes/src/materials/NavierStokesMaterial.C
+++ b/modules/navier_stokes/src/materials/NavierStokesMaterial.C
@@ -253,7 +253,7 @@ void NavierStokesMaterial::compute_h_supg(unsigned qp)
   // .) The denominator will be identically zero only if the velocity
   //    is identically zero, in which case we can't divide by it.
   if (denom != 0.0)
-    _hsupg[qp] = 2.* sqrt( U.size_sq() / denom );
+    _hsupg[qp] = 2.* sqrt( U.norm_sq() / denom );
   else
     _hsupg[qp] = 0.;
 
@@ -380,7 +380,7 @@ void NavierStokesMaterial::compute_strong_residuals(unsigned qp)
   RealVectorValue zero(0., 0., 0.);
 
   // Velocity vector magnitude squared
-  Real velmag2 = vel.size_sq();
+  Real velmag2 = vel.norm_sq();
 
   // Debugging: How large are the time derivative parts of the strong residuals?
 //  Moose::out << "drho_dt=" << _drho_dt

--- a/modules/phase_field/src/auxkernels/KKSGlobalFreeEnergy.C
+++ b/modules/phase_field/src/auxkernels/KKSGlobalFreeEnergy.C
@@ -49,7 +49,7 @@ KKSGlobalFreeEnergy::computeValue()
 
   // Calculate interfacial energy of each variable
   for (unsigned int i = 0; i < _nvars; ++i)
-    total_energy += (*_kappas[i])[_qp] / 2.0 * (*_grad_vars[i])[_qp].size_sq();
+    total_energy += (*_kappas[i])[_qp] / 2.0 * (*_grad_vars[i])[_qp].norm_sq();
 
   return total_energy;
 }

--- a/modules/phase_field/src/auxkernels/TotalFreeEnergy.C
+++ b/modules/phase_field/src/auxkernels/TotalFreeEnergy.C
@@ -38,7 +38,7 @@ TotalFreeEnergy::computeValue()
 
   // Calculate interfacial energy of each variable
   for (unsigned int i = 0; i < _nvars; ++i)
-    total_energy += (*_kappas[i])[_qp] / 2.0 * (*_grad_vars[i])[_qp].size_sq();
+    total_energy += (*_kappas[i])[_qp] / 2.0 * (*_grad_vars[i])[_qp].norm_sq();
 
   return total_energy;
 }

--- a/modules/phase_field/src/ics/MultiSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothCircleIC.C
@@ -110,14 +110,14 @@ MultiSmoothCircleIC::computeCircleCenters()
 
       for (unsigned int j = 0; j < i; j++)
       {
-        if (j == 0) rr = _range.size();
+        if (j == 0) rr = _range.norm();
 
         Real tmp_rr = _mesh.minPeriodicDistance(_var.number(), _centers[j], newcenter);
 
         if (tmp_rr < rr) rr = tmp_rr;
       }
 
-      if (i == 0) rr = _range.size();
+      if (i == 0) rr = _range.norm();
     }
 
     if (num_tries == _numtries)

--- a/modules/phase_field/src/ics/PolycrystalReducedIC.C
+++ b/modules/phase_field/src/ics/PolycrystalReducedIC.C
@@ -121,7 +121,7 @@ PolycrystalReducedIC::value(const Point & p)
 {
   Real val = 0.0;
 
-  unsigned int min_index = PolycrystalICTools::assignPointToGrain(p, _centerpoints, _mesh, _var, _range.size());
+  unsigned int min_index = PolycrystalICTools::assignPointToGrain(p, _centerpoints, _mesh, _var, _range.norm());
 
   //If the current order parameter index (_op_index) is equal to the min_index, set the value to 1.0
   if (_assigned_op[min_index] == _op_index) //Make sure that the _op_index goes from 0 to _op_num-1

--- a/modules/phase_field/src/ics/Tricrystal2CircleGrainsIC.C
+++ b/modules/phase_field/src/ics/Tricrystal2CircleGrainsIC.C
@@ -52,8 +52,8 @@ Tricrystal2CircleGrainsIC::value(const Point & p)
   grain_center_right(2) = _bottom_left(2) + _range(2)/2.0;
 
   Real radius = _range(0)/5.0;
-  Real dist_left = (p - grain_center_left).size();
-  Real dist_right = (p - grain_center_right).size();
+  Real dist_left = (p - grain_center_left).norm();
+  Real dist_right = (p - grain_center_right).norm();
 
   if ((dist_left <= radius && _op_index == 1) || (dist_right <= radius && _op_index == 2) || (dist_left > radius && dist_right > radius && _op_index == 0))
     return 1.0;

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -327,7 +327,7 @@ GrainTracker::buildBoundingSpheres()
 
       // The radius is the different between the outer edge of the "bounding box"
       // and the center plus the "hull buffer" value
-      Real radius = (max - center).size() + _hull_buffer;
+      Real radius = (max - center).norm() + _hull_buffer;
 
       unsigned int some_node_id = *(it1->_entity_ids.begin());
       _bounding_spheres[map_num].push_back(new BoundingSphereInfo(some_node_id, center, radius));

--- a/modules/phase_field/src/userobjects/DiscreteNucleationMap.C
+++ b/modules/phase_field/src/userobjects/DiscreteNucleationMap.C
@@ -72,7 +72,7 @@ DiscreteNucleationMap::execute()
       {
         // use a non-periodic or periodic distance
         r = _periodic < 0 ?
-              (_q_point[qp] - _nucleus_list[i].second).size() :
+              (_q_point[qp] - _nucleus_list[i].second).norm() :
               _mesh.minPeriodicDistance(_periodic, _q_point[qp], _nucleus_list[i].second);
         if (r < rmin)
           rmin = r;

--- a/modules/solid_mechanics/src/auxkernels/DomainIntegralQFunction.C
+++ b/modules/solid_mechanics/src/auxkernels/DomainIntegralQFunction.C
@@ -115,5 +115,5 @@ DomainIntegralQFunction::projectToFrontAtPoint(Real & dist_to_front, Real & dist
   dist_along_tangent = crack_node_to_current_node * crack_front_tangent;
   RealVectorValue projection_point = *crack_front_point + dist_along_tangent * crack_front_tangent;
   RealVectorValue axis_to_current_node = p - projection_point;
-  dist_to_front = axis_to_current_node.size();
+  dist_to_front = axis_to_current_node.norm();
 }

--- a/modules/solid_mechanics/src/auxkernels/ElementsOnLineAux.C
+++ b/modules/solid_mechanics/src/auxkernels/ElementsOnLineAux.C
@@ -39,7 +39,7 @@ ElementsOnLineAux::compute()
   const Point elem_pos(_current_elem->centroid());
 
   const Point line_vec(_line2 - _line1);
-  const Real length(line_vec.size());
+  const Real length(line_vec.norm());
   const Point line_unit_vec(line_vec / length);
 
   const Point line1_to_elem_vec(elem_pos - _line1);
@@ -47,7 +47,7 @@ ElementsOnLineAux::compute()
   const Point proj_vec(proj * line_unit_vec);
   const Point dist_vec(line1_to_elem_vec - proj_vec);
 
-  const Real distance(dist_vec.size());
+  const Real distance(dist_vec.norm());
 
   if (distance < _dist_tol)
   {

--- a/modules/solid_mechanics/src/auxkernels/MaterialTensorCalculator.C
+++ b/modules/solid_mechanics/src/auxkernels/MaterialTensorCalculator.C
@@ -28,7 +28,7 @@ MaterialTensorCalculator::MaterialTensorCalculator(const InputParameters & param
   _quantity_moose_enum(parameters.get<MooseEnum>("quantity")),
   _p1(parameters.get<RealVectorValue>("point1")),
   _p2(parameters.get<RealVectorValue>("point2")),
-  _direction(parameters.get<RealVectorValue>("direction")/parameters.get<RealVectorValue>("direction").size())
+  _direction(parameters.get<RealVectorValue>("direction")/parameters.get<RealVectorValue>("direction").norm())
 {
   const std::string & name = parameters.get<std::string>("_object_name");
 
@@ -120,12 +120,12 @@ MaterialTensorCalculator::getTensorQuantity(const SymmTensor & tensor,
     // axis closest to p0 is found by the following for t:
     const Point p2p1( _p2 - _p1 );
     const Point p1p0( _p1 - p0 );
-    const Real t( -(p1p0*p2p1)/p2p1.size_sq() );
+    const Real t( -(p1p0*p2p1)/p2p1.norm_sq() );
     // The nearest point on the cylindrical axis to p0 is p.
     const Point p( _p1 + t * p2p1 );
     Point xp( p0 - p );
-    xp /= xp.size();
-    Point yp( p2p1/p2p1.size() );
+    xp /= xp.norm();
+    Point yp( p2p1/p2p1.norm() );
     Point zp( xp.cross( yp ));
     //
     // The following works but does more than we need
@@ -168,11 +168,11 @@ MaterialTensorCalculator::getTensorQuantity(const SymmTensor & tensor,
     // axis closest to p0 is found by the following for t:
     const Point p2p1( _p2 - _p1 );
     const Point p1p0( _p1 - p0 );
-    const Real t( -(p1p0*p2p1)/p2p1.size_sq() );
+    const Real t( -(p1p0*p2p1)/p2p1.norm_sq() );
     // The nearest point on the cylindrical axis to p0 is p.
     const Point p( _p1 + t * p2p1 );
     Point xp( p0 - p );
-    xp /= xp.size();
+    xp /= xp.norm();
     const Real xp0( xp(0) );
     const Real xp1( xp(1) );
     const Real xp2( xp(2) );
@@ -185,7 +185,7 @@ MaterialTensorCalculator::getTensorQuantity(const SymmTensor & tensor,
   {
     // The vector p2p1=(_p2-_p1) defines the axis, which is the direction in which we want the stress.
     Point p2p1( _p2 - _p1 );
-    p2p1 /= p2p1.size();
+    p2p1 /= p2p1.norm();
 
     const Real axis0( p2p1(0) );
     const Real axis1( p2p1(1) );

--- a/modules/solid_mechanics/src/auxkernels/MaterialVectorAux.C
+++ b/modules/solid_mechanics/src/auxkernels/MaterialVectorAux.C
@@ -56,7 +56,7 @@ MaterialVectorAux::computeValue()
   }
   else if ( _quantity == MVA_LENGTH )
   {
-    value = vector.size();
+    value = vector.norm();
   }
   else
   {

--- a/modules/solid_mechanics/src/kernels/StressDivergenceTruss.C
+++ b/modules/solid_mechanics/src/kernels/StressDivergenceTruss.C
@@ -62,7 +62,7 @@ StressDivergenceTruss::computeResidual()
   _local_re.zero();
 
   RealGradient orientation( (*_orientation)[0] );
-  orientation /= orientation.size();
+  orientation /= orientation.norm();
   VectorValue<Real> force_local = _axial_stress[0] * _area[0] * orientation;
 
   int sign(-_test[0][0]/std::abs(_test[0][0]));
@@ -83,7 +83,7 @@ void
 StressDivergenceTruss::computeStiffness(ColumnMajorMatrix & stiff_global)
 {
   RealGradient orientation( (*_orientation)[0] );
-  orientation /= orientation.size();
+  orientation /= orientation.norm();
 
   Real k = _E_over_L[0] * _area[0];
   stiff_global(0,0) = orientation(0)*orientation(0)*k;

--- a/modules/solid_mechanics/src/postprocessors/TorqueReaction.C
+++ b/modules/solid_mechanics/src/postprocessors/TorqueReaction.C
@@ -55,7 +55,7 @@ TorqueReaction::execute()
   //Sum over T = r x F
   Point force(_react_x[_qp], _react_y[_qp], _react_z[_qp]);
   Point torque = r.cross(force);
-  Real torque_len = torque.size();
+  Real torque_len = torque.norm();
   _sum += torque_len;
 }
 

--- a/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -450,7 +450,7 @@ CrackFrontDefinition::pickLoopCrackEndNodes(std::vector<dof_id_type> &end_nodes,
   for (std::set<dof_id_type>::iterator nit = nodes.begin(); nit != nodes.end(); ++nit )
   {
     Node & node = _mesh.node(*nit);
-    Real dist = node.size();
+    Real dist = node.norm();
     if (dist > max_dist)
     {
       max_dist = dist;
@@ -630,7 +630,7 @@ CrackFrontDefinition::updateCrackFrontGeometry()
     if (_closed_loop)
     {
       back_segment = *getCrackFrontPoint(0) - *getCrackFrontPoint(num_crack_front_points-1);
-      back_segment_len = back_segment.size();
+      back_segment_len = back_segment.norm();
     }
 
     for (unsigned int i=0; i<num_crack_front_points; ++i)
@@ -652,12 +652,12 @@ CrackFrontDefinition::updateCrackFrontGeometry()
       else if (_closed_loop && i==num_crack_front_points-1)
       {
         forward_segment = *getCrackFrontPoint(0) - *getCrackFrontPoint(i);
-        forward_segment_len = forward_segment.size();
+        forward_segment_len = forward_segment.norm();
       }
       else
       {
         forward_segment = *getCrackFrontPoint(i+1) - *getCrackFrontPoint(i);
-        forward_segment_len = forward_segment.size();
+        forward_segment_len = forward_segment.norm();
         _overall_length += forward_segment_len;
       }
 
@@ -668,7 +668,7 @@ CrackFrontDefinition::updateCrackFrontGeometry()
         _distances_along_front.push_back(back_segment_len + _distances_along_front[i - 1]);
 
       RealVectorValue tangent_direction = back_segment + forward_segment;
-      tangent_direction = tangent_direction / tangent_direction.size();
+      tangent_direction = tangent_direction / tangent_direction.norm();
       _tangent_directions.push_back(tangent_direction);
       _crack_directions.push_back(calculateCrackFrontDirection(*getCrackFrontPoint(i),tangent_direction,ntype));
 
@@ -698,10 +698,10 @@ CrackFrontDefinition::updateCrackFrontGeometry()
     if (hasAngleAlongFront())
     {
       RealVectorValue origin_to_first_node = *getCrackFrontPoint(0) - _crack_mouth_coordinates;
-      Real hyp = origin_to_first_node.size();
+      Real hyp = origin_to_first_node.norm();
       RealVectorValue norm_origin_to_first_node = origin_to_first_node / hyp;
       RealVectorValue tangent_to_first_node = -norm_origin_to_first_node.cross(_crack_plane_normal);
-      tangent_to_first_node /= tangent_to_first_node.size();
+      tangent_to_first_node /= tangent_to_first_node.norm();
 
       for (unsigned int i=0; i<num_crack_front_points; ++i)
       {
@@ -1072,7 +1072,7 @@ CrackFrontDefinition::calculateRThetaToCrackFront(const Point qp, const unsigned
 
     //Find r, the distance between the qp and the crack front
     RealVectorValue r_vec = p_rot;
-    r = r_vec.size();
+    r = r_vec.norm();
   }
   else
   {
@@ -1082,7 +1082,7 @@ CrackFrontDefinition::calculateRThetaToCrackFront(const Point qp, const unsigned
     {
       const Point* crack_front_point = getCrackFrontPoint(pit);
       RealVectorValue crack_point_to_current_point = qp - *crack_front_point;
-      Real dist = crack_point_to_current_point.size();
+      Real dist = crack_point_to_current_point.norm();
 
       if (dist < min_dist)
       {
@@ -1096,13 +1096,13 @@ CrackFrontDefinition::calculateRThetaToCrackFront(const Point qp, const unsigned
     closest_point = closest_point - crack_front_point_rot;
 
     //Find r, the distance between the qp and the crack front
-    Real edge_length_sq = crack_front_edge.size_sq();
+    Real edge_length_sq = crack_front_edge.norm_sq();
     closest_point_to_p = p_rot - closest_point;
     Real perp = crack_front_edge * closest_point_to_p;
     Real dist_along_edge = perp / edge_length_sq;
     RealVectorValue point_on_edge = closest_point + crack_front_edge * dist_along_edge;
     RealVectorValue r_vec = p_rot - point_on_edge;
-    r = r_vec.size();
+    r = r_vec.norm();
   }
 
   //Find theta, the angle between r and the crack front plane
@@ -1231,11 +1231,11 @@ CrackFrontDefinition::calculateTangentialStrainAlongFront()
 
     forward_segment0 = *next_node - *current_node;
     forward_segment0 = (forward_segment0 * _tangent_directions[0]) * _tangent_directions[0];
-    forward_segment0_len = forward_segment0.size();
+    forward_segment0_len = forward_segment0.norm();
 
     forward_segment1 = (*next_node + disp_next_node) - (*current_node + disp_current_node);
     forward_segment1 = (forward_segment1 * _tangent_directions[0]) * _tangent_directions[0];
-    forward_segment1_len = forward_segment1.size();
+    forward_segment1_len = forward_segment1.norm();
 
     _strain_along_front[0] = (forward_segment1_len - forward_segment0_len) / forward_segment0_len;
   }
@@ -1261,19 +1261,19 @@ CrackFrontDefinition::calculateTangentialStrainAlongFront()
 
       back_segment0 = *current_node - *previous_node;
       back_segment0 = (back_segment0 * _tangent_directions[i]) * _tangent_directions[i];
-      back_segment0_len = back_segment0.size();
+      back_segment0_len = back_segment0.norm();
 
       back_segment1 = (*current_node + disp_current_node) - (*previous_node + disp_previous_node);
       back_segment1 = (back_segment1 * _tangent_directions[i]) * _tangent_directions[i];
-      back_segment1_len = back_segment1.size();
+      back_segment1_len = back_segment1.norm();
 
       forward_segment0 = *next_node - *current_node;
       forward_segment0 = (forward_segment0 * _tangent_directions[i]) * _tangent_directions[i];
-      forward_segment0_len = forward_segment0.size();
+      forward_segment0_len = forward_segment0.norm();
 
       forward_segment1 = (*next_node + disp_next_node) - (*current_node + disp_current_node);
       forward_segment1 = (forward_segment1 * _tangent_directions[i]) * _tangent_directions[i];
-      forward_segment1_len = forward_segment1.size();
+      forward_segment1_len = forward_segment1.norm();
 
       _strain_along_front[i] = 0.5 * ((back_segment1_len - back_segment0_len) / back_segment0_len
                                       + (forward_segment1_len - forward_segment0_len) / forward_segment0_len);
@@ -1294,11 +1294,11 @@ CrackFrontDefinition::calculateTangentialStrainAlongFront()
 
     back_segment0 = *current_node - *previous_node;
     back_segment0 = (back_segment0 * _tangent_directions[num_crack_front_nodes-1]) * _tangent_directions[num_crack_front_nodes-1];
-    back_segment0_len = back_segment0.size();
+    back_segment0_len = back_segment0.norm();
 
     back_segment1 = (*current_node + disp_current_node) - (*previous_node + disp_previous_node);
     back_segment1 = (back_segment1 * _tangent_directions[num_crack_front_nodes-1]) * _tangent_directions[num_crack_front_nodes-1];
-    back_segment1_len = back_segment1.size();
+    back_segment1_len = back_segment1.norm();
 
     _strain_along_front[num_crack_front_nodes-1] = (back_segment1_len - back_segment0_len) / back_segment0_len;
   }

--- a/modules/solid_mechanics/src/userobjects/MaterialTensorOnLine.C
+++ b/modules/solid_mechanics/src/userobjects/MaterialTensorOnLine.C
@@ -81,7 +81,7 @@ MaterialTensorOnLine::execute()
   {
 
     const Point line_vec(_lp2-_lp1);
-    const Real length(line_vec.size());
+    const Real length(line_vec.norm());
     const Point line_unit_vec(line_vec/length);
 
     for ( qp = 0; qp < _qrule->n_points(); ++qp )
@@ -93,7 +93,7 @@ MaterialTensorOnLine::execute()
       const Point proj_vec(proj*line_unit_vec);
 
       const Point dist_vec(line1_qp_vec-proj_vec);
-      const Real distance(dist_vec.size());
+      const Real distance(dist_vec.norm());
 
       const SymmTensor & tensor( _tensor[qp] );
       RealVectorValue direction;

--- a/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
@@ -83,10 +83,10 @@ ComputeMultiPlasticityStress::ComputeMultiPlasticityStress(const InputParameters
   if (_n_supplied)
   {
     // normalise the inputted transverse_direction
-    if (_n_input.size() == 0)
+    if (_n_input.norm() == 0)
       mooseError("ComputeMultiPlasticityStress: transverse_direction vector must not have zero length");
     else
-      _n_input /= _n_input.size();
+      _n_input /= _n_input.norm();
   }
 
   if (_num_surfaces == 1)

--- a/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
+++ b/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
@@ -156,7 +156,7 @@ ElementPropertyReadFile::getGrainData(const Elem * elem , unsigned int prop_num)
         //Calculates minimum distance when nothing is specified
         //for rve_type
         Point dist_vec = _center[i] - centroid;
-        dist = dist_vec.size();
+        dist = dist_vec.norm();
     }
 
     if (dist < min_dist)
@@ -174,7 +174,7 @@ Real
 ElementPropertyReadFile::minPeriodicDistance(Point c, Point p) const
 {
   Point dist_vec = c - p;
-  Real min_dist = dist_vec.size();
+  Real min_dist = dist_vec.norm();
 
   Real fac[3] = {-1.0, 0.0, 1.0};
   for ( unsigned int i = 0; i < 3; i++ )
@@ -187,7 +187,7 @@ ElementPropertyReadFile::minPeriodicDistance(Point c, Point p) const
         p1(2) = p(2) + fac[k] * _range(2);
 
         dist_vec = c - p1;
-        Real dist = dist_vec.size();
+        Real dist = dist_vec.norm();
 
         if ( dist < min_dist ) min_dist = dist;
       }

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticWeakPlaneTensileN.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticWeakPlaneTensileN.C
@@ -25,10 +25,10 @@ TensorMechanicsPlasticWeakPlaneTensileN::TensorMechanicsPlasticWeakPlaneTensileN
   // cannot check the following for all values of strength, but this is a start
   if (_strength.value(0) < 0)
     mooseError("Weak plane tensile strength must not be negative");
-  if (_input_n.size() == 0)
+  if (_input_n.norm() == 0)
      mooseError("Weak-plane normal vector must not have zero length");
    else
-     _input_n /= _input_n.size();
+     _input_n /= _input_n.norm();
   _rot = RotationMatrix::rotVecToZ(_input_n);
 
   for (unsigned i = 0; i < 3; ++i)

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -449,8 +449,8 @@ XFEM::correctCrackExtensionDirection(const Elem * elem,
       edge1_to_tip = (edge_ends[0]*0.95 + edge_ends[1]*0.05) - crack_tip_origin;
       edge2_to_tip = (edge_ends[0]*0.05 + edge_ends[1]*0.95) - crack_tip_origin;
 
-      edge1_to_tip /= pow(edge1_to_tip.size_sq(),0.5);
-      edge2_to_tip /= pow(edge2_to_tip.size_sq(),0.5);
+      edge1_to_tip /= pow(edge1_to_tip.norm_sq(),0.5);
+      edge2_to_tip /= pow(edge2_to_tip.norm_sq(),0.5);
 
       edge1_to_tip_normal(0) = -edge1_to_tip(1);
       edge1_to_tip_normal(1) = edge1_to_tip(0);
@@ -606,7 +606,7 @@ XFEM::markCutEdgesByState(Real time)
           edge_center /= 2.0;
           crack_tip_origin = edge_center;
           crack_tip_direction = elem_center - edge_center;
-          crack_tip_direction /= pow(crack_tip_direction.size_sq(),0.5);
+          crack_tip_direction /= pow(crack_tip_direction.norm_sq(),0.5);
         }
         else
           continue; // skip this elem if specified boundary edge is phantom
@@ -637,7 +637,7 @@ XFEM::markCutEdgesByState(Real time)
         edge_center /= 2.0;
         crack_tip_origin = edge_center;
         crack_tip_direction = elem_center - edge_center;
-        crack_tip_direction /= pow(crack_tip_direction.size_sq(),0.5);
+        crack_tip_direction /= pow(crack_tip_direction.norm_sq(),0.5);
       }
       else
         mooseError ("element " << elem->id() << " flagged for state-based growth, but has no edge intersections");
@@ -680,7 +680,7 @@ XFEM::markCutEdgesByState(Real time)
     }
 
     Point between_two_cuts = (cut_edge_point - crack_tip_origin);
-    between_two_cuts /= pow(between_two_cuts.size_sq(),0.5);
+    between_two_cuts /= pow(between_two_cuts.norm_sq(),0.5);
     Real angle_between_two_cuts = between_two_cuts * crack_tip_direction;
 
     if (angle_between_two_cuts > std::cos(45.0/180.0*3.14159)) //original cut direction is good

--- a/modules/xfem/src/base/XFEMCircleCut.C
+++ b/modules/xfem/src/base/XFEMCircleCut.C
@@ -27,8 +27,8 @@ XFEMCircleCut::XFEMCircleCut(std::vector<Real> circle_nodes) :
   _normal = ray1.cross(ray2);
   Xfem::normalizePoint(_normal);
 
-  Real R1 = std::sqrt(ray1.size_sq());
-  Real R2 = std::sqrt(ray2.size_sq());
+  Real R1 = std::sqrt(ray1.norm_sq());
+  Real R2 = std::sqrt(ray2.norm_sq());
   if ( std::abs(R1 - R2) > 1e-10 )
     mooseError("XFEMCircleCut only works for a circular cut");
 
@@ -42,7 +42,7 @@ XFEMCircleCut::~XFEMCircleCut()
 
 bool XFEMCircleCut::isInsideCutPlane(Point p){
     Point ray = p - _center;
-    if ( std::abs(ray*_normal)<1e-15 && std::sqrt(ray.size_sq()) < _radius )
+    if ( std::abs(ray*_normal)<1e-15 && std::sqrt(ray.norm_sq()) < _radius )
       return true;
     return false;
 }

--- a/modules/xfem/src/base/XFEMCutElem2D.C
+++ b/modules/xfem/src/base/XFEMCutElem2D.C
@@ -140,7 +140,7 @@ XFEMCutElem2D::getCutPlaneNormal(unsigned int plane_id, MeshBase* displaced_mesh
     Point cut_line_p1 = getNodeCoordinates(cut_line_nodes[plane_id][0], displaced_mesh);
     Point cut_line_p2 = getNodeCoordinates(cut_line_nodes[plane_id][1], displaced_mesh);
     Point cut_line = cut_line_p2 - cut_line_p1;
-    Real len = std::sqrt(cut_line.size_sq());
+    Real len = std::sqrt(cut_line.norm_sq());
     cut_line *= (1.0/len);
     normal = Point(cut_line(1), -cut_line(0), 0.0);
   }
@@ -179,7 +179,7 @@ XFEMCutElem2D::getCrackTipOriginAndDirection(unsigned tip_id, Point & origin, Po
   Point cut_line_p1 = getNodeCoordinates(cut_line_nodes[0]);
   Point cut_line_p2 = getNodeCoordinates(cut_line_nodes[1]);
   Point cut_line = cut_line_p2 - cut_line_p1;
-  Real len = std::sqrt(cut_line.size_sq());
+  Real len = std::sqrt(cut_line.norm_sq());
   cut_line *= (1.0/len);
   origin = cut_line_p2;
   direction = Point(cut_line(0), cut_line(1), 0.0);

--- a/modules/xfem/src/base/XFEMEllipseCut.C
+++ b/modules/xfem/src/base/XFEMEllipseCut.C
@@ -32,8 +32,8 @@ XFEMEllipseCut::XFEMEllipseCut(std::vector<Real> ellipse_nodes) :
   _normal = ray1.cross(ray2);
   Xfem::normalizePoint(_normal);
 
-  Real R1 = std::sqrt(ray1.size_sq());
-  Real R2 = std::sqrt(ray2.size_sq());
+  Real R1 = std::sqrt(ray1.norm_sq());
+  Real R2 = std::sqrt(ray2.norm_sq());
 
   if (R1>R2)
   {

--- a/modules/xfem/src/base/XFEMFuncs.C
+++ b/modules/xfem/src/base/XFEMFuncs.C
@@ -594,7 +594,7 @@ void i4vec_zero ( int n, int a[] )
 
 void normalizePoint(Point & p)
 {
-  Real len = p.size();
+  Real len = p.norm();
   if (len != 0.0)
     p = (1.0/len)*p;
 }

--- a/modules/xfem/src/base/XFEMGeometricCut3D.C
+++ b/modules/xfem/src/base/XFEMGeometricCut3D.C
@@ -152,7 +152,7 @@ Real
 XFEMGeometricCut3D::getRelativePosition(Point p1, Point p2, Point p)
 {
   // get the relative position of p from p1
-  Real full_len = (p2 - p1).size();
-  Real len_p1_p = (p - p1).size();
+  Real full_len = (p2 - p1).norm();
+  Real len_p1_p = (p - p1).norm();
   return len_p1_p / full_len;
 }

--- a/test/src/userobjects/RandomHitSolutionModifier.C
+++ b/test/src/userobjects/RandomHitSolutionModifier.C
@@ -60,7 +60,7 @@ RandomHitSolutionModifier::execute()
       for (unsigned int n=0; n<elem->n_nodes(); n++)
       {
         Node * cur_node = elem->get_node(n);
-        Real cur_distance = (hit - *cur_node).size();
+        Real cur_distance = (hit - *cur_node).norm();
 
         if (cur_distance < closest_distance)
         {


### PR DESCRIPTION
TypeVector::size() was deprecated in the recent libmesh update, this patch updates MOOSE to use the new TypeVector::norm() instead.

Refs libMesh/libmesh#813
