### PR TITLE
Added interface in SinglePhaseFluidProperties for p(h,s)

### DIFF
--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -52,6 +52,9 @@ public:
   virtual Real h(Real pressure, Real temperature) const;
   virtual void h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const;
 
+  virtual Real p_from_h_s(Real h, Real s) const;
+  virtual Real dpdh_from_h_s(Real h, Real s) const;
+
 protected:
   Real _gamma;
   Real _R;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -66,6 +66,11 @@ public:
   /// Compute enthalpy and its derivatives
   virtual void h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const = 0;
 
+  /// Pressure as a function of specific enthalpy and specific entropy
+  virtual Real p_from_h_s(Real h, Real s) const = 0;
+  /// Derivative of pressure wrt specific enthalpy
+  virtual Real dpdh_from_h_s(Real h, Real s) const = 0;
+
   /// Thermal expansion coefficient
   virtual Real beta(Real p, Real T) const = 0;
 };

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -52,6 +52,9 @@ public:
   virtual Real h(Real pressure, Real temperature) const;
   virtual void h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const;
 
+  virtual Real p_from_h_s(Real h, Real s) const;
+  virtual Real dpdh_from_h_s(Real h, Real s) const;
+
   virtual Real c2_from_p_rho(Real pressure, Real rho) const;
 
 protected:

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -191,3 +191,17 @@ IdealGasFluidProperties::h_dpT(Real pressure, Real temperature, Real & h, Real &
   dh_dp = 0;
   dh_dT = _cv + pressure / rho / temperature;
 }
+
+Real
+IdealGasFluidProperties::p_from_h_s(Real h, Real s) const
+{
+  mooseError(name() << ": p_from_h_s() not implemented.");
+  return 0;
+}
+
+Real
+IdealGasFluidProperties::dpdh_from_h_s(Real h, Real s) const
+{
+  mooseError(name() << ": dpdh_from_h_s() not implemented.");
+  return 0;
+}

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -193,6 +193,19 @@ StiffenedGasFluidProperties::h_dpT(Real, Real temperature, Real & h, Real & dh_d
   dh_dT = _gamma * _cv;
 }
 
+
+Real
+StiffenedGasFluidProperties::p_from_h_s(Real h, Real s) const
+{
+  return std::pow((h - _q) / (_gamma * _cv), _gamma / (_gamma-1)) * std::exp((_q_prime - s) / ((_gamma - 1) * _cv)) - _p_inf;
+}
+
+Real
+StiffenedGasFluidProperties::dpdh_from_h_s(Real h, Real s) const
+{
+  return _gamma / (_gamma - 1.0) / (_gamma * _cv) * std::pow((h - _q) / (_gamma * _cv), 1.0 / (_gamma - 1.0)) * std::exp((_q_prime - s) / ((_gamma - 1.0) * _cv));
+}
+
 Real
 StiffenedGasFluidProperties::gamma(Real, Real) const
 {


### PR DESCRIPTION
The p(h,s) function is needed for some BC. An interface for p(h,s)
and its derivative dp/dh(h,s) has been added.

Closes #7934
