### PR TITLE
Get rid of System from ThreadedElementLoop

### DIFF
--- a/framework/include/base/ComputeDiracThread.h
+++ b/framework/include/base/ComputeDiracThread.h
@@ -32,7 +32,7 @@ typedef StoredRange<std::set<const Elem *>::const_iterator, const Elem *> DistEl
 class ComputeDiracThread : public ThreadedElementLoop<DistElemRange>
 {
 public:
-  ComputeDiracThread(FEProblem & feproblem, NonlinearSystem & system, SparseMatrix<Number> * jacobian = NULL);
+  ComputeDiracThread(FEProblem & feproblem, SparseMatrix<Number> * jacobian = NULL);
 
   // Splitting Constructor
   ComputeDiracThread(ComputeDiracThread & x, Threads::split);
@@ -49,7 +49,7 @@ public:
 
 protected:
   SparseMatrix<Number> * _jacobian;
-  NonlinearSystem & _sys;
+  NonlinearSystem & _nl;
 
   /// Storage for DiracKernel objects
   const MooseObjectWarehouse<DiracKernel> & _dirac_kernels;

--- a/framework/include/base/ComputeElemAuxBcsThread.h
+++ b/framework/include/base/ComputeElemAuxBcsThread.h
@@ -29,7 +29,7 @@ class AuxKernel;
 class ComputeElemAuxBcsThread
 {
 public:
-  ComputeElemAuxBcsThread(FEProblem & problem, AuxiliarySystem & sys, const MooseObjectWarehouse<AuxKernel> & storage, bool need_materials);
+  ComputeElemAuxBcsThread(FEProblem & problem, const MooseObjectWarehouse<AuxKernel> & storage, bool need_materials);
   // Splitting Constructor
   ComputeElemAuxBcsThread(ComputeElemAuxBcsThread & x, Threads::split split);
 
@@ -39,7 +39,7 @@ public:
 
 protected:
   FEProblem & _problem;
-  AuxiliarySystem & _sys;
+  AuxiliarySystem & _aux_sys;
   THREAD_ID _tid;
 
   /// Storage object containing active AuxKernel objects

--- a/framework/include/base/ComputeElemAuxVarsThread.h
+++ b/framework/include/base/ComputeElemAuxVarsThread.h
@@ -30,7 +30,7 @@ class AuxiliarySystem;
 class ComputeElemAuxVarsThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  ComputeElemAuxVarsThread(FEProblem & problem, AuxiliarySystem & sys, const MooseObjectWarehouse<AuxKernel> & storage, bool need_materials);
+  ComputeElemAuxVarsThread(FEProblem & problem, const MooseObjectWarehouse<AuxKernel> & storage, bool need_materials);
   // Splitting Constructor
   ComputeElemAuxVarsThread(ComputeElemAuxVarsThread & x, Threads::split split);
 

--- a/framework/include/base/ComputeElemDampingThread.h
+++ b/framework/include/base/ComputeElemDampingThread.h
@@ -29,7 +29,7 @@ class ElementDamper;
 class ComputeElemDampingThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  ComputeElemDampingThread(FEProblem & feproblem, NonlinearSystem & sys);
+  ComputeElemDampingThread(FEProblem & feproblem);
 
   // Splitting Constructor
   ComputeElemDampingThread(ComputeElemDampingThread & x, Threads::split split);

--- a/framework/include/base/ComputeFullJacobianThread.h
+++ b/framework/include/base/ComputeFullJacobianThread.h
@@ -24,7 +24,7 @@ class NonlinearSystem;
 class ComputeFullJacobianThread : public ComputeJacobianThread
 {
 public:
-  ComputeFullJacobianThread(FEProblem & fe_problem, NonlinearSystem & sys, SparseMatrix<Number> & jacobian);
+  ComputeFullJacobianThread(FEProblem & fe_problem, SparseMatrix<Number> & jacobian);
 
   // Splitting Constructor
   ComputeFullJacobianThread(ComputeFullJacobianThread & x, Threads::split split);
@@ -38,6 +38,8 @@ protected:
   virtual void computeFaceJacobian(BoundaryID bnd_id) override;
   virtual void computeInternalFaceJacobian(const Elem * neighbor) override;
   virtual void computeInternalInterFaceJacobian(BoundaryID bnd_id) override;
+
+  NonlinearSystem & _nl;
 
   // Reference to BC storage structures
   const MooseObjectWarehouse<IntegratedBC> & _integrated_bcs;

--- a/framework/include/base/ComputeIndicatorThread.h
+++ b/framework/include/base/ComputeIndicatorThread.h
@@ -33,7 +33,7 @@ public:
    * @param indicator_whs Warehouse of Indicator objects.
    * @param finalize Whether or not we are just in the "finalize" stage or not.
    */
-  ComputeIndicatorThread(FEProblem & fe_problem, AuxiliarySystem & sys, bool finalize = false);
+  ComputeIndicatorThread(FEProblem & fe_problem, bool finalize = false);
 
   // Splitting Constructor
   ComputeIndicatorThread(ComputeIndicatorThread & x, Threads::split split);

--- a/framework/include/base/ComputeJacobianThread.h
+++ b/framework/include/base/ComputeJacobianThread.h
@@ -31,7 +31,7 @@ class KernelWarehouse;
 class ComputeJacobianThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  ComputeJacobianThread(FEProblem & fe_problem, NonlinearSystem & sys, SparseMatrix<Number> & jacobian);
+  ComputeJacobianThread(FEProblem & fe_problem, SparseMatrix<Number> & jacobian);
 
   // Splitting Constructor
   ComputeJacobianThread(ComputeJacobianThread & x, Threads::split split);
@@ -50,7 +50,7 @@ public:
 
 protected:
   SparseMatrix<Number> & _jacobian;
-  NonlinearSystem & _sys;
+  NonlinearSystem & _nl;
 
   unsigned int _num_cached;
 

--- a/framework/include/base/ComputeMarkerThread.h
+++ b/framework/include/base/ComputeMarkerThread.h
@@ -25,7 +25,7 @@ class AuxiliarySystem;
 class ComputeMarkerThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  ComputeMarkerThread(FEProblem & fe_problem, AuxiliarySystem & sys);
+  ComputeMarkerThread(FEProblem & fe_problem);
 
   // Splitting Constructor
   ComputeMarkerThread(ComputeMarkerThread & x, Threads::split split);

--- a/framework/include/base/ComputeMaterialsObjectThread.h
+++ b/framework/include/base/ComputeMaterialsObjectThread.h
@@ -30,7 +30,7 @@ class Assembly;
 class ComputeMaterialsObjectThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  ComputeMaterialsObjectThread(FEProblem & fe_problem, NonlinearSystem & sys,
+  ComputeMaterialsObjectThread(FEProblem & fe_problem,
                                std::vector<MooseSharedPointer<MaterialData> > & material_data,
                                std::vector<MooseSharedPointer<MaterialData> > & bnd_material_data,
                                std::vector<MooseSharedPointer<MaterialData> > & neighbor_material_data,
@@ -53,7 +53,7 @@ public:
 
 protected:
   FEProblem & _fe_problem;
-  NonlinearSystem & _sys;
+  NonlinearSystem & _nl;
   std::vector<MooseSharedPointer<MaterialData> > & _material_data;
   std::vector<MooseSharedPointer<MaterialData> > & _bnd_material_data;
   std::vector<MooseSharedPointer<MaterialData> > & _neighbor_material_data;

--- a/framework/include/base/ComputeNodalAuxBcsThread.h
+++ b/framework/include/base/ComputeNodalAuxBcsThread.h
@@ -21,7 +21,7 @@
 class ComputeNodalAuxBcsThread : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
 {
 public:
-  ComputeNodalAuxBcsThread(FEProblem & fe_problem, AuxiliarySystem & sys, const MooseObjectWarehouse<AuxKernel> & storage);
+  ComputeNodalAuxBcsThread(FEProblem & fe_problem, const MooseObjectWarehouse<AuxKernel> & storage);
 
   // Splitting Constructor
   ComputeNodalAuxBcsThread(ComputeNodalAuxBcsThread & x, Threads::split split);

--- a/framework/include/base/ComputeNodalAuxVarsThread.h
+++ b/framework/include/base/ComputeNodalAuxVarsThread.h
@@ -29,7 +29,7 @@ class AuxiliarySystem;
 class ComputeNodalAuxVarsThread : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
 {
 public:
-  ComputeNodalAuxVarsThread(FEProblem & fe_problem, AuxiliarySystem & sys, const MooseObjectWarehouse<AuxKernel> & storage);
+  ComputeNodalAuxVarsThread(FEProblem & fe_problem, const MooseObjectWarehouse<AuxKernel> & storage);
   // Splitting Constructor
   ComputeNodalAuxVarsThread(ComputeNodalAuxVarsThread & x, Threads::split split);
 
@@ -38,7 +38,7 @@ public:
   void join(const ComputeNodalAuxVarsThread & /*y*/);
 
 protected:
-  AuxiliarySystem & _sys;
+  AuxiliarySystem & _aux_sys;
 
   /// Storage object containing active AuxKernel objects
   const MooseObjectWarehouse<AuxKernel> & _storage;

--- a/framework/include/base/ComputeNodalKernelBCJacobiansThread.h
+++ b/framework/include/base/ComputeNodalKernelBCJacobiansThread.h
@@ -28,7 +28,7 @@ class NodalKernel;
 class ComputeNodalKernelBCJacobiansThread : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
 {
 public:
-  ComputeNodalKernelBCJacobiansThread(FEProblem & fe_problem, AuxiliarySystem & sys, const MooseObjectWarehouse<NodalKernel> & nodal_kernels,  SparseMatrix<Number> & jacobian);
+  ComputeNodalKernelBCJacobiansThread(FEProblem & fe_problem, const MooseObjectWarehouse<NodalKernel> & nodal_kernels,  SparseMatrix<Number> & jacobian);
 
   // Splitting Constructor
   ComputeNodalKernelBCJacobiansThread(ComputeNodalKernelBCJacobiansThread & x, Threads::split split);
@@ -40,7 +40,7 @@ public:
   void join(const ComputeNodalKernelBCJacobiansThread & /*y*/);
 
 protected:
-  AuxiliarySystem & _sys;
+  AuxiliarySystem & _aux_sys;
 
   const MooseObjectWarehouse<NodalKernel> & _nodal_kernels;
 

--- a/framework/include/base/ComputeNodalKernelBcsThread.h
+++ b/framework/include/base/ComputeNodalKernelBcsThread.h
@@ -24,7 +24,7 @@ class NodalKernel;
 class ComputeNodalKernelBcsThread : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
 {
 public:
-  ComputeNodalKernelBcsThread(FEProblem & fe_problem, AuxiliarySystem & sys, const MooseObjectWarehouse<NodalKernel> & nodal_kernels);
+  ComputeNodalKernelBcsThread(FEProblem & fe_problem, const MooseObjectWarehouse<NodalKernel> & nodal_kernels);
   // Splitting Constructor
   ComputeNodalKernelBcsThread(ComputeNodalKernelBcsThread & x, Threads::split split);
 
@@ -35,7 +35,7 @@ public:
   void join(const ComputeNodalKernelBcsThread & /*y*/);
 
 protected:
-  AuxiliarySystem & _sys;
+  AuxiliarySystem & _aux_sys;
 
   const MooseObjectWarehouse<NodalKernel> & _nodal_kernels;
 

--- a/framework/include/base/ComputeNodalKernelJacobiansThread.h
+++ b/framework/include/base/ComputeNodalKernelJacobiansThread.h
@@ -36,7 +36,6 @@ class ComputeNodalKernelJacobiansThread : public ThreadedNodeLoop<ConstNodeRange
 {
 public:
   ComputeNodalKernelJacobiansThread(FEProblem & fe_problem,
-                                    AuxiliarySystem & sys,
                                     const MooseObjectWarehouse<NodalKernel> & nodal_kernels,
                                     SparseMatrix<Number> & jacobian);
 

--- a/framework/include/base/ComputeNodalKernelsThread.h
+++ b/framework/include/base/ComputeNodalKernelsThread.h
@@ -28,7 +28,7 @@ class NodalKernel;
 class ComputeNodalKernelsThread : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
 {
 public:
-  ComputeNodalKernelsThread(FEProblem & fe_problem, AuxiliarySystem & sys, const MooseObjectWarehouse<NodalKernel> & nodal_kernels);
+  ComputeNodalKernelsThread(FEProblem & fe_problem, const MooseObjectWarehouse<NodalKernel> & nodal_kernels);
 
   // Splitting Constructor
   ComputeNodalKernelsThread(ComputeNodalKernelsThread & x, Threads::split split);

--- a/framework/include/base/ComputeResidualThread.h
+++ b/framework/include/base/ComputeResidualThread.h
@@ -33,7 +33,7 @@ class KernelWarehouse;
 class ComputeResidualThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
-  ComputeResidualThread(FEProblem & fe_problem, NonlinearSystem & sys, Moose::KernelType type);
+  ComputeResidualThread(FEProblem & fe_problem, Moose::KernelType type);
   // Splitting Constructor
   ComputeResidualThread(ComputeResidualThread & x, Threads::split split);
 
@@ -50,7 +50,7 @@ public:
   void join(const ComputeResidualThread & /*y*/);
 
 protected:
-  NonlinearSystem & _sys;
+  NonlinearSystem & _nl;
   Moose::KernelType _kernel_type;
   unsigned int _num_cached;
 

--- a/framework/include/base/ThreadedElementLoop.h
+++ b/framework/include/base/ThreadedElementLoop.h
@@ -38,7 +38,7 @@ template<typename RangeType>
 class ThreadedElementLoop : public ThreadedElementLoopBase<RangeType>
 {
 public:
-  ThreadedElementLoop(FEProblem & feproblem, SystemBase & system);
+  ThreadedElementLoop(FEProblem & feproblem);
 
   ThreadedElementLoop(ThreadedElementLoop & x, Threads::split split);
 
@@ -48,15 +48,13 @@ public:
 
   virtual bool keepGoing() override { return !_fe_problem.hasException(); }
 protected:
-  SystemBase & _system;
   FEProblem & _fe_problem;
 };
 
 
 template<typename RangeType>
-ThreadedElementLoop<RangeType>::ThreadedElementLoop(FEProblem & fe_problem, SystemBase & system) :
-    ThreadedElementLoopBase<RangeType>(system.mesh()),
-    _system(system),
+ThreadedElementLoop<RangeType>::ThreadedElementLoop(FEProblem & fe_problem) :
+    ThreadedElementLoopBase<RangeType>(fe_problem.mesh()),
     _fe_problem(fe_problem)
 {
 }
@@ -64,7 +62,6 @@ ThreadedElementLoop<RangeType>::ThreadedElementLoop(FEProblem & fe_problem, Syst
 template<typename RangeType>
 ThreadedElementLoop<RangeType>::ThreadedElementLoop(ThreadedElementLoop & x, Threads::split /*split*/) :
     ThreadedElementLoopBase<RangeType>(x),
-    _system(x._system),
     _fe_problem(x._fe_problem)
 {
 }

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -389,7 +389,7 @@ AuxiliarySystem::computeNodalVars(ExecFlagType type)
     if (nodal.hasActiveBlockObjects())
     {
       ConstNodeRange & range = *_mesh.getLocalNodeRange();
-      ComputeNodalAuxVarsThread navt(_fe_problem, *this, nodal);
+      ComputeNodalAuxVarsThread navt(_fe_problem, nodal);
       Threads::parallel_reduce(range, navt);
 
       solution().close();
@@ -405,7 +405,7 @@ AuxiliarySystem::computeNodalVars(ExecFlagType type)
     if (nodal.hasActiveBoundaryObjects())
     {
       ConstBndNodeRange & bnd_nodes = *_mesh.getBoundaryNodeRange();
-      ComputeNodalAuxBcsThread nabt(_fe_problem, *this, nodal);
+      ComputeNodalAuxBcsThread nabt(_fe_problem, nodal);
       Threads::parallel_reduce(bnd_nodes, nabt);
 
       solution().close();
@@ -430,7 +430,7 @@ AuxiliarySystem::computeElementalVars(ExecFlagType type)
     if (elemental.hasActiveBlockObjects())
     {
       ConstElemRange & range = *_mesh.getActiveLocalElementRange();
-      ComputeElemAuxVarsThread eavt(_fe_problem, *this, elemental, true);
+      ComputeElemAuxVarsThread eavt(_fe_problem, elemental, true);
       Threads::parallel_reduce(range, eavt);
 
       solution().close();
@@ -441,7 +441,7 @@ AuxiliarySystem::computeElementalVars(ExecFlagType type)
     if (elemental.hasActiveBoundaryObjects())
     {
       ConstBndElemRange & bnd_elems = *_mesh.getBoundaryElementRange();
-      ComputeElemAuxBcsThread eabt(_fe_problem, *this, elemental, true);
+      ComputeElemAuxBcsThread eabt(_fe_problem, elemental, true);
       Threads::parallel_reduce(bnd_elems, eabt);
 
       solution().close();

--- a/framework/src/base/ComputeDiracThread.C
+++ b/framework/src/base/ComputeDiracThread.C
@@ -27,19 +27,18 @@
 #include "libmesh/threads.h"
 
 ComputeDiracThread::ComputeDiracThread(FEProblem & feproblem,
-                                       NonlinearSystem & system,
                                        SparseMatrix<Number> * jacobian) :
     ThreadedElementLoop<DistElemRange>(feproblem),
     _jacobian(jacobian),
-    _sys(system),
-    _dirac_kernels(_sys.getDiracKernelWarehouse())
+    _nl(feproblem.getNonlinearSystem()),
+    _dirac_kernels(_nl.getDiracKernelWarehouse())
 {}
 
 // Splitting Constructor
 ComputeDiracThread::ComputeDiracThread(ComputeDiracThread & x, Threads::split split) :
     ThreadedElementLoop<DistElemRange>(x, split),
     _jacobian(x._jacobian),
-    _sys(x._sys),
+    _nl(x._nl),
     _dirac_kernels(x._dirac_kernels)
 {
 }

--- a/framework/src/base/ComputeDiracThread.C
+++ b/framework/src/base/ComputeDiracThread.C
@@ -29,7 +29,7 @@
 ComputeDiracThread::ComputeDiracThread(FEProblem & feproblem,
                                        NonlinearSystem & system,
                                        SparseMatrix<Number> * jacobian) :
-    ThreadedElementLoop<DistElemRange>(feproblem, system),
+    ThreadedElementLoop<DistElemRange>(feproblem),
     _jacobian(jacobian),
     _sys(system),
     _dirac_kernels(_sys.getDiracKernelWarehouse())

--- a/framework/src/base/ComputeElemAuxVarsThread.C
+++ b/framework/src/base/ComputeElemAuxVarsThread.C
@@ -20,9 +20,9 @@
 #include "libmesh/threads.h"
 
 
-ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(FEProblem & problem, AuxiliarySystem & sys, const MooseObjectWarehouse<AuxKernel> & storage, bool need_materials) :
+ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(FEProblem & problem, const MooseObjectWarehouse<AuxKernel> & storage, bool need_materials) :
     ThreadedElementLoop<ConstElemRange>(problem),
-    _aux_sys(sys),
+    _aux_sys(problem.getAuxiliarySystem()),
     _aux_kernels(storage),
     _need_materials(need_materials)
 {

--- a/framework/src/base/ComputeElemAuxVarsThread.C
+++ b/framework/src/base/ComputeElemAuxVarsThread.C
@@ -21,7 +21,7 @@
 
 
 ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(FEProblem & problem, AuxiliarySystem & sys, const MooseObjectWarehouse<AuxKernel> & storage, bool need_materials) :
-    ThreadedElementLoop<ConstElemRange>(problem, sys),
+    ThreadedElementLoop<ConstElemRange>(problem),
     _aux_sys(sys),
     _aux_kernels(storage),
     _need_materials(need_materials)
@@ -30,7 +30,7 @@ ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(FEProblem & problem, Auxiliar
 
 // Splitting Constructor
 ComputeElemAuxVarsThread::ComputeElemAuxVarsThread(ComputeElemAuxVarsThread & x, Threads::split /*split*/) :
-    ThreadedElementLoop<ConstElemRange>(x._fe_problem, x._system),
+    ThreadedElementLoop<ConstElemRange>(x._fe_problem),
     _aux_sys(x._aux_sys),
     _aux_kernels(x._aux_kernels),
     _need_materials(x._need_materials)
@@ -93,7 +93,7 @@ ComputeElemAuxVarsThread::onElement(const Elem * elem)
       for (const auto & it : _aux_sys._elem_vars[_tid])
       {
         MooseVariable * var = it.second;
-        var->insert(_system.solution());
+        var->insert(_aux_sys.solution());
       }
     }
   }

--- a/framework/src/base/ComputeElemDampingThread.C
+++ b/framework/src/base/ComputeElemDampingThread.C
@@ -23,7 +23,7 @@
 
 ComputeElemDampingThread::ComputeElemDampingThread(FEProblem & feproblem,
                                                    NonlinearSystem & sys) :
-    ThreadedElementLoop<ConstElemRange>(feproblem, sys),
+    ThreadedElementLoop<ConstElemRange>(feproblem),
     _damping(1.0),
     _nl(sys),
     _element_dampers(sys.getElementDamperWarehouse())

--- a/framework/src/base/ComputeElemDampingThread.C
+++ b/framework/src/base/ComputeElemDampingThread.C
@@ -21,12 +21,11 @@
 // libMesh includes
 #include "libmesh/threads.h"
 
-ComputeElemDampingThread::ComputeElemDampingThread(FEProblem & feproblem,
-                                                   NonlinearSystem & sys) :
+ComputeElemDampingThread::ComputeElemDampingThread(FEProblem & feproblem) :
     ThreadedElementLoop<ConstElemRange>(feproblem),
     _damping(1.0),
-    _nl(sys),
-    _element_dampers(sys.getElementDamperWarehouse())
+    _nl(feproblem.getNonlinearSystem()),
+    _element_dampers(_nl.getElementDamperWarehouse())
 {
 }
 

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -23,11 +23,10 @@
 #include "libmesh/threads.h"
 
 ComputeIndicatorThread::ComputeIndicatorThread(FEProblem & fe_problem,
-                                               AuxiliarySystem & sys,
                                                bool finalize) :
     ThreadedElementLoop<ConstElemRange>(fe_problem),
     _fe_problem(fe_problem),
-    _aux_sys(sys),
+    _aux_sys(fe_problem.getAuxiliarySystem()),
     _indicator_whs(_fe_problem.getIndicatorWarehouse()),
     _internal_side_indicators(_fe_problem.getInternalSideIndicatorWarehouse()),
     _finalize(finalize)

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -25,7 +25,7 @@
 ComputeIndicatorThread::ComputeIndicatorThread(FEProblem & fe_problem,
                                                AuxiliarySystem & sys,
                                                bool finalize) :
-    ThreadedElementLoop<ConstElemRange>(fe_problem, sys),
+    ThreadedElementLoop<ConstElemRange>(fe_problem),
     _fe_problem(fe_problem),
     _aux_sys(sys),
     _indicator_whs(_fe_problem.getIndicatorWarehouse()),

--- a/framework/src/base/ComputeJacobianBlocksThread.C
+++ b/framework/src/base/ComputeJacobianBlocksThread.C
@@ -22,7 +22,7 @@
 #include "libmesh/threads.h"
 
 ComputeJacobianBlocksThread::ComputeJacobianBlocksThread(FEProblem & fe_problem, std::vector<JacobianBlock*> & blocks) :
-    ComputeFullJacobianThread(fe_problem, fe_problem.getNonlinearSystem(), blocks[0]->_jacobian /* have to pass something */),
+    ComputeFullJacobianThread(fe_problem, blocks[0]->_jacobian /* have to pass something */),
     _blocks(blocks)
 {
 }

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -25,15 +25,15 @@
 // libmesh includes
 #include "libmesh/threads.h"
 
-ComputeJacobianThread::ComputeJacobianThread(FEProblem & fe_problem, NonlinearSystem & sys, SparseMatrix<Number> & jacobian) :
+ComputeJacobianThread::ComputeJacobianThread(FEProblem & fe_problem, SparseMatrix<Number> & jacobian) :
     ThreadedElementLoop<ConstElemRange>(fe_problem),
     _jacobian(jacobian),
-    _sys(sys),
+    _nl(fe_problem.getNonlinearSystem()),
     _num_cached(0),
-    _integrated_bcs(sys.getIntegratedBCWarehouse()),
-    _dg_kernels(sys.getDGKernelWarehouse()),
-    _interface_kernels(sys.getInterfaceKernelWarehouse()),
-    _kernels(sys.getKernelWarehouse())
+    _integrated_bcs(_nl.getIntegratedBCWarehouse()),
+    _dg_kernels(_nl.getDGKernelWarehouse()),
+    _interface_kernels(_nl.getInterfaceKernelWarehouse()),
+    _kernels(_nl.getKernelWarehouse())
 {
 }
 
@@ -41,7 +41,7 @@ ComputeJacobianThread::ComputeJacobianThread(FEProblem & fe_problem, NonlinearSy
 ComputeJacobianThread::ComputeJacobianThread(ComputeJacobianThread & x, Threads::split split) :
     ThreadedElementLoop<ConstElemRange>(x, split),
     _jacobian(x._jacobian),
-    _sys(x._sys),
+    _nl(x._nl),
     _num_cached(x._num_cached),
     _integrated_bcs(x._integrated_bcs),
     _dg_kernels(x._dg_kernels),
@@ -141,7 +141,7 @@ ComputeJacobianThread::onElement(const Elem *elem)
   _fe_problem.reinitElem(elem, _tid);
 
   _fe_problem.reinitMaterials(_subdomain, _tid);
-  if (_sys.getScalarVariables(_tid).size() > 0)
+  if (_nl.getScalarVariables(_tid).size() > 0)
     _fe_problem.reinitOffDiagScalars(_tid);
 
   computeJacobian();

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -26,7 +26,7 @@
 #include "libmesh/threads.h"
 
 ComputeJacobianThread::ComputeJacobianThread(FEProblem & fe_problem, NonlinearSystem & sys, SparseMatrix<Number> & jacobian) :
-    ThreadedElementLoop<ConstElemRange>(fe_problem, sys),
+    ThreadedElementLoop<ConstElemRange>(fe_problem),
     _jacobian(jacobian),
     _sys(sys),
     _num_cached(0),

--- a/framework/src/base/ComputeMarkerThread.C
+++ b/framework/src/base/ComputeMarkerThread.C
@@ -23,7 +23,7 @@
 #include "libmesh/threads.h"
 
 ComputeMarkerThread::ComputeMarkerThread(FEProblem & fe_problem, AuxiliarySystem & sys) :
-    ThreadedElementLoop<ConstElemRange>(fe_problem, sys),
+    ThreadedElementLoop<ConstElemRange>(fe_problem),
     _fe_problem(fe_problem),
     _aux_sys(sys),
     _marker_whs(_fe_problem.getMarkerWarehouse())

--- a/framework/src/base/ComputeMarkerThread.C
+++ b/framework/src/base/ComputeMarkerThread.C
@@ -22,10 +22,10 @@
 // libmesh includes
 #include "libmesh/threads.h"
 
-ComputeMarkerThread::ComputeMarkerThread(FEProblem & fe_problem, AuxiliarySystem & sys) :
+ComputeMarkerThread::ComputeMarkerThread(FEProblem & fe_problem) :
     ThreadedElementLoop<ConstElemRange>(fe_problem),
     _fe_problem(fe_problem),
-    _aux_sys(sys),
+    _aux_sys(fe_problem.getAuxiliarySystem()),
     _marker_whs(_fe_problem.getMarkerWarehouse())
 {
 }

--- a/framework/src/base/ComputeMaterialsObjectThread.C
+++ b/framework/src/base/ComputeMaterialsObjectThread.C
@@ -27,7 +27,7 @@
 #include "libmesh/threads.h"
 #include "libmesh/quadrature.h"
 
-ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(FEProblem & fe_problem, NonlinearSystem & sys,
+ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(FEProblem & fe_problem,
                                                            std::vector<MooseSharedPointer<MaterialData> > & material_data,
                                                            std::vector<MooseSharedPointer<MaterialData> > & bnd_material_data,
                                                            std::vector<MooseSharedPointer<MaterialData> > & neighbor_material_data,
@@ -36,7 +36,7 @@ ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(FEProblem & fe_proble
                                                            std::vector<Assembly *> & assembly) :
 ThreadedElementLoop<ConstElemRange>(fe_problem),
   _fe_problem(fe_problem),
-  _sys(sys),
+  _nl(fe_problem.getNonlinearSystem()),
   _material_data(material_data),
   _bnd_material_data(bnd_material_data),
   _neighbor_material_data(neighbor_material_data),
@@ -55,7 +55,7 @@ ThreadedElementLoop<ConstElemRange>(fe_problem),
 ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(ComputeMaterialsObjectThread & x, Threads::split split) :
     ThreadedElementLoop<ConstElemRange>(x, split),
     _fe_problem(x._fe_problem),
-    _sys(x._sys),
+    _nl(x._nl),
     _material_data(x._material_data),
     _bnd_material_data(x._bnd_material_data),
     _neighbor_material_data(x._neighbor_material_data),

--- a/framework/src/base/ComputeMaterialsObjectThread.C
+++ b/framework/src/base/ComputeMaterialsObjectThread.C
@@ -34,7 +34,7 @@ ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(FEProblem & fe_proble
                                                            MaterialPropertyStorage & material_props,
                                                            MaterialPropertyStorage & bnd_material_props,
                                                            std::vector<Assembly *> & assembly) :
-ThreadedElementLoop<ConstElemRange>(fe_problem, sys),
+ThreadedElementLoop<ConstElemRange>(fe_problem),
   _fe_problem(fe_problem),
   _sys(sys),
   _material_data(material_data),

--- a/framework/src/base/ComputeNodalAuxBcsThread.C
+++ b/framework/src/base/ComputeNodalAuxBcsThread.C
@@ -23,10 +23,9 @@
 
 
 ComputeNodalAuxBcsThread::ComputeNodalAuxBcsThread(FEProblem & fe_problem,
-                                                   AuxiliarySystem & sys,
                                                    const MooseObjectWarehouse<AuxKernel> & storage) :
     ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>(fe_problem),
-    _aux_sys(sys),
+    _aux_sys(fe_problem.getAuxiliarySystem()),
     _storage(storage)
 {
 }

--- a/framework/src/base/ComputeNodalAuxVarsThread.C
+++ b/framework/src/base/ComputeNodalAuxVarsThread.C
@@ -21,10 +21,9 @@
 #include "libmesh/threads.h"
 
 ComputeNodalAuxVarsThread::ComputeNodalAuxVarsThread(FEProblem & fe_problem,
-                                                     AuxiliarySystem & sys,
                                                      const MooseObjectWarehouse<AuxKernel> & storage) :
     ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(fe_problem),
-    _sys(sys),
+    _aux_sys(fe_problem.getAuxiliarySystem()),
     _storage(storage)
 {
 }
@@ -32,7 +31,7 @@ ComputeNodalAuxVarsThread::ComputeNodalAuxVarsThread(FEProblem & fe_problem,
 // Splitting Constructor
 ComputeNodalAuxVarsThread::ComputeNodalAuxVarsThread(ComputeNodalAuxVarsThread & x, Threads::split split) :
     ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(x, split),
-    _sys(x._sys),
+    _aux_sys(x._aux_sys),
     _storage(x._storage)
 {
 }
@@ -43,7 +42,7 @@ ComputeNodalAuxVarsThread::onNode(ConstNodeRange::const_iterator & node_it)
   const Node * node = *node_it;
 
   // prepare variables
-  for (const auto & it : _sys._nodal_vars[_tid])
+  for (const auto & it : _aux_sys._nodal_vars[_tid])
   {
     MooseVariable * var = it.second;
     var->prepareAux();
@@ -55,7 +54,7 @@ ComputeNodalAuxVarsThread::onNode(ConstNodeRange::const_iterator & node_it)
   const std::map<SubdomainID, std::vector<MooseSharedPointer<AuxKernel> > > & block_kernels = _storage.getActiveBlockObjects(_tid);
 
   // Loop over all SubdomainIDs for the curnent node, if an AuxKernel is active on this block then compute it.
-  const std::set<SubdomainID> & block_ids = _sys.mesh().getNodeBlockIds(*node);
+  const std::set<SubdomainID> & block_ids = _aux_sys.mesh().getNodeBlockIds(*node);
   for (const auto & block : block_ids)
   {
     std::map<SubdomainID, std::vector<MooseSharedPointer<AuxKernel> > >::const_iterator iter = block_kernels.find(block);
@@ -68,10 +67,10 @@ ComputeNodalAuxVarsThread::onNode(ConstNodeRange::const_iterator & node_it)
   // We are done, so update the solution vector
   {
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-    for (const auto & it : _sys._nodal_vars[_tid])
+    for (const auto & it : _aux_sys._nodal_vars[_tid])
     {
       MooseVariable * var = it.second;
-      var->insert(_sys.solution());
+      var->insert(_aux_sys.solution());
     }
   }
 }

--- a/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
@@ -21,11 +21,10 @@
 #include "libmesh/threads.h"
 
 ComputeNodalKernelBCJacobiansThread::ComputeNodalKernelBCJacobiansThread(FEProblem & fe_problem,
-                                                                         AuxiliarySystem & sys,
                                                                          const MooseObjectWarehouse<NodalKernel> & nodal_kernels,
                                                                          SparseMatrix<Number> & jacobian) :
     ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>(fe_problem),
-    _sys(sys),
+    _aux_sys(fe_problem.getAuxiliarySystem()),
     _nodal_kernels(nodal_kernels),
     _jacobian(jacobian),
     _num_cached(0)
@@ -35,7 +34,7 @@ ComputeNodalKernelBCJacobiansThread::ComputeNodalKernelBCJacobiansThread(FEProbl
 // Splitting Constructor
 ComputeNodalKernelBCJacobiansThread::ComputeNodalKernelBCJacobiansThread(ComputeNodalKernelBCJacobiansThread & x, Threads::split split) :
     ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>(x, split),
-    _sys(x._sys),
+    _aux_sys(x._aux_sys),
     _nodal_kernels(x._nodal_kernels),
     _jacobian(x._jacobian),
     _num_cached(0)
@@ -101,7 +100,7 @@ ComputeNodalKernelBCJacobiansThread::onNode(ConstBndNodeRange::const_iterator & 
     if (!active_involved_kernels.empty())
     {
       // prepare variables
-      for (const auto & it : _sys._nodal_vars[_tid])
+      for (const auto & it : _aux_sys._nodal_vars[_tid])
       {
         MooseVariable * var = it.second;
         var->prepareAux();

--- a/framework/src/base/ComputeNodalKernelBcsThread.C
+++ b/framework/src/base/ComputeNodalKernelBcsThread.C
@@ -22,10 +22,9 @@
 #include "libmesh/threads.h"
 
 ComputeNodalKernelBcsThread::ComputeNodalKernelBcsThread(FEProblem & fe_problem,
-                                                         AuxiliarySystem & sys,
                                                          const MooseObjectWarehouse<NodalKernel> & nodal_kernels) :
     ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>(fe_problem),
-    _sys(sys),
+    _aux_sys(fe_problem.getAuxiliarySystem()),
     _nodal_kernels(nodal_kernels),
     _num_cached(0)
 {
@@ -34,7 +33,7 @@ ComputeNodalKernelBcsThread::ComputeNodalKernelBcsThread(FEProblem & fe_problem,
 // Splitting Constructor
 ComputeNodalKernelBcsThread::ComputeNodalKernelBcsThread(ComputeNodalKernelBcsThread & x, Threads::split split) :
     ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>(x, split),
-    _sys(x._sys),
+    _aux_sys(x._aux_sys),
     _nodal_kernels(x._nodal_kernels),
     _num_cached(0)
 {
@@ -54,7 +53,7 @@ ComputeNodalKernelBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
   BoundaryID boundary_id = bnode->_bnd_id;
 
   // prepare variables
-  for (const auto & it : _sys._nodal_vars[_tid])
+  for (const auto & it : _aux_sys._nodal_vars[_tid])
   {
     MooseVariable * var = it.second;
     var->prepareAux();

--- a/framework/src/base/ComputeNodalKernelJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelJacobiansThread.C
@@ -22,11 +22,10 @@
 #include "libmesh/sparse_matrix.h"
 
 ComputeNodalKernelJacobiansThread::ComputeNodalKernelJacobiansThread(FEProblem & fe_problem,
-                                                                     AuxiliarySystem & sys,
                                                                      const MooseObjectWarehouse<NodalKernel> & nodal_kernels,
                                                                      SparseMatrix<Number> & jacobian) :
     ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(fe_problem),
-    _aux_sys(sys),
+    _aux_sys(fe_problem.getAuxiliarySystem()),
     _nodal_kernels(nodal_kernels),
     _jacobian(jacobian),
     _num_cached(0)

--- a/framework/src/base/ComputeNodalKernelsThread.C
+++ b/framework/src/base/ComputeNodalKernelsThread.C
@@ -21,10 +21,9 @@
 #include "libmesh/threads.h"
 
 ComputeNodalKernelsThread::ComputeNodalKernelsThread(FEProblem & fe_problem,
-                                                     AuxiliarySystem & sys,
                                                      const MooseObjectWarehouse<NodalKernel> & nodal_kernels) :
     ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(fe_problem),
-    _aux_sys(sys),
+    _aux_sys(fe_problem.getAuxiliarySystem()),
     _nodal_kernels(nodal_kernels),
     _num_cached(0)
 {

--- a/framework/src/base/ComputeResidualThread.C
+++ b/framework/src/base/ComputeResidualThread.C
@@ -28,7 +28,7 @@
 #include "libmesh/threads.h"
 
 ComputeResidualThread::ComputeResidualThread(FEProblem & fe_problem, NonlinearSystem & sys, Moose::KernelType type) :
-    ThreadedElementLoop<ConstElemRange>(fe_problem, sys),
+    ThreadedElementLoop<ConstElemRange>(fe_problem),
     _sys(sys),
     _kernel_type(type),
     _num_cached(0),

--- a/framework/src/base/ComputeResidualThread.C
+++ b/framework/src/base/ComputeResidualThread.C
@@ -27,24 +27,24 @@
 // libmesh includes
 #include "libmesh/threads.h"
 
-ComputeResidualThread::ComputeResidualThread(FEProblem & fe_problem, NonlinearSystem & sys, Moose::KernelType type) :
+ComputeResidualThread::ComputeResidualThread(FEProblem & fe_problem, Moose::KernelType type) :
     ThreadedElementLoop<ConstElemRange>(fe_problem),
-    _sys(sys),
+    _nl(fe_problem.getNonlinearSystem()),
     _kernel_type(type),
     _num_cached(0),
-    _integrated_bcs(sys.getIntegratedBCWarehouse()),
-    _dg_kernels(sys.getDGKernelWarehouse()),
-    _interface_kernels(sys.getInterfaceKernelWarehouse()),
-    _kernels(sys.getKernelWarehouse()),
-    _time_kernels(sys.getTimeKernelWarehouse()),
-    _non_time_kernels(sys.getNonTimeKernelWarehouse())
+    _integrated_bcs(_nl.getIntegratedBCWarehouse()),
+    _dg_kernels(_nl.getDGKernelWarehouse()),
+    _interface_kernels(_nl.getInterfaceKernelWarehouse()),
+    _kernels(_nl.getKernelWarehouse()),
+    _time_kernels(_nl.getTimeKernelWarehouse()),
+    _non_time_kernels(_nl.getNonTimeKernelWarehouse())
 {
 }
 
 // Splitting Constructor
 ComputeResidualThread::ComputeResidualThread(ComputeResidualThread & x, Threads::split split) :
     ThreadedElementLoop<ConstElemRange>(x, split),
-    _sys(x._sys),
+    _nl(x._nl),
     _kernel_type(x._kernel_type),
     _num_cached(0),
     _integrated_bcs(x._integrated_bcs),

--- a/framework/src/base/ComputeUserObjectsThread.C
+++ b/framework/src/base/ComputeUserObjectsThread.C
@@ -29,7 +29,7 @@ ComputeUserObjectsThread::ComputeUserObjectsThread(FEProblem & problem,
                                                    const MooseObjectWarehouse<ElementUserObject> & elemental_user_objects,
                                                    const MooseObjectWarehouse<SideUserObject> & side_user_objects,
                                                    const MooseObjectWarehouse<InternalSideUserObject> & internal_side_user_objects) :
-    ThreadedElementLoop<ConstElemRange>(problem, sys),
+    ThreadedElementLoop<ConstElemRange>(problem),
     _soln(*sys.currentSolution()),
     _elemental_user_objects(elemental_user_objects),
     _side_user_objects(side_user_objects),
@@ -39,7 +39,7 @@ ComputeUserObjectsThread::ComputeUserObjectsThread(FEProblem & problem,
 
 // Splitting Constructor
 ComputeUserObjectsThread::ComputeUserObjectsThread(ComputeUserObjectsThread & x, Threads::split) :
-    ThreadedElementLoop<ConstElemRange>(x._fe_problem, x._system),
+    ThreadedElementLoop<ConstElemRange>(x._fe_problem),
     _soln(x._soln),
     _elemental_user_objects(x._elemental_user_objects),
     _side_user_objects(x._side_user_objects),

--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -450,7 +450,7 @@ void FEProblem::initialSetup()
     }
 
     ConstElemRange & elem_range = *_mesh.getActiveLocalElementRange();
-    ComputeMaterialsObjectThread cmt(*this, _nl, _material_data, _bnd_material_data, _neighbor_material_data,
+    ComputeMaterialsObjectThread cmt(*this, _material_data, _bnd_material_data, _neighbor_material_data,
                                      _material_props, _bnd_material_props, _assembly);
     /**
      * The ComputeMaterialObjectThread object now allocates memory as needed for the material storage system.
@@ -627,7 +627,7 @@ void FEProblem::initialSetup()
   if (!_app.isRecovering() && !_app.isRestarting() && (_material_props.hasStatefulProperties() || _bnd_material_props.hasStatefulProperties()))
   {
     ConstElemRange & elem_range = *_mesh.getActiveLocalElementRange();
-    ComputeMaterialsObjectThread cmt(*this, _nl, _material_data, _bnd_material_data, _neighbor_material_data,
+    ComputeMaterialsObjectThread cmt(*this, _material_data, _bnd_material_data, _neighbor_material_data,
                                      _material_props, _bnd_material_props, _assembly);
     Threads::parallel_reduce(elem_range, cmt);
   }
@@ -2359,12 +2359,12 @@ FEProblem::computeIndicators()
   // compute Indicators
   if (_indicators.hasActiveObjects() || _internal_side_indicators.hasActiveObjects())
   {
-    ComputeIndicatorThread cit(*this, getAuxiliarySystem());
+    ComputeIndicatorThread cit(*this);
     Threads::parallel_reduce(*_mesh.getActiveLocalElementRange(), cit);
     _aux.solution().close();
     _aux.update();
 
-    ComputeIndicatorThread finalize_cit(*this, getAuxiliarySystem(), true);
+    ComputeIndicatorThread finalize_cit(*this, true);
     Threads::parallel_reduce(*_mesh.getActiveLocalElementRange(), finalize_cit);
     _aux.solution().close();
     _aux.update();
@@ -2399,7 +2399,7 @@ FEProblem::computeMarkers()
         marker->markerSetup();
     }
 
-    ComputeMarkerThread cmt(*this, getAuxiliarySystem());
+    ComputeMarkerThread cmt(*this);
     Threads::parallel_reduce(*_mesh.getActiveLocalElementRange(), cmt);
 
     _aux.solution().close();

--- a/framework/src/base/FlagElementsThread.C
+++ b/framework/src/base/FlagElementsThread.C
@@ -29,7 +29,7 @@ FlagElementsThread::FlagElementsThread(FEProblem & fe_problem,
                                        std::vector<Number> & serialized_solution,
                                        unsigned int max_h_level,
                                        const std::string & marker_name) :
-    ThreadedElementLoop<ConstElemRange>(fe_problem, fe_problem.getAuxiliarySystem()),
+    ThreadedElementLoop<ConstElemRange>(fe_problem),
     _fe_problem(fe_problem),
     _displaced_problem(_fe_problem.getDisplacedProblem()),
     _aux_sys(fe_problem.getAuxiliarySystem()),

--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -1246,7 +1246,7 @@ NonlinearSystem::computeResidualInternal(Moose::KernelType type)
   // residual contributions from the domain
   PARALLEL_TRY {
     ConstElemRange & elem_range = *_mesh.getActiveLocalElementRange();
-    ComputeResidualThread cr(_fe_problem, *this, type);
+    ComputeResidualThread cr(_fe_problem, type);
 
     Threads::parallel_reduce(elem_range, cr);
 
@@ -1297,7 +1297,7 @@ NonlinearSystem::computeResidualInternal(Moose::KernelType type)
   {
     if (_nodal_kernels.hasActiveBlockObjects())
     {
-      ComputeNodalKernelsThread cnk(_fe_problem, _fe_problem.getAuxiliarySystem(), _nodal_kernels);
+      ComputeNodalKernelsThread cnk(_fe_problem, _nodal_kernels);
 
       ConstNodeRange & range = *_mesh.getLocalNodeRange();
 
@@ -1317,7 +1317,7 @@ NonlinearSystem::computeResidualInternal(Moose::KernelType type)
   {
     if (_nodal_kernels.hasActiveBoundaryObjects())
     {
-      ComputeNodalKernelBcsThread cnk(_fe_problem, _fe_problem.getAuxiliarySystem(), _nodal_kernels);
+      ComputeNodalKernelBcsThread cnk(_fe_problem, _nodal_kernels);
 
       ConstBndNodeRange & bnd_node_range = *_mesh.getBoundaryNodeRange();
 
@@ -1899,7 +1899,7 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
     {
     case Moose::COUPLING_DIAG:
       {
-        ComputeJacobianThread cj(_fe_problem, *this, jacobian);
+        ComputeJacobianThread cj(_fe_problem, jacobian);
         Threads::parallel_reduce(elem_range, cj);
 
         unsigned int n_threads = libMesh::n_threads();
@@ -1909,7 +1909,7 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
         // Block restricted Nodal Kernels
         if (_nodal_kernels.hasActiveBlockObjects())
         {
-          ComputeNodalKernelJacobiansThread cnkjt(_fe_problem, _fe_problem.getAuxiliarySystem(), _nodal_kernels, jacobian);
+          ComputeNodalKernelJacobiansThread cnkjt(_fe_problem, _nodal_kernels, jacobian);
           ConstNodeRange & range = *_mesh.getLocalNodeRange();
           Threads::parallel_reduce(range, cnkjt);
 
@@ -1921,7 +1921,7 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
         // Boundary restricted Nodal Kernels
         if (_nodal_kernels.hasActiveBoundaryObjects())
         {
-          ComputeNodalKernelBCJacobiansThread cnkjt(_fe_problem, _fe_problem.getAuxiliarySystem(), _nodal_kernels, jacobian);
+          ComputeNodalKernelBCJacobiansThread cnkjt(_fe_problem, _nodal_kernels, jacobian);
           ConstBndNodeRange & bnd_range = *_mesh.getBoundaryNodeRange();
 
           Threads::parallel_reduce(bnd_range, cnkjt);
@@ -1935,7 +1935,7 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
     default:
     case Moose::COUPLING_CUSTOM:
       {
-        ComputeFullJacobianThread cj(_fe_problem, *this, jacobian);
+        ComputeFullJacobianThread cj(_fe_problem, jacobian);
         Threads::parallel_reduce(elem_range, cj);
         unsigned int n_threads = libMesh::n_threads();
 
@@ -1945,7 +1945,7 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
         // Block restricted Nodal Kernels
         if (_nodal_kernels.hasActiveBlockObjects())
         {
-          ComputeNodalKernelJacobiansThread cnkjt(_fe_problem, _fe_problem.getAuxiliarySystem(), _nodal_kernels, jacobian);
+          ComputeNodalKernelJacobiansThread cnkjt(_fe_problem, _nodal_kernels, jacobian);
           ConstNodeRange & range = *_mesh.getLocalNodeRange();
           Threads::parallel_reduce(range, cnkjt);
 
@@ -1957,7 +1957,7 @@ NonlinearSystem::computeJacobianInternal(SparseMatrix<Number> &  jacobian)
         // Boundary restricted Nodal Kernels
         if (_nodal_kernels.hasActiveBoundaryObjects())
         {
-          ComputeNodalKernelBCJacobiansThread cnkjt(_fe_problem, _fe_problem.getAuxiliarySystem(), _nodal_kernels, jacobian);
+          ComputeNodalKernelBCJacobiansThread cnkjt(_fe_problem, _nodal_kernels, jacobian);
           ConstBndNodeRange & bnd_range = *_mesh.getBoundaryNodeRange();
 
           Threads::parallel_reduce(bnd_range, cnkjt);
@@ -2266,7 +2266,7 @@ NonlinearSystem::computeDamping(const NumericVector<Number> & solution,
   if (_element_dampers.hasActiveObjects())
   {
     *_increment_vec = update;
-    ComputeElemDampingThread cid(_fe_problem, *this);
+    ComputeElemDampingThread cid(_fe_problem);
     Threads::parallel_reduce(*_mesh.getActiveLocalElementRange(), cid);
     damping = cid.damping();
   }
@@ -2312,7 +2312,7 @@ NonlinearSystem::computeDiracContributions(SparseMatrix<Number> * jacobian)
       }
     }
 
-    ComputeDiracThread cd(_fe_problem, *this, jacobian);
+    ComputeDiracThread cd(_fe_problem, jacobian);
 
     _fe_problem.getDiracElements(dirac_elements);
 

--- a/framework/src/base/ProjectMaterialProperties.C
+++ b/framework/src/base/ProjectMaterialProperties.C
@@ -32,7 +32,7 @@ ProjectMaterialProperties::ProjectMaterialProperties(bool refine,
                                                      std::vector<MooseSharedPointer<MaterialData> > & bnd_material_data,
                                                      MaterialPropertyStorage & material_props,
                                                      MaterialPropertyStorage & bnd_material_props, std::vector<Assembly *> & assembly) :
-    ThreadedElementLoop<ConstElemPointerRange>(fe_problem, sys),
+    ThreadedElementLoop<ConstElemPointerRange>(fe_problem),
     _refine(refine),
     _fe_problem(fe_problem),
     _sys(sys),

--- a/framework/src/base/UpdateErrorVectorsThread.C
+++ b/framework/src/base/UpdateErrorVectorsThread.C
@@ -24,7 +24,7 @@
 
 UpdateErrorVectorsThread::UpdateErrorVectorsThread(FEProblem & fe_problem,
                                                    const std::map<std::string, std::unique_ptr<ErrorVector> > & indicator_field_to_error_vector) :
-    ThreadedElementLoop<ConstElemRange>(fe_problem, fe_problem.getAuxiliarySystem()),
+    ThreadedElementLoop<ConstElemRange>(fe_problem),
     _indicator_field_to_error_vector(indicator_field_to_error_vector),
     _aux_sys(fe_problem.getAuxiliarySystem()),
     _system_number(_aux_sys.number()),


### PR DESCRIPTION
`ThreadedElementLoop` does not necessarily depend on
`System`.

Refs #7398 #7654
