### PR TITLE
Illustrates the Impossible problem of cutting dt from Materials

### DIFF
--- a/modules/tensor_mechanics/include/materials/ComputeLinearElasticStress_CUT_DT.h
+++ b/modules/tensor_mechanics/include/materials/ComputeLinearElasticStress_CUT_DT.h
@@ -1,0 +1,27 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef COMPUTELINEARELASTICSTRESS_CUT_DT_H
+#define COMPUTELINEARELASTICSTRESS_CUT_DT_H
+
+#include "ComputeStressBase.h"
+
+/**
+ * ComputeLinearElasticStress_CUT_DT computes the stress following linear elasticity theory (small strains)
+ */
+class ComputeLinearElasticStress_CUT_DT : public ComputeStressBase
+{
+public:
+  ComputeLinearElasticStress_CUT_DT(const InputParameters & parameters);
+  virtual void initialSetup();
+
+protected:
+  virtual void computeQpStress();
+
+  const MaterialProperty<RankTwoTensor> & _mechanical_strain;
+};
+
+#endif //COMPUTELINEARELASTICSTRESS_CUT_DT_H

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -58,6 +58,7 @@
 #include "ComputeAxisymmetricRZFiniteStrain.h"
 #include "ComputeRSphericalFiniteStrain.h"
 #include "ComputeLinearElasticStress.h"
+#include "ComputeLinearElasticStress_CUT_DT.h"
 #include "ComputeFiniteStrainElasticStress.h"
 #include "ComputeEigenstrain.h"
 #include "ComputeVariableBaseEigenStrain.h"
@@ -225,6 +226,7 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerMaterial(ComputeAxisymmetricRZFiniteStrain);
   registerMaterial(ComputeRSphericalFiniteStrain);
   registerMaterial(ComputeLinearElasticStress);
+  registerMaterial(ComputeLinearElasticStress_CUT_DT);
   registerMaterial(ComputeFiniteStrainElasticStress);
   registerMaterial(ComputeEigenstrain);
   registerMaterial(ComputeVariableBaseEigenStrain);

--- a/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress_CUT_DT.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress_CUT_DT.C
@@ -1,0 +1,45 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#include "ComputeLinearElasticStress_CUT_DT.h"
+
+template<>
+InputParameters validParams<ComputeLinearElasticStress_CUT_DT>()
+{
+  InputParameters params = validParams<ComputeStressBase>();
+  params.addClassDescription("Compute stress using elasticity for small strains");
+  return params;
+}
+
+ComputeLinearElasticStress_CUT_DT::ComputeLinearElasticStress_CUT_DT(const InputParameters & parameters) :
+    ComputeStressBase(parameters),
+    _mechanical_strain(getMaterialPropertyByName<RankTwoTensor>(_base_name + "mechanical_strain"))
+{
+}
+
+void
+ComputeLinearElasticStress_CUT_DT::initialSetup()
+{
+  if (hasMaterialProperty<RankTwoTensor>(_base_name + "strain_increment"))
+    mooseError("This linear elastic stress calculation only works for small strains");
+}
+
+void
+ComputeLinearElasticStress_CUT_DT::computeQpStress()
+{
+  // stress = C * e
+  _stress[_qp] = _elasticity_tensor[_qp] * _mechanical_strain[_qp];
+
+  if (_stress[_qp](1, 1) > 1) {
+    throw MooseException("Wooops, stress is too big!");
+  }
+
+  // Assign value for elastic strain, which is equal to the mechanical strain
+  _elastic_strain[_qp] = _mechanical_strain[_qp];
+
+  // Compute dstress_dstrain
+  _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
+}

--- a/modules/tensor_mechanics/tests/gravity/push.i
+++ b/modules/tensor_mechanics/tests/gravity/push.i
@@ -1,0 +1,97 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+  [../]
+[]
+
+[BCs]
+  [./no_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = bottom
+    value = 0.0
+  [../]
+  [./no_y]
+    type = DirichletBC
+    variable = disp_y
+    boundary = bottom
+    value = 0.0
+  [../]
+  [./no_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = bottom
+    value = 0.0
+  [../]
+  [./top_move]
+    type = FunctionPresetBC
+    variable = disp_y
+    function = t
+    boundary = top
+  [../]
+[]
+
+[AuxVariables]
+  [./stress_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./stress_yy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    index_i = 1
+    index_j = 1
+    variable = stress_yy
+  [../]
+[]
+
+[Materials]
+  [./Elasticity_tensor]
+    type = ComputeElasticityTensor
+    fill_method = symmetric_isotropic
+    C_ijkl = '0 1'
+  [../]
+  [./strain]
+    type = ComputeSmallStrain
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress_CUT_DT
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Transient
+  solve_type = NEWTON
+  nl_abs_tol = 1e-10
+  l_max_its = 20
+  dt = 0.4
+  end_time = 0.8
+[]
+
+[Outputs]
+  [./out]
+    type = Exodus
+  [../]
+[]
+


### PR DESCRIPTION
This illustrates the Impossible error experienced by myself and others.  A Material calls

throw MooseExcecption("Something happened, dt needs to be reduced")

and MOOSE responds with Impossible.  Could someone take the time to fix this bug, please?

In this case, the material is ComputeLinearElasticStress_CUT_DT, that attempts to cut the timestep if stress(1, 1) > 1.
The test file that may be used to obtain the 'Impossible' error is push.i

Refs #3789
