### PR TITLE
Fix wrong kernel name in tutorial step 5.

### DIFF
--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5b_transient.i
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5b_transient.i
@@ -19,7 +19,7 @@
     variable = temp
   [../]
   [./heat_conduction_time_derivative]
-    type = HeatCapacityConductionTimeDerivative
+    type = HeatConductionTimeDerivative
     variable = temp
   [../]
 []

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5c_outflow.i
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5c_outflow.i
@@ -19,7 +19,7 @@
     variable = temp
   [../]
   [./heat_conduction_time_derivative]
-    type = HeatCapacityConductionTimeDerivative
+    type = HeatConductionTimeDerivative
     variable = temp
   [../]
 []


### PR DESCRIPTION
We test the tutorial I believe, but only by calling `./run_tests` and not running the input files in the "problems" directory that are actually used in the training.  One idea would be to symbolically link the problem input files into the test directory and add gold files for them...

Refs #7759.