### PR TITLE
Add C++11 test to prevent serialization of polymorphic types

### DIFF
--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -24,6 +24,9 @@
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/parallel.h"
+#ifdef LIBMESH_HAVE_CXX11_TYPE_TRAITS
+#  include <type_traits>
+#endif
 
 // C++ includes
 #include <string>
@@ -123,6 +126,13 @@ template<typename T>
 inline void
 dataStore(std::ostream & stream, T & v, void * /*context*/)
 {
+  #ifdef LIBMESH_HAVE_CXX11_TYPE_TRAITS
+    static_assert( std::is_polymorphic<T>::value == false,
+      "Cannot serialize a class that has virtual members!\nWrite a custom dataStore() template specialization!\n\n");
+    // static_assert( std::is_trivially_copyable<T>::value,
+    //   "Cannot serialize a class that is not trivially copyable!\nWrite a custom dataStore() template specialization!\n\n");
+  #endif
+
   // Moose::out<<"Generic dataStore"<<std::endl;
   stream.write((char *) &v, sizeof(v));
 }

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -129,8 +129,8 @@ dataStore(std::ostream & stream, T & v, void * /*context*/)
   #ifdef LIBMESH_HAVE_CXX11_TYPE_TRAITS
     static_assert( std::is_polymorphic<T>::value == false,
       "Cannot serialize a class that has virtual members!\nWrite a custom dataStore() template specialization!\n\n");
-    // static_assert( std::is_trivially_copyable<T>::value,
-    //   "Cannot serialize a class that is not trivially copyable!\nWrite a custom dataStore() template specialization!\n\n");
+    static_assert( std::is_trivially_copyable<T>::value || std::is_same<T, Point>::value,
+      "Cannot serialize a class that is not trivially copyable!\nWrite a custom dataStore() template specialization!\n\n");
   #endif
 
   // Moose::out<<"Generic dataStore"<<std::endl;
@@ -142,6 +142,14 @@ inline void
 dataStore(std::ostream & /*stream*/, T * & /*v*/, void * /*context*/)
 {
   mooseError("Cannot store raw pointers as restartable data!\nWrite a custom dataStore() template specialization!\n\n");
+}
+
+template<typename T, typename U>
+inline void
+dataStore(std::ostream & stream, std::pair<T, U> & p, void * context)
+{
+  dataStore(stream, p.first, context);
+  dataStore(stream, p.second, context);
 }
 
 template<typename T>
@@ -283,6 +291,14 @@ template<typename T>
 void dataLoad(std::istream & /*stream*/, T * & /*v*/, void * /*context*/)
 {
   mooseError("Cannot load raw pointers as restartable data!\nWrite a custom dataLoad() template specialization!\n\n");
+}
+
+template<typename T, typename U>
+inline void
+dataLoad(std::istream & stream, std::pair<T, U> & p, void * context)
+{
+  dataLoad(stream, p.first, context);
+  dataLoad(stream, p.second, context);
 }
 
 template<typename T>

--- a/modules/misc/include/DiagTensor.h
+++ b/modules/misc/include/DiagTensor.h
@@ -57,15 +57,6 @@ public:
         mooseError("please enter a vector with 3 entries.");
     }
 
-  DiagTensor(const DiagTensor &a)
-    {
-      *this = a;
-    }
-
-
-  ~DiagTensor() {}
-
-
   Real rowDot(const unsigned int r,
               const libMesh::TypeVector<Real> & v) const
     {

--- a/modules/solid_mechanics/include/materials/SymmElasticityTensor.h
+++ b/modules/solid_mechanics/include/materials/SymmElasticityTensor.h
@@ -190,6 +190,18 @@ protected:
                  // 3 in fourth
                  // 2 in fifth
                  // 1 in sixth
+
+  template<class T>
+  friend void dataStore(std::ostream &, T &, void *);
+
+  template<class T>
+  friend void dataLoad(std::istream &, T &, void *);
 };
+
+template<>
+void dataStore(std::ostream &, SymmElasticityTensor &, void *);
+
+template<>
+void dataLoad(std::istream &, SymmElasticityTensor &, void *);
 
 #endif //SYMMELASTICITYTENSOR_H

--- a/modules/solid_mechanics/include/materials/SymmTensor.h
+++ b/modules/solid_mechanics/include/materials/SymmTensor.h
@@ -75,10 +75,6 @@ public:
     }
   }
 
-
-  ~SymmTensor() {}
-
-
   void fillFromInputVector(const std::vector<Real> & input)
   {
     if (input.size() != 6)

--- a/modules/solid_mechanics/src/materials/SymmElasticityTensor.C
+++ b/modules/solid_mechanics/src/materials/SymmElasticityTensor.C
@@ -7,6 +7,24 @@
 #include "SymmElasticityTensor.h"
 #include <vector>
 
+template<>
+void
+dataStore(std::ostream & stream, SymmElasticityTensor & set, void * context)
+{
+  dataStore(stream, set._constant, context);
+  dataStore(stream, set._values_computed, context);
+  dataStore(stream, set._val, context);
+}
+
+template<>
+void
+dataLoad(std::istream & stream, SymmElasticityTensor & set, void * context)
+{
+  dataLoad(stream, set._constant, context);
+  dataLoad(stream, set._values_computed, context);
+  dataLoad(stream, set._val, context);
+}
+
 SymmElasticityTensor::SymmElasticityTensor(const bool constant)
   : _constant(constant),
     _values_computed(false)

--- a/modules/tensor_mechanics/include/utils/ElasticityTensorR4.h
+++ b/modules/tensor_mechanics/include/utils/ElasticityTensorR4.h
@@ -32,13 +32,7 @@ void mooseSetToZero<ElasticityTensorR4>(ElasticityTensorR4 & v);
 class ElasticityTensorR4 : public RankFourTensor
 {
 public:
-  virtual ~ElasticityTensorR4() {}
-
-  /// Default constructor; fills to zero
-  ElasticityTensorR4();
-
-  /// Copy constructor
-  ElasticityTensorR4(const ElasticityTensorR4 &a);
+  ElasticityTensorR4() : RankFourTensor() {}
 
   /// Copy constructor for RankFourTensor
   ElasticityTensorR4(const RankFourTensor &a);
@@ -50,25 +44,38 @@ public:
    * This is used for the standard kernel stress_ij*d(test)/dx_j, when varied wrt u_k
    * Jacobian entry: d(stress_ij*d(test)/dx_j)/du_k = d(C_ijmn*du_m/dx_n*dtest/dx_j)/du_k
    */
-  virtual Real elasticJacobian( const unsigned int i, const unsigned int k, const RealGradient & grad_test, const RealGradient & grad_phi) const;
+  Real elasticJacobian( const unsigned int i, const unsigned int k, const RealGradient & grad_test, const RealGradient & grad_phi) const;
 
   /**
    * This is used for the standard kernel stress_ij*d(test)/dx_j, when varied wrt w_k (the cosserat rotation)
    * Jacobian entry: d(stress_ij*d(test)/dx_j)/dw_k = d(C_ijmn*eps_mnp*w_p*dtest/dx_j)/dw_k
    */
-  virtual Real elasticJacobianwc(const unsigned int i, const unsigned int k, const RealGradient & grad_test, Real phi) const;
+  Real elasticJacobianwc(const unsigned int i, const unsigned int k, const RealGradient & grad_test, Real phi) const;
 
   /**
    * This is used for the moment-balancing kernel eps_ijk*stress_jk*test, when varied wrt u_k
    * Jacobian entry: d(eps_ijm*stress_jm*test)/du_k = d(eps_ijm*C_jmln*du_l/dx_n*test)/du_k
    */
-  virtual Real momentJacobian(const unsigned int i, const unsigned int k, Real test, const RealGradient & grad_phi) const;
+  Real momentJacobian(const unsigned int i, const unsigned int k, Real test, const RealGradient & grad_phi) const;
 
   /**
    * This is used for the moment-balancing kernel eps_ijk*stress_jk*test, when varied wrt w_k (the cosserat rotation)
    * Jacobian entry: d(eps_ijm*stress_jm*test)/dw_k = d(eps_ijm*C_jmln*eps_lnp*w_p*test)/dw_k
    */
-  virtual Real momentJacobianwc(const unsigned int i, const unsigned int k, Real test, Real phi) const;
+  Real momentJacobianwc(const unsigned int i, const unsigned int k, Real test, Real phi) const;
+  void fillPrincipalFromInputVector(const std::vector<Real> & input);
+
+  template<class T>
+  friend void dataStore(std::ostream &, T &, void *);
+
+  template<class T>
+  friend void dataLoad(std::istream &, T &, void *);
 };
+
+template<>
+void dataStore(std::ostream &, ElasticityTensorR4 &, void *);
+
+template<>
+void dataLoad(std::istream &, ElasticityTensorR4 &, void *);
 
 #endif //ELASTICITYTENSORR4_H

--- a/modules/tensor_mechanics/include/utils/RankFourTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankFourTensor.h
@@ -84,12 +84,6 @@ public:
   /// Fill from vector
   RankFourTensor(const std::vector<Real> &, FillMethod);
 
-  /// Copy constructor
-  RankFourTensor(const RankFourTensor &);
-
-  /// Destructor
-  ~RankFourTensor() {}
-
   // Named constructors
   static RankFourTensor Identity() { return RankFourTensor(initIdentity); }
   static RankFourTensor IdentityFour() { return RankFourTensor(initIdentityFour); };
@@ -168,13 +162,13 @@ public:
    * Rotate the tensor using
    * C_ijkl = R_im R_in R_ko R_lp C_mnop
    */
-  virtual void rotate(RealTensorValue & R);
+  void rotate(RealTensorValue & R);
 
   /**
    * Rotate the tensor using
    * C_ijkl = R_im R_in R_ko R_lp C_mnop
    */
-  virtual void rotate(const RankTwoTensor & R);
+  void rotate(const RankTwoTensor & R);
 
   /**
    * Transpose the tensor by swapping the first pair with the second pair of indices
@@ -192,7 +186,7 @@ public:
    *                       C_2211 = input[7], C_2212 = input[8], C_2222 = input[9]
    *                       and C_ijkl = C_jikl = C_ijlk
    */
-  virtual void surfaceFillFromInputVector(const std::vector<Real> & input);
+  void surfaceFillFromInputVector(const std::vector<Real> & input);
 
   /// Static method for use in validParams for getting the "fill_method"
   static MooseEnum fillMethodEnum();
@@ -310,8 +304,20 @@ protected:
    * C3333 = input8
    * with all other components being zero
    */
+
   void fillPrincipalFromInputVector(const std::vector<Real> & input);
+  template<class T>
+  friend void dataStore(std::ostream &, T &, void *);
+
+  template<class T>
+  friend void dataLoad(std::istream &, T &, void *);
 };
+
+template<>
+void dataStore(std::ostream &, RankFourTensor &, void *);
+
+template<>
+void dataLoad(std::istream &, RankFourTensor &, void *);
 
 inline RankFourTensor operator*(Real a, const RankFourTensor & b) { return b * a; }
 

--- a/modules/tensor_mechanics/include/utils/RankTwoTensor.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoTensor.h
@@ -87,9 +87,6 @@ public:
   /// Initialization list replacement constructors, 9 arguments
   RankTwoTensor(Real S11, Real S21, Real S31, Real S12, Real S22, Real S32, Real S13, Real S23, Real S33);
 
-  /// Copy constructor from RankTwoTensor
-  RankTwoTensor(const RankTwoTensor & a);
-
   /// Copy constructor from RealTensorValue
   RankTwoTensor(const TypeTensor<Real> & a);
 
@@ -133,20 +130,20 @@ public:
    * _vals[i][j] = R_ij * R_jl * _vals[k][l]
    * @param R rotation matrix as a RealTensorValue
    */
-  virtual void rotate(RealTensorValue & R);
+  void rotate(RealTensorValue & R);
 
   /**
    * rotates the tensor data given a rank two tensor rotation tensor
    * _vals[i][j] = R_ij * R_jl * _vals[k][l]
    * @param R rotation matrix as a RankTwoTensor
    */
-  virtual void rotate(RankTwoTensor & R);
+  void rotate(RankTwoTensor & R);
 
   /**
    * rotates the tensor data anticlockwise around the z-axis
    * @param a angle in radians
    */
-  virtual RankTwoTensor rotateXyPlane(const Real a);
+  RankTwoTensor rotateXyPlane(const Real a);
 
   /**
    * Returns a matrix that is the transpose of the matrix this
@@ -382,14 +379,23 @@ public:
   /// RankTwoTensor from outer product of vectors
   void vectorOuterProduct(const TypeVector<Real> &, const TypeVector<Real> &);
 
-protected:
-
-
 private:
   static const unsigned int N = LIBMESH_DIM;
   Real _vals[N][N];
+
+  template<class T>
+  friend void dataStore(std::ostream &, T &, void *);
+
+  template<class T>
+  friend void dataLoad(std::istream &, T &, void *);
 };
 
 inline RankTwoTensor operator*(Real a, const RankTwoTensor & b) { return b * a; }
+
+template<>
+void dataStore(std::ostream & stream, RankTwoTensor &, void *);
+
+template<>
+void dataLoad(std::istream & stream, RankTwoTensor &, void *);
 
 #endif //RANKTWOTENSOR_H

--- a/modules/tensor_mechanics/src/utils/ElasticityTensorR4.C
+++ b/modules/tensor_mechanics/src/utils/ElasticityTensorR4.C
@@ -12,14 +12,18 @@ void mooseSetToZero<ElasticityTensorR4>(ElasticityTensorR4 & v)
   v.zero();
 }
 
-ElasticityTensorR4::ElasticityTensorR4() :
-    RankFourTensor()
+template<>
+void
+dataStore(std::ostream & stream, ElasticityTensorR4 & et, void * context)
 {
+  dataStore(stream, et._vals, context);
 }
 
-ElasticityTensorR4::ElasticityTensorR4(const ElasticityTensorR4 &a) :
-    RankFourTensor(a)
+template<>
+void
+dataLoad(std::istream & stream, ElasticityTensorR4 & et, void * context)
 {
+  dataLoad(stream, et._vals, context);
 }
 
 ElasticityTensorR4::ElasticityTensorR4(const RankFourTensor &a) :

--- a/modules/tensor_mechanics/src/utils/RankFourTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankFourTensor.C
@@ -22,6 +22,20 @@ void mooseSetToZero<RankFourTensor>(RankFourTensor & v)
   v.zero();
 }
 
+template<>
+void
+dataStore(std::ostream & stream, RankFourTensor & rft, void * context)
+{
+  dataStore(stream, rft._vals, context);
+}
+
+template<>
+void
+dataLoad(std::istream & stream, RankFourTensor & rft, void * context)
+{
+  dataLoad(stream, rft._vals, context);
+}
+
 MooseEnum
 RankFourTensor::fillMethodEnum()
 {
@@ -37,11 +51,6 @@ RankFourTensor::RankFourTensor()
       for (unsigned int k = 0; k < N; ++k)
         for (unsigned int l = 0; l < N; ++l)
           _vals[i][j][k][l] = 0.0;
-}
-
-RankFourTensor::RankFourTensor(const RankFourTensor & a)
-{
-  *this = a;
 }
 
 RankFourTensor::RankFourTensor(const InitMethod init)

--- a/modules/tensor_mechanics/src/utils/RankTwoTensor.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoTensor.C
@@ -19,6 +19,20 @@ void mooseSetToZero<RankTwoTensor>(RankTwoTensor & v)
   v.zero();
 }
 
+template<>
+void
+dataStore(std::ostream & stream, RankTwoTensor & rtt, void * context)
+{
+  dataStore(stream, rtt._vals, context);
+}
+
+template<>
+void
+dataLoad(std::istream & stream, RankTwoTensor & rtt, void * context)
+{
+  dataLoad(stream, rtt._vals, context);
+}
+
 MooseEnum
 RankTwoTensor::fillMethodEnum()
 {
@@ -63,11 +77,6 @@ RankTwoTensor::RankTwoTensor(const TypeVector<Real> & row1, const TypeVector<Rea
 
   for (unsigned int i=0; i<N; i++)
     _vals[2][i] = row3(i);
-}
-
-RankTwoTensor::RankTwoTensor(const RankTwoTensor & a)
-{
-  *this = a;
 }
 
 RankTwoTensor::RankTwoTensor(const TypeTensor<Real> & a)


### PR DESCRIPTION
This adds a `static_assert` for _polymorphic types_, i.e. classes with vtables and prevents the use of the unspecialized `dataStore` function template for those. I'd love to add a check for _is trivially copyable_ as well, as this would error out when serializing structs that have members that store data on the heap etc.
Unfortunately it complains about `libMesh::Point`, because this class implements a copy constructor (for no good reason as fat as I can see...). 

I could make exceptions for these types using `std::is_same`...

Closes #6493
