### PR TITLE
make valgrind options case-insensitive

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -151,7 +151,7 @@ class RunApp(Tester):
 
     if self.force_mpi or options.parallel or ncpus > 1 or nthreads > 1:
       command = self.mpi_command + ' -n ' + str(ncpus) + ' ' + specs['executable'] + ' --n-threads=' + str(nthreads) + ' ' + specs['input_switch'] + ' ' + specs['input'] + ' ' +  ' '.join(specs['cli_args'])
-    elif options.valgrind_mode == specs['valgrind'] or options.valgrind_mode == 'HEAVY' and specs['valgrind'] == 'NORMAL':
+    elif options.valgrind_mode.upper() == specs['valgrind'].upper() or options.valgrind_mode.upper() == 'HEAVY' and specs['valgrind'].upper() == 'NORMAL':
       command = 'valgrind --suppressions=' + os.path.join(specs['moose_dir'], 'python', 'TestHarness', 'suppressions', 'errors.supp') + ' --leak-check=full --tool=memcheck --dsymutil=yes --track-origins=yes --demangle=yes -v ' + specs['executable'] + ' ' + specs['input_switch'] + ' ' + specs['input'] + ' ' + ' '.join(specs['cli_args'])
     else:
       command = specs['executable'] + timing_string + specs['input_switch'] + ' ' + specs['input'] + ' ' + ' '.join(specs['cli_args'])

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -167,9 +167,9 @@ class Tester(MooseObject):
       return (False, reason)
     # If we're testing with valgrind, then skip tests that require parallel or threads or don't meet the valgrind setting
     elif options.valgrind_mode != '':
-      if self.specs['valgrind'] == 'NONE':
+      if self.specs['valgrind'].upper() == 'NONE':
         reason = 'skipped (Valgrind==NONE)'
-      elif self.specs['valgrind'] == 'HEAVY' and options.valgrind_mode == 'NORMAL':
+      elif self.specs['valgrind'].upper() == 'HEAVY' and options.valgrind_mode.upper() == 'NORMAL':
         reason = 'skipped (Valgrind==HEAVY)'
       elif self.specs['min_parallel'] > 1 or self.specs['min_threads'] > 1:
         reason = 'skipped (Valgrind requires serial)'


### PR DESCRIPTION
Covert valgrind options to uppercase when being evaluated.
Refs #6573