### PR TITLE
Hide params

### DIFF
--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -24,6 +24,9 @@ InputParameters validParams<MooseObject>()
   params.addParam<bool>("enable", true, "Set the enabled status of the MooseObject.");
   params.addParam<std::vector<std::string> >("control_tags", "Adds user-defined labels for accessing object parameters via control logic.");
   params.addPrivateParam<std::string>("_object_name"); // the name passed to Factory::create
+
+  params.addParamNamesToGroup("enable control_tags", "Advanced");
+
   return params;
 }
 

--- a/framework/src/outputs/OutputInterface.C
+++ b/framework/src/outputs/OutputInterface.C
@@ -24,6 +24,9 @@ InputParameters validParams<OutputInterface>()
 {
   InputParameters params = emptyInputParameters();
   params.addParam<std::vector<OutputName> >("outputs", "Vector of output names were you would like to restrict the output of variables(s) associated with this object");
+
+  params.addParamNamesToGroup("outputs", "Advanced");
+
   return params;
 }
 


### PR DESCRIPTION
Move a few parameters to the Advanced group to declutter the Parameters in Peacock

closes #7442 
closes #7440 
closes #7441 
