### PR TITLE
Updated syntax of example problem for elasticity driven grain growth with an EBSD reconstructed IC

### DIFF
--- a/modules/combined/examples/phase_field-mechanics/EBSD_reconstruction_grain_growth_mech.i
+++ b/modules/combined/examples/phase_field-mechanics/EBSD_reconstruction_grain_growth_mech.i
@@ -8,7 +8,7 @@
 []
 
 [GlobalParams]
-  op_num = 30
+  op_num = 15
   var_name_base = gr
   grain_num = 110
 []
@@ -33,11 +33,6 @@
     order = CONSTANT
     family = MONOMIAL
   [../]
-  [./T]
-    order = CONSTANT
-    family = MONOMIAL
-    initial_condition = 500
-  [../]
   [./vonmises_stress]
     order = CONSTANT
     family = MONOMIAL
@@ -58,13 +53,16 @@
     order = CONSTANT
     family = MONOMIAL
   [../]
+  [./EBSD_grain]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
 []
 
 [ICs]
   [./PolycrystalICs]
     [./ReconVarIC]
       ebsd_reader = ebsd
-      consider_phase = false
     [../]
   [../]
 []
@@ -140,6 +138,13 @@
     output_euler_angle = 'phi2'
     execute_on = 'initial'
   [../]
+  [./grain_aux]
+    type = EBSDReaderPointDataAux
+    variable = EBSD_grain
+    ebsd_reader = ebsd
+    data_name = 'grain'
+    execute_on = 'initial'
+  [../]
 []
 
 [BCs]
@@ -168,7 +173,7 @@
     # T = 500 # K
     type = GBEvolution
     block = 0
-    T = T
+    T = 500
     wGB = 0.6 # um
     GBmob0 = 2.5e-6 # m^4/(Js) from Schoenfelder 1997
     Q = 0.23 # Migration energy in eV
@@ -220,13 +225,9 @@
   [../]
   [./grain_tracker]
     type = GrainTracker
-    threshold = 0.1
-    convex_hull_buffer = 0
-    use_single_map = false
-    enable_var_coloring = true
-    condense_map_info = true
+    threshold = 0.2
+    connecting_threshold = 0.2
     compute_op_maps = true
-    bubble_volume_file = IN100-grn-vols.txt
     execute_on = 'initial timestep_begin'
     ebsd_reader = ebsd
     flood_entity_type = ELEMENTAL
@@ -236,7 +237,7 @@
 [Executioner]
   type = Transient
   scheme = bdf2
-  solve_type = PJFNK # Preconditioned JFNK (default)
+  solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_strong_threshold'
   petsc_options_value = '  hypre    boomeramg                   0.7'
   l_tol = 1.0e-4


### PR DESCRIPTION
I updated the syntax of EBSD_reconstructoin_grain_growth_mech.i so it runs again. Closes #7190.
