### PR TITLE
Minor changes in support of a better documentation writing experience.

### DIFF
--- a/python/FactorySystem/ParseGetPot.py
+++ b/python/FactorySystem/ParseGetPot.py
@@ -64,25 +64,25 @@ class GPNode:
     # String to be returned
     output = ''
 
-    # Write the block headings
-    if level == 0:
-       output += '[' + self.name + ']\n'
-    elif level > 0:
-      output += ' '*2*level + '[./' + self.name + ']\n'
+    # Create the opening and closing blocks
+    if self.parent and self.parent.name != 'root':
+      output += '{}[./{}]\n'.format(' '*2*level, self.name)
+    else:
+      output += '{}[{}]\n'.format(' '*2*level, self.name)
 
     # Write the parameters
     for param in self.params_list:
-      output += ' '*2*(level + 1) + param + " = '" + str(self.params[param]) + "'\n"
+      output += '{}{} = {}\n'.format(' '*2*(level + 1), param, str(self.params[param]))
 
     # Write the children
     for child in self.children_list:
       output += self.children[child].createString(level + 1) + '\n'
 
     # Write the block closing
-    if level == 0:
-      output += '[]\n'
-    elif level > 0:
-      output += ' '*2*level + '[../]'
+    if self.parent and self.parent.name != 'root':
+      output += '{}[../]'.format(' '*2*level)
+    else:
+      output += '{}[]\n'.format(' '*2*level)
 
     # Return the data
     return output

--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -129,13 +129,18 @@ def load_pages(filename, keys=[], **kwargs):
     A YAML loader for reading the pages file.
 
     Args:
-        filename[str]: The name for the file to load.
+        filename[str]: The name for the file to load. This is normally a '.yml' file that contains the complete
+                       website layout. It may also be a markdown file, in this case only that single file will be
+                       served with the "home" page.
         keys[list]: A list of top-level keys to include.
         kwargs: key, value pairs passed to yaml_load function.
     """
 
-    # Load the yaml data
-    pages = yaml_load(filename, **kwargs)
+    if filename.endswith('.md'):
+        pages = [{'Home':'index.md'}, {os.path.basename(filename):filename}]
+
+    else:
+        pages = yaml_load(filename, **kwargs)
 
     # Restrict the top-level keys to those provided in the 'include' argument
     if keys:
@@ -196,7 +201,7 @@ def command_line_options():
     # Both build and serve need config file
     for p in [serve_parser, build_parser]:
         p.add_argument('--theme', help="Build documentation using specified theme. The available themes are: cosmo, cyborg, readthedocs, yeti, journal, bootstrap, readable, united, simplex, flatly, spacelab, amelia, cerulean, slate, mkdocs")
-        p.add_argument('--pages', default='pages.yml', help="YAML file containing the pages that are supplied to the mkdocs 'pages' configuration item.")
+        p.add_argument('--pages', default='pages.yml', help="YAML file containing the pages that are supplied to the mkdocs 'pages' configuration item. It also supports passing the name of a single markdown file, in this case only this file will be served with the 'Home' page.")
         p.add_argument('--page-keys', default=[], nargs='+', help='A list of top-level keys from the "pages" file to include. This is a tool to help speed up the serving for development of documentation.')
 
     # Parse the arguments

--- a/python/MooseDocs/extensions/MooseObjectSyntax.py
+++ b/python/MooseDocs/extensions/MooseObjectSyntax.py
@@ -172,7 +172,7 @@ class MooseObjectSyntax(MooseSyntaxBase):
 
                 a = etree.SubElement(p, 'a')
                 a.set('href', os.path.join(self._repo, rel_include))
-                a.text = rel_include
+                a.text = self._name
 
                 source = include.replace('/include/', '/src/').replace('.h', '.C')
                 if os.path.exists(source):
@@ -183,7 +183,7 @@ class MooseObjectSyntax(MooseSyntaxBase):
                     rel_source = os.path.relpath(source, self._root)
                     a = etree.SubElement(p, 'a')
                     a.set('href', os.path.join(self._repo, rel_source))
-                    a.text = rel_source
+                    a.text = self._name
 
                     if syntax.doxygen:
                         p = etree.SubElement(el, 'p')

--- a/python/MooseDocs/extensions/MooseTextPatternBase.py
+++ b/python/MooseDocs/extensions/MooseTextPatternBase.py
@@ -61,7 +61,7 @@ class MooseTextPatternBase(MooseCommonExtension, Pattern):
             stop = content.rfind('*******/\n')
             content = content.replace(content[strt:stop+9], '')
 
-        return content.strip()
+        return content
 
     def createElement(self, label, content, filename, rel_filename, settings, styles):
         """


### PR DESCRIPTION
Removes complete path to development links.
Provides the ability to pass a single .md file for serving.

```
./moosedocs.py serve --pages=/content/some/path/and/file.md
```
