### PR TITLE
Simplify Valgrind suppresion

### DIFF
--- a/python/TestHarness/suppressions/errors.supp
+++ b/python/TestHarness/suppressions/errors.supp
@@ -44,14 +44,7 @@
 {
    tbb_scalable_allocator_bug
    Memcheck:Cond
-   fun:_ZN3rml8internal13isLargeObjectEPv
-   fun:scalable_free
-   fun:*
-}
-{
-   tbb_scalable_allocator_bug_gcc_5_3_0
-   Memcheck:Cond
-   fun:_ZN3rml8internal13isLargeObjectILNS0_12MemoryOriginE0EEEbPv
+   fun:_ZN3rml8internal13isLargeObject*
    fun:*
 }
 {


### PR DESCRIPTION
refs #6942

I turns out that you can use a wildcard in the Valgrind suppression in the middle of a FunctionName. My test of this capability last week was simply faulty. This should simplify the several different versions of this error we see under different compilers on different boxes.
