### PR TITLE
Fix libMesh::COMM_WORLD left over in PETSc < 3.2 code branch.

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -408,7 +408,7 @@ NonlinearSystem::setupFiniteDifferencedPreconditioner()
 #if PETSC_VERSION_LESS_THAN(3,2,0)
   // PETSc 3.2.x
   ierr = MatGetColoring(petsc_mat->mat(), MATCOLORING_LF, &iscoloring);
-  CHKERRABORT(libMesh::COMM_WORLD,ierr);
+  CHKERRABORT(_communicator.get(),ierr);
 #elif PETSC_VERSION_LESS_THAN(3,5,0)
   // PETSc 3.3.x, 3.4.x
   ierr = MatGetColoring(petsc_mat->mat(), MATCOLORINGLF, &iscoloring);

--- a/modules/combined/examples/phase_field-mechanics/tests
+++ b/modules/combined/examples/phase_field-mechanics/tests
@@ -27,15 +27,18 @@
     type = RunApp
     input = 'grain_texture.i'
     cli_args = '--check-input'
+    method = 'OPT'
   [../]
   [./hex_grain_growth_2D_eldrforce]
     type = RunApp
     input = 'hex_grain_growth_2D_eldrforce.i'
     cli_args = '--check-input Executioner/Adaptivity/initial_adaptivity=0'
+    method = 'OPT'
   [../]
   [./poly_grain_growth_2D_eldrforce]
     type = RunApp
     input = 'poly_grain_growth_2D_eldrforce.i'
     cli_args = '--check-input Executioner/Adaptivity/initial_adaptivity=0'
+    method = 'OPT'
   [../]
 []

--- a/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/tests
+++ b/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/tests
@@ -17,5 +17,8 @@
     exodiff = 'sliding_elastic_blocks_2d_fcp_out.e'
     custom_cmp = 'sliding_elastic_blocks_2d.cmp'
     max_parallel = 1
+    # This test has been known to timeout in debug mode, so it's
+    # probably just a bit too expensive to be a regression test.
+    method = 'OPT'
   [../]
 []

--- a/modules/phase_field/examples/grain_growth/tests
+++ b/modules/phase_field/examples/grain_growth/tests
@@ -10,16 +10,19 @@
     type = RunApp
     input = 'grain_growth_2D_random.i'
     cli_args = '--check-input'
+    method = 'OPT'
   [../]
   [./grain_growth_2D_voronoi]
     type = RunApp
     input = 'grain_growth_2D_voronoi.i'
     cli_args = '--check-input Mesh/uniform_refine=0 Executioner/Adaptivity/initial_adaptivity=0'
+    method = 'OPT'
   [../]
   [./grain_growth_2D_voronoi_newadapt]
     type = RunApp
     input = 'grain_growth_2D_voronoi_newadapt.i'
     cli_args = '--check-input Adaptivity/max_h_level=0'
+    method = 'OPT'
   [../]
   [./grain_growth_3D]
     type = RunApp

--- a/modules/solid_mechanics/tests/rate_dep_smear_crack/tests
+++ b/modules/solid_mechanics/tests/rate_dep_smear_crack/tests
@@ -15,5 +15,8 @@
     abs_zero = 1e-08
     scale_refine = 1
     compiler = 'GCC CLANG'
+    # This test has been known to timeout in debug mode, so it's
+    # probably just a bit too expensive to be a regression test.
+    method = 'OPT'
   [../]
 []


### PR DESCRIPTION
Refs #2943.

Reported-by: eleni.gerolymatou@gmail.com