### PR TITLE
Don't disable logging if it's needed elsewhere

### DIFF
--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -186,10 +186,8 @@ protected:
   /// State for setup performance log
   bool _setup_log;
 
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
   /// Control the display libMesh performance log
   bool _libmesh_log;
-#endif
 
   /// State for early setup log printing
   bool _setup_log_early;

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -189,6 +189,12 @@ public:
    */
   void bufferConsoleOutputsBeforeConstruction(bool buffer) { _buffer_action_console_outputs = buffer; }
 
+  /// Sets a Boolean indicating that at least one object is requesting performance logging in this application
+  void setLoggingRequested() { _logging_requested = true; }
+
+  /// Returns a Boolean indicating whether performance logging is requested in this application
+  bool getLoggingRequested() const { return _logging_requested; }
+
 private:
 
   /**
@@ -338,6 +344,9 @@ private:
 
   /// Flag indicating that next call to outputStep is forced
   bool _force_output;
+
+  /// Indicates that performance logging has been requested by the console or some object (PerformanceData)
+  bool _logging_requested;
 
   // Allow complete access:
   // FEProblemBase for calling initial, timestepSetup, outputStep, etc. methods

--- a/framework/src/actions/CheckOutputAction.C
+++ b/framework/src/actions/CheckOutputAction.C
@@ -126,9 +126,7 @@ CheckOutputAction::checkPerfLogOutput()
   {
     Moose::perf_log.disable_logging();
     Moose::setup_perf_log.disable_logging();
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
     libMesh::perflog.disable_logging();
-#endif
   }
 
   // If the --timing option is used from the command-line, enable all logging
@@ -136,8 +134,6 @@ CheckOutputAction::checkPerfLogOutput()
   {
     Moose::perf_log.enable_logging();
     Moose::setup_perf_log.enable_logging();
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
     libMesh::perflog.enable_logging();
-#endif
   }
 }

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -58,9 +58,7 @@ InputParameters validParams<Console>()
   params.addParam<bool>("solve_log", "Toggles the printing of the 'Moose Test Performance' log");
   params.addParam<bool>("perf_header", "Print the libMesh performance log header (requires that 'perf_log = true')");
 
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
   params.addParam<bool>("libmesh_log", true, "Print the libMesh performance log, requires libMesh to be configured with --enable-perflog");
-#endif
 
   // Toggle printing of mesh information on adaptivity steps
   params.addParam<bool>("print_mesh_changed_info", false, "When true, each time the mesh is changed the mesh information is printed");
@@ -84,9 +82,7 @@ InputParameters validParams<Console>()
 
   // Performance log group
   params.addParamNamesToGroup("perf_log setup_log_early setup_log solve_log perf_header", "Perf Log");
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
   params.addParamNamesToGroup("libmesh_log", "Performance Log");
-#endif
 
   // Variable norms group
   params.addParamNamesToGroup("outlier_variable_norms all_variable_norms outlier_multiplier", "Norms");
@@ -122,9 +118,7 @@ Console::Console(const InputParameters & parameters) :
     _perf_log_interval(getParam<unsigned int>("perf_log_interval")),
     _solve_log(isParamValid("solve_log") ? getParam<bool>("solve_log") : _perf_log),
     _setup_log(isParamValid("setup_log") ? getParam<bool>("setup_log") : _perf_log),
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
     _libmesh_log(getParam<bool>("libmesh_log")),
-#endif
     _setup_log_early(getParam<bool>("setup_log_early")),
     _perf_header(isParamValid("perf_header") ? getParam<bool>("perf_header") : _perf_log),
     _all_variable_norms(getParam<bool>("all_variable_norms")),
@@ -167,9 +161,7 @@ Console::Console(const InputParameters & parameters) :
        _pars.isParamSetByUser("setup_log") ||
        _pars.isParamSetByUser("solve_log") ||
        _pars.isParamSetByUser("perf_header") ||
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
        _pars.isParamSetByUser("libmesh_log") ||
-#endif
        common_action->parameters().isParamSetByUser("print_perf_log")))
     mooseWarning("Performance logging cannot currently be controlled from a Multiapp, please set all performance options in the main input file");
 
@@ -210,10 +202,8 @@ Console::~Console()
     write(Moose::perf_log.get_perf_info(), false);
 
   // Write the libMesh log
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
   if (_libmesh_log)
     write(libMesh::perflog.get_perf_info(), false);
-#endif
 
   // Write the file output stream
   writeStreamToFile();
@@ -226,9 +216,7 @@ Console::~Console()
     /* Disable the logs, without this the logs will be printed
        during the destructors of the logs themselves */
     Moose::perf_log.disable_logging();
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
     libMesh::perflog.disable_logging();
-#endif
   }
 }
 
@@ -248,10 +236,8 @@ Console::initialSetup()
       Moose::perf_log.disable_logging();
 
     // Disable libMesh log
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
     if (!_libmesh_log)
       libMesh::perflog.disable_logging();
-#endif
   }
 
   // system info flag can be changed only before console initial setup

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -29,7 +29,8 @@ OutputWarehouse::OutputWarehouse(MooseApp & app) :
     _app(app),
     _buffer_action_console_outputs(false),
     _output_exec_flag(EXEC_CUSTOM),
-    _force_output(false)
+    _force_output(false),
+    _logging_requested(false)
 {
   // Set the reserved names
   _reserved.insert("none");                  // allows 'none' to be used as a keyword in 'outputs' parameter

--- a/framework/src/postprocessors/PerformanceData.C
+++ b/framework/src/postprocessors/PerformanceData.C
@@ -36,7 +36,10 @@ PerformanceData::PerformanceData(const InputParameters & parameters) :
     _column(getParam<MooseEnum>("column").getEnum<PerfLogCols>()),
     _category(getParam<std::string>("category")),
     _event(getParam<std::string>("event"))
-{}
+{
+  // Notify the OutputWarehouse that logging has been requested
+  _app.getOutputWarehouse().setLoggingRequested();
+}
 
 Real
 PerformanceData::getValue()

--- a/test/tests/postprocessors/print_perf_data/tests
+++ b/test/tests/postprocessors/print_perf_data/tests
@@ -1,7 +1,32 @@
 [Tests]
-  [./test]
+  [./csv_log]
     type = CheckFiles
     input = print_perf_data.i
     check_files = print_perf_data_out.csv
+  [../]
+
+  [./use_log_data_no_print]
+    type = RunApp
+    input = use_log_data_no_print.i
+
+    # Make sure that the perf_log table doesn't just report
+    # the same active time each timestep
+
+    # The RE below looks for numbers in the last column of the table that are identical.
+    # This indicates that logging has been disabled which we don't want to see.
+    #
+    #   | time           | elapsed_active |
+    #   +----------------+----------------+
+    #   |   0.000000e+00 |   0.000000e+00 |
+    #   |   1.000000e-01 |   3.028400e-02 |  <- Does this number match
+    #   |   2.000000e-01 |   4.311600e-02 |  <- this number?
+
+    # Match non-space content followed by a single space, a pipe, then the newline character.
+    #   Make sure that the non-space content matches the entire number by bounding it on both
+    #   sides with required spaces.
+    # On the next line match the same number again after throwing away as much content as you
+    #   need that doesn't match.
+    #   Make sure that you don't cross lines by not allowing the throwaway content to have newlines.
+    absent_out = '(\s(\S+)\s\|\n)[^\n]*\1'
   [../]
 []

--- a/test/tests/postprocessors/print_perf_data/use_log_data_no_print.i
+++ b/test/tests/postprocessors/print_perf_data/use_log_data_no_print.i
@@ -1,0 +1,57 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Postprocessors]
+  [./elapsed_active]
+    type = PerformanceData
+    event = 'ACTIVE'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+  dt = 0.1
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]


### PR DESCRIPTION
PerformanceData postprocessor needs access to the perf log even if it's not being printed to the screen.