### PR TITLE
Fix signedness and add exceptions 

### DIFF
--- a/framework/include/utils/MatrixTools.h
+++ b/framework/include/utils/MatrixTools.h
@@ -9,6 +9,7 @@
 
 #include "MooseTypes.h"
 #include "PetscSupport.h"
+#include "Conversion.h"
 #include "petscblaslapack.h"
 #include <vector>
 
@@ -20,7 +21,7 @@ namespace MatrixTools
  * @ param[out] m_inv The inverse of m, which must be of the same size as m.
  * @ return if zero then the inversion was successful.  Otherwise m was not square, contained illegal entries or was singular
  */
-int inverse(const std::vector<std::vector<Real> > & m, std::vector<std::vector<Real> > & m_inv);
+void inverse(const std::vector<std::vector<Real> > & m, std::vector<std::vector<Real> > & m_inv);
 
 /**
  * Inverts the dense "matrix" A using LAPACK routines
@@ -28,7 +29,36 @@ int inverse(const std::vector<std::vector<Real> > & m, std::vector<std::vector<R
  * @param n size of the vector A
  * @return if zero then inversion was successful.  Otherwise A contained illegal entries or was singular
  */
-int inverse(std::vector<PetscScalar> & A, unsigned int n);
+void inverse(std::vector<PetscScalar> & A, unsigned int n);
+
+/**
+ * Exception classe that captur the things that can go wrong with matrix inversion
+ */
+class LUDecompositionException : public MooseException
+{
+public:
+  LUDecompositionException() : MooseException("LU decomposition failed during matrix inversion.") {}
+};
+
+class NoInputMatrixException : public MooseException
+{
+public:
+  NoInputMatrixException() : MooseException("Input matrix empty during matrix inversion.") {}
+};
+
+class MatrixMismatchException : public MooseException
+{
+public:
+  MatrixMismatchException() : MooseException("Input and output matrix are not same size square matrices.") {}
+};
+
+class MatrixInversionException : public MooseException
+{
+public:
+  MatrixInversionException(int error) :
+      MooseException(error < 0 ? "Argument " + Moose::stringify(-error) + " was invalid during matrix inversion."
+                               : "Matrix on-diagonal entry " + Moose::stringify(error) + " was exactly zero. Inversion failed.") {}
+};
 }
 
 #endif //MATRIXTOOLS_H

--- a/framework/include/utils/MatrixTools.h
+++ b/framework/include/utils/MatrixTools.h
@@ -30,35 +30,6 @@ void inverse(const std::vector<std::vector<Real> > & m, std::vector<std::vector<
  * @return if zero then inversion was successful.  Otherwise A contained illegal entries or was singular
  */
 void inverse(std::vector<PetscScalar> & A, unsigned int n);
-
-/**
- * Exception classe that captur the things that can go wrong with matrix inversion
- */
-class LUDecompositionException : public MooseException
-{
-public:
-  LUDecompositionException() : MooseException("LU decomposition failed during matrix inversion.") {}
-};
-
-class NoInputMatrixException : public MooseException
-{
-public:
-  NoInputMatrixException() : MooseException("Input matrix empty during matrix inversion.") {}
-};
-
-class MatrixMismatchException : public MooseException
-{
-public:
-  MatrixMismatchException() : MooseException("Input and output matrix are not same size square matrices.") {}
-};
-
-class MatrixInversionException : public MooseException
-{
-public:
-  MatrixInversionException(int error) :
-      MooseException(error < 0 ? "Argument " + Moose::stringify(-error) + " was invalid during matrix inversion."
-                               : "Matrix on-diagonal entry " + Moose::stringify(error) + " was exactly zero. Inversion failed.") {}
-};
 }
 
 #endif //MATRIXTOOLS_H

--- a/framework/src/utils/RankFourTensor.C
+++ b/framework/src/utils/RankFourTensor.C
@@ -316,8 +316,7 @@ RankFourTensor
 RankFourTensor::invSymm() const
 {
   unsigned int ntens = N * (N+1) / 2;
-  int nskip = N-1;
-  int error;
+  int nskip = N - 1;
 
   RankFourTensor result;
   const RankFourTensor & a = *this;

--- a/framework/src/utils/RankFourTensor.C
+++ b/framework/src/utils/RankFourTensor.C
@@ -408,9 +408,7 @@ RankFourTensor::invSymm() const
       mat[i*ntens+j] /= 2.0; // because of double-counting above
 
   // use LAPACK to find the inverse
-  error = MatrixTools::inverse(mat, ntens);
-  if (error != 0)
-    throw MooseException("Error in Matrix  Inversion in RankFourTensor");
+  MatrixTools::inverse(mat, ntens);
 
   // build the resulting rank-four tensor
   // using the inverse of the above algorithm

--- a/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
@@ -1379,7 +1379,7 @@ ComputeMultiPlasticityStress::consistentTangentOperator(const RankTwoTensor & st
     {
       MatrixTools::inverse(zzz, num_currently_active);
     }
-    catch(const MatrixTools::MatrixInversionException & e)
+    catch(const MooseException & e)
     {
       // in the very rare case of zzz being singular, just return the "elastic" tangent operator
       #ifdef DEBUG
@@ -1464,7 +1464,7 @@ ComputeMultiPlasticityStress::consistentTangentOperator(const RankTwoTensor & st
   {
     s_inv = stress_coeff.invSymm();
   }
-  catch (MooseException & e)
+  catch (const MooseException & e)
   {
     return strain_coeff; // when stress_coeff is singular (perhaps for incompressible plasticity?) return the "linear" tangent operator
   }

--- a/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
@@ -1382,9 +1382,6 @@ ComputeMultiPlasticityStress::consistentTangentOperator(const RankTwoTensor & st
     catch(const MooseException & e)
     {
       // in the very rare case of zzz being singular, just return the "elastic" tangent operator
-      #ifdef DEBUG
-        mooseWarning(e.what());
-      #endif
       return E_ijkl;
     }
   }

--- a/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
@@ -1375,9 +1375,18 @@ ComputeMultiPlasticityStress::consistentTangentOperator(const RankTwoTensor & st
   if (num_currently_active > 0)
   {
     // invert zzz, in place.  if num_currently_active = 0 then zzz is not needed.
-    const int ierr = MatrixTools::inverse(zzz, num_currently_active);
-    if (ierr != 0)
-      return E_ijkl; // in the very rare case of zzz being singular, just return the "elastic" tangent operator
+    try
+    {
+      MatrixTools::inverse(zzz, num_currently_active);
+    }
+    catch(const MatrixTools::MatrixInversionException & e)
+    {
+      // in the very rare case of zzz being singular, just return the "elastic" tangent operator
+      #ifdef DEBUG
+        mooseWarning(e.what());
+      #endif
+      return E_ijkl;
+    }
   }
 
 

--- a/unit/include/MatrixToolsTest.h
+++ b/unit/include/MatrixToolsTest.h
@@ -34,7 +34,6 @@ class MatrixToolsTest : public CppUnit::TestFixture
 
 public:
   MatrixToolsTest();
-  ~MatrixToolsTest();
 
   void matrixInversionTest1();
   void matrixInversionTest2();

--- a/unit/src/MatrixToolsTest.C
+++ b/unit/src/MatrixToolsTest.C
@@ -19,9 +19,6 @@ MatrixToolsTest::MatrixToolsTest()
 {
 }
 
-MatrixToolsTest::~MatrixToolsTest()
-{}
-
 void
 MatrixToolsTest::matrixInversionTest1()
 {
@@ -41,15 +38,13 @@ MatrixToolsTest::matrixInversionTest1()
   mat2[2] = m[1][0] = 0.5;
   mat2[3] = m[1][1] = 1.0;
 
-  int error = MatrixTools::inverse(mat2, 2);
-  CPPUNIT_ASSERT(error == 0);
+  MatrixTools::inverse(mat2, 2);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(1, mat2[0], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(-2, mat2[1], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(-0.5, mat2[2], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(2, mat2[3], 1E-5);
 
-  error = MatrixTools::inverse(m, m);
-  CPPUNIT_ASSERT(error == 0);
+  MatrixTools::inverse(m, m);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(1, m[0][0], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(-2, m[0][1], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(-0.5, m[1][0], 1E-5);
@@ -79,11 +74,17 @@ MatrixToolsTest::matrixInversionTest2()
   mat3[7] = m[2][1] = 8.0;
   mat3[8] = m[2][2] = 9.0;
 
-  int error = MatrixTools::inverse(mat3, 3);
-  CPPUNIT_ASSERT(error != 0);
+  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(mat3, 3), MatrixTools::MatrixInversionException);
+  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m, m), MatrixTools::MatrixInversionException);
 
-  error = MatrixTools::inverse(m, m);
-  CPPUNIT_ASSERT(error != 0);
+  std::vector<std::vector<Real> > m2(2);
+  for (auto & row : m)
+    row.resize(3);
+
+  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m, m2), MatrixTools::MatrixMismatchException);
+
+  std::vector<std::vector<Real> > m3(0);
+  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m3, m3), MatrixTools::NoInputMatrixException);
 }
 
 void
@@ -112,8 +113,7 @@ MatrixToolsTest::matrixInversionTest3()
   mat3[7] = m[2][1] = 6.0;
   mat3[8] = m[2][2] = 0.0;
 
-  int error = MatrixTools::inverse(mat3, 3);
-  CPPUNIT_ASSERT(error == 0);
+  MatrixTools::inverse(mat3, 3);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(-24, mat3[0], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(18, mat3[1], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(5, mat3[2], 1E-5);
@@ -124,8 +124,7 @@ MatrixToolsTest::matrixInversionTest3()
   CPPUNIT_ASSERT_DOUBLES_EQUAL(4, mat3[7], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(1, mat3[8], 1E-5);
 
-  error = MatrixTools::inverse(m, m);
-  CPPUNIT_ASSERT(error == 0);
+  MatrixTools::inverse(m, m);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(-24, m[0][0], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(18, m[0][1], 1E-5);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(5, m[0][2], 1E-5);

--- a/unit/src/MatrixToolsTest.C
+++ b/unit/src/MatrixToolsTest.C
@@ -74,17 +74,17 @@ MatrixToolsTest::matrixInversionTest2()
   mat3[7] = m[2][1] = 8.0;
   mat3[8] = m[2][2] = 9.0;
 
-  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(mat3, 3), MatrixTools::MatrixInversionException);
-  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m, m), MatrixTools::MatrixInversionException);
+  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(mat3, 3), MooseException);
+  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m, m), MooseException);
 
   std::vector<std::vector<Real> > m2(2);
   for (auto & row : m)
     row.resize(3);
 
-  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m, m2), MatrixTools::MatrixMismatchException);
+  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m, m2), MooseException);
 
   std::vector<std::vector<Real> > m3(0);
-  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m3, m3), MatrixTools::NoInputMatrixException);
+  CPPUNIT_ASSERT_THROW(MatrixTools::inverse(m3, m3), MooseException);
 }
 
 void


### PR DESCRIPTION
Replace `int` return codes with exceptions. Keep types sane all the way up to the Fortran calls.

Refs #7041
