### PR TITLE
Allow time stepper to control Transient output

### DIFF
--- a/framework/include/timesteppers/TimeStepper.h
+++ b/framework/include/timesteppers/TimeStepper.h
@@ -101,6 +101,11 @@ public:
   void addSyncTime(const std::set<Real> & times);
   ///@}
 
+  /**
+   * Gives ability for TimeStepper to control output of solution in Transient
+   */
+  virtual bool enableOutput() { return true; }
+
 protected:
   /**
    * Called to compute _current_dt for the first timestep.

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -474,6 +474,8 @@ Transient::endStep(Real input_time)
 
   _picard_converged=false;
 
+  bool ts_output =_time_stepper->enableOutput();
+
   _last_solve_converged = lastSolveConverged();
 
   if (_last_solve_converged && !_xfem_repeat_step)
@@ -483,7 +485,8 @@ Transient::endStep(Real input_time)
     _problem.computeMarkers();
 
     // Perform the output of the current time step
-    _problem.outputStep(EXEC_TIMESTEP_END);
+    if (ts_output)
+      _problem.outputStep(EXEC_TIMESTEP_END);
 
     //output
     if (_time_interval && (_time + _timestep_tolerance >= _next_interval_output_time))


### PR DESCRIPTION
Creates function in TimeStepper that returns Boolean on whether or not to output solution in Transient, always true.

Closes Issue #7893 
