### PR TITLE
Base materials for Porous Flow

### DIFF
--- a/modules/porous_flow/include/materials/PorousFlowCapillaryPressureBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowCapillaryPressureBase.h
@@ -8,9 +8,7 @@
 #ifndef POROUSFLOWCAPILLARYPRESSUREBASE_H
 #define POROUSFLOWCAPILLARYPRESSUREBASE_H
 
-#include "DerivativeMaterialInterface.h"
-#include "Material.h"
-#include "PorousFlowDictator.h"
+#include "PorousFlowMaterialBase.h"
 
 class PorousFlowCapillaryPressureBase;
 
@@ -20,19 +18,13 @@ InputParameters validParams<PorousFlowCapillaryPressureBase>();
 /**
  * Base class for capillary pressure
  */
-class PorousFlowCapillaryPressureBase : public DerivativeMaterialInterface<Material>
+class PorousFlowCapillaryPressureBase : public PorousFlowMaterialBase
 {
 public:
   PorousFlowCapillaryPressureBase(const InputParameters & parameters);
 
 protected:
   virtual void computeQpProperties();
-
-  /// Phase number of fluid that this relative permeability relates to
-  const unsigned int _phase_num;
-
-  /// The PorousFlowDictator UserObject
-  const PorousFlowDictator & _dictator;
 
   /// Name of (dummy) saturation primary variable
   VariableName _saturation_variable_name;

--- a/modules/porous_flow/include/materials/PorousFlowEffectiveFluidPressure.h
+++ b/modules/porous_flow/include/materials/PorousFlowEffectiveFluidPressure.h
@@ -8,10 +8,7 @@
 #ifndef POROUSFLOWEFFECTIVEFLUIDPRESSURE_H
 #define POROUSFLOWEFFECTIVEFLUIDPRESSURE_H
 
-#include "DerivativeMaterialInterface.h"
-#include "Material.h"
-
-#include "PorousFlowDictator.h"
+#include "PorousFlowMaterialVectorBase.h"
 
 //Forward Declarations
 class PorousFlowEffectiveFluidPressure;
@@ -25,20 +22,13 @@ InputParameters validParams<PorousFlowEffectiveFluidPressure>();
  * and other similar places.  This class computes
  * effective fluid pressure = sum_{phases}Saturation_{phase}*Porepressure_{phase}
  */
-class PorousFlowEffectiveFluidPressure : public DerivativeMaterialInterface<Material>
+class PorousFlowEffectiveFluidPressure : public PorousFlowMaterialVectorBase
 {
 public:
   PorousFlowEffectiveFluidPressure(const InputParameters & parameters);
 
 protected:
-  /// The dictator UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator;
-
-  /// number of phases in this simulation
-  const unsigned int _num_ph;
-
-  /// number of porous-flow variables in this simulation
-  const unsigned int _num_var;
+  virtual void computeQpProperties();
 
   /// quadpoint porepressure of each phase
   const MaterialProperty<std::vector<Real> > & _porepressure_qp;
@@ -75,8 +65,6 @@ protected:
 
   /// d(_pf_nodal)/d(PorousFlow variable)
   MaterialProperty<std::vector<Real> > & _dpf_nodal_dvar;
-
-  virtual void computeQpProperties();
 };
 
 #endif //POROUSFLOWEFFECTIVEFLUIDPRESSURE_H

--- a/modules/porous_flow/include/materials/PorousFlowFluidPropertiesBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowFluidPropertiesBase.h
@@ -8,8 +8,7 @@
 #ifndef POROUSFLOWFLUIDPROPERTIESBASE_H
 #define POROUSFLOWFLUIDPROPERTIESBASE_H
 
-#include "DerivativeMaterialInterface.h"
-#include "Material.h"
+#include "PorousFlowMaterialBase.h"
 #include "PorousFlowDictator.h"
 
 class PorousFlowFluidPropertiesBase;
@@ -18,19 +17,16 @@ template<>
 InputParameters validParams<PorousFlowFluidPropertiesBase>();
 
 /**
- * Base class for fluid properties
+ * Base class for fluid properties materials. All PorousFlow fluid
+ * materials must override computeQpProperties()
  */
-class PorousFlowFluidPropertiesBase : public DerivativeMaterialInterface<Material>
+class PorousFlowFluidPropertiesBase : public PorousFlowMaterialBase
 {
 public:
   PorousFlowFluidPropertiesBase(const InputParameters & parameters);
 
 protected:
-  /// Somehow should be able to make this pure virtual?
   virtual void computeQpProperties();
-
-  /// Phase number of fluid that this relative permeability relates to
-  const unsigned int _phase_num;
 
   /// Pore pressure at the nodes
   const MaterialProperty<std::vector<Real> > & _porepressure_nodal;
@@ -43,9 +39,6 @@ protected:
 
   /// Fluid temperature at the qps
   const MaterialProperty<std::vector<Real> > & _temperature_qp;
-
-  /// The PorousFlowDictator UserObject
-  const PorousFlowDictator & _dictator;
 
   /// Name of (dummy) pressure primary variable
   const VariableName _pressure_variable_name;

--- a/modules/porous_flow/include/materials/PorousFlowJoiner.h
+++ b/modules/porous_flow/include/materials/PorousFlowJoiner.h
@@ -8,10 +8,7 @@
 #ifndef POROUSFLOWJOINER_H
 #define POROUSFLOWJOINER_H
 
-#include "DerivativeMaterialInterface.h"
-#include "Material.h"
-
-#include "PorousFlowDictator.h"
+#include "PorousFlowMaterialVectorBase.h"
 
 //Forward Declarations
 class PorousFlowJoiner;
@@ -37,7 +34,7 @@ InputParameters validParams<PorousFlowJoiner>();
  *
  * Only values at the nodes are used - not at the quadpoints
  */
-class PorousFlowJoiner : public DerivativeMaterialInterface<Material>
+class PorousFlowJoiner : public PorousFlowMaterialVectorBase
 {
 public:
   PorousFlowJoiner(const InputParameters & parameters);
@@ -46,9 +43,6 @@ protected:
   virtual void initQpStatefulProperties();
 
   virtual void computeQpProperties();
-
-  /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator;
 
   /// Name of (dummy) pressure variable
   const VariableName _pressure_variable_name;
@@ -61,12 +55,6 @@ protected:
 
   /// Name of (dummy) mass fraction variable
   const VariableName _mass_fraction_variable_name;
-
-  /// Number of phases
-  const unsigned int _num_phases;
-
-  /// Number of porous flow variables
-  const unsigned int _num_var;
 
   /// Name of material property to be joined
   const std::string _pf_prop;

--- a/modules/porous_flow/include/materials/PorousFlowMassFraction.h
+++ b/modules/porous_flow/include/materials/PorousFlowMassFraction.h
@@ -8,10 +8,7 @@
 #ifndef POROUSFLOWMASSFRACTION_H
 #define POROUSFLOWMASSFRACTION_H
 
-#include "DerivativeMaterialInterface.h"
-#include "Material.h"
-
-#include "PorousFlowDictator.h"
+#include "PorousFlowMaterialVectorBase.h"
 
 //Forward Declarations
 class PorousFlowMassFraction;
@@ -23,21 +20,12 @@ InputParameters validParams<PorousFlowMassFraction>();
  * Material designed to form a std::vector<std::vector>
  * of mass fractions from the individual mass fraction variables
  */
-class PorousFlowMassFraction : public DerivativeMaterialInterface<Material>
+class PorousFlowMassFraction : public PorousFlowMaterialVectorBase
 {
 public:
   PorousFlowMassFraction(const InputParameters & parameters);
 
 protected:
-  /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator;
-
-  /// Number of fluid phases
-  const unsigned int _num_phases;
-
-  /// Number of fluid components
-  const unsigned int _num_components;
-
   /// Mass fraction matrix
   MaterialProperty<std::vector<std::vector<Real> > > & _mass_frac;
 

--- a/modules/porous_flow/include/materials/PorousFlowMaterialBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowMaterialBase.h
@@ -1,0 +1,43 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWMATERIALBASE_H
+#define POROUSFLOWMATERIALBASE_H
+
+#include "Material.h"
+#include "DerivativeMaterialInterface.h"
+#include "PorousFlowDictator.h"
+
+class PorousFlowMaterialBase;
+
+template<>
+InputParameters validParams<PorousFlowMaterialBase>();
+
+/**
+ * Base class for all PorousFlow materials that provide phase-dependent properties.
+ * These include: fluid properties, relative permeabilities and capillary pressures.
+ * and relative permeability classes. This base class checks that the specified fluid
+ * phase index is valid, and provides a stringified version of the phase index to use
+ * in the material property names.
+ */
+class PorousFlowMaterialBase : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowMaterialBase(const InputParameters & parameters);
+
+protected:
+  /// The PorousFlow Dictator UserObject
+  const PorousFlowDictator & _dictator;
+
+  /// Phase number of fluid
+  const unsigned int _phase_num;
+
+  /// Stringified fluid phase number
+  const std::string _phase;
+};
+
+#endif //POROUSFLOWMATERIALBASE_H

--- a/modules/porous_flow/include/materials/PorousFlowMaterialVectorBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowMaterialVectorBase.h
@@ -1,0 +1,45 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWMATERIALVECTORBASE_H
+#define POROUSFLOWMATERIALVECTORBASE_H
+
+#include "Material.h"
+#include "DerivativeMaterialInterface.h"
+#include "PorousFlowDictator.h"
+
+class PorousFlowMaterialVectorBase;
+
+template<>
+InputParameters validParams<PorousFlowMaterialVectorBase>();
+
+/**
+ * Base class for all PorousFlow materials that combine phase-dependent properties
+ * such as fluid properties, relative permeability etc. This base class provides the
+ * number of phases and number of fluid components (amongst other things) to all
+ * PorousFlow materials that provide the vectors of properties expected by the kernels.
+ */
+class PorousFlowMaterialVectorBase : public DerivativeMaterialInterface<Material>
+{
+public:
+  PorousFlowMaterialVectorBase(const InputParameters & parameters);
+
+protected:
+  /// The PorousFlow Dictator UserObject
+  const PorousFlowDictator & _dictator;
+
+  /// Number of phases
+  const unsigned int _num_phases;
+
+  /// Number of fluid components
+  const unsigned int _num_components;
+
+  /// Number of PorousFlow variables
+  const unsigned int _num_var;
+};
+
+#endif //POROUSFLOWMATERIALVECTORBASE_H

--- a/modules/porous_flow/include/materials/PorousFlowPermeabilityConst.h
+++ b/modules/porous_flow/include/materials/PorousFlowPermeabilityConst.h
@@ -8,10 +8,7 @@
 #ifndef POROUSFLOWPERMEABILITYCONST_H
 #define POROUSFLOWPERMEABILITYCONST_H
 
-#include "DerivativeMaterialInterface.h"
-#include "Material.h"
-
-#include "PorousFlowDictator.h"
+#include "PorousFlowMaterialVectorBase.h"
 
 //Forward Declarations
 class PorousFlowPermeabilityConst;
@@ -23,26 +20,23 @@ InputParameters validParams<PorousFlowPermeabilityConst>();
  * Material designed to provide the permeability tensor
  * which is assumed constant
  */
-class PorousFlowPermeabilityConst : public DerivativeMaterialInterface<Material>
+class PorousFlowPermeabilityConst : public PorousFlowMaterialVectorBase
 {
 public:
   PorousFlowPermeabilityConst(const InputParameters & parameters);
 
 protected:
+    virtual void initQpStatefulProperties();
+    virtual void computeQpProperties();
+
   /// constant value of permeability tensor
   const RealTensorValue _input_permeability;
-
-  /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _PorousFlow_name_UO;
 
   /// permeability
   MaterialProperty<RealTensorValue> & _permeability;
 
   /// d(permeability)/d(PorousFlow variable) which are all zero in this case
   MaterialProperty<std::vector<RealTensorValue> > & _dpermeability_dvar;
-
-  virtual void initQpStatefulProperties();
-  virtual void computeQpProperties();
 };
 
 #endif //POROUSFLOWPERMEABILITYCONST_H

--- a/modules/porous_flow/include/materials/PorousFlowPorosityConst.h
+++ b/modules/porous_flow/include/materials/PorousFlowPorosityConst.h
@@ -26,12 +26,12 @@ public:
   PorousFlowPorosityConst(const InputParameters & parameters);
 
 protected:
-  /// constant input value of porosity
-  const Real _input_porosity;
-
   virtual void initQpStatefulProperties();
 
   virtual void computeQpProperties();
+
+  /// constant input value of porosity
+  const Real _input_porosity;
 };
 
 #endif //POROUSFLOWPOROSITYCONST_H

--- a/modules/porous_flow/include/materials/PorousFlowPorosityHM.h
+++ b/modules/porous_flow/include/materials/PorousFlowPorosityHM.h
@@ -27,6 +27,10 @@ public:
   PorousFlowPorosityHM(const InputParameters & parameters);
 
 protected:
+  virtual void initQpStatefulProperties();
+
+  virtual void computeQpProperties();
+
   /// porosity at zero strain and zero porepressure
   const Real _phi0;
 
@@ -35,9 +39,6 @@ protected:
 
   /// drained bulk modulus of the porous skeleton
   const Real _solid_bulk;
-
-  /// number of porous-flow variables
-  const unsigned int _num_var;
 
   /// short-hand number (biot-1)/solid_bulk
   const Real _coeff;
@@ -65,10 +66,6 @@ protected:
 
   /// d(effective qp porepressure)/(d porflow variable)
   const MaterialProperty<std::vector<Real> > & _dpf_qp_dvar;
-
-  virtual void initQpStatefulProperties();
-
-  virtual void computeQpProperties();
 };
 
 #endif //POROUSFLOWPOROSITYHM_H

--- a/modules/porous_flow/include/materials/PorousFlowPorosityUnity.h
+++ b/modules/porous_flow/include/materials/PorousFlowPorosityUnity.h
@@ -8,10 +8,7 @@
 #ifndef POROUSFLOWPOROSITYUNITY_H
 #define POROUSFLOWPOROSITYUNITY_H
 
-#include "DerivativeMaterialInterface.h"
-#include "Material.h"
-
-#include "PorousFlowDictator.h"
+#include "PorousFlowMaterialVectorBase.h"
 
 //Forward Declarations
 class PorousFlowPorosityUnity;
@@ -23,14 +20,14 @@ InputParameters validParams<PorousFlowPorosityUnity>();
  * Base class Material designed to provide the porosity.
  * In this class porosity = 1
  */
-class PorousFlowPorosityUnity : public DerivativeMaterialInterface<Material>
+class PorousFlowPorosityUnity : public PorousFlowMaterialVectorBase
 {
 public:
   PorousFlowPorosityUnity(const InputParameters & parameters);
 
 protected:
-  /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator;
+    virtual void initQpStatefulProperties();
+    virtual void computeQpProperties();
 
   /// nodal porosity
   MaterialProperty<Real> & _porosity_nodal;
@@ -55,9 +52,6 @@ protected:
 
   /// d(quadpoint porosity)/d(PorousFlow variable)
   MaterialProperty<std::vector<RealGradient> > & _dporosity_qp_dgradvar;
-
-  virtual void initQpStatefulProperties();
-  virtual void computeQpProperties();
 };
 
 #endif //POROUSFLOWPOROSITYUNITY_H

--- a/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityBase.h
@@ -1,0 +1,43 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWRELATIVEPERMEABILITYBASE_H
+#define POROUSFLOWRELATIVEPERMEABILITYBASE_H
+
+#include "PorousFlowMaterialBase.h"
+
+class PorousFlowRelativePermeabilityBase;
+
+template<>
+InputParameters validParams<PorousFlowRelativePermeabilityBase>();
+
+/**
+ * Base class for PorousFlow relative permeability materials. All materials
+ * that derive from this class must override computeQpProperties()
+ */
+class PorousFlowRelativePermeabilityBase : public PorousFlowMaterialBase
+{
+public:
+  PorousFlowRelativePermeabilityBase(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// Name of (dummy) saturation primary variable
+  VariableName _saturation_variable_name;
+
+  /// Saturation material property
+  const MaterialProperty<std::vector<Real> > & _saturation_nodal;
+
+  /// Relative permeability material property
+  MaterialProperty<Real> & _relative_permeability;
+
+  /// Derivative of relative permeability wrt phase saturation
+  MaterialProperty<Real> & _drelative_permeability_ds;
+};
+
+#endif //POROUSFLOWRELATIVEPERMEABILITYBASE_H

--- a/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityCorey.h
+++ b/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityCorey.h
@@ -8,7 +8,7 @@
 #ifndef POROUSFLOWRELATIVEPERMEABILITYCOREY_H
 #define POROUSFLOWRELATIVEPERMEABILITYCOREY_H
 
-#include "PorousFlowRelativePermeabilityUnity.h"
+#include "PorousFlowRelativePermeabilityBase.h"
 
 class PorousFlowRelativePermeabilityCorey;
 
@@ -17,10 +17,9 @@ InputParameters validParams<PorousFlowRelativePermeabilityCorey>();
 
 /**
  * Material designed to calculate Corey-type relative permeability
- * of an arbitrary phase given the saturation and
- * Corey exponent of that phase.
+ * of an arbitrary phase given the saturation and Corey exponent of that phase
  */
-class PorousFlowRelativePermeabilityCorey : public PorousFlowRelativePermeabilityUnity
+class PorousFlowRelativePermeabilityCorey : public PorousFlowRelativePermeabilityBase
 {
 public:
   PorousFlowRelativePermeabilityCorey(const InputParameters & parameters);
@@ -28,7 +27,7 @@ public:
 protected:
   virtual void computeQpProperties();
 
-  /// Core exponent n for the phase
+  /// Corey exponent n for the specified phase
   const Real _n;
 };
 

--- a/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityUnity.h
+++ b/modules/porous_flow/include/materials/PorousFlowRelativePermeabilityUnity.h
@@ -8,9 +8,7 @@
 #ifndef POROUSFLOWRELATIVEPERMEABILITYUNITY_H
 #define POROUSFLOWRELATIVEPERMEABILITYUNITY_H
 
-#include "DerivativeMaterialInterface.h"
-#include "Material.h"
-#include "PorousFlowDictator.h"
+#include "PorousFlowRelativePermeabilityBase.h"
 
 class PorousFlowRelativePermeabilityUnity;
 
@@ -18,34 +16,15 @@ template<>
 InputParameters validParams<PorousFlowRelativePermeabilityUnity>();
 
 /**
- * Base class for relative permeability materials
  * This class simply sets relative permeability = 1 at the nodes
  */
-class PorousFlowRelativePermeabilityUnity : public DerivativeMaterialInterface<Material>
+class PorousFlowRelativePermeabilityUnity : public PorousFlowRelativePermeabilityBase
 {
 public:
   PorousFlowRelativePermeabilityUnity(const InputParameters & parameters);
 
 protected:
   virtual void computeQpProperties();
-
-  /// Phase number of fluid that this relative permeability relates to
-  const unsigned int _phase_num;
-
-  /// The PorousFlowDictator UserObject
-  const PorousFlowDictator & _dictator;
-
-  /// Name of (dummy) saturation primary variable
-  VariableName _saturation_variable_name;
-
-  /// Saturation material property
-  const MaterialProperty<std::vector<Real> > & _saturation_nodal;
-
-  /// Relative permeability material property
-  MaterialProperty<Real> & _relative_permeability;
-
-  /// Derivative of relative permeability wrt phase saturation
-  MaterialProperty<Real> & _drelative_permeability_ds;
 };
 
 #endif //POROUSFLOWRELATIVEPERMEABILITYUNITY_H

--- a/modules/porous_flow/include/materials/PorousFlowViscosityConst.h
+++ b/modules/porous_flow/include/materials/PorousFlowViscosityConst.h
@@ -16,8 +16,7 @@ template<>
 InputParameters validParams<PorousFlowViscosityConst>();
 
 /**
- * Material designed to provide the viscosity
- * which is assumed constant
+ * Material that provides a constant viscosity
  */
 class PorousFlowViscosityConst : public PorousFlowFluidPropertiesBase
 {
@@ -29,12 +28,6 @@ protected:
 
   /// constant value of viscosity
   const Real _input_viscosity;
-
-  /// the phase number
-  unsigned int _phase_num;
-
-  /// The variable names UserObject for the Porous-Flow variables
-  const PorousFlowDictator & _dictator;
 
   /// viscosity
   MaterialProperty<Real> & _viscosity;

--- a/modules/porous_flow/include/materials/PorousFlowVolumetricStrain.h
+++ b/modules/porous_flow/include/materials/PorousFlowVolumetricStrain.h
@@ -8,16 +8,13 @@
 #ifndef POROUSFLOWVOLUMETRICSTRAIN_H
 #define POROUSFLOWVOLUMETRICSTRAIN_H
 
-#include "DerivativeMaterialInterface.h"
+#include "PorousFlowMaterialVectorBase.h"
 #include "RankTwoTensor.h"
-#include "Material.h"
-
-#include "PorousFlowDictator.h"
 
 /**
  * PorousFlowVolumetricStrain computes volumetric strains, and derivatives thereof
  */
-class PorousFlowVolumetricStrain : public DerivativeMaterialInterface<Material>
+class PorousFlowVolumetricStrain : public PorousFlowMaterialVectorBase
 {
 public:
   PorousFlowVolumetricStrain(const InputParameters & parameters);
@@ -27,12 +24,6 @@ protected:
 
   /// If true then the strain rate will include terms that ensure mass is conserved when doing integrals over the displaced mesh
   const bool _consistent;
-
-  /// The dictator UserObject for the Porous-Flow simulation
-  const PorousFlowDictator & _dictator;
-
-  /// number of porous-flow variables
-  const unsigned int _num_var;
 
   /// number of displacements supplied (1 in 1D, 2 in 2D, 3 in 3D)
   const unsigned int _ndisp;

--- a/modules/porous_flow/src/materials/PorousFlowBrine.C
+++ b/modules/porous_flow/src/materials/PorousFlowBrine.C
@@ -6,7 +6,6 @@
 /**********************************************2******************/
 
 #include "PorousFlowBrine.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowBrine>()

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureBase.C
@@ -6,35 +6,27 @@
 /****************************************************************/
 
 #include "PorousFlowCapillaryPressureBase.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowCapillaryPressureBase>()
 {
-  InputParameters params = validParams<Material>();
-  params.addRequiredParam<unsigned int>("phase", "The phase number");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
+  InputParameters params = validParams<PorousFlowMaterialBase>();
   params.addClassDescription("Base class for PorousFlow capillary pressure materials");
   return params;
 }
 
 PorousFlowCapillaryPressureBase::PorousFlowCapillaryPressureBase(const InputParameters & parameters) :
-    DerivativeMaterialInterface<Material>(parameters),
-
-    _phase_num(getParam<unsigned int>("phase")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    PorousFlowMaterialBase(parameters),
     _saturation_variable_name(_dictator.saturationVariableNameDummy()),
     _saturation_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
     _saturation_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_qp")),
-    _capillary_pressure_nodal(declareProperty<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num))),
-    _dcapillary_pressure_nodal_ds(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _saturation_variable_name)),
-    _d2capillary_pressure_nodal_ds2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _saturation_variable_name, _saturation_variable_name)),
-    _capillary_pressure_qp(declareProperty<Real>("PorousFlow_capillary_pressure_qp" + Moose::stringify(_phase_num))),
-    _dcapillary_pressure_qp_ds(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_qp" + Moose::stringify(_phase_num), _saturation_variable_name)),
-    _d2capillary_pressure_qp_ds2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_qp" + Moose::stringify(_phase_num), _saturation_variable_name, _saturation_variable_name))
+    _capillary_pressure_nodal(declareProperty<Real>("PorousFlow_capillary_pressure_nodal" + _phase)),
+    _dcapillary_pressure_nodal_ds(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + _phase, _saturation_variable_name)),
+    _d2capillary_pressure_nodal_ds2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + _phase, _saturation_variable_name, _saturation_variable_name)),
+    _capillary_pressure_qp(declareProperty<Real>("PorousFlow_capillary_pressure_qp" + _phase)),
+    _dcapillary_pressure_qp_ds(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_qp" + _phase, _saturation_variable_name)),
+    _d2capillary_pressure_qp_ds2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_qp" + _phase, _saturation_variable_name, _saturation_variable_name))
 {
-  if (_phase_num >= _dictator.numPhases())
-    mooseError("PorousFlowCapillaryPressure: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGP.C
+++ b/modules/porous_flow/src/materials/PorousFlowCapillaryPressureVGP.C
@@ -6,7 +6,6 @@
 /****************************************************************/
 
 #include "PorousFlowCapillaryPressureVGP.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowCapillaryPressureVGP>()
@@ -23,8 +22,8 @@ PorousFlowCapillaryPressureVGP::PorousFlowCapillaryPressureVGP(const InputParame
     _pressure_variable_name(_dictator.pressureVariableNameDummy()),
     _porepressure_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_nodal")),
     _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
-    _dcapillary_pressure_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _d2capillary_pressure_nodal_dp2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + Moose::stringify(_phase_num), _pressure_variable_name, _pressure_variable_name)),
+    _dcapillary_pressure_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + _phase, _pressure_variable_name)),
+    _d2capillary_pressure_nodal_dp2(declarePropertyDerivative<Real>("PorousFlow_capillary_pressure_nodal" + _phase, _pressure_variable_name, _pressure_variable_name)),
     _al(getParam<Real>("al")),
     _m(getParam<Real>("m"))
 {

--- a/modules/porous_flow/src/materials/PorousFlowDensityConstBulk.C
+++ b/modules/porous_flow/src/materials/PorousFlowDensityConstBulk.C
@@ -6,7 +6,6 @@
 /****************************************************************/
 
 #include "PorousFlowDensityConstBulk.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowDensityConstBulk>()
@@ -23,11 +22,11 @@ PorousFlowDensityConstBulk::PorousFlowDensityConstBulk(const InputParameters & p
 
     _dens0(getParam<Real>("density_P0")),
     _bulk(getParam<Real>("bulk_modulus")),
-    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
-    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name))
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _pressure_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name))
 {
 }
 

--- a/modules/porous_flow/src/materials/PorousFlowEffectiveFluidPressure.C
+++ b/modules/porous_flow/src/materials/PorousFlowEffectiveFluidPressure.C
@@ -10,20 +10,13 @@
 template<>
 InputParameters validParams<PorousFlowEffectiveFluidPressure>()
 {
-  InputParameters params = validParams<Material>();
-
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
+  InputParameters params = validParams<PorousFlowMaterialVectorBase>();
   params.addClassDescription("This Material calculates an effective fluid pressure: effective_stress = total_stress + biot_coeff*effective_fluid_pressure.  The effective_fluid_pressure = sum_{phases}(S_phase * P_phase)");
   return params;
 }
 
 PorousFlowEffectiveFluidPressure::PorousFlowEffectiveFluidPressure(const InputParameters & parameters) :
-    DerivativeMaterialInterface<Material>(parameters),
-
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _num_ph(_dictator.numPhases()),
-    _num_var(_dictator.numVariables()),
-
+    PorousFlowMaterialVectorBase(parameters),
     _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
     _dporepressure_qp_dvar(getMaterialProperty<std::vector<std::vector<Real> > >("dPorousFlow_porepressure_qp_dvar")),
     _saturation_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_qp")),
@@ -46,7 +39,7 @@ PorousFlowEffectiveFluidPressure::computeQpProperties()
   _pf_nodal[_qp] = 0.0;
   _dpf_qp_dvar[_qp].assign(_num_var, 0.0);
   _dpf_nodal_dvar[_qp].assign(_num_var, 0.0);
-  for (unsigned ph = 0; ph < _num_ph; ++ph)
+  for (unsigned ph = 0; ph < _num_phases; ++ph)
   {
     _pf_qp[_qp] += _saturation_qp[_qp][ph] * _porepressure_qp[_qp][ph];
     _pf_nodal[_qp] += _saturation_nodal[_qp][ph] * _porepressure_nodal[_qp][ph];

--- a/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
@@ -6,34 +6,26 @@
 /****************************************************************/
 
 #include "PorousFlowFluidPropertiesBase.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowFluidPropertiesBase>()
 {
-  InputParameters params = validParams<Material>();
-  params.addRequiredParam<unsigned int>("phase", "The phase number");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
+  InputParameters params = validParams<PorousFlowMaterialBase>();
   params.addClassDescription("Base class for PorousFlow fluid materials");
   return params;
 }
 
 PorousFlowFluidPropertiesBase::PorousFlowFluidPropertiesBase(const InputParameters & parameters) :
-    DerivativeMaterialInterface<Material>(parameters),
-
-    _phase_num(getParam<unsigned int>("phase")),
+    PorousFlowMaterialBase(parameters),
     _porepressure_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_nodal")),
     _porepressure_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_porepressure_qp")),
     _temperature_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_temperature_nodal")),
     _temperature_qp(getMaterialProperty<std::vector<Real> >("PorousFlow_temperature_qp")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _pressure_variable_name(_dictator.pressureVariableNameDummy()),
     _temperature_variable_name(_dictator.temperatureVariableNameDummy()),
     _t_c2k(273.15),
     _R(8.3144621)
 {
-  if (_phase_num >= _dictator.numPhases())
-    mooseError("PorousFlowFluidProperties: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << " in " << _name << ".  Be aware that the Dictator does not tolerate mistakes.");
 }
 
 void
@@ -41,4 +33,3 @@ PorousFlowFluidPropertiesBase::computeQpProperties()
 {
   mooseError("computeQpProperties() must be overriden in materials derived from PorousFlowFluidPropertiesBase");
 }
-

--- a/modules/porous_flow/src/materials/PorousFlowIdealGas.C
+++ b/modules/porous_flow/src/materials/PorousFlowIdealGas.C
@@ -6,7 +6,6 @@
 /****************************************************************/
 
 #include "PorousFlowIdealGas.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowIdealGas>()
@@ -21,13 +20,13 @@ PorousFlowIdealGas::PorousFlowIdealGas(const InputParameters & parameters) :
     PorousFlowFluidPropertiesBase(parameters),
 
     _molar_mass(getParam<Real>("molar_mass")),
-    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _temperature_variable_name)),
-    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
-    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name))
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _pressure_variable_name)),
+    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _temperature_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name)),
+    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _temperature_variable_name))
 {
 }
 

--- a/modules/porous_flow/src/materials/PorousFlowJoiner.C
+++ b/modules/porous_flow/src/materials/PorousFlowJoiner.C
@@ -12,9 +12,7 @@
 template<>
 InputParameters validParams<PorousFlowJoiner>()
 {
-  InputParameters params = validParams<Material>();
-
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
+  InputParameters params = validParams<PorousFlowMaterialVectorBase>();
   params.addRequiredParam<std::string>("material_property", "The property that you want joined into a std::vector");
   params.addParam<bool>("at_qps", false, "If true then join quadpoint properties, otherwise join nodal properties");
   params.addParam<bool>("include_old", false, "Join old properties into vectors as well as the current properties");
@@ -23,15 +21,12 @@ InputParameters validParams<PorousFlowJoiner>()
 }
 
 PorousFlowJoiner::PorousFlowJoiner(const InputParameters & parameters) :
-    DerivativeMaterialInterface<Material>(parameters),
+    PorousFlowMaterialVectorBase(parameters),
 
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _pressure_variable_name(_dictator.pressureVariableNameDummy()),
     _saturation_variable_name(_dictator.saturationVariableNameDummy()),
     _temperature_variable_name(_dictator.temperatureVariableNameDummy()),
     _mass_fraction_variable_name(_dictator.massFractionVariableNameDummy()),
-    _num_phases(_dictator.numPhases()),
-    _num_var(_dictator.numVariables()),
     _pf_prop(getParam<std::string>("material_property")),
     _include_old(getParam<bool>("include_old")),
     _at_qps(getParam<bool>("at_qps")),

--- a/modules/porous_flow/src/materials/PorousFlowMaterialBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowMaterialBase.C
@@ -1,0 +1,29 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowMaterialBase.h"
+#include "Conversion.h"
+
+template<>
+InputParameters validParams<PorousFlowMaterialBase>()
+{
+  InputParameters params = validParams<Material>();
+  params.addRequiredParam<unsigned int>("phase", "The phase number");
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
+  params.addClassDescription("Base class for PorousFlow materials");
+  return params;
+}
+
+PorousFlowMaterialBase::PorousFlowMaterialBase(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _phase_num(getParam<unsigned int>("phase")),
+    _phase(Moose::stringify(_phase_num))
+{
+  if (_phase_num >= _dictator.numPhases())
+    mooseError("PorousFlowMaterial: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << " in " << _name << ".  Be aware that the Dictator does not tolerate mistakes.");
+}

--- a/modules/porous_flow/src/materials/PorousFlowMaterialVectorBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowMaterialVectorBase.C
@@ -1,0 +1,26 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowMaterialVectorBase.h"
+
+template<>
+InputParameters validParams<PorousFlowMaterialVectorBase>()
+{
+  InputParameters params = validParams<Material>();
+  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
+  params.addClassDescription("Base class for PorousFlow materials that combine phase-dependent properties into vectors expected by the kernels");
+  return params;
+}
+
+PorousFlowMaterialVectorBase::PorousFlowMaterialVectorBase(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Material>(parameters),
+    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _num_phases(_dictator.numPhases()),
+    _num_components(_dictator.numComponents()),
+    _num_var(_dictator.numVariables())
+{
+}

--- a/modules/porous_flow/src/materials/PorousFlowMethane.C
+++ b/modules/porous_flow/src/materials/PorousFlowMethane.C
@@ -6,7 +6,6 @@
 /****************************************************************/
 
 #include "PorousFlowMethane.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowMethane>()
@@ -19,15 +18,15 @@ InputParameters validParams<PorousFlowMethane>()
 PorousFlowMethane::PorousFlowMethane(const InputParameters & parameters) :
     PorousFlowFluidPropertiesBase(parameters),
 
-    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _temperature_variable_name)),
-    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
-    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name)),
-    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num))),
-    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _pressure_variable_name)),
+    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _temperature_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name)),
+    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _temperature_variable_name)),
+    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + _phase)),
+    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + _phase, _temperature_variable_name)),
     _Mch4(16.0425e-3)
 {
 }

--- a/modules/porous_flow/src/materials/PorousFlowPermeabilityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowPermeabilityConst.C
@@ -10,20 +10,15 @@
 template<>
 InputParameters validParams<PorousFlowPermeabilityConst>()
 {
-  InputParameters params = validParams<Material>();
-
+  InputParameters params = validParams<PorousFlowMaterialVectorBase>();
   params.addRequiredParam<RealTensorValue>("permeability", "The permeability tensor (usually in m^2), which is assumed constant for this material");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("This Material calculates the permeability tensor assuming it is constant");
   return params;
 }
 
 PorousFlowPermeabilityConst::PorousFlowPermeabilityConst(const InputParameters & parameters) :
-    DerivativeMaterialInterface<Material>(parameters),
-
+    PorousFlowMaterialVectorBase(parameters),
     _input_permeability(getParam<RealTensorValue>("permeability")),
-    _PorousFlow_name_UO(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-
     _permeability(declareProperty<RealTensorValue>("PorousFlow_permeability")),
     _dpermeability_dvar(declareProperty<std::vector<RealTensorValue> >("dPorousFlow_permeability_dvar"))
 {
@@ -39,8 +34,5 @@ void
 PorousFlowPermeabilityConst::computeQpProperties()
 {
   _permeability[_qp] = _input_permeability;
-
-  const unsigned int num_var = _PorousFlow_name_UO.numVariables();
-  _dpermeability_dvar[_qp].resize(num_var, RealTensorValue());
+  _dpermeability_dvar[_qp].resize(_num_var, RealTensorValue());
 }
-

--- a/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
@@ -7,8 +7,6 @@
 
 #include "PorousFlowPorosityConst.h"
 
-#include "Conversion.h"
-
 template<>
 InputParameters validParams<PorousFlowPorosityConst>()
 {
@@ -30,11 +28,10 @@ PorousFlowPorosityConst::initQpStatefulProperties()
   _porosity_nodal[_qp] = _input_porosity; // this becomes _porosity_old[_qp] in the first call to computeQpProperties
   _porosity_qp[_qp] = _input_porosity; // this becomes _porosity_old[_qp] in the first call to computeQpProperties
 
-  const unsigned int num_var = _dictator.numVariables();
-  _dporosity_nodal_dvar[_qp].assign(num_var, 0.0);
-  _dporosity_qp_dvar[_qp].assign(num_var, 0.0);
-  _dporosity_nodal_dgradvar[_qp].assign(num_var, RealGradient());
-  _dporosity_qp_dgradvar[_qp].assign(num_var, RealGradient());
+  _dporosity_nodal_dvar[_qp].assign(_num_var, 0.0);
+  _dporosity_qp_dvar[_qp].assign(_num_var, 0.0);
+  _dporosity_nodal_dgradvar[_qp].assign(_num_var, RealGradient());
+  _dporosity_qp_dgradvar[_qp].assign(_num_var, RealGradient());
 }
 
 void
@@ -43,4 +40,3 @@ PorousFlowPorosityConst::computeQpProperties()
   _porosity_nodal[_qp] = _input_porosity;
   _porosity_qp[_qp] = _input_porosity;
 }
-

--- a/modules/porous_flow/src/materials/PorousFlowPorosityHM.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityHM.C
@@ -13,7 +13,6 @@ template<>
 InputParameters validParams<PorousFlowPorosityHM>()
 {
   InputParameters params = validParams<PorousFlowPorosityUnity>();
-
   params.addRequiredParam<Real>("porosity_zero", "The porosity at zero volumetric strain and zero effective porepressure");
   params.addRangeCheckedParam<Real>("biot_coefficient", 1, "biot_coefficient>=0&biot_coefficient<=1", "Biot coefficient");
   params.addRequiredRangeCheckedParam<Real>("solid_bulk", "solid_bulk>0", "Bulk modulus of the drained porous solid skeleton");
@@ -28,7 +27,6 @@ PorousFlowPorosityHM::PorousFlowPorosityHM(const InputParameters & parameters) :
     _phi0(getParam<Real>("porosity_zero")),
     _biot(getParam<Real>("biot_coefficient")),
     _solid_bulk(getParam<Real>("solid_bulk")),
-    _num_var(_dictator.numVariables()),
     _coeff((_biot - 1.0)/_solid_bulk),
 
     _ndisp(coupledComponents("displacements")),
@@ -81,4 +79,3 @@ PorousFlowPorosityHM::computeQpProperties()
     _dporosity_nodal_dgradvar[_qp][v] = -(_porosity_nodal[_qp] - _biot) * _dvol_strain_qp_dvar[_qp][v];
   }
 }
-

--- a/modules/porous_flow/src/materials/PorousFlowPorosityUnity.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityUnity.C
@@ -7,22 +7,16 @@
 
 #include "PorousFlowPorosityUnity.h"
 
-#include "Conversion.h"
-
 template<>
 InputParameters validParams<PorousFlowPorosityUnity>()
 {
-  InputParameters params = validParams<Material>();
-
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
+  InputParameters params = validParams<PorousFlowMaterialVectorBase>();
   params.addClassDescription("This Material calculates the porosity assuming it is equal to 1.0");
   return params;
 }
 
 PorousFlowPorosityUnity::PorousFlowPorosityUnity(const InputParameters & parameters) :
-    DerivativeMaterialInterface<Material>(parameters),
-
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    PorousFlowMaterialVectorBase(parameters),
     _porosity_nodal(declareProperty<Real>("PorousFlow_porosity_nodal")),
     _porosity_nodal_old(declarePropertyOld<Real>("PorousFlow_porosity_nodal")),
     _dporosity_nodal_dvar(declareProperty<std::vector<Real> >("dPorousFlow_porosity_nodal_dvar")),
@@ -40,11 +34,10 @@ PorousFlowPorosityUnity::initQpStatefulProperties()
   _porosity_nodal[_qp] = 1.0;
   _porosity_qp[_qp] = 1.0;
 
-  const unsigned int num_var = _dictator.numVariables();
-  _dporosity_nodal_dvar[_qp].assign(num_var, 0.0);
-  _dporosity_qp_dvar[_qp].assign(num_var, 0.0);
-  _dporosity_nodal_dgradvar[_qp].assign(num_var, RealGradient());
-  _dporosity_qp_dgradvar[_qp].assign(num_var, RealGradient());
+  _dporosity_nodal_dvar[_qp].assign(_num_var, 0.0);
+  _dporosity_qp_dvar[_qp].assign(_num_var, 0.0);
+  _dporosity_nodal_dgradvar[_qp].assign(_num_var, RealGradient());
+  _dporosity_qp_dgradvar[_qp].assign(_num_var, RealGradient());
 }
 
 void
@@ -53,4 +46,3 @@ PorousFlowPorosityUnity::computeQpProperties()
   _porosity_nodal[_qp] = 1.0;
   _porosity_qp[_qp] = 1.0;
 }
-

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityBase.C
@@ -1,0 +1,31 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowRelativePermeabilityBase.h"
+
+template<>
+InputParameters validParams<PorousFlowRelativePermeabilityBase>()
+{
+  InputParameters params = validParams<PorousFlowMaterialBase>();
+  params.addClassDescription("Base class for PorousFlow relative permeability materials");
+  return params;
+}
+
+PorousFlowRelativePermeabilityBase::PorousFlowRelativePermeabilityBase(const InputParameters & parameters) :
+    PorousFlowMaterialBase(parameters),
+    _saturation_variable_name(_dictator.saturationVariableNameDummy()),
+    _saturation_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
+    _relative_permeability(declareProperty<Real>("PorousFlow_relative_permeability" + _phase)),
+    _drelative_permeability_ds(declarePropertyDerivative<Real>("PorousFlow_relative_permeability" + _phase, _saturation_variable_name))
+{
+}
+
+void
+PorousFlowRelativePermeabilityBase::computeQpProperties()
+{
+  mooseError("computeQpProperties() must be overriden in materials derived from PorousFlowRelativePermeabilityBase");
+}

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityCorey.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityCorey.C
@@ -12,17 +12,14 @@
 template<>
 InputParameters validParams<PorousFlowRelativePermeabilityCorey>()
 {
-  InputParameters params = validParams<PorousFlowRelativePermeabilityUnity>();
-
+  InputParameters params = validParams<PorousFlowRelativePermeabilityBase>();
   params.addRequiredParam<Real>("n_j", "The Corey exponent of phase j.");
-  params.addRequiredParam<unsigned int>("phase", "The phase number j");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("This Material calculates relative permeability of either phase Sj, using the simple Corey model (Sj-Sjr)^n/(1-S1r-S2r)");
   return params;
 }
 
 PorousFlowRelativePermeabilityCorey::PorousFlowRelativePermeabilityCorey(const InputParameters & parameters) :
-    PorousFlowRelativePermeabilityUnity(parameters),
+    PorousFlowRelativePermeabilityBase(parameters),
     _n(getParam<Real>("n_j"))
 {
 }

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityUnity.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityUnity.C
@@ -6,30 +6,18 @@
 /****************************************************************/
 
 #include "PorousFlowRelativePermeabilityUnity.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowRelativePermeabilityUnity>()
 {
-  InputParameters params = validParams<Material>();
-  params.addRequiredParam<unsigned int>("phase", "The phase number for which to calculate the relative permeability for");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
-  params.addClassDescription("Base class for PorousFlow relative permeability materials.  This class sets the relative permeability = 1");
+  InputParameters params = validParams<PorousFlowRelativePermeabilityBase>();
+  params.addClassDescription("This class sets the relative permeability = 1");
   return params;
 }
 
 PorousFlowRelativePermeabilityUnity::PorousFlowRelativePermeabilityUnity(const InputParameters & parameters) :
-    DerivativeMaterialInterface<Material>(parameters),
-
-    _phase_num(getParam<unsigned int>("phase")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _saturation_variable_name(_dictator.saturationVariableNameDummy()),
-    _saturation_nodal(getMaterialProperty<std::vector<Real> >("PorousFlow_saturation_nodal")),
-    _relative_permeability(declareProperty<Real>("PorousFlow_relative_permeability" + Moose::stringify(_phase_num))),
-    _drelative_permeability_ds(declarePropertyDerivative<Real>("PorousFlow_relative_permeability" + Moose::stringify(_phase_num), _saturation_variable_name))
+    PorousFlowRelativePermeabilityBase(parameters)
 {
-  if (_phase_num >= _dictator.numPhases())
-    mooseError("PorousFlowRelativePermeability: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowSimpleCO2.C
+++ b/modules/porous_flow/src/materials/PorousFlowSimpleCO2.C
@@ -6,7 +6,6 @@
 /****************************************************************/
 
 #include "PorousFlowSimpleCO2.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowSimpleCO2>()
@@ -19,15 +18,15 @@ InputParameters validParams<PorousFlowSimpleCO2>()
 PorousFlowSimpleCO2::PorousFlowSimpleCO2(const InputParameters & parameters) :
     PorousFlowFluidPropertiesBase(parameters),
 
-    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _temperature_variable_name)),
-    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
-    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name)),
-    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num))),
-    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _pressure_variable_name)),
+    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _temperature_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name)),
+    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _temperature_variable_name)),
+    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + _phase)),
+    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + _phase, _temperature_variable_name)),
     _Mco2(44.0e-3),
     _critical_pressure(7.3773e6),
     _critical_temperature(30.9782)

--- a/modules/porous_flow/src/materials/PorousFlowViscosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowViscosityConst.C
@@ -7,8 +7,6 @@
 
 #include "PorousFlowViscosityConst.h"
 
-#include "Conversion.h"
-
 template<>
 InputParameters validParams<PorousFlowViscosityConst>()
 {
@@ -20,12 +18,9 @@ InputParameters validParams<PorousFlowViscosityConst>()
 
 PorousFlowViscosityConst::PorousFlowViscosityConst(const InputParameters & parameters) :
     PorousFlowFluidPropertiesBase(parameters),
-
     _input_viscosity(getParam<Real>("viscosity")),
     _viscosity(declareProperty<Real>("PorousFlow_viscosity" + _phase))
 {
-  if (_phase_num >= _dictator.numPhases())
-    mooseError("PorousFlowViscosityConst: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowViscosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowViscosityConst.C
@@ -13,10 +13,7 @@ template<>
 InputParameters validParams<PorousFlowViscosityConst>()
 {
   InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
-
   params.addRequiredParam<Real>("viscosity", "The viscosity, which is assumed constant for this material");
-  params.addRequiredParam<unsigned int>("phase", "The phase number");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("This Material calculates the viscosity assuming it is constant");
   return params;
 }
@@ -25,10 +22,7 @@ PorousFlowViscosityConst::PorousFlowViscosityConst(const InputParameters & param
     PorousFlowFluidPropertiesBase(parameters),
 
     _input_viscosity(getParam<Real>("viscosity")),
-    _phase_num(getParam<unsigned int>("phase")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-
-    _viscosity(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num)))
+    _viscosity(declareProperty<Real>("PorousFlow_viscosity" + _phase))
 {
   if (_phase_num >= _dictator.numPhases())
     mooseError("PorousFlowViscosityConst: The Dictator proclaims that the number of fluid phases is " << _dictator.numPhases() << " while you have foolishly entered phase = " << _phase_num << ".  Be aware that the Dictator does not tolerate mistakes.");

--- a/modules/porous_flow/src/materials/PorousFlowVolumetricStrain.C
+++ b/modules/porous_flow/src/materials/PorousFlowVolumetricStrain.C
@@ -14,9 +14,8 @@
 template<>
 InputParameters validParams<PorousFlowVolumetricStrain>()
 {
-  InputParameters params = validParams<Material>();
+  InputParameters params = validParams<PorousFlowMaterialVectorBase>();
   params.addRequiredCoupledVar("displacements", "The displacements appropriate for the simulation geometry and coordinate system");
-  params.addRequiredParam<UserObjectName>("PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addParam<bool>("consistent_with_displaced_mesh", true, "The volumetric strain rate will include terms that ensure fluid mass conservation in the displaced mesh");
   params.addClassDescription("Compute volumetric strain and the volumetric_strain rate, for use in PorousFlow.");
   params.set<bool>("stateful_displacements") = true;
@@ -24,11 +23,8 @@ InputParameters validParams<PorousFlowVolumetricStrain>()
 }
 
 PorousFlowVolumetricStrain::PorousFlowVolumetricStrain(const InputParameters & parameters) :
-    DerivativeMaterialInterface<Material>(parameters),
-
+    PorousFlowMaterialVectorBase(parameters),
     _consistent(getParam<bool>("consistent_with_displaced_mesh")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _num_var(_dictator.numVariables()),
     _ndisp(coupledComponents("displacements")),
     _disp(3),
     _disp_var_num(3),

--- a/modules/porous_flow/src/materials/PorousFlowWater.C
+++ b/modules/porous_flow/src/materials/PorousFlowWater.C
@@ -6,7 +6,6 @@
 /****************************************************************/
 
 #include "PorousFlowWater.h"
-#include "Conversion.h"
 
 template<>
 InputParameters validParams<PorousFlowWater>()
@@ -19,15 +18,15 @@ InputParameters validParams<PorousFlowWater>()
 PorousFlowWater::PorousFlowWater(const InputParameters & parameters) :
     PorousFlowFluidPropertiesBase(parameters),
 
-    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num))),
-    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + Moose::stringify(_phase_num), _temperature_variable_name)),
-    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num))),
-    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _pressure_variable_name)),
-    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name)),
-    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num))),
-    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + Moose::stringify(_phase_num), _temperature_variable_name)),
+    _density_nodal(declareProperty<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _density_nodal_old(declarePropertyOld<Real>("PorousFlow_fluid_phase_density" + _phase)),
+    _ddensity_nodal_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _pressure_variable_name)),
+    _ddensity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density" + _phase, _temperature_variable_name)),
+    _density_qp(declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
+    _ddensity_qp_dp(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name)),
+    _ddensity_qp_dt(declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _temperature_variable_name)),
+    _viscosity_nodal(declareProperty<Real>("PorousFlow_viscosity" + _phase)),
+    _dviscosity_nodal_dt(declarePropertyDerivative<Real>("PorousFlow_viscosity" + _phase, _temperature_variable_name)),
     _Mh2o(18.015e-3),
     _p_critical(22.064e6),
     _t_critical(647.096),


### PR DESCRIPTION
Refs #6938

Adds base classes for level 2 and level 3 materials, removing a lot of code duplication following suggestions from @dschwen and @WilkAndy
