### PR TITLE
Add --redirect-stdout for select tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ temp_print_trace.*
 *Revision.h
 *.json
 *.bak
+*.processor.*
 .clang_complete
 
 # Allow certain files in gold directories

--- a/modules/misc/tests/dynamic_loading/dynamic_obj_registration/tests
+++ b/modules/misc/tests/dynamic_loading/dynamic_obj_registration/tests
@@ -62,7 +62,6 @@
     cli_args = 'Problem/register_objects_from=FooApp'
     library_mode = 'DYNAMIC'
     prereq = 'dynamic_object_loading_wrong_app'
-    max_parallel = 1 # Looking for stdout
 
     # Test must be run with the misc app to test dynamic loading
     executable_pattern = 'misc-\w+$'

--- a/python/TestHarness/testers/CSVDiff.py
+++ b/python/TestHarness/testers/CSVDiff.py
@@ -11,14 +11,13 @@ class CSVDiff(RunApp):
     params.addParam('gold_dir',      'gold', "The directory where the \"golden standard\" files reside relative to the TEST_DIR: (default: ./gold/)")
     params.addParam('abs_zero',       1e-10, "Absolute zero cutoff used in exodiff comparisons.")
     params.addParam('rel_err',       5.5e-6, "Relative error value used in exodiff comparisons.")
-    params.addParam('delete_output_before_running',  True, "Delete pre-existing output files before running test. Only set to False if you know what you're doing!")
 
     return params
 
   def __init__(self, name, params):
     RunApp.__init__(self, name, params)
 
-  def prepare(self):
+  def prepare(self, options):
     if self.specs['delete_output_before_running'] == True:
       self.deleteFilesAndFolders(self.specs['test_dir'], self.specs['csvdiff'])
 

--- a/python/TestHarness/testers/CheckFiles.py
+++ b/python/TestHarness/testers/CheckFiles.py
@@ -9,15 +9,13 @@ class CheckFiles(RunApp):
     params = RunApp.validParams()
     params.addParam('check_files', [], "A list of files that MUST exist.")
     params.addParam('check_not_exists', [], "A list of files that must NOT exist.")
-    params.addParam('delete_output_before_running',  True, "Delete pre-existing output files before running test. Only set to False if you know what you're doing!")
-    params.addParam('delete_output_folders', True, "Delete output folders before running")
     params.addParam('file_expect_out', "A regular expression that must occur in all of the check files in order for the test to be considered passing.")
     return params
 
   def __init__(self, name, params):
     RunApp.__init__(self, name, params)
 
-  def prepare(self):
+  def prepare(self, options):
     if self.specs['delete_output_before_running'] == True:
       self.deleteFilesAndFolders(self.specs['test_dir'], self.specs['check_files'] + self.specs['check_not_exists'], self.specs['delete_output_folders'])
 

--- a/python/TestHarness/testers/Exodiff.py
+++ b/python/TestHarness/testers/Exodiff.py
@@ -14,8 +14,6 @@ class Exodiff(RunApp):
     params.addParam('rel_err',       5.5e-6, "Relative error value used in exodiff comparisons.")
     params.addParam('custom_cmp',            "Custom comparison file")
     params.addParam('use_old_floor',  False, "Use Exodiff old floor option")
-    params.addParam('delete_output_before_running',  True, "Delete pre-existing output files before running test. Only set to False if you know what you're doing!")
-    params.addParam('delete_output_folders', True, "Delete output folders before running")
     params.addParam('map',  True, "Use geometrical mapping to match up elements.  This is usually a good idea because it makes files comparable between runs with Serial and Parallel Mesh.")
 
     return params
@@ -24,7 +22,7 @@ class Exodiff(RunApp):
     RunApp.__init__(self, name, params)
 
 
-  def prepare(self):
+  def prepare(self, options):
     if self.specs['delete_output_before_running'] == True:
       self.deleteFilesAndFolders(self.specs['test_dir'], self.specs['exodiff'], self.specs['delete_output_folders'])
 

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -16,6 +16,8 @@ class RunApp(Tester):
     params.addParam('absent_out',         "A regular expression that must be *absent* from the output for the test to pass.")
     params.addParam('should_crash', False, "Inidicates that the test is expected to crash or otherwise terminate early")
     params.addParam('executable_pattern', "A test that only runs if the exectuable name matches the given pattern")
+    params.addParam('delete_output_before_running',  True, "Delete pre-existing output files before running test. Only set to False if you know what you're doing!")
+    params.addParam('delete_output_folders', True, "Delete output folders before running")
 
     params.addParam('walltime',           "The max time as pbs understands it")
     params.addParam('job_name',           "The test name as pbs understands it")
@@ -27,6 +29,7 @@ class RunApp(Tester):
     params.addParam('max_threads',    16, "Max number of threads (Default: 16)")
     params.addParam('min_threads',     1, "Min number of threads (Default: 1)")
     params.addParam('allow_warnings',   False, "If the test harness is run --error warnings become errors, setting this to true will disable this an run the test without --error");
+    params.addParam('redirect_output',  False, "Redirect stdout to files. Neccessary when expecting an error when using parallel options")
 
     params.addParamWithType('allow_deprecated_until', type(time.localtime()), "A test that only runs if current date is less than specified date")
 
@@ -134,6 +137,9 @@ class RunApp(Tester):
       default_ncpus = 1
     else:
       default_ncpus = options.parallel
+
+    if specs['redirect_output'] and ncpus > 1:
+      specs['cli_args'].append('--redirect-output ' + self.name())
 
     caveats = []
     if nthreads > options.nthreads:

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -94,7 +94,7 @@ class Tester(MooseObject):
 
   # This method is called prior to running the test.  It can be used to cleanup files
   # or do other preparations before the tester is run
-  def prepare(self):
+  def prepare(self, options):
     return
 
   def getThreads(self, options):

--- a/python/TestHarness/testers/VTKDiff.py
+++ b/python/TestHarness/testers/VTKDiff.py
@@ -12,7 +12,6 @@ class VTKDiff(RunApp):
     params.addParam('gold_dir',      'gold', "The directory where the \"golden standard\" files reside relative to the TEST_DIR: (default: ./gold/)")
     params.addParam('abs_zero',       1e-10, "Absolute zero cutoff used in exodiff comparisons.")
     params.addParam('rel_err',       5.5e-6, "Relative error value used in exodiff comparisons.")
-    params.addParam('delete_output_before_running',  True, "Delete pre-existing output files before running test. Only set to False if you know what you're doing!")
     params.addParam('ignored_attributes',  [], "Ignore e.g. type and/or version in sample XML block <VTKFile type=\"Foo\" version=\"0.1\">")
 
     return params
@@ -20,7 +19,7 @@ class VTKDiff(RunApp):
   def __init__(self, name, params):
     RunApp.__init__(self, name, params)
 
-  def prepare(self):
+  def prepare(self, options):
     if self.specs['delete_output_before_running'] == True:
       self.deleteFilesAndFolders(self.specs['test_dir'], self.specs['vtkdiff'])
 

--- a/test/tests/actions/aux_scalar_variable/tests
+++ b/test/tests/actions/aux_scalar_variable/tests
@@ -2,14 +2,13 @@
   [./invalid_order_high]
     type = 'RunException'
     input = 'aux_scalar_variable.i'
-		cli_args = 'AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/order=TENTH'
+    cli_args = 'AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/order=TENTH'
     expect_err = "Non-scalar AuxVariables must be CONSTANT, FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH, SEVENTH, EIGHTH or NINTH order \(10 supplied\)"
-    max_parallel = 1
   [../]
-	[./high_order_scalar]
+  [./high_order_scalar]
     type = RunApp
-		input = 'aux_scalar_variable.i'
-		cli_args = 'AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/order=TWENTYFIRST AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/family=SCALAR'
-		expect_out = 'a_very_unique_auxiliary_variable_name_good_for_error_checking.*SCALAR.*TWENTYFIRST'
+    input = 'aux_scalar_variable.i'
+    cli_args = 'AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/order=TWENTYFIRST AuxVariables/a_very_unique_auxiliary_variable_name_good_for_error_checking/family=SCALAR'
+    expect_out = 'a_very_unique_auxiliary_variable_name_good_for_error_checking.*SCALAR.*TWENTYFIRST'
   [../]
 []

--- a/test/tests/actions/setup_postprocessor_data/tests
+++ b/test/tests/actions/setup_postprocessor_data/tests
@@ -8,6 +8,6 @@
     type = 'RunException'
     input = 'setup_postprocessor_data.i'
     expect_err = 'TestSetupPostprocessorDataActionFunction fail'
-	 cli_args = 'Functions/tester/postprocessor=unknown'
+    cli_args = 'Functions/tester/postprocessor=unknown'
   [../]
 []

--- a/test/tests/functions/linear_combination_function/tests
+++ b/test/tests/functions/linear_combination_function/tests
@@ -3,7 +3,6 @@
     type = 'RunException'
     input = 'except1.i'
     expect_err = "LinearCombinationFunction: The number of functions must equal the number of w values"
-    max_parallel = 1
   [../]
   [./lcf1]
     type = 'CSVDiff'

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -349,6 +349,7 @@
     type = 'RunException'
     input = 'multi_precond_test.i'
     expect_err = "More than one active Preconditioner detected"
+    max_parallel = 1
   [../]
 
   [./nan_test]

--- a/test/tests/restart/kernel_restartable/tests
+++ b/test/tests/restart/kernel_restartable/tests
@@ -68,5 +68,6 @@
     cli_args = 'Problem/restart_file_base=kernel_restartable_out_threads_cp/0005'
     expect_err = 'Cannot restart using a different number of threads'
     group = 'requirements'
+    max_parallel = 1
   [../]
 []

--- a/test/tests/restrictable/check_error/tests
+++ b/test/tests/restrictable/check_error/tests
@@ -2,13 +2,13 @@
   [./fe_problem_null]
     type = 'RunException'
     input = 'check_error.i'
-	  cli_args = "Kernels/diff/test=fe_problem_null"
+    cli_args = "Kernels/diff/test=fe_problem_null"
     expect_err = "The input parameters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'"
   [../]
 
-	[./mesh_null]
+  [./mesh_null]
     type = 'RunException'
     input = 'check_error.i'
-		cli_args = "Kernels/diff/test=mesh_null"
+    cli_args = "Kernels/diff/test=mesh_null"
     expect_err = "The input parameters must contain a pointer to FEProblem via '_fe_problem' or a pointer to the MooseMesh via '_mesh'"
   [../]

--- a/test/tests/restrictable/current_boundary_id/tests
+++ b/test/tests/restrictable/current_boundary_id/tests
@@ -3,13 +3,11 @@
     type = 'RunException'
     input = 'current_boundary_id.i'
     expect_err = "Valid boundary id test passed"
-    max_threads = 1 # expect error
   [../]
   [./current_boundary_id_invalid]
     type = 'RunException'
     input = 'current_boundary_id.i'
     cli_args = 'UserObjects/test/test_invalid=true'
     expect_err = "Invalid boundary id test passed"
-    max_threads = 1 # expect error
   [../]
 []

--- a/test/tests/transfers/multiapp_postprocessor_to_scalar/tests
+++ b/test/tests/transfers/multiapp_postprocessor_to_scalar/tests
@@ -17,12 +17,10 @@
     type = 'RunException'
     input = 'master2_wrong_order.i'
     expect_err = "The number of sub apps \(3\) must be equal to the order of the scalar AuxVariable \(4\)"
-    max_parallel = 1
   [../]
   [./sub_to_master_wrong_positions]
     type = 'RunException'
     input = 'master2_wrong_positions.i'
     expect_err = "The number of sub apps \(1\) must be equal to the order of the scalar AuxVariable \(3\)"
-    max_parallel = 1
   [../]
 []


### PR DESCRIPTION
Allow parallel test's stdout to be redirected and processed in files.
Refs #4668