### PR TITLE
Fix rel_err typo in tests

### DIFF
--- a/modules/rdg/tests/advection_1d/tests
+++ b/modules/rdg/tests/advection_1d/tests
@@ -32,6 +32,6 @@
     input = 'block_restrictable.i'
     exodiff = 'block_restrictable_out.e'
     abs_zero = 1e-4
-    rel_error = 5e-5
+    rel_err = 5e-5
   [../]
 []


### PR DESCRIPTION
Typo introduced in #8364 

Currently only a warning is printed:
```
Warning detected when parsing file "modules/rdg/tests/advection_1d/tests"
       Ignored Parameter(s):  set(['rel_error'])
```
Is there a reason why this wouldn't be an error? Odds are if there are ignored parameters in the `tests` file then there is a mistake...