### PR TITLE
Adding warning for centroid + PBC use

### DIFF
--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -397,6 +397,9 @@ FeatureFloodCount::getEntityValue(dof_id_type entity_id, FieldType field_type, u
 
     case FieldType::CENTROID:
     {
+      if (_periodic_node_map.size())
+        mooseDoOnce(mooseWarning("Centroids are not correct when using periodic boundaries, contact the MOOSE team"));
+
       // If this element contains the centroid of one of features, return it's index
       const auto * elem_ptr = _mesh.elemPtr(entity_id);
 


### PR DESCRIPTION
Fixing the centroids with PBCs is a low priority since we have no planned usage right now. I've captured the task in ticket #7377 but I'll add this warning for anyone who may stumble on it accidentally.

refs #7330
