### PR TITLE
Rename SerialMesh, ParallelMesh

### DIFF
--- a/examples/ex14_pps/ex14_compare_solutions_1.i
+++ b/examples/ex14_pps/ex14_compare_solutions_1.i
@@ -8,7 +8,7 @@
   ymin = 0.0
   ymax = 1.0
 
-  distribution = serial # This uses SolutionUserObject which doesn't work with ParallelMesh.
+  distribution = serial # This uses SolutionUserObject which doesn't work with DistributedMesh.
 []
 
 [Variables]

--- a/examples/ex14_pps/ex14_compare_solutions_1.i
+++ b/examples/ex14_pps/ex14_compare_solutions_1.i
@@ -8,7 +8,7 @@
   ymin = 0.0
   ymax = 1.0
 
-  distribution = serial # This uses SolutionUserObject which doesn't work with DistributedMesh.
+  parallel_type = replicated # This uses SolutionUserObject which doesn't work with DistributedMesh.
 []
 
 [Variables]

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -265,10 +265,20 @@ public:
   virtual void executeExecutioner();
 
   /**
-   * Returns true if the user specified --parallel-mesh on the command line and false
-   * otherwise.
+   * Returns true if the user specified --distributed-mesh (or
+   * --parallel-mesh, for backwards compatibility) on the command line
+   * and false otherwise.
    */
-  bool getParallelMeshOnCommandLine() const { return _parallel_mesh_on_command_line; }
+  bool getDistributedMeshOnCommandLine() const { return _distributed_mesh_on_command_line; }
+
+  /**
+   * Deprecated.  Call getDistributedMeshOnCommandLine() instead.
+   */
+  bool getParallelMeshOnCommandLine() const
+  {
+    mooseDeprecated("getParallelMeshOnCommandLine() is deprecated, call getDistributedMeshOnCommandLine() instead.");
+    return getDistributedMeshOnCommandLine();
+  }
 
   /**
    * Whether or not this is a "recover" calculation.
@@ -570,8 +580,8 @@ public:
   /// This variable indicates when a request has been made to restart from an Exodus file
   bool _initial_from_file;
 
-  /// This variable indicates that ParallelMesh should be used for the libMesh mesh underlying MooseMesh.
-  bool _parallel_mesh_on_command_line;
+  /// This variable indicates that DistributedMesh should be used for the libMesh mesh underlying MooseMesh.
+  bool _distributed_mesh_on_command_line;
 
   /// Whether or not this is a recovery run
   bool _recover;

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -687,16 +687,22 @@ public:
 
   /**
    * Generate a unified error message if the underlying libMesh mesh
-   * is a ParallelMesh.  Clients of MooseMesh can use this function to
-   * throw an error if they know they don't work with ParallelMesh.
+   * is a DistributedMesh.  Clients of MooseMesh can use this function to
+   * throw an error if they know they don't work with DistributedMesh.
    * See, for example, the NodalVariableValue class.
+   */
+  void errorIfDistributedMesh(std::string name) const;
+
+  /**
+   * Deprecated.  Just calls errorIfDistributedMesh().
    */
   void errorIfParallelDistribution(std::string name) const;
 
   /**
    * Returns the final Mesh distribution type.
    */
-  bool isParallelMesh() const { return _use_parallel_mesh; }
+  bool isDistributedMesh() const { return _use_distributed_mesh; }
+  bool isParallelMesh() const { mooseDeprecated("isParallelMesh() is deprecated, call isDistributedMesh() instead."); return isDistributedMesh(); }
 
   /**
    * Tell the user if the distribution was overriden for any reason
@@ -754,17 +760,17 @@ public:
 
 protected:
   /// Can be set to PARALLEL, SERIAL, or DEFAULT.  Determines whether
-  /// the underlying libMesh mesh is a ReplicatedMesh or ParallelMesh.
+  /// the underlying libMesh mesh is a ReplicatedMesh or DistributedMesh.
   MooseEnum _mesh_distribution_type;
 
   /// False by default.  Final value is determined by several factors
   /// including the 'distribution' setting in the input file, and whether
   /// or not the Mesh file is a Nemesis file.
-  bool _use_parallel_mesh;
+  bool _use_distributed_mesh;
   bool _distribution_overridden;
 
   /// Pointer to underlying libMesh mesh object
-  libMesh::MeshBase* _mesh;
+  libMesh::MeshBase * _mesh;
 
   /// The partitioner used on this mesh
   MooseEnum _partitioner_name;

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -754,7 +754,7 @@ public:
 
 protected:
   /// Can be set to PARALLEL, SERIAL, or DEFAULT.  Determines whether
-  /// the underlying libMesh mesh is a SerialMesh or ParallelMesh.
+  /// the underlying libMesh mesh is a ReplicatedMesh or ParallelMesh.
   MooseEnum _mesh_distribution_type;
 
   /// False by default.  Final value is determined by several factors

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -707,7 +707,13 @@ public:
   /**
    * Tell the user if the distribution was overriden for any reason
    */
-  bool isDistributionForced() const { return _distribution_overridden; }
+  bool isDistributionForced() const
+  {
+    mooseDeprecated("isDistributionForced() is deprecated, call isParallelTypeFoced() instead.");
+    return isParallelTypeForced();
+  }
+
+  bool isParallelTypeForced() const { return _parallel_type_overridden; }
 
   /*
    * Set/Get the partitioner name
@@ -763,11 +769,16 @@ protected:
   /// the underlying libMesh mesh is a ReplicatedMesh or DistributedMesh.
   MooseEnum _mesh_distribution_type;
 
+  /// Can be set to DISTRIBUTED, REPLICATED, or DEFAULT.  Determines whether
+  /// the underlying libMesh mesh is a ReplicatedMesh or DistributedMesh.
+  MooseEnum _mesh_parallel_type;
+
   /// False by default.  Final value is determined by several factors
   /// including the 'distribution' setting in the input file, and whether
   /// or not the Mesh file is a Nemesis file.
   bool _use_distributed_mesh;
   bool _distribution_overridden;
+  bool _parallel_type_overridden;
 
   /// Pointer to underlying libMesh mesh object
   libMesh::MeshBase * _mesh;

--- a/framework/include/mesh/PatternedMesh.h
+++ b/framework/include/mesh/PatternedMesh.h
@@ -53,10 +53,10 @@ protected:
   const std::vector<std::vector<unsigned int> > & _pattern;
 
   // Holds the pointers to the meshes
-  std::vector<SerialMesh *> _meshes;
+  std::vector<ReplicatedMesh *> _meshes;
 
   // Holds a mesh for each row, these will be stitched together in the end
-  std::vector<SerialMesh *> _row_meshes;
+  std::vector<ReplicatedMesh *> _row_meshes;
 
   const Real _x_width;
   const Real _y_width;

--- a/framework/src/actions/AddPeriodicBCAction.C
+++ b/framework/src/actions/AddPeriodicBCAction.C
@@ -71,7 +71,7 @@ AddPeriodicBCAction::autoTranslationBoundaries()
   if (isParamValid("auto_direction"))
   {
     // If we are working with a parallel mesh then we're going to ghost all the boundaries everywhere because we don't know what we need...
-    if (_mesh->isParallelMesh())
+    if (_mesh->isDistributedMesh())
     {
       const std::set<BoundaryID> & ids = _mesh->meshBoundaryIds();
       for (std::set<BoundaryID>::const_iterator id_it = ids.begin();

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -83,7 +83,8 @@ InputParameters validParams<MooseApp>()
   params.addCommandLineParam<bool>("error_deprecated", "--error-deprecated", false, "Turn deprecated code messages into Errors");
   params.addCommandLineParam<bool>("allow_deprecated", "--allow-deprecated", false, "Can be used in conjunction with --error to turn off deprecated errors");
 
-  params.addCommandLineParam<bool>("parallel_mesh", "--parallel-mesh", false, "The libMesh Mesh underlying MooseMesh should always be a ParallelMesh");
+  params.addCommandLineParam<bool>("parallel_mesh", "--parallel-mesh", false, "This command line option is deprecated, use --distributed-mesh instead.");
+  params.addCommandLineParam<bool>("distributed_mesh", "--distributed-mesh", false, "The libMesh Mesh underlying MooseMesh should always be a DistributedMesh");
 
   params.addCommandLineParam<unsigned int>("refinements", "-r <n>", 0, "Specify additional initial uniform refinements for automatic scaling");
 
@@ -140,7 +141,7 @@ MooseApp::MooseApp(InputParameters parameters) :
     _error_overridden(false),
     _ready_to_exit(false),
     _initial_from_file(false),
-    _parallel_mesh_on_command_line(false),
+    _distributed_mesh_on_command_line(false),
     _recover(false),
     _restart(false),
     _half_transient(false),
@@ -197,7 +198,14 @@ MooseApp::setupOptions()
   if (getParam<bool>("error_override"))
     setErrorOverridden();
 
-  _parallel_mesh_on_command_line = getParam<bool>("parallel_mesh");
+  // Warn if user passed the old command line arg, but still accept it.
+  if (getParam<bool>("parallel_mesh"))
+  {
+    mooseWarning("The --parallel-mesh command line option is deprecated, use --distributed-mesh instead.");
+    _distributed_mesh_on_command_line = getParam<bool>("parallel_mesh");
+  }
+
+  _distributed_mesh_on_command_line = getParam<bool>("distributed_mesh");
   _half_transient = getParam<bool>("half_transient");
   _pars.set<bool>("timing") = getParam<bool>("timing");
 

--- a/framework/src/indicators/LaplacianJumpIndicator.C
+++ b/framework/src/indicators/LaplacianJumpIndicator.C
@@ -28,7 +28,7 @@ LaplacianJumpIndicator::LaplacianJumpIndicator(const InputParameters & parameter
     _second_u(second()),
     _second_u_neighbor(neighborSecond())
 {
-  _mesh.errorIfParallelDistribution("LaplacianJumpIndicator");
+  _mesh.errorIfDistributedMesh("LaplacianJumpIndicator");
 }
 
 

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -66,8 +66,8 @@ FileMesh::buildMesh()
   Moose::perf_log.push("Read Mesh", "Setup");
   if (_is_nemesis)
   {
-    // Nemesis_IO only takes a reference to ParallelMesh, so we can't be quite so short here.
-    ParallelMesh& pmesh = cast_ref<ParallelMesh&>(getMesh());
+    // Nemesis_IO only takes a reference to DistributedMesh, so we can't be quite so short here.
+    DistributedMesh & pmesh = cast_ref<DistributedMesh &>(getMesh());
     Nemesis_IO(pmesh).read(_file_name);
 
     getMesh().allow_renumbering(false);
@@ -106,7 +106,7 @@ FileMesh::buildMesh()
 void
 FileMesh::read(const std::string & file_name)
 {
-  if (dynamic_cast<ParallelMesh *>(&getMesh()) && !_is_nemesis)
+  if (dynamic_cast<DistributedMesh *>(&getMesh()) && !_is_nemesis)
     getMesh().read(file_name, /*mesh_data=*/NULL, /*skip_renumber=*/false);
   else
     getMesh().read(file_name, /*mesh_data=*/NULL, /*skip_renumber=*/true);

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -61,8 +61,8 @@ InputParameters validParams<MooseMesh>()
   MooseEnum mesh_distribution_type("PARALLEL=0 SERIAL DEFAULT", "DEFAULT");
   params.addParam<MooseEnum>("distribution", mesh_distribution_type,
                              "PARALLEL: Always use libMesh::ParallelMesh "
-                             "SERIAL: Always use libMesh::SerialMesh "
-                             "DEFAULT: Use libMesh::SerialMesh unless --parallel-mesh is specified on the command line");
+                             "SERIAL: Always use libMesh::ReplicatedMesh "
+                             "DEFAULT: Use libMesh::ReplicatedMesh unless --parallel-mesh is specified on the command line");
 
   params.addParam<bool>("nemesis", false,
                         "If nemesis=true and file=foo.e, actually reads "
@@ -140,7 +140,7 @@ MooseMesh::MooseMesh(const InputParameters & parameters) :
   case 2: // DEFAULT
     // The user did not specify 'distribution = XYZ' in the input file,
     // so we allow the --parallel-mesh command line arg to possibly turn
-    // on ParallelMesh.  If the command line arg is not present, we pick SerialMesh.
+    // on ParallelMesh.  If the command line arg is not present, we pick ReplicatedMesh.
     if (_app.getParallelMeshOnCommandLine())
       _use_parallel_mesh = true;
 
@@ -165,7 +165,7 @@ MooseMesh::MooseMesh(const InputParameters & parameters) :
     }
   }
   else
-    _mesh = new SerialMesh(_communicator, dim);
+    _mesh = new ReplicatedMesh(_communicator, dim);
 }
 
 MooseMesh::MooseMesh(const MooseMesh & other_mesh) :
@@ -1570,7 +1570,7 @@ MooseMesh::findAdaptivityQpMaps(const Elem * template_elem,
                                 int child,
                                 int child_side)
 {
-  SerialMesh mesh(_communicator);
+  ReplicatedMesh mesh(_communicator);
   mesh.skip_partitioning(true);
 
   unsigned int dim = template_elem->dim();

--- a/framework/src/mesh/PatternedMesh.C
+++ b/framework/src/mesh/PatternedMesh.C
@@ -55,7 +55,7 @@ PatternedMesh::PatternedMesh(const InputParameters & parameters) :
     _z_width(getParam<Real>("z_width"))
 {
   // The PatternedMesh class only works with ReplicatedMesh
-  errorIfParallelDistribution("PatternedMesh");
+  errorIfDistributedMesh("PatternedMesh");
 
   _meshes.resize(_files.size());
 

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -60,7 +60,7 @@ TiledMesh::TiledMesh(const InputParameters & parameters) :
     _z_width(getParam<Real>("z_width"))
 {
   // The TiledMesh class only works with ReplicatedMesh
-  errorIfParallelDistribution("TiledMesh");
+  errorIfDistributedMesh("TiledMesh");
 }
 
 TiledMesh::TiledMesh(const TiledMesh & other_mesh) :

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -59,7 +59,7 @@ TiledMesh::TiledMesh(const InputParameters & parameters) :
     _y_width(getParam<Real>("y_width")),
     _z_width(getParam<Real>("z_width"))
 {
-  // The TiledMesh class only works with SerialMesh
+  // The TiledMesh class only works with ReplicatedMesh
   errorIfParallelDistribution("TiledMesh");
 }
 
@@ -80,12 +80,12 @@ TiledMesh::clone() const
 void
 TiledMesh::buildMesh()
 {
-  // stitch_meshes() is only implemented for SerialMesh.  So make sure
+  // stitch_meshes() is only implemented for ReplicatedMesh.  So make sure
   // we have one here before continuing.
-  SerialMesh* serial_mesh = dynamic_cast<SerialMesh*>( &getMesh() );
+  ReplicatedMesh * serial_mesh = dynamic_cast<ReplicatedMesh *>( &getMesh() );
 
   if (!serial_mesh)
-    mooseError("Error, TiledMesh calls stitch_meshes() which only works on SerialMesh.");
+    mooseError("Error, TiledMesh calls stitch_meshes() which only works on ReplicatedMesh.");
   else
   {
     std::string mesh_file(getParam<MeshFileName>("file"));
@@ -114,7 +114,7 @@ TiledMesh::buildMesh()
       for (unsigned int i = 1; i < getParam<unsigned int>("x_tiles"); ++i)
       {
         MeshTools::Modification::translate(*clone, _x_width, 0, 0);
-        serial_mesh->stitch_meshes(dynamic_cast<SerialMesh &>(*clone), right, left, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
+        serial_mesh->stitch_meshes(dynamic_cast<ReplicatedMesh &>(*clone), right, left, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
       }
     }
     {
@@ -124,7 +124,7 @@ TiledMesh::buildMesh()
       for (unsigned int i = 1; i < getParam<unsigned int>("y_tiles"); ++i)
       {
         MeshTools::Modification::translate(*clone, 0, _y_width, 0);
-        serial_mesh->stitch_meshes(dynamic_cast<SerialMesh &>(*clone), top, bottom, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
+        serial_mesh->stitch_meshes(dynamic_cast<ReplicatedMesh &>(*clone), top, bottom, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
       }
     }
     {
@@ -134,7 +134,7 @@ TiledMesh::buildMesh()
       for (unsigned int i = 1; i < getParam<unsigned int>("z_tiles"); ++i)
       {
         MeshTools::Modification::translate(*clone, 0, 0, _z_width);
-        serial_mesh->stitch_meshes(dynamic_cast<SerialMesh &>(*clone), front, back, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
+        serial_mesh->stitch_meshes(dynamic_cast<ReplicatedMesh &>(*clone), front, back, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
       }
     }
   }

--- a/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
+++ b/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
@@ -49,7 +49,7 @@ AddAllSideSetsByNormals::modify()
     mooseError("_mesh_ptr must be initialized before calling AddAllSideSetsByNormals::modify()!");
 
   // We can't call this in the constructor, it appears that _mesh_ptr is always NULL there.
-  _mesh_ptr->errorIfParallelDistribution("AddAllSideSetsByNormals");
+  _mesh_ptr->errorIfDistributedMesh("AddAllSideSetsByNormals");
 
   // Get the current list of boundaries so we can generate new ones that won't conflict
   _mesh_boundary_ids = _mesh_ptr->meshBoundaryIds();

--- a/framework/src/meshmodifiers/MeshExtruder.C
+++ b/framework/src/meshmodifiers/MeshExtruder.C
@@ -74,7 +74,7 @@ MeshExtruder::modify()
                                          _num_layers);
 
   // The first argument to build_extrusion() is required to be UnstructuredMesh&, a common
-  // base class of both SerialMesh and ParallelMesh, hence the dynamic_cast...
+  // base class of both ReplicatedMesh and ParallelMesh, hence the dynamic_cast...
   MeshTools::Generation::build_extrusion(dynamic_cast<libMesh::UnstructuredMesh&>(_mesh_ptr->getMesh()),
                                          source_mesh->getMesh(),
                                          _num_layers,

--- a/framework/src/meshmodifiers/MeshExtruder.C
+++ b/framework/src/meshmodifiers/MeshExtruder.C
@@ -74,7 +74,7 @@ MeshExtruder::modify()
                                          _num_layers);
 
   // The first argument to build_extrusion() is required to be UnstructuredMesh&, a common
-  // base class of both ReplicatedMesh and ParallelMesh, hence the dynamic_cast...
+  // base class of both ReplicatedMesh and DistributedMesh, hence the dynamic_cast...
   MeshTools::Generation::build_extrusion(dynamic_cast<libMesh::UnstructuredMesh&>(_mesh_ptr->getMesh()),
                                          source_mesh->getMesh(),
                                          _num_layers,

--- a/framework/src/meshmodifiers/SideSetsFromNormals.C
+++ b/framework/src/meshmodifiers/SideSetsFromNormals.C
@@ -64,7 +64,7 @@ SideSetsFromNormals::modify()
     mooseError("_mesh_ptr must be initialized before calling SideSetsFromNormals::modify()!");
 
   // We can't call this in the constructor, it appears that _mesh_ptr is always NULL there.
-  _mesh_ptr->errorIfParallelDistribution("SideSetsFromNormals");
+  _mesh_ptr->errorIfDistributedMesh("SideSetsFromNormals");
 
   std::vector<BoundaryID> boundary_ids = _mesh_ptr->getBoundaryIDs(_boundary_names, true);
 

--- a/framework/src/meshmodifiers/SideSetsFromPoints.C
+++ b/framework/src/meshmodifiers/SideSetsFromPoints.C
@@ -53,7 +53,7 @@ SideSetsFromPoints::modify()
     mooseError("_mesh_ptr must be initialized before calling SideSetsFromPoints::modify()!");
 
   // We can't call this in the constructor, it appears that _mesh_ptr is always NULL there.
-  _mesh_ptr->errorIfParallelDistribution("SideSetsFromPoints");
+  _mesh_ptr->errorIfDistributedMesh("SideSetsFromPoints");
 
   // Get the BoundaryIDs from the mesh
   std::vector<BoundaryID> boundary_ids = _mesh_ptr->getBoundaryIDs(_boundary_names, true);

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -48,7 +48,7 @@ Checkpoint::Checkpoint(const InputParameters & parameters) :
     _num_files(getParam<unsigned int>("num_files")),
     _suffix(getParam<std::string>("suffix")),
     _binary(getParam<bool>("binary")),
-    _parallel_mesh(_problem_ptr->mesh().isParallelMesh()),
+    _parallel_mesh(_problem_ptr->mesh().isDistributedMesh()),
     _restartable_data(_app.getRestartableData()),
     _recoverable_data(_app.getRecoverableData()),
     _material_property_storage(_problem_ptr->getMaterialPropertyStorage()),

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -68,7 +68,7 @@ outputMeshInformation(FEProblem & problem, bool verbose)
   {
     oss << "Mesh: " << '\n'
         << std::setw(console_field_width) << "  Distribution: " << (moose_mesh.isDistributedMesh() ? "parallel" : "serial")
-        << (moose_mesh.isDistributionForced() ? " (forced) " : "") << '\n'
+        << (moose_mesh.isParallelTypeForced() ? " (forced) " : "") << '\n'
         << std::setw(console_field_width) << "  Mesh Dimension: " << mesh.mesh_dimension() << '\n'
         << std::setw(console_field_width) << "  Spatial Dimension: " << mesh.spatial_dimension() << '\n';
   }

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -67,7 +67,7 @@ outputMeshInformation(FEProblem & problem, bool verbose)
   if (verbose)
   {
     oss << "Mesh: " << '\n'
-        << std::setw(console_field_width) << "  Distribution: " << (moose_mesh.isParallelMesh() ? "parallel" : "serial")
+        << std::setw(console_field_width) << "  Distribution: " << (moose_mesh.isDistributedMesh() ? "parallel" : "serial")
         << (moose_mesh.isDistributionForced() ? " (forced) " : "") << '\n'
         << std::setw(console_field_width) << "  Mesh Dimension: " << mesh.mesh_dimension() << '\n'
         << std::setw(console_field_width) << "  Spatial Dimension: " << mesh.spatial_dimension() << '\n';

--- a/framework/src/postprocessors/ElementalVariableValue.C
+++ b/framework/src/postprocessors/ElementalVariableValue.C
@@ -31,7 +31,7 @@ ElementalVariableValue::ElementalVariableValue(const InputParameters & parameter
     _var_name(parameters.get<VariableName>("variable")),
     _element(_mesh.getMesh().query_elem_ptr(parameters.get<unsigned int>("elementid")))
 {
-  // This class only works with SerialMesh, since it relies on a
+  // This class only works with ReplicatedMesh, since it relies on a
   // specific element numbering that we can't guarantee with ParallelMesh
   _mesh.errorIfParallelDistribution("ElementalVariableValue");
 }

--- a/framework/src/postprocessors/ElementalVariableValue.C
+++ b/framework/src/postprocessors/ElementalVariableValue.C
@@ -32,8 +32,8 @@ ElementalVariableValue::ElementalVariableValue(const InputParameters & parameter
     _element(_mesh.getMesh().query_elem_ptr(parameters.get<unsigned int>("elementid")))
 {
   // This class only works with ReplicatedMesh, since it relies on a
-  // specific element numbering that we can't guarantee with ParallelMesh
-  _mesh.errorIfParallelDistribution("ElementalVariableValue");
+  // specific element numbering that we can't guarantee with DistributedMesh
+  _mesh.errorIfDistributedMesh("ElementalVariableValue");
 }
 
 Real

--- a/framework/src/postprocessors/NodalVariableValue.C
+++ b/framework/src/postprocessors/NodalVariableValue.C
@@ -36,7 +36,7 @@ NodalVariableValue::NodalVariableValue(const InputParameters & parameters) :
     _node_ptr(_mesh.getMesh().query_node_ptr(getParam<unsigned int>("nodeid"))),
     _scale_factor(getParam<Real>("scale_factor"))
 {
-  // This class only works with SerialMesh, since it relies on a
+  // This class only works with ReplicatedMesh, since it relies on a
   // specific node numbering that we can't guarantee with ParallelMesh
   _mesh.errorIfParallelDistribution("NodalVariableValue");
 

--- a/framework/src/postprocessors/NodalVariableValue.C
+++ b/framework/src/postprocessors/NodalVariableValue.C
@@ -37,8 +37,8 @@ NodalVariableValue::NodalVariableValue(const InputParameters & parameters) :
     _scale_factor(getParam<Real>("scale_factor"))
 {
   // This class only works with ReplicatedMesh, since it relies on a
-  // specific node numbering that we can't guarantee with ParallelMesh
-  _mesh.errorIfParallelDistribution("NodalVariableValue");
+  // specific node numbering that we can't guarantee with DistributedMesh
+  _mesh.errorIfDistributedMesh("NodalVariableValue");
 
   if (_node_ptr == NULL)
     mooseError("Node #" << getParam<unsigned int>("nodeid") << " specified in '" << name() << "' not found in the mesh!");

--- a/framework/src/timesteppers/ExodusTimeSequenceStepper.C
+++ b/framework/src/timesteppers/ExodusTimeSequenceStepper.C
@@ -38,7 +38,7 @@ ExodusTimeSequenceStepper::ExodusTimeSequenceStepper(const InputParameters & par
     MooseUtils::checkFileReadable(_mesh_file);
 
     // dummy mesh
-    SerialMesh mesh(_communicator);
+    ReplicatedMesh mesh(_communicator);
 
     ExodusII_IO exodusII_io(mesh);
     exodusII_io.read(_mesh_file);

--- a/framework/src/transfers/MultiAppCopyTransfer.C
+++ b/framework/src/transfers/MultiAppCopyTransfer.C
@@ -72,7 +72,7 @@ MultiAppCopyTransfer::execute()
       unsigned int from_sys_num = from_sys.number();
 
       // Only works with a serialized mesh to transfer from!
-      mooseAssert(from_sys.get_mesh().is_serial(), "MultiAppCopyTransfer only works with SerialMesh!");
+      mooseAssert(from_sys.get_mesh().is_serial(), "MultiAppCopyTransfer only works with ReplicatedMesh!");
 
       unsigned int from_var_num = from_sys.variable_number(from_var.name());
 
@@ -165,7 +165,7 @@ MultiAppCopyTransfer::execute()
       unsigned int to_sys_num = to_sys.number();
 
       // Only works with a serialized mesh to transfer to!
-      mooseAssert(to_sys.get_mesh().is_serial(), "MultiAppCopyTransfer only works with SerialMesh!");
+      mooseAssert(to_sys.get_mesh().is_serial(), "MultiAppCopyTransfer only works with ReplicatedMesh!");
 
       unsigned int to_var_num = to_sys.variable_number(to_var.name());
 
@@ -193,7 +193,7 @@ MultiAppCopyTransfer::execute()
         unsigned int from_var_num = from_sys.variable_number(from_var.name());
 
         // Only works with a serialized mesh to transfer from!
-        mooseAssert(from_sys.get_mesh().is_serial(), "MultiAppCopyTransfer only works with SerialMesh!");
+        mooseAssert(from_sys.get_mesh().is_serial(), "MultiAppCopyTransfer only works with ReplicatedMesh!");
 
         //Create a serialized version of the solution vector
 //        NumericVector<Number> * serialized_solution = NumericVector<Number>::build(from_sys.comm()).release();

--- a/framework/src/transfers/MultiAppCopyTransfer.C
+++ b/framework/src/transfers/MultiAppCopyTransfer.C
@@ -40,8 +40,8 @@ MultiAppCopyTransfer::MultiAppCopyTransfer(const InputParameters & parameters) :
     _to_var_name(getParam<AuxVariableName>("variable")),
     _from_var_name(getParam<VariableName>("source_variable"))
 {
-  // This transfer does not work with ParallelMesh
-  _fe_problem.mesh().errorIfParallelDistribution("MultiAppCopyTransfer");
+  // This transfer does not work with DistributedMesh
+  _fe_problem.mesh().errorIfDistributedMesh("MultiAppCopyTransfer");
 }
 
 void

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -269,7 +269,7 @@ MultiAppInterpolationTransfer::execute()
       unsigned int to_sys_num = to_sys.number();
 
       // Only works with a serialized mesh to transfer to!
-      mooseAssert(to_sys.get_mesh().is_serial(), "MultiAppInterpolationTransfer only works with SerialMesh!");
+      mooseAssert(to_sys.get_mesh().is_serial(), "MultiAppInterpolationTransfer only works with ReplicatedMesh!");
 
       unsigned int to_var_num = to_sys.variable_number(to_var.name());
 

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -55,8 +55,8 @@ MultiAppInterpolationTransfer::MultiAppInterpolationTransfer(const InputParamete
     _interp_type(getParam<MooseEnum>("interp_type")),
     _radius(getParam<Real>("radius"))
 {
-  // This transfer does not work with ParallelMesh
-  _fe_problem.mesh().errorIfParallelDistribution("MultiAppInterpolationTransfer");
+  // This transfer does not work with DistributedMesh
+  _fe_problem.mesh().errorIfDistributedMesh("MultiAppInterpolationTransfer");
   _displaced_source_mesh = getParam<bool>("displaced_source_mesh");
   _displaced_target_mesh = getParam<bool>("displaced_target_mesh");
 }

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -54,7 +54,7 @@ MultiAppNearestNodeTransfer::MultiAppNearestNodeTransfer(const InputParameters &
     _cached_from_inds(declareRestartableData<std::map<unsigned int, unsigned int> >("cached_from_ids")),
     _cached_qp_inds(declareRestartableData<std::map<unsigned int, unsigned int> >("cached_qp_inds"))
 {
-  // This transfer does not work with ParallelMesh
+  // This transfer does not work with DistributedMesh
   _displaced_source_mesh = getParam<bool>("displaced_source_mesh");
   _displaced_target_mesh = getParam<bool>("displaced_target_mesh");
 }

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -164,7 +164,7 @@ MultiAppUserObjectTransfer::execute()
       unsigned int to_sys_num = to_sys.number();
 
       // Only works with a serialized mesh to transfer to!
-      mooseAssert(to_sys.get_mesh().is_serial(), "MultiAppUserObjectTransfer only works with SerialMesh!");
+      mooseAssert(to_sys.get_mesh().is_serial(), "MultiAppUserObjectTransfer only works with ReplicatedMesh!");
 
       unsigned int to_var_num = to_sys.variable_number(to_var.name());
 

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -45,8 +45,8 @@ MultiAppUserObjectTransfer::MultiAppUserObjectTransfer(const InputParameters & p
     _user_object_name(getParam<UserObjectName>("user_object")),
     _displaced_target_mesh(getParam<bool>("displaced_target_mesh"))
 {
-  // This transfer does not work with ParallelMesh
-  _fe_problem.mesh().errorIfParallelDistribution("MultiAppUserObjectTransfer");
+  // This transfer does not work with DistributedMesh
+  _fe_problem.mesh().errorIfDistributedMesh("MultiAppUserObjectTransfer");
 }
 
 void

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -399,9 +399,9 @@ SolutionUserObject::initialSetup()
 
 
   // Create a libmesh::Mesh object for storing the loaded data.  Since
-  // SolutionUserObject is restricted to only work with SerialMesh
-  // (see above) we can force the Mesh used here to be a SerialMesh.
-  _mesh = new SerialMesh(_communicator);
+  // SolutionUserObject is restricted to only work with ReplicatedMesh
+  // (see above) we can force the Mesh used here to be a ReplicatedMesh.
+  _mesh = new ReplicatedMesh(_communicator);
 
   // ExodusII mesh file supplied
   if (MooseUtils::hasExtension(_mesh_file, "e", /*strip_exodus_ext =*/ true))

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -219,7 +219,7 @@ SolutionUserObject::readExodusII()
     mooseError("In SolutionUserObject, exodus file contains no timesteps.");
 
   // Account for parallel mesh
-  if (dynamic_cast<ParallelMesh *>(_mesh))
+  if (dynamic_cast<DistributedMesh *>(_mesh))
   {
     _mesh->allow_renumbering(true);
     _mesh->prepare_for_use(/*false*/);
@@ -391,11 +391,11 @@ SolutionUserObject::initialSetup()
     return;
 
   // Several aspects of SolutionUserObject won't work if the FEProblem's MooseMesh is
-  // a ParallelMesh:
+  // a DistributedMesh:
   // .) ExodusII_IO::copy_nodal_solution() doesn't work in parallel.
   // .) We don't know if directValue will be used, which may request
   //    a value on a Node we don't have.
-  _fe_problem.mesh().errorIfParallelDistribution("SolutionUserObject");
+  _fe_problem.mesh().errorIfDistributedMesh("SolutionUserObject");
 
 
   // Create a libmesh::Mesh object for storing the loaded data.  Since

--- a/framework/src/userobject/VerifyElementUniqueID.C
+++ b/framework/src/userobject/VerifyElementUniqueID.C
@@ -59,7 +59,7 @@ void
 VerifyElementUniqueID::finalize()
 {
   // On Parallel Mesh we have to look at all the ids over all the processors
-  if (_subproblem.mesh().isParallelMesh())
+  if (_subproblem.mesh().isDistributedMesh())
     _communicator.allgather(_all_ids);
 
   std::sort(_all_ids.begin(), _all_ids.end());

--- a/framework/src/userobject/VerifyNodalUniqueID.C
+++ b/framework/src/userobject/VerifyNodalUniqueID.C
@@ -59,7 +59,7 @@ void
 VerifyNodalUniqueID::finalize()
 {
   // On Parallel Mesh we have to look at all the ids over all the processors
-  if (_subproblem.mesh().isParallelMesh())
+  if (_subproblem.mesh().isDistributedMesh())
     _communicator.allgather(_all_ids);
 
   std::sort(_all_ids.begin(), _all_ids.end());

--- a/framework/src/utils/RandomData.C
+++ b/framework/src/utils/RandomData.C
@@ -83,7 +83,7 @@ RandomData::updateGenerators()
    * processor based on their individual processor ids before generating seeds for
    * the mesh entities.
    */
-  if (_rd_mesh.isParallelMesh())
+  if (_rd_mesh.isDistributedMesh())
   {
     unsigned int parallel_seed;
     for (processor_id_type proc_id = 0; proc_id < _rd_problem.n_processors(); ++proc_id)

--- a/modules/phase_field/tutorials/spinodal_decomposition/s3_decomp.i
+++ b/modules/phase_field/tutorials/spinodal_decomposition/s3_decomp.i
@@ -5,7 +5,6 @@
 [Mesh]
   type = GeneratedMesh
   dim = 2
-  distribution = DEFAULT
   elem_type = QUAD4
   nx = 25
   ny = 25

--- a/modules/phase_field/tutorials/spinodal_decomposition/s4_mobility.i
+++ b/modules/phase_field/tutorials/spinodal_decomposition/s4_mobility.i
@@ -8,7 +8,6 @@
 [Mesh]
   type = GeneratedMesh
   dim = 2
-  distribution = DEFAULT
   elem_type = QUAD4
   nx = 25
   ny = 25

--- a/modules/phase_field/tutorials/spinodal_decomposition/s5_energycurve.i
+++ b/modules/phase_field/tutorials/spinodal_decomposition/s5_energycurve.i
@@ -7,7 +7,6 @@
 [Mesh]
   type = GeneratedMesh
   dim = 2
-  distribution = DEFAULT
   elem_type = QUAD4
   nx = 25
   ny = 25

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -116,10 +116,11 @@ class TestHarness:
       self.checks['cxx11'] =  getLibMeshConfigOption(self.libmesh_dir, 'cxx11')
       self.checks['asio'] =  getIfAsioExists(self.moose_dir)
 
-    # Override the MESH_MODE option if using '--parallel-mesh' option
-    if self.options.parallel_mesh == True or \
+    # Override the MESH_MODE option if using the '--distributed-mesh'
+    # or (deprecated) '--parallel-mesh' option.
+    if (self.options.parallel_mesh == True or self.options.distributed_mesh == True) or \
           (self.options.cli_args != None and \
-          self.options.cli_args.find('--parallel-mesh') != -1):
+           (self.options.cli_args.find('--parallel-mesh') != -1 or self.options.cli_args.find('--distributed-mesh') != -1)):
 
       option_set = set(['ALL', 'PARALLEL'])
       self.checks['mesh_mode'] = option_set
@@ -742,7 +743,8 @@ class TestHarness:
     parser.add_argument('--re', action='store', type=str, dest='reg_exp', help='Run tests that match --re=regular_expression')
 
     # Options that pass straight through to the executable
-    parser.add_argument('--parallel-mesh', action='store_true', dest='parallel_mesh', help='Pass "--parallel-mesh" to executable')
+    parser.add_argument('--parallel-mesh', action='store_true', dest='parallel_mesh', help='Deprecated, use --distributed-mesh instead')
+    parser.add_argument('--distributed-mesh', action='store_true', dest='distributed_mesh', help='Pass "--distributed-mesh" to executable')
     parser.add_argument('--error', action='store_true', help='Run the tests with warnings as errors (Pass "--error" to executable)')
     parser.add_argument('--error-unused', action='store_true', help='Run the tests with errors on unused parameters (Pass "--error-unused" to executable)')
 

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -94,10 +94,10 @@ class RunApp(Tester):
       print 'Application not found: ' + str(specs['executable'])
       sys.exit(1)
 
-    if options.parallel_mesh and '--parallel-mesh' not in specs['cli_args']:
+    if (options.parallel_mesh or options.distributed_mesh) and ('--parallel-mesh' not in specs['cli_args'] or '--distributed-mesh' not in specs['cli_args']):
       # The user has passed the parallel-mesh option to the test harness
       # and it is NOT supplied already in the cli-args option
-      specs['cli_args'].append('--parallel-mesh')
+      specs['cli_args'].append('--distributed-mesh')
 
     if options.error and '--error' not in specs['cli_args'] and not specs["allow_warnings"]:
       # The user has passed the error option to the test harness

--- a/test/src/meshes/StripeMesh.C
+++ b/test/src/meshes/StripeMesh.C
@@ -29,7 +29,7 @@ StripeMesh::StripeMesh(const InputParameters & parameters) :
     _n_stripes(getParam<unsigned int>("stripes"))
 {
   // The StripeMesh class only works with ReplicatedMesh
-  errorIfParallelDistribution("StripeMesh");
+  errorIfDistributedMesh("StripeMesh");
 }
 
 StripeMesh::StripeMesh(const StripeMesh & other_mesh) :

--- a/test/src/meshes/StripeMesh.C
+++ b/test/src/meshes/StripeMesh.C
@@ -28,7 +28,7 @@ StripeMesh::StripeMesh(const InputParameters & parameters) :
     GeneratedMesh(parameters),
     _n_stripes(getParam<unsigned int>("stripes"))
 {
-  // The StripeMesh class only works with SerialMesh
+  // The StripeMesh class only works with ReplicatedMesh
   errorIfParallelDistribution("StripeMesh");
 }
 
@@ -62,7 +62,7 @@ StripeMesh::buildMesh()
 
     if (!e)
     {
-      mooseError("Error getting element " << en << ". StripeMesh only works with SerialMesh...");
+      mooseError("Error getting element " << en << ". StripeMesh only works with ReplicatedMesh...");
     }
     else
     {

--- a/test/tests/auxkernels/aux_nodal_scalar_kernel/aux_nodal_scalar_kernel.i
+++ b/test/tests/auxkernels/aux_nodal_scalar_kernel/aux_nodal_scalar_kernel.i
@@ -4,7 +4,7 @@
   xmin = 0
   xmax = 1
   nx = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/element_var/element_var_test.i
+++ b/test/tests/auxkernels/element_var/element_var_test.i
@@ -10,7 +10,7 @@
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
   # elements, if you use DistributedMesh the elements get renumbered.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/auxkernels/element_var/element_var_test.i
+++ b/test/tests/auxkernels/element_var/element_var_test.i
@@ -9,7 +9,7 @@
   ny = 10
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
-  # elements, if you use ParallelMesh the elements get renumbered.
+  # elements, if you use DistributedMesh the elements get renumbered.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/gap_value/gap_value.i
+++ b/test/tests/auxkernels/gap_value/gap_value.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = nonmatching.e
   dim = 2
-  # This test will not work in parallel with ParallelMesh enabled
+  # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in the GeometricSearch system.  See #2121 for more
   # information.
   distribution = serial

--- a/test/tests/auxkernels/gap_value/gap_value.i
+++ b/test/tests/auxkernels/gap_value/gap_value.i
@@ -4,7 +4,7 @@
   # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in the GeometricSearch system.  See #2121 for more
   # information.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/gap_value/gap_value_subdomain_restricted.i
+++ b/test/tests/auxkernels/gap_value/gap_value_subdomain_restricted.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = nonmatching.e
   dim = 2
-  # This test will not work in parallel with ParallelMesh enabled
+  # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in the GeometricSearch system.  See #2121 for more
   # information.
   distribution = serial

--- a/test/tests/auxkernels/gap_value/gap_value_subdomain_restricted.i
+++ b/test/tests/auxkernels/gap_value/gap_value_subdomain_restricted.i
@@ -4,7 +4,7 @@
   # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in the GeometricSearch system.  See #2121 for more
   # information.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_adapt_xda.i
+++ b/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_adapt_xda.i
@@ -1,5 +1,5 @@
 [Mesh]
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = FileMesh
   file = aux_nonlinear_solution_adapt_out_0004_mesh.xda
   distribution = serial

--- a/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_adapt_xda.i
+++ b/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_adapt_xda.i
@@ -2,7 +2,7 @@
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = FileMesh
   file = aux_nonlinear_solution_adapt_out_0004_mesh.xda
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Adaptivity]

--- a/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_xda.i
+++ b/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_xda.i
@@ -1,5 +1,5 @@
 [Mesh]
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = GeneratedMesh
   distribution = SERIAL
   dim = 2

--- a/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_xda.i
+++ b/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_xda.i
@@ -1,7 +1,7 @@
 [Mesh]
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = GeneratedMesh
-  distribution = SERIAL
+  parallel_type = replicated
   dim = 2
   nx = 2
   ny = 2

--- a/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_xdr.i
+++ b/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_xdr.i
@@ -1,5 +1,5 @@
 [Mesh]
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = GeneratedMesh
   distribution = SERIAL
   dim = 2

--- a/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_xdr.i
+++ b/test/tests/auxkernels/solution_aux/aux_nonlinear_solution_xdr.i
@@ -1,7 +1,7 @@
 [Mesh]
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = GeneratedMesh
-  distribution = SERIAL
+  parallel_type = replicated
   dim = 2
   nx = 2
   ny = 2

--- a/test/tests/auxkernels/solution_aux/output_error.i
+++ b/test/tests/auxkernels/solution_aux/output_error.i
@@ -8,7 +8,7 @@
   ymin = 1
   ymax = 3
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/output_error.i
+++ b/test/tests/auxkernels/solution_aux/output_error.i
@@ -7,7 +7,7 @@
   xmax = 4
   ymin = 1
   ymax = 3
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = square.e
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux.i
@@ -2,7 +2,7 @@
   type = FileMesh
   file = square.e
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_direct.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_direct.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = build_out_0001_mesh.xda
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_direct.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_direct.i
@@ -2,7 +2,7 @@
   type = FileMesh
   file = build_out_0001_mesh.xda
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus.i
@@ -5,7 +5,7 @@
   # has been renumbered (it will be reunumbered if you are running with
   # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus.i
@@ -4,7 +4,7 @@
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
   # ParallelMesh in parallel).  Hence, we restrict this test to run with
-  # SerialMesh only.
+  # ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus.i
@@ -3,7 +3,7 @@
   # The SolutionUserObject uses the copy_nodal_solution() capability
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
-  # ParallelMesh in parallel).  Hence, we restrict this test to run with
+  # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
   distribution = serial
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_direct.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_direct.i
@@ -6,7 +6,7 @@
   # has been renumbered (it will be reunumbered if you are running with
   # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_direct.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_direct.i
@@ -5,7 +5,7 @@
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
   # ParallelMesh in parallel).  Hence, we restrict this test to run with
-  # SerialMesh only.
+  # ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_direct.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_direct.i
@@ -4,7 +4,7 @@
   # The SolutionUserObject uses the copy_nodal_solution() capability
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
-  # ParallelMesh in parallel).  Hence, we restrict this test to run with
+  # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
   distribution = serial
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elem_map.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elem_map.i
@@ -5,7 +5,7 @@
   # has been renumbered (it will be reunumbered if you are running with
   # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elem_map.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elem_map.i
@@ -4,7 +4,7 @@
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
   # ParallelMesh in parallel).  Hence, we restrict this test to run with
-  # SerialMesh only.
+  # ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elem_map.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elem_map.i
@@ -3,7 +3,7 @@
   # The SolutionUserObject uses the copy_nodal_solution() capability
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
-  # ParallelMesh in parallel).  Hence, we restrict this test to run with
+  # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
   distribution = serial
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental.i
@@ -5,7 +5,7 @@
   # has been renumbered (it will be reunumbered if you are running with
   # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental.i
@@ -4,7 +4,7 @@
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
   # ParallelMesh in parallel).  Hence, we restrict this test to run with
-  # SerialMesh only.
+  # ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental.i
@@ -3,7 +3,7 @@
   # The SolutionUserObject uses the copy_nodal_solution() capability
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
-  # ParallelMesh in parallel).  Hence, we restrict this test to run with
+  # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
   distribution = serial
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental_only.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental_only.i
@@ -5,7 +5,7 @@
   # has been renumbered (it will be reunumbered if you are running with
   # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental_only.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental_only.i
@@ -4,7 +4,7 @@
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
   # ParallelMesh in parallel).  Hence, we restrict this test to run with
-  # SerialMesh only.
+  # ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental_only.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_elemental_only.i
@@ -3,7 +3,7 @@
   # The SolutionUserObject uses the copy_nodal_solution() capability
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
-  # ParallelMesh in parallel).  Hence, we restrict this test to run with
+  # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
   distribution = serial
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_file_extension.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_file_extension.i
@@ -5,7 +5,7 @@
   # has been renumbered (it will be reunumbered if you are running with
   # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_file_extension.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_file_extension.i
@@ -4,7 +4,7 @@
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
   # ParallelMesh in parallel).  Hence, we restrict this test to run with
-  # SerialMesh only.
+  # ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_file_extension.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_file_extension.i
@@ -3,7 +3,7 @@
   # The SolutionUserObject uses the copy_nodal_solution() capability
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
-  # ParallelMesh in parallel).  Hence, we restrict this test to run with
+  # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
   distribution = serial
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp.i
@@ -2,7 +2,7 @@
   type = FileMesh
   file = cubesource.e
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = cubesource.e
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_direct.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_direct.i
@@ -6,7 +6,7 @@
   # has been renumbered (it will be reunumbered if you are running with
   # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_direct.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_direct.i
@@ -5,7 +5,7 @@
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
   # ParallelMesh in parallel).  Hence, we restrict this test to run with
-  # SerialMesh only.
+  # ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_direct.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_direct.i
@@ -4,7 +4,7 @@
   # The SolutionUserObject uses the copy_nodal_solution() capability
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
-  # ParallelMesh in parallel).  Hence, we restrict this test to run with
+  # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
   distribution = serial
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart1.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart1.i
@@ -2,7 +2,7 @@
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = FileMesh
   file = cubesource.e
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart1.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart1.i
@@ -1,5 +1,5 @@
 [Mesh]
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = FileMesh
   file = cubesource.e
   distribution = serial

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart2.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart2.i
@@ -2,7 +2,7 @@
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = FileMesh
   file = cubesource.e
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart2.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart2.i
@@ -1,5 +1,5 @@
 [Mesh]
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   type = FileMesh
   file = cubesource.e
   distribution = serial

--- a/test/tests/auxkernels/solution_aux/solution_aux_multi_err.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_multi_err.i
@@ -1,6 +1,6 @@
 [Mesh]
   file = cubesource.e
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_multi_err.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_multi_err.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = cubesource.e
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_multi_var.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_multi_var.i
@@ -5,7 +5,7 @@
   # has been renumbered (it will be reunumbered if you are running with
   # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_multi_var.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_multi_var.i
@@ -4,7 +4,7 @@
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
   # ParallelMesh in parallel).  Hence, we restrict this test to run with
-  # SerialMesh only.
+  # ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/auxkernels/solution_aux/solution_aux_multi_var.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_multi_var.i
@@ -3,7 +3,7 @@
   # The SolutionUserObject uses the copy_nodal_solution() capability
   # of the Exodus reader, and therefore won't work if the initial mesh
   # has been renumbered (it will be reunumbered if you are running with
-  # ParallelMesh in parallel).  Hence, we restrict this test to run with
+  # DistributedMesh in parallel).  Hence, we restrict this test to run with
   # ReplicatedMesh only.
   distribution = serial
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_scale.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_scale.i
@@ -8,7 +8,7 @@
   ymin = 1
   ymax = 3
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/auxkernels/solution_aux/solution_aux_scale.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_scale.i
@@ -7,7 +7,7 @@
   xmax = 4
   ymin = 1
   ymax = 3
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/bcs/periodic/periodic_level_1_test.i
+++ b/test/tests/bcs/periodic/periodic_level_1_test.i
@@ -9,7 +9,7 @@
   zmax = 0
   elem_type = QUAD4
   uniform_refine = 4
-  distribution = SERIAL #This is because of floating point roundoff being different with parallel mesh
+  parallel_type = replicated # This is because of floating point roundoff being different with DistributedMesh
 []
 
 [Variables]

--- a/test/tests/checkpoint/checkpoint_interval.i
+++ b/test/tests/checkpoint/checkpoint_interval.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/executioners/adapt_and_modify/adapt_and_modify_heavy.i
+++ b/test/tests/executioners/adapt_and_modify/adapt_and_modify_heavy.i
@@ -6,7 +6,7 @@
   dim = 2
   nx = 15
   ny = 15
-#  distribution = serial
+#  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/functions/function_file_format/function_file_format_test.i
+++ b/test/tests/functions/function_file_format/function_file_format_test.i
@@ -24,7 +24,7 @@
   # This problem only has 1 element, so using DistributedMesh in parallel
   # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/functions/function_file_format/function_file_format_test.i
+++ b/test/tests/functions/function_file_format/function_file_format_test.i
@@ -21,8 +21,8 @@
 # At time = 0, the variable = 0, at time = 1, variable = 4 and so on.
 [Mesh]
   file = cube.e
-  # This problem only has 1 element, so using ParallelMesh in parallel
-  # isn't really an option, and we don't care that much about ParallelMesh
+  # This problem only has 1 element, so using DistributedMesh in parallel
+  # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
   distribution = serial
 []

--- a/test/tests/functions/image_function/threshold_adapt_parallel.i
+++ b/test/tests/functions/image_function/threshold_adapt_parallel.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 2
   ny = 2
-  distribution = PARALLEL
+  parallel_type = distributed
 []
 
 [Variables]

--- a/test/tests/functions/piecewise_constant/piecewise_constant.i
+++ b/test/tests/functions/piecewise_constant/piecewise_constant.i
@@ -8,8 +8,8 @@
 
 [Mesh]
   file = cube.e
-  # This problem only has 1 element, so using ParallelMesh in parallel
-  # isn't really an option, and we don't care that much about ParallelMesh
+  # This problem only has 1 element, so using DistributedMesh in parallel
+  # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
   distribution = serial
 []

--- a/test/tests/functions/piecewise_constant/piecewise_constant.i
+++ b/test/tests/functions/piecewise_constant/piecewise_constant.i
@@ -11,7 +11,7 @@
   # This problem only has 1 element, so using DistributedMesh in parallel
   # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/functions/solution_function/solution_function_exodus_interp_test.i
+++ b/test/tests/functions/solution_function/solution_function_exodus_interp_test.i
@@ -1,6 +1,6 @@
 [Mesh]
   file = cubesource.e
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/functions/solution_function/solution_function_exodus_interp_test.i
+++ b/test/tests/functions/solution_function/solution_function_exodus_interp_test.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = cubesource.e
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/functions/solution_function/solution_function_exodus_test.i
+++ b/test/tests/functions/solution_function/solution_function_exodus_test.i
@@ -9,7 +9,7 @@
   type = FileMesh
   file = cubesource.e
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/functions/solution_function/solution_function_exodus_test.i
+++ b/test/tests/functions/solution_function/solution_function_exodus_test.i
@@ -8,7 +8,7 @@
 [Mesh]
   type = FileMesh
   file = cubesource.e
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/functions/solution_function/solution_function_test.i
+++ b/test/tests/functions/solution_function/solution_function_test.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = square.e
-  # This test uses SolutionUserObject which doesn't work with ParallelMesh.
+  # This test uses SolutionUserObject which doesn't work with DistributedMesh.
   distribution = serial
 []
 

--- a/test/tests/functions/solution_function/solution_function_test.i
+++ b/test/tests/functions/solution_function/solution_function_test.i
@@ -2,7 +2,7 @@
   type = FileMesh
   file = square.e
   # This test uses SolutionUserObject which doesn't work with DistributedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/ics/data_struct_ic/data_struct_ic_test.i
+++ b/test/tests/ics/data_struct_ic/data_struct_ic_test.i
@@ -5,7 +5,7 @@
   dim = 2
 
   # DataStructIC creates an IC based on node numbering
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/indicators/laplacian_jump_indicator/laplacian_jump_indicator_test.i
+++ b/test/tests/indicators/laplacian_jump_indicator/laplacian_jump_indicator_test.i
@@ -4,7 +4,7 @@
   nx = 10
   ny = 10
   nz = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/mesh/centroid_partitioner/centroid_partitioner_test.i
+++ b/test/tests/mesh/centroid_partitioner/centroid_partitioner_test.i
@@ -31,7 +31,7 @@
   centroid_partitioner_direction = y
 
   # The centroid partitioner behaves differently depending on
-  # whether you are using Serial or ParallelMesh, so to get
+  # whether you are using Serial or DistributedMesh, so to get
   # repeatable results, we restrict this test to using ReplicatedMesh.
   distribution = serial
 []

--- a/test/tests/mesh/centroid_partitioner/centroid_partitioner_test.i
+++ b/test/tests/mesh/centroid_partitioner/centroid_partitioner_test.i
@@ -33,7 +33,7 @@
   # The centroid partitioner behaves differently depending on
   # whether you are using Serial or DistributedMesh, so to get
   # repeatable results, we restrict this test to using ReplicatedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/mesh/centroid_partitioner/centroid_partitioner_test.i
+++ b/test/tests/mesh/centroid_partitioner/centroid_partitioner_test.i
@@ -32,7 +32,7 @@
 
   # The centroid partitioner behaves differently depending on
   # whether you are using Serial or ParallelMesh, so to get
-  # repeatable results, we restrict this test to using SerialMesh.
+  # repeatable results, we restrict this test to using ReplicatedMesh.
   distribution = serial
 []
 

--- a/test/tests/mesh/custom_partitioner/custom_linear_partitioner_restart_test.i
+++ b/test/tests/mesh/custom_partitioner/custom_linear_partitioner_restart_test.i
@@ -15,7 +15,7 @@
     type = LibmeshPartitioner
     partitioner = linear
   [../]
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/mesh/custom_partitioner/custom_linear_partitioner_test.i
+++ b/test/tests/mesh/custom_partitioner/custom_linear_partitioner_test.i
@@ -25,7 +25,7 @@
     type = LibmeshPartitioner
     partitioner = linear
   [../]
-  distribution = serial
+  parallel_type = replicated
 []
 
 

--- a/test/tests/mesh/mixed_dim/1d_2d.i
+++ b/test/tests/mesh/mixed_dim/1d_2d.i
@@ -3,7 +3,7 @@
   # Mixed-dimension meshes don't seem to work with DistributedMesh.  The
   # program hangs, I can't get a useful stack trace when I attach to
   # it.  See also #2130.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/mesh/mixed_dim/1d_2d.i
+++ b/test/tests/mesh/mixed_dim/1d_2d.i
@@ -1,6 +1,6 @@
 [Mesh]
   file = 1d_2d.e
-  # Mixed-dimension meshes don't seem to work with ParallelMesh.  The
+  # Mixed-dimension meshes don't seem to work with DistributedMesh.  The
   # program hangs, I can't get a useful stack trace when I attach to
   # it.  See also #2130.
   distribution = serial

--- a/test/tests/mesh/mixed_dim/1d_2d_w_matl.i
+++ b/test/tests/mesh/mixed_dim/1d_2d_w_matl.i
@@ -2,7 +2,7 @@
 # This is important for testing the robustness of re-initializing materials
 [Mesh]
   file = 1d_2d-2.e
-  # Mixed-dimension meshes don't seem to work with ParallelMesh.  The
+  # Mixed-dimension meshes don't seem to work with DistributedMesh.  The
   # program hangs, I can't get a useful stack trace when I attach to
   # it.  See also #2130.
   distribution = serial

--- a/test/tests/mesh/mixed_dim/1d_2d_w_matl.i
+++ b/test/tests/mesh/mixed_dim/1d_2d_w_matl.i
@@ -5,7 +5,7 @@
   # Mixed-dimension meshes don't seem to work with DistributedMesh.  The
   # program hangs, I can't get a useful stack trace when I attach to
   # it.  See also #2130.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/mesh/mixed_dim/1d_3d.i
+++ b/test/tests/mesh/mixed_dim/1d_3d.i
@@ -3,7 +3,7 @@
   # Mixed-dimension meshes don't seem to work with DistributedMesh.  The
   # program hangs, I can't get a useful stack trace when I attach to
   # it.  See also #2130.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/mesh/mixed_dim/1d_3d.i
+++ b/test/tests/mesh/mixed_dim/1d_3d.i
@@ -1,6 +1,6 @@
 [Mesh]
   file = 1d_3d.e
-  # Mixed-dimension meshes don't seem to work with ParallelMesh.  The
+  # Mixed-dimension meshes don't seem to work with DistributedMesh.  The
   # program hangs, I can't get a useful stack trace when I attach to
   # it.  See also #2130.
   distribution = serial

--- a/test/tests/mesh/named_entities/periodic_bc_names_test.i
+++ b/test/tests/mesh/named_entities/periodic_bc_names_test.i
@@ -10,7 +10,7 @@
   elem_type = QUAD4
   # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/mesh/named_entities/periodic_bc_names_test.i
+++ b/test/tests/mesh/named_entities/periodic_bc_names_test.i
@@ -8,7 +8,7 @@
   ymax = 40
   zmax = 0
   elem_type = QUAD4
-  # This test will not work in parallel with ParallelMesh enabled
+  # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
   distribution = serial
 []

--- a/test/tests/mesh/patterned_mesh/patterned_mesh.i
+++ b/test/tests/mesh/patterned_mesh/patterned_mesh.i
@@ -19,5 +19,5 @@
   left_boundary = 4
   y_width = 1.2
   x_width = 1.2
-  distribution = SERIAL
+  parallel_type = replicated
 []

--- a/test/tests/mesh/tiled_mesh/tiled_mesh_test.i
+++ b/test/tests/mesh/tiled_mesh/tiled_mesh_test.i
@@ -17,7 +17,7 @@
   y_tiles = 2
   z_tiles = 2
 
-  # You can only run this test with SerialMesh because the underlying
-  # algorithm, stitch_meshes(), only works with SerialMesh.
+  # You can only run this test with ReplicatedMesh because the underlying
+  # algorithm, stitch_meshes(), only works with ReplicatedMesh.
   distribution = serial
 []

--- a/test/tests/mesh/tiled_mesh/tiled_mesh_test.i
+++ b/test/tests/mesh/tiled_mesh/tiled_mesh_test.i
@@ -19,5 +19,5 @@
 
   # You can only run this test with ReplicatedMesh because the underlying
   # algorithm, stitch_meshes(), only works with ReplicatedMesh.
-  distribution = serial
+  parallel_type = replicated
 []

--- a/test/tests/mesh/unique_ids/tests
+++ b/test/tests/mesh/unique_ids/tests
@@ -10,7 +10,7 @@
     type = 'RunApp'
     input = 'unique_ids.i'
     unique_ids = True
-    cli_args = '--parallel-mesh'
+    cli_args = '--distributed-mesh'
     min_parallel = 2
     prereq = serial_mesh
   [../]

--- a/test/tests/mesh_modifiers/add_all_side_sets/less_simple.i
+++ b/test/tests/mesh_modifiers/add_all_side_sets/less_simple.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = reactor.e
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   distribution = serial
 []

--- a/test/tests/mesh_modifiers/add_all_side_sets/less_simple.i
+++ b/test/tests/mesh_modifiers/add_all_side_sets/less_simple.i
@@ -3,7 +3,7 @@
   file = reactor.e
   # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/add_all_side_sets/simple.i
+++ b/test/tests/mesh_modifiers/add_all_side_sets/simple.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = twoblocks.e
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   distribution = serial
 []

--- a/test/tests/mesh_modifiers/add_all_side_sets/simple.i
+++ b/test/tests/mesh_modifiers/add_all_side_sets/simple.i
@@ -3,7 +3,7 @@
   file = twoblocks.e
   # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/add_extra_nodeset/extra_nodeset_test.i
+++ b/test/tests/mesh_modifiers/add_extra_nodeset/extra_nodeset_test.i
@@ -2,7 +2,7 @@
   file = square.e
   # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/add_extra_nodeset/extra_nodeset_test.i
+++ b/test/tests/mesh_modifiers/add_extra_nodeset/extra_nodeset_test.i
@@ -1,6 +1,6 @@
 [Mesh]
   file = square.e
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   distribution = serial
 []

--- a/test/tests/mesh_modifiers/add_side_sets/cylinder_normals.i
+++ b/test/tests/mesh_modifiers/add_side_sets/cylinder_normals.i
@@ -11,7 +11,7 @@
 [Mesh]
   type = FileMesh
   file = cylinder.e
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   distribution = serial
 []

--- a/test/tests/mesh_modifiers/add_side_sets/cylinder_normals.i
+++ b/test/tests/mesh_modifiers/add_side_sets/cylinder_normals.i
@@ -13,7 +13,7 @@
   file = cylinder.e
   # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
-  distribution = serial
+  parallel_type = replicated
 []
 
 # Mesh Modifiers

--- a/test/tests/mesh_modifiers/add_side_sets/cylinder_normals_fixed.i
+++ b/test/tests/mesh_modifiers/add_side_sets/cylinder_normals_fixed.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = cylinder.e
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   distribution = serial
 []

--- a/test/tests/mesh_modifiers/add_side_sets/cylinder_normals_fixed.i
+++ b/test/tests/mesh_modifiers/add_side_sets/cylinder_normals_fixed.i
@@ -3,7 +3,7 @@
   file = cylinder.e
   # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
-  distribution = serial
+  parallel_type = replicated
 []
 
 # Mesh Modifiers

--- a/test/tests/mesh_modifiers/add_side_sets/cylinder_points.i
+++ b/test/tests/mesh_modifiers/add_side_sets/cylinder_points.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = cylinder.e
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   distribution = serial
 []

--- a/test/tests/mesh_modifiers/add_side_sets/cylinder_points.i
+++ b/test/tests/mesh_modifiers/add_side_sets/cylinder_points.i
@@ -3,7 +3,7 @@
   file = cylinder.e
   # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
-  distribution = serial
+  parallel_type = replicated
 []
 
 # Mesh Modifiers

--- a/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_inside_test.i
+++ b/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_inside_test.i
@@ -1,5 +1,5 @@
 [Mesh]
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   type = GeneratedMesh
   dim = 2

--- a/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_inside_test.i
+++ b/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_inside_test.i
@@ -5,7 +5,7 @@
   dim = 2
   nx = 2
   ny = 2
-  distribution = serial
+  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_outside_test.i
+++ b/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_outside_test.i
@@ -1,5 +1,5 @@
 [Mesh]
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   type = GeneratedMesh
   dim = 2

--- a/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_outside_test.i
+++ b/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_outside_test.i
@@ -5,7 +5,7 @@
   dim = 2
   nx = 2
   ny = 2
-  distribution = serial
+  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/modifier_depend_order/modifier_depend_order.i
+++ b/test/tests/mesh_modifiers/modifier_depend_order/modifier_depend_order.i
@@ -3,7 +3,7 @@
   file = square.e
   # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
-  distribution = serial
+  parallel_type = replicated
 []
 
 # Mesh Modifiers

--- a/test/tests/mesh_modifiers/modifier_depend_order/modifier_depend_order.i
+++ b/test/tests/mesh_modifiers/modifier_depend_order/modifier_depend_order.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = square.e
-  # This MeshModifier currently only works with SerialMesh.
+  # This MeshModifier currently only works with ReplicatedMesh.
   # For more information, refer to #2129.
   distribution = serial
 []

--- a/test/tests/misc/no_exodiff_map/no_exodiff_map.i
+++ b/test/tests/misc/no_exodiff_map/no_exodiff_map.i
@@ -1,7 +1,7 @@
 [Mesh]
   type = FileMesh
   file = double_square.e
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/multiapps/picard/picard_abs_tol_master.i
+++ b/test/tests/multiapps/picard/picard_abs_tol_master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/multiapps/picard/picard_master.i
+++ b/test/tests/multiapps/picard/picard_master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/multiapps/picard/picard_rel_tol_master.i
+++ b/test/tests/multiapps/picard/picard_rel_tol_master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/multiapps/picard_failure/picard_master.i
+++ b/test/tests/multiapps/picard_failure/picard_master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 2
   ny = 2
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/multiapps/picard_multilevel/picard_master.i
+++ b/test/tests/multiapps/picard_multilevel/picard_master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/multiapps/picard_sub_cycling/picard_master.i
+++ b/test/tests/multiapps/picard_sub_cycling/picard_master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/outputs/checkpoint/checkpoint.i
+++ b/test/tests/outputs/checkpoint/checkpoint.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/outputs/checkpoint/checkpoint_block.i
+++ b/test/tests/outputs/checkpoint/checkpoint_block.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/outputs/checkpoint/checkpoint_interval.i
+++ b/test/tests/outputs/checkpoint/checkpoint_interval.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/outputs/console/console_final.i
+++ b/test/tests/outputs/console/console_final.i
@@ -19,7 +19,7 @@
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
   # elements, if you use DistributedMesh the elements get renumbered.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/outputs/console/console_final.i
+++ b/test/tests/outputs/console/console_final.i
@@ -18,7 +18,7 @@
   ny = 10
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
-  # elements, if you use ParallelMesh the elements get renumbered.
+  # elements, if you use DistributedMesh the elements get renumbered.
   distribution = serial
 []
 

--- a/test/tests/outputs/csv/csv_transient.i
+++ b/test/tests/outputs/csv/csv_transient.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/outputs/iterative/iterative_vtk.i
+++ b/test/tests/outputs/iterative/iterative_vtk.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/outputs/variables/show_single_vars.i
+++ b/test/tests/outputs/variables/show_single_vars.i
@@ -10,7 +10,7 @@
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
   # elements, if you use DistributedMesh the elements get renumbered.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/outputs/variables/show_single_vars.i
+++ b/test/tests/outputs/variables/show_single_vars.i
@@ -9,7 +9,7 @@
   ny = 10
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
-  # elements, if you use ParallelMesh the elements get renumbered.
+  # elements, if you use DistributedMesh the elements get renumbered.
   distribution = serial
 []
 

--- a/test/tests/postprocessors/all_print_pps/all_print_pps_test.i
+++ b/test/tests/postprocessors/all_print_pps/all_print_pps_test.i
@@ -11,7 +11,7 @@
   # output strongly depends on the number of processors you run it on,
   # and, apparently, the type of Mesh.  To reduce this variability, we
   # limit it to run with ReplicatedMesh only.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/all_print_pps/all_print_pps_test.i
+++ b/test/tests/postprocessors/all_print_pps/all_print_pps_test.i
@@ -10,7 +10,7 @@
   # Since this test prints the number of residual evaluations, its
   # output strongly depends on the number of processors you run it on,
   # and, apparently, the type of Mesh.  To reduce this variability, we
-  # limit it to run with SerialMesh only.
+  # limit it to run with ReplicatedMesh only.
   distribution = serial
 []
 

--- a/test/tests/postprocessors/element_pps/elem_pps_multi_block_test.i
+++ b/test/tests/postprocessors/element_pps/elem_pps_multi_block_test.i
@@ -12,7 +12,7 @@
   ny = 3
   elem_type = QUAD4
   stripes = 3
-  # StripeMesh currently only works correctly with SerialMesh.
+  # StripeMesh currently only works correctly with ReplicatedMesh.
   distribution = serial
 []
 

--- a/test/tests/postprocessors/element_pps/elem_pps_multi_block_test.i
+++ b/test/tests/postprocessors/element_pps/elem_pps_multi_block_test.i
@@ -13,7 +13,7 @@
   elem_type = QUAD4
   stripes = 3
   # StripeMesh currently only works correctly with ReplicatedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/postprocessors/nodal_pps/nodal_extreme_pps_test.i
+++ b/test/tests/postprocessors/nodal_pps/nodal_extreme_pps_test.i
@@ -2,7 +2,7 @@
   type = FileMesh
   file = trapezoid.e
   uniform_refine = 1
-  # This test will not work in parallel with ParallelMesh enabled
+  # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
   distribution = serial
 []

--- a/test/tests/postprocessors/nodal_pps/nodal_extreme_pps_test.i
+++ b/test/tests/postprocessors/nodal_pps/nodal_extreme_pps_test.i
@@ -4,7 +4,7 @@
   uniform_refine = 1
   # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/postprocessors/nodal_pps/nodal_max_pps_test.i
+++ b/test/tests/postprocessors/nodal_pps/nodal_max_pps_test.i
@@ -3,7 +3,7 @@
   uniform_refine = 1
   # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/postprocessors/nodal_pps/nodal_max_pps_test.i
+++ b/test/tests/postprocessors/nodal_pps/nodal_max_pps_test.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = trapezoid.e
   uniform_refine = 1
-  # This test will not work in parallel with ParallelMesh enabled
+  # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
   distribution = serial
 []

--- a/test/tests/postprocessors/nodal_var_value/nodal_aux_var_value.i
+++ b/test/tests/postprocessors/nodal_var_value/nodal_aux_var_value.i
@@ -12,7 +12,7 @@
   # DistributedMesh, the nodes get renumbered and thus the
   # NodalVariableValue postprocessor's output is necessarily
   # different.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/nodal_var_value/nodal_aux_var_value.i
+++ b/test/tests/postprocessors/nodal_var_value/nodal_aux_var_value.i
@@ -8,7 +8,7 @@
   ymin = 0
   ymax = 1
   elem_type = QUAD4
-  # This test can only be run with SerialMesh since, in parallel with
+  # This test can only be run with ReplicatedMesh since, in parallel with
   # ParallelMesh, the nodes get renumbered and thus the
   # NodalVariableValue postprocessor's output is necessarily
   # different.

--- a/test/tests/postprocessors/nodal_var_value/nodal_aux_var_value.i
+++ b/test/tests/postprocessors/nodal_var_value/nodal_aux_var_value.i
@@ -9,7 +9,7 @@
   ymax = 1
   elem_type = QUAD4
   # This test can only be run with ReplicatedMesh since, in parallel with
-  # ParallelMesh, the nodes get renumbered and thus the
+  # DistributedMesh, the nodes get renumbered and thus the
   # NodalVariableValue postprocessor's output is necessarily
   # different.
   distribution = serial

--- a/test/tests/postprocessors/nodal_var_value/nodal_var_value.i
+++ b/test/tests/postprocessors/nodal_var_value/nodal_var_value.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
-  # only works with SerialMesh
+  # only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/postprocessors/nodal_var_value/nodal_var_value.i
+++ b/test/tests/postprocessors/nodal_var_value/nodal_var_value.i
@@ -2,7 +2,7 @@
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
   # only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/nodal_var_value/pps_output_test.i
+++ b/test/tests/postprocessors/nodal_var_value/pps_output_test.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
-  # only works with SerialMesh
+  # only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/postprocessors/nodal_var_value/pps_output_test.i
+++ b/test/tests/postprocessors/nodal_var_value/pps_output_test.i
@@ -2,7 +2,7 @@
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
   # only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/nodal_var_value/screen_output_test.i
+++ b/test/tests/postprocessors/nodal_var_value/screen_output_test.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
-  # only works with SerialMesh
+  # only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/postprocessors/nodal_var_value/screen_output_test.i
+++ b/test/tests/postprocessors/nodal_var_value/screen_output_test.i
@@ -2,7 +2,7 @@
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
   # only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/pps_interval/pps_bad_interval2.i
+++ b/test/tests/postprocessors/pps_interval/pps_bad_interval2.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
-  # only works with SerialMesh
+  # only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/postprocessors/pps_interval/pps_bad_interval2.i
+++ b/test/tests/postprocessors/pps_interval/pps_bad_interval2.i
@@ -2,7 +2,7 @@
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
   # only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/pps_interval/pps_bad_interval3.i
+++ b/test/tests/postprocessors/pps_interval/pps_bad_interval3.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
-  # only works with SerialMesh
+  # only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/postprocessors/pps_interval/pps_bad_interval3.i
+++ b/test/tests/postprocessors/pps_interval/pps_bad_interval3.i
@@ -2,7 +2,7 @@
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
   # only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/pps_interval/pps_interval_mismatch.i
+++ b/test/tests/postprocessors/pps_interval/pps_interval_mismatch.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
-  # only works with SerialMesh
+  # only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/postprocessors/pps_interval/pps_interval_mismatch.i
+++ b/test/tests/postprocessors/pps_interval/pps_interval_mismatch.i
@@ -2,7 +2,7 @@
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
   # only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/pps_interval/pps_out_interval.i
+++ b/test/tests/postprocessors/pps_interval/pps_out_interval.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
-  # only works with SerialMesh
+  # only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/postprocessors/pps_interval/pps_out_interval.i
+++ b/test/tests/postprocessors/pps_interval/pps_out_interval.i
@@ -2,7 +2,7 @@
   file = square-2x2-nodeids.e
   # This test uses a NodalVariableValue postprocessor, which
   # only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/postprocessors/side_pps/side_pps_multi_bnd_test.i
+++ b/test/tests/postprocessors/side_pps/side_pps_multi_bnd_test.i
@@ -12,7 +12,7 @@
   ny = 3
   elem_type = QUAD4
   stripes = 3
-  # StripeMesh currently only works correctly with SerialMesh.
+  # StripeMesh currently only works correctly with ReplicatedMesh.
   distribution = serial
 []
 

--- a/test/tests/postprocessors/side_pps/side_pps_multi_bnd_test.i
+++ b/test/tests/postprocessors/side_pps/side_pps_multi_bnd_test.i
@@ -13,7 +13,7 @@
   elem_type = QUAD4
   stripes = 3
   # StripeMesh currently only works correctly with ReplicatedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/restart/restart/elem_part2.i
+++ b/test/tests/restart/restart/elem_part2.i
@@ -5,7 +5,7 @@
   file = elem_part1_out.e
   # This problem uses ExodusII_IO::copy_elemental_solution(), which only
   # works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/restart/restart/elem_part2.i
+++ b/test/tests/restart/restart/elem_part2.i
@@ -4,7 +4,7 @@
 [Mesh]
   file = elem_part1_out.e
   # This problem uses ExodusII_IO::copy_elemental_solution(), which only
-  # works with SerialMesh
+  # works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/restart/restart/part1.i
+++ b/test/tests/restart/restart/part1.i
@@ -10,7 +10,7 @@
   ymax = 1
   nx = 20
   ny = 20
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/restart/restart/part2.i
+++ b/test/tests/restart/restart/part2.i
@@ -1,6 +1,6 @@
 [Mesh]
   file = out_part1_cp/0005_mesh.cpr
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/restart/restart_diffusion/exodus_refined_refined_restart_2_test.i
+++ b/test/tests/restart/restart_diffusion/exodus_refined_refined_restart_2_test.i
@@ -3,7 +3,7 @@
   uniform_refine = 1
   # Restart relies on the ExodusII_IO::copy_nodal_solution()
   # functionality, which only works with ReplicatedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/restart/restart_diffusion/exodus_refined_refined_restart_2_test.i
+++ b/test/tests/restart/restart_diffusion/exodus_refined_refined_restart_2_test.i
@@ -2,7 +2,7 @@
   file = exodus_refined_restart_1.e
   uniform_refine = 1
   # Restart relies on the ExodusII_IO::copy_nodal_solution()
-  # functionality, which only works with SerialMesh.
+  # functionality, which only works with ReplicatedMesh.
   distribution = serial
 []
 

--- a/test/tests/restart/restart_diffusion/exodus_refined_restart_2_test.i
+++ b/test/tests/restart/restart_diffusion/exodus_refined_restart_2_test.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = exodus_refined_restart_1.e
   # Restart relies on the ExodusII_IO::copy_nodal_solution()
-  # functionality, which only works with SerialMesh.
+  # functionality, which only works with ReplicatedMesh.
   distribution = serial
 []
 

--- a/test/tests/restart/restart_diffusion/exodus_refined_restart_2_test.i
+++ b/test/tests/restart/restart_diffusion/exodus_refined_restart_2_test.i
@@ -2,7 +2,7 @@
   file = exodus_refined_restart_1.e
   # Restart relies on the ExodusII_IO::copy_nodal_solution()
   # functionality, which only works with ReplicatedMesh.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/3d_to_2d_dtk_interpolation/master.i
+++ b/test/tests/transfers/3d_to_2d_dtk_interpolation/master.i
@@ -4,7 +4,7 @@
   nx = 4
   ny = 4
   nz = 4
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/3d_to_2d_dtk_interpolation/sub.i
+++ b/test/tests/transfers/3d_to_2d_dtk_interpolation/sub.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 4
   ny = 4
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/from_full_solve/master.i
+++ b/test/tests/transfers/from_full_solve/master.i
@@ -6,7 +6,7 @@
   # This test currently diffs when run in parallel with DistributedMesh enabled,
   # most likely due to the fact that CONSTANT MONOMIALS are currently not written
   # out correctly in this case.  For more information, see #2122.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/from_full_solve/master.i
+++ b/test/tests/transfers/from_full_solve/master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  # This test currently diffs when run in parallel with ParallelMesh enabled,
+  # This test currently diffs when run in parallel with DistributedMesh enabled,
   # most likely due to the fact that CONSTANT MONOMIALS are currently not written
   # out correctly in this case.  For more information, see #2122.
   distribution = serial

--- a/test/tests/transfers/multiapp_dtk_interpolation_transfer/master.i
+++ b/test/tests/transfers/multiapp_dtk_interpolation_transfer/master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_dtk_interpolation_transfer/multilevel_master.i
+++ b/test/tests/transfers/multiapp_dtk_interpolation_transfer/multilevel_master.i
@@ -5,7 +5,7 @@
   ny = 32
   xmax = 16
   ymax = 16
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_dtk_interpolation_transfer/multilevel_sub.i
+++ b/test/tests/transfers/multiapp_dtk_interpolation_transfer/multilevel_sub.i
@@ -5,7 +5,7 @@
   ny = 8
   xmax = 4
   ymax = 4
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_dtk_interpolation_transfer/multilevel_subsub.i
+++ b/test/tests/transfers/multiapp_dtk_interpolation_transfer/multilevel_subsub.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 2
   ny = 2
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_dtk_interpolation_transfer/sub.i
+++ b/test/tests/transfers/multiapp_dtk_interpolation_transfer/sub.i
@@ -5,7 +5,7 @@
   ny = 10
   xmax = 0.2
   ymax = 0.2
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_dtk_interpolation_transfer/tosub_master.i
+++ b/test/tests/transfers/multiapp_dtk_interpolation_transfer/tosub_master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_dtk_interpolation_transfer/tosub_sub.i
+++ b/test/tests/transfers/multiapp_dtk_interpolation_transfer/tosub_sub.i
@@ -5,7 +5,7 @@
   ny = 10
   xmax = 0.2
   ymax = 0.2
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_dtk_userobject_transfer/master.i
+++ b/test/tests/transfers/multiapp_dtk_userobject_transfer/master.i
@@ -4,7 +4,7 @@
   nx = 20
   ny = 20
   nz = 20
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_dtk_userobject_transfer/sub.i
+++ b/test/tests/transfers/multiapp_dtk_userobject_transfer/sub.i
@@ -5,7 +5,7 @@
   ny = 8
   xmax = 0.1
   ymax = 0.5
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_interpolation_transfer/fromsub_master.i
+++ b/test/tests/transfers/multiapp_interpolation_transfer/fromsub_master.i
@@ -14,7 +14,7 @@
   nx = 10
   ny = 10
   displacements = 'disp_x disp_y'
-  # The MultiAppInterpolationTransfer object only works with SerialMesh
+  # The MultiAppInterpolationTransfer object only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/transfers/multiapp_interpolation_transfer/fromsub_master.i
+++ b/test/tests/transfers/multiapp_interpolation_transfer/fromsub_master.i
@@ -15,7 +15,7 @@
   ny = 10
   displacements = 'disp_x disp_y'
   # The MultiAppInterpolationTransfer object only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_interpolation_transfer/tosub_master.i
+++ b/test/tests/transfers/multiapp_interpolation_transfer/tosub_master.i
@@ -16,7 +16,7 @@
   xmin = .21
   xmax = .79
   displacements = 'disp_x disp_y'
-  # The MultiAppInterpolationTransfer object only works with SerialMesh
+  # The MultiAppInterpolationTransfer object only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/transfers/multiapp_interpolation_transfer/tosub_master.i
+++ b/test/tests/transfers/multiapp_interpolation_transfer/tosub_master.i
@@ -17,7 +17,7 @@
   xmax = .79
   displacements = 'disp_x disp_y'
   # The MultiAppInterpolationTransfer object only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_userobject_transfer/master.i
+++ b/test/tests/transfers/multiapp_userobject_transfer/master.i
@@ -5,7 +5,7 @@
   ny = 20
   nz = 20
   # The MultiAppUserObjectTransfer object only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_userobject_transfer/master.i
+++ b/test/tests/transfers/multiapp_userobject_transfer/master.i
@@ -4,7 +4,7 @@
   nx = 20
   ny = 20
   nz = 20
-  # The MultiAppUserObjectTransfer object only works with SerialMesh
+  # The MultiAppUserObjectTransfer object only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/transfers/multiapp_userobject_transfer/tosub_displaced_master.i
+++ b/test/tests/transfers/multiapp_userobject_transfer/tosub_displaced_master.i
@@ -5,7 +5,7 @@
   ny = 20
   nz = 20
   # The MultiAppUserObjectTransfer object only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_userobject_transfer/tosub_displaced_master.i
+++ b/test/tests/transfers/multiapp_userobject_transfer/tosub_displaced_master.i
@@ -4,7 +4,7 @@
   nx = 20
   ny = 20
   nz = 20
-  # The MultiAppUserObjectTransfer object only works with SerialMesh
+  # The MultiAppUserObjectTransfer object only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/transfers/multiapp_userobject_transfer/tosub_master.i
+++ b/test/tests/transfers/multiapp_userobject_transfer/tosub_master.i
@@ -5,7 +5,7 @@
   ny = 20
   nz = 20
   # The MultiAppUserObjectTransfer object only works with ReplicatedMesh
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_userobject_transfer/tosub_master.i
+++ b/test/tests/transfers/multiapp_userobject_transfer/tosub_master.i
@@ -4,7 +4,7 @@
   nx = 20
   ny = 20
   nz = 20
-  # The MultiAppUserObjectTransfer object only works with SerialMesh
+  # The MultiAppUserObjectTransfer object only works with ReplicatedMesh
   distribution = serial
 []
 

--- a/test/tests/transfers/transfer_interpolation/master.i
+++ b/test/tests/transfers/transfer_interpolation/master.i
@@ -6,7 +6,7 @@
   # This test currently diffs when run in parallel with DistributedMesh enabled,
   # most likely due to the fact that it uses some geometric search stuff.
   # For more information, see #2121.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/transfer_interpolation/master.i
+++ b/test/tests/transfers/transfer_interpolation/master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  # This test currently diffs when run in parallel with ParallelMesh enabled,
+  # This test currently diffs when run in parallel with DistributedMesh enabled,
   # most likely due to the fact that it uses some geometric search stuff.
   # For more information, see #2121.
   distribution = serial

--- a/test/tests/transfers/transfer_with_reset/master.i
+++ b/test/tests/transfers/transfer_with_reset/master.i
@@ -6,7 +6,7 @@
   # This test currently diffs when run in parallel with DistributedMesh enabled,
   # most likely due to the fact that it uses some geometric search stuff.
   # For more information, see #2121.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/transfer_with_reset/master.i
+++ b/test/tests/transfers/transfer_with_reset/master.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  # This test currently diffs when run in parallel with ParallelMesh enabled,
+  # This test currently diffs when run in parallel with DistributedMesh enabled,
   # most likely due to the fact that it uses some geometric search stuff.
   # For more information, see #2121.
   distribution = serial

--- a/test/tests/utils/2d_linear_interpolation/2d_linear_interpolation_test.i
+++ b/test/tests/utils/2d_linear_interpolation/2d_linear_interpolation_test.i
@@ -101,7 +101,7 @@
   # This problem only has 1 element, so using DistributedMesh in parallel
   # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/utils/2d_linear_interpolation/2d_linear_interpolation_test.i
+++ b/test/tests/utils/2d_linear_interpolation/2d_linear_interpolation_test.i
@@ -98,8 +98,8 @@
 #
 [Mesh]
   file = cube.e
-  # This problem only has 1 element, so using ParallelMesh in parallel
-  # isn't really an option, and we don't care that much about ParallelMesh
+  # This problem only has 1 element, so using DistributedMesh in parallel
+  # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
   distribution = serial
 []

--- a/test/tests/utils/2d_linear_interpolation/2d_linear_interpolation_test_internal.i
+++ b/test/tests/utils/2d_linear_interpolation/2d_linear_interpolation_test_internal.i
@@ -103,7 +103,7 @@
   # This problem only has 1 element, so using DistributedMesh in parallel
   # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/utils/2d_linear_interpolation/2d_linear_interpolation_test_internal.i
+++ b/test/tests/utils/2d_linear_interpolation/2d_linear_interpolation_test_internal.i
@@ -100,8 +100,8 @@
 #
 [Mesh]
   file = cube.e
-  # This problem only has 1 element, so using ParallelMesh in parallel
-  # isn't really an option, and we don't care that much about ParallelMesh
+  # This problem only has 1 element, so using DistributedMesh in parallel
+  # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
   distribution = serial
 []

--- a/test/tests/utils/2d_linear_interpolation/xyz_error.i
+++ b/test/tests/utils/2d_linear_interpolation/xyz_error.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = cube.e
-  # This problem only has 1 element, so using ParallelMesh in parallel
-  # isn't really an option, and we don't care that much about ParallelMesh
+  # This problem only has 1 element, so using DistributedMesh in parallel
+  # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
   distribution = serial
 []

--- a/test/tests/utils/2d_linear_interpolation/xyz_error.i
+++ b/test/tests/utils/2d_linear_interpolation/xyz_error.i
@@ -3,7 +3,7 @@
   # This problem only has 1 element, so using DistributedMesh in parallel
   # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/utils/random/random.i
+++ b/test/tests/utils/random/random.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = SERIAL
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/utils/random/random_material.i
+++ b/test/tests/utils/random/random_material.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = SERIAL
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/utils/random/random_uo.i
+++ b/test/tests/utils/random/random_uo.i
@@ -3,7 +3,7 @@
   dim = 2
   nx = 10
   ny = 10
-  distribution = SERIAL
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/utils/random/tests
+++ b/test/tests/utils/random/tests
@@ -33,7 +33,7 @@
     exodiff = 'parallel_mesh_out.e'
     min_parallel = 2
     max_parallel = 2
-    cli_args = 'Mesh/distribution=PARALLEL Outputs/file_base=parallel_mesh_out'
+    cli_args = 'Mesh/parallel_type=distributed Outputs/file_base=parallel_mesh_out'
     prereq = 'threads_verification'
   [../]
 
@@ -69,7 +69,7 @@
     exodiff = 'parallel_mesh_uo_out.e'
     min_parallel = 2
     max_parallel = 2
-    cli_args = 'Mesh/distribution=PARALLEL Outputs/file_base=parallel_mesh_uo_out'
+    cli_args = 'Mesh/parallel_type=distributed Outputs/file_base=parallel_mesh_uo_out'
     prereq = 'threads_verification_uo'
   [../]
 

--- a/test/tests/variables/block_aux_kernel/block_aux_kernel_test.i
+++ b/test/tests/variables/block_aux_kernel/block_aux_kernel_test.i
@@ -12,7 +12,7 @@
   file = gap_test.e
   # This test uses the geometric search system, which does not currently work
   # in parallel with DistributedMesh enabled.  For more information, see #2121.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/variables/block_aux_kernel/block_aux_kernel_test.i
+++ b/test/tests/variables/block_aux_kernel/block_aux_kernel_test.i
@@ -11,7 +11,7 @@
 [Mesh]
   file = gap_test.e
   # This test uses the geometric search system, which does not currently work
-  # in parallel with ParallelMesh enabled.  For more information, see #2121.
+  # in parallel with DistributedMesh enabled.  For more information, see #2121.
   distribution = serial
 []
 

--- a/test/tests/variables/curvilinear_element/curvilinear_element_test.i
+++ b/test/tests/variables/curvilinear_element/curvilinear_element_test.i
@@ -3,7 +3,7 @@
   # This mesh only has one element.  It does seem to work if you
   # use ReplicatedMesh on two processors, but it hangs with DistributedMesh
   # on two processors.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/variables/curvilinear_element/curvilinear_element_test.i
+++ b/test/tests/variables/curvilinear_element/curvilinear_element_test.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = curvi.e
   # This mesh only has one element.  It does seem to work if you
-  # use SerialMesh on two processors, but it hangs with ParallelMesh
+  # use ReplicatedMesh on two processors, but it hangs with ParallelMesh
   # on two processors.
   distribution = serial
 []

--- a/test/tests/variables/curvilinear_element/curvilinear_element_test.i
+++ b/test/tests/variables/curvilinear_element/curvilinear_element_test.i
@@ -1,7 +1,7 @@
 [Mesh]
   file = curvi.e
   # This mesh only has one element.  It does seem to work if you
-  # use ReplicatedMesh on two processors, but it hangs with ParallelMesh
+  # use ReplicatedMesh on two processors, but it hangs with DistributedMesh
   # on two processors.
   distribution = serial
 []

--- a/test/tests/variables/fe_hermite/hermite-3-3d.i
+++ b/test/tests/variables/fe_hermite/hermite-3-3d.i
@@ -14,7 +14,7 @@
   # This problem only has 1 element, so using DistributedMesh in parallel
   # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/variables/fe_hermite/hermite-3-3d.i
+++ b/test/tests/variables/fe_hermite/hermite-3-3d.i
@@ -11,8 +11,8 @@
   ny = 1
   nz = 1
   elem_type = HEX27
-  # This problem only has 1 element, so using ParallelMesh in parallel
-  # isn't really an option, and we don't care that much about ParallelMesh
+  # This problem only has 1 element, so using DistributedMesh in parallel
+  # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
   distribution = serial
 []

--- a/test/tests/variables/fe_hermite_convergence/hermite_converge_neumann.i
+++ b/test/tests/variables/fe_hermite_convergence/hermite_converge_neumann.i
@@ -8,7 +8,7 @@
   nx = 4
   ny = 4
   elem_type = QUAD4
-  # This test will not work in parallel with ParallelMesh enabled
+  # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
   distribution = serial
 []

--- a/test/tests/variables/fe_hermite_convergence/hermite_converge_neumann.i
+++ b/test/tests/variables/fe_hermite_convergence/hermite_converge_neumann.i
@@ -10,7 +10,7 @@
   elem_type = QUAD4
   # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/variables/fe_hermite_convergence/hermite_converge_periodic.i
+++ b/test/tests/variables/fe_hermite_convergence/hermite_converge_periodic.i
@@ -8,7 +8,7 @@
   nx = 4
   ny = 4
   elem_type = QUAD4
-  # This test will not work in parallel with ParallelMesh enabled
+  # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
   distribution = serial
 []

--- a/test/tests/variables/fe_hermite_convergence/hermite_converge_periodic.i
+++ b/test/tests/variables/fe_hermite_convergence/hermite_converge_periodic.i
@@ -10,7 +10,7 @@
   elem_type = QUAD4
   # This test will not work in parallel with DistributedMesh enabled
   # due to a bug in PeriodicBCs.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/variables/fe_hier/hier-2-3d.i
+++ b/test/tests/variables/fe_hier/hier-2-3d.i
@@ -14,7 +14,7 @@
   # This problem only has 1 element, so using DistributedMesh in parallel
   # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/variables/fe_hier/hier-2-3d.i
+++ b/test/tests/variables/fe_hier/hier-2-3d.i
@@ -11,8 +11,8 @@
   ny = 1
   nz = 1
   elem_type = HEX27
-  # This problem only has 1 element, so using ParallelMesh in parallel
-  # isn't really an option, and we don't care that much about ParallelMesh
+  # This problem only has 1 element, so using DistributedMesh in parallel
+  # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
   distribution = serial
 []

--- a/test/tests/variables/fe_hier/hier-3-3d.i
+++ b/test/tests/variables/fe_hier/hier-3-3d.i
@@ -14,7 +14,7 @@
   # This problem only has 1 element, so using DistributedMesh in parallel
   # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
-  distribution = serial
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/variables/fe_hier/hier-3-3d.i
+++ b/test/tests/variables/fe_hier/hier-3-3d.i
@@ -11,8 +11,8 @@
   ny = 1
   nz = 1
   elem_type = HEX27
-  # This problem only has 1 element, so using ParallelMesh in parallel
-  # isn't really an option, and we don't care that much about ParallelMesh
+  # This problem only has 1 element, so using DistributedMesh in parallel
+  # isn't really an option, and we don't care that much about DistributedMesh
   # in serial.
   distribution = serial
 []


### PR DESCRIPTION
to ReplicatedMesh and DistributedMesh, respectively.  Summary of changes include:
- Rename/deprecate various APIs that referred directly to `ParallelMesh`, e.g. `MooseMesh::isParallelMesh(), errorIfParallelDistribution(), getParallelMeshOnCommandLine()`, etc.
- Change the TestHarness to respect the command line option `--distributed-mesh` in addition to `--parallel-mesh`.
- Also changed the `[Mesh]` block `distribution` flag to `parallel_type`, so that instead of:

```
distribution = distributed
```

which is kind of awkward, one can say:

```
parallel_type = distributed
```

and 

```
parallel_type = replicated
```

as necessary.

Refs libMesh/libmesh#929.
