### PR TITLE
Remove trailing whitespace from .tex files.

### DIFF
--- a/framework/scripts/mooseExamplesLateX/preamble.tex
+++ b/framework/scripts/mooseExamplesLateX/preamble.tex
@@ -18,7 +18,7 @@
    showstringspaces=false,
    basicstyle=\footnotesize\ttfamily,
    emph={label}
-} 
+}
 
 \lstdefinelanguage{ini}
 {
@@ -30,7 +30,7 @@
 }
 
 \lstdefinestyle{ini}
-{  
+{
    language=ini,
    tabsize=3,
    frame=lines,
@@ -38,7 +38,7 @@
    commentstyle=\color{darkgreen},
    stringstyle=\color{red},
    showstringspaces=false,
-   basicstyle=\footnotesize\ttfamily,   
+   basicstyle=\footnotesize\ttfamily,
 }
 
 \usepackage{caption}

--- a/modules/chemical_reactions/doc/desorption/desorption.tex
+++ b/modules/chemical_reactions/doc/desorption/desorption.tex
@@ -52,7 +52,7 @@ The adsorption/desorption equation is
 \dot{C} = \left\{
 \begin{array}{ll}
 -(C - C_{\mathrm{e}})/\tau_{d} & \ \ \ \mbox{for } \ \ C\geq C_{\mathrm{e}} \\
--(C - C_{\mathrm{e}})/\tau_{a} & \ \ \ \mbox{for } \ \ C < C_{\mathrm{e}} 
+-(C - C_{\mathrm{e}})/\tau_{a} & \ \ \ \mbox{for } \ \ C < C_{\mathrm{e}}
 \ .
 \end{array}
 \right.
@@ -139,7 +139,7 @@ time constant is
 \tanh \left| \frac{C-C_{\mathrm{e}}}{m\rho_{L}}\right| \,
 \end{equation}
 for $C_{\mathrm{e}}$ given by the Langmuir expression of
-Eqn~(\ref{langmuir.ce}).  
+Eqn~(\ref{langmuir.ce}).
 Here $m$ is a mollification parameter.  As $m \rightarrow 0^{+}$ the
 mollified version tends to the original Langmuir version.
 

--- a/modules/combined/doc/desorption/desorption.tex
+++ b/modules/combined/doc/desorption/desorption.tex
@@ -52,7 +52,7 @@ The adsorption/desorption equation is
 \dot{C} = \left\{
 \begin{array}{ll}
 -(C - C_{\mathrm{e}})/\tau_{d} & \ \ \ \mbox{for } \ \ C\geq C_{\mathrm{e}} \\
--(C - C_{\mathrm{e}})/\tau_{a} & \ \ \ \mbox{for } \ \ C < C_{\mathrm{e}} 
+-(C - C_{\mathrm{e}})/\tau_{a} & \ \ \ \mbox{for } \ \ C < C_{\mathrm{e}}
 \ .
 \end{array}
 \right.

--- a/modules/combined/doc/richards/tests/tests.tex
+++ b/modules/combined/doc/richards/tests/tests.tex
@@ -158,7 +158,7 @@ with respect to $S$ are correctly coded.
 (\kappa_{s}-\kappa_{n})\frac{\Theta^{2}(C-1)}{C-\Theta} \ ,
 \label{bw.krel}
 \end{equation}
-where $\Theta = (S-S_{n})/(S_{s}-S_{n})$, 
+where $\Theta = (S-S_{n})/(S_{s}-S_{n})$,
 is correctly coded, and also that its first and second derivatives
 with respect to $S$ are correctly coded.  Broadbridge and White assume
 that saturation is bounded $S_{n}\leq S\leq S_{s}$, so for most MOOSE
@@ -187,7 +187,7 @@ is correctly coded, and also that its first and second derivatives
 with respect to $P$ are correctly coded.
 
 \item That the density of methane (kg.m$^{-3}$) at 20degC as a
-  function of $P$ (Pa): 
+  function of $P$ (Pa):
 \begin{equation}
 \rho(P) = 6.54576947608\times 10^{-6}P + 1.04357716547\times 10^{-13} P^{2}
 \end{equation}
@@ -208,7 +208,7 @@ with respect to $P_{\mathrm{c}}$ are correctly coded.
 \frac{P_{\mathrm{c}}}{\lambda_{s}} = \frac{1-\Theta}{\Theta} - \frac{1}{C}\log
 \left( \frac{C-\Theta}{(C-1)\Theta} \right) \ ,
 \end{equation}
-with $\Theta = (S_{\mathrm{eff}} - S_{n})/(S_{s}-S_{n})$, 
+with $\Theta = (S_{\mathrm{eff}} - S_{n})/(S_{s}-S_{n})$,
 is correctly coded, and also that the first and second derivatives of
 $S_{\mathrm{eff}}$ with respect to $P_{\mathrm{c}}$ are correctly
 coded.  Note that Broadbridge and White assume that
@@ -310,7 +310,7 @@ Van Genuchten $m$ & 0.5 \\
 Van Genuchten $\alpha$ & 1\,Pa$^{-1}$ \\
 Porosity & 0.1 \\
 \hline
-\end{tabular} 
+\end{tabular}
 \end{center}
 The porepressure is set at $P=x$.
 
@@ -330,7 +330,7 @@ $x$ & $p$ & Density & $S_{\mathrm{eff}}$ & Saturation & Mass \\
 \hline
  & & & & Total & 0.206884 \\
 \hline
-\end{tabular} 
+\end{tabular}
 \end{center}
 MOOSE also gives the total mass as 0.206884\,kg.  This test is part of
 the automatic test suite that is run every time the code is updated.
@@ -427,7 +427,7 @@ $\mbox{}$ \\
 $\mbox{}$ \\
 \begin{tabular}{cc}
 \includegraphics[width=8cm]{gh_seff_50.eps} &
-\includegraphics[width=8cm]{gh_p_50.eps} 
+\includegraphics[width=8cm]{gh_p_50.eps}
 \end{tabular}
 \caption{Results for $S_{\mathrm{imm}}=0.3$.  Gravity points to the
   left.  Top picture: Effective saturation.  Middle picture: Pore
@@ -474,7 +474,7 @@ Power-type relative permeabilty $n$ & 2 \\
 $\kappa_{xx}$ & $10^{-5}$\,m$^{2}$ \\
 Porosity & 0.1 \\
 \hline
-\end{tabular} 
+\end{tabular}
 \end{center}
 
 \noindent In the first test a piecewise-linear sink is applied with strength:
@@ -483,7 +483,7 @@ Porosity & 0.1 \\
 \begin{array}{ll}
 1 & \mbox{ for } p \leq 0 \\
 1+p & \mbox{ for } 0<p<1 \\
-2 & \mbox{ for } p\geq 1 
+2 & \mbox{ for } p\geq 1
 \end{array}
 \right.
 \label{eqn.s01}
@@ -518,7 +518,7 @@ Figure~\ref{s01.fig}.
 \mbox{sink flux (kg.m$^{-1}$.s$^{-1}$)} = \left\{
 \begin{array}{ll}
 2\exp(-0.5(P-1)^{2}) & \mbox{ for } p < 1 \\
-2 & \mbox{ for } p\geq 1 
+2 & \mbox{ for } p\geq 1
 \end{array}
 \right.
 \label{eqn.s02}
@@ -552,13 +552,13 @@ Figure~\ref{s02.fig}.
 \noindent In the third test a piecewise-linear sink with relative
 permeability and mobility affects is used.  The flux strength is:
 \begin{equation}
-\mbox{sink flux (kg.m$^{-1}$.s$^{-1}$)} = 
+\mbox{sink flux (kg.m$^{-1}$.s$^{-1}$)} =
 \frac{\rho\kappa_{xx}\kappa_{\mathrm{rel}}}{\mu}
 \times \left\{
 \begin{array}{ll}
 100 & \mbox{ for } p \leq -1 \\
 150+50p& \mbox{ for } -1<p<1 \\
-200 & \mbox{ for } p\geq 1 
+200 & \mbox{ for } p\geq 1
 \end{array}
 \right.
 \label{eqn.s03}
@@ -610,7 +610,7 @@ element occurs.  The following fluid properties are used:
 Constant fluid bulk modulus & 2\,GPa \\
 Fluid density at zero pressure & 1000\,kg.m$^{-3}$ \\
 \hline
-\end{tabular} 
+\end{tabular}
 \end{center}
 The test is fully-saturated, so the van Genuchten parameters, etc, are
 irrelevant.  The initial porepressure is set to 10\,MPa, and the
@@ -665,7 +665,7 @@ becomes
 \begin{equation}
 \frac{\partial}{\partial t}\rho = \nabla_{i}\alpha_{ij}\nabla\rho \ ,
 \end{equation}
-with 
+with
 \begin{equation}
 \alpha_{ij} = \frac{\kappa_{ij}B}{\mu\phi} \ .
 \end{equation}
@@ -709,7 +709,7 @@ These tests run rapidly and are part of the automatic test suite.
 \caption{Comparison between the MOOSE result (in dots), and the
   exact analytic expression given by Eqn~(\ref{eqn.exact.pp}).  This
   test had 10 elements in the $x$ direction, with $0\leq x \leq
-  100$\,m, and ran for a total of 
+  100$\,m, and ran for a total of
   10$^4$ seconds with 10 timesteps.  The parameters were $B=2$\,GPa,
   $\kappa_{xx}=10^{-15}$\,m$^{2}$, $\mu=10^{-3}$\,Pa.s, $\phi=0.1$,
   with initial pressure $P=2$\,MPa, and applied pressure $P=3$\,MPa at
@@ -729,7 +729,7 @@ This test demonstrates that MOOSE behaves correctly when a simulation
 contains a sink.  The sink is a piecewise linear function of pressure.
 
 Darcy's equation for flow through a fully saturated medium without
-gravity and without sources is 
+gravity and without sources is
 \begin{equation}
 \frac{\partial}{\partial t}\phi\rho = \nabla_{i}\left(\frac{\rho
   \kappa_{ij}}{\mu} \nabla_{j}P \right) \ ,
@@ -740,7 +740,7 @@ becomes
 \begin{equation}
 \frac{\partial}{\partial t}\rho = \nabla_{i}\alpha_{ij}\nabla_{j}\rho \ ,
 \end{equation}
-with 
+with
 \begin{equation}
 \alpha_{ij} = \frac{\kappa_{ij}B}{\mu\phi} \ .
 \end{equation}
@@ -836,7 +836,7 @@ aquifer height, $b$ (m).  In the Theis solution, gravitational
 effects are ignored (the pressures at the bottom and top of the
 aquifer are is assumed equal).  At some horizontal radial distance, $r$, from
 the borehole the pressure is measured.  The geometry is shown in
-Figure~\ref{th.setup.fig}. 
+Figure~\ref{th.setup.fig}.
 
 \begin{figure}[htb]
 \begin{center}
@@ -900,7 +900,7 @@ P(r,t) = P_{0} - \frac{Q\mu}{4\pi b \kappa} \int_{\frac{r^{2}\phi\mu}{4 t \kappa
 
 The hydrogeology literature uses different notation.  It defines the
 head, $h=P/\rho g$; the transmissivity, $T = \kappa\rho g b/\mu$; the
-storativity, $S = b\rho 
+storativity, $S = b\rho
 g \phi/K_{\mathrm{w}}$; and the well function $W(x) =
 \int_{x}^{\infty}u^{-1}e^{-u}\mathrm{d}u$, so that the Theis solution,
 Eqn~(\ref{eqn.theis}) becomes
@@ -953,7 +953,7 @@ Eqn~(\ref{assumption.eqn}) contains an important assumption of the
 Theis solution which constrains the validity of the result.
 Substituting the solution, Eqn~(\ref{eqn.theis}), into the assumption
 yields
-\begin{equation} 
+\begin{equation}
 \frac{1}{u} e^{-u} \ll \frac{4 \pi b \kappa K_{\mathrm{w}}}{Q\phi\mu}
 = \frac{4\pi b T}{QS} \ ,
 \end{equation}
@@ -1157,7 +1157,7 @@ $r=300$\,m; and the outer pressure is $P_{R}=10$\,MPa.
 \label{bw}
 
 The Richards' equation for an incompressible fluid reads in one
-spatial dimension ($z$) reads 
+spatial dimension ($z$) reads
 \begin{equation}
 \dot{S} = \nabla \left(D \nabla S\right) - \nabla K \ ,
 \end{equation}
@@ -1182,7 +1182,7 @@ assume the hydraulic conductivity is
 \begin{equation}
 K(S) = K_{n} + (K_{s}-K_{n})\frac{\Theta^{2}(C-1)}{C-\Theta} \ ,
 \end{equation}
-where 
+where
 \begin{equation}
 \Theta = \frac{S - S_{n}}{S_{s} - S_{s}} \ ,
 \end{equation}
@@ -1428,7 +1428,7 @@ The initial condition is
 P(t=0) = \left\{
 \begin{array}{ll}
 P_{0} - (P_{0}-P_{15})x/5 & \ \ \ \mbox{for }\ \ x<5 \\
-P_{15} & \ \ \ \mbox{for }\ \ x\geq 5  
+P_{15} & \ \ \ \mbox{for }\ \ x\geq 5
 \end{array}
 \right. \ ,
 \end{equation}
@@ -1464,7 +1464,7 @@ and the front position $f(t)$ may be determined from
 P(x,t) & = & \left\{
 \begin{array}{ll}
 P_{0} - (P_{0}-P_{15})x/f & \mbox{ for } x\leq f  \\
-P_{15} & \mbox{ for } x>f 
+P_{15} & \mbox{ for } x>f
 \end{array}
 \right. \ ,
 \label{eqn.predicted.bl.posn.eqna}
@@ -1722,7 +1722,7 @@ The initial condition is
 P_{\mathrm{water}}(t=0) = \left\{
 \begin{array}{ll}
 10^{6}(1-x/5) & \ \ \ \mbox{for }\ \ x<5 \\
--10^{5} & \ \ \ \mbox{for }\ \ x\geq 5  
+-10^{5} & \ \ \ \mbox{for }\ \ x\geq 5
 \end{array}
 \right. \ ,
 \end{equation}
@@ -1731,7 +1731,7 @@ and
 P_{\mathrm{gas}}(t=0) = \left\{
 \begin{array}{ll}
 10^{6}(1-x/5) + 10^{3} & \ \ \ \mbox{for }\ \ x<5 \\
-10^{3} & \ \ \ \mbox{for }\ \ x\geq 5  
+10^{3} & \ \ \ \mbox{for }\ \ x\geq 5
 \end{array}
 \right. \ .
 \end{equation}
@@ -1794,7 +1794,7 @@ flow.  The simulation details are:
   to run, so is marked as ``heavy'' in the test suite and is not run
   every time the code is updated.
 \item A uniform mesh of size 0.5\,m, with timestep between 0.1\,s and
-  4\,s.  The van Genuchten 
+  4\,s.  The van Genuchten
   $\alpha=10^{-5}$\,Pa$^{-1}$ and $m=0.8$.  Instead of $P=-10^{5}$\,Pa
   at the $x=15$ end, $P=-3\times 10^{5}$\,Pa is used instead, which
   means $s=0.01$ in the unsaturated zone.  At $t=50$\,s the mesh sits

--- a/modules/combined/doc/richards/theory/theory.tex
+++ b/modules/combined/doc/richards/theory/theory.tex
@@ -192,7 +192,7 @@ presence of large negative porepressures.)
 The MOOSE implementation allows users to specify arbitrary
 relationships between density and porepressure.  One common case
 for liquids is that the fluid bulk modulus is constant, which means
-that 
+that
 \begin{equation}
 \rho = \rho_{0}e^{P/K} \ .
 \end{equation}
@@ -316,7 +316,7 @@ The Broadbridge-White capillary curve valid for small $K_{n}$ has also been code
 
 The Rogers-Stallybrass-Clements capillary curve valid for zero
 residual saturations and oil viscosity double that of water viscosity
-has also been coded into MOOSE~\cite{rsc1983}. 
+has also been coded into MOOSE~\cite{rsc1983}.
 
 \section{Relative permeability}
 \label{rel.perm.sec}
@@ -552,7 +552,7 @@ permeability.  Another example is in coupled problems when $\kappa$ is
 a function of time.
 
 Finally, all these piecewise-linear sink fluxes may be multiplied by a
-user-defined function: 
+user-defined function:
 \begin{equation}
 F \rightarrow F\times g(t, x, y, z) \ ,
 \end{equation}
@@ -658,12 +658,12 @@ about 5\,m, so a standard value for $\sigma$ is $\sigma = 5\times
 is 1000\,kg.m$^{-3}$ and gravity is 10\,m.s$^{-2}$.
 
 Finally, the half-Gaussian sink may be multiplied by a
-user-defined function: 
+user-defined function:
 \begin{equation}
 F \rightarrow F\times g(t, x, y, z) \ ,
 \end{equation}
 if the user desires.  This is useful, for instance, if
-evapotranspiration is a known function of space and time. 
+evapotranspiration is a known function of space and time.
 
 
 If the half-Gaussian sink is unsuitable, a piecewise-linear
@@ -769,22 +769,22 @@ P_{\mathrm{atm}}) )$.
 
 Wellbores are implemented in a similar way to
 Eqn~(\ref{source.stream.eqn}) using the method first described by
-Peaceman~\cite{peaceman1983}.  Here  
+Peaceman~\cite{peaceman1983}.  Here
 \begin{equation}
 F = \sum_{i}f(P_{i}, x_{i})\delta(x - x_{i}) \ ,
 \end{equation}
 with $P_{i}$ being the porepressure at point $i$.  Here $f$ is a
-special function (measured in kg.s$^{-1}$ in standard 
+special function (measured in kg.s$^{-1}$ in standard
 units) defined in terms of the pressure at a
 point at the wall of the wellbore (which is an input parameter: it is
-not the porepressure) 
+not the porepressure)
 \begin{equation}
 P_{\mathrm{wellbore}}(x_{i}) = P_{\mathrm{bot}} + \gamma \cdot (x_{i} -
 x_{i}^{\mathrm{bot}})
 \end{equation}
 The form of $f$ is
 \begin{equation}
-f(P_{i}, x_{i}) = 
+f(P_{i}, x_{i}) =
 W \left|C(P_{i}-P_{\mathrm{wellbore}})\right|
 \frac{\kappa_{\mathrm{rel}}\rho}{\mu}(P_{i} - P_{\mathrm{wellbore}})
 \end{equation}
@@ -813,7 +813,7 @@ There are a number of parameters in these expressions:
   acts as a source, adding fluid to the porespace.
 \end{itemize}
 \item The function $W$ is called the well-constant of the wellbore, and is
-measured in units of length$^{3}$. 
+measured in units of length$^{3}$.
 \end{itemize}
 
 Peaceman~\cite{peaceman1983} described the form of $W$ by performing
@@ -832,7 +832,7 @@ finite-difference approach, Peaceman found that
 \begin{equation}
 r_{e} = 0.28 \frac{\sqrt{\sqrt{\kappa_{xx}/\kappa_{yy}}L_{x}^{2} +
     \sqrt{\kappa_{yy}/\kappa_{xx}}L_{y}^{2}}}{(\kappa_{xx}/\kappa_{yy})^{1/4}
-  + (\kappa_{yy}/\kappa_{xx})^{1/4}} 
+  + (\kappa_{yy}/\kappa_{xx})^{1/4}}
 = 0.2 \frac{\sqrt{\mbox{$\frac{1}{2}$}\sqrt{\kappa_{xx}/\kappa_{yy}}L_{x}^{2} +
     \mbox{$\frac{1}{2}$}\sqrt{\kappa_{yy}/\kappa_{xx}}L_{y}^{2}}}{\mbox{$\frac{1}{2}$}(\kappa_{xx}/\kappa_{yy})^{1/4}
   + \mbox{$\frac{1}{2}$}(\kappa_{yy}/\kappa_{xx})^{1/4}} \ .
@@ -1264,7 +1264,7 @@ Richards' equations for multi-phase flow are
 \begin{equation}
 \phi \frac{\partial}{\partial t} \left( \rho^{\gamma} S^{\gamma} \right) = \nabla_{i}
 \left( \frac{\rho^{\gamma} \kappa_{ij}\kappa^{\gamma}_{\mathrm{rel}}}{\mu^{\gamma}} (\nabla_{j}P^{\gamma} - \rho^{\gamma}
-g_{j}) \right) 
+g_{j}) \right)
 + F^{\gamma} \ ,
 \label{richards.eqn.multi}
 \end{equation}
@@ -1293,7 +1293,7 @@ S^{\gamma}_{\mathrm{eff}}(P_{1},\ P_{2},\ldots) \ .
 It is therefore the saturations that couple the separate phases
 together.  The MOOSE implementation allows users to specify arbitrary
 functions for the effective saturations, but these must obey the
-constraint 
+constraint
 \begin{equation}
 \sum_{\gamma}S^{\gamma} = 1 \ .
 \end{equation}
@@ -1490,7 +1490,7 @@ and the mobility function
 The isoparametric coordinate for the first element is $\xi =
 \frac{z-L/2}{L/2}$, which yields $b=2v/L$
 (Eqn~(\ref{eqn.b.params.supg}).  When $P_{\mathrm{SUPG}}$ is set
-small, the upwinding parameter 
+small, the upwinding parameter
 \begin{equation}
 \tau = \left|\frac{L}{2v}\right| \ .
 \end{equation}

--- a/modules/combined/doc/richards/user/user.tex
+++ b/modules/combined/doc/richards/user/user.tex
@@ -42,7 +42,7 @@ MOOSE code, drawing mainly upon the test suite.  There are two other
 accompanying documents: (1) The theoretical and numerical foundations
 of the code, which also describes the notation used throughout this
 document; (2) The test suite, which describes the benchmark tests used
-to validate the code. 
+to validate the code.
 
 
 \chapter{The examples}
@@ -135,7 +135,7 @@ Evaluate this for your ``steadystate'' solution.  For instance, in the
 case of water just quoted, $R = V|\kappa|\rho_{0}/\mu\epsilon =
 V|\kappa|\times 10^{6}\epsilon$, where: $V$ is the volume of the
 finite-element mesh, and I have inserted standard values for
-$\rho_{0}$ and $\mu$.  
+$\rho_{0}$ and $\mu$.
 \item In the previous step, an appropriate tolernace on the residual
   was given as $V|\kappa|\rho_{0}\epsilon/\mu$.  However, this is often too
   large because of the factor of $V$.  The previous step assumed that

--- a/modules/combined/examples/phase_field-mechanics/grn_36_rand_2D.tex
+++ b/modules/combined/examples/phase_field-mechanics/grn_36_rand_2D.tex
@@ -1,5 +1,5 @@
 Texture File
- 
+
 File generated from MATLAB
 B 36
    80.00   0.00   0.00  1.00

--- a/modules/combined/examples/phase_field-mechanics/grn_36_test_2D.tex
+++ b/modules/combined/examples/phase_field-mechanics/grn_36_test_2D.tex
@@ -1,5 +1,5 @@
 Texture File
- 
+
 File generated from MATLAB
 B 36
    0.0   0.00   0.00  1.00

--- a/modules/combined/tests/ACGrGrElasticDrivingForce/test.tex
+++ b/modules/combined/tests/ACGrGrElasticDrivingForce/test.tex
@@ -1,5 +1,5 @@
 Texture File
- 
+
 File generated from MATLAB
 B 2
    0.00   0.00   0.00  1.00

--- a/modules/misc/doc/fracture_flow/fracture_flow.tex
+++ b/modules/misc/doc/fracture_flow/fracture_flow.tex
@@ -108,7 +108,7 @@ In this equation:
   be unity within the fracture, since it is assumed to be fully filled
   with solvent, but less than unity in the bulk.
 \item $D_{ij}$ is the anisotropic diffusivity tensor
-  [L$^{2}$.T$^{-1}$], which is different in the fracture and in the bulk.  The analytical 
+  [L$^{2}$.T$^{-1}$], which is different in the fracture and in the bulk.  The analytical
   results are only valid for certain $D_{ij}$ as described below
 \item $v_{i}$ is the solvent velocity, for instance provided through
   Darcy flow [L.T$^{-1}$].  The analytical results are only valid for certain

--- a/modules/richards/doc/q2p/q2p.tex
+++ b/modules/richards/doc/q2p/q2p.tex
@@ -339,7 +339,7 @@ specifically to the Q2P formulation.
 \item Setting the diffusivity can be key to ensuring good convergence.
   If it is set too small then shocks will form.  If you observe this
   occuring, eg, the saturation   varies from 0 to 1 over one element,
-  then $D$ should be increased. 
+  then $D$ should be increased.
 
 \item I have found the system can exit the physical region $0\leq
   S_{w} \leq 1$ more easily than in the Richards formulation.  I'm not

--- a/modules/richards/doc/tests/tests.tex
+++ b/modules/richards/doc/tests/tests.tex
@@ -158,7 +158,7 @@ with respect to $S$ are correctly coded.
 (\kappa_{s}-\kappa_{n})\frac{\Theta^{2}(C-1)}{C-\Theta} \ ,
 \label{bw.krel}
 \end{equation}
-where $\Theta = (S-S_{n})/(S_{s}-S_{n})$, 
+where $\Theta = (S-S_{n})/(S_{s}-S_{n})$,
 is correctly coded, and also that its first and second derivatives
 with respect to $S$ are correctly coded.  Broadbridge and White assume
 that saturation is bounded $S_{n}\leq S\leq S_{s}$, so for most MOOSE
@@ -195,7 +195,7 @@ is correctly coded, and also that its first and second derivatives
 with respect to $P$ are correctly coded.
 
 \item That the density of methane (kg.m$^{-3}$) at 20degC as a
-  function of $P$ (Pa) for pressures less than 12\,MPa: 
+  function of $P$ (Pa) for pressures less than 12\,MPa:
 \begin{equation}
 \rho(P) = 6.54576947608\times 10^{-6}P + 1.04357716547\times 10^{-13} P^{2}
 \end{equation}
@@ -224,7 +224,7 @@ with respect to $P_{\mathrm{c}}$ are correctly coded.
 \frac{P_{\mathrm{c}}}{\lambda_{s}} = \frac{1-\Theta}{\Theta} - \frac{1}{C}\log
 \left( \frac{C-\Theta}{(C-1)\Theta} \right) \ ,
 \end{equation}
-with $\Theta = (S_{\mathrm{eff}} - S_{n})/(S_{s}-S_{n})$, 
+with $\Theta = (S_{\mathrm{eff}} - S_{n})/(S_{s}-S_{n})$,
 is correctly coded, and also that the first and second derivatives of
 $S_{\mathrm{eff}}$ with respect to $P_{\mathrm{c}}$ are correctly
 coded.  Note that Broadbridge and White assume that
@@ -349,7 +349,7 @@ Van Genuchten $m$ & 0.5 \\
 Van Genuchten $\alpha$ & 1\,Pa$^{-1}$ \\
 Porosity & 0.1 \\
 \hline
-\end{tabular} 
+\end{tabular}
 \end{center}
 The porepressure is set at $P=x$.
 
@@ -369,7 +369,7 @@ $x$ & $p$ & Density & $S_{\mathrm{eff}}$ & Saturation & Mass \\
 \hline
  & & & & Total & 0.206884 \\
 \hline
-\end{tabular} 
+\end{tabular}
 \end{center}
 MOOSE also gives the total mass as 0.206884\,kg.  This test is part of
 the automatic test suite that is run every time the code is updated.
@@ -478,7 +478,7 @@ $\mbox{}$ \\
 $\mbox{}$ \\
 \begin{tabular}{cc}
 \includegraphics[width=8cm]{gh_seff_50.eps} &
-\includegraphics[width=8cm]{gh_p_50.eps} 
+\includegraphics[width=8cm]{gh_p_50.eps}
 \end{tabular}
 \caption{Results for $S_{\mathrm{imm}}=0.3$.  Gravity points to the
   left.  Top picture: Effective saturation.  Middle picture: Pore
@@ -496,7 +496,7 @@ $\mbox{}$ \\
 \includegraphics[width=8cm]{gh2_20.eps} &
 \includegraphics[width=8cm]{gh2.eps}
 \end{tabular}
-\includegraphics[width=8cm]{gh2_p.eps} 
+\includegraphics[width=8cm]{gh2_p.eps}
 \caption{Two-phase long-time results for
   $S^{\mathrm{gas}}_{\mathrm{imm}}=0.3$ and
   $S^{\mathrm{water}}_{\mathrm{imm}}=0.4$.  Left: 20-element
@@ -538,7 +538,7 @@ Power-type relative permeabilty $n$ & 2 \\
 $\kappa_{xx}$ & $10^{-5}$\,m$^{2}$ \\
 Porosity & 0.1 \\
 \hline
-\end{tabular} 
+\end{tabular}
 \end{center}
 
 \noindent In the first set of two tests a piecewise-linear sink is applied with strength:
@@ -547,7 +547,7 @@ Porosity & 0.1 \\
 \begin{array}{ll}
 1 & \mbox{ for } p \leq 0 \\
 1+p & \mbox{ for } 0<p<1 \\
-2 & \mbox{ for } p\geq 1 
+2 & \mbox{ for } p\geq 1
 \end{array}
 \right.
 \label{eqn.s01}
@@ -583,7 +583,7 @@ Figure~\ref{s01.fig}.
 \mbox{sink flux (kg.m$^{-1}$.s$^{-1}$)} = \left\{
 \begin{array}{ll}
 2\exp(-0.5(P-1)^{2}) & \mbox{ for } p < 1 \\
-2 & \mbox{ for } p\geq 1 
+2 & \mbox{ for } p\geq 1
 \end{array}
 \right.
 \label{eqn.s02}
@@ -617,13 +617,13 @@ Figure~\ref{s02.fig}.
 \noindent In the third set of two tests a piecewise-linear sink with relative
 permeability and mobility affects is used.  The flux strength is:
 \begin{equation}
-\mbox{sink flux (kg.m$^{-1}$.s$^{-1}$)} = 
+\mbox{sink flux (kg.m$^{-1}$.s$^{-1}$)} =
 \frac{\rho\kappa_{xx}\kappa_{\mathrm{rel}}}{\mu}
 \times \left\{
 \begin{array}{ll}
 100 & \mbox{ for } p \leq -1 \\
 150+50p& \mbox{ for } -1<p<1 \\
-200 & \mbox{ for } p\geq 1 
+200 & \mbox{ for } p\geq 1
 \end{array}
 \right.
 \label{eqn.s03}
@@ -695,7 +695,7 @@ element occurs.  The following fluid properties are used:
 Constant fluid bulk modulus & 2\,GPa \\
 Fluid density at zero pressure & 1000\,kg.m$^{-3}$ \\
 \hline
-\end{tabular} 
+\end{tabular}
 \end{center}
 The test is fully-saturated, so the van Genuchten parameters, etc, are
 irrelevant.  The initial porepressure is set to 10\,MPa, and the
@@ -750,7 +750,7 @@ becomes
 \begin{equation}
 \frac{\partial}{\partial t}\rho = \nabla_{i}\alpha_{ij}\nabla\rho \ ,
 \end{equation}
-with 
+with
 \begin{equation}
 \alpha_{ij} = \frac{\kappa_{ij}B}{\mu\phi} \ .
 \end{equation}
@@ -783,7 +783,7 @@ This is verified by using the following twelve tests on a line of
   steady-state of $\rho = \rho_{\infty}$ is achieved.
 \item Transient 1-phase analysis with an unlumped time derivative.
 \item Transient 1-phase analysis with a lumped time derivative.
-\item Steady state 2-phase analysis with a fully-water saturated configuration. 
+\item Steady state 2-phase analysis with a fully-water saturated configuration.
 \item Transient 2-phase analysis with unlumped time derivatives.
 \item Transient 2-phase analysis with lumped time derivatives.
 \end{enumerate}
@@ -797,7 +797,7 @@ These tests run rapidly and are part of the automatic test suite.
 \caption{Comparison between the MOOSE result (in dots), and the
   exact analytic expression given by Eqn~(\ref{eqn.exact.pp}).  This
   test had 10 elements in the $x$ direction, with $0\leq x \leq
-  100$\,m, and ran for a total of 
+  100$\,m, and ran for a total of
   10$^4$ seconds with 10 timesteps.  The parameters were $B=2$\,GPa,
   $\kappa_{xx}=10^{-15}$\,m$^{2}$, $\mu=10^{-3}$\,Pa.s, $\phi=0.1$,
   with initial pressure $P=2$\,MPa, and applied pressure $P=3$\,MPa at
@@ -817,7 +817,7 @@ This test demonstrates that MOOSE behaves correctly when a simulation
 contains a sink.  The sink is a piecewise linear function of pressure.
 
 Darcy's equation for flow through a fully saturated medium without
-gravity and without sources is 
+gravity and without sources is
 \begin{equation}
 \frac{\partial}{\partial t}\phi\rho = \nabla_{i}\left(\frac{\rho
   \kappa_{ij}}{\mu} \nabla_{j}P \right) \ ,
@@ -828,7 +828,7 @@ becomes
 \begin{equation}
 \frac{\partial}{\partial t}\rho = \nabla_{i}\alpha_{ij}\nabla_{j}\rho \ ,
 \end{equation}
-with 
+with
 \begin{equation}
 \alpha_{ij} = \frac{\kappa_{ij}B}{\mu\phi} \ .
 \end{equation}
@@ -926,7 +926,7 @@ aquifer height, $b$ (m).  In the Theis solution, gravitational
 effects are ignored (the pressures at the bottom and top of the
 aquifer are is assumed equal).  At some horizontal radial distance, $r$, from
 the borehole the pressure is measured.  The geometry is shown in
-Figure~\ref{th.setup.fig}. 
+Figure~\ref{th.setup.fig}.
 
 \begin{figure}[htb]
 \begin{center}
@@ -990,7 +990,7 @@ P(r,t) = P_{0} - \frac{Q\mu}{4\pi b \kappa} \int_{\frac{r^{2}\phi\mu}{4 t \kappa
 
 The hydrogeology literature uses different notation.  It defines the
 head, $h=P/\rho g$; the transmissivity, $T = \kappa\rho g b/\mu$; the
-storativity, $S = b\rho 
+storativity, $S = b\rho
 g \phi/K_{\mathrm{w}}$; and the well function $W(x) =
 \int_{x}^{\infty}u^{-1}e^{-u}\mathrm{d}u$, so that the Theis solution,
 Eqn~(\ref{eqn.theis}) becomes
@@ -1043,7 +1043,7 @@ Eqn~(\ref{assumption.eqn}) contains an important assumption of the
 Theis solution which constrains the validity of the result.
 Substituting the solution, Eqn~(\ref{eqn.theis}), into the assumption
 yields
-\begin{equation} 
+\begin{equation}
 \frac{1}{u} e^{-u} \ll \frac{4 \pi b \kappa K_{\mathrm{w}}}{Q\phi\mu}
 = \frac{4\pi b T}{QS} \ ,
 \end{equation}
@@ -1254,7 +1254,7 @@ $r=300$\,m; and the outer pressure is $P_{R}=10$\,MPa.
 \label{bw}
 
 The Richards' equation for an incompressible fluid reads in one
-spatial dimension ($z$) reads 
+spatial dimension ($z$) reads
 \begin{equation}
 \dot{S} = \nabla \left(D \nabla S\right) - \nabla K \ ,
 \end{equation}
@@ -1279,7 +1279,7 @@ assume the hydraulic conductivity is
 \begin{equation}
 K(S) = K_{n} + (K_{s}-K_{n})\frac{\Theta^{2}(C-1)}{C-\Theta} \ ,
 \end{equation}
-where 
+where
 \begin{equation}
 \Theta = \frac{S - S_{n}}{S_{s} - S_{s}} \ ,
 \end{equation}
@@ -1525,7 +1525,7 @@ The initial condition is
 P(t=0) = \left\{
 \begin{array}{ll}
 P_{0} - (P_{0}-P_{15})x/5 & \ \ \ \mbox{for }\ \ x<5 \\
-P_{15} & \ \ \ \mbox{for }\ \ x\geq 5  
+P_{15} & \ \ \ \mbox{for }\ \ x\geq 5
 \end{array}
 \right. \ ,
 \end{equation}
@@ -1561,7 +1561,7 @@ and the front position $f(t)$ may be determined from
 P(x,t) & = & \left\{
 \begin{array}{ll}
 P_{0} - (P_{0}-P_{15})x/f & \mbox{ for } x\leq f  \\
-P_{15} & \mbox{ for } x>f 
+P_{15} & \mbox{ for } x>f
 \end{array}
 \right. \ ,
 \label{eqn.predicted.bl.posn.eqna}
@@ -1824,7 +1824,7 @@ The initial condition is
 P_{\mathrm{water}}(t=0) = \left\{
 \begin{array}{ll}
 10^{6}(1-x/5) & \ \ \ \mbox{for }\ \ x<5 \\
--10^{5} & \ \ \ \mbox{for }\ \ x\geq 5  
+-10^{5} & \ \ \ \mbox{for }\ \ x\geq 5
 \end{array}
 \right. \ ,
 \end{equation}
@@ -1833,7 +1833,7 @@ and
 P_{\mathrm{gas}}(t=0) = \left\{
 \begin{array}{ll}
 10^{6}(1-x/5) + 10^{3} & \ \ \ \mbox{for }\ \ x<5 \\
-10^{3} & \ \ \ \mbox{for }\ \ x\geq 5  
+10^{3} & \ \ \ \mbox{for }\ \ x\geq 5
 \end{array}
 \right. \ .
 \end{equation}
@@ -1897,7 +1897,7 @@ flow.  Six simulations in total are part of the test suite:
   to run, so are marked as ``heavy'' in the test suite and are not run
   every time the code is updated.
 \item ``Low res''.  A uniform mesh of size 0.5\,m, with timestep between 0.1\,s and
-  4\,s.  The van Genuchten 
+  4\,s.  The van Genuchten
   $\alpha=10^{-5}$\,Pa$^{-1}$ and $m=0.8$.  Instead of $P=-10^{5}$\,Pa
   at the $x=15$ end, $P=-3\times 10^{5}$\,Pa is used instead, which
   means $s=0.01$ in the unsaturated zone.  At $t=50$\,s the mesh sits
@@ -1934,7 +1934,7 @@ $\mbox{}$
 \caption{Comparison of the two-phase Buckley-Leverett solution at
   $t=50$\,s with SUPG and no mass lumping, with SUPG and mass lumping,
   and with full upwinding and mass lumping, for
-  the ``high res'' case 
+  the ``high res'' case
   with $\alpha = 10^{-4}$\,Pa$^{-1}$.  Note the oscillatory
   behaviour in the unlumped version even though it uses SUPG.}
 \label{bl_lump.fig}

--- a/modules/richards/doc/theory/theory.tex
+++ b/modules/richards/doc/theory/theory.tex
@@ -191,7 +191,7 @@ presence of large negative porepressures.)
 The MOOSE implementation allows users to specify arbitrary
 relationships between density and porepressure.  One common case
 for liquids is that the fluid bulk modulus is constant, which means
-that 
+that
 \begin{equation}
 \rho = \rho_{0}e^{P/K} \ .
 \end{equation}
@@ -315,7 +315,7 @@ The Broadbridge-White capillary curve valid for small $K_{n}$ has also been code
 
 The Rogers-Stallybrass-Clements capillary curve valid for zero
 residual saturations and oil viscosity double that of water viscosity
-has also been coded into MOOSE~\cite{rsc1983}. 
+has also been coded into MOOSE~\cite{rsc1983}.
 
 A ``shifted'' version of Eqn~(\ref{vg.cap.eqn}) has been coded for
 into MOOSE for 2-phase simulations.  The effective saturation for the
@@ -582,7 +582,7 @@ permeability.  Another example is in coupled problems when $\kappa$ is
 a function of time.
 
 Finally, all these piecewise-linear sink fluxes may be multiplied by a
-user-defined function: 
+user-defined function:
 \begin{equation}
 F \rightarrow F\times g(t, x, y, z) \ ,
 \end{equation}
@@ -699,12 +699,12 @@ about 5\,m, so a standard value for $\sigma$ is $\sigma = 5\times
 is 1000\,kg.m$^{-3}$ and gravity is 10\,m.s$^{-2}$.
 
 Finally, the half-Gaussian sink may be multiplied by a
-user-defined function: 
+user-defined function:
 \begin{equation}
 F \rightarrow F\times g(t, x, y, z) \ ,
 \end{equation}
 if the user desires.  This is useful, for instance, if
-evapotranspiration is a known function of space and time. 
+evapotranspiration is a known function of space and time.
 
 
 If the half-Gaussian sink is unsuitable, a piecewise-linear
@@ -810,22 +810,22 @@ P_{\mathrm{atm}}) )$.
 
 Wellbores are implemented in a similar way to
 Eqn~(\ref{source.stream.eqn}) using the method first described by
-Peaceman~\cite{peaceman1983}.  Here  
+Peaceman~\cite{peaceman1983}.  Here
 \begin{equation}
 F = \sum_{i}f(P_{i}, x_{i})\delta(x - x_{i}) \ ,
 \end{equation}
 with $P_{i}$ being the porepressure at point $i$.  Here $f$ is a
-special function (measured in kg.s$^{-1}$ in standard 
+special function (measured in kg.s$^{-1}$ in standard
 units) defined in terms of the pressure at a
 point at the wall of the wellbore (which is an input parameter: it is
-not the porepressure) 
+not the porepressure)
 \begin{equation}
 P_{\mathrm{wellbore}}(x_{i}) = P_{\mathrm{bot}} + \gamma \cdot (x_{i} -
 x_{i}^{\mathrm{bot}})
 \end{equation}
 The form of $f$ is
 \begin{equation}
-f(P_{i}, x_{i}) = 
+f(P_{i}, x_{i}) =
 W \left|C(P_{i}-P_{\mathrm{wellbore}})\right|
 \frac{\kappa_{\mathrm{rel}}\rho}{\mu}(P_{i} - P_{\mathrm{wellbore}})
 \end{equation}
@@ -854,7 +854,7 @@ There are a number of parameters in these expressions:
   acts as a source, adding fluid to the porespace.
 \end{itemize}
 \item The function $W$ is called the well-constant of the wellbore, and is
-measured in units of length$^{3}$. 
+measured in units of length$^{3}$.
 \end{itemize}
 
 Peaceman~\cite{peaceman1983} described the form of $W$ by performing
@@ -873,7 +873,7 @@ finite-difference approach, Peaceman found that
 \begin{equation}
 r_{e} = 0.28 \frac{\sqrt{\sqrt{\kappa_{xx}/\kappa_{yy}}L_{x}^{2} +
     \sqrt{\kappa_{yy}/\kappa_{xx}}L_{y}^{2}}}{(\kappa_{xx}/\kappa_{yy})^{1/4}
-  + (\kappa_{yy}/\kappa_{xx})^{1/4}} 
+  + (\kappa_{yy}/\kappa_{xx})^{1/4}}
 = 0.2 \frac{\sqrt{\mbox{$\frac{1}{2}$}\sqrt{\kappa_{xx}/\kappa_{yy}}L_{x}^{2} +
     \mbox{$\frac{1}{2}$}\sqrt{\kappa_{yy}/\kappa_{xx}}L_{y}^{2}}}{\mbox{$\frac{1}{2}$}(\kappa_{xx}/\kappa_{yy})^{1/4}
   + \mbox{$\frac{1}{2}$}(\kappa_{yy}/\kappa_{xx})^{1/4}} \ .
@@ -1314,7 +1314,7 @@ and the mobility function
 The isoparametric coordinate for the first element is $\xi =
 \frac{z-L/2}{L/2}$, which yields $b=2v/L$
 (Eqn~(\ref{eqn.b.params.supg}).  When $P_{\mathrm{SUPG}}$ is set
-small, the upwinding parameter 
+small, the upwinding parameter
 \begin{equation}
 \tau = \left|\frac{L}{2v}\right| \ .
 \end{equation}
@@ -1451,7 +1451,7 @@ think this approach was first introduced by Dalen~\cite{dalen1979} in
 The residual at the downwind nodes is determined by conserving mass.
 Specifically, let
 \begin{equation}
-I_{\mathrm{up}} = \sum_{I_{a}\geq 0}I_{a} \ \ \ \mbox{and}\ \ \ 
+I_{\mathrm{up}} = \sum_{I_{a}\geq 0}I_{a} \ \ \ \mbox{and}\ \ \
 I_{\mathrm{down}} = -\sum_{I_{a}<0} I_{a} \ .
 \end{equation}
 Then
@@ -1603,7 +1603,7 @@ Richards' equations for multi-phase flow are
 \begin{equation}
 \phi \frac{\partial}{\partial t} \left( \rho^{\gamma} S^{\gamma} \right) = \nabla_{i}
 \left( \frac{\rho^{\gamma} \kappa_{ij}\kappa^{\gamma}_{\mathrm{rel}}}{\mu^{\gamma}} (\nabla_{j}P^{\gamma} - \rho^{\gamma}
-g_{j}) \right) 
+g_{j}) \right)
 + F^{\gamma} \ ,
 \label{richards.eqn.multi}
 \end{equation}
@@ -1632,7 +1632,7 @@ S^{\gamma}_{\mathrm{eff}}(P_{1},\ P_{2},\ldots) \ .
 It is therefore the saturations that couple the separate phases
 together.  The MOOSE implementation allows users to specify arbitrary
 functions for the effective saturations, but these must obey the
-constraint 
+constraint
 \begin{equation}
 \sum_{\gamma}S^{\gamma} = 1 \ .
 \end{equation}

--- a/modules/richards/doc/user/user.tex
+++ b/modules/richards/doc/user/user.tex
@@ -134,7 +134,7 @@ MOOSE is struggling with.
   ``power'' covers over the ``VG'' curves.
 \item In multiphase problems if one phase completely disappears, MOOSE
   may not converge, as discussed more fully in
-  Chapter~\ref{chap.sing.jac}.  To avoid this: 
+  Chapter~\ref{chap.sing.jac}.  To avoid this:
 \begin{enumerate}
 \item The fully-upwind kernel and boundary fluxes and dirac sources
   can be used.  If the immobile saturation of the phase is nonzero,
@@ -202,7 +202,7 @@ Evaluate this for your ``steadystate'' solution.  For instance, in the
 case of water just quoted, $R = V|\kappa|\rho_{0}/\mu\epsilon =
 V|\kappa|\times 10^{6}\epsilon$, where: $V$ is the volume of the
 finite-element mesh, and I have inserted standard values for
-$\rho_{0}$ and $\mu$.  
+$\rho_{0}$ and $\mu$.
 \item In the previous step, an appropriate tolernace on the residual
   was given as $V|\kappa|\rho_{0}\epsilon/\mu$.  However, this is often too
   large because of the factor of $V$.  The previous step assumed that
@@ -343,7 +343,7 @@ J = \frac{\phi}{dt} \left(
 \begin{array}{cc}
 \rho_{g}'S_{g} + \rho_{g}S' &
 -\rho_{g}S' \\
--\rho_{w}S' & 
+-\rho_{w}S' &
 \rho_{w}'S_{w} + \rho_{w}S'
 \end{array}
 \right)
@@ -360,7 +360,7 @@ J = \frac{\phi}{dt} \left(
 \begin{array}{cc}
 \rho_{g}'S_{g}^{\mathrm{res}}  &
 0 \\
-0 & 
+0 &
 \rho_{w}'(1 - S_{g}^{\mathrm{res}})
 \end{array}
 \right)

--- a/modules/tensor_mechanics/doc/theory/cosserat.tex
+++ b/modules/tensor_mechanics/doc/theory/cosserat.tex
@@ -79,7 +79,7 @@ These will be rederived in a more general setting in 3D in Section~\ref{3d.coss.
   moments/unit area in 3D).  The filled-in-dot or crossed-dot
   is the standard pictorial method for representing a moment ``coming
   out of or into the paper (respectively)'' using the right-hand screw
-  convention.} 
+  convention.}
 \label{inf_cosserat.fig}
 \end{center}
 \end{figure}
@@ -104,8 +104,8 @@ moved according to
 \begin{equation}
 \left(\begin{array}{c}x\\y\end{array}\right) \rightarrow
 \left(\begin{array}{cc}\cos\theta & -\sin\theta \\ \sin\theta & \cos\theta
-\end{array}\right) 
-\left(\begin{array}{c}x\\y\end{array}\right) 
+\end{array}\right)
+\left(\begin{array}{c}x\\y\end{array}\right)
 \approx
 \left(\begin{array}{c}x - \theta y\\y + \theta x\end{array}\right)   \ .
 \label{rigid.rot.eqn}
@@ -161,7 +161,7 @@ Natural measures of infinitesimal strain are
 \pl_{x}\thetac \\
 \pl_{y}\thetac
 \end{array}
-\right) = 
+\right) =
 \left(\begin{array}{c}
 \ep_{xx} \\
 \ep_{yy} \\
@@ -170,11 +170,11 @@ Natural measures of infinitesimal strain are
 \pl_{x}\thetac \\
 \pl_{y}\thetac
 \end{array}
-\right) 
+\right)
 \label{nat.2d.deform.measures}
 \end{equation}
 These are natural for the following reasons.  Importantly, these
-measures transform covariantly under both 
+measures transform covariantly under both
 $x\rightarrow -x$ and $y\rightarrow -y$.    This is
 because under each of these $\thetarel\rightarrow -\thetarel$, which may be
 understood from a number of different perspectives, such as handedness
@@ -211,7 +211,7 @@ Figure~\ref{inf_cosserat.fig} and the 3D extension is obvious.
 Equilibrium of the volume $V$ is equivalent to requiring
 \begin{eqnarray*}
 0 & = & -\int_{V}\rho \ddot{x}_{i} + \int_{\pl V}\si_{ij}n_{j} +
-\int_{V}F_{i} \ , \\ 
+\int_{V}F_{i} \ , \\
 0 & = & -\int_{V}\rho \ep_{ijk}x_{j}\ddot{x}_{k} + \tilde{\rho}\ddot{\theta}_{c} =
 \int_{\pl V}\left(\ep_{ijk}x_{j}\si_{kl}n_{l} + m_{ij}n_{j}\right) +
 \int_{V}\left(\ep_{ijk}x_{j}F_{k} + M_{i}\right) \ .
@@ -278,7 +278,7 @@ Since $\ga_{ij}$ is a proper tensor and $\ka_{ij}$ is a pseudo
 vector, the most general second-order form for the energy density is
 $$
 \mathcal{E} = \mbox{$\frac{1}{4}$}\la(\tr\ga)^{2} +
-\mu\ga_{(ij)}\ga_{(ij)} - \al\ga_{[ij]}\ga_{[ij]} 
+\mu\ga_{(ij)}\ga_{(ij)} - \al\ga_{[ij]}\ga_{[ij]}
 + \mbox{$\frac{1}{4}$}\be(\tr\ka)^{2} +
 \ga\ka_{(ij)}\ka_{(ij)} - \ep\ka_{[ij]}\ka_{[ij]}  \ .
 $$
@@ -290,7 +290,7 @@ hope that in the following formulae, the modulus $\ga$ can be
 distinguished from the deformation measure $\ga_{ij}$.  The moduli
 $\al$, $\be$, $\ga$ and $\ep$ are used in this section {\em only}.
 
-Varying the energy gives 
+Varying the energy gives
 \begin{eqnarray}
 \si_{ij} & = & \la\de_{ij}\tr\ga + 2\mu\ga_{(ij)} + 2\al\ga_{[ij]} \ ,
 \non \\

--- a/scripts/delete_trailing_whitespace.sh
+++ b/scripts/delete_trailing_whitespace.sh
@@ -15,5 +15,5 @@ else
       echo "Adding newline at EOF: $fname"
       sed -i -e '$a\' "$fname"
     fi
-  done < <( find "$REPO_DIR" -path ./contrib -prune -o -path ./libmesh -prune -o \( -name "*.[Chi]" -o -name "*.py" \) -type f -print0)
+  done < <( find "$REPO_DIR" -path ./contrib -prune -o -path ./libmesh -prune -o \( -name "*.[Chi]" -o -name "*.py" -o -name "*.tex" \) -type f -print0)
 fi


### PR DESCRIPTION
scripts/delete_trailing_whitespace.sh will now remove trailing whitespace from .tex files.

refs #6689
