### PR TITLE
Strengthen PETSc options in PorousFlow tests

### DIFF
--- a/modules/porous_flow/tests/dispersion/diff01.i
+++ b/modules/porous_flow/tests/dispersion/diff01.i
@@ -192,6 +192,8 @@
   [./smp]
     type = SMP
     full = true
+    petsc_options_iname = '-ksp_type -pc_type -sub_pc_type -sub_pc_factor_shift_type -pc_asm_overlap'
+    petsc_options_value = 'gmres      asm      lu           NONZERO                   2             '
   [../]
 []
 

--- a/modules/porous_flow/tests/dispersion/disp01.i
+++ b/modules/porous_flow/tests/dispersion/disp01.i
@@ -197,6 +197,8 @@
   [./smp]
     type = SMP
     full = true
+    petsc_options_iname = '-ksp_type -pc_type -sub_pc_type -sub_pc_factor_shift_type -pc_asm_overlap'
+    petsc_options_value = 'gmres      asm      lu           NONZERO                   2             '
   [../]
 []
 

--- a/modules/porous_flow/tests/dispersion/disp01_heavy.i
+++ b/modules/porous_flow/tests/dispersion/disp01_heavy.i
@@ -197,6 +197,8 @@
   [./smp]
     type = SMP
     full = true
+    petsc_options_iname = '-ksp_type -pc_type -sub_pc_type -sub_pc_factor_shift_type -pc_asm_overlap'
+    petsc_options_value = 'gmres      asm      lu           NONZERO                   2             '
   [../]
 []
 


### PR DESCRIPTION
These are @cpgr 's tests, so i give him the right to veto this PR.

Chris - these tests fail on one of my local computers, unless i include "stronger" PETSc options such as the ones i've used here.

Fixes #7737
