### PR TITLE
Re-enable the maximum timestep growth in FunctionDT

### DIFF
--- a/framework/src/timesteppers/FunctionDT.C
+++ b/framework/src/timesteppers/FunctionDT.C
@@ -15,6 +15,7 @@
 #include "FunctionDT.h"
 #include "FEProblem.h"
 #include "Transient.h"
+#include <limits>
 
 template<>
 InputParameters validParams<FunctionDT>()
@@ -22,7 +23,7 @@ InputParameters validParams<FunctionDT>()
   InputParameters params = validParams<TimeStepper>();
   params.addRequiredParam<std::vector<Real> >("time_t", "The values of t");
   params.addRequiredParam<std::vector<Real> >("time_dt", "The values of dt");
-  params.addParam<Real>("growth_factor", 2, "Maximum ratio of new to previous timestep sizes following a step that required the time step to be cut due to a failed solve.");
+  params.addParam<Real>("growth_factor", std::numeric_limits<Real>::max(), "Maximum ratio of new to previous timestep sizes following a step that required the time step to be cut due to a failed solve.");
   params.addParam<Real>("min_dt", 0, "The minimal dt to take.");
   params.addParam<bool>("interpolate", true, "Whether or not to interpolate DT between times.  This is true by default for historical reasons.");
 
@@ -102,8 +103,8 @@ FunctionDT::computeDT()
   if (local_dt < _min_dt)
     local_dt = _min_dt;
 
-//  if (_cutback_occurred && (local_dt > _dt * _growth_factor))
-//    local_dt = _dt * _growth_factor;
+  if (_cutback_occurred && (local_dt > _dt * _growth_factor))
+    local_dt = _dt * _growth_factor;
   _cutback_occurred = false;
 
   return local_dt;


### PR DESCRIPTION
Re-enables maximum timestep growth after cutback occurred in FunctionDT. This works now due to the regions stated by @andrsd in issue #7497.
