### PR TITLE
Update libmesh.

### DIFF
--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/tests
@@ -18,6 +18,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
+    deleted = 'Ticket #7073'
   [../]
   [./frictionless_kin]
     type = 'CSVDiff'


### PR DESCRIPTION
Brief summary of changes included in this update:
- Fix missing rehash call in Fparser.
- Many fixes for --enable-singleprecision builds.
- Add support for TRISHELL3, QUADSHELL4 element types.
- Add BoundaryInfo support for new shell element types.
- Add support for writing shell elements in XdrIO.
- Add optimized contains_point() implementations for Tri3 and Tet4.
- Add TypeTensor::solve().
- Minor optimizations to 2D/3D Elem::volume() optimizations.
- Add TypeVector::cross_norm().
- Clean up misc_ex7.
- Add libmesh_noexcept wrapping C++11 noexcept specification.
- Add const-correct Elem interfaces neighbor_ptr(), child_ptr(), side_ptr(), etc.
- Handle NULL elements in EquationSystems::get_solution().
- Add MeshBase::active_semilocal_elements_begin() interface.
- Add C++11 std::make_unique workaround.
- Optimize stitch_meshes() by avoiding unnecessary PointLocator calls.
- Speed up "make check" by modifying examples slightly.
- All all_first_order option to meshtool app.
- Add BoundaryInfo::copy_boundary_ids() interface.
- Add --enable-cxx11-required configure flag.
- Avoid writing trailing whitespace in XDA files.
- Fix a few unsigned -> dof_id_type type mismatches.
- Add configure test for C++11 std::condition_variable.
- Use non-deprecated PETSc-3.7 interfaces.
- Nonblocking send/receive of packed ranges.

Refs #000.
