### PR TITLE
Loosen the abs_zero a bit more for this Intel test.

### DIFF
--- a/modules/navier_stokes/tests/ins/open_bc/tests
+++ b/modules/navier_stokes/tests/ins/open_bc/tests
@@ -3,6 +3,6 @@
     type = 'Exodiff'
     input = 'open_bc_pressure_BC.i'
     exodiff = 'open_bc_out_pressure_BC.e'
-    abs_zero = 1e-9
+    abs_zero = 1e-8
   [../]
 []


### PR DESCRIPTION
This problem converges almost identically on both Clang/OSX and Linux/Intel:
## Clang/OSX:

```
0 Nonlinear |R| = 3.316625e+00
     0 Linear |R| = 3.316625e+00
     1 Linear |R| = 7.630822e-02
     2 Linear |R| = 4.169769e-02
     3 Linear |R| = 2.053140e-02
     4 Linear |R| = 5.370829e-03
     5 Linear |R| = 1.923983e-03
     6 Linear |R| = 8.233753e-04
     7 Linear |R| = 1.784678e-04
     8 Linear |R| = 4.127695e-05
     9 Linear |R| = 6.872437e-06
    10 Linear |R| = 7.858643e-07
1 Nonlinear |R| = 2.704333e-05
     0 Linear |R| = 2.704333e-05
     1 Linear |R| = 3.632747e-06
     2 Linear |R| = 4.188563e-07
     3 Linear |R| = 2.909151e-07
     4 Linear |R| = 9.015013e-08
     5 Linear |R| = 2.845631e-08
     6 Linear |R| = 6.865264e-09
     7 Linear |R| = 1.594213e-09
     8 Linear |R| = 4.522611e-10
     9 Linear |R| = 1.303507e-10
    10 Linear |R| = 3.857298e-11
    11 Linear |R| = 4.470817e-12
2 Nonlinear |R| = 9.885280e-12
```
## Linux/Intel:

```
0 Nonlinear |R| = 3.316625e+00
     0 Linear |R| = 3.316625e+00
     1 Linear |R| = 7.630822e-02
     2 Linear |R| = 4.169769e-02
     3 Linear |R| = 2.053140e-02
     4 Linear |R| = 5.370829e-03
     5 Linear |R| = 1.923983e-03
     6 Linear |R| = 8.233753e-04
     7 Linear |R| = 1.784678e-04
     8 Linear |R| = 4.127695e-05
     9 Linear |R| = 6.872437e-06
    10 Linear |R| = 7.858643e-07
1 Nonlinear |R| = 2.704333e-05
     0 Linear |R| = 2.704333e-05
     1 Linear |R| = 3.632747e-06
     2 Linear |R| = 4.188563e-07
     3 Linear |R| = 2.909151e-07
     4 Linear |R| = 9.015016e-08
     5 Linear |R| = 2.845631e-08
     6 Linear |R| = 6.865264e-09
     7 Linear |R| = 1.594211e-09
     8 Linear |R| = 4.522612e-10
     9 Linear |R| = 1.303507e-10
    10 Linear |R| = 3.857298e-11
    11 Linear |R| = 4.470818e-12
2 Nonlinear |R| = 9.824694e-12
```

And the diffs are _very_ small:

```
  --------- Time step 2, 1.0000000e+00 ~ 1.0000000e+00, rel diff:  0.00000e+00 ---------
Nodal variables:
   vel_y  rel diff:  1.4386991e-09 ~  1.4387765e-09 = 5.37867e-05 (node 713)
```

So I think that loosening abs_zero is still the right approach. If
this _still_ doesn't work, I'll actually get an Intel build going and
see if I can get it fixed that way.

Refs #6601.
