### PR TITLE
Fixed the issue "DIVERGED_NANORINF" with PETSc-3.7.x

### DIFF
--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3066,6 +3066,11 @@ FEProblem::solve()
 
   possiblyRebuildGeomSearchPatches();
 
+  // reset flag so that linear solver does not use
+  // the old converged reason "DIVERGED_NANORINF", when
+  // we throw  an exception and stop solve
+  _fail_next_linear_convergence_check = false;
+
   if (_solve)
     _nl.solve();
 


### PR DESCRIPTION
Manually set a few entries of the solution vector to NAN to force the linear solver diverge and return  DIVERGED_NANORINF, when the system throws an exception.  There are two functions to determine convergence of the linear iterative solvers, one in PETSc and the other in MOOSE. In PETSc-3.7.X, the linear solver will not call the function in MOOSE any more once the PETSc function detects  divergence. it leaves the variable in MOOSE unreset,  and hence the old converged reason will be reused in the next linear solve. We fixed this issue by reseting the flag just right before the nonlinear solve every time.

Closes #6924
