### PR TITLE
Use "install -C" when installing libmesh.

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -87,7 +87,8 @@ if [ -z "$go_fast" ]; then
   mkdir build
   cd build
 
-  ../configure --with-methods="${METHODS}" \
+  ../configure INSTALL="`which install` -C" \
+               --with-methods="${METHODS}" \
                --prefix=$LIBMESH_DIR \
                --enable-silent-rules \
                --enable-unique-id \


### PR DESCRIPTION
This will somewhat reduce the amount of recompilation required after
libmesh updates, although the main benefit will be to people who
recompile libmesh more frequently, but do so via the
update_and_rebuild_libmesh.sh script instead of using custom build
scripts.  @dschwen and I confirmed that the -C flag does the right
thing (only copying files which have changed) on both Linux and Mac.

Refs #6741.
