### PR TITLE
Demonstrate allgather_packed_range bug

### DIFF
--- a/test/include/userobjects/PackedRangeOverflow.h
+++ b/test/include/userobjects/PackedRangeOverflow.h
@@ -1,0 +1,41 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef PACKEDRANGEOVERFLOW_H
+#define PACKEDRANGEOVERFLOW_H
+
+#include "GeneralUserObject.h"
+
+class PackedRangeOverflow;
+
+template<>
+InputParameters validParams<PackedRangeOverflow>();
+
+/**
+ * Debug the packed range allgather method
+ */
+class PackedRangeOverflow : public GeneralUserObject
+{
+public:
+  PackedRangeOverflow(const InputParameters & parameters);
+
+  virtual void initialize();
+  virtual void execute();
+  virtual void finalize();
+  virtual void threadJoin(const UserObject & uo);
+
+  unsigned int _buffer_size;
+};
+
+#endif //PACKEDRANGEOVERFLOW_H

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -200,6 +200,7 @@
 #include "RealControlParameterReporter.h"
 #include "ScalarCoupledPostprocessor.h"
 #include "NumAdaptivityCycles.h"
+#include "PackedRangeOverflow.h"
 
 // Functions
 #include "TimestepSetupFunction.h"
@@ -505,6 +506,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerPostprocessor(RealControlParameterReporter);
   registerPostprocessor(ScalarCoupledPostprocessor);
   registerPostprocessor(NumAdaptivityCycles);
+  registerPostprocessor(PackedRangeOverflow);
 
   registerMarker(RandomHitMarker);
   registerMarker(QPointMarker);

--- a/test/src/userobjects/PackedRangeOverflow.C
+++ b/test/src/userobjects/PackedRangeOverflow.C
@@ -1,0 +1,59 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "PackedRangeOverflow.h"
+
+template<>
+InputParameters validParams<PackedRangeOverflow>()
+{
+  InputParameters params = validParams<GeneralUserObject >();
+  params.addRequiredParam<unsigned int>("buffer_size", "String buffer size (should be around 1000000)");
+  return params;
+}
+
+PackedRangeOverflow::PackedRangeOverflow(const InputParameters & parameters) :
+    GeneralUserObject(parameters),
+    _buffer_size(getParam<unsigned int>("buffer_size"))
+{
+}
+
+void
+PackedRangeOverflow::initialize()
+{
+}
+
+void
+PackedRangeOverflow::execute()
+{
+}
+
+void
+PackedRangeOverflow::finalize()
+{
+  std::vector<std::string> send_buffers(1);
+  std::vector<std::string> recv_buffers;
+
+  send_buffers[0].assign(_buffer_size, '*');
+
+  _communicator.allgather_packed_range((void *)(nullptr), send_buffers.begin(), send_buffers.end(),
+                                       std::back_inserter(recv_buffers));
+
+  if (recv_buffers.size() != _communicator.size())
+    mooseError("recv_buffers size is wrong");
+}
+
+void
+PackedRangeOverflow::threadJoin(const UserObject & /*uo*/)
+{
+}

--- a/test/tests/allgather_packed_range_bug/packed_range_debug.i
+++ b/test/tests/allgather_packed_range_bug/packed_range_debug.i
@@ -1,0 +1,20 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[UserObjects]
+  [./pack]
+    type = PackedRangeOverflow
+  [../]
+[]
+
+[Problem]
+  solve = false
+  kernel_coverage_check = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]

--- a/test/tests/allgather_packed_range_bug/tests
+++ b/test/tests/allgather_packed_range_bug/tests
@@ -1,0 +1,13 @@
+[Test]
+  [./overflow]
+    type = RunApp
+    input = 'packed_range_debug.i'
+    cli_args = "UserObjects/pack/buffer_size=1000080"
+  [../]
+  [./underflow]
+    type = RunApp
+    input = 'packed_range_debug.i'
+    cli_args = "UserObjects/pack/buffer_size=999920"
+    prereq = overflow
+  [../]
+[]


### PR DESCRIPTION
@permcody and @roystgnr , this demonstrates the packed range bug triggered by buffers > 1000000 bytes.

It looks like the `Parallel::pack_range` routine might not doing its job properly.
