### PR TITLE
Changes InputParameters::getControllableParameters() to be const.

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -530,7 +530,7 @@ public:
   /**
    * Return list of controllable parameters
    */
-  const std::set<std::string> & getControllableParameters() { return _controllable_params; }
+  const std::set<std::string> & getControllableParameters() const { return _controllable_params; }
 
 
 private:


### PR DESCRIPTION
getControllableParameters() being const would allow classes that only have access to a const version of InputParameters to use it.

Refs #8216