### PR TITLE
Fixes for when there is no active threading model

### DIFF
--- a/framework/include/utils/ParallelUniqueId.h
+++ b/framework/include/utils/ParallelUniqueId.h
@@ -51,7 +51,8 @@ public:
     id = _ids.front();
     _ids.pop();
 #else
-    mooseError("Threading disabled - Please check your libMesh configuration");
+    // There is no thread model active, so we're always on thread 0.
+    id = 0;
 #endif
   }
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -200,6 +200,17 @@ MooseApp::setupOptions()
   Moose::_warnings_are_errors = getParam<bool>("error");
   Moose::_color_console = !getParam<bool>("no_color");
 
+  // If there's no threading model active, but the user asked for
+  // --n-threads > 1 on the command line, throw a mooseError.  This is
+  // intended to prevent situations where the user has potentially
+  // built MOOSE incorrectly (neither TBB nor pthreads found) and is
+  // asking for multiple threads, not knowing that there will never be
+  // any threads launched.
+#if !LIBMESH_USING_THREADS
+  if (libMesh::command_line_value ("--n-threads", 1) > 1)
+    mooseError("You specified --n-threads > 1, but there is no threading model active!");
+#endif
+
   // Build a minimal running application, ignoring the input file.
   if (getParam<bool>("minimal"))
     createMinimalApp();


### PR DESCRIPTION
A small fix and a sanity check in the case where neither TBB nor pthreads is active.  I'm working on making this (compiling with no thread model) a supported option in libMesh, and everything except this one issue seems to already work fine in MOOSE.

I discussed with @permcody whether it should be an error or a warning to ask for multiple threads when you have no threading model enabled, and we decided on error, as it likely means that something went wrong with your build and you thought you had threading enabled...

Refs #6371.
