### PR TITLE
Better error message that tells users which compute*stress to use

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress.C
@@ -24,7 +24,7 @@ void
 ComputeLinearElasticStress::initialSetup()
 {
   if (hasMaterialProperty<RankTwoTensor>(_base_name + "strain_increment"))
-    mooseError("This linear elastic stress calculation only works for small strains");
+    mooseError("This linear elastic stress calculation only works for small strains; use ComputeFiniteStrainElasticStress for simulations using incremental and finite strains.");
 }
 
 void

--- a/modules/tensor_mechanics/tests/finite_strain_elastic/finite_strain_stress_errorcheck.i
+++ b/modules/tensor_mechanics/tests/finite_strain_elastic/finite_strain_stress_errorcheck.i
@@ -1,0 +1,77 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+    displacements = 'disp_x disp_y disp_z'
+    use_displaced_mesh = true
+  [../]
+[]
+
+[BCs]
+  [./symmy]
+    type = PresetBC
+    variable = disp_y
+    boundary = bottom
+    value = 0
+  [../]
+  [./symmx]
+    type = PresetBC
+    variable = disp_x
+    boundary = left
+    value = 0
+  [../]
+  [./symmz]
+    type = PresetBC
+    variable = disp_z
+    boundary = back
+    value = 0
+  [../]
+  [./tdisp]
+    type = PresetBC
+    variable = disp_z
+    boundary = front
+    value = 0.1
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 1.0e10
+    poissons_ratio = 0.3
+  [../]
+  [./strain]
+    type = ComputeFiniteStrain
+    displacements = 'disp_x disp_y disp_z'
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 0.05
+
+  #Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = -pc_hypre_type
+  petsc_options_value = boomeramg
+
+  dtmin = 0.05
+  num_steps = 1
+[]

--- a/modules/tensor_mechanics/tests/finite_strain_elastic/tests
+++ b/modules/tensor_mechanics/tests/finite_strain_elastic/tests
@@ -19,4 +19,9 @@
     input = 'finite_strain_elastic_eigen_sol.i'
     exodiff = 'finite_strain_elastic_eigen_sol_out.e'
   [../]
+  [./stress_errorcheck]
+    type = 'RunException'
+    input = 'finite_strain_stress_errorcheck.i'
+    expect_err = 'This linear elastic stress calculation only works for small strains; use ComputeFiniteStrainElasticStress for simulations using incremental and finite strains.'
+  [../]
 []


### PR DESCRIPTION
### Design information

@novasr noted that `ComputeLinearElasticStress` needed a better error message to tell users to use `ComputeFiniteStrainElasticStress` when using incremental or finite strains.  
### Test Cases

Created a new test to check for this error message.

@dschwen Please review
Refs #6810
