### PR TITLE
Deprecate ElasticityTensorR4

### DIFF
--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -245,7 +245,7 @@ private:
 /**
  * Helper function templates to set a variable to zero.
  * Specializations may have to be implemented (for examples see
- * RankTwoTensor, RankFourTensor, ElasticityTensorR4).
+ * RankTwoTensor, RankFourTensor).
  */
 template<typename T>
 inline void mooseSetToZero(T & v)

--- a/modules/phase_field/include/kernels/ACGrGrElasticDrivingForce.h
+++ b/modules/phase_field/include/kernels/ACGrGrElasticDrivingForce.h
@@ -6,7 +6,7 @@
 //Forward Declarations
 class ACGrGrElasticDrivingForce;
 class RankTwoTensor;
-class ElasticityTensorR4;
+class RankFourTensor;
 
 template<>
 InputParameters validParams<ACGrGrElasticDrivingForce>();
@@ -24,7 +24,7 @@ protected:
   virtual Real computeDFDOP(PFFunctionType type);
 
 private:
-  const MaterialProperty<ElasticityTensorR4> & _D_elastic_tensor;
+  const MaterialProperty<RankFourTensor> & _D_elastic_tensor;
   const MaterialProperty<RankTwoTensor> & _elastic_strain;
 };
 

--- a/modules/phase_field/include/materials/ComputePolycrystalElasticityTensor.h
+++ b/modules/phase_field/include/materials/ComputePolycrystalElasticityTensor.h
@@ -26,7 +26,7 @@ protected:
   virtual void computeQpElasticityTensor();
 
   /// Unrotated elasticity tensor
-  ElasticityTensorR4 _C_unrotated;
+  RankFourTensor _C_unrotated;
 
   Real _length_scale;
   Real _pressure_scale;
@@ -50,10 +50,10 @@ protected:
   std::vector<const VariableValue *> _vals;
 
   /// vector of elasticity tensor material properties
-  std::vector< MaterialProperty<ElasticityTensorR4> *> _D_elastic_tensor;
+  std::vector< MaterialProperty<RankFourTensor> *> _D_elastic_tensor;
 
   /// vector of elasticity tensors for storing rotated elasticity tensors for each grain
-  std::vector<ElasticityTensorR4> _C_rotated;
+  std::vector<RankFourTensor> _C_rotated;
 
   /// Conversion factor from J to eV
   const Real _JtoeV;

--- a/modules/phase_field/include/materials/ElasticEnergyMaterial.h
+++ b/modules/phase_field/include/materials/ElasticEnergyMaterial.h
@@ -12,7 +12,7 @@
 // Forward Declaration
 class ElasticEnergyMaterial;
 class RankTwoTensor;
-class ElasticityTensorR4;
+class RankFourTensor;
 
 template<>
 InputParameters validParams<DerivativeFunctionMaterialBase>();
@@ -38,9 +38,9 @@ protected:
   // std::vector<std::vector<const MaterialProperty<RankTwoTensor> *> > _d2stress;
 
   ///@{ Elasticity tensor derivatives
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
-  std::vector<const MaterialProperty<ElasticityTensorR4> *> _delasticity_tensor;
-  std::vector<std::vector<const MaterialProperty<ElasticityTensorR4> *> > _d2elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
+  std::vector<const MaterialProperty<RankFourTensor> *> _delasticity_tensor;
+  std::vector<std::vector<const MaterialProperty<RankFourTensor> *> > _d2elasticity_tensor;
   ///@}
 
   ///@{ Strain and derivatives

--- a/modules/phase_field/src/kernels/ACGrGrElasticDrivingForce.C
+++ b/modules/phase_field/src/kernels/ACGrGrElasticDrivingForce.C
@@ -1,7 +1,7 @@
 #include "ACGrGrElasticDrivingForce.h"
 
 #include "Material.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 template<>
@@ -15,7 +15,7 @@ InputParameters validParams<ACGrGrElasticDrivingForce>()
 
 ACGrGrElasticDrivingForce::ACGrGrElasticDrivingForce(const InputParameters & parameters) :
     ACBulk<Real>(parameters),
-    _D_elastic_tensor(getMaterialProperty<ElasticityTensorR4>("D_tensor_name")),
+    _D_elastic_tensor(getMaterialProperty<RankFourTensor>("D_tensor_name")),
     _elastic_strain(getMaterialPropertyByName<RankTwoTensor>("elastic_strain"))
 {
 }

--- a/modules/phase_field/src/materials/ComputePolycrystalElasticityTensor.C
+++ b/modules/phase_field/src/materials/ComputePolycrystalElasticityTensor.C
@@ -74,7 +74,7 @@ ComputePolycrystalElasticityTensor::ComputePolycrystalElasticityTensor(const Inp
     std::string material_name = propertyNameFirst(_elasticity_tensor_name, var_name);
 
     // declare elasticity tensor derivative properties
-    _D_elastic_tensor[op] = &declareProperty<ElasticityTensorR4>(material_name);
+    _D_elastic_tensor[op] = &declareProperty<RankFourTensor>(material_name);
   }
 }
 
@@ -82,7 +82,7 @@ void
 ComputePolycrystalElasticityTensor::computeQpElasticityTensor()
 {
   // Initialize local elasticity tnesor and sum of h
-  ElasticityTensorR4 local_elasticity_tensor;
+  RankFourTensor local_elasticity_tensor;
 
   Real sum_h = 0.0;
 
@@ -129,7 +129,7 @@ ComputePolycrystalElasticityTensor::computeQpElasticityTensor()
     unsigned int grn_index = active_ops[op].first;
     unsigned int op_index = active_ops[op].second;
     Real dhdopi = libMesh::pi * std::cos(libMesh::pi * ((*_vals[op_index])[_qp] - 0.5))/2.0;
-    ElasticityTensorR4 C_deriv(_C_rotated[grn_index]);
+    RankFourTensor C_deriv(_C_rotated[grn_index]);
     C_deriv -= local_elasticity_tensor;
     C_deriv *= dhdopi/sum_h;
 

--- a/modules/phase_field/src/materials/ElasticEnergyMaterial.C
+++ b/modules/phase_field/src/materials/ElasticEnergyMaterial.C
@@ -6,7 +6,7 @@
 /****************************************************************/
 #include "ElasticEnergyMaterial.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 template<>
 InputParameters validParams<ElasticEnergyMaterial>()
@@ -23,7 +23,7 @@ ElasticEnergyMaterial::ElasticEnergyMaterial(const InputParameters & parameters)
     DerivativeFunctionMaterialBase(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "" ),
     _stress(getMaterialPropertyByName<RankTwoTensor>(_base_name + "stress")),
-    _elasticity_tensor(getMaterialPropertyByName<ElasticityTensorR4>(_base_name + "elasticity_tensor")),
+    _elasticity_tensor(getMaterialPropertyByName<RankFourTensor>(_base_name + "elasticity_tensor")),
     _strain(getMaterialPropertyByName<RankTwoTensor>(_base_name + "elastic_strain"))
 {
   _dstrain.resize(_nargs);
@@ -35,7 +35,7 @@ ElasticEnergyMaterial::ElasticEnergyMaterial(const InputParameters & parameters)
   for (unsigned int i = 0; i < _nargs; ++i)
   {
     _dstrain[i]            = &getMaterialPropertyDerivativeByName<RankTwoTensor>(_base_name + "elastic_strain", _arg_names[i]);
-    _delasticity_tensor[i] = &getMaterialPropertyDerivativeByName<ElasticityTensorR4>(_base_name + "elasticity_tensor", _arg_names[i]);
+    _delasticity_tensor[i] = &getMaterialPropertyDerivativeByName<RankFourTensor>(_base_name + "elasticity_tensor", _arg_names[i]);
 
     _d2strain[i].resize(_nargs);
     _d2elasticity_tensor[i].resize(_nargs);
@@ -43,7 +43,7 @@ ElasticEnergyMaterial::ElasticEnergyMaterial(const InputParameters & parameters)
     for (unsigned int j = 0; j < _nargs; ++j)
     {
       _d2strain[i][j]            = &getMaterialPropertyDerivativeByName<RankTwoTensor>(_base_name + "elastic_strain", _arg_names[i], _arg_names[j]);
-      _d2elasticity_tensor[i][j] = &getMaterialPropertyDerivativeByName<ElasticityTensorR4>(_base_name + "elasticity_tensor", _arg_names[i], _arg_names[j]);
+      _d2elasticity_tensor[i][j] = &getMaterialPropertyDerivativeByName<RankFourTensor>(_base_name + "elasticity_tensor", _arg_names[i], _arg_names[j]);
     }
   }
 }

--- a/modules/tensor_mechanics/include/auxkernels/RankFourAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/RankFourAux.h
@@ -8,12 +8,12 @@
 #define RANKFOURAUX_H
 
 #include "AuxKernel.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 class RankFourAux;
 
 /**
- * RankFourAux is designed to take the data in the ElasticityTensorR4 material
+ * RankFourAux is designed to take the data in the RankFourTensor material
  * property, for example stiffness, and output the value for the
  * supplied indices.
  */
@@ -32,7 +32,7 @@ protected:
   virtual Real computeValue();
 
 private:
-  const MaterialProperty<ElasticityTensorR4> & _tensor;
+  const MaterialProperty<RankFourTensor> & _tensor;
   const unsigned int _i;
   const unsigned int _j;
   const unsigned int _k;

--- a/modules/tensor_mechanics/include/kernels/MomentBalancing.h
+++ b/modules/tensor_mechanics/include/kernels/MomentBalancing.h
@@ -11,7 +11,7 @@
 
 //Forward Declarations
 class MomentBalancing;
-class ElasticityTensorR4;
+class RankFourTensor;
 class RankTwoTensor;
 
 template<>
@@ -28,7 +28,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   const MaterialProperty<RankTwoTensor> & _stress;
-  const MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
+  const MaterialProperty<RankFourTensor> & _Jacobian_mult;
 
 private:
   const unsigned int _component;

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
@@ -8,12 +8,12 @@
 #define STRESSDIVERGENCETENSORS_H
 
 #include "Kernel.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 //Forward Declarations
 class StressDivergenceTensors;
-class ElasticityTensorR4;
+class RankFourTensor;
 class RankTwoTensor;
 
 template<>
@@ -37,7 +37,7 @@ protected:
   std::string _base_name;
 
   const MaterialProperty<RankTwoTensor> & _stress;
-  const MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
+  const MaterialProperty<RankFourTensor> & _Jacobian_mult;
   // MaterialProperty<RankTwoTensor> & _d_stress_dT;
 
   const unsigned int _component;

--- a/modules/tensor_mechanics/include/materials/CompositeElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/CompositeElasticityTensor.h
@@ -8,17 +8,17 @@
 #define COMPOSITEELASTICITYTENSOR_H
 
 #include "CompositeTensorBase.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 /**
- * CompositeElasticityTensor provides a simple ElasticityTensorR4 type
+ * CompositeElasticityTensor provides a simple RankFourTensor type
  * MaterialProperty that can be used as an Elasticity tensor in a mechanics simulation.
  * This tensor is computes as a weighted sum of base elasticity tensors where each weight
  * can be a scalar material property that may depend on simulation variables.
  * The generic logic that computes a weighted sum of tensors is located in the
  * templated base class CompositeTensorBase.
  */
-class CompositeElasticityTensor : public CompositeTensorBase<ElasticityTensorR4>
+class CompositeElasticityTensor : public CompositeTensorBase<RankFourTensor>
 {
 public:
   CompositeElasticityTensor(const InputParameters & parameters);

--- a/modules/tensor_mechanics/include/materials/ComputeConcentrationDependentElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeConcentrationDependentElasticityTensor.h
@@ -21,15 +21,15 @@ protected:
   virtual void computeQpElasticityTensor();
 
   /// Elasticity tensor for phase with zero concentration.
-  ElasticityTensorR4 _Cijkl0;
+  RankFourTensor _Cijkl0;
   /// Elasticity tensor for phase with concentration 1.
-  ElasticityTensorR4 _Cijkl1;
+  RankFourTensor _Cijkl1;
   /// Concentration variable.
   const VariableValue & _c;
   VariableName _c_name;
 
   /// Derivative of elasticity tensor with respect to concentration.
-  MaterialProperty<ElasticityTensorR4> & _delasticity_tensor_dc;
+  MaterialProperty<RankFourTensor> & _delasticity_tensor_dc;
 };
 
 #endif //COMPUTECONCENTRATIONDEPENDENTELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeDeformGradBasedStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeDeformGradBasedStress.h
@@ -9,7 +9,7 @@
 
 #include "Material.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RotationTensor.h"
 #include "DerivativeMaterialInterface.h"
 
@@ -27,10 +27,10 @@ protected:
   virtual void computeQpStress();
 
   const MaterialProperty<RankTwoTensor> & _deformation_gradient;
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
 
   MaterialProperty<RankTwoTensor> & _stress;
-  MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
+  MaterialProperty<RankFourTensor> & _Jacobian_mult;
 };
 
 #endif

--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTensor.h
@@ -21,7 +21,7 @@ protected:
   virtual void computeQpElasticityTensor();
 
   /// Individual material information
-  ElasticityTensorR4 _Cijkl;
+  RankFourTensor _Cijkl;
 };
 
 #endif //COMPUTEELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTensorBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTensorBase.h
@@ -8,7 +8,7 @@
 #define COMPUTEELASTICITYTENSORBASE_H
 
 #include "Material.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 /**
  * ComputeElasticityTensorBase the base class for computing elasticity tensors
@@ -25,7 +25,7 @@ protected:
   std::string _base_name;
   std::string _elasticity_tensor_name;
 
-  MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  MaterialProperty<RankFourTensor> & _elasticity_tensor;
 
   /// prefactor function to multiply the elasticity tensor with
   Function * const _prefactor_function;

--- a/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
@@ -34,7 +34,7 @@ protected:
   Real _youngs_modulus;
 
   /// Individual elasticity tensor
-  ElasticityTensorR4 _Cijkl;
+  RankFourTensor _Cijkl;
 };
 
 #endif //COMPUTEISOTROPICELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
@@ -140,7 +140,7 @@ protected:
   MaterialProperty<RankTwoTensor> & _elastic_strain_old;
 
   /// Elasticity tensor that can be rotated by this class (ie, its not const)
-  ElasticityTensorR4 _my_elasticity_tensor;
+  RankFourTensor _my_elasticity_tensor;
 
   /// Strain increment that can be rotated by this class, and split into multiple increments (ie, its not const)
   RankTwoTensor _my_strain_increment;

--- a/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
@@ -9,7 +9,7 @@
 
 #include "Material.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RotationTensor.h"
 #include "DerivativeMaterialInterface.h"
 

--- a/modules/tensor_mechanics/include/materials/ComputeStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStressBase.h
@@ -9,7 +9,7 @@
 
 #include "Material.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RotationTensor.h"
 #include "DerivativeMaterialInterface.h"
 
@@ -31,7 +31,7 @@ protected:
   const MaterialProperty<RankTwoTensor> & _mechanical_strain;
   MaterialProperty<RankTwoTensor> & _stress;
   MaterialProperty<RankTwoTensor> & _elastic_strain;
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
 
   /// Extra stress tensor
   const MaterialProperty<RankTwoTensor> & _extra_stress;
@@ -40,7 +40,7 @@ protected:
   std::vector<Function *> _initial_stress;
 
   /// derivative of stress w.r.t. strain (_dstress_dstrain)
-  MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
+  MaterialProperty<RankFourTensor> & _Jacobian_mult;
 
   /// Parameter which decides whether to store old stress. This is required for HHT time integration and Rayleigh damping
   const bool _store_stress_old;

--- a/modules/tensor_mechanics/include/materials/CosseratLinearElasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/CosseratLinearElasticMaterial.h
@@ -37,11 +37,11 @@ protected:
   MaterialProperty<RankTwoTensor> & _antisymmetric_stress;
   MaterialProperty<RankTwoTensor> & _stress_couple;
 
-  MaterialProperty<ElasticityTensorR4> & _elastic_flexural_rigidity_tensor;
-  MaterialProperty<ElasticityTensorR4> & _Jacobian_mult_couple;
+  MaterialProperty<RankFourTensor> & _elastic_flexural_rigidity_tensor;
+  MaterialProperty<RankFourTensor> & _Jacobian_mult_couple;
 
   std::vector<Real> _Bijkl_vector;
-  ElasticityTensorR4 _Bijkl;
+  RankFourTensor _Bijkl;
 
 private:
   const VariableValue & _T;

--- a/modules/tensor_mechanics/include/materials/EigenStrainBaseMaterial.h
+++ b/modules/tensor_mechanics/include/materials/EigenStrainBaseMaterial.h
@@ -35,8 +35,8 @@ protected:
   MaterialProperty<RankTwoTensor> & _delastic_strain_dc;
   MaterialProperty<RankTwoTensor> & _d2elastic_strain_dc2;
 
-  MaterialProperty<ElasticityTensorR4> & _delasticity_tensor_dc;
-  MaterialProperty<ElasticityTensorR4> & _d2elasticity_tensor_dc2;
+  MaterialProperty<RankFourTensor> & _delasticity_tensor_dc;
+  MaterialProperty<RankFourTensor> & _d2elasticity_tensor_dc2;
 };
 
 #endif //EIGENSTRAINBASEMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
@@ -191,17 +191,17 @@ protected:
    * Exact jacobian is currently implemented.
    * tan_mod_type can be modified to exact in .i file to turn it on.
    */
-  virtual ElasticityTensorR4 calcTangentModuli();
+  virtual RankFourTensor calcTangentModuli();
 
   /**
    * This function calculate the elastic tangent moduli for preconditioner.
    */
-  virtual ElasticityTensorR4 elasticTangentModuli();
+  virtual RankFourTensor elasticTangentModuli();
 
   /**
    * This function calculate the exact tangent moduli for preconditioner.
    */
-  virtual ElasticityTensorR4 elastoPlasticTangentModuli();
+  virtual RankFourTensor elastoPlasticTangentModuli();
 
   /**
    * This function perform RU decomposition to obtain the rotation tensor.

--- a/modules/tensor_mechanics/include/materials/MultiPhaseStressMaterial.h
+++ b/modules/tensor_mechanics/include/materials/MultiPhaseStressMaterial.h
@@ -12,7 +12,7 @@
 // Forward Declarations
 class MultiPhaseStressMaterial;
 class RankTwoTensor;
-class ElasticityTensorR4;
+class RankFourTensor;
 
 template<>
 InputParameters validParams<MultiPhaseStressMaterial>();
@@ -41,12 +41,12 @@ protected:
   // phase material properties
   std::vector<std::string> _phase_base;
   std::vector<const MaterialProperty<RankTwoTensor> *> _phase_stress;
-  std::vector<const MaterialProperty<ElasticityTensorR4> *> _dphase_stress_dstrain;
+  std::vector<const MaterialProperty<RankFourTensor> *> _dphase_stress_dstrain;
 
   // global material properties
   std::string _base_name;
   MaterialProperty<RankTwoTensor> & _stress;
-  MaterialProperty<ElasticityTensorR4> & _dstress_dstrain;
+  MaterialProperty<RankFourTensor> & _dstress_dstrain;
 };
 
 #endif //MULTIPHASESTRESSMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/RecomputeGeneralReturnStressIncrement.h
+++ b/modules/tensor_mechanics/include/materials/RecomputeGeneralReturnStressIncrement.h
@@ -9,7 +9,7 @@
 
 #include "Material.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "Conversion.h"
 
 //Forward declaration
@@ -55,7 +55,7 @@ protected:
 
   const unsigned int _max_its;
 
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
   const MaterialProperty<RankTwoTensor> & _strain_increment;
   const MaterialProperty<RankTwoTensor> & _stress;
   const MaterialProperty<RankTwoTensor> & _stress_old;

--- a/modules/tensor_mechanics/include/materials/RecomputeRadialReturnStressIncrement.h
+++ b/modules/tensor_mechanics/include/materials/RecomputeRadialReturnStressIncrement.h
@@ -9,7 +9,7 @@
 
 #include "RecomputeGeneralReturnStressIncrement.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "Conversion.h"
 
 //Forward declaration

--- a/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
+++ b/modules/tensor_mechanics/include/materials/TensorMechanicsMaterial.h
@@ -11,7 +11,7 @@
 
 #include "Material.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RotationTensor.h"
 
 //Forward declaration
@@ -56,15 +56,15 @@ protected:
   MaterialProperty<RankTwoTensor> & _elastic_strain;
 
   std::string _elasticity_tensor_name;
-  MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  MaterialProperty<RankFourTensor> & _elasticity_tensor;
 
   /// derivative of stress w.r.t. strain (_dstress_dstrain)
-  MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
+  MaterialProperty<RankFourTensor> & _Jacobian_mult;
 
   RealVectorValue _Euler_angles;
 
   /// Individual material information
-  ElasticityTensorR4 _Cijkl;
+  RankFourTensor _Cijkl;
 
   /// prefactor function to multiply the elasticity tensor with
   Function * const _prefactor_function;

--- a/modules/tensor_mechanics/include/materials/TwoPhaseStressMaterial.h
+++ b/modules/tensor_mechanics/include/materials/TwoPhaseStressMaterial.h
@@ -12,7 +12,7 @@
 // Forward Declarations
 class TwoPhaseStressMaterial;
 class RankTwoTensor;
-class ElasticityTensorR4;
+class RankFourTensor;
 
 template<>
 InputParameters validParams<TwoPhaseStressMaterial>();
@@ -35,17 +35,17 @@ protected:
   // phase A material properties
   std::string _base_A;
   const MaterialProperty<RankTwoTensor> & _stress_A;
-  const MaterialProperty<ElasticityTensorR4> & _dstress_dstrain_A;
+  const MaterialProperty<RankFourTensor> & _dstress_dstrain_A;
 
   // phase B material properties
   std::string _base_B;
   const MaterialProperty<RankTwoTensor> & _stress_B;
-  const MaterialProperty<ElasticityTensorR4> & _dstress_dstrain_B;
+  const MaterialProperty<RankFourTensor> & _dstress_dstrain_B;
 
   // global material properties
   std::string _base_name;
   MaterialProperty<RankTwoTensor> & _stress;
-  MaterialProperty<ElasticityTensorR4> & _dstress_dstrain;
+  MaterialProperty<RankFourTensor> & _dstress_dstrain;
 };
 
 #endif //TWOPHASESTRESSMATERIAL_H

--- a/modules/tensor_mechanics/include/materials/VolumeDeformGradCorrectedStress.h
+++ b/modules/tensor_mechanics/include/materials/VolumeDeformGradCorrectedStress.h
@@ -9,7 +9,7 @@
 
 #include "Material.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RotationTensor.h"
 #include "DerivativeMaterialInterface.h"
 
@@ -28,10 +28,10 @@ protected:
 
   const MaterialProperty<RankTwoTensor> & _pre_stress;
   const MaterialProperty<RankTwoTensor> & _deformation_gradient;
-  const MaterialProperty<ElasticityTensorR4> * _pre_Jacobian_mult;
+  const MaterialProperty<RankFourTensor> * _pre_Jacobian_mult;
 
   MaterialProperty<RankTwoTensor> & _stress;
-  MaterialProperty<ElasticityTensorR4> * _Jacobian_mult;
+  MaterialProperty<RankFourTensor> * _Jacobian_mult;
 };
 
 #endif

--- a/modules/tensor_mechanics/include/utils/ElasticityTensorR4.h
+++ b/modules/tensor_mechanics/include/utils/ElasticityTensorR4.h
@@ -32,7 +32,7 @@ void mooseSetToZero<ElasticityTensorR4>(ElasticityTensorR4 & v);
 class ElasticityTensorR4 : public RankFourTensor
 {
 public:
-  ElasticityTensorR4() : RankFourTensor() {}
+  ElasticityTensorR4() : RankFourTensor() { mooseDeprecated("Use RankFourTensor instead of ElasticityTensorR4. See http://mooseframework.org/wiki/PhysicsModules/TensorMechanics/Deprecations/ElasticityTensorR4/ to update your code"); }
 
   /// Copy constructor for RankFourTensor
   ElasticityTensorR4(const RankFourTensor &a);

--- a/modules/tensor_mechanics/include/utils/ElasticityTensorTools.h
+++ b/modules/tensor_mechanics/include/utils/ElasticityTensorTools.h
@@ -1,0 +1,41 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef ELASTICITYTENSORTOOLS_H
+#define ELASTICITYTENSORTOOLS_H
+
+class RankFourTensor;
+
+namespace ElasticityTensorTools
+{
+
+/**
+ * This is used for the standard kernel stress_ij*d(test)/dx_j, when varied wrt u_k
+ * Jacobian entry: d(stress_ij*d(test)/dx_j)/du_k = d(C_ijmn*du_m/dx_n*dtest/dx_j)/du_k
+ */
+Real elasticJacobian(const RankFourTensor & r4t, unsigned int i, unsigned int k, const RealGradient & grad_test, const RealGradient & grad_phi);
+
+/**
+ * This is used for the standard kernel stress_ij*d(test)/dx_j, when varied wrt w_k (the cosserat rotation)
+ * Jacobian entry: d(stress_ij*d(test)/dx_j)/dw_k = d(C_ijmn*eps_mnp*w_p*dtest/dx_j)/dw_k
+ */
+Real elasticJacobianWC(const RankFourTensor & r4t,unsigned int i, unsigned int k, const RealGradient & grad_test, Real phi);
+
+/**
+ * This is used for the moment-balancing kernel eps_ijk*stress_jk*test, when varied wrt u_k
+ * Jacobian entry: d(eps_ijm*stress_jm*test)/du_k = d(eps_ijm*C_jmln*du_l/dx_n*test)/du_k
+ */
+Real momentJacobian(const RankFourTensor & r4t,unsigned int i, unsigned int k, Real test, const RealGradient & grad_phi);
+
+/**
+ * This is used for the moment-balancing kernel eps_ijk*stress_jk*test, when varied wrt w_k (the cosserat rotation)
+ * Jacobian entry: d(eps_ijm*stress_jm*test)/dw_k = d(eps_ijm*C_jmln*eps_lnp*w_p*test)/dw_k
+ */
+Real momentJacobianWC(const RankFourTensor & r4t,unsigned int i, unsigned int k, Real test, Real phi);
+
+}
+
+#endif //ELASTICITYTENSORTOOLS_H

--- a/modules/tensor_mechanics/src/auxkernels/RankFourAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankFourAux.C
@@ -24,7 +24,7 @@ InputParameters validParams<RankFourAux>()
 
 RankFourAux::RankFourAux(const InputParameters & parameters) :
     AuxKernel(parameters),
-    _tensor(getMaterialProperty<ElasticityTensorR4>("rank_four_tensor")),
+    _tensor(getMaterialProperty<RankFourTensor>("rank_four_tensor")),
     _i(getParam<unsigned int>("index_i")),
     _j(getParam<unsigned int>("index_j")),
     _k(getParam<unsigned int>("index_k")),

--- a/modules/tensor_mechanics/src/kernels/CosseratStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/CosseratStressDivergenceTensors.C
@@ -8,6 +8,7 @@
 #include "CosseratStressDivergenceTensors.h"
 #include "Material.h"
 #include "RankFourTensor.h"
+#include "ElasticityTensorTools.h"
 #include "RankTwoTensor.h"
 #include "MooseMesh.h"
 
@@ -43,8 +44,7 @@ CosseratStressDivergenceTensors::computeQpOffDiagJacobian(unsigned int jvar)
     coupled_component = 2;
 
   if (coupled_component < 3)
-    return _Jacobian_mult[_qp].elasticJacobianwc(_component, coupled_component, _grad_test[_i][_qp], _phi[_j][_qp]);
+    return ElasticityTensorTools::elasticJacobianWC(_Jacobian_mult[_qp], _component, coupled_component, _grad_test[_i][_qp], _phi[_j][_qp]);
 
   return StressDivergenceTensors::computeQpOffDiagJacobian(jvar);
 }
-

--- a/modules/tensor_mechanics/src/kernels/CosseratStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/CosseratStressDivergenceTensors.C
@@ -7,7 +7,7 @@
 
 #include "CosseratStressDivergenceTensors.h"
 #include "Material.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 #include "MooseMesh.h"
 

--- a/modules/tensor_mechanics/src/kernels/DynamicStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/DynamicStressDivergenceTensors.C
@@ -5,6 +5,7 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 #include "DynamicStressDivergenceTensors.h"
+#include "ElasticityTensorTools.h"
 
 template<>
 InputParameters validParams<DynamicStressDivergenceTensors>()
@@ -51,7 +52,7 @@ Real
 DynamicStressDivergenceTensors::computeQpJacobian()
 {
   if (_dt > 0)
-    return _Jacobian_mult[_qp].elasticJacobian(_component, _component, _grad_test[_i][_qp], _grad_phi[_j][_qp])*(1+_alpha+_zeta/_dt);
+    return ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], _component, _component, _grad_test[_i][_qp], _grad_phi[_j][_qp])*(1+_alpha+_zeta/_dt);
   else
     return 0;
 }
@@ -72,7 +73,7 @@ DynamicStressDivergenceTensors::computeQpOffDiagJacobian(unsigned int jvar)
   if (active)
   {
     if (_dt > 0)
-      return _Jacobian_mult[_qp].elasticJacobian(_component, coupled_component, _grad_test[_i][_qp], _grad_phi[_j][_qp])*(1+_alpha+_zeta/_dt);
+      return ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], _component, coupled_component, _grad_test[_i][_qp], _grad_phi[_j][_qp])*(1+_alpha+_zeta/_dt);
     else
       return 0;
    }

--- a/modules/tensor_mechanics/src/kernels/MomentBalancing.C
+++ b/modules/tensor_mechanics/src/kernels/MomentBalancing.C
@@ -8,6 +8,7 @@
 
 #include "Material.h"
 #include "RankFourTensor.h"
+#include "ElasticityTensorTools.h"
 #include "RankTwoTensor.h"
 
 template<>
@@ -54,7 +55,7 @@ MomentBalancing::computeQpResidual()
 Real
 MomentBalancing::computeQpJacobian()
 {
-  return _Jacobian_mult[_qp].momentJacobianwc(_component, _component, _test[_i][_qp], _phi[_j][_qp]);
+  return ElasticityTensorTools::momentJacobianWC(_Jacobian_mult[_qp], _component, _component, _test[_i][_qp], _phi[_j][_qp]);
 }
 
 Real
@@ -71,7 +72,7 @@ MomentBalancing::computeQpOffDiagJacobian(unsigned int jvar)
     coupled_component = 2;
 
   if (coupled_component < 3)
-    return _Jacobian_mult[_qp].momentJacobian(_component, coupled_component, _test[_i][_qp], _grad_phi[_j][_qp]);
+    return ElasticityTensorTools::momentJacobian(_Jacobian_mult[_qp], _component, coupled_component, _test[_i][_qp], _grad_phi[_j][_qp]);
 
   // What does 2D look like here?
   if (jvar == _wc_x_var)
@@ -82,7 +83,7 @@ MomentBalancing::computeQpOffDiagJacobian(unsigned int jvar)
     coupled_component = 2;
 
   if (coupled_component < 3)
-    return _Jacobian_mult[_qp].momentJacobianwc(_component, coupled_component, _test[_i][_qp], _phi[_j][_qp]);
+    return ElasticityTensorTools::momentJacobianWC(_Jacobian_mult[_qp], _component, coupled_component, _test[_i][_qp], _phi[_j][_qp]);
 
   return 0;
 }

--- a/modules/tensor_mechanics/src/kernels/MomentBalancing.C
+++ b/modules/tensor_mechanics/src/kernels/MomentBalancing.C
@@ -7,7 +7,7 @@
 #include "MomentBalancing.h"
 
 #include "Material.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 template<>
@@ -30,7 +30,7 @@ InputParameters validParams<MomentBalancing>()
 MomentBalancing::MomentBalancing(const InputParameters & parameters) :
     Kernel(parameters),
     _stress(getMaterialProperty<RankTwoTensor>("stress" + getParam<std::string>("appended_property_name"))),
-    _Jacobian_mult(getMaterialProperty<ElasticityTensorR4>("Jacobian_mult" + getParam<std::string>("appended_property_name"))),
+    _Jacobian_mult(getMaterialProperty<RankFourTensor>("Jacobian_mult" + getParam<std::string>("appended_property_name"))),
     _component(getParam<unsigned int>("component")),
     _wc_x_var(coupled("wc_x")),
     _wc_y_var(coupled("wc_y")),
@@ -86,4 +86,3 @@ MomentBalancing::computeQpOffDiagJacobian(unsigned int jvar)
 
   return 0;
 }
-

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceRSphericalTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceRSphericalTensors.C
@@ -7,6 +7,7 @@
 
 #include "StressDivergenceRSphericalTensors.h"
 #include "Assembly.h"
+#include "ElasticityTensorTools.h"
 
 template<>
 InputParameters validParams<StressDivergenceRSphericalTensors>()
@@ -85,7 +86,7 @@ StressDivergenceRSphericalTensors::calculateJacobian(unsigned int ivar, unsigned
 
   if (ivar == 0 && jvar == 0)  // Only nonzero case for a 1D simulation
   {
-    return _Jacobian_mult[_qp].elasticJacobian(ivar, jvar, test_r, phi_r);
+    return ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], ivar, jvar, test_r, phi_r);
   }
   else
     mooseError("Invalid component in Jacobian Calculation");

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceRZTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceRZTensors.C
@@ -7,6 +7,7 @@
 
 #include "StressDivergenceRZTensors.h"
 #include "Assembly.h"
+#include "ElasticityTensorTools.h"
 
 template<>
 InputParameters validParams<StressDivergenceRZTensors>()
@@ -100,31 +101,30 @@ StressDivergenceRZTensors::calculateJacobian(unsigned int ivar, unsigned int jva
 
   if (ivar == 0 && jvar == 0)  // Case when both phi and test are functions of x and z; requires four terms
   {
-    const Real first_sum = _Jacobian_mult[_qp].elasticJacobian(ivar, jvar, test, phi); //test_x and phi_x
-    const Real second_sum = _Jacobian_mult[_qp].elasticJacobian(2, 2, test_z, phi_z); //test_z and phi_z
-    const Real mixed_sum1 = _Jacobian_mult[_qp].elasticJacobian(ivar, 2, test, phi_z); //test_x and phi_z
-    const Real mixed_sum2 = _Jacobian_mult[_qp].elasticJacobian(2, jvar, test_z, phi); //test_z and phi_x
+    const Real first_sum = ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], ivar, jvar, test, phi); //test_x and phi_x
+    const Real second_sum = ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], 2, 2, test_z, phi_z); //test_z and phi_z
+    const Real mixed_sum1 = ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], ivar, 2, test, phi_z); //test_x and phi_z
+    const Real mixed_sum2 = ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], 2, jvar, test_z, phi); //test_z and phi_x
 
     return first_sum + second_sum + mixed_sum1 + mixed_sum2;
   }
   else if (ivar == 0 && jvar == 1)
   {
-    const Real first_sum = _Jacobian_mult[_qp].elasticJacobian(ivar, jvar, test, phi); //test_x and phi_y
-    const Real mixed_sum2 = _Jacobian_mult[_qp].elasticJacobian(2, jvar, test_z, phi); //test_z and phi_y
+    const Real first_sum = ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], ivar, jvar, test, phi); //test_x and phi_y
+    const Real mixed_sum2 = ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], 2, jvar, test_z, phi); //test_z and phi_y
 
     return first_sum + mixed_sum2;
   }
   else if (ivar == 1 && jvar == 0)
   {
-    const Real second_sum = _Jacobian_mult[_qp].elasticJacobian(ivar, jvar, test, phi); //test_y and phi_x
-    const Real mixed_sum1 = _Jacobian_mult[_qp].elasticJacobian(ivar, 2, test, phi_z); //test_y and phi_z
+    const Real second_sum = ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], ivar, jvar, test, phi); //test_y and phi_x
+    const Real mixed_sum1 = ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], ivar, 2, test, phi_z); //test_y and phi_z
 
     return second_sum + mixed_sum1;
   }
   else if (ivar == 1 && jvar == 1)
-    return _Jacobian_mult[_qp].elasticJacobian(ivar, jvar, test, phi); //test_y and phi_y
+    return ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], ivar, jvar, test, phi); //test_y and phi_y
 
   else
     mooseError("Invalid component in Jacobian Calculation");
 }
-

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
@@ -8,6 +8,7 @@
 #include "StressDivergenceTensors.h"
 #include "Material.h"
 #include "MooseMesh.h"
+#include "ElasticityTensorTools.h"
 
 template<>
 InputParameters validParams<StressDivergenceTensors>()
@@ -86,7 +87,7 @@ StressDivergenceTensors::computeQpResidual()
 Real
 StressDivergenceTensors::computeQpJacobian()
 {
-  return _Jacobian_mult[_qp].elasticJacobian(_component, _component, _grad_test[_i][_qp], _grad_phi[_j][_qp]);
+  return ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], _component, _component, _grad_test[_i][_qp], _grad_phi[_j][_qp]);
 }
 
 Real
@@ -103,7 +104,7 @@ StressDivergenceTensors::computeQpOffDiagJacobian(unsigned int jvar)
     }
 
   if (active)
-    return _Jacobian_mult[_qp].elasticJacobian(_component, coupled_component,
+    return ElasticityTensorTools::elasticJacobian(_Jacobian_mult[_qp], _component, coupled_component,
                                           _grad_test[_i][_qp], _grad_phi[_j][_qp]);
 
   if (_temp_coupled && jvar == _temp_var)
@@ -114,4 +115,3 @@ StressDivergenceTensors::computeQpOffDiagJacobian(unsigned int jvar)
 
   return 0;
 }
-

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
@@ -31,7 +31,7 @@ StressDivergenceTensors::StressDivergenceTensors(const InputParameters & paramet
     Kernel(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _stress(getMaterialPropertyByName<RankTwoTensor>(_base_name + "stress")),
-    _Jacobian_mult(getMaterialPropertyByName<ElasticityTensorR4>(_base_name + "Jacobian_mult")),
+    _Jacobian_mult(getMaterialPropertyByName<RankFourTensor>(_base_name + "Jacobian_mult")),
     _component(getParam<unsigned int>("component")),
     _ndisp(coupledComponents("displacements")),
     _disp(3),

--- a/modules/tensor_mechanics/src/materials/CompositeElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/CompositeElasticityTensor.C
@@ -9,14 +9,14 @@
 template<>
 InputParameters validParams<CompositeElasticityTensor>()
 {
-  InputParameters params = CompositeTensorBase<ElasticityTensorR4>::validParams();
+  InputParameters params = CompositeTensorBase<RankFourTensor>::validParams();
   params.addClassDescription("Assemble an elasticity tensor from multiple tensor contributions weighted by material properties");
   params.addParam<std::string>("base_name", "Optional parameter that allows the user to define multiple mechanics material systems on the same block, i.e. for multiple phases");
   return params;
 }
 
 CompositeElasticityTensor::CompositeElasticityTensor(const InputParameters & parameters) :
-    CompositeTensorBase<ElasticityTensorR4>(parameters),
+    CompositeTensorBase<RankFourTensor>(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "" )
 {
   _M_name = _base_name + "elasticity_tensor";

--- a/modules/tensor_mechanics/src/materials/ComputeConcentrationDependentElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeConcentrationDependentElasticityTensor.C
@@ -26,7 +26,7 @@ ComputeConcentrationDependentElasticityTensor::ComputeConcentrationDependentElas
     _Cijkl1(getParam<std::vector<Real> >("C1_ijkl"), (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method1")),
     _c(coupledValue("c")),
     _c_name(getVar("c", 0)->name()),
-    _delasticity_tensor_dc(declarePropertyDerivative<ElasticityTensorR4>(_elasticity_tensor_name, _c_name))
+    _delasticity_tensor_dc(declarePropertyDerivative<RankFourTensor>(_elasticity_tensor_name, _c_name))
 {
   // Define a rotation according to Euler angle parameters
   RotationTensor R(_Euler_angles); // R type: RealTensorValue

--- a/modules/tensor_mechanics/src/materials/ComputeDeformGradBasedStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeDeformGradBasedStress.C
@@ -21,9 +21,9 @@ InputParameters validParams<ComputeDeformGradBasedStress>()
 ComputeDeformGradBasedStress::ComputeDeformGradBasedStress(const InputParameters & parameters) :
     DerivativeMaterialInterface<Material>(parameters),
     _deformation_gradient(getMaterialProperty<RankTwoTensor>("deform_grad_name")),
-    _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor_name")),
+    _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor_name")),
     _stress(declareProperty<RankTwoTensor>(getParam<MaterialPropertyName>("stress_name"))),
-    _Jacobian_mult(declareProperty<ElasticityTensorR4>(getParam<MaterialPropertyName>("jacobian_name")))
+    _Jacobian_mult(declareProperty<RankFourTensor>(getParam<MaterialPropertyName>("jacobian_name")))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTensorBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTensorBase.C
@@ -21,7 +21,7 @@ ComputeElasticityTensorBase::ComputeElasticityTensorBase(const InputParameters &
     DerivativeMaterialInterface<Material>(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "" ),
     _elasticity_tensor_name(_base_name + "elasticity_tensor"),
-    _elasticity_tensor(declareProperty<ElasticityTensorR4>(_elasticity_tensor_name)),
+    _elasticity_tensor(declareProperty<RankFourTensor>(_elasticity_tensor_name)),
     _prefactor_function(isParamValid("elasticity_tensor_prefactor") ? &getFunction("elasticity_tensor_prefactor") : NULL)
 {
 }

--- a/modules/tensor_mechanics/src/materials/ComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStressBase.C
@@ -24,9 +24,9 @@ ComputeStressBase::ComputeStressBase(const InputParameters & parameters) :
     _mechanical_strain(getMaterialPropertyByName<RankTwoTensor>(_base_name + "mechanical_strain")),
     _stress(declareProperty<RankTwoTensor>(_base_name + "stress")),
     _elastic_strain(declareProperty<RankTwoTensor>(_base_name + "elastic_strain")),
-    _elasticity_tensor(getMaterialPropertyByName<ElasticityTensorR4>(_base_name + "elasticity_tensor")),
+    _elasticity_tensor(getMaterialPropertyByName<RankFourTensor>(_base_name + "elasticity_tensor")),
     _extra_stress(getDefaultMaterialProperty<RankTwoTensor>(_base_name + "extra_stress")),
-    _Jacobian_mult(declareProperty<ElasticityTensorR4>(_base_name + "Jacobian_mult")),
+    _Jacobian_mult(declareProperty<RankFourTensor>(_base_name + "Jacobian_mult")),
     _store_stress_old(getParam<bool>("store_stress_old"))
 {
   //Declares old stress and older stress if the parameter _store_stress_old is true. This parameter can be set from the input file using any of the child classes of ComputeStressBase.

--- a/modules/tensor_mechanics/src/materials/CosseratLinearElasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/CosseratLinearElasticMaterial.C
@@ -43,8 +43,8 @@ CosseratLinearElasticMaterial::CosseratLinearElasticMaterial(const InputParamete
     _symmetric_stress(declareProperty<RankTwoTensor>("symmetric_stress")),
     _antisymmetric_stress(declareProperty<RankTwoTensor>("antisymmetric_stress")),
     _stress_couple(declareProperty<RankTwoTensor>("coupled_stress")),
-    _elastic_flexural_rigidity_tensor(declareProperty<ElasticityTensorR4>("elastic_flexural_rigidity_tensor")),
-    _Jacobian_mult_couple(declareProperty<ElasticityTensorR4>("coupled_Jacobian_mult")),
+    _elastic_flexural_rigidity_tensor(declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
+    _Jacobian_mult_couple(declareProperty<RankFourTensor>("coupled_Jacobian_mult")),
     _Bijkl_vector(getParam<std::vector<Real> >("B_ijkl")),
     _Bijkl(),
     _T(coupledValue("T")),
@@ -126,4 +126,3 @@ void CosseratLinearElasticMaterial::computeQpElasticityTensor()
   _elastic_flexural_rigidity_tensor[_qp] = _Bijkl;
   _Jacobian_mult_couple[_qp] = _Bijkl;
 }
-

--- a/modules/tensor_mechanics/src/materials/EigenStrainBaseMaterial.C
+++ b/modules/tensor_mechanics/src/materials/EigenStrainBaseMaterial.C
@@ -27,8 +27,8 @@ EigenStrainBaseMaterial::EigenStrainBaseMaterial(const InputParameters & paramet
     _delastic_strain_dc(declarePropertyDerivative<RankTwoTensor>(_base_name + "elastic_strain", _c_name)),
     _d2elastic_strain_dc2(declarePropertyDerivative<RankTwoTensor>(_base_name + "elastic_strain", _c_name, _c_name)),
 
-    _delasticity_tensor_dc(declarePropertyDerivative<ElasticityTensorR4>(_elasticity_tensor_name, _c_name)),
-    _d2elasticity_tensor_dc2(declarePropertyDerivative<ElasticityTensorR4>(_elasticity_tensor_name, _c_name, _c_name))
+    _delasticity_tensor_dc(declarePropertyDerivative<RankFourTensor>(_elasticity_tensor_name, _c_name)),
+    _d2elasticity_tensor_dc2(declarePropertyDerivative<RankFourTensor>(_elasticity_tensor_name, _c_name, _c_name))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -1007,10 +1007,10 @@ FiniteStrainCrystalPlasticity::computeQpElasticityTensor()
 
 }
 
-ElasticityTensorR4
+RankFourTensor
 FiniteStrainCrystalPlasticity::calcTangentModuli()
 {
-  ElasticityTensorR4 tan_mod;
+  RankFourTensor tan_mod;
 
   switch ( _tan_mod_type )
   {
@@ -1055,10 +1055,10 @@ FiniteStrainCrystalPlasticity::calc_schmid_tensor()
 }
 
 
-ElasticityTensorR4
+RankFourTensor
 FiniteStrainCrystalPlasticity::elastoPlasticTangentModuli()
 {
-  ElasticityTensorR4 tan_mod;
+  RankFourTensor tan_mod;
   RankTwoTensor pk2fet, fepk2;
   RankFourTensor deedfe, dsigdpk2dfe;
 
@@ -1095,7 +1095,7 @@ FiniteStrainCrystalPlasticity::elastoPlasticTangentModuli()
 }
 
 
-ElasticityTensorR4
+RankFourTensor
 FiniteStrainCrystalPlasticity::elasticTangentModuli()
 {
   return _elasticity_tensor[_qp];//update jacobian_mult

--- a/modules/tensor_mechanics/src/materials/FiniteStrainUObasedCP.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainUObasedCP.C
@@ -545,7 +545,7 @@ FiniteStrainUObasedCP::calcTangentModuli()
 void
 FiniteStrainUObasedCP::elastoPlasticTangentModuli()
 {
-  ElasticityTensorR4 tan_mod;
+  RankFourTensor tan_mod;
   RankTwoTensor pk2fet, fepk2;
   RankFourTensor deedfe, dsigdpk2dfe, dfedf;
 

--- a/modules/tensor_mechanics/src/materials/MultiPhaseStressMaterial.C
+++ b/modules/tensor_mechanics/src/materials/MultiPhaseStressMaterial.C
@@ -6,7 +6,7 @@
 /****************************************************************/
 #include "MultiPhaseStressMaterial.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 template<>
 InputParameters validParams<MultiPhaseStressMaterial>()
@@ -29,7 +29,7 @@ MultiPhaseStressMaterial::MultiPhaseStressMaterial(const InputParameters & param
     _dphase_stress_dstrain(_n_phase),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "" ),
     _stress(declareProperty<RankTwoTensor>(_base_name + "stress")),
-    _dstress_dstrain(declareProperty<ElasticityTensorR4>(_base_name + "Jacobian_mult"))
+    _dstress_dstrain(declareProperty<RankFourTensor>(_base_name + "Jacobian_mult"))
 {
   // verify parameter length
   if (_n_phase != _phase_base.size())
@@ -39,7 +39,7 @@ MultiPhaseStressMaterial::MultiPhaseStressMaterial(const InputParameters & param
   {
     _h_eta[i] = &getMaterialProperty<Real>(_h_list[i]);
     _phase_stress[i] = &getMaterialProperty<RankTwoTensor>(_phase_base[i] + "_stress");
-    _dphase_stress_dstrain[i] = &getMaterialProperty<ElasticityTensorR4>(_phase_base[i] + "_Jacobian_mult");
+    _dphase_stress_dstrain[i] = &getMaterialProperty<RankFourTensor>(_phase_base[i] + "_Jacobian_mult");
   }
 }
 

--- a/modules/tensor_mechanics/src/materials/RecomputeGeneralReturnStressIncrement.C
+++ b/modules/tensor_mechanics/src/materials/RecomputeGeneralReturnStressIncrement.C
@@ -23,7 +23,7 @@ RecomputeGeneralReturnStressIncrement::RecomputeGeneralReturnStressIncrement(con
     _return_stress_increment(declareProperty<RankTwoTensor>("return_stress_increment")),
     _inelastic_strain_increment(declareProperty<RankTwoTensor>("inelastic_strain_increment")),
     _max_its(parameters.get<unsigned int>("max_iterations")),
-    _elasticity_tensor(getMaterialPropertyByName<ElasticityTensorR4>(_base_name + "elasticity_tensor")),
+    _elasticity_tensor(getMaterialPropertyByName<RankFourTensor>(_base_name + "elasticity_tensor")),
     _strain_increment(getMaterialProperty<RankTwoTensor>(_base_name + "strain_increment")),
     _stress(getMaterialPropertyByName<RankTwoTensor>(_base_name + "stress")),
     _stress_old(getMaterialPropertyOldByName<RankTwoTensor>(_base_name + "stress"))

--- a/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
@@ -47,9 +47,9 @@ TensorMechanicsMaterial::TensorMechanicsMaterial(const InputParameters & paramet
     _elastic_strain(declareProperty<RankTwoTensor>(_base_name + "elastic_strain")),
 
     _elasticity_tensor_name(_base_name + "elasticity_tensor"),
-    _elasticity_tensor(declareProperty<ElasticityTensorR4>(_elasticity_tensor_name)),
+    _elasticity_tensor(declareProperty<RankFourTensor>(_elasticity_tensor_name)),
 
-    _Jacobian_mult(declareProperty<ElasticityTensorR4>(_base_name + "Jacobian_mult")),
+    _Jacobian_mult(declareProperty<RankFourTensor>(_base_name + "Jacobian_mult")),
 
     _Euler_angles(getParam<Real>("euler_angle_1"),
                   getParam<Real>("euler_angle_2"),

--- a/modules/tensor_mechanics/src/materials/TwoPhaseStressMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TwoPhaseStressMaterial.C
@@ -6,7 +6,7 @@
 /****************************************************************/
 #include "TwoPhaseStressMaterial.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 template<>
 InputParameters validParams<TwoPhaseStressMaterial>()
@@ -26,15 +26,15 @@ TwoPhaseStressMaterial::TwoPhaseStressMaterial(const InputParameters & parameter
 
     _base_A(getParam<std::string>("base_A") + "_"),
     _stress_A(getMaterialPropertyByName<RankTwoTensor>(_base_A + "stress")),
-    _dstress_dstrain_A(getMaterialPropertyByName<ElasticityTensorR4>(_base_A + "Jacobian_mult")),
+    _dstress_dstrain_A(getMaterialPropertyByName<RankFourTensor>(_base_A + "Jacobian_mult")),
 
     _base_B(getParam<std::string>("base_B") + "_"),
     _stress_B(getMaterialPropertyByName<RankTwoTensor>(_base_B + "stress")),
-    _dstress_dstrain_B(getMaterialPropertyByName<ElasticityTensorR4>(_base_B + "Jacobian_mult")),
+    _dstress_dstrain_B(getMaterialPropertyByName<RankFourTensor>(_base_B + "Jacobian_mult")),
 
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "" ),
     _stress(declareProperty<RankTwoTensor>(_base_name + "stress")),
-    _dstress_dstrain(declareProperty<ElasticityTensorR4>(_base_name + "Jacobian_mult"))
+    _dstress_dstrain(declareProperty<RankFourTensor>(_base_name + "Jacobian_mult"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/VolumeDeformGradCorrectedStress.C
+++ b/modules/tensor_mechanics/src/materials/VolumeDeformGradCorrectedStress.C
@@ -26,10 +26,10 @@ VolumeDeformGradCorrectedStress::VolumeDeformGradCorrectedStress(const InputPara
     _stress(declareProperty<RankTwoTensor>(getParam<MaterialPropertyName>("stress_name")))
 {
   if (isParamValid("pre_jacobian_name"))
-    _pre_Jacobian_mult = &getMaterialProperty<ElasticityTensorR4>("pre_jacobian_name");
+    _pre_Jacobian_mult = &getMaterialProperty<RankFourTensor>("pre_jacobian_name");
 
   if (isParamValid("jacobian_name"))
-    _Jacobian_mult = &declareProperty<ElasticityTensorR4>(getParam<MaterialPropertyName>("jacobian_name"));
+    _Jacobian_mult = &declareProperty<RankFourTensor>(getParam<MaterialPropertyName>("jacobian_name"));
 }
 
 void

--- a/modules/tensor_mechanics/src/utils/ElasticityTensorR4.C
+++ b/modules/tensor_mechanics/src/utils/ElasticityTensorR4.C
@@ -29,6 +29,7 @@ dataLoad(std::istream & stream, ElasticityTensorR4 & et, void * context)
 ElasticityTensorR4::ElasticityTensorR4(const RankFourTensor &a) :
     RankFourTensor(a)
 {
+  mooseDeprecated("Use RankFourTensor instead of ElasticityTensorR4. See http://mooseframework.org/wiki/PhysicsModules/TensorMechanics/Deprecations/ElasticityTensorR4/ to update your code");
 }
 
 Real

--- a/modules/tensor_mechanics/src/utils/ElasticityTensorTools.C
+++ b/modules/tensor_mechanics/src/utils/ElasticityTensorTools.C
@@ -1,0 +1,63 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "MooseTypes.h"
+#include "RankFourTensor.h"
+
+namespace ElasticityTensorTools
+{
+
+Real
+elasticJacobian(const RankFourTensor & r4t, unsigned int i, unsigned int k, const RealGradient & grad_test, const RealGradient & grad_phi)
+{
+  // d(stress_ij*d(test)/dx_j)/du_k = d(C_ijmn*du_m/dx_n dtest/dx_j)/du_k (which is nonzero for m == k)
+  Real sum = 0.0;
+  for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
+    for (unsigned int l = 0; l < LIBMESH_DIM; ++l)
+      sum += r4t(i,j,k,l) * grad_phi(l) * grad_test(j);
+  return sum;
+}
+
+Real
+elasticJacobianWC(const RankFourTensor & r4t, unsigned int i, unsigned int k, const RealGradient & grad_test, Real phi)
+{
+  // d(stress_ij*d(test)/dx_j)/dw_k = d(C_ijmn*eps_mnp*w_p*dtest/dx_j)/dw_k (only nonzero for p == k)
+  Real sum = 0.0;
+  for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
+    for (unsigned int m = 0; m < LIBMESH_DIM; ++m)
+      for (unsigned int n = 0; n < LIBMESH_DIM; ++n)
+        sum += r4t(i,j,m,n) * PermutationTensor::eps(m,n,k) * grad_test(j);
+  return sum * phi;
+}
+
+Real
+momentJacobian(const RankFourTensor & r4t, unsigned int i, unsigned int k, Real test, const RealGradient & grad_phi)
+{
+  // Jacobian entry: d(eps_ijm*stress_jm*test)/du_k = d(eps_ijm*C_jmln*du_l/dx_n*test)/du_k (only nonzero for l == k)
+  Real sum = 0.0;
+  for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
+    for (unsigned int m = 0; m < LIBMESH_DIM; ++m)
+      for (unsigned int n = 0; n < LIBMESH_DIM; ++n)
+        sum += PermutationTensor::eps(i,j,m) *r4t(j,m,k,n) * grad_phi(n);
+  return test * sum;
+}
+
+Real
+momentJacobianWC(const RankFourTensor & r4t, unsigned int i, unsigned int k, Real test, Real phi)
+{
+  // Jacobian entry: d(eps_ijm*stress_jm*test)/dw_k = d(eps_ijm*C_jmln*eps_lnp*w_p*test)/dw_k (only nonzero for p ==k)
+  Real sum = 0.0;
+  for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
+    for (unsigned int l = 0; l < LIBMESH_DIM; ++l)
+      for (unsigned int m = 0; m < LIBMESH_DIM; ++m)
+        for (unsigned int n = 0; n < LIBMESH_DIM; ++n)
+          sum += PermutationTensor::eps(i,j,m) * r4t(j,m,l,n) * PermutationTensor::eps(l,n,k);
+
+  return test * phi * sum;
+}
+
+}


### PR DESCRIPTION
Move the members of `ElasticityTensorR4` into a namespace. This allows us to do everything with only **one** rank four tensor class. I'll fix up the apps before I delete `ElasticityTensorR4`. 

Refs #6698
