### PR TITLE
Make computeQpElasticityTensor pure abstract in TensorMechanics materials

### DIFF
--- a/modules/tensor_mechanics/include/materials/CosseratLinearElasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/CosseratLinearElasticMaterial.h
@@ -10,6 +10,7 @@
 #define COSSERATLINEARELASTICMATERIAL_H
 
 #include "TensorMechanicsMaterial.h"
+#include "Function.h"
 
 /**
  * CosseratLinearElasticMaterial handles a fully anisotropic, single-crystal material's elastic
@@ -61,6 +62,10 @@ private:
 
   /// determines the translation from B_ijkl to the Rank-4 tensor
   MooseEnum _fill_method_bending;
+
+protected:
+  ElasticityTensorR4 _Cijkl;
+  Function * const _prefactor_function;
 };
 
 #endif //COSSERATLINEARELASTICMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
@@ -9,6 +9,7 @@
 
 #include "FiniteStrainMaterial.h"
 #include "ElementPropertyReadFile.h"
+#include "Function.h"
 
 /**
  * FiniteStrainCrystalPlasticity uses the multiplicative decomposition of deformation gradient
@@ -368,6 +369,10 @@ protected:
   Real _dfgrd_scale_factor;
   ///Flags to reset variables and reinitialize variables
   bool _first_step_iter, _last_step_iter, _first_substep;
+
+  ElasticityTensorR4 _Cijkl;
+  Function * const _prefactor_function;
+
 };
 
 #endif //FINITESTRAINCRYSTALPLASTICITY_H

--- a/modules/tensor_mechanics/include/materials/FiniteStrainElasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainElasticMaterial.h
@@ -10,6 +10,7 @@
 #define FINITESTRAINELASTICMATERIAL_H
 
 #include "FiniteStrainMaterial.h"
+#include "Function.h"
 
 /**
  * FiniteStrainElasticMaterial handles a fully anisotropic, single-crystal material's elastic
@@ -24,6 +25,12 @@ public:
 
 protected:
   virtual void computeQpStress();
+  virtual void computeQpElasticityTensor();
+
+  ElasticityTensorR4 _Cijkl;
+  Function * const _prefactor_function;
+
 };
+
 
 #endif //FINITESTRAINELASTICMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/FiniteStrainPlasticBase.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainPlasticBase.h
@@ -8,6 +8,7 @@
 #define FINITESTRAINPLASTICBASE
 
 #include "FiniteStrainMaterial.h"
+#include "Function.h"
 
 class FiniteStrainPlasticBase;
 
@@ -26,6 +27,7 @@ public:
 
 protected:
   virtual void computeQpStress();
+  virtual void computeQpElasticityTensor();
   virtual void initQpStatefulProperties();
 
   /// Maximum number of Newton-Raphson iterations allowed
@@ -283,6 +285,8 @@ protected:
    */
   virtual bool lineSearch(Real & nr_res2, RankTwoTensor & stress, const std::vector<Real> & intnl_old, std::vector<Real> & intnl, std::vector<Real> & pm, const RankFourTensor & E_inv, RankTwoTensor & delta_dp, const RankTwoTensor & dstress, const std::vector<Real> & dpm, const std::vector<Real> & dintnl, std::vector<Real> & f, RankTwoTensor & epp, std::vector<Real> & ic);
 
+  ElasticityTensorR4 _Cijkl;
+  Function * const _prefactor_function;
 
  private:
 

--- a/modules/tensor_mechanics/include/materials/FiniteStrainPlasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainPlasticMaterial.h
@@ -10,6 +10,7 @@
 #define FINITESTRAINPLASTICMATERIAL_H
 
 #include "FiniteStrainMaterial.h"
+#include "Function.h"
 
 class FiniteStrainPlasticMaterial;
 
@@ -31,6 +32,7 @@ public:
 
 protected:
   virtual void computeQpStress();
+  virtual void computeQpElasticityTensor();
   virtual void initQpStatefulProperties();
 
   std::vector<Real> _yield_stress_vector;
@@ -118,6 +120,9 @@ protected:
    * d(yieldstress)/d(equivalent plastic strain)
    */
   Real getdYieldStressdPlasticStrain(const Real equivalent_plastic_strain);
+
+  ElasticityTensorR4 _Cijkl;
+  Function * const _prefactor_function;
 };
 
 #endif //FINITESTRAINPLASTICMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/LinearElasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/LinearElasticMaterial.h
@@ -10,6 +10,7 @@
 #define LINEARELASTICMATERIAL_H
 
 #include "TensorMechanicsMaterial.h"
+#include "Function.h"
 
 /**
  * LinearElasticMaterial handles a fully anisotropic, single-crystal material's elastic
@@ -25,6 +26,7 @@ public:
 protected:
   virtual void computeQpStrain();
   virtual void computeQpStress();
+  virtual void computeQpElasticityTensor();
   virtual RankTwoTensor computeStressFreeStrain();
 
 private:
@@ -35,6 +37,10 @@ private:
 
   std::vector<Real> _applied_strain_vector;
   RankTwoTensor _applied_strain_tensor;
+
+protected:
+  ElasticityTensorR4 _Cijkl;
+  Function * const _prefactor_function;  
 };
 
 #endif //LINEARELASTICMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
+++ b/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
@@ -34,7 +34,7 @@ public:
 protected:
   virtual void initQpStatefulProperties();
   virtual void computeProperties();
-  virtual void computeQpElasticityTensor();
+  virtual void computeQpElasticityTensor() = 0;
   virtual void computeStrain();
 
   virtual void computeQpStrain() = 0;
@@ -62,12 +62,6 @@ protected:
   MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
 
   RealVectorValue _Euler_angles;
-
-  /// Individual material information
-  ElasticityTensorR4 _Cijkl;
-
-  /// prefactor function to multiply the elasticity tensor with
-  Function * const _prefactor_function;
 
   RankTwoTensor _strain_increment;
 


### PR DESCRIPTION
The following changes are made
1. TensorMechanicsMaterial::computeQpElasticityTensor is made purely abstract
2. The elasticity tensor Cijkl and the scaling function are removed from the TensorMechanicsMaterial params
3. Where needed, the above are implemented in derived classes (for example, LinearElasticMaterial::computeQpElasticityTensor is defined, and Cijkl and the scaling function added.)

The reasons for this change are the following:
1. It does not make sense for TensorMechanicsMaterial to have a pure abstract computeQpStresses function and a defined computeQpElasticityTensor function.
2. For finite strain, it is meaningless to define elasticity tensor constants, as they generally change with material deformation.
3. Future finite strain classes should not have Cijkl as a required parameter.
