### PR TITLE
Use override keyword in tensor mechanics userobjects

### DIFF
--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningConstant.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningConstant.h
@@ -24,17 +24,15 @@ class TensorMechanicsHardeningConstant : public TensorMechanicsHardeningModel
  public:
   TensorMechanicsHardeningConstant(const InputParameters & parameters);
 
-  virtual Real value(Real intnl) const;
+  virtual Real value(Real intnl) const override;
 
-  virtual Real derivative(Real intnl) const;
+  virtual Real derivative(Real intnl) const override;
 
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  private:
-
   /// The value that the parameter will take
   Real _val;
-
 };
 
 #endif // TENSORMECHANICSHARDENINGCONSTANT_H

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningCubic.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningCubic.h
@@ -27,14 +27,13 @@ class TensorMechanicsHardeningCubic : public TensorMechanicsHardeningModel
  public:
   TensorMechanicsHardeningCubic(const InputParameters & parameters);
 
-  virtual Real value(Real intnl) const;
+  virtual Real value(Real intnl) const override;
 
-  virtual Real derivative(Real intnl) const;
+  virtual Real derivative(Real intnl) const override;
 
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  private:
-
   /// value is cubic between _val_0 at internal_parameter=_intnl_0, at _val_res at internal_parameter=_intnl_limit
   Real _val_0;
 
@@ -55,7 +54,6 @@ class TensorMechanicsHardeningCubic : public TensorMechanicsHardeningModel
 
   /// convenience parameter for cubic
   Real _beta;
-
 };
 
 #endif // TENSORMECHANICSHARDENINGCUBIC_H

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningCutExponential.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningCutExponential.h
@@ -26,14 +26,13 @@ class TensorMechanicsHardeningCutExponential : public TensorMechanicsHardeningMo
  public:
   TensorMechanicsHardeningCutExponential(const InputParameters & parameters);
 
-  virtual Real value(Real intnl) const;
+  virtual Real value(Real intnl) const override;
 
-  virtual Real derivative(Real intnl) const;
+  virtual Real derivative(Real intnl) const override;
 
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  private:
-
   /// The value = _val_res + (val_0 - val_res)*exp(-rate*(internal_parameter - _intnl_0)), for internal_parameter >= _intnl_0, otherwise value = _val_0
   Real _val_0;
 
@@ -45,7 +44,6 @@ class TensorMechanicsHardeningCutExponential : public TensorMechanicsHardeningMo
 
   /// The value = _val_res + (val_0 - val_res)*exp(-rate*(internal_parameter - _intnl_0)), for internal_parameter >= _intnl_0, otherwise value = _val_0
   Real _rate;
-
 };
 
 #endif // TENSORMECHANICSHARDENINGCUTEXPONENTIAL_H

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningExponential.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningExponential.h
@@ -26,14 +26,13 @@ class TensorMechanicsHardeningExponential : public TensorMechanicsHardeningModel
  public:
   TensorMechanicsHardeningExponential(const InputParameters & parameters);
 
-  virtual Real value(Real intnl) const;
+  virtual Real value(Real intnl) const override;
 
-  virtual Real derivative(Real intnl) const;
+  virtual Real derivative(Real intnl) const override;
 
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  private:
-
   /// The value = _val_res + (val_0 - val_res)*exp(-rate*internal_parameter)
   Real _val_0;
 
@@ -42,7 +41,6 @@ class TensorMechanicsHardeningExponential : public TensorMechanicsHardeningModel
 
   /// The value = _val_res + (val_0 - val_res)*exp(-rate*internal_parameter)
   Real _rate;
-
 };
 
 #endif // TENSORMECHANICSHARDENINGEXPONENTIAL_H

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningGaussian.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningGaussian.h
@@ -26,14 +26,13 @@ class TensorMechanicsHardeningGaussian : public TensorMechanicsHardeningModel
  public:
   TensorMechanicsHardeningGaussian(const InputParameters & parameters);
 
-  virtual Real value(Real intnl) const;
+  virtual Real value(Real intnl) const override;
 
-  virtual Real derivative(Real intnl) const;
+  virtual Real derivative(Real intnl) const override;
 
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  private:
-
   /// The value = _val_res + (val_0 - val_res)*exp(-0.5*rate*(p - intnl_0)^2) for p>intnl_0.  Here p = internal parameter
   Real _val_0;
 
@@ -45,7 +44,6 @@ class TensorMechanicsHardeningGaussian : public TensorMechanicsHardeningModel
 
   /// The value = _val_res + (val_0 - val_res)*exp(-0.5*rate*(p - intnl_0)^2) for p>intnl_0.  Here p = internal parameter
   Real _rate;
-
 };
 
 #endif // TENSORMECHANICSHARDENINGGAUSSIAN_H

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningModel.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningModel.h
@@ -16,7 +16,10 @@ template<>
 InputParameters validParams<TensorMechanicsHardeningModel>();
 
 /**
- * Hardening Model base class
+ * Hardening Model base class.  The derived classes will provide
+ * a value and a derivative of that value with respect to a
+ * single internal parameter.
+ *
  * The virtual functions written below must be
  * over-ridden in derived classes to provide actual values
  */
@@ -29,12 +32,22 @@ class TensorMechanicsHardeningModel : public GeneralUserObject
   void execute();
   void finalize();
 
+  /* provides the value of the hardening parameter at given internal parameter
+   * @param intnl the value of the internal parameter at which to evaluate the hardening parameter
+   * @return the value of the hardening parameter
+   */
   virtual Real value(Real intnl) const;
 
+  /* provides d(hardening parameter)/d(internal parameter)
+   * @param intnl the value of the internal parameter at which to evaluate the derivative
+   * @return the value of the hardening parameter
+   */
   virtual Real derivative(Real intnl) const;
 
+  /* A name for this hardening model.  Plasticity models can use
+   * this name to enable certain optimizations
+   */
   virtual std::string modelName() const = 0;
-
 };
 
 #endif // TENSORMECHANICSHARDENINGMODEL_H

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningPowerRule.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsHardeningPowerRule.h
@@ -24,11 +24,11 @@ class TensorMechanicsHardeningPowerRule : public TensorMechanicsHardeningModel
  public:
   TensorMechanicsHardeningPowerRule(const InputParameters & parameters);
 
-  virtual Real value(Real intnl) const;
+  virtual Real value(Real intnl) const override;
 
-  virtual Real derivative(Real intnl) const;
+  virtual Real derivative(Real intnl) const override;
 
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  private:
   /// The value = value_0 * (p / epsilon0 + 1)^{exponent})

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticDruckerPrager.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticDruckerPrager.h
@@ -27,8 +27,7 @@ class TensorMechanicsPlasticDruckerPrager : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticDruckerPrager(const InputParameters & parameters);
 
-  /// Returns the model name (DruckerPrager)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  protected:
   /// Hardening model for cohesion
@@ -40,53 +39,17 @@ class TensorMechanicsPlasticDruckerPrager : public TensorMechanicsPlasticModel
   /// Hardening model for tan(psi)
   const TensorMechanicsHardeningModel & _mc_psi;
 
-  /**
-   * The yield function
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the yield function
-   */
-  virtual Real yieldFunction(const RankTwoTensor & stress, Real intnl) const;
+  virtual Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return df_dstress(i, j) = dyieldFunction/dstress(i, j)
-   */
-  virtual RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const;
+  virtual RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the derivative
-   */
-  virtual Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  virtual Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The flow potential
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return the flow potential
-   */
-  virtual RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const;
+  virtual RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dstress(i, j, k, l) = dr(i, j)/dstress(k, l)
-   */
-  virtual RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
+  virtual RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dintnl(i, j) = dr(i, j)/dintnl
-   */
-  virtual RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  virtual RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
   /**
    * The parameters aaa and bbb are chosen to closely match the Mohr-Coulomb

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticDruckerPragerHyperbolic.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticDruckerPragerHyperbolic.h
@@ -26,123 +26,27 @@ class TensorMechanicsPlasticDruckerPragerHyperbolic : public TensorMechanicsPlas
  public:
   TensorMechanicsPlasticDruckerPragerHyperbolic(const InputParameters & parameters);
 
-  /// Returns the model name (DruckerPragerHyperbolic)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
-  /// Returns _use_custom_returnMap
-  virtual bool useCustomReturnMap() const;
+  virtual bool useCustomReturnMap() const override;
 
-  /// Returns _use_custom_cto
-  virtual bool useCustomCTO() const;
+  virtual bool useCustomCTO() const override;
 
  protected:
-  /**
-   * The yield function
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the yield function
-   */
-  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const;
+  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dstress(i, j, k, l) = dr(i, j)/dstress(k, l)
-   */
-  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
+  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
   /// Function that's used in dyieldFunction_dstress and flowPotential
   virtual RankTwoTensor df_dsig(const RankTwoTensor & stress, Real bbb) const;
 
-  /**
-   * Performs a custom return-map.
-   * You may choose to over-ride this in your
-   * derived TensorMechanicsPlasticXXXX class,
-   * and you may implement the return-map
-   * algorithm in any way that suits you.  Eg, using
-   * a Newton-Raphson approach, or a radial-return,
-   * etc.
-   * This may also be used as a quick way of ascertaining
-   * whether (trial_stress, intnl_old) is in fact admissible.
-   *
-   * For over-riding this function, please note the
-   * following.
-   *
-   * (1) Denoting the return value of the function by "successful_return",
-   * the only possible output values should be:
-   *   (A) trial_stress_inadmissible=false, successful_return=true.
-   *       That is, (trial_stress, intnl_old) is in fact admissible
-   *       (in the elastic domain).
-   *   (B) trial_stress_inadmissible=true, successful_return=false.
-   *       That is (trial_stress, intnl_old) is inadmissible
-   *       (outside the yield surface), and you didn't return
-   *       to the yield surface.
-   *   (C) trial_stress_inadmissible=true, successful_return=true.
-   *       That is (trial_stress, intnl_old) is inadmissible
-   *       (outside the yield surface), but you did return
-   *       to the yield surface.
-   * The default implementation only handles case (A) and (B):
-   * it does not attempt to do a return-map algorithm.
-   *
-   * (2) you must correctly signal "successful_return" using the
-   * return value of this function.  Don't assume the calling function
-   * will do Kuhn-Tucker checking and so forth!
-   *
-   * (3) In cases (A) and (B) you needn't set returned_stress,
-   * returned_intnl, delta_dp, or dpm.  This is for computational
-   * efficiency.
-   *
-   * (4) In cases (A) and (B), you MUST place the yield function
-   * values at (trial_stress, intnl_old) into yf so the calling
-   * function can use this information optimally.  You will have
-   * already calculated these yield function values, which can be
-   * quite expensive, and it's not very optimal for the calling
-   * function to have to re-calculate them.
-   *
-   * (5) In case (C), you need to set:
-   *   returned_stress (the returned value of stress)
-   *   returned_intnl  (the returned value of the internal variable)
-   *   delta_dp   (the change in plastic strain)
-   *   dpm (the plastic multipliers needed to bring about the return)
-   *   yf (yield function values at the returned configuration)
-   *
-   * (Note, if you over-ride returnMap, you will probably
-   * want to override consistentTangentOpertor too, otherwise
-   * it will default to E_ijkl.)
-   *
-   * @param trial_stress The trial stress
-   * @param intnl_old Value of the internal parameter
-   * @param E_ijkl Elasticity tensor
-   * @param ep_plastic_tolerance Tolerance defined by the user for the plastic strain
-   * @param[out] returned_stress In case (C): lies on the yield surface after returning and produces the correct plastic strain (normality condition).  Otherwise: not defined
-   * @param[out] returned_intnl In case (C): the value of the internal parameter after returning.  Otherwise: not defined
-   * @param[out] dpm  In case (C): the plastic multipliers needed to bring about the return.  Otherwise: not defined
-   * @param[out] delta_dp In case (C): The change in plastic strain induced by the return process.  Otherwise: not defined
-   * @param[out] yf In case (C): the yield function at (returned_stress, returned_intnl).  Otherwise: the yield function at (trial_stress, intnl_old)
-   * @param[out] trial_stress_inadmissible Should be set to false if the trial_stress is admissible, and true if the trial_stress is inadmissible.  This can be used by the calling prorgram
-   * @return true if a successful return (or a return-map not needed), false if the trial_stress is inadmissible but the return process failed
-   */
   virtual bool returnMap(const RankTwoTensor & trial_stress, Real intnl_old, const RankFourTensor & E_ijkl,
                          Real ep_plastic_tolerance, RankTwoTensor & returned_stress, Real & returned_intnl,
                          std::vector<Real> & dpm, RankTwoTensor & delta_dp, std::vector<Real> & yf,
-                         bool & trial_stress_inadmissible) const;
+                         bool & trial_stress_inadmissible) const override;
 
-  /**
-    * Calculates a custom consistent tangent operator.
-    * You may choose to over-ride this in your
-    * derived TensorMechanicsPlasticXXXX class.
-    *
-    * @param stress_old trial stress before returning
-    * @param intnl_old internal parameter before returning
-    * @param stress current stress state
-    * @param intnl internal parameter
-    * @param E_ijkl elasticity tensor
-    * @param cumulative_pm the cumulative plastic multipliers
-    * @return the consistent tangent operator for J2 (radial return) case
-    */
   virtual RankFourTensor consistentTangentOperator(const RankTwoTensor & trial_stress, Real intnl_old, const RankTwoTensor & stress, Real intnl,
-                                                   const RankFourTensor & E_ijkl, const std::vector<Real> & cumulative_pm) const;
+                                                   const RankFourTensor & E_ijkl, const std::vector<Real> & cumulative_pm) const override;
 
  private:
   /// smoothing parameter for the cone's tip

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticJ2.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticJ2.h
@@ -24,153 +24,32 @@ class TensorMechanicsPlasticJ2 : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticJ2(const InputParameters & parameters);
 
-  /// returns the model name (J2)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
-  /// Returns _use_custom_returnMap
-  virtual bool useCustomReturnMap() const;
+  virtual bool useCustomReturnMap() const override;
 
-  /// Returns _use_custom_cto
-  virtual bool useCustomCTO() const;
+  virtual bool useCustomCTO() const override;
 
-  /**
-    * Performs a custom return-map.
-    * You may choose to over-ride this in your
-    * derived TensorMechanicsPlasticXXXX class,
-    * and you may implement the return-map
-    * algorithm in any way that suits you.  Eg, using
-    * a Newton-Raphson approach, or a radial-return,
-    * etc.
-    * This may also be used as a quick way of ascertaining
-    * whether (trial_stress, intnl_old) is in fact admissible.
-    *
-    * For over-riding this function, please note the
-    * following.
-    *
-    * (1) Denoting the return value of the function by "successful_return",
-    * the only possible output values should be:
-    *   (A) trial_stress_inadmissible=false, successful_return=true.
-    *       That is, (trial_stress, intnl_old) is in fact admissible
-    *       (in the elastic domain).
-    *   (B) trial_stress_inadmissible=true, successful_return=false.
-    *       That is (trial_stress, intnl_old) is inadmissible
-    *       (outside the yield surface), and you didn't return
-    *       to the yield surface.
-    *   (C) trial_stress_inadmissible=true, successful_return=true.
-    *       That is (trial_stress, intnl_old) is inadmissible
-    *       (outside the yield surface), but you did return
-    *       to the yield surface.
-    * The default implementation only handles case (A) and (B):
-    * it does not attempt to do a return-map algorithm.
-    *
-    * (2) you must correctly signal "successful_return" using the
-    * return value of this function.  Don't assume the calling function
-    * will do Kuhn-Tucker checking and so forth!
-    *
-    * (3) In cases (A) and (B) you needn't set returned_stress,
-    * returned_intnl, delta_dp, or dpm.  This is for computational
-    * efficiency.
-    *
-    * (4) In cases (A) and (B), you MUST place the yield function
-    * values at (trial_stress, intnl_old) into yf so the calling
-    * function can use this information optimally.  You will have
-    * already calculated these yield function values, which can be
-    * quite expensive, and it's not very optimal for the calling
-    * function to have to re-calculate them.
-    *
-    * (5) In case (C), you need to set:
-    *   returned_stress (the returned value of stress)
-    *   returned_intnl  (the returned value of the internal variable)
-    *   delta_dp   (the change in plastic strain)
-    *   dpm (the plastic multipliers needed to bring about the return)
-    *   yf (yield function values at the returned configuration)
-    *
-    * (Note, if you over-ride returnMap, you will probably
-    * want to override consistentTangentOpertor too, otherwise
-    * it will default to E_ijkl.)
-    *
-    * @param trial_stress The trial stress
-    * @param intnl_old Value of the internal parameter
-    * @param E_ijkl Elasticity tensor
-    * @param ep_plastic_tolerance Tolerance defined by the user for the plastic strain
-    * @param[out] returned_stress In case (C): lies on the yield surface after returning and produces the correct plastic strain (normality condition).  Otherwise: not defined
-    * @param[out] returned_intnl In case (C): the value of the internal parameter after returning.  Otherwise: not defined
-    * @param[out] dpm  In case (C): the plastic multipliers needed to bring about the return.  Otherwise: not defined
-    * @param[out] delta_dp In case (C): The change in plastic strain induced by the return process.  Otherwise: not defined
-    * @param[out] yf In case (C): the yield function at (returned_stress, returned_intnl).  Otherwise: the yield function at (trial_stress, intnl_old)
-    * @param[out] trial_stress_inadmissible Should be set to false if the trial_stress is admissible, and true if the trial_stress is inadmissible.  This can be used by the calling prorgram
-    * @return true if a successful return (or a return-map not needed), false if the trial_stress is inadmissible but the return process failed
-    */
   virtual bool returnMap(const RankTwoTensor & trial_stress, Real intnl_old, const RankFourTensor & E_ijkl,
                          Real ep_plastic_tolerance, RankTwoTensor & returned_stress, Real & returned_intnl,
                          std::vector<Real> & dpm, RankTwoTensor & delta_dp, std::vector<Real> & yf,
-                         bool & trial_stress_inadmissible) const;
+                         bool & trial_stress_inadmissible) const override;
 
-  /**
-    * Calculates a custom consistent tangent operator.
-    * You may choose to over-ride this in your
-    * derived TensorMechanicsPlasticXXXX class.
-    *
-    * @param stress_old trial stress before returning
-    * @param intnl_old internal parameter before returning
-    * @param stress current stress state
-    * @param intnl internal parameter
-    * @param E_ijkl elasticity tensor
-    * @param cumulative_pm the cumulative plastic multipliers
-    * @return the consistent tangent operator for J2 (radial return) case
-    */
   virtual RankFourTensor consistentTangentOperator(const RankTwoTensor & trial_stress, Real intnl_old, const RankTwoTensor & stress, Real intnl,
-                                                   const RankFourTensor & E_ijkl, const std::vector<Real> & cumulative_pm) const;
+                                                   const RankFourTensor & E_ijkl, const std::vector<Real> & cumulative_pm) const override;
 
  protected:
+  virtual Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The yield function
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the yield function
-   */
-  virtual Real yieldFunction(const RankTwoTensor & stress, Real intnl) const;
+  virtual RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return df_dstress(i, j) = dyieldFunction/dstress(i, j)
-   */
-  virtual RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const;
+  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the derivative
-   */
-  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  virtual RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The flow potential
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return the flow potential
-   */
-  virtual RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const;
+  virtual RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dstress(i, j, k, l) = dr(i, j)/dstress(k, l)
-   */
-  virtual RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
-
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dintnl(i, j) = dr(i, j)/dintnl
-   */
-  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
   /**
    * YieldStrength.  The yield function is sqrt(3*J2) - yieldStrength.

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMeanCap.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMeanCap.h
@@ -29,58 +29,20 @@ class TensorMechanicsPlasticMeanCap : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticMeanCap(const InputParameters & parameters);
 
-  /// Returns the model name (MeanCap)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  protected:
+  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The yield function
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the yield function
-   */
-  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return df_dstress(i, j) = dyieldFunction/dstress(i, j)
-   */
-  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const;
+  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the derivative
-   */
-  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The flow potential
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return the flow potential
-   */
-  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const;
+  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dstress(i, j, k, l) = dr(i, j)/dstress(k, l)
-   */
-  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
-
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dintnl(i, j) = dr(i, j)/dintnl
-   */
-  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
   /// a/3
   Real _a_over_3;

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMeanCapTC.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMeanCapTC.h
@@ -31,118 +31,21 @@ class TensorMechanicsPlasticMeanCapTC : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticMeanCapTC(const InputParameters & parameters);
 
-  /**
-   * The active yield surfaces, given a vector of yield functions.
-   * This is used by FiniteStrainMultiPlasticity to determine the initial
-   * set of active constraints at the trial (stress, intnl) configuration.
-   * It is up to you (the coder) to determine how accurate you want the
-   * returned_stress to be.  Currently it is only used by FiniteStrainMultiPlasticity
-   * to estimate a good starting value for the Newton-Rahson procedure,
-   * so currently it may not need to be super perfect.
-   * @param f values of the yield functions
-   * @param stress stress tensor
-   * @param intnl internal parameter
-   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
-   * @param[out] act act[i] = true if the i_th yield function is active
-   * @param[out] returned_stress Approximate value of the returned stress
-   */
-  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, Real intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const;
+  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, Real intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const override;
 
-  /// Returns _use_custom_returnMap
-  virtual bool useCustomReturnMap() const;
+  virtual bool useCustomReturnMap() const override;
 
-  /// Returns _use_custom_cto
-  virtual bool useCustomCTO() const;
+  virtual bool useCustomCTO() const override;
 
-  /**
-    * Performs a custom return-map.
-    * You may choose to over-ride this in your
-    * derived TensorMechanicsPlasticXXXX class,
-    * and you may implement the return-map
-    * algorithm in any way that suits you.  Eg, using
-    * a Newton-Raphson approach, or a radial-return,
-    * etc.
-    * This may also be used as a quick way of ascertaining
-    * whether (trial_stress, intnl_old) is in fact admissible.
-    *
-    * For over-riding this function, please note the
-    * following.
-    *
-    * (1) Denoting the return value of the function by "successful_return",
-    * the only possible output values should be:
-    *   (A) trial_stress_inadmissible=false, successful_return=true.
-    *       That is, (trial_stress, intnl_old) is in fact admissible
-    *       (in the elastic domain).
-    *   (B) trial_stress_inadmissible=true, successful_return=false.
-    *       That is (trial_stress, intnl_old) is inadmissible
-    *       (outside the yield surface), and you didn't return
-    *       to the yield surface.
-    *   (C) trial_stress_inadmissible=true, successful_return=true.
-    *       That is (trial_stress, intnl_old) is inadmissible
-    *       (outside the yield surface), but you did return
-    *       to the yield surface.
-    * The default implementation only handles case (A) and (B):
-    * it does not attempt to do a return-map algorithm.
-    *
-    * (2) you must correctly signal "successful_return" using the
-    * return value of this function.  Don't assume the calling function
-    * will do Kuhn-Tucker checking and so forth!
-    *
-    * (3) In cases (A) and (B) you needn't set returned_stress,
-    * returned_intnl, delta_dp, or dpm.  This is for computational
-    * efficiency.
-    *
-    * (4) In cases (A) and (B), you MUST place the yield function
-    * values at (trial_stress, intnl_old) into yf so the calling
-    * function can use this information optimally.  You will have
-    * already calculated these yield function values, which can be
-    * quite expensive, and it's not very optimal for the calling
-    * function to have to re-calculate them.
-    *
-    * (5) In case (C), you need to set:
-    *   returned_stress (the returned value of stress)
-    *   returned_intnl  (the returned value of the internal variable)
-    *   delta_dp   (the change in plastic strain)
-    *   dpm (the plastic multipliers needed to bring about the return)
-    *   yf (yield function values at the returned configuration)
-    *
-    * (Note, if you over-ride returnMap, you will probably
-    * want to override consistentTangentOpertor too, otherwise
-    * it will default to E_ijkl.)
-    *
-    * @param trial_stress The trial stress
-    * @param intnl_old Value of the internal parameter
-    * @param E_ijkl Elasticity tensor
-    * @param ep_plastic_tolerance Tolerance defined by the user for the plastic strain
-    * @param[out] returned_stress In case (C): lies on the yield surface after returning and produces the correct plastic strain (normality condition).  Otherwise: not defined
-    * @param[out] returned_intnl In case (C): the value of the internal parameter after returning.  Otherwise: not defined
-    * @param[out] dpm  In case (C): the plastic multipliers needed to bring about the return.  Otherwise: not defined
-    * @param[out] delta_dp In case (C): The change in plastic strain induced by the return process.  Otherwise: not defined
-    * @param[out] yf In case (C): the yield function at (returned_stress, returned_intnl).  Otherwise: the yield function at (trial_stress, intnl_old)
-    * @param[out] trial_stress_inadmissible Should be set to false if the trial_stress is admissible, and true if the trial_stress is inadmissible.  This can be used by the calling prorgram
-    * @return true if a successful return (or a return-map not needed), false if the trial_stress is inadmissible but the return process failed
-    */
   virtual bool returnMap(const RankTwoTensor & trial_stress, Real intnl_old, const RankFourTensor & E_ijkl,
                          Real ep_plastic_tolerance, RankTwoTensor & returned_stress, Real & returned_intnl,
                          std::vector<Real> & dpm, RankTwoTensor & delta_dp, std::vector<Real> & yf,
-                         bool & trial_stress_inadmissible) const;
+                         bool & trial_stress_inadmissible) const override;
 
-  /**
-    * Calculates the custom consistent tangent operator.
-    *
-    * @param stress_old trial stress before returning
-    * @param intnl_old internal parameter before returning
-    * @param stress current stress state
-    * @param intnl internal parameter
-    * @param E_ijkl elasticity tensor
-    * @param cumulative_pm the cumulative plastic multipliers
-    * @return the consistent tangent operator for J2 (radial return) case
-    */
   virtual RankFourTensor consistentTangentOperator(const RankTwoTensor & trial_stress, Real intnl_old, const RankTwoTensor & stress, Real intnl,
-                                                   const RankFourTensor & E_ijkl, const std::vector<Real> & cumulative_pm) const;
+                                                   const RankFourTensor & E_ijkl, const std::vector<Real> & cumulative_pm) const override;
 
-  /// Returns the model name (MeanCapTC)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  protected:
   /// max iters for custom return map loop
@@ -160,53 +63,17 @@ class TensorMechanicsPlasticMeanCapTC : public TensorMechanicsPlasticModel
   /// the compressive strength
   const TensorMechanicsHardeningModel & _c_strength;
 
-  /**
-   * The yield function
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the yield function
-   */
-  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const;
+  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return df_dstress(i, j) = dyieldFunction/dstress(i, j)
-   */
-  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the derivative
-   */
-  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The flow potential
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return the flow potential
-   */
-  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dstress(i, j, k, l) = dr(i, j)/dstress(k, l)
-   */
-  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
+  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dintnl(i, j) = dr(i, j)/dintnl
-   */
-  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
   /**
    * The hardening potential.  Note that it is -1 for stress.trace() > _strength,
@@ -218,21 +85,9 @@ class TensorMechanicsPlasticMeanCapTC : public TensorMechanicsPlasticModel
    */
   Real hardPotential(const RankTwoTensor & stress, Real intnl) const;
 
-  /**
-   * The derivative of the hardening potential with respect to stress
-   * @param stress the stress at which to calculate the hardening potentials
-   * @param intnl internal parameter
-   * @return dh_dstress(i, j) = dh/dstress(i, j)
-   */
-  virtual RankTwoTensor dhardPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
+  virtual RankTwoTensor dhardPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the hardening potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the hardening potentials
-   * @param intnl internal parameter
-   * @return the derivative
-   */
-  virtual Real dhardPotential_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  virtual Real dhardPotential_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
   /**
    * Derivative of the yield function with respect to stress.  This is also the flow potential.

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticModel.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticModel.h
@@ -140,8 +140,7 @@ class TensorMechanicsPlasticModel : public GeneralUserObject
   virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, Real intnl,
                                  const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const;
 
-  /// Returns the model name (eg "MohrCoulomb")
-  virtual std::string modelName() const;
+  virtual std::string modelName() const = 0;
 
   /// Returns false.  You will want to override this in your derived class if you write a custom returnMap function
   virtual bool useCustomReturnMap() const;

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMohrCoulomb.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMohrCoulomb.h
@@ -32,57 +32,20 @@ class TensorMechanicsPlasticMohrCoulomb : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticMohrCoulomb(const InputParameters & parameters);
 
-  /// Returns the model name (MohrCoulomb)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  protected:
-  /**
-   * The yield function
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the yield function
-   */
-  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const;
+  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return df_dstress(i, j) = dyieldFunction/dstress(i, j)
-   */
-  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the derivative
-   */
-  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The flow potential
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return the flow potential
-   */
-  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dstress(i, j, k, l) = dr(i, j)/dstress(k, l)
-   */
-  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
+  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dintnl(i, j) = dr(i, j)/dintnl
-   */
-  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
   /// Hardening model for cohesion
   const TensorMechanicsHardeningModel & _cohesion;

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMohrCoulombMulti.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticMohrCoulombMulti.h
@@ -27,150 +27,28 @@ class TensorMechanicsPlasticMohrCoulombMulti : public TensorMechanicsPlasticMode
   /// The number of yield surfaces for this plasticity model
   virtual unsigned int numberSurfaces() const;
 
-  /**
-   * Calculates the yield functions.  Note that for single-surface plasticity
-   * you don't want to override this - override the private yieldFunction below
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @param[out] f the yield functions
-   */
-  virtual void yieldFunctionV(const RankTwoTensor & stress, Real intnl, std::vector<Real> & f) const;
+  virtual void yieldFunctionV(const RankTwoTensor & stress, Real intnl, std::vector<Real> & f) const override;
 
-  /**
-   * The derivative of yield functions with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @param[out] df_dstress df_dstress[alpha](i, j) = dyieldFunction[alpha]/dstress(i, j)
-   */
-  virtual void dyieldFunction_dstressV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & df_dstress) const;
+  virtual void dyieldFunction_dstressV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & df_dstress) const override;
 
-  /**
-   * The derivative of yield functions with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @param[out] df_dintnl df_dintnl[alpha] = df[alpha]/dintnl
-   */
-  virtual void dyieldFunction_dintnlV(const RankTwoTensor & stress, Real intnl, std::vector<Real> & df_dintnl) const;
+  virtual void dyieldFunction_dintnlV(const RankTwoTensor & stress, Real intnl, std::vector<Real> & df_dintnl) const override;
 
-  /**
-   * The flow potentials
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @param[out] r r[alpha] is the flow potential for the "alpha" yield function
-   */
-  virtual void flowPotentialV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & r) const;
+  virtual void flowPotentialV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & r) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @param[out] dr_dstress dr_dstress[alpha](i, j, k, l) = dr[alpha](i, j)/dstress(k, l)
-   */
-  virtual void dflowPotential_dstressV(const RankTwoTensor & stress, Real intnl, std::vector<RankFourTensor> & dr_dstress) const;
+  virtual void dflowPotential_dstressV(const RankTwoTensor & stress, Real intnl, std::vector<RankFourTensor> & dr_dstress) const override;
 
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @param[out] dr_dintnl  dr_dintnl[alpha](i, j) = dr[alpha](i, j)/dintnl
-   */
-  virtual void dflowPotential_dintnlV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & dr_dintnl) const;
+  virtual void dflowPotential_dintnlV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & dr_dintnl) const override;
 
-  /**
-   * The active yield surfaces, given a vector of yield functions.
-   * This is used by FiniteStrainMultiPlasticity to determine the initial
-   * set of active constraints at the trial (stress, intnl) configuration.
-   * It is up to you (the coder) to determine how accurate you want the
-   * returned_stress to be.  Currently it is only used by FiniteStrainMultiPlasticity
-   * to estimate a good starting value for the Newton-Rahson procedure,
-   * so currently it may not need to be super perfect.
-   * @param f values of the yield functions
-   * @param stress stress tensor
-   * @param intnl internal parameter
-   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
-   * @param[out] act act[i] = true if the i_th yield function is active
-   * @param[out] returned_stress Approximate value of the returned stress
-   */
-  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, Real intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const;
+  virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, Real intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const override;
 
-  /// Returns the model name (MohrCoulombMulti)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
-  /// Returns _use_custom_returnMap
-  virtual bool useCustomReturnMap() const;
+  virtual bool useCustomReturnMap() const override;
 
-  /**
-    * Performs a custom return-map.
-    * You may choose to over-ride this in your
-    * derived TensorMechanicsPlasticXXXX class,
-    * and you may implement the return-map
-    * algorithm in any way that suits you.  Eg, using
-    * a Newton-Raphson approach, or a radial-return,
-    * etc.
-    * This may also be used as a quick way of ascertaining
-    * whether (trial_stress, intnl_old) is in fact admissible.
-    *
-    * For over-riding this function, please note the
-    * following.
-    *
-    * (1) Denoting the return value of the function by "successful_return",
-    * the only possible output values should be:
-    *   (A) trial_stress_inadmissible=false, successful_return=true.
-    *       That is, (trial_stress, intnl_old) is in fact admissible
-    *       (in the elastic domain).
-    *   (B) trial_stress_inadmissible=true, successful_return=false.
-    *       That is (trial_stress, intnl_old) is inadmissible
-    *       (outside the yield surface), and you didn't return
-    *       to the yield surface.
-    *   (C) trial_stress_inadmissible=true, successful_return=true.
-    *       That is (trial_stress, intnl_old) is inadmissible
-    *       (outside the yield surface), but you did return
-    *       to the yield surface.
-    * The default implementation only handles case (A) and (B):
-    * it does not attempt to do a return-map algorithm.
-    *
-    * (2) you must correctly signal "successful_return" using the
-    * return value of this function.  Don't assume the calling function
-    * will do Kuhn-Tucker checking and so forth!
-    *
-    * (3) In cases (A) and (B) you needn't set returned_stress,
-    * returned_intnl, delta_dp, or dpm.  This is for computational
-    * efficiency.
-    *
-    * (4) In cases (A) and (B), you MUST place the yield function
-    * values at (trial_stress, intnl_old) into yf so the calling
-    * function can use this information optimally.  You will have
-    * already calculated these yield function values, which can be
-    * quite expensive, and it's not very optimal for the calling
-    * function to have to re-calculate them.
-    *
-    * (5) In case (C), you need to set:
-    *   returned_stress (the returned value of stress)
-    *   returned_intnl  (the returned value of the internal variable)
-    *   delta_dp   (the change in plastic strain)
-    *   dpm (the plastic multipliers needed to bring about the return)
-    *   yf (yield function values at the returned configuration)
-    *
-    * (Note, if you over-ride returnMap, you will probably
-    * want to override consistentTangentOpertor too, otherwise
-    * it will default to E_ijkl.)
-    *
-    * @param trial_stress The trial stress
-    * @param intnl_old Value of the internal parameter
-    * @param E_ijkl Elasticity tensor
-    * @param ep_plastic_tolerance Tolerance defined by the user for the plastic strain
-    * @param[out] returned_stress In case (C): lies on the yield surface after returning and produces the correct plastic strain (normality condition).  Otherwise: not defined
-    * @param[out] returned_intnl In case (C): the value of the internal parameter after returning.  Otherwise: not defined
-    * @param[out] dpm  In case (C): the plastic multipliers needed to bring about the return.  Otherwise: not defined
-    * @param[out] delta_dp In case (C): The change in plastic strain induced by the return process.  Otherwise: not defined
-    * @param[out] yf In case (C): the yield function at (returned_stress, returned_intnl).  Otherwise: the yield function at (trial_stress, intnl_old)
-    * @param[out] trial_stress_inadmissible Should be set to false if the trial_stress is admissible, and true if the trial_stress is inadmissible.  This can be used by the calling prorgram
-    * @return true if a successful return (or a return-map not needed), false if the trial_stress is inadmissible but the return process failed
-    */
   virtual bool returnMap(const RankTwoTensor & trial_stress, Real intnl_old, const RankFourTensor & E_ijkl,
                          Real ep_plastic_tolerance, RankTwoTensor & returned_stress, Real & returned_intnl,
                          std::vector<Real> & dpm, RankTwoTensor & delta_dp, std::vector<Real> & yf,
-                         bool & trial_stress_inadmissible) const;
+                         bool & trial_stress_inadmissible) const override;
 
  protected:
 

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticSimpleTester.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticSimpleTester.h
@@ -26,58 +26,20 @@ class TensorMechanicsPlasticSimpleTester : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticSimpleTester(const InputParameters & parameters);
 
-  /// Returns the model name (SimpleTester)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  protected:
+  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The yield function
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the yield function
-   */
-  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return df_dstress(i, j) = dyieldFunction/dstress(i, j)
-   */
-  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const;
+  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the derivative
-   */
-  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The flow potential
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return the flow potential
-   */
-  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const;
+  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dstress(i, j, k, l) = dr(i, j)/dstress(k, l)
-   */
-  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
-
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dintnl(i, j) = dr(i, j)/dintnl
-   */
-  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
   /// a
   Real _a;

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticTensile.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticTensile.h
@@ -31,57 +31,20 @@ class TensorMechanicsPlasticTensile : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticTensile(const InputParameters & parameters);
 
-  /// Returns the model name (Tensile)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  protected:
-  /**
-   * The yield function
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the yield function
-   */
-  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const;
+  Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return df_dstress(i, j) = dyieldFunction/dstress(i, j)
-   */
-  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dyieldFunction_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of yield function with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @return the derivative
-   */
-  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  Real dyieldFunction_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The flow potential
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return the flow potential
-   */
-  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor flowPotential(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dstress(i, j, k, l) = dr(i, j)/dstress(k, l)
-   */
-  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const;
+  RankFourTensor dflowPotential_dstress(const RankTwoTensor & stress, Real intnl) const override;
 
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @return dr_dintnl(i, j) = dr(i, j)/dintnl
-   */
-  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const;
+  RankTwoTensor dflowPotential_dintnl(const RankTwoTensor & stress, Real intnl) const override;
 
   const TensorMechanicsHardeningModel & _strength;
 

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticTensileMulti.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticTensileMulti.h
@@ -24,178 +24,37 @@ class TensorMechanicsPlasticTensileMulti : public TensorMechanicsPlasticModel
  public:
   TensorMechanicsPlasticTensileMulti(const InputParameters & parameters);
 
-  /// The number of yield surfaces for this plasticity model
-  virtual unsigned int numberSurfaces() const;
+  virtual unsigned int numberSurfaces() const override;
 
-  /**
-   * Calculates the yield functions.  Note that for single-surface plasticity
-   * you don't want to override this - override the private yieldFunction below
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @param[out] f the yield functions
-   */
-  virtual void yieldFunctionV(const RankTwoTensor & stress, Real intnl, std::vector<Real> & f) const;
+  virtual void yieldFunctionV(const RankTwoTensor & stress, Real intnl, std::vector<Real> & f) const override;
 
-  /**
-   * The derivative of yield functions with respect to stress
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @param[out] df_dstress df_dstress[alpha](i, j) = dyieldFunction[alpha]/dstress(i, j)
-   */
-  virtual void dyieldFunction_dstressV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & df_dstress) const;
+  virtual void dyieldFunction_dstressV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & df_dstress) const override;
 
-  /**
-   * The derivative of yield functions with respect to the internal parameter
-   * @param stress the stress at which to calculate the yield function
-   * @param intnl internal parameter
-   * @param[out] df_dintnl df_dintnl[alpha] = df[alpha]/dintnl
-   */
-  virtual void dyieldFunction_dintnlV(const RankTwoTensor & stress, Real intnl, std::vector<Real> & df_dintnl) const;
+  virtual void dyieldFunction_dintnlV(const RankTwoTensor & stress, Real intnl, std::vector<Real> & df_dintnl) const override;
 
-  /**
-   * The flow potentials
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @param[out] r r[alpha] is the flow potential for the "alpha" yield function
-   */
-  virtual void flowPotentialV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & r) const;
+  virtual void flowPotentialV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & r) const override;
 
-  /**
-   * The derivative of the flow potential with respect to stress
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @param[out] dr_dstress dr_dstress[alpha](i, j, k, l) = dr[alpha](i, j)/dstress(k, l)
-   */
-  virtual void dflowPotential_dstressV(const RankTwoTensor & stress, Real intnl, std::vector<RankFourTensor> & dr_dstress) const;
+  virtual void dflowPotential_dstressV(const RankTwoTensor & stress, Real intnl, std::vector<RankFourTensor> & dr_dstress) const override;
 
-  /**
-   * The derivative of the flow potential with respect to the internal parameter
-   * @param stress the stress at which to calculate the flow potential
-   * @param intnl internal parameter
-   * @param[out] dr_dintnl  dr_dintnl[alpha](i, j) = dr[alpha](i, j)/dintnl
-   */
-  virtual void dflowPotential_dintnlV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & dr_dintnl) const;
+  virtual void dflowPotential_dintnlV(const RankTwoTensor & stress, Real intnl, std::vector<RankTwoTensor> & dr_dintnl) const override;
 
-  /**
-   * The active yield surfaces, given a vector of yield functions.
-   * This is used by FiniteStrainMultiPlasticity to determine the initial
-   * set of active constraints at the trial (stress, intnl) configuration.
-   * It is up to you (the coder) to determine how accurate you want the
-   * returned_stress to be.  Currently it is only used by FiniteStrainMultiPlasticity
-   * to estimate a good starting value for the Newton-Rahson procedure,
-   * so currently it may not need to be super perfect.
-   * @param f values of the yield functions
-   * @param stress stress tensor
-   * @param intnl internal parameter
-   * @param Eijkl elasticity tensor (stress = Eijkl*strain)
-   * @param[out] act act[i] = true if the i_th yield function is active
-   * @param[out] returned_stress Approximate value of the returned stress
-   */
   virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress,
                                  Real intnl, const RankFourTensor & Eijkl, std::vector<bool> & act,
-                                 RankTwoTensor & returned_stress) const;
+                                 RankTwoTensor & returned_stress) const override;
 
-  /// Returns the model name (TensileMulti)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
-  /// Returns _use_custom_returnMap
-  virtual bool useCustomReturnMap() const;
+  virtual bool useCustomReturnMap() const override;
 
-  /// Returns _use_custom_cto
-  virtual bool useCustomCTO() const;
+  virtual bool useCustomCTO() const override;
 
-  /**
-    * Performs a custom return-map.
-    * You may choose to over-ride this in your
-    * derived TensorMechanicsPlasticXXXX class,
-    * and you may implement the return-map
-    * algorithm in any way that suits you.  Eg, using
-    * a Newton-Raphson approach, or a radial-return,
-    * etc.
-    * This may also be used as a quick way of ascertaining
-    * whether (trial_stress, intnl_old) is in fact admissible.
-    *
-    * For over-riding this function, please note the
-    * following.
-    *
-    * (1) Denoting the return value of the function by "successful_return",
-    * the only possible output values should be:
-    *   (A) trial_stress_inadmissible=false, successful_return=true.
-    *       That is, (trial_stress, intnl_old) is in fact admissible
-    *       (in the elastic domain).
-    *   (B) trial_stress_inadmissible=true, successful_return=false.
-    *       That is (trial_stress, intnl_old) is inadmissible
-    *       (outside the yield surface), and you didn't return
-    *       to the yield surface.
-    *   (C) trial_stress_inadmissible=true, successful_return=true.
-    *       That is (trial_stress, intnl_old) is inadmissible
-    *       (outside the yield surface), but you did return
-    *       to the yield surface.
-    * The default implementation only handles case (A) and (B):
-    * it does not attempt to do a return-map algorithm.
-    *
-    * (2) you must correctly signal "successful_return" using the
-    * return value of this function.  Don't assume the calling function
-    * will do Kuhn-Tucker checking and so forth!
-    *
-    * (3) In cases (A) and (B) you needn't set returned_stress,
-    * returned_intnl, delta_dp, or dpm.  This is for computational
-    * efficiency.
-    *
-    * (4) In cases (A) and (B), you MUST place the yield function
-    * values at (trial_stress, intnl_old) into yf so the calling
-    * function can use this information optimally.  You will have
-    * already calculated these yield function values, which can be
-    * quite expensive, and it's not very optimal for the calling
-    * function to have to re-calculate them.
-    *
-    * (5) In case (C), you need to set:
-    *   returned_stress (the returned value of stress)
-    *   returned_intnl  (the returned value of the internal variable)
-    *   delta_dp   (the change in plastic strain)
-    *   dpm (the plastic multipliers needed to bring about the return)
-    *   yf (yield function values at the returned configuration)
-    *
-    * (Note, if you over-ride returnMap, you will probably
-    * want to override consistentTangentOpertor too, otherwise
-    * it will default to E_ijkl.)
-    *
-    * @param trial_stress The trial stress
-    * @param intnl_old Value of the internal parameter
-    * @param E_ijkl Elasticity tensor
-    * @param ep_plastic_tolerance Tolerance defined by the user for the plastic strain
-    * @param[out] returned_stress In case (C): lies on the yield surface after returning and produces the correct plastic strain (normality condition).  Otherwise: not defined
-    * @param[out] returned_intnl In case (C): the value of the internal parameter after returning.  Otherwise: not defined
-    * @param[out] dpm  In case (C): the plastic multipliers needed to bring about the return.  Otherwise: not defined
-    * @param[out] delta_dp In case (C): The change in plastic strain induced by the return process.  Otherwise: not defined
-    * @param[out] yf In case (C): the yield function at (returned_stress, returned_intnl).  Otherwise: the yield function at (trial_stress, intnl_old)
-    * @param[out] trial_stress_inadmissible Should be set to false if the trial_stress is admissible, and true if the trial_stress is inadmissible.  This can be used by the calling prorgram
-    * @return true if a successful return (or a return-map not needed), false if the trial_stress is inadmissible but the return process failed
-    */
   virtual bool returnMap(const RankTwoTensor & trial_stress, Real intnl_old, const RankFourTensor & E_ijkl,
                          Real ep_plastic_tolerance, RankTwoTensor & returned_stress, Real & returned_intnl,
                          std::vector<Real> & dpm, RankTwoTensor & delta_dp, std::vector<Real> & yf,
-                         bool & trial_stress_inadmissible) const;
+                         bool & trial_stress_inadmissible) const override;
 
-  /**
-    * Calculates a custom consistent tangent operator.
-    * You may choose to over-ride this in your
-    * derived TensorMechanicsPlasticXXXX class.
-    *
-    * (Note, if you over-ride returnMap, you will probably
-    * want to override consistentTangentOpertor too, otherwise
-    * it will default to E_ijkl.)
-    *
-    * @param stress_old trial stress before returning
-    * @param intnl_old internal parameter before returning
-    * @param stress current returned stress state
-    * @param intnl internal parameter
-    * @param E_ijkl elasticity tensor
-    * @param cumulative_pm the cumulative plastic multipliers
-    * @return the consistent tangent operator: E_ijkl if not over-ridden
-    */
   virtual RankFourTensor consistentTangentOperator(const RankTwoTensor & trial_stress, Real intnl_old, const RankTwoTensor & stress, Real intnl,
-                                                   const RankFourTensor & E_ijkl, const std::vector<Real> & cumulative_pm) const;
+                                                   const RankFourTensor & E_ijkl, const std::vector<Real> & cumulative_pm) const override;
 
  protected:
 

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticWeakPlaneShear.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticWeakPlaneShear.h
@@ -28,8 +28,7 @@ class TensorMechanicsPlasticWeakPlaneShear : public TensorMechanicsPlasticModel
 
   virtual void activeConstraints(const std::vector<Real> & f, const RankTwoTensor & stress, Real intnl, const RankFourTensor & Eijkl, std::vector<bool> & act, RankTwoTensor & returned_stress) const override;
 
-  /// Returns the model name (WeakPlaneShear)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  protected:
   /// Hardening model for cohesion

--- a/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticWeakPlaneTensileN.h
+++ b/modules/tensor_mechanics/include/userobjects/TensorMechanicsPlasticWeakPlaneTensileN.h
@@ -25,8 +25,7 @@ class TensorMechanicsPlasticWeakPlaneTensileN : public TensorMechanicsPlasticWea
  public:
   TensorMechanicsPlasticWeakPlaneTensileN(const InputParameters & parameters);
 
-  /// Returns the model name (WeakPlaneTensileN)
-  virtual std::string modelName() const;
+  virtual std::string modelName() const override;
 
  protected:
   Real yieldFunction(const RankTwoTensor & stress, Real intnl) const override;


### PR DESCRIPTION
This allows removal of lots of repeated doxygen comments and makes the code slightly more readable.

Fixes #7956
