### PR TITLE
Throw error on bad MooseEnum string comparison

### DIFF
--- a/framework/src/utils/MooseEnum.C
+++ b/framework/src/utils/MooseEnum.C
@@ -105,6 +105,10 @@ MooseEnum::operator==(const char * name) const
   std::string upper(name);
   std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
 
+  if (std::find(_names.begin(), _names.end(), upper) == _names.end())
+    if (_out_of_range_index == 0)     // Are out of range values allowed?
+      mooseError(std::string("Invalid string comparison \"") + upper + "\" in MooseEnum.  Valid options (not case-sensitive) are \"" + _raw_names + "\".");
+
   return _current_name == upper;
 }
 

--- a/framework/src/utils/MooseEnum.C
+++ b/framework/src/utils/MooseEnum.C
@@ -105,7 +105,7 @@ MooseEnum::operator==(const char * name) const
   std::string upper(name);
   std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
 
-  if (std::find(_names.begin(), _names.end(), upper) == _names.end())
+  if (std::find(_names.begin(), _names.end(), upper) == _names.end() && (upper != ""))
     if (_out_of_range_index == 0)     // Are out of range values allowed?
       mooseError(std::string("Invalid string comparison \"") + upper + "\" in MooseEnum.  Valid options (not case-sensitive) are \"" + _raw_names + "\".");
 

--- a/test/include/auxkernels/BadEnumAux.h
+++ b/test/include/auxkernels/BadEnumAux.h
@@ -1,0 +1,46 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef BADENUMAUX_H
+#define BADENUMAUX_H
+
+#include "AuxKernel.h"
+
+
+//Forward Declarations
+class BadEnumAux;
+
+template<>
+InputParameters validParams<BadEnumAux>();
+
+/**
+ * Self auxiliary value
+ */
+class BadEnumAux : public AuxKernel
+{
+public:
+
+  /**
+   * Factory constructor, takes parameters so that all derived classes can be built using the same
+   * constructor.
+   */
+  BadEnumAux(const InputParameters & parameters);
+
+  virtual ~BadEnumAux();
+
+protected:
+  virtual Real computeValue();
+};
+
+#endif //BADENUMAUX_H

--- a/test/src/auxkernels/BadEnumAux.C
+++ b/test/src/auxkernels/BadEnumAux.C
@@ -1,0 +1,48 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "BadEnumAux.h"
+
+template<>
+InputParameters validParams<BadEnumAux>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  MooseEnum choice("this that", "this");
+
+  params.addParam<MooseEnum>("choice", choice, "Time to choose.");
+
+  return params;
+}
+
+BadEnumAux::BadEnumAux(const InputParameters & parameters) :
+    AuxKernel(parameters)
+{
+  MooseEnum my_choice = parameters.get<MooseEnum>("choice");
+
+  // use a bad string comparison here
+  if (my_choice == "the_other")
+    mooseError("Should not reach here because 'the_other' was not in the original MooseEnum");
+}
+
+BadEnumAux::~BadEnumAux()
+{
+}
+
+Real
+BadEnumAux::computeValue()
+{
+  return _u[_qp];
+}
+

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -92,6 +92,7 @@
 #include "FluxAverageAux.h"
 #include "OldMaterialAux.h"
 #include "DotCouplingAux.h"
+#include "BadEnumAux.h"
 
 #include "RobinBC.h"
 #include "InflowBC.h"
@@ -352,6 +353,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerAux(FluxAverageAux);
   registerAux(OldMaterialAux);
   registerAux(DotCouplingAux);
+  registerAux(BadEnumAux);
 
   // DG kernels
   registerDGKernel(DGMatDiffusion);

--- a/test/tests/misc/check_error/bad_enum_comparison_test.i
+++ b/test/tests/misc/check_error/bad_enum_comparison_test.i
@@ -1,0 +1,40 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[AuxVariables]
+  [./aux_u]
+  [../]
+[]
+
+[AuxKernels]
+  [./bad_enum_aux]
+    type = BadEnumAux
+    variable = aux_u
+    choice = that
+    execute_on = timestep_end
+  [../]
+[]
+
+[Problem]
+  type = FEProblem
+  solve = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -535,4 +535,10 @@
     input = wrong_displacement_order.i
     expect_err = "Error: mesh has SECOND order elements, so all displacement variables must be SECOND order."
   [../]
+
+  [./bad_enum_comparison_test]
+    type = 'RunException'
+    input = 'bad_enum_comparison_test.i'
+    expect_err = 'Invalid string comparison "\w+" in MooseEnum.'
+  [../]
 []


### PR DESCRIPTION
Basically took the code in the = operator that tested the input string against the MooseEnum members and copied into the == operator. Now when doing a bad string comparison against a MooseEnum, it throws an error. Also added a test for this.

closes #7141 
