### PR TITLE
TensorMechanicsMaterial and all children with Deprecated warnings

### DIFF
--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -28,7 +28,6 @@
 #include "DynamicStressDivergenceTensors.h"
 #include "OutOfPlanePressure.h"
 
-#include "LinearElasticMaterial.h"
 #include "LinearElasticTruss.h"
 #include "FiniteStrainPlasticMaterial.h"
 #include "FiniteStrainCrystalPlasticity.h"
@@ -41,7 +40,6 @@
 #include "ComputeLayeredCosseratElasticityTensor.h"
 #include "TwoPhaseStressMaterial.h"
 #include "MultiPhaseStressMaterial.h"
-#include "SimpleEigenStrainMaterial.h"
 #include "CompositeEigenstrain.h"
 #include "CompositeElasticityTensor.h"
 #include "ComputeElasticityTensor.h"
@@ -194,7 +192,6 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerKernel(DynamicStressDivergenceTensors);
   registerKernel(OutOfPlanePressure);
 
-  registerMaterial(LinearElasticMaterial);
   registerMaterial(LinearElasticTruss);
   registerMaterial(FiniteStrainPlasticMaterial);
   registerMaterial(FiniteStrainCrystalPlasticity);
@@ -207,7 +204,6 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerMaterial(ComputeLayeredCosseratElasticityTensor);
   registerMaterial(TwoPhaseStressMaterial);
   registerMaterial(MultiPhaseStressMaterial);
-  registerMaterial(SimpleEigenStrainMaterial);
   registerMaterial(CompositeEigenstrain);
   registerMaterial(CompositeElasticityTensor);
   registerMaterial(ComputeElasticityTensor);

--- a/modules/tensor_mechanics/src/materials/EigenStrainBaseMaterial.C
+++ b/modules/tensor_mechanics/src/materials/EigenStrainBaseMaterial.C
@@ -30,6 +30,7 @@ EigenStrainBaseMaterial::EigenStrainBaseMaterial(const InputParameters & paramet
     _delasticity_tensor_dc(declarePropertyDerivative<RankFourTensor>(_elasticity_tensor_name, _c_name)),
     _d2elasticity_tensor_dc2(declarePropertyDerivative<RankFourTensor>(_elasticity_tensor_name, _c_name, _c_name))
 {
+  mooseDeprecated("EigenStrainBaseMaterial is deprecated.   Please use ComputeVariableEigenstrain instead.");
 }
 
 RankTwoTensor EigenStrainBaseMaterial::computeStressFreeStrain()

--- a/modules/tensor_mechanics/src/materials/FiniteStrainMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainMaterial.C
@@ -29,6 +29,7 @@ FiniteStrainMaterial::FiniteStrainMaterial(const InputParameters & parameters) :
     _rotation_increment(declareProperty<RankTwoTensor>("rotation_increment")),
     _deformation_gradient(declareProperty<RankTwoTensor>("deformation_gradient"))
 {
+  mooseDeprecated("EigenStrainBaseMaterial is deprecated.   Please use the TensorMechanics plug-and-play system instead: http://mooseframework.org/wiki/PhysicsModules/TensorMechanics/PlugAndPlayMechanicsApproach/");
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
@@ -58,6 +58,8 @@ TensorMechanicsMaterial::TensorMechanicsMaterial(const InputParameters & paramet
     _Cijkl(getParam<std::vector<Real> >("C_ijkl"), (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method")),
     _prefactor_function(isParamValid("elasticity_tensor_prefactor") ? &getFunction("elasticity_tensor_prefactor") : NULL)
 {
+  mooseDeprecated("EigenStrainBaseMaterial is deprecated.   Please use the TensorMechanics plug-and-play system instead: http://mooseframework.org/wiki/PhysicsModules/TensorMechanics/PlugAndPlayMechanicsApproach/");
+
   const std::vector<FunctionName> & fcn_names(getParam<std::vector<FunctionName> >("initial_stress"));
   const unsigned num = fcn_names.size();
 


### PR DESCRIPTION
This is hopefully a better solution than simply removing all TensorMechanicsMaterial stuff, as I tried in #7390, where Marmot and Ferret failed.

Fixes #6973
