### PR TITLE
Reinit shape functions at physical points within neighbor element

### DIFF
--- a/framework/include/base/DisplacedProblem.h
+++ b/framework/include/base/DisplacedProblem.h
@@ -109,6 +109,7 @@ public:
   virtual void reinitNodesNeighbor(const std::vector<dof_id_type> & nodes, THREAD_ID tid);
   virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid);
   virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid);
+  virtual void reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid);
   virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid);
   virtual void reinitScalars(THREAD_ID tid);
 

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -286,6 +286,7 @@ public:
   virtual void reinitNodesNeighbor(const std::vector<dof_id_type> & nodes, THREAD_ID tid);
   virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid);
   virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid);
+  virtual void reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid);
   virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid);
   virtual void reinitScalars(THREAD_ID tid);
   virtual void reinitOffDiagScalars(THREAD_ID tid);

--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -106,6 +106,10 @@ public:
   const VariablePhiGradient & gradPhiFace();
   const VariablePhiSecond & secondPhiFace();
 
+  const VariablePhiValue & phiNeighbor();
+  const VariablePhiGradient & gradPhiNeighbor();
+  const VariablePhiSecond & secondPhiNeighbor();
+
   const VariablePhiValue & phiFaceNeighbor();
   const VariablePhiGradient & gradPhiFaceNeighbor();
   const VariablePhiSecond & secondPhiFaceNeighbor();
@@ -360,6 +364,11 @@ protected:
   const VariablePhiValue & _phi_face;
   const VariablePhiGradient & _grad_phi_face;
   const VariablePhiSecond * _second_phi_face;
+
+ // Values, gradients and second derivatives of shape function
+  const VariablePhiValue & _phi_neighbor;
+  const VariablePhiGradient & _grad_phi_neighbor;
+  const VariablePhiSecond * _second_phi_neighbor;
 
   // Values, gradients and second derivatives of shape function on faces
   const VariablePhiValue & _phi_face_neighbor;

--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -155,6 +155,7 @@ public:
   virtual void reinitNodesNeighbor(const std::vector<dof_id_type> & nodes, THREAD_ID tid) = 0;
   virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid) = 0;
   virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid) = 0;
+  virtual void reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid) = 0;
   virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid) = 0;
   virtual void reinitScalars(THREAD_ID tid) = 0;
 

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -69,11 +69,11 @@ Assembly::Assembly(SystemBase & sys, CouplingMatrix * & cm, THREAD_ID tid) :
   // Build fe's for the helpers
   buildFE(FEType(FIRST, LAGRANGE));
   buildFaceFE(FEType(FIRST, LAGRANGE));
-  buildNeighborFE(FEType(FIRST,LAGRANGE));
+  buildNeighborFE(FEType(FIRST, LAGRANGE));
   buildFaceNeighborFE(FEType(FIRST, LAGRANGE));
 
   // Build an FE helper object for this type for each dimension up to the dimension of the current mesh
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
   {
     _holder_fe_helper[dim] = &_fe[dim][FEType(FIRST, LAGRANGE)];
     (*_holder_fe_helper[dim])->get_phi();
@@ -97,16 +97,16 @@ Assembly::Assembly(SystemBase & sys, CouplingMatrix * & cm, THREAD_ID tid) :
 
 Assembly::~Assembly()
 {
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
     for (std::map<FEType, FEBase *>::iterator it = _fe[dim].begin(); it != _fe[dim].end(); ++it)
       delete it->second;
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
     for (std::map<FEType, FEBase *>::iterator it = _fe_face[dim].begin(); it != _fe_face[dim].end(); ++it)
       delete it->second;
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
     for (std::map<FEType, FEBase *>::iterator it = _fe_neighbor[dim].begin(); it != _fe_neighbor[dim].end(); ++it)
       delete it->second;
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
     for (std::map<FEType, FEBase *>::iterator it = _fe_face_neighbor[dim].begin(); it != _fe_face_neighbor[dim].end(); ++it)
       delete it->second;
 
@@ -144,7 +144,7 @@ Assembly::buildFE(FEType type)
     _fe_shape_data[type] = new FEShapeData;
 
   // Build an FE object for this type for each dimension up to the dimension of the current mesh
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
   {
     if (!_fe[dim][type])
       _fe[dim][type] = FEBase::build(dim, type).release();
@@ -166,7 +166,7 @@ Assembly::buildFaceFE(FEType type)
     _fe_shape_data_face[type] = new FEShapeData;
 
   // Build an FE object for this type for each dimension up to the dimension of the current mesh
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
   {
     if (!_fe_face[dim][type])
       _fe_face[dim][type] = FEBase::build(dim, type).release();
@@ -184,7 +184,7 @@ Assembly::buildNeighborFE(FEType type)
     _fe_shape_data_neighbor[type] = new FEShapeData;
 
   // Build an FE object for this type for each dimension up to the dimension of the current mesh
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
   {
     if (!_fe_neighbor[dim][type])
       _fe_neighbor[dim][type] = FEBase::build(dim, type).release();
@@ -202,7 +202,7 @@ Assembly::buildFaceNeighborFE(FEType type)
     _fe_shape_data_face_neighbor[type] = new FEShapeData;
 
   // Build an FE object for this type for each dimension up to the dimension of the current mesh
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
   {
     if (!_fe_face_neighbor[dim][type])
       _fe_face_neighbor[dim][type] = FEBase::build(dim, type).release();
@@ -326,19 +326,19 @@ void
 Assembly::createQRules(QuadratureType type, Order order, Order volume_order, Order face_order)
 {
   _holder_qrule_volume.clear();
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
     _holder_qrule_volume[dim] = QBase::build(type, dim, volume_order).release();
 
   _holder_qrule_face.clear();
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
     _holder_qrule_face[dim] = QBase::build(type, dim - 1, face_order).release();
 
   _holder_qrule_neighbor.clear();
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
     _holder_qrule_neighbor[dim] = new ArbitraryQuadrature(dim, face_order);
 
   _holder_qrule_arbitrary.clear();
-  for (unsigned int dim=1; dim<=_mesh_dimension; dim++)
+  for (unsigned int dim = 1; dim <= _mesh_dimension; dim++)
     _holder_qrule_arbitrary[dim] = new ArbitraryQuadrature(dim, order);
 }
 
@@ -815,7 +815,6 @@ Assembly::reinitNeighborAtPhysical(const Elem * neighbor, const std::vector<Poin
   // Save off the physical points
   _current_physical_points = physical_points;
 }
-
 
 DenseMatrix<Number> &
 Assembly::jacobianBlock(unsigned int ivar, unsigned int jvar)

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -378,9 +378,25 @@ DisplacedProblem::reinitNeighborPhys(const Elem * neighbor, unsigned int neighbo
   prepareAssemblyNeighbor(tid);
 
   // Compute values at the points
-//  unsigned int bnd_id = 0;
+  _displaced_nl.reinitNeighborFace(neighbor, neighbor_side, 0, tid);
+  _displaced_aux.reinitNeighborFace(neighbor, neighbor_side, 0, tid);
+}
+
+void
+DisplacedProblem::reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid)
+{
+  // Reinit shape functions
+  _assembly[tid]->reinitNeighborAtPhysical(neighbor, physical_points);
+
+  // Set the neighbor dof indices
+  _displaced_nl.prepareNeighbor(tid);
+  _displaced_aux.prepareNeighbor(tid);
+
+  prepareAssemblyNeighbor(tid);
+
+  // Compute values at the points
   _displaced_nl.reinitNeighbor(neighbor, tid);
-  _displaced_aux.reinitNeighbor(neighbor,tid);
+  _displaced_aux.reinitNeighbor(neighbor, tid);
 }
 
 void

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1150,13 +1150,36 @@ FEProblem::reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side,
   _assembly[tid]->prepareNeighbor();
 
   // Compute the values of each variable at the points
-  _nl.reinitNeighbor(neighbor, tid);
-  _aux.reinitNeighbor(neighbor, tid);
+  _nl.reinitNeighborFace(neighbor, neighbor_side, 0, tid);
+  _aux.reinitNeighborFace(neighbor, neighbor_side, 0, tid);
 
   // Do the same for the displaced problem
   if (_displaced_problem != NULL)
     _displaced_problem->reinitNeighborPhys(_displaced_mesh->elem(neighbor->id()), neighbor_side, physical_points, tid);
 }
+
+void
+FEProblem::reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid)
+{
+  // Reinits shape the functions at the physical points
+  _assembly[tid]->reinitNeighborAtPhysical(neighbor, physical_points);
+
+  // Sets the neighbor dof indices
+  _nl.prepareNeighbor(tid);
+  _aux.prepareNeighbor(tid);
+
+  // Resizes Re and Ke
+  _assembly[tid]->prepareNeighbor();
+
+  // Compute the values of each variable at the points
+  _nl.reinitNeighbor(neighbor, tid);
+  _aux.reinitNeighbor(neighbor, tid);
+
+  // Do the same for the displaced problem
+  if (_displaced_problem != NULL)
+    _displaced_problem->reinitNeighborPhys(_displaced_mesh->elem(neighbor->id()), physical_points, tid);
+}
+
 
 void
 FEProblem::getDiracElements(std::set<const Elem *> & elems)

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1180,7 +1180,6 @@ FEProblem::reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & 
     _displaced_problem->reinitNeighborPhys(_displaced_mesh->elem(neighbor->id()), physical_points, tid);
 }
 
-
 void
 FEProblem::getDiracElements(std::set<const Elem *> & elems)
 {

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -74,6 +74,9 @@ MooseVariable::MooseVariable(unsigned int var_num, const FEType & fe_type, Syste
     _phi_face(_assembly.fePhiFace(_fe_type)),
     _grad_phi_face(_assembly.feGradPhiFace(_fe_type)),
 
+    _phi_neighbor(_assembly.fePhiNeighbor(_fe_type)),
+    _grad_phi_neighbor(_assembly.feGradPhiNeighbor(_fe_type)),
+
     _phi_face_neighbor(_assembly.fePhiFaceNeighbor(_fe_type)),
     _grad_phi_face_neighbor(_assembly.feGradPhiFaceNeighbor(_fe_type)),
 
@@ -388,6 +391,25 @@ MooseVariable::secondPhiFace()
 {
   _second_phi_face = &_assembly.feSecondPhiFace(_fe_type);
   return *_second_phi_face;
+}
+
+const VariablePhiValue &
+MooseVariable::phiNeighbor()
+{
+  return _phi_neighbor;
+}
+
+const VariablePhiGradient &
+MooseVariable::gradPhiNeighbor()
+{
+  return _grad_phi_neighbor;
+}
+
+const VariablePhiSecond &
+MooseVariable::secondPhiNeighbor()
+{
+  _second_phi_neighbor = &_assembly.feSecondPhiNeighbor(_fe_type);
+  return *_second_phi_neighbor;
 }
 
 const VariablePhiValue &
@@ -1392,11 +1414,11 @@ MooseVariable::computeNeighborValues()
 
     for (unsigned int qp=0; qp < nqp; ++qp)
     {
-      phi_local = _phi_face_neighbor[i][qp];
-      dphi_local = _grad_phi_face_neighbor[i][qp];
+      phi_local = _phi_neighbor[i][qp];
+      dphi_local = _grad_phi_neighbor[i][qp];
 
       if (_need_second_neighbor || _need_second_old_neighbor || _need_second_older_neighbor)
-        d2phi_local = (*_second_phi_face_neighbor)[i][qp];
+        d2phi_local = (*_second_phi_neighbor)[i][qp];
 
       _u_neighbor[qp]      += phi_local * soln_local;
       _grad_u_neighbor[qp] += dphi_local * soln_local;

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1252,7 +1252,7 @@ NonlinearSystem::constraintResiduals(NumericVector<Number> & residual, bool disp
           MooseSharedPointer<ElemElemConstraint> ec = *ec_it;
 
           _fe_problem.reinitElemPhys(elem, info._constraint_q_point, tid);
-          _fe_problem.reinitNeighborPhys(pair_elem, 0, info._constraint_q_point, tid);
+          _fe_problem.reinitNeighborPhys(pair_elem, info._constraint_q_point, tid);
 
           ec->subProblem().prepareShapes(ec->variable().number(), tid);
           ec->subProblem().prepareNeighborShapes(ec->variable().number(), tid);
@@ -1882,7 +1882,7 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
           MooseSharedPointer<ElemElemConstraint> ec = *ec_it;
 
           _fe_problem.reinitElemPhys(elem, info._constraint_q_point, tid);
-          _fe_problem.reinitNeighborPhys(pair_elem, 0, info._constraint_q_point, tid);
+          _fe_problem.reinitNeighborPhys(pair_elem, info._constraint_q_point, tid);
 
           ec->subProblem().prepareShapes(ec->variable().number(), tid);
           ec->subProblem().prepareNeighborShapes(ec->variable().number(), tid);

--- a/framework/src/constraints/ElemElemConstraint.C
+++ b/framework/src/constraints/ElemElemConstraint.C
@@ -46,11 +46,11 @@ ElemElemConstraint::ElemElemConstraint(const InputParameters & parameters) :
     _test(_var.phi()),
     _grad_test(_var.gradPhi()),
 
-    _phi_neighbor(_assembly.phiFaceNeighbor()),
-    _grad_phi_neighbor(_assembly.gradPhiFaceNeighbor()),
+    _phi_neighbor(_assembly.phiNeighbor()),
+    _grad_phi_neighbor(_assembly.gradPhiNeighbor()),
 
-    _test_neighbor(_var.phiFaceNeighbor()),
-    _grad_test_neighbor(_var.gradPhiFaceNeighbor()),
+    _test_neighbor(_var.phiNeighbor()),
+    _grad_test_neighbor(_var.gradPhiNeighbor()),
 
     _u_neighbor(_var.slnNeighbor()),
     _grad_u_neighbor(_var.gradSlnNeighbor())


### PR DESCRIPTION
This will add and fix some functions to allow users to reinit shape functions at physical points within neighbor element.  These functions are used in `ElemElemConstraint` and `NonlinearSystem`, see recent merged #6756 .

The existing tests under `\module\xfem\tests\single_var_constraint_2d` and `single_var_constraint_3d` are used to test the changed codes. 

closes #6607
