### PR TITLE
Allow longer timeout for Valgrind Heavy Tests

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -62,7 +62,7 @@ class Tester(MooseObject):
     if mode == 'NORMAL':
       self.specs['max_time'] = self.specs['max_time'] * 2
     elif mode == 'HEAVY':
-      self.specs['max_time'] = self.specs['max_time'] * 4
+      self.specs['max_time'] = self.specs['max_time'] * 6
 
 
   # Override this method to tell the harness whether or not this test should run.


### PR DESCRIPTION
We are seeing several tests timeout in Valgrind Heavy mode. This
target runs once a day and is made for larger tests. I think it
may be reasonable to adjust the timeout a bit for these larger
tests. Currently it's set for 15 minutes, I'd like to push it to
25 mins.

refs #6159
