### PR TITLE
Trim down libmesh doxygen

### DIFF
--- a/framework/doc/doxygen/Doxyfile_libmesh
+++ b/framework/doc/doxygen/Doxyfile_libmesh
@@ -700,7 +700,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = doc contrib build-aux reference_elements
+EXCLUDE                = doc contrib build-aux reference_elements build installed
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
Building doxygen for libmesh takes a long time since it processes all of `build` and `installed`
which are not needed.
Currently it can take almost an hour to produce doxygen for libmesh on the "Infrastructure" MOOSE target. This should reduce it to about a minute.
