### PR TITLE
Memory optimization for MOOSE PRNG

### DIFF
--- a/framework/include/utils/RandomData.h
+++ b/framework/include/utils/RandomData.h
@@ -52,6 +52,9 @@ public:
 private:
   void updateGenerators();
 
+  template<typename T>
+  void updateGeneratorHelper(T it, T end_it);
+
   FEProblem & _rd_problem;
   MooseMesh & _rd_mesh;
 

--- a/framework/src/utils/RandomData.C
+++ b/framework/src/utils/RandomData.C
@@ -96,32 +96,29 @@ RandomData::updateGenerators()
   }
 
   if (_is_nodal)
-  {
-    MeshBase::const_node_iterator it = _rd_mesh.getMesh().active_nodes_begin();
-    MeshBase::const_node_iterator end_it = _rd_mesh.getMesh().active_nodes_end();
-
-    for (; it != end_it; ++it)
-    {
-      dof_id_type id = (*it)->id();
-      _seeds[id] = _generator.randl(MASTER);
-
-      // Update the individual dof object generators
-      _generator.seed(static_cast<unsigned int>(id), _seeds[id]);
-    }
-  }
+    updateGeneratorHelper(_rd_mesh.getMesh().active_nodes_begin(), _rd_mesh.getMesh().active_nodes_end());
   else
-  {
-    MeshBase::const_element_iterator it = _rd_mesh.getMesh().active_elements_begin();
-    MeshBase::const_element_iterator end_it = _rd_mesh.getMesh().active_elements_end();
+    updateGeneratorHelper(_rd_mesh.getMesh().active_elements_begin(),_rd_mesh.getMesh().active_elements_end());
+}
 
-    for (; it != end_it; ++it)
+template<typename T>
+void
+RandomData::updateGeneratorHelper(T it, T end_it)
+{
+  processor_id_type processor_id = _rd_problem.processor_id();
+
+  for (; it != end_it; ++it)
+  {
+    dof_id_type id = (*it)->id();
+    uint32_t rand_int = _generator.randl(MASTER);
+
+    if (processor_id == (*it)->processor_id())
     {
-      dof_id_type id = (*it)->id();
-      _seeds[id] = _generator.randl(MASTER);
+      // Only save states for local dofs
+      _seeds[id] = rand_int;
 
       // Update the individual dof object generators
       _generator.seed(static_cast<unsigned int>(id), _seeds[id]);
     }
   }
-
 }


### PR DESCRIPTION
Currently we're storing all generator states per dof
but we simply don't need to do that. This PR stores
less state reducing memory usage.

~~Additionally, I'm re-enabling the random test. I believe this may be working again due to recent threading fixes.~~

refs #6590, #2088
