### PR TITLE
Fix memory leak in unit tests

### DIFF
--- a/unit/src/EBSDMeshErrorTest.C
+++ b/unit/src/EBSDMeshErrorTest.C
@@ -36,7 +36,6 @@ void
 EBSDMeshErrorTest::tearDown()
 {
   delete _app;
-  _app = NULL;
 }
 
 
@@ -52,7 +51,7 @@ EBSDMeshErrorTest::fileDoesNotExist()
   params.set<FileName>("filename") = "FILEDOESNOTEXIST";
 
   // construct mesh object
-  EBSDMesh * mesh = new EBSDMesh(params);
+  std::unique_ptr<EBSDMesh> mesh(new EBSDMesh(params));
 
   try
   {
@@ -64,9 +63,6 @@ EBSDMeshErrorTest::fileDoesNotExist()
     std::string msg(e.what());
     CPPUNIT_ASSERT( msg.find("Can't open EBSD file: FILEDOESNOTEXIST") != std::string::npos );
   }
-
-  // delete mesh object
-  delete mesh;
 }
 
 void
@@ -98,7 +94,7 @@ EBSDMeshErrorTest::headerErrorHelper(const char * filename, const char * error)
   params.set<unsigned int>("uniform_refine") = 2;
 
   // construct mesh object
-  EBSDMesh * mesh = new EBSDMesh(params);
+  std::unique_ptr<EBSDMesh> mesh(new EBSDMesh(params));
 
   try
   {
@@ -110,9 +106,6 @@ EBSDMeshErrorTest::headerErrorHelper(const char * filename, const char * error)
     std::string msg(e.what());
     CPPUNIT_ASSERT_MESSAGE( filename, msg.find(error) != std::string::npos );
   }
-
-  // delete mesh object
-  delete mesh;
 }
 
 void
@@ -153,8 +146,7 @@ EBSDMeshErrorTest::testParam(unsigned int nparam, const char ** param_list, std:
     try
     {
       // construct mesh object
-      EBSDMesh * mesh = new EBSDMesh(params);
-      delete mesh;
+      std::unique_ptr<EBSDMesh> mesh(new EBSDMesh(params));
     }
     catch(const std::exception & e)
     {

--- a/unit/src/ExpressionBuilderTest.C
+++ b/unit/src/ExpressionBuilderTest.C
@@ -125,5 +125,8 @@ void ExpressionBuilderTest::test()
     s[1] = new EBTermSubstitution(y, a);
     w.substitute(s);
     CPPUNIT_ASSERT( std::string(w) == "if" "(y<1,y*1,y/1)" );
+
+    delete s[0];
+    delete s[1];
   }
 }

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -54,6 +54,8 @@ void
 IdealGasFluidPropertiesTest::tearDown()
 {
   delete _fe_problem;
+  delete _mesh;
+  delete _app;
 }
 
 void

--- a/unit/src/ParsedFunctionTest.C
+++ b/unit/src/ParsedFunctionTest.C
@@ -36,7 +36,7 @@ ParsedFunctionTest::init()
   InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
   mesh_params.set<MooseEnum>("dim") = "3";
   mesh_params.set<std::string>("_object_name") = "mesh";
-  _mesh = new GeneratedMesh(mesh_params); // deleted by ~FEProblem
+  _mesh = new GeneratedMesh(mesh_params);
 
   InputParameters problem_params = _factory->getValidParams("FEProblem");
   problem_params.set<MooseMesh *>("mesh") = _mesh;
@@ -48,13 +48,8 @@ void
 ParsedFunctionTest::finalize()
 {
   delete _fe_problem;
-  _fe_problem = NULL;
-
-  delete _app;
-  _app = NULL;
-
   delete _mesh;
-  _mesh = NULL;
+  delete _app;
 }
 
 

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -58,6 +58,8 @@ void
 StiffenedGasFluidPropertiesTest::tearDown()
 {
   delete _fe_problem;
+  delete _mesh;
+  delete _app;
 }
 
 void


### PR DESCRIPTION
The mesh is _not_ deleted by `~FEProblem`. Also worked on making one test exception safe by using unique pointers.

Closes #7977 