### PR TITLE
Begin moving Jacobian graph augmentation into the Constraints

### DIFF
--- a/framework/include/constraints/Constraint.h
+++ b/framework/include/constraints/Constraint.h
@@ -67,6 +67,14 @@ public:
 
   virtual bool addCouplingEntriesToJacobian() { return true; }
 
+  /**
+   * Constraints can override this to specify dof pairs that are linked by this
+   * Constraint in order to get storage for their derivatives pre-allocated in the Jacobian
+   *
+   * @param graph This links dof_row -> dof_columns.  The job of this routine is to add extra row->column linkages.
+   */
+  void augmentJacobianGraph(std::map<dof_id_type, std::vector<dof_id_type> > & graph) {}
+
 protected:
   SubProblem & _subproblem;
   SystemBase & _sys;

--- a/framework/include/constraints/ConstraintWarehouse.h
+++ b/framework/include/constraints/ConstraintWarehouse.h
@@ -50,6 +50,11 @@ public:
   const std::vector<MooseSharedPointer<NodeFaceConstraint> > & getActiveNodeFaceConstraints(BoundaryID boundary_id, bool displaced);
   ///@}
 
+  /**
+   * Accessor for the complete list of NodeFaceConstraints
+   */
+  std::vector<MooseSharedPointer<NodeFaceConstraint> > getAllNodeFaceConstraints(THREAD_ID tid = 0);
+
   ///@{
   /**
    * Deterimine if active objects exist.

--- a/framework/include/constraints/NodeFaceConstraint.h
+++ b/framework/include/constraints/NodeFaceConstraint.h
@@ -74,6 +74,14 @@ public:
   virtual void getConnectedDofIndices(unsigned int var_num);
 
   /**
+   * Constraints can override this to specify dof pairs that are linked by this
+   * Constraint in order to get storage for their derivatives pre-allocated in the Jacobian
+   *
+   * @param graph This links dof_row -> dof_columns.  The job of this routine is to add extra row->column linkages.
+   */
+  void augmentJacobianGraph(std::map<dof_id_type, std::vector<dof_id_type> > & graph);
+
+  /**
    * Compute the value the slave node should have at the beginning of a timestep.
    */
   virtual Real computeQpSlaveValue() = 0;

--- a/framework/src/constraints/ConstraintWarehouse.C
+++ b/framework/src/constraints/ConstraintWarehouse.C
@@ -101,6 +101,33 @@ ConstraintWarehouse::getActiveNodeFaceConstraints(BoundaryID boundary_id, bool d
   return it->second.getActiveObjects();
 }
 
+std::vector<MooseSharedPointer<NodeFaceConstraint> >
+ConstraintWarehouse::getAllNodeFaceConstraints(THREAD_ID tid)
+{
+  std::vector<MooseSharedPointer<NodeFaceConstraint> > all_constraints;
+
+  // Undisplaced
+  for (auto & boundary_warehouse_pair : _node_face_constraints)
+  {
+    auto & warehouse = boundary_warehouse_pair.second;
+
+    all_constraints.insert(all_constraints.end(),
+                           warehouse.getObjects(tid).begin(),
+                           warehouse.getObjects(tid).end());
+  }
+
+  // Displaced
+  for (auto & boundary_warehouse_pair : _displaced_node_face_constraints)
+  {
+    auto & warehouse = boundary_warehouse_pair.second;
+
+    all_constraints.insert(all_constraints.end(),
+                           warehouse.getObjects(tid).begin(),
+                           warehouse.getObjects(tid).end());
+  }
+
+  return all_constraints;
+}
 
 const std::vector<MooseSharedPointer<FaceFaceConstraint> > &
 ConstraintWarehouse::getActiveFaceFaceConstraints(const std::string & interface) const

--- a/test/tests/constraints/tied_value_constraint/tied_value_constraint_test.i
+++ b/test/tests/constraints/tied_value_constraint/tied_value_constraint_test.i
@@ -59,6 +59,10 @@
   [../]
 []
 
+[Problem]
+  error_on_jacobian_nonzero_reallocation=true
+[../]
+
 [Executioner]
   # l_tol = 1e-1
   # l_tol = 1e-
@@ -72,4 +76,3 @@
   file_base = out
   exodus = true
 []
-


### PR DESCRIPTION
Constraints have become MUCH more complicated than they originally were.  In the beginning (TM) there were basically only `NodeFaceConstraint`s.  Because of that the framework itself tried to handle Jacobian sparsity pattern augmentation by inferring coupled dofs from the geometric search system.

Now we have MANY different types of constraints... some of which don't use the geometric search system but still need to be able to augment the Jacobian sparsity pattern.  To handle this the augmentation needs to get moved to _inside_ the Constraint system.

I'm going to continue to grow this branch... but I wanted to start the testing early because the Constraints are complicated.  For now this is just setting things up and getting the NodeFaceConstraints working...

refs #7000
