### PR TITLE
Ignore warnings coming from Trilinos header files.

### DIFF
--- a/framework/include/transfers/DTKInterpolationAdapter.h
+++ b/framework/include/transfers/DTKInterpolationAdapter.h
@@ -22,6 +22,9 @@
 // libMesh includes
 #include "libmesh/point.h"
 
+// Ignore warnings coming from Trilinos/DTK.
+#include "libmesh/ignore_warnings.h"
+
 // DTK includes
 #include <DTK_MeshManager.hpp>
 #include <DTK_MeshContainer.hpp>
@@ -35,6 +38,9 @@
 #include <Teuchos_RCP.hpp>
 #include <Teuchos_ArrayRCP.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
+
+// Restore warnings.
+#include "libmesh/restore_warnings.h"
 
 // Forward declarations
 namespace libMesh

--- a/framework/include/transfers/DTKInterpolationEvaluator.h
+++ b/framework/include/transfers/DTKInterpolationEvaluator.h
@@ -22,6 +22,9 @@
 // libMesh includes
 #include "libmesh/point.h"
 
+// Ignore warnings coming from Trilinos/DTK.
+#include "libmesh/ignore_warnings.h"
+
 // DTK includes
 #include <DTK_MeshContainer.hpp>
 #include <DTK_FieldEvaluator.hpp>
@@ -30,6 +33,9 @@
 // Trilinos includes
 #include <Teuchos_RCP.hpp>
 #include <Teuchos_ArrayRCP.hpp>
+
+// Restore warnings.
+#include "libmesh/restore_warnings.h"
 
 namespace libMesh
 {

--- a/framework/include/transfers/DTKInterpolationHelper.h
+++ b/framework/include/transfers/DTKInterpolationHelper.h
@@ -23,7 +23,9 @@
 #include "DTKInterpolationAdapter.h"
 
 // DTK includes
+#include "libmesh/ignore_warnings.h"
 #include <DTK_SharedDomainMap.hpp>
+#include "libmesh/restore_warnings.h"
 
 namespace libMesh
 {

--- a/framework/include/transfers/MultiAppDTKUserObjectEvaluator.h
+++ b/framework/include/transfers/MultiAppDTKUserObjectEvaluator.h
@@ -23,10 +23,12 @@
 class MultiApp;
 
 // DTK includes
+#include "libmesh/ignore_warnings.h"
 #include <DTK_FieldEvaluator.hpp>
 #include <DTK_FieldContainer.hpp>
 #include <DTK_GeometryManager.hpp>
 #include <DTK_Box.hpp>
+#include "libmesh/restore_warnings.h"
 
 /**
  * Evaluates the specified UserObject and returns the result in a DTK FieldContainer.

--- a/framework/include/transfers/MultiAppDTKUserObjectTransfer.h
+++ b/framework/include/transfers/MultiAppDTKUserObjectTransfer.h
@@ -27,6 +27,9 @@
 // libMesh includes
 #include "libmesh/dtk_adapter.h"
 
+// Ignore warnings coming from DTK/Trilinos headers
+#include "libmesh/ignore_warnings.h"
+
 // DTK includes
 #include <DTK_VolumeSourceMap.hpp>
 #include <DTK_MeshManager.hpp>
@@ -48,6 +51,9 @@
 #include <Teuchos_DefaultComm.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_Ptr.hpp>
+
+// Restore the warnings.
+#include "libmesh/restore_warnings.h"
 
 // Forward declarations
 class MultiAppDTKUserObjectTransfer;

--- a/framework/src/transfers/DTKInterpolationAdapter.C
+++ b/framework/src/transfers/DTKInterpolationAdapter.C
@@ -29,7 +29,9 @@
 #include "libmesh/equation_systems.h"
 
 // DTK includes
+#include "libmesh/ignore_warnings.h"
 #include <DTK_MeshTypes.hpp>
+#include "libmesh/restore_warnings.h"
 
 DTKInterpolationAdapter::DTKInterpolationAdapter(Teuchos::RCP<const Teuchos::MpiComm<int> > in_comm, EquationSystems & in_es, const Point & offset, unsigned int from_dim):
     comm(in_comm),

--- a/framework/src/transfers/DTKInterpolationHelper.C
+++ b/framework/src/transfers/DTKInterpolationHelper.C
@@ -22,6 +22,9 @@
 // libMesh includes
 #include "libmesh/equation_systems.h"
 
+// Ignore warnings coming from Trilinos/DTK headers.
+#include "libmesh/ignore_warnings.h"
+
 // Trilinos Includes
 #include <Teuchos_RCP.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
@@ -36,6 +39,9 @@
 #include <DTK_FieldTools.hpp>
 #include <DTK_CommTools.hpp>
 #include <DTK_CommIndexer.hpp>
+
+// Restore warnings.
+#include "libmesh/restore_warnings.h"
 
 namespace libMesh
 {

--- a/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
@@ -49,7 +49,7 @@ MultiAppDTKUserObjectEvaluator::evaluate(const Teuchos::ArrayRCP<GlobalOrdinal>&
 
   unsigned int dim = 3;  // TODO: REPLACE ME!!!!!!!!!
 
-  for (GlobalOrdinal i=0; i<num_values; i++)
+  for (GlobalOrdinal i=0; i<static_cast<GlobalOrdinal>(num_values); i++)
   {
     // See if this app is on this processor
     if (std::binary_search(_box_ids.begin(), _box_ids.end(), bids[i]))


### PR DESCRIPTION
For some reason I had a Trilinos-enabled build on my laptop; this fixes warnings coming from Trilinos header files, but won't actually do so until libmesh/libMesh#1045 is merged and the libmesh submodule in MOOSE gets updated.

Refs #1777.
