### PR TITLE
Allow colored messages inside of colored messages

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -142,4 +142,11 @@ void enableFPE(bool on = true);
 
 } // namespace Moose
 
+/**
+ * Global alias to Moose::out. This is here so that _console can be used anywhere
+ * throughout the framework (namely by the mooseWarning() macro). If there's a local
+ * object _console, that will be used, if not, we'll fall back to just using Moose::out.
+ */
+extern OStreamProxy & _console;
+
 #endif /* MOOSE_H */

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -42,10 +42,10 @@
   {                                                                                 \
     std::ostringstream _error_oss_;                                                 \
     _error_oss_ << "\n\n"                                                           \
-                << (Moose::_color_console ? XTERM_RED : "")                         \
+                << COLOR_RED                                                        \
                 << "\n\n*** ERROR ***\n"                                            \
                 << msg                                                              \
-                << (Moose::_color_console ? XTERM_DEFAULT : "")                     \
+                << COLOR_DEFAULT                                                    \
                 << "\n\n";                                                          \
     if (Moose::_throw_on_error)                                                     \
       throw std::runtime_error(_error_oss_.str());                                  \
@@ -82,12 +82,12 @@
     {                                                                               \
       std::ostringstream _assert_oss_;                                              \
       _assert_oss_                                                                  \
-        << (Moose::_color_console ? XTERM_RED : "")                                 \
+        << COLOR_RED                                                                \
         << "\n\nAssertion `" #asserted "' failed\n"                                 \
         << msg                                                                      \
         << "\nat "                                                                  \
         << __FILE__ << ", line " << __LINE__                                        \
-        << (Moose::_color_console ? XTERM_DEFAULT : "")                             \
+        << COLOR_DEFAULT                                                            \
         << std::endl;                                                               \
       if (Moose::_throw_on_error)                                                   \
         throw std::runtime_error(_assert_oss_.str());                               \
@@ -115,11 +115,11 @@
       std::ostringstream _warn_oss_;                                                \
                                                                                     \
       _warn_oss_                                                                    \
-        << (Moose::_color_console ? XTERM_YELLOW : "")                              \
+        << COLOR_YELLOW                                                             \
         << "\n\n*** Warning ***\n"                                                  \
         << msg                                                                      \
         << "\nat " << __FILE__ << ", line " << __LINE__                             \
-        << (Moose::_color_console ? XTERM_DEFAULT : "")                             \
+        << COLOR_DEFAULT                                                            \
         << "\n\n";                                                                  \
       if (Moose::_throw_on_error)                                                   \
         throw std::runtime_error(_warn_oss_.str());                                 \
@@ -136,11 +136,11 @@
       mooseDoOnce(                                                                  \
         {                                                                           \
           Moose::out                                                                \
-            << (Moose::_color_console ? XTERM_CYAN : "")                            \
+            << COLOR_CYAN                                                           \
             << "\n\n*** Info ***\n"                                                 \
             << msg                                                                  \
             << "\nat " << __FILE__ << ", line " << __LINE__                         \
-            << (Moose::_color_console ? XTERM_DEFAULT : "")                         \
+            << COLOR_DEFAULT                                                        \
             << "\n" << std::endl;                                                   \
         }                                                                           \
       );                                                                            \
@@ -154,7 +154,7 @@
     else                                                                                                    \
       mooseDoOnce(                                                                                          \
         Moose::out                                                                                          \
-          << (Moose::_color_console ? XTERM_YELLOW : "")                                                    \
+          << COLOR_YELLOW                                                                                   \
           << "*** Warning, This code is deprecated, and likely to be removed in future library versions!\n" \
           << msg << '\n'                                                                                    \
           << __FILE__ << ", line " << __LINE__ << ", compiled "                                             \
@@ -163,7 +163,7 @@
             print_trace(Moose::out);                                                                        \
           else                                                                                              \
             libMesh::write_traceout();                                                                      \
-          Moose::out << (Moose::_color_console ? XTERM_DEFAULT : "") << std::endl;                          \
+          Moose::out << COLOR_DEFAULT << std::endl;                                                         \
       );                                                                                                    \
    } while (0)
 

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -248,6 +248,23 @@ namespace MooseUtils
    * @param prefix The prefix to use for indenting
    * @param message The message that will be indented
    * @param color The color to apply to the prefix (default CYAN)
+   *
+   * Takes a message like the following and indents it with another color code (see below)
+   *
+   * Input messsage:
+   * COLOR_YELLOW
+   * *** Warning ***
+   * Something bad has happened and we want to draw attention to it with color
+   * COLOR_DEFAULT
+   *
+   * Output message:
+   * COLOR_CYAN sub_app: COLOR_YELLOW
+   * COLOR_CYAN sub_app: COLOR_YELLOW *** Warning ***
+   * COLOR_CYAN sub_app: COLOR_YELLOW Something bad has happened and we want to draw attention to it with color
+   * COLOR_DEFAULT
+   *
+   * Also handles single line color codes
+   * COLOR_CYAN sub_app: 0 Nonline |R| = COLOR_GREEN 1.0e-10 COLOR_DEFAULT
    */
   void indentMessage(const std::string & prefix, std::string & message, const char* color = COLOR_CYAN);
 

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -1195,3 +1195,5 @@ bool _deprecated_is_error = false;
 bool _throw_on_error = false;
 
 } // namespace Moose
+
+OStreamProxy & _console = Moose::out;

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -27,7 +27,7 @@
 
 OutputWarehouse::OutputWarehouse(MooseApp & app) :
     _app(app),
-    _buffer_action_console_outputs(true),
+    _buffer_action_console_outputs(false),
     _output_exec_flag(EXEC_CUSTOM),
     _force_output(false)
 {


### PR DESCRIPTION
This PR properly handles and formats *most* colored messages inside of colored messages. This occurs for instance when a warning messages are printed from a multiapp. There are two keys to making this work:

 1.  We need to be able to rely upon `_console` existing everywhere. This PR does this by adding a new global symbol by that name. This makes it possible to use _console from the mooseWarning() macro among others.

2. We need to not stomp on multi-line color codes common in error and warning messages. Extra logic to format multi-line color codes with the existing `indentMessage()` utility was added.