### PR TITLE
Removing shadowing member variable

### DIFF
--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -443,9 +443,6 @@ protected:
   // damping
   VariableValue _increment;
 
-  /// scaling factor for this variable
-  Real _scaling_factor;
-
   friend class NodeFaceConstraint;
   friend class ValueThresholdMarker;
   friend class ValueRangeMarker;


### PR DESCRIPTION
MooseVariable::_scaling_factor is shadowing
MooseVariableBase::_scaling_factor.  Luckily it is not used in
MooseVariable, so it does not break anything. The true scaling factor is
in the base class.

Closes #7065
