### PR TITLE
Update libmesh.

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -86,6 +86,7 @@ if [ -z "$go_fast" ]; then
                --enable-unique-ptr \
                --enable-openmp \
                --disable-maintainer-mode \
+               --enable-petsc-required \
                $DISABLE_TIMESTAMPS $* || exit 1
 else
   # The build directory must already exist: you can't do --fast for


### PR DESCRIPTION
Brief summary of changes included in this update:
- Fix detection of VTK 6.0 (we skipped straight to 6.1 for some reason)
- Improve TRISHELL3 support in various FE switch statements.
- Merge updated NEWS file from 1.0.0 release.
- Update bundled boost subset from 1.55 to 1.61.
- Minimum boost version required for building libmesh bumped to 1.57.
- Remove deprecated Mesh IO classes (DivaIO, LegacyXdrIO, MGF).
- Fix deprecated header warnings caused by CPPUnit.
- Misc. infinite elements fixes.
- Enhance MeshFunction/PointLocator to work with discontinuous FEM on faces.
- Enhance System::point_value() interface to make it harder to call incorrectly.
- Implement DenseMatrix::svd() for --enable-complex builds.
- Avoid double call to KSPSetFromOptions.
- Throw exception from TypeTensor::solve() on zero determinant.
- Handle exceptions thrown by TypeTensor::solve() in FE::inverse_map().
- Remove previously-deprecated PointLocatorList class.
- Fix Hypre detection for PETSc 3.6.x+ builds.
- Use Use n_active_elem() instead of n_elem() when flagging by elem fraction.
- Guard Trilinos header includes with ignore/restore warnings headers.
- Steps 1, 2 (of N) of ghosting policy refactor.
- Fix issue where the PointLocator _initialized flag was not reset by clear().
- Add get_array() capability to PetscVector and use internally.
- Enhance DenseMatrix::evd() interface to also compute left and right eigenvalues.
- Add MPI_Scatter wrappers to Parallel:: interface.
- Add --enable-petsc-required option.

Refs #000
