### PR TITLE
Reorder deletions in ~SolutionUserObject

### DIFF
--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -138,22 +138,23 @@ SolutionUserObject::SolutionUserObject(const InputParameters & parameters) :
 
 SolutionUserObject::~SolutionUserObject()
 {
-  delete _es;
-  delete _mesh;
-  delete _serialized_solution;
-  delete _mesh_function;
-
   if (_exodusII_io)
     delete _exodusII_io;
 
-  if (_es2)
-    delete _es2;
+  delete _serialized_solution;
+  delete _mesh_function;
+  delete _es;
 
   if (_mesh_function2)
     delete _mesh_function2;
 
   if (_serialized_solution2)
     delete _serialized_solution2;
+
+  if (_es2)
+    delete _es2;
+
+  delete _mesh;
 }
 
 void


### PR DESCRIPTION
This is hopefully the last instance of the bug described in
https://github.com/idaholab/moose/issues/7562

There's actually another lurking bug in this class, but not one with an equally-trivial solution; I'll fill out a separate issue.
