### PR TITLE
Allow syntax deprecation

### DIFF
--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -146,7 +146,6 @@
     do                                                                              \
     {                                                                               \
       mooseDoOnce(                                                                  \
-        {                                                                           \
           _console                                                                  \
             << COLOR_CYAN                                                           \
             << "\n\n*** Info ***\n"                                                 \
@@ -154,29 +153,32 @@
             << "\nat " << __FILE__ << ", line " << __LINE__                         \
             << COLOR_DEFAULT                                                        \
             << "\n" << std::endl;                                                   \
-        }                                                                           \
       );                                                                            \
     } while (0)
 
-#define mooseDeprecated(msg)                                                                                \
-  do                                                                                                        \
-  {                                                                                                         \
-    if (Moose::_deprecated_is_error)                                                                        \
-      mooseError("\n\nDeprecated code:\n" << msg << '\n');                                                  \
-    else                                                                                                    \
-      mooseDoOnce(                                                                                          \
-        _console                                                                                            \
-          << COLOR_YELLOW                                                                                   \
-          << "*** Warning, This code is deprecated, and likely to be removed in future library versions!\n" \
-          << msg << '\n'                                                                                    \
-          << __FILE__ << ", line " << __LINE__ << ", compiled "                                             \
-          << LIBMESH_DATE << " at " << LIBMESH_TIME << " ***\n";                                            \
-          if (libMesh::global_n_processors() == 1)                                                          \
-            print_trace(Moose::out);                                                                        \
-          else                                                                                              \
-            libMesh::write_traceout();                                                                      \
-          Moose::out << COLOR_DEFAULT << std::endl;                                                         \
-      );                                                                                                    \
+#define mooseDeprecated(msg)                                                                                  \
+  do                                                                                                          \
+  {                                                                                                           \
+    if (Moose::_deprecated_is_error)                                                                          \
+      mooseError("\n\nDeprecated code:\n" << msg << '\n');                                                    \
+    else                                                                                                      \
+      mooseDoOnce(                                                                                            \
+        std::ostringstream _deprecate_oss_;                                                                   \
+                                                                                                              \
+        _deprecate_oss_                                                                                       \
+          << COLOR_YELLOW                                                                                     \
+          << "*** Warning, This code is deprecated, and likely to be removed in future library versions!\n"   \
+          << msg << '\n'                                                                                      \
+          << __FILE__ << ", line " << __LINE__ << ", compiled "                                               \
+          << LIBMESH_DATE << " at " << LIBMESH_TIME << " ***"                                                 \
+          << COLOR_DEFAULT                                                                                    \
+          << "\n\n";                                                                                          \
+        if (libMesh::global_n_processors() == 1)                                                              \
+          print_trace(_deprecate_oss_);                                                                       \
+        else                                                                                                  \
+          libMesh::write_traceout();                                                                          \
+        _console << _deprecate_oss_.str() << std::flush;                                                      \
+      );                                                                                                      \
    } while (0)
 
 #define mooseCheckMPIErr(err) do { if (err != MPI_SUCCESS) { if (libMesh::global_n_processors() == 1) print_trace(); libmesh_here(); MOOSE_ABORT; } } while (0)

--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -59,6 +59,15 @@ public:
    */
   void replaceActionSyntax(const std::string & action, const std::string & syntax, const std::string & task);
 
+  /**
+   * This method deprecates previously registered syntax. You should use the exact form that you want deprecated
+   * in the passed in parameter.
+   */
+  void deprecateActionSyntax(const std::string & syntax);
+
+  /// Returns a Boolean indicating whether the syntax has been deprecated through a call to deprecateActionSyntax
+  bool isDeprecatedSyntax(const std::string & syntax) const;
+
   // Retrieve the Syntax associated with the passed Action and task
   std::string getSyntaxByAction(const std::string & action, const std::string & task);
 
@@ -87,6 +96,8 @@ protected:
 
   /// Actions/Syntax association
   std::multimap<std::string, ActionInfo> _associated_actions;
+
+  std::set<std::string> _deprecated_syntax;
 };
 
 

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -231,6 +231,9 @@ Parser::parse(const std::string &input_filename)
       {
         if (!is_parent)
         {
+          if (_syntax.isDeprecatedSyntax(registered_identifier))
+            mooseDeprecated("The input file syntax \"[" << registered_identifier << "]\" is deprecated.");
+
           params = _action_factory.getValidParams(it->second._action);
 
           params.set<ActionWarehouse *>("awh") = &_action_wh;

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -121,6 +121,18 @@ Syntax::replaceActionSyntax(const std::string & action, const std::string & synt
   registerActionSyntax(action, syntax, task);
 }
 
+void
+Syntax::deprecateActionSyntax(const std::string & syntax)
+{
+  _deprecated_syntax.insert(syntax);
+}
+
+bool
+Syntax::isDeprecatedSyntax(const std::string & syntax) const
+{
+  return _deprecated_syntax.find(syntax) != _deprecated_syntax.end();
+}
+
 std::string
 Syntax::getSyntaxByAction(const std::string & action, const std::string & task)
 {

--- a/unit/include/SyntaxTest.h
+++ b/unit/include/SyntaxTest.h
@@ -1,0 +1,44 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef SYNTAXTEST_H
+#define SYNTAXTEST_H
+
+// CPPUnit includes
+#include "GuardedHelperMacros.h"
+
+#include "Syntax.h"
+
+class SyntaxTest : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(SyntaxTest);
+
+  CPPUNIT_TEST(testGeneral);
+  CPPUNIT_TEST(testDeprecated);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp();
+  void tearDown();
+
+  void testGeneral();
+  void errorChecks();
+  void testDeprecated();
+
+private:
+  Syntax _syntax;
+};
+
+#endif // SYNTAXTEST_H

--- a/unit/src/SyntaxTest.C
+++ b/unit/src/SyntaxTest.C
@@ -1,0 +1,118 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "SyntaxTest.h"
+#include "Syntax.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(SyntaxTest);
+
+void
+SyntaxTest::setUp()
+{
+  _syntax.registerTaskName("first", false);
+  _syntax.registerTaskName("second", true);
+
+  // MOOSE object task
+  _syntax.registerTaskName("first_mo", "MooseSystem1", false);
+  _syntax.registerTaskName("second_mo", "MooseSystem2", true);
+
+  _syntax.registerActionSyntax("SomeAction", "TopBlock");
+  _syntax.registerActionSyntax("SomeAction", "TopBlock", "second");
+}
+
+void
+SyntaxTest::errorChecks()
+{
+  try
+  {
+    _syntax.registerTaskName("first", true);
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+
+    CPPUNIT_ASSERT(msg.find("is already registered") != std::string::npos);
+  }
+
+  try
+  {
+    _syntax.registerTaskName("second_mo", false);
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+
+    CPPUNIT_ASSERT(msg.find("is already registered") != std::string::npos);
+  }
+
+  try
+  {
+    _syntax.appendTaskName("third", "MooseSystem");
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+
+    CPPUNIT_ASSERT(msg.find("is not a registered task name") != std::string::npos);
+  }
+
+  try
+  {
+    _syntax.addDependency("forth", "third");
+
+    // Unreachable
+    CPPUNIT_ASSERT( false );
+  }
+  catch(const std::exception & e)
+  {
+    std::string msg(e.what());
+
+    CPPUNIT_ASSERT(msg.find("is not a registered task name") != std::string::npos);
+  }
+}
+
+void
+SyntaxTest::testGeneral()
+{
+  CPPUNIT_ASSERT(_syntax.hasTask("second"));
+  CPPUNIT_ASSERT(_syntax.hasTask("third") == false);
+
+  CPPUNIT_ASSERT(_syntax.isActionRequired("first") == false);
+  CPPUNIT_ASSERT(_syntax.isActionRequired("second_mo"));
+
+  // TODO: test this
+  _syntax.replaceActionSyntax("MooseSystem", "NewBlock", "first");
+}
+
+void
+SyntaxTest::testDeprecated()
+{
+  _syntax.deprecateActionSyntax("TopBlock");
+
+  CPPUNIT_ASSERT(_syntax.isDeprecatedSyntax("TopBlock"));
+}
+
+void
+SyntaxTest::tearDown()
+{
+}


### PR DESCRIPTION
Sorry, no test to check in so I don't really want to deprecate any syntax in MOOSE. There are ways of testing this if we need to but I tested it locally before figuring out that "Bounds" is not actually deprecated.

```
*** Warning, This code is deprecated, and likely to be removed in future library versions!
The input file syntax "[Bounds]" is deprecated.
/Users/permcj/projects/moose/framework/src/parser/Parser.C, line 235, compiled nodate at notime ***
```
