### PR TITLE
Destroy the mesh only after the problem using it

### DIFF
--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -60,10 +60,9 @@ ActionWarehouse::clear()
   // destructor) we must guarantee that ActionWarehouse::clear()
   // releases all the resources which have to be released _before_ the
   // _comm object owned by the MooseApp is destroyed.
-  _mesh.reset();
-  _displaced_mesh.reset();
-
   _problem.reset();
+  _displaced_mesh.reset();
+  _mesh.reset();
 }
 
 void

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -73,14 +73,15 @@ OversampleOutput::~OversampleOutput()
   // they are owned by other objects.
   if (_oversample || _change_position)
   {
-    // Delete the mesh and equation system pointers
-    delete _mesh_ptr;
-    delete _es_ptr;
-
     // Delete the mesh functions
     for (unsigned int sys_num=0; sys_num < _mesh_functions.size(); ++sys_num)
       for (unsigned int var_num=0; var_num < _mesh_functions[sys_num].size(); ++var_num)
         delete _mesh_functions[sys_num][var_num];
+
+    // Delete the mesh and equation system pointers, in the correct
+    // order.
+    delete _es_ptr;
+    delete _mesh_ptr;
   }
 }
 


### PR DESCRIPTION
The FEProblem class contains System, DofMap, etc. objects which may
try to perform cleanup on their underlying MeshBase during their own
destructors, so the mesh should continue exist until that destruction
is done.

This should fix the bug noticed in
https://github.com/libMesh/libmesh/pull/1064 and resolve the issue
reported in https://github.com/idaholab/moose/issues/7562

"make test" appears to be working again for me even with the modified libMesh.
