### PR TITLE
New gt sort

### DIFF
--- a/framework/include/base/ConsoleStream.h
+++ b/framework/include/base/ConsoleStream.h
@@ -54,7 +54,7 @@ public:
    *   _console << "The combination to the air lock is " << 12345 << std::endl;
    */
   template<typename StreamType>
-  const ConsoleStream & operator<<(StreamType s) const;
+  const ConsoleStream & operator<<(const StreamType & s) const;
 
   /**
    * This overload is here to handle the the std::endl manipulator
@@ -72,7 +72,7 @@ private:
 
 template<typename StreamType>
 const ConsoleStream &
-ConsoleStream::operator<<(StreamType s) const
+ConsoleStream::operator<<(const StreamType & s) const
 {
   _oss << s;
   return *this;

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -91,9 +91,14 @@ public:
     {
     }
 
-    // Copy constructors
-    FeatureData(const FeatureData & f) = default;
-    FeatureData & operator=(const FeatureData & f) = default;
+    /**
+     * We do not expect these objects to ever be copied. This is important
+     * since they are stored in standard containers directly. To enforce
+     * this, we are explicitly deleting the copy constructor, and copy
+     * assignment operator.
+     */
+    FeatureData(const FeatureData & f) = delete;
+    FeatureData & operator=(const FeatureData & f) = delete;
 
     // Move constructors
     FeatureData(FeatureData && f) = default;
@@ -313,7 +318,7 @@ protected:
    * The data structure used to hold the globally unique features. The outer vector
    * is indexed by variable number, the inner vector is indexed by feature number
    */
-  std::vector<std::vector<std::unique_ptr<FeatureData> > > _feature_sets;
+  std::vector<std::vector<FeatureData> > _feature_sets;
 
   /**
    * The feature maps contain the raw flooded node information and eventually the unique grain numbers.  We have a vector
@@ -418,11 +423,9 @@ FeatureFloodCount::writeCSVFile(const std::string file_name, const std::vector<T
 }
 
 template<> void dataStore(std::ostream & stream, FeatureFloodCount::FeatureData & feature, void * context);
-template<> void dataStore(std::ostream & stream, std::unique_ptr<FeatureFloodCount::FeatureData> & feature, void * context);
 template<> void dataStore(std::ostream & stream, MeshTools::BoundingBox & bbox, void * context);
 
 template<> void dataLoad(std::istream & stream, FeatureFloodCount::FeatureData & feature, void * context);
-template<> void dataLoad(std::istream & stream, std::unique_ptr<FeatureFloodCount::FeatureData> & feature, void * context);
 template<> void dataLoad(std::istream & stream, MeshTools::BoundingBox & bbox, void * context);
 
 

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -91,18 +91,13 @@ public:
     {
     }
 
-    FeatureData(const FeatureData & f) :
-        _ghosted_ids(f._ghosted_ids),
-        _local_ids(f._local_ids),
-        _halo_ids(f._halo_ids),
-        _periodic_nodes(f._periodic_nodes),
-        _var_idx(f._var_idx),
-        _bboxes(f._bboxes),
-        _min_entity_id(f._min_entity_id),
-        _status(NOT_MARKED),
-        _merged(f._merged),
-        _intersects_boundary(f._intersects_boundary)
-    {}
+    // Copy constructors
+    FeatureData(const FeatureData & f) = default;
+    FeatureData & operator=(const FeatureData & f) = default;
+
+    // Move constructors
+    FeatureData(FeatureData && f) = default;
+    FeatureData & operator=(FeatureData && f) = default;
 
     void updateBBoxMin(MeshTools::BoundingBox & bbox, const Point & min);
     void updateBBoxMax(MeshTools::BoundingBox & bbox, const Point & max);

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -157,7 +157,7 @@ protected:
   NonlinearSystem & _nl;
 
   /// This data structure holds the map of unique grains.  The information is updated each timestep to track grains over time.
-  std::map<unsigned int, std::unique_ptr<FeatureData> > & _unique_grains;
+  std::map<unsigned int, FeatureData> & _unique_grains;
 
   /**
    * This data structure holds unique grain to EBSD data map information. It's possible when using 2D scans of 3D microstructures

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -188,6 +188,14 @@ struct GrainDistance
   GrainDistance();
   GrainDistance(Real distance, unsigned int grain_id, unsigned int var_index);
 
+  // Copy constructors
+  GrainDistance(const GrainDistance & f) = default;
+  GrainDistance & operator=(const GrainDistance & f) = default;
+
+  // Move constructors
+  GrainDistance(GrainDistance && f) = default;
+  GrainDistance & operator=(GrainDistance && f) = default;
+
   bool operator<(const GrainDistance & rhs) const;
 
   Real _distance;

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -122,8 +122,12 @@ GrainTracker::finalize()
       {
         for (auto elem_id : grain_pair.second._local_ids)
         {
-          mooseAssert(!_ebsd_reader || _unique_grain_to_ebsd_num.find(grain_pair.first) != _unique_grain_to_ebsd_num.end(), "Bad mapping in unique_grain_to_ebsd_num");
-          _elemental_data[elem_id].push_back(std::make_pair(_ebsd_reader ? _unique_grain_to_ebsd_num[grain_pair.first] : grain_pair.first, grain_pair.second._var_idx));
+          mooseAssert(!_ebsd_reader || _unique_grain_to_ebsd_num.find(grain_pair.first) !=
+                      _unique_grain_to_ebsd_num.end(), "Bad mapping in unique_grain_to_ebsd_num");
+          _elemental_data[elem_id].emplace_back(_ebsd_reader ?
+                                                _unique_grain_to_ebsd_num[grain_pair.first] :
+                                                grain_pair.first,
+                                                grain_pair.second._var_idx);
         }
       }
     }
@@ -437,7 +441,7 @@ GrainTracker::trackGrains()
       // If it's not in the index list, it hasn't been transferred
       if (new_grain_idx_to_existing_grain_idx.find(std::make_pair(map_num, feature_num)) == new_grain_idx_to_existing_grain_idx.end())
       {
-        mooseAssert(_feature_sets[map_num][i]._status == NOT_MARKED, "Feature in wrong state, logic error");
+        mooseAssert(_feature_sets[map_num][feature_num]._status == NOT_MARKED, "Feature in wrong state, logic error");
 
         auto new_idx = _unique_grains.size();
 

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -332,12 +332,6 @@ GrainTracker::trackGrains()
                          return std::move(std::pair<unsigned int, std::unique_ptr<FeatureData> >(counter++, std::move(item)));
                        });
       }
-
-
-      for (auto & grain_pair : _unique_grains)
-        std::cout << grain_pair.first << " " << grain_pair.second->_var_idx << std::endl;
-
-
     }
     return;  // Return early - no matching or tracking to do
   }
@@ -640,6 +634,7 @@ GrainTracker::attemptGrainRenumber(FeatureData & grain, unsigned int grain_id, u
                 return lhs.begin()->_distance > rhs.begin()->_distance;
             });
 
+#ifndef NDEBUG
   _console << "\n********************************************\nDistances list for grain " << grain_id << '\n';
   for (unsigned int i = 0; i < min_distances.size(); ++i)
   {
@@ -647,6 +642,7 @@ GrainTracker::attemptGrainRenumber(FeatureData & grain, unsigned int grain_id, u
       _console << grain_distance._distance << ": " << grain_distance._grain_id << ": " <<  grain_distance._var_index << '\n';
     _console << '\n';
   }
+#endif
 
   for (unsigned int i = 0; i < min_distances.size(); ++i)
   {

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -325,7 +325,11 @@ GrainTracker::trackGrains()
                     return lhs->_min_entity_id < rhs->_min_entity_id;
                   });
 
-        // Transfer the grains to the _unique_grains structure and assign ids
+        /**
+         * Transfer the grains to the _unique_grains structure and assign ids
+         * Transform a vector that looks like this { A, D, C, B, F, E}
+         * into a map like this { {1,A}, {2,D}, {3,D}, {4, B}, {5, F}, {6, E} }
+         */
         std::transform(_feature_sets[map_num].begin(), _feature_sets[map_num].end(), std::inserter(_unique_grains, _unique_grains.end()),
                        [&counter](std::unique_ptr<FeatureData> & item)
                        {


### PR DESCRIPTION
A little cleanup with more C++11. However this also does a better sort on the initial id assignment for the grains. It shouldn't depend on the number of processors, so we are sorting on the minimum mesh entity in the grain.

refs #6711 
