### PR TITLE
Rewrite BoundingBoxNodeSet

### DIFF
--- a/framework/include/meshmodifiers/BoundingBoxNodeSet.h
+++ b/framework/include/meshmodifiers/BoundingBoxNodeSet.h
@@ -41,14 +41,11 @@ protected:
   virtual void modify() override;
 
 private:
-
-  /// ID location (inside of outside of box)
+  /// Select nodes on the 'inside' or the 'outside' of the bounding box
   MooseEnum _location;
 
   /// Bounding box for testing element centroids against. Note that
-  /// the box includes nodes based on the element centroids and not
-  /// the actual nodes itself.
   MeshTools::BoundingBox _bounding_box;
 };
 
-#endif // BOUNDINGBOXNODESET_H
+#endif //BOUNDINGBOXNODESET_H

--- a/framework/src/meshmodifiers/BoundingBoxNodeSet.C
+++ b/framework/src/meshmodifiers/BoundingBoxNodeSet.C
@@ -22,8 +22,8 @@ InputParameters validParams<BoundingBoxNodeSet>()
 
   InputParameters params = validParams<MeshModifier>();
   params.addRequiredParam<std::vector<BoundaryName> >("new_boundary", "The name of the nodeset to create");
-  params.addParam<RealVectorValue>("bottom_left", "The bottom left point (in x,y,z with spaces in-between) of the box which contains the centroids of the elements whose nodes will be selected.");
-  params.addParam<RealVectorValue>("top_right", "The bottom left point (in x,y,z with spaces in-between) of the box which contains the centroids of the elements whose nodes will be selected.");
+  params.addRequiredParam<RealVectorValue>("bottom_left", "The bottom left point (in x,y,z with spaces in-between) of the box to select the nodes.");
+  params.addRequiredParam<RealVectorValue>("top_right", "The bottom left point (in x,y,z with spaces in-between) of the box to select the nodes.");
   params.addParam<MooseEnum>("location", location, "Control of where the nodeset is to be set");
 
   return params;
@@ -39,51 +39,37 @@ BoundingBoxNodeSet::BoundingBoxNodeSet(const InputParameters & parameters) :
 void
 BoundingBoxNodeSet::modify()
 {
-
   // Get the BoundaryIDs from the mesh
   std::vector<BoundaryName> boundary_names = getParam<std::vector<BoundaryName> >("new_boundary");
   std::vector<BoundaryID> boundary_ids = _mesh_ptr->getBoundaryIDs(boundary_names, true);
+  if (boundary_ids.size() != 1)
+    mooseError("Only one boundary ID can be assigned to a nodeset using a bounding box!");
+
   // Get a reference to our BoundaryInfo object
   BoundaryInfo & boundary_info = _mesh_ptr->getMesh().get_boundary_info();
 
-  if (_pars.isParamValid("bottom_left") && _pars.isParamValid("top_right"))
+  // Check that we have access to the mesh
+  if (!_mesh_ptr)
+    mooseError("_mesh_ptr must be initialized before calling BoundingBoxNodeSet::modify()");
+
+  // Reference the the libMesh::MeshBase
+  MeshBase & mesh = _mesh_ptr->getMesh();
+
+  bool found_node = false;
+  const bool inside = (_location == "INSIDE");
+
+  // Loop over the elements and assign node set id to nodes within the bounding box
+  for (auto node = mesh.active_nodes_begin(); node != mesh.active_nodes_end(); ++node)
   {
-    int num_bound_ids = boundary_ids.size();
-    if (num_bound_ids != 1)//you cannot define more than one nodeset within a bounding box.
-      mooseError("Only one boundary ID can be assigned to a nodeset using a bounding box!");
-
-    // Check that we have access to the mesh
-    if (!_mesh_ptr)
-      mooseError("_mesh_ptr must be initialized before calling BoundingBoxNodeSet::modify()");
-
-    // Reference the the libMesh::MeshBase
-    MeshBase & mesh = _mesh_ptr->getMesh();
-    bool found_node = false;
-    // Loop over the elements and assign node set id to nodes within the bounding box
-    for (MeshBase::element_iterator el = mesh.active_elements_begin(); el != mesh.active_elements_end(); ++el)
+    if (_bounding_box.contains_point(**node) == inside)
     {
-      const Elem * elem = *el;
-
-      bool contains = _bounding_box.contains_point((*el)->centroid());
-      if ((contains && _location == "INSIDE") || (!contains && _location == "OUTSIDE"))
-      {
-        for (unsigned int j = 0; j < elem->n_nodes(); ++j)
-        {
-          const Node * node = elem->node_ptr(j);
-
-          for (const auto & boundary_id : boundary_ids)
-            boundary_info.add_node(node, boundary_id);
-
-          found_node = true;
-        }
-      }
+      boundary_info.add_node(*node, boundary_ids[0]);
+      found_node = true;
     }
-    if (!found_node)
-      mooseError("No element centroids found within the bounding box!");
   }
-  else
-    mooseError("Node set can not be empty!");
 
-  for (unsigned int i = 0; i < boundary_ids.size(); ++i)
-    boundary_info.nodeset_name(boundary_ids[i]) = boundary_names[i];
+  if (!found_node)
+    mooseError("No element centroids found within the bounding box!");
+
+  boundary_info.nodeset_name(boundary_ids[0]) = boundary_names[0];
 }

--- a/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_inside_test.i
+++ b/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_inside_test.i
@@ -12,8 +12,8 @@
   [./middle_node]
     type = BoundingBoxNodeSet
     new_boundary = middle_node
-    top_right = '1 1 0'
-    bottom_left = '0.5 0.5 0'
+    top_right = '1.1 1.1 0'
+    bottom_left = '0.49 0.49 0'
   [../]
 []
 
@@ -62,4 +62,3 @@
   file_base = boundingbox_nodeset_inside_out
   exodus = true
 []
-

--- a/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_outside_test.i
+++ b/test/tests/mesh_modifiers/boundingbox_nodeset/boundingbox_nodeset_outside_test.i
@@ -12,8 +12,8 @@
   [./middle_node]
     type = BoundingBoxNodeSet
     new_boundary = middle_node
-    top_right = '1 1 0'
-    bottom_left = '0.5 0.5 0'
+    top_right = '1.1 1.1 0'
+    bottom_left = '0.51 0.51 0'
     location = OUTSIDE
   [../]
 []
@@ -63,4 +63,3 @@
   file_base = boundingbox_nodeset_outside_out
   exodus = true
 []
-

--- a/test/tests/mesh_modifiers/boundingbox_nodeset/tests
+++ b/test/tests/mesh_modifiers/boundingbox_nodeset/tests
@@ -15,7 +15,7 @@
     type = 'RunException'
     input = 'boundingbox_nodeset_inside_test.i'
     expect_err = "No element centroids found within the bounding box!"
-    cli_args = 'MeshModifiers/middle_node/bottom_left="1 1 0"'
+    cli_args = 'MeshModifiers/middle_node/bottom_left="1.05 1.05 0"'
   [../]
 
   [./test_bad_boundaryid]


### PR DESCRIPTION
Apply the bounding box only to the node coordinates. This seems much more straightforward than what it previously did (principle of least surprise).

Closes #7537
