### PR TITLE
Use correct ifdef guard in ICE Updater.

### DIFF
--- a/framework/contrib/ice_updater/include/Updater.h
+++ b/framework/contrib/ice_updater/include/Updater.h
@@ -43,7 +43,7 @@
 #include "MooseError.h"
 #include "INetworkingTool.h"
 
-#ifdef LIBMESH_HAVE_CXX11
+#ifdef LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE
 
 #include <condition_variable>
 #include <mutex>
@@ -445,6 +445,6 @@ public:
   void updateProgress(int) {}
 };
 
-#endif // LIBMESH_HAVE_CXX11
+#endif // LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE
 
 #endif

--- a/framework/contrib/ice_updater/src/Updater.cpp
+++ b/framework/contrib/ice_updater/src/Updater.cpp
@@ -35,7 +35,7 @@
 
 #include "Updater.h"
 
-#ifdef LIBMESH_HAVE_CXX11
+#ifdef LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE
 #include "NetworkingToolFactory.h"
 
 std::vector<std::string> &split(const std::string &s, char delim,
@@ -606,4 +606,4 @@ void Updater::initialize(std::string propertyString)
     errorLoggerPtr->dumpErrors();
 }
 
-#endif // LIBMESH_HAVE_CXX11
+#endif // LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE

--- a/framework/include/outputs/ICEUpdater.h
+++ b/framework/include/outputs/ICEUpdater.h
@@ -23,8 +23,8 @@
 // Forward declarations
 class Updater;
 
-// Currently the ICE Updater requires C++11
-#ifdef LIBMESH_HAVE_CXX11
+// Currently the ICE Updater requires C++11 threads and std::condition_variable
+#ifdef LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE
 
 // Forward declarations
 class ICEUpdater;
@@ -73,4 +73,4 @@ protected:
 
 #endif
 
-#endif // LIBMESH_HAVE_CXX11
+#endif // LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -416,7 +416,7 @@
 #include "TopResidualDebugOutput.h"
 #include "DOFMapOutput.h"
 #include "ControlOutput.h"
-#ifdef LIBMESH_HAVE_CXX11
+#ifdef LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE
 #include "ICEUpdater.h"
 #endif
 
@@ -778,7 +778,7 @@ registerObjects(Factory & factory)
   registerOutput(ControlOutput);
 
   // Currently the ICE Updater requires TBB
-  #ifdef LIBMESH_HAVE_CXX11
+  #ifdef LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE
   registerOutput(ICEUpdater);
   #endif
 

--- a/framework/src/outputs/ICEUpdater.C
+++ b/framework/src/outputs/ICEUpdater.C
@@ -19,8 +19,8 @@
 #include <sstream>
 #include "MooseTypes.h"
 
-// Currently the ICE Updater requires TBB
-#ifdef LIBMESH_HAVE_CXX11
+// Currently the ICE Updater requires C++11 threads.
+#ifdef LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE
 
 template<>
 InputParameters validParams<ICEUpdater>()
@@ -122,4 +122,4 @@ void ICEUpdater::outputPostprocessors()
   }
 }
 
-#endif // LIBMESH_HAVE_CXX11
+#endif // LIBMESH_HAVE_CXX11_THREAD && LIBMESH_HAVE_CXX11_CONDITION_VARIABLE


### PR DESCRIPTION
This class uses std::thread, so it should only be active if the
compiler actually supports C++11 threads, not just the 'basic' C++11
features.

Refs #6887.
