### PR TITLE
Fixing coordinate system syntax

### DIFF
--- a/framework/include/actions/CreateProblemAction.h
+++ b/framework/include/actions/CreateProblemAction.h
@@ -32,6 +32,11 @@ public:
 protected:
   std::vector<SubdomainName> _blocks;
   MultiMooseEnum _coord_sys;
+  /// One entry of coord system per block, the size of _blocks and _coord_sys has to match, except:
+  /// 1. _blocks.size() == 0, then there needs to be just one entry in _coord_sys, which will
+  ///    be set for the whole domain
+  /// 2. _blocks.size() > 0 and no coordinate system was specified, then the whole domain will be XYZ.
+  /// 3. _blocks.size() > 0 and one coordinate system was specified, then the whole domain will be that system.
   bool _fe_cache;
 };
 

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -283,21 +283,44 @@ FEProblem::setCoordSystem(const std::vector<SubdomainName> & blocks, const Multi
   }
   else
   {
-    if (blocks.size() != coord_sys.size())
-      mooseError("Number of blocks and coordinate systems does not match.");
-
-    for (unsigned int i = 0; i < blocks.size(); i++)
+    // user specified 'blocks' but not coordinate systems
+    if (coord_sys.size() == 0)
     {
-      SubdomainID sid = _mesh.getSubdomainID(blocks[i]);
-      Moose::CoordinateSystemType coord_type = Moose::stringToEnum<Moose::CoordinateSystemType>(coord_sys[i]);
-      _coord_sys[sid] = coord_type;
+      // set all blocks to cartesian coordinate system
+      for (unsigned int i = 0; i < blocks.size(); i++)
+      {
+        SubdomainID sid = _mesh.getSubdomainID(blocks[i]);
+        _coord_sys[sid] = Moose::COORD_XYZ;
+      }
     }
-
-    for (std::set<SubdomainID>::const_iterator it = subdomains.begin(); it != subdomains.end(); ++it)
+    else if (coord_sys.size() == 1)
     {
-      SubdomainID sid = *it;
-      if (_coord_sys.find(sid) == _coord_sys.end())
-        mooseError("Subdomain '" + Moose::stringify(sid) + "' does not have a coordinate system specified.");
+      // set all blocks to the coordinate system specified by `coord_sys[0]`
+      Moose::CoordinateSystemType coord_type = Moose::stringToEnum<Moose::CoordinateSystemType>(coord_sys[0]);
+      for (unsigned int i = 0; i < blocks.size(); i++)
+      {
+        SubdomainID sid = _mesh.getSubdomainID(blocks[i]);
+        _coord_sys[sid] = coord_type;
+      }
+    }
+    else
+    {
+      if (blocks.size() != coord_sys.size())
+        mooseError("Number of blocks and coordinate systems does not match.");
+
+      for (unsigned int i = 0; i < blocks.size(); i++)
+      {
+        SubdomainID sid = _mesh.getSubdomainID(blocks[i]);
+        Moose::CoordinateSystemType coord_type = Moose::stringToEnum<Moose::CoordinateSystemType>(coord_sys[i]);
+        _coord_sys[sid] = coord_type;
+      }
+
+      for (std::set<SubdomainID>::const_iterator it = subdomains.begin(); it != subdomains.end(); ++it)
+      {
+        SubdomainID sid = *it;
+        if (_coord_sys.find(sid) == _coord_sys.end())
+          mooseError("Subdomain '" + Moose::stringify(sid) + "' does not have a coordinate system specified.");
+      }
     }
   }
 }

--- a/test/tests/coord_type/tests
+++ b/test/tests/coord_type/tests
@@ -5,7 +5,7 @@
     input = coord_type_rz.i
     exodiff = coord_type_rz_out.e
   [../]
-  [/rz-x-rotation]
+  [./rz-x-rotation]
     # Simple diffusion with rotation around the x-axis
     type = Exodiff
     input = coord_type_rz.i


### PR DESCRIPTION
The "coord_type" parameter was `MultiMooseEnum` which was incorrect, because we have to be able to specify one value multiple times. One entry per block ID.

Another issue related to this problem that this MR is fixing is that when users specify `block` in `[GlobalParams]`, MOOSE sees mismatch between blocks and coord_sys. Thus an additional logic was included to prevent this. When people specify multi blocks and just one coord_type, we will set all these blocks to this coord_type.

Closes #6765 
