### PR TITLE
Fix unused variable warning.

### DIFF
--- a/framework/include/base/MooseObjectWarehouseBase.h
+++ b/framework/include/base/MooseObjectWarehouseBase.h
@@ -577,7 +577,7 @@ MooseObjectWarehouseBase<T>::sortHelper(std::vector<MooseSharedPointer<T> > & ob
 
 template<typename T>
 inline void
-MooseObjectWarehouseBase<T>::checkThreadID(THREAD_ID tid) const
+MooseObjectWarehouseBase<T>::checkThreadID(THREAD_ID libmesh_dbg_var(tid)) const
 {
   mooseAssert(tid < _num_threads, "Attempting to access a thread id (" << tid << ") greater than the number allowed by the storage item (" << _num_threads << ")");
 }

--- a/framework/include/restart/RestartableData.h
+++ b/framework/include/restart/RestartableData.h
@@ -144,7 +144,7 @@ RestartableData<T>::type ()
 
 template <typename T>
 inline void
-RestartableData<T>::swap (RestartableDataValue *rhs)
+RestartableData<T>::swap (RestartableDataValue * libmesh_dbg_var(rhs))
 {
   mooseAssert(rhs != NULL, "Assigning NULL?");
 //  _value.swap(cast_ptr<RestartableData<T>*>(rhs)->_value);

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -596,7 +596,7 @@ SolutionUserObject::pointValue(Real t, const Point & p, const std::string & var_
 }
 
 Real
-SolutionUserObject::pointValue(Real t, const Point & p, const unsigned int local_var_index) const
+SolutionUserObject::pointValue(Real libmesh_dbg_var(t), const Point & p, const unsigned int local_var_index) const
 {
   // Create copy of point
   Point pt(p);


### PR DESCRIPTION
"tid" was only used in an assert, so when compiling in opt mode, GCC
5.2.0 was spewing unused variable warnings on almost every file.

Refs #1777.
