### PR TITLE
Add GlobalManager system

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -30,6 +30,7 @@
 #include "ExecuteMooseObjectWarehouse.h"
 #include "AuxGroupExecuteMooseObjectWarehouse.h"
 #include "MaterialWarehouse.h"
+#include "GlobalManager.h"
 
 // libMesh includes
 #include "libmesh/enum_quadrature_type.h"
@@ -39,8 +40,6 @@ class DisplacedProblem;
 class FEProblem;
 class MooseMesh;
 class NonlinearSystem;
-class RandomInterface;
-class RandomData;
 class MeshChangedInterface;
 class MultiMooseEnum;
 class MaterialPropertyStorage;
@@ -851,8 +850,6 @@ public:
    */
   void setConstJacobian(bool state) { _const_jacobian = state; }
 
-  void registerRandomInterface(RandomInterface & random_interface, const std::string & name);
-
   void setKernelCoverageCheck(bool flag) { _kernel_coverage_check = flag; }
 
   void setMaterialCoverageCheck(bool flag) { _material_coverage_check = flag; }
@@ -966,7 +963,8 @@ public:
    */
   virtual void computeAuxiliaryKernels(const ExecFlagType & type);
 
-public:
+  /// fetch the GlobalManager object of type T
+  template <class T> T & getGlobal();
 
   ///@{
   /**
@@ -997,13 +995,10 @@ public:
 
 protected:
 
-  ///@{
   /**
    *
    */
   VectorPostprocessorData & getVectorPostprocessorData();
-  ///@}
-
 
   MooseMesh & _mesh;
   EquationSystems _eq;
@@ -1100,9 +1095,6 @@ protected:
 
   /// Transfers executed just after MultiApps to transfer data from them
   ExecuteMooseObjectWarehouse<Transfer> _from_multi_app_transfers;
-
-  /// A map of objects that consume random numbers
-  std::map<std::string, RandomData *> _random_data_objects;
 
   /// Cache for calculating materials on side
   std::vector<LIBMESH_BEST_UNORDERED_MAP<SubdomainID, bool> > _block_mat_side_cache;
@@ -1206,6 +1198,8 @@ protected:
   Moose::PetscSupport::PetscOptions _petsc_options;
 #endif //LIBMESH_HAVE_PETSC
 
+  std::map<std::string, MooseSharedPointer<GlobalManager> > _global_managers;
+
 private:
   bool _use_legacy_uo_aux_computation;
   bool _use_legacy_uo_initialization;
@@ -1271,5 +1265,36 @@ FEProblem::finalizeUserObjects(const MooseObjectWarehouse<T> & warehouse)
   }
 }
 
+template <class T>
+T &
+FEProblem::getGlobal()
+{
+  // get the class name as map key
+  const std::string name = typeid(T).name();
+
+  // look up the class by its name in the _global_managers_map
+  std::map<std::string, MooseSharedPointer<GlobalManager> >::iterator it = _global_managers.find(name);
+  if (it != _global_managers.end())
+  {
+    // the object was found. Check that the type is correct and return a reference
+    MooseSharedPointer<T> object = MooseSharedNamespace::dynamic_pointer_cast<T>(it->second);
+    if (object.get() == NULL)
+      mooseError("Internal error in GlobalManager store");
+
+    return *object;
+  }
+  else
+  {
+    // create a new instance of the object, insert it in the map, and return a reference
+    MooseSharedPointer<T> object(new T(*this));
+    MooseSharedPointer<GlobalManager> gm_object(MooseSharedNamespace::dynamic_pointer_cast<GlobalManager>(object));
+    if (gm_object.get())
+      _global_managers.insert(std::make_pair(name, gm_object));
+    else
+      mooseError("Objects stored as globals need to inherit from the `GlobalManager` class.");
+
+    return *object;
+  }
+}
 
 #endif /* FEPROBLEM_H */

--- a/framework/include/utils/GlobalManager.h
+++ b/framework/include/utils/GlobalManager.h
@@ -1,0 +1,32 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef GLOBALMANAGER_H
+#define GLOBALMANAGER_H
+
+class FEProblem;
+
+/**
+ * Base class for globally registered manager classes in FEProblem
+ */
+class GlobalManager
+{
+public:
+  GlobalManager(FEProblem & fe_problem) : _fe_problem(fe_problem) {}
+
+protected:
+  FEProblem & _fe_problem;
+};
+
+#endif //GLOBALMANAGER_H

--- a/framework/include/utils/GlobalManager.h
+++ b/framework/include/utils/GlobalManager.h
@@ -26,7 +26,15 @@ public:
   GlobalManager(FEProblem & fe_problem) : _fe_problem(fe_problem) {}
 
 protected:
+  ///@{ Setup methods called by FEProblem
+  virtual void initialSetup() {}
+  virtual void timestepSetup() {}
+  virtual void jacobianSetup() {}
+  virtual void residualSetup() {}
+  ///@}
+
   FEProblem & _fe_problem;
+  friend class FEProblem;
 };
 
 #endif //GLOBALMANAGER_H

--- a/framework/include/utils/RandomInterface.h
+++ b/framework/include/utils/RandomInterface.h
@@ -23,6 +23,7 @@ class RandomInterface;
 class Assembly;
 class RandomData;
 class MooseRandom;
+class RandomInterfaceManager;
 
 template<>
 InputParameters validParams<RandomInterface>();
@@ -68,13 +69,13 @@ public:
   bool isNodal() const { return _is_nodal; }
   ExecFlagType getResetOnTime() const { return _reset_on; }
 
-  void setRandomDataPointer(RandomData *random_data);
+  void setRandomDataPointer(const MooseSharedPointer<RandomData> & random_data);
 
 private:
-  RandomData *_random_data;
-  mutable MooseRandom *_generator;
+  MooseSharedPointer<RandomData> _random_data;
+  mutable MooseRandom * _generator;
 
-  FEProblem & _ri_problem;
+  RandomInterfaceManager & _ri_manager;
   const std::string _ri_name;
 
   unsigned int _master_seed;

--- a/framework/include/utils/RandomInterfaceManager.h
+++ b/framework/include/utils/RandomInterfaceManager.h
@@ -1,0 +1,49 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef RANDOMINTERFACEMANAGER_H
+#define RANDOMINTERFACEMANAGER_H
+
+#include "GlobalManager.h"
+#include "MooseTypes.h"
+
+#include <string>
+#include <map>
+
+class RandomInterface;
+class RandomData;
+
+/**
+ * Manage the RandomInterface features in FEProblem
+ */
+class RandomInterfaceManager : public GlobalManager
+{
+public:
+  RandomInterfaceManager(FEProblem & fe_problem);
+
+  void registerRandomInterface(RandomInterface & random_interface, const std::string & name);
+
+protected:
+  ///@{ Setup methods called by FEProblem
+  virtual void initialSetup();
+  virtual void timestepSetup();
+  virtual void jacobianSetup();
+  virtual void residualSetup();
+  ///@}
+
+  typedef std::map<std::string, MooseSharedPointer<RandomData> > RandomDataStore;
+  RandomDataStore _random_data_objects;
+};
+
+#endif //RANDOMINTERFACEMANAGER_H

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -532,6 +532,12 @@ void FEProblem::initialSetup()
   updateGeomSearch(); // Call all of the rest of the geometric searches
   Moose::perf_log.pop("Initial updateGeomSearch()", "Setup");
 
+  // Global manager setup
+  for (std::map<std::string, MooseSharedPointer<GlobalManager> >::iterator it = _global_managers.begin();
+       it != _global_managers.end();
+       ++it)
+    it->second->initialSetup();
+
   // Random interface objects
   for (std::map<std::string, RandomData *>::iterator it = _random_data_objects.begin();
        it != _random_data_objects.end();
@@ -661,6 +667,12 @@ void FEProblem::timestepSetup()
 
   _aux.timestepSetup();
   _nl.timestepSetup();
+
+  // Global manager setup
+  for (std::map<std::string, MooseSharedPointer<GlobalManager> >::iterator it = _global_managers.begin();
+       it != _global_managers.end();
+       ++it)
+    it->second->timestepSetup();
 
   // Random interface objects
   for (std::map<std::string, RandomData *>::iterator it = _random_data_objects.begin();
@@ -3302,6 +3314,12 @@ FEProblem::computeResidualType(const NumericVector<Number>& soln, NumericVector<
 
   unsigned int n_threads = libMesh::n_threads();
 
+  // Global manager setup
+  for (std::map<std::string, MooseSharedPointer<GlobalManager> >::iterator it = _global_managers.begin();
+       it != _global_managers.end();
+       ++it)
+    it->second->residualSetup();
+
   // Random interface objects
   for (std::map<std::string, RandomData *>::iterator it = _random_data_objects.begin();
        it != _random_data_objects.end();
@@ -3350,6 +3368,12 @@ FEProblem::computeJacobian(NonlinearImplicitSystem & sys, const NumericVector<Nu
     _aux.zeroVariablesForJacobian();
 
     unsigned int n_threads = libMesh::n_threads();
+
+    // Global manager setup
+    for (std::map<std::string, MooseSharedPointer<GlobalManager> >::iterator it = _global_managers.begin();
+         it != _global_managers.end();
+         ++it)
+      it->second->jacobianSetup();
 
     // Random interface objects
     for (std::map<std::string, RandomData *>::iterator it = _random_data_objects.begin();

--- a/framework/src/utils/RandomInterface.C
+++ b/framework/src/utils/RandomInterface.C
@@ -14,6 +14,7 @@
 
 #include "Moose.h"
 #include "RandomInterface.h"
+#include "RandomInterfaceManager.h"
 #include "Assembly.h"
 #include "RandomData.h"
 #include "MooseRandom.h"
@@ -29,9 +30,9 @@ InputParameters validParams<RandomInterface>()
 }
 
 RandomInterface::RandomInterface(const InputParameters & parameters, FEProblem & problem, THREAD_ID tid, bool is_nodal) :
-    _random_data(NULL),
+    _random_data(),
     _generator(NULL),
-    _ri_problem(problem),
+    _ri_manager(problem.getGlobal<RandomInterfaceManager>()),
     _ri_name(parameters.get<std::string>("_object_name")),
     _master_seed(parameters.get<unsigned int>("seed")),
     _is_nodal(is_nodal),
@@ -49,11 +50,11 @@ void
 RandomInterface::setRandomResetFrequency(ExecFlagType exec_flag)
 {
   _reset_on = exec_flag;
-  _ri_problem.registerRandomInterface(*this, _ri_name);
+  _ri_manager.registerRandomInterface(*this, _ri_name);
 }
 
 void
-RandomInterface::setRandomDataPointer(RandomData *random_data)
+RandomInterface::setRandomDataPointer(const MooseSharedPointer<RandomData> & random_data)
 {
   _random_data = random_data;
   _generator = &_random_data->getGenerator();

--- a/framework/src/utils/RandomInterfaceManager.C
+++ b/framework/src/utils/RandomInterfaceManager.C
@@ -1,0 +1,73 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "RandomInterfaceManager.h"
+#include "RandomInterface.h"
+#include "RandomData.h"
+
+RandomInterfaceManager::RandomInterfaceManager(FEProblem & fe_problem) :
+    GlobalManager(fe_problem)
+{
+}
+
+void
+RandomInterfaceManager::registerRandomInterface(RandomInterface & random_interface, const std::string & name)
+{
+  ;
+  if (_random_data_objects.find(name) == _random_data_objects.end())
+  {
+    MooseSharedPointer<RandomData> random_data(new RandomData(_fe_problem, random_interface));
+    random_interface.setRandomDataPointer(random_data);
+
+    _random_data_objects[name] = random_data;
+  }
+  else
+    random_interface.setRandomDataPointer(_random_data_objects[name]);
+}
+
+void
+RandomInterfaceManager::initialSetup()
+{
+  for (RandomDataStore::iterator it = _random_data_objects.begin();
+       it != _random_data_objects.end();
+       ++it)
+    it->second->updateSeeds(EXEC_INITIAL);
+}
+
+void
+RandomInterfaceManager::timestepSetup()
+{
+  for (RandomDataStore::iterator it = _random_data_objects.begin();
+       it != _random_data_objects.end();
+       ++it)
+    it->second->updateSeeds(EXEC_TIMESTEP_BEGIN);
+}
+
+void
+RandomInterfaceManager::jacobianSetup()
+{
+  for (RandomDataStore::iterator it = _random_data_objects.begin();
+       it != _random_data_objects.end();
+       ++it)
+    it->second->updateSeeds(EXEC_NONLINEAR);
+}
+
+void
+RandomInterfaceManager::residualSetup()
+{
+  for (RandomDataStore::iterator it = _random_data_objects.begin();
+       it != _random_data_objects.end();
+       ++it)
+    it->second->updateSeeds(EXEC_LINEAR);
+}


### PR DESCRIPTION
This adds the global singleton registration system to `FEProblem` (b4e897d) and demonstrates its use by moving `RandomInterface` related stuff out of `FEProblem` (5cecc1a). I foresee that we may need a few more hooks to this system (as in d9d40e5) to make the interface more powerful. 

I hope this will let us migrate the XFEM stuff over to this system as well (so that all code could just stay in the XFEM module). I also have a use in mind for phase field (and derivative parsed materials).

Closes #6777
