### PR TITLE
Overhaul PerformanceData

### DIFF
--- a/framework/include/postprocessors/PerformanceData.h
+++ b/framework/include/postprocessors/PerformanceData.h
@@ -36,9 +36,21 @@ public:
    */
   virtual Real getValue();
 
-protected:
-  MooseEnum _column;
+  enum PerfLogCols
+  {
+    N_CALLS,
+    TOTAL_TIME,
+    AVERAGE_TIME,
+    TOTAL_TIME_WITH_SUB,
+    AVERAGE_TIME_WITH_SUB,
+    PERCENT_OF_ACTIVE_TIME,
+    PERCENT_OF_ACTIVE_TIME_WITH_SUB
+  };
 
+protected:
+  PerfLogCols _column;
+
+  std::string _category;
   std::string _event;
 };
 

--- a/framework/src/postprocessors/PerformanceData.C
+++ b/framework/src/postprocessors/PerformanceData.C
@@ -22,43 +22,55 @@ InputParameters validParams<PerformanceData>()
 {
   InputParameters params = validParams<GeneralPostprocessor>();
 
-  MooseEnum column_options("n_calls total_time average_time total_time_with_sub average_time_with_sub percent_of_active_time percent_of_active_time_with_sub");
+  MooseEnum column_options("n_calls total_time average_time total_time_with_sub average_time_with_sub percent_of_active_time percent_of_active_time_with_sub", "total_time_with_sub");
 
-  params.addRequiredParam<MooseEnum>("column", column_options, "The column you want the value of.");
-  params.addRequiredParam<std::string>("event", "The name of the event.");
+  params.addParam<MooseEnum>("column", column_options, "The column you want the value of (Default: total_time_with_sub).");
+  params.addParam<std::string>("category", "Execution", "The category or \"Header\" for the event");
+  params.addRequiredParam<std::string>("event", "The name or \"label\" of the event (\"ALIVE\" and \"ACTIVE\" are also valid events, category and column are ignored for these cases).");
 
   return params;
 }
 
 PerformanceData::PerformanceData(const InputParameters & parameters) :
     GeneralPostprocessor(parameters),
-    _column(getParam<MooseEnum>("column")),
+    _column(static_cast<PerfLogCols>(static_cast<int>(getParam<MooseEnum>("column")))),
+    _category(getParam<std::string>("category")),
     _event(getParam<std::string>("event"))
 {}
 
 Real
 PerformanceData::getValue()
 {
-  PerfData perf_data = Moose::perf_log.get_perf_data(_event, "Execution");
-  double total_time = Moose::perf_log.get_active_time();
+  if (_event == "ALIVE")
+    return Moose::perf_log.get_elapsed_time();
 
+  Real total_time = Moose::perf_log.get_active_time();
+  if (_event == "ACTIVE")
+    return total_time;
+
+  PerfData perf_data = Moose::perf_log.get_perf_data(_event, _category);
   if (perf_data.count == 0)
     return 0.0;
 
-  if (_column == "n_calls")
-    return perf_data.count;
-  else if (_column == "total_time")
-    return perf_data.tot_time;
-  else if (_column == "average_time")
-    return perf_data.tot_time / static_cast<double>(perf_data.count);
-  else if (_column == "total_time_with_sub")
-    return perf_data.tot_time_incl_sub;
-  else if (_column == "average_time_with_sub")
-    return perf_data.tot_time_incl_sub / static_cast<double>(perf_data.count);
-  else if (_column == "percent_of_active_time")
-    return (total_time != 0.) ? perf_data.tot_time / total_time * 100. : 0.;
-  else if (_column == "percent_of_active_time_with_sub")
-    return (total_time != 0.) ? perf_data.tot_time_incl_sub / total_time * 100. : 0.;
+  switch (_column)
+  {
+    case N_CALLS:
+      return perf_data.count;
+    case TOTAL_TIME:
+      return perf_data.tot_time;
+    case AVERAGE_TIME:
+      return perf_data.tot_time / static_cast<double>(perf_data.count);
+    case TOTAL_TIME_WITH_SUB:
+      return perf_data.tot_time_incl_sub;
+    case AVERAGE_TIME_WITH_SUB:
+      return perf_data.tot_time_incl_sub / static_cast<double>(perf_data.count);
+    case PERCENT_OF_ACTIVE_TIME:
+      return (total_time != 0.) ? perf_data.tot_time / total_time * 100. : 0.;
+    case PERCENT_OF_ACTIVE_TIME_WITH_SUB:
+      return (total_time != 0.) ? perf_data.tot_time_incl_sub / total_time * 100. : 0.;
+    default:
+      mooseError("Invalid column!");
+  }
 
-  mooseError("Invalid column!");
+  return 0;
 }

--- a/test/tests/postprocessors/print_perf_data/print_perf_data.i
+++ b/test/tests/postprocessors/print_perf_data/print_perf_data.i
@@ -33,6 +33,14 @@
 []
 
 [Postprocessors]
+  [./elapsed_alive]
+    type = PerformanceData
+    event = 'ALIVE'
+  [../]
+  [./elapsed_active]
+    type = PerformanceData
+    event = 'ACTIVE'
+  [../]
   [./res_calls]
     type = PerformanceData
     column = n_calls
@@ -88,4 +96,5 @@
 [Outputs]
   exodus = true
   csv = true
+  print_perf_log = true
 []


### PR DESCRIPTION
- Add Enum to avoid if/else chain and string comparisons
- Add the ability to get active and alive times
- Add the ability to pull events besides those in 'Execution'
- Add a default column so that retrieving alive and active isn't awkward

closes #6905

Since there isn't a "diffing" test for this capability, there are no tests to change or update.
