### PR TITLE
CappedWeakPlaneStress plasticity refactored

### DIFF
--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -130,20 +130,20 @@ public:
    * _vals[i][j] = R_ij * R_jl * _vals[k][l]
    * @param R rotation matrix as a RealTensorValue
    */
-  void rotate(RealTensorValue & R);
+  void rotate(const RealTensorValue & R);
 
   /**
    * rotates the tensor data given a rank two tensor rotation tensor
    * _vals[i][j] = R_ij * R_jl * _vals[k][l]
    * @param R rotation matrix as a RankTwoTensor
    */
-  void rotate(RankTwoTensor & R);
+  void rotate(const RankTwoTensor & R);
 
   /**
    * rotates the tensor data anticlockwise around the z-axis
    * @param a angle in radians
    */
-  RankTwoTensor rotateXyPlane(const Real a);
+  RankTwoTensor rotateXyPlane(Real a);
 
   /**
    * Returns a matrix that is the transpose of the matrix this

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -203,7 +203,7 @@ RankTwoTensor::column(const unsigned int c) const
 }
 
 void
-RankTwoTensor::rotate(RealTensorValue & R)
+RankTwoTensor::rotate(const RealTensorValue & R)
 {
   RankTwoTensor temp;
   for (unsigned int i = 0; i < N; i++)
@@ -219,7 +219,7 @@ RankTwoTensor::rotate(RealTensorValue & R)
 }
 
 void
-RankTwoTensor::rotate(RankTwoTensor & R)
+RankTwoTensor::rotate(const RankTwoTensor & R)
 {
   RankTwoTensor temp;
   for (unsigned int i = 0; i < N; i++)

--- a/modules/tensor_mechanics/include/materials/ComputeCappedWeakPlaneStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCappedWeakPlaneStress.h
@@ -7,7 +7,7 @@
 #ifndef COMPUTECAPPEDWEAKPLANESTRESS_H
 #define COMPUTECAPPEDWEAKPLANESTRESS_H
 
-#include "ComputeStressBase.h"
+#include "PQPlasticModel.h"
 #include "TensorMechanicsHardeningModel.h"
 
 #include <array>
@@ -22,35 +22,17 @@ InputParameters validParams<ComputeCappedWeakPlaneStress>();
  * algorithm and associated stress updates for plastic
  * models that describe capped weak-plane plasticity
  *
- * It assumes various things about the elasticity tensor.
+ * It assumes various things about the elasticity tensor, viz
  * E(i,i,j,k) = 0 except if k=j
  * E(0,0,i,j) = E(1,1,i,j)
  */
 class ComputeCappedWeakPlaneStress :
-  public ComputeStressBase
+  public PQPlasticModel
 {
 public:
   ComputeCappedWeakPlaneStress(const InputParameters & parameters);
 
 protected:
-  virtual void computeQpStress() override;
-  virtual void initQpStatefulProperties() override;
-
-  /// Number of variables = 2 = (p, q)
-  constexpr static int _num_pq = 2;
-
-  /// Number of yield functions
-  constexpr static unsigned _num_yf = 3;
-
-  /// Number of internal parameters
-  constexpr static unsigned _num_intnl = 2;
-
-  /// Number of equations in the Return-map Newton-Raphson
-  constexpr static int _num_rhs = 3;
-
-  /// Internal dimensionality of tensors (currently this is 3 throughout tensor_mechanics)
-  constexpr static unsigned _tensor_dimensionality = 3;
-
   /// Hardening model for cohesion
   const TensorMechanicsHardeningModel & _cohesion;
 
@@ -69,30 +51,11 @@ protected:
   /// The cone vertex is smoothed by this amount
   const Real _small_smoother2;
 
-  /// Maximum number of Newton-Raphson iterations allowed in the return-map process
-  const unsigned _max_nr_its;
-
-  /// Whether to perform finite-strain rotations
-  const bool _perform_finite_strain_rotations;
-
-  /// Smoothing tolerance: edges of the yield surface get smoothed by this amount
-  const Real _smoothing_tol;
-
-  /// The yield-function tolerance
-  const Real _f_tol;
-
-  /// Square of the yield-function tolerance
-  const Real _f_tol2;
-
-  /// The type of tangent operator to return.  tangent operator = d(stress_rate)/d(strain_rate).
-  enum class TangentOperatorEnum {
-    elastic, nonlinear
-  } _tangent_operator_type;
-
   /// Initialise the NR proceedure from a guess coming from perfect plasticity
   const bool _perfect_guess;
 
-  /** This allows some simplification in the return-map process.
+  /**
+   * This allows some simplification in the return-map process.
    * If the tensile yield function yf[1] >= 0 at the trial stress then
    * clearly the quadpoint is not going to fail in compression, so
    * _stress_return_type is set to no_compression, and every time
@@ -108,270 +71,46 @@ protected:
     nothing_special, no_compression, no_tension
   } _stress_return_type;
 
-  /** In order to help the Newton-Raphson procedure, the applied
-   * strain increment may be applied in sub-increments of size
-   * greater than this value.
-   */
-  const Real _min_step_size;
+  /// trial value of stress(2, 0)
+  Real _in_trial20;
 
-  /// handles case of initial_stress that is inadmissible being supplied
-  bool _step_one;
+  /// trial value of stress(2, 1)
+  Real _in_trial21;
 
-  /// Output a warning message if precision loss is encountered during the return-map process
-  const bool _warn_about_precision_loss;
+  /// trial value of q
+  Real _in_q_trial;
 
+  virtual void yieldFunctionValues(Real p, Real q, const std::vector<Real> & intnl, std::vector<Real> & yf) const override;
 
-  /// plastic strain
-  MaterialProperty<RankTwoTensor> & _plastic_strain;
+  virtual void computeAllQ(Real p, Real q, const std::vector<Real> & intnl, std::vector<f_and_derivs> & all_q) const override;
 
-  /// Old value of plastic strain
-  MaterialProperty<RankTwoTensor> & _plastic_strain_old;
+  virtual void consistentTangentOperator(const RankTwoTensor & stress_trial, Real p_trial, Real q_trial, const RankTwoTensor & stress, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q, RankFourTensor & cto) const override;
 
-  /// internal parameters.  intnl[0] = shear.  intnl[1] = tensile.
-  MaterialProperty<std::vector<Real> > & _intnl;
+  virtual void setStressAfterReturn(const RankTwoTensor & stress_trial, Real p_ok, Real q_ok, Real gaE, const std::vector<Real> & intnl, const f_and_derivs & smoothed_q, RankTwoTensor & stress) const override;
 
-  /// old values of internal parameters
-  MaterialProperty<std::vector<Real> > & _intnl_old;
+  virtual void preReturnMap(Real p_trial, Real q_trial, const RankTwoTensor & stress_trial, const std::vector<Real> & intnl_old, const std::vector<Real> & yf) override;
 
-  /// yield functions
-  MaterialProperty<std::vector<Real> > & _yf;
+  virtual void initialiseVars(Real p_trial, Real q_trial, const std::vector<Real> & intnl_old, Real & p, Real & q, Real & gaE, std::vector<Real> & intnl) const override;
 
-  /// Number of Newton-Raphson iterations used in the return-map
-  MaterialProperty<Real> & _iter;
+  virtual void setIntnlValues(Real p_trial, Real q_trial, Real p, Real q, const std::vector<Real> & intnl_old, std::vector<Real> & intnl) const override;
 
-  /// Whether a line-search was needed in the latest Newton-Raphson process (1 if true, 0 otherwise)
-  MaterialProperty<Real> & _linesearch_needed;
+  virtual void setIntnlDerivatives(Real p_trial, Real q_trial, Real p, Real q, const std::vector<Real> & intnl, std::vector<std::vector<Real> > & dintnl) const override;
 
-  /// strain increment (coming from ComputeIncrementalSmallStrain, for example)
-  const MaterialProperty<RankTwoTensor> & _strain_increment;
+  virtual void computePQ(const RankTwoTensor & stress, Real & p, Real & q) const override;
 
-  /// Rotation increment (coming from ComputeIncrementalSmallStrain, for example)
-  const MaterialProperty<RankTwoTensor> & _rotation_increment;
+  virtual void initialiseReturnProcess() override;
 
-  /// Old value of stress
-  MaterialProperty<RankTwoTensor> & _stress_old;
+  virtual void finaliseReturnProcess() override;
 
-  /// Old value of elastic strain
-  MaterialProperty<RankTwoTensor> & _elastic_strain_old;
+  virtual void setEppEqq(const RankFourTensor & Eijkl, Real & Epp, Real & Eqq) const override;
 
-  /** Computes the values of the yield functions, given stress and intnl
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   * @param[out] yf The yield function values (yf[0] = shear, yf[1] = tensile, yf[2] = compressive)
-   */
-  virtual void unsmoothedYieldFunctions(Real p, Real q, const std::vector<Real> & intnl, std::vector<Real> & yf) const;
+  virtual RankTwoTensor dpdstress(const RankTwoTensor & stress) const override;
 
-  /** Computes the values of the yield functions, given stress and intnl, and puts them into _all_q
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   */
-  virtual void unsmoothedYieldFunctions(Real p, Real q, const std::vector<Real> & intnl);
+  virtual RankFourTensor d2pdstress2(const RankTwoTensor & stress) const override;
 
-  /** Computes d(yieldFunctions)/d(p, q), and puts them into _all_q
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   */
-  virtual void dyieldFunctions(Real p, Real q, const std::vector<Real> & intnl);
+  virtual RankTwoTensor dqdstress(const RankTwoTensor & stress) const override;
 
-  /** Computes d(yieldFunctions)/d(intnl), and puts them into _all_q
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   */
-  virtual void dyieldFunctions_di(Real p, Real q, const std::vector<Real> & intnl);
-
-  /** Computes d(flowPotential)/d(p, q), and puts them into _all_q
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   */
-  virtual void dflowPotential(Real p, Real q, const std::vector<Real> & intnl);
-
-  /** Computes d2(flowPotential)/d(p, q)/d(p, q), and puts them into _all_q
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   */
-  virtual void d2flowPotential(Real p, Real q, const std::vector<Real> & intnl);
-
-  /** Computes d2(flowPotential)/d(p, q)/dintnl, and puts them into _all_q
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   */
-  virtual void d2flowPotential_di(Real p, Real q, const std::vector<Real> & intnl);
-
-  /** Computes the smoothed yield function
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   * @return The smoothed yield function value
-   */
-  virtual Real yieldF(Real p, Real q, const std::vector<Real> & intnl) const;
-
-  /** Smooths yield functions
-   */
-  Real ismoother(Real f_diff) const;
-
-  /** Derivative of ismoother
-   */
-  Real smoother(Real f_diff) const;
-
-  /** Derivative of smoother
-   */
-  Real dsmoother(Real f_diff) const;
-
-  /** Performs the return-map algorithm
-   */
-  virtual void returnMap();
-
-  struct f_and_derivs
-  {
-    Real f;
-    std::vector<Real> df;
-    std::vector<Real> df_di;
-    std::vector<Real> dg;
-    std::vector<std::vector<Real> > d2g;
-    std::vector<std::vector<Real> > d2g_di;
-
-    f_and_derivs(): f_and_derivs(0, 0)
-    {}
-
-    f_and_derivs(unsigned num_var, unsigned num_intnl):
-      f(0.0),
-      df(num_var),
-      df_di(num_intnl),
-      dg(num_var),
-      d2g(num_var),
-      d2g_di(num_var)
-    {
-      for (unsigned i = 0; i < num_var; ++i)
-      {
-        d2g[i].assign(num_var, 0.0);
-        d2g_di[i].assign(num_intnl, 0.0);
-      }
-    }
-
-    bool operator < (const f_and_derivs & fd) const
-    {
-      return f < fd.f;
-    }
-  };
-
-  /** Calculates _all_q, and then performs the smoothing scheme
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl Internal parameters
-   * @return The smoothed yield function and derivatives
-   */
-  f_and_derivs smoothAllQuantities(Real p, Real q, const std::vector<Real> & intnl);
-
-  /** Calculates _dp_dpt, _dp_dqt, etc for the (sub)strain increment
-   * @param elastic_only whether this was an elastic step: if so then the updates to _dp_dpt, etc are fairly trivial
-   * @param q the returned value of q for this (sub)strain increment
-   * @param q_trial the trial value of q for this (sub)strain increment
-   * @param gaE the value of gaE that came from this (sub)strain increment
-   * @param smoothed_q contains the yield function and derivatives evaluated at (p, q)
-   * @param step_size size of this (sub)strain increment
-   */
-  void dVardTrial(bool elastic_only, Real q, Real q_trial, Real gaE, const f_and_derivs & smoothed_q, Real step_size);
-
-  /** Calculates the consistent tangent operator, _Jacobian_mult
-   * @param q returned value of q after all Newton-Raphson has completed
-   * @param q_trial the trial value of q for this strain increment
-   * @param trial20 the trial value of stress_zx for this strain increment
-   * @param trial21 the trial value of stress_zy for this strain increment
-   * @param gaE the total value of that came from this strain increment
-   * @param smoothed_q contains the yield function and derivatives evaluated at (p, q)
-   */
-  void consistentTangentOperator(Real q, Real q_trial, Real trial20, Real trial21, Real gaE, const f_and_derivs & smoothed_q);
-
-  /** Performs a line-search to find (p, q)
-   * Upon entry, this assumes that _rhs contains the Newton-Raphson full step (ie nrStep should have been called)
-   * Upon exit, _rhs will contain the updated _rhs values ready for the next Newton-Raphson step,
-   * Also _all_q and _intnl will be calculated at the new (p, q)
-   * @param res2 the residual-squared, both as an input and output
-   * @param gaE Upon input the value of gaE predicted from Newton Raphson.  Upon exit this will hold the value coming from the line-search
-   * @param p Upon input the value of p predicted from Newton Raphson.  Upon exit this will be p coming from the line-search
-   * @param q Upon input the value of q predicted from Newton Raphson.  Upon exit this will be q coming from the line-search
-   * @param p_trial Trial value of p for this (sub)strain increment
-   * @param q_trial Trial value of q for this (sub)strain increment
-   * @param smoothed_q Upon input, the value of the smoothed yield function and derivatives at the prior-to-Newton configuration.  Upon exit this is evaluated at the new (p, q, intnl)
-   * @param intnl_ok The value of _intnl from either the start of this (sub)strain increment
-   */
-  int lineSearch(Real & res2, Real & gaE, Real & p, Real & q, Real q_trial, Real p_trial, f_and_derivs & smoothed_q, const std::array<Real, 2> intnl_ok);
-
-  /** Performs a Newton-Raphson step to zero _rhs
-   * Upon return, _rhs will contain the solution.
-   * @param smoothed_q The value of the smoothed yield function and derivatives prior to this Newton-Raphson step
-   * @param q_trial The trial value of q for this (sub)strain increment
-   * @param q The current value of q during the Newton-Raphson process
-   * @param gaE The current value of ga during the Newton-Raphson process
-   */
-  int nrStep(const f_and_derivs & smoothed_q, Real q_trial, Real q, Real gaE);
-
-  /** Calculates _rhs
-   * 0 = _rhs[0] = f(p, q, intnl) = yield function
-   * 0 = _rhs[1] = p - p_trial + Ezzzz * ga * dg/dp = normality in p direction
-   * 0 = _rhs[2] = q - q_trial + Ezxzx * ga * dg/dq = normality in q direction
-   * @param p_trial The trial value of p for this (sub)strain increment
-   * @param q_trial The trial value of q for this (sub)strain increment
-   * @param p The current value of p during the Newton-Raphson process
-   * @param q The current value of q during the Newton-Raphson process
-   * @param gaE The current value of ga during the Newton-Raphson process
-   * @param smoothed_q Holds the current value of yield function and derivatives evaluated at (p, q, _intnl)
-   */
-  Real calculateRHS(Real p_trial, Real q_trial, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q);
-
-  /** Initialises (p, q, gaE) depending on _perfect_guess.
-   * If _perfect_guess=false then p=p_trial, q=q_trial, gaE=0,
-   * otherwise perfect plasticity (with no smoothing) is used to find a good initialisation
-   * @param p_trial The trial value of p for this (sub)strain increment
-   * @param q_trial The trial value of q for this (sub)strain increment
-   * @param p The initialised value of p
-   * @param q The initialised value of q
-   * @param gaE The initialised value of gaE
-   */
-  void initialiseVars(Real p_trial, Real q_trial, Real & p, Real & q, Real & gaE);
-
-  /**
-   * Performs any necessary cleaning-up, then throw MooseException(message)
-   * @param message The message to using in MooseException
-   */
-  virtual void errorHandler(const std::string & message);
-
-private:
-  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
-  Real _dgaE_dpt;
-  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
-  Real _dp_dpt;
-  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
-  Real _dq_dpt;
-  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
-  Real _dgaE_dqt;
-  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
-  Real _dp_dqt;
-  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
-  Real _dq_dqt;
-
-  /** A Newton-Raphson-with-linesearch is used for the return-map
-   * process.  Three equations must be solved:
-   * 0 = _rhs[0] = f(p, q, intnl) = yield function
-   * 0 = _rhs[1] = p - p_trial + Ezzzz * ga * dg/dp = normality in p direction
-   * 0 = _rhs[2] = q - q_trial + Ezxzx * ga * dg/dq = normality in q direction
-   * Not only does _rhs hold the current value of the right-hand-side
-   * in these equations, but the PETSc-LAPACK gesv routine puts the
-   * changes of the variables into the _rhs too
-   */
-  std::array<Real, _num_rhs> _rhs;
-
-  /** Holds the yield function, derivatives and flow information for the
-   * three yield functions of this model
-   */
-  std::vector<f_and_derivs> _all_q;
+  virtual RankFourTensor d2qdstress2(const RankTwoTensor & stress) const override;
 };
 
 #endif //COMPUTECAPPEDWEAKPLANESTRESS_H

--- a/modules/tensor_mechanics/include/materials/PQPlasticModel.h
+++ b/modules/tensor_mechanics/include/materials/PQPlasticModel.h
@@ -1,0 +1,495 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef PQPLASTICMODEL_H
+#define PQPLASTICMODEL_H
+
+#include "ComputeStressBase.h"
+
+#include <array>
+
+class PQPlasticModel;
+
+template<>
+InputParameters validParams<PQPlasticModel>();
+
+/**
+ * PQPlasticModel performs the return-map
+ * algorithm and associated stress updates for plastic
+ * models that describe (p, q) plasticity.  That is,
+ * for plastic models where the yield function and flow
+ * directions only depend on two parameters, p and q, that
+ * are themselves functions of stress
+ */
+class PQPlasticModel :
+  public ComputeStressBase
+{
+public:
+  PQPlasticModel(const InputParameters & parameters, unsigned num_yf, unsigned num_intnl);
+
+protected:
+  virtual void computeQpStress() override;
+  virtual void initQpStatefulProperties() override;
+
+  /// Number of variables = 2 = (p, q)
+  constexpr static int _num_pq = 2;
+
+  /// Number of equations in the Return-map Newton-Raphson
+  constexpr static int _num_rhs = 3;
+
+  /// Internal dimensionality of tensors (currently this is 3 throughout tensor_mechanics)
+  constexpr static unsigned _tensor_dimensionality = 3;
+
+  /// Number of yield functions
+  const unsigned _num_yf;
+
+  /// Number of internal parameters
+  const unsigned _num_intnl;
+
+  /// Maximum number of Newton-Raphson iterations allowed in the return-map process
+  const unsigned _max_nr_its;
+
+  /// Whether to perform finite-strain rotations
+  const bool _perform_finite_strain_rotations;
+
+  /// Smoothing tolerance: edges of the yield surface get smoothed by this amount
+  const Real _smoothing_tol;
+
+  /// The yield-function tolerance
+  const Real _f_tol;
+
+  /// Square of the yield-function tolerance
+  const Real _f_tol2;
+
+  /// The type of tangent operator to return.  tangent operator = d(stress_rate)/d(strain_rate).
+  enum class TangentOperatorEnum {
+    elastic, nonlinear
+  } _tangent_operator_type;
+
+  /**
+   * In order to help the Newton-Raphson procedure, the applied
+   * strain increment may be applied in sub-increments of size
+   * greater than this value.
+   */
+  const Real _min_step_size;
+
+  /// handles case of initial_stress that is inadmissible being supplied
+  bool _step_one;
+
+  /// Output a warning message if precision loss is encountered during the return-map process
+  const bool _warn_about_precision_loss;
+
+  /// plastic strain
+  MaterialProperty<RankTwoTensor> & _plastic_strain;
+
+  /// Old value of plastic strain
+  MaterialProperty<RankTwoTensor> & _plastic_strain_old;
+
+  /// internal parameters.  intnl[0] = shear.  intnl[1] = tensile.
+  MaterialProperty<std::vector<Real> > & _intnl;
+
+  /// old values of internal parameters
+  MaterialProperty<std::vector<Real> > & _intnl_old;
+
+  /// yield functions
+  MaterialProperty<std::vector<Real> > & _yf;
+
+  /// Number of Newton-Raphson iterations used in the return-map
+  MaterialProperty<Real> & _iter;
+
+  /// Whether a line-search was needed in the latest Newton-Raphson process (1 if true, 0 otherwise)
+  MaterialProperty<Real> & _linesearch_needed;
+
+  /// strain increment (coming from ComputeIncrementalSmallStrain, for example)
+  const MaterialProperty<RankTwoTensor> & _strain_increment;
+
+  /// Rotation increment (coming from ComputeIncrementalSmallStrain, for example)
+  const MaterialProperty<RankTwoTensor> & _rotation_increment;
+
+  /// Old value of stress
+  MaterialProperty<RankTwoTensor> & _stress_old;
+
+  /// Old value of elastic strain
+  MaterialProperty<RankTwoTensor> & _elastic_strain_old;
+
+  /// Trial value of p
+  Real _p_trial;
+
+  /// Trial value of q
+  Real _q_trial;
+
+  /// State at (p_ok, q_ok, _intnl_ok) is known to be admissible
+  std::vector<Real> _intnl_ok;
+
+  /// _dintnl[i][j] = d(intnl[i])/d(variable j), where variable0=p and variable1=q
+  std::vector<std::vector<Real> > _dintnl;
+
+  /// elasticity tensor in p direction
+  Real _Epp;
+
+  /// elasticity tensor in q direction
+  Real _Eqq;
+
+  struct f_and_derivs
+  {
+    Real f;
+    std::vector<Real> df;
+    std::vector<Real> df_di;
+    std::vector<Real> dg;
+    std::vector<std::vector<Real> > d2g;
+    std::vector<std::vector<Real> > d2g_di;
+
+    f_and_derivs(): f_and_derivs(0, 0)
+    {}
+
+    f_and_derivs(unsigned num_var, unsigned num_intnl):
+      f(0.0),
+      df(num_var),
+      df_di(num_intnl),
+      dg(num_var),
+      d2g(num_var),
+      d2g_di(num_var)
+    {
+      for (unsigned i = 0; i < num_var; ++i)
+      {
+        d2g[i].assign(num_var, 0.0);
+        d2g_di[i].assign(num_intnl, 0.0);
+      }
+    }
+
+    bool operator < (const f_and_derivs & fd) const
+    {
+      return f < fd.f;
+    }
+  };
+
+  /**
+   * Computes the smoothed yield function
+   * @param p stress_zz
+   * @param q sqrt(stress_zx^2 + stress_zy^2)
+   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
+   * @return The smoothed yield function value
+   */
+  Real yieldF(Real p, Real q, const std::vector<Real> & intnl) const;
+
+  /**
+   * Smooths yield functions
+   */
+  Real ismoother(Real f_diff) const;
+
+  /**
+   * Derivative of ismoother
+   */
+  Real smoother(Real f_diff) const;
+
+  /**
+   * Derivative of smoother
+   */
+  Real dsmoother(Real f_diff) const;
+
+  /**
+   * Performs the return-map algorithm
+   */
+  void returnMap();
+
+  /**
+   * Calculates _all_q, and then performs the smoothing scheme
+   * @param p stress_zz
+   * @param q sqrt(stress_zx^2 + stress_zy^2)
+   * @param intnl Internal parameters
+   * @return The smoothed yield function and derivatives
+   */
+  f_and_derivs smoothAllQuantities(Real p, Real q, const std::vector<Real> & intnl);
+
+  /**
+   * Calculates _dp_dpt, _dp_dqt, etc for the (sub)strain increment
+   * @param elastic_only whether this was an elastic step: if so then the updates to _dp_dpt, etc are fairly trivial
+   * @param p_trial the trial value of p for this (sub)strain increment
+   * @param q_trial the trial value of q for this (sub)strain increment
+   * @param p the returned value of p for this (sub)strain increment
+   * @param q the returned value of q for this (sub)strain increment
+   * @param gaE the value of gaE that came from this (sub)strain increment
+   * @param intnl the value of the internal parameters at the returned position
+   * @param smoothed_q contains the yield function and derivatives evaluated at (p, q)
+   * @param step_size size of this (sub)strain increment
+   */
+  void dVardTrial(bool elastic_only, Real p_trial, Real q_trial, Real p, Real q, Real gaE, const std::vector<Real> & intnl, const f_and_derivs & smoothed_q, Real step_size);
+
+  /**
+   * Performs a line-search to find (p, q)
+   * Upon entry, this assumes that _rhs contains the Newton-Raphson full step (ie nrStep should have been called)
+   * Upon exit, _rhs will contain the updated _rhs values ready for the next Newton-Raphson step,
+   * Also _all_q and _intnl will be calculated at the new (p, q)
+   * @param res2 the residual-squared, both as an input and output
+   * @param gaE Upon input the value of gaE predicted from Newton Raphson.  Upon exit this will hold the value coming from the line-search
+   * @param p Upon input the value of p predicted from Newton Raphson.  Upon exit this will be p coming from the line-search
+   * @param q Upon input the value of q predicted from Newton Raphson.  Upon exit this will be q coming from the line-search
+   * @param p_trial Trial value of p for this (sub)strain increment
+   * @param q_trial Trial value of q for this (sub)strain increment
+   * @param smoothed_q Upon input, the value of the smoothed yield function and derivatives at the prior-to-Newton configuration.  Upon exit this is evaluated at the new (p, q, intnl)
+   * @param intnl_ok The value of _intnl from either the start of this (sub)strain increment
+   */
+  int lineSearch(Real & res2, Real & gaE, Real & p, Real & q, Real p_trial, Real q_trial, f_and_derivs & smoothed_q, const std::vector<Real> & intnl_ok);
+
+  /**
+   * Performs a Newton-Raphson step to attempt to zero _rhs
+   * Upon return, _rhs will contain the solution.
+   * @param smoothed_q The value of the smoothed yield function and derivatives prior to this Newton-Raphson step
+   * @param p_trial The trial value of p for this (sub)strain increment
+   * @param q_trial The trial value of q for this (sub)strain increment
+   * @param p The current value of p during the Newton-Raphson process
+   * @param q The current value of q during the Newton-Raphson process
+   * @param gaE The current value of ga during the Newton-Raphson process
+   */
+  int nrStep(const f_and_derivs & smoothed_q, Real p_trial, Real q_trial, Real p, Real q, Real gaE);
+
+  /**
+   * Calculates _rhs
+   * 0 = _rhs[0] = f(p, q, intnl) = yield function
+   * 0 = _rhs[1] = p - p_trial + Epp * ga * dg/dp = normality in p direction
+   * 0 = _rhs[2] = q - q_trial + Eqq * ga * dg/dq = normality in q direction
+   * @param p_trial The trial value of p for this (sub)strain increment
+   * @param q_trial The trial value of q for this (sub)strain increment
+   * @param p The current value of p during the Newton-Raphson process
+   * @param q The current value of q during the Newton-Raphson process
+   * @param gaE The current value of ga during the Newton-Raphson process
+   * @param smoothed_q Holds the current value of yield function and derivatives evaluated at (p, q, _intnl)
+   */
+  Real calculateRHS(Real p_trial, Real q_trial, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q);
+
+  /**
+   * Derivative of -RHS with respect to the variables, placed
+   * into an array ready for solving the linear system using
+   * LAPACK gsev
+   * @param smoothed_q Holds the current value of yield function and derivatives evaluated at (p, q, _intnl)
+   * @param dintnl The derivatives of the internal parameters wrt p and q
+   * @param gaE The current value of ga during the Newton-Raphson process
+   * @param jac The outputted derivatives
+   */
+  void dnRHSdVar(const f_and_derivs & smoothed_q, const std::vector<std::vector<Real> > & dintnl, Real gaE, std::array<double, _num_rhs * _num_rhs> & jac) const;
+
+  /**
+   * Performs any necessary cleaning-up, then throw MooseException(message)
+   * @param message The message to using in MooseException
+   */
+  virtual void errorHandler(const std::string & message);
+
+
+  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
+  Real _dgaE_dpt;
+  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
+  Real _dp_dpt;
+  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
+  Real _dq_dpt;
+  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
+  Real _dgaE_dqt;
+  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
+  Real _dp_dqt;
+  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
+  Real _dq_dqt;
+
+  /** A Newton-Raphson-with-linesearch is used for the return-map
+   * process.  Three equations must be solved:
+   * 0 = _rhs[0] = f(p, q, intnl) = yield function
+   * 0 = _rhs[1] = p - p_trial + Ezzzz * ga * dg/dp = normality in p direction
+   * 0 = _rhs[2] = q - q_trial + Ezxzx * ga * dg/dq = normality in q direction
+   * Not only does _rhs hold the current value of the right-hand-side
+   * in these equations, but the PETSc-LAPACK gesv routine puts the
+   * changes of the variables into the _rhs too
+   */
+  std::array<Real, _num_rhs> _rhs;
+
+  /** Holds the yield function, derivatives and flow information for the
+   * three yield functions of this model
+   */
+  std::vector<f_and_derivs> _all_q;
+
+  /**
+   * Computes the values of the yield functions, given p, q and intnl parameters.
+   * Derived classes must override this, to provide the values of the yield functions
+   * in yf.
+   * @param p p stress
+   * @param q q stress
+   * @param intnl The internal parameters
+   * @param[out] yf The yield function values
+   */
+  virtual void yieldFunctionValues(Real p, Real q, const std::vector<Real> & intnl, std::vector<Real> & yf) const = 0;
+
+  /**
+   * Completely fills all_q with correct values.  These values are:
+   * (1) the yield function values, yf[i]
+   * (2) d(yf[i])/d(p, q)
+   * (3) d(yf[i])/d(intnl[j])
+   * (4) d(flowPotential[i])/d(p, q)
+   * (5) d2(flowPotential[i])/d(p, q)/d(p, q)
+   * (6) d2(flowPotential[i])/d(p, q)/d(intnl[j])
+   * @param p p stress
+   * @param q q stress
+   * @param intnl The internal parameters
+   * @param[out] all_q All the desired quantities
+   */
+  virtual void computeAllQ(Real p, Real q, const std::vector<Real> & intnl, std::vector<f_and_derivs> & all_q) const = 0;
+
+  /**
+   * Derived classes may employ this function to record stuff or do
+   * other computations prior to the return-mapping algorithm.  We
+   * know that (p_trial, q_trial, intnl_old) is inadmissible.
+   * @param p_trial Trial value of p
+   * @param q_trial Trial value of q
+   * @param stress_trial Trial stress tensor
+   * @param intnl_old Old value of the internal parameters.
+   * @param yf The yield functions at (p_trial, q_trial, intnl_old)
+   */
+  virtual void preReturnMap(Real p_trial, Real q_trial, const RankTwoTensor & stress_trial, const std::vector<Real> & intnl_old, const std::vector<Real> & yf);
+
+  /**
+   * Sets (p, q, gaE, intnl) at "good guesses" of the solution to the Return-Map algorithm.
+   * The purpose of these "good guesses" is to speed up the Newton-Raphson process by providing
+   * it with a good initial guess.
+   * Derived classes may choose to override this if their plastic models are easy
+   * enough to solve approximately.
+   * The default values, provided by this class, are simply p=p_trial, etc: that is,
+   * the "good guess" is just the trial point for this (sub)strain increment.
+   * @param p_trial The trial value of p for this (sub)strain increment
+   * @param q_trial The trial value of q for this (sub)strain increment
+   * @param intnl_old The internal parameters before applying the (sub)strain increment
+   * @param p[out] The "good guess" value of p.  Default = p_trial
+   * @param q[out] The "good guess" value of q.  Default = q_trial
+   * @param gaE[out] The "good guess" value of gaE.  Default = 0
+   * @param intnl[out] The "good guess" value of the internal parameters
+   */
+  virtual void initialiseVars(Real p_trial, Real q_trial, const std::vector<Real> & intnl_old, Real & p, Real & q, Real & gaE, std::vector<Real> & intnl) const;
+
+  /**
+   * Sets the internal parameters based on the trial values of
+   * p and q, their current values, and the old values of the
+   * internal parameters.
+   * Derived classes must override this.
+   * @param p_trial Trial value of p
+   * @param q_trial Trial value of q
+   * @param p Current value of p
+   * @param q Current value of q
+   * @param intnl_old Old value of internal parameters
+   * @param intnl[out] The value of internal parameters to be set
+   */
+  virtual void setIntnlValues(Real p_trial, Real q_trial, Real p, Real q, const std::vector<Real> & intnl_old, std::vector<Real> & intnl) const = 0;
+
+  /**
+   * Sets the derivatives of internal parameters, based on the trial values of
+   * p and q, their current values, and the old values of the
+   * internal parameters.
+   * Derived classes must override this.
+   * @param p_trial Trial value of p
+   * @param q_trial Trial value of q
+   * @param p Current value of p
+   * @param q Current value of q
+   * @param intnl The current value of the internal parameters
+   * @param dintnl The derivatives dintnl[i][j] = d(intnl[i])/d(variable j), where variable0=p and variable1=q
+   */
+  virtual void setIntnlDerivatives(Real p_trial, Real q_trial, Real p, Real q, const std::vector<Real> & intnl, std::vector<std::vector<Real> > & dintnl) const = 0;
+
+  /**
+   * Computes p and q, given stress.  Derived classes must
+   * override this
+   * @param stress Stress tensor
+   * @param p p stress
+   * @param q q q stress
+   */
+  virtual void computePQ(const RankTwoTensor & stress, Real & p, Real & q) const = 0;
+
+  /**
+   * Set Epp and Eqq based on the elasticity tensor
+   * Derived classes must override this
+   * @param Eijkl elasticity tensor
+   * @param[out] Epp Epp value
+   * @param[out] Eqq Eqq value
+   */
+  virtual void setEppEqq(const RankFourTensor & Eijkl, Real & Epp, Real & Eqq) const = 0;
+
+  /**
+   * Derived classes may use this to perform calculations before
+   * any return-map process is performed, for instance, to initialise
+   * variables.
+   * This is called at the very start of computeQpStress, even before
+   * any checking for admissible stresses, etc, is performed
+   */
+  virtual void initialiseReturnProcess();
+
+  /**
+   * Derived classes may use this to perform calculations after the
+   * return-map process has completed successfully in (p, q) space
+   * but before the returned stress tensor has been performed.
+   */
+  virtual void finaliseReturnProcess();
+
+  /**
+   * Sets stress from the admissible parameters.
+   * This is called after the return-map process has completed
+   * successfully in (p, q) space, just after finaliseReturnProcess
+   * has been called.
+   * Derived classes must override this function
+   * @param stress_trial The trial value of stress
+   * @param p_ok Returned value of p
+   * @param q_ok Returned value of q
+   * @param gaE Value of gaE induced by the return (gaE = gamma * Epp)
+   * @param smoothed_q Holds the current value of yield function and derivatives evaluated at (p_ok, q_ok, _intnl)
+   * @param stress[out] The returned value of the stress tensor
+   */
+  virtual void setStressAfterReturn(const RankTwoTensor & stress_trial, Real p_ok, Real q_ok, Real gaE, const std::vector<Real> & intnl, const f_and_derivs & smoothed_q, RankTwoTensor & stress) const = 0;
+
+  /**
+   * Calculates the consistent tangent operator.
+   * Derived classes may choose to override this for computational
+   * efficiency.  The implementation in this class is quite expensive,
+   * even though it looks compact and clean, because of all the
+   * manipulations of RankFourTensors involved.
+   * @param stress_trial the trial value of the stress tensor for this strain increment
+   * @param p_trial the trial value of p for this strain increment
+   * @param q_trial the trial value of q for this strain increment
+   * @param stress the returned value of the stress tensor for this strain increment
+   * @param p the returned value of p for this strain increment
+   * @param q the returned value of q for this strain increment
+   * @param gaE the total value of that came from this strain increment
+   * @param smoothed_q contains the yield function and derivatives evaluated at (p, q)
+   * @param[out] cto The consistent tangent operator
+   */
+  virtual void consistentTangentOperator(const RankTwoTensor & stress_trial, Real p_trial, Real q_trial, const RankTwoTensor & stress, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q, RankFourTensor & cto) const;
+
+  /**
+   * d(p)/d(stress)
+   * Derived classes must override this
+   * @param stress stress tensor
+   * @return d(p)/d(stress)
+   */
+  virtual RankTwoTensor dpdstress(const RankTwoTensor & stress) const = 0;
+
+  /**
+   * d2(p)/d(stress)/d(stress)
+   * Derived classes must override this
+   * @param stress stress tensor
+   * @return d2(p)/d(stress)/d(stress)
+   */
+  virtual RankFourTensor d2pdstress2(const RankTwoTensor & stress) const = 0;
+
+  /**
+   * d(q)/d(stress)
+   * Derived classes must override this
+   * @param stress stress tensor
+   * @return d(q)/d(stress)
+   */
+  virtual RankTwoTensor dqdstress(const RankTwoTensor & stress) const = 0;
+
+  /**
+   * d2(q)/d(stress)/d(stress)
+   * Derived classes must override this
+   * @param stress stress tensor
+   * @return d2(q)/d(stress)/d(stress)
+   */
+  virtual RankFourTensor d2qdstress2(const RankTwoTensor & stress) const = 0;
+
+};
+
+#endif //PQPLASTICMODEL_H

--- a/modules/tensor_mechanics/src/materials/ComputeCappedWeakInclinedPlaneStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCappedWeakInclinedPlaneStress.C
@@ -6,12 +6,13 @@
 /****************************************************************/
 #include "ComputeCappedWeakInclinedPlaneStress.h"
 #include "RotationMatrix.h" // for rotVecToZ
+#include "libmesh/utility.h"
 
 template<>
 InputParameters validParams<ComputeCappedWeakInclinedPlaneStress>()
 {
   InputParameters params = validParams<ComputeCappedWeakPlaneStress>();
-  params.addClassDescription("Capped weak inclined-plane plasticity stress calculator");
+  params.addClassDescription("Capped weak inclined plane plasticity stress calculator");
   params.addRequiredParam<RealVectorValue>("normal_vector", "The normal vector to the weak plane");
   return params;
 }
@@ -21,12 +22,18 @@ ComputeCappedWeakInclinedPlaneStress::ComputeCappedWeakInclinedPlaneStress(const
     _n_input(getParam<RealVectorValue>("normal_vector")),
     _n(declareProperty<RealVectorValue>("weak_plane_normal")),
     _n_old(declarePropertyOld<RealVectorValue>("weak_plane_normal")),
-    _rot(RealTensorValue())
+    _rot_n_to_z(RealTensorValue()),
+    _rot_z_to_n(RealTensorValue()),
+    _rotated_trial(RankTwoTensor()),
+    _rotated_Eijkl(RankFourTensor())
 {
   if (_n_input.norm() == 0)
     mooseError("ComputeCappedWeakInclinedPlaneStress: normal_vector must not have zero length");
   else
     _n_input /= _n_input.norm();
+
+  _rot_n_to_z = RotationMatrix::rotVecToZ(_n_input);
+  _rot_z_to_n = _rot_n_to_z.transpose();
 }
 
 void
@@ -39,65 +46,112 @@ ComputeCappedWeakInclinedPlaneStress::initQpStatefulProperties()
 void
 ComputeCappedWeakInclinedPlaneStress::computeQpStress()
 {
-  rotate();
+  ComputeCappedWeakPlaneStress::computeQpStress();
 
-  if (_t_step >= 2)
-    _step_one = false;
-
-  ComputeCappedWeakPlaneStress::returnMap();
-
-  unrotate();
-
-  //Update measures of strain
-  _elastic_strain[_qp] = _elastic_strain_old[_qp] + _strain_increment[_qp] - (_plastic_strain[_qp] - _plastic_strain_old[_qp]);
-
-  //Rotate the tensors to the current configuration
   if (_perform_finite_strain_rotations)
-  {
-    _stress[_qp] = _rotation_increment[_qp]*_stress[_qp]*_rotation_increment[_qp].transpose();
-    _elastic_strain[_qp] = _rotation_increment[_qp] * _elastic_strain[_qp] * _rotation_increment[_qp].transpose();
-    _plastic_strain[_qp] = _rotation_increment[_qp] * _plastic_strain[_qp] * _rotation_increment[_qp].transpose();
-
-    // Rotate n by _rotation_increment
     for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     {
       _n[_qp](i) = 0.0;
       for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
         _n[_qp](i) += _rotation_increment[_qp](i, j) * _n_old[_qp](j);
     }
+}
+
+void
+ComputeCappedWeakInclinedPlaneStress::initialiseReturnProcess()
+{
+  ComputeCappedWeakPlaneStress::initialiseReturnProcess();
+  if (_perform_finite_strain_rotations)
+  {
+    _rot_n_to_z = RotationMatrix::rotVecToZ(_n[_qp]);
+    _rot_z_to_n = _rot_n_to_z.transpose();
   }
 }
 
-void
-ComputeCappedWeakInclinedPlaneStress::rotate()
-{
-  _rot = RotationMatrix::rotVecToZ(_n[_qp]);  // rotation matrix that will rotate _n to the "z" axis
 
-  // _elasticity_tensor and _strain_increment are both "const" as usually in computing
-  // stress these don't need to be altered.  Here, however, we need to rotate them.
-  (const_cast<MaterialProperty<RankFourTensor> &>(_elasticity_tensor))[_qp].rotate(_rot);
-  _stress_old[_qp].rotate(_rot);
-  _plastic_strain_old[_qp].rotate(_rot);
-  (const_cast<MaterialProperty<RankTwoTensor> &>(_strain_increment))[_qp].rotate(_rot);
+void
+ComputeCappedWeakInclinedPlaneStress::preReturnMap(Real /*p_trial*/, Real q_trial, const RankTwoTensor & stress_trial, const std::vector<Real> & /*intnl_old*/, const std::vector<Real> & yf)
+{
+  // If it's obvious, then simplify the return-type
+  if (yf[1] >= 0)
+    _stress_return_type = StressReturnType::no_compression;
+  else if (yf[2] >= 0)
+    _stress_return_type = StressReturnType::no_tension;
+
+  _rotated_trial = stress_trial;
+  _rotated_trial.rotate(_rot_n_to_z);
+  _in_trial20 = _rotated_trial(2, 0);
+  _in_trial21 = _rotated_trial(2, 1);
+  _in_q_trial = q_trial;
+
+  _rotated_Eijkl = _elasticity_tensor[_qp];
+  _rotated_Eijkl.rotate(_rot_n_to_z);
 }
 
 void
-ComputeCappedWeakInclinedPlaneStress::unrotate()
+ComputeCappedWeakInclinedPlaneStress::computePQ(const RankTwoTensor & stress, Real & p, Real & q) const
 {
-  _rot = _rot.transpose(); // rotation matrix will now rotate "z" axis back to _n
-
-  (const_cast<MaterialProperty<RankFourTensor> &>(_elasticity_tensor))[_qp].rotate(_rot);
-  _stress_old[_qp].rotate(_rot);
-  _plastic_strain_old[_qp].rotate(_rot);
-  (const_cast<MaterialProperty<RankTwoTensor> &>(_strain_increment))[_qp].rotate(_rot);
-  _Jacobian_mult[_qp].rotate(_rot);
-  _stress[_qp].rotate(_rot);
-  _plastic_strain[_qp].rotate(_rot);
+  RankTwoTensor rotated_stress = stress;
+  rotated_stress.rotate(_rot_n_to_z);
+  p = rotated_stress(2, 2);
+  q = std::sqrt(Utility::pow<2>(rotated_stress(2, 0)) + Utility::pow<2>(rotated_stress(2, 1)));
 }
 
 void
-ComputeCappedWeakInclinedPlaneStress::errorHandler(const std::string & message)
+ComputeCappedWeakInclinedPlaneStress::setEppEqq(const RankFourTensor & /*Eijkl*/, Real & Epp, Real & Eqq) const
 {
-  unrotate();
-  ComputeCappedWeakPlaneStress::errorHandler(message);
+  Epp = _rotated_Eijkl(2, 2, 2, 2);
+  Eqq = _rotated_Eijkl(2, 0, 2, 0);
+}
+
+void
+ComputeCappedWeakInclinedPlaneStress::setStressAfterReturn(const RankTwoTensor & /*stress_trial*/, Real p_ok, Real q_ok, Real gaE, const std::vector<Real> & /*intnl*/, const f_and_derivs & smoothed_q, RankTwoTensor & stress) const
+{
+  // first get stress in the frame where _n points along "z"
+  stress = _rotated_trial;
+  stress(2, 2) = p_ok;
+  // stress_xx and stress_yy are sitting at their trial-stress values
+  // so need to bring them back via Poisson's ratio
+  stress(0, 0) -= _rotated_Eijkl(2, 2, 0, 0) * gaE / _Epp * smoothed_q.dg[0];
+  stress(1, 1) -= _rotated_Eijkl(2, 2, 1, 1) * gaE / _Epp * smoothed_q.dg[0];
+  if (_in_q_trial == 0.0)
+    stress(2, 0) = stress(2, 1) = stress(0, 2) = stress(1, 2) = 0.0;
+  else
+  {
+    stress(2, 0) = stress(0, 2) = _in_trial20 * q_ok / _in_q_trial;
+    stress(2, 1) = stress(1, 2) = _in_trial21 * q_ok / _in_q_trial;
+  }
+
+  // rotate back to the original frame
+  stress.rotate(_rot_z_to_n);
+}
+
+void
+ComputeCappedWeakInclinedPlaneStress::consistentTangentOperator(const RankTwoTensor & stress_trial, Real p_trial, Real q_trial, const RankTwoTensor & stress, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q, RankFourTensor & cto) const
+{
+  PQPlasticModel::consistentTangentOperator(stress_trial, p_trial, q_trial, stress, p, q, gaE, smoothed_q, cto);
+}
+
+RankTwoTensor
+ComputeCappedWeakInclinedPlaneStress::dpdstress(const RankTwoTensor & stress) const
+{
+  RankTwoTensor dpdsig = ComputeCappedWeakPlaneStress::dpdstress(stress);
+  dpdsig.rotate(_rot_z_to_n);
+  return dpdsig;
+}
+
+RankTwoTensor
+ComputeCappedWeakInclinedPlaneStress::dqdstress(const RankTwoTensor & stress) const
+{
+  RankTwoTensor dqdsig = ComputeCappedWeakPlaneStress::dqdstress(stress);
+  dqdsig.rotate(_rot_z_to_n);
+  return dqdsig;
+}
+
+RankFourTensor
+ComputeCappedWeakInclinedPlaneStress::d2qdstress2(const RankTwoTensor & stress) const
+{
+  RankFourTensor d2qdsig2 = ComputeCappedWeakPlaneStress::d2qdstress2(stress);
+  d2qdsig2.rotate(_rot_z_to_n);
+  return d2qdsig2;
 }

--- a/modules/tensor_mechanics/src/materials/ComputeCappedWeakPlaneStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCappedWeakPlaneStress.C
@@ -6,73 +6,36 @@
 /****************************************************************/
 #include "ComputeCappedWeakPlaneStress.h"
 
-#include "Conversion.h" // for stringify
 #include "libmesh/utility.h"
 
 template<>
 InputParameters validParams<ComputeCappedWeakPlaneStress>()
 {
-  InputParameters params = validParams<ComputeStressBase>();
+  InputParameters params = validParams<PQPlasticModel>();
   params.addClassDescription("Capped weak-plane plasticity stress calculator");
   params.addRequiredParam<UserObjectName>("cohesion", "A TensorMechanicsHardening UserObject that defines hardening of the cohesion.  Physically the cohesion should not be negative.");
   params.addRequiredParam<UserObjectName>("tan_friction_angle", "A TensorMechanicsHardening UserObject that defines hardening of tan(friction angle).  Physically the friction angle should be between 0 and 90deg.");
   params.addRequiredParam<UserObjectName>("tan_dilation_angle", "A TensorMechanicsHardening UserObject that defines hardening of the tan(dilation angle).  Usually the dilation angle is not greater than the friction angle, and it is between 0 and 90deg.");
   params.addRequiredParam<UserObjectName>("tensile_strength", "A TensorMechanicsHardening UserObject that defines hardening of the weak-plane tensile strength.  In physical situations this is positive (and always must be greater than negative compressive-strength.");
   params.addRequiredParam<UserObjectName>("compressive_strength", "A TensorMechanicsHardening UserObject that defines hardening of the weak-plane compressive strength.  In physical situations this is positive.");
-  params.addRangeCheckedParam<unsigned int>("max_NR_iterations", 20, "max_NR_iterations>0", "Maximum number of Newton-Raphson iterations allowed during the return-map algorithm");
   params.addRequiredRangeCheckedParam<Real>("tip_smoother", "tip_smoother>=0", "The cone vertex at shear-stress = 0 will be smoothed by the given amount.  Typical value is 0.1*cohesion");
-  params.addParam<bool>("perform_finite_strain_rotations", false, "Tensors are correctly rotated in finite-strain simulations.  For optimal performance you can set this to 'false' if you are only ever using small strains");
-  params.addRequiredParam<Real>("smoothing_tol", "Intersections of the yield surfaces will be smoothed by this amount (this is measured in units of stress).  Often this is 0.1*cohesion, but it is important to set this small enough so that the tensile and compressive yield do not mix together in the smoothing process, otherwise no stresses will be admissible");
-  params.addRequiredParam<Real>("yield_function_tol", "The return-map process will be deemed to have converged if all yield functions are within yield_function_tol of zero.  If this is set very low then precision-loss might be encountered: if the code detects precision loss then it also deems the return-map process has converged.");
-  MooseEnum tangent_operator("elastic nonlinear", "nonlinear");
-  params.addParam<MooseEnum>("tangent_operator", tangent_operator, "Type of tangent operator to return.  'elastic': return the elasticity tensor.  'nonlinear': return the full consistent tangent operator.");
   params.addParam<bool>("perfect_guess", true, "Provide a guess to the Newton-Raphson proceedure that is the result from perfect plasticity.  With severe hardening/softening this may be suboptimal.");
-  params.addParam<Real>("min_step_size", 1.0, "In order to help the Newton-Raphson procedure, the applied strain increment may be applied in sub-increments of size greater than this value.  Usually it is better for Moose's nonlinear convergence to increase max_NR_iterations rather than decrease this parameter.");
-  params.addParam<bool>("warn_about_precision_loss", false, "Output a message to the console every time precision-loss is encountered during the Newton-Raphson process");
   return params;
 }
 
 ComputeCappedWeakPlaneStress::ComputeCappedWeakPlaneStress(const InputParameters & parameters) :
-    ComputeStressBase(parameters),
+    PQPlasticModel(parameters, 3, 2),
     _cohesion(getUserObject<TensorMechanicsHardeningModel>("cohesion")),
     _tan_phi(getUserObject<TensorMechanicsHardeningModel>("tan_friction_angle")),
     _tan_psi(getUserObject<TensorMechanicsHardeningModel>("tan_dilation_angle")),
     _tstrength(getUserObject<TensorMechanicsHardeningModel>("tensile_strength")),
     _cstrength(getUserObject<TensorMechanicsHardeningModel>("compressive_strength")),
     _small_smoother2(Utility::pow<2>(getParam<Real>("tip_smoother"))),
-    _max_nr_its(getParam<unsigned>("max_NR_iterations")),
-    _perform_finite_strain_rotations(getParam<bool>("perform_finite_strain_rotations")),
-    _smoothing_tol(getParam<Real>("smoothing_tol")),
-    _f_tol(getParam<Real>("yield_function_tol")),
-    _f_tol2(Utility::pow<2>(getParam<Real>("yield_function_tol"))),
-    _tangent_operator_type((TangentOperatorEnum)(int)getParam<MooseEnum>("tangent_operator")),
     _perfect_guess(getParam<bool>("perfect_guess")),
     _stress_return_type(StressReturnType::nothing_special),
-    _min_step_size(getParam<Real>("min_step_size")),
-    _step_one(declareRestartableData<bool>("step_one", true)),
-    _warn_about_precision_loss(getParam<bool>("warn_about_precision_loss")),
-
-    _plastic_strain(declareProperty<RankTwoTensor>("plastic_strain")),
-    _plastic_strain_old(declarePropertyOld<RankTwoTensor>("plastic_strain")),
-    _intnl(declareProperty<std::vector<Real> >("plastic_internal_parameter")),
-    _intnl_old(declarePropertyOld<std::vector<Real> >("plastic_internal_parameter")),
-    _yf(declareProperty<std::vector<Real> >("plastic_yield_function")),
-    _iter(declareProperty<Real>("plastic_NR_iterations")), // this is really an unsigned int, but for visualisation i convert it to Real
-    _linesearch_needed(declareProperty<Real>("plastic_linesearch_needed")), // this is really a boolean, but for visualisation i convert it to Real
-
-    _strain_increment(getMaterialPropertyByName<RankTwoTensor>(_base_name + "strain_increment")),
-    _rotation_increment(getMaterialPropertyByName<RankTwoTensor>(_base_name + "rotation_increment")),
-
-    _stress_old(declarePropertyOld<RankTwoTensor>(_base_name + "stress")),
-    _elastic_strain_old(declarePropertyOld<RankTwoTensor>(_base_name + "elastic_strain")),
-
-    _dgaE_dpt(0.0),
-    _dp_dpt(0.0),
-    _dq_dpt(0.0),
-    _dgaE_dqt(0.0),
-    _dp_dqt(0.0),
-    _dq_dqt(0.0),
-    _all_q(_num_yf)
+    _in_trial20(0.0),
+    _in_trial21(0.0),
+    _in_q_trial(0.0)
 {
   // With arbitary UserObjects, it is impossible to check everything,
   // but this will catch the common errors
@@ -84,340 +47,84 @@ ComputeCappedWeakPlaneStress::ComputeCappedWeakPlaneStress(const InputParameters
     mooseError("ComputeCappedWeakPlaneStress: Weak-plane cohesion must not be negative");
   if (_tstrength.value(0) + _cstrength.value(0) <= _smoothing_tol)
     mooseError("ComputeCappedWeakPlaneStress: Weak plane tensile strength plus compressive strength must be greater than smoothing_tol");
-
-  for (unsigned i = 0; i < _num_yf; ++i)
-    _all_q[i] = f_and_derivs(_num_pq, _num_intnl);
 }
 
-void
-ComputeCappedWeakPlaneStress::initQpStatefulProperties()
-{
-  ComputeStressBase::initQpStatefulProperties();
-
-  _plastic_strain[_qp].zero();
-  _intnl[_qp].assign(_num_intnl, 0);
-  _yf[_qp].assign(_num_yf, 0);
-  _iter[_qp] = 0.0;
-  _linesearch_needed[_qp] = 0.0;
-}
 
 void
-ComputeCappedWeakPlaneStress::computeQpStress()
+ComputeCappedWeakPlaneStress::initialiseReturnProcess()
 {
-  if (_t_step >= 2)
-    _step_one = false;
-
-  returnMap();
-
-  //Update measures of strain
-  _elastic_strain[_qp] = _elastic_strain_old[_qp] + _strain_increment[_qp] - (_plastic_strain[_qp] - _plastic_strain_old[_qp]);
-
-  //Rotate the tensors to the current configuration
-  if (_perform_finite_strain_rotations)
-  {
-    _stress[_qp] = _rotation_increment[_qp]*_stress[_qp]*_rotation_increment[_qp].transpose();
-    _elastic_strain[_qp] = _rotation_increment[_qp] * _elastic_strain[_qp] * _rotation_increment[_qp].transpose();
-    _plastic_strain[_qp] = _rotation_increment[_qp] * _plastic_strain[_qp] * _rotation_increment[_qp].transpose();
-  }
-}
-
-void
-ComputeCappedWeakPlaneStress::returnMap()
-{
-  // initially assume an elastic deformation
-  _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * _strain_increment[_qp];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    _intnl[_qp][i] = _intnl_old[_qp][i];
-  _iter[_qp] = 0.0;
-  _linesearch_needed[_qp] = 0.0;
-
   _stress_return_type = StressReturnType::nothing_special;
+}
 
-  Real p_trial = _stress[_qp](2, 2);
-  Real q_trial = std::sqrt(Utility::pow<2>(_stress[_qp](2, 0)) + Utility::pow<2>(_stress[_qp](2, 1)));
-  unsmoothedYieldFunctions(p_trial, q_trial, _intnl[_qp], _yf[_qp]);
+void
+ComputeCappedWeakPlaneStress::finaliseReturnProcess()
+{
+  _stress_return_type = StressReturnType::nothing_special;
+}
 
-  /* Need to consider smoothing_tol, not just yf<=0, because
-   * some yield functions might mix.  However, if some yield
-   * functions are -smoothing_tol <= yf < 0, then the smoothed
-   * yield function must be computed and checked vs f_tol
-   */
-  if ((_yf[_qp][0] < -_smoothing_tol &&
-      _yf[_qp][1] < -_smoothing_tol &&
-      _yf[_qp][2] < -_smoothing_tol) ||
-      yieldF(p_trial, q_trial, _intnl[_qp]) <= _f_tol)
-  {
-    // elastic case
-    _plastic_strain[_qp] = _plastic_strain_old[_qp];
-    if (_fe_problem.currentlyComputingJacobian())
-      _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
-    return;
-  }
-
-
-  /* The trial stress (_stress[_qp]) must be inadmissible
-   * so we need to return to the yield surface.  The following
-   * equations must be satisfied.
-   * 0 = f(p, q, intnl)                    = rhs[0]
-   * 0 = p - p^trial + Ezzzz * ga * dg/dp  = rhs[1]
-   * 0 = q - q^trial + Ezxzx * ga * dg/dq  = rhs[2]
-   * 0 = intnl[0] - intnl_old[0] - (q^trial - q)/Ezxzx
-   * 0 = intnl[1] - intnl_old[1] - (p^trial - p)/Ezzzz + (q^trial - q) * tanpsi / Ezxzx
-   * With unknowns p, q, ga, intnl[0] and intnl[1]
-   * I find it convenient to solve the first three equations for p, q and ga*Ezzzz,
-   * while substituting the last two equations into these during the solve process
-   * (tanpsi depends only on intnl[0], and hence on q)
-   */
-
-  const Real in_trial20 = _stress[_qp](2, 0);
-  const Real in_trial21 = _stress[_qp](2, 1);
-  const Real in_q_trial = q_trial;
-
-  // values of p, q  and intnl we know to be admissible
-  Real p_ok = _stress_old[_qp](2, 2);
-  Real q_ok = std::sqrt(Utility::pow<2>(_stress[_qp](2, 0)) + Utility::pow<2>(_stress[_qp](2, 1)));
-  // note that _intnl[_qp] is the "running" intnl variable that gets updated every NR iteration
-  std::array<Real, 2> intnl_ok = {{ _intnl_old[_qp][0], _intnl_old[_qp][1] }};
-  if (isParamValid("initial_stress") && _step_one)
-  {
-    // the initial stress might be inadmissible
-    p_ok = 0.0;
-    q_ok = 0.0;
-  }
-
-  _dgaE_dpt = 0.0;
-  _dp_dpt = 0.0;
-  _dq_dpt = 0.0;
-  _dgaE_dqt = 0.0;
-  _dp_dqt = 0.0;
-  _dq_dqt = 0.0;
-
-  // Return-map problem: must apply the following changes in p and q, and find the returned p and q.
-  const Real del_p = p_trial - p_ok;
-  const Real del_q = q_trial - q_ok;
-
+void
+ComputeCappedWeakPlaneStress::preReturnMap(Real /*p_trial*/, Real q_trial, const RankTwoTensor & stress_trial, const std::vector<Real> & /*intnl_old*/, const std::vector<Real> & yf)
+{
   // If it's obvious, then simplify the return-type
-  if (_yf[_qp][1] >= 0)
+  if (yf[1] >= 0)
     _stress_return_type = StressReturnType::no_compression;
-  else if (_yf[_qp][2] >= 0)
+  else if (yf[2] >= 0)
     _stress_return_type = StressReturnType::no_tension;
 
-  Real step_taken = 0.0; // amount of (del_p, del_q) that we've applied and the return-map problem has succeeded
-  Real step_size = 1.0; // potentially can apply (del_p, del_q) in substeps
-  Real gaE_total = 0.0;
+  _in_trial20 = stress_trial(2, 0);
+  _in_trial21 = stress_trial(2, 1);
+  _in_q_trial = q_trial;
+}
 
-  // current values of the yield function, derivatives, etc
-  f_and_derivs smoothed_q;
+void
+ComputeCappedWeakPlaneStress::computePQ(const RankTwoTensor & stress, Real & p, Real & q) const
+{
+  p = stress(2, 2);
+  q = std::sqrt(Utility::pow<2>(stress(2, 0)) + Utility::pow<2>(stress(2, 1)));
+}
 
-  // In the following sub-stepping procedure it is possible that
-  // the last step is an elastic step, and therefore smoothed_q won't
-  // be computed on the last step, so we have to compute it.
-  bool smoothed_q_calculated = false;
+void
+ComputeCappedWeakPlaneStress::setEppEqq(const RankFourTensor & Eijkl, Real & Epp, Real & Eqq) const
+{
+  Epp = Eijkl(2, 2, 2, 2);
+  Eqq = Eijkl(2, 0, 2, 0);
+}
 
-  while (step_taken < 1.0 && step_size >= _min_step_size)
-  {
-    if (1.0 - step_taken < step_size)
-      // prevent over-shoots of substepping
-      step_size = 1.0 - step_taken;
-
-    // trial variables in terms of admissible variables
-    p_trial = p_ok + step_size * del_p;
-    q_trial = q_ok + step_size * del_q;
-
-    // initialise (p, q, gaE)
-    Real p = p_trial;
-    Real q = q_trial;
-    Real gaE = 0.0;
-
-    // flags indicating failure of newton-raphson and line-search
-    int nr_failure = 0;
-    int ls_failure = 0;
-
-    // NR iterations taken in this substep
-    Real step_iter = 0.0;
-
-    // The residual-squared for the line-search
-    Real res2 = 0.0;
-
-    if (step_size < 1.0 && yieldF(p_trial, q_trial, _intnl[_qp]) <= _f_tol)
-      // This is an elastic step
-      // The "step_size < 1.0" in above condition is for efficiency: we definitely
-      // know that this is a plastic step if step_size = 1.0
-      smoothed_q_calculated = false;
-    else
-    {
-      // this is a plastic step
-
-      // initialise p, q and gaE using a good guess based on the non-smoothed situation
-      initialiseVars(p_trial, q_trial, p, q, gaE);
-      smoothed_q = smoothAllQuantities(p, q, _intnl[_qp]);
-      smoothed_q_calculated = true;
-      res2 = calculateRHS(p_trial, q_trial, p, q, gaE, smoothed_q);
-
-      // Perform a Newton-Raphson with linesearch to get p, q, gaE, and also smoothed_q
-      while (res2 > _f_tol2 && step_iter < (float) _max_nr_its && nr_failure == 0 && ls_failure == 0)
-      {
-        // solve the linear system and store the answer (the "updates") in _rhs
-        nr_failure = nrStep(smoothed_q, q_trial, q, gaE);
-        if (nr_failure != 0)
-          break;
-
-        // check for precision loss
-        if (std::abs(_rhs[0]) <= 1E-13 * std::abs(gaE) &&
-            std::abs(_rhs[1]) <= 1E-13 * std::abs(p) &&
-            std::abs(_rhs[2]) <= 1E-13 * std::abs(q)) {
-          if (_warn_about_precision_loss)
-            Moose::err << "ComputeCappedWeakPlaneStress: precision-loss in element " <<_current_elem->id() << " quadpoint=" << _qp << " p=" << p << " q=" << q << " gaE=" << gaE << "\n";
-          res2 = 0.0;
-          break;
-        }
-
-        // apply (parts of) the updates, re-calculate smoothed_q, and res2
-        ls_failure = lineSearch(res2, gaE, p, q, q_trial, p_trial, smoothed_q, intnl_ok);
-        step_iter++;
-      }
-    }
-
-    if (res2 <= _f_tol2 && step_iter < (float) _max_nr_its && nr_failure == 0 && ls_failure == 0 && gaE >= 0.0)
-    {
-      // this Newton-Raphson worked fine, or this was an elastic step
-      p_ok = p;
-      q_ok = q;
-      step_taken += step_size;
-      gaE_total += gaE;
-      const Real Ezzzz = _elasticity_tensor[_qp](2, 2, 2, 2);
-      const Real Ezxzx = _elasticity_tensor[_qp](2, 0, 2, 0);
-      intnl_ok[0] = _intnl[_qp][0] = intnl_ok[0] + (q_trial - q_ok) / Ezxzx;
-      const Real tanpsi = _tan_psi.value(_intnl[_qp][0]);
-      intnl_ok[1] = _intnl[_qp][1] = intnl_ok[1] + (p_trial - p_ok) / Ezzzz - (q_trial - q_ok) * tanpsi / Ezxzx;
-      // calculate dp/dp_trial, dp/dq_trial, etc, for Jacobian
-      dVardTrial(!smoothed_q_calculated, q_ok, q_trial, gaE, smoothed_q, step_size);
-      if (step_iter > _iter[_qp])
-        _iter[_qp] = step_iter;
-      step_size *= 1.1;
-    }
-    else
-    {
-      // Newton-Raphson + line-search process failed
-      step_size *= 0.5;
-    }
-  }
-
-
-  if (step_size < _min_step_size)
-    errorHandler("ComputeCappedWeakPlaneStress: Minimum step-size violated");
-
-  // success!
-  _stress_return_type = StressReturnType::nothing_special;
-  unsmoothedYieldFunctions(p_ok, q_ok, _intnl[_qp], _yf[_qp]);
-
-  if (!smoothed_q_calculated)
-    smoothed_q = smoothAllQuantities(p_ok, q_ok, _intnl[_qp]);
-
-  _stress[_qp](2, 2) = p_ok;
+void
+ComputeCappedWeakPlaneStress::setStressAfterReturn(const RankTwoTensor & stress_trial, Real p_ok, Real q_ok, Real gaE, const std::vector<Real> & /*intnl*/, const f_and_derivs & smoothed_q, RankTwoTensor & stress) const
+{
+  stress = stress_trial;
+  stress(2, 2) = p_ok;
   // stress_xx and stress_yy are sitting at their trial-stress values
   // so need to bring them back via Poisson's ratio
-  const Real Ezzzz = _elasticity_tensor[_qp](2, 2, 2, 2);
-  _stress[_qp](0, 0) -= _elasticity_tensor[_qp](2, 2, 0, 0) * gaE_total / Ezzzz * smoothed_q.dg[0];
-  _stress[_qp](1, 1) -= _elasticity_tensor[_qp](2, 2, 1, 1) * gaE_total / Ezzzz * smoothed_q.dg[0];
-  if (in_q_trial == 0.0)
-    _stress[_qp](2, 0) = _stress[_qp](2, 1) = _stress[_qp](0, 2) = _stress[_qp](1, 2) = 0.0;
+  stress(0, 0) -= _elasticity_tensor[_qp](2, 2, 0, 0) * gaE / _Epp * smoothed_q.dg[0];
+  stress(1, 1) -= _elasticity_tensor[_qp](2, 2, 1, 1) * gaE / _Epp * smoothed_q.dg[0];
+  if (_in_q_trial == 0.0)
+    stress(2, 0) = stress(2, 1) = stress(0, 2) = stress(1, 2) = 0.0;
   else
   {
-    _stress[_qp](2, 0) = _stress[_qp](0, 2) = in_trial20 * q_ok / in_q_trial;
-    _stress[_qp](2, 1) = _stress[_qp](1, 2) = in_trial21 * q_ok / in_q_trial;
+    stress(2, 0) = stress(0, 2) = _in_trial20 * q_ok / _in_q_trial;
+    stress(2, 1) = stress(1, 2) = _in_trial21 * q_ok / _in_q_trial;
   }
-
-  _plastic_strain[_qp] = _plastic_strain_old[_qp] + _strain_increment[_qp] + _elasticity_tensor[_qp].invSymm() * (_stress_old[_qp] - _stress[_qp]);
-
-  consistentTangentOperator(q_ok, in_q_trial, in_trial20, in_trial21, gaE_total, smoothed_q);
 }
 
 void
-ComputeCappedWeakPlaneStress::dVardTrial(bool elastic_only, Real q, Real q_trial, Real gaE, const f_and_derivs & smoothed_q, Real step_size)
+ComputeCappedWeakPlaneStress::setIntnlDerivatives(Real /*p_trial*/, Real q_trial, Real /*p*/, Real q, const std::vector<Real> & intnl, std::vector<std::vector<Real> > & dintnl) const
+{
+  const Real tanpsi = _tan_psi.value(intnl[0]);
+  dintnl[0][0] = 0.0;
+  dintnl[0][1] = -1.0 / _Eqq;
+  dintnl[1][0] = -1.0 / _Epp;
+  dintnl[1][1] = tanpsi / _Eqq - (q_trial - q) * _tan_psi.derivative(intnl[0]) * dintnl[0][1] / _Eqq;
+}
+
+void
+ComputeCappedWeakPlaneStress::consistentTangentOperator(const RankTwoTensor & /*stress_trial*/, Real /*p_trial*/, Real q_trial, const RankTwoTensor & /*stress*/, Real /*p*/, Real q, Real gaE, const f_and_derivs & smoothed_q, RankFourTensor & cto) const
 {
   if (!_fe_problem.currentlyComputingJacobian())
     return;
 
-  if (_tangent_operator_type == TangentOperatorEnum::elastic)
-    return;
-
-  if (elastic_only)
-  {
-    // no change to gaE, and dp_dqt and dq_dpt are unchanged from previous step
-    _dp_dpt = step_size + _dp_dpt;
-    _dq_dqt = step_size + _dq_dqt;
-    return;
-  }
-
-  const Real Ezzzz = _elasticity_tensor[_qp](2, 2, 2, 2);
-  const Real Ezxzx = _elasticity_tensor[_qp](2, 0, 2, 0);
-  const Real tanpsi = _tan_psi.value(_intnl[_qp][0]);
-  const Real dintnl0_dq = -1.0 / Ezxzx;
-  const Real dintnl0_dqt = 1.0 / Ezxzx;
-  const Real dintnl1_dp = -1.0 / Ezzzz;
-  const Real dintnl1_dpt = 1.0 / Ezzzz;
-  const Real dintnl1_dq = tanpsi / Ezxzx - (q_trial - q) * _tan_psi.derivative(_intnl[_qp][0]) * dintnl0_dq / Ezxzx;
-  const Real dintnl1_dqt = - tanpsi / Ezxzx - (q_trial - q) * _tan_psi.derivative(_intnl[_qp][0]) * dintnl0_dqt / Ezxzx;
-
-  // _rhs is defined above, the following are changes in rhs wrt the trial p and q values
-  std::array<Real, _num_pq * _num_rhs> rhs_cto;
-  // change in p_trial
-  rhs_cto[0] = - smoothed_q.df_di[1] * dintnl1_dpt;
-  rhs_cto[1] = 1.0 - gaE * smoothed_q.d2g_di[0][1] * dintnl1_dpt;
-  rhs_cto[2] = - Ezxzx * gaE / Ezzzz * smoothed_q.d2g_di[1][1] * dintnl1_dpt;
-  // change in q_trial
-  rhs_cto[3] = - smoothed_q.df_di[0] * dintnl0_dqt - smoothed_q.df_di[1] * dintnl1_dqt;
-  rhs_cto[4] = - gaE * (smoothed_q.d2g_di[0][0] * dintnl0_dqt + smoothed_q.d2g_di[0][1] * dintnl1_dqt);
-  rhs_cto[5] = 1.0 - Ezxzx * gaE / Ezzzz * (smoothed_q.d2g_di[1][0] * dintnl0_dqt + smoothed_q.d2g_di[1][1] * dintnl1_dqt);
-
-  // jac = d(rhs)/d(var), where var[0] = gaE, var[1] = p, var[2] = q.
-  std::array<double, _num_rhs * _num_rhs> jac;
-  jac[0] = 0;
-  jac[1] = smoothed_q.dg[0];
-  jac[2] = Ezxzx * smoothed_q.dg[1] / Ezzzz;
-  jac[3] = (smoothed_q.df[0] + smoothed_q.df_di[1] * dintnl1_dp);
-  jac[4] = 1.0 + gaE * (smoothed_q.d2g[0][0] + smoothed_q.d2g_di[0][1] * dintnl1_dp);
-  jac[5] = Ezxzx * gaE / Ezzzz * (smoothed_q.d2g[1][0] + smoothed_q.d2g_di[1][1] * dintnl1_dp);
-  jac[6] = (smoothed_q.df[1] + smoothed_q.df_di[0] * dintnl0_dq + smoothed_q.df_di[1] * dintnl1_dq);
-  jac[7] = gaE * (smoothed_q.d2g[0][1] + smoothed_q.d2g_di[0][0] * dintnl0_dq + smoothed_q.d2g_di[0][1] * dintnl1_dq);
-  jac[8] = 1.0 + Ezxzx * gaE / Ezzzz * (smoothed_q.d2g[1][1] + smoothed_q.d2g_di[1][0] * dintnl0_dq + smoothed_q.d2g_di[1][1] * dintnl1_dq);
-
-  std::array<int, _num_rhs> ipiv;
-  int info;
-  const int gesv_num_rhs = _num_rhs;
-  const int gesv_num_pq = _num_pq;
-  LAPACKgesv_(&gesv_num_rhs, &gesv_num_pq, &jac[0], &gesv_num_rhs, &ipiv[0], &rhs_cto[0], &gesv_num_rhs, &info);
-  if (info != 0)
-    errorHandler("ComputeCappedWeakPlaneStress: PETSC LAPACK gsev routine returned with error code " + Moose::stringify(info));
-
-  const Real dgaEn_dptn = rhs_cto[0];
-  const Real dpn_dptn = rhs_cto[1];
-  const Real dqn_dptn = rhs_cto[2];
-  const Real dgaEn_dqtn = rhs_cto[3];
-  const Real dpn_dqtn = rhs_cto[4];
-  const Real dqn_dqtn = rhs_cto[5];
-
-  const Real dp_dpt_old = _dp_dpt;
-  const Real dq_dpt_old = _dq_dpt;
-  const Real dp_dqt_old = _dp_dqt;
-  const Real dq_dqt_old = _dq_dqt;
-
-  _dgaE_dpt += dgaEn_dptn * (step_size + dp_dpt_old) + dgaEn_dqtn * dq_dpt_old;
-  _dp_dpt = dpn_dptn * (step_size + dp_dpt_old) + dpn_dqtn * dq_dpt_old;
-  _dq_dpt = dqn_dptn * (step_size + dp_dpt_old) + dqn_dqtn * dq_dpt_old;
-  _dgaE_dqt += dgaEn_dqtn * (step_size + dq_dqt_old) + dgaEn_dptn * dp_dqt_old;
-  _dp_dqt = dpn_dqtn * (step_size + dq_dqt_old) + dpn_dptn * dp_dqt_old;
-  _dq_dqt = dqn_dqtn * (step_size + dq_dqt_old) + dqn_dptn * dp_dqt_old;
-}
-
-void
-ComputeCappedWeakPlaneStress::consistentTangentOperator(Real q, Real q_trial, Real trial20, Real trial21, Real gaE, const f_and_derivs & smoothed_q)
-{
-  if (!_fe_problem.currentlyComputingJacobian())
-    return;
-
-  _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
+  cto = _elasticity_tensor[_qp];
   if (_tangent_operator_type == TangentOperatorEnum::elastic)
     return;
 
@@ -434,50 +141,50 @@ ComputeCappedWeakPlaneStress::consistentTangentOperator(Real q, Real q_trial, Re
   for (unsigned i = 0; i < _tensor_dimensionality; ++i)
   {
     const Real dpt_depii = _elasticity_tensor[_qp](2, 2, i, i);
-    _Jacobian_mult[_qp](2, 2, i, i) = _dp_dpt * dpt_depii;
+    cto(2, 2, i, i) = _dp_dpt * dpt_depii;
     const Real poisson_effect = _elasticity_tensor[_qp](2, 2, 0, 0) / Ezzzz * (_dgaE_dpt * smoothed_q.dg[0] + gaE * smoothed_q.d2g[0][0] * _dp_dpt + gaE * smoothed_q.d2g[0][1] * _dq_dpt + gaE * smoothed_q.d2g_di[0][0] * (dintnl0_dq * _dq_dpt) + gaE * smoothed_q.d2g_di[0][1] * (dintnl1_dpt + dintnl1_dp * _dp_dpt + dintnl1_dq * _dq_dpt)) * dpt_depii;
-    _Jacobian_mult[_qp](0, 0, i, i) -= poisson_effect;
-    _Jacobian_mult[_qp](1, 1, i, i) -= poisson_effect;
+    cto(0, 0, i, i) -= poisson_effect;
+    cto(1, 1, i, i) -= poisson_effect;
     if (q_trial > 0.0)
     {
-      _Jacobian_mult[_qp](2, 0, i, i) = _Jacobian_mult[_qp](0, 2, i, i) = trial20 / q_trial * _dq_dpt * dpt_depii;
-      _Jacobian_mult[_qp](2, 1, i, i) = _Jacobian_mult[_qp](1, 2, i, i) = trial21 / q_trial * _dq_dpt * dpt_depii;
+      cto(2, 0, i, i) = cto(0, 2, i, i) = _in_trial20 / q_trial * _dq_dpt * dpt_depii;
+      cto(2, 1, i, i) = cto(1, 2, i, i) = _in_trial21 / q_trial * _dq_dpt * dpt_depii;
     }
   }
 
   const Real poisson_effect = - _elasticity_tensor[_qp](2, 2, 0, 0) / Ezzzz * (_dgaE_dqt * smoothed_q.dg[0] + gaE * smoothed_q.d2g[0][0] * _dp_dqt + gaE * smoothed_q.d2g[0][1] * _dq_dqt + gaE * smoothed_q.d2g_di[0][0] * (dintnl0_dqt + dintnl0_dq * _dq_dqt) + gaE * smoothed_q.d2g_di[0][1] * (dintnl1_dqt + dintnl1_dp * _dp_dqt + dintnl1_dq * _dq_dqt));
 
-  const Real dqt_dep20 = (q_trial == 0.0 ? 1.0 : trial20 / q_trial) * _elasticity_tensor[_qp](2, 0, 2, 0);
-  _Jacobian_mult[_qp](2, 2, 2, 0) = _Jacobian_mult[_qp](2, 2, 0, 2) = _dp_dqt * dqt_dep20;
-  _Jacobian_mult[_qp](0, 0, 2, 0) = _Jacobian_mult[_qp](0, 0, 0, 2) = _Jacobian_mult[_qp](1, 1, 2, 0) = _Jacobian_mult[_qp](1, 1, 0, 2) =  poisson_effect* dqt_dep20;
+  const Real dqt_dep20 = (q_trial == 0.0 ? 1.0 : _in_trial20 / q_trial) * _elasticity_tensor[_qp](2, 0, 2, 0);
+  cto(2, 2, 2, 0) = cto(2, 2, 0, 2) = _dp_dqt * dqt_dep20;
+  cto(0, 0, 2, 0) = cto(0, 0, 0, 2) = cto(1, 1, 2, 0) = cto(1, 1, 0, 2) =  poisson_effect* dqt_dep20;
   if (q_trial > 0.0)
   {
     // for q_trial=0, Jacobian_mult is just given by the elastic case
-    _Jacobian_mult[_qp](0, 2, 0, 2) = _Jacobian_mult[_qp](2, 0, 0, 2) = _Jacobian_mult[_qp](0, 2, 2, 0) = _Jacobian_mult[_qp](2, 0, 2, 0) = _elasticity_tensor[_qp](2, 0, 2, 0) * q / q_trial + trial20 * (_dq_dqt - q / q_trial) / q_trial * dqt_dep20;
-    _Jacobian_mult[_qp](1, 2, 0, 2) = _Jacobian_mult[_qp](2, 1, 0, 2) = _Jacobian_mult[_qp](1, 2, 2, 0) = _Jacobian_mult[_qp](2, 1, 2, 0) = trial21 * (_dq_dqt - q / q_trial) / q_trial * dqt_dep20;
+    cto(0, 2, 0, 2) = cto(2, 0, 0, 2) = cto(0, 2, 2, 0) = cto(2, 0, 2, 0) = _elasticity_tensor[_qp](2, 0, 2, 0) * q / q_trial + _in_trial20 * (_dq_dqt - q / q_trial) / q_trial * dqt_dep20;
+    cto(1, 2, 0, 2) = cto(2, 1, 0, 2) = cto(1, 2, 2, 0) = cto(2, 1, 2, 0) = _in_trial21 * (_dq_dqt - q / q_trial) / q_trial * dqt_dep20;
   }
 
-  const Real dqt_dep21 = (q_trial == 0.0 ? 1.0 : trial21 / q_trial) * _elasticity_tensor[_qp](2, 1, 2, 1);
-  _Jacobian_mult[_qp](2, 2, 2, 1) = _Jacobian_mult[_qp](2, 2, 1, 2) = _dp_dqt * dqt_dep21;
-  _Jacobian_mult[_qp](0, 0, 2, 1) = _Jacobian_mult[_qp](0, 0, 1, 2) = _Jacobian_mult[_qp](1, 1, 2, 1) = _Jacobian_mult[_qp](1, 1, 1, 2) = poisson_effect * dqt_dep21;
+  const Real dqt_dep21 = (q_trial == 0.0 ? 1.0 : _in_trial21 / q_trial) * _elasticity_tensor[_qp](2, 1, 2, 1);
+  cto(2, 2, 2, 1) = cto(2, 2, 1, 2) = _dp_dqt * dqt_dep21;
+  cto(0, 0, 2, 1) = cto(0, 0, 1, 2) = cto(1, 1, 2, 1) = cto(1, 1, 1, 2) = poisson_effect * dqt_dep21;
   if (q_trial > 0.0)
   {
     // for q_trial=0, Jacobian_mult is just given by the elastic case
-    _Jacobian_mult[_qp](0, 2, 1, 2) = _Jacobian_mult[_qp](2, 0, 1, 2) = _Jacobian_mult[_qp](0, 2, 2, 1) = _Jacobian_mult[_qp](2, 0, 2, 1) = trial20 * (_dq_dqt - q / q_trial) / q_trial * dqt_dep21;
-    _Jacobian_mult[_qp](1, 2, 1, 2) = _Jacobian_mult[_qp](2, 1, 1, 2) = _Jacobian_mult[_qp](1, 2, 2, 1) = _Jacobian_mult[_qp](2, 1, 2, 1) = _elasticity_tensor[_qp](2, 1, 2, 1) * q / q_trial + trial21 * (_dq_dqt - q / q_trial) / q_trial * dqt_dep21;
+    cto(0, 2, 1, 2) = cto(2, 0, 1, 2) = cto(0, 2, 2, 1) = cto(2, 0, 2, 1) = _in_trial20 * (_dq_dqt - q / q_trial) / q_trial * dqt_dep21;
+    cto(1, 2, 1, 2) = cto(2, 1, 1, 2) = cto(1, 2, 2, 1) = cto(2, 1, 2, 1) = _elasticity_tensor[_qp](2, 1, 2, 1) * q / q_trial + _in_trial21 * (_dq_dqt - q / q_trial) / q_trial * dqt_dep21;
   }
 }
 
 void
-ComputeCappedWeakPlaneStress::unsmoothedYieldFunctions(Real p, Real q, const std::vector<Real> & intnl, std::vector<Real> & yf) const
+ComputeCappedWeakPlaneStress::yieldFunctionValues(Real p, Real q, const std::vector<Real> & intnl, std::vector<Real> & yf) const
 {
-  mooseAssert(intnl.size() == _num_intnl, "ComputeCappedWeakPlaneStress: yieldFunctions called with intnl size " << intnl.size());;
-  mooseAssert(yf.size() == _num_yf, "ComputeCappedWeakPlaneStress: yieldFunctions called with yf size " << yf.size());
   yf[0] = std::sqrt(Utility::pow<2>(q) + _small_smoother2) + p * _tan_phi.value(intnl[0]) - _cohesion.value(intnl[0]);
+
   if (_stress_return_type == StressReturnType::no_tension)
     yf[1] = std::numeric_limits<Real>::lowest();
   else
     yf[1] = p - _tstrength.value(intnl[1]);
+
   if (_stress_return_type == StressReturnType::no_compression)
     yf[2] = std::numeric_limits<Real>::lowest();
   else
@@ -485,342 +192,100 @@ ComputeCappedWeakPlaneStress::unsmoothedYieldFunctions(Real p, Real q, const std
 }
 
 void
-ComputeCappedWeakPlaneStress::unsmoothedYieldFunctions(Real p, Real q, const std::vector<Real> & intnl)
+ComputeCappedWeakPlaneStress::computeAllQ(Real p, Real q, const std::vector<Real> & intnl, std::vector<f_and_derivs> & all_q) const
 {
-  _all_q[0].f = std::sqrt(Utility::pow<2>(q) + _small_smoother2) + p * _tan_phi.value(intnl[0]) - _cohesion.value(intnl[0]);
+  // yield function values
+  all_q[0].f = std::sqrt(Utility::pow<2>(q) + _small_smoother2) + p * _tan_phi.value(intnl[0]) - _cohesion.value(intnl[0]);
   if (_stress_return_type == StressReturnType::no_tension)
-    _all_q[1].f = std::numeric_limits<Real>::lowest();
+    all_q[1].f = std::numeric_limits<Real>::lowest();
   else
-    _all_q[1].f = p - _tstrength.value(intnl[1]);
+    all_q[1].f = p - _tstrength.value(intnl[1]);
   if (_stress_return_type == StressReturnType::no_compression)
-    _all_q[2].f = std::numeric_limits<Real>::lowest();
+    all_q[2].f = std::numeric_limits<Real>::lowest();
   else
-    _all_q[2].f = - p - _cstrength.value(intnl[1]);
-}
+    all_q[2].f = - p - _cstrength.value(intnl[1]);
 
-void
-ComputeCappedWeakPlaneStress::dyieldFunctions(Real /*p*/, Real q, const std::vector<Real> & intnl)
-{
+  // d(yield Function)/d(p, q)
   // derivatives wrt p
-  _all_q[0].df[0] = _tan_phi.value(intnl[0]);
-  _all_q[1].df[0] = 1.0;
-  _all_q[2].df[0] = - 1.0;
+  all_q[0].df[0] = _tan_phi.value(intnl[0]);
+  all_q[1].df[0] = 1.0;
+  all_q[2].df[0] = - 1.0;
 
   // derivatives wrt q
   if (_small_smoother2 == 0.0)
-    _all_q[0].df[1] = 1.0;
+    all_q[0].df[1] = 1.0;
   else
-    _all_q[0].df[1] = q / std::sqrt(Utility::pow<2>(q) + _small_smoother2);
-  _all_q[1].df[1] = 0.0;
-  _all_q[2].df[1] = 0.0;
-}
+    all_q[0].df[1] = q / std::sqrt(Utility::pow<2>(q) + _small_smoother2);
+  all_q[1].df[1] = 0.0;
+  all_q[2].df[1] = 0.0;
 
-void
-ComputeCappedWeakPlaneStress::dyieldFunctions_di(Real p, Real /*q*/, const std::vector<Real> & intnl)
-{
+  // d(yield Function)/d(intnl)
   // derivatives wrt intnl[0] (shear plastic strain)
-  _all_q[0].df_di[0] = p * _tan_phi.derivative(intnl[0]) - _cohesion.derivative(intnl[0]);
-  _all_q[1].df_di[0] = 0.0;
-  _all_q[2].df_di[0] = 0.0;
+  all_q[0].df_di[0] = p * _tan_phi.derivative(intnl[0]) - _cohesion.derivative(intnl[0]);
+  all_q[1].df_di[0] = 0.0;
+  all_q[2].df_di[0] = 0.0;
   // derivatives wrt intnl[q] (tensile plastic strain)
-  _all_q[0].df_di[1] = 0.0;
-  _all_q[1].df_di[1] = - _tstrength.derivative(intnl[1]);
-  _all_q[2].df_di[1] = - _cstrength.derivative(intnl[1]);
-}
+  all_q[0].df_di[1] = 0.0;
+  all_q[1].df_di[1] = - _tstrength.derivative(intnl[1]);
+  all_q[2].df_di[1] = - _cstrength.derivative(intnl[1]);
 
-void
-ComputeCappedWeakPlaneStress::dflowPotential(Real /*p*/, Real q, const std::vector<Real> & intnl)
-{
+  // d(flowPotential)/d(p, q)
   // derivatives wrt p
-  _all_q[0].dg[0] = _tan_psi.value(intnl[0]);
-  _all_q[1].dg[0] = 1.0;
-  _all_q[2].dg[0] = - 1.0;
+  all_q[0].dg[0] = _tan_psi.value(intnl[0]);
+  all_q[1].dg[0] = 1.0;
+  all_q[2].dg[0] = - 1.0;
   // derivatives wrt q
   if (_small_smoother2 == 0.0)
-    _all_q[0].dg[1] = 1.0;
+    all_q[0].dg[1] = 1.0;
   else
-    _all_q[0].dg[1] = q / std::sqrt(Utility::pow<2>(q) + _small_smoother2);
-  _all_q[1].dg[1] = 0.0;
-  _all_q[2].dg[1] = 0.0;
-}
+    all_q[0].dg[1] = q / std::sqrt(Utility::pow<2>(q) + _small_smoother2);
+  all_q[1].dg[1] = 0.0;
+  all_q[2].dg[1] = 0.0;
 
-void
-ComputeCappedWeakPlaneStress::d2flowPotential_di(Real /*p*/, Real /*q*/, const std::vector<Real> & intnl)
-{
+  // d2(flowPotential)/d(p, q)/d(intnl)
   // d(dg/dp)/dintnl[0]
-  _all_q[0].d2g_di[0][0] = _tan_psi.derivative(intnl[0]);
-  _all_q[1].d2g_di[0][0] = 0.0;
-  _all_q[2].d2g_di[0][0] = 0.0;
+  all_q[0].d2g_di[0][0] = _tan_psi.derivative(intnl[0]);
+  all_q[1].d2g_di[0][0] = 0.0;
+  all_q[2].d2g_di[0][0] = 0.0;
   // d(dg/dp)/dintnl[1]
-  _all_q[0].d2g_di[0][1] = 0.0;
-  _all_q[1].d2g_di[0][1] = 0.0;
-  _all_q[2].d2g_di[0][1] = 0.0;
+  all_q[0].d2g_di[0][1] = 0.0;
+  all_q[1].d2g_di[0][1] = 0.0;
+  all_q[2].d2g_di[0][1] = 0.0;
   // d(dg/dq)/dintnl[0]
-  _all_q[0].d2g_di[1][0] = 0.0;
-  _all_q[1].d2g_di[1][0] = 0.0;
-  _all_q[2].d2g_di[1][0] = 0.0;
+  all_q[0].d2g_di[1][0] = 0.0;
+  all_q[1].d2g_di[1][0] = 0.0;
+  all_q[2].d2g_di[1][0] = 0.0;
   // d(dg/dq)/dintnl[1]
-  _all_q[0].d2g_di[1][1] = 0.0;
-  _all_q[1].d2g_di[1][1] = 0.0;
-  _all_q[2].d2g_di[1][1] = 0.0;
-}
+  all_q[0].d2g_di[1][1] = 0.0;
+  all_q[1].d2g_di[1][1] = 0.0;
+  all_q[2].d2g_di[1][1] = 0.0;
 
-void
-ComputeCappedWeakPlaneStress::d2flowPotential(Real /*p*/, Real q, const std::vector<Real> & /*intnl*/)
-{
+  // d2(flowPotential)/d(p, q)/d(p, q)
   // d(dg/dp)/dp
-  _all_q[0].d2g[0][0] = 0.0;
-  _all_q[1].d2g[0][0] = 0.0;
-  _all_q[2].d2g[0][0] = 0.0;
+  all_q[0].d2g[0][0] = 0.0;
+  all_q[1].d2g[0][0] = 0.0;
+  all_q[2].d2g[0][0] = 0.0;
   // d(dg/dp)/dq
-  _all_q[0].d2g[0][1] = 0.0;
-  _all_q[1].d2g[0][1] = 0.0;
-  _all_q[2].d2g[0][1] = 0.0;
+  all_q[0].d2g[0][1] = 0.0;
+  all_q[1].d2g[0][1] = 0.0;
+  all_q[2].d2g[0][1] = 0.0;
   // d(dg/dq)/dp
-  _all_q[0].d2g[1][0] = 0.0;
-  _all_q[1].d2g[1][0] = 0.0;
-  _all_q[2].d2g[1][0] = 0.0;
+  all_q[0].d2g[1][0] = 0.0;
+  all_q[1].d2g[1][0] = 0.0;
+  all_q[2].d2g[1][0] = 0.0;
   // d(dg/dq)/dq
   if (_small_smoother2 == 0.0)
-    _all_q[0].d2g[1][1] = 0.0;
+    all_q[0].d2g[1][1] = 0.0;
   else
-    _all_q[0].d2g[1][1] = _small_smoother2 / std::pow(Utility::pow<2>(q) + _small_smoother2, 1.5);
-  _all_q[1].d2g[1][1] = 0.0;
-  _all_q[2].d2g[1][1] = 0.0;
-}
-
-Real
-ComputeCappedWeakPlaneStress::yieldF(Real p, Real q, const std::vector<Real> & intnl) const
-{
-  std::vector<Real> yf(_num_yf);
-  unsmoothedYieldFunctions(p, q, intnl, yf);
-  std::sort(yf.begin(), yf.end());
-  unsigned num = yf.size();
-  while (num > 1 && yf[num - 1] < yf[num - 2] + _smoothing_tol)
-  {
-    yf[num - 2] = yf[num - 1] + ismoother(yf[num - 2] - yf[num - 1]);
-    yf.pop_back();
-    num = yf.size();
-  }
-  return yf.back();
-}
-
-ComputeCappedWeakPlaneStress::f_and_derivs
-ComputeCappedWeakPlaneStress::smoothAllQuantities(Real p, Real q, const std::vector<Real> & intnl)
-{
-  for (unsigned i = _all_q.size(); i < _num_yf; ++i)
-    _all_q.push_back(f_and_derivs(2, 2));
-
-  unsmoothedYieldFunctions(p, q, intnl);
-  dyieldFunctions(p, q, intnl);
-  dyieldFunctions_di(p, q, intnl);
-  dflowPotential(p, q, intnl);
-  d2flowPotential(p, q, intnl);
-  d2flowPotential_di(p, q, intnl);
-
-  std::sort(_all_q.begin(), _all_q.end());
-
-  /* This is the key to my smoothing strategy.  While the two
-   * biggest yield functions are closer to each other than
-   * _smoothing_tol, make a linear combination of them:
-   * _all_q[num - 2].f = the second-biggest yield function
-   * = _all_q[num - 1].f + ismoother(_all_q[num - 2].f - _all_q[num - 1].f);
-   * = biggest yield function + ismoother(second-biggest - biggest)
-   * Then pop off the biggest yield function, and repeat this
-   * strategy.
-   * Of course all the derivatives must also be smoothed.
-   * I assume that d(flow potential)/dstress gets smoothed by the *yield function*, viz
-   * d(second-biggest-g) = d(biggest-g) + smoother(second-biggest-f - biggest-f)*(d(second-biggest-g) - d(biggest-g))
-   * Only time will tell whether this is a good strategy.
-   */
-  unsigned num = _all_q.size();
-  while (num > 1 && _all_q[num - 1].f < _all_q[num - 2].f + _smoothing_tol)
-  {
-    const Real ism = ismoother(_all_q[num - 2].f - _all_q[num - 1].f);
-    const Real sm = smoother(_all_q[num - 2].f - _all_q[num - 1].f);
-    const Real dsm = dsmoother(_all_q[num - 2].f - _all_q[num - 1].f);
-    for (unsigned i = 0; i < _num_pq; ++i)
-    {
-      for (unsigned j = 0; j < _num_pq; ++j)
-        _all_q[num - 2].d2g[i][j] = _all_q[num - 1].d2g[i][j] + dsm * (_all_q[num - 2].df[j] - _all_q[num - 1].df[j]) * (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]) + sm * (_all_q[num - 2].d2g[i][j] - _all_q[num - 1].d2g[i][j]);
-      for (unsigned j = 0; j < _num_intnl; ++j)
-        _all_q[num - 2].d2g_di[i][j] = _all_q[num - 1].d2g_di[i][j] + dsm * (_all_q[num - 2].df_di[j] - _all_q[num - 1].df_di[j]) * (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]) + sm * (_all_q[num - 2].d2g_di[i][j] - _all_q[num - 1].d2g_di[i][j]);
-    }
-    for (unsigned i = 0; i < _num_pq; ++i)
-    {
-      _all_q[num - 2].dg[i] = _all_q[num - 1].dg[i] + sm * (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]);
-      _all_q[num - 2].df[i] = _all_q[num - 1].df[i] + sm * (_all_q[num - 2].df[i] - _all_q[num - 1].df[i]);
-    }
-    for (unsigned i = 0; i < _num_intnl; ++i)
-      _all_q[num - 2].df_di[i] = _all_q[num - 1].df_di[i] + sm * (_all_q[num - 2].df_di[i] - _all_q[num - 1].df_di[i]);
-    _all_q[num - 2].f = _all_q[num - 1].f + ism;
-    _all_q.pop_back();
-    num = _all_q.size();
-  }
-  return _all_q.back();
-}
-
-
-Real
-ComputeCappedWeakPlaneStress::ismoother(Real f_diff) const
-{
-  mooseAssert(f_diff <= 0.0, "ComputeCappedWeakPlaneStress: ismoother called with positive argument");
-  if (f_diff <= -_smoothing_tol)
-    return 0.0;
-  return 0.5 * (f_diff + _smoothing_tol) - _smoothing_tol / M_PI * std::cos(0.5 * M_PI * f_diff / _smoothing_tol);
-}
-
-
-Real
-ComputeCappedWeakPlaneStress::smoother(Real f_diff) const
-{
-  if (f_diff >= _smoothing_tol)
-    return 1.0;
-  else if (f_diff <= -_smoothing_tol)
-    return 0.0;
-  return 0.5 * (1.0 + std::sin(f_diff * M_PI * 0.5 / _smoothing_tol));
-}
-
-Real
-ComputeCappedWeakPlaneStress::dsmoother(Real f_diff) const
-{
-  if (f_diff >= _smoothing_tol)
-    return 0.0;
-  else if (f_diff <= -_smoothing_tol)
-    return 0.0;
-  return 0.25 * M_PI / _smoothing_tol * std::cos(f_diff * M_PI * 0.5 / _smoothing_tol);
-}
-
-
-int
-ComputeCappedWeakPlaneStress::lineSearch(Real & res2, Real & gaE, Real & p, Real & q, Real q_trial, Real p_trial, f_and_derivs & smoothed_q, const std::array<Real, 2> intnl_ok)
-{
-  const Real res2_old = res2;
-  const Real gaE_old = gaE;
-  const Real p_old = p;
-  const Real q_old = q;
-  const Real de_gaE = _rhs[0];
-  const Real de_p = _rhs[1];
-  const Real de_q = _rhs[2];
-
-  const Real Ezzzz = _elasticity_tensor[_qp](2, 2, 2, 2);
-  const Real Ezxzx = _elasticity_tensor[_qp](2, 0, 2, 0);
-
-  Real lam = 1.0; // line-search parameter
-  const Real lam_min = 1E-10; // minimum value of lam allowed
-  const Real slope = -2.0 * res2_old; // "Numerical Recipes" uses -b*A*x, in order to check for roundoff, but i hope the nrStep would warn if there were problems
-  Real tmp_lam; // cached value of lam used in quadratic & cubic line search
-  Real f2 = res2_old; // cached value of f = residual2 used in the cubic in the line search
-  Real lam2 = lam; // cached value of lam used in the cubic in the line search
-
-  while (true)
-  {
-    // update variables using the current line-search parameter
-    gaE = gaE_old + lam * de_gaE;
-    p = p_old + lam * de_p;
-    q = q_old + lam * de_q;
-
-    // and internal parameters
-    _intnl[_qp][0] = intnl_ok[0] + (q_trial - q) / Ezxzx;
-    const Real tanpsi = _tan_psi.value(_intnl[_qp][0]);
-    _intnl[_qp][1] = intnl_ok[1] + (p_trial - p) / Ezzzz - (q_trial - q) * tanpsi / Ezxzx;
-
-    smoothed_q = smoothAllQuantities(p, q, _intnl[_qp]);
-
-    // update rhs for next-time through
-    res2 = calculateRHS(p_trial, q_trial, p, q, gaE, smoothed_q);
-
-    // do the line-search
-    if (res2 < res2_old + 1E-4 * lam * slope)
-      break;
-    else if (lam < lam_min)
-      return 1;
-    else if (lam == 1.0)
-    {
-      // model as a quadratic
-      tmp_lam = - 0.5 * slope / (res2 - res2_old - slope);
-    }
-    else
-    {
-      //model as a cubic
-      const Real rhs1 = res2 - res2_old - lam * slope;
-      const Real rhs2 = f2 - res2_old - lam2 * slope;
-      const Real a = (rhs1 / Utility::pow<2>(lam) - rhs2 / Utility::pow<2>(lam2)) / (lam - lam2);
-      const Real b = (-lam2 * rhs1 / Utility::pow<2>(lam) + lam * rhs2 / Utility::pow<2>(lam2)) / (lam - lam2);
-      if (a == 0.0)
-        tmp_lam = -slope / (2.0 * b);
-      else
-      {
-        const Real disc = Utility::pow<2>(b) - 3.0 * a * slope;
-        if (disc < 0)
-          tmp_lam = 0.5 * lam;
-        else if (b <= 0)
-          tmp_lam = (-b + std::sqrt(disc)) / (3.0 * a);
-        else
-          tmp_lam = -slope / (b + std::sqrt(disc));
-      }
-      if (tmp_lam > 0.5 * lam)
-        tmp_lam = 0.5 * lam;
-    }
-    lam2 = lam;
-    f2 = res2;
-    lam = std::max(tmp_lam, 0.1 * lam);
-  }
-
-  if (lam < 1.0)
-    _linesearch_needed[_qp] = 1.0;
-  return 0;
-}
-
-
-int
-ComputeCappedWeakPlaneStress::nrStep(const f_and_derivs & smoothed_q, Real q_trial, Real q, Real gaE)
-{
-  const Real Ezzzz = _elasticity_tensor[_qp](2, 2, 2, 2);
-  const Real Ezxzx = _elasticity_tensor[_qp](2, 0, 2, 0);
-
-  const Real dintnl0_dq = -1.0 / Ezxzx;
-  const Real dintnl1_dp = -1.0 / Ezzzz;
-  const Real tanpsi = _tan_psi.value(_intnl[_qp][0]);
-  const Real dintnl1_dq = tanpsi / Ezxzx - (q_trial - q) * _tan_psi.derivative(_intnl[_qp][0]) * dintnl0_dq / Ezxzx;
-
-  std::array<double, _num_rhs * _num_rhs> jac;
-
-  // LAPACK gsev stores the matrix in the following way:
-  // d(-yieldF)/d(gaE)
-  jac[0] = 0;
-  // d(-rhs[1])/d(gaE)
-  jac[1] = - smoothed_q.dg[0];
-  // d(-rhs[2])/d(gaE))
-  jac[2] = - Ezxzx * smoothed_q.dg[1] / Ezzzz;
-  // d(-yieldF)/d(p)
-  jac[3] = - (smoothed_q.df[0] + smoothed_q.df_di[1] * dintnl1_dp);
-  // d(-rhs[1])/d(p)
-  jac[4] = - 1.0 - gaE * (smoothed_q.d2g[0][0] + smoothed_q.d2g_di[0][1] * dintnl1_dp);
-  // d(-rhs[2])/d(p)
-  jac[5] = - Ezxzx * gaE / Ezzzz * (smoothed_q.d2g[1][0] + smoothed_q.d2g_di[1][1] * dintnl1_dp);
-  // d(-yieldF)/d(q)
-  jac[6] = - (smoothed_q.df[1] + smoothed_q.df_di[0] * dintnl0_dq + smoothed_q.df_di[1] * dintnl1_dq);
-  // d(-rhs[1])/d(q)
-  jac[7] = - gaE * (smoothed_q.d2g[0][1] + smoothed_q.d2g_di[0][0] * dintnl0_dq + smoothed_q.d2g_di[0][1] * dintnl1_dq);
-  // d(-rhs[2])/d(q)
-  jac[8] = - 1.0 - Ezxzx * gaE / Ezzzz * (smoothed_q.d2g[1][1] + smoothed_q.d2g_di[1][0] * dintnl0_dq + smoothed_q.d2g_di[1][1] * dintnl1_dq);
-
-  // use LAPACK to solve the linear system
-  const int nrhs = 1;
-  std::array<int, _num_rhs> ipiv;
-  int info;
-  const int gesv_num_rhs = _num_rhs;
-  LAPACKgesv_(&gesv_num_rhs, &nrhs, &jac[0], &gesv_num_rhs, &ipiv[0], &_rhs[0], &gesv_num_rhs, &info);
-  return info;
+    all_q[0].d2g[1][1] = _small_smoother2 / std::pow(Utility::pow<2>(q) + _small_smoother2, 1.5);
+  all_q[1].d2g[1][1] = 0.0;
+  all_q[2].d2g[1][1] = 0.0;
 }
 
 void
-ComputeCappedWeakPlaneStress::initialiseVars(Real p_trial, Real q_trial, Real & p, Real & q, Real & gaE)
+ComputeCappedWeakPlaneStress::initialiseVars(Real p_trial, Real q_trial, const std::vector<Real> & intnl_old, Real & p, Real & q, Real & gaE, std::vector<Real> & intnl) const
 {
-  const Real Ezzzz = _elasticity_tensor[_qp](2, 2, 2, 2);
-  const Real Ezxzx = _elasticity_tensor[_qp](2, 0, 2, 0);
-  const Real tanpsi = _tan_psi.value(_intnl[_qp][0]);
+  const Real tanpsi = _tan_psi.value(intnl_old[0]);
 
   if (!_perfect_guess)
   {
@@ -830,10 +295,10 @@ ComputeCappedWeakPlaneStress::initialiseVars(Real p_trial, Real q_trial, Real & 
   }
   else
   {
-    const Real coh = _cohesion.value(_intnl[_qp][0]);
-    const Real tanphi = _tan_phi.value(_intnl[_qp][0]);
-    const Real tens = _tstrength.value(_intnl[_qp][1]);
-    const Real comp = _cstrength.value(_intnl[_qp][1]);
+    const Real coh = _cohesion.value(intnl_old[0]);
+    const Real tanphi = _tan_phi.value(intnl_old[0]);
+    const Real tens = _tstrength.value(intnl_old[1]);
+    const Real comp = _cstrength.value(intnl_old[1]);
     const Real q_at_T = coh - tens * tanphi;
     const Real q_at_C = coh + comp * tanphi;
 
@@ -855,7 +320,7 @@ ComputeCappedWeakPlaneStress::initialiseVars(Real p_trial, Real q_trial, Real & 
     {
       // shear failure or a mixture
       // Calculate ga assuming a pure shear failure
-      const Real ga = (q_trial + p_trial * tanphi - coh) / (Ezxzx + Ezzzz * tanphi * tanpsi);
+      const Real ga = (q_trial + p_trial * tanphi - coh) / (_Eqq + _Epp * tanphi * tanpsi);
       if (ga <= 0 && p_trial <= tens && p_trial >= - comp) {
         // very close to one of the rounded corners:  there is no advantage to guessing the solution, so:
         p = p_trial;
@@ -864,7 +329,7 @@ ComputeCappedWeakPlaneStress::initialiseVars(Real p_trial, Real q_trial, Real & 
       }
       else
       {
-        q = q_trial - Ezxzx * ga;
+        q = q_trial - _Eqq * ga;
         if (q <= 0.0 && q_at_T <= 0.0)
         {
           // user has set tensile strength so large that it is irrelevant: return to the tip of the shear cone
@@ -884,9 +349,9 @@ ComputeCappedWeakPlaneStress::initialiseVars(Real p_trial, Real q_trial, Real & 
           // pure shear is incorrect: mixture of compression and shear is correct
           q = q_at_C;
           p = - comp;
-          if (p - p_trial < Ezzzz * tanpsi * (q_trial - q) / Ezxzx)
+          if (p - p_trial < _Epp * tanpsi * (q_trial - q) / _Eqq)
             // trial point is sitting almost directly above corner
-            gaE = (q_trial - q) * Ezzzz / Ezxzx;
+            gaE = (q_trial - q) * _Epp / _Eqq;
           else
             // trial point is sitting to the left of the corner
             gaE = (p - p_trial) / tanpsi;
@@ -894,31 +359,84 @@ ComputeCappedWeakPlaneStress::initialiseVars(Real p_trial, Real q_trial, Real & 
         else
         {
           // pure shear was correct
-          p = p_trial - Ezzzz * ga * tanpsi;
-          gaE = ga * Ezzzz;
+          p = p_trial - _Epp * ga * tanpsi;
+          gaE = ga * _Epp;
         }
       }
     }
   }
-
-  _intnl[_qp][0] = _intnl_old[_qp][0] + (q_trial - q) / Ezxzx;
-  _intnl[_qp][1] = _intnl_old[_qp][1] + (p_trial - p) / Ezzzz - (q_trial - q) * tanpsi / Ezxzx;
-}
-
-Real
-ComputeCappedWeakPlaneStress::calculateRHS(Real p_trial, Real q_trial, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q)
-{
-  const Real Ezzzz = _elasticity_tensor[_qp](2, 2, 2, 2);
-  const Real Ezxzx = _elasticity_tensor[_qp](2, 0, 2, 0);
-
-  _rhs[0] = smoothed_q.f;
-  _rhs[1] = p - p_trial + gaE * smoothed_q.dg[0];
-  _rhs[2] = q - q_trial + Ezxzx * gaE / Ezzzz * smoothed_q.dg[1];
-  return _rhs[0] * _rhs[0] + _rhs[1] * _rhs[1] + _rhs[2] * _rhs[2];
+  setIntnlValues(p_trial, q_trial, p, q, intnl_old, intnl);
 }
 
 void
-ComputeCappedWeakPlaneStress::errorHandler(const std::string & message)
+ComputeCappedWeakPlaneStress::setIntnlValues(Real p_trial, Real q_trial, Real p, Real q, const std::vector<Real> & intnl_old, std::vector<Real> & intnl) const
 {
-  throw MooseException(message);
+  intnl[0] = intnl_old[0] + (q_trial - q) / _Eqq;
+  const Real tanpsi = _tan_psi.value(intnl[0]);
+  intnl[1] = intnl_old[1] + (p_trial - p) / _Epp - (q_trial - q) * tanpsi / _Eqq;
+}
+
+
+RankTwoTensor
+ComputeCappedWeakPlaneStress::dpdstress(const RankTwoTensor & /*stress*/) const
+{
+  RankTwoTensor deriv = RankTwoTensor();
+  deriv(2, 2) = 1.0;
+  return deriv;
+}
+
+RankFourTensor
+ComputeCappedWeakPlaneStress::d2pdstress2(const RankTwoTensor & /*stress*/) const
+{
+  return RankFourTensor();
+}
+
+RankTwoTensor
+ComputeCappedWeakPlaneStress::dqdstress(const RankTwoTensor & stress) const
+{
+  RankTwoTensor deriv = RankTwoTensor();
+  const Real q = std::sqrt(Utility::pow<2>(stress(2, 0)) + Utility::pow<2>(stress(2, 1)));
+  if (q > 0.0)
+  {
+    deriv(2, 0) = deriv(0, 2) = 0.5 * stress(2, 0) / q;
+    deriv(2, 1) = deriv(1, 2) = 0.5 * stress(2, 1) / q;
+  }
+  else
+  {
+    // derivative is not defined here.  For now i'll set:
+    deriv(2, 0) = deriv(0, 2) = 0.5;
+    deriv(2, 1) = deriv(1, 2) = 0.5;
+  }
+  return deriv;
+}
+
+RankFourTensor
+ComputeCappedWeakPlaneStress::d2qdstress2(const RankTwoTensor & stress) const
+{
+  RankFourTensor d2 = RankFourTensor();
+
+  const Real q = std::sqrt(Utility::pow<2>(stress(2, 0)) + Utility::pow<2>(stress(2, 1)));
+  if (q == 0.0)
+    return d2;
+
+  RankTwoTensor dq = RankTwoTensor();
+  dq(2, 0) = dq(0, 2) = 0.25 * (stress(2, 0) + stress(0, 2)) / q;
+  dq(2, 1) = dq(1, 2) = 0.25 * (stress(2, 1) + stress(1, 2)) / q;
+
+  for (unsigned i = 0; i < _tensor_dimensionality; ++i)
+    for (unsigned j = 0; j < _tensor_dimensionality; ++j)
+      for (unsigned k = 0; k < _tensor_dimensionality; ++k)
+        for (unsigned l = 0; l < _tensor_dimensionality; ++l)
+          d2(i, j, k, l) = - dq(i, j) * dq(k, l) / q;
+
+  d2(0, 2, 0, 2) += 0.25 / q;
+  d2(0, 2, 2, 0) += 0.25 / q;
+  d2(2, 0, 0, 2) += 0.25 / q;
+  d2(2, 0, 2, 0) += 0.25 / q;
+  d2(1, 2, 1, 2) += 0.25 / q;
+  d2(1, 2, 2, 1) += 0.25 / q;
+  d2(2, 1, 1, 2) += 0.25 / q;
+  d2(2, 1, 2, 1) += 0.25 / q;
+
+  return d2;
 }

--- a/modules/tensor_mechanics/src/materials/PQPlasticModel.C
+++ b/modules/tensor_mechanics/src/materials/PQPlasticModel.C
@@ -1,0 +1,698 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#include "PQPlasticModel.h"
+
+#include "Conversion.h" // for stringify
+#include "libmesh/utility.h" // for Utility::pow
+
+template<>
+InputParameters validParams<PQPlasticModel>()
+{
+  InputParameters params = validParams<ComputeStressBase>();
+  params.addClassDescription("Return-map and Jacobian algorithms for (P, Q) plastic models");
+  params.addRangeCheckedParam<unsigned int>("max_NR_iterations", 20, "max_NR_iterations>0", "Maximum number of Newton-Raphson iterations allowed during the return-map algorithm");
+  params.addParam<bool>("perform_finite_strain_rotations", false, "Tensors are correctly rotated in finite-strain simulations.  For optimal performance you can set this to 'false' if you are only ever using small strains");
+  params.addRequiredParam<Real>("smoothing_tol", "Intersections of the yield surfaces will be smoothed by this amount (this is measured in units of stress).  Often this is related to other physical parameters (eg, 0.1*cohesion) but it is important to set this small enough so that the individual yield surfaces do not mix together in the smoothing process to produce a result where no stress is admissible (for example, mixing together tensile and compressive failure envelopes).");
+  params.addRequiredParam<Real>("yield_function_tol", "The return-map process will be deemed to have converged if all yield functions are within yield_function_tol of zero.  If this is set very low then precision-loss might be encountered: if the code detects precision loss then it also deems the return-map process has converged.");
+  MooseEnum tangent_operator("elastic nonlinear", "nonlinear");
+  params.addParam<MooseEnum>("tangent_operator", tangent_operator, "Type of tangent operator to return.  'elastic': return the elasticity tensor.  'nonlinear': return the full consistent tangent operator.");
+  params.addParam<Real>("min_step_size", 1.0, "In order to help the Newton-Raphson procedure, the applied strain increment may be applied in sub-increments of size greater than this value.  Usually it is better for Moose's nonlinear convergence to increase max_NR_iterations rather than decrease this parameter.");
+  params.addParam<bool>("warn_about_precision_loss", false, "Output a message to the console every time precision-loss is encountered during the Newton-Raphson process");
+  return params;
+}
+
+PQPlasticModel::PQPlasticModel(const InputParameters & parameters, unsigned num_yf, unsigned num_intnl) :
+    ComputeStressBase(parameters),
+    _num_yf(num_yf),
+    _num_intnl(num_intnl),
+    _max_nr_its(getParam<unsigned>("max_NR_iterations")),
+    _perform_finite_strain_rotations(getParam<bool>("perform_finite_strain_rotations")),
+    _smoothing_tol(getParam<Real>("smoothing_tol")),
+    _f_tol(getParam<Real>("yield_function_tol")),
+    _f_tol2(Utility::pow<2>(getParam<Real>("yield_function_tol"))),
+    _tangent_operator_type((TangentOperatorEnum)(int)getParam<MooseEnum>("tangent_operator")),
+    _min_step_size(getParam<Real>("min_step_size")),
+    _step_one(declareRestartableData<bool>("step_one", true)),
+    _warn_about_precision_loss(getParam<bool>("warn_about_precision_loss")),
+
+    _plastic_strain(declareProperty<RankTwoTensor>("plastic_strain")),
+    _plastic_strain_old(declarePropertyOld<RankTwoTensor>("plastic_strain")),
+    _intnl(declareProperty<std::vector<Real> >("plastic_internal_parameter")),
+    _intnl_old(declarePropertyOld<std::vector<Real> >("plastic_internal_parameter")),
+    _yf(declareProperty<std::vector<Real> >("plastic_yield_function")),
+    _iter(declareProperty<Real>("plastic_NR_iterations")), // this is really an unsigned int, but for visualisation i convert it to Real
+    _linesearch_needed(declareProperty<Real>("plastic_linesearch_needed")), // this is really a boolean, but for visualisation i convert it to Real
+
+    _strain_increment(getMaterialPropertyByName<RankTwoTensor>(_base_name + "strain_increment")),
+    _rotation_increment(getMaterialPropertyByName<RankTwoTensor>(_base_name + "rotation_increment")),
+
+    _stress_old(declarePropertyOld<RankTwoTensor>(_base_name + "stress")),
+    _elastic_strain_old(declarePropertyOld<RankTwoTensor>(_base_name + "elastic_strain")),
+
+    _p_trial(0.0),
+    _q_trial(0.0),
+    _intnl_ok(_num_intnl),
+    _dintnl(_num_intnl),
+    _Epp(0.0),
+    _Eqq(0.0),
+
+    _dgaE_dpt(0.0),
+    _dp_dpt(0.0),
+    _dq_dpt(0.0),
+    _dgaE_dqt(0.0),
+    _dp_dqt(0.0),
+    _dq_dqt(0.0),
+    _all_q(_num_yf)
+{
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    _dintnl[i].resize(_num_pq);
+  for (unsigned i = 0; i < _num_yf; ++i)
+    _all_q[i] = f_and_derivs(_num_pq, _num_intnl);
+}
+
+void
+PQPlasticModel::initQpStatefulProperties()
+{
+  ComputeStressBase::initQpStatefulProperties();
+
+  _plastic_strain[_qp].zero();
+  _intnl[_qp].assign(_num_intnl, 0);
+  _yf[_qp].assign(_num_yf, 0);
+  _iter[_qp] = 0.0;
+  _linesearch_needed[_qp] = 0.0;
+}
+
+void
+PQPlasticModel::computeQpStress()
+{
+  initialiseReturnProcess();
+  if (_t_step >= 2)
+    _step_one = false;
+
+  returnMap();
+
+  //Update measures of strain
+  _elastic_strain[_qp] = _elastic_strain_old[_qp] + _strain_increment[_qp] - (_plastic_strain[_qp] - _plastic_strain_old[_qp]);
+
+  //Rotate the tensors to the current configuration
+  if (_perform_finite_strain_rotations)
+  {
+    _stress[_qp] = _rotation_increment[_qp]*_stress[_qp]*_rotation_increment[_qp].transpose();
+    _elastic_strain[_qp] = _rotation_increment[_qp] * _elastic_strain[_qp] * _rotation_increment[_qp].transpose();
+    _plastic_strain[_qp] = _rotation_increment[_qp] * _plastic_strain[_qp] * _rotation_increment[_qp].transpose();
+  }
+}
+
+void
+PQPlasticModel::returnMap()
+{
+  // initially assume an elastic deformation
+  _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * _strain_increment[_qp];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    _intnl[_qp][i] = _intnl_old[_qp][i];
+  _iter[_qp] = 0.0;
+  _linesearch_needed[_qp] = 0.0;
+
+  computePQ(_stress[_qp], _p_trial, _q_trial);
+  yieldFunctionValues(_p_trial, _q_trial, _intnl[_qp], _yf[_qp]);
+
+  /* Need to consider smoothing_tol, not just yf<=0, because
+   * some yield functions might mix.  However, if some yield
+   * functions are -smoothing_tol <= yf, then the smoothed
+   * yield function must be computed and checked vs f_tol
+   */
+  bool elastic = true;
+  for (auto yf : _yf[_qp])
+    if (yf > -_smoothing_tol)
+      elastic = false;
+  if (!elastic && yieldF(_p_trial, _q_trial, _intnl[_qp]) <= _f_tol)
+    elastic = true;
+  if (elastic)
+  {
+    _plastic_strain[_qp] = _plastic_strain_old[_qp];
+    if (_fe_problem.currentlyComputingJacobian())
+      _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
+    return;
+  }
+
+
+  const RankTwoTensor stress_trial = _stress[_qp];
+  /* The trial stress must be inadmissible
+   * so we need to return to the yield surface.  The following
+   * equations must be satisfied.
+   *
+   * 0 = f(p, q, intnl)                  = rhs[0]
+   * 0 = p - p^trial + Epp * ga * dg/dp  = rhs[1]
+   * 0 = q - q^trial + Eqq * ga * dg/dq  = rhs[2]
+   * Equations defining intnl parameters as functions of (p, q, p_trial, q_trial, intnl_old)
+   *
+   * The unknowns are p, q, ga, and intnl.
+   * I find it convenient to solve the first three equations for p, q and ga*Epp=gaE,
+   * while substituting the "intnl parameters" equations into these during the solve process
+   */
+
+  preReturnMap(_p_trial, _q_trial, _stress[_qp], _intnl_old[_qp], _yf[_qp]);
+  setEppEqq(_elasticity_tensor[_qp], _Epp, _Eqq);
+
+  // values of p, q  and intnl we know to be admissible
+  Real p_ok;
+  Real q_ok;
+  computePQ(_stress_old[_qp], p_ok, q_ok);
+  std::copy(_intnl_old[_qp].begin(), _intnl_old[_qp].end(), _intnl_ok.begin());
+  // note that _intnl[_qp] is the "running" intnl variable that gets updated every NR iteration
+  if (isParamValid("initial_stress") && _step_one)
+  {
+    // the initial stress might be inadmissible
+    p_ok = 0.0;
+    q_ok = 0.0;
+  }
+
+  _dgaE_dpt = 0.0;
+  _dp_dpt = 0.0;
+  _dq_dpt = 0.0;
+  _dgaE_dqt = 0.0;
+  _dp_dqt = 0.0;
+  _dq_dqt = 0.0;
+
+  // Return-map problem: must apply the following changes in p and q, and find the returned p and q.
+  const Real del_p = _p_trial - p_ok;
+  const Real del_q = _q_trial - q_ok;
+
+  Real step_taken = 0.0; // amount of (del_p, del_q) that we've applied and the return-map problem has succeeded
+  Real step_size = 1.0; // potentially can apply (del_p, del_q) in substeps
+  Real gaE_total = 0.0;
+
+  // current values of the yield function, derivatives, etc
+  f_and_derivs smoothed_q;
+
+  // In the following sub-stepping procedure it is possible that
+  // the last step is an elastic step, and therefore smoothed_q won't
+  // be computed on the last step, so we have to compute it.
+  bool smoothed_q_calculated = false;
+
+  while (step_taken < 1.0 && step_size >= _min_step_size)
+  {
+    if (1.0 - step_taken < step_size)
+      // prevent over-shoots of substepping
+      step_size = 1.0 - step_taken;
+
+    // trial variables in terms of admissible variables
+    _p_trial = p_ok + step_size * del_p;
+    _q_trial = q_ok + step_size * del_q;
+
+    // initialise (p, q, gaE)
+    Real p = _p_trial;
+    Real q = _q_trial;
+    Real gaE = 0.0;
+
+    // flags indicating failure of newton-raphson and line-search
+    int nr_failure = 0;
+    int ls_failure = 0;
+
+    // NR iterations taken in this substep
+    Real step_iter = 0.0;
+
+    // The residual-squared for the line-search
+    Real res2 = 0.0;
+
+    if (step_size < 1.0 && yieldF(_p_trial, _q_trial, _intnl[_qp]) <= _f_tol)
+      // This is an elastic step
+      // The "step_size < 1.0" in above condition is for efficiency: we definitely
+      // know that this is a plastic step if step_size = 1.0
+      smoothed_q_calculated = false;
+    else
+    {
+      // this is a plastic step
+
+      // initialise p, q and gaE using a good guess based on the non-smoothed situation
+      initialiseVars(_p_trial, _q_trial, _intnl_old[_qp], p, q, gaE, _intnl[_qp]);
+      smoothed_q = smoothAllQuantities(p, q, _intnl[_qp]);
+      smoothed_q_calculated = true;
+      res2 = calculateRHS(_p_trial, _q_trial, p, q, gaE, smoothed_q);
+
+      // Perform a Newton-Raphson with linesearch to get p, q, gaE, and also smoothed_q
+      while (res2 > _f_tol2 && step_iter < (float) _max_nr_its && nr_failure == 0 && ls_failure == 0)
+      {
+        // solve the linear system and store the answer (the "updates") in _rhs
+        nr_failure = nrStep(smoothed_q, _p_trial, _q_trial, p, q, gaE);
+        if (nr_failure != 0)
+          break;
+
+        // check for precision loss
+        if (std::abs(_rhs[0]) <= 1E-13 * std::abs(gaE) &&
+            std::abs(_rhs[1]) <= 1E-13 * std::abs(p) &&
+            std::abs(_rhs[2]) <= 1E-13 * std::abs(q)) {
+          if (_warn_about_precision_loss)
+            Moose::err << "PQPlasticModel: precision-loss in element " <<_current_elem->id() << " quadpoint=" << _qp << " p=" << p << " q=" << q << " gaE=" << gaE << "\n";
+          res2 = 0.0;
+          break;
+        }
+
+        // apply (parts of) the updates, re-calculate smoothed_q, and res2
+        ls_failure = lineSearch(res2, gaE, p, q, _p_trial, _q_trial, smoothed_q, _intnl_ok);
+        step_iter++;
+      }
+
+    }
+
+    if (res2 <= _f_tol2 && step_iter < (float) _max_nr_its && nr_failure == 0 && ls_failure == 0 && gaE >= 0.0)
+    {
+      // this Newton-Raphson worked fine, or this was an elastic step
+      p_ok = p;
+      q_ok = q;
+      step_taken += step_size;
+      gaE_total += gaE;
+      setIntnlValues(_p_trial, _q_trial, p_ok, q_ok, _intnl_ok, _intnl[_qp]);
+      std::copy(_intnl[_qp].begin(), _intnl[_qp].end(), _intnl_ok.begin());
+      // calculate dp/dp_trial, dp/dq_trial, etc, for Jacobian
+      dVardTrial(!smoothed_q_calculated, _p_trial, _q_trial, p_ok, q_ok, gaE, _intnl_ok, smoothed_q, step_size);
+      if (step_iter > _iter[_qp])
+        _iter[_qp] = step_iter;
+      step_size *= 1.1;
+    }
+    else
+    {
+      // Newton-Raphson + line-search process failed
+      step_size *= 0.5;
+    }
+  }
+
+
+  if (step_size < _min_step_size)
+    errorHandler("PQPlasticModel: Minimum step-size violated");
+
+
+  // success!
+  finaliseReturnProcess();
+  yieldFunctionValues(p_ok, q_ok, _intnl[_qp], _yf[_qp]);
+
+  if (!smoothed_q_calculated)
+    smoothed_q = smoothAllQuantities(p_ok, q_ok, _intnl[_qp]);
+
+  setStressAfterReturn(stress_trial, p_ok, q_ok, gaE_total, _intnl[_qp], smoothed_q, _stress[_qp]);
+
+  _plastic_strain[_qp] = _plastic_strain_old[_qp] + _strain_increment[_qp] + _elasticity_tensor[_qp].invSymm() * (_stress_old[_qp] - _stress[_qp]);
+
+  consistentTangentOperator(stress_trial, _p_trial, _q_trial, _stress[_qp], p_ok, q_ok, gaE_total, smoothed_q, _Jacobian_mult[_qp]);
+}
+
+void
+PQPlasticModel::dVardTrial(bool elastic_only, Real p_trial, Real q_trial, Real p, Real q, Real gaE, const std::vector<Real> & intnl, const f_and_derivs & smoothed_q, Real step_size)
+{
+  if (!_fe_problem.currentlyComputingJacobian())
+    return;
+
+  if (_tangent_operator_type == TangentOperatorEnum::elastic)
+    return;
+
+  if (elastic_only)
+  {
+    // no change to gaE, and dp_dqt and dq_dpt are unchanged from previous step
+    _dp_dpt = step_size + _dp_dpt;
+    _dq_dqt = step_size + _dq_dqt;
+    return;
+  }
+
+  setIntnlDerivatives(p_trial, q_trial, p, q, intnl, _dintnl);
+
+  // _rhs is defined above, the following are changes in rhs wrt the trial p and q values
+  // In the following we use d(intnl)/d(trial variable) = - d(intnl)/d(variable)
+  std::array<Real, _num_pq * _num_rhs> rhs_cto{0.0};
+
+  // change in p_trial
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    rhs_cto[0] -= smoothed_q.df_di[i] * _dintnl[i][0];
+  rhs_cto[1] = - 1.0;
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    rhs_cto[1] -= gaE * smoothed_q.d2g_di[0][i] * _dintnl[i][0];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    rhs_cto[2] -= _Eqq * gaE / _Epp * smoothed_q.d2g_di[1][i] * _dintnl[i][0];
+
+  // change in q_trial
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    rhs_cto[3] -= smoothed_q.df_di[i] * _dintnl[i][1];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    rhs_cto[4] -= gaE * smoothed_q.d2g_di[0][i] * _dintnl[i][1];
+  rhs_cto[5] = -1.0;
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    rhs_cto[5] -= _Eqq * gaE / _Epp * smoothed_q.d2g_di[1][i] * _dintnl[i][1];
+
+  // jac = d(-rhs)/d(var), where var[0] = gaE, var[1] = p, var[2] = q.
+  std::array<double, _num_rhs * _num_rhs> jac;
+  dnRHSdVar(smoothed_q, _dintnl, gaE, jac);
+
+  std::array<int, _num_rhs> ipiv;
+  int info;
+  const int gesv_num_rhs = _num_rhs;
+  const int gesv_num_pq = _num_pq;
+  LAPACKgesv_(&gesv_num_rhs, &gesv_num_pq, &jac[0], &gesv_num_rhs, &ipiv[0], &rhs_cto[0], &gesv_num_rhs, &info);
+  if (info != 0)
+    errorHandler("PQPlasticModel: PETSC LAPACK gsev routine returned with error code " + Moose::stringify(info));
+
+  const Real dgaEn_dptn = rhs_cto[0];
+  const Real dpn_dptn = rhs_cto[1];
+  const Real dqn_dptn = rhs_cto[2];
+  const Real dgaEn_dqtn = rhs_cto[3];
+  const Real dpn_dqtn = rhs_cto[4];
+  const Real dqn_dqtn = rhs_cto[5];
+
+  const Real dp_dpt_old = _dp_dpt;
+  const Real dq_dpt_old = _dq_dpt;
+  const Real dp_dqt_old = _dp_dqt;
+  const Real dq_dqt_old = _dq_dqt;
+
+  _dgaE_dpt += dgaEn_dptn * (step_size + dp_dpt_old) + dgaEn_dqtn * dq_dpt_old;
+  _dp_dpt = dpn_dptn * (step_size + dp_dpt_old) + dpn_dqtn * dq_dpt_old;
+  _dq_dpt = dqn_dptn * (step_size + dp_dpt_old) + dqn_dqtn * dq_dpt_old;
+  _dgaE_dqt += dgaEn_dqtn * (step_size + dq_dqt_old) + dgaEn_dptn * dp_dqt_old;
+  _dp_dqt = dpn_dqtn * (step_size + dq_dqt_old) + dpn_dptn * dp_dqt_old;
+  _dq_dqt = dqn_dqtn * (step_size + dq_dqt_old) + dqn_dptn * dp_dqt_old;
+}
+
+PQPlasticModel::f_and_derivs
+PQPlasticModel::smoothAllQuantities(Real p, Real q, const std::vector<Real> & intnl)
+{
+  for (unsigned i = _all_q.size(); i < _num_yf; ++i)
+    _all_q.push_back(f_and_derivs(_num_pq, _num_intnl));
+
+  computeAllQ(p, q, intnl, _all_q);
+
+  std::sort(_all_q.begin(), _all_q.end());
+
+  /* This is the key to my smoothing strategy.  While the two
+   * biggest yield functions are closer to each other than
+   * _smoothing_tol, make a linear combination of them:
+   * _all_q[num - 2].f = the second-biggest yield function
+   * = _all_q[num - 1].f + ismoother(_all_q[num - 2].f - _all_q[num - 1].f);
+   * = biggest yield function + ismoother(second-biggest - biggest)
+   * Then pop off the biggest yield function, and repeat this
+   * strategy.
+   * Of course all the derivatives must also be smoothed.
+   * I assume that d(flow potential)/dstress gets smoothed by the *yield function*, viz
+   * d(second-biggest-g) = d(biggest-g) + smoother(second-biggest-f - biggest-f)*(d(second-biggest-g) - d(biggest-g))
+   * Only time will tell whether this is a good strategy.
+   */
+  unsigned num = _all_q.size();
+  while (num > 1 && _all_q[num - 1].f < _all_q[num - 2].f + _smoothing_tol)
+  {
+    const Real ism = ismoother(_all_q[num - 2].f - _all_q[num - 1].f);
+    const Real sm = smoother(_all_q[num - 2].f - _all_q[num - 1].f);
+    const Real dsm = dsmoother(_all_q[num - 2].f - _all_q[num - 1].f);
+    for (unsigned i = 0; i < _num_pq; ++i)
+    {
+      for (unsigned j = 0; j < _num_pq; ++j)
+        _all_q[num - 2].d2g[i][j] = _all_q[num - 1].d2g[i][j] + dsm * (_all_q[num - 2].df[j] - _all_q[num - 1].df[j]) * (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]) + sm * (_all_q[num - 2].d2g[i][j] - _all_q[num - 1].d2g[i][j]);
+      for (unsigned j = 0; j < _num_intnl; ++j)
+        _all_q[num - 2].d2g_di[i][j] = _all_q[num - 1].d2g_di[i][j] + dsm * (_all_q[num - 2].df_di[j] - _all_q[num - 1].df_di[j]) * (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]) + sm * (_all_q[num - 2].d2g_di[i][j] - _all_q[num - 1].d2g_di[i][j]);
+    }
+    for (unsigned i = 0; i < _num_pq; ++i)
+    {
+      _all_q[num - 2].dg[i] = _all_q[num - 1].dg[i] + sm * (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]);
+      _all_q[num - 2].df[i] = _all_q[num - 1].df[i] + sm * (_all_q[num - 2].df[i] - _all_q[num - 1].df[i]);
+    }
+    for (unsigned i = 0; i < _num_intnl; ++i)
+      _all_q[num - 2].df_di[i] = _all_q[num - 1].df_di[i] + sm * (_all_q[num - 2].df_di[i] - _all_q[num - 1].df_di[i]);
+    _all_q[num - 2].f = _all_q[num - 1].f + ism;
+    _all_q.pop_back();
+    num = _all_q.size();
+  }
+  return _all_q.back();
+}
+
+
+Real
+PQPlasticModel::ismoother(Real f_diff) const
+{
+  mooseAssert(f_diff <= 0.0, "PQPlasticModel: ismoother called with positive argument");
+  if (f_diff <= -_smoothing_tol)
+    return 0.0;
+  return 0.5 * (f_diff + _smoothing_tol) - _smoothing_tol / M_PI * std::cos(0.5 * M_PI * f_diff / _smoothing_tol);
+}
+
+
+Real
+PQPlasticModel::smoother(Real f_diff) const
+{
+  if (f_diff >= _smoothing_tol)
+    return 1.0;
+  else if (f_diff <= -_smoothing_tol)
+    return 0.0;
+  return 0.5 * (1.0 + std::sin(f_diff * M_PI * 0.5 / _smoothing_tol));
+}
+
+Real
+PQPlasticModel::dsmoother(Real f_diff) const
+{
+  if (f_diff >= _smoothing_tol)
+    return 0.0;
+  else if (f_diff <= -_smoothing_tol)
+    return 0.0;
+  return 0.25 * M_PI / _smoothing_tol * std::cos(f_diff * M_PI * 0.5 / _smoothing_tol);
+}
+
+
+int
+PQPlasticModel::lineSearch(Real & res2, Real & gaE, Real & p, Real & q, Real p_trial, Real q_trial, f_and_derivs & smoothed_q, const std::vector<Real> & intnl_ok)
+{
+  const Real res2_old = res2;
+  const Real gaE_old = gaE;
+  const Real p_old = p;
+  const Real q_old = q;
+  const Real de_gaE = _rhs[0];
+  const Real de_p = _rhs[1];
+  const Real de_q = _rhs[2];
+
+  Real lam = 1.0; // line-search parameter
+  const Real lam_min = 1E-10; // minimum value of lam allowed
+  const Real slope = -2.0 * res2_old; // "Numerical Recipes" uses -b*A*x, in order to check for roundoff, but i hope the nrStep would warn if there were problems
+  Real tmp_lam; // cached value of lam used in quadratic & cubic line search
+  Real f2 = res2_old; // cached value of f = residual2 used in the cubic in the line search
+  Real lam2 = lam; // cached value of lam used in the cubic in the line search
+
+  while (true)
+  {
+    // update variables using the current line-search parameter
+    gaE = gaE_old + lam * de_gaE;
+    p = p_old + lam * de_p;
+    q = q_old + lam * de_q;
+
+    // and internal parameters
+    setIntnlValues(_p_trial, _q_trial, p, q, intnl_ok, _intnl[_qp]);
+
+    smoothed_q = smoothAllQuantities(p, q, _intnl[_qp]);
+
+    // update rhs for next-time through
+    res2 = calculateRHS(p_trial, q_trial, p, q, gaE, smoothed_q);
+
+    // do the line-search
+    if (res2 < res2_old + 1E-4 * lam * slope)
+      break;
+    else if (lam < lam_min)
+      return 1;
+    else if (lam == 1.0)
+    {
+      // model as a quadratic
+      tmp_lam = - 0.5 * slope / (res2 - res2_old - slope);
+    }
+    else
+    {
+      //model as a cubic
+      const Real rhs1 = res2 - res2_old - lam * slope;
+      const Real rhs2 = f2 - res2_old - lam2 * slope;
+      const Real a = (rhs1 / Utility::pow<2>(lam) - rhs2 / Utility::pow<2>(lam2)) / (lam - lam2);
+      const Real b = (-lam2 * rhs1 / Utility::pow<2>(lam) + lam * rhs2 / Utility::pow<2>(lam2)) / (lam - lam2);
+      if (a == 0.0)
+        tmp_lam = -slope / (2.0 * b);
+      else
+      {
+        const Real disc = Utility::pow<2>(b) - 3.0 * a * slope;
+        if (disc < 0)
+          tmp_lam = 0.5 * lam;
+        else if (b <= 0)
+          tmp_lam = (-b + std::sqrt(disc)) / (3.0 * a);
+        else
+          tmp_lam = -slope / (b + std::sqrt(disc));
+      }
+      if (tmp_lam > 0.5 * lam)
+        tmp_lam = 0.5 * lam;
+    }
+    lam2 = lam;
+    f2 = res2;
+    lam = std::max(tmp_lam, 0.1 * lam);
+  }
+
+  if (lam < 1.0)
+    _linesearch_needed[_qp] = 1.0;
+  return 0;
+}
+
+void
+PQPlasticModel::dnRHSdVar(const f_and_derivs & smoothed_q, const std::vector<std::vector<Real> > & dintnl, Real gaE, std::array<double, _num_rhs * _num_rhs> & jac) const
+{
+  // LAPACK gsev stores the matrix in the following way:
+
+  // d(-yieldF)/d(gaE)
+  jac[0] = 0;
+
+  // d(-rhs[1])/d(gaE)
+  jac[1] = - smoothed_q.dg[0];
+
+  // d(-rhs[2])/d(gaE))
+  jac[2] = - _Eqq * smoothed_q.dg[1] / _Epp;
+
+  // d(-yieldF)/d(p)
+  jac[3] = - smoothed_q.df[0];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    jac[3] -= smoothed_q.df_di[i] * dintnl[i][0];
+
+  // d(-rhs[1])/d(p)
+  jac[4] = - 1.0 - gaE * smoothed_q.d2g[0][0];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    jac[4] -= gaE * smoothed_q.d2g_di[0][i] * dintnl[i][0];
+
+  // d(-rhs[2])/d(p)
+  jac[5] = - _Eqq * gaE / _Epp * smoothed_q.d2g[1][0];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    jac[5] -= _Eqq * gaE / _Epp * smoothed_q.d2g_di[1][i] * dintnl[i][0];
+
+  // d(-yieldF)/d(q)
+  jac[6] = - smoothed_q.df[1];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    jac[6] -= smoothed_q.df_di[i] * dintnl[i][1];
+
+  // d(-rhs[1])/d(q)
+  jac[7] = - gaE * smoothed_q.d2g[0][1];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    jac[7] -= gaE * smoothed_q.d2g_di[0][i] * dintnl[i][1];
+
+  // d(-rhs[2])/d(q)
+  jac[8] = - 1.0 - _Eqq * gaE / _Epp * smoothed_q.d2g[1][1];
+  for (unsigned i = 0; i < _num_intnl; ++i)
+    jac[8] -= _Eqq * gaE / _Epp * smoothed_q.d2g_di[1][i] * dintnl[i][1];
+}
+
+int
+PQPlasticModel::nrStep(const f_and_derivs & smoothed_q, Real p_trial, Real q_trial, Real p, Real q, Real gaE)
+{
+  setIntnlDerivatives(p_trial, q_trial, p, q, _intnl[_qp], _dintnl);
+
+  std::array<double, _num_rhs * _num_rhs> jac;
+  dnRHSdVar(smoothed_q, _dintnl, gaE, jac);
+
+  // use LAPACK to solve the linear system
+  const int nrhs = 1;
+  std::array<int, _num_rhs> ipiv;
+  int info;
+  const int gesv_num_rhs = _num_rhs;
+  LAPACKgesv_(&gesv_num_rhs, &nrhs, &jac[0], &gesv_num_rhs, &ipiv[0], &_rhs[0], &gesv_num_rhs, &info);
+  return info;
+}
+
+Real
+PQPlasticModel::calculateRHS(Real p_trial, Real q_trial, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q)
+{
+  _rhs[0] = smoothed_q.f;
+  _rhs[1] = p - p_trial + gaE * smoothed_q.dg[0];
+  _rhs[2] = q - q_trial + _Eqq * gaE / _Epp * smoothed_q.dg[1];
+  return _rhs[0] * _rhs[0] + _rhs[1] * _rhs[1] + _rhs[2] * _rhs[2];
+}
+
+void
+PQPlasticModel::errorHandler(const std::string & message)
+{
+  throw MooseException(message);
+}
+
+void
+PQPlasticModel::initialiseReturnProcess()
+{
+  return;
+}
+
+void
+PQPlasticModel::finaliseReturnProcess()
+{
+  return;
+}
+
+void
+PQPlasticModel::preReturnMap(Real /*p_trial*/, Real /*q_trial*/, const RankTwoTensor & /*stress_trial*/, const std::vector<Real> & /*intnl_old*/, const std::vector<Real> & /*yf*/)
+{
+  return;
+}
+
+Real
+PQPlasticModel::yieldF(Real p, Real q, const std::vector<Real> & intnl) const
+{
+  std::vector<Real> yf(_num_yf);
+  yieldFunctionValues(p, q, intnl, yf);
+  std::sort(yf.begin(), yf.end());
+  unsigned num = yf.size();
+  while (num > 1 && yf[num - 1] < yf[num - 2] + _smoothing_tol)
+  {
+    yf[num - 2] = yf[num - 1] + ismoother(yf[num - 2] - yf[num - 1]);
+    yf.pop_back();
+    num = yf.size();
+  }
+  return yf.back();
+}
+
+
+void
+PQPlasticModel::initialiseVars(Real p_trial, Real q_trial, const std::vector<Real> & intnl_old, Real & p, Real & q, Real & gaE, std::vector<Real> & intnl) const
+{
+  p = p_trial;
+  q = q_trial;
+  gaE = 0.0;
+  std::copy(intnl_old.begin(), intnl_old.end(), intnl.begin());
+}
+
+void
+PQPlasticModel::consistentTangentOperator(const RankTwoTensor & stress_trial, Real /*p_trial*/, Real /*q_trial*/, const RankTwoTensor & stress, Real /*p*/, Real /*q*/, Real gaE, const f_and_derivs & smoothed_q, RankFourTensor & cto) const
+{
+  if (!_fe_problem.currentlyComputingJacobian())
+    return;
+
+  cto = _elasticity_tensor[_qp];
+  if (_tangent_operator_type == TangentOperatorEnum::elastic)
+    return;
+
+  const RankTwoTensor dpdsig = dpdstress(stress);
+  const RankTwoTensor dpdsig_trial = dpdstress(stress_trial);
+  const RankTwoTensor dqdsig = dqdstress(stress);
+  const RankTwoTensor dqdsig_trial = dqdstress(stress_trial);
+
+  const RankTwoTensor s1 = _elasticity_tensor[_qp] * ((1.0 / _Epp) * (1.0 - _dp_dpt) * dpdsig + (1.0 / _Eqq) * (- _dq_dpt) * dqdsig);
+  const RankTwoTensor s2 = _elasticity_tensor[_qp] * ((1.0 / _Epp) * (- _dp_dqt) * dpdsig + (1.0 / _Eqq) * (1.0 - _dq_dqt) * dqdsig);
+  const RankTwoTensor t1 = _elasticity_tensor[_qp] * dpdsig_trial;
+  const RankTwoTensor t2 = _elasticity_tensor[_qp] * dqdsig_trial;
+
+  for (unsigned i = 0; i < _tensor_dimensionality; ++i)
+    for (unsigned j = 0; j < _tensor_dimensionality; ++j)
+      for (unsigned k = 0; k < _tensor_dimensionality; ++k)
+        for (unsigned l = 0; l < _tensor_dimensionality; ++l)
+          cto(i, j, k, l) -= s1(i, j) * t1(k, l) + s2(i, j) * t2(k, l);
+
+  const RankFourTensor d2pdsig2 = d2pdstress2(stress);
+  const RankFourTensor d2qdsig2 = d2qdstress2(stress);
+
+  const RankFourTensor Tijab = _elasticity_tensor[_qp] * (gaE / _Epp) * (smoothed_q.dg[0] * d2pdsig2 + smoothed_q.dg[1] * d2qdsig2);
+
+  RankFourTensor inv = RankFourTensor(RankFourTensor::initIdentityFour) + Tijab;
+  try
+  {
+    inv = inv.transposeMajor().invSymm();
+  }
+  catch (const MooseException & e)
+  {
+    // Cannot form the inverse, so probably at some degenerate place in stress space.
+    // Just return with the "best estimate" of the cto.
+    return;
+  }
+
+  cto = (cto.transposeMajor() * inv).transposeMajor();
+}


### PR DESCRIPTION
If you have the time, I'd love a thorough review of "PQPlasticModel".  At the moment there are only 2 classes that derived from it, but i'm planning at least 4 children, and possibly 8, so would like to get PQPlasticModel as correct as practical at this point in time.

Details:

PQPlasticModel added.

This is a generalisation of the old ComputeCappedWeakPlaneStress to the case where arbitrary plastic models are formulated in a 2-dimensional stress space, that i call p-q space.  PQPlasticModel does the return-map process using a robust NR process that includes the possibility of sub-stepping the strain increment, as well as a line search.

ComputeCappedWeakPlaneStress now derives from PQPlasticModel, making it much simpler.
ComputeCappedWeakInclinedPlaneStress derives from this, and so the const_cast stuff originally contained in this class is now not necessary.

No extra tests are included as the original tests were pretty exhaustive and this is just a refactor.

Fixes #8316