### PR TITLE
Update to petsc-3.7.x

### DIFF
--- a/update_petsc.txt
+++ b/update_petsc.txt
@@ -1,0 +1,1 @@
+petsc-3.7.x has been released for a couple of months. It is time to make petsc-3.7.x as the default solver.


### PR DESCRIPTION
petsc-3.7.x has been released for a couple of months. It is time to make petsc-3.7.x as the default solver.

This PR is dummy at this step. I am testing which apps and examples will fail with petsc-3.7.x.  

And I am going to fix in the next step.