### PR TITLE
Improving error message in DataIO

### DIFF
--- a/framework/include/restart/Backup.h
+++ b/framework/include/restart/Backup.h
@@ -1,0 +1,40 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef BACKUP_H
+#define BACKUP_H
+
+// C++ includes
+#include <sstream>
+#include <list>
+#include <vector>
+
+/**
+ * Helper class to hold streams for Backup and Restore operations.
+ */
+class Backup
+{
+public:
+  Backup();
+
+  ~Backup();
+
+  std::stringstream _system_data;
+
+  std::vector<std::stringstream*> _restartable_data;
+};
+
+// Specializations for dataLoad and dataStore appear in DataIO.C
+
+#endif /* BACKUP_H */

--- a/framework/include/restart/RestartableDataIO.h
+++ b/framework/include/restart/RestartableDataIO.h
@@ -17,6 +17,7 @@
 
 // MOOSE includes
 #include "DataIO.h"
+#include "Backup.h"
 
 // C++ includes
 #include <sstream>
@@ -27,56 +28,6 @@
 class RestartableDatas;
 class RestartableDataValue;
 class FEProblem;
-
-/**
- * Helper class to hold streams for Backup and Restore operations.
- */
-class Backup
-{
-public:
-  Backup()
-  {
-    unsigned int n_threads = libMesh::n_threads();
-
-    _restartable_data.resize(n_threads);
-
-    for (unsigned int i=0; i < n_threads; i++)
-      _restartable_data[i] = new std::stringstream;
-  }
-
-  ~Backup()
-  {
-    unsigned int n_threads = libMesh::n_threads();
-
-    for (unsigned int i=0; i < n_threads; i++)
-      delete _restartable_data[i];
-  }
-
-  std::stringstream _system_data;
-
-  std::vector<std::stringstream*> _restartable_data;
-};
-
-template<>
-inline void
-dataStore(std::ostream & stream, Backup * & backup, void * context)
-{
-  dataStore(stream, backup->_system_data, context);
-
-  for (unsigned int i=0; i<backup->_restartable_data.size(); i++)
-    dataStore(stream, backup->_restartable_data[i], context);
-}
-
-template<>
-inline void
-dataLoad(std::istream & stream, Backup * & backup, void * context)
-{
-  dataLoad(stream, backup->_system_data, context);
-
-  for (unsigned int i=0; i<backup->_restartable_data.size(); i++)
-    dataLoad(stream, backup->_restartable_data[i], context);
-}
-
 
 /**
  * Class for doing restart.

--- a/framework/src/restart/Backup.C
+++ b/framework/src/restart/Backup.C
@@ -1,0 +1,39 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+// MOOSE includes
+#include "Backup.h"
+#include "RestartableData.h"
+
+#include "libmesh/parallel.h"
+
+
+// Backup Definitions
+Backup::Backup()
+{
+  unsigned int n_threads = libMesh::n_threads();
+
+  _restartable_data.resize(n_threads);
+
+  for (unsigned int i=0; i < n_threads; i++)
+    _restartable_data[i] = new std::stringstream;
+}
+
+Backup::~Backup()
+{
+  unsigned int n_threads = libMesh::n_threads();
+
+  for (unsigned int i=0; i < n_threads; i++)
+    delete _restartable_data[i];
+}

--- a/framework/src/restart/Backup.C
+++ b/framework/src/restart/Backup.C
@@ -26,7 +26,7 @@ Backup::Backup()
 
   _restartable_data.resize(n_threads);
 
-  for (unsigned int i=0; i < n_threads; i++)
+  for (unsigned int i = 0; i < n_threads; ++i)
     _restartable_data[i] = new std::stringstream;
 }
 
@@ -34,6 +34,6 @@ Backup::~Backup()
 {
   unsigned int n_threads = libMesh::n_threads();
 
-  for (unsigned int i=0; i < n_threads; i++)
+  for (unsigned int i = 0; i < n_threads; ++i)
     delete _restartable_data[i];
 }

--- a/test/include/userobjects/PointerLoadError.h
+++ b/test/include/userobjects/PointerLoadError.h
@@ -22,7 +22,7 @@ class PointerLoadError;
 template<>
 InputParameters validParams<PointerLoadError>();
 
-class Stupid
+class TypeWithNoLoad
 {
 public:
   int _i;
@@ -31,7 +31,7 @@ public:
 /// Store but no Load!
 template<>
 inline void
-dataStore(std::ostream & stream, Stupid * & v, void * context)
+dataStore(std::ostream & stream, TypeWithNoLoad * & v, void * context)
 {
   dataStore(stream, v->_i, context);
 }
@@ -51,7 +51,7 @@ public:
   virtual void finalize() {};
 
 protected:
-  Stupid * & _pointer_data;
+  TypeWithNoLoad * & _pointer_data;
 };
 
 

--- a/test/include/userobjects/PointerStoreError.h
+++ b/test/include/userobjects/PointerStoreError.h
@@ -22,7 +22,7 @@ class PointerStoreError;
 template<>
 InputParameters validParams<PointerStoreError>();
 
-class ReallyDumb
+class TypeWithNoStore
 {
 public:
   int _i;
@@ -42,7 +42,7 @@ public:
   virtual void finalize() {};
 
 protected:
-  ReallyDumb * & _pointer_data;
+  TypeWithNoStore * & _pointer_data;
 };
 
 

--- a/test/src/userobjects/PointerLoadError.C
+++ b/test/src/userobjects/PointerLoadError.C
@@ -24,9 +24,9 @@ InputParameters validParams<PointerLoadError>()
 
 PointerLoadError::PointerLoadError(const InputParameters & params) :
     GeneralUserObject(params),
-    _pointer_data(declareRestartableData<Stupid *>("pointer_data"))
+    _pointer_data(declareRestartableData<TypeWithNoLoad *>("pointer_data"))
 {
-  _pointer_data = new Stupid;
+  _pointer_data = new TypeWithNoLoad;
   _pointer_data->_i = 1;
 }
 

--- a/test/src/userobjects/PointerStoreError.C
+++ b/test/src/userobjects/PointerStoreError.C
@@ -24,9 +24,9 @@ InputParameters validParams<PointerStoreError>()
 
 PointerStoreError::PointerStoreError(const InputParameters & params) :
     GeneralUserObject(params),
-    _pointer_data(declareRestartableData<ReallyDumb *>("pointer_data"))
+    _pointer_data(declareRestartableData<TypeWithNoStore *>("pointer_data"))
 {
-  _pointer_data = new ReallyDumb;
+  _pointer_data = new TypeWithNoStore;
   _pointer_data->_i = 1;
 }
 

--- a/test/tests/restart/pointer_restart_errors/tests
+++ b/test/tests/restart/pointer_restart_errors/tests
@@ -2,7 +2,7 @@
   [./pointer_store_error]
     type = 'RunException'
     input = 'pointer_store_error.i'
-    expect_err = 'Cannot store raw pointers'
+    expect_err = 'Attempting to store a raw pointer type:'
   [../]
 
   [./pointer_load_error]
@@ -14,7 +14,7 @@
   [./pointer_load_error2]
     type = 'RunException'
     input = 'pointer_load_error2.i'
-    expect_err = 'Cannot load raw pointers'
+    expect_err = 'Attempting to load a raw pointer type:'
     prereq = pointer_load_error
     max_parallel = 16
   [../]


### PR DESCRIPTION
This PR adds "demangle" to print a better error message when a raw pointer is seen in the checkpoint operation. It required me to split out the `Backup` type into it's own file due to both `DataIO` and `RestartableDataIO` needing access to that type.

closes #6673
