### PR TITLE
Documentation fixes and clean up

### DIFF
--- a/docs/content/moose_tools/memory_logger.md
+++ b/docs/content/moose_tools/memory_logger.md
@@ -26,7 +26,7 @@ memory_logger.py  --repeat-rate .01 \
 Okay... A bit too accurate, as several samples remained unchanged during tracking. However sometimes more is desirable, though just not printed in this fashion. For data dumps like this, using Matplotlib is far more efficient.
 
 ## Using Matplotlib
-!image memory_logger-plot_multi.png width=300 float=right caption=Figure 1
+!image media/memory_logger-plot_multi.png width=300 float=right caption=Figure 1
 
 We can visualize the results by plotting the data with Matplotlib (Figure 1):
 ```text
@@ -65,7 +65,7 @@ You can also display stdout along the Matplotlib graph:
 ```text
 memory_logger.py --pstack --stdout --plot simple_diffusion_memory.log
 ```
-!image memory_logger-darkmode.png width=300 float=right caption=--darkmode
+!image media/memory_logger-darkmode.png width=300 float=right caption=--darkmode
 
 That white back ground to bright for you? Try dark mode:
 ```text

--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -74,6 +74,10 @@ It is possible to include complete or partial C++ or input files from the local 
 markdown syntax to needed, including the application of special settings in the form of key, value pairings that are supplied within
 the custom markdown. A complete list of available settings is provided in the [Settings](MooseFlavoredMarkdown.md#optional-settings) of the included code.
 
+!!! note
+    When including code the path specified should be defined from the "root" directory, which by default is the
+    top level of the git repository (e.g., ~/projects/moose).
+
 ### Complete Files
 You can include complete files from the repository using the `!text` syntax. For example, the following
 includes the complete code as shown.
@@ -161,7 +165,23 @@ the syntax for the system or object being documented.
 
 ---
 
-## Slideshows
+## Images and Slideshows
+It is possible to include images and slideshows of images with more flexibility than standard markdown.
+
+!!! note
+    Images paths should be specified from the "doc_dir", which by default is the "docs" directory at the top-level
+    of the repository.
+
+### Single Images
+You can include images in your documentation by use of the !image markdown syntax:
+
+```markdown
+!image media/memory_logger-plot_multi.png width=300px align=right caption=figure 1
+```
+
+!image media/memory_logger-plot_multi.png width=300px align=right caption=figure 1
+
+### Slideshows
 A sequence of images can be shown via a `carousel`. By default the images will auto cycle between images.
 
 A simple example:
@@ -189,26 +209,15 @@ line.
 A full slideshow example might be:
 ```markdown
 !slideshow caption=My caption with spaces interval=5000 pause=null wrap=false keyboard=false width=500px
-    memory_logger-plot_multi.png caption=Memory Logger plotting two results
-    memory_logger-darkmode.png caption=Memory Logger utilizing darkmode
-    memory_*.png
+    media/memory_logger-plot_multi.png caption=Memory Logger plotting two results
+    media/memory_logger-darkmode.png caption=Memory Logger utilizing darkmode
+    media/memory_*.png
 ```
 
 !slideshow caption=My caption with spaces interval=5000 pause=null wrap=false keyboard=false width=500px
-    memory_logger-plot_multi.png caption=Memory Logger plotting two results
-    memory_logger-darkmode.png caption=Memory Logger utilizing darkmode
-    memory_*.png
-
----
-
-## Images
-You can include images in your documentation by use of the !image markdown syntax:
-
-```markdown
-!image memory_logger-plot_multi.png width=300px align=right caption=figure 1
-```
-
-!image memory_logger-plot_multi.png width=300px align=right caption=figure 1
+    media/memory_logger-plot_multi.png caption=Memory Logger plotting two results
+    media/memory_logger-darkmode.png caption=Memory Logger utilizing darkmode
+    media/memory_*.png
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-!image rd100.png width=230 float=right
+!image media/rd100.png width=230 float=right
 
 # MOOSE: Multiphysics Object Oriented Simulation Environment
 

--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import mkdocs
 import MooseDocs
+import logging
+log = logging.getLogger(__name__)
 
 def update_extra():
     """
@@ -17,7 +19,9 @@ def update_extra():
                 if (not os.path.exists(dst)) or (os.path.getmtime(src) > os.path.getmtime(dst)):
                     dst_dir = os.path.dirname(dst)
                     if not os.path.exists(dst_dir):
+                        log.debug('Creating {} directory.'.format(d))
                         os.makedirs(dst_dir)
+                    log.debug('Copying file {} --> {}'.format(src, dst))
                     shutil.copy(src, dst)
 
 

--- a/python/MooseDocs/extensions/MooseBuildStatus.py
+++ b/python/MooseDocs/extensions/MooseBuildStatus.py
@@ -22,9 +22,9 @@ class MooseBuildStatus(MooseCommonExtension, Pattern):
     # Find !buildstatus url attribute=value
     RE = r'^!buildstatus\s+(.*?)(?:$|\s+)(.*)'
 
-    def __init__(self, **kwargs):
-        MooseCommonExtension.__init__(self)
-        Pattern.__init__(self, self.RE, **kwargs)
+    def __init__(self, markdown_instance=None, **kwargs):
+        MooseCommonExtension.__init__(self, **kwargs)
+        Pattern.__init__(self, self.RE, markdown_instance)
 
         # We have a strict width set that can not be disturbed
         self._invalid_css = { 'div' : ['width'] }

--- a/python/MooseDocs/extensions/MooseCSS.py
+++ b/python/MooseDocs/extensions/MooseCSS.py
@@ -18,9 +18,9 @@ class MooseCSS(BlockProcessor, MooseCommonExtension):
     # they need to have different ids
     MATCHES_FOUND = 0
 
-    def __init__(self, parser, root=None, **kwargs):
-      MooseCommonExtension.__init__(self)
-      BlockProcessor.__init__(self, parser, **kwargs)
+    def __init__(self, parser, **kwargs):
+      MooseCommonExtension.__init__(self, **kwargs)
+      BlockProcessor.__init__(self, parser)
 
     def test(self, parent, block):
       """

--- a/python/MooseDocs/extensions/MooseCarousel.py
+++ b/python/MooseDocs/extensions/MooseCarousel.py
@@ -24,11 +24,9 @@ class MooseCarousel(BlockProcessor, MooseCommonExtension):
     # they need to have different ids
     MATCHES_FOUND = 0
 
-    def __init__(self, parser, root=None, **kwargs):
-      MooseCommonExtension.__init__(self)
-      BlockProcessor.__init__(self, parser, **kwargs)
-
-      self._root = os.path.join(root, 'docs/media')
+    def __init__(self, parser, **kwargs):
+      MooseCommonExtension.__init__(self, **kwargs)
+      BlockProcessor.__init__(self, parser)
 
       # The default settings
       self._settings = {'caption'  : None,
@@ -63,7 +61,7 @@ class MooseCarousel(BlockProcessor, MooseCommonExtension):
           caption = ""
           fname = sline
 
-        new_files = glob.glob(os.path.join(self._root, fname))
+        new_files = glob.glob(os.path.join(self._docs_dir, fname))
         if not new_files:
           # If one of the paths is broken then
           # we return an empty list to indicate
@@ -102,7 +100,7 @@ class MooseCarousel(BlockProcessor, MooseCommonExtension):
         div = self.addStyle(etree.SubElement(parent, "div"), **styles)
         filenames = self.parseFilenames(files)
         if not filenames:
-            return self.createErrorElement(files, "No matching files found")
+            return self.createErrorElement("No matching files found: {}".format(files))
         self.createCarousel(parsed_options, div, filenames)
         # We processed this whole block so mark it as done
         block = ""

--- a/python/MooseDocs/extensions/MooseCommonExtension.py
+++ b/python/MooseDocs/extensions/MooseCommonExtension.py
@@ -11,9 +11,14 @@ import utils
 class MooseCommonExtension(object):
     """
     Class containing commonly used routines.
-
     """
-    def __init__(self):
+    def __init__(self, root=None, docs_dir=None, **kwargs):
+
+        # 'root' and 'docs_dir' are required
+        if not root:
+            log.error("The 'root' keyword argument is required for {}".format(self.__class__.__name__))
+        if not docs_dir:
+            log.error("The 'docs_dir' keyword argument is required for {}".format(self.__class__.__name__))
 
         # The default settings should be stored here
         self._settings = dict()
@@ -22,21 +27,15 @@ class MooseCommonExtension(object):
         # { element.tag : [attribute,] }
         self._invalid_css = dict()
 
-    def checkFilename(self, rel_filename):
-        """
-        Checks that the filename exists, if it does not a error Element is return.
-
-        Args:
-            filename[str]: The filename to check for existence.
-        """
-        filename = os.path.abspath(os.path.join(self._root, rel_filename))
-        if os.path.exists(filename):
-            return filename
-        return None
+        # Set the directories
+        self._root = root
+        if not os.path.isabs(docs_dir):
+            docs_dir = os.path.join(self._root, docs_dir)
+        self._docs_dir = docs_dir
 
     def getSettings(self, settings_line):
       """
-      Parses a string of space seperated key=value pairs.
+      Parses a string of space separated key=value pairs.
       This supports having values with spaces in them.
       So something like "key0=foo bar key1=value1"
       is supported.
@@ -89,7 +88,7 @@ class MooseCommonExtension(object):
                     element.set('style', ':'.join([attribute,value]) + ';')
             return element
 
-    def createErrorElement(self, rel_filename='', message=None, title='Markdown Parsing Error', parent=None):
+    def createErrorElement(self, message, title='Markdown Parsing Error', parent=None):
         """
         Returns a tree element containing error message.
 
@@ -101,7 +100,6 @@ class MooseCommonExtension(object):
         <p>...</p>
         </div>
         """
-
         if parent:
             el = etree.SubElement(parent, 'div')
         else:
@@ -113,8 +111,6 @@ class MooseCommonExtension(object):
         title_el.text = title
 
         msg = etree.SubElement(el, 'p')
-        msg.text = 'Invalid markdown for ' + rel_filename
-        if message:
-            msg.text = message
+        msg.text = message
         log.error('{}: {}'.format(title, message))
         return el

--- a/python/MooseDocs/extensions/MooseCppMethod.py
+++ b/python/MooseDocs/extensions/MooseCppMethod.py
@@ -42,19 +42,18 @@ class MooseCppMethod(MooseTextPatternBase):
         # Error if the clang parser did not load
         if not HAVE_MOOSE_CPP_PARSER:
             log.error("Unable to load the MOOSE clang C++ parser.")
-            el = self.createErrorElement(rel_filename, message="Failed to load python clang python bindings.")
+            el = self.createErrorElement(message="Failed to load python clang python bindings.")
             return el
 
         # Read the file and create element
-        filename = self.checkFilename(rel_filename)
-        if not filename:
-            el = self.createErrorElement(rel_filename, message="File not found")
+        filename = os.path.join(self._root, rel_filename)
+        if not os.path.exists(filename):
+            el = self.createErrorElement("C++ file not found: {}".format(rel_filename))
         elif not settings.has_key('method'):
-            el = self.createErrorElement(rel_filename, message="Use of !clang syntax while not providing a method=some_method. If you wish to include the entire file, use !text instead")
+            el = self.createErrorElement("Use of !clang syntax while not providing a method=some_method. If you wish to include the entire file, use !text instead.")
         else:
             if self._make == None:
-                log.error('The location of the Makefile must be supplied to parser.')
-                el = self.createErrorElement(rel_filename)
+                el = self.createErrorElement("The location of the Makefile ({}) must be supplied to parser.".format(self._make))
             else:
                 log.info('Parsing method "{}" from {}'.format(settings['method'], filename))
 

--- a/python/MooseDocs/extensions/MooseCppMethod.py
+++ b/python/MooseDocs/extensions/MooseCppMethod.py
@@ -42,7 +42,7 @@ class MooseCppMethod(MooseTextPatternBase):
         # Error if the clang parser did not load
         if not HAVE_MOOSE_CPP_PARSER:
             log.error("Unable to load the MOOSE clang C++ parser.")
-            el = self.createErrorElement(message="Failed to load python clang python bindings.")
+            el = self.createErrorElement("Failed to load python clang python bindings.")
             return el
 
         # Read the file and create element

--- a/python/MooseDocs/extensions/MooseDiagram.py
+++ b/python/MooseDocs/extensions/MooseDiagram.py
@@ -16,7 +16,8 @@ class MooseDiagram(BlockProcessor, MooseCommonExtension):
     RE = re.compile(r'^(graph|dirgraph)(.*)')
 
     def __init__(self, md, graphviz=None, **kwargs):
-        super(MooseDiagram, self).__init__(md, **kwargs)
+        MooseCommonExtension.__init__(self, **kwargs)
+        BlockProcessor.__init__(self, md)
 
         # Location of the graphviz
         self._graphviz = graphviz
@@ -38,7 +39,7 @@ class MooseDiagram(BlockProcessor, MooseCommonExtension):
         # Test if graphviz can be found
         executable = os.path.join(self._graphviz, 'dot')
         if not os.path.exists(executable):
-            return self.createErrorElement(title='Failed to locate Graphviz', message=block, parent=parent)
+            return self.createErrorElement(block, title='Failed to locate Graphviz', parent=parent)
 
         # Create the temporary dot file
         dot_file = 'tmp_' + uuid.uuid4().hex + '.dot'
@@ -56,7 +57,7 @@ class MooseDiagram(BlockProcessor, MooseCommonExtension):
         except:
             if os.path.exists(dot_file):
                 os.remove(dot_file)
-            return self.createErrorElement(title='Failed to execute Graphviz', message=block, parent=parent)
+            return self.createErrorElement(block, title='Failed to execute Graphviz', parent=parent)
 
         # Clean up dot temporary
         if os.path.exists(dot_file):

--- a/python/MooseDocs/extensions/MooseImageFile.py
+++ b/python/MooseDocs/extensions/MooseImageFile.py
@@ -22,11 +22,9 @@ class MooseImageFile(MooseCommonExtension, Pattern):
     # Find !image /path/to/file attribute=setting
     RE = r'^!image\s+(.*?)(?:$|\s+)(.*)'
 
-    def __init__(self, root=None, **kwargs):
-        MooseCommonExtension.__init__(self)
-        Pattern.__init__(self, self.RE, **kwargs)
-
-        self._root = os.path.join(root, 'docs/media')
+    def __init__(self, markdown_instance=None, **kwargs):
+        MooseCommonExtension.__init__(self, **kwargs)
+        Pattern.__init__(self, self.RE, markdown_instance)
 
         # Valid settings for MOOS specific documentation features
         # All other markdown 'attributes' will be treated as HTML
@@ -44,13 +42,12 @@ class MooseImageFile(MooseCommonExtension, Pattern):
         settings, styles = self.getSettings(match.group(3))
 
         # Read the file and create element
-        filename = self.checkFilename(rel_filename)
-
-        if not filename:
-            el = self.createErrorElement(rel_filename, message='file not found')
+        filename = os.path.join(self._root, self._docs_dir, rel_filename)
+        if not os.path.exists(filename):
+            el = self.createErrorElement(message='File not found: {}'.format(rel_filename))
         else:
             # When aligning to one side or another, we need to adjust the margins
-            # on the opisite side... silly looking buy necessary
+            # on the opposite side... silly looking buy necessary
             reverse_margin = { 'left' : 'right',
                                'right' : 'left',
                                'None' : 'none'}

--- a/python/MooseDocs/extensions/MooseImageFile.py
+++ b/python/MooseDocs/extensions/MooseImageFile.py
@@ -44,7 +44,7 @@ class MooseImageFile(MooseCommonExtension, Pattern):
         # Read the file and create element
         filename = os.path.join(self._root, self._docs_dir, rel_filename)
         if not os.path.exists(filename):
-            el = self.createErrorElement(message='File not found: {}'.format(rel_filename))
+            el = self.createErrorElement('File not found: {}'.format(rel_filename))
         else:
             # When aligning to one side or another, we need to adjust the margins
             # on the opposite side... silly looking buy necessary

--- a/python/MooseDocs/extensions/MooseInputBlock.py
+++ b/python/MooseDocs/extensions/MooseInputBlock.py
@@ -11,7 +11,7 @@ class MooseInputBlock(MooseTextPatternBase):
     CPP_RE = r'^!input\s+(.*?)(?:$|\s+)(.*)'
 
     def __init__(self, **kwargs):
-        super(MooseInputBlock, self).__init__(self.CPP_RE, language='text', **kwargs)
+        MooseTextPatternBase.__init__(self, self.CPP_RE, language='text', **kwargs)
 
     def handleMatch(self, match):
         """
@@ -22,16 +22,14 @@ class MooseInputBlock(MooseTextPatternBase):
         settings, styles = self.getSettings(match.group(3))
 
         # Build the complete filename.
-        # NOTE: os.path.join doesn't like the unicode even if you call str() on it first.
-        rel_filename = match.group(2).lstrip('/')
-        filename = MooseDocs.MOOSE_DIR.rstrip('/') + os.path.sep + rel_filename
+        rel_filename = match.group(2)
+        filename = os.path.join(self._root, rel_filename)
 
         # Read the file and create element
-        filename = self.checkFilename(rel_filename)
-        if not filename:
-            el = self.createErrorElement(rel_filename)
+        if not os.path.exists(filename):
+            el = self.createErrorElement("The input file was not located: {}".format(rel_filename))
         elif not settings.has_key('block'):
-            el = self.createErrorElement(rel_filename, message="Use of !input syntax while not providing a block=some_block. If you wish to include the entire file, use !text instead")
+            el = self.createErrorElement("Use of !input syntax while not providing a block=some_block. If you wish to include the entire file, use !text instead")
         else:
             parser = ParseGetPot(filename)
             node = parser.root_node.getNode(settings['block'])

--- a/python/MooseDocs/extensions/MooseMarkdown.py
+++ b/python/MooseDocs/extensions/MooseMarkdown.py
@@ -53,7 +53,8 @@ class MooseMarkdown(markdown.Extension):
         self.config['locations'] = [dict(), "The locations to parse for syntax."]
         self.config['repo'] = ['', "The remote repository to create hyperlinks."]
         self.config['links'] = [dict(), "The set of paths for generating input file and source code links to objects."]
-        self.config['docs_dir'] = [os.path.join('docs', 'content'), "The location of the markdown to be used for generating the site."]
+        self.config['docs_dir'] = ['docs', "The location of the documentation directory."]
+        self.config['markdown_dir'] = [os.path.join('docs', 'content'), "The location of the markdown to be used for generating the site."]
         self.config['slides'] = [False, "Enable the parsing for creating reveal.js slides."]
         self.config['package'] = [False, "Enable the use of the MoosePackageParser."]
         self.config['graphviz'] = ['/opt/moose/graphviz/bin', 'The location of graphviz executable for use with diagrams.']
@@ -107,9 +108,9 @@ class MooseMarkdown(markdown.Extension):
             md.preprocessors.add('moose_slides', MooseSlidePreprocessor(markdown_instance=md), '_end')
 
         # Block processors
-        md.parser.blockprocessors.add('diagrams', MooseDiagram(md.parser, graphviz=config['graphviz']), '_begin')
-        md.parser.blockprocessors.add('slideshow', MooseCarousel(md.parser, root=config['root']), '_begin')
-        md.parser.blockprocessors.add('css', MooseCSS(md.parser, root=config['root']), '_begin')
+        md.parser.blockprocessors.add('diagrams', MooseDiagram(md.parser, root=config['root'], docs_dir=config['docs_dir'], graphviz=config['graphviz']), '_begin')
+        md.parser.blockprocessors.add('slideshow', MooseCarousel(md.parser, root=config['root'], docs_dir=config['docs_dir']), '_begin')
+        md.parser.blockprocessors.add('css', MooseCSS(md.parser, root=config['root'], docs_dir=config['docs_dir']), '_begin')
 
         # Inline Patterns
         object_markdown = MooseObjectSyntax(markdown_instance=md,
@@ -118,21 +119,24 @@ class MooseMarkdown(markdown.Extension):
                                             input_files=cache['input_files'],
                                             child_objects=cache['child_objects'],
                                             repo=config['repo'],
-                                            root=config['root'])
+                                            root=config['root'],
+                                            docs_dir=config['docs_dir'])
         system_markdown = MooseSystemSyntax(markdown_instance=md,
                                             yaml=cache['yaml'],
-                                            syntax=cache['syntax'])
+                                            syntax=cache['syntax'],
+                                            root=config['root'],
+                                            docs_dir=config['docs_dir'])
         md.inlinePatterns.add('moose_object_syntax', object_markdown, '_begin')
         md.inlinePatterns.add('moose_system_syntax', system_markdown, '_begin')
 
-        md.inlinePatterns.add('moose_input_block', MooseInputBlock(markdown_instance=md, repo=config['repo'], root=config['root']), '<image_link')
-        md.inlinePatterns.add('moose_cpp_method', MooseCppMethod(markdown_instance=md, make=config['make'], repo=config['repo'], root=config['root']), '<image_link')
-        md.inlinePatterns.add('moose_text', MooseTextFile(markdown_instance=md, repo=config['repo'], root=config['root']), '<image_link')
-        md.inlinePatterns.add('moose_image', MooseImageFile(markdown_instance=md, root=config['root']), '<image_link')
-        md.inlinePatterns.add('moose_build_status', MooseBuildStatus(markdown_instance=md), '_begin')
+        md.inlinePatterns.add('moose_input_block', MooseInputBlock(markdown_instance=md, root=config['root'], docs_dir=config['docs_dir'], repo=config['repo']), '<image_link')
+        md.inlinePatterns.add('moose_cpp_method', MooseCppMethod(markdown_instance=md, root=config['root'], docs_dir=config['docs_dir'], make=config['make'], repo=config['repo']), '<image_link')
+        md.inlinePatterns.add('moose_text', MooseTextFile(markdown_instance=md, root=config['root'], docs_dir=config['docs_dir'], repo=config['repo']), '<image_link')
+        md.inlinePatterns.add('moose_image', MooseImageFile(markdown_instance=md, root=config['root'], docs_dir=config['docs_dir']), '<image_link')
+        md.inlinePatterns.add('moose_build_status', MooseBuildStatus(markdown_instance=md, root=config['root'], docs_dir=config['docs_dir']), '_begin')
 
         if config['package']:
-            md.inlinePatterns.add('moose_package_parser', MoosePackageParser(markdown_instance=md), '_end')
+            md.inlinePatterns.add('moose_package_parser', MoosePackageParser(markdown_instance=md, root=config['root'], docs_dir=config['docs_dir']), '_end')
 
 def makeExtension(*args, **kwargs):
     return MooseMarkdown(*args, **kwargs)

--- a/python/MooseDocs/extensions/MooseMarkdownLinkPreprocessor.py
+++ b/python/MooseDocs/extensions/MooseMarkdownLinkPreprocessor.py
@@ -10,8 +10,6 @@ class MooseMarkdownLinkPreprocessor(Preprocessor):
     A preprocessor for creating automatic linking between markdown files.
     """
 
-    RE = r'\s+(.*?.md)'
-
     def __init__(self, pages=None, **kwargs):
         super(MooseMarkdownLinkPreprocessor, self).__init__(**kwargs)
         self._pages = pages
@@ -33,7 +31,6 @@ class MooseMarkdownLinkPreprocessor(Preprocessor):
             match[re.Match]: The python re.Match object.
         """
         name = self._findFile(match.group(1))
-        print match.group(1), name
         if name:
             return '[{}](/{}{})'.format(name, name, match.group(2))
         return match.group(0)
@@ -49,7 +46,6 @@ class MooseMarkdownLinkPreprocessor(Preprocessor):
         if name:
             return '[{}](/{}{})'.format(match.group(1), name, match.group(3))
         return match.group(0)
-
 
     def _findFile(self, name):
         """

--- a/python/MooseDocs/extensions/MooseObjectSyntax.py
+++ b/python/MooseDocs/extensions/MooseObjectSyntax.py
@@ -28,13 +28,12 @@ class MooseObjectSyntax(MooseSyntaxBase):
 
     RE = r'^!(description|parameters|inputfiles|childobjects|devel)\s+(.*?)(?:$|\s+)(.*)'
 
-    def __init__(self, yaml=None, syntax=None, input_files=dict(), child_objects=dict(), root=None, repo=None, **kwargs):
-        MooseSyntaxBase.__init__(self, self.RE, yaml=yaml, syntax=syntax, **kwargs)
+    def __init__(self, input_files=dict(), child_objects=dict(), repo=None, **kwargs):
+        super(MooseObjectSyntax, self).__init__(self.RE, **kwargs)
 
         # Input arguments
         self._input_files = input_files
         self._child_objects = child_objects
-        self._root = root
         self._repo = repo
         self._name = None
 
@@ -51,7 +50,7 @@ class MooseObjectSyntax(MooseSyntaxBase):
         # Locate description
         node = self._yaml.find(syntax)
         if not node:
-            return self.createErrorElement(message='Failed to locate {} syntax.'.format(syntax))
+            return self.createErrorElement('Failed to locate {} syntax.'.format(syntax))
 
         # Determine object name
         self._name = node['name'].split('/')[-1]
@@ -80,7 +79,7 @@ class MooseObjectSyntax(MooseSyntaxBase):
         """
 
         if ('description' not in node) or (not node['description']):
-            return self.createErrorElement(message='Failed to locate class description for {} syntax.'.format(node['name']))
+            return self.createErrorElement('Failed to locate class description for {} syntax.'.format(node['name']))
 
         # Create the html element with supplied styles
         el = self.addStyle(etree.Element('p'), **styles)
@@ -158,7 +157,7 @@ class MooseObjectSyntax(MooseSyntaxBase):
         """
 
         if not self._repo:
-            el = createErrorElement(message="Attempting to create source links to repository, but the 'repo' configuration option was not supplied.")
+            el = createErrorElement("Attempting to create source links to repository, but the 'repo' configuration option was not supplied.")
 
         el = self.addStyle(etree.Element('div'), **styles)
 

--- a/python/MooseDocs/extensions/MoosePackageParser.py
+++ b/python/MooseDocs/extensions/MoosePackageParser.py
@@ -16,9 +16,9 @@ class MoosePackageParser(MooseCommonExtension, Pattern):
 
     RE = r'!MOOSEPACKAGE\s*(.*?)!'
 
-    def __init__(self, **kwargs):
-        MooseCommonExtension.__init__(self)
-        Pattern.__init__(self, self.RE, **kwargs)
+    def __init__(self, markdown_instance=None, **kwargs):
+        MooseCommonExtension.__init__(self, **kwargs)
+        Pattern.__init__(self, self.RE, markdown_instance)
 
         # Load the yaml data containing package information
         self.package = MooseDocs.yaml_load("packages.yml")
@@ -42,10 +42,10 @@ class MoosePackageParser(MooseCommonExtension, Pattern):
         # Update the settings from regex match
         settings, styles = self.getSettings(match.group(2))
         if not settings.has_key('arch') or not settings.has_key('return'):
-            el = self.createErrorElement('', message='Invalid MOOSEPACKAGE markdown syntax. Requires arch=, return=link|name')
+            el = self.createErrorElement(message='Invalid MOOSEPACKAGE markdown syntax. Requires arch=, return=link|name')
         else:
             if settings['arch'] not in self.package.keys():
-                el = self.createErrorElement('', message='arch not found in packages.yml')
+                el = self.createErrorElement(message='"arch" not found in packages.yml')
             else:
                 if settings['return'] == 'link':
                     el = etree.Element('a')

--- a/python/MooseDocs/extensions/MoosePackageParser.py
+++ b/python/MooseDocs/extensions/MoosePackageParser.py
@@ -42,10 +42,10 @@ class MoosePackageParser(MooseCommonExtension, Pattern):
         # Update the settings from regex match
         settings, styles = self.getSettings(match.group(2))
         if not settings.has_key('arch') or not settings.has_key('return'):
-            el = self.createErrorElement(message='Invalid MOOSEPACKAGE markdown syntax. Requires arch=, return=link|name')
+            el = self.createErrorElement('Invalid MOOSEPACKAGE markdown syntax. Requires arch=, return=link|name')
         else:
             if settings['arch'] not in self.package.keys():
-                el = self.createErrorElement(message='"arch" not found in packages.yml')
+                el = self.createErrorElement('"arch" not found in packages.yml')
             else:
                 if settings['return'] == 'link':
                     el = etree.Element('a')

--- a/python/MooseDocs/extensions/MooseSyntaxBase.py
+++ b/python/MooseDocs/extensions/MooseSyntaxBase.py
@@ -19,9 +19,9 @@ class MooseSyntaxBase(MooseCommonExtension, Pattern):
         syntax[dict]: A dictionary of MooseApplicatinSyntax objects.
     """
 
-    def __init__(self, regex,  yaml=None, syntax=None, **kwargs):
-        MooseCommonExtension.__init__(self)
-        Pattern.__init__(self, regex, **kwargs)
+    def __init__(self, regex, markdown_instance=None, yaml=None, syntax=None, **kwargs):
+        MooseCommonExtension.__init__(self, **kwargs)
+        Pattern.__init__(self, regex, markdown_instance)
 
         self._yaml = yaml
         self._syntax = syntax

--- a/python/MooseDocs/extensions/MooseSystemSyntax.py
+++ b/python/MooseDocs/extensions/MooseSystemSyntax.py
@@ -54,7 +54,7 @@ class MooseSystemSyntax(MooseSyntaxBase):
             node = self._yaml.find(os.path.join(syntax, '<type>'))
 
         if not node:
-            return self.createErrorElement(message="The are not any sub-objects for the supplied syntax: {}".format(syntax))
+            return self.createErrorElement("The are not any sub-objects for the supplied syntax: {}".format(syntax))
 
         table = MooseDocs.MarkdownTable('Name', 'Description')
         for child in node['subblocks']:
@@ -70,7 +70,7 @@ class MooseSystemSyntax(MooseSyntaxBase):
                 table.addRow(a, child['description'])
 
         if table.size() == 0:
-            return self.createErrorElement(message="No sub-objects exists for the supplied syntax: {}".format(syntax))
+            return self.createErrorElement("No sub-objects exists for the supplied syntax: {}".format(syntax))
 
         el = etree.Element('div', styles)
         h2 = etree.SubElement(el, 'h2')
@@ -85,7 +85,7 @@ class MooseSystemSyntax(MooseSyntaxBase):
 
         node = self._yaml.find(syntax)
         if not node:
-            return createErrorElement(message="The are not any sub-systems for the supplied syntax: {} You likely need to remove the '!subobjects' syntax.".format(syntax))
+            return createErrorElement("The are not any sub-systems for the supplied syntax: {} You likely need to remove the '!subobjects' syntax.".format(syntax))
 
         table = MooseDocs.MarkdownTable('Name', 'Description')
         if node['subblocks']:
@@ -99,7 +99,7 @@ class MooseSystemSyntax(MooseSyntaxBase):
                     table.addRow(a, child['description'])
 
         if table.size() == 0:
-            return self.createErrorElement(message="No sub-systems exists for the supplied syntax: {}. You likely need to remove the '!subsystems' markdown.".format(syntax))
+            return self.createErrorElement("No sub-systems exists for the supplied syntax: {}. You likely need to remove the '!subsystems' markdown.".format(syntax))
 
         el = etree.Element('div', styles)
         h2 = etree.SubElement(el, 'h2')

--- a/python/MooseDocs/extensions/MooseTextFile.py
+++ b/python/MooseDocs/extensions/MooseTextFile.py
@@ -27,11 +27,9 @@ class MooseTextFile(MooseTextPatternBase):
 
         # Read the file
         rel_filename = match.group(2).lstrip('/')
-        filename = self.checkFilename(rel_filename)
-
-        if not filename:
-            return self.createErrorElement(rel_filename)
-
+        filename = os.path.join(self._root, rel_filename)
+        if not os.path.exists(filename):
+            return self.createErrorElement("Unable to locate file: {}".format(rel_filename))
         if settings['line']:
             content = self.extractLine(filename, settings["line"])
 
@@ -43,8 +41,7 @@ class MooseTextFile(MooseTextPatternBase):
                 content = fid.read()
 
         if content == None:
-            log.error("Failed to extract content from {}.".format(filename))
-            return self.createErrorElement(rel_filename, 'No content')
+            return self.createErrorElement("Failed to extract content from {}.".format(filename))
 
         # Return the Element object
         el = self.createElement(match.group(2), content, filename, rel_filename, settings, styles)

--- a/python/MooseDocs/extensions/MooseTextPatternBase.py
+++ b/python/MooseDocs/extensions/MooseTextPatternBase.py
@@ -18,14 +18,14 @@ class MooseTextPatternBase(MooseCommonExtension, Pattern):
         language[str]: The code language (e.g., 'python' or 'c++')
     """
 
-    def __init__(self, pattern, language=None, repo=None, root=None, **kwargs):
-        Pattern.__init__(self, pattern, **kwargs)
+    def __init__(self, pattern, markdown_instance=None, language=None, repo=None, **kwargs):
+        MooseCommonExtension.__init__(self, **kwargs)
+        Pattern.__init__(self, pattern, markdown_instance)
 
         # Set the language
         self._language = language
 
         # The root/repo settings
-        self._root = root
         self._repo = repo
 
         # The default settings


### PR DESCRIPTION
- Makes markdown extensions more consistent with paths. the Mastodon page wasn't working correctly because of some hard-coded paths, this fixes that problem and cleans up the markdown extensions to be more consistent
-  Add some extra information when copying js/css directories from MOOSE when running in an application

(refs #6699)
