### PR TITLE
Fix building framework with 64 bit dofs

### DIFF
--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -51,8 +51,8 @@ MultiAppNearestNodeTransfer::MultiAppNearestNodeTransfer(const InputParameters &
     _neighbors_cached(declareRestartableData<bool>("neighbors_cached", false)),
     _cached_froms(declareRestartableData<std::vector< std::vector<unsigned int> > >("cached_froms")),
     _cached_dof_ids(declareRestartableData<std::vector< std::vector<dof_id_type> > >("cached_dof_ids")),
-    _cached_from_inds(declareRestartableData<std::map<unsigned int, unsigned int> >("cached_from_ids")),
-    _cached_qp_inds(declareRestartableData<std::map<unsigned int, unsigned int> >("cached_qp_inds"))
+    _cached_from_inds(declareRestartableData<std::map<dof_id_type, unsigned int> >("cached_from_ids")),
+    _cached_qp_inds(declareRestartableData<std::map<dof_id_type, unsigned int> >("cached_qp_inds"))
 {
   // This transfer does not work with DistributedMesh
   _displaced_source_mesh = getParam<bool>("displaced_source_mesh");


### PR DESCRIPTION
Currently the framework cannot be built with libmesh configured with `--with-dof-id-bytes=8`.
This was broken in #8258 

I have added the 64 bit moose job. It will still fail due to #8200 but it will at least build and fail in the same way it used to.