### PR TITLE
Richards Kernels test coverage increased.

### DIFF
--- a/modules/richards/include/actions/Q2PAction.h
+++ b/modules/richards/include/actions/Q2PAction.h
@@ -34,6 +34,10 @@ private:
   Real _diffusivity;
   std::vector<OutputName> _output_nodal_masses_to;
   std::vector<OutputName> _output_total_masses_to;
+  bool _save_gas_flux_in_Q2PGasFluxResidual;
+  bool _save_water_flux_in_Q2PWaterFluxResidual;
+  bool _save_gas_Jacobian_in_Q2PGasJacobian;
+  bool _save_water_Jacobian_in_Q2PWaterJacobian;
   bool _nodal_masses_not_outputted;
   bool _total_masses_not_outputted;
   bool _no_mass_calculations;

--- a/modules/richards/include/kernels/Q2PPorepressureFlux.h
+++ b/modules/richards/include/kernels/Q2PPorepressureFlux.h
@@ -62,17 +62,11 @@ protected:
   /// This simply calls upwind
   virtual void computeResidual();
 
-  /// Not used.  I use computeQpJac instead.
-  virtual Real computeQpJacobian();
-
-  /// Not used.  I use computeQpJac instead.
+  /// this simply calls upwind
   virtual void computeOffDiagJacobian(unsigned int jvar);
 
   /// this simply calls upwind
   virtual void computeJacobian();
-
-  /// this simply calls upwind
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// the derivative of the flux without the upstream mobility terms
   Real computeQpJac(unsigned int dvar);

--- a/modules/richards/include/kernels/Q2PSaturationFlux.h
+++ b/modules/richards/include/kernels/Q2PSaturationFlux.h
@@ -62,17 +62,11 @@ protected:
   /// This simply calls upwind
   virtual void computeResidual();
 
-  /// Not used.  I use computeQpJac instead.
-  virtual Real computeQpJacobian();
-
-  /// Not used.  I use computeQpJac instead.
+  /// this simply calls upwind
   virtual void computeOffDiagJacobian(unsigned int jvar);
 
   /// this simply calls upwind
   virtual void computeJacobian();
-
-  /// this simply calls upwind
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// the derivative of the flux without the upstream mobility terms
   Real computeQpJac(unsigned int dvar);

--- a/modules/richards/include/kernels/RichardsFullyUpwindFlux.h
+++ b/modules/richards/include/kernels/RichardsFullyUpwindFlux.h
@@ -63,17 +63,8 @@ protected:
   /// This simply calls upwind
   virtual void computeResidual();
 
-  /// Not used.  I use computeQpJac instead.
-  virtual Real computeQpJacobian();
-
-  /// Not used.  I use computeQpJac instead.
+  /// this simply calls upwind
   virtual void computeOffDiagJacobian(unsigned int jvar);
-
-  /// this simply calls upwind
-  virtual void computeJacobian();
-
-  /// this simply calls upwind
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// the derivative of the flux without the upstream mobility terms
   Real computeQpJac(unsigned int dvar);

--- a/modules/richards/src/kernels/Q2PPorepressureFlux.C
+++ b/modules/richards/src/kernels/Q2PPorepressureFlux.C
@@ -88,23 +88,6 @@ Q2PPorepressureFlux::computeResidual()
   upwind(true, false, 0);
 }
 
-
-Real
-Q2PPorepressureFlux::computeQpJacobian()
-{
-  // not used.  I use computeQpJac instead
-  return 0.0;
-}
-
-
-Real
-Q2PPorepressureFlux::computeQpOffDiagJacobian(unsigned int /*jvar*/)
-{
-  // not used.  I use computeQpJac instead
-  return 0.0;
-}
-
-
 void
 Q2PPorepressureFlux::computeJacobian()
 {
@@ -292,7 +275,7 @@ Q2PPorepressureFlux::upwind(bool compute_res, bool compute_jac, unsigned int jva
 
     if (_has_diag_save_in && jvar == _var.number())
     {
-      unsigned int rows = ke.m();
+      const unsigned int rows = ke.m();
       DenseVector<Number> diag(rows);
       for (unsigned int i = 0; i < rows; i++)
         diag(i) = _local_ke(i,i);

--- a/modules/richards/src/kernels/Q2PSaturationFlux.C
+++ b/modules/richards/src/kernels/Q2PSaturationFlux.C
@@ -91,22 +91,6 @@ Q2PSaturationFlux::computeResidual()
 }
 
 
-Real
-Q2PSaturationFlux::computeQpJacobian()
-{
-  // not used.  I use computeQpJac instead
-  return 0.0;
-}
-
-
-Real
-Q2PSaturationFlux::computeQpOffDiagJacobian(unsigned int /*jvar*/)
-{
-  // not used.  I use computeQpJac instead
-  return 0.0;
-}
-
-
 void
 Q2PSaturationFlux::computeJacobian()
 {
@@ -294,7 +278,7 @@ Q2PSaturationFlux::upwind(bool compute_res, bool compute_jac, unsigned int jvar)
 
     if (_has_diag_save_in && jvar == _var.number())
     {
-      unsigned int rows = ke.m();
+      const unsigned int rows = ke.m();
       DenseVector<Number> diag(rows);
       for (unsigned int i = 0; i < rows; i++)
         diag(i) = _local_ke(i,i);

--- a/modules/richards/src/kernels/RichardsFullyUpwindFlux.C
+++ b/modules/richards/src/kernels/RichardsFullyUpwindFlux.C
@@ -97,30 +97,6 @@ RichardsFullyUpwindFlux::computeResidual()
 }
 
 
-Real
-RichardsFullyUpwindFlux::computeQpJacobian()
-{
-  // not used.  I use computeQpJac instead
-  return 0.0;
-}
-
-
-Real
-RichardsFullyUpwindFlux::computeQpOffDiagJacobian(unsigned int /*jvar*/)
-{
-  // not used.  I use computeQpJac instead
-  return 0.0;
-}
-
-
-void
-RichardsFullyUpwindFlux::computeJacobian()
-{
-  upwind(false, true, _var.number());
-  return;
-}
-
-
 void
 RichardsFullyUpwindFlux::computeOffDiagJacobian(unsigned int jvar)
 {
@@ -161,12 +137,10 @@ RichardsFullyUpwindFlux::upwind(bool compute_res, bool compute_jac, unsigned int
       _local_re(_i) += _JxW[_qp] * _coord[_qp] * computeQpResidual();
 
 
-  unsigned int dvar;
+  const unsigned int dvar = _richards_name_UO.richards_var_num(jvar);
   DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
   if (compute_jac)
   {
-    dvar = _richards_name_UO.richards_var_num(jvar);
-
     _local_ke.resize(ke.m(), ke.n());
     _local_ke.zero();
 
@@ -301,7 +275,7 @@ RichardsFullyUpwindFlux::upwind(bool compute_res, bool compute_jac, unsigned int
 
     if (_has_diag_save_in && dvar == _pvar)
     {
-      unsigned int rows = ke.m();
+      const unsigned int rows = ke.m();
       DenseVector<Number> diag(rows);
       for (unsigned int i = 0; i < rows; i++)
         diag(i) = _local_ke(i,i);

--- a/modules/richards/src/kernels/RichardsLumpedMassChange.C
+++ b/modules/richards/src/kernels/RichardsLumpedMassChange.C
@@ -53,31 +53,16 @@ Real
 RichardsLumpedMassChange::computeQpResidual()
 {
   // current values:
-  Real density = (*_density_UO).density((*_ps_at_nodes[_pvar])[_i]);
-  Real seff = (*_seff_UO).seff(_ps_at_nodes, _i);
-  Real sat = (*_sat_UO).sat(seff);
-  Real mass = _porosity[_qp]*density*sat;
-
+  const Real density = (*_density_UO).density((*_ps_at_nodes[_pvar])[_i]);
+  const Real seff = (*_seff_UO).seff(_ps_at_nodes, _i);
+  const Real sat = (*_sat_UO).sat(seff);
+  const Real mass = _porosity[_qp]*density*sat;
 
   // old values:
-  // for snes_type = test (and perhaps others?) the Old values
-  // aren't defined for some reason
-  // hence all the fluffing around with checking of sizes
-  Real density_old;
-  Real seff_old;
-  if ((*_ps_old_at_nodes[0]).size() <= _i)
-  {
-    density_old = (*_density_UO).density((*_ps_at_nodes[_pvar])[_i]);
-    seff_old = (*_seff_UO).seff(_ps_at_nodes, _i);
-  }
-  else
-  {
-    density_old = (*_density_UO).density((*_ps_old_at_nodes[_pvar])[_i]);
-    seff_old = (*_seff_UO).seff(_ps_old_at_nodes, _i);
-  }
-  Real sat_old = (*_sat_UO).sat(seff_old);
-  Real mass_old = _porosity_old[_qp]*density_old*sat_old;
-
+  const Real density_old = (*_density_UO).density((*_ps_old_at_nodes[_pvar])[_i]);
+  const Real seff_old = (*_seff_UO).seff(_ps_old_at_nodes, _i);
+  const Real sat_old = (*_sat_UO).sat(seff_old);
+  const Real mass_old = _porosity_old[_qp]*density_old*sat_old;
 
   return _test[_i][_qp]*(mass - mass_old)/_dt;
 }
@@ -89,16 +74,16 @@ RichardsLumpedMassChange::computeQpJacobian()
   if (_i != _j)
     return 0.0;
 
-  Real density = (*_density_UO).density((*_ps_at_nodes[_pvar])[_i]);
-  Real ddensity = (*_density_UO).ddensity((*_ps_at_nodes[_pvar])[_i]);
+  const Real density = (*_density_UO).density((*_ps_at_nodes[_pvar])[_i]);
+  const Real ddensity = (*_density_UO).ddensity((*_ps_at_nodes[_pvar])[_i]);
 
-  Real seff = (*_seff_UO).seff(_ps_at_nodes, _i);
+  const Real seff = (*_seff_UO).seff(_ps_at_nodes, _i);
   (*_seff_UO).dseff(_ps_at_nodes, _i, _dseff);
 
-  Real sat = (*_sat_UO).sat(seff);
-  Real dsat = (*_sat_UO).dsat(seff);
+  const Real sat = (*_sat_UO).sat(seff);
+  const Real dsat = (*_sat_UO).dsat(seff);
 
-  Real mass_prime = _porosity[_qp]*(ddensity*sat + density*_dseff[_pvar]*dsat);
+  const Real mass_prime = _porosity[_qp]*(ddensity*sat + density*_dseff[_pvar]*dsat);
 
   return _test[_i][_qp]*mass_prime/_dt;
 }
@@ -112,16 +97,16 @@ RichardsLumpedMassChange::computeQpOffDiagJacobian(unsigned int jvar)
     return 0.0;
   if (_i != _j)
     return 0.0;
-  unsigned int dvar = _richards_name_UO.richards_var_num(jvar);
+  const unsigned int dvar = _richards_name_UO.richards_var_num(jvar);
 
-  Real density = (*_density_UO).density((*_ps_at_nodes[_pvar])[_i]);
+  const Real density = (*_density_UO).density((*_ps_at_nodes[_pvar])[_i]);
 
-  Real seff = (*_seff_UO).seff(_ps_at_nodes, _i);
+  const Real seff = (*_seff_UO).seff(_ps_at_nodes, _i);
   (*_seff_UO).dseff(_ps_at_nodes, _i, _dseff);
 
-  Real dsat = (*_sat_UO).dsat(seff);
+  const Real dsat = (*_sat_UO).dsat(seff);
 
-  Real mass_prime = _porosity[_qp]*density*_dseff[dvar]*dsat;
+  const Real mass_prime = _porosity[_qp]*density*_dseff[dvar]*dsat;
 
   return _test[_i][_qp]*mass_prime/_dt;
 }

--- a/modules/richards/tests/jacobian_1/jn17.i
+++ b/modules/richards/tests/jacobian_1/jn17.i
@@ -1,33 +1,24 @@
-# unsaturated = false
-# gravity = false
-# supg = false
-# transient = false
+# unsaturated = true
+# gravity = true
+# supg = true
+# transient = true with supg
 
 [Mesh]
   type = GeneratedMesh
-  dim = 1
+  dim = 3
   nx = 1
+  ny = 1
+  nz = 1
   xmin = -1
   xmax = 1
+  ymin = -1
+  ymax = 1
+  zmin = -1
+  zmax = 1
 []
-
-[BCs]
-  [./left]
-    type = DirichletBC
-    boundary = left
-    value = 1
-    variable = pressure
-  [../]
-[]
-
 
 [GlobalParams]
   richardsVarNames_UO = PPNames
-  density_UO = DensityConstBulk
-  relperm_UO = RelPermPower
-  SUPG_UO = SUPGnone
-  sat_UO = Saturation
-  seff_UO = SeffVG
 []
 
 [UserObjects]
@@ -38,16 +29,16 @@
   [./DensityConstBulk]
     type = RichardsDensityConstBulk
     dens0 = 1
-    bulk_mod = 1.0E3
+    bulk_mod = 1.0 # notice small quantity, so the PETSc constant state works
   [../]
   [./SeffVG]
     type = RichardsSeff1VG
     m = 0.8
-    al = 1
+    al = 1 # notice small quantity, so the PETSc constant state works
   [../]
   [./RelPermPower]
     type = RichardsRelPermPower
-    simm = 0.0
+    simm = 0.2
     n = 2
   [../]
   [./Saturation]
@@ -55,8 +46,9 @@
     s_res = 0.1
     sum_s_res = 0.1
   [../]
-  [./SUPGnone]
-    type = RichardsSUPGnone
+  [./SUPGstandard]
+    type = RichardsSUPGstandard
+    p_SUPG = 0.1
   [../]
 []
 
@@ -67,31 +59,23 @@
     [./InitialCondition]
       type = RandomIC
       block = 0
-      min = 0
-      max = 1
+      min = -1
+      max = 0
     [../]
   [../]
 []
 
-[AuxVariables]
-  [./RFUF_Residual]
-  [../]
-  [./RFUF_Jacobian]
-  [../]
-[]
 
 [Kernels]
-  active = 'richardsf'
+  active = 'richardsf richardst'
   [./richardst]
     type = RichardsMassChange
     variable = pressure
+    use_supg = true
   [../]
   [./richardsf]
-    type = RichardsFullyUpwindFlux
-    richardsVarNames_UO = PPNames
+    type = RichardsFlux
     variable = pressure
-    save_in = RFUF_Residual
-    diag_save_in = RFUF_Jacobian
   [../]
 []
 
@@ -101,8 +85,13 @@
     block = 0
     mat_porosity = 0.1
     mat_permeability = '1E-5 0 0  0 1E-5 0  0 0 1E-5'
+    density_UO = DensityConstBulk
+    relperm_UO = RelPermPower
+    SUPG_UO = SUPGstandard
+    sat_UO = Saturation
+    seff_UO = SeffVG
     viscosity = 1E-3
-    gravity = '0 0 0'
+    gravity = '1 2 3'
     linear_shape_fcns = true
   [../]
 []
@@ -112,21 +101,19 @@
   [./andy]
     type = SMP
     full = true
-    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
-    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000'
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
   [../]
 []
 
 [Executioner]
-  type = Steady
+  type = Transient
   solve_type = Newton
+  dt = 1E-5
 []
 
 [Outputs]
   execute_on = 'timestep_end'
-  file_base = gh_fu_01
-  [./Exodus]
-    hide = 'RFUF_Residual RFUF_Jacobian'
-    type = Exodus
-  [../]
+  file_base = jn16
+  exodus = false
 []

--- a/modules/richards/tests/jacobian_1/tests
+++ b/modules/richards/tests/jacobian_1/tests
@@ -95,6 +95,12 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
   [../]
+  [./jn17]
+    type = 'PetscJacobianTester'
+    input = 'jn17.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+  [../]
 
   [./jn_lumped_16]
     type = 'PetscJacobianTester'

--- a/modules/richards/tests/jacobian_2/jnQ2P.i
+++ b/modules/richards/tests/jacobian_2/jnQ2P.i
@@ -66,6 +66,8 @@
       max = 1
     [../]
   [../]
+  [./nonQ2P_var]
+  []
 []
 
 [Q2P]
@@ -80,6 +82,15 @@
   gas_viscosity = 1
   diffusivity = 1E-2
 []
+
+[Kernels]
+  [./nonQ2P_variable_check]
+    type = BodyForce
+    variable = nonQ2P_var
+    function = 0
+  [../]
+[]
+
 
 [Materials]
   [./rock]

--- a/modules/richards/tests/jacobian_2/jn_fu_01.i
+++ b/modules/richards/tests/jacobian_2/jn_fu_01.i
@@ -102,11 +102,13 @@
       max = 1
     [../]
   [../]
+  [./non_Richards]
+  [../]
 []
 
 
 [Kernels]
-  active = 'richardsfwater richardsfgas'
+  active = 'richardsfwater richardsfgas non_Richards_should_have_0_off_diag'
   [./richardstwater]
     type = RichardsMassChange
     variable = pwater
@@ -122,6 +124,11 @@
   [./richardsfgas]
     type = RichardsFullyUpwindFlux
     variable = pgas
+  [../]
+  [./non_Richards_should_have_0_off_diag]
+    type = BodyForce
+    variable = non_Richards
+    function = 0
   [../]
 []
 

--- a/modules/richards/tests/sinks/q2p01.i
+++ b/modules/richards/tests/sinks/q2p01.i
@@ -63,6 +63,10 @@
   gas_viscosity = 0.5
   diffusivity = 0.0
   output_total_masses_to = 'CSV'
+  save_gas_flux_in_Q2PGasFluxResidual = true
+  save_water_flux_in_Q2PWaterFluxResidual = true
+  save_gas_Jacobian_in_Q2PGasJacobian = true
+  save_water_Jacobian_in_Q2PWaterJacobian = true
 []
 
 [Postprocessors]


### PR DESCRIPTION
Put some "consts" in a variety of places.
Enhanced Q2PAction to allow the user to specify whether she'd like to output Residuals and Jacobians from the Q2P Kernels.
This also allowed more full testing of those Q2P Kernels.
Quite minor changes to various input files to increase test coverage by adding save_in and diag_save_in, and the like.

Refs #6402
