### PR TITLE
XFEM tests require --enable-unique-ids

### DIFF
--- a/modules/combined/tests/heat_conduction_xfem/tests
+++ b/modules/combined/tests/heat_conduction_xfem/tests
@@ -4,5 +4,7 @@
     input = heat.i
     exodiff = 'heat_out.e'
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
 []

--- a/modules/combined/tests/solid_mechanics/xfem/tests
+++ b/modules/combined/tests/solid_mechanics/xfem/tests
@@ -5,6 +5,8 @@
     exodiff = 'crack_propagation_2d_out.e crack_propagation_2d_out.e-s002'
     abs_zero = 1e-8
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
   [./edge_crack_3d]
     type = Exodiff
@@ -12,35 +14,47 @@
     exodiff = 'edge_crack_3d_out.e'
     abs_zero = 1e-8
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
   [./elliptical_crack]
     type = Exodiff
     input = elliptical_crack.i
     exodiff = 'elliptical_crack_out.e'
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
   [./penny_crack]
     type = Exodiff
     input = penny_crack.i
     exodiff = 'penny_crack_out.e'
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
   [./square_branch_quad_2d]
     type = Exodiff
     input = square_branch_quad_2d.i
     exodiff = 'square_branch_quad_2d_out.e square_branch_quad_2d_out.e-s002 square_branch_quad_2d_out.e-s003'
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
   [./square_branch_tri_2d]
     type = Exodiff
     input = square_branch_tri_2d.i
     exodiff = 'square_branch_tri_2d_out.e square_branch_tri_2d_out.e-s002 square_branch_tri_2d_out.e-s003'
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
   [./square_moment_fitting]
     type = Exodiff
     input = square_moment_fitting.i
     exodiff = 'square_moment_fitting_out.e'
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
 []

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -28,6 +28,9 @@ XFEM::XFEM (MooseApp & app) :
     XFEMInterface(app),
     _efa_mesh(Moose::out)
 {
+#ifndef LIBMESH_ENABLE_UNIQUE_ID
+  mooseError("MOOSE requires unique ids to be enabled in libmesh (configure with --enable-unique-id) to use XFEM!");
+#endif
 }
 
 XFEM::~XFEM ()

--- a/modules/xfem/tests/diffusion_xfem/tests
+++ b/modules/xfem/tests/diffusion_xfem/tests
@@ -4,5 +4,7 @@
     input = diffusion.i
     exodiff = 'diffusion_out.e'
     map = false
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
   [../]
 []

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -95,6 +95,7 @@ class TestHarness:
       self.checks['curl'] = set(['ALL'])
       self.checks['tbb'] = set(['ALL'])
       self.checks['superlu'] = set(['ALL'])
+      self.checks['unique_id'] = set(['ALL'])
       self.checks['cxx11'] = set(['ALL'])
       self.checks['asio'] =  set(['ALL'])
     else:
@@ -111,6 +112,7 @@ class TestHarness:
       self.checks['curl'] =  getLibMeshConfigOption(self.libmesh_dir, 'curl')
       self.checks['tbb'] =  getLibMeshConfigOption(self.libmesh_dir, 'tbb')
       self.checks['superlu'] =  getLibMeshConfigOption(self.libmesh_dir, 'superlu')
+      self.checks['unique_id'] =  getLibMeshConfigOption(self.libmesh_dir, 'unique_id')
       self.checks['cxx11'] =  getLibMeshConfigOption(self.libmesh_dir, 'cxx11')
       self.checks['asio'] =  getIfAsioExists(self.moose_dir)
 

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -42,6 +42,7 @@ class Tester(MooseObject):
     params.addParam('curl',          ['ALL'], "A test that runs only if CURL is detected ('ALL', 'TRUE', 'FALSE')")
     params.addParam('tbb',           ['ALL'], "A test that runs only if TBB is available ('ALL', 'TRUE', 'FALSE')")
     params.addParam('superlu',       ['ALL'], "A test that runs only if SuperLU is available via PETSc ('ALL', 'TRUE', 'FALSE')")
+    params.addParam('unique_id',     ['ALL'], "A test that runs only if libmesh is configured with --enable-unique-id ('ALL', 'TRUE', 'FALSE')")
     params.addParam('cxx11',         ['ALL'], "A test that runs only if CXX11 is available ('ALL', 'TRUE', 'FALSE')")
     params.addParam('asio',          ['ALL'], "A test that runs only if ASIO is available ('ALL', 'TRUE', 'FALSE')")
     params.addParam('depend_files',  [], "A test that only runs if all depend files exist (files listed are expected to be relative to the base directory, not the test directory")
@@ -163,7 +164,8 @@ class Tester(MooseObject):
       return (False, reason)
 
     # PETSc is being explicitly checked above
-    local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot', 'petsc_debug', 'curl', 'tbb', 'superlu', 'cxx11', 'asio']
+    local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot', \
+                    'petsc_debug', 'curl', 'tbb', 'superlu', 'cxx11', 'asio', 'unique_id']
     for check in local_checks:
       test_platforms = set()
       for x in self.specs[check]:

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -75,6 +75,10 @@ LIBMESH_OPTIONS = {
                      'default'   : 'FALSE',
                      'options'   : {'TRUE' : '1', 'FALSE' : '0'}
                    },
+  'unique_id' :    { 're_option' : r'#define\s+LIBMESH_ENABLE_UNIQUE_ID\s+(\d+)',
+                     'default'   : 'FALSE',
+                     'options'   : {'TRUE' : '1', 'FALSE' : '0'}
+                   },
 }
 
 


### PR DESCRIPTION
This issue won't affect anyone that builds libmesh using the update_and_rebuild_libmesh.sh script, but I somehow neglected to ever add `--enable-unique-ids` to my libmesh build script, and the XFEM tests all require this to run correctly.  

Note that MOOSE and the modules still compile without unique ids enabled, and the rest of the tests run fine, so the failures were a bit surprising (and I sent @bwspenc on some wild goose chases looking for them) at first.

Refs #6453.
