### PR TITLE
Adding ZeroInterface to DGKernels

### DIFF
--- a/framework/include/dgkernels/DGKernel.h
+++ b/framework/include/dgkernels/DGKernel.h
@@ -27,6 +27,7 @@
 #include "FunctionInterface.h"
 #include "TwoMaterialPropertyInterface.h"
 #include "Restartable.h"
+#include "ZeroInterface.h"
 #include "MeshChangedInterface.h"
 
 // Forward Declarations
@@ -55,6 +56,7 @@ class DGKernel :
   public NeighborCoupleableMooseVariableDependencyIntermediateInterface,
   protected TwoMaterialPropertyInterface,
   public Restartable,
+  public ZeroInterface,
   public MeshChangedInterface
 {
 public:

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -58,6 +58,7 @@ DGKernel::DGKernel(const InputParameters & parameters) :
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, false, false),
     TwoMaterialPropertyInterface(this),
     Restartable(parameters, "DGKernels"),
+    ZeroInterface(parameters),
     MeshChangedInterface(parameters),
     _subproblem(*parameters.get<SubProblem *>("_subproblem")),
     _sys(*parameters.get<SystemBase *>("_sys")),


### PR DESCRIPTION
Like other systems have `ZeroInterface`, `DGKernel`s should have it as well.

Closes #7137
