### PR TITLE
Added an option to the fieldSplit preconditioner

### DIFF
--- a/modules/combined/tests/fieldsplit_contact/2blocks3d.i
+++ b/modules/combined/tests/fieldsplit_contact/2blocks3d.i
@@ -123,6 +123,7 @@
       uncontact_slave    = '2'
       uncontact_displaced = '1'
       blocks              = '1 2'
+      include_all_contact_nodes = 1
       petsc_options_iname = '-ksp_type -ksp_max_it -ksp_rtol -ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -pc_hypre_strong_threshold'
       petsc_options_value = ' preonly 10 1e-4 201                hypre    boomeramg      1                            0.25'
     [../]
@@ -132,6 +133,7 @@
       contact_master   = '3'
       contact_slave    = '2'
       contact_displaced = '1'
+      include_all_contact_nodes = 1
       petsc_options_iname = '-ksp_type -ksp_max_it -pc_type -pc_asm_overlap -sub_pc_type   -pc_factor_levels'
       petsc_options_value = '  preonly 10 asm  1 lu 0'
     [../]

--- a/modules/contact/include/ContactSplit.h
+++ b/modules/contact/include/ContactSplit.h
@@ -35,6 +35,7 @@ class ContactSplit : public Split
   std::vector<std::string>              _uncontact_master;
   std::vector<std::string>              _uncontact_slave;
   std::vector<int>                     _uncontact_displaced;
+  bool _include_all_contact_nodes;
 #endif // defined(LIBMESH_HAVE_PETSC) && !PETSC_VERSION_LESS_THAN(3,3,0)
 };
 

--- a/modules/contact/src/ContactSplit.C
+++ b/modules/contact/src/ContactSplit.C
@@ -27,6 +27,9 @@ InputParameters validParams<ContactSplit>()
   params.addParam<std::vector<std::string> >("uncontact_master", "Master surface list for excluded contacts");
   params.addParam<std::vector<std::string> >("uncontact_slave",  "Slave surface list for excluded contacts");
   params.addParam<std::vector<int> >("uncontact_displaced", "List of indicators whether displaced mesh is used to define excluded contact");
+  // Right now, we consider this as a required parameter.
+  // After some tests from BISON, we will set a default value for this parameter.
+  params.addRequiredParam<bool>("include_all_contact_nodes","Whether to include all nodes on the contact surfaces");
   return params;
 }
 
@@ -37,7 +40,8 @@ ContactSplit::ContactSplit (const InputParameters & params) :
     _contact_displaced(getParam<std::vector<int> >("contact_displaced")),
     _uncontact_master(getParam<std::vector<std::string> >("uncontact_master")),
     _uncontact_slave(getParam<std::vector<std::string> >("uncontact_slave")),
-    _uncontact_displaced(getParam<std::vector<int> >("uncontact_displaced"))
+    _uncontact_displaced(getParam<std::vector<int> >("uncontact_displaced")),
+    _include_all_contact_nodes(getParam<bool >("include_all_contact_nodes"))
 {
   if (_contact_master.size() != _contact_slave.size()) {
     std::ostringstream err;
@@ -165,6 +169,16 @@ ContactSplit::setup(const std::string& prefix)
       }
     }
   }
+
+  // Whether to include all nodes on the contact surfaces
+  // into the contact subsolver
+  opt = dmprefix+"includeAllContactNodes";
+  if (_include_all_contact_nodes)
+    val = "yes";
+  else
+    val = "no";
+  po.inames.push_back(opt);
+  po.values.push_back(val);
   Split::setup(prefix);
 }
 #endif


### PR DESCRIPTION
Added an option, include_all_contact_nodes, in the input file to let users specify whether they want to contain all freedoms on the contact surfaces into the corresponding subsolver. For some problems, this could improve the convergence.

Closes #7559
