### PR TITLE
Allow deprecated

### DIFF
--- a/python/FactorySystem/InputParameters.py
+++ b/python/FactorySystem/InputParameters.py
@@ -1,6 +1,7 @@
 class InputParameters:
   def __init__(self, *args):
     self.valid = {}
+    self.strict_types = {}
     self.desc = {}
     self.substitute = {}
     self.required = set()
@@ -14,6 +15,16 @@ class InputParameters:
   def addParam(self, name, *args):
     if len(args) == 2:
       self.valid[name] = args[0]
+    self.desc[name] = args[-1]
+
+  def addRequiredParamWithType(self, name, my_type, *args):
+    self.required.add(name)
+    self.addParamWithType(name, my_type, *args)
+
+  def addParamWithType(self, name, my_type, *args):
+    if len(args) == 3:
+      self.valid[name] = args[0]
+    self.strict_types[name] = my_type
     self.desc[name] = args[-1]
 
   def addPrivateParam(self, name, *args):
@@ -57,7 +68,6 @@ class InputParameters:
 
     # Return this InputParameters object
     return self
-
 
   def type(self, key):
     if key in self.valid:

--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import os, sys, re
+import os, sys, re, time
 
 import ParseGetPot, Factory
 from MooseObject import MooseObject
@@ -72,9 +72,16 @@ class Parser:
                 print "Unrecognized (key,value) pair: (", key, ',', value, ")"
                 params['error_code'] = 0x02
                 error_code = error_code | params['error_code']
-
-              # Otherwise, just do normal assignment
+            # Prevent date types from being stored as strings
+            elif params.isValid(key) and (type(params[key]) == type(time.localtime())):
+              try:
+                params[key] = time.strptime(value, "%m/%d/%Y")
+              except ValueError:
+                # Input file has invalid date. But we still want to return a
+                # valid date type object... (12/31/1969)
+                params[key] = time.strptime(time.ctime(0))
             else:
+              # Otherwise, just do normal assignment
               params[key] = value
       else:
         self.params_ignored.add(key)

--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -24,6 +24,8 @@ class Parser:
     0x01 - pyGetpot parsing error
     0x02 - Unrecogonized Boolean key/value pair
     0x04 - Missing required parameter
+    0x08 - Bad value
+    0x10 - Mismatched type
   """
   def parse(self, filename):
     error_code = 0x00
@@ -60,9 +62,26 @@ class Parser:
           if re.match('".*"', value):   # Strip quotes
             params[key] = value[1:-1]
           else:
+            if key in params.strict_types:
+              # The developer wants to enforce a specific type without setting a valid value
+              strict_type = params.strict_types[key]
+
+              if strict_type == time.struct_time:
+                # Dates have to be parsed
+                try:
+                  params[key] = time.strptime(value, "%m/%d/%Y")
+                except ValueError:
+                  print "Bad Value for key '" + full_name + '/' + key + "': " + value
+                  params['error_code'] = 0x08
+                  error_code = error_code | params['error_code']
+              elif strict_type != type(value):
+                print "Mismatched type for key '" + full_name + '/' + key + "': " + value
+                params['error_code'] = 0x10
+                error_code = error_code | params['error_code']
+
             # Prevent bool types from being stored as strings.  This can lead to the
             # strange situation where string('False') evaluates to true...
-            if params.isValid(key) and (type(params[key]) == type(bool())):
+            elif params.isValid(key) and (type(params[key]) == type(bool())):
               # We support using the case-insensitive strings {true, false} and the string '0', '1'.
               if (value.lower()=='true') or (value=='1'):
                 params[key] = True
@@ -72,14 +91,6 @@ class Parser:
                 print "Unrecognized (key,value) pair: (", key, ',', value, ")"
                 params['error_code'] = 0x02
                 error_code = error_code | params['error_code']
-            # Prevent date types from being stored as strings
-            elif params.isValid(key) and (type(params[key]) == type(time.localtime())):
-              try:
-                params[key] = time.strptime(value, "%m/%d/%Y")
-              except ValueError:
-                # Input file has invalid date. But we still want to return a
-                # valid date type object... (12/31/1969)
-                params[key] = time.strptime(time.ctime(0))
             else:
               # Otherwise, just do normal assignment
               params[key] = value

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -1,4 +1,4 @@
-import re, os, sys
+import re, os, sys, time
 from Tester import Tester
 from RunParallel import RunParallel # For TIMEOUT value
 
@@ -16,6 +16,7 @@ class RunApp(Tester):
     params.addParam('absent_out',         "A regular expression that must be *absent* from the output for the test to pass.")
     params.addParam('should_crash', False, "Inidicates that the test is expected to crash or otherwise terminate early")
     params.addParam('executable_pattern', "A test that only runs if the exectuable name matches the given pattern")
+    params.addParam('allow_deprecated_until', time.strptime(time.ctime(0)), "A test that only runs if current date is less than specified date")
 
     params.addParam('walltime',           "The max time as pbs understands it")
     params.addParam('job_name',           "The test name as pbs understands it")
@@ -83,6 +84,11 @@ class RunApp(Tester):
     specs = self.specs
     # Create the command line string to run
     command = ''
+
+    # If deprecated day is not epoch and today is greater than deprecated day
+    if specs.isValid('allow_deprecated_until') and self.specs['allow_deprecated_until'] != time.strptime(time.ctime(0)) \
+       and time.mktime(time.gmtime()) > time.mktime(self.specs['allow_deprecated_until']):
+      specs['cli_args'].append('--allow-deprecated')
 
     # Check for built application
     if not options.dry_run and not os.path.exists(specs['executable']):


### PR DESCRIPTION
This PR allows developers to set a parameter to allow deprecated parameters to exist in a test for some set period of time

```
[Tests]
  [./test]
    type = Exodiff
    ...
    allow_deprecated_until = '06/01/2016'
   [../]
[]
```

If the application is ALSO using `--error` like moose test and moose modules, it'll allow deprecated code to exist without throwing an error until the given date.     

@sapitts - This still means you have more work than you'd like. You'll first need to identify the tests that need to be deprecated and add this flag to those tests in the apps. You can do that ahead of time and independent of the PR that will actually deprecate the code. Then your PR will run and pass the test just fine
