### PR TITLE
Update Navier-Stokes module to use FluidProperties

### DIFF
--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -20,9 +20,9 @@ public:
   virtual Real pressure(Real v, Real u) const;
   virtual Real temperature(Real v, Real u) const;
   virtual Real c(Real v, Real u) const;
-  virtual Real cp(Real v=0., Real u=0.) const;
-  virtual Real cv(Real v=0., Real u=0.) const;
-  virtual Real gamma(Real v=0., Real u=0.) const;
+  virtual Real cp(Real v = 0., Real u = 0.) const;
+  virtual Real cv(Real v = 0., Real u = 0.) const;
+  virtual Real gamma(Real v = 0., Real u = 0.) const;
   virtual Real mu(Real v, Real u) const;
   virtual Real k(Real v, Real u) const;
   virtual Real s(Real v, Real u) const;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -20,8 +20,9 @@ public:
   virtual Real pressure(Real v, Real u) const;
   virtual Real temperature(Real v, Real u) const;
   virtual Real c(Real v, Real u) const;
-  virtual Real cp(Real v, Real u) const;
-  virtual Real cv(Real v, Real u) const;
+  virtual Real cp(Real v=0., Real u=0.) const;
+  virtual Real cv(Real v=0., Real u=0.) const;
+  virtual Real gamma(Real v=0., Real u=0.) const;
   virtual Real mu(Real v, Real u) const;
   virtual Real k(Real v, Real u) const;
   virtual Real s(Real v, Real u) const;

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -70,6 +70,12 @@ IdealGasFluidProperties::cv(Real, Real) const
 }
 
 Real
+IdealGasFluidProperties::gamma(Real, Real) const
+{
+  return _gamma;
+}
+
+Real
 IdealGasFluidProperties::mu(Real, Real) const
 {
   return _mu;

--- a/modules/navier_stokes/Makefile
+++ b/modules/navier_stokes/Makefile
@@ -17,6 +17,10 @@ FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
+# dependency on fluid_properties module
+FLUID_PROPERTIES := yes
+include $(MODULE_DIR)/modules.mk
+
 # dep apps
 APPLICATION_DIR    := $(MODULE_DIR)/navier_stokes
 APPLICATION_NAME   := navier_stokes

--- a/modules/navier_stokes/include/auxkernels/NSEnthalpyAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSEnthalpyAux.h
@@ -34,7 +34,7 @@ protected:
   virtual Real computeValue();
 
   const VariableValue & _rho;
-  const VariableValue & _rhoe;
+  const VariableValue & _rhoE;
   const VariableValue & _pressure;
 
   const Real _gamma;

--- a/modules/navier_stokes/include/auxkernels/NSEnthalpyAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSEnthalpyAux.h
@@ -7,6 +7,7 @@
 #ifndef NSENTHALPYAUX_H
 #define NSENTHALPYAUX_H
 
+// MOOSE includes
 #include "AuxKernel.h"
 
 //Forward Declarations
@@ -36,8 +37,6 @@ protected:
   const VariableValue & _rho;
   const VariableValue & _rhoE;
   const VariableValue & _pressure;
-
-  const Real _gamma;
 };
 
 #endif // NSENTHALPYAUX_H

--- a/modules/navier_stokes/include/auxkernels/NSInternalEnergyAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSInternalEnergyAux.h
@@ -1,0 +1,38 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef NSINTERNALENERGYAUX_H
+#define NSINTERNALENERGYAUX_H
+
+#include "AuxKernel.h"
+
+// Forward Declarations
+class NSInternalEnergyAux;
+
+template<>
+InputParameters validParams<NSInternalEnergyAux>();
+
+/**
+ * Auxiliary kernel for computing the internal energy of the fluid.
+ */
+class NSInternalEnergyAux : public AuxKernel
+{
+public:
+  NSInternalEnergyAux(const InputParameters & parameters);
+
+  virtual ~NSInternalEnergyAux() {}
+
+protected:
+  virtual Real computeValue();
+
+  const VariableValue & _rho;
+  const VariableValue & _u_vel;
+  const VariableValue & _v_vel;
+  const VariableValue & _w_vel;
+  const VariableValue & _rhoE;
+};
+
+#endif

--- a/modules/navier_stokes/include/auxkernels/NSMachAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSMachAux.h
@@ -7,10 +7,12 @@
 #ifndef NSMACHAUX_H
 #define NSMACHAUX_H
 
+// MOOSE includes
 #include "AuxKernel.h"
 
-//Forward Declarations
+// Forward Declarations
 class NSMachAux;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NSMachAux>();
@@ -31,10 +33,11 @@ protected:
   const VariableValue & _u_vel;
   const VariableValue & _v_vel;
   const VariableValue & _w_vel;
-  const VariableValue & _temperature;
+  const VariableValue & _specific_volume;
+  const VariableValue & _internal_energy;
 
-  Real _gamma;
-  Real _R;
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 };
 
 #endif

--- a/modules/navier_stokes/include/auxkernels/NSPressureAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSPressureAux.h
@@ -37,7 +37,7 @@ protected:
   const VariableValue & _u_vel;
   const VariableValue & _v_vel;
   const VariableValue & _w_vel;
-  const VariableValue & _rhoe;
+  const VariableValue & _rhoE;
 
   Real _gamma;
 };

--- a/modules/navier_stokes/include/auxkernels/NSPressureAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSPressureAux.h
@@ -9,8 +9,9 @@
 
 #include "AuxKernel.h"
 
-//Forward Declarations
+// Forward Declarations
 class NSPressureAux;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NSPressureAux>();
@@ -21,11 +22,6 @@ InputParameters validParams<NSPressureAux>();
 class NSPressureAux : public AuxKernel
 {
 public:
-
-  /**
-   * Factory constructor, takes parameters so that all derived classes can be built using the same
-   * constructor.
-   */
   NSPressureAux(const InputParameters & parameters);
 
   virtual ~NSPressureAux() {}
@@ -33,13 +29,11 @@ public:
 protected:
   virtual Real computeValue();
 
-  const VariableValue & _rho;
-  const VariableValue & _u_vel;
-  const VariableValue & _v_vel;
-  const VariableValue & _w_vel;
-  const VariableValue & _rhoE;
+  const VariableValue & _specific_volume;
+  const VariableValue & _internal_energy;
 
-  Real _gamma;
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 };
 
 #endif //VELOCITYAUX_H

--- a/modules/navier_stokes/include/auxkernels/NSSpecificVolumeAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSSpecificVolumeAux.h
@@ -1,0 +1,34 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef NSSPECIFICVOLUMEAUX_H
+#define NSSPECIFICVOLUMEAUX_H
+
+#include "AuxKernel.h"
+
+// Forward Declarations
+class NSSpecificVolumeAux;
+
+template<>
+InputParameters validParams<NSSpecificVolumeAux>();
+
+/**
+ * Auxiliary kernel for computing the specific volume (1/rho) of the fluid.
+ */
+class NSSpecificVolumeAux : public AuxKernel
+{
+public:
+  NSSpecificVolumeAux(const InputParameters & parameters);
+
+  virtual ~NSSpecificVolumeAux() {}
+
+protected:
+  virtual Real computeValue();
+
+  const VariableValue & _rho;
+};
+
+#endif

--- a/modules/navier_stokes/include/auxkernels/NSTemperatureAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSTemperatureAux.h
@@ -11,15 +11,14 @@
 
 // Forward Declarations
 class NSTemperatureAux;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NSTemperatureAux>();
 
 /**
  * Temperature is an auxiliary value computed from the total energy
- * and the velocity magnitude (e_i = internal energy, e_t = total energy):
- * T = e_i / c_v
- *   = (e_t - |u|^2/2) / c_v
+ * based on the FluidProperties.
  */
 class NSTemperatureAux : public AuxKernel
 {
@@ -29,17 +28,11 @@ public:
 protected:
   virtual Real computeValue();
 
-  // The temperature depends on velocities and total energy
-  const VariableValue & _rho;
-  const VariableValue & _u_vel;
-  const VariableValue & _v_vel;
-  const VariableValue & _w_vel;
-  const VariableValue & _rhoE;
+  const VariableValue & _specific_volume;
+  const VariableValue & _internal_energy;
 
-  // Specific heat at constant volume, treated as a single
-  // constant value.
-  const Real _R;
-  const Real _gamma;
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 };
 
 #endif // NSTEMPERATUREAUX_H

--- a/modules/navier_stokes/include/auxkernels/NSTemperatureAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSTemperatureAux.h
@@ -34,7 +34,7 @@ protected:
   const VariableValue & _u_vel;
   const VariableValue & _v_vel;
   const VariableValue & _w_vel;
-  const VariableValue & _rhoe;
+  const VariableValue & _rhoE;
 
   // Specific heat at constant volume, treated as a single
   // constant value.

--- a/modules/navier_stokes/include/bcs/NSInflowThermalBC.h
+++ b/modules/navier_stokes/include/bcs/NSInflowThermalBC.h
@@ -7,11 +7,12 @@
 #ifndef NSTHERMALINFLOWBC_H
 #define NSTHERMALINFLOWBC_H
 
+// MOOSE includes
 #include "NodalBC.h"
-
 
 // Forward Declarations
 class NSInflowThermalBC;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NSInflowThermalBC>();
@@ -32,11 +33,6 @@ protected:
   // to simply have a 1 on the diagonal.
   virtual Real computeQpResidual();
 
-  // Specific heat at constant volume, treated as a single
-  // constant value.
-  const Real _R;
-  const Real _gamma;
-
   // The specified density for this inflow boundary
   const Real _specified_rho;
 
@@ -45,6 +41,9 @@ protected:
 
   // The specified velocity magnitude for this inflow boundary
   const Real _specified_velocity_magnitude;
+
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 };
 
 #endif //NSTHERMALINFLOWBC_H

--- a/modules/navier_stokes/include/bcs/NSIntegratedBC.h
+++ b/modules/navier_stokes/include/bcs/NSIntegratedBC.h
@@ -37,19 +37,19 @@ protected:
   const VariableValue & _rho_u;
   const VariableValue & _rho_v;
   const VariableValue & _rho_w;
-  const VariableValue & _rho_e;
+  const VariableValue & _rho_E;
 
   const VariableGradient & _grad_rho;
   const VariableGradient & _grad_rho_u;
   const VariableGradient & _grad_rho_v;
   const VariableGradient & _grad_rho_w;
-  const VariableGradient & _grad_rho_e;
+  const VariableGradient & _grad_rho_E;
 
   unsigned _rho_var_number;
   unsigned _rhou_var_number;
   unsigned _rhov_var_number;
   unsigned _rhow_var_number;
-  unsigned _rhoe_var_number;
+  unsigned _rhoE_var_number;
 
   // Integrated BC can use Mat. properties...
   const MaterialProperty<Real> & _dynamic_viscosity;

--- a/modules/navier_stokes/include/bcs/NSIntegratedBC.h
+++ b/modules/navier_stokes/include/bcs/NSIntegratedBC.h
@@ -11,6 +11,7 @@
 
 // Forward Declarations
 class NSIntegratedBC;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NSIntegratedBC>();
@@ -55,9 +56,8 @@ protected:
   const MaterialProperty<Real> & _dynamic_viscosity;
   const MaterialProperty<RealTensorValue> & _viscous_stress_tensor; // Includes _dynamic_viscosity
 
-  // Required parameters
-  Real _gamma;
-  Real _R;
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 
   // Helper function for mapping Moose variable numberings into
   // the "canonical" numbering for the compressible NS equations.

--- a/modules/navier_stokes/include/bcs/NSPressureNeumannBC.h
+++ b/modules/navier_stokes/include/bcs/NSPressureNeumannBC.h
@@ -48,7 +48,6 @@ protected:
 
   // Required parameters
   unsigned _component;
-  Real _gamma;
 
   // An object for computing pressure derivatives.
   // Constructed via a reference to ourself

--- a/modules/navier_stokes/include/bcs/NSStagnationBC.h
+++ b/modules/navier_stokes/include/bcs/NSStagnationBC.h
@@ -11,6 +11,7 @@
 
 // Forward Declarations
 class NSStagnationBC;
+class IdealGasFluidProperties;
 
 // Specialization required of all user-level Moose objects
 template<>
@@ -27,14 +28,10 @@ public:
   NSStagnationBC(const InputParameters & parameters);
 
 protected:
-  const VariableValue & _u_vel;
-  const VariableValue & _v_vel;
-  const VariableValue & _w_vel;
+  const VariableValue & _mach;
 
-  const VariableValue & _temperature;
-
-  const Real _gamma;
-  const Real _R;
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 };
 
 #endif // NSSTAGNATIONBC_H

--- a/modules/navier_stokes/include/bcs/NSStagnationTemperatureBC.h
+++ b/modules/navier_stokes/include/bcs/NSStagnationTemperatureBC.h
@@ -31,6 +31,8 @@ protected:
   // diagonal for this DoF.
   virtual Real computeQpResidual();
 
+  const VariableValue & _temperature;
+
   // Required paramters
   const Real _desired_stagnation_temperature;
 };

--- a/modules/navier_stokes/include/bcs/NSThermalBC.h
+++ b/modules/navier_stokes/include/bcs/NSThermalBC.h
@@ -11,6 +11,7 @@
 
 // Forward Declarations
 class NSThermalBC;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NSThermalBC>();
@@ -32,10 +33,8 @@ protected:
   Real _final;
   Real _duration;
 
-  // Specific heat at constant volume, treated as a single
-  // constant value.
-  const Real _R;
-  const Real _gamma;
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 };
 
 #endif //NSTHERMALBC_H

--- a/modules/navier_stokes/include/kernels/NSKernel.h
+++ b/modules/navier_stokes/include/kernels/NSKernel.h
@@ -11,6 +11,7 @@
 
 // Forward Declarations
 class NSKernel;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NSKernel>();
@@ -54,13 +55,12 @@ protected:
   unsigned _rhow_var_number;
   unsigned _rhoE_var_number;
 
-  // Required parameters
-  Real _gamma;
-  Real _R;
-
   // Integrated BC can use Mat. properties...
   const MaterialProperty<Real> & _dynamic_viscosity;
   const MaterialProperty<RealTensorValue> & _viscous_stress_tensor; // Includes _dynamic_viscosity
+
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 
   /**
    * Helper function for mapping Moose variable numberings into

--- a/modules/navier_stokes/include/kernels/NSKernel.h
+++ b/modules/navier_stokes/include/kernels/NSKernel.h
@@ -38,21 +38,21 @@ protected:
   const VariableValue & _rho_u;
   const VariableValue & _rho_v;
   const VariableValue & _rho_w;
-  const VariableValue & _rho_e;
+  const VariableValue & _rho_E;
 
   // Gradients
   const VariableGradient & _grad_rho;
   const VariableGradient & _grad_rho_u;
   const VariableGradient & _grad_rho_v;
   const VariableGradient & _grad_rho_w;
-  const VariableGradient & _grad_rho_e;
+  const VariableGradient & _grad_rho_E;
 
   // Variable numberings
   unsigned _rho_var_number;
   unsigned _rhou_var_number;
   unsigned _rhov_var_number;
   unsigned _rhow_var_number;
-  unsigned _rhoe_var_number;
+  unsigned _rhoE_var_number;
 
   // Required parameters
   Real _gamma;

--- a/modules/navier_stokes/include/kernels/NSSUPGBase.h
+++ b/modules/navier_stokes/include/kernels/NSSUPGBase.h
@@ -60,7 +60,7 @@ protected:
   const VariableValue & _d_rhoudot_du;
   const VariableValue & _d_rhovdot_du;
   const VariableValue & _d_rhowdot_du;
-  const VariableValue & _d_rhoedot_du;
+  const VariableValue & _d_rhoEdot_du;
 
   // Temperature is need to compute speed of sound
   const VariableValue & _temperature;

--- a/modules/navier_stokes/include/materials/NavierStokesMaterial.h
+++ b/modules/navier_stokes/include/materials/NavierStokesMaterial.h
@@ -93,21 +93,21 @@ protected:
   const VariableValue & _rho_u;
   const VariableValue & _rho_v;
   const VariableValue & _rho_w;
-  const VariableValue & _rho_e;
+  const VariableValue & _rho_E;
 
   // Time derivative values for dependent variables
   const VariableValue & _drho_dt;
   const VariableValue & _drhou_dt;
   const VariableValue & _drhov_dt;
   const VariableValue & _drhow_dt;
-  const VariableValue & _drhoe_dt;
+  const VariableValue & _drhoE_dt;
 
   // Gradients
   const VariableGradient & _grad_rho;
   const VariableGradient & _grad_rho_u;
   const VariableGradient & _grad_rho_v;
   const VariableGradient & _grad_rho_w;
-  const VariableGradient & _grad_rho_e;
+  const VariableGradient & _grad_rho_E;
 
   // The real-valued material properties representing the element stabilization
   // parameters for each of the equations.

--- a/modules/navier_stokes/include/materials/NavierStokesMaterial.h
+++ b/modules/navier_stokes/include/materials/NavierStokesMaterial.h
@@ -9,8 +9,9 @@
 
 #include "Material.h"
 
-//Forward Declarations
+// Forward Declarations
 class NavierStokesMaterial;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NavierStokesMaterial>();
@@ -70,10 +71,7 @@ protected:
   // we can refer to them in a loop.
   std::vector<const VariableGradient *> _vel_grads;
 
-  // Specific heat at constant volume, treated as single
-  // constant values.
-  Real _R;
-  Real _gamma;
+  // Prandtl number
   Real _Pr;
 
   // Coupled values needed to compute strong form residuals
@@ -119,6 +117,9 @@ protected:
   // The (vector-valued) material property which is the strong-form
   // residual at each quadrature point.
   MaterialProperty<std::vector<Real> > & _strong_residuals;
+
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 
 private:
   // To be called from computeProperties() function to compute _hsupg

--- a/modules/navier_stokes/include/materials/NavierStokesMaterial.h
+++ b/modules/navier_stokes/include/materials/NavierStokesMaterial.h
@@ -71,9 +71,6 @@ protected:
   // we can refer to them in a loop.
   std::vector<const VariableGradient *> _vel_grads;
 
-  // Prandtl number
-  Real _Pr;
-
   // Coupled values needed to compute strong form residuals
   // for SUPG stabilization...
   const VariableValue & _u_vel;

--- a/modules/navier_stokes/include/postprocessors/NSEntropyError.h
+++ b/modules/navier_stokes/include/postprocessors/NSEntropyError.h
@@ -12,6 +12,7 @@
 
 // Forward Declarations
 class NSEntropyError;
+class IdealGasFluidProperties;
 
 template<>
 InputParameters validParams<NSEntropyError>();
@@ -27,10 +28,12 @@ protected:
 
   Real _rho_infty;
   Real _p_infty;
-  Real _gamma;
 
   const VariableValue & _rho;
   const VariableValue & _pressure;
+
+  // Fluid properties
+  const IdealGasFluidProperties & _fp;
 };
 
 #endif

--- a/modules/navier_stokes/include/userobjects/NSPressureDerivs.h
+++ b/modules/navier_stokes/include/userobjects/NSPressureDerivs.h
@@ -7,6 +7,9 @@
 #ifndef NSPRESSUREDERIVS_H
 #define NSPRESSUREDERIVS_H
 
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
 /**
  * Class outside the Moose hierarchy that contains common
  * functionality for computing derivatives of the pressure
@@ -50,7 +53,7 @@ Real NSPressureDerivs<T>::get_grad(unsigned i)
   const Real w = _data._w_vel[_data._qp];
 
   const Real vel2 = (u*u + v*v + w*w);
-  const Real gam = _data._gamma;
+  const Real gam = _data._fp.gamma();
 
   switch (i)
   {
@@ -87,7 +90,7 @@ Real NSPressureDerivs<T>::get_hess(unsigned i, unsigned j)
   const Real vel2 = (u*u + v*v + w*w);
 
   // Save some typing...
-  const Real gam = _data._gamma;
+  const Real gam = _data._fp.gamma();
 
   // A frequently-used variable
   const Real tmp = (1.0 - gam) / U0;

--- a/modules/navier_stokes/include/userobjects/NSTemperatureDerivs.h
+++ b/modules/navier_stokes/include/userobjects/NSTemperatureDerivs.h
@@ -49,7 +49,7 @@ Real NSTemperatureDerivs<T>::get_grad(unsigned i)
   const Real U1 = _data._rho_u[_data._qp];
   const Real U2 = _data._rho_v[_data._qp];
   const Real U3 = _data._rho_w[_data._qp];
-  const Real U4 = _data._rho_e[_data._qp];
+  const Real U4 = _data._rho_E[_data._qp];
 
   const Real rho2 = U0 * U0;
   const Real mom2 = U1*U1 + U2*U2 + U3*U3;
@@ -88,7 +88,7 @@ Real NSTemperatureDerivs<T>::get_hess(unsigned i, unsigned j)
   const Real U1 = _data._rho_u[_data._qp];
   const Real U2 = _data._rho_v[_data._qp];
   const Real U3 = _data._rho_w[_data._qp];
-  const Real U4 = _data._rho_e[_data._qp];
+  const Real U4 = _data._rho_E[_data._qp];
 
   const Real rho2 = U0 * U0;
   const Real rho3 = rho2 * U0;

--- a/modules/navier_stokes/include/userobjects/NSTemperatureDerivs.h
+++ b/modules/navier_stokes/include/userobjects/NSTemperatureDerivs.h
@@ -7,6 +7,9 @@
 #ifndef NSTEMPERATUREDERIVS_H
 #define NSTEMPERATUREDERIVS_H
 
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
 /**
  * Class outside the Moose hierarchy that contains common
  * functionality for computing derivatives of the temperature
@@ -53,9 +56,7 @@ Real NSTemperatureDerivs<T>::get_grad(unsigned i)
 
   const Real rho2 = U0 * U0;
   const Real mom2 = U1*U1 + U2*U2 + U3*U3;
-
-  const Real cv = _data._R / (_data._gamma-1.);
-  const Real tmp = -1.0 / rho2 / cv;
+  const Real tmp = -1.0 / rho2 / _data._fp.cv();
 
   switch (i)
   {
@@ -95,7 +96,7 @@ Real NSTemperatureDerivs<T>::get_hess(unsigned i, unsigned j)
   const Real rho4 = rho3 * U0;
   const Real mom2 = U1*U1 + U2*U2 + U3*U3;
 
-  const Real cv = _data._R / (_data._gamma - 1.0);
+  const Real cv = _data._fp.cv();
   const Real tmp = -1.0 / rho2 / cv;
 
   // Only lower-triangle of matrix is defined, it is symmetric

--- a/modules/navier_stokes/src/auxkernels/NSEnthalpyAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSEnthalpyAux.C
@@ -12,9 +12,9 @@ InputParameters validParams<NSEnthalpyAux>()
   InputParameters params = validParams<AuxKernel>();
 
   // Mark variables as required
-  params.addRequiredCoupledVar("rho", "");
-  params.addRequiredCoupledVar("rhoe", "");
-  params.addRequiredCoupledVar("pressure", "");
+  params.addRequiredCoupledVar("rho", "density");
+  params.addRequiredCoupledVar("rhoE", "total energy");
+  params.addRequiredCoupledVar("pressure", "pressure");
 
   // Parameters with default values
   params.addRequiredParam<Real>("gamma", "Ratio of specific heats");
@@ -25,7 +25,7 @@ InputParameters validParams<NSEnthalpyAux>()
 NSEnthalpyAux::NSEnthalpyAux(const InputParameters & parameters) :
     AuxKernel(parameters),
     _rho(coupledValue("rho")),
-    _rhoe(coupledValue("rhoe")),
+    _rhoE(coupledValue("rhoE")),
     _pressure(coupledValue("pressure")),
     _gamma(getParam<Real>("gamma"))
 {
@@ -35,5 +35,5 @@ Real
 NSEnthalpyAux::computeValue()
 {
   // H = (rho*E + P) / rho
-  return (_rhoe[_qp] + _pressure[_qp]) / _rho[_qp];
+  return (_rhoE[_qp] + _pressure[_qp]) / _rho[_qp];
 }

--- a/modules/navier_stokes/src/auxkernels/NSEnthalpyAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSEnthalpyAux.C
@@ -16,9 +16,6 @@ InputParameters validParams<NSEnthalpyAux>()
   params.addRequiredCoupledVar("rhoE", "total energy");
   params.addRequiredCoupledVar("pressure", "pressure");
 
-  // Parameters with default values
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats");
-
   return params;
 }
 
@@ -26,8 +23,7 @@ NSEnthalpyAux::NSEnthalpyAux(const InputParameters & parameters) :
     AuxKernel(parameters),
     _rho(coupledValue("rho")),
     _rhoE(coupledValue("rhoE")),
-    _pressure(coupledValue("pressure")),
-    _gamma(getParam<Real>("gamma"))
+    _pressure(coupledValue("pressure"))
 {
 }
 

--- a/modules/navier_stokes/src/auxkernels/NSInternalEnergyAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSInternalEnergyAux.C
@@ -1,0 +1,41 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "NSInternalEnergyAux.h"
+#include "MooseMesh.h"
+
+template<>
+InputParameters validParams<NSInternalEnergyAux>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addRequiredCoupledVar("rho", "density");
+  params.addRequiredCoupledVar("u", "x-velocity");
+  params.addCoupledVar("v", "y-velocity"); // Only required in >= 2D
+  params.addCoupledVar("w", "z-velocity"); // Only required in 3D...
+  params.addRequiredCoupledVar("rhoE", "total energy");
+
+  return params;
+}
+
+NSInternalEnergyAux::NSInternalEnergyAux(const InputParameters & parameters) :
+    AuxKernel(parameters),
+    _rho(coupledValue("rho")),
+    _u_vel(coupledValue("u")),
+    _v_vel(_mesh.dimension() >= 2 ? coupledValue("v") : _zero),
+    _w_vel(_mesh.dimension() == 3 ? coupledValue("w") : _zero),
+    _rhoE(coupledValue("rhoE"))
+{
+}
+
+Real
+NSInternalEnergyAux::computeValue()
+{
+  const RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
+
+  return _rhoE[_qp]/_rho[_qp] - 0.5 * vel.norm_sq();
+}

--- a/modules/navier_stokes/src/auxkernels/NSInternalEnergyAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSInternalEnergyAux.C
@@ -37,5 +37,5 @@ NSInternalEnergyAux::computeValue()
 {
   const RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
-  return _rhoE[_qp]/_rho[_qp] - 0.5 * vel.norm_sq();
+  return _rhoE[_qp] / _rho[_qp] - 0.5 * vel.norm_sq();
 }

--- a/modules/navier_stokes/src/auxkernels/NSPressureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSPressureAux.C
@@ -6,6 +6,11 @@
 /****************************************************************/
 
 #include "NSPressureAux.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
+// MOOSE includes
 #include "MooseMesh.h"
 
 template<>
@@ -14,35 +19,23 @@ InputParameters validParams<NSPressureAux>()
   InputParameters params = validParams<AuxKernel>();
 
   // Mark variables as required
-  params.addRequiredCoupledVar("rho", "");
-  params.addRequiredCoupledVar("u", "x-velocity");
-  params.addCoupledVar("v", "y-velocity"); // Only required in >= 2D
-  params.addCoupledVar("w", "z-velocity"); // Only required in 3D...
-  params.addRequiredCoupledVar("rhoE", "total energy");
-
-  // Parameters with default values
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats");
+  params.addRequiredCoupledVar("specific_volume", "");
+  params.addRequiredCoupledVar("internal_energy", "");
+  params.addRequiredParam<UserObjectName>("fluid_properties", "The name of the user object for fluid properties");
 
   return params;
 }
 
 NSPressureAux::NSPressureAux(const InputParameters & parameters) :
     AuxKernel(parameters),
-    _rho(coupledValue("rho")),
-    _u_vel(coupledValue("u")),
-    _v_vel(_mesh.dimension() >= 2 ? coupledValue("v") : _zero),
-    _w_vel(_mesh.dimension() == 3 ? coupledValue("w") : _zero),
-    _rhoE(coupledValue("rhoE")),
-    _gamma(getParam<Real>("gamma")) // can't use Material properties in Nodal Aux...
+    _specific_volume(coupledValue("specific_volume")),
+    _internal_energy(coupledValue("internal_energy")),
+    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
 }
 
 Real
 NSPressureAux::computeValue()
 {
-  // Velocity vector, squared
-  const Real V2 = _u_vel[_qp]*_u_vel[_qp] + _v_vel[_qp]*_v_vel[_qp] + _w_vel[_qp]*_w_vel[_qp];
-
-  // P = (gam-1) * ( rho*e_t - 1/2 * rho * V^2)
-  return (_gamma - 1)*(_rhoE[_qp] - 0.5 * _rho[_qp] * V2);
+  return _fp.pressure(_specific_volume[_qp], _internal_energy[_qp]);
 }

--- a/modules/navier_stokes/src/auxkernels/NSPressureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSPressureAux.C
@@ -18,7 +18,7 @@ InputParameters validParams<NSPressureAux>()
   params.addRequiredCoupledVar("u", "x-velocity");
   params.addCoupledVar("v", "y-velocity"); // Only required in >= 2D
   params.addCoupledVar("w", "z-velocity"); // Only required in 3D...
-  params.addRequiredCoupledVar("rhoe", "");
+  params.addRequiredCoupledVar("rhoE", "total energy");
 
   // Parameters with default values
   params.addRequiredParam<Real>("gamma", "Ratio of specific heats");
@@ -32,7 +32,7 @@ NSPressureAux::NSPressureAux(const InputParameters & parameters) :
     _u_vel(coupledValue("u")),
     _v_vel(_mesh.dimension() >= 2 ? coupledValue("v") : _zero),
     _w_vel(_mesh.dimension() == 3 ? coupledValue("w") : _zero),
-    _rhoe(coupledValue("rhoe")),
+    _rhoE(coupledValue("rhoE")),
     _gamma(getParam<Real>("gamma")) // can't use Material properties in Nodal Aux...
 {
 }
@@ -44,5 +44,5 @@ NSPressureAux::computeValue()
   const Real V2 = _u_vel[_qp]*_u_vel[_qp] + _v_vel[_qp]*_v_vel[_qp] + _w_vel[_qp]*_w_vel[_qp];
 
   // P = (gam-1) * ( rho*e_t - 1/2 * rho * V^2)
-  return (_gamma - 1)*(_rhoe[_qp] - 0.5 * _rho[_qp] * V2);
+  return (_gamma - 1)*(_rhoE[_qp] - 0.5 * _rho[_qp] * V2);
 }

--- a/modules/navier_stokes/src/auxkernels/NSSpecificVolumeAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSSpecificVolumeAux.C
@@ -1,0 +1,35 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "NSSpecificVolumeAux.h"
+#include "MooseMesh.h"
+
+template<>
+InputParameters validParams<NSSpecificVolumeAux>()
+{
+  InputParameters params = validParams<AuxKernel>();
+
+  params.addRequiredCoupledVar("rho", "density");
+
+  return params;
+}
+
+NSSpecificVolumeAux::NSSpecificVolumeAux(const InputParameters & parameters) :
+    AuxKernel(parameters),
+    _rho(coupledValue("rho"))
+{
+}
+
+Real
+NSSpecificVolumeAux::computeValue()
+{
+  // Return a "big" value rather than dividing by zero.
+  if (_rho[_qp] == 0.)
+    return 1.e10;
+
+  return 1. / _rho[_qp];
+}

--- a/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
@@ -18,7 +18,7 @@ InputParameters validParams<NSTemperatureAux>()
   params.addRequiredCoupledVar("u", "x-velocity");
   params.addCoupledVar("v", "y-velocity"); // Only required in >= 2D
   params.addCoupledVar("w", "z-velocity"); // Only required in 3D...
-  params.addRequiredCoupledVar("rhoe", "");
+  params.addRequiredCoupledVar("rhoE", "total energy");
 
   // Parameters with default values
   params.addRequiredParam<Real>("R", "Gas constant.");
@@ -33,7 +33,7 @@ NSTemperatureAux::NSTemperatureAux(const InputParameters & parameters) :
     _u_vel(coupledValue("u")),
     _v_vel(_mesh.dimension() >= 2 ? coupledValue("v") : _zero),
     _w_vel(_mesh.dimension() == 3 ? coupledValue("w") : _zero),
-    _rhoe(coupledValue("rhoe")),
+    _rhoE(coupledValue("rhoE")),
     _R(getParam<Real>("R")),
     _gamma(getParam<Real>("gamma"))
 {
@@ -48,7 +48,7 @@ NSTemperatureAux::computeValue()
     _w_vel[_qp]*_w_vel[_qp];
 
   // Internal Energy = Total Energy - Kinetic
-  Real e_i = (_rhoe[_qp] / _rho[_qp]) - 0.5 * V2;
+  Real e_i = (_rhoE[_qp] / _rho[_qp]) - 0.5 * V2;
 
   // T = e_i / cv
   Real cv = _R / (_gamma-1.);

--- a/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
@@ -6,6 +6,11 @@
 /****************************************************************/
 
 #include "NSTemperatureAux.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
+// MOOSE includes
 #include "MooseMesh.h"
 
 template<>
@@ -14,43 +19,23 @@ InputParameters validParams<NSTemperatureAux>()
   InputParameters params = validParams<AuxKernel>();
 
   // Mark variables as required
-  params.addRequiredCoupledVar("rho", "");
-  params.addRequiredCoupledVar("u", "x-velocity");
-  params.addCoupledVar("v", "y-velocity"); // Only required in >= 2D
-  params.addCoupledVar("w", "z-velocity"); // Only required in 3D...
-  params.addRequiredCoupledVar("rhoE", "total energy");
-
-  // Parameters with default values
-  params.addRequiredParam<Real>("R", "Gas constant.");
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats.");
+  params.addRequiredCoupledVar("specific_volume", "");
+  params.addRequiredCoupledVar("internal_energy", "");
+  params.addRequiredParam<UserObjectName>("fluid_properties", "The name of the user object for fluid properties");
 
   return params;
 }
 
 NSTemperatureAux::NSTemperatureAux(const InputParameters & parameters) :
     AuxKernel(parameters),
-    _rho(coupledValue("rho")),
-    _u_vel(coupledValue("u")),
-    _v_vel(_mesh.dimension() >= 2 ? coupledValue("v") : _zero),
-    _w_vel(_mesh.dimension() == 3 ? coupledValue("w") : _zero),
-    _rhoE(coupledValue("rhoE")),
-    _R(getParam<Real>("R")),
-    _gamma(getParam<Real>("gamma"))
+    _specific_volume(coupledValue("specific_volume")),
+    _internal_energy(coupledValue("internal_energy")),
+    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
 }
 
 Real
 NSTemperatureAux::computeValue()
 {
-  Real V2 =
-    _u_vel[_qp]*_u_vel[_qp] +
-    _v_vel[_qp]*_v_vel[_qp] +
-    _w_vel[_qp]*_w_vel[_qp];
-
-  // Internal Energy = Total Energy - Kinetic
-  Real e_i = (_rhoE[_qp] / _rho[_qp]) - 0.5 * V2;
-
-  // T = e_i / cv
-  Real cv = _R / (_gamma-1.);
-  return e_i / cv;
+  return _fp.temperature(_specific_volume[_qp], _internal_energy[_qp]);
 }

--- a/modules/navier_stokes/src/base/NavierStokesApp.C
+++ b/modules/navier_stokes/src/base/NavierStokesApp.C
@@ -17,6 +17,8 @@
 #include "NSThermalBC.h"
 #include "NSVelocityAux.h"
 #include "NSMachAux.h"
+#include "NSInternalEnergyAux.h"
+#include "NSSpecificVolumeAux.h"
 #include "NSImposedVelocityBC.h"
 #include "NSTemperatureAux.h"
 #include "NSTemperatureL2.h"
@@ -136,6 +138,8 @@ NavierStokesApp::registerObjects(Factory & factory)
   registerBoundaryCondition(NSThermalBC);
   registerAux(NSVelocityAux);
   registerAux(NSMachAux);
+  registerAux(NSInternalEnergyAux);
+  registerAux(NSSpecificVolumeAux);
   registerBoundaryCondition(NSImposedVelocityBC);
   registerAux(NSTemperatureAux);
   registerAux(NSPressureAux);

--- a/modules/navier_stokes/src/base/NavierStokesApp.C
+++ b/modules/navier_stokes/src/base/NavierStokesApp.C
@@ -53,6 +53,9 @@
 #include "NSPressureNeumannBC.h"
 #include "NSEntropyError.h"
 
+// So we can register objects from the fluid_properties module.
+#include "FluidPropertiesApp.h"
+
 //
 // Incompressible
 //
@@ -99,9 +102,11 @@ NavierStokesApp::NavierStokesApp(InputParameters parameters) :
     MooseApp(parameters)
 {
   Moose::registerObjects(_factory);
+  FluidPropertiesApp::registerObjects(_factory);
   NavierStokesApp::registerObjects(_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
+  FluidPropertiesApp::associateSyntax(_syntax, _action_factory);
   NavierStokesApp::associateSyntax(_syntax, _action_factory);
 }
 

--- a/modules/navier_stokes/src/bcs/NSEnergyInviscidBC.C
+++ b/modules/navier_stokes/src/bcs/NSEnergyInviscidBC.C
@@ -6,6 +6,9 @@
 /****************************************************************/
 #include "NSEnergyInviscidBC.h"
 
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
 template<>
 InputParameters validParams<NSEnergyInviscidBC>()
 {
@@ -30,17 +33,16 @@ Real NSEnergyInviscidBC::qpResidualHelper(Real pressure, Real un)
 Real NSEnergyInviscidBC::qpResidualHelper(Real rho, RealVectorValue u, Real /*pressure*/)
 {
   // return (rho*(cv*_temperature[_qp] + 0.5*u.norm_sq()) + pressure) * (u*_normals[_qp]) * _test[_i][_qp];
-
   // We can also expand pressure in terms of rho... does this make a difference?
   // Then we don't use the input pressure value.
-  Real cv = _R / (_gamma - 1.0);
-  return rho * (_gamma * cv * _temperature[_qp] + 0.5 * u.norm_sq()) * (u * _normals[_qp]) * _test[_i][_qp];
+  return rho * (_fp.gamma() * _fp.cv() * _temperature[_qp] + 0.5 * u.norm_sq()) * (u * _normals[_qp]) * _test[_i][_qp];
 }
 
 // (U4+p) * d(u.n)/dX
 Real NSEnergyInviscidBC::qpJacobianTermA(unsigned var_number, Real pressure)
 {
   Real result = 0.0;
+
   switch (var_number)
   {
     case 0: // density

--- a/modules/navier_stokes/src/bcs/NSEnergyInviscidBC.C
+++ b/modules/navier_stokes/src/bcs/NSEnergyInviscidBC.C
@@ -24,7 +24,7 @@ NSEnergyInviscidBC::NSEnergyInviscidBC(const InputParameters & parameters) :
 
 Real NSEnergyInviscidBC::qpResidualHelper(Real pressure, Real un)
 {
-  return (_rho_e[_qp] + pressure) * un * _test[_i][_qp];
+  return (_rho_E[_qp] + pressure) * un * _test[_i][_qp];
 }
 
 Real NSEnergyInviscidBC::qpResidualHelper(Real rho, RealVectorValue u, Real /*pressure*/)
@@ -69,7 +69,7 @@ Real NSEnergyInviscidBC::qpJacobianTermA(unsigned var_number, Real pressure)
 
   // Notice the division by _rho[_qp] here.  This comes from taking the
   // derivative wrt to either density or momentum.
-  return (_rho_e[_qp] + pressure) / _rho[_qp] * result * _phi[_j][_qp] * _test[_i][_qp];
+  return (_rho_E[_qp] + pressure) / _rho[_qp] * result * _phi[_j][_qp] * _test[_i][_qp];
 }
 
 // d(U4)/dX * (u.n)

--- a/modules/navier_stokes/src/bcs/NSEnergyViscousBC.C
+++ b/modules/navier_stokes/src/bcs/NSEnergyViscousBC.C
@@ -29,7 +29,7 @@ NSEnergyViscousBC::NSEnergyViscousBC(const InputParameters & parameters) :
   _gradU[1] = &_grad_rho_u;
   _gradU[2] = &_grad_rho_v;
   _gradU[3] = &_grad_rho_w;
-  _gradU[4] = &_grad_rho_e;
+  _gradU[4] = &_grad_rho_E;
 }
 
 Real NSEnergyViscousBC::computeQpResidual()
@@ -66,7 +66,7 @@ Real NSEnergyViscousBC::computeQpJacobian()
     intermediate_result *= _phi[_j][_qp];
 
     // Add in the temperature gradient contribution
-    intermediate_result += _temp_derivs.get_grad(/*rhoe=*/4) * _grad_phi[_j][_qp](ell);
+    intermediate_result += _temp_derivs.get_grad(/*rhoE=*/4) * _grad_phi[_j][_qp](ell);
 
     // Hit the result with the normal component, accumulate in thermal_term
     thermal_term += intermediate_result * _normals[_qp](ell);

--- a/modules/navier_stokes/src/bcs/NSEnergyWeakStagnationBC.C
+++ b/modules/navier_stokes/src/bcs/NSEnergyWeakStagnationBC.C
@@ -6,6 +6,9 @@
 /****************************************************************/
 #include "NSEnergyWeakStagnationBC.h"
 
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
 template<>
 InputParameters validParams<NSEnergyWeakStagnationBC>()
 {
@@ -20,6 +23,9 @@ NSEnergyWeakStagnationBC::NSEnergyWeakStagnationBC(const InputParameters & param
 
 Real NSEnergyWeakStagnationBC::computeQpResidual()
 {
+  // Ratio of specific heats
+  const Real gam = _fp.gamma();
+
   // Compute stagnation values
   Real T_s = 0.0, p_s = 0.0, rho_s = 0.0;
   staticValues(T_s, p_s, rho_s);
@@ -28,8 +34,7 @@ Real NSEnergyWeakStagnationBC::computeQpResidual()
   Real velmag2 = this->velmag2();
 
   // Compute static total energy, E_s
-  Real cv = _R / (_gamma - 1.0);
-  Real E_s = cv*T_s + 0.5 * velmag2;
+  Real E_s = _fp.cv()*T_s + 0.5 * velmag2;
 
   // Compute the product rho_s * H_s (H_s = static enthalpy)
   Real rhoH_s = rho_s * E_s + p_s;

--- a/modules/navier_stokes/src/bcs/NSEnergyWeakStagnationBC.C
+++ b/modules/navier_stokes/src/bcs/NSEnergyWeakStagnationBC.C
@@ -34,7 +34,7 @@ Real NSEnergyWeakStagnationBC::computeQpResidual()
   Real velmag2 = this->velmag2();
 
   // Compute static total energy, E_s
-  Real E_s = _fp.cv()*T_s + 0.5 * velmag2;
+  Real E_s = _fp.cv() * T_s + 0.5 * velmag2;
 
   // Compute the product rho_s * H_s (H_s = static enthalpy)
   Real rhoH_s = rho_s * E_s + p_s;

--- a/modules/navier_stokes/src/bcs/NSInflowThermalBC.C
+++ b/modules/navier_stokes/src/bcs/NSInflowThermalBC.C
@@ -44,5 +44,5 @@ NSInflowThermalBC::computeQpResidual()
   //
   // ***at a no-slip wall*** this further reduces to (no coupling to velocity variables):
   // rho*E - rho*cv*T = 0
-  return _u[_qp] - _specified_rho * (_fp.cv() * _specified_temperature + 0.5*_specified_velocity_magnitude*_specified_velocity_magnitude);
+  return _u[_qp] - _specified_rho * (_fp.cv() * _specified_temperature + 0.5 * _specified_velocity_magnitude * _specified_velocity_magnitude);
 }

--- a/modules/navier_stokes/src/bcs/NSInflowThermalBC.C
+++ b/modules/navier_stokes/src/bcs/NSInflowThermalBC.C
@@ -4,32 +4,32 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSInflowThermalBC.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
 
 template<>
 InputParameters validParams<NSInflowThermalBC>()
 {
   InputParameters params = validParams<NodalBC>();
 
-  // Global constant parameters
-  params.addRequiredParam<Real>("R", "Gas constant.");
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats.");
-
   // Boundary condition values, all required except for velocity which defaults to zero.
   params.addRequiredParam<Real>("specified_rho", "Density of incoming flow");
   params.addRequiredParam<Real>("specified_temperature", "Temperature of incoming flow");
   params.addParam<Real>("specified_velocity_magnitude", 0., "Velocity magnitude of incoming flow");
+  params.addRequiredParam<UserObjectName>("fluid_properties", "The name of the user object for fluid properties");
 
   return params;
 }
 
 NSInflowThermalBC::NSInflowThermalBC(const InputParameters & parameters) :
     NodalBC(parameters),
-    _R(getParam<Real>("R")),
-    _gamma(getParam<Real>("gamma")),
     _specified_rho(getParam<Real>("specified_rho")),
     _specified_temperature(getParam<Real>("specified_temperature")),
-    _specified_velocity_magnitude(getParam<Real>("specified_velocity_magnitude"))
+    _specified_velocity_magnitude(getParam<Real>("specified_velocity_magnitude")),
+    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
 }
 
@@ -44,7 +44,5 @@ NSInflowThermalBC::computeQpResidual()
   //
   // ***at a no-slip wall*** this further reduces to (no coupling to velocity variables):
   // rho*E - rho*cv*T = 0
-
-  Real cv = _R / (_gamma-1.);
-  return _u[_qp] - _specified_rho * (cv * _specified_temperature + 0.5*_specified_velocity_magnitude*_specified_velocity_magnitude);
+  return _u[_qp] - _specified_rho * (_fp.cv() * _specified_temperature + 0.5*_specified_velocity_magnitude*_specified_velocity_magnitude);
 }

--- a/modules/navier_stokes/src/bcs/NSIntegratedBC.C
+++ b/modules/navier_stokes/src/bcs/NSIntegratedBC.C
@@ -5,6 +5,11 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 #include "NSIntegratedBC.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
+// MOOSE includes
 #include "MooseMesh.h"
 
 template<>
@@ -21,9 +26,7 @@ InputParameters validParams<NSIntegratedBC>()
   params.addCoupledVar("rhov", "y-momentum"); // only required in >= 2D
   params.addCoupledVar("rhow", "z-momentum"); // only required in 3D
   params.addRequiredCoupledVar("rhoE", "energy");
-
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats.");
-  params.addRequiredParam<Real>("R", "Gas constant.");
+  params.addRequiredParam<UserObjectName>("fluid_properties", "The name of the user object for fluid properties");
 
   return params;
 }
@@ -56,9 +59,8 @@ NSIntegratedBC::NSIntegratedBC(const InputParameters & parameters) :
     _dynamic_viscosity(getMaterialProperty<Real>("dynamic_viscosity")),
     _viscous_stress_tensor(getMaterialProperty<RealTensorValue>("viscous_stress_tensor")),
 
-    // Required parameters
-    _gamma(getParam<Real>("gamma")),
-    _R(getParam<Real>("R"))
+    // FluidProperties UserObject
+    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
 }
 

--- a/modules/navier_stokes/src/bcs/NSIntegratedBC.C
+++ b/modules/navier_stokes/src/bcs/NSIntegratedBC.C
@@ -20,7 +20,7 @@ InputParameters validParams<NSIntegratedBC>()
   params.addRequiredCoupledVar("rhou", "x-momentum");
   params.addCoupledVar("rhov", "y-momentum"); // only required in >= 2D
   params.addCoupledVar("rhow", "z-momentum"); // only required in 3D
-  params.addRequiredCoupledVar("rhoe", "energy");
+  params.addRequiredCoupledVar("rhoE", "energy");
 
   params.addRequiredParam<Real>("gamma", "Ratio of specific heats.");
   params.addRequiredParam<Real>("R", "Gas constant.");
@@ -38,20 +38,20 @@ NSIntegratedBC::NSIntegratedBC(const InputParameters & parameters) :
     _rho_u(coupledValue("rhou")),
     _rho_v(_mesh.dimension() >= 2 ? coupledValue("rhov") : _zero),
     _rho_w(_mesh.dimension() == 3 ? coupledValue("rhow") : _zero),
-    _rho_e(coupledValue("rhoe")),
+    _rho_E(coupledValue("rhoE")),
 
     _grad_rho(coupledGradient("rho")),
     _grad_rho_u(coupledGradient("rhou")),
     _grad_rho_v(_mesh.dimension() >= 2 ? coupledGradient("rhov") : _grad_zero),
     _grad_rho_w(_mesh.dimension() == 3 ? coupledGradient("rhow") : _grad_zero),
-    _grad_rho_e(coupledGradient("rhoe")),
+    _grad_rho_E(coupledGradient("rhoE")),
 
     // Variable numberings
     _rho_var_number( coupled("rho") ),
     _rhou_var_number( coupled("rhou") ),
     _rhov_var_number(_mesh.dimension() >= 2 ? coupled("rhov") : libMesh::invalid_uint),
     _rhow_var_number(_mesh.dimension() == 3 ? coupled("rhow") : libMesh::invalid_uint),
-    _rhoe_var_number( coupled("rhoe") ),
+    _rhoE_var_number( coupled("rhoE") ),
 
     _dynamic_viscosity(getMaterialProperty<Real>("dynamic_viscosity")),
     _viscous_stress_tensor(getMaterialProperty<RealTensorValue>("viscous_stress_tensor")),
@@ -82,7 +82,7 @@ NSIntegratedBC::mapVarNumber(unsigned var)
     mapped_var_number = 2;
   else if (var == _rhow_var_number)
     mapped_var_number = 3;
-  else if (var == _rhoe_var_number)
+  else if (var == _rhoE_var_number)
     mapped_var_number = 4;
   else
     mooseError("Invalid var!");

--- a/modules/navier_stokes/src/bcs/NSPressureNeumannBC.C
+++ b/modules/navier_stokes/src/bcs/NSPressureNeumannBC.C
@@ -14,7 +14,6 @@ InputParameters validParams<NSPressureNeumannBC>()
 
   params.addRequiredCoupledVar("pressure", "The current value of the pressure");
   params.addRequiredParam<unsigned>("component", "(0,1,2) = (x,y,z) for which momentum component this BC is applied to");
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats.");
 
   return params;
 }
@@ -25,7 +24,6 @@ NSPressureNeumannBC::NSPressureNeumannBC(const InputParameters & parameters) :
     NSIntegratedBC(parameters),
     _pressure(coupledValue("pressure")),
     _component(getParam<unsigned>("component")),
-    _gamma(getParam<Real>("gamma")),
     _pressure_derivs(*this)
 {
 }

--- a/modules/navier_stokes/src/bcs/NSStagnationBC.C
+++ b/modules/navier_stokes/src/bcs/NSStagnationBC.C
@@ -4,29 +4,27 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSStagnationBC.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
+// MOOSE includes
 #include "MooseMesh.h"
 
 template<>
 InputParameters validParams<NSStagnationBC>()
 {
   InputParameters params = validParams<NodalBC>();
-  params.addRequiredCoupledVar("u", "");
-  params.addCoupledVar("v", ""); // only required in >= 2D
-  params.addCoupledVar("w", ""); // only required in 3D
-  params.addRequiredCoupledVar("temperature", "");
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats");
-  params.addRequiredParam<Real>("R", "Gas constant.");
+  params.addRequiredCoupledVar("mach", "Mach number");
+  params.addRequiredParam<UserObjectName>("fluid_properties", "The name of the user object for fluid properties");
   return params;
 }
 
 NSStagnationBC::NSStagnationBC(const InputParameters & parameters) :
     NodalBC(parameters),
-    _u_vel(coupledValue("u")),
-    _v_vel(_mesh.dimension() >= 2 ? coupledValue("v") : _zero),
-    _w_vel(_mesh.dimension() == 3 ? coupledValue("w") : _zero),
-    _temperature(coupledValue("temperature")),
-    _gamma(getParam<Real>("gamma")),
-    _R(getParam<Real>("R"))
+    _mach(coupledValue("mach")),
+    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
 }

--- a/modules/navier_stokes/src/bcs/NSStagnationPressureBC.C
+++ b/modules/navier_stokes/src/bcs/NSStagnationPressureBC.C
@@ -31,7 +31,7 @@ Real
 NSStagnationPressureBC::computeQpResidual()
 {
   // p_0 = p*(1 + 0.5*(gam-1)*M^2)^(gam/(gam-1))
-  const Real computed_stagnation_pressure = _pressure[_qp] * std::pow(1. + 0.5*(_fp.gamma() - 1.) * _mach[_qp] * _mach[_qp], _fp.gamma()/(_fp.gamma() - 1.));
+  const Real computed_stagnation_pressure = _pressure[_qp] * std::pow(1. + 0.5 * (_fp.gamma() - 1.) * _mach[_qp] * _mach[_qp], _fp.gamma() / (_fp.gamma() - 1.));
 
   // Return the difference between the current solution's stagnation pressure
   // and the desired.  The Dirichlet condition asserts that these should be equal.

--- a/modules/navier_stokes/src/bcs/NSStagnationPressureBC.C
+++ b/modules/navier_stokes/src/bcs/NSStagnationPressureBC.C
@@ -4,7 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSStagnationPressureBC.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
 
 // Full specialization of the validParams function for this object
 template<>
@@ -26,14 +30,8 @@ NSStagnationPressureBC::NSStagnationPressureBC(const InputParameters & parameter
 Real
 NSStagnationPressureBC::computeQpResidual()
 {
-  // The velocity vector
-  const RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
-
-  // Mach number, squared
-  const Real M2 = vel.norm_sq() / (_gamma * _R * _temperature[_qp]);
-
   // p_0 = p*(1 + 0.5*(gam-1)*M^2)^(gam/(gam-1))
-  const Real computed_stagnation_pressure = _pressure[_qp] * std::pow(1. + 0.5*(_gamma-1.)*M2, _gamma/(_gamma-1.));
+  const Real computed_stagnation_pressure = _pressure[_qp] * std::pow(1. + 0.5*(_fp.gamma() - 1.) * _mach[_qp] * _mach[_qp], _fp.gamma()/(_fp.gamma() - 1.));
 
   // Return the difference between the current solution's stagnation pressure
   // and the desired.  The Dirichlet condition asserts that these should be equal.

--- a/modules/navier_stokes/src/bcs/NSStagnationTemperatureBC.C
+++ b/modules/navier_stokes/src/bcs/NSStagnationTemperatureBC.C
@@ -4,18 +4,24 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSStagnationTemperatureBC.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
 
 template<>
 InputParameters validParams<NSStagnationTemperatureBC>()
 {
   InputParameters params = validParams<NSStagnationBC>();
+  params.addRequiredCoupledVar("temperature", "");
   params.addRequiredParam<Real>("desired_stagnation_temperature", "");
   return params;
 }
 
 NSStagnationTemperatureBC::NSStagnationTemperatureBC(const InputParameters & parameters) :
     NSStagnationBC(parameters),
+    _temperature(coupledValue("temperature")),
     _desired_stagnation_temperature(getParam<Real>("desired_stagnation_temperature"))
 {
 }
@@ -23,14 +29,8 @@ NSStagnationTemperatureBC::NSStagnationTemperatureBC(const InputParameters & par
 Real
 NSStagnationTemperatureBC::computeQpResidual()
 {
-  // The velocity vector
-  RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
-
-  // Mach number, squared
-  Real M2 = vel.norm_sq() / (_gamma * _R * _temperature[_qp]);
-
   // T_0 = T*(1 + 0.5*(gam-1)*M^2)
-  Real computed_stagnation_temperature = _temperature[_qp] * (1. + 0.5*(_gamma-1.)*M2);
+  Real computed_stagnation_temperature = _temperature[_qp] * (1. + 0.5*(_fp.gamma() - 1.) * _mach[_qp] * _mach[_qp]);
 
   // Return the difference between the current solution's stagnation temperature
   // and the desired.  The Dirichlet condition asserts that these should be equal.

--- a/modules/navier_stokes/src/bcs/NSStagnationTemperatureBC.C
+++ b/modules/navier_stokes/src/bcs/NSStagnationTemperatureBC.C
@@ -30,7 +30,7 @@ Real
 NSStagnationTemperatureBC::computeQpResidual()
 {
   // T_0 = T*(1 + 0.5*(gam-1)*M^2)
-  Real computed_stagnation_temperature = _temperature[_qp] * (1. + 0.5*(_fp.gamma() - 1.) * _mach[_qp] * _mach[_qp]);
+  Real computed_stagnation_temperature = _temperature[_qp] * (1. + 0.5 * (_fp.gamma() - 1.) * _mach[_qp] * _mach[_qp]);
 
   // Return the difference between the current solution's stagnation temperature
   // and the desired.  The Dirichlet condition asserts that these should be equal.

--- a/modules/navier_stokes/src/bcs/NSThermalBC.C
+++ b/modules/navier_stokes/src/bcs/NSThermalBC.C
@@ -4,7 +4,11 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
+
 #include "NSThermalBC.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
 
 template<>
 InputParameters validParams<NSThermalBC>()
@@ -14,8 +18,7 @@ InputParameters validParams<NSThermalBC>()
   params.addRequiredParam<Real>("initial", "Initial temperature");
   params.addRequiredParam<Real>("final", "Final temperature");
   params.addRequiredParam<Real>("duration", "Time over which temperature ramps up from initial to final");
-  params.addRequiredParam<Real>("R", "Gas constant.");
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats.");
+  params.addRequiredParam<UserObjectName>("fluid_properties", "The name of the user object for fluid properties");
   return params;
 }
 
@@ -26,8 +29,7 @@ NSThermalBC::NSThermalBC(const InputParameters & parameters) :
     _initial(getParam<Real>("initial")),
     _final(getParam<Real>("final")),
     _duration(getParam<Real>("duration")),
-    _R(getParam<Real>("R")),
-    _gamma(getParam<Real>("gamma"))
+    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
 }
 
@@ -59,7 +61,5 @@ NSThermalBC::computeQpResidual()
   // Moose::out << "(_p[_qp] * _c_v[_qp] * value)=" << (_p[_qp] * _c_v[_qp] * value) << std::endl;
   // //Moose::out << "_c_v[_qp]                    =" << _c_v[_qp] << std::endl;
   // Moose::out.flags(flags);
-
-  Real cv = _R / (_gamma - 1.0);
-  return _u[_qp] - (_rho[_qp] * cv * value);
+  return _u[_qp] - (_rho[_qp] * _fp.cv() * value);
 }

--- a/modules/navier_stokes/src/bcs/NSWeakStagnationBC.C
+++ b/modules/navier_stokes/src/bcs/NSWeakStagnationBC.C
@@ -42,7 +42,7 @@ NSWeakStagnationBC::staticValues(Real & T_s, Real & p_s, Real & rho_s)
     mooseError("Negative temperature detected in NSWeakStagnationBC!");
 
   // p_s = p_0 * (T_0/T)^(-gam/(gam-1))
-  p_s = _stagnation_pressure * std::pow(_stagnation_temperature/T_s, -_fp.gamma() / (_fp.gamma() - 1.));
+  p_s = _stagnation_pressure * std::pow(_stagnation_temperature / T_s, -_fp.gamma() / (_fp.gamma() - 1.));
 
   // Compute static rho from static pressure and temperature using equation of state.
   rho_s = _fp.rho(p_s, T_s);

--- a/modules/navier_stokes/src/bcs/NSWeakStagnationBC.C
+++ b/modules/navier_stokes/src/bcs/NSWeakStagnationBC.C
@@ -6,6 +6,9 @@
 /****************************************************************/
 #include "NSWeakStagnationBC.h"
 
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
 // Full specialization of the validParams function for this object
 template<>
 InputParameters validParams<NSWeakStagnationBC>()
@@ -33,17 +36,16 @@ void
 NSWeakStagnationBC::staticValues(Real & T_s, Real & p_s, Real & rho_s)
 {
   // T_s = T_0 - |u|^2/2/cp
-  Real cv = _R / (_gamma-1.);
-  T_s = _stagnation_temperature - 0.5 * this->velmag2() / (_gamma * cv);
+  T_s = _stagnation_temperature - 0.5 * this->velmag2() / _fp.cp();
 
   if (T_s < 0.)
     mooseError("Negative temperature detected in NSWeakStagnationBC!");
 
   // p_s = p_0 * (T_0/T)^(-gam/(gam-1))
-  p_s = _stagnation_pressure * std::pow(_stagnation_temperature/T_s, -_gamma / (_gamma-1.));
+  p_s = _stagnation_pressure * std::pow(_stagnation_temperature/T_s, -_fp.gamma() / (_fp.gamma() - 1.));
 
-  // rho_s = p_s / R / T_s
-  rho_s = p_s / _R / T_s;
+  // Compute static rho from static pressure and temperature using equation of state.
+  rho_s = _fp.rho(p_s, T_s);
 }
 
 Real

--- a/modules/navier_stokes/src/kernels/NSEnergyInviscidFlux.C
+++ b/modules/navier_stokes/src/kernels/NSEnergyInviscidFlux.C
@@ -6,6 +6,9 @@
 /****************************************************************/
 #include "NSEnergyInviscidFlux.h"
 
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
 template<>
 InputParameters validParams<NSEnergyInviscidFlux>()
 {
@@ -46,8 +49,11 @@ NSEnergyInviscidFlux::computeQpJacobian()
   // Derivative of this kernel wrt rho*E
   const RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
+  // Ratio of specific heats
+  const Real gam = _fp.gamma();
+
   // -gamma * phi_j * (U*grad(phi_i))
-  return -_gamma * _phi[_j][_qp] * (vel*_grad_test[_i][_qp]);
+  return -gam * _phi[_j][_qp] * (vel*_grad_test[_i][_qp]);
 }
 
 Real
@@ -56,9 +62,12 @@ NSEnergyInviscidFlux::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
   Real V2 = vel.norm_sq();
 
+  // Ratio of specific heats
+  const Real gam = _fp.gamma();
+
   // Derivative wrt density
   if (jvar == _rho_var_number)
-    return -((0.5*(_gamma-1)*V2 - _enthalpy[_qp]) * _phi[_j][_qp] * (vel * _grad_test[_i][_qp]));
+    return -((0.5*(gam-1)*V2 - _enthalpy[_qp]) * _phi[_j][_qp] * (vel * _grad_test[_i][_qp]));
 
   // Derivatives wrt momentums
   else if ((jvar == _rhou_var_number) || (jvar == _rhov_var_number) || (jvar == _rhow_var_number))
@@ -72,7 +81,7 @@ NSEnergyInviscidFlux::computeQpOffDiagJacobian(unsigned int jvar)
       jlocal = 2;
 
     // Scale the velocity vector by the scalar (1-gamma)*vel(jlocal)
-    vel *= (1.0 - _gamma) * vel(jlocal);
+    vel *= (1.0 - gam) * vel(jlocal);
 
     // Add in the enthalpy in the jlocal'th entry
     vel(jlocal) += _enthalpy[_qp];

--- a/modules/navier_stokes/src/kernels/NSEnergyInviscidFlux.C
+++ b/modules/navier_stokes/src/kernels/NSEnergyInviscidFlux.C
@@ -40,7 +40,7 @@ NSEnergyInviscidFlux::computeQpResidual()
   vel *= (_rho[_qp] * _enthalpy[_qp]);
 
   // Return -1 * vel * grad(phi_i)
-  return -(vel*_grad_test[_i][_qp]);
+  return -(vel * _grad_test[_i][_qp]);
 }
 
 Real
@@ -53,7 +53,7 @@ NSEnergyInviscidFlux::computeQpJacobian()
   const Real gam = _fp.gamma();
 
   // -gamma * phi_j * (U*grad(phi_i))
-  return -gam * _phi[_j][_qp] * (vel*_grad_test[_i][_qp]);
+  return -gam * _phi[_j][_qp] * (vel * _grad_test[_i][_qp]);
 }
 
 Real
@@ -67,7 +67,7 @@ NSEnergyInviscidFlux::computeQpOffDiagJacobian(unsigned int jvar)
 
   // Derivative wrt density
   if (jvar == _rho_var_number)
-    return -((0.5*(gam-1)*V2 - _enthalpy[_qp]) * _phi[_j][_qp] * (vel * _grad_test[_i][_qp]));
+    return -((0.5 * (gam - 1) * V2 - _enthalpy[_qp]) * _phi[_j][_qp] * (vel * _grad_test[_i][_qp]));
 
   // Derivatives wrt momentums
   else if ((jvar == _rhou_var_number) || (jvar == _rhov_var_number) || (jvar == _rhow_var_number))

--- a/modules/navier_stokes/src/kernels/NSEnergyThermalFlux.C
+++ b/modules/navier_stokes/src/kernels/NSEnergyThermalFlux.C
@@ -27,7 +27,7 @@ NSEnergyThermalFlux::NSEnergyThermalFlux(const InputParameters & parameters) :
   _gradU[1] = &_grad_rho_u;
   _gradU[2] = &_grad_rho_v;
   _gradU[3] = &_grad_rho_w;
-  _gradU[4] = &_grad_rho_e;
+  _gradU[4] = &_grad_rho_E;
 }
 
 Real

--- a/modules/navier_stokes/src/kernels/NSKernel.C
+++ b/modules/navier_stokes/src/kernels/NSKernel.C
@@ -5,6 +5,11 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 #include "NSKernel.h"
+
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
+// MOOSE includes
 #include "MooseMesh.h"
 
 template<>
@@ -19,8 +24,7 @@ InputParameters validParams<NSKernel>()
   params.addCoupledVar("rhov", "y-momentum"); // only required in 2D and 3D
   params.addCoupledVar("rhow", "z-momentum"); // only required in 3D
   params.addRequiredCoupledVar("rhoE", "total energy");
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats");
-  params.addRequiredParam<Real>("R", "Gas constant.");
+  params.addRequiredParam<UserObjectName>("fluid_properties", "The name of the user object for fluid properties");
   return params;
 }
 
@@ -51,13 +55,12 @@ NSKernel::NSKernel(const InputParameters & parameters) :
     _rhow_var_number( _mesh.dimension() == 3 ? coupled("rhow") : libMesh::invalid_uint),
     _rhoE_var_number( coupled("rhoE") ),
 
-    // Required parameters
-    _gamma(getParam<Real>("gamma")),
-    _R(getParam<Real>("R")),
-
     // Material properties
     _dynamic_viscosity(getMaterialProperty<Real>("dynamic_viscosity")),
-    _viscous_stress_tensor(getMaterialProperty<RealTensorValue>("viscous_stress_tensor"))
+    _viscous_stress_tensor(getMaterialProperty<RealTensorValue>("viscous_stress_tensor")),
+
+    // FluidProperties UserObject
+    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/NSKernel.C
+++ b/modules/navier_stokes/src/kernels/NSKernel.C
@@ -18,7 +18,7 @@ InputParameters validParams<NSKernel>()
   params.addRequiredCoupledVar("rhou", "x-momentum");
   params.addCoupledVar("rhov", "y-momentum"); // only required in 2D and 3D
   params.addCoupledVar("rhow", "z-momentum"); // only required in 3D
-  params.addRequiredCoupledVar("rhoe", "energy");
+  params.addRequiredCoupledVar("rhoE", "total energy");
   params.addRequiredParam<Real>("gamma", "Ratio of specific heats");
   params.addRequiredParam<Real>("R", "Gas constant.");
   return params;
@@ -35,21 +35,21 @@ NSKernel::NSKernel(const InputParameters & parameters) :
     _rho_u(coupledValue("rhou")),
     _rho_v( _mesh.dimension() >= 2 ? coupledValue("rhov") : _zero),
     _rho_w( _mesh.dimension() == 3 ? coupledValue("rhow") : _zero),
-    _rho_e(coupledValue("rhoe")),
+    _rho_E(coupledValue("rhoE")),
 
     // Gradients
     _grad_rho(coupledGradient("rho")),
     _grad_rho_u(coupledGradient("rhou")),
     _grad_rho_v( _mesh.dimension() >= 2 ? coupledGradient("rhov") : _grad_zero),
     _grad_rho_w( _mesh.dimension() == 3 ? coupledGradient("rhow") : _grad_zero),
-    _grad_rho_e(coupledGradient("rhoe")),
+    _grad_rho_E(coupledGradient("rhoE")),
 
     // Variable numberings
     _rho_var_number( coupled("rho") ),
     _rhou_var_number( coupled("rhou") ),
     _rhov_var_number( _mesh.dimension() >= 2 ? coupled("rhov") : libMesh::invalid_uint),
     _rhow_var_number( _mesh.dimension() == 3 ? coupled("rhow") : libMesh::invalid_uint),
-    _rhoe_var_number( coupled("rhoe") ),
+    _rhoE_var_number( coupled("rhoE") ),
 
     // Required parameters
     _gamma(getParam<Real>("gamma")),
@@ -81,7 +81,7 @@ NSKernel::mapVarNumber(unsigned var)
     mapped_var_number = 2;
   else if (var == _rhow_var_number)
     mapped_var_number = 3;
-  else if (var == _rhoe_var_number)
+  else if (var == _rhoE_var_number)
     mapped_var_number = 4;
   else
     mooseError("Invalid var!");

--- a/modules/navier_stokes/src/kernels/NSMomentumInviscidFlux.C
+++ b/modules/navier_stokes/src/kernels/NSMomentumInviscidFlux.C
@@ -6,6 +6,9 @@
 /****************************************************************/
 #include "NSMomentumInviscidFlux.h"
 
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
 template<>
 InputParameters validParams<NSMomentumInviscidFlux>()
 {
@@ -61,12 +64,15 @@ NSMomentumInviscidFlux::computeJacobianHelper(unsigned int m)
 {
   const RealVectorValue vel(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
 
+  // Ratio of specific heats
+  const Real gam = _fp.gamma();
+
   switch (m)
   {
     case 0: // density
     {
       const Real V2 = vel.norm_sq();
-      return vel(_component) * (vel * _grad_test[_i][_qp]) - 0.5 * (_gamma - 1.0) * V2 * _grad_test[_i][_qp](_component);
+      return vel(_component) * (vel * _grad_test[_i][_qp]) - 0.5 * (gam - 1.0) * V2 * _grad_test[_i][_qp](_component);
     }
 
     case 1:
@@ -81,11 +87,11 @@ NSMomentumInviscidFlux::computeJacobianHelper(unsigned int m)
 
       return -1.0 * (vel(_component) * _grad_test[_i][_qp](m_local)
                     + delta_kl * (vel * _grad_test[_i][_qp])
-                    + (1.-_gamma) * vel(m_local) * _grad_test[_i][_qp](_component)) * _phi[_j][_qp];
+                    + (1.-gam) * vel(m_local) * _grad_test[_i][_qp](_component)) * _phi[_j][_qp];
     }
 
     case 4: // energy
-      return -1.0 * (_gamma - 1.0) * _phi[_j][_qp] * _grad_test[_i][_qp](_component);
+      return -1.0 * (gam - 1.0) * _phi[_j][_qp] * _grad_test[_i][_qp](_component);
   }
 
   mooseError("Shouldn't get here!");

--- a/modules/navier_stokes/src/kernels/NSMomentumInviscidFlux.C
+++ b/modules/navier_stokes/src/kernels/NSMomentumInviscidFlux.C
@@ -39,7 +39,7 @@ NSMomentumInviscidFlux::computeQpResidual()
   vec(_component) += _pressure[_qp];
 
   // -((rho*u_k) * u + e_k * P) * grad(phi)
-  return -(vec*_grad_test[_i][_qp]);
+  return -(vec * _grad_test[_i][_qp]);
 }
 
 Real
@@ -69,29 +69,29 @@ NSMomentumInviscidFlux::computeJacobianHelper(unsigned int m)
 
   switch (m)
   {
-    case 0: // density
-    {
-      const Real V2 = vel.norm_sq();
-      return vel(_component) * (vel * _grad_test[_i][_qp]) - 0.5 * (gam - 1.0) * V2 * _grad_test[_i][_qp](_component);
-    }
+  case 0: // density
+  {
+    const Real V2 = vel.norm_sq();
+    return vel(_component) * (vel * _grad_test[_i][_qp]) - 0.5 * (gam - 1.0) * V2 * _grad_test[_i][_qp](_component);
+  }
 
-    case 1:
-    case 2:
-    case 3: // momentums
-    {
-      // Map m into m_local = {0,1,2}
-      unsigned int m_local = m - 1;
+  case 1:
+  case 2:
+  case 3: // momentums
+  {
+    // Map m into m_local = {0,1,2}
+    unsigned int m_local = m - 1;
 
-      // Kronecker delta
-      const Real delta_kl = (_component == m_local ? 1. : 0.);
+    // Kronecker delta
+    const Real delta_kl = (_component == m_local ? 1. : 0.);
 
-      return -1.0 * (vel(_component) * _grad_test[_i][_qp](m_local)
-                    + delta_kl * (vel * _grad_test[_i][_qp])
-                    + (1.-gam) * vel(m_local) * _grad_test[_i][_qp](_component)) * _phi[_j][_qp];
-    }
+    return -1.0 * (vel(_component) * _grad_test[_i][_qp](m_local)
+                   + delta_kl * (vel * _grad_test[_i][_qp])
+                   + (1. - gam) * vel(m_local) * _grad_test[_i][_qp](_component)) * _phi[_j][_qp];
+  }
 
-    case 4: // energy
-      return -1.0 * (gam - 1.0) * _phi[_j][_qp] * _grad_test[_i][_qp](_component);
+  case 4: // energy
+    return -1.0 * (gam - 1.0) * _phi[_j][_qp] * _grad_test[_i][_qp](_component);
   }
 
   mooseError("Shouldn't get here!");

--- a/modules/navier_stokes/src/kernels/NSMomentumInviscidFluxWithGradP.C
+++ b/modules/navier_stokes/src/kernels/NSMomentumInviscidFluxWithGradP.C
@@ -29,7 +29,7 @@ NSMomentumInviscidFluxWithGradP::NSMomentumInviscidFluxWithGradP(const InputPara
   _gradU[1] = &_grad_rho_u;
   _gradU[2] = &_grad_rho_v;
   _gradU[3] = &_grad_rho_w;
-  _gradU[4] = &_grad_rho_e;
+  _gradU[4] = &_grad_rho_E;
 }
 
 Real
@@ -118,7 +118,7 @@ NSMomentumInviscidFluxWithGradP::computeQpOffDiagJacobian(unsigned int jvar)
       + dFdp*_test[_i][_qp];
   }
 
-  else if (jvar == _rhoe_var_number)
+  else if (jvar == _rhoE_var_number)
   {
     // Pressure term Jacobian
     return dFdp * _test[_i][_qp];

--- a/modules/navier_stokes/src/kernels/NSSUPGBase.C
+++ b/modules/navier_stokes/src/kernels/NSSUPGBase.C
@@ -45,7 +45,7 @@ NSSUPGBase::NSSUPGBase(const InputParameters & parameters) :
     // _rho_u_old(coupledValueOld("rhou")),
     // _rho_v_old(_mesh.dimension() >= 2 ? coupledValueOld("rhov") : _zero),
     // _rho_w_old(_mesh.dimension() == 3 ? coupledValueOld("rhow") : _zero),
-    // _rho_e_old(coupledValueOld("rhoe")),
+    // _rho_E_old(coupledValueOld("rhoE")),
 
     // Time derivative derivatives (no, that's not a typo).  You can
     // just think of these as 1/dt for simplicity, they usually are...
@@ -53,7 +53,7 @@ NSSUPGBase::NSSUPGBase(const InputParameters & parameters) :
     _d_rhoudot_du(coupledDotDu("rhou")),
     _d_rhovdot_du(_mesh.dimension() >= 2 ? coupledDotDu("rhov") : _zero),
     _d_rhowdot_du(_mesh.dimension() == 3 ? coupledDotDu("rhow") : _zero),
-    _d_rhoedot_du(coupledDotDu("rhoe")),
+    _d_rhoEdot_du(coupledDotDu("rhoE")),
 
     // Coupled aux variables
     _temperature(coupledValue("temperature")),

--- a/modules/navier_stokes/src/kernels/NSSUPGEnergy.C
+++ b/modules/navier_stokes/src/kernels/NSSUPGEnergy.C
@@ -68,7 +68,7 @@ Real
 NSSUPGEnergy::computeQpJacobian()
 {
   // This is the energy equation, so pass the on-diagonal variable number.
-  return computeJacobianHelper(_rhoe_var_number);
+  return computeJacobianHelper(_rhoE_var_number);
 }
 
 Real

--- a/modules/navier_stokes/src/kernels/NSSUPGEnergy.C
+++ b/modules/navier_stokes/src/kernels/NSSUPGEnergy.C
@@ -41,7 +41,7 @@ NSSUPGEnergy::computeQpResidual()
   Real velmag2 = vel.norm_sq();
 
   // Velocity vector, dotted with the test function gradient
-  Real U_grad_phi = vel*_grad_test[_i][_qp];
+  Real U_grad_phi = vel * _grad_test[_i][_qp];
 
   // Vector object of momentum equation strong residuals
   RealVectorValue Ru (_strong_residuals[_qp][1],
@@ -112,8 +112,8 @@ NSSUPGEnergy::computeJacobianHelper(unsigned var)
   // Art. Diffusion matrix for taum-proportional term = (diag(H) + (1-gam)*S) * A_{ell}
   //
   RealTensorValue mom_mat;
-  mom_mat(0,0) = mom_mat(1,1) = mom_mat(2,2) = _enthalpy[_qp];        // (diag(H)
-  mom_mat += (1.-gam) * _calC[_qp][0] * _calC[_qp][0].transpose(); //  + (1-gam)*S)
+  mom_mat(0, 0) = mom_mat(1, 1) = mom_mat(2, 2) = _enthalpy[_qp];     // (diag(H)
+  mom_mat += (1. - gam) * _calC[_qp][0] * _calC[_qp][0].transpose(); //  + (1-gam)*S)
   mom_mat = mom_mat * _calA[_qp][mapped_var_number];                  // * A_{ell}
   Real mom_term = _taum[_qp] * grad_test_i * (mom_mat * grad_phi_j);
 
@@ -129,22 +129,22 @@ NSSUPGEnergy::computeJacobianHelper(unsigned var)
 
   switch (mapped_var_number)
   {
-    case 1:
-    case 2:
-    case 3:
-    {
-      // Variable for zero-based indexing into local matrices and vectors.
-      unsigned m_local = mapped_var_number-1;
+  case 1:
+  case 2:
+  case 3:
+  {
+    // Variable for zero-based indexing into local matrices and vectors.
+    unsigned m_local = mapped_var_number - 1;
 
-      //
-      // Art. Diffusion matrix for tauc-proportional term = (0.5*(gam-1.)*velmag2 - H)*C_m
-      //
-      RealTensorValue mass_mat = (0.5*(gam-1.)*velmag2 - _enthalpy[_qp]) * _calC[_qp][m_local];
-      mass_term = _tauc[_qp] * grad_test_i * (mass_mat * grad_phi_j);
+    //
+    // Art. Diffusion matrix for tauc-proportional term = (0.5*(gam-1.)*velmag2 - H)*C_m
+    //
+    RealTensorValue mass_mat = (0.5 * (gam - 1.) * velmag2 - _enthalpy[_qp]) * _calC[_qp][m_local];
+    mass_term = _tauc[_qp] * grad_test_i * (mass_mat * grad_phi_j);
 
-      // Don't even need to break, no other cases to fall through to...
-      break;
-    }
+    // Don't even need to break, no other cases to fall through to...
+    break;
+  }
   }
 
   // Sum up values and return

--- a/modules/navier_stokes/src/kernels/NSSUPGMomentum.C
+++ b/modules/navier_stokes/src/kernels/NSSUPGMomentum.C
@@ -44,7 +44,7 @@ NSSUPGMomentum::computeQpResidual()
   const Real gam = _fp.gamma();
 
   // Velocity vector, dotted with the test function gradient
-  Real U_grad_phi = vel*_grad_test[_i][_qp];
+  Real U_grad_phi = vel * _grad_test[_i][_qp];
 
   // _component'th entry of test function gradient
   Real dphi_dxk = _grad_test[_i][_qp](_component);
@@ -63,9 +63,9 @@ NSSUPGMomentum::computeQpResidual()
   //Moose::out << "mass_term[" << _qp << "]=" << mass_term << std::endl;
 
   // 2.) The momentum-residual term:
-  Real mom_term1 = U_grad_phi * _strong_residuals[_qp][_component+1]; // <- momentum indices are 1,2,3, _component is 0,1,2
-  Real mom_term2 = (1.-gam)*dphi_dxk*(vel*Ru);
-  Real mom_term3 = vel(_component) * (_grad_test[_i][_qp]*Ru);
+  Real mom_term1 = U_grad_phi * _strong_residuals[_qp][_component + 1]; // <- momentum indices are 1,2,3, _component is 0,1,2
+  Real mom_term2 = (1. - gam) * dphi_dxk * (vel * Ru);
+  Real mom_term3 = vel(_component) * (_grad_test[_i][_qp] * Ru);
 
   mom_term = _taum[_qp] * (mom_term1 + mom_term2 + mom_term3);
   //Moose::out << "mom_term[" << _qp << "]=" << mom_term << std::endl;
@@ -125,7 +125,7 @@ NSSUPGMomentum::computeJacobianHelper(unsigned int var)
   // Art. Diffusion matrix for taum-proportional term = ( C_k + (1-gam)*C_k^T + diag(u_k) ) * calA_{ell}
   //
   RealTensorValue mom_mat;
-  mom_mat(0,0) = mom_mat(1,1) = mom_mat(2,2) = vel(_component); // (diag(u_k)
+  mom_mat(0, 0) = mom_mat(1, 1) = mom_mat(2, 2) = vel(_component); // (diag(u_k)
   mom_mat += _calC[_qp][_component];                            //  + C_k
   mom_mat += (1.0 - gam) * _calC[_qp][_component].transpose();  //  + (1-gam)*C_k^T)
   mom_mat = mom_mat * _calA[_qp][mapped_var_number];            // * calA_{ell}
@@ -134,7 +134,7 @@ NSSUPGMomentum::computeJacobianHelper(unsigned int var)
   //
   // Art. Diffusion matrix for taue-proportional term = (gam-1) * calE_km
   //
-  RealTensorValue ene_mat = (gam-1) * _calE[_qp][_component][mapped_var_number];
+  RealTensorValue ene_mat = (gam - 1) * _calE[_qp][_component][mapped_var_number];
   Real ene_term = _taue[_qp] * grad_test_i * (ene_mat * grad_phi_j); // taue * grad(phi_i) * (M*grad(phi_j))
 
   // 2.) Terms only present if the variable is one of the momentums
@@ -142,21 +142,21 @@ NSSUPGMomentum::computeJacobianHelper(unsigned int var)
 
   switch (mapped_var_number)
   {
-    case 1:
-    case 2:
-    case 3:
-    {
-      // Variable for zero-based indexing into local matrices and vectors.
-      unsigned m_local = mapped_var_number - 1;
+  case 1:
+  case 2:
+  case 3:
+  {
+    // Variable for zero-based indexing into local matrices and vectors.
+    unsigned m_local = mapped_var_number - 1;
 
-      //
-      // Art. Diffusion matrix for tauc-proportional term = 0.5*(gam - 1.0)*velmag2*D_km - vel(_component)*C_m
-      //
-      RealTensorValue mass_mat;
-      mass_mat(_component, m_local) = 0.5 * (gam - 1.0) * velmag2;    // 0.5*(gam - 1.0)*velmag2*D_km
-      mass_mat -= vel(_component)*_calC[_qp][m_local];                // vel(_component)*C_m
-      mass_term = _tauc[_qp] * grad_test_i * (mass_mat * grad_phi_j); // tauc * grad(phi_i) * (M*grad(phi_j))
-    }
+    //
+    // Art. Diffusion matrix for tauc-proportional term = 0.5*(gam - 1.0)*velmag2*D_km - vel(_component)*C_m
+    //
+    RealTensorValue mass_mat;
+    mass_mat(_component, m_local) = 0.5 * (gam - 1.0) * velmag2;    // 0.5*(gam - 1.0)*velmag2*D_km
+    mass_mat -= vel(_component) * _calC[_qp][m_local];              // vel(_component)*C_m
+    mass_term = _tauc[_qp] * grad_test_i * (mass_mat * grad_phi_j); // tauc * grad(phi_i) * (M*grad(phi_j))
+  }
     // Nothing else to do if we are not a momentum...
   }
 

--- a/modules/navier_stokes/src/materials/NavierStokesMaterial.C
+++ b/modules/navier_stokes/src/materials/NavierStokesMaterial.C
@@ -33,7 +33,7 @@ InputParameters validParams<NavierStokesMaterial>()
   params.addRequiredCoupledVar("rhou", "x-momentum");
   params.addCoupledVar("rhov", "y-momentum"); // only required in >= 2D
   params.addCoupledVar("rhow", "z-momentum"); // only required in 3D
-  params.addRequiredCoupledVar("rhoe", "energy");
+  params.addRequiredCoupledVar("rhoE", "energy");
 
   return params;
 }
@@ -82,21 +82,21 @@ NavierStokesMaterial::NavierStokesMaterial(const InputParameters & parameters) :
     _rho_u(coupledValue("rhou")),
     _rho_v(_mesh.dimension() >= 2 ? coupledValue("rhov") : _zero),
     _rho_w(_mesh.dimension() == 3 ? coupledValue("rhow") : _zero),
-    _rho_e(coupledValue("rhoe")),
+    _rho_E(coupledValue("rhoE")),
 
     // Time derivative values
     _drho_dt(coupledDot("rho")),
     _drhou_dt(coupledDot("rhou")),
     _drhov_dt(_mesh.dimension() >= 2 ? coupledDot("rhov") : _zero),
     _drhow_dt(_mesh.dimension() == 3 ? coupledDot("rhow") : _zero),
-    _drhoe_dt(coupledDot("rhoe")),
+    _drhoE_dt(coupledDot("rhoE")),
 
     // Gradients
     _grad_rho(coupledGradient("rho")),
     _grad_rho_u(coupledGradient("rhou")),
     _grad_rho_v(_mesh.dimension() >= 2 ? coupledGradient("rhov") : _grad_zero),
     _grad_rho_w(_mesh.dimension() == 3 ? coupledGradient("rhow") : _grad_zero),
-    _grad_rho_e(coupledGradient("rhoe")),
+    _grad_rho_E(coupledGradient("rhoE")),
 
     // Material properties for stabilization
     _hsupg(declareProperty<Real>("hsupg")),
@@ -371,7 +371,7 @@ void NavierStokesMaterial::computeStrongResiduals(unsigned int qp)
 //            << ", drhou_dt=" << _drhou_dt
 //            << ", drhov_dt=" << _drhov_dt
 //            << ", drhow_dt=" << _drhow_dt
-//            << ", drhoe_dt=" << _drhoe_dt
+//            << ", drhoE_dt=" << _drhoE_dt
 //            << std::endl;
 
   // Momentum divergence
@@ -468,7 +468,7 @@ void NavierStokesMaterial::computeStrongResiduals(unsigned int qp)
     _calA[qp][1]*_grad_rho_u[qp] +
     _calA[qp][2]*_grad_rho_v[qp] +
     _calA[qp][3]*_grad_rho_w[qp] +
-    _calA[qp][4]*_grad_rho_e[qp];
+    _calA[qp][4]*_grad_rho_E[qp];
 
   // No matrices/vectors for the energy residual strong form... just write it out like
   // the mass equation residual.  See "Momentum SUPG terms prop. to energy residual"
@@ -479,7 +479,7 @@ void NavierStokesMaterial::computeStrongResiduals(unsigned int qp)
     (1.-_gamma)*(vel(0)*(vel*_grad_rho_u[qp]) +
                  vel(1)*(vel*_grad_rho_v[qp]) +
                  vel(2)*(vel*_grad_rho_w[qp])) +
-    _gamma*(vel*_grad_rho_e[qp])
+    _gamma*(vel*_grad_rho_E[qp])
     ;
 
   // Now for the actual residual values...
@@ -503,5 +503,5 @@ void NavierStokesMaterial::computeStrongResiduals(unsigned int qp)
     _strong_residuals[qp][3] = 0.;
 
   // The energy equation strong residual
-  _strong_residuals[qp][4] = _drhoe_dt[qp] + energy_resid;
+  _strong_residuals[qp][4] = _drhoE_dt[qp] + energy_resid;
 }

--- a/modules/navier_stokes/src/postprocessors/NSEntropyError.C
+++ b/modules/navier_stokes/src/postprocessors/NSEntropyError.C
@@ -7,15 +7,18 @@
 
 #include "NSEntropyError.h"
 
+// FluidProperties includes
+#include "IdealGasFluidProperties.h"
+
 template<>
 InputParameters validParams<NSEntropyError>()
 {
   InputParameters params = validParams<ElementIntegralPostprocessor>();
   params.addRequiredParam<Real>("rho_infty", "Freestream density");
   params.addRequiredParam<Real>("p_infty", "Freestream pressure");
-  params.addRequiredParam<Real>("gamma", "Ratio of specific heats");
   params.addRequiredCoupledVar("rho", "density");
   params.addRequiredCoupledVar("pressure", "pressure");
+  params.addRequiredParam<UserObjectName>("fluid_properties", "The name of the user object for fluid properties");
   return params;
 }
 
@@ -23,9 +26,9 @@ NSEntropyError::NSEntropyError(const InputParameters & parameters) :
     ElementIntegralPostprocessor(parameters),
     _rho_infty(getParam<Real>("rho_infty")),
     _p_infty(getParam<Real>("p_infty")),
-    _gamma(getParam<Real>("gamma")),
     _rho(coupledValue("rho")),
-    _pressure(coupledValue("pressure"))
+    _pressure(coupledValue("pressure")),
+    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
 }
 
@@ -38,6 +41,6 @@ NSEntropyError::getValue()
 Real
 NSEntropyError::computeQpIntegral()
 {
-  Real integrand = (_pressure[_qp] / _p_infty) * std::pow(_rho_infty / _rho[_qp], _gamma) - 1.;
+  Real integrand = (_pressure[_qp] / _p_infty) * std::pow(_rho_infty / _rho[_qp], _fp.gamma()) - 1.;
   return integrand * integrand;
 }

--- a/modules/navier_stokes/tests/bump/bump.i
+++ b/modules/navier_stokes/tests/bump/bump.i
@@ -161,6 +161,20 @@
       value = 316417.5
     [../]
   [../]
+
+  [./internal_energy]
+    [./InitialCondition]
+      type = ConstantIC
+      value = 215250. # J/kg, echo "271044.375/1.17682926829268 - 0.5*173.594354746921*173.594354746921" | bc -l
+    [../]
+  [../]
+
+  [./specific_volume]
+    [./InitialCondition]
+      type = ConstantIC
+      value = 0.84974093264248915997 # m^3/kg, echo "1/1.17682926829268" | bc -l
+    [../]
+  [../]
 []
 
 
@@ -384,6 +398,21 @@
     u = vel_x
     v = vel_y
     temperature = temperature
+  [../]
+
+  [./internal_energy_auxkernel]
+    type = NSInternalEnergyAux
+    variable = internal_energy
+    rho = rho
+    u = vel_x
+    v = vel_y
+    rhoE = rhoE
+  [../]
+
+  [./specific_volume_auxkernel]
+    type = NSSpecificVolumeAux
+    variable = specific_volume
+    rho = rho
   [../]
 []
 

--- a/modules/navier_stokes/tests/bump/bump.i
+++ b/modules/navier_stokes/tests/bump/bump.i
@@ -20,9 +20,7 @@
 # second-order in this norm.
 [GlobalParams]
   # Ratio of specific heats
-  gamma = 1.4
   Pr = 0.71
-  R = 287
 []
 
 
@@ -211,6 +209,7 @@
     rhoE = rhoE
     u = vel_x
     v = vel_y
+    fluid_properties = ideal_gas
   [../]
 
   ################################################################################
@@ -235,6 +234,7 @@
     rhoE = rhoE
     pressure = pressure
     component = 0
+    fluid_properties = ideal_gas
   [../]
 
   ################################################################################
@@ -259,6 +259,7 @@
     rhoE = rhoE
     pressure = pressure
     component = 1
+    fluid_properties = ideal_gas
   [../]
 
 
@@ -283,6 +284,7 @@
     u = vel_x
     v = vel_y
     enthalpy = enthalpy
+    fluid_properties = ideal_gas
   [../]
 
 
@@ -302,6 +304,7 @@
     v = vel_y
     temperature = temperature
     enthalpy = enthalpy
+    fluid_properties = ideal_gas
   [../]
 
   # The SUPG stabilization terms for the x-momentum equation
@@ -317,6 +320,7 @@
     v = vel_y
     temperature = temperature
     enthalpy = enthalpy
+    fluid_properties = ideal_gas
   [../]
 
   # The SUPG stabilization terms for the y-momentum equation
@@ -332,6 +336,7 @@
     v = vel_y
     temperature = temperature
     enthalpy = enthalpy
+    fluid_properties = ideal_gas
   [../]
 
   # The SUPG stabilization terms for the energy equation
@@ -346,6 +351,7 @@
     v = vel_y
     temperature = temperature
     enthalpy = enthalpy
+    fluid_properties = ideal_gas
   [../]
 []
 
@@ -369,19 +375,17 @@
   [./temperature_auxkernel]
     type = NSTemperatureAux
     variable = temperature
-    rho = rho
-    u = vel_x
-    v = vel_y
-    rhoE = rhoE
+    internal_energy = internal_energy
+    specific_volume = specific_volume
+    fluid_properties = ideal_gas
   [../]
 
   [./pressure_auxkernel]
     type = NSPressureAux
     variable = pressure
-    rho = rho
-    u = vel_x
-    v = vel_y
-    rhoE = rhoE
+    internal_energy = internal_energy
+    specific_volume = specific_volume
+    fluid_properties = ideal_gas
   [../]
 
   [./enthalpy_auxkernel]
@@ -397,7 +401,9 @@
     variable = Mach
     u = vel_x
     v = vel_y
-    temperature = temperature
+    internal_energy = internal_energy
+    specific_volume = specific_volume
+    fluid_properties = ideal_gas
   [../]
 
   [./internal_energy_auxkernel]
@@ -430,6 +436,7 @@
     u = vel_x
     v = vel_y
     boundary = '2' # 'Outflow'
+    fluid_properties = ideal_gas
   [../]
 
   # Specified pressure x-momentum equation invsicid outflow BC
@@ -445,6 +452,7 @@
     component = 0
     boundary = '2' # 'Outflow'
     specified_pressure = 101325 # Pa
+    fluid_properties = ideal_gas
   [../]
 
   # Specified pressure y-momentum equation inviscid outflow BC
@@ -460,6 +468,7 @@
     component = 1
     boundary = '2' # 'Outflow'
     specified_pressure = 101325 # Pa
+    fluid_properties = ideal_gas
   [../]
 
   # Specified pressure energy equation outflow BC
@@ -475,6 +484,7 @@
     temperature = temperature
     boundary = '2' # 'Outflow'
     specified_pressure = 101325 # Pa
+    fluid_properties = ideal_gas
   [../]
 
   # The no penentration BC (u.n=0) applies on all the solid surfaces.
@@ -491,6 +501,7 @@
     rhov = rhov
     rhoE = rhoE
     pressure = pressure
+    fluid_properties = ideal_gas
   [../]
 
   # The no penentration BC (u.n=0) applies on all the solid surfaces.
@@ -507,6 +518,7 @@
     rhov = rhov
     rhoE = rhoE
     pressure = pressure
+    fluid_properties = ideal_gas
   [../]
 
   #
@@ -526,6 +538,7 @@
     rhov = rhov
     u = vel_x
     v = vel_y
+    fluid_properties = ideal_gas
   [../]
 
   [./weak_stagnation_rhou_convective_inflow]
@@ -543,6 +556,7 @@
     rhov = rhov
     u = vel_x
     v = vel_y
+    fluid_properties = ideal_gas
   [../]
 
   [./weak_stagnation_rhou_pressure_inflow]
@@ -560,6 +574,7 @@
     rhov = rhov
     u = vel_x
     v = vel_y
+    fluid_properties = ideal_gas
   [../]
 
   [./weak_stagnation_rhov_convective_inflow]
@@ -577,6 +592,7 @@
     rhov = rhov
     u = vel_x
     v = vel_y
+    fluid_properties = ideal_gas
   [../]
 
   [./weak_stagnation_rhov_pressure_inflow]
@@ -594,6 +610,7 @@
     rhov = rhov
     u = vel_x
     v = vel_y
+    fluid_properties = ideal_gas
   [../]
 
   [./weak_stagnation_energy_inflow]
@@ -610,6 +627,7 @@
     rhov = rhov
     u = vel_x
     v = vel_y
+    fluid_properties = ideal_gas
   [../]
 []
 
@@ -633,18 +651,19 @@
     # the amount of artificial viscosity added, so it's best to use a
     # realistic value.
     dynamic_viscosity = 0.0
+    fluid_properties = ideal_gas
   [../]
 
   # A Material is the most efficient way to use the FluidProperties
   # stuff, as the values will be computed once and then used by all
   # the Kernels, rather than calling getUserObject from individual
   # Kernels and computing properties repeatedly.
-  # [./fp_mat]
-  #   type = FluidPropertiesMaterial
-  #   e = e # internal energy
-  #   v = v # specific volume
-  #   fp = ideal_gas
-  # [../]
+  [./fp_mat]
+    type = FluidPropertiesMaterial
+    e = internal_energy
+    v = specific_volume
+    fp = ideal_gas
+  [../]
 []
 
 
@@ -658,6 +677,7 @@
     p_infty = 101325
     rho = rho
     pressure = pressure
+    fluid_properties = ideal_gas
   [../]
 []
 

--- a/modules/navier_stokes/tests/bump/bump.i
+++ b/modules/navier_stokes/tests/bump/bump.i
@@ -18,13 +18,6 @@
 # demonstrate convergence of the numerical solution (since the true
 # solution should produce zero entropy).  The error should converge at
 # second-order in this norm.
-[GlobalParams]
-  # Ratio of specific heats
-  Pr = 0.71
-[]
-
-
-
 [Mesh]
   # Bi-Linear elements
   # file = SmoothBump_quad_ref1_Q1.msh # 84 elems, 65 nodes
@@ -194,7 +187,7 @@
   ################################################################################
 
   # Time derivative term
-  [./rho_ie]
+  [./rho_time_deriv]
     type = TimeDerivative
     variable = rho
   [../]
@@ -217,7 +210,7 @@
   ################################################################################
 
   # Time derivative term
-  [./rhou_ie]
+  [./rhou_time_deriv]
     type = TimeDerivative
     variable = rhou
   [../]
@@ -242,7 +235,7 @@
   ################################################################################
 
   # Time derivative term
-  [./rhov_ie]
+  [./rhov_time_deriv]
     type = TimeDerivative
     variable = rhov
   [../]
@@ -268,7 +261,7 @@
   ################################################################################
 
   # Time derivative term
-  [./rhoE_ie]
+  [./rhoE_time_deriv]
     type = TimeDerivative
     variable = rhoE
   [../]
@@ -654,16 +647,17 @@
     fluid_properties = ideal_gas
   [../]
 
-  # A Material is the most efficient way to use the FluidProperties
-  # stuff, as the values will be computed once and then used by all
-  # the Kernels, rather than calling getUserObject from individual
-  # Kernels and computing properties repeatedly.
-  [./fp_mat]
-    type = FluidPropertiesMaterial
-    e = internal_energy
-    v = specific_volume
-    fp = ideal_gas
-  [../]
+  # A Material is probably the most efficient way to use the
+  # FluidProperties stuff, as the values will be computed once and
+  # then used by all the Kernels, rather than calling getUserObject
+  # from individual Kernels and computing properties repeatedly.
+  # This could possibly be refactored in the future...
+  # [./fp_mat]
+  #   type = FluidPropertiesMaterial
+  #   e = internal_energy
+  #   v = specific_volume
+  #   fp = ideal_gas
+  # [../]
 []
 
 

--- a/modules/navier_stokes/tests/bump/bump.i
+++ b/modules/navier_stokes/tests/bump/bump.i
@@ -72,7 +72,7 @@
     family = LAGRANGE
   [../]
 
-  [./rhoe]
+  [./rhoE]
     order = FIRST
     family = LAGRANGE
 
@@ -165,6 +165,17 @@
 
 
 
+[Modules]
+  [./FluidProperties]
+    [./ideal_gas]
+      type = IdealGasFluidProperties
+      gamma = 1.4
+      R = 287
+    [../]
+  [../]
+[]
+
+
 [Kernels]
   ################################################################################
   # Mass conservation Equation
@@ -183,7 +194,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
   [../]
@@ -207,7 +218,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     pressure = pressure
     component = 0
   [../]
@@ -231,7 +242,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     pressure = pressure
     component = 1
   [../]
@@ -242,19 +253,19 @@
   ################################################################################
 
   # Time derivative term
-  [./rhoe_ie]
+  [./rhoE_ie]
     type = TimeDerivative
-    variable = rhoe
+    variable = rhoE
   [../]
 
   # Energy equation inviscid flux term (integrated by parts)
-  [./rhoe_if]
+  [./rhoE_if]
     type = NSEnergyInviscidFlux
-    variable = rhoe
+    variable = rhoE
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     enthalpy = enthalpy
@@ -272,7 +283,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     temperature = temperature
@@ -287,7 +298,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     temperature = temperature
@@ -302,7 +313,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     temperature = temperature
@@ -310,13 +321,13 @@
   [../]
 
   # The SUPG stabilization terms for the energy equation
-  [./rhoe_supg]
+  [./rhoE_supg]
     type = NSSUPGEnergy
-    variable = rhoe
+    variable = rhoE
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     temperature = temperature
@@ -347,7 +358,7 @@
     rho = rho
     u = vel_x
     v = vel_y
-    rhoe = rhoe
+    rhoE = rhoE
   [../]
 
   [./pressure_auxkernel]
@@ -356,14 +367,14 @@
     rho = rho
     u = vel_x
     v = vel_y
-    rhoe = rhoe
+    rhoE = rhoE
   [../]
 
   [./enthalpy_auxkernel]
     type = NSEnthalpyAux
     variable = enthalpy
     rho = rho
-    rhoe = rhoe
+    rhoE = rhoE
     pressure = pressure
   [../]
 
@@ -386,7 +397,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     boundary = '2' # 'Outflow'
@@ -399,7 +410,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     component = 0
@@ -414,7 +425,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     component = 1
@@ -423,13 +434,13 @@
   [../]
 
   # Specified pressure energy equation outflow BC
-  [./rhoe_specified_pressure_outflow]
+  [./rhoE_specified_pressure_outflow]
     type = NSEnergyInviscidSpecifiedPressureBC
-    variable = rhoe
+    variable = rhoE
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     temperature = temperature
@@ -449,7 +460,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     pressure = pressure
   [../]
 
@@ -465,7 +476,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     pressure = pressure
   [../]
 
@@ -481,7 +492,7 @@
     sx = 1.
     sy = 0.
     rho = rho
-    rhoe = rhoe
+    rhoE = rhoE
     rhou = rhou
     rhov = rhov
     u = vel_x
@@ -498,7 +509,7 @@
     sx = 1.
     sy = 0.
     rho = rho
-    rhoe = rhoe
+    rhoE = rhoE
     rhou = rhou
     rhov = rhov
     u = vel_x
@@ -515,7 +526,7 @@
     sx = 1.
     sy = 0.
     rho = rho
-    rhoe = rhoe
+    rhoE = rhoE
     rhou = rhou
     rhov = rhov
     u = vel_x
@@ -532,7 +543,7 @@
     sx = 1.
     sy = 0.
     rho = rho
-    rhoe = rhoe
+    rhoE = rhoE
     rhou = rhou
     rhov = rhov
     u = vel_x
@@ -549,7 +560,7 @@
     sx = 1.
     sy = 0.
     rho = rho
-    rhoe = rhoe
+    rhoE = rhoE
     rhou = rhou
     rhov = rhov
     u = vel_x
@@ -558,14 +569,14 @@
 
   [./weak_stagnation_energy_inflow]
     type = NSEnergyWeakStagnationBC
-    variable = rhoe
+    variable = rhoE
     boundary = '1' # 'Inflow'
     stagnation_pressure = 120192.995549849 # Pa, Mach=0.5 at 1 atm
     stagnation_temperature = 315 # K, Mach=0.5 at 1 atm
     sx = 1.
     sy = 0.
     rho = rho
-    rhoe = rhoe
+    rhoE = rhoE
     rhou = rhou
     rhov = rhov
     u = vel_x
@@ -583,7 +594,7 @@
     rho = rho
     rhou = rhou
     rhov = rhov
-    rhoe = rhoe
+    rhoE = rhoE
     u = vel_x
     v = vel_y
     temperature = temperature
@@ -594,6 +605,17 @@
     # realistic value.
     dynamic_viscosity = 0.0
   [../]
+
+  # A Material is the most efficient way to use the FluidProperties
+  # stuff, as the values will be computed once and then used by all
+  # the Kernels, rather than calling getUserObject from individual
+  # Kernels and computing properties repeatedly.
+  # [./fp_mat]
+  #   type = FluidPropertiesMaterial
+  #   e = e # internal energy
+  #   v = v # specific volume
+  #   fp = ideal_gas
+  # [../]
 []
 
 


### PR DESCRIPTION
@andrsd, I added some default values in the IdealGasFluidProperties.h, so that you can call these functions that just return constants without passing dummy values in user code.  Also, I added an override for `IdealGasFluidProperties::gamma()` as we discussed.

Refs #6972.
