### PR TITLE
Restricting test that's failing under the new clang package

### DIFF
--- a/test/tests/multiapps/sub_cycling_failure/tests
+++ b/test/tests/multiapps/sub_cycling_failure/tests
@@ -17,5 +17,6 @@
     prereq = test_failure
     superlu = true
     allow_warnings = true
+    compiler = 'INTEL GCC' # 6855
   [../]
 []


### PR DESCRIPTION
refs #6855
