### PR TITLE
Update libMesh.

### DIFF
--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -27,10 +27,7 @@
 
 // Some VTK header files have extra semi-colons in them, and clang
 // loves to warn about it...
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wextra-semi"
-#endif
+#include "libmesh/ignore_warnings.h"
 
 #include "vtkSmartPointer.h"
 #include "vtkPNGReader.h"
@@ -44,9 +41,7 @@
 #include "vtkImageMagnitude.h"
 #include "vtkImageFlip.h"
 
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include "libmesh/restore_warnings.h"
 
 #endif
 

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -154,7 +154,7 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
     if (_parallel_mesh)
     {
       std::ostringstream oss;
-      oss << delete_files.checkpoint << '-' << proc_id;
+      oss << delete_files.checkpoint << '-' << n_processors() << '-' << proc_id;
       ret = remove(oss.str().c_str());
       if (ret != 0)
         mooseWarning("Error during the deletion of file '" << oss.str().c_str() << "': " << ret);

--- a/framework/src/utils/SplineInterpolationBase.C
+++ b/framework/src/utils/SplineInterpolationBase.C
@@ -114,7 +114,7 @@ SplineInterpolationBase::sampleDerivative(const std::vector<Real> & x, const std
 }
 
 Real
-SplineInterpolationBase::sample2ndDerivative(const std::vector<Real> & x, const std::vector<Real> & y, const std::vector<Real> & y2, Real x_int) const
+SplineInterpolationBase::sample2ndDerivative(const std::vector<Real> & x, const std::vector<Real> & /*y*/, const std::vector<Real> & y2, Real x_int) const
 {
   unsigned int klo, khi;
   findInterval(x, x_int, klo, khi);


### PR DESCRIPTION
Brief summary of changes included in this update:
* Rename serial/parallel_mesh.h -> replicated/distributed_mesh.h
* MeshBase option to stop delete_remote_elements()
* Support 1D runs in adaptivity_ex4.
* Add --redirect-output command line option.
* Fix bug where libmesh always had two copies of command line arguments.
* Fix GetPot off-by-1 bug.
* Prefix libMesh Parallel:: macros with LIBMESH_
* Print the physical point when inverse_map() fails.
* Add CheckpointIO based "splitter" app and unit test.
* Some bug fixes for adaptivity on infinite elements.
* Use non-deprecated os_unfair_lock on macOS Sierra.
* Fix unique_id setting in all_tri().
* Use UniquePtr in several classes where manual memory management was being done.
* Add PointNeighborCoupling class and unit test.
* Restrict MatSetTransposeNullSpace use to PETSc >= 3.6.
* SLEPc: restrict use of EPS_TARGET_XXX to SLEPc >= 3.1.
* SLEPc: add 'target' spectrum positions.
* Fixes for VTK-7.1 compatibility.
* Fix bug where MOOSE wouldn't build when Trilinos with no Epetra is present.
* Add SLEPC_VERSION_{MAJOR,MINOR,SUBMINOR} defines in libmesh_config.h.

Refs #000.