### PR TITLE
Move Dirac point off element boundary slightly.

### DIFF
--- a/test/tests/dirackernels/multiplicity/multiplicity.i
+++ b/test/tests/dirackernels/multiplicity/multiplicity.i
@@ -53,7 +53,7 @@
     type = MaterialMultiPointSource
     variable = u1
     points = '0.2 0.3 0.0
-              0.7 0.5 0.0'
+              0.7 0.6 0.0'
   [../]
   [./material_source2]
     type = MaterialMultiPointSource


### PR DESCRIPTION
This makes the test more robust to different partitionings in
parallel, and does not require regolding.

Refs #7060.
