### PR TITLE
Fix restart

### DIFF
--- a/modules/solid_mechanics/src/materials/ConstitutiveModel.C
+++ b/modules/solid_mechanics/src/materials/ConstitutiveModel.C
@@ -99,7 +99,7 @@ ConstitutiveModel::applyThermalStrain(unsigned qp,
     Real d_thermal_strain_d_temp;
 
     Real old_temp;
-    if (_t_step == 1 && _has_stress_free_temp)
+    if (_t_step == 1 && _has_stress_free_temp && !_app.isRestarting())
       old_temp = _stress_free_temp;
     else
       old_temp = _temperature_old[qp];

--- a/modules/solid_mechanics/src/materials/SolidModel.C
+++ b/modules/solid_mechanics/src/materials/SolidModel.C
@@ -497,7 +497,7 @@ SolidModel::applyThermalStrain()
     Real d_thermal_strain_d_temp;
 
     Real old_temp;
-    if (_t_step == 1 && _has_stress_free_temp)
+    if (_t_step == 1 && _has_stress_free_temp && !_app.isRestarting())
       old_temp = _stress_free_temp;
     else
       old_temp = _temperature_old[_qp];
@@ -744,7 +744,7 @@ SolidModel::computeConstitutiveModelStress()
   // Given the stretching, compute the stress increment and add it to the old stress. Also update the creep strain
   // stress = stressOld + stressIncrement
 
-  if (_t_step == 0) return;
+  if (_t_step == 0 && !_app.isRestarting()) return;
 
   const SubdomainID current_block = _current_elem->subdomain_id();
   MooseSharedPointer<ConstitutiveModel> cm = _constitutive_model[current_block];

--- a/modules/solid_mechanics/tests/umat_linear_strain_hardening/tests
+++ b/modules/solid_mechanics/tests/umat_linear_strain_hardening/tests
@@ -6,5 +6,6 @@
     library_mode = 'DYNAMIC'
     compiler = 'INTEL'
     valgrind = 'NONE'
+    skip = 'ill-posed test' # See #5104
   [../]
 []


### PR DESCRIPTION
### Complete each of the following items before creating a PR
- Conditional statements looking for t_step == 0 or 1 cause restart to fail, since restarts rest the time step to 0 and applies it on restart. Correct statement should also check to see if restart with _tstep == 0 && !_app.isRestarting().
- Add only && !_app.isRestarting()
- Test cases being added to BISON tests.
- Fix problems with restart Issue #7457.
