### PR TITLE
Do not print errors from all ranks

### DIFF
--- a/modules/misc/tests/dynamic_loading/dynamic_obj_registration/tests
+++ b/modules/misc/tests/dynamic_loading/dynamic_obj_registration/tests
@@ -62,7 +62,6 @@
     cli_args = 'Problem/register_objects_from=FooApp'
     library_mode = 'DYNAMIC'
     prereq = 'dynamic_object_loading_wrong_app'
-    max_parallel = 1 # Looking for stdout
 
     # Test must be run with the misc app to test dynamic loading
     executable_pattern = 'misc-\w+$'

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -27,6 +27,7 @@ class RunApp(Tester):
     params.addParam('max_threads',    16, "Max number of threads (Default: 16)")
     params.addParam('min_threads',     1, "Min number of threads (Default: 1)")
     params.addParam('allow_warnings',   False, "If the test harness is run --error warnings become errors, setting this to true will disable this an run the test without --error");
+    params.addParam('keep_cerr',        True,  "keep stderr on all ranks")
 
     params.addParamWithType('allow_deprecated_until', type(time.localtime()), "A test that only runs if current date is less than specified date")
 
@@ -134,6 +135,10 @@ class RunApp(Tester):
       default_ncpus = 1
     else:
       default_ncpus = options.parallel
+
+    # This is overridden as False in RunException.py
+    if not specs['keep_cerr']:
+      specs['cli_args'].append('--drop-cerr')
 
     caveats = []
     if nthreads > options.nthreads:

--- a/python/TestHarness/testers/RunException.py
+++ b/python/TestHarness/testers/RunException.py
@@ -10,8 +10,8 @@ class RunException(RunApp):
     params.addParam('expect_assert', "DEBUG MODE ONLY: A regular expression that must occur in the ouput. (Test may terminiate unexpectedly and be considered passing)")
     params.addParam('should_crash', True, "Inidicates that the test is expected to crash or otherwise terminate early")
 
-    # Printing errors in parallel often intertwine when multiple processors receive the same error.  We will set max_parallel = 1 by default, but it can be overridden
-    params['max_parallel'] = 1
+    # RunException tests executed in parallel will suppress multiple writes to stderr. Can be overridden: keep_cerr = true
+    params['keep_cerr'] = False
 
     return params
 

--- a/test/tests/actions/aux_scalar_variable/tests
+++ b/test/tests/actions/aux_scalar_variable/tests
@@ -2,14 +2,13 @@
   [./invalid_order_high]
     type = 'RunException'
     input = 'aux_scalar_variable.i'
-		cli_args = 'AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/order=TENTH'
+    cli_args = 'AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/order=TENTH'
     expect_err = "Non-scalar AuxVariables must be CONSTANT, FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH, SEVENTH, EIGHTH or NINTH order \(10 supplied\)"
-    max_parallel = 1
   [../]
-	[./high_order_scalar]
+  [./high_order_scalar]
     type = RunApp
-		input = 'aux_scalar_variable.i'
-		cli_args = 'AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/order=TWENTYFIRST AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/family=SCALAR'
-		expect_out = 'a_very_unique_auxiliary_variable_name_good_for_error_checking.*SCALAR.*TWENTYFIRST'
+    input = 'aux_scalar_variable.i'
+    cli_args = 'AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/order=TWENTYFIRST AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/family=SCALAR'
+    expect_out = 'a_very_unique_auxiliary_variable_name_good_for_error_checking.*SCALAR.*TWENTYFIRST'
   [../]
 []

--- a/test/tests/actions/setup_postprocessor_data/tests
+++ b/test/tests/actions/setup_postprocessor_data/tests
@@ -8,6 +8,6 @@
     type = 'RunException'
     input = 'setup_postprocessor_data.i'
     expect_err = 'TestSetupPostprocessorDataActionFunction fail'
-	 cli_args = 'Functions/tester/postprocessor=unknown'
+    cli_args = 'Functions/tester/postprocessor=unknown'
   [../]
 []

--- a/test/tests/functions/linear_combination_function/tests
+++ b/test/tests/functions/linear_combination_function/tests
@@ -3,7 +3,6 @@
     type = 'RunException'
     input = 'except1.i'
     expect_err = "LinearCombinationFunction: The number of functions must equal the number of w values"
-    max_parallel = 1
   [../]
   [./lcf1]
     type = 'CSVDiff'

--- a/test/tests/restrictable/check_error/tests
+++ b/test/tests/restrictable/check_error/tests
@@ -2,13 +2,13 @@
   [./fe_problem_null]
     type = 'RunException'
     input = 'check_error.i'
-	  cli_args = "Kernels/diff/test=fe_problem_null"
+    cli_args = "Kernels/diff/test=fe_problem_null"
     expect_err = "The input parameters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'"
   [../]
 
-	[./mesh_null]
+  [./mesh_null]
     type = 'RunException'
     input = 'check_error.i'
-		cli_args = "Kernels/diff/test=mesh_null"
+    cli_args = "Kernels/diff/test=mesh_null"
     expect_err = "The input parameters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'"
   [../]

--- a/test/tests/restrictable/current_boundary_id/tests
+++ b/test/tests/restrictable/current_boundary_id/tests
@@ -3,13 +3,11 @@
     type = 'RunException'
     input = 'current_boundary_id.i'
     expect_err = "Valid boundary id test passed"
-    max_threads = 1 # expect error
   [../]
   [./current_boundary_id_invalid]
     type = 'RunException'
     input = 'current_boundary_id.i'
     cli_args = 'UserObjects/test/test_invalid=true'
     expect_err = "Invalid boundary id test passed"
-    max_threads = 1 # expect error
   [../]
 []

--- a/test/tests/transfers/multiapp_postprocessor_to_scalar/tests
+++ b/test/tests/transfers/multiapp_postprocessor_to_scalar/tests
@@ -17,12 +17,10 @@
     type = 'RunException'
     input = 'master2_wrong_order.i'
     expect_err = "The number of sub apps \(3\) must be equal to the order of the scalar AuxVariable \(4\)"
-    max_parallel = 1
   [../]
   [./sub_to_master_wrong_positions]
     type = 'RunException'
     input = 'master2_wrong_positions.i'
     expect_err = "The number of sub apps \(1\) must be equal to the order of the scalar AuxVariable \(3\)"
-    max_parallel = 1
   [../]
 []


### PR DESCRIPTION
Allow TestHarness not to print errors from all ranks when performing parallel tests by default.
The PR to remove all max_parallel lines from our tests, will come later and close this ticket.

Refs #4668