### PR TITLE
Deprecate GrainTracker::getElementalValues()

### DIFF
--- a/modules/phase_field/include/auxkernels/FeatureFloodCountAux.h
+++ b/modules/phase_field/include/auxkernels/FeatureFloodCountAux.h
@@ -12,6 +12,7 @@
 
 //Forward Declarations
 class FeatureFloodCountAux;
+class GrainTrackerInterface;
 
 template<>
 InputParameters validParams<FeatureFloodCountAux>();
@@ -36,6 +37,8 @@ protected:
 
   /// Function being used to compute the value of this kernel
   const FeatureFloodCount & _flood_counter;
+  /// Extra interface pointer if this is a GrainTracker object
+  const GrainTrackerInterface * _grain_tracker_ptr;
 
   const unsigned int _var_idx;
   const MooseEnum _field_display;

--- a/modules/phase_field/src/postprocessors/FauxGrainTracker.C
+++ b/modules/phase_field/src/postprocessors/FauxGrainTracker.C
@@ -93,6 +93,8 @@ FauxGrainTracker::getEntityValue(dof_id_type entity_id, FeatureFloodCount::Field
 const std::vector<std::pair<unsigned int, unsigned int> > &
 FauxGrainTracker::getElementalValues(dof_id_type /*elem_id*/) const
 {
+  mooseDeprecated("GrainTrackerInterface::getElementalValues() is deprecated use GrainTrackerInterface::getOpToGrainsVector() instead");
+
   return _faux_data;
 }
 

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -121,7 +121,7 @@ GrainTracker::getGrainVolume(unsigned int grain_id) const
   if (grain_idx != libMesh::invalid_uint)
   {
     mooseAssert(_grain_id_to_grain_idx[grain_id] < _feature_sets.size(), "Grain index out of bounds");
-    // TODO: Not parallel consistent
+    // Note: This value is parallel consistent, see GrainTracker::broadcastAndUpdateGrainData()
     return _feature_sets[_grain_id_to_grain_idx[grain_id]]._volume;
   }
 
@@ -138,7 +138,7 @@ GrainTracker::getGrainCentroid(unsigned int grain_id) const
   if (grain_idx != libMesh::invalid_uint)
   {
     mooseAssert(_grain_id_to_grain_idx[grain_id] < _feature_sets.size(), "Grain index out of bounds");
-    // TODO: Not parallel consistent
+    // Note: This value is parallel consistent, see GrainTracker::broadcastAndUpdateGrainData()
     return _feature_sets[_grain_id_to_grain_idx[grain_id]]._centroid;
   }
 

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -90,6 +90,8 @@ GrainTracker::getEntityValue(dof_id_type entity_id, FieldType field_type, unsign
 const std::vector<std::pair<unsigned int, unsigned int> > &
 GrainTracker::getElementalValues(dof_id_type elem_id) const
 {
+  mooseDeprecated("GrainTrackerInterface::getElementalValues() is deprecated use GrainTrackerInterface::getOpToGrainsVector() instead");
+
   const auto pos = _elemental_data.find(elem_id);
 
   if (pos != _elemental_data.end())


### PR DESCRIPTION
This method is superseded by `getOpToGrainsVector()`. I plan to drop this method very soon (after all affected applications are cleaned up).

Ping @SudiptaBiswas, @dschwen 
