### PR TITLE
Improve MooseDocs in support of applications

### DIFF
--- a/docs/templates/latex.tex
+++ b/docs/templates/latex.tex
@@ -1,7 +1,6 @@
 \documentclass[++fontsize++]{++documentclass++}
 \usepackage[paper=++paper++, top=++margin++, bottom=++margin++, left=++margin++, right=++margin++]{geometry}
 \usepackage[T1]{fontenc}
-\usepackage{cmbright}
 \catcode`\_=12
 
 \usepackage{hyperref}

--- a/docs/tests/bibtex/test_bibtex.py
+++ b/docs/tests/bibtex/test_bibtex.py
@@ -8,53 +8,28 @@ class TestBibtexExtension(MarkdownTestCase):
   """
   Tests that Bibtex is working correctly.
   """
-  def writeGoldFile(self, file_name, html_array):
+  def readGold(self, name):
     """
     The parsed markdown contains a path to ".../moose/docs/bib/moose.bib".
     This puts in the correct path after given the HTML that comes before
-    and after the string "/Users/<username>/<intermediate_directories>/moose",
-    and writes the appropriate gold file to compare the generated HTML.
+    and after the string "/Users/<username>/<intermediate_directories>/moose".
     """
-    RE = re.compile(r'.*?/moose')
-    dir_match = RE.search(os.getcwd())
-    gold_name = os.path.join(self._path, 'gold', file_name)
-    with open(gold_name,'w') as goldFile:
-      html = html_array[0] + dir_match.group(0) + html_array[1]
-      goldFile.write(html)
+
+    html = super(TestBibtexExtension, self).readGold(name)
+    repl = 'data-moose-bibfiles="[u\'{}\']"'.format(os.path.abspath(os.path.join(os.getcwd(), '..', '..', 'bib', 'moose.bib')))
+    html[0] = re.sub(r'data-moose-bibfiles=\"\[.*?\]\"', repl, html[0])
+    return html
+
 
   def testCite(self):
-    html_array = ['<p><a href="#testkey" data-moose-cite="\cite{testkey}">Smith and Doe (1980)</a>\\n<ol class="moose-bibliography" data-moose-bibfiles="[u\'',
-             '/docs/bib/moose.bib\']">\n' \
-             '<li name="testkey">Jane Smith and John Doe.\n' \
-             'A test citation without special characters for easy testing.\n' \
-             '<em>A Prestigous Journal</em>, 1980.</li>\n' \
-             '</ol>\n' \
-             '</p>\n']
-    self.writeGoldFile('test_cite.html',html_array)
     md = r'\cite{testkey}\n\bibliography{docs/bib/moose.bib}'
     self.assertConvert('test_cite.html', md)
 
   def testCitet(self):
-    html_array = ['<p><a href="#testkey" data-moose-cite="\citet{testkey}">Smith and Doe (1980)</a>\\n<ol class="moose-bibliography" data-moose-bibfiles="[u\'',
-             '/docs/bib/moose.bib\']">\n' \
-             '<li name="testkey">Jane Smith and John Doe.\n' \
-             'A test citation without special characters for easy testing.\n' \
-             '<em>A Prestigous Journal</em>, 1980.</li>\n' \
-             '</ol>\n' \
-             '</p>\n']
-    self.writeGoldFile('test_citet.html',html_array)
     md = r'\citet{testkey}\n\bibliography{docs/bib/moose.bib}'
     self.assertConvert('test_citet.html', md)
 
   def testCitep(self):
-    html_array = ['<p>(<a href="#testkey" data-moose-cite="\citep{testkey}">Smith and Doe, 1980</a>)\\n<ol class="moose-bibliography" data-moose-bibfiles="[u\'',
-             '/docs/bib/moose.bib\']">\n' \
-             '<li name="testkey">Jane Smith and John Doe.\n' \
-             'A test citation without special characters for easy testing.\n' \
-             '<em>A Prestigous Journal</em>, 1980.</li>\n' \
-             '</ol>\n' \
-             '</p>\n']
-    self.writeGoldFile('test_citep.html',html_array)
     md = r'\citep{testkey}\n\bibliography{docs/bib/moose.bib}'
     self.assertConvert('test_citep.html', md)
 

--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -228,6 +228,13 @@ def moosedocs():
   log.debug('Removing *.moose.svg files from {}'.format(os.getcwd()))
   purge(['svg'])
 
+  # Pull LFS image files
+  try:
+    subprocess.check_output(['git', 'lfs', 'pull'])
+  except subprocess.CalledProcessError:
+    print "ERROR: Unable to run 'git lfs', it is likely not installed but required for the MOOSE documentation system."
+    sys.exit(1)
+
   # Execute command
   cmd = options.pop('command')
   if cmd == 'test':

--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -238,17 +238,21 @@ def moosedocs():
   # Execute command
   cmd = options.pop('command')
   if cmd == 'test':
-    commands.test(**options)
+    retcode = commands.test(**options)
   elif cmd == 'check':
-    commands.check(**options)
+    retcode = commands.check(**options)
   elif cmd == 'generate':
-    commands.generate(**options)
+    retcode = commands.generate(**options)
   elif cmd == 'serve':
-    commands.serve(**options)
+    retcode = commands.serve(**options)
   elif cmd == 'build':
-    commands.build(**options)
+    retcode = commands.build(**options)
   elif cmd == 'latex':
-    commands.latex(**options)
+    retcode = commands.latex(**options)
+
+  # Check retcode
+  if retcode != 0:
+      return retcode
 
   # Display logging results
   warn, err = formatter.counts()

--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -141,7 +141,7 @@ class Builder(object):
       helper(os.path.join(from_dir, 'media'), os.path.join(self._site_dir, 'media'))
 
 
-def build(config_file='moosedocs.yml', disable_threads=False, **kwargs):
+def build_site(config_file='moosedocs.yml', disable_threads=False, **kwargs):
   """
   The main build command.
   """
@@ -159,3 +159,11 @@ def build(config_file='moosedocs.yml', disable_threads=False, **kwargs):
   # Create the html
   builder.build(disable_threads=disable_threads)
   return config, parser, builder
+
+
+def build(*args, **kwargs):
+  """
+  The main build command.
+  """
+  build_site(*args, **kwargs)
+  return 0 # error checking handled by MooseDocs.moosedocs

--- a/python/MooseDocs/commands/check.py
+++ b/python/MooseDocs/commands/check.py
@@ -16,3 +16,4 @@ def check(**kwargs):
   Performs checks for missing documentation.
   """
   MooseDocs.commands.generate(generate=False, **kwargs)
+  return 0 # error handled in MooseDocs.moosedocs

--- a/python/MooseDocs/commands/generate.py
+++ b/python/MooseDocs/commands/generate.py
@@ -42,3 +42,4 @@ def generate(config_file='moosedocs.yml', generate=True, locations=None, **kwarg
         syntax = MooseDocs.MooseApplicationSyntax(yaml, generate=generate, install=ext_config['install'], **value)
         log.info("Checking documentation for '{}'.".format(key))
         syntax.check()
+  return 0 # error handled in MooseDocs.moosedocs

--- a/python/MooseDocs/commands/latex.py
+++ b/python/MooseDocs/commands/latex.py
@@ -67,3 +67,4 @@ def latex(config_file=None, output=None, input=None, **kwargs):
   # Create PDF
   if output.endswith('.pdf'):
     html2latex.generate_pdf(tex_file, output)
+  return 0 # error check in MooseDocs.moosedocs

--- a/python/MooseDocs/commands/serve.py
+++ b/python/MooseDocs/commands/serve.py
@@ -43,7 +43,7 @@ def serve(config_file='moosedocs.yml', host='127.0.0.1', port='8000', disable_th
 
   # Wrapper for building complete website
   def build_complete():
-    return build.build(config_file=config_file, site_dir=tempdir, disable_threads=disable_threads)
+    return build.build_site(config_file=config_file, site_dir=tempdir, disable_threads=disable_threads)
   config, parser, builder = build_complete()
 
   # Start the live server
@@ -64,3 +64,4 @@ def serve(config_file='moosedocs.yml', host='127.0.0.1', port='8000', disable_th
 
   # Start the server
   server.serve(root=config['site_dir'], host=host, port=port, restart_delay=0)
+  return 0 # error handled in MooseDocs.moosedocs

--- a/python/MooseDocs/commands/test.py
+++ b/python/MooseDocs/commands/test.py
@@ -8,16 +8,19 @@ def test_options(parser, subparser):
   """
   test_parser = subparser.add_parser('test', help='Performs unitesting of MooseDocs module')
   test_parser.add_argument('--pattern', default='test*.py', help="The test name pattern to search.")
-  test_parser.add_argument('--start-dir', default='tests', help="The location of the tests directory.")
   return test_parser
 
 
-def test(pattern=None, start_dir=None, **kwargs):
+def test(pattern=None, **kwargs):
   """
   Runs MooseDocs unittests.
   """
-  os.chdir(start_dir)
-  loader = unittest.TestLoader()
-  suite = loader.discover(os.getcwd(), pattern)
-  runner = unittest.TextTestRunner(verbosity=2)
-  runner.run(suite)
+  if not os.path.exists('tests'):
+      print 'No {} directory located.'.format('tests')
+      return 0
+  else:
+      os.chdir('tests')
+      loader = unittest.TestLoader()
+      suite = loader.discover(os.getcwd(), pattern)
+      runner = unittest.TextTestRunner(verbosity=2)
+      runner.run(suite)

--- a/python/MooseDocs/commands/test.py
+++ b/python/MooseDocs/commands/test.py
@@ -23,4 +23,5 @@ def test(pattern=None, **kwargs):
       loader = unittest.TestLoader()
       suite = loader.discover(os.getcwd(), pattern)
       runner = unittest.TextTestRunner(verbosity=2)
-      runner.run(suite)
+      result = runner.run(suite)
+      return result.wasSuccessful()

--- a/python/MooseDocs/extensions/MooseSystemSyntax.py
+++ b/python/MooseDocs/extensions/MooseSystemSyntax.py
@@ -70,7 +70,7 @@ class MooseSystemSyntax(MooseSyntaxBase):
 
     node = self._yaml.find(sys_name)
     if not node:
-      return createErrorElement("The are not any sub-systems for the supplied syntax: {} You likely need to remove the '!subobjects' syntax.".format(sys_name))
+      return self.createErrorElement("The are not any sub-systems for the supplied syntax: {} You likely need to remove the '!subobjects' syntax.".format(sys_name))
 
     el = self.applyElementSettings(etree.Element('div'), settings)
     h2 = etree.SubElement(el, 'h2')

--- a/python/MooseDocs/testing.py
+++ b/python/MooseDocs/testing.py
@@ -5,13 +5,13 @@ import difflib
 import markdown
 import MooseDocs
 
-def text_diff(text, gold, gold_name):
+def text_diff(text, gold):
     """
     Helper for creating nicely formatted text diff message.
     """
     result = list(difflib.ndiff(gold, text))
     n =  len(max(result, key=len))
-    msg = "\nThe supplied text differs from the gold ({}) as follows:\n{}\n{}\n{}".format(gold_name, '~'*n, '\n'.join(result).encode('utf-8'), '~'*n)
+    msg = "\nThe supplied text differs from the gold as follows:\n{0}\n{1}\n{0}".format('~'*n, '\n'.join(result).encode('utf-8'))
     return msg
 
 class MarkdownTestCase(unittest.TestCase):
@@ -40,6 +40,16 @@ class MarkdownTestCase(unittest.TestCase):
     cls.parser = markdown.Markdown(extensions=extensions, extension_configs=extension_configs)
     os.chdir(cwd)
 
+  def readGold(self, name):
+    """
+    Read and return the contents of the gold file.
+    """
+    gold_name = os.path.join(os.path.dirname(name), 'gold', os.path.basename(name))
+    self.assertTrue(os.path.exists(gold_name), "Failed to locate gold file: {}".format(gold_name))
+    with open(gold_name) as fid:
+        gold = fid.read().encode('utf-8').splitlines()
+    return gold
+
   def assertTextFile(self, name):
     """
     Assert method for comparing converted html (text) against the text in gold file.
@@ -53,12 +63,8 @@ class MarkdownTestCase(unittest.TestCase):
         text = fid.read().encode('utf-8').splitlines()
 
     # Read gold file
-    gold_name = os.path.join(os.path.dirname(name), 'gold', os.path.basename(name))
-    self.assertTrue(os.path.exists(gold_name), "Failed to locate gold file: {}".format(gold_name))
-    with open(gold_name) as fid:
-      gold = fid.read().encode('utf-8').splitlines()
-
-    self.assertEqual(text, gold, text_diff(text, gold, gold_name))
+    gold = self.readGold(name)
+    self.assertEqual(text, gold, text_diff(text, gold))
 
   def assertConvert(self, name, md):
     """


### PR DESCRIPTION
* Allows `moosedocs.py test` to work in applications even when they don't have tests, which they probably won't.
* Re-factors the bibtex test to be simpler
* Adds a check that git lfs is installed and working
* Fixes the latex generation on linux


(refs #6699)