### PR TITLE
Make TestHarness a little more windows compatable

### DIFF
--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -84,7 +84,9 @@ LIBMESH_OPTIONS = {
 
 ## Run a command and return the output, or ERROR: + output if retcode != 0
 def runCommand(cmd, cwd=None):
-  p = Popen([cmd], cwd=cwd, stdout=PIPE,stderr=STDOUT, close_fds=True, shell=True)
+  # On Windows it is not allowed to close fds while redirecting output
+  should_close = platform.system() != "Windows"
+  p = Popen([cmd], cwd=cwd, stdout=PIPE,stderr=STDOUT, close_fds=should_close, shell=True)
   output = p.communicate()[0]
   if (p.returncode != 0):
     output = 'ERROR: ' + output


### PR DESCRIPTION
Currently the `utils.runCommand` will always fail on Windows as closing file descriptors while redirecting output is not allowed.
