### PR TITLE
Start fixing up DistributedMesh testing

### DIFF
--- a/framework/include/mesh/GeneratedMesh.h
+++ b/framework/include/mesh/GeneratedMesh.h
@@ -35,8 +35,9 @@ public:
   GeneratedMesh & operator=(const GeneratedMesh & other_mesh) = delete;
 
   virtual MooseMesh & clone() const override;
-
   virtual void buildMesh() override;
+  virtual Real getMinInDimension(unsigned int component) const override;
+  virtual Real getMaxInDimension(unsigned int component) const override;
 
 protected:
   /// The dimension of the mesh

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -73,6 +73,39 @@ GeneratedMesh::GeneratedMesh(const InputParameters & parameters) :
 {
   if (_gauss_lobatto_grid && (_bias_x != 1.0 || _bias_y != 1.0 || _bias_z != 1.0))
     mooseError("Cannot apply both Gauss-Lobatto mesh grading and biasing at the same time.");
+
+  // All generated meshes are regular orthogonal meshes
+  _regular_orthogonal_mesh = true;
+}
+
+Real GeneratedMesh::getMinInDimension(unsigned int component) const
+{
+  switch (component)
+  {
+  case 0:
+    return _xmin;
+  case 1:
+    return _dim > 1 ? _ymin : 0;
+  case 2:
+    return _dim > 2 ? _zmin : 0;
+  default:
+    mooseError("Invalid component");
+  }
+}
+
+Real GeneratedMesh::getMaxInDimension(unsigned int component) const
+{
+  switch (component)
+  {
+  case 0:
+    return _xmax;
+  case 1:
+    return _dim > 1 ? _ymax : 0;
+  case 2:
+    return _dim > 2 ? _zmax : 0;
+  default:
+    mooseError("Invalid component");
+  }
 }
 
 MooseMesh &

--- a/modules/phase_field/examples/rigidbodymotion/tests
+++ b/modules/phase_field/examples/rigidbodymotion/tests
@@ -3,27 +3,27 @@
     type = RunApp
     input = 'AC_CH_Multigrain.i'
     cli_args = '--check-input Mesh/uniform_refine=0 Executioner/Adaptivity/initial_adaptivity=0'
+
     # This example uses ShapeElementUserObject which contains a
-    # mooseWarning() that is treated as an error in dbg mode.
-    # Therefore only check this test in opt mode.
-    method = 'OPT'
+    # mooseWarning()
+    executable_pattern = 'phase_field-\w+$'
   [../]
   [./AC_CH_advection_constforce_rect]
     type = RunApp
     input = 'AC_CH_advection_constforce_rect.i'
     cli_args = '--check-input'
+
     # This example uses NonlocalKernel which contains a
-    # mooseWarning() that is treated as an error in dbg mode.
-    # Therefore only check this test in opt mode.
-    method = 'OPT'
+    # mooseWarning()
+    executable_pattern = 'phase_field-\w+$'
   [../]
   [./grain_forcedensity_ext]
     type = RunApp
     input = 'grain_forcedensity_ext.i'
     cli_args = '--check-input'
+
     # This example uses ShapeElementUserObject which contains a
-    # mooseWarning() that is treated as an error in dbg mode.
-    # Therefore only check this test in opt mode.
-    method = 'OPT'
+    # mooseWarning()
+    executable_pattern = 'phase_field-\w+$'
   [../]
 []


### PR DESCRIPTION
The start of getting DistributedMesh to work. This fixes several tests that use GeneratedMesh and the bounds functions in that class. 

There's a second unrelated commit that just needs to go in. Someone improperly restricted tests on their system but that's not the issue here at all!