### PR TITLE
Add CSS block extension

### DIFF
--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -195,7 +195,9 @@ You can include images in your documentation by use of the !image markdown synta
 
 ---
 
-## Inline CSS Options
+## CSS Options
+
+### In-line CSS
 !text test/tests/kernels/simple_diffusion/simple_diffusion.i start=Kernels end=Executioner float=right padding-left=20px font-size=smaller
 
 You can provide any valid CSS attribute to any markdown extension (!text, !input, !clang, !image, !slideshow). Some extensions can not be controlled as much as others. For example the !slideshow extension ignores alignment attributes. Your milage may vary.
@@ -204,7 +206,7 @@ Some of the most useful ones are perhaps width, float, align and padding. Howeve
 
 In the following example, we will display an input code block. It will 'float' to the right, which should allow this section of text and elements, to appear to the left of the code block, and wrap around it.
 
-  * Keep in mind, that the actual element tag was placed in this document just beneath the "Inline CSS Options" title. This is because the placement of the element still applies to where it starts being drawn on the screen.
+  * Keep in mind, that the actual element tag was placed in this document just beneath the "In-line CSS" title. This is because the placement of the element still applies to where it starts being drawn on the screen.
 
 !!! Info
     It should also work with admonitions
@@ -213,6 +215,31 @@ Markdown allowing an input code block to float to the right:
 ```markdown
 !text test/tests/kernels/simple_diffusion/simple_diffusion.i start=Kernels end=Executioner float=right padding-left=20px font-size=smaller
 ```
+
+### Block CSS Options
+You can apply a style sheet to a markdown paragraph through the use of !css extension:
+
+```markdown
+!css font-size=smaller margin-left=70% color=red text-shadow=1px 1px 1px rgba(0,0,0,.4)
+This paragraph should be of a smaller red font with a black offset text shadow. The text
+will be aligned to the right due to the margin-left attribute (nice trick to preserve the
+'justify' attribute currently in use)
+
+An empty new line, designates the end of the css block.
+
+!css font-size=smaller margin-left=70% color=red text-shadow=1px 1px 1px rgba(0,0,0,.4)
+Another paragraph modified by CSS.
+```
+
+!css font-size=smaller margin-left=70% color=red text-shadow=1px 1px 1px rgba(0,0,0,.4)
+This paragraph should be of a smaller red font with a black offset text shadow. The text
+will be aligned to the right due to the margin-left attribute (nice trick to preserve the
+'justify' attribute currently in use)
+
+An empty new line, designates the end of the css block.
+
+!css font-size=smaller margin-left=70% color=red text-shadow=1px 1px 1px rgba(0,0,0,.4)
+Another paragraph modified by CSS.
 
 ---
 
@@ -243,3 +270,18 @@ graph {
     a -- b -- c;
     b -- d;
 }
+
+---
+
+## Build Status
+!buildstatus https://moosebuild.org/mooseframework/ float=right padding-left=10px
+
+You can add a Civet build status widget to any page using !buildstatus http://url/to/civet
+
+Currently this will only work with Civet CI servicies.
+
+```markdown
+!buildstatus https://moosebuild.org/mooseframework/ float=right padding-left=10px
+```
+!!! note
+    Be sure to follow your !buildstatus extension with an empty new line.

--- a/docs/css/moose.css
+++ b/docs/css/moose.css
@@ -29,6 +29,11 @@ hr {
     color: #383d3e;
 }
 
+/* Slideshows with white backgrounds and captions, need a black drop text shadow */
+.carousel-caption {
+    text-shadow: 1px 1px 9px rgba(0, 0, 0, 1);
+}
+
 .admonition-title {
     font-weight: bold;
     display: block;

--- a/docs/css/moose.css
+++ b/docs/css/moose.css
@@ -1,3 +1,6 @@
+p {
+    text-align: justify;
+}
 a {
     color: #0333a5;
     text-decoration: none;
@@ -20,6 +23,10 @@ pre {
 hr {
     border-bottom-style: groove;
     border-bottom-width: 2px;
+}
+/* NavBar submenu font color */
+.dropdown-menu>li>a {
+    color: #383d3e;
 }
 
 .admonition-title {
@@ -99,7 +106,6 @@ hr {
     color: #000;
     border: 0px solid transparent;
 }
-
 /*
 Slide style
 */
@@ -111,7 +117,56 @@ Slide style
     font-size: 1.5em;
 }
 
-
 .reveal .slides > section {
   text-align: left;
 }
+/* MOOSE Build status CSS */
+.boxed_job_status_Passed {
+    vertical-align: middle;
+    text-align: center;
+    width: 60px;
+    background-color:#A9F5A9;
+    box-shadow: 2px 2px 3px #888888;
+    display: inline-block
+}
+.boxed_job_status_Failed {
+    vertical-align: middle;
+    text-align: center;
+    width: 60px;
+    background-color:#F5A9A9;
+    box-shadow: 2px 2px 3px #888888;
+    display: inline-block
+}
+.boxed_job_status_Running {
+    vertical-align: middle;
+    text-align: center;
+    width: 60px;
+    background-color:#F2F5A9;
+    box-shadow: 2px 2px 3px #888888;
+    display: inline-block
+}
+.boxed_job_status_Failed_OK {
+    vertical-align: middle;
+    text-align: center;
+    width: 60px;
+    background-color:#FAAC58;
+    box-shadow: 2px 2px 3px #888888;
+    display: inline-block
+}
+.boxed_job_status_Not_Started {
+    vertical-align: middle;
+    text-align: center;
+    width: 60px;
+    background-color:#FFFFFF;
+    box-shadow: 2px 2px 3px #888888;
+    display: inline-block;
+}
+.boxed_job_status_Canceled {
+    vertical-align: middle;
+    text-align: center;
+    width: 60px;
+    background-color:#CCCCCC;
+    box-shadow: 2px 2px 3px #888888;
+    display: inline-block;
+}
+/* MOOSE Build status CSS */

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,30 @@
+!image rd100.png width=230 float=right
+
 # MOOSE: Multiphysics Object Oriented Simulation Environment
+
+### Advanced capability, delivered simply
+
+The Multiphysics Object-Oriented Simulation Environment (MOOSE) is a finite-element, multiphysics framework primarily developed by Idaho National Laboratory. It provides a high-level interface to some of the most sophisticated nonlinear solver technology on the planet. MOOSE presents a straightforward API that aligns well with the real-world problems scientists and engineers need to tackle. Every detail about how an engineer interacts with MOOSE has been thought through, from the installation process through running your simulation on state of the art supercomputers, the MOOSE system will accelerate your research.
+
+!buildstatus https://moosebuild.org/mooseframework/ float=right
+
+### Some of the capability at your fingertips:
+
+ * Fully-coupled, fully-implicit multiphysics solver
+ * Dimension independent physics
+ * Automatically parallel (largest runs >100,000 CPU cores!)
+ * Modular development simplifies code reuse
+ * Built-in mesh adaptivity
+ * Continuous and Discontinuous Galerkin (DG) (at the same time!)
+ * Intuitive parallel multiscale solves (see videos below)
+ * Dimension agnostic, parallel geometric search (for contact related applications)
+ * Flexible, plugable graphical user interface
+ * ~30 plugable interfaces allow specialization of every part of the solve
+ * Physics modules providing general capability for solid mechanics, phase field modeling, Navier-Stokes, heat conduction and more
+
+### Have a different relationship with your framework
+
+MOOSE is different. MOOSE is a way of developing software just as much as it is a finite-element framework. When we change something in the framework we contribute patches to you that fix your application! As MOOSE is developed we test against your tests each step of the way to ensure that we're not creating problems. MOOSE is developed directly on GitHub providing a unique workflow that ensures smooth community involvement. Every step of the way we make decisions to keep scientists and engineers doing... SCIENCE and ENGINEERING!
+Real results, really delivered
+
+Don't simply talk about that simulation you would like to do... make it a reality!

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 The Multiphysics Object-Oriented Simulation Environment (MOOSE) is a finite-element, multiphysics framework primarily developed by Idaho National Laboratory. It provides a high-level interface to some of the most sophisticated nonlinear solver technology on the planet. MOOSE presents a straightforward API that aligns well with the real-world problems scientists and engineers need to tackle. Every detail about how an engineer interacts with MOOSE has been thought through, from the installation process through running your simulation on state of the art supercomputers, the MOOSE system will accelerate your research.
 
-!buildstatus https://moosebuild.org/mooseframework/ float=right
+!buildstatus https://moosebuild.org/mooseframework/ float=right padding-left=10px
 
 ### Some of the capability at your fingertips:
 

--- a/docs/media/rd100.png
+++ b/docs/media/rd100.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08307b4390ae072778a96ee5bc6190d3f5542c2c95ec72fe78449bf6c30a0b4f
+size 205575

--- a/python/MooseDocs/extensions/MooseBuildStatus.py
+++ b/python/MooseDocs/extensions/MooseBuildStatus.py
@@ -12,12 +12,11 @@ import utils
 
 class MooseBuildStatus(MooseCommonExtension, Pattern):
     """
-    Markdown extension for handling images.
+    Markdown extension for add Build Status widget.
 
     Usage:
-      !image image_file.png|jpg|etc attribute=setting
+      !buildstatus http://civet/buildstatus/site css_attribute=setting
 
-    All images/media should be stored in docs/media
     """
 
     # Find !buildstatus url attribute=value

--- a/python/MooseDocs/extensions/MooseBuildStatus.py
+++ b/python/MooseDocs/extensions/MooseBuildStatus.py
@@ -1,0 +1,86 @@
+import re
+import os
+from markdown.util import etree
+from markdown.util import AtomicString
+import logging
+log = logging.getLogger(__name__)
+
+import MooseDocs
+from markdown.inlinepatterns import Pattern
+from MooseCommonExtension import MooseCommonExtension
+import utils
+
+class MooseBuildStatus(MooseCommonExtension, Pattern):
+    """
+    Markdown extension for handling images.
+
+    Usage:
+      !image image_file.png|jpg|etc attribute=setting
+
+    All images/media should be stored in docs/media
+    """
+
+    # Find !buildstatus url attribute=value
+    RE = r'^!buildstatus\s+(.*?)(?:$|\s+)(.*)'
+
+    def __init__(self, **kwargs):
+        MooseCommonExtension.__init__(self)
+        Pattern.__init__(self, self.RE, **kwargs)
+
+        # We have a strict width set that can not be disturbed
+        self._invalid_css = { 'div' : ['width'] }
+
+    def handleMatch(self, match):
+        """
+        process settings associated with !buildstatus markdown
+        """
+        reverse_margin = { 'left' : 'right',
+                           'right' : 'left',
+                           'None' : 'none'}
+
+        url = match.group(2)
+
+        # A tuple separating specific MOOSE documentation features (self._settings) from HTML styles
+        settings, styles = self.getSettings(match.group(3))
+
+        # Create parent div, and set any allowed CSS
+        parent_div = self.addStyle(etree.Element('div'), **styles)
+
+        child_div = etree.SubElement(parent_div, 'div')
+        jquery_script = etree.SubElement(parent_div, 'script')
+        build_status_script = etree.SubElement(parent_div, 'script')
+
+        jquery_script.set('src', 'http://code.jquery.com/jquery-1.11.0.min.js')
+
+        # We need to inform SmartyPants to not format for paragraph use
+        build_status_script.text = AtomicString('$(document).ready(function(){ $("#buildstatus").load("%s");});' % (url))
+
+        # Set some necessary defaults for our child div
+        child_div.set('id', 'buildstatus')
+
+        # work with the special case of align or float
+        if 'align' in styles.keys() or 'float' in styles.keys():
+            if 'align' in styles.keys():
+                position = styles['align']
+                r_position = reverse_margin[styles['align']]
+
+                parent_css_style = ';'.join(['width: 100%; text-align: -moz-{}; text-align: -webkit-{};'.format(position, position), parent_div.get('style')])
+                child_css_style = 'text-align: -moz-{}; text-align: -webkit-{};'.format(r_position, r_position)
+
+                # drop any further use of 'align'
+                styles.pop('align', None)
+            else:
+                position = styles['float']
+                r_position = reverse_margin[styles['float']]
+
+                parent_css_style = ';'.join(['width: 25%; text-align: -moz-{}; text-align: -webkit-{};'.format(position, position), parent_div.get('style')])
+                child_css_style = 'text-align: -moz-{}; text-align: -webkit-{};'.format(r_position, r_position)
+                # drop any further use of 'float'
+                styles.pop('float', None)
+
+            parent_div.set('style', parent_css_style)
+            child_div.set('style', child_css_style)
+
+        # Set any additional allowed CSS
+        child_div = self.addStyle(child_div, **styles)
+        return parent_div

--- a/python/MooseDocs/extensions/MooseCSS.py
+++ b/python/MooseDocs/extensions/MooseCSS.py
@@ -1,0 +1,65 @@
+from markdown.blockprocessors import BlockProcessor
+from MooseCommonExtension import MooseCommonExtension
+import re
+from markdown.util import etree
+
+class MooseCSS(BlockProcessor, MooseCommonExtension):
+    """
+    Markdown extension for applying CSS styles to paragraph
+    Markdown syntax is:
+      !css <options>
+      Paragraph text here
+
+    Where <options> are key=value pairs.
+    """
+
+    RE = re.compile(r'^!\ ?css(.*)')
+    # If there are multiple css blocks on the same page then
+    # they need to have different ids
+    MATCHES_FOUND = 0
+
+    def __init__(self, parser, root=None, **kwargs):
+      MooseCommonExtension.__init__(self)
+      BlockProcessor.__init__(self, parser, **kwargs)
+
+    def test(self, parent, block):
+      """
+      Test to see if we should process this block of markdown.
+      Inherited from BlockProcessor.
+      """
+      return self.RE.search(block)
+
+    def run(self, parent, blocks):
+      """
+      Called when it is determined that we can process this block.
+      This will convert the markdown into HTML
+      """
+      sibling = self.lastChild(parent)
+      block = blocks.pop(0)
+      m = self.RE.search(block)
+
+      if m:
+        # Parse out the options on the css line
+        options, styles = self.getSettings(m.group(1))
+        block = block[m.end() + 1:] # removes the css line
+
+      block, paragraph = self.detab(block)
+      if m:
+        top_div = etree.SubElement(parent, 'div')
+        self.createCSS(top_div, styles, paragraph)
+      else:
+        top_div = sibling
+
+      self.parser.parseChunk(top_div, block)
+
+    def createCSS(self, top_div, styles, paragraph):
+        """
+        Creates the actual HTML required for the CSS paragraph to work.
+        Input:
+          top_div: div element that will contain the paragraph element
+          styles[dict]: The CSS style attributes
+          paragraph: the actual text within the <p></p> element
+        """
+
+        p_el = self.addStyle(etree.SubElement(top_div, 'p'), **styles)
+        p_el.text = paragraph

--- a/python/MooseDocs/extensions/MooseCarousel.py
+++ b/python/MooseDocs/extensions/MooseCarousel.py
@@ -181,10 +181,10 @@ class MooseCarousel(BlockProcessor, MooseCommonExtension):
         """
         c = etree.SubElement(parent, "a")
         alt_dir = "left"
-        chev = "glyphicon-chevron-left"
+        chev = "fa-chevron-circle-left"
         if direction == "next":
             alt_dir = "right"
-            chev = "glyphicon-chevron-right"
+            chev = "fa-chevron-circle-right"
 
         c.set("class", "%s carousel-control" % alt_dir)
         c.set("href", "#%s" % cid)
@@ -192,7 +192,7 @@ class MooseCarousel(BlockProcessor, MooseCommonExtension):
         c.set("data-slide", direction)
         s = etree.SubElement(c, "span")
 
-        s.set("class", "glyphicon %s" % chev)
+        s.set("class", "fa %s" % chev)
         s.set("aria-hidden", "true")
         s = etree.SubElement(c, "span")
         s.set("class", "sr-only")

--- a/python/MooseDocs/extensions/MooseCommonExtension.py
+++ b/python/MooseDocs/extensions/MooseCommonExtension.py
@@ -49,10 +49,11 @@ class MooseCommonExtension(object):
       SETTINGS_RE = re.compile("([^\s=]+)=(.*?)(?=(?:\s[^\s=]+=|$))")
       matches = SETTINGS_RE.findall(settings_line.strip())
 
-      if not matches:
-        return {}
       options = copy.copy(self._settings)
       styles = {}
+      if len(matches) == 0:
+          return options, styles
+
       for entry in matches:
         if entry[0] in options.keys():
             options[entry[0].strip()] = entry[1].strip()

--- a/python/MooseDocs/extensions/MooseImageFile.py
+++ b/python/MooseDocs/extensions/MooseImageFile.py
@@ -20,7 +20,7 @@ class MooseImageFile(MooseCommonExtension, Pattern):
     """
 
     # Find !image /path/to/file attribute=setting
-    RE = r'^!\ ?image\s+(.*?)\s+(.*)'
+    RE = r'^!image\s+(.*?)(?:$|\s+)(.*)'
 
     def __init__(self, root=None, **kwargs):
         MooseCommonExtension.__init__(self)

--- a/python/MooseDocs/extensions/MooseMarkdown.py
+++ b/python/MooseDocs/extensions/MooseMarkdown.py
@@ -10,6 +10,7 @@ from MoosePackageParser import MoosePackageParser
 from MooseMarkdownLinkPreprocessor import MooseMarkdownLinkPreprocessor
 from MooseCarousel import MooseCarousel
 from MooseDiagram import MooseDiagram
+from MooseCSS import MooseCSS
 from MooseSlidePreprocessor import MooseSlidePreprocessor
 from MooseBuildStatus import MooseBuildStatus
 import MooseDocs
@@ -57,6 +58,7 @@ class MooseMarkdown(markdown.Extension):
         # Block processors
         md.parser.blockprocessors.add('diagrams', MooseDiagram(md.parser, graphviz=config['graphviz']), '_begin')
         md.parser.blockprocessors.add('slideshow', MooseCarousel(md.parser, root=config['root']), '_begin')
+        md.parser.blockprocessors.add('css', MooseCSS(md.parser, root=config['root']), '_begin')
 
         # Inline Patterns
         md.inlinePatterns.add('moose_input_block', MooseInputBlock(markdown_instance=md, repo=config['repo'], root=config['root']), '<image_link')

--- a/python/MooseDocs/extensions/MooseMarkdown.py
+++ b/python/MooseDocs/extensions/MooseMarkdown.py
@@ -11,6 +11,7 @@ from MooseMarkdownLinkPreprocessor import MooseMarkdownLinkPreprocessor
 from MooseCarousel import MooseCarousel
 from MooseDiagram import MooseDiagram
 from MooseSlidePreprocessor import MooseSlidePreprocessor
+from MooseBuildStatus import MooseBuildStatus
 import MooseDocs
 import utils
 
@@ -62,6 +63,7 @@ class MooseMarkdown(markdown.Extension):
         md.inlinePatterns.add('moose_cpp_method', MooseCppMethod(markdown_instance=md, make=config['make'], repo=config['repo'], root=config['root']), '<image_link')
         md.inlinePatterns.add('moose_text', MooseTextFile(markdown_instance=md, repo=config['repo'], root=config['root']), '<image_link')
         md.inlinePatterns.add('moose_image', MooseImageFile(markdown_instance=md, root=config['root']), '<image_link')
+        md.inlinePatterns.add('moose_build_status', MooseBuildStatus(markdown_instance=md), '_begin')
 
         if config['package']:
             md.inlinePatterns.add('moose_package_parser', MoosePackageParser(markdown_instance=md), '_end')


### PR DESCRIPTION
Allow for CSS to control markdown paragraphs.

Refs: #7716 
