### PR TITLE
An example for iteration adaptive timestepper in multiapp

### DIFF
--- a/test/tests/multiapps/multiapp_iterative_adaptive/adaptiveDT.i
+++ b/test/tests/multiapps/multiapp_iterative_adaptive/adaptiveDT.i
@@ -1,0 +1,60 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  active = 'diff'
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  active = 'left right'
+
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  start_time = 0
+  end_time = 0.006
+  [./TimeStepper]
+    type = IterationAdaptiveDT
+    dt = 0.001
+  [../]
+  nl_abs_tol = 1.0e-8
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/multiapps/multiapp_iterative_adaptive/constDT.i
+++ b/test/tests/multiapps/multiapp_iterative_adaptive/constDT.i
@@ -1,0 +1,57 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  active = 'diff'
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  active = 'left right'
+
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  start_time = 0
+  end_time = 0.006
+  dt = 0.001
+  nl_abs_tol = 1.0e-8
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/multiapps/multiapp_iterative_adaptive/master.i
+++ b/test/tests/multiapps/multiapp_iterative_adaptive/master.i
@@ -1,0 +1,65 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  active = 'diff'
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  active = 'left right'
+
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[MultiApps]
+  [./dummy]
+    type = TransientMultiApp
+    input_files = adaptiveDT.i
+    execute_on = timestep_end
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  start_time = 0
+  end_time = 0.006
+  dt = 0.006
+  nl_abs_tol = 1.0e-8
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]


### PR DESCRIPTION
@YaqiWang @elementx54

I run a very simple diffusion problem with a tiny time step so nonlinear convergence is very rapid.

In the first case, I run a problem without multiapp using `IterationAdaptiveDT`: end_time = 0.006,  dt = 0.001 (initially). It detects rapid convergence and doubles the time steps hitting t = 0.001, t=0.003, and t=0.006 seconds. This is as expected.

In the second case, I set up a `dummy` multiapp, that doesn't communicate with the master. Master and sub problem are the same except that the master uses constant time steps allowed to be t=0.006, so it won't constrain the time steps. The sub app is executed in timestep end. The sub app should actually reproduce the dt history of case 1 but it does not. It solves the first time step, but keeps dt = 0.001, then solves the second time steps. After the second time step it decides to increase to dt = 0.002. The time step history is t=0.001, 0.002, 0.004, 0.006. 
