### PR TITLE
Fix case sensitivity typo.

### DIFF
--- a/framework/doc/sqa/Makefile
+++ b/framework/doc/sqa/Makefile
@@ -3,7 +3,7 @@ FRAMEWORK_DIR ?= $(MOOSE_DIR)/framework
 
 all: SoftwareRequirements.pdf framework_requirements_traceability.pdf
 
-SoftwareRequirements.pdf: SoftwareRequirements.tex INLReport.cls DOEbwlogo.pdf inl-left_black.pdf
+SoftwareRequirements.pdf: SoftwareRequirements.tex INLreport.cls DOEbwlogo.pdf inl-left_black.pdf
 	pdflatex SoftwareRequirements.tex
 
 framework_requirements_traceability.pdf:


### PR DESCRIPTION
Worked on the Mac because case insensitive filenames. Didn't work on Linux.

refs #6558
