### PR TITLE
Remove post_command and add separate RunCommand tester

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -33,8 +33,6 @@ class RunApp(Tester):
     # Valgrind
     params.addParam('valgrind', 'NORMAL', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
 
-    params.addParam('post_command',       "Command to be run after the MOOSE job is run")
-
     return params
 
   def __init__(self, name, params):
@@ -160,10 +158,6 @@ class RunApp(Tester):
 
     if options.pbs:
       return self.getPBSCommand(options)
-
-    if self.specs.isValid('post_command'):
-      command += ';\n'
-      command += self.specs['post_command']
 
     return command
 

--- a/python/TestHarness/testers/RunCommand.py
+++ b/python/TestHarness/testers/RunCommand.py
@@ -1,0 +1,27 @@
+import re, os, sys, time
+from Tester import Tester
+from RunParallel import RunParallel # For TIMEOUT value
+
+class RunCommand(Tester):
+
+  @staticmethod
+  def validParams():
+    params = Tester.validParams()
+    params.addRequiredParam('command',      "The command line to execute for this test.")
+    params.addParam('test_name',          "The name of the test - populated automatically")
+    return params
+
+  def __init__(self, name, params):
+    Tester.__init__(self, name, params)
+    self.command = params['command']
+
+  def getCommand(self, options):
+    # Create the command line string to run
+    return self.command
+
+  def processResults(self, moose_dir, retcode, options, output):
+    reason = ''
+    if retcode != 0 :
+      reason = 'CODE %d' % retcode
+
+    return (reason, output)

--- a/test/tests/misc/test_harness_tester/tests
+++ b/test/tests/misc/test_harness_tester/tests
@@ -1,4 +1,8 @@
 [Tests]
+  [./test_runcommand]
+    type = 'RunCommand'
+    command = 'echo Hello World'
+  [../]
 
 # All tests are disabled so that we don't see unecessary TestHarness tester
 # during normal operation.  Feel free to uncomment these tests and run them


### PR DESCRIPTION
I'd like to replace the `post_command` option with a dedicated command execution tester.

Closes #7410
