### PR TITLE
HeatConductionKernel does not need a _dim.

### DIFF
--- a/modules/heat_conduction/include/kernels/HeatConduction.h
+++ b/modules/heat_conduction/include/kernels/HeatConduction.h
@@ -34,7 +34,6 @@ protected:
   virtual Real computeQpJacobian();
 
 private:
-  const unsigned _dim;
   const MaterialProperty<Real> & _diffusion_coefficient;
   const MaterialProperty<Real> * const _diffusion_coefficient_dT;
 };

--- a/modules/heat_conduction/src/kernels/HeatConduction.C
+++ b/modules/heat_conduction/src/kernels/HeatConduction.C
@@ -35,7 +35,7 @@ HeatConductionKernel::HeatConductionKernel(const InputParameters & parameters) :
 Real
 HeatConductionKernel::computeQpResidual()
 {
-  return _diffusion_coefficient[_qp]*Diffusion::computeQpResidual();
+  return _diffusion_coefficient[_qp] * Diffusion::computeQpResidual();
 }
 
 Real

--- a/modules/heat_conduction/src/kernels/HeatConduction.C
+++ b/modules/heat_conduction/src/kernels/HeatConduction.C
@@ -26,7 +26,6 @@ InputParameters validParams<HeatConductionKernel>()
 
 HeatConductionKernel::HeatConductionKernel(const InputParameters & parameters) :
     Diffusion(parameters),
-    _dim(_subproblem.mesh().dimension()),
     _diffusion_coefficient(getMaterialProperty<Real>("diffusion_coefficient_name")),
     _diffusion_coefficient_dT(hasMaterialProperty<Real>("diffusion_coefficient_dT_name") ?
                               &getMaterialProperty<Real>("diffusion_coefficient_dT_name") : NULL)


### PR DESCRIPTION
It used it at one time for something but now no longer needs it.

Refs #5275.