### PR TITLE
Adding the critical option --keep-cout when --redirect-output is used

### DIFF
--- a/python/TestHarness/RunParallel.py
+++ b/python/TestHarness/RunParallel.py
@@ -154,7 +154,7 @@ class RunParallel:
       # Obtain path and append processor id to redirect_output filename
       file_path = os.path.join(tester.specs['test_dir'], tester.name() + '.processor.{}'.format(processor_id))
       with open(file_path, 'r') as f:
-        file_output += self.readOutput(f)
+        file_output += "#"*80 + "\nOutput from processor " + str(processor_id) + "\n" + "#"*80 + "\n" + self.readOutput(f)
     return file_output
 
   ## Return control the the test harness by finalizing the test output and calling the callback

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -139,7 +139,7 @@ class RunApp(Tester):
       default_ncpus = options.parallel
 
     if specs['redirect_output'] and ncpus > 1:
-      specs['cli_args'].append('--redirect-output ' + self.name())
+      specs['cli_args'].append('--keep-cout --redirect-output ' + self.name())
 
     caveats = []
     if nthreads > options.nthreads:


### PR DESCRIPTION
This option is necessary so that if a non-master process hits a warning or error
that output will be recorded in the output file. This is especially important
when the output is on the stdout stream which is normally dropped by libMesh

refs #8080

