### PR TITLE
Override in the framework/src/base directory

### DIFF
--- a/framework/include/base/AuxGroupExecuteMooseObjectWarehouse.h
+++ b/framework/include/base/AuxGroupExecuteMooseObjectWarehouse.h
@@ -62,7 +62,7 @@ public:
   /**
    * Updates the various active lists of objects.
    */
-  virtual void updateActive(THREAD_ID tid = 0);
+  virtual void updateActive(THREAD_ID tid = 0) override;
 
 protected:
 

--- a/framework/include/base/CacheChangedListsThread.h
+++ b/framework/include/base/CacheChangedListsThread.h
@@ -27,7 +27,7 @@ public:
   CacheChangedListsThread(CacheChangedListsThread & x, Threads::split split);
   virtual ~CacheChangedListsThread();
 
-  virtual void onElement(const Elem *elem);
+  virtual void onElement(const Elem * elem) override;
 
   void join(const CacheChangedListsThread & y);
 

--- a/framework/include/base/ComputeDiracThread.h
+++ b/framework/include/base/ComputeDiracThread.h
@@ -39,11 +39,11 @@ public:
 
   virtual ~ComputeDiracThread();
 
-  virtual void subdomainChanged();
-  virtual void pre();
-  virtual void onElement(const Elem *elem);
-  virtual void postElement(const Elem * /*elem*/);
-  virtual void post();
+  virtual void subdomainChanged() override;
+  virtual void pre() override;
+  virtual void onElement(const Elem * elem) override;
+  virtual void postElement(const Elem * /*elem*/) override;
+  virtual void post() override;
 
   void join(const ComputeDiracThread & /*y*/);
 

--- a/framework/include/base/ComputeElemAuxVarsThread.h
+++ b/framework/include/base/ComputeElemAuxVarsThread.h
@@ -36,9 +36,9 @@ public:
 
   virtual ~ComputeElemAuxVarsThread();
 
-  virtual void subdomainChanged();
-  virtual void onElement(const Elem *elem);
-  virtual void post();
+  virtual void subdomainChanged() override;
+  virtual void onElement(const Elem * elem) override;
+  virtual void post() override;
 
   void join(const ComputeElemAuxVarsThread & /*y*/);
 

--- a/framework/include/base/ComputeElemDampingThread.h
+++ b/framework/include/base/ComputeElemDampingThread.h
@@ -36,7 +36,7 @@ public:
 
   virtual ~ComputeElemDampingThread();
 
-  virtual void onElement(const Elem *elem);
+  virtual void onElement(const Elem * elem) override;
 
   void join(const ComputeElemDampingThread & /*y*/);
 

--- a/framework/include/base/ComputeFullJacobianThread.h
+++ b/framework/include/base/ComputeFullJacobianThread.h
@@ -31,15 +31,13 @@ public:
 
   virtual ~ComputeFullJacobianThread();
 
-  void join(const ComputeJacobianThread & /*y*/)
-  {}
-
+  void join(const ComputeJacobianThread & /*y*/) {}
 
 protected:
-  virtual void computeJacobian();
-  virtual void computeFaceJacobian(BoundaryID bnd_id);
-  virtual void computeInternalFaceJacobian(const Elem * neighbor);
-  virtual void computeInternalInterFaceJacobian(BoundaryID bnd_id);
+  virtual void computeJacobian() override;
+  virtual void computeFaceJacobian(BoundaryID bnd_id) override;
+  virtual void computeInternalFaceJacobian(const Elem * neighbor) override;
+  virtual void computeInternalInterFaceJacobian(BoundaryID bnd_id) override;
 
   // Reference to BC storage structures
   const MooseObjectWarehouse<IntegratedBC> & _integrated_bcs;

--- a/framework/include/base/ComputeIndicatorThread.h
+++ b/framework/include/base/ComputeIndicatorThread.h
@@ -40,12 +40,12 @@ public:
 
   virtual ~ComputeIndicatorThread();
 
-  virtual void subdomainChanged();
-  virtual void onElement(const Elem *elem);
-  virtual void onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void onInternalSide(const Elem *elem, unsigned int side);
-  virtual void postElement(const Elem * /*elem*/);
-  virtual void post();
+  virtual void subdomainChanged() override;
+  virtual void onElement(const Elem * elem) override;
+  virtual void onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void onInternalSide(const Elem * elem, unsigned int side) override;
+  virtual void postElement(const Elem * /*elem*/) override;
+  virtual void post() override;
 
   void join(const ComputeIndicatorThread & /*y*/);
 

--- a/framework/include/base/ComputeJacobianBlocksThread.h
+++ b/framework/include/base/ComputeJacobianBlocksThread.h
@@ -56,7 +56,7 @@ public:
   {}
 
 protected:
-  virtual void postElement(const Elem * elem);
+  virtual void postElement(const Elem * elem) override;
 
   std::vector<JacobianBlock*> _blocks;
 };

--- a/framework/include/base/ComputeJacobianThread.h
+++ b/framework/include/base/ComputeJacobianThread.h
@@ -38,13 +38,13 @@ public:
 
   virtual ~ComputeJacobianThread();
 
-  virtual void subdomainChanged();
-  virtual void onElement(const Elem *elem);
-  virtual void onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void onInternalSide(const Elem *elem, unsigned int side);
-  virtual void onInterface(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void postElement(const Elem * /*elem*/);
-  virtual void post();
+  virtual void subdomainChanged() override;
+  virtual void onElement(const Elem * elem) override;
+  virtual void onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void onInternalSide(const Elem * elem, unsigned int side) override;
+  virtual void onInterface(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void postElement(const Elem * /*elem*/) override;
+  virtual void post() override;
 
   void join(const ComputeJacobianThread & /*y*/);
 

--- a/framework/include/base/ComputeMarkerThread.h
+++ b/framework/include/base/ComputeMarkerThread.h
@@ -32,12 +32,12 @@ public:
 
   virtual ~ComputeMarkerThread();
 
-  virtual void subdomainChanged();
-  virtual void onElement(const Elem *elem);
-  virtual void onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void onInternalSide(const Elem *elem, unsigned int side);
-  virtual void postElement(const Elem * /*elem*/);
-  virtual void post();
+  virtual void subdomainChanged() override;
+  virtual void onElement(const Elem * elem) override;
+  virtual void onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void onInternalSide(const Elem * elem, unsigned int side) override;
+  virtual void postElement(const Elem * /*elem*/) override;
+  virtual void post() override;
 
   void join(const ComputeMarkerThread & /*y*/);
 

--- a/framework/include/base/ComputeMaterialsObjectThread.h
+++ b/framework/include/base/ComputeMaterialsObjectThread.h
@@ -43,10 +43,10 @@ public:
 
   virtual ~ComputeMaterialsObjectThread();
 
-  virtual void subdomainChanged();
-  virtual void onElement(const Elem *elem);
-  virtual void onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void onInternalSide(const Elem *elem, unsigned int side);
+  virtual void subdomainChanged() override;
+  virtual void onElement(const Elem * elem) override;
+  virtual void onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void onInternalSide(const Elem * elem, unsigned int side) override;
 
   void join(const ComputeMaterialsObjectThread & /*y*/);
 

--- a/framework/include/base/ComputeNodalAuxBcsThread.h
+++ b/framework/include/base/ComputeNodalAuxBcsThread.h
@@ -26,7 +26,7 @@ public:
   // Splitting Constructor
   ComputeNodalAuxBcsThread(ComputeNodalAuxBcsThread & x, Threads::split split);
 
-  virtual void onNode(ConstBndNodeRange::const_iterator & node_it);
+  virtual void onNode(ConstBndNodeRange::const_iterator & node_it) override;
 
   void join(const ComputeNodalAuxBcsThread & /*y*/);
 

--- a/framework/include/base/ComputeNodalKernelBCJacobiansThread.h
+++ b/framework/include/base/ComputeNodalKernelBCJacobiansThread.h
@@ -33,9 +33,9 @@ public:
   // Splitting Constructor
   ComputeNodalKernelBCJacobiansThread(ComputeNodalKernelBCJacobiansThread & x, Threads::split split);
 
-  virtual void pre();
+  virtual void pre() override;
 
-  virtual void onNode(ConstBndNodeRange::const_iterator & node_it);
+  virtual void onNode(ConstBndNodeRange::const_iterator & node_it) override;
 
   void join(const ComputeNodalKernelBCJacobiansThread & /*y*/);
 

--- a/framework/include/base/ComputeNodalKernelBcsThread.h
+++ b/framework/include/base/ComputeNodalKernelBcsThread.h
@@ -28,9 +28,9 @@ public:
   // Splitting Constructor
   ComputeNodalKernelBcsThread(ComputeNodalKernelBcsThread & x, Threads::split split);
 
-  virtual void pre();
+  virtual void pre() override;
 
-  virtual void onNode(ConstBndNodeRange::const_iterator & node_it);
+  virtual void onNode(ConstBndNodeRange::const_iterator & node_it) override;
 
   void join(const ComputeNodalKernelBcsThread & /*y*/);
 

--- a/framework/include/base/ComputeNodalKernelJacobiansThread.h
+++ b/framework/include/base/ComputeNodalKernelJacobiansThread.h
@@ -43,9 +43,9 @@ public:
   // Splitting Constructor
   ComputeNodalKernelJacobiansThread(ComputeNodalKernelJacobiansThread & x, Threads::split split);
 
-  virtual void pre();
+  virtual void pre() override;
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it);
+  virtual void onNode(ConstNodeRange::const_iterator & node_it) override;
 
   void join(const ComputeNodalKernelJacobiansThread & /*y*/);
 

--- a/framework/include/base/ComputeNodalKernelsThread.h
+++ b/framework/include/base/ComputeNodalKernelsThread.h
@@ -33,9 +33,9 @@ public:
   // Splitting Constructor
   ComputeNodalKernelsThread(ComputeNodalKernelsThread & x, Threads::split split);
 
-  virtual void pre();
+  virtual void pre() override;
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it);
+  virtual void onNode(ConstNodeRange::const_iterator & node_it) override;
 
   void join(const ComputeNodalKernelsThread & /*y*/);
 

--- a/framework/include/base/ComputeNodalUserObjectsThread.h
+++ b/framework/include/base/ComputeNodalUserObjectsThread.h
@@ -32,7 +32,7 @@ public:
 
   virtual ~ComputeNodalUserObjectsThread();
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it);
+  virtual void onNode(ConstNodeRange::const_iterator & node_it) override;
 
   void join(const ComputeNodalUserObjectsThread & /*y*/);
 

--- a/framework/include/base/ComputeResidualThread.h
+++ b/framework/include/base/ComputeResidualThread.h
@@ -39,13 +39,13 @@ public:
 
   virtual ~ComputeResidualThread();
 
-  virtual void subdomainChanged();
-  virtual void onElement(const Elem *elem );
-  virtual void onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void onInterface(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void onInternalSide(const Elem *elem, unsigned int side);
-  virtual void postElement(const Elem * /*elem*/);
-  virtual void post();
+  virtual void subdomainChanged() override;
+  virtual void onElement(const Elem * elem ) override;
+  virtual void onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void onInterface(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void onInternalSide(const Elem * elem, unsigned int side) override;
+  virtual void postElement(const Elem * /*elem*/) override;
+  virtual void post() override;
 
   void join(const ComputeResidualThread & /*y*/);
 

--- a/framework/include/base/ComputeUserObjectsThread.h
+++ b/framework/include/base/ComputeUserObjectsThread.h
@@ -43,11 +43,11 @@ public:
 
   virtual ~ComputeUserObjectsThread();
 
-  virtual void onElement(const Elem *elem);
-  virtual void onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void onInternalSide(const Elem *elem, unsigned int side);
-  virtual void post();
-  virtual void subdomainChanged();
+  virtual void onElement(const Elem * elem) override;
+  virtual void onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void onInternalSide(const Elem * elem, unsigned int side) override;
+  virtual void post() override;
+  virtual void subdomainChanged() override;
 
   void join(const ComputeUserObjectsThread & /*y*/);
 

--- a/framework/include/base/DisplacedProblem.h
+++ b/framework/include/base/DisplacedProblem.h
@@ -48,8 +48,8 @@ public:
   DisplacedProblem(const InputParameters & parameters);
   virtual ~DisplacedProblem();
 
-  virtual EquationSystems & es() { return _eq; }
-  virtual MooseMesh & mesh() { return _mesh; }
+  virtual EquationSystems & es() override { return _eq; }
+  virtual MooseMesh & mesh() override { return _mesh; }
   MooseMesh & refMesh();
 
   DisplacedSystem & nlSys() { return _displaced_nl; }
@@ -65,11 +65,11 @@ public:
    *
    * @param fe_cache True for using the cache false for not.
    */
-  virtual void useFECache(bool fe_cache);
+  virtual void useFECache(bool fe_cache) override;
 
-  virtual void init();
-  virtual void solve();
-  virtual bool converged();
+  virtual void init() override;
+  virtual void solve() override;
+  virtual bool converged() override;
 
   /**
    * Allocate vectors and save old solutions into them.
@@ -103,14 +103,14 @@ public:
    */
   virtual void updateMesh(const NumericVector<Number> & soln, const NumericVector<Number> & aux_soln);
 
-  virtual bool isTransient() const;
-  virtual Moose::CoordinateSystemType getCoordSystem(SubdomainID sid);
+  virtual bool isTransient() const override;
+  virtual Moose::CoordinateSystemType getCoordSystem(SubdomainID sid) override;
 
   // Variables /////
-  virtual bool hasVariable(const std::string & var_name);
-  virtual MooseVariable & getVariable(THREAD_ID tid, const std::string & var_name);
-  virtual bool hasScalarVariable(const std::string & var_name);
-  virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid, const std::string & var_name);
+  virtual bool hasVariable(const std::string & var_name) override;
+  virtual MooseVariable & getVariable(THREAD_ID tid, const std::string & var_name) override;
+  virtual bool hasScalarVariable(const std::string & var_name) override;
+  virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid, const std::string & var_name) override;
   virtual void addVariable(const std::string & var_name, const FEType & type, Real scale_factor, const std::set< SubdomainID > * const active_subdomains = NULL);
   virtual void addAuxVariable(const std::string & var_name, const FEType & type, const std::set< SubdomainID > * const active_subdomains = NULL);
   virtual void addScalarVariable(const std::string & var_name, Order order, Real scale_factor = 1., const std::set< SubdomainID > * const active_subdomains = NULL);
@@ -118,91 +118,91 @@ public:
 
   // Adaptivity /////
   virtual void initAdaptivity();
-  virtual void meshChanged();
+  virtual void meshChanged() override;
 
   // reinit /////
 
-  virtual void prepare(const Elem * elem, THREAD_ID tid);
-  virtual void prepareFace(const Elem * elem, THREAD_ID tid);
-  virtual void prepare(const Elem * elem, unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid);
-  virtual void prepareAssembly(THREAD_ID tid);
+  virtual void prepare(const Elem * elem, THREAD_ID tid) override;
+  virtual void prepareFace(const Elem * elem, THREAD_ID tid) override;
+  virtual void prepare(const Elem * elem, unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid) override;
+  virtual void prepareAssembly(THREAD_ID tid) override;
   virtual void prepareAssemblyNeighbor(THREAD_ID tid);
 
-  virtual bool reinitDirac(const Elem * elem, THREAD_ID tid);
-  virtual void reinitElem(const Elem * elem, THREAD_ID tid);
-  virtual void reinitElemPhys(const Elem * elem, std::vector<Point> phys_points_in_elem, THREAD_ID tid);
-  virtual void reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid);
-  virtual void reinitNode(const Node * node, THREAD_ID tid);
-  virtual void reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID tid);
-  virtual void reinitNodes(const std::vector<dof_id_type> & nodes, THREAD_ID tid);
-  virtual void reinitNodesNeighbor(const std::vector<dof_id_type> & nodes, THREAD_ID tid);
-  virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid);
-  virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid);
-  virtual void reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid);
-  virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid);
-  virtual void reinitScalars(THREAD_ID tid);
+  virtual bool reinitDirac(const Elem * elem, THREAD_ID tid) override;
+  virtual void reinitElem(const Elem * elem, THREAD_ID tid) override;
+  virtual void reinitElemPhys(const Elem * elem, std::vector<Point> phys_points_in_elem, THREAD_ID tid) override;
+  virtual void reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid) override;
+  virtual void reinitNode(const Node * node, THREAD_ID tid) override;
+  virtual void reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID tid) override;
+  virtual void reinitNodes(const std::vector<dof_id_type> & nodes, THREAD_ID tid) override;
+  virtual void reinitNodesNeighbor(const std::vector<dof_id_type> & nodes, THREAD_ID tid) override;
+  virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid) override;
+  virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid) override;
+  virtual void reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid) override;
+  virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid) override;
+  virtual void reinitScalars(THREAD_ID tid) override;
 
   /// Fills "elems" with the elements that should be looped over for Dirac Kernels
-  virtual void getDiracElements(std::set<const Elem *> & elems);
-  virtual void clearDiracInfo();
+  virtual void getDiracElements(std::set<const Elem *> & elems) override;
+  virtual void clearDiracInfo() override;
 
-  virtual void addResidual(THREAD_ID tid);
-  virtual void addResidualNeighbor(THREAD_ID tid);
+  virtual void addResidual(THREAD_ID tid) override;
+  virtual void addResidualNeighbor(THREAD_ID tid) override;
 
-  virtual void cacheResidual(THREAD_ID tid);
-  virtual void cacheResidualNeighbor(THREAD_ID tid);
-  virtual void addCachedResidual(THREAD_ID tid);
+  virtual void cacheResidual(THREAD_ID tid) override;
+  virtual void cacheResidualNeighbor(THREAD_ID tid) override;
+  virtual void addCachedResidual(THREAD_ID tid) override;
 
   virtual void addCachedResidualDirectly(NumericVector<Number> & residual, THREAD_ID tid);
 
-  virtual void setResidual(NumericVector<Number> & residual, THREAD_ID tid);
-  virtual void setResidualNeighbor(NumericVector<Number> & residual, THREAD_ID tid);
+  virtual void setResidual(NumericVector<Number> & residual, THREAD_ID tid) override;
+  virtual void setResidualNeighbor(NumericVector<Number> & residual, THREAD_ID tid) override;
 
-  virtual void addJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid);
-  virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, THREAD_ID tid);
-  virtual void addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid);
-  virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, std::vector<dof_id_type> & neighbor_dof_indices, THREAD_ID tid);
+  virtual void addJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
+  virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
+  virtual void addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid) override;
+  virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, std::vector<dof_id_type> & neighbor_dof_indices, THREAD_ID tid) override;
 
-  virtual void cacheJacobian(THREAD_ID tid);
-  virtual void cacheJacobianNeighbor(THREAD_ID tid);
-  virtual void addCachedJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid);
+  virtual void cacheJacobian(THREAD_ID tid) override;
+  virtual void cacheJacobianNeighbor(THREAD_ID tid) override;
+  virtual void addCachedJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
 
-  virtual void prepareShapes(unsigned int var, THREAD_ID tid);
-  virtual void prepareFaceShapes(unsigned int var, THREAD_ID tid);
-  virtual void prepareNeighborShapes(unsigned int var, THREAD_ID tid);
+  virtual void prepareShapes(unsigned int var, THREAD_ID tid) override;
+  virtual void prepareFaceShapes(unsigned int var, THREAD_ID tid) override;
+  virtual void prepareNeighborShapes(unsigned int var, THREAD_ID tid) override;
 
-  virtual Assembly & assembly(THREAD_ID tid) { return *_assembly[tid]; }
+  virtual Assembly & assembly(THREAD_ID tid) override { return *_assembly[tid]; }
 
   // Geom Search /////
-  virtual void updateGeomSearch(GeometricSearchData::GeometricSearchType type = GeometricSearchData::ALL);
-  virtual GeometricSearchData & geomSearchData() { return _geometric_search_data; }
+  virtual void updateGeomSearch(GeometricSearchData::GeometricSearchType type = GeometricSearchData::ALL) override;
+  virtual GeometricSearchData & geomSearchData() override { return _geometric_search_data; }
 
-  virtual bool computingInitialResidual();
+  virtual bool computingInitialResidual() override;
 
-  virtual void onTimestepBegin();
-  virtual void onTimestepEnd();
+  virtual void onTimestepBegin() override;
+  virtual void onTimestepEnd() override;
 
   /**
    * Return the list of elements that should have their DoFs ghosted to this processor.
    * @return The list
    */
-  virtual std::set<dof_id_type> & ghostedElems();
+  virtual std::set<dof_id_type> & ghostedElems() override;
 
   /**
    * Will make sure that all dofs connected to elem_id are ghosted to this processor
    */
-  virtual void addGhostedElem(dof_id_type elem_id);
+  virtual void addGhostedElem(dof_id_type elem_id) override;
 
   /**
    * Will make sure that all necessary elements from boundary_id are ghosted to this processor
    * @param boundary_id Boundary ID
    */
-  virtual void addGhostedBoundary(BoundaryID boundary_id);
+  virtual void addGhostedBoundary(BoundaryID boundary_id) override;
 
   /**
    * Causes the boundaries added using addGhostedBoundary to actually be ghosted.
    */
-  virtual void ghostGhostedBoundaries();
+  virtual void ghostGhostedBoundaries() override;
 
   /**
    * Resets the displaced mesh to the reference mesh.  Required when

--- a/framework/include/base/DisplacedSystem.h
+++ b/framework/include/base/DisplacedSystem.h
@@ -31,27 +31,27 @@ public:
   DisplacedSystem(DisplacedProblem & problem, SystemBase & undisplaced_system, const std::string & name, Moose::VarKindType var_kind);
   virtual ~DisplacedSystem();
 
-  virtual void init();
+  virtual void init() override;
 
-  virtual NumericVector<Number> & getVector(const std::string & name);
+  virtual NumericVector<Number> & getVector(const std::string & name) override;
 
-  virtual NumericVector<Number> & serializedSolution() { return _undisplaced_system.serializedSolution(); }
+  virtual NumericVector<Number> & serializedSolution() override { return _undisplaced_system.serializedSolution(); }
 
-  virtual const NumericVector<Number> * & currentSolution() { return _undisplaced_system.currentSolution(); }
+  virtual const NumericVector<Number> * & currentSolution() override { return _undisplaced_system.currentSolution(); }
 
-  virtual NumericVector<Number> & solution() { return _undisplaced_system.solution(); }
+  virtual NumericVector<Number> & solution() override { return _undisplaced_system.solution(); }
 
-  virtual NumericVector<Number> & solutionUDot() { return _undisplaced_system.solutionUDot(); }
-  virtual Number & duDotDu() { return _undisplaced_system.duDotDu(); }
+  virtual NumericVector<Number> & solutionUDot() override { return _undisplaced_system.solutionUDot(); }
+  virtual Number & duDotDu() override { return _undisplaced_system.duDotDu(); }
 
   /**
    * Return the residual copy from the NonlinearSystem
    * @return Residual copy
    */
-  virtual NumericVector<Number> & residualCopy() { return _undisplaced_system.residualCopy(); }
-  virtual NumericVector<Number> & residualGhosted() { return _undisplaced_system.residualGhosted(); }
+  virtual NumericVector<Number> & residualCopy() override { return _undisplaced_system.residualCopy(); }
+  virtual NumericVector<Number> & residualGhosted() override { return _undisplaced_system.residualGhosted(); }
 
-  virtual void augmentSendList(std::vector<dof_id_type> & send_list){ _undisplaced_system.augmentSendList(send_list); }
+  virtual void augmentSendList(std::vector<dof_id_type> & send_list) override { _undisplaced_system.augmentSendList(send_list); }
 
   /**
    * This is an empty function since the displaced system doesn't have a matrix!
@@ -59,25 +59,24 @@ public:
    */
   virtual void augmentSparsity(SparsityPattern::Graph & /*sparsity*/,
                                std::vector<dof_id_type> & /*n_nz*/,
-                               std::vector<dof_id_type> & /*n_oz*/)
-    {}
+                               std::vector<dof_id_type> & /*n_oz*/) override {}
 
   /**
    * Adds this variable to the list of variables to be zeroed during each residual evaluation.
    * @param var_name The name of the variable to be zeroed.
    */
-  virtual void addVariableToZeroOnResidual(std::string var_name) { _undisplaced_system.addVariableToZeroOnResidual(var_name); }
+  virtual void addVariableToZeroOnResidual(std::string var_name) override { _undisplaced_system.addVariableToZeroOnResidual(var_name); }
 
   /**
    * Adds this variable to the list of variables to be zeroed during each jacobian evaluation.
    * @param var_name The name of the variable to be zeroed.
    */
-  virtual void addVariableToZeroOnJacobian(std::string var_name) { _undisplaced_system.addVariableToZeroOnJacobian(var_name); }
+  virtual void addVariableToZeroOnJacobian(std::string var_name) override { _undisplaced_system.addVariableToZeroOnJacobian(var_name); }
 
   /**
    * Zero out the solution for the list of variables passed in.
    */
-  virtual void zeroVariables(std::vector<std::string> & vars_to_be_zeroed) { _undisplaced_system.zeroVariables(vars_to_be_zeroed); }
+  virtual void zeroVariables(std::vector<std::string> & vars_to_be_zeroed) override { _undisplaced_system.zeroVariables(vars_to_be_zeroed); }
 
 protected:
   SystemBase & _undisplaced_system;

--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -129,10 +129,10 @@ public:
   FEProblem(const InputParameters & parameters);
   virtual ~FEProblem();
 
-  virtual EquationSystems & es() { return _eq; }
-  virtual MooseMesh & mesh() { return _mesh; }
+  virtual EquationSystems & es() override { return _eq; }
+  virtual MooseMesh & mesh() override { return _mesh; }
 
-  virtual Moose::CoordinateSystemType getCoordSystem(SubdomainID sid);
+  virtual Moose::CoordinateSystemType getCoordSystem(SubdomainID sid) override;
   virtual void setCoordSystem(const std::vector<SubdomainName> & blocks, const MultiMooseEnum & coord_sys);
   void setAxisymmetricCoordAxis(const MooseEnum & rz_coord_axis);
 
@@ -203,10 +203,10 @@ public:
                                                               const PetscInt maxits);
 
 
-  virtual bool hasVariable(const std::string & var_name);
-  virtual MooseVariable & getVariable(THREAD_ID tid, const std::string & var_name);
-  virtual bool hasScalarVariable(const std::string & var_name);
-  virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid, const std::string & var_name);
+  virtual bool hasVariable(const std::string & var_name) override;
+  virtual MooseVariable & getVariable(THREAD_ID tid, const std::string & var_name) override;
+  virtual bool hasScalarVariable(const std::string & var_name) override;
+  virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid, const std::string & var_name) override;
 
   /**
    * Set the MOOSE variables to be reinited on each element.
@@ -214,21 +214,21 @@ public:
    *
    * @param tid The thread id
    */
-  virtual void setActiveElementalMooseVariables(const std::set<MooseVariable *> & moose_vars, THREAD_ID tid);
+  virtual void setActiveElementalMooseVariables(const std::set<MooseVariable *> & moose_vars, THREAD_ID tid) override;
 
   /**
    * Get the MOOSE variables to be reinited on each element.
    *
    * @param tid The thread id
    */
-  virtual const std::set<MooseVariable *> & getActiveElementalMooseVariables(THREAD_ID tid);
+  virtual const std::set<MooseVariable *> & getActiveElementalMooseVariables(THREAD_ID tid) override;
 
   /**
    * Whether or not a list of active elemental moose variables has been set.
    *
    * @return True if there has been a list of active elemental moose variables set, False otherwise
    */
-  virtual bool hasActiveElementalMooseVariables(THREAD_ID tid);
+  virtual bool hasActiveElementalMooseVariables(THREAD_ID tid) override;
 
   /**
    * Clear the active elemental MooseVariable.  If there are no active variables then they will all be reinited.
@@ -236,7 +236,7 @@ public:
    *
    * @param tid The thread id
    */
-  virtual void clearActiveElementalMooseVariables(THREAD_ID tid);
+  virtual void clearActiveElementalMooseVariables(THREAD_ID tid) override;
 
   virtual void createQRules(QuadratureType type, Order order, Order volume_order=INVALID_ORDER, Order face_order=INVALID_ORDER);
 
@@ -255,7 +255,7 @@ public:
    */
   Order getMaxScalarOrder() const;
 
-  virtual Assembly & assembly(THREAD_ID tid) { return *_assembly[tid]; }
+  virtual Assembly & assembly(THREAD_ID tid) override { return *_assembly[tid]; }
 
   /**
    * Returns a list of all the variables in the problem (both from the NL and Aux systems.
@@ -266,35 +266,35 @@ public:
   virtual void initialSetup();
   virtual void timestepSetup();
 
-  virtual void prepare(const Elem * elem, THREAD_ID tid);
-  virtual void prepareFace(const Elem * elem, THREAD_ID tid);
-  virtual void prepare(const Elem * elem, unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid);
+  virtual void prepare(const Elem * elem, THREAD_ID tid) override;
+  virtual void prepareFace(const Elem * elem, THREAD_ID tid) override;
+  virtual void prepare(const Elem * elem, unsigned int ivar, unsigned int jvar, const std::vector<dof_id_type> & dof_indices, THREAD_ID tid) override;
 
-  virtual void prepareAssembly(THREAD_ID tid);
+  virtual void prepareAssembly(THREAD_ID tid) override;
 
-  virtual void addGhostedElem(dof_id_type elem_id);
-  virtual void addGhostedBoundary(BoundaryID boundary_id);
-  virtual void ghostGhostedBoundaries();
+  virtual void addGhostedElem(dof_id_type elem_id) override;
+  virtual void addGhostedBoundary(BoundaryID boundary_id) override;
+  virtual void ghostGhostedBoundaries() override;
 
   virtual void sizeZeroes(unsigned int size, THREAD_ID tid);
-  virtual bool reinitDirac(const Elem * elem, THREAD_ID tid);
-  virtual void reinitElem(const Elem * elem, THREAD_ID tid);
-  virtual void reinitElemPhys(const Elem * elem, std::vector<Point> phys_points_in_elem, THREAD_ID tid);
-  virtual void reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid);
-  virtual void reinitNode(const Node * node, THREAD_ID tid);
-  virtual void reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID tid);
-  virtual void reinitNodes(const std::vector<dof_id_type> & nodes, THREAD_ID tid);
-  virtual void reinitNodesNeighbor(const std::vector<dof_id_type> & nodes, THREAD_ID tid);
-  virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid);
-  virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid);
-  virtual void reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid);
-  virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid);
-  virtual void reinitScalars(THREAD_ID tid);
+  virtual bool reinitDirac(const Elem * elem, THREAD_ID tid) override;
+  virtual void reinitElem(const Elem * elem, THREAD_ID tid) override;
+  virtual void reinitElemPhys(const Elem * elem, std::vector<Point> phys_points_in_elem, THREAD_ID tid) override;
+  virtual void reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid) override;
+  virtual void reinitNode(const Node * node, THREAD_ID tid) override;
+  virtual void reinitNodeFace(const Node * node, BoundaryID bnd_id, THREAD_ID tid) override;
+  virtual void reinitNodes(const std::vector<dof_id_type> & nodes, THREAD_ID tid) override;
+  virtual void reinitNodesNeighbor(const std::vector<dof_id_type> & nodes, THREAD_ID tid) override;
+  virtual void reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid) override;
+  virtual void reinitNeighborPhys(const Elem * neighbor, unsigned int neighbor_side, const std::vector<Point> & physical_points, THREAD_ID tid) override;
+  virtual void reinitNeighborPhys(const Elem * neighbor, const std::vector<Point> & physical_points, THREAD_ID tid) override;
+  virtual void reinitNodeNeighbor(const Node * node, THREAD_ID tid) override;
+  virtual void reinitScalars(THREAD_ID tid) override;
   virtual void reinitOffDiagScalars(THREAD_ID tid);
 
   /// Fills "elems" with the elements that should be looped over for Dirac Kernels
-  virtual void getDiracElements(std::set<const Elem *> & elems);
-  virtual void clearDiracInfo();
+  virtual void getDiracElements(std::set<const Elem *> & elems) override;
+  virtual void clearDiracInfo() override;
 
   virtual void subdomainSetup(SubdomainID subdomain, THREAD_ID tid);
 
@@ -303,10 +303,10 @@ public:
    *
    * @param fe_cache True for using the cache false for not.
    */
-  virtual void useFECache(bool fe_cache);
+  virtual void useFECache(bool fe_cache) override;
 
-  virtual void init();
-  virtual void solve();
+  virtual void init() override;
+  virtual void solve() override;
 
   /**
    * Set an exception.  Usually this should not be directly called - but should be called through the mooseException() macro.
@@ -331,11 +331,11 @@ public:
    */
   virtual void checkExceptionAndStopSolve();
 
-  virtual bool converged();
-  virtual unsigned int nNonlinearIterations();
-  virtual unsigned int nLinearIterations();
-  virtual Real finalNonlinearResidual();
-  virtual bool computingInitialResidual();
+  virtual bool converged() override;
+  virtual unsigned int nNonlinearIterations() override;
+  virtual unsigned int nLinearIterations() override;
+  virtual Real finalNonlinearResidual() override;
+  virtual bool computingInitialResidual() override;
 
   /**
    * Returns true if we are currently computing Jacobian
@@ -352,8 +352,8 @@ public:
    */
   virtual Real relativeSolutionDifferenceNorm();
 
-  virtual void onTimestepBegin();
-  virtual void onTimestepEnd();
+  virtual void onTimestepBegin() override;
+  virtual void onTimestepEnd() override;
 
   virtual Real & time() const { return _time; }
   virtual Real & timeOld() const { return _time_old; }
@@ -362,7 +362,7 @@ public:
   virtual Real & dtOld() const { return _dt_old; }
 
   virtual void transient(bool trans) { _transient = trans; }
-  virtual bool isTransient() const { return _transient; }
+  virtual bool isTransient() const override { return _transient; }
 
   virtual void addTimeIntegrator(const std::string & type, const std::string & name, InputParameters parameters);
   virtual void addPredictor(const std::string & type, const std::string & name, InputParameters parameters);
@@ -749,13 +749,13 @@ public:
 
   virtual NumericVector<Number> & residualVector(Moose::KernelType type);
 
-  virtual void addResidual(THREAD_ID tid);
-  virtual void addResidualNeighbor(THREAD_ID tid);
+  virtual void addResidual(THREAD_ID tid) override;
+  virtual void addResidualNeighbor(THREAD_ID tid) override;
   virtual void addResidualScalar(THREAD_ID tid = 0);
 
-  virtual void cacheResidual(THREAD_ID tid);
-  virtual void cacheResidualNeighbor(THREAD_ID tid);
-  virtual void addCachedResidual(THREAD_ID tid);
+  virtual void cacheResidual(THREAD_ID tid) override;
+  virtual void cacheResidualNeighbor(THREAD_ID tid) override;
+  virtual void addCachedResidual(THREAD_ID tid) override;
 
   /**
    * Allows for all the residual contributions that are currently cached to be added directly into the vector passed in.
@@ -765,33 +765,33 @@ public:
    */
   virtual void addCachedResidualDirectly(NumericVector<Number> & residual, THREAD_ID tid);
 
-  virtual void setResidual(NumericVector<Number> & residual, THREAD_ID tid);
-  virtual void setResidualNeighbor(NumericVector<Number> & residual, THREAD_ID tid);
+  virtual void setResidual(NumericVector<Number> & residual, THREAD_ID tid) override;
+  virtual void setResidualNeighbor(NumericVector<Number> & residual, THREAD_ID tid) override;
 
-  virtual void addJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid);
-  virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, THREAD_ID tid);
-  virtual void addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid);
-  virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, std::vector<dof_id_type> & neighbor_dof_indices, THREAD_ID tid);
+  virtual void addJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
+  virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
+  virtual void addJacobianBlock(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, THREAD_ID tid) override;
+  virtual void addJacobianNeighbor(SparseMatrix<Number> & jacobian, unsigned int ivar, unsigned int jvar, const DofMap & dof_map, std::vector<dof_id_type> & dof_indices, std::vector<dof_id_type> & neighbor_dof_indices, THREAD_ID tid) override;
   virtual void addJacobianScalar(SparseMatrix<Number> & jacobian, THREAD_ID tid = 0);
   virtual void addJacobianOffDiagScalar(SparseMatrix<Number> & jacobian, unsigned int ivar, THREAD_ID tid = 0);
 
-  virtual void cacheJacobian(THREAD_ID tid);
-  virtual void cacheJacobianNeighbor(THREAD_ID tid);
-  virtual void addCachedJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid);
+  virtual void cacheJacobian(THREAD_ID tid) override;
+  virtual void cacheJacobianNeighbor(THREAD_ID tid) override;
+  virtual void addCachedJacobian(SparseMatrix<Number> & jacobian, THREAD_ID tid) override;
 
-  virtual void prepareShapes(unsigned int var, THREAD_ID tid);
-  virtual void prepareFaceShapes(unsigned int var, THREAD_ID tid);
-  virtual void prepareNeighborShapes(unsigned int var, THREAD_ID tid);
+  virtual void prepareShapes(unsigned int var, THREAD_ID tid) override;
+  virtual void prepareFaceShapes(unsigned int var, THREAD_ID tid) override;
+  virtual void prepareNeighborShapes(unsigned int var, THREAD_ID tid) override;
 
   // Displaced problem /////
   virtual void addDisplacedProblem(MooseSharedPointer<DisplacedProblem> displaced_problem);
   virtual MooseSharedPointer<DisplacedProblem> getDisplacedProblem() { return _displaced_problem; }
 
-  virtual void updateGeomSearch(GeometricSearchData::GeometricSearchType type = GeometricSearchData::ALL);
+  virtual void updateGeomSearch(GeometricSearchData::GeometricSearchType type = GeometricSearchData::ALL) override;
 
   virtual void possiblyRebuildGeomSearchPatches();
 
-  virtual GeometricSearchData & geomSearchData() { return _geometric_search_data; }
+  virtual GeometricSearchData & geomSearchData() override { return _geometric_search_data; }
 
   /**
    * Communicate to the Resurector the name of the restart filer
@@ -845,7 +845,7 @@ public:
   /// Update the mesh due to changing XFEM cuts
   virtual bool updateMeshXFEM();
 
-  virtual void meshChanged();
+  virtual void meshChanged() override;
 
   /**
    * Register an object that derives from MeshChangedInterface

--- a/framework/include/base/FlagElementsThread.h
+++ b/framework/include/base/FlagElementsThread.h
@@ -32,7 +32,7 @@ public:
   // Splitting Constructor
   FlagElementsThread(FlagElementsThread & x, Threads::split split);
 
-  virtual void onElement(const Elem *elem);
+  virtual void onElement(const Elem * elem) override;
 
   void join(const FlagElementsThread & /*y*/);
 

--- a/framework/include/base/MeshChangedInterface.h
+++ b/framework/include/base/MeshChangedInterface.h
@@ -32,12 +32,12 @@ class MeshChangedInterface
 {
 public:
   MeshChangedInterface(const InputParameters & params);
-  virtual ~MeshChangedInterface() {};
+  virtual ~MeshChangedInterface() = default;
 
   /**
    * Called on this object when the mesh changes
    */
-  virtual void meshChanged() {};
+  virtual void meshChanged() {}
 
 protected:
 

--- a/framework/include/base/MooseInit.h
+++ b/framework/include/base/MooseInit.h
@@ -30,7 +30,7 @@ class MooseInit : public LibMeshInit
 {
 public:
   MooseInit(int argc, char *argv[], MPI_Comm COMM_WORLD_IN=MPI_COMM_WORLD);
-  virtual ~MooseInit();
+  virtual ~MooseInit() = default;
 };
 
 #endif /* MOOSEINIT_H */

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -39,7 +39,7 @@ class MooseObject :
 public:
   MooseObject(const InputParameters & parameters);
 
-  virtual ~MooseObject() { }
+  virtual ~MooseObject() = default;
 
   /**
    * Get the name of the object

--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -76,7 +76,7 @@ public:
    * Is this variable nodal
    * @return true if it nodal, otherwise false
    */
-  virtual bool isNodal() const;
+  virtual bool isNodal() const override;
 
   /**
    * Current element this variable is evaluated at

--- a/framework/include/base/MooseVariableScalar.h
+++ b/framework/include/base/MooseVariableScalar.h
@@ -35,7 +35,7 @@ public:
 
   void reinit();
 
-  virtual bool isNodal() const;
+  virtual bool isNodal() const override;
 
   //
   VariableValue & sln() { return _u; }

--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -61,9 +61,9 @@ public:
   NonlinearSystem(FEProblem & problem, const std::string & name);
   virtual ~NonlinearSystem();
 
-  virtual void init();
-  virtual void solve();
-  virtual void restoreSolutions();
+  virtual void init() override;
+  virtual void solve() override;
+  virtual void restoreSolutions() override;
 
   /**
    * Quit the current solve as soon as possible.
@@ -286,20 +286,20 @@ public:
    */
   virtual void setSolutionUDot(const NumericVector<Number> & udot);
 
-  virtual NumericVector<Number> & solutionUDot();
-  virtual NumericVector<Number> & residualVector(Moose::KernelType type);
+  virtual NumericVector<Number> & solutionUDot() override;
+  virtual NumericVector<Number> & residualVector(Moose::KernelType type) override;
 
-  virtual const NumericVector<Number> * & currentSolution() { return _current_solution; }
+  virtual const NumericVector<Number> * & currentSolution() override { return _current_solution; }
 
   virtual void serializeSolution();
-  virtual NumericVector<Number> & serializedSolution();
+  virtual NumericVector<Number> & serializedSolution() override;
 
-  virtual NumericVector<Number> & residualCopy();
-  virtual NumericVector<Number> & residualGhosted();
+  virtual NumericVector<Number> & residualCopy() override;
+  virtual NumericVector<Number> & residualGhosted() override;
 
   virtual void augmentSparsity(SparsityPattern::Graph & sparsity,
                                std::vector<dof_id_type> & n_nz,
-                               std::vector<dof_id_type> & n_oz);
+                               std::vector<dof_id_type> & n_oz) override;
 
   /**
    * Sets a preconditioner

--- a/framework/include/base/ProjectMaterialProperties.h
+++ b/framework/include/base/ProjectMaterialProperties.h
@@ -43,10 +43,10 @@ public:
 
   virtual ~ProjectMaterialProperties();
 
-  virtual void subdomainChanged();
-  virtual void onElement(const Elem *elem);
-  virtual void onBoundary(const Elem *elem, unsigned int side, BoundaryID bnd_id);
-  virtual void onInternalSide(const Elem *elem, unsigned int side);
+  virtual void subdomainChanged() override;
+  virtual void onElement(const Elem * elem) override;
+  virtual void onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id) override;
+  virtual void onInternalSide(const Elem * elem, unsigned int side) override;
 
   void join(const ProjectMaterialProperties & /*y*/);
 

--- a/framework/include/base/ThreadedElementLoop.h
+++ b/framework/include/base/ThreadedElementLoop.h
@@ -44,9 +44,9 @@ public:
 
   virtual ~ThreadedElementLoop();
 
-  virtual void caughtMooseException(MooseException & e);
+  virtual void caughtMooseException(MooseException & e) override;
 
-  virtual bool keepGoing() { return !_fe_problem.hasException(); }
+  virtual bool keepGoing() override { return !_fe_problem.hasException(); }
 protected:
   SystemBase & _system;
   FEProblem & _fe_problem;

--- a/framework/include/base/UpdateDisplacedMeshThread.h
+++ b/framework/include/base/UpdateDisplacedMeshThread.h
@@ -36,9 +36,9 @@ public:
 
   UpdateDisplacedMeshThread(UpdateDisplacedMeshThread & x, Threads::split split);
 
-  virtual void pre();
+  virtual void pre() override;
 
-  virtual void onNode(SemiLocalNodeRange::const_iterator & nd);
+  virtual void onNode(SemiLocalNodeRange::const_iterator & nd) override;
 
   void join(const UpdateDisplacedMeshThread & /*y*/);
 

--- a/framework/include/base/UpdateErrorVectorsThread.h
+++ b/framework/include/base/UpdateErrorVectorsThread.h
@@ -31,7 +31,7 @@ public:
   // Splitting Constructor
   UpdateErrorVectorsThread(UpdateErrorVectorsThread & x, Threads::split split);
 
-  virtual void onElement(const Elem *elem);
+  virtual void onElement(const Elem * elem) override;
 
   void join(const UpdateErrorVectorsThread & /*y*/);
 

--- a/framework/src/base/MooseInit.C
+++ b/framework/src/base/MooseInit.C
@@ -45,6 +45,3 @@ MooseInit::MooseInit(int argc, char *argv[], MPI_Comm COMM_WORLD_IN) :
   // Make sure that any calls to the global random number generator are consistent among processes
   MooseRandom::seed(0);
 }
-
-MooseInit::~MooseInit()
-{}


### PR DESCRIPTION
Part 2 of 2 for the override keyword. This adds the remaining overrides to the framework folder in the base directory. I was much more conservative on this set of changes (only deleted the MooseInit() destructor.

Let's get this merged before we start tiger team!
@idaholab/moose-team 

refs #7171
