### PR TITLE
Re-enable random threaded test

### DIFF
--- a/test/tests/utils/random/tests
+++ b/test/tests/utils/random/tests
@@ -60,9 +60,6 @@
     exodiff = 'random_uo_out.e'
     prereq = 'parallel_verification_uo'
     min_threads = 2
-    # This test fails, well, randomly, and needs to be fixed before it
-    # can be trusted as a reliable regression test.
-    deleted = '#2088'
   [../]
 
   # User Object Tests


### PR DESCRIPTION
I believe that the failures previously seen with
this test are related to https://github.com/libMesh/libmesh/pull/842

refs #2088
