### PR TITLE
Add a #error directive for compilers that don't support C++11.

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -28,6 +28,15 @@ using namespace libMesh;
 class ActionFactory;
 class Factory;
 
+
+/**
+ * MOOSE now contains C++11 code, so give a reasonable error message
+ * stating the minimum required compiler versions.
+ */
+#ifndef LIBMESH_HAVE_CXX11
+#error MOOSE requires a C++11 compatible compiler (GCC >= 4.8.4, Clang >= 3.4.0, Intel >= 20130607). Please update your compiler and try again.
+#endif
+
 /**
  * Testing a condition on a local CPU that need to be propagated across all processes.
  *

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -650,11 +650,6 @@ private:
   friend class FEProblem;
   friend class Restartable;
   friend class SubProblem;
-
-  /// Helper functions used for C++11 compatibility stuff.  These will
-  /// eventually go away...
-  void printYesNo(std::stringstream & oss, const std::string & feature, bool defined);
-  bool setBool(const std::string & value);
 };
 
 template <typename T>


### PR DESCRIPTION
This way you get a human-understandable error message rather than a cryptic syntax error message.

Also remove the previous C++11 warning that we had -- if your compiler doesn't support C++11, you will no longer be able to see this warning anyway!

Refs #6887.
