### PR TITLE
Flush console output after adaptivity cycles

### DIFF
--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3691,6 +3691,9 @@ FEProblem::adaptMesh()
       computeMarkers();
     if (_adaptivity.adaptMesh())
       meshChanged();
+
+    // Show adaptivity progress
+    _console << std::flush;
   }
 }
 #endif //LIBMESH_ENABLE_AMR


### PR DESCRIPTION
Added a `std::flush` following adaptivity cycles in `FEProblem::adaptMesh()`. This is purely cosmetic and shouldn't affect any tests.

Is there a record for smallest PR?

refs #6894 
