### PR TITLE
Add support for multiple source directories

### DIFF
--- a/python/MooseDocs/MooseApplicationSyntax.py
+++ b/python/MooseDocs/MooseApplicationSyntax.py
@@ -20,11 +20,11 @@ class MooseApplicationSyntax(object):
 
     Args:
         yaml[MooseYaml]: The MooseYaml object obtained by running the application with --yaml option.
-        path[str]: Valid source directory to extract syntax.
+        path[str|list]: Valid source directory to extract syntax.
     """
 
 
-    def __init__(self, yaml_data, path):
+    def __init__(self, yaml_data, paths):
 
         # The databases containing the system/object/markdown/source information for this directory
         self._yaml_data = yaml_data
@@ -33,11 +33,16 @@ class MooseApplicationSyntax(object):
         self._filenames = dict()
         self._syntax = set()
 
+        # Path should be a list of directories
+        if not isinstance(paths, list):
+            paths = [paths]
+
         # Update the syntax maps
-        if (not path) or (not os.path.exists(path)):
-            log.critical("Unknown source directory supplied: {}".format(os.path.abspath(path)))
-            raise IOError(os.path.abspath(path))
-        self._updateSyntax(path)
+        for path in paths:
+            if (not path) or (not os.path.exists(path)):
+                log.critical("Unknown source directory supplied: {}".format(os.path.abspath(path)))
+                raise IOError(os.path.abspath(path))
+            self._updateSyntax(path)
 
         for s in self._syntax:
             nodes = self._yaml_data[s]

--- a/python/MooseDocs/MooseObjectInformation.py
+++ b/python/MooseDocs/MooseObjectInformation.py
@@ -104,7 +104,7 @@ class MooseObjectInformation(MooseInformationBase):
         # The class description
         if not self._description:
             log.error('Class description does not exist: {}'.format(self._details))
-            md += ['\n\n!!! danger "ERROR!"\n{}The class description for the {} object does not exist.\n\n'.format(4*' ', self._details)]
+            md += ['\n\n!!! error "ERROR!"\n{}The class description for the {} object does not exist.\n\n'.format(4*' ', self._details)]
         else:
             md += [self._description]
         md += ['']
@@ -112,7 +112,7 @@ class MooseObjectInformation(MooseInformationBase):
         # The details
         if not os.path.exists(self._details):
             log.error('Details file does not exist: {}'.format(self._details))
-            md += ['\n\n!!! danger "ERROR!"\n{}The details file does not exist: `{}`\n\n'.format(4*' ', self._details)]
+            md += ['\n\n!!! error "ERROR!"\n{}The details file does not exist: `{}`\n\n'.format(4*' ', self._details)]
         else:
             md += ['{{!{}!}}'.format(self._details)]
         md += ['']

--- a/python/MooseDocs/MooseSystemInformation.py
+++ b/python/MooseDocs/MooseSystemInformation.py
@@ -36,7 +36,7 @@ class MooseSystemInformation(MooseInformationBase):
         # The details
         if not os.path.exists(self._details):
             log.error('Details file does not exist: {}'.format(self._details))
-            md += ['\n\n!!! danger "ERROR!"\n{}The details file does not exist: `{}`\n\n'.format(4*' ', self._details)]
+            md += ['\n\n!!! error "ERROR!"\n{}The details file does not exist: `{}`\n\n'.format(4*' ', self._details)]
         else:
             md += ['{{!{}!}}'.format(self._details)]
         md += ['']


### PR DESCRIPTION
This allows for include/src directories or other directories to be searched, thus allowing for submodule documentation to be ignored as well

(refs #6699)
