### PR TITLE
Revert "Only output color esc. sequences if stdout is interactive" (refs #7825)

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -80,6 +80,11 @@ extern PerfLog setup_perf_log;
 extern bool _trap_fpe;
 
 /**
+ * Variable indicating whether Console coloring will be turned on (default: true).
+ */
+extern bool _color_console;
+
+/**
  * Variable to toggle any warning into an error (includes deprecated code warnings)
  */
 extern bool _warnings_are_errors;
@@ -98,24 +103,15 @@ extern bool _throw_on_error;
 /**
  * Macros for coloring any output stream (_console, std::ostringstream, etc.)
  */
-#define COLOR_BLACK   (Moose::colorConsole() ? XTERM_BLACK : "")
-#define COLOR_RED     (Moose::colorConsole() ? XTERM_RED : "")
-#define COLOR_GREEN   (Moose::colorConsole() ? XTERM_GREEN : "")
-#define COLOR_YELLOW  (Moose::colorConsole() ? XTERM_YELLOW : "")
-#define COLOR_BLUE    (Moose::colorConsole() ? XTERM_BLUE : "")
-#define COLOR_MAGENTA (Moose::colorConsole() ? XTERM_MAGENTA : "")
-#define COLOR_CYAN    (Moose::colorConsole() ? XTERM_CYAN : "")
-#define COLOR_WHITE   (Moose::colorConsole() ? XTERM_WHITE : "")
-#define COLOR_DEFAULT (Moose::colorConsole() ? XTERM_DEFAULT : "")
-
-
-
-/// Returns whether Console coloring is turned on (default: true).
-bool colorConsole();
-
-/// Turns color escape sequences on/off for info written to stdout.
-/// Returns the the set value which may be different than use_color.
-bool setColorConsole(bool use_color, bool force = false);
+#define COLOR_BLACK   (Moose::_color_console ? XTERM_BLACK : "")
+#define COLOR_RED     (Moose::_color_console ? XTERM_RED : "")
+#define COLOR_GREEN   (Moose::_color_console ? XTERM_GREEN : "")
+#define COLOR_YELLOW  (Moose::_color_console ? XTERM_YELLOW : "")
+#define COLOR_BLUE    (Moose::_color_console ? XTERM_BLUE : "")
+#define COLOR_MAGENTA (Moose::_color_console ? XTERM_MAGENTA : "")
+#define COLOR_CYAN    (Moose::_color_console ? XTERM_CYAN : "")
+#define COLOR_WHITE   (Moose::_color_console ? XTERM_WHITE : "")
+#define COLOR_DEFAULT (Moose::_color_console ? XTERM_DEFAULT : "")
 
 /**
  * Import libMesh::out, and libMesh::err for use in MOOSE.

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -42,10 +42,10 @@
   {                                                                                 \
     std::ostringstream _error_oss_;                                                 \
     _error_oss_ << "\n\n"                                                           \
-                << COLOR_RED                         \
+                << (Moose::_color_console ? XTERM_RED : "")                         \
                 << "\n\n*** ERROR ***\n"                                            \
                 << msg                                                              \
-                << COLOR_DEFAULT                     \
+                << (Moose::_color_console ? XTERM_DEFAULT : "")                     \
                 << "\n\n";                                                          \
     if (Moose::_throw_on_error)                                                     \
       throw std::runtime_error(_error_oss_.str());                                  \
@@ -82,12 +82,12 @@
     {                                                                               \
       std::ostringstream _assert_oss_;                                              \
       _assert_oss_                                                                  \
-        << COLOR_RED                                 \
+        << (Moose::_color_console ? XTERM_RED : "")                                 \
         << "\n\nAssertion `" #asserted "' failed\n"                                 \
         << msg                                                                      \
         << "\nat "                                                                  \
         << __FILE__ << ", line " << __LINE__                                        \
-        << COLOR_DEFAULT                             \
+        << (Moose::_color_console ? XTERM_DEFAULT : "")                             \
         << std::endl;                                                               \
       if (Moose::_throw_on_error)                                                   \
         throw std::runtime_error(_assert_oss_.str());                               \
@@ -115,11 +115,11 @@
       std::ostringstream _warn_oss_;                                                \
                                                                                     \
       _warn_oss_                                                                    \
-        << COLOR_YELLOW                              \
+        << (Moose::_color_console ? XTERM_YELLOW : "")                              \
         << "\n\n*** Warning ***\n"                                                  \
         << msg                                                                      \
         << "\nat " << __FILE__ << ", line " << __LINE__                             \
-        << COLOR_DEFAULT                             \
+        << (Moose::_color_console ? XTERM_DEFAULT : "")                             \
         << "\n\n";                                                                  \
       if (Moose::_throw_on_error)                                                   \
         throw std::runtime_error(_warn_oss_.str());                                 \
@@ -136,11 +136,11 @@
       mooseDoOnce(                                                                  \
         {                                                                           \
           Moose::out                                                                \
-            << COLOR_CYAN                            \
+            << (Moose::_color_console ? XTERM_CYAN : "")                            \
             << "\n\n*** Info ***\n"                                                 \
             << msg                                                                  \
             << "\nat " << __FILE__ << ", line " << __LINE__                         \
-            << COLOR_DEFAULT                         \
+            << (Moose::_color_console ? XTERM_DEFAULT : "")                         \
             << "\n" << std::endl;                                                   \
         }                                                                           \
       );                                                                            \
@@ -154,12 +154,12 @@
     else                                                                                                    \
       mooseDoOnce(                                                                                          \
         Moose::out                                                                                          \
-          << COLOR_YELLOW                                                    \
+          << (Moose::_color_console ? XTERM_YELLOW : "")                                                    \
           << "*** Warning, This code is deprecated, and likely to be removed in future library versions!\n" \
           << msg << '\n'                                                                                    \
           << __FILE__ << ", line " << __LINE__ << ", compiled "                                             \
           << LIBMESH_DATE << " at " << LIBMESH_TIME << " ***"                                               \
-          << COLOR_DEFAULT                                                   \
+          << (Moose::_color_console ? XTERM_DEFAULT : "")                                                   \
           << std::endl;                                                                                     \
       );                                                                                                    \
    } while (0)

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -150,7 +150,7 @@ CommonOutputAction::act()
     create("ControlOutput");
 
   if (!getParam<bool>("color"))
-    Moose::setColorConsole(false);
+    Moose::_color_console = false;
 }
 
 void

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -441,8 +441,6 @@
 #include "TimeDerivativeNodalKernel.h"
 #include "UserForcingFunctionNodalKernel.h"
 
-#include <unistd.h>
-
 namespace Moose {
 
 static bool registered = false;
@@ -1174,20 +1172,7 @@ bool _trap_fpe = true;
 bool _trap_fpe = false;
 #endif
 
-static bool _color_console = isatty(fileno(stdout));
-
-bool
-colorConsole()
-{
-  return _color_console;
-}
-
-bool
-setColorConsole(bool use_color, bool force)
-{
-  _color_console = (isatty(fileno(stdout)) || force) && use_color;
-  return _color_console;
-}
+bool _color_console = true;
 
 bool _warnings_are_errors = false;
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -65,7 +65,6 @@ InputParameters validParams<MooseApp>()
   params.addCommandLineParam<bool>("show_controls", "--show-controls", false, "Shows the Control logic available and executed.");
 
   params.addCommandLineParam<bool>("no_color", "--no-color", false, "Disable coloring of all Console outputs.");
-  params.addCommandLineParam<std::string>("color", "--color [auto,on,off]", "auto", "Whether to use color in console output.");
 
   params.addCommandLineParam<bool>("help", "-h --help", false, "Displays CLI usage statement.");
   params.addCommandLineParam<bool>("minimal", "--minimal", false, "Ignore input file and build a minimal application with Transient executioner.");
@@ -233,23 +232,7 @@ MooseApp::setupOptions()
     Moose::_deprecated_is_error = false;
 
   // Toggle the color console off
-  if (getParam<bool>("no_color"))
-    Moose::setColorConsole(false);
-
-  std::string color = getParam<std::string>("color");
-  if (color == "auto")
-    Moose::setColorConsole(true);
-  else if (color == "on")
-    Moose::setColorConsole(true, true);
-  else if (color == "off")
-    Moose::setColorConsole(false, true);
-  else
-    mooseWarning("ignoring invalid --color arg (want 'auto', 'on', or 'off')");
-
-  // this warning goes below --color processing to honor that setting for
-  // the warning. And below settings for warnings/error setup.
-  if (getParam<bool>("no_color"))
-    mooseDeprecated("The --no-color flag is deprecated. Use '--color off' instead.");
+  Moose::_color_console = !getParam<bool>("no_color");
 
   // If there's no threading model active, but the user asked for
   // --n-threads > 1 on the command line, throw a mooseError.  This is

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -187,14 +187,14 @@ Console::Console(const InputParameters & parameters) :
     _system_info_flags.push_back("output");
 
   // Set output coloring
-  if (Moose::colorConsole())
+  if (Moose::_color_console)
   {
     char * term_env = getenv("TERM");
     if (term_env)
     {
       std::string term(term_env);
       if (term != "xterm-256color" && term != "xterm")
-        Moose::setColorConsole(false);
+        Moose::_color_console = false;
     }
   }
 }

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -52,6 +52,17 @@ DOFMapOutput::DOFMapOutput(const InputParameters & parameters) :
     _system_name(getParam<std::string>("system_name")),
     _mesh(_problem_ptr->mesh())
 {
+  // Set output coloring
+  if (Moose::_color_console)
+  {
+    char * term_env = getenv("TERM");
+    if (term_env)
+    {
+      std::string term(term_env);
+      if (term != "xterm-256color" && term != "xterm")
+        Moose::_color_console = false;
+    }
+  }
 }
 
 std::string

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -114,9 +114,7 @@ class RunApp(Tester):
       specs['cli_args'].append('Outputs/print_perf_log=true')
 
     if options.colored == False:
-      specs['cli_args'].append('--color off')
-    else:
-      specs['cli_args'].append('--color on')
+      specs['cli_args'].append('--no-color')
 
     if options.cli_args:
       specs['cli_args'].insert(0, options.cli_args)


### PR DESCRIPTION
Reverts idaholab/moose#7825
