### PR TITLE
Improving the check for libmesh submodule

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -67,7 +67,7 @@ moose_revision:
 	  $(moose_revision_header) MOOSE)
 
 # libmesh submodule status
-libmesh_status := $(shell git -C $(MOOSE_DIR) submodule status 2>/dev/null)
+libmesh_status := $(shell git -C $(MOOSE_DIR) submodule status 2>/dev/null | grep libmesh | cut -c1)
 ifneq (,$(findstring +,$(libmesh_status)))
   ifneq ($(origin MOOSE_DIR),environment)
     libmesh_message = "\n***WARNING***\nYour libmesh is out of date.\nYou need to run update_and_rebuild_libmesh.sh in the scripts directory.\n\n"


### PR DESCRIPTION
We need to look at the first character to determine if the submodule is
up to date or not.  Currently we were looking at the whole line.

Closes #7074
