### PR TITLE
Fix compile warinings

### DIFF
--- a/modules/porous_flow/include/utils/PorousFlowCapillaryPressureVG.h
+++ b/modules/porous_flow/include/utils/PorousFlowCapillaryPressureVG.h
@@ -67,6 +67,6 @@ Real dCapillaryPressure(Real s, Real m, Real sat_r, Real sat_s, Real p0, Real pc
  * @return d^2(capillary pressure)/ds^2 (Pa)
  */
 Real d2CapillaryPressure(Real s, Real m, Real sat_r, Real sat_s, Real p0, Real pc_max);
-};
+}
 
 #endif // POROUSFLOWCAPILLARYPRESSUREVG_H

--- a/modules/porous_flow/include/utils/PorousFlowEffectiveSaturationVG.h
+++ b/modules/porous_flow/include/utils/PorousFlowEffectiveSaturationVG.h
@@ -42,6 +42,6 @@ Real dseff(Real p, Real al, Real m);
  * @param m van-genuchten m parameter
  */
 Real d2seff(Real p, Real al, Real m);
-};
+}
 
 #endif // POROUSFLOWEFFECTIVESATURATIONVG_H

--- a/modules/solid_mechanics/src/materials/IsotropicTempDepHardening.C
+++ b/modules/solid_mechanics/src/materials/IsotropicTempDepHardening.C
@@ -135,7 +135,6 @@ Real
 IsotropicTempDepHardening::computeHardeningDerivative(unsigned qp, Real /*scalar*/)
 {
   const Real strain_old = (*_scalar_plastic_strain_old)[qp];
-  Real temp = _temperature[qp];
   Real derivative = 0.0;
   Point p;
 


### PR DESCRIPTION
Remove `;` after namespace, rm unused variable.

Refs #1777 
