### PR TITLE
Add explicit parentheses to silence warning

### DIFF
--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -210,7 +210,7 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
         bool local_first = _first;
 
         // Now do all of the solves we need
-        while (!at_steady && ex->getTime() + app_time_offset + 2e-14 < target_time || !ex->lastSolveConverged())
+        while ((!at_steady && ex->getTime() + app_time_offset + 2e-14 < target_time) || !ex->lastSolveConverged())
         {
           if (local_first != true)
             ex->incrementStepOrReject();


### PR DESCRIPTION
refs #8328

This can be merged before testing is complete. It's logically equivalent but gets rid of a compile warning in Clang.