### PR TITLE
Replace deprecated Tensor Mechanics materials

### DIFF
--- a/modules/combined/examples/phase_field-mechanics/Pattern1.i
+++ b/modules/combined/examples/phase_field-mechanics/Pattern1.i
@@ -37,6 +37,7 @@
   # CahnHilliard needs the third derivatives
   derivative_order = 3
   enable_jit = true
+  displacements = 'disp_x disp_y'
 []
 
 # AuxVars to compute the free energy density for outputting
@@ -121,8 +122,6 @@
 [Kernels]
   # Set up stress divergence kernels
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
   [../]
 
   # Cahn-Hilliard kernels
@@ -258,43 +257,75 @@
   [../]
 
   # matrix phase
-  [./eigenstrain_1]
-    type = LinearElasticMaterial
-    base_name = phase1
+  [./elasticity_tensor_1]
+    type = ComputeElasticityTensor
     block = 0
-    disp_y = disp_y
-    disp_x = disp_x
-    # Stiffness tensor lambda, mu values
+    base_name = phase1
     C_ijkl = '3 3'
     fill_method = symmetric_isotropic
   [../]
-
-  # oversized phase (simulated using thermal expansion)
-  [./eigenstrain_2]
-    type = LinearElasticMaterial
-    base_name = phase2
+  [./strain_1]
+    type = ComputeSmallStrain
     block = 0
-    thermal_expansion_coeff = 0.02
-    T0 = 0
-    T = 1
-    disp_y = disp_y
-    disp_x = disp_x
+    base_name = phase1
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress_1]
+    type = ComputeLinearElasticStress
+    block = 0
+    base_name = phase1
+  [../]
+
+  # oversized phase
+  [./elasticity_tensor_2]
+    type = ComputeElasticityTensor
+    block = 0
+    base_name = phase2
     C_ijkl = '7 7'
     fill_method = symmetric_isotropic
   [../]
-
-  # undersized phase (simulated using thermal expansion)
-  [./eigenstrain_3]
-    type = LinearElasticMaterial
-    base_name = phase3
+  [./strain_2]
+    type = ComputeSmallStrain
     block = 0
-    thermal_expansion_coeff = -0.05
-    T0 = 0
-    T = 1
-    disp_y = disp_y
-    disp_x = disp_x
+    base_name = phase2
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress_2]
+    type = ComputeLinearElasticStress
+    block = 0
+    base_name = phase2
+  [../]
+  [./eigenstrain_2]
+    type = ComputeEigenstrain
+    block = 0
+    base_name = phase2
+    eigen_base = '0.02'
+  [../]
+
+  # undersized phase
+  [./elasticity_tensor_3]
+    type = ComputeElasticityTensor
+    block = 0
+    base_name = phase3
     C_ijkl = '7 7'
     fill_method = symmetric_isotropic
+  [../]
+  [./strain_3]
+    type = ComputeSmallStrain
+    block = 0
+    base_name = phase3
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress_3]
+    type = ComputeLinearElasticStress
+    block = 0
+    base_name = phase3
+  [../]
+  [./eigenstrain_3]
+    type = ComputeEigenstrain
+    block = 0
+    base_name = phase3
+    eigen_base = '-0.05'
   [../]
 
   # switching functions

--- a/modules/combined/tests/linear_elasticity/LinearElasticMaterial_test.i
+++ b/modules/combined/tests/linear_elasticity/LinearElasticMaterial_test.i
@@ -1,5 +1,3 @@
-# This input file is designed to test the LinearElasticMaterial class.
-
 [Mesh]
   type = GeneratedMesh
   dim = 2
@@ -133,16 +131,22 @@
 []
 
 [Materials]
-  [./Anisotropic]
-    type = LinearElasticMaterial
+  # these materials replace the deprecated LinearElasticMaterial
+  [./elasticity_tensor]
+    type = ComputeElasticityTensor
     block = 0
-    disp_x = disp_x
-    disp_y = disp_y
-
-    #set from elk/tests/anisotropic_path/anisotropic_patch_test.i
     fill_method = symmetric9
     #reading C_11  C_12  C_13  C_22  C_23  C_33  C_44  C_55  C_66
     C_ijkl ='1.0e6  0.0   0.0 1.0e6  0.0  1.0e6 0.5e6 0.5e6 0.5e6'
+  [../]
+  [./strain]
+    type = ComputeSmallStrain
+    block = 0
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+    block = 0
   [../]
 []
 

--- a/modules/combined/tests/linear_elasticity/Tensor_test.i
+++ b/modules/combined/tests/linear_elasticity/Tensor_test.i
@@ -451,14 +451,20 @@
 []
 
 [Materials]
-  [./Anisotropic]
-    type = LinearElasticMaterial
+  [./elasticity_tensor]
+    type = ComputeElasticityTensor
     block = 0
-    disp_x = disp_x
-    disp_y = disp_y
-
     fill_method = symmetric21
     C_ijkl ='1111 1122 1133 1123 1113 1112 2222 2233 2223 2213 2212 3333 3323 3313 3312 2323 2313 2312 1313 1312 1212'
+  [../]
+  [./strain]
+    type = ComputeSmallStrain
+    block = 0
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+    block = 0
   [../]
 []
 

--- a/modules/combined/tests/linear_elasticity/applied_strain_test.i
+++ b/modules/combined/tests/linear_elasticity/applied_strain_test.i
@@ -76,14 +76,26 @@
 []
 
 [Materials]
-  [./Anisotropic]
-    type = LinearElasticMaterial
+  [./elasticity_tensor]
+    type = ComputeElasticityTensor
     block = 0
-    disp_x = disp_x
-    disp_y = disp_y
     fill_method = symmetric9
     C_ijkl = '1e6 0 0 1e6 0 1e6 .5e6 .5e6 .5e6'
-    applied_strain_vector = '0.1 0.05 0 0 0 0.01'
+  [../]
+  [./strain]
+    type = ComputeSmallStrain
+    block = 0
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+    block = 0
+  [../]
+  [./eigenstrain]
+    type = ComputeEigenstrain
+    block = 0
+    eigen_base = '0.1 0.05 0 0 0 0.01'
+    prefactor = -1
   [../]
 []
 

--- a/modules/combined/tests/linear_elasticity/thermal_expansion_test.i
+++ b/modules/combined/tests/linear_elasticity/thermal_expansion_test.i
@@ -79,15 +79,29 @@
 []
 
 [Materials]
-  [./Anisotropic]
-    type = LinearElasticMaterial
+  [./elasticity_tensor]
+    type = ComputeElasticityTensor
     block = 0
-    disp_x = disp_x
-    disp_y = disp_y
     fill_method = symmetric9
     C_ijkl = '1e6 0 0 1e6 0 1e6 .5e6 .5e6 .5e6'
-    thermal_expansion_coeff = 1.0e-6
-    T = 400
+  [../]
+  [./strain]
+    type = ComputeSmallStrain
+    block = 0
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+    block = 0
+  [../]
+  [./eigenstrain]
+    type = ComputeEigenstrain
+    # this models the
+    #   thermal_expansion_coeff = 1.0e-6
+    #   T = 400
+    #   T0 = 300
+    # options of LinearElasticMaterial (T-T0)*1e-6 = 1e-4
+    eigen_base = '1e-4'
   [../]
 []
 

--- a/modules/combined/tests/multiphase_mechanics/elasticenergymaterial.i
+++ b/modules/combined/tests/multiphase_mechanics/elasticenergymaterial.i
@@ -64,17 +64,37 @@
 []
 
 [Materials]
-  [./eigenstrain]
-    # this material is deprecated
-    type = SimpleEigenStrainMaterial
+  [./elasticity_tensor]
+    type = ComputeElasticityTensor
     block = 0
-    epsilon0 = 0.05
-    c = c
-    disp_x = disp_x
-    disp_y = disp_y
-    C_ijkl = '3 1 1 3 1 3 1 1 1 '
     fill_method = symmetric9
+    C_ijkl = '3 1 1 3 1 3 1 1 1 '
   [../]
+  [./strain]
+    type = ComputeSmallStrain
+    block = 0
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+    block = 0
+  [../]
+  [./prefactor]
+    type = DerivativeParsedMaterial
+    block = 0
+    args = c
+    f_name = prefactor
+    constant_names       = 'epsilon0 c0'
+    constant_expressions = '0.05     0'
+    function = '(c - c0) * epsilon0'
+  [../]
+  [./eigenstrain]
+    type = ComputeVariableEigenstrain
+    eigen_base = '1'
+    args = c
+    prefactor = prefactor
+  [../]
+
   [./elasticenergy]
     type = ElasticEnergyMaterial
     block = 0

--- a/modules/combined/tests/multiphase_mechanics/multiphasestress.i
+++ b/modules/combined/tests/multiphase_mechanics/multiphasestress.i
@@ -66,39 +66,81 @@
 []
 
 [Materials]
-  [./Anisotropic_A]
-    # this material is deprecated
-    type = LinearElasticMaterial
-    base_name = A
+  [./elasticity_tensor_A]
+    type = ComputeElasticityTensor
     block = 0
-    disp_x = disp_x
-    disp_y = disp_y
+    base_name = A
     fill_method = symmetric9
     C_ijkl = '1e6 1e5 1e5 1e6 0 1e6 .4e6 .2e6 .5e6'
-    applied_strain_vector = '0.1 0.05 0 0 0 0.01'
   [../]
-  [./Anisotropic_B]
-    # this material is deprecated
-    type = LinearElasticMaterial
+  [./strain_A]
+    type = ComputeSmallStrain
+    block = 0
+    base_name = A
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress_A]
+    type = ComputeLinearElasticStress
+    base_name = A
+  [../]
+  [./eigenstrain_A]
+    type = ComputeEigenstrain
+    block = 0
+    base_name = A
+    eigen_base = '0.1 0.05 0 0 0 0.01'
+    prefactor = -1
+  [../]
+
+  [./elasticity_tensor_B]
+    type = ComputeElasticityTensor
+    block = 0
     base_name = B
-    block = 0
-    disp_x = disp_x
-    disp_y = disp_y
     fill_method = symmetric9
-    C_ijkl = '1e6 0 0 1e6 0 1.1e6 .5e6 .5e6 .5e6'
-    applied_strain_vector = '0.1 0.05 0 0 0 0.01'
+    C_ijkl = '1e6 0 0 1e6 0 1e6 .5e6 .5e6 .5e6'
   [../]
-  [./Anisotropic_C]
-    # this material is deprecated
-    type = LinearElasticMaterial
-    base_name = C
+  [./strain_B]
+    type = ComputeSmallStrain
     block = 0
-    disp_x = disp_x
-    disp_y = disp_y
+    base_name = B
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress_B]
+    type = ComputeLinearElasticStress
+    base_name = B
+  [../]
+  [./eigenstrain_B]
+    type = ComputeEigenstrain
+    block = 0
+    base_name = B
+    eigen_base = '0.1 0.05 0 0 0 0.01'
+    prefactor = -1
+  [../]
+
+  [./elasticity_tensor_C]
+    type = ComputeElasticityTensor
+    block = 0
+    base_name = C
     fill_method = symmetric9
     C_ijkl = '1.1e6 1e5 0 1e6 0 1e6 .5e6 .2e6 .5e6'
-    applied_strain_vector = '0.1 0.05 0 0 0 0.01'
   [../]
+  [./strain_C]
+    type = ComputeSmallStrain
+    block = 0
+    base_name = C
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress_C]
+    type = ComputeLinearElasticStress
+    base_name = C
+  [../]
+  [./eigenstrain_C]
+    type = ComputeEigenstrain
+    block = 0
+    base_name = C
+    eigen_base = '0.1 0.05 0 0 0 0.01'
+    prefactor = -1
+  [../]
+
 
   [./switching_A]
     type = SwitchingFunctionMaterial
@@ -124,7 +166,6 @@
     block = 0
     phase_base = 'A  B  C'
     h          = 'h1 h2 h3'
-    #outputs = exodus
   [../]
 []
 

--- a/modules/combined/tests/multiphase_mechanics/simpleeigenstrain.i
+++ b/modules/combined/tests/multiphase_mechanics/simpleeigenstrain.i
@@ -76,16 +76,48 @@
 []
 
 [Materials]
-  [./eigenstrain]
-    # this material is deprecated
-    type = SimpleEigenStrainMaterial
+  # This deprecated material is replaced by the materials below
+  #
+  #[./eigenstrain]
+  #  type = SimpleEigenStrainMaterial
+  #  block = 0
+  #  epsilon0 = 0.05
+  #  c = c
+  #  disp_y = disp_y
+  #  disp_x = disp_x
+  #  C_ijkl = '3 1 1 3 1 3 1 1 1 '
+  #  fill_method = symmetric9
+  #[../]
+
+  [./elasticity_tensor]
+    type = ComputeElasticityTensor
     block = 0
-    epsilon0 = 0.05
-    c = c
-    disp_y = disp_y
-    disp_x = disp_x
-    C_ijkl = '3 1 1 3 1 3 1 1 1 '
     fill_method = symmetric9
+    C_ijkl = '3 1 1 3 1 3 1 1 1 '
+  [../]
+  [./strain]
+    type = ComputeSmallStrain
+    block = 0
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+    block = 0
+  [../]
+  [./prefactor]
+    type = DerivativeParsedMaterial
+    block = 0
+    args = c
+    f_name = prefactor
+    constant_names       = 'epsilon0 c0'
+    constant_expressions = '0.05     0'
+    function = '(c - c0) * epsilon0'
+  [../]
+  [./eigenstrain]
+    type = ComputeVariableEigenstrain
+    eigen_base = '1'
+    args = c
+    prefactor = prefactor
   [../]
 []
 

--- a/modules/combined/tests/multiphase_mechanics/twophasestress.i
+++ b/modules/combined/tests/multiphase_mechanics/twophasestress.i
@@ -54,30 +54,54 @@
 []
 
 [Materials]
-  # active = 'Anisotropic'
-  active = 'Anisotropic_A Anisotropic_B switching combined'
-
-  [./Anisotropic_A]
-    # this material is deprecated
-    type = LinearElasticMaterial
-    base_name = A
+  [./elasticity_tensor_A]
+    type = ComputeElasticityTensor
     block = 0
-    disp_x = disp_x
-    disp_y = disp_y
+    base_name = A
     fill_method = symmetric9
     C_ijkl = '1e6 1e5 1e5 1e6 0 1e6 .4e6 .2e6 .5e6'
-    applied_strain_vector = '0.1 0.05 0 0 0 0.01'
   [../]
-  [./Anisotropic_B]
-    # this material is deprecated
-    type = LinearElasticMaterial
-    base_name = B
+  [./strain_A]
+    type = ComputeSmallStrain
     block = 0
-    disp_x = disp_x
-    disp_y = disp_y
+    base_name = A
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress_A]
+    type = ComputeLinearElasticStress
+    base_name = A
+  [../]
+  [./eigenstrain_A]
+    type = ComputeEigenstrain
+    block = 0
+    base_name = A
+    eigen_base = '0.1 0.05 0 0 0 0.01'
+    prefactor = -1
+  [../]
+
+  [./elasticity_tensor_B]
+    type = ComputeElasticityTensor
+    block = 0
+    base_name = B
     fill_method = symmetric9
     C_ijkl = '1e6 0 0 1e6 0 1e6 .5e6 .5e6 .5e6'
-    applied_strain_vector = '0.1 0.05 0 0 0 0.01'
+  [../]
+  [./strain_B]
+    type = ComputeSmallStrain
+    block = 0
+    base_name = B
+    displacements = 'disp_x disp_y'
+  [../]
+  [./stress_B]
+    type = ComputeLinearElasticStress
+    base_name = B
+  [../]
+  [./eigenstrain_B]
+    type = ComputeEigenstrain
+    block = 0
+    base_name = B
+    eigen_base = '0.1 0.05 0 0 0 0.01'
+    prefactor = -1
   [../]
 
   [./switching]
@@ -90,7 +114,6 @@
     block = 0
     base_A = A
     base_B = B
-    #outputs = exodus
   [../]
 []
 

--- a/modules/tensor_mechanics/src/materials/ComputeEigenstrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeEigenstrain.C
@@ -11,7 +11,7 @@ InputParameters validParams<ComputeEigenstrain>()
 {
   InputParameters params = validParams<ComputeStressFreeStrainBase>();
   params.addClassDescription("Computes a constant Eigenstrain");
-  params.addRequiredParam<std::vector<Real> >("eigen_base","Vector of values defining the constant base tensor for the Eigenstrain");
+  params.addRequiredParam<std::vector<Real> >("eigen_base", "Vector of values defining the constant base tensor for the Eigenstrain");
   params.addParam<MaterialPropertyName>("prefactor", 1.0, "Name of material defining the variable dependence");
   return params;
 }
@@ -29,4 +29,3 @@ ComputeEigenstrain::computeQpStressFreeStrain()
   //Define Eigenstrain
   _stress_free_strain[_qp] = _eigen_base_tensor * _prefactor[_qp];
 }
-

--- a/modules/tensor_mechanics/src/materials/LinearElasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/LinearElasticMaterial.C
@@ -32,6 +32,8 @@ LinearElasticMaterial::LinearElasticMaterial(const InputParameters & parameters)
     _thermal_expansion_coeff(getParam<Real>("thermal_expansion_coeff")),
     _applied_strain_vector(getParam<std::vector<Real> >("applied_strain_vector"))
 {
+  mooseDeprecated("LinearElasticMaterial is deprecated. Refer to http://mooseframework.org/wiki/PhysicsModules/TensorMechanics/Deprecations/LinearElasticMaterial to convert this input file.");
+
   //Initialize applied strain tensor from input vector
   if (_applied_strain_vector.size() == 6)
     _applied_strain_tensor.fillFromInputVector(_applied_strain_vector);
@@ -78,4 +80,3 @@ LinearElasticMaterial::computeStressFreeStrain()
 
   return stress_free_strain;
 }
-

--- a/modules/tensor_mechanics/src/materials/SimpleEigenStrainMaterial.C
+++ b/modules/tensor_mechanics/src/materials/SimpleEigenStrainMaterial.C
@@ -24,6 +24,7 @@ SimpleEigenStrainMaterial::SimpleEigenStrainMaterial(const InputParameters & par
     _epsilon0(getParam<Real>("epsilon0")),
     _c0(getParam<Real>("c0"))
 {
+  mooseDeprecated("SimpleEigenStrainMaterial is deprecated. Refer to http://mooseframework.org/wiki/PhysicsModules/TensorMechanics/Deprecations/SimpleEigenStrainMaterial to convert this input file.");
 }
 
 void SimpleEigenStrainMaterial::computeEigenStrain()
@@ -47,4 +48,3 @@ void SimpleEigenStrainMaterial::computeQpElasticityTensor()
   _delasticity_tensor_dc[_qp].zero();
   _d2elasticity_tensor_dc2[_qp].zero();
 }
-


### PR DESCRIPTION
Replaces use of `LinearElasticMaterial` and `SimpleEigenStrainMaterial`.

Refs #6125
