### PR TITLE
Use new Mesh/Elem interfaces in libMesh.

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -223,6 +223,8 @@ public:
    */
   virtual const Node & node (const dof_id_type i) const;
   virtual Node & node (const dof_id_type i);
+  virtual const Node & nodeRef (const dof_id_type i) const;
+  virtual Node & nodeRef (const dof_id_type i);
   virtual const Node* nodePtr(const dof_id_type i) const;
   virtual Node* nodePtr(const dof_id_type i);
 

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -233,6 +233,8 @@ public:
    */
   virtual Elem * elem(const dof_id_type i);
   virtual const Elem * elem(const dof_id_type i) const;
+  virtual Elem * elemPtr(const dof_id_type i);
+  virtual const Elem * elemPtr(const dof_id_type i) const;
 
   /**
    * Setter/getter for the _is_changed flag.

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -712,7 +712,7 @@ FEProblem::prepare(const Elem * elem, THREAD_ID tid)
   _assembly[tid]->prepare();
 
   if (_displaced_problem != NULL && (_reinit_displaced_elem || _reinit_displaced_face))
-    _displaced_problem->prepare(_displaced_mesh->elem(elem->id()), tid);
+    _displaced_problem->prepare(_displaced_mesh->elemPtr(elem->id()), tid);
 }
 
 void
@@ -722,7 +722,7 @@ FEProblem::prepareFace(const Elem * elem, THREAD_ID tid)
   _aux.prepareFace(tid, false);
 
   if (_displaced_problem != NULL && (_reinit_displaced_elem || _reinit_displaced_face))
-    _displaced_problem->prepareFace(_displaced_mesh->elem(elem->id()), tid);
+    _displaced_problem->prepareFace(_displaced_mesh->elemPtr(elem->id()), tid);
 }
 
 void
@@ -735,7 +735,7 @@ FEProblem::prepare(const Elem * elem, unsigned int ivar, unsigned int jvar, cons
   _assembly[tid]->prepareBlock(ivar, jvar, dof_indices);
 
   if (_displaced_problem != NULL && (_reinit_displaced_elem || _reinit_displaced_face))
-    _displaced_problem->prepare(_displaced_mesh->elem(elem->id()), ivar, jvar, dof_indices, tid);
+    _displaced_problem->prepare(_displaced_mesh->elemPtr(elem->id()), ivar, jvar, dof_indices, tid);
 }
 
 void
@@ -920,7 +920,7 @@ FEProblem::prepareNeighborShapes(unsigned int var, THREAD_ID tid)
 void
 FEProblem::addGhostedElem(dof_id_type elem_id)
 {
-  if (_mesh.elem(elem_id)->processor_id() != processor_id())
+  if (_mesh.elemPtr(elem_id)->processor_id() != processor_id())
     _ghosted_elems.insert(elem_id);
 }
 
@@ -985,7 +985,7 @@ FEProblem::reinitDirac(const Elem * elem, THREAD_ID tid)
 
   bool have_points = n_points > 0;
   if (_displaced_problem != NULL && (_reinit_displaced_elem))
-    have_points |= _displaced_problem->reinitDirac(_displaced_mesh->elem(elem->id()), tid);
+    have_points |= _displaced_problem->reinitDirac(_displaced_mesh->elemPtr(elem->id()), tid);
 
   return have_points;
 }
@@ -997,7 +997,7 @@ FEProblem::reinitElem(const Elem * elem, THREAD_ID tid)
   _aux.reinitElem(elem, tid);
 
   if (_displaced_problem != NULL && _reinit_displaced_elem)
-    _displaced_problem->reinitElem(_displaced_mesh->elem(elem->id()), tid);
+    _displaced_problem->reinitElem(_displaced_mesh->elemPtr(elem->id()), tid);
 }
 
 void
@@ -1015,7 +1015,7 @@ FEProblem::reinitElemPhys(const Elem * elem, std::vector<Point> phys_points_in_e
   _assembly[tid]->prepare();
 
   if (_displaced_problem != NULL && (_reinit_displaced_elem))
-    _displaced_problem->reinitElemPhys(_displaced_mesh->elem(elem->id()), phys_points_in_elem, tid);
+    _displaced_problem->reinitElemPhys(_displaced_mesh->elemPtr(elem->id()), phys_points_in_elem, tid);
 }
 
 void
@@ -1027,7 +1027,7 @@ FEProblem::reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_i
   _aux.reinitElemFace(elem, side, bnd_id, tid);
 
   if (_displaced_problem != NULL && _reinit_displaced_face)
-    _displaced_problem->reinitElemFace(_displaced_mesh->elem(elem->id()), side, bnd_id, tid);
+    _displaced_problem->reinitElemFace(_displaced_mesh->elemPtr(elem->id()), side, bnd_id, tid);
 }
 
 void
@@ -1149,7 +1149,7 @@ FEProblem::reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side,
 
   // Do the same for the displaced problem
   if (_displaced_problem != NULL)
-    _displaced_problem->reinitNeighborPhys(_displaced_mesh->elem(neighbor->id()), neighbor_side, physical_points, tid);
+    _displaced_problem->reinitNeighborPhys(_displaced_mesh->elemPtr(neighbor->id()), neighbor_side, physical_points, tid);
 }
 
 void
@@ -1171,7 +1171,7 @@ FEProblem::reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & 
 
   // Do the same for the displaced problem
   if (_displaced_problem != NULL)
-    _displaced_problem->reinitNeighborPhys(_displaced_mesh->elem(neighbor->id()), physical_points, tid);
+    _displaced_problem->reinitNeighborPhys(_displaced_mesh->elemPtr(neighbor->id()), physical_points, tid);
 }
 
 void
@@ -1191,7 +1191,7 @@ FEProblem::getDiracElements(std::set<const Elem *> & elems)
       std::set<const Elem *>::iterator end = displaced_elements.end();
 
       for (;it != end; ++it)
-        elems.insert(_mesh.elem((*it)->id()));
+        elems.insert(_mesh.elemPtr((*it)->id()));
     }
   }
 }

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -1036,7 +1036,7 @@ FEProblem::reinitNode(const Node * node, THREAD_ID tid)
   _assembly[tid]->reinit(node);
 
   if (_displaced_problem != NULL && _reinit_displaced_elem)
-    _displaced_problem->reinitNode(&_displaced_mesh->node(node->id()), tid);
+    _displaced_problem->reinitNode(&_displaced_mesh->nodeRef(node->id()), tid);
 
   _nl.reinitNode(node, tid);
   _aux.reinitNode(node, tid);
@@ -1048,7 +1048,7 @@ FEProblem::reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID tid)
   _assembly[tid]->reinit(node);
 
   if (_displaced_problem != NULL && _reinit_displaced_face)
-    _displaced_problem->reinitNodeFace(&_displaced_mesh->node(node->id()), bnd_id, tid);
+    _displaced_problem->reinitNodeFace(&_displaced_mesh->nodeRef(node->id()), bnd_id, tid);
 
   _nl.reinitNodeFace(node, bnd_id, tid);
   _aux.reinitNodeFace(node, bnd_id, tid);
@@ -1081,7 +1081,7 @@ FEProblem::reinitNodeNeighbor(const Node * node, THREAD_ID tid)
   _assembly[tid]->reinitNodeNeighbor(node);
 
   if (_displaced_problem != NULL && _reinit_displaced_elem)
-    _displaced_problem->reinitNodeNeighbor(&_displaced_mesh->node(node->id()), tid);
+    _displaced_problem->reinitNodeNeighbor(&_displaced_mesh->nodeRef(node->id()), tid);
 
   _nl.reinitNodeNeighbor(node, tid);
   _aux.reinitNodeNeighbor(node, tid);

--- a/framework/src/base/FlagElementsThread.C
+++ b/framework/src/base/FlagElementsThread.C
@@ -85,7 +85,7 @@ FlagElementsThread::onElement(const Elem *elem)
   const_cast<Elem *>(elem)->set_refinement_flag((Elem::RefinementState)marker_value);
 
   if (_displaced_problem)
-    _displaced_problem->mesh().elem(elem->id())->set_refinement_flag((Elem::RefinementState)marker_value);
+    _displaced_problem->mesh().elemPtr(elem->id())->set_refinement_flag((Elem::RefinementState)marker_value);
 }
 
 void

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1480,7 +1480,7 @@ NonlinearSystem::findImplicitGeometricCouplingEntries(GeometricSearchData & geom
           dof_id_type cur_elem = elems[el];
 
           std::vector<dof_id_type> dof_indices;
-          dofMap().dof_indices(_mesh.elem(cur_elem), dof_indices);
+          dofMap().dof_indices(_mesh.elemPtr(cur_elem), dof_indices);
 
           for (unsigned int di=0; di < dof_indices.size(); di++)
             unique_slave_indices.insert(dof_indices[di]);
@@ -1502,7 +1502,7 @@ NonlinearSystem::findImplicitGeometricCouplingEntries(GeometricSearchData & geom
             dof_id_type cur_elem = elems[el];
 
             std::vector<dof_id_type> dof_indices;
-            dofMap().dof_indices(_mesh.elem(cur_elem), dof_indices);
+            dofMap().dof_indices(_mesh.elemPtr(cur_elem), dof_indices);
 
             for (unsigned int di=0; di < dof_indices.size(); di++)
               unique_master_indices.insert(dof_indices[di]);

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -974,7 +974,7 @@ NonlinearSystem::setConstraintSlaveValues(NumericVector<Number> & solution, bool
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
         dof_id_type slave_node_num = slave_nodes[i];
-        Node & slave_node = _mesh.node(slave_node_num);
+        Node & slave_node = _mesh.nodeRef(slave_node_num);
 
         if (slave_node.processor_id() == processor_id())
         {
@@ -1067,7 +1067,7 @@ NonlinearSystem::constraintResiduals(NumericVector<Number> & residual, bool disp
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
         dof_id_type slave_node_num = slave_nodes[i];
-        Node & slave_node = _mesh.node(slave_node_num);
+        Node & slave_node = _mesh.nodeRef(slave_node_num);
 
         if (slave_node.processor_id() == processor_id())
         {
@@ -1443,7 +1443,7 @@ NonlinearSystem::computeNodalBCs(NumericVector<Number> & residual)
 void
 NonlinearSystem::getNodeDofs(unsigned int node_id, std::vector<dof_id_type> & dofs)
 {
-  const Node & node = _mesh.node(node_id);
+  const Node & node = _mesh.nodeRef(node_id);
   unsigned int s = number();
   if (node.has_dofs(s))
   {
@@ -1634,7 +1634,7 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
         dof_id_type slave_node_num = slave_nodes[i];
-        Node & slave_node = _mesh.node(slave_node_num);
+        Node & slave_node = _mesh.nodeRef(slave_node_num);
 
         if (slave_node.processor_id() == processor_id())
         {

--- a/framework/src/base/ResetDisplacedMeshThread.C
+++ b/framework/src/base/ResetDisplacedMeshThread.C
@@ -38,7 +38,7 @@ ResetDisplacedMeshThread::onNode(NodeRange::const_iterator & nd)
   Node & displaced_node = **nd;
 
   // Get the same node from the reference mesh.
-  Node & reference_node = _ref_mesh.node(displaced_node.id());
+  Node & reference_node = _ref_mesh.nodeRef(displaced_node.id());
 
   // Undisplace the node
   for (unsigned int i=0; i<LIBMESH_DIM; ++i)

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -443,7 +443,7 @@ SystemBase::augmentSendList(std::vector<dof_id_type> & send_list)
       // might live on nodes connected to this element.
       for (unsigned int n=0; n<elem->n_nodes(); n++)
       {
-        Node * node = elem->get_node(n);
+        Node * node = elem->node_ptr(n);
 
         // Have to get each variable's dofs
         for (unsigned int v=0; v<n_vars; v++)

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -423,7 +423,7 @@ SystemBase::augmentSendList(std::vector<dof_id_type> & send_list)
       elem_id != ghosted_elems.end();
       ++elem_id)
   {
-    Elem * elem = _mesh.elem(*elem_id);
+    Elem * elem = _mesh.elemPtr(*elem_id);
 
     if (elem->active())
     {

--- a/framework/src/base/UpdateDisplacedMeshThread.C
+++ b/framework/src/base/UpdateDisplacedMeshThread.C
@@ -92,7 +92,7 @@ UpdateDisplacedMeshThread::onNode(SemiLocalNodeRange::const_iterator & nd)
 {
   Node & displaced_node = *(*nd);
 
-  Node & reference_node = _ref_mesh.node(displaced_node.id());
+  Node & reference_node = _ref_mesh.nodeRef(displaced_node.id());
 
   for (unsigned int i=0; i<_num_var_nums; i++)
   {

--- a/framework/src/constraints/EqualValueBoundaryConstraint.C
+++ b/framework/src/constraints/EqualValueBoundaryConstraint.C
@@ -54,7 +54,7 @@ EqualValueBoundaryConstraint::EqualValueBoundaryConstraint(const InputParameters
 
     for (in = nodelist.begin(); in != nodelist.end(); ++in)
     {
-      if ((*in != _master_node_id) && (_mesh.node(*in).processor_id() == _subproblem.processor_id()))
+      if ((*in != _master_node_id) && (_mesh.nodeRef(*in).processor_id() == _subproblem.processor_id()))
         _connected_nodes.push_back(*in); //_connected_nodes defines slave nodes in the base class
     }
   }
@@ -68,7 +68,7 @@ EqualValueBoundaryConstraint::EqualValueBoundaryConstraint(const InputParameters
     std::vector<unsigned int>::iterator its;
     for (its = _slave_node_ids.begin(); its != _slave_node_ids.end(); ++its)
     {
-      if ((_mesh.node(*its).processor_id() == _subproblem.processor_id()) && (*its != _master_node_id))
+      if ((_mesh.nodeRef(*its).processor_id() == _subproblem.processor_id()) && (*its != _master_node_id))
         _connected_nodes.push_back(*its);
     }
   }

--- a/framework/src/constraints/LinearNodalConstraint.C
+++ b/framework/src/constraints/LinearNodalConstraint.C
@@ -52,7 +52,7 @@ LinearNodalConstraint::LinearNodalConstraint(const InputParameters & parameters)
 
     for (in = nodelist.begin(); in != nodelist.end(); ++in)
     {
-      if (_mesh.node(*in).processor_id() == _subproblem.processor_id())
+      if (_mesh.nodeRef(*in).processor_id() == _subproblem.processor_id())
         _connected_nodes.push_back(*in); //defining slave nodes in the base class
     }
   }
@@ -60,7 +60,7 @@ LinearNodalConstraint::LinearNodalConstraint(const InputParameters & parameters)
   {
     for (its = _slave_node_ids.begin(); its != _slave_node_ids.end(); ++its)
     {
-      if (_mesh.node(*its).processor_id() == _subproblem.processor_id())
+      if (_mesh.nodeRef(*its).processor_id() == _subproblem.processor_id())
         _connected_nodes.push_back(*its);
     }
   }

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -238,7 +238,7 @@ NodeFaceConstraint::getConnectedDofIndices(unsigned int var_num)
 
     std::vector<dof_id_type> dof_indices;
 
-    var.getDofIndices(_mesh.elem(cur_elem), dof_indices);
+    var.getDofIndices(_mesh.elemPtr(cur_elem), dof_indices);
 
     for (unsigned int di=0; di < dof_indices.size(); di++)
       unique_dof_indices.insert(dof_indices[di]);

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -328,7 +328,7 @@ DiracKernel::currentPointCachedID()
 bool
 DiracKernel::hasPointsOnElem(const Elem * elem)
 {
-  return _local_dirac_kernel_info.getElements().count(_mesh.elem(elem->id())) != 0;
+  return _local_dirac_kernel_info.getElements().count(_mesh.elemPtr(elem->id())) != 0;
 }
 
 bool

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -66,13 +66,13 @@ findContactPoint(PenetrationInfo & p_info,
 
   if (dim == 1)
   {
-    Node * left(master_elem->get_node(0));
+    Node * left(master_elem->node_ptr(0));
     Node * right(left);
     Real leftCoor((*left)(0));
     Real rightCoor(leftCoor);
     for (unsigned i(1); i < master_elem->n_nodes(); ++i)
     {
-      Node * curr = master_elem->get_node(i);
+      Node * curr = master_elem->node_ptr(i);
       Real coor = (*curr)(0);
       if (coor < leftCoor)
       {
@@ -287,12 +287,12 @@ void restrictPointToFace(Point& p,
       if (xi < -1.0)
       {
         xi = -1.0;
-        off_edge_nodes.push_back(side->get_node(0));
+        off_edge_nodes.push_back(side->node_ptr(0));
       }
       else if (xi > 1.0)
       {
         xi = 1.0;
-        off_edge_nodes.push_back(side->get_node(1));
+        off_edge_nodes.push_back(side->node_ptr(1));
       }
       break;
     }
@@ -307,43 +307,43 @@ void restrictPointToFace(Point& p,
       {
         xi = 0.0;
         eta = 0.0;
-        off_edge_nodes.push_back(side->get_node(0));
+        off_edge_nodes.push_back(side->node_ptr(0));
       }
       else if (xi > 0.0 && xi < 1.0
                && eta < 0.0)
       {
         eta = 0.0;
-        off_edge_nodes.push_back(side->get_node(0));
-        off_edge_nodes.push_back(side->get_node(1));
+        off_edge_nodes.push_back(side->node_ptr(0));
+        off_edge_nodes.push_back(side->node_ptr(1));
       }
       else if (eta > 0.0 && eta < 1.0
                && xi < 0.0)
       {
         xi = 0.0;
-        off_edge_nodes.push_back(side->get_node(2));
-        off_edge_nodes.push_back(side->get_node(0));
+        off_edge_nodes.push_back(side->node_ptr(2));
+        off_edge_nodes.push_back(side->node_ptr(0));
       }
       else if (xi >= 1.0
                && (eta - xi) <= -1.0)
       {
         xi = 1.0;
         eta = 0.0;
-        off_edge_nodes.push_back(side->get_node(1));
+        off_edge_nodes.push_back(side->node_ptr(1));
       }
       else if (eta >= 1.0
                && (eta - xi) >= 1.0)
       {
         xi = 0.0;
         eta = 1.0;
-        off_edge_nodes.push_back(side->get_node(2));
+        off_edge_nodes.push_back(side->node_ptr(2));
       }
       else if ((xi + eta) > 1.0)
       {
         Real delta = (xi+eta-1.0)/2.0;
         xi -= delta;
         eta -= delta;
-        off_edge_nodes.push_back(side->get_node(1));
-        off_edge_nodes.push_back(side->get_node(2));
+        off_edge_nodes.push_back(side->node_ptr(1));
+        off_edge_nodes.push_back(side->node_ptr(2));
       }
       break;
     }
@@ -359,17 +359,17 @@ void restrictPointToFace(Point& p,
         if (eta < -1.0)
         {
           eta = -1.0;
-          off_edge_nodes.push_back(side->get_node(0));
+          off_edge_nodes.push_back(side->node_ptr(0));
         }
         else if (eta > 1.0)
         {
           eta = 1.0;
-          off_edge_nodes.push_back(side->get_node(3));
+          off_edge_nodes.push_back(side->node_ptr(3));
         }
         else
         {
-          off_edge_nodes.push_back(side->get_node(3));
-          off_edge_nodes.push_back(side->get_node(0));
+          off_edge_nodes.push_back(side->node_ptr(3));
+          off_edge_nodes.push_back(side->node_ptr(0));
         }
       }
       else if (xi > 1.0)
@@ -378,17 +378,17 @@ void restrictPointToFace(Point& p,
         if (eta < -1.0)
         {
           eta = -1.0;
-          off_edge_nodes.push_back(side->get_node(1));
+          off_edge_nodes.push_back(side->node_ptr(1));
         }
         else if (eta > 1.0)
         {
           eta = 1.0;
-          off_edge_nodes.push_back(side->get_node(2));
+          off_edge_nodes.push_back(side->node_ptr(2));
         }
         else
         {
-          off_edge_nodes.push_back(side->get_node(1));
-          off_edge_nodes.push_back(side->get_node(2));
+          off_edge_nodes.push_back(side->node_ptr(1));
+          off_edge_nodes.push_back(side->node_ptr(2));
         }
       }
       else
@@ -396,14 +396,14 @@ void restrictPointToFace(Point& p,
         if (eta < -1.0)
         {
           eta = -1.0;
-          off_edge_nodes.push_back(side->get_node(0));
-          off_edge_nodes.push_back(side->get_node(1));
+          off_edge_nodes.push_back(side->node_ptr(0));
+          off_edge_nodes.push_back(side->node_ptr(1));
         }
         else if (eta > 1.0)
         {
           eta = 1.0;
-          off_edge_nodes.push_back(side->get_node(2));
-          off_edge_nodes.push_back(side->get_node(3));
+          off_edge_nodes.push_back(side->node_ptr(2));
+          off_edge_nodes.push_back(side->node_ptr(3));
         }
       }
       break;

--- a/framework/src/geomsearch/NearestNodeThread.C
+++ b/framework/src/geomsearch/NearestNodeThread.C
@@ -46,7 +46,7 @@ NearestNodeThread::operator() (const NodeIdRange & range)
   {
     dof_id_type node_id = *nd;
 
-    const Node & node = _mesh.node(node_id);
+    const Node & node = _mesh.nodeRef(node_id);
 
     const Node * closest_node = NULL;
     Real closest_distance = std::numeric_limits<Real>::max();
@@ -57,7 +57,7 @@ NearestNodeThread::operator() (const NodeIdRange & range)
 
     for (unsigned int k=0; k<n_neighbor_nodes; k++)
     {
-      const Node * cur_node = &_mesh.node(neighbor_nodes[k]);
+      const Node * cur_node = &_mesh.nodeRef(neighbor_nodes[k]);
       Real distance = ((*cur_node) - node).norm();
 
       if (distance < closest_distance)

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -113,7 +113,7 @@ PenetrationThread::operator() (const NodeIdRange & range)
 
   for (NodeIdRange::const_iterator nd = range.begin() ; nd != range.end(); ++nd)
   {
-    const Node & node = _mesh.node(*nd);
+    const Node & node = _mesh.nodeRef(*nd);
 
     // We're going to get a reference to the pointer for the pinfo for this node
     // This will allow us to manipulate this pointer without having to go through

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -187,7 +187,7 @@ PenetrationThread::operator() (const NodeIdRange & range)
       for (unsigned int j=0; j<closest_elems.size(); j++)
       {
         dof_id_type elem_id = closest_elems[j];
-        const Elem * elem = _mesh.elem(elem_id);
+        const Elem * elem = _mesh.elemPtr(elem_id);
 
         std::vector<PenetrationInfo*> thisElemInfo;
         std::vector<const Node*> nodesThatMustBeOnSide;
@@ -1512,7 +1512,7 @@ PenetrationThread::getInfoForFacesWithCommonNodes(const Node *slave_node,
   {
     if (elems_to_exclude.find(elems_connected_to_node[ecni]) != elems_to_exclude.end())
       continue;
-    const Elem * elem = _mesh.elem(elems_connected_to_node[ecni]);
+    const Elem * elem = _mesh.elemPtr(elems_connected_to_node[ecni]);
 
     std::vector<const Node*> nodevec;
     for (unsigned int ni=0; ni<elem->n_nodes(); ++ni)

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -731,8 +731,8 @@ PenetrationThread::getSideCornerNodes(Elem* side,
   const ElemType t(side->type());
   corner_nodes.clear();
 
-  corner_nodes.push_back(side->get_node(0));
-  corner_nodes.push_back(side->get_node(1));
+  corner_nodes.push_back(side->node_ptr(0));
+  corner_nodes.push_back(side->node_ptr(1));
   switch (t)
   {
     case EDGE2:
@@ -745,7 +745,7 @@ PenetrationThread::getSideCornerNodes(Elem* side,
     case TRI3:
     case TRI6:
     {
-      corner_nodes.push_back(side->get_node(2));
+      corner_nodes.push_back(side->node_ptr(2));
       break;
     }
 
@@ -753,8 +753,8 @@ PenetrationThread::getSideCornerNodes(Elem* side,
     case QUAD8:
     case QUAD9:
     {
-      corner_nodes.push_back(side->get_node(2));
-      corner_nodes.push_back(side->get_node(3));
+      corner_nodes.push_back(side->node_ptr(2));
+      corner_nodes.push_back(side->node_ptr(3));
       break;
     }
 
@@ -802,7 +802,7 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
         {
           xi = -1.0;
           off_of_this_edge=true;
-          closest_node = side->get_node(0);
+          closest_node = side->node_ptr(0);
         }
       }
       else if (local_node_indices[0] == 1)
@@ -811,7 +811,7 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
         {
           xi = 1.0;
           off_of_this_edge=true;
-          closest_node = side->get_node(1);
+          closest_node = side->node_ptr(1);
         }
       }
       else
@@ -832,9 +832,9 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
           eta = 0.0;
           off_of_this_edge=true;
           if (xi<0.0)
-            closest_node = side->get_node(0);
+            closest_node = side->node_ptr(0);
           else if (xi>1.0)
-            closest_node = side->get_node(1);
+            closest_node = side->node_ptr(1);
         }
       }
       else if ((local_node_indices[0] == 1) &&
@@ -847,9 +847,9 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
           eta -= delta;
           off_of_this_edge=true;
           if (xi>1.0)
-            closest_node = side->get_node(1);
+            closest_node = side->node_ptr(1);
           else if (xi<0.0)
-            closest_node = side->get_node(2);
+            closest_node = side->node_ptr(2);
         }
       }
       else if ((local_node_indices[0] == 0) &&
@@ -860,9 +860,9 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
           xi = 0.0;
           off_of_this_edge=true;
           if (eta>1.0)
-            closest_node = side->get_node(2);
+            closest_node = side->node_ptr(2);
           else if (eta<0.0)
-            closest_node = side->get_node(0);
+            closest_node = side->node_ptr(0);
         }
       }
       else
@@ -885,9 +885,9 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
           eta = -1.0;
           off_of_this_edge=true;
           if (xi<-1.0)
-            closest_node = side->get_node(0);
+            closest_node = side->node_ptr(0);
           else if (xi>1.0)
-            closest_node = side->get_node(1);
+            closest_node = side->node_ptr(1);
         }
       }
       else if ((local_node_indices[0] == 1) &&
@@ -898,9 +898,9 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
           xi = 1.0;
           off_of_this_edge=true;
           if (eta<-1.0)
-            closest_node = side->get_node(1);
+            closest_node = side->node_ptr(1);
           else if (eta>1.0)
-            closest_node = side->get_node(2);
+            closest_node = side->node_ptr(2);
         }
       }
       else if ((local_node_indices[0] == 2) &&
@@ -911,9 +911,9 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
           eta = 1.0;
           off_of_this_edge=true;
           if (xi<-1.0)
-            closest_node = side->get_node(3);
+            closest_node = side->node_ptr(3);
           else if (xi>1.0)
-            closest_node = side->get_node(2);
+            closest_node = side->node_ptr(2);
         }
       }
       else if ((local_node_indices[0] == 0) &&
@@ -924,9 +924,9 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
           xi = -1.0;
           off_of_this_edge=true;
           if (eta<-1.0)
-            closest_node = side->get_node(0);
+            closest_node = side->node_ptr(0);
           else if (eta>1.0)
-            closest_node = side->get_node(3);
+            closest_node = side->node_ptr(3);
         }
       }
       else
@@ -967,13 +967,13 @@ PenetrationThread::restrictPointToFace(Point& p,
       {
         xi = -1.0;
         off_of_this_face=true;
-        closest_node = side->get_node(0);
+        closest_node = side->node_ptr(0);
       }
       else if (xi > 1.0)
       {
         xi = 1.0;
         off_of_this_face=true;
-        closest_node = side->get_node(1);
+        closest_node = side->node_ptr(1);
       }
       break;
     }
@@ -987,13 +987,13 @@ PenetrationThread::restrictPointToFace(Point& p,
         off_of_this_face=true;
         if (xi < 0.5)
         {
-          closest_node = side->get_node(0);
+          closest_node = side->node_ptr(0);
           if (xi<0.0)
             xi = 0.0;
         }
         else
         {
-          closest_node = side->get_node(1);
+          closest_node = side->node_ptr(1);
           if (xi>1.0)
             xi = 1.0;
         }
@@ -1006,7 +1006,7 @@ PenetrationThread::restrictPointToFace(Point& p,
         off_of_this_face=true;
         if (xi>0.5)
         {
-          closest_node = side->get_node(1);
+          closest_node = side->node_ptr(1);
           if (xi>1.0)
           {
             xi = 1.0;
@@ -1015,7 +1015,7 @@ PenetrationThread::restrictPointToFace(Point& p,
         }
         else
         {
-          closest_node = side->get_node(2);
+          closest_node = side->node_ptr(2);
           if (xi<0.0)
           {
             xi = 0.0;
@@ -1029,13 +1029,13 @@ PenetrationThread::restrictPointToFace(Point& p,
         off_of_this_face=true;
         if (eta>0.5)
         {
-          closest_node = side->get_node(2);
+          closest_node = side->node_ptr(2);
           if (eta>1.0)
             eta = 1.0;
         }
         else
         {
-          closest_node = side->get_node(0);
+          closest_node = side->node_ptr(0);
           if (eta<0.0)
             eta = 0.0;
         }
@@ -1053,13 +1053,13 @@ PenetrationThread::restrictPointToFace(Point& p,
         off_of_this_face=true;
         if (xi < 0.0)
         {
-          closest_node = side->get_node(0);
+          closest_node = side->node_ptr(0);
           if (xi < -1.0)
             xi = -1.0;
         }
         else
         {
-          closest_node = side->get_node(1);
+          closest_node = side->node_ptr(1);
           if (xi > 1.0)
             xi = 1.0;
         }
@@ -1070,13 +1070,13 @@ PenetrationThread::restrictPointToFace(Point& p,
         off_of_this_face=true;
         if (eta < 0.0)
         {
-          closest_node = side->get_node(1);
+          closest_node = side->node_ptr(1);
           if (eta < -1.0)
             eta = -1.0;
         }
         else
         {
-          closest_node = side->get_node(2);
+          closest_node = side->node_ptr(2);
           if (eta > 1.0)
             eta = 1.0;
         }
@@ -1087,13 +1087,13 @@ PenetrationThread::restrictPointToFace(Point& p,
         off_of_this_face=true;
         if (xi < 0.0)
         {
-          closest_node = side->get_node(3);
+          closest_node = side->node_ptr(3);
           if (xi < -1.0)
             xi = -1.0;
         }
         else
         {
-          closest_node = side->get_node(2);
+          closest_node = side->node_ptr(2);
           if (xi > 1.0)
             xi = 1.0;
         }
@@ -1104,13 +1104,13 @@ PenetrationThread::restrictPointToFace(Point& p,
         off_of_this_face=true;
         if (eta < 0.0)
         {
-          closest_node = side->get_node(0);
+          closest_node = side->node_ptr(0);
           if (eta < -1.0)
             eta = -1.0;
         }
         else
         {
-          closest_node = side->get_node(3);
+          closest_node = side->node_ptr(3);
           if (eta > 1.0)
             eta = 1.0;
         }
@@ -1378,7 +1378,7 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       if (xi < -smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(0));
+        en.push_back(side->node_ptr(0));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 + xi)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1388,7 +1388,7 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       else if (xi > smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(1));
+        en.push_back(side->node_ptr(1));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 - xi)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1404,8 +1404,8 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       if (eta < -smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(0));
-        en.push_back(side->get_node(1));
+        en.push_back(side->node_ptr(0));
+        en.push_back(side->node_ptr(1));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 + eta)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1415,8 +1415,8 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       if ((xi+eta) > smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(1));
-        en.push_back(side->get_node(2));
+        en.push_back(side->node_ptr(1));
+        en.push_back(side->node_ptr(2));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 - xi - eta)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1426,8 +1426,8 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       if (xi < -smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(2));
-        en.push_back(side->get_node(0));
+        en.push_back(side->node_ptr(2));
+        en.push_back(side->node_ptr(0));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 + xi)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1444,8 +1444,8 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       if (eta < -smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(0));
-        en.push_back(side->get_node(1));
+        en.push_back(side->node_ptr(0));
+        en.push_back(side->node_ptr(1));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 + eta)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1455,8 +1455,8 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       if (xi > smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(1));
-        en.push_back(side->get_node(2));
+        en.push_back(side->node_ptr(1));
+        en.push_back(side->node_ptr(2));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 - xi)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1466,8 +1466,8 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       if (eta > smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(2));
-        en.push_back(side->get_node(3));
+        en.push_back(side->node_ptr(2));
+        en.push_back(side->node_ptr(3));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 - eta)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1477,8 +1477,8 @@ PenetrationThread::getSmoothingEdgeNodesAndWeights(const Point& p,
       if (xi < -smooth_limit)
       {
         std::vector<const Node*> en;
-        en.push_back(side->get_node(3));
-        en.push_back(side->get_node(0));
+        en.push_back(side->node_ptr(3));
+        en.push_back(side->node_ptr(0));
         edge_nodes.push_back(en);
         Real fw = 0.5 - (1.0 + xi)/(2.0 * _normal_smoothing_distance);
         if (fw > 0.5)
@@ -1519,7 +1519,7 @@ PenetrationThread::getInfoForFacesWithCommonNodes(const Node *slave_node,
     {
       if (elem->is_vertex(ni))
       {
-        nodevec.push_back(elem->get_node(ni));
+        nodevec.push_back(elem->node_ptr(ni));
       }
     }
     std::vector<const Node*> common_nodes;
@@ -1642,7 +1642,7 @@ PenetrationThread::createInfoForElem(std::vector<PenetrationInfo*> &thisElemInfo
     std::vector<const Node*> nodevec;
     for (unsigned int ni=0; ni<side->n_nodes(); ++ni)
     {
-      nodevec.push_back(side->get_node(ni));
+      nodevec.push_back(side->node_ptr(ni));
     }
     std::sort(nodevec.begin(),nodevec.end());
     std::vector<const Node*> common_nodes;

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -119,7 +119,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
         const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[node_id];
 
         for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
-          if (_mesh.elem(elems_connected_to_node[elem_id_it])->processor_id() == processor_id)
+          if (_mesh.elemPtr(elems_connected_to_node[elem_id_it])->processor_id() == processor_id)
           {
             need_to_track = true;
             break; // Break out of element loop
@@ -139,7 +139,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
             const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[neighbor_node_id];
 
             for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
-              if (_mesh.elem(elems_connected_to_node[elem_id_it])->processor_id() == processor_id)
+              if (_mesh.elemPtr(elems_connected_to_node[elem_id_it])->processor_id() == processor_id)
               {
                 need_to_track = true;
                 break; // Break out of element loop

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -81,7 +81,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
     for (unsigned int k=0; k<n_master_nodes; k++)
     {
       dof_id_type master_id = _trial_master_nodes[k];
-      const Node * cur_node = &_mesh.node(master_id);
+      const Node * cur_node = _mesh.nodePtr(master_id);
       Real distance = ((*cur_node) - node).norm();
 
       neighbors.push(std::make_pair(master_id, distance));
@@ -111,7 +111,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
 
     bool need_to_track = false;
 
-    if (_mesh.node(node_id).processor_id() == processor_id)
+    if (_mesh.nodeRef(node_id).processor_id() == processor_id)
       need_to_track = true;
     else
     {
@@ -132,7 +132,7 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
         {
           dof_id_type neighbor_node_id = neighbor_nodes[neighbor_it];
 
-          if (_mesh.node(neighbor_node_id).processor_id() == processor_id)
+          if (_mesh.nodeRef(neighbor_node_id).processor_id() == processor_id)
             need_to_track = true;
           else // Now see if we own any of the elements connected to the neighbor nodes
           {

--- a/framework/src/ics/InitialCondition.C
+++ b/framework/src/ics/InitialCondition.C
@@ -186,7 +186,7 @@ InitialCondition::compute()
     {
       libmesh_assert(nc == 1);
       _qp = n;
-      _current_node = _current_elem->get_node(n);
+      _current_node = _current_elem->node_ptr(n);
       Ue(current_dof) = value(*_current_node);
       dof_is_fixed[current_dof] = true;
       current_dof++;
@@ -195,7 +195,7 @@ InitialCondition::compute()
     else if (fe_type.family == HERMITE)
     {
       _qp = n;
-      _current_node = _current_elem->get_node(n);
+      _current_node = _current_elem->node_ptr(n);
       Ue(current_dof) = value(*_current_node);
       dof_is_fixed[current_dof] = true;
       current_dof++;
@@ -275,7 +275,7 @@ InitialCondition::compute()
     else if (cont == C_ONE)
     {
       libmesh_assert(nc == 1 + dim);
-      _current_node = _current_elem->get_node(n);
+      _current_node = _current_elem->node_ptr(n);
       Ue(current_dof) = value(*_current_node);
       dof_is_fixed[current_dof] = true;
       current_dof++;

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -351,7 +351,7 @@ MooseMesh::node(const dof_id_type i) const
   if (i > getMesh().max_node_id())
     return *(*_quadrature_nodes.find(i)).second;
 
-  return getMesh().node(i);
+  return getMesh().node_ref(i);
 }
 
 Node &
@@ -360,7 +360,7 @@ MooseMesh::node(const dof_id_type i)
   if (i > getMesh().max_node_id())
     return *_quadrature_nodes[i];
 
-  return getMesh().node(i);
+  return getMesh().node_ref(i);
 }
 
 const Node*
@@ -479,7 +479,7 @@ MooseMesh::updateActiveSemiLocalNodeRange(std::set<dof_id_type> & ghosted_elems)
     const Elem * elem = *it;
     for (unsigned int n = 0; n < elem->n_nodes(); ++n)
     {
-      Node * node = elem->get_node(n);
+      Node * node = elem->node_ptr(n);
 
       _semilocal_node_list.insert(node);
     }
@@ -490,10 +490,10 @@ MooseMesh::updateActiveSemiLocalNodeRange(std::set<dof_id_type> & ghosted_elems)
       it!=ghosted_elems.end();
       ++it)
   {
-    Elem * elem = getMesh().elem(*it);
+    Elem * elem = getMesh().elem_ptr(*it);
     for (unsigned int n = 0; n < elem->n_nodes(); n++)
     {
-      Node * node = elem->get_node(n);
+      Node * node = elem->node_ptr(n);
 
       _semilocal_node_list.insert(node);
     }
@@ -586,7 +586,7 @@ MooseMesh::buildBndElemList()
   _bnd_elems.resize(n);
   for (int i = 0; i < n; i++)
   {
-    _bnd_elems[i] = new BndElement(getMesh().elem(elems[i]), sides[i], ids[i]);
+    _bnd_elems[i] = new BndElement(getMesh().elem_ptr(elems[i]), sides[i], ids[i]);
     _bnd_elem_ids[ids[i]].insert(elems[i]);
   }
 }
@@ -735,7 +735,7 @@ MooseMesh::cacheInfo()
 
     for (unsigned int nd = 0; nd < elem->n_nodes(); ++nd)
     {
-      Node & node = *elem->get_node(nd);
+      Node & node = *elem->node_ptr(nd);
       _block_node_list[node.id()].insert(elem->subdomain_id());
     }
   }
@@ -1061,11 +1061,11 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
           // At this point we have matching sides - lets find matching nodes
           for (unsigned int i = 0; i < elem_side->n_nodes(); ++i)
           {
-            Node * master_node = elem->get_node(i);
+            Node * master_node = elem->node_ptr(i);
             Point master_point = periodic->get_corresponding_pos(*master_node);
             for (unsigned int j = 0; j < neigh_side->n_nodes(); ++j)
             {
-              Node *slave_node = neigh_side->get_node(j);
+              Node *slave_node = neigh_side->node_ptr(j);
               if (master_point.absolute_fuzzy_equals(*slave_node))
               {
                 // Avoid inserting any duplicates
@@ -1910,13 +1910,13 @@ MooseMesh::nElem() const
 Elem *
 MooseMesh::elem(const dof_id_type i)
 {
-  return getMesh().elem(i);
+  return getMesh().elem_ptr(i);
 }
 
 const Elem *
 MooseMesh::elem(const dof_id_type i) const
 {
-  return getMesh().elem(i);
+  return getMesh().elem_ptr(i);
 }
 
 bool
@@ -2076,7 +2076,7 @@ MooseMesh::ghostGhostedBoundaries()
   {
     if (_ghosted_boundaries.find(ids[i]) != _ghosted_boundaries.end())
     {
-      Elem * elem = mesh.elem(elems[i]);
+      Elem * elem = mesh.elem_ptr(elems[i]);
 
 #ifdef LIBMESH_ENABLE_AMR
       elem->family_tree(family_tree);
@@ -2090,7 +2090,7 @@ MooseMesh::ghostGhostedBoundaries()
         boundary_elems_to_ghost.insert(felem);
 
         for (unsigned int n = 0; n < felem->n_nodes(); ++n)
-          connected_nodes_to_ghost.insert (felem->get_node(n));
+          connected_nodes_to_ghost.insert (felem->node_ptr(n));
       }
     }
   }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -348,6 +348,20 @@ MooseMesh::update()
 const Node &
 MooseMesh::node(const dof_id_type i) const
 {
+  // mooseDeprecated("MooseMesh::node() is deprecated, please use MooseMesh::nodeRef() instead");
+  return nodeRef(i);
+}
+
+Node &
+MooseMesh::node(const dof_id_type i)
+{
+  // mooseDeprecated("MooseMesh::node() is deprecated, please use MooseMesh::nodeRef() instead");
+  return nodeRef(i);
+}
+
+const Node &
+MooseMesh::nodeRef(const dof_id_type i) const
+{
   if (i > getMesh().max_node_id())
     return *(*_quadrature_nodes.find(i)).second;
 
@@ -355,7 +369,7 @@ MooseMesh::node(const dof_id_type i) const
 }
 
 Node &
-MooseMesh::node(const dof_id_type i)
+MooseMesh::nodeRef(const dof_id_type i)
 {
   if (i > getMesh().max_node_id())
     return *_quadrature_nodes[i];

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1924,11 +1924,25 @@ MooseMesh::nElem() const
 Elem *
 MooseMesh::elem(const dof_id_type i)
 {
-  return getMesh().elem_ptr(i);
+  // mooseDeprecated("MooseMesh::elem() is deprecated, please use MooseMesh::elemPtr() instead");
+  return elemPtr(i);
 }
 
 const Elem *
 MooseMesh::elem(const dof_id_type i) const
+{
+  // mooseDeprecated("MooseMesh::elem() is deprecated, please use MooseMesh::elemPtr() instead");
+  return elemPtr(i);
+}
+
+Elem *
+MooseMesh::elemPtr(const dof_id_type i)
+{
+  return getMesh().elem_ptr(i);
+}
+
+const Elem *
+MooseMesh::elemPtr(const dof_id_type i) const
 {
   return getMesh().elem_ptr(i);
 }

--- a/framework/src/meshmodifiers/AddExtraNodeset.C
+++ b/framework/src/meshmodifiers/AddExtraNodeset.C
@@ -87,7 +87,7 @@ AddExtraNodeset::modify()
     bool on_node = false;
     for (unsigned int j = 0; j<elem->n_nodes(); ++j)
     {
-      const Node * node = elem->get_node(j);
+      const Node * node = elem->node_ptr(j);
 
       Point q;
       for (unsigned int k = 0; k < dim; ++k)

--- a/framework/src/meshmodifiers/AssignElementSubdomainID.C
+++ b/framework/src/meshmodifiers/AssignElementSubdomainID.C
@@ -52,7 +52,7 @@ AssignElementSubdomainID::modify()
     std::vector<dof_id_type> elemids = getParam<std::vector<dof_id_type> >("element_ids");
     for (dof_id_type i = 0; i < elemids.size(); ++i)
     {
-      Elem * elem = mesh.query_elem(elemids[i]);
+      Elem * elem = mesh.query_elem_ptr(elemids[i]);
       if (!elem)
         mooseError("invalid element ID is in element_ids");
       else

--- a/framework/src/meshmodifiers/BoundingBoxNodeSet.C
+++ b/framework/src/meshmodifiers/BoundingBoxNodeSet.C
@@ -69,7 +69,7 @@ BoundingBoxNodeSet::modify()
       {
         for (unsigned int j = 0; j < elem->n_nodes(); ++j)
         {
-          const Node * node = elem->get_node(j);
+          const Node * node = elem->node_ptr(j);
 
           for (unsigned int j = 0; j < boundary_ids.size(); ++j)
             boundary_info.add_node(node, boundary_ids[j]);

--- a/framework/src/multiapps/AutoPositionsMultiApp.C
+++ b/framework/src/multiapps/AutoPositionsMultiApp.C
@@ -59,7 +59,7 @@ AutoPositionsMultiApp::fillPositions()
 
     for (unsigned int i=0; i<boundary_node_ids.size(); i++)
     {
-      Node & node = master_mesh.node(boundary_node_ids[i]);
+      Node & node = master_mesh.nodeRef(boundary_node_ids[i]);
 
       _positions.push_back(node);
     }

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -177,10 +177,10 @@ DOFMapOutput::output(const ExecFlagType & /*type*/)
         // get the list of unique DOFs for this variable
         std::set<dof_id_type> dofs;
         for (unsigned int i = 0; i < _mesh.nElem(); ++i)
-          if (_mesh.elem(i)->subdomain_id() == *sd)
+          if (_mesh.elemPtr(i)->subdomain_id() == *sd)
           {
             std::vector<dof_id_type> di;
-            dof_map.dof_indices(_mesh.elem(i), di, var);
+            dof_map.dof_indices(_mesh.elemPtr(i), di, var);
             dofs.insert(di.begin(), di.end());
           }
         oss << join(dofs.begin(), dofs.end(), ", ") << "]}";

--- a/framework/src/postprocessors/ElementalVariableValue.C
+++ b/framework/src/postprocessors/ElementalVariableValue.C
@@ -29,7 +29,7 @@ ElementalVariableValue::ElementalVariableValue(const InputParameters & parameter
     GeneralPostprocessor(parameters),
     _mesh(_subproblem.mesh()),
     _var_name(parameters.get<VariableName>("variable")),
-    _element(_mesh.getMesh().query_elem(parameters.get<unsigned int>("elementid")))
+    _element(_mesh.getMesh().query_elem_ptr(parameters.get<unsigned int>("elementid")))
 {
   // This class only works with SerialMesh, since it relies on a
   // specific element numbering that we can't guarantee with ParallelMesh

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -331,7 +331,7 @@ dataLoad(std::istream & stream, const Elem * & e, void * context)
   loadHelper(stream, id, context);
 
   if (id != libMesh::DofObject::invalid_id)
-    e = mesh->elem(id);
+    e = mesh->elemPtr(id);
   else
     e = NULL;
 }
@@ -371,7 +371,7 @@ dataLoad(std::istream & stream, Elem * & e, void * context)
   loadHelper(stream, id, context);
 
   if (id != libMesh::DofObject::invalid_id)
-    e = mesh->elem(id);
+    e = mesh->elemPtr(id);
   else
     e = NULL;
 }

--- a/framework/src/transfers/DTKInterpolationAdapter.C
+++ b/framework/src/transfers/DTKInterpolationAdapter.C
@@ -58,7 +58,7 @@ DTKInterpolationAdapter::DTKInterpolationAdapter(Teuchos::RCP<const Teuchos::Mpi
         it != semi_local_nodes.end();
         ++it)
     {
-      const Node & node = mesh.node(*it);
+      const Node & node = mesh.node_ref(*it);
 
       vertices[i] = node.id();
 
@@ -73,8 +73,8 @@ DTKInterpolationAdapter::DTKInterpolationAdapter(Teuchos::RCP<const Teuchos::Mpi
   }
 
   // Currently assuming all elements are the same!
-  DataTransferKit::DTK_ElementTopology element_topology = get_element_topology(mesh.elem(0));
-  GlobalOrdinal n_nodes_per_elem = mesh.elem(0)->n_nodes();
+  DataTransferKit::DTK_ElementTopology element_topology = get_element_topology(mesh.elem_ptr(0));
+  GlobalOrdinal n_nodes_per_elem = mesh.elem_ptr(0)->n_nodes();
 
   GlobalOrdinal n_local_elem = mesh.n_local_elem();
 
@@ -96,7 +96,7 @@ DTKInterpolationAdapter::DTKInterpolationAdapter(Teuchos::RCP<const Teuchos::Mpi
       elements[i] = elem.id();
 
       for (GlobalOrdinal j=0; j<n_nodes_per_elem; j++)
-        connectivity[(j*n_local_elem)+i] = elem.node(j);
+        connectivity[(j*n_local_elem)+i] = elem.node_id(j);
 
       {
         Point centroid = elem.centroid();
@@ -276,7 +276,7 @@ DTKInterpolationAdapter::update_variable_values(std::string var_name, Teuchos::A
     if (is_nodal)
       dof_object = mesh.node_ptr(vertices[i]);
     else
-      dof_object = mesh.elem(elements[i]);
+      dof_object = mesh.elem_ptr(elements[i]);
 
     if (dof_object->processor_id() == mesh.processor_id())
     {
@@ -333,7 +333,7 @@ DTKInterpolationAdapter::get_semi_local_nodes(std::set<GlobalOrdinal> & semi_loc
     const Elem & elem = *(*it);
 
     for (unsigned int j=0; j<elem.n_nodes(); j++)
-      semi_local_nodes.insert(elem.node(j));
+      semi_local_nodes.insert(elem.node_id(j));
   }
 }
 

--- a/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
@@ -75,9 +75,6 @@ MultiAppDTKUserObjectEvaluator::createSourceGeometry( const Teuchos::RCP<const T
   _boxes.resize(_multi_app.numLocalApps());
   _box_ids.resize(_multi_app.numLocalApps());
 
-  // How much to inflate each bounding box by (helps with non-matching surfaces)
-  unsigned int inflation = 0.01;
-
   comm->barrier();
 
   for (unsigned int app=0; app<_multi_app.numLocalApps(); app++)

--- a/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
@@ -35,7 +35,7 @@ InputParameters validParams<MultiAppDTKUserObjectTransfer>()
 
 MultiAppDTKUserObjectTransfer::MultiAppDTKUserObjectTransfer(const InputParameters & parameters) :
     MultiAppTransfer(parameters),
-    MooseVariableInterface(parameters, true),
+    MooseVariableInterface(this, true),
     _user_object_name(getParam<UserObjectName>("user_object")),
     _setup(false)
 {

--- a/framework/src/userobject/NodalNormalsCorner.C
+++ b/framework/src/userobject/NodalNormalsCorner.C
@@ -48,7 +48,7 @@ NodalNormalsCorner::execute()
 
   for (unsigned int nd = 0; nd < _current_side_elem->n_nodes(); nd++)
   {
-    const Node * node = _current_side_elem->get_node(nd);
+    const Node * node = _current_side_elem->node_ptr(nd);
     if (boundary_info.has_boundary_id(node, _corner_boundary_id) &&
         node->n_dofs(_aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_x").number()) > 0)
       {

--- a/framework/src/userobject/NodalNormalsPreprocessor.C
+++ b/framework/src/userobject/NodalNormalsPreprocessor.C
@@ -73,7 +73,7 @@ NodalNormalsPreprocessor::execute()
   for (unsigned int i = 0; i < _current_elem->n_nodes(); i++)
   {
     // Extract a pointer to a node
-    const Node * node = _current_elem->get_node(i);
+    const Node * node = _current_elem->node_ptr(i);
 
     // Only continue if the node is on a boundary
     if (_mesh.isBoundaryNode(node->id()))

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -338,7 +338,7 @@ SolutionUserObject::directValue(const Node * node, const std::string & var_name)
 
   // Get the node id and associated dof
   dof_id_type node_id = node->id();
-  dof_id_type dof_id = _system->get_mesh().node(node_id).dof_number(sys_num, var_num, 0);
+  dof_id_type dof_id = _system->get_mesh().node_ref(node_id).dof_number(sys_num, var_num, 0);
 
   // Return the desired value for the dof
   return directValue(dof_id);

--- a/framework/src/utils/ElementsIntersectedByPlane.C
+++ b/framework/src/utils/ElementsIntersectedByPlane.C
@@ -37,13 +37,13 @@ void findElementsIntersectedByPlane(const Plane & plane, const MeshBase & mesh, 
     bool intersected = false;
 
     // Check whether the first node of this element is below or above the plane
-    const Node node0 = *elem->get_node(0);
+    const Node & node0 = elem->node_ref(0);
     bool node0_above_plane = plane.above_surface(node0);
 
     // Loop over the rest of the nodes and check if any node is on the other side of the plane
     for (unsigned int i = 1; i < elem->n_nodes(); ++i)
     {
-      const Node node = *elem->get_node(i);
+      const Node & node = elem->node_ref(i);
 
       bool node_above_plane = plane.above_surface(node);
       if (node0_above_plane != node_above_plane)

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -477,7 +477,7 @@ static PetscErrorCode DMMooseGetEmbedding_Private(DM dm, IS *embedding)
     // for (dof_id_type i = 0; i < sides.size(); ++i) {
     //   boundary_id_type s = sides[i];
     //   if (!dmm->sidenames->count(s)) continue;
-    //  const Node& node = dmm->nl->sys().get_mesh().node(snodes[i]);
+    //  const Node& node = dmm->nl->sys().get_mesh().node_ref(snodes[i]);
     //  // determine v's dof on node and insert into indices
     // }
     ConstBndNodeRange & bnodes = *dmm->nl->mesh().getBoundaryNodeRange();
@@ -525,7 +525,7 @@ static PetscErrorCode DMMooseGetEmbedding_Private(DM dm, IS *embedding)
       std::vector<dof_id_type>& slave_nodes = locator->_nearest_node._slave_nodes;
       for (dof_id_type i = 0; i < slave_nodes.size(); ++i) {
         if (locator->_has_penetrated.find(slave_nodes[i]) == locator->_has_penetrated.end()) continue;
-        Node& slave_node = dmm->nl->sys().get_mesh().node(slave_nodes[i]);
+        Node& slave_node = dmm->nl->sys().get_mesh().node_ref(slave_nodes[i]);
         dof_id_type dof = slave_node.dof_number(dmm->nl->sys().number(),v,0);
         if (dof >= dofmap.first_dof() && dof < dofmap.end_dof()) { /* might want to use variable_first/last_local_dof instead */
     indices.insert(dof);
@@ -552,7 +552,7 @@ static PetscErrorCode DMMooseGetEmbedding_Private(DM dm, IS *embedding)
       std::vector<dof_id_type>& slave_nodes = locator->_nearest_node._slave_nodes;
       for (dof_id_type i = 0; i < slave_nodes.size(); ++i) {
         if (locator->_has_penetrated.find(slave_nodes[i]) == locator->_has_penetrated.end()) continue;
-        Node& slave_node = dmm->nl->sys().get_mesh().node(slave_nodes[i]);
+        Node& slave_node = dmm->nl->sys().get_mesh().node_ref(slave_nodes[i]);
         dof_id_type dof = slave_node.dof_number(dmm->nl->sys().number(),v,0);
         if (dof >= dofmap.first_dof() && dof < dofmap.end_dof()) { /* might want to use variable_first/last_local_dof instead */
     unindices.insert(dof);

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -145,7 +145,7 @@ ContactMaster::updateContactSet(bool beginning_of_step)
     }
 
     const Real contact_pressure = -(pinfo->_normal * pinfo->_contact_force) / nodalArea(*pinfo);
-    const Real distance = pinfo->_normal * (pinfo->_closest_point - _mesh.node(slave_node_num));
+    const Real distance = pinfo->_normal * (pinfo->_closest_point - _mesh.nodeRef(slave_node_num));
 
     // Capture
     if ( ! pinfo->isCaptured() && MooseUtils::absoluteFuzzyGreaterEqual(distance, 0, _capture_tolerance))
@@ -213,7 +213,7 @@ ContactMaster::computeContactForce(PenetrationInfo * pinfo)
 
   const Real area = nodalArea(*pinfo);
 
-  RealVectorValue distance_vec(_mesh.node(node->id()) - pinfo->_closest_point);
+  RealVectorValue distance_vec(_mesh.nodeRef(node->id()) - pinfo->_closest_point);
   RealVectorValue pen_force(_penalty * distance_vec);
   if (_normalize_penalty)
     pen_force *= area;
@@ -240,7 +240,7 @@ ContactMaster::computeContactForce(PenetrationInfo * pinfo)
   }
   else if (_model == CM_COULOMB && _formulation == CF_PENALTY)
   {
-    distance_vec = pinfo->_incremental_slip + (pinfo->_normal * (_mesh.node(node->id()) - pinfo->_closest_point)) * pinfo->_normal;
+    distance_vec = pinfo->_incremental_slip + (pinfo->_normal * (_mesh.nodeRef(node->id()) - pinfo->_closest_point)) * pinfo->_normal;
     pen_force = _penalty * distance_vec;
     if (_normalize_penalty)
       pen_force *= area;

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -371,7 +371,7 @@ FrictionalContactProblem::enforceRateConstraint(NumericVector<Number>& vec_solut
               // RealVectorValue current_coords = *node;
               // RealVectorValue correction = info._closest_point - current_coords;
 
-              const Node & undisp_node = _mesh.node(node->id());
+              const Node & undisp_node = _mesh.nodeRef(node->id());
               RealVectorValue solution = info._closest_point - undisp_node;
 
               for (unsigned int i=0; i<dim; ++i)

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -176,7 +176,7 @@ MechanicalContactConstraint::updateContactSet(bool beginning_of_step)
     pinfo->_mech_status_old = pinfo->_mech_status;
 
     const Real contact_pressure = -(pinfo->_normal * pinfo->_contact_force) / nodalArea(*pinfo);
-    const Real distance = pinfo->_normal * (pinfo->_closest_point - _mesh.node(slave_node_num));
+    const Real distance = pinfo->_normal * (pinfo->_closest_point - _mesh.nodeRef(slave_node_num));
 
     // Capture
     if ( ! pinfo->isCaptured() && MooseUtils::absoluteFuzzyGreaterEqual(distance, 0, _capture_tolerance))
@@ -239,7 +239,7 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
     dof_id_type dof_number = node->dof_number(0, _vars(i), 0);
     res_vec(i) = _residual_copy(dof_number);
   }
-  RealVectorValue distance_vec(_mesh.node(node->id()) - pinfo->_closest_point);
+  RealVectorValue distance_vec(_mesh.nodeRef(node->id()) - pinfo->_closest_point);
   const Real penalty = getPenalty(*pinfo);
   RealVectorValue pen_force(penalty * distance_vec);
 
@@ -325,7 +325,7 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo)
         }
         case CF_PENALTY:
         {
-          distance_vec = pinfo->_incremental_slip + (pinfo->_normal * (_mesh.node(node->id()) - pinfo->_closest_point)) * pinfo->_normal;
+          distance_vec = pinfo->_incremental_slip + (pinfo->_normal * (_mesh.nodeRef(node->id()) - pinfo->_closest_point)) * pinfo->_normal;
           pen_force = penalty * distance_vec;
 
           // Frictional capacity

--- a/modules/contact/src/MultiDContactConstraint.C
+++ b/modules/contact/src/MultiDContactConstraint.C
@@ -172,7 +172,7 @@ MultiDContactConstraint::computeQpResidual(Moose::ConstraintType type)
     res_vec(i) = _residual_copy(dof_number);
   }
 
-  const RealVectorValue distance_vec(_mesh.node(node->id()) - pinfo->_closest_point);
+  const RealVectorValue distance_vec(_mesh.nodeRef(node->id()) - pinfo->_closest_point);
   const RealVectorValue pen_force(_penalty * distance_vec);
   Real resid = 0;
 

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -106,7 +106,7 @@ SlaveConstraint::addPoints()
 
       for (unsigned int i=0; i<connected_elems.size() && !elem; ++i)
       {
-        Elem * cur_elem = _mesh.elem(connected_elems[i]);
+        Elem * cur_elem = _mesh.elemPtr(connected_elems[i]);
         if (cur_elem->processor_id() == processor_id())
           elem = cur_elem;
       }

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -131,7 +131,7 @@ SlaveConstraint::computeQpResidual()
 
   if (_formulation == CF_DEFAULT)
   {
-    RealVectorValue distance_vec(_mesh.node(node->id()) - pinfo->_closest_point);
+    RealVectorValue distance_vec(_mesh.nodeRef(node->id()) - pinfo->_closest_point);
     RealVectorValue pen_force(_penalty * distance_vec);
     if (_normalize_penalty)
       pen_force *= area;
@@ -207,7 +207,7 @@ SlaveConstraint::computeQpJacobian()
       d2.zero();
     }
 
-    const RealVectorValue distance_vec(_mesh.node(node->id()) - pinfo->_closest_point);
+    const RealVectorValue distance_vec(_mesh.nodeRef(node->id()) - pinfo->_closest_point);
     const Real ATA11( A1 * A1 );
     const Real ATA12( A1 * A2 );
     const Real ATA22( A2 * A2 );

--- a/modules/misc/src/CInterfacePosition.C
+++ b/modules/misc/src/CInterfacePosition.C
@@ -45,6 +45,6 @@ Real
 CInterfacePosition::getValue()
 {
   unsigned int node_id = NodalProxyMaxValue::getValue();
-  return _mesh.node(node_id)(_direction_index);
+  return _mesh.nodeRef(node_id)(_direction_index);
 }
 

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -801,7 +801,7 @@ FeatureFloodCount::appendPeriodicNeighborNodes(FeatureData & data) const
   {
     for (std::set<dof_id_type>::iterator entity_it = data._local_ids.begin(); entity_it != data._local_ids.end(); ++entity_it)
     {
-      Elem * elem = _mesh.elem(*entity_it);
+      Elem * elem = _mesh.elemPtr(*entity_it);
 
       for (unsigned int node_n = 0; node_n < elem->n_nodes(); node_n++)
       {

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -177,7 +177,7 @@ GrainTracker::expandHalos()
                entity_it != orig_halo_ids.end(); ++entity_it)
           {
             if (_is_elemental)
-              visitElementalNeighbors(_mesh.elem(*entity_it), feature._var_idx, &feature, /*recurse =*/false);
+              visitElementalNeighbors(_mesh.elemPtr(*entity_it), feature._var_idx, &feature, /*recurse =*/false);
             else
               visitNodalNeighbors(_mesh.nodePtr(*entity_it), feature._var_idx, &feature, /*recurse =*/false);
           }

--- a/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -242,7 +242,7 @@ CrackFrontDefinition::getCrackFrontNodes(std::set<dof_id_type>& nodes)
 
       for (std::set<dof_id_type>::iterator sit=nodes.begin(); sit != nodes.end(); ++sit)
       {
-        Node & curr_node = _mesh.node(*sit);
+        Node & curr_node = _mesh.nodeRef(*sit);
         if (sit == nodes.begin())
         {
           node0coor0 = curr_node(axis0);
@@ -391,8 +391,8 @@ void
 CrackFrontDefinition::orderEndNodes(std::vector<dof_id_type> &end_nodes)
 {
   //Choose the node to be the first node.  Do that based on undeformed coordinates for repeatability.
-  Node & node0 = _mesh.node(end_nodes[0]);
-  Node & node1 = _mesh.node(end_nodes[1]);
+  Node & node0 = _mesh.nodeRef(end_nodes[0]);
+  Node & node1 = _mesh.nodeRef(end_nodes[1]);
 
   unsigned int num_positive_coor0 = 0;
   unsigned int num_positive_coor1 = 0;
@@ -449,7 +449,7 @@ CrackFrontDefinition::pickLoopCrackEndNodes(std::vector<dof_id_type> &end_nodes,
   //the greatest x coordinate if the nodes are equidistant from the origin
   for (std::set<dof_id_type>::iterator nit = nodes.begin(); nit != nodes.end(); ++nit )
   {
-    Node & node = _mesh.node(*nit);
+    Node & node = _mesh.nodeRef(*nit);
     Real dist = node.norm();
     if (dist > max_dist)
     {
@@ -1351,7 +1351,7 @@ CrackFrontDefinition::createQFunctionRings()
            ++nit)
       {
         std::vector<const Node *> neighbors;
-        MeshTools::find_nodal_neighbors(_mesh.getMesh(), _mesh.node(*nit), nodes_to_elem_map, neighbors);
+        MeshTools::find_nodal_neighbors(_mesh.getMesh(), _mesh.nodeRef(*nit), nodes_to_elem_map, neighbors);
         for (unsigned int inei=0; inei<neighbors.size(); ++inei)
         {
           std::set<dof_id_type>::iterator thisit = connected_nodes_this_cfn.find(neighbors[inei]->id());
@@ -1470,7 +1470,7 @@ CrackFrontDefinition::addNodesToQFunctionRing(std::set<dof_id_type>& nodes_new_r
        ++nit)
   {
     std::vector<const Node *> neighbors;
-    MeshTools::find_nodal_neighbors(_mesh.getMesh(), _mesh.node(*nit), nodes_to_elem_map, neighbors);
+    MeshTools::find_nodal_neighbors(_mesh.getMesh(), _mesh.nodeRef(*nit), nodes_to_elem_map, neighbors);
     for (unsigned int inei=0; inei<neighbors.size(); ++inei)
     {
       std::set<dof_id_type>::const_iterator previt = nodes_all_rings.find(neighbors[inei]->id());

--- a/test/src/meshes/StripeMesh.C
+++ b/test/src/meshes/StripeMesh.C
@@ -58,7 +58,7 @@ StripeMesh::buildMesh()
   for (unsigned int en = 0; en < nElem(); en++)
   {
     // get an element
-    Elem * e = elem(en);
+    Elem * e = elemPtr(en);
 
     if (!e)
     {

--- a/test/src/userobjects/MaterialCopyUserObject.C
+++ b/test/src/userobjects/MaterialCopyUserObject.C
@@ -47,8 +47,8 @@ MaterialCopyUserObject::execute()
   {
     if (std::abs(_t - _copy_times[i]) < _time_tol)
     {
-      Elem *elem_from = _mesh.elem(_copy_from_element);
-      Elem *elem_to = _mesh.elem(_copy_to_element);
+      Elem * elem_from = _mesh.elemPtr(_copy_from_element);
+      Elem * elem_to = _mesh.elemPtr(_copy_to_element);
       _material_data->copy(*elem_to, *elem_from, 0);
     }
   }

--- a/test/src/userobjects/TrackDiracFront.C
+++ b/test/src/userobjects/TrackDiracFront.C
@@ -77,7 +77,7 @@ TrackDiracFront::localElementConnectedToCurrentNode()
   // Look through all of the elements connected to this node and find one owned by the local processor
   for (unsigned int i=0; i<connected_elems.size(); i++)
   {
-    Elem * elem = _mesh.elem(connected_elems[i]);
+    Elem * elem = _mesh.elemPtr(connected_elems[i]);
 
     if (elem->processor_id() == pid) // Is this element owned by the local processor?
       return elem;


### PR DESCRIPTION
- Elem::node() -> Elem::node_id()
- Mesh::node() -> Mesh::node_ref()
- Mesh::query_elem() -> Mesh::query_elem_ptr()
- Elem::get_node() -> Elem::node_ptr()
- Mesh::elem() -> Mesh::elem_ptr()

Also make the corresponding `MooseMesh` interfaces more consistent by renaming them in a similar way.  The old methods are still there and will not be officially deprecated until I've had a chance to fix apps.

Refs libMesh/libmesh#918.
