### PR TITLE
Better error checking for BoundaryRestrictable

### DIFF
--- a/framework/include/base/BoundaryRestrictable.h
+++ b/framework/include/base/BoundaryRestrictable.h
@@ -49,8 +49,9 @@ public:
    * Populates the _bnd_ids for the given boundary names supplied
    * with the 'boundary' input parameter
    * @param parameters The input parameters
+   * @param nodal True indicates that the object is operating on nodesets, false for sidesets
    */
-  BoundaryRestrictable(const InputParameters & parameters);
+  BoundaryRestrictable(const InputParameters & parameters, bool nodal);
 
   /**
    * Class constructor
@@ -58,8 +59,9 @@ public:
    * see the general class documentation for details.
    * @param parameters The input parameters (see the detailed help for additional information)
    * @param block_ids The block ids that the object is restricted to
+   * @param nodal True indicates that the object is operating on nodesets, false for sidesets
    */
-  BoundaryRestrictable(const InputParameters & parameters, const std::set<SubdomainID> & block_ids);
+  BoundaryRestrictable(const InputParameters & parameters, const std::set<SubdomainID> & block_ids, bool nodal);
 
   /**
    * Empty class destructor
@@ -199,6 +201,9 @@ private:
 
   /// Pointer to MaterialData for boundary (@see hasBoundaryMaterialProperty)
   MooseSharedPointer<MaterialData> _bnd_material_data;
+
+  /// Whether or not this object is restricted to nodesets
+  bool _bnd_nodal;
 
   /**
    * An initialization routine needed for dual constructors

--- a/framework/include/base/BoundaryRestrictableRequired.h
+++ b/framework/include/base/BoundaryRestrictableRequired.h
@@ -33,7 +33,7 @@ InputParameters validParams<BoundaryRestrictableRequired>();
 class BoundaryRestrictableRequired : public BoundaryRestrictable
 {
 public:
-  BoundaryRestrictableRequired(const InputParameters & parameters);
+  BoundaryRestrictableRequired(const InputParameters & parameters, bool nodal);
 };
 
 #endif // BOUNDARYRESTRICTABLEREQURIED_H

--- a/framework/include/bcs/BoundaryCondition.h
+++ b/framework/include/bcs/BoundaryCondition.h
@@ -62,8 +62,9 @@ public:
   /**
    * Class constructor.
    * @param parameters The InputParameters for the object
+   * @param nodal Whether this BC is applied to nodes or not
    */
-  BoundaryCondition(const InputParameters & parameters);
+  BoundaryCondition(const InputParameters & parameters, bool nodal);
 
   /**
    * Gets the variable this BC is active on

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -328,10 +328,22 @@ public:
   const std::set<SubdomainID> & meshSubdomains() const;
 
   /**
-   * Returns a read-only reference to the set of subdomains currently
+   * Returns a read-only reference to the set of boundary IDs currently
    * present in the Mesh.
    */
   const std::set<BoundaryID> & meshBoundaryIds() const;
+
+  /**
+   * Returns a read-only reference to the set of sidesets currently
+   * present in the Mesh.
+   */
+  const std::set<BoundaryID> & meshSidesetIds() const;
+
+  /**
+   * Returns a read-only reference to the set of nodesets currently
+   * present in the Mesh.
+   */
+  const std::set<BoundaryID> & meshNodesetIds() const;
 
   /**
    * Sets the mapping between BoundaryID and normal vector
@@ -827,6 +839,7 @@ protected:
    */
   std::set<SubdomainID> _mesh_subdomains;
 
+  ///@{
   /**
    * A set of boundary IDs currently present in the mesh.
    * In serial, this is equivalent to the values returned
@@ -834,6 +847,9 @@ protected:
    * it will contain off-processor boundary IDs as well.
    */
   std::set<BoundaryID> _mesh_boundary_ids;
+  std::set<BoundaryID> _mesh_sideset_ids;
+  std::set<BoundaryID> _mesh_nodeset_ids;
+  ///@}
 
   /// The boundary to normal map - valid only when AddAllSideSetsByNormals is active
   UniquePtr<std::map<BoundaryID, RealVectorValue> > _boundary_to_normal_map;
@@ -995,6 +1011,9 @@ private:
 
   /// Whether or not this Mesh is allowed to read a recovery file
   bool _allow_recovery;
+
+  /// Whether or not to allow generation of nodesets from sidesets
+  bool _construct_node_list_from_side_list;
 };
 
 

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -56,7 +56,7 @@ InputParameters validParams<AuxKernel>()
 AuxKernel::AuxKernel(const InputParameters & parameters) :
     MooseObject(parameters),
     BlockRestrictable(parameters),
-    BoundaryRestrictable(parameters),
+    BoundaryRestrictable(parameters, parameters.get<AuxiliarySystem *>("_aux_sys")->getVariable(parameters.get<THREAD_ID>("_tid"), parameters.get<AuxVariableName>("variable")).isNodal()),
     SetupInterface(this),
     CoupleableMooseVariableDependencyIntermediateInterface(this, parameters.get<AuxiliarySystem *>("_aux_sys")->getVariable(parameters.get<THREAD_ID>("_tid"), parameters.get<AuxVariableName>("variable")).isNodal()),
     FunctionInterface(this),

--- a/framework/src/base/BoundaryRestrictableRequired.C
+++ b/framework/src/base/BoundaryRestrictableRequired.C
@@ -31,7 +31,7 @@ InputParameters validParams<BoundaryRestrictableRequired>()
   return params;
 }
 
-BoundaryRestrictableRequired::BoundaryRestrictableRequired(const InputParameters & parameters) :
-    BoundaryRestrictable(parameters)
+BoundaryRestrictableRequired::BoundaryRestrictableRequired(const InputParameters & parameters, bool nodal) :
+    BoundaryRestrictable(parameters, nodal)
 {
 }

--- a/framework/src/bcs/BoundaryCondition.C
+++ b/framework/src/bcs/BoundaryCondition.C
@@ -35,9 +35,9 @@ InputParameters validParams<BoundaryCondition>()
   return params;
 }
 
-BoundaryCondition::BoundaryCondition(const InputParameters & parameters) :
+BoundaryCondition::BoundaryCondition(const InputParameters & parameters, bool nodal) :
     MooseObject(parameters),
-    BoundaryRestrictableRequired(parameters),
+    BoundaryRestrictableRequired(parameters, nodal),
     SetupInterface(this),
     FunctionInterface(this),
     UserObjectInterface(this),

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -40,7 +40,7 @@ InputParameters validParams<IntegratedBC>()
 }
 
 IntegratedBC::IntegratedBC(const InputParameters & parameters) :
-    BoundaryCondition(parameters),
+    BoundaryCondition(parameters, false), // False is because this is NOT nodal
     RandomInterface(parameters, _fe_problem, _tid, false),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
     MaterialPropertyInterface(this),

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -29,7 +29,7 @@ InputParameters validParams<NodalBC>()
 
 
 NodalBC::NodalBC(const InputParameters & parameters) :
-    BoundaryCondition(parameters),
+    BoundaryCondition(parameters, true), // true is for being Nodal
     RandomInterface(parameters, _fe_problem, _tid, true),
     CoupleableMooseVariableDependencyIntermediateInterface(this, true),
     _current_node(_var.node()),

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -50,7 +50,7 @@ InputParameters validParams<DGKernel>()
 DGKernel::DGKernel(const InputParameters & parameters) :
     MooseObject(parameters),
     BlockRestrictable(parameters),
-    BoundaryRestrictable(parameters),
+    BoundaryRestrictable(parameters, false), // false for _not_ nodal
     SetupInterface(this),
     TransientInterface(this),
     FunctionInterface(this),

--- a/framework/src/ics/InitialCondition.C
+++ b/framework/src/ics/InitialCondition.C
@@ -42,7 +42,7 @@ InitialCondition::InitialCondition(const InputParameters & parameters) :
     FunctionInterface(this),
     UserObjectInterface(this),
     BlockRestrictable(parameters),
-    BoundaryRestrictable(parameters),
+    BoundaryRestrictable(parameters, true), // true for being nodal
     DependencyResolverInterface(),
     Restartable(parameters, "InitialConditions"),
     ZeroInterface(parameters),

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -50,7 +50,7 @@ InputParameters validParams<Material>()
 Material::Material(const InputParameters & parameters) :
     MooseObject(parameters),
     BlockRestrictable(parameters),
-    BoundaryRestrictable(parameters, blockIDs()),
+    BoundaryRestrictable(parameters, blockIDs(), false), // false for being _not_ nodal
     SetupInterface(this),
     Coupleable(this, false),
     MooseVariableDependencyInterface(),

--- a/framework/src/multiapps/AutoPositionsMultiApp.C
+++ b/framework/src/multiapps/AutoPositionsMultiApp.C
@@ -33,7 +33,7 @@ InputParameters validParams<AutoPositionsMultiApp>()
 
 AutoPositionsMultiApp::AutoPositionsMultiApp(const InputParameters & parameters):
     TransientMultiApp(parameters),
-    BoundaryRestrictable(parameters)
+    BoundaryRestrictable(parameters, true) // true for applying to nodesets
 {
 }
 

--- a/framework/src/nodalkernels/NodalKernel.C
+++ b/framework/src/nodalkernels/NodalKernel.C
@@ -48,7 +48,7 @@ InputParameters validParams<NodalKernel>()
 NodalKernel::NodalKernel(const InputParameters & parameters) :
     MooseObject(parameters),
     BlockRestrictable(parameters),
-    BoundaryRestrictable(parameters),
+    BoundaryRestrictable(parameters, true), // true for applying to nodesets
     SetupInterface(this),
     FunctionInterface(this),
     UserObjectInterface(this),

--- a/framework/src/userobject/NodalNormalsPreprocessor.C
+++ b/framework/src/userobject/NodalNormalsPreprocessor.C
@@ -36,7 +36,7 @@ InputParameters validParams<NodalNormalsPreprocessor>()
 
 NodalNormalsPreprocessor::NodalNormalsPreprocessor(const InputParameters & parameters) :
     ElementUserObject(parameters),
-    BoundaryRestrictable(parameters),
+    BoundaryRestrictable(parameters, true), // true for applying to nodesets
     _aux(_fe_problem.getAuxiliarySystem()),
     _fe_type(getParam<Order>("fe_order"), getParam<FEFamily>("fe_family")),
     _has_corners(isParamValid("corner_boundary")),

--- a/framework/src/userobject/NodalUserObject.C
+++ b/framework/src/userobject/NodalUserObject.C
@@ -33,7 +33,7 @@ InputParameters validParams<NodalUserObject>()
 NodalUserObject::NodalUserObject(const InputParameters & parameters) :
     UserObject(parameters),
     BlockRestrictable(parameters),
-    BoundaryRestrictable(parameters, blockIDs()),
+    BoundaryRestrictable(parameters, blockIDs(), true), // true for applying to nodesets
     MaterialPropertyInterface(this, blockIDs(), boundaryIDs()),
     UserObjectInterface(this),
     Coupleable(this, true),

--- a/framework/src/userobject/SideUserObject.C
+++ b/framework/src/userobject/SideUserObject.C
@@ -28,7 +28,7 @@ InputParameters validParams<SideUserObject>()
 
 SideUserObject::SideUserObject(const InputParameters & parameters) :
     UserObject(parameters),
-    BoundaryRestrictableRequired(parameters),
+    BoundaryRestrictableRequired(parameters, false), // false for applying to sidesets
     MaterialPropertyInterface(this, boundaryIDs()),
     Coupleable(this, false),
     MooseVariableDependencyInterface(),

--- a/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -50,7 +50,7 @@ const Real CrackFrontDefinition::_tol = 1e-10;
 
 CrackFrontDefinition::CrackFrontDefinition(const InputParameters & parameters) :
     GeneralUserObject(parameters),
-    BoundaryRestrictable(parameters),
+    BoundaryRestrictable(parameters, true), // false means nodesets
     _aux(_fe_problem.getAuxiliarySystem()),
     _mesh(_subproblem.mesh()),
     _treat_as_2d(getParam<bool>("2d")),

--- a/test/tests/mesh/node_list_from_side_list/node_list_from_side_list.i
+++ b/test/tests/mesh/node_list_from_side_list/node_list_from_side_list.i
@@ -1,0 +1,46 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+  construct_node_list_from_side_list = false
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Steady
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/mesh/node_list_from_side_list/tests
+++ b/test/tests/mesh/node_list_from_side_list/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./test]
+    type = 'RunException'
+    input = 'node_list_from_side_list.i'
+    expect_err = 'The object \'left\' contains the following boundary ids that do no exist on the mesh: 3'
+  [../]
+[]


### PR DESCRIPTION
Implements better error checking in BoundaryRestrictable by only checking for the existence of sidesets/nodesets that match the restricted object.

Also adds a capability for suppressing nodeset generation and this is used to test the new error checking.

closes #6985 closes #6987
