### PR TITLE
A 'moose' command for users/developers

### DIFF
--- a/bin/moose
+++ b/bin/moose
@@ -5,6 +5,7 @@ from __future__ import print_function
 import re
 import argparse
 import os.path
+import sys
 import shutil
 
 def prepare_obj_paths(proj, kind, name):
@@ -52,8 +53,11 @@ def rename_internal(fname, objname):
 
 def newobj(args):
     proj, kind, name = args.proj, args.kind, args.name
-
     path_info = prepare_obj_paths(proj, kind, name)
+    if path_info is None:
+        print("invalid object kind '{}'".format(kind), file=sys.stderr)
+        sys.exit(1)
+
     os.makedirs(os.path.dirname(path_info['dst_h']), exist_ok=True)
     os.makedirs(os.path.dirname(path_info['dst_C']), exist_ok=True)
     shutil.copyfile(path_info['template_h'], path_info['dst_h'])

--- a/bin/moose
+++ b/bin/moose
@@ -20,10 +20,14 @@ def build_cmds(parser):
     if mpath is None:
         print('the MOOSE_DIR environment variable must be set to use this command', file=sys.stderr)
         sys.exit(1)
+    sys.path.append(os.path.join(mpath, 'python'))
 
-    projname, projpath = find_app('./')
+    import path_tool # this needs to die
+    path_tool.activate_module('TestHarness') # this needs to die
 
-    projinfo = {'path': projpath, 'name': projname, 'moose_path': mpath}
+    classname, projname, projpath = find_app('./')
+
+    projinfo = {'path': projpath, 'class': classname, 'name': projname, 'moose_path': mpath}
     parser.set_defaults(proj=projinfo, parser=parser)
 
     subs = parser.add_subparsers()
@@ -66,6 +70,15 @@ def build_cmds(parser):
     sub.add_argument('-j', type=int, default=4, help='number of parallel build jobs')
     sub.set_defaults(func=buildproj)
 
+    subcmd = 'test'
+    help = 'test moose apps, libraries, and modules'
+    desc = 'With no arguments, runs regression tests for the moose app in the current location. ' \
+           'To use test harness options, put -h (or desired options) after a -- (i.e. "moose test -- --no-color" or "moose test -- -h").'
+    sub = subs.add_parser(subcmd, help=help, description=desc)
+    sub.add_argument('--unit', action='store_true', default=False, help='run unit tests for the current project')
+    sub.add_argument('testflags', nargs='*', default=[], help='flags to pass into the test harness')
+    sub.set_defaults(func=testproj)
+
 def helpcmd(args):
     if args.subcommand == 'summary':
         args.parser.print_help()
@@ -82,25 +95,66 @@ def helpcmd(args):
                 return
 
 def show_app_info(args):
-    if args.proj['name'] is None:
+    if args.proj['class'] is None:
         print('no MOOSE app found here', file=sys.stderr)
         sys.exit(1)
 
     proj = args.proj
     print(' ' + proj['name'] + ':')
+    print('    Class:', proj['class'])
     print('    Path:', proj['path'])
     print('    MOOSE_DIR:', proj['moose_path'])
+
+
+def testproj(args):
+    proj = args.proj
+    iscore = in_moose_core('./')
+    if proj['class'] is None and not iscore:
+        print('no MOOSE app/project found here', file=sys.stderr)
+        sys.exit(1)
+
+    mpath = proj['moose_path']
+    if proj['class'] is None:
+        appname = 'moose_test'
+        wd = os.path.join(mpath, 'test')
+        if args.unit:
+            wd = os.path.join(mpath, 'unit')
+    else:
+        wd = proj['path']
+        appname = proj['class'].lower()
+        if args.unit:
+            wd = os.path.join(proj['path'], 'unit')
+
+    if not args.unit:
+        print("Running regression tests for '{}'...".format(appname))
+        runtests(proj, wd, appname, args.testflags)
+    else:
+        print("Running unit tests for '{}'...".format(appname))
+        p = subprocess.Popen('./run_tests', cwd=wd, stdout=sys.stdout, stderr=subprocess.STDOUT)
+        p.communicate()
+        if p.returncode != 0:
+            print('unit tests in "{}" failed to run'.format(wd), file=sys.stderr)
+            sys.exit(p.returncode)
+
+def runtests(proj, path, app_name, flags):
+    from TestHarness import TestHarness
+    os.chdir(path)
+
+    flags.insert(0, './run_tests')
+    flags.insert(1, '--error')
+
+    TestHarness.buildAndRun(flags, app_name, proj['moose_path'])
 
 def buildproj(args):
     proj = args.proj
     iscore = in_moose_core('./')
-    if proj['name'] is None and not iscore:
+    if proj['class'] is None and not iscore:
         print('no MOOSE app/project found here', file=sys.stderr)
         sys.exit(1)
 
     mpath = proj['moose_path']
     cmd = ['make', '-j', str(args.j)]
-    if iscore:
+    if proj['class'] is None:
         if args.unit:
             wd = os.path.join(mpath, 'unit')
         elif args.modules:
@@ -135,7 +189,7 @@ def update_libmesh(args):
         sys.exit(p.returncode)
 
 def newobj(args):
-    if args.proj['name'] is None:
+    if args.proj['class'] is None:
         print('no MOOSE app found here', file=sys.stderr)
         sys.exit(1)
 
@@ -189,18 +243,29 @@ def find_app(proj_path, depth=0):
         maxdepth = 10
         if depth < maxdepth:
             return find_app(os.path.join(proj_path, '..'), depth+1)
-        return None, None
+        return None, None, None
 
     with open(fpath, 'r') as f:
         body = f.read()
     r = re.compile(r'\s([A-Za-z0-9_]*)App::registerApps\(\s*\)\s*;')
     m = r.search(body)
+    if m is None:
+        return None, None, None
+
+    fpath = os.path.join(proj_path, 'Makefile')
+    if not os.path.exists(fpath):
+        return None, None, None
+
+    with open(fpath, 'r') as f:
+        body = f.read()
+
+    r = re.compile(r'\s*APPLICATION_NAME\s*:=\s*([a-zA-Z_-][a-zA-Z0-9_-]*)\s*')
+    m = r.search(body)
+    if m is None:
+        return None, None, None
 
     proj_path = os.path.abspath(proj_path)
-    if m is None:
-        return None, None
-
-    return m.group(1), proj_path
+    return m.group(1), m.group(1), proj_path
 
 def rename_internal(fname, objname):
     with open(fname, 'r') as f:
@@ -215,7 +280,7 @@ def rename_internal(fname, objname):
 def register_object(proj, name):
     r = re.compile(r'(App::registerObjects\( *Factory.*\)\s*{[^\n]*\n)')
 
-    appfile = os.path.join(proj['path'], 'src/base', proj['name']+'App.C')
+    appfile = os.path.join(proj['path'], 'src/base', proj['class']+'App.C')
     if not os.path.exists(appfile):
         print('app file "{}" not foundA)'.format(appfile), file=stderr)
         sys.exit(1)

--- a/bin/moose
+++ b/bin/moose
@@ -139,20 +139,28 @@ def newobj(args):
         sys.exit(1)
 
     proj, kind, name = args.proj, args.kind, args.name
+    copy_template(proj, kind, name)
+
+    if not args.noregister:
+        register_object(proj, name)
+
+def copy_template(proj, kind, name):
     path_info = prepare_obj_paths(proj, kind, name)
     if path_info is None:
         print("invalid object kind '{}'".format(kind), file=sys.stderr)
         sys.exit(1)
 
-    os.makedirs(os.path.dirname(path_info['dst_h']), exist_ok=True)
-    os.makedirs(os.path.dirname(path_info['dst_C']), exist_ok=True)
+
+    dirname = os.path.dirname(path_info['dst_h'])
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+    dirname = os.path.dirname(path_info['dst_C'])
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
     shutil.copyfile(path_info['template_h'], path_info['dst_h'])
     shutil.copyfile(path_info['template_C'], path_info['dst_C'])
     rename_internal(path_info['dst_h'], name)
     rename_internal(path_info['dst_C'], name)
-
-    if not args.noregister:
-        register_object(proj, name)
 
 def prepare_obj_paths(proj, kind, name):
     mpath, ppath = proj['moose_path'], proj['path']

--- a/bin/moose
+++ b/bin/moose
@@ -7,6 +7,7 @@ import argparse
 import os.path
 import sys
 import shutil
+import subprocess
 
 def main():
     parser = argparse.ArgumentParser()
@@ -21,25 +22,59 @@ def build_cmds(parser):
         sys.exit(1)
 
     projpath = './'
-    projname = find_proj_name(projpath)
+    projname, projpath = find_proj(projpath)
     if projname is None:
         print('no MOOSE app found here', file=sys.stderr)
         sys.exit(1)
 
     projinfo = {'path': projpath, 'name': 'Stork', 'moose_path': mpath}
+    parser.set_defaults(proj=projinfo, parser=parser)
+
     subs = parser.add_subparsers()
 
-    sub = subs.add_parser('newobj', help='add and register a new moose object')
+    subcmd = 'help'
+    help = 'display help subcomands'
+    sub = subs.add_parser(subcmd, help=help, description=help)
+    sub.add_argument('subcommand', nargs='?', default='summary', help='show help for a specific subcommand')
+    sub.set_defaults(func=helpcmd)
+
+    subcmd = 'info'
+    help = 'display local project info'
+    sub = subs.add_parser(subcmd, help=help, description=help)
+    sub.set_defaults(func=show_proj_info)
+
+    subcmd = 'newobj'
+    help = 'add and register a new moose object'
+    sub = subs.add_parser(subcmd, help=help, description=help)
     sub.add_argument('kind', type=str, help='superclass of object to create')
     sub.add_argument('name', type=str, help='class name for new object')
-    sub.add_argument('--register', type=t_or_f, default=True, help='auto-generate the in-app registration line (default=True)')
-    sub.set_defaults(proj=projinfo, func=newobj)
+    sub.add_argument('--noregister', action='store_true', default=False, help="don't auto-generate the in-app registration line (default=True)")
+    sub.set_defaults(func=newobj)
 
-    sub = subs.add_parser('info', help='display local project info')
-    sub.set_defaults(proj=projinfo, func=show_proj_info)
+    subcmd = 'libmesh'
+    help = 'perform libmesh-related tasks'
+    sub = subs.add_parser(subcmd, help=help, description=help)
+    subsubs = sub.add_subparsers()
+    help='update and rebuild the libmesh submodule in MOOSE'
+    subsub = subsubs.add_parser('update', help=help, description=help)
+    subsub.add_argument('--clean', action='store_true', default=False, help='remove existing build directory and reconfigure before build')
+    subsub.add_argument('--enable-timestamps', action='store_true', default=False, help='use timestamps to trigger object rebuilds')
+    subsub.set_defaults(func=update_libmesh)
 
-    sub = subs.add_parser('help', help='display help for subcomands')
-    sub.set_defaults(proj=projinfo, func=helpcmd)
+def helpcmd(args):
+    if args.subcommand == 'summary':
+        args.parser.print_help()
+        return
+
+    # retrieve subparsers from parser and find the one matching [subcommand]
+    subparsers_actions = [
+        action for action in args.parser._actions
+        if isinstance(action, argparse._SubParsersAction)]
+    for subparsers_action in subparsers_actions:
+        for subname, subparser in subparsers_action.choices.items():
+            if subname == args.subcommand:
+                print(subparser.format_help())
+                return
 
 def show_proj_info(args):
     proj = args.proj
@@ -47,40 +82,21 @@ def show_proj_info(args):
     print('    Path:', proj['path'])
     print('    MOOSE_DIR:', proj['moose_path'])
 
-def prepare_obj_paths(proj, kind, name):
-    mpath, ppath = proj['moose_path'], proj['path']
-    if kind == 'Kernel':
-        return {
-            'template_h': os.path.join(mpath, 'templates/Kernel.h'),
-            'template_C': os.path.join(mpath, 'templates/Kernel.C'),
-            'dst_h': os.path.join(ppath, 'include/kernels/{}.h'.format(name)),
-            'dst_C': os.path.join(ppath, 'src/kernels/{}.C'.format(name)),
-            }
-    return None
+def update_libmesh(args):
+    proj = args.proj
+    cmd = [os.path.join(proj['moose_path'], 'scripts', 'update_and_rebuild_libmesh.sh')]
+    if args.enable_timestamps:
+        cmd.append('--enable-timestamps')
+    if not args.clean:
+        cmd.append('--fast')
 
-def find_proj_name(proj_path):
-    fpath = os.path.join(proj_path, 'src/main.C')
-    with open(fpath, 'r') as f:
-        body = f.read()
-    r = re.compile(r'\s([A-Za-z0-9_]*)App::registerApps\(\s*\)\s*;')
-    m = r.search(body)
-
-    if m is None:
-        return None
-    return m.group(1)
-
-def helpcmd(args):
-    pass
-
-def rename_internal(fname, objname):
-    with open(fname, 'r') as f:
-        body = f.read()
-
-    body = body.replace('TmplKernel', objname)
-    body = body.replace('TMPLKERNEL', objname.upper())
-
-    with open(fname, 'w') as f:
-        f.write(body)
+    #cmd = ['bash', '-c', 'floobyjoober']
+    print(proj['moose_path'])
+    p = subprocess.Popen(cmd, cwd=proj['moose_path'], stdout=sys.stdout, stderr=subprocess.STDOUT)
+    _, error = p.communicate()
+    if p.returncode != 0:
+        print('libmesh update failed', file=sys.stderr)
+        sys.exit(p.returncode)
 
 def newobj(args):
     proj, kind, name = args.proj, args.kind, args.name
@@ -96,8 +112,47 @@ def newobj(args):
     rename_internal(path_info['dst_h'], name)
     rename_internal(path_info['dst_C'], name)
 
-    if args.register:
+    if not args.noregister:
         register_object(proj, name)
+
+def prepare_obj_paths(proj, kind, name):
+    mpath, ppath = proj['moose_path'], proj['path']
+    if kind == 'Kernel':
+        return {
+            'template_h': os.path.join(mpath, 'templates/Kernel.h'),
+            'template_C': os.path.join(mpath, 'templates/Kernel.C'),
+            'dst_h': os.path.join(ppath, 'include/kernels/{}.h'.format(name)),
+            'dst_C': os.path.join(ppath, 'src/kernels/{}.C'.format(name)),
+            }
+    return None
+
+def find_proj(proj_path, depth=0):
+    fpath = os.path.join(proj_path, 'src/main.C')
+    if not os.path.exists(fpath):
+        maxdepth = 10
+        if depth < maxdepth:
+            return find_proj(os.path.join(proj_path, '..'), depth+1)
+        return None, None
+
+    with open(fpath, 'r') as f:
+        body = f.read()
+    r = re.compile(r'\s([A-Za-z0-9_]*)App::registerApps\(\s*\)\s*;')
+    m = r.search(body)
+
+    proj_path = os.path.abspath(proj_path)
+    if m is None:
+        return None, proj_path
+    return m.group(1), proj_path
+
+def rename_internal(fname, objname):
+    with open(fname, 'r') as f:
+        body = f.read()
+
+    body = body.replace('TmplKernel', objname)
+    body = body.replace('TMPLKERNEL', objname.upper())
+
+    with open(fname, 'w') as f:
+        f.write(body)
 
 def register_object(proj, name):
     r = re.compile(r'(App::registerObjects\( *Factory.*\)\s*{[^\n]*\n)')
@@ -110,13 +165,6 @@ def register_object(proj, name):
 
     with open(appfile, 'w') as f:
         f.write(body)
-
-# hack to get python's argparse to do something useful with boolean flags
-def t_or_f(arg):
-    s = str(arg).lower()
-    if s in ('f', 'false', 'n', 'no'):
-        return False
-    return True
 
 if __name__ == '__main__':
     main()

--- a/bin/moose
+++ b/bin/moose
@@ -8,6 +8,45 @@ import os.path
 import sys
 import shutil
 
+def main():
+    parser = argparse.ArgumentParser()
+    build_cmds(parser)
+    args = parser.parse_args()
+    args.func(args)
+
+def build_cmds(parser):
+    mpath = os.environ.get('MOOSE_DIR')
+    if mpath is None:
+        print('the MOOSE_DIR environment variable must be set to use this command', file=sys.stderr)
+        sys.exit(1)
+
+    projpath = './'
+    projname = find_proj_name(projpath)
+    if projname is None:
+        print('no MOOSE app found here', file=sys.stderr)
+        sys.exit(1)
+
+    projinfo = {'path': projpath, 'name': 'Stork', 'moose_path': mpath}
+    subs = parser.add_subparsers()
+
+    sub = subs.add_parser('newobj', help='add and register a new moose object')
+    sub.add_argument('kind', type=str, help='superclass of object to create')
+    sub.add_argument('name', type=str, help='class name for new object')
+    sub.add_argument('--register', type=t_or_f, default=True, help='auto-generate the in-app registration line (default=True)')
+    sub.set_defaults(proj=projinfo, func=newobj)
+
+    sub = subs.add_parser('info', help='display local project info')
+    sub.set_defaults(proj=projinfo, func=show_proj_info)
+
+    sub = subs.add_parser('help', help='display help for subcomands')
+    sub.set_defaults(proj=projinfo, func=helpcmd)
+
+def show_proj_info(args):
+    proj = args.proj
+    print(' ' + proj['name'] + ':')
+    print('    Path:', proj['path'])
+    print('    MOOSE_DIR:', proj['moose_path'])
+
 def prepare_obj_paths(proj, kind, name):
     mpath, ppath = proj['moose_path'], proj['path']
     if kind == 'Kernel':
@@ -19,24 +58,16 @@ def prepare_obj_paths(proj, kind, name):
             }
     return None
 
-def main():
-    parser = argparse.ArgumentParser()
-    build_cmds(parser)
-    args = parser.parse_args()
-    args.func(args)
+def find_proj_name(proj_path):
+    fpath = os.path.join(proj_path, 'src/main.C')
+    with open(fpath, 'r') as f:
+        body = f.read()
+    r = re.compile(r'\s([A-Za-z0-9_]*)App::registerApps\(\s*\)\s*;')
+    m = r.search(body)
 
-def build_cmds(parser):
-    projinfo = {'path': './', 'name': 'Stork', 'moose_path': '../moose'}
-    subs = parser.add_subparsers()
-
-    sub = subs.add_parser('newobj', help='add and register a new moose object')
-    sub.add_argument('kind', type=str, help='superclass of object to create')
-    sub.add_argument('name', type=str, help='class name for new object')
-    sub.add_argument('--register', type=t_or_f, default=True, help='auto-generate the in-app registration line (default=True)')
-    sub.set_defaults(proj=projinfo, func=newobj)
-
-    sub = subs.add_parser('help')
-    sub.set_defaults(proj=projinfo, func=helpcmd)
+    if m is None:
+        return None
+    return m.group(1)
 
 def helpcmd(args):
     pass

--- a/bin/moose
+++ b/bin/moose
@@ -14,7 +14,7 @@ def prepare_obj_paths(proj, kind, name):
             'template_h': os.path.join(mpath, 'templates/Kernel.h'),
             'template_C': os.path.join(mpath, 'templates/Kernel.C'),
             'dst_h': os.path.join(ppath, 'include/kernels/{}.h'.format(name)),
-            'dst_C': os.path.join(ppath, 'include/kernels/{}.C'.format(name)),
+            'dst_C': os.path.join(ppath, 'src/kernels/{}.C'.format(name)),
             }
     return None
 
@@ -54,6 +54,8 @@ def newobj(args):
     proj, kind, name = args.proj, args.kind, args.name
 
     path_info = prepare_obj_paths(proj, kind, name)
+    os.makedirs(os.path.dirname(path_info['dst_h']), exist_ok=True)
+    os.makedirs(os.path.dirname(path_info['dst_C']), exist_ok=True)
     shutil.copyfile(path_info['template_h'], path_info['dst_h'])
     shutil.copyfile(path_info['template_C'], path_info['dst_C'])
     rename_internal(path_info['dst_h'], name)

--- a/bin/moose
+++ b/bin/moose
@@ -208,6 +208,7 @@ def register_object(proj, name):
     with open(appfile, 'r') as f:
         body = f.read()
 
+    body = '#include "{}.h"\n'.format(name) + body
     body = r.sub(r'\g<1>  registerObject({});\n'.format(name), body)
 
     with open(appfile, 'w') as f:

--- a/bin/moose
+++ b/bin/moose
@@ -21,13 +21,9 @@ def build_cmds(parser):
         print('the MOOSE_DIR environment variable must be set to use this command', file=sys.stderr)
         sys.exit(1)
 
-    projpath = './'
-    projname, projpath = find_proj(projpath)
-    if projname is None:
-        print('no MOOSE app found here', file=sys.stderr)
-        sys.exit(1)
+    projname, projpath = find_app('./')
 
-    projinfo = {'path': projpath, 'name': 'Stork', 'moose_path': mpath}
+    projinfo = {'path': projpath, 'name': projname, 'moose_path': mpath}
     parser.set_defaults(proj=projinfo, parser=parser)
 
     subs = parser.add_subparsers()
@@ -38,10 +34,10 @@ def build_cmds(parser):
     sub.add_argument('subcommand', nargs='?', default='summary', help='show help for a specific subcommand')
     sub.set_defaults(func=helpcmd)
 
-    subcmd = 'info'
+    subcmd = 'appinfo'
     help = 'display local project info'
     sub = subs.add_parser(subcmd, help=help, description=help)
-    sub.set_defaults(func=show_proj_info)
+    sub.set_defaults(func=show_app_info)
 
     subcmd = 'newobj'
     help = 'add and register a new moose object'
@@ -61,6 +57,16 @@ def build_cmds(parser):
     subsub.add_argument('--enable-timestamps', action='store_true', default=False, help='use timestamps to trigger object rebuilds')
     subsub.set_defaults(func=update_libmesh)
 
+    subcmd = 'build'
+    help = 'build/update moose libraries'
+    sub = subs.add_parser(subcmd, help=help, description=help)
+    sub.add_argument('--all', action='store_true', default=False, help='build everything')
+    sub.add_argument('--modules', action='store_true', default=False, help='build all module binaries and tests')
+    sub.add_argument('--tests', action='store_true', default=True, help='build moose regression tests and binary')
+    sub.add_argument('--unit', action='store_true', default=False, help='build unit tests')
+    sub.add_argument('-j', type=int, default=2, help='number of parallel build jobs')
+    sub.set_defaults(func=buildmoose)
+
 def helpcmd(args):
     if args.subcommand == 'summary':
         args.parser.print_help()
@@ -76,11 +82,42 @@ def helpcmd(args):
                 print(subparser.format_help())
                 return
 
-def show_proj_info(args):
+def show_app_info(args):
+    if args.proj['name'] is None:
+        print('no MOOSE app found here', file=sys.stderr)
+        sys.exit(1)
+
     proj = args.proj
     print(' ' + proj['name'] + ':')
     print('    Path:', proj['path'])
     print('    MOOSE_DIR:', proj['moose_path'])
+
+def buildmoose(args):
+    proj = args.proj
+    mpath = proj['moose_path']
+    testdir = os.path.join(mpath, 'test')
+    moduledir = os.path.join(mpath, 'modules')
+    unitdir = os.path.join(mpath, 'unit')
+
+    cmds = []
+    if args.all:
+        cmds.append((testdir , ['make', '-j', str(args.j)]))
+        cmds.append((moduledir , ['make', '-j', str(args.j)]))
+        cmds.append((unitdir , ['make', '-j', str(args.j)]))
+    else:
+        if args.tests:
+            cmds.append((testdir , ['make', '-j', str(args.j)]))
+        if args.modules:
+            cmds.append((moduledir , ['make', '-j', str(args.j)]))
+        if args.unit:
+            cmds.append((unitdir , ['make', '-j', str(args.j)]))
+
+    for (cwd, cmd) in cmds:
+        p = subprocess.Popen(cmd, cwd=cwd, stdout=sys.stdout, stderr=subprocess.STDOUT)
+        p.communicate()
+        if p.returncode != 0:
+            print('build in "{}" failed'.format(cwd), file=sys.stderr)
+            sys.exit(p.returncode)
 
 def update_libmesh(args):
     proj = args.proj
@@ -90,15 +127,17 @@ def update_libmesh(args):
     if not args.clean:
         cmd.append('--fast')
 
-    #cmd = ['bash', '-c', 'floobyjoober']
-    print(proj['moose_path'])
     p = subprocess.Popen(cmd, cwd=proj['moose_path'], stdout=sys.stdout, stderr=subprocess.STDOUT)
-    _, error = p.communicate()
+    p.communicate()
     if p.returncode != 0:
         print('libmesh update failed', file=sys.stderr)
         sys.exit(p.returncode)
 
 def newobj(args):
+    if args.proj['name'] is None:
+        print('no MOOSE app found here', file=sys.stderr)
+        sys.exit(1)
+
     proj, kind, name = args.proj, args.kind, args.name
     path_info = prepare_obj_paths(proj, kind, name)
     if path_info is None:
@@ -126,12 +165,12 @@ def prepare_obj_paths(proj, kind, name):
             }
     return None
 
-def find_proj(proj_path, depth=0):
+def find_app(proj_path, depth=0):
     fpath = os.path.join(proj_path, 'src/main.C')
     if not os.path.exists(fpath):
         maxdepth = 10
         if depth < maxdepth:
-            return find_proj(os.path.join(proj_path, '..'), depth+1)
+            return find_app(os.path.join(proj_path, '..'), depth+1)
         return None, None
 
     with open(fpath, 'r') as f:
@@ -141,7 +180,7 @@ def find_proj(proj_path, depth=0):
 
     proj_path = os.path.abspath(proj_path)
     if m is None:
-        return None, proj_path
+        return None, None
     return m.group(1), proj_path
 
 def rename_internal(fname, objname):

--- a/bin/moose
+++ b/bin/moose
@@ -29,7 +29,7 @@ def build_cmds(parser):
     subs = parser.add_subparsers()
 
     subcmd = 'help'
-    help = 'display help subcomands'
+    help = 'display help for subcomands'
     sub = subs.add_parser(subcmd, help=help, description=help)
     sub.add_argument('subcommand', nargs='?', default='summary', help='show help for a specific subcommand')
     sub.set_defaults(func=helpcmd)
@@ -58,14 +58,13 @@ def build_cmds(parser):
     subsub.set_defaults(func=update_libmesh)
 
     subcmd = 'build'
-    help = 'build/update moose libraries'
-    sub = subs.add_parser(subcmd, help=help, description=help)
-    sub.add_argument('--all', action='store_true', default=False, help='build everything')
-    sub.add_argument('--modules', action='store_true', default=False, help='build all module binaries and tests')
-    sub.add_argument('--tests', action='store_true', default=True, help='build moose regression tests and binary')
-    sub.add_argument('--unit', action='store_true', default=False, help='build unit tests')
-    sub.add_argument('-j', type=int, default=2, help='number of parallel build jobs')
-    sub.set_defaults(func=buildmoose)
+    help = '(re)build moose apps, libraries, modules, and tests'
+    desc = 'With no arguments, builds the moose app in the current location.'
+    sub = subs.add_parser(subcmd, help=help, description=desc)
+    sub.add_argument('--modules', action='store_true', default=False, help='build core moose module binaries and tests')
+    sub.add_argument('--unit', action='store_true', default=False, help='build unit tests for the current project')
+    sub.add_argument('-j', type=int, default=4, help='number of parallel build jobs')
+    sub.set_defaults(func=buildproj)
 
 def helpcmd(args):
     if args.subcommand == 'summary':
@@ -92,32 +91,34 @@ def show_app_info(args):
     print('    Path:', proj['path'])
     print('    MOOSE_DIR:', proj['moose_path'])
 
-def buildmoose(args):
+def buildproj(args):
     proj = args.proj
+    iscore = in_moose_core('./')
+    if proj['name'] is None and not iscore:
+        print('no MOOSE app/project found here', file=sys.stderr)
+        sys.exit(1)
+
     mpath = proj['moose_path']
-    testdir = os.path.join(mpath, 'test')
-    moduledir = os.path.join(mpath, 'modules')
-    unitdir = os.path.join(mpath, 'unit')
-
-    cmds = []
-    if args.all:
-        cmds.append((testdir , ['make', '-j', str(args.j)]))
-        cmds.append((moduledir , ['make', '-j', str(args.j)]))
-        cmds.append((unitdir , ['make', '-j', str(args.j)]))
-    else:
-        if args.tests:
-            cmds.append((testdir , ['make', '-j', str(args.j)]))
-        if args.modules:
-            cmds.append((moduledir , ['make', '-j', str(args.j)]))
+    cmd = ['make', '-j', str(args.j)]
+    if iscore:
         if args.unit:
-            cmds.append((unitdir , ['make', '-j', str(args.j)]))
+            wd = os.path.join(mpath, 'unit')
+        elif args.modules:
+            wd = os.path.join(mpath, 'modules')
+        else:
+            wd = os.path.join(mpath, 'test')
+    else:
+        if args.unit:
+            wd = os.path.join(proj['path'], 'unit')
+        else:
+            wd = proj['path']
 
-    for (cwd, cmd) in cmds:
-        p = subprocess.Popen(cmd, cwd=cwd, stdout=sys.stdout, stderr=subprocess.STDOUT)
-        p.communicate()
-        if p.returncode != 0:
-            print('build in "{}" failed'.format(cwd), file=sys.stderr)
-            sys.exit(p.returncode)
+
+    p = subprocess.Popen(cmd, cwd=wd, stdout=sys.stdout, stderr=subprocess.STDOUT)
+    p.communicate()
+    if p.returncode != 0:
+        print('build in "{}" failed'.format(wd), file=sys.stderr)
+        sys.exit(p.returncode)
 
 def update_libmesh(args):
     proj = args.proj
@@ -173,6 +174,15 @@ def prepare_obj_paths(proj, kind, name):
             }
     return None
 
+def in_moose_core(curr_path, depth=0):
+    maxdepth = 10
+    fpath = os.path.join(curr_path, 'framework/include/kernels/Kernel.h')
+    if os.path.exists(fpath):
+        return True
+    if depth < maxdepth:
+        return in_moose_core(os.path.join(curr_path, '..'), depth+1)
+    return False
+
 def find_app(proj_path, depth=0):
     fpath = os.path.join(proj_path, 'src/main.C')
     if not os.path.exists(fpath):
@@ -189,6 +199,7 @@ def find_app(proj_path, depth=0):
     proj_path = os.path.abspath(proj_path)
     if m is None:
         return None, None
+
     return m.group(1), proj_path
 
 def rename_internal(fname, objname):

--- a/bin/moose
+++ b/bin/moose
@@ -106,7 +106,7 @@ def register_object(proj, name):
     with open(appfile, 'r') as f:
         body = f.read()
 
-    body = r.sub(r'\g<1>    registerObject({});\n'.format(name), body)
+    body = r.sub(r'\g<1>  registerObject({});\n'.format(name), body)
 
     with open(appfile, 'w') as f:
         f.write(body)
@@ -117,7 +117,6 @@ def t_or_f(arg):
     if s in ('f', 'false', 'n', 'no'):
         return False
     return True
-
 
 if __name__ == '__main__':
     main()

--- a/bin/moose
+++ b/bin/moose
@@ -216,6 +216,9 @@ def register_object(proj, name):
     r = re.compile(r'(App::registerObjects\( *Factory.*\)\s*{[^\n]*\n)')
 
     appfile = os.path.join(proj['path'], 'src/base', proj['name']+'App.C')
+    if not os.path.exists(appfile):
+        print('app file "{}" not foundA)'.format(appfile), file=stderr)
+        sys.exit(1)
     with open(appfile, 'r') as f:
         body = f.read()
 

--- a/moose
+++ b/moose
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import re
+import argparse
+import os.path
+import shutil
+
+def prepare_obj_paths(proj, kind, name):
+    mpath, ppath = proj['moose_path'], proj['path']
+    if kind == 'Kernel':
+        return {
+            'template_h': os.path.join(mpath, 'templates/Kernel.h'),
+            'template_C': os.path.join(mpath, 'templates/Kernel.C'),
+            'dst_h': os.path.join(ppath, 'include/kernels/{}.h'.format(name)),
+            'dst_C': os.path.join(ppath, 'include/kernels/{}.C'.format(name)),
+            }
+    return None
+
+def main():
+    parser = argparse.ArgumentParser()
+    build_cmds(parser)
+    args = parser.parse_args()
+    args.func(args)
+
+def build_cmds(parser):
+    projinfo = {'path': './', 'name': 'Stork', 'moose_path': '../moose'}
+    subs = parser.add_subparsers()
+
+    sub = subs.add_parser('newobj', help='add and register a new moose object')
+    sub.add_argument('kind', type=str, help='superclass of object to create')
+    sub.add_argument('name', type=str, help='class name for new object')
+    sub.add_argument('--register', type=t_or_f, default=True, help='auto-generate the in-app registration line (default=True)')
+    sub.set_defaults(proj=projinfo, func=newobj)
+
+    sub = subs.add_parser('help')
+    sub.set_defaults(proj=projinfo, func=helpcmd)
+
+def helpcmd(args):
+    pass
+
+def rename_internal(fname, objname):
+    with open(fname, 'r') as f:
+        body = f.read()
+
+    body = body.replace('TmplKernel', objname)
+    body = body.replace('TMPLKERNEL', objname.upper())
+
+    with open(fname, 'w') as f:
+        f.write(body)
+
+def newobj(args):
+    proj, kind, name = args.proj, args.kind, args.name
+
+    path_info = prepare_obj_paths(proj, kind, name)
+    shutil.copyfile(path_info['template_h'], path_info['dst_h'])
+    shutil.copyfile(path_info['template_C'], path_info['dst_C'])
+    rename_internal(path_info['dst_h'], name)
+    rename_internal(path_info['dst_C'], name)
+
+    if args.register:
+        register_object(proj, name)
+
+def register_object(proj, name):
+    r = re.compile(r'(App::registerObjects\( *Factory.*\)\s*{[^\n]*\n)')
+
+    appfile = os.path.join(proj['path'], 'src/base', proj['name']+'App.C')
+    with open(appfile, 'r') as f:
+        body = f.read()
+
+    body = r.sub(r'\g<1>    registerObject({});\n'.format(name), body)
+
+    with open(appfile, 'w') as f:
+        f.write(body)
+
+# hack to get python's argparse to do something useful with boolean flags
+def t_or_f(arg):
+    s = str(arg).lower()
+    if s in ('f', 'false', 'n', 'no'):
+        return False
+    return True
+
+
+if __name__ == '__main__':
+    main()
+

--- a/templates/Kernel.C
+++ b/templates/Kernel.C
@@ -4,7 +4,7 @@
 template<>
 InputParameters validParams<TmplKernel>()
 {
-  InputParameters params = validParams<TmplKernel>();
+  InputParameters params = validParams<Kernel>();
   // add custom kernel parameters here
   return params;
 }

--- a/templates/Kernel.C
+++ b/templates/Kernel.C
@@ -28,5 +28,6 @@ TmplKernel::computeQpJacobian() {
 // implement these functions only if you have a particular need to:
 Real TmplKernel::computeQpOffDiagJacobian(unsigned int /*jvar*/) { return 0; }
 void TmplKernel::precalculateResidual() { }
-void precalculateJacobian() { }
-void precalculateOffDiagJacobian(unsigned int /* jvar */) { }
+void TmplKernel::precalculateJacobian() { }
+void TmplKernel::precalculateOffDiagJacobian(unsigned int /* jvar */) { }
+

--- a/templates/Kernel.C
+++ b/templates/Kernel.C
@@ -10,13 +10,14 @@ InputParameters validParams<TmplKernel>()
 }
 
 TmplKernel::TmplKernel(const InputParameters & parameters)
-    : TmplKernel(parameters)
+    : Kernel(parameters)
 {
 }
 
 Real
 TmplKernel::computeQpResidual() {
   // implement residual calculation here
+  return 0;
 }
 
 Real

--- a/templates/Kernel.C
+++ b/templates/Kernel.C
@@ -1,0 +1,32 @@
+
+#include "TmplKernel.h"
+
+template<>
+InputParameters validParams<TmplKernel>()
+{
+  InputParameters params = validParams<TmplKernel>();
+  // add custom kernel parameters here
+  return params;
+}
+
+TmplKernel::TmplKernel(const InputParameters & parameters)
+    : TmplKernel(parameters)
+{
+}
+
+Real
+TmplKernel::computeQpResidual() {
+  // implement residual calculation here
+}
+
+Real
+TmplKernel::computeQpJacobian() {
+  // optionally implement jacobian calculation here
+  return 0;
+}
+
+// implement these functions only if you have a particular need to:
+Real TmplKernel::computeQpOffDiagJacobian(unsigned int /*jvar*/) { return 0; }
+void TmplKernel::precalculateResidual() { }
+void precalculateJacobian() { }
+void precalculateOffDiagJacobian(unsigned int /* jvar */) { }

--- a/templates/Kernel.h
+++ b/templates/Kernel.h
@@ -1,0 +1,37 @@
+
+#ifndef TMPLKERNEL_H
+#define TMPLKERNEL_H
+
+#include "TmplKernel.h"
+
+class TmplKernel;
+
+template<>
+InputParameters validParams<TmplKernel>();
+
+class TmplKernel : public Kernel
+{
+public:
+  TmplKernel(const InputParameters & parameters);
+
+protected:
+
+  /// Compute this kernel's contribution to the residual at the current
+  /// quadrature point.
+  virtual Real computeQpResidual();
+
+  /// Compute this kernel's contribution to the Jacobian at the current
+  /// quadrature point.
+  virtual Real computeQpJacobian();
+
+  /// Implement if you need to compute an off-diagonal Jacobian component.
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
+  /// Following methods can be used by kernels that need to perform a
+  /// per-element calculation:
+  virtual void precalculateResidual();
+  virtual void precalculateJacobian();
+  virtual void precalculateOffDiagJacobian(unsigned int /* jvar */);
+};
+
+#endif

--- a/templates/Kernel.h
+++ b/templates/Kernel.h
@@ -2,7 +2,7 @@
 #ifndef TMPLKERNEL_H
 #define TMPLKERNEL_H
 
-#include "TmplKernel.h"
+#include "Kernel.h"
 
 class TmplKernel;
 


### PR DESCRIPTION
After attending the moose workshop, I decided it would be worth a bit of time to create a helper tool for users (and developers) to make it easier for people to learn and work with MOOSE.

usage:
```
[user@hose MyApp] $ moose -h
usage: moose [-h] {help,appinfo,newobj,libmesh,build} ...

positional arguments:
  {help,appinfo,newobj,libmesh,build}
    help                display help for subcomands
    appinfo             display local project info
    newobj              add and register a new moose object
    libmesh             perform libmesh-related tasks
    build               (re)build moose apps, libraries, modules, and tests

optional arguments:
  -h, --help            show this help message and exit
```

Add a new kernel to your project (files created, renamed, registered, etc.) starting from any directory within your project - it goes in the right place:
```
[user@hose MyApp/src] $ moose newobj Kernel MyFooKernel
[user@hose MyApp/src] $ git status
On branch master
Your branch is ahead of 'up/master' by 13 commits.
  (use "git push" to publish your local commits)
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   src/base/StorkApp.C

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	include/kernels/MyFooKernel.h
	src/kernels/MyFooKernel.C
	unit/include/base/

[user@hose MyApp/src] $ git diff
diff --git a/src/base/MyApp.C b/src/base/MyApp.C
index 51b46c5..d47dc38 100644
--- a/src/base/MyApp.C
+++ b/src/base/MyApp.C
@@ -1,3 +1,4 @@
+#include "MyFooKernel.h"
 #include "MyApp.h"
 #include "Moose.h"
 #include "AppFactory.h"
@@ -40,6 +41,7 @@ extern "C" void StorkApp__registerObjects(Factory & fact
 void
 StorkApp::registerObjects(Factory & factory)
 {
+  registerObject(MyFooKernel);
 }
```

Build your app (or moose framework) from anywhere within the project directory:

```
[user@hose MyApp/src] $ moose build # build the project binary
MOOSE Compiling C++ (in opt mode) /Users/user/MyApp/src/base/StorkApp.C...
MOOSE Compiling C++ (in opt mode) /Users/user/MyApp/src/kernels/MyFooKernel.C...
...
[user@hose MyApp] $ moose build --unit #or build your unit tests
...
```

Update libmesh:

```
[user@hose MyApp] $ moose libmesh update --clean # do a clean/full rebuild of libmesh
...
```

@aeslaughter's docs commands could easily be plumbed in as a ``moose docs`` subcommand.  I also think it would be valuable to have a ``moose init [appname]`` or ``moose newapp [appname]`` subcommand that automatically populates a directory full of makefiles, c++ files, etc. for a new moose app with the given name.  We would also need to add a test compile for the template files used for creating new object stubs.

Thoughts?