### PR TITLE
Fix for code element block fix, when passing CSS float style

### DIFF
--- a/docs/css/moose.css
+++ b/docs/css/moose.css
@@ -25,6 +25,12 @@
 }
 /* End Collapse Nav-bar correctly */
 
+/* Get rid of the Previous and Next buttons */
+ul.nav.navbar-right > li:nth-of-type(2), ul.nav.navbar-right > li:nth-of-type(3){
+    display: none;
+}
+/* Get rid of the Previous and Next buttons */
+
 p {
     text-align: justify;
 }
@@ -83,10 +89,6 @@ hr {
 .admonition > p{
     padding: 6px;
     text-align: left;
-}
-
-.info .admonition-title {
-    background: #528452;
 }
 
 .admonition.info {

--- a/python/MooseDocs/extensions/MooseTextPatternBase.py
+++ b/python/MooseDocs/extensions/MooseTextPatternBase.py
@@ -37,7 +37,8 @@ class MooseTextPatternBase(MooseCommonExtension, Pattern):
                           'strip-extra-newlines': False}
 
         # Applying overflow/max-height CSS to <div> and <code> causes multiple scroll bars
-        self._invalid_css = { 'div' : ['overflow-y', 'overflow-x', 'max-height'] }
+        # do not let code float, the div will do this for us
+        self._invalid_css = { 'div' : ['overflow-y', 'overflow-x', 'max-height'], 'code' : ['float'] }
 
     def prepareContent(self, content, settings):
         """


### PR DESCRIPTION
Fix code block when passing CSS float style
Remove a duplicate moose.css entry
Remove Next and Previous buttons as they are entirely useless and take up precious nav_bar space.
Refs #7787
