### PR TITLE
Making time_adaptive test more robust

### DIFF
--- a/framework/include/timesteppers/SolutionTimeAdaptiveDT.h
+++ b/framework/include/timesteppers/SolutionTimeAdaptiveDT.h
@@ -45,19 +45,19 @@ protected:
    * Multiplier specifying the direction the timestep is currently going.
    * Positive for up.  Negative for down.
    */
-  int _direction;
+  short _direction;
 
   /// Percentage to change the timestep by either way.
   Real _percent_change;
 
-  timeval _solve_start, _solve_end;
-
+  /// Ratios to control whether to increase or decrease the current timestep
   Real _older_sol_time_vs_dt, _old_sol_time_vs_dt, _sol_time_vs_dt;
 
+  /// Boolean to control whether a separate adapt log is written to a file
   bool _adapt_log;
 
+  /// The filehandle to hold the log
   std::ofstream _adaptive_log;
-
 };
 
 #endif /* SOLUTIONTIMEADAPTIVEDT_H */

--- a/test/tests/time_steppers/time_adaptive/time-adaptive.i
+++ b/test/tests/time_steppers/time_adaptive/time-adaptive.i
@@ -16,8 +16,6 @@
 []
 
 [Variables]
-  active = 'u'
-
   [./u]
     order = FIRST
     family = LAGRANGE
@@ -29,8 +27,6 @@
 []
 
 [Kernels]
-  active = 'td diff ffn'
-
   [./td]
     type = TimeDerivative
     variable = u
@@ -48,8 +44,6 @@
 []
 
 [BCs]
-  active = 'all'
-
   [./all]
     type = TEJumpBC
     variable = u
@@ -57,33 +51,25 @@
   [../]
 []
 
-[Postprocessors]
-  active = ''
-
-  [./dt]
-    type = TimestepSize
-  [../]
-[]
-
 [Executioner]
   type = Transient
+
   [./TimeStepper]
     type = SolutionTimeAdaptiveDT
-    dt = 0.15
+    dt = 0.5
   [../]
-
 
   # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   nl_abs_tol = 1e-15
-#  l_tol = 1e-5
 
   start_time = 0.0
   end_time = 5
   num_steps = 500000
 
-  dtmax = 0.25
+  dtmin = 0.4
+  dtmax = 0.9
 []
 
 [Outputs]


### PR DESCRIPTION
Also modernizing code in SolutionTimeAdaptive

closes #8318 

The real key here is that we needed to limit the minimum time step. That's done here. I also bumped the start and range of "dt"s allowed quite a bit to limit the number time steps taken.