### PR TITLE
Limit image test to opt and oprof

### DIFF
--- a/test/tests/mesh_modifiers/image_subdomain/tests
+++ b/test/tests/mesh_modifiers/image_subdomain/tests
@@ -5,6 +5,7 @@
     input = image_2d.i
     exodiff = image_2d_out.e
     vtk = true
+    method = 'OPT OPROF' # This test is slow in debug b/c of calls to libMesh::MeshTools::libmesh_assert_valid_dof_ids
   [../]
   [./3d]
     # Test ability to read in a single 20x20x20 stack of images and assign subdomain ids based on image


### PR DESCRIPTION
This test is slow in debug b/c of calls to libMesh::MeshTools::libmesh_assert_valid_dof_ids
