### PR TITLE
Add Image parsing to Markdown

### DIFF
--- a/docs/content/getting_started/build_libmesh.md
+++ b/docs/content/getting_started/build_libmesh.md
@@ -2,10 +2,10 @@
 ## Compile libMesh
 * MOOSE directly relies on the libMesh finite-element framework. Because of this strong tie MOOSE contains a particular version of libMesh that we have vetted for our users. We will periodically update that version (about once a month) so stay tuned to the MOOSE-users mailing list for those announcements. To pull down and compile this version of libMesh you simply need to run a script in MOOSE:
 
-    <pre>
-    cd ~/projects/moose
-    scripts/update_and_rebuild_libmesh.sh
-    </pre>
+```bash
+cd ~/projects/moose
+scripts/update_and_rebuild_libmesh.sh
+```
 
 !!! Important
      Do not use `sudo` when running update_and_rebuild_libmesh.sh.
@@ -14,11 +14,11 @@
 ## Test It!
 * All that's left is to make sure that everything is working properly...
 
-    <pre>
-    cd ~/projects/moose/test
-    make -j 4
-    ./run_tests -j 4
-    </pre>
+```bash
+cd ~/projects/moose/test
+make -j 4
+./run_tests -j 4
+```
 
 * If everything is good then all of the tests will pass.
 

--- a/docs/content/getting_started/clone_moose.md
+++ b/docs/content/getting_started/clone_moose.md
@@ -2,13 +2,13 @@
 ## Clone MOOSE
 * MOOSE is hosted on GitHub and can be cloned directly from there using Git. We recommend creating a directory named projects to put all of your MOOSE related work in which leads to the following commands (from your home directory):
 
-    <pre>
-    mkdir ~/projects
-    cd ~/projects
-    git clone https://github.com/idaholab/moose.git
-    cd ~/projects/moose
-    git checkout master
-    </pre>
+```bash
+mkdir ~/projects
+cd ~/projects
+git clone https://github.com/idaholab/moose.git
+cd ~/projects/moose
+git checkout master
+```
 
 !!! note
     The master branch of MOOSE is the stable branch that will only be updated after all tests are passing. This protects you from the day-to-day churn in the MOOSE repository

--- a/docs/content/getting_started/conclusion.md
+++ b/docs/content/getting_started/conclusion.md
@@ -17,11 +17,11 @@
 
 * Update your copy of MOOSE for the latest features and fixes.
 
-    <pre>
-    cd ~/projects/moose
-    git fetch origin
-    git rebase origin/master
-    </pre>
+```bash
+cd ~/projects/moose
+git fetch origin
+git rebase origin/master
+```
 
 ---
 ## Create an App

--- a/docs/content/moose_tools/memory_logger.md
+++ b/docs/content/moose_tools/memory_logger.md
@@ -194,7 +194,7 @@ Date Stamp                 Memory Usage | Percent of MAX memory used: ( 264,256 
 Okay... A bit too accurate, as several samples remained unchanged during tracking. However sometimes more is desirable, though just not printed in this fashion. For data dumps like this, using Matplotlib is far more efficient.
 
 ## Using Matplotlib
-!image memory_logger-plot_multi.png width=300 align=right
+!image memory_logger-plot_multi.png width=300 float=right
 
 We can visualize the results by plotting the data with Matplotlib:
 ```text
@@ -233,7 +233,7 @@ You can also display stdout along the Matplotlib graph:
 ```text
 memory_logger.py --pstack --stdout --plot simple_diffusion_memory.log
 ```
-!image memory_logger-darkmode.png width=300 align=right
+!image memory_logger-darkmode.png width=300 float=right
 
 That white back ground to bright for you? Try dark mode:
 ```text

--- a/docs/content/moose_tools/memory_logger.md
+++ b/docs/content/moose_tools/memory_logger.md
@@ -1,5 +1,5 @@
 # Memory Logger
-Memory Logger is a simple tool for gathering information about a running process. Such things as memory usage, stdout and stack traces can be sampled, either on a single process or on multiple nodes in a job scheduling environment. Currently PBS is the only job scheduling system supported. memory_logger.py is located in the moose/scripts directory.
+Memory Logger is a simple tool for gathering information about a running process. Such things as memory usage, stdout and stack traces can be sampled, either on a single process or on multiple nodes in a job scheduling environment. Currently PBS is the only job scheduling system supported.
 
 ## Basic usage
 In its simplest use case scenario, you encapsulate the command you would normally run with out Memory Logger as an argument to Memory Logger:
@@ -194,15 +194,16 @@ Date Stamp                 Memory Usage | Percent of MAX memory used: ( 264,256 
 Okay... A bit too accurate, as several samples remained unchanged during tracking. However sometimes more is desirable, though just not printed in this fashion. For data dumps like this, using Matplotlib is far more efficient.
 
 ## Using Matplotlib
-<img width="300" src="../../../media/memory_logger-plot_multi.png">
+!image memory_logger-plot_multi.png width=300 align=right
 
-We can visualize the results by plotting the data with Matplotlib. In the following sample we load up two results for a side-by-side comparison. You can load as many samples as you like in this fashion:
+We can visualize the results by plotting the data with Matplotlib:
 ```text
 memory_logger.py --plot simple_diffusion-r4_memory.log simple_diffusion-r6_repeat-rate0.01_memory.log
 ```
+We can render multiple logs simultaneously to allow an easy comparison.
 
 ## Tracking PBS jobs
-Memory Logger has the ability to track your processes across multiple nodes. In order for this to work correctly, we must launch Memory Logger within an interactive job (qsub -I) while providing the --pbs argument.
+Memory Logger has the ability to track your processes across multiple nodes. In order for this to work correctly, we must launch an interactive job (qsub -I). The reason for this, is we can not have PBS launch a bunch of memory_loggers all in the same fashion... Instead we need one memory_logger, acting as the server, while a bunch of others acting as agents gathering data. The only thing we need to do is provide the --pbs argument.
 
 ```text
 headnode #> qsub -I
@@ -210,7 +211,7 @@ headnode #> qsub -I
 node #> memory_logger.py --pbs \
 --run "mpiexec /absolute/path/to/moose_test-opt -i simple_diffusion.i -r 5"
 ```
-When Memory Logger encounters a --pbs argument, it will look at the contents of your $PBS_NODEFILE and determine what other machines will be used to process your job. Memory Logger will remote into these machines (using SSH), and launch its own memory_logger process, instructing it how to communicate back to the original memory_logger you launched interactively.
+When Memory Logger encounters a --pbs argument, it will look at the contents of your $PBS_NODEFILE, to determine what other machines will be used to process your job. Memory Logger will remote into these machines (SSH), and launch its own memory_logger process, instructing it, how to communicate back to the original memory_logger you launched interactively.
 
 
 ## Stack Traces, Dark Mode and other cool things
@@ -219,25 +220,24 @@ Obtaining stack traces while tracking memory usage on a single machine or across
 memory_logger.py --pstack --debugger gdb \
 --run "mpiexec /absolute/path/to/moose_test-opt -i simple_diffusion.i -r 5"
 ```
-!!! Info
-    While both LLDB and GDB are supported, GDB is many times quicker at gathering stack traces.
-
 The --pstack argument is used for both tracking and plotting. It tells Memory Logger to actually display stack trace information (if available in the log file).
 ```text
 memory_logger.py --pstack --plot simple_diffusion_memory.log
 ```
-Stack traces are represented in the form of points along the line graph. Clicking on these dots will cause memory_logger.py to print the actual stack trace gleamed at the time to stdout. However, if you choose to display all this junk on the terminal, you can with --read:
+Stack traces are represented in the form of points along the Matplotlib line graph. Clicking on these dots will cause memory_logger.py to print the actual stack trace gleamed at that time to stdout. However, if you choose to display all this junk on the terminal, you can with --read:
 ```text
 memory_logger.py --pstack --read simple_diffusion_memory.log
+<not going to paste this data here. I am telling ya, its pages and pages>
 ```
-You can also display stdout along the plotted graph:
+You can also display stdout along the Matplotlib graph:
 ```text
 memory_logger.py --pstack --stdout --plot simple_diffusion_memory.log
 ```
+!image memory_logger-darkmode.png width=300 align=right
+
 That white back ground to bright for you? Try dark mode:
 ```text
 memory_logger.py --pstack \
 --darkmode \
 --plot simple_diffusion-r4_memory.log simple_diffusion-r6_repeat-rate0.01_memory.log
 ```
-<img width="300" src="../../../media/memory_logger-darkmode.png">

--- a/docs/content/utilities/documentation/create.md
+++ b/docs/content/utilities/documentation/create.md
@@ -27,7 +27,7 @@ of the `InputParameters` object. For example, in the [FunctionIC](../systems/fra
 the following parameter documentation is added, which is then present in the parameter summary table of the
 generated site.
 
-![](framework/src/ics/FunctionIC.C line=addRequiredParam)
+!text framework/src/ics/FunctionIC.C line=addRequiredParam
 
 The string supplied in this function will appear in the parameter tables within the documentation that is generated.
 For example, see the parameter table for the [DirichletBC object](/BCs/DirichletBC.md).
@@ -36,7 +36,7 @@ Secondly, a short description should be supplied in each `addParam`, `addPrivate
 example, in the [Diffusion](/Kernels/Diffusion.md) object the following class
 description.
 
-![](framework/src/kernels/Diffusion.C line=addClassDescription)
+!text framework/src/kernels/Diffusion.C line=addClassDescription
 
 When the documentation for this object is generated this string is added to the first portion of the page and the
 system overview table. For example, the [Kernels overview](/Kernels/Overview.md) includes a table with each object
@@ -82,7 +82,7 @@ The include option contains the information that indicates what documentation sh
 the MOOSE documentation the following is contained within this option to build the documentation from the framework itself
 as well as the phase field module.
 
-![](docs/moosedocs.yml start=include end=contact:)
+!text docs/moosedocs.yml start=include end=contact:
 
 The names provided in the sub-sections (i.e., "framework" and "phase_field") are arbitrary. All of the options listed
 in the table above may be used within each of the sub-sections to taylor the generation of the pages as needed to
@@ -97,7 +97,7 @@ the docs directory. The information within this file mimics the [mkdocs pages](h
 configuration, with one exception: it is possible to include other markdown files. For example, the "pages.yml" for
 the MOOSE website includes the following.
 
-![](docs/pages.yml)
+!text docs/pages.yml
 
 Notice, that the framework and the modules each have include statements pointing to another "pages.yml" file. This
 file is generated for each item in the "include" setting discussed above and is placed in the "install" directory.
@@ -115,7 +115,7 @@ The [mkdocs] uses the python [markdown](http://pythonhosted.org/Markdown/) packa
 necessary functionality. This custom extension is located in `python/MooseDocs/extensions/MooseMarkdown.py` and includes
 three configuration options, which are set as done in the `mkdocs.yml` file.
 
-![](docs/mkdocs.yml start=markdown_extensions)
+!text docs/mkdocs.yml start=markdown_extensions
 
 | Option | Description |
 | ------ | ----------- |

--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -173,3 +173,12 @@ A full slideshow example might be:
     images/other*.png caption=Other images
     images/more*.png
 ```
+
+## Images
+You can include images in your documentation by use of the !image markdown syntax:
+
+```markdown
+!image memory_logger-plot_multi.png width=300 align=right caption=figure 1
+```
+!image memory_logger-plot_multi.png width=300 align=right caption=figure 1
+

--- a/docs/css/moose.css
+++ b/docs/css/moose.css
@@ -1,35 +1,62 @@
+.admonition-title {
+    margin: -15px;
+    font-weight: bold;
+    display: block;
+    padding: 6px 12px;
+    color: #fff;
+    margin-bottom: 12px;
+    border: 0px solid transparent;
+}
+.info .admonition-title {
+    background: #528452;
+}
 .admonition.info {
-  color: #186a3b;
-  background-color: #82e0aa;
-  border-color: #82e0aa;
+    background: #82e0aa;
+    color: #000;
+    border: 0px solid transparent;
 }
 
+.note .admonition-title {
+    background: #3a7296;
+}
 .admonition.note {
-  color: #1b4f72 ;
-  background-color: #85c1e9;
-  border-color: #85c1e9;
+    background: #85c1e9;
+    color: #000;
+    border: 0px solid transparent;
 }
 
+.important .admonition-title {
+    background: #b100b0;
+}
 .admonition.important {
-    color: #000000;
-    background-color: #FF00FF;
-    border-color: #FF00FF;
+    background: #FF00FF;
+    color: #000;
+    border: 0px solid transparent;
 }
 
+.warning .admonition-title {
+    background: #968b2b;
+}
 .admonition.warning {
-    color: #9c640c;
-    background-color: #fff9c4;
-    border-color: #fff9c4
+    background: #ffec46;
+    color: #000;
+    border: 0px solid transparent;
 }
 
+.danger .admonition-title {
+    background: #b14d00;
+}
 .admonition.danger {
-    color: #6e2c00;
-    background-color: #ffb74d;
-    border-color: #ffb74d;
+    background: #f75e1d;
+    color: #000;
+    border: 0px solid transparent;
 }
 
+.error .admonition-title {
+    background: #940000;
+}
 .admonition.error {
-    color: #000000;
-    background-color: #ff0000;
-    border-color: #ff0000;
+    background: #ffb4b4;
+    color: #000;
+    border: 0px solid transparent;
 }

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,6 +2,8 @@ site_name: MOOSE
 
 docs_dir: .
 
+media_dir: ../media
+
 site_dir: ../site
 
 repo_url: https://github.com/idaholab/moose/

--- a/python/MooseDocs/extensions/MooseCarousel.py
+++ b/python/MooseDocs/extensions/MooseCarousel.py
@@ -19,29 +19,9 @@ class MooseCarousel(BlockProcessor, MooseCommonExtension):
     """
 
     RE = re.compile(r'^!\ ?slideshow(.*)')
-    SETTINGS_RE = re.compile("([^\s=]+)=(.*?)(?=(?:\s[^\s=]+=|$))")
     # If there are multiple carousels on the same page then
     # they need to have different ids
     MATCHES_FOUND = 0
-
-    def parseOptions(self, settings_line):
-      """
-      Parses a string of space seperated key=value pairs.
-      This supports having values with spaces in them.
-      So something like "key0=foo bar key1=value1"
-      is supported.
-      Input:
-        settings_line[str]: Line to parse
-      Returns:
-        dict of values that were parsed
-      """
-      matches = self.SETTINGS_RE.findall(settings_line.strip())
-      if not matches:
-        return {}
-      options = {}
-      for entry in matches:
-        options[entry[0].strip()] = entry[1].strip()
-      return options
 
     def parseFilenames(self, filenames_block):
       """
@@ -97,7 +77,7 @@ class MooseCarousel(BlockProcessor, MooseCommonExtension):
       if m:
         # Parse out the options on the slideshow line
         options = m.group(1)
-        parsed_options = self.parseOptions(options)
+        parsed_options = self.getSettings(options)
         block = block[m.end() + 1:] # removes the slideshow line
 
       block, theRest = self.detab(block)

--- a/python/MooseDocs/extensions/MooseImageFile.py
+++ b/python/MooseDocs/extensions/MooseImageFile.py
@@ -1,0 +1,98 @@
+import re
+import os
+from markdown.util import etree
+import logging
+log = logging.getLogger(__name__)
+
+import MooseDocs
+from markdown.inlinepatterns import Pattern
+from MooseCommonExtension import MooseCommonExtension
+import utils
+
+class MooseImageFile(MooseCommonExtension, Pattern):
+    """
+    Markdown extension for handling images.
+
+    Usage:
+      !image image_file.png|jpg|etc attribute=setting
+
+    All images/media should be stored in docs/media
+    """
+
+    # Find !image /path/to/file attribute=setting
+    RE = r'^!\ ?image\s+(.*?)\s+(.*)'
+
+    def __init__(self, media_dir=None, root=None, **kwargs):
+        MooseCommonExtension.__init__(self)
+        Pattern.__init__(self, self.RE, **kwargs)
+
+        self._root = os.path.join(root, media_dir)
+
+        # The default settings
+        self._settings = {'alt'     : None,
+                          'caption' : None,
+                          'width'   : None,
+                          'height'  : None,
+                          'float'   : None,
+                          'align'   : 'left'}
+
+
+
+    def handleMatch(self, match):
+        """
+        process settings associated with !image markdown
+        """
+
+        rel_filename = match.group(2)
+
+        # Perform second regex to capture key=value pairs with
+        # possible spaces in the value
+        settings = self.getSettings(match.group(3))
+
+        # Read the file and create element
+        filename = self.checkFilename(rel_filename)
+
+        if not filename:
+            print '{}'.format(rel_filename)
+            el = self.createErrorElement(rel_filename, message='file not found')
+        else:
+            # Use the more friendly term 'caption' within markdown, but make
+            # the HTML tag attribute 'alt' correction
+            if settings['caption'] != None:
+                settings['alt'] = settings['caption']
+
+            # When aligning to one side or another, we need to adjust the margins
+            # on the opisite side... silly looking buy necessary
+            reverse_margin = { 'left' : 'right',
+                               'right' : 'left',
+                               'None' : 'none'}
+
+            el_list = {}
+            el_list['div'] = etree.Element('div')
+            el_list['figure'] = etree.SubElement(el_list['div'], 'figure')
+            el_list['img'] = etree.SubElement(el_list['figure'], 'img')
+            el_list['img'].set('src', os.path.join('/media', os.path.basename(filename)))
+
+            # Set the default figcaption text alignment
+            el_list['figure'].set('style', 'text-align: left; display: table;')
+
+            # Set any extra supplied attributes
+            for attribute in settings.keys():
+                if attribute == 'align':
+                    el_list['div'].set('style', 'text-align: -moz-{}; text-align: -webkit-{};'.format(settings[attribute], settings[attribute]))
+                elif attribute == 'float' and settings[attribute] is not None:
+                    el_list['figure'].set('style', el_list['figure'].get('style') + \
+                                          'float: {}; margin-{}: 20px'.format(settings[attribute], reverse_margin[settings[attribute]]))
+                elif settings[attribute] != None:
+                    el_list['img'].set(attribute, str(settings[attribute]))
+
+            # if caption/alt set, add figcaption
+            if settings['alt'] != None:
+                # Unset the large default bottom-margin for figcaption
+                el_list['img'].set('style', 'margin-bottom: unset;')
+                el_list['figcaption'] = etree.SubElement(el_list['figure'], 'figcaption')
+                el_list['figcaption'].text = settings['alt']
+
+            el = el_list['div']
+
+        return el

--- a/python/MooseDocs/extensions/MooseMarkdown.py
+++ b/python/MooseDocs/extensions/MooseMarkdown.py
@@ -3,6 +3,7 @@ import subprocess
 import markdown
 
 from MooseTextFile import MooseTextFile
+from MooseImageFile import MooseImageFile
 from MooseInputBlock import MooseInputBlock
 from MooseCppMethod import MooseCppMethod
 from MoosePackageParser import MoosePackageParser
@@ -28,6 +29,7 @@ class MooseMarkdown(markdown.Extension):
         self.config['make'] = [root, "The location of the Makefile responsible for building the application."]
         self.config['repo'] = ['', "The remote repository to create hyperlinks."]
         self.config['docs_dir'] = [os.path.join('docs', 'content'), "The location of the markdown to be used for generating the site."]
+        self.config['media_dir'] = [os.path.join('docs', 'media'), "The location of the media files to be used for generating the site."]
         self.config['slides'] = [False, "Enable the parsing for creating reveal.js slides."]
         self.config['package'] = [False, "Enable the use of the MoosePackageParser."]
 
@@ -58,7 +60,8 @@ class MooseMarkdown(markdown.Extension):
         # Inline Patterns
         md.inlinePatterns.add('moose_input_block', MooseInputBlock(markdown_instance=md, repo=config['repo'], root=config['root']), '<image_link')
         md.inlinePatterns.add('moose_cpp_method', MooseCppMethod(markdown_instance=md, make=config['make'], repo=config['repo'], root=config['root']), '<image_link')
-        md.inlinePatterns.add('moose_source', MooseTextFile(markdown_instance=md, repo=config['repo'], root=config['root']), '<image_link')
+        md.inlinePatterns.add('moose_text', MooseTextFile(markdown_instance=md, repo=config['repo'], root=config['root']), '<image_link')
+        md.inlinePatterns.add('moose_image', MooseImageFile(markdown_instance=md, media_dir=config['media_dir'], root=config['root']), '<image_link')
 
         if config['package']:
             md.inlinePatterns.add('moose_package_parser', MoosePackageParser(markdown_instance=md), '_end')

--- a/python/MooseDocs/extensions/MoosePackageParser.py
+++ b/python/MooseDocs/extensions/MoosePackageParser.py
@@ -14,11 +14,11 @@ class MoosePackageParser(MooseCommonExtension, Pattern):
     Markdown extension for extracting package arch and version.
     """
 
-    CPP_RE = r'!MOOSEPACKAGE\s*(.*?)!'
+    RE = r'!MOOSEPACKAGE\s*(.*?)!'
 
     def __init__(self, **kwargs):
         MooseCommonExtension.__init__(self)
-        Pattern.__init__(self, self.CPP_RE, **kwargs)
+        Pattern.__init__(self, self.RE, **kwargs)
 
         # Load the yaml data containing package information
         self.package = MooseDocs.yaml_load("packages.yml")

--- a/python/MooseDocs/extensions/MooseTextPatternBase.py
+++ b/python/MooseDocs/extensions/MooseTextPatternBase.py
@@ -74,19 +74,6 @@ class MooseTextPatternBase(MooseCommonExtension, Pattern):
 
         return content.strip()
 
-    def checkFilename(self, rel_filename):
-        """
-        Checks that the filename exists, if it does not a error Element is return.
-
-        Args:
-            filename[str]: The filename to check for existence.
-        """
-
-        filename = os.path.abspath(os.path.join(self._root, rel_filename))
-        if os.path.exists(filename):
-            return filename
-        return None
-
     def createElement(self, label, content, filename, rel_filename, settings):
         """
         Create the code element from the supplied source code content.


### PR DESCRIPTION
Adding support for image markdown.
Images were already supported but we will now have more functionality.

@brianmoose  Not sure how to check to see if I broke anything, because of what I am attempting to do: Moved option parser from MooseCarousel to MooseCommon, as we will be using it from multiple extensions.

Refs #7646
