### PR TITLE
Fixup subdomain boundary ID caching

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -384,7 +384,7 @@ public:
    * Getter/setter for the patch_size parameter.
    */
   void setPatchSize(const unsigned int patch_size);
-  unsigned int getPatchSize();
+  unsigned int getPatchSize() const;
 
   /**
    * Set the patch size update strategy
@@ -394,7 +394,7 @@ public:
   /**
    * Get the current patch update strategy.
    */
-  const MooseEnum & getPatchUpdateStrategy();
+  const MooseEnum & getPatchUpdateStrategy() const;
 
   /**
    * Get a (slightly inflated) processor bounding box.
@@ -423,18 +423,18 @@ public:
   /**
    * Calls print_info() on the underlying Mesh.
    */
-  void printInfo(std::ostream &os=libMesh::out);
+  void printInfo(std::ostream &os=libMesh::out) const;
 
   /**
    * Return list of blocks to which the given node belongs.
    */
-  std::set<SubdomainID> & getNodeBlockIds(const Node & node);
+  const std::set<SubdomainID> & getNodeBlockIds(const Node & node) const;
 
   /**
    * Return a writable reference to a vector of node IDs that belong
    * to nodeset_id.
    */
-  std::vector<dof_id_type> & getNodeList(boundary_id_type nodeset_id);
+  const std::vector<dof_id_type> & getNodeList(boundary_id_type nodeset_id) const;
 
   /**
    * Add a new node to the mesh.  If there is already a node located at the point passed
@@ -629,7 +629,7 @@ public:
    * @param subdomain_id The subdomain ID you want to get the boundary ids for.
    * @return All boundary IDs connected to elements in the give
    */
-  const std::set<unsigned int> & getSubdomainBoundaryIds(unsigned int subdomain_id);
+  const std::set<unsigned int> & getSubdomainBoundaryIds(unsigned int subdomain_id) const;
 
   /**
    * Returns true if the requested node is in the list of boundary

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -629,31 +629,31 @@ public:
    * @param subdomain_id The subdomain ID you want to get the boundary ids for.
    * @return All boundary IDs connected to elements in the give
    */
-  const std::set<unsigned int> & getSubdomainBoundaryIds(unsigned int subdomain_id) const;
+  const std::set<BoundaryID> & getSubdomainBoundaryIds(SubdomainID subdomain_id) const;
 
   /**
    * Returns true if the requested node is in the list of boundary
    * nodes, false otherwise.
    */
-  bool isBoundaryNode(dof_id_type node_id);
+  bool isBoundaryNode(dof_id_type node_id) const;
 
   /**
    * Returns true if the requested node is in the list of boundary
    * nodes for the specified boundary, false otherwise.
    */
-  bool isBoundaryNode(dof_id_type node_id, BoundaryID bnd_id);
+  bool isBoundaryNode(dof_id_type node_id, BoundaryID bnd_id) const;
 
   /**
    * Returns true if the requested element is in the list of boundary
    * elements, false otherwise.
    */
-  bool isBoundaryElem(dof_id_type elem_id);
+  bool isBoundaryElem(dof_id_type elem_id) const;
 
   /**
    * Returns true if the requested element is in the list of boundary
    * elements for the specified boundary, false otherwise.
    */
-  bool isBoundaryElem(dof_id_type elem_id, BoundaryID bnd_id);
+  bool isBoundaryElem(dof_id_type elem_id, BoundaryID bnd_id) const;
 
   /**
    * Generate a unified error message if the underlying libMesh mesh
@@ -973,7 +973,7 @@ private:
   std::map<std::pair<int, ElemType>, std::vector<std::pair<unsigned int, QpMap> > > _elem_type_to_coarsening_map;
 
   /// Holds a map from subomdain ids to the boundary ids that are attached to it
-  std::map<unsigned int, std::set<unsigned int> > _subdomain_boundary_ids;
+  std::map<SubdomainID, std::set<BoundaryID> > _subdomain_boundary_ids;
 
   /// Whether or not this Mesh is allowed to read a recovery file
   bool _allow_recovery;

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1720,8 +1720,8 @@ FEProblem::prepareMaterials(SubdomainID blk_id, THREAD_ID tid)
   if (_materials_base.hasActiveBlockObjects(blk_id, tid))
     _materials_base.updateVariableDependency(needed_moose_vars, tid);
 
-  const std::set<unsigned int> & ids = _mesh.getSubdomainBoundaryIds(blk_id);
-  for (std::set<unsigned int>::const_iterator it = ids.begin(); it != ids.end(); ++it)
+  const std::set<BoundaryID> & ids = _mesh.getSubdomainBoundaryIds(blk_id);
+  for (std::set<BoundaryID>::const_iterator it = ids.begin(); it != ids.end(); ++it)
     _materials.updateBoundaryVariableDependency(*it, needed_moose_vars, tid);
 
   const std::set<MooseVariable *> & current_active_elemental_moose_variables = getActiveElementalMooseVariables(tid);

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -716,6 +716,8 @@ void
 MooseMesh::cacheInfo()
 {
   const MeshBase::element_iterator end = getMesh().elements_end();
+
+  // TODO: Thread this!
   for (MeshBase::element_iterator el = getMesh().elements_begin(); el != end; ++el)
   {
     Elem * elem = *el;
@@ -726,8 +728,10 @@ MooseMesh::cacheInfo()
     {
       std::vector<BoundaryID> boundaryids = getBoundaryIDs(elem, side);
 
+      std::set<unsigned int> subdomain_set = _subdomain_boundary_ids[subdomain_id];
+
       for (unsigned int i=0; i<boundaryids.size(); i++)
-        _subdomain_boundary_ids[subdomain_id].insert(boundaryids[i]);
+        subdomain_set.insert(boundaryids[i]);
     }
 
     for (unsigned int nd = 0; nd < elem->n_nodes(); ++nd)
@@ -738,10 +742,10 @@ MooseMesh::cacheInfo()
   }
 }
 
-std::set<SubdomainID> &
-MooseMesh::getNodeBlockIds(const Node & node)
+const std::set<SubdomainID> &
+MooseMesh::getNodeBlockIds(const Node & node) const
 {
-  return _block_node_list[node.id()];
+  return _block_node_list.at(node.id());
 }
 
 
@@ -2088,7 +2092,7 @@ MooseMesh::setPatchSize(const unsigned int patch_size)
 }
 
 unsigned int
-MooseMesh::getPatchSize()
+MooseMesh::getPatchSize() const
 {
   return _patch_size;
 }
@@ -2100,7 +2104,7 @@ MooseMesh::setPatchUpdateStrategy(MooseEnum patch_update_strategy)
 }
 
 const MooseEnum &
-MooseMesh::getPatchUpdateStrategy()
+MooseMesh::getPatchUpdateStrategy() const
 {
   return _patch_update_strategy;
 }
@@ -2152,21 +2156,21 @@ MooseMesh::exReader() const
   return NULL;
 }
 
-void MooseMesh::printInfo(std::ostream &os)
+void MooseMesh::printInfo(std::ostream &os) const
 {
   getMesh().print_info(os);
 }
 
-std::vector<dof_id_type> &
-MooseMesh::getNodeList(boundary_id_type nodeset_id)
+const std::vector<dof_id_type> &
+MooseMesh::getNodeList(boundary_id_type nodeset_id) const
 {
-  return _node_set_nodes[nodeset_id];
+  return _node_set_nodes.at(nodeset_id);
 }
 
 const std::set<unsigned int> &
-MooseMesh::getSubdomainBoundaryIds(unsigned int subdomain_id)
+MooseMesh::getSubdomainBoundaryIds(unsigned int subdomain_id) const
 {
-  return _subdomain_boundary_ids[subdomain_id];
+  return _subdomain_boundary_ids.at(subdomain_id);
 }
 
 bool

--- a/framework/src/multiapps/AutoPositionsMultiApp.C
+++ b/framework/src/multiapps/AutoPositionsMultiApp.C
@@ -55,7 +55,7 @@ AutoPositionsMultiApp::fillPositions()
     BoundaryID boundary_id = *bid_it;
 
     // Grab the nodes on the boundary ID and add a Sub-App at each one.
-    std::vector<dof_id_type> & boundary_node_ids = master_mesh.getNodeList(boundary_id);
+    const std::vector<dof_id_type> & boundary_node_ids = master_mesh.getNodeList(boundary_id);
 
     for (unsigned int i=0; i<boundary_node_ids.size(); i++)
     {


### PR DESCRIPTION
- Fixes up a few caching issues in MooseMesh
- Marks several methods const
- Adds exception handling around `std::vector::at()` methods

Note: Using `find` doesn't work well here because these methods return references to the found element. We'd have to use find() for the check followed by at() anyway. We might as well just use try/catch blocks for this instead.

closes #6509 
sepersedes #6510 
