### PR TITLE
Fix edge case in IsotropicTempDepHardening

### DIFF
--- a/modules/solid_mechanics/include/materials/IsotropicTempDepHardening.h
+++ b/modules/solid_mechanics/include/materials/IsotropicTempDepHardening.h
@@ -30,7 +30,8 @@ protected:
   const std::vector<FunctionName> _hardening_functions_names;
   std::vector<PiecewiseLinear *> _hardening_functions;
   std::vector<Real> _hf_temperatures;
-  unsigned int _hf_index;
+  unsigned int _hf_index_lo;
+  unsigned int _hf_index_hi;
   Real _hf_fraction;
 };
 

--- a/modules/tensor_mechanics/include/materials/RecomputeRadialReturnTempDepHardening.h
+++ b/modules/tensor_mechanics/include/materials/RecomputeRadialReturnTempDepHardening.h
@@ -36,7 +36,8 @@ protected:
   const std::vector<FunctionName> _hardening_functions_names;
   std::vector<PiecewiseLinear *> _hardening_functions;
   std::vector<Real> _hf_temperatures;
-  unsigned int _hf_index;
+  unsigned int _hf_index_lo;
+  unsigned int _hf_index_hi;
   Real _hf_fraction;
 };
 


### PR DESCRIPTION
 and RecomputeRadialReturnTempDepHardening closes #7722

@bwspenc 

(The style changes in IsotropicTempDepHardening are just to make the solid_mechanics version more similar to the same model in tensor_mechanics (RecomputeRadialReturnTempDepHardening).)
