### PR TITLE
add a master rand generator to each app/problem

### DIFF
--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -1299,7 +1299,12 @@ private:
 
 public:
   unsigned int rand() {return _rand_engine();}
-  void seedMasterRand(unsigned int seed) {_rand_engine.seed(seed); _reseed_subapps = true;}
+  void seedMasterRand(unsigned int seed) {
+    _reseed_subapps = true;
+    _master_seed = seed;
+    _rand_engine.seed(_master_seed);
+  }
+  unsigned int masterSeed() {return _master_seed;}
   bool subappsNeedReseed() { bool val = _reseed_subapps; _reseed_subapps = false; return val;}
 private:
   void reseedRand(ExecFlagType exec_flag) {

--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -1297,6 +1297,20 @@ private:
   /// At or beyond initialSteup stage
   bool _started_initial_setup;
 
+public:
+  unsigned int rand() {return _rand_engine();}
+  void seedMasterRand(unsigned int seed) {_rand_engine.seed(seed); _reseed_subapps = true;}
+  bool subappsNeedReseed() { bool val = _reseed_subapps; _reseed_subapps = false; return val;}
+private:
+  void reseedRand(ExecFlagType exec_flag) {
+    if (exec_flag == _reset_rand_on)
+      seedMasterRand(_master_seed);
+  }
+  bool _reseed_subapps;
+  unsigned int _master_seed;
+  RandGen<std::mt19937>& _rand_engine;
+  ExecFlagType _reset_rand_on;
+
   friend class AuxiliarySystem;
   friend class NonlinearSystemBase;
   friend class MooseEigenSystem;

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -20,6 +20,7 @@
 #include "HashMap.h"
 #include "MooseError.h"
 #include "Backup.h"
+#include "RandGen.h"
 
 // libMesh includes
 #include "libmesh/vector_value.h"
@@ -35,6 +36,7 @@
 #include <list>
 #include <iostream>
 #include <map>
+#include <random>
 
 // Forward declarations
 class ColumnMajorMatrix;
@@ -415,6 +417,23 @@ dataLoad(std::istream & stream, HashMap<T,U> & m, void * context)
     U & value = m[key];
     loadHelper(stream, value, context);
   }
+}
+
+template <typename T>
+inline void
+dataLoad(std::istream & stream, RandGen<T> & eng, void * context)
+{
+  std::stringstream ss;
+  dataLoad(stream, ss, context);
+  ss >> eng;
+}
+template <typename T>
+inline void
+dataStore(std::ostream & stream, RandGen<T> & eng, void * context)
+{
+  std::stringstream ss;
+  ss << eng;
+  dataStore(stream, ss, context);
 }
 
 // Specializations (defined in .C)

--- a/framework/include/transfers/MultiAppSeedTransfer.h
+++ b/framework/include/transfers/MultiAppSeedTransfer.h
@@ -1,0 +1,49 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef MULTIAPPSEEDTRANSFER_H
+#define MULTIAPPSEEDTRANSFER_H
+
+#include "MultiAppTransfer.h"
+
+// Forward declarations
+class MultiAppSeedTransfer;
+class MooseVariable;
+
+template<>
+InputParameters validParams<MultiAppSeedTransfer>();
+
+/**
+ * Copy the value to the target domain from the nearest node in the source domain.
+ */
+class MultiAppSeedTransfer :
+  public MultiAppTransfer
+{
+public:
+  MultiAppSeedTransfer(const InputParameters & parameters);
+
+  /**
+   * Performs the transfer of a variable (Nonlinear or Auxiliary) to/from the Multiapp.
+   */
+  virtual void execute() override;
+
+protected:
+
+  /**
+   * Performs the transfer of a variable between two problems.
+   */
+  void transfer(FEProblemBase & to_problem, FEProblemBase & from_problem);
+};
+
+#endif // MULTIAPPSEEDTRANSFER_H

--- a/framework/include/utils/RandGen.h
+++ b/framework/include/utils/RandGen.h
@@ -1,0 +1,25 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef RANDGEN_H
+#define RANDGEN_H
+
+/// This class mostly exists to enable correct data[Store/Load] for restart/recovery by
+/// enabling the unambiguous template overloading for those functions keyed
+/// specifically to RandGen type.  This is necessary because c++ random generators
+/// do not have a common base class.
+template <typename T>
+class RandGen : public T { };
+
+#endif /* RANDGEN_H */

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -165,12 +165,13 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters) :
     _fail_next_linear_convergence_check(false),
     _currently_computing_jacobian(false),
     _started_initial_setup(false),
-    _reseed_subapps(declareRestartableData<bool>("reseed_subapps")),
-    _master_seed(parameters.get<unsigned int>("master_rand_seed")),
+    _reseed_subapps(false),
+    _master_seed(declareRestartableData<unsigned int>("master_rand_seed")),
     _rand_engine(declareRestartableData<RandGen<std::mt19937>>("rand_engine")),
     _reset_rand_on(parameters.get<ExecFlagType>("reset_rand_on"))
 {
-  seedMasterRand(_master_seed);
+  // this is retrieved here so we can have _master_seed be restartable data
+  seedMasterRand(parameters.get<unsigned int>("master_rand_seed"));
   _time = 0.0;
   _time_old = 0.0;
   _t_step = 0;

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -348,6 +348,7 @@
 #include "MultiAppUserObjectTransfer.h"
 #include "MultiAppNearestNodeTransfer.h"
 #include "MultiAppCopyTransfer.h"
+#include "MultiAppSeedTransfer.h"
 #include "MultiAppInterpolationTransfer.h"
 #include "MultiAppPostprocessorTransfer.h"
 #include "MultiAppProjectionTransfer.h"
@@ -776,6 +777,7 @@ registerObjects(Factory & factory)
   registerTransfer(MultiAppUserObjectTransfer);
   registerTransfer(MultiAppNearestNodeTransfer);
   registerTransfer(MultiAppCopyTransfer);
+  registerTransfer(MultiAppSeedTransfer);
   registerTransfer(MultiAppInterpolationTransfer);
   registerTransfer(MultiAppPostprocessorTransfer);
   registerTransfer(MultiAppProjectionTransfer);

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -475,6 +475,7 @@ MultiApp::createApp(unsigned int i, Real start_time)
 
   InputParameters app_params = AppFactory::instance().getValidParams(_app_type);
   app_params.set<FEProblemBase *>("_parent_fep") = &_fe_problem;
+  app_params.set<unsigned int>("master_rand_seed") = _app.getExecutioner()->feProblem().rand();
   app_params.set<MooseSharedPointer<CommandLine> >("_command_line") = _app.commandLine();
   MooseApp * app = AppFactory::instance().create(_app_type, full_name, app_params, _my_comm);
   _apps[i] = app;

--- a/framework/src/transfers/MultiAppSeedTransfer.C
+++ b/framework/src/transfers/MultiAppSeedTransfer.C
@@ -1,0 +1,63 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+// MOOSE includes
+#include "MultiAppSeedTransfer.h"
+#include "MooseTypes.h"
+#include "FEProblem.h"
+#include "DisplacedProblem.h"
+#include "MultiApp.h"
+#include "MooseMesh.h"
+#include "NonlinearSystem.h"
+
+// libMesh includes
+#include "libmesh/system.h"
+#include "libmesh/mesh_tools.h"
+#include "libmesh/id_types.h"
+
+template <>
+InputParameters
+validParams<MultiAppSeedTransfer>()
+{
+  InputParameters params = validParams<MultiAppTransfer>();
+  params.set<MultiMooseEnum>("execute_on") = "timestep_begin nonlinear timestep_end timestep_begin custom";
+  return params;
+}
+
+MultiAppSeedTransfer::MultiAppSeedTransfer(const InputParameters & parameters)
+  : MultiAppTransfer(parameters)
+{
+}
+
+void
+MultiAppSeedTransfer::transfer(FEProblemBase & to_problem, FEProblemBase & from_problem)
+{
+  to_problem.seedMasterRand(from_problem.rand());
+}
+
+void
+MultiAppSeedTransfer::execute()
+{
+  _console << "Beginning MultiAppSeedTransfer " << name() << std::endl;
+  FEProblemBase & from_problem = _multi_app->problemBase();
+  if (_direction != TO_MULTIAPP)
+    mooseError("MultiAppSeedTransfer only supports transfers *to* multi-apps");
+  if (!from_problem.subappsNeedReseed())
+    return;
+
+  for (unsigned int i = 0; i < _multi_app->numGlobalApps(); i++)
+    if (_multi_app->hasLocalApp(i))
+      transfer(_multi_app->appProblemBase(i), from_problem);
+  _console << "Finished MultiAppSeedTransfer " << name() << std::endl;
+}


### PR DESCRIPTION
This is just a quick cut at the idea - basically anybody who needs random numbers can create their own c++11 generator and seed it with a number from the app master generator (and reset/reseed whenever they want).  This way we get reproducibility while enabling unique random number sequences to be generated in multiple places (e.g. subapps) all from a single master app seed.  Details of the PR include:

* Added load/store functions for mersenne twister generator for
  restart/recover.

* Each app (re)seeds subapps' master generators by pulling values from
  its master generator.

* If an apps generator is reseeded, then a transfer reseeding
  to subapps occurs.

* a reset_rand_on param was added to FEProblem params - that takes an
  ExecFlagType. This is used to auto-reset the app's generator when that
  flag phase fires.

* multiapp subapps are seeded immediately upon creation

ref #8101 (fixes maybe), #8111 (provides alternate soln)