### PR TITLE
Test harness jobs

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -713,7 +713,7 @@ class TestHarness:
     parser.add_argument('--devel', action='store_const', dest='method', const='devel', help='test the app_name-devel binary')
     parser.add_argument('--oprof', action='store_const', dest='method', const='oprof', help='test the app_name-oprof binary')
     parser.add_argument('--pro', action='store_const', dest='method', const='pro', help='test the app_name-pro binary')
-    parser.add_argument('-j', '--jobs', nargs=1, metavar='int', action='store', type=int, dest='jobs', default=1, help='run test binaries in parallel')
+    parser.add_argument('-j', '--jobs', nargs='?', metavar='int', action='store', type=int, dest='jobs', const=1, help='run test binaries in parallel')
     parser.add_argument('-e', action='store_true', dest='extra_info', help='Display "extra" information including all caveats and deleted tests')
     parser.add_argument('-c', '--no-color', action='store_false', dest='colored', help='Do not show colored output')
     parser.add_argument('--heavy', action='store_true', dest='heavy_tests', help='Run tests marked with HEAVY : True')

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -80,6 +80,11 @@ class Tester(MooseObject):
   def prepare(self):
     return
 
+  def getThreads(self, options):
+    return 1
+
+  def getProcs(self, options):
+    return 1
 
   # This method should return the executable command that will be executed by the tester
   def getCommand(self, options):


### PR DESCRIPTION
Add new feature to RunParallel that makes the TestHarness respect slots.

If you run without _any_ job request. All jobs will still be run regardless of size but serially.

closes #6841 
