### PR TITLE
PorousFlow cleaning

### DIFF
--- a/modules/porous_flow/include/kernels/PorousFlowAdvectiveFlux.h
+++ b/modules/porous_flow/include/kernels/PorousFlowAdvectiveFlux.h
@@ -109,10 +109,10 @@ protected:
   const MaterialProperty<std::vector<std::vector<Real> > > & _drelative_permeability_dvar;
 
   /// PorousFlow UserObject
-  const PorousFlowDictator & _porousflow_dictator_UO;
+  const PorousFlowDictator & _porousflow_dictator;
 
-  /// Index of the component that this kernel acts on
-  const unsigned int _component_index;
+  /// Index of the fluid component that this kernel acts on
+  const unsigned int _fluid_component;
 
   /// The number of fluid phases
   const unsigned int _num_phases;

--- a/modules/porous_flow/include/kernels/PorousFlowEffectiveStressCoupling.h
+++ b/modules/porous_flow/include/kernels/PorousFlowEffectiveStressCoupling.h
@@ -35,7 +35,7 @@ public:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// The Porous-Flow dictator that holds global info about the simulation
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// Biot coefficient
   const Real _coefficient;

--- a/modules/porous_flow/include/kernels/PorousFlowMassTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowMassTimeDerivative.h
@@ -35,10 +35,10 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// the fluid component index
-  const unsigned int _component_index;
+  const unsigned int _fluid_component;
 
   /// holds info on the PorousFlow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// whether the Variable for this Kernel is a porous-flow variable according to the Dictator
   const bool _var_is_porflow_var;

--- a/modules/porous_flow/include/kernels/PorousFlowMassVolumetricExpansion.h
+++ b/modules/porous_flow/include/kernels/PorousFlowMassVolumetricExpansion.h
@@ -36,10 +36,10 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   /// the fluid component index
-  const unsigned int _component_index;
+  const unsigned int _fluid_component;
 
   /// holds info on the Porous Flow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// whether the Variable for this Kernel is a porous-flow variable according to the Dictator
   const bool _var_is_porflow_var;

--- a/modules/porous_flow/include/materials/PorousFlowCapillaryPressureBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowCapillaryPressureBase.h
@@ -32,7 +32,7 @@ protected:
   const unsigned int _phase_num;
 
   /// The PorousFlowDictator UserObject
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// Name of (dummy) saturation primary variable
   VariableName _saturation_variable_name;

--- a/modules/porous_flow/include/materials/PorousFlowEffectiveFluidPressure.h
+++ b/modules/porous_flow/include/materials/PorousFlowEffectiveFluidPressure.h
@@ -32,7 +32,7 @@ public:
 
 protected:
   /// The dictator UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// number of phases in this simulation
   const unsigned int _num_ph;

--- a/modules/porous_flow/include/materials/PorousFlowFluidPropertiesBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowFluidPropertiesBase.h
@@ -45,7 +45,7 @@ protected:
   const MaterialProperty<std::vector<Real> > & _temperature_qp;
 
   /// The PorousFlowDictator UserObject
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// Name of (dummy) pressure primary variable
   const VariableName _pressure_variable_name;

--- a/modules/porous_flow/include/materials/PorousFlowJoiner.h
+++ b/modules/porous_flow/include/materials/PorousFlowJoiner.h
@@ -48,7 +48,7 @@ protected:
   virtual void computeQpProperties();
 
   /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// Name of (dummy) pressure variable
   const VariableName _pressure_variable_name;

--- a/modules/porous_flow/include/materials/PorousFlowMassFraction.h
+++ b/modules/porous_flow/include/materials/PorousFlowMassFraction.h
@@ -30,7 +30,7 @@ public:
 
 protected:
   /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// Number of fluid phases
   const unsigned int _num_phases;

--- a/modules/porous_flow/include/materials/PorousFlowPorosityUnity.h
+++ b/modules/porous_flow/include/materials/PorousFlowPorosityUnity.h
@@ -30,7 +30,7 @@ public:
 
 protected:
   /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// nodal porosity
   MaterialProperty<Real> & _porosity_nodal;

--- a/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityUnity.h
+++ b/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityUnity.h
@@ -33,7 +33,7 @@ protected:
   const unsigned int _phase_num;
 
   /// The PorousFlowDictator UserObject
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// Name of (dummy) saturation primary variable
   VariableName _saturation_variable_name;

--- a/modules/porous_flow/include/materials/PorousFlowVariableBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowVariableBase.h
@@ -32,7 +32,7 @@ protected:
   virtual void computeQpProperties();
 
   /// The variable names UserObject for the PorousFlow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// Number of phases
   const unsigned int _num_phases;

--- a/modules/porous_flow/include/materials/PorousFlowViscosityConst.h
+++ b/modules/porous_flow/include/materials/PorousFlowViscosityConst.h
@@ -34,7 +34,7 @@ protected:
   unsigned int _phase_num;
 
   /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// viscosity
   MaterialProperty<Real> & _viscosity;

--- a/modules/porous_flow/include/materials/PorousFlowVolumetricStrain.h
+++ b/modules/porous_flow/include/materials/PorousFlowVolumetricStrain.h
@@ -29,7 +29,7 @@ protected:
   const bool _consistent;
 
   /// The dictator UserObject for the Porous-Flow simulation
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// number of porous-flow variables
   const unsigned int _num_var;

--- a/modules/porous_flow/include/postprocessors/PorousFlowFluidMass.h
+++ b/modules/porous_flow/include/postprocessors/PorousFlowFluidMass.h
@@ -29,10 +29,10 @@ protected:
   virtual Real computeQpIntegral();
 
   /// the fluid component for which you want the mass
-  const unsigned int _component_index;
+  const unsigned int _fluid_component;
 
   /// holds info on the PorousFlow variables
-  const PorousFlowDictator & _dictator_UO;
+  const PorousFlowDictator & _dictator;
 
   /// porosity at the nodes
   const MaterialProperty<Real> & _porosity;

--- a/modules/porous_flow/src/kernels/PorousFlowAdvectiveFlux.C
+++ b/modules/porous_flow/src/kernels/PorousFlowAdvectiveFlux.C
@@ -16,10 +16,10 @@ template<>
 InputParameters validParams<PorousFlowAdvectiveFlux>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addParam<unsigned int>("component_index", 0, "The index corresponding to the component for this kernel");
+  params.addParam<unsigned int>("fluid_component", 0, "The index corresponding to the fluid component for this kernel");
   params.addRequiredParam<RealVectorValue>("gravity", "Gravitational acceleration vector downwards (m/s^2)");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of PorousFlow variable names");
-  params.addClassDescription("Fully-upwinded advective flux of the component given by component_index");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
+  params.addClassDescription("Fully-upwinded advective flux of the component given by fluid_component");
   return params;
 }
 
@@ -41,9 +41,9 @@ PorousFlowAdvectiveFlux::PorousFlowAdvectiveFlux(const InputParameters & paramet
     _dgrad_p_dvar(getMaterialProperty<std::vector<std::vector<RealGradient> > >("dPorousFlow_grad_porepressure_qp_dvar")),
     _relative_permeability(getMaterialProperty<std::vector<Real> >("PorousFlow_relative_permeability")),
     _drelative_permeability_dvar(getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_relative_permeability_dvar")),
-    _porousflow_dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _component_index(getParam<unsigned int>("component_index")),
-    _num_phases(_porousflow_dictator_UO.numPhases()),
+    _porousflow_dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _fluid_component(getParam<unsigned int>("fluid_component")),
+    _num_phases(_porousflow_dictator.numPhases()),
     _gravity(getParam<RealVectorValue>("gravity"))
 {
 }
@@ -57,10 +57,10 @@ PorousFlowAdvectiveFlux::darcyQp(unsigned int ph)
 Real
 PorousFlowAdvectiveFlux::darcyQpJacobian(unsigned int jvar, unsigned int ph)
 {
-  if (_porousflow_dictator_UO.notPorousFlowVariable(jvar))
+  if (_porousflow_dictator.notPorousFlowVariable(jvar))
     return 0.0;
 
-  const unsigned int pvar = _porousflow_dictator_UO.porousFlowVariableNum(jvar);
+  const unsigned int pvar = _porousflow_dictator.porousFlowVariableNum(jvar);
   return _grad_test[_i][_qp] * (_dpermeability_dvar[_qp][pvar] * (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph]*_gravity) + _permeability[_qp] * (_grad_phi[_j][_qp] * _dgrad_p_dgrad_var[_qp][ph][pvar] - _phi[_j][_qp] * _dfluid_density_qp_dvar[_qp][ph][pvar] * _gravity) + _permeability[_qp] * (_dgrad_p_dvar[_qp][ph][pvar] * _phi[_j][_qp]) );
 }
 
@@ -92,11 +92,11 @@ PorousFlowAdvectiveFlux::computeOffDiagJacobian(unsigned int jvar)
 void
 PorousFlowAdvectiveFlux::upwind(JacRes res_or_jac, unsigned int jvar)
 {
-  if ((res_or_jac == CALCULATE_JACOBIAN) && _porousflow_dictator_UO.notPorousFlowVariable(jvar))
+  if ((res_or_jac == CALCULATE_JACOBIAN) && _porousflow_dictator.notPorousFlowVariable(jvar))
       return;
 
   /// The PorousFlow variable index corresponding to the variable number jvar
-  const unsigned int pvar = ((res_or_jac == CALCULATE_JACOBIAN) ? _porousflow_dictator_UO.porousFlowVariableNum(jvar) : 0);
+  const unsigned int pvar = ((res_or_jac == CALCULATE_JACOBIAN) ? _porousflow_dictator.porousFlowVariableNum(jvar) : 0);
 
   /// The number of nodes in the element
   const unsigned int num_nodes = _test.size();
@@ -224,13 +224,13 @@ PorousFlowAdvectiveFlux::upwind(JacRes res_or_jac, unsigned int jvar)
       {
         upwind_node[n] = true;
         /// The massfrac*mobility at the upstream node
-        mobility = _mass_fractions[n][ph][_component_index] * _fluid_density_node[n][ph] * _relative_permeability[n][ph] / _fluid_viscosity[n][ph];
+        mobility = _mass_fractions[n][ph][_fluid_component] * _fluid_density_node[n][ph] * _relative_permeability[n][ph] / _fluid_viscosity[n][ph];
         if (res_or_jac == CALCULATE_JACOBIAN)
         {
           /// The derivative of the massfrac*mobility wrt the PorousFlow variable
-          dmobility = _dmass_fractions_dvar[n][ph][_component_index][pvar] * _fluid_density_node[n][ph] * _relative_permeability[n][ph] / _fluid_viscosity[n][ph];
-          dmobility += _mass_fractions[n][ph][_component_index] * _dfluid_density_node_dvar[n][ph][pvar] * _relative_permeability[n][ph] / _fluid_viscosity[n][ph];
-          dmobility += _mass_fractions[n][ph][_component_index] * _fluid_density_node[n][ph] * _drelative_permeability_dvar[n][ph][pvar] / _fluid_viscosity[n][ph];
+          dmobility = _dmass_fractions_dvar[n][ph][_fluid_component][pvar] * _fluid_density_node[n][ph] * _relative_permeability[n][ph] / _fluid_viscosity[n][ph];
+          dmobility += _mass_fractions[n][ph][_fluid_component] * _dfluid_density_node_dvar[n][ph][pvar] * _relative_permeability[n][ph] / _fluid_viscosity[n][ph];
+          dmobility += _mass_fractions[n][ph][_fluid_component] * _fluid_density_node[n][ph] * _drelative_permeability_dvar[n][ph][pvar] / _fluid_viscosity[n][ph];
           dmobility -= mobility / _fluid_viscosity[n][ph] * _dfluid_viscosity_dvar[n][ph][pvar];
 
           for (_j = 0; _j < _phi.size(); _j++)

--- a/modules/porous_flow/src/kernels/PorousFlowEffectiveStressCoupling.C
+++ b/modules/porous_flow/src/kernels/PorousFlowEffectiveStressCoupling.C
@@ -14,7 +14,7 @@ InputParameters validParams<PorousFlowEffectiveStressCoupling>()
 {
   InputParameters params = validParams<Kernel>();
   params.addClassDescription("Adds -BiotCoefficient*effective_porepressure*grad_test[component]");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addRangeCheckedParam<Real>("biot_coefficient", 1, "biot_coefficient>=0&biot_coefficient<=1", "Biot coefficient");
   params.addRequiredParam<unsigned int>("component", "The gradient direction (0 for x, 1 for y and 2 for z)");
   return params;
@@ -22,7 +22,7 @@ InputParameters validParams<PorousFlowEffectiveStressCoupling>()
 
 PorousFlowEffectiveStressCoupling::PorousFlowEffectiveStressCoupling(const InputParameters & parameters) :
     Kernel(parameters),
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _coefficient(getParam<Real>("biot_coefficient")),
     _component(getParam<unsigned int>("component")),
     _pf(getMaterialProperty<Real>("PorousFlow_effective_fluid_pressure_qp")),
@@ -41,18 +41,18 @@ PorousFlowEffectiveStressCoupling::computeQpResidual()
 Real
 PorousFlowEffectiveStressCoupling::computeQpJacobian()
 {
-  if (_dictator_UO.notPorousFlowVariable(_var.number()))
+  if (_dictator.notPorousFlowVariable(_var.number()))
     return 0.0;
-  const unsigned int pvar = _dictator_UO.porousFlowVariableNum(_var.number());
+  const unsigned int pvar = _dictator.porousFlowVariableNum(_var.number());
   return -_coefficient * _phi[_j][_qp] * _dpf_dvar[_qp][pvar] * _grad_test[_i][_qp](_component);
 }
 
 Real
 PorousFlowEffectiveStressCoupling::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if (_dictator_UO.notPorousFlowVariable(jvar))
+  if (_dictator.notPorousFlowVariable(jvar))
     return 0.0;
-  const unsigned int pvar = _dictator_UO.porousFlowVariableNum(jvar);
+  const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
   return -_coefficient * _phi[_j][_qp] * _dpf_dvar[_qp][pvar] * _grad_test[_i][_qp](_component);
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowMassTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowMassTimeDerivative.C
@@ -11,18 +11,18 @@ template<>
 InputParameters validParams<PorousFlowMassTimeDerivative>()
 {
   InputParameters params = validParams<TimeKernel>();
-  params.addParam<unsigned int>("component_index", 0, "The index corresponding to the component for this kernel");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
-  params.addClassDescription("Component mass derivative wrt time for component given by component_index");
+  params.addParam<unsigned int>("fluid_component", 0, "The index corresponding to the component for this kernel");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addClassDescription("Component mass derivative wrt time for component given by fluid_component");
   return params;
 }
 
 PorousFlowMassTimeDerivative::PorousFlowMassTimeDerivative(const InputParameters & parameters) :
     TimeKernel(parameters),
-    _component_index(getParam<unsigned int>("component_index")),
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _var_is_porflow_var(_dictator_UO.isPorousFlowVariable(_var.number())),
-    _num_phases(_dictator_UO.numPhases()),
+    _fluid_component(getParam<unsigned int>("fluid_component")),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _var_is_porflow_var(_dictator.isPorousFlowVariable(_var.number())),
+    _num_phases(_dictator.numPhases()),
     _porosity(getMaterialProperty<Real>("PorousFlow_porosity_nodal")),
     _porosity_old(getMaterialPropertyOld<Real>("PorousFlow_porosity_nodal")),
     _dporosity_dvar(getMaterialProperty<std::vector<Real> >("dPorousFlow_porosity_nodal_dvar")),
@@ -37,8 +37,8 @@ PorousFlowMassTimeDerivative::PorousFlowMassTimeDerivative(const InputParameters
     _mass_frac_old(getMaterialPropertyOld<std::vector<std::vector<Real> > >("PorousFlow_mass_frac")),
     _dmass_frac_dvar(getMaterialProperty<std::vector<std::vector<std::vector<Real> > > >("dPorousFlow_mass_frac_dvar"))
 {
-  if (_component_index >= _dictator_UO.numComponents())
-    mooseError("The Dictator proclaims that the number of components in this simulation is " << _dictator_UO.numComponents() << " whereas you have used the Kernel PorousFlowComponetMassTimeDerivative with component = " << _component_index << ".  The Dictator does not take such mistakes lightly");
+  if (_fluid_component >= _dictator.numComponents())
+    mooseError("The Dictator proclaims that the number of components in this simulation is " << _dictator.numComponents() << " whereas you have used the Kernel PorousFlowComponetMassTimeDerivative with component = " << _fluid_component << ".  The Dictator does not take such mistakes lightly");
 }
 
 Real
@@ -48,8 +48,8 @@ PorousFlowMassTimeDerivative::computeQpResidual()
   Real mass_old = 0.0;
   for (unsigned ph = 0; ph < _num_phases; ++ph)
   {
-    mass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_component_index];
-    mass_old += _fluid_density_old[_i][ph] * _fluid_saturation_nodal_old[_i][ph] * _mass_frac_old[_i][ph][_component_index];
+    mass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component];
+    mass_old += _fluid_density_old[_i][ph] * _fluid_saturation_nodal_old[_i][ph] * _mass_frac_old[_i][ph][_fluid_component];
    }
 
   return _test[_i][_qp] * (_porosity[_i] * mass - _porosity_old[_i] * mass_old) / _dt;
@@ -61,16 +61,16 @@ PorousFlowMassTimeDerivative::computeQpJacobian()
   /// If the variable is not a PorousFlow variable (very unusual), the diag Jacobian terms are 0
   if (!_var_is_porflow_var)
     return 0.0;
-  return computeQpJac(_dictator_UO.porousFlowVariableNum(_var.number()));
+  return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
 }
 
 Real
 PorousFlowMassTimeDerivative::computeQpOffDiagJacobian(unsigned int jvar)
 {
   /// If the variable is not a PorousFlow variable, the OffDiag Jacobian terms are 0
-  if (_dictator_UO.notPorousFlowVariable(jvar))
+  if (_dictator.notPorousFlowVariable(jvar))
     return 0.0;
-  return computeQpJac(_dictator_UO.porousFlowVariableNum(jvar));
+  return computeQpJac(_dictator.porousFlowVariableNum(jvar));
 }
 
 Real
@@ -81,7 +81,7 @@ PorousFlowMassTimeDerivative::computeQpJac(unsigned int pvar)
   // of variables, which are NOT lumped to the nodes, hence:
   Real dmass = 0.0;
   for (unsigned ph = 0; ph < _num_phases; ++ph)
-    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_component_index] * _dporosity_dgradvar[_i][pvar] * _grad_phi[_j][_i];
+    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component] * _dporosity_dgradvar[_i][pvar] * _grad_phi[_j][_i];
 
   if (_i != _j)
     return _test[_i][_qp] * dmass/_dt;
@@ -89,10 +89,10 @@ PorousFlowMassTimeDerivative::computeQpJac(unsigned int pvar)
   /// As the fluid mass is lumped to the nodes, only non-zero terms are for _i==_j
   for (unsigned ph = 0; ph < _num_phases; ++ph)
   {
-    dmass += _dfluid_density_dvar[_i][ph][pvar] * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_component_index] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _dfluid_saturation_nodal_dvar[_i][ph][pvar] * _mass_frac[_i][ph][_component_index] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] * _dmass_frac_dvar[_i][ph][_component_index][pvar] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_component_index] * _dporosity_dvar[_i][pvar];
+    dmass += _dfluid_density_dvar[_i][ph][pvar] * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
+    dmass += _fluid_density[_i][ph] * _dfluid_saturation_nodal_dvar[_i][ph][pvar] * _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
+    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] * _dmass_frac_dvar[_i][ph][_fluid_component][pvar] * _porosity[_i];
+    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component] * _dporosity_dvar[_i][pvar];
   }
   return _test[_i][_qp] * dmass / _dt;
 }

--- a/modules/porous_flow/src/kernels/PorousFlowMassVolumetricExpansion.C
+++ b/modules/porous_flow/src/kernels/PorousFlowMassVolumetricExpansion.C
@@ -11,17 +11,17 @@ template<>
 InputParameters validParams<PorousFlowMassVolumetricExpansion>()
 {
   InputParameters params = validParams<TimeKernel>();
-  params.addParam<unsigned int>("component_index", 0, "The index corresponding to the component for this kernel");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addParam<unsigned int>("fluid_component", 0, "The index corresponding to the component for this kernel");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("Component_mass*rate_of_solid_volumetric_expansion");
   return params;
 }
 
 PorousFlowMassVolumetricExpansion::PorousFlowMassVolumetricExpansion(const InputParameters & parameters) :
     TimeKernel(parameters),
-    _component_index(getParam<unsigned int>("component_index")),
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _var_is_porflow_var(!_dictator_UO.notPorousFlowVariable(_var.number())),
+    _fluid_component(getParam<unsigned int>("fluid_component")),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _var_is_porflow_var(!_dictator.notPorousFlowVariable(_var.number())),
     _porosity(getMaterialProperty<Real>("PorousFlow_porosity_nodal")),
     _dporosity_dvar(getMaterialProperty<std::vector<Real> >("dPorousFlow_porosity_nodal_dvar")),
     _dporosity_dgradvar(getMaterialProperty<std::vector<RealGradient> >("dPorousFlow_porosity_nodal_dgradvar")),
@@ -34,20 +34,20 @@ PorousFlowMassVolumetricExpansion::PorousFlowMassVolumetricExpansion(const Input
     _strain_rate_qp(getMaterialProperty<Real>("PorousFlow_volumetric_strain_rate_qp")),
     _dstrain_rate_qp_dvar(getMaterialProperty<std::vector<RealGradient> >("dPorousFlow_volumetric_strain_rate_qp_dvar"))
 {
-  if (_component_index >= _dictator_UO.numComponents())
-    mooseError("The Dictator proclaims that the number of components in this simulation is " << _dictator_UO.numComponents() << " whereas you have used the Kernel PorousFlowComponetMassVolumetricExpansion with component = " << _component_index << ".  The Dictator is watching you");
+  if (_fluid_component >= _dictator.numComponents())
+    mooseError("The Dictator proclaims that the number of components in this simulation is " << _dictator.numComponents() << " whereas you have used the Kernel PorousFlowComponetMassVolumetricExpansion with component = " << _fluid_component << ".  The Dictator is watching you");
 }
 
 Real
 PorousFlowMassVolumetricExpansion::computeQpResidual()
 {
-  mooseAssert(_component_index < _mass_frac[_i][0].size(), "PorousFlowMassVolumetricExpansion: component_index is given as " << _component_index << " which must be less than the number of fluid components described by the mass-fraction matrix, which is " << _mass_frac[_i][0].size());
+  mooseAssert(_fluid_component < _mass_frac[_i][0].size(), "PorousFlowMassVolumetricExpansion: fluid_component is given as " << _fluid_component << " which must be less than the number of fluid components described by the mass-fraction matrix, which is " << _mass_frac[_i][0].size());
   unsigned int num_phases = _fluid_density[_i].size();
   mooseAssert(num_phases == _fluid_saturation[_i].size(), "PorousFlowMassVolumetricExpansion: Size of fluid density = " << num_phases << " size of fluid saturation = " << _fluid_saturation[_i].size() << " but both these must be equal to the number of phases in the system");
 
   Real mass = 0.0;
   for (unsigned ph = 0; ph < num_phases; ++ph)
-    mass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_component_index];
+    mass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_fluid_component];
 
   return _test[_i][_qp] * mass * _porosity[_i] * _strain_rate_qp[_qp];
 }
@@ -67,15 +67,15 @@ PorousFlowMassVolumetricExpansion::computeQpOffDiagJacobian(unsigned int jvar)
 Real
 PorousFlowMassVolumetricExpansion::computedVolQpJac(unsigned int jvar)
 {
-  if (_dictator_UO.notPorousFlowVariable(jvar))
+  if (_dictator.notPorousFlowVariable(jvar))
     return 0.0;
 
-  const unsigned int pvar = _dictator_UO.porousFlowVariableNum(jvar);
+  const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
 
   unsigned int num_phases = _fluid_density[_i].size();
   Real mass = 0.0;
   for (unsigned ph = 0; ph < num_phases; ++ph)
-    mass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_component_index];
+    mass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_fluid_component];
 
   Real dvol = _dstrain_rate_qp_dvar[_qp][pvar] * _grad_phi[_j][_qp];
 
@@ -84,25 +84,25 @@ PorousFlowMassVolumetricExpansion::computedVolQpJac(unsigned int jvar)
 Real
 PorousFlowMassVolumetricExpansion::computedMassQpJac(unsigned int jvar)
 {
-  if (_dictator_UO.notPorousFlowVariable(jvar))
+  if (_dictator.notPorousFlowVariable(jvar))
     return 0.0;
 
-  const unsigned int pvar = _dictator_UO.porousFlowVariableNum(jvar);
+  const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
 
   const unsigned int num_phases = _fluid_density[_i].size();
   Real dmass = 0.0;
   for (unsigned ph = 0; ph < num_phases; ++ph)
-    dmass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_component_index] * _dporosity_dgradvar[_i][pvar] * _grad_phi[_j][_i];
+    dmass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_fluid_component] * _dporosity_dgradvar[_i][pvar] * _grad_phi[_j][_i];
 
   if (_i != _j)
     return _test[_i][_qp] * dmass * _strain_rate_qp[_qp];
 
   for (unsigned ph = 0; ph < num_phases; ++ph)
   {
-    dmass += _dfluid_density_dvar[_i][ph][pvar] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_component_index] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _dfluid_saturation_dvar[_i][ph][pvar] * _mass_frac[_i][ph][_component_index] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _dmass_frac_dvar[_i][ph][_component_index][pvar] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_component_index] * _dporosity_dvar[_i][pvar];
+    dmass += _dfluid_density_dvar[_i][ph][pvar] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
+    dmass += _fluid_density[_i][ph] * _dfluid_saturation_dvar[_i][ph][pvar] * _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
+    dmass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _dmass_frac_dvar[_i][ph][_fluid_component][pvar] * _porosity[_i];
+    dmass += _fluid_density[_i][ph] * _fluid_saturation[_i][ph] * _mass_frac[_i][ph][_fluid_component] * _dporosity_dvar[_i][pvar];
   }
 
   return _test[_i][_qp] * dmass * _strain_rate_qp[_qp];

--- a/modules/porous_flow/src/materials/PorousFlow1PhaseMD_Gaussian.C
+++ b/modules/porous_flow/src/materials/PorousFlow1PhaseMD_Gaussian.C
@@ -33,10 +33,10 @@ PorousFlow1PhaseMD_Gaussian::PorousFlow1PhaseMD_Gaussian(const InputParameters &
     _md_qp_var(coupledValue("mass_density")),
     _gradmd_qp_var(coupledGradient("mass_density")),
     _md_varnum(coupled("mass_density")),
-    _pvar(_dictator_UO.isPorousFlowVariable(_md_varnum) ? _dictator_UO.porousFlowVariableNum(_md_varnum) : 0)
+    _pvar(_dictator.isPorousFlowVariable(_md_varnum) ? _dictator.porousFlowVariableNum(_md_varnum) : 0)
 {
-  if (_dictator_UO.numPhases() != 1)
-    mooseError("The Dictator proclaims that the number of phases is " << _dictator_UO.numPhases() << " whereas PorousFlow1PhaseMD_Gaussian can only be used for 1-phase simulations.  Be aware that the Dictator has noted your mistake.");
+  if (_dictator.numPhases() != 1)
+    mooseError("The Dictator proclaims that the number of phases is " << _dictator.numPhases() << " whereas PorousFlow1PhaseMD_Gaussian can only be used for 1-phase simulations.  Be aware that the Dictator has noted your mistake.");
 }
 
 void
@@ -54,7 +54,7 @@ PorousFlow1PhaseMD_Gaussian::computeQpProperties()
 
   buildPS();
 
-  if (_dictator_UO.notPorousFlowVariable(_md_varnum))
+  if (_dictator.notPorousFlowVariable(_md_varnum))
     return;
 
   if (_md_nodal_var[_qp] >= _logdens0)
@@ -96,11 +96,11 @@ PorousFlow1PhaseMD_Gaussian::computeQpProperties()
   }
 
   // _temperature is only dependent on _temperature, and its derivative is = 1
-  if (!_dictator_UO.notPorousFlowVariable(_temperature_varnum))
+  if (!_dictator.notPorousFlowVariable(_temperature_varnum))
   {
     // _temperature is a PorousFlow variable
-    _dtemperature_nodal_dvar[_qp][0][_dictator_UO.porousFlowVariableNum(_temperature_varnum)] = 1.0;
-    _dtemperature_qp_dvar[_qp][0][_dictator_UO.porousFlowVariableNum(_temperature_varnum)] = 1.0;
+    _dtemperature_nodal_dvar[_qp][0][_dictator.porousFlowVariableNum(_temperature_varnum)] = 1.0;
+    _dtemperature_qp_dvar[_qp][0][_dictator.porousFlowVariableNum(_temperature_varnum)] = 1.0;
   }
 }
 

--- a/modules/porous_flow/src/materials/PorousFlow1PhaseP.C
+++ b/modules/porous_flow/src/materials/PorousFlow1PhaseP.C
@@ -24,11 +24,11 @@ PorousFlow1PhaseP::PorousFlow1PhaseP(const InputParameters & parameters) :
     _porepressure_qp_var(coupledValue("porepressure")),
     _gradp_qp_var(coupledGradient("porepressure")),
     _porepressure_varnum(coupled("porepressure")),
-    _p_var_num(_dictator_UO.isPorousFlowVariable(_porepressure_varnum) ? _dictator_UO.porousFlowVariableNum(_porepressure_varnum) : 0),
-    _t_var_num(_dictator_UO.isPorousFlowVariable(_temperature_varnum) ? _dictator_UO.porousFlowVariableNum(_temperature_varnum) : 0)
+    _p_var_num(_dictator.isPorousFlowVariable(_porepressure_varnum) ? _dictator.porousFlowVariableNum(_porepressure_varnum) : 0),
+    _t_var_num(_dictator.isPorousFlowVariable(_temperature_varnum) ? _dictator.porousFlowVariableNum(_temperature_varnum) : 0)
 {
-  if (_dictator_UO.numPhases() != 1)
-    mooseError("The Dictator proclaims that the number of phases is " << _dictator_UO.numPhases() << " whereas PorousFlow1PhaseP can only be used for 1-phase simulations.  Be aware that the Dictator has noted your mistake.");
+  if (_dictator.numPhases() != 1)
+    mooseError("The Dictator proclaims that the number of phases is " << _dictator.numPhases() << " whereas PorousFlow1PhaseP can only be used for 1-phase simulations.  Be aware that the Dictator has noted your mistake.");
 }
 
 void
@@ -53,7 +53,7 @@ PorousFlow1PhaseP::computeQpProperties()
   }
 
   // _porepressure is only dependent on _porepressure, and its derivative is 1
-  if (_dictator_UO.isPorousFlowVariable(_porepressure_varnum))
+  if (_dictator.isPorousFlowVariable(_porepressure_varnum))
   {
     // _porepressure is a PorousFlow variable
     _dporepressure_nodal_dvar[_qp][0][_p_var_num] = 1.0;
@@ -70,7 +70,7 @@ PorousFlow1PhaseP::computeQpProperties()
     _dgrads_qp_dv[_qp][phase].assign(_num_pf_vars, RealGradient());
   }
 
-  if (_dictator_UO.isPorousFlowVariable(_porepressure_varnum))
+  if (_dictator.isPorousFlowVariable(_porepressure_varnum))
   {
     // _porepressure is a porflow variable
     _dsaturation_nodal_dvar[_qp][0][_p_var_num] = dEffectiveSaturation_dP(_porepressure_nodal_var[_qp]);
@@ -87,7 +87,7 @@ PorousFlow1PhaseP::computeQpProperties()
   }
 
   // _temperature is only dependent on _temperature, and its derivative is = 1
-  if (_dictator_UO.isPorousFlowVariable(_temperature_varnum))
+  if (_dictator.isPorousFlowVariable(_temperature_varnum))
   {
     // _temperature is a porflow variable
     _dtemperature_nodal_dvar[_qp][0][_t_var_num] = 1.0;

--- a/modules/porous_flow/src/materials/PorousFlow2PhasePP.C
+++ b/modules/porous_flow/src/materials/PorousFlow2PhasePP.C
@@ -25,19 +25,19 @@ PorousFlow2PhasePP::PorousFlow2PhasePP(const InputParameters & parameters) :
     _phase0_porepressure_qp(coupledValue("phase0_porepressure")),
     _phase0_gradp_qp(coupledGradient("phase0_porepressure")),
     _phase0_porepressure_varnum(coupled("phase0_porepressure")),
-    _p0var(_dictator_UO.isPorousFlowVariable(_phase0_porepressure_varnum) ? _dictator_UO.porousFlowVariableNum(_phase0_porepressure_varnum) : 0),
+    _p0var(_dictator.isPorousFlowVariable(_phase0_porepressure_varnum) ? _dictator.porousFlowVariableNum(_phase0_porepressure_varnum) : 0),
 
     _phase1_porepressure_nodal(coupledNodalValue("phase1_porepressure")),
     _phase1_porepressure_qp(coupledValue("phase1_porepressure")),
     _phase1_gradp_qp(coupledGradient("phase1_porepressure")),
     _phase1_porepressure_varnum(coupled("phase1_porepressure")),
-    _p1var(_dictator_UO.isPorousFlowVariable(_phase1_porepressure_varnum) ? _dictator_UO.porousFlowVariableNum(_phase1_porepressure_varnum) : 0),
+    _p1var(_dictator.isPorousFlowVariable(_phase1_porepressure_varnum) ? _dictator.porousFlowVariableNum(_phase1_porepressure_varnum) : 0),
 
-    _tvar(_dictator_UO.isPorousFlowVariable(_temperature_varnum) ? _dictator_UO.porousFlowVariableNum(_temperature_varnum) : 0)
+    _tvar(_dictator.isPorousFlowVariable(_temperature_varnum) ? _dictator.porousFlowVariableNum(_temperature_varnum) : 0)
 
 {
-  if (_dictator_UO.numPhases() != 2)
-    mooseError("The Dictator announces that the number of phases is " << _dictator_UO.numPhases() << " whereas PorousFlow2PhasePP can only be used for 2-phase simulation.  When you have an efficient government, you have a dictatorship.");
+  if (_dictator.numPhases() != 2)
+    mooseError("The Dictator announces that the number of phases is " << _dictator.numPhases() << " whereas PorousFlow2PhasePP can only be used for 2-phase simulation.  When you have an efficient government, you have a dictatorship.");
 }
 
 void
@@ -60,14 +60,14 @@ PorousFlow2PhasePP::initQpStatefulProperties()
     _dgradp_qp_dv[_qp][phase].assign(_num_pf_vars, RealGradient());
   }
 
-  if (_dictator_UO.isPorousFlowVariable(_phase0_porepressure_varnum))
+  if (_dictator.isPorousFlowVariable(_phase0_porepressure_varnum))
   {
     // _phase0_porepressure is a PorousFlow variable
     _dporepressure_nodal_dvar[_qp][0][_p0var] = 1.0;
     _dporepressure_qp_dvar[_qp][0][_p0var] = 1.0;
     _dgradp_qp_dgradv[_qp][0][_p0var] = 1.0;
   }
-  if (_dictator_UO.isPorousFlowVariable(_phase1_porepressure_varnum))
+  if (_dictator.isPorousFlowVariable(_phase1_porepressure_varnum))
   {
     // _phase1_porepressure is a PorousFlow variable
     _dporepressure_nodal_dvar[_qp][1][_p1var] = 1.0;
@@ -83,7 +83,7 @@ PorousFlow2PhasePP::initQpStatefulProperties()
   }
 
   // _temperature is only dependent on _temperature, and its derivative is = 1
-  if (_dictator_UO.isPorousFlowVariable(_temperature_varnum))
+  if (_dictator.isPorousFlowVariable(_temperature_varnum))
   {
     // _phase0_temperature is a porflow variable
     _dtemperature_nodal_dvar[_qp][0][_tvar] = 1.0;
@@ -113,7 +113,7 @@ PorousFlow2PhasePP::computeQpProperties()
   const Real dseff_qp = dEffectiveSaturation_dP(pc_qp); // d(seff_qp)/d(pc_qp)
   const Real d2seff_qp = d2EffectiveSaturation_dP2(pc_qp); // d^2(seff_qp)/d(pc_qp)^2
 
-  if (_dictator_UO.isPorousFlowVariable(_phase0_porepressure_varnum))
+  if (_dictator.isPorousFlowVariable(_phase0_porepressure_varnum))
   {
     _dsaturation_nodal_dvar[_qp][0][_p0var] = dseff_nodal;
     _dsaturation_qp_dvar[_qp][0][_p0var] = dseff_qp;
@@ -126,7 +126,7 @@ PorousFlow2PhasePP::computeQpProperties()
     _dgrads_qp_dv[_qp][1][_p0var] = - d2seff_qp * (_phase0_gradp_qp[_qp] - _phase1_gradp_qp[_qp]);
   }
 
-  if (_dictator_UO.isPorousFlowVariable(_phase1_porepressure_varnum))
+  if (_dictator.isPorousFlowVariable(_phase1_porepressure_varnum))
   {
     _dsaturation_nodal_dvar[_qp][0][_p1var] = - dseff_nodal;
     _dsaturation_qp_dvar[_qp][0][_p1var] = - dseff_qp;

--- a/modules/porous_flow/src/materials/PorousFlow2PhasePS.C
+++ b/modules/porous_flow/src/materials/PorousFlow2PhasePS.C
@@ -25,21 +25,21 @@ PorousFlow2PhasePS::PorousFlow2PhasePS(const InputParameters & parameters) :
     _phase0_porepressure_qp(coupledValue("phase0_porepressure")),
     _phase0_gradp_qp(coupledGradient("phase0_porepressure")),
     _phase0_porepressure_varnum(coupled("phase0_porepressure")),
-    _pvar(_dictator_UO.isPorousFlowVariable(_phase0_porepressure_varnum) ? _dictator_UO.porousFlowVariableNum(_phase0_porepressure_varnum) : 0),
+    _pvar(_dictator.isPorousFlowVariable(_phase0_porepressure_varnum) ? _dictator.porousFlowVariableNum(_phase0_porepressure_varnum) : 0),
 
     _phase1_saturation_nodal(coupledNodalValue("phase1_saturation")),
     _phase1_saturation_qp(coupledValue("phase1_saturation")),
     _phase1_grads_qp(coupledGradient("phase1_saturation")),
     _phase1_saturation_varnum(coupled("phase1_saturation")),
-    _svar(_dictator_UO.isPorousFlowVariable(_phase1_saturation_varnum) ? _dictator_UO.porousFlowVariableNum(_phase1_saturation_varnum) : 0),
+    _svar(_dictator.isPorousFlowVariable(_phase1_saturation_varnum) ? _dictator.porousFlowVariableNum(_phase1_saturation_varnum) : 0),
 
-    _tvar(_dictator_UO.isPorousFlowVariable(_temperature_varnum) ? _dictator_UO.porousFlowVariableNum(_temperature_varnum) : 0),
+    _tvar(_dictator.isPorousFlowVariable(_temperature_varnum) ? _dictator.porousFlowVariableNum(_temperature_varnum) : 0),
 
     _pc(getParam<Real>("pc"))
 
 {
-  if (_dictator_UO.numPhases() != 2)
-    mooseError("The Dictator proclaims that the number of phases is " << _dictator_UO.numPhases() << " whereas PorousFlow2PhasePS can only be used for 2-phase simulation.  Be aware that the Dictator has noted your mistake.");
+  if (_dictator.numPhases() != 2)
+    mooseError("The Dictator proclaims that the number of phases is " << _dictator.numPhases() << " whereas PorousFlow2PhasePS can only be used for 2-phase simulation.  Be aware that the Dictator has noted your mistake.");
 }
 
 void
@@ -58,7 +58,7 @@ PorousFlow2PhasePS::computeQpProperties()
   buildQpPPSS();
 
   // _porepressure depends on _phase0_porepressure, and its derivative is 1
-  if (_dictator_UO.isPorousFlowVariable(_phase0_porepressure_varnum))
+  if (_dictator.isPorousFlowVariable(_phase0_porepressure_varnum))
   {
     // _phase0_porepressure is a PorousFlow variable
     for (unsigned phase = 0; phase < _num_phases; ++phase)
@@ -75,7 +75,7 @@ PorousFlow2PhasePS::computeQpProperties()
   const Real d2pc_qp = d2CapillaryPressure_dS2(_phase1_saturation_qp[_qp]);
 
   // _saturation is only dependent on _phase1_saturation, and its derivative is +/- 1
-  if (_dictator_UO.isPorousFlowVariable(_phase1_saturation_varnum))
+  if (_dictator.isPorousFlowVariable(_phase1_saturation_varnum))
   {
     // _phase1_saturation is a porflow variable
     _dsaturation_nodal_dvar[_qp][0][_svar] = -1.0;
@@ -93,7 +93,7 @@ PorousFlow2PhasePS::computeQpProperties()
   }
 
   // _temperature is only dependent on temperature, and its derivative is = 1
-  if (_dictator_UO.isPorousFlowVariable(_temperature_varnum))
+  if (_dictator.isPorousFlowVariable(_temperature_varnum))
   {
     // _phase0_temperature is a PorousFlow variable
     for (unsigned int phase = 0; phase < _num_phases; ++phase)

--- a/modules/porous_flow/src/materials/PorousFlow2PhasePS_VG.C
+++ b/modules/porous_flow/src/materials/PorousFlow2PhasePS_VG.C
@@ -29,8 +29,8 @@ PorousFlow2PhasePS_VG::PorousFlow2PhasePS_VG(const InputParameters & parameters)
     _pc_max(getParam<Real>("pc_max")),
     _p0(getParam<Real>("p0"))
 {
-  if (_dictator_UO.numPhases() != 2)
-    mooseError("The Dictator proclaims that the number of phases is " << _dictator_UO.numPhases() << " whereas PorousFlow2PhasePS_VG can only be used for 2-phase simulation.  Be aware that the Dictator has noted your mistake.");
+  if (_dictator.numPhases() != 2)
+    mooseError("The Dictator proclaims that the number of phases is " << _dictator.numPhases() << " whereas PorousFlow2PhasePS_VG can only be used for 2-phase simulation.  Be aware that the Dictator has noted your mistake.");
 }
 
 Real

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureBase.C
@@ -13,7 +13,7 @@ InputParameters validParams<PorousFlowCapillaryPressureBase>()
 {
   InputParameters params = validParams<Material>();
   params.addRequiredParam<unsigned int>("phase", "The phase number");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of PorousFlow variable names");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
   params.addClassDescription("Base class for PorousFlow capillary pressure materials");
   return params;
 }
@@ -22,8 +22,8 @@ PorousFlowCapillaryPressureBase::PorousFlowCapillaryPressureBase(const InputPara
     DerivativeMaterialInterface<Material>(parameters),
 
     _phase_num(getParam<unsigned int>("phase")),
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _saturation_variable_name(_dictator_UO.saturationVariableNameDummy()),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _saturation_variable_name(_dictator.saturationVariableNameDummy()),
     _saturation_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
     _saturation_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_qp")),
     _capillary_pressure_nodal(declareProperty<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num))),
@@ -33,8 +33,8 @@ PorousFlowCapillaryPressureBase::PorousFlowCapillaryPressureBase(const InputPara
     _dcapillary_pressure_qp_ds(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_qp" + Moose::stringify(_phase_num), _saturation_variable_name)),
     _d2capillary_pressure_qp_ds2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_qp" + Moose::stringify(_phase_num), _saturation_variable_name, _saturation_variable_name))
 {
-  if (_phase_num >= _dictator_UO.numPhases())
-    mooseError("PorousFlowCapillaryPressure: The Dictator proclaims that the number of fluid phases is " << _dictator_UO.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
+  if (_phase_num >= _dictator.numPhases())
+    mooseError("PorousFlowCapillaryPressure: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGP.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGP.C
@@ -20,7 +20,7 @@ InputParameters validParams<PorousFlowCapillaryPressureVGP>()
 
 PorousFlowCapillaryPressureVGP::PorousFlowCapillaryPressureVGP(const InputParameters & parameters) :
     PorousFlowCapillaryPressureBase(parameters),
-    _pressure_variable_name(_dictator_UO.pressureVariableNameDummy()),
+    _pressure_variable_name(_dictator.pressureVariableNameDummy()),
     _porepressure_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_nodal")),
     _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
     _dcapillary_pressure_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _pressure_variable_name)),

--- a/modules/porous_flow/src/materials/PorousFlowEffectiveFluidPressure.C
+++ b/modules/porous_flow/src/materials/PorousFlowEffectiveFluidPressure.C
@@ -12,7 +12,7 @@ InputParameters validParams<PorousFlowEffectiveFluidPressure>()
 {
   InputParameters params = validParams<Material>();
 
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("This Material calculates an effective fluid pressure: effective_stress = total_stress + biot_coeff*effective_fluid_pressure.  The effective_fluid_pressure = sum_{phases}(S_phase * P_phase)");
   return params;
 }
@@ -20,9 +20,9 @@ InputParameters validParams<PorousFlowEffectiveFluidPressure>()
 PorousFlowEffectiveFluidPressure::PorousFlowEffectiveFluidPressure(const InputParameters & parameters) :
     DerivativeMaterialInterface<Material>(parameters),
 
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _num_ph(_dictator_UO.numPhases()),
-    _num_var(_dictator_UO.numVariables()),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _num_ph(_dictator.numPhases()),
+    _num_var(_dictator.numVariables()),
 
     _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
     _dporepressure_qp_dvar(getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_porepressure_qp_dvar")),

--- a/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
@@ -13,7 +13,7 @@ InputParameters validParams<PorousFlowFluidPropertiesBase>()
 {
   InputParameters params = validParams<Material>();
   params.addRequiredParam<unsigned int>("phase", "The phase number");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of PorousFlow variable names");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
   params.addClassDescription("Base class for PorousFlow fluid materials");
   return params;
 }
@@ -26,14 +26,14 @@ PorousFlowFluidPropertiesBase::PorousFlowFluidPropertiesBase(const InputParamete
     _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
     _temperature_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_temperature_nodal")),
     _temperature_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_temperature_qp")),
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _pressure_variable_name(_dictator_UO.pressureVariableNameDummy()),
-    _temperature_variable_name(_dictator_UO.temperatureVariableNameDummy()),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _pressure_variable_name(_dictator.pressureVariableNameDummy()),
+    _temperature_variable_name(_dictator.temperatureVariableNameDummy()),
     _t_c2k(273.15),
     _R(8.3144621)
 {
-  if (_phase_num >= _dictator_UO.numPhases())
-    mooseError("PorousFlowFluidProperties: The Dictator proclaims that the number of fluid phases is " << _dictator_UO.numPhases() << " while you have foolishly entered phase = " << _phase_num << " in " << _name << ".  Be aware that the Dictator does not tolerate mistakes.");
+  if (_phase_num >= _dictator.numPhases())
+    mooseError("PorousFlowFluidProperties: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << " in " << _name << ".  Be aware that the Dictator does not tolerate mistakes.");
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowJoiner.C
+++ b/modules/porous_flow/src/materials/PorousFlowJoiner.C
@@ -14,7 +14,7 @@ InputParameters validParams<PorousFlowJoiner>()
 {
   InputParameters params = validParams<Material>();
 
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addRequiredParam<std::string>("material_property", "The property that you want joined into a std::vector");
   params.addParam<bool>("at_qps", false, "If true then join quadpoint properties, otherwise join nodal properties");
   params.addParam<bool>("include_old", false, "Join old properties into vectors as well as the current properties");
@@ -25,13 +25,13 @@ InputParameters validParams<PorousFlowJoiner>()
 PorousFlowJoiner::PorousFlowJoiner(const InputParameters & parameters) :
     DerivativeMaterialInterface<Material>(parameters),
 
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _pressure_variable_name(_dictator_UO.pressureVariableNameDummy()),
-    _saturation_variable_name(_dictator_UO.saturationVariableNameDummy()),
-    _temperature_variable_name(_dictator_UO.temperatureVariableNameDummy()),
-    _mass_fraction_variable_name(_dictator_UO.massFractionVariableNameDummy()),
-    _num_phases(_dictator_UO.numPhases()),
-    _num_var(_dictator_UO.numVariables()),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _pressure_variable_name(_dictator.pressureVariableNameDummy()),
+    _saturation_variable_name(_dictator.saturationVariableNameDummy()),
+    _temperature_variable_name(_dictator.temperatureVariableNameDummy()),
+    _mass_fraction_variable_name(_dictator.massFractionVariableNameDummy()),
+    _num_phases(_dictator.numPhases()),
+    _num_var(_dictator.numVariables()),
     _pf_prop(getParam<std::string>("material_property")),
     _include_old(getParam<bool>("include_old")),
     _at_qps(getParam<bool>("at_qps")),

--- a/modules/porous_flow/src/materials/PorousFlowPermeabilityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowPermeabilityConst.C
@@ -13,7 +13,7 @@ InputParameters validParams<PorousFlowPermeabilityConst>()
   InputParameters params = validParams<Material>();
 
   params.addRequiredParam<RealTensorValue>("permeability", "The permeability tensor (usually in m^2), which is assumed constant for this material");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("This Material calculates the permeability tensor assuming it is constant");
   return params;
 }
@@ -22,7 +22,7 @@ PorousFlowPermeabilityConst::PorousFlowPermeabilityConst(const InputParameters &
     DerivativeMaterialInterface<Material>(parameters),
 
     _input_permeability(getParam<RealTensorValue>("permeability")),
-    _PorousFlow_name_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _PorousFlow_name_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
 
     _permeability(declareProperty<RealTensorValue>("PorousFlow_permeability")),
     _dpermeability_dvar(declareProperty<std::vector<RealTensorValue> >("dPorousFlow_permeability_dvar"))

--- a/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
@@ -30,7 +30,7 @@ PorousFlowPorosityConst::initQpStatefulProperties()
   _porosity_nodal[_qp] = _input_porosity; // this becomes _porosity_old[_qp] in the first call to computeQpProperties
   _porosity_qp[_qp] = _input_porosity; // this becomes _porosity_old[_qp] in the first call to computeQpProperties
 
-  const unsigned int num_var = _dictator_UO.numVariables();
+  const unsigned int num_var = _dictator.numVariables();
   _dporosity_nodal_dvar[_qp].assign(num_var, 0.0);
   _dporosity_qp_dvar[_qp].assign(num_var, 0.0);
   _dporosity_nodal_dgradvar[_qp].assign(num_var, RealGradient());

--- a/modules/porous_flow/src/materials/PorousFlowPorosityHM.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityHM.C
@@ -28,7 +28,7 @@ PorousFlowPorosityHM::PorousFlowPorosityHM(const InputParameters & parameters) :
     _phi0(getParam<Real>("porosity_zero")),
     _biot(getParam<Real>("biot_coefficient")),
     _solid_bulk(getParam<Real>("solid_bulk")),
-    _num_var(_dictator_UO.numVariables()),
+    _num_var(_dictator.numVariables()),
     _coeff((_biot - 1.0)/_solid_bulk),
 
     _ndisp(coupledComponents("displacements")),

--- a/modules/porous_flow/src/materials/PorousFlowPorosityUnity.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityUnity.C
@@ -14,7 +14,7 @@ InputParameters validParams<PorousFlowPorosityUnity>()
 {
   InputParameters params = validParams<Material>();
 
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("This Material calculates the porosity assuming it is equal to 1.0");
   return params;
 }
@@ -22,7 +22,7 @@ InputParameters validParams<PorousFlowPorosityUnity>()
 PorousFlowPorosityUnity::PorousFlowPorosityUnity(const InputParameters & parameters) :
     DerivativeMaterialInterface<Material>(parameters),
 
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _porosity_nodal(declareProperty<Real>("PorousFlow_porosity_nodal")),
     _porosity_nodal_old(declarePropertyOld<Real>("PorousFlow_porosity_nodal")),
     _dporosity_nodal_dvar(declareProperty<std::vector<Real> >("dPorousFlow_porosity_nodal_dvar")),
@@ -40,7 +40,7 @@ PorousFlowPorosityUnity::initQpStatefulProperties()
   _porosity_nodal[_qp] = 1.0;
   _porosity_qp[_qp] = 1.0;
 
-  const unsigned int num_var = _dictator_UO.numVariables();
+  const unsigned int num_var = _dictator.numVariables();
   _dporosity_nodal_dvar[_qp].assign(num_var, 0.0);
   _dporosity_qp_dvar[_qp].assign(num_var, 0.0);
   _dporosity_nodal_dgradvar[_qp].assign(num_var, RealGradient());

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityCorey.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityCorey.C
@@ -16,7 +16,7 @@ InputParameters validParams<PorousFlowRelativePermeabilityCorey>()
 
   params.addRequiredParam<Real>("n_j", "The Corey exponent of phase j.");
   params.addRequiredParam<unsigned int>("phase", "The phase number j");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("This Material calculates relative permeability of either phase Sj, using the simple Corey model (Sj-Sjr)^n/(1-S1r-S2r)");
   return params;
 }

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityUnity.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityUnity.C
@@ -13,7 +13,7 @@ InputParameters validParams<PorousFlowRelativePermeabilityUnity>()
 {
   InputParameters params = validParams<Material>();
   params.addRequiredParam<unsigned int>("phase", "The phase number for which to calculate the relative permeability for");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of PorousFlow variable names");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
   params.addClassDescription("Base class for PorousFlow relative permeability materials.  This class sets the relative permeability = 1");
   return params;
 }
@@ -22,14 +22,14 @@ PorousFlowRelativePermeabilityUnity::PorousFlowRelativePermeabilityUnity(const I
     DerivativeMaterialInterface<Material>(parameters),
 
     _phase_num(getParam<unsigned int>("phase")),
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _saturation_variable_name(_dictator_UO.saturationVariableNameDummy()),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _saturation_variable_name(_dictator.saturationVariableNameDummy()),
     _saturation_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
     _relative_permeability(declareProperty<Real>("PorousFlow_relative_permeability" + Moose::stringify(_phase_num))),
     _drelative_permeability_ds(declarePropertyDerivative<Real>("PorousFlow_relative_permeability" + Moose::stringify(_phase_num), _saturation_variable_name))
 {
-  if (_phase_num >= _dictator_UO.numPhases())
-    mooseError("PorousFlowRelativePermeability: The Dictator proclaims that the number of fluid phases is " << _dictator_UO.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
+  if (_phase_num >= _dictator.numPhases())
+    mooseError("PorousFlowRelativePermeability: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowVariableBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowVariableBase.C
@@ -13,7 +13,7 @@ InputParameters validParams<PorousFlowVariableBase>()
 {
   InputParameters params = validParams<Material>();
   params.addCoupledVar("temperature", 20.0, "Fluid temperature");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names");
   params.addClassDescription("Base class for thermophysical variable materials. Provides pressure, saturation and temperature material properties for all phases as required");
   return params;
 }
@@ -21,10 +21,10 @@ InputParameters validParams<PorousFlowVariableBase>()
 PorousFlowVariableBase::PorousFlowVariableBase(const InputParameters & parameters) :
     DerivativeMaterialInterface<Material>(parameters),
 
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _num_phases(_dictator_UO.numPhases()),
-    _num_components(_dictator_UO.numComponents()),
-    _num_pf_vars(_dictator_UO.numVariables()),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _num_phases(_dictator.numPhases()),
+    _num_components(_dictator.numComponents()),
+    _num_pf_vars(_dictator.numVariables()),
     _temperature_nodal_var(coupledNodalValue("temperature")),
     _temperature_qp_var(coupledValue("temperature")),
     _temperature_varnum(coupled("temperature")),

--- a/modules/porous_flow/src/materials/PorousFlowViscosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowViscosityConst.C
@@ -16,7 +16,7 @@ InputParameters validParams<PorousFlowViscosityConst>()
 
   params.addRequiredParam<Real>("viscosity", "The viscosity, which is assumed constant for this material");
   params.addRequiredParam<unsigned int>("phase", "The phase number");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("This Material calculates the viscosity assuming it is constant");
   return params;
 }
@@ -26,12 +26,12 @@ PorousFlowViscosityConst::PorousFlowViscosityConst(const InputParameters & param
 
     _input_viscosity(getParam<Real>("viscosity")),
     _phase_num(getParam<unsigned int>("phase")),
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
 
     _viscosity(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num)))
 {
-  if (_phase_num >= _dictator_UO.numPhases())
-    mooseError("PorousFlowViscosityConst: The Dictator proclaims that the number of fluid phases is " << _dictator_UO.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
+  if (_phase_num >= _dictator.numPhases())
+    mooseError("PorousFlowViscosityConst: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowVolumetricStrain.C
+++ b/modules/porous_flow/src/materials/PorousFlowVolumetricStrain.C
@@ -16,7 +16,7 @@ InputParameters validParams<PorousFlowVolumetricStrain>()
 {
   InputParameters params = validParams<Material>();
   params.addRequiredCoupledVar("displacements", "The displacements appropriate for the simulation geometry and coordinate system");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addParam<bool>("consistent_with_displaced_mesh", true, "The volumetric strain rate will include terms that ensure fluid mass conservation in the displaced mesh");
   params.addClassDescription("Compute volumetric strain and the volumetric_strain rate, for use in PorousFlow.");
   params.set<bool>("stateful_displacements") = true;
@@ -27,8 +27,8 @@ PorousFlowVolumetricStrain::PorousFlowVolumetricStrain(const InputParameters & p
     DerivativeMaterialInterface<Material>(parameters),
 
     _consistent(getParam<bool>("consistent_with_displaced_mesh")),
-    _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
-    _num_var(_dictator_UO.numVariables()),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _num_var(_dictator.numVariables()),
     _ndisp(coupledComponents("displacements")),
     _disp(3),
     _disp_var_num(3),
@@ -57,7 +57,7 @@ PorousFlowVolumetricStrain::PorousFlowVolumetricStrain(const InputParameters & p
   {
     _disp[i] = &_zero;
     _disp_var_num[i] = 0;
-    while (_dictator_UO.isPorousFlowVariable(_disp_var_num[i]))
+    while (_dictator.isPorousFlowVariable(_disp_var_num[i]))
       _disp_var_num[i]++; // increment until disp_var_num[i] is not a porflow var
     _grad_disp[i] = &_grad_zero;
     _grad_disp_old[i] = &_grad_zero;
@@ -82,10 +82,10 @@ PorousFlowVolumetricStrain::computeQpProperties()
   _dvol_strain_rate_qp_dvar[_qp].resize(_num_var, RealGradient());
   _dvol_total_strain_qp_dvar[_qp].resize(_num_var, RealGradient());
   for (unsigned i = 0 ; i < _ndisp ; ++i)
-    if (_dictator_UO.isPorousFlowVariable(_disp_var_num[i]))
+    if (_dictator.isPorousFlowVariable(_disp_var_num[i]))
     {
     // the i_th displacement is a porous-flow variable
-      const unsigned int pvar = _dictator_UO.porousFlowVariableNum(_disp_var_num[i]);
+      const unsigned int pvar = _dictator.porousFlowVariableNum(_disp_var_num[i]);
       _dvol_strain_rate_qp_dvar[_qp][pvar](i) = 1.0/_dt/andy;
       _dvol_total_strain_qp_dvar[_qp][pvar](i) = 1.0;
     }

--- a/modules/porous_flow/src/postprocessors/PorousFlowFluidMass.C
+++ b/modules/porous_flow/src/postprocessors/PorousFlowFluidMass.C
@@ -11,8 +11,8 @@ template<>
 InputParameters validParams<PorousFlowFluidMass>()
 {
   InputParameters params = validParams<ElementIntegralVariablePostprocessor>();
-  params.addParam<unsigned int>("fluid_component_index", 0, "The index corresponding to the component for this kernel");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator_UO", "The UserObject that holds the list of Porous-Flow variable names.");
+  params.addParam<unsigned int>("fluid_component", 0, "The index corresponding to the component for this kernel");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("Returns the fluid mass of a given component in a region.");
   return params;
 }
@@ -20,24 +20,24 @@ InputParameters validParams<PorousFlowFluidMass>()
 PorousFlowFluidMass::PorousFlowFluidMass(const InputParameters & parameters) :
   ElementIntegralVariablePostprocessor(parameters),
 
-  _component_index(getParam<unsigned int>("fluid_component_index")),
-  _dictator_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator_UO")),
+  _fluid_component(getParam<unsigned int>("fluid_component")),
+  _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
 
   _porosity(getMaterialProperty<Real>("PorousFlow_porosity_nodal")),
   _fluid_density(getMaterialProperty<std::vector<Real> >("PorousFlow_fluid_phase_density")),
   _fluid_saturation(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
   _mass_frac(getMaterialProperty<std::vector<std::vector<Real> > >("PorousFlow_mass_frac"))
 {
-  if (_component_index >= _dictator_UO.numComponents())
-    mooseError("The Dictator proclaims that the number of components in this simulation is " << _dictator_UO.numComponents() << " whereas you have used the Postprocessor PorousFlowFluidMass with component = " << _component_index << ".  The Dictator does not take such mistakes lightly.");
+  if (_fluid_component >= _dictator.numComponents())
+    mooseError("The Dictator proclaims that the number of components in this simulation is " << _dictator.numComponents() << " whereas you have used the Postprocessor PorousFlowFluidMass with component = " << _fluid_component << ".  The Dictator does not take such mistakes lightly.");
 }
 
 Real
 PorousFlowFluidMass::computeQpIntegral()
 {
   Real mass = 0.0;
-  for (unsigned ph = 0; ph < _dictator_UO.numPhases(); ++ph)
-    mass += _fluid_density[_qp][ph] * _fluid_saturation[_qp][ph] * _mass_frac[_qp][ph][_component_index];
+  for (unsigned ph = 0; ph < _dictator.numPhases(); ++ph)
+    mass += _fluid_density[_qp][ph] * _fluid_saturation[_qp][ph] * _mass_frac[_qp][ph][_fluid_component];
 
   return _porosity[_qp] * mass;
 }

--- a/modules/porous_flow/tests/buckley_leverett/bl01.i
+++ b/modules/porous_flow/tests/buckley_leverett/bl01.i
@@ -17,7 +17,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -32,12 +32,12 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = pp
     gravity = '0 0 0'
   [../]

--- a/modules/porous_flow/tests/fluids/brine1.i
+++ b/modules/porous_flow/tests/fluids/brine1.i
@@ -13,7 +13,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/fluids/constant_bulk.i
+++ b/modules/porous_flow/tests/fluids/constant_bulk.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/fluids/h2o1.i
+++ b/modules/porous_flow/tests/fluids/h2o1.i
@@ -13,7 +13,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/fluids/h2o2.i
+++ b/modules/porous_flow/tests/fluids/h2o2.i
@@ -13,7 +13,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/fluids/ideal_gas.i
+++ b/modules/porous_flow/tests/fluids/ideal_gas.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/fluids/methane1.i
+++ b/modules/porous_flow/tests/fluids/methane1.i
@@ -11,7 +11,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/fluids/methane2.i
+++ b/modules/porous_flow/tests/fluids/methane2.i
@@ -11,7 +11,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/fluids/simpleco21.i
+++ b/modules/porous_flow/tests/fluids/simpleco21.i
@@ -13,7 +13,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/fluids/simpleco22.i
+++ b/modules/porous_flow/tests/fluids/simpleco22.i
@@ -13,7 +13,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [UserObjects]

--- a/modules/porous_flow/tests/gravity/grav01a.i
+++ b/modules/porous_flow/tests/gravity/grav01a.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -28,7 +28,7 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = pp
     gravity = '-1 0 0'
   [../]

--- a/modules/porous_flow/tests/gravity/grav01b.i
+++ b/modules/porous_flow/tests/gravity/grav01b.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -28,7 +28,7 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = pp
     gravity = '-1 0 0'
   [../]

--- a/modules/porous_flow/tests/gravity/grav01c.i
+++ b/modules/porous_flow/tests/gravity/grav01c.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -28,7 +28,7 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = pp
     gravity = '-1 0 0'
   [../]

--- a/modules/porous_flow/tests/gravity/grav02a.i
+++ b/modules/porous_flow/tests/gravity/grav02a.i
@@ -11,7 +11,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -36,23 +36,23 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
   [../]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
     gravity = '-1 0 0'
   [../]
   [./mass1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
     gravity = '-1 0 0'
   [../]
@@ -188,13 +188,13 @@
   [../]
   [./mass_ph0]
     type = PorousFlowFluidMass
-    fluid_component_index = 0
+    fluid_component = 0
     variable = ppwater
     execute_on = 'initial timestep_end'
   [../]
   [./mass_ph1]
     type = PorousFlowFluidMass
-    fluid_component_index = 1
+    fluid_component = 1
     variable = ppgas
     execute_on = 'initial timestep_end'
   [../]

--- a/modules/porous_flow/tests/gravity/grav02b.i
+++ b/modules/porous_flow/tests/gravity/grav02b.i
@@ -11,7 +11,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -35,13 +35,13 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
     gravity = '-1 0 0'
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
     gravity = '-1 0 0'
   [../]

--- a/modules/porous_flow/tests/gravity/grav02c.i
+++ b/modules/porous_flow/tests/gravity/grav02c.i
@@ -11,7 +11,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -36,23 +36,23 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
   [../]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
     gravity = '-1 0 0'
   [../]
   [./mass1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
     gravity = '-1 0 0'
   [../]
@@ -167,13 +167,13 @@
   [../]
   [./mass_ph0]
     type = PorousFlowFluidMass
-    fluid_component_index = 0
+    fluid_component = 0
     variable = ppwater
     execute_on = 'initial timestep_end'
   [../]
   [./mass_ph1]
     type = PorousFlowFluidMass
-    fluid_component_index = 1
+    fluid_component = 1
     variable = ppgas
     execute_on = 'initial timestep_end'
   [../]

--- a/modules/porous_flow/tests/gravity/grav02d.i
+++ b/modules/porous_flow/tests/gravity/grav02d.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -51,23 +51,23 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
   [../]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
     gravity = '-1 0 0'
   [../]
   [./mass1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
     gravity = '-1 0 0'
   [../]

--- a/modules/porous_flow/tests/jacobian/eff_stress01.i
+++ b/modules/porous_flow/tests/jacobian/eff_stress01.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]

--- a/modules/porous_flow/tests/jacobian/eff_stress02.i
+++ b/modules/porous_flow/tests/jacobian/eff_stress02.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]

--- a/modules/porous_flow/tests/jacobian/fflux01.i
+++ b/modules/porous_flow/tests/jacobian/fflux01.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -32,7 +32,7 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = pp
     gravity = '-1 -0.1 0'
   [../]

--- a/modules/porous_flow/tests/jacobian/fflux02.i
+++ b/modules/porous_flow/tests/jacobian/fflux02.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -48,19 +48,19 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = pp
     gravity = '-1 -0.1 0'
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
-    component_index = 1
+    fluid_component = 1
     variable = massfrac0
     gravity = '-1 -0.1 0'
   [../]
   [./flux2]
     type = PorousFlowAdvectiveFlux
-    component_index = 2
+    fluid_component = 2
     variable = massfrac1
     gravity = '-1 -0.1 0'
   [../]

--- a/modules/porous_flow/tests/jacobian/fflux03.i
+++ b/modules/porous_flow/tests/jacobian/fflux03.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -60,13 +60,13 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
     gravity = '-1 -0.1 0'
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
     gravity = '-1 -0.1 0'
   [../]

--- a/modules/porous_flow/tests/jacobian/fflux04.i
+++ b/modules/porous_flow/tests/jacobian/fflux04.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -76,19 +76,19 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
     gravity = '-1 -0.1 0'
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
     gravity = '-1 -0.1 0'
   [../]
   [./flux2]
     type = PorousFlowAdvectiveFlux
-    component_index = 2
+    fluid_component = 2
     variable = massfrac_ph0_sp0
     gravity = '-1 -0.1 0'
   [../]

--- a/modules/porous_flow/tests/jacobian/fflux05.i
+++ b/modules/porous_flow/tests/jacobian/fflux05.i
@@ -14,7 +14,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 
@@ -36,7 +36,7 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = md
     gravity = '-1 -0.1 0'
   [../]

--- a/modules/porous_flow/tests/jacobian/fflux06.i
+++ b/modules/porous_flow/tests/jacobian/fflux06.i
@@ -14,7 +14,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 
@@ -36,7 +36,7 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = md
     gravity = '-1 -0.1 0'
   [../]

--- a/modules/porous_flow/tests/jacobian/fflux07.i
+++ b/modules/porous_flow/tests/jacobian/fflux07.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -60,13 +60,13 @@
 [Kernels]
   [./flux0]
     type = PorousFlowAdvectiveFlux
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
     gravity = '-1 -0.1 0'
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
-    component_index = 1
+    fluid_component = 1
     variable = sgas
     gravity = '-1 -0.1 0'
   [../]

--- a/modules/porous_flow/tests/jacobian/mass01.i
+++ b/modules/porous_flow/tests/jacobian/mass01.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -22,7 +22,7 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass02.i
+++ b/modules/porous_flow/tests/jacobian/mass02.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -22,7 +22,7 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass03.i
+++ b/modules/porous_flow/tests/jacobian/mass03.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -46,17 +46,17 @@
 [Kernels]
   [./mass_comp0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
   [./masscomp1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = mass_frac_comp0
   [../]
   [./masscomp2]
     type = PorousFlowMassTimeDerivative
-    component_index = 2
+    fluid_component = 2
     variable = mass_frac_comp1
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass04.i
+++ b/modules/porous_flow/tests/jacobian/mass04.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -57,12 +57,12 @@
 [Kernels]
   [./mass_sp0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
   [../]
   [./mass_sp1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass05.i
+++ b/modules/porous_flow/tests/jacobian/mass05.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -73,17 +73,17 @@
 [Kernels]
   [./mass_sp0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
   [../]
   [./mass_sp1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
   [../]
   [./mass_sp2]
     type = PorousFlowMassTimeDerivative
-    component_index = 2
+    fluid_component = 2
     variable = massfrac_ph0_sp0
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass06.i
+++ b/modules/porous_flow/tests/jacobian/mass06.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -30,7 +30,7 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = md
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass07.i
+++ b/modules/porous_flow/tests/jacobian/mass07.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -30,7 +30,7 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = md
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass08.i
+++ b/modules/porous_flow/tests/jacobian/mass08.i
@@ -8,7 +8,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -68,7 +68,7 @@
   [../]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass09.i
+++ b/modules/porous_flow/tests/jacobian/mass09.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -56,12 +56,12 @@
 [Kernels]
   [./mass_sp0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
   [../]
   [./mass_sp1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = sgas
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass_vol_exp01.i
+++ b/modules/porous_flow/tests/jacobian/mass_vol_exp01.i
@@ -17,7 +17,7 @@
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
   block = 0
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -79,7 +79,7 @@
   [../]
   [./poro]
     type = PorousFlowMassVolumetricExpansion
-    component_index = 0
+    fluid_component = 0
     variable = porepressure
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/mass_vol_exp02.i
+++ b/modules/porous_flow/tests/jacobian/mass_vol_exp02.i
@@ -17,7 +17,7 @@
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
   block = 0
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -79,7 +79,7 @@
   [../]
   [./poro]
     type = PorousFlowMassVolumetricExpansion
-    component_index = 0
+    fluid_component = 0
     variable = porepressure
   [../]
 []

--- a/modules/porous_flow/tests/mass_conservation/mass01.i
+++ b/modules/porous_flow/tests/mass_conservation/mass01.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -28,7 +28,7 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
 []

--- a/modules/porous_flow/tests/mass_conservation/mass02.i
+++ b/modules/porous_flow/tests/mass_conservation/mass02.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -35,12 +35,12 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
   [./mass1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = mass_frac_comp0
   [../]
 []
@@ -90,7 +90,7 @@
   [./total_mass_1]
     type = PorousFlowFluidMass
     variable = pp
-    fluid_component_index = 1
+    fluid_component = 1
   [../]
 []
 

--- a/modules/porous_flow/tests/mass_conservation/mass03.i
+++ b/modules/porous_flow/tests/mass_conservation/mass03.i
@@ -6,7 +6,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -19,7 +19,7 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
   [./source]

--- a/modules/porous_flow/tests/mass_conservation/mass04.i
+++ b/modules/porous_flow/tests/mass_conservation/mass04.i
@@ -39,7 +39,7 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
   block = 0
 []
 
@@ -120,11 +120,11 @@
   [./poro_vol_exp]
     type = PorousFlowMassVolumetricExpansion
     variable = porepressure
-    component_index = 0
+    fluid_component = 0
   [../]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = porepressure
   [../]
 []
@@ -325,7 +325,7 @@
   [../]
   [./fluid_mass]
     type = PorousFlowFluidMass
-    fluid_component_index = 0
+    fluid_component = 0
     variable = porepressure
     execute_on = 'initial timestep_end'
     use_displaced_mesh = true

--- a/modules/porous_flow/tests/poro_elasticity/mandel.i
+++ b/modules/porous_flow/tests/poro_elasticity/mandel.i
@@ -66,7 +66,7 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
   block = 0
 []
 
@@ -200,18 +200,18 @@
   [./poro_vol_exp]
     type = PorousFlowMassVolumetricExpansion
     variable = porepressure
-    component_index = 0
+    fluid_component = 0
   [../]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = porepressure
   [../]
   [./flux]
     type = PorousFlowAdvectiveFlux
     variable = porepressure
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
 []
 

--- a/modules/porous_flow/tests/poro_elasticity/pp_generation.i
+++ b/modules/porous_flow/tests/poro_elasticity/pp_generation.i
@@ -35,7 +35,7 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
   block = 0
 []
 
@@ -118,18 +118,18 @@
   [./poro_vol_exp]
     type = PorousFlowMassVolumetricExpansion
     variable = porepressure
-    component_index = 0
+    fluid_component = 0
   [../]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = porepressure
   [../]
   [./flux]
     type = PorousFlowAdvectiveFlux
     variable = porepressure
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
   [./source]
     type = UserForcingFunction
@@ -307,7 +307,7 @@
 [Postprocessors]
   [./fluid_mass]
     type = PorousFlowFluidMass
-    fluid_component_index = 0
+    fluid_component = 0
     variable = porepressure
     execute_on = 'initial timestep_end'
     use_displaced_mesh = true

--- a/modules/porous_flow/tests/poro_elasticity/pp_generation_unconfined.i
+++ b/modules/porous_flow/tests/poro_elasticity/pp_generation_unconfined.i
@@ -36,7 +36,7 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
   block = 0
 []
 
@@ -119,18 +119,18 @@
   [./poro_vol_exp]
     type = PorousFlowMassVolumetricExpansion
     variable = porepressure
-    component_index = 0
+    fluid_component = 0
   [../]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = porepressure
   [../]
   [./flux]
     type = PorousFlowAdvectiveFlux
     variable = porepressure
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
   [./source]
     type = UserForcingFunction

--- a/modules/porous_flow/tests/poro_elasticity/terzaghi.i
+++ b/modules/porous_flow/tests/poro_elasticity/terzaghi.i
@@ -68,7 +68,7 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
   block = 0
 []
 
@@ -163,18 +163,18 @@
   [./poro_vol_exp]
     type = PorousFlowMassVolumetricExpansion
     variable = porepressure
-    component_index = 0
+    fluid_component = 0
   [../]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = porepressure
   [../]
   [./flux]
     type = PorousFlowAdvectiveFlux
     variable = porepressure
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
 []
 

--- a/modules/porous_flow/tests/poro_elasticity/undrained_oedometer.i
+++ b/modules/porous_flow/tests/poro_elasticity/undrained_oedometer.i
@@ -39,7 +39,7 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
   block = 0
 []
 
@@ -98,32 +98,14 @@
     variable = disp_z
     component = 2
   [../]
-  #[./poro_x]
-  #  type = PorousFlowEffectiveStressCoupling
-  #  biot_coefficient = 0.3
-  #  variable = disp_x
-  #  component = 0
-  #[../]
-  #[./poro_y]
-  #  type = PorousFlowEffectiveStressCoupling
-  #  biot_coefficient = 0.3
-  #  variable = disp_y
-  #  component = 1
-  #[../]
-  #[./poro_z]
-  #  type = PorousFlowEffectiveStressCoupling
-  #  biot_coefficient = 0.3
-  #  component = 2
-  #  variable = disp_z
-  #[../]
   [./poro_vol_exp]
     type = PorousFlowMassVolumetricExpansion
     variable = porepressure
-    component_index = 0
+    fluid_component = 0
   [../]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = porepressure
   [../]
 []
@@ -286,7 +268,7 @@
 [Postprocessors]
   [./fluid_mass]
     type = PorousFlowFluidMass
-    fluid_component_index = 0
+    fluid_component = 0
     variable = porepressure
     execute_on = 'initial timestep_end'
     use_displaced_mesh = true

--- a/modules/porous_flow/tests/poro_elasticity/vol_expansion.i
+++ b/modules/porous_flow/tests/poro_elasticity/vol_expansion.i
@@ -27,7 +27,7 @@
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
   block = 0
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]

--- a/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d.i
+++ b/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d.i
@@ -8,7 +8,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -20,14 +20,14 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
   [./flux]
     type = PorousFlowAdvectiveFlux
     variable = pp
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
 []
 

--- a/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d_2phase.i
+++ b/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d_2phase.i
@@ -8,7 +8,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -33,25 +33,25 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = ppwater
   [../]
   [./flux0]
     type = PorousFlowAdvectiveFlux
     variable = ppwater
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
   [./mass1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = ppgas
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
     variable = ppgas
     gravity = '0 0 0'
-    component_index = 1
+    fluid_component = 1
   [../]
 []
 

--- a/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d_3comp.i
+++ b/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d_3comp.i
@@ -8,7 +8,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -26,36 +26,36 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
   [./flux0]
     type = PorousFlowAdvectiveFlux
     variable = pp
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
   [./mass1]
     type = PorousFlowMassTimeDerivative
-    component_index = 1
+    fluid_component = 1
     variable = massfrac0
   [../]
   [./flux1]
     type = PorousFlowAdvectiveFlux
     variable = massfrac0
     gravity = '0 0 0'
-    component_index = 1
+    fluid_component = 1
   [../]
   [./mass2]
     type = PorousFlowMassTimeDerivative
-    component_index = 2
+    fluid_component = 2
     variable = massfrac1
   [../]
   [./flux2]
     type = PorousFlowAdvectiveFlux
     variable = massfrac1
     gravity = '0 0 0'
-    component_index = 2
+    fluid_component = 2
   [../]
 []
 

--- a/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d_MD.i
+++ b/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d_MD.i
@@ -9,7 +9,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -23,14 +23,14 @@
 [Kernels]
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = md
   [../]
   [./flux]
     type = PorousFlowAdvectiveFlux
     variable = md
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
 []
 

--- a/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d_steady.i
+++ b/modules/porous_flow/tests/pressure_pulse/pressure_pulse_1d_steady.i
@@ -8,7 +8,7 @@
 []
 
 [GlobalParams]
-  PorousFlowDictator_UO = dictator
+  PorousFlowDictator = dictator
 []
 
 [Variables]
@@ -21,14 +21,14 @@
   active = flux
   [./mass0]
     type = PorousFlowMassTimeDerivative
-    component_index = 0
+    fluid_component = 0
     variable = pp
   [../]
   [./flux]
     type = PorousFlowAdvectiveFlux
     variable = pp
     gravity = '0 0 0'
-    component_index = 0
+    fluid_component = 0
   [../]
 []
 


### PR DESCRIPTION
component, component_index and fluid_component_index all changed to fluid_component.
got rid of the "_UO" suffix on dictator objects and in the input files

Fixes #6986
Fixes #6939
