### PR TITLE
Check to see if a function name could evaluate to a parsed function

### DIFF
--- a/framework/src/actions/AddFunctionAction.C
+++ b/framework/src/actions/AddFunctionAction.C
@@ -29,5 +29,9 @@ AddFunctionAction::AddFunctionAction(InputParameters params) :
 void
 AddFunctionAction::act()
 {
+  FunctionParserBase<Real> fp;
+  std::string vars = "x,y,z,t,NaN,pi,e";
+  if (fp.Parse(_name, vars) == -1) // -1 for success
+    mooseWarning("Function name '" + _name + "' could evaluate as a ParsedFunction");
   _problem->addFunction(_type, _name, _moose_object_pars);
 }

--- a/framework/src/actions/AddFunctionAction.C
+++ b/framework/src/actions/AddFunctionAction.C
@@ -32,6 +32,6 @@ AddFunctionAction::act()
   FunctionParserBase<Real> fp;
   std::string vars = "x,y,z,t,NaN,pi,e";
   if (fp.Parse(_name, vars) == -1) // -1 for success
-    mooseWarning("Function name '" + _name + "' could evaluate as a ParsedFunction");
+    mooseWarning2("Function name '" + _name + "' could evaluate as a ParsedFunction");
   _problem->addFunction(_type, _name, _moose_object_pars);
 }

--- a/modules/combined/tests/heat_conduction_ortho/heat_conduction_ortho.i
+++ b/modules/combined/tests/heat_conduction_ortho/heat_conduction_ortho.i
@@ -13,21 +13,6 @@
   file = heat_conduction_ortho.e
 [] # Mesh
 
-[Functions]
-  [./1000]
-    type = ParsedFunction
-    value = 1000
-  [../]
-  [./100]
-    type = ParsedFunction
-    value = 100
-  [../]
-  [./10]
-    type = ParsedFunction
-    value = 10
-  [../]
-[]
-
 [Variables]
 
   [./temp]

--- a/test/tests/functions/function_file_format/function_file_format_test.i
+++ b/test/tests/functions/function_file_format/function_file_format_test.i
@@ -72,7 +72,7 @@
     data_file = columns_space.dat
     format = columns
   [../]
-  [./e]
+  [./e_func]
     type = PiecewiseLinear
     data_file = rows_more_data.csv
     format = rows
@@ -151,7 +151,7 @@
     type = FunctionDirichletBC
     variable = e
     boundary = '1'
-    function = e
+    function = e_func
   [../]
   [./f]
     type = FunctionDirichletBC

--- a/test/tests/functions/linear_combination_function/except1.i
+++ b/test/tests/functions/linear_combination_function/except1.i
@@ -37,11 +37,6 @@
 
 
 [Functions]
-  [./x]
-    type = ParsedFunction
-    value = x
-  [../]
-
   [./twoxplus1]
     type = ParsedFunction
     value = 2*x+1

--- a/test/tests/misc/check_error/function_conflict.i
+++ b/test/tests/misc/check_error/function_conflict.i
@@ -1,0 +1,37 @@
+# A function name that could be interpreted as a ParsedFunction
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[Functions]
+  [./x]
+    type = ConstantFunction
+  [../]
+[]
+
+[Variables]
+  [./var]
+  [../]
+[]
+
+[ICs]
+  [./dummy]
+    type = FunctionIC
+    variable = var
+    function = x
+  [../]
+[]
+
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = var
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -543,4 +543,12 @@
     expect_err = "Performance logging cannot currently be controlled from a Multiapp"
     max_parallel = 1
   [../]
+
+  [./function_conflict]
+    # Check to see if a warning is produced when a function name could evaluate to a ParsedFunction
+    type = 'RunApp'
+    input = 'function_conflict.i'
+    expect_out = "Function name 'x' could evaluate as a ParsedFunction"
+    allow_warnings = true
+  [../]
 []

--- a/test/tests/problems/no_solve/no_solve.i
+++ b/test/tests/problems/no_solve/no_solve.i
@@ -10,13 +10,6 @@
   [../]
 []
 
-[Functions]
-  [./t]
-    type = ParsedFunction
-    value = t
-  [../]
-[]
-
 [AuxKernels]
   [./t]
     type = FunctionAux

--- a/test/tests/transfers/transfer_with_reset/sub.i
+++ b/test/tests/transfers/transfer_with_reset/sub.i
@@ -17,13 +17,6 @@
   [../]
 []
 
-[Functions]
-  [./t]
-    type = ParsedFunction
-    value = t
-  [../]
-[]
-
 [Kernels]
   [./diff]
     type = Diffusion

--- a/test/tests/userobjects/layered_integral/average_sample.i
+++ b/test/tests/userobjects/layered_integral/average_sample.i
@@ -18,13 +18,6 @@
   [../]
 []
 
-[Functions]
-  [./y]
-    type = ParsedFunction
-    value = y
-  [../]
-[]
-
 [Kernels]
   [./diff]
     type = Diffusion

--- a/test/tests/userobjects/layered_integral/cumulative_layered_integral.i
+++ b/test/tests/userobjects/layered_integral/cumulative_layered_integral.i
@@ -28,13 +28,6 @@
   [../]
 []
 
-[Functions]
-  [./y]
-    type = ParsedFunction
-    value = y
-  [../]
-[]
-
 [Kernels]
   [./diff]
     type = Diffusion

--- a/test/tests/userobjects/layered_integral/layered_integral_test.i
+++ b/test/tests/userobjects/layered_integral/layered_integral_test.i
@@ -29,13 +29,6 @@
   [../]
 []
 
-[Functions]
-  [./y]
-    type = ParsedFunction
-    value = y
-  [../]
-[]
-
 [Kernels]
   [./diff]
     type = Diffusion

--- a/test/tests/userobjects/layered_side_integral/layered_side_average.i
+++ b/test/tests/userobjects/layered_side_integral/layered_side_average.i
@@ -18,13 +18,6 @@
   [../]
 []
 
-[Functions]
-  [./y]
-    type = ParsedFunction
-    value = y
-  [../]
-[]
-
 [Kernels]
   [./diff]
     type = Diffusion

--- a/test/tests/userobjects/layered_side_integral/layered_side_flux_average.i
+++ b/test/tests/userobjects/layered_side_integral/layered_side_flux_average.i
@@ -18,13 +18,6 @@
   [../]
 []
 
-[Functions]
-  [./y]
-    type = ParsedFunction
-    value = y
-  [../]
-[]
-
 [Kernels]
   [./diff]
     type = Diffusion

--- a/test/tests/userobjects/layered_side_integral/layered_side_integral_test.i
+++ b/test/tests/userobjects/layered_side_integral/layered_side_integral_test.i
@@ -18,13 +18,6 @@
   [../]
 []
 
-[Functions]
-  [./y]
-    type = ParsedFunction
-    value = y
-  [../]
-[]
-
 [Kernels]
   [./diff]
     type = Diffusion

--- a/test/tests/variables/block_aux_kernel/block_aux_kernel_test.i
+++ b/test/tests/variables/block_aux_kernel/block_aux_kernel_test.i
@@ -24,18 +24,6 @@
   [../]
 []
 
-[Functions]
-  [./t]
-    type = ParsedFunction
-    value = t
-  [../]
-
-  [./zero]
-    type = ParsedFunction
-    value = 0
-  [../]
-[]
-
 [AuxVariables]
   [./distance]
     order = FIRST
@@ -76,14 +64,14 @@
   [./x]
     type = FunctionAux
     variable = disp_x
-    function = zero
+    function = 0
     block = 1
   [../]
 
   [./y]
     type = FunctionAux
     variable = disp_y
-    function = zero
+    function = 0
     block = 1
   [../]
 


### PR DESCRIPTION
This just gives a warning, wasn't sure if it should be an error.
This also ignores `ParsedFunctions`. There seems to be several places where people
have something like:
```
[Functions]
  [./x]
    type = ParsedFunction
    value = x
  [../]
  [./10]
    type = ParsedFunction
    value = 10
   [../]
[]
```
I wasn't sure if you wanted to warn/error there as well.

closes #7659