### PR TITLE
Split Dampers into GeneralDamper, ElementDamper 

### DIFF
--- a/framework/include/base/ComputeElemDampingThread.h
+++ b/framework/include/base/ComputeElemDampingThread.h
@@ -12,37 +12,40 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef CONSTANTDAMPER_H
-#define CONSTANTDAMPER_H
+#ifndef COMPUTEELEMDAMPINGTHREAD_H
+#define COMPUTEELEMDAMPINGTHREAD_H
 
-// Moose Includes
-#include "GeneralDamper.h"
+// MOOSE includes
+#include "ThreadedElementLoop.h"
+#include "MooseObjectWarehouse.h"
 
-//Forward Declarations
-class ConstantDamper;
+// libMesh includes
+#include "libmesh/elem_range.h"
 
-template<>
-InputParameters validParams<ConstantDamper>();
+// Forward declarations
+class NonlinearSystem;
+class ElementDamper;
 
-/**
- * Simple constant damper.
- *
- * Modifies the non-linear step by applying a constant damping factor
- */
-class ConstantDamper : public GeneralDamper
+class ComputeElemDampingThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  ConstantDamper(const InputParameters & parameters);
+  ComputeElemDampingThread(FEProblem & feproblem, NonlinearSystem & sys);
+
+  // Splitting Constructor
+  ComputeElemDampingThread(ComputeElemDampingThread & x, Threads::split split);
+
+  virtual ~ComputeElemDampingThread();
+
+  virtual void onElement(const Elem *elem);
+
+  void join(const ComputeElemDampingThread & /*y*/);
+
+  Real damping();
 
 protected:
-
-  /**
-   * Return the constant damping value.
-   */
-  virtual Real computeDamping(const NumericVector<Number> & update);
-
-  /// The constant amount of the Newton update to take.
   Real _damping;
+  NonlinearSystem & _nl;
+  const MooseObjectWarehouse<ElementDamper> & _element_dampers;
 };
 
-#endif //CONSTANTDAMPER_H
+#endif //COMPUTEELEMDAMPINGTHREAD_H

--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -227,9 +227,9 @@ public:
   void setNodalValueNeighbor(const DenseVector<Number> & value);
 
   /**
-   * Compute damping for this variable based on increment_vec
+   * Compute and store incremental change based on increment_vec
    */
-  void computeDamping(const NumericVector<Number> & increment_vec);
+  void computeIncrement(const NumericVector<Number> & increment_vec);
 
   /**
    * Get DOF indices for currently selected element

--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -30,7 +30,8 @@ class MoosePreconditioner;
 class JacobianBlock;
 class TimeIntegrator;
 class Predictor;
-class Damper;
+class ElementDamper;
+class GeneralDamper;
 class IntegratedBC;
 class NodalBC;
 class PresetNodalBC;
@@ -356,10 +357,10 @@ public:
    */
   void setupDampers();
   /**
-   * Reinit dampers. Called before we use damping
+   * Compute the incremental change in variables for dampers. Called before we use damping
    * @param tid Thread ID
    */
-  void reinitDampers(THREAD_ID tid);
+  void reinitIncrementForDampers(THREAD_ID tid);
 
   ///@{
   /// System Integrity Checks
@@ -447,7 +448,7 @@ public:
   const MooseObjectWarehouse<DiracKernel> & getDiracKernelWarehouse() { return _dirac_kernels; }
   const MooseObjectWarehouse<NodalKernel> & getNodalKernelWarehouse(THREAD_ID tid);
   const MooseObjectWarehouse<IntegratedBC> & getIntegratedBCWarehouse() { return _integrated_bcs; }
-  const MooseObjectWarehouse<Damper> & getDamperWarehouse() { return _dampers; }
+  const MooseObjectWarehouse<ElementDamper> & getElementDamperWarehouse() { return _element_dampers; }
   //@}
 
   /**
@@ -541,8 +542,11 @@ protected:
   /// Dirac Kernel storage for each thread
   MooseObjectWarehouse<DiracKernel> _dirac_kernels;
 
-  /// Dampers for each thread
-  MooseObjectWarehouse<Damper> _dampers;
+  /// Element Dampers for each thread
+  MooseObjectWarehouse<ElementDamper> _element_dampers;
+
+  /// General Dampers
+  MooseObjectWarehouse<GeneralDamper> _general_dampers;
 
   /// NodalKernels for each thread
   MooseObjectWarehouse<NodalKernel> _nodal_kernels;

--- a/framework/include/dampers/Damper.h
+++ b/framework/include/dampers/Damper.h
@@ -18,83 +18,32 @@
 // Moose Includes
 #include "MooseObject.h"
 #include "SetupInterface.h"
-#include "ParallelUniqueId.h"
-#include "MaterialPropertyInterface.h"
 #include "Restartable.h"
 #include "MeshChangedInterface.h"
-#include "MooseVariableBase.h"
 
 //Forward Declarations
 class Damper;
 class SubProblem;
 class SystemBase;
-class MooseVariable;
-class Assembly;
 
 template<>
 InputParameters validParams<Damper>();
 
 /**
  * Base class for deriving dampers
- *
  */
 class Damper :
   public MooseObject,
   public SetupInterface,
-  protected MaterialPropertyInterface,
   public Restartable,
   public MeshChangedInterface
 {
 public:
   Damper(const InputParameters & parameters);
 
-  /**
-   * Computes this Damper's damping for one element.
-   */
-  Real computeDamping();
-
-  void printTime();
-
-
 protected:
-  /**
-   * This MUST be overridden by a child damper.
-   *
-   * This is where they actually compute a number between 0 and 1.
-   */
-  virtual Real computeQpDamping() = 0;
-
   SubProblem & _subproblem;
   SystemBase & _sys;
-
-  /// Thread ID
-  THREAD_ID _tid;
-  Assembly & _assembly;
-
-  /// Coordinate system
-  const Moose::CoordinateSystemType & _coord_sys;
-
-  /// Non-linear variable this damper works on
-  MooseVariable & _var;
-
-  /// Current element
-  const Elem * & _current_elem;
-
-  /// Quadrature point index
-  unsigned int _qp;
-  /// Quadrature points
-  const MooseArray< Point > & _q_point;
-  /// Quadrature rule
-  QBase * & _qrule;
-  /// Transformed Jacobian weights
-  const MooseArray<Real> & _JxW;
-
-  /// The current Newton increment
-  VariableValue & _u_increment;
-  /// Holds the current solution at the current quadrature point
-  const VariableValue & _u;
-  /// Holds the current solution gradient at the current quadrature point
-  const VariableGradient & _grad_u;
 };
 
 #endif

--- a/framework/include/dampers/ElementDamper.h
+++ b/framework/include/dampers/ElementDamper.h
@@ -1,0 +1,93 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef ELEMENTDAMPER_H
+#define ELEMENTDAMPER_H
+
+// Moose Includes
+#include "Damper.h"
+#include "ParallelUniqueId.h"
+#include "MaterialPropertyInterface.h"
+#include "MooseVariableBase.h"
+
+//Forward Declarations
+class ElementDamper;
+class SubProblem;
+class SystemBase;
+class MooseVariable;
+class Assembly;
+
+template<>
+InputParameters validParams<ElementDamper>();
+
+/**
+ * Base class for deriving element dampers
+ */
+class ElementDamper :
+  public Damper,
+  protected MaterialPropertyInterface
+{
+public:
+  ElementDamper(const InputParameters & parameters);
+
+  /**
+   * Computes this Damper's damping for one element.
+   */
+  Real computeDamping();
+
+  /**
+   * Get the variable this damper is acting on
+   */
+  MooseVariable * getVariable() { return &_var; }
+
+
+protected:
+  /**
+   * This MUST be overridden by a child damper.
+   *
+   * This is where they actually compute a number between 0 and 1.
+   */
+  virtual Real computeQpDamping() = 0;
+
+  /// Thread ID
+  THREAD_ID _tid;
+  Assembly & _assembly;
+
+  /// Coordinate system
+  const Moose::CoordinateSystemType & _coord_sys;
+
+  /// Non-linear variable this damper works on
+  MooseVariable & _var;
+
+  /// Current element
+  const Elem * & _current_elem;
+
+  /// Quadrature point index
+  unsigned int _qp;
+  /// Quadrature points
+  const MooseArray< Point > & _q_point;
+  /// Quadrature rule
+  QBase * & _qrule;
+  /// Transformed Jacobian weights
+  const MooseArray<Real> & _JxW;
+
+  /// The current Newton increment
+  VariableValue & _u_increment;
+  /// Holds the current solution at the current quadrature point
+  const VariableValue & _u;
+  /// Holds the current solution gradient at the current quadrature point
+  const VariableGradient & _grad_u;
+};
+
+#endif //ELEMENTDAMPER_H

--- a/framework/include/dampers/GeneralDamper.h
+++ b/framework/include/dampers/GeneralDamper.h
@@ -12,40 +12,35 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef COMPUTEDAMPINGTHREAD_H
-#define COMPUTEDAMPINGTHREAD_H
+#ifndef GENERALDAMPER_H
+#define GENERALDAMPER_H
 
-// MOOSE includes
-#include "ThreadedElementLoop.h"
-#include "MooseObjectWarehouse.h"
+// Moose Includes
+#include "Damper.h"
 
-// libMesh includes
-#include "libmesh/elem_range.h"
+//Forward Declarations
+class GeneralDamper;
+class SubProblem;
+class SystemBase;
+class MooseVariable;
+class Assembly;
 
-// Forward declarations
-class NonlinearSystem;
-class Damper;
+template<>
+InputParameters validParams<GeneralDamper>();
 
-class ComputeDampingThread : public ThreadedElementLoop<ConstElemRange>
+/**
+ * Base class for deriving general dampers
+ */
+class GeneralDamper :
+  public Damper
 {
 public:
-  ComputeDampingThread(FEProblem & feproblem, NonlinearSystem & sys);
+  GeneralDamper(const InputParameters & parameters);
 
-  // Splitting Constructor
-  ComputeDampingThread(ComputeDampingThread & x, Threads::split split);
-
-  virtual ~ComputeDampingThread();
-
-  virtual void onElement(const Elem *elem);
-
-  void join(const ComputeDampingThread & /*y*/);
-
-  Real damping();
-
-protected:
-  Real _damping;
-  NonlinearSystem & _nl;
-  const MooseObjectWarehouse<Damper> & _dampers;
+  /**
+   * Computes this Damper's damping
+   */
+  virtual Real computeDamping(const NumericVector<Number> & update) = 0;
 };
 
-#endif //COMPUTEDAMPINGTHREAD_H
+#endif //GENERALDAMPER_H

--- a/framework/include/dampers/MaxIncrement.h
+++ b/framework/include/dampers/MaxIncrement.h
@@ -16,7 +16,7 @@
 #define MAXINCREMENT_H
 
 // Moose Includes
-#include "Damper.h"
+#include "ElementDamper.h"
 
 //Forward Declarations
 class MaxIncrement;
@@ -27,7 +27,7 @@ InputParameters validParams<MaxIncrement>();
 /**
  * TODO
  */
-class MaxIncrement : public Damper
+class MaxIncrement : public ElementDamper
 {
 public:
   MaxIncrement(const InputParameters & parameters);

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -1573,7 +1573,7 @@ MooseVariable::setNodalValueNeighbor(Number value)
 }
 
 void
-MooseVariable::computeDamping(const NumericVector<Number> & increment_vec)
+MooseVariable::computeIncrement(const NumericVector<Number> & increment_vec)
 {
   unsigned int nqp = _qrule->n_points();
 

--- a/framework/src/dampers/ConstantDamper.C
+++ b/framework/src/dampers/ConstantDamper.C
@@ -17,19 +17,19 @@
 template<>
 InputParameters validParams<ConstantDamper>()
 {
-  InputParameters params = validParams<Damper>();
+  InputParameters params = validParams<GeneralDamper>();
   params.addRequiredParam<Real>("damping", "The percentage (between 0 and 1) of the newton update to take.");
   return params;
 }
 
 ConstantDamper::ConstantDamper(const InputParameters & parameters) :
-    Damper(parameters),
+    GeneralDamper(parameters),
     _damping(getParam<Real>("damping"))
 {
 }
 
 Real
-ConstantDamper::computeQpDamping()
+ConstantDamper::computeDamping(const NumericVector<Number> & /*update*/)
 {
   return _damping;
 }

--- a/framework/src/dampers/Damper.C
+++ b/framework/src/dampers/Damper.C
@@ -15,17 +15,11 @@
 #include "Damper.h"
 #include "SystemBase.h"
 #include "SubProblem.h"
-#include "Assembly.h"
-
-// libMesh includes
-#include "libmesh/quadrature.h"
 
 template<>
 InputParameters validParams<Damper>()
 {
   InputParameters params = validParams<MooseObject>();
-  params += validParams<MaterialPropertyInterface>();
-  params.addRequiredParam<NonlinearVariableName>("variable", "The name of the variable that this damper operates on");
   params.declareControllable("enable"); // allows Control to enable/disable this type of object
   params.registerBase("Damper");
   return params;
@@ -34,40 +28,9 @@ InputParameters validParams<Damper>()
 Damper::Damper(const InputParameters & parameters) :
     MooseObject(parameters),
     SetupInterface(parameters),
-    MaterialPropertyInterface(parameters),
     Restartable(parameters, "Dampers"),
     MeshChangedInterface(parameters),
     _subproblem(*parameters.get<SubProblem *>("_subproblem")),
-    _sys(*parameters.get<SystemBase *>("_sys")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
-    _coord_sys(_assembly.coordSystem()),
-    _var(_sys.getVariable(_tid, parameters.get<NonlinearVariableName>("variable"))),
-
-    _current_elem(_var.currentElem()),
-    _q_point(_assembly.qPoints()),
-    _qrule(_assembly.qRule()),
-    _JxW(_assembly.JxW()),
-
-    _u_increment(_var.increment()),
-
-    _u(_var.sln()),
-    _grad_u(_var.gradSln())
+    _sys(*parameters.get<SystemBase *>("_sys"))
 {
-}
-
-Real
-Damper::computeDamping()
-{
-  Real damping = 1.0;
-  Real cur_damping = 1.0;
-
-  for (_qp=0; _qp<_qrule->n_points(); _qp++)
-  {
-    cur_damping = computeQpDamping();
-    if (cur_damping < damping)
-      damping = cur_damping;
-  }
-
-  return damping;
 }

--- a/framework/src/dampers/ElementDamper.C
+++ b/framework/src/dampers/ElementDamper.C
@@ -1,0 +1,66 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ElementDamper.h"
+#include "SystemBase.h"
+#include "SubProblem.h"
+#include "Assembly.h"
+
+// libMesh includes
+#include "libmesh/quadrature.h"
+
+template<>
+InputParameters validParams<ElementDamper>()
+{
+  InputParameters params = validParams<Damper>();
+  params += validParams<MaterialPropertyInterface>();
+  params.addRequiredParam<NonlinearVariableName>("variable", "The name of the variable that this damper operates on");
+  return params;
+}
+
+ElementDamper::ElementDamper(const InputParameters & parameters) :
+    Damper(parameters),
+    MaterialPropertyInterface(parameters),
+    _tid(parameters.get<THREAD_ID>("_tid")),
+    _assembly(_subproblem.assembly(_tid)),
+    _coord_sys(_assembly.coordSystem()),
+    _var(_sys.getVariable(_tid, parameters.get<NonlinearVariableName>("variable"))),
+
+    _current_elem(_var.currentElem()),
+    _q_point(_assembly.qPoints()),
+    _qrule(_assembly.qRule()),
+    _JxW(_assembly.JxW()),
+
+    _u_increment(_var.increment()),
+
+    _u(_var.sln()),
+    _grad_u(_var.gradSln())
+{
+}
+
+Real
+ElementDamper::computeDamping()
+{
+  Real damping = 1.0;
+  Real cur_damping = 1.0;
+
+  for (_qp=0; _qp<_qrule->n_points(); _qp++)
+  {
+    cur_damping = computeQpDamping();
+    if (cur_damping < damping)
+      damping = cur_damping;
+  }
+
+  return damping;
+}

--- a/framework/src/dampers/GeneralDamper.C
+++ b/framework/src/dampers/GeneralDamper.C
@@ -12,37 +12,16 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef CONSTANTDAMPER_H
-#define CONSTANTDAMPER_H
-
-// Moose Includes
 #include "GeneralDamper.h"
 
-//Forward Declarations
-class ConstantDamper;
-
 template<>
-InputParameters validParams<ConstantDamper>();
-
-/**
- * Simple constant damper.
- *
- * Modifies the non-linear step by applying a constant damping factor
- */
-class ConstantDamper : public GeneralDamper
+InputParameters validParams<GeneralDamper>()
 {
-public:
-  ConstantDamper(const InputParameters & parameters);
+  InputParameters params = validParams<Damper>();
+  return params;
+}
 
-protected:
-
-  /**
-   * Return the constant damping value.
-   */
-  virtual Real computeDamping(const NumericVector<Number> & update);
-
-  /// The constant amount of the Newton update to take.
-  Real _damping;
-};
-
-#endif //CONSTANTDAMPER_H
+GeneralDamper::GeneralDamper(const InputParameters & parameters) :
+    Damper(parameters)
+{
+}

--- a/framework/src/dampers/MaxIncrement.C
+++ b/framework/src/dampers/MaxIncrement.C
@@ -17,13 +17,13 @@
 template<>
 InputParameters validParams<MaxIncrement>()
 {
-  InputParameters params = validParams<Damper>();
+  InputParameters params = validParams<ElementDamper>();
   params.addRequiredParam<Real>("max_increment", "The maximum newton increment for the variable.");
   return params;
 }
 
 MaxIncrement::MaxIncrement(const InputParameters & parameters) :
-    Damper(parameters),
+    ElementDamper(parameters),
     _max_increment(parameters.get<Real>("max_increment"))
 {
 }

--- a/test/tests/controls/time_periods/aux_kernels/enable_disable.i
+++ b/test/tests/controls/time_periods/aux_kernels/enable_disable.i
@@ -40,9 +40,8 @@
 []
 
 [Dampers]
-  [./u_damp]
+  [./const_damp]
     type = ConstantDamper
-    variable = u
     damping = 0.9
   [../]
 []

--- a/test/tests/controls/time_periods/aux_scalar_kernels/enable_disable.i
+++ b/test/tests/controls/time_periods/aux_scalar_kernels/enable_disable.i
@@ -40,9 +40,8 @@
 []
 
 [Dampers]
-  [./u_damp]
+  [./const_damp]
     type = ConstantDamper
-    variable = u
     damping = 0.9
   [../]
 []

--- a/test/tests/controls/time_periods/dampers/control.i
+++ b/test/tests/controls/time_periods/dampers/control.i
@@ -54,9 +54,8 @@
 []
 
 [Dampers]
-  [./u_damp]
+  [./const_damp]
     type = ConstantDamper
-    variable = u
     damping = 0.9
   [../]
 []
@@ -68,7 +67,7 @@
 [Controls]
   [./damping_control]
     type = TimePeriod
-    disable_objects = 'u_damp'
+    disable_objects = 'const_damp'
     start_time = 0.25
     execute_on = 'initial timestep_begin'
   [../]

--- a/test/tests/controls/time_periods/dampers/enable_disable.i
+++ b/test/tests/controls/time_periods/dampers/enable_disable.i
@@ -40,9 +40,8 @@
 []
 
 [Dampers]
-  [./u_damp]
+  [./const_damp]
     type = ConstantDamper
-    variable = u
     damping = 0.9
   [../]
 []

--- a/test/tests/controls/time_periods/dampers/tests
+++ b/test/tests/controls/time_periods/dampers/tests
@@ -4,14 +4,14 @@
     type = RunApp
     input = 'enable_disable.i'
     absent_out = '6\s*Nonlinear'
-    cli_args = "Dampers/u_damp/enable=false"
+    cli_args = "Dampers/const_damp/enable=false"
   [../]
   [./enable_true]
     # Tests that MooseObject parameter operates correctly when set to 'true'
     type = RunApp
     input = 'enable_disable.i'
     expect_out = '6\s*Nonlinear'
-    cli_args = "Dampers/u_damp/enable=true"
+    cli_args = "Dampers/const_damp/enable=true"
   [../]
   [./control]
     # Test that a damper may be disabled during simulation

--- a/test/tests/controls/time_periods/error/control.i
+++ b/test/tests/controls/time_periods/error/control.i
@@ -47,9 +47,8 @@
 []
 
 [Dampers]
-  [./u_damp]
+  [./const_damp]
     type = ConstantDamper
-    variable = u
     damping = 0.9
   [../]
 []
@@ -60,7 +59,7 @@
 [Controls]
   [./damping_control]
     type = TimePeriod
-    disable_objects = 'u_damp'
+    disable_objects = 'const_damp'
     start_time = 0.25
     end_time = 0.55
     execute_on = 'initial timestep_begin'

--- a/test/tests/controls/time_periods/error/steady_error.i
+++ b/test/tests/controls/time_periods/error/steady_error.i
@@ -45,9 +45,8 @@
 []
 
 [Dampers]
-  [./u_damp]
+  [./const_damp]
     type = ConstantDamper
-    variable = u
     damping = 0.9
   [../]
 []
@@ -59,7 +58,7 @@
 [Controls]
   [./damping_control]
     type = TimePeriod
-    disable_objects = 'u_damp'
+    disable_objects = 'const_damp'
     start_time = 0.25
     execute_on = 'initial timestep_begin'
   [../]

--- a/test/tests/dampers/constant_damper/constant_damper_test.i
+++ b/test/tests/dampers/constant_damper/constant_damper_test.i
@@ -40,9 +40,8 @@
 []
 
 [Dampers]
-  [./u_damp]
+  [./const_damp]
     type = ConstantDamper
-    variable = u
     damping = 0.9
   [../]
 []


### PR DESCRIPTION
closes #6596

-Created ElementDamper, GeneralDamper classes that derive from Damper.
-Add calls to both types of Damper in NonlinearSystem.
-Converted ConstantDamper to be based on GeneralDamper.
-ConstantDamper no longer requires 'variable' parameter, which was unused.
-Renamed functions related to computing incremental solution for variables
to names more reflective of what they actually do:
  NonlinearSystem::reinitDampers() --> NonlinearSystem::reinitIncrementForDampers()
  MooseVariable::computeDamping() --> MooseVariable::computeIncrement()
