### PR TITLE
Add warning message for missing C++11 features.

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -650,6 +650,11 @@ private:
   friend class FEProblem;
   friend class Restartable;
   friend class SubProblem;
+
+  /// Helper functions used for C++11 compatibility stuff.  These will
+  /// eventually go away...
+  void printYesNo(std::stringstream & oss, const std::string & feature, bool defined);
+  bool setBool(const std::string & value);
 };
 
 template <typename T>


### PR DESCRIPTION
This removes the previous --check-cxx11 command line option.  The user
can opt out of seeing this message entiresly by setting `MOOSE_CXX11_IGNORE`
in their environment.

Refs #6581.

Below is a (fake, Clang 3.7.0 does support auto) screenshot of the latest version of the warning message.

![new_screenshot](https://cloud.githubusercontent.com/assets/1775907/15029001/d19dd70c-1208-11e6-9472-55f29f0f9cda.png)
