### PR TITLE
Loosen tolerance for 64-bit diff

### DIFF
--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
@@ -5,7 +5,7 @@
     csvdiff = 'ring3_glued_kin_check.csv ring3_glued_kin_check_cont_press_0001.csv ring3_glued_kin_check_x_disp_0001.csv'
     cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic Outputs/file_base=ring3_glued_kin_out Outputs/chkfile/file_base=ring3_glued_kin_check'
     rel_err = 1e-5
-    abs_zero = 1e-8
+    abs_zero = 1e-6
     max_parallel = 1
     superlu = true
   [../]


### PR DESCRIPTION
This test has several values that are essentially zero. They are
diffing under our 64-bit index build.

I have confirmed that this works on buildq10.

refs #7001
