### PR TITLE
Mark resetProperties and resetQpProperties as final 

### DIFF
--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -42,8 +42,8 @@ public:
   void setQp(unsigned int qp);
 
   ///@{ Retained as empty methods to avoid a warning from Material.C in framework. These methods are unused in all inheriting classes and should not be overwritten.
-  void resetQpProperties();
-  void resetProperties();
+  void resetQpProperties() final {}
+  void resetProperties() final {}
   ///@}
 
 protected:

--- a/modules/tensor_mechanics/src/materials/StressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/StressUpdateBase.C
@@ -40,13 +40,3 @@ StressUpdateBase::setQp(unsigned int qp)
 {
   _qp = qp;
 }
-
-void
-StressUpdateBase::resetQpProperties()
-{
-}
-
-void
-StressUpdateBase::resetProperties()
-{
-}


### PR DESCRIPTION
### Design information

Follow on to PR #8030 to mark the `resetProperties` and `resetQpProperties` functions as `final` to prevent inheriting classes from overwriting these functions now that MAMMOTH has been updated.

@aeslaughter  or @bwspenc  please review

Refs #5481