### PR TITLE
New flag to allow deprecated code

### DIFF
--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -142,7 +142,7 @@
 #define mooseDeprecated(msg)                                                                                \
   do                                                                                                        \
   {                                                                                                         \
-    if (Moose::_warnings_are_errors || Moose::_deprecated_is_error)                                         \
+    if (Moose::_deprecated_is_error)                                                                        \
       mooseError("\n\nDeprecated code:\n" << msg << '\n');                                                  \
     else                                                                                                    \
       mooseDoOnce(                                                                                          \


### PR DESCRIPTION
This PR adds a new flag --allow-deprecated that works in conjuction
with --error to allow deprecated code. The use case is mostly just
for the TestHarness and applications that have --error hardcoded
in their ./run_tests script. The flag is ignored if it's passed
alone.

refs #6911
