### PR TITLE
Change the declaration of restartable step_one and step_zero to prote…

### DIFF
--- a/modules/solid_mechanics/include/materials/ConstitutiveModel.h
+++ b/modules/solid_mechanics/include/materials/ConstitutiveModel.h
@@ -57,14 +57,14 @@ protected:
   bool _mean_alpha_function;
   Real _ref_temp;
 
+  ///@{ Restartable data to check for the zeroth and first time steps
+  bool & _step_zero_cm;
+  bool & _step_one_cm;
+  ///@}
+
 private:
   using Material::computeProperties;
   using Material::_qp;
-
-  ///@{ Restartable data to check for the zeroth and first time steps for thermal calculations
-  bool & _step_zero;
-  bool & _step_one;
-  ///@}
 };
 
 template<>

--- a/modules/solid_mechanics/include/materials/SolidModel.h
+++ b/modules/solid_mechanics/include/materials/SolidModel.h
@@ -116,10 +116,6 @@ protected:
 private:
   MaterialProperty<SymmTensor> & _stress_old_prop;
 
-  ///@{ Restartable data to check for the zeroth and first time steps for thermal calculations
-  bool & _step_zero;
-  bool & _step_one;
-  ///@}
 protected:
   SymmTensor _stress_old;
 
@@ -267,6 +263,11 @@ protected:
   virtual void computeConstitutiveModelStress();
 
   void createConstitutiveModel(const std::string & cm_name);
+
+  ///@{ Restartable data to check for the zeroth and first time steps for thermal calculations
+  bool & _step_zero;
+  bool & _step_one;
+  ///@}
 
 
 private:

--- a/modules/solid_mechanics/src/materials/ConstitutiveModel.C
+++ b/modules/solid_mechanics/src/materials/ConstitutiveModel.C
@@ -41,8 +41,8 @@ ConstitutiveModel::ConstitutiveModel(const InputParameters & parameters) :
     _has_stress_free_temp(isParamValid("stress_free_temperature")),
     _stress_free_temp(_has_stress_free_temp ? getParam<Real>("stress_free_temperature") : 0.0),
     _ref_temp(0.0),
-    _step_zero(declareRestartableData<bool>("step_zero", true)),
-    _step_one(declareRestartableData<bool>("step_one", true))
+    _step_zero_cm(declareRestartableData<bool>("step_zero_cm", true)),
+    _step_one_cm(declareRestartableData<bool>("step_one_cm", true))
 {
   if (parameters.isParamValid("thermal_expansion_function_type"))
   {
@@ -96,18 +96,18 @@ ConstitutiveModel::applyThermalStrain(unsigned qp,
                                       SymmTensor & d_strain_dT)
 {
   if (_t_step >= 1)
-    _step_zero = false;
+    _step_zero_cm = false;
 
   if (_t_step >= 2)
-    _step_one = false;
+    _step_one_cm = false;
 
-  if (_has_temp && !_step_zero)
+  if (_has_temp && !_step_zero_cm)
   {
     Real inc_thermal_strain;
     Real d_thermal_strain_d_temp;
 
     Real old_temp;
-    if (_step_one && _has_stress_free_temp)
+    if (_step_one_cm && _has_stress_free_temp)
       old_temp = _stress_free_temp;
     else
       old_temp = _temperature_old[qp];

--- a/modules/solid_mechanics/src/materials/SolidModel.C
+++ b/modules/solid_mechanics/src/materials/SolidModel.C
@@ -131,8 +131,6 @@ SolidModel::SolidModel( const InputParameters & parameters) :
   _dep_matl_props(),
   _stress(createProperty<SymmTensor>("stress")),
   _stress_old_prop(createPropertyOld<SymmTensor>("stress")),
-  _step_zero(declareRestartableData<bool>("step_zero", true)),
-  _step_one(declareRestartableData<bool>("step_one", true)),
   _stress_old(0),
   _total_strain(createProperty<SymmTensor>("total_strain")),
   _total_strain_old(createPropertyOld<SymmTensor>("total_strain")),
@@ -165,6 +163,8 @@ SolidModel::SolidModel( const InputParameters & parameters) :
   _J_thermal_term_vec(NULL),
   _block_id(std::vector<SubdomainID>(blockIDs().begin(), blockIDs().end())),
   _constitutive_active(false),
+  _step_zero(declareRestartableData<bool>("step_zero", true)),
+  _step_one(declareRestartableData<bool>("step_one", true)),
   _element(NULL),
   _local_elasticity_tensor(NULL)
 {


### PR DESCRIPTION
### Design Information

This commit changes the declaration of the restartable `_step_one` and `_step_zero` booleans from `private`, as declared in #7481, to `protected` so that the inheriting classes in BISON can use these boolean variables.  The boolean variables in Constitutive model now have the suffix `_cm` to avoid double declarations in inheriting classes in BISON.  The need for the suffix will go away with the migration to tensor mechanics.

@permcody please review
### Test Cases

No modified test cases.

Refs #7457
