### PR TITLE
Making the default CLI parameters apply to master apps only (no subs)

### DIFF
--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -205,22 +205,22 @@ CommandLine::haveVariable(const std::string & name, bool allow_prefix_change)
       _get_pot->set_prefix((_base_prefix + ":").c_str());
       if (_get_pot->have_variable(name))
         return true;
-    }
 
     /**
      * As a final attempt we'll see if the user has passed a global command line parameter
      * in the form ":name=value". Similarly to the normal subapp prefix, this will also
      * modify subsequent invocations to GetPot until resetPrefix() has been called.
      */
-    _get_pot->set_prefix(":");
-    if (_get_pot->have_variable(name))
-      return true;
-    else
+      _get_pot->set_prefix(":");
+      if (_get_pot->have_variable(name))
+        return true;
+
       /**
        * We failed to find the parameter with the subapp prefix (if applicable) or
-       * in the global section so we need to reset the prefix now back to nothing.
+       * in the global section so we need to reset the prefix back to the way it was.
        */
-      _get_pot->set_prefix("");
+      resetPrefix();
+    }
   }
 
   return false;

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -345,7 +345,7 @@ class TestHarness:
         # Part 1:
         part1_params = part1.parameters()
         part1_params['test_name'] += '_part1'
-        part1_params['cli_args'].append('--half-transient :Outputs/checkpoint=true')
+        part1_params['cli_args'].append('--half-transient Outputs/checkpoint=true')
         part1_params['skip_checks'] = True
 
         # Part 2:


### PR DESCRIPTION
refs #8296

Note: This PR changes existing behavior. CLI overrides no long apply to sub apps by default. Let's see if this destroys Yak! Instead one must use the "colon" syntax to apply CLI overrides to subapps.

@YaqiWang 