### PR TITLE
Fix a warning NonlinearSystemBase

### DIFF
--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -113,7 +113,7 @@ public:
    */
   virtual void addKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters);
 
-  virtual void addEigenKernels(MooseSharedPointer<KernelBase> kernel, THREAD_ID tid) {};
+  virtual void addEigenKernels(MooseSharedPointer<KernelBase> /*kernel*/, THREAD_ID /*tid*/) {};
 
   /**
    * Adds a NodalKernel


### PR DESCRIPTION
Refer #1777.

Because this is in the NonlinearSystemBase.h, a warning is issued by almost compiling every file...