### PR TITLE
Convert GrainTracker to C++11

### DIFF
--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -65,6 +65,12 @@ template<typename P>
 inline void storeHelper(std::ostream & stream, MooseSharedPointer<P> & data, void * context);
 
 /**
+ * Unique pointer helper routine
+ */
+template<typename P>
+inline void storeHelper(std::ostream & stream, std::unique_ptr<P> & data, void * context);
+
+/**
  * Set helper routine
  */
 template<typename P>
@@ -95,10 +101,16 @@ template<typename P>
 inline void loadHelper(std::istream & stream, std::vector<P> & data, void * context);
 
 /**
- * SharedPointer helper routine
+ * Shared Pointer helper routine
  */
 template<typename P>
 inline void loadHelper(std::istream & stream, MooseSharedPointer<P> & data, void * context);
+
+/**
+ * Unique Pointer helper routine
+ */
+template<typename P>
+inline void loadHelper(std::istream & stream, std::unique_ptr<P> & data, void * context);
 
 /**
  * Set helper routine
@@ -169,6 +181,15 @@ dataStore(std::ostream & stream, std::vector<T> & v, void * context)
 template<typename T>
 inline void
 dataStore(std::ostream & stream, MooseSharedPointer<T> & v, void * context)
+{
+  T * tmp = v.get();
+
+  storeHelper(stream, tmp, context);
+}
+
+template<typename T>
+inline void
+dataStore(std::ostream & stream, std::unique_ptr<T> & v, void * context)
 {
   T * tmp = v.get();
 
@@ -318,6 +339,15 @@ dataLoad(std::istream & stream, MooseSharedPointer<T> & v, void * context)
 
 template<typename T>
 inline void
+dataLoad(std::istream & stream, std::unique_ptr<T> & v, void * context)
+{
+  T * tmp = v.get();
+
+  loadHelper(stream, tmp, context);
+}
+
+template<typename T>
+inline void
 dataLoad(std::istream & stream, std::set<T> & s, void * context)
 {
   // First read the size of the set
@@ -427,6 +457,14 @@ storeHelper(std::ostream & stream, MooseSharedPointer<P> & data, void * context)
   dataStore(stream, data, context);
 }
 
+// std::unique Helper Function
+template<typename P>
+inline void
+storeHelper(std::ostream & stream, std::unique_ptr<P> & data, void * context)
+{
+  dataStore(stream, data, context);
+}
+
 // Set Helper Function
 template<typename P>
 inline void
@@ -471,6 +509,14 @@ loadHelper(std::istream & stream, std::vector<P> & data, void * context)
 template<typename P>
 inline void
 loadHelper(std::istream & stream, MooseSharedPointer<P> & data, void * context)
+{
+  dataLoad(stream, data, context);
+}
+
+// Unique Pointer Helper Function
+template<typename P>
+inline void
+loadHelper(std::istream & stream, std::unique_ptr<P> & data, void * context)
 {
   dataLoad(stream, data, context);
 }

--- a/modules/phase_field/include/postprocessors/FauxGrainTracker.h
+++ b/modules/phase_field/include/postprocessors/FauxGrainTracker.h
@@ -29,13 +29,10 @@ public:
   FauxGrainTracker(const InputParameters & parameters);
   virtual ~FauxGrainTracker();
 
-  virtual void initialize();
-
-  virtual void finalize();
-
-  virtual Real getValue();
-
-  virtual void execute();
+  virtual void initialize() override;
+  virtual void finalize() override;
+  virtual Real getValue() override;
+  virtual void execute() override;
 
   /**
    * Accessor for retrieving either nodal or elemental information (unique grains or variable indicies)
@@ -44,14 +41,14 @@ public:
    * @param show_var_coloring pass true to view variable index for a region, false for unique grain information
    * @return the entity value
    */
-  virtual Real getEntityValue(dof_id_type entity_id, FeatureFloodCount::FIELD_TYPE field_type, unsigned int var_idx) const;
+  virtual Real getEntityValue(dof_id_type entity_id, FeatureFloodCount::FIELD_TYPE field_type, unsigned int var_idx) const override;
 
   /**
    * Returns a list of active unique grains for a particular elem based on the node numbering.  The outer vector
    * holds the ith node with the inner vector holds the list of active unique grains.
    * (unique_grain_id, variable_idx)
    */
-  virtual const std::vector<std::pair<unsigned int, unsigned int> > & getElementalValues(dof_id_type elem_id) const;
+  virtual const std::vector<std::pair<unsigned int, unsigned int> > & getElementalValues(dof_id_type elem_id) const override;
 
 private:
   /// The mapping of entities to grains, in this case always the order parameter

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -310,7 +310,7 @@ protected:
    * The data structure used to hold the globally unique features. The outer vector
    * is indexed by variable number, the inner vector is indexed by feature number
    */
-  std::vector<std::vector<MooseSharedPointer<FeatureData> > > _feature_sets;
+  std::vector<std::vector<std::unique_ptr<FeatureData> > > _feature_sets;
 
   /**
    * The feature maps contain the raw flooded node information and eventually the unique grain numbers.  We have a vector

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -47,10 +47,10 @@ public:
   FeatureFloodCount(const InputParameters & parameters);
   ~FeatureFloodCount();
 
-  virtual void initialize();
-  virtual void execute();
-  virtual void finalize();
-  virtual Real getValue();
+  virtual void initialize() override;
+  virtual void execute() override;
+  virtual void finalize() override;
+  virtual Real getValue() override;
 
   enum FIELD_TYPE
   {
@@ -377,8 +377,8 @@ FeatureFloodCount::writeCSVFile(const std::string file_name, const std::vector<T
 {
   if (processor_id() == 0)
   {
-    // typdef makes subsequent code easier to read...
-    typedef std::map<std::string, MooseSharedPointer<std::ofstream> >::iterator iterator_t;
+    // alias declaration
+    using iterator_t = std::map<std::string, MooseSharedPointer<std::ofstream> >::iterator;
 
     // Try to find the filename
     iterator_t handle_it = _file_handles.find(file_name);

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -153,11 +153,11 @@ protected:
    * for a new region to mark, otherwise we are in the recursive calls
    * currently marking a region.
    */
-  void flood(const DofObject * dof_object, int current_idx, FeatureData * feature);
+  void flood(const DofObject * dof_object, unsigned long current_idx, FeatureData * feature);
 
   // TODO: doco
-  void visitElementalNeighbors(const Elem * elem, int current_idx, FeatureData * feature, bool recurse);
-  void visitNodalNeighbors(const Node * elem, int current_idx, FeatureData * feature, bool recurse);
+  void visitElementalNeighbors(const Elem * elem, unsigned long current_idx, FeatureData * feature, bool recurse);
+  void visitNodalNeighbors(const Node * elem, unsigned long current_idx, FeatureData * feature, bool recurse);
 
   /**
    * This routine uses the local flooded data to build up the local feature data structures (_feature_sets).
@@ -256,7 +256,7 @@ protected:
    * Assumption: We are going to assume that either all variables are periodic or none are.
    *             This assumption can be relaxed at a later time if necessary.
    */
-  unsigned int _var_number;
+  unsigned long _var_number;
 
   /// This variable is used to indicate whether or not multiple maps are used during flooding
   const bool _single_map_mode;
@@ -276,8 +276,14 @@ protected:
    */
   const bool _use_less_than_threshold_comparison;
 
-  /// Convienence variable holding the size of all the datastructures size by the number of maps
-  const unsigned int _maps_size;
+  // Convenience variable holding the number of variables coupled into this object
+  const unsigned long _n_vars;
+
+  /// Convenience variable holding the size of all the datastructures size by the number of maps
+  const unsigned long _maps_size;
+
+  /// Convenience variable holding the number of processors in this simulation
+  const processor_id_type _n_procs;
 
   /**
    * This variable keeps track of which nodes have been visited during execution.  We don't use the _feature_map
@@ -337,7 +343,7 @@ protected:
 
   /**
    * The filename and filehandle used if bubble volumes are being recorded to a file.
-   * MooseSharedPointer is used so we don't have to worry about cleaning up after ourselves...
+   * std::unique_ptr is used so we don't have to worry about cleaning up after ourselves...
    */
   std::map<std::string, std::unique_ptr<std::ofstream> > _file_handles;
 
@@ -377,11 +383,8 @@ FeatureFloodCount::writeCSVFile(const std::string file_name, const std::vector<T
 {
   if (processor_id() == 0)
   {
-    // alias declaration
-    using iterator_t = std::map<std::string, std::unique_ptr<std::ofstream> >::iterator;
-
     // Try to find the filename
-    iterator_t handle_it = _file_handles.find(file_name);
+    auto handle_it = _file_handles.find(file_name);
 
     // If the file_handle isn't found, create it
     if (handle_it == _file_handles.end())
@@ -389,8 +392,7 @@ FeatureFloodCount::writeCSVFile(const std::string file_name, const std::vector<T
       MooseUtils::checkFileWriteable(file_name);
 
       // Store the new filename in the map
-      std::pair<iterator_t, bool> result =
-        _file_handles.insert(std::make_pair(file_name, std::unique_ptr<std::ofstream>(new std::ofstream(file_name.c_str()))));
+      auto result = _file_handles.insert(std::make_pair(file_name, std::unique_ptr<std::ofstream>(new std::ofstream(file_name.c_str()))));
 
       // Be sure that the insert worked!
       mooseAssert(result.second, "Insertion into _file_handles map failed!");
@@ -413,11 +415,11 @@ FeatureFloodCount::writeCSVFile(const std::string file_name, const std::vector<T
 }
 
 template<> void dataStore(std::ostream & stream, FeatureFloodCount::FeatureData & feature, void * context);
-template<> void dataStore(std::ostream & stream, MooseSharedPointer<FeatureFloodCount::FeatureData> & feature, void * context);
+template<> void dataStore(std::ostream & stream, std::unique_ptr<FeatureFloodCount::FeatureData> & feature, void * context);
 template<> void dataStore(std::ostream & stream, MeshTools::BoundingBox & bbox, void * context);
 
 template<> void dataLoad(std::istream & stream, FeatureFloodCount::FeatureData & feature, void * context);
-template<> void dataLoad(std::istream & stream, MooseSharedPointer<FeatureFloodCount::FeatureData> & feature, void * context);
+template<> void dataLoad(std::istream & stream, std::unique_ptr<FeatureFloodCount::FeatureData> & feature, void * context);
 template<> void dataLoad(std::istream & stream, MeshTools::BoundingBox & bbox, void * context);
 
 

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -339,7 +339,7 @@ protected:
    * The filename and filehandle used if bubble volumes are being recorded to a file.
    * MooseSharedPointer is used so we don't have to worry about cleaning up after ourselves...
    */
-  std::map<std::string, MooseSharedPointer<std::ofstream> > _file_handles;
+  std::map<std::string, std::unique_ptr<std::ofstream> > _file_handles;
 
   /**
    * The vector hold the volume of each flooded bubble.  Note: this vector is only populated
@@ -378,7 +378,7 @@ FeatureFloodCount::writeCSVFile(const std::string file_name, const std::vector<T
   if (processor_id() == 0)
   {
     // alias declaration
-    using iterator_t = std::map<std::string, MooseSharedPointer<std::ofstream> >::iterator;
+    using iterator_t = std::map<std::string, std::unique_ptr<std::ofstream> >::iterator;
 
     // Try to find the filename
     iterator_t handle_it = _file_handles.find(file_name);
@@ -390,7 +390,7 @@ FeatureFloodCount::writeCSVFile(const std::string file_name, const std::vector<T
 
       // Store the new filename in the map
       std::pair<iterator_t, bool> result =
-        _file_handles.insert(std::make_pair(file_name, MooseSharedPointer<std::ofstream>(new std::ofstream(file_name.c_str()))));
+        _file_handles.insert(std::make_pair(file_name, std::unique_ptr<std::ofstream>(new std::ofstream(file_name.c_str()))));
 
       // Be sure that the insert worked!
       mooseAssert(result.second, "Insertion into _file_handles map failed!");

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -89,19 +89,19 @@ protected:
    * for a given grain. There are _vars.size() entries in the outer vector, one for each order parameter.
    * A list of grains with the same OP are ordered in lists per OP.
    */
-  void computeMinDistancesFromGrain(MooseSharedPointer<FeatureData> grain, std::vector<std::list<GrainDistance> > & min_distances);
+  void computeMinDistancesFromGrain(FeatureData & grain, std::vector<std::list<GrainDistance> > & min_distances);
 
   /**
    * This is the recursive part of the remapping algorithm. It attempts to remap a grain to a new index and recurses until max_depth
    * is reached.
    */
-  bool attemptGrainRenumber(MooseSharedPointer<FeatureData> grain, unsigned int grain_idx, unsigned int depth, unsigned int max);
+  bool attemptGrainRenumber(FeatureData & grain, unsigned int grain_idx, unsigned int depth, unsigned int max);
 
   /**
    * A routine for moving all of the solution values from a given grain to a new variable number. It is called
    * with different modes to only cache, or actually do the work, or bypass the cache altogether.
    */
-  void swapSolutionValues(MooseSharedPointer<FeatureData> grain, unsigned int var_idx, std::map<Node *, CacheValues> & cache,
+  void swapSolutionValues(FeatureData &  grain, unsigned int var_idx, std::map<Node *, CacheValues> & cache,
                           REMAP_CACHE_MODE cache_mode, unsigned int depth);
 
   /**
@@ -146,7 +146,7 @@ protected:
   NonlinearSystem & _nl;
 
   /// This data structure holds the map of unique grains.  The information is updated each timestep to track grains over time.
-  std::map<unsigned int, MooseSharedPointer<FeatureData> > & _unique_grains;
+  std::map<unsigned int, std::unique_ptr<FeatureData> > & _unique_grains;
 
   /**
    * This data structure holds unique grain to EBSD data map information. It's possible when using 2D scans of 3D microstructures

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -184,12 +184,4 @@ struct GrainDistance
   unsigned int _var_index;
 };
 
-/**
- * GrainDistance sort functor
- */
-struct GrainDistanceSorter
-{
-  bool operator()(const std::list<GrainDistance> & lhs, const std::list<GrainDistance> & rhs) const;
-};
-
 #endif

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -28,11 +28,9 @@ public:
   GrainTracker(const InputParameters & parameters);
   virtual ~GrainTracker();
 
-  virtual void initialize();
-
-  virtual void execute();
-
-  virtual void finalize();
+  virtual void initialize() override;
+  virtual void execute() override;
+  virtual void finalize() override;
 
   struct CacheValues
   {
@@ -55,18 +53,17 @@ public:
    * @param show_var_coloring pass true to view variable index for a region, false for unique grain information
    * @return the nodal value
    */
-  virtual Real getEntityValue(dof_id_type node_id, FIELD_TYPE field_type, unsigned int var_idx=0) const;
+  virtual Real getEntityValue(dof_id_type node_id, FIELD_TYPE field_type, unsigned int var_idx=0) const override;
 
   /**
    * Returns a list of active unique grains for a particular elem based on the node numbering.  The outer vector
    * holds the ith node with the inner vector holds the list of active unique grains.
    * (unique_grain_id, variable_idx)
    */
-  virtual const std::vector<std::pair<unsigned int, unsigned int> > & getElementalValues(dof_id_type elem_id) const;
+  virtual const std::vector<std::pair<unsigned int, unsigned int> > & getElementalValues(dof_id_type elem_id) const override;
 
 protected:
-  /// This routine is called at the of finalize to update the field data
-  virtual void updateFieldInfo();
+  virtual void updateFieldInfo() override;
 
   /**
    * This method serves two purposes:
@@ -127,7 +124,7 @@ protected:
   /**
    * Calculate the volume of each grain maintaining proper order and dumping results to CSV
    */
-  virtual void calculateBubbleVolumes();
+  virtual void calculateBubbleVolumes() override;
 
   /*************************************************
    *************** Data Structures *****************

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -111,10 +111,15 @@ protected:
                                 REMAP_CACHE_MODE cache_mode);
 
   /**
-   * This method returns the periodic distance between two bounding boxes.  If use_centroids_only is true, then the distance will be between the two
-   * bounding box centers.  If ignore_radii is false, then the distance will be -1 or 1 depending on whether the intersect or not (respectively).
+   * This method returns the minimum periodic distance between two vectors of bounding boxes. If the bounding boxes overlap
+   * the result is always -1.0.
    */
-  Real boundingRegionDistance(std::vector<MeshTools::BoundingBox> & bboxes1, std::vector<MeshTools::BoundingBox> bboxes2, bool use_centroids_only) const;
+  Real boundingRegionDistance(std::vector<MeshTools::BoundingBox> & bboxes1, std::vector<MeshTools::BoundingBox> bboxes2) const;
+
+  /**
+   * This method returns the minimum periodic distance between the centroids of two vectors of bounding boxes.
+   */
+  Real centroidRegionDistance(std::vector<MeshTools::BoundingBox> & bboxes1, std::vector<MeshTools::BoundingBox> bboxes2) const;
 
   /**
    * This method colors neighbors of halo entries to expand the halo as desired for a given simulation.

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -574,7 +574,7 @@ FeatureFloodCount::mergeSets(bool use_periodic_boundary_info)
       {
         if (!feature._merged)
         {
-          _feature_sets[map_num].push_back(std::unique_ptr<FeatureData>(new FeatureData(feature)));
+          _feature_sets[map_num].emplace_back(std::unique_ptr<FeatureData>(new FeatureData(feature)));
           ++_feature_count;
         }
       }
@@ -693,7 +693,7 @@ FeatureFloodCount::flood(const DofObject * dof_object, unsigned long current_idx
 
   // New Feature (we need to create it and add it to our data structure)
   if (!feature)
-    _partial_feature_sets[rank][map_num].push_back(FeatureData(current_idx));
+    _partial_feature_sets[rank][map_num].emplace_back(current_idx);
 
   // Get a handle to the feature we will update (always the last feature in the data structure)
   feature = &_partial_feature_sets[rank][map_num].back();

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -38,7 +38,7 @@ void dataStore(std::ostream & stream, FeatureFloodCount::FeatureData & feature, 
 }
 
 template<>
-void dataStore(std::ostream & stream, MooseSharedPointer<FeatureFloodCount::FeatureData> & feature, void * context)
+void dataStore(std::ostream & stream, std::unique_ptr<FeatureFloodCount::FeatureData> & feature, void * context)
 {
   dataStore(stream, *feature, context);
 }
@@ -65,9 +65,9 @@ void dataLoad(std::istream & stream, FeatureFloodCount::FeatureData & feature, v
 }
 
 template<>
-void dataLoad(std::istream & stream, MooseSharedPointer<FeatureFloodCount::FeatureData> & feature, void * context)
+void dataLoad(std::istream & stream, std::unique_ptr<FeatureFloodCount::FeatureData> & feature, void * context)
 {
-  feature = MooseSharedPointer<FeatureFloodCount::FeatureData>(new FeatureFloodCount::FeatureData());
+  feature = std::unique_ptr<FeatureFloodCount::FeatureData>(new FeatureFloodCount::FeatureData());
 
   dataLoad(stream, *feature, context);
 }
@@ -576,7 +576,7 @@ FeatureFloodCount::mergeSets(bool use_periodic_boundary_info)
       {
         if (!feature._merged)
         {
-          _feature_sets[map_num].push_back(MooseSharedPointer<FeatureData>(std::make_shared<FeatureData>(feature)));
+          _feature_sets[map_num].push_back(std::unique_ptr<FeatureData>(new FeatureData(feature)));
           ++_feature_count;
         }
       }
@@ -605,7 +605,7 @@ FeatureFloodCount::updateFieldInfo()
      * sorted indices vector.
      */
     Moose::indirectSort(_feature_sets[map_num].begin(), _feature_sets[map_num].end(), index_vector,
-                        [](const MooseSharedPointer<FeatureData> & lhs, const MooseSharedPointer<FeatureData> & rhs)
+                        [](const std::unique_ptr<FeatureData> & lhs, const std::unique_ptr<FeatureData> & rhs)
                         {
                           return *lhs < *rhs;
                         });
@@ -879,9 +879,8 @@ FeatureFloodCount::calculateBubbleVolumes()
 
     for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
     {
-      std::vector<MooseSharedPointer<FeatureData> >::const_iterator
-        bubble_it = _feature_sets[map_num].begin(),
-        bubble_end = _feature_sets[map_num].end();
+      auto bubble_it = _feature_sets[map_num].cbegin();
+      auto bubble_end = _feature_sets[map_num].cend();
 
       for (unsigned int bubble_counter = 0; bubble_it != bubble_end; ++bubble_it, ++bubble_counter)
       {

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -131,7 +131,7 @@ FeatureFloodCount::FeatureFloodCount(const InputParameters & parameters) :
     _partial_feature_sets(_app.n_processors()),
     _feature_sets(_maps_size),
     _feature_maps(_maps_size),
-    _pbs(NULL),
+    _pbs(nullptr),
     _element_average_value(parameters.isParamValid("elem_avg_value") ? getPostprocessorValue("elem_avg_value") : _real_zero),
     _compute_boundary_intersecting_volume(getParam<bool>("compute_boundary_intersecting_volume")),
     _is_elemental(getParam<MooseEnum>("flood_entity_type") == "ELEMENTAL" ? true : false)
@@ -200,7 +200,7 @@ FeatureFloodCount::execute()
     if (_is_elemental)
     {
       for (unsigned int var_num = 0; var_num < _vars.size(); ++var_num)
-        flood(current_elem, var_num, NULL /* Designates inactive feature */);
+        flood(current_elem, var_num, nullptr /* Designates inactive feature */);
     }
     else
     {
@@ -210,7 +210,7 @@ FeatureFloodCount::execute()
         const Node * current_node = current_elem->get_node(i);
 
         for (unsigned int var_num = 0; var_num < _vars.size(); ++var_num)
-          flood(current_node, var_num, NULL /* Designates inactive feature */);
+          flood(current_node, var_num, nullptr /* Designates inactive feature */);
       }
     }
   }
@@ -251,7 +251,7 @@ void FeatureFloodCount::communicateAndMerge()
    * Each processor needs information from all other processors to create a complete
    * global feature map.
    */
-  _communicator.allgather_packed_range((void *)(NULL), send_buffers.begin(), send_buffers.end(),
+  _communicator.allgather_packed_range((void *)(nullptr), send_buffers.begin(), send_buffers.end(),
                                        std::back_inserter(recv_buffers));
 
   deserialize(recv_buffers);
@@ -656,7 +656,7 @@ FeatureFloodCount::updateFieldInfo()
 void
 FeatureFloodCount::flood(const DofObject * dof_object, int current_idx, FeatureData * feature)
 {
-  if (dof_object == NULL)
+  if (dof_object == nullptr)
     return;
 
   // Retrieve the id of the current entity

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -23,16 +23,6 @@
 #include <algorithm>
 #include <limits>
 
-// TODO: Replace this with something better that can handle MooseSharedPointer<T>
-template<typename T>
-struct DereferenceSorter
-{
-  bool operator()(const T & lhs, const T & rhs) const
-  {
-    return *lhs < *rhs;
-  }
-};
-
 template<>
 void dataStore(std::ostream & stream, FeatureFloodCount::FeatureData & feature, void * context)
 {
@@ -614,7 +604,11 @@ FeatureFloodCount::updateFieldInfo()
      * We use the "min_entity_id" inside each feature to assign it's position in the
      * sorted indices vector.
      */
-    Moose::indirectSort(_feature_sets[map_num].begin(), _feature_sets[map_num].end(), index_vector, DereferenceSorter<MooseSharedPointer<FeatureData> >());
+    Moose::indirectSort(_feature_sets[map_num].begin(), _feature_sets[map_num].end(), index_vector,
+                        [](const MooseSharedPointer<FeatureData> & lhs, const MooseSharedPointer<FeatureData> & rhs)
+                        {
+                          return *lhs < *rhs;
+                        });
 
     // Clear out the original markings since they aren't unique globally
     _feature_maps[map_num].clear();

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -119,16 +119,14 @@ GrainTracker::finalize()
 
   if (_compute_op_maps)
   {
-    for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::const_iterator grain_it = _unique_grains.begin();
-         grain_it != _unique_grains.end(); ++grain_it)
+    for (const auto & grain_kv : _unique_grains)
     {
-      if (grain_it->second->_status != INACTIVE)
+      if (grain_kv.second->_status != INACTIVE)
       {
-        std::set<dof_id_type>::const_iterator elem_it_end = grain_it->second->_local_ids.end();
-        for (std::set<dof_id_type>::const_iterator elem_it = grain_it->second->_local_ids.begin(); elem_it != elem_it_end; ++elem_it)
+        for (auto elem_id : grain_kv.second->_local_ids)
         {
-          mooseAssert(!_ebsd_reader || _unique_grain_to_ebsd_num.find(grain_it->first) != _unique_grain_to_ebsd_num.end(), "Bad mapping in unique_grain_to_ebsd_num");
-          _elemental_data[*elem_it].push_back(std::make_pair(_ebsd_reader ? _unique_grain_to_ebsd_num[grain_it->first] : grain_it->first, grain_it->second->_var_idx));
+          mooseAssert(!_ebsd_reader || _unique_grain_to_ebsd_num.find(grain_kv.first) != _unique_grain_to_ebsd_num.end(), "Bad mapping in unique_grain_to_ebsd_num");
+          _elemental_data[elem_id].push_back(std::make_pair(_ebsd_reader ? _unique_grain_to_ebsd_num[grain_kv.first] : grain_kv.first, grain_kv.second->_var_idx));
         }
       }
     }
@@ -140,7 +138,7 @@ GrainTracker::finalize()
 const std::vector<std::pair<unsigned int, unsigned int> > &
 GrainTracker::getElementalValues(dof_id_type elem_id) const
 {
-  const std::map<dof_id_type, std::vector<std::pair<unsigned int, unsigned int> > >::const_iterator pos = _elemental_data.find(elem_id);
+  const auto pos = _elemental_data.find(elem_id);
 
   if (pos != _elemental_data.end())
     return pos->second;
@@ -160,11 +158,8 @@ GrainTracker::expandHalos()
 
   for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
     for (processor_id_type rank = 0; rank < n_procs; ++rank)
-      for (std::vector<FeatureData>::iterator it = _partial_feature_sets[rank][map_num].begin();
-           it != _partial_feature_sets[rank][map_num].end(); ++it)
+      for (auto & feature : _partial_feature_sets[rank][map_num])
       {
-        FeatureData & feature = *it;
-
         for (unsigned int halo_level = 1; halo_level < _halo_level; ++halo_level)
         {
           /**
@@ -173,13 +168,12 @@ GrainTracker::expandHalos()
            */
           std::set<dof_id_type> orig_halo_ids(feature._halo_ids);
 
-          for (std::set<dof_id_type>::iterator entity_it = orig_halo_ids.begin();
-               entity_it != orig_halo_ids.end(); ++entity_it)
+          for (auto entity : orig_halo_ids)
           {
             if (_is_elemental)
-              visitElementalNeighbors(_mesh.elemPtr(*entity_it), feature._var_idx, &feature, /*recurse =*/false);
+              visitElementalNeighbors(_mesh.elemPtr(entity), feature._var_idx, &feature, /*recurse =*/false);
             else
-              visitNodalNeighbors(_mesh.nodePtr(*entity_it), feature._var_idx, &feature, /*recurse =*/false);
+              visitNodalNeighbors(_mesh.nodePtr(entity), feature._var_idx, &feature, /*recurse =*/false);
           }
         }
       }
@@ -194,13 +188,12 @@ GrainTracker::trackGrains()
 
   // Reset Status on active unique grains
   std::vector<unsigned int> map_sizes(_maps_size);
-  for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::iterator grain_it = _unique_grains.begin();
-       grain_it != _unique_grains.end(); ++grain_it)
+  for (auto & grain_kv : _unique_grains)
   {
-    if (grain_it->second->_status != INACTIVE)
+    if (grain_kv.second->_status != INACTIVE)
     {
-      grain_it->second->_status = NOT_MARKED;
-      map_sizes[grain_it->second->_var_idx]++;
+      grain_kv.second->_status = NOT_MARKED;
+      map_sizes[grain_kv.second->_var_idx]++;
     }
   }
 
@@ -310,12 +303,12 @@ GrainTracker::trackGrains()
 
       if (!error_indices.empty())
       {
-        for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::const_iterator grain_it = _unique_grains.begin(); grain_it != _unique_grains.end(); ++grain_it)
-          Moose::out << "Grain " << grain_it->first << ": " << center_points[grain_it->first] << '\n';
+        for (const auto & grain_kv : _unique_grains)
+          Moose::out << "Grain " << grain_kv.first << ": " << center_points[grain_kv.first] << '\n';
 
         Moose::out << "Error Indices:\n";
-        for (std::map<unsigned int, unsigned int>::const_iterator it = error_indices.begin(); it != error_indices.end(); ++it)
-          Moose::out << "Grain " << it->first << '(' << it->second << ')' << ": " << center_points[it->second] << '\n';
+        for (const auto & error_kv : error_indices)
+          Moose::out << "Grain " << error_kv.first << '(' << error_kv.second << ')' << ": " << center_points[error_kv.second] << '\n';
 
         mooseError("Error with ESBD Mapping (see above unused indices)");
       }
@@ -326,7 +319,7 @@ GrainTracker::trackGrains()
       for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
         for (unsigned int feature_num = 0; feature_num < _feature_sets[map_num].size(); ++feature_num)
         {
-          MooseSharedPointer<FeatureData> feature_ptr = _feature_sets[map_num][feature_num];
+          auto feature_ptr = _feature_sets[map_num][feature_num];
 
           feature_ptr->_status = MARKED;
           _unique_grains[counter++] = feature_ptr;
@@ -342,9 +335,9 @@ GrainTracker::trackGrains()
    */
   std::map<std::pair<unsigned int, unsigned int>, std::vector<unsigned int> > new_grain_idx_to_existing_grain_idx;
 
-  for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::iterator curr_it = _unique_grains.begin(); curr_it != _unique_grains.end(); ++curr_it)
+  for (auto & grain_kv : _unique_grains)
   {
-    if (curr_it->second->_status == INACTIVE)                         // Don't try to find matches for inactive grains
+    if (grain_kv.second->_status == INACTIVE)                         // Don't try to find matches for inactive grains
       continue;
 
     unsigned int closest_match_idx;
@@ -352,12 +345,12 @@ GrainTracker::trackGrains()
     Real min_centroid_diff = std::numeric_limits<Real>::max();
 
     // We only need to examine grains that have matching variable indices
-    unsigned int map_idx = _single_map_mode ? 0 : curr_it->second->_var_idx;
+    unsigned int map_idx = _single_map_mode ? 0 : grain_kv.second->_var_idx;
     for (unsigned int new_grain_idx = 0; new_grain_idx < _feature_sets[map_idx].size(); ++new_grain_idx)
     {
-      if (curr_it->second->_var_idx == _feature_sets[map_idx][new_grain_idx]->_var_idx)  // Do the variables indicies match?
+      if (grain_kv.second->_var_idx == _feature_sets[map_idx][new_grain_idx]->_var_idx)  // Do the variables indicies match?
       {
-        Real curr_centroid_diff = boundingRegionDistance(curr_it->second->_bboxes, _feature_sets[map_idx][new_grain_idx]->_bboxes, true);
+        Real curr_centroid_diff = boundingRegionDistance(grain_kv.second->_bboxes, _feature_sets[map_idx][new_grain_idx]->_bboxes, true);
         if (curr_centroid_diff <= min_centroid_diff)
         {
           found_one = true;
@@ -369,7 +362,7 @@ GrainTracker::trackGrains()
 
     if (found_one)
       // Keep track of which new grains the existing ones want to map to
-      new_grain_idx_to_existing_grain_idx[std::make_pair(map_idx, closest_match_idx)].push_back(curr_it->first);
+      new_grain_idx_to_existing_grain_idx[std::make_pair(map_idx, closest_match_idx)].push_back(grain_kv.first);
   }
 
   /**
@@ -377,16 +370,15 @@ GrainTracker::trackGrains()
    * new_grain_idx_to_existing_grain_idx data structure).  This will happen any time a grain disappears during
    * this time step. We need to figure out the rightful owner in this case and inactivate the old grain.
    */
-  for (std::map<std::pair<unsigned int, unsigned int>, std::vector<unsigned int> >::iterator it = new_grain_idx_to_existing_grain_idx.begin();
-       it != new_grain_idx_to_existing_grain_idx.end(); ++it)
+  for (const auto & new_to_exist_kv : new_grain_idx_to_existing_grain_idx)
   {
                                                                 // map index     feature index
-    MooseSharedPointer<FeatureData> feature_ptr = _feature_sets[it->first.first][it->first.second];
+    MooseSharedPointer<FeatureData> feature_ptr = _feature_sets[new_to_exist_kv.first.first][new_to_exist_kv.first.second];
 
     // If there is only a single mapping - we've found the correct grain
-    if (it->second.size() == 1)
+    if (new_to_exist_kv.second.size() == 1)
     {
-      unsigned int curr_idx = (it->second)[0];
+      unsigned int curr_idx = (new_to_exist_kv.second)[0];
       feature_ptr->_status = MARKED;                          // Mark it
       _unique_grains[curr_idx] = feature_ptr;                 // transfer ownership of new grain
     }
@@ -397,9 +389,9 @@ GrainTracker::trackGrains()
       Real min_centroid_diff = std::numeric_limits<Real>::max();
       unsigned int min_idx = 0;
 
-      for (unsigned int i = 0; i < it->second.size(); ++i)
+      for (unsigned int i = 0; i < new_to_exist_kv.second.size(); ++i)
       {
-        unsigned int curr_idx = (it->second)[i];
+        unsigned int curr_idx = (new_to_exist_kv.second)[i];
 
         Real curr_centroid_diff = boundingRegionDistance(feature_ptr->_bboxes, _unique_grains[curr_idx]->_bboxes, true);
         if (curr_centroid_diff <= min_centroid_diff)
@@ -410,9 +402,9 @@ GrainTracker::trackGrains()
       }
 
       // One more time over the competing indices.  We will mark the non-winners as inactive and transfer ownership to the winner (the closest centroid).
-      for (unsigned int i = 0; i < it->second.size(); ++i)
+      for (unsigned int i = 0; i < new_to_exist_kv.second.size(); ++i)
       {
-        unsigned int curr_idx = (it->second)[i];
+        unsigned int curr_idx = (new_to_exist_kv.second)[i];
         if (i == min_idx)
         {
           feature_ptr->_status = MARKED;                          // Mark it
@@ -450,13 +442,13 @@ GrainTracker::trackGrains()
    * unique grains that didn't match up to any bounding sphere.  Should only happen if it's the last active grain for
    * this particular variable.
    */
-  for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::iterator it = _unique_grains.begin(); it != _unique_grains.end(); ++it)
-    if (it->second->_status == NOT_MARKED)
+  for (auto & grain_kv : _unique_grains)
+    if (grain_kv.second->_status == NOT_MARKED)
     {
-      _console << "Marking Grain " << it->first << " as INACTIVE (variable index: "
-               << it->second->_var_idx <<  ")\n"
-               << *it->second;
-      it->second->_status = INACTIVE;
+      _console << "Marking Grain " << grain_kv.first << " as INACTIVE (variable index: "
+               << grain_kv.second->_var_idx <<  ")\n"
+               << *grain_kv.second;
+      grain_kv.second->_status = INACTIVE;
     }
 }
 
@@ -474,9 +466,8 @@ GrainTracker::remapGrains()
    * to track which grains are currently being remapped so we don't have runaway recursion.
    * TODO: Possibly rename this variable?
    */
-  for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::iterator grain_it = _unique_grains.begin();
-       grain_it != _unique_grains.end(); ++grain_it)
-    grain_it->second->_merged = false;
+  for (auto & grain_kv : _unique_grains)
+    grain_kv.second->_merged = false;
 
   /**
    * Loop over each grain and see if any grains represented by the same variable are "touching"
@@ -558,16 +549,15 @@ GrainTracker::computeMinDistancesFromGrain(MooseSharedPointer<FeatureData> grain
    *        __/  0  \___/
    *
    */
-  for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::iterator grain_it = _unique_grains.begin();
-       grain_it != _unique_grains.end(); ++grain_it)
+  for (auto & grain_kv : _unique_grains)
   {
-    if (grain_it->second->_status == INACTIVE || grain_it->second->_var_idx == grain->_var_idx)
+    if (grain_kv.second->_status == INACTIVE || grain_kv.second->_var_idx == grain->_var_idx)
       continue;
 
-    unsigned int target_var_index = grain_it->second->_var_idx;
-    unsigned int target_grain_id = grain_it->first;
+    unsigned int target_var_index = grain_kv.second->_var_idx;
+    unsigned int target_grain_id = grain_kv.first;
 
-    Real curr_sphere_diff = boundingRegionDistance(grain->_bboxes, grain_it->second->_bboxes, false);
+    Real curr_sphere_diff = boundingRegionDistance(grain->_bboxes, grain_kv.second->_bboxes, false);
 
     GrainDistance grain_distance_obj(curr_sphere_diff, target_grain_id, target_var_index);
 
@@ -580,7 +570,7 @@ GrainTracker::computeMinDistancesFromGrain(MooseSharedPointer<FeatureData> grain
     }
 
     // Insertion sort into a list
-    std::list<GrainDistance>::iterator insert_it = min_distances[target_var_index].begin();
+    auto insert_it = min_distances[target_var_index].begin();
     while (insert_it != min_distances[target_var_index].end() && !(grain_distance_obj < *insert_it))
       ++insert_it;
     min_distances[target_var_index].insert(insert_it, grain_distance_obj);
@@ -621,14 +611,14 @@ GrainTracker::attemptGrainRenumber(MooseSharedPointer<FeatureData> grain, unsign
   _console << "\n********************************************\nDistances list for grain " << grain_id << '\n';
   for (unsigned int i = 0; i < min_distances.size(); ++i)
   {
-    for (std::list<GrainDistance>::iterator min_it = min_distances[i].begin(); min_it != min_distances[i].end(); ++min_it)
-      _console << min_it->_distance << ": " << min_it->_grain_id << ": " <<  min_it->_var_index << '\n';
+    for (const auto & grain_distance : min_distances[i])
+      _console << grain_distance._distance << ": " << grain_distance._grain_id << ": " <<  grain_distance._var_index << '\n';
     _console << '\n';
   }
 
   for (unsigned int i = 0; i < min_distances.size(); ++i)
   {
-    std::list<GrainDistance>::const_iterator target_it = min_distances[i].begin();
+    const auto target_it = min_distances[i].begin();
     if (target_it == min_distances[i].end())
       continue;
 
@@ -648,7 +638,7 @@ GrainTracker::attemptGrainRenumber(MooseSharedPointer<FeatureData> grain, unsign
 
     // If the distance isn't positive we just need to make sure that none of the grains represented by the
     // target variable index would intersect this one if we were to remap
-    std::list<GrainDistance>::const_iterator next_target_it = target_it;
+    auto next_target_it = target_it;
     bool intersection_hit = false;
     std::ostringstream oss;
     while (!intersection_hit && next_target_it != min_distances[i].end())
@@ -732,12 +722,11 @@ GrainTracker::swapSolutionValues(MooseSharedPointer<FeatureData> grain, unsigned
 
   // Remap the grain
   std::set<Node *> updated_nodes_tmp; // Used only in the elemental case
-  for (std::set<dof_id_type>::const_iterator entity_it = grain->_local_ids.begin();
-       entity_it != grain->_local_ids.end(); ++entity_it)
+  for (auto entity : grain->_local_ids)
   {
     if (_is_elemental)
     {
-      Elem * elem = mesh.query_elem(*entity_it);
+      Elem * elem = mesh.query_elem(entity);
       if (!elem)
         continue;
 
@@ -752,7 +741,7 @@ GrainTracker::swapSolutionValues(MooseSharedPointer<FeatureData> grain, unsigned
       }
     }
     else
-      swapSolutionValuesHelper(mesh.query_node_ptr(*entity_it), grain->_var_idx, var_idx, cache, cache_mode);
+      swapSolutionValuesHelper(mesh.query_node_ptr(entity), grain->_var_idx, var_idx, cache, cache_mode);
   }
 
   // Update the variable index in the unique grain datastructure
@@ -789,11 +778,11 @@ GrainTracker::swapSolutionValuesHelper(Node * curr_node, unsigned int curr_var_i
     }
     else // USE
     {
-      std::map<Node *, CacheValues>::const_iterator it = cache.find(curr_node);
-      mooseAssert(it != cache.end(), "Error in cache");
-      current = it->second.current;
-      old = it->second.old;
-      older = it->second.older;
+      const auto cache_it = cache.find(curr_node);
+      mooseAssert(cache_it != cache.end(), "Error in cache");
+      current = cache_it->second.current;
+      old = cache_it->second.old;
+      older = cache_it->second.older;
     }
 
     // Cache the value or use it!
@@ -806,7 +795,7 @@ GrainTracker::swapSolutionValuesHelper(Node * curr_node, unsigned int curr_var_i
     else // USE or BYPASS
     {
       {
-        dof_id_type & dof_index = _vars[new_var_idx]->nodalDofIndex();
+        const auto & dof_index = _vars[new_var_idx]->nodalDofIndex();
 
         // Transfer this solution from the current to the new
         _nl.solution().set(dof_index, current);
@@ -814,7 +803,7 @@ GrainTracker::swapSolutionValuesHelper(Node * curr_node, unsigned int curr_var_i
         _nl.solutionOlder().set(dof_index, older);
       }
       {
-        dof_id_type & dof_index = _vars[curr_var_idx]->nodalDofIndex();
+        const auto & dof_index = _vars[curr_var_idx]->nodalDofIndex();
 
         // Set the DOF for the current variable to zero
         _nl.solution().set(dof_index, 0.0);
@@ -836,49 +825,46 @@ GrainTracker::updateFieldInfo()
   std::map<unsigned int, Real> tmp_map;
   MeshBase & mesh = _mesh.getMesh();
 
-  for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::iterator grain_it = _unique_grains.begin(); grain_it != _unique_grains.end(); ++grain_it)
+  for (const auto & grain_kv : _unique_grains)
   {
-    unsigned int curr_var = grain_it->second->_var_idx;
+    unsigned int curr_var = grain_kv.second->_var_idx;
     unsigned int map_idx = (_single_map_mode || _condense_map_info) ? 0 : curr_var;
 
-    if (grain_it->second->_status == INACTIVE)
+    if (grain_kv.second->_status == INACTIVE)
       continue;
 
-    for (std::set<dof_id_type>::iterator entity_it = grain_it->second->_local_ids.begin();
-         entity_it != grain_it->second->_local_ids.end(); ++entity_it)
+    for (auto entity : grain_kv.second->_local_ids)
     {
       // Highest variable value at this entity wins
       Real entity_value = -std::numeric_limits<Real>::max();
       if (_is_elemental)
       {
-        const Elem * elem = mesh.elem(*entity_it);
+        const Elem * elem = mesh.elem(entity);
         std::vector<Point> centroid(1, elem->centroid());
         _fe_problem.reinitElemPhys(elem, centroid, 0);
         entity_value = _vars[curr_var]->sln()[0];
       }
       else
       {
-        Node & node = mesh.node(*entity_it);
+        Node & node = mesh.node(entity);
         entity_value = _vars[curr_var]->getNodalValue(node);
       }
 
-      if (tmp_map.find(*entity_it) == tmp_map.end() || entity_value > tmp_map[*entity_it])
+      if (tmp_map.find(entity) == tmp_map.end() || entity_value > tmp_map[entity])
       {
         // TODO: Add an option for EBSD Reader
-        _feature_maps[map_idx][*entity_it] = _ebsd_reader ? _unique_grain_to_ebsd_num[grain_it->first] : grain_it->first;
+        _feature_maps[map_idx][entity] = _ebsd_reader ? _unique_grain_to_ebsd_num[grain_kv.first] : grain_kv.first;
         if (_var_index_mode)
-          _var_index_maps[map_idx][*entity_it] = grain_it->second->_var_idx;
+          _var_index_maps[map_idx][entity] = grain_kv.second->_var_idx;
 
-        tmp_map[*entity_it] = entity_value;
+        tmp_map[entity] = entity_value;
       }
     }
-    for (std::set<dof_id_type>::const_iterator entity_it = grain_it->second->_halo_ids.begin();
-         entity_it != grain_it->second->_halo_ids.end(); ++entity_it)
-      _halo_ids[*entity_it] = grain_it->second->_var_idx;
+    for (auto entity : grain_kv.second->_halo_ids)
+      _halo_ids[entity] = grain_kv.second->_var_idx;
 
-    for (std::set<dof_id_type>::const_iterator entity_it = grain_it->second->_ghosted_ids.begin();
-         entity_it != grain_it->second->_ghosted_ids.end(); ++entity_it)
-      _ghosted_entity_ids[*entity_it] = grain_it->first;
+    for (auto entity : grain_kv.second->_ghosted_ids)
+      _ghosted_entity_ids[entity] = grain_kv.first;
   }
 }
 
@@ -892,14 +878,12 @@ GrainTracker::boundingRegionDistance(std::vector<MeshTools::BoundingBox> & bboxe
    * one selected from each grain.
    */
   Real min_distance = std::numeric_limits<Real>::max();
-  for (std::vector<MeshTools::BoundingBox>::const_iterator bbox_it1 = bboxes1.begin(); bbox_it1 != bboxes1.end(); ++bbox_it1)
+  for (const auto & bbox1 : bboxes1)
   {
-    const MeshTools::BoundingBox & bbox1 = *bbox_it1;
     const Point centroid1 = (bbox1.max() + bbox1.min()) / 2.0;
 
-    for (std::vector<MeshTools::BoundingBox>::const_iterator bbox_it2 = bboxes2.begin(); bbox_it2 != bboxes2.end(); ++bbox_it2)
+    for (const auto & bbox2 : bboxes2)
     {
-      const MeshTools::BoundingBox & bbox2 = *bbox_it2;
       const Point centroid2 = (bbox2.max() + bbox2.min()) / 2.0;
 
       Real curr_distance = std::numeric_limits<Real>::max();
@@ -960,18 +944,18 @@ GrainTracker::calculateBubbleVolumes()
     unsigned int elem_n_nodes = elem->n_nodes();
     Real curr_volume = elem->volume();
 
-    for (std::map<unsigned int, MooseSharedPointer<FeatureData> >::iterator it = _unique_grains.begin(); it != _unique_grains.end(); ++it)
+    for (auto & grain_kv : _unique_grains)
     {
-      if (it->second->_status == INACTIVE)
+      if (grain_kv.second->_status == INACTIVE)
         continue;
 
       if (_is_elemental)
       {
         dof_id_type elem_id = elem->id();
-        if (it->second->_local_ids.find(elem_id) != it->second->_local_ids.end())
+        if (grain_kv.second->_local_ids.find(elem_id) != grain_kv.second->_local_ids.end())
         {
-          mooseAssert(it->first < _all_feature_volumes.size(), "_all_feature_volumes access out of bounds");
-          _all_feature_volumes[it->first] += curr_volume;
+          mooseAssert(grain_kv.first < _all_feature_volumes.size(), "_all_feature_volumes access out of bounds");
+          _all_feature_volumes[grain_kv.first] += curr_volume;
           break;
         }
       }
@@ -982,14 +966,14 @@ GrainTracker::calculateBubbleVolumes()
         for (unsigned int node = 0; node < elem_n_nodes; ++node)
         {
           dof_id_type node_id = elem->node(node);
-          if (it->second->_local_ids.find(node_id) != it->second->_local_ids.end())
+          if (grain_kv.second->_local_ids.find(node_id) != grain_kv.second->_local_ids.end())
             ++flooded_nodes;
         }
 
         // If a majority of the nodes for this element are flooded,
         // assign its volume to the current bubble_counter entry.
         if (flooded_nodes >= elem_n_nodes / 2)
-          _all_feature_volumes[it->first] += curr_volume;
+          _all_feature_volumes[grain_kv.first] += curr_volume;
       }
     }
   }

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -19,9 +19,6 @@
 #include <limits>
 #include <algorithm>
 
-// Forward Declaration (Helper Functor)
-struct GrainDistanceSorter;
-
 template<>
 InputParameters validParams<GrainTracker>()
 {
@@ -606,7 +603,18 @@ GrainTracker::attemptGrainRenumber(MooseSharedPointer<FeatureData> grain, unsign
    * min_distance of a variable is explicitly set up above.
    */
 
-  std::sort(min_distances.begin(), min_distances.end(), GrainDistanceSorter());
+  std::sort(min_distances.begin(), min_distances.end(),
+            [](const std::list<GrainDistance> & lhs, const std::list<GrainDistance> & rhs)
+            {
+              // Sort lists in reverse order (largest distance first)
+              // These empty cases are here to make this comparison stable
+              if (lhs.empty())
+                return false;
+              else if (rhs.empty())
+                return true;
+              else
+                return lhs.begin()->_distance > rhs.begin()->_distance;
+            });
 
   _console << "\n********************************************\nDistances list for grain " << grain_id << '\n';
   for (unsigned int i = 0; i < min_distances.size(); ++i)
@@ -1007,20 +1015,4 @@ bool
 GrainDistance::operator<(const GrainDistance & rhs) const
 {
   return _distance < rhs._distance;
-}
-
-
-/**
- * GrainDistance sort functor (sorts in reverse order!)
- */
-bool
-GrainDistanceSorter::operator()(const std::list<GrainDistance> & lhs, const std::list<GrainDistance> & rhs) const
-{
-  // These empty cases are here to make this comparison stable
-  if (lhs.empty())
-    return false;
-  else if (rhs.empty())
-    return true;
-  else
-    return lhs.begin()->_distance > rhs.begin()->_distance;
 }

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -40,7 +40,7 @@ GrainTracker::GrainTracker(const InputParameters & parameters) :
     _remap(getParam<bool>("remap_grains")),
     _nl(static_cast<FEProblem &>(_subproblem).getNonlinearSystem()),
     _unique_grains(declareRestartableData<std::map<unsigned int, MooseSharedPointer<FeatureData> > >("unique_grains")),
-    _ebsd_reader(parameters.isParamValid("ebsd_reader") ? &getUserObject<EBSDReader>("ebsd_reader") : NULL),
+    _ebsd_reader(parameters.isParamValid("ebsd_reader") ? &getUserObject<EBSDReader>("ebsd_reader") : nullptr),
     _compute_op_maps(getParam<bool>("compute_op_maps"))
 {
   if (!_is_elemental && _compute_op_maps)

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -116,14 +116,14 @@ GrainTracker::finalize()
 
   if (_compute_op_maps)
   {
-    for (const auto & grain_kv : _unique_grains)
+    for (const auto & grain_pair : _unique_grains)
     {
-      if (grain_kv.second->_status != INACTIVE)
+      if (grain_pair.second->_status != INACTIVE)
       {
-        for (auto elem_id : grain_kv.second->_local_ids)
+        for (auto elem_id : grain_pair.second->_local_ids)
         {
-          mooseAssert(!_ebsd_reader || _unique_grain_to_ebsd_num.find(grain_kv.first) != _unique_grain_to_ebsd_num.end(), "Bad mapping in unique_grain_to_ebsd_num");
-          _elemental_data[elem_id].push_back(std::make_pair(_ebsd_reader ? _unique_grain_to_ebsd_num[grain_kv.first] : grain_kv.first, grain_kv.second->_var_idx));
+          mooseAssert(!_ebsd_reader || _unique_grain_to_ebsd_num.find(grain_pair.first) != _unique_grain_to_ebsd_num.end(), "Bad mapping in unique_grain_to_ebsd_num");
+          _elemental_data[elem_id].push_back(std::make_pair(_ebsd_reader ? _unique_grain_to_ebsd_num[grain_pair.first] : grain_pair.first, grain_pair.second->_var_idx));
         }
       }
     }
@@ -151,13 +151,11 @@ GrainTracker::getElementalValues(dof_id_type elem_id) const
 void
 GrainTracker::expandHalos()
 {
-  processor_id_type n_procs = _app.n_processors();
-
-  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
-    for (processor_id_type rank = 0; rank < n_procs; ++rank)
+  for (auto map_num = decltype(_maps_size)(0); map_num < _maps_size; ++map_num)
+    for (auto rank = decltype(_n_procs)(0); rank < _n_procs; ++rank)
       for (auto & feature : _partial_feature_sets[rank][map_num])
       {
-        for (unsigned int halo_level = 1; halo_level < _halo_level; ++halo_level)
+        for (auto halo_level = decltype(_halo_level)(1); halo_level < _halo_level; ++halo_level)
         {
           /**
            * Create a copy of the halo set so that as we insert new ids into the
@@ -185,12 +183,12 @@ GrainTracker::trackGrains()
 
   // Reset Status on active unique grains
   std::vector<unsigned int> map_sizes(_maps_size);
-  for (auto & grain_kv : _unique_grains)
+  for (auto & grain_pair : _unique_grains)
   {
-    if (grain_kv.second->_status != INACTIVE)
+    if (grain_pair.second->_status != INACTIVE)
     {
-      grain_kv.second->_status = NOT_MARKED;
-      map_sizes[grain_kv.second->_var_idx]++;
+      grain_pair.second->_status = NOT_MARKED;
+      map_sizes[grain_pair.second->_var_idx]++;
     }
   }
 
@@ -198,7 +196,7 @@ GrainTracker::trackGrains()
   if (_t_step > _tracking_step)
   {
     bool display_them = false;
-    for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
+    for (auto map_num = decltype(_maps_size)(0); map_num < _maps_size; ++map_num)
     {
       _console << "\nGrains active index " << map_num << ": " << map_sizes[map_num] << " -> " << _feature_sets[map_num].size();
       if (map_sizes[map_num] > _feature_sets[map_num].size())
@@ -227,7 +225,7 @@ GrainTracker::trackGrains()
   {
     if (_ebsd_reader)
     {
-      Real grain_num = _ebsd_reader->getGrainNum();
+      auto grain_num = _ebsd_reader->getGrainNum();
 
       std::vector<Point> center_points(grain_num);
 
@@ -246,16 +244,16 @@ GrainTracker::trackGrains()
       std::map<unsigned int, unsigned int> error_indices;
 
       unsigned int total_grains = 0;
-      for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
+      for (auto map_num = decltype(_maps_size)(0); map_num < _maps_size; ++map_num)
         total_grains += _feature_sets[map_num].size();
 
       if (grain_num != total_grains && processor_id() == 0)
         mooseWarning("Mismatch:\nEBSD centers: " << grain_num << " Grain Tracker Centers: " << total_grains);
 
-      unsigned int next_index = grain_num;
+      auto next_index = grain_num;
 
       // Loop over all of the features (grains)
-      for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
+      for (auto map_num = decltype(_maps_size)(0); map_num < _maps_size; ++map_num)
         for (unsigned int feature_num = 0; feature_num < _feature_sets[map_num].size(); ++feature_num)
         {
           Real min_centroid_diff = std::numeric_limits<Real>::max();
@@ -300,8 +298,8 @@ GrainTracker::trackGrains()
 
       if (!error_indices.empty())
       {
-        for (const auto & grain_kv : _unique_grains)
-          Moose::out << "Grain " << grain_kv.first << ": " << center_points[grain_kv.first] << '\n';
+        for (const auto & grain_pair : _unique_grains)
+          Moose::out << "Grain " << grain_pair.first << ": " << center_points[grain_pair.first] << '\n';
 
         Moose::out << "Error Indices:\n";
         for (const auto & error_kv : error_indices)
@@ -313,7 +311,7 @@ GrainTracker::trackGrains()
     else // Just assign IDs in order
     {
       unsigned int counter = 0;
-      for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
+      for (auto map_num = decltype(_maps_size)(0); map_num < _maps_size; ++map_num)
         for (unsigned int feature_num = 0; feature_num < _feature_sets[map_num].size(); ++feature_num)
         {
           _feature_sets[map_num][feature_num]->_status = MARKED;
@@ -330,9 +328,9 @@ GrainTracker::trackGrains()
    */
   std::map<std::pair<unsigned int, unsigned int>, std::vector<unsigned int> > new_grain_idx_to_existing_grain_idx;
 
-  for (auto & grain_kv : _unique_grains)
+  for (auto & grain_pair : _unique_grains)
   {
-    if (grain_kv.second->_status == INACTIVE)                         // Don't try to find matches for inactive grains
+    if (grain_pair.second->_status == INACTIVE)                         // Don't try to find matches for inactive grains
       continue;
 
     unsigned int closest_match_idx;
@@ -340,12 +338,12 @@ GrainTracker::trackGrains()
     Real min_centroid_diff = std::numeric_limits<Real>::max();
 
     // We only need to examine grains that have matching variable indices
-    unsigned int map_idx = _single_map_mode ? 0 : grain_kv.second->_var_idx;
+    unsigned int map_idx = _single_map_mode ? 0 : grain_pair.second->_var_idx;
     for (unsigned int new_grain_idx = 0; new_grain_idx < _feature_sets[map_idx].size(); ++new_grain_idx)
     {
-      if (grain_kv.second->_var_idx == _feature_sets[map_idx][new_grain_idx]->_var_idx)  // Do the variables indicies match?
+      if (grain_pair.second->_var_idx == _feature_sets[map_idx][new_grain_idx]->_var_idx)  // Do the variables indicies match?
       {
-        Real curr_centroid_diff = boundingRegionDistance(grain_kv.second->_bboxes, _feature_sets[map_idx][new_grain_idx]->_bboxes, true);
+        Real curr_centroid_diff = boundingRegionDistance(grain_pair.second->_bboxes, _feature_sets[map_idx][new_grain_idx]->_bboxes, true);
         if (curr_centroid_diff <= min_centroid_diff)
         {
           found_one = true;
@@ -357,7 +355,7 @@ GrainTracker::trackGrains()
 
     if (found_one)
       // Keep track of which new grains the existing ones want to map to
-      new_grain_idx_to_existing_grain_idx[std::make_pair(map_idx, closest_match_idx)].push_back(grain_kv.first);
+      new_grain_idx_to_existing_grain_idx[std::make_pair(map_idx, closest_match_idx)].push_back(grain_pair.first);
   }
 
   /**
@@ -367,7 +365,7 @@ GrainTracker::trackGrains()
    */
   for (const auto & new_to_exist_kv : new_grain_idx_to_existing_grain_idx)
   {                                                             // map index     feature index
-    std::unique_ptr<FeatureData> feature_ptr(std::move(_feature_sets[new_to_exist_kv.first.first][new_to_exist_kv.first.second]));
+    std::unique_ptr<FeatureData> feature_ptr = std::move(_feature_sets[new_to_exist_kv.first.first][new_to_exist_kv.first.second]);
 
     // If there is only a single mapping - we've found the correct grain
     if (new_to_exist_kv.second.size() == 1)
@@ -418,7 +416,7 @@ GrainTracker::trackGrains()
   /**
    * Next we need to look at our new list and see which grains weren't matched up.  These are new grains.
    */
-  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
+  for (auto map_num = decltype(_maps_size)(0); map_num < _maps_size; ++map_num)
     for (unsigned int i = 0; i < _feature_sets[map_num].size(); ++i)
       if (_feature_sets[map_num][i] && _feature_sets[map_num][i]->_status == NOT_MARKED)
       {
@@ -436,13 +434,13 @@ GrainTracker::trackGrains()
    * unique grains that didn't match up to any bounding sphere.  Should only happen if it's the last active grain for
    * this particular variable.
    */
-  for (auto & grain_kv : _unique_grains)
-    if (grain_kv.second->_status == NOT_MARKED)
+  for (auto & grain_pair : _unique_grains)
+    if (grain_pair.second->_status == NOT_MARKED)
     {
-      _console << "Marking Grain " << grain_kv.first << " as INACTIVE (variable index: "
-               << grain_kv.second->_var_idx <<  ")\n"
-               << *grain_kv.second;
-      grain_kv.second->_status = INACTIVE;
+      _console << "Marking Grain " << grain_pair.first << " as INACTIVE (variable index: "
+               << grain_pair.second->_var_idx <<  ")\n"
+               << *grain_pair.second;
+      grain_pair.second->_status = INACTIVE;
     }
 }
 
@@ -460,8 +458,8 @@ GrainTracker::remapGrains()
    * to track which grains are currently being remapped so we don't have runaway recursion.
    * TODO: Possibly rename this variable?
    */
-  for (auto & grain_kv : _unique_grains)
-    grain_kv.second->_merged = false;
+  for (auto & grain_pair : _unique_grains)
+    grain_pair.second->_merged = false;
 
   /**
    * Loop over each grain and see if any grains represented by the same variable are "touching"
@@ -541,15 +539,15 @@ GrainTracker::computeMinDistancesFromGrain(FeatureData & grain,
    *        __/  0  \___/
    *
    */
-  for (auto & grain_kv : _unique_grains)
+  for (auto & grain_pair : _unique_grains)
   {
-    if (grain_kv.second->_status == INACTIVE || grain_kv.second->_var_idx == grain._var_idx)
+    if (grain_pair.second->_status == INACTIVE || grain_pair.second->_var_idx == grain._var_idx)
       continue;
 
-    unsigned int target_var_index = grain_kv.second->_var_idx;
-    unsigned int target_grain_id = grain_kv.first;
+    unsigned int target_var_index = grain_pair.second->_var_idx;
+    unsigned int target_grain_id = grain_pair.first;
 
-    Real curr_sphere_diff = boundingRegionDistance(grain._bboxes, grain_kv.second->_bboxes, false);
+    Real curr_sphere_diff = boundingRegionDistance(grain._bboxes, grain_pair.second->_bboxes, false);
 
     GrainDistance grain_distance_obj(curr_sphere_diff, target_grain_id, target_var_index);
 
@@ -820,7 +818,7 @@ GrainTracker::swapSolutionValuesHelper(Node * curr_node, unsigned int curr_var_i
 void
 GrainTracker::updateFieldInfo()
 {
-  for (unsigned int map_num = 0; map_num < _maps_size; ++map_num)
+  for (auto map_num = decltype(_maps_size)(0); map_num < _maps_size; ++map_num)
     _feature_maps[map_num].clear();
 
   _halo_ids.clear();
@@ -828,15 +826,15 @@ GrainTracker::updateFieldInfo()
   std::map<unsigned int, Real> tmp_map;
   MeshBase & mesh = _mesh.getMesh();
 
-  for (const auto & grain_kv : _unique_grains)
+  for (const auto & grain_pair : _unique_grains)
   {
-    unsigned int curr_var = grain_kv.second->_var_idx;
+    unsigned int curr_var = grain_pair.second->_var_idx;
     unsigned int map_idx = (_single_map_mode || _condense_map_info) ? 0 : curr_var;
 
-    if (grain_kv.second->_status == INACTIVE)
+    if (grain_pair.second->_status == INACTIVE)
       continue;
 
-    for (auto entity : grain_kv.second->_local_ids)
+    for (auto entity : grain_pair.second->_local_ids)
     {
       // Highest variable value at this entity wins
       Real entity_value = -std::numeric_limits<Real>::max();
@@ -856,18 +854,18 @@ GrainTracker::updateFieldInfo()
       if (tmp_map.find(entity) == tmp_map.end() || entity_value > tmp_map[entity])
       {
         // TODO: Add an option for EBSD Reader
-        _feature_maps[map_idx][entity] = _ebsd_reader ? _unique_grain_to_ebsd_num[grain_kv.first] : grain_kv.first;
+        _feature_maps[map_idx][entity] = _ebsd_reader ? _unique_grain_to_ebsd_num[grain_pair.first] : grain_pair.first;
         if (_var_index_mode)
-          _var_index_maps[map_idx][entity] = grain_kv.second->_var_idx;
+          _var_index_maps[map_idx][entity] = grain_pair.second->_var_idx;
 
         tmp_map[entity] = entity_value;
       }
     }
-    for (auto entity : grain_kv.second->_halo_ids)
-      _halo_ids[entity] = grain_kv.second->_var_idx;
+    for (auto entity : grain_pair.second->_halo_ids)
+      _halo_ids[entity] = grain_pair.second->_var_idx;
 
-    for (auto entity : grain_kv.second->_ghosted_ids)
-      _ghosted_entity_ids[entity] = grain_kv.first;
+    for (auto entity : grain_pair.second->_ghosted_ids)
+      _ghosted_entity_ids[entity] = grain_pair.first;
   }
 }
 
@@ -880,20 +878,20 @@ GrainTracker::boundingRegionDistance(std::vector<MeshTools::BoundingBox> & bboxe
    * by a bounding box. The distance between any two grains is defined as the minimum distance between any pair of boxes,
    * one selected from each grain.
    */
-  Real min_distance = std::numeric_limits<Real>::max();
+  auto min_distance = std::numeric_limits<Real>::max();
   for (const auto & bbox1 : bboxes1)
   {
-    const Point centroid1 = (bbox1.max() + bbox1.min()) / 2.0;
+    const auto centroid_point1 = (bbox1.max() + bbox1.min()) / 2.0;
 
     for (const auto & bbox2 : bboxes2)
     {
-      const Point centroid2 = (bbox2.max() + bbox2.min()) / 2.0;
+      const auto centroid_point2 = (bbox2.max() + bbox2.min()) / 2.0;
 
-      Real curr_distance = std::numeric_limits<Real>::max();
+      auto curr_distance = std::numeric_limits<Real>::max();
 
       if (use_centroids_only)
         // Here we'll calculate a distance between the centroids
-        curr_distance = _mesh.minPeriodicDistance(_var_number, centroid1, centroid2);
+        curr_distance = _mesh.minPeriodicDistance(_var_number, centroid_point1, centroid_point2);
       else
       {
         // AABB squared distance
@@ -901,20 +899,20 @@ GrainTracker::boundingRegionDistance(std::vector<MeshTools::BoundingBox> & bboxe
         bool boxes_overlap = true;
         for (unsigned int dim = 0; dim < LIBMESH_DIM; ++dim)
         {
-          const Real & min1 = bbox1.min()(dim);
-          const Real & max1 = bbox1.max()(dim);
-          const Real & min2 = bbox2.min()(dim);
-          const Real & max2 = bbox2.max()(dim);
+          const auto & min1 = bbox1.min()(dim);
+          const auto & max1 = bbox1.max()(dim);
+          const auto & min2 = bbox2.min()(dim);
+          const auto & max2 = bbox2.max()(dim);
 
           if (min1 > max2)
           {
-            const Real delta = max2 - min1;
+            const auto delta = max2 - min1;
             result += delta * delta;
             boxes_overlap = false;
           }
           else if (min2 > max1)
           {
-            const Real delta = max1 - min2;
+            const auto delta = max1 - min2;
             result += delta * delta;
             boxes_overlap = false;
           }
@@ -944,21 +942,21 @@ GrainTracker::calculateBubbleVolumes()
   for (MeshBase::const_element_iterator el = _mesh.getMesh().active_local_elements_begin(); el != el_end; ++el)
   {
     Elem * elem = *el;
-    unsigned int elem_n_nodes = elem->n_nodes();
-    Real curr_volume = elem->volume();
+    auto elem_n_nodes = elem->n_nodes();
+    auto curr_volume = elem->volume();
 
-    for (auto & grain_kv : _unique_grains)
+    for (auto & grain_pair : _unique_grains)
     {
-      if (grain_kv.second->_status == INACTIVE)
+      if (grain_pair.second->_status == INACTIVE)
         continue;
 
       if (_is_elemental)
       {
-        dof_id_type elem_id = elem->id();
-        if (grain_kv.second->_local_ids.find(elem_id) != grain_kv.second->_local_ids.end())
+        auto elem_id = elem->id();
+        if (grain_pair.second->_local_ids.find(elem_id) != grain_pair.second->_local_ids.end())
         {
-          mooseAssert(grain_kv.first < _all_feature_volumes.size(), "_all_feature_volumes access out of bounds");
-          _all_feature_volumes[grain_kv.first] += curr_volume;
+          mooseAssert(grain_pair.first < _all_feature_volumes.size(), "_all_feature_volumes access out of bounds");
+          _all_feature_volumes[grain_pair.first] += curr_volume;
           break;
         }
       }
@@ -968,15 +966,15 @@ GrainTracker::calculateBubbleVolumes()
         unsigned int flooded_nodes = 0;
         for (unsigned int node = 0; node < elem_n_nodes; ++node)
         {
-          dof_id_type node_id = elem->node(node);
-          if (grain_kv.second->_local_ids.find(node_id) != grain_kv.second->_local_ids.end())
+          auto node_id = elem->node(node);
+          if (grain_pair.second->_local_ids.find(node_id) != grain_pair.second->_local_ids.end())
             ++flooded_nodes;
         }
 
         // If a majority of the nodes for this element are flooded,
         // assign its volume to the current bubble_counter entry.
         if (flooded_nodes >= elem_n_nodes / 2)
-          _all_feature_volumes[grain_kv.first] += curr_volume;
+          _all_feature_volumes[grain_pair.first] += curr_volume;
       }
     }
   }


### PR DESCRIPTION
Convert the FeatureFloodCount and GT objects to C++11.
Also adding `std::unique` pointer helpers in DataIO.

Theres a slight reduction in code count due to this change which is nice and that's including the addition of the new helpers! I've split the commits by "conversion action taken". The only controversial part of this PR is my prolific use of `std::unique_ptr`! I'll say a few things about that. First, the use of `std::unique_ptr` in these contexts is actually perfect. There really is never sharing and in the GT ownership has, and still is intended to be transferred from the `_feature_sets` data structure to the `_unique_grains` data structure. You'll see several uses of `std::move` making that happen.

I welcome any comments from @idaholab/moose-team and @dschwen.
