### PR TITLE
Undo aggressive cleanup

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -101,6 +101,9 @@ class RunApp(Tester):
     if options.colored == False:
       specs['cli_args'].append('--no-color')
 
+    if options.cli_args:
+      specs['cli_args'].insert(0, options.cli_args)
+
     if options.scaling and specs['scale_refine'] > 0:
       specs['cli_args'].insert(0, ' -r ' + str(specs['scale_refine']))
 

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -49,7 +49,7 @@
     input = 'output_test_tecplot_binary.i'
     check_files = 'output_test_tecplot_binary_out_0000.dat'
     tecplot = false
-    allow_warnings = false
+    allow_warnings = true
   [../]
 
   [./dump_test]


### PR DESCRIPTION
This fixes the --cli-args option in the TestHarness. Something that is used
infrequently but is used by CIVET and other advanced testing.

refs #6809
