### PR TITLE
Added a new KSP convergence enum

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -112,8 +112,9 @@ enum MooseLinearConvergenceReason
   // MOOSE_DIVERGED_BREAKDOWN_BICG      = -6,
   // MOOSE_DIVERGED_NONSYMMETRIC        = -7,
   // MOOSE_DIVERGED_INDEFINITE_PC       = -8,
-  MOOSE_DIVERGED_NANORINF               = -9
+  MOOSE_DIVERGED_NANORINF               = -9,
   // MOOSE_DIVERGED_INDEFINITE_MAT      = -10
+  MOOSE_DIVERGED_PCSETUP_FAILED         = -11
 };
 
 /**

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -301,7 +301,11 @@ petscConverged(KSP ksp, PetscInt n, PetscReal rnorm, KSPConvergedReason * reason
     *reason = KSP_DIVERGED_NANORINF;
 #endif
     break;
-
+#if !PETSC_VERSION_LESS_THAN(3,6,0) // A new convergence enum in PETSc 3.6
+  case MOOSE_DIVERGED_PCSETUP_FAILED:
+    *reason = KSP_DIVERGED_PCSETUP_FAILED;
+    break;
+#endif
   default:
   {
     // If it's not either of the two specific cases we handle, just go


### PR DESCRIPTION
KSP_DIVERGED_PCSETUP_FAILED is introduced in PETSc from version 3.6.0. We updated MooseLinearConvergenceReason.

Closes #7119
