### PR TITLE
Fix to allow macros in bibtex files.

### DIFF
--- a/docs/bib/macro_test.bib
+++ b/docs/bib/macro_test.bib
@@ -1,0 +1,6 @@
+@article{macroTestKey,
+  author={Jane Smith and John Doe},
+  title={A test citation to see if macros work},
+  year={2017},
+  journal=jmt
+}

--- a/docs/bib/macro_test_abbrev.bib
+++ b/docs/bib/macro_test_abbrev.bib
@@ -1,0 +1,1 @@
+@STRING{jmt="Journal of Macro Testing"}

--- a/docs/tests/bibtex/gold/test_bibtex_macro.html
+++ b/docs/tests/bibtex/gold/test_bibtex_macro.html
@@ -1,0 +1,6 @@
+<p><span data-moose-cite="\cite{macroTestKey}"><a href="#macroTestKey">Smith and Doe (2017)</a></span>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/macro_test.bib']">
+<li name="macroTestKey">Jane Smith and John Doe.
+A test citation to see if macros work.
+<em>Journal of Macro Testing</em>, 2017.</li>
+</ol>
+</p>

--- a/docs/tests/bibtex/test_bibtex.py
+++ b/docs/tests/bibtex/test_bibtex.py
@@ -51,3 +51,7 @@ class TestBibtexExtension(MarkdownTestCase):
   def testCitepThree(self):
     md = r'\citep{testkey, testkey, testkey}\n\bibliography{docs/bib/moose.bib}'
     self.assertConvert('test_citepThree.html', md)
+
+  def testBibtexMacro(self):
+    md = r'\cite{macroTestKey}\n\bibliography{docs/bib/macro_test.bib}'
+    self.assertConvert('test_bibtex_macro.html', md)

--- a/python/MooseDocs/extensions/MooseMarkdown.py
+++ b/python/MooseDocs/extensions/MooseMarkdown.py
@@ -48,6 +48,7 @@ class MooseMarkdown(markdown.Extension):
     self.config['graphviz']     = ['/opt/moose/graphviz/bin', 'The location of graphviz executable for use with diagrams.']
     self.config['dot_ext']      = ['svg', "The graphviz/dot output file extension (default: svg)."]
     self.config['install']      = ['', "The location to install system and object documentation."]
+    self.config['macro_files']  = ['', "List of paths to files that contain macros to be used in bibtex parsing."]
 
     # Construct the extension object
     super(MooseMarkdown, self).__init__(**kwargs)

--- a/python/MooseDocs/testing.py
+++ b/python/MooseDocs/testing.py
@@ -36,11 +36,24 @@ class MarkdownTestCase(unittest.TestCase):
     cwd = os.getcwd()
     os.chdir(os.path.join(MooseDocs.MOOSE_DIR, 'docs'))
 
-    config = MooseDocs.yaml_load('moosedocs.yml')
+    config = MooseDocs.load_config('moosedocs.yml')
 
     extensions, extension_configs = MooseDocs.get_markdown_extensions(config)
+    cls.updateExtensionConfigs(extension_configs)
     cls.parser = markdown.Markdown(extensions=extensions, extension_configs=extension_configs)
     os.chdir(cwd)
+
+  @classmethod
+  def updateExtensionConfigs(cls, extension_configs):
+    """
+    Method to change the arguments that come from the configuration file for
+    specific tests.  This way one can test optional arguments without permanently
+    changing moosedocs.yml
+    """
+    if 'testBibtexMacro' in dir(cls):
+      if 'MooseDocs.extensions.MooseMarkdown' in extension_configs:
+        extension_configs['MooseDocs.extensions.MooseMarkdown']['macro_files'] =\
+          ['docs/bib/macro_test_abbrev.bib']
 
   def setUp(self):
     """


### PR DESCRIPTION
Extra line in configuration file can be supplied to point to where files of macro
definitions are as is the case with how the BISON bibtex folder is set-up.

Refs #6699