### PR TITLE
Allow to test only on-diagonal Jacobians 

### DIFF
--- a/python/TestHarness/testers/AnalyzeJacobian.py
+++ b/python/TestHarness/testers/AnalyzeJacobian.py
@@ -11,6 +11,7 @@ class AnalyzeJacobian(Tester):
     params.addParam('test_name',      "The name of the test - populated automatically")
     params.addParam('expect_out',     "A regular expression that must occur in the input in order for the test to be considered passing.")
     params.addParam('resize_mesh', False, "Resize the input mesh")
+    params.addParam('off_diagonal', True, "Also test the off-diagonal Jacobian entries")
     params.addParam('mesh_size',   1, "Resize the input mesh")
 
     return params
@@ -32,6 +33,9 @@ class AnalyzeJacobian(Tester):
     mesh_options = ' -m %s' % options.method
     if specs['resize_mesh'] :
       mesh_options += ' -r -s %d' % specs['mesh_size']
+
+    if not specs['off_diagonal'] :
+      mesh_options += ' -D'
 
     command += mesh_options + ' ' + specs['input'] + ' -e ' + specs['executable'] + ' ' + ' '.join(specs['cli_args'])
 

--- a/python/jacobiandebug/analyzejacobian.py
+++ b/python/jacobiandebug/analyzejacobian.py
@@ -93,6 +93,9 @@ def findExecutable(executable_option, method_option):
 #   sd1  kern3
 
 def analyze(dofdata, Mfd, Mhc, Mdiff) :
+  global options
+
+  diagonal_only = options.diagonal_only
   dofs = dofdata['ndof']
   nlvars = [var['name'] for var in dofdata['vars']]
   numvars = len(nlvars)
@@ -140,6 +143,9 @@ def analyze(dofdata, Mfd, Mhc, Mdiff) :
 
     for j in range(nblocks) :
 
+      if i != j and diagonal_only :
+        continue
+
       if norm[i][j] > e*fd[i][j] :
         if not printed :
           print "\nKernel for variable '%s':" % nlvars[i]
@@ -182,7 +188,10 @@ def saveMatrixToFile(M, dofs, filename) :
 #
 # Simple state machine parser for the MOOSE output
 #
-def parseOutput(output, dofdata, write_matrices) :
+def parseOutput(output, dofdata) :
+  global options
+
+  write_matrices = options.write_matrices
   dofs = dofdata['ndof']
 
   state = 0
@@ -263,6 +272,8 @@ if __name__ == '__main__':
 
   parser.add_option("-r", "--resize-mesh", dest="resize_mesh", action="store_true", help="Perform resizing of generated meshs (to speed up the testing).")
   parser.add_option("-s", "--mesh-size", dest="mesh_size", default=1, type="int", help="Set the mesh dimensions to this number of elements along each dimension (defaults to 1, requires -r option).")
+
+  parser.add_option("-D", "--on-diagonal-only", dest="diagonal_only", action="store_true", help="Test on-diagonal Jacobians only.")
 
   parser.add_option("-d", "--debug", dest="debug", action="store_true", help="Output the command line used to run the application.")
   parser.add_option("-w", "--write-matrices", dest="write_matrices", action="store_true", help="Output the Jacobian matrices in gnuplot format.")
@@ -374,4 +385,4 @@ if __name__ == '__main__':
     sys.exit(1)
 
   # parse the raw output, which contains the PETSc debug information
-  parseOutput(data, dofdata, options.write_matrices)
+  parseOutput(data, dofdata)

--- a/test/include/kernels/WrongJacobianDiffusion.h
+++ b/test/include/kernels/WrongJacobianDiffusion.h
@@ -43,6 +43,11 @@ protected:
    */
   virtual Real computeQpJacobian();
 
+  /**
+   * Set a constant off-diagonal Jacobian
+   */
+  virtual Real computeQpOffDiagJacobian(unsigned int);
+
 private:
   /// prefactor of the Residual
   Real _rfactor;

--- a/test/src/kernels/WrongJacobianDiffusion.C
+++ b/test/src/kernels/WrongJacobianDiffusion.C
@@ -41,3 +41,9 @@ WrongJacobianDiffusion::computeQpJacobian()
 {
   return _jfactor * _grad_test[_i][_qp] * _grad_phi[_j][_qp];
 }
+
+Real
+WrongJacobianDiffusion::computeQpOffDiagJacobian(unsigned int)
+{
+  return 1.0;
+}

--- a/test/tests/misc/jacobian/offdiag.i
+++ b/test/tests/misc/jacobian/offdiag.i
@@ -1,0 +1,46 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./s]
+    [./InitialCondition]
+      type = FunctionIC
+      function = sin(10*x+y)
+    [../]
+  [../]
+  [./t]
+    [./InitialCondition]
+      type = FunctionIC
+      function = sin(13*y+x)
+    [../]
+  [../]
+[]
+
+[Kernels]
+  [./diffs]
+    type = WrongJacobianDiffusion
+    variable = s
+    coupled = t
+  [../]
+  [./difft]
+    type = WrongJacobianDiffusion
+    variable = t
+    coupled = s
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+[]

--- a/test/tests/misc/jacobian/tests
+++ b/test/tests/misc/jacobian/tests
@@ -5,10 +5,21 @@
     expect_out = "\(0,0\) On-diagonal Jacobian is slightly off \(by 0.500132 %\).*\(1,1\) On-diagonal Jacobian is wrong \(off by 100.0 %\).*\(2,2\) On-diagonal Jacobian needs to be implemented.*\(3,3\) On-diagonal Jacobian should just return  zero"
     recover = false
   []
+
   [med]
     type = AnalyzeJacobian
     input = med.i
     expect_out = "\(0,0\) On-diagonal Jacobian is questionable \(off by 10.00 %\).*\(1,1\) On-diagonal Jacobian is wrong \(off by 30.0 %\)"
-    recover = false 
+    recover = false
+  []
+
+  # this test only has a wrong off-diagonal Jacobian, but we switch of testing
+  # the off diagonal. The test of the on-diagonal only should therefore throw no errors.
+  [offdiag]
+    type = AnalyzeJacobian
+    input = offdiag.i
+    off_diagonal = false
+    expect_out = "No errors detected. :-\)"
+    recover = false
   []
 []


### PR DESCRIPTION
Allow restricting the AnalyzeJacobian (analyzejacobian.py) tests to be restricted to on-diagonal testing.
This can be activated by adding the 

```
off_diagonal = False
```

option in your `tests` file in the block for the test you want to restrict.

Closes #6624
