### PR TITLE
Allow PBS to function in our HPC environment

### DIFF
--- a/python/ClusterLauncher/PBSJob.py
+++ b/python/ClusterLauncher/PBSJob.py
@@ -19,6 +19,7 @@ class PBSJob(Job):
     params.addParam('copy_files', "A list of files specifically to copy")
 
     params.addStringSubParam('pbs_o_workdir', 'PBS_O_WORKDIR', "Move to this directory")
+    params.addStringSubParam('pbs_project', '#PBS -P PBS_PROJECT', "Identify as PBS_PROJECT in the PBS queuing system")
     params.addStringSubParam('pbs_stdout', '#PBS -o PBS_STDOUT', "Save stdout to this location")
     params.addStringSubParam('pbs_stderr', '#PBS -e PBS_STDERR', "Save stderr to this location")
 

--- a/python/ClusterLauncher/pbs_submit.sh
+++ b/python/ClusterLauncher/pbs_submit.sh
@@ -3,6 +3,7 @@
 #PBS -l select=<CHUNKS>:ncpus=<NCPUS_PER_CHUNK>:mpiprocs=<MPI_PROCS_PER_CHUNK>
 #PBS -l place=<PLACE>
 #PBS -l walltime=<WALLTIME>
+<PBS_PROJECT>
 <PBS_STDOUT>
 <PBS_STDERR>
 <NOTIFICATIONS>

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -738,6 +738,7 @@ class TestHarness:
     parser.add_argument('--max-fails', nargs=1, type=int, dest='max_fails', default=50, help='The number of tests allowed to fail before any additional tests will run')
     parser.add_argument('--pbs', nargs='?', metavar='batch_file', dest='pbs', const='generate', help='Enable launching tests via PBS. If no batch file is specified one will be created for you')
     parser.add_argument('--pbs-cleanup', nargs=1, metavar='batch_file', help='Clean up the directories/files created by PBS. You must supply the same batch_file used to launch PBS.')
+    parser.add_argument('--pbs-project', nargs='?', default='moose', help='Identify PBS job submission to specified project')
     parser.add_argument('--re', action='store', type=str, dest='reg_exp', help='Run tests that match --re=regular_expression')
 
     # Options that pass straight through to the executable

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -738,7 +738,7 @@ class TestHarness:
     parser.add_argument('--max-fails', nargs=1, type=int, dest='max_fails', default=50, help='The number of tests allowed to fail before any additional tests will run')
     parser.add_argument('--pbs', nargs='?', metavar='batch_file', dest='pbs', const='generate', help='Enable launching tests via PBS. If no batch file is specified one will be created for you')
     parser.add_argument('--pbs-cleanup', nargs=1, metavar='batch_file', help='Clean up the directories/files created by PBS. You must supply the same batch_file used to launch PBS.')
-    parser.add_argument('--pbs-project', nargs='?', default='moose', help='Identify PBS job submission to specified project')
+    parser.add_argument('--pbs-project', nargs=1, default='moose', help='Identify PBS job submission to specified project')
     parser.add_argument('--re', action='store', type=str, dest='reg_exp', help='Run tests that match --re=regular_expression')
 
     # Options that pass straight through to the executable

--- a/python/TestHarness/pbs_template.i
+++ b/python/TestHarness/pbs_template.i
@@ -8,6 +8,7 @@
     input_file = <INPUT>
     <PBS_STDOUT>
     <PBS_STDERR>
+    <PBS_PROJECT>
     walltime = <WALLTIME>
     no_copy = <NO_COPY>
     no_copy_pattern = 'pbs_\d+.cluster'

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -208,6 +208,10 @@ class RunApp(Tester):
     if options.PBSEmulator:
       self.specs['pbs_stdout'] = 'pbs_stdout = PBS_EMULATOR'
       self.specs['pbs_stderr'] = 'pbs_stderr = PBS_EMULATOR'
+    else:
+      self.specs.addStringSubParam('pbs_project', 'PBS_PROJECT', "Identify this job submission with this project")
+      self.specs['pbs_project'] = 'pbs_project = %s' % (options.pbs_project)
+
 
     # Do all of the replacements for the valid parameters
     for spec in self.specs.valid_keys():

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -209,6 +209,7 @@ class RunApp(Tester):
       self.specs['pbs_stdout'] = 'pbs_stdout = PBS_EMULATOR'
       self.specs['pbs_stderr'] = 'pbs_stderr = PBS_EMULATOR'
     else:
+      # The PBS Emulator fails when using the PROJECT argument (#PBS -P <project name>)
       self.specs.addStringSubParam('pbs_project', 'PBS_PROJECT', "Identify this job submission with this project")
       self.specs['pbs_project'] = 'pbs_project = %s' % (options.pbs_project)
 


### PR DESCRIPTION
Add ability to identify with a project when using PBS job submission. Defaults to the following when using --pbs options:

``` bash
#PBS -P moose
```

The project can be modified through arguments:

``` bash
--pbs-project <project name>
```

Refs #6851
