### PR TITLE
Make moose_test work with --error

### DIFF
--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -94,6 +94,9 @@ private:
   /// True if outputing checkpoint files in binary format
   bool _binary;
 
+  /// True if running with parallel mesh
+  bool _parallel_mesh;
+
   /// Reference to the restartable data
   const RestartableDatas & _restartable_data;
 

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -9,7 +9,6 @@ class RunApp(Tester):
     params = Tester.validParams()
     params.addRequiredParam('input',      "The input file to use for this test.")
     params.addParam('test_name',          "The name of the test - populated automatically")
-    params.addParam('skip_test_harness_cli_args', False, "Skip adding global TestHarness CLI Args for this test")
     params.addParam('input_switch', '-i', "The default switch used for indicating an input to the executable")
     params.addParam('errors',             ['ERROR', 'command not found', 'erminate called after throwing an instance of'], "The error messages to detect a failed run")
     params.addParam('expect_out',         "A regular expression that must occur in the input in order for the test to be considered passing.")
@@ -88,7 +87,7 @@ class RunApp(Tester):
       # and it is NOT supplied already in the cli-args option\
       specs['cli_args'].append('--error')
 
-    if options.error_unused and '--error-unused' not in specs['cli_args'] and '--warn-unused' not in specs['cli_args']:
+    if options.error_unused and '--error-unused' not in specs['cli_args'] and '--warn-unused' not in specs['cli_args'] and not specs["allow_warnings"]:
       # The user has passed the error-unused option to the test harness
       # and it is NOT supplied already in the cli-args option
       # also, neither is the conflicting option "warn-unused"
@@ -101,9 +100,6 @@ class RunApp(Tester):
 
     if options.colored == False:
       specs['cli_args'].append('--no-color')
-
-    if options.cli_args and not specs['skip_test_harness_cli_args']:
-      specs['cli_args'].insert(0, options.cli_args)
 
     if options.scaling and specs['scale_refine'] > 0:
       specs['cli_args'].insert(0, ' -r ' + str(specs['scale_refine']))

--- a/test/run_tests
+++ b/test/run_tests
@@ -16,8 +16,8 @@ sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 import path_tool
 path_tool.activate_module('TestHarness')
 
-# Append error unused flag when running tests
-sys.argv.insert(1, "--error-unused")
+# Append error flag when running tests
+sys.argv.insert(1, "--error")
 
 from TestHarness import TestHarness
 # Run the tests!

--- a/test/tests/ics/function_ic/tests
+++ b/test/tests/ics/function_ic/tests
@@ -3,11 +3,13 @@
     type = 'Exodiff'
     input = 'parsed_function.i'
     exodiff = 'parsed.e'
+    recover = false #see #2295
   [../]
 
   [./spline_function]
     type = 'Exodiff'
     input = 'spline_function.i'
     exodiff = 'spline.e'
+    recover = false #see #2295
   [../]
 []

--- a/test/tests/materials/derivativematerialinterface/execution_order.i
+++ b/test/tests/materials/derivativematerialinterface/execution_order.i
@@ -17,6 +17,7 @@
     type = DerivativeMaterialInterfaceTestProvider
     block = 0
     outputs = exodus
+    output_properties = 'dprop/db dprop/da d^2prop/dadb d^2prop/dadc d^3prop/dadbdc'
   [../]
 []
 

--- a/test/tests/materials/derivativematerialinterface/test.i
+++ b/test/tests/materials/derivativematerialinterface/test.i
@@ -10,6 +10,7 @@
     type = DerivativeMaterialInterfaceTestProvider
     block = 0
     outputs = exodus
+    output_properties = 'dprop/db dprop/da d^2prop/dadb d^2prop/dadc d^3prop/dadbdc'
   [../]
   [./client]
     type = DerivativeMaterialInterfaceTestClient

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -399,6 +399,7 @@
     input = 'override_name_variable_test.i'
     expect_out = "The following variables were overridden or supplied multiple times:"
     max_parallel = 1
+    allow_warnings = true
   [../]
 
   [./rz_3d_error_check_test]
@@ -430,8 +431,7 @@
     expect_out = "The following parameters were unused in your input file"
     input = 'unused_param_test.i'
     cli_args = '--warn-unused'
-    # Don't allow --error-unused on this test
-    skip_test_harness_cli_args = true
+    allow_warnings = true
     max_parallel = 1 # warning can mix on multiple processes
   [../]
 
@@ -440,8 +440,7 @@
     expect_out = "The following parameters were unused on the command line"
     input = 'unused_param_test.i'
     cli_args = '--warn-unused Executioner/unused_param=true'
-    # Don't allow --error-unused on this test
-    skip_test_harness_cli_args = true
+    allow_warnings = true
     max_parallel = 1 # warning can mix on multiple processes
   [../]
 

--- a/test/tests/multiapps/picard_failure/tests
+++ b/test/tests/multiapps/picard_failure/tests
@@ -7,5 +7,6 @@
     max_threads = 1 # NanAtCountKernel changes behavior with threads
     recover = false
     petsc_version = '>=3.6.1'
+    allow_warnings = true
   [../]
 []

--- a/test/tests/multiapps/picard_multilevel/tests
+++ b/test/tests/multiapps/picard_multilevel/tests
@@ -3,5 +3,6 @@
     type = 'Exodiff'
     input = 'picard_master.i'
     exodiff = 'picard_master_out.e picard_master_out_sub10.e picard_master_out_sub10_sub20.e'
+    allow_warnings = true
   [../]
 []

--- a/test/tests/multiapps/picard_sub_cycling/tests
+++ b/test/tests/multiapps/picard_sub_cycling/tests
@@ -3,5 +3,6 @@
     type = 'Exodiff'
     input = 'picard_master.i'
     exodiff = 'picard_master_out.e'
+    allow_warnings = true
   [../]
 []

--- a/test/tests/multiapps/sub_cycling_failure/tests
+++ b/test/tests/multiapps/sub_cycling_failure/tests
@@ -3,6 +3,7 @@
     type = 'Exodiff'
     input = 'master.i'
     exodiff = 'master_out.e master_out_sub0.e'
+    allow_warnings = true
   [../]
 
   [./test_failure_max_procs]
@@ -15,5 +16,6 @@
     min_parallel = 2
     prereq = test_failure
     superlu = true
+    allow_warnings = true
   [../]
 []

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -49,6 +49,7 @@
     input = 'output_test_tecplot_binary.i'
     check_files = 'output_test_tecplot_binary_out_0000.dat'
     tecplot = false
+    allow_warnings = false
   [../]
 
   [./dump_test]

--- a/test/tests/outputs/misc/tests
+++ b/test/tests/outputs/misc/tests
@@ -31,5 +31,6 @@
     type = CheckFiles
     input = default_names.i
     check_files = 'default_names_out.e default_names_oversample.e'
+    recover = false
   [../]
 []

--- a/test/tests/outputs/oversample/tests
+++ b/test/tests/outputs/oversample/tests
@@ -4,6 +4,7 @@
     type = 'Exodiff'
     input = 'oversample.i'
     exodiff = 'oversample_out.e'
+    recover = false #see #2295
   [../]
 
   [./oversample_filemesh]
@@ -11,6 +12,7 @@
     type = 'Exodiff'
     input = 'oversample_file.i'
     exodiff = 'exodus_oversample_custom_name.e'
+    recover = false #see #2295
   [../]
 
   [./adapt]
@@ -24,12 +26,14 @@
     type = 'Exodiff'
     input = 'over_sampling_test_gen.i'
     exodiff = 'out_gen.e out_gen_oversample.e'
+    recover = false #see #2295
   [../]
 
   [./test_file]
     type = 'Exodiff'
     input = 'over_sampling_test_file.i'
     exodiff = 'out_file.e out_file_oversample.e'
+    recover = false #see #2295
   [../]
 
   [./test_first_order]
@@ -37,6 +41,7 @@
     input = 'over_sampling_second_file.i'
     exodiff = 'out_wedge_oversample.e'
     valgrind = 'HEAVY'   # Too slow
+    recover = false #see #2295
   [../]
 
   [./ex02]
@@ -44,6 +49,7 @@
     type = 'Exodiff'
     input = 'ex02_oversample.i'
     exodiff = 'ex02_oversample_out.e ex02_oversample_os2.e ex02_oversample_os4.e'
+    recover = false #see #2295
   [../]
 
   [./ex02_adapt]
@@ -51,5 +57,6 @@
     type = 'Exodiff'
     input = 'ex02_adapt.i'
     exodiff = 'ex02_adapt_out.e ex02_adapt_os2.e ex02_adapt_os4.e'
+    recover = false #see #2295
   [../]
 []

--- a/test/tests/outputs/position/tests
+++ b/test/tests/outputs/position/tests
@@ -3,5 +3,6 @@
     type = 'Exodiff'
     input = 'position.i'
     exodiff = 'position_out.e'
+    recover = false #see #2295
   [../]
 []

--- a/test/tests/transfers/multiapp_mesh_function_transfer/tests
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/tests
@@ -45,6 +45,7 @@
     type = 'RunApp'
     input = 'exec_on_mismatch.i'
     expect_out = 'MultiAppTransfer execute_on flags do not match'
+    allow_warnings = true
     max_parallel = 1
   [../]
 []


### PR DESCRIPTION
It turns out we had two options that almost did the same thing in the TestHarness. This PR removes one of those options and adds the right flags to several tests.

More importantly, this PR also turns on the `--error` flag in moose/test!

closes #6806
