### PR TITLE
Q2PPiecewiseLinearSink tested using PJFNK and no Preconditioning block.

### DIFF
--- a/modules/richards/tests/sinks/q2p01.i
+++ b/modules/richards/tests/sinks/q2p01.i
@@ -189,6 +189,7 @@
 
 
 [Preconditioning]
+  active = 'andy'
   [./andy]
     type = SMP
     full = true

--- a/modules/richards/tests/sinks/tests
+++ b/modules/richards/tests/sinks/tests
@@ -71,6 +71,13 @@
     prereq = 'Q2P01'
     csvdiff = 'q2p01.csv'
   [../]
+  [./Q2P01_PJFNK]
+    type = 'CSVDiff'
+    input = 'q2p01.i'
+    prereq = 'Q2P01 Q2P01_permchange'
+    cli_args = 'Preconditioning/active="" Executioner/solve_type=PJFNK'
+    csvdiff = 'q2p01.csv'
+  [../]
 
   [./except01]
     type = 'RunException'


### PR DESCRIPTION
This completes the test coverage of Q2PPiecewiseLinearSink as its computeJacobian function now gets called.

Refs #6402
