### PR TITLE
Update libmesh; fix VTKIO output in parallel

### DIFF
--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -146,6 +146,10 @@ Assembly::buildFE(FEType type)
       _fe[dim][type] = FEBase::build(dim, type).release();
     _fe[dim][type]->get_phi();
     _fe[dim][type]->get_dphi();
+    // Pre-request xyz.  We have always computed xyz, but due to
+    // recent optimizations in libmesh, we now need to explicity
+    // request it, since apps (Yak) may rely on it being computed.
+    _fe[dim][type]->get_xyz();
     if (_need_second_derivative.find(type) != _need_second_derivative.end())
       _fe[dim][type]->get_d2phi();
   }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -209,8 +209,8 @@ MooseApp::~MooseApp()
     oss << "OS: " << sys_info.version << '\n';
     oss << "Compiler: " << compiler_name << ' ' << compiler_version << '\n';
     oss << "----------------------------------------" << '\n';
-    print_yes_no(oss, "Basic functionality", QUOTE(LIBMESH_HAVE_CXX11));
 #ifdef LIBMESH_HAVE_CXX11
+    print_yes_no(oss, "Basic functionality", QUOTE(LIBMESH_HAVE_CXX11));
     print_yes_no(oss, "Alias declarations", QUOTE(LIBMESH_HAVE_CXX11_ALIAS_DECLARATIONS));
     print_yes_no(oss, "auto keyword", QUOTE(LIBMESH_HAVE_CXX11_AUTO));
     print_yes_no(oss, "constexpr keyword", QUOTE(LIBMESH_HAVE_CXX11_CONSTEXPR));

--- a/test/tests/outputs/vtk/gold/vtk_diff_out_005.vtk
+++ b/test/tests/outputs/vtk/gold/vtk_diff_out_005.vtk
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
   <PUnstructuredGrid GhostLevel="1">
     <PPointData>
       <PDataArray type="Float64" Name="aux"/>
@@ -8,6 +8,7 @@
     <PCellData>
       <PDataArray type="Int32" Name="libmesh_elem_id"/>
       <PDataArray type="Int32" Name="subdomain_id"/>
+      <PDataArray type="Int32" Name="processor_id"/>
     </PCellData>
     <PPoints>
       <PDataArray type="Float64" Name="Points" NumberOfComponents="3"/>

--- a/test/tests/outputs/vtk/gold/vtk_diff_out_005_0.vtu
+++ b/test/tests/outputs/vtk/gold/vtk_diff_out_005_0.vtu
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
   <UnstructuredGrid>
     <Piece NumberOfPoints="9" NumberOfCells="4">
       <PointData>
@@ -17,6 +17,9 @@
           0 1 2 3
         </DataArray>
         <DataArray type="Int32" Name="subdomain_id" format="ascii" RangeMin="0" RangeMax="0">
+          0 0 0 0
+        </DataArray>
+        <DataArray type="Int32" Name="processor_id" format="ascii" RangeMin="0" RangeMax="0">
           0 0 0 0
         </DataArray>
       </CellData>

--- a/test/tests/outputs/vtk/gold/vtk_diff_parallel_mesh_out_005.pvtu
+++ b/test/tests/outputs/vtk/gold/vtk_diff_parallel_mesh_out_005.pvtu
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
   <PUnstructuredGrid GhostLevel="1">
     <PPointData>
       <PDataArray type="Float64" Name="aux"/>
@@ -8,6 +8,7 @@
     <PCellData>
       <PDataArray type="Int32" Name="libmesh_elem_id"/>
       <PDataArray type="Int32" Name="subdomain_id"/>
+      <PDataArray type="Int32" Name="processor_id"/>
     </PCellData>
     <PPoints>
       <PDataArray type="Float64" Name="Points" NumberOfComponents="3"/>

--- a/test/tests/outputs/vtk/gold/vtk_diff_parallel_mesh_out_005_0.vtu
+++ b/test/tests/outputs/vtk/gold/vtk_diff_parallel_mesh_out_005_0.vtu
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
   <UnstructuredGrid>
     <Piece NumberOfPoints="6" NumberOfCells="2">
       <PointData>
@@ -15,6 +15,9 @@
           1 3
         </DataArray>
         <DataArray type="Int32" Name="subdomain_id" format="ascii" RangeMin="0" RangeMax="0">
+          0 0
+        </DataArray>
+        <DataArray type="Int32" Name="processor_id" format="ascii" RangeMin="0" RangeMax="0">
           0 0
         </DataArray>
       </CellData>

--- a/test/tests/outputs/vtk/gold/vtk_diff_parallel_mesh_out_005_1.vtu
+++ b/test/tests/outputs/vtk/gold/vtk_diff_parallel_mesh_out_005_1.vtu
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
   <UnstructuredGrid>
     <Piece NumberOfPoints="6" NumberOfCells="2">
       <PointData>
         <DataArray type="Float64" Name="aux" format="ascii" RangeMin="0" RangeMax="0">
           0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Float64" Name="u" format="ascii" RangeMin="0" RangeMax="0">
-          0 0 0 0 0 0
+        <DataArray type="Float64" Name="u" format="ascii" RangeMin="0" RangeMax="0.074429858227">
+          0 0 0 0.074429858072 0.074429858005 0.074429858227
         </DataArray>
       </PointData>
       <CellData>
@@ -16,6 +16,9 @@
         </DataArray>
         <DataArray type="Int32" Name="subdomain_id" format="ascii" RangeMin="0" RangeMax="0">
           0 0
+        </DataArray>
+        <DataArray type="Int32" Name="processor_id" format="ascii" RangeMin="1" RangeMax="1">
+          1 1
         </DataArray>
       </CellData>
       <Points>

--- a/test/tests/outputs/vtk/gold/vtk_diff_serial_mesh_parallel_out_005.pvtu
+++ b/test/tests/outputs/vtk/gold/vtk_diff_serial_mesh_parallel_out_005.pvtu
@@ -8,6 +8,7 @@
     <PCellData>
       <PDataArray type="Int32" Name="libmesh_elem_id"/>
       <PDataArray type="Int32" Name="subdomain_id"/>
+      <PDataArray type="Int32" Name="processor_id"/>
     </PCellData>
     <PPoints>
       <PDataArray type="Float64" Name="Points" NumberOfComponents="3"/>

--- a/test/tests/outputs/vtk/gold/vtk_diff_serial_mesh_parallel_out_005_0.vtu
+++ b/test/tests/outputs/vtk/gold/vtk_diff_serial_mesh_parallel_out_005_0.vtu
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
   <UnstructuredGrid>
     <Piece NumberOfPoints="6" NumberOfCells="2">
       <PointData>
@@ -15,6 +15,9 @@
           0 2
         </DataArray>
         <DataArray type="Int32" Name="subdomain_id" format="ascii" RangeMin="0" RangeMax="0">
+          0 0
+        </DataArray>
+        <DataArray type="Int32" Name="processor_id" format="ascii" RangeMin="0" RangeMax="0">
           0 0
         </DataArray>
       </CellData>

--- a/test/tests/outputs/vtk/gold/vtk_diff_serial_mesh_parallel_out_005_1.vtu
+++ b/test/tests/outputs/vtk/gold/vtk_diff_serial_mesh_parallel_out_005_1.vtu
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
   <UnstructuredGrid>
     <Piece NumberOfPoints="6" NumberOfCells="2">
       <PointData>
         <DataArray type="Float64" Name="aux" format="ascii" RangeMin="0" RangeMax="0">
           0 0 0 0 0 0
         </DataArray>
-        <DataArray type="Float64" Name="u" format="ascii" RangeMin="0" RangeMax="0">
-          0 0 0 0 0 0
+        <DataArray type="Float64" Name="u" format="ascii" RangeMin="0.074429857677" RangeMax="1.0000000002">
+          1.0000000002 1.0000000002 1.0000000002 0.074429857677 0.074429857773 0.074429857977
         </DataArray>
       </PointData>
       <CellData>
@@ -16,6 +16,9 @@
         </DataArray>
         <DataArray type="Int32" Name="subdomain_id" format="ascii" RangeMin="0" RangeMax="0">
           0 0
+        </DataArray>
+        <DataArray type="Int32" Name="processor_id" format="ascii" RangeMin="1" RangeMax="1">
+          1 1
         </DataArray>
       </CellData>
       <Points>


### PR DESCRIPTION
~~Just pushing this to see if it will pass the tests, we probably want to wait awhile until the next libmesh update, at least until @friedmud has a chance to fix up the PetscVector::operator() locking stuff.~~

I'd like to get this merged ASAP.  The libmesh update now includes:
- The fix for C++11 threaded calls to PetscVector::operator().
- Fixes for VTKIO output in parallel.
- C++11 tests for `std::to_string()`.
- Optimizations to `FE`/`FEMap` to speed up `reinit()`.

Refs libMesh/libmesh#882.
