### PR TITLE
Control Logic simplifications.

### DIFF
--- a/framework/include/controls/Control.h
+++ b/framework/include/controls/Control.h
@@ -114,10 +114,10 @@ protected:
   void setControllableValueByName(const std::string & tag, const std::string & param_name, const T & value, bool warn_when_values_differ = false);
   ///@}
 
-private:
-
   /// A reference to the InputParameterWarehouse which is used for access the parameter objects
   InputParameterWarehouse & _input_parameter_warehouse;
+
+private:
 
   /// Helper method for retrieving controllable parameters
   template<typename T>

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -530,7 +530,7 @@ public:
   /**
    * Return list of controllable parameters
    */
-  const std::set<std::string> & getControllableParameters() { return _controllable_params; }
+  const std::set<std::string> & getControllableParameters() const { return _controllable_params; }
 
 
 private:


### PR DESCRIPTION
Changes InputParameters::getControllableParameters() to be const.
Changes Control::_input_parameter_warehouse to be protected instead of private.

getControllableParameters() being const would allow classes that only have access to a const version of InputParameters to use it.

_input_parameter_warehouse being protected would save child classes of Control from needing to use _app.getInputParameterWarehouse() to get a variable that already is in the parent Control class.

closes #8216 