### PR TITLE
Reinit scalar vars before user objects are evaluated

### DIFF
--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -3493,6 +3493,9 @@ FEProblem::computeResidualType(const NumericVector<Number>& soln, NumericVector<
 
   execMultiApps(EXEC_LINEAR);
 
+  for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
+    reinitScalars(tid);
+
   computeUserObjects(EXEC_LINEAR, Moose::PRE_AUX);
 
   if (_displaced_problem != NULL)
@@ -3540,6 +3543,9 @@ FEProblem::computeJacobian(NonlinearImplicitSystem & sys, const NumericVector<Nu
 
     execTransfers(EXEC_NONLINEAR);
     execMultiApps(EXEC_NONLINEAR);
+
+    for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
+      reinitScalars(tid);
 
     computeUserObjects(EXEC_NONLINEAR, Moose::PRE_AUX);
 


### PR DESCRIPTION
Since user objects can couple scalar variables in, we should reinit the
values of all scalar variables before we execute the user object loop.

Refs #000
