### PR TITLE
include serial_mesh.h in PatternedMesh.h

### DIFF
--- a/framework/include/mesh/PatternedMesh.h
+++ b/framework/include/mesh/PatternedMesh.h
@@ -17,6 +17,8 @@
 
 #include "MooseMesh.h"
 
+#include "libmesh/serial_mesh.h"
+
 class PatternedMesh;
 
 template<>


### PR DESCRIPTION
Against typical libMesh builds that happens indirectly via mesh.h via
MooseMesh.h, but for libMesh --enable-parmesh builds we need to
include the SerialMesh definition explicitly.

This fixes #6957 for me.
