### PR TITLE
Level 2 Materials.

### DIFF
--- a/modules/porous_flow/include/materials/PorousFlowBrine.h
+++ b/modules/porous_flow/include/materials/PorousFlowBrine.h
@@ -1,0 +1,148 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWBRINE_H
+#define POROUSFLOWBRINE_H
+
+#include "PorousFlowFluidPropertiesBase.h"
+#include "PorousFlowWater.h"
+
+class PorousFlowBrine;
+
+template<>
+InputParameters validParams<PorousFlowBrine>();
+
+/**
+ * Fluid properties of Brine.
+ * Provides density, viscosity, derivatives wrt pressure and temperature
+ */
+class PorousFlowBrine : public PorousFlowWater
+{
+public:
+  PorousFlowBrine(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+
+  virtual void computeQpProperties();
+
+  /**
+   * Density of brine.
+   * From Driesner, The system H2o-NaCl. Part II: Correlations for molar volume,
+   * enthalpy, and isobaric heat capacity from 0 to 1000 C, 1 to 500 bar, and 0
+   * to 1 Xnacl, Geochimica et Cosmochimica Acta 71, 4902-4919 (2007).
+   *
+   * @param pressure brine pressure (Pa)
+   * @param temperature brine temperature (C)
+   * @param xnacl salt mass fraction (-)
+   * @return water density (kg/m^3)
+   */
+  Real density(Real pressure, Real temperature, Real xnacl) const;
+
+  /**
+   * Derivative of brine density with respect to presure.
+   *
+   * @param pressure brine pressure (Pa)
+   * @param temperature brine temperature (C)
+   * @param xnacl salt mass fraction (-)
+   * @return derivative of brine density wrt pressure (kg/m^3/Pa)
+   */
+  Real dDensity_dP(Real pressure, Real temperature, Real xnacl) const;
+
+  /**
+   * Derivative of brine density with respect to temperature
+   *
+   * @param pressure brine pressure (Pa)
+   * @param temperature brine temperature (C)
+   * @param xnacl salt mass fraction (-)
+   * @return derivative of brine density wrt temperature (kg/m^3/C)
+   */
+  Real dDensity_dT(Real pressure, Real temperature, Real xnacl) const;
+
+  /**
+   * Viscosity of brine.
+   * From Phillips et al, A technical databook for geothermal energy utilization,
+   * LbL-12810 (1981).
+   *
+   * @param temperature brine temperature (C)
+   * @param water_density water density (kg/m^3)
+   * @param xnacl salt mass fraction (-)
+   * @return viscosity (Pa.s)
+   */
+  Real viscosity(Real temperature, Real water_density, Real xnacl) const;
+
+  /**
+   * Derivative of viscosity with respect to density. Derived from
+   * Eq. (10) from Release on the IAPWS Formulation 2008 for the
+   * Viscosity of Ordinary Brine Substance.
+   *
+   * @param temperature water temperature (C)
+   * @param water_density water density (kg/m^3)
+   * @param xnacl salt mass fraction (-)
+   * @return derivative of water viscosity wrt density
+   */
+  Real dViscosity_dT(Real temperature, Real water_density, Real xnacl) const;
+
+  /**
+   * Brine vapour pressure
+   * From Haas, Physical properties of the coexisting phases and thermochemical
+   * properties of the H20 component in boiling NaCl solutions, Geological Survey
+   * Bulletin, 1421-A (1976).
+   *
+   * @param temperature brine temperature (C)
+   * @param xnacl salt mass fraction (-)
+   * @return brine vapour pressure (Pa)
+   */
+  Real pSat(Real temperature, Real xnacl) const;
+
+  /**
+   * Derivative of brine viscosity with respect to density
+   *
+   * @param temperature brine temperature (C)
+   * @param water_density water density (kg/m^3)
+   * @param xnacl salt mass fraction (-)
+   * @return derivative of brine viscosity wrt density
+   */
+  Real dViscosity_dDensity(Real temperature, Real water_density, Real xnacl) const;
+
+  /**
+   * Density of halite (solid NaCl)
+   * From Driesner, The system H2o-NaCl. Part II: Correlations for molar volume,
+   * enthalpy, and isobaric heat capacity from 0 to 1000 C, 1 to 500 bar, and 0
+   * to 1 Xnacl, Geochimica et Cosmochimica Acta 71, 4902-4919 (2007).
+   *
+   * @param pressure pressure (Pa)
+   * @param temperature halite temperature (C)
+   * @return density (kg/m^3)
+   */
+  Real haliteDensity(Real pressure, Real temperature) const;
+
+  /**
+   * Halite solubility
+   * Originally from Potter et al., A new method for determining the solubility
+   * of salts in aqueous solutions at elevated temperatures, J. Res. U.S. Geol.
+   * Surv., 5, 389-395 (1977). Equation describing halite solubility is repeated
+   * in Chou, Phase relations in the system NaCI-KCI-H20. III: Solubilities of
+   * halite in vapor-saturated liquids above 445°C and redetermination of phase
+   * equilibrium properties in the system NaCI-HzO to 1000°C and 1500 bars,
+   * Geochimica et Cosmochimica Acta 51, 1965-1975 (1987).
+   *
+   * @param temperature temperature (C)
+   * @return halite solubility (kg/kg)
+   *
+   * This correlation is valid for 0 <= T << 424.5 C
+   */
+  Real haliteSolubility(Real temperature) const;
+
+  /// Molar mass of NaCl
+  const Real _Mnacl;
+
+  /// Mass fraction of NaCl
+  const Real _xnacl;
+};
+
+#endif //POROUSFLOWBRINE_H

--- a/modules/porous_flow/include/materials/PorousFlowCapillaryPressureBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowCapillaryPressureBase.h
@@ -1,0 +1,65 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWCAPILLARYPRESSUREBASE_H
+#define POROUSFLOWCAPILLARYPRESSUREBASE_H
+
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+#include "PorousFlowDictator.h"
+
+class PorousFlowCapillaryPressureBase;
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureBase>();
+
+/**
+ * Base class for capillary pressure
+ */
+class PorousFlowCapillaryPressureBase : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowCapillaryPressureBase(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// Phase number of fluid that this relative permeability relates to
+  const unsigned int _phase_num;
+
+  /// The PorousFlowDictator UserObject
+  const PorousFlowDictator & _dictator_UO;
+
+  /// Name of (dummy) saturation primary variable
+  VariableName _saturation_variable_name;
+
+  /// Saturation material property at the nodes
+  const MaterialProperty<std::vector<Real> > & _saturation_nodal;
+
+  /// Saturation material property at the qps
+  const MaterialProperty<std::vector<Real> > & _saturation_qp;
+
+  /// Capillary pressure material property at the nodes
+  MaterialProperty<Real> & _capillary_pressure_nodal;
+
+  /// Derivative of capillary pressure at the nodes wrt phase saturation
+  MaterialProperty<Real> & _dcapillary_pressure_nodal_ds;
+
+  /// Second derivative of capillary pressure at the nodes wrt phase saturation
+  MaterialProperty<Real> & _d2capillary_pressure_nodal_ds2;
+
+  /// Capillary pressure material property at the qps
+  MaterialProperty<Real> & _capillary_pressure_qp;
+
+  /// Derivative of capillary pressure at the qps wrt phase saturation
+  MaterialProperty<Real> & _dcapillary_pressure_qp_ds;
+
+  /// Second derivative of capillary pressure at the qps wrt phase saturation
+  MaterialProperty<Real> & _d2capillary_pressure_qp_ds2;
+};
+
+#endif //POROUSFLOWCAPILLARYPRESSUREBASE_H

--- a/modules/porous_flow/include/materials/PorousFlowCapillaryPressureConstant.h
+++ b/modules/porous_flow/include/materials/PorousFlowCapillaryPressureConstant.h
@@ -1,0 +1,33 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWCAPILLARYPRESSURECONSTANT_H
+#define POROUSFLOWCAPILLARYPRESSURECONSTANT_H
+
+#include "PorousFlowCapillaryPressureBase.h"
+
+class PorousFlowCapillaryPressureConstant;
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureConstant>();
+
+/**
+ * Returns a constant capillary pressure as specified in the input file
+ */
+class PorousFlowCapillaryPressureConstant : public PorousFlowCapillaryPressureBase
+{
+public:
+  PorousFlowCapillaryPressureConstant(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// The capillary pressure (Pa)
+  const Real _pc;
+};
+
+#endif //POROUSFLOWCAPILLARYPRESSURECONSTANT_H

--- a/modules/porous_flow/include/materials/PorousFlowCapillaryPressureLinear.h
+++ b/modules/porous_flow/include/materials/PorousFlowCapillaryPressureLinear.h
@@ -1,0 +1,34 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWCAPILLARYPRESSURELINEAR_H
+#define POROUSFLOWCAPILLARYPRESSURELINEAR_H
+
+#include "PorousFlowCapillaryPressureBase.h"
+
+//Forward Declarations
+class PorousFlowCapillaryPressureLinear;
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureLinear>();
+
+/**
+ * Linear capillary pressure (equal to the phase saturation)
+ */
+class PorousFlowCapillaryPressureLinear : public PorousFlowCapillaryPressureBase
+{
+public:
+  PorousFlowCapillaryPressureLinear(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// The maximum value of the capillary pressure
+  const Real _pc_max;
+};
+
+#endif //POROUSFLOWCAPILLARYPRESSURELINEAR_H

--- a/modules/porous_flow/include/materials/PorousFlowCapillaryPressureVGP.h
+++ b/modules/porous_flow/include/materials/PorousFlowCapillaryPressureVGP.h
@@ -1,0 +1,66 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWCAPILLARYPRESSUREVGP_H
+#define POROUSFLOWCAPILLARYPRESSUREVGP_H
+
+#include "PorousFlowCapillaryPressureBase.h"
+
+//Forward Declarations
+class PorousFlowCapillaryPressureVGP;
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureVGP>();
+
+/**
+ * van Genuchten capillary pressure for multiphase flow in porous media.
+ * Note: this formulation is in terms of pore pressure, not saturation
+ *
+ * Based on van Genuchten, M. Th., A closed for equation for
+ * predicting the hydraulic conductivity of unsaturated soils,
+ * Soil Sci. Soc., 44, 892-898 (1980).
+ */
+class PorousFlowCapillaryPressureVGP : public PorousFlowCapillaryPressureBase
+{
+public:
+  PorousFlowCapillaryPressureVGP(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// Effective phase saturation as a function of phase pore pressure
+  Real effectiveSaturation(Real pressure) const;
+
+  /// Derivative of effective saturation wrt phase pore pressure
+  Real dEffectiveSaturation(Real pressure) const;
+
+  /// Second derivative of effective saturation wrt phase pore pressure
+  Real d2EffectiveSaturation(Real pressure) const;
+
+  /// Name of (dummy) pressure primary variable
+  VariableName _pressure_variable_name;
+
+  /// Pressure material property at the nodes
+  const MaterialProperty<std::vector<Real> > & _porepressure_nodal;
+
+  /// Pressure material property at the qps
+  const MaterialProperty<std::vector<Real> > & _porepressure_qp;
+
+  /// Derivative of capillary pressure at the nodes wrt phase pore pressure
+  MaterialProperty<Real> & _dcapillary_pressure_nodal_dp;
+
+  /// Second derivative of capillary pressure at the nodes wrt pore pressure
+  MaterialProperty<Real> & _d2capillary_pressure_nodal_dp2;
+
+  /// van Genuchten alpha parameter
+  const Real _al;
+
+  /// van Genuchten exponent m
+  const Real _m;
+};
+
+#endif //POROUSFLOWCAPILLARYPRESSUREVGP_H

--- a/modules/porous_flow/include/materials/PorousFlowCapillaryPressureVGS.h
+++ b/modules/porous_flow/include/materials/PorousFlowCapillaryPressureVGS.h
@@ -1,0 +1,62 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWCAPILLARYPRESSUREVGS_H
+#define POROUSFLOWCAPILLARYPRESSUREVGS_H
+
+#include "PorousFlowCapillaryPressureBase.h"
+
+//Forward Declarations
+class PorousFlowCapillaryPressureVGS;
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureVGS>();
+
+/**
+ * van Genuchten capillary pressure for multiphase flow in porous media.
+ *
+ * Based on van Genuchten, M. Th., A closed for equation for
+ * predicting the hydraulic conductivity of unsaturated soils,
+ * Soil Sci. Soc., 44, 892-898 (1980).
+ */
+class PorousFlowCapillaryPressureVGS : public PorousFlowCapillaryPressureBase
+{
+public:
+  PorousFlowCapillaryPressureVGS(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// Capillary pressure as a function of phase saturation
+  Real capillaryPressure(Real saturation) const;
+
+  /// Derivative of capillary pressure wrt phase saturation
+  Real dCapillaryPressure(Real saturation) const;
+
+  /// Second derivative of capillary pressure wrt phase saturation
+  Real d2CapillaryPressure(Real saturation) const;
+
+  /// Effective saturation
+  Real effectiveSaturation(Real saturation) const;
+
+  /// Liquid residual saturation
+  const Real _sat_lr;
+
+  /// Liquid phase fully saturated saturation
+  const Real _sat_ls;
+
+  /// van Genuchten exponent m
+  const Real _m;
+
+  /// Maximum capillary pressure
+  const Real _pc_max;
+
+  /// van Genuchten capillary pressure coefficient
+  const Real _p0;
+};
+
+#endif //POROUSFLOWCAPILLARYPRESSUREVGS_H

--- a/modules/porous_flow/include/materials/PorousFlowDensityConstBulk.h
+++ b/modules/porous_flow/include/materials/PorousFlowDensityConstBulk.h
@@ -1,0 +1,71 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWDENSITYCONSTBULK_H
+#define POROUSFLOWDENSITYCONSTBULK_H
+
+#include "PorousFlowFluidPropertiesBase.h"
+
+class PorousFlowDensityConstBulk;
+
+template<>
+InputParameters validParams<PorousFlowDensityConstBulk>();
+
+/**
+ * Material designed to calculate fluid density
+ * from porepressure, assuming constant bulk modulus
+ * for the fluid.
+ */
+class PorousFlowDensityConstBulk : public PorousFlowFluidPropertiesBase
+{
+public:
+  PorousFlowDensityConstBulk(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+  virtual void computeQpProperties();
+
+  /**
+   * Density calucaled assuming a constant bulk modulus
+   *
+   * @param pressure gas pressure (Pa)
+   * @return density (kg/m^3)
+   */
+  Real density(Real pressure) const;
+
+  /**
+   * Derivative of the density of a constant bulk density a function of
+   * pressure.
+   *
+   * @param pressure gas pressure (Pa)
+   * @return derivative of density (kg/m^3) with respect to pressure
+   */
+  Real dDensity_dP(Real pressure) const;
+
+  /// density at zero porepressure
+  const Real _dens0;
+
+  /// constant bulk modulus
+  const Real _bulk;
+
+  /// Fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal;
+
+  /// Old fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal_old;
+
+  /// Derivative of fluid density wrt phase pore pressure at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dp;
+
+  /// Fluid phase density at the qps
+  MaterialProperty<Real> & _density_qp;
+
+  /// Derivative of fluid density wrt phase pore pressure at the qps
+  MaterialProperty<Real> & _ddensity_qp_dp;
+};
+
+#endif //POROUSFLOWDENSITYCONSTBULK_H

--- a/modules/porous_flow/include/materials/PorousFlowEffectiveFluidPressure.h
+++ b/modules/porous_flow/include/materials/PorousFlowEffectiveFluidPressure.h
@@ -1,0 +1,82 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWEFFECTIVEFLUIDPRESSURE_H
+#define POROUSFLOWEFFECTIVEFLUIDPRESSURE_H
+
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+
+#include "PorousFlowDictator.h"
+
+//Forward Declarations
+class PorousFlowEffectiveFluidPressure;
+
+template<>
+InputParameters validParams<PorousFlowEffectiveFluidPressure>();
+
+/**
+ * Material designed to calculate the effective fluid pressure
+ * that can be used in the mechanical effective-stress calculations
+ * and other similar places.  This class computes
+ * effective fluid pressure = sum_{phases}Saturation_{phase}*Porepressure_{phase}
+ */
+class PorousFlowEffectiveFluidPressure : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowEffectiveFluidPressure(const InputParameters & parameters);
+
+protected:
+  /// The dictator UserObject for the Porous-Flow variables
+  const PorousFlowDictator & _dictator_UO;
+
+  /// number of phases in this simulation
+  const unsigned int _num_ph;
+
+  /// number of porous-flow variables in this simulation
+  const unsigned int _num_var;
+
+  /// quadpoint porepressure of each phase
+  const MaterialProperty<std::vector<Real> > & _porepressure_qp;
+
+  /// d(quadpoint porepressure)/d(PorousFlow variable)
+  const MaterialProperty<std::vector<std::vector<Real> > > & _dporepressure_qp_dvar;
+
+  /// quadpoint saturation of each phase
+  const MaterialProperty<std::vector<Real> > & _saturation_qp;
+
+  /// d(quadpoint saturation)/d(PorousFlow variable)
+  const MaterialProperty<std::vector<std::vector<Real> > > & _dsaturation_qp_dvar;
+
+  /// nodal porepressure of each phase
+  const MaterialProperty<std::vector<Real> > & _porepressure_nodal;
+
+  /// d(nodal porepressure)/d(PorousFlow variable)
+  const MaterialProperty<std::vector<std::vector<Real> > > & _dporepressure_nodal_dvar;
+
+  /// nodal saturation of each phase
+  const MaterialProperty<std::vector<Real> > & _saturation_nodal;
+
+  /// d(nodal saturation)/d(PorousFlow variable)
+  const MaterialProperty<std::vector<std::vector<Real> > > & _dsaturation_nodal_dvar;
+
+  /// computed effective fluid pressure (at quadpoints)
+  MaterialProperty<Real> & _pf_qp;
+
+  /// d(_pf_qp)/d(PorousFlow variable)
+  MaterialProperty<std::vector<Real> > & _dpf_qp_dvar;
+
+  /// computed effective fluid pressure (at nodes)
+  MaterialProperty<Real> & _pf_nodal;
+
+  /// d(_pf_nodal)/d(PorousFlow variable)
+  MaterialProperty<std::vector<Real> > & _dpf_nodal_dvar;
+
+  virtual void computeQpProperties();
+};
+
+#endif //POROUSFLOWEFFECTIVEFLUIDPRESSURE_H

--- a/modules/porous_flow/include/materials/PorousFlowFluidPropertiesBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowFluidPropertiesBase.h
@@ -1,0 +1,63 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWFLUIDPROPERTIESBASE_H
+#define POROUSFLOWFLUIDPROPERTIESBASE_H
+
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+#include "PorousFlowDictator.h"
+
+class PorousFlowFluidPropertiesBase;
+
+template<>
+InputParameters validParams<PorousFlowFluidPropertiesBase>();
+
+/**
+ * Base class for fluid properties
+ */
+class PorousFlowFluidPropertiesBase : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowFluidPropertiesBase(const InputParameters & parameters);
+
+protected:
+  /// Somehow should be able to make this pure virtual?
+  virtual void computeQpProperties();
+
+  /// Phase number of fluid that this relative permeability relates to
+  const unsigned int _phase_num;
+
+  /// Pore pressure at the nodes
+  const MaterialProperty<std::vector<Real> > & _porepressure_nodal;
+
+  /// Pore pressure at the qps
+  const MaterialProperty<std::vector<Real> > & _porepressure_qp;
+
+  /// Fluid temperature at the nodes
+  const MaterialProperty<std::vector<Real> > & _temperature_nodal;
+
+  /// Fluid temperature at the qps
+  const MaterialProperty<std::vector<Real> > & _temperature_qp;
+
+  /// The PorousFlowDictator UserObject
+  const PorousFlowDictator & _dictator_UO;
+
+  /// Name of (dummy) pressure primary variable
+  const VariableName _pressure_variable_name;
+
+  /// Name of (dummy) temperature primary variable
+  const VariableName _temperature_variable_name;
+
+  /// Conversion from degrees Celsius to degrees Kelvin
+  const Real _t_c2k;
+
+  /// Universal gas constant
+  const Real _R;
+};
+
+#endif //POROUSFLOWFLUIDPROPERTIESBASE_H

--- a/modules/porous_flow/include/materials/PorousFlowIdealGas.h
+++ b/modules/porous_flow/include/materials/PorousFlowIdealGas.h
@@ -1,0 +1,87 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWIDEALGAS_H
+#define POROUSFLOWIDEALGAS_H
+
+#include "PorousFlowFluidPropertiesBase.h"
+
+class PorousFlowIdealGas;
+
+template<>
+InputParameters validParams<PorousFlowIdealGas>();
+
+/**
+ * This material computes fluid properties for an ideal gas
+ */
+class PorousFlowIdealGas : public PorousFlowFluidPropertiesBase
+{
+public:
+  PorousFlowIdealGas(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+
+  virtual void computeQpProperties();
+
+  /**
+   * Ideal gas density as a function of pressure, temperature and molar mass.
+   *
+   * @param pressure gas pressure (Pa)
+   * @param temperature gas temperature (C)
+   * @param molar mass gas molar mass (kg/mol)
+   * @return density (kg/m^3)
+   */
+  Real density(Real pressure, Real temperature, Real molar_mass) const;
+
+  /**
+   * Derivative of the density of an ideal gas as a function of
+   * pressure.
+   *
+   * @param temperature gas temperature (C)
+   * @param molar mass gas molar mass (kg/mol)
+   * @return derivative of ideal gas density (kg/m^3) with respect to pressure
+   */
+  Real dDensity_dP(Real temperature, Real molar_mass) const;
+
+  /**
+   * Derivative of the density of an ideal gas as a function of
+   * temperature.
+   *
+   * @param pressure gas pressure (Pa)
+   * @param temperature gas temperature (C)
+   * @param molar mass gas molar mass (kg/mol)
+   * @return derivative of ideal gas density (kg/m^3) with respect to pressure
+   */
+  Real dDensity_dT(Real pressure, Real temperature, Real molar_mass) const;
+
+  /// Molar mass (kg/mol)
+  const Real _molar_mass;
+
+  /// Fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal;
+
+  /// Old fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal_old;
+
+  /// Derivative of fluid density wrt phase pore pressure at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dp;
+
+  /// Derivative of fluid density wrt temperature at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dt;
+
+  /// Fluid phase density at the qps
+  MaterialProperty<Real> & _density_qp;
+
+  /// Derivative of fluid density wrt phase pore pressure at the qps
+  MaterialProperty<Real> & _ddensity_qp_dp;
+
+  /// Derivative of fluid density wrt temperature at the qps
+  MaterialProperty<Real> & _ddensity_qp_dt;
+};
+
+#endif // POROUSFLOWIDEALGAS_H

--- a/modules/porous_flow/include/materials/PorousFlowMethane.h
+++ b/modules/porous_flow/include/materials/PorousFlowMethane.h
@@ -1,0 +1,120 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWMETHANE_H
+#define POROUSFLOWMETHANE_H
+
+#include "PorousFlowFluidPropertiesBase.h"
+
+class PorousFlowMethane;
+
+template<>
+InputParameters validParams<PorousFlowMethane>();
+
+/**
+ * Fluid properties of Methane (CH4).
+ * Provides density, viscosity, derivatives wrt pressure and temperature,
+ * and Henry Law constants.
+ */
+class PorousFlowMethane : public PorousFlowFluidPropertiesBase
+{
+public:
+  PorousFlowMethane(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+  virtual void computeQpProperties();
+
+  /**
+   * Methane gas density as a function of pressure and temperature
+   * (assuming an ideal gas).
+   *
+   * @param pressure gas pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return density (kg/m^3)
+   */
+  Real density(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of gaseous CH4 as a function of
+   * pressure.
+   *
+   * @param temperature gas temperature (C)
+   * @return derivative of CH4 density (kg/m^3) with respect to pressure
+   */
+  Real dDensity_dP(Real temperature) const;
+
+  /**
+   * Derivative of the density of gaseous CH4 as a function of
+   * temperature.
+   *
+   * @param pressure gas pressure (Pa)
+   * @param temperature gas temperature (C)
+   * @return derivative of CH4 density (kg/m^3) with respect to temperature
+   */
+  Real dDensity_dT(Real pressure, Real temperature) const;
+
+  /**
+   * Methane gas viscosity as a function of temperature.
+   * From Irvine Jr, T. F. and Liley, P. E. (1984) Steam and Gas Tables with
+   * Computer Equations.
+   *
+   * @param temperature fluid temperature (C)
+   * @return viscosity (Pa.s)
+   */
+  Real viscosity(Real temperature) const;
+
+  /**
+   * Derivative of the viscosity of gaseous CH4 as a function of temperature
+   *
+   * @param temperature gas temperature (C)
+   * @return derivative of CH4 viscosity wrt temperature
+   */
+  Real dViscosity_dT(Real temperature) const;
+
+  /**
+   * Henry's law constant coefficients for dissolution of CH4 into water.
+   * From Guidelines on the Henry's constant and vapour
+   * liquid distribution constant for gases in H20 and D20 at high
+   * temperatures, IAPWS (2004).
+   *
+   * @return constants for Henry's constant (-)
+   */
+  std::vector<Real> henryConstants() const;
+
+  /// Fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal;
+
+  /// Old fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal_old;
+
+  /// Derivative of fluid density wrt phase pore pressure at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dp;
+
+  /// Derivative of fluid density wrt temperature at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dt;
+
+  /// Fluid phase density at the qps
+  MaterialProperty<Real> & _density_qp;
+
+  /// Derivative of fluid density wrt phase pore pressure at the qps
+  MaterialProperty<Real> & _ddensity_qp_dp;
+
+  /// Derivative of fluid density wrt temperature at the qps
+  MaterialProperty<Real> & _ddensity_qp_dt;
+
+  /// Fluid phase viscosity at the nodes
+  MaterialProperty<Real> & _viscosity_nodal;
+
+  /// Derivative of fluid phase viscosity wrt temperature at the nodes
+  MaterialProperty<Real> & _dviscosity_nodal_dt;
+
+  /// Methane molar mass (kg/mol)
+  const Real _Mch4;
+};
+
+#endif //POROUSFLOWMETHANE_H

--- a/modules/porous_flow/include/materials/PorousFlowPermeabilityConst.h
+++ b/modules/porous_flow/include/materials/PorousFlowPermeabilityConst.h
@@ -1,0 +1,48 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWPERMEABILITYCONST_H
+#define POROUSFLOWPERMEABILITYCONST_H
+
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+
+#include "PorousFlowDictator.h"
+
+//Forward Declarations
+class PorousFlowPermeabilityConst;
+
+template<>
+InputParameters validParams<PorousFlowPermeabilityConst>();
+
+/**
+ * Material designed to provide the permeability tensor
+ * which is assumed constant
+ */
+class PorousFlowPermeabilityConst : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowPermeabilityConst(const InputParameters & parameters);
+
+protected:
+  /// constant value of permeability tensor
+  const RealTensorValue _input_permeability;
+
+  /// The variable names UserObject for the Porous-Flow variables
+  const PorousFlowDictator & _PorousFlow_name_UO;
+
+  /// permeability
+  MaterialProperty<RealTensorValue> & _permeability;
+
+  /// d(permeability)/d(PorousFlow variable) which are all zero in this case
+  MaterialProperty<std::vector<RealTensorValue> > & _dpermeability_dvar;
+
+  virtual void initQpStatefulProperties();
+  virtual void computeQpProperties();
+};
+
+#endif //POROUSFLOWPERMEABILITYCONST_H

--- a/modules/porous_flow/include/materials/PorousFlowPorosityConst.h
+++ b/modules/porous_flow/include/materials/PorousFlowPorosityConst.h
@@ -1,0 +1,37 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWPOROSITYCONST_H
+#define POROUSFLOWPOROSITYCONST_H
+
+#include "PorousFlowPorosityUnity.h"
+
+//Forward Declarations
+class PorousFlowPorosityConst;
+
+template<>
+InputParameters validParams<PorousFlowPorosityConst>();
+
+/**
+ * Material designed to provide the porosity
+ * which is assumed constant
+ */
+class PorousFlowPorosityConst : public PorousFlowPorosityUnity
+{
+public:
+  PorousFlowPorosityConst(const InputParameters & parameters);
+
+protected:
+  /// constant input value of porosity
+  const Real _input_porosity;
+
+  virtual void initQpStatefulProperties();
+
+  virtual void computeQpProperties();
+};
+
+#endif //POROUSFLOWPOROSITYCONST_H

--- a/modules/porous_flow/include/materials/PorousFlowPorosityHM.h
+++ b/modules/porous_flow/include/materials/PorousFlowPorosityHM.h
@@ -1,0 +1,74 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWPOROSITYHM_H
+#define POROUSFLOWPOROSITYHM_H
+
+#include "PorousFlowPorosityUnity.h"
+#include "RankTwoTensor.h"
+
+//Forward Declarations
+class PorousFlowPorosityHM;
+
+template<>
+InputParameters validParams<PorousFlowPorosityHM>();
+
+/**
+ * Material designed to provide the porosity in hydro-mechanical simulations
+ * biot + (phi0 - biot)*exp(-vol_strain + (biot-1)effective_porepressure/solid_bulk)
+ */
+class PorousFlowPorosityHM : public PorousFlowPorosityUnity
+{
+public:
+  PorousFlowPorosityHM(const InputParameters & parameters);
+
+protected:
+  /// porosity at zero strain and zero porepressure
+  const Real _phi0;
+
+  /// biot coefficient
+  const Real _biot;
+
+  /// drained bulk modulus of the porous skeleton
+  const Real _solid_bulk;
+
+  /// number of porous-flow variables
+  const unsigned int _num_var;
+
+  /// short-hand number (biot-1)/solid_bulk
+  const Real _coeff;
+
+  /// number of displacement variables
+  const unsigned int _ndisp;
+
+  /// variable number of the displacements variables
+  std::vector<unsigned int> _disp_var_num;
+
+  /// strain
+  const MaterialProperty<Real> & _vol_strain_qp;
+
+  /// d(strain)/(dvar)
+  const MaterialProperty<std::vector<RealGradient> > & _dvol_strain_qp_dvar;
+
+  /// effective nodal porepressure
+  const MaterialProperty<Real> & _pf_nodal;
+
+  /// d(effective nodal porepressure)/(d porflow variable)
+  const MaterialProperty<std::vector<Real> > & _dpf_nodal_dvar;
+
+  /// effective qp porepressure
+  const MaterialProperty<Real> & _pf_qp;
+
+  /// d(effective qp porepressure)/(d porflow variable)
+  const MaterialProperty<std::vector<Real> > & _dpf_qp_dvar;
+
+  virtual void initQpStatefulProperties();
+
+  virtual void computeQpProperties();
+};
+
+#endif //POROUSFLOWPOROSITYHM_H

--- a/modules/porous_flow/include/materials/PorousFlowPorosityUnity.h
+++ b/modules/porous_flow/include/materials/PorousFlowPorosityUnity.h
@@ -1,0 +1,63 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWPOROSITYUNITY_H
+#define POROUSFLOWPOROSITYUNITY_H
+
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+
+#include "PorousFlowDictator.h"
+
+//Forward Declarations
+class PorousFlowPorosityUnity;
+
+template<>
+InputParameters validParams<PorousFlowPorosityUnity>();
+
+/**
+ * Base class Material designed to provide the porosity.
+ * In this class porosity = 1
+ */
+class PorousFlowPorosityUnity : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowPorosityUnity(const InputParameters & parameters);
+
+protected:
+  /// The variable names UserObject for the Porous-Flow variables
+  const PorousFlowDictator & _dictator_UO;
+
+  /// nodal porosity
+  MaterialProperty<Real> & _porosity_nodal;
+
+  /// old value of nodal porosity (which is, of course = _porosity in this case)
+  MaterialProperty<Real> & _porosity_nodal_old;
+
+  /// d(nodal porosity)/d(PorousFlow variable)
+  MaterialProperty<std::vector<Real> > & _dporosity_nodal_dvar;
+
+  /// d(nodal porosity)/d(PorousFlow variable)
+  MaterialProperty<std::vector<RealGradient> > & _dporosity_nodal_dgradvar;
+
+  /// qaudpoint porosity
+  MaterialProperty<Real> & _porosity_qp;
+
+  /// old value of quadpoint porosity (which is, of course = _porosity in this case)
+  MaterialProperty<Real> & _porosity_qp_old;
+
+  /// d(quadpoint porosity)/d(PorousFlow variable)
+  MaterialProperty<std::vector<Real> > & _dporosity_qp_dvar;
+
+  /// d(quadpoint porosity)/d(PorousFlow variable)
+  MaterialProperty<std::vector<RealGradient> > & _dporosity_qp_dgradvar;
+
+  virtual void initQpStatefulProperties();
+  virtual void computeQpProperties();
+};
+
+#endif //POROUSFLOWPOROSITYUNITY_H

--- a/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityCorey.h
+++ b/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityCorey.h
@@ -1,0 +1,35 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWRELATIVEPERMEABILITYCOREY_H
+#define POROUSFLOWRELATIVEPERMEABILITYCOREY_H
+
+#include "PorousFlowRelativePermeabilityUnity.h"
+
+class PorousFlowRelativePermeabilityCorey;
+
+template<>
+InputParameters validParams<PorousFlowRelativePermeabilityCorey>();
+
+/**
+ * Material designed to calculate Corey-type relative permeability
+ * of an arbitrary phase given the saturation and
+ * Corey exponent of that phase.
+ */
+class PorousFlowRelativePermeabilityCorey : public PorousFlowRelativePermeabilityUnity
+{
+public:
+  PorousFlowRelativePermeabilityCorey(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// Core exponent n for the phase
+  const Real _n;
+};
+
+#endif //POROUSFLOWRELATIVEPERMEABILITYCOREY_H

--- a/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityUnity.h
+++ b/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityUnity.h
@@ -1,0 +1,51 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWRELATIVEPERMEABILITYUNITY_H
+#define POROUSFLOWRELATIVEPERMEABILITYUNITY_H
+
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+#include "PorousFlowDictator.h"
+
+class PorousFlowRelativePermeabilityUnity;
+
+template<>
+InputParameters validParams<PorousFlowRelativePermeabilityUnity>();
+
+/**
+ * Base class for relative permeability materials
+ * This class simply sets relative permeability = 1 at the nodes
+ */
+class PorousFlowRelativePermeabilityUnity : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowRelativePermeabilityUnity(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// Phase number of fluid that this relative permeability relates to
+  const unsigned int _phase_num;
+
+  /// The PorousFlowDictator UserObject
+  const PorousFlowDictator & _dictator_UO;
+
+  /// Name of (dummy) saturation primary variable
+  VariableName _saturation_variable_name;
+
+  /// Saturation material property
+  const MaterialProperty<std::vector<Real> > & _saturation_nodal;
+
+  /// Relative permeability material property
+  MaterialProperty<Real> & _relative_permeability;
+
+  /// Derivative of relative permeability wrt phase saturation
+  MaterialProperty<Real> & _drelative_permeability_ds;
+};
+
+#endif //POROUSFLOWRELATIVEPERMEABILITYUNITY_H

--- a/modules/porous_flow/include/materials/PorousFlowSimpleCO2.h
+++ b/modules/porous_flow/include/materials/PorousFlowSimpleCO2.h
@@ -252,10 +252,10 @@ protected:
   const Real _Mco2;
 
   /// Critical pressure (Pa)
-  const Real _p_critical;
+  const Real _critical_pressure;
 
   /// Critical temperature (C)
-  const Real _t_critical;
+  const Real _critical_temperature;
 };
 
 #endif //POROUSFLOWSIMPLECO2_H

--- a/modules/porous_flow/include/materials/PorousFlowSimpleCO2.h
+++ b/modules/porous_flow/include/materials/PorousFlowSimpleCO2.h
@@ -1,0 +1,261 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWSIMPLECO2_H
+#define POROUSFLOWSIMPLECO2_H
+
+#include "PorousFlowFluidPropertiesBase.h"
+
+class PorousFlowSimpleCO2;
+
+template<>
+InputParameters validParams<PorousFlowSimpleCO2>();
+
+/**
+ * Simplified fluid properties of carbon dioxide (CO2).
+ * Provides density, viscosity, derivatives wrt pressure and temperature,
+ * and Henry Law constants.
+ *
+ * Note: These aren't as accurate as the full CO2 implementation, but are
+ * fast and have simple analytical derivatives
+ */
+class PorousFlowSimpleCO2 : public PorousFlowFluidPropertiesBase
+{
+public:
+  PorousFlowSimpleCO2(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+  virtual void computeQpProperties();
+
+  /**
+   * CO2 density as a function of pressure and temperature.
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return density (kg/m^3)
+   */
+  Real density(Real pressure, Real temperature) const;
+
+  /**
+   * CO2 viscosity as a function of  pressure and temperature.
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @param density phase density (kg/m^3)
+   * @return viscosity (Pa.s)
+   */
+  Real viscosity(Real pressure, Real temperature, Real density) const;
+
+  /**
+   * Derivative of the viscosity of CO2 as a function of temperature
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @param density phase density (kg/m^3)
+   * @return derivative of CO2 viscosity wrt temperature
+   */
+  Real dViscosity_dT(Real pressure, Real temperature, Real density) const;
+
+  /**
+   * Partial density of dissolved CO2. From Garcia, Density of aqueous
+   * solutions of CO2, LBNL-49023 (2001).
+   *
+   * @param temperature fluid temperature (C)
+   * @return partial molar density (kg/m^3)
+   */
+  Real partialDensity(Real temperature) const;
+
+  /**
+   * Density of supercritical CO2. From Ouyang, New correlations for predicting
+   * the density and viscosity of supercritical Carbon Dioxide under conditions
+   * expected in Carbon Capture and Sequestration operations, The Open Petroleum
+   * Engineering Journal, 4, 13-21 (2011)
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return density (kg/m^3)
+   */
+  Real supercriticalDensity(Real pressure, Real temperature) const;
+
+  /**
+   * CO2 gas density as a function of  pressure and temperature.
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return density (kg/m^3)
+   */
+  Real gasDensity(Real pressure, Real temperature) const;
+
+  /**
+   * CO2 gas viscosity as a function of  pressure and temperature.
+   * From Fenghour et al., The viscosity of carbon dioxide, J. Phys. Chem. Ref.
+   * Data, 27, 31-44 (1998).
+   * Note: used up to the critical point. The supercritical viscosity is calculated
+   * in supercriticalViscosity(). As a result, the critical enhancement is not
+   * implemented.
+   *
+   * @param temperature fluid temperature (C)
+   * @param density fluid density (kg/m^3)
+   * @return viscosity (Pa.s)
+   */
+  Real gasViscosity(Real temperature, Real density) const;
+
+  /**
+   * Viscosity of supercritical CO2. From Ouyang, New correlations for predicting
+   * the density and viscosity of supercritical Carbon Dioxide under conditions
+   * expected in Carbon Capture and Sequestration operations, The Open Petroleum
+   * Engineering Journal, 4, 13-21 (2011)
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return viscosity (Pa.s)
+   */
+  Real supercriticalViscosity(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of CO2 as a function of
+   * pressure.
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 density (kg/m^3) with respect to pressure (Pa)
+   */
+  Real dDensity_dP(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of CO2 as a function of
+   * temperature.
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 density (kg/m^3) with respect to temperature (C)
+   */
+  Real dDensity_dT(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of gaseous CO2 as a function of
+   * pressure.
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 density (kg/m^3) with respect to pressure (Pa)
+   */
+  Real dGasDensity_dP(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of gaseous CO2 as a function of
+   * temperature.
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 density (kg/m^3) with respect to temperature (C)
+   */
+  Real dGasDensity_dT(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of supercritical CO2 as a function of
+   * pressure.
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 density (kg/m^3) with respect to pressure (Pa)
+   */
+  Real dSupercriticalDensity_dP(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of supercritical CO2 as a function of
+   * temperature.
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 density (kg/m^3) with respect to temperature (C)
+   */
+  Real dSupercriticalDensity_dT(Real pressure, Real temperature) const;
+
+  /**
+   * The derivative of CO2 viscosity with respect to density
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 viscosity wrt density
+   */
+  Real dViscosity_dDensity(Real pressure, Real temperature, Real density) const;
+
+  /**
+   * Derivative of the viscosity of gaseous CO2 as a function of density
+   *
+   * @param temperature fluid temperature (C)
+   * @param density fluid density (kg/m^3)
+   * @return derivative of CO2 viscosity wrt density
+   */
+  Real dGasViscosity_dDensity(Real temperature, Real density) const;
+
+  /**
+   * Derivative of the viscosity of supercritical CO2 as a function of density
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 viscosity wrt density
+   */
+  Real dSupercriticalViscosity_dDensity(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the viscosity of supercritical CO2 as a function of pressure
+   *
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (C)
+   * @return derivative of CO2 viscosity wrt pressure
+   */
+  Real dSupercriticalViscosity_dP(Real pressure, Real temperature) const;
+
+  /**
+   * Henry's law constant coefficients for dissolution of CO2 into water.
+   * From Guidelines on the Henry's constant and vapour
+   * liquid distribution constant for gases in H20 and D20 at high
+   * temperatures, IAPWS (2004).
+   *
+   * @return constants for Henry's constant (-)
+   */
+  std::vector<Real> henryConstants() const;
+
+  /// Fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal;
+
+  /// Old fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal_old;
+
+  /// Derivative of fluid density wrt phase pore pressure at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dp;
+
+  /// Derivative of fluid density wrt temperature at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dt;
+
+  /// Fluid phase density at the qps
+  MaterialProperty<Real> & _density_qp;
+
+  /// Derivative of fluid density wrt phase pore pressure at the qps
+  MaterialProperty<Real> & _ddensity_qp_dp;
+
+  /// Derivative of fluid density wrt temperature at the qps
+  MaterialProperty<Real> & _ddensity_qp_dt;
+
+  /// Fluid phase viscosity at the nodes
+  MaterialProperty<Real> & _viscosity_nodal;
+
+  /// Derivative of fluid phase viscosity wrt temperature at the nodes
+  MaterialProperty<Real> & _dviscosity_nodal_dt;
+
+  /// CO2 molar mass (kg/mol)
+  const Real _Mco2;
+
+  /// Critical pressure (Pa)
+  const Real _p_critical;
+
+  /// Critical temperature (C)
+  const Real _t_critical;
+};
+
+#endif //POROUSFLOWSIMPLECO2_H

--- a/modules/porous_flow/include/materials/PorousFlowViscosityConst.h
+++ b/modules/porous_flow/include/materials/PorousFlowViscosityConst.h
@@ -1,0 +1,43 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWVISCOSITYCONST_H
+#define POROUSFLOWVISCOSITYCONST_H
+
+#include "PorousFlowFluidPropertiesBase.h"
+
+class PorousFlowViscosityConst;
+
+template<>
+InputParameters validParams<PorousFlowViscosityConst>();
+
+/**
+ * Material designed to provide the viscosity
+ * which is assumed constant
+ */
+class PorousFlowViscosityConst : public PorousFlowFluidPropertiesBase
+{
+public:
+  PorousFlowViscosityConst(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// constant value of viscosity
+  const Real _input_viscosity;
+
+  /// the phase number
+  unsigned int _phase_num;
+
+  /// The variable names UserObject for the Porous-Flow variables
+  const PorousFlowDictator & _dictator_UO;
+
+  /// viscosity
+  MaterialProperty<Real> & _viscosity;
+};
+
+#endif //POROUSFLOWVISCOSITYCONST_H

--- a/modules/porous_flow/include/materials/PorousFlowVolumetricStrain.h
+++ b/modules/porous_flow/include/materials/PorousFlowVolumetricStrain.h
@@ -1,0 +1,73 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWVOLUMETRICSTRAIN_H
+#define POROUSFLOWVOLUMETRICSTRAIN_H
+
+#include "DerivativeMaterialInterface.h"
+#include "RankTwoTensor.h"
+#include "Material.h"
+
+#include "PorousFlowDictator.h"
+
+/**
+ * PorousFlowVolumetricStrain computes volumetric strains, and derivatives thereof
+ */
+class PorousFlowVolumetricStrain : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowVolumetricStrain(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// If true then the strain rate will include terms that ensure mass is conserved when doing integrals over the displaced mesh
+  const bool _consistent;
+
+  /// The dictator UserObject for the Porous-Flow simulation
+  const PorousFlowDictator & _dictator_UO;
+
+  /// number of porous-flow variables
+  const unsigned int _num_var;
+
+  /// number of displacements supplied (1 in 1D, 2 in 2D, 3 in 3D)
+  const unsigned int _ndisp;
+
+  /// displacement variable values at the quad point
+  std::vector<const VariableValue *> _disp;
+
+  /// moose variable number of the displacements variables provided
+  std::vector<unsigned int> _disp_var_num;
+
+  /// gradient of the displacements
+  std::vector<const VariableGradient *> _grad_disp;
+
+  /// old value of gradient of the displacements
+  std::vector<const VariableGradient *> _grad_disp_old;
+
+  /// The volumetric strain rate at the quadpoints
+  MaterialProperty<Real> & _vol_strain_rate_qp;
+
+  /**
+   * The derivative of the volumetric strain rate with respect to the porous flow variables.
+   * Since the volumetric strain rate depends on derivatives of the displacement variables,
+   * this should be multiplied by _grad_phi in kernels
+   */
+  MaterialProperty<std::vector<RealGradient> > & _dvol_strain_rate_qp_dvar;
+
+  /// The total volumetric strain at the quadpoints
+  MaterialProperty<Real> & _vol_total_strain_qp;
+
+  /**
+   * The derivative of the total volumetric strain with respect to the porous flow variables.
+   * Since the total volumetric strain depends on derivatives of the displacement variables,
+   * this should be multiplied by _grad_phi in kernels
+   */
+  MaterialProperty<std::vector<RealGradient> > & _dvol_total_strain_qp_dvar;
+};
+
+#endif //POROUSFLOWVOLUMETRICSTRAIN_H

--- a/modules/porous_flow/include/materials/PorousFlowWater.h
+++ b/modules/porous_flow/include/materials/PorousFlowWater.h
@@ -1,0 +1,274 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWWATER_H
+#define POROUSFLOWWATER_H
+
+#include "PorousFlowFluidPropertiesBase.h"
+
+class PorousFlowWater;
+
+template<>
+InputParameters validParams<PorousFlowWater>();
+
+/**
+ * Fluid properties of Water (H20).
+ * Provides density, viscosity, derivatives wrt pressure and temperature.
+ */
+class PorousFlowWater : public PorousFlowFluidPropertiesBase
+{
+public:
+  PorousFlowWater(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+
+  virtual void computeQpProperties();
+
+  /**
+   * Density of water
+   * From IAPWS IF97 Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam.
+   *
+   * Valid for 273.15 K <= T <= 1073.15 K, p <= 100 MPa
+   *          1073.15 K <= T <= 2273.15 K, p <= 50 Mpa
+   *
+   * @param pressure water pressure (Pa)
+   * @param temperature water temperature (C)
+   * @return water density (kg/m^3)
+   */
+  Real density(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of water with respect to pressure.
+   * From IAPWS IF97 Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam.
+   *
+   * Valid for 273.15 K <= T <= 1073.15 K, p <= 100 MPa
+   *          1073.15 K <= T <= 2273.15 K, p <= 50 Mpa
+   *
+   * @param pressure water pressure (Pa)
+   * @param temperature water temperature (C)
+   * @return derivative of water density (kg/m^3) with respect to pressure
+   */
+  Real dDensity_dP(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of the density of water with respect to temperature.
+   * From IAPWS IF97 Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam.
+   *
+   * Valid for 273.15 K <= T <= 1073.15 K, p <= 100 MPa
+   *          1073.15 K <= T <= 2273.15 K, p <= 50 Mpa
+   *
+   * @param pressure water pressure (Pa)
+   * @param temperature water temperature (C)
+   * @return derivative of water density (kg/m^3) with respect to temperature
+   */
+  Real dDensity_dT(Real pressure, Real temperature) const;
+
+  /**
+   * Viscosity of water.
+   * Eq.(10) from Release on the IAPWS Formulation 2008 for the
+   * Viscosity of Ordinary Water Substance.
+   * Note: critical enhancement not yet included
+   *
+   * @param temperature water temperature (C)
+   * @param density water density (kg/m^3)
+   * @return viscosity (Pa.s)
+   */
+  Real viscosity(Real temperature, Real density) const;
+
+  /**
+   * Derivative of viscosity with respect to density. Derived from
+   * Eq. (10) from Release on the IAPWS Formulation 2008 for the
+   * Viscosity of Ordinary Water Substance.
+   *
+   * @param temperature water temperature (C)
+   * @param density water density (kg/m^3)
+   * @return derivative of water viscosity wrt density
+   */
+  Real dViscosity_dT(Real temperature, Real density) const;
+
+  /**
+   *Saturation pressure as a function of temperature.
+   *
+   * Eq. (30) from Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam, IAPWS 2007.
+   *
+   * Valid for 273.15 K <= t <= 647.096 K
+   *
+   * @param temperature water temperature (C)
+   * @return saturation pressure (Pa)
+   */
+  Real pSat(Real temperature) const;
+
+  /**
+   * Saturation temperature as a function of pressure.
+   *
+   * Eq. (31) from Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam, IAPWS 2007.
+   *
+   * Valid for 611.213 Pa <= p <= 22.064 MPa
+   *
+   * @param pressure water pressure (Pa)
+   * @return saturation temperature (C)
+   */
+  Real tSat(Real pressure) const;
+
+  /**
+   *Auxillary equation for the boundary between regions 2 and 3.
+   *
+   * Eq. (5) from Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam, IAPWS 2007.
+   *
+   * @param temperature water temperature (C)
+   * @return pressure (Pa) on the boundary between region 2 and 3
+   */
+  Real b23p(Real temperature) const;
+
+  /**
+   * Auxillary equation for the boundary between regions 2 and 3.
+   *
+   * Eq. (6) from Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam, IAPWS 2007.
+   *
+   * @param pressure water pressure (Pa)
+   * @return temperature (C) on the boundary between regions 2 and 3
+   */
+  Real b23t(Real pressure) const;
+
+  /**
+   * Density function for Region 1 - single phase liquid region
+   *
+   * From Eq. (7) From Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam, IAPWS 2007.
+   *
+   * @param pressure water pressure (Pa)
+   * @param temperature water temperature (C)
+   * @return density (kg/m^3) in region 1
+   */
+  Real densityRegion1(Real pressure, Real temperature) const;
+
+  /**
+   * Density function for Region 2 - superheated steam
+   *
+   * From Eq. (15) From Revised Release on the IAPWS Industrial
+   * Formulation 1997 for the Thermodynamic Properties of Water
+   * and Steam, IAPWS 2007.
+   *
+   * @param pressure water pressure (Pa)
+   * @param temperature water temperature (C)
+   * @return density (kg/m^3) in region 2
+   */
+  Real densityRegion2(Real pressure, Real temperature) const;
+
+  /**
+   * Density function for Region 3 - supercritical water and steam
+   *
+   * To avoid iteration, use the backwards equations for region 3
+   * from Revised Supplementary Release on Backward Equations for
+   * Specific Volume as a Function of Pressure and Temperature v(p,T)
+   * for Region 3 of the IAPWS Industrial Formulation 1997 for the
+   * Thermodynamic Properties of Water and Steam.
+   *
+   * @param pressure water pressure (Pa)
+   * @param temperature water temperature (C)
+   * @return density (kg/m^3) in region 3
+   */
+  Real densityRegion3(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of density function for Region 1 - single phase liquid region
+   * with respect to presure.
+   * From Revised Release on the IAPWS Industrial Formulation 1997 for the
+   * Thermodynamic Properties of Water and Steam, IAPWS 2007.
+   *
+   * @param pressure water pressure (Pa)
+   * @param temperature water temperature (C)
+   * @return derivative of density (kg/m^3) in region 1 with respect to pressure
+   */
+  Real dDensityRegion1_dP(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of density function for Region 2 - superheated steam
+   * with respect to presure.
+   * From Revised Release on the IAPWS Industrial Formulation 1997 for the
+   * Thermodynamic Properties of Water and Steam, IAPWS 2007.
+   *
+   * @param pressure water pressure (Pa)
+   * @param temperature water temperature (C)
+   * @return derivative of water density (kg/m^3) in region 2 with respect to pressure
+   */
+  Real dDensityRegion2_dP(Real pressure, Real temperature) const;
+
+  /**
+   * Derivative of viscosity with respect to density. Derived from
+   * Eq. (10) from Release on the IAPWS Formulation 2008 for the
+   * Viscosity of Ordinary Water Substance.
+   *
+   * @param temperature water temperature (C)
+   * @param density water density (kg/m^3)
+   * @return derivative of water viscosity wrt density
+   */
+  Real dViscosity_dDensity(Real temperature, Real density) const;
+
+  /// Fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal;
+
+  /// Old fluid phase density at the nodes
+  MaterialProperty<Real> & _density_nodal_old;
+
+  /// Derivative of fluid density wrt phase pore pressure at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dp;
+
+  /// Derivative of fluid density wrt temperature at the nodes
+  MaterialProperty<Real> & _ddensity_nodal_dt;
+
+  /// Fluid phase density at the qps
+  MaterialProperty<Real> & _density_qp;
+
+  /// Derivative of fluid density wrt phase pore pressure at the qps
+  MaterialProperty<Real> & _ddensity_qp_dp;
+
+  /// Derivative of fluid density wrt temperature at the qps
+  MaterialProperty<Real> & _ddensity_qp_dt;
+
+  /// Fluid phase viscosity at the nodes
+  MaterialProperty<Real> & _viscosity_nodal;
+
+  /// Derivative of fluid phase viscosity wrt temperature at the nodes
+  MaterialProperty<Real> & _dviscosity_nodal_dt;
+
+  /// Molar mass of water (kg/mol)
+  const Real _Mh2o;
+
+  /// Pressure of water at the critical point (Pa)
+  const Real _p_critical;
+
+  /// Temperature of water at the critical point (C)
+  const Real _t_critical;
+
+  /// Density of water at the critical point (kg/m^3)
+  const Real _rho_critical;
+
+  /// Specific volume of water at the critical point (m^3/kg)
+  const Real _v_critical;
+
+  /// Specific gas constant of water (universal gas constant / molar mass of water) (kJ/kg/K)
+  const Real _Rw;
+};
+
+#endif //POROUSFLOWWATER_H

--- a/modules/porous_flow/src/base/PorousFlowApp.C
+++ b/modules/porous_flow/src/base/PorousFlowApp.C
@@ -20,6 +20,27 @@
 #include "PorousFlow1PhaseP_VG.h"
 #include "PorousFlow2PhasePS.h"
 #include "PorousFlowVariableBase.h"
+#include "PorousFlowBrine.h"
+#include "PorousFlowCapillaryPressureBase.h"
+#include "PorousFlowCapillaryPressureConstant.h"
+#include "PorousFlowCapillaryPressureLinear.h"
+#include "PorousFlowCapillaryPressureVGS.h"
+#include "PorousFlowCapillaryPressureVGP.h"
+#include "PorousFlowDensityConstBulk.h"
+#include "PorousFlowEffectiveFluidPressure.h"
+#include "PorousFlowFluidPropertiesBase.h"
+#include "PorousFlowIdealGas.h"
+#include "PorousFlowMethane.h"
+#include "PorousFlowPermeabilityConst.h"
+#include "PorousFlowPorosityConst.h"
+#include "PorousFlowPorosityHM.h"
+#include "PorousFlowPorosityUnity.h"
+#include "PorousFlowRelativePermeabilityCorey.h"
+#include "PorousFlowRelativePermeabilityUnity.h"
+#include "PorousFlowSimpleCO2.h"
+#include "PorousFlowViscosityConst.h"
+#include "PorousFlowVolumetricStrain.h"
+#include "PorousFlowWater.h"
 
 // Kernels
 #include "PorousFlowAdvectiveFlux.h"
@@ -85,6 +106,27 @@ PorousFlowApp::registerObjects(Factory & factory)
   registerMaterial(PorousFlow1PhaseP_VG);
   registerMaterial(PorousFlow2PhasePS);
   registerMaterial(PorousFlowVariableBase);
+  registerMaterial(PorousFlowBrine);
+  registerMaterial(PorousFlowCapillaryPressureBase);
+  registerMaterial(PorousFlowCapillaryPressureConstant);
+  registerMaterial(PorousFlowCapillaryPressureLinear);
+  registerMaterial(PorousFlowCapillaryPressureVGS);
+  registerMaterial(PorousFlowCapillaryPressureVGP);
+  registerMaterial(PorousFlowDensityConstBulk);
+  registerMaterial(PorousFlowEffectiveFluidPressure);
+  registerMaterial(PorousFlowFluidPropertiesBase);
+  registerMaterial(PorousFlowIdealGas);
+  registerMaterial(PorousFlowMethane);
+  registerMaterial(PorousFlowPermeabilityConst);
+  registerMaterial(PorousFlowPorosityConst);
+  registerMaterial(PorousFlowPorosityHM);
+  registerMaterial(PorousFlowPorosityUnity);
+  registerMaterial(PorousFlowRelativePermeabilityCorey);
+  registerMaterial(PorousFlowRelativePermeabilityUnity);
+  registerMaterial(PorousFlowSimpleCO2);
+  registerMaterial(PorousFlowViscosityConst);
+  registerMaterial(PorousFlowVolumetricStrain);
+  registerMaterial(PorousFlowWater);
 
   // Kernels
   registerKernel(PorousFlowAdvectiveFlux);

--- a/modules/porous_flow/src/materials/PorousFlowBrine.C
+++ b/modules/porous_flow/src/materials/PorousFlowBrine.C
@@ -52,6 +52,11 @@ PorousFlowBrine::computeQpProperties()
 Real
 PorousFlowBrine::density(Real pressure, Real temperature, Real xnacl) const
 {
+  /*
+   * From Driesner, The system H2o-NaCl. Part II: Correlations for molar volume,
+   * enthalpy, and isobaric heat capacity from 0 to 1000 C, 1 to 500 bar, and 0
+   * to 1 Xnacl, Geochimica et Cosmochimica Acta 71, 4902-4919 (2007).
+   */
   Real n1, n2, n11, n12, n1x1, n20, n21, n22, n23, n2x1, Tv;
   Real water_density, density;
 
@@ -125,6 +130,11 @@ PorousFlowBrine::dDensity_dT(Real /*pressure*/, Real /*temperature*/, Real /*xna
 Real
 PorousFlowBrine::viscosity(Real temperature, Real water_density, Real xnacl) const
 {
+  /*
+   * Viscosity of brine.
+   * From Phillips et al, A technical databook for geothermal energy utilization,
+   * LbL-12810 (1981).
+   */
   // Correlation requires molar concentration (mol/kg)
   Real mol = xnacl / ((1.0 - xnacl) * _Mnacl);
   Real mol2 = mol * mol;
@@ -145,6 +155,12 @@ PorousFlowBrine::dViscosity_dT(Real /*temperature*/, Real /*density*/, Real /*xn
 Real
 PorousFlowBrine::pSat(Real temperature, Real xnacl) const
 {
+  /*
+   * Brine vapour pressure
+   * From Haas, Physical properties of the coexisting phases and thermochemical
+   * properties of the H20 component in boiling NaCl solutions, Geological Survey
+   * Bulletin, 1421-A (1976).
+   */
   // Temperature in K
   Real tk = temperature + _t_c2k;
 
@@ -185,6 +201,12 @@ PorousFlowBrine::dViscosity_dDensity(Real temperature, Real water_density, Real 
 Real
 PorousFlowBrine::haliteDensity(Real pressure, Real temperature) const
 {
+  /*
+   * Density of halite (solid NaCl)
+   * From Driesner, The system H2o-NaCl. Part II: Correlations for molar volume,
+   * enthalpy, and isobaric heat capacity from 0 to 1000 C, 1 to 500 bar, and 0
+   * to 1 Xnacl, Geochimica et Cosmochimica Acta 71, 4902-4919 (2007).
+   */
   // Correlation needs pressure in bar
   Real pbar = pressure * 1.e-5;
 
@@ -200,6 +222,16 @@ PorousFlowBrine::haliteDensity(Real pressure, Real temperature) const
 Real
 PorousFlowBrine::haliteSolubility(Real temperature) const
 {
+  /*
+   * Halite solubility
+   * Originally from Potter et al., A new method for determining the solubility
+   * of salts in aqueous solutions at elevated temperatures, J. Res. U.S. Geol.
+   * Surv., 5, 389-395 (1977). Equation describing halite solubility is repeated
+   * in Chou, Phase relations in the system NaCI-KCI-H20. III: Solubilities of
+   * halite in vapor-saturated liquids above 445°C and redetermination of phase
+   * equilibrium properties in the system NaCI-HzO to 1000°C and 1500 bars,
+   * Geochimica et Cosmochimica Acta 51, 1965-1975 (1987).
+   */
   Real solubility = (26.18 + 7.2e-3 * temperature + 1.06e-4 * temperature * temperature) / 100.0;
 
   return solubility;

--- a/modules/porous_flow/src/materials/PorousFlowBrine.C
+++ b/modules/porous_flow/src/materials/PorousFlowBrine.C
@@ -1,0 +1,206 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/**********************************************2******************/
+
+#include "PorousFlowBrine.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowBrine>()
+{
+  InputParameters params = validParams<PorousFlowWater>();
+  params.addRequiredParam<Real>("xnacl", "The salt mass fraction in the brine (kg/kg)");
+  params.addClassDescription("This Material calculates fluid properties for brine");
+  return params;
+}
+
+PorousFlowBrine::PorousFlowBrine(const InputParameters & parameters) :
+    PorousFlowWater(parameters),
+
+    _Mnacl(58.443e-3),
+    _xnacl(getParam<Real>("xnacl"))
+{
+}
+
+void
+PorousFlowBrine::initQpStatefulProperties()
+{
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _xnacl);
+}
+
+void
+PorousFlowBrine::computeQpProperties()
+{
+  /// Density and derivatives wrt pressure and temperature at the nodes
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _xnacl);
+  _ddensity_nodal_dp[_qp] = dDensity_dP(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _xnacl);
+  _ddensity_nodal_dt[_qp] = dDensity_dT(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _xnacl);
+
+  /// Density and derivatives wrt pressure and temperature at the qps
+  _density_qp[_qp] = density(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num], _xnacl);
+  _ddensity_qp_dp[_qp] = dDensity_dP(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num], _xnacl);
+  _ddensity_qp_dt[_qp] = dDensity_dT(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num], _xnacl);
+
+  /// Viscosity and derivative wrt temperature at the nodes
+  _viscosity_nodal[_qp] = viscosity(_temperature_nodal[_qp][_phase_num], _density_nodal[_qp], _xnacl);
+  _dviscosity_nodal_dt[_qp] = dViscosity_dT(_temperature_nodal[_qp][_phase_num], _density_nodal[_qp], _xnacl);
+}
+
+Real
+PorousFlowBrine::density(Real pressure, Real temperature, Real xnacl) const
+{
+  Real n1, n2, n11, n12, n1x1, n20, n21, n22, n23, n2x1, Tv;
+  Real water_density, density;
+
+  // The correlation requires the pressure in bar, not Pa.
+  Real pbar = pressure * 1.0e-5;
+  Real pbar2 = pbar * pbar;
+  Real pbar3 = pbar2 * pbar;
+
+  // The correlation requires mole fraction. First calculate the average molar mass
+  // from the mass fraction, then compute the mole fraction
+  Real Mbrine = 1.0 / (xnacl / _Mnacl + (1.0 - xnacl) / _Mh2o);
+  Real Xnacl = xnacl / _Mnacl * Mbrine;
+
+  n11 = -54.2958 - 45.7623 * std::exp(-9.44785e-4 * pbar);
+  n21 = -2.6142 - 2.39092e-4 * pbar;
+  n22 = 0.0356828 + 4.37235e-6 * pbar + 2.0566e-9 * pbar2;
+  n1x1 = 330.47 + 0.942876 * std::sqrt(pbar) + 0.0817193 * pbar - 2.47556e-8 * pbar2
+         + 3.45052e-10 * pbar3;
+  n2x1 = -0.0370751 + 0.00237723 * std::sqrt(pbar) + 5.42049e-5 * pbar
+         + 5.84709e-9 * pbar2 - 5.99373e-13 * pbar3;
+  n12 = - n1x1 - n11;
+  n20 = 1.0 - n21 * std::sqrt(n22);
+  n23 = n2x1 - n20 -n21 * std::sqrt(1.0 + n22);
+
+  // The temperature Tv (C) where the brine has the same molar volume as pure water
+  n1 = n1x1 + n11 * (1.0 - Xnacl) + n12 * (1.0 - Xnacl) * (1.0 - Xnacl);
+  n2 = n20 + n21 * std::sqrt(Xnacl + n22) + n23 * Xnacl;
+  Tv = n1 + n2 * temperature;
+
+  /// The brine density is then given by the density of water at temperature Tv.
+  Real psat = pSat(temperature, xnacl);
+
+  if (Tv >= 0. && Tv <= 350.)
+  {
+    if (pressure > psat && pressure <= 100.e6)
+    {
+      /// Region 1: single phase liquid
+      water_density = PorousFlowWater::densityRegion1(pressure, Tv);
+    }
+
+    else if (pressure <= psat)
+    {
+      /// Region 2: vapour phase
+      water_density = PorousFlowWater::densityRegion2(pressure, Tv);
+    }
+
+    else
+      mooseError("Pressure "<< pressure << " is out of range in BrineProperties::density");
+  }
+  else
+    mooseError("Temperature " << temperature << " is out of range in BrineProperties::density");
+
+  density = water_density * Mbrine / _Mh2o;
+
+  return density;
+}
+
+Real
+PorousFlowBrine::dDensity_dP(Real pressure, Real temperature, Real /*xnacl*/) const
+{
+  //TODO: implement brine density derivative wrt P
+  return PorousFlowWater::dDensity_dP(pressure, temperature);
+}
+
+Real
+PorousFlowBrine::dDensity_dT(Real /*pressure*/, Real /*temperature*/, Real /*xnacl*/) const
+{
+  //TODO: implement brine density derivative wrt T
+  return 0.;}
+
+Real
+PorousFlowBrine::viscosity(Real temperature, Real water_density, Real xnacl) const
+{
+  // Correlation requires molar concentration (mol/kg)
+  Real mol = xnacl / ((1.0 - xnacl) * _Mnacl);
+  Real mol2 = mol * mol;
+  Real mol3 = mol2 * mol;
+
+  Real a = 1.0 + 0.0816 * mol + 0.0122 * mol2 + 0.128e-3 * mol3 + 0.629e-3 * temperature
+           * (1.0 - std::exp(-0.7 * mol));
+
+  return a * PorousFlowWater::viscosity(temperature, water_density);
+}
+
+Real
+PorousFlowBrine::dViscosity_dT(Real /*temperature*/, Real /*density*/, Real /*xnacl*/) const
+{
+  return 0.; // TODO: not implemented yet
+}
+
+Real
+PorousFlowBrine::pSat(Real temperature, Real xnacl) const
+{
+  // Temperature in K
+  Real tk = temperature + _t_c2k;
+
+  // Correlation requires molar concentration (mol/kg)
+  Real mol = xnacl / ((1.0 - xnacl) * _Mnacl);
+  Real mol2 = mol * mol;
+  Real mol3 = mol2 * mol;
+
+  Real a = 1.0 + 5.93582e-6 * mol - 5.19386e-5 * mol2 + 1.23156e-5 * mol3;
+  Real b = 1.1542e-6 * mol + 1.41254e-7 * mol2 - 1.92476e-8 * mol3 - 1.70717e-9 * mol * mol3
+           + 1.0539e-10 * mol2 * mol3;
+
+  // The temperature of pure water at the same pressure as the brine is given by
+  // Note that this correlation uses temperature in K, not C
+  Real th20 = std::exp(std::log(tk) / (a + b * tk)) - _t_c2k;
+
+  // The brine vapour pressure is then found by evaluating the saturation pressure for pure water
+  // using this effective temperature
+  return PorousFlowWater::pSat(th20);
+}
+
+Real
+PorousFlowBrine::dViscosity_dDensity(Real temperature, Real water_density, Real xnacl) const
+{
+  // Correlation requires molar concentration (mol/kg)
+  Real mol = xnacl / ((1.0 - xnacl) * _Mnacl);
+  Real mol2 = mol * mol;
+  Real mol3 = mol2 * mol;
+
+  Real a = 1.0 + 0.0816 * mol + 0.0122 * mol2 + 0.128e-3 * mol3 + 0.629e-3 * temperature
+         * (1.0 - std::exp(-0.7 * mol));
+
+  // The brine viscosity is then given by a multiplied by the viscosity of pure water. Note
+  // that the density is the density of pure water.
+  return a * PorousFlowWater::dViscosity_dDensity(temperature, water_density);
+}
+
+Real
+PorousFlowBrine::haliteDensity(Real pressure, Real temperature) const
+{
+  // Correlation needs pressure in bar
+  Real pbar = pressure * 1.e-5;
+
+  // Halite density at 0 Pa
+  Real density_P0 = 2.17043e3 - 2.4599e-1 * temperature - 9.5797e-5 * temperature * temperature;
+
+  // Halite density as a function of pressure
+  Real l = 5.727e-3 + 2.715e-3 * std::exp(temperature / 733.4);
+
+  return density_P0 + l * pbar;
+}
+
+Real
+PorousFlowBrine::haliteSolubility(Real temperature) const
+{
+  Real solubility = (26.18 + 7.2e-3 * temperature + 1.06e-4 * temperature * temperature) / 100.0;
+
+  return solubility;
+}

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureBase.C
@@ -1,0 +1,44 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowCapillaryPressureBase.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureBase>()
+{
+  InputParameters params = validParams<Material>();
+  params.addRequiredParam<unsigned int>("phase", "The phase number");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of PorousFlow variable names");
+  params.addClassDescription("Base class for PorousFlow capillary pressure materials");
+  return params;
+}
+
+PorousFlowCapillaryPressureBase::PorousFlowCapillaryPressureBase(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+
+    _phase_num(getParam<unsigned int>("phase")),
+    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _saturation_variable_name(_dictator_UO.saturationVariableNameDummy()),
+    _saturation_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
+    _saturation_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_qp")),
+    _capillary_pressure_nodal(declareProperty<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num))),
+    _dcapillary_pressure_nodal_ds(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _saturation_variable_name)),
+    _d2capillary_pressure_nodal_ds2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _saturation_variable_name, _saturation_variable_name)),
+    _capillary_pressure_qp(declareProperty<Real>("PorousFlow_capillary_pressure_qp" + Moose::stringify(_phase_num))),
+    _dcapillary_pressure_qp_ds(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_qp" + Moose::stringify(_phase_num), _saturation_variable_name)),
+    _d2capillary_pressure_qp_ds2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_qp" + Moose::stringify(_phase_num), _saturation_variable_name, _saturation_variable_name))
+{
+  if (_phase_num >= _dictator_UO.numPhases())
+    mooseError("PorousFlowCapillaryPressure: The Dictator proclaims that the number of fluid phases is " << _dictator_UO.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
+}
+
+void
+PorousFlowCapillaryPressureBase::computeQpProperties()
+{
+  mooseError("computeQpProperties() must be overriden in materials derived from PorousFlowCapillaryPressureBase");
+}

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureConstant.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureConstant.C
@@ -1,0 +1,37 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowCapillaryPressureConstant.h"
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureConstant>()
+{
+  InputParameters params = validParams<PorousFlowCapillaryPressureBase>();
+  params.addRequiredParam<Real>("capillary_pressure", "The capillary pressure (Pa)");
+  params.addClassDescription("This Material provides a constantant capillary pressure (Pa)");
+  return params;
+}
+
+PorousFlowCapillaryPressureConstant::PorousFlowCapillaryPressureConstant(const InputParameters & parameters) :
+    PorousFlowCapillaryPressureBase(parameters),
+    _pc(getParam<Real>("capillary_pressure"))
+{
+}
+
+void
+PorousFlowCapillaryPressureConstant::computeQpProperties()
+{
+  /// Capillary pressure and derivatives wrt phase saturation at the nodes
+  _capillary_pressure_nodal[_qp] = _pc;
+  _dcapillary_pressure_nodal_ds[_qp] = 0.0;
+  _d2capillary_pressure_nodal_ds2[_qp] = 0.0;
+
+  /// Capillary pressure and derivatives wrt phase saturation at the qps
+  _capillary_pressure_qp[_qp] = _pc;
+  _dcapillary_pressure_qp_ds[_qp] = 0.0;
+  _d2capillary_pressure_qp_ds2[_qp] = 0.0;
+}

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureLinear.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureLinear.C
@@ -1,0 +1,37 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowCapillaryPressureLinear.h"
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureLinear>()
+{
+  InputParameters params = validParams<PorousFlowCapillaryPressureBase>();
+  params.addRequiredParam<Real>("pc_max",  "Maximum capillary pressure (Pa)");
+  params.addClassDescription("This Material provides a linear capillary pressure");
+  return params;
+}
+
+PorousFlowCapillaryPressureLinear::PorousFlowCapillaryPressureLinear(const InputParameters & parameters) :
+  PorousFlowCapillaryPressureBase(parameters),
+  _pc_max(getParam<Real>("pc_max"))
+{
+}
+
+void
+PorousFlowCapillaryPressureLinear::computeQpProperties()
+{
+  /// Capillary pressure and derivatives wrt phase saturation at the nodes
+  _capillary_pressure_nodal[_qp] = _pc_max * (1.0 - _saturation_nodal[_qp][_phase_num]);
+  _dcapillary_pressure_nodal_ds[_qp] = - _pc_max;
+  _d2capillary_pressure_nodal_ds2[_qp] = 0.0;
+
+  /// Capillary pressure and derivatives wrt phase saturation at the qps
+  _capillary_pressure_qp[_qp] = _pc_max * (1.0 - _saturation_qp[_qp][_phase_num]);
+  _dcapillary_pressure_qp_ds[_qp] = - _pc_max;
+  _d2capillary_pressure_qp_ds2[_qp] = 0.0;
+}

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGP.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGP.C
@@ -47,16 +47,12 @@ PorousFlowCapillaryPressureVGP::computeQpProperties()
 Real
 PorousFlowCapillaryPressureVGP::effectiveSaturation(Real pressure) const
 {
-  Real n, seff;
-
   if (pressure >= 0.0)
     return 1.0;
-  else
-  {
-    n = 1.0 / (1.0 - _m);
-    seff = 1.0 + std::pow(- _al * pressure, n);
-    return std::pow(seff, - _m);
-  }
+
+  const Real n = 1.0 / (1.0 - _m);
+  const Real seff = 1.0 + std::pow(- _al * pressure, n);
+  return std::pow(seff, - _m);
 }
 
 Real
@@ -64,14 +60,12 @@ PorousFlowCapillaryPressureVGP::dEffectiveSaturation(Real pressure) const
 {
   if (pressure >= 0.0)
     return 0.0;
-  else
-  {
-    Real n = 1.0 / (1.0 - _m);
-    Real inner = 1.0 + std::pow(- _al * pressure, n);
-    Real dinner_dp = - n * _al * std::pow(- _al * pressure, n - 1.0);
-    Real dseff_dp = - _m * std::pow(inner, - _m - 1.0) * dinner_dp;
-    return dseff_dp;
-  }
+
+  const Real n = 1.0 / (1.0 - _m);
+  const Real inner = 1.0 + std::pow(- _al * pressure, n);
+  const Real dinner_dp = - n * _al * std::pow(- _al * pressure, n - 1.0);
+  const Real dseff_dp = - _m * std::pow(inner, - _m - 1.0) * dinner_dp;
+  return dseff_dp;
 }
 
 Real
@@ -79,13 +73,11 @@ PorousFlowCapillaryPressureVGP::d2EffectiveSaturation(Real pressure) const
 {
   if (pressure >= 0.0)
     return 0.0;
-  else
-  {
-    Real n = 1.0 / (1.0 - _m);
-    Real inner = 1.0 + std::pow(- _al * pressure, n);
-    Real dinner_dp = - n * _al * std::pow(- _al * pressure, n - 1.0);
-    Real d2inner_dp2 = n * (n - 1.0) * _al * _al * std::pow(- _al * pressure, n - 2.0);
-    Real d2seff_dp2 = _m * (_m + 1.0) * std::pow(inner, - _m - 2.0) * std::pow(dinner_dp, 2.0) - _m * std::pow(inner, - _m - 1.0) * d2inner_dp2;
-    return d2seff_dp2;
-  }
+
+  const Real n = 1.0 / (1.0 - _m);
+  const Real inner = 1.0 + std::pow(- _al * pressure, n);
+  const Real dinner_dp = - n * _al * std::pow(- _al * pressure, n - 1.0);
+  const Real d2inner_dp2 = n * (n - 1.0) * _al * _al * std::pow(- _al * pressure, n - 2.0);
+  const Real d2seff_dp2 = _m * (_m + 1.0) * std::pow(inner, - _m - 2.0) * std::pow(dinner_dp, 2.0) - _m * std::pow(inner, - _m - 1.0) * d2inner_dp2;
+  return d2seff_dp2;
 }

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGP.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGP.C
@@ -1,0 +1,91 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowCapillaryPressureVGP.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureVGP>()
+{
+  InputParameters params = validParams<PorousFlowCapillaryPressureBase>();
+  params.addRequiredRangeCheckedParam<Real>("al", "al > 0", "van Genuchten alpha parameter.  Must be positive.  effectiveSaturation = (1 + (-al*P)^(1/(1-m)))^(-m), where P = phase0_porepressure - phase1_porepressure <= 0");
+  params.addRequiredRangeCheckedParam<Real>("m", "m > 0 & m < 1", "van Genuchten m parameter.  Must be between 0 and 1, and optimally should be set to >0.5   EffectiveSaturation = (1 + (-al*p)^(1/(1-m)))^(-m)");
+  params.addClassDescription("This Material provides a van Genuchten effective saturation as a function of pore pressure");
+  return params;
+}
+
+PorousFlowCapillaryPressureVGP::PorousFlowCapillaryPressureVGP(const InputParameters & parameters) :
+    PorousFlowCapillaryPressureBase(parameters),
+    _pressure_variable_name(_dictator_UO.pressureVariableNameDummy()),
+    _porepressure_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_nodal")),
+    _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
+    _dcapillary_pressure_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _d2capillary_pressure_nodal_dp2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _pressure_variable_name, _pressure_variable_name)),
+    _al(getParam<Real>("al")),
+    _m(getParam<Real>("m"))
+{
+}
+
+void
+PorousFlowCapillaryPressureVGP::computeQpProperties()
+{
+  /// Capillary pressure (really effecive saturation) and derivatives wrt phase pore pressure at the nodes
+  _capillary_pressure_nodal[_qp] = effectiveSaturation(_porepressure_nodal[_qp][_phase_num]);
+  _dcapillary_pressure_nodal_ds[_qp] = dEffectiveSaturation(_porepressure_nodal[_qp][_phase_num]);
+  _d2capillary_pressure_nodal_ds2[_qp] = d2EffectiveSaturation(_porepressure_nodal[_qp][_phase_num]);
+
+  /// Capillary pressure (really effecive saturation) and derivatives wrt phase pore pressure at the qps
+  _capillary_pressure_qp[_qp] = effectiveSaturation(_porepressure_qp[_qp][_phase_num]);
+  _dcapillary_pressure_qp_ds[_qp] = dEffectiveSaturation(_porepressure_qp[_qp][_phase_num]);
+  _d2capillary_pressure_qp_ds2[_qp] = d2EffectiveSaturation(_porepressure_qp[_qp][_phase_num]);
+}
+
+Real
+PorousFlowCapillaryPressureVGP::effectiveSaturation(Real pressure) const
+{
+  Real n, seff;
+
+  if (pressure >= 0.0)
+    return 1.0;
+  else
+  {
+    n = 1.0 / (1.0 - _m);
+    seff = 1.0 + std::pow(- _al * pressure, n);
+    return std::pow(seff, - _m);
+  }
+}
+
+Real
+PorousFlowCapillaryPressureVGP::dEffectiveSaturation(Real pressure) const
+{
+  if (pressure >= 0.0)
+    return 0.0;
+  else
+  {
+    Real n = 1.0 / (1.0 - _m);
+    Real inner = 1.0 + std::pow(- _al * pressure, n);
+    Real dinner_dp = - n * _al * std::pow(- _al * pressure, n - 1.0);
+    Real dseff_dp = - _m * std::pow(inner, - _m - 1.0) * dinner_dp;
+    return dseff_dp;
+  }
+}
+
+Real
+PorousFlowCapillaryPressureVGP::d2EffectiveSaturation(Real pressure) const
+{
+  if (pressure >= 0.0)
+    return 0.0;
+  else
+  {
+    Real n = 1.0 / (1.0 - _m);
+    Real inner = 1.0 + std::pow(- _al * pressure, n);
+    Real dinner_dp = - n * _al * std::pow(- _al * pressure, n - 1.0);
+    Real d2inner_dp2 = n * (n - 1.0) * _al * _al * std::pow(- _al * pressure, n - 2.0);
+    Real d2seff_dp2 = _m * (_m + 1.0) * std::pow(inner, - _m - 2.0) * std::pow(dinner_dp, 2.0) - _m * std::pow(inner, - _m - 1.0) * d2inner_dp2;
+    return d2seff_dp2;
+  }
+}

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGS.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGS.C
@@ -1,0 +1,84 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowCapillaryPressureVGS.h"
+
+template<>
+InputParameters validParams<PorousFlowCapillaryPressureVGS>()
+{
+  InputParameters params = validParams<PorousFlowCapillaryPressureBase>();
+  params.addRequiredRangeCheckedParam<Real>("sat_lr", "sat_lr >= 0 & sat_lr <= 1", "Liquid residual saturation.  Must be between 0 and 1");
+  params.addRequiredRangeCheckedParam<Real>("sat_ls", "sat_ls >= 0 & sat_ls <= 1", "Liquid fully saturated saturation.  Must be between 0 and 1");
+  params.addRequiredRangeCheckedParam<Real>("m", "m >= 0 & m <= 1", "van Genuchten exponent m");
+  params.addRequiredParam<Real>("pc_max", "Maximum capillary pressure");
+  params.addRequiredParam<Real>("p0", "Capillary pressure coefficient P0");
+  params.addClassDescription("This Material provides a van Genuchten capillary pressure as a function of phase saturation");
+  return params;
+}
+
+PorousFlowCapillaryPressureVGS::PorousFlowCapillaryPressureVGS(const InputParameters & parameters) :
+  PorousFlowCapillaryPressureBase(parameters),
+  _sat_lr(getParam<Real>("sat_lr")),
+  _sat_ls(getParam<Real>("sat_ls")),
+  _m(getParam<Real>("m")),
+  _pc_max(getParam<Real>("pc_max")),
+  _p0(getParam<Real>("p0"))
+{
+}
+
+void
+PorousFlowCapillaryPressureVGS::computeQpProperties()
+{
+  /// Capillary pressure and derivatives wrt phase saturation at the nodes
+  _capillary_pressure_nodal[_qp] = _pc_max * (1.0 - _saturation_nodal[_qp][_phase_num]);
+  _dcapillary_pressure_nodal_ds[_qp] = - _pc_max;
+  _d2capillary_pressure_nodal_ds2[_qp] = 0.0;
+
+  /// Capillary pressure and derivatives wrt phase saturation at the qps
+  _capillary_pressure_qp[_qp] = _pc_max * (1.0 - _saturation_qp[_qp][_phase_num]);
+  _dcapillary_pressure_qp_ds[_qp] = - _pc_max;
+  _d2capillary_pressure_qp_ds2[_qp] = 0.0;
+}
+
+Real
+PorousFlowCapillaryPressureVGS::effectiveSaturation(Real saturation) const
+{
+  return (saturation - _sat_lr)/(_sat_ls - _sat_lr);
+}
+
+Real
+PorousFlowCapillaryPressureVGS::capillaryPressure(Real saturation) const
+{
+  Real sat_eff = effectiveSaturation(saturation);
+  Real cp = _p0 * std::pow(std::pow(sat_eff, -1.0/_m) - 1.0, 1.0 - _m);
+
+  /// Return the max of this and _cp_max
+  return std::max(cp, _pc_max);
+}
+
+Real
+PorousFlowCapillaryPressureVGS::dCapillaryPressure(Real saturation) const
+{
+  Real sat_eff = effectiveSaturation(saturation);
+
+  return _p0 * (1.0 - _m) * std::pow(std::pow(sat_eff, -1.0 / _m) - 1.0, -_m) * std::pow(sat_eff, -1.0 - 1.0 / _m) / (_m * (_sat_ls - _sat_lr));
+}
+
+Real
+PorousFlowCapillaryPressureVGS::d2CapillaryPressure(Real saturation) const
+{
+  Real d2cp;
+  Real a;
+  Real sat_eff = effectiveSaturation(saturation);
+
+  a = std::pow(sat_eff, -1.0 / _m) - 1.0;
+  d2cp = std::pow(a, -1.0 - _m) * std::pow(sat_eff, -2.0 - 2.0 / _m) - ((1.0 + _m) / _m) *std::pow(a, - _m) *
+    std::pow(sat_eff, -1.0 / _m - 2.0);
+  d2cp *= _p0 * (1.0 - _m) / _m / (_sat_ls - _sat_lr) / (_sat_ls - _sat_lr);
+
+  return d2cp;
+}

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGS.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGS.C
@@ -21,12 +21,12 @@ InputParameters validParams<PorousFlowCapillaryPressureVGS>()
 }
 
 PorousFlowCapillaryPressureVGS::PorousFlowCapillaryPressureVGS(const InputParameters & parameters) :
-  PorousFlowCapillaryPressureBase(parameters),
-  _sat_lr(getParam<Real>("sat_lr")),
-  _sat_ls(getParam<Real>("sat_ls")),
-  _m(getParam<Real>("m")),
-  _pc_max(getParam<Real>("pc_max")),
-  _p0(getParam<Real>("p0"))
+    PorousFlowCapillaryPressureBase(parameters),
+    _sat_lr(getParam<Real>("sat_lr")),
+    _sat_ls(getParam<Real>("sat_ls")),
+    _m(getParam<Real>("m")),
+    _pc_max(getParam<Real>("pc_max")),
+    _p0(getParam<Real>("p0"))
 {
 }
 
@@ -47,14 +47,14 @@ PorousFlowCapillaryPressureVGS::computeQpProperties()
 Real
 PorousFlowCapillaryPressureVGS::effectiveSaturation(Real saturation) const
 {
-  return (saturation - _sat_lr)/(_sat_ls - _sat_lr);
+  return (saturation - _sat_lr) / (_sat_ls - _sat_lr);
 }
 
 Real
 PorousFlowCapillaryPressureVGS::capillaryPressure(Real saturation) const
 {
   Real sat_eff = effectiveSaturation(saturation);
-  Real cp = _p0 * std::pow(std::pow(sat_eff, -1.0/_m) - 1.0, 1.0 - _m);
+  Real cp = _p0 * std::pow(std::pow(sat_eff, -1.0 / _m) - 1.0, 1.0 - _m);
 
   /// Return the max of this and _cp_max
   return std::max(cp, _pc_max);

--- a/modules/porous_flow/src/materials/PorousFlowDensityConstBulk.C
+++ b/modules/porous_flow/src/materials/PorousFlowDensityConstBulk.C
@@ -1,0 +1,62 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowDensityConstBulk.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowDensityConstBulk>()
+{
+  InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
+  params.addRequiredParam<Real>("density_P0", "The density of each phase at zero porepressure");
+  params.addRequiredParam<Real>("bulk_modulus", "The constant bulk modulus of each phase");
+  params.addClassDescription("This Material calculates a fluid density from its porepressure, assuming constant bulk modulus for the fluid");
+  return params;
+}
+
+PorousFlowDensityConstBulk::PorousFlowDensityConstBulk(const InputParameters & parameters) :
+    PorousFlowFluidPropertiesBase(parameters),
+
+    _dens0(getParam<Real>("density_P0")),
+    _bulk(getParam<Real>("bulk_modulus")),
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name))
+{
+}
+
+void
+PorousFlowDensityConstBulk::initQpStatefulProperties()
+{
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num]);
+}
+
+void
+PorousFlowDensityConstBulk::computeQpProperties()
+{
+  /// Density and derivatives wrt pressure at the nodes
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num]);
+  _ddensity_nodal_dp[_qp] = dDensity_dP(_porepressure_nodal[_qp][_phase_num]);
+
+  /// Density and derivatives wrt pressure at the qps
+  _density_qp[_qp] = density(_porepressure_qp[_qp][_phase_num]);
+  _ddensity_qp_dp[_qp] = dDensity_dP(_porepressure_qp[_qp][_phase_num]);
+}
+
+Real
+PorousFlowDensityConstBulk::density(Real pressure) const
+{
+  return _dens0 * std::exp(pressure / _bulk);
+}
+
+Real
+PorousFlowDensityConstBulk::dDensity_dP(Real pressure) const
+{
+  return density(pressure) / _bulk;
+}

--- a/modules/porous_flow/src/materials/PorousFlowEffectiveFluidPressure.C
+++ b/modules/porous_flow/src/materials/PorousFlowEffectiveFluidPressure.C
@@ -1,0 +1,59 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowEffectiveFluidPressure.h"
+
+template<>
+InputParameters validParams<PorousFlowEffectiveFluidPressure>()
+{
+  InputParameters params = validParams<Material>();
+
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addClassDescription("This Material calculates an effective fluid pressure: effective_stress = total_stress + biot_coeff*effective_fluid_pressure.  The effective_fluid_pressure = sum_{phases}(S_phase * P_phase)");
+  return params;
+}
+
+PorousFlowEffectiveFluidPressure::PorousFlowEffectiveFluidPressure(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+
+    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _num_ph(_dictator_UO.numPhases()),
+    _num_var(_dictator_UO.numVariables()),
+
+    _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
+    _dporepressure_qp_dvar(getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_porepressure_qp_dvar")),
+    _saturation_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_qp")),
+    _dsaturation_qp_dvar(getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_saturation_qp_dvar")),
+    _porepressure_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_nodal")),
+    _dporepressure_nodal_dvar(getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_porepressure_nodal_dvar")),
+    _saturation_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
+    _dsaturation_nodal_dvar(getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_saturation_nodal_dvar")),
+    _pf_qp(declareProperty<Real>("PorousFlow_effective_fluid_pressure_qp")),
+    _dpf_qp_dvar(declareProperty<std::vector<Real> >("dPorousFlow_effective_fluid_pressure_qp_dvar")),
+    _pf_nodal(declareProperty<Real>("PorousFlow_effective_fluid_pressure_nodal")),
+    _dpf_nodal_dvar(declareProperty<std::vector<Real> >("dPorousFlow_effective_fluid_pressure_nodal_dvar"))
+{
+}
+
+void
+PorousFlowEffectiveFluidPressure::computeQpProperties()
+{
+  _pf_qp[_qp] = 0;
+  _pf_nodal[_qp] = 0;
+  _dpf_qp_dvar[_qp].assign(_num_var, 0.0);
+  _dpf_nodal_dvar[_qp].assign(_num_var, 0.0);
+  for (unsigned ph = 0; ph < _num_ph; ++ph)
+  {
+    _pf_qp[_qp] += _saturation_qp[_qp][ph] * _porepressure_qp[_qp][ph];
+    _pf_nodal[_qp] += _saturation_nodal[_qp][ph] * _porepressure_nodal[_qp][ph];
+    for (unsigned v = 0; v < _num_var; ++v)
+    {
+      _dpf_qp_dvar[_qp][v] += _dsaturation_qp_dvar[_qp][ph][v] * _porepressure_qp[_qp][ph] + _saturation_qp[_qp][ph] * _dporepressure_qp_dvar[_qp][ph][v];
+      _dpf_nodal_dvar[_qp][v] += _dsaturation_nodal_dvar[_qp][ph][v] * _porepressure_nodal[_qp][ph] + _saturation_nodal[_qp][ph] * _dporepressure_nodal_dvar[_qp][ph][v];
+    }
+  }
+}

--- a/modules/porous_flow/src/materials/PorousFlowEffectiveFluidPressure.C
+++ b/modules/porous_flow/src/materials/PorousFlowEffectiveFluidPressure.C
@@ -42,8 +42,8 @@ PorousFlowEffectiveFluidPressure::PorousFlowEffectiveFluidPressure(const InputPa
 void
 PorousFlowEffectiveFluidPressure::computeQpProperties()
 {
-  _pf_qp[_qp] = 0;
-  _pf_nodal[_qp] = 0;
+  _pf_qp[_qp] = 0.0;
+  _pf_nodal[_qp] = 0.0;
   _dpf_qp_dvar[_qp].assign(_num_var, 0.0);
   _dpf_nodal_dvar[_qp].assign(_num_var, 0.0);
   for (unsigned ph = 0; ph < _num_ph; ++ph)

--- a/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
@@ -1,0 +1,44 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowFluidPropertiesBase.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowFluidPropertiesBase>()
+{
+  InputParameters params = validParams<Material>();
+  params.addRequiredParam<unsigned int>("phase", "The phase number");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of PorousFlow variable names");
+  params.addClassDescription("Base class for PorousFlow fluid materials");
+  return params;
+}
+
+PorousFlowFluidPropertiesBase::PorousFlowFluidPropertiesBase(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+
+    _phase_num(getParam<unsigned int>("phase")),
+    _porepressure_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_nodal")),
+    _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
+    _temperature_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_temperature_nodal")),
+    _temperature_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_temperature_qp")),
+    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _pressure_variable_name(_dictator_UO.pressureVariableNameDummy()),
+    _temperature_variable_name(_dictator_UO.temperatureVariableNameDummy()),
+    _t_c2k(273.15),
+    _R(8.3144621)
+{
+  if (_phase_num >= _dictator_UO.numPhases())
+    mooseError("PorousFlowFluidProperties: The Dictator proclaims that the number of fluid phases is " << _dictator_UO.numPhases() << " while you have foolishly entered phase = " << _phase_num << " in " << _name << ".  Be aware that the Dictator does not tolerate mistakes.");
+}
+
+void
+PorousFlowFluidPropertiesBase::computeQpProperties()
+{
+  mooseError("computeQpProperties() must be overriden in materials derived from PorousFlowFluidPropertiesBase");
+}
+

--- a/modules/porous_flow/src/materials/PorousFlowIdealGas.C
+++ b/modules/porous_flow/src/materials/PorousFlowIdealGas.C
@@ -1,0 +1,71 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowIdealGas.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowIdealGas>()
+{
+  InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
+  params.addRequiredParam<Real>("molar_mass", "The molar mass of the Ideal gas (kg/mol)");
+  params.addClassDescription("This Material calculates fluid density for an ideal gas");
+  return params;
+}
+
+PorousFlowIdealGas::PorousFlowIdealGas(const InputParameters & parameters) :
+    PorousFlowFluidPropertiesBase(parameters),
+
+    _molar_mass(getParam<Real>("molar_mass")),
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name))
+{
+}
+
+void
+PorousFlowIdealGas::initQpStatefulProperties()
+{
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _molar_mass);
+}
+
+void
+PorousFlowIdealGas::computeQpProperties()
+{
+  /// Density and derivatives wrt pressure and temperature at the nodes
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _molar_mass);
+  _ddensity_nodal_dp[_qp] = dDensity_dP(_temperature_nodal[_qp][_phase_num], _molar_mass);
+  _ddensity_nodal_dt[_qp] = dDensity_dT(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _molar_mass);
+
+  /// Density and derivatives wrt pressure and temperature at the qps
+  _density_qp[_qp] = density(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num], _molar_mass);
+  _ddensity_qp_dp[_qp] = dDensity_dP(_temperature_qp[_qp][_phase_num], _molar_mass);
+  _ddensity_qp_dt[_qp] = dDensity_dT(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num], _molar_mass);
+}
+
+Real
+PorousFlowIdealGas::density(Real pressure, Real temperature, Real molar_mass) const
+{
+  return pressure * molar_mass / (_R * (temperature + _t_c2k));
+}
+
+Real
+PorousFlowIdealGas::dDensity_dP(Real temperature, Real molar_mass) const
+{
+  return molar_mass / (_R * (temperature + _t_c2k));
+}
+
+Real
+PorousFlowIdealGas::dDensity_dT(Real pressure, Real temperature, Real molar_mass) const
+{
+  Real tk = temperature + _t_c2k;
+  return - pressure * molar_mass / (_R * tk * tk);
+}

--- a/modules/porous_flow/src/materials/PorousFlowMethane.C
+++ b/modules/porous_flow/src/materials/PorousFlowMethane.C
@@ -1,0 +1,122 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowMethane.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowMethane>()
+{
+  InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
+  params.addClassDescription("This Material calculates fluid properties for methane");
+  return params;
+}
+
+PorousFlowMethane::PorousFlowMethane(const InputParameters & parameters) :
+    PorousFlowFluidPropertiesBase(parameters),
+
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num))),
+    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _Mch4(16.0425e-3)
+{
+}
+
+void
+PorousFlowMethane::initQpStatefulProperties()
+{
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+}
+
+void
+PorousFlowMethane::computeQpProperties()
+{
+  /// Density and derivatives wrt pressure and temperature at the nodes
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+  _ddensity_nodal_dp[_qp] = dDensity_dP(_temperature_nodal[_qp][_phase_num]);
+  _ddensity_nodal_dt[_qp] = dDensity_dT(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+
+  /// Density and derivatives wrt pressure and temperature at the qps
+  _density_qp[_qp] = density(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num]);
+  _ddensity_qp_dp[_qp] = dDensity_dP(_temperature_qp[_qp][_phase_num]);
+  _ddensity_qp_dt[_qp] = dDensity_dT(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num]);
+
+  /// Viscosity and derivative wrt temperature at the nodes
+  _viscosity_nodal[_qp] = viscosity(_temperature_nodal[_qp][_phase_num]);
+  _dviscosity_nodal_dt[_qp] = dViscosity_dT(_temperature_nodal[_qp][_phase_num]);
+}
+
+Real
+PorousFlowMethane::density(Real pressure, Real temperature) const
+{
+  return pressure * _Mch4 / (_R * (temperature + _t_c2k));
+}
+
+Real
+PorousFlowMethane::dDensity_dP(Real temperature) const
+{
+  return _Mch4 / (_R * (temperature + _t_c2k));
+}
+
+Real
+PorousFlowMethane::dDensity_dT(Real pressure, Real temperature) const
+{
+  Real tk = temperature + _t_c2k;
+  return - pressure * _Mch4 / (_R * tk * tk);
+}
+
+Real
+PorousFlowMethane::viscosity(Real temperature) const
+{
+  Real a[6] = {2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11,
+    -2.7237166e-14};
+
+  Real viscosity;
+  Real tk = temperature + _t_c2k;
+  Real tk2 = tk * tk;
+  Real tk3 = tk2 * tk;
+  Real tk4 = tk3 * tk;
+  Real tk5 = tk4 * tk;
+
+  viscosity = a[0] + a[1] * tk + a[2] * tk2 + a[3] * tk3 + a[4] * tk4 + a[5] * tk5;
+
+  return viscosity * 1.e-6;
+}
+
+Real
+PorousFlowMethane::dViscosity_dT(Real temperature) const
+{
+  Real a[6] = {2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11,
+    -2.7237166e-14};
+
+  Real dviscosity;
+  Real tk = temperature + _t_c2k;
+  Real tk2 = tk * tk;
+  Real tk3 = tk2 * tk;
+  Real tk4 = tk3 * tk;
+
+  dviscosity = a[1] + 2.0 * a[2] * tk + 3.0 * a[3] * tk2 + 4.0 * a[4] * tk3 + 5.0 * a[5] * tk4;
+
+  return dviscosity * 1.e-6;
+}
+
+std::vector<Real>
+PorousFlowMethane::henryConstants() const
+{
+  std::vector<Real> ch4henry;
+  ch4henry.push_back(-10.44708);
+  ch4henry.push_back(4.66491);
+  ch4henry.push_back(12.12986);
+
+  return ch4henry;
+}

--- a/modules/porous_flow/src/materials/PorousFlowMethane.C
+++ b/modules/porous_flow/src/materials/PorousFlowMethane.C
@@ -71,22 +71,22 @@ PorousFlowMethane::dDensity_dP(Real temperature) const
 Real
 PorousFlowMethane::dDensity_dT(Real pressure, Real temperature) const
 {
-  Real tk = temperature + _t_c2k;
+  const Real tk = temperature + _t_c2k;
   return - pressure * _Mch4 / (_R * tk * tk);
 }
 
 Real
 PorousFlowMethane::viscosity(Real temperature) const
 {
-  Real a[6] = {2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11,
+  const Real a[6] = {2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11,
     -2.7237166e-14};
 
   Real viscosity;
-  Real tk = temperature + _t_c2k;
-  Real tk2 = tk * tk;
-  Real tk3 = tk2 * tk;
-  Real tk4 = tk3 * tk;
-  Real tk5 = tk4 * tk;
+  const Real tk = temperature + _t_c2k;
+  const Real tk2 = tk * tk;
+  const Real tk3 = tk2 * tk;
+  const Real tk4 = tk3 * tk;
+  const Real tk5 = tk4 * tk;
 
   viscosity = a[0] + a[1] * tk + a[2] * tk2 + a[3] * tk3 + a[4] * tk4 + a[5] * tk5;
 
@@ -96,14 +96,14 @@ PorousFlowMethane::viscosity(Real temperature) const
 Real
 PorousFlowMethane::dViscosity_dT(Real temperature) const
 {
-  Real a[6] = {2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11,
+  const Real a[6] = {2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11,
     -2.7237166e-14};
 
   Real dviscosity;
-  Real tk = temperature + _t_c2k;
-  Real tk2 = tk * tk;
-  Real tk3 = tk2 * tk;
-  Real tk4 = tk3 * tk;
+  const Real tk = temperature + _t_c2k;
+  const Real tk2 = tk * tk;
+  const Real tk3 = tk2 * tk;
+  const Real tk4 = tk3 * tk;
 
   dviscosity = a[1] + 2.0 * a[2] * tk + 3.0 * a[3] * tk2 + 4.0 * a[4] * tk3 + 5.0 * a[5] * tk4;
 

--- a/modules/porous_flow/src/materials/PorousFlowPermeabilityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowPermeabilityConst.C
@@ -1,0 +1,46 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowPermeabilityConst.h"
+
+template<>
+InputParameters validParams<PorousFlowPermeabilityConst>()
+{
+  InputParameters params = validParams<Material>();
+
+  params.addRequiredParam<RealTensorValue>("permeability", "The permeability tensor (usually in m^2), which is assumed constant for this material");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addClassDescription("This Material calculates the permeability tensor assuming it is constant");
+  return params;
+}
+
+PorousFlowPermeabilityConst::PorousFlowPermeabilityConst(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+
+    _input_permeability(getParam<RealTensorValue>("permeability")),
+    _PorousFlow_name_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+
+    _permeability(declareProperty<RealTensorValue>("PorousFlow_permeability")),
+    _dpermeability_dvar(declareProperty<std::vector<RealTensorValue> >("dPorousFlow_permeability_dvar"))
+{
+}
+
+void
+PorousFlowPermeabilityConst::initQpStatefulProperties()
+{
+  _permeability[_qp] = _input_permeability;
+}
+
+void
+PorousFlowPermeabilityConst::computeQpProperties()
+{
+  _permeability[_qp] = _input_permeability;
+
+  const unsigned int num_var = _PorousFlow_name_UO.numVariables();
+  _dpermeability_dvar[_qp].resize(num_var, RealTensorValue());
+}
+

--- a/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
@@ -1,0 +1,46 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowPorosityConst.h"
+
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowPorosityConst>()
+{
+  InputParameters params = validParams<PorousFlowPorosityUnity>();
+  params.addRequiredParam<Real>("porosity", "The porosity, which is assumed constant for this material");
+  params.addClassDescription("This Material calculates the porosity assuming it is constant");
+  return params;
+}
+
+PorousFlowPorosityConst::PorousFlowPorosityConst(const InputParameters & parameters) :
+    PorousFlowPorosityUnity(parameters),
+    _input_porosity(getParam<Real>("porosity"))
+{
+}
+
+void
+PorousFlowPorosityConst::initQpStatefulProperties()
+{
+  _porosity_nodal[_qp] = _input_porosity; // this becomes _porosity_old[_qp] in the first call to computeQpProperties
+  _porosity_qp[_qp] = _input_porosity; // this becomes _porosity_old[_qp] in the first call to computeQpProperties
+
+  const unsigned int num_var = _dictator_UO.numVariables();
+  _dporosity_nodal_dvar[_qp].resize(num_var, 0.0);
+  _dporosity_qp_dvar[_qp].resize(num_var, 0.0);
+  _dporosity_nodal_dgradvar[_qp].resize(num_var, RealGradient());
+  _dporosity_qp_dgradvar[_qp].resize(num_var, RealGradient());
+}
+
+void
+PorousFlowPorosityConst::computeQpProperties()
+{
+  _porosity_nodal[_qp] = _input_porosity;
+  _porosity_qp[_qp] = _input_porosity;
+}
+

--- a/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
@@ -31,10 +31,10 @@ PorousFlowPorosityConst::initQpStatefulProperties()
   _porosity_qp[_qp] = _input_porosity; // this becomes _porosity_old[_qp] in the first call to computeQpProperties
 
   const unsigned int num_var = _dictator_UO.numVariables();
-  _dporosity_nodal_dvar[_qp].resize(num_var, 0.0);
-  _dporosity_qp_dvar[_qp].resize(num_var, 0.0);
-  _dporosity_nodal_dgradvar[_qp].resize(num_var, RealGradient());
-  _dporosity_qp_dgradvar[_qp].resize(num_var, RealGradient());
+  _dporosity_nodal_dvar[_qp].assign(num_var, 0.0);
+  _dporosity_qp_dvar[_qp].assign(num_var, 0.0);
+  _dporosity_nodal_dgradvar[_qp].assign(num_var, RealGradient());
+  _dporosity_qp_dgradvar[_qp].assign(num_var, RealGradient());
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowPorosityHM.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityHM.C
@@ -1,0 +1,84 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowPorosityHM.h"
+
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowPorosityHM>()
+{
+  InputParameters params = validParams<PorousFlowPorosityUnity>();
+
+  params.addRequiredParam<Real>("porosity_zero", "The porosity at zero volumetric strain and zero effective porepressure");
+  params.addRangeCheckedParam<Real>("biot_coefficient", 1, "biot_coefficient>=0&biot_coefficient<=1", "Biot coefficient");
+  params.addRequiredRangeCheckedParam<Real>("solid_bulk", "solid_bulk>0", "Bulk modulus of the drained porous solid skeleton");
+  params.addRequiredCoupledVar("displacements", "The solid-mechanics displacement variables");
+  params.addClassDescription("This Material calculates the porosity for hydro-mechanical simulations");
+  return params;
+}
+
+PorousFlowPorosityHM::PorousFlowPorosityHM(const InputParameters & parameters) :
+    PorousFlowPorosityUnity(parameters),
+
+    _phi0(getParam<Real>("porosity_zero")),
+    _biot(getParam<Real>("biot_coefficient")),
+    _solid_bulk(getParam<Real>("solid_bulk")),
+    _num_var(_dictator_UO.numVariables()),
+    _coeff((_biot - 1.0)/_solid_bulk),
+
+    _ndisp(coupledComponents("displacements")),
+    _disp_var_num(_ndisp),
+
+    _vol_strain_qp(getMaterialProperty<Real>("PorousFlow_total_volumetric_strain_qp")), // TODO: perhaps can put temperature here at some stage?
+    _dvol_strain_qp_dvar(getMaterialProperty<std::vector<RealGradient> >("dPorousFlow_total_volumetric_strain_qp_dvar")),
+
+    _pf_nodal(getMaterialProperty<Real>("PorousFlow_effective_fluid_pressure_nodal")),
+    _dpf_nodal_dvar(getMaterialProperty<std::vector<Real> >("dPorousFlow_effective_fluid_pressure_nodal_dvar")),
+    _pf_qp(getMaterialProperty<Real>("PorousFlow_effective_fluid_pressure_qp")),
+    _dpf_qp_dvar(getMaterialProperty<std::vector<Real> >("dPorousFlow_effective_fluid_pressure_qp_dvar"))
+{
+  for (unsigned i = 0 ; i < _ndisp ; ++i)
+    _disp_var_num[i] = coupled("displacements", i);
+}
+
+void
+PorousFlowPorosityHM::initQpStatefulProperties()
+{
+  _porosity_nodal[_qp] = _phi0;
+  _porosity_qp[_qp] = _phi0;
+}
+
+void
+PorousFlowPorosityHM::computeQpProperties()
+{
+  // Note that in the following _strain[_qp] is evaluated at the quadpoint
+  // _pf_nodal[_qp] is actually the nodal value (it is just stored at the quadpoint).
+  // So _porosity_nodal[_qp], which should be the nodal value of porosity (but
+  // stored at the quadpoint) actually uses the strain at the quadpoint.  This
+  // is OK for LINEAR elements, as strain is constant over the element anyway.
+
+  _porosity_nodal[_qp] = _biot + (_phi0 - _biot) * std::exp(-_vol_strain_qp[_qp] + _coeff * _pf_nodal[_qp]);
+  _porosity_qp[_qp] = _biot + (_phi0 - _biot) * std::exp(-_vol_strain_qp[_qp] + _coeff * _pf_qp[_qp]);
+
+  _dporosity_qp_dvar[_qp].resize(_num_var, 0.0);
+  _dporosity_nodal_dvar[_qp].resize(_num_var, 0.0);
+  for (unsigned v = 0; v < _num_var; ++v)
+  {
+    _dporosity_qp_dvar[_qp][v] = _coeff * _dpf_qp_dvar[_qp][v] * (_porosity_qp[_qp] - _biot);
+    _dporosity_nodal_dvar[_qp][v] = _coeff * _dpf_nodal_dvar[_qp][v] * (_porosity_nodal[_qp] - _biot);
+  }
+
+  _dporosity_qp_dgradvar[_qp].resize(_num_var, RealGradient());
+  _dporosity_nodal_dgradvar[_qp].resize(_num_var, RealGradient());
+  for (unsigned v = 0; v < _num_var; ++v)
+  {
+    _dporosity_qp_dgradvar[_qp][v] = -(_porosity_qp[_qp] - _biot) * _dvol_strain_qp_dvar[_qp][v];
+    _dporosity_nodal_dgradvar[_qp][v] = -(_porosity_nodal[_qp] - _biot) * _dvol_strain_qp_dvar[_qp][v];
+  }
+}
+

--- a/modules/porous_flow/src/materials/PorousFlowPorosityHM.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityHM.C
@@ -65,16 +65,16 @@ PorousFlowPorosityHM::computeQpProperties()
   _porosity_nodal[_qp] = _biot + (_phi0 - _biot) * std::exp(-_vol_strain_qp[_qp] + _coeff * _pf_nodal[_qp]);
   _porosity_qp[_qp] = _biot + (_phi0 - _biot) * std::exp(-_vol_strain_qp[_qp] + _coeff * _pf_qp[_qp]);
 
-  _dporosity_qp_dvar[_qp].resize(_num_var, 0.0);
-  _dporosity_nodal_dvar[_qp].resize(_num_var, 0.0);
+  _dporosity_qp_dvar[_qp].resize(_num_var);
+  _dporosity_nodal_dvar[_qp].resize(_num_var);
   for (unsigned v = 0; v < _num_var; ++v)
   {
     _dporosity_qp_dvar[_qp][v] = _coeff * _dpf_qp_dvar[_qp][v] * (_porosity_qp[_qp] - _biot);
     _dporosity_nodal_dvar[_qp][v] = _coeff * _dpf_nodal_dvar[_qp][v] * (_porosity_nodal[_qp] - _biot);
   }
 
-  _dporosity_qp_dgradvar[_qp].resize(_num_var, RealGradient());
-  _dporosity_nodal_dgradvar[_qp].resize(_num_var, RealGradient());
+  _dporosity_qp_dgradvar[_qp].resize(_num_var);
+  _dporosity_nodal_dgradvar[_qp].resize(_num_var);
   for (unsigned v = 0; v < _num_var; ++v)
   {
     _dporosity_qp_dgradvar[_qp][v] = -(_porosity_qp[_qp] - _biot) * _dvol_strain_qp_dvar[_qp][v];

--- a/modules/porous_flow/src/materials/PorousFlowPorosityUnity.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityUnity.C
@@ -1,0 +1,56 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowPorosityUnity.h"
+
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowPorosityUnity>()
+{
+  InputParameters params = validParams<Material>();
+
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addClassDescription("This Material calculates the porosity assuming it is equal to 1.0");
+  return params;
+}
+
+PorousFlowPorosityUnity::PorousFlowPorosityUnity(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+
+    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _porosity_nodal(declareProperty<Real>("PorousFlow_porosity_nodal")),
+    _porosity_nodal_old(declarePropertyOld<Real>("PorousFlow_porosity_nodal")),
+    _dporosity_nodal_dvar(declareProperty<std::vector<Real> >("dPorousFlow_porosity_nodal_dvar")),
+    _dporosity_nodal_dgradvar(declareProperty<std::vector<RealGradient> >("dPorousFlow_porosity_nodal_dgradvar")),
+    _porosity_qp(declareProperty<Real>("PorousFlow_porosity_qp")),
+    _porosity_qp_old(declarePropertyOld<Real>("PorousFlow_porosity_qp")),
+    _dporosity_qp_dvar(declareProperty<std::vector<Real> >("dPorousFlow_porosity_qp_dvar")),
+    _dporosity_qp_dgradvar(declareProperty<std::vector<RealGradient> >("dPorousFlow_porosity_qp_dgradvar"))
+{
+}
+
+void
+PorousFlowPorosityUnity::initQpStatefulProperties()
+{
+  _porosity_nodal[_qp] = 1.0;
+  _porosity_qp[_qp] = 1.0;
+
+  const unsigned int num_var = _dictator_UO.numVariables();
+  _dporosity_nodal_dvar[_qp].resize(num_var, 0.0);
+  _dporosity_qp_dvar[_qp].resize(num_var, 0.0);
+  _dporosity_nodal_dgradvar[_qp].resize(num_var, RealGradient());
+  _dporosity_qp_dgradvar[_qp].resize(num_var, RealGradient());
+}
+
+void
+PorousFlowPorosityUnity::computeQpProperties()
+{
+  _porosity_nodal[_qp] = 1.0;
+  _porosity_qp[_qp] = 1.0;
+}
+

--- a/modules/porous_flow/src/materials/PorousFlowPorosityUnity.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityUnity.C
@@ -41,10 +41,10 @@ PorousFlowPorosityUnity::initQpStatefulProperties()
   _porosity_qp[_qp] = 1.0;
 
   const unsigned int num_var = _dictator_UO.numVariables();
-  _dporosity_nodal_dvar[_qp].resize(num_var, 0.0);
-  _dporosity_qp_dvar[_qp].resize(num_var, 0.0);
-  _dporosity_nodal_dgradvar[_qp].resize(num_var, RealGradient());
-  _dporosity_qp_dgradvar[_qp].resize(num_var, RealGradient());
+  _dporosity_nodal_dvar[_qp].assign(num_var, 0.0);
+  _dporosity_qp_dvar[_qp].assign(num_var, 0.0);
+  _dporosity_nodal_dgradvar[_qp].assign(num_var, RealGradient());
+  _dporosity_qp_dgradvar[_qp].assign(num_var, RealGradient());
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityCorey.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityCorey.C
@@ -1,0 +1,35 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowRelativePermeabilityCorey.h"
+
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowRelativePermeabilityCorey>()
+{
+  InputParameters params = validParams<PorousFlowRelativePermeabilityUnity>();
+
+  params.addRequiredParam<Real>("n_j", "The Corey exponent of phase j.");
+  params.addRequiredParam<unsigned int>("phase", "The phase number j");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addClassDescription("This Material calculates relative permeability of either phase Sj, using the simple Corey model (Sj-Sjr)^n/(1-S1r-S2r)");
+  return params;
+}
+
+PorousFlowRelativePermeabilityCorey::PorousFlowRelativePermeabilityCorey(const InputParameters & parameters) :
+    PorousFlowRelativePermeabilityUnity(parameters),
+    _n(getParam<Real>("n_j"))
+{
+}
+
+void
+PorousFlowRelativePermeabilityCorey::computeQpProperties()
+{
+  _relative_permeability[_qp] = std::pow(_saturation_nodal[_qp][_phase_num], _n);
+  _drelative_permeability_ds[_qp] = _n * std::pow(_saturation_nodal[_qp][_phase_num], _n - 1.0);
+}

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityUnity.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityUnity.C
@@ -1,0 +1,40 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowRelativePermeabilityUnity.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowRelativePermeabilityUnity>()
+{
+  InputParameters params = validParams<Material>();
+  params.addRequiredParam<unsigned int>("phase", "The phase number for which to calculate the relative permeability for");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of PorousFlow variable names");
+  params.addClassDescription("Base class for PorousFlow relative permeability materials.  This class sets the relative permeability = 1");
+  return params;
+}
+
+PorousFlowRelativePermeabilityUnity::PorousFlowRelativePermeabilityUnity(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+
+    _phase_num(getParam<unsigned int>("phase")),
+    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _saturation_variable_name(_dictator_UO.saturationVariableNameDummy()),
+    _saturation_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
+    _relative_permeability(declareProperty<Real>("PorousFlow_relative_permeability" + Moose::stringify(_phase_num))),
+    _drelative_permeability_ds(declarePropertyDerivative<Real>("PorousFlow_relative_permeability" + Moose::stringify(_phase_num), _saturation_variable_name))
+{
+  if (_phase_num >= _dictator_UO.numPhases())
+    mooseError("PorousFlowRelativePermeability: The Dictator proclaims that the number of fluid phases is " << _dictator_UO.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
+}
+
+void
+PorousFlowRelativePermeabilityUnity::computeQpProperties()
+{
+  _relative_permeability[_qp] = 1.0;
+  _drelative_permeability_ds[_qp] = 0.0;
+}

--- a/modules/porous_flow/src/materials/PorousFlowSimpleCO2.C
+++ b/modules/porous_flow/src/materials/PorousFlowSimpleCO2.C
@@ -1,0 +1,562 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowSimpleCO2.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowSimpleCO2>()
+{
+  InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
+  params.addClassDescription("This Material calculates fluid properties for CO2");
+  return params;
+}
+
+PorousFlowSimpleCO2::PorousFlowSimpleCO2(const InputParameters & parameters) :
+    PorousFlowFluidPropertiesBase(parameters),
+
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num))),
+    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _Mco2(44.0e-3),
+    _p_critical(7.3773e6),
+    _t_critical(30.9782)
+{
+}
+
+void
+PorousFlowSimpleCO2::initQpStatefulProperties()
+{
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+}
+
+void
+PorousFlowSimpleCO2::computeQpProperties()
+{
+  /// Density and derivatives wrt pressure and temperature at the nodes
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+  _ddensity_nodal_dp[_qp] = dDensity_dP(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+  _ddensity_nodal_dt[_qp] = dDensity_dT(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+
+  /// Density and derivatives wrt pressure and temperature at the qps
+  _density_qp[_qp] = density(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num]);
+  _ddensity_qp_dp[_qp] = dDensity_dP(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num]);
+  _ddensity_qp_dt[_qp] = dDensity_dT(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num]);
+
+  /// Viscosity and derivative wrt temperature at the nodes
+  _viscosity_nodal[_qp] = viscosity(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _density_nodal[_qp]);
+  _dviscosity_nodal_dt[_qp] = dViscosity_dT(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num], _density_nodal[_qp]);
+}
+
+Real
+PorousFlowSimpleCO2::density(Real pressure, Real temperature) const
+{
+  Real rho;
+
+  if (pressure <= _p_critical)
+    rho = gasDensity(pressure, temperature);
+
+  else // if (pressure > _p_critical)
+    rho = supercriticalDensity(pressure, temperature);
+
+  return rho;
+}
+
+Real
+PorousFlowSimpleCO2::viscosity(Real pressure, Real temperature, Real density) const
+{
+  Real mu;
+
+  if (pressure <= _p_critical)
+    mu = gasViscosity(temperature, density);
+
+  else // if (pressure > _p_critical)
+    mu = supercriticalViscosity(pressure, temperature);
+
+  return mu;
+}
+
+Real
+PorousFlowSimpleCO2::dDensity_dP(Real pressure, Real temperature) const
+{
+  Real drho;
+
+  if (pressure <= _p_critical)
+    drho = dGasDensity_dP(pressure, temperature);
+
+  else // if (pressure > _p_critical)
+    drho = dSupercriticalDensity_dP(pressure, temperature);
+
+  return drho;
+}
+
+Real
+PorousFlowSimpleCO2::dDensity_dT(Real pressure, Real temperature) const
+{
+  Real drho;
+
+  if (pressure <= _p_critical)
+    drho = dGasDensity_dT(pressure, temperature);
+
+  else // if (pressure > _p_critical)
+    drho = dSupercriticalDensity_dT(pressure, temperature);
+
+  return drho;
+}
+
+Real
+PorousFlowSimpleCO2::gasViscosity(Real temperature, Real density) const
+{
+  Real tk = temperature + _t_c2k;
+  Real tstar = tk / 251.196;
+  Real a[5] = {0.235156, -0.491266, 5.211155e-2, 5.347906e-2, -1.537102e-2};
+  Real d[5] = {0.4071119e-2, 0.7198037e-4, 0.2411697e-16, 0.2971072e-22, -0.1627888e-22};
+  int j[5] = {1, 1, 4, 1, 2};
+  int i[5] = {1, 2, 6, 8, 8};
+
+  // Zero-denisty viscosity
+  Real sum = 0.0;
+
+  for (int n = 0; n < 5; ++n)
+    sum += a[n] * std::pow(std::log(tstar), n);
+
+  Real theta = std::exp(sum);
+  Real mu0 = 1.00697 * std::sqrt(tk) / theta;
+
+  Real b[5];
+  for (unsigned int n = 0; n < 5; ++n)
+    b[n] = d[n] /  std::pow(tstar, j[n] - 1);
+
+  // Excess viscosity due to density
+  Real mu = 0.0;
+
+  for (unsigned int n = 0; n < 5; ++n)
+    mu += b[n] * std::pow(density, i[n]);
+
+  return (mu0 + mu) * 1e-6; // convert to Pa.s
+}
+
+Real
+PorousFlowSimpleCO2::supercriticalViscosity(Real pressure, Real temperature) const
+{
+  Real b0[5] = {-1.958098980443E+01, 1.123243298270E+00, -2.320378874100E-02,
+    2.067060943050E-04, -6.740205984528E-07};
+  Real b1[5] = {4.187280585109E-02, -2.425666731623E-03, 5.051177210444E-05,
+    -4.527585394282E-07, 1.483580144144E-09};
+  Real b2[5] = {-3.164424775231E-05, 1.853493293079E-06, -3.892243662924E-08,
+    3.511599795831E-10, -1.156613338683E-12};
+  Real b3[5] = {1.018084854204E-08, -6.013995738056E-10, 1.271924622771E-11,
+    -1.154170663233E-13, 3.819260251596E-16};
+  Real b4[5] = {-1.185834697489E-12, 7.052301533772E-14, -1.500321307714E-15,
+    1.368104294236E-17, -4.545472651918E-20};
+
+  Real c0[5] = {1.856798626054E-02, 3.083186834281E-03, -1.004022090988E-04,
+    8.331453343531E-07, -1.824126204417E-09};
+  Real c1[5] = {6.519276827948E-05, -3.174897980949E-06, 7.524167185714E-08,
+    -6.141534284471E-10, 1.463896995503E-12};
+  Real c2[5] = {-1.310632653461E-08, 7.702474418324E-10, -1.830098887313E-11,
+    1.530419648245E-13, -3.852361658746E-16};
+  Real c3[5] = {1.335772487425E-12, -8.113168443709E-14, 1.921794651400E-15,
+    -1.632868926659E-17, 4.257160059035E-20};
+  Real c4[5] = {-5.047795395464E-17, 3.115707980951E-18, -7.370406590957E-20,
+    6.333570782917E-22, -1.691344581198E-24};
+
+  Real a0, a1, a2, a3, a4;
+
+  Real t1 = temperature;
+  Real t2 = t1 * t1;
+  Real t3 = t2 * t1;
+  Real t4 = t3 * t1;
+
+  // Correlation uses pressure in psia
+  Real pa2psia = 1.45037738007e-4;
+  Real p1 = pressure * pa2psia;
+  Real p2 = p1 * p1;
+  Real p3 = p2 * p1;
+  Real p4 = p3 * p1;
+
+  if (p1 <= 3000)
+  {
+    a0 = b0[0] + b0[1] * t1 + b0[2] * t2 + b0[3] * t3 + b0[4] * t4;
+    a1 = b1[0] + b1[1] * t1 + b1[2] * t2 + b1[3] * t3 + b1[4] * t4;
+    a2 = b2[0] + b2[1] * t1 + b2[2] * t2 + b2[3] * t3 + b2[4] * t4;
+    a3 = b3[0] + b3[1] * t1 + b3[2] * t2 + b3[3] * t3 + b3[4] * t4;
+    a4 = b4[0] + b4[1] * t1 + b4[2] * t2 + b4[3] * t3 + b4[4] * t4;
+   }
+
+  else // if (p1 > 3000)
+  {
+    a0 = c0[0] + c0[1] * t1 + c0[2] * t2 + c0[3] * t3 + c0[4] * t4;
+    a1 = c1[0] + c1[1] * t1 + c1[2] * t2 + c1[3] * t3 + c1[4] * t4;
+    a2 = c2[0] + c2[1] * t1 + c2[2] * t2 + c2[3] * t3 + c2[4] * t4;
+    a3 = c3[0] + c3[1] * t1 + c3[2] * t2 + c3[3] * t3 + c3[4] * t4;
+    a4 = c4[0] + c4[1] * t1 + c4[2] * t2 + c4[3] * t3 + c4[4] * t4;
+  }
+
+ Real mu = a0 + a1 * p1 + a2 * p2 + a3 * p3 + a4 * p4;
+
+ return mu * 1e-3; //cP to Pa.s
+}
+
+Real
+PorousFlowSimpleCO2::partialDensity(Real temperature) const
+{
+  Real t2 = temperature * temperature;
+  Real t3 = t2 * temperature;
+
+  Real V = 37.51 - 9.585e-2 * temperature + 8.74e-4 * t2 - 5.044e-7 * t3;
+
+  return 1.e6 * _Mco2 / V;
+}
+
+Real
+PorousFlowSimpleCO2::supercriticalDensity(Real pressure, Real temperature) const
+{
+  Real b0[5] = {-2.148322085348e5, 1.168116599408e4, -2.302236659392e2,
+    1.967428940167, -6.184842764145e-3};
+  Real b1[5] = {4.757146002428e2, -2.619250287624e1, 5.215134206837e-1,
+    -4.494511089838e-3, 1.423058795982e-5};
+  Real b2[5] = {-3.713900186613e-1, 2.072488876536e-2, -4.169082831078e-4,
+    3.622975674137e-6, -1.155050860329e-8};
+  Real b3[5] = {1.228907393482e-4, -6.930063746226e-6, 1.406317206628e-7,
+    -1.230995287169e-9, 3.948417428040e-12};
+  Real b4[5] = {-1.466408011784e-8, 8.338008651366e-10, -1.704242447194e-11,
+    1.500878861807e-13, -4.838826574173e-16};
+
+  Real c0[5] = {6.897382693936e2, 2.730479206931, -2.254102364542e-2,
+    -4.651196146917e-3, 3.439702234956e-5};
+  Real c1[5] = {2.213692462613e-1, -6.547268255814e-3, 5.982258882656e-5,
+    2.274997412526e-6, -1.888361337660e-8};
+  Real c2[5] = {-5.118724890479e-5, 2.019697017603e-6, -2.311332097185e-8,
+    -4.079557404679e-10, 3.893599641874e-12};
+  Real c3[5] ={5.517971126745e-9, -2.415814703211e-10, 3.121603486524e-12,
+    3.171271084870e-14, -3.560785550401e-16};
+  Real c4[5] = {-2.184152941323e-13, 1.010703706059e-14, -1.406620681883e-16,
+    -8.957731136447e-19, 1.215810469539e-20};
+
+  Real a0, a1, a2, a3, a4;
+
+  Real t1 = temperature;
+  Real t2 = t1 * t1;
+  Real t3 = t2 * t1;
+  Real t4 = t3 * t1;
+
+  // Correlation uses pressure in psia
+  Real pa2psia = 1.45037738007e-4;
+  Real p1 = pressure * pa2psia;
+  Real p2 = p1 * p1;
+  Real p3 = p2 * p1;
+  Real p4 = p3 * p1;
+
+  if (p1 <= 3000)
+  {
+     a0 = b0[0] + b0[1] * t1 + b0[2] * t2 + b0[3] * t3 + b0[4] * t4;
+     a1 = b1[0] + b1[1] * t1 + b1[2] * t2 + b1[3] * t3 + b1[4] * t4;
+     a2 = b2[0] + b2[1] * t1 + b2[2] * t2 + b2[3] * t3 + b2[4] * t4;
+     a3 = b3[0] + b3[1] * t1 + b3[2] * t2 + b3[3] * t3 + b3[4] * t4;
+     a4 = b4[0] + b4[1] * t1 + b4[2] * t2 + b4[3] * t3 + b4[4] * t4;
+   }
+
+   else // if (p1 > 3000)
+   {
+     a0 = c0[0] + c0[1] * t1 + c0[2] * t2 + c0[3] * t3 + c0[4] * t4;
+     a1 = c1[0] + c1[1] * t1 + c1[2] * t2 + c1[3] * t3 + c1[4] * t4;
+     a2 = c2[0] + c2[1] * t1 + c2[2] * t2 + c2[3] * t3 + c2[4] * t4;
+     a3 = c3[0] + c3[1] * t1 + c3[2] * t2 + c3[3] * t3 + c3[4] * t4;
+     a4 = c4[0] + c4[1] * t1 + c4[2] * t2 + c4[3] * t3 + c4[4] * t4;
+   }
+
+  return a0 + a1 * p1 + a2 * p2 + a3 * p3 + a4 * p4;
+}
+
+Real
+PorousFlowSimpleCO2::gasDensity(Real pressure, Real temperature) const
+{
+  Real tk = temperature + _t_c2k;
+  Real tc = std::pow((tk * 1.e-2), 10./3.);
+  Real pc = pressure * 1.e-6;
+
+  Real vc1 = 1.8882e-4 * tk;
+  Real vc2 = - pc * (8.24e-2 + 1.249e-2 * pc) / tc;
+
+  return pc / (vc1 + vc2);
+}
+
+Real
+PorousFlowSimpleCO2::dGasDensity_dP(Real pressure, Real temperature) const
+{
+  Real tk = temperature + _t_c2k;
+  Real tc = std::pow((tk * 1.e-2), 10./3.);
+  Real pc = pressure * 1.e-6;
+
+  Real vc1 = 1.8882e-4 * tk;
+  Real vc2 = - pc * (8.24e-2 + 1.249e-2 * pc) / tc;
+  Real dvc2 = - (8.24e-2 + 2.498e-2 * pc) / tc;
+
+  return (vc1 + vc2 - pc * dvc2) / ((vc1 + vc2) * (vc1 + vc2)) * 1e-6;
+}
+
+Real
+PorousFlowSimpleCO2::dGasDensity_dT(Real pressure, Real temperature) const
+{
+  Real tk = temperature + _t_c2k;
+  Real tc = std::pow((tk * 1.e-2), 10./3.);
+  Real pc = pressure * 1.e-6;
+
+  Real vc1 = 1.8882e-4 * tk;
+  Real vc2 = - pc * (8.24e-2 + 1.249e-2 * pc) / tc;
+  Real dtc = (0.1 / 3.0) * std::pow((tk * 1.e-2), 7./3.);
+  Real dvc1 = 1.8882e-4;
+  Real dvc2 = - vc2 / tc;
+
+  return - pc / (vc1 + vc2) / (vc1 + vc2) * (dvc1 + dvc2 * dtc);
+}
+
+Real
+PorousFlowSimpleCO2::dSupercriticalDensity_dP(Real pressure, Real temperature) const
+{
+  Real b1[5] = {4.757146002428e2, -2.619250287624e1, 5.215134206837e-1,
+    -4.494511089838e-3, 1.423058795982e-5};
+  Real b2[5] = {-3.713900186613e-1, 2.072488876536e-2, -4.169082831078e-4,
+    3.622975674137e-6, -1.155050860329e-8};
+  Real b3[5] = {1.228907393482e-4, -6.930063746226e-6, 1.406317206628e-7,
+    -1.230995287169e-9, 3.948417428040e-12};
+  Real b4[5] = {-1.466408011784e-8, 8.338008651366e-10, -1.704242447194e-11,
+    1.500878861807e-13, -4.838826574173e-16};
+
+  Real c1[5] = {2.213692462613e-1, -6.547268255814e-3, 5.982258882656e-5,
+    2.274997412526e-6, -1.888361337660e-8};
+  Real c2[5] = {-5.118724890479e-5, 2.019697017603e-6, -2.311332097185e-8,
+    -4.079557404679e-10, 3.893599641874e-12};
+  Real c3[5] ={5.517971126745e-9, -2.415814703211e-10, 3.121603486524e-12,
+    3.171271084870e-14, -3.560785550401e-16};
+  Real c4[5] = {-2.184152941323e-13, 1.010703706059e-14, -1.406620681883e-16,
+    -8.957731136447e-19, 1.215810469539e-20};
+
+  Real a1, a2, a3, a4;
+
+  Real t1 = temperature;
+  Real t2 = t1 * t1;
+  Real t3 = t2 * t1;
+  Real t4 = t3 * t1;
+
+  // Correlation uses pressure in psia
+  Real pa2psia = 1.45037738007e-4;
+  Real p1 = pressure * pa2psia;
+  Real p2 = p1 * p1;
+  Real p3 = p2 * p1;
+
+  if (p1 <= 3000)
+  {
+     a1 = b1[0] + b1[1] * t1 + b1[2] * t2 + b1[3] * t3 + b1[4] * t4;
+     a2 = b2[0] + b2[1] * t1 + b2[2] * t2 + b2[3] * t3 + b2[4] * t4;
+     a3 = b3[0] + b3[1] * t1 + b3[2] * t2 + b3[3] * t3 + b3[4] * t4;
+     a4 = b4[0] + b4[1] * t1 + b4[2] * t2 + b4[3] * t3 + b4[4] * t4;
+   }
+
+   else // if (p1 > 3000)
+   {
+     a1 = c1[0] + c1[1] * t1 + c1[2] * t2 + c1[3] * t3 + c1[4] * t4;
+     a2 = c2[0] + c2[1] * t1 + c2[2] * t2 + c2[3] * t3 + c2[4] * t4;
+     a3 = c3[0] + c3[1] * t1 + c3[2] * t2 + c3[3] * t3 + c3[4] * t4;
+     a4 = c4[0] + c4[1] * t1 + c4[2] * t2 + c4[3] * t3 + c4[4] * t4;
+   }
+
+  return (a1 + 2.0 * a2 * p1 + 3.0 * a3 * p2 + 4.0 * a4 * p3) * pa2psia;
+}
+
+Real
+PorousFlowSimpleCO2::dSupercriticalDensity_dT(Real pressure, Real temperature) const
+{
+  Real b0[5] = {-2.148322085348e5, 1.168116599408e4, -2.302236659392e2,
+    1.967428940167, -6.184842764145e-3};
+  Real b1[5] = {4.757146002428e2, -2.619250287624e1, 5.215134206837e-1,
+    -4.494511089838e-3, 1.423058795982e-5};
+  Real b2[5] = {-3.713900186613e-1, 2.072488876536e-2, -4.169082831078e-4,
+    3.622975674137e-6, -1.155050860329e-8};
+  Real b3[5] = {1.228907393482e-4, -6.930063746226e-6, 1.406317206628e-7,
+    -1.230995287169e-9, 3.948417428040e-12};
+  Real b4[5] = {-1.466408011784e-8, 8.338008651366e-10, -1.704242447194e-11,
+    1.500878861807e-13, -4.838826574173e-16};
+
+  Real c0[5] = {6.897382693936e2, 2.730479206931, -2.254102364542e-2,
+    -4.651196146917e-3, 3.439702234956e-5};
+  Real c1[5] = {2.213692462613e-1, -6.547268255814e-3, 5.982258882656e-5,
+    2.274997412526e-6, -1.888361337660e-8};
+  Real c2[5] = {-5.118724890479e-5, 2.019697017603e-6, -2.311332097185e-8,
+    -4.079557404679e-10, 3.893599641874e-12};
+  Real c3[5] ={5.517971126745e-9, -2.415814703211e-10, 3.121603486524e-12,
+    3.171271084870e-14, -3.560785550401e-16};
+  Real c4[5] = {-2.184152941323e-13, 1.010703706059e-14, -1.406620681883e-16,
+    -8.957731136447e-19, 1.215810469539e-20};
+
+  Real a0, a1, a2, a3, a4;
+
+  Real t1 = temperature;
+  Real t2 = t1 * t1;
+  Real t3 = t2 * t1;
+
+  // Correlation uses pressure in psia
+  Real pa2psia = 1.45037738007e-4;
+  Real p1 = pressure * pa2psia;
+  Real p2 = p1 * p1;
+  Real p3 = p2 * p1;
+  Real p4 = p3 * p1;
+
+  if (p1 <= 3000)
+  {
+     a0 = b0[1]  + 2.0 * b0[2] * t1 + 3.0 * b0[3] * t2 + 4.0 * b0[4] * t3;
+     a1 = b1[1]  + 2.0 * b1[2] * t1 + 3.0 * b1[3] * t2 + 4.0 * b1[4] * t3;
+     a2 = b2[1]  + 2.0 * b2[2] * t1 + 3.0 * b2[3] * t2 + 4.0 * b2[4] * t3;
+     a3 = b3[1]  + 2.0 * b3[2] * t1 + 3.0 * b3[3] * t2 + 4.0 * b3[4] * t3;
+     a4 = b4[1]  + 2.0 * b4[2] * t1 + 3.0 * b4[3] * t2 + 4.0 * b4[4] * t3;
+   }
+
+   else // if (p1 > 3000)
+   {
+     a0 = c0[1]  + 2.0 * c0[2] * t1 + 3.0 * c0[3] * t2 + 4.0 * c0[4] * t3;
+     a1 = c1[1]  + 2.0 * c1[2] * t1 + 3.0 * c1[3] * t2 + 4.0 * c1[4] * t3;
+     a2 = c2[1]  + 2.0 * c2[2] * t1 + 3.0 * c2[3] * t2 + 4.0 * c2[4] * t3;
+     a3 = c3[1]  + 2.0 * c3[2] * t1 + 3.0 * c3[3] * t2 + 4.0 * c3[4] * t3;
+     a4 = c4[1]  + 2.0 * c4[2] * t1 + 3.0 * c4[3] * t2 + 4.0 * c4[4] * t3;
+   }
+
+  return a0 + a1 * p1 + a2 * p2 + a3 * p3 + a4 * p4;
+}
+
+Real
+PorousFlowSimpleCO2::dViscosity_dDensity(Real pressure, Real temperature, Real density) const
+{
+  Real dmu_drho;
+
+  if (pressure <= _p_critical)
+    dmu_drho = dGasViscosity_dDensity(temperature, density);
+
+  else // if (pressure > _p_critical)
+    dmu_drho = dSupercriticalViscosity_dDensity(pressure, temperature);
+
+  return dmu_drho;
+}
+
+Real
+PorousFlowSimpleCO2::dGasViscosity_dDensity(Real temperature, Real density) const
+{
+  Real tk = temperature + _t_c2k;
+  Real tstar = tk / 251.196;
+  Real d[5] = {0.4071119e-2, 0.7198037e-4, 0.2411697e-16, 0.2971072e-22, -0.1627888e-22};
+  int j[5] = {1, 1, 4, 1, 2};
+  int i[5] = {1, 2, 6, 8, 8};
+
+  Real b[5];
+  for (unsigned int n = 0; n < 5; ++n)
+    b[n] = d[n] /  std::pow(tstar, j[n] - 1);
+
+  // Excess viscosity due to density
+  Real dmu = 0.0;
+
+  for (unsigned int n = 0; n < 5; ++n)
+    dmu += b[n] * i[n] * std::pow(density, i[n] - 1);
+
+  return  dmu * 1e-6; // convert to Pa.s
+}
+
+Real
+PorousFlowSimpleCO2::dSupercriticalViscosity_dDensity(Real pressure, Real temperature) const
+{
+  Real dmu_drho = 0.;
+
+  /**
+   * The correlation for supercritical CO2 gives viscosity as a function of pressure. Therefore, The
+   * derivative of viscosity wrt density is given by the chain rule.
+   * Note that if d(density)/d(pressure) = 0, so should d(viscosity)/d(density)
+   */
+  Real drho_dp = dSupercriticalDensity_dP(pressure, temperature);
+
+  if (drho_dp != 0.0)
+    dmu_drho += dSupercriticalViscosity_dP(pressure, temperature) / drho_dp;
+
+  return dmu_drho;
+}
+
+Real
+PorousFlowSimpleCO2::dSupercriticalViscosity_dP(Real pressure, Real temperature) const
+{
+  Real b1[5] = {4.187280585109E-02, -2.425666731623E-03, 5.051177210444E-05,
+    -4.527585394282E-07, 1.483580144144E-09};
+  Real b2[5] = {-3.164424775231E-05, 1.853493293079E-06, -3.892243662924E-08,
+    3.511599795831E-10, -1.156613338683E-12};
+  Real b3[5] = {1.018084854204E-08, -6.013995738056E-10, 1.271924622771E-11,
+    -1.154170663233E-13, 3.819260251596E-16};
+  Real b4[5] = {-1.185834697489E-12, 7.052301533772E-14, -1.500321307714E-15,
+    1.368104294236E-17, -4.545472651918E-20};
+
+  Real c1[5] = {6.519276827948E-05, -3.174897980949E-06, 7.524167185714E-08,
+    -6.141534284471E-10, 1.463896995503E-12};
+  Real c2[5] = {-1.310632653461E-08, 7.702474418324E-10, -1.830098887313E-11,
+    1.530419648245E-13, -3.852361658746E-16};
+  Real c3[5] = {1.335772487425E-12, -8.113168443709E-14, 1.921794651400E-15,
+    -1.632868926659E-17, 4.257160059035E-20};
+  Real c4[5] = {-5.047795395464E-17, 3.115707980951E-18, -7.370406590957E-20,
+    6.333570782917E-22, -1.691344581198E-24};
+
+  Real a1, a2, a3, a4;
+
+  Real t1 = temperature;
+  Real t2 = t1 * t1;
+  Real t3 = t2 * t1;
+  Real t4 = t3 * t1;
+
+  // Correlation uses pressure in psia
+  Real pa2psia = 1.45037738007e-4;
+  Real p1 = pressure * pa2psia;
+  Real p2 = p1 * p1;
+  Real p3 = p2 * p1;
+
+  if (p1 <= 3000)
+  {
+    a1 = b1[0] + b1[1] * t1 + b1[2] * t2 + b1[3] * t3 + b1[4] * t4;
+    a2 = b2[0] + b2[1] * t1 + b2[2] * t2 + b2[3] * t3 + b2[4] * t4;
+    a3 = b3[0] + b3[1] * t1 + b3[2] * t2 + b3[3] * t3 + b3[4] * t4;
+    a4 = b4[0] + b4[1] * t1 + b4[2] * t2 + b4[3] * t3 + b4[4] * t4;
+   }
+
+  else // if (p1 > 3000)
+  {
+    a1 = c1[0] + c1[1] * t1 + c1[2] * t2 + c1[3] * t3 + c1[4] * t4;
+    a2 = c2[0] + c2[1] * t1 + c2[2] * t2 + c2[3] * t3 + c2[4] * t4;
+    a3 = c3[0] + c3[1] * t1 + c3[2] * t2 + c3[3] * t3 + c3[4] * t4;
+    a4 = c4[0] + c4[1] * t1 + c4[2] * t2 + c4[3] * t3 + c4[4] * t4;
+  }
+
+ Real dmu = a1 + 2.0 * a2 * p1 + 3.0 * a3 * p2 + 4.0 * a4 * p3;
+
+ return dmu * pa2psia * 1e-3; // cP to Pa.s
+}
+
+Real
+PorousFlowSimpleCO2::dViscosity_dT(Real /*pressure*/, Real /*temperature*/, Real /*density*/) const
+{
+  //TODO: implement
+  return 0.0;
+}
+
+std::vector<Real>
+PorousFlowSimpleCO2::henryConstants() const
+{
+  std::vector<Real> co2henry;
+  co2henry.push_back(-8.55445);
+  co2henry.push_back(4.01195);
+  co2henry.push_back(9.52345);
+
+  return co2henry;
+}

--- a/modules/porous_flow/src/materials/PorousFlowViscosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowViscosityConst.C
@@ -1,0 +1,41 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowViscosityConst.h"
+
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowViscosityConst>()
+{
+  InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
+
+  params.addRequiredParam<Real>("viscosity", "The viscosity, which is assumed constant for this material");
+  params.addRequiredParam<unsigned int>("phase", "The phase number");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addClassDescription("This Material calculates the viscosity assuming it is constant");
+  return params;
+}
+
+PorousFlowViscosityConst::PorousFlowViscosityConst(const InputParameters & parameters) :
+    PorousFlowFluidPropertiesBase(parameters),
+
+    _input_viscosity(getParam<Real>("viscosity")),
+    _phase_num(getParam<unsigned int>("phase")),
+    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+
+    _viscosity(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num)))
+{
+  if (_phase_num >= _dictator_UO.numPhases())
+    mooseError("PorousFlowViscosityConst: The Dictator proclaims that the number of fluid phases is " << _dictator_UO.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
+}
+
+void
+PorousFlowViscosityConst::computeQpProperties()
+{
+  _viscosity[_qp] = _input_viscosity;
+}

--- a/modules/porous_flow/src/materials/PorousFlowVolumetricStrain.C
+++ b/modules/porous_flow/src/materials/PorousFlowVolumetricStrain.C
@@ -1,0 +1,92 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowVolumetricStrain.h"
+#include "MooseMesh.h"
+
+// libmesh includes
+#include "libmesh/quadrature.h"
+
+template<>
+InputParameters validParams<PorousFlowVolumetricStrain>()
+{
+  InputParameters params = validParams<Material>();
+  params.addRequiredCoupledVar("displacements", "The displacements appropriate for the simulation geometry and coordinate system");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addParam<bool>("consistent_with_displaced_mesh", true, "The volumetric strain rate will include terms that ensure fluid mass conservation in the displaced mesh");
+  params.addClassDescription("Compute volumetric strain and the volumetric_strain rate, for use in PorousFlow.");
+  params.set<bool>("stateful_displacements") = true;
+  return params;
+}
+
+PorousFlowVolumetricStrain::PorousFlowVolumetricStrain(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+
+    _consistent(getParam<bool>("consistent_with_displaced_mesh")),
+    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _num_var(_dictator_UO.numVariables()),
+    _ndisp(coupledComponents("displacements")),
+    _disp(3),
+    _disp_var_num(3),
+    _grad_disp(3),
+    _grad_disp_old(3),
+
+    _vol_strain_rate_qp(declareProperty<Real>("PorousFlow_volumetric_strain_rate_qp")),
+    _dvol_strain_rate_qp_dvar(declareProperty<std::vector<RealGradient> >("dPorousFlow_volumetric_strain_rate_qp_dvar")),
+    _vol_total_strain_qp(declareProperty<Real>("PorousFlow_total_volumetric_strain_qp")),
+    _dvol_total_strain_qp_dvar(declareProperty<std::vector<RealGradient> >("dPorousFlow_total_volumetric_strain_qp_dvar"))
+{
+  if (_ndisp != _mesh.dimension())
+    mooseError("PorousFlowVolumetricStrain: The number of variables supplied in 'displacements' must match the mesh dimension.");
+
+  // fetch coupled variables and gradients (as stateful properties if necessary)
+  for (unsigned int i = 0; i < _ndisp; ++i)
+  {
+    _disp[i] = &coupledValue("displacements", i);
+    _disp_var_num[i] = coupled("displacements", i);
+    _grad_disp[i] = &coupledGradient("displacements", i);
+    _grad_disp_old[i] = &coupledGradientOld("displacements" ,i);
+  }
+
+  // set unused dimensions to zero
+  for (unsigned i = _ndisp; i < 3; ++i)
+  {
+    _disp[i] = &_zero;
+    _disp_var_num[i] = 0;
+    while (_dictator_UO.isPorousFlowVariable(_disp_var_num[i]))
+      _disp_var_num[i]++; // increment until disp_var_num[i] is not a porflow var
+    _grad_disp[i] = &_grad_zero;
+    _grad_disp_old[i] = &_grad_zero;
+  }
+}
+
+void
+PorousFlowVolumetricStrain::computeQpProperties()
+{
+  RankTwoTensor A((*_grad_disp[0])[_qp], (*_grad_disp[1])[_qp], (*_grad_disp[2])[_qp]); //Deformation gradient
+  RankTwoTensor Fbar((*_grad_disp_old[0])[_qp], (*_grad_disp_old[1])[_qp], (*_grad_disp_old[2])[_qp]); //Old Deformation gradient
+
+  _vol_total_strain_qp[_qp] = A.trace();
+
+  A -= Fbar; // A = grad_disp - grad_disp_old
+
+  RankTwoTensor total_strain_increment = 0.5*(A + A.transpose());
+  const Real andy = (_consistent ? 1.0 + (*_grad_disp_old[0])[_qp](0) + (*_grad_disp_old[1])[_qp](1) + (*_grad_disp_old[2])[_qp](2) : 1.0);
+  _vol_strain_rate_qp[_qp] = total_strain_increment.trace()/_dt/andy;
+
+  // prepare the derivatives with zeroes
+  _dvol_strain_rate_qp_dvar[_qp].resize(_num_var, RealGradient());
+  _dvol_total_strain_qp_dvar[_qp].resize(_num_var, RealGradient());
+  for (unsigned i = 0 ; i < _ndisp ; ++i)
+    if (_dictator_UO.isPorousFlowVariable(_disp_var_num[i]))
+    {
+    // the i_th displacement is a porous-flow variable
+      const unsigned int pvar = _dictator_UO.porousFlowVariableNum(_disp_var_num[i]);
+      _dvol_strain_rate_qp_dvar[_qp][pvar](i) = 1.0/_dt/andy;
+      _dvol_total_strain_qp_dvar[_qp][pvar](i) = 1.0;
+    }
+}

--- a/modules/porous_flow/src/materials/PorousFlowWater.C
+++ b/modules/porous_flow/src/materials/PorousFlowWater.C
@@ -1,0 +1,486 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowWater.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowWater>()
+{
+  InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
+  params.addClassDescription("This Material calculates fluid properties for water (H20)");
+  return params;
+}
+
+PorousFlowWater::PorousFlowWater(const InputParameters & parameters) :
+    PorousFlowFluidPropertiesBase(parameters),
+
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name)),
+    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num))),
+    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _Mh2o(18.015e-3),
+    _p_critical(22.064e6),
+    _t_critical(647.096),
+    _rho_critical(322.0),
+    _v_critical(1.0 / _rho_critical),
+    _Rw(_R / _Mh2o)
+
+{
+}
+
+void
+PorousFlowWater::initQpStatefulProperties()
+{
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+}
+
+void
+PorousFlowWater::computeQpProperties()
+{
+  /// Density and derivatives wrt pressure and temperature at the nodes
+
+  _density_nodal[_qp] = density(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+  _ddensity_nodal_dp[_qp] = dDensity_dP(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+  _ddensity_nodal_dt[_qp] = dDensity_dT(_porepressure_nodal[_qp][_phase_num], _temperature_nodal[_qp][_phase_num]);
+
+  /// Density and derivatives wrt pressure and temperature at the qps
+  _density_qp[_qp] = density(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num]);
+  _ddensity_qp_dp[_qp] = dDensity_dP(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num]);
+  _ddensity_qp_dt[_qp] = dDensity_dT(_porepressure_qp[_qp][_phase_num], _temperature_qp[_qp][_phase_num]);
+
+  /// Viscosity and derivative wrt temperature at the nodes
+  _viscosity_nodal[_qp] = viscosity(_temperature_nodal[_qp][_phase_num], _density_nodal[_qp]);
+  _dviscosity_nodal_dt[_qp] = dViscosity_dT(_temperature_nodal[_qp][_phase_num], _density_nodal[_qp]);
+}
+
+Real
+PorousFlowWater::density(Real pressure, Real temperature) const
+{
+  /**
+   * Valid for 273.15 K <= T <= 1073.15 K, p <= 100 MPa
+   *          1073.15 K <= T <= 2273.15 K, p <= 50 Mpa
+   */
+  Real density;
+
+  /// Determine which region the point is in
+  Real psat = pSat(temperature);
+
+  if (temperature >= 0. && temperature <= 350.)
+  {
+    if (pressure > psat && pressure <= 100.e6)
+      /// Region 1: single phase liquid
+      density = densityRegion1(pressure, temperature);
+    else if (pressure <= psat)
+      /// Region 2: vapour phase
+      density = densityRegion2(pressure, temperature);
+    else
+      mooseError("Pressure "<< pressure << " is out of range in " << _name << "::density");
+  }
+  else
+    mooseError("Temperature " << temperature << " is out of range in " << _name << "::density");
+
+  return density;
+}
+
+Real
+PorousFlowWater::dDensity_dP(Real pressure, Real temperature) const
+{
+  /**
+   * Valid for 273.15 K <= T <= 1073.15 K, p <= 100 MPa
+   *          1073.15 K <= T <= 2273.15 K, p <= 50 Mpa
+   */
+  Real ddensity = 0.0;
+
+  /**
+   * Determine which region the point is in. First calculate the saturated pressure
+   * from the input temperature
+   */
+  Real psat = pSat(temperature);
+
+  if (temperature >= 0. && temperature <= 350.)
+  {
+    if (pressure > psat && pressure <= 100.e6)
+      /// Region 1: single phase liquid
+      ddensity = dDensityRegion1_dP(pressure, temperature);
+
+    if (pressure <= psat)
+      /// Region 2: vapour phase
+      ddensity = dDensityRegion2_dP(pressure, temperature);
+  }
+  return ddensity;
+}
+
+Real
+PorousFlowWater::dDensity_dT(Real /*pressure*/, Real /*temperature*/) const
+{
+  return 0.; // TODO: not implemented yet
+}
+
+Real
+PorousFlowWater::viscosity(Real temperature, Real density) const
+{
+  /// Constants for viscosity calculation.
+  int iv[21] = {0, 1, 2, 3, 0, 1, 2, 3, 5, 0, 1, 2, 3, 4, 0, 1, 0, 3, 4, 3, 5};
+  int jv[21] = {0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6};
+  Real h0v[4] = {1.67752, 2.20462, 0.6366564, -0.241605};
+  Real h1v[21] = {5.20094e-1, 8.50895e-2, -1.08374, -2.89555e-1, 2.22531e-1, 9.99115e-1,
+           1.88797, 1.26613, 1.20573e-1, -2.81378e-1, -9.06851e-1, -7.72479e-1,
+           -4.89837e-1, -2.57040e-1, 1.61913e-1, 2.57399e-1, -3.25372e-2, 6.98452e-2,
+           8.72102e-3, -4.35673e-3, -5.93264e-4};
+
+  Real t0[4], t1[6], d1[7];
+
+  Real mu_star = 1.e-6;
+
+  Real tbar = (temperature + _t_c2k) / _t_critical;
+  Real rhobar = density / _rho_critical;
+
+  t0[0] = 1.;
+  t0[1] = 1. / tbar;
+  t0[2] = t0[1] * t0[1];
+  t0[3] = t0[2] * t0[1];
+
+  t1[0] = 1.;
+  t1[1] = 1. / tbar - 1.;
+  t1[2] = t1[1] * t1[1];
+  t1[3] = t1[2] * t1[1];
+  t1[4] = t1[3] * t1[1];
+  t1[5] = t1[4] * t1[1];
+
+  d1[0] = 1.;
+  d1[1] = rhobar - 1.;
+  d1[2] = d1[1] * d1[1];
+  d1[3] = d1[2] * d1[1];
+  d1[4] = d1[3] * d1[1];
+  d1[5] = d1[4] * d1[1];
+  d1[6] = d1[5] * d1[1];
+
+  /// Calculate mu0
+  Real sum0 = 0.;
+  for (unsigned int i = 0; i < 4; i++)
+     sum0 += h0v[i] * t0[i];
+
+  Real mu0 = 100. * std::sqrt(tbar) / sum0;
+
+  /// Now calculate mu1
+  Real sum1 = 0.;
+  for (unsigned int i = 0; i < 21; i++)
+     sum1 += t1[iv[i]] * h1v[i] * d1[jv[i]];
+
+  Real mu1 = std::exp(rhobar * sum1);
+
+  /// The water viscosity (in Pa.s) is then given by
+  return mu_star * mu0 * mu1;
+}
+
+Real
+PorousFlowWater::dViscosity_dT(Real /*temperature*/, Real /*density*/) const
+{
+  return 0.; // TODO: not implemented yet
+}
+
+Real
+PorousFlowWater::pSat(Real temperature) const
+{
+  Real tk = temperature + _t_c2k;
+
+  Real n[10] = {0.11670521452767e4, -0.72421316703206e6, -0.17073846940092e2, 0.12020824702470e5,
+                -0.32325550322333e7, 0.14915108613530e2, -0.48232657361591e4, 0.40511340542057e6,
+                -0.238555575678490, 0.65017534844798e3};
+
+  Real theta, theta2, a, b, c, p;
+
+  /**
+   * Check whether the input temperature is within the region of validity of this equation.
+   * Valid for 273.15 K <= t <= 647.096 K
+   */
+  if (tk >= _t_c2k && tk <= _t_critical)
+  {
+    theta = tk + n[8] / (tk - n[9]);
+    theta2 = theta * theta;
+    a = theta2 + n[0] * theta + n[1];
+    b = n[2] * theta2 + n[3] * theta + n[4];
+    c = n[5] * theta2 + n[6] * theta + n[7];
+    p = std::pow(2.0 * c/(-b + std::sqrt(b * b - 4.0 * a * c)), 4.0);
+  }
+  else
+    mooseError("Temperature is outside range 0 <= t <= 400.964 in " << _name << "::pSat()");
+
+  return p * 1.e6;
+}
+
+Real
+PorousFlowWater::tSat(Real pressure) const
+{
+  Real n[10] = {0.11670521452767e4, -0.72421316703206e6, -0.17073846940092e2, 0.12020824702470e5,
+                -0.32325550322333e7, 0.14915108613530e2, -0.48232657361591e4, 0.40511340542057e6,
+                -0.238555575678490, 0.65017534844798e3};
+
+  Real beta, beta2, e, f, g, d, t;
+
+  /**
+   * Check whether the input pressure is within the region of validity of this equation.
+   * Valid for 611.213 Pa <= p <= 22.064 MPa
+   */
+  if (pressure >= 611.23 && pressure <= _p_critical)
+  {
+    beta = std::pow(pressure / 1.e6, 0.25);
+    beta2 = beta * beta;
+    e = beta2 + n[2] * beta + n[5];
+    f = n[0] * beta2 + n[3] * beta + n[6];
+    g = n[1] * beta2 + n[4] * beta + n[7];
+    d = 2.0 * g /(-f - std::sqrt(f * f - 4.0 * e * g));
+    t = (n[9] + d - std::sqrt((n[9] + d) * (n[9] + d) - 4.0 * (n[8] + n[9] * d))) / 2.0;
+  }
+  else
+    mooseError("Pressure is outside range 611.213 Pa <= p <= 22.064 MPa in " << _name << "::tSat()");
+
+  return t - _t_c2k;
+}
+
+Real
+PorousFlowWater::b23p(Real temperature) const
+{
+  Real n[5] = {0.34805185628969e3, -0.11671859879975e1, 0.10192970039326e-2, 0.57254459862746e3,
+               0.13918839778870e2};
+
+  Real tk = temperature + _t_c2k;
+
+  return (n[0] + n[1] * tk + n[2] * tk * tk) * 1.e6;
+}
+
+Real
+PorousFlowWater::b23t(Real pressure) const
+{
+  Real n[5] = {0.34805185628969e3, -0.11671859879975e1, 0.10192970039326e-2, 0.57254459862746e3,
+               0.13918839778870e2};
+
+  return n[3] + std::sqrt((pressure / 1.e6 - n[4]) / n[2]) - _t_c2k;
+}
+
+Real
+PorousFlowWater::densityRegion1(Real pressure, Real temperature) const
+{
+  Real p_star1 = 16.53e6;
+  Real t_star1 = 1386.;
+  Real tk = temperature + _t_c2k;
+
+  /// Constants for region 1.
+  Real n1[34] = {0.14632971213167e0, -0.84548187169114e0, -0.37563603672040e1, 0.33855169168385e1,
+                -0.95791963387872e0, 0.15772038513228e0, -0.16616417199501e-1, 0.81214629983568e-3,
+                 0.28319080123804e-3, -0.60706301565874e-3, -0.18990068218419e-1, -0.32529748770505e-1,
+                -0.21841717175414e-1, -0.52838357969930e-4, -0.47184321073267e-3, -0.30001780793026e-3,
+                 0.47661393906987e-4, -0.44141845330846e-5, -0.72694996297594e-15, -0.31679644845054e-4,
+                -0.28270797985312e-5, -0.85205128120103e-9, -0.22425281908000e-5, -0.65171222895601e-6,
+                -0.14341729937924e-12, -0.40516996860117e-6, -0.12734301741641e-8, -0.17424871230634e-9,
+                -0.68762131295531e-18, 0.14478307828521e-19, 0.26335781662795e-22, -0.11947622640071e-22,
+                 0.18228094581404e-23, -0.93537087292458e-25};
+
+  int I1[34] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 8, 8, 21,
+                  23, 29, 30, 31, 32};
+
+  int J1[34] = {-2, -1, 0, 1, 2, 3, 4, 5, -9, -7, -1, 0, 1, 3, -3, 0, 1, 3, 17, -4, 0, 6, -5, -2, 10, -8,
+                  -11, -6, -29, -31, -38, -39, -40, -41};
+
+  /// Now evaluate the sums
+  Real sum1 = 0.;
+  Real tau1 = t_star1 / tk;
+  Real pi1 = pressure / p_star1;
+
+  for (unsigned int i = 0; i < 34; i++)
+    sum1 -= n1[i] * I1[i] * std::pow(7.1 - pi1, I1[i]-1) * std::pow(tau1 - 1.222, J1[i]);
+
+  /// The density of water in this region is then given by
+  return p_star1 / (sum1 * _Rw * tk);
+}
+
+Real
+PorousFlowWater::densityRegion2(Real pressure, Real temperature) const
+{
+  Real p_star2 = 1.e6;
+  Real t_star2 = 540.;
+  Real tk = temperature + _t_c2k;
+
+  /// Constants for region 2.
+  Real n2[43] = {-0.17731742473213e-2, -0.17834862292358e-1, -0.45996013696365e-1, -0.57581259083432e-1,
+                 -0.50325278727930e-1, -0.33032641670203e-4, -0.18948987516315e-3, -0.39392777243355e-2,
+                 -0.43797295650573e-1, -0.26674547914087e-4, 0.20481737692309e-7, 0.43870667284435e-6,
+                 -0.32277677238570e-4, -0.15033924542148e-2, -0.40668253562649e-1, -0.78847309559367e-9,
+                  0.12790717852285e-7, 0.48225372718507e-6, 0.22922076337661e-5, -0.16714766451061e-10,
+                 -0.21171472321355e-2, -0.23895741934104e2, -0.59059564324270e-17, -0.12621808899101e-5,
+                 -0.38946842435739e-1, 0.11256211360459e-10, -0.82311340897998e1, 0.19809712802088e-7,
+                  0.10406965210174e-18, -0.10234747095929e-12, -0.10018179379511e-8, -0.80882908646985e-10,
+                  0.10693031879409e0, -0.33662250574171e0, 0.89185845355421e-24, 0.30629316876232e-12,
+                 -0.42002467698208e-5, -0.59056029685639e-25, 0.37826947613457e-5, -0.12768608934681e-14,
+                  0.73087610595061e-28, 0.55414715350778e-16, -0.94369707241210e-6};
+
+  int I2[43] = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 5, 6, 6, 6, 7, 7, 7, 8, 8, 9, 10, 10,
+                10, 16, 16, 18, 20, 20, 20, 21, 22, 23, 24, 24, 24};
+
+  int J2[43] = {0, 1, 2, 3, 6, 1, 2, 4, 7, 36, 0, 1, 3, 6, 35, 1, 2, 3, 7, 3, 16, 35, 0, 11, 25, 8, 36, 13,
+                4, 10, 14, 29, 50, 57, 20, 35, 48, 21, 53, 39, 26, 40, 58};
+
+  /// Ideal gas component of region 2 - Eq. (16)
+  Real tau2 = t_star2 / tk;
+  Real pi2 = pressure / p_star2;
+
+  /// Residual component of Gibbs free energy - Eq. (17).
+  Real sumr2 = 0.;
+
+  for (unsigned int i = 0; i < 43; i++)
+    sumr2 += n2[i] * I2[i] * std::pow(pi2, I2[i] - 1) * std::pow(tau2 - 0.5, J2[i]);
+
+  /// The density in Region 2 is then given by
+  return p_star2 / (_Rw * tk * (1.0 / pi2 + sumr2));
+}
+
+Real
+PorousFlowWater::densityRegion3(Real /* pressure */, Real /* temperature */) const
+{
+  /**
+   * Region 3 is subdivided into 26 subregions, each with a given backwards equation
+   * to directly calculate density from pressure and temperature without the need for
+   * expensive iterations.
+   */
+  //TODO: needs to be implemented!
+
+  return 0.;
+}
+
+Real
+PorousFlowWater::dDensityRegion1_dP(Real pressure, Real temperature) const
+{
+  Real p_star1 = 16.53e6;
+  Real t_star1 = 1386.;
+  Real tk = temperature + _t_c2k;
+
+  /// Constants for region 1.
+  Real n1[34] = {0.14632971213167e0, -0.84548187169114e0, -0.37563603672040e1, 0.33855169168385e1,
+                -0.95791963387872e0, 0.15772038513228e0, -0.16616417199501e-1, 0.81214629983568e-3,
+                 0.28319080123804e-3, -0.60706301565874e-3, -0.18990068218419e-1, -0.32529748770505e-1,
+                -0.21841717175414e-1, -0.52838357969930e-4, -0.47184321073267e-3, -0.30001780793026e-3,
+                 0.47661393906987e-4, -0.44141845330846e-5, -0.72694996297594e-15, -0.31679644845054e-4,
+                -0.28270797985312e-5, -0.85205128120103e-9, -0.22425281908000e-5, -0.65171222895601e-6,
+                -0.14341729937924e-12, -0.40516996860117e-6, -0.12734301741641e-8, -0.17424871230634e-9,
+                -0.68762131295531e-18, 0.14478307828521e-19, 0.26335781662795e-22, -0.11947622640071e-22,
+                 0.18228094581404e-23, -0.93537087292458e-25};
+
+  int I1[34] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 8, 8, 21,
+                  23, 29, 30, 31, 32};
+
+  int J1[34] = {-2, -1, 0, 1, 2, 3, 4, 5, -9, -7, -1, 0, 1, 3, -3, 0, 1, 3, 17, -4, 0, 6, -5, -2, 10, -8,
+                  -11, -6, -29, -31, -38, -39, -40, -41};
+
+  /// Now evaluate the sums
+  Real sum1 = 0.;
+  Real sum2 = 0.;
+  Real tau1 = t_star1 / tk;
+  Real pi1 = pressure / p_star1;
+
+  for (unsigned int i = 0; i < 34; i++)
+  {
+    sum1 -= n1[i] * I1[i] * std::pow(7.1 - pi1, I1[i]-1) * std::pow(tau1 - 1.222, J1[i]);
+    sum2 += n1[i] * I1[i] * (I1[i] - 1) * std::pow(7.1 - pi1, I1[i]-2) * std::pow(tau1 - 1.222, J1[i]);
+  }
+
+  /// The derivative of the density of water with respect to pressure in this region is then given by
+  return - sum2 / (sum1 * sum1 * _Rw * tk);
+}
+
+Real
+PorousFlowWater::dDensityRegion2_dP(Real pressure, Real temperature) const
+{
+  Real p_star2 = 1.e6;
+  Real t_star2 = 540.;
+  Real tk = temperature + _t_c2k;
+
+  /// Constants for region 2.
+  Real n2[43] = {-0.17731742473213e-2, -0.17834862292358e-1, -0.45996013696365e-1, -0.57581259083432e-1,
+                 -0.50325278727930e-1, -0.33032641670203e-4, -0.18948987516315e-3, -0.39392777243355e-2,
+                 -0.43797295650573e-1, -0.26674547914087e-4, 0.20481737692309e-7, 0.43870667284435e-6,
+                 -0.32277677238570e-4, -0.15033924542148e-2, -0.40668253562649e-1, -0.78847309559367e-9,
+                  0.12790717852285e-7, 0.48225372718507e-6, 0.22922076337661e-5, -0.16714766451061e-10,
+                 -0.21171472321355e-2, -0.23895741934104e2, -0.59059564324270e-17, -0.12621808899101e-5,
+                 -0.38946842435739e-1, 0.11256211360459e-10, -0.82311340897998e1, 0.19809712802088e-7,
+                  0.10406965210174e-18, -0.10234747095929e-12, -0.10018179379511e-8, -0.80882908646985e-10,
+                  0.10693031879409e0, -0.33662250574171e0, 0.89185845355421e-24, 0.30629316876232e-12,
+                 -0.42002467698208e-5, -0.59056029685639e-25, 0.37826947613457e-5, -0.12768608934681e-14,
+                  0.73087610595061e-28, 0.55414715350778e-16, -0.94369707241210e-6};
+
+  int I2[43] = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 5, 6, 6, 6, 7, 7, 7, 8, 8, 9, 10, 10,
+                10, 16, 16, 18, 20, 20, 20, 21, 22, 23, 24, 24, 24};
+
+  int J2[43] = {0, 1, 2, 3, 6, 1, 2, 4, 7, 36, 0, 1, 3, 6, 35, 1, 2, 3, 7, 3, 16, 35, 0, 11, 25, 8, 36, 13,
+                4, 10, 14, 29, 50, 57, 20, 35, 48, 21, 53, 39, 26, 40, 58};
+
+  /// Ideal gas component of region 2 - Eq. (16)
+  Real tau2 = t_star2 / tk;
+  Real pi2 = pressure / p_star2;
+
+  /// Residual component of Gibbs free energy - Eq. (17).
+  Real sumr2 = 0.;
+  Real sumdr2 = 0.;
+
+  for (unsigned int i = 0; i < 43; i++)
+  {
+    sumr2 += n2[i] * I2[i] * std::pow(pi2, I2[i] - 1) * std::pow(tau2 - 0.5, J2[i]);
+    sumdr2 += n2[i] * I2[i] * (I2[i] - 1) * std::pow(pi2, I2[i] - 2) * std::pow(tau2 - 0.5, J2[i]);
+  }
+
+  /// The derivative of the density in Region 2 with respect to pressure is then given by
+  return - (- 1.0/(pi2 * pi2) + sumdr2) / (_Rw * tk * (1.0 / pi2 + sumr2) * (1.0 / pi2 + sumr2));
+}
+
+Real
+PorousFlowWater::dViscosity_dDensity(Real temperature, Real density) const
+{
+  Real t1[6], d1[7];
+
+  Real tbar = (temperature + _t_c2k) / _t_critical;
+  Real rhobar = density / _rho_critical;
+
+  /// Constants for viscosity calculation.
+  int iv[21] = {0, 1, 2, 3, 0, 1, 2, 3, 5, 0, 1, 2, 3, 4, 0, 1, 0, 3, 4, 3, 5};
+  int jv[21] = {0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6};
+  Real h1v[21] = {5.20094e-1, 8.50895e-2, -1.08374, -2.89555e-1, 2.22531e-1, 9.99115e-1,
+           1.88797, 1.26613, 1.20573e-1, -2.81378e-1, -9.06851e-1, -7.72479e-1,
+           -4.89837e-1, -2.57040e-1, 1.61913e-1, 2.57399e-1, -3.25372e-2, 6.98452e-2,
+           8.72102e-3, -4.35673e-3, -5.93264e-4};
+
+  t1[0] = 1.;
+  t1[1] = 1. / tbar - 1.;
+  t1[2] = t1[1] * t1[1];
+  t1[3] = t1[2] * t1[1];
+  t1[4] = t1[3] * t1[1];
+  t1[5] = t1[4] * t1[1];
+
+  d1[0] = 1.;
+  d1[1] = rhobar - 1.;
+  d1[2] = d1[1] * d1[1];
+  d1[3] = d1[2] * d1[1];
+  d1[4] = d1[3] * d1[1];
+  d1[5] = d1[4] * d1[1];
+  d1[6] = d1[5] * d1[1];
+
+  /// Prefactor to derivative of viscosity
+  Real sum1 = 0.;
+  Real sum2 = 0.;
+  for (unsigned int i = 0; i < 21; i++)
+  {
+    sum1 += t1[iv[i]] * h1v[i] * d1[jv[i]];
+    sum2 += t1[iv[i]] * jv[i] * h1v[i] * d1[jv[i]] / (rhobar - 1.0);
+  }
+
+  /// The derivative of viscosity wrt density is then
+  return viscosity(temperature, density) * (sum1 + rhobar * sum2) / _rho_critical;
+}

--- a/modules/porous_flow/src/materials/PorousFlowWater.C
+++ b/modules/porous_flow/src/materials/PorousFlowWater.C
@@ -12,7 +12,7 @@ template<>
 InputParameters validParams<PorousFlowWater>()
 {
   InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
-  params.addClassDescription("This Material calculates fluid properties for water (H20)");
+  params.addClassDescription("This Material calculates fluid properties for water (H2O)");
   return params;
 }
 
@@ -73,11 +73,11 @@ PorousFlowWater::density(Real pressure, Real temperature) const
   Real density;
 
   /// Determine which region the point is in
-  Real psat = pSat(temperature);
+  const Real psat = pSat(temperature);
 
-  if (temperature >= 0. && temperature <= 350.)
+  if (temperature >= 0.0 && temperature <= 350.0)
   {
-    if (pressure > psat && pressure <= 100.e6)
+    if (pressure > psat && pressure <= 100.0e6)
       /// Region 1: single phase liquid
       density = densityRegion1(pressure, temperature);
     else if (pressure <= psat)
@@ -105,11 +105,11 @@ PorousFlowWater::dDensity_dP(Real pressure, Real temperature) const
    * Determine which region the point is in. First calculate the saturated pressure
    * from the input temperature
    */
-  Real psat = pSat(temperature);
+  const Real psat = pSat(temperature);
 
-  if (temperature >= 0. && temperature <= 350.)
+  if (temperature >= 0.0 && temperature <= 350.0)
   {
-    if (pressure > psat && pressure <= 100.e6)
+    if (pressure > psat && pressure <= 100.0e6)
       /// Region 1: single phase liquid
       ddensity = dDensityRegion1_dP(pressure, temperature);
 
@@ -123,27 +123,27 @@ PorousFlowWater::dDensity_dP(Real pressure, Real temperature) const
 Real
 PorousFlowWater::dDensity_dT(Real /*pressure*/, Real /*temperature*/) const
 {
-  return 0.; // TODO: not implemented yet
+  return 0.0; // TODO: not implemented yet
 }
 
 Real
 PorousFlowWater::viscosity(Real temperature, Real density) const
 {
   /// Constants for viscosity calculation.
-  int iv[21] = {0, 1, 2, 3, 0, 1, 2, 3, 5, 0, 1, 2, 3, 4, 0, 1, 0, 3, 4, 3, 5};
-  int jv[21] = {0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6};
-  Real h0v[4] = {1.67752, 2.20462, 0.6366564, -0.241605};
-  Real h1v[21] = {5.20094e-1, 8.50895e-2, -1.08374, -2.89555e-1, 2.22531e-1, 9.99115e-1,
+  const int iv[21] = {0, 1, 2, 3, 0, 1, 2, 3, 5, 0, 1, 2, 3, 4, 0, 1, 0, 3, 4, 3, 5};
+  const int jv[21] = {0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6};
+  const Real h0v[4] = {1.67752, 2.20462, 0.6366564, -0.241605};
+  const Real h1v[21] = {5.20094e-1, 8.50895e-2, -1.08374, -2.89555e-1, 2.22531e-1, 9.99115e-1,
            1.88797, 1.26613, 1.20573e-1, -2.81378e-1, -9.06851e-1, -7.72479e-1,
            -4.89837e-1, -2.57040e-1, 1.61913e-1, 2.57399e-1, -3.25372e-2, 6.98452e-2,
            8.72102e-3, -4.35673e-3, -5.93264e-4};
 
   Real t0[4], t1[6], d1[7];
 
-  Real mu_star = 1.e-6;
+  const Real mu_star = 1.e-6;
 
-  Real tbar = (temperature + _t_c2k) / _t_critical;
-  Real rhobar = density / _rho_critical;
+  const Real tbar = (temperature + _t_c2k) / _t_critical;
+  const Real rhobar = density / _rho_critical;
 
   t0[0] = 1.;
   t0[1] = 1. / tbar;
@@ -166,18 +166,18 @@ PorousFlowWater::viscosity(Real temperature, Real density) const
   d1[6] = d1[5] * d1[1];
 
   /// Calculate mu0
-  Real sum0 = 0.;
+  Real sum0 = 0.0;
   for (unsigned int i = 0; i < 4; i++)
      sum0 += h0v[i] * t0[i];
 
-  Real mu0 = 100. * std::sqrt(tbar) / sum0;
+  const Real mu0 = 100.0 * std::sqrt(tbar) / sum0;
 
   /// Now calculate mu1
-  Real sum1 = 0.;
+  Real sum1 = 0.0;
   for (unsigned int i = 0; i < 21; i++)
      sum1 += t1[iv[i]] * h1v[i] * d1[jv[i]];
 
-  Real mu1 = std::exp(rhobar * sum1);
+  const Real mu1 = std::exp(rhobar * sum1);
 
   /// The water viscosity (in Pa.s) is then given by
   return mu_star * mu0 * mu1;
@@ -186,15 +186,15 @@ PorousFlowWater::viscosity(Real temperature, Real density) const
 Real
 PorousFlowWater::dViscosity_dT(Real /*temperature*/, Real /*density*/) const
 {
-  return 0.; // TODO: not implemented yet
+  return 0.0; // TODO: not implemented yet
 }
 
 Real
 PorousFlowWater::pSat(Real temperature) const
 {
-  Real tk = temperature + _t_c2k;
+  const Real tk = temperature + _t_c2k;
 
-  Real n[10] = {0.11670521452767e4, -0.72421316703206e6, -0.17073846940092e2, 0.12020824702470e5,
+  const Real n[10] = {0.11670521452767e4, -0.72421316703206e6, -0.17073846940092e2, 0.12020824702470e5,
                 -0.32325550322333e7, 0.14915108613530e2, -0.48232657361591e4, 0.40511340542057e6,
                 -0.238555575678490, 0.65017534844798e3};
 
@@ -222,7 +222,7 @@ PorousFlowWater::pSat(Real temperature) const
 Real
 PorousFlowWater::tSat(Real pressure) const
 {
-  Real n[10] = {0.11670521452767e4, -0.72421316703206e6, -0.17073846940092e2, 0.12020824702470e5,
+  const Real n[10] = {0.11670521452767e4, -0.72421316703206e6, -0.17073846940092e2, 0.12020824702470e5,
                 -0.32325550322333e7, 0.14915108613530e2, -0.48232657361591e4, 0.40511340542057e6,
                 -0.238555575678490, 0.65017534844798e3};
 
@@ -251,10 +251,10 @@ PorousFlowWater::tSat(Real pressure) const
 Real
 PorousFlowWater::b23p(Real temperature) const
 {
-  Real n[5] = {0.34805185628969e3, -0.11671859879975e1, 0.10192970039326e-2, 0.57254459862746e3,
+  const Real n[5] = {0.34805185628969e3, -0.11671859879975e1, 0.10192970039326e-2, 0.57254459862746e3,
                0.13918839778870e2};
 
-  Real tk = temperature + _t_c2k;
+  const Real tk = temperature + _t_c2k;
 
   return (n[0] + n[1] * tk + n[2] * tk * tk) * 1.e6;
 }
@@ -262,7 +262,7 @@ PorousFlowWater::b23p(Real temperature) const
 Real
 PorousFlowWater::b23t(Real pressure) const
 {
-  Real n[5] = {0.34805185628969e3, -0.11671859879975e1, 0.10192970039326e-2, 0.57254459862746e3,
+  const Real n[5] = {0.34805185628969e3, -0.11671859879975e1, 0.10192970039326e-2, 0.57254459862746e3,
                0.13918839778870e2};
 
   return n[3] + std::sqrt((pressure / 1.e6 - n[4]) / n[2]) - _t_c2k;
@@ -271,12 +271,12 @@ PorousFlowWater::b23t(Real pressure) const
 Real
 PorousFlowWater::densityRegion1(Real pressure, Real temperature) const
 {
-  Real p_star1 = 16.53e6;
-  Real t_star1 = 1386.;
-  Real tk = temperature + _t_c2k;
+  const Real p_star1 = 16.53e6;
+  const Real t_star1 = 1386.;
+  const Real tk = temperature + _t_c2k;
 
   /// Constants for region 1.
-  Real n1[34] = {0.14632971213167e0, -0.84548187169114e0, -0.37563603672040e1, 0.33855169168385e1,
+  const Real n1[34] = {0.14632971213167e0, -0.84548187169114e0, -0.37563603672040e1, 0.33855169168385e1,
                 -0.95791963387872e0, 0.15772038513228e0, -0.16616417199501e-1, 0.81214629983568e-3,
                  0.28319080123804e-3, -0.60706301565874e-3, -0.18990068218419e-1, -0.32529748770505e-1,
                 -0.21841717175414e-1, -0.52838357969930e-4, -0.47184321073267e-3, -0.30001780793026e-3,
@@ -286,16 +286,16 @@ PorousFlowWater::densityRegion1(Real pressure, Real temperature) const
                 -0.68762131295531e-18, 0.14478307828521e-19, 0.26335781662795e-22, -0.11947622640071e-22,
                  0.18228094581404e-23, -0.93537087292458e-25};
 
-  int I1[34] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 8, 8, 21,
+  const int I1[34] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 8, 8, 21,
                   23, 29, 30, 31, 32};
 
-  int J1[34] = {-2, -1, 0, 1, 2, 3, 4, 5, -9, -7, -1, 0, 1, 3, -3, 0, 1, 3, 17, -4, 0, 6, -5, -2, 10, -8,
+  const int J1[34] = {-2, -1, 0, 1, 2, 3, 4, 5, -9, -7, -1, 0, 1, 3, -3, 0, 1, 3, 17, -4, 0, 6, -5, -2, 10, -8,
                   -11, -6, -29, -31, -38, -39, -40, -41};
 
   /// Now evaluate the sums
-  Real sum1 = 0.;
-  Real tau1 = t_star1 / tk;
-  Real pi1 = pressure / p_star1;
+  Real sum1 = 0.0;
+  const Real tau1 = t_star1 / tk;
+  const Real pi1 = pressure / p_star1;
 
   for (unsigned int i = 0; i < 34; i++)
     sum1 -= n1[i] * I1[i] * std::pow(7.1 - pi1, I1[i]-1) * std::pow(tau1 - 1.222, J1[i]);
@@ -307,12 +307,12 @@ PorousFlowWater::densityRegion1(Real pressure, Real temperature) const
 Real
 PorousFlowWater::densityRegion2(Real pressure, Real temperature) const
 {
-  Real p_star2 = 1.e6;
-  Real t_star2 = 540.;
-  Real tk = temperature + _t_c2k;
+  const Real p_star2 = 1.e6;
+  const Real t_star2 = 540.0;
+  const Real tk = temperature + _t_c2k;
 
   /// Constants for region 2.
-  Real n2[43] = {-0.17731742473213e-2, -0.17834862292358e-1, -0.45996013696365e-1, -0.57581259083432e-1,
+  const Real n2[43] = {-0.17731742473213e-2, -0.17834862292358e-1, -0.45996013696365e-1, -0.57581259083432e-1,
                  -0.50325278727930e-1, -0.33032641670203e-4, -0.18948987516315e-3, -0.39392777243355e-2,
                  -0.43797295650573e-1, -0.26674547914087e-4, 0.20481737692309e-7, 0.43870667284435e-6,
                  -0.32277677238570e-4, -0.15033924542148e-2, -0.40668253562649e-1, -0.78847309559367e-9,
@@ -324,18 +324,18 @@ PorousFlowWater::densityRegion2(Real pressure, Real temperature) const
                  -0.42002467698208e-5, -0.59056029685639e-25, 0.37826947613457e-5, -0.12768608934681e-14,
                   0.73087610595061e-28, 0.55414715350778e-16, -0.94369707241210e-6};
 
-  int I2[43] = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 5, 6, 6, 6, 7, 7, 7, 8, 8, 9, 10, 10,
+  const int I2[43] = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 5, 6, 6, 6, 7, 7, 7, 8, 8, 9, 10, 10,
                 10, 16, 16, 18, 20, 20, 20, 21, 22, 23, 24, 24, 24};
 
-  int J2[43] = {0, 1, 2, 3, 6, 1, 2, 4, 7, 36, 0, 1, 3, 6, 35, 1, 2, 3, 7, 3, 16, 35, 0, 11, 25, 8, 36, 13,
+  const int J2[43] = {0, 1, 2, 3, 6, 1, 2, 4, 7, 36, 0, 1, 3, 6, 35, 1, 2, 3, 7, 3, 16, 35, 0, 11, 25, 8, 36, 13,
                 4, 10, 14, 29, 50, 57, 20, 35, 48, 21, 53, 39, 26, 40, 58};
 
   /// Ideal gas component of region 2 - Eq. (16)
-  Real tau2 = t_star2 / tk;
-  Real pi2 = pressure / p_star2;
+  const Real tau2 = t_star2 / tk;
+  const Real pi2 = pressure / p_star2;
 
   /// Residual component of Gibbs free energy - Eq. (17).
-  Real sumr2 = 0.;
+  Real sumr2 = 0.0;
 
   for (unsigned int i = 0; i < 43; i++)
     sumr2 += n2[i] * I2[i] * std::pow(pi2, I2[i] - 1) * std::pow(tau2 - 0.5, J2[i]);
@@ -354,18 +354,18 @@ PorousFlowWater::densityRegion3(Real /* pressure */, Real /* temperature */) con
    */
   //TODO: needs to be implemented!
 
-  return 0.;
+  return 0.0;
 }
 
 Real
 PorousFlowWater::dDensityRegion1_dP(Real pressure, Real temperature) const
 {
-  Real p_star1 = 16.53e6;
-  Real t_star1 = 1386.;
-  Real tk = temperature + _t_c2k;
+  const Real p_star1 = 16.53e6;
+  const Real t_star1 = 1386.;
+  const Real tk = temperature + _t_c2k;
 
   /// Constants for region 1.
-  Real n1[34] = {0.14632971213167e0, -0.84548187169114e0, -0.37563603672040e1, 0.33855169168385e1,
+  const Real n1[34] = {0.14632971213167e0, -0.84548187169114e0, -0.37563603672040e1, 0.33855169168385e1,
                 -0.95791963387872e0, 0.15772038513228e0, -0.16616417199501e-1, 0.81214629983568e-3,
                  0.28319080123804e-3, -0.60706301565874e-3, -0.18990068218419e-1, -0.32529748770505e-1,
                 -0.21841717175414e-1, -0.52838357969930e-4, -0.47184321073267e-3, -0.30001780793026e-3,
@@ -375,17 +375,17 @@ PorousFlowWater::dDensityRegion1_dP(Real pressure, Real temperature) const
                 -0.68762131295531e-18, 0.14478307828521e-19, 0.26335781662795e-22, -0.11947622640071e-22,
                  0.18228094581404e-23, -0.93537087292458e-25};
 
-  int I1[34] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 8, 8, 21,
+  const int I1[34] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 8, 8, 21,
                   23, 29, 30, 31, 32};
 
-  int J1[34] = {-2, -1, 0, 1, 2, 3, 4, 5, -9, -7, -1, 0, 1, 3, -3, 0, 1, 3, 17, -4, 0, 6, -5, -2, 10, -8,
+  const int J1[34] = {-2, -1, 0, 1, 2, 3, 4, 5, -9, -7, -1, 0, 1, 3, -3, 0, 1, 3, 17, -4, 0, 6, -5, -2, 10, -8,
                   -11, -6, -29, -31, -38, -39, -40, -41};
 
   /// Now evaluate the sums
-  Real sum1 = 0.;
-  Real sum2 = 0.;
-  Real tau1 = t_star1 / tk;
-  Real pi1 = pressure / p_star1;
+  Real sum1 = 0.0;
+  Real sum2 = 0.0;
+  const Real tau1 = t_star1 / tk;
+  const Real pi1 = pressure / p_star1;
 
   for (unsigned int i = 0; i < 34; i++)
   {
@@ -400,12 +400,12 @@ PorousFlowWater::dDensityRegion1_dP(Real pressure, Real temperature) const
 Real
 PorousFlowWater::dDensityRegion2_dP(Real pressure, Real temperature) const
 {
-  Real p_star2 = 1.e6;
-  Real t_star2 = 540.;
-  Real tk = temperature + _t_c2k;
+  const Real p_star2 = 1.e6;
+  const Real t_star2 = 540.0;
+  const Real tk = temperature + _t_c2k;
 
   /// Constants for region 2.
-  Real n2[43] = {-0.17731742473213e-2, -0.17834862292358e-1, -0.45996013696365e-1, -0.57581259083432e-1,
+  const Real n2[43] = {-0.17731742473213e-2, -0.17834862292358e-1, -0.45996013696365e-1, -0.57581259083432e-1,
                  -0.50325278727930e-1, -0.33032641670203e-4, -0.18948987516315e-3, -0.39392777243355e-2,
                  -0.43797295650573e-1, -0.26674547914087e-4, 0.20481737692309e-7, 0.43870667284435e-6,
                  -0.32277677238570e-4, -0.15033924542148e-2, -0.40668253562649e-1, -0.78847309559367e-9,
@@ -417,19 +417,19 @@ PorousFlowWater::dDensityRegion2_dP(Real pressure, Real temperature) const
                  -0.42002467698208e-5, -0.59056029685639e-25, 0.37826947613457e-5, -0.12768608934681e-14,
                   0.73087610595061e-28, 0.55414715350778e-16, -0.94369707241210e-6};
 
-  int I2[43] = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 5, 6, 6, 6, 7, 7, 7, 8, 8, 9, 10, 10,
+  const int I2[43] = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 5, 6, 6, 6, 7, 7, 7, 8, 8, 9, 10, 10,
                 10, 16, 16, 18, 20, 20, 20, 21, 22, 23, 24, 24, 24};
 
-  int J2[43] = {0, 1, 2, 3, 6, 1, 2, 4, 7, 36, 0, 1, 3, 6, 35, 1, 2, 3, 7, 3, 16, 35, 0, 11, 25, 8, 36, 13,
+  const int J2[43] = {0, 1, 2, 3, 6, 1, 2, 4, 7, 36, 0, 1, 3, 6, 35, 1, 2, 3, 7, 3, 16, 35, 0, 11, 25, 8, 36, 13,
                 4, 10, 14, 29, 50, 57, 20, 35, 48, 21, 53, 39, 26, 40, 58};
 
   /// Ideal gas component of region 2 - Eq. (16)
-  Real tau2 = t_star2 / tk;
-  Real pi2 = pressure / p_star2;
+  const Real tau2 = t_star2 / tk;
+  const Real pi2 = pressure / p_star2;
 
   /// Residual component of Gibbs free energy - Eq. (17).
-  Real sumr2 = 0.;
-  Real sumdr2 = 0.;
+  Real sumr2 = 0.0;
+  Real sumdr2 = 0.0;
 
   for (unsigned int i = 0; i < 43; i++)
   {
@@ -446,13 +446,13 @@ PorousFlowWater::dViscosity_dDensity(Real temperature, Real density) const
 {
   Real t1[6], d1[7];
 
-  Real tbar = (temperature + _t_c2k) / _t_critical;
-  Real rhobar = density / _rho_critical;
+  const Real tbar = (temperature + _t_c2k) / _t_critical;
+  const Real rhobar = density / _rho_critical;
 
   /// Constants for viscosity calculation.
-  int iv[21] = {0, 1, 2, 3, 0, 1, 2, 3, 5, 0, 1, 2, 3, 4, 0, 1, 0, 3, 4, 3, 5};
-  int jv[21] = {0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6};
-  Real h1v[21] = {5.20094e-1, 8.50895e-2, -1.08374, -2.89555e-1, 2.22531e-1, 9.99115e-1,
+  const int iv[21] = {0, 1, 2, 3, 0, 1, 2, 3, 5, 0, 1, 2, 3, 4, 0, 1, 0, 3, 4, 3, 5};
+  const int jv[21] = {0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6};
+  const Real h1v[21] = {5.20094e-1, 8.50895e-2, -1.08374, -2.89555e-1, 2.22531e-1, 9.99115e-1,
            1.88797, 1.26613, 1.20573e-1, -2.81378e-1, -9.06851e-1, -7.72479e-1,
            -4.89837e-1, -2.57040e-1, 1.61913e-1, 2.57399e-1, -3.25372e-2, 6.98452e-2,
            8.72102e-3, -4.35673e-3, -5.93264e-4};
@@ -473,8 +473,8 @@ PorousFlowWater::dViscosity_dDensity(Real temperature, Real density) const
   d1[6] = d1[5] * d1[1];
 
   /// Prefactor to derivative of viscosity
-  Real sum1 = 0.;
-  Real sum2 = 0.;
+  Real sum1 = 0.0;
+  Real sum2 = 0.0;
   for (unsigned int i = 0; i < 21; i++)
   {
     sum1 += t1[iv[i]] * h1v[i] * d1[jv[i]];


### PR DESCRIPTION
Refs #6845

The Material architecture in the Porous Flow module is as follows.

(1) Level 1 Materials.  A user typically chooses one of these for their
particular simulation type, depending upon the overall type
of simulation.  For instance, there are Materials suitable for:
 (a) 1-phase saturated+unsaturated flow with porepressure as the primary nonlinear variable
 (b) 1-phase saturated+unsaturated flow with log(mass density) as the primary nonlinear variable
 (c) 2-phase flow with the two porepressures being the primary nonlinear variables
 (d) 2-phase flow with (porepressure0, saturation1) being the primary nonlinear variables
The purpose of these Level 1 Materials is to calculate, for each phase,
the porepressure, the saturation, gradients of these, and derivatives of
these wrt to the primary variables.  Also temperature, gradients of
temperature and derivatives of these wrt the primary variables.  Also
the mass fraction matrix, gradients and derivatives.  All these things
are calculated at the quadpoints and potentially the nodes depending on
whether we'll need nodal quantities in the mass-lumping and full-upwinding
in the Kernels.

(2) Level 2 Materials.  A user typically chooses many of these.
They are designed to get information from the Level 1 Materials and
calculate equation-of-state related things, such as fluid-phase density,
viscosity, relative permeability, and also solid-phase porosity.
They are coded so as to be independent of the Level 1 description, eg
a user can use the water density Material in both the 1-phase and
the 2-phase situation.  Typically these Level 2 Materials compute derivatives
of density, viscosity, etc, with respect to porepressures, saturations,
etc, independently of what the actual primary nonlinear variables are.

(3) Level 3 Materials.  These join the Level 2 Materials into std::vectors
for use in Kernels, and also join the derivative information of Level 2 Materials
into std::vectors that contain derivatives wrt the primary nonlinear variables
