### PR TITLE
Added OutputRGB to two examples 

### DIFF
--- a/modules/combined/examples/phase_field-mechanics/EBSD_reconstruction_grain_growth_mech.i
+++ b/modules/combined/examples/phase_field-mechanics/EBSD_reconstruction_grain_growth_mech.i
@@ -8,7 +8,7 @@
 []
 
 [GlobalParams]
-  op_num = 15
+  op_num = 8
   var_name_base = gr
   grain_num = 110
 []
@@ -54,6 +54,10 @@
     family = MONOMIAL
   [../]
   [./EBSD_grain]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./RGB]
     family = MONOMIAL
     order = CONSTANT
   [../]
@@ -145,6 +149,14 @@
     data_name = 'grain'
     execute_on = 'initial'
   [../]
+  [./RGB]
+    type = OutputRGB
+    variable = RGB
+    euler_angle_provider = ebsd
+    grain_tracker_object = grain_tracker
+    crystal_structure = cubic
+    execute_on = 'initial timestep_end'
+  [../]
 []
 
 [BCs]
@@ -226,7 +238,6 @@
   [./grain_tracker]
     type = GrainTracker
     threshold = 0.2
-    connecting_threshold = 0.2
     compute_op_maps = true
     execute_on = 'initial timestep_begin'
     ebsd_reader = ebsd

--- a/modules/combined/examples/phase_field-mechanics/hex_grain_growth_2D_eldrforce.i
+++ b/modules/combined/examples/phase_field-mechanics/hex_grain_growth_2D_eldrforce.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  op_num = 15
+  op_num = 8
   var_name_base = gr
   grain_num = 36
   #use_displaced_mesh = true
@@ -161,7 +161,7 @@
   [./Periodic]
     [./All]
       auto_direction = 'x y'
-      variable = 'gr0 gr1 gr2 gr3 gr4 gr5 gr6 gr7 gr8 gr9 gr10 gr11 gr12 gr13 gr14'
+      variable = 'gr0 gr1 gr2 gr3 gr4 gr5 gr6 gr7'
     [../]
   [../]
   [./top_displacement]
@@ -236,11 +236,6 @@
   [./grain_tracker]
     type = GrainTracker
     threshold = 0.2
-    convex_hull_buffer = 5.0
-    use_single_map = false
-    enable_var_coloring = true
-    condense_map_info = true
-    connecting_threshold = 0.05
     compute_op_maps = true
     execute_on = 'initial timestep_begin'
     flood_entity_type = ELEMENTAL

--- a/modules/combined/examples/phase_field-mechanics/poly_grain_growth_2D_eldrforce.i
+++ b/modules/combined/examples/phase_field-mechanics/poly_grain_growth_2D_eldrforce.i
@@ -12,7 +12,7 @@
 []
 
 [GlobalParams]
-  op_num = 15
+  op_num = 8
   var_name_base = gr
   grain_num = 36
   use_displaced_mesh = true
@@ -146,6 +146,7 @@
     variable = vonmises_stress
     rank_two_tensor = stress
     scalar_type = VonMisesStress
+    execute_on = timestep_end
   [../]
   [./euler_angle]
     type = OutputEulerAngles
@@ -153,6 +154,7 @@
     euler_angle_provider = euler_angle_file
     GrainTracker_object = grain_tracker
     output_euler_angle = 'phi1'
+    execute_on = 'initial timestep_end'
   [../]
 []
 
@@ -160,7 +162,7 @@
   [./Periodic]
     [./All]
       auto_direction = 'x'
-      variable = 'gr0 gr1 gr2 gr3 gr4 gr5 gr6 gr7 gr8 gr9 gr10 gr11 gr12 gr13 gr14'
+      variable = 'gr0 gr1 gr2 gr3 gr4 gr5 gr6 gr7'
     [../]
   [../]
   [./top_displacement]
@@ -235,14 +237,9 @@
   [./grain_tracker]
     type = GrainTracker
     threshold = 0.2
-    convex_hull_buffer = 5.0
-    use_single_map = false
-    enable_var_coloring = true
-    condense_map_info = true
-    connecting_threshold = 0.05
     compute_op_maps = true
     execute_on = 'initial timestep_begin'
-    flood_entity_type = elemental
+    flood_entity_type = ELEMENTAL
   [../]
   [./euler_angle_file]
     type = EulerAngleFileReader

--- a/modules/phase_field/examples/ebsd_reconstruction/IN100-111grn.i
+++ b/modules/phase_field/examples/ebsd_reconstruction/IN100-111grn.i
@@ -1,5 +1,5 @@
 [Mesh]
-  # uniform_refine = 4
+  uniform_refine = 2
   type = EBSDMesh
   filename = IN100_128x128.txt
 []
@@ -36,6 +36,10 @@
     family = MONOMIAL
   [../]
   [./var_indices]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./RGB]
     order = CONSTANT
     family = MONOMIAL
   [../]
@@ -88,6 +92,14 @@
     bubble_object = grain_tracker
     field_display = UNIQUE_REGION
   [../]
+  [./RGB]
+    type = OutputRGB
+    variable = RGB
+    euler_angle_provider = ebsd
+    grain_tracker_object = grain_tracker
+    crystal_structure = cubic
+    execute_on = 'initial timestep_end'
+  [../]
 []
 
 [Materials]
@@ -123,17 +135,11 @@
   [../]
   [./grain_tracker]
     type = GrainTracker
-    threshold = 0.1
-    convex_hull_buffer = 0.0
-    use_single_map = false
-    enable_var_coloring = true
-    condense_map_info = true
-    connecting_threshold = 0.05
-    execute_on = 'initial timestep_end'
-    flood_entity_type = ELEMENTAL
-    halo_level = 2
-    bubble_volume_file = IN100-grn-vols.txt
+    threshold = 0.2
+    connecting_threshold = 0.2
+    execute_on = 'initial timestep_begin'
     ebsd_reader = ebsd
+    flood_entity_type = ELEMENTAL
   [../]
 []
 
@@ -166,18 +172,11 @@
     refine_fraction = 0.7
     coarsen_fraction = 0.1
     max_h_level = 2
-    print_changed_info = true
   [../]
 []
 
 [Outputs]
   exodus = true
   checkpoint = true
-  csv = true
-  [./console]
-    type = Console
-    max_rows = 20
-    perf_log = true
-    perf_log_interval = 10
-  [../]
+  print_perf_log = true
 []


### PR DESCRIPTION
I added OutputRGB to the two EBSD reconstruction examples in the phase field and combined modules. I also fixed two other examples so that they now run.

Closes #7316.
