### PR TITLE
Set an abs_zero for the adapt_and_modify test.

### DIFF
--- a/test/tests/executioners/adapt_and_modify/tests
+++ b/test/tests/executioners/adapt_and_modify/tests
@@ -6,5 +6,6 @@
     compiler = 'GCC'
     rel_err = 5.e-5
     recover = false
+    abs_zero = 1.e-8
   [../]
 []


### PR DESCRIPTION
This test diffed ever so slightly on our new 64-bit build target (see
below) so it might be possible to fix simply by loosening the abs_zero
setting slightly.

Refs #6959.

```
   --------- Time step 1, 4.0000000e-03 ~ 4.0000000e-03, rel diff:  0.00000e+00 ---------
 Nodal variables:
    u  rel diff:  1.5019635e-10 ~  1.4481588e-10 = 3.58229e-02 (node 230)
 Element variables:
    gji    rel diff:  5.4255747e-09 ~  5.4316172e-09 = 1.11246e-03 (block 0, elmt 214)
```
