### PR TITLE
Update actions in TM to use stringify Refs #6467

### DIFF
--- a/modules/tensor_mechanics/include/actions/PoroMechanicsAction.h
+++ b/modules/tensor_mechanics/include/actions/PoroMechanicsAction.h
@@ -20,9 +20,6 @@ public:
   PoroMechanicsAction(const InputParameters & params);
 
   virtual void act();
-
-private:
-
 };
 
 #endif //POROMECHANICSACTION_H

--- a/modules/tensor_mechanics/include/actions/PressureAction.h
+++ b/modules/tensor_mechanics/include/actions/PressureAction.h
@@ -36,4 +36,4 @@ protected:
 template<>
 InputParameters validParams<PressureAction>();
 
-#endif // PRESSUREACTION_H
+#endif //PRESSUREACTION_H

--- a/modules/tensor_mechanics/include/actions/TensorMechanicsAxisymmetricRZAction.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsAxisymmetricRZAction.h
@@ -20,10 +20,6 @@ public:
   TensorMechanicsAxisymmetricRZAction(const InputParameters & params);
 
   virtual void act();
-
-private:
-  /// Base name for the kernels + components used in the model
-  std::string _base_name;
 };
 
 #endif //TENSORMECHANICSAXISYMMETRICRZACTION_H

--- a/modules/tensor_mechanics/include/actions/TensorMechanicsRSphericalAction.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsRSphericalAction.h
@@ -20,10 +20,6 @@ public:
   TensorMechanicsRSphericalAction(const InputParameters & params);
 
   virtual void act();
-
-private:
-  /// Base name for the kernels + components used in the model
-  std::string _base_name;
 };
 
 #endif //TENSORMECHANICSRSPHERICALACTION_H

--- a/modules/tensor_mechanics/src/actions/PoroMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/PoroMechanicsAction.C
@@ -9,6 +9,7 @@
 #include "Factory.h"
 #include "FEProblem.h"
 #include "Parser.h"
+#include "Conversion.h"
 
 template<>
 InputParameters validParams<PoroMechanicsAction>()
@@ -32,7 +33,6 @@ PoroMechanicsAction::act()
   std::vector<NonlinearVariableName> displacements = getParam<std::vector<NonlinearVariableName> >("displacements");
   unsigned int dim = displacements.size();
 
-
   // all the kernels added below have porepressure as a coupled variable
   // add this to the kernel's params
   std::string type("PoroMechanicsCoupling");
@@ -41,19 +41,14 @@ PoroMechanicsAction::act()
   params.addCoupledVar("porepressure", "");
   params.set<std::vector<VariableName> >("porepressure") = std::vector<VariableName>(1, pp_var);
 
-
   // now add the kernels
-  std::string short_name = "PoroMechanics";
   for (unsigned int i = 0; i < dim; ++i)
   {
-    std::stringstream name;
-    name << short_name;
-    name << i;
+    std::string kernel_name = "PoroMechanics" + Moose::stringify(i);
 
     params.set<unsigned int>("component") = i;
     params.set<NonlinearVariableName>("variable") = displacements[i];
 
-    _problem->addKernel(type, name.str(), params);
+    _problem->addKernel(type, kernel_name, params);
   }
 }
-

--- a/modules/tensor_mechanics/src/actions/PressureAction.C
+++ b/modules/tensor_mechanics/src/actions/PressureAction.C
@@ -9,6 +9,7 @@
 #include "Factory.h"
 #include "FEProblem.h"
 #include "Parser.h"
+#include "Conversion.h"
 
 template<>
 InputParameters validParams<PressureAction>()
@@ -73,10 +74,8 @@ PressureAction::act()
   //Create pressure BCs
   for (unsigned int i = 0; i < dim; ++i)
   {
-    std::stringstream name;
-    name << _name;
-    name << "_";
-    name << i;
+    //Create unique kernel name for each of the components
+    std::string unique_kernel_name = _kernel_name + "_" + _name + "_" + Moose::stringify(i);
 
     InputParameters params = _factory.getValidParams(_kernel_name);
 
@@ -94,6 +93,6 @@ PressureAction::act()
     if (_has_save_in_vars[i])
       params.set<std::vector<AuxVariableName> >("save_in") = _save_in_vars[i];
 
-    _problem->addBoundaryCondition(_kernel_name, name.str(), params);
+    _problem->addBoundaryCondition(_kernel_name, unique_kernel_name, params);
   }
 }

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
@@ -9,6 +9,7 @@
 #include "Factory.h"
 #include "FEProblem.h"
 #include "Parser.h"
+#include "Conversion.h"
 
 template<>
 InputParameters validParams<TensorMechanicsAction>()
@@ -67,8 +68,7 @@ TensorMechanicsAction::act()
 
 
   // Retain this code 'as is' because StressDivergenceTensors inherits from Kernel.C
-  std::vector<std::vector<AuxVariableName> > save_in;
-  save_in.resize(dim);
+  std::vector<std::vector<AuxVariableName> > save_in(dim);
 
   if (isParamValid("save_in_disp_x"))
     save_in[0] = getParam<std::vector<AuxVariableName> >("save_in_disp_x");
@@ -91,19 +91,15 @@ TensorMechanicsAction::act()
   if (isParamValid("base_name"))
     params.set<std::string>("base_name") = getParam<std::string>("base_name");
 
-  std::string short_name = "TensorMechanics";
-
   for (unsigned int i = 0; i < dim; ++i)
   {
-    std::stringstream name;
-    name << short_name;
-    name << i;
+    std::string kernel_name = "TensorMechanics_" + Moose::stringify(i);
 
     params.set<unsigned int>("component") = i;
     params.set<NonlinearVariableName>("variable") = displacements[i];
     params.set<std::vector<AuxVariableName> >("save_in") = save_in[i];
 
-    addkernel(name.str(), params);
+    addkernel(kernel_name, params);
   }
 }
 

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAxisymmetricRZAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAxisymmetricRZAction.C
@@ -63,8 +63,8 @@ TensorMechanicsAxisymmetricRZAction::act()
 
   for (unsigned int i = 0; i < dim; ++i)
   {
-    // Create kernal name dependent on the displacement variable
-    std::string kernel_name = "TensorMechanicsAxisymmetricRZ" + _base_name + Moose::stringify(i);
+    // Create kernel name dependent on the displacement variable
+    std::string kernel_name = "TensorMechanicsAxisymmetricRZ_" + Moose::stringify(i);
 
     params.set<unsigned int>("component") = i;
     params.set<NonlinearVariableName>("variable") = displacements[i];

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsRSphericalAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsRSphericalAction.C
@@ -25,8 +25,7 @@ InputParameters validParams<TensorMechanicsRSphericalAction>()
 }
 
 TensorMechanicsRSphericalAction::TensorMechanicsRSphericalAction(const InputParameters & params) :
-    Action(params),
-    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "")
+    Action(params)
 {
 }
 
@@ -57,8 +56,8 @@ TensorMechanicsRSphericalAction::act()
 
   for (unsigned int i = 0; i < dim; ++i)
   {
-    // Create kernal name dependent on the displacement variable
-    std::string kernel_name = "TensorMechanicsRSpherical" + _base_name + Moose::stringify(i);
+    // Create kernel name dependent on the displacement variable
+    std::string kernel_name = "TensorMechanicsRSpherical_" + Moose::stringify(i);
 
     params.set<unsigned int>("component") = i;
     params.set<NonlinearVariableName>("variable") = displacements[i];


### PR DESCRIPTION
- Changed the tensor mechanics actions to use Moose::stringify instead of std::stringstream
- Corrected spelling mistakes in the RSpherical and AxisymmetricRZ actions
- Used the atom option 'Show Invisibles' so that I could count dots for the spaces
- Existing test cases
- Closes #6467 
