### PR TITLE
Added ScalarCoupleable to Postprocessors through UOs

### DIFF
--- a/framework/include/userobject/ElementUserObject.h
+++ b/framework/include/userobject/ElementUserObject.h
@@ -21,7 +21,6 @@
 #include "MaterialPropertyInterface.h"
 #include "UserObjectInterface.h"
 #include "Coupleable.h"
-#include "ScalarCoupleable.h"
 #include "MooseVariableDependencyInterface.h"
 #include "TransientInterface.h"
 #include "PostprocessorInterface.h"
@@ -46,7 +45,6 @@ class ElementUserObject :
   public MaterialPropertyInterface,
   public UserObjectInterface,
   public Coupleable,
-  public ScalarCoupleable,
   public MooseVariableDependencyInterface,
   public TransientInterface,
   protected PostprocessorInterface,

--- a/framework/include/userobject/NodalUserObject.h
+++ b/framework/include/userobject/NodalUserObject.h
@@ -22,7 +22,6 @@
 #include "MaterialPropertyInterface.h"
 #include "UserObjectInterface.h"
 #include "Coupleable.h"
-#include "ScalarCoupleable.h"
 #include "MooseVariableDependencyInterface.h"
 #include "TransientInterface.h"
 #include "PostprocessorInterface.h"
@@ -46,7 +45,6 @@ class NodalUserObject :
   public MaterialPropertyInterface,
   public UserObjectInterface,
   public Coupleable,
-  public ScalarCoupleable,
   public MooseVariableDependencyInterface,
   public TransientInterface,
   protected PostprocessorInterface,

--- a/framework/include/userobject/UserObject.h
+++ b/framework/include/userobject/UserObject.h
@@ -22,6 +22,7 @@
 #include "Restartable.h"
 #include "MeshChangedInterface.h"
 #include "ParallelUniqueId.h"
+#include "ScalarCoupleable.h"
 
 // libMesh includes
 #include "libmesh/parallel.h"
@@ -43,7 +44,8 @@ class UserObject :
   public SetupInterface,
   public FunctionInterface,
   public Restartable,
-  public MeshChangedInterface
+  public MeshChangedInterface,
+  public ScalarCoupleable
 {
 public:
   UserObject(const InputParameters & params);

--- a/framework/src/userobject/ElementUserObject.C
+++ b/framework/src/userobject/ElementUserObject.C
@@ -36,7 +36,6 @@ ElementUserObject::ElementUserObject(const InputParameters & parameters) :
     MaterialPropertyInterface(this, blockIDs()),
     UserObjectInterface(this),
     Coupleable(this, false),
-    ScalarCoupleable(this),
     MooseVariableDependencyInterface(),
     TransientInterface(this),
     PostprocessorInterface(this),

--- a/framework/src/userobject/NodalUserObject.C
+++ b/framework/src/userobject/NodalUserObject.C
@@ -37,7 +37,6 @@ NodalUserObject::NodalUserObject(const InputParameters & parameters) :
     MaterialPropertyInterface(this, blockIDs(), boundaryIDs()),
     UserObjectInterface(this),
     Coupleable(this, true),
-    ScalarCoupleable(this),
     MooseVariableDependencyInterface(),
     TransientInterface(this),
     PostprocessorInterface(this),

--- a/framework/src/userobject/UserObject.C
+++ b/framework/src/userobject/UserObject.C
@@ -44,6 +44,7 @@ UserObject::UserObject(const InputParameters & parameters) :
     FunctionInterface(this),
     Restartable(parameters, "UserObjects"),
     MeshChangedInterface(parameters),
+    ScalarCoupleable(this),
     _subproblem(*parameters.get<SubProblem *>("_subproblem")),
     _fe_problem(*parameters.get<FEProblem *>("_fe_problem")),
     _tid(parameters.get<THREAD_ID>("_tid")),

--- a/test/include/postprocessors/ScalarCoupledPostprocessor.h
+++ b/test/include/postprocessors/ScalarCoupledPostprocessor.h
@@ -1,0 +1,24 @@
+#ifndef SCALARCOUPLEDPOSTPROCESSOR_H
+#define SCALARCOUPLEDPOSTPROCESSOR_H
+
+#include "SideIntegralPostprocessor.h"
+
+class ScalarCoupledPostprocessor;
+
+template<>
+InputParameters validParams<ScalarCoupledPostprocessor>();
+
+class ScalarCoupledPostprocessor : public SideIntegralPostprocessor
+{
+public:
+  ScalarCoupledPostprocessor(const InputParameters & parameters);
+
+protected:
+
+  Real computeQpIntegral();
+
+  const VariableValue & _coupled_scalar;
+  const VariableValue & _u;
+};
+
+#endif

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -190,6 +190,7 @@
 #include "TestPostprocessor.h"
 #include "ElementSidePP.h"
 #include "RealControlParameterReporter.h"
+#include "ScalarCoupledPostprocessor.h"
 
 // Functions
 #include "TimestepSetupFunction.h"
@@ -481,6 +482,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerPostprocessor(TestPostprocessor);
   registerPostprocessor(ElementSidePP);
   registerPostprocessor(RealControlParameterReporter);
+  registerPostprocessor(ScalarCoupledPostprocessor);
 
   registerMarker(RandomHitMarker);
   registerMarker(QPointMarker);

--- a/test/src/postprocessors/ScalarCoupledPostprocessor.C
+++ b/test/src/postprocessors/ScalarCoupledPostprocessor.C
@@ -1,0 +1,26 @@
+/**
+* This postprocessor demonstrates coupling a scalar variable to a postprocessor
+*/
+
+#include "ScalarCoupledPostprocessor.h"
+
+template<>
+InputParameters validParams<ScalarCoupledPostprocessor>()
+{
+  InputParameters params = validParams<SideIntegralPostprocessor>();
+  params.addRequiredCoupledVar("variable", "Name of variable");
+  params.addRequiredCoupledVar("coupled_scalar", "The name of the scalar coupled variable");
+  return params;
+}
+
+ScalarCoupledPostprocessor::ScalarCoupledPostprocessor(const InputParameters & parameters) :
+    SideIntegralPostprocessor(parameters),
+    _coupled_scalar(coupledScalarValue("coupled_scalar")),
+    _u(coupledValue("variable"))
+{}
+
+Real
+ScalarCoupledPostprocessor::computeQpIntegral()
+{
+  return _coupled_scalar[0] - _u[_qp];
+}

--- a/test/tests/postprocessors/scalar_coupled_postprocessor/scalar_coupled_postprocessor_test.i
+++ b/test/tests/postprocessors/scalar_coupled_postprocessor/scalar_coupled_postprocessor_test.i
@@ -1,0 +1,73 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 20
+  ny = 20
+  xmax = 1
+  ymax = 1
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [./u]
+    initial_condition = 1
+  [../]
+  [./scalar_variable]
+    family = SCALAR
+    order = FIRST
+    initial_condition = 2
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[ScalarKernels]
+  [./td1]
+    type = ODETimeDerivative
+    variable = scalar_variable
+  [../]
+[]
+
+[BCs]
+  [./leftDirichlet]
+      type = DirichletBC
+      variable = u
+      boundary = 'left'
+      value = 1
+  [../]
+  [./rightDirichlet]
+      type = DirichletBC
+      variable = u
+      boundary = 'right'
+      value = 0
+  [../]
+[]
+
+[Postprocessors]
+  [./totalFlux]
+    type = ScalarCoupledPostprocessor
+    variable = u
+    coupled_scalar = scalar_variable
+    boundary = left
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = JFNK
+  l_max_its = 30
+  l_tol = 1e-6
+  nl_max_its = 20
+  nl_rel_tol = 1e-5
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+  csv = true
+[]

--- a/test/tests/postprocessors/scalar_coupled_postprocessor/tests
+++ b/test/tests/postprocessors/scalar_coupled_postprocessor/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./test]
+    type = 'Exodiff'
+    input = 'scalar_coupled_postprocessor_test.i’
+    exodiff = 'out.e'
+  [../]
+[]


### PR DESCRIPTION
_Fixes: adds ScalarCoupleable to UO
_Fixes: removes ScalarCoupleable from classes that currently inherit from both UO and ScalarCoupleable
_Enhancement: can now couple scalar variables to postprocessors
_Includes a test for the same
_closes #7198
