### PR TITLE
Restrict the mu_0_2_kin test to only run on GCC and CLANG.

### DIFF
--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
@@ -57,6 +57,7 @@
     abs_zero = 2e-6
     max_parallel = 1
     superlu = true
+    compiler = 'GCC CLANG'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'


### PR DESCRIPTION
After recently updating GCC on the build boxes, this test started
failing reliably.  It needs further work to make sure it can pass on
Intel.

Refs #000.