### PR TITLE
Refactoring Transient to get rid of the uneccessary adaptivity

### DIFF
--- a/test/tests/outputs/system_info/tests
+++ b/test/tests/outputs/system_info/tests
@@ -10,20 +10,20 @@
     # Check that mesh information prints when the mesh changes
     type = RunApp
     input = 'system_info_mesh.i'
-    expect_out = 'time\s=\s0.1.*?Nodes:.*?time\s=\s0.2.*?Nodes:.*?time\s=\s0.3.*?Nodes:'
+    expect_out = 'time\s=\s0.1.*?Nodes:.*?time\s=\s0.2.*?Nodes:.*?time\s=\s0.3'
   [../]
 
   [./aux]
     # Check that Aux system information prints when the mesh changes
     type = RunApp
     input = 'system_info_mesh.i'
-    expect_out = 'Num DOFs:\s*2889'
+    expect_out = 'Num DOFs:\s*1892'
   [../]
 
   [./nonlinear]
     # Check that Nonlinear system information prints when the mesh changes
     type = RunApp
     input = 'system_info_mesh.i'
-    expect_out = 'Num DOFs:\s*1009'
+    expect_out = 'Num DOFs:\s*672'
   [../]
 []


### PR DESCRIPTION
closes #6913

This PR does some nice refactoring of the main executioner loop in Transient. The existing logic made my eyes bleed. I learned that both `incrementStepOrReject()` and `keepGoing()` are both a big lie.

I pulled the adaptivity out of `incrementStepOrReject()` - YES you read that right, maybe it should have been called `incrementStepOrRejectAndThrowInAdaptivity()`. By doing that and some other refactoring I was able to put `keepGoing()` in a logical place (i.e. the while condition!).

The only real side effect that I'm seeing so far is that it slightly changes when the adapt interval happens. It happens _before_ the step instead of _after_ as @dschwen originally implemented. Either definition is fine and I'm willing to change the behavior. 

Let's see if there are other adverse side effects to playing Monte Carlo in the main Transient Executioner loop.
