### PR TITLE
Remove tensor mechanics dependence

### DIFF
--- a/modules/phase_field/Makefile
+++ b/modules/phase_field/Makefile
@@ -17,10 +17,6 @@ FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dependency on tensor_mechanics
-TENSOR_MECHANICS := yes
-include $(MODULE_DIR)/modules.mk
-
 # dep apps
 APPLICATION_DIR    := $(MODULE_DIR)/phase_field
 APPLICATION_NAME   := phase_field


### PR DESCRIPTION
I missed a crucial bit in  #6707 when I removed the dependence of phase field on tensor mechanics.

Refs #6497
