### PR TITLE
Print extra information about compiler C++11 compatibility.

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -45,6 +45,7 @@
 
 // System include for dynamic library methods
 #include <dlfcn.h>
+#include <sys/utsname.h> // utsname
 
 #define QUOTE(macro) stringifyName(macro)
 
@@ -178,9 +179,36 @@ MooseApp::~MooseApp()
 
   if (check_cxx11)
   {
+    // Get system information
+    struct utsname sys_info;
+    uname(&sys_info);
+
+    // Get compiler name and version
+#ifdef __clang__
+    std::string
+      compiler_name = "Clang",
+      compiler_version = QUOTE(__clang_major__) "." QUOTE(__clang_minor__) "." QUOTE(__clang_patchlevel__);
+#elif __INTEL_COMPILER
+    std::string
+      compiler_name = "Intel",
+      compiler_version = QUOTE(__INTEL_COMPILER_BUILD_DATE);
+#elif __GNUG__
+    std::string
+      compiler_name = "GCC",
+      compiler_version = QUOTE(__GNUC__) "." QUOTE(__GNUC_MINOR__) "." QUOTE(__GNUC_PATCHLEVEL__);
+#else
+    std::string
+      compiler_name = "Unknown compiler",
+      compiler_version = "Unknown version";
+#endif
+
     std::stringstream oss;
 
-    oss << std::left << "Compiler C++11 compatibility report: " << '\n';
+    oss << "----------------------------------------" << '\n';
+    oss << std::left << "C++11 compiler compatibility report: " << '\n';
+    oss << "OS: " << sys_info.version << '\n';
+    oss << "Compiler: " << compiler_name << ' ' << compiler_version << '\n';
+    oss << "----------------------------------------" << '\n';
     print_yes_no(oss, "Basic functionality", QUOTE(LIBMESH_HAVE_CXX11));
 #ifdef LIBMESH_HAVE_CXX11
     print_yes_no(oss, "Alias declarations", QUOTE(LIBMESH_HAVE_CXX11_ALIAS_DECLARATIONS));


### PR DESCRIPTION
This implements most of what is needed for #6564.

For instance, on Clang 3.7.0 at the end of the simulation, it now prints

```
Compiler C++11 compatibility report: 
  Basic functionality:     yes
  Deleted functions:       yes
  'final' keyword:         yes
  Initializer lists:       yes
  'move' keyword:          yes
  'nullptr' keyword:       yes
  'override' keyword:      yes
  <regex>:                 yes
  std::shared_ptr:         yes
  <thread>:                yes
  <type_traits>:           yes
  std::unique_ptr:         yes
  Variadic templates:      yes
```

while on GCC 4.6.3, a compiler that does not support much C++11 stuff, it prints:

```
Compiler C++11 compatibility report: 
  Basic functionality:     no
  Deleted functions:       yes
  'final' keyword:         no
  Initializer lists:       no
  'move' keyword:          no
  'nullptr' keyword:       no
  'override' keyword:      no
  <regex>:                 no
  std::shared_ptr:         no
  <thread>:                no
  <type_traits>:           no
  std::unique_ptr:         no
  Variadic templates:      yes
```

What is still needed is:
- [x] A command line argument that will turn off this printing altogether.  I need suggestions for what this should be...
- [x] If the user explicitly disables C++11 support by configuring with --disable-cxx11, all of the features above will currently print "no" because they won't be tested.  I can fix this so that it runs the tests even if you explicitly disable C++11 support, and therefore still prints a useful feature summary, but that will require a libmesh update (this is implemented in libMesh/libmesh#869).

This PR also contains a libmesh update.  The following is a short summary of changes to libmesh:
- Enable FETypes of arbitrary order (larger than the largest Order enumeration).
- Properly free communicators created by calling split().
- Fixes for adaptive p and h-p refinement.
- More thorough testing for C++11 threads (std::atomic, std::mutex, etc).
- Fix issue with VTK autoconf tests that caused test programs to fail linking.
- Enhance and expand C++11 configure tests.
- Make TypeTensor row() const.
- Optimize/fix issues with constant monomial projection.
- Make --enable-unique-ptr is now the default, MOOSE has been using this for a while already.
- Allow threading directly over std::vectors (without copying).
- Fix issue with XDA I/O on highly-refined meshes.
