### PR TITLE
Introduce C++11 range-based for loops in framework

### DIFF
--- a/framework/include/outputs/formatters/YAMLFormatter.h
+++ b/framework/include/outputs/formatters/YAMLFormatter.h
@@ -17,6 +17,7 @@
 
 #include "SyntaxTree.h"
 #include <sstream>
+#include <iterator>
 
 /**
  * This class produces produces a yaml dump of the InputFileParameters that is machine parsable by any YAML formatter.
@@ -42,7 +43,7 @@ protected:
    * @param output Reference to the output string
    * @param iter InputParameters iterator that is being output
    */
-  void buildOutputString(std::ostringstream & output, const InputParameters::iterator iter);
+  void buildOutputString(std::ostringstream & output, const std::iterator_traits<InputParameters::iterator>::value_type & p);
 };
 
 #endif /* YAMLFORMATTER_H */

--- a/framework/src/actions/AddElementalFieldAction.C
+++ b/framework/src/actions/AddElementalFieldAction.C
@@ -39,9 +39,9 @@ AddElementalFieldAction::act()
 {
   std::set<SubdomainID> blocks;
   std::vector<SubdomainName> block_param = getParam<std::vector<SubdomainName> >("block");
-  for (std::vector<SubdomainName>::iterator it = block_param.begin(); it != block_param.end(); ++it)
+  for (const auto & subdomain_name : block_param)
   {
-    SubdomainID blk_id = _problem->mesh().getSubdomainID(*it);
+    SubdomainID blk_id = _problem->mesh().getSubdomainID(subdomain_name);
     blocks.insert(blk_id);
   }
 

--- a/framework/src/actions/AddPeriodicBCAction.C
+++ b/framework/src/actions/AddPeriodicBCAction.C
@@ -48,7 +48,7 @@ void
 AddPeriodicBCAction::setPeriodicVars(PeriodicBoundaryBase & p, const std::vector<VariableName> & var_names)
 {
   NonlinearSystem & nl = _problem->getNonlinearSystem();
-  std::vector<VariableName> const * var_names_ptr;
+  const std::vector<VariableName> * var_names_ptr;
 
   // If var_names is empty - then apply this periodic condition to all variables in the system
   if (var_names.empty())
@@ -56,9 +56,9 @@ AddPeriodicBCAction::setPeriodicVars(PeriodicBoundaryBase & p, const std::vector
   else
     var_names_ptr = &var_names;
 
-  for (std::vector<VariableName>::const_iterator it = var_names_ptr->begin(); it != var_names_ptr->end(); ++it)
+  for (const auto & var_name : *var_names_ptr)
   {
-    unsigned int var_num = nl.getVariable(0, (*it)).number();
+    unsigned int var_num = nl.getVariable(0, var_name).number();
 
     p.set_variable(var_num);
     _mesh->addPeriodicVariable(var_num, p.myboundary, p.pairedboundary);
@@ -74,10 +74,8 @@ AddPeriodicBCAction::autoTranslationBoundaries()
     if (_mesh->isDistributedMesh())
     {
       const std::set<BoundaryID> & ids = _mesh->meshBoundaryIds();
-      for (std::set<BoundaryID>::const_iterator id_it = ids.begin();
-          id_it != ids.end();
-          ++id_it)
-        _problem->addGhostedBoundary(*id_it);
+      for (const auto & bid : ids)
+        _problem->addGhostedBoundary(bid);
 
       _problem->ghostGhostedBoundaries();
       _mesh->detectOrthogonalDimRanges();
@@ -87,18 +85,18 @@ AddPeriodicBCAction::autoTranslationBoundaries()
     std::vector<std::string> auto_dirs = getParam<std::vector<std::string> >("auto_direction");
 
     int dim_offset = _mesh->dimension() - 2;
-    for (unsigned int i=0; i<auto_dirs.size(); ++i)
+    for (const auto & dir : auto_dirs)
     {
       int component = -1;
-      if (auto_dirs[i] == "X" || auto_dirs[i] == "x")
+      if (dir == "X" || dir == "x")
         component = 0;
-      else if (auto_dirs[i] == "Y" || auto_dirs[i] == "y")
+      else if (dir == "Y" || dir == "y")
       {
         if (dim_offset < 0)
           mooseError("Cannot wrap 'Y' direction when using a 1D mesh");
         component = 1;
       }
-      else if (auto_dirs[i] == "Z" || auto_dirs[i] == "z")
+      else if (dir == "Z" || dir == "z")
       {
         if (dim_offset <= 0)
           mooseError("Cannot wrap 'Z' direction when using a 1D or 2D mesh");
@@ -107,7 +105,7 @@ AddPeriodicBCAction::autoTranslationBoundaries()
 
       if (component >= 0)
       {
-        std::pair<BoundaryID, BoundaryID> *boundary_ids = _mesh->getPairedBoundaryMapping(component);
+        std::pair<BoundaryID, BoundaryID> * boundary_ids = _mesh->getPairedBoundaryMapping(component);
         RealVectorValue v;
         v(component) = _mesh->dimensionWidth(component);
         PeriodicBoundary p(v);

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -154,9 +154,9 @@ AddVariableAction::getSubdomainIDs()
   // Extract and return the block ids supplied in the input
   std::set<SubdomainID> blocks;
   std::vector<SubdomainName> block_param = getParam<std::vector<SubdomainName> >("block");
-  for (std::vector<SubdomainName>::iterator it = block_param.begin(); it != block_param.end(); ++it)
+  for (const auto & subdomain_name : block_param)
   {
-    SubdomainID blk_id = _problem->mesh().getSubdomainID(*it);
+    SubdomainID blk_id = _problem->mesh().getSubdomainID(subdomain_name);
     blocks.insert(blk_id);
   }
   return blocks;

--- a/framework/src/actions/CheckOutputAction.C
+++ b/framework/src/actions/CheckOutputAction.C
@@ -50,10 +50,10 @@ CheckOutputAction::checkVariableOutput(const std::string & task)
   {
     // Loop through the actions for the given task
     const std::vector<Action *> & actions = _awh.getActionsByName(task);
-    for (std::vector<Action *>::const_iterator it = actions.begin(); it != actions.end(); ++it)
+    for (const auto & act : actions)
     {
       // Cast the object to AddVariableAction so that that OutputInterface::buildOutputHideVariableList may be called
-      AddVariableAction * ptr = dynamic_cast<AddVariableAction*>(*it);
+      AddVariableAction * ptr = dynamic_cast<AddVariableAction*>(act);
 
       // If the cast fails move to the next action, this is the case with NodalNormals which is also associated with
       // the "add_aux_variable" task.
@@ -82,10 +82,10 @@ CheckOutputAction::checkMaterialOutput()
   // TODO include boundary materials
 
   // Loop through each material object
-  for (std::vector<MooseSharedPointer<Material> >::const_iterator material_iter = materials.begin(); material_iter != materials.end(); ++material_iter)
+  for (const auto & mat : materials)
   {
     // Extract the names of the output objects to which the material properties will be exported
-    std::set<OutputName> outputs = (*material_iter)->getOutputs();
+    std::set<OutputName> outputs = mat->getOutputs();
 
     // Check that the outputs exist
     _app.getOutputWarehouse().checkOutputs(outputs);
@@ -98,8 +98,8 @@ CheckOutputAction::checkConsoleOutput()
   // Warning if multiple Console objects are added with 'output_screen=true' in the input file
   std::vector<Console *> console_ptrs = _app.getOutputWarehouse().getOutputs<Console>();
   unsigned int num_screen_outputs = 0;
-  for (std::vector<Console *>::iterator it = console_ptrs.begin(); it != console_ptrs.end(); ++it)
-    if ((*it)->getParam<bool>("output_screen"))
+  for (const auto & console : console_ptrs)
+    if (console->getParam<bool>("output_screen"))
       num_screen_outputs++;
 
   if (num_screen_outputs > 1)
@@ -113,8 +113,8 @@ CheckOutputAction::checkPerfLogOutput()
   // Search for the existence of a Console output object
   bool has_console = false;
   std::vector<Console *> ptrs = _app.getOutputWarehouse().getOutputs<Console>();
-  for (std::vector<Console *>::const_iterator it = ptrs.begin(); it != ptrs.end(); ++it)
-    if ((*it)->getParam<bool>("output_screen"))
+  for (const auto & console : ptrs)
+    if (console->getParam<bool>("output_screen"))
     {
       has_console = true;
       break;

--- a/framework/src/actions/DynamicObjectRegistrationAction.C
+++ b/framework/src/actions/DynamicObjectRegistrationAction.C
@@ -44,10 +44,10 @@ DynamicObjectRegistrationAction::DynamicObjectRegistrationAction(InputParameters
 
 
     std::vector<std::string> application_names = getParam<std::vector<std::string> >("register_objects_from");
-    for (unsigned int i = 0; i < application_names.size(); ++i)
+    for (const auto & app_name : application_names)
     {
-      _app.dynamicObjectRegistration(application_names[i], &_factory, getParam<std::string>("library_path"));
-      _app.dynamicSyntaxAssociation(application_names[i], &_awh.syntax(), &_action_factory, getParam<std::string>("library_path"));
+      _app.dynamicObjectRegistration(app_name, &_factory, getParam<std::string>("library_path"));
+      _app.dynamicSyntaxAssociation(app_name, &_awh.syntax(), &_action_factory, getParam<std::string>("library_path"));
     }
   }
 }

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -63,8 +63,8 @@ SetupMeshAction::setupMesh(MooseMesh *mesh)
 {
   std::vector<BoundaryName> ghosted_boundaries = getParam<std::vector<BoundaryName> >("ghosted_boundaries");
 
-  for (unsigned int i=0; i<ghosted_boundaries.size(); i++)
-    mesh->addGhostedBoundary(mesh->getBoundaryID(ghosted_boundaries[i]));
+  for (const auto & bnd_name : ghosted_boundaries)
+    mesh->addGhostedBoundary(mesh->getBoundaryID(bnd_name));
 
   mesh->setPatchSize(getParam<unsigned int>("patch_size"));
 

--- a/framework/src/actions/SetupResidualDebugAction.C
+++ b/framework/src/actions/SetupResidualDebugAction.C
@@ -46,10 +46,8 @@ SetupResidualDebugAction::act()
   _problem->getNonlinearSystem().debuggingResiduals(true);
 
   // debug variable residuals
-  for (std::vector<NonlinearVariableName>::const_iterator it = _show_var_residual.begin(); it != _show_var_residual.end(); ++it)
+  for (const auto & var_name : _show_var_residual)
   {
-    NonlinearVariableName var_name = *it;
-
     // add aux-variable
     MooseVariable & var = _problem->getVariable(0, var_name);
     const std::set<SubdomainID> & subdomains = var.activeSubdomains();

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -105,9 +105,9 @@ AuxKernel::AuxKernel(const InputParameters & parameters) :
   _supplied_vars.insert(parameters.get<AuxVariableName>("variable"));
 
   std::map<std::string, std::vector<MooseVariable *> > coupled_vars = getCoupledVars();
-  for (std::map<std::string, std::vector<MooseVariable *> >::iterator it = coupled_vars.begin(); it != coupled_vars.end(); ++it)
-    for (std::vector<MooseVariable *>::iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2)
-      _depend_vars.insert((*it2)->name());
+  for (const auto & it : coupled_vars)
+    for (const auto & var : it.second)
+      _depend_vars.insert(var->name());
 }
 
 AuxKernel::~AuxKernel()
@@ -153,8 +153,8 @@ AuxKernel::coupledCallback(const std::string & var_name, bool is_old)
   if (is_old)
   {
     std::vector<VariableName> var_names = getParam<std::vector<VariableName> >(var_name);
-    for (std::vector<VariableName>::const_iterator it = var_names.begin(); it != var_names.end(); ++it)
-      _depend_vars.erase(*it);
+    for (const auto & name : var_names)
+      _depend_vars.erase(name);
   }
 }
 

--- a/framework/src/auxkernels/AuxNodalScalarKernel.C
+++ b/framework/src/auxkernels/AuxNodalScalarKernel.C
@@ -31,8 +31,8 @@ AuxNodalScalarKernel::AuxNodalScalarKernel(const InputParameters & parameters) :
 {
   // Fill in the MooseVariable dependencies
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 }
 
 AuxNodalScalarKernel::~AuxNodalScalarKernel()

--- a/framework/src/auxkernels/AuxScalarKernel.C
+++ b/framework/src/auxkernels/AuxScalarKernel.C
@@ -59,8 +59,8 @@ AuxScalarKernel::AuxScalarKernel(const InputParameters & parameters) :
   _supplied_vars.insert(parameters.get<AuxVariableName>("variable"));
 
   const std::vector<MooseVariableScalar *> & coupled_vars = getCoupledMooseScalarVars();
-  for (std::vector<MooseVariableScalar *>::const_iterator it = coupled_vars.begin(); it != coupled_vars.end(); ++it)
-    _depend_vars.insert((*it)->name());
+  for (const auto & var : coupled_vars)
+    _depend_vars.insert(var->name());
 }
 
 AuxScalarKernel::~AuxScalarKernel()

--- a/framework/src/auxkernels/FunctionScalarAux.C
+++ b/framework/src/auxkernels/FunctionScalarAux.C
@@ -30,8 +30,9 @@ FunctionScalarAux::FunctionScalarAux(const InputParameters & parameters) :
   std::vector<FunctionName> funcs = getParam<std::vector<FunctionName> >("function");
   if (funcs.size() != _var.order())
     mooseError("number of functions is not equal to the number of scalar variable components");
-  for (unsigned int i = 0; i < funcs.size(); ++i)
-    _functions.push_back(&getFunctionByName(funcs[i]));
+
+  for (const auto & func : funcs)
+    _functions.push_back(&getFunctionByName(func));
 }
 
 FunctionScalarAux::~FunctionScalarAux()

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -57,11 +57,8 @@ Adaptivity::Adaptivity(FEProblem & subproblem) :
 
 Adaptivity::~Adaptivity()
 {
-  std::map<std::string, ErrorVector *>::iterator it = _indicator_field_to_error_vector.begin();
-  std::map<std::string, ErrorVector *>::iterator end = _indicator_field_to_error_vector.end();
-
-  for (; it != end; ++it)
-    delete it->second;
+  for (const auto & it : _indicator_field_to_error_vector)
+    delete it.second;
 
   delete _mesh_refinement;
   delete _error;
@@ -296,11 +293,9 @@ void
 Adaptivity::updateErrorVectors()
 {
   // Resize all of the ErrorVectors in case the mesh has changed
-  for (std::map<std::string, ErrorVector *>::iterator it=_indicator_field_to_error_vector.begin();
-      it != _indicator_field_to_error_vector.end();
-      ++it)
+  for (const auto & it : _indicator_field_to_error_vector)
   {
-    ErrorVector & vec = *(it->second);
+    ErrorVector & vec = *(it.second);
     vec.resize(_mesh.getMesh().max_elem_id());
     for (unsigned int i=0; i<vec.size(); i++)
       vec[i] = 0.0;
@@ -311,10 +306,8 @@ Adaptivity::updateErrorVectors()
   Threads::parallel_reduce(*_mesh.getActiveLocalElementRange(), uevt);
 
   // Now sum across all processors
-  for (std::map<std::string, ErrorVector *>::iterator it=_indicator_field_to_error_vector.begin();
-      it != _indicator_field_to_error_vector.end();
-      ++it)
-    _subproblem.comm().sum((std::vector<float>&)*(it->second));
+  for (const auto & it : _indicator_field_to_error_vector)
+    _subproblem.comm().sum((std::vector<float>&)*(it.second));
 }
 
 bool

--- a/framework/src/base/AllLocalDofIndicesThread.C
+++ b/framework/src/base/AllLocalDofIndicesThread.C
@@ -48,10 +48,8 @@ AllLocalDofIndicesThread::operator() (const ConstElemRange & range)
   ParallelUniqueId puid;
   _tid = puid.id;
 
-  for (ConstElemRange::const_iterator elem_it = range.begin() ; elem_it != range.end(); ++elem_it)
+  for (const auto & elem : range)
   {
-    const Elem * elem = *elem_it;
-
     std::vector<dof_id_type> dof_indices;
 
     dof_id_type local_dof_begin = _dof_map.first_dof();

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -175,15 +175,15 @@ AuxiliarySystem::addScalarKernel(const std::string & kernel_name, const std::str
 void
 AuxiliarySystem::reinitElem(const Elem * /*elem*/, THREAD_ID tid)
 {
-  for (std::map<std::string, MooseVariable *>::iterator it = _nodal_vars[tid].begin(); it != _nodal_vars[tid].end(); ++it)
+  for (const auto & it : _nodal_vars[tid])
   {
-    MooseVariable *var = it->second;
+    MooseVariable * var = it.second;
     var->computeElemValues();
   }
 
-  for (std::map<std::string, MooseVariable *>::iterator it = _elem_vars[tid].begin(); it != _elem_vars[tid].end(); ++it)
+  for (const auto & it : _elem_vars[tid])
   {
-    MooseVariable *var = it->second;
+    MooseVariable * var = it.second;
     var->reinitAux();
     var->computeElemValues();
   }
@@ -192,15 +192,15 @@ AuxiliarySystem::reinitElem(const Elem * /*elem*/, THREAD_ID tid)
 void
 AuxiliarySystem::reinitElemFace(const Elem * /*elem*/, unsigned int /*side*/, BoundaryID /*bnd_id*/, THREAD_ID tid)
 {
-  for (std::map<std::string, MooseVariable *>::iterator it = _nodal_vars[tid].begin(); it != _nodal_vars[tid].end(); ++it)
+  for (const auto & it : _nodal_vars[tid])
   {
-    MooseVariable *var = it->second;
+    MooseVariable * var = it.second;
     var->computeElemValuesFace();
   }
 
-  for (std::map<std::string, MooseVariable *>::iterator it = _elem_vars[tid].begin(); it != _elem_vars[tid].end(); ++it)
+  for (const auto & it : _elem_vars[tid])
   {
-    MooseVariable *var = it->second;
+    MooseVariable * var = it.second;
     var->reinitAux();
     var->reinitAuxNeighbor();
     var->computeElemValuesFace();
@@ -284,9 +284,9 @@ AuxiliarySystem::getDependObjects(ExecFlagType type)
   // Elemental AuxKernels
   {
     const std::vector<MooseSharedPointer<AuxKernel> > & auxs = _elemental_aux_storage[type].getActiveObjects();
-    for (std::vector<MooseSharedPointer<AuxKernel> >::const_iterator it = auxs.begin(); it != auxs.end(); ++it)
+    for (const auto & aux : auxs)
     {
-      const std::set<std::string> & uo = (*it)->getDependObjects();
+      const std::set<std::string> & uo = aux->getDependObjects();
       depend_objects.insert(uo.begin(), uo.end());
     }
   }
@@ -294,9 +294,9 @@ AuxiliarySystem::getDependObjects(ExecFlagType type)
   // Nodal AuxKernels
   {
     const std::vector<MooseSharedPointer<AuxKernel> > & auxs = _nodal_aux_storage[type].getActiveObjects();
-    for (std::vector<MooseSharedPointer<AuxKernel> >::const_iterator it = auxs.begin(); it != auxs.end(); ++it)
+    for (const auto & aux : auxs)
     {
-      const std::set<std::string> & uo = (*it)->getDependObjects();
+      const std::set<std::string> & uo = aux->getDependObjects();
       depend_objects.insert(uo.begin(), uo.end());
     }
   }
@@ -312,9 +312,9 @@ AuxiliarySystem::getDependObjects()
   // Elemental AuxKernels
   {
     const std::vector<MooseSharedPointer<AuxKernel> > & auxs = _elemental_aux_storage.getActiveObjects();
-    for (std::vector<MooseSharedPointer<AuxKernel> >::const_iterator it = auxs.begin(); it != auxs.end(); ++it)
+    for (const auto & aux : auxs)
     {
-      const std::set<std::string> & uo = (*it)->getDependObjects();
+      const std::set<std::string> & uo = aux->getDependObjects();
       depend_objects.insert(uo.begin(), uo.end());
     }
   }
@@ -322,9 +322,9 @@ AuxiliarySystem::getDependObjects()
   // Nodal AuxKernels
   {
     const std::vector<MooseSharedPointer<AuxKernel> > & auxs = _nodal_aux_storage.getActiveObjects();
-    for (std::vector<MooseSharedPointer<AuxKernel> >::const_iterator it = auxs.begin(); it != auxs.end(); ++it)
+    for (const auto & aux : auxs)
     {
-      const std::set<std::string> & uo = (*it)->getDependObjects();
+      const std::set<std::string> & uo = aux->getDependObjects();
       depend_objects.insert(uo.begin(), uo.end());
     }
   }
@@ -361,15 +361,12 @@ AuxiliarySystem::computeScalarVars(ExecFlagType type)
 
       // Call compute() method on all active AuxScalarKernel objects
       const std::vector<MooseSharedPointer<AuxScalarKernel> > & objects = storage.getActiveObjects(tid);
-      for (std::vector<MooseSharedPointer<AuxScalarKernel> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
-        (*it)->compute();
+      for (const auto & obj : objects)
+        obj->compute();
 
       const std::vector<MooseVariableScalar *> & scalar_vars = getScalarVariables(tid);
-      for (std::vector<MooseVariableScalar *>::const_iterator it = scalar_vars.begin(); it != scalar_vars.end(); ++it)
-      {
-        MooseVariableScalar * var = *it;
+      for (const auto & var : scalar_vars)
         var->insert(solution());
-      }
     }
   }
   PARALLEL_CATCH;
@@ -468,11 +465,11 @@ AuxiliarySystem::getMinQuadratureOrder()
 {
   Order order = CONSTANT;
   std::vector<MooseVariable *> vars = _vars[0].variables();
-  for (std::vector<MooseVariable *>::iterator it = vars.begin(); it != vars.end(); ++it)
+  for (const auto & var : vars)
   {
-    if (!(*it)->isNodal()) // nodal aux variables do not need quadrature
+    if (!var->isNodal()) // nodal aux variables do not need quadrature
     {
-      FEType fe_type = (*it)->feType();
+      FEType fe_type = var->feType();
       if (fe_type.default_quadrature_order() > order)
         order = fe_type.default_quadrature_order();
     }

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -148,8 +148,8 @@ BlockRestrictable::initializeBlockRestrictable(const InputParameters & parameter
     {
       std::ostringstream msg;
       msg << "The object '" << name << "' contains the following block ids that do no exist on the mesh:";
-      for (std::vector<SubdomainID>::iterator it = diff.begin(); it != diff.end(); ++it)
-        msg << " " << *it;
+      for (const auto & id : diff)
+        msg << " " << id;
       mooseError(msg.str());
     }
   }
@@ -303,18 +303,18 @@ BlockRestrictable::hasBlockMaterialPropertyHelper(const std::string & prop_name)
   const std::set<SubdomainID> & ids = hasBlocks(Moose::ANY_BLOCK_ID) ? meshBlockIDs() : blockIDs();
 
   // Loop over each id for this object
-  for (std::set<SubdomainID>::const_iterator id_it = ids.begin(); id_it != ids.end(); ++id_it)
+  for (const auto & id : ids)
   {
     // Storage of material properties that have been DECLARED on this id
     std::set<std::string> declared_props;
 
     // If block materials exist, populated the set of properties that were declared
-    if (warehouse.hasActiveBlockObjects(*id_it))
+    if (warehouse.hasActiveBlockObjects(id))
     {
-      const std::vector<MooseSharedPointer<Material> > & mats = warehouse.getActiveBlockObjects(*id_it);
-      for (std::vector<MooseSharedPointer<Material> >::const_iterator mat_it = mats.begin(); mat_it != mats.end(); ++mat_it)
+      const std::vector<MooseSharedPointer<Material> > & mats = warehouse.getActiveBlockObjects(id);
+      for (const auto & mat : mats)
       {
-        const std::set<std::string> & mat_props = (*mat_it)->getSuppliedItems();
+        const std::set<std::string> & mat_props = mat->getSuppliedItems();
         declared_props.insert(mat_props.begin(), mat_props.end());
       }
     }

--- a/framework/src/base/BoundaryRestrictable.C
+++ b/framework/src/base/BoundaryRestrictable.C
@@ -125,8 +125,8 @@ BoundaryRestrictable::initializeBoundaryRestrictable(const InputParameters & par
     {
       std::ostringstream msg;
       msg << "The object '" << name << "' contains the following boundary ids that do no exist on the mesh:";
-      for (std::vector<BoundaryID>::iterator it = diff.begin(); it != diff.end(); ++it)
-        msg << " " << *it;
+      for (const auto & id : diff)
+        msg << " " << id;
       mooseError(msg.str());
     }
   }
@@ -213,10 +213,10 @@ BoundaryRestrictable::hasBoundary(std::set<BoundaryID> ids, TEST_TYPE type) cons
   else
   {
     // Loop through the supplied ids
-    for (std::set<BoundaryID>::const_iterator it = ids.begin(); it != ids.end(); ++it)
+    for (const auto & id : ids)
     {
       // Test the current supplied id
-      bool test = hasBoundary(*it);
+      bool test = hasBoundary(id);
 
       // If the id exists in the stored ids, then return true, otherwise
       if (test)
@@ -262,18 +262,18 @@ BoundaryRestrictable::hasBoundaryMaterialPropertyHelper(const std::string & prop
   const std::set<BoundaryID> & ids = hasBoundary(Moose::ANY_BOUNDARY_ID) ? meshBoundaryIDs() : boundaryIDs();
 
   // Loop over each BoundaryID for this object
-  for (std::set<BoundaryID>::const_iterator id_it = ids.begin(); id_it != ids.end(); ++id_it)
+  for (const auto & id : ids)
   {
     // Storage of material properties that have been DECLARED on this BoundaryID
     std::set<std::string> declared_props;
 
     // If boundary materials exist, populated the set of properties that were declared
-    if (warehouse.hasActiveBoundaryObjects(*id_it))
+    if (warehouse.hasActiveBoundaryObjects(id))
     {
-      const std::vector<MooseSharedPointer<Material> > & mats = warehouse.getActiveBoundaryObjects(*id_it);
-      for (std::vector<MooseSharedPointer<Material> >::const_iterator mat_it = mats.begin(); mat_it != mats.end(); ++mat_it)
+      const std::vector<MooseSharedPointer<Material> > & mats = warehouse.getActiveBoundaryObjects(id);
+      for (const auto & mat : mats)
       {
-        const std::set<std::string> & mat_props = (*mat_it)->getSuppliedItems();
+        const std::set<std::string> & mat_props = mat->getSuppliedItems();
         declared_props.insert(mat_props.begin(), mat_props.end());
       }
     }

--- a/framework/src/base/ComputeBoundaryInitialConditionThread.C
+++ b/framework/src/base/ComputeBoundaryInitialConditionThread.C
@@ -41,10 +41,8 @@ ComputeBoundaryInitialConditionThread::onNode(ConstBndNodeRange::const_iterator 
   if (warehouse.hasActiveBoundaryObjects(boundary_id, _tid))
   {
     const std::vector<MooseSharedPointer<InitialCondition> > & ics = warehouse.getActiveBoundaryObjects(boundary_id, _tid);
-    for (std::vector<MooseSharedPointer<InitialCondition> >::const_iterator it = ics.begin(); it != ics.end(); ++it)
+    for (const auto & ic : ics)
     {
-      MooseSharedPointer<InitialCondition> ic = (*it);
-
       if (node->processor_id() == _fe_problem.processor_id())
       {
         MooseVariable & var = ic->variable();

--- a/framework/src/base/ComputeDiracThread.C
+++ b/framework/src/base/ComputeDiracThread.C
@@ -80,11 +80,11 @@ ComputeDiracThread::onElement(const Elem * elem)
   // DiracKernels and check whether this is the case.
   bool need_reinit_materials = false;
   {
-    for (std::vector<MooseSharedPointer<DiracKernel> >::const_iterator it = dkernels.begin(); it != dkernels.end(); ++it)
+    for (const auto & dirac_kernel : dkernels)
     {
       // If any of the DiracKernels have had getMaterialProperty()
       // called, we need to reinit Materials.
-      if ((*it)->getMaterialPropertyCalled())
+      if (dirac_kernel->getMaterialPropertyCalled())
       {
         need_reinit_materials = true;
         break;
@@ -95,10 +95,8 @@ ComputeDiracThread::onElement(const Elem * elem)
   if (need_reinit_materials)
     _fe_problem.reinitMaterials(_subdomain, _tid, /*swap_stateful=*/false);
 
-  for (std::vector<MooseSharedPointer<DiracKernel> >::const_iterator it = dkernels.begin(); it != dkernels.end(); ++it)
+  for (const auto & dirac_kernel : dkernels)
   {
-    MooseSharedPointer<DiracKernel> dirac_kernel = *it;
-
     if (dirac_kernel->hasPointsOnElem(elem))
     {
       if (_jacobian == NULL)

--- a/framework/src/base/ComputeElemDampingThread.C
+++ b/framework/src/base/ComputeElemDampingThread.C
@@ -51,9 +51,9 @@ ComputeElemDampingThread::onElement(const Elem *elem)
   _nl.reinitIncrementForDampers(_tid);
 
   const std::vector<MooseSharedPointer<ElementDamper> > & objects = _element_dampers.getActiveObjects(_tid);
-  for (std::vector<MooseSharedPointer<ElementDamper> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+  for (const auto & obj : objects)
   {
-    Real cur_damping = (*it)->computeDamping();
+    Real cur_damping = obj->computeDamping();
     if (cur_damping < _damping)
       _damping = cur_damping;
   }

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -68,9 +68,9 @@ ComputeIndicatorThread::subdomainChanged()
 void
 ComputeIndicatorThread::onElement(const Elem *elem)
 {
-  for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._elem_vars[_tid].begin(); it != _aux_sys._elem_vars[_tid].end(); ++it)
+  for (const auto & it : _aux_sys._elem_vars[_tid])
   {
-    MooseVariable * var = it->second;
+    MooseVariable * var = it.second;
     var->prepareAux();
   }
 
@@ -85,8 +85,8 @@ ComputeIndicatorThread::onElement(const Elem *elem)
     if (_indicator_whs.hasActiveBlockObjects(_subdomain, _tid))
     {
       const std::vector<MooseSharedPointer<Indicator> > & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
-      for (std::vector<MooseSharedPointer<Indicator> >::const_iterator it = indicators.begin(); it != indicators.end(); ++it)
-        (*it)->computeIndicator();
+      for (const auto & indicator : indicators)
+        indicator->computeIndicator();
     }
   }
 
@@ -96,15 +96,15 @@ ComputeIndicatorThread::onElement(const Elem *elem)
     if (_indicator_whs.hasActiveBlockObjects(_subdomain, _tid))
     {
       const std::vector<MooseSharedPointer<Indicator> > & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
-      for (std::vector<MooseSharedPointer<Indicator> >::const_iterator it = indicators.begin(); it != indicators.end(); ++it)
-        (*it)->finalize();
+      for (const auto & indicator : indicators)
+        indicator->finalize();
     }
 
     if (_internal_side_indicators.hasActiveBlockObjects(_subdomain, _tid))
     {
       const std::vector<MooseSharedPointer<InternalSideIndicator> > & internal_indicators = _internal_side_indicators.getActiveBlockObjects(_subdomain, _tid);
-      for (std::vector<MooseSharedPointer<InternalSideIndicator> >::const_iterator it = internal_indicators.begin(); it != internal_indicators.end(); ++it)
-        (*it)->finalize();
+      for (const auto & internal_indicator : internal_indicators)
+        internal_indicator->finalize();
     }
   }
 
@@ -113,9 +113,9 @@ ComputeIndicatorThread::onElement(const Elem *elem)
   if (!_finalize) // During finalize the Indicators should be setting values in the vectors manually
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._elem_vars[_tid].begin(); it != _aux_sys._elem_vars[_tid].end(); ++it)
+    for (const auto & it : _aux_sys._elem_vars[_tid])
     {
-      MooseVariable * var = it->second;
+      MooseVariable * var = it.second;
       var->add(_aux_sys.solution());
     }
   }
@@ -142,9 +142,9 @@ ComputeIndicatorThread::onInternalSide(const Elem *elem, unsigned int side)
 
   if ((neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) || (neighbor->level() < elem->level()))
   {
-    for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._elem_vars[_tid].begin(); it != _aux_sys._elem_vars[_tid].end(); ++it)
+    for (const auto & it : _aux_sys._elem_vars[_tid])
     {
-      MooseVariable * var = it->second;
+      MooseVariable * var = it.second;
       var->prepareAux();
     }
 
@@ -156,8 +156,8 @@ ComputeIndicatorThread::onInternalSide(const Elem *elem, unsigned int side)
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
       const std::vector<MooseSharedPointer<InternalSideIndicator> > & indicators = _internal_side_indicators.getActiveBlockObjects(block_id, _tid);
-      for (std::vector<MooseSharedPointer<InternalSideIndicator> >::const_iterator it = indicators.begin(); it != indicators.end(); ++it)
-        (*it)->computeIndicator();
+      for (const auto & indicator : indicators)
+        indicator->computeIndicator();
 
       _fe_problem.swapBackMaterialsFace(_tid);
       _fe_problem.swapBackMaterialsNeighbor(_tid);

--- a/framework/src/base/ComputeInitialConditionThread.C
+++ b/framework/src/base/ComputeInitialConditionThread.C
@@ -35,10 +35,8 @@ ComputeInitialConditionThread::operator() (const ConstElemRange & range)
   const InitialConditionWarehouse & warehouse = _fe_problem.getInitialConditionWarehouse();
 
   // Iterate over all the elements in the range
-  for (ConstElemRange::const_iterator elem_it=range.begin(); elem_it != range.end(); ++elem_it)
+  for (const auto & elem : range)
   {
-    const Elem* elem = *elem_it;
-
     SubdomainID subdomain = elem->subdomain_id();
 
     _fe_problem.prepare(elem, _tid);

--- a/framework/src/base/ComputeJacobianBlocksThread.C
+++ b/framework/src/base/ComputeJacobianBlocksThread.C
@@ -46,16 +46,11 @@ ComputeJacobianBlocksThread::postElement(const Elem * elem)
 
   Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
 
-  std::vector<JacobianBlock*>::iterator it = _blocks.begin();
-  std::vector<JacobianBlock*>::iterator end = _blocks.end();
-
-  for (; it != end; ++it)
+  for (const auto & block : _blocks)
   {
-    JacobianBlock & block = *(*it);
-
-    const DofMap & dof_map = block._precond_system.get_dof_map();
+    const DofMap & dof_map = block->_precond_system.get_dof_map();
     dof_map.dof_indices(elem, dof_indices);
 
-    _fe_problem.addJacobianBlock(block._jacobian, block._ivar, block._jvar, dof_map, dof_indices, _tid);
+    _fe_problem.addJacobianBlock(block->_jacobian, block->_ivar, block->_jvar, dof_map, dof_indices, _tid);
   }
 }

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -59,15 +59,12 @@ ComputeJacobianThread::computeJacobian()
   if (_kernels.hasActiveBlockObjects(_subdomain, _tid))
   {
     const std::vector<MooseSharedPointer<KernelBase> > & kernels = _kernels.getActiveBlockObjects(_subdomain, _tid);
-    for (std::vector<MooseSharedPointer<KernelBase> >::const_iterator it = kernels.begin(); it != kernels.end(); ++it)
-    {
-      MooseSharedPointer<KernelBase> kernel = *it;
+    for (const auto & kernel : kernels)
       if (kernel->isImplicit())
       {
         kernel->subProblem().prepareShapes(kernel->variable().number(), _tid);
         kernel->computeJacobian();
       }
-    }
   }
 }
 
@@ -75,15 +72,12 @@ void
 ComputeJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
 {
   const std::vector<MooseSharedPointer<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
-  for (std::vector<MooseSharedPointer<IntegratedBC> >::const_iterator it = bcs.begin(); it != bcs.end(); ++it)
-  {
-    MooseSharedPointer<IntegratedBC> bc = *it;
+  for (const auto & bc : bcs)
     if (bc->shouldApply() && bc->isImplicit())
     {
       bc->subProblem().prepareFaceShapes(bc->variable().number(), _tid);
       bc->computeJacobian();
     }
-  }
 }
 
 void
@@ -91,9 +85,7 @@ ComputeJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
 {
   // No need to call hasActiveObjects, this is done in the calling method (see onInternalSide)
   const std::vector<MooseSharedPointer<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
-  for (std::vector<MooseSharedPointer<DGKernel> >::const_iterator it = dgks.begin(); it != dgks.end(); ++it)
-  {
-    MooseSharedPointer<DGKernel> dg = *it;
+  for (const auto & dg : dgks)
     if (dg->isImplicit())
     {
       dg->subProblem().prepareFaceShapes(dg->variable().number(), _tid);
@@ -101,7 +93,6 @@ ComputeJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
       if (dg->hasBlocks(neighbor->subdomain_id()))
         dg->computeJacobian();
     }
-  }
 }
 
 void
@@ -109,16 +100,13 @@ ComputeJacobianThread::computeInternalInterFaceJacobian(BoundaryID bnd_id)
 {
   // No need to call hasActiveObjects, this is done in the calling method (see onInterface)
   const std::vector<MooseSharedPointer<InterfaceKernel> > & intks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
-  for (std::vector<MooseSharedPointer<InterfaceKernel> >::const_iterator it = intks.begin(); it != intks.end(); ++it)
-  {
-    MooseSharedPointer<InterfaceKernel> intk = *it;
+  for (const auto & intk : intks)
     if (intk->isImplicit())
     {
       intk->subProblem().prepareFaceShapes(intk->variable().number(), _tid);
       intk->subProblem().prepareNeighborShapes(intk->variable().number(), _tid);
       intk->computeJacobian(intk->variable().number());
     }
-  }
 }
 
 void

--- a/framework/src/base/ComputeMarkerThread.C
+++ b/framework/src/base/ComputeMarkerThread.C
@@ -52,9 +52,9 @@ ComputeMarkerThread::subdomainChanged()
   std::set<MooseVariable *> needed_moose_vars;
   _marker_whs.updateVariableDependency(needed_moose_vars, _tid);
 
-  for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._elem_vars[_tid].begin(); it != _aux_sys._elem_vars[_tid].end(); ++it)
+  for (const auto & it : _aux_sys._elem_vars[_tid])
   {
-    MooseVariable * var = it->second;
+    MooseVariable * var = it.second;
     var->prepareAux();
   }
 
@@ -72,17 +72,17 @@ ComputeMarkerThread::onElement(const Elem *elem)
   if (_marker_whs.hasActiveBlockObjects(_subdomain, _tid))
   {
     const std::vector<MooseSharedPointer<Marker> > & markers = _marker_whs.getActiveBlockObjects(_subdomain, _tid);
-    for (std::vector<MooseSharedPointer<Marker> >::const_iterator it = markers.begin(); it != markers.end(); ++it)
-      (*it)->computeMarker();
+    for (const auto & marker : markers)
+      marker->computeMarker();
   }
 
   _fe_problem.swapBackMaterials(_tid);
 
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._elem_vars[_tid].begin(); it != _aux_sys._elem_vars[_tid].end(); ++it)
+    for (const auto & it : _aux_sys._elem_vars[_tid])
     {
-      MooseVariable * var = it->second;
+      MooseVariable * var = it.second;
       var->insert(_aux_sys.solution());
     }
   }

--- a/framework/src/base/ComputeNodalAuxBcsThread.C
+++ b/framework/src/base/ComputeNodalAuxBcsThread.C
@@ -47,9 +47,9 @@ ComputeNodalAuxBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
   BoundaryID boundary_id = bnode->_bnd_id;
 
   // prepare variables
-  for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._nodal_vars[_tid].begin(); it != _aux_sys._nodal_vars[_tid].end(); ++it)
+  for (const auto & it : _aux_sys._nodal_vars[_tid])
   {
-    MooseVariable * var = it->second;
+    MooseVariable * var = it.second;
     var->prepareAux();
   }
 
@@ -64,10 +64,10 @@ ComputeNodalAuxBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
     const std::map<BoundaryID, std::vector<MooseSharedPointer<AuxKernel> > >::const_iterator iter = kernels.find(boundary_id);
     if (iter != kernels.end())
     {
-          _fe_problem.reinitNodeFace(node, boundary_id, _tid);
+      _fe_problem.reinitNodeFace(node, boundary_id, _tid);
 
-          for (std::vector<MooseSharedPointer<AuxKernel> >::const_iterator aux_it = iter->second.begin(); aux_it != iter->second.end(); ++aux_it)
-            (*aux_it)->compute();
+      for (const auto & aux : iter->second)
+        aux->compute();
     }
   }
 
@@ -75,9 +75,9 @@ ComputeNodalAuxBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
     // update the solution vector
-    for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._nodal_vars[_tid].begin(); it != _aux_sys._nodal_vars[_tid].end(); ++it)
+    for (const auto & it : _aux_sys._nodal_vars[_tid])
     {
-      MooseVariable * var = it->second;
+      MooseVariable * var = it.second;
       var->insert(_aux_sys.solution());
     }
   }

--- a/framework/src/base/ComputeNodalAuxVarsThread.C
+++ b/framework/src/base/ComputeNodalAuxVarsThread.C
@@ -43,9 +43,9 @@ ComputeNodalAuxVarsThread::onNode(ConstNodeRange::const_iterator & node_it)
   const Node * node = *node_it;
 
   // prepare variables
-  for (std::map<std::string, MooseVariable *>::iterator it = _sys._nodal_vars[_tid].begin(); it != _sys._nodal_vars[_tid].end(); ++it)
+  for (const auto & it : _sys._nodal_vars[_tid])
   {
-    MooseVariable * var = it->second;
+    MooseVariable * var = it.second;
     var->prepareAux();
   }
 
@@ -56,21 +56,21 @@ ComputeNodalAuxVarsThread::onNode(ConstNodeRange::const_iterator & node_it)
 
   // Loop over all SubdomainIDs for the curnent node, if an AuxKernel is active on this block then compute it.
   const std::set<SubdomainID> & block_ids = _sys.mesh().getNodeBlockIds(*node);
-  for (std::set<SubdomainID>::const_iterator block_it = block_ids.begin(); block_it != block_ids.end(); ++block_it)
+  for (const auto & block : block_ids)
   {
-    std::map<SubdomainID, std::vector<MooseSharedPointer<AuxKernel> > >::const_iterator iter = block_kernels.find(*block_it);
+    std::map<SubdomainID, std::vector<MooseSharedPointer<AuxKernel> > >::const_iterator iter = block_kernels.find(block);
 
     if (iter != block_kernels.end())
-      for (std::vector<MooseSharedPointer<AuxKernel> >::const_iterator aux_it = iter->second.begin(); aux_it != iter->second.end(); ++aux_it)
-        (*aux_it)->compute();
+      for (const auto & aux : iter->second)
+        aux->compute();
   }
 
   // We are done, so update the solution vector
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (std::map<std::string, MooseVariable *>::iterator it = _sys._nodal_vars[_tid].begin(); it != _sys._nodal_vars[_tid].end(); ++it)
+    for (const auto & it : _sys._nodal_vars[_tid])
     {
-      MooseVariable * var = it->second;
+      MooseVariable * var = it.second;
       var->insert(_sys.solution());
     }
   }

--- a/framework/src/base/ComputeNodalKernelBcsThread.C
+++ b/framework/src/base/ComputeNodalKernelBcsThread.C
@@ -54,9 +54,9 @@ ComputeNodalKernelBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
   BoundaryID boundary_id = bnode->_bnd_id;
 
   // prepare variables
-  for (std::map<std::string, MooseVariable *>::iterator it = _sys._nodal_vars[_tid].begin(); it != _sys._nodal_vars[_tid].end(); ++it)
+  for (const auto & it : _sys._nodal_vars[_tid])
   {
-    MooseVariable * var = it->second;
+    MooseVariable * var = it.second;
     var->prepareAux();
   }
 
@@ -67,8 +67,8 @@ ComputeNodalKernelBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
     {
       _fe_problem.reinitNodeFace(node, boundary_id, _tid);
       const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
-      for (std::vector<MooseSharedPointer<NodalKernel> >::const_iterator nodal_kernel_it = objects.begin(); nodal_kernel_it != objects.end(); ++nodal_kernel_it)
-        (*nodal_kernel_it)->computeResidual();
+      for (const auto & nodal_kernel : objects)
+        nodal_kernel->computeResidual();
 
       _num_cached++;
     }

--- a/framework/src/base/ComputeNodalKernelJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelJacobiansThread.C
@@ -55,10 +55,10 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
   const Node * node = *node_it;
 
   std::vector<std::pair<MooseVariable *, MooseVariable *> > & ce = _fe_problem.couplingEntries(_tid);
-  for (std::vector<std::pair<MooseVariable *, MooseVariable *> >::iterator it = ce.begin(); it != ce.end(); ++it)
+  for (const auto & it : ce)
   {
-    MooseVariable & ivariable = *(*it).first;
-    MooseVariable & jvariable = *(*it).second;
+    MooseVariable & ivariable = *(it.first);
+    MooseVariable & jvariable = *(it.second);
 
     unsigned int ivar = ivariable.number();
     unsigned int jvar = jvariable.number();
@@ -67,19 +67,17 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
     std::vector<MooseSharedPointer<NodalKernel> > active_involved_kernels;
 
     const std::set<SubdomainID> & block_ids = _aux_sys.mesh().getNodeBlockIds(*node);
-    for (std::set<SubdomainID>::const_iterator block_it = block_ids.begin(); block_it != block_ids.end(); ++block_it)
+    for (const auto & block : block_ids)
     {
-      if (_nodal_kernels.hasActiveBlockObjects(*block_it, _tid))
+      if (_nodal_kernels.hasActiveBlockObjects(block, _tid))
       {
         // Loop over each NodalKernel to see if it's involved with the jvar
-        const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(*block_it, _tid);
-        for (std::vector<MooseSharedPointer<NodalKernel> >::const_iterator nodal_kernel_it = objects.begin(); nodal_kernel_it != objects.end(); ++nodal_kernel_it)
+        const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
+        for (const auto & nodal_kernel : objects)
         {
-          const MooseSharedPointer<NodalKernel> & nodal_kernel = *nodal_kernel_it;
-
           // If this NodalKernel isn't operating on this ivar... skip it
           if (nodal_kernel->variable().number() != ivar)
-          break;
+            break;
 
           // If this NodalKernel is acting on the jvar add it to the list and short-circuit the loop
           if (nodal_kernel->variable().number() == jvar)
@@ -89,15 +87,13 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
           }
 
           // See if this NodalKernel is coupled to the jvar
-          const std::vector<MooseVariable *> & coupled_vars = (*nodal_kernel_it)->getCoupledMooseVars();
-          for (std::vector<MooseVariable *>::const_iterator var_it = coupled_vars.begin(); var_it != coupled_vars.end(); ++var_it)
-          {
-            if ( (*var_it)->number() == jvar )
+          const std::vector<MooseVariable *> & coupled_vars = nodal_kernel->getCoupledMooseVars();
+          for (const auto & var : coupled_vars)
+            if (var->number() == jvar)
             {
               active_involved_kernels.push_back(nodal_kernel);
               break; // It only takes one
             }
-          }
         }
       }
     }
@@ -106,18 +102,16 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
     if (!active_involved_kernels.empty())
     {
       // prepare variables
-      for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._nodal_vars[_tid].begin(); it != _aux_sys._nodal_vars[_tid].end(); ++it)
+      for (const auto & it : _aux_sys._nodal_vars[_tid])
       {
-        MooseVariable * var = it->second;
+        MooseVariable * var = it.second;
         var->prepareAux();
       }
 
       _fe_problem.reinitNode(node, _tid);
 
-      for (std::vector<MooseSharedPointer<NodalKernel> >::iterator nodal_kernel_it = active_involved_kernels.begin();
-           nodal_kernel_it != active_involved_kernels.end();
-           ++nodal_kernel_it)
-        (*nodal_kernel_it)->computeOffDiagJacobian(jvar);
+      for (const auto & nodal_kernel : active_involved_kernels)
+        nodal_kernel->computeOffDiagJacobian(jvar);
 
       _num_cached++;
 

--- a/framework/src/base/ComputeNodalKernelsThread.C
+++ b/framework/src/base/ComputeNodalKernelsThread.C
@@ -51,21 +51,21 @@ ComputeNodalKernelsThread::onNode(ConstNodeRange::const_iterator & node_it)
   const Node * node = *node_it;
 
   // prepare variables
-  for (std::map<std::string, MooseVariable *>::iterator it = _aux_sys._nodal_vars[_tid].begin(); it != _aux_sys._nodal_vars[_tid].end(); ++it)
+  for (const auto & it : _aux_sys._nodal_vars[_tid])
   {
-    MooseVariable * var = it->second;
+    MooseVariable * var = it.second;
     var->prepareAux();
   }
 
   _fe_problem.reinitNode(node, _tid);
 
   const std::set<SubdomainID> & block_ids = _aux_sys.mesh().getNodeBlockIds(*node);
-  for (std::set<SubdomainID>::const_iterator block_it = block_ids.begin(); block_it != block_ids.end(); ++block_it)
-    if (_nodal_kernels.hasActiveBlockObjects(*block_it, _tid))
+  for (const auto & block : block_ids)
+    if (_nodal_kernels.hasActiveBlockObjects(block, _tid))
     {
-      const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(*block_it, _tid);
-      for (std::vector<MooseSharedPointer<NodalKernel> >::const_iterator nodal_kernel_it = objects.begin(); nodal_kernel_it != objects.end(); ++nodal_kernel_it)
-         (*nodal_kernel_it)->computeResidual();
+      const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
+      for (const auto & nodal_kernel : objects)
+        nodal_kernel->computeResidual();
     }
 
   _num_cached++;

--- a/framework/src/base/ComputeNodalUserObjectsThread.C
+++ b/framework/src/base/ComputeNodalUserObjectsThread.C
@@ -46,13 +46,13 @@ ComputeNodalUserObjectsThread::onNode(ConstNodeRange::const_iterator & node_it)
   // Boundary Restricted
   std::vector<BoundaryID> nodeset_ids;
   _fe_problem.mesh().getMesh().get_boundary_info().boundary_ids(node, nodeset_ids);
-  for (std::vector<BoundaryID>::const_iterator bnd_it = nodeset_ids.begin(); bnd_it != nodeset_ids.end(); ++bnd_it)
+  for (const auto & bnd : nodeset_ids)
   {
-    if (_user_objects.hasActiveBoundaryObjects(*bnd_it, _tid))
+    if (_user_objects.hasActiveBoundaryObjects(bnd, _tid))
     {
-      const std::vector<MooseSharedPointer<NodalUserObject> > & objects = _user_objects.getActiveBoundaryObjects(*bnd_it, _tid);
-      for (std::vector<MooseSharedPointer<NodalUserObject> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
-        (*it)->execute();
+      const std::vector<MooseSharedPointer<NodalUserObject> > & objects = _user_objects.getActiveBoundaryObjects(bnd, _tid);
+      for (const auto & uo : objects)
+        uo->execute();
     }
   }
 
@@ -65,21 +65,17 @@ ComputeNodalUserObjectsThread::onNode(ConstNodeRange::const_iterator & node_it)
   std::vector<MooseSharedPointer<NodalUserObject> > computed;
 
   const std::set<SubdomainID> & block_ids = _fe_problem.mesh().getNodeBlockIds(*node);
-  for (std::set<SubdomainID>::const_iterator blk_it = block_ids.begin(); blk_it != block_ids.end(); ++blk_it)
-  {
-    if (_user_objects.hasActiveBlockObjects(*blk_it, _tid))
+  for (const auto & block : block_ids)
+    if (_user_objects.hasActiveBlockObjects(block, _tid))
     {
-      const std::vector<MooseSharedPointer<NodalUserObject> > & objects = _user_objects.getActiveBlockObjects(*blk_it, _tid);
-      for (std::vector<MooseSharedPointer<NodalUserObject> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
-      {
-        if (!(*it)->isUniqueNodeExecute() || std::count(computed.begin(), computed.end(), *it) == 0)
+      const std::vector<MooseSharedPointer<NodalUserObject> > & objects = _user_objects.getActiveBlockObjects(block, _tid);
+      for (const auto & uo : objects)
+        if (!uo->isUniqueNodeExecute() || std::count(computed.begin(), computed.end(), uo) == 0)
         {
-          (*it)->execute();
-          computed.push_back(*it);
+          uo->execute();
+          computed.push_back(uo);
         }
-      }
     }
-  }
 }
 
 void

--- a/framework/src/base/ComputeResidualThread.C
+++ b/framework/src/base/ComputeResidualThread.C
@@ -103,8 +103,8 @@ ComputeResidualThread::onElement(const Elem *elem)
   if (warehouse->hasActiveBlockObjects(_subdomain, _tid))
   {
     const std::vector<MooseSharedPointer<KernelBase> > & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
-    for (std::vector<MooseSharedPointer<KernelBase> >::const_iterator it = kernels.begin(); it != kernels.end(); ++it)
-      (*it)->computeResidual();
+    for (const auto & kernel : kernels)
+      kernel->computeResidual();
   }
 
   _fe_problem.swapBackMaterials(_tid);
@@ -126,10 +126,10 @@ ComputeResidualThread::onBoundary(const Elem *elem, unsigned int side, BoundaryI
     // Set the active boundary id so that BoundaryRestrictable::_boundary_id is correct
     _fe_problem.setCurrentBoundaryID(bnd_id);
 
-    for (std::vector<MooseSharedPointer<IntegratedBC> >::const_iterator it = bcs.begin(); it != bcs.end(); ++it)
+    for (const auto & bc : bcs)
     {
-      if ((*it)->shouldApply())
-        (*it)->computeResidual();
+      if (bc->shouldApply())
+        bc->computeResidual();
     }
     _fe_problem.swapBackMaterialsFace(_tid);
 
@@ -158,8 +158,8 @@ ComputeResidualThread::onInterface(const Elem *elem, unsigned int side, Boundary
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
       const std::vector<MooseSharedPointer<InterfaceKernel> > & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
-      for (std::vector<MooseSharedPointer<InterfaceKernel> >::const_iterator it = int_ks.begin(); it != int_ks.end(); ++it)
-        (*it)->computeResidual();
+      for (const auto & interface_kernel : int_ks)
+        interface_kernel->computeResidual();
 
       _fe_problem.swapBackMaterialsFace(_tid);
       _fe_problem.swapBackMaterialsNeighbor(_tid);
@@ -193,9 +193,9 @@ ComputeResidualThread::onInternalSide(const Elem *elem, unsigned int side)
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
       const std::vector<MooseSharedPointer<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
-      for (std::vector<MooseSharedPointer<DGKernel> >::const_iterator it = dgks.begin(); it != dgks.end(); ++it)
-        if ((*it)->hasBlocks(neighbor->subdomain_id()))
-          (*it)->computeResidual();
+      for (const auto & dg_kernel : dgks)
+        if (dg_kernel->hasBlocks(neighbor->subdomain_id()))
+          dg_kernel->computeResidual();
 
       _fe_problem.swapBackMaterialsFace(_tid);
       _fe_problem.swapBackMaterialsNeighbor(_tid);

--- a/framework/src/base/ComputeUserObjectsThread.C
+++ b/framework/src/base/ComputeUserObjectsThread.C
@@ -76,8 +76,8 @@ ComputeUserObjectsThread::onElement(const Elem * elem)
   if (_elemental_user_objects.hasActiveBlockObjects(_subdomain, _tid))
   {
     const std::vector<MooseSharedPointer<ElementUserObject> > & objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
-    for (std::vector<MooseSharedPointer<ElementUserObject> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
-      (*it)->execute();
+    for (const auto & uo : objects)
+      uo->execute();
   }
 
   _fe_problem.swapBackMaterials(_tid);
@@ -94,8 +94,8 @@ ComputeUserObjectsThread::onBoundary(const Elem *elem, unsigned int side, Bounda
     _fe_problem.setCurrentBoundaryID(bnd_id);
 
     const std::vector<MooseSharedPointer<SideUserObject> > & objects = _side_user_objects.getActiveBoundaryObjects(bnd_id, _tid);
-    for (std::vector<MooseSharedPointer<SideUserObject> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
-      (*it)->execute();
+    for (const auto & uo : objects)
+      uo->execute();
 
     _fe_problem.setCurrentBoundaryID(Moose::INVALID_BOUNDARY_ID);
     _fe_problem.swapBackMaterialsFace(_tid);
@@ -123,13 +123,13 @@ ComputeUserObjectsThread::onInternalSide(const Elem *elem, unsigned int side)
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
       const std::vector<MooseSharedPointer<InternalSideUserObject> > & objects = _internal_side_user_objects.getActiveBlockObjects(_subdomain, _tid);
-      for (std::vector<MooseSharedPointer<InternalSideUserObject> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+      for (const auto & uo : objects)
       {
-        if ( !(*it)->blockRestricted())
-          (*it)->execute();
+        if (!uo->blockRestricted())
+          uo->execute();
 
-        else if ( (*it)->hasBlocks(neighbor->subdomain_id()) )
-          (*it)->execute();
+        else if (uo->hasBlocks(neighbor->subdomain_id()))
+          uo->execute();
       }
       _fe_problem.swapBackMaterialsFace(_tid);
       _fe_problem.swapBackMaterialsNeighbor(_tid);

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -42,9 +42,8 @@ Coupleable::Coupleable(const MooseObject * moose_object, bool nodal) :
     if (_c_parameters.getVecMooseType(name) != std::vector<std::string>())
     {
       std::vector<std::string> vars = _c_parameters.getVecMooseType(*iter);
-      for (unsigned int i = 0; i < vars.size(); i++)
+      for (const auto & coupled_var_name : vars)
       {
-        std::string coupled_var_name = vars[i];
         if (problem.hasVariable(coupled_var_name))
         {
           MooseVariable * moose_var = &problem.getVariable(tid, coupled_var_name);
@@ -68,10 +67,10 @@ Coupleable::Coupleable(const MooseObject * moose_object, bool nodal) :
 
 Coupleable::~Coupleable()
 {
-  for (std::map<std::string, VariableValue *>::iterator it = _default_value.begin(); it != _default_value.end(); ++it)
+  for (auto & it : _default_value)
   {
-    it->second->release();
-    delete it->second;
+    it.second->release();
+    delete it.second;
   }
   _default_value_zero.release();
   _default_gradient.release();

--- a/framework/src/base/EigenSystem.C
+++ b/framework/src/base/EigenSystem.C
@@ -92,11 +92,8 @@ EigenSystem::scaleSystemSolution(SYSTEMTAG tag, Real scaling_factor)
     }
     else
     {
-      std::set<dof_id_type>::iterator it      = _eigen_var_indices.begin();
-      std::set<dof_id_type>::iterator it_end  = _eigen_var_indices.end();
-
-      for (; it !=it_end; ++it)
-        solution().set( *it, solution()(*it)*scaling_factor );
+      for (const auto & dof : _eigen_var_indices)
+        solution().set(dof, solution()(dof) * scaling_factor);
     }
   }
   solution().close();
@@ -123,34 +120,31 @@ EigenSystem::combineSystemSolution(SYSTEMTAG tag, const std::vector<Real> & coef
     }
     else
     {
-      std::set<dof_id_type>::iterator it      = _eigen_var_indices.begin();
-      std::set<dof_id_type>::iterator it_end  = _eigen_var_indices.end();
-
       if (coefficients.size()>2)
       {
-        for (; it !=it_end; ++it)
+        for (const auto & dof : _eigen_var_indices)
         {
-          Real t = solution()(*it) * coefficients[0];
-          t += solutionOld()(*it) * coefficients[1];
-          t += solutionOlder()(*it) * coefficients[2];
-          solution().set( *it, t );
+          Real t = solution()(dof) * coefficients[0];
+          t += solutionOld()(dof) * coefficients[1];
+          t += solutionOlder()(dof) * coefficients[2];
+          solution().set(dof, t);
         }
       }
       else if (coefficients.size()>1)
       {
-        for (; it !=it_end; ++it)
+        for (const auto & dof : _eigen_var_indices)
         {
-          Real t = solution()(*it) * coefficients[0];
-          t += solutionOld()(*it) * coefficients[1];
-          solution().set( *it, t );
+          Real t = solution()(dof) * coefficients[0];
+          t += solutionOld()(dof) * coefficients[1];
+          solution().set(dof, t);
         }
       }
       else
       {
-        for (; it !=it_end; ++it)
+        for (const auto & dof : _eigen_var_indices)
         {
-          Real t = solution()(*it) * coefficients[0];
-          solution().set( *it, t );
+          Real t = solution()(dof) * coefficients[0];
+          solution().set(dof, t);
         }
       }
     }
@@ -174,11 +168,8 @@ EigenSystem::initSystemSolution(SYSTEMTAG tag, Real v)
     }
     else
     {
-      std::set<dof_id_type>::iterator it      = _eigen_var_indices.begin();
-      std::set<dof_id_type>::iterator it_end  = _eigen_var_indices.end();
-
-      for (; it !=it_end; ++it)
-        solution().set( *it, v );
+      for (const auto & dof : _eigen_var_indices)
+        solution().set(dof, v);
     }
   }
   solution().close();
@@ -200,11 +191,8 @@ EigenSystem::initSystemSolutionOld(SYSTEMTAG tag, Real v)
     }
     else
     {
-      std::set<dof_id_type>::iterator it      = _eigen_var_indices.begin();
-      std::set<dof_id_type>::iterator it_end  = _eigen_var_indices.end();
-
-      for (; it !=it_end; ++it)
-        solutionOld().set( *it, v );
+      for (const auto & dof : _eigen_var_indices)
+        solutionOld().set(dof, v);
     }
   }
   solutionOld().close();

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -179,7 +179,7 @@ std::vector<std::string>
 Factory::getConstructedObjects() const
 {
   std::vector<std::string> list;
-  for (std::set<std::string>::iterator i = _constructed_types.begin(); i != _constructed_types.end(); ++i)
-    list.push_back(*i);
+  for (const auto & name : _constructed_types)
+    list.push_back(name);
   return list;
 }

--- a/framework/src/base/MaxQpsThread.C
+++ b/framework/src/base/MaxQpsThread.C
@@ -51,10 +51,8 @@ MaxQpsThread::operator() (const ConstElemRange & range)
 
   // For short circuiting reinit
   std::set<ElemType> seen_it;
-  for (ConstElemRange::const_iterator elem_it = range.begin() ; elem_it != range.end(); ++elem_it)
+  for (const auto & elem : range)
   {
-    const Elem * elem = *elem_it;
-
     // Only reinit if the element type has not previously been seen
     if (seen_it.insert(elem->type()).second)
     {

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -290,9 +290,9 @@ void
 MooseVariable::reinitNodes(const std::vector<dof_id_type> & nodes)
 {
   _dof_indices.clear();
-  for (unsigned int i = 0; i < nodes.size(); i++)
+  for (const auto & node_id : nodes)
   {
-    Node * nd = _subproblem.mesh().getMesh().query_node_ptr(nodes[i]);
+    Node * nd = _subproblem.mesh().getMesh().query_node_ptr(node_id);
     if (nd && (_subproblem.mesh().isSemiLocal(nd)))
     {
       if (nd->n_dofs(_sys.number(), _var_num) > 0)
@@ -313,9 +313,9 @@ void
 MooseVariable::reinitNodesNeighbor(const std::vector<dof_id_type> & nodes)
 {
   _dof_indices_neighbor.clear();
-  for (unsigned int i = 0; i < nodes.size(); i++)
+  for (const auto & node_id : nodes)
   {
-    Node * nd = _subproblem.mesh().getMesh().query_node_ptr(nodes[i]);
+    Node * nd = _subproblem.mesh().getMesh().query_node_ptr(node_id);
     if (nd && (_subproblem.mesh().isSemiLocal(nd)))
     {
       if (nd->n_dofs(_sys.number(), _var_num) > 0)

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -748,15 +748,13 @@ NonlinearSystem::computeResidual(NumericVector<Number> & residual, Moose::Kernel
 
   Moose::enableFPE();
 
-  for (unsigned int i = 0; i < _vecs_to_zero_for_residual.size(); ++i)
-  {
-    if (hasVector(_vecs_to_zero_for_residual[i]))
+  for (const auto & numeric_vec : _vecs_to_zero_for_residual)
+    if (hasVector(numeric_vec))
     {
-      NumericVector<Number> & vec = getVector(_vecs_to_zero_for_residual[i]);
+      NumericVector<Number> & vec = getVector(numeric_vec);
       vec.close();
       vec.zero();
     }
-  }
 
   try
   {
@@ -817,9 +815,8 @@ NonlinearSystem::setInitialSolution()
 
   // do nodal BC
   ConstBndNodeRange & bnd_nodes = *_mesh.getBoundaryNodeRange();
-  for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin() ; nd != bnd_nodes.end(); ++nd)
+  for (const auto & bnode : bnd_nodes)
   {
-    const BndNode * bnode = *nd;
     BoundaryID boundary_id = bnode->_bnd_id;
     Node * node = bnode->_node;
 
@@ -830,9 +827,9 @@ NonlinearSystem::setInitialSolution()
 
       if (_preset_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
       {
-        const std::vector<MooseSharedPointer<PresetNodalBC> > & preset = _preset_nodal_bcs.getActiveBoundaryObjects(boundary_id);
-        for (std::vector<MooseSharedPointer<PresetNodalBC> >::const_iterator it = preset.begin(); it != preset.end(); ++it)
-          (*it)->computeValue(initial_solution);
+        const std::vector<MooseSharedPointer<PresetNodalBC> > & preset_bcs = _preset_nodal_bcs.getActiveBoundaryObjects(boundary_id);
+        for (const auto & preset_bc : preset_bcs)
+          preset_bc->computeValue(initial_solution);
       }
     }
   }
@@ -894,9 +891,8 @@ NonlinearSystem::enforceNodalConstraintsResidual(NumericVector<Number> & residua
   if (_constraints.hasActiveNodalConstraints())
   {
     const std::vector<MooseSharedPointer<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
-    for (std::vector<MooseSharedPointer<NodalConstraint> >::const_iterator it = ncs.begin(); it != ncs.end(); ++it)
+    for (const auto & nc : ncs)
     {
-      MooseSharedPointer<NodalConstraint> nc = (*it);
       std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
       std::vector<dof_id_type> & master_node_ids = nc->getMasterNodeId();
 
@@ -920,9 +916,8 @@ NonlinearSystem::enforceNodalConstraintsJacobian(SparseMatrix<Number> & jacobian
   if (_constraints.hasActiveNodalConstraints())
   {
     const std::vector<MooseSharedPointer<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
-    for (std::vector<MooseSharedPointer<NodalConstraint> >::const_iterator it = ncs.begin(); it != ncs.end(); ++it)
+    for (const auto & nc : ncs)
     {
-      MooseSharedPointer<NodalConstraint> nc = (*it);
       std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
       std::vector<dof_id_type> & master_node_ids = nc->getMasterNodeId();
 
@@ -956,11 +951,9 @@ NonlinearSystem::setConstraintSlaveValues(NumericVector<Number> & solution, bool
 
   bool constraints_applied = false;
 
-  for (std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator it = penetration_locators->begin();
-      it != penetration_locators->end();
-      ++it)
+  for (const auto & it : *penetration_locators)
   {
-    PenetrationLocator & pen_loc = *it->second;
+    PenetrationLocator & pen_loc = *(it.second);
 
     std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
@@ -995,16 +988,12 @@ NonlinearSystem::setConstraintSlaveValues(NumericVector<Number> & solution, bool
             // reinit variables on the master element's face at the contact point
             _fe_problem.reinitNeighborPhys(master_elem, master_side, points, 0);
 
-            for (unsigned int c=0; c < constraints.size(); c++)
-            {
-              MooseSharedPointer<NodeFaceConstraint> nfc = constraints[c];
-
+            for (const auto & nfc : constraints)
               if (nfc->shouldApply())
               {
                 constraints_applied = true;
                 nfc->computeSlaveValue(solution);
               }
-            }
           }
         }
       }
@@ -1043,17 +1032,14 @@ NonlinearSystem::constraintResiduals(NumericVector<Number> & residual, bool disp
   bool constraints_applied;
   bool residual_has_inserted_values = false;
   if (!_assemble_constraints_separately) constraints_applied = false;
-  for (std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator it = penetration_locators->begin();
-      it != penetration_locators->end();
-      ++it)
+  for (const auto & it : *penetration_locators)
   {
-
     if (_assemble_constraints_separately)
     {
       // Reset the constraint_applied flag before each new constraint, as they need to be assembled separately
       constraints_applied = false;
     }
-    PenetrationLocator & pen_loc = *it->second;
+    PenetrationLocator & pen_loc = *(it.second);
 
     std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
@@ -1091,10 +1077,7 @@ NonlinearSystem::constraintResiduals(NumericVector<Number> & residual, bool disp
             // reinit variables on the master element's face at the contact point
             _fe_problem.reinitNeighborPhys(master_elem, master_side, points, 0);
 
-            for (unsigned int c=0; c < constraints.size(); c++)
-            {
-              MooseSharedPointer<NodeFaceConstraint> nfc = constraints[c];
-
+            for (const auto & nfc : constraints)
               if (nfc->shouldApply())
               {
                 constraints_applied = true;
@@ -1109,7 +1092,6 @@ NonlinearSystem::constraintResiduals(NumericVector<Number> & residual, bool disp
                   _fe_problem.cacheResidual(0);
                 _fe_problem.cacheResidualNeighbor(0);
               }
-            }
           }
         }
       }
@@ -1164,36 +1146,30 @@ NonlinearSystem::constraintResiduals(NumericVector<Number> & residual, bool disp
   THREAD_ID tid = 0;
   // go over mortar interfaces
   std::vector<MooseMesh::MortarInterface *> & ifaces = _mesh.getMortarInterfaces();
-  for (std::vector<MooseMesh::MortarInterface *>::iterator it = ifaces.begin(); it != ifaces.end(); ++it)
+  for (const auto & iface : ifaces)
   {
-    MooseMesh::MortarInterface * iface = *it;
-
     if (_constraints.hasActiveFaceFaceConstraints(iface->_name))
     {
       const std::vector<MooseSharedPointer<FaceFaceConstraint> > & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
 
       // go over elements on that interface
       const std::vector<Elem *> & elems = iface->_elems;
-      for (std::vector<Elem *>::const_iterator el = elems.begin(); el != elems.end(); ++el)
+      for (const auto & elem : elems)
       {
-        const Elem * elem = *el;
         // for each element process constraints on the
         _fe_problem.prepare(elem, tid);
         _fe_problem.reinitElem(elem, tid);
 
-        for (std::vector<MooseSharedPointer<FaceFaceConstraint> >::const_iterator fc_it = face_constraints.begin(); fc_it != face_constraints.end(); ++fc_it)
+        for (const auto & ffc : face_constraints)
         {
-          MooseSharedPointer<FaceFaceConstraint> ffc = *fc_it;
           ffc->reinit();
           ffc->computeResidual();
         }
         _fe_problem.cacheResidual(tid);
 
         // evaluate residuals that go into master and slave side
-        for (std::vector<MooseSharedPointer<FaceFaceConstraint> >::const_iterator fc_it = face_constraints.begin(); fc_it != face_constraints.end(); ++fc_it)
+        for (const auto & ffc : face_constraints)
         {
-          MooseSharedPointer<FaceFaceConstraint> ffc = *fc_it;
-
           ffc->reinitSide(Moose::Master);
           ffc->computeResidualSide(Moose::Master);
           _fe_problem.cacheResidual(tid);
@@ -1221,35 +1197,30 @@ NonlinearSystem::constraintResiduals(NumericVector<Number> & residual, bool disp
     element_pair_locators = &displaced_geom_search_data._element_pair_locators;
   }
 
-  for (std::map<unsigned int, MooseSharedPointer<ElementPairLocator> >::iterator it = element_pair_locators->begin();
-       it != element_pair_locators->end();
-       ++it)
+  for (const auto & it : *element_pair_locators)
   {
-    ElementPairLocator & elem_pair_loc = *it->second;
+    ElementPairLocator & elem_pair_loc = *(it.second);
 
-    if (_constraints.hasActiveElemElemConstraints(it->first))
+    if (_constraints.hasActiveElemElemConstraints(it.first))
     {
       // ElemElemConstraint objects
-      const std::vector<MooseSharedPointer<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it->first);
+      const std::vector<MooseSharedPointer<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
 
       // go over pair elements
       const std::list<std::pair<const Elem*, const Elem*> > & elem_pairs = elem_pair_loc.getElemPairs();
-      for (std::list<std::pair<const Elem *, const Elem*> >::const_iterator it = elem_pairs.begin();
-           it != elem_pairs.end(); ++it)
+      for (const auto & pr : elem_pairs)
       {
-        const Elem * elem1 = it->first;
-        const Elem * elem2 = it->second;
+        const Elem * elem1 = pr.first;
+        const Elem * elem2 = pr.second;
 
         if (elem1->processor_id() != processor_id())
           continue;
 
-        const ElementPairInfo & info = elem_pair_loc.getElemPairInfo(*it);
+        const ElementPairInfo & info = elem_pair_loc.getElemPairInfo(pr);
 
         // for each element process constraints on the
-        for (std::vector<MooseSharedPointer<ElemElemConstraint> >::const_iterator ec_it = _element_constraints.begin(); ec_it != _element_constraints.end(); ++ec_it)
+        for (const auto & ec : _element_constraints)
         {
-          MooseSharedPointer<ElemElemConstraint> ec = *ec_it;
-
           _fe_problem.reinitElemPhys(elem1, info._elem1_constraint_q_point, tid);
           _fe_problem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
 
@@ -1310,10 +1281,10 @@ NonlinearSystem::computeResidualInternal(Moose::KernelType type)
     if (_scalar_kernels.hasActiveObjects())
     {
       const std::vector<MooseSharedPointer<ScalarKernel> > & scalars = _scalar_kernels.getActiveObjects();
-      for (std::vector<MooseSharedPointer<ScalarKernel> >::const_iterator it = scalars.begin(); it != scalars.end(); ++it)
+      for (const auto & scalar_kernel : scalars)
       {
-        (*it)->reinit();
-        (*it)->computeResidual();
+        scalar_kernel->reinit();
+        scalar_kernel->computeResidual();
       }
       _fe_problem.addResidualScalar();
     }
@@ -1411,9 +1382,8 @@ NonlinearSystem::computeNodalBCs(NumericVector<Number> & residual)
   PARALLEL_TRY {
     // last thing to do are nodal BCs
     ConstBndNodeRange & bnd_nodes = *_mesh.getBoundaryNodeRange();
-    for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin() ; nd != bnd_nodes.end(); ++nd)
+    for (const auto & bnode : bnd_nodes)
     {
-      const BndNode * bnode = *nd;
       BoundaryID boundary_id = bnode->_bnd_id;
       Node * node = bnode->_node;
 
@@ -1425,9 +1395,9 @@ NonlinearSystem::computeNodalBCs(NumericVector<Number> & residual)
         if (_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
         {
           const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
-          for (std::vector<MooseSharedPointer<NodalBC> >::const_iterator it = bcs.begin(); it != bcs.end(); ++it)
-            if ((*it)->shouldApply())
-              (*it)->computeResidual(residual);
+          for (const auto & nbc : bcs)
+            if (nbc->shouldApply())
+              nbc->computeResidual(residual);
         }
       }
     }
@@ -1457,106 +1427,79 @@ NonlinearSystem::findImplicitGeometricCouplingEntries(GeometricSearchData & geom
 {
   std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *> & nearest_node_locators = geom_search_data._nearest_node_locators;
 
-  for (std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator it = nearest_node_locators.begin();
-      it != nearest_node_locators.end();
-      ++it)
+  for (const auto & it : nearest_node_locators)
   {
-    std::vector<dof_id_type> & slave_nodes = it->second->_slave_nodes;
+    std::vector<dof_id_type> & slave_nodes = it.second->_slave_nodes;
 
-    for (unsigned int i=0; i<slave_nodes.size(); i++)
+    for (const auto & slave_node : slave_nodes)
     {
       std::set<dof_id_type> unique_slave_indices;
       std::set<dof_id_type> unique_master_indices;
 
-      dof_id_type slave_node = slave_nodes[i];
+      std::vector<dof_id_type> & elems = _mesh.nodeToElemMap()[slave_node];
 
+      // Get the dof indices from each elem connected to the node
+      for (const auto & cur_elem : elems)
       {
-        std::vector<dof_id_type> & elems = _mesh.nodeToElemMap()[slave_node];
+        std::vector<dof_id_type> dof_indices;
+        dofMap().dof_indices(_mesh.elemPtr(cur_elem), dof_indices);
+
+        for (const auto & dof : dof_indices)
+          unique_slave_indices.insert(dof);
+      }
+
+      std::vector<dof_id_type> master_nodes = it.second->_neighbor_nodes[slave_node];
+
+      for (const auto & master_node : master_nodes)
+      {
+        std::vector<dof_id_type> & master_node_elems = _mesh.nodeToElemMap()[master_node];
 
         // Get the dof indices from each elem connected to the node
-        for (unsigned int el=0; el < elems.size(); ++el)
+        for (const auto & cur_elem : master_node_elems)
         {
-          dof_id_type cur_elem = elems[el];
-
           std::vector<dof_id_type> dof_indices;
           dofMap().dof_indices(_mesh.elemPtr(cur_elem), dof_indices);
 
-          for (unsigned int di=0; di < dof_indices.size(); di++)
-            unique_slave_indices.insert(dof_indices[di]);
+          for (const auto & dof : dof_indices)
+            unique_master_indices.insert(dof);
         }
       }
 
-      std::vector<dof_id_type> master_nodes = it->second->_neighbor_nodes[slave_node];
-
-      for (unsigned int k=0; k<master_nodes.size(); k++)
-      {
-        dof_id_type master_node = master_nodes[k];
-
+      for (const auto & slave_id : unique_slave_indices)
+        for (const auto & master_id : unique_master_indices)
         {
-          std::vector<dof_id_type> & elems = _mesh.nodeToElemMap()[master_node];
-
-          // Get the dof indices from each elem connected to the node
-          for (unsigned int el=0; el < elems.size(); ++el)
-          {
-            dof_id_type cur_elem = elems[el];
-
-            std::vector<dof_id_type> dof_indices;
-            dofMap().dof_indices(_mesh.elemPtr(cur_elem), dof_indices);
-
-            for (unsigned int di=0; di < dof_indices.size(); di++)
-              unique_master_indices.insert(dof_indices[di]);
-          }
-        }
-      }
-
-      for (std::set<dof_id_type>::iterator sit=unique_slave_indices.begin(); sit != unique_slave_indices.end(); ++sit)
-      {
-        dof_id_type slave_id = *sit;
-
-        for (std::set<dof_id_type>::iterator mit=unique_master_indices.begin(); mit != unique_master_indices.end(); ++mit)
-        {
-          dof_id_type master_id = *mit;
-
           graph[slave_id].push_back(master_id);
           graph[master_id].push_back(slave_id);
         }
-      }
     }
   }
 
   // handle node-to-node constraints
   const std::vector<MooseSharedPointer<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
-  for (std::vector<MooseSharedPointer<NodalConstraint> >::const_iterator it = ncs.begin(); it != ncs.end(); ++it)
+  for (const auto & nc : ncs)
   {
-    MooseSharedPointer<NodalConstraint> nc = (*it);
-
     std::vector<dof_id_type> master_dofs;
-    std::vector<dof_id_type> &  master_node_ids = nc->getMasterNodeId();
-    for (std::vector<dof_id_type>::iterator mi = master_node_ids.begin(); mi != master_node_ids.end(); mi++)
-      getNodeDofs(*mi, master_dofs);
+    std::vector<dof_id_type> & master_node_ids = nc->getMasterNodeId();
+    for (const auto & dof : master_node_ids)
+      getNodeDofs(dof, master_dofs);
 
     std::vector<dof_id_type> slave_dofs;
     std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
-    for (std::vector<dof_id_type>::iterator si = slave_node_ids.begin(); si != slave_node_ids.end(); si++)
-      getNodeDofs(*si, slave_dofs);
+    for (const auto & dof : slave_node_ids)
+      getNodeDofs(dof, slave_dofs);
 
-    for (std::vector<dof_id_type>::iterator mi = master_dofs.begin(); mi != master_dofs.end(); mi++)
-    {
-      dof_id_type master_id = *mi;
-      for (std::vector<dof_id_type>::iterator si = slave_dofs.begin(); si != slave_dofs.end(); si++)
+    for (const auto & master_id : master_dofs)
+      for (const auto & slave_id : slave_dofs)
       {
-        dof_id_type slave_id = *si;
         graph[master_id].push_back(slave_id);
         graph[slave_id].push_back(master_id);
       }
-    }
   }
 
   // Make every entry sorted and unique
-  for (std::map<dof_id_type, std::vector<dof_id_type> >::iterator git=graph.begin(); git != graph.end(); ++git)
+  for (auto & it : graph)
   {
-    std::vector<dof_id_type> & row = git->second;
-
+    std::vector<dof_id_type> & row = it.second;
     std::sort(row.begin(), row.end());
     std::vector<dof_id_type>::iterator uit = std::unique(row.begin(), row.end());
     row.resize(uit - row.begin());
@@ -1572,16 +1515,13 @@ NonlinearSystem::addImplicitGeometricCouplingEntries(SparseMatrix<Number> & jaco
 
   findImplicitGeometricCouplingEntries(geom_search_data, graph);
 
-  for (std::map<dof_id_type, std::vector<dof_id_type> >::iterator git=graph.begin(); git != graph.end(); ++git)
+  for (const auto & it : graph)
   {
-    dof_id_type dof = git->first;
-    std::vector<dof_id_type> & row = git->second;
+    dof_id_type dof = it.first;
+    const std::vector<dof_id_type> & row = it.second;
 
-    for (unsigned int i=0; i<row.size(); i++)
-    {
-      dof_id_type coupled_dof = row[i];
+    for (const auto & coupled_dof : row)
       jacobian.add(dof, coupled_dof, 0);
-    }
   }
 }
 
@@ -1610,16 +1550,14 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
 
   bool constraints_applied;
   if (!_assemble_constraints_separately) constraints_applied = false;
-  for (std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator it = penetration_locators->begin();
-      it != penetration_locators->end();
-      ++it)
+  for (const auto & it : *penetration_locators)
   {
     if (_assemble_constraints_separately)
     {
       // Reset the constraint_applied flag before each new constraint, as they need to be assembled separately
       constraints_applied = false;
     }
-    PenetrationLocator & pen_loc = *it->second;
+    PenetrationLocator & pen_loc = *(it.second);
 
     std::vector<dof_id_type> & slave_nodes = pen_loc._nearest_node._slave_nodes;
 
@@ -1630,9 +1568,8 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
     {
       const std::vector<MooseSharedPointer<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
 
-      for (unsigned int i=0; i<slave_nodes.size(); i++)
+      for (const auto & slave_node_num : slave_nodes)
       {
-        dof_id_type slave_node_num = slave_nodes[i];
         Node & slave_node = _mesh.nodeRef(slave_node_num);
 
         if (slave_node.processor_id() == processor_id())
@@ -1655,10 +1592,8 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
 
             // reinit variables on the master element's face at the contact point
             _fe_problem.reinitNeighborPhys(master_elem, master_side, points, 0);
-            for (unsigned int c=0; c < constraints.size(); c++)
+            for (const auto & nfc : constraints)
             {
-              MooseSharedPointer<NodeFaceConstraint> nfc = constraints[c];
-
               nfc->_jacobian = &jacobian;
 
               if (nfc->shouldApply())
@@ -1691,26 +1626,24 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
 
                 // Do the off-diagonals next
                 const std::vector<MooseVariable *> coupled_vars = nfc->getCoupledMooseVars();
-                for (std::vector<MooseVariable *>::const_iterator jt = coupled_vars.begin(); jt != coupled_vars.end(); jt++)
+                for (const auto & jvar : coupled_vars)
                 {
-                  MooseVariable & jvar = *(*jt);
-
                   // Only compute jacobians for nonlinear variables
-                  if (jvar.kind() != Moose::VAR_NONLINEAR)
+                  if (jvar->kind() != Moose::VAR_NONLINEAR)
                     continue;
 
                   // Only compute Jacobian entries if this coupling is being used by the preconditioner
-                  if (nfc->variable().number() == jvar.number() ||
-                      !_fe_problem.areCoupled(nfc->variable().number(), jvar.number()))
+                  if (nfc->variable().number() == jvar->number() ||
+                      !_fe_problem.areCoupled(nfc->variable().number(), jvar->number()))
                     continue;
 
                   // Need to zero out the matrices first
                   _fe_problem.prepareAssembly(0);
 
                   nfc->subProblem().prepareShapes(nfc->variable().number(), 0);
-                  nfc->subProblem().prepareNeighborShapes(jvar.number(), 0);
+                  nfc->subProblem().prepareNeighborShapes(jvar->number(), 0);
 
-                  nfc->computeOffDiagJacobian(jvar.number());
+                  nfc->computeOffDiagJacobian(jvar->number());
 
                   // Cache the jacobian block for the slave side
                   _fe_problem.assembly(0).cacheJacobianBlock(nfc->_Kee, slave_dofs, nfc->_connected_dof_indices, nfc->variable().scalingFactor());
@@ -1796,10 +1729,8 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
   THREAD_ID tid = 0;
   // go over mortar interfaces
   std::vector<MooseMesh::MortarInterface *> & ifaces = _mesh.getMortarInterfaces();
-  for (std::vector<MooseMesh::MortarInterface *>::iterator it = ifaces.begin(); it != ifaces.end(); ++it)
+  for (const auto & iface : ifaces)
   {
-    MooseMesh::MortarInterface * iface = *it;
-
     if (_constraints.hasActiveFaceFaceConstraints(iface->_name))
     {
       // FaceFaceConstraint objects
@@ -1807,15 +1738,11 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
 
       // go over elements on that interface
       const std::vector<Elem *> & elems = iface->_elems;
-      for (std::vector<Elem *>::const_iterator el = elems.begin(); el != elems.end(); ++el)
+      for (const auto & elem : elems)
       {
-        const Elem * elem = *el;
-
         // for each element process constraints on the
-        for (std::vector<MooseSharedPointer<FaceFaceConstraint> >::const_iterator fc_it = face_constraints.begin(); fc_it != face_constraints.end(); ++fc_it)
+        for (const auto & ffc : face_constraints)
         {
-          MooseSharedPointer<FaceFaceConstraint> ffc = *fc_it;
-
           _fe_problem.prepare(elem, tid);
           _fe_problem.reinitElem(elem, tid);
           ffc->reinit();
@@ -1851,35 +1778,30 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
     element_pair_locators = &displaced_geom_search_data._element_pair_locators;
   }
 
-  for (std::map<unsigned int, MooseSharedPointer<ElementPairLocator> >::iterator it = element_pair_locators->begin();
-       it != element_pair_locators->end();
-       ++it)
+  for (const auto & it : *element_pair_locators)
   {
-    ElementPairLocator & elem_pair_loc = *it->second;
+    ElementPairLocator & elem_pair_loc = *(it.second);
 
-    if (_constraints.hasActiveElemElemConstraints(it->first))
+    if (_constraints.hasActiveElemElemConstraints(it.first))
     {
       // ElemElemConstraint objects
-      const std::vector<MooseSharedPointer<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it->first);
+      const std::vector<MooseSharedPointer<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
 
       // go over pair elements
       const std::list<std::pair<const Elem*, const Elem*> > & elem_pairs = elem_pair_loc.getElemPairs();
-      for (std::list<std::pair<const Elem *, const Elem*> >::const_iterator it = elem_pairs.begin();
-           it != elem_pairs.end(); ++it)
+      for (const auto & pr : elem_pairs)
       {
-        const Elem * elem1 = it->first;
-        const Elem * elem2 = it->second;
+        const Elem * elem1 = pr.first;
+        const Elem * elem2 = pr.second;
 
         if (elem1->processor_id() != processor_id())
           continue;
 
-        const ElementPairInfo & info = elem_pair_loc.getElemPairInfo(*it);
+        const ElementPairInfo & info = elem_pair_loc.getElemPairInfo(pr);
 
         // for each element process constraints on the
-        for (std::vector<MooseSharedPointer<ElemElemConstraint> >::const_iterator ec_it = _element_constraints.begin(); ec_it != _element_constraints.end(); ++ec_it)
+        for (const auto & ec : _element_constraints)
         {
-          MooseSharedPointer<ElemElemConstraint> ec = *ec_it;
-
           _fe_problem.reinitElemPhys(elem1, info._elem1_constraint_q_point, tid);
           _fe_problem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
 
@@ -1906,10 +1828,8 @@ NonlinearSystem::computeScalarKernelsJacobians(SparseMatrix<Number> & jacobian)
     const std::vector<MooseSharedPointer<ScalarKernel> > & scalars = _scalar_kernels.getActiveObjects();
 
     _fe_problem.reinitScalars(/*tid=*/0);
-    for (std::vector<MooseSharedPointer<ScalarKernel> >::const_iterator it = scalars.begin(); it != scalars.end(); ++it)
+    for (const auto & kernel : scalars)
     {
-      MooseSharedPointer<ScalarKernel> kernel = *it;
-
       kernel->reinit();
       kernel->computeJacobian();
       _fe_problem.addJacobianOffDiagScalar(jacobian, kernel->variable().number());
@@ -2087,26 +2007,22 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
     // variables, so we don't have to figure it out for each node.
     std::map<std::string, std::set<unsigned int> > bc_involved_vars;
     const std::set<BoundaryID> & all_boundary_ids = _mesh.getBoundaryIDs();
-    for (std::set<BoundaryID>::const_iterator it=all_boundary_ids.begin(); it != all_boundary_ids.end(); ++it)
+    for (const auto & bid : all_boundary_ids)
     {
       // Get reference to all the NodalBCs for this ID.  This is only
       // safe if there are NodalBCs there to be gotten...
-      if (_nodal_bcs.hasActiveBoundaryObjects(*it))
+      if (_nodal_bcs.hasActiveBoundaryObjects(bid))
       {
-        const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(*it);
-        for (std::vector<MooseSharedPointer<NodalBC> >::const_iterator bc_it = bcs.begin(); bc_it != bcs.end(); ++bc_it)
+        const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(bid);
+        for (const auto & bc : bcs)
         {
-          MooseSharedPointer<NodalBC> bc = *bc_it;
-
           const std::vector<MooseVariable *> & coupled_moose_vars = bc->getCoupledMooseVars();
 
           // Create the set of "involved" MOOSE nonlinear vars, which includes all coupled vars and the BC's own variable
           std::set<unsigned int> & var_set = bc_involved_vars[bc->name()];
-          for (unsigned int var = 0; var < coupled_moose_vars.size(); ++var)
-          {
-            if (coupled_moose_vars[var]->kind() == Moose::VAR_NONLINEAR)
-              var_set.insert(coupled_moose_vars[var]->number());
-          }
+          for (const auto & coupled_var : coupled_moose_vars)
+            if (coupled_var->kind() == Moose::VAR_NONLINEAR)
+              var_set.insert(coupled_var->number());
 
           var_set.insert(bc->variable().number());
         }
@@ -2122,9 +2038,8 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
 
     // Compute Jacobians for NodalBCs
     ConstBndNodeRange & bnd_nodes = *_mesh.getBoundaryNodeRange();
-    for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin(); nd != bnd_nodes.end(); ++nd)
+    for (const auto & bnode : bnd_nodes)
     {
-      const BndNode * bnode = *nd;
       BoundaryID boundary_id = bnode->_bnd_id;
       Node * node = bnode->_node;
 
@@ -2133,10 +2048,8 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
         _fe_problem.reinitNodeFace(node, boundary_id, 0);
 
         const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
-        for (std::vector<MooseSharedPointer<NodalBC> >::const_iterator bc_it = bcs.begin(); bc_it != bcs.end(); ++bc_it)
+        for (const auto & bc : bcs)
         {
-          MooseSharedPointer<NodalBC> bc = *bc_it;
-
           // Get the set of involved MOOSE vars for this BC
           std::set<unsigned int> & var_set = bc_involved_vars[bc->name()];
 
@@ -2144,12 +2057,11 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
           // actually being computed, call computeOffDiagJacobian()
           // for each one which is actually coupled (otherwise the
           // value is zero.)
-          for (std::vector<std::pair<MooseVariable *, MooseVariable *> >::iterator it = coupling_entries.begin();
-               it != coupling_entries.end(); ++it)
+          for (const auto & it : coupling_entries)
           {
             unsigned int
-              ivar = it->first->number(),
-              jvar = it->second->number();
+              ivar = it.first->number(),
+              jvar = it.second->number();
 
             // We are only going to call computeOffDiagJacobian() if:
             // 1.) the BC's variable is ivar
@@ -2262,31 +2174,26 @@ NonlinearSystem::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks)
     std::vector<numeric_index_type> zero_rows;
     PARALLEL_TRY {
       ConstBndNodeRange & bnd_nodes = *_mesh.getBoundaryNodeRange();
-      for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin() ; nd != bnd_nodes.end(); ++nd)
+      for (const auto & bnode : bnd_nodes)
       {
-        const BndNode * bnode = *nd;
         BoundaryID boundary_id = bnode->_bnd_id;
         Node * node = bnode->_node;
 
         if (_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
         {
           const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
-          {
-            if (node->processor_id() == processor_id())
-            {
-              _fe_problem.reinitNodeFace(node, boundary_id, 0);
 
-              for (std::vector<MooseSharedPointer<NodalBC> >::const_iterator it = bcs.begin(); it != bcs.end(); ++it)
+          if (node->processor_id() == processor_id())
+          {
+            _fe_problem.reinitNodeFace(node, boundary_id, 0);
+
+            for (const auto & bc : bcs)
+              if (bc->variable().number() == ivar && bc->shouldApply())
               {
-                MooseSharedPointer<NodalBC> bc = *it;
-                if (bc->variable().number() == ivar && bc->shouldApply())
-                {
-                  //The first zero is for the variable number... there is only one variable in each mini-system
-                  //The second zero only works with Lagrange elements!
-                  zero_rows.push_back(node->dof_number(precond_system.number(), 0, 0));
-                }
+                //The first zero is for the variable number... there is only one variable in each mini-system
+                //The second zero only works with Lagrange elements!
+                zero_rows.push_back(node->dof_number(precond_system.number(), 0, 0));
               }
-            }
           }
         }
       }
@@ -2349,9 +2256,9 @@ NonlinearSystem::computeDamping(const NumericVector<Number> & solution,
   if (_general_dampers.hasActiveObjects())
   {
     const std::vector<MooseSharedPointer<GeneralDamper> > & gdampers = _general_dampers.getActiveObjects();
-    for (std::vector<MooseSharedPointer<GeneralDamper> >::const_iterator it = gdampers.begin(); it != gdampers.end(); ++it)
+    for (const auto & damper : gdampers)
     {
-      Real gd_damping = (*it)->computeDamping(solution, update);
+      Real gd_damping = damper->computeDamping(solution, update);
       if (gd_damping < damping)
         damping = gd_damping;
     }
@@ -2380,10 +2287,10 @@ NonlinearSystem::computeDiracContributions(SparseMatrix<Number> * jacobian)
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
     {
       const std::vector<MooseSharedPointer<DiracKernel> > & dkernels = _dirac_kernels.getActiveObjects(tid);
-      for (std::vector<MooseSharedPointer<DiracKernel> >::const_iterator it = dkernels.begin(); it != dkernels.end(); ++it)
+      for (const auto & dkernel : dkernels)
       {
-        (*it)->clearPoints();
-        (*it)->addPoints();
+        dkernel->clearPoints();
+        dkernel->addPoints();
       }
     }
 
@@ -2452,15 +2359,15 @@ NonlinearSystem::augmentSparsity(SparsityPattern::Graph & sparsity,
 
     unsigned int max_nz = sparsity.size();
 
-    for (std::map<dof_id_type, std::vector<dof_id_type> >::iterator git=graph.begin(); git != graph.end(); ++git)
+    for (const auto & git : graph)
     {
-      dof_id_type dof = git->first;
+      dof_id_type dof = git.first;
       dof_id_type local_dof = dof - first_dof_on_proc;
 
       if (dof < first_dof_on_proc || dof >= end_dof_on_proc)
         continue;
 
-      std::vector<dof_id_type> & row = git->second;
+      const std::vector<dof_id_type> & row = git.second;
 
       SparsityPattern::Row & sparsity_row = sparsity[local_dof];
 
@@ -2471,10 +2378,8 @@ NonlinearSystem::augmentSparsity(SparsityPattern::Graph & sparsity,
       SparsityPattern::sort_row(sparsity_row.begin(), sparsity_row.begin()+original_row_length, sparsity_row.end());
 
       // Fix up nonzero arrays
-      for (unsigned int i=0; i<row.size(); i++)
+      for (const auto & coupled_dof : row)
       {
-        dof_id_type coupled_dof = row[i];
-
         if (coupled_dof < first_dof_on_proc || coupled_dof >= end_dof_on_proc)
         {
           if (n_oz[local_dof] < max_nz)
@@ -2556,15 +2461,11 @@ NonlinearSystem::reinitIncrementForDampers(THREAD_ID tid)
   std::set<MooseVariable *> damped_vars;
 
   const std::vector<MooseSharedPointer<ElementDamper> > & edampers = _element_dampers.getActiveObjects(tid);
-  for (std::vector<MooseSharedPointer<ElementDamper> >::const_iterator it = edampers.begin(); it != edampers.end(); ++it)
-    damped_vars.insert( (*it)->getVariable() );
+  for (const auto & damper : edampers)
+    damped_vars.insert(damper->getVariable());
 
-  for (std::set<MooseVariable *>::const_iterator it = damped_vars.begin();
-       it != damped_vars.end(); ++it)
-  {
-    MooseVariable * var = *it;
+  for (const auto & var : damped_vars)
     var->computeIncrement(*_increment_vec);
-  }
 }
 
 void

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -36,9 +36,8 @@ ScalarCoupleable::ScalarCoupleable(const MooseObject * moose_object) :
     if (_sc_parameters.getVecMooseType(*iter) != std::vector<std::string>())
     {
       std::vector<std::string> vars = _sc_parameters.getVecMooseType(*iter);
-      for (unsigned int i = 0; i < vars.size(); i++)
+      for (const auto & coupled_var_name : vars)
       {
-        std::string coupled_var_name = vars[i];
         if (problem.hasScalarVariable(coupled_var_name))
         {
           MooseVariableScalar * scalar_var = &problem.getScalarVariable(tid, coupled_var_name);
@@ -56,10 +55,10 @@ ScalarCoupleable::ScalarCoupleable(const MooseObject * moose_object) :
 
 ScalarCoupleable::~ScalarCoupleable()
 {
-  for (std::map<std::string, VariableValue *>::iterator it = _default_value.begin(); it != _default_value.end(); ++it)
+  for (auto & it : _default_value)
   {
-    it->second->release();
-    delete it->second;
+    it.second->release();
+    delete it.second;
   }
 }
 

--- a/framework/src/base/UpdateErrorVectorsThread.C
+++ b/framework/src/base/UpdateErrorVectorsThread.C
@@ -32,12 +32,10 @@ UpdateErrorVectorsThread::UpdateErrorVectorsThread(FEProblem & fe_problem, std::
     _solution(_aux_sys.solution())
 {
   // Build up this map once so we don't have to do these lookups over and over again
-  for (std::map<std::string, ErrorVector *>::iterator it=_indicator_field_to_error_vector.begin();
-      it != _indicator_field_to_error_vector.end();
-      ++it)
+  for (const auto & it : _indicator_field_to_error_vector)
   {
-    unsigned int var_num = _aux_sys.getVariable(0, it->first).number();
-    _indicator_field_number_to_error_vector[var_num] = it->second;
+    unsigned int var_num = _aux_sys.getVariable(0, it.first).number();
+    _indicator_field_number_to_error_vector[var_num] = it.second;
   }
 }
 
@@ -55,14 +53,12 @@ UpdateErrorVectorsThread::UpdateErrorVectorsThread(UpdateErrorVectorsThread & x,
 }
 
 void
-UpdateErrorVectorsThread::onElement(const Elem *elem)
+UpdateErrorVectorsThread::onElement(const Elem * elem)
 {
-  for (std::map<unsigned int, ErrorVector *>::iterator it=_indicator_field_number_to_error_vector.begin();
-      it != _indicator_field_number_to_error_vector.end();
-      ++it)
+  for (const auto & it : _indicator_field_number_to_error_vector)
   {
-    unsigned int var_num = it->first;
-    ErrorVector & ev = *(it->second);
+    unsigned int var_num = it.first;
+    ErrorVector & ev = *(it.second);
 
     dof_id_type dof_number = elem->dof_number(_system_number, var_num, 0);
     Real value = _solution(dof_number);

--- a/framework/src/base/VariableWarehouse.C
+++ b/framework/src/base/VariableWarehouse.C
@@ -23,8 +23,8 @@ VariableWarehouse::VariableWarehouse()
 
 VariableWarehouse::~VariableWarehouse()
 {
-  for (std::vector<MooseVariableBase *>::iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    delete *it;
+  for (auto & var : _all_objects)
+    delete var;
 }
 
 void
@@ -55,17 +55,17 @@ VariableWarehouse::addBoundaryVar(BoundaryID bnd, MooseVariable *var)
 void
 VariableWarehouse::addBoundaryVar(const std::set<BoundaryID> & boundary_ids, MooseVariable *var)
 {
-  for (std::set<BoundaryID>::const_iterator it = boundary_ids.begin(); it != boundary_ids.end(); ++it)
-    addBoundaryVar(*it, var);
+  for (const auto & bid : boundary_ids)
+    addBoundaryVar(bid, var);
 }
 
 void
 VariableWarehouse::addBoundaryVars(const std::set<BoundaryID> & boundary_ids, const std::map<std::string, std::vector<MooseVariable *> > & vars)
 {
-  for (std::set<BoundaryID>::const_iterator bnd_it = boundary_ids.begin(); bnd_it != boundary_ids.end(); ++bnd_it)
-    for (std::map<std::string, std::vector<MooseVariable *> >::const_iterator it = vars.begin(); it != vars.end(); ++it)
-      for (std::vector<MooseVariable *>::const_iterator jt = it->second.begin(); jt != it->second.end(); ++jt)
-        addBoundaryVar(*bnd_it, *jt);
+  for (const auto & bid : boundary_ids)
+    for (const auto & it : vars)
+      for (const auto & var : it.second)
+        addBoundaryVar(bid, var);
 }
 
 MooseVariableBase *

--- a/framework/src/constraints/ConstraintWarehouse.C
+++ b/framework/src/constraints/ConstraintWarehouse.C
@@ -167,39 +167,30 @@ ConstraintWarehouse::updateActive(THREAD_ID /*tid*/)
   MooseObjectWarehouse<Constraint>::updateActive();
   _nodal_constraints.updateActive();
 
-  {
-    std::map<BoundaryID, MooseObjectWarehouse<NodeFaceConstraint> >::iterator it;
-    for (it = _node_face_constraints.begin(); it != _node_face_constraints.end(); ++it)
-      it->second.updateActive();
-    for (it = _displaced_node_face_constraints.begin(); it != _displaced_node_face_constraints.end(); ++it)
-      it->second.updateActive();
-  }
+  for (auto & it : _node_face_constraints)
+    it.second.updateActive();
 
-  {
-    std::map<std::string, MooseObjectWarehouse<FaceFaceConstraint> >::iterator it;
-    for (std::map<BoundaryID, MooseObjectWarehouse<NodeFaceConstraint> >::iterator it = _node_face_constraints.begin(); it != _node_face_constraints.end(); ++it)
-      it->second.updateActive();
-  }
+  for (auto & it : _displaced_node_face_constraints)
+    it.second.updateActive();
 
-  {
-    std::map<unsigned int, MooseObjectWarehouse<ElemElemConstraint> >::iterator it;
-    for (it = _element_constraints.begin(); it != _element_constraints.end(); ++it)
-      it->second.updateActive();
-  }
+  // FIXME: We call updateActive() on the NodeFaceConstraints again?
+  for (auto & it : _node_face_constraints)
+    it.second.updateActive();
+
+  for (auto & it : _element_constraints)
+    it.second.updateActive();
 }
 
 
 void
 ConstraintWarehouse::subdomainsCovered(std::set<SubdomainID> & subdomains_covered, std::set<std::string> & unique_variables, THREAD_ID/*tid=0*/) const
 {
-  std::map<std::string, MooseObjectWarehouse<FaceFaceConstraint> >::const_iterator it;
-
-  for (it = _face_face_constraints.begin(); it != _face_face_constraints.end(); ++it)
+  for (const auto & it : _face_face_constraints)
   {
-    const std::vector<MooseSharedPointer<FaceFaceConstraint> > & objects = it->second.getActiveObjects();
-    for (std::vector<MooseSharedPointer<FaceFaceConstraint> >::const_iterator jt = objects.begin(); jt != objects.end(); ++jt)
+    const std::vector<MooseSharedPointer<FaceFaceConstraint> > & objects = it.second.getActiveObjects();
+    for (const auto & ffc : objects)
     {
-      MooseVariable & var = (*jt)->variable();
+      MooseVariable & var = ffc->variable();
       unique_variables.insert(var.name());
       const std::set<SubdomainID> & subdomains = var.activeSubdomains();
       subdomains_covered.insert(subdomains.begin(), subdomains.end());

--- a/framework/src/constraints/EqualValueBoundaryConstraint.C
+++ b/framework/src/constraints/EqualValueBoundaryConstraint.C
@@ -85,13 +85,10 @@ EqualValueBoundaryConstraint::updateConstrainedNodes()
     if (_master_node_id == std::numeric_limits<unsigned int>::max())
       _master_node_vector.push_back(_slave_node_ids[0]); //_master_node_vector defines master nodes in the base class
 
-    //Fill in _connected_nodes, which defines slave nodes in the base class
-    std::vector<unsigned int>::iterator its;
-    for (its = _slave_node_ids.begin(); its != _slave_node_ids.end(); ++its)
-    {
-      if ((_mesh.nodeRef(*its).processor_id() == _subproblem.processor_id()) && (*its != _master_node_vector[0]))
-        _connected_nodes.push_back(*its);
-    }
+    // Fill in _connected_nodes, which defines slave nodes in the base class
+    for (const auto & dof : _slave_node_ids)
+      if ((_mesh.nodeRef(dof).processor_id() == _subproblem.processor_id()) && (dof != _master_node_vector[0]))
+        _connected_nodes.push_back(dof);
   }
 
   // Add elements connected to master node to Ghosted Elements

--- a/framework/src/constraints/LinearNodalConstraint.C
+++ b/framework/src/constraints/LinearNodalConstraint.C
@@ -40,9 +40,6 @@ LinearNodalConstraint::LinearNodalConstraint(const InputParameters & parameters)
   if (_master_node_ids.size() != _weights.size())
     mooseError("master and weights should be of equal size.");
 
-  std::vector<unsigned int>::iterator it;
-  std::vector<unsigned int>::iterator its;
-
   if ((_slave_node_ids.size() == 0) && (_slave_node_set_id == "NaN"))
     mooseError("Please specify slave_node_ids or slave_node_set.");
   else if ((_slave_node_ids.size() == 0) && (_slave_node_set_id != "NaN"))
@@ -58,20 +55,20 @@ LinearNodalConstraint::LinearNodalConstraint(const InputParameters & parameters)
   }
   else if ((_slave_node_ids.size() > 0) && (_slave_node_set_id == "NaN"))
   {
-    for (its = _slave_node_ids.begin(); its != _slave_node_ids.end(); ++its)
-    {
-      if (_mesh.nodeRef(*its).processor_id() == _subproblem.processor_id())
-        _connected_nodes.push_back(*its);
-    }
+    for (const auto & dof : _slave_node_ids)
+      if (_mesh.nodeRef(dof).processor_id() == _subproblem.processor_id())
+        _connected_nodes.push_back(dof);
   }
 
   // Add elements connected to master node to Ghosted Elements
-  for (it = _master_node_ids.begin(); it != _master_node_ids.end(); ++it)
+  for (const auto & dof : _master_node_ids)
   {
-    _master_node_vector.push_back(*it); //defining master nodes in base class
-    std::vector<dof_id_type> & elems = _mesh.nodeToElemMap()[*it];
-    for (unsigned int i = 0; i < elems.size(); i++)
-      _subproblem.addGhostedElem(elems[i]);
+    // defining master nodes in base class
+    _master_node_vector.push_back(dof);
+
+    std::vector<dof_id_type> & elems = _mesh.nodeToElemMap()[dof];
+    for (const auto & elem_id : elems)
+      _subproblem.addGhostedElem(elem_id);
   }
 }
 

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -232,20 +232,18 @@ NodeFaceConstraint::getConnectedDofIndices(unsigned int var_num)
   std::vector<dof_id_type> & elems = _node_to_elem_map[_current_node->id()];
 
   // Get the dof indices from each elem connected to the node
-  for (unsigned int el=0; el < elems.size(); ++el)
+  for (const auto & cur_elem : elems)
   {
-    dof_id_type cur_elem = elems[el];
-
     std::vector<dof_id_type> dof_indices;
 
     var.getDofIndices(_mesh.elemPtr(cur_elem), dof_indices);
 
-    for (unsigned int di=0; di < dof_indices.size(); di++)
-      unique_dof_indices.insert(dof_indices[di]);
+    for (const auto & dof : dof_indices)
+      unique_dof_indices.insert(dof);
   }
 
-  for (std::set<dof_id_type>::iterator sit=unique_dof_indices.begin(); sit != unique_dof_indices.end(); ++sit)
-    _connected_dof_indices.push_back(*sit);
+  for (const auto & dof : unique_dof_indices)
+    _connected_dof_indices.push_back(dof);
 }
 
 bool

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -340,15 +340,11 @@ DiracKernel::currentPointCachedID()
   // Do a linear search in the (hopefully small) vector of Points for this Elem
   reverse_cache_t::mapped_type & points = it->second;
 
-  reverse_cache_t::mapped_type::iterator
-    points_it = points.begin(),
-    points_end = points.end();
-
-  for (; points_it != points_end; ++points_it)
+  for (const auto & points_it : points)
   {
     // If the current_point equals the cached point, return the associated id
-    if (_current_point.relative_fuzzy_equals(points_it->first))
-      return points_it->second;
+    if (_current_point.relative_fuzzy_equals(points_it.first))
+      return points_it.second;
   }
 
   // If we made it here, we didn't find the cached point, so return invalid_uint

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -66,12 +66,8 @@ DiracKernelInfo::hasPoint(const Elem * elem, Point p)
 {
   std::vector<Point> & point_list = _points[elem].first;
 
-  std::vector<Point>::iterator
-    it = point_list.begin(),
-    end = point_list.end();
-
-  for (; it != end; ++it)
-    if (pointsFuzzyEqual(*it, p))
+  for (const auto & pt : point_list)
+    if (pointsFuzzyEqual(pt, p))
       return true;
 
   // If we haven't found it, we don't have it.

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -685,16 +685,14 @@ Transient::lastSolveConverged()
 void
 Transient::preExecute()
 {
-  /*
   // Add time period start times to sync times
-  const std::vector<MooseSharedPointer<Control> > & controls = _problem.getControlWarehouse().getActiveObjects();
-  for (std::vector<MooseSharedPointer<Control> >::const_iterator it = controls.begin(); it != controls.end(); ++it)
-  {
-    MooseSharedPointer<TimePeriod> tp = MooseSharedNamespace::dynamic_pointer_cast<TimePeriod>(*it);
-    if (tp)
-      _time_stepper->addSyncTime(tp->getSyncTimes());
-  }
-  */
+  // const std::vector<MooseSharedPointer<Control> > & controls = _problem.getControlWarehouse().getActiveObjects();
+  // for (auto & control : controls)
+  // {
+  //   MooseSharedPointer<TimePeriod> tp = MooseSharedNamespace::dynamic_pointer_cast<TimePeriod>(control);
+  //   if (tp)
+  //     _time_stepper->addSyncTime(tp->getSyncTimes());
+  // }
   _time_stepper->preExecute();
 }
 

--- a/framework/src/functions/CompositeFunction.C
+++ b/framework/src/functions/CompositeFunction.C
@@ -29,20 +29,19 @@ CompositeFunction::CompositeFunction(const InputParameters & parameters) :
   _scale_factor( getParam<Real>("scale_factor") )
 {
 
-  const std::vector<FunctionName> & names( getParam<std::vector<FunctionName> >("functions") );
-  const unsigned len( names.size() );
+  const std::vector<FunctionName> & names = getParam<std::vector<FunctionName> >("functions");
+  const unsigned int len = names.size();
   if (len == 0)
-  {
     mooseError( "A composite function must reference at least one other function" );
-  }
+
   _f.resize(len);
-  for (unsigned i(0); i < len; ++i)
+
+  for (unsigned i = 0; i < len; ++i)
   {
     if (name() == names[i])
-    {
       mooseError( "A composite function must not reference itself" );
-    }
-    Function * const f = &getFunctionByName( names[i] );
+
+    Function * const f = &getFunctionByName(names[i]);
     if (!f)
     {
       std::string msg("Error in composite function ");
@@ -63,10 +62,10 @@ CompositeFunction::~CompositeFunction()
 Real
 CompositeFunction::value(Real t, const Point & p)
 {
-  Real val(_scale_factor);
-  for (unsigned i(0); i < _f.size(); ++i)
-  {
-    val *= _f[i]->value( t, p );
-  }
+  Real val = _scale_factor;
+
+  for (const auto & func : _f)
+    val *= func->value(t, p);
+
   return val;
 }

--- a/framework/src/functions/LinearCombinationFunction.C
+++ b/framework/src/functions/LinearCombinationFunction.C
@@ -30,8 +30,8 @@ LinearCombinationFunction::LinearCombinationFunction(const InputParameters & par
     _w(getParam<std::vector<Real> >("w"))
 {
 
-  const std::vector<FunctionName> & names(getParam<std::vector<FunctionName> >("functions"));
-  const unsigned len(names.size());
+  const std::vector<FunctionName> & names = getParam<std::vector<FunctionName> >("functions");
+  const unsigned int len = names.size();
   if (len != _w.size())
     mooseError("LinearCombinationFunction: The number of functions must equal the number of w values");
 

--- a/framework/src/functions/MooseParsedFunctionBase.C
+++ b/framework/src/functions/MooseParsedFunctionBase.C
@@ -11,23 +11,9 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
-/****************************************************************/
-/*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
-/*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
-/*                   ALL RIGHTS RESERVED                        */
-/*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
-/*                                                              */
-/*           See COPYRIGHT for full restrictions                */
-/****************************************************************/
 
 #include "MooseError.h"
 #include "MooseParsedFunctionBase.h"
-//#include "MooseParsedFunction.h"
 
 template<>
 InputParameters validParams<MooseParsedFunctionBase>()
@@ -47,8 +33,8 @@ MooseParsedFunctionBase::MooseParsedFunctionBase(const InputParameters & paramet
     mooseError("Number of vars must match the number of vals for a MooseParsedFunction!");
 
   // Loop through the variables assigned by the user and give an error if x,y,z,t are used
-  for (unsigned int i = 0; i < _vars.size(); ++i)
-    if (_vars[i].find_first_of("xyzt") != std::string::npos && _vars[i].size() == 1)
+  for (const auto & var : _vars)
+    if (var.find_first_of("xyzt") != std::string::npos && var.size() == 1)
       mooseError("The variables \"x, y, z, and t\" in the ParsedFunction are pre-declared for use and must not be declared in \"vars\"");
 }
 

--- a/framework/src/functions/MooseParsedFunctionWrapper.C
+++ b/framework/src/functions/MooseParsedFunctionWrapper.C
@@ -33,10 +33,11 @@ MooseParsedFunctionWrapper::MooseParsedFunctionWrapper(FEProblem & feproblem,
   _function_ptr = new ParsedFunction<Real,RealGradient>(_function_str, &_vars, &_vals);
 
   // Loop through the Postprocessor and Scalar variables and point the libMesh::ParsedFunction to the PostprocessorValue
-  for (unsigned int i = 0; i < _pp_index.size(); ++i)
-    _addr.push_back(&_function_ptr->getVarAddress(_vars[_pp_index[i]]));
-  for (unsigned int i = 0; i < _scalar_index.size(); ++i)
-    _addr.push_back(&_function_ptr->getVarAddress(_vars[_scalar_index[i]]));
+  for (const auto & index : _pp_index)
+    _addr.push_back(&_function_ptr->getVarAddress(_vars[index]));
+
+  for (const auto & index : _scalar_index)
+    _addr.push_back(&_function_ptr->getVarAddress(_vars[index]));
 }
 
 MooseParsedFunctionWrapper::~MooseParsedFunctionWrapper()

--- a/framework/src/functions/PiecewiseBilinear.C
+++ b/framework/src/functions/PiecewiseBilinear.C
@@ -151,7 +151,7 @@ PiecewiseBilinear::parse( std::vector<Real> & x,
       std::istringstream i(item);
       Real d;
       i >> d;
-      data.push_back( d );
+      data.push_back(d);
     }
 
     if (linenum == 1)
@@ -166,19 +166,19 @@ PiecewiseBilinear::parse( std::vector<Real> & x,
   z.reshape(linenum-1,itemnum-1);
   unsigned int offset(0);
   // Extract the first line's data (the x axis data)
-  for (unsigned int j(0); j < itemnum-1; ++j)
+  for (unsigned int j = 0; j < itemnum-1; ++j)
   {
     x[j] = data[offset];
     ++offset;
   }
-  for (unsigned int i(0); i < linenum-1; ++i)
+  for (unsigned int i = 0; i < linenum-1; ++i)
   {
     // Extract the y axis entry for this line
     y[i] = data[offset];
     ++offset;
 
     // Extract the function values for this row in the matrix
-    for (unsigned int j(0); j < itemnum-1; ++j)
+    for (unsigned int j = 0; j < itemnum-1; ++j)
     {
       z(i,j) = data[offset];
       ++offset;

--- a/framework/src/functions/PiecewiseConstant.C
+++ b/framework/src/functions/PiecewiseConstant.C
@@ -110,16 +110,15 @@ Real
 PiecewiseConstant::integral()
 {
   const unsigned len = functionSize();
-  Real sum(0);
+  Real sum = 0;
   unsigned offset = 0;
+
   if (_direction == RIGHT)
-  {
     offset = 1;
-  }
-  for (unsigned i(0); i < len-1; ++i)
-  {
+
+  for (unsigned i = 0; i < len-1; ++i)
     sum += range(i+offset) * (domain(i+1) - domain(i));
-  }
+
   return _scale_factor * sum;
 }
 

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -124,9 +124,8 @@ findContactPoint(PenetrationInfo & p_info,
   Real update_size = std::numeric_limits<Real>::max();
 
   //Least squares
-  for (unsigned int it=0; it<3 && update_size > TOLERANCE*1e3; ++it)
+  for (unsigned int it = 0; it < 3 && update_size > TOLERANCE*1e3; ++it)
   {
-
     DenseMatrix<Real> jac(dim-1, dim-1);
 
     jac(0,0) = -(dxyz_dxi[0] * dxyz_dxi[0]);
@@ -167,7 +166,7 @@ findContactPoint(PenetrationInfo & p_info,
   unsigned nit=0;
 
   // Newton Loop
-  for (; nit<12 && update_size > TOLERANCE*TOLERANCE; nit++)
+  for (; nit < 12 && update_size > TOLERANCE*TOLERANCE; nit++)
   {
     d = slave_point - phys_point[0];
 

--- a/framework/src/geomsearch/GeometricSearchData.C
+++ b/framework/src/geomsearch/GeometricSearchData.C
@@ -32,19 +32,11 @@ GeometricSearchData::GeometricSearchData(SubProblem & subproblem, MooseMesh & me
 
 GeometricSearchData::~GeometricSearchData()
 {
-  for (std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator it = _penetration_locators.begin();
-      it != _penetration_locators.end();
-      ++it)
-  {
-    delete it->second;
-  }
+  for (auto & it : _penetration_locators)
+    delete it.second;
 
-  for (std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator it = _nearest_node_locators.begin();
-      it != _nearest_node_locators.end();
-      ++it)
-  {
-    delete it->second;
-  }
+  for (auto & it : _nearest_node_locators)
+    delete it.second;
 }
 
 void
@@ -56,25 +48,20 @@ GeometricSearchData::update(GeometricSearchType type)
     {
       _first = false;
 
-      for (std::map<unsigned int, unsigned int>::iterator it = _slave_to_qslave.begin();
-          it != _slave_to_qslave.end();
-          ++it)
-        generateQuadratureNodes(it->first, it->second);
+      for (const auto & it : _slave_to_qslave)
+        generateQuadratureNodes(it.first, it.second);
 
       // reinit on displaced mesh before update
-      for (std::map<unsigned int, MooseSharedPointer<ElementPairLocator> >::iterator epl_it = _element_pair_locators.begin();
-           epl_it != _element_pair_locators.end(); ++epl_it)
+      for (const auto & epl_it : _element_pair_locators)
       {
-        ElementPairLocator & epl = *epl_it->second;
+        ElementPairLocator & epl = *(epl_it.second);
         epl.reinit();
       }
     }
 
     // Update the position of quadrature nodes first
-    for (std::set<unsigned int>::iterator qbnd_it = _quadrature_boundaries.begin();
-        qbnd_it != _quadrature_boundaries.end();
-        ++qbnd_it)
-      updateQuadratureNodes(*qbnd_it);
+    for (const auto & qbnd : _quadrature_boundaries)
+      updateQuadratureNodes(qbnd);
   }
 
   if (type == ALL || type == MORTAR)
@@ -83,34 +70,25 @@ GeometricSearchData::update(GeometricSearchType type)
 
   if (type == ALL || type == NEAREST_NODE)
   {
-    std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator nnl_it = _nearest_node_locators.begin();
-    const std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator nnl_end = _nearest_node_locators.end();
-
-    for (; nnl_it != nnl_end; ++nnl_it)
+    for (const auto & nnl_it : _nearest_node_locators)
     {
-      NearestNodeLocator * nnl = nnl_it->second;
-
+      NearestNodeLocator * nnl = nnl_it.second;
       nnl->findNodes();
     }
   }
 
   if (type == ALL || type == PENETRATION)
   {
-    std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator pl_it = _penetration_locators.begin();
-    std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator pl_end = _penetration_locators.end();
-
-    for (; pl_it != pl_end; ++pl_it)
+    for (const auto & pl_it : _penetration_locators)
     {
-      PenetrationLocator * pl = pl_it->second;
-
+      PenetrationLocator * pl = pl_it.second;
       pl->detectPenetration();
     }
   }
 
-  for (std::map<unsigned int, MooseSharedPointer<ElementPairLocator> >::iterator epl_it = _element_pair_locators.begin();
-       epl_it != _element_pair_locators.end(); ++epl_it)
+  for (const auto & epl_it : _element_pair_locators)
   {
-    ElementPairLocator & epl = *epl_it->second;
+    ElementPairLocator & epl = *(epl_it.second);
     epl.update();
   }
 }
@@ -120,36 +98,25 @@ GeometricSearchData::reinit()
 {
   _mesh.clearQuadratureNodes();
   // Update the position of quadrature nodes first
-  for (std::set<unsigned int>::iterator qbnd_it = _quadrature_boundaries.begin();
-      qbnd_it != _quadrature_boundaries.end();
-      ++qbnd_it)
-    reinitQuadratureNodes(*qbnd_it);
+  for (const auto & qbnd : _quadrature_boundaries)
+    reinitQuadratureNodes(qbnd);
   reinitMortarNodes();
 
-  std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator nnl_it = _nearest_node_locators.begin();
-  const std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator nnl_end = _nearest_node_locators.end();
-
-  for (; nnl_it != nnl_end; ++nnl_it)
+  for (const auto & nnl_it : _nearest_node_locators)
   {
-    NearestNodeLocator * nnl = nnl_it->second;
-
+    NearestNodeLocator * nnl = nnl_it.second;
     nnl->reinit();
   }
 
-  std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator pl_it = _penetration_locators.begin();
-  std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *>::iterator pl_end = _penetration_locators.end();
-
-  for (; pl_it != pl_end; ++pl_it)
+  for (const auto & pl_it : _penetration_locators)
   {
-    PenetrationLocator * pl = pl_it->second;
-
+    PenetrationLocator * pl = pl_it.second;
     pl->reinit();
   }
 
-  for (std::map<unsigned int, MooseSharedPointer<ElementPairLocator> >::iterator epl_it = _element_pair_locators.begin();
-       epl_it != _element_pair_locators.end(); ++epl_it)
+  for (const auto & epl_it : _element_pair_locators)
   {
-    ElementPairLocator & epl = *epl_it->second;
+    ElementPairLocator & epl = *(epl_it.second);
     epl.reinit();
   }
 }
@@ -157,13 +124,9 @@ GeometricSearchData::reinit()
 void
 GeometricSearchData::clearNearestNodeLocators()
 {
-  std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator nnl_it = _nearest_node_locators.begin();
-  const std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator nnl_end = _nearest_node_locators.end();
-
-  for (; nnl_it != nnl_end; ++nnl_it)
+  for (const auto & nnl_it : _nearest_node_locators)
   {
-    NearestNodeLocator * nnl = nnl_it->second;
-
+    NearestNodeLocator * nnl = nnl_it.second;
     nnl->reinit();
   }
 }
@@ -173,12 +136,9 @@ GeometricSearchData::maxPatchPercentage()
 {
   Real max = 0.0;
 
-  std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator nnl_it = _nearest_node_locators.begin();
-  const std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *>::iterator nnl_end = _nearest_node_locators.end();
-
-  for (; nnl_it != nnl_end; ++nnl_it)
+  for (const auto & nnl_it : _nearest_node_locators)
   {
-    NearestNodeLocator * nnl = nnl_it->second;
+    NearestNodeLocator * nnl = nnl_it.second;
 
     if (nnl->_max_patch_percentage > max)
       max = nnl->_max_patch_percentage;
@@ -333,10 +293,8 @@ GeometricSearchData::generateQuadratureNodes(unsigned int slave_id, unsigned int
   const MooseArray<Point> & points_face = _subproblem.assembly(0).qPointsFace();
 
   ConstBndElemRange & range = *_mesh.getBoundaryElementRange();
-  for (ConstBndElemRange::const_iterator elem_it = range.begin() ; elem_it != range.end(); ++elem_it)
+  for (const auto & belem : range)
   {
-    const BndElement * belem = *elem_it;
-
     const Elem * elem = belem->_elem;
     unsigned short int side = belem->_side;
     BoundaryID boundary_id = belem->_bnd_id;
@@ -349,9 +307,7 @@ GeometricSearchData::generateQuadratureNodes(unsigned int slave_id, unsigned int
         _subproblem.reinitElemFace(elem, side, boundary_id, 0);
 
         for (unsigned int qp=0; qp<points_face.size(); qp++)
-        {
           _mesh.addQuadratureNode(elem, side, qp, qslave_id, points_face[qp]);
-        }
       }
     }
   }
@@ -410,9 +366,8 @@ GeometricSearchData::generateMortarNodes(unsigned int master_id, unsigned int sl
   MooseMesh::MortarInterface * iface = _mesh.getMortarInterface(master_id, slave_id);
 
   const MooseArray<Point> & qpoints = _subproblem.assembly(0).qPoints();
-  for (std::vector<Elem *>::iterator it = iface->_elems.begin(); it != iface->_elems.end(); ++it)
+  for (const auto & elem : iface->_elems)
   {
-    Elem * elem = *it;
     _subproblem.assembly(0).reinit(elem);
 
     for (unsigned int qp = 0; qp < qpoints.size(); qp++)
@@ -427,10 +382,8 @@ GeometricSearchData::updateQuadratureNodes(unsigned int slave_id)
   const MooseArray<Point> & points_face = _subproblem.assembly(0).qPointsFace();
 
   ConstBndElemRange & range = *_mesh.getBoundaryElementRange();
-  for (ConstBndElemRange::const_iterator elem_it = range.begin() ; elem_it != range.end(); ++elem_it)
+  for (const auto & belem : range)
   {
-    const BndElement * belem = *elem_it;
-
     const Elem * elem = belem->_elem;
     unsigned short int side = belem->_side;
     BoundaryID boundary_id = belem->_bnd_id;
@@ -453,10 +406,8 @@ void
 GeometricSearchData::reinitQuadratureNodes(unsigned int /*slave_id*/)
 {
   // Regenerate the quadrature nodes
-  for (std::map<unsigned int, unsigned int>::iterator it = _slave_to_qslave.begin();
-      it != _slave_to_qslave.end();
-      ++it)
-    generateQuadratureNodes(it->first, it->second);
+  for (const auto & it : _slave_to_qslave)
+    generateQuadratureNodes(it.first, it.second);
 }
 
 
@@ -466,19 +417,14 @@ GeometricSearchData::updateMortarNodes()
   const MooseArray<Point> & qpoints = _subproblem.assembly(0).qPoints();
 
   std::vector<MooseMesh::MortarInterface *> & ifaces = _mesh.getMortarInterfaces();
-  for (std::vector<MooseMesh::MortarInterface *>::iterator iface_it = ifaces.begin(); iface_it != ifaces.end(); ++iface_it)
-  {
-    MooseMesh::MortarInterface * iface = *iface_it;
-
-    for (std::vector<Elem *>::iterator it = iface->_elems.begin(); it != iface->_elems.end(); ++it)
+  for (const auto & iface : ifaces)
+    for (const auto & elem : iface->_elems)
     {
-      Elem * elem = *it;
       _subproblem.assembly(0).reinit(elem);
 
       for (unsigned int qp = 0; qp < qpoints.size(); qp++)
         (*_mesh.getQuadratureNode(elem, 0, qp)) = qpoints[qp];
     }
-  }
 }
 
 void
@@ -487,9 +433,8 @@ GeometricSearchData::reinitMortarNodes()
   _mortar_boundaries.clear();
   // Regenerate the quadrature nodes for mortar spaces
   std::vector<MooseMesh::MortarInterface *> & ifaces = _mesh.getMortarInterfaces();
-  for (std::vector<MooseMesh::MortarInterface *>::iterator it = ifaces.begin(); it != ifaces.end(); ++it)
+  for (const auto & iface : ifaces)
   {
-    MooseMesh::MortarInterface * iface = *it;
     unsigned int master_id = _mesh.getBoundaryID(iface->_master);
     unsigned int slave_id  = _mesh.getBoundaryID(iface->_slave);
     generateMortarNodes(master_id, slave_id, 0);

--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -116,9 +116,8 @@ NearestNodeLocator::findNodes()
 
     // Data structures to hold the Nodal Boundary conditions
     ConstBndNodeRange & bnd_nodes = *_mesh.getBoundaryNodeRange();
-    for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin() ; nd != bnd_nodes.end(); ++nd)
+    for (const auto & bnode : bnd_nodes)
     {
-      const BndNode * bnode = *nd;
       BoundaryID boundary_id = bnode->_bnd_id;
       dof_id_type node_id = bnode->_node->id();
 
@@ -146,10 +145,8 @@ NearestNodeLocator::findNodes()
     _slave_nodes = snt._slave_nodes;
     _neighbor_nodes = snt._neighbor_nodes;
 
-    for (std::set<dof_id_type>::iterator it = snt._ghosted_elems.begin();
-        it != snt._ghosted_elems.end();
-        ++it)
-      _subproblem.addGhostedElem(*it);
+    for (const auto & dof : snt._ghosted_elems)
+      _subproblem.addGhostedElem(dof);
 
     // Cache the slave_node_range so we don't have to build it each time
     _slave_node_range = new NodeIdRange(_slave_nodes.begin(), _slave_nodes.end(), 1);

--- a/framework/src/geomsearch/NearestNodeThread.C
+++ b/framework/src/geomsearch/NearestNodeThread.C
@@ -42,10 +42,8 @@ NearestNodeThread::NearestNodeThread(NearestNodeThread & x, Threads::split /*spl
 void
 NearestNodeThread::operator() (const NodeIdRange & range)
 {
-  for (NodeIdRange::const_iterator nd = range.begin() ; nd != range.end(); ++nd)
+  for (const auto & node_id : range)
   {
-    dof_id_type node_id = *nd;
-
     const Node & node = _mesh.nodeRef(node_id);
 
     const Node * closest_node = NULL;

--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -68,8 +68,8 @@ PenetrationLocator::~PenetrationLocator()
     for (unsigned int dim = 0; dim < _fe[i].size(); dim++)
       delete _fe[i][dim];
 
-  for (std::map<dof_id_type, PenetrationInfo *>::iterator it = _penetration_info.begin(); it != _penetration_info.end(); ++it)
-    delete it->second;
+  for (auto & it : _penetration_info)
+    delete it.second;
 }
 
 void

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -67,10 +67,8 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
 {
   processor_id_type processor_id = _mesh.processor_id();
 
-  for (NodeIdRange::const_iterator nd = range.begin() ; nd != range.end(); ++nd)
+  for (const auto & node_id : range)
   {
-    dof_id_type node_id = *nd;
-
     const Node & node = *_mesh.nodePtr(node_id);
 
     std::priority_queue<std::pair<unsigned int, Real>, std::vector<std::pair<unsigned int, Real> >, ComparePair> neighbors;
@@ -118,8 +116,8 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       { // See if we own any of the elements connected to the slave node
         const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[node_id];
 
-        for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
-          if (_mesh.elemPtr(elems_connected_to_node[elem_id_it])->processor_id() == processor_id)
+        for (const auto & dof : elems_connected_to_node)
+          if (_mesh.elemPtr(dof)->processor_id() == processor_id)
           {
             need_to_track = true;
             break; // Break out of element loop
@@ -128,18 +126,16 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
 
       if (!need_to_track)
       { // Now check the neighbor nodes to see if we own any of them
-        for (unsigned int neighbor_it=0; neighbor_it < neighbor_nodes.size(); neighbor_it++)
+        for (const auto & neighbor_node_id : neighbor_nodes)
         {
-          dof_id_type neighbor_node_id = neighbor_nodes[neighbor_it];
-
           if (_mesh.nodeRef(neighbor_node_id).processor_id() == processor_id)
             need_to_track = true;
           else // Now see if we own any of the elements connected to the neighbor nodes
           {
             const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[neighbor_node_id];
 
-            for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
-              if (_mesh.elemPtr(elems_connected_to_node[elem_id_it])->processor_id() == processor_id)
+            for (const auto & dof : elems_connected_to_node)
+              if (_mesh.elemPtr(dof)->processor_id() == processor_id)
               {
                 need_to_track = true;
                 break; // Break out of element loop
@@ -163,8 +159,8 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       { // Add the elements connected to the slave node to the ghosted list
         const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[node_id];
 
-        for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
-          _ghosted_elems.insert(elems_connected_to_node[elem_id_it]);
+        for (const auto & dof : elems_connected_to_node)
+          _ghosted_elems.insert(dof);
       }
 
       // Now add elements connected to the neighbor nodes to the ghosted list
@@ -172,8 +168,8 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       {
         const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[neighbor_nodes[neighbor_it]];
 
-        for (unsigned int elem_id_it=0; elem_id_it < elems_connected_to_node.size(); elem_id_it++)
-          _ghosted_elems.insert(elems_connected_to_node[elem_id_it]);
+        for (const auto & dof : elems_connected_to_node)
+          _ghosted_elems.insert(dof);
       }
     }
   }

--- a/framework/src/ics/FunctionScalarIC.C
+++ b/framework/src/ics/FunctionScalarIC.C
@@ -31,8 +31,8 @@ FunctionScalarIC::FunctionScalarIC(const InputParameters & parameters) :
   if (funcs.size() != _ncomp)
     mooseError("number of functions must be equal to the scalar variable order");
 
-  for (unsigned int i = 0; i < funcs.size(); ++i)
-    _func.push_back(&getFunctionByName(funcs[i]));
+  for (const auto & func_name : funcs)
+    _func.push_back(&getFunctionByName(func_name));
 }
 
 Real

--- a/framework/src/ics/InitialCondition.C
+++ b/framework/src/ics/InitialCondition.C
@@ -61,9 +61,9 @@ InitialCondition::InitialCondition(const InputParameters & parameters) :
   _supplied_vars.insert(getParam<VariableName>("variable"));
 
   std::map<std::string, std::vector<MooseVariable *> > coupled_vars = getCoupledVars();
-  for (std::map<std::string, std::vector<MooseVariable *> >::iterator it = coupled_vars.begin(); it != coupled_vars.end(); ++it)
-    for (std::vector<MooseVariable *>::iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2)
-      _depend_vars.insert((*it2)->name());
+  for (const auto & it : coupled_vars)
+    for (const auto & var : it.second)
+      _depend_vars.insert(var->name());
 }
 
 InitialCondition::~InitialCondition()

--- a/framework/src/ics/InitialConditionWarehouse.C
+++ b/framework/src/ics/InitialConditionWarehouse.C
@@ -26,9 +26,8 @@ void
 InitialConditionWarehouse::initialSetup(THREAD_ID tid)
 {
   MooseObjectWarehouseBase<InitialCondition>::sort(tid);
-  std::vector<MooseSharedPointer<InitialCondition> >::const_iterator it;
-  for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    (*it)->initialSetup();
+  for (const auto & ic : _active_objects[tid])
+    ic->initialSetup();
 }
 
 

--- a/framework/src/ics/ScalarInitialCondition.C
+++ b/framework/src/ics/ScalarInitialCondition.C
@@ -43,8 +43,8 @@ ScalarInitialCondition::ScalarInitialCondition(const InputParameters & parameter
   _supplied_vars.insert(getParam<VariableName>("variable"));
 
   const std::vector<MooseVariableScalar *> & coupled_vars = getCoupledMooseScalarVars();
-  for (std::vector<MooseVariableScalar *>::const_iterator it = coupled_vars.begin(); it != coupled_vars.end(); ++it)
-    _depend_vars.insert((*it)->name());
+  for (const auto & var : coupled_vars)
+    _depend_vars.insert(var->name());
 }
 
 ScalarInitialCondition::~ScalarInitialCondition()

--- a/framework/src/indicators/ElementIndicator.C
+++ b/framework/src/indicators/ElementIndicator.C
@@ -61,8 +61,8 @@ ElementIndicator::ElementIndicator(const InputParameters & parameters) :
     _du_dot_du(_var.duDotDu())
 {
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 
   addMooseVariableDependency(mooseVariable());
 }

--- a/framework/src/indicators/InternalSideIndicator.C
+++ b/framework/src/indicators/InternalSideIndicator.C
@@ -74,8 +74,8 @@ InternalSideIndicator::InternalSideIndicator(const InputParameters & parameters)
     _grad_u_neighbor(_var.gradSlnNeighbor())
 {
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 
   addMooseVariableDependency(mooseVariable());
 }

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -95,8 +95,8 @@ EigenKernel::computeResidual()
   if (_has_save_in)
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (unsigned int i=0; i<_save_in.size(); i++)
-      _save_in[i]->sys().solution().add_vector(_local_re, _save_in[i]->dofIndices());
+    for (const auto & var : _save_in)
+      var->sys().solution().add_vector(_local_re, var->dofIndices());
   }
 }
 

--- a/framework/src/kernels/FDKernel.C
+++ b/framework/src/kernels/FDKernel.C
@@ -75,25 +75,27 @@ FDKernel::computeOffDiagJacobian(unsigned int jvar_index)
   // FIXME: pull out the already computed element residual instead of recomputing it
   Real h;
   DenseVector<Number> re = perturbedResidual(_var.number(),0,0.0,h);
-  for (_j = 0; _j < _phi.size(); _j++) {
+  for (_j = 0; _j < _phi.size(); _j++)
+  {
     DenseVector<Number> p_re = perturbedResidual(jvar_index,_j,_scale,h);
-    for (_i = 0; _i < _test.size(); _i++) {
+    for (_i = 0; _i < _test.size(); _i++)
       local_ke(_i,_j) = (p_re(_i) - re(_i))/h;
-    }
   }
   ke += local_ke;
 
-  if (jvar_index == _var.number()) {
+  if (jvar_index == _var.number())
+  {
     _local_ke = local_ke;
-    if (_has_diag_save_in) {
+    if (_has_diag_save_in)
+    {
       unsigned int rows = ke.m();
       DenseVector<Number> diag(rows);
       for (unsigned int i=0; i<rows; i++)
-  diag(i) = _local_ke(i,i);
+        diag(i) = _local_ke(i, i);
 
       Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-      for (unsigned int i=0; i<_diag_save_in.size(); i++)
-  _diag_save_in[i]->sys().solution().add_vector(diag, _diag_save_in[i]->dofIndices());
+      for (const auto & var : _diag_save_in)
+        var->sys().solution().add_vector(diag, var->dofIndices());
     }
   }
 }

--- a/framework/src/kernels/Kernel.C
+++ b/framework/src/kernels/Kernel.C
@@ -61,8 +61,8 @@ Kernel::computeResidual()
   if (_has_save_in)
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (unsigned int i=0; i<_save_in.size(); i++)
-      _save_in[i]->sys().solution().add_vector(_local_re, _save_in[i]->dofIndices());
+    for (const auto & var : _save_in)
+      var->sys().solution().add_vector(_local_re, var->dofIndices());
   }
 }
 
@@ -88,8 +88,8 @@ Kernel::computeJacobian()
       diag(i) = _local_ke(i,i);
 
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (unsigned int i=0; i<_diag_save_in.size(); i++)
-      _diag_save_in[i]->sys().solution().add_vector(diag, _diag_save_in[i]->dofIndices());
+    for (const auto & var : _diag_save_in)
+      var->sys().solution().add_vector(diag, var->dofIndices());
   }
 }
 
@@ -105,9 +105,7 @@ Kernel::computeOffDiagJacobian(unsigned int jvar)
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < _phi.size(); _j++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-        {
           ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
-        }
   }
 }
 

--- a/framework/src/kernels/KernelGrad.C
+++ b/framework/src/kernels/KernelGrad.C
@@ -57,8 +57,8 @@ KernelGrad::computeResidual()
   if (_has_save_in)
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (unsigned int i = 0; i < _save_in.size(); i++)
-      _save_in[i]->sys().solution().add_vector(_local_re, _save_in[i]->dofIndices());
+    for (const auto & var : _save_in)
+      var->sys().solution().add_vector(_local_re, var->dofIndices());
   }
 }
 
@@ -88,8 +88,8 @@ KernelGrad::computeJacobian()
       diag(i) = _local_ke(i,i);
 
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (unsigned int i = 0; i < _diag_save_in.size(); i++)
-      _diag_save_in[i]->sys().solution().add_vector(diag, _diag_save_in[i]->dofIndices());
+    for (const auto & var : _diag_save_in)
+      var->sys().solution().add_vector(diag, var->dofIndices());
   }
 }
 

--- a/framework/src/kernels/KernelValue.C
+++ b/framework/src/kernels/KernelValue.C
@@ -57,8 +57,8 @@ KernelValue::computeResidual()
   if (_has_save_in)
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (unsigned int i=0; i<_save_in.size(); i++)
-      _save_in[i]->sys().solution().add_vector(_local_re, _save_in[i]->dofIndices());
+    for (const auto & var : _save_in)
+      var->sys().solution().add_vector(_local_re, var->dofIndices());
   }
 }
 
@@ -88,8 +88,8 @@ KernelValue::computeJacobian()
       diag(i) = _local_ke(i,i);
 
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (unsigned int i = 0; i < _diag_save_in.size(); i++)
-      _diag_save_in[i]->sys().solution().add_vector(diag, _diag_save_in[i]->dofIndices());
+    for (const auto & var : _diag_save_in)
+      var->sys().solution().add_vector(diag, var->dofIndices());
   }
 }
 

--- a/framework/src/kernels/KernelWarehouse.C
+++ b/framework/src/kernels/KernelWarehouse.C
@@ -59,7 +59,6 @@ KernelWarehouse::updateActive(THREAD_ID tid)
 {
   MooseObjectWarehouse<KernelBase>::updateActive(tid);
 
-  std::map<unsigned int, MooseObjectWarehouse<KernelBase> >::iterator it;
-  for (it = _variable_kernel_storage.begin(); it != _variable_kernel_storage.end(); ++it)
-    it->second.updateActive(tid);
+  for (auto & it : _variable_kernel_storage)
+    it.second.updateActive(tid);
 }

--- a/framework/src/kernels/NodalScalarKernel.C
+++ b/framework/src/kernels/NodalScalarKernel.C
@@ -32,8 +32,8 @@ NodalScalarKernel::NodalScalarKernel(const InputParameters & parameters) :
 {
   // Fill in the MooseVariable dependencies
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 }
 
 NodalScalarKernel::~NodalScalarKernel()

--- a/framework/src/kernels/ODEKernel.C
+++ b/framework/src/kernels/ODEKernel.C
@@ -56,11 +56,8 @@ ODEKernel::computeJacobian()
 
   // compute off-diagonal jacobians wrt scalar variables
   const std::vector<MooseVariableScalar *> & scalar_vars = _sys.getScalarVariables(_tid);
-  for (std::vector<MooseVariableScalar *>::const_iterator it = scalar_vars.begin(); it != scalar_vars.end(); ++it)
-  {
-    MooseVariableScalar * jvar = *it;
-    computeOffDiagJacobian(jvar->number());
-  }
+  for (const auto & var : scalar_vars)
+    computeOffDiagJacobian(var->number());
 }
 
 void

--- a/framework/src/markers/ComboMarker.C
+++ b/framework/src/markers/ComboMarker.C
@@ -27,8 +27,8 @@ ComboMarker::ComboMarker(const InputParameters & parameters) :
     Marker(parameters),
     _names(parameters.get<std::vector<MarkerName> >("markers"))
 {
-  for (unsigned int i=0; i<_names.size(); i++)
-    _markers.push_back(&getMarkerValue(_names[i]));
+  for (const auto & marker_name : _names)
+    _markers.push_back(&getMarkerValue(marker_name));
 }
 
 Marker::MarkerValue
@@ -37,8 +37,9 @@ ComboMarker::computeElementMarker()
   // We start with DONT_MARK because it's -1
   MarkerValue marker_value = DONT_MARK;
 
-  for (unsigned int i=0; i<_markers.size(); i++)
-    marker_value = std::max(marker_value, (MarkerValue)(*_markers[i])[0]);
+  for (const auto & var : _markers)
+    marker_value = std::max(marker_value,
+                            static_cast<MarkerValue>((*var)[0]));
 
   return marker_value;
 }

--- a/framework/src/markers/ErrorFractionMarker.C
+++ b/framework/src/markers/ErrorFractionMarker.C
@@ -43,10 +43,10 @@ ErrorFractionMarker::markerSetup()
   _max = 0;
 
   // First find the max and min error
-  for (unsigned int i=0; i<_error_vector.size(); i++)
+  for (const auto & val : _error_vector)
   {
-    _min = std::min(_min, static_cast<Real>(_error_vector[i]));
-    _max = std::max(_max, static_cast<Real>(_error_vector[i]));
+    _min = std::min(_min, static_cast<Real>(val));
+    _max = std::max(_max, static_cast<Real>(val));
   }
 
   _delta = _max-_min;

--- a/framework/src/markers/QuadraturePointMarker.C
+++ b/framework/src/markers/QuadraturePointMarker.C
@@ -44,8 +44,8 @@ QuadraturePointMarker::QuadraturePointMarker(const InputParameters & parameters)
     _qp(0)
 {
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 }
 
 Marker::MarkerValue

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -90,8 +90,8 @@ Material::Material(const InputParameters & parameters) :
 {
   // Fill in the MooseVariable dependencies
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 }
 
 
@@ -113,11 +113,9 @@ Material::initQpStatefulProperties()
 void
 Material::checkStatefulSanity() const
 {
-  for (std::map<std::string, int>::const_iterator it = _props_to_flags.begin(); it != _props_to_flags.end(); ++it)
-  {
-    if (static_cast<int>(it->second) % 2 == 0) // Only Stateful properties declared!
-      mooseError("Material '" << name() << "' has stateful properties declared but not associated \"current\" properties." << it->second);
-  }
+  for (const auto & it : _props_to_flags)
+    if (static_cast<int>(it.second) % 2 == 0) // Only Stateful properties declared!
+      mooseError("Material '" << name() << "' has stateful properties declared but not associated \"current\" properties." << it.second);
 }
 
 
@@ -132,21 +130,21 @@ Material::registerPropName(std::string prop_name, bool is_get, Material::Prop_St
   }
 
   // Store material properties for block ids
-  for (std::set<SubdomainID>::const_iterator it = blockIDs().begin(); it != blockIDs().end(); ++it)
+  for (const auto & block_id : blockIDs())
   {
     // Only save this prop as a "supplied" prop is it was registered as a result of a call to declareProperty not getMaterialProperty
     if (!is_get)
       _supplied_props.insert(prop_name);
-    _fe_problem.storeMatPropName(*it, prop_name);
+    _fe_problem.storeMatPropName(block_id, prop_name);
   }
 
   // Store material properties for the boundary ids
-  for (std::set<BoundaryID>::const_iterator it = boundaryIDs().begin(); it != boundaryIDs().end(); ++it)
+  for (const auto & boundary_id : boundaryIDs())
   {
     // Only save this prop as a "supplied" prop is it was registered as a result of a call to declareProperty not getMaterialProperty
     if (!is_get)
       _supplied_props.insert(prop_name);
-    _fe_problem.storeMatPropName(*it, prop_name);
+    _fe_problem.storeMatPropName(boundary_id, prop_name);
   }
 }
 

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -76,15 +76,15 @@ MaterialData::swap(const Elem & elem, unsigned int side/* = 0*/)
 void
 MaterialData::reinit(const std::vector<MooseSharedPointer<Material> > & mats)
 {
-  for (std::vector<MooseSharedPointer<Material> >::const_iterator it = mats.begin(); it != mats.end(); ++it)
-    (*it)->computeProperties();
+  for (const auto & mat : mats)
+    mat->computeProperties();
 }
 
 void
 MaterialData::reset(const std::vector<MooseSharedPointer<Material> > & mats)
 {
-  for (std::vector<MooseSharedPointer<Material> >::const_iterator it = mats.begin(); it != mats.end(); ++it)
-    (*it)->resetProperties();
+  for (const auto & mat : mats)
+    mat->resetProperties();
 }
 
 void

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -127,7 +127,7 @@ MaterialPropertyInterface::defaultMaterialProperty(const std::string & name)
 
     // set values for all qpoints to the given default
     for (unsigned int qp = 0; qp < nqp; ++qp)
-    (*default_property)[qp] = real_value;
+      (*default_property)[qp] = real_value;
 
     // add to the default property storage
     _default_real_properties.push_back(default_property);
@@ -167,13 +167,13 @@ MaterialPropertyInterface::checkMaterialProperty(const std::string & name)
 {
   // If the material property is block restrictable, add to the list of materials to check
   if (!_mi_block_ids.empty())
-    for (std::set<SubdomainID>::const_iterator it = _mi_block_ids.begin(); it != _mi_block_ids.end(); ++it)
-      _mi_feproblem.storeDelayedCheckMatProp(_mi_name, *it, name);
+    for (const auto & sbd_id : _mi_block_ids)
+      _mi_feproblem.storeDelayedCheckMatProp(_mi_name, sbd_id, name);
 
   // If the material property is boundary restrictable, add to the list of materials to check
   if (!_mi_boundary_ids.empty())
-    for (std::set<BoundaryID>::const_iterator it = _mi_boundary_ids.begin(); it != _mi_boundary_ids.end(); ++it)
-      _mi_feproblem.storeDelayedCheckMatProp(_mi_name, *it, name);
+    for (const auto & bnd_id : _mi_boundary_ids)
+      _mi_feproblem.storeDelayedCheckMatProp(_mi_name, bnd_id, name);
 }
 
 void
@@ -207,12 +207,12 @@ MaterialPropertyInterface::getMaterialByName(const std::string & name)
     std::ostringstream oss;
     oss << "The Material object '" << discrete->name() << "' is defined on blocks that are incompatible with the retrieving object '" << _mi_name << "':\n";
     oss << "  " << discrete->name();
-    for (std::set<SubdomainID>::const_iterator it = discrete->blockIDs().begin(); it != discrete->blockIDs().end(); ++it)
-      oss << " " << *it;
+    for (const auto & sbd_id : discrete->blockIDs())
+      oss << " " << sbd_id;
     oss << "\n";
     oss << "  " << _mi_name;
-    for (std::set<SubdomainID>::const_iterator it = _mi_block_ids.begin(); it != _mi_block_ids.end(); ++it)
-      oss << " " << *it;
+    for (const auto & block_id : _mi_block_ids)
+      oss << " " << block_id;
     oss << "\n";
     mooseError(oss.str());
   }
@@ -223,12 +223,12 @@ MaterialPropertyInterface::getMaterialByName(const std::string & name)
     std::ostringstream oss;
     oss << "The Material object '" << discrete->name() << "' is defined on boundaries that are incompatible with the retrieving object '" << _mi_name << "':\n";
     oss << "  " << discrete->name();
-    for (std::set<BoundaryID>::const_iterator it = discrete->boundaryIDs().begin(); it != discrete->boundaryIDs().end(); ++it)
-      oss << " " << *it;
+    for (const auto & bnd_id : discrete->boundaryIDs())
+      oss << " " << bnd_id;
     oss << "\n";
     oss << "  " << _mi_name;
-    for (std::set<BoundaryID>::const_iterator it = _mi_boundary_ids.begin(); it != _mi_boundary_ids.end(); ++it)
-      oss << " " << *it;
+    for (const auto & bnd_id : _mi_boundary_ids)
+      oss << " " << bnd_id;
     oss << "\n";
     mooseError(oss.str());
   }

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -72,31 +72,29 @@ MaterialPropertyStorage::~MaterialPropertyStorage()
 void
 MaterialPropertyStorage::releaseProperties()
 {
-  HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> >::iterator i;
-  for (i = _props_elem->begin(); i != _props_elem->end(); ++i)
-  {
-    HashMap<unsigned int, MaterialProperties>::iterator j;
-    for (j = i->second.begin(); j != i->second.end(); ++j)
-      j->second.destroy();
-  }
+  for (auto & i : *_props_elem)
+    for (auto & j : i.second)
+      j.second.destroy();
 
-  for (i = _props_elem_old->begin(); i != _props_elem_old->end(); ++i)
-  {
-    HashMap<unsigned int, MaterialProperties>::iterator j;
-    for (j = i->second.begin(); j != i->second.end(); ++j)
-      j->second.destroy();
-  }
+  for (auto & i : *_props_elem_old)
+    for (auto & j : i.second)
+      j.second.destroy();
 
-  for (i = _props_elem_older->begin(); i != _props_elem_older->end(); ++i)
-  {
-    HashMap<unsigned int, MaterialProperties>::iterator j;
-    for (j = i->second.begin(); j != i->second.end(); ++j)
-      j->second.destroy();
-  }
+  for (auto & i : *_props_elem_older)
+    for (auto & j : i.second)
+      j.second.destroy();
 }
 
 void
-MaterialPropertyStorage::prolongStatefulProps(const std::vector<std::vector<QpMap> > & refinement_map, QBase & qrule, QBase & qrule_face, MaterialPropertyStorage & parent_material_props, MaterialData & child_material_data, const Elem & elem, const int input_parent_side, const int input_child, const int input_child_side)
+MaterialPropertyStorage::prolongStatefulProps(const std::vector<std::vector<QpMap> > & refinement_map,
+                                              QBase & qrule,
+                                              QBase & qrule_face,
+                                              MaterialPropertyStorage & parent_material_props,
+                                              MaterialData & child_material_data,
+                                              const Elem & elem,
+                                              const int input_parent_side,
+                                              const int input_child,
+                                              const int input_child_side)
 {
   mooseAssert(input_child != -1 || input_parent_side == input_child_side, "Invalid inputs!");
 
@@ -126,10 +124,8 @@ MaterialPropertyStorage::prolongStatefulProps(const std::vector<std::vector<QpMa
       children[child] = child;
   }
 
-  for (unsigned int i=0; i < children.size(); i++)
+  for (const auto & child : children)
   {
-    unsigned int child = children[i];
-
     // If we're not projecting an internal child side, but we are projecting sides, see if this child is on that side
     if (input_child == -1 && input_child_side != -1 && !elem.is_child_on_side(child, parent_side))
       continue;
@@ -172,7 +168,13 @@ MaterialPropertyStorage::prolongStatefulProps(const std::vector<std::vector<QpMa
 
 
 void
-MaterialPropertyStorage::restrictStatefulProps(const std::vector<std::pair<unsigned int, QpMap> > & coarsening_map, std::vector<const Elem *> & coarsened_element_children, QBase & qrule, QBase & qrule_face, MaterialData & material_data, const Elem & elem, int input_side)
+MaterialPropertyStorage::restrictStatefulProps(const std::vector<std::pair<unsigned int, QpMap> > & coarsening_map,
+                                               std::vector<const Elem *> & coarsened_element_children,
+                                               QBase & qrule,
+                                               QBase & qrule_face,
+                                               MaterialData & material_data,
+                                               const Elem & elem,
+                                               int input_side)
 {
   unsigned int side;
 
@@ -263,8 +265,8 @@ MaterialPropertyStorage::initStatefulProps(MaterialData & material_data, const s
   // copy from storage to material data
   swap(material_data, elem, side);
   // run custom init on properties
-  for (std::vector<MooseSharedPointer<Material> >::const_iterator it = mats.begin(); it != mats.end(); ++it)
-    (*it)->initStatefulProperties(n_qpoints);
+  for (const auto & mat : mats)
+    mat->initStatefulProperties(n_qpoints);
   swapBack(material_data, elem, side);
 
   // Copy the properties to Old and Older as needed

--- a/framework/src/mesh/ImageMesh.C
+++ b/framework/src/mesh/ImageMesh.C
@@ -95,12 +95,12 @@ ImageMesh::buildMesh3D(const std::vector<std::string> & filenames)
   // TODO: Check that all images are the same aspect ratio and have
   // the same number of pixels?  ImageFunction does not currently do
   // this...
-  // for (unsigned i = 0; i < filenames.size(); ++i)
+  // for (const auto & filename : filenames)
   // {
   //   // Extract the number of pixels from the image using the file command
-  //   GetPixelInfo(filenames[i], xpixels, ypixels);
+  //   GetPixelInfo(filename, xpixels, ypixels);
   //
-  //   // Moose::out << "Image " << filenames[i] << " has size: " << xpixels << " by " << ypixels << std::endl;
+  //   // Moose::out << "Image " << filename << " has size: " << xpixels << " by " << ypixels << std::endl;
   // }
 
   // Use the number of x and y pixels and the number of images to

--- a/framework/src/meshmodifiers/AddExtraNodeset.C
+++ b/framework/src/meshmodifiers/AddExtraNodeset.C
@@ -65,9 +65,9 @@ AddExtraNodeset::modify()
 
   // add nodes with their ids
   const std::vector<unsigned int> & nodes = getParam<std::vector<unsigned int> >("nodes");
-  for (unsigned int i = 0; i < nodes.size(); i++)
-    for (unsigned int j = 0; j < boundary_ids.size(); ++j)
-      boundary_info.add_node(nodes[i], boundary_ids[j]);
+  for (const auto & node_id : nodes)
+    for (const auto & boundary_id : boundary_ids)
+      boundary_info.add_node(node_id, boundary_id);
 
   // add nodes with their coordinates
   const std::vector<Real> & coord = getParam<std::vector<Real> >("coord");
@@ -95,8 +95,8 @@ AddExtraNodeset::modify()
 
       if (p.absolute_fuzzy_equals(q, getParam<Real>("tolerance")))
       {
-        for (unsigned int j = 0; j < boundary_ids.size(); ++j)
-          boundary_info.add_node(node, boundary_ids[j]);
+        for (const auto & boundary_id : boundary_ids)
+          boundary_info.add_node(node, boundary_id);
 
         on_node = true;
         break;

--- a/framework/src/meshmodifiers/AssignElementSubdomainID.C
+++ b/framework/src/meshmodifiers/AssignElementSubdomainID.C
@@ -50,9 +50,9 @@ AssignElementSubdomainID::modify()
   if (isParamValid("element_ids"))
   {
     std::vector<dof_id_type> elemids = getParam<std::vector<dof_id_type> >("element_ids");
-    for (dof_id_type i = 0; i < elemids.size(); ++i)
+    for (const auto & dof : elemids)
     {
-      Elem * elem = mesh.query_elem_ptr(elemids[i]);
+      Elem * elem = mesh.query_elem_ptr(dof);
       if (!elem)
         mooseError("invalid element ID is in element_ids");
       else
@@ -83,27 +83,27 @@ AssignElementSubdomainID::modify()
   std::map<ElemType, std::set<SubdomainID> > type2blocks;
   for (dof_id_type e = 0; e<elements.size(); ++e)
   {
-    Elem* elem = elements[e];
+    Elem * elem = elements[e];
     ElemType type = elem->type();
     SubdomainID newid = bids[e];
 
     bool has_type = false;
-    for (std::map<ElemType, std::set<SubdomainID> >::iterator it = type2blocks.begin(); it != type2blocks.end(); ++it)
+    for (auto & it : type2blocks)
     {
-      if (it->first == type)
+      if (it.first == type)
       {
         has_type = true;
-        it->second.insert(newid);
+        it.second.insert(newid);
       }
-      else
-        if (it->second.count(newid)>0)
-          mooseError("trying to assign elements with different types with the same subdomain ID");
+      else if (it.second.count(newid) > 0)
+        mooseError("trying to assign elements with different types with the same subdomain ID");
     }
+
     if (!has_type)
     {
       std::set<SubdomainID> blocks;
       blocks.insert(newid);
-      type2blocks.insert(std::pair<ElemType, std::set<SubdomainID> >(type, blocks));
+      type2blocks.insert(std::make_pair(type, blocks));
     }
 
     elem->subdomain_id() = newid;

--- a/framework/src/meshmodifiers/BoundingBoxNodeSet.C
+++ b/framework/src/meshmodifiers/BoundingBoxNodeSet.C
@@ -71,8 +71,8 @@ BoundingBoxNodeSet::modify()
         {
           const Node * node = elem->node_ptr(j);
 
-          for (unsigned int j = 0; j < boundary_ids.size(); ++j)
-            boundary_info.add_node(node, boundary_ids[j]);
+          for (const auto & boundary_id : boundary_ids)
+            boundary_info.add_node(node, boundary_id);
 
           found_node = true;
         }

--- a/framework/src/meshmodifiers/ElementDeleterBase.C
+++ b/framework/src/meshmodifiers/ElementDeleterBase.C
@@ -53,8 +53,8 @@ ElementDeleterBase::modify()
    * TODO: We need to sort these not because they have to be deleted in a certain order in libMesh,
    *       but because the order of deletion might impact what happens to any existing sidesets or nodesets.
    */
-  for (std::set<Elem *>::const_iterator it = deleteable_elems.begin(); it != deleteable_elems.end(); ++it)
-    mesh.delete_elem(*it);
+  for (const auto & elem : deleteable_elems)
+    mesh.delete_elem(elem);
 
   /**
    * Deleting nodes and elements leaves NULLs in the mesh datastructure. We need to get rid of those.

--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -115,8 +115,8 @@ SideSetsAroundSubdomain::modify()
 
           // Add the boundaries, if appropriate
           if (add_to_bdy)
-            for (unsigned int i = 0; i < boundary_ids.size(); ++i)
-              boundary_info.add_side(elem, side, boundary_ids[i]);
+            for (const auto & boundary_id : boundary_ids)
+              boundary_info.add_side(elem, side, boundary_id);
         }
     }
   }

--- a/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
+++ b/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
@@ -67,8 +67,8 @@ SideSetsBetweenSubdomains::modify()
       if (neighbor != NULL && neighbor->subdomain_id() == paired_id)  // is this side between the two blocks?
 
         // Add the boundaries
-        for (unsigned int i=0; i<boundary_ids.size(); ++i)
-          boundary_info.add_side(elem, side, boundary_ids[i]);
+        for (const auto & boundary_id : boundary_ids)
+          boundary_info.add_side(elem, side, boundary_id);
     }
   }
 

--- a/framework/src/meshmodifiers/SideSetsFromNormals.C
+++ b/framework/src/meshmodifiers/SideSetsFromNormals.C
@@ -46,10 +46,10 @@ SideSetsFromNormals::SideSetsFromNormals(const InputParameters & parameters) :
     mooseError("normal list and boundary list are not the same length");
 
   // Make sure that the normals are normalized
-  for (std::vector<Point>::iterator normal_it = _normals.begin(); normal_it != _normals.end(); ++normal_it)
+  for (auto & normal : _normals)
   {
-    mooseAssert(normal_it->norm() >= 1e-5, "Normal is zero");
-    *normal_it /= normal_it->norm();
+    mooseAssert(normal.norm() >= 1e-5, "Normal is zero");
+    normal /= normal.norm();
   }
 }
 

--- a/framework/src/multiapps/AutoPositionsMultiApp.C
+++ b/framework/src/multiapps/AutoPositionsMultiApp.C
@@ -48,18 +48,14 @@ AutoPositionsMultiApp::fillPositions()
 
   const std::set<BoundaryID> & bids = boundaryIDs();
 
-  for (std::set<BoundaryID>::iterator bid_it = bids.begin();
-       bid_it != bids.end();
-       ++bid_it)
+  for (const auto & boundary_id : bids)
   {
-    BoundaryID boundary_id = *bid_it;
-
     // Grab the nodes on the boundary ID and add a Sub-App at each one.
     const std::vector<dof_id_type> & boundary_node_ids = master_mesh.getNodeList(boundary_id);
 
-    for (unsigned int i=0; i<boundary_node_ids.size(); i++)
+    for (const auto & boundary_node_id : boundary_node_ids)
     {
-      Node & node = master_mesh.nodeRef(boundary_node_ids[i]);
+      Node & node = master_mesh.nodeRef(boundary_node_id);
 
       _positions.push_back(node);
     }

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -250,8 +250,8 @@ MultiApp::preTransfer(Real /*dt*/, Real target_time)
   if (!_reset_happened && target_time + 1e-14 >= _reset_time)
   {
     _reset_happened = true;
-    for (unsigned int i=0; i<_reset_apps.size(); i++)
-      resetApp(_reset_apps[i]);
+    for (auto & app : _reset_apps)
+      resetApp(app);
   }
 
   // Now move any apps that should be moved

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -243,12 +243,8 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
             transfer.close();
             transfer_old.close();
 
-            std::set<dof_id_type>::iterator it  = _transferred_dofs.begin();
-            std::set<dof_id_type>::iterator end = _transferred_dofs.end();
-
-            for (; it != end; ++it)
+            for (const auto & dof : _transferred_dofs)
             {
-              dof_id_type dof = *it;
               solution.set(dof, (transfer_old(dof) * one_minus_step_percent) + (transfer(dof) * step_percent));
 //            solution.set(dof, transfer_old(dof));
 //            solution.set(dof, transfer(dof));

--- a/framework/src/nodalkernels/NodalKernel.C
+++ b/framework/src/nodalkernels/NodalKernel.C
@@ -132,8 +132,8 @@ NodalKernel::computeResidual()
     if (_has_save_in)
     {
       Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-      for (unsigned int i=0; i<_save_in.size(); i++)
-        _save_in[i]->sys().solution().add(_save_in[i]->nodalDofIndex(), res);
+      for (const auto & var : _save_in)
+        var->sys().solution().add(var->nodalDofIndex(), res);
     }
   }
 }
@@ -152,8 +152,8 @@ NodalKernel::computeJacobian()
     if (_has_diag_save_in)
     {
       Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-      for (unsigned int i=0; i<_diag_save_in.size(); i++)
-        _diag_save_in[i]->sys().solution().add(_diag_save_in[i]->nodalDofIndex(), cached_val);
+      for (const auto & var : _diag_save_in)
+        var->sys().solution().add(var->nodalDofIndex(), cached_val);
     }
   }
 }

--- a/framework/src/nodalkernels/TimeNodalKernel.C
+++ b/framework/src/nodalkernels/TimeNodalKernel.C
@@ -40,8 +40,8 @@ TimeNodalKernel::computeResidual()
     if (_has_save_in)
     {
       Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-      for (unsigned int i=0; i<_save_in.size(); i++)
-        _save_in[i]->sys().solution().add(_save_in[i]->nodalDofIndex(), res);
+      for (const auto & var : _save_in)
+        var->sys().solution().add(var->nodalDofIndex(), res);
     }
   }
 }

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -184,12 +184,12 @@ AdvancedOutput<T>::initialSetup()
   }
 
   // Initialize the show/hide/output lists for each of the types of output
-  for (std::map<std::string, OutputData>::iterator it = _execute_data.begin(); it != _execute_data.end(); ++it)
-    initOutputList(it->second);
+  for (auto & it : _execute_data)
+    initOutputList(it.second);
 
   // Initialize the execution flags
-  for (std::map<std::string, MultiMooseEnum>::iterator it = T::_advanced_execute_on.begin(); it != T::_advanced_execute_on.end(); ++it)
-    initExecutionTypes(it->first, it->second);
+  for (auto & it : T::_advanced_execute_on)
+    initExecutionTypes(it.first, it.second);
 
   // Set the initialization flag
   T::_initialized = true;
@@ -416,8 +416,8 @@ bool
 AdvancedOutput<T>::hasOutput(const ExecFlagType & type)
 {
   // If any of the component outputs are true, then there is some output to perform
-  for (std::map<std::string, MultiMooseEnum>::const_iterator it = T::_advanced_execute_on.begin(); it != T::_advanced_execute_on.end(); ++it)
-    if (shouldOutput(it->first, type))
+  for (const auto & it : T::_advanced_execute_on)
+    if (shouldOutput(it.first, type))
       return true;
 
   // There is nothing to output
@@ -429,10 +429,10 @@ bool
 AdvancedOutput<T>::hasOutput()
 {
   // Test that variables exist for output AND that output execution flags are valid
-  for (std::map<std::string, OutputData>::const_iterator it = _execute_data.begin(); it != _execute_data.end(); ++it)
-    if (!(it->second).output.empty() &&
-        T::_advanced_execute_on.contains(it->first) &&
-        T::_advanced_execute_on[it->first].isValid())
+  for (const auto & it : _execute_data)
+    if (!(it.second).output.empty() &&
+        T::_advanced_execute_on.contains(it.first) &&
+        T::_advanced_execute_on[it.first].isValid())
       return true;
 
   // Test execution flags for non-variable output
@@ -462,20 +462,20 @@ AdvancedOutput<T>::initAvailableLists()
   std::vector<VariableName> variables = T::_problem_ptr->getVariableNames();
 
   // Loop through the variables and store the names in the correct available lists
-  for (std::vector<VariableName>::const_iterator it = variables.begin(); it != variables.end(); ++it)
+  for (const auto & var_name : variables)
   {
-    if (T::_problem_ptr->hasVariable(*it))
+    if (T::_problem_ptr->hasVariable(var_name))
     {
-      MooseVariable & var = T::_problem_ptr->getVariable(0, *it);
+      MooseVariable & var = T::_problem_ptr->getVariable(0, var_name);
       const FEType type = var.feType();
       if (type.order == CONSTANT)
-        _execute_data["elemental"].available.insert(*it);
+        _execute_data["elemental"].available.insert(var_name);
       else
-        _execute_data["nodal"].available.insert(*it);
+        _execute_data["nodal"].available.insert(var_name);
     }
 
-    else if (T::_problem_ptr->hasScalarVariable(*it))
-      _execute_data["scalars"].available.insert(*it);
+    else if (T::_problem_ptr->hasScalarVariable(var_name))
+      _execute_data["scalars"].available.insert(var_name);
   }
 }
 
@@ -511,47 +511,47 @@ AdvancedOutput<T>::initShowHideLists(const std::vector<VariableName> & show, con
     _execute_data.setHasShowList(true);
 
   // Populate the show lists
-  for (std::vector<VariableName>::const_iterator it = show.begin(); it != show.end(); ++it)
+  for (const auto & var_name : show)
   {
-    if (T::_problem_ptr->hasVariable(*it))
+    if (T::_problem_ptr->hasVariable(var_name))
     {
-      MooseVariable & var = T::_problem_ptr->getVariable(0, *it);
+      MooseVariable & var = T::_problem_ptr->getVariable(0, var_name);
       const FEType type = var.feType();
       if (type.order == CONSTANT)
-        _execute_data["elemental"].show.insert(*it);
+        _execute_data["elemental"].show.insert(var_name);
       else
-        _execute_data["nodal"].show.insert(*it);
+        _execute_data["nodal"].show.insert(var_name);
     }
-    else if (T::_problem_ptr->hasScalarVariable(*it))
-      _execute_data["scalars"].show.insert(*it);
-    else if (T::_problem_ptr->hasPostprocessor(*it))
-      _execute_data["postprocessors"].show.insert(*it);
-    else if (T::_problem_ptr->hasVectorPostprocessor(*it))
-      _execute_data["vector_postprocessors"].show.insert(*it);
+    else if (T::_problem_ptr->hasScalarVariable(var_name))
+      _execute_data["scalars"].show.insert(var_name);
+    else if (T::_problem_ptr->hasPostprocessor(var_name))
+      _execute_data["postprocessors"].show.insert(var_name);
+    else if (T::_problem_ptr->hasVectorPostprocessor(var_name))
+      _execute_data["vector_postprocessors"].show.insert(var_name);
     else
-      unknown.insert(*it);
+      unknown.insert(var_name);
   }
 
   // Populate the hide lists
-  for (std::vector<VariableName>::const_iterator it = hide.begin(); it != hide.end(); ++it)
+  for (const auto & var_name : hide)
   {
-    if (T::_problem_ptr->hasVariable(*it))
+    if (T::_problem_ptr->hasVariable(var_name))
     {
-      MooseVariable & var = T::_problem_ptr->getVariable(0, *it);
+      MooseVariable & var = T::_problem_ptr->getVariable(0, var_name);
       const FEType type = var.feType();
       if (type.order == CONSTANT)
-        _execute_data["elemental"].hide.insert(*it);
+        _execute_data["elemental"].hide.insert(var_name);
       else
-        _execute_data["nodal"].hide.insert(*it);
+        _execute_data["nodal"].hide.insert(var_name);
     }
-    else if (T::_problem_ptr->hasScalarVariable(*it))
-      _execute_data["scalars"].hide.insert(*it);
-    else if (T::_problem_ptr->hasPostprocessor(*it))
-      _execute_data["postprocessors"].hide.insert(*it);
-    else if (T::_problem_ptr->hasVectorPostprocessor(*it))
-      _execute_data["vector_postprocessors"].hide.insert(*it);
+    else if (T::_problem_ptr->hasScalarVariable(var_name))
+      _execute_data["scalars"].hide.insert(var_name);
+    else if (T::_problem_ptr->hasPostprocessor(var_name))
+      _execute_data["postprocessors"].hide.insert(var_name);
+    else if (T::_problem_ptr->hasVectorPostprocessor(var_name))
+      _execute_data["vector_postprocessors"].hide.insert(var_name);
     else
-      unknown.insert(*it);
+      unknown.insert(var_name);
   }
 
   // Error if an unknown variable or postprocessor is found

--- a/framework/src/outputs/CSV.C
+++ b/framework/src/outputs/CSV.C
@@ -102,22 +102,22 @@ CSV::output(const ExecFlagType & type)
 
   // Output each VectorPostprocessor's data to a file
   if (_write_vector_table)
-    for (std::map<std::string, FormattedTable>::iterator it = _vector_postprocessor_tables.begin(); it != _vector_postprocessor_tables.end(); ++it)
+    for (auto & it : _vector_postprocessor_tables)
     {
       std::ostringstream output;
-      output << _file_base << "_" << MooseUtils::shortName(it->first);
+      output << _file_base << "_" << MooseUtils::shortName(it.first);
       output << "_" << std::setw(_padding) << std::setprecision(0) << std::setfill('0') << std::right << timeStep() << ".csv";
 
       if (_set_delimiter)
-        it->second.setDelimiter(_delimiter);
-      it->second.setPrecision(_precision);
-      it->second.printCSV(output.str(), 1, _align);
+        it.second.setDelimiter(_delimiter);
+      it.second.setPrecision(_precision);
+      it.second.printCSV(output.str(), 1, _align);
 
       if (_time_data)
       {
         std::ostringstream filename;
-        filename << _file_base << "_" << MooseUtils::shortName(it->first) << "_time.csv";
-        _vector_postprocessor_time_tables[it->first].printCSV(filename.str());
+        filename << _file_base << "_" << MooseUtils::shortName(it.first) << "_time.csv";
+        _vector_postprocessor_time_tables[it.first].printCSV(filename.str());
       }
     }
 

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -165,8 +165,8 @@ Console::Console(const InputParameters & parameters) :
   // Append the common 'execute_on' to the setting for this object
   // This is unique to the Console object, all other objects inherit from the common options
   const MultiMooseEnum & common_execute_on = common_action->getParam<MultiMooseEnum>("execute_on");
-  for (MooseEnumIterator it = common_execute_on.begin(); it != common_execute_on.end(); ++it)
-    _execute_on.push_back(*it);
+  for (auto & mme : common_execute_on)
+    _execute_on.push_back(mme);
 
   // If --timing was used from the command-line, do nothing, all logs are enabled
   if (!_timing)

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -242,19 +242,19 @@ outputOutputInformation(MooseApp & app)
 
   const std::vector<Output *> outputs = app.getOutputWarehouse().getOutputs<Output>();
   oss << "Outputs:\n";
-  for (std::vector<Output *>::const_iterator it = outputs.begin(); it != outputs.end(); ++it)
+  for (const auto & out : outputs)
   {
     // Display the "execute_on" settings
-    const MultiMooseEnum & execute_on = (*it)->executeOn();
-    oss << "  " << std::setw(console_field_width-2) << (*it)->name() <<  "\"" << execute_on << "\"\n";
+    const MultiMooseEnum & execute_on = out->executeOn();
+    oss << "  " << std::setw(console_field_width-2) << out->name() <<  "\"" << execute_on << "\"\n";
 
     // Display the advanced "execute_on" settings, only if they are different from "execute_on"
-    if ((*it)->isAdvanced())
+    if (out->isAdvanced())
     {
-      const OutputOnWarehouse & adv_on = (*it)->advancedExecuteOn();
-      for (std::map<std::string, MultiMooseEnum>::const_iterator adv_it = adv_on.begin(); adv_it != adv_on.end(); ++adv_it)
-        if (execute_on != adv_it->second)
-          oss << "    " << std::setw(console_field_width-4) << adv_it->first + ":" <<  "\"" << adv_it->second << "\"\n";
+      const OutputOnWarehouse & adv_on = out->advancedExecuteOn();
+      for (const auto & adv_it : adv_on)
+        if (execute_on != adv_it.second)
+          oss << "    " << std::setw(console_field_width-4) << adv_it.first + ":" <<  "\"" << adv_it.second << "\"\n";
     }
   }
 

--- a/framework/src/outputs/ControlOutput.C
+++ b/framework/src/outputs/ControlOutput.C
@@ -67,8 +67,8 @@ ControlOutput::outputActiveObjects()
 
   // Populate a map based on unique InputParameter objects
   std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectName> > objects;
-  for (std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> >::const_iterator iter = params.begin(); iter != params.end(); ++iter)
-    objects[iter->second].insert(iter->first);
+  for (const auto & iter : params)
+    objects[iter.second].insert(iter.first);
 
   // The stream to build
   std::stringstream oss;
@@ -76,17 +76,22 @@ ControlOutput::outputActiveObjects()
 
   // Loop through unique objects
   oss << "Active Objects:\n" << COLOR_DEFAULT;
-  for (std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectName> >::const_iterator iter = objects.begin(); iter != objects.end(); ++iter)
+  for (const auto & iter : objects)
   {
-    MooseSharedPointer<InputParameters> ptr = iter->first;
+    MooseSharedPointer<InputParameters> ptr = iter.first;
     if (ptr->get<bool>("enable"))
     {
-      for (std::set<MooseObjectName>::const_iterator it = iter->second.begin(); it != iter->second.end(); ++it)
+      // We print slightly differently in the first iteration of the loop.
+      bool first_iteration = true;
+      for (const auto & obj_name : iter.second)
       {
-        if (it == iter->second.begin())
-          oss << ConsoleUtils::indent(2) << COLOR_YELLOW << *it << COLOR_DEFAULT << '\n';
+        if (first_iteration)
+        {
+          oss << ConsoleUtils::indent(2) << COLOR_YELLOW << obj_name << COLOR_DEFAULT << '\n';
+          first_iteration = false;
+        }
         else
-          oss << ConsoleUtils::indent(4) << *it << '\n';
+          oss << ConsoleUtils::indent(4) << obj_name << '\n';
       }
     }
   }
@@ -108,14 +113,14 @@ ControlOutput::outputControls()
 
   // Populate a map based on unique InputParameter objects
   std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectName> > objects;
-  for (std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> >::const_iterator iter = params.begin(); iter != params.end(); ++iter)
-    objects[iter->second].insert(iter->first);
+  for (const auto & iter : params)
+    objects[iter.second].insert(iter.first);
 
   // Produce the control information
   oss << "Controls:\n";
-  for (std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectName> >::const_iterator iter = objects.begin(); iter != objects.end(); ++iter)
+  for (const auto & iter : objects)
   {
-    MooseSharedPointer<InputParameters> ptr = iter->first;
+    MooseSharedPointer<InputParameters> ptr = iter.first;
 
     const std::set<std::string> & names = ptr->getControllableParameters();
 
@@ -125,8 +130,8 @@ ControlOutput::outputControls()
 
       // Full names(s)
       oss << ConsoleUtils::indent(4) << "Name(s): ";
-      for (std::set<MooseObjectName>::const_iterator it = iter->second.begin(); it != iter->second.end(); ++it)
-        oss << (*it) << " ";
+      for (const auto & obj_name : iter.second)
+        oss << obj_name << " ";
       oss << '\n';
 
       // Tag(s)
@@ -134,14 +139,14 @@ ControlOutput::outputControls()
       if (!tags.empty())
       {
         oss << ConsoleUtils::indent(4) << "Tag(s): ";
-        for (std::vector<std::string>::const_iterator it = tags.begin(); it != tags.end(); ++it)
-          oss << *it << " ";
+        for (const auto & tag_name : tags)
+          oss << tag_name << " ";
         oss << '\n';
       }
 
       oss <<  ConsoleUtils::indent(4) << "Parameter(s):\n";
-      for (std::set<std::string>::const_iterator it = names.begin(); it != names.end(); ++it)
-        oss << ConsoleUtils::indent(6) << std::setw(ConsoleUtils::console_field_width) << *it << ptr->type(*it) << '\n';
+      for (const auto & param_name : names)
+        oss << ConsoleUtils::indent(6) << std::setw(ConsoleUtils::console_field_width) << param_name << ptr->type(param_name) << '\n';
     }
   }
 
@@ -165,9 +170,9 @@ ControlOutput::outputChangedControls()
     oss << "Active Controls:\n";
 
   // Loop over the controlled parameters
-  for (std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectParameterName> >::const_iterator iter = controls.begin(); iter != controls.end(); ++iter)
+  for (const auto & iter : controls)
   {
-    const MooseSharedPointer<InputParameters> ptr = iter->first;
+    const MooseSharedPointer<InputParameters> ptr = iter.first;
     oss << "  " << COLOR_YELLOW << ptr->get<std::string>("_object_name") << COLOR_DEFAULT << '\n';
 
     // Tag(s)
@@ -175,14 +180,14 @@ ControlOutput::outputChangedControls()
     if (!tags.empty())
     {
       oss << ConsoleUtils::indent(4) << "Tag(s): ";
-      for (std::vector<std::string>::const_iterator it = tags.begin(); it != tags.end(); ++it)
-        oss << *it << " ";
+      for (const auto & tag_name : tags)
+        oss << tag_name << " ";
       oss << '\n';
     }
 
     oss << ConsoleUtils::indent(4) << "Parameter(s):\n";
-    for (std::set<MooseObjectParameterName>::const_iterator it = iter->second.begin(); it != iter->second.end(); ++it)
-      oss << ConsoleUtils::indent(6) << std::setw(ConsoleUtils::console_field_width) << it->parameter() << ptr->type(it->parameter()) << '\n';
+    for (const auto & param_name : iter.second)
+      oss << ConsoleUtils::indent(6) << std::setw(ConsoleUtils::console_field_width) << param_name.parameter() << ptr->type(param_name.parameter()) << '\n';
   }
 
   _console << oss.str() << std::endl;

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -221,10 +221,10 @@ Exodus::outputPostprocessors()
 
   // Append the postprocessor data to the global name value parameters; scalar outputs
   // also append these member variables
-  for (std::set<std::string>::const_iterator it = pps.begin(); it != pps.end(); ++it)
+  for (const auto & name : pps)
   {
-    _global_names.push_back(*it);
-    _global_values.push_back(_problem_ptr->getPostprocessorValue(*it));
+    _global_names.push_back(name);
+    _global_values.push_back(_problem_ptr->getPostprocessorValue(name));
   }
 }
 
@@ -235,15 +235,15 @@ Exodus::outputScalarVariables()
   const std::set<std::string> & out = getScalarOutput();
 
   // Append the scalar to the global output lists
-  for (std::set<std::string>::const_iterator it = out.begin(); it != out.end(); ++it)
+  for (const auto & out_name : out)
   {
-    VariableValue & variable = _problem_ptr->getScalarVariable(0, *it).sln();
+    VariableValue & variable = _problem_ptr->getScalarVariable(0, out_name).sln();
     unsigned int n = variable.size();
 
     // If the scalar has a single component, output the name directly
     if (n == 1)
     {
-      _global_names.push_back(*it);
+      _global_names.push_back(out_name);
       _global_values.push_back(variable[0]);
     }
 
@@ -253,7 +253,7 @@ Exodus::outputScalarVariables()
       for (unsigned int i = 0; i < n; ++i)
       {
         std::ostringstream os;
-        os << *it << "_" << i;
+        os << out_name << "_" << i;
         _global_names.push_back(os.str());
         _global_values.push_back(variable[i]);
       }

--- a/framework/src/outputs/FileOutput.C
+++ b/framework/src/outputs/FileOutput.C
@@ -130,10 +130,10 @@ FileOutput::checkFilename()
   bool output = false;
 
   // Loop through each string in the list
-  for (std::vector<std::string>::const_iterator it = _output_if_base_contains.begin(); it != _output_if_base_contains.end(); ++it)
+  for (const auto & search_string : _output_if_base_contains)
   {
     // Search for the string in the file base, if found set the output to true and break the loop
-    if (_file_base.find(*it) != std::string::npos)
+    if (_file_base.find(search_string) != std::string::npos)
     {
       output = true;
       break;

--- a/framework/src/outputs/ICEUpdater.C
+++ b/framework/src/outputs/ICEUpdater.C
@@ -105,17 +105,17 @@ void ICEUpdater::outputPostprocessors()
 
   // Get the list of Postprocessors
   const std::set<std::string> & pps = getPostprocessorOutput();
-  for (std::set<std::string>::const_iterator it = pps.begin(); it != pps.end(); ++it)
+  for (const auto & name : pps)
   {
 
     // Grab the value at the current time
-    PostprocessorValue value = _problem_ptr->getPostprocessorValue(*it);
+    PostprocessorValue value = _problem_ptr->getPostprocessorValue(name);
 
     // Create a string stream to use in posting the message
     std::stringstream ss;
 
     // Create the message as PPName:time:value
-    ss << *it << ":" << _time << ":" << value;
+    ss << name << ":" << _time << ":" << value;
 
     // Post the message
     _updater->postMessage(ss.str());

--- a/framework/src/outputs/MaterialPropertyDebugOutput.C
+++ b/framework/src/outputs/MaterialPropertyDebugOutput.C
@@ -57,40 +57,40 @@ MaterialPropertyDebugOutput::printMaterialMap() const
   // Active materials on block
   {
     const std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > > & objects = warehouse.getBlockObjects();
-    for (std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+    for (const auto & it : objects)
     {
-      active_block << "    Block ID " << it->first << ":\n";
-      printMaterialProperties(active_block, it->second);
+      active_block << "    Block ID " << it.first << ":\n";
+      printMaterialProperties(active_block, it.second);
     }
   }
 
   // Active face materials on blocks
   {
     const std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > > & objects = warehouse[Moose::FACE_MATERIAL_DATA].getBlockObjects();
-    for (std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+    for (const auto & it : objects)
     {
-      active_face << "    Block ID " << it->first << ":\n";
-      printMaterialProperties(active_face, it->second);
+      active_face << "    Block ID " << it.first << ":\n";
+      printMaterialProperties(active_face, it.second);
     }
   }
 
   // Active neighbor materials on blocks
   {
     const std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > > & objects = warehouse[Moose::NEIGHBOR_MATERIAL_DATA].getBlockObjects();
-    for (std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+    for (const auto & it : objects)
     {
-      active_neighbor << "    Block ID " << it->first << ":\n";
-      printMaterialProperties(active_neighbor, it->second);
+      active_neighbor << "    Block ID " << it.first << ":\n";
+      printMaterialProperties(active_neighbor, it.second);
     }
   }
 
   // Active boundary materials
   {
     const std::map<BoundaryID, std::vector<MooseSharedPointer<Material> > > & objects = warehouse.getBoundaryObjects();
-    for (std::map<BoundaryID, std::vector<MooseSharedPointer<Material> > >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+    for (const auto & it : objects)
     {
-      active_boundary << "    Boundary ID " << it->first << ":\n";
-      printMaterialProperties(active_boundary, it->second);
+      active_boundary << "    Boundary ID " << it.first << ":\n";
+      printMaterialProperties(active_boundary, it.second);
     }
   }
 
@@ -113,21 +113,21 @@ void
 MaterialPropertyDebugOutput::printMaterialProperties(std::stringstream & output, const std::vector<MooseSharedPointer<Material> > & materials) const
 {
   // Loop through all material objects
-  for (std::vector<MooseSharedPointer<Material> >::const_iterator jt = materials.begin(); jt != materials.end(); ++jt)
+  for (const auto & mat : materials)
   {
     // Get a list of properties for the current material
-    const std::set<std::string> & props = (*jt)->getSuppliedItems();
+    const std::set<std::string> & props = mat->getSuppliedItems();
 
     // Adds the material name to the output stream
-    output << std::left << std::setw(ConsoleUtils::console_field_width) << "      Material Name: " << (*jt)->name() << '\n';
+    output << std::left << std::setw(ConsoleUtils::console_field_width) << "      Material Name: " << mat->name() << '\n';
 
     // Build stream for properties using the ConsoleUtils helper functions to wrap the names if there are too many for one line
     std::streampos begin_string_pos = output.tellp();
     std::streampos curr_string_pos = begin_string_pos;
     output << std::left << std::setw(ConsoleUtils::console_field_width) << "      Property Names: ";
-    for (std::set<std::string>::const_iterator prop_it = props.begin(); prop_it != props.end(); ++prop_it)
+    for (const auto & prop : props)
     {
-      output << "\"" << (*prop_it) << "\" ";
+      output << "\"" << prop << "\" ";
       curr_string_pos = output.tellp();
       ConsoleUtils::insertNewline(output, begin_string_pos, curr_string_pos);
     }

--- a/framework/src/outputs/Nemesis.C
+++ b/framework/src/outputs/Nemesis.C
@@ -95,10 +95,10 @@ Nemesis::outputPostprocessors()
 
   // Append the postprocessor data to the global name value parameters; scalar outputs
   // also append these member variables
-  for (std::set<std::string>::const_iterator it = pps.begin(); it != pps.end(); ++it)
+  for (const auto & name : pps)
   {
-    _global_names.push_back(*it);
-    _global_values.push_back(_problem_ptr->getPostprocessorValue(*it));
+    _global_names.push_back(name);
+    _global_values.push_back(_problem_ptr->getPostprocessorValue(name));
   }
 }
 
@@ -109,15 +109,15 @@ Nemesis::outputScalarVariables()
   const std::set<std::string> & out = getScalarOutput();
 
   // Append the scalar to the global output lists
-  for (std::set<std::string>::const_iterator it = out.begin(); it != out.end(); ++it)
+  for (const auto & out_name : out)
   {
-    VariableValue & variable = _problem_ptr->getScalarVariable(0, *it).sln();
+    VariableValue & variable = _problem_ptr->getScalarVariable(0, out_name).sln();
     unsigned int n = variable.size();
 
     // If the scalar has a single component, output the name directly
     if (n == 1)
     {
-      _global_names.push_back(*it);
+      _global_names.push_back(out_name);
       _global_values.push_back(variable[0]);
     }
 
@@ -127,7 +127,7 @@ Nemesis::outputScalarVariables()
       for (unsigned int i = 0; i < n; ++i)
       {
         std::ostringstream os;
-        os << *it << "_" << i;
+        os << out_name << "_" << i;
         _global_names.push_back(os.str());
         _global_values.push_back(variable[i]);
       }

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -105,8 +105,8 @@ Output::Output(const InputParameters & parameters) :
   if (isParamValid("additional_execute_on"))
   {
     MultiMooseEnum add = getParam<MultiMooseEnum>("additional_execute_on");
-    for (MooseEnumIterator it = add.begin(); it != add.end(); ++it)
-      _execute_on.push_back(*it);
+    for (auto & me : add)
+      _execute_on.push_back(me);
   }
 }
 

--- a/framework/src/outputs/OutputInterface.C
+++ b/framework/src/outputs/OutputInterface.C
@@ -59,8 +59,8 @@ OutputInterface::buildOutputHideVariableList(std::set<std::string> variable_name
 
   // Check for 'none'; hide variables on all outputs
   if (_oi_outputs.find("none") != _oi_outputs.end())
-    for (std::set<OutputName>::const_iterator it = avail.begin(); it != avail.end(); ++ it)
-      _oi_output_warehouse.addInterfaceHideVariables(*it, variable_names);
+    for (const auto & name : avail)
+      _oi_output_warehouse.addInterfaceHideVariables(name, variable_names);
 
   // Check for empty and 'all' in 'outputs' parameter; do not perform any variable restrictions in these cases
   else if (_oi_outputs.empty() || _oi_outputs.find("all") != _oi_outputs.end())
@@ -74,8 +74,8 @@ OutputInterface::buildOutputHideVariableList(std::set<std::string> variable_name
     std::set_difference(avail.begin(), avail.end(), _oi_outputs.begin(), _oi_outputs.end(), std::inserter(hide, hide.begin()));
 
     // If 'outputs' is specified add the object name to the list of items to hide
-    for (std::set<OutputName>::const_iterator it = hide.begin(); it != hide.end(); ++ it)
-      _oi_output_warehouse.addInterfaceHideVariables(*it, variable_names);
+    for (const auto & name : hide)
+      _oi_output_warehouse.addInterfaceHideVariables(name, variable_names);
   }
 }
 

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -46,43 +46,43 @@ OutputWarehouse::~OutputWarehouse()
 void
 OutputWarehouse::initialSetup()
 {
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->initialSetup();
+  for (const auto & obj : _all_objects)
+    obj->initialSetup();
 }
 
 void
 OutputWarehouse::timestepSetup()
 {
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->timestepSetup();
+  for (const auto & obj : _all_objects)
+    obj->timestepSetup();
 }
 
 void
 OutputWarehouse::solveSetup()
 {
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->solveSetup();
+  for (const auto & obj : _all_objects)
+    obj->solveSetup();
 }
 
 void
 OutputWarehouse::jacobianSetup()
 {
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->jacobianSetup();
+  for (const auto & obj : _all_objects)
+    obj->jacobianSetup();
 }
 
 void
 OutputWarehouse::residualSetup()
 {
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->residualSetup();
+  for (const auto & obj : _all_objects)
+    obj->residualSetup();
 }
 
 void
 OutputWarehouse::subdomainSetup()
 {
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->subdomainSetup();
+  for (const auto & obj : _all_objects)
+    obj->subdomainSetup();
 }
 
 void
@@ -126,8 +126,8 @@ OutputWarehouse::getOutputNames()
   if (_object_names.empty())
   {
     std::vector<Action *> actions =  _app.actionWarehouse().getActionsByName("add_output");
-    for (std::vector<Action *>::const_iterator it = actions.begin(); it != actions.end(); ++it)
-      _object_names.insert((*it)->name());
+    for (const auto & act : actions)
+      _object_names.insert(act->name());
   }
   return _object_names;
 }
@@ -146,8 +146,8 @@ OutputWarehouse::outputStep(ExecFlagType type)
   if (_force_output)
     type = EXEC_FORCED;
 
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->outputStep(type);
+  for (const auto & obj : _all_objects)
+    obj->outputStep(type);
 
   /**
    * This is one of three locations where we explicitly flush the output buffers during a simulation:
@@ -167,8 +167,8 @@ OutputWarehouse::outputStep(ExecFlagType type)
 void
 OutputWarehouse::meshChanged()
 {
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->meshChanged();
+  for (const auto & obj : _all_objects)
+    obj->meshChanged();
 }
 
 void
@@ -178,8 +178,8 @@ OutputWarehouse::mooseConsole()
   std::vector<Console *> objects = getOutputs<Console>();
   if (!objects.empty())
   {
-    for (std::vector<Console *>::iterator it = objects.begin(); it != objects.end(); ++it)
-      (*it)->mooseConsole(_console_buffer.str());
+    for (const auto & obj : objects)
+      obj->mooseConsole(_console_buffer.str());
 
     // Reset
     _console_buffer.clear();
@@ -210,9 +210,9 @@ OutputWarehouse::flushConsoleBuffer()
 void
 OutputWarehouse::setFileNumbers(std::map<std::string, unsigned int> input, unsigned int offset)
 {
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
+  for (const auto & obj : _all_objects)
   {
-    FileOutput * ptr = dynamic_cast<FileOutput *>(*it);
+    FileOutput * ptr = dynamic_cast<FileOutput *>(obj);
     if (ptr != NULL)
     {
       std::map<std::string, unsigned int>::const_iterator it = input.find(ptr->name());
@@ -233,9 +233,9 @@ OutputWarehouse::getFileNumbers()
 {
 
   std::map<std::string, unsigned int> output;
-  for (std::vector<Output *>::const_iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
+  for (const auto & obj : _all_objects)
   {
-    FileOutput * ptr = dynamic_cast<FileOutput *>(*it);
+    FileOutput * ptr = dynamic_cast<FileOutput *>(obj);
     if (ptr != NULL)
       output[ptr->name()] = ptr->getFileNumber();
   }
@@ -277,9 +277,9 @@ OutputWarehouse::buildInterfaceHideVariables(const std::string & output_name, st
 void
 OutputWarehouse::checkOutputs(const std::set<OutputName> & names)
 {
-  for (std::set<OutputName>::const_iterator it = names.begin(); it != names.end(); ++it)
-    if (!isReservedName(*it) && !hasOutput(*it))
-      mooseError("The output object '" << *it << "' is not a defined output object");
+  for (const auto & name : names)
+    if (!isReservedName(name) && !hasOutput(name))
+      mooseError("The output object '" << name << "' is not a defined output object");
 }
 
 
@@ -304,8 +304,8 @@ OutputWarehouse::setOutputExecutionType(ExecFlagType type)
 void
 OutputWarehouse::allowOutput(bool state)
 {
-  for (std::vector<Output *>::iterator it = _all_objects.begin(); it != _all_objects.end(); ++it)
-    (*it)->allowOutput(state);
+  for (const auto & obj : _all_objects)
+    obj->allowOutput(state);
 }
 
 void

--- a/framework/src/outputs/SolutionHistory.C
+++ b/framework/src/outputs/SolutionHistory.C
@@ -49,8 +49,8 @@ SolutionHistory::output(const ExecFlagType & /*type*/)
   slh_file.open(filename().c_str(), std::ios::app);
   slh_file << nl_sys._current_nl_its;
 
-  for (unsigned int i = 0; i < nl_sys._current_l_its.size(); i++)
-    slh_file << " " << nl_sys._current_l_its[i];
+  for (const auto & linear_its : nl_sys._current_l_its)
+    slh_file << " " << linear_its;
 
   slh_file << std::endl;
 }

--- a/framework/src/outputs/TableOutput.C
+++ b/framework/src/outputs/TableOutput.C
@@ -61,11 +61,11 @@ TableOutput::outputPostprocessors()
   const std::set<std::string> & out = getPostprocessorOutput();
 
   // Loop through the postprocessor names and extract the values from the PostprocessorData storage
-  for (std::set<std::string>::const_iterator it = out.begin(); it != out.end(); ++it)
+  for (const auto & out_name : out)
   {
-    PostprocessorValue value = _problem_ptr->getPostprocessorValue(*it);
-    _postprocessor_table.addData(*it, value, time());
-    _all_data_table.addData(*it, value, time());
+    PostprocessorValue value = _problem_ptr->getPostprocessorValue(out_name);
+    _postprocessor_table.addData(out_name, value, time());
+    _all_data_table.addData(out_name, value, time());
   }
 }
 
@@ -76,10 +76,8 @@ TableOutput::outputVectorPostprocessors()
   const std::set<std::string> & out = getVectorPostprocessorOutput();
 
   // Loop through the postprocessor names and extract the values from the VectorPostprocessorData storage
-  for (std::set<std::string>::const_iterator it = out.begin(); it != out.end(); ++it)
+  for (const auto & vpp_name : out)
   {
-    std::string vpp_name = *it;
-
     const std::map<std::string, VectorPostprocessorValue*> & vectors = _problem_ptr->getVectorPostprocessorVectors(vpp_name);
 
     FormattedTable & table = _vector_postprocessor_tables[vpp_name];
@@ -87,12 +85,12 @@ TableOutput::outputVectorPostprocessors()
     table.clear();
     table.outputTimeColumn(false);
 
-    for (std::map<std::string, VectorPostprocessorValue*>::const_iterator vec_it = vectors.begin(); vec_it != vectors.end(); ++vec_it)
+    for (const auto & vec_it : vectors)
     {
-      VectorPostprocessorValue vector = *(vec_it->second);
+      VectorPostprocessorValue vector = *(vec_it.second);
 
       for (unsigned int i=0; i<vector.size(); i++)
-        table.addData(vec_it->first, vector[i], i);
+        table.addData(vec_it.first, vector[i], i);
     }
 
     if (_time_data)
@@ -110,10 +108,10 @@ TableOutput::outputScalarVariables()
   const std::set<std::string> & out = getScalarOutput();
 
   // Loop through each variable
-  for (std::set<std::string>::const_iterator it = out.begin(); it != out.end(); ++it)
+  for (const auto & out_name : out)
   {
     // Get reference to the variable (0 is for TID)
-    MooseVariableScalar & scalar_var = _problem_ptr->getScalarVariable(0, *it);
+    MooseVariableScalar & scalar_var = _problem_ptr->getScalarVariable(0, out_name);
 
     // Make sure the value of the variable is in sync with the solution vector
     scalar_var.reinit();
@@ -125,8 +123,8 @@ TableOutput::outputScalarVariables()
     // If the variable has a single component, simply output the value with the name
     if (n == 1)
     {
-      _scalar_table.addData(*it, value[0], time());
-      _all_data_table.addData(*it, value[0], time());
+      _scalar_table.addData(out_name, value[0], time());
+      _all_data_table.addData(out_name, value[0], time());
     }
 
     // Multi-component variables are appended with the component index
@@ -134,7 +132,7 @@ TableOutput::outputScalarVariables()
       for (unsigned int i = 0; i < n; ++i)
       {
         std::ostringstream os;
-        os << *it << "_" << i;
+        os << out_name << "_" << i;
         _scalar_table.addData(os.str(), value[i], time());
         _all_data_table.addData(os.str(), value[i], time());
       }

--- a/framework/src/outputs/TopResidualDebugOutput.C
+++ b/framework/src/outputs/TopResidualDebugOutput.C
@@ -87,22 +87,20 @@ TopResidualDebugOutput::printTopResiduals(const NumericVector<Number> & residual
   // Loop over all scalar variables
   std::vector<unsigned int> var_nums;
   _sys.get_all_variable_numbers(var_nums);
-  const DofMap &dof_map(_sys.get_dof_map());
-  for (std::vector<unsigned int>::const_iterator it = var_nums.begin(); it != var_nums.end(); ++it)
-  {
-    if (_sys.variable_type(*it).family == SCALAR)
+  const DofMap & dof_map = _sys.get_dof_map();
+  for (const auto & var_num : var_nums)
+    if (_sys.variable_type(var_num).family == SCALAR)
     {
       std::vector<dof_id_type> dof_indices;
-      dof_map.SCALAR_dof_indices(dof_indices, *it);
-      for (std::vector<dof_id_type>::const_iterator dof_it = dof_indices.begin(); dof_it != dof_indices.end(); ++dof_it)
-        if (*dof_it >= dof_map.first_dof() && *it < dof_map.end_dof())
+      dof_map.SCALAR_dof_indices(dof_indices, var_num);
+
+      for (const auto & dof : dof_indices)
+        if (dof >= dof_map.first_dof() && dof < dof_map.end_dof())
         {
-          vec[j] = TopResidualDebugOutputTopResidualData(*it, 0, residual(*dof_it), true);
+          vec[j] = TopResidualDebugOutputTopResidualData(var_num, 0, residual(dof), true);
           j++;
         }
     }
-
-  }
 
   // Sort vec by residuals
   std::sort(vec.begin(), vec.end(), sortTopResidualData);

--- a/framework/src/outputs/formatters/ExodusFormatter.C
+++ b/framework/src/outputs/formatters/ExodusFormatter.C
@@ -63,30 +63,27 @@ ExodusFormatter::format()
   while (std::getline(_ss, s))
   {
     // MAX_LINE_LENGTH is from ExodusII
-    if ( s.length() > MAX_LINE_LENGTH )
+    if (s.length() > MAX_LINE_LENGTH)
     {
       const std::string continuation("...");
-      const size_t cont_len(continuation.length());
+      const size_t cont_len = continuation.length();
       size_t num_lines = s.length() / (MAX_LINE_LENGTH - cont_len) + 1;
       std::string split_line;
-      for (size_t j(0), l_begin(0); j < num_lines; ++j, l_begin+=MAX_LINE_LENGTH-cont_len)
+      for (size_t j = 0, l_begin = 0; j < num_lines; ++j, l_begin += MAX_LINE_LENGTH - cont_len)
       {
-        size_t l_len = MAX_LINE_LENGTH-cont_len;
-        if (s.length() < l_begin + l_len )
-        {
+        size_t l_len = MAX_LINE_LENGTH - cont_len;
+        if (s.length() < l_begin + l_len)
           l_len = s.length() - l_begin;
-        }
-        split_line = s.substr( l_begin, l_len );
-        if ( l_begin + l_len != s.length())
-        {
+
+        split_line = s.substr(l_begin, l_len);
+
+        if (l_begin + l_len != s.length())
           split_line += continuation;
-        }
+
         _input_file_record.push_back(split_line);
       }
     }
     else
-    {
       _input_file_record.push_back(s);
-    }
   }
 }

--- a/framework/src/outputs/formatters/InputFileFormatter.C
+++ b/framework/src/outputs/formatters/InputFileFormatter.C
@@ -50,8 +50,12 @@ InputFileFormatter::printBlockClose(const std::string & /*name*/, short depth) c
 }
 
 std::string
-InputFileFormatter::printParams(const std::string & /*prefix*/, const std::string &fully_qualified_name, InputParameters &params,
-                                short depth, const std::string &search_string, bool &found)
+InputFileFormatter::printParams(const std::string & /*prefix*/,
+                                const std::string & fully_qualified_name,
+                                InputParameters & params,
+                                short depth,
+                                const std::string & search_string,
+                                bool & found)
 {
   std::stringstream oss;
 
@@ -60,60 +64,60 @@ InputFileFormatter::printParams(const std::string & /*prefix*/, const std::strin
   std::string forward  = "";
   std::string backdots = "";
   int         offset   = 30;
-  for (int i=0; i<depth; ++i)
+  for (int i = 0; i < depth; ++i)
   {
     spacing += "  ";
     forward = ".";
     offset -= 2;
   }
 
-  for (InputParameters::iterator iter = params.begin(); iter != params.end(); ++iter)
+  for (const auto & iter : params)
   {
     // We only want non-private params and params that we haven't already seen
-    if (params.isPrivate(iter->first) || haveSeenIt(fully_qualified_name, iter->first))
+    if (params.isPrivate(iter.first) || haveSeenIt(fully_qualified_name, iter.first))
       continue;
 
     std::string value = "INVALID";
-    if (params.isParamValid(iter->first))
+    if (params.isParamValid(iter.first))
     {
       // Print the parameter's value to a stringstream.
       std::ostringstream toss;
-      iter->second->print(toss);
+      iter.second->print(toss);
       value = MooseUtils::trim(toss.str());
     }
-    else if (params.hasDefaultCoupledValue(iter->first))
+    else if (params.hasDefaultCoupledValue(iter.first))
     {
       std::ostringstream toss;
-      toss << params.defaultCoupledValue(iter->first);
+      toss << params.defaultCoupledValue(iter.first);
       value = toss.str();
     }
 
     // See if we match the search string
-    if (wildCardMatch(iter->first, search_string) || wildCardMatch(value, search_string))
+    if (wildCardMatch(iter.first, search_string) || wildCardMatch(value, search_string))
     {
       // Don't print active if it is the default all, that means it's not in the input file - unless of course we are in dump mode
-      if (!_dump_mode && iter->first == "active")
+      if (!_dump_mode && iter.first == "active")
       {
-        libMesh::Parameters::Parameter<std::vector<std::string> > * val = dynamic_cast<libMesh::Parameters::Parameter<std::vector<std::string> >*>(iter->second);
+        libMesh::Parameters::Parameter<std::vector<std::string> > * val = dynamic_cast<libMesh::Parameters::Parameter<std::vector<std::string> >*>(iter.second);
         const std::vector<std::string> & active = val->get();
         if (val != NULL && active.size() == 1 && active[0] == "__all__")
           continue;
       }
 
       // Mark it as "seen"
-      seenIt(fully_qualified_name, iter->first);
+      seenIt(fully_qualified_name, iter.first);
 
       // Don't print type if it is blank
-      if (iter->first == "type")
+      if (iter.first == "type")
       {
-        libMesh::Parameters::Parameter<std::string> * val = dynamic_cast<libMesh::Parameters::Parameter<std::string>*>(iter->second);
+        libMesh::Parameters::Parameter<std::string> * val = dynamic_cast<libMesh::Parameters::Parameter<std::string>*>(iter.second);
         const std::string & active = val->get();
         if (val != NULL && active == "")
           continue;
       }
 
       found = true;
-      oss << spacing << "  " << std::left << std::setw(offset) << iter->first << " = ";
+      oss << spacing << "  " << std::left << std::setw(offset) << iter.first << " = ";
       // std::setw() takes an int
       int l_offset = 30;
 
@@ -130,7 +134,7 @@ InputFileFormatter::printParams(const std::string & /*prefix*/, const std::strin
         oss << quotes << value << quotes;
         l_offset -= value.size();
       }
-      else if (_dump_mode && params.isParamRequired(iter->first))
+      else if (_dump_mode && params.isParamRequired(iter.first))
       {
         oss << "(required)";
         l_offset -= 10;
@@ -140,13 +144,13 @@ InputFileFormatter::printParams(const std::string & /*prefix*/, const std::strin
       if (_dump_mode)
       {
         std::vector<std::string> elements;
-        std::string doc = params.getDocString(iter->first);
+        std::string doc = params.getDocString(iter.first);
         if (MooseUtils::trim(doc) != "")
         {
           MooseUtils::tokenize(doc, elements, 68, " \t");
 
-          for (unsigned int i=0; i<elements.size(); ++i)
-            MooseUtils::escape(elements[i]);
+          for (auto & element : elements)
+            MooseUtils::escape(element);
 
           oss << std::right << std::setw(l_offset) << "# " << elements[0];
           for (unsigned int i=1; i<elements.size(); ++i)

--- a/framework/src/outputs/formatters/YAMLFormatter.C
+++ b/framework/src/outputs/formatters/YAMLFormatter.C
@@ -45,27 +45,27 @@ YAMLFormatter::printParams(const std::string &prefix, const std::string & /*full
   std::ostringstream oss;
   std::string indent(depth*2, ' ');
 
-  for (InputParameters::iterator iter = params.begin(); iter != params.end(); ++iter)
+  for (auto & iter : params)
   {
-    std::string name = iter->first;
+    std::string name = iter.first;
     // First make sure we want to see this parameter, also block active and type
-    if (params.isPrivate(iter->first) || name == "active" || (search_string != "" && search_string != iter->first) || haveSeenIt(prefix, iter->first))
+    if (params.isPrivate(iter.first) || name == "active" || (search_string != "" && search_string != iter.first) || haveSeenIt(prefix, iter.first))
       continue;
 
     found = true;
 
     // Mark it as "seen"
-    seenIt(prefix, iter->first);
+    seenIt(prefix, iter.first);
 
     // Block params may be required and will have a doc string
-    std::string required = params.isParamRequired(iter->first) ? "Yes" : "No";
+    std::string required = params.isParamRequired(iter.first) ? "Yes" : "No";
 
     oss << indent << "  - name: " << name << "\n";
     oss << indent << "    required: " << required << "\n";
     oss << indent << "    default: !!str ";
 
     // Only output default if it has one
-    if (params.isParamValid(iter->first))
+    if (params.isParamValid(iter.first))
     {
       //prints the value, which is the default value when dumping the tree
       //because it hasn't been changed
@@ -76,36 +76,32 @@ YAMLFormatter::printParams(const std::string &prefix, const std::string & /*full
 
       // remove additional '\n' possibly generated in output (breaks YAML parsing)
       std::string tmp_str = toss.str();
-      for (std::string::iterator it=tmp_str.begin(); it!=tmp_str.end(); ++it)
-      {
-        if ( *it == '\n')
-        {
-          *it = ' ';
-        }
-      }
+      for (auto & ch : tmp_str)
+        if (ch == '\n')
+          ch = ' ';
       oss << tmp_str;
     }
-    else if (params.hasDefaultCoupledValue(iter->first))
-      oss <<  params.defaultCoupledValue(iter->first);
+    else if (params.hasDefaultCoupledValue(iter.first))
+      oss <<  params.defaultCoupledValue(iter.first);
 
-    std::string doc = params.getDocString(iter->first);
+    std::string doc = params.getDocString(iter.first);
     MooseUtils::escape(doc);
     // Print the type
-    oss << "\n" << indent << "    cpp_type: " << params.type(iter->first)
-        << "\n" << indent << "    group_name: " << params.getGroupName(iter->first);
+    oss << "\n" << indent << "    cpp_type: " << params.type(iter.first)
+        << "\n" << indent << "    group_name: " << params.getGroupName(iter.first);
 
     {
-      InputParameters::Parameter<MooseEnum> * enum_type = dynamic_cast<InputParameters::Parameter<MooseEnum>*>(iter->second);
+      InputParameters::Parameter<MooseEnum> * enum_type = dynamic_cast<InputParameters::Parameter<MooseEnum>*>(iter.second);
       if (enum_type)
         oss << "\n" << indent << "    options: " << enum_type->get().getRawNames();
     }
     {
-      InputParameters::Parameter<MultiMooseEnum> * enum_type = dynamic_cast<InputParameters::Parameter<MultiMooseEnum>*>(iter->second);
+      InputParameters::Parameter<MultiMooseEnum> * enum_type = dynamic_cast<InputParameters::Parameter<MultiMooseEnum>*>(iter.second);
       if (enum_type)
         oss << "\n" << indent << "    options: " << enum_type->get().getRawNames();
     }
     {
-      InputParameters::Parameter<std::vector<MooseEnum> > * enum_type = dynamic_cast<InputParameters::Parameter<std::vector<MooseEnum> >*>(iter->second);
+      InputParameters::Parameter<std::vector<MooseEnum> > * enum_type = dynamic_cast<InputParameters::Parameter<std::vector<MooseEnum> >*>(iter.second);
       if (enum_type)
         oss << "\n" << indent << "    options: " << (enum_type->get())[0].getRawNames();
     }
@@ -150,31 +146,23 @@ YAMLFormatter::printBlockClose(const std::string &/*name*/, short /*depth*/) con
 }
 
 void
-YAMLFormatter::buildOutputString(std::ostringstream & output, const InputParameters::iterator iter)
+YAMLFormatter::buildOutputString(std::ostringstream & output, const std::iterator_traits<InputParameters::iterator>::value_type & p)
 {
-
   // Account for Point
-  InputParameters::Parameter<Point> * ptr0 = dynamic_cast<InputParameters::Parameter<Point>*>(iter->second);
+  InputParameters::Parameter<Point> * ptr0 = dynamic_cast<InputParameters::Parameter<Point>*>(p.second);
 
   // Account for RealVectorValues
-  InputParameters::Parameter<RealVectorValue> * ptr1  = dynamic_cast<InputParameters::Parameter<RealVectorValue>*>(iter->second);
+  InputParameters::Parameter<RealVectorValue> * ptr1  = dynamic_cast<InputParameters::Parameter<RealVectorValue>*>(p.second);
 
   // Output the Point components
   if (ptr0)
-  {
     output << ptr0->get().operator()(0) << " " << ptr0->get().operator()(1) << " " << ptr0->get().operator()(2);
-  }
 
   // Output the RealVectorValue components
   else if (ptr1)
-  {
     output << ptr1->get().operator()(0) << " " << ptr1->get().operator()(1) << " " << ptr1->get().operator()(2);
-  }
 
   // General case, call the print operator
   else
-  {
-    iter->second->print(output);
-  }
-
+    p.second->print(output);
 }

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -37,17 +37,17 @@ CommandLine::~CommandLine()
 void
 CommandLine::addCommandLineOptionsFromParams(InputParameters & params)
 {
-  for (InputParameters::iterator it = params.begin(); it != params.end(); ++it)
+  for (const auto & it : params)
   {
     Option cli_opt;
     std::vector<std::string> syntax;
-    std::string orig_name = it->first;
+    std::string orig_name = it.first;
 
     cli_opt.description = params.getDocString(orig_name);
     syntax = params.getSyntax(orig_name);
     cli_opt.cli_syntax = syntax;
     cli_opt.required = false;
-    InputParameters::Parameter<bool> * bool_type = dynamic_cast<InputParameters::Parameter<bool>*>(it->second);
+    InputParameters::Parameter<bool> * bool_type = dynamic_cast<InputParameters::Parameter<bool>*>(it.second);
     if (bool_type)
       cli_opt.argument_type = CommandLine::NONE;
     else
@@ -60,41 +60,41 @@ CommandLine::addCommandLineOptionsFromParams(InputParameters & params)
 void
 CommandLine::populateInputParams(InputParameters & params)
 {
-  for (InputParameters::iterator it = params.begin(); it != params.end(); ++it)
+  for (const auto & it : params)
   {
-    std::string orig_name = it->first;
+    std::string orig_name = it.first;
     if (search(orig_name))
     {
       {
-        InputParameters::Parameter<std::string> * string_type = dynamic_cast<InputParameters::Parameter<std::string>*>(it->second);
+        InputParameters::Parameter<std::string> * string_type = dynamic_cast<InputParameters::Parameter<std::string>*>(it.second);
         if (string_type)
         {
           search(orig_name, params.set<std::string>(orig_name));
           continue;
         }
 
-        InputParameters::Parameter<Real> * real_type = dynamic_cast<InputParameters::Parameter<Real>*>(it->second);
+        InputParameters::Parameter<Real> * real_type = dynamic_cast<InputParameters::Parameter<Real>*>(it.second);
         if (real_type)
         {
           search(orig_name, params.set<Real>(orig_name));
           continue;
         }
 
-        InputParameters::Parameter<unsigned int> * uint_type = dynamic_cast<InputParameters::Parameter<unsigned int>*>(it->second);
+        InputParameters::Parameter<unsigned int> * uint_type = dynamic_cast<InputParameters::Parameter<unsigned int>*>(it.second);
         if (uint_type)
         {
           search(orig_name, params.set<unsigned int>(orig_name));
           continue;
         }
 
-        InputParameters::Parameter<int> * int_type = dynamic_cast<InputParameters::Parameter<int>*>(it->second);
+        InputParameters::Parameter<int> * int_type = dynamic_cast<InputParameters::Parameter<int>*>(it.second);
         if (int_type)
         {
           search(orig_name, params.set<int>(orig_name));
           continue;
         }
 
-        InputParameters::Parameter<bool> * bool_type = dynamic_cast<InputParameters::Parameter<bool>*>(it->second);
+        InputParameters::Parameter<bool> * bool_type = dynamic_cast<InputParameters::Parameter<bool>*>(it.second);
         if (bool_type)
         {
           search(orig_name, params.set<bool>(orig_name));
@@ -110,26 +110,21 @@ CommandLine::populateInputParams(InputParameters & params)
 void
 CommandLine::addOption(const std::string & name, Option cli_opt)
 {
-  for (unsigned int i = 0; i < cli_opt.cli_syntax.size(); i++)
-  {
-    std::string stx = cli_opt.cli_syntax[i];
+  for (const auto & stx : cli_opt.cli_syntax)
     cli_opt.cli_switch.push_back(stx.substr(0, stx.find_first_of(" =")));
-  }
 
   _cli_options[name] = cli_opt;
 }
 
 bool
-CommandLine::search(const std::string &option_name)
+CommandLine::search(const std::string & option_name)
 {
   std::map<std::string, Option>::iterator pos = _cli_options.find(option_name);
   if (pos != _cli_options.end())
   {
-    for (unsigned int i=0; i<pos->second.cli_switch.size(); ++i)
-    {
-      if (_get_pot->search(pos->second.cli_switch[i]))
+    for (const auto & search_string : pos->second.cli_switch)
+      if (_get_pot->search(search_string))
         return true;
-    }
 
     if (pos->second.required)
     {
@@ -153,18 +148,19 @@ CommandLine::printUsage() const
   Moose::out << "Usage: " << command << " [<options>]\n\n"
              << "Options:\n" << std::left;
 
-  for (std::map<std::string, Option>::const_iterator i = _cli_options.begin(); i != _cli_options.end(); ++i)
+  for (const auto & i : _cli_options)
   {
-    if (i->second.cli_syntax.empty())
+    if (i.second.cli_syntax.empty())
       continue;
 
     std::stringstream oss;
-    for (unsigned int j = 0; j < i->second.cli_syntax.size(); ++j)
+    for (unsigned int j = 0; j < i.second.cli_syntax.size(); ++j)
     {
-      if (j) oss << " ";
-      oss << i->second.cli_syntax[j];
+      if (j)
+        oss << " ";
+      oss << i.second.cli_syntax[j];
     }
-    Moose::out << "  " << std::setw(50) << oss.str() << i->second.description << "\n";
+    Moose::out << "  " << std::setw(50) << oss.str() << i.second.description << "\n";
   }
 
   Moose::out << "\nSolver Options:\n"

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -105,8 +105,8 @@ Parser::isSectionActive(const std::string & s,
   }
 
   // Finally see if any of the inactive strings are partially contained in this path (matching from the beginning)
-  for (std::set<std::string>::iterator i = _inactive_strings.begin(); i != _inactive_strings.end(); ++i)
-    if (s.find(*i) == 0)
+  for (const auto & search_string : _inactive_strings)
+    if (s.find(search_string) == 0)
       retValue = false;
 
   // If this section is not active - then keep track of it for future checks
@@ -190,8 +190,8 @@ Parser::parse(const std::string &input_filename)
     if (!ufos.empty())
     {
       Moose::err << "Error: the following unidentified entries were found in your input file:" << std::endl;
-      for (unsigned int i=0; i<ufos.size(); ++i)
-        Moose::err << ufos[i] << std::endl;
+      for (const auto & ufo : ufos)
+        Moose::err << ufo << std::endl;
       mooseError("Your input file may have a syntax error, or you may have forgotten to put quotes around a vector, ie. v='1 2'.");
     }
   }
@@ -202,9 +202,9 @@ Parser::parse(const std::string &input_filename)
   // Set the class variable to indicate that sections names have been read, this is used later by the checkOverriddenParams function
   _sections_read = true;
 
-  for (std::vector<std::string>::iterator i=section_names.begin(); i != section_names.end(); ++i)
+  for (auto & section_name : section_names)
   {
-    curr_identifier = i->erase(i->size()-1);  // Chop off the last character (the trailing slash)
+    curr_identifier = section_name.erase(section_name.size()-1);  // Chop off the last character (the trailing slash)
 
     // Before we retrieve any actions or build any objects, make sure that the section they are in is active
     if (isSectionActive(curr_identifier, active_lists))
@@ -213,7 +213,7 @@ Parser::parse(const std::string &input_filename)
       // There may be more than one Action registered for a given section in which case we need to
       // build them all
       bool is_parent;
-      std::string registered_identifier = _syntax.isAssociated(*i, &is_parent);
+      std::string registered_identifier = _syntax.isAssociated(section_name, &is_parent);
 
       // We need to retrieve a list of Actions associated with the current identifier
       std::pair<std::multimap<std::string, Syntax::ActionInfo>::iterator,
@@ -271,13 +271,12 @@ Parser::checkActiveUsed(std::vector<std::string > & sections,
   std::set<std::string> active_lists_set;
   std::vector<std::string> difference;
 
-  for (std::map<std::string, std::vector<std::string> >::const_iterator i = active_lists.begin();
-       i != active_lists.end(); ++i)
-    for (std::vector<std::string>::const_iterator j = (i->second).begin(); j != (i->second).end(); ++j)
+  for (const auto & i : active_lists)
+    for (const auto & j : i.second)
     {
-      active_lists_set.insert(i->first);
-      if (*j != "__all__")
-        active_lists_set.insert(i->first + "/" + *j);
+      active_lists_set.insert(i.first);
+      if (j != "__all__")
+        active_lists_set.insert(i.first + "/" + j);
     }
 
   std::sort(sections.begin(), sections.end());
@@ -289,8 +288,8 @@ Parser::checkActiveUsed(std::vector<std::string > & sections,
   {
     std::ostringstream oss;
     oss << "One or more active lists in the input file are missing a referenced section:\n";
-    for (std::vector<std::string>::iterator i = difference.begin(); i != difference.end();  ++i)
-      oss << *i << "\n";
+    for (const auto & name : difference)
+      oss << name << "\n";
     mooseError(oss.str());
   }
 }
@@ -362,11 +361,11 @@ Parser::checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_
                       std::inserter(difference, difference.end()));
 
   // Remove un-parsed parameters that were located in an inactive sections
-  for (std::set<std::string>::iterator i=_inactive_strings.begin(); i != _inactive_strings.end(); ++i)
+  for (const auto & inactive_string : _inactive_strings)
     for (std::set<std::string>::iterator j=difference.begin(); j != difference.end(); /*no increment*/)
     {
       std::set<std::string>::iterator curr = j++;
-      if (curr->find(*i) != std::string::npos)
+      if (curr->find(inactive_string) != std::string::npos)
         difference.erase(curr);
     }
 
@@ -381,8 +380,8 @@ Parser::checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_
     std::ostringstream oss;
 
     oss << "The following parameters were unused " << (in_input_file ? "in your input file:\n" : "on the command line:\n");
-    for (std::set<std::string>::iterator i=no_overrides.begin(); i != no_overrides.end(); ++i)
-      oss << *i << "\n";
+    for (const auto & name : no_overrides)
+      oss << name << "\n";
 
     if (error_on_warn)
       mooseError(oss.str());
@@ -405,9 +404,8 @@ Parser::checkOverriddenParams(bool error_on_warn) const
     std::ostringstream oss;
 
     oss << "The following variables were overridden or supplied multiple times:\n";
-    for (std::set<std::string>::const_iterator i=overridden_vars.begin();
-         i != overridden_vars.end(); ++i)
-      oss << *i << "\n";
+    for (const auto & name : overridden_vars)
+      oss << name << "\n";
 
     if (error_on_warn)
       mooseError(oss.str());
@@ -434,17 +432,17 @@ Parser::appendAndReorderSectionNames(std::vector<std::string> & section_names)
     mooseAssert(get_pot, "GetPot object is NULL");
 
     std::vector<std::string> cli_variables = get_pot->get_variable_names();
-    for (unsigned int i=0; i<cli_variables.size(); ++i)
+    for (const auto & cli_var : cli_variables)
     {
-      std::string::size_type colon_pos = cli_variables[i].find(':');
-      std::string::size_type last_slash_pos = cli_variables[i].find_last_of('/');
+      std::string::size_type colon_pos = cli_var.find(':');
+      std::string::size_type last_slash_pos = cli_var.find_last_of('/');
 
       // Make sure that the variable does not contain a colon. This indicates that the override is for
       // a Multiapp parameter which we won't handle here.
       if (colon_pos == std::string::npos && last_slash_pos != std::string::npos)
       {
         // If the user supplies a CLI argument whose section doesn't exist in the input file, we'll append it here
-        std::string section = cli_variables[i].substr(0, last_slash_pos+1);
+        std::string section = cli_var.substr(0, last_slash_pos+1);
         if (std::find(section_names.begin(), section_names.end(), section) == section_names.end())
           section_names.push_back(section);
       }
@@ -513,32 +511,31 @@ Parser::initSyntaxFormatter(SyntaxFormatterType type, bool dump_mode)
 }
 
 void
-Parser::buildFullTree(const std::string &search_string)
+Parser::buildFullTree(const std::string & search_string)
 {
 //  std::string prev_name = "";
 //  std::vector<InputParameters *> params_ptrs(2);
   std::vector<std::pair<std::string, Syntax::ActionInfo> > all_names;
 
-  for (std::multimap<std::string, Syntax::ActionInfo>::const_iterator iter = _syntax.getAssociatedActions().begin();
-       iter != _syntax.getAssociatedActions().end(); ++iter)
+  for (const auto & iter : _syntax.getAssociatedActions())
   {
-    Syntax::ActionInfo act_info = iter->second;
+    Syntax::ActionInfo act_info = iter.second;
     // If the task is NULL that means we need to figure out which task
     // goes with this syntax for the purpose of building the Moose Object part of the tree.
     // We will figure this out by asking the ActionFactory for the registration info.
     if (act_info._task == "")
       act_info._task = _action_factory.getTaskName(act_info._action);
 
-    all_names.push_back(std::pair<std::string, Syntax::ActionInfo>(iter->first, act_info));
+    all_names.push_back(std::pair<std::string, Syntax::ActionInfo>(iter.first, act_info));
   }
 
-  for (std::vector<std::pair<std::string, Syntax::ActionInfo> >::iterator act_names = all_names.begin(); act_names != all_names.end(); ++act_names)
+  for (const auto & act_names : all_names)
   {
-    InputParameters action_obj_params = _action_factory.getValidParams(act_names->second._action);
-    _syntax_formatter->insertNode(act_names->first, act_names->second._action, true, &action_obj_params);
+    InputParameters action_obj_params = _action_factory.getValidParams(act_names.second._action);
+    _syntax_formatter->insertNode(act_names.first, act_names.second._action, true, &action_obj_params);
 
-    const std::string & task = act_names->second._task;
-    std::string act_name = act_names->first;
+    const std::string & task = act_names.second._task;
+    std::string act_name = act_names.first;
 
     // We need to see if this action is inherited from MooseObjectAction
     // If it is, then we will loop over all the Objects in MOOSE's Factory object to print them out
@@ -687,7 +684,7 @@ void Parser::setDoubleIndexParameter<VariableName>(const std::string & full_name
   } while (0)
 
 void
-Parser::extractParams(const std::string & prefix, InputParameters &p)
+Parser::extractParams(const std::string & prefix, InputParameters & p)
 {
   std::ostringstream error_stream;
   static const std::string global_params_task = "set_global_params";
@@ -703,27 +700,27 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
   // Set a pointer to the current InputParameters object being parsed so that it can be referred to in the extraction routines
   _current_params = &p;
   _current_error_stream = &error_stream;
-  for (InputParameters::iterator it = p.begin(); it != p.end(); ++it)
+  for (const auto & it : p)
   {
     bool found = false;
     bool in_global = false;
-    std::string orig_name = prefix + "/" + it->first;
+    std::string orig_name = prefix + "/" + it.first;
     std::string full_name = orig_name;
 
     // Mark parameters appearing in the input file or command line
     if (_getpot_file.have_variable(full_name.c_str()) || (_app.commandLine() && _app.commandLine()->haveVariable(full_name.c_str())))
     {
-      p.set_attributes(it->first, false);
+      p.set_attributes(it.first, false);
       _extracted_vars.insert(full_name);  // Keep track of all variables extracted from the input file
       found = true;
     }
     // Wait! Check the GlobalParams section
     else if (global_params_block != NULL)
     {
-      full_name = global_params_block_name + "/" + it->first;
+      full_name = global_params_block_name + "/" + it.first;
       if (_getpot_file.have_variable(full_name.c_str()))
       {
-        p.set_attributes(it->first, false);
+        p.set_attributes(it.first, false);
         _extracted_vars.insert(full_name);  // Keep track of all variables extracted from the input file
         found = true;
         in_global = true;
@@ -740,7 +737,7 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
       // In the case where we have OutFileName but it wasn't actually found in the input filename,
       // we will populate it with the actual parsed filename which is available here in the parser.
 
-      InputParameters::Parameter<OutFileBase> * scalar_p = dynamic_cast<InputParameters::Parameter<OutFileBase>*>(it->second);
+      InputParameters::Parameter<OutFileBase> * scalar_p = dynamic_cast<InputParameters::Parameter<OutFileBase>*>(it.second);
       if (scalar_p)
       {
         std::string input_file_name = getFileName();
@@ -748,7 +745,7 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
         size_t pos = input_file_name.find_last_of('.');
         mooseAssert(pos != std::string::npos, "Unable to determine suffix of input file name");
         scalar_p->set() = input_file_name.substr(0,pos) + "_out";
-        p.set_attributes(it->first, false);
+        p.set_attributes(it.first, false);
       }
     }
     else
@@ -758,54 +755,54 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
        */
       // built-ins
       // NOTE: Similar dynamic casting is done in InputParameters.C, please update appropriately
-      dynamicCastAndExtractScalarValueType(Real, Real         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalarValueType(int,  long         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalarValueType(long, long         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalarValueType(unsigned int, long , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(bool                        , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractScalarValueType(Real, Real         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalarValueType(int,  long         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalarValueType(long, long         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalarValueType(unsigned int, long , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(bool                        , it.second, full_name, it.first, in_global, global_params_block);
 
       // Moose Scalars
-      dynamicCastAndExtractScalar(SubdomainID           , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(BoundaryID            , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(SubdomainID           , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(BoundaryID            , it.second, full_name, it.first, in_global, global_params_block);
 
       // Moose Compound Scalars
-      dynamicCastAndExtractScalar(RealVectorValue       , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(Point                 , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(MooseEnum             , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(MultiMooseEnum        , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(RealTensorValue       , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(RealVectorValue       , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(Point                 , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(MooseEnum             , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(MultiMooseEnum        , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(RealTensorValue       , it.second, full_name, it.first, in_global, global_params_block);
 
       // Moose String-derived scalars
-      dynamicCastAndExtractScalar(/*std::*/string       , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(SubdomainName         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(BoundaryName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(FileName              , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(FileNameNoExtension   , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(MeshFileName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(OutFileBase           , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(VariableName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(NonlinearVariableName , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(AuxVariableName       , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(FunctionName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(UserObjectName        , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(PostprocessorName     , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(VectorPostprocessorName, it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(IndicatorName         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(MarkerName            , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(MultiAppName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(OutputName            , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(MaterialPropertyName  , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractScalar(MaterialName          , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(/*std::*/string       , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(SubdomainName         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(BoundaryName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(FileName              , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(FileNameNoExtension   , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(MeshFileName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(OutFileBase           , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(VariableName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(NonlinearVariableName , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(AuxVariableName       , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(FunctionName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(UserObjectName        , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(PostprocessorName     , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(VectorPostprocessorName, it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(IndicatorName         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(MarkerName            , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(MultiAppName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(OutputName            , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(MaterialPropertyName  , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractScalar(MaterialName          , it.second, full_name, it.first, in_global, global_params_block);
 
 
       /**
        * Vector types
        */
       // built-ins
-      dynamicCastAndExtractVector(Real                  , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(int                   , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(long                  , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(unsigned int          , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractVector(Real                  , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(int                   , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(long                  , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(unsigned int          , it.second, full_name, it.first, in_global, global_params_block);
       // We need to be able to parse 8-byte unsigned types when
       // libmesh is configured --with-dof-id-bytes=8.  Officially,
       // libmesh uses uint64_t in that scenario, which is usually
@@ -814,72 +811,72 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
       // but presumably uint64_t is the "most standard" way to get a
       // 64-bit unsigned type, so we'll stick with that here.
 #if LIBMESH_DOF_ID_BYTES == 8
-      dynamicCastAndExtractVector(uint64_t              , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractVector(uint64_t              , it.second, full_name, it.first, in_global, global_params_block);
 #endif
 
       // Moose Vectors
-      dynamicCastAndExtractVector(SubdomainID           , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(BoundaryID            , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(RealVectorValue       , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(Point                 , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(MooseEnum             , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractVector(SubdomainID           , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(BoundaryID            , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(RealVectorValue       , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(Point                 , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(MooseEnum             , it.second, full_name, it.first, in_global, global_params_block);
       /* We won't try to do vectors of tensors ;) */
 
       // Moose String-derived vectors
-      dynamicCastAndExtractVector(/*std::*/string       , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(FileName              , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(FileNameNoExtension   , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(MeshFileName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(SubdomainName         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(BoundaryName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(VariableName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(NonlinearVariableName , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(AuxVariableName       , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(FunctionName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(UserObjectName        , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(IndicatorName         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(MarkerName            , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(MultiAppName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(PostprocessorName     , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(VectorPostprocessorName, it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(OutputName            , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(MaterialPropertyName  , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractVector(MaterialName          , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractVector(/*std::*/string       , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(FileName              , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(FileNameNoExtension   , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(MeshFileName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(SubdomainName         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(BoundaryName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(VariableName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(NonlinearVariableName , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(AuxVariableName       , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(FunctionName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(UserObjectName        , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(IndicatorName         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(MarkerName            , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(MultiAppName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(PostprocessorName     , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(VectorPostprocessorName, it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(OutputName            , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(MaterialPropertyName  , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractVector(MaterialName          , it.second, full_name, it.first, in_global, global_params_block);
 
       /**
        * Double indexed types
        */
        // built-ins
-       dynamicCastAndExtractDoubleIndex(Real                  , it->second, full_name, it->first, in_global, global_params_block);
-       dynamicCastAndExtractDoubleIndex(int                   , it->second, full_name, it->first, in_global, global_params_block);
-       dynamicCastAndExtractDoubleIndex(long                  , it->second, full_name, it->first, in_global, global_params_block);
-       dynamicCastAndExtractDoubleIndex(unsigned int          , it->second, full_name, it->first, in_global, global_params_block);
+       dynamicCastAndExtractDoubleIndex(Real                  , it.second, full_name, it.first, in_global, global_params_block);
+       dynamicCastAndExtractDoubleIndex(int                   , it.second, full_name, it.first, in_global, global_params_block);
+       dynamicCastAndExtractDoubleIndex(long                  , it.second, full_name, it.first, in_global, global_params_block);
+       dynamicCastAndExtractDoubleIndex(unsigned int          , it.second, full_name, it.first, in_global, global_params_block);
        // See vector type explanation
  #if LIBMESH_DOF_ID_BYTES == 8
-       dynamicCastAndExtractDoubleIndex(uint64_t              , it->second, full_name, it->first, in_global, global_params_block);
+       dynamicCastAndExtractDoubleIndex(uint64_t              , it.second, full_name, it.first, in_global, global_params_block);
  #endif
 
-      dynamicCastAndExtractDoubleIndex(SubdomainID           , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(BoundaryID            , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(SubdomainID           , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(BoundaryID            , it.second, full_name, it.first, in_global, global_params_block);
 
       // Moose String-derived vectors
-      dynamicCastAndExtractDoubleIndex(/*std::*/string       , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(FileName              , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(FileNameNoExtension   , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(MeshFileName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(SubdomainName         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(BoundaryName          , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(/*std::*/string       , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(FileName              , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(FileNameNoExtension   , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(MeshFileName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(SubdomainName         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(BoundaryName          , it.second, full_name, it.first, in_global, global_params_block);
       // reading double indexed Variable name is problematic because Coupleable assumes they come as vectors
       // therefore they not included in this list
-      dynamicCastAndExtractDoubleIndex(FunctionName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(UserObjectName        , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(IndicatorName         , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(MarkerName            , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(MultiAppName          , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(PostprocessorName     , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(VectorPostprocessorName, it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(OutputName            , it->second, full_name, it->first, in_global, global_params_block);
-      dynamicCastAndExtractDoubleIndex(MaterialPropertyName  , it->second, full_name, it->first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(FunctionName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(UserObjectName        , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(IndicatorName         , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(MarkerName            , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(MultiAppName          , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(PostprocessorName     , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(VectorPostprocessorName, it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(OutputName            , it.second, full_name, it.first, in_global, global_params_block);
+      dynamicCastAndExtractDoubleIndex(MaterialPropertyName  , it.second, full_name, it.first, in_global, global_params_block);
     }
   }
 
@@ -889,13 +886,13 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
 
   // Here we will see if there are any auto build vectors that need to be created
   const std::map<std::string, std::pair<std::string, std::string> > & auto_build_vectors = p.getAutoBuildVectors();
-  for (std::map<std::string, std::pair<std::string, std::string> >::const_iterator it = auto_build_vectors.begin(); it != auto_build_vectors.end(); ++it)
+  for (const auto & it : auto_build_vectors)
   {
     // We'll autogenerate values iff the requested vector is not valid but both the base and number are valid
-    const std::string & base_name = it->second.first;
-    const std::string & num_repeat = it->second.second;
+    const std::string & base_name = it.second.first;
+    const std::string & num_repeat = it.second.second;
 
-    if (!p.isParamValid(it->first) && p.isParamValid(base_name) && p.isParamValid(num_repeat))
+    if (!p.isParamValid(it.first) && p.isParamValid(base_name) && p.isParamValid(num_repeat))
     {
       unsigned int vec_size = p.get<unsigned int>(num_repeat);
       const std::string & name = p.get<std::string>(base_name);
@@ -909,7 +906,7 @@ Parser::extractParams(const std::string & prefix, InputParameters &p)
       }
 
       // Finally set the autogenerated vector into the InputParameters object
-      p.set<std::vector<VariableName> >(it->first) = variable_names;
+      p.set<std::vector<VariableName> >(it.first) = variable_names;
     }
   }
 }
@@ -1241,7 +1238,7 @@ void Parser::setVectorParameter<MooseEnum>(const std::string & full_name, const 
   std::vector<MooseEnum> enum_values = param->get();
   std::vector<std::string> values(enum_values.size());
   for (unsigned int i=0; i<values.size(); ++i)
-    values[i] = (std::string)enum_values[i];
+    values[i] = static_cast<std::string>(enum_values[i]);
 
   /**
    * With MOOSE Enums we need a default object so it should have been passed in the param

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -130,13 +130,9 @@ Syntax::getSyntaxByAction(const std::string & action, const std::string & task)
    * is only used by the build full tree routine so it doesn't need to be fast.  We
    * will do a linear search for each call to this routine
    */
-  for (std::multimap<std::string, ActionInfo>::const_iterator iter = _associated_actions.begin();
-       iter != _associated_actions.end(); ++iter)
-  {
-    if (iter->second._action == action &&
-        (iter->second._task == task || iter->second._task == ""))
-      syntax = iter->first;
-  }
+  for (const auto & iter : _associated_actions)
+    if (iter.second._action == action && (iter.second._task == task || iter.second._task == ""))
+      syntax = iter.first;
 
   return syntax;
 }

--- a/framework/src/postprocessors/PostprocessorData.C
+++ b/framework/src/postprocessors/PostprocessorData.C
@@ -76,9 +76,9 @@ PostprocessorData::storeValue(const std::string & name, PostprocessorValue value
 void
 PostprocessorData::copyValuesBack()
 {
-  for (std::map<std::string, PostprocessorValue*>::iterator it = _values.begin(); it != _values.end(); ++it)
+  for (const auto & it : _values)
   {
-    getPostprocessorValueOlder(it->first) = getPostprocessorValueOld(it->first);
-    getPostprocessorValueOld(it->first) = getPostprocessorValue(it->first);
+    getPostprocessorValueOlder(it.first) = getPostprocessorValueOld(it.first);
+    getPostprocessorValueOld(it.first) = getPostprocessorValue(it.first);
   }
 }

--- a/framework/src/preconditioners/MoosePreconditioner.C
+++ b/framework/src/preconditioners/MoosePreconditioner.C
@@ -60,7 +60,7 @@ MoosePreconditioner::copyVarValues(MeshBase & mesh,
     MeshBase::node_iterator it = mesh.local_nodes_begin();
     MeshBase::node_iterator it_end = mesh.local_nodes_end();
 
-    for (;it!=it_end;++it)
+    for (; it != it_end; ++it)
     {
       Node * node = *it;
 
@@ -82,7 +82,7 @@ MoosePreconditioner::copyVarValues(MeshBase & mesh,
     MeshBase::element_iterator it = mesh.local_elements_begin();
     MeshBase::element_iterator it_end = mesh.local_elements_end();
 
-    for (;it!=it_end;++it)
+    for (; it != it_end; ++it)
     {
       Elem * elem = *it;
 

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -133,9 +133,8 @@ PhysicsBasedPreconditioner::~PhysicsBasedPreconditioner ()
 {
   this->clear();
 
-  std::vector<Preconditioner<Number> *>::iterator it;
-  for (it = _preconditioners.begin(); it != _preconditioners.end(); ++it)
-    delete *it;
+  for (auto & pc : _preconditioners)
+    delete pc;
 }
 
 void
@@ -153,7 +152,7 @@ PhysicsBasedPreconditioner::addSystem(unsigned int var, std::vector<unsigned int
   _pre_type[var] = type;
 
   _off_diag_mats[var].resize(off_diag.size());
-  for (unsigned int i=0;i<off_diag.size();i++)
+  for (unsigned int i = 0; i < off_diag.size(); i++)
   {
     //Add the matrix to hold the off-diagonal piece
     _off_diag_mats[var][i] = &precond_system.add_matrix(_nl.sys().variable_name(off_diag[i]));
@@ -176,7 +175,7 @@ PhysicsBasedPreconditioner::init ()
   if (_solve_order.size() == 0)
   {
     _solve_order.resize(num_systems);
-    for (unsigned int i=0;i<num_systems;i++)
+    for (unsigned int i = 0; i < num_systems; i++)
       _solve_order[i]=i;
   }
 
@@ -216,7 +215,7 @@ PhysicsBasedPreconditioner::setup()
       blocks.push_back(block);
     }
 
-    for (unsigned int diag=0;diag<_off_diag[system_var].size();diag++)
+    for (unsigned int diag = 0; diag < _off_diag[system_var].size(); diag++)
     {
       unsigned int coupled_var = _off_diag[system_var][diag];
       std::string coupled_name = _nl.sys().variable_name(coupled_var);
@@ -229,8 +228,8 @@ PhysicsBasedPreconditioner::setup()
   _fe_problem.computeJacobianBlocks(blocks);
 
   // cleanup
-  for (unsigned int i=0; i<blocks.size(); i++)
-    delete blocks[i];
+  for (auto & block : blocks)
+    delete block;
 }
 
 void
@@ -260,7 +259,7 @@ PhysicsBasedPreconditioner::apply(const NumericVector<Number> & x, NumericVector
 
     //Modify the RHS by subtracting off the matvecs of the solutions for the other preconditioning
     //systems with the off diagonal blocks in this system.
-    for (unsigned int diag=0;diag<_off_diag[system_var].size();diag++)
+    for (unsigned int diag = 0; diag < _off_diag[system_var].size(); diag++)
     {
       unsigned int coupled_var = _off_diag[system_var][diag];
       LinearImplicitSystem & coupled_system = *_systems[coupled_var];

--- a/framework/src/restart/RestartableDataIO.C
+++ b/framework/src/restart/RestartableDataIO.C
@@ -85,23 +85,19 @@ RestartableDataIO::serializeRestartableData(const std::map<std::string, Restarta
     stream.write((const char *) &n_data, sizeof(n_data));
 
     // data names
-    for (std::map<std::string, RestartableDataValue *>::const_iterator it = restartable_data.begin();
-         it != restartable_data.end();
-         ++it)
+    for (const auto & it : restartable_data)
     {
-      std::string name = it->first;
+      std::string name = it.first;
       stream.write(name.c_str(), name.length() + 1); // trailing 0!
     }
   }
   {
     std::ostringstream data_blk;
 
-    for (std::map<std::string, RestartableDataValue *>::const_iterator it = restartable_data.begin();
-         it != restartable_data.end();
-         ++it)
+    for (const auto & it : restartable_data)
     {
       std::ostringstream data;
-      it->second->store(data);
+      it.second->store(data);
 
       // Store the size of the data then the data
       unsigned int data_size = static_cast<unsigned int>(data.tellp());

--- a/framework/src/transfers/DTKInterpolationAdapter.C
+++ b/framework/src/transfers/DTKInterpolationAdapter.C
@@ -54,11 +54,9 @@ DTKInterpolationAdapter::DTKInterpolationAdapter(Teuchos::RCP<const Teuchos::Mpi
   {
     GlobalOrdinal i = 0;
 
-    for (std::set<GlobalOrdinal>::iterator it = semi_local_nodes.begin();
-        it != semi_local_nodes.end();
-        ++it)
+    for (const auto & dof : semi_local_nodes)
     {
-      const Node & node = mesh.node_ref(*it);
+      const Node & node = mesh.node_ref(dof);
 
       vertices[i] = node.id();
 
@@ -255,14 +253,12 @@ DTKInterpolationAdapter::update_variable_values(std::string var_name, Teuchos::A
   // We're only going to update values for points that were not missed
   std::vector<bool> missed(values->size(), false);
 
-  for (Teuchos::ArrayView<const GlobalOrdinal>::const_iterator i=missed_points.begin();
-      i != missed_points.end();
-      ++i)
-    missed[*i] = true;
+  for (const auto & dof : missed_points)
+    missed[dof] = true;
 
   unsigned int i=0;
   // Loop over the values (one for each node) and assign the value of this variable at each node
-  for (FieldContainerType::iterator it=values->begin(); it != values->end(); ++it)
+  for (const auto & val : *values)
   {
     // If this point "missed" then skip it
     if (missed[i])
@@ -282,7 +278,7 @@ DTKInterpolationAdapter::update_variable_values(std::string var_name, Teuchos::A
     {
       // The 0 is for the component... this only works for LAGRANGE!
       dof_id_type dof = dof_object->dof_number(sys->number(), var_num, 0);
-      sys->solution->set(dof, *it);
+      sys->solution->set(dof, val);
     }
 
     i++;

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -119,12 +119,9 @@ MultiAppNearestNodeTransfer::execute()
           BoundaryID target_bnd_id = _to_meshes[i_to]->getBoundaryID(getParam<BoundaryName>("target_boundary"));
 
           ConstBndNodeRange & bnd_nodes = *(_to_meshes[i_to])->getBoundaryNodeRange();
-          for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin(); nd != bnd_nodes.end(); ++nd)
-          {
-            const BndNode * bnode = *nd;
+          for (const auto & bnode : bnd_nodes)
             if (bnode->_bnd_id == target_bnd_id && bnode->_node->processor_id() == processor_id())
               target_local_nodes.push_back(bnode->_node);
-          }
         }
         else
         {
@@ -137,19 +134,17 @@ MultiAppNearestNodeTransfer::execute()
             target_local_nodes[i] = *nodes_it;
         }
 
-        for (std::vector<Node *>::iterator node_it = target_local_nodes.begin(); node_it != target_local_nodes.end(); ++node_it)
+        for (const auto & node : target_local_nodes)
         {
-          Node * node = *node_it;
-
           // Skip this node if the variable has no dofs at it.
           if (node->n_dofs(sys_num, var_num) < 1)
             continue;
 
           // Find which bboxes might have the nearest node to this point.
           Real nearest_max_distance = std::numeric_limits<Real>::max();
-          for (unsigned int i_from = 0; i_from < bboxes.size(); i_from++)
+          for (const auto & bbox : bboxes)
           {
-            Real distance = bboxMaxDistance(*node, bboxes[i_from]);
+            Real distance = bboxMaxDistance(*node, bbox);
             if (distance < nearest_max_distance)
               nearest_max_distance = distance;
           }
@@ -191,9 +186,9 @@ MultiAppNearestNodeTransfer::execute()
 
           // Find which bboxes might have the nearest node to this point.
           Real nearest_max_distance = std::numeric_limits<Real>::max();
-          for (unsigned int i_from = 0; i_from < bboxes.size(); i_from++)
+          for (const auto & bbox : bboxes)
           {
-            Real distance = bboxMaxDistance(centroid, bboxes[i_from]);
+            Real distance = bboxMaxDistance(centroid, bbox);
             if (distance < nearest_max_distance)
               nearest_max_distance = distance;
           }
@@ -382,12 +377,9 @@ MultiAppNearestNodeTransfer::execute()
         BoundaryID target_bnd_id = _to_meshes[i_to]->getBoundaryID(getParam<BoundaryName>("target_boundary"));
 
         ConstBndNodeRange & bnd_nodes = *(_to_meshes[i_to])->getBoundaryNodeRange();
-        for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin(); nd != bnd_nodes.end(); ++nd)
-        {
-          const BndNode * bnode = *nd;
+        for (const auto & bnode : bnd_nodes)
           if (bnode->_bnd_id == target_bnd_id && bnode->_node->processor_id() == processor_id())
             target_local_nodes.push_back(bnode->_node);
-        }
       }
       else
       {
@@ -400,10 +392,8 @@ MultiAppNearestNodeTransfer::execute()
           target_local_nodes[i] = *nodes_it;
       }
 
-      for (std::vector<Node *>::iterator node_it = target_local_nodes.begin(); node_it != target_local_nodes.end(); ++node_it)
+      for (const auto & node : target_local_nodes)
       {
-        Node * node = *node_it;
-
         // Skip this node if the variable has no dofs at it.
         if (node->n_dofs(sys_num, var_num) < 1)
           continue;
@@ -517,9 +507,8 @@ MultiAppNearestNodeTransfer::getNearestNode(const Point & p, Real & distance, Mo
     BoundaryID src_bnd_id = mesh->getBoundaryID(getParam<BoundaryName>("source_boundary"));
 
     ConstBndNodeRange & bnd_nodes = *mesh->getBoundaryNodeRange();
-    for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin() ; nd != bnd_nodes.end(); ++nd)
+    for (const auto & bnode : bnd_nodes)
     {
-      const BndNode * bnode = *nd;
       if (bnode->_bnd_id == src_bnd_id)
       {
         Node * node = bnode->_node;
@@ -562,15 +551,9 @@ MultiAppNearestNodeTransfer::bboxMaxDistance(Point p, MeshTools::BoundingBox bbo
 
   std::vector<Point> all_points(8);
   for (unsigned int x = 0; x < 2; x++)
-  {
     for (unsigned int y = 0; y < 2; y++)
-    {
       for (unsigned int z = 0; z < 2; z++)
-      {
         all_points[x + 2*y + 4*z] = Point(source_points[x](0), source_points[y](1), source_points[z](2));
-      }
-    }
-  }
 
   Real max_distance = 0.;
 
@@ -592,15 +575,9 @@ MultiAppNearestNodeTransfer::bboxMinDistance(Point p, MeshTools::BoundingBox bbo
 
   std::vector<Point> all_points(8);
   for (unsigned int x = 0; x < 2; x++)
-  {
     for (unsigned int y = 0; y < 2; y++)
-    {
       for (unsigned int z = 0; z < 2; z++)
-      {
         all_points[x + 2*y + 4*z] = Point(source_points[x](0), source_points[y](1), source_points[z](2));
-      }
-    }
-  }
 
   Real min_distance = 0.;
 
@@ -621,12 +598,9 @@ MultiAppNearestNodeTransfer::getLocalNodes(MooseMesh * mesh, std::vector<Node *>
     BoundaryID src_bnd_id = mesh->getBoundaryID(getParam<BoundaryName>("source_boundary"));
 
     ConstBndNodeRange & bnd_nodes = *mesh->getBoundaryNodeRange();
-    for (ConstBndNodeRange::const_iterator nd = bnd_nodes.begin() ; nd != bnd_nodes.end(); ++nd)
-    {
-      const BndNode * bnode = *nd;
+    for (const auto & bnode : bnd_nodes)
       if (bnode->_bnd_id == src_bnd_id && bnode->_node->processor_id() == processor_id())
         local_nodes.push_back(bnode->_node);
-    }
   }
   else
   {
@@ -637,8 +611,6 @@ MultiAppNearestNodeTransfer::getLocalNodes(MooseMesh * mesh, std::vector<Node *>
 
     unsigned int i = 0;
     for (MeshBase::const_node_iterator node_it = nodes_begin; node_it != nodes_end; ++node_it, ++i)
-    {
       local_nodes[i] = *node_it;
-    }
   }
 }

--- a/framework/src/userobject/ElementUserObject.C
+++ b/framework/src/userobject/ElementUserObject.C
@@ -52,6 +52,6 @@ ElementUserObject::ElementUserObject(const InputParameters & parameters) :
 {
   // Keep track of which variables are coupled so we know what we depend on
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 }

--- a/framework/src/userobject/InternalSideUserObject.C
+++ b/framework/src/userobject/InternalSideUserObject.C
@@ -49,8 +49,8 @@ InternalSideUserObject::InternalSideUserObject(const InputParameters & parameter
 {
   // Keep track of which variables are coupled so we know what we depend on
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 }
 
 InternalSideUserObject::~InternalSideUserObject()

--- a/framework/src/userobject/LayeredAverage.C
+++ b/framework/src/userobject/LayeredAverage.C
@@ -33,8 +33,8 @@ LayeredAverage::initialize()
 {
   LayeredIntegral::initialize();
 
-  for (unsigned int i=0; i<_layer_volumes.size(); i++)
-    _layer_volumes[i] = 0.0;
+  for (auto & vol : _layer_volumes)
+    vol = 0.0;
 }
 
 void

--- a/framework/src/userobject/LayeredSideAverage.C
+++ b/framework/src/userobject/LayeredSideAverage.C
@@ -33,8 +33,8 @@ LayeredSideAverage::initialize()
 {
   LayeredSideIntegral::initialize();
 
-  for (unsigned int i=0; i<_layer_volumes.size(); i++)
-    _layer_volumes[i] = 0.0;
+  for (auto & vol : _layer_volumes)
+    vol = 0.0;
 }
 
 void

--- a/framework/src/userobject/NodalUserObject.C
+++ b/framework/src/userobject/NodalUserObject.C
@@ -49,8 +49,8 @@ NodalUserObject::NodalUserObject(const InputParameters & parameters) :
     _unique_node_execute(getParam<bool>("unique_node_execute"))
 {
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 }
 
 

--- a/framework/src/userobject/SideUserObject.C
+++ b/framework/src/userobject/SideUserObject.C
@@ -49,6 +49,6 @@ SideUserObject::SideUserObject(const InputParameters & parameters) :
 {
   // Keep track of which variables are coupled so we know what we depend on
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
-  for (unsigned int i=0; i<coupled_vars.size(); i++)
-    addMooseVariableDependency(coupled_vars[i]);
+  for (const auto & var : coupled_vars)
+    addMooseVariableDependency(var);
 }

--- a/framework/src/utils/ImageSampler.C
+++ b/framework/src/utils/ImageSampler.C
@@ -144,8 +144,8 @@ ImageSampler::setupImageSampler(MooseMesh & mesh)
   // Storage for the file names
   _files = vtkSmartPointer<vtkStringArray>::New();
 
-  for (unsigned i=0; i<filenames.size(); ++i)
-    _files->InsertNextValue(filenames[i]);
+  for (const auto & filename : filenames)
+    _files->InsertNextValue(filename);
 
   // Error if no files where located
   if (_files->GetNumberOfValues() == 0)

--- a/framework/src/utils/InputParameterWarehouse.C
+++ b/framework/src/utils/InputParameterWarehouse.C
@@ -55,8 +55,8 @@ InputParameterWarehouse::addInputParameters(const std::string & name, InputParam
   if (ptr->isParamValid("control_tags"))
   {
     const std::vector<std::string> & tags = ptr->get<std::vector<std::string> >("control_tags");
-    for (std::vector<std::string>::const_iterator it = tags.begin(); it != tags.end(); ++it)
-      _input_parameters[tid].insert(std::pair<MooseObjectName, MooseSharedPointer<InputParameters> >(MooseObjectName(*it, name),  ptr));
+    for (const auto & tag : tags)
+      _input_parameters[tid].insert(std::pair<MooseObjectName, MooseSharedPointer<InputParameters> >(MooseObjectName(tag, name),  ptr));
   }
 
   // Set the name and tid parameters

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -239,13 +239,12 @@ InputParameters::getDocString(const std::string & name) const
   std::string doc_string;
   std::map<std::string, std::string>::const_iterator doc_string_it = _doc_string.find(name);
   if (doc_string_it != _doc_string.end())
-    for (std::string::const_iterator it = (doc_string_it->second).begin();
-         it != (doc_string_it->second).end(); ++it)
+    for (const auto & ch : doc_string_it->second)
     {
-      if (*it == '\n')
+      if (ch == '\n')
         doc_string += " ... ";
       else
-        doc_string += *it;
+        doc_string += ch;
     }
 
   return doc_string;
@@ -277,8 +276,8 @@ InputParameters::isParamSetByAddParam(const std::string & name) const
 bool
 InputParameters::areAllRequiredParamsValid() const
 {
-  for (Parameters::const_iterator it = this->begin(); it != this->end(); ++it)
-    if (isParamRequired(it->first) && !isParamValid(it->first))
+  for (const auto & it : *this)
+    if (isParamRequired(it.first) && !isParamValid(it.first))
       return false;
   return true;
 }
@@ -368,51 +367,51 @@ InputParameters::checkParams(const std::string & parsing_syntax)
 
   std::ostringstream oss;
   // Required parameters
-  for (InputParameters::const_iterator it = this->begin(); it != this->end(); ++it)
+  for (const auto & it : *this)
   {
-    if (!isParamValid(it->first) && isParamRequired(it->first))
+    if (!isParamValid(it.first) && isParamRequired(it.first))
     {
       // The parameter is required but missing
       if (oss.str().empty())
         oss << "The following required parameters are missing:" << std::endl;
-      oss << l_prefix << "/" << it->first << std::endl;
-      oss << "\tDoc String: \"" + getDocString(it->first) + "\"" << std::endl;
+      oss << l_prefix << "/" << it.first << std::endl;
+      oss << "\tDoc String: \"" + getDocString(it.first) + "\"" << std::endl;
     }
   }
 
   // Range checked parameters
-  for (InputParameters::const_iterator it = this->begin(); it != this->end(); ++it)
+  for (const auto & it : *this)
   {
-    std::string long_name(l_prefix + "/" + it->first);
+    std::string long_name(l_prefix + "/" + it.first);
 
-    dynamicCastRangeCheck(Real, Real,         long_name, it->first, it->second, oss);
-    dynamicCastRangeCheck(int,  long,         long_name, it->first, it->second, oss);
-    dynamicCastRangeCheck(long, long,         long_name, it->first, it->second, oss);
-    dynamicCastRangeCheck(unsigned int, long, long_name, it->first, it->second, oss);
+    dynamicCastRangeCheck(Real, Real,         long_name, it.first, it.second, oss);
+    dynamicCastRangeCheck(int,  long,         long_name, it.first, it.second, oss);
+    dynamicCastRangeCheck(long, long,         long_name, it.first, it.second, oss);
+    dynamicCastRangeCheck(unsigned int, long, long_name, it.first, it.second, oss);
   }
 
   if (!oss.str().empty())
     mooseError(oss.str());
 
   // Controllable parameters
-  for (std::set<std::string>::const_iterator it = _controllable_params.begin(); it != _controllable_params.end(); ++it)
+  for (const auto & param_name : _controllable_params)
   {
     // Check that parameter is valid
-    if (!isParamValid(*it))
-      mooseError("The parameter '" << *it << "' is not a valid parameter for the object " << l_prefix << " thus cannot be marked as controllable.");
+    if (!isParamValid(param_name))
+      mooseError("The parameter '" << param_name << "' is not a valid parameter for the object " << l_prefix << " thus cannot be marked as controllable.");
 
-    if (isPrivate(*it))
-      mooseError("The parameter, '" << *it << "', in " << l_prefix << " is a private parameter and cannot be marked as controllable");
+    if (isPrivate(param_name))
+      mooseError("The parameter, '" << param_name << "', in " << l_prefix << " is a private parameter and cannot be marked as controllable");
 
-    checkMooseType(NonlinearVariableName, *it);
-    checkMooseType(AuxVariableName, *it);
-    checkMooseType(VariableName, *it);
-    checkMooseType(BoundaryName, *it);
-    checkMooseType(SubdomainName, *it);
-    checkMooseType(PostprocessorName, *it);
-    checkMooseType(VectorPostprocessorName, *it);
-    checkMooseType(UserObjectName, *it);
-    checkMooseType(MaterialPropertyName, *it);
+    checkMooseType(NonlinearVariableName, param_name);
+    checkMooseType(AuxVariableName, param_name);
+    checkMooseType(VariableName, param_name);
+    checkMooseType(BoundaryName, param_name);
+    checkMooseType(SubdomainName, param_name);
+    checkMooseType(PostprocessorName, param_name);
+    checkMooseType(VectorPostprocessorName, param_name);
+    checkMooseType(UserObjectName, param_name);
+    checkMooseType(MaterialPropertyName, param_name);
   }
 }
 
@@ -532,14 +531,14 @@ InputParameters::addParamNamesToGroup(const std::string & space_delim_names, con
   // Since we don't require types (templates) for this method, we need
   // to get a raw list of parameter names to compare against.
   std::set<std::string> param_names;
-  for (InputParameters::iterator it = begin(); it != end(); ++it)
-    param_names.insert(it->first);
+  for (const auto & it : *this)
+    param_names.insert(it.first);
 
-  for (std::vector<std::string>::const_iterator it = elements.begin(); it != elements.end(); ++it)
-    if (param_names.find(*it) != param_names.end())
-      _group[*it] = group_name;
+  for (const auto & param_name : elements)
+    if (param_names.find(param_name) != param_names.end())
+      _group[param_name] = group_name;
     else
-      mooseError("Unable to find a parameter with name: " << *it << " when adding to group " << group_name << '.');
+      mooseError("Unable to find a parameter with name: " << param_name << " when adding to group " << group_name << '.');
 }
 
 std::vector<std::string>
@@ -590,10 +589,10 @@ InputParameters::applyParameters(const InputParameters & common, const std::vect
   _show_deprecated_message = false;
 
   // Loop through the common parameters
-  for (InputParameters::const_iterator it = common.begin(); it != common.end(); ++it)
+  for (const auto & it : common)
   {
     // Common parameter name
-    const std::string & common_name = it->first;
+    const std::string & common_name = it.first;
 
     // Continue to next parameter, if the current is in list of  excluded parameters
     if (std::find(exclude.begin(), exclude.end(), common_name) != exclude.end())
@@ -618,7 +617,7 @@ InputParameters::applyParameters(const InputParameters & common, const std::vect
     if ( local_exist && common_valid && (!local_valid || !local_set) && (!common_priv || !local_priv))
     {
       delete _values[common_name];
-      _values[common_name] = it->second->clone();
+      _values[common_name] = it.second->clone();
       set_attributes(common_name, false);
     }
   }

--- a/framework/src/utils/LinearInterpolation.C
+++ b/framework/src/utils/LinearInterpolation.C
@@ -82,11 +82,9 @@ LinearInterpolation::sampleDerivative(Real x) const
 Real
 LinearInterpolation::integrate()
 {
-  Real answer(0);
-  for (unsigned int i(1); i < _x.size(); ++i)
-  {
+  Real answer = 0;
+  for (unsigned int i = 1; i < _x.size(); ++i)
     answer += 0.5*(_y[i]+_y[i-1])*(_x[i]-_x[i-1]);
-  }
 
   return answer;
 }

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -48,9 +48,9 @@ escape(std::string & str)
   escapes['\v'] = "\\v";
   escapes['\r'] = "\\r";
 
-  for (std::map<char, std::string>::iterator it = escapes.begin(); it != escapes.end(); ++it)
-    for (size_t pos=0; (pos=str.find(it->first, pos)) != std::string::npos; pos+=it->second.size())
-      str.replace(pos, 1, it->second);
+  for (const auto & it : escapes)
+    for (size_t pos=0; (pos=str.find(it.first, pos)) != std::string::npos; pos+=it.second.size())
+      str.replace(pos, 1, it.second);
 }
 
 
@@ -317,26 +317,21 @@ relativeFuzzyLessThan(const Real & var1, const Real & var2, const Real & tol)
 void
 MaterialPropertyStorageDump(const HashMap<const libMesh::Elem *, HashMap<unsigned int, MaterialProperties> > & props)
 {
-  // Define the iterators
-  HashMap<const Elem *, HashMap<unsigned int, MaterialProperties> >::const_iterator elem_it;
-  HashMap<unsigned int, MaterialProperties>::const_iterator side_it;
-  MaterialProperties::const_iterator prop_it;
-
   // Loop through the elements
-  for (elem_it = props.begin(); elem_it != props.end(); ++elem_it)
+  for (const auto & elem_it : props)
   {
-    Moose::out << "Element " << elem_it->first->id() << '\n';
+    Moose::out << "Element " << elem_it.first->id() << '\n';
 
     // Loop through the sides
-    for (side_it = elem_it->second.begin(); side_it != elem_it->second.end(); ++side_it)
+    for (const auto & side_it : elem_it.second)
     {
-      Moose::out << "  Side " << side_it->first << '\n';
+      Moose::out << "  Side " << side_it.first << '\n';
 
       // Loop over properties
       unsigned int cnt = 0;
-      for (prop_it = side_it->second.begin(); prop_it != side_it->second.end(); ++prop_it)
+      for (const auto & mat_prop : side_it.second)
       {
-        MaterialProperty<Real> * mp = dynamic_cast<MaterialProperty<Real> *>(*prop_it);
+        MaterialProperty<Real> * mp = dynamic_cast<MaterialProperty<Real> *>(mat_prop);
         if (mp)
         {
           Moose::out << "    Property " << cnt << '\n';
@@ -370,11 +365,11 @@ getFilesInDirs(const std::list<std::string> & directory_list)
 {
   std::list<std::string> files;
 
-  for (std::list<std::string>::const_iterator it = directory_list.begin(); it != directory_list.end(); ++it)
+  for (const auto & dir_name : directory_list)
   {
     tinydir_dir dir;
     dir.has_next = 0; // Avoid a garbage value in has_next (clang StaticAnalysis)
-    tinydir_open(&dir, it->c_str());
+    tinydir_open(&dir, dir_name.c_str());
 
     while (dir.has_next)
     {
@@ -383,7 +378,7 @@ getFilesInDirs(const std::list<std::string> & directory_list)
       tinydir_readfile(&dir, &file);
 
       if (!file.is_dir)
-        files.push_back(*it + "/" + file.name);
+        files.push_back(dir_name + "/" + file.name);
 
       tinydir_next(&dir);
     }
@@ -404,10 +399,10 @@ getRecoveryFileBase(const std::list<std::string> & checkpoint_files)
   std::list<std::string> newest_restart_files;
 
   // Loop through all possible files and store the newest
-  for (std::list<std::string>::const_iterator it = checkpoint_files.begin(); it != checkpoint_files.end(); ++it)
+  for (const auto & cp_file : checkpoint_files)
   {
       struct stat stats;
-      stat(it->c_str(), &stats);
+      stat(cp_file.c_str(), &stats);
 
       time_t mod_time = stats.st_mtime;
       if (mod_time > newest_time)
@@ -417,7 +412,7 @@ getRecoveryFileBase(const std::list<std::string> & checkpoint_files)
       }
 
       if (mod_time == newest_time)
-        newest_restart_files.push_back(*it);
+        newest_restart_files.push_back(cp_file);
   }
 
   // Loop through all of the newest files according the number in the file name
@@ -426,12 +421,12 @@ getRecoveryFileBase(const std::list<std::string> & checkpoint_files)
   pcrecpp::RE re_base_and_file_num("(.*?(\\d+))\\..*"); // Will pull out the full base and the file number simultaneously
 
   // Now, out of the newest files find the one with the largest number in it
-  for (std::list<std::string>::const_iterator it = newest_restart_files.begin(); it != newest_restart_files.end(); ++it)
+  for (const auto & res_file : newest_restart_files)
   {
     std::string the_base;
     int file_num = 0;
 
-    re_base_and_file_num.FullMatch(*it, &the_base, &file_num);
+    re_base_and_file_num.FullMatch(res_file, &the_base, &file_num);
 
     if (file_num > max_file_num)
     {

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -68,8 +68,8 @@ MultiMooseEnum::operator==(const MultiMooseEnum & value) const
     return false;
 
   // Return false if this enum does not contain an item from the other
-  for (MooseEnumIterator it = value.begin(); it != value.end(); ++it)
-    if (!contains(*it))
+  for (const auto & me : value)
+    if (!contains(me))
       return false;
 
   // If you get here, they must be the same
@@ -108,8 +108,8 @@ MultiMooseEnum::contains(const MultiMooseEnum & value) const
 {
   std::set<int> lookup_set(_current_ids.begin(), _current_ids.end());
 
-  for (std::vector<int>::const_iterator it = value._current_ids.begin(); it != value._current_ids.end(); ++it)
-    if (lookup_set.find(*it) == lookup_set.end())
+  for (const auto & id : value._current_ids)
+    if (lookup_set.find(id) == lookup_set.end())
       return false;
 
   return true;
@@ -275,8 +275,8 @@ MultiMooseEnum::unique_items_size() const
 void
 MultiMooseEnum::checkDeprecated() const
 {
-  for (std::set<std::string>::const_iterator it = _current_names.begin(); it != _current_names.end(); ++it)
-    checkDeprecatedBase(*it);
+  for (const auto & name : _current_names)
+    checkDeprecatedBase(name);
 }
 
 std::ostream &

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -102,9 +102,10 @@ PetscErrorCode DMMooseGetContacts(DM dm, std::vector<std::pair<std::string,std::
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE,&ismoose);CHKERRQ(ierr);
   if (!ismoose) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMMOOSE);
   DM_Moose *dmm = (DM_Moose *)dm->data;
-  for (std::map<DM_Moose::ContactID,DM_Moose::ContactName>::const_iterator it = dmm->contactnames->begin(); it != dmm->contactnames->end(); ++it) {
-    contactnames.push_back(it->second);
-    displaced.push_back((*dmm->contact_displaced)[it->second]);
+  for (const auto & it : *(dmm->contactnames))
+  {
+    contactnames.push_back(it.second);
+    displaced.push_back((*dmm->contact_displaced)[it.second]);
   }
   PetscFunctionReturn(0);
 }
@@ -121,9 +122,10 @@ PetscErrorCode DMMooseGetUnContacts(DM dm, std::vector<std::pair<std::string,std
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE,&ismoose);CHKERRQ(ierr);
   if (!ismoose) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMMOOSE);
   DM_Moose *dmm = (DM_Moose *)dm->data;
-  for (std::map<DM_Moose::ContactID,DM_Moose::ContactName>::const_iterator it = dmm->uncontactnames->begin(); it != dmm->uncontactnames->end(); ++it) {
-    uncontactnames.push_back(it->second);
-    displaced.push_back((*dmm->uncontact_displaced)[it->second]);
+  for (const auto & it : *(dmm->uncontactnames))
+  {
+    uncontactnames.push_back(it.second);
+    displaced.push_back((*dmm->uncontact_displaced)[it.second]);
   }
   PetscFunctionReturn(0);
 }
@@ -140,7 +142,8 @@ PetscErrorCode DMMooseGetSides(DM dm, std::vector<std::string>& sidenames)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE,&ismoose);CHKERRQ(ierr);
   if (!ismoose) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMMOOSE);
   DM_Moose *dmm = (DM_Moose *)dm->data;
-  for (std::map<std::string, BoundaryID>::const_iterator it = dmm->sideids->begin(); it != dmm->sideids->end(); ++it) sidenames.push_back(it->first);
+  for (const auto & it : *(dmm->sideids))
+    sidenames.push_back(it.first);
   PetscFunctionReturn(0);
 }
 
@@ -156,7 +159,8 @@ PetscErrorCode DMMooseGetUnSides(DM dm, std::vector<std::string>& sidenames)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE,&ismoose);CHKERRQ(ierr);
   if (!ismoose) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMMOOSE);
   DM_Moose *dmm = (DM_Moose *)dm->data;
-  for (std::map<std::string, BoundaryID>::const_iterator it = dmm->unsideids->begin(); it != dmm->unsideids->end(); ++it) sidenames.push_back(it->first);
+  for (const auto & it : *(dmm->unsideids))
+    sidenames.push_back(it.first);
   PetscFunctionReturn(0);
 }
 
@@ -172,7 +176,8 @@ PetscErrorCode DMMooseGetBlocks(DM dm, std::vector<std::string>& blocknames)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE,&ismoose);CHKERRQ(ierr);
   if (!ismoose) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMMOOSE);
   DM_Moose *dmm = (DM_Moose *)dm->data;
-  for (std::map<std::string, subdomain_id_type>::const_iterator it = dmm->blockids->begin(); it != dmm->blockids->end(); ++it) blocknames.push_back(it->first);
+  for (const auto & it : *(dmm->blockids))
+    blocknames.push_back(it.first);
   PetscFunctionReturn(0);
 }
 
@@ -188,9 +193,8 @@ PetscErrorCode DMMooseGetVariables(DM dm, std::vector<std::string>& varnames)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE,&ismoose);CHKERRQ(ierr);
   if (!ismoose) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMMOOSE);
   DM_Moose *dmm = (DM_Moose *)(dm->data);
-  for (std::map<std::string, unsigned int>::const_iterator it = dmm->varids->begin(); it != dmm->varids->end(); ++it){
-    varnames.push_back(it->first);
-  }
+  for (const auto & it : *(dmm->varids))
+    varnames.push_back(it.first);
   PetscFunctionReturn(0);
 }
 
@@ -300,9 +304,10 @@ PetscErrorCode DMMooseSetContacts(DM dm, const std::vector<std::pair<std::string
   if (dmm->contacts) delete dmm->contacts;
   dmm->contact_displaced->clear();
   dmm->contacts = new std::set<DM_Moose::ContactName>();
-  for (unsigned int i = 0; i < contacts.size(); ++i) {
+  for (unsigned int i = 0; i < contacts.size(); ++i)
+  {
     dmm->contacts->insert(contacts[i]);
-    dmm->contact_displaced->insert(std::pair<DM_Moose::ContactName,PetscBool>(contacts[i],displaced[i]));
+    dmm->contact_displaced->insert(std::make_pair(contacts[i], displaced[i]));
   }
   PetscFunctionReturn(0);
 }
@@ -324,9 +329,10 @@ PetscErrorCode DMMooseSetUnContacts(DM dm, const std::vector<std::pair<std::stri
   if (dmm->uncontacts) delete dmm->uncontacts;
   dmm->uncontact_displaced->clear();
   dmm->uncontacts = new std::set<DM_Moose::ContactName>();
-  for (unsigned int i = 0; i < uncontacts.size(); ++i) {
+  for (unsigned int i = 0; i < uncontacts.size(); ++i)
+  {
     dmm->uncontacts->insert(uncontacts[i]);
-    dmm->uncontact_displaced->insert(std::pair<DM_Moose::ContactName,PetscBool>(uncontacts[i],displaced[i]));
+    dmm->uncontact_displaced->insert(std::make_pair(uncontacts[i], displaced[i]));
   }
   PetscFunctionReturn(0);
 }
@@ -363,9 +369,10 @@ PetscErrorCode DMMooseSetSplitNames(DM dm, const std::vector<std::string>& split
   DM_Moose *dmm = (DM_Moose *)(dm->data);
 
   if (dmm->splits) {
-    for (std::map<std::string,DM_Moose::SplitInfo>::iterator it = dmm->splits->begin(); it != dmm->splits->end(); ++it) {
-      ierr = DMDestroy(&(it->second.dm));CHKERRQ(ierr);
-      ierr = ISDestroy(&(it->second.rembedding));CHKERRQ(ierr);
+    for (auto & it : *(dmm->splits))
+    {
+      ierr = DMDestroy(&(it.second.dm)); CHKERRQ(ierr);
+      ierr = ISDestroy(&(it.second.rembedding)); CHKERRQ(ierr);
     }
     delete dmm->splits;
     dmm->splits = PETSC_NULL;
@@ -376,14 +383,14 @@ PetscErrorCode DMMooseSetSplitNames(DM dm, const std::vector<std::string>& split
   }
   dmm->splits   = new std::map<std::string, DM_Moose::SplitInfo>();
   dmm->splitlocs = new std::multimap<std::string,unsigned int>();
-  for (unsigned int i = 0; i < splitnames.size(); ++i) {
+  for (unsigned int i = 0; i < splitnames.size(); ++i)
+  {
     DM_Moose::SplitInfo info;
     info.dm = PETSC_NULL;
     info.rembedding = PETSC_NULL;
     std::string name = splitnames[i];
     (*dmm->splits)[name] = info;
-    std::pair<std::string,unsigned int> pair(name,i);
-    dmm->splitlocs->insert(pair);
+    dmm->splitlocs->insert(std::make_pair(name, i));
   }
   PetscFunctionReturn(0);
 }
@@ -403,13 +410,13 @@ PetscErrorCode DMMooseGetSplitNames(DM dm, std::vector<std::string>& splitnames)
   if (!dm->setupcalled) SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "DM not set up");
   splitnames.clear();
   splitnames.reserve(dmm->splitlocs->size());
-  if (dmm->splitlocs && dmm->splitlocs->size()) {
-    for (std::multimap<std::string, unsigned int >::const_iterator lit = dmm->splitlocs->begin(); lit != dmm->splitlocs->end(); ++lit) {
-      std::string sname = lit->first;
-      unsigned int sloc = lit->second;
+  if (dmm->splitlocs && dmm->splitlocs->size())
+    for (const auto & lit : *(dmm->splitlocs))
+    {
+      std::string sname = lit.first;
+      unsigned int sloc = lit.second;
       splitnames[sloc] = sname;
     }
-  }
   PetscFunctionReturn(0);
 }
 
@@ -422,157 +429,199 @@ static PetscErrorCode DMMooseGetEmbedding_Private(DM dm, IS *embedding)
 
   PetscFunctionBegin;
   if (!embedding) PetscFunctionReturn(0);
-  if (!dmm->embedding) {
-    /* The rules interpreting the coexistence of blocks (un)sides/(un)contacts are these
-       [sides and contacts behave similarly, so 'sides' means 'sides/contacts']
-       ['ANY' means 'not NONE' and covers 'ALL' as well, unless there is a specific 'ALL' clause, which overrides 'ANY'; 'NOT ALL' means not ALL and not NONE]
-       [there are always some blocks, since by default 'ALL' is assumed, unless it is overridden by a specific list, which implies ANY]
-       In general,
-       (1)  ALL blocks      and ANY sides are interpreted as the INTERSECTION of blocks and sides, equivalent to just the sides (since ALL blocks are assumed to be a cover).
-       (2)  NOT ALL blocks  and ANY or NO sides are interpreted as the UNION of blocks and sides.
-       (3a) ANY unsides and ANY blocks are interpreted as the DIFFERENCE of blocks and unsides.
-       (3b) ANY unsides and ANY sides are interpreted as the DIFFERENCE of sides and unsides.
-       (4)  NO  unsides means NO DIFFERENCE is needed.
-       The result is easily computed by first computing the result of (1 & 2) followed by difference with the result of (3 & 4).
-       To simply (1 & 2) observe the following:
-       - The intersection is computed only if ALL blocks and ANY sides, and the result is the sides, so block dofs do not need to be computed.
-       - Otherwise the union is computed, and initially consists of the blocks' dofs, to which the sides' dofs are added, if ANY.
-       - The result is called 'indices'
-       To satisfy (3 & 4) simply cmpute subtrahend set 'unindices' as all of the unsides' dofs:
-       Then take the set difference of 'indices' and 'unindices', putting the result in 'dindices'.
-    */
-
-    if (!dmm->allvars || !dmm->allblocks || !dmm->nosides || !dmm->nounsides || !dmm->nocontacts || !dmm->nouncontacts) {
-      DofMap& dofmap = dmm->nl->sys().get_dof_map();
-      std::set<dof_id_type>               indices;
+  if (!dmm->embedding)
+  {
+    // The rules interpreting the coexistence of blocks (un)sides/(un)contacts are these
+    // [sides and contacts behave similarly, so 'sides' means 'sides/contacts']
+    // ['ANY' means 'not NONE' and covers 'ALL' as well, unless there is a specific 'ALL' clause, which overrides 'ANY'; 'NOT ALL' means not ALL and not NONE]
+    // [there are always some blocks, since by default 'ALL' is assumed, unless it is overridden by a specific list, which implies ANY]
+    // In general,
+    // (1)  ALL blocks      and ANY sides are interpreted as the INTERSECTION of blocks and sides, equivalent to just the sides (since ALL blocks are assumed to be a cover).
+    // (2)  NOT ALL blocks  and ANY or NO sides are interpreted as the UNION of blocks and sides.
+    // (3a) ANY unsides and ANY blocks are interpreted as the DIFFERENCE of blocks and unsides.
+    // (3b) ANY unsides and ANY sides are interpreted as the DIFFERENCE of sides and unsides.
+    // (4)  NO  unsides means NO DIFFERENCE is needed.
+    // The result is easily computed by first computing the result of (1 & 2) followed by difference with the result of (3 & 4).
+    // To simply (1 & 2) observe the following:
+    // - The intersection is computed only if ALL blocks and ANY sides, and the result is the sides, so block dofs do not need to be computed.
+    // - Otherwise the union is computed, and initially consists of the blocks' dofs, to which the sides' dofs are added, if ANY.
+    // - The result is called 'indices'
+    // To satisfy (3 & 4) simply cmpute subtrahend set 'unindices' as all of the unsides' dofs:
+    // Then take the set difference of 'indices' and 'unindices', putting the result in 'dindices'.
+    if (!dmm->allvars || !dmm->allblocks || !dmm->nosides || !dmm->nounsides || !dmm->nocontacts || !dmm->nouncontacts)
+    {
+      DofMap & dofmap = dmm->nl->sys().get_dof_map();
+      std::set<dof_id_type> indices;
       std::set<dof_id_type> unindices;
-      for (std::map<std::string, unsigned int>::const_iterator vit = dmm->varids->begin(); vit != dmm->varids->end(); ++vit){
-        unsigned int v = vit->second;
-  /* Iterate only over this DM's blocks. */
-  if (!dmm->allblocks || (dmm->nosides && dmm->nocontacts)) {
-    for (std::map<std::string, subdomain_id_type>::const_iterator bit = dmm->blockids->begin(); bit != dmm->blockids->end(); ++bit) {
-      subdomain_id_type b = bit->second;
-      MeshBase::const_element_iterator el     = dmm->nl->sys().get_mesh().active_local_subdomain_elements_begin(b);
-      MeshBase::const_element_iterator end_el = dmm->nl->sys().get_mesh().active_local_subdomain_elements_end(b);
-      for ( ; el != end_el; ++el) {
-        const Elem* elem = *el;
-        std::vector<dof_id_type> evindices;
-        // Get the degree of freedom indices for the given variable off the current element.
-        dofmap.dof_indices(elem, evindices, v);
-        for (dof_id_type i = 0; i < evindices.size(); ++i) {
-    dof_id_type dof = evindices[i];
-    if (dof >= dofmap.first_dof() && dof < dofmap.end_dof()) /* might want to use variable_first/last_local_dof instead */
-      indices.insert(dof);
+      for (const auto & vit : *(dmm->varids))
+      {
+        unsigned int v = vit.second;
+        // Iterate only over this DM's blocks.
+        if (!dmm->allblocks || (dmm->nosides && dmm->nocontacts))
+        {
+          for (const auto & bit : *(dmm->blockids))
+          {
+            subdomain_id_type b = bit.second;
+            MeshBase::const_element_iterator el     = dmm->nl->sys().get_mesh().active_local_subdomain_elements_begin(b);
+            MeshBase::const_element_iterator end_el = dmm->nl->sys().get_mesh().active_local_subdomain_elements_end(b);
+            for ( ; el != end_el; ++el)
+            {
+              const Elem * elem = *el;
+
+              // Get the degree of freedom indices for the given variable off the current element.
+              std::vector<dof_id_type> evindices;
+              dofmap.dof_indices(elem, evindices, v);
+
+              // might want to use variable_first/last_local_dof instead
+              for (const auto & dof : evindices)
+                if (dof >= dofmap.first_dof() && dof < dofmap.end_dof())
+                  indices.insert(dof);
+            }
+          }
+        }
+
+        // Iterate over the sides from this split.
+        if (dmm->sideids->size())
+        {
+          // For some reason the following may return an empty node list
+          // std::vector<dof_id_type> snodes;
+          // std::vector<boundary_id_type> sides;
+          // dmm->nl->sys().get_mesh().get_boundary_info().build_node_list(snodes, sides);
+          // // FIXME: make an array of (snode,side) pairs, sort on side and use std::lower_bound from <algorithm>
+          // for (dof_id_type i = 0; i < sides.size(); ++i) {
+          //   boundary_id_type s = sides[i];
+          //   if (!dmm->sidenames->count(s)) continue;
+          //  const Node& node = dmm->nl->sys().get_mesh().node_ref(snodes[i]);
+          //  // determine v's dof on node and insert into indices
+          // }
+          ConstBndNodeRange & bnodes = *dmm->nl->mesh().getBoundaryNodeRange();
+          for (const auto & bnode : bnodes)
+          {
+            BoundaryID boundary_id = bnode->_bnd_id;
+            if (dmm->sidenames->find(boundary_id) == dmm->sidenames->end())
+              continue;
+
+            const Node * node = bnode->_node;
+            dof_id_type dof = node->dof_number(dmm->nl->sys().number(),v,0);
+
+            // might want to use variable_first/last_local_dof instead
+            if (dof >= dofmap.first_dof() && dof < dofmap.end_dof())
+              indices.insert(dof);
+          }
+        }
+
+        // Iterate over the sides excluded from this split.
+        if (dmm->unsideids->size())
+        {
+          ConstBndNodeRange & bnodes = *dmm->nl->mesh().getBoundaryNodeRange();
+          for (const auto & bnode : bnodes)
+          {
+            BoundaryID boundary_id = bnode->_bnd_id;
+            if (dmm->unsidenames->find(boundary_id) == dmm->unsidenames->end())
+              continue;
+            const Node * node = bnode->_node;
+
+            // might want to use variable_first/last_local_dof instead
+            dof_id_type dof = node->dof_number(dmm->nl->sys().number(),v,0);
+            if (dof >= dofmap.first_dof() && dof < dofmap.end_dof())
+              unindices.insert(dof);
+          }
+        }
+
+        // Iterate over the contacts included in this split.
+        if (dmm->contactnames->size())
+        {
+          for (const auto & it : *(dmm->contactnames))
+          {
+            PetscBool displaced = (*dmm->contact_displaced)[it.second];
+            PenetrationLocator * locator;
+            if (displaced)
+            {
+              MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
+              if (!displaced_problem)
+              {
+                std::ostringstream err;
+                err << "Cannot use a displaced contact (" << it.second.first << "," << it.second.second << ") with an undisplaced problem";
+                mooseError(err.str());
+              }
+              locator = displaced_problem->geomSearchData()._penetration_locators[it.first];
+            }
+            else
+              locator = dmm->nl->_fe_problem.geomSearchData()._penetration_locators[it.first];
+
+            std::vector<dof_id_type> & slave_nodes = locator->_nearest_node._slave_nodes;
+            for (dof_id_type i = 0; i < slave_nodes.size(); ++i)
+            {
+              if (locator->_has_penetrated.find(slave_nodes[i]) == locator->_has_penetrated.end())
+                continue;
+
+              Node & slave_node = dmm->nl->sys().get_mesh().node_ref(slave_nodes[i]);
+              dof_id_type dof = slave_node.dof_number(dmm->nl->sys().number(),v,0);
+
+              // might want to use variable_first/last_local_dof instead
+              if (dof >= dofmap.first_dof() && dof < dofmap.end_dof())
+                indices.insert(dof);
+            }
+          }
+        }
+
+        // Iterate over the contacts excluded from this split.
+        if (dmm->uncontactnames->size())
+        {
+          for (const auto & it : *(dmm->uncontactnames))
+          {
+            PetscBool displaced = (*dmm->uncontact_displaced)[it.second];
+            PenetrationLocator * locator;
+            if (displaced)
+            {
+              MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
+              if (!displaced_problem)
+              {
+                std::ostringstream err;
+                err << "Cannot use a displaced uncontact (" << it.second.first << "," << it.second.second << ") with an undisplaced problem";
+                mooseError(err.str());
+              }
+              locator = displaced_problem->geomSearchData()._penetration_locators[it.first];
+            }
+            else
+              locator = dmm->nl->_fe_problem.geomSearchData()._penetration_locators[it.first];
+
+            std::vector<dof_id_type> & slave_nodes = locator->_nearest_node._slave_nodes;
+            for (dof_id_type i = 0; i < slave_nodes.size(); ++i)
+            {
+              if (locator->_has_penetrated.find(slave_nodes[i]) == locator->_has_penetrated.end())
+                continue;
+
+              // might want to use variable_first/last_local_dof instead
+              Node & slave_node = dmm->nl->sys().get_mesh().node_ref(slave_nodes[i]);
+              dof_id_type dof = slave_node.dof_number(dmm->nl->sys().number(),v,0);
+              if (dof >= dofmap.first_dof() && dof < dofmap.end_dof())
+                unindices.insert(dof);
+            }
+          }
         }
       }
-    }
-  }
-  /* Iterate over the sides from this split. */
-  if (dmm->sideids->size()) {
-    // For some reason the following may return an empty node list
-    // std::vector<dof_id_type> snodes;
-    // std::vector<boundary_id_type> sides;
-    // dmm->nl->sys().get_mesh().get_boundary_info().build_node_list(snodes, sides);
-    // // FIXME: make an array of (snode,side) pairs, sort on side and use std::lower_bound from <algorithm>
-    // for (dof_id_type i = 0; i < sides.size(); ++i) {
-    //   boundary_id_type s = sides[i];
-    //   if (!dmm->sidenames->count(s)) continue;
-    //  const Node& node = dmm->nl->sys().get_mesh().node_ref(snodes[i]);
-    //  // determine v's dof on node and insert into indices
-    // }
-    ConstBndNodeRange & bnodes = *dmm->nl->mesh().getBoundaryNodeRange();
-    for (ConstBndNodeRange::const_iterator bnodeit = bnodes.begin(); bnodeit != bnodes.end(); ++bnodeit) {
-      const BndNode * bnode = *bnodeit;
-      BoundaryID      boundary_id = bnode->_bnd_id;
-      if (dmm->sidenames->find(boundary_id) == dmm->sidenames->end()) continue;
-      const Node*     node = bnode->_node;
-      dof_id_type dof = node->dof_number(dmm->nl->sys().number(),v,0);
-      if (dof >= dofmap.first_dof() && dof < dofmap.end_dof()) { /* might want to use variable_first/last_local_dof instead */
-        indices.insert(dof);
-      }
-    }
-  }
-  /* Iterate over the sides excluded from this split. */
-  if (dmm->unsideids->size()) {
-    ConstBndNodeRange & bnodes = *dmm->nl->mesh().getBoundaryNodeRange();
-    for (ConstBndNodeRange::const_iterator bnodeit = bnodes.begin(); bnodeit != bnodes.end(); ++bnodeit) {
-      const BndNode * bnode = *bnodeit;
-      BoundaryID      boundary_id = bnode->_bnd_id;
-      if (dmm->unsidenames->find(boundary_id) == dmm->unsidenames->end()) continue;
-      const Node*     node = bnode->_node;
-      dof_id_type dof = node->dof_number(dmm->nl->sys().number(),v,0);
-      if (dof >= dofmap.first_dof() && dof < dofmap.end_dof()) { /* might want to use variable_first/last_local_dof instead */
-        unindices.insert(dof);
-      }
-    }
-  }
-  /* Iterate over the contacts included in this split. */
-  if (dmm->contactnames->size()) {
-    for (std::map<DM_Moose::ContactID, DM_Moose::ContactName>::const_iterator it = dmm->contactnames->begin(); it != dmm->contactnames->end(); ++it) {
-      PetscBool displaced = (*dmm->contact_displaced)[it->second];
-      PenetrationLocator *locator;
-      if (displaced) {
-        MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
-        if (!displaced_problem) {
-    std::ostringstream err;
-    err << "Cannot use a displaced contact (" << it->second.first << "," << it->second.second << ") with an undisplaced problem";
-    mooseError(err.str());
-        }
-        locator = displaced_problem->geomSearchData()._penetration_locators[it->first];
-      } else {
-        locator = dmm->nl->_fe_problem.geomSearchData()._penetration_locators[it->first];
-      }
-      std::vector<dof_id_type>& slave_nodes = locator->_nearest_node._slave_nodes;
-      for (dof_id_type i = 0; i < slave_nodes.size(); ++i) {
-        if (locator->_has_penetrated.find(slave_nodes[i]) == locator->_has_penetrated.end()) continue;
-        Node& slave_node = dmm->nl->sys().get_mesh().node_ref(slave_nodes[i]);
-        dof_id_type dof = slave_node.dof_number(dmm->nl->sys().number(),v,0);
-        if (dof >= dofmap.first_dof() && dof < dofmap.end_dof()) { /* might want to use variable_first/last_local_dof instead */
-    indices.insert(dof);
-        }
-      }
-    }
-  }
-  /* Iterate over the contacts excluded from this split. */
-  if (dmm->uncontactnames->size()) {
-    for (std::map<DM_Moose::ContactID, DM_Moose::ContactName>::const_iterator it = dmm->uncontactnames->begin(); it != dmm->uncontactnames->end(); ++it) {
-      PetscBool displaced = (*dmm->uncontact_displaced)[it->second];
-      PenetrationLocator *locator;
-      if (displaced) {
-        MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->nl->_fe_problem.getDisplacedProblem();
-        if (!displaced_problem) {
-    std::ostringstream err;
-    err << "Cannot use a displaced uncontact (" << it->second.first << "," << it->second.second << ") with an undisplaced problem";
-    mooseError(err.str());
-        }
-        locator = displaced_problem->geomSearchData()._penetration_locators[it->first];
-      } else {
-        locator = dmm->nl->_fe_problem.geomSearchData()._penetration_locators[it->first];
-      }
-      std::vector<dof_id_type>& slave_nodes = locator->_nearest_node._slave_nodes;
-      for (dof_id_type i = 0; i < slave_nodes.size(); ++i) {
-        if (locator->_has_penetrated.find(slave_nodes[i]) == locator->_has_penetrated.end()) continue;
-        Node& slave_node = dmm->nl->sys().get_mesh().node_ref(slave_nodes[i]);
-        dof_id_type dof = slave_node.dof_number(dmm->nl->sys().number(),v,0);
-        if (dof >= dofmap.first_dof() && dof < dofmap.end_dof()) { /* might want to use variable_first/last_local_dof instead */
-    unindices.insert(dof);
-        }
-      }
-    }
-  }
-      }
+
       std::set<dof_id_type> dindices;
-      std::set_difference(indices.begin(),indices.end(),unindices.begin(),unindices.end(),std::inserter(dindices,dindices.end()));
-      PetscInt *darray;
+      std::set_difference(indices.begin(),
+                          indices.end(),
+                          unindices.begin(),
+                          unindices.end(),
+                          std::inserter(dindices,dindices.end()));
+      PetscInt * darray;
       ierr = PetscMalloc(sizeof(PetscInt)*dindices.size(),&darray);CHKERRQ(ierr);
       dof_id_type i = 0;
-      for (std::set<dof_id_type>::const_iterator it = dindices.begin(); it != dindices.end(); ++it) {
-  darray[i] = *it;
-  ++i;
+      for (const auto & dof : dindices)
+      {
+        darray[i] = dof;
+        ++i;
       }
       ierr = ISCreateGeneral(((PetscObject)dm)->comm, dindices.size(),darray, PETSC_OWN_POINTER, &dmm->embedding); CHKERRQ(ierr);
-    } else { /* if (dmm->allblocks && dmm->allvars && dmm->nosides && dmm->nounsides && dmm->nocontacts && dmm->nouncontacts) */
-      /* DMCreateGlobalVector is defined() */
+    }
+    else
+    {
+      // if (dmm->allblocks && dmm->allvars && dmm->nosides && dmm->nounsides && dmm->nocontacts && dmm->nouncontacts)
+      // DMCreateGlobalVector is defined()
       Vec v;
       PetscInt low, high;
 
@@ -601,9 +650,9 @@ static PetscErrorCode  DMCreateFieldDecomposition_Moose(DM dm, PetscInt *len, ch
   if (namelist) {ierr = PetscMalloc(*len*sizeof(char*),namelist);CHKERRQ(ierr);}
   if (islist)   {ierr = PetscMalloc(*len*sizeof(IS),islist);CHKERRQ(ierr);}
   if (dmlist)   {ierr = PetscMalloc(*len*sizeof(DM),dmlist);CHKERRQ(ierr);}
-  for (std::multimap<std::string, unsigned int>::const_iterator dit = dmm->splitlocs->begin(); dit != dmm->splitlocs->end(); ++dit) {
-    unsigned int                         d = dit->second;
-    std::string                          dname = dit->first;
+  for (const auto & dit : *(dmm->splitlocs)) {
+    unsigned int                         d = dit.second;
+    std::string                          dname = dit.first;
     DM_Moose::SplitInfo&                 dinfo = (*dmm->splits)[dname];
     if (!dinfo.dm) {
       ierr = DMCreateMoose(((PetscObject)dm)->comm, *dmm->nl, &dinfo.dm);CHKERRQ(ierr);
@@ -1043,73 +1092,98 @@ static PetscErrorCode  DMView_Moose(DM dm, PetscViewer viewer)
     ierr = PetscObjectGetOptionsPrefix((PetscObject)dm, &prefix); CHKERRQ(ierr);
     ierr = PetscViewerASCIIPrintf(viewer, "DM Moose with name %s and prefix %s\n", name, prefix); CHKERRQ(ierr);
     ierr = PetscViewerASCIIPrintf(viewer, "variables:", name, prefix); CHKERRQ(ierr);
-    std::map<std::string,unsigned int>::iterator vit = dmm->varids->begin();
-    std::map<std::string,unsigned int>::const_iterator vend = dmm->varids->end();
-    for (; vit != vend; ++vit) {
-      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", vit->first.c_str(), vit->second); CHKERRQ(ierr);
+    for (const auto & vit : *(dmm->varids))
+    {
+      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", vit.first.c_str(), vit.second);
+      CHKERRQ(ierr);
     }
     ierr = PetscViewerASCIIPrintf(viewer, "\n");CHKERRQ(ierr);
     ierr = PetscViewerASCIIPrintf(viewer, "blocks:"); CHKERRQ(ierr);
-    std::map<std::string, subdomain_id_type>::iterator bit = dmm->blockids->begin();
-    std::map<std::string, subdomain_id_type>::const_iterator bend = dmm->blockids->end();
-    for (; bit != bend; ++bit) {
-      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", bit->first.c_str(), bit->second); CHKERRQ(ierr);
+    for (const auto & bit : *(dmm->blockids))
+    {
+      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", bit.first.c_str(), bit.second);
+      CHKERRQ(ierr);
     }
-    ierr = PetscViewerASCIIPrintf(viewer, "\n");CHKERRQ(ierr);
-    if (dmm->sideids->size()) {
+    ierr = PetscViewerASCIIPrintf(viewer, "\n"); CHKERRQ(ierr);
+
+    if (dmm->sideids->size())
+    {
       ierr = PetscViewerASCIIPrintf(viewer, "sides:"); CHKERRQ(ierr);
-      std::map<std::string,BoundaryID>::iterator sit = dmm->sideids->begin();
-      std::map<std::string,BoundaryID>::const_iterator send = dmm->sideids->end();
-      for (; sit != send; ++sit) {
-  ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", sit->first.c_str(), sit->second);CHKERRQ(ierr);
+      for (const auto & sit : *(dmm->sideids))
+      {
+        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", sit.first.c_str(), sit.second);
+        CHKERRQ(ierr);
       }
-      ierr = PetscViewerASCIIPrintf(viewer, "\n");CHKERRQ(ierr);
+      ierr = PetscViewerASCIIPrintf(viewer, "\n"); CHKERRQ(ierr);
     }
-    if (dmm->unsideids->size()) {
+
+    if (dmm->unsideids->size())
+    {
       ierr = PetscViewerASCIIPrintf(viewer, "unsides:");CHKERRQ(ierr);
-      std::map<std::string,BoundaryID>::iterator sit = dmm->unsideids->begin();
-      std::map<std::string,BoundaryID>::const_iterator send = dmm->unsideids->end();
-      for (; sit != send; ++sit) {
-  ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", sit->first.c_str(), sit->second);CHKERRQ(ierr);
+      for (const auto & sit : *(dmm->unsideids))
+      {
+        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", sit.first.c_str(), sit.second);
+        CHKERRQ(ierr);
       }
       ierr = PetscViewerASCIIPrintf(viewer, "\n");CHKERRQ(ierr);
     }
-    if (dmm->contactnames->size()) {
+
+    if (dmm->contactnames->size())
+    {
       ierr = PetscViewerASCIIPrintf(viewer, "contacts:");CHKERRQ(ierr);
-      for (std::map<DM_Moose::ContactID,DM_Moose::ContactName>::iterator cit = dmm->contactnames->begin(); cit != dmm->contactnames->end(); ++cit) {
-  ierr = PetscViewerASCIIPrintf(viewer, "(%s,%s,", cit->second.first.c_str(), cit->second.second.c_str());CHKERRQ(ierr);
-  if ((*dmm->contact_displaced)[cit->second]) {
-    ierr = PetscViewerASCIIPrintf(viewer, "displaced) ", cit->second.first.c_str(), cit->second.second.c_str());CHKERRQ(ierr);
-  } else {
-    ierr = PetscViewerASCIIPrintf(viewer, "undisplaced) ", cit->second.first.c_str(), cit->second.second.c_str());CHKERRQ(ierr);
-  }
+      for (const auto & cit : *(dmm->contactnames))
+      {
+        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%s,", cit.second.first.c_str(), cit.second.second.c_str());
+        CHKERRQ(ierr);
+        if ((*dmm->contact_displaced)[cit.second])
+        {
+          ierr = PetscViewerASCIIPrintf(viewer, "displaced) ", cit.second.first.c_str(), cit.second.second.c_str());
+          CHKERRQ(ierr);
+        }
+        else
+        {
+          ierr = PetscViewerASCIIPrintf(viewer, "undisplaced) ", cit.second.first.c_str(), cit.second.second.c_str());
+          CHKERRQ(ierr);
+        }
       }
       ierr = PetscViewerASCIIPrintf(viewer, "\n");CHKERRQ(ierr);
     }
-    if (dmm->uncontactnames->size()) {
+
+    if (dmm->uncontactnames->size())
+    {
       ierr = PetscViewerASCIIPrintf(viewer, "uncontacts:");CHKERRQ(ierr);
-      for (std::map<DM_Moose::ContactID,DM_Moose::ContactName>::iterator cit = dmm->uncontactnames->begin(); cit != dmm->uncontactnames->end(); ++cit) {
-  ierr = PetscViewerASCIIPrintf(viewer, "(%s,%s,", cit->second.first.c_str(), cit->second.second.c_str());CHKERRQ(ierr);
-  if ((*dmm->uncontact_displaced)[cit->second]) {
-    ierr = PetscViewerASCIIPrintf(viewer, "displaced) ", cit->second.first.c_str(), cit->second.second.c_str());CHKERRQ(ierr);
-  } else {
-    ierr = PetscViewerASCIIPrintf(viewer, "undisplaced) ", cit->second.first.c_str(), cit->second.second.c_str());CHKERRQ(ierr);
-  }
+      for (const auto & cit : *(dmm->uncontactnames))
+      {
+        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%s,", cit.second.first.c_str(), cit.second.second.c_str());CHKERRQ(ierr);
+        if ((*dmm->uncontact_displaced)[cit.second])
+        {
+          ierr = PetscViewerASCIIPrintf(viewer, "displaced) ", cit.second.first.c_str(), cit.second.second.c_str());
+          CHKERRQ(ierr);
+        }
+        else
+        {
+          ierr = PetscViewerASCIIPrintf(viewer, "undisplaced) ", cit.second.first.c_str(), cit.second.second.c_str());
+          CHKERRQ(ierr);
+        }
       }
       ierr = PetscViewerASCIIPrintf(viewer, "\n");CHKERRQ(ierr);
     }
-    if (dmm->splitlocs && dmm->splitlocs->size()) {
+
+    if (dmm->splitlocs && dmm->splitlocs->size())
+    {
       ierr = PetscViewerASCIIPrintf(viewer, "Field decomposition:");CHKERRQ(ierr);
-      /* FIX: decompositions might have different sizes and components on different ranks. */
-      for (std::multimap<std::string, unsigned int>::const_iterator dit = dmm->splitlocs->begin(); dit != dmm->splitlocs->end(); ++dit) {
-  std::string dname = dit->first;
-  ierr = PetscViewerASCIIPrintf(viewer, " %s", dname.c_str());CHKERRQ(ierr);
+      // FIX: decompositions might have different sizes and components on different ranks.
+      for (const auto & dit : *(dmm->splitlocs))
+      {
+        std::string dname = dit.first;
+        ierr = PetscViewerASCIIPrintf(viewer, " %s", dname.c_str());CHKERRQ(ierr);
       }
       ierr = PetscViewerASCIIPrintf(viewer, "\n");CHKERRQ(ierr);
     }
-  } else {
-    SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP, "Non-ASCII viewers are not supported");
   }
+  else
+    SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP, "Non-ASCII viewers are not supported");
+
   PetscFunctionReturn(0);
 }
 
@@ -1164,11 +1238,11 @@ static PetscErrorCode  DMSetUp_Moose_Pre(DM dm)
   if (dmm->sides) {
     dmm->nosides = PETSC_FALSE;
     std::set<BoundaryID> ids;
-    for (std::set<std::string>::iterator nameit = dmm->sides->begin(); nameit != dmm->sides->end(); ++nameit) {
-      std::string name = *nameit;
+    for (const auto & name : *(dmm->sides))
+    {
       boundary_id_type id = dmm->nl->mesh().getBoundaryID(name);
-      dmm->sidenames->insert(std::pair<boundary_id_type,std::string>(id,name));
-      dmm->sideids->insert(std::pair<std::string,boundary_id_type>(name,id));
+      dmm->sidenames->insert(std::make_pair(id, name));
+      dmm->sideids->insert(std::make_pair(name, id));
     }
     delete dmm->sides;
     dmm->sides = PETSC_NULL;
@@ -1179,57 +1253,65 @@ static PetscErrorCode  DMSetUp_Moose_Pre(DM dm)
   if (dmm->unsides) {
     dmm->nounsides = PETSC_FALSE;
     std::set<BoundaryID> ids;
-    for (std::set<std::string>::iterator nameit = dmm->unsides->begin(); nameit != dmm->unsides->end(); ++nameit) {
-      std::string name = *nameit;
+    for (const auto & name : *(dmm->unsides))
+    {
       boundary_id_type id = dmm->nl->mesh().getBoundaryID(name);
-      dmm->unsidenames->insert(std::pair<boundary_id_type,std::string>(id,name));
-      dmm->unsideids->insert(std::pair<std::string,boundary_id_type>(name,id));
+      dmm->unsidenames->insert(std::make_pair(id, name));
+      dmm->unsideids->insert(std::make_pair(name, id));
     }
     delete dmm->unsides;
     dmm->unsides = PETSC_NULL;
   }
   dmm->nocontacts = PETSC_TRUE;
-  if (dmm->contacts) {
+
+  if (dmm->contacts)
+  {
     dmm->nocontacts = PETSC_FALSE;
-    for (std::set<DM_Moose::ContactName>::iterator cit = dmm->contacts->begin(); cit != dmm->contacts->end(); ++cit) {
-      try {
-  if ((*dmm->contact_displaced)[*cit]) {
-    dmm->nl->_fe_problem.getDisplacedProblem()->geomSearchData().getPenetrationLocator(cit->first,cit->second);
-  } else {
-    dmm->nl->_fe_problem.geomSearchData().getPenetrationLocator(cit->first,cit->second);
-  }
+    for (const auto & cpair : *(dmm->contacts))
+    {
+      try
+      {
+        if ((*dmm->contact_displaced)[cpair])
+          dmm->nl->_fe_problem.getDisplacedProblem()->geomSearchData().getPenetrationLocator(cpair.first, cpair.second);
+        else
+          dmm->nl->_fe_problem.geomSearchData().getPenetrationLocator(cpair.first, cpair.second);
       }
-      catch(...) {
-  std::ostringstream err;
-  err << "Problem retrieving contact for PenetrationLocator with master " << cit->first << " and slave " << cit->second;
-  mooseError(err.str());
+      catch(...)
+      {
+        std::ostringstream err;
+        err << "Problem retrieving contact for PenetrationLocator with master " << cpair.first << " and slave " << cpair.second;
+        mooseError(err.str());
       }
-      BoundaryID master_id = dmm->nl->mesh().getBoundaryID(cit->first);
-      BoundaryID slave_id = dmm->nl->mesh().getBoundaryID(cit->second);
-      DM_Moose::ContactID  cid(master_id,slave_id);
-      dmm->contactnames->insert(std::pair<DM_Moose::ContactID,DM_Moose::ContactName>(cid,*cit));
+      BoundaryID master_id = dmm->nl->mesh().getBoundaryID(cpair.first);
+      BoundaryID slave_id = dmm->nl->mesh().getBoundaryID(cpair.second);
+      DM_Moose::ContactID cid(master_id, slave_id);
+      dmm->contactnames->insert(std::make_pair(cid, cpair));
     }
   }
+
   dmm->nouncontacts = PETSC_TRUE;
-  if (dmm->uncontacts) {
+  if (dmm->uncontacts)
+  {
     dmm->nouncontacts = PETSC_FALSE;
-    for (std::set<DM_Moose::ContactName>::iterator cit = dmm->uncontacts->begin(); cit != dmm->uncontacts->end(); ++cit) {
-      try {
-  if ((*dmm->uncontact_displaced)[*cit]) {
-    dmm->nl->_fe_problem.getDisplacedProblem()->geomSearchData().getPenetrationLocator(cit->first,cit->second);
-  } else {
-    dmm->nl->_fe_problem.geomSearchData().getPenetrationLocator(cit->first,cit->second);
-  }
+    for (const auto & cpair : *(dmm->uncontacts))
+    {
+      try
+      {
+        if ((*dmm->uncontact_displaced)[cpair])
+          dmm->nl->_fe_problem.getDisplacedProblem()->geomSearchData().getPenetrationLocator(cpair.first, cpair.second);
+        else
+          dmm->nl->_fe_problem.geomSearchData().getPenetrationLocator(cpair.first, cpair.second);
       }
-      catch(...) {
-  std::ostringstream err;
-  err << "Problem retrieving uncontact for PenetrationLocator with master " << cit->first << " and slave " << cit->second;
-  mooseError(err.str());
+      catch(...)
+      {
+        std::ostringstream err;
+        err << "Problem retrieving uncontact for PenetrationLocator with master " << cpair.first << " and slave " << cpair.second;
+        mooseError(err.str());
       }
-      BoundaryID master_id = dmm->nl->mesh().getBoundaryID(cit->first);
-      BoundaryID slave_id = dmm->nl->mesh().getBoundaryID(cit->second);
-      DM_Moose::ContactID   cid(master_id,slave_id);
-      dmm->uncontactnames->insert(std::pair<DM_Moose::ContactID,DM_Moose::ContactName>(cid,*cit));
+      BoundaryID master_id = dmm->nl->mesh().getBoundaryID(cpair.first);
+      BoundaryID slave_id = dmm->nl->mesh().getBoundaryID(cpair.second);
+      DM_Moose::ContactID cid(master_id, slave_id);
+      dmm->uncontactnames->insert(std::make_pair(cid, cpair));
     }
   }
 
@@ -1254,17 +1336,16 @@ static PetscErrorCode  DMSetUp_Moose_Pre(DM dm)
   dmm->blocknames->clear();
   std::set<subdomain_id_type> blocks;
   ierr = DMMooseGetMeshBlocks_Private(dm,blocks);CHKERRQ(ierr);
-  std::set<subdomain_id_type>::iterator bit = blocks.begin();
-  std::set<subdomain_id_type>::iterator bend = blocks.end();
-  if (bit == bend) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "No mesh blocks found.");
-  for (; bit != bend; ++bit) {
-    subdomain_id_type bid = *bit;
+  if (blocks.empty())
+    SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "No mesh blocks found.");
+
+  for (const auto & bid : blocks)
+  {
     std::string bname = mesh.subdomain_name(bid);
     if (!bname.length()) {
-      /* Block names are currently implemented for Exodus II meshes
-   only, so we might have to make up our own block names and
-   maintain our own mapping of block ids to names.
-      */
+      // Block names are currently implemented for Exodus II meshes
+      // only, so we might have to make up our own block names and
+      // maintain our own mapping of block ids to names.
       std::ostringstream ss;
       ss << bid;
       bname = ss.str();
@@ -1279,9 +1360,10 @@ static PetscErrorCode  DMSetUp_Moose_Pre(DM dm)
       // Equivalently, skip this block if dmm->blocks is dmm->blocks is null or empty or excludes this block.
       if (!dmm->blocks || !dmm->blocks->size() || dmm->blocks->find(bname) == dmm->blocks->end()) continue;
     }
-    dmm->blockids->insert(std::pair<std::string, subdomain_id_type>(bname,bid));
-    dmm->blocknames->insert(std::pair<unsigned int,std::string>(bid,bname));
+    dmm->blockids->insert(std::make_pair(bname, bid));
+    dmm->blocknames->insert(std::make_pair(bid, bname));
   }
+
   if (dmm->blockids->size() == blocks.size()) dmm->allblocks = PETSC_TRUE; else dmm->allblocks = PETSC_FALSE;
   if (dmm->blocks) {
     delete dmm->blocks;
@@ -1290,36 +1372,37 @@ static PetscErrorCode  DMSetUp_Moose_Pre(DM dm)
 
   std::string name = dmm->nl->sys().name();
   name += "_vars";
-  for (std::map<unsigned int, std::string>::const_iterator vit = dmm->varnames->begin(); vit != dmm->varnames->end(); ++vit) {
-    name += "_"+vit->second;
-  }
+  for (const auto & vit : *(dmm->varnames))
+    name += "_" + vit.second;
+
   name += "_blocks";
-  for (std::map<unsigned int, std::string>::const_iterator bit = dmm->blocknames->begin(); bit != dmm->blocknames->end(); ++bit) {
-    name += "_"+bit->second;
-  }
-  if (dmm->sidenames && dmm->sidenames->size()) {
+
+  for (const auto & bit : *(dmm->blocknames))
+    name += "_" + bit.second;
+
+  if (dmm->sidenames && dmm->sidenames->size())
+  {
     name += "_sides";
-    for (std::map<BoundaryID, std::string>::const_iterator sit = dmm->sidenames->begin(); sit != dmm->sidenames->end(); ++sit) {
-      name += "_"+sit->second;
-    }
+    for (const auto & sit : *(dmm->sidenames))
+      name += "_" + sit.second;
   }
-  if (dmm->unsidenames && dmm->unsidenames->size()) {
+  if (dmm->unsidenames && dmm->unsidenames->size())
+  {
     name += "_unsides";
-    for (std::map<BoundaryID, std::string>::const_iterator sit = dmm->unsidenames->begin(); sit != dmm->unsidenames->end(); ++sit) {
-      name += "_"+sit->second;
-    }
+    for (const auto & sit : *(dmm->unsidenames))
+      name += "_" + sit.second;
   }
-  if (dmm->contactnames && dmm->contactnames->size()) {
+  if (dmm->contactnames && dmm->contactnames->size())
+  {
     name += "_contacts";
-    for (std::map<DM_Moose::ContactID, DM_Moose::ContactName>::const_iterator cit = dmm->contactnames->begin(); cit != dmm->contactnames->end(); ++cit) {
-      name += "_master_"+cit->second.first+"_slave_"+cit->second.second;
-    }
+    for (const auto & cit : *(dmm->contactnames))
+      name += "_master_" + cit.second.first + "_slave_" + cit.second.second;
   }
-  if (dmm->uncontactnames && dmm->uncontactnames->size()) {
+  if (dmm->uncontactnames && dmm->uncontactnames->size())
+  {
     name += "_uncontacts";
-    for (std::map<DM_Moose::ContactID, DM_Moose::ContactName>::const_iterator cit = dmm->uncontactnames->begin(); cit != dmm->uncontactnames->end(); ++cit) {
-      name += "_master_"+cit->second.first+"_slave_"+cit->second.second;
-    }
+    for (const auto & cit : *(dmm->uncontactnames))
+      name += "_master_" + cit.second.first + "_slave_" + cit.second.second;
   }
   ierr = PetscObjectSetName((PetscObject)dm,name.c_str());CHKERRQ(ierr);
   PetscFunctionReturn(0);
@@ -1338,8 +1421,9 @@ PetscErrorCode  DMMooseReset(DM dm)
   if (!ismoose)  PetscFunctionReturn(0);
   if (!dmm->nl) SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
   ierr = ISDestroy(&dmm->embedding);CHKERRQ(ierr);
-  for (std::map<std::string,DM_Moose::SplitInfo>::iterator it = dmm->splits->begin(); it != dmm->splits->end(); ++it) {
-    DM_Moose::SplitInfo& split = it->second;
+  for (auto & it : *(dmm->splits))
+  {
+    DM_Moose::SplitInfo & split = it.second;
     ierr = ISDestroy(&split.rembedding);CHKERRQ(ierr);
     if (split.dm) {
       ierr = DMMooseReset(split.dm);CHKERRQ(ierr);
@@ -1624,9 +1708,10 @@ static PetscErrorCode  DMDestroy_Moose(DM dm)
   delete dmm->uncontactnames;
   delete dmm->uncontact_displaced;
   if (dmm->splits) {
-    for (std::map<std::string, DM_Moose::SplitInfo>::iterator sit = dmm->splits->begin(); sit != dmm->splits->end(); ++sit) {
-      ierr = DMDestroy(&(sit->second.dm));CHKERRQ(ierr);
-      ierr = ISDestroy(&(sit->second.rembedding));CHKERRQ(ierr);
+    for (auto & sit : *(dmm->splits))
+    {
+      ierr = DMDestroy(&(sit.second.dm));CHKERRQ(ierr);
+      ierr = ISDestroy(&(sit.second.rembedding));CHKERRQ(ierr);
     }
     delete dmm->splits;
   }

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -194,8 +194,8 @@ petscSetOptions(FEProblem & problem)
   setSolverOptions(problem.solverParams());
 
   // Add any additional options specified in the input file
-  for (MooseEnumIterator it = petsc.flags.begin(); it != petsc.flags.end(); ++it)
-    setSinglePetscOption(it->c_str());
+  for (const auto & flag : petsc.flags)
+    setSinglePetscOption(flag.c_str());
   for (unsigned int i=0; i<petsc.inames.size(); ++i)
     setSinglePetscOption(petsc.inames[i], petsc.values[i]);
 
@@ -508,31 +508,31 @@ storePetscOptions(FEProblem & fe_problem, const InputParameters & params)
   Moose::PetscSupport::PetscOptions & po = fe_problem.getPetscOptions();
 
   // Update the PETSc single flags
-  for (MooseEnumIterator it = petsc_options.begin(); it != petsc_options.end(); ++it)
+  for (const auto & option : petsc_options)
   {
     /**
      * "-log_summary" cannot be used in the input file. This option needs to be set when PETSc is initialized
      * which happens before the parser is even created.  We'll throw an error if somebody attempts to add this option later.
      */
-    if (*it == "-log_summary")
+    if (option == "-log_summary")
       mooseError("The PETSc option \"-log_summary\" can only be used on the command line.  Please remove it from the input file");
 
     // Warn about superseded PETSc options (Note: -snes is not a REAL option, but people used it in their input files)
     else
     {
       std::string help_string;
-      if (*it == "-snes" || *it == "-snes_mf" || *it == "-snes_mf_operator")
+      if (option == "-snes" || option == "-snes_mf" || option == "-snes_mf_operator")
         help_string = "Please set the solver type through \"solve_type\".";
-      else if (*it == "-ksp_monitor")
+      else if (option == "-ksp_monitor")
         help_string = "Please use \"Outputs/print_linear_residuals=true\"";
 
       if (help_string != "")
-        mooseWarning("The PETSc option " << *it << " should not be used directly in a MOOSE input file. " << help_string);
+        mooseWarning("The PETSc option " << option << " should not be used directly in a MOOSE input file. " << help_string);
     }
 
     // Update the stored items, but do not create duplicates
-    if (find(po.flags.begin(), po.flags.end(), *it) == po.flags.end())
-      po.flags.push_back(*it);
+    if (find(po.flags.begin(), po.flags.end(), option) == po.flags.end())
+      po.flags.push_back(option);
   }
 
   // Check that the name value pairs are sized correctly

--- a/framework/src/utils/SyntaxTree.C
+++ b/framework/src/utils/SyntaxTree.C
@@ -82,16 +82,14 @@ SyntaxTree::TreeNode::TreeNode(const std::string &name, SyntaxTree &syntax_tree,
 
 SyntaxTree::TreeNode::~TreeNode()
 {
-  for (std::multimap<std::string, InputParameters *>::iterator it = _action_params.begin();
-       it != _action_params.end(); ++it)
-    delete it->second;
+  for (const auto & it : _action_params)
+    delete it.second;
 
-  for (std::multimap<std::string, InputParameters *>::iterator it = _moose_object_params.begin();
-       it != _moose_object_params.end(); ++it)
-    delete it->second;
+  for (const auto & it : _moose_object_params)
+    delete it.second;
 
-  for (std::map<std::string, TreeNode *>::iterator it = _children.begin(); it != _children.end(); ++it)
-    delete it->second;
+  for (const auto & it : _children)
+    delete it.second;
 }
 
 void
@@ -143,10 +141,10 @@ SyntaxTree::TreeNode::print(short depth, const std::string &search_string, bool 
 
   if (depth < 0)
   {
-    for (std::map<std::string, TreeNode *>::const_iterator c_it = _children.begin(); c_it != _children.end(); ++c_it)
+    for (const auto & c_it : _children)
     {
       bool local_found = false;
-      std::string local_out (c_it->second->print(depth+1, search_string, local_found));
+      std::string local_out (c_it.second->print(depth+1, search_string, local_found));
       found |= local_found;  // Update the current frame's found variable
       if (local_found)
         out += local_out;
@@ -181,10 +179,10 @@ SyntaxTree::TreeNode::print(short depth, const std::string &search_string, bool 
 
     local_out += _syntax_tree.printBlockOpen(name, depth, doc);
 
-    for (std::multimap<std::string, InputParameters *>::const_iterator a_it = _action_params.begin(); a_it != _action_params.end(); ++a_it)
-      if (a_it->first != "EmptyAction")
+    for (const auto & a_it : _action_params)
+      if (a_it.first != "EmptyAction")
       {
-        local_out += _syntax_tree.printParams(name, long_name, *a_it->second, depth, local_search_string, local_found);
+        local_out += _syntax_tree.printParams(name, long_name, *(a_it.second), depth, local_search_string, local_found);
         found |= local_found;   // Update the current frame's found variable
         //DEBUG
         // Moose::out << "\n" << indent << "(" << ait->first << ")";
@@ -202,10 +200,10 @@ SyntaxTree::TreeNode::print(short depth, const std::string &search_string, bool 
 
     local_out += _syntax_tree.preTraverse(depth);
 
-    for (std::map<std::string, TreeNode *>::const_iterator c_it = _children.begin(); c_it != _children.end(); ++c_it)
+    for (const auto & c_it : _children)
     {
       bool child_found = false;
-      std::string child_out (c_it->second->print(depth+1, local_search_string, child_found));
+      std::string child_out (c_it.second->print(depth+1, local_search_string, child_found));
       found |= child_found;   // Update the current frame's found variable
 
       if (child_found)

--- a/framework/src/vectorpostprocessors/VectorOfPostprocessors.C
+++ b/framework/src/vectorpostprocessors/VectorOfPostprocessors.C
@@ -32,11 +32,11 @@ VectorOfPostprocessors::VectorOfPostprocessors(const InputParameters & parameter
 {
   std::vector<PostprocessorName> pps_names(getParam<std::vector<PostprocessorName> >("postprocessors"));
   _pp_vec.resize(pps_names.size());
-  for (unsigned int i=0; i<pps_names.size(); ++i)
+  for (const auto & pps_name : pps_names)
   {
-    if (!hasPostprocessorByName(pps_names[i]))
-      mooseError("In VectorOfPostprocessors, postprocessor with name: "<<pps_names[i]<<" does not exist");
-    _postprocessor_values.push_back(&getPostprocessorValueByName(pps_names[i]));
+    if (!hasPostprocessorByName(pps_name))
+      mooseError("In VectorOfPostprocessors, postprocessor with name: " << pps_name << " does not exist");
+    _postprocessor_values.push_back(&getPostprocessorValueByName(pps_name));
   }
 }
 
@@ -49,6 +49,6 @@ VectorOfPostprocessors::initialize()
 void
 VectorOfPostprocessors::execute()
 {
-  for (unsigned int i=0; i<_postprocessor_values.size(); ++i)
-    _pp_vec.push_back(*_postprocessor_values[i]);
+  for (const auto & ppv : _postprocessor_values)
+    _pp_vec.push_back(*ppv);
 }

--- a/framework/src/vectorpostprocessors/VectorPostprocessorData.C
+++ b/framework/src/vectorpostprocessors/VectorPostprocessorData.C
@@ -60,7 +60,7 @@ VectorPostprocessorData::declareVector(const std::string & vpp_name, const std::
 void
 VectorPostprocessorData::copyValuesBack()
 {
-  for (std::map<std::string, std::map<std::string, VectorPostprocessorValue*> >::iterator it = _values.begin(); it != _values.end(); ++it)
-    for (std::map<std::string, VectorPostprocessorValue*>::iterator vec_it = it->second.begin(); vec_it != it->second.end(); ++vec_it)
-      getVectorPostprocessorValueOld(it->first, vec_it->first) = *vec_it->second;
+  for (const auto & it : _values)
+    for (const auto & vec_it : it.second)
+      getVectorPostprocessorValueOld(it.first, vec_it.first) = *(vec_it.second);
 }


### PR DESCRIPTION
For whenever we officially decide to turn on C++11: this PR converts all relevant for loops (see also #6993) to range-based for loops that use `auto`.

Refs #6993, #6887.
