### PR TITLE
Fix const-correctness issues when getting Nodes from Elems

### DIFF
--- a/framework/include/geomsearch/FindContactPoint.h
+++ b/framework/include/geomsearch/FindContactPoint.h
@@ -36,7 +36,7 @@ findContactPoint(PenetrationInfo & p_info,
 void
 restrictPointToFace(Point& p,
                     const Elem* side,
-                    std::vector<Node*> &off_edge_nodes);
+                    std::vector<const Node *> & off_edge_nodes);
 
 }
 

--- a/framework/include/geomsearch/PenetrationInfo.h
+++ b/framework/include/geomsearch/PenetrationInfo.h
@@ -36,7 +36,17 @@ class Elem;
 class PenetrationInfo
 {
 public:
-  PenetrationInfo(const Node * node, const Elem * elem, Elem * side, unsigned int side_num, RealVectorValue norm, Real norm_distance, Real tangential_distance, const Point & closest_point, const Point & closest_point_ref, const Point & closest_point_on_face_ref, std::vector<Node*> off_edge_nodes, const std::vector<std::vector<Real> > & side_phi, const std::vector<std::vector<RealGradient> > & side_grad_phi, const std::vector<RealGradient> & dxyzdxi, const std::vector<RealGradient> & dxyzdeta, const std::vector<RealGradient> & d2xyzdxideta);
+  PenetrationInfo(const Node * node, const Elem * elem, Elem * side,
+                  unsigned int side_num, RealVectorValue norm, Real norm_distance, Real tangential_distance,
+                  const Point & closest_point,
+                  const Point & closest_point_ref,
+                  const Point & closest_point_on_face_ref,
+                  std::vector<const Node *> off_edge_nodes,
+                  const std::vector<std::vector<Real> > & side_phi,
+                  const std::vector<std::vector<RealGradient> > & side_grad_phi,
+                  const std::vector<RealGradient> & dxyzdxi,
+                  const std::vector<RealGradient> & dxyzdeta,
+                  const std::vector<RealGradient> & d2xyzdxideta);
 
   PenetrationInfo(const PenetrationInfo & p);
 
@@ -67,7 +77,7 @@ public:
   Point _closest_point;
   Point _closest_point_ref;
   Point _closest_point_on_face_ref;
-  std::vector<Node*> _off_edge_nodes;
+  std::vector<const Node*> _off_edge_nodes;
   std::vector<std::vector<Real> > _side_phi;
   std::vector<std::vector<RealGradient> > _side_grad_phi;
   std::vector<RealGradient> _dxyzdxi;

--- a/framework/include/geomsearch/PenetrationThread.h
+++ b/framework/include/geomsearch/PenetrationThread.h
@@ -114,7 +114,7 @@ protected:
   bool
   findRidgeContactPoint(Point &contact_point,
                         Real & tangential_distance,
-                        Node* &closest_node,
+                        const Node * & closest_node,
                         unsigned int &index,
                         Point &contact_point_ref,
                         std::vector<PenetrationInfo*> &p_info,
@@ -127,12 +127,12 @@ protected:
 
   bool
   restrictPointToSpecifiedEdgeOfFace(Point& p,
-                                     Node* &closest_node,
+                                     const Node * & closest_node,
                                      const Elem* side,
                                      const std::vector<Node*> &edge_nodes);
   bool
   restrictPointToFace(Point& p,
-                      Node* &closest_node,
+                      const Node * & closest_node,
                       const Elem* side);
 
   bool
@@ -196,14 +196,14 @@ protected:
     Point _closest_coor;
     Point _closest_coor_ref;
     Real _tangential_distance;
-    Node* _closest_node;
+    const Node * _closest_node;
   };
 
   struct RidgeSetData
   {
     Real _distance;
     Point _closest_coor;
-    Node* _closest_node;
+    const Node * _closest_node;
     std::vector<RidgeData> _ridge_data_vec;
   };
 };

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -66,13 +66,13 @@ findContactPoint(PenetrationInfo & p_info,
 
   if (dim == 1)
   {
-    Node * left(master_elem->node_ptr(0));
-    Node * right(left);
-    Real leftCoor((*left)(0));
-    Real rightCoor(leftCoor);
-    for (unsigned i(1); i < master_elem->n_nodes(); ++i)
+    const Node * left = master_elem->node_ptr(0);
+    const Node * right = left;
+    Real leftCoor = (*left)(0);
+    Real rightCoor = leftCoor;
+    for (unsigned i = 1; i < master_elem->n_nodes(); ++i)
     {
-      Node * curr = master_elem->node_ptr(i);
+      const Node * curr = master_elem->node_ptr(i);
       Real coor = (*curr)(0);
       if (coor < leftCoor)
       {
@@ -85,7 +85,7 @@ findContactPoint(PenetrationInfo & p_info,
         rightCoor = coor;
       }
     }
-    Node * nearestNode(left);
+    const Node * nearestNode = left;
     Point nearestPoint(leftCoor, 0, 0);
     if (side->node(0) == right->id())
     {
@@ -270,7 +270,7 @@ findContactPoint(PenetrationInfo & p_info,
 
 void restrictPointToFace(Point& p,
                          const Elem* side,
-                         std::vector<Node*> &off_edge_nodes)
+                         std::vector<const Node *> & off_edge_nodes)
 {
   const ElemType t(side->type());
   off_edge_nodes.clear();

--- a/framework/src/geomsearch/PenetrationInfo.C
+++ b/framework/src/geomsearch/PenetrationInfo.C
@@ -25,8 +25,10 @@
 
 PenetrationInfo::PenetrationInfo(const Node * node, const Elem * elem, Elem * side, unsigned int side_num,
                                  RealVectorValue norm, Real norm_distance, Real tangential_distance,
-                                 const Point & closest_point, const Point & closest_point_ref, const Point & closest_point_on_face_ref,
-                                 std::vector<Node *> off_edge_nodes,
+                                 const Point & closest_point,
+                                 const Point & closest_point_ref,
+                                 const Point & closest_point_on_face_ref,
+                                 std::vector<const Node *> off_edge_nodes,
                                  const std::vector<std::vector<Real> > & side_phi,
                                  const std::vector<std::vector<RealGradient> > & side_grad_phi,
                                  const std::vector<RealGradient> & dxyzdxi,

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -214,7 +214,7 @@ PenetrationThread::operator() (const NodeIdRange & range)
           {
             Point closest_coor;
             Real tangential_distance(0.0);
-            Node* closest_node_on_ridge(NULL);
+            const Node * closest_node_on_ridge = NULL;
             unsigned int index=0;
             Point closest_coor_ref;
             bool found_ridge_contact_point = findRidgeContactPoint(closest_coor,
@@ -345,7 +345,7 @@ PenetrationThread::operator() (const NodeIdRange & range)
             }
             else
             { //peak
-              Node* closest_node_on_face;
+              const Node * closest_node_on_face;
               bool restricted = restrictPointToFace(p_info[face_index]->_closest_point_ref, closest_node_on_face, p_info[face_index]->_side);
               if (restricted)
               {
@@ -578,8 +578,8 @@ PenetrationThread::interactionsOffCommonEdge(PenetrationInfo * pi1,
                                              PenetrationInfo * pi2)
 {
   CommonEdgeResult common_edge(NO_COMMON);
-  const std::vector<Node*> &off_edge_nodes1(pi1->_off_edge_nodes);
-  const std::vector<Node*> &off_edge_nodes2(pi2->_off_edge_nodes);
+  const std::vector<const Node *> & off_edge_nodes1 = pi1->_off_edge_nodes;
+  const std::vector<const Node *> & off_edge_nodes2 = pi2->_off_edge_nodes;
   const unsigned dim1(pi1->_side->dim());
   const unsigned dim2(pi2->_side->dim());
 
@@ -632,7 +632,7 @@ PenetrationThread::interactionsOffCommonEdge(PenetrationInfo * pi1,
 bool
 PenetrationThread::findRidgeContactPoint(Point &contact_point,
                                          Real & tangential_distance,
-                                         Node* &closest_node,
+                                         const Node * & closest_node,
                                          unsigned int &index,
                                          Point &contact_point_ref,
                                          std::vector<PenetrationInfo*> &p_info,
@@ -666,12 +666,12 @@ PenetrationThread::findRidgeContactPoint(Point &contact_point,
 
   bool found_point1, found_point2;
   Point closest_coor_ref1(pi1->_closest_point_ref);
-  Node* closest_node1;
-  found_point1 = restrictPointToSpecifiedEdgeOfFace(closest_coor_ref1,closest_node1,pi1->_side,common_nodes);
+  const Node * closest_node1;
+  found_point1 = restrictPointToSpecifiedEdgeOfFace(closest_coor_ref1, closest_node1, pi1->_side, common_nodes);
 
   Point closest_coor_ref2(pi2->_closest_point_ref);
-  Node* closest_node2;
-  found_point2 = restrictPointToSpecifiedEdgeOfFace(closest_coor_ref2,closest_node2,pi2->_side,common_nodes);
+  const Node * closest_node2;
+  found_point2 = restrictPointToSpecifiedEdgeOfFace(closest_coor_ref2, closest_node2, pi2->_side, common_nodes);
 
   if (!found_point1 || !found_point2)
     return false;
@@ -768,7 +768,7 @@ PenetrationThread::getSideCornerNodes(Elem* side,
 
 bool
 PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
-                                                      Node* &closest_node,
+                                                      const Node * & closest_node,
                                                       const Elem* side,
                                                       const std::vector<Node*> &edge_nodes)
 {
@@ -947,7 +947,7 @@ PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point& p,
 
 bool
 PenetrationThread::restrictPointToFace(Point& p,
-                                       Node* &closest_node,
+                                       const Node * & closest_node,
                                        const Elem* side)
 {
   const ElemType t(side->type());
@@ -1675,7 +1675,7 @@ PenetrationThread::createInfoForElem(std::vector<PenetrationInfo*> &thisElemInfo
     Real tangential_distance = 0.;
     RealGradient normal;
     bool contact_point_on_side;
-    std::vector<Node*> off_edge_nodes;
+    std::vector<const Node *> off_edge_nodes;
     std::vector<std::vector<Real> > side_phi;
     std::vector<std::vector<RealGradient> > side_grad_phi;
     std::vector<RealGradient> dxyzdxi;


### PR DESCRIPTION
An upcoming libmesh PR will fix some const-correctness issues with `Elem::node_ptr()`.  The current implementation allows you to retrieve a non-const `Node *` from a `const Elem`, potentially allowing the Elem to be indirectly modified via the Node.  

There were only two places (MooseMesh and PenetrationLocator stuff) in the framework where we had const-correctness issues related to this, and they are fixed by this PR.  For the most part it was just adding const, but e.g. `MooseMesh::ghostGhostedBoundaries()` will need to be fixed again in the future, since it relies on different const-correctness weirdness in `Elem::family_tree()` that will be fixed by a libmesh update.

I also tested this with some of the bigger apps and didn't find any problems, going to let Civet test the rest of them for me...

Refs libMesh/libmesh#918.
