### PR TITLE
Restrict test to only run on 32bit dof_indices

### DIFF
--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
@@ -57,6 +57,9 @@
     abs_zero = 3e-6
     max_parallel = 1
     superlu = true
+
+    # This test is unstable on PETSc 3.7.4 with 64bit indices enabled.
+    dof_id_bytes = 4
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'


### PR DESCRIPTION
refs #8200
