### PR TITLE
Adds bibtex support to MOOSE markdown

### DIFF
--- a/docs/content/framework/systems/AuxKernels/ElementLengthAux.md
+++ b/docs/content/framework/systems/AuxKernels/ElementLengthAux.md
@@ -4,7 +4,7 @@
 !description /AuxKernels/ElementLengthAux
 
 ## Description
-The element "length" is often needed for creating stabilization coefficients or when adapting the mesh. This will compute the minimum or maximum element length and populate an [AuxVariable](auto::/AuxVariables/Overview)
+The element "length" is often needed for creating stabilization coefficients or when adapting the mesh. This will compute the minimum or maximum element length and populate an [AuxVariable](/AuxVariables/Overview.md)
 with the result. The element size calculation uses the [libMesh](http://libmesh.github.io/) `hmin()` or `hmax()` method
 from the [`Elem`](https://libmesh.github.io/doxygen/classlibMesh_1_1Elem.html) class to compute the length.
 

--- a/docs/content/framework/systems/Transfers/MultiAppCopyTransfer.md
+++ b/docs/content/framework/systems/Transfers/MultiAppCopyTransfer.md
@@ -5,7 +5,7 @@
 !description /Transfers/MultiAppCopyTransfer
 
 ## Description
-The MultiAppCopyTransfer allows for copying variables (both [nonlinear](auto::/Variables/Overview) and [auxiliary](auto::/AuxVariables/Overview)) between [MultiApps](auto::/MultiApps/Overview). All types of
+The MultiAppCopyTransfer allows for copying variables (both [nonlinear](/Variables/Overview.md) and [auxiliary](/AuxVariables/Overview.md)) between [MultiApps](/MultiApps/Overview.md). All types of
 variables, including higher order, elemental, and nodal are supported. The only limitiation is that the
 meshes in the master and sub application must be identical.
 

--- a/docs/content/modules/heat_conduction/systems/Kernels/HeatCapacityConductionTimeDerivative.md
+++ b/docs/content/modules/heat_conduction/systems/Kernels/HeatCapacityConductionTimeDerivative.md
@@ -8,7 +8,7 @@
     and accesses derivatives of the heat capacity to build the Jacobian.
 
 # See also
-* [[auto::/Kernels/SpecificHeatConductionTimeDerivative]]
+* [[/Kernels/SpecificHeatConductionTimeDerivative.md]]
 
 !parameters /Kernels/HeatCapacityConductionTimeDerivative
 

--- a/docs/content/modules/heat_conduction/systems/Kernels/HeatConductionTimeDerivative.md
+++ b/docs/content/modules/heat_conduction/systems/Kernels/HeatConductionTimeDerivative.md
@@ -9,8 +9,8 @@
     contribute an off-diagonal Jacobian at all.
 
 # See also
-* [[auto::/Kernels/HeatCapacityConductionTimeDerivative]]
-* [[auto::/Kernels/SpecificHeatConductionTimeDerivative]]
+* [[/Kernels/HeatCapacityConductionTimeDerivative.md]]
+* [[/Kernels/SpecificHeatConductionTimeDerivative.md]]
 
 !parameters /Kernels/HeatConductionTimeDerivative
 

--- a/docs/content/modules/heat_conduction/systems/Kernels/SpecificHeatConductionTimeDerivative.md
+++ b/docs/content/modules/heat_conduction/systems/Kernels/SpecificHeatConductionTimeDerivative.md
@@ -8,7 +8,7 @@
     and accesses derivatives of the specific heat and density to build the Jacobian.
 
 # See also
-* [[auto::/Kernels/HeatCapacityConductionTimeDerivative]]
+* [[/Kernels/HeatCapacityConductionTimeDerivative.md]]
 
 !parameters /Kernels/SpecificHeatConductionTimeDerivative
 

--- a/docs/content/utilities/documentation/create.md
+++ b/docs/content/utilities/documentation/create.md
@@ -18,7 +18,7 @@ The first step is to add documentation for your application in the `validParams`
 and parameter documentation strings and calling the class description method.
 
 A description of each parameter should also be provided when they are added with the various add methods
-of the `InputParameters` object. For example, in the [FunctionIC](../systems/framework/ICs/FunctionIC.md)
+of the `InputParameters` object. For example, in the [FunctionIC](/ICs/FunctionIC.md)
 the following parameter documentation is added, which is then present in the parameter summary table of the
 generated site.
 
@@ -34,13 +34,13 @@ description.
 !text framework/src/kernels/Diffusion.C line=addClassDescription
 
 When the documentation for this object is generated this string is added to the first portion of the page and the
-system overview table. For example, the [Kernels overview](/Kernels/Overview.md) includes a table with each object
+system overview table. For example, the [Kernels overview](framework/systems/Kernels/Overview.md) includes a table with each object
 listed; the table includes the class description from the source code.
 
 ## Object and System Markdown
 A detailed description should be provided in addition to the generated, in-code documentation for an object by creating a markdown file using
 [MOOSE Flavored Markdown](moose_flavored_markdown.md). The created file must be stored in a file named according to the
-registered MOOSE syntax within the "install" directory explained in the [Configuration](/contents/utilities/documentation/setup.md#configuration) section. For example, the details for the [Diffision](/Kernels/Diffusion.md) are in the `framework/docs/content/framework/systems/Kernels/Diffusion.md` file.
+registered MOOSE syntax within the "install" directory explained in the [Configuration](/content/utilities/documentation/setup.md#configuration) section. For example, the details for the [Diffision](/Kernels/Diffusion.md) are in the `framework/docs/content/framework/systems/Kernels/Diffusion.md` file.
 
 ---
 

--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -112,6 +112,7 @@ the following limits the included code to the `computeQpResidual` method.
 ```markdown
 !clang framework/src/kernels/Diffusion.C method=computeQpResidual
 ```
+
 !clang framework/src/kernels/Diffusion.C method=computeQpResidual
 
 !!! warning "Warning"
@@ -300,3 +301,22 @@ Currently this will only work with Civet CI services.
 ```
 !!! note
     Be sure to follow your !buildstatus extension with an empty new line.
+
+
+---
+
+## Bibliographies
+
+It is possible to include citations using latex commands, the following commands are supported within the markdown.
+
+* `\cite{slaughter2015continuous}`: \cite{slaughter2015continuous}
+* `\citet{wang2014diffusion}`: \citet{wang2014diffusion}
+* `\citep{gaston2015physics}`: \citep{gaston2015physics}
+
+The bibliography style may be set within a page using the latex command
+`\bibliographystyle{unsrt}`. Three styles are currently available: 'unsrt', 'plain', 'alpha', and 'unsrtalpha'.
+
+The references are displayed by using the latex `\bibliography{docs/moose.bib}` command. This command accepts a comma separated list of bibtex files (*.bib) to use to build citations and references. The files specified in this list must be given as a relative path to the root directory (e.g., `~/projects/moose`) of the repository.
+
+\bibliographystyle{unsrt}
+\bibliography{docs/moose.bib}

--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -60,11 +60,12 @@ The supported "types" for MOOSE are: "info", "note", "important, "warning", "dan
 ## Automatic Links
 
 Moose Flavored Markdown is capable of automatically creating links based on Markdown filenames, which is
-especially useful when linking to generated pages. The syntax is as follows:
+especially useful when linking to generated pages. The syntax is identical to creating links as
+defined by [mkdocs], however the markdown path may be incomplete.
 
-* `[auto::/Kernels/Diffusion]`: [auto::/Kernels/Diffusion]
-* `[auto::framework/Kernels/Overview]`: [auto::/Kernels/Overview]
-* `[Diffusion](auto::/Kernels/Diffusion)`: [Diffusion](auto::/Kernels/Diffusion)
+* `[/Kernels/Diffusion.md]`: [/Kernels/Diffusion.md]
+* `[framework/systems/Kernels/Overview.md]`: [framework/systems/Kernels/Overview.md]
+* `[Diffusion](/Kernels/Diffusion)`: [Diffusion](/Kernels/Diffusion.md)
 
 ---
 

--- a/docs/moose.bib
+++ b/docs/moose.bib
@@ -1,0 +1,126 @@
+@inproceedings{wang2015convergence,
+ author={Y.~Wang and M.~D.~{DeHart} and D.~R.~Gaston and F.~N.~Gleicher and R.~C.~Martineau and J.~W.~Peterson and J.~Ortensi and S.~Schunert},
+ title={{Convergence study of RattleSnake solutions for the two-dimensional C5G7 MOX benchmark}},
+ booktitle={{Proceedings of the Joint International Conference on Mathematics and Computation (M\&C), Supercomputing in Nuclear Applications (SNA), and the Monte Carlo (MC) Method, Nashville, TN}},
+ month={Apr.{~19--23}},
+ year={2015},
+ url={http://www.mc2015.org}
+}
+
+@article{libMeshPaper,
+  author = {B.~S.~Kirk and J.~W.~Peterson and R.~H.~Stogner and G.~F.~Carey},
+  title = {{\texttt{libMesh}: A C++ Library for Parallel Adaptive Mesh
+              Refinement/Coarsening Simulations}},
+  journal = {Engineering with Computers},
+  volume = {22},
+  number = {3--4},
+  pages = {237--254},
+  year = {2006},
+  url={http://dx.doi.org/10.1007/s00366-006-0049-3}
+}
+
+@article{williamson2012multidimensional,
+  title={Multidimensional multiphysics simulation of nuclear fuel behavior},
+  author={Williamson, RL and Hales, JD and Novascone, SR and Tonks, MR and Gaston, DR and Permann, CJ and Andr\v{s}, D and Martineau, RC},
+  journal={Journal of Nuclear Materials},
+  volume={423},
+  number={1},
+  pages={149--163},
+  year={2012},
+  publisher={Elsevier},
+  url={http://dx.doi.org/10.1016/j.jnucmat.2012.01.012}
+}
+
+@article{tonks2012object,
+  title={An object-oriented finite element framework for multiphysics phase field simulations},
+  author={Tonks, Michael R and Gaston, Derek and Millett, Paul C and Andr\v{s}, David and Talbot, Paul},
+  journal={Computational Materials Science},
+  volume={51},
+  number={1},
+  pages={20--29},
+  year={2012},
+  publisher={Elsevier},
+  url={http://dx.doi.org/10.1016/j.commatsci.2011.07.028}
+}
+
+@article{gaston2014continuous,
+  Title  = {Continuous integration for concurrent computational framework and application development},
+  Author = {Gaston, D.~R. and Peterson, J.~W. and Permann, C.~J. and Andr\v{s}, D. and Slaughter, A.~E. and Miller, J.~M.},
+  Journal= {Journal of Open Research Software},
+  Year   = {2014},
+  Month  = jul,
+  Note   = {Article e10},
+  Number = {1},
+  Pages  = {1--6},
+  Volume = {2},
+  url = {http://dx.doi.org/10.5334/jors.as}
+}
+
+
+@article{gaston2015physics,
+   author = {D.~R.~Gaston and C.~J.~Permann and J.~W.~Peterson and A.~E.~Slaughter and D.~Andr\v{s} and Y.~Wang and
+             M.~P.~Short and D.~M.~Perez and M.~R.~Tonks and J.~Ortensi and R.~C.~Martineau},
+    title = {Physics-based multiscale coupling for full core nuclear reactor simulation},
+  journal = {Annals of Nuclear Energy, Special Issue on Multi-Physics Modelling of LWR Static and Transient Behaviour},
+    month = oct,
+     year = 2015,
+   volume = 84,
+    pages = {45--54},
+     url= {http://dx.doi.org/10.1016/j.anucene.2014.09.060}
+}
+
+@article{wang2014diffusion,
+  title={Diffusion Acceleration Schemes for Self-Adjoint Angular Flux Formulation with a Void Treatment},
+  author={Wang, Yaqi and Zhang, Hongbin and Martineau, Richard C},
+  journal={Nuclear Science and Engineering},
+  volume={176},
+  number={2},
+  pages={201--225},
+  year={2014},
+  publisher={American Nuclear Society},
+  url={http://dx.doi.org/10.13182/NSE12-83}
+}
+
+@article{hales2013multidimensional,
+  title={Multidimensional multiphysics simulation of TRISO particle fuel},
+  author={Hales, JD and Williamson, RL and Novascone, SR and Perez, DM and Spencer, BW and Pastore, G},
+  journal={Journal of Nuclear Materials},
+  volume={443},
+  number={1},
+  pages={531--543},
+  year={2013},
+  publisher={Elsevier},
+  url={http://dx.doi.org/10.1016/j.jnucmat.2013.07.070}
+}
+
+@article{hales2014verification,
+  title={Verification of the BISON fuel performance code},
+  author={Hales, JD and Novascone, SR and Spencer, BW and Williamson, RL and Pastore, G and Perez, DM},
+  journal={Annals of Nuclear Energy},
+  volume={71},
+  pages={81--90},
+  year={2014},
+  publisher={Elsevier},
+  url={http://dx.doi.org/10.1016/j.anucene.2014.03.027}
+}
+
+@article{slaughter2015continuous,
+  title={Continuous integration for concurrent MOOSE framework and application development on GitHub},
+  author={Slaughter, Andrew E and Peterson, John W and Gaston, Derek R and Permann, Cody J and Andr{\v{s}}, David and Miller, Jason M},
+  journal={Journal of Open Research Software},
+  volume={3},
+  number={1},
+  year={2015},
+  publisher={Ubiquity Press},
+  url={ http://doi.org/10.5334/jors.bx}
+}
+
+
+@inproceedings{slaughter2014framework,
+  title={{MOOSE}: A Framework to Enable Rapid Advances and Collaboration in Modeling Snow and Avalanches},
+  author={Slaughter, A.E. and Johnson, M.J. and Tonks, M.R. and Gaston, D.R. and Permann, C.J. and Peterson, J.W. and Andr\v{s}, D. and Miller, J.M. and Adams, E.E. and Walters, D.J.},
+  booktitle={International Snow Science Workshop},
+  year={2014},
+  address={Banff, AB},
+  url={http://arc.lib.montana.edu/snow-science/item.php?id=2120}
+}

--- a/python/MooseDocs/extensions/MooseBibtex.py
+++ b/python/MooseDocs/extensions/MooseBibtex.py
@@ -1,0 +1,115 @@
+import sys
+import os
+import re
+import io
+
+from pybtex.plugin import find_plugin
+from pybtex.database import BibliographyData, parse_file
+
+from markdown.preprocessors import Preprocessor
+from markdown.util import etree
+
+import logging
+log = logging.getLogger(__name__)
+
+class MooseBibtex(Preprocessor):
+    """
+    Creates per-page bibliographies using latex syntax.
+    """
+
+    RE_BIBLIOGRAPHY = r'(?<!`)\\bibliography\{(.*?)\}'
+    RE_STYLE = r'(?<!`)\\bibliographystyle\{(.*?)\}'
+    RE_CITE = r'(?<!`)\\(?P<cmd>cite|citet|citep)\{(?P<key>.*?)\}'
+
+    def __init__(self, root=None, **kwargs):
+        Preprocessor.__init__(self, **kwargs)
+
+        self._citations = []
+        self._bibtex = BibliographyData()
+        self._root = root
+
+    def run(self, lines):
+        """
+        Create a bibliography from cite commands.
+        """
+
+        # Join the content to enable regex searches throughout entire text
+        content = '\n'.join(lines)
+
+        # Build the database of bibtex data
+        bibfiles = []
+        match = re.search(self.RE_BIBLIOGRAPHY, content)
+        if match:
+            bib_string = match.group(0)
+            for bfile in match.group(1).split(','):
+                try:
+                    data = parse_file(os.path.join(self._root, bfile))
+                except:
+                    log.error('Failed to parse bibtex file: {}'.format(bfile))
+                    return lines
+                self._bibtex.add_entries(data.entries.iteritems())
+        else:
+            return lines
+
+        # Determine the style
+        match = re.search(self.RE_STYLE, content)
+        if match:
+            content = content.replace(match.group(0), '')
+            try:
+                style = find_plugin('pybtex.style.formatting', match.group(1))
+            except:
+                log.error('Unknown bibliography style "{}"'.format(match.group(1)))
+                return lines
+
+        else:
+            style = find_plugin('pybtex.style.formatting', 'plain')
+
+        # Replace citations with author date, as an anchor
+        content = re.sub(self.RE_CITE, self.authors, content)
+
+        # Create html bibliography
+        if self._citations:
+
+            # Generate formatted html using pybtex
+            formatted_bibliography = style().format_bibliography(self._bibtex, self._citations)
+            backend = find_plugin('pybtex.backends', 'html')
+            stream = io.StringIO()
+            backend().write_to_stream(formatted_bibliography, stream)
+
+            # Strip the bib items from the formated html
+            html = re.findall(r'\<dd\>(.*?)\</dd\>', stream.getvalue(), flags=re.MULTILINE|re.DOTALL)
+
+            # Produces an ordered list with anchors to the citations
+            output = u'<ol>\n'
+            for i, item in enumerate(html):
+                output += u'<li name="{}">{}</a></li>\n'.format(self._citations[i], item)
+
+            content = re.sub(self.RE_BIBLIOGRAPHY, output, content)
+
+        return content.split('\n')
+
+    def authors(self, match):
+        """
+        Return the author(s) citation for text, linked to bibligraphy.
+        """
+        cmd = match.group('cmd')
+        key = match.group('key')
+
+        if key in self._bibtex.entries:
+            self._citations.append(key)
+            entry = self._bibtex.entries[key]
+            a = entry.persons['author']
+            n = len(a)
+            if n > 2:
+                author = '{} et al.'.format(' '.join(a[0].last_names))
+            elif n == 2:
+                a0 = ' '.join(a[0].last_names)
+                a1 = ' '.join(a[1].last_names)
+                author = '{} and {}'.format(a0, a1)
+            else:
+                author = ' '.join(a[0].last_names)
+
+            if cmd == 'citep':
+                return '(<a href="#{}">{}, {}</a>)'.format(key, author, entry.fields['year'])
+            else:
+                return '<a href="#{}">{} ({})</a>'.format(key, author, entry.fields['year'])


### PR DESCRIPTION
- Adds bibtex
- Generalizes "auto" links to work with any .md 

(refs #6699)

@brianmoose @milljm We need to add `pip install pybtex` to the package/civet for this feature to work.
