### PR TITLE
Set default use_displaced_mesh = true in TM StressDivergenceKernels

### DIFF
--- a/modules/combined/tests/PLC_LSH_combined/PLC_LSH_combined2TM.i
+++ b/modules/combined/tests/PLC_LSH_combined/PLC_LSH_combined2TM.i
@@ -128,7 +128,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
   [./heat]
     type = HeatConduction

--- a/modules/combined/tests/cavity_pressure/cavity_pressure.i
+++ b/modules/combined/tests/cavity_pressure/cavity_pressure.i
@@ -117,7 +117,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
   [./heat]
     type = HeatConduction

--- a/modules/combined/tests/cavity_pressure/cavity_pressure_init_temp.i
+++ b/modules/combined/tests/cavity_pressure/cavity_pressure_init_temp.i
@@ -120,7 +120,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
   [./heat]
     type = HeatConduction

--- a/modules/combined/tests/cavity_pressure/cavity_pressure_rz.i
+++ b/modules/combined/tests/cavity_pressure/cavity_pressure_rz.i
@@ -63,7 +63,6 @@
 
 [Kernels]
   [./StressDivergence2DAxisymmetricRZ]
-    use_displaced_mesh = true
   [../]
   [./heat]
     type = HeatConduction

--- a/modules/combined/tests/eigenstrain/variable.i
+++ b/modules/combined/tests/eigenstrain/variable.i
@@ -25,6 +25,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/combined/tests/eigenstrain/variable_finite.i
+++ b/modules/combined/tests/eigenstrain/variable_finite.i
@@ -55,6 +55,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/combined/tests/evolving_mass_density/rz_tensors.i
+++ b/modules/combined/tests/evolving_mass_density/rz_tensors.i
@@ -77,7 +77,6 @@
 
 [Kernels]
   [./StressDivergence2DAxisymmetricRZ]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/combined/tests/finite_strain_tensor_mechanics_tests/elastic_rotation_test.i
+++ b/modules/combined/tests/finite_strain_tensor_mechanics_tests/elastic_rotation_test.i
@@ -100,7 +100,6 @@ active = ''
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/combined/tests/finite_strain_tensor_mechanics_tests/finite_strain_elasticity_test.i
+++ b/modules/combined/tests/finite_strain_tensor_mechanics_tests/finite_strain_elasticity_test.i
@@ -108,7 +108,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/combined/tests/j2_plasticity_vs_LSH/necking/j2_hard1_necking.i
+++ b/modules/combined/tests/j2_plasticity_vs_LSH/necking/j2_hard1_necking.i
@@ -19,7 +19,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y'
-    use_displaced_mesh = true
 #    save_in_disp_x = force_x
     save_in_disp_y = force_y
   [../]

--- a/modules/combined/tests/j2_plasticity_vs_LSH/necking/j2_hard1_neckingRZ.i
+++ b/modules/combined/tests/j2_plasticity_vs_LSH/necking/j2_hard1_neckingRZ.i
@@ -25,7 +25,6 @@
 
 [Kernels]
   [./AxisymmetricRZ]
-    use_displaced_mesh = true
 #    save_in_disp_r = force_r
     save_in_disp_z = force_z
   [../]

--- a/modules/combined/tests/linear_elasticity/LinearElasticMaterial_test.i
+++ b/modules/combined/tests/linear_elasticity/LinearElasticMaterial_test.i
@@ -72,6 +72,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
 
   [./diff]

--- a/modules/combined/tests/linear_elasticity/Tensor_test.i
+++ b/modules/combined/tests/linear_elasticity/Tensor_test.i
@@ -182,6 +182,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
 
   [./diff]

--- a/modules/combined/tests/linear_elasticity/applied_strain_test.i
+++ b/modules/combined/tests/linear_elasticity/applied_strain_test.i
@@ -1,5 +1,3 @@
-
-
 [Mesh]
   type = GeneratedMesh
   dim = 2
@@ -48,6 +46,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/combined/tests/multiphase_mechanics/elasticenergymaterial.i
+++ b/modules/combined/tests/multiphase_mechanics/elasticenergymaterial.i
@@ -55,6 +55,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
   [./dummy]
     type = MatDiffusion

--- a/modules/combined/tests/multiphase_mechanics/multiphasestress.i
+++ b/modules/combined/tests/multiphase_mechanics/multiphasestress.i
@@ -62,6 +62,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/combined/tests/multiphase_mechanics/simpleeigenstrain.i
+++ b/modules/combined/tests/multiphase_mechanics/simpleeigenstrain.i
@@ -72,6 +72,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/combined/tests/multiphase_mechanics/twophasestress.i
+++ b/modules/combined/tests/multiphase_mechanics/twophasestress.i
@@ -50,6 +50,7 @@
 
 [Kernels]
   [./TensorMechanics]
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/combined/tests/phase_field_fracture_viscoplastic/crack2d.i
+++ b/modules/combined/tests/phase_field_fracture_viscoplastic/crack2d.i
@@ -60,7 +60,6 @@
     block = 1
     save_in = resid_x
     c = c
-    use_displaced_mesh = true
   [../]
   [./solid_y]
     type = StressDivergencePFFracTensors
@@ -70,7 +69,6 @@
     block = 1
     save_in = resid_y
     c = c
-    use_displaced_mesh = true
   [../]
   [./dcdt]
     type = TimeDerivative

--- a/modules/combined/tests/poro_mechanics/borehole_highres.i
+++ b/modules/combined/tests/poro_mechanics/borehole_highres.i
@@ -130,16 +130,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/combined/tests/poro_mechanics/borehole_lowres.i
+++ b/modules/combined/tests/poro_mechanics/borehole_lowres.i
@@ -130,16 +130,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/combined/tests/poro_mechanics/jacobian1.i
+++ b/modules/combined/tests/poro_mechanics/jacobian1.i
@@ -62,18 +62,21 @@
     variable = disp_x
     displacements = 'disp_x disp_y disp_z'
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     displacements = 'disp_x disp_y disp_z'
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     displacements = 'disp_x disp_y disp_z'
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro]
     type = PoroFullSatTimeDerivative

--- a/modules/combined/tests/poro_mechanics/mandel.i
+++ b/modules/combined/tests/poro_mechanics/mandel.i
@@ -150,18 +150,21 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
-    [./poro_x]
+  [./poro_x]
     type = PoroMechanicsCoupling
     variable = disp_x
     component = 0

--- a/modules/combined/tests/poro_mechanics/pp_generation.i
+++ b/modules/combined/tests/poro_mechanics/pp_generation.i
@@ -81,16 +81,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/combined/tests/poro_mechanics/pp_generation_unconfined.i
+++ b/modules/combined/tests/poro_mechanics/pp_generation_unconfined.i
@@ -87,16 +87,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/combined/tests/poro_mechanics/pp_generation_unconfined_action.i
+++ b/modules/combined/tests/poro_mechanics/pp_generation_unconfined_action.i
@@ -87,6 +87,7 @@
 
 [Kernels]
   [./PoroMechanics]
+    use_displaced_mesh = false
   [../]
   [./poro_timederiv]
     type = PoroFullSatTimeDerivative

--- a/modules/combined/tests/poro_mechanics/selected_qp.i
+++ b/modules/combined/tests/poro_mechanics/selected_qp.i
@@ -51,16 +51,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/combined/tests/poro_mechanics/terzaghi.i
+++ b/modules/combined/tests/poro_mechanics/terzaghi.i
@@ -114,16 +114,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
     [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/combined/tests/poro_mechanics/unconsolidated_undrained.i
+++ b/modules/combined/tests/poro_mechanics/unconsolidated_undrained.i
@@ -105,16 +105,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/combined/tests/poro_mechanics/undrained_oedometer.i
+++ b/modules/combined/tests/poro_mechanics/undrained_oedometer.i
@@ -88,16 +88,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/combined/tests/power_law_creep/power_law_creep_test_tm.i
+++ b/modules/combined/tests/power_law_creep/power_law_creep_test_tm.i
@@ -68,7 +68,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 
   [./heat]

--- a/modules/combined/tests/solid_mechanics/hoop_stress/hoop_stress.i
+++ b/modules/combined/tests/solid_mechanics/hoop_stress/hoop_stress.i
@@ -117,7 +117,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/combined/tests/solid_mechanics/hoop_stress/hoop_stress_default_yaxis.i
+++ b/modules/combined/tests/solid_mechanics/hoop_stress/hoop_stress_default_yaxis.i
@@ -85,7 +85,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/porous_flow/tests/jacobian/mass08.i
+++ b/modules/porous_flow/tests/jacobian/mass08.i
@@ -55,16 +55,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./mass0]
     type = PorousFlowMassTimeDerivative

--- a/modules/porous_flow/tests/jacobian/mass_vol_exp01.i
+++ b/modules/porous_flow/tests/jacobian/mass_vol_exp01.i
@@ -64,18 +64,21 @@
     variable = disp_x
     displacements = 'disp_x disp_y disp_z'
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     displacements = 'disp_x disp_y disp_z'
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     displacements = 'disp_x disp_y disp_z'
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro]
     type = PorousFlowMassVolumetricExpansion

--- a/modules/porous_flow/tests/jacobian/mass_vol_exp02.i
+++ b/modules/porous_flow/tests/jacobian/mass_vol_exp02.i
@@ -64,18 +64,21 @@
     variable = disp_x
     displacements = 'disp_x disp_y disp_z'
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     displacements = 'disp_x disp_y disp_z'
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     displacements = 'disp_x disp_y disp_z'
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro]
     type = PorousFlowMassVolumetricExpansion

--- a/modules/porous_flow/tests/mass_conservation/mass04.i
+++ b/modules/porous_flow/tests/mass_conservation/mass04.i
@@ -88,16 +88,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PorousFlowEffectiveStressCoupling

--- a/modules/porous_flow/tests/poro_elasticity/mandel.i
+++ b/modules/porous_flow/tests/poro_elasticity/mandel.i
@@ -168,16 +168,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PorousFlowEffectiveStressCoupling

--- a/modules/porous_flow/tests/poro_elasticity/pp_generation.i
+++ b/modules/porous_flow/tests/poro_elasticity/pp_generation.i
@@ -86,16 +86,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PorousFlowEffectiveStressCoupling

--- a/modules/porous_flow/tests/poro_elasticity/pp_generation_unconfined.i
+++ b/modules/porous_flow/tests/poro_elasticity/pp_generation_unconfined.i
@@ -87,16 +87,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PorousFlowEffectiveStressCoupling

--- a/modules/porous_flow/tests/poro_elasticity/terzaghi.i
+++ b/modules/porous_flow/tests/poro_elasticity/terzaghi.i
@@ -131,16 +131,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PorousFlowEffectiveStressCoupling

--- a/modules/porous_flow/tests/poro_elasticity/undrained_oedometer.i
+++ b/modules/porous_flow/tests/poro_elasticity/undrained_oedometer.i
@@ -87,16 +87,19 @@
     type = StressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./grad_stress_y]
     type = StressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./grad_stress_z]
     type = StressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./poro_vol_exp]
     type = PorousFlowMassVolumetricExpansion

--- a/modules/porous_flow/tests/poro_elasticity/vol_expansion.i
+++ b/modules/porous_flow/tests/poro_elasticity/vol_expansion.i
@@ -74,6 +74,7 @@
     variable = p
   [../]
   [./TensorMechanics]
+    use_displaced_mesh = false
     displacements = 'disp_x disp_y disp_z'
   [../]
   [./poro_x]

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
@@ -18,7 +18,7 @@ InputParameters validParams<TensorMechanicsAction>()
   params.addRequiredParam<std::vector<NonlinearVariableName> >("displacements", "The nonlinear displacement variables for the problem");
   params.addParam<NonlinearVariableName>("temp", "The temperature");
   params.addParam<std::string>("base_name", "Material property base name");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether to use displaced mesh in the kernels");
+  params.addParam<bool>("use_displaced_mesh", true, "Whether to use displaced mesh in the kernels");
   params.addParam<std::vector<SubdomainName> >("block", "The list of ids of the blocks (subdomain) that the stress divergence kernel will be applied to");
   params.addParam<std::vector<AuxVariableName> >("save_in", "The displacement residuals");
   params.addParam<std::vector<AuxVariableName> >("diag_save_in", "The displacement diagonal preconditioner terms");

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAxisymmetricRZAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAxisymmetricRZAction.C
@@ -17,7 +17,7 @@ InputParameters validParams<TensorMechanicsAxisymmetricRZAction>()
   params.addClassDescription("Set up stress divergence kernel for 2D cylindrical problem");
   params.addRequiredParam<std::vector<NonlinearVariableName> >("displacements", "The nonlinear displacement variables for the problem");
   params.addParam<std::string>("base_name", "Material property base name");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether to use displaced mesh in the kernels");
+  params.addParam<bool>("use_displaced_mesh", true, "Whether to use displaced mesh in the kernels");
   params.addParam<std::vector<SubdomainName> >("block", "The list of ids of the blocks (subdomain) that the stress divergence kernel will be applied to");
   params.addParam<std::vector<AuxVariableName> >("save_in", "The displacement residuals");
   params.addParam<std::vector<AuxVariableName> >("diag_save_in", "The displacement diagonal preconditioner terms");

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsRSphericalAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsRSphericalAction.C
@@ -18,7 +18,7 @@ InputParameters validParams<TensorMechanicsRSphericalAction>()
   params.addClassDescription("Set up stress divergence kernel for the 1D spherical problem");
   params.addRequiredParam<std::vector<NonlinearVariableName> >("displacements", "The nonlinear displacement variable for the problem (should only be a single variable)");
   params.addParam<std::string>("base_name", "Material property base name");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether to use displaced mesh in the kernels");
+  params.addParam<bool>("use_displaced_mesh", true, "Whether to use displaced mesh in the kernels");
   params.addParam<std::vector<SubdomainName> >("block", "The list of ids of the blocks (subdomain) that the stress divergence kernel will be applied to");
   params.addParam<std::vector<AuxVariableName> >("save_in", "The r displacement residuals");
   params.addParam<std::vector<AuxVariableName> >("diag_save_in", "The r displacement diagonal preconditoner term");

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
@@ -19,7 +19,7 @@ InputParameters validParams<StressDivergenceTensors>()
   params.addRequiredCoupledVar("displacements", "The string of displacements suitable for the problem statement");
   params.addCoupledVar("temp", "The temperature");
   params.addParam<std::string>("base_name", "Material property base name");
-  params.set<bool>("use_displaced_mesh") = false;
+  params.set<bool>("use_displaced_mesh") = true;
 
   return params;
 }

--- a/modules/tensor_mechanics/tests/1D_spherical/smallStrain_1DSphere.i
+++ b/modules/tensor_mechanics/tests/1D_spherical/smallStrain_1DSphere.i
@@ -42,7 +42,6 @@
 
 [Kernels]
   [./StressDivergence1DRSpherical]
-    use_displaced_mesh = true
     save_in = residual_r
   [../]
 []

--- a/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_finiteStrain_resid.i
+++ b/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_finiteStrain_resid.i
@@ -44,7 +44,6 @@
 
 [Kernels]
   [./StressDivergence2DAxisymmetricRZ]
-    use_displaced_mesh = true
     save_in = 'force_r force_z'
   [../]
 []

--- a/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_finiteStrain_test.i
+++ b/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_finiteStrain_test.i
@@ -58,7 +58,6 @@
 
 [Kernels]
   [./StressDivergence2DAxisymmetricRZ]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_test.i
+++ b/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_test.i
@@ -40,7 +40,6 @@
 [Kernels]
   [./StressDivergence2DAxisymmetricRZ]
     displacements = 'disp_r disp_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/2D_geometries/3D-RZ_finiteStrain_test.i
+++ b/modules/tensor_mechanics/tests/2D_geometries/3D-RZ_finiteStrain_test.i
@@ -58,7 +58,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/2D_geometries/planestrain_test.i
+++ b/modules/tensor_mechanics/tests/2D_geometries/planestrain_test.i
@@ -50,6 +50,7 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y'
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/anisotropic_patch/anisotropic_patch_test.i
+++ b/modules/tensor_mechanics/tests/anisotropic_patch/anisotropic_patch_test.i
@@ -131,7 +131,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/auxkernels/principalstress.i
+++ b/modules/tensor_mechanics/tests/auxkernels/principalstress.i
@@ -32,6 +32,7 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_slip_rate_integ/crysp.i
+++ b/modules/tensor_mechanics/tests/cp_slip_rate_integ/crysp.i
@@ -50,7 +50,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_slip_rate_integ/crysp_linesearch.i
+++ b/modules/tensor_mechanics/tests/cp_slip_rate_integ/crysp_linesearch.i
@@ -50,7 +50,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_slip_rate_integ/crysp_substep.i
+++ b/modules/tensor_mechanics/tests/cp_slip_rate_integ/crysp_substep.i
@@ -50,7 +50,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_user_object/crysp.i
+++ b/modules/tensor_mechanics/tests/cp_user_object/crysp.i
@@ -55,7 +55,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_user_object/crysp_fileread.i
+++ b/modules/tensor_mechanics/tests/cp_user_object/crysp_fileread.i
@@ -55,7 +55,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_user_object/crysp_linesearch.i
+++ b/modules/tensor_mechanics/tests/cp_user_object/crysp_linesearch.i
@@ -50,7 +50,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_user_object/crysp_save_euler.i
+++ b/modules/tensor_mechanics/tests/cp_user_object/crysp_save_euler.i
@@ -280,7 +280,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_user_object/crysp_substep.i
+++ b/modules/tensor_mechanics/tests/cp_user_object/crysp_substep.i
@@ -55,7 +55,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/cp_user_object/crysp_user_object.i
+++ b/modules/tensor_mechanics/tests/cp_user_object/crysp_user_object.i
@@ -241,7 +241,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp.i
@@ -55,7 +55,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp_cutback.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp_cutback.i
@@ -55,7 +55,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp_fileread.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp_fileread.i
@@ -64,7 +64,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp_linesearch.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp_linesearch.i
@@ -50,7 +50,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp_read_slip_prop.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp_read_slip_prop.i
@@ -55,7 +55,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp_save_euler.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp_save_euler.i
@@ -246,7 +246,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp_substep.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp_substep.i
@@ -55,7 +55,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/crystal_plasticity/crysp_user_object.i
+++ b/modules/tensor_mechanics/tests/crystal_plasticity/crysp_user_object.i
@@ -206,7 +206,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/elastic_patch/elastic_patch_quadratic.i
+++ b/modules/tensor_mechanics/tests/elastic_patch/elastic_patch_quadratic.i
@@ -126,7 +126,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/elem_prop_read_user_object/prop_elem_read.i
+++ b/modules/tensor_mechanics/tests/elem_prop_read_user_object/prop_elem_read.i
@@ -156,7 +156,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/elem_prop_read_user_object/prop_grain_read.i
+++ b/modules/tensor_mechanics/tests/elem_prop_read_user_object/prop_grain_read.i
@@ -158,7 +158,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/elem_prop_read_user_object/prop_grain_read_3d.i
+++ b/modules/tensor_mechanics/tests/elem_prop_read_user_object/prop_grain_read_3d.i
@@ -165,7 +165,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/finite_strain_elastic/elastic_rotation_test.i
+++ b/modules/tensor_mechanics/tests/finite_strain_elastic/elastic_rotation_test.i
@@ -96,7 +96,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/finite_strain_elastic/finite_strain_elastic_new_test.i
+++ b/modules/tensor_mechanics/tests/finite_strain_elastic/finite_strain_elastic_new_test.i
@@ -27,7 +27,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/finite_strain_elastic/finite_strain_fake_plastic.i
+++ b/modules/tensor_mechanics/tests/finite_strain_elastic/finite_strain_fake_plastic.i
@@ -27,7 +27,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/generalized_plane_strain/planestrain.i
+++ b/modules/tensor_mechanics/tests/generalized_plane_strain/planestrain.i
@@ -72,7 +72,6 @@
 [Kernels]
   [./TensorMechanics]
     save_in = 'saved_x saved_y'
-    use_displaced_mesh = true
     temp = temp
   [../]
 []

--- a/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem.i
+++ b/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem.i
@@ -20,7 +20,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem_base.i
+++ b/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem_base.i
@@ -20,7 +20,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
     base_name = test
   [../]
 []

--- a/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem_linear_harden.i
+++ b/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem_linear_harden.i
@@ -20,7 +20,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem_multi.i
+++ b/modules/tensor_mechanics/tests/hyperelastic_viscoplastic/one_elem_multi.i
@@ -20,7 +20,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'ux uy uz'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/isotropic_elasticity_tensor/2D-axisymmetric_rz_test.i
+++ b/modules/tensor_mechanics/tests/isotropic_elasticity_tensor/2D-axisymmetric_rz_test.i
@@ -25,7 +25,6 @@
 
 [Kernels]
   [./StressDivergence2DAxisymmetricRZ]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/j2_plasticity/tensor_mechanics_j2plasticity.i
+++ b/modules/tensor_mechanics/tests/j2_plasticity/tensor_mechanics_j2plasticity.i
@@ -48,7 +48,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'x_disp y_disp z_disp'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/poro/vol_expansion.i
+++ b/modules/tensor_mechanics/tests/poro/vol_expansion.i
@@ -74,6 +74,7 @@
   [../]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
+    use_displaced_mesh = false
   [../]
   [./poro_x]
     type = PoroMechanicsCoupling

--- a/modules/tensor_mechanics/tests/poro/vol_expansion_action.i
+++ b/modules/tensor_mechanics/tests/poro/vol_expansion_action.i
@@ -74,6 +74,7 @@
   [./PoroMechanics]
     porepressure = p
     displacements = 'disp_x disp_y disp_z'
+    use_displaced_mesh = false
   [../]
   [./unimportant_p]
     type = Diffusion

--- a/modules/tensor_mechanics/tests/pressure/pressure_test.i
+++ b/modules/tensor_mechanics/tests/pressure/pressure_test.i
@@ -55,6 +55,7 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/rate_plasticity/tensor_mechanics_rate_plasticity.i
+++ b/modules/tensor_mechanics/tests/rate_plasticity/tensor_mechanics_rate_plasticity.i
@@ -48,7 +48,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'x_disp y_disp z_disp'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/recompute_radial_return/isotropic_plasticity_errors.i
+++ b/modules/tensor_mechanics/tests/recompute_radial_return/isotropic_plasticity_errors.i
@@ -72,7 +72,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/recompute_radial_return/isotropic_plasticity_finite_strain.i
+++ b/modules/tensor_mechanics/tests/recompute_radial_return/isotropic_plasticity_finite_strain.i
@@ -76,7 +76,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/recompute_radial_return/isotropic_plasticity_incremental_strain.i
+++ b/modules/tensor_mechanics/tests/recompute_radial_return/isotropic_plasticity_incremental_strain.i
@@ -80,7 +80,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/smeared_cracking/cracking_exponential.i
+++ b/modules/tensor_mechanics/tests/smeared_cracking/cracking_exponential.i
@@ -90,7 +90,7 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
-#    use_displaced_mesh = true
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/static_deformations/cosserat_shear.i
+++ b/modules/tensor_mechanics/tests/static_deformations/cosserat_shear.i
@@ -53,18 +53,21 @@
     variable = disp_x
     displacements = 'disp_x disp_y disp_z'
     component = 0
+    use_displaced_mesh = false
   [../]
   [./cy_elastic]
     type = CosseratStressDivergenceTensors
     variable = disp_y
     displacements = 'disp_x disp_y disp_z'
     component = 1
+    use_displaced_mesh = false
   [../]
   [./cz_elastic]
     type = CosseratStressDivergenceTensors
     variable = disp_z
     component = 2
     displacements = 'disp_x disp_y disp_z'
+    use_displaced_mesh = false
   [../]
   [./x_couple]
     type = StressDivergenceTensors
@@ -72,6 +75,7 @@
     displacements = 'wc_x wc_y wc_z'
     component = 0
     base_name = couple
+    use_displaced_mesh = false
   [../]
   [./y_couple]
     type = StressDivergenceTensors
@@ -79,6 +83,7 @@
     component = 1
     displacements = 'wc_x wc_y wc_z'
     base_name = couple
+    use_displaced_mesh = false
   [../]
   [./z_couple]
     type = StressDivergenceTensors
@@ -86,6 +91,7 @@
     component = 2
     displacements = 'wc_x wc_y wc_z'
     base_name = couple
+    use_displaced_mesh = false
   [../]
   [./x_moment]
     type = MomentBalancing

--- a/modules/tensor_mechanics/tests/static_deformations/cosserat_tension.i
+++ b/modules/tensor_mechanics/tests/static_deformations/cosserat_tension.i
@@ -78,16 +78,19 @@
     type = CosseratStressDivergenceTensors
     variable = disp_x
     component = 0
+    use_displaced_mesh = false
   [../]
   [./cy_elastic]
     type = CosseratStressDivergenceTensors
     variable = disp_y
     component = 1
+    use_displaced_mesh = false
   [../]
   [./cz_elastic]
     type = CosseratStressDivergenceTensors
     variable = disp_z
     component = 2
+    use_displaced_mesh = false
   [../]
   [./x_couple]
     type = StressDivergenceTensors
@@ -95,6 +98,7 @@
     displacements = 'wc_x wc_y wc_z'
     component = 0
     base_name = couple
+    use_displaced_mesh = false
   [../]
   [./y_couple]
     type = StressDivergenceTensors
@@ -102,6 +106,7 @@
     displacements = 'wc_x wc_y wc_z'
     component = 1
     base_name = couple
+    use_displaced_mesh = false
   [../]
   [./z_couple]
     type = StressDivergenceTensors
@@ -109,6 +114,7 @@
     displacements = 'wc_x wc_y wc_z'
     component = 2
     base_name = couple
+    use_displaced_mesh = false
   [../]
   [./x_moment]
     type = MomentBalancing

--- a/modules/tensor_mechanics/tests/temperature_dependent_hardening/temp_dep_hardening.i
+++ b/modules/tensor_mechanics/tests/temperature_dependent_hardening/temp_dep_hardening.i
@@ -119,7 +119,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/torque_reaction/disp_about_axis_axial_motion.i
+++ b/modules/tensor_mechanics/tests/torque_reaction/disp_about_axis_axial_motion.i
@@ -54,7 +54,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/torque_reaction/disp_about_axis_errors.i
+++ b/modules/tensor_mechanics/tests/torque_reaction/disp_about_axis_errors.i
@@ -54,7 +54,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/torque_reaction/torque_reaction_3D_tm.i
+++ b/modules/tensor_mechanics/tests/torque_reaction/torque_reaction_3D_tm.i
@@ -56,6 +56,7 @@
 [Kernels]
   [./TensorMechanics]
     save_in = 'saved_x saved_y saved_z'
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/torque_reaction/torque_reaction_cylinder.i
+++ b/modules/tensor_mechanics/tests/torque_reaction/torque_reaction_cylinder.i
@@ -48,7 +48,6 @@
 [Kernels]
   [./TensorMechanics]
     save_in = 'saved_x saved_y saved_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/torque_reaction/torque_reaction_tm.i
+++ b/modules/tensor_mechanics/tests/torque_reaction/torque_reaction_tm.i
@@ -49,6 +49,7 @@
 [Kernels]
   [./TensorMechanics]
     save_in = 'saved_x saved_y'
+    use_displaced_mesh = false
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/volumetric_deform_grad/elastic_stress.i
+++ b/modules/tensor_mechanics/tests/volumetric_deform_grad/elastic_stress.i
@@ -17,7 +17,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/volumetric_deform_grad/volumetric_strain_interface.i
+++ b/modules/tensor_mechanics/tests/volumetric_deform_grad/volumetric_strain_interface.i
@@ -20,7 +20,6 @@
 [Kernels]
   [./TensorMechanics]
     displacements = 'disp_x disp_y disp_z'
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tutorials/basics/part_2.3.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.3.i
@@ -28,7 +28,6 @@
 
 [Kernels]
   [./StressDivergence2DAxisymmetricRZ]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tutorials/basics/part_2.4.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.4.i
@@ -28,7 +28,6 @@
 
 [Kernels]
   [./StressDivergence2DAxisymmetricRZ]
-    use_displaced_mesh = true
   [../]
 []
 

--- a/modules/tensor_mechanics/tutorials/basics/part_3_1.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_3_1.i
@@ -34,7 +34,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    use_displaced_mesh = true
   [../]
 []
 


### PR DESCRIPTION
### Design Changes

The default value of `use_displaced_mesh` is changed to `true` in the `StressDivergenceTensors` kernel to better align with existing BCs (e.g. pressure) and with solid mechanics assumptions.
### Test Cases

Many test cases were changed, either to remove the now unnecessary `used_displaced_mesh = true` line in the input file, or to add `use_displaced_mesh = false` for small strain cases which exodiff failed without the explicit use of the undeformed mesh.

Closes #6947
