### PR TITLE
Node locking fix for tangential penalty contact. Issue #7688.

### DIFF
--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -193,7 +193,7 @@ MechanicalContactConstraint::updateContactSet(bool beginning_of_step)
       pinfo->capture();
 
       // Increment the lock count every time the node comes back into contact from not being in contact.
-      if (_formulation == CF_KINEMATIC)
+      if (_formulation == CF_KINEMATIC || _formulation == CF_TANGENTIAL_PENALTY)
         ++pinfo->_locked_this_step;
     }
     // Release


### PR DESCRIPTION
Added tangential penalty to block for enforcing node locking feature in mechanical contact. @bwspenc 

Closes #7688.
