### PR TITLE
Global PerfLog stats only when running an input file

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -524,15 +524,22 @@ MooseApp::legacyUoInitializationDefault()
 void
 MooseApp::run()
 {
-  Moose::perf_log.push("Full Runtime", "Application");
+  bool running_input_file = (_input_filename != "" || isParamValid("input_file"));
 
-  Moose::perf_log.push("Application Setup", "Setup");
+  if (running_input_file)
+  {
+    Moose::perf_log.push("Full Runtime", "Application");
+
+    Moose::perf_log.push("Application Setup", "Setup");
+  }
   setupOptions();
   runInputFile();
-  Moose::perf_log.pop("Application Setup", "Setup");
+  if (running_input_file)
+    Moose::perf_log.pop("Application Setup", "Setup");
 
   executeExecutioner();
-  Moose::perf_log.pop("Full Runtime", "Application");
+  if (running_input_file)
+    Moose::perf_log.pop("Full Runtime", "Application");
 }
 
 void


### PR DESCRIPTION
Adding 'Full runtime' and 'Application setup' to PerfLog needs to happen
only when running an input file. Otherwise, the output of things like --syntax
--yaml, or even running without any command line arguments shows the perflog.
And that's not what we want.

Refs #6300
