### PR TITLE
Fixed an obvious bug in augmentSparsity

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -2427,19 +2427,15 @@ NonlinearSystem::augmentSparsity(SparsityPattern::Graph & sparsity,
       {
         if (coupled_dof < first_dof_on_proc || coupled_dof >= end_dof_on_proc)
         {
-          if (n_oz[local_dof] < max_nz)
+          if (n_oz[local_dof] < n_dofs_not_on_proc)
             n_oz[local_dof]++;
         }
         else
         {
-          if (n_nz[local_dof] < max_nz)
+          if (n_nz[local_dof] < n_dofs_on_proc)
             n_nz[local_dof]++;
         }
       }
-
-      // Safety
-      n_nz[local_dof] = std::min(n_nz[local_dof], n_dofs_on_proc);
-      n_oz[local_dof] = std::min(n_oz[local_dof], n_dofs_not_on_proc);
     }
   }
 }

--- a/modules/combined/tests/fieldsplit_contact/2blocks3d.i
+++ b/modules/combined/tests/fieldsplit_contact/2blocks3d.i
@@ -140,7 +140,9 @@
   [../]
 []
 
-
+[Problem]
+  error_on_jacobian_nonzero_reallocation = true;
+[]
 
 [Executioner]
   type = Transient

--- a/modules/combined/tests/fieldsplit_contact/tests
+++ b/modules/combined/tests/fieldsplit_contact/tests
@@ -3,5 +3,6 @@
     type = 'Exodiff'
     input = '2blocks3d.i'
     exodiff = '2blocks3d_out.e'
+    max_parallel = 4
   [../]
 []


### PR DESCRIPTION
The preallocation works right for the test case 2blocks3d.i

For other cases, we need to adjust patch_size to make preallocation correct.

But larger patch_size makes gometricsearch slower.

Refs #7901
