### PR TITLE
Update force densities for rigid body motion of grains

### DIFF
--- a/modules/phase_field/examples/rigidbodymotion/AC_CH_Multigrain.i
+++ b/modules/phase_field/examples/rigidbodymotion/AC_CH_Multigrain.i
@@ -78,6 +78,7 @@
     mob_name = L
     kappa_name = kappa_gr
     grain_force = grain_force
+    grain_volumes = grain_volumes
     grain_tracker_object = grain_center
   [../]
   # Cahn Hilliard kernels
@@ -105,6 +106,7 @@
     c = c
     v = 'gr0 gr1 gr2 gr3'
     grain_force = grain_force
+    grain_volumes = grain_volumes
     grain_tracker_object = grain_center
   [../]
 []
@@ -183,6 +185,11 @@
     type = GrainForcesPostprocessor
     grain_force = grain_force
   [../]
+  [./grain_volumes]
+    type = FeatureVolumeVectorPostprocessor
+    flood_counter = grain_center
+    execute_on = 'initial timestep_begin'
+  [../]
 []
 
 [UserObjects]
@@ -190,11 +197,10 @@
     type = GrainTracker
     outputs = none
     compute_var_to_feature_map = true
-    calculate_feature_volumes = true
     execute_on = 'initial timestep_begin'
   [../]
   [./grain_force]
-    type = ComputeGrainForceAndTorque
+    type = ComputeExternalGrainForceAndTorque
     grain_data = grain_center
     c = c
     etas = 'gr0 gr1 gr2 gr3'

--- a/modules/phase_field/examples/rigidbodymotion/grain_forcedensity_ext.i
+++ b/modules/phase_field/examples/rigidbodymotion/grain_forcedensity_ext.i
@@ -73,6 +73,7 @@
     v = 'eta0 eta1'
     grain_tracker_object = grain_center
     grain_force = grain_force
+    grain_volumes = grain_volumes
   [../]
 []
 
@@ -187,6 +188,11 @@
     type = GrainForcesPostprocessor
     grain_force = grain_force
   [../]
+  [./grain_volumes]
+    type = FeatureVolumeVectorPostprocessor
+    flood_counter = grain_center
+    execute_on = 'initial timestep_begin'
+  [../]
 []
 
 [UserObjects]
@@ -194,11 +200,10 @@
     type = GrainTracker
     outputs = none
     compute_var_to_feature_map = true
-    calculate_feature_volumes = true
     execute_on = 'initial timestep_begin'
   [../]
   [./grain_force]
-    type = ComputeGrainForceAndTorque
+    type = ComputeExternalGrainForceAndTorque
     c = c
     etas = 'eta0 eta1'
     grain_data = grain_center

--- a/modules/phase_field/examples/rigidbodymotion/grain_motion_GT.i
+++ b/modules/phase_field/examples/rigidbodymotion/grain_motion_GT.i
@@ -53,6 +53,7 @@
     v = 'eta0 eta1 eta2 eta3'
     grain_tracker_object = grain_center
     grain_force = grain_force
+    grain_volumes = grain_volumes
   [../]
 
   [./RigidBodyMultiKernel]
@@ -62,6 +63,7 @@
     mob_name = L
     kappa_name = kappa_eta
     grain_force = grain_force
+    grain_volumes = grain_volumes
     grain_tracker_object = grain_center
   [../]
 []
@@ -238,6 +240,11 @@
     type = GrainForcesPostprocessor
     grain_force = grain_force
   [../]
+  [./grain_volumes]
+    type = FeatureVolumeVectorPostprocessor
+    flood_counter = grain_center
+    execute_on = 'initial timestep_begin'
+  [../]
 []
 
 [UserObjects]
@@ -245,11 +252,10 @@
     type = GrainTracker
     outputs = none
     compute_var_to_feature_map = true
-    calculate_feature_volumes = true
     execute_on = 'initial timestep_begin'
   [../]
   [./grain_force]
-    type = ComputeGrainForceAndTorque
+    type = ComputeExternalGrainForceAndTorque
     c = c
     grain_data = grain_center
     force_density = force_density_ext

--- a/modules/phase_field/include/materials/ExternalForceDensityMaterial.h
+++ b/modules/phase_field/include/materials/ExternalForceDensityMaterial.h
@@ -38,7 +38,7 @@ private:
   const VariableValue & _c;
   VariableName _c_name;
   /// stiffness constant
-  Real _k;
+  const Real _k;
 
   unsigned int _op_num;
   std::vector<const VariableValue *> _vals;
@@ -49,7 +49,7 @@ private:
   /// first order derivative of force density material w.r.t c
   MaterialProperty<std::vector<RealGradient> > & _dFdc;
 
-  std::vector<MaterialProperty<std::vector<Real> > *> _dFdeta;
+  std::vector<MaterialProperty<std::vector<RealGradient> > *> _dFdeta;
 };
 
 #endif //EXTERNALFORCEDENSITYMATERIAL_H

--- a/modules/phase_field/include/userobjects/ComputeExternalGrainForceAndTorque.h
+++ b/modules/phase_field/include/userobjects/ComputeExternalGrainForceAndTorque.h
@@ -1,0 +1,77 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef COMPUTEEXTERNALGRAINFORCEANDTORQUE_H
+#define COMPUTEEXTERNALGRAINFORCEANDTORQUE_H
+
+#include "ShapeElementUserObject.h"
+#include "GrainForceAndTorqueInterface.h"
+#include "DerivativeMaterialPropertyNameInterface.h"
+
+//Forward Declarations
+class ComputeExternalGrainForceAndTorque;
+class GrainTrackerInterface;
+
+template<>
+InputParameters validParams<ComputeExternalGrainForceAndTorque>();
+
+/**
+ * This class is here to get the force and torque acting on a grain
+ */
+class ComputeExternalGrainForceAndTorque :
+    public ShapeElementUserObject,
+    public DerivativeMaterialPropertyNameInterface,
+    public GrainForceAndTorqueInterface
+{
+public:
+  ComputeExternalGrainForceAndTorque(const InputParameters & parameters);
+
+  virtual void initialize();
+  virtual void execute();
+  virtual void executeJacobian(unsigned int jvar);
+  virtual void finalize();
+  virtual void threadJoin(const UserObject & y);
+
+  virtual const std::vector<RealGradient> & getForceValues() const;
+  virtual const std::vector<RealGradient> & getTorqueValues() const;
+  virtual const std::vector<Real> & getForceCJacobians() const;
+  virtual const std::vector<std::vector<Real> > & getForceEtaJacobians() const;
+
+protected:
+  unsigned int _qp;
+
+  VariableName _c_name;
+  unsigned int _c_var;
+  /// material property that provides force density
+  MaterialPropertyName _dF_name;
+  const MaterialProperty<std::vector<RealGradient> > & _dF;
+  /// material property that provides jacobian of force density with respect to c
+  const MaterialProperty<std::vector<RealGradient> > & _dFdc;
+  /// no. of order parameters
+  unsigned int _op_num;
+  /// provide UserObject for calculating grain volumes and centers
+  const GrainTrackerInterface & _grain_tracker;
+  unsigned int _grain_num;
+  unsigned int _ncomp;
+
+  std::vector<unsigned int> _vals_var;
+  std::vector<VariableName> _vals_name;
+  std::vector<const MaterialProperty<std::vector<RealGradient> > *> _dFdeta;
+
+  ///@{ providing grain forces, torques and their jacobians w. r. t c
+  std::vector<RealGradient> _force_values;
+  std::vector<RealGradient> _torque_values;
+
+  /// vector storing grain force and torque values
+  std::vector<Real> _force_torque_store;
+  /// vector storing jacobian of grain force and torque values
+  std::vector<Real> _force_torque_c_jacobian_store;
+  std::vector<std::vector<Real> > _force_torque_eta_jacobian_store;
+
+  unsigned int _total_dofs;
+};
+
+#endif //COMPUTEEXTERNALGRAINFORCEANDTORQUE_H

--- a/modules/phase_field/include/userobjects/ComputeExternalGrainForceAndTorque.h
+++ b/modules/phase_field/include/userobjects/ComputeExternalGrainForceAndTorque.h
@@ -9,7 +9,7 @@
 
 #include "ShapeElementUserObject.h"
 #include "GrainForceAndTorqueInterface.h"
-#include "DerivativeMaterialPropertyNameInterface.h"
+#include "DerivativeMaterialInterface.h"
 
 //Forward Declarations
 class ComputeExternalGrainForceAndTorque;
@@ -22,8 +22,7 @@ InputParameters validParams<ComputeExternalGrainForceAndTorque>();
  * This class is here to get the force and torque acting on a grain
  */
 class ComputeExternalGrainForceAndTorque :
-    public ShapeElementUserObject,
-    public DerivativeMaterialPropertyNameInterface,
+    public DerivativeMaterialInterface<ShapeElementUserObject>,
     public GrainForceAndTorqueInterface
 {
 public:

--- a/modules/phase_field/include/userobjects/ComputeGrainForceAndTorque.h
+++ b/modules/phase_field/include/userobjects/ComputeGrainForceAndTorque.h
@@ -9,7 +9,7 @@
 
 #include "ShapeElementUserObject.h"
 #include "GrainForceAndTorqueInterface.h"
-#include "DerivativeMaterialPropertyNameInterface.h"
+#include "DerivativeMaterialInterface.h"
 
 //Forward Declarations
 class ComputeGrainForceAndTorque;
@@ -22,8 +22,7 @@ InputParameters validParams<ComputeGrainForceAndTorque>();
  * This class is here to get the force and torque acting on a grain
  */
 class ComputeGrainForceAndTorque :
-    public ShapeElementUserObject,
-    public DerivativeMaterialPropertyNameInterface,
+    public DerivativeMaterialInterface<ShapeElementUserObject>,
     public GrainForceAndTorqueInterface
 {
 public:

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -184,6 +184,7 @@
 /*
  * User Objects
  */
+#include "ComputeExternalGrainForceAndTorque.h"
 #include "ComputeGrainCenterUserObject.h"
 #include "ComputeGrainForceAndTorque.h"
 #include "ConservedMaskedNormalNoise.h"
@@ -431,6 +432,7 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerAux(TotalFreeEnergy);
 
   registerDeprecatedObjectName(FauxGrainTracker, "ComputeGrainCenterUserObject", "11/01/2016 00:00");
+  registerUserObject(ComputeExternalGrainForceAndTorque);
   registerUserObject(ComputeGrainForceAndTorque);
   registerUserObject(ConservedMaskedNormalNoise);
   registerUserObject(ConservedMaskedUniformNoise);

--- a/modules/phase_field/src/materials/ExternalForceDensityMaterial.C
+++ b/modules/phase_field/src/materials/ExternalForceDensityMaterial.C
@@ -41,7 +41,7 @@ ExternalForceDensityMaterial::ExternalForceDensityMaterial(const InputParameters
   {
     _vals[i] = &coupledValue("etas", i);
     _vals_name[i] = getVar("etas", i)->name();
-    _dFdeta[i] = &declarePropertyDerivative<std::vector<Real> >("force_density_ext", _vals_name[i]);
+    _dFdeta[i] = &declarePropertyDerivative<std::vector<RealGradient> >("force_density_ext", _vals_name[i]);
   }
 }
 
@@ -66,6 +66,10 @@ ExternalForceDensityMaterial::computeQpProperties()
   {
     (*_dFdeta[i])[_qp].resize(_op_num);
     for (unsigned int j = 0; j < _op_num; ++j)
-      (*_dFdeta[i])[_qp][j] = _k * _c[_qp];
+    {
+      (*_dFdeta[i])[_qp][j](0) = _k * _c[_qp] * _force_x.value(_t, _q_point[_qp]);
+      (*_dFdeta[i])[_qp][j](1) = _k * _c[_qp] * _force_y.value(_t, _q_point[_qp]);
+      (*_dFdeta[i])[_qp][j](2) = _k * _c[_qp] * _force_z.value(_t, _q_point[_qp]);
+    }
   }
 }

--- a/modules/phase_field/src/materials/ForceDensityMaterial.C
+++ b/modules/phase_field/src/materials/ForceDensityMaterial.C
@@ -51,6 +51,13 @@ ForceDensityMaterial::computeQpProperties()
 {
   _dF[_qp].resize(_op_num);
   _dFdc[_qp].resize(_op_num);
+
+  Real c = _c[_qp];
+  if (c >= _ceq)
+    c = _ceq;
+  else if (c < 0.0 )
+    c = 0.0;
+
   for (unsigned int i = 0; i < _op_num; ++i)
   {
     _sum_grad_etas[i] = 0.0;

--- a/modules/phase_field/src/userobjects/ComputeExternalGrainForceAndTorque.C
+++ b/modules/phase_field/src/userobjects/ComputeExternalGrainForceAndTorque.C
@@ -1,0 +1,198 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#include "ComputeExternalGrainForceAndTorque.h"
+#include "GrainTrackerInterface.h"
+
+// libmesh includes
+#include "libmesh/quadrature.h"
+
+template<>
+InputParameters validParams<ComputeExternalGrainForceAndTorque>()
+{
+  InputParameters params = validParams<ShapeElementUserObject>();
+  params.addClassDescription("Userobject for calculating force and torque acting on a grain");
+  params.addParam<MaterialPropertyName>("force_density", "force_density", "Force density material");
+  params.addParam<UserObjectName>("grain_data", "center of mass of grains");
+  params.addCoupledVar("c", "Concentration field");
+  params.addCoupledVar("etas", "Array of coupled order parameters");
+  return params;
+}
+
+ComputeExternalGrainForceAndTorque::ComputeExternalGrainForceAndTorque(const InputParameters & parameters) :
+    ShapeElementUserObject(parameters),
+    GrainForceAndTorqueInterface(),
+    _c_name(getVar("c", 0)->name()),
+    _c_var(coupled("c")),
+    _dF_name(getParam<MaterialPropertyName>("force_density")),
+    _dF(getMaterialPropertyByName<std::vector<RealGradient> >(_dF_name)),
+    _dFdc(getMaterialPropertyByName<std::vector<RealGradient> >(propertyNameFirst(_dF_name, _c_name))),
+    _op_num(coupledComponents("etas")),
+    _grain_tracker(getUserObject<GrainTrackerInterface>("grain_data")),
+    _vals_var(_op_num),
+    _vals_name(_op_num),
+    _dFdeta(_op_num)
+{
+  for (unsigned int i = 0; i < _op_num; ++i)
+  {
+    _vals_var[i] = coupled("etas", i);
+    _vals_name[i] = getVar("etas", i)->name();
+    _dFdeta[i] = &getMaterialPropertyByName<std::vector<RealGradient> >(propertyNameFirst(_dF_name, _vals_name[i]));
+  }
+}
+
+void
+ComputeExternalGrainForceAndTorque::initialize()
+{
+  _grain_num = _grain_tracker.getTotalFeatureCount();
+  _ncomp = 6 * _grain_num;
+
+  _force_values.resize(_grain_num);
+  _torque_values.resize(_grain_num);
+  _force_torque_store.assign(_ncomp, 0.0);
+
+  if (_fe_problem.currentlyComputingJacobian())
+  {
+    _total_dofs = _subproblem.es().n_dofs();
+    _force_torque_c_jacobian_store.assign(_ncomp*_total_dofs, 0.0);
+    _force_torque_eta_jacobian_store.resize(_op_num);
+
+    for (unsigned int i = 0; i < _op_num; ++i)
+      _force_torque_eta_jacobian_store[i].assign(_ncomp*_total_dofs, 0.0);
+  }
+}
+
+void
+ComputeExternalGrainForceAndTorque::execute()
+{
+  const auto & op_to_grains = _grain_tracker.getVarToFeatureVector(_current_elem->id());
+
+  for (unsigned int i = 0; i < _grain_num; ++i)
+    for (unsigned int j = 0; j < _op_num; ++j)
+      if (i == op_to_grains[j])
+      {
+        const auto centroid = _grain_tracker.getGrainCentroid(i);
+        for (_qp=0; _qp<_qrule->n_points(); ++_qp)
+          if (_dF[_qp][j](0) != 0.0 || _dF[_qp][j](1) != 0.0 || _dF[_qp][j](2) != 0.0)
+          {
+            const RealGradient compute_torque =_JxW[_qp] * _coord[_qp] * (_current_elem->centroid() - centroid).cross(_dF[_qp][j]);
+            _force_torque_store[6*i+0] += _JxW[_qp] * _coord[_qp] * _dF[_qp][j](0);
+            _force_torque_store[6*i+1] += _JxW[_qp] * _coord[_qp] * _dF[_qp][j](1);
+            _force_torque_store[6*i+2] += _JxW[_qp] * _coord[_qp] * _dF[_qp][j](2);
+            _force_torque_store[6*i+3] += compute_torque(0);
+            _force_torque_store[6*i+4] += compute_torque(1);
+            _force_torque_store[6*i+5] += compute_torque(2);
+          }
+      }
+}
+
+void
+ComputeExternalGrainForceAndTorque::executeJacobian(unsigned int jvar)
+{
+  const auto & op_to_grains = _grain_tracker.getVarToFeatureVector(_current_elem->id());
+
+  if (jvar == _c_var)
+    for (unsigned int i = 0; i < _grain_num; ++i)
+      for (unsigned int j = 0; j < _op_num; ++j)
+        if (i == op_to_grains[j])
+        {
+          const auto centroid = _grain_tracker.getGrainCentroid(i);
+          for (_qp=0; _qp<_qrule->n_points(); ++_qp)
+            if (_dFdc[_qp][j](0) != 0.0 || _dFdc[_qp][j](1) != 0.0 || _dFdc[_qp][j](2) != 0.0)
+            {
+              const Real factor = _JxW[_qp] * _coord[_qp] * _phi[_j][_qp];
+              const RealGradient compute_torque_jacobian_c = factor * (_current_elem->centroid() - centroid).cross(_dFdc[_qp][j]);
+              _force_torque_c_jacobian_store[(6*i+0)*_total_dofs+_j_global] += factor * _dFdc[_qp][j](0);
+              _force_torque_c_jacobian_store[(6*i+1)*_total_dofs+_j_global] += factor * _dFdc[_qp][j](1);
+              _force_torque_c_jacobian_store[(6*i+2)*_total_dofs+_j_global] += factor * _dFdc[_qp][j](2);
+              _force_torque_c_jacobian_store[(6*i+3)*_total_dofs+_j_global] += compute_torque_jacobian_c(0);
+              _force_torque_c_jacobian_store[(6*i+4)*_total_dofs+_j_global] += compute_torque_jacobian_c(1);
+              _force_torque_c_jacobian_store[(6*i+5)*_total_dofs+_j_global] += compute_torque_jacobian_c(2);
+            }
+        }
+
+  for (unsigned int i = 0; i < _op_num; ++i)
+    if (jvar == _vals_var[i])
+      for (unsigned int j = 0; j < _grain_num; ++j)
+        for (unsigned int k = 0; k < _op_num; ++k)
+          if (j == op_to_grains[k])
+          {
+            const auto centroid = _grain_tracker.getGrainCentroid(j);
+            for (_qp=0; _qp<_qrule->n_points(); ++_qp)
+              if ((*_dFdeta[i])[_qp][j](0) != 0.0 || (*_dFdeta[i])[_qp][j](1) != 0.0 || (*_dFdeta[i])[_qp][j](2) != 0.0)
+              {
+                const Real factor = _JxW[_qp] * _coord[_qp] * _phi[_j][_qp];
+                const RealGradient compute_torque_jacobian_eta = factor * (_current_elem->centroid() - centroid).cross((*_dFdeta[i])[_qp][k]);
+                _force_torque_eta_jacobian_store[i][(6*j+0)*_total_dofs+_j_global] += factor * (*_dFdeta[i])[_qp][k](0);
+                _force_torque_eta_jacobian_store[i][(6*j+1)*_total_dofs+_j_global] += factor * (*_dFdeta[i])[_qp][k](1);
+                _force_torque_eta_jacobian_store[i][(6*j+2)*_total_dofs+_j_global] += factor * (*_dFdeta[i])[_qp][k](2);
+                _force_torque_eta_jacobian_store[i][(6*j+3)*_total_dofs+_j_global] += compute_torque_jacobian_eta(0);
+                _force_torque_eta_jacobian_store[i][(6*j+4)*_total_dofs+_j_global] += compute_torque_jacobian_eta(1);
+                _force_torque_eta_jacobian_store[i][(6*j+5)*_total_dofs+_j_global] += compute_torque_jacobian_eta(2);
+              }
+          }
+}
+
+void
+ComputeExternalGrainForceAndTorque::finalize()
+{
+  gatherSum(_force_torque_store);
+  for (unsigned int i = 0; i < _grain_num; ++i)
+  {
+    _force_values[i](0) = _force_torque_store[6*i+0];
+    _force_values[i](1) = _force_torque_store[6*i+1];
+    _force_values[i](2) = _force_torque_store[6*i+2];
+    _torque_values[i](0) = _force_torque_store[6*i+3];
+    _torque_values[i](1) = _force_torque_store[6*i+4];
+    _torque_values[i](2) = _force_torque_store[6*i+5];
+  }
+
+  if (_fe_problem.currentlyComputingJacobian())
+  {
+    gatherSum(_force_torque_c_jacobian_store);
+    for (unsigned int i = 0; i < _op_num; ++i)
+      gatherSum(_force_torque_eta_jacobian_store[i]);
+  }
+}
+
+void
+ComputeExternalGrainForceAndTorque::threadJoin(const UserObject & y)
+{
+  const ComputeExternalGrainForceAndTorque & pps = static_cast<const ComputeExternalGrainForceAndTorque &>(y);
+  for (unsigned int i = 0; i < _ncomp; ++i)
+    _force_torque_store[i] += pps._force_torque_store[i];
+  if (_fe_problem.currentlyComputingJacobian())
+  {
+    for (unsigned int i = 0; i < _ncomp*_total_dofs; ++i)
+      _force_torque_c_jacobian_store[i] += pps._force_torque_c_jacobian_store[i];
+    for (unsigned int i = 0; i < _op_num; ++i)
+      for (unsigned int j = 0; j < _ncomp*_total_dofs; ++j)
+        _force_torque_eta_jacobian_store[i][j] += pps._force_torque_eta_jacobian_store[i][j];
+  }
+}
+
+const std::vector<RealGradient> &
+ComputeExternalGrainForceAndTorque::getForceValues() const
+{
+  return _force_values;
+}
+
+const std::vector<RealGradient> &
+ComputeExternalGrainForceAndTorque::getTorqueValues() const
+{
+  return _torque_values;
+}
+
+const std::vector<Real> &
+ComputeExternalGrainForceAndTorque::getForceCJacobians() const
+{
+  return _force_torque_c_jacobian_store;
+}
+const std::vector<std::vector<Real> > &
+ComputeExternalGrainForceAndTorque::getForceEtaJacobians() const
+{
+  return _force_torque_eta_jacobian_store;
+}

--- a/modules/phase_field/src/userobjects/ComputeExternalGrainForceAndTorque.C
+++ b/modules/phase_field/src/userobjects/ComputeExternalGrainForceAndTorque.C
@@ -23,7 +23,7 @@ InputParameters validParams<ComputeExternalGrainForceAndTorque>()
 }
 
 ComputeExternalGrainForceAndTorque::ComputeExternalGrainForceAndTorque(const InputParameters & parameters) :
-    ShapeElementUserObject(parameters),
+    DerivativeMaterialInterface<ShapeElementUserObject>(parameters),
     GrainForceAndTorqueInterface(),
     _c_name(getVar("c", 0)->name()),
     _c_var(coupled("c")),

--- a/modules/phase_field/src/userobjects/ComputeGrainForceAndTorque.C
+++ b/modules/phase_field/src/userobjects/ComputeGrainForceAndTorque.C
@@ -23,7 +23,7 @@ InputParameters validParams<ComputeGrainForceAndTorque>()
 }
 
 ComputeGrainForceAndTorque::ComputeGrainForceAndTorque(const InputParameters & parameters) :
-    ShapeElementUserObject(parameters),
+    DerivativeMaterialInterface<ShapeElementUserObject>(parameters),
     GrainForceAndTorqueInterface(),
     _c_name(getVar("c", 0)->name()),
     _c_var(coupled("c")),

--- a/modules/phase_field/tests/rigidbodymotion/grain_appliedforcedensity.i
+++ b/modules/phase_field/tests/rigidbodymotion/grain_appliedforcedensity.i
@@ -161,7 +161,7 @@
     execute_on = 'initial timestep_begin'
   [../]
   [./grain_force]
-    type = ComputeGrainForceAndTorque
+    type = ComputeExternalGrainForceAndTorque
     execute_on = 'linear nonlinear'
     grain_data = grain_center
     c = c


### PR DESCRIPTION
- Update `ForceDensityMaterial` to prevent non-physical scenarios
- Correct eta derivatives in `ExternalForceDensityMaterial` and create corresponding force & torque UO.
- Update tests and example input files
- Addresses #7920 
