### PR TITLE
Add new interface to Assembly to deprecate ctor

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -329,7 +329,10 @@ public:
    */
   void reinitNodeNeighbor(const Node * node);
 
+  // DEPRECATED init method
   void init();
+
+  void init(const CouplingMatrix * cm);
 
   /// Create pair of variables requiring nonlocal jacobian contributions
   void initNonlocalCoupling();
@@ -561,8 +564,10 @@ protected:
   void modifyWeightsDueToXFEM(const Elem* elem);
 
   SystemBase & _sys;
-  /// Reference to coupling matrix
-  CouplingMatrix * & _cm;
+  /// Reference to coupling matrix (Will be removed)
+  CouplingMatrix * & _cm_deprecated;
+
+  const CouplingMatrix * _cm;
   const CouplingMatrix & _nonlocal_cm;
   /// Entries in the coupling matrix (only for field variables)
   std::vector<std::pair<MooseVariable *, MooseVariable *> > _cm_entry;

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -36,7 +36,7 @@
 
 Assembly::Assembly(SystemBase & sys, CouplingMatrix * & cm, THREAD_ID tid) :
     _sys(sys),
-    _cm(cm),
+    _cm_deprecated(cm),
     _nonlocal_cm(_sys.subproblem().nonlocalCouplingMatrix()),
     _dof_map(_sys.dofMap()),
     _tid(tid),
@@ -893,6 +893,16 @@ Assembly::jacobianBlockNeighbor(Moose::DGJacobianType type, unsigned int ivar, u
 void
 Assembly::init()
 {
+  // TODO: Will deprecate
+  init(_cm_deprecated);
+}
+
+void
+Assembly::init(const CouplingMatrix * cm)
+{
+  // Set the coupling matrix here. We don't need to do this again.
+  _cm = cm;
+
   unsigned int n_vars = _sys.nVariables();
 
   // I want the blocks to go by columns first to reduce copying of shape function in assembling "full" Jacobian


### PR DESCRIPTION
refs #8190

This is part 1 of 2. After Yak is updated, We'll stop passing in the CouplingMatrix and just call the new `init()` method directly.

