### PR TITLE
Documentation improvments in support of Mastodon

### DIFF
--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -166,20 +166,22 @@ the syntax for the system or object being documented.
 ---
 
 ## Images and Slideshows
+!image media/memory_logger-plot_multi.png width=30% padding-left=20px float=right caption=The [memory_logger](/memory_logger.md) is a utility that allows the user to track the memory use of a simulation.
+
 It is possible to include images and slideshows of images with more flexibility than standard markdown.
 
 !!! note
-    Images paths should be specified from the "doc_dir", which by default is the "docs" directory at the top-level
-    of the repository.
+    Images paths should be specified relative to the "doc_dir", which by default is the "docs" directory
+    at the top-level of the repository.
 
 ### Single Images
-You can include images in your documentation by use of the !image markdown syntax:
+The markdown keyword for MOOSE images is `!image` followed by the filename as shown below. This command, like most of the other
+special MOOSE markdown commands except arbitrary html attributes. Therefore, any keyword, value pairs (e.g., `width=50%`) are
+automatically applied to the `<figure>` tag of the image. For example, the following syntax was used to include the image on the right.
 
 ```markdown
-!image media/memory_logger-plot_multi.png width=300px align=right caption=figure 1
+!image media/memory_logger-plot_multi.png width=30% padding-left=20px float=right caption=The [memory_logger](/memory_logger.md) is a utility that allows the user to track the memory use of a simulation.
 ```
-
-!image media/memory_logger-plot_multi.png width=300px align=right caption=figure 1
 
 ### Slideshows
 A sequence of images can be shown via a `carousel`. By default the images will auto cycle between images.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-!image media/rd100.png width=230 float=right
+!image media/rd100.png width=30% float=right
 
 # MOOSE: Multiphysics Object Oriented Simulation Environment
 

--- a/modules/xfem/src/base/XFEMApp.C
+++ b/modules/xfem/src/base/XFEMApp.C
@@ -91,6 +91,5 @@ XFEMApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   registerAction(XFEMAction, "add_aux_kernel");
 
   syntax.registerActionSyntax("XFEMAction", "XFEM");
-  syntax.registerActionSyntax("AddUserObjectAction", "XFEM/*");
 
 }

--- a/modules/xfem/tests/solid_mechanics_basic/crack_propagation_2d.i
+++ b/modules/xfem/tests/solid_mechanics_basic/crack_propagation_2d.i
@@ -10,14 +10,6 @@
   output_cut_plane = true
   use_crack_growth_increment = true
   crack_growth_increment = 0.2
-  [./xfem_marker_uo]
-    type = XFEMMaterialTensorMarkerUserObject
-    execute_on = timestep_end
-    tensor = stress
-    quantity = MaxPrincipal
-    threshold = 5e+1
-    average = true
-  [../]
 []
 
 [Mesh]
@@ -31,6 +23,17 @@
   ymax = 1.0
   elem_type = QUAD4
   displacements = 'disp_x disp_y'
+[]
+
+[UserObjects]
+  [./xfem_marker_uo]
+    type = XFEMMaterialTensorMarkerUserObject
+    execute_on = timestep_end
+    tensor = stress
+    quantity = MaxPrincipal
+    threshold = 5e+1
+    average = true
+  [../]
 []
 
 [Variables]

--- a/python/MooseDocs/MooseApplicationSyntax.py
+++ b/python/MooseDocs/MooseApplicationSyntax.py
@@ -79,7 +79,7 @@ class MooseApplicationSyntax(object):
     generate[bool]: When True stub pages are generated if they do not exist
   """
 
-  def __init__(self, yaml_data, paths=[], doxygen=None, pages='pages.yml', name=None, install=None, stubs=False, pages_stubs=False, **kwargs):
+  def __init__(self, yaml_data, paths=[], doxygen=None, pages='pages.yml', name=None, install=None, stubs=False, pages_stubs=False, hide=[], **kwargs):
 
     # Store the input variables
     self._yaml_data = yaml_data
@@ -89,6 +89,7 @@ class MooseApplicationSyntax(object):
     self.pages_stubs = pages_stubs
     self.doxygen = doxygen
     self.name = name
+    self.hide = hide
 
     if pages:
       self.pages = PagesHelper(pages)
@@ -164,6 +165,12 @@ class MooseApplicationSyntax(object):
       if not self.pages.check(md):
         log.error('The markdown file {} was not found in the pages.yml'.format(md))
 
+  def hidden(self, name):
+    """
+    Return True if the syntax is hidden.
+    """
+    return any([name.startswith(h) for h in self.hide])
+
   def _checkNode(self, node):
     """
     Check a YAML node.
@@ -196,6 +203,9 @@ class MooseApplicationSyntax(object):
     """
     # The full name of the object
     name = node['name']
+    if self.hidden(name):
+      return
+
     stub = '<!-- MOOSE System Documentation Stub: Remove this when content is added. -->'
 
     # Determine the filename
@@ -251,6 +261,9 @@ class MooseApplicationSyntax(object):
     """
     # The full name of the object
     name = node['name']
+    if self.hidden(name):
+      return
+
     stub = '<!-- MOOSE Object Documentation Stub: Remove this when content is added. -->'
 
     # Test for class description

--- a/python/MooseDocs/extensions/MooseCommonExtension.py
+++ b/python/MooseDocs/extensions/MooseCommonExtension.py
@@ -72,7 +72,7 @@ class MooseCommonExtension(object):
     Usage:
     addStyle(etree.Element, width='300px')
 
-    returns your element with style="with=300px;" along
+    returns your element with style="width=300px;" along
     with any pre-existing styles set.
 
     """

--- a/python/MooseDocs/extensions/MooseCppMethod.py
+++ b/python/MooseDocs/extensions/MooseCppMethod.py
@@ -63,7 +63,7 @@ class MooseCppMethod(MooseTextPatternBase):
           decl, defn = parser.method(settings['method'])
           el = self.createElement(match.group(2), defn, filename, rel_filename, settings, styles)
         except:
-          el = self.createErrorElement(rel_filename, message='Failed to parse method using clang, check that you have the make file option passed to the MooseMarkdown object.')
+          el = self.createErrorElement('Failed to parse method using clang, check that you have the make file option passed to the MooseMarkdown object.')
 
     # Return the Element object
     return el

--- a/python/MooseDocs/extensions/MooseImageFile.py
+++ b/python/MooseDocs/extensions/MooseImageFile.py
@@ -16,7 +16,10 @@ class MooseImageFile(MooseCommonExtension, Pattern):
   Usage:
    !image image_file.png|jpg|etc attribute=setting
 
-  All images/media should be stored in docs/media
+  Settings:
+    caption[str]: Creates a figcaption tag with the supplied text applied.
+
+  All image filenames should be supplied as relative to the docs directory, i.e., media/my_image.png
   """
 
   # Find !image /path/to/file attribute=setting
@@ -36,54 +39,28 @@ class MooseImageFile(MooseCommonExtension, Pattern):
     process settings associated with !image markdown
     """
 
-    rel_filename = match.group(2)
-
     # A tuple separating specific MOOSE documentation features (self._settings) from HTML styles
     settings, styles = self.getSettings(match.group(3))
 
     # Read the file and create element
-    filename = os.path.join(self._root, self._docs_dir, rel_filename)
+    filename = os.path.join(self._root, self._docs_dir, match.group(2))
+    rel_filename = '/' + os.path.relpath(filename, os.path.join(self._root, self._docs_dir))
     if not os.path.exists(filename):
-      el = self.createErrorElement('File not found: {}'.format(rel_filename))
-    else:
-      # When aligning to one side or another, we need to adjust the margins
-      # on the opposite side... silly looking buy necessary
-      reverse_margin = { 'left' : 'right',
-                'right' : 'left',
-                'None' : 'none'}
+      return self.createErrorElement('File not found: {}'.format(rel_filename))
 
-      el_list = {}
-      el_list['div'] = etree.Element('div')
-      el_list['figure'] = etree.SubElement(el_list['div'], 'figure')
-      el_list['img'] = etree.SubElement(el_list['figure'], 'img')
-      el_list['img'].set('src', os.path.join('/media', os.path.basename(filename)))
+    # Create the figure element
+    fig = etree.Element('figure')
+    self.addStyle(fig, **styles)
 
-      # Set the default figcaption text alignment
-      el_list['figure'].set('style', 'text-align: left; display: table;')
+    # Add the image
+    img = etree.SubElement(fig, 'img')
+    img.set('src', rel_filename)
 
-      # Set any extra supplied attributes
-      if el_list['div'].get('style') != None:
-        previous_style = el_list['div'].get('style')
-      else:
-        previous_style = ''
-      for attribute in styles.keys():
-        if attribute == 'align':
-          el_list['div'].set('style', ';'.join(['text-align: -moz-{}; text-align: -webkit-{};'.format(styles[attribute],
-                                                        styles[attribute]),
-                             previous_style]))
-        elif attribute == 'float' and styles[attribute] is not None:
-          el_list['figure'].set('style', el_list['figure'].get('style') + \
-                     'float: {}; margin-{}: 20px'.format(styles[attribute], reverse_margin[styles[attribute]]))
-        elif styles[attribute] != None:
-          el_list['img'].set(attribute, str(styles[attribute]))
+    # Add caption
+    if settings['caption']:
+      caption = etree.SubElement(fig, 'figcaption')
+      p = etree.SubElement(caption, 'p')
+      p.set('align', "justify")
+      p.text = settings['caption']
 
-      # if caption set, add figcaption
-      if settings['caption'] != None:
-        # Unset the large default bottom-margin for figcaption
-        el_list['img'].set('style', 'margin-bottom: unset;')
-        el_list['figcaption'] = etree.SubElement(el_list['figure'], 'figcaption')
-        el_list['figcaption'].text = settings['caption']
-
-      el = el_list['div']
-
-    return el
+    return fig

--- a/python/MooseDocs/extensions/MooseImageFile.py
+++ b/python/MooseDocs/extensions/MooseImageFile.py
@@ -26,9 +26,9 @@ class MooseImageFile(MooseCommonExtension, Pattern):
     MooseCommonExtension.__init__(self, **kwargs)
     Pattern.__init__(self, self.RE, markdown_instance)
 
-    # Valid settings for MOOS specific documentation features
+    # Valid settings for MOOSE specific documentation features
     # All other markdown 'attributes' will be treated as HTML
-    # style settings
+    # style settings for the figure tag.
     self._settings = {'caption' : None}
 
   def handleMatch(self, match):


### PR DESCRIPTION
I am writing docs for Mastodon and needed to improve a few items:
- The !image markdown need to be updated to use the recently added "addStyle" method
- The ability to hide syntax was needed to avoid the "Bounds" block
- The XFEM module shouldn't need the ability to add UserObjects in the XFEM block.
