### PR TITLE
Small bugfix for "not shouldExecute and valgrind mode"

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -276,7 +276,7 @@ class RunApp(Tester):
       elif retcode != 0 and specs['should_crash'] == False:
         reason = 'CRASH'
       # Valgrind runs
-      elif retcode == 0 and options.valgrind_mode != '' and 'ERROR SUMMARY: 0 errors' not in output:
+      elif retcode == 0 and self.shouldExecute() and options.valgrind_mode != '' and 'ERROR SUMMARY: 0 errors' not in output:
         reason = 'MEMORY ERROR'
       # PBS runs
       elif retcode == 0 and options.pbs and 'command not found' in output:


### PR DESCRIPTION
if shouldExecute() is false when we are running in valgrind mode we erroneously fall into this case, which appears to be the only case that _really_ expects output for success.

refs #7215 
