### PR TITLE
Level 3 PorousFlow Materials added.

### DIFF
--- a/modules/porous_flow/include/materials/PorousFlowJoiner.h
+++ b/modules/porous_flow/include/materials/PorousFlowJoiner.h
@@ -1,0 +1,111 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWJOINER_H
+#define POROUSFLOWJOINER_H
+
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+
+#include "PorousFlowDictator.h"
+
+//Forward Declarations
+class PorousFlowJoiner;
+
+template<>
+InputParameters validParams<PorousFlowJoiner>();
+
+/**
+ * Material designed to form a std::vector of property
+ * and derivatives of these wrt the nonlinear variables
+ * from the individual phase properties.
+ *
+ * Old values are included if include_old=true
+ * Values at the quadpoint or the nodes are formed depending on _at_qps
+ *
+ * Properties can be viscosities, densities, thermal conductivities , etc
+ * and the user specifies the property they are interested
+ * in using the pf_prop string.
+ *
+ * Also, using d(property)/dP, d(property)/dS, etc, and
+ * dP/dvar, dS/dvar, etc, the matrix of derivatives of property
+ * with respect to the nonlinear Variables,  var, are computed.
+ *
+ * Only values at the nodes are used - not at the quadpoints
+ */
+class PorousFlowJoiner : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowJoiner(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+
+  virtual void computeQpProperties();
+
+  /// The variable names UserObject for the Porous-Flow variables
+  const PorousFlowDictator & _dictator_UO;
+
+  /// Name of (dummy) pressure variable
+  const VariableName _pressure_variable_name;
+
+  /// Name of (dummy) saturation variable
+  const VariableName _saturation_variable_name;
+
+  /// Name of (dummy) temperature variable
+  const VariableName _temperature_variable_name;
+
+  /// Name of (dummy) mass fraction variable
+  const VariableName _mass_fraction_variable_name;
+
+  /// Number of phases
+  const unsigned int _num_phases;
+
+  /// Number of porous flow variables
+  const unsigned int _num_var;
+
+  /// Name of material property to be joined
+  const std::string _pf_prop;
+
+  /// Whether to include old variables
+  const bool _include_old;
+
+  /// If _at_qps=true then all quantities are computed at quadpoints, otherwise at the nodes
+  const bool _at_qps;
+
+  /// Derivatives of porepressure variable wrt PorousFlow variables at the qps or nodes
+  const MaterialProperty<std::vector<std::vector<Real> > > & _dporepressure_dvar;
+
+  /// Derivatives of saturation variable wrt PorousFlow variables at the qps or nodes
+  const MaterialProperty<std::vector<std::vector<Real> > > & _dsaturation_dvar;
+
+  /// Derivatives of temperature variable wrt PorousFlow variables at the qps or nodes
+  const MaterialProperty<std::vector<std::vector<Real> > > & _dtemperature_dvar;
+
+  /// computed property of the phase
+  MaterialProperty<std::vector<Real> > & _property;
+
+  /// old value of property of the phase
+  MaterialProperty<std::vector<Real> > * const _property_old;
+
+  /// d(property)/d(PorousFlow variable)
+  MaterialProperty<std::vector<std::vector<Real> > > & _dproperty_dvar;
+
+  /// property of each phase
+  std::vector<const MaterialProperty<Real> *> _phase_property;
+
+  /// d(property of each phase)/d(pressure)
+  std::vector<const MaterialProperty<Real> *> _dphase_property_dp;
+
+  /// d(property of each phase)/d(saturation)
+  std::vector<const MaterialProperty<Real> *> _dphase_property_ds;
+
+  /// d(property of each phase)/d(temperature)
+  std::vector<const MaterialProperty<Real> *> _dphase_property_dt;
+};
+
+#endif //POROUSFLOWJOINER_H

--- a/modules/porous_flow/src/base/PorousFlowApp.C
+++ b/modules/porous_flow/src/base/PorousFlowApp.C
@@ -41,13 +41,13 @@
 #include "PorousFlowViscosityConst.h"
 #include "PorousFlowVolumetricStrain.h"
 #include "PorousFlowWater.h"
+#include "PorousFlowJoiner.h"
 
 // Kernels
 #include "PorousFlowAdvectiveFlux.h"
 #include "PorousFlowMassTimeDerivative.h"
 #include "PorousFlowEffectiveStressCoupling.h"
 #include "PorousFlowMassVolumetricExpansion.h"
-
 
 template<>
 InputParameters validParams<PorousFlowApp>()
@@ -127,6 +127,7 @@ PorousFlowApp::registerObjects(Factory & factory)
   registerMaterial(PorousFlowViscosityConst);
   registerMaterial(PorousFlowVolumetricStrain);
   registerMaterial(PorousFlowWater);
+  registerMaterial(PorousFlowJoiner);
 
   // Kernels
   registerKernel(PorousFlowAdvectiveFlux);

--- a/modules/porous_flow/src/materials/PorousFlowJoiner.C
+++ b/modules/porous_flow/src/materials/PorousFlowJoiner.C
@@ -1,0 +1,91 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowJoiner.h"
+
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowJoiner>()
+{
+  InputParameters params = validParams<Material>();
+
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<std::string>("material_property", "The property that you want joined into a std::vector");
+  params.addParam<bool>("at_qps", false, "If true then join quadpoint properties, otherwise join nodal properties");
+  params.addParam<bool>("include_old", false, "Join old properties into vectors as well as the current properties");
+  params.addClassDescription("This Material forms a std::vector of properties, old properties (optionally), and derivatives, out of the individual phase properties");
+  return params;
+}
+
+PorousFlowJoiner::PorousFlowJoiner(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+
+    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _pressure_variable_name(_dictator_UO.pressureVariableNameDummy()),
+    _saturation_variable_name(_dictator_UO.saturationVariableNameDummy()),
+    _temperature_variable_name(_dictator_UO.temperatureVariableNameDummy()),
+    _mass_fraction_variable_name(_dictator_UO.massFractionVariableNameDummy()),
+    _num_phases(_dictator_UO.numPhases()),
+    _num_var(_dictator_UO.numVariables()),
+    _pf_prop(getParam<std::string>("material_property")),
+    _include_old(getParam<bool>("include_old")),
+    _at_qps(getParam<bool>("position")),
+
+    _dporepressure_dvar(_at_qps ? getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_porepressure_qp_dvar") : getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_porepressure_nodal_dvar")),
+    _dsaturation_dvar(_at_qps ? getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_saturation_qp_dvar") : getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_saturation_nodal_dvar")),
+    _dtemperature_dvar(_at_qps ? getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_temperature_qp_dvar") : getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_temperature_nodal_dvar")),
+
+    _property(declareProperty<std::vector<Real> >(_pf_prop)),
+    _property_old(_include_old ? &declarePropertyOld<std::vector<Real> >(_pf_prop) : NULL),
+    _dproperty_dvar(declareProperty<std::vector<std::vector<Real> > >("d" + _pf_prop + "_dvar"))
+{
+  _phase_property.resize(_num_phases);
+  for (unsigned int ph = 0; ph < _num_phases; ++ph)
+    _phase_property[ph] = &getMaterialProperty<Real>(_pf_prop + Moose::stringify(ph));
+
+    _dphase_property_dp.resize(_num_phases);
+    _dphase_property_ds.resize(_num_phases);
+    _dphase_property_dt.resize(_num_phases);
+
+  for (unsigned int ph = 0; ph < _num_phases; ++ph)
+  {
+    _dphase_property_dp[ph] = &getMaterialPropertyDerivative<Real>(_pf_prop + Moose::stringify(ph), _pressure_variable_name);
+    _dphase_property_ds[ph] = &getMaterialPropertyDerivative<Real>(_pf_prop + Moose::stringify(ph), _saturation_variable_name);
+    _dphase_property_dt[ph] = &getMaterialPropertyDerivative<Real>(_pf_prop + Moose::stringify(ph), _temperature_variable_name);
+  }
+}
+
+void
+PorousFlowJoiner::initQpStatefulProperties()
+{
+  _property[_qp].resize(_num_phases);
+  for (unsigned int ph = 0; ph < _num_phases; ++ph)
+    _property[_qp][ph] = (*_phase_property[ph])[_qp];
+
+  _dproperty_dvar[_qp].resize(_num_phases);
+  for (unsigned int ph = 0; ph < _num_phases; ++ph)
+    _dproperty_dvar[_qp][ph].resize(_num_var);
+}
+
+void
+PorousFlowJoiner::computeQpProperties()
+{
+  if (!_include_old)
+    initQpStatefulProperties();
+
+  for (unsigned int ph = 0; ph < _num_phases; ++ph)
+  {
+    _property[_qp][ph] = (*_phase_property[ph])[_qp];
+    for (unsigned v = 0; v < _num_var; ++v)
+    {
+      _dproperty_dvar[_qp][ph][v] = (*_dphase_property_dp[ph])[_qp] * _dporepressure_dvar[_qp][ph][v];
+      _dproperty_dvar[_qp][ph][v] += (*_dphase_property_ds[ph])[_qp] * _dsaturation_dvar[_qp][ph][v];
+      _dproperty_dvar[_qp][ph][v] += (*_dphase_property_dt[ph])[_qp] * _dtemperature_dvar[_qp][ph][v];
+    }
+  }
+}


### PR DESCRIPTION
Refs #6845.

@dschwen  (or someone) - i need some help here.  These two Materials are
very similar and could be combined if i could make the declareMaterial
for the "old" versions of the properties optional somehow.  Can
you think of a way of doing this?

The Material architecture in the Porous Flow module is as follows.

(1) Level 1 Materials.  A user typically chooses one of these for their
particular simulation type, depending upon the overall type
of simulation.  For instance, there are Materials suitable for:
 (a) 1-phase saturated+unsaturated flow with porepressure as the primary nonlinear variable
 (b) 1-phase saturated+unsaturated flow with log(mass density) as the primary nonlinear variable
 (c) 2-phase flow with the two porepressures being the primary nonlinear variables
 (d) 2-phase flow with (porepressure0, saturation1) being the primary nonlinear variables
The purpose of these Level 1 Materials is to calculate, for each phase,
the porepressure, the saturation, gradients of these, and derivatives of
these wrt to the primary variables.  Also temperature, gradients of
temperature and derivatives of these wrt the primary variables.  Also
the mass fraction matrix, gradients and derivatives.  All these things
are calculated at the quadpoints and potentially the nodes depending on
whether we'll need nodal quantities in the mass-lumping and full-upwinding
in the Kernels.

(2) Level 2 Materials.  A user typically chooses many of these.
They are designed to get information from the Level 1 Materials and
calculate equation-of-state related things, such as fluid-phase density,
viscosity, relative permeability, and also solid-phase porosity.
They are coded so as to be independent of the Level 1 description, eg
a user can use the water density Material in both the 1-phase and
the 2-phase situation.  Typically these Level 2 Materials compute derivatives
of density, viscosity, etc, with respect to porepressures, saturations,
etc, independently of what the actual primary nonlinear variables are.

(3) Level 3 Materials.  These join the Level 2 Materials into std::vectors
for use in Kernels, and also join the derivative information of Level 2 Materials
into std::vectors that contain derivatives wrt the primary nonlinear variables
