### PR TITLE
A test for multithreading issue 6682

### DIFF
--- a/test/tests/auxkernels/solution_aux/thread_xda.i
+++ b/test/tests/auxkernels/solution_aux/thread_xda.i
@@ -1,0 +1,78 @@
+[Mesh]
+  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  type = GeneratedMesh
+  distribution = SERIAL
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Functions]
+  [./u_xda_func]
+    type = SolutionFunction
+    solution = xda_u
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 1
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 2
+  [../]
+[]
+
+[UserObjects]
+  [./xda_u]
+    type = SolutionUserObject
+    system = nl0
+    mesh = aux_nonlinear_solution_out_0001_mesh.xda
+    es = aux_nonlinear_solution_out_0001.xda
+    system_variables = u
+    execute_on = initial
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Steady
+  solve_type = PJFNK
+  nl_rel_tol = 1e-10
+[]
+
+[Postprocessors]
+  [./unorm]
+    type = ElementL2Norm
+    variable = u
+  [../]
+  [./uerror]
+    type = ElementL2Error
+    variable = u
+    function = u_xda_func
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+[]


### PR DESCRIPTION
This input is mainly copied from `tests/auxkernels/solution_aux/aux_nonlinear_solution_xda.i`.
On my local mac, I got with this test:

```
Number of threads   uerror
1                               1
2                               1.023513
3                               1.010285
4                               1.011200
```

Refer #6682.
