### PR TITLE
Restrict NS variables to a subdomain - closes #8433

### DIFF
--- a/modules/navier_stokes/include/actions/AddNavierStokesVariablesAction.h
+++ b/modules/navier_stokes/include/actions/AddNavierStokesVariablesAction.h
@@ -11,7 +11,7 @@
 
 class AddNavierStokesVariablesAction;
 
-template<>
+template <>
 InputParameters validParams<AddNavierStokesVariablesAction>();
 
 /**
@@ -38,6 +38,7 @@ public:
 
 protected:
   std::vector<Real> _scaling;
+  std::vector<SubdomainName> _blocks;
 };
 
 #endif /* ADDNAVIERSTOKESVARIABLESACTION_H */

--- a/modules/navier_stokes/src/actions/AddNavierStokesVariablesAction.C
+++ b/modules/navier_stokes/src/actions/AddNavierStokesVariablesAction.C
@@ -9,28 +9,32 @@
 // MOOSE includes
 #include "AddVariableAction.h"
 #include "FEProblem.h"
+#include "MooseMesh.h"
 
 // libMesh includes
-#include "libmesh/string_to_enum.h"
 #include "libmesh/fe.h"
+#include "libmesh/string_to_enum.h"
 
-template<>
-InputParameters validParams<AddNavierStokesVariablesAction>()
+template <>
+InputParameters
+validParams<AddNavierStokesVariablesAction>()
 {
   InputParameters params = validParams<NSAction>();
 
   MooseEnum families(AddVariableAction::getNonlinearVariableFamilies(), "LAGRANGE");
   MooseEnum orders(AddVariableAction::getNonlinearVariableOrders(), "FIRST");
+  params.addParam<std::vector<SubdomainName>>("block", "The list of block ids (SubdomainID) on which this action will be applied");
   params.addParam<MooseEnum>("family", families, "Specifies the family of FE shape functions to use for this variable");
-  params.addParam<MooseEnum>("order", orders,  "Specifies the order of the FE shape function to use for this variable (additional orders not listed are allowed)");
-  params.addRequiredParam<std::vector<Real> >("scaling", "Specifies a scaling factor to apply to this variable");
+  params.addParam<MooseEnum>("order", orders, "Specifies the order of the FE shape function to use for this variable (additional orders not listed are allowed)");
+  params.addRequiredParam<std::vector<Real>>("scaling", "Specifies a scaling factor to apply to this variable");
 
   return params;
 }
 
-AddNavierStokesVariablesAction::AddNavierStokesVariablesAction(InputParameters parameters) :
-    NSAction(parameters),
-    _scaling(getParam<std::vector<Real> >("scaling"))
+AddNavierStokesVariablesAction::AddNavierStokesVariablesAction(InputParameters parameters)
+  : NSAction(parameters),
+    _scaling(getParam<std::vector<Real>>("scaling")),
+    _blocks(getParam<std::vector<SubdomainName>>("block"))
 {
 }
 
@@ -52,13 +56,35 @@ AddNavierStokesVariablesAction::act()
   FEType fe_type(Utility::string_to_enum<Order>(getParam<MooseEnum>("order")),
                  Utility::string_to_enum<FEFamily>(getParam<MooseEnum>("family")));
 
-  // Add the variables to the FEProblemBase
-  for (unsigned int i = 0; i < _vars.size(); ++i)
-    _problem->addVariable(_vars[i], fe_type, _scaling[i]);
+  std::set<SubdomainID> _block_ids;
+  for (const auto & subdomain_name : _blocks)
+  {
+    SubdomainID id = _mesh->getSubdomainID(subdomain_name);
+    _block_ids.insert(id);
+  }
 
-  // Add Aux variables.  These are all required in order for the code
-  // to run, so they should not be independently selectable by the
-  // user.
-  for (const auto & aux_name : _auxs)
-    _problem->addAuxVariable(aux_name, fe_type);
+  if (_block_ids.size() == 0)
+  {
+    // Add the variables to the FEProblemBase
+    for (unsigned int i = 0; i < _vars.size(); ++i)
+      _problem->addVariable(_vars[i], fe_type, _scaling[i]);
+
+    // Add Aux variables.  These are all required in order for the code
+    // to run, so they should not be independently selectable by the
+    // user.
+    for (const auto & aux_name : _auxs)
+      _problem->addAuxVariable(aux_name, fe_type);
+  }
+  else
+  {
+    // Add the variables to the FEProblemBase
+    for (unsigned int i = 0; i < _vars.size(); ++i)
+      _problem->addVariable(_vars[i], fe_type, _scaling[i], &_block_ids);
+
+    // Add Aux variables.  These are all required in order for the code
+    // to run, so they should not be independently selectable by the
+    // user.
+    for (const auto & aux_name : _auxs)
+      _problem->addAuxVariable(aux_name, fe_type, &_block_ids);
+  }
 }


### PR DESCRIPTION
A 'block' parameter has been added to the Navier-Stokes action for adding variables.  This closes #8433.