### PR TITLE
Further generalization in Grand Potential test

### DIFF
--- a/modules/phase_field/tests/GrandPotentialPFM/GrandPotentialPFM.i
+++ b/modules/phase_field/tests/GrandPotentialPFM/GrandPotentialPFM.i
@@ -128,9 +128,8 @@
   [./concentration]
     type = ParsedMaterial
     f_name = c
-    args = 'w eta'
-    material_property_names = 'A cs cl h'
-    function = 'w/A + cs * h + cl * (1.0 - h)'
+    material_property_names = 'dF:=D[F,w]'
+    function = '-dF'
     outputs = exodus
   [../]
 []


### PR DESCRIPTION
Another small change to the Grand Potential test, that is a generalization. Again rather than explicitly specifying the expression for the concentration, which is the derivative of the grand potential, we use the MaterialProperty derivative system to pull in the automatically generated derivative of the Grand Potential.

Ping @karim86 

Refs #8170