### PR TITLE
Drop LIBMESH_BEST_UNORDERED map usage

### DIFF
--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -35,6 +35,8 @@
 // libMesh includes
 #include "libmesh/enum_quadrature_type.h"
 
+#include <unordered_map>
+
 // Forward declarations
 class DisplacedProblem;
 class FEProblemBase;
@@ -1174,10 +1176,10 @@ protected:
   std::map<std::string, RandomData *> _random_data_objects;
 
   /// Cache for calculating materials on side
-  std::vector<LIBMESH_BEST_UNORDERED_MAP<SubdomainID, bool> > _block_mat_side_cache;
+  std::vector<std::unordered_map<SubdomainID, bool>> _block_mat_side_cache;
 
   /// Cache for calculating materials on side
-  std::vector<LIBMESH_BEST_UNORDERED_MAP<BoundaryID, bool> > _bnd_mat_side_cache;
+  std::vector<std::unordered_map<BoundaryID, bool>> _bnd_mat_side_cache;
 
   /// Objects to be notified when the mesh changes
   std::vector<MeshChangedInterface *> _notify_when_mesh_changes;

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -28,7 +28,6 @@
 #ifdef LIBMESH_HAVE_CXX11_TYPE_TRAITS
 #  include <type_traits>
 #endif
-#include LIBMESH_INCLUDE_UNORDERED_MAP
 
 // C++ includes
 #include <string>
@@ -36,6 +35,7 @@
 #include <list>
 #include <iostream>
 #include <map>
+#include <unordered_map>
 
 // Forward declarations
 class ColumnMajorMatrix;
@@ -87,7 +87,7 @@ inline void storeHelper(std::ostream & stream, std::map<P,Q> & data, void * cont
  * Unordered_map helper routine
  */
 template<typename P, typename Q>
-inline void storeHelper(std::ostream & stream, LIBMESH_BEST_UNORDERED_MAP<P,Q> & data, void * context);
+inline void storeHelper(std::ostream & stream, std::unordered_map<P,Q> & data, void * context);
 
 /**
  * HashMap helper routine
@@ -135,7 +135,7 @@ inline void loadHelper(std::istream & stream, std::map<P,Q> & data, void * conte
  * Unordered_map helper routine
  */
 template<typename P, typename Q>
-inline void loadHelper(std::istream & stream, LIBMESH_BEST_UNORDERED_MAP<P,Q> & data, void * context);
+inline void loadHelper(std::istream & stream, std::unordered_map<P,Q> & data, void * context);
 
 /**
  * Hashmap helper routine
@@ -269,14 +269,14 @@ dataStore(std::ostream & stream, std::map<T,U> & m, void * context)
 
 template<typename T, typename U>
 inline void
-dataStore(std::ostream & stream, LIBMESH_BEST_UNORDERED_MAP<T,U> & m, void * context)
+dataStore(std::ostream & stream, std::unordered_map<T,U> & m, void * context)
 {
   // First store the size of the map
   unsigned int size = m.size();
   stream.write((char *) &size, sizeof(size));
 
-  typename LIBMESH_BEST_UNORDERED_MAP<T,U>::iterator it = m.begin();
-  typename LIBMESH_BEST_UNORDERED_MAP<T,U>::iterator end = m.end();
+  typename std::unordered_map<T,U>::iterator it = m.begin();
+  typename std::unordered_map<T,U>::iterator end = m.end();
 
   for (; it != end; ++it)
   {
@@ -434,7 +434,7 @@ dataLoad(std::istream & stream, std::map<T,U> & m, void * context)
 
 template<typename T, typename U>
 inline void
-dataLoad(std::istream & stream, LIBMESH_BEST_UNORDERED_MAP<T,U> & m, void * context)
+dataLoad(std::istream & stream, std::unordered_map<T,U> & m, void * context)
 {
   m.clear();
 
@@ -538,7 +538,7 @@ storeHelper(std::ostream & stream, std::map<P,Q> & data, void * context)
 // Unordered_map Helper Function
 template<typename P, typename Q>
 inline void
-storeHelper(std::ostream & stream, LIBMESH_BEST_UNORDERED_MAP<P,Q> & data, void * context)
+storeHelper(std::ostream & stream, std::unordered_map<P,Q> & data, void * context)
 {
   dataStore(stream, data, context);
 }
@@ -602,7 +602,7 @@ loadHelper(std::istream & stream, std::map<P,Q> & data, void * context)
 // Unordered_map Helper Function
 template<typename P, typename Q>
 inline void
-loadHelper(std::istream & stream, LIBMESH_BEST_UNORDERED_MAP<P,Q> & data, void * context)
+loadHelper(std::istream & stream, std::unordered_map<P,Q> & data, void * context)
 {
   dataLoad(stream, data, context);
 }

--- a/framework/include/utils/HashMap.h
+++ b/framework/include/utils/HashMap.h
@@ -52,11 +52,10 @@ public:
 #else
 
 // Use a hash table
-#include "libmesh/libmesh_common.h"
-#include LIBMESH_INCLUDE_UNORDERED_MAP
+#include <unordered_map>
 
 template<typename Key, typename T> /*, typename Hash = std::tr1::hash<Key>, class Pred = std::equal_to<Key>, typename Allocator = std::allocator<std::pair<const Key,T> > >*/
-class HashMap : public LIBMESH_BEST_UNORDERED_MAP< Key, T > /*, Hash, Pred, Allocator >*/
+class HashMap : public std::unordered_map<Key, T> /*, Hash, Pred, Allocator >*/
 {
 
 #ifdef LIBMESH_HAVE_PTHREAD
@@ -66,7 +65,7 @@ public:
   {
     libMesh::Threads::spin_mutex::scoped_lock lock(spin_mutex);
 
-    return LIBMESH_BEST_UNORDERED_MAP< Key, T > /*, Hash, Pred, Allocator >*/::operator[](k);
+    return std::unordered_map<Key, T> /*, Hash, Pred, Allocator >*/::operator[](k);
   }
 
   inline bool contains(const Key & key)

--- a/framework/include/utils/MooseRandom.h
+++ b/framework/include/utils/MooseRandom.h
@@ -19,9 +19,7 @@
 #include "MooseError.h"
 #include "DataIO.h"
 
-// libMesh includes
-#include "libmesh/libmesh_config.h"
-#include LIBMESH_INCLUDE_UNORDERED_MAP
+#include <unordered_map>
 
 // External library includes
 #include "randistrs.h"
@@ -153,9 +151,11 @@ public:
    */
   void saveState()
   {
-    for (LIBMESH_BEST_UNORDERED_MAP<unsigned int, std::pair<mt_state, mt_state> >::iterator it = _states.begin();
-         it != _states.end(); ++it)
-      it->second.second = it->second.first;
+    std::for_each(_states.begin(), _states.end(),
+                  [](std::pair<const unsigned int, std::pair<mt_state, mt_state>> & pair)
+                    {
+                      pair.second.second = pair.second.first;
+                    });
   }
 
   /**
@@ -163,9 +163,11 @@ public:
    */
   void restoreState()
   {
-    for (LIBMESH_BEST_UNORDERED_MAP<unsigned int, std::pair<mt_state, mt_state> >::iterator it = _states.begin();
-         it != _states.end(); ++it)
-      it->second.first = it->second.second;
+    std::for_each(_states.begin(), _states.end(),
+                  [](std::pair<const unsigned int, std::pair<mt_state, mt_state>> & pair)
+                    {
+                      pair.second.first = pair.second.second;
+                    });
   }
 
 private:
@@ -175,7 +177,7 @@ private:
    * second is the backup state. It is used to restore state at a later time
    * to the active state.
    */
-  LIBMESH_BEST_UNORDERED_MAP<unsigned int, std::pair<mt_state, mt_state> > _states;
+  std::unordered_map<unsigned int, std::pair<mt_state, mt_state>> _states;
 
   // for restart capability
   friend void dataStore<MooseRandom>(std::ostream & stream, MooseRandom & v, void * context);

--- a/framework/include/utils/RandomData.h
+++ b/framework/include/utils/RandomData.h
@@ -19,8 +19,7 @@
 #include "MooseTypes.h"
 #include "MooseRandom.h"
 
-#include "libmesh/libmesh_config.h"
-#include LIBMESH_INCLUDE_UNORDERED_MAP
+#include <unordered_map>
 
 class FEProblemBase;
 class MooseMesh;
@@ -66,7 +65,7 @@ private:
   unsigned int _current_master_seed;
   unsigned int _new_seed;
 
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, unsigned int> _seeds;
+  std::unordered_map<dof_id_type, unsigned int> _seeds;
 };
 
 #endif //RANDOMDATA_H

--- a/modules/phase_field/include/userobjects/ConservedMaskedNoiseBase.h
+++ b/modules/phase_field/include/userobjects/ConservedMaskedNoiseBase.h
@@ -9,6 +9,8 @@
 
 #include "ConservedNoiseInterface.h"
 
+#include <unordered_map>
+
 //Forward Declarations
 class ConservedMaskedNoiseBase;
 
@@ -40,7 +42,7 @@ public:
   Real getQpValue(dof_id_type element_id, unsigned int qp) const;
 
 protected:
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::vector<std::pair<Real, Real> > > _random_data;
+  std::unordered_map<dof_id_type, std::vector<std::pair<Real, Real>>> _random_data;
 
   const MaterialProperty<Real> & _mask;
 };

--- a/modules/phase_field/include/userobjects/ConservedNoiseBase.h
+++ b/modules/phase_field/include/userobjects/ConservedNoiseBase.h
@@ -9,6 +9,8 @@
 
 #include "ConservedNoiseInterface.h"
 
+#include <unordered_map>
+
 //Forward Declarations
 class ConservedNoiseBase;
 
@@ -39,7 +41,7 @@ public:
   Real getQpValue(dof_id_type element_id, unsigned int qp) const;
 
 protected:
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::vector<Real> > _random_data;
+  std::unordered_map<dof_id_type, std::vector<Real>> _random_data;
 };
 
 #endif //CONSERVEDNOISEBASE_H

--- a/modules/phase_field/include/userobjects/DiscreteNucleationMap.h
+++ b/modules/phase_field/include/userobjects/DiscreteNucleationMap.h
@@ -64,7 +64,7 @@ protected:
 
   ///@{
   /// Per element list with 0/1 flags indicating the presence of a nucleus
-  typedef LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::vector<Real> > NucleusMap;
+  using NucleusMap = std::unordered_map<dof_id_type, std::vector<Real>>;
   NucleusMap _nucleus_map;
   ///@}
 };

--- a/modules/phase_field/src/userobjects/ConservedMaskedNoiseBase.C
+++ b/modules/phase_field/src/userobjects/ConservedMaskedNoiseBase.C
@@ -75,14 +75,13 @@ ConservedMaskedNoiseBase::finalize()
 Real
 ConservedMaskedNoiseBase::getQpValue(dof_id_type element_id, unsigned int qp) const
 {
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::vector<std::pair<Real, Real> > >::const_iterator me = _random_data.find(element_id);
+  const auto it_pair = _random_data.find(element_id);
 
-  if (me == _random_data.end())
+  if (it_pair == _random_data.end())
     mooseError("Element not found.");
   else
   {
-    libmesh_assert_less(qp, me->second.size());
-    return (me->second[qp].first - _offset) * me->second[qp].second;
+    libmesh_assert_less(qp, it_pair->second.size());
+    return (it_pair->second[qp].first - _offset) * it_pair->second[qp].second;
   }
 }
-

--- a/modules/phase_field/src/userobjects/ConservedNoiseBase.C
+++ b/modules/phase_field/src/userobjects/ConservedNoiseBase.C
@@ -71,14 +71,13 @@ ConservedNoiseBase::finalize()
 Real
 ConservedNoiseBase::getQpValue(dof_id_type element_id, unsigned int qp) const
 {
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::vector<Real> >::const_iterator me = _random_data.find(element_id);
+  const auto it_pair = _random_data.find(element_id);
 
-  if (me == _random_data.end())
+  if (it_pair == _random_data.end())
     mooseError("Element not found.");
   else
   {
-    libmesh_assert_less(qp, me->second.size());
-    return me->second[qp] - _offset;
+    libmesh_assert_less(qp, it_pair->second.size());
+    return it_pair->second[qp] - _offset;
   }
 }
-


### PR DESCRIPTION
This typedef is no longer required in MOOSE because we are C++11
closes #8269

Note: I added in the proper header includes in a few places where they were completely missing. We are getting lucky and picking up that header through other includes.
