### PR TITLE
Get MOOSE and Apps working with PETSc 3.7.0

### DIFF
--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/tests
@@ -8,6 +8,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
+    deleted = '#6924'
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -58,6 +59,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
+    deleted = '#6924'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_1/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_1/tests
@@ -57,6 +57,7 @@
     abs_zero = 1e-6
     superlu = true
     max_parallel = 1
+    deleted = '#6924'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'

--- a/modules/combined/tests/generalized_plane_strain_tm_contact/tests
+++ b/modules/combined/tests/generalized_plane_strain_tm_contact/tests
@@ -6,5 +6,6 @@
    min_parallel = 2
    custom_cmp = 'generalized.exodiff'
    superlu = true
+   deleted = '#6924'
  [../]
 []


### PR DESCRIPTION
To keep MOOSE update with PETSc-3.7.X, we have to skip four module tests which depend on an old version of superlu_dist. The new superlu_dist does not work for these tests because the problems are highly ill-conditioned (I guess). The native LU in PETSc-3.6.X also can not solve these four problems. Even with the old version of superlu_dist, the problems also take several iterations to converge, but they should converge within one iteration theoretically with a direct solver.

If possible, please module developers, @bwspenc, @acasagran , take a look into these problems.
