### PR TITLE
Rewrite minimum distance algorithm

### DIFF
--- a/modules/phase_field/include/ics/BimodalSuperellipsoidsIC.h
+++ b/modules/phase_field/include/ics/BimodalSuperellipsoidsIC.h
@@ -25,19 +25,20 @@ InputParameters validParams<BimodalSuperellipsoidsIC>();
  * is placed, it it checked to make sure it does not collide with previously placed particles (either
  * large or small ones). Variables to describe the specified (larger) superellipsoids are inherited
  * from the parent class.
- **/
+ */
 class BimodalSuperellipsoidsIC : public SpecifiedSmoothSuperellipsoidIC
 {
 public:
   BimodalSuperellipsoidsIC(const InputParameters & parameters);
 
   virtual void initialSetup();
+
+protected:
   virtual void computeSuperellipsoidCenters();
   virtual void computeSuperellipsoidSemiaxes();
   virtual void computeSuperellipsoidExponents();
 
-protected:
-  /// Variables to describe the randomly placed (smaller) superellipsoids
+  ///@{ Variables to describe the randomly placed (smaller) superellipsoids
   unsigned int _npart;
   Real _small_spac;
   Real _large_spac;
@@ -45,10 +46,12 @@ protected:
   Real _small_b;
   Real _small_c;
   Real _small_n;
-  Real _size_variation;
-  MooseEnum _size_variation_type;
+  const Real _size_variation;
+  const MooseEnum _size_variation_type;
+  ///@}
 
-  unsigned int _numtries;
+  const unsigned int _max_num_tries;
+
   Point _bottom_left;
   Point _top_right;
   Point _range;

--- a/modules/phase_field/include/ics/MultiSmoothCircleIC.h
+++ b/modules/phase_field/include/ics/MultiSmoothCircleIC.h
@@ -22,32 +22,26 @@ InputParameters validParams<MultiSmoothCircleIC>();
 /**
  * MultismoothCircleIC creates multiple SmoothCircles (number = numbub) that are randomly
  * positioned around the domain, with a minimum spacing equal to bubspac
- **/
+ */
 class MultiSmoothCircleIC : public SmoothCircleBaseIC
 {
 public:
-  /**
-   * Constructor
-   *
-   * @param parameters The parameters object holding data for the class to use.
-   */
   MultiSmoothCircleIC(const InputParameters & parameters);
 
   virtual void initialSetup();
 
+protected:
   virtual void computeCircleRadii();
-
   virtual void computeCircleCenters();
 
-protected:
+  const unsigned int _numbub;
+  const Real _bubspac;
 
-  unsigned int _numbub;
-  Real _bubspac;
+  const unsigned int _max_num_tries;
 
-  unsigned int _numtries;
-  Real _radius;
-  Real _radius_variation;
-  MooseEnum _radius_variation_type;
+  const Real _radius;
+  const Real _radius_variation;
+  const MooseEnum _radius_variation_type;
 
   Point _bottom_left;
   Point _top_right;

--- a/modules/phase_field/include/ics/MultiSmoothSuperellipsoidIC.h
+++ b/modules/phase_field/include/ics/MultiSmoothSuperellipsoidIC.h
@@ -18,15 +18,10 @@ InputParameters validParams<MultiSmoothSuperellipsoidIC>();
 /**
  * MultismoothSuperellipsoidIC creates multiple SmoothSuperellipsoid (number = numbub) that are randomly
  * positioned around the domain, with a minimum spacing equal to bubspac
- **/
+ */
 class MultiSmoothSuperellipsoidIC : public SmoothSuperellipsoidBaseIC
 {
 public:
-  /**
-   * Constructor
-   *
-   * @param parameters The parameters object holding data for the class to use.
-   */
   MultiSmoothSuperellipsoidIC(const InputParameters & parameters);
 
   virtual void initialSetup();
@@ -35,12 +30,14 @@ protected:
   virtual void computeSuperellipsoidSemiaxes();
   virtual void computeSuperellipsoidCenters();
   virtual void computeSuperellipsoidExponents();
-  virtual bool overlapCheck(const Point & newcenter, Real nc_as, Real nc_bs, Real nc_cs, Real nc_ns);
 
-  unsigned int _max_num_tries;
-  Real _gk;
+  virtual bool ellipsoidsOverlap(unsigned int i, unsigned int j);
+  virtual bool checkExtremes(unsigned int i, unsigned int j);
 
-  MooseEnum _semiaxis_variation_type;
+  const unsigned int _max_num_tries;
+  unsigned int _gk;
+
+  const MooseEnum _semiaxis_variation_type;
   const bool _prevent_overlap;
   const bool _check_extremes;
   const bool _vary_axes_independently;

--- a/modules/phase_field/src/ics/BimodalInverseSuperellipsoidsIC.C
+++ b/modules/phase_field/src/ics/BimodalInverseSuperellipsoidsIC.C
@@ -36,7 +36,7 @@ BimodalInverseSuperellipsoidsIC::value(const Point & p)
   Real value = _outvalue;
   Real val2 = 0.0;
 
-  //First loop over the specified superellipsoids
+  // First loop over the specified superellipsoids
   for (unsigned int ellip = 0; ellip < _x_positions.size() && value != _invalue; ++ellip)
   {
     val2 = computeSuperellipsoidValue(p, _centers[ellip], _as[ellip], _bs[ellip], _cs[ellip], _ns[ellip]);
@@ -44,7 +44,7 @@ BimodalInverseSuperellipsoidsIC::value(const Point & p)
       value = val2;
   }
 
-  //Then loop over the randomly positioned particles and set value inside them back to outvalue
+  // Then loop over the randomly positioned particles and set value inside them back to outvalue
   for (unsigned int ellip = _x_positions.size(); ellip < _x_positions.size() + _npart; ++ellip)
   {
     val2 = computeSuperellipsoidInverseValue(p, _centers[ellip], _as[ellip], _bs[ellip], _cs[ellip], _ns[ellip]);
@@ -61,7 +61,7 @@ BimodalInverseSuperellipsoidsIC::computeSuperellipsoidCenters()
 {
   _centers.resize(_x_positions.size() + _npart);
 
-  //First place the specified (large) particles from the input file
+  // First place the specified (large) particles from the input file
   for (unsigned int i = 0; i < _x_positions.size(); ++i)
   {
     _centers[i](0) = _x_positions[i];
@@ -69,96 +69,69 @@ BimodalInverseSuperellipsoidsIC::computeSuperellipsoidCenters()
     _centers[i](2) = _z_positions[i];
   }
 
-  //Next place the randomly positioned (small) particles
-  for (unsigned int i = _x_positions.size(); i < _x_positions.size() + _npart; i++)
+  // Next place the randomly positioned (small) particles
+  for (unsigned int i = _x_positions.size(); i < _x_positions.size() + _npart; ++i)
   {
     unsigned int num_tries = 0;
 
-    Real dsmall_min = 0.0; //minimum distance from the random particle to another random particle
-    Real dlarge_max = 0.0; //minimum distance from the random particle to edge of the specified (large) particle
-
-    Point newcenter = 0.0;
-
-    while ((dsmall_min < _small_spac || dlarge_max < _large_spac) && num_tries < _numtries)
+    while (num_tries < _max_num_tries)
     {
       num_tries++;
 
-      Real ran1 = _random.rand(_tid);
-      Real ran2 = _random.rand(_tid);
-      Real ran3 = _random.rand(_tid);
+      RealTensorValue ran;
+      ran(0,0) = _random.rand(_tid);
+      ran(1,1) = _random.rand(_tid);
+      ran(2,2) = _random.rand(_tid);
 
-      newcenter(0) = _bottom_left(0) + ran1*_range(0);
-      newcenter(1) = _bottom_left(1) + ran2*_range(1);
-      newcenter(2) = _bottom_left(2) + ran3*_range(2);
+      _centers[i] = _bottom_left + ran * _range;
 
-      //First check to make sure we are INSIDE a larger particle
-      for (unsigned int j = 0; j < _x_positions.size(); j++)
+      // check for collisions with the specified (large) and randomly placed small particles
+      for (unsigned int j = 0; j < i; ++j)
       {
-        if (j == 0)
-          dlarge_max = - _range.norm();
+        // Compute the distance r1 from the center of each specified superellipsoid to its
+        // outside edge along the vector between the specified superellipsoid and the current
+        // randomly positioned one.
+        // This uses the equation for a superellipse in polar coordinates and substitutes
+        // distances for sin, cos functions.
+        Point dist_vec = _mesh.minPeriodicVector(_var.number(), _centers[i], _centers[j]);
+        const Real dist = dist_vec.norm();
 
-        //Compute the distance r1 from the center of each specified superellipsoid to its outside edge
-        //along the vector between the specified superellipsoid and the current randomly
-        //positioned one
-        //This uses the equation for a superellipse in polar coordinates and substitutes
-        //distances for sin, cos functions
-        Real dist = _mesh.minPeriodicDistance(_var.number(), _centers[j], newcenter);
-        Point dist_vec = _mesh.minPeriodicVector(_var.number(), _centers[j], newcenter);
-
-        //First calculate rmn1 = r1^(-n), replacing sin, cos functions with distances
+        // First calculate rmn1 = r1^(-n), replacing sin, cos functions with distances
         Real rmn1 = (std::pow(std::abs(dist_vec(0) / dist / _as[j]), _ns[j])
-                  + std::pow(std::abs(dist_vec(1) / dist / _bs[j]), _ns[j])
-                  + std::pow(std::abs(dist_vec(2) / dist / _cs[j]), _ns[j]) );
-        //Then calculate r1 from rmn1
-        Real r1 = std::pow(rmn1, (-1.0/_ns[j]));
+                   + std::pow(std::abs(dist_vec(1) / dist / _bs[j]), _ns[j])
+                   + std::pow(std::abs(dist_vec(2) / dist / _cs[j]), _ns[j]));
+        // Then calculate r1 from rmn1
+        const Real r1 = std::pow(rmn1, (-1.0/_ns[j]));
 
-        //Now calculate the distance r2 from the center of the randomly placed superellipsoid
-        //to its outside edge in the same manner
+        // Now calculate the distance r2 from the center of the randomly placed
+        // superellipsoid to its outside edge in the same manner
         Real rmn2 = (std::pow(std::abs(dist_vec(0) / dist / _as[i]), _ns[i])
-                  + std::pow(std::abs(dist_vec(1) / dist / _bs[i]), _ns[i])
-                  + std::pow(std::abs(dist_vec(2) / dist / _cs[i]), _ns[i]) );
-        Real r2 = std::pow(rmn2, (-1.0/_ns[i]));
+                   + std::pow(std::abs(dist_vec(1) / dist / _bs[i]), _ns[i])
+                   + std::pow(std::abs(dist_vec(2) / dist / _cs[i]), _ns[i]));
+        const Real r2 = std::pow(rmn2, (-1.0/_ns[i]));
 
-        //Calculate the distance between the edges for an interior particle
-        Real tmp_dlarge_max = r1 - dist - r2;
-
-        if (tmp_dlarge_max > dlarge_max)
-          dlarge_max = tmp_dlarge_max;
+        if (j < _x_positions.size())
+        {
+          if (r1 - dist - r2 > _large_spac)
+            goto fail;
+        }
+        else
+        {
+          if (dist - r1 - r2 < _small_spac)
+            goto fail;
+        }
       }
 
-      //Then check for collisions between the randomly placed particles
-      for (unsigned int j = _x_positions.size(); j < i; j++)
-      {
-        if (j == _x_positions.size())
-          dsmall_min = _range.norm();
+      // accept the position of the new center
+      goto accept;
 
-        Real dist = _mesh.minPeriodicDistance(_var.number(), _centers[j], newcenter);
-        Point dist_vec = _mesh.minPeriodicVector(_var.number(), _centers[j], newcenter);
-
-        Real rmn1 = (std::pow(std::abs(dist_vec(0) / dist / _as[j]), _ns[j])
-                  + std::pow(std::abs(dist_vec(1) / dist / _bs[j]), _ns[j])
-                  + std::pow(std::abs(dist_vec(2) / dist / _cs[j]), _ns[j]) );
-        Real r1 = std::pow(rmn1, (-1.0/_ns[j]));
-
-        Real rmn2 = (std::pow(std::abs(dist_vec(0) / dist / _as[i]), _ns[i])
-                  + std::pow(std::abs(dist_vec(1) / dist / _bs[i]), _ns[i])
-                  + std::pow(std::abs(dist_vec(2) / dist / _cs[i]), _ns[i]) );
-        Real r2 = std::pow(rmn2, (-1.0/_ns[i]));
-
-        //Calculate the distance between the edges
-        Real tmp_dsmall_min = dist - r1 - r2;
-
-        if (tmp_dsmall_min < dsmall_min)
-          dsmall_min = tmp_dsmall_min;
-      }
-      //Cause while statement to exit for the first randomly placed particle
-      if (i == _x_positions.size())
-        dsmall_min = _range.norm();
+      // retry a new position until tries are exhausted
+      fail: continue;
     }
 
-    if (num_tries == _numtries)
-      mooseError("Too many tries in BimodalInverseSuperellipsoidsIC");
+    if (num_tries == _max_num_tries)
+      mooseError("Too many tries in MultiSmoothCircleIC");
 
-    _centers[i] = newcenter;
+    accept: continue;
   }
 }

--- a/modules/phase_field/src/ics/BimodalSuperellipsoidsIC.C
+++ b/modules/phase_field/src/ics/BimodalSuperellipsoidsIC.C
@@ -38,16 +38,15 @@ BimodalSuperellipsoidsIC::BimodalSuperellipsoidsIC(const InputParameters & param
     _small_n(getParam<Real>("small_n")),
     _size_variation(getParam<Real>("size_variation")),
     _size_variation_type(getParam<MooseEnum>("size_variation_type")),
-    _numtries(getParam<unsigned int>("numtries"))
+    _max_num_tries(getParam<unsigned int>("numtries"))
 {
 }
 
 void
 BimodalSuperellipsoidsIC::initialSetup()
 {
-
-  //Set up domain bounds with mesh tools
-  for (unsigned int i = 0; i < LIBMESH_DIM; i++)
+  // Set up domain bounds with mesh tools
+  for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
   {
     _bottom_left(i) = _mesh.getMinInDimension(i);
     _top_right(i) = _mesh.getMaxInDimension(i);
@@ -67,7 +66,7 @@ BimodalSuperellipsoidsIC::computeSuperellipsoidSemiaxes()
   _bs.resize(_input_bs.size() + _npart);
   _cs.resize(_input_cs.size() + _npart);
 
-  //First fill in the specified (large) superellipsoids from the input file
+  // First fill in the specified (large) superellipsoids from the input file
   for (unsigned int i = 0; i < _input_as.size(); ++i)
   {
     _as[i] = _input_as[i];
@@ -75,13 +74,13 @@ BimodalSuperellipsoidsIC::computeSuperellipsoidSemiaxes()
     _cs[i] = _input_cs[i];
   }
 
-  //Then fill in the randomly positioned (small) superellipsoids
-  for (unsigned int i = _input_as.size(); i < _input_as.size() + _npart; i++)
+  // Then fill in the randomly positioned (small) superellipsoids
+  for (unsigned int i = _input_as.size(); i < _input_as.size() + _npart; ++i)
   {
-    //Vary semiaxes
+    // Vary semiaxes
     switch (_size_variation_type)
     {
-      case 0: //Random distrubtion, maintaining constant shape
+      case 0: // Random distrubtion, maintaining constant shape
       {
         Real rand_num = _random.rand(_tid);
         _as[i] = _small_a*(1.0 + (1.0 - 2.0 * rand_num) * _size_variation);
@@ -89,12 +88,12 @@ BimodalSuperellipsoidsIC::computeSuperellipsoidSemiaxes()
         _cs[i] = _small_c*(1.0 + (1.0 - 2.0 * rand_num) * _size_variation);
         break;
       }
-      case 1: //Normal distribution of semiaxis size, maintaining constant shape
+      case 1: // Normal distribution of semiaxis size, maintaining constant shape
         _as[i] = _random.randNormal(_tid, _small_a, _size_variation);
         _bs[i] = _as[i] * _small_b / _small_a;
         _cs[i] = _as[i] * _small_c / _small_a;
         break;
-      case 2: //No variation
+      case 2: // No variation
         _as[i] = _small_a;
         _bs[i] = _small_b;
         _cs[i] = _small_c;
@@ -114,23 +113,22 @@ BimodalSuperellipsoidsIC::computeSuperellipsoidExponents()
 {
   _ns.resize(_input_ns.size() + _npart);
 
-  //First fill in the specified (large) superellipsoids from the input file
+  // First fill in the specified (large) superellipsoids from the input file
   for (unsigned int i = 0; i < _input_ns.size(); ++i)
     _ns[i] = _input_ns[i];
 
-  //Then fill in the randomly positioned (small) superellipsoids
-  //The shape is assumed to stay constant so n does not vary
-  for (unsigned int i = _input_ns.size(); i < _input_ns.size() + _npart; i++)
+  // Then fill in the randomly positioned (small) superellipsoids
+  // The shape is assumed to stay constant so n does not vary
+  for (unsigned int i = _input_ns.size(); i < _input_ns.size() + _npart; ++i)
     _ns[i] = _small_n;
 }
-
 
 void
 BimodalSuperellipsoidsIC::computeSuperellipsoidCenters()
 {
   _centers.resize(_x_positions.size() + _npart);
 
-  //First place the specified (large) particles from the input file
+  // First place the specified (large) particles from the input file
   for (unsigned int i = 0; i < _x_positions.size(); ++i)
   {
     _centers[i](0) = _x_positions[i];
@@ -138,96 +136,62 @@ BimodalSuperellipsoidsIC::computeSuperellipsoidCenters()
     _centers[i](2) = _z_positions[i];
   }
 
-  //Next place the randomly positioned (small) particles
-  for (unsigned int i = _x_positions.size(); i < _x_positions.size() + _npart; i++)
+  // Next place the randomly positioned (small) particles
+  for (unsigned int i = _x_positions.size(); i < _x_positions.size() + _npart; ++i)
   {
     unsigned int num_tries = 0;
 
-    Real dsmall_min = 0.0; //minimum distance from the random particle to another random particle
-    Real dlarge_min = 0.0; //minimum distance from the random particle to specified (large) particle
-
-    Point newcenter = 0.0;
-
-    while ((dsmall_min < _small_spac || dlarge_min < _large_spac) && num_tries < _numtries)
+    while (num_tries < _max_num_tries)
     {
       num_tries++;
 
-      Real ran1 = _random.rand(_tid);
-      Real ran2 = _random.rand(_tid);
-      Real ran3 = _random.rand(_tid);
+      RealTensorValue ran;
+      ran(0,0) = _random.rand(_tid);
+      ran(1,1) = _random.rand(_tid);
+      ran(2,2) = _random.rand(_tid);
 
-      newcenter(0) = _bottom_left(0) + ran1*_range(0);
-      newcenter(1) = _bottom_left(1) + ran2*_range(1);
-      newcenter(2) = _bottom_left(2) + ran3*_range(2);
+      _centers[i] = _bottom_left + ran * _range;
 
-      //First check for collisions with the specified (large) particles
-      for (unsigned int j = 0; j < _x_positions.size(); j++)
+      // check for collisions with the specified (large) and randomly placed small particles
+      for (unsigned int j = 0; j < i; ++j)
       {
-        if (j == 0)
-          dlarge_min = _range.norm();
+        // Compute the distance r1 from the center of each specified superellipsoid to its
+        // outside edge along the vector between the specified superellipsoid and the current
+        // randomly positioned one.
+        // This uses the equation for a superellipse in polar coordinates and substitutes
+        // distances for sin, cos functions.
+        Point dist_vec = _mesh.minPeriodicVector(_var.number(), _centers[i], _centers[j]);
+        const Real dist = dist_vec.norm();
 
-        //Compute the distance r1 from the center of each specified superellipsoid to its outside edge
-        //along the vector between the specified superellipsoid and the current randomly
-        //positioned one
-        //This uses the equation for a superellipse in polar coordinates and substitutes
-        //distances for sin, cos functions
-        Real dist = _mesh.minPeriodicDistance(_var.number(), _centers[j], newcenter);
-        Point dist_vec = _mesh.minPeriodicVector(_var.number(), _centers[j], newcenter);
-
-        //First calculate rmn1 = r1^(-n), replacing sin, cos functions with distances
+        // First calculate rmn1 = r1^(-n), replacing sin, cos functions with distances
         Real rmn1 = (std::pow(std::abs(dist_vec(0) / dist / _as[j]), _ns[j])
-                  + std::pow(std::abs(dist_vec(1) / dist / _bs[j]), _ns[j])
-                  + std::pow(std::abs(dist_vec(2) / dist / _cs[j]), _ns[j]) );
-        //Then calculate r1 from rmn1
-        Real r1 = std::pow(rmn1, (-1.0/_ns[j]));
+                   + std::pow(std::abs(dist_vec(1) / dist / _bs[j]), _ns[j])
+                   + std::pow(std::abs(dist_vec(2) / dist / _cs[j]), _ns[j]));
+        // Then calculate r1 from rmn1
+        const Real r1 = std::pow(rmn1, (-1.0/_ns[j]));
 
-        //Now calculate the distance r2 from the center of the randomly placed superellipsoid
-        //to its outside edge in the same manner
+        // Now calculate the distance r2 from the center of the randomly placed
+        // superellipsoid to its outside edge in the same manner
         Real rmn2 = (std::pow(std::abs(dist_vec(0) / dist / _as[i]), _ns[i])
-                  + std::pow(std::abs(dist_vec(1) / dist / _bs[i]), _ns[i])
-                  + std::pow(std::abs(dist_vec(2) / dist / _cs[i]), _ns[i]) );
-        Real r2 = std::pow(rmn2, (-1.0/_ns[i]));
+                   + std::pow(std::abs(dist_vec(1) / dist / _bs[i]), _ns[i])
+                   + std::pow(std::abs(dist_vec(2) / dist / _cs[i]), _ns[i]));
+        const Real r2 = std::pow(rmn2, (-1.0/_ns[i]));
 
-        //Calculate the distance between the edges
-        Real tmp_dlarge_min = dist - r1 - r2;
-
-        if (tmp_dlarge_min < dlarge_min)
-          dlarge_min = tmp_dlarge_min;
+        // Calculate the distance between the edges (first in the list are the large then come the small)
+        if ((dist - r1 - r2) < (j < _x_positions.size() ? _large_spac : _small_spac))
+          goto fail;
       }
 
-      //Then check for collisions between the randomly placed particles
-      for (unsigned int j = _x_positions.size(); j < i; j++)
-      {
-        if (j == _x_positions.size())
-          dsmall_min = _range.norm();
+      // accept the position of the new center
+      goto accept;
 
-        Real dist = _mesh.minPeriodicDistance(_var.number(), _centers[j], newcenter);
-        Point dist_vec = _mesh.minPeriodicVector(_var.number(), _centers[j], newcenter);
-
-        Real rmn1 = (std::pow(std::abs(dist_vec(0) / dist / _as[j]), _ns[j])
-                  + std::pow(std::abs(dist_vec(1) / dist / _bs[j]), _ns[j])
-                  + std::pow(std::abs(dist_vec(2) / dist / _cs[j]), _ns[j]) );
-        Real r1 = std::pow(rmn1, (-1.0/_ns[j]));
-
-        Real rmn2 = (std::pow(std::abs(dist_vec(0) / dist / _as[i]), _ns[i])
-                  + std::pow(std::abs(dist_vec(1) / dist / _bs[i]), _ns[i])
-                  + std::pow(std::abs(dist_vec(2) / dist / _cs[i]), _ns[i]) );
-        Real r2 = std::pow(rmn2, (-1.0/_ns[i]));
-
-        //Calculate the distance between the edges
-        Real tmp_dsmall_min = dist - r1 - r2;
-
-        if (tmp_dsmall_min < dsmall_min)
-          dsmall_min = tmp_dsmall_min;
-      }
-      //Cause while statement to exit for the first randomly placed particle
-      if (i == _x_positions.size())
-        dsmall_min = _range.norm();
+      // retry a new position until tries are exhausted
+      fail: continue;
     }
 
-    if (num_tries == _numtries)
-      mooseError("Too many tries in BimodalSuperellipsoidsIC");
+    if (num_tries == _max_num_tries)
+      mooseError("Too many tries in MultiSmoothCircleIC");
 
-    _centers[i] = newcenter;
+    accept: continue;
   }
 }

--- a/modules/phase_field/src/ics/MultiSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothCircleIC.C
@@ -18,7 +18,7 @@ InputParameters validParams<MultiSmoothCircleIC>()
   params.addParam<unsigned int>("numtries", 1000, "The number of tries");
   params.addRequiredParam<Real>("radius", "Mean radius value for the circles");
   params.addParam<Real>("radius_variation", 0.0, "Plus or minus fraction of random variation in the bubble radius for uniform, standard deviation for normal");
-  MooseEnum rand_options("uniform normal none","none");
+  MooseEnum rand_options("uniform normal none", "none");
   params.addParam<MooseEnum>("radius_variation_type", rand_options, "Type of distribution that random circle radii will follow");
   return params;
 }
@@ -27,7 +27,7 @@ MultiSmoothCircleIC::MultiSmoothCircleIC(const InputParameters & parameters) :
     SmoothCircleBaseIC(parameters),
     _numbub(getParam<unsigned int>("numbub")),
     _bubspac(getParam<Real>("bubspac")),
-    _numtries(getParam<unsigned int>("numtries")),
+    _max_num_tries(getParam<unsigned int>("numtries")),
     _radius(getParam<Real>("radius")),
     _radius_variation(getParam<Real>("radius_variation")),
     _radius_variation_type(getParam<MooseEnum>("radius_variation_type"))
@@ -37,22 +37,17 @@ MultiSmoothCircleIC::MultiSmoothCircleIC(const InputParameters & parameters) :
 void
 MultiSmoothCircleIC::initialSetup()
 {
-
   //Set up domain bounds with mesh tools
-  for (unsigned int i = 0; i < LIBMESH_DIM; i++)
+  for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
   {
     _bottom_left(i) = _mesh.getMinInDimension(i);
     _top_right(i) = _mesh.getMaxInDimension(i);
   }
   _range = _top_right - _bottom_left;
 
-  switch (_radius_variation_type)
-  {
-  case 2: //No variation
-    if (_radius_variation > 0.0)
-      mooseError("If radius_variation > 0.0, you must pass in a radius_variation_type in MultiSmoothCircleIC");
-    break;
-  }
+  // a variation is provided, but the type is set to 'none'
+  if (_radius_variation > 0.0 && _radius_variation_type == 2)
+    mooseError("If radius_variation > 0.0, you must pass in a radius_variation_type in MultiSmoothCircleIC");
 
   SmoothCircleBaseIC::initialSetup();
 }
@@ -64,65 +59,56 @@ MultiSmoothCircleIC::computeCircleRadii()
 
   for (unsigned int i = 0; i < _numbub; i++)
   {
-    //Vary bubble radius
+    // Vary bubble radius
     switch (_radius_variation_type)
     {
-    case 0: //Uniform distrubtion
-      _radii[i] = _radius*(1.0 + (1.0 - 2.0 * _random.rand(_tid)) * _radius_variation);
-      break;
-    case 1: //Normal distribution
-      _radii[i] = _random.randNormal(_tid, _radius,_radius_variation);
-      break;
-    case 2: //No variation
-      _radii[i] = _radius;
+      case 0: // Uniform distribution
+        _radii[i] = _radius * (1.0 + (1.0 - 2.0 * _random.rand(_tid)) * _radius_variation);
+        break;
+      case 1: // Normal distribution
+        _radii[i] = _random.randNormal(_tid, _radius, _radius_variation);
+        break;
+      case 2: // No variation
+        _radii[i] = _radius;
     }
 
-    if (_radii[i] < 0.0) _radii[i] = 0.0;
+    _radii[i] = std::max(_radii[i], 0.0);
   }
 }
-
 
 void
 MultiSmoothCircleIC::computeCircleCenters()
 {
   _centers.resize(_numbub);
-
-  for (unsigned int i = 0; i < _numbub; i++)
+  for (unsigned int i = 0; i < _numbub; ++i)
   {
-    //Vary circle center positions
+    // Vary circle center positions
     unsigned int num_tries = 0;
-
-    Real rr = 0.0;
-    Point newcenter = 0.0;
-
-    while (rr <= _bubspac && num_tries < _numtries)
+    while (num_tries < _max_num_tries)
     {
       num_tries++;
-      //Moose::out<<"num_tries: "<<num_tries<<std::endl;
 
-      Real ran1 = _random.rand(_tid);
-      Real ran2 = _random.rand(_tid);
-      Real ran3 = _random.rand(_tid);
+      RealTensorValue ran;
+      ran(0,0) = _random.rand(_tid);
+      ran(1,1) = _random.rand(_tid);
+      ran(2,2) = _random.rand(_tid);
 
-      newcenter(0) = _bottom_left(0) + ran1*_range(0);
-      newcenter(1) = _bottom_left(1) + ran2*_range(1);
-      newcenter(2) = _bottom_left(2) + ran3*_range(2);
+      _centers[i] = _bottom_left + ran * _range;
 
-      for (unsigned int j = 0; j < i; j++)
-      {
-        if (j == 0) rr = _range.norm();
+      for (unsigned int j = 0; j < i; ++j)
+        if (_mesh.minPeriodicDistance(_var.number(), _centers[j], _centers[i]) < _bubspac)
+          goto fail;
 
-        Real tmp_rr = _mesh.minPeriodicDistance(_var.number(), _centers[j], newcenter);
+      // accept the position of the new center
+      goto accept;
 
-        if (tmp_rr < rr) rr = tmp_rr;
-      }
-
-      if (i == 0) rr = _range.norm();
+      // retry a new position until tries are exhausted
+      fail: continue;
     }
 
-    if (num_tries == _numtries)
+    if (num_tries == _max_num_tries)
       mooseError("Too many tries in MultiSmoothCircleIC");
 
-    _centers[i] = newcenter;
+    accept: continue;
   }
 }


### PR DESCRIPTION
Shorter minimum bubble distance algorithm. Uses fewer local variables (I eliminated 3!) and does not discard a viable center location if it happens to be found during the last try!

To break out of nested loops I'm using goto here. The jump distances are extremely short and documented using comments. I think the gains outweigh the potential reservations some people may have against the goto keyword.

Refs #7296
