### PR TITLE
Use of restartable data boolean to determine first step

### DIFF
--- a/modules/heat_conduction/include/postprocessors/ThermalConductivity.h
+++ b/modules/heat_conduction/include/postprocessors/ThermalConductivity.h
@@ -31,6 +31,13 @@ protected:
   const PostprocessorValue & _T_hot;
   const Real _length_scale;
   const Real _k0;
+
+private:
+  /// True if this is the zeroth timestep (timestep < 1). At the zero
+  /// timestep, the initial value of thermal conductivity should be returned.
+  /// This boolean is delcared as a reference so that the variable is restartable
+  /// data:  if we restart, the code will not think it is the zero timestep again.
+  bool & _step_zero;
 };
 
 #endif //THERMALCONDUCTIVITY_H

--- a/modules/heat_conduction/src/postprocessors/ThermalConductivity.C
+++ b/modules/heat_conduction/src/postprocessors/ThermalConductivity.C
@@ -24,7 +24,8 @@ ThermalConductivity::ThermalConductivity(const InputParameters & parameters) :
     _flux(getPostprocessorValue("flux")),
     _T_hot(getPostprocessorValue("T_hot")),
     _length_scale(getParam<Real>("length_scale")),
-    _k0(getParam<Real>("k0"))
+    _k0(getParam<Real>("k0")),
+    _step_zero(declareRestartableData<bool>("step_zero", true))
 {
 }
 
@@ -33,12 +34,14 @@ ThermalConductivity::getValue()
 {
   const Real T_cold = SideAverageValue::getValue();
   Real Th_cond = 0.0;
+  if (_t_step >= 1)
+    _step_zero = false;
 
   // Calculate effective thermal conductivity in W/(length_scale-K)
   if (std::abs(_T_hot - T_cold) > 1.0e-20)
     Th_cond = std::abs(_flux) * _dx / std::abs(_T_hot - T_cold);
 
-  if (_t_step == 0)
+  if (_step_zero)
     return _k0;
   else
     return Th_cond / _length_scale; //In W/(m-K)

--- a/modules/solid_mechanics/include/materials/ConstitutiveModel.h
+++ b/modules/solid_mechanics/include/materials/ConstitutiveModel.h
@@ -60,6 +60,11 @@ protected:
 private:
   using Material::computeProperties;
   using Material::_qp;
+
+  ///@{ Restartable data to check for the zeroth and first time steps for thermal calculations
+  bool & _step_zero;
+  bool & _step_one;
+  ///@}
 };
 
 template<>

--- a/modules/solid_mechanics/include/materials/SolidModel.h
+++ b/modules/solid_mechanics/include/materials/SolidModel.h
@@ -115,6 +115,11 @@ protected:
   MaterialProperty<SymmTensor> & _stress;
 private:
   MaterialProperty<SymmTensor> & _stress_old_prop;
+
+  ///@{ Restartable data to check for the zeroth and first time steps for thermal calculations
+  bool & _step_zero;
+  bool & _step_one;
+  ///@}
 protected:
   SymmTensor _stress_old;
 

--- a/modules/solid_mechanics/src/materials/ConstitutiveModel.C
+++ b/modules/solid_mechanics/src/materials/ConstitutiveModel.C
@@ -31,16 +31,18 @@ InputParameters validParams<ConstitutiveModel>()
 }
 
 
-ConstitutiveModel::ConstitutiveModel(const InputParameters & parameters)
-  :Material(parameters),
-   _has_temp(isCoupled("temp")),
-   _temperature(_has_temp ? coupledValue("temp") : _zero),
-   _temperature_old(_has_temp ? coupledValueOld("temp") : _zero),
-   _alpha(parameters.isParamValid("thermal_expansion") ? getParam<Real>("thermal_expansion") : 0.),
-   _alpha_function(parameters.isParamValid("thermal_expansion_function") ? &getFunction("thermal_expansion_function") : NULL),
-   _has_stress_free_temp(isParamValid("stress_free_temperature")),
-   _stress_free_temp(_has_stress_free_temp ? getParam<Real>("stress_free_temperature") : 0.0),
-   _ref_temp(0.0)
+ConstitutiveModel::ConstitutiveModel(const InputParameters & parameters) :
+    Material(parameters),
+    _has_temp(isCoupled("temp")),
+    _temperature(_has_temp ? coupledValue("temp") : _zero),
+    _temperature_old(_has_temp ? coupledValueOld("temp") : _zero),
+    _alpha(parameters.isParamValid("thermal_expansion") ? getParam<Real>("thermal_expansion") : 0.),
+    _alpha_function(parameters.isParamValid("thermal_expansion_function") ? &getFunction("thermal_expansion_function") : NULL),
+    _has_stress_free_temp(isParamValid("stress_free_temperature")),
+    _stress_free_temp(_has_stress_free_temp ? getParam<Real>("stress_free_temperature") : 0.0),
+    _ref_temp(0.0),
+    _step_zero(declareRestartableData<bool>("step_zero", true)),
+    _step_one(declareRestartableData<bool>("step_one", true))
 {
   if (parameters.isParamValid("thermal_expansion_function_type"))
   {
@@ -93,13 +95,19 @@ ConstitutiveModel::applyThermalStrain(unsigned qp,
                                       SymmTensor & strain_increment,
                                       SymmTensor & d_strain_dT)
 {
-  if (_has_temp && _t_step != 0)
+  if (_t_step >= 1)
+    _step_zero = false;
+
+  if (_t_step >= 2)
+    _step_one = false;
+
+  if (_has_temp && !_step_zero)
   {
     Real inc_thermal_strain;
     Real d_thermal_strain_d_temp;
 
     Real old_temp;
-    if (_t_step == 1 && _has_stress_free_temp && !_app.isRestarting())
+    if (_step_one && _has_stress_free_temp)
       old_temp = _stress_free_temp;
     else
       old_temp = _temperature_old[qp];

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
@@ -37,6 +37,16 @@ protected:
 
   const Real & _current_elem_volume;
   std::vector<RankTwoTensor> _Fhat;
+
+private:
+  /// True if this is the first timestep (timestep < 2). At the first
+  /// timestep, the change in temperature should be calculated with the reference
+  /// stress free temperature, not the stateful _temperature_old; this boolean variable
+  /// eliminates the use of the _app.isRestarting() in the soon to be deprecicated
+  /// calculation of thermal expansion strain in this class.
+  /// This boolean is delcared as a reference so that the variable is restartable
+  /// data:  if we restart, the code will not think it is the first timestep again.
+  bool & _step_one;
 };
 
 #endif //COMPUTEFINITESTRAIN_H

--- a/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
@@ -443,6 +443,14 @@ protected:
    * @param cumulative_pm The plastic multipliers needed for this current Return (this is the sum of the plastic multipliers over all substeps if the strain increment was applied in small substeps)
    */
   RankFourTensor consistentTangentOperator(const RankTwoTensor & stress, const std::vector<Real> & intnl, const RankFourTensor & E_ijkl, const std::vector<Real> & pm_this_step, const std::vector<Real> & cumulative_pm);
+
+private:
+  /// True if this is the first timestep (timestep < 2). In the first timestep,
+  /// an initial stress is needed to subdivide.  This boolean variable
+  /// eliminates the use of the _app.isRestarting() in this class.
+  /// This boolean is delcared as a reference so that the variable is restartable
+  /// data:  if we restart, the code will not think it is the first timestep again.
+  bool & _step_one;
 };
 
 #endif //COMPUTEMULTIPLASTICITYSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeThermalExpansionEigenStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeThermalExpansionEigenStrain.h
@@ -31,6 +31,15 @@ protected:
   const VariableValue * _temperature_old;
   const Real & _thermal_expansion_coeff;
   const Real & _stress_free_reference_temperature;
+
+private:
+  /// True if this is the first timestep (timestep < 2). At the first
+  /// timestep, the change in temperature should be calculated with the reference
+  /// stress free temperature, not the stateful _temperature_old; this boolean variable
+  /// eliminates the use of _app.isRestarting() in this class.
+  /// This boolean is delcared as a reference so that the variable is restartable
+  /// data:  if we restart, the code will not think it is the first timestep again.
+  bool & _step_one;
 };
 
 #endif // COMPUTETHERMALEXPANSIONEIGENSTRAIN_H

--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
@@ -32,7 +32,8 @@ ComputeFiniteStrain::ComputeFiniteStrain(const InputParameters & parameters) :
     _stress_free_strain_increment(getDefaultMaterialProperty<RankTwoTensor>(_base_name + "stress_free_strain_increment")),
     _T_old(coupledValueOld("temperature")), //Deprecated, use ComputeThermalExpansionEigenStrain instead
     _current_elem_volume(_assembly.elemVolume()),
-    _Fhat(_fe_problem.getMaxQps())
+    _Fhat(_fe_problem.getMaxQps()),
+    _step_one(declareRestartableData<bool>("step_one", true))
 {
 }
 
@@ -122,9 +123,11 @@ ComputeFiniteStrain::computeQpStrain()
 
     if (_no_thermal_eigenstrains) //Deprecated; use ComputeThermalExpansionEigenStrains instead
     {
-      if (_t_step == 1 && !_app.isRestarting()) // total strain form always uses the ref temp
-        _strain_increment[_qp].addIa(-_thermal_expansion_coeff * (_T[_qp] - _T0));
+      if (_t_step >= 2)
+          _step_one = false;
 
+      if (_step_one)
+        _strain_increment[_qp].addIa(-_thermal_expansion_coeff * (_T[_qp] - _T0));
       else
         _strain_increment[_qp].addIa(-_thermal_expansion_coeff * (_T[_qp] - _T_old[_qp]));
     }

--- a/modules/tensor_mechanics/src/materials/ComputeReturnMappingStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeReturnMappingStress.C
@@ -50,11 +50,11 @@ ComputeReturnMappingStress::initialSetup()
 void
 ComputeReturnMappingStress::computeQpStress()
 {
-  // Nothing to update during the first time step, return immediately
-  if (_t_step == 0 && !_app.isRestarting())
-    return;
+  // Nothing to update during the first time step
+  // ComputeQpStress is not called during the zeroth time step, so no need to
+  // guard against _t_step == 0
 
-  RankTwoTensor strain_increment(_strain_increment[_qp]);
+  RankTwoTensor strain_increment = _strain_increment[_qp];
   RankTwoTensor stress_new;
   computeStress(strain_increment, stress_new);
   _elastic_strain[_qp] = _rotation_increment[_qp] * (strain_increment + _elastic_strain_old[_qp]) * _rotation_increment[_qp].transpose();
@@ -68,9 +68,6 @@ void
 ComputeReturnMappingStress::computeStress(RankTwoTensor & strain_increment,
                                           RankTwoTensor & stress_new)
 {
-  if (_t_step == 0 && !_app.isRestarting())
-    return;
-
   if (_output_iteration_info == true)
   {
     _console
@@ -87,7 +84,7 @@ ComputeReturnMappingStress::computeStress(RankTwoTensor & strain_increment,
   RankTwoTensor inelastic_strain_increment;
 
   RankTwoTensor elastic_strain_increment;
-  RankTwoTensor stress_new_last(stress_new);
+  RankTwoTensor stress_new_last = stress_new;
   Real delS = _absolute_tolerance+1;
   Real first_delS = delS;
   unsigned int counter =0;


### PR DESCRIPTION
### Relevant design information

 The use of the `_app.isRestarting()` flag is replaced by a boolean as suggested by @friedmud and @permcody in Solid and Tensor Mechanics.  The change to the boolean does not remove the need of the materials to query `_t_step`, but it does more gracefully allow for restarts.

@permcody  please review.
### Test Cases

No test cases modified or added.

Closes #7457 
