### PR TITLE
Provide alternative stringify method for Reals with round-trip guarantee

### DIFF
--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -67,11 +67,17 @@ namespace Moose
     return os.str();
   }
 
-  /**
-   * Convert solve type into human readable string
-   */
+  /// Convert solve type into human readable string
   template<>
   std::string stringify(const SolveType & t);
+
+  /// Convert execute flags type into human readable string
+  template<>
+  std::string stringify(const ExecFlagType & t);
+
+   /// Stringify Reals with high precision
+  template<>
+  std::string stringify(const Real & t);
 }
 
 /**

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -75,9 +75,11 @@ namespace Moose
   template<>
   std::string stringify(const ExecFlagType & t);
 
-   /// Stringify Reals with high precision
-  template<>
-  std::string stringify(const Real & t);
+  /**
+   * Stringify Reals with enough precision to gurantee lossless
+   * Real -> string -> Real roundtrips.
+   */
+  std::string stringifyExact(Real);
 }
 
 /**

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -76,7 +76,7 @@ namespace Moose
   std::string stringify(const ExecFlagType & t);
 
   /**
-   * Stringify Reals with enough precision to gurantee lossless
+   * Stringify Reals with enough precision to guarantee lossless
    * Real -> string -> Real roundtrips.
    */
   std::string stringifyExact(Real);

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -57,7 +57,7 @@ namespace Moose
   template<>
   std::vector<ExecFlagType> vectorStringsToEnum<ExecFlagType>(const MultiMooseEnum & v);
 
-  // conversion to string
+  /// conversion to string
   template<typename T>
   std::string
   stringify(const T & t)

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -233,10 +233,12 @@ namespace Moose
   template<>
   std::string stringify(const Real & t)
   {
+    // this or std::numeric_limits<T>::max_digits10
+    const unsigned int max_digits10 = std::floor(std::numeric_limits<Real>::digits * std::log10(2) + 2);
+
     std::ostringstream os;
-    // the correct value would be std::numeric_limits<Real>::max_digits10 (C++11)
     os << std::scientific
-       << std::setprecision(std::numeric_limits<Real>::digits10 + 1)
+       << std::setprecision(max_digits10)
        << t;
     return os.str();
   }

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -230,15 +230,13 @@ namespace Moose
     return "";
   }
 
-  template<>
-  std::string stringify(const Real & t)
+  std::string stringifyExact(Real t)
   {
     // this or std::numeric_limits<T>::max_digits10
     const unsigned int max_digits10 = std::floor(std::numeric_limits<Real>::digits * std::log10(2) + 2);
 
     std::ostringstream os;
-    os << std::scientific
-       << std::setprecision(max_digits10)
+    os << std::setprecision(max_digits10)
        << t;
     return os.str();
   }

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -20,6 +20,9 @@
 // libMesh includes
 #include "libmesh/string_to_enum.h"
 
+// system includes
+#include <iomanip>
+
 namespace Moose
 {
   std::map<std::string, ExecFlagType> execstore_type_to_enum;
@@ -198,11 +201,11 @@ namespace Moose
   {
     switch (t)
     {
-    case ST_NEWTON: return "NEWTON";
-    case ST_JFNK:   return "JFNK";
-    case ST_PJFNK:  return "Preconditioned JFNK";
-    case ST_FD:     return "FD";
-    case ST_LINEAR: return "Linear";
+      case ST_NEWTON: return "NEWTON";
+      case ST_JFNK:   return "JFNK";
+      case ST_PJFNK:  return "Preconditioned JFNK";
+      case ST_FD:     return "FD";
+      case ST_LINEAR: return "Linear";
     }
     return "";
   }
@@ -212,19 +215,30 @@ namespace Moose
   {
     switch (t)
     {
-    case EXEC_INITIAL:        return "INITIAL";
-    case EXEC_LINEAR:         return "LINEAR";
-    case EXEC_NONLINEAR:      return "NONLINEAR";
-    case EXEC_TIMESTEP_END:   return "TIMESTEP_END";
-    case EXEC_TIMESTEP_BEGIN: return "TIMESTEP_BEGIN";
-    case EXEC_CUSTOM:         return "CUSTOM";
-    case EXEC_FINAL:          return "FINAL";
-    case EXEC_FORCED:         return "FORCED";
-    case EXEC_FAILED:         return "FAILED";
-    case EXEC_SUBDOMAIN:      return "SUBDOMAIN";
-    case EXEC_NONE:           return "NONE";
+      case EXEC_INITIAL:        return "INITIAL";
+      case EXEC_LINEAR:         return "LINEAR";
+      case EXEC_NONLINEAR:      return "NONLINEAR";
+      case EXEC_TIMESTEP_END:   return "TIMESTEP_END";
+      case EXEC_TIMESTEP_BEGIN: return "TIMESTEP_BEGIN";
+      case EXEC_CUSTOM:         return "CUSTOM";
+      case EXEC_FINAL:          return "FINAL";
+      case EXEC_FORCED:         return "FORCED";
+      case EXEC_FAILED:         return "FAILED";
+      case EXEC_SUBDOMAIN:      return "SUBDOMAIN";
+      case EXEC_NONE:           return "NONE";
     }
     return "";
+  }
+
+  template<>
+  std::string stringify(const Real & t)
+  {
+    std::ostringstream os;
+    // the correct value would be std::numeric_limits<Real>::max_digits10 (C++11)
+    os << std::scientific
+       << std::setprecision(std::numeric_limits<Real>::digits10 + 1)
+       << t;
+    return os.str();
   }
 }
 


### PR DESCRIPTION
I propose we give `std::to_string` the finger and go with this instead. I'm using the maximum representable number of digits (from numeric_limits) to set the stringstream precision.

Ping @friedmud and @jwpeterson 

Closes #6749
