### PR TITLE
Remove unused directory, fix comment in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,5 @@ framework/contrib/asio/
 # phase_field/tests/solution_rasterizer
 out.xyz
 
-#Jit output
-.jitdir/
+# JIT and automatic differentiation cache files
 .jitcache/


### PR DESCRIPTION
The `.jitdir` directory hasn't been used since libmesh/libmesh#1000

Refs #7273
