### PR TITLE
Insufficient Slots when using -host localhost

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -41,7 +41,7 @@ class RunApp(Tester):
       self.mpi_command = os.environ['MOOSE_MPI_COMMAND']
       self.force_mpi = True
     else:
-      self.mpi_command = 'mpiexec -host localhost'
+      self.mpi_command = 'mpiexec'
       self.force_mpi = False
 
     # Handle the special allow_deprecated_until parameter


### PR DESCRIPTION
remove -host localhost from mpiexec command.

Closes #8091