### PR TITLE
Allow user to enable c++11

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -9,6 +9,16 @@ do
   fi
 done
 
+# check if C++11 is enabled
+DISABLE_CXX11='--disable-cxx11'
+for i in "$@"
+do
+  if [ "$i" == "--enable-cxx11" ]; then
+    DISABLE_CXX11='';
+    break;
+  fi
+done
+
 # If --fast was used, it means we are going to skip configure, so
 # don't allow the user to pass any other flags to the script thinking
 # they are going to do something.
@@ -92,7 +102,7 @@ if [ -z "$go_fast" ]; then
                --enable-silent-rules \
                --enable-unique-id \
                --disable-warnings \
-               --disable-cxx11 \
+               $DISABLE_CXX11 \
                --enable-unique-ptr \
                --enable-openmp \
                --disable-maintainer-mode \


### PR DESCRIPTION
This PR removes the disable C++11 switch if the user explicitly enables it through an additional argument to update and rebuild libmesh.

Closes #6995
