### PR TITLE
Moose mesh const

### DIFF
--- a/framework/include/constraints/NodeFaceConstraint.h
+++ b/framework/include/constraints/NodeFaceConstraint.h
@@ -197,7 +197,7 @@ protected:
   /// DOF map
   const DofMap & _dof_map;
 
-  std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map;
+  const std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map;
 
   /**
    * Whether or not the slave's residual should be overwritten.

--- a/framework/include/geomsearch/PenetrationThread.h
+++ b/framework/include/geomsearch/PenetrationThread.h
@@ -40,7 +40,7 @@ public:
                     std::vector<std::vector<FEBase *> > & fes,
                     FEType & fe_type,
                     NearestNodeLocator & nearest_node,
-                    std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
+                    const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
                     std::vector<dof_id_type> & elem_list,
                     std::vector<unsigned short int> & side_list,
                     std::vector<boundary_id_type> & id_list);
@@ -78,7 +78,7 @@ protected:
 
   NearestNodeLocator & _nearest_node;
 
-  std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map;
+  const std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map;
 
   std::vector<dof_id_type> & _elem_list;
   std::vector<unsigned short int> & _side_list;

--- a/framework/include/geomsearch/SlaveNeighborhoodThread.h
+++ b/framework/include/geomsearch/SlaveNeighborhoodThread.h
@@ -26,7 +26,7 @@ class SlaveNeighborhoodThread
 public:
   SlaveNeighborhoodThread(const MooseMesh & mesh,
                           const std::vector<dof_id_type> & trial_master_nodes,
-                          std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
+                          const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
                           const unsigned int patch_size);
 
 
@@ -54,7 +54,7 @@ protected:
   const std::vector<dof_id_type> & _trial_master_nodes;
 
   /// Node to elem map
-  std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map;
+  const std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map;
 
   /// The number of nodes to keep
   unsigned int _patch_size;

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -93,7 +93,7 @@ public:
    * @param input_side Side of the element 'elem' (0 for volumetric material properties)
    */
   void restrictStatefulProps(const std::vector<std::pair<unsigned int, QpMap> > & coarsening_map,
-                             std::vector<const Elem *> & coarsened_element_children,
+                             const std::vector<const Elem *> & coarsened_element_children,
                              QBase & qrule,
                              QBase & qrule_face,
                              MaterialData & material_data,

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -21,6 +21,8 @@
 #include "Restartable.h"
 #include "MooseEnum.h"
 
+#include <memory> //std::unique_ptr
+
 // libMesh
 #include "libmesh/mesh.h"
 #include "libmesh/elem_range.h"
@@ -745,7 +747,7 @@ public:
 
   void addMortarInterface(const std::string & name, BoundaryName master, BoundaryName slave, SubdomainName domain_id);
 
-  std::vector<MooseMesh::MortarInterface *> & getMortarInterfaces() { return _mortar_interface; }
+  std::vector<std::unique_ptr<MooseMesh::MortarInterface> > & getMortarInterfaces() { return _mortar_interface; }
 
   MooseMesh::MortarInterface * getMortarInterfaceByName(const std::string name);
   MooseMesh::MortarInterface * getMortarInterface(BoundaryID master, BoundaryID slave);
@@ -788,7 +790,7 @@ protected:
   bool _parallel_type_overridden;
 
   /// Pointer to underlying libMesh mesh object
-  libMesh::MeshBase * _mesh;
+  std::unique_ptr<libMesh::MeshBase> _mesh;
 
   /// The partitioner used on this mesh
   MooseEnum _partitioner_name;
@@ -825,10 +827,10 @@ protected:
   bool _needs_prepare_for_use;
 
   /// The elements that were just refined.
-  ConstElemPointerRange * _refined_elements;
+  std::unique_ptr<ConstElemPointerRange> _refined_elements;
 
   /// The elements that were just coarsened.
-  ConstElemPointerRange * _coarsened_elements;
+  std::unique_ptr<ConstElemPointerRange> _coarsened_elements;
 
   /// Map of Parent elements to child elements for elements that were just coarsened.  NOTE: the child element pointers ARE PROBABLY INVALID.  Only use them for indexing!
   std::map<const Elem *, std::vector<const Elem *> > _coarsened_element_children;
@@ -840,13 +842,13 @@ protected:
    * A range for use with threading.  We do this so that it doesn't have
    * to get rebuilt all the time (which takes time).
    */
-  ConstElemRange * _active_local_elem_range;
-  /// active local + active ghosted
-  SemiLocalNodeRange * _active_semilocal_node_range;
-  NodeRange * _active_node_range;
-  ConstNodeRange * _local_node_range;
-  StoredRange<MooseMesh::const_bnd_node_iterator, const BndNode*> * _bnd_node_range;
-  StoredRange<MooseMesh::const_bnd_elem_iterator, const BndElement*> * _bnd_elem_range;
+  std::unique_ptr<ConstElemRange> _active_local_elem_range;
+
+  std::unique_ptr<SemiLocalNodeRange> _active_semilocal_node_range;
+  std::unique_ptr<NodeRange> _active_node_range;
+  std::unique_ptr<ConstNodeRange> _local_node_range;
+  std::unique_ptr<StoredRange<MooseMesh::const_bnd_node_iterator, const BndNode*> > _bnd_node_range;
+  std::unique_ptr<StoredRange<MooseMesh::const_bnd_elem_iterator, const BndElement*> > _bnd_elem_range;
 
   /// A map of all of the current nodes to the elements that they are connected to.
   std::map<dof_id_type, std::vector<dof_id_type> > _node_to_elem_map;
@@ -928,7 +930,7 @@ protected:
 
   /// Mortar interfaces mapped through their names
   std::map<std::string, MortarInterface *> _mortar_interface_by_name;
-  std::vector<MortarInterface *> _mortar_interface;
+  std::vector<std::unique_ptr<MortarInterface> > _mortar_interface;
   /// Mortar interfaces mapped though master, slave IDs pairs
   std::map<std::pair<BoundaryID, BoundaryID>, MortarInterface *> _mortar_interface_by_ids;
 

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -151,7 +151,7 @@ public:
    * If not already created, creates a map from every node to all
    * elements to which they are connected.
    */
-  std::map<dof_id_type, std::vector<dof_id_type> > & nodeToElemMap();
+  const std::map<dof_id_type, std::vector<dof_id_type> > & nodeToElemMap();
 
   /**
    * If not already created, creates a map from every node to all
@@ -160,7 +160,7 @@ public:
    * one node with a local element.
    * \note Extra ghosted elements are not included in this map!
    */
-  std::map<dof_id_type, std::vector<dof_id_type> > & nodeToActiveSemilocalElemMap();
+  const std::map<dof_id_type, std::vector<dof_id_type> > & nodeToActiveSemilocalElemMap();
 
   /**
    * These structs are required so that the bndNodes{Begin,End} and
@@ -279,7 +279,7 @@ public:
    *
    * @return The _Parent_ elements that are now set to be INACTIVE.  Their _children_ are the new elements.
    */
-  ConstElemPointerRange * refinedElementRange();
+  ConstElemPointerRange * refinedElementRange() const;
 
   /**
    * Return a range that is suitable for threaded execution over elements that were just coarsened.
@@ -287,7 +287,7 @@ public:
    * are the elements that were just removed.  Use coarsenedElementChildren() to get the element
    * IDs for the children that were just removed for a particular parent element.
    */
-  ConstElemPointerRange * coarsenedElementRange();
+  ConstElemPointerRange * coarsenedElementRange() const;
 
   /**
    * Get the newly removed children element ids for an element that was just coarsened.
@@ -295,7 +295,7 @@ public:
    * @param elem Pointer to the parent element that was coarsened to.
    * @return The child element ids in Elem::child() order.
    */
-  std::vector<const Elem *> & coarsenedElementChildren(const Elem * elem);
+  const std::vector<const Elem *> & coarsenedElementChildren(const Elem * elem) const;
 
   /**
    * Clears the "semi-local" node list and rebuilds it.  Semi-local nodes
@@ -316,7 +316,7 @@ public:
    */
   ConstElemRange * getActiveLocalElementRange();
   NodeRange * getActiveNodeRange();
-  SemiLocalNodeRange * getActiveSemiLocalNodeRange();
+  SemiLocalNodeRange * getActiveSemiLocalNodeRange() const;
   ConstNodeRange * getLocalNodeRange();
   StoredRange<MooseMesh::const_bnd_node_iterator, const BndNode*> * getBoundaryNodeRange();
   StoredRange<MooseMesh::const_bnd_elem_iterator, const BndElement*> * getBoundaryElementRange();
@@ -398,12 +398,12 @@ public:
   /**
    * Return a writable reference to the set of ghosted boundary IDs.
    */
-  std::set<unsigned int> & getGhostedBoundaries();
+  const std::set<unsigned int> & getGhostedBoundaries() const;
 
   /**
    * Return a writable reference to the _ghosted_boundaries_inflation vector.
    */
-  std::vector<Real> & getGhostedBoundaryInflation();
+  const std::vector<Real> & getGhostedBoundaryInflation() const;
 
   /**
    * Actually do the ghosting of boundaries that need to be ghosted to this processor.
@@ -616,7 +616,7 @@ public:
    * @param component - An integer representing the desired component (dimension)
    * @return std::pair pointer - The matching boundary pairs for the passed component
    */
-  std::pair<BoundaryID, BoundaryID> * getPairedBoundaryMapping(unsigned int component);
+  const std::pair<BoundaryID, BoundaryID> * getPairedBoundaryMapping(unsigned int component);
 
   /**
    * Create the refinement and coarsening maps necessary for projection of stateful material properties

--- a/framework/src/actions/AddPeriodicBCAction.C
+++ b/framework/src/actions/AddPeriodicBCAction.C
@@ -111,7 +111,7 @@ AddPeriodicBCAction::autoTranslationBoundaries()
 
       if (component >= 0)
       {
-        std::pair<BoundaryID, BoundaryID> * boundary_ids = _mesh->getPairedBoundaryMapping(component);
+        const std::pair<BoundaryID, BoundaryID> * boundary_ids = _mesh->getPairedBoundaryMapping(component);
         RealVectorValue v;
         v(component) = _mesh->dimensionWidth(component);
         PeriodicBoundary p(v);
@@ -184,4 +184,3 @@ AddPeriodicBCAction::act()
     mooseError("You have to specify either 'auto_direction', 'translation' or 'trans_func' in your period boundary section '" + _name + "'");
   }
 }
-

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -4045,7 +4045,7 @@ FEProblem::checkProblemIntegrity()
       }
 
       // also exclude mortar spaces from the material check
-      std::vector<MooseMesh::MortarInterface *> & mortar_ifaces = _mesh.getMortarInterfaces();
+      auto & mortar_ifaces = _mesh.getMortarInterfaces();
       for (const auto & mortar_iface : mortar_ifaces)
         local_mesh_subs.erase(mortar_iface->_id);
 

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1126,7 +1126,7 @@ NonlinearSystem::constraintResiduals(NumericVector<Number> & residual, bool disp
 
   THREAD_ID tid = 0;
   // go over mortar interfaces
-  std::vector<MooseMesh::MortarInterface *> & ifaces = _mesh.getMortarInterfaces();
+  auto & ifaces = _mesh.getMortarInterfaces();
   for (const auto & iface : ifaces)
   {
     if (_constraints.hasActiveFaceFaceConstraints(iface->_name))
@@ -1734,7 +1734,7 @@ NonlinearSystem::constraintJacobians(SparseMatrix<Number> & jacobian, bool displ
 
   THREAD_ID tid = 0;
   // go over mortar interfaces
-  std::vector<MooseMesh::MortarInterface *> & ifaces = _mesh.getMortarInterfaces();
+  auto & ifaces = _mesh.getMortarInterfaces();
   for (const auto & iface : ifaces)
   {
     if (_constraints.hasActiveFaceFaceConstraints(iface->_name))

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1437,7 +1437,10 @@ NonlinearSystem::findImplicitGeometricCouplingEntries(GeometricSearchData & geom
       std::set<dof_id_type> unique_slave_indices;
       std::set<dof_id_type> unique_master_indices;
 
-      std::vector<dof_id_type> & elems = _mesh.nodeToElemMap()[slave_node];
+      const auto & node_to_elem_map = _mesh.nodeToElemMap();
+      auto node_to_elem_pair = node_to_elem_map.find(slave_node);
+      mooseAssert(node_to_elem_pair != node_to_elem_map.end(), "Missing entry in node to elem map");
+      const std::vector<dof_id_type> & elems = node_to_elem_pair->second;
 
       // Get the dof indices from each elem connected to the node
       for (const auto & cur_elem : elems)
@@ -1453,7 +1456,9 @@ NonlinearSystem::findImplicitGeometricCouplingEntries(GeometricSearchData & geom
 
       for (const auto & master_node : master_nodes)
       {
-        std::vector<dof_id_type> & master_node_elems = _mesh.nodeToElemMap()[master_node];
+        auto master_node_to_elem_pair = node_to_elem_map.find(master_node);
+        mooseAssert(master_node_to_elem_pair != node_to_elem_map.end(), "Missing entry in node to elem map");
+        const std::vector<dof_id_type> & master_node_elems = master_node_to_elem_pair->second;
 
         // Get the dof indices from each elem connected to the node
         for (const auto & cur_elem : master_node_elems)

--- a/framework/src/constraints/EqualValueBoundaryConstraint.C
+++ b/framework/src/constraints/EqualValueBoundaryConstraint.C
@@ -88,7 +88,11 @@ EqualValueBoundaryConstraint::updateConstrainedNodes()
   }
 
   // Add elements connected to master node to Ghosted Elements
-  std::vector<dof_id_type> & elems = _mesh.nodeToElemMap()[_master_node_vector[0]];
+  const auto & node_to_elem_map = _mesh.nodeToElemMap();
+  auto node_to_elem_pair = node_to_elem_map.find(_master_node_vector[0]);
+  mooseAssert(node_to_elem_pair != node_to_elem_map.end(), "Missing entry in node to elem map");
+  const std::vector<dof_id_type> & elems = node_to_elem_pair->second;
+
   if (elems.size() == 0)
     mooseError("Couldn't find any elements connected to master node");
   _subproblem.addGhostedElem(elems[0]);

--- a/framework/src/constraints/LinearNodalConstraint.C
+++ b/framework/src/constraints/LinearNodalConstraint.C
@@ -60,13 +60,18 @@ LinearNodalConstraint::LinearNodalConstraint(const InputParameters & parameters)
         _connected_nodes.push_back(dof);
   }
 
+  const auto & node_to_elem_map = _mesh.nodeToElemMap();
+
   // Add elements connected to master node to Ghosted Elements
   for (const auto & dof : _master_node_ids)
   {
     // defining master nodes in base class
     _master_node_vector.push_back(dof);
 
-    std::vector<dof_id_type> & elems = _mesh.nodeToElemMap()[dof];
+    auto node_to_elem_pair = node_to_elem_map.find(dof);
+    mooseAssert(node_to_elem_pair != node_to_elem_map.end(), "Missing entry in node to elem map");
+    const std::vector<dof_id_type> & elems = node_to_elem_pair->second;
+
     for (const auto & elem_id : elems)
       _subproblem.addGhostedElem(elem_id);
   }

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -229,7 +229,9 @@ NodeFaceConstraint::getConnectedDofIndices(unsigned int var_num)
   _connected_dof_indices.clear();
   std::set<dof_id_type> unique_dof_indices;
 
-  std::vector<dof_id_type> & elems = _node_to_elem_map[_current_node->id()];
+  auto node_to_elem_pair = _node_to_elem_map.find(_current_node->id());
+  mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
+  const std::vector<dof_id_type> & elems = node_to_elem_pair->second;
 
   // Get the dof indices from each elem connected to the node
   for (const auto & cur_elem : elems)

--- a/framework/src/geomsearch/GeometricSearchData.C
+++ b/framework/src/geomsearch/GeometricSearchData.C
@@ -420,7 +420,7 @@ GeometricSearchData::updateMortarNodes()
 {
   const MooseArray<Point> & qpoints = _subproblem.assembly(0).qPoints();
 
-  std::vector<MooseMesh::MortarInterface *> & ifaces = _mesh.getMortarInterfaces();
+  auto & ifaces = _mesh.getMortarInterfaces();
   for (const auto & iface : ifaces)
     for (const auto & elem : iface->_elems)
     {
@@ -436,7 +436,7 @@ GeometricSearchData::reinitMortarNodes()
 {
   _mortar_boundaries.clear();
   // Regenerate the quadrature nodes for mortar spaces
-  std::vector<MooseMesh::MortarInterface *> & ifaces = _mesh.getMortarInterfaces();
+  auto & ifaces = _mesh.getMortarInterfaces();
   for (const auto & iface : ifaces)
   {
     unsigned int master_id = _mesh.getBoundaryID(iface->_master);

--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -87,7 +87,7 @@ NearestNodeLocator::findNodes()
     // Build a bounding box.  No reason to consider nodes outside of our inflated BB
     MeshTools::BoundingBox * my_inflated_box = NULL;
 
-    std::vector<Real> & inflation = _mesh.getGhostedBoundaryInflation();
+    const std::vector<Real> & inflation = _mesh.getGhostedBoundaryInflation();
 
     // This means there was a user specified inflation... so we can build a BB
     if (inflation.size() > 0)
@@ -134,7 +134,7 @@ NearestNodeLocator::findNodes()
     // don't need the BB anymore
     delete my_inflated_box;
 
-    std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToElemMap();
+    const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToElemMap();
 
     NodeIdRange trial_slave_node_range(trial_slave_nodes.begin(), trial_slave_nodes.end(), 1);
 

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -43,7 +43,7 @@ PenetrationThread::PenetrationThread(SubProblem & subproblem,
                                      std::vector<std::vector<FEBase *> > & fes,
                                      FEType & fe_type,
                                      NearestNodeLocator & nearest_node,
-                                     std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
+                                     const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
                                      std::vector<dof_id_type> & elem_list,
                                      std::vector<unsigned short int> & side_list,
                                      std::vector<boundary_id_type> & id_list) :
@@ -182,7 +182,9 @@ PenetrationThread::operator() (const NodeIdRange & range)
     if (!info_set)
     {
       const Node * closest_node = _nearest_node.nearestNode(node.id());
-      std::vector<dof_id_type> & closest_elems = _node_to_elem_map[closest_node->id()];
+      auto node_to_elem_pair = _node_to_elem_map.find(closest_node->id());
+      mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
+      const std::vector<dof_id_type> & closest_elems = node_to_elem_pair->second;
 
       for (const auto & elem_id : closest_elems)
       {
@@ -1495,7 +1497,9 @@ PenetrationThread::getInfoForFacesWithCommonNodes(const Node * slave_node,
                                                   std::vector<PenetrationInfo *> & p_info)
 {
   //elems connected to a node on this edge, find one that has the same corners as this, and is not the current elem
-  std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[edge_nodes[0]->id()]; //just need one of the nodes
+  auto node_to_elem_pair = _node_to_elem_map.find(edge_nodes[0]->id()); //just need one of the nodes
+  mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
+  const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
 
   std::vector<const Elem *> elems_connected_to_edge;
 

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -115,16 +115,18 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
     {
       {
         auto node_to_elem_pair = _node_to_elem_map.find(node_id);
-        mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
-        const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
+        if (node_to_elem_pair != _node_to_elem_map.end())
+        {
+          const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
 
-        // See if we own any of the elements connected to the slave node
-        for (const auto & dof : elems_connected_to_node)
-          if (_mesh.elemPtr(dof)->processor_id() == processor_id)
-          {
-            need_to_track = true;
-            break; // Break out of element loop
-          }
+          // See if we own any of the elements connected to the slave node
+          for (const auto & dof : elems_connected_to_node)
+            if (_mesh.elemPtr(dof)->processor_id() == processor_id)
+            {
+              need_to_track = true;
+              break; // Break out of element loop
+            }
+        }
       }
 
       if (!need_to_track)
@@ -163,11 +165,14 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
 
       { // Add the elements connected to the slave node to the ghosted list
         auto node_to_elem_pair = _node_to_elem_map.find(node_id);
-        mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
-        const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
 
-        for (const auto & dof : elems_connected_to_node)
-          _ghosted_elems.insert(dof);
+        if (node_to_elem_pair != _node_to_elem_map.end())
+        {
+          const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
+
+          for (const auto & dof : elems_connected_to_node)
+            _ghosted_elems.insert(dof);
+        }
       }
 
       // Now add elements connected to the neighbor nodes to the ghosted list

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -39,7 +39,7 @@ public:
 
 SlaveNeighborhoodThread::SlaveNeighborhoodThread(const MooseMesh & mesh,
                                                  const std::vector<dof_id_type> & trial_master_nodes,
-                                                 std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
+                                                 const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map,
                                                  const unsigned int patch_size) :
   _mesh(mesh),
   _trial_master_nodes(trial_master_nodes),
@@ -113,9 +113,12 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       need_to_track = true;
     else
     {
-      { // See if we own any of the elements connected to the slave node
-        const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[node_id];
+      {
+        auto node_to_elem_pair = _node_to_elem_map.find(node_id);
+        mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
+        const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
 
+        // See if we own any of the elements connected to the slave node
         for (const auto & dof : elems_connected_to_node)
           if (_mesh.elemPtr(dof)->processor_id() == processor_id)
           {
@@ -132,7 +135,9 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
             need_to_track = true;
           else // Now see if we own any of the elements connected to the neighbor nodes
           {
-            const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[neighbor_node_id];
+            auto node_to_elem_pair = _node_to_elem_map.find(neighbor_node_id);
+            mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
+            const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
 
             for (const auto & dof : elems_connected_to_node)
               if (_mesh.elemPtr(dof)->processor_id() == processor_id)
@@ -157,7 +162,9 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       _neighbor_nodes[node_id] = neighbor_nodes;
 
       { // Add the elements connected to the slave node to the ghosted list
-        const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[node_id];
+        auto node_to_elem_pair = _node_to_elem_map.find(node_id);
+        mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
+        const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
 
         for (const auto & dof : elems_connected_to_node)
           _ghosted_elems.insert(dof);
@@ -166,7 +173,9 @@ SlaveNeighborhoodThread::operator() (const NodeIdRange & range)
       // Now add elements connected to the neighbor nodes to the ghosted list
       for (unsigned int neighbor_it=0; neighbor_it < neighbor_nodes.size(); neighbor_it++)
       {
-        const std::vector<dof_id_type> & elems_connected_to_node = _node_to_elem_map[neighbor_nodes[neighbor_it]];
+        auto node_to_elem_pair = _node_to_elem_map.find(neighbor_nodes[neighbor_it]);
+        mooseAssert(node_to_elem_pair != _node_to_elem_map.end(), "Missing entry in node to elem map");
+        const std::vector<dof_id_type> & elems_connected_to_node = node_to_elem_pair->second;
 
         for (const auto & dof : elems_connected_to_node)
           _ghosted_elems.insert(dof);

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -169,7 +169,7 @@ MaterialPropertyStorage::prolongStatefulProps(const std::vector<std::vector<QpMa
 
 void
 MaterialPropertyStorage::restrictStatefulProps(const std::vector<std::pair<unsigned int, QpMap> > & coarsening_map,
-                                               std::vector<const Elem *> & coarsened_element_children,
+                                               const std::vector<const Elem *> & coarsened_element_children,
                                                QBase & qrule,
                                                QBase & qrule_face,
                                                MaterialData & material_data,

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -500,21 +500,23 @@ MooseMesh::cacheChangedLists()
 }
 
 ConstElemPointerRange *
-MooseMesh::refinedElementRange()
+MooseMesh::refinedElementRange() const
 {
   return _refined_elements;
 }
 
 ConstElemPointerRange *
-MooseMesh::coarsenedElementRange()
+MooseMesh::coarsenedElementRange() const
 {
   return _coarsened_elements;
 }
 
-std::vector<const Elem *> &
-MooseMesh::coarsenedElementChildren(const Elem * elem)
+const std::vector<const Elem *> &
+MooseMesh::coarsenedElementChildren(const Elem * elem) const
 {
-  return _coarsened_element_children[elem];
+  auto elem_to_child_pair = _coarsened_element_children.find(elem);
+  mooseAssert(elem_to_child_pair != _coarsened_element_children.end(), "Missing element in map");
+  return elem_to_child_pair->second;
 }
 
 void
@@ -643,7 +645,7 @@ MooseMesh::buildBndElemList()
   }
 }
 
-std::map<dof_id_type, std::vector<dof_id_type> > &
+const std::map<dof_id_type, std::vector<dof_id_type> > &
 MooseMesh::nodeToElemMap()
 {
   if (!_node_to_elem_map_built) // Guard the creation with a double checked lock
@@ -665,7 +667,7 @@ MooseMesh::nodeToElemMap()
   return _node_to_elem_map;
 }
 
-std::map<dof_id_type, std::vector<dof_id_type> > &
+const std::map<dof_id_type, std::vector<dof_id_type> > &
 MooseMesh::nodeToActiveSemilocalElemMap()
 {
   if (!_node_to_active_semilocal_elem_map_built) // Guard the creation with a double checked lock
@@ -714,16 +716,9 @@ MooseMesh::getActiveNodeRange()
 }
 
 SemiLocalNodeRange *
-MooseMesh::getActiveSemiLocalNodeRange()
+MooseMesh::getActiveSemiLocalNodeRange() const
 {
   mooseAssert(_active_semilocal_node_range, "_active_semilocal_node_range has not been created yet!");
-/*
-  if (!_active_node_range)
-  {
-    _active_semilocal_node_range = new NodeRange(getMesh().local_nodes_begin(),
-                                                 getMesh().local_nodes_end(), GRAIN_SIZE);
-  }
- */
 
   return _active_semilocal_node_range;
 }
@@ -1389,7 +1384,7 @@ MooseMesh::addPeriodicVariable(unsigned int var_num, BoundaryID primary, Boundar
 
   for (unsigned int component = 0; component < dimension(); ++component)
   {
-    std::pair<BoundaryID, BoundaryID> * boundary_ids = getPairedBoundaryMapping(component);
+    const std::pair<BoundaryID, BoundaryID> * boundary_ids = getPairedBoundaryMapping(component);
 
     if (boundary_ids != NULL &&
         ((boundary_ids->first == primary && boundary_ids->second == secondary) ||
@@ -1442,7 +1437,7 @@ MooseMesh::minPeriodicDistance(unsigned int nonlinear_var_num, Point p, Point q)
   return minPeriodicVector(nonlinear_var_num, p, q).norm();
 }
 
-std::pair<BoundaryID, BoundaryID> *
+const std::pair<BoundaryID, BoundaryID> *
 MooseMesh::getPairedBoundaryMapping(unsigned int component)
 {
   if (!_regular_orthogonal_mesh)
@@ -2117,14 +2112,14 @@ MooseMesh::setGhostedBoundaryInflation(const std::vector<Real> & inflation)
   _ghosted_boundaries_inflation = inflation;
 }
 
-std::set<unsigned int> &
-MooseMesh::getGhostedBoundaries()
+const std::set<unsigned int> &
+MooseMesh::getGhostedBoundaries() const
 {
   return _ghosted_boundaries;
 }
 
-std::vector<Real> &
-MooseMesh::getGhostedBoundaryInflation()
+const std::vector<Real> &
+MooseMesh::getGhostedBoundaryInflation() const
 {
   return _ghosted_boundaries_inflation;
 }

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -659,7 +659,7 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
             {
               const dof_id_type slave_node_num = lit->first;
               PenetrationInfo * pinfo = lit->second;
-              std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map =
+              const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map =
               dmm->_nl->_fe_problem.mesh().nodeToElemMap();
               if (pinfo && pinfo->isCaptured())
               {
@@ -672,7 +672,10 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
                   cached_indices.insert(dof); // cache nonlocal indices
                 // indices of slave elements
                 evindices.clear();
-                for (const auto & elem_num : node_to_elem_map[slave_node_num])
+
+                auto node_to_elem_pair = node_to_elem_map.find(slave_node_num);
+                mooseAssert(node_to_elem_pair != node_to_elem_map.end(), "Missing entry in node to elem map");
+                for (const auto & elem_num : node_to_elem_pair->second)
                 {
                   Elem & slave_elem = dmm->_nl->sys().get_mesh().elem_ref(elem_num);
                   // Get the degree of freedom indices for the given variable off the current element.

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -85,6 +85,8 @@ SlaveConstraint::addPoints()
   std::map<dof_id_type, PenetrationInfo *>::iterator
     it  = _penetration_locator._penetration_info.begin(),
     end = _penetration_locator._penetration_info.end();
+
+  const auto & node_to_elem_map = _mesh.nodeToElemMap();
   for (; it!=end; ++it)
   {
     PenetrationInfo * pinfo = it->second;
@@ -99,8 +101,9 @@ SlaveConstraint::addPoints()
     if (pinfo->isCaptured() && node->processor_id() == processor_id())
     {
       // Find an element that is connected to this node that and that is also on this processor
-
-      std::vector<dof_id_type> & connected_elems = _mesh.nodeToElemMap()[slave_node_num];
+      auto node_to_elem_pair = node_to_elem_map.find(slave_node_num);
+      mooseAssert(node_to_elem_pair != node_to_elem_map.end(), "Missing node in node to elem map");
+      const std::vector<dof_id_type> & connected_elems = node_to_elem_pair->second;
 
       Elem * elem = NULL;
 
@@ -291,4 +294,3 @@ SlaveConstraint::nodalArea(PenetrationInfo & pinfo)
   }
   return area;
 }
-

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -311,7 +311,7 @@ EBSDReader::buildNodeWeightMaps()
 {
   // Import nodeToElemMap from MooseMesh for current node
   // This map consists of the node index followed by a vector of element indices that are associated with that node
-  std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToActiveSemilocalElemMap();
+  const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToActiveSemilocalElemMap();
   libMesh::MeshBase &mesh = _mesh.getMesh();
 
   // Loop through each node in mesh and calculate eta values for each grain associated with the node
@@ -327,12 +327,14 @@ EBSDReader::buildNodeWeightMaps()
     _node_to_phase_weight_map[node_id].assign(getPhaseNum(), 0.0);
 
     // Loop through element indices associated with the current node and record weighted eta value in new map
-    unsigned int n_elems = node_to_elem_map[node_id].size();  // n_elems can range from 1 to 4 for 2D and 1 to 8 for 3D problems
+    const auto & node_to_elem_pair = node_to_elem_map.find(node_id);
+    mooseAssert(node_to_elem_pair != node_to_elem_map.end(), "Missing node in node to elem map");
+    unsigned int n_elems = node_to_elem_pair->second.size();  // n_elems can range from 1 to 4 for 2D and 1 to 8 for 3D problems
 
     for (unsigned int ne = 0; ne < n_elems; ++ne)
     {
       // Current element index
-      unsigned int elem_id = node_to_elem_map[node_id][ne];
+      unsigned int elem_id = (node_to_elem_pair->second)[ne];
 
       // Retrieve EBSD grain number for the current element index
       const Elem * elem = mesh.elem(elem_id);

--- a/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -276,18 +276,17 @@ CrackFrontDefinition::orderCrackFrontNodes(std::set<dof_id_type> &nodes)
     //Loop through the set of crack front nodes, and create a node to element map for just the crack front nodes
     //The main reason for creating a second map is that we need to do a sort prior to the set_intersection.
     //The original map contains vectors, and we can't sort them, so we create sets in the local map.
-    std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToElemMap();
+    const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToElemMap();
     std::map<dof_id_type, std::set<dof_id_type> > crack_front_node_to_elem_map;
 
-    for (std::set<dof_id_type>::iterator nit = nodes.begin(); nit != nodes.end(); ++nit )
+    for (const auto & node_id : nodes)
     {
-      std::map<dof_id_type, std::vector<dof_id_type> >::iterator nemit = node_to_elem_map.find(*nit);
-      if (nemit == node_to_elem_map.end())
-        mooseError("Could not find crack front node " << *nit << "in the node to elem map");
+      const auto & node_to_elem_pair = node_to_elem_map.find(node_id);
+      mooseAssert(node_to_elem_pair != node_to_elem_map.end(), "Could not find crack front node " << node_id << "in the node to elem map");
 
-      std::vector<dof_id_type> & connected_elems = nemit->second;
-      for (unsigned int i=0; i<connected_elems.size(); ++i)
-        crack_front_node_to_elem_map[*nit].insert(connected_elems[i]);
+      const std::vector<dof_id_type> & connected_elems = node_to_elem_pair->second;
+      for (unsigned int i = 0; i < connected_elems.size(); ++i)
+        crack_front_node_to_elem_map[node_id].insert(connected_elems[i]);
     }
 
 

--- a/test/src/userobjects/TrackDiracFront.C
+++ b/test/src/userobjects/TrackDiracFront.C
@@ -66,18 +66,18 @@ TrackDiracFront::finalize()
 Elem *
 TrackDiracFront::localElementConnectedToCurrentNode()
 {
-  std::map<dof_id_type, std::vector<dof_id_type> > & _node_to_elem_map = _mesh.nodeToElemMap();
+  const std::map<dof_id_type, std::vector<dof_id_type> > & node_to_elem_map = _mesh.nodeToElemMap();
+  auto node_to_elem_pair = node_to_elem_map.find(_current_node->id());
+  mooseAssert(node_to_elem_pair != node_to_elem_map.end(), "Node missing in node to elem map");
+  const std::vector<dof_id_type> & connected_elems = node_to_elem_pair->second;
 
-  dof_id_type id = _current_node->id();
-
-  const std::vector<dof_id_type> & connected_elems = _node_to_elem_map.at(id);
-
-  unsigned int pid = processor_id(); // This processor id
+  auto pid = processor_id(); // This processor id
 
   // Look through all of the elements connected to this node and find one owned by the local processor
-  for (unsigned int i=0; i<connected_elems.size(); i++)
+  for (auto elem_id : connected_elems)
   {
-    Elem * elem = _mesh.elemPtr(connected_elems[i]);
+    Elem * elem = _mesh.elemPtr(elem_id);
+    mooseAssert(elem, "Elem pointer is NULL");
 
     if (elem->processor_id() == pid) // Is this element owned by the local processor?
       return elem;


### PR DESCRIPTION
Huge cleanup, modernization and const correctness commit for MooseMesh and affected classes.

There are several places where we were using a returned map on the lhs so I've removed nearly a dozen accidental insertion points. Additionally I've removed almost all raw pointers from MooseMesh. 

@jwpeterson - I didn't deal with the iterator stuff yet so those are the only remaining raw pointers in MooseMesh. No biggie but they could probably be cleaned up eventually too.
