### PR TITLE
Re-enable automatic FPOptimizer run

### DIFF
--- a/framework/src/utils/FunctionParserUtils.C
+++ b/framework/src/utils/FunctionParserUtils.C
@@ -49,7 +49,7 @@ FunctionParserUtils::FunctionParserUtils(const InputParameters & parameters) :
                 parameters.get<bool>("enable_jit")),
     _enable_ad_cache(parameters.get<bool>("enable_ad_cache")),
     _disable_fpoptimizer(parameters.get<bool>("disable_fpoptimizer")),
-    _enable_auto_optimize(false && parameters.get<bool>("enable_auto_optimize") && !_disable_fpoptimizer), // disabled due to #7160
+    _enable_auto_optimize(parameters.get<bool>("enable_auto_optimize") && !_disable_fpoptimizer),
     _fail_on_evalerror(parameters.get<bool>("fail_on_evalerror")),
     _nan(std::numeric_limits<Real>::quiet_NaN())
 {


### PR DESCRIPTION
This was disabled in #7169, the fix from libmesh/libmesh#1000 is in the submodule. So this can be re-enabled.

Refs #7160
