### PR TITLE
Small optimizations for reinit at phys

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -737,6 +737,10 @@ protected:
   /// Temporary work vector to keep from reallocating it
   std::vector<dof_id_type> _temp_dof_indices;
 
+  /// Temporary work data for reinitAtPhysical()
+  std::vector<Point> _temp_reference_points;
+  FEType _temp_fe_type;
+
   /**
    * Storage for cached Jacobian entries
    */

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -509,13 +509,11 @@ Assembly::reinitAtPhysical(const Elem * elem, const std::vector<Point> & physica
   _current_elem = elem;
   _current_neighbor_elem = NULL;
 
-  std::vector<Point> reference_points;
-
-  FEInterface::inverse_map(elem->dim(), FEType(), elem, physical_points, reference_points);
+  FEInterface::inverse_map(elem->dim(), _temp_fe_type, elem, physical_points, _temp_reference_points);
 
   _currently_fe_caching = false;
 
-  reinit(elem, reference_points);
+  reinit(elem, _temp_reference_points);
 
   // Save off the physical points
   _current_physical_points = physical_points;

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -985,10 +985,7 @@ FEProblem::reinitElem(const Elem * elem, THREAD_ID tid)
 void
 FEProblem::reinitElemPhys(const Elem * elem, std::vector<Point> phys_points_in_elem, THREAD_ID tid)
 {
-  std::vector<Point> points(phys_points_in_elem.size());
-  std::copy(phys_points_in_elem.begin(), phys_points_in_elem.end(), points.begin());
-
-  _assembly[tid]->reinitAtPhysical(elem, points);
+  _assembly[tid]->reinitAtPhysical(elem, phys_points_in_elem);
 
   _nl.prepare(tid);
   _aux.prepare(tid);


### PR DESCRIPTION
These small optimizations (mostly about not creating and destroying millions of temporaries) sped up my current code by %10!

I need to do a lot more optimization in this area... but this is a good start!

Refs #6675
