### PR TITLE
Fixup Graintracker + Mechanics example

### DIFF
--- a/framework/src/userobject/UserObject.C
+++ b/framework/src/userobject/UserObject.C
@@ -45,8 +45,8 @@ UserObject::UserObject(const InputParameters & parameters) :
     Restartable(parameters, "UserObjects"),
     MeshChangedInterface(parameters),
     ScalarCoupleable(this),
-    _subproblem(*parameters.get<SubProblem *>("_subproblem")),
-    _fe_problem(*parameters.get<FEProblemBase *>("_fe_problem_base")),
+    _subproblem(*parameters.getCheckedPointerParam<SubProblem *>("_subproblem")),
+    _fe_problem(*parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
     _tid(parameters.get<THREAD_ID>("_tid")),
     _assembly(_subproblem.assembly(_tid)),
     _coord_sys(_assembly.coordSystem())

--- a/modules/combined/examples/phase_field-mechanics/EBSD_reconstruction_grain_growth_mech.i
+++ b/modules/combined/examples/phase_field-mechanics/EBSD_reconstruction_grain_growth_mech.i
@@ -10,7 +10,7 @@
 [GlobalParams]
   op_num = 8
   var_name_base = gr
-  grain_num = 110
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -63,6 +63,7 @@
   [./PolycrystalICs]
     [./ReconVarIC]
       ebsd_reader = ebsd
+      advanced_op_assignment = true
     [../]
   [../]
 []
@@ -73,7 +74,6 @@
   [./PolycrystalElasticDrivingForce]
   [../]
   [./TensorMechanics]
-    displacements = 'disp_x disp_y'
   [../]
 []
 
@@ -142,7 +142,7 @@
     type = EBSDReaderPointDataAux
     variable = EBSD_grain
     ebsd_reader = ebsd
-    data_name = 'grain'
+    data_name = 'feature_id'
     execute_on = 'initial'
   [../]
 []
@@ -230,11 +230,8 @@
   [../]
   [./grain_tracker]
     type = GrainTrackerElasticity
-    threshold = 0.2
     compute_var_to_feature_map = true
-    execute_on = 'initial timestep_begin'
     ebsd_reader = ebsd
-    flood_entity_type = ELEMENTAL
 
     fill_method = symmetric9
     C_ijkl = '1.27e5 0.708e5 0.708e5 1.27e5 0.708e5 1.27e5 0.7355e5 0.7355e5 0.7355e5'

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -207,6 +207,19 @@ protected:
   /// Boolean to indicate that we should retrieve EBSD information from a specific phase
   const bool _consider_phase;
 
+  /**
+   * Boolean to indicate the first time this object executes.
+   * Note: _tracking_step isn't enough if people skip initial or execute more than once per step.
+   */
+  bool _first_time;
+
+  /**
+   * Boolean to terminate with an error if a new grain is created during the simulation.
+   * This is for simulations where new grains are not expected. Note, this does not impact
+   * the initial callback to newGrainCreated() nor does it get triggered for splitting grains.
+   */
+  bool _error_on_grain_creation;
+
 private:
   /// Holds the first unique grain index when using _reserve_op (all the remaining indices are sequential)
   unsigned int _reserve_grain_first_index;
@@ -216,10 +229,6 @@ private:
 
   /// Holds the next "regular" grain ID (a grain found or remapped to the standard op vars)
   unsigned int _max_curr_grain_id;
-
-  /// Boolean to indicate the first time this object executes.
-  /// _tracking_step isn't enough if people skip initial or execute more than once per step
-  bool _first_time;
 
   /// Boolean to indicate whether this is a Steady or Transient solve
   const bool _is_transient;

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -95,7 +95,14 @@ InputParameters validParams<FeatureFloodCount>()
   params.addParam<bool>("compute_halo_maps", false, "Instruct the Postprocessor to communicate proper halo information to all ranks");
   params.addParam<bool>("compute_var_to_feature_map", false, "Instruct the Postprocessor to compute the active vars to features map");
   params.addParam<bool>("use_less_than_threshold_comparison", true, "Controls whether features are defined to be less than or greater than the threshold value.");
-  params.set<bool>("use_displaced_mesh") = true;
+
+  /**
+   * The FeatureFloodCount and derived objects should not to operate on the displaced mesh. These objects consume variable values from
+   * the nonlinear system and use a lot of raw geometric element information from the mesh. If you use the displaced system with
+   * EBSD information for instance, you'll have difficulties reconciling the difference between the coordinates from the EBSD data file
+   * and the potential displacements applied via boundary conditions.
+   */
+  params.set<bool>("use_displaced_mesh") = false;
 
   params.addParamNamesToGroup("use_single_map condense_map_info use_global_numbering", "Advanced");
 

--- a/modules/phase_field/src/postprocessors/GrainTrackerInterface.C
+++ b/modules/phase_field/src/postprocessors/GrainTrackerInterface.C
@@ -19,6 +19,8 @@ InputParameters validParams<GrainTrackerInterface>()
   params.addParam<Real>("reserve_op_threshold", 0.95, "Threshold for locating a new feature on the reserved op variable(s)" );
   params.addParam<UserObjectName>("ebsd_reader", "Optional: EBSD Reader for initial condition");
   params.addParam<unsigned int>("phase", "EBSD phase number from which to retrieve information");
+  params.addParam<bool>("error_on_grain_creation", false, "Terminate with an error if a grain is created "
+                        "(does not include initial callback to start simulation)");
 
   params.addRequiredCoupledVarWithAutoBuild("variable", "var_name_base", "op_num", "Array of coupled variables");
 

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -274,7 +274,7 @@ EBSDReader::indexFromIndex(unsigned int var) const
 
   // Don't access out of range!
   if (avg_index >= _avg_data.size())
-    mooseError("Error! Index out of range in EBSDReader::indexFromIndex()");
+    mooseError("Error! Index out of range in EBSDReader::indexFromIndex(), index: " << avg_index << " size: " << _avg_data.size());
 
   return avg_index;
 }


### PR DESCRIPTION
The big change here is that I'm changing the use_displaced_mesh value to false
again. I don't see why we need it but perhaps I'm missing something.
The mechanics example still doesn't converge but it's running now. The output
at the first step (with displacements, looks correct).

refs #8320
