### PR TITLE
Only allow perf log control from the master app

### DIFF
--- a/test/tests/misc/check_error/multi_master.i
+++ b/test/tests/misc/check_error/multi_master.i
@@ -1,0 +1,58 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+  print_perf_log = true
+[]
+
+[MultiApps]
+  [./full_solve]
+    # not setting app_type to use the same app type of master, i.e. MooseTestApp
+    type = FullSolveMultiApp
+    execute_on = initial
+    positions = '0 0 0'
+    input_files = multi_sub.i
+  [../]
+[]

--- a/test/tests/misc/check_error/multi_sub.i
+++ b/test/tests/misc/check_error/multi_sub.i
@@ -1,0 +1,56 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./td]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+  dt = 0.01
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+
+  # We can't control perf log output from a subapp
+  print_perf_log = true
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -535,4 +535,11 @@
     input = wrong_displacement_order.i
     expect_err = "Error: mesh has SECOND order elements, so all displacement variables must be SECOND order."
   [../]
+
+  [./perf_log_control_from_multiapp_sub]
+    type = 'RunException'
+    input = 'multi_master.i'
+    expect_err = "Performance logging cannot currently be controlled from a Multiapp"
+    max_parallel = 1
+  [../]
 []

--- a/test/tests/multiapps/full_solve_multiapp/master.i
+++ b/test/tests/multiapps/full_solve_multiapp/master.i
@@ -44,6 +44,7 @@
 
 [Outputs]
   exodus = true
+  print_perf_log = true
 []
 
 [MultiApps]


### PR DESCRIPTION
closes #5377

Currently MOOSE only has a single perf_log. Putting in parameters to control it's output from subapps can conflict with options in the master. You can also easily get into scenarios where you end up with several copies of the perf_log.

I believe the best design with the current constraints is to simply not allow any perf_log control from the subapps.