### PR TITLE
Remove active lists in /examples

### DIFF
--- a/examples/ex01_inputfile/diffusion_pathological.i
+++ b/examples/ex01_inputfile/diffusion_pathological.i
@@ -17,7 +17,6 @@
 
 [Variables]
   active = 'diffused'   # Note the active list here
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -32,8 +31,6 @@
 []
 
 [Kernels]
-  active = 'diff'
-
   [./diff]
     type = Diffusion
     variable = diffused
@@ -42,8 +39,6 @@
 
 # This example applies DirichletBCs to all four sides of our square domain
 [BCs]
-  active = 'left right'
-
   [./left]
     type = DirichletBC
     variable = diffused

--- a/examples/ex01_inputfile/ex01.i
+++ b/examples/ex01_inputfile/ex01.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'diffused'
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -12,8 +10,6 @@
 []
 
 [Kernels]
-  active = 'diff'
-
   [./diff]
     type = Diffusion
     variable = diffused
@@ -21,8 +17,6 @@
 []
 
 [BCs]
-  active = 'bottom top'
-
   [./bottom]
     type = DirichletBC
     variable = diffused

--- a/examples/ex02_kernel/ex02.i
+++ b/examples/ex02_kernel/ex02.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'convected'
-
   [./convected]
     order = FIRST
     family = LAGRANGE
@@ -12,8 +10,6 @@
 []
 
 [Kernels]
-  active = 'diff conv'
-
   [./diff]
     type = Diffusion
     variable = convected
@@ -27,8 +23,6 @@
 []
 
 [BCs]
-  active = 'bottom top'
-
   [./bottom]
     type = DirichletBC
     variable = convected

--- a/examples/ex02_kernel/ex02_oversample.i
+++ b/examples/ex02_kernel/ex02_oversample.i
@@ -15,7 +15,6 @@
 []
 
 [Kernels]
-  active = 'diff'
   [./diff]
     type = Diffusion
     variable = diffused
@@ -32,7 +31,6 @@
 []
 
 [BCs]
-  active = 'all'
   [./all]
     type = DirichletBC
     variable = diffused

--- a/examples/ex03_coupling/ex03.i
+++ b/examples/ex03_coupling/ex03.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'convected diffused'
-
   [./convected]
     order = FIRST
     family = LAGRANGE
@@ -17,8 +15,6 @@
 []
 
 [Kernels]
-  active = 'diff_convected conv diff_diffused'
-
   [./diff_convected]
     type = Diffusion
     variable = convected
@@ -39,8 +35,6 @@
 []
 
 [BCs]
-  active = 'bottom_convected top_convected bottom_diffused top_diffused'
-
   [./bottom_convected]
     type = DirichletBC
     variable = convected

--- a/examples/ex04_bcs/dirichlet_bc.i
+++ b/examples/ex04_bcs/dirichlet_bc.i
@@ -4,8 +4,6 @@
 []
 
 [Variables]
-  active = 'convected diffused'
-
   [./convected]
     order = FIRST
     family = LAGRANGE
@@ -18,8 +16,6 @@
 []
 
 [Kernels]
-  active = 'diff_convected conv diff_diffused'
-
   [./diff_convected]
     type = Diffusion
     variable = convected

--- a/examples/ex04_bcs/neumann_bc.i
+++ b/examples/ex04_bcs/neumann_bc.i
@@ -4,8 +4,6 @@
 []
 
 [Variables]
-  active = 'convected diffused'
-
   [./convected]
     order = FIRST
     family = LAGRANGE
@@ -18,8 +16,6 @@
 []
 
 [Kernels]
-  active = 'diff_convected conv diff_diffused'
-
   [./diff_convected]
     type = Diffusion
     variable = convected

--- a/examples/ex06_transient/ex06.i
+++ b/examples/ex06_transient/ex06.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'diffused'
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -12,8 +10,6 @@
 []
 
 [Kernels]
-  active = 'diff euler'
-
   [./diff]
     type = Diffusion
     variable = diffused
@@ -27,8 +23,6 @@
 []
 
 [BCs]
-  active = 'bottom_diffused top_diffused'
-
   [./bottom_diffused]
     type = DirichletBC
     variable = diffused
@@ -42,7 +36,6 @@
     boundary = 'top'
     value = 1
   [../]
-
 []
 
 [Executioner]

--- a/examples/ex07_ics/steady.i
+++ b/examples/ex07_ics/steady.i
@@ -3,11 +3,7 @@
 []
 
 [Variables]
-  active = 'diffused'
-
   [./diffused]
-    # Note that we do not have the 'active' parameter here.  Since it
-    # is missing we will automatically pickup all nested blocks
     order = FIRST
     family = LAGRANGE
 
@@ -21,8 +17,6 @@
 []
 
 [Kernels]
-  active = 'diff'
-
   [./diff]
     type = Diffusion
     variable = diffused
@@ -30,8 +24,6 @@
 []
 
 [BCs]
-  active = 'left right'
-
   [./left]
     type = DirichletBC
     variable = diffused
@@ -52,8 +44,6 @@
 
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 []
 
 [Outputs]

--- a/examples/ex07_ics/transient.i
+++ b/examples/ex07_ics/transient.i
@@ -3,11 +3,7 @@
 []
 
 [Variables]
-  active = 'diffused'
-
   [./diffused]
-    # Note that we do not have the 'active' parameter here.  Since it
-    # is missing we will automatically pickup all nested blocks
     order = FIRST
     family = LAGRANGE
 
@@ -33,8 +29,6 @@
 []
 
 [BCs]
-  active = 'left right'
-
   [./left]
     type = DirichletBC
     variable = diffused

--- a/examples/ex09_stateful_materials/ex09.i
+++ b/examples/ex09_stateful_materials/ex09.i
@@ -4,8 +4,6 @@
 []
 
 [Variables]
-  active = 'convected diffused'
-
   [./convected]
     order = FIRST
     family = LAGRANGE
@@ -18,8 +16,6 @@
 []
 
 [Kernels]
-  active = 'convected_ie example_diff conv diffused_ie diff'
-
   [./convected_ie]
     type = TimeDerivative
     variable = convected
@@ -49,8 +45,6 @@
 []
 
 [BCs]
-  active = 'left_convected right_convected left_diffused right_diffused'
-
   [./left_convected]
     type = DirichletBC
     variable = convected
@@ -84,8 +78,6 @@
 []
 
 [Materials]
-  active = example_material
-
   [./example_material]
     type = ExampleMaterial
     block = 1

--- a/examples/ex10_aux/ex10.i
+++ b/examples/ex10_aux/ex10.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'diffused'
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -15,8 +13,6 @@
 # will hold the AuxKernel calcuations.  The declaration syntax is very
 # similar to that of the regular variables section
 [AuxVariables]
-  active = 'nodal_aux element_aux'
-
   [./nodal_aux]
     order = FIRST
     family = LAGRANGE
@@ -29,8 +25,6 @@
 []
 
 [Kernels]
-  active = 'diff'
-
   [./diff]
     type = Diffusion
     variable = diffused
@@ -40,8 +34,6 @@
 # Here is the AuxKernels section where we enable the AuxKernels, link
 # them to our AuxVariables, set coupling parameters, and set input parameters
 [AuxKernels]
-  active = 'nodal_example element_example'
-
   [./nodal_example]
     type = ExampleAux
     variable = nodal_aux
@@ -58,8 +50,6 @@
 []
 
 [BCs]
-  active = 'bottom top'
-
   [./bottom]
     type = DirichletBC
     variable = diffused

--- a/examples/ex11_prec/default.i
+++ b/examples/ex11_prec/default.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'diffused forced'
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -17,8 +15,6 @@
 []
 
 [Kernels]
-  active = 'diff_diffused conv_forced diff_forced'
-
   [./diff_diffused]
     type = Diffusion
     variable = diffused
@@ -37,6 +33,7 @@
 []
 
 [BCs]
+  #Note we have active on and neglect the right_forced BC
   active = 'left_diffused right_diffused left_forced'
 
   [./left_diffused]

--- a/examples/ex11_prec/fdp.i
+++ b/examples/ex11_prec/fdp.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'diffused forced'
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -62,8 +60,6 @@
 []
 
 [Kernels]
-  active = 'diff_diffused conv_forced diff_forced'
-
   [./diff_diffused]
     type = Diffusion
     variable = diffused
@@ -82,6 +78,7 @@
 []
 
 [BCs]
+  #Note we have active on, and neglect the right_forced BC
   active = 'left_diffused right_diffused left_forced'
 
   [./left_diffused]

--- a/examples/ex11_prec/smp.i
+++ b/examples/ex11_prec/smp.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'diffused forced'
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -64,8 +62,6 @@
 []
 
 [Kernels]
-  active = 'diff_diffused conv_forced diff_forced'
-
   [./diff_diffused]
     type = Diffusion
     variable = diffused
@@ -84,8 +80,8 @@
 []
 
 [BCs]
+  #Note we have active on and neglect the right_forced BC
   active = 'left_diffused right_diffused left_forced'
-
   [./left_diffused]
     type = DirichletBC
     variable = diffused
@@ -117,9 +113,6 @@
 
 [Executioner]
   type = Steady
-
-
-
 []
 
 [Outputs]

--- a/examples/ex12_pbp/ex12.i
+++ b/examples/ex12_pbp/ex12.i
@@ -3,8 +3,6 @@
 []
 
 [Variables]
-  active = 'diffused forced'
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -18,8 +16,6 @@
 
 # The Preconditioning block
 [Preconditioning]
-  active = 'PBP'
-
   [./PBP]
     type = PBP
     solve_order = 'diffused forced'
@@ -30,8 +26,6 @@
 []
 
 [Kernels]
-  active = 'diff_diffused conv_forced diff_forced'
-
   [./diff_diffused]
     type = Diffusion
     variable = diffused
@@ -50,6 +44,7 @@
 []
 
 [BCs]
+  #Note we have active on and neglect the right_forced BC
   active = 'left_diffused right_diffused left_forced'
 
   [./left_diffused]
@@ -83,9 +78,6 @@
 
 [Executioner]
   type = Steady
-
-
-
 []
 
 [Outputs]

--- a/examples/ex13_functions/ex13.i
+++ b/examples/ex13_functions/ex13.i
@@ -13,8 +13,6 @@
 []
 
 [Variables]
-  active = 'forced'
-
   [./forced]
     order = FIRST
     family = LAGRANGE
@@ -22,8 +20,6 @@
 []
 
 [Functions]
-  active = 'bc_func forcing_func'
-
   # A ParsedFunction allows us to supply analytic expressions
   # directly in the input file
   [./bc_func]
@@ -42,8 +38,6 @@
 []
 
 [Kernels]
-  active = 'diff forcing'
-
   [./diff]
     type = Diffusion
     variable = forced
@@ -58,8 +52,6 @@
 []
 
 [BCs]
-  active = 'all'
-
   # The BC can take a function name to use
   [./all]
     type = FunctionDirichletBC

--- a/examples/ex15_actions/ex15.i
+++ b/examples/ex15_actions/ex15.i
@@ -4,8 +4,6 @@
 []
 
 [Variables]
-  active = 'convected diffused'
-
   [./convected]
     order = FIRST
     family = LAGRANGE
@@ -27,8 +25,6 @@
 []
 
 [BCs]
-  active = 'left_convected right_convected left_diffused right_diffused'
-
   [./left_convected]
     type = DirichletBC
     variable = convected
@@ -58,7 +54,6 @@
     boundary = 'right'
     value = 1
   [../]
-
 []
 
 [Executioner]

--- a/examples/ex16_timestepper/ex16.i
+++ b/examples/ex16_timestepper/ex16.i
@@ -4,8 +4,6 @@
 []
 
 [Variables]
-  active = 'convected diffused'
-
   [./convected]
     order = FIRST
     family = LAGRANGE
@@ -18,8 +16,6 @@
 []
 
 [Kernels]
-  active = 'example_diff conv diff euler'
-
   [./example_diff]
     type = ExampleDiffusion
     variable = convected
@@ -43,8 +39,6 @@
 []
 
 [BCs]
-  active = 'left_convected right_convected left_diffused right_diffused'
-
   [./left_convected]
     type = DirichletBC
     variable = convected
@@ -72,12 +66,9 @@
     boundary = 'right'
     value = 1
   [../]
-
 []
 
 [Materials]
-  active = 'example'
-
   [./example]
     type = ExampleMaterial
     block = 1

--- a/examples/ex17_dirac/ex17.i
+++ b/examples/ex17_dirac/ex17.i
@@ -3,16 +3,13 @@
 []
 
 [Variables]
-  active = 'diffused'
-
   [./diffused]
     order = FIRST
     family = LAGRANGE
   [../]
 []
-[Kernels]
-  active = 'diff'
 
+[Kernels]
   [./diff]
     type = Diffusion
     variable = diffused
@@ -20,8 +17,6 @@
 []
 
 [DiracKernels]
-  active = 'example_point_source'
-
   [./example_point_source]
     type = ExampleDirac
     variable = diffused
@@ -31,8 +26,6 @@
 []
 
 [BCs]
-  active = 'left right'
-
   [./right]
     type = DirichletBC
     variable = diffused

--- a/examples/ex18_scalar_kernel/ex18.i
+++ b/examples/ex18_scalar_kernel/ex18.i
@@ -99,6 +99,7 @@
     variable = x
     execute_on = timestep_end
   [../]
+
   [./y]
     type = ScalarVariable
     variable = y
@@ -143,8 +144,6 @@
 
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 []
 
 [Outputs]

--- a/examples/ex19_dampers/ex19.i
+++ b/examples/ex19_dampers/ex19.i
@@ -12,8 +12,6 @@
 []
 
 [Variables]
-  active = 'diffusion'
-
   [./diffusion]
     order = FIRST
     family = LAGRANGE
@@ -21,8 +19,6 @@
 []
 
 [Kernels]
-  active = 'diff'
-
   [./diff]
     type = Diffusion
     variable = diffusion
@@ -30,8 +26,6 @@
 []
 
 [BCs]
-  active = 'left right'
-
   [./left]
     type = DirichletBC
     variable = diffusion
@@ -61,8 +55,6 @@
 
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 []
 
 [Outputs]

--- a/examples/ex21_debugging/ex21.i
+++ b/examples/ex21_debugging/ex21.i
@@ -9,7 +9,7 @@
 []
 
 [Variables]
-  #Use active lists to help debug problems. Switching on and off 
+  #Use active lists to help debug problems. Switching on and off
   #different Kernels or Variables is extremely useful!
   active = 'diffused convected'
   [./diffused]

--- a/examples/ex21_debugging/ex21.i
+++ b/examples/ex21_debugging/ex21.i
@@ -9,6 +9,9 @@
 []
 
 [Variables]
+  #Use active lists to help debug problems. Switching on and off 
+  #different Kernels or Variables is extremely useful!
+  active = 'diffused convected'
   [./diffused]
     order = FIRST
     family = LAGRANGE
@@ -24,6 +27,7 @@
 
 [Kernels]
   #This Kernel consumes a real-gradient material property from the active material
+  active = 'convection diff_convected example_diff time_deriv_diffused time_deriv_convected'
   [./convection]
     type = ExampleConvection
     variable = convected

--- a/modules/tensor_mechanics/doc/theory/cosserat.tex
+++ b/modules/tensor_mechanics/doc/theory/cosserat.tex
@@ -328,12 +328,12 @@ flat layers perpendicular to the $z$ direction.  The layers have
 thickness $h$ and are separated from each other by an interface
 material.  The interface material has thickness $h_{\mathrm{i}}$,
 Young's modulus $E_{\mathrm{i}}$ and shear modulus $G_{\mathrm{i}}$.
-The theory describes the limit 
+The theory describes the limit
 \begin{equation}
-h_{\mathrm{i}} \rightarrow 0 \ , \ \ \ 
-E_{\mathrm{i}} \rightarrow 0 \ , \ \ \ 
+h_{\mathrm{i}} \rightarrow 0 \ , \ \ \
+E_{\mathrm{i}} \rightarrow 0 \ , \ \ \
 E_{\mathrm{i}}/h_{\mathrm{i}} \rightarrow hk_{n} \ \ \ \mbox{and}
-\ \ \ 
+\ \ \
 G_{\mathrm{i}}/h_{\mathrm{i}} \rightarrow hk_{s} \ .
 \label{thin.layer.limits.eqn}
 \end{equation}


### PR DESCRIPTION
**Changes:**

If there was a comment explaining the active list, then the list was left in. I also added an active list with a comment about their usefulness in debugging in the ex21_debug example.

Otherwise I removed them. I think it's best to show new users that whatever blocks they have in the input file will get read by the Parser. This will avoid confusion with new users whether or not active lists are required. 

As a result of these changes, the example input files are simpler.

closes #7227.

Perhaps we can't merge this yet because the workshop slides need to be changed? Are they technically in the moose repo? Anyway, not sure how I would do that.
