### PR TITLE
Frictional contact damper

### DIFF
--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -262,10 +262,12 @@ public:
 
   /**
    * Compute damping
-   * @param update
+   * @param solution The trail solution vector
+   * @param update The incremental update to the solution vector
    * @return returns The damping factor
    */
-  Real computeDamping(const NumericVector<Number>& update);
+  Real computeDamping(const NumericVector<Number> & solution,
+                      const NumericVector<Number> & update);
 
   /**
    * Computes the time derivative vector

--- a/framework/include/dampers/ConstantDamper.h
+++ b/framework/include/dampers/ConstantDamper.h
@@ -39,7 +39,8 @@ protected:
   /**
    * Return the constant damping value.
    */
-  virtual Real computeDamping(const NumericVector<Number> & update);
+  virtual Real computeDamping(const NumericVector<Number> & solution,
+                              const NumericVector<Number> & update);
 
   /// The constant amount of the Newton update to take.
   Real _damping;

--- a/framework/include/dampers/GeneralDamper.h
+++ b/framework/include/dampers/GeneralDamper.h
@@ -40,7 +40,8 @@ public:
   /**
    * Computes this Damper's damping
    */
-  virtual Real computeDamping(const NumericVector<Number> & update) = 0;
+  virtual Real computeDamping(const NumericVector<Number> & solution,
+                              const NumericVector<Number> & update) = 0;
 };
 
 #endif //GENERALDAMPER_H

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3544,7 +3544,7 @@ FEProblem::computeDamping(const NumericVector<Number>& soln, const NumericVector
     //   values.  Once more complete dependency checking is in place, auxiliary variables (and
     //   material properties) will be computed as needed by dampers.
 //    _aux.compute();
-    damping = _nl.computeDamping(update);
+    damping = _nl.computeDamping(soln, update);
 
     // restore saved solution
     _nl.setSolution(*_saved_current_solution);

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -2212,7 +2212,8 @@ NonlinearSystem::updateActive(THREAD_ID tid)
 }
 
 Real
-NonlinearSystem::computeDamping(const NumericVector<Number> & update)
+NonlinearSystem::computeDamping(const NumericVector<Number> & solution,
+                                const NumericVector<Number> & update)
 {
   Moose::perf_log.push("compute_dampers()", "Execution");
 
@@ -2232,7 +2233,7 @@ NonlinearSystem::computeDamping(const NumericVector<Number> & update)
     const std::vector<MooseSharedPointer<GeneralDamper> > & gdampers = _general_dampers.getActiveObjects();
     for (std::vector<MooseSharedPointer<GeneralDamper> >::const_iterator it = gdampers.begin(); it != gdampers.end(); ++it)
     {
-      Real gd_damping = (*it)->computeDamping(update);
+      Real gd_damping = (*it)->computeDamping(solution, update);
       if (gd_damping < damping)
         damping = gd_damping;
     }

--- a/framework/src/dampers/ConstantDamper.C
+++ b/framework/src/dampers/ConstantDamper.C
@@ -29,7 +29,8 @@ ConstantDamper::ConstantDamper(const InputParameters & parameters) :
 }
 
 Real
-ConstantDamper::computeDamping(const NumericVector<Number> & /*update*/)
+ConstantDamper::computeDamping(const NumericVector<Number> & /*solution*/,
+                               const NumericVector<Number> & /*update*/)
 {
   return _damping;
 }

--- a/modules/combined/tests/frictional_contact/single_point_2d/gold/single_point_2d_fcp_out.e
+++ b/modules/combined/tests/frictional_contact/single_point_2d/gold/single_point_2d_fcp_out.e
@@ -1,0 +1,1 @@
+single_point_2d_out.e

--- a/modules/combined/tests/frictional_contact/single_point_2d/gold/single_point_2d_fcp_predictor_out.e
+++ b/modules/combined/tests/frictional_contact/single_point_2d/gold/single_point_2d_fcp_predictor_out.e
@@ -1,0 +1,1 @@
+single_point_2d_out.e

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d.i
@@ -52,19 +52,19 @@
 []
 
 [AuxKernels]
-  [./zeroslip_x]
-    type = ConstantAux
+  [./incslip_x]
+    type = PenetrationAux
     variable = inc_slip_x
+    quantity = incremental_slip_x
     boundary = 3
-    execute_on = timestep_begin
-    value = 0.0
+    paired_boundary = 2
   [../]
-  [./zeroslip_y]
-    type = ConstantAux
+  [./incslip_y]
+    type = PenetrationAux
     variable = inc_slip_y
+    quantity = incremental_slip_y
     boundary = 3
-    execute_on = timestep_begin
-    value = 0.0
+    paired_boundary = 2
   [../]
   [./accum_slip_x]
     type = AccumulateAux
@@ -185,8 +185,8 @@
 
 
 
-  petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
-  petsc_options_value = 'hypre    boomeramg      101'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
+  petsc_options_value = 'lu    superlu_dist'
 
 
   line_search = 'none'
@@ -205,6 +205,8 @@
 [Outputs]
   file_base = single_point_2d_out
   exodus = true
+  print_linear_residuals = true
+  print_perf_log = true
   [./console]
     type = Console
     max_rows = 5
@@ -217,30 +219,16 @@
     slave = 3
     disp_y = disp_y
     disp_x = disp_x
-    model = glued
+    model = coulomb
+    system = constraint
+    friction_coefficient = '0.25'
   [../]
 []
 
-[Problem]
-  type = FrictionalContactProblem
-  master = '2'
-  slave = '3'
-  friction_coefficient = '0.25'
-  slip_factor = '1.0'
-  slip_too_far_factor = '1.0'
-  disp_x = disp_x
-  disp_y = disp_y
-  residual_x = saved_x
-  residual_y = saved_y
-  diag_stiff_x = diag_saved_x
-  diag_stiff_y = diag_saved_y
-  inc_slip_x = inc_slip_x
-  inc_slip_y = inc_slip_y
-  contact_slip_tolerance_factor = 100.
-  target_relative_contact_residual = 1.e-8
-  maximum_slip_iterations = 50
-  minimum_slip_iterations = 1
-  slip_updates_per_iteration = 5
-  solution_variables = 'disp_x disp_y'
-  reference_residual_variables = 'saved_x saved_y'
+[Dampers]
+  [./contact_slip]
+    type = ContactSlipDamper
+    master = '2'
+    slave = '3'
+  [../]
 []

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_fcp.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_fcp.i
@@ -52,19 +52,19 @@
 []
 
 [AuxKernels]
-  [./incslip_x]
-    type = PenetrationAux
+  [./zeroslip_x]
+    type = ConstantAux
     variable = inc_slip_x
-    quantity = incremental_slip_x
     boundary = 3
-    paired_boundary = 2
+    execute_on = timestep_begin
+    value = 0.0
   [../]
-  [./incslip_y]
-    type = PenetrationAux
+  [./zeroslip_y]
+    type = ConstantAux
     variable = inc_slip_y
-    quantity = incremental_slip_y
     boundary = 3
-    paired_boundary = 2
+    execute_on = timestep_begin
+    value = 0.0
   [../]
   [./accum_slip_x]
     type = AccumulateAux
@@ -200,15 +200,10 @@
   nl_abs_tol = 1e-8
   dtmin = 0.001
   l_tol = 1e-3
-
-  [./Predictor]
-    type = SimplePredictor
-    scale = 1.0
-  [../]
 []
 
 [Outputs]
-  file_base = single_point_2d_predictor_out
+  file_base = single_point_2d_fcp_out
   exodus = true
   print_linear_residuals = true
   print_perf_log = true
@@ -226,14 +221,29 @@
     disp_x = disp_x
     model = coulomb
     system = constraint
-    friction_coefficient = '0.25'
   [../]
 []
 
-[Dampers]
-  [./contact_slip]
-    type = ContactSlipDamper
-    master = '2'
-    slave = '3'
-  [../]
+[Problem]
+  type = FrictionalContactProblem
+  master = '2'
+  slave = '3'
+  friction_coefficient = '0.25'
+  slip_factor = '1.0'
+  slip_too_far_factor = '1.0'
+  disp_x = disp_x
+  disp_y = disp_y
+  residual_x = saved_x
+  residual_y = saved_y
+  diag_stiff_x = diag_saved_x
+  diag_stiff_y = diag_saved_y
+  inc_slip_x = inc_slip_x
+  inc_slip_y = inc_slip_y
+  contact_slip_tolerance_factor = 100.
+  target_relative_contact_residual = 1.e-8
+  maximum_slip_iterations = 50
+  minimum_slip_iterations = 1
+  slip_updates_per_iteration = 5
+  solution_variables = 'disp_x disp_y'
+  reference_residual_variables = 'saved_x saved_y'
 []

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_fcp_predictor.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_fcp_predictor.i
@@ -52,19 +52,19 @@
 []
 
 [AuxKernels]
-  [./incslip_x]
-    type = PenetrationAux
+  [./zeroslip_x]
+    type = ConstantAux
     variable = inc_slip_x
-    quantity = incremental_slip_x
     boundary = 3
-    paired_boundary = 2
+    execute_on = timestep_begin
+    value = 0.0
   [../]
-  [./incslip_y]
-    type = PenetrationAux
+  [./zeroslip_y]
+    type = ConstantAux
     variable = inc_slip_y
-    quantity = incremental_slip_y
     boundary = 3
-    paired_boundary = 2
+    execute_on = timestep_begin
+    value = 0.0
   [../]
   [./accum_slip_x]
     type = AccumulateAux
@@ -208,7 +208,7 @@
 []
 
 [Outputs]
-  file_base = single_point_2d_predictor_out
+  file_base = single_point_2d_fcp_predictor_out
   exodus = true
   print_linear_residuals = true
   print_perf_log = true
@@ -226,14 +226,29 @@
     disp_x = disp_x
     model = coulomb
     system = constraint
-    friction_coefficient = '0.25'
   [../]
 []
 
-[Dampers]
-  [./contact_slip]
-    type = ContactSlipDamper
-    master = '2'
-    slave = '3'
-  [../]
+[Problem]
+  type = FrictionalContactProblem
+  master = '2'
+  slave = '3'
+  friction_coefficient = '0.25'
+  slip_factor = '1.0'
+  slip_too_far_factor = '1.0'
+  disp_x = disp_x
+  disp_y = disp_y
+  residual_x = saved_x
+  residual_y = saved_y
+  diag_stiff_x = diag_saved_x
+  diag_stiff_y = diag_saved_y
+  inc_slip_x = inc_slip_x
+  inc_slip_y = inc_slip_y
+  contact_slip_tolerance_factor = 100.
+  target_relative_contact_residual = 1.e-8
+  maximum_slip_iterations = 50
+  minimum_slip_iterations = 1
+  slip_updates_per_iteration = 5
+  solution_variables = 'disp_x disp_y'
+  reference_residual_variables = 'saved_x saved_y'
 []

--- a/modules/combined/tests/frictional_contact/single_point_2d/tests
+++ b/modules/combined/tests/frictional_contact/single_point_2d/tests
@@ -4,13 +4,28 @@
     input = 'single_point_2d.i'
     exodiff = 'single_point_2d_out.e'
     custom_cmp = 'single_point_2d.cmp'
-    max_parallel = 1
+    superlu = true
+  [../]
+  [./fcp]
+    type = 'Exodiff'
+    input = 'single_point_2d_fcp.i'
+    exodiff = 'single_point_2d_fcp_out.e'
+    custom_cmp = 'single_point_2d.cmp'
+    superlu = true
   [../]
   [./predictor]
     type = 'Exodiff'
     input = 'single_point_2d_predictor.i'
     exodiff = 'single_point_2d_predictor_out.e'
     custom_cmp = 'single_point_2d.cmp'
+    superlu = true
+  [../]
+  [./fcp_predictor]
+    type = 'Exodiff'
+    input = 'single_point_2d_fcp_predictor.i'
+    exodiff = 'single_point_2d_fcp_predictor_out.e'
+    custom_cmp = 'single_point_2d.cmp'
+    superlu = true
     max_parallel = 1
   [../]
 []

--- a/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
+++ b/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
@@ -259,3 +259,11 @@
     penalty = 1e6
   [../]
 []
+
+[Dampers]
+  [./contact_slip]
+    type = ContactSlipDamper
+    master = '2'
+    slave = '3'
+  [../]
+[]

--- a/modules/contact/include/ContactSlipDamper.h
+++ b/modules/contact/include/ContactSlipDamper.h
@@ -48,7 +48,7 @@ protected:
    */
   bool operateOnThisInteraction(const PenetrationLocator & pen_loc);
 
-  std::set<std::pair<int,int> > _interactions;
+  std::set<std::pair<int, int> > _interactions;
 
   int _num_contact_nodes;
   int _num_sticking;
@@ -56,8 +56,6 @@ protected:
   int _num_slipping_friction;
   int _num_stick_locked;
   int _num_slip_reversed;
-  Real _inc_slip_norm;
-  Real _it_slip_norm;
   Real _max_iterative_slip;
   Real _min_damping_factor;
   Real _damping_threshold_factor;

--- a/modules/contact/include/ContactSlipDamper.h
+++ b/modules/contact/include/ContactSlipDamper.h
@@ -1,0 +1,70 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef CONTACTSLIPDAMPER_H
+#define CONTACTSLIPDAMPER_H
+
+// Moose Includes
+#include "GeneralDamper.h"
+
+//Forward Declarations
+class ContactSlipDamper;
+class AuxiliarySystem;
+class DisplacedProblem;
+class PenetrationLocator;
+
+template<>
+InputParameters validParams<ContactSlipDamper>();
+
+/**
+ * Simple constant damper.
+ *
+ * Modifies the non-linear step by applying a constant damping factor
+ */
+class ContactSlipDamper : public GeneralDamper
+{
+public:
+  ContactSlipDamper(const InputParameters & parameters);
+
+  virtual void timestepSetup();
+
+protected:
+  AuxiliarySystem & _aux_sys;
+  MooseSharedPointer<DisplacedProblem> _displaced_problem;
+
+  /**
+   * Compute the amount of damping
+   */
+  virtual Real computeDamping(const NumericVector<Number> & solution,
+                              const NumericVector<Number> & update);
+
+  /**
+   * Determine whether the damper should operate on the interaction corresponding to the supplied
+   * PenetrationLocator.
+   */
+  bool operateOnThisInteraction(const PenetrationLocator & pen_loc);
+
+  std::set<std::pair<int,int> > _interactions;
+
+  int _num_contact_nodes;
+  int _num_sticking;
+  int _num_slipping;
+  int _num_slipping_friction;
+  int _num_stick_locked;
+  int _num_slip_reversed;
+  Real _inc_slip_norm;
+  Real _it_slip_norm;
+  Real _max_iterative_slip;
+  Real _min_damping_factor;
+  Real _damping_threshold_factor;
+  bool _debug_output;
+
+  /// Convenient typedef for frequently used iterator
+  typedef std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator pl_iterator;
+};
+
+#endif //CONTACTSLIPDAMPER_H

--- a/modules/contact/src/ContactSlipDamper.C
+++ b/modules/contact/src/ContactSlipDamper.C
@@ -1,0 +1,224 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "ContactSlipDamper.h"
+#include "FEProblem.h"
+#include "DisplacedProblem.h"
+#include "AuxiliarySystem.h"
+#include "PenetrationLocator.h"
+#include "NearestNodeLocator.h"
+
+template<>
+InputParameters validParams<ContactSlipDamper>()
+{
+  InputParameters params = validParams<GeneralDamper>();
+  params.addRequiredParam<std::vector<int> >("master", "IDs of the master surfaces for which slip reversals should be damped");
+  params.addRequiredParam<std::vector<int> >("slave", "IDs of the slave surfaces for which slip reversals should be damped");
+  params.addParam<Real>("max_iterative_slip", std::numeric_limits<Real>::max(), "Maximum iterative slip");
+  params.addRangeCheckedParam<Real>("min_damping_factor", 0.0, "min_damping_factor < 1.0", "Minimum permissible value for damping factor");
+  params.addParam<Real>("damping_threshold_factor", 1.0e3, "If previous iterations's slip is below the slip tolerance, only damp a slip reversal if the slip magnitude is greater than than this factor times the old slip.");
+  params.addParam<bool>("debug_output", false, "Output detailed debugging information");
+  return params;
+}
+
+ContactSlipDamper::ContactSlipDamper(const InputParameters & parameters) :
+    GeneralDamper(parameters),
+    _aux_sys(parameters.get<FEProblem *>("_fe_problem")->getAuxiliarySystem()),
+    _displaced_problem(parameters.get<FEProblem *>("_fe_problem")->getDisplacedProblem()),
+    _num_contact_nodes(0),
+    _num_sticking(0),
+    _num_slipping(0),
+    _num_slipping_friction(0),
+    _num_stick_locked(0),
+    _num_slip_reversed(0),
+    _max_iterative_slip(parameters.get<Real>("max_iterative_slip")),
+    _min_damping_factor(parameters.get<Real>("min_damping_factor")),
+    _damping_threshold_factor(parameters.get<Real>("damping_threshold_factor")),
+    _debug_output(parameters.get<bool>("debug_output"))
+{
+  if (!_displaced_problem)
+    mooseError("Must have displaced problem to use ContactSlipDamper");
+
+  std::vector<int> master = parameters.get<std::vector<int> >("master");
+  std::vector<int> slave = parameters.get<std::vector<int> >("slave");
+
+  unsigned int num_interactions = master.size();
+  if (num_interactions != slave.size())
+    mooseError("Sizes of master surface and slave surface lists must match in ContactSlipDamper");
+  if (num_interactions == 0)
+    mooseError("Must define at least one master/slave pair in ContactSlipDamper");
+
+  for (unsigned int i = 0; i < master.size(); ++i)
+  {
+    std::pair<int, int> ms_pair(master[i], slave[i]);
+    _interactions.insert(ms_pair);
+  }
+}
+
+void
+ContactSlipDamper::timestepSetup()
+{
+  GeometricSearchData & displaced_geom_search_data = _displaced_problem->geomSearchData();
+  std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators = &displaced_geom_search_data._penetration_locators;
+
+  for (pl_iterator plit = penetration_locators->begin(); plit != penetration_locators->end(); ++plit)
+  {
+    PenetrationLocator & pen_loc = *plit->second;
+
+    if (operateOnThisInteraction(pen_loc))
+    {
+      std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
+
+      for (unsigned int i = 0; i < slave_nodes.size(); i++)
+      {
+        dof_id_type slave_node_num = slave_nodes[i];
+
+        if (pen_loc._penetration_info[slave_node_num])
+        {
+          PenetrationInfo & info = *pen_loc._penetration_info[slave_node_num];
+          const Node * node = info._node;
+
+          if (node->processor_id() == processor_id())
+//              && info.isCaptured())                  //TODO maybe just set this everywhere?
+            info._slip_reversed = false;
+        }
+      }
+    }
+  }
+}
+
+Real
+ContactSlipDamper::computeDamping(const NumericVector<Number> & solution,
+                                  const NumericVector<Number> & /*update*/)
+{
+  //Do new contact search to update positions of slipped nodes
+  _displaced_problem->updateMesh(solution, *_aux_sys.currentSolution());
+
+  Real damping = 1.0;
+
+  _num_contact_nodes = 0;
+  _num_sticking = 0;
+  _num_slipping = 0;
+  _num_slipping_friction = 0;
+  _num_stick_locked = 0;
+  _num_slip_reversed = 0;
+
+  GeometricSearchData & displaced_geom_search_data = _displaced_problem->geomSearchData();
+  std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators = &displaced_geom_search_data._penetration_locators;
+
+  for (pl_iterator plit = penetration_locators->begin(); plit != penetration_locators->end(); ++plit)
+  {
+    PenetrationLocator & pen_loc = *plit->second;
+
+    if (operateOnThisInteraction(pen_loc))
+    {
+      std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
+
+      for (unsigned int i = 0; i < slave_nodes.size(); i++)
+      {
+        dof_id_type slave_node_num = slave_nodes[i];
+
+        if (pen_loc._penetration_info[slave_node_num])
+        {
+          PenetrationInfo & info = *pen_loc._penetration_info[slave_node_num];
+          const Node * node = info._node;
+
+          if (node->processor_id() == processor_id())
+          {
+            if (info.isCaptured())
+            {
+              _num_contact_nodes++;
+              if (info._mech_status == PenetrationInfo::MS_STICKING)
+                _num_sticking++;
+              else if (info._mech_status == PenetrationInfo::MS_SLIPPING)
+                _num_slipping++;
+              else if (info._mech_status == PenetrationInfo::MS_SLIPPING_FRICTION)
+                _num_slipping_friction++;
+              if (info._stick_locked_this_step >= 2) //TODO get from contact interaction
+                _num_stick_locked++;
+
+              RealVectorValue tangential_inc_slip_prev_iter = info._incremental_slip_prev_iter -
+                                                              (info._incremental_slip_prev_iter * info._normal) * info._normal;
+              RealVectorValue tangential_inc_slip = info._incremental_slip -
+                                                    (info._incremental_slip * info._normal) * info._normal;
+
+              RealVectorValue tangential_it_slip = tangential_inc_slip - tangential_inc_slip_prev_iter;
+              Real node_damping_factor = 1.0;
+              if ((tangential_inc_slip_prev_iter * tangential_inc_slip < 0.0) &&
+                  info._mech_status == PenetrationInfo::MS_SLIPPING_FRICTION)
+              {
+                info._slip_reversed = true;
+                _num_slip_reversed++;
+                Real prev_iter_slip_mag = tangential_inc_slip_prev_iter.norm();
+                RealVectorValue prev_iter_slip_dir = tangential_inc_slip_prev_iter / prev_iter_slip_mag;
+                Real cur_it_slip_in_old_dir = tangential_it_slip * prev_iter_slip_dir;
+
+                if (prev_iter_slip_mag > info._slip_tol ||
+                    cur_it_slip_in_old_dir > -_damping_threshold_factor * prev_iter_slip_mag)
+                  node_damping_factor = 1.0 - (cur_it_slip_in_old_dir + prev_iter_slip_mag) / cur_it_slip_in_old_dir;
+
+                if (node_damping_factor < 0.0)
+                  mooseError("Damping factor can't be negative");
+
+                if (node_damping_factor < _min_damping_factor)
+                  node_damping_factor = _min_damping_factor;
+              }
+
+              if (tangential_it_slip.norm() > _max_iterative_slip)
+                node_damping_factor = (tangential_it_slip.norm() - _max_iterative_slip) / tangential_it_slip.norm();
+
+              if (_debug_output && node_damping_factor < 1.0)
+                _console << "Damping node: " << node->id()
+                  << " prev iter slip: " << info._incremental_slip_prev_iter
+                  << " curr iter slip: "<< info._incremental_slip
+                  << " slip_tol: " << info._slip_tol
+                  << " damping factor: " << node_damping_factor
+                  << "\n";
+
+              if (node_damping_factor < damping)
+                damping = node_damping_factor;
+            }
+          }
+        }
+      }
+    }
+    _console << std::flush;
+    _communicator.sum(_num_contact_nodes);
+    _communicator.sum(_num_sticking);
+    _communicator.sum(_num_slipping);
+    _communicator.sum(_num_slipping_friction);
+    _communicator.sum(_num_stick_locked);
+    _communicator.sum(_num_slip_reversed);
+    _communicator.min(damping);
+  }
+
+  _console << "   ContactSlipDamper:   Damping  #Cont    #Stick     #Slip #SlipFric #StickLock  #SlipRev\n";
+
+  _console << std::setw(28) << damping
+           << std::setw(10) << _num_contact_nodes
+           << std::setw(10) << _num_sticking
+           << std::setw(10) << _num_slipping
+           << std::setw(10) << _num_slipping_friction
+           << std::setw(11) << _num_stick_locked
+           << std::setw(10) << _num_slip_reversed
+           << "\n\n";
+  _console << std::flush;
+
+  return damping;
+}
+
+bool
+ContactSlipDamper::operateOnThisInteraction(const PenetrationLocator & pen_loc)
+{
+  bool operate_on_this_interaction = false;
+  std::set<std::pair<int, int> >::iterator ipit;
+  std::pair<int, int> ms_pair(pen_loc._master_boundary, pen_loc._slave_boundary);
+  ipit = _interactions.find(ms_pair);
+  if (ipit != _interactions.end())
+    operate_on_this_interaction = true;
+  return operate_on_this_interaction;
+}

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -277,7 +277,6 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
           RealVectorValue contact_force_normal( (pinfo->_contact_force*pinfo->_normal) * pinfo->_normal );
           RealVectorValue contact_force_tangential( pinfo->_contact_force - contact_force_normal );
 
-          RealVectorValue tangential_inc_slip_prev_iter = pinfo->_incremental_slip_prev_iter - (pinfo->_incremental_slip_prev_iter * pinfo->_normal) * pinfo->_normal;
           RealVectorValue tangential_inc_slip = pinfo->_incremental_slip - (pinfo->_incremental_slip * pinfo->_normal) * pinfo->_normal;
 
           // Magnitude of tangential predictor force

--- a/modules/contact/src/base/ContactApp.C
+++ b/modules/contact/src/base/ContactApp.C
@@ -28,6 +28,7 @@
 #include "NodalArea.h"
 #include "NodalAreaAction.h"
 #include "NodalAreaVarAction.h"
+#include "ContactSlipDamper.h"
 
 template<>
 InputParameters validParams<ContactApp>()
@@ -76,6 +77,7 @@ ContactApp::registerObjects(Factory & factory)
   registerProblem(ReferenceResidualProblem);
   registerUserObject(NodalArea);
   registerAux(ContactPressureAux);
+  registerDamper(ContactSlipDamper);
 }
 
 // External entry point for dynamic syntax association


### PR DESCRIPTION
ref #6524

This PR has two commits: the commit that is in currently active PR #6528, and a second commit that adds a damper to limit slip reversals for frictional contact.

I'm submitting this now because I'd like to start a discussion on how to do this.  We shouldn't actually merge this until the other PR gets merged and I remove that first commit.

This damping capability is currently implemented in the `updateSolution()` method in `FrictionalContactDamperProblem` which derives from `Problem`.  It works, but I think this is ugly.  I'd much rather do this in a `Damper`.  The problem is that the current Damper objects are only called within an element loop.  I think that the right way to do this is to expand the current Damper system to include GeneralDampers and ElementDampers, just like UserObjects. My code here would go in a General Damper.  Thoughts? How big of a development would that be?
