### PR TITLE
Have TensorMechanics Action select the correct kernels for the coordinate system automatically

### DIFF
--- a/modules/combined/tests/cavity_pressure/cavity_pressure_rz.i
+++ b/modules/combined/tests/cavity_pressure/cavity_pressure_rz.i
@@ -62,7 +62,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     use_displaced_mesh = true
   [../]
   [./heat]

--- a/modules/combined/tests/evolving_mass_density/rz_tensors.i
+++ b/modules/combined/tests/evolving_mass_density/rz_tensors.i
@@ -76,7 +76,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     use_displaced_mesh = true
   [../]
 []

--- a/modules/tensor_mechanics/include/actions/DynamicTensorMechanicsAction.h
+++ b/modules/tensor_mechanics/include/actions/DynamicTensorMechanicsAction.h
@@ -19,8 +19,9 @@ class DynamicTensorMechanicsAction : public TensorMechanicsAction
 public:
   DynamicTensorMechanicsAction(const InputParameters & params);
 
-  virtual void act();
-  virtual void addkernel(const std::string & name, InputParameters & params);
+protected:
+  virtual std::string getKernelType();
+  virtual InputParameters getParameters(std::string type);
 };
 
 #endif //DYNAMICTENSORMECHANICSACTION_H

--- a/modules/tensor_mechanics/include/actions/TensorMechanicsAction.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsAction.h
@@ -20,7 +20,20 @@ public:
   TensorMechanicsAction(const InputParameters & params);
 
   virtual void act();
-  virtual void addkernel(const std::string & name, InputParameters & params);
+
+protected:
+  virtual std::string getKernelType();
+  virtual InputParameters getParameters(std::string type);
+
+  std::vector<NonlinearVariableName> _displacements;
+  unsigned int _ndisp;
+
+  std::vector<VariableName> _coupled_displacements;
+
+  std::vector<AuxVariableName> _save_in;
+  std::vector<AuxVariableName> _diag_save_in;
+
+  Moose::CoordinateSystemType _coord_system;
 };
 
 #endif //TENSORMECHANICSACTION_H

--- a/modules/tensor_mechanics/include/actions/TensorMechanicsAxisymmetricRZAction.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsAxisymmetricRZAction.h
@@ -7,19 +7,17 @@
 #ifndef TENSORMECHANICSAXISYMMETRICRZACTION_H
 #define TENSORMECHANICSAXISYMMETRICRZACTION_H
 
-#include "Action.h"
+#include "TensorMechanicsAction.h"
 
 class TensorMechanicsAxisymmetricRZAction;
 
 template<>
 InputParameters validParams<TensorMechanicsAxisymmetricRZAction>();
 
-class TensorMechanicsAxisymmetricRZAction : public Action
+class TensorMechanicsAxisymmetricRZAction : public TensorMechanicsAction
 {
 public:
   TensorMechanicsAxisymmetricRZAction(const InputParameters & params);
-
-  virtual void act();
 };
 
 #endif //TENSORMECHANICSAXISYMMETRICRZACTION_H

--- a/modules/tensor_mechanics/include/actions/TensorMechanicsRSphericalAction.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsRSphericalAction.h
@@ -7,19 +7,17 @@
 #ifndef TENSORMECHANICSRSPHERICALACTION_H
 #define TENSORMECHANICSRSPHERICALACTION_H
 
-#include "Action.h"
+#include "TensorMechanicsAction.h"
 
 class TensorMechanicsRSphericalAction;
 
 template<>
 InputParameters validParams<TensorMechanicsRSphericalAction>();
 
-class TensorMechanicsRSphericalAction : public Action
+class TensorMechanicsRSphericalAction : public TensorMechanicsAction
 {
 public:
   TensorMechanicsRSphericalAction(const InputParameters & params);
-
-  virtual void act();
 };
 
 #endif //TENSORMECHANICSRSPHERICALACTION_H

--- a/modules/tensor_mechanics/src/actions/DynamicTensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/DynamicTensorMechanicsAction.C
@@ -25,23 +25,35 @@ DynamicTensorMechanicsAction::DynamicTensorMechanicsAction(const InputParameters
 {
 }
 
-void
-DynamicTensorMechanicsAction::addkernel(const std::string & name, InputParameters & params)
+std::string
+DynamicTensorMechanicsAction::getKernelType()
 {
-  //Add the zeta and alpha parameters to the params (which belongs to StressDivergenceTensors).
-  //Add DynamicStressDivergenceTensors kernel
+  std::string type;
+
+  // choose kernel type based on coordinate system
+  switch (_coord_system)
+  {
+    case Moose::COORD_XYZ:
+      type = "DynamicStressDivergenceTensors";
+      break;
+
+    default:
+      mooseError("Unsupported coordinate system");
+  }
+
+  return type;
+}
+
+InputParameters
+DynamicTensorMechanicsAction::getParameters(std::string type)
+{
+  InputParameters params = TensorMechanicsAction::getParameters(type);
+
   params.addParam<Real>("zeta", 0, "zeta parameter for the Rayleigh damping");
   params.addParam<Real>("alpha", 0, "alpha parameter for HHT time integration");
 
   params.set<Real>("zeta") = getParam<Real>("zeta");
   params.set<Real>("alpha") = getParam<Real>("alpha");
 
-  _problem->addKernel("DynamicStressDivergenceTensors", name, params);
+  return params;
 }
-
-void
-DynamicTensorMechanicsAction::act()
-{
-  TensorMechanicsAction::act();
-}
-

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
@@ -9,6 +9,7 @@
 #include "Factory.h"
 #include "FEProblem.h"
 #include "Conversion.h"
+#include "MooseMesh.h"
 
 template<>
 InputParameters validParams<TensorMechanicsAction>()
@@ -27,30 +28,88 @@ InputParameters validParams<TensorMechanicsAction>()
 }
 
 TensorMechanicsAction::TensorMechanicsAction(const InputParameters & params) :
-    Action(params)
+    Action(params),
+    _displacements(getParam<std::vector<NonlinearVariableName> >("displacements")),
+    _ndisp(_displacements.size()),
+    _coupled_displacements(_ndisp),
+    _save_in(getParam<std::vector<AuxVariableName> >("save_in")),
+    _diag_save_in(getParam<std::vector<AuxVariableName> >("diag_save_in"))
 {
+  // convert vector of NonlinearVariableName to vector of VariableName
+  for (unsigned int i = 0; i < _ndisp; ++i)
+    _coupled_displacements[i] = _displacements[i];
+
+  if (_save_in.size() != 0 && _save_in.size() != _ndisp)
+    mooseError("Number of save_in variables should equal to the number of displacement variables " << _ndisp);
+
+  if (_diag_save_in.size() != 0 && _diag_save_in.size() != _ndisp)
+    mooseError("Number of diag_save_in variables should equal to the number of displacement variables " << _ndisp);
 }
 
 void
 TensorMechanicsAction::act()
 {
-  std::vector<NonlinearVariableName>displacements = getParam<std::vector<NonlinearVariableName> >("displacements");
-  unsigned int _ndisp = displacements.size();
+  // get a list of all subdomains first
+  const auto & subdomain_set = _problem->mesh().meshSubdomains();
+  std::vector<SubdomainID> subdomains(subdomain_set.begin(), subdomain_set.end());
 
-  std::vector<VariableName>coupled_displacements;
+  // make sure all subdomains are using the same coordinate system
+  _coord_system = _problem->getCoordSystem(subdomains[0]);
+  for (auto s : subdomains)
+    if (_problem->getCoordSystem(s) != _coord_system)
+      mooseError("The TensorMechanics action requires all subdomains to have the same coordinate system");
+
+  auto tensor_kernel_type = getKernelType();
+  auto params = getParameters(tensor_kernel_type);
+
   for (unsigned int i = 0; i < _ndisp; ++i)
-    coupled_displacements.push_back(displacements[i]);
+  {
+    std::string kernel_name = "TensorMechanics_" + Moose::stringify(i);
 
-  std::vector<AuxVariableName>save_in = getParam<std::vector<AuxVariableName> >("save_in");
-  if (isParamValid("save_in") && save_in.size() != _ndisp)
-    mooseError("Number of save_in variables should equal to the number of displacement variables " << _ndisp);
+    params.set<unsigned int>("component") = i;
+    params.set<NonlinearVariableName>("variable") = _displacements[i];
 
-  std::vector<AuxVariableName>diag_save_in = getParam<std::vector<AuxVariableName> >("diag_save_in");
-  if (isParamValid("diag_save_in") && diag_save_in.size() != _ndisp)
-    mooseError("Number of diag_save_in variables should equal to the number of displacement variables " << _ndisp);
+    if (_save_in.size() != 0)
+      params.set<std::vector<AuxVariableName> >("save_in") = {_save_in[i]};
+    if (_diag_save_in.size() != 0)
+      params.set<std::vector<AuxVariableName> >("diag_save_in") = {_diag_save_in[i]};
 
-  InputParameters params = _factory.getValidParams("StressDivergenceTensors");
-  params.set<std::vector<VariableName> >("displacements") = coupled_displacements;
+    _problem->addKernel(tensor_kernel_type, kernel_name, params);
+  }
+}
+
+std::string
+TensorMechanicsAction::getKernelType()
+{
+  std::string type;
+
+  // choose kernel type based on coordinate system
+  switch (_coord_system)
+  {
+    case Moose::COORD_XYZ:
+      type = "StressDivergenceTensors";
+      break;
+
+    case Moose::COORD_RZ:
+      type = "StressDivergenceRZTensors";
+      break;
+
+    case Moose::COORD_RSPHERICAL:
+      type = "StressDivergenceRSphericalTensors";
+      break;
+
+    default:
+      mooseError("Unsupported coordinate system");
+  }
+
+  return type;
+}
+
+InputParameters
+TensorMechanicsAction::getParameters(std::string type)
+{
+  InputParameters params = _factory.getValidParams(type);
+  params.set<std::vector<VariableName> >("displacements") = _coupled_displacements;
 
   if (isParamValid("temp"))
     params.addCoupledVar("temp", "");
@@ -63,27 +122,9 @@ TensorMechanicsAction::act()
   if (isParamValid("use_finite_deform_jacobian"))
     params.set<bool>("use_finite_deform_jacobian") = getParam<bool>("use_finite_deform_jacobian");
 
-// Check whether this StressDivergenceTensor kernel is restricted to certain block?
+  // Check whether this StressDivergenceTensor kernel is restricted to certain block?
   if (isParamValid("block"))
     params.set<std::vector<SubdomainName> >("block") = getParam<std::vector<SubdomainName> >("block");
 
-  for (unsigned int i = 0; i < _ndisp; ++i)
-  {
-    std::string kernel_name = "TensorMechanics_" + Moose::stringify(i);
-
-    params.set<unsigned int>("component") = i;
-    params.set<NonlinearVariableName>("variable") = displacements[i];
-    if (isParamValid("save_in"))
-      params.set<std::vector<AuxVariableName> >("save_in") = {save_in[i]};
-    if (isParamValid("diag_save_in"))
-      params.set<std::vector<AuxVariableName> >("diag_save_in") = {diag_save_in[i]};
-
-    addkernel(kernel_name, params);
-  }
-}
-
-void
-TensorMechanicsAction::addkernel(const std::string & name,  InputParameters & params)
-{
-  _problem->addKernel("StressDivergenceTensors", name, params);
+  return params;
 }

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAxisymmetricRZAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAxisymmetricRZAction.C
@@ -6,74 +6,14 @@
 /****************************************************************/
 #include "TensorMechanicsAxisymmetricRZAction.h"
 
-#include "Factory.h"
-#include "FEProblem.h"
-#include "Conversion.h"
-
 template<>
 InputParameters validParams<TensorMechanicsAxisymmetricRZAction>()
 {
-  InputParameters params = validParams<Action>();
-  params.addClassDescription("Set up stress divergence kernel for 2D cylindrical problem");
-  params.addRequiredParam<std::vector<NonlinearVariableName> >("displacements", "The nonlinear displacement variables for the problem");
-  params.addParam<std::string>("base_name", "Material property base name");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether to use displaced mesh in the kernels");
-  params.addParam<std::vector<SubdomainName> >("block", "The list of ids of the blocks (subdomain) that the stress divergence kernel will be applied to");
-  params.addParam<std::vector<AuxVariableName> >("save_in", "The displacement residuals");
-  params.addParam<std::vector<AuxVariableName> >("diag_save_in", "The displacement diagonal preconditioner terms");
-  return params;
+  return validParams<TensorMechanicsAction>();
 }
 
 TensorMechanicsAxisymmetricRZAction::TensorMechanicsAxisymmetricRZAction(const InputParameters & params) :
-    Action(params)
+    TensorMechanicsAction(params)
 {
-}
-
-void
-TensorMechanicsAxisymmetricRZAction::act()
-{
-  std::vector<NonlinearVariableName>displacements = getParam<std::vector<NonlinearVariableName> >("displacements");
-  unsigned int _ndisp = displacements.size();
-
-  //Error checking:  Can only take two displacement variables in StressDivergenceRZTensors kernel
-  if (_ndisp != 2)
-    mooseError("Number of displacement variables should be 2 but recieved " << _ndisp);
-
-  std::vector<VariableName>coupled_displacements;
-  for (unsigned int i = 0; i < _ndisp; ++i)
-    coupled_displacements.push_back(displacements[i]);
-
-  std::vector<AuxVariableName>save_in = getParam<std::vector<AuxVariableName> >("save_in");
-  if (isParamValid("save_in") && save_in.size() != _ndisp)
-    mooseError("Number of save_in variables should equal to the number of displacement variables " << _ndisp);
-
-  std::vector<AuxVariableName>diag_save_in = getParam<std::vector<AuxVariableName> >("diag_save_in");
-  if (isParamValid("diag_save_in") && diag_save_in.size() != _ndisp)
-    mooseError("Number of diag_save_in variables should equal to the number of displacement variables " << _ndisp);
-
-  InputParameters params = _factory.getValidParams("StressDivergenceRZTensors");
-  params.set<std::vector<VariableName> >("displacements") = coupled_displacements;
-
-  params.set<bool>("use_displaced_mesh") = getParam<bool>("use_displaced_mesh");
-
-  if (isParamValid("base_name"))
-    params.set<std::string>("base_name") = getParam<std::string>("base_name");
-
-// Check whether this StressDivergenceRZTensors kernel is restricted to certain block?
-  if (isParamValid("block"))
-    params.set<std::vector<SubdomainName> >("block") = getParam<std::vector<SubdomainName> >("block");
-
-  for (unsigned int i = 0; i < _ndisp; ++i)
-  {
-    std::string kernel_name = "TensorMechanicsAxisymmetricRZ_" + Moose::stringify(i);
-
-    params.set<unsigned int>("component") = i;
-    params.set<NonlinearVariableName>("variable") = displacements[i];
-  if (isParamValid("save_in"))
-    params.set<std::vector<AuxVariableName> >("save_in") = {save_in[i]};
-  if (isParamValid("diag_save_in"))
-    params.set<std::vector<AuxVariableName> >("diag_save_in") = {diag_save_in[i]};
-
-    _problem->addKernel("StressDivergenceRZTensors", kernel_name, params);
-  }
+  mooseDeprecated("Use the 'TensorMechanics' action instead. It autodetects the coordinate system.");
 }

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsRSphericalAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsRSphericalAction.C
@@ -6,75 +6,14 @@
 /****************************************************************/
 #include "TensorMechanicsRSphericalAction.h"
 
-#include "Factory.h"
-#include "FEProblem.h"
-#include "Parser.h"
-#include "Conversion.h"
-
 template<>
 InputParameters validParams<TensorMechanicsRSphericalAction>()
 {
-  InputParameters params = validParams<Action>();
-  params.addClassDescription("Set up stress divergence kernel for the 1D spherical problem");
-  params.addRequiredParam<std::vector<NonlinearVariableName> >("displacements", "The nonlinear displacement variable for the problem (should only be a single variable)");
-  params.addParam<std::string>("base_name", "Material property base name");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether to use displaced mesh in the kernels");
-  params.addParam<std::vector<SubdomainName> >("block", "The list of ids of the blocks (subdomain) that the stress divergence kernel will be applied to");
-  params.addParam<std::vector<AuxVariableName> >("save_in", "The r displacement residuals");
-  params.addParam<std::vector<AuxVariableName> >("diag_save_in", "The r displacement diagonal preconditoner term");
-  return params;
+  return validParams<TensorMechanicsAction>();
 }
 
 TensorMechanicsRSphericalAction::TensorMechanicsRSphericalAction(const InputParameters & params) :
-    Action(params)
+    TensorMechanicsAction(params)
 {
-}
-
-void
-TensorMechanicsRSphericalAction::act()
-{
-  std::vector<NonlinearVariableName>displacements = getParam<std::vector<NonlinearVariableName> > ("displacements");
-  unsigned int _ndisp = displacements.size();
-
-  // Error checking:  Can only take one displacement variable in StressDivergenceRSphericalTensors kernel
-  if (_ndisp != 1)
-    mooseError("Number of displacement variable should be 1 but recieved " << _ndisp);
-
-  std::vector<VariableName>coupled_displacements;
-  for (unsigned int i = 0; i < _ndisp; ++i)
-    coupled_displacements.push_back(displacements[i]);
-
-  std::vector<AuxVariableName>save_in = getParam<std::vector<AuxVariableName> >("save_in");
-  if (isParamValid("save_in") && save_in.size() != _ndisp)
-    mooseError("Number of save_in variables should equal to the number of displacement variables " << _ndisp);
-
-  std::vector<AuxVariableName>diag_save_in = getParam<std::vector<AuxVariableName> >("diag_save_in");
-  if (isParamValid("diag_save_in") && diag_save_in.size() != _ndisp)
-    mooseError("Number of diag_save_in variables should equal to the number of displacement variables " << _ndisp);
-
-  InputParameters params = _factory.getValidParams("StressDivergenceRSphericalTensors");
-  params.set<std::vector<VariableName> >("displacements") = coupled_displacements;
-
-  params.set<bool>("use_displaced_mesh") = getParam<bool>("use_displaced_mesh");
-
-  if (isParamValid("base_name"))
-    params.set<std::string>("base_name") = getParam<std::string>("base_name");
-
-// Check whether this StressDivergenceRSphericalTensors kernel is restricted to certain block?
-  if (isParamValid("block"))
-    params.set<std::vector<SubdomainName> >("block") = getParam<std::vector<SubdomainName> >("block");
-
-  for (unsigned int i = 0; i < _ndisp; ++i)
-  {
-    std::string kernel_name = "TensorMechanicsRSpherical_" + Moose::stringify(i);
-
-    params.set<unsigned int>("component") = i;
-    params.set<NonlinearVariableName>("variable") = displacements[i];
-    if (isParamValid("save_in"))
-      params.set<std::vector<AuxVariableName> >("save_in") = {save_in[i]};
-    if (isParamValid("diag_save_in"))
-      params.set<std::vector<AuxVariableName> >("diag_save_in") = {diag_save_in[i]};
-
-    _problem->addKernel("StressDivergenceRSphericalTensors", kernel_name, params);
-  }
+  mooseDeprecated("Use the 'TensorMechanics' action instead. It autodetects the coordinate system.");
 }

--- a/modules/tensor_mechanics/tests/1D_spherical/smallStrain_1DSphere.i
+++ b/modules/tensor_mechanics/tests/1D_spherical/smallStrain_1DSphere.i
@@ -41,7 +41,7 @@
 []
 
 [Kernels]
-  [./StressDivergence1DRSpherical]
+  [./TensorMechanics]
     use_displaced_mesh = true
     save_in = residual_r
   [../]

--- a/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_finiteStrain_resid.i
+++ b/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_finiteStrain_resid.i
@@ -43,7 +43,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     use_displaced_mesh = true
     save_in = 'force_r force_z'
   [../]

--- a/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_finiteStrain_test.i
+++ b/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_finiteStrain_test.i
@@ -57,7 +57,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     use_displaced_mesh = true
   [../]
 []

--- a/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_test.i
+++ b/modules/tensor_mechanics/tests/2D_geometries/2D-RZ_test.i
@@ -38,7 +38,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     displacements = 'disp_r disp_z'
     use_displaced_mesh = true
   [../]

--- a/modules/tensor_mechanics/tests/isotropic_elasticity_tensor/2D-axisymmetric_rz_test.i
+++ b/modules/tensor_mechanics/tests/isotropic_elasticity_tensor/2D-axisymmetric_rz_test.i
@@ -24,7 +24,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     use_displaced_mesh = true
   [../]
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_2.1.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.1.i
@@ -23,7 +23,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
   [../]
 []
 

--- a/modules/tensor_mechanics/tutorials/basics/part_2.2.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.2.i
@@ -27,7 +27,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
   [../]
 []
 

--- a/modules/tensor_mechanics/tutorials/basics/part_2.3.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.3.i
@@ -27,7 +27,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     use_displaced_mesh = true
   [../]
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_2.4.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.4.i
@@ -27,7 +27,7 @@
 []
 
 [Kernels]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     use_displaced_mesh = true
   [../]
 []

--- a/tutorials/darcy_thermo_mech/step09_mechanics/problems/step9.i
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/problems/step9.i
@@ -57,7 +57,7 @@
     variable = temp
     darcy_pressure = pressure
   [../]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     # This block adds all of the proper Kernels for TensorMechanics in RZ
     use_displaced_mesh = true
     displacements = 'disp_r disp_z'

--- a/tutorials/darcy_thermo_mech/step10_multiapps/problems/step10.i
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/problems/step10.i
@@ -61,7 +61,7 @@
     variable = temp
     darcy_pressure = pressure
   [../]
-  [./StressDivergence2DAxisymmetricRZ]
+  [./TensorMechanics]
     # This block adds all of the proper Kernels for TensorMechanics in RZ
     use_displaced_mesh = true
     displacements = 'disp_r disp_z'


### PR DESCRIPTION
This gets rid of the coordinate system specific actions and thus removes a potential error source and simplifies the syntax.

Closes #7555 
