### PR TITLE
Allow per-element calculation during jacobian computations

### DIFF
--- a/framework/include/kernels/Kernel.h
+++ b/framework/include/kernels/Kernel.h
@@ -43,8 +43,10 @@ protected:
   /// This is the virtual that derived classes should override for computing an off-diagonal Jacobian component.
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  /// This callback is used for Kernels that need to perform a per-element calculation
+  /// Following methods are used for Kernels that need to perform a per-element calculation
   virtual void precalculateResidual();
+  virtual void precalculateJacobian() {}
+  virtual void precalculateOffDiagJacobian(unsigned int /* jvar */) {}
 
   /// Holds the solution at current quadrature points
   const VariableValue & _u;

--- a/framework/src/kernels/Kernel.C
+++ b/framework/src/kernels/Kernel.C
@@ -69,6 +69,7 @@ Kernel::computeJacobian()
   _local_ke.resize(ke.m(), ke.n());
   _local_ke.zero();
 
+  precalculateJacobian();
   for (_i = 0; _i < _test.size(); _i++)
     for (_j = 0; _j < _phi.size(); _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
@@ -98,6 +99,7 @@ Kernel::computeOffDiagJacobian(unsigned int jvar)
   {
     DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar);
 
+    precalculateOffDiagJacobian(jvar);
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < _phi.size(); _j++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)


### PR DESCRIPTION
- Adds new methods in kernel allowing per-element calculation during execution of computeJacobian methods
  - Closes #7829 
