### PR TITLE
More PETSc 3.7.0 API changes.

### DIFF
--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1395,10 +1395,12 @@ static PetscErrorCode  DMSetUp_Moose(DM dm)
 
 #undef __FUNCT__
 #define __FUNCT__ "DMSetFromOptions_Moose"
-#if !PETSC_RELEASE_LESS_THAN(3,6,0)
-PetscErrorCode  DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm)
+#if !PETSC_VERSION_LESS_THAN(3,7,0)
+PetscErrorCode  DMSetFromOptions_Moose(PetscOptionItems * /*options*/, DM dm) // >= 3.7.0
+#elif !PETSC_RELEASE_LESS_THAN(3,6,0)
+PetscErrorCode  DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
 #else
-PetscErrorCode  DMSetFromOptions_Moose(DM dm)
+PetscErrorCode  DMSetFromOptions_Moose(DM dm) // < 3.6.0
 #endif
 {
   PetscErrorCode ierr;

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -184,7 +184,11 @@ petscSetOptions(FEProblem & problem)
     char ** args;
 
     PetscGetArgs(&argc, &args);
+#if PETSC_VERSION_LESS_THAN(3,7,0)
     PetscOptionsInsert(&argc, &args, NULL);
+#else
+    PetscOptionsInsert(PETSC_NULL, &argc, &args, NULL);
+#endif
   }
 
   setSolverOptions(problem.solverParams());


### PR DESCRIPTION
I'm also seeing a failure on the test which throws an exception (misc/exception.parallel_exception_residual_transient) but I need to investigate that a bit more to see if its real or if they changed something about the way NaNs in residuals get handled...

Refs #5162.
