### PR TITLE
Renamed EigenSystem to MooseEigenSystem

### DIFF
--- a/framework/include/base/FEProblem.h
+++ b/framework/include/base/FEProblem.h
@@ -1246,7 +1246,7 @@ private:
 
   friend class AuxiliarySystem;
   friend class NonlinearSystem;
-  friend class EigenSystem;
+  friend class MooseEigenSystem;
   friend class Resurrector;
   friend class RestartableDataIO;
   friend class Restartable;

--- a/framework/include/base/MooseEigenSystem.h
+++ b/framework/include/base/MooseEigenSystem.h
@@ -17,13 +17,16 @@
 
 #include "NonlinearSystem.h"
 
+// libMesh
+#include "libmesh/eigen_system.h"
+
 class FEProblem;
 
-class EigenSystem : public NonlinearSystem
+class MooseEigenSystem : public NonlinearSystem
 {
 public:
-  EigenSystem(FEProblem & problem, const std::string & name);
-  virtual ~EigenSystem();
+  MooseEigenSystem(FEProblem & problem, const std::string & name);
+  virtual ~MooseEigenSystem();
 
   /**
    * Adds a kernel

--- a/framework/include/executioners/EigenExecutionerBase.h
+++ b/framework/include/executioners/EigenExecutionerBase.h
@@ -19,7 +19,7 @@
 
 // Forward Declarations
 class EigenExecutionerBase;
-class EigenSystem;
+class MooseEigenSystem;
 class FEProblem;
 
 template<>
@@ -123,7 +123,7 @@ protected:
 
   // the fe problem
   FEProblem & _problem;
-  EigenSystem & _eigen_sys;
+  MooseEigenSystem & _eigen_sys;
 
   /// Storage for the eigenvalue computed by the executioner
   Real & _eigenvalue;

--- a/framework/include/kernels/EigenKernel.h
+++ b/framework/include/kernels/EigenKernel.h
@@ -19,7 +19,7 @@
 
 //Forward Declarations
 class EigenKernel;
-class EigenSystem;
+class MooseEigenSystem;
 
 template<>
 InputParameters validParams<EigenKernel>();
@@ -55,7 +55,7 @@ protected:
   bool _eigen;
 
   /// EigenKernel always lives in EigenSystem
-  EigenSystem * _eigen_sys;
+  MooseEigenSystem * _eigen_sys;
 
   /**
    * A pointer to the eigenvalue that is stored in a postprocessor

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -21,7 +21,7 @@
 #include "FEProblem.h"
 #include "Factory.h"
 #include "MooseEnum.h"
-#include "EigenSystem.h"
+#include "MooseEigenSystem.h"
 #include "MooseObjectAction.h"
 #include "MooseMesh.h"
 
@@ -143,7 +143,7 @@ AddVariableAction::addVariable(std::string & var_name)
 
   if (getParam<bool>("eigen"))
   {
-    EigenSystem & esys(static_cast<EigenSystem &>(_problem->getNonlinearSystem()));
+    MooseEigenSystem & esys(static_cast<MooseEigenSystem &>(_problem->getNonlinearSystem()));
     esys.markEigenVariable(var_name);
   }
 }

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -39,7 +39,7 @@
 #include "PetscSupport.h"
 #include "RandomInterface.h"
 #include "RandomData.h"
-#include "EigenSystem.h"
+#include "MooseEigenSystem.h"
 #include "MooseParsedFunction.h"
 #include "MeshChangedInterface.h"
 #include "ComputeJacobianBlocksThread.h"
@@ -111,7 +111,7 @@ FEProblem::FEProblem(const InputParameters & parameters) :
     _dt(declareRestartableData<Real>("dt")),
     _dt_old(declareRestartableData<Real>("dt_old")),
 
-    _nl(getParam<bool>("use_nonlinear") ? *(new NonlinearSystem(*this, "nl0")) : *(new EigenSystem(*this, "nl0"))),
+    _nl(getParam<bool>("use_nonlinear") ? *(new NonlinearSystem(*this, "nl0")) : *(new MooseEigenSystem(*this, "eigen0"))),
     _aux(*this, "aux0"),
     _coupling(Moose::COUPLING_DIAG),
     _cm(NULL),

--- a/framework/src/base/MooseEigenSystem.C
+++ b/framework/src/base/MooseEigenSystem.C
@@ -11,13 +11,13 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
-#include "EigenSystem.h"
+#include "MooseEigenSystem.h"
 
 #include "MaterialData.h"
 #include "Factory.h"
 #include "EigenKernel.h"
 
-EigenSystem::EigenSystem(FEProblem & fe_problem, const std::string & name) :
+MooseEigenSystem::MooseEigenSystem(FEProblem & fe_problem, const std::string & name) :
     NonlinearSystem(fe_problem, name),
     _all_eigen_vars(false),
     _active_on_old(false),
@@ -25,12 +25,12 @@ EigenSystem::EigenSystem(FEProblem & fe_problem, const std::string & name) :
 {
 }
 
-EigenSystem::~EigenSystem()
+MooseEigenSystem::~MooseEigenSystem()
 {
 }
 
 void
-EigenSystem::addKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters)
+MooseEigenSystem::addKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters)
 {
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
@@ -72,13 +72,13 @@ EigenSystem::addKernel(const std::string & kernel_name, const std::string & name
 }
 
 void
-EigenSystem::markEigenVariable(const VariableName & var_name)
+MooseEigenSystem::markEigenVariable(const VariableName & var_name)
 {
   _eigen_var_names.insert(var_name);
 }
 
 void
-EigenSystem::scaleSystemSolution(SYSTEMTAG tag, Real scaling_factor)
+MooseEigenSystem::scaleSystemSolution(SYSTEMTAG tag, Real scaling_factor)
 {
   if (tag==ALL)
   {
@@ -101,7 +101,7 @@ EigenSystem::scaleSystemSolution(SYSTEMTAG tag, Real scaling_factor)
 }
 
 void
-EigenSystem::combineSystemSolution(SYSTEMTAG tag, const std::vector<Real> & coefficients)
+MooseEigenSystem::combineSystemSolution(SYSTEMTAG tag, const std::vector<Real> & coefficients)
 {
   mooseAssert(coefficients.size()>0 && coefficients.size()<=3, "Size error on coefficients");
   if (tag==ALL)
@@ -154,7 +154,7 @@ EigenSystem::combineSystemSolution(SYSTEMTAG tag, const std::vector<Real> & coef
 }
 
 void
-EigenSystem::initSystemSolution(SYSTEMTAG tag, Real v)
+MooseEigenSystem::initSystemSolution(SYSTEMTAG tag, Real v)
 {
   if (tag==ALL)
   {
@@ -177,7 +177,7 @@ EigenSystem::initSystemSolution(SYSTEMTAG tag, Real v)
 }
 
 void
-EigenSystem::initSystemSolutionOld(SYSTEMTAG tag, Real v)
+MooseEigenSystem::initSystemSolutionOld(SYSTEMTAG tag, Real v)
 {
   if (tag==ALL)
   {
@@ -200,27 +200,27 @@ EigenSystem::initSystemSolutionOld(SYSTEMTAG tag, Real v)
 }
 
 void
-EigenSystem::eigenKernelOnOld()
+MooseEigenSystem::eigenKernelOnOld()
 {
   _active_on_old = true;
   _fe_problem.updateActiveObjects();   // update warehouse active objects
 }
 
 void
-EigenSystem::eigenKernelOnCurrent()
+MooseEigenSystem::eigenKernelOnCurrent()
 {
   _active_on_old = false;
   _fe_problem.updateActiveObjects();   // update warehouse active objects
 }
 
 bool
-EigenSystem::activeOnOld()
+MooseEigenSystem::activeOnOld()
 {
   return _active_on_old;
 }
 
 void
-EigenSystem::buildSystemDoFIndices(SYSTEMTAG tag)
+MooseEigenSystem::buildSystemDoFIndices(SYSTEMTAG tag)
 {
   if (tag==ALL)
   {
@@ -245,7 +245,7 @@ EigenSystem::buildSystemDoFIndices(SYSTEMTAG tag)
 }
 
 bool
-EigenSystem::containsEigenKernel() const
+MooseEigenSystem::containsEigenKernel() const
 {
   return _eigen_kernel_counter>0;
 }

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -13,7 +13,7 @@
 /****************************************************************/
 
 #include "EigenKernel.h"
-#include "EigenSystem.h"
+#include "MooseEigenSystem.h"
 #include "MooseApp.h"
 #include "Executioner.h"
 #include "EigenExecutionerBase.h"
@@ -37,7 +37,7 @@ EigenKernel::EigenKernel(const InputParameters & parameters) :
     _u(_is_implicit ? _var.sln() : _var.slnOld()),
     _grad_u(_is_implicit ? _var.gradSln() : _var.gradSlnOld()),
     _eigen(getParam<bool>("eigen")),
-    _eigen_sys(dynamic_cast<EigenSystem *>(&_fe_problem.getNonlinearSystem())),
+    _eigen_sys(dynamic_cast<MooseEigenSystem *>(&_fe_problem.getNonlinearSystem())),
     _eigenvalue(NULL)
 {
   // The name to the postprocessor storing the eigenvalue


### PR DESCRIPTION
There is already a class called EigenSystem in LibMesh. Renamed EigenSystem to MooseEigenSystem
to resolve the name confict because we are going to bring the libmesh EigenSystem into
moose.

Refs #7398
