### PR TITLE
PETSc 3.7 compatibility fixes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -40,3 +40,9 @@ Swetha Veeraraghavan <swetha.veeraraghavan@inl.gov>
 Sudipta Biswas <biswas7@purdue.edu>
 Yang Xia <cbh515258@gmail.com>
 Wen Jiang <wen.jiang@inl.gov>
+Jesse Carter <jesse.carter@gmail.com>
+Brian Alger <brianmoose@users.noreply.github.com>
+Alex McCaskey <mccaskeyaj@ornl.gov>
+Stephen Novascone <stephen.novascone@inl.gov>
+Hailong Chen <hailong.chen@inl.gov>
+Andrew Parnell <andrew.parnell@connect.qut.edu.au>

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -103,6 +103,15 @@ MultiMooseEnum getCommonPetscFlags();
 
 /// A helper function to produce a MultiMooseEnum with commonly used PETSc iname options (keys in key-value pairs)
 MultiMooseEnum getCommonPetscKeys();
+
+/**
+ * A wrapper function for dealing with different versions of
+ * PetscOptionsSetValue.  This is not generally called from
+ * MOOSE code, it is instead intended to be called by stuff in
+ * MOOSE::PetscSupport.
+ */
+void setSinglePetscOption(const char * name, const char * value);
+
 }
 }
 

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -110,7 +110,7 @@ MultiMooseEnum getCommonPetscKeys();
  * MOOSE code, it is instead intended to be called by stuff in
  * MOOSE::PetscSupport.
  */
-void setSinglePetscOption(const char * name, const char * value);
+void setSinglePetscOption(const std::string & name, const std::string & value = "");
 
 }
 }

--- a/framework/src/splits/ContactSplit.C
+++ b/framework/src/splits/ContactSplit.C
@@ -78,17 +78,17 @@ ContactSplit::setup(const std::string& prefix)
       oval << _contact_master.size();
       val  =  oval.str();
     }
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
     for (unsigned int j = 0;  j < _contact_master.size(); ++j) {
       std::ostringstream oopt;
       oopt << dmprefix << "contact_" << j;
       opt = oopt.str();
       val = _contact_master[j]+","+_contact_slave[j];
-      Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+      Moose::PetscSupport::setSinglePetscOption(opt, val);
       if (_contact_displaced[j]) {
   opt = opt + "_displaced";
   val = "yes";
-  Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+  Moose::PetscSupport::setSinglePetscOption(opt, val);
       }
     }
   }
@@ -100,17 +100,17 @@ ContactSplit::setup(const std::string& prefix)
       oval << _uncontact_master.size();
       val  =  oval.str();
     }
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
     for (unsigned int j = 0;  j < _uncontact_master.size(); ++j) {
       std::ostringstream oopt;
       oopt << dmprefix << "uncontact_" << j;
       opt = oopt.str();
       val = _uncontact_master[j]+","+_uncontact_slave[j];
-      Moose::PetscSupport::setSinglePetscOption(opt.c_str(),val.c_str());
+      Moose::PetscSupport::setSinglePetscOption(opt, val);
       if (_uncontact_displaced[j]) {
   opt = opt + "_displaced";
   val = "yes";
-  Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+  Moose::PetscSupport::setSinglePetscOption(opt, val);
       }
     }
   }

--- a/framework/src/splits/ContactSplit.C
+++ b/framework/src/splits/ContactSplit.C
@@ -78,20 +78,17 @@ ContactSplit::setup(const std::string& prefix)
       oval << _contact_master.size();
       val  =  oval.str();
     }
-    ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(_communicator.get(),ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
     for (unsigned int j = 0;  j < _contact_master.size(); ++j) {
       std::ostringstream oopt;
       oopt << dmprefix << "contact_" << j;
       opt = oopt.str();
       val = _contact_master[j]+","+_contact_slave[j];
-      ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-      CHKERRABORT(_communicator.get(),ierr);
+      Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
       if (_contact_displaced[j]) {
   opt = opt + "_displaced";
   val = "yes";
-  ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-  CHKERRABORT(_communicator.get(),ierr);
+  Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
       }
     }
   }
@@ -103,20 +100,17 @@ ContactSplit::setup(const std::string& prefix)
       oval << _uncontact_master.size();
       val  =  oval.str();
     }
-    ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-    CHKERRABORT(_communicator.get(),ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
     for (unsigned int j = 0;  j < _uncontact_master.size(); ++j) {
       std::ostringstream oopt;
       oopt << dmprefix << "uncontact_" << j;
       opt = oopt.str();
       val = _uncontact_master[j]+","+_uncontact_slave[j];
-      ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-      CHKERRABORT(_communicator.get(),ierr);
+      Moose::PetscSupport::setSinglePetscOption(opt.c_str(),val.c_str());
       if (_uncontact_displaced[j]) {
   opt = opt + "_displaced";
   val = "yes";
-  ierr = PetscOptionsSetValue(opt.c_str(),val.c_str());
-  CHKERRABORT(_communicator.get(),ierr);
+  Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
       }
     }
   }

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -87,7 +87,7 @@ Split::setup(const std::string& prefix)
     val="";
     for (unsigned int j = 0; j < _vars.size(); ++j)
       val += (j ? "," : "") + _vars[j];
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
   }
 
   // block options
@@ -96,7 +96,7 @@ Split::setup(const std::string& prefix)
     val = "";
     for (unsigned int j = 0; j < _blocks.size(); ++j)
       val += (j ? "," : "") + _blocks[j];
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
   }
 
   // side options
@@ -105,7 +105,7 @@ Split::setup(const std::string& prefix)
     val = "";
     for (unsigned int j = 0; j < _sides.size(); ++j)
       val += (j ? "," : "") + _sides[j];
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
   }
 
   // unside options
@@ -114,7 +114,7 @@ Split::setup(const std::string& prefix)
     val = "";
     for (unsigned int j = 0; j < _unsides.size(); ++j)
       val += (j ? "," : "") + _unsides[j];
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
   }
 
   if (_splitting.size()) {
@@ -122,7 +122,7 @@ Split::setup(const std::string& prefix)
     // with the following parameters (unless overridden by the user-specified petsc_options below).
     opt = prefix + "pc_type";
     val = "fieldsplit";
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
 
     // set Splitting Type
     const char * petsc_splitting_type[] = {
@@ -132,7 +132,7 @@ Split::setup(const std::string& prefix)
       "schur"
     };
     opt = prefix + "pc_fieldsplit_type";
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), petsc_splitting_type[_splitting_type]);
+    Moose::PetscSupport::setSinglePetscOption(opt, petsc_splitting_type[_splitting_type]);
 
     if (_splitting_type == SplittingTypeSchur)
     {
@@ -144,7 +144,7 @@ Split::setup(const std::string& prefix)
         "full"
       };
       opt = prefix + "pc_fieldsplit_schur_fact_type";
-      Moose::PetscSupport::setSinglePetscOption(opt.c_str(), petsc_schur_type[_splitting_type]);
+      Moose::PetscSupport::setSinglePetscOption(opt, petsc_schur_type[_splitting_type]);
 
       // set Schur Preconditioner
       const char * petsc_schur_pre[] = {
@@ -157,7 +157,7 @@ Split::setup(const std::string& prefix)
         #endif
       };
       opt = prefix + "pc_fieldsplit_schur_precondition";
-      Moose::PetscSupport::setSinglePetscOption(opt.c_str(), petsc_schur_pre[_schur_pre]);
+      Moose::PetscSupport::setSinglePetscOption(opt, petsc_schur_pre[_schur_pre]);
 
       // set Schur AInv
       const char * petsc_schur_ainv[] = {
@@ -165,7 +165,7 @@ Split::setup(const std::string& prefix)
         "lump"
       };
       opt = prefix + "mat_schur_complement_ainv_type";
-      Moose::PetscSupport::setSinglePetscOption(opt.c_str(), petsc_schur_ainv[_schur_ainv]);
+      Moose::PetscSupport::setSinglePetscOption(opt, petsc_schur_ainv[_schur_ainv]);
     }
     // FIXME: How would we support the user-provided Pmat?
 
@@ -174,13 +174,13 @@ Split::setup(const std::string& prefix)
     std::ostringstream sval;
     sval << _splitting.size();
     val = sval.str();
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
 
     opt = dmprefix + "fieldsplit_names";
     val = "";
     for (unsigned int i = 0; i < _splitting.size(); ++i)
       val += (i ? "," : "") + _splitting[i];
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, val);
 
     // Finally, recursively configure the splits contained within this split.
     for (unsigned int i = 0; i < _splitting.size(); ++i)
@@ -199,7 +199,7 @@ Split::setup(const std::string& prefix)
     if (op[0] != '-')
       mooseError("Invalid petsc option name " << op << " for Split " << _name);
     std::string opt = prefix + op.substr(1);
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), PETSC_NULL);
+    Moose::PetscSupport::setSinglePetscOption(opt);
   }
   for (unsigned j = 0; j < _petsc_options.inames.size(); ++j)
   {
@@ -208,7 +208,7 @@ Split::setup(const std::string& prefix)
     if (op[0] != '-')
       mooseError("Invalid petsc option name " << op << " for Split " << _name);
     std::string opt = prefix + op.substr(1);
-    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), _petsc_options.values[j].c_str());
+    Moose::PetscSupport::setSinglePetscOption(opt, _petsc_options.values[j]);
   }
 }
 

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -87,8 +87,7 @@ Split::setup(const std::string& prefix)
     val="";
     for (unsigned int j = 0; j < _vars.size(); ++j)
       val += (j ? "," : "") + _vars[j];
-    ierr = PetscOptionsSetValue(opt.c_str(), val.c_str());
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
   }
 
   // block options
@@ -97,8 +96,7 @@ Split::setup(const std::string& prefix)
     val = "";
     for (unsigned int j = 0; j < _blocks.size(); ++j)
       val += (j ? "," : "") + _blocks[j];
-    ierr = PetscOptionsSetValue(opt.c_str(), val.c_str());
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
   }
 
   // side options
@@ -107,8 +105,7 @@ Split::setup(const std::string& prefix)
     val = "";
     for (unsigned int j = 0; j < _sides.size(); ++j)
       val += (j ? "," : "") + _sides[j];
-    ierr = PetscOptionsSetValue(opt.c_str(), val.c_str());
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
   }
 
   // unside options
@@ -117,8 +114,7 @@ Split::setup(const std::string& prefix)
     val = "";
     for (unsigned int j = 0; j < _unsides.size(); ++j)
       val += (j ? "," : "") + _unsides[j];
-    ierr = PetscOptionsSetValue(opt.c_str(), val.c_str());
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
   }
 
   if (_splitting.size()) {
@@ -126,8 +122,7 @@ Split::setup(const std::string& prefix)
     // with the following parameters (unless overridden by the user-specified petsc_options below).
     opt = prefix + "pc_type";
     val = "fieldsplit";
-    ierr = PetscOptionsSetValue(opt.c_str(), val.c_str());
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
 
     // set Splitting Type
     const char * petsc_splitting_type[] = {
@@ -137,8 +132,7 @@ Split::setup(const std::string& prefix)
       "schur"
     };
     opt = prefix + "pc_fieldsplit_type";
-    ierr = PetscOptionsSetValue(opt.c_str(), petsc_splitting_type[_splitting_type]);
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), petsc_splitting_type[_splitting_type]);
 
     if (_splitting_type == SplittingTypeSchur)
     {
@@ -150,8 +144,7 @@ Split::setup(const std::string& prefix)
         "full"
       };
       opt = prefix + "pc_fieldsplit_schur_fact_type";
-      ierr = PetscOptionsSetValue(opt.c_str(), petsc_schur_type[_splitting_type]);
-      CHKERRABORT(_communicator.get(), ierr);
+      Moose::PetscSupport::setSinglePetscOption(opt.c_str(), petsc_schur_type[_splitting_type]);
 
       // set Schur Preconditioner
       const char * petsc_schur_pre[] = {
@@ -164,8 +157,7 @@ Split::setup(const std::string& prefix)
         #endif
       };
       opt = prefix + "pc_fieldsplit_schur_precondition";
-      ierr = PetscOptionsSetValue(opt.c_str(), petsc_schur_pre[_schur_pre]);
-      CHKERRABORT(_communicator.get(), ierr);
+      Moose::PetscSupport::setSinglePetscOption(opt.c_str(), petsc_schur_pre[_schur_pre]);
 
       // set Schur AInv
       const char * petsc_schur_ainv[] = {
@@ -173,8 +165,7 @@ Split::setup(const std::string& prefix)
         "lump"
       };
       opt = prefix + "mat_schur_complement_ainv_type";
-      ierr = PetscOptionsSetValue(opt.c_str(), petsc_schur_ainv[_schur_ainv]);
-      CHKERRABORT(_communicator.get(), ierr);
+      Moose::PetscSupport::setSinglePetscOption(opt.c_str(), petsc_schur_ainv[_schur_ainv]);
     }
     // FIXME: How would we support the user-provided Pmat?
 
@@ -183,15 +174,13 @@ Split::setup(const std::string& prefix)
     std::ostringstream sval;
     sval << _splitting.size();
     val = sval.str();
-    ierr = PetscOptionsSetValue(opt.c_str(), val.c_str());
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
 
     opt = dmprefix + "fieldsplit_names";
     val = "";
     for (unsigned int i = 0; i < _splitting.size(); ++i)
       val += (i ? "," : "") + _splitting[i];
-    ierr = PetscOptionsSetValue(opt.c_str(), val.c_str());
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), val.c_str());
 
     // Finally, recursively configure the splits contained within this split.
     for (unsigned int i = 0; i < _splitting.size(); ++i)
@@ -210,8 +199,7 @@ Split::setup(const std::string& prefix)
     if (op[0] != '-')
       mooseError("Invalid petsc option name " << op << " for Split " << _name);
     std::string opt = prefix + op.substr(1);
-    ierr = PetscOptionsSetValue(opt.c_str(), PETSC_NULL);
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), PETSC_NULL);
   }
   for (unsigned j = 0; j < _petsc_options.inames.size(); ++j)
   {
@@ -220,8 +208,7 @@ Split::setup(const std::string& prefix)
     if (op[0] != '-')
       mooseError("Invalid petsc option name " << op << " for Split " << _name);
     std::string opt = prefix + op.substr(1);
-    ierr = PetscOptionsSetValue(opt.c_str(), _petsc_options.values[j].c_str());
-    CHKERRABORT(_communicator.get(), ierr);
+    Moose::PetscSupport::setSinglePetscOption(opt.c_str(), _petsc_options.values[j].c_str());
   }
 }
 

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -102,18 +102,18 @@ setSolverOptions(SolverParams & solver_params)
   switch (solver_params._type)
   {
   case Moose::ST_PJFNK:
-    setSinglePetscOption("-snes_mf_operator", PETSC_NULL);
+    setSinglePetscOption("-snes_mf_operator");
     break;
 
   case Moose::ST_JFNK:
-    setSinglePetscOption("-snes_mf", PETSC_NULL);
+    setSinglePetscOption("-snes_mf");
     break;
 
   case Moose::ST_NEWTON:
     break;
 
   case Moose::ST_FD:
-    setSinglePetscOption("-snes_fd", PETSC_NULL);
+    setSinglePetscOption("-snes_fd");
     break;
 
   case Moose::ST_LINEAR:
@@ -131,7 +131,7 @@ setSolverOptions(SolverParams & solver_params)
     setSinglePetscOption("-snes_type", "ls");
     setSinglePetscOption("-snes_ls", stringify(ls_type));
 #else
-    setSinglePetscOption("-snes_linesearch_type", stringify(ls_type).c_str());
+    setSinglePetscOption("-snes_linesearch_type", stringify(ls_type));
 #endif
   }
 }
@@ -187,9 +187,9 @@ petscSetOptions(FEProblem & problem)
 
   // Add any additional options specified in the input file
   for (MooseEnumIterator it = petsc.flags.begin(); it != petsc.flags.end(); ++it)
-    setSinglePetscOption(it->c_str(), PETSC_NULL);
+    setSinglePetscOption(it->c_str());
   for (unsigned int i=0; i<petsc.inames.size(); ++i)
-    setSinglePetscOption(petsc.inames[i].c_str(), petsc.values[i].c_str());
+    setSinglePetscOption(petsc.inames[i], petsc.values[i]);
 
   SolverParams& solver_params = problem.solverParams();
   if (solver_params._type != Moose::ST_JFNK  &&
@@ -633,16 +633,16 @@ getCommonPetscKeys()
 }
 
 void
-setSinglePetscOption(const char * name, const char * value)
+setSinglePetscOption(const std::string & name, const std::string & value)
 {
   PetscErrorCode ierr;
 
 #if PETSC_VERSION_LESS_THAN(3,7,0)
-  ierr = PetscOptionsSetValue(name, value);
+  ierr = PetscOptionsSetValue(name.c_str(), value == "" ? PETSC_NULL : value.c_str());
 #else
   // PETSc 3.7.0 and later version.  First argument is the options
   // database to use, NULL indicates the default global database.
-  ierr = PetscOptionsSetValue(PETSC_NULL, name, value);
+  ierr = PetscOptionsSetValue(PETSC_NULL, name.c_str(), value == "" ? PETSC_NULL : value.c_str());
 #endif
 
   // Not convenient to use the usual error checking macro, because we

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -102,22 +102,22 @@ setSolverOptions(SolverParams & solver_params)
   switch (solver_params._type)
   {
   case Moose::ST_PJFNK:
-    PetscOptionsSetValue("-snes_mf_operator", PETSC_NULL);
+    setSinglePetscOption("-snes_mf_operator", PETSC_NULL);
     break;
 
   case Moose::ST_JFNK:
-    PetscOptionsSetValue("-snes_mf", PETSC_NULL);
+    setSinglePetscOption("-snes_mf", PETSC_NULL);
     break;
 
   case Moose::ST_NEWTON:
     break;
 
   case Moose::ST_FD:
-    PetscOptionsSetValue("-snes_fd", PETSC_NULL);
+    setSinglePetscOption("-snes_fd", PETSC_NULL);
     break;
 
   case Moose::ST_LINEAR:
-    PetscOptionsSetValue("-snes_type", "ksponly");
+    setSinglePetscOption("-snes_type", "ksponly");
     break;
   }
 
@@ -128,10 +128,10 @@ setSolverOptions(SolverParams & solver_params)
   if (ls_type != Moose::LS_DEFAULT)
   {
 #if PETSC_VERSION_LESS_THAN(3,3,0)
-    PetscOptionsSetValue("-snes_type", "ls");
-    PetscOptionsSetValue("-snes_ls", stringify(ls_type));
+    setSinglePetscOption("-snes_type", "ls");
+    setSinglePetscOption("-snes_ls", stringify(ls_type));
 #else
-    PetscOptionsSetValue("-snes_linesearch_type", stringify(ls_type).c_str());
+    setSinglePetscOption("-snes_linesearch_type", stringify(ls_type).c_str());
 #endif
   }
 }
@@ -187,9 +187,9 @@ petscSetOptions(FEProblem & problem)
 
   // Add any additional options specified in the input file
   for (MooseEnumIterator it = petsc.flags.begin(); it != petsc.flags.end(); ++it)
-    PetscOptionsSetValue(it->c_str(), PETSC_NULL);
+    setSinglePetscOption(it->c_str(), PETSC_NULL);
   for (unsigned int i=0; i<petsc.inames.size(); ++i)
-    PetscOptionsSetValue(petsc.inames[i].c_str(), petsc.values[i].c_str());
+    setSinglePetscOption(petsc.inames[i].c_str(), petsc.values[i].c_str());
 
   SolverParams& solver_params = problem.solverParams();
   if (solver_params._type != Moose::ST_JFNK  &&
@@ -631,6 +631,26 @@ getCommonPetscKeys()
     "-pc_hypre_boomeramg_strong_threshold -pc_hypre_type -pc_type -snes_atol -snes_linesearch_type "
     "-snes_ls -snes_max_it -snes_rtol -snes_type -sub_ksp_type -sub_pc_type", "", true);
 }
+
+void
+setSinglePetscOption(const char * name, const char * value)
+{
+  PetscErrorCode ierr;
+
+#if PETSC_VERSION_LESS_THAN(3,7,0)
+  ierr = PetscOptionsSetValue(name, value);
+#else
+  // PETSc 3.7.0 and later version.  First argument is the options
+  // database to use, NULL indicates the default global database.
+  ierr = PetscOptionsSetValue(PETSC_NULL, name, value);
+#endif
+
+  // Not convenient to use the usual error checking macro, because we
+  // don't have a specific communicator in this helper function.
+  if (ierr)
+    mooseError("Error setting PETSc option.");
+}
+
 
 } // Namespace PetscSupport
 } // Namespace MOOSE


### PR DESCRIPTION
Add function wrapping PetscOptionsSetValue().  This handles an API change from PETSc 3.6 -> 3.7. 

Refs #5162.
