### PR TITLE
Deal with resetQpProperties in StressUpdateBase class

### DIFF
--- a/modules/tensor_mechanics/include/materials/HyperbolicViscoplasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/HyperbolicViscoplasticityStressUpdate.h
@@ -30,14 +30,13 @@ public:
   HyperbolicViscoplasticityStressUpdate(const InputParameters & parameters);
 
 protected:
-  virtual void initQpStatefulProperties();
-  void resetQpProperties();
+  virtual void initQpStatefulProperties() override;
 
-  virtual void computeStressInitialize(Real effectiveTrialStress);
-  virtual Real computeResidual(Real effectiveTrialStress, Real scalar);
-  virtual Real computeDerivative(Real effectiveTrialStress, Real scalar);
-  virtual void iterationFinalize(Real scalar);
-  virtual void computeStressFinalize(const RankTwoTensor & plasticStrainIncrement);
+  virtual void computeStressInitialize(Real effectiveTrialStress) override;
+  virtual Real computeResidual(Real effectiveTrialStress, Real scalar) override;
+  virtual Real computeDerivative(Real effectiveTrialStress, Real scalar) override;
+  virtual void iterationFinalize(Real scalar) override;
+  virtual void computeStressFinalize(const RankTwoTensor & plasticStrainIncrement) override;
 
   ///@{ Linear strain hardening parameters
   const Real _yield_stress;

--- a/modules/tensor_mechanics/include/materials/IsotropicPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/IsotropicPlasticityStressUpdate.h
@@ -33,14 +33,13 @@ public:
   IsotropicPlasticityStressUpdate(const InputParameters & parameters);
 
 protected:
-  virtual void initQpStatefulProperties();
-  void resetQpProperties();
+  virtual void initQpStatefulProperties() override;
 
-  virtual void computeStressInitialize(Real effectiveTrialStress);
-  virtual Real computeResidual(Real effectiveTrialStress, Real scalar);
-  virtual Real computeDerivative(Real effectiveTrialStress, Real scalar);
-  virtual void iterationFinalize(Real scalar);
-  virtual void computeStressFinalize(const RankTwoTensor & plasticStrainIncrement);
+  virtual void computeStressInitialize(Real effectiveTrialStress) override;
+  virtual Real computeResidual(Real effectiveTrialStress, Real scalar) override;
+  virtual Real computeDerivative(Real effectiveTrialStress, Real scalar) override;
+  virtual void iterationFinalize(Real scalar) override;
+  virtual void computeStressFinalize(const RankTwoTensor & plasticStrainIncrement) override;
 
   virtual void computeYieldStress();
   virtual Real computeHardeningValue(Real scalar);

--- a/modules/tensor_mechanics/include/materials/IsotropicPowerLawHardeningStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/IsotropicPowerLawHardeningStressUpdate.h
@@ -33,9 +33,9 @@ public:
   IsotropicPowerLawHardeningStressUpdate(const InputParameters & parameters);
 
 protected:
-  virtual void computeStressInitialize(Real effectiveTrialStress);
-  virtual void computeYieldStress();
-  virtual Real computeHardeningDerivative(Real scalar);
+  virtual void computeStressInitialize(Real effectiveTrialStress) override;
+  virtual void computeYieldStress() override;
+  virtual Real computeHardeningDerivative(Real scalar) override;
 
   ///@{ Power law hardening coefficients
   Real _K;

--- a/modules/tensor_mechanics/include/materials/PowerLawCreepStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/PowerLawCreepStressUpdate.h
@@ -28,14 +28,13 @@ public:
   PowerLawCreepStressUpdate(const InputParameters & parameters);
 
 protected:
-  virtual void initQpStatefulProperties();
-  void resetQpProperties();
+  virtual void initQpStatefulProperties() override;
 
-  virtual void computeStressInitialize(Real effectiveTrialStress);
-  virtual void computeStressFinalize(const RankTwoTensor & plasticStrainIncrement);
+  virtual void computeStressInitialize(Real effectiveTrialStress) override;
+  virtual void computeStressFinalize(const RankTwoTensor & plasticStrainIncrement) override;
 
-  virtual Real computeResidual(Real effectiveTrialStress, Real scalar);
-  virtual Real computeDerivative(Real effectiveTrialStress, Real scalar);
+  virtual Real computeResidual(Real effectiveTrialStress, Real scalar) override;
+  virtual Real computeDerivative(Real effectiveTrialStress, Real scalar) override;
 
   const Real _coefficient;
   const Real _n_exponent;

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -37,7 +37,7 @@ public:
   /// the computeInelasticStrainIncrement method.
   virtual void updateStress(RankTwoTensor & strain_increment,
                             RankTwoTensor & inelastic_strain_increment,
-                            RankTwoTensor & stress_new);
+                            RankTwoTensor & stress_new) override;
 
 protected:
   virtual void computeStressInitialize(Real /*effectiveTrialStress*/){}

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -36,9 +36,15 @@ public:
   /// overwrite this method.
   virtual void updateStress(RankTwoTensor & strain_increment,
                             RankTwoTensor & inelastic_strain_increment,
-                            RankTwoTensor & stress_new);
+                            RankTwoTensor & stress_new) = 0;
 
+  /// Sets the value of the global variable _qp for inheriting classes
   void setQp(unsigned int qp);
+
+  ///@{ Retained as empty methods to avoid a warning from Material.C in framework. These methods are unused in all inheriting classes and should not be overwritten.
+  void resetQpProperties();
+  void resetProperties();
+  ///@}
 
 protected:
   const std::string _base_name;

--- a/modules/tensor_mechanics/include/materials/TemperatureDependentHardeningStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/TemperatureDependentHardeningStressUpdate.h
@@ -24,11 +24,11 @@ public:
   TemperatureDependentHardeningStressUpdate(const InputParameters & parameters);
 
 protected:
-  virtual void computeStressInitialize(Real effectiveTrialStress);
+  virtual void computeStressInitialize(Real effectiveTrialStress) override;
 
-  virtual void computeYieldStress();
-  virtual Real computeHardeningValue(Real scalar);
-  virtual Real computeHardeningDerivative(Real scalar);
+  virtual void computeYieldStress() override;
+  virtual Real computeHardeningValue(Real scalar) override;
+  virtual Real computeHardeningDerivative(Real scalar) override;
 
   void initializeHardeningFunctions();
 

--- a/modules/tensor_mechanics/src/materials/HyperbolicViscoplasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/HyperbolicViscoplasticityStressUpdate.C
@@ -51,12 +51,6 @@ HyperbolicViscoplasticityStressUpdate::initQpStatefulProperties()
 }
 
 void
-HyperbolicViscoplasticityStressUpdate::resetQpProperties()
-{
-  _plastic_strain[_qp] = _plastic_strain_old[_qp];
-}
-
-void
 HyperbolicViscoplasticityStressUpdate::computeStressInitialize(Real effectiveTrialStress)
 {
   _shear_modulus = getIsotropicShearModulus();

--- a/modules/tensor_mechanics/src/materials/IsotropicPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/IsotropicPlasticityStressUpdate.C
@@ -71,12 +71,6 @@ IsotropicPlasticityStressUpdate::initQpStatefulProperties()
 }
 
 void
-IsotropicPlasticityStressUpdate::resetQpProperties()
-{
-  _scalar_plastic_strain[_qp] = 0.;
-}
-
-void
 IsotropicPlasticityStressUpdate::computeStressInitialize(Real effectiveTrialStress)
 {
   _shear_modulus = getIsotropicShearModulus();

--- a/modules/tensor_mechanics/src/materials/PowerLawCreepStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/PowerLawCreepStressUpdate.C
@@ -51,12 +51,6 @@ PowerLawCreepStressUpdate::initQpStatefulProperties()
 }
 
 void
-PowerLawCreepStressUpdate::resetQpProperties()
-{
-  _creep_strain[_qp] = _creep_strain_old[_qp];
-}
-
-void
 PowerLawCreepStressUpdate::computeStressInitialize(Real /*effectiveTrialStress*/)
 {
   _shear_modulus = getIsotropicShearModulus();

--- a/modules/tensor_mechanics/src/materials/StressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/StressUpdateBase.C
@@ -40,3 +40,13 @@ StressUpdateBase::setQp(unsigned int qp)
 {
   _qp = qp;
 }
+
+void
+StressUpdateBase::resetQpProperties()
+{
+}
+
+void
+StressUpdateBase::resetProperties()
+{
+}


### PR DESCRIPTION
### Design Changes
To simplify writing recompute material classes, e.g. creep and plasticity, which inherit from `StressUpdateBase`, the method `resetQpProperties` is included as an empty method in the base class.  The empty method is necessary to avoid a MooseWarning from `Material.C`.  Additionally `override` is added to the inheriting classes in tensor mechanics.

### Test Cases
No tests cases were modified nor any results files regolded.

Refs #5841, pinging @bwspenc, @aeslaughter 