### PR TITLE
Add custom comparison file for DiffuseCreep tests.

### DIFF
--- a/modules/combined/tests/DiffuseCreep/stress.cmp
+++ b/modules/combined/tests/DiffuseCreep/stress.cmp
@@ -1,0 +1,23 @@
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:               5 @ t6
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 0.0
+	c
+	disp_x  absolute 1.e-9
+	disp_y  absolute 1.e-9
+	gb
+	jx      absolute 1.e-9
+	jy      absolute 1.e-9
+	mu
+
+ELEMENT VARIABLES relative 1.e-6 floor 0.0
+	creep_strain_xx  absolute 1.e-9
+	creep_strain_yy  absolute 1.e-9
+	creep_strain_xy  absolute 1.e-9
+	stress_xx        absolute 1.e-9
+	stress_yy        absolute 1.e-9
+	stress_xy        absolute 1.e-9

--- a/modules/combined/tests/DiffuseCreep/tests
+++ b/modules/combined/tests/DiffuseCreep/tests
@@ -14,12 +14,14 @@
     input = 'stress.i'
     exodiff = 'stress_out.e'
     compiler = 'GCC CLANG'
+    custom_cmp = 'stress.cmp'
   [../]
   [./stress_flux_n_gb_relax]
     type = 'Exodiff'
     input = 'stress_flux_n_gb_relax.i'
     exodiff = 'stress_flux_n_gb_relax_out.e'
     compiler = 'GCC CLANG'
+    custom_cmp = 'stress.cmp'
   [../]
   [./stress_based_chem_pot]
     type = 'Exodiff'


### PR DESCRIPTION
These tests have very small stress values in them which should not be
compared using relative tolerances.  These tests were diffing when run
with Apple BLAS, but only by very small amounts on numbers which were
already very small.

Refs #7859.
