### PR TITLE
Improve MooseDocs when used in applications w/o "framework" content

### DIFF
--- a/docs/tests/objects/gold/test_description_error.html
+++ b/docs/tests/objects/gold/test_description_error.html
@@ -1,6 +1,6 @@
 <p>
 <div class="admonition error">
 <p class="admonition-title">Markdown Parsing Error</p>
-<p>Failed to locate MooseObject or Action with syntax: /Not/A/Real/Object</p>
+<p>Failed to locate MooseObject or Action for the command: !description /Not/A/Real/Object</p>
 </div>
 </p>

--- a/modules/tensor_mechanics/tests/finite_strain_elastic/elastic_rotation_test.i
+++ b/modules/tensor_mechanics/tests/finite_strain_elastic/elastic_rotation_test.i
@@ -56,11 +56,15 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
-  [./all]
-    strain = FINITE
-    add_variables = true
-    #generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+[Modules]
+  [./TensorMechanics]
+    [./Master]
+      [./all]
+        strain = FINITE
+        add_variables = true
+        #generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+      [../]
+    [../]
   [../]
 []
 

--- a/python/MooseDocs/MooseApplicationSyntax.py
+++ b/python/MooseDocs/MooseApplicationSyntax.py
@@ -183,9 +183,14 @@ class MooseApplicationSyntax(object):
         raise IOError(full_path)
       self._updateSyntax(path, objects, actions)
 
-    # Create MooseObjctInfo objects
+    # Create MooseObjectInfo objects
     for key, value in objects.iteritems():
       for node in self._yaml_data['/' + key]:
+
+        # Skip this node if it has subblocks, which is not possible for MooseObjects
+        if node['subblocks']:
+          continue
+
         info = MooseObjectInfo(node,
                                code=self._filenames[value],
                                install=install,

--- a/python/MooseDocs/commands/MooseDocsMarkdownNode.py
+++ b/python/MooseDocs/commands/MooseDocsMarkdownNode.py
@@ -43,7 +43,7 @@ class MooseDocsMarkdownNode(MooseDocsNode):
     """
 
     # Read the markdown and parse the HTML
-    log.debug('Parsing markdown: {}'.format(self.__md_file))
+    log.info('Parsing markdown: {}'.format(self.__md_file))
     content, meta = MooseDocs.read_markdown(self.__md_file)
     self.__html = self.__parser.convert(content)
 

--- a/python/MooseDocs/extensions/MooseDescription.py
+++ b/python/MooseDocs/extensions/MooseDescription.py
@@ -27,7 +27,7 @@ class MooseDescription(MooseSyntaxBase):
     # Locate description
     info = self.getInfo(syntax)
     if not info:
-      return self.createErrorElement('Failed to locate MooseObject or Action with syntax: {}'.format(syntax))
+      return self.createErrorElement('Failed to locate MooseObject or Action for the command: !description {}'.format(syntax))
 
     # Create an Error element, but do not produce warning/error log because the
     # moosedocs check/generate commands produce errors.

--- a/python/MooseDocs/extensions/MooseObjectSyntax.py
+++ b/python/MooseDocs/extensions/MooseObjectSyntax.py
@@ -47,9 +47,8 @@ class MooseObjectSyntax(MooseSyntaxBase):
     # Locate description
     info = self.getObject(syntax)
     if not info:
-      return self.createErrorElement('Failed to locate MooseObject with syntax {} in {} command.'.format(syntax, action))
-
-    if action == 'inputfiles':
+      el = self.createErrorElement('Failed to locate MooseObject with syntax in command: !{} {}'.format(action, syntax), error=False)
+    elif action == 'inputfiles':
       el = self.inputfilesElement(info, settings)
     elif action == 'childobjects':
       el = self.childobjectsElement(info, settings)

--- a/python/MooseDocs/extensions/MooseParameters.py
+++ b/python/MooseDocs/extensions/MooseParameters.py
@@ -32,7 +32,7 @@ class MooseParameters(MooseSyntaxBase):
     # Locate description
     info = self.getInfo(syntax)
     if not info:
-      return self.createErrorElement('Failed to locate MooseObject or Action with syntax: {}'.format(syntax))
+      return self.createErrorElement('Failed to locate MooseObject or Action for the command: !parameters {}'.format(syntax))
 
     # Create the tables (generate 'Required' and 'Optional' initially so that they come out in the proper order)
     tables = collections.OrderedDict()

--- a/python/MooseDocs/extensions/__init__.py
+++ b/python/MooseDocs/extensions/__init__.py
@@ -2,7 +2,7 @@ import os
 from MooseMarkdown import MooseMarkdown
 from markdown.util import etree
 
-def get_collection_items(info_objects):
+def get_collection_items(info_objects, show_hidden=False):
   """
   Returns li html elements for each object in a system.
 
@@ -11,7 +11,7 @@ def get_collection_items(info_objects):
   """
   items = []
   for info in info_objects:
-    if info.hidden:
+    if info.hidden and not show_hidden:
       continue
     item = etree.Element('li')
     items.append(item)
@@ -34,7 +34,7 @@ def get_collection_items(info_objects):
   return items
 
 
-def create_collection(name, syntax, action, groups=[]):
+def create_collection(name, syntax, action, groups=[], **kwargs):
   """
   Creates subobject collection for a given node from the YAML dump.
 
@@ -51,9 +51,9 @@ def create_collection(name, syntax, action, groups=[]):
   children = []
   for group in groups:
     if action == 'object':
-      items = get_collection_items(syntax[group].objects(name, include_self=False))
+      items = get_collection_items(syntax[group].objects(name, include_self=False), **kwargs)
     elif action == 'system':
-      items = get_collection_items(syntax[group].actions(name, include_self=False))
+      items = get_collection_items(syntax[group].actions(name, include_self=False), **kwargs)
     else:
       log.error('Invalid action name, must supply "system" or "object".')
       return None


### PR DESCRIPTION
This should allow the !systems command to build the correct headings when MooseDocs is configured to *not* include the framework directory.

Once this goes through we are going to add App documentation testing to the documentation target to aid in keeping both MOOSE and App docs running correctly.
(refs #8329)