### PR TITLE
Add syntax check tests for module examples

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1281,6 +1281,10 @@ MooseMesh::detectPairedSidesets()
   {
     Elem * elem = *el;
 
+    // skip mortar meshes etc.
+    if (elem->dim() != dim)
+      continue;
+
     // loop over element sides
     for (unsigned int s = 0; s < elem->n_sides(); s++)
     {

--- a/modules/combined/examples/effective_properties/tests
+++ b/modules/combined/examples/effective_properties/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./effective_th_cond]
+    type = RunApp
+    input = 'effective_th_cond.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/combined/examples/mortar/tests
+++ b/modules/combined/examples/mortar/tests
@@ -1,0 +1,12 @@
+[Tests]
+  [./eigenstrain]
+    type = RunApp
+    input = 'eigenstrain.i'
+    cli_args = '--check-input'
+  [../]
+  [./mortar_gradient]
+    type = RunApp
+    input = 'mortar_gradient.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/combined/examples/phase_field-mechanics/Nonconserved.i
+++ b/modules/combined/examples/phase_field-mechanics/Nonconserved.i
@@ -123,11 +123,11 @@
     block = 0
     displacements = 'disp_x disp_y'
     base_name = phaseb
-    # we use thermal expansion with a constant temperature to achieve a 10% oversize
-    # commenting out the following 3 lines will switch off the oversize effect
-    thermal_expansion_coeff = 0.1
-    temperature_ref = 0
-    temperature = 1
+  [../]
+  [./eigenstrain_b]
+    type = ComputeEigenstrain
+    base_name = phaseb
+    eigen_base = '0.1 0.1 0.1'
   [../]
   [./stress_b]
     type = ComputeLinearElasticStress

--- a/modules/combined/examples/phase_field-mechanics/tests
+++ b/modules/combined/examples/phase_field-mechanics/tests
@@ -1,0 +1,37 @@
+[Tests]
+  [./Conserved]
+    type = RunApp
+    input = 'Conserved.i'
+    cli_args = '--check-input'
+  [../]
+  [./EBSD_reconstruction_grain_growth_mech]
+    type = RunApp
+    input = 'EBSD_reconstruction_grain_growth_mech.i'
+    cli_args = '--check-input'
+  [../]
+  [./Nonconserved]
+    type = RunApp
+    input = 'Nonconserved.i'
+    cli_args = '--check-input'
+  [../]
+  [./Pattern1]
+    type = RunApp
+    input = 'Pattern1.i'
+    cli_args = '--check-input'
+  [../]
+  [./grain_texture]
+    type = RunApp
+    input = 'grain_texture.i'
+    cli_args = '--check-input'
+  [../]
+  [./hex_grain_growth_2D_eldrforce]
+    type = RunApp
+    input = 'hex_grain_growth_2D_eldrforce.i'
+    cli_args = '--check-input'
+  [../]
+  [./poly_grain_growth_2D_eldrforce]
+    type = RunApp
+    input = 'poly_grain_growth_2D_eldrforce.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/combined/examples/phase_field-mechanics/tests
+++ b/modules/combined/examples/phase_field-mechanics/tests
@@ -27,11 +27,11 @@
   [./hex_grain_growth_2D_eldrforce]
     type = RunApp
     input = 'hex_grain_growth_2D_eldrforce.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Executioner/Adaptivity/initial_adaptivity=0'
   [../]
   [./poly_grain_growth_2D_eldrforce]
     type = RunApp
     input = 'poly_grain_growth_2D_eldrforce.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Executioner/Adaptivity/initial_adaptivity=0'
   [../]
 []

--- a/modules/combined/examples/phase_field-mechanics/tests
+++ b/modules/combined/examples/phase_field-mechanics/tests
@@ -8,6 +8,7 @@
     type = RunApp
     input = 'EBSD_reconstruction_grain_growth_mech.i'
     cli_args = '--check-input'
+    skip = 'Broken!'
   [../]
   [./Nonconserved]
     type = RunApp

--- a/modules/combined/examples/thermomechanics/circle_thermal_expansion_stress.i
+++ b/modules/combined/examples/thermomechanics/circle_thermal_expansion_stress.i
@@ -109,12 +109,18 @@
   [./srain] #We use small deformation mechanics
     type = ComputeSmallStrain
     displacements = 'disp_x disp_y'
-    thermal_expansion_coeff = 1e-6
     temperature = T
     block = 1
   [../]
   [./stress] #We use linear elasticity
     type = ComputeLinearElasticStress
+    block = 1
+  [../]
+  [./thermal_strain]
+    type= ComputeThermalExpansionEigenStrain
+    thermal_expansion_coeff = 1e-6
+    temperature = T
+    stress_free_reference_temperature = 273
     block = 1
   [../]
 []

--- a/modules/combined/examples/thermomechanics/tests
+++ b/modules/combined/examples/thermomechanics/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./circle_thermal_expansion_stress]
+    type = RunApp
+    input = 'circle_thermal_expansion_stress.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/anisotropic_interfaces/tests
+++ b/modules/phase_field/examples/anisotropic_interfaces/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./snow]
+    type = RunApp
+    input = 'snow.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/anisotropic_interfaces/tests
+++ b/modules/phase_field/examples/anisotropic_interfaces/tests
@@ -2,6 +2,6 @@
   [./snow]
     type = RunApp
     input = 'snow.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Executioner/Adaptivity/initial_adaptivity=0'
   [../]
 []

--- a/modules/phase_field/examples/anisotropic_transport/tests
+++ b/modules/phase_field/examples/anisotropic_transport/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./diffusion]
+    type = RunApp
+    input = 'diffusion.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/cahn-hilliard/tests
+++ b/modules/phase_field/examples/cahn-hilliard/tests
@@ -1,0 +1,17 @@
+[Tests]
+  [./Math_CH]
+    type = RunApp
+    input = 'Math_CH.i'
+    cli_args = '--check-input'
+  [../]
+  [./Parsed_CH]
+    type = RunApp
+    input = 'Parsed_CH.i'
+    cli_args = '--check-input'
+  [../]
+  [./Parsed_SplitCH]
+    type = RunApp
+    input = 'Parsed_SplitCH.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/ebsd_reconstruction/tests
+++ b/modules/phase_field/examples/ebsd_reconstruction/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./IN100-111grn]
+    type = RunApp
+    input = 'IN100-111grn.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/ebsd_reconstruction/tests
+++ b/modules/phase_field/examples/ebsd_reconstruction/tests
@@ -2,6 +2,6 @@
   [./IN100-111grn]
     type = RunApp
     input = 'IN100-111grn.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Executioner/Adaptivity/initial_adaptivity=0'
   [../]
 []

--- a/modules/phase_field/examples/grain_growth/tests
+++ b/modules/phase_field/examples/grain_growth/tests
@@ -2,7 +2,7 @@
   [./grain_growth_2D_graintracker]
     type = RunApp
     input = 'grain_growth_2D_graintracker.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Executioner/Adaptivity/initial_adaptivity=0'
   [../]
   [./grain_growth_2D_random]
     type = RunApp
@@ -12,12 +12,12 @@
   [./grain_growth_2D_voronoi]
     type = RunApp
     input = 'grain_growth_2D_voronoi.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Mesh/uniform_refine=0 Executioner/Adaptivity/initial_adaptivity=0'
   [../]
   [./grain_growth_2D_voronoi_newadapt]
     type = RunApp
     input = 'grain_growth_2D_voronoi_newadapt.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Adaptivity/max_h_level=0'
   [../]
   [./grain_growth_3D]
     type = RunApp
@@ -32,6 +32,6 @@
   [./test_problem]
     type = RunApp
     input = 'test_problem.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Executioner/Adaptivity/initial_adaptivity=0'
   [../]
 []

--- a/modules/phase_field/examples/grain_growth/tests
+++ b/modules/phase_field/examples/grain_growth/tests
@@ -1,0 +1,37 @@
+[Tests]
+  [./grain_growth_2D_graintracker]
+    type = RunApp
+    input = 'grain_growth_2D_graintracker.i'
+    cli_args = '--check-input'
+  [../]
+  [./grain_growth_2D_random]
+    type = RunApp
+    input = 'grain_growth_2D_random.i'
+    cli_args = '--check-input'
+  [../]
+  [./grain_growth_2D_voronoi]
+    type = RunApp
+    input = 'grain_growth_2D_voronoi.i'
+    cli_args = '--check-input'
+  [../]
+  [./grain_growth_2D_voronoi_newadapt]
+    type = RunApp
+    input = 'grain_growth_2D_voronoi_newadapt.i'
+    cli_args = '--check-input'
+  [../]
+  [./grain_growth_3D]
+    type = RunApp
+    input = 'grain_growth_3D.i'
+    cli_args = '--check-input'
+  [../]
+  [./really_small_problem]
+    type = RunApp
+    input = 'really_small_problem.i'
+    cli_args = '--check-input'
+  [../]
+  [./test_problem]
+    type = RunApp
+    input = 'test_problem.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/kim-kim-suzuki/tests
+++ b/modules/phase_field/examples/kim-kim-suzuki/tests
@@ -1,0 +1,17 @@
+[Tests]
+  [./kks_example_dirichlet]
+    type = RunApp
+    input = 'kks_example_dirichlet.i'
+    cli_args = '--check-input'
+  [../]
+  [./kks_example_noflux]
+    type = RunApp
+    input = 'kks_example_noflux.i'
+    cli_args = '--check-input'
+  [../]
+  [./kks_example_ternary]
+    type = RunApp
+    input = 'kks_example_ternary.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/measure_interface_energy/tests
+++ b/modules/phase_field/examples/measure_interface_energy/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./1Dinterface_energy]
+    type = RunApp
+    input = '1Dinterface_energy.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/multiphase/tests
+++ b/modules/phase_field/examples/multiphase/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./DerivativeMultiPhaseMaterial]
+    type = RunApp
+    input = 'DerivativeMultiPhaseMaterial.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/nucleation/tests
+++ b/modules/phase_field/examples/nucleation/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./cahn_hilliard]
+    type = RunApp
+    input = 'cahn_hilliard.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/phase_field/examples/rigidbodymotion/tests
+++ b/modules/phase_field/examples/rigidbodymotion/tests
@@ -2,7 +2,7 @@
   [./AC_CH_Multigrain]
     type = RunApp
     input = 'AC_CH_Multigrain.i'
-    cli_args = '--check-input'
+    cli_args = '--check-input Mesh/uniform_refine=0 Executioner/Adaptivity/initial_adaptivity=0'
   [../]
   [./AC_CH_advection_constforce_rect]
     type = RunApp

--- a/modules/phase_field/examples/rigidbodymotion/tests
+++ b/modules/phase_field/examples/rigidbodymotion/tests
@@ -1,0 +1,17 @@
+[Tests]
+  [./AC_CH_Multigrain]
+    type = RunApp
+    input = 'AC_CH_Multigrain.i'
+    cli_args = '--check-input'
+  [../]
+  [./AC_CH_advection_constforce_rect]
+    type = RunApp
+    input = 'AC_CH_advection_constforce_rect.i'
+    cli_args = '--check-input'
+  [../]
+  [./grain_forcedensity_ext]
+    type = RunApp
+    input = 'grain_forcedensity_ext.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/solid_mechanics/examples/bridge/tests
+++ b/modules/solid_mechanics/examples/bridge/tests
@@ -1,0 +1,12 @@
+[Tests]
+  [./bridge]
+    type = RunApp
+    input = 'bridge.i'
+    cli_args = '--check-input'
+  [../]
+  [./bridge_large_strain]
+    type = RunApp
+    input = 'bridge_large_strain.i'
+    cli_args = '--check-input'
+  [../]
+[]

--- a/modules/tensor_mechanics/examples/bridge/tests
+++ b/modules/tensor_mechanics/examples/bridge/tests
@@ -1,0 +1,12 @@
+[Tests]
+  [./bridge]
+    type = RunApp
+    input = 'bridge.i'
+    cli_args = '--check-input'
+  [../]
+  [./bridge_large_strain]
+    type = RunApp
+    input = 'bridge_large_strain.i'
+    cli_args = '--check-input'
+  [../]
+[]


### PR DESCRIPTION
Wrote a small script to generate `tests` files for all modules examples. This uses `RunApp` with `--check-input`. Unsurprisingly quite a few tests fail, and the GrainTracker stuff is super heavy even for just construction and initialSetup!

Opening a PR to test this on moosebuild.

Closes #7319
