### PR TITLE
Fix building rdg when libmesh is configured with --with-dof-id-bytes=8

### DIFF
--- a/modules/rdg/include/userobjects/AEFVFreeOutflowBoundaryFlux.h
+++ b/modules/rdg/include/userobjects/AEFVFreeOutflowBoundaryFlux.h
@@ -29,13 +29,13 @@ public:
   virtual ~AEFVFreeOutflowBoundaryFlux();
 
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
+                        dof_id_type ielem,
                         const std::vector<Real> & uvec1,
                         const RealVectorValue & dwave,
                         std::vector<Real> & flux) const override;
 
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
+                            dof_id_type ielem,
                             const std::vector<Real> & uvec1,
                             const RealVectorValue & dwave,
                             DenseMatrix<Real> & jac1) const override;

--- a/modules/rdg/src/userobjects/AEFVFreeOutflowBoundaryFlux.C
+++ b/modules/rdg/src/userobjects/AEFVFreeOutflowBoundaryFlux.C
@@ -26,7 +26,7 @@ AEFVFreeOutflowBoundaryFlux::~AEFVFreeOutflowBoundaryFlux()
 
 void
 AEFVFreeOutflowBoundaryFlux::calcFlux(unsigned int /*iside*/,
-                                      unsigned int /*ielem*/,
+                                      dof_id_type /*ielem*/,
                                       const std::vector<Real> & uvec1,
                                       const RealVectorValue & dwave,
                                       std::vector<Real> & flux) const
@@ -45,7 +45,7 @@ AEFVFreeOutflowBoundaryFlux::calcFlux(unsigned int /*iside*/,
 
 void
 AEFVFreeOutflowBoundaryFlux::calcJacobian(unsigned int /*iside*/,
-                                          unsigned int /*ielem*/,
+                                          dof_id_type /*ielem*/,
                                           const std::vector<Real> & libmesh_dbg_var(uvec1),
                                           const RealVectorValue & /*dwave*/,
                                           DenseMatrix<Real> & /*jac1*/) const


### PR DESCRIPTION
Looks like #8250 broke this.

I have added the 64 bit moose job. It will still fail due to known problems with PETSc 3.7.4 but it will at least build and fail in the same way it used to.

