### PR TITLE
Restricting a couple of error check tests

### DIFF
--- a/test/tests/restart/pointer_restart_errors/tests
+++ b/test/tests/restart/pointer_restart_errors/tests
@@ -8,7 +8,7 @@
   [./pointer_load_error]
     type = 'RunApp'
     input = 'pointer_load_error.i'
-    max_parallel = 16
+    max_parallel = 1 # Sometimes times out in parallel after producing correct message
   [../]
 
   [./pointer_load_error2]
@@ -16,6 +16,6 @@
     input = 'pointer_load_error2.i'
     expect_err = 'Attempting to load a raw pointer type:'
     prereq = pointer_load_error
-    max_parallel = 16
+    max_parallel = 1 # Sometimes times out in parallel after producing correct message
   [../]
 []


### PR DESCRIPTION
These tests sometimes timeout under Linux for unknown reasons _after_
they've produced the correct error message. I suspect that there is
a problem terminating out of the DataLoad routines which isn't all
that important. For now, I suggest we restrict these tests so we
don't have spurious failures.

refs #7073
