### PR TITLE
Compute neighbor element volume on demand

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -532,6 +532,8 @@ protected:
 
   void computeCurrentFaceVolume();
 
+  void computeCurrentNeighborVolume();
+
   void addResidualBlock(NumericVector<Number> & residual, DenseVector<Number> & res_block, const std::vector<dof_id_type> & dof_indices, Real scaling_factor);
   void cacheResidualBlock(std::vector<Real> & cached_residual_values,
                           std::vector<dof_id_type> & cached_residual_rows,
@@ -657,6 +659,7 @@ protected:
   std::map<unsigned int, std::map<FEType, FEBase *> > _fe_neighbor;
   std::map<unsigned int, std::map<FEType, FEBase *> > _fe_face_neighbor;
   /// Each dimension's helper objects
+  std::map<unsigned int, FEBase **> _holder_fe_neighbor_helper;
   std::map<unsigned int, FEBase **> _holder_fe_face_neighbor_helper;
 
   /// quadrature rule used on neighbors
@@ -665,6 +668,8 @@ protected:
   std::map<unsigned int, ArbitraryQuadrature *> _holder_qrule_neighbor;
   /// The current transformed jacobian weights on a neighbor's face
   MooseArray<Real> _current_JxW_neighbor;
+  /// The current coordinate transformation coefficients
+  MooseArray<Real> _coord_neighbor;
 
   /// The current "element" we are currently on.
   const Elem * _current_elem;

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -214,7 +214,7 @@ public:
    * Returns the reference to the current neighbor volume
    * @return A _reference_.  Make sure to store this as a reference!
    */
-  const Real & neighborVolume() { return _current_neighbor_volume; }
+  const Real & neighborVolume();
 
   /**
    * Returns the reference to the current quadrature being used on a current neighbor
@@ -682,6 +682,8 @@ protected:
   unsigned int _current_neighbor_side;
   /// The current side element of the ncurrent neighbor element
   const Elem * _current_neighbor_side_elem;
+  /// true is apps need to compute neighbor element volume
+  bool _need_neighbor_elem_volume;
   /// Volume of the current neighbor
   Real _current_neighbor_volume;
   /// The current node we are working with

--- a/framework/include/dgkernels/DGKernel.h
+++ b/framework/include/dgkernels/DGKernel.h
@@ -130,9 +130,6 @@ protected:
   /// The neighboring element
   const Elem * & _neighbor_elem;
 
-  /// The volume (or length) of the current neighbor
-  const Real & _neighbor_elem_volume;
-
   /// Current side
   unsigned int & _current_side;
   /// Current side element
@@ -199,6 +196,9 @@ protected:
    * This is the virtual that derived classes should override for computing the off-diag Jacobian.
    */
   virtual Real computeQpOffDiagJacobian(Moose::DGJacobianType type, unsigned int jvar);
+
+  /// The volume (or length) of the current neighbor
+  const Real & getNeighborElemVolume();
 
 public:
   // boundary id used for internal edges (all DG kernels lives on this boundary id -- a made-up number)

--- a/framework/include/userobject/InternalSideUserObject.h
+++ b/framework/include/userobject/InternalSideUserObject.h
@@ -65,8 +65,9 @@ protected:
 
   /// The neighboring element
   const Elem * & _neighbor_elem;
+
   /// The volume (or length) of the current neighbor
-  const Real & _neighbor_elem_volume;
+  const Real & getNeighborElemVolume();
 };
 
 

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -73,7 +73,6 @@ DGKernel::DGKernel(const InputParameters & parameters) :
     _current_elem_volume(_assembly.elemVolume()),
 
     _neighbor_elem(_assembly.neighbor()),
-    _neighbor_elem_volume(_assembly.neighborVolume()),
 
     _current_side(_assembly.side()),
     _current_side_elem(_assembly.sideElem()),
@@ -231,4 +230,10 @@ SubProblem &
 DGKernel::subProblem()
 {
   return _subproblem;
+}
+
+const Real &
+DGKernel::getNeighborElemVolume()
+{
+  return _assembly.neighborVolume();
 }

--- a/framework/src/userobject/InternalSideUserObject.C
+++ b/framework/src/userobject/InternalSideUserObject.C
@@ -44,11 +44,17 @@ InternalSideUserObject::InternalSideUserObject(const InputParameters & parameter
     _current_side(_assembly.side()),
     _current_side_elem(_assembly.sideElem()),
     _current_side_volume(_assembly.sideElemVolume()),
-    _neighbor_elem(_assembly.neighbor()),
-    _neighbor_elem_volume(_assembly.neighborVolume())
+    _neighbor_elem(_assembly.neighbor())
 {
   // Keep track of which variables are coupled so we know what we depend on
   const std::vector<MooseVariable *> & coupled_vars = getCoupledMooseVars();
   for (const auto & var : coupled_vars)
     addMooseVariableDependency(var);
+}
+
+
+const Real &
+InternalSideUserObject::getNeighborElemVolume()
+{
+  return _assembly.neighborVolume();
 }


### PR DESCRIPTION
MOOSE was computing the neighbor element volume even though it was not
really needed. The computation is quite expensive and shows up in
profiling.  If the volume is needed in a DG kernel, users can obtain it
by:

```
.h:
const Real & _neighbor_volume;

.C:
_neighbor_volume(getNeighborElemVolume())
```

This will tell MOOSE to compute the volume. The same holds for `InternalSideUserObject`s.

Refs #3661, #6788
