### PR TITLE
Quote group_name in YAML output.

### DIFF
--- a/framework/src/outputs/formatters/YAMLFormatter.C
+++ b/framework/src/outputs/formatters/YAMLFormatter.C
@@ -88,7 +88,10 @@ YAMLFormatter::printParams(const std::string &prefix, const std::string & /*full
     MooseUtils::escape(doc);
     // Print the type
     oss << "\n" << indent << "    cpp_type: " << params.type(iter.first)
-        << "\n" << indent << "    group_name: " << params.getGroupName(iter.first);
+        << "\n" << indent << "    group_name: ";
+    std::string group_name = params.getGroupName(iter.first);
+    if (!group_name.empty())
+        oss << "'" << group_name << "'";
 
     {
       InputParameters::Parameter<MooseEnum> * enum_type = dynamic_cast<InputParameters::Parameter<MooseEnum>*>(iter.second);


### PR DESCRIPTION
This just fixes the case of special characters in `group_name` in the YAML dump by quoting the entire group name.
Other fields in the YAML dump probably don't need to be quoted since special characters are probably not allowed (I hope). For example, the name of a parameter shouldn't be `Foo: bar`

We already use the "block style" for things like description where there might be special characters.

closes #8263