### PR TITLE
Fetch grain number in initialize

### DIFF
--- a/modules/phase_field/include/vectorpostprocessors/GrainForcesPostprocessor.h
+++ b/modules/phase_field/include/vectorpostprocessors/GrainForcesPostprocessor.h
@@ -27,7 +27,7 @@ public:
   GrainForcesPostprocessor(const InputParameters & parameters);
 
   virtual ~GrainForcesPostprocessor() {}
-  virtual void initialize() {};
+  virtual void initialize();
   virtual void execute();
 
 protected:

--- a/modules/phase_field/src/vectorpostprocessors/GrainForcesPostprocessor.C
+++ b/modules/phase_field/src/vectorpostprocessors/GrainForcesPostprocessor.C
@@ -4,11 +4,12 @@
 /*          All contents are licensed under LGPL V2.1           */
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
-#include "GrainForcesPostprocessor.h"
 #include "GrainForceAndTorqueInterface.h"
+#include "GrainForcesPostprocessor.h"
 
-template<>
-InputParameters validParams<GrainForcesPostprocessor>()
+template <>
+InputParameters
+validParams<GrainForcesPostprocessor>()
 {
   InputParameters params = validParams<VectorPostprocessor>();
   params.addClassDescription("Outputs the values from GrainForcesPostprocessor");
@@ -16,27 +17,35 @@ InputParameters validParams<GrainForcesPostprocessor>()
   return params;
 }
 
-GrainForcesPostprocessor::GrainForcesPostprocessor(const InputParameters & parameters) :
-    GeneralVectorPostprocessor(parameters),
+GrainForcesPostprocessor::GrainForcesPostprocessor(const InputParameters & parameters)
+  : GeneralVectorPostprocessor(parameters),
     _grain_force_torque_vector(declareVector("grain_force_torque_vector")),
     _grain_force_torque(getUserObject<GrainForceAndTorqueInterface>("grain_force")),
     _grain_forces(_grain_force_torque.getForceValues()),
     _grain_torques(_grain_force_torque.getTorqueValues()),
-    _grain_num(_grain_forces.size())
+    _grain_num(0)
 {
-  _grain_force_torque_vector.resize(_grain_num*12);
+}
+
+void
+GrainForcesPostprocessor::initialize()
+{
+  _grain_num = _grain_forces.size();
+
+  // for each grain a force and a torque vector with 3 components each are serialized into the output vector
+  _grain_force_torque_vector.resize(_grain_num * 2 * 3);
 }
 
 void
 GrainForcesPostprocessor::execute()
 {
-  for (unsigned int i=0; i< _grain_num; ++i)
+  for (unsigned int i = 0; i < _grain_num; ++i)
   {
-    _grain_force_torque_vector[12*i+0] = _grain_forces[i](0);
-    _grain_force_torque_vector[12*i+1] = _grain_forces[i](1);
-    _grain_force_torque_vector[12*i+2] = _grain_forces[i](2);
-    _grain_force_torque_vector[12*i+3] = _grain_torques[i](0);
-    _grain_force_torque_vector[12*i+4] = _grain_torques[i](1);
-    _grain_force_torque_vector[12*i+5] = _grain_torques[i](2);
+    _grain_force_torque_vector[6 * i + 0] = _grain_forces[i](0);
+    _grain_force_torque_vector[6 * i + 1] = _grain_forces[i](1);
+    _grain_force_torque_vector[6 * i + 2] = _grain_forces[i](2);
+    _grain_force_torque_vector[6 * i + 3] = _grain_torques[i](0);
+    _grain_force_torque_vector[6 * i + 4] = _grain_torques[i](1);
+    _grain_force_torque_vector[6 * i + 5] = _grain_torques[i](2);
   }
 }


### PR DESCRIPTION
Fixes empty force torque vector postprocessor output in the rigid body motion module.

Closes #8310