### PR TITLE
Switch the underlying Action block data structure to lists

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -18,14 +18,16 @@
 #include <string>
 #include <set>
 #include <map>
+#include <vector>
+#include <list>
 #include <ostream>
 
 // MOOSE includes
 #include "Action.h"
 #include "ConsoleStreamInterface.h"
 
-/// Typedef to hide implementation details
-typedef std::vector<Action *>::iterator ActionIterator;
+/// alias to hide implementation details
+using ActionIterator = std::list<Action *>::iterator;
 
 class MooseMesh;
 class Syntax;
@@ -89,15 +91,21 @@ public:
    * Iterators to the Actions in the warehouse.  Iterators should always be used when executing
    * Actions to capture dynamically added Actions (meta-Actions).  Meta-Actions are allowed to
    * create and add additional Actions to the warehouse on the fly.  Those Actions will fire
-   * as long as their associated task occurs after the task that created them.
+   * as long as their associated task hasn't already passed (i.e. matches or is later).
    */
   ActionIterator actionBlocksWithActionBegin(const std::string & task);
   ActionIterator actionBlocksWithActionEnd(const std::string & task);
 
   /**
    * Retrieve a constant vector of \p Action pointers associated with the passed in task.
+   * TODO: Deprecate
    */
-  const std::vector<Action *> & getActionsByName(const std::string & task) const;
+  const std::vector<Action *> & getActionsByName(const std::string & task);
+
+  /**
+   * Retrieve a constant list of \p Action pointers associated with the passed in task.
+   */
+  const std::list<Action *> & getActionListByName(const std::string & task) const;
 
   /**
    * Retrieve an action with its name and the desired type.
@@ -206,7 +214,9 @@ protected:
   /// The Factory that builds Actions
   ActionFactory & _action_factory;
   /// Pointers to the actual parsed input file blocks
-  std::map<std::string, std::vector<Action *> > _action_blocks;
+  std::map<std::string, std::list<Action *> > _action_blocks;
+  /// Action blocks that have been requested
+  std::map<std::string, std::vector<Action *> > _requested_action_blocks;
   /// The container that holds the sorted action names from the DependencyResolver
   std::vector<std::string> _ordered_names;
   /// Use to store the current list of unsatisfied dependencies

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -167,11 +167,33 @@ ActionWarehouse::actionBlocksWithActionEnd(const std::string & task)
 }
 
 const std::vector<Action *> &
-ActionWarehouse::getActionsByName(const std::string & task) const
+ActionWarehouse::getActionsByName(const std::string & task)
 {
-  std::map<std::string, std::vector<Action *> >::const_iterator it = _action_blocks.find(task);
+  // TODO: Deprecate this method
+  const auto it = _action_blocks.find(task);
   if (it == _action_blocks.end())
     mooseError("The task " << task << " does not exist.");
+
+  /**
+   * For backwards compatibility we will populate a vector
+   * and return it.
+   */
+  auto it2 = _requested_action_blocks.lower_bound(task);
+  if (it2 == _requested_action_blocks.end() || it2->first != task)
+    it2 = _requested_action_blocks.emplace_hint(it2, task, std::vector<Action *>(it->second.begin(), it->second.end()));
+  else
+    it2->second.assign(it->second.begin(), it->second.end());
+
+  return it2->second;
+}
+
+const std::list<Action *> &
+ActionWarehouse::getActionListByName(const std::string & task) const
+{
+  const auto it = _action_blocks.find(task);
+  if (it == _action_blocks.end())
+    mooseError("The task " << task << " does not exist.");
+
   return it->second;
 }
 


### PR DESCRIPTION
Right now we have vectors but iterators get invalidated with push_back.
Switching to lists will allow meta-meta Actions which we are finally
in the business of creating.

refs #8154

If this passes, we'll want to start switching people away from `ActionWarehouse::getActionsByName()` and using the new similarly named method instead. Let's see what Yak does...