### PR TITLE
Build libMesh with VTK options when available

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -21,7 +21,7 @@ fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ ! -z "$LIBMESH_DIR" ]; then
+if [[ -n "$LIBMESH_DIR" ]]; then
   echo "INFO: LIBMESH_DIR set - overriding default installed path"
   echo "INFO: No cleaning will be done in specified path"
   mkdir -p $LIBMESH_DIR
@@ -40,7 +40,7 @@ fi
 
 # If the user has VTK available via our modules, we'll build with VTK
 VTK_OPTIONS=""
-if [[ ! -z "$VTKLIB_DIR" && ! -z "$VTKINCLUDE_DIR" ]]; then
+if [[ -n "$VTKLIB_DIR" && -n "$VTKINCLUDE_DIR" ]]; then
   export VTK_OPTIONS="--with-vtk-lib=$VTKLIB_DIR --with-vtk-include=$VTKINCLUDE_DIR"
 fi
 

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -38,6 +38,12 @@ if [[ -n "$METHOD" && -z "$METHODS" ]]; then
   export METHODS="$METHOD"
 fi
 
+# If the user has VTK available via our modules, we'll build with VTK
+VTK_OPTIONS=""
+if [[ ! -z "$VTKLIB_DIR" && ! -z "$VTKINCLUDE_DIR" ]]; then
+  export VTK_OPTIONS="--with-vtk-lib=$VTKLIB_DIR --with-vtk-include=$VTKINCLUDE_DIR"
+fi
+
 # Finally, if METHODS is still not set, set a default value.
 export METHODS=${METHODS:="opt oprof dbg"}
 
@@ -87,7 +93,7 @@ if [ -z "$go_fast" ]; then
                --enable-openmp \
                --disable-maintainer-mode \
                --enable-petsc-required \
-               $DISABLE_TIMESTAMPS $* || exit 1
+               $DISABLE_TIMESTAMPS $VTK_OPTIONS $* || exit 1
 else
   # The build directory must already exist: you can't do --fast for
   # an initial build.


### PR DESCRIPTION
Build libMesh with VTK options when moose-environment's VTK modules are loaded. Or rather, when the update_and_rebuild_libmesh.sh script discovers $VTKLIB_DIR and $VTKINCLUDE_DIR.

 Refs #7551
