### PR TITLE
Add sanity check for free energy base names

### DIFF
--- a/modules/phase_field/include/kernels/CahnHilliardBase.h
+++ b/modules/phase_field/include/kernels/CahnHilliardBase.h
@@ -105,6 +105,7 @@ CahnHilliardBase<T>:: initialSetup()
    * the residual.
    */
   this->template validateCoupling<Real>("f_name", _var.name());
+  this->template validateDerivativeMaterialPropertyBase<Real>("f_name");
 }
 
 template<typename T>

--- a/modules/phase_field/src/kernels/AllenCahn.C
+++ b/modules/phase_field/src/kernels/AllenCahn.C
@@ -32,6 +32,7 @@ AllenCahn::initialSetup()
 {
   ACBulk<Real>::initialSetup();
   validateNonlinearCoupling<Real>("f_name");
+  validateDerivativeMaterialPropertyBase<Real>("f_name");
 }
 
 Real

--- a/modules/phase_field/src/kernels/KKSSplitCHCRes.C
+++ b/modules/phase_field/src/kernels/KKSSplitCHCRes.C
@@ -54,6 +54,7 @@ void
 KKSSplitCHCRes::initialSetup()
 {
   validateNonlinearCoupling<Real>("fa_name");
+  validateDerivativeMaterialPropertyBase<Real>("fa_name");
 }
 
 Real

--- a/modules/phase_field/src/kernels/SplitCHParsed.C
+++ b/modules/phase_field/src/kernels/SplitCHParsed.C
@@ -39,6 +39,7 @@ SplitCHParsed::initialSetup()
    * do not have Jacobian entries.
    */
   validateNonlinearCoupling<Real>("f_name", _var.name());
+  validateDerivativeMaterialPropertyBase<Real>("f_name");
 }
 
 Real

--- a/test/include/materials/DerivativeMaterialInterfaceTestClient.h
+++ b/test/include/materials/DerivativeMaterialInterfaceTestClient.h
@@ -30,6 +30,7 @@ class DerivativeMaterialInterfaceTestClient : public DerivativeMaterialInterface
 public:
   DerivativeMaterialInterfaceTestClient(const InputParameters & parameters);
 
+  virtual void initialSetup();
   virtual void computeQpProperties();
 
 protected:

--- a/test/src/materials/DerivativeMaterialInterfaceTestClient.C
+++ b/test/src/materials/DerivativeMaterialInterfaceTestClient.C
@@ -38,6 +38,12 @@ DerivativeMaterialInterfaceTestClient::DerivativeMaterialInterfaceTestClient(con
 {
 }
 
+void
+DerivativeMaterialInterfaceTestClient::initialSetup()
+{
+  if (!_by_name)
+   validateDerivativeMaterialPropertyBase<Real>("prop_name");
+}
 
 void
 DerivativeMaterialInterfaceTestClient::computeQpProperties()

--- a/test/tests/materials/derivativematerialinterface/tests
+++ b/test/tests/materials/derivativematerialinterface/tests
@@ -23,4 +23,11 @@
     type = 'RunApp'
     input = 'multiblock.i'
   [../]
+
+  [./warn]
+    type = 'RunException'
+    input = 'warn.i'
+    expect_err = "The material property 'prop' does not exist."
+    recover = false
+  [../]
 []

--- a/test/tests/materials/derivativematerialinterface/warn.i
+++ b/test/tests/materials/derivativematerialinterface/warn.i
@@ -27,13 +27,6 @@
     block = 0
     outputs = exodus
   [../]
-
-  [./dummy]
-    type = GenericConstantMaterial
-    prop_names = prop
-    block = 0
-    prop_values = 0
-  [../]
 []
 
 [Executioner]


### PR DESCRIPTION
This adds a sanity check to kernels using _only_ material property derivatives. It checks if the underived material property exists and issues a warning if it doesn't. This most likely indicates a typo in the input file. Ping @tonkmr 

Close #6901
