### PR TITLE
Add a required_submodule option to the test harness

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -78,6 +78,7 @@ class TestHarness:
 
     self.checks = {}
     self.checks['platform'] = getPlatforms()
+    self.checks['submodules'] = getInitializedSubmodules(self.run_tests_dir)
 
     # The TestHarness doesn't strictly require the existence of libMesh in order to run. Here we allow the user
     # to select whether they want to probe for libMesh configuration options.

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -48,6 +48,7 @@ class Tester(MooseObject):
     params.addParam('depend_files',  [], "A test that only runs if all depend files exist (files listed are expected to be relative to the base directory, not the test directory")
     params.addParam('env_vars',      [], "A test that only runs if all the environment variables listed exist")
     params.addParam('should_execute', True, 'Whether or not the executeable needs to be run.  Use this to chain together multiple tests based off of one executeable invocation')
+    params.addParam('required_submodule', [], "A list of initialized submodules for which this test requires.")
 
     return params
 
@@ -223,6 +224,12 @@ class Tester(MooseObject):
     for file in self.specs['depend_files']:
       if not os.path.isfile(os.path.join(self.specs['base_dir'], file)):
         reason = 'skipped (DEPEND FILES)'
+        return (False, reason)
+
+    # Check to make sure required submodules are initialized
+    for var in self.specs['required_submodule']:
+      if var not in checks["submodules"]:
+        reason = 'skipped (%s submodule not initialized)' % var
         return (False, reason)
 
     # Check to make sure environment variable exists

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -83,8 +83,8 @@ LIBMESH_OPTIONS = {
 
 
 ## Run a command and return the output, or ERROR: + output if retcode != 0
-def runCommand(cmd):
-  p = Popen([cmd],stdout=PIPE,stderr=STDOUT, close_fds=True, shell=True)
+def runCommand(cmd, cwd=None):
+  p = Popen([cmd], cwd=cwd, stdout=PIPE,stderr=STDOUT, close_fds=True, shell=True)
   output = p.communicate()[0]
   if (p.returncode != 0):
     output = 'ERROR: ' + output
@@ -340,3 +340,18 @@ def getSharedOption(libmesh_dir):
     exit(1)
 
   return shared_option
+
+def getInitializedSubmodules(root_dir):
+  """
+  Gets a list of initialized submodules.
+  Input:
+    root_dir[str]: path to execute the git command. This should be the root
+      directory of the app so that the submodule names are correct
+  Return:
+    list[str]: List of iniitalized submodule names or an empty list if there was an error.
+  """
+  output = runCommand("git submodule status", cwd=root_dir)
+  if output.startswith("ERROR"):
+    return []
+  # This ignores submodules that have a '-' at the beginning which means they are not initialized
+  return re.findall(r'^[ +]\S+ (\S+)', output, flags=re.MULTILINE)


### PR DESCRIPTION
This adds a `required_submodule` option to the test harness.
It takes a list of submodules that must be initialized for the test to run.

closes #7774
