### PR TITLE
Allows for multiple include and source directories

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,8 +2,6 @@ site_name: MOOSE
 
 docs_dir: .
 
-media_dir: ../media
-
 site_dir: ../site
 
 repo_url: https://github.com/idaholab/moose/

--- a/docs/moosedocs.yml
+++ b/docs/moosedocs.yml
@@ -25,7 +25,8 @@ defaults:
 # Directories/applications to include
 include:
     framework:
-        source: ../framework
+        source: ../framework/src
+        include: ../framework/include
         doxygen: http://mooseframework.com/docs/doxygen/moose/
         details: details/framework
         install: content/framework/systems
@@ -40,7 +41,8 @@ include:
                 - ../tutorials
 
     phase_field:
-        source: ../modules/phase_field
+        source: ../modules/phase_field/src
+        include: ../modules/phase_field/include
         doxygen: http://mooseframework.com/docs/doxygen/modules/
         details: details/phase_field
         install: content/modules/phase_field/systems
@@ -53,7 +55,8 @@ include:
                 - ../modules/phase_field/examples
 
     contact:
-        source: ../modules/contact
+        source: ../modules/contact/src
+        include: ../modules/contact/include
         doxygen: http://mooseframework.com/docs/doxygen/modules/
         details: details/contact
         install: content/modules/contact/systems

--- a/python/MooseDocs/MooseApplicationDocGenerator.py
+++ b/python/MooseDocs/MooseApplicationDocGenerator.py
@@ -59,6 +59,7 @@ class MooseApplicationDocGenerator(object):
         defaults = yml.get('defaults', dict())
         defaults.setdefault('details', os.path.join(os.getcwd(), 'details'))
         defaults.setdefault('source', None)
+        defaults.setdefault('include', None)
         defaults.setdefault('install', os.path.join(os.getcwd(), 'content'))
         defaults.setdefault('repo', None)
         defaults.setdefault('doxygen', None)

--- a/python/MooseDocs/MooseApplicationSyntax.py
+++ b/python/MooseDocs/MooseApplicationSyntax.py
@@ -20,7 +20,7 @@ class MooseApplicationSyntax(object):
 
     Args:
         yaml[MooseYaml]: The MooseYaml object obtained by running the application with --yaml option.
-        path[str|list]: Valid source directory to extract syntax.
+        paths[list]: Valid source directory to extract syntax.
     """
 
 
@@ -33,13 +33,12 @@ class MooseApplicationSyntax(object):
         self._filenames = dict()
         self._syntax = set()
 
-        # Path should be a list of directories
-        if not isinstance(paths, list):
-            paths = [paths]
-
         # Update the syntax maps
         for path in paths:
-            if (not path) or (not os.path.exists(path)):
+            if (not path):
+                log.critical("Missing or invalid source/include directory.")
+                raise Exception("A directory with a value of None was supplied, which is not allowed.")
+            elif not os.path.exists(path):
                 log.critical("Unknown source directory supplied: {}".format(os.path.abspath(path)))
                 raise IOError(os.path.abspath(path))
             self._updateSyntax(path)

--- a/python/MooseDocs/MooseSubApplicationDocGenerator.py
+++ b/python/MooseDocs/MooseSubApplicationDocGenerator.py
@@ -37,11 +37,19 @@ class MooseSubApplicationDocGenerator(object):
             inputs[key] = database.Database('.i', path, database.items.InputFileItem, **options)
             children[key] = database.Database('.h', path, database.items.ChildClassItem, **options)
 
+        # Combine the 'include' and 'source' into a single list (putting the include first)
+        include = self._config.get('include')
+        if not isinstance(include, list):
+            include = [include]
+        source = self._config.get('source')
+        if not isinstance(source, list):
+            source = [source]
+
         # Parse the syntax for the given source directory.
-        src = self._config.get('source')
-        log.info('Locating syntax for application: {}'.format(src))
+        paths = include + source
+        log.info('Locating syntax for application: {}'.format(paths))
         self._yaml_data = yaml_data
-        self._syntax = MooseApplicationSyntax(yaml_data, src)
+        self._syntax = MooseApplicationSyntax(yaml_data, paths)
 
         self._systems = []
         log.info('Initializing MOOSE system information...')

--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -163,13 +163,13 @@ def command_line_options():
     # Command-line options
     parser = argparse.ArgumentParser(description="Tool for building and developing MOOSE and MOOSE-based application documentation.")
     parser.add_argument('--verbose', '-v', action='store_true', help="Execute with verbose (debug) output.")
-    parser.add_argument('--purge', '-p', action='store_true', help="Remove all generated content (*.moose.md, *.moose.svg, *.moose.yml files) from the install directories.")
 
     subparser = parser.add_subparsers(title='Commands', description="Documentation creation command to execute.", dest='command')
 
     # Generate options
     generate_parser = subparser.add_parser('generate', help="Generate the markdown documentation from MOOSE application executable. This is done by the serve and build command automatically.")
     generate_parser.add_argument('--moosedocs-config-file', type=str, default=os.path.join('moosedocs.yml'), help="The configuration file to use for building the documentation using MOOSE. (Default: %(default)s)")
+    generate_parser.add_argument('--purge', '-p', action='store_true', help="Remove all generated content (*.moose.md, *.moose.svg, *.moose.yml files) from the install directories.")
 
     # Serve options
     serve_parser = subparser.add_parser('serve', help='Generate and Sever the documentation using a local server.')
@@ -206,16 +206,15 @@ def moosedocs():
     formatter = init_logging(options.verbose)
     log = logging.getLogger('MooseDocs')
 
-    # Purge
-    if options.purge:
-        log.info('Purging *.moose.md, *.moose.yml, and *.moose.svg files from {}'.format(os.getcwd()))
-        purge(['md', 'yml', 'svg'])
-    else:
-        log.info('Removing *.moose.svg files from {}'.format(os.getcwd()))
-        purge(['svg'])
+    # Remove moose.svg files (these get generated via dot)
+    log.info('Removing *.moose.svg files from {}'.format(os.getcwd()))
+    purge(['svg'])
 
     # Execute command
     if options.command == 'generate':
+        if options.purge:
+            log.info('Purging *.moose.md, *.moose.yml, and *.moose.svg files from {}'.format(os.getcwd()))
+            purge(['md', 'yml', 'svg'])
         commands.generate(config_file=options.moosedocs_config_file)
     elif options.command == 'serve':
         commands.serve(config_file=options.mkdocs_config_file, strict=options.strict, livereload=options.livereload, clean=options.clean, theme=options.theme, pages=options.pages)

--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -13,30 +13,6 @@ def build(config_file='mkdocs.yml', pages='pages.yml', **kwargs):
     """
     pages = MooseDocs.yaml_load(pages)
     config = mkdocs.config.load_config(config_file, pages=pages, **kwargs)
-
-    # Copy the css/js directories
-    def ignore(src, names):
-        """
-        An ignore helper for the shutil.copytree command.
-        """
-        output = []
-        for i, name in enumerate(names):
-            s = os.path.join(root, name)
-            d = os.path.join(src, name)
-            if os.path.getmtime(s) >= os.path.getmtime(d):
-                output.append(name)
-        print output
-        return output
-
-    for d in ['js', 'css']:
-        loc = os.path.join(MooseDocs.MOOSE_DIR, 'docs', d)
-        for root, dirs, files in os.walk(loc):
-            for filename in files:
-                src = os.path.join(loc, filename)
-                dst = os.path.join(d, filename)
-                if os.path.getmtime(src) > os.path.getmtime(dst):
-                    shutil.copy(src, dst)
-
     mkdocs.commands.build.build(config)
     mkdocs.utils.copy_media_files(config['docs_dir'], config['site_dir'])
     return config


### PR DESCRIPTION
This is required for applications, especially those with submodules, to break up the code to search through and include in the site
(refs #6699)
