### PR TITLE
Fix run_tests script in combined module

### DIFF
--- a/modules/combined/run_tests
+++ b/modules/combined/run_tests
@@ -5,7 +5,7 @@ import sys, os
 os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
 
 #### Set the name of the application here and moose directory relative to the application
-app_name = 'modules'
+app_name = 'combined'
 
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -430,7 +430,6 @@ FrictionalContactProblem::calculateSlip(const NumericVector<Number>& ghosted_sol
   _slip_residual = 0.0;
   _it_slip_norm = 0.0;
   _inc_slip_norm = 0.0;
-  System & system = getNonlinearSystemBase().system();
 
   if (iterative_slip)
     iterative_slip->clear();


### PR DESCRIPTION
Fix run_tests script in the combined directory. This was left behind when I added the module loader and dynamic module Makefile capability.
closes #8178 

Also removing an unrelated by annoying compiler warning.
refs #1777