### PR TITLE
Fix unused variable warnings.

### DIFF
--- a/framework/include/meshmodifiers/MeshExtruder.h
+++ b/framework/include/meshmodifiers/MeshExtruder.h
@@ -55,8 +55,11 @@ protected:
     /// Data structure for holding the old -> new id mapping based on the layer number
     std::map<unsigned int, std::map<SubdomainID, unsigned int> > _layer_data;
 
-    /// The total number of layers in the extrusion
+    /// The total number of layers in the extrusion.  This is
+    /// currently only used for a sanity check in dbg mode.
+#ifdef DEBUG
     unsigned int _num_layers;
+#endif
   };
 
 private:

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -169,7 +169,10 @@ Adaptivity::adaptMesh(std::string marker_name /*=std::string()*/)
   if (_displaced_problem && mesh_changed)
   {
     // Now do refinement/coarsening
-    bool displaced_mesh_changed = _displaced_mesh_refinement->refine_and_coarsen_elements();
+#ifdef DEBUG
+    bool displaced_mesh_changed =
+#endif
+      _displaced_mesh_refinement->refine_and_coarsen_elements();
 
     // Since the undisplaced mesh changed, the displaced mesh better have changed!
     mooseAssert(displaced_mesh_changed, "Undisplaced mesh changed, but displaced mesh did not!");

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -580,19 +580,18 @@ PenetrationThread::interactionsOffCommonEdge(PenetrationInfo * pi1,
   CommonEdgeResult common_edge(NO_COMMON);
   const std::vector<const Node *> & off_edge_nodes1 = pi1->_off_edge_nodes;
   const std::vector<const Node *> & off_edge_nodes2 = pi2->_off_edge_nodes;
-  const unsigned dim1(pi1->_side->dim());
-  const unsigned dim2(pi2->_side->dim());
+  const unsigned dim1 = pi1->_side->dim();
 
   if (dim1 == 1)
   {
-    mooseAssert(dim2==1,"Incompatible dimensionalities");
+    mooseAssert(pi2->_side->dim() == 1, "Incompatible dimensions.");
     mooseAssert(off_edge_nodes1.size()<2 && off_edge_nodes2.size()<2,"off_edge_nodes size should be <2 for 2D contact");
     if (off_edge_nodes1.size()==1 && off_edge_nodes2.size()==1 && off_edge_nodes1[0]==off_edge_nodes2[0])
       common_edge = COMMON_EDGE;
   }
   else
   {
-    mooseAssert(dim1==2 && dim2==2,"Incompatible dimensionalities");
+    mooseAssert(dim1 == 2 && pi2->_side->dim() == 2, "Incompatible dimensions.");
     mooseAssert(off_edge_nodes1.size()<3 && off_edge_nodes2.size()<3,"off_edge_nodes size should be <3 for 3D contact");
     if (off_edge_nodes1.size()==1)
     {

--- a/framework/src/meshmodifiers/MeshExtruder.C
+++ b/framework/src/meshmodifiers/MeshExtruder.C
@@ -114,9 +114,11 @@ MeshExtruder::changeID(const std::vector<BoundaryName> & names, BoundaryID old_i
 MeshExtruder::QueryElemSubdomainID::QueryElemSubdomainID(std::vector<SubdomainID> existing_subdomains,
                                                          std::vector<unsigned int> layers,
                                                          std::vector<unsigned int> new_ids,
-                                                         unsigned int num_layers) :
-    QueryElemSubdomainIDBase(),
-    _num_layers(num_layers)
+                                                         unsigned int libmesh_dbg_var(num_layers)) :
+    QueryElemSubdomainIDBase()
+#ifdef DEBUG
+    ,_num_layers(num_layers)
+#endif
 {
   // Setup our stride depending on whether the user passed unique sets in new ids or just a single set of new ids
   const unsigned int zero = 0;


### PR DESCRIPTION
These showed up after adding -Wunused to optimized mode compiles on clang.

Refs #1777.
