### PR TITLE
Revert "Remove tensor mechanics dependence"

### DIFF
--- a/modules/phase_field/Makefile
+++ b/modules/phase_field/Makefile
@@ -17,6 +17,10 @@ FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
+# dependency on tensor_mechanics
+TENSOR_MECHANICS := yes
+include $(MODULE_DIR)/modules.mk
+
 # dep apps
 APPLICATION_DIR    := $(MODULE_DIR)/phase_field
 APPLICATION_NAME   := phase_field


### PR DESCRIPTION
Reverts idaholab/moose#6767

Before this can be done another class needs to be moved into framework.

@brianmoose I'll take a closer look at it, but it seems that the test system did not detect the breakage at all. Weird.
