### PR TITLE
Removes call to sort on global list of execute objects in warehouse.

### DIFF
--- a/framework/include/base/ExecuteMooseObjectWarehouse.h
+++ b/framework/include/base/ExecuteMooseObjectWarehouse.h
@@ -21,6 +21,9 @@
 
 /**
  * A class for storing MooseObjects based on execution flag.
+ *
+ * Note: The global list of objects, those accessed via the "get" methods of this class, are not sorted when the
+ *       sort method is called. This is because cyclic errors occur even when the execution flags differ.
  */
 template<typename T>
 class ExecuteMooseObjectWarehouse : public MooseObjectWarehouse<T>
@@ -84,6 +87,7 @@ public:
 
   /**
    * Performs a sort using the DependencyResolver.
+   * @param tid The thread id to access.
    */
   void sort(THREAD_ID tid = 0);
 
@@ -233,9 +237,6 @@ template<typename T>
 void
 ExecuteMooseObjectWarehouse<T>::sort(THREAD_ID tid/* = 0*/)
 {
-  // Sort all objects
-  MooseObjectWarehouse<T>::sort(tid);
-
   // Sort execute object storage
   typename std::map<ExecFlagType, MooseObjectWarehouse<T> >::iterator iter;
   for (iter = _execute_objects.begin(); iter != _execute_objects.end(); ++iter)

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -2004,8 +2004,11 @@ FEProblem::reinitMaterials(SubdomainID blk_id, THREAD_ID tid, bool swap_stateful
     if (_discrete_materials.hasActiveBlockObjects(blk_id, tid))
       _material_data[tid]->reset(_discrete_materials.getActiveBlockObjects(blk_id, tid));
 
-    if (_materials.hasActiveBlockObjects(blk_id, tid))
-      _material_data[tid]->reinit(_materials.getActiveBlockObjects(blk_id, tid));
+    for (auto map_iter = _materials.begin(); map_iter != _materials.end(); ++map_iter)
+    {
+      if (map_iter->second.hasActiveBlockObjects(blk_id, tid))
+        _material_data[tid]->reinit(map_iter->second.getActiveBlockObjects(blk_id, tid));
+    }
   }
 }
 
@@ -2027,8 +2030,11 @@ FEProblem::reinitMaterialsFace(SubdomainID blk_id, THREAD_ID tid, bool swap_stat
     if (_discrete_materials[Moose::FACE_MATERIAL_DATA].hasActiveBlockObjects(blk_id, tid))
       _bnd_material_data[tid]->reset(_discrete_materials[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(blk_id, tid));
 
-    if (_materials[Moose::FACE_MATERIAL_DATA].hasActiveBlockObjects(blk_id, tid))
-      _bnd_material_data[tid]->reinit(_materials[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(blk_id, tid));
+    for (auto map_iter = _materials[Moose::FACE_MATERIAL_DATA].begin(); map_iter != _materials[Moose::FACE_MATERIAL_DATA].end(); ++map_iter)
+    {
+      if (map_iter->second.hasActiveBlockObjects(blk_id, tid))
+        _bnd_material_data[tid]->reinit(map_iter->second.getActiveBlockObjects(blk_id, tid));
+    }
   }
 }
 
@@ -2051,8 +2057,11 @@ FEProblem::reinitMaterialsNeighbor(SubdomainID blk_id, THREAD_ID tid, bool swap_
     if (_discrete_materials[Moose::NEIGHBOR_MATERIAL_DATA].hasActiveBlockObjects(blk_id, tid))
       _neighbor_material_data[tid]->reset(_discrete_materials[Moose::NEIGHBOR_MATERIAL_DATA].getActiveBlockObjects(blk_id, tid));
 
-    if (_materials[Moose::NEIGHBOR_MATERIAL_DATA].hasActiveBlockObjects(blk_id, tid))
-      _neighbor_material_data[tid]->reinit(_materials[Moose::NEIGHBOR_MATERIAL_DATA].getActiveBlockObjects(blk_id, tid));
+    for (auto map_iter = _materials[Moose::NEIGHBOR_MATERIAL_DATA].begin(); map_iter != _materials[Moose::NEIGHBOR_MATERIAL_DATA].end(); ++map_iter)
+    {
+      if (map_iter->second.hasActiveBlockObjects(blk_id, tid))
+        _neighbor_material_data[tid]->reinit(map_iter->second.getActiveBlockObjects(blk_id, tid));
+    }
   }
 }
 

--- a/test/tests/auxkernels/execute_on_cyclic/execute_on_cyclic.i
+++ b/test/tests/auxkernels/execute_on_cyclic/execute_on_cyclic.i
@@ -1,0 +1,74 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[AuxVariables]
+  [./aux0]
+  [../]
+  [./aux1]
+  [../]
+[]
+
+[AuxKernels]
+  [./aux0]
+    type = CoupledAux
+    variable = aux0
+    coupled = aux1
+    execute_on = linear
+  [../]
+  [./aux1]
+    type = CoupledAux
+    variable = aux1
+    coupled = aux0
+    execute_on = timestep_end
+  [../]
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Transient
+  num_steps = 20
+  dt = 0.1
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/auxkernels/execute_on_cyclic/tests
+++ b/test/tests/auxkernels/execute_on_cyclic/tests
@@ -1,0 +1,8 @@
+[Tests]
+  [./run]
+    # This makes sure that cyclic dependency errors are not triggered for objects that depend on each other but have
+    # differing execution flags.
+    type = RunApp
+    input = execute_on_cyclic.i
+  [../]
+[]


### PR DESCRIPTION
This eliminates false cyclic dependency errors when objects depend on each other but have differing execution flags.
(closes #7626)
