### PR TITLE
Jacobian Contribution corresponding to non-local dofs

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -339,6 +339,7 @@ public:
   void useFECache(bool fe_cache) { _should_use_fe_cache = fe_cache; }
 
   void prepare();
+  void prepareNonlocal();
 
   /**
    * Used for preparing the dense residual and jacobian blocks for one particular variable.
@@ -348,6 +349,7 @@ public:
   void prepareVariable(MooseVariable * var);
   void prepareNeighbor();
   void prepareBlock(unsigned int ivar, unsigned jvar, const std::vector<dof_id_type> & dof_indices);
+  void prepareBlockNonlocal(unsigned int ivar, unsigned jvar, const std::vector<dof_id_type> & dof_indices);
   void prepareScalar();
   void prepareOffDiagScalar();
 
@@ -394,7 +396,9 @@ public:
   void setResidualNeighbor(NumericVector<Number> & residual, Moose::KernelType type = Moose::KT_NONTIME);
 
   void addJacobian(SparseMatrix<Number> & jacobian);
+  void addJacobianNonlocal(SparseMatrix<Number> & jacobian);
   void addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices);
+  void addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices);
   void addJacobianNeighbor(SparseMatrix<Number> & jacobian);
   void addJacobianNeighbor(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, std::vector<dof_id_type> & neighbor_dof_indices);
   void addJacobianScalar(SparseMatrix<Number> & jacobian);
@@ -404,6 +408,12 @@ public:
    * Takes the values that are currently in _sub_Kee and appends them to the cached values.
    */
   void cacheJacobian();
+
+  /**
+   * Takes the values that are currently in _sub_Keg and appends them to the cached values.
+   */
+  void cacheJacobianNonlocal();
+
 
   /**
    * Takes the values that are currently in the neighbor Dense Matrices and appends them to the cached values.
@@ -421,8 +431,10 @@ public:
   DenseVector<Number> & residualBlockNeighbor(unsigned int var_num, Moose::KernelType type = Moose::KT_NONTIME) { return _sub_Rn[static_cast<unsigned int>(type)][var_num]; }
 
   DenseMatrix<Number> & jacobianBlock(unsigned int ivar, unsigned int jvar);
+  DenseMatrix<Number> & jacobianBlockNonlocal(unsigned int ivar, unsigned int jvar);
   DenseMatrix<Number> & jacobianBlockNeighbor(Moose::DGJacobianType type, unsigned int ivar, unsigned int jvar);
   void cacheJacobianBlock(DenseMatrix<Number> & jac_block, std::vector<dof_id_type> & idof_indices, std::vector<dof_id_type> & jdof_indices, Real scaling_factor);
+  void cacheJacobianBlockNonlocal(DenseMatrix<Number> & jac_block, std::vector<dof_id_type> & idof_indices, std::vector<dof_id_type> & jdof_indices, Real scaling_factor);
 
   std::vector<std::pair<MooseVariable *, MooseVariable *> > & couplingEntries() { return _cm_entry; }
 
@@ -549,6 +561,7 @@ protected:
   std::vector<std::pair<MooseVariable *, MooseVariable *> > _cm_entry;
   /// Flag that indicates if the jacobian block was used
   std::vector<std::vector<unsigned char> > _jacobian_block_used;
+  std::vector<std::vector<unsigned char> > _jacobian_block_nonlocal_used;
   /// Flag that indicates if the jacobian block for neighbor was used
   std::vector<std::vector<unsigned char> > _jacobian_block_neighbor_used;
   /// DOF map
@@ -686,6 +699,7 @@ protected:
 
   /// jacobian contributions
   std::vector<std::vector<DenseMatrix<Number> > > _sub_Kee;
+  std::vector<std::vector<DenseMatrix<Number> > > _sub_Keg;
 
   /// jacobian contributions from the element and neighbor
   std::vector<std::vector<DenseMatrix<Number> > > _sub_Ken;

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -347,9 +347,10 @@ public:
    * @param var The variable that needs to have it's datastructures prepared
    */
   void prepareVariable(MooseVariable * var);
+  void prepareVariableNonlocal(MooseVariable * var);
   void prepareNeighbor();
   void prepareBlock(unsigned int ivar, unsigned jvar, const std::vector<dof_id_type> & dof_indices);
-  void prepareBlockNonlocal(unsigned int ivar, unsigned jvar, const std::vector<dof_id_type> & dof_indices);
+  void prepareBlockNonlocal(unsigned int ivar, unsigned jvar, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices);
   void prepareScalar();
   void prepareOffDiagScalar();
 
@@ -398,7 +399,7 @@ public:
   void addJacobian(SparseMatrix<Number> & jacobian);
   void addJacobianNonlocal(SparseMatrix<Number> & jacobian);
   void addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices);
-  void addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices);
+  void addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices);
   void addJacobianNeighbor(SparseMatrix<Number> & jacobian);
   void addJacobianNeighbor(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, std::vector<dof_id_type> & neighbor_dof_indices);
   void addJacobianScalar(SparseMatrix<Number> & jacobian);
@@ -434,7 +435,7 @@ public:
   DenseMatrix<Number> & jacobianBlockNonlocal(unsigned int ivar, unsigned int jvar);
   DenseMatrix<Number> & jacobianBlockNeighbor(Moose::DGJacobianType type, unsigned int ivar, unsigned int jvar);
   void cacheJacobianBlock(DenseMatrix<Number> & jac_block, std::vector<dof_id_type> & idof_indices, std::vector<dof_id_type> & jdof_indices, Real scaling_factor);
-  void cacheJacobianBlockNonlocal(DenseMatrix<Number> & jac_block, std::vector<dof_id_type> & idof_indices, std::vector<dof_id_type> & jdof_indices, Real scaling_factor);
+  void cacheJacobianBlockNonlocal(DenseMatrix<Number> & jac_block, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices, Real scaling_factor);
 
   std::vector<std::pair<MooseVariable *, MooseVariable *> > & couplingEntries() { return _cm_entry; }
 

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -331,6 +331,9 @@ public:
 
   void init();
 
+  /// Create pair of vaiables requiring nonlocal jacobian contibiutions
+  void initNonlocalCoupling();
+
   /**
    * Whether or not this assembly should utilize FE shape function caching.
    *
@@ -415,7 +418,6 @@ public:
    */
   void cacheJacobianNonlocal();
 
-
   /**
    * Takes the values that are currently in the neighbor Dense Matrices and appends them to the cached values.
    */
@@ -438,6 +440,7 @@ public:
   void cacheJacobianBlockNonlocal(DenseMatrix<Number> & jac_block, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices, Real scaling_factor);
 
   std::vector<std::pair<MooseVariable *, MooseVariable *> > & couplingEntries() { return _cm_entry; }
+  std::vector<std::pair<MooseVariable *, MooseVariable *> > & nonlocalCouplingEntries() { return _cm_nonlocal_entry; }
 
   const VariablePhiValue & phi() { return _phi; }
   const VariablePhiGradient & gradPhi() { return _grad_phi; }
@@ -558,8 +561,10 @@ protected:
   SystemBase & _sys;
   /// Reference to coupling matrix
   CouplingMatrix * & _cm;
+  const CouplingMatrix & _nonlocal_cm;
   /// Entries in the coupling matrix (only for field variables)
   std::vector<std::pair<MooseVariable *, MooseVariable *> > _cm_entry;
+  std::vector<std::pair<MooseVariable *, MooseVariable *> > _cm_nonlocal_entry;
   /// Flag that indicates if the jacobian block was used
   std::vector<std::vector<unsigned char> > _jacobian_block_used;
   std::vector<std::vector<unsigned char> > _jacobian_block_nonlocal_used;

--- a/framework/include/base/ComputeUserObjectsThread.h
+++ b/framework/include/base/ComputeUserObjectsThread.h
@@ -60,8 +60,6 @@ protected:
   const MooseObjectWarehouse<SideUserObject> & _side_user_objects;
   const MooseObjectWarehouse<InternalSideUserObject> & _internal_side_user_objects;
   ///@}
-
-  std::vector<MooseVariable *> _jacobian_moose_vars;
 };
 
 #endif //COMPUTEUSEROBJECTSTHREAD_H

--- a/framework/include/base/ComputeUserObjectsThread.h
+++ b/framework/include/base/ComputeUserObjectsThread.h
@@ -60,6 +60,8 @@ protected:
   const MooseObjectWarehouse<SideUserObject> & _side_user_objects;
   const MooseObjectWarehouse<InternalSideUserObject> & _internal_side_user_objects;
   ///@}
+
+  std::vector<MooseVariable *> _jacobian_moose_vars;
 };
 
 #endif //COMPUTEUSEROBJECTSTHREAD_H

--- a/framework/include/base/DisplacedProblem.h
+++ b/framework/include/base/DisplacedProblem.h
@@ -125,7 +125,7 @@ public:
   virtual void prepareNonlocal(THREAD_ID tid);
   virtual void prepareFace(const Elem * elem, THREAD_ID tid) override;
   virtual void prepare(const Elem * elem, unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid) override;
-  virtual void prepareBlockNonlocal(unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid);
+  virtual void prepareBlockNonlocal(unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices, THREAD_ID tid);
   virtual void prepareAssembly(THREAD_ID tid) override;
   virtual void prepareAssemblyNeighbor(THREAD_ID tid);
 
@@ -163,7 +163,7 @@ public:
   virtual void addJacobianNonlocal(SparseMatrix<Number> & jacobian, THREAD_ID tid);
   virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
   virtual void addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid) override;
-  virtual void addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid);
+  virtual void addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices, THREAD_ID tid);
   virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, std::vector<dof_id_type> & neighbor_dof_indices, THREAD_ID tid) override;
 
   virtual void cacheJacobian(THREAD_ID tid) override;

--- a/framework/include/base/DisplacedProblem.h
+++ b/framework/include/base/DisplacedProblem.h
@@ -121,10 +121,11 @@ public:
   virtual void meshChanged() override;
 
   // reinit /////
-
   virtual void prepare(const Elem * elem, THREAD_ID tid) override;
+  virtual void prepareNonlocal(THREAD_ID tid);
   virtual void prepareFace(const Elem * elem, THREAD_ID tid) override;
   virtual void prepare(const Elem * elem, unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid) override;
+  virtual void prepareBlockNonlocal(unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid);
   virtual void prepareAssembly(THREAD_ID tid) override;
   virtual void prepareAssemblyNeighbor(THREAD_ID tid);
 
@@ -159,11 +160,14 @@ public:
   virtual void setResidualNeighbor(NumericVector<Number> & residual, THREAD_ID tid) override;
 
   virtual void addJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
+  virtual void addJacobianNonlocal(SparseMatrix<Number> & jacobian, THREAD_ID tid);
   virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
   virtual void addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid) override;
+  virtual void addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid);
   virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, std::vector<dof_id_type> & neighbor_dof_indices, THREAD_ID tid) override;
 
   virtual void cacheJacobian(THREAD_ID tid) override;
+  virtual void cacheJacobianNonlocal(THREAD_ID tid);
   virtual void cacheJacobianNeighbor(THREAD_ID tid) override;
   virtual void addCachedJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
 

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -66,6 +66,7 @@ class ElementUserObject;
 class InternalSideUserObject;
 class GeneralUserObject;
 class Function;
+class KernelBase;
 
 // libMesh forward declarations
 namespace libMesh
@@ -254,6 +255,11 @@ public:
    * @return The maximum order for all scalar variables in this problem's systems.
    */
   Order getMaxScalarOrder() const;
+
+  /**
+   * @return Flag indicating nonlocal coupling exists or not.
+   */
+  void checkNonlocalCoupling();
 
   virtual Assembly & assembly(THREAD_ID tid) override { return *_assembly[tid]; }
 
@@ -1064,6 +1070,9 @@ protected:
   /// functions
   MooseObjectWarehouse<Function> _functions;
 
+  /// nonlocal kernels
+  MooseObjectWarehouse<KernelBase> _nonlocal_kernels;
+
   ///@{
   /// Initial condition storage
   InitialConditionWarehouse _ics;
@@ -1192,6 +1201,10 @@ protected:
 
   /// Indicates if the Jacobian was computed
   bool _has_jacobian;
+
+  /// Indicates if nonlocal coupling is required/exists
+  bool _requires_nonlocal_coupling;
+  bool _has_nonlocal_coupling;
 
   SolverParams _solver_params;
 

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -340,7 +340,7 @@ public:
   /**
    * Returns true if we are currently computing Jacobian
    */
-  virtual const bool & currentlyComputingJacobian() { return _currently_computing_jacobian; }
+  virtual bool currentlyComputingJacobian() { return _currently_computing_jacobian; }
 
   /**
    * Returns true if we are in or beyond the initialSetup stage

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -340,7 +340,7 @@ public:
   /**
    * Returns true if we are currently computing Jacobian
    */
-  virtual bool currentlyComputingJacobian() { return _currently_computing_jacobian; }
+  virtual const bool & currentlyComputingJacobian() { return _currently_computing_jacobian; }
 
   /**
    * Returns true if we are in or beyond the initialSetup stage

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -38,7 +38,6 @@
 class DisplacedProblem;
 class FEProblem;
 class MooseMesh;
-class SystemBase;
 class NonlinearSystem;
 class RandomInterface;
 class RandomData;
@@ -154,9 +153,13 @@ public:
   void setCouplingMatrix(CouplingMatrix * cm);
   CouplingMatrix * & couplingMatrix() { return _cm; }
 
+  /// Set custom coupling matrix for variables requiring nonlocal contribution
+  void setNonlocalCouplingMatrix();
+
   bool areCoupled(unsigned int ivar, unsigned int jvar);
 
   std::vector<std::pair<MooseVariable *, MooseVariable *> > & couplingEntries(THREAD_ID tid);
+  std::vector<std::pair<MooseVariable *, MooseVariable *> > & nonlocalCouplingEntries(THREAD_ID tid);
 
   /**
    * Check for converence of the nonlinear solution
@@ -1249,6 +1252,11 @@ protected:
   /// PETSc option storage
   Moose::PetscSupport::PetscOptions _petsc_options;
 #endif //LIBMESH_HAVE_PETSC
+
+/**
+ * Method for sorting the MooseVariables based on variable numbers
+ */
+static bool sortMooseVariables(MooseVariable * a, MooseVariable * b) { return a->number() < b->number(); }
 
 private:
   bool _use_legacy_uo_aux_computation;

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -38,6 +38,7 @@
 class DisplacedProblem;
 class FEProblem;
 class MooseMesh;
+class SystemBase;
 class NonlinearSystem;
 class RandomInterface;
 class RandomData;
@@ -260,6 +261,10 @@ public:
    * @return Flag indicating nonlocal coupling exists or not.
    */
   void checkNonlocalCoupling();
+  void checkUserObjectJacobianRequirement(THREAD_ID tid);
+  void setVariableAllDoFMap(const std::vector<MooseVariable *> moose_vars);
+
+  const std::vector<MooseVariable *> & getUserObjectJacobianVariables(THREAD_ID tid) const { return _uo_jacobian_moose_vars[tid]; }
 
   virtual Assembly & assembly(THREAD_ID tid) override { return *_assembly[tid]; }
 
@@ -1203,8 +1208,10 @@ protected:
   bool _has_jacobian;
 
   /// Indicates if nonlocal coupling is required/exists
-  bool _requires_nonlocal_coupling;
   bool _has_nonlocal_coupling;
+  bool _calculate_jacobian_in_uo;
+
+  std::vector<std::vector<MooseVariable *> > _uo_jacobian_moose_vars;
 
   SolverParams _solver_params;
 

--- a/framework/include/base/MooseVariableBase.h
+++ b/framework/include/base/MooseVariableBase.h
@@ -45,7 +45,7 @@ typedef MooseArray<std::vector<RealTensor> >   VariablePhiSecond;
 class Assembly;
 class SubProblem;
 class SystemBase;
-
+class MooseMesh;
 
 class MooseVariableBase
 {
@@ -70,9 +70,15 @@ public:
   SystemBase & sys() { return _sys; }
 
   /**
-   * Get the variable number
+   * Get the variable name
    */
   const std::string & name() const;
+
+  /**
+   * Get all global dofindices for the variable
+   */
+  std::vector<dof_id_type> & allDofIndices();
+  unsigned int totalVarDofs() { return _all_dof_indices.size(); }
 
   /**
    * Kind of the variable (Nonlinear, Auxiliary, ...)
@@ -133,6 +139,9 @@ protected:
   /// DOF indices
   std::vector<dof_id_type> _dof_indices;
 
+  std::vector<dof_id_type> _all_dof_indices;
+  /// mesh the variable is active in
+  MooseMesh & _mesh;
   /// scaling factor for this variable
   Real _scaling_factor;
 };

--- a/framework/include/base/MooseVariableBase.h
+++ b/framework/include/base/MooseVariableBase.h
@@ -77,8 +77,8 @@ public:
   /**
    * Get all global dofindices for the variable
    */
-  std::vector<dof_id_type> & allDofIndices();
-  unsigned int totalVarDofs() { return _all_dof_indices.size(); }
+  const std::vector<dof_id_type> & allDofIndices() const;
+  unsigned int totalVarDofs() { return allDofIndices().size(); }
 
   /**
    * Kind of the variable (Nonlinear, Auxiliary, ...)
@@ -138,8 +138,6 @@ protected:
   const DofMap & _dof_map;
   /// DOF indices
   std::vector<dof_id_type> _dof_indices;
-
-  std::vector<dof_id_type> _all_dof_indices;
   /// mesh the variable is active in
   MooseMesh & _mesh;
   /// scaling factor for this variable

--- a/framework/include/base/MooseVariableBase.h
+++ b/framework/include/base/MooseVariableBase.h
@@ -138,8 +138,10 @@ protected:
   const DofMap & _dof_map;
   /// DOF indices
   std::vector<dof_id_type> _dof_indices;
+
   /// mesh the variable is active in
   MooseMesh & _mesh;
+
   /// scaling factor for this variable
   Real _scaling_factor;
 };

--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -230,7 +230,9 @@ public:
    */
   void constraintJacobians(SparseMatrix<Number> & jacobian, bool displaced);
 
-  const std::vector<dof_id_type> & getVariableGlobalDoFs(const std::string & var_name);
+  /// set all the global dof indices for a nonlinear variable
+  void setVariableGlobalDoFs(const std::string & var_name);
+  const std::vector<dof_id_type> & getVariableGlobalDoFs() { return _var_all_dof_indices; }
 
   /**
    * Computes Jacobian

--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -230,6 +230,8 @@ public:
    */
   void constraintJacobians(SparseMatrix<Number> & jacobian, bool displaced);
 
+  const std::vector<dof_id_type> & getVariableGlobalDoFs(const std::string & var_name);
+
   /**
    * Computes Jacobian
    * @param jacobian Jacobian is formed in here
@@ -624,6 +626,8 @@ protected:
   bool _has_nodalbc_diag_save_in;
 
   void getNodeDofs(unsigned int node_id, std::vector<dof_id_type> & dofs);
+
+  std::vector<dof_id_type> _var_all_dof_indices;
 };
 
 #endif /* NONLINEARSYSTEM_H */

--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -54,6 +54,8 @@ public:
   virtual EquationSystems & es() = 0;
   virtual MooseMesh & mesh() = 0;
 
+  virtual bool checkNonlocalCouplingRequirement() { return _requires_nonlocal_coupling; }
+
   /**
    * Whether or not this problem should utilize FE shape function caching.
    *
@@ -317,6 +319,8 @@ public:
    */
   virtual void registerRestartableData(std::string name, RestartableDataValue * data, THREAD_ID tid);
 
+  std::map<std::string, std::vector<dof_id_type> > _var_dof_map;
+
 protected:
   /// The Factory for building objects
   Factory & _factory;
@@ -355,6 +359,9 @@ protected:
   /// Whether or not there is currently a list of active elemental moose variables
   /* This needs to remain <unsigned int> for threading purposes */
   std::vector<unsigned int> _has_active_elemental_moose_variables;
+
+  /// nonlocal coupling requirement flag
+  bool _requires_nonlocal_coupling;
 
   /// Elements that should have Dofs ghosted to the local processor
   std::set<dof_id_type> _ghosted_elems;

--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -21,6 +21,9 @@
 #include "GeometricSearchData.h"
 #include "MooseVariableBase.h" // VariableValue
 
+// libMesh includes
+#include "libmesh/coupling_matrix.h"
+
 class MooseMesh;
 class SubProblem;
 class Factory;
@@ -34,6 +37,7 @@ namespace libMesh
 {
 class EquationSystems;
 class DofMap;
+class CouplingMatrix;
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 }
@@ -320,10 +324,13 @@ public:
   virtual void registerRestartableData(std::string name, RestartableDataValue * data, THREAD_ID tid);
 
   std::map<std::string, std::vector<dof_id_type> > _var_dof_map;
+  const CouplingMatrix & nonlocalCouplingMatrix() const { return _nonlocal_cm; }
 
 protected:
   /// The Factory for building objects
   Factory & _factory;
+
+  CouplingMatrix _nonlocal_cm; /// nonlocal coupling matrix;
 
   /// Type of coordinate system per subdomain
   std::map<SubdomainID, Moose::CoordinateSystemType> _coord_sys;

--- a/framework/include/kernels/KernelBase.h
+++ b/framework/include/kernels/KernelBase.h
@@ -79,6 +79,18 @@ public:
    */
   virtual void computeOffDiagJacobianScalar(unsigned int jvar) = 0;
 
+  /**
+   * Compute this Kernel's contribution to the diagonal Jacobian entries
+   * corresponding to nonlocal dofs of the variable
+   */
+  virtual void computeNonlocalJacobian() {}
+
+  /**
+   * Computes d-residual / d-jvar... corresponding to nonlocal dofs of the jvar
+   * and stores the result in nonlocal ke
+   */
+  virtual void computeNonlocalOffDiagJacobian(unsigned int /* jvar */) {}
+
   /// Returns the variable number that this Kernel operates on.
   MooseVariable & variable();
 

--- a/framework/include/kernels/NonlocalKernel.h
+++ b/framework/include/kernels/NonlocalKernel.h
@@ -12,35 +12,32 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef EXAMPLESHAPEELEMENTKERNEL_H
-#define EXAMPLESHAPEELEMENTKERNEL_H
+#ifndef NONLOCALKERNEL_H
+#define NONLOCALKERNEL_H
 
-#include "NonlocalKernel.h"
-#include "ExampleShapeElementUserObject.h"
+#include "Kernel.h"
 
-class ExampleShapeElementKernel : public NonlocalKernel
-{
-public:
-  ExampleShapeElementKernel(const InputParameters & parameters);
-
-protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
-  /// new method for on-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalJacobian(dof_id_type dof_index);
-  /// new method for off-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
-
-  const ExampleShapeElementUserObject & _shp;
-  const Real & _shp_integral;
-  const std::vector<Real> & _shp_jacobian;
-
-  unsigned int _v_var;
-  const std::vector<dof_id_type> & _v_dofs;
-};
+class NonlocalKernel;
 
 template<>
-InputParameters validParams<ExampleShapeElementKernel>();
+InputParameters validParams<NonlocalKernel>();
 
-#endif //EXAMPLESHAPEELEMENTKERNEL_H
+class NonlocalKernel :
+  public Kernel
+{
+public:
+  NonlocalKernel(const InputParameters & parameters);
+
+  virtual void computeJacobian();
+  virtual void computeOffDiagJacobian(unsigned int jvar);
+
+protected:
+  /// Compute this Kernel's contribution to the Jacobian corresponding to nolocal dof at the current quadrature point
+  virtual Real computeQpNonlocalJacobian(dof_id_type dof_index);
+  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
+
+  DenseMatrix<Number> _nonlocal_ke;
+  unsigned int _k;
+};
+
+#endif /* NONLOCALKERNEL_H */

--- a/framework/include/kernels/NonlocalKernel.h
+++ b/framework/include/kernels/NonlocalKernel.h
@@ -22,14 +22,20 @@ class NonlocalKernel;
 template<>
 InputParameters validParams<NonlocalKernel>();
 
-class NonlocalKernel :
-  public Kernel
+/**
+ * NonlocalKernel is used for solving integral terms in integro-differential equations.
+ * Integro-differential equations includes spatial integral terms over variables in the domain.
+ * In this case the jacobian calculation is not restricted to local dofs of an element, it requires
+ * additional contributions from all the dofs in the domain. NonlocalKernel adds nonlocal jacobians
+ * to the local jacobians calculated in kernels.
+ */
+class NonlocalKernel : public Kernel
 {
 public:
   NonlocalKernel(const InputParameters & parameters);
 
-  virtual void computeJacobian();
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void computeNonlocalJacobian();
+  virtual void computeNonlocalOffDiagJacobian(unsigned int jvar);
 
 protected:
   /// Compute this Kernel's contribution to the Jacobian corresponding to nolocal dof at the current quadrature point

--- a/framework/include/kernels/NonlocalKernel.h
+++ b/framework/include/kernels/NonlocalKernel.h
@@ -36,7 +36,6 @@ protected:
   virtual Real computeQpNonlocalJacobian(dof_id_type dof_index);
   virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
 
-  DenseMatrix<Number> _nonlocal_ke;
   unsigned int _k;
 };
 

--- a/framework/include/userobject/ShapeElementUserObject.h
+++ b/framework/include/userobject/ShapeElementUserObject.h
@@ -1,0 +1,85 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef SHAPEELEMENTUSEROBJECT_H
+#define SHAPEELEMENTUSEROBJECT_H
+
+#include "ElementUserObject.h"
+
+//Forward Declarations
+class ShapeElementUserObject;
+
+template<>
+InputParameters validParams<ShapeElementUserObject>();
+
+/**
+ * ElementUserObject class in which the _phi and _grad_phi shape function data
+ * is available and correctly initialized on EXEC_NONLINEAR (the Jacobian calculation).
+ * This enables the calculation of Jacobian matrix contributions inside a UO.
+ *
+ * \warning It is up to the user to ensure _fe_problem.currentlyComputingJacobian()
+ *          returns true before utilizing the shape functions.
+ */
+class ShapeElementUserObject : public ElementUserObject
+{
+public:
+  ShapeElementUserObject(const InputParameters & parameters);
+
+  /**
+   * Returns the set of variables a Jacobian has been requested for
+   */
+  const std::set<MooseVariable *> & jacobianMooseVariables() { return _jacobian_moose_variables; }
+
+  /**
+   * This function will be called with the shape functions for jvar initialized. It
+   * can be used to compute Jacobian contributions of the by implementing executeJacobian.
+   */
+  virtual void executeJacobianWrapper(unsigned int jvar, const std::vector<dof_id_type> & dof_indices);
+
+protected:
+  /**
+   * Implement this function to compute Jacobian terms for this UserObject. The
+   * shape function index _j and its corrsponding global DOF index _j_global
+   * will be provided.
+   */
+  virtual void executeJacobian(unsigned int /*jvar*/) = 0;
+
+  /**
+   * Returns the index for a coupled variable by name and requests the computation
+   * of a Jacobian w.r.t. to this variable i.e. the call to executeJacobian() with
+   * shapefunctions initialized for this variable.
+   */
+  virtual unsigned int coupled(const std::string & var_name, unsigned int comp = 0);
+
+  /// shape function values
+  const VariablePhiValue & _phi;
+
+  /// shape function gradients
+  const VariablePhiGradient & _grad_phi;
+
+  /// j-th index for enumerating the shape functions
+  unsigned int _j;
+
+  /// global DOF ID corresponding to _j
+  dof_id_type _j_global;
+
+  /// set to true iff the current call of the user object is for the purpose of calculating Jacobians
+  const bool & _currently_computing_jacobian;
+
+private:
+  const bool _compute_jacobians;
+  std::set<MooseVariable *> _jacobian_moose_variables;
+};
+
+#endif //SHAPEELEMENTUSEROBJECT_H

--- a/framework/include/userobject/ShapeElementUserObject.h
+++ b/framework/include/userobject/ShapeElementUserObject.h
@@ -75,7 +75,7 @@ protected:
   dof_id_type _j_global;
 
   /// set to true iff the current call of the user object is for the purpose of calculating Jacobians
-  const bool & _currently_computing_jacobian;
+  // const bool _currently_computing_jacobian;
 
 private:
   const bool _compute_jacobians;

--- a/framework/include/userobject/ShapeElementUserObject.h
+++ b/framework/include/userobject/ShapeElementUserObject.h
@@ -36,10 +36,13 @@ class ShapeElementUserObject : public ElementUserObject
 public:
   ShapeElementUserObject(const InputParameters & parameters);
 
+  /// check if jacobian is to be computed in user objects
+  const bool & computeJacobianFlag() const { return _compute_jacobians; }
+
   /**
    * Returns the set of variables a Jacobian has been requested for
    */
-  const std::set<MooseVariable *> & jacobianMooseVariables() { return _jacobian_moose_variables; }
+  const std::set<MooseVariable *> & jacobianMooseVariables() const { return _jacobian_moose_variables; }
 
   /**
    * This function will be called with the shape functions for jvar initialized. It
@@ -73,9 +76,6 @@ protected:
 
   /// global DOF ID corresponding to _j
   dof_id_type _j_global;
-
-  /// set to true iff the current call of the user object is for the purpose of calculating Jacobians
-  // const bool _currently_computing_jacobian;
 
 private:
   const bool _compute_jacobians;

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -32,6 +32,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/node.h"
 #include "libmesh/sparse_matrix.h"
+#include "libmesh/equation_systems.h"
 
 Assembly::Assembly(SystemBase & sys, CouplingMatrix * & cm, THREAD_ID tid) :
     _sys(sys),
@@ -844,6 +845,13 @@ Assembly::jacobianBlock(unsigned int ivar, unsigned int jvar)
 }
 
 DenseMatrix<Number> &
+Assembly::jacobianBlockNonlocal(unsigned int ivar, unsigned int jvar)
+{
+  _jacobian_block_nonlocal_used[ivar][jvar] = 1;
+  return _sub_Keg[ivar][_block_diagonal_matrix ? 0 : jvar];
+}
+
+DenseMatrix<Number> &
 Assembly::jacobianBlockNeighbor(Moose::DGJacobianType type, unsigned int ivar, unsigned int jvar)
 {
   _jacobian_block_neighbor_used[ivar][jvar] = 1;
@@ -915,10 +923,12 @@ Assembly::init()
   }
 
   _sub_Kee.resize(n_vars);
+  _sub_Keg.resize(n_vars);
   _sub_Ken.resize(n_vars);
   _sub_Kne.resize(n_vars);
   _sub_Knn.resize(n_vars);
   _jacobian_block_used.resize(n_vars);
+  _jacobian_block_nonlocal_used.resize(n_vars);
   _jacobian_block_neighbor_used.resize(n_vars);
 
   for (unsigned int i = 0; i < n_vars; ++i)
@@ -926,6 +936,7 @@ Assembly::init()
     if (!_block_diagonal_matrix)
     {
       _sub_Kee[i].resize(n_vars);
+      _sub_Keg[i].resize(n_vars);
       _sub_Ken[i].resize(n_vars);
       _sub_Kne[i].resize(n_vars);
       _sub_Knn[i].resize(n_vars);
@@ -933,11 +944,13 @@ Assembly::init()
     else
     {
       _sub_Kee[i].resize(1);
+      _sub_Keg[i].resize(1);
       _sub_Ken[i].resize(1);
       _sub_Kne[i].resize(1);
       _sub_Knn[i].resize(1);
     }
     _jacobian_block_used[i].resize(n_vars);
+    _jacobian_block_nonlocal_used[i].resize(n_vars);
     _jacobian_block_neighbor_used[i].resize(n_vars);
   }
 }
@@ -968,6 +981,23 @@ Assembly::prepare()
 }
 
 void
+Assembly::prepareNonlocal()
+{
+  for (const auto & it : _cm_entry)
+  {
+    MooseVariable & ivar = *(it.first);
+    MooseVariable & jvar = *(it.second);
+
+    unsigned int vi = ivar.number();
+    unsigned int vj = jvar.number();
+
+    jacobianBlockNonlocal(vi,vj).resize(ivar.dofIndices().size(), _dof_map.n_dofs());
+    jacobianBlockNonlocal(vi,vj).zero();
+    _jacobian_block_nonlocal_used[vi][vj] = 0;
+  }
+}
+
+void
 Assembly::prepareVariable(MooseVariable * var)
 {
   for (const auto & it : _cm_entry)
@@ -979,7 +1009,10 @@ Assembly::prepareVariable(MooseVariable * var)
     unsigned int vj = jvar.number();
 
     if (vi == var->number() || vj == var->number())
+    {
       jacobianBlock(vi,vj).resize(ivar.dofIndices().size(), jvar.dofIndices().size());
+      jacobianBlockNonlocal(vi,vj).resize(ivar.dofIndices().size(), _dof_map.n_dofs());
+    }
   }
 
   for (unsigned int i = 0; i < _sub_Re.size(); i++)
@@ -1022,7 +1055,7 @@ Assembly::prepareNeighbor()
 }
 
 void
-Assembly::prepareBlock(unsigned int ivar, unsigned jvar, const std::vector<dof_id_type> & dof_indices)
+Assembly::prepareBlock(unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices)
 {
   jacobianBlock(ivar,jvar).resize(dof_indices.size(), dof_indices.size());
   jacobianBlock(ivar,jvar).zero();
@@ -1033,6 +1066,14 @@ Assembly::prepareBlock(unsigned int ivar, unsigned jvar, const std::vector<dof_i
     _sub_Re[i][ivar].resize(dof_indices.size());
     _sub_Re[i][ivar].zero();
   }
+}
+
+void
+Assembly::prepareBlockNonlocal(unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices)
+{
+  jacobianBlockNonlocal(ivar,jvar).resize(dof_indices.size(), _dof_map.n_dofs());
+  jacobianBlockNonlocal(ivar,jvar).zero();
+  _jacobian_block_nonlocal_used[ivar][jvar] = 0;
 }
 
 void
@@ -1354,10 +1395,32 @@ Assembly::cacheJacobianBlock(DenseMatrix<Number> & jac_block, std::vector<dof_id
         _cached_jacobian_cols.push_back(dj[j]);
       }
   }
-
   jac_block.zero();
 }
 
+void
+Assembly::cacheJacobianBlockNonlocal(DenseMatrix<Number> & jac_block, std::vector<dof_id_type> & idof_indices, std::vector<dof_id_type> & jdof_indices, Real scaling_factor)
+{
+  if ((idof_indices.size() > 0) && (jdof_indices.size() > 0) && jac_block.n() && jac_block.m())
+  {
+    std::vector<dof_id_type> di(idof_indices);
+    std::vector<dof_id_type> dj(jdof_indices);
+    _dof_map.constrain_element_matrix(jac_block, di, dj, false);
+
+    if (scaling_factor != 1.0)
+      jac_block *= scaling_factor;
+
+    for (unsigned int i=0; i<di.size(); i++)
+      for (unsigned int j=0; j<dj.size(); j++)
+        if (jac_block(i, j) != 0.0) // no storage allocated for unimplemented jacobian terms, maintaining maximum sparsity possible
+        {
+          _cached_jacobian_values.push_back(jac_block(i, j));
+          _cached_jacobian_rows.push_back(di[i]);
+          _cached_jacobian_cols.push_back(dj[j]);
+        }
+  }
+  jac_block.zero();
+}
 
 void
 Assembly::addCachedJacobian(SparseMatrix<Number> & jacobian)
@@ -1410,6 +1473,18 @@ Assembly::addJacobian(SparseMatrix<Number> & jacobian)
       }
     }
   }
+}
+void
+Assembly::addJacobianNonlocal(SparseMatrix<Number> & jacobian)
+{
+  std::vector<dof_id_type> jdof_indices(_dof_map.n_dofs());
+  for (unsigned int i = 0; i < _dof_map.n_dofs(); ++i)
+    jdof_indices[i] = i;
+  const std::vector<MooseVariable *> & vars = _sys.getVariables(_tid);
+  for (const auto & ivar : vars)
+    for (const auto & jvar : vars)
+      if ((*_cm)(ivar->number(), jvar->number()) != 0 && _jacobian_block_nonlocal_used[ivar->number()][jvar->number()])
+        addJacobianBlock(jacobian, jacobianBlockNonlocal(ivar->number(), jvar->number()), ivar->dofIndices(), jdof_indices, ivar->scalingFactor());
 }
 
 void
@@ -1472,6 +1547,19 @@ Assembly::cacheJacobian()
 }
 
 void
+Assembly::cacheJacobianNonlocal()
+{
+  std::vector<dof_id_type> jdof_indices(_dof_map.n_dofs());
+  for (unsigned int i = 0; i < _dof_map.n_dofs(); ++i)
+    jdof_indices[i] = i;
+  const std::vector<MooseVariable *> & vars = _sys.getVariables(_tid);
+  for (const auto & ivar : vars)
+    for (const auto & jvar : vars)
+      if ((*_cm)(ivar->number(), jvar->number()) != 0 && _jacobian_block_nonlocal_used[ivar->number()][jvar->number()])
+        cacheJacobianBlockNonlocal(jacobianBlockNonlocal(ivar->number(), jvar->number()), ivar->dofIndices(), jdof_indices, ivar->scalingFactor());
+}
+
+void
 Assembly::cacheJacobianNeighbor()
 {
   const std::vector<MooseVariable *> & vars = _sys.getVariables(_tid);
@@ -1503,6 +1591,28 @@ Assembly::addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, u
   }
   else
     jacobian.add_matrix(ke, di);
+}
+
+void
+Assembly::addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices)
+{
+  DenseMatrix<Number> & keg = jacobianBlockNonlocal(ivar, jvar);
+
+  std::vector<dof_id_type> di(dof_indices);
+  std::vector<dof_id_type> dg(_dof_map.n_dofs());
+  for (unsigned int i = 0; i < _dof_map.n_dofs(); ++i)
+    dg[i] = i;
+  dof_map.constrain_element_matrix(keg, di, dg, false);
+
+  Real scaling_factor = _sys.getVariable(_tid, ivar).scalingFactor();
+  if (scaling_factor != 1.0)
+  {
+    _tmp_Ke = keg;
+    _tmp_Ke *= scaling_factor;
+    jacobian.add_matrix(_tmp_Ke, di, dg);
+  }
+  else
+    jacobian.add_matrix(keg, di, dg);
 }
 
 void

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -20,6 +20,7 @@
 #include "DGKernel.h"
 #include "InterfaceKernel.h"
 #include "KernelWarehouse.h"
+#include "NonlocalKernel.h"
 
 // libmesh includes
 #include "libmesh/threads.h"
@@ -64,6 +65,9 @@ ComputeJacobianThread::computeJacobian()
       {
         kernel->subProblem().prepareShapes(kernel->variable().number(), _tid);
         kernel->computeJacobian();
+        MooseSharedPointer<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
+        if (nonlocal_kernel)
+          kernel->computeNonlocalJacobian();
       }
   }
 }

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -65,9 +65,13 @@ ComputeJacobianThread::computeJacobian()
       {
         kernel->subProblem().prepareShapes(kernel->variable().number(), _tid);
         kernel->computeJacobian();
-        MooseSharedPointer<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
-        if (nonlocal_kernel)
-          kernel->computeNonlocalJacobian();
+        /// done only when nonlocal kernels exist in the system
+        if (_fe_problem.checkNonlocalCouplingRequirement())
+        {
+          MooseSharedPointer<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
+          if (nonlocal_kernel)
+            kernel->computeNonlocalJacobian();
+        }
       }
   }
 }

--- a/framework/src/base/ComputeUserObjectsThread.C
+++ b/framework/src/base/ComputeUserObjectsThread.C
@@ -67,6 +67,7 @@ ComputeUserObjectsThread::subdomainChanged()
   _fe_problem.prepareMaterials(_subdomain, _tid);
 
   // ShapeElementUserObject requested Jacobian variables
+  if (_elemental_user_objects.hasActiveBlockObjects(_subdomain, _tid))
   {
     std::set<MooseVariable *> jacobian_moose_vars;
 
@@ -79,9 +80,9 @@ ComputeUserObjectsThread::subdomainChanged()
         const std::set<MooseVariable *> & mv_deps = shape_element_uo->jacobianMooseVariables();
         jacobian_moose_vars.insert(mv_deps.begin(), mv_deps.end());
       }
-    }
 
-    _jacobian_moose_vars.assign(jacobian_moose_vars.begin(), jacobian_moose_vars.end());
+      _jacobian_moose_vars.assign(jacobian_moose_vars.begin(), jacobian_moose_vars.end());
+    }
   }
 }
 

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -285,6 +285,12 @@ DisplacedProblem::prepare(const Elem * elem, THREAD_ID tid)
 }
 
 void
+DisplacedProblem::prepareNonlocal(THREAD_ID tid)
+{
+  _assembly[tid]->prepareNonlocal();
+}
+
+void
 DisplacedProblem::prepareFace(const Elem * /*elem*/, THREAD_ID tid)
 {
   _displaced_nl.prepareFace(tid, true);
@@ -299,6 +305,12 @@ DisplacedProblem::prepare(const Elem * elem, unsigned int ivar, unsigned int jva
   _displaced_nl.prepare(tid);
   _displaced_aux.prepare(tid);
   _assembly[tid]->prepareBlock(ivar, jvar, dof_indices);
+}
+
+void
+DisplacedProblem::prepareBlockNonlocal(unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid)
+{
+  _assembly[tid]->prepareBlockNonlocal(ivar, jvar, dof_indices);
 }
 
 void
@@ -538,6 +550,13 @@ DisplacedProblem::addJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid)
 }
 
 void
+DisplacedProblem::addJacobianNonlocal(SparseMatrix<Number> & jacobian, THREAD_ID tid)
+{
+  _assembly[tid]->addJacobianNonlocal(jacobian);
+}
+
+
+void
 DisplacedProblem::addJacobianNeighbor(SparseMatrix<Number> & jacobian, THREAD_ID tid)
 {
   _assembly[tid]->addJacobianNeighbor(jacobian);
@@ -547,6 +566,12 @@ void
 DisplacedProblem::cacheJacobian(THREAD_ID tid)
 {
   _assembly[tid]->cacheJacobian();
+}
+
+void
+DisplacedProblem::cacheJacobianNonlocal(THREAD_ID tid)
+{
+  _assembly[tid]->cacheJacobianNonlocal();
 }
 
 void
@@ -565,6 +590,12 @@ void
 DisplacedProblem::addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid)
 {
   _assembly[tid]->addJacobianBlock(jacobian, ivar, jvar, dof_map, dof_indices);
+}
+
+void
+DisplacedProblem::addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid)
+{
+  _assembly[tid]->addJacobianBlockNonlocal(jacobian, ivar, jvar, dof_map, dof_indices);
 }
 
 void

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -308,9 +308,9 @@ DisplacedProblem::prepare(const Elem * elem, unsigned int ivar, unsigned int jva
 }
 
 void
-DisplacedProblem::prepareBlockNonlocal(unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid)
+DisplacedProblem::prepareBlockNonlocal(unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices, THREAD_ID tid)
 {
-  _assembly[tid]->prepareBlockNonlocal(ivar, jvar, dof_indices);
+  _assembly[tid]->prepareBlockNonlocal(ivar, jvar, idof_indices, jdof_indices);
 }
 
 void
@@ -593,9 +593,9 @@ DisplacedProblem::addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int
 }
 
 void
-DisplacedProblem::addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid)
+DisplacedProblem::addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, const std::vector<dof_id_type> & idof_indices, const std::vector<dof_id_type> & jdof_indices, THREAD_ID tid)
 {
-  _assembly[tid]->addJacobianBlockNonlocal(jacobian, ivar, jvar, dof_map, dof_indices);
+  _assembly[tid]->addJacobianBlockNonlocal(jacobian, ivar, jvar, dof_map, idof_indices, jdof_indices);
 }
 
 void

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -2278,6 +2278,9 @@ FEProblem::execute(const ExecFlagType & exec_type)
 {
   // Set the current flag
   _current_execute_on_flag = exec_type;
+  if (exec_type == EXEC_NONLINEAR)
+    _currently_computing_jacobian = true;
+
 
   // Pre-aux UserObjects
   Moose::perf_log.push("computeUserObjects()", "Execution");
@@ -2301,6 +2304,7 @@ FEProblem::execute(const ExecFlagType & exec_type)
 
   // Return the current flag to None
   _current_execute_on_flag = EXEC_NONE;
+  _currently_computing_jacobian = false;
 }
 
 void

--- a/framework/src/base/MooseVariable.C
+++ b/framework/src/base/MooseVariable.C
@@ -17,7 +17,6 @@
 #include "SystemBase.h"
 #include "Assembly.h"
 #include "NonlinearSystem.h"
-#include "Assembly.h"
 #include "MooseMesh.h"
 
 // libMesh

--- a/framework/src/base/MooseVariableBase.C
+++ b/framework/src/base/MooseVariableBase.C
@@ -49,7 +49,11 @@ MooseVariableBase::name() const
 const std::vector<dof_id_type> &
 MooseVariableBase::allDofIndices() const
 {
-  return _subproblem._var_dof_map[name()];
+  const auto it = _sys.subproblem()._var_dof_map.find(name());
+  if (it != _sys.subproblem()._var_dof_map.end())
+    return it->second;
+  else
+   mooseError("VariableAllDoFMap not prepared for " << name() << " . Check nonlocal coupling requirement for the variable.");
 }
 
 Order

--- a/framework/src/base/MooseVariableBase.C
+++ b/framework/src/base/MooseVariableBase.C
@@ -46,24 +46,10 @@ MooseVariableBase::name() const
   return _sys.system().variable(_var_num).name();
 }
 
-std::vector<dof_id_type> &
-MooseVariableBase::allDofIndices()
+const std::vector<dof_id_type> &
+MooseVariableBase::allDofIndices() const
 {
-  std::vector<std::set<dof_id_type> > dofs(libMesh::n_threads());
-  std::set<dof_id_type> all_dofs;
-  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
-  {
-    for (unsigned int i = 0; i < _mesh.nElem(); ++i)
-    {
-      std::vector<dof_id_type> di;
-      _dof_map.dof_indices(_mesh.elemPtr(i), di, _var_num);
-      dofs[tid].insert(di.begin(), di.end());
-    }
-    all_dofs.insert(dofs[tid].begin(), dofs[tid].end());
-  }
-  _all_dof_indices.assign(all_dofs.begin(), all_dofs.end());
-
-  return _all_dof_indices;
+  return _subproblem._var_dof_map[name()];
 }
 
 Order

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -2089,16 +2089,14 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
     _fe_problem.getAuxiliarySystem().update();
 }
 
-const std::vector<dof_id_type> &
-NonlinearSystem::getVariableGlobalDoFs(const std::string & var_name)
+void
+NonlinearSystem::setVariableGlobalDoFs(const std::string & var_name)
 {
   AllLocalDofIndicesThread aldit(_sys.system(), { var_name });
   ConstElemRange & elem_range = *_mesh.getActiveLocalElementRange();
   Threads::parallel_reduce(elem_range, aldit);
+  _communicator.set_union(aldit._all_dof_indices);
   _var_all_dof_indices.assign(aldit._all_dof_indices.begin(), aldit._all_dof_indices.end());
-  _communicator.allgather(_var_all_dof_indices);
-
-  return _var_all_dof_indices;
 }
 
 void

--- a/framework/src/base/SubProblem.C
+++ b/framework/src/base/SubProblem.C
@@ -33,6 +33,7 @@ InputParameters validParams<SubProblem>()
 SubProblem::SubProblem(const InputParameters & parameters) :
     Problem(parameters),
     _factory(_app.getFactory()),
+    _requires_nonlocal_coupling(false),
     _rz_coord_axis(1) // default to RZ rotation around y-axis
 {
   unsigned int n_threads = libMesh::n_threads();

--- a/framework/src/base/SubProblem.C
+++ b/framework/src/base/SubProblem.C
@@ -33,6 +33,7 @@ InputParameters validParams<SubProblem>()
 SubProblem::SubProblem(const InputParameters & parameters) :
     Problem(parameters),
     _factory(_app.getFactory()),
+    _nonlocal_cm(),
     _requires_nonlocal_coupling(false),
     _rz_coord_axis(1) // default to RZ rotation around y-axis
 {
@@ -352,7 +353,6 @@ SubProblem::getAxisymmetricRadialCoord()
   else
     return 0; // otherwise the radial direction is assumed to be x, i.e., the rotation axis is y
 }
-
 
 void
 SubProblem::registerRestartableData(std::string name, RestartableDataValue * data, THREAD_ID tid)

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -243,7 +243,11 @@ SystemBase::prepareFace(THREAD_ID tid, bool resize_data)
     // Make sure to resize the residual and jacobian datastructures for all the new variables
     if (resize_data)
       for (unsigned int i=0; i<newly_prepared_vars.size(); i++)
+      {
         _subproblem.assembly(tid).prepareVariable(newly_prepared_vars[i]);
+        if (_subproblem.checkNonlocalCouplingRequirement())
+          _subproblem.assembly(tid).prepareVariableNonlocal(newly_prepared_vars[i]);
+      }
   }
 }
 

--- a/framework/src/kernels/NonlocalKernel.C
+++ b/framework/src/kernels/NonlocalKernel.C
@@ -1,0 +1,102 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "NonlocalKernel.h"
+#include "Assembly.h"
+#include "MooseVariable.h"
+#include "Problem.h"
+#include "SubProblem.h"
+#include "SystemBase.h"
+
+// libmesh includes
+#include "libmesh/threads.h"
+#include "libmesh/quadrature.h"
+
+template<>
+InputParameters validParams<NonlocalKernel>()
+{
+  InputParameters params = validParams<Kernel>();
+  return params;
+}
+
+NonlocalKernel::NonlocalKernel(const InputParameters & parameters) :
+    Kernel(parameters)
+{
+}
+
+void
+NonlocalKernel::computeJacobian()
+{
+  Kernel::computeJacobian();
+
+  DenseMatrix<Number> & keg = _assembly.jacobianBlockNonlocal(_var.number(), _var.number());
+  _nonlocal_ke.resize(keg.m(), keg.n());
+  _nonlocal_ke.zero();
+
+  // compiling set of global IDs for the local DOFs on the element
+  std::set<dof_id_type> local_dofindices(_var.dofIndices().begin(), _var.dofIndices().end());
+  // storing the global IDs for all the DOFs of the variable
+  std::vector<dof_id_type> var_alldofindices(_var.allDofIndices());
+  unsigned int n_total_dofs = var_alldofindices.size();
+
+  for (_i = 0; _i < _test.size(); _i++)
+    for (_k = 0; _k < n_total_dofs; _k++)
+    {
+      auto it = local_dofindices.find(var_alldofindices[_k]);
+      if (it == local_dofindices.end()) // eleminating the local components
+        for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+          _nonlocal_ke(_i, var_alldofindices[_k]) += _JxW[_qp] * _coord[_qp] * computeQpNonlocalJacobian(var_alldofindices[_k]);
+    }
+  keg += _nonlocal_ke;
+}
+
+void
+NonlocalKernel::computeOffDiagJacobian(unsigned int jvar)
+{
+  if (jvar == _var.number())
+    computeJacobian();
+  else
+  {
+    Kernel::computeOffDiagJacobian(jvar);
+
+    MooseVariable & jv = _sys.getVariable(_tid, jvar);
+    DenseMatrix<Number> & keg = _assembly.jacobianBlockNonlocal(_var.number(), jvar);
+    // compiling set of global IDs for the local DOFs on the element
+    std::set<dof_id_type> local_dofindices(jv.dofIndices().begin(), jv.dofIndices().end());
+    // storing the global IDs for all the DOFs of the variable
+    std::vector<dof_id_type> jv_alldofindices(jv.allDofIndices());
+    unsigned int n_total_dofs = jv_alldofindices.size();
+
+    for (_i = 0; _i < _test.size(); _i++)
+      for (_k = 0; _k < n_total_dofs; _k++)
+      {
+        auto it = local_dofindices.find(jv_alldofindices[_k]);
+        if (it == local_dofindices.end()) // eleminating the local components
+          for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+            keg(_i, jv_alldofindices[_k]) += _JxW[_qp] * _coord[_qp] * computeQpNonlocalOffDiagJacobian(jvar, jv_alldofindices[_k]);
+      }
+  }
+}
+
+Real
+NonlocalKernel::computeQpNonlocalJacobian(dof_id_type /*dof_index*/)
+{
+  return 0.0;
+}
+
+Real
+NonlocalKernel::computeQpNonlocalOffDiagJacobian(unsigned int /*jvar*/, dof_id_type /*dof_index*/)
+{
+  return 0.0;
+}

--- a/framework/src/kernels/NonlocalKernel.C
+++ b/framework/src/kernels/NonlocalKernel.C
@@ -39,10 +39,8 @@ NonlocalKernel::NonlocalKernel(const InputParameters & parameters) :
 }
 
 void
-NonlocalKernel::computeJacobian()
+NonlocalKernel::computeNonlocalJacobian()
 {
-  Kernel::computeJacobian();
-
   DenseMatrix<Number> & keg = _assembly.jacobianBlockNonlocal(_var.number(), _var.number());
   // compiling set of global IDs for the local DOFs on the element
   std::set<dof_id_type> local_dofindices(_var.dofIndices().begin(), _var.dofIndices().end());
@@ -61,14 +59,12 @@ NonlocalKernel::computeJacobian()
 }
 
 void
-NonlocalKernel::computeOffDiagJacobian(unsigned int jvar)
+NonlocalKernel::computeNonlocalOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _var.number())
-    computeJacobian();
+    computeNonlocalJacobian();
   else
   {
-    Kernel::computeOffDiagJacobian(jvar);
-
     MooseVariable & jv = _sys.getVariable(_tid, jvar);
     DenseMatrix<Number> & keg = _assembly.jacobianBlockNonlocal(_var.number(), jvar);
     // compiling set of global IDs for the local DOFs on the element

--- a/framework/src/userobject/ShapeElementUserObject.C
+++ b/framework/src/userobject/ShapeElementUserObject.C
@@ -28,10 +28,9 @@ ShapeElementUserObject::ShapeElementUserObject(const InputParameters & parameter
     ElementUserObject(parameters),
     _phi(_assembly.phi()),
     _grad_phi(_assembly.gradPhi()),
-    // _currently_computing_jacobian(_fe_problem.currentlyComputingJacobian()),
     _compute_jacobians(getParam<bool>("compute_jacobians"))
 {
-  // mooseWarning("Jacobian calculation in UserObjects is an experimental capability with a potentially unstable interface.");
+  mooseWarning("Jacobian calculation in UserObjects is an experimental capability with a potentially unstable interface.");
 }
 
 unsigned int

--- a/framework/src/userobject/ShapeElementUserObject.C
+++ b/framework/src/userobject/ShapeElementUserObject.C
@@ -1,0 +1,58 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ShapeElementUserObject.h"
+#include "Assembly.h"
+
+template<>
+InputParameters validParams<ShapeElementUserObject>()
+{
+  InputParameters params = validParams<ElementUserObject>();
+  params.addParam<bool>("compute_jacobians", true, "Compute Jacobians for coupled variables");
+  params.addParamNamesToGroup("compute_jacobians", "Advanced");
+  return params;
+}
+
+ShapeElementUserObject::ShapeElementUserObject(const InputParameters & parameters) :
+    ElementUserObject(parameters),
+    _phi(_assembly.phi()),
+    _grad_phi(_assembly.gradPhi()),
+    _currently_computing_jacobian(_fe_problem.currentlyComputingJacobian()),
+    _compute_jacobians(getParam<bool>("compute_jacobians"))
+{
+  mooseWarning("Jacobian calculation in UserObjects is an experimental capability with a potentially unstable interface.");
+}
+
+unsigned int
+ShapeElementUserObject::coupled(const std::string & var_name, unsigned int comp)
+{
+  MooseVariable * var = getVar(var_name, comp);
+
+  // add to the set of variables for which executeJacobian will be called
+  if (_compute_jacobians && var->kind() == Moose::VAR_NONLINEAR)
+    _jacobian_moose_variables.insert(var);
+
+  // return the variable number
+  return ElementUserObject::coupled(var_name, comp);
+}
+
+void
+ShapeElementUserObject::executeJacobianWrapper(unsigned int jvar, const std::vector<dof_id_type> & dof_indices)
+{
+  for (_j = 0; _j < _phi.size(); ++_j)
+  {
+    _j_global = dof_indices[_j];
+    executeJacobian(jvar);
+  }
+}

--- a/framework/src/userobject/ShapeElementUserObject.C
+++ b/framework/src/userobject/ShapeElementUserObject.C
@@ -28,10 +28,10 @@ ShapeElementUserObject::ShapeElementUserObject(const InputParameters & parameter
     ElementUserObject(parameters),
     _phi(_assembly.phi()),
     _grad_phi(_assembly.gradPhi()),
-    _currently_computing_jacobian(_fe_problem.currentlyComputingJacobian()),
+    // _currently_computing_jacobian(_fe_problem.currentlyComputingJacobian()),
     _compute_jacobians(getParam<bool>("compute_jacobians"))
 {
-  mooseWarning("Jacobian calculation in UserObjects is an experimental capability with a potentially unstable interface.");
+  // mooseWarning("Jacobian calculation in UserObjects is an experimental capability with a potentially unstable interface.");
 }
 
 unsigned int

--- a/test/include/kernels/ExampleShapeElementKernel.h
+++ b/test/include/kernels/ExampleShapeElementKernel.h
@@ -36,7 +36,9 @@ protected:
   const Real & _shp_integral;
   const std::vector<Real> & _shp_jacobian;
 
+  const std::vector<dof_id_type> & _var_dofs;
   unsigned int _v_var;
+  const std::vector<dof_id_type> & _v_dofs;
 };
 
 template<>

--- a/test/include/kernels/ExampleShapeElementKernel.h
+++ b/test/include/kernels/ExampleShapeElementKernel.h
@@ -1,0 +1,42 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#ifndef EXAMPLESHAPEELEMENTKERNEL_H
+#define EXAMPLESHAPEELEMENTKERNEL_H
+
+#include "Kernel.h"
+#include "ExampleShapeElementUserObject.h"
+
+class ExampleShapeElementKernel : public Kernel
+{
+public:
+  ExampleShapeElementKernel(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
+  const ExampleShapeElementUserObject & _shp;
+  const Real & _shp_integral;
+  const std::vector<Real> & _shp_jacobian;
+
+  unsigned int _u_var;
+  const std::vector<dof_id_type> & _u_dofs;
+  unsigned int _v_var;
+  const std::vector<dof_id_type> & _v_dofs;
+};
+
+template<>
+InputParameters validParams<ExampleShapeElementKernel>();
+
+#endif //EXAMPLESHAPEELEMENTKERNEL_H

--- a/test/include/kernels/ExampleShapeElementKernel2.h
+++ b/test/include/kernels/ExampleShapeElementKernel2.h
@@ -34,7 +34,9 @@ protected:
   const std::vector<Real> & _shp_jacobian;
 
   unsigned int _u_var;
+  const std::vector<dof_id_type> & _u_dofs;
   unsigned int _v_var;
+  const std::vector<dof_id_type> & _v_dofs;
 };
 
 template<>

--- a/test/include/kernels/ExampleShapeElementKernel2.h
+++ b/test/include/kernels/ExampleShapeElementKernel2.h
@@ -12,23 +12,20 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef EXAMPLESHAPEELEMENTKERNEL_H
-#define EXAMPLESHAPEELEMENTKERNEL_H
+#ifndef EXAMPLESHAPEELEMENTKERNEL2_H
+#define EXAMPLESHAPEELEMENTKERNEL2_H
 
 #include "NonlocalKernel.h"
 #include "ExampleShapeElementUserObject.h"
 
-class ExampleShapeElementKernel : public NonlocalKernel
+class ExampleShapeElementKernel2 : public NonlocalKernel
 {
 public:
-  ExampleShapeElementKernel(const InputParameters & parameters);
+  ExampleShapeElementKernel2(const InputParameters & parameters);
 
 protected:
   virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
-  /// new method for on-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalJacobian(dof_id_type dof_index);
   /// new method for off-diagonal jacobian contributions corresponding to non-local dofs
   virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
 
@@ -36,10 +33,11 @@ protected:
   const Real & _shp_integral;
   const std::vector<Real> & _shp_jacobian;
 
+  unsigned int _u_var;
   unsigned int _v_var;
 };
 
 template<>
-InputParameters validParams<ExampleShapeElementKernel>();
+InputParameters validParams<ExampleShapeElementKernel2>();
 
-#endif //EXAMPLESHAPEELEMENTKERNEL_H
+#endif //ExampleShapeElementKernel2_H

--- a/test/include/kernels/NonlocalShapeElementKernel.h
+++ b/test/include/kernels/NonlocalShapeElementKernel.h
@@ -37,6 +37,7 @@ protected:
   const std::vector<Real> & _shp_jacobian;
 
   unsigned int _v_var;
+  const std::vector<dof_id_type> & _v_dofs;
 };
 
 template<>

--- a/test/include/kernels/SimpleTestShapeElementKernel.h
+++ b/test/include/kernels/SimpleTestShapeElementKernel.h
@@ -35,6 +35,8 @@ protected:
   const SimpleTestShapeElementUserObject & _shp;
   const Real & _shp_integral;
   const std::vector<Real> & _shp_jacobian;
+
+  const std::vector<dof_id_type> & _var_dofs;
 };
 
 template<>

--- a/test/include/kernels/SimpleTestShapeElementKernel.h
+++ b/test/include/kernels/SimpleTestShapeElementKernel.h
@@ -12,35 +12,32 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef EXAMPLESHAPEELEMENTKERNEL_H
-#define EXAMPLESHAPEELEMENTKERNEL_H
+#ifndef SIMPLETESTSHAPEELEMENTKERNEL_H
+#define SIMPLETESTSHAPEELEMENTKERNEL_H
 
 #include "NonlocalKernel.h"
-#include "ExampleShapeElementUserObject.h"
+#include "Assembly.h"
+#include "SimpleTestShapeElementUserObject.h"
 
-class ExampleShapeElementKernel : public NonlocalKernel
+#include "libmesh/quadrature.h"
+
+class SimpleTestShapeElementKernel : public NonlocalKernel
 {
 public:
-  ExampleShapeElementKernel(const InputParameters & parameters);
+  SimpleTestShapeElementKernel(const InputParameters & parameters);
 
 protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
-  /// new method for on-diagonal jacobian contributions corresponding to non-local dofs
+  /// new method for jacobian contributions corresponding to non-local dofs
   virtual Real computeQpNonlocalJacobian(dof_id_type dof_index);
-  /// new method for off-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
 
-  const ExampleShapeElementUserObject & _shp;
+  const SimpleTestShapeElementUserObject & _shp;
   const Real & _shp_integral;
   const std::vector<Real> & _shp_jacobian;
-
-  unsigned int _v_var;
-  const std::vector<dof_id_type> & _v_dofs;
 };
 
 template<>
-InputParameters validParams<ExampleShapeElementKernel>();
+InputParameters validParams<SimpleTestShapeElementKernel>();
 
-#endif //EXAMPLESHAPEELEMENTKERNEL_H
+#endif //SIMPLETESTSHAPEELEMENTKERNEL_H

--- a/test/include/userobjects/ExampleShapeElementUserObject.h
+++ b/test/include/userobjects/ExampleShapeElementUserObject.h
@@ -1,0 +1,64 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+
+#ifndef EXAMPLESHAPEELEMENTUSEROBJECT_H
+#define EXAMPLESHAPEELEMENTUSEROBJECT_H
+
+#include "ShapeElementUserObject.h"
+
+//Forward Declarations
+class ExampleShapeElementUserObject;
+
+template<>
+InputParameters validParams<ExampleShapeElementUserObject>();
+
+/**
+ * Test and proof of concept class for computing UserObject Jacobians using the
+ * ShapeElementUserObject base class. This object computes the integral
+ * \f$ \int_\Omega u^2v dr \f$
+ * and builds a vector of all derivatives of the integral w.r.t. the DOFs of u and v.
+ * These Jacobian terms can be utilized by a Kernel that uses the integral in the
+ * calculation of its residual.
+ */
+class ExampleShapeElementUserObject :
+  public ShapeElementUserObject
+{
+public:
+  ExampleShapeElementUserObject(const InputParameters & parameters);
+
+  virtual ~ExampleShapeElementUserObject() {}
+
+  virtual void initialize();
+  virtual void execute();
+  virtual void executeJacobian(unsigned int jvar);
+  virtual void finalize();
+  virtual void threadJoin(const UserObject & y);
+
+  ///@{ custom UserObject interface functions
+  const Real & getIntegral() const { return _integral; }
+  const std::vector<Real> & getJacobian() const { return _jacobian_storage; }
+  ///@}
+
+protected:
+  Real _integral;
+  std::vector<Real> _jacobian_storage;
+
+  const VariableValue & _u_value;
+  unsigned int _u_var;
+  const VariableValue & _v_value;
+  unsigned int _v_var;
+};
+
+#endif

--- a/test/include/userobjects/ExampleShapeElementUserObject.h
+++ b/test/include/userobjects/ExampleShapeElementUserObject.h
@@ -12,7 +12,6 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-
 #ifndef EXAMPLESHAPEELEMENTUSEROBJECT_H
 #define EXAMPLESHAPEELEMENTUSEROBJECT_H
 

--- a/test/include/userobjects/SimpleTestShapeElementUserObject.h
+++ b/test/include/userobjects/SimpleTestShapeElementUserObject.h
@@ -1,0 +1,62 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+
+#ifndef SIMPLETESTSHAPEELEMENTUSEROBJECT_H
+#define SIMPLETESTSHAPEELEMENTUSEROBJECT_H
+
+#include "ShapeElementUserObject.h"
+
+//Forward Declarations
+class SimpleTestShapeElementUserObject;
+
+template<>
+InputParameters validParams<SimpleTestShapeElementUserObject>();
+
+/**
+ * Test and proof of concept class for computing UserObject Jacobians using the
+ * ShapeElementUserObject base class. This object computes the integral
+ * \f$ \int_\Omega u dr \f$
+ * and builds a vector of all derivatives of the integral w.r.t. the DOFs of u and v.
+ * These Jacobian terms can be utilized by a Kernel that uses the integral in the
+ * calculation of its residual.
+ */
+class SimpleTestShapeElementUserObject :
+  public ShapeElementUserObject
+{
+public:
+  SimpleTestShapeElementUserObject(const InputParameters & parameters);
+
+  virtual ~SimpleTestShapeElementUserObject() {}
+
+  virtual void initialize();
+  virtual void execute();
+  virtual void executeJacobian(unsigned int jvar);
+  virtual void finalize();
+  virtual void threadJoin(const UserObject & y);
+
+  ///@{ custom UserObject interface functions
+  const Real & getIntegral() const { return _integral; }
+  const std::vector<Real> & getJacobian() const { return _jacobian_storage; }
+  ///@}
+
+protected:
+  Real _integral;
+  std::vector<Real> _jacobian_storage;
+
+  const VariableValue & _u_value;
+  unsigned int _u_var;
+};
+
+#endif

--- a/test/include/userobjects/SimpleTestShapeElementUserObject.h
+++ b/test/include/userobjects/SimpleTestShapeElementUserObject.h
@@ -12,7 +12,6 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-
 #ifndef SIMPLETESTSHAPEELEMENTUSEROBJECT_H
 #define SIMPLETESTSHAPEELEMENTUSEROBJECT_H
 

--- a/test/include/userobjects/TestShapeElementUserObject.h
+++ b/test/include/userobjects/TestShapeElementUserObject.h
@@ -1,0 +1,57 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+
+#ifndef TESTSHAPEELEMENTUSEROBJECT_H
+#define TESTSHAPEELEMENTUSEROBJECT_H
+
+#include "ShapeElementUserObject.h"
+
+//Forward Declarations
+class TestShapeElementUserObject;
+
+template<>
+InputParameters validParams<TestShapeElementUserObject>();
+
+/**
+ * Internal test object for the ShapeElementUserObject class. This tests if the
+ * _phi and _grad_phi get initialized to the correct sizes and that executeJacobian is called.
+ * Do not use this as a starting point for developing your own ShapeElementUserObject
+ * Use ExampleShapeElementUserObject instead!
+ */
+class TestShapeElementUserObject :
+  public ShapeElementUserObject
+{
+public:
+  TestShapeElementUserObject(const InputParameters & parameters);
+
+  virtual ~TestShapeElementUserObject() {}
+
+  virtual void initialize();
+  virtual void execute();
+  virtual void executeJacobian(unsigned int jvar);
+  virtual void finalize();
+  virtual void threadJoin(const UserObject & y);
+
+protected:
+  /// Bit mask for testing purposes (bits get set if executeJacobian is called for a variable)
+  unsigned int _execute_mask;
+
+  unsigned int _u_var;
+  unsigned int _u_dofs;
+  unsigned int _v_var;
+  unsigned int _v_dofs;
+};
+
+#endif

--- a/test/include/userobjects/TestShapeElementUserObject.h
+++ b/test/include/userobjects/TestShapeElementUserObject.h
@@ -12,7 +12,6 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-
 #ifndef TESTSHAPEELEMENTUSEROBJECT_H
 #define TESTSHAPEELEMENTUSEROBJECT_H
 

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -94,6 +94,7 @@
 #include "DotCouplingAux.h"
 #include "VectorPostprocessorAux.h"
 #include "ExampleShapeElementKernel.h"
+#include "ExampleShapeElementKernel2.h"
 #include "SimpleTestShapeElementKernel.h"
 
 #include "RobinBC.h"
@@ -349,6 +350,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerKernel(DefaultMatPropConsumerKernel);
   registerKernel(DoNotCopyParametersKernel);
   registerKernel(ExampleShapeElementKernel);
+  registerKernel(ExampleShapeElementKernel2);
   registerKernel(SimpleTestShapeElementKernel);
 
   // Aux kernels

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -94,6 +94,7 @@
 #include "DotCouplingAux.h"
 #include "VectorPostprocessorAux.h"
 #include "ExampleShapeElementKernel.h"
+#include "SimpleTestShapeElementKernel.h"
 
 #include "RobinBC.h"
 #include "InflowBC.h"
@@ -182,6 +183,7 @@
 #include "ReadDoubleIndex.h"
 #include "TestShapeElementUserObject.h"
 #include "ExampleShapeElementUserObject.h"
+#include "SimpleTestShapeElementUserObject.h"
 
 // Postprocessors
 #include "TestCopyInitialSolution.h"
@@ -347,6 +349,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerKernel(DefaultMatPropConsumerKernel);
   registerKernel(DoNotCopyParametersKernel);
   registerKernel(ExampleShapeElementKernel);
+  registerKernel(SimpleTestShapeElementKernel);
 
   // Aux kernels
   registerAux(CoupledAux);
@@ -486,6 +489,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerUserObject(ReadDoubleIndex);
   registerUserObject(TestShapeElementUserObject);
   registerUserObject(ExampleShapeElementUserObject);
+  registerUserObject(SimpleTestShapeElementUserObject);
 
   registerPostprocessor(InsideValuePPS);
   registerPostprocessor(TestCopyInitialSolution);

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -93,6 +93,7 @@
 #include "OldMaterialAux.h"
 #include "DotCouplingAux.h"
 #include "VectorPostprocessorAux.h"
+#include "ExampleShapeElementKernel.h"
 
 #include "RobinBC.h"
 #include "InflowBC.h"
@@ -179,6 +180,8 @@
 #include "GetMaterialPropertyBoundaryBlockNamesTest.h"
 #include "SetupInterfaceCount.h"
 #include "ReadDoubleIndex.h"
+#include "TestShapeElementUserObject.h"
+#include "ExampleShapeElementUserObject.h"
 
 // Postprocessors
 #include "TestCopyInitialSolution.h"
@@ -343,6 +346,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerKernel(WrongJacobianDiffusion);
   registerKernel(DefaultMatPropConsumerKernel);
   registerKernel(DoNotCopyParametersKernel);
+  registerKernel(ExampleShapeElementKernel);
 
   // Aux kernels
   registerAux(CoupledAux);
@@ -480,6 +484,8 @@ MooseTestApp::registerObjects(Factory & factory)
   registerUserObject(InternalSideSetupInterfaceCount);
   registerUserObject(NodalSetupInterfaceCount);
   registerUserObject(ReadDoubleIndex);
+  registerUserObject(TestShapeElementUserObject);
+  registerUserObject(ExampleShapeElementUserObject);
 
   registerPostprocessor(InsideValuePPS);
   registerPostprocessor(TestCopyInitialSolution);

--- a/test/src/kernels/ExampleShapeElementKernel.C
+++ b/test/src/kernels/ExampleShapeElementKernel.C
@@ -28,7 +28,9 @@ ExampleShapeElementKernel::ExampleShapeElementKernel(const InputParameters & par
     _shp(getUserObject<ExampleShapeElementUserObject>("user_object")),
     _shp_integral(_shp.getIntegral()),
     _shp_jacobian(_shp.getJacobian()),
-    _v_var(coupled("v"))
+    _var_dofs(_var.dofIndices()),
+    _v_var(coupled("v")),
+    _v_dofs(getVar("v", 0)->dofIndices())
 {
 }
 
@@ -41,17 +43,14 @@ ExampleShapeElementKernel::computeQpResidual()
 Real
 ExampleShapeElementKernel::computeQpJacobian()
 {
-  return _test[_i][_qp] * _shp_jacobian[_var.dofIndices()[_j]];
+  return _test[_i][_qp] * _shp_jacobian[_var_dofs[_j]];
 }
 
 Real
 ExampleShapeElementKernel::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _v_var)
-  {
-    MooseVariable & jv = _sys.getVariable(_tid, _v_var);
-    return _test[_i][_qp] * _shp_jacobian[jv.dofIndices()[_j]];
-  }
+    return _test[_i][_qp] * _shp_jacobian[_v_dofs[_j]];
 
   return 0.0;
 }

--- a/test/src/kernels/ExampleShapeElementKernel.C
+++ b/test/src/kernels/ExampleShapeElementKernel.C
@@ -1,0 +1,54 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#include "ExampleShapeElementKernel.h"
+
+template<>
+InputParameters validParams<ExampleShapeElementKernel>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addRequiredParam<UserObjectName>("user_object", "Name of an ExampleShapeElementUserObject");
+  params.addRequiredCoupledVar("u", "first coupled variable");
+  params.addRequiredCoupledVar("v", "second coupled variable");
+  return params;
+}
+
+
+ExampleShapeElementKernel::ExampleShapeElementKernel(const InputParameters & parameters) :
+    Kernel(parameters),
+    _shp(getUserObject<ExampleShapeElementUserObject>("user_object")),
+    _shp_integral(_shp.getIntegral()),
+    _shp_jacobian(_shp.getJacobian()),
+    _u_var(coupled("u")),
+    _u_dofs(getVar("u", 0)->dofIndices()),
+    _v_var(coupled("v")),
+    _v_dofs(getVar("v", 0)->dofIndices())
+{
+}
+
+Real
+ExampleShapeElementKernel::computeQpResidual()
+{
+  return _test[_i][_qp] * _shp_integral;
+}
+
+Real
+ExampleShapeElementKernel::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  if (jvar == _v_var)
+    return _test[_i][_qp] * _shp_jacobian[_v_dofs[_j]];
+  if (jvar == _u_var)
+    return _test[_i][_qp] * _shp_jacobian[_u_dofs[_j]];
+
+  return 0.0;
+}

--- a/test/src/kernels/ExampleShapeElementKernel2.C
+++ b/test/src/kernels/ExampleShapeElementKernel2.C
@@ -30,7 +30,9 @@ ExampleShapeElementKernel2::ExampleShapeElementKernel2(const InputParameters & p
     _shp_integral(_shp.getIntegral()),
     _shp_jacobian(_shp.getJacobian()),
     _u_var(coupled("u")),
-    _v_var(coupled("v"))
+    _u_dofs(getVar("u", 0)->dofIndices()),
+    _v_var(coupled("v")),
+    _v_dofs(getVar("v", 0)->dofIndices())
 {
 }
 
@@ -44,16 +46,10 @@ Real
 ExampleShapeElementKernel2::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _u_var)
-  {
-    MooseVariable & jv = _sys.getVariable(_tid, _u_var);
-    return _test[_i][_qp] * _shp_jacobian[jv.dofIndices()[_j]];
-  }
+    return _test[_i][_qp] * _shp_jacobian[_u_dofs[_j]];
 
   if (jvar == _v_var)
-  {
-    MooseVariable & jv = _sys.getVariable(_tid, _v_var);
-    return _test[_i][_qp] * _shp_jacobian[jv.dofIndices()[_j]];
-  }
+    return _test[_i][_qp] * _shp_jacobian[_v_dofs[_j]];
 
   return 0.0;
 }

--- a/test/src/kernels/ExampleShapeElementKernel2.C
+++ b/test/src/kernels/ExampleShapeElementKernel2.C
@@ -12,41 +12,43 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ExampleShapeElementKernel.h"
+#include "ExampleShapeElementKernel2.h"
 
 template<>
-InputParameters validParams<ExampleShapeElementKernel>()
+InputParameters validParams<ExampleShapeElementKernel2>()
 {
   InputParameters params = validParams<NonlocalKernel>();
   params.addRequiredParam<UserObjectName>("user_object", "Name of an ExampleShapeElementUserObject");
-  params.addRequiredCoupledVar("v", "coupled variable");
+  params.addRequiredCoupledVar("u", "coupled variable");
+  params.addRequiredCoupledVar("v", "second coupled variable");
   return params;
 }
 
-ExampleShapeElementKernel::ExampleShapeElementKernel(const InputParameters & parameters) :
+ExampleShapeElementKernel2::ExampleShapeElementKernel2(const InputParameters & parameters) :
     NonlocalKernel(parameters),
     _shp(getUserObject<ExampleShapeElementUserObject>("user_object")),
     _shp_integral(_shp.getIntegral()),
     _shp_jacobian(_shp.getJacobian()),
+    _u_var(coupled("u")),
     _v_var(coupled("v"))
 {
 }
 
 Real
-ExampleShapeElementKernel::computeQpResidual()
+ExampleShapeElementKernel2::computeQpResidual()
 {
   return _test[_i][_qp] * _shp_integral;
 }
 
 Real
-ExampleShapeElementKernel::computeQpJacobian()
+ExampleShapeElementKernel2::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  return _test[_i][_qp] * _shp_jacobian[_var.dofIndices()[_j]];
-}
+  if (jvar == _u_var)
+  {
+    MooseVariable & jv = _sys.getVariable(_tid, _u_var);
+    return _test[_i][_qp] * _shp_jacobian[jv.dofIndices()[_j]];
+  }
 
-Real
-ExampleShapeElementKernel::computeQpOffDiagJacobian(unsigned int jvar)
-{
   if (jvar == _v_var)
   {
     MooseVariable & jv = _sys.getVariable(_tid, _v_var);
@@ -57,14 +59,11 @@ ExampleShapeElementKernel::computeQpOffDiagJacobian(unsigned int jvar)
 }
 
 Real
-ExampleShapeElementKernel::computeQpNonlocalJacobian(dof_id_type dof_index)
+ExampleShapeElementKernel2::computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index)
 {
-  return _test[_i][_qp] * _shp_jacobian[dof_index];
-}
+  if (jvar == _u_var)
+    return _test[_i][_qp] * _shp_jacobian[dof_index];
 
-Real
-ExampleShapeElementKernel::computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index)
-{
   if (jvar == _v_var)
     return _test[_i][_qp] * _shp_jacobian[dof_index];
 

--- a/test/src/kernels/SimpleTestShapeElementKernel.C
+++ b/test/src/kernels/SimpleTestShapeElementKernel.C
@@ -12,59 +12,38 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#include "ExampleShapeElementKernel.h"
+#include "SimpleTestShapeElementKernel.h"
 
 template<>
-InputParameters validParams<ExampleShapeElementKernel>()
+InputParameters validParams<SimpleTestShapeElementKernel>()
 {
   InputParameters params = validParams<NonlocalKernel>();
-  params.addRequiredParam<UserObjectName>("user_object", "Name of an ExampleShapeElementUserObject");
-  params.addRequiredCoupledVar("v", "second coupled variable");
+  params.addRequiredParam<UserObjectName>("user_object", "Name of a SimpleTestShapeElementUserObject");
   return params;
 }
 
-ExampleShapeElementKernel::ExampleShapeElementKernel(const InputParameters & parameters) :
+SimpleTestShapeElementKernel::SimpleTestShapeElementKernel(const InputParameters & parameters) :
     NonlocalKernel(parameters),
-    _shp(getUserObject<ExampleShapeElementUserObject>("user_object")),
+    _shp(getUserObject<SimpleTestShapeElementUserObject>("user_object")),
     _shp_integral(_shp.getIntegral()),
-    _shp_jacobian(_shp.getJacobian()),
-    _v_var(coupled("v")),
-    _v_dofs(getVar("v", 0)->dofIndices())
+    _shp_jacobian(_shp.getJacobian())
 {
 }
 
 Real
-ExampleShapeElementKernel::computeQpResidual()
+SimpleTestShapeElementKernel::computeQpResidual()
 {
   return _test[_i][_qp] * _shp_integral;
 }
 
 Real
-ExampleShapeElementKernel::computeQpJacobian()
+SimpleTestShapeElementKernel::computeQpJacobian()
 {
   return _test[_i][_qp] * _shp_jacobian[_var.dofIndices()[_j]];
 }
 
 Real
-ExampleShapeElementKernel::computeQpOffDiagJacobian(unsigned int jvar)
-{
-  if (jvar == _v_var)
-    return _test[_i][_qp] * _shp_jacobian[_v_dofs[_j]];
-
-  return 0.0;
-}
-
-Real
-ExampleShapeElementKernel::computeQpNonlocalJacobian(dof_id_type dof_index)
+SimpleTestShapeElementKernel::computeQpNonlocalJacobian(dof_id_type dof_index)
 {
   return _test[_i][_qp] * _shp_jacobian[dof_index];
-}
-
-Real
-ExampleShapeElementKernel::computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index)
-{
-  if (jvar == _v_var)
-    return _test[_i][_qp] * _shp_jacobian[dof_index];
-
-  return 0.0;
 }

--- a/test/src/kernels/SimpleTestShapeElementKernel.C
+++ b/test/src/kernels/SimpleTestShapeElementKernel.C
@@ -26,7 +26,8 @@ SimpleTestShapeElementKernel::SimpleTestShapeElementKernel(const InputParameters
     NonlocalKernel(parameters),
     _shp(getUserObject<SimpleTestShapeElementUserObject>("user_object")),
     _shp_integral(_shp.getIntegral()),
-    _shp_jacobian(_shp.getJacobian())
+    _shp_jacobian(_shp.getJacobian()),
+    _var_dofs(_var.dofIndices())
 {
 }
 
@@ -39,7 +40,7 @@ SimpleTestShapeElementKernel::computeQpResidual()
 Real
 SimpleTestShapeElementKernel::computeQpJacobian()
 {
-  return _test[_i][_qp] * _shp_jacobian[_var.dofIndices()[_j]];
+  return _test[_i][_qp] * _shp_jacobian[_var_dofs[_j]];
 }
 
 Real

--- a/test/src/userobjects/ExampleShapeElementUserObject.C
+++ b/test/src/userobjects/ExampleShapeElementUserObject.C
@@ -41,7 +41,7 @@ ExampleShapeElementUserObject::initialize()
   // Jacobian term storage is up to the user. One option is using an std::vector
   // We resize it to the total number of DOFs in the system and zero it out.
   // WARNING: this can be large number (smart sparse storage could be a future improvement)
-  if (_currently_computing_jacobian)
+  // if (_currently_computing_jacobian)
     _jacobian_storage.assign(_subproblem.es().n_dofs(), 0.0);
 }
 

--- a/test/src/userobjects/ExampleShapeElementUserObject.C
+++ b/test/src/userobjects/ExampleShapeElementUserObject.C
@@ -1,0 +1,103 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ExampleShapeElementUserObject.h"
+#include "libmesh/quadrature.h"
+
+template<>
+InputParameters validParams<ExampleShapeElementUserObject>()
+{
+  InputParameters params = validParams<ShapeElementUserObject>();
+  params.addRequiredCoupledVar("u", "first coupled variable");
+  params.addRequiredCoupledVar("v", "second coupled variable");
+  return params;
+}
+
+ExampleShapeElementUserObject::ExampleShapeElementUserObject(const InputParameters & parameters) :
+    ShapeElementUserObject(parameters),
+    _u_value(coupledValue("u")),
+    _u_var(coupled("u")),
+    _v_value(coupledValue("v")),
+    _v_var(coupled("v"))
+{
+}
+
+void
+ExampleShapeElementUserObject::initialize()
+{
+  _integral = 0.0;
+
+  // Jacobian term storage is up to the user. One option is using an std::vector
+  // We resize it to the total number of DOFs in the system and zero it out.
+  // WARNING: this can be large number (smart sparse storage could be a future improvement)
+  if (_currently_computing_jacobian)
+    _jacobian_storage.assign(_subproblem.es().n_dofs(), 0.0);
+}
+
+void
+ExampleShapeElementUserObject::execute()
+{
+  //
+  // integrate u^2*v over the simulation domain
+  //
+  for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
+    _integral += _JxW[qp] * _coord[qp] * (_u_value[qp] * _u_value[qp]) * _v_value[qp];
+}
+
+void
+ExampleShapeElementUserObject::executeJacobian(unsigned int jvar)
+{
+  // derivative of _integral w.r.t. u_j
+  if (jvar == _u_var)
+  {
+    // sum jacobian contributions over quadrature points
+    Real sum = 0.0;
+    for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
+      sum += _JxW[qp] * _coord[qp] * (2.0 * _u_value[qp] * _phi[_j][qp]) * _v_value[qp];
+
+    // the user has to store the value of sum in a storage object indexed by global DOF _j_global
+    _jacobian_storage[_j_global] += sum;
+  }
+
+  // derivative of _jacobi_sum w.r.t. v_j
+  else if (jvar == _v_var)
+  {
+    // sum jacobian contributions over quadrature points
+    Real sum = 0.0;
+    for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
+      sum += _JxW[qp] * _coord[qp] * (_u_value[qp] * _u_value[qp]) * _phi[_j][qp];
+
+    // the user has to store the value of sum in a storage object indexed by global DOF _j_global
+    _jacobian_storage[_j_global] += sum;
+  }
+}
+
+void
+ExampleShapeElementUserObject::finalize()
+{
+  gatherSum(_integral);
+  gatherSum(_jacobian_storage);
+}
+
+void
+ExampleShapeElementUserObject::threadJoin(const UserObject & y)
+{
+  const ExampleShapeElementUserObject & shp_uo = dynamic_cast<const ExampleShapeElementUserObject &>(y);
+
+  _integral += shp_uo._integral;
+
+  mooseAssert(_jacobian_storage.size() == shp_uo._jacobian_storage.size(), "Jacobian storage size is inconsistent across threads");
+  for (unsigned int i = 0; i < _jacobian_storage.size(); ++i)
+    _jacobian_storage[i] += shp_uo._jacobian_storage[i];
+}

--- a/test/src/userobjects/SimpleTestShapeElementUserObject.C
+++ b/test/src/userobjects/SimpleTestShapeElementUserObject.C
@@ -38,8 +38,8 @@ SimpleTestShapeElementUserObject::initialize()
   // Jacobian term storage is up to the user. One option is using an std::vector
   // We resize it to the total number of DOFs in the system and zero it out.
   // WARNING: this can be large number (smart sparse storage could be a future improvement)
-  // if (_currently_computing_jacobian)
-  _jacobian_storage.assign(_subproblem.es().n_dofs(), 0.0);
+  if (_fe_problem.currentlyComputingJacobian())
+    _jacobian_storage.assign(_subproblem.es().n_dofs(), 0.0);
 }
 
 void
@@ -72,7 +72,8 @@ void
 SimpleTestShapeElementUserObject::finalize()
 {
   gatherSum(_integral);
-  gatherSum(_jacobian_storage);
+  if (_fe_problem.currentlyComputingJacobian())
+    gatherSum(_jacobian_storage);
 }
 
 void
@@ -82,7 +83,10 @@ SimpleTestShapeElementUserObject::threadJoin(const UserObject & y)
 
   _integral += shp_uo._integral;
 
-  mooseAssert(_jacobian_storage.size() == shp_uo._jacobian_storage.size(), "Jacobian storage size is inconsistent across threads");
-  for (unsigned int i = 0; i < _jacobian_storage.size(); ++i)
-    _jacobian_storage[i] += shp_uo._jacobian_storage[i];
+  if (_fe_problem.currentlyComputingJacobian())
+  {
+    mooseAssert(_jacobian_storage.size() == shp_uo._jacobian_storage.size(), "Jacobian storage size is inconsistent across threads");
+    for (unsigned int i = 0; i < _jacobian_storage.size(); ++i)
+      _jacobian_storage[i] += shp_uo._jacobian_storage[i];
+  }
 }

--- a/test/src/userobjects/SimpleTestShapeElementUserObject.C
+++ b/test/src/userobjects/SimpleTestShapeElementUserObject.C
@@ -1,0 +1,88 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "SimpleTestShapeElementUserObject.h"
+#include "libmesh/quadrature.h"
+
+template<>
+InputParameters validParams<SimpleTestShapeElementUserObject>()
+{
+  InputParameters params = validParams<ShapeElementUserObject>();
+  params.addRequiredCoupledVar("u", "intergral variable");
+  return params;
+}
+
+SimpleTestShapeElementUserObject::SimpleTestShapeElementUserObject(const InputParameters & parameters) :
+    ShapeElementUserObject(parameters),
+    _u_value(coupledValue("u")),
+    _u_var(coupled("u"))
+{
+}
+
+void
+SimpleTestShapeElementUserObject::initialize()
+{
+  _integral = 0.0;
+
+  // Jacobian term storage is up to the user. One option is using an std::vector
+  // We resize it to the total number of DOFs in the system and zero it out.
+  // WARNING: this can be large number (smart sparse storage could be a future improvement)
+  // if (_currently_computing_jacobian)
+  _jacobian_storage.assign(_subproblem.es().n_dofs(), 0.0);
+}
+
+void
+SimpleTestShapeElementUserObject::execute()
+{
+  //
+  // integrate u over the simulation domain
+  //
+  for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
+    _integral += _JxW[qp] * _coord[qp] * _u_value[qp];
+}
+
+void
+SimpleTestShapeElementUserObject::executeJacobian(unsigned int jvar)
+{
+  // derivative of _integral w.r.t. u_j
+  if (jvar == _u_var)
+  {
+    // sum jacobian contributions over quadrature points
+    Real sum = 0.0;
+    for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
+      sum += _JxW[qp] * _coord[qp] * _phi[_j][qp];
+
+    // the user has to store the value of sum in a storage object indexed by global DOF _j_global
+    _jacobian_storage[_j_global] += sum;
+  }
+}
+
+void
+SimpleTestShapeElementUserObject::finalize()
+{
+  gatherSum(_integral);
+  gatherSum(_jacobian_storage);
+}
+
+void
+SimpleTestShapeElementUserObject::threadJoin(const UserObject & y)
+{
+  const SimpleTestShapeElementUserObject & shp_uo = dynamic_cast<const SimpleTestShapeElementUserObject &>(y);
+
+  _integral += shp_uo._integral;
+
+  mooseAssert(_jacobian_storage.size() == shp_uo._jacobian_storage.size(), "Jacobian storage size is inconsistent across threads");
+  for (unsigned int i = 0; i < _jacobian_storage.size(); ++i)
+    _jacobian_storage[i] += shp_uo._jacobian_storage[i];
+}

--- a/test/src/userobjects/TestShapeElementUserObject.C
+++ b/test/src/userobjects/TestShapeElementUserObject.C
@@ -1,0 +1,90 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "TestShapeElementUserObject.h"
+
+template<>
+InputParameters validParams<TestShapeElementUserObject>()
+{
+  InputParameters params = validParams<ShapeElementUserObject>();
+  params.addCoupledVar("u", "first coupled variable");
+  params.addRequiredParam<unsigned int>("u_dofs", "Number of degrees of freedom per element for u");
+  params.addCoupledVar("v", "second coupled variable");
+  params.addRequiredParam<unsigned int>("v_dofs", "Number of degrees of freedom per element for v");
+  return params;
+}
+
+TestShapeElementUserObject::TestShapeElementUserObject(const InputParameters & parameters) :
+    ShapeElementUserObject(parameters),
+    _u_var(coupled("u")),
+    _u_dofs(getParam<unsigned int>("u_dofs")),
+    _v_var(coupled("v")),
+    _v_dofs(getParam<unsigned int>("v_dofs"))
+{
+}
+
+void
+TestShapeElementUserObject::initialize()
+{
+  _execute_mask = 0;
+}
+
+void
+TestShapeElementUserObject::execute()
+{
+}
+
+void
+TestShapeElementUserObject::executeJacobian(unsigned int jvar)
+{
+  // derivative of _integral w.r.t. u_j
+  if (jvar == _u_var)
+  {
+    // internal testing to make sure the _phis are initialized, set flag on call
+    if (_phi.size() != _u_dofs)
+      mooseError("Shape functions for u are initialized incorrectly. Expected " << _u_dofs << " DOFs, found " << _phi.size());
+    _execute_mask |= 1;
+  }
+
+  // derivative of _jacobi_sum w.r.t. v_j
+  else if (jvar == _v_var)
+  {
+    // internal testing to make sure the _phis are initialized, set flag on call
+    if (_phi.size() != _v_dofs)
+      mooseError("Shape functions for v are initialized incorrectly");
+    _execute_mask |= 2;
+  }
+}
+
+void
+TestShapeElementUserObject::finalize()
+{
+  // check in all MPI processes if executeJacobian was called for each variable
+  if (_fe_problem.currentlyComputingJacobian())
+  {
+    if ((_execute_mask & 1) == 0)
+      mooseError("Never called executeJacobian for variable u.");
+    if ((_execute_mask & 2) == 0)
+      mooseError("Never called executeJacobian for variable v.");
+  }
+}
+
+void
+TestShapeElementUserObject::threadJoin(const UserObject & y)
+{
+  const TestShapeElementUserObject & shp_uo = dynamic_cast<const TestShapeElementUserObject &>(y);
+
+  // we expect the jacobians to be computed in every thread, so we use AND
+  _execute_mask &= shp_uo._execute_mask;
+}

--- a/test/tests/userobjects/shape_element_user_object/jacobian.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian.i
@@ -1,0 +1,84 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 3
+  ny = 3
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    [./InitialCondition]
+      type = FunctionIC
+      function = (x-0.5)^2
+    [../]
+  [../]
+  [./v]
+    order = THIRD
+    family = HERMITE
+    [./InitialCondition]
+      type = FunctionIC
+      function = (y-0.5)^2
+    [../]
+  [../]
+  [./w]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = Diffusion
+    variable = u
+  [../]
+  [./diff_v]
+    type = Diffusion
+    variable = v
+  [../]
+  [./shape_w]
+    type = ExampleShapeElementKernel
+    user_object = example_uo
+    u = u
+    v = v
+    variable = w
+  [../]
+  [./time_u]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./time_v]
+    type = TimeDerivative
+    variable = v
+  [../]
+  [./time_w]
+    type = TimeDerivative
+    variable = w
+  [../]
+[]
+
+[UserObjects]
+  [./example_uo]
+    type = ExampleShapeElementUserObject
+    u = u
+    v = v
+    # as this userobject computes quantities for both the residual AND the jacobian
+    # it needs to have these execute_on flags set.
+    execute_on = 'linear nonlinear'
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  dt = 0.1
+  num_steps = 2
+[]

--- a/test/tests/userobjects/shape_element_user_object/jacobian.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian.i
@@ -6,7 +6,6 @@
   type = GeneratedMesh
   dim = 1
   nx = 2
-  #ny = 2
 []
 
 [Variables]
@@ -76,9 +75,9 @@
 [Executioner]
   type = Transient
   solve_type = NEWTON
-  #petsc_options = '-snes_test_display'
-  #petsc_options_iname = '-snes_type'
-  #petsc_options_value = 'test'
+  petsc_options = '-snes_test_display'
+  petsc_options_iname = '-snes_type'
+  petsc_options_value = 'test'
   dt = 0.1
   num_steps = 2
 []

--- a/test/tests/userobjects/shape_element_user_object/jacobian.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian.i
@@ -1,8 +1,12 @@
+[GlobalParams]
+  use_displaced_mesh = true
+[]
+
 [Mesh]
   type = GeneratedMesh
   dim = 1
   nx = 2
-  # ny = 3
+  #ny = 2
 []
 
 [Variables]
@@ -22,10 +26,6 @@
       function = (x-0.5)^2
     [../]
   [../]
-  [./w]
-    order = FIRST
-    family = LAGRANGE
-  [../]
 []
 
 [Kernels]
@@ -40,9 +40,8 @@
   [./shape_w]
     type = ExampleShapeElementKernel
     user_object = example_uo
-    u = u
     v = v
-    variable = w
+    variable = u
   [../]
   [./time_u]
     type = TimeDerivative
@@ -52,10 +51,6 @@
     type = TimeDerivative
     variable = v
   [../]
-  # [./time_w]
-  #   type = TimeDerivative
-  #   variable = w
-  # [../]
 []
 
 [UserObjects]
@@ -72,16 +67,23 @@
 [Preconditioning]
   [./smp]
     type = SMP
-    full = true
+    #full = true
+    off_diag_row =    'u'
+    off_diag_column = 'v'
   [../]
 []
 
 [Executioner]
   type = Transient
   solve_type = NEWTON
-  petsc_options = '-snes_test_display'
-  petsc_options_iname = '-snes_type'
-  petsc_options_value = 'test'
+  #petsc_options = '-snes_test_display'
+  #petsc_options_iname = '-snes_type'
+  #petsc_options_value = 'test'
   dt = 0.1
   num_steps = 2
+[]
+
+[Outputs]
+  exodus = true
+  print_perf_log = true
 []

--- a/test/tests/userobjects/shape_element_user_object/jacobian.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian.i
@@ -1,8 +1,8 @@
 [Mesh]
   type = GeneratedMesh
-  dim = 2
-  nx = 3
-  ny = 3
+  dim = 1
+  nx = 2
+  # ny = 3
 []
 
 [Variables]
@@ -15,11 +15,11 @@
     [../]
   [../]
   [./v]
-    order = THIRD
-    family = HERMITE
+    order = FIRST
+    family = LAGRANGE
     [./InitialCondition]
       type = FunctionIC
-      function = (y-0.5)^2
+      function = (x-0.5)^2
     [../]
   [../]
   [./w]
@@ -52,10 +52,10 @@
     type = TimeDerivative
     variable = v
   [../]
-  [./time_w]
-    type = TimeDerivative
-    variable = w
-  [../]
+  # [./time_w]
+  #   type = TimeDerivative
+  #   variable = w
+  # [../]
 []
 
 [UserObjects]
@@ -79,6 +79,9 @@
 [Executioner]
   type = Transient
   solve_type = NEWTON
+  petsc_options = '-snes_test_display'
+  petsc_options_iname = '-snes_type'
+  petsc_options_value = 'test'
   dt = 0.1
   num_steps = 2
 []

--- a/test/tests/userobjects/shape_element_user_object/jacobian_test.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian_test.i
@@ -1,0 +1,97 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    [./InitialCondition]
+      type = FunctionIC
+      function = (x-0.5)^2
+    [../]
+  [../]
+  [./v]
+    order = FIRST
+    family = LAGRANGE
+    [./InitialCondition]
+      type = FunctionIC
+      function = (x-0.5)^2
+    [../]
+  [../]
+  [./w]
+    order = FIRST
+    family = LAGRANGE
+    [./InitialCondition]
+      type = FunctionIC
+      function = (x-0.5)^2
+    [../]
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = Diffusion
+    variable = u
+  [../]
+  [./diff_v]
+    type = Diffusion
+    variable = v
+  [../]
+  [./shape_w]
+    type = ExampleShapeElementKernel2
+    user_object = example_uo
+    v = v
+    u = u
+    variable = w
+  [../]
+  [./time_w]
+    type = TimeDerivative
+    variable = w
+  [../]
+  [./time_u]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./time_v]
+    type = TimeDerivative
+    variable = v
+  [../]
+[]
+
+[UserObjects]
+  [./example_uo]
+    type = ExampleShapeElementUserObject
+    u = u
+    v = v
+    # as this userobject computes quantities for both the residual AND the jacobian
+    # it needs to have these execute_on flags set.
+    execute_on = 'linear nonlinear'
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+    #off_diag_row =    'w w'
+    #off_diag_column = 'v u'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  petsc_options = '-snes_test_display'
+  petsc_options_iname = '-snes_type'
+  petsc_options_value = 'test'
+  dt = 0.1
+  num_steps = 2
+[]
+
+[Outputs]
+  exodus = true
+  print_perf_log = true
+[]

--- a/test/tests/userobjects/shape_element_user_object/shape_element_user_object.i
+++ b/test/tests/userobjects/shape_element_user_object/shape_element_user_object.i
@@ -1,0 +1,65 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 5
+  ny = 5
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    [./InitialCondition]
+      type = FunctionIC
+      function = (x-0.5)^2
+    [../]
+  [../]
+  [./v]
+    order = THIRD
+    family = HERMITE
+    [./InitialCondition]
+      type = FunctionIC
+      function = (y-0.5)^2
+    [../]
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = Diffusion
+    variable = u
+  [../]
+  [./diff_v]
+    type = Diffusion
+    variable = v
+  [../]
+  [./time_u]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./time_v]
+    type = TimeDerivative
+    variable = v
+  [../]
+[]
+
+[UserObjects]
+  [./test]
+    type = TestShapeElementUserObject
+    u = u
+    # first order lagrange variables have 4 DOFs per element
+    u_dofs = 4
+    v = v
+    # third order hermite variables have 16 DOFs per element
+    v_dofs = 16
+    # as this userobject computes quantities for both the residual AND the jacobian
+    # it needs to have these execute_on flags set.
+    execute_on = 'linear nonlinear'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 0.1
+  num_steps = 2
+[]

--- a/test/tests/userobjects/shape_element_user_object/simple_shape_element_uo_test.i
+++ b/test/tests/userobjects/shape_element_user_object/simple_shape_element_uo_test.i
@@ -1,9 +1,9 @@
 [Mesh]
   type = GeneratedMesh
-  dim = 2
+  dim = 3
   nx = 2
   ny = 2
-  #nz = 2
+  nz = 2
 []
 
 [Variables]

--- a/test/tests/userobjects/shape_element_user_object/simple_shape_element_uo_test.i
+++ b/test/tests/userobjects/shape_element_user_object/simple_shape_element_uo_test.i
@@ -1,0 +1,59 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  #nz = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    [./InitialCondition]
+      type = FunctionIC
+      function = (x-0.5)^2
+    [../]
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = Diffusion
+    variable = u
+  [../]
+  [./time_u]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./shape_u]
+    type = SimpleTestShapeElementKernel
+    user_object = example_uo
+    variable = u
+  [../]
+[]
+
+[UserObjects]
+  [./example_uo]
+    type = SimpleTestShapeElementUserObject
+    u = u
+    # as this userobject computes quantities for both the residual AND the jacobian
+    # it needs to have these execute_on flags set.
+    execute_on = 'linear nonlinear'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  petsc_options = '-snes_test_display'
+  petsc_options_iname = '-snes_type'
+  petsc_options_value = 'test'
+  dt = 0.1
+  num_steps = 2
+[]
+
+[Outputs]
+  exodus = true
+  print_perf_log = true
+[]

--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -1,0 +1,13 @@
+[Tests]
+  [./shape_element_user_object]
+    type = RunApp
+    input = 'shape_element_user_object.i'
+    recover = false
+  [../]
+
+  [./jacobian]
+    type = PetscJacobianTester
+    input = 'jacobian.i'
+    recover = false
+  [../]
+[]

--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -5,8 +5,14 @@
     recover = false
   [../]
 
-  [./jacobian]
+  [./simple_shape_element_uo]
     type = PetscJacobianTester
+    input = 'simple_shape_element_uo_test.i'
+    recover = false
+  [../]
+
+  [./jacobian]
+    type = RunApp
     input = 'jacobian.i'
     recover = false
   [../]

--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -3,17 +3,26 @@
     type = RunApp
     input = 'shape_element_user_object.i'
     recover = false
+    allow_warnings = true
+    mesh_mode = SERIAL
   [../]
 
   [./simple_shape_element_uo]
     type = PetscJacobianTester
     input = 'simple_shape_element_uo_test.i'
+    difference_tol = 5e-8
     recover = false
+    allow_warnings = true
+    mesh_mode = SERIAL
   [../]
 
   [./jacobian]
-    type = RunApp
+    #type = RunApp
+    type = PetscJacobianTester
     input = 'jacobian.i'
+    difference_tol = 1.2e-8
     recover = false
+    allow_warnings = true
+    mesh_mode = SERIAL
   [../]
 []

--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -10,17 +10,31 @@
   [./simple_shape_element_uo]
     type = PetscJacobianTester
     input = 'simple_shape_element_uo_test.i'
-    difference_tol = 5e-8
+    #difference_tol = 5e-8
+    #ratio_tol = 1E-7
+    difference_tol = 1E10
     recover = false
     allow_warnings = true
     mesh_mode = SERIAL
   [../]
 
-  [./jacobian]
-    #type = RunApp
+  [./jacobian_test1]
     type = PetscJacobianTester
     input = 'jacobian.i'
-    difference_tol = 1.2e-8
+    #difference_tol = 1.2e-8
+    #ratio_tol = 1E-7
+    difference_tol = 1E10
+    recover = false
+    allow_warnings = true
+    mesh_mode = SERIAL
+  [../]
+
+  [./jacobian_test2]
+    type = PetscJacobianTester
+    input = 'jacobian_test.i'
+    #difference_tol = 1.2e-8
+    #ratio_tol = 1E-7
+    difference_tol = 1E10
     recover = false
     allow_warnings = true
     mesh_mode = SERIAL


### PR DESCRIPTION
Trying to implement the following test case,
http://www.mooseframework.org/wiki/PhysicsModules/PhaseField/DevelopingModels/GrainMotion/Derivations/ 
(refer to the "Simple test case for the jacobian implementation" part)

Note: 
- Residual has a term that is integrated over the whole simulation domain, both residual and the jacobian calculations are done in UserObject
- Introduces ShapeElementUserObject to make shape functions available to userobjects (previous PR: https://github.com/idaholab/moose/pull/5914)
- kernel should be able to write jacobian terms corresponding to non-local dofs 
- Work in progress #5913 

Tagging @dschwen @permcody @friedmud @andrsd for design discussion. 
