### PR TITLE
Removing some of the RELAP-7 friend classes

### DIFF
--- a/framework/include/utils/InputParameterWarehouse.h
+++ b/framework/include/utils/InputParameterWarehouse.h
@@ -132,8 +132,6 @@ private:
 
   // RELAP-7 Control Logic (This will go away when the MOOSE system is created)
   friend class Component;
-  friend class R7SetupOutputAction;
-  friend class SolidMaterialProperties;
 };
 
 


### PR DESCRIPTION
We can easily remove those 2 classes now, because we do not need them to
be friends any more.

Refs #4606