### PR TITLE
Add missing prereq

### DIFF
--- a/test/tests/auxkernels/solution_aux/tests
+++ b/test/tests/auxkernels/solution_aux/tests
@@ -152,5 +152,6 @@
     input = 'thread_xda.i'
     csvdiff = 'thread_xda_out.csv'
     min_threads = 2
+    prereq = aux_nonlinear_solution_from_xda
   [../]
 []


### PR DESCRIPTION
The test added in 1d5bda7 didn't have the proper TestHarness prereq.

refs #7080

This should be merged in as soon as possible to avoid spurious fails as seen in https://www.moosebuild.org/job/25413/
