### PR TITLE
ContactSlipDamper output fix. Issue #7664.

### DIFF
--- a/modules/contact/src/ContactSlipDamper.C
+++ b/modules/contact/src/ContactSlipDamper.C
@@ -186,15 +186,15 @@ ContactSlipDamper::computeDamping(const NumericVector<Number> & solution,
         }
       }
     }
-    _console << std::flush;
-    _communicator.sum(_num_contact_nodes);
-    _communicator.sum(_num_sticking);
-    _communicator.sum(_num_slipping);
-    _communicator.sum(_num_slipping_friction);
-    _communicator.sum(_num_stick_locked);
-    _communicator.sum(_num_slip_reversed);
-    _communicator.min(damping);
   }
+  _console << std::flush;
+  _communicator.sum(_num_contact_nodes);
+  _communicator.sum(_num_sticking);
+  _communicator.sum(_num_slipping);
+  _communicator.sum(_num_slipping_friction);
+  _communicator.sum(_num_stick_locked);
+  _communicator.sum(_num_slip_reversed);
+  _communicator.min(damping);
 
   _console << "   ContactSlipDamper: Damping     #Cont    #Stick     #Slip #SlipFric #StickLock  #SlipRev\n";
 


### PR DESCRIPTION
Moved lines accumulating contact slip damper status variables out of loop on interactions. Fixes issue with wrong values being reported when running large models in parallel.  @bwspenc

Closes #7664.
