### PR TITLE
Uniquify the preprocessor constant names in XTermConstants.h.

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -89,15 +89,15 @@ extern bool _throw_on_error;
 /**
  * Macros for coloring any output stream (_console, std::ostringstream, etc.)
  */
-#define COLOR_BLACK   (Moose::_color_console ? BLACK : "")
-#define COLOR_RED     (Moose::_color_console ? RED : "")
-#define COLOR_GREEN   (Moose::_color_console ? GREEN : "")
-#define COLOR_YELLOW  (Moose::_color_console ? YELLOW : "")
-#define COLOR_BLUE    (Moose::_color_console ? BLUE : "")
-#define COLOR_MAGENTA (Moose::_color_console ? MAGENTA : "")
-#define COLOR_CYAN    (Moose::_color_console ? CYAN : "")
-#define COLOR_WHITE   (Moose::_color_console ? WHITE : "")
-#define COLOR_DEFAULT (Moose::_color_console ? DEFAULT : "")
+#define COLOR_BLACK   (Moose::_color_console ? XTERM_BLACK : "")
+#define COLOR_RED     (Moose::_color_console ? XTERM_RED : "")
+#define COLOR_GREEN   (Moose::_color_console ? XTERM_GREEN : "")
+#define COLOR_YELLOW  (Moose::_color_console ? XTERM_YELLOW : "")
+#define COLOR_BLUE    (Moose::_color_console ? XTERM_BLUE : "")
+#define COLOR_MAGENTA (Moose::_color_console ? XTERM_MAGENTA : "")
+#define COLOR_CYAN    (Moose::_color_console ? XTERM_CYAN : "")
+#define COLOR_WHITE   (Moose::_color_console ? XTERM_WHITE : "")
+#define COLOR_DEFAULT (Moose::_color_console ? XTERM_DEFAULT : "")
 
 /**
  * Import libMesh::out, and libMesh::err for use in MOOSE.

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -37,10 +37,10 @@
   {                                                                                 \
     std::ostringstream _error_oss_;                                                 \
     _error_oss_ << "\n\n"                                                           \
-                << (Moose::_color_console ? RED : "")                               \
+                << (Moose::_color_console ? XTERM_RED : "")                         \
                 << "\n\n*** ERROR ***\n"                                            \
                 << msg                                                              \
-                << (Moose::_color_console ? DEFAULT : "")                           \
+                << (Moose::_color_console ? XTERM_DEFAULT : "")                     \
                 << "\n\n";                                                          \
     if (Moose::_throw_on_error)                                                     \
       throw std::runtime_error(_error_oss_.str());                                  \
@@ -77,12 +77,12 @@
     if (!(asserted))                                                                \
     {                                                                               \
       Moose::err                                                                    \
-        << (Moose::_color_console ? RED : "")                                       \
+        << (Moose::_color_console ? XTERM_RED : "")                                 \
         << "\n\nAssertion `" #asserted "' failed\n"                                 \
         << msg                                                                      \
         << "\nat "                                                                  \
         << __FILE__ << ", line " << __LINE__                                        \
-        << (Moose::_color_console ? DEFAULT : "")                                   \
+        << (Moose::_color_console ? XTERM_DEFAULT : "")                             \
         << std::endl;                                                               \
      if (libMesh::global_n_processors() == 1)                                       \
        print_trace();                                                               \
@@ -105,11 +105,11 @@
       std::ostringstream _warn_oss_;                                                \
                                                                                     \
       _warn_oss_                                                                    \
-        << (Moose::_color_console ? YELLOW : "")                                    \
+        << (Moose::_color_console ? XTERM_YELLOW : "")                              \
       << "\n\n*** Warning ***\n"                                                    \
       << msg                                                                        \
       << "\nat " << __FILE__ << ", line " << __LINE__                               \
-      << (Moose::_color_console ? DEFAULT : "")                                     \
+      << (Moose::_color_console ? XTERM_DEFAULT : "")                               \
         << "\n\n";                                                                  \
       if (Moose::_throw_on_error)                                                   \
         throw std::runtime_error(_warn_oss_.str());                                 \
@@ -128,12 +128,12 @@
     else                                                                                                    \
       mooseDoOnce(                                                                                          \
         Moose::out                                                                                          \
-          << (Moose::_color_console ? YELLOW : "")                                                          \
+          << (Moose::_color_console ? XTERM_YELLOW : "")                                                    \
           << "*** Warning, This code is deprecated, and likely to be removed in future library versions!\n" \
           << msg << '\n'                                                                                    \
           << __FILE__ << ", line " << __LINE__ << ", compiled "                                             \
           << __LIBMESH_DATE__ << " at " << __LIBMESH_TIME__ << " ***"                                       \
-          << (Moose::_color_console ? DEFAULT : "")                                                         \
+          << (Moose::_color_console ? XTERM_DEFAULT : "")                                                   \
           << std::endl;                                                                                     \
         );                                                                                                  \
    } while (0)

--- a/framework/include/utils/XTermConstants.h
+++ b/framework/include/utils/XTermConstants.h
@@ -15,14 +15,14 @@
 #ifndef XTERMCONSTANTS_H
 #define XTERMCONSTANTS_H
 
-#define BLACK    "\33[30m"
-#define RED      "\33[31m"
-#define GREEN    "\33[32m"
-#define YELLOW   "\33[33m"
-#define BLUE     "\33[34m"
-#define MAGENTA  "\33[35m"
-#define CYAN     "\33[36m"
-#define WHITE    "\33[37m"
-#define DEFAULT  "\33[39m"
+#define XTERM_BLACK    "\33[30m"
+#define XTERM_RED      "\33[31m"
+#define XTERM_GREEN    "\33[32m"
+#define XTERM_YELLOW   "\33[33m"
+#define XTERM_BLUE     "\33[34m"
+#define XTERM_MAGENTA  "\33[35m"
+#define XTERM_CYAN     "\33[36m"
+#define XTERM_WHITE    "\33[37m"
+#define XTERM_DEFAULT  "\33[39m"
 
 #endif


### PR DESCRIPTION
We ran into an issue (libMesh/libmesh#910) with another codebase
(HDF5) #defining the constant "DEFAULT" without properly checking to
see if it was already #defined.  Making the constant names more
specific should help fix the issue.
