### PR TITLE
New GrainTracker API

### DIFF
--- a/modules/phase_field/include/postprocessors/FauxGrainTracker.h
+++ b/modules/phase_field/include/postprocessors/FauxGrainTracker.h
@@ -34,21 +34,10 @@ public:
   virtual Real getValue() override;
   virtual void execute() override;
 
-  /**
-   * Accessor for retrieving either nodal or elemental information (unique grains or variable indicies)
-   * @param entity_id the node identifier for which to retrieve field data
-   * @param var_idx when using multi-map mode, the map number from which to retrieve data.
-   * @param show_var_coloring pass true to view variable index for a region, false for unique grain information
-   * @return the entity value
-   */
-  virtual Real getEntityValue(dof_id_type entity_id, FeatureFloodCount::FieldType field_type, unsigned int var_idx) const override;
-
-  /**
-   * Returns a list of active unique grains for a particular elem based on the node numbering.  The outer vector
-   * holds the ith node with the inner vector holds the list of active unique grains.
-   * (unique_grain_id, variable_idx)
-   */
+  // GrainTrackerInterface methods
+  virtual Real getEntityValue(dof_id_type node_id, FieldType field_type, unsigned int var_idx=0) const override;
   virtual const std::vector<std::pair<unsigned int, unsigned int> > & getElementalValues(dof_id_type elem_id) const override;
+  virtual const std::vector<unsigned int> & getOpToGrainsVector(dof_id_type elem_id) const override;
 
 private:
   /// The mapping of entities to grains, in this case always the order parameter
@@ -61,6 +50,7 @@ private:
   const int _tracking_step;
 
   std::vector<std::pair<unsigned int, unsigned int> > _faux_data;
+  std::vector<unsigned int> _faux_data_2;
 };
 
 #endif

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -46,21 +46,10 @@ public:
     BYPASS
   };
 
-  /**
-   * Accessor for retrieving nodal field information (unique grains or variable indicies)
-   * @param node_id the node identifier for which to retrieve field data
-   * @param var_idx when using multi-map mode, the map number from which to retrieve data.
-   * @param show_var_coloring pass true to view variable index for a region, false for unique grain information
-   * @return the nodal value
-   */
+  // GrainTrackerInterface methods
   virtual Real getEntityValue(dof_id_type node_id, FieldType field_type, unsigned int var_idx=0) const override;
-
-  /**
-   * Returns a list of active unique grains for a particular elem based on the node numbering.  The outer vector
-   * holds the ith node with the inner vector holds the list of active unique grains.
-   * (unique_grain_id, variable_idx)
-   */
   virtual const std::vector<std::pair<unsigned int, unsigned int> > & getElementalValues(dof_id_type elem_id) const override;
+  virtual const std::vector<unsigned int> & getOpToGrainsVector(dof_id_type elem_id) const override;
 
 protected:
   virtual void updateFieldInfo() override;
@@ -171,6 +160,9 @@ protected:
    * elem_id -> a vector of pairs each containing the grain number and the variable index representing that grain
    */
   std::map<dof_id_type, std::vector<std::pair<unsigned int, unsigned int> > > _elemental_data;
+  std::map<dof_id_type, std::vector<unsigned int> > _elemental_data_2;
+
+  static std::vector<unsigned int> _empty_2;
 };
 
 

--- a/modules/phase_field/include/postprocessors/GrainTrackerInterface.h
+++ b/modules/phase_field/include/postprocessors/GrainTrackerInterface.h
@@ -41,6 +41,12 @@ public:
    * (unique_grain_id, variable_idx)
    */
   virtual const std::vector<std::pair<unsigned int, unsigned int> > & getElementalValues(dof_id_type elem_id) const = 0;
+
+  /**
+   * Returns a list of active unique grains for a particular element. The vector is indexed by order parameter
+   * with each entry containing an invalid uint (no grain active at that location) or a grain id if it's active at that location.
+   */
+  virtual const std::vector<unsigned int> & getOpToGrainsVector(dof_id_type elem_id) const = 0;
 };
 
 #endif

--- a/modules/phase_field/src/postprocessors/FauxGrainTracker.C
+++ b/modules/phase_field/src/postprocessors/FauxGrainTracker.C
@@ -27,6 +27,10 @@ FauxGrainTracker::FauxGrainTracker(const InputParameters & parameters) :
   _faux_data.resize(_vars.size());
   for (unsigned int var_num = 0; var_num < _faux_data.size(); ++var_num)
     _faux_data[var_num] = std::make_pair(var_num, var_num);
+
+  _faux_data_2.resize(_vars.size());
+  for (unsigned int var_num = 0; var_num < _faux_data_2.size(); ++var_num)
+    _faux_data_2[var_num] = var_num;
 }
 
 FauxGrainTracker::~FauxGrainTracker()
@@ -72,6 +76,12 @@ const std::vector<std::pair<unsigned int, unsigned int> > &
 FauxGrainTracker::getElementalValues(dof_id_type /*elem_id*/) const
 {
   return _faux_data;
+}
+
+const std::vector<unsigned int> &
+FauxGrainTracker::getOpToGrainsVector(dof_id_type /*elem_id*/) const
+{
+  return _faux_data_2;
 }
 
 void


### PR DESCRIPTION
closes #7373 

Same information, new format.

BTW - The std::map::emplace() method is pretty cool. I think if people get in the habit of using it, we'll have less accidental insertion into std::map problems.
