### PR TITLE
Documentation improvments

### DIFF
--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -228,13 +228,13 @@ A full slideshow example might be:
 ---
 
 ## Figures
-When writing documentation is customary to reference figures within text by number. To create a numbered figure use
+When writing documentation it is customary to reference figures within text by number. To create a numbered figure use
 the `!figure` markdown syntax. This syntax operates nearly identically to the `!image` syntax with two exceptions.
 
 !figure docs/media/memory_logger-plot_multi.png width=250px caption=The numbered prefix is automatically applied to the caption. id=fig:memory_logger
 
 First, the caption will automatically be prefixed with the figure number (e.g., Figure \ref{fig:dark_mode}). The
-numbering begins at one and is reset on each page. The prefix "Figure" can be modified with by setting
+numbering begins at one and is reset on each page. The prefix "Figure" can be modified by setting
 the "prefix" option.
 
 !figure docs/media/memory_logger-darkmode.png width=250px id=fig:dark_mode prefix=Fig. caption=The "prefix" setting changes the text that proceeds the number.

--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -24,9 +24,12 @@ be enclosed in `$$`:
 
 $$
 \begin{equation}
+\label{eqn:test}
 x=\frac{1+y}{1+2z^2}.
 \end{equation}
 $$
+
+If the `\label{eqn:test}` was placed within the latex then it is possible to link to the equation using traditional latex syntax (`\eqref{eqn:test}`): Equation \eqref{eqn:test}.
 
 ### Admonition
 The [admonition](https://pythonhosted.org/Markdown/extensions/admonition.html) package enables for important and critical

--- a/docs/content/utilities/documentation/moose_flavored_markdown.md
+++ b/docs/content/utilities/documentation/moose_flavored_markdown.md
@@ -163,7 +163,6 @@ the syntax for the system or object being documented.
 * `!parameters /Kernels/Diffusion`: Inserts tables describing the available input parameters for an object or action.
 * `!inputfiles /Kernels/Diffusion`: Creates a list of input files that use the object or action.
 * `!childobjects /Kernels/Diffusion`: Create a list of objects that inherit from the supplied object.
-* `!devel /Kernels/Diffusion`: Creates links to the repository source code and Doxygen page for the object.
 * `!subobjects /Kernels`: Creates a table of objects within the supplied system.
 * `!subsystems /Adaptivity`: Creates a table of sub-systems within the supplied system.
 
@@ -225,6 +224,56 @@ A full slideshow example might be:
 
 ---
 
+## Figures
+When writing documentation is customary to reference figures within text by number. To create a numbered figure use
+the `!figure` markdown syntax. This syntax operates nearly identically to the `!image` syntax with two exceptions.
+
+!figure docs/media/memory_logger-plot_multi.png width=250px caption=The numbered prefix is automatically applied to the caption. id=fig:memory_logger
+
+First, the caption will automatically be prefixed with the figure number (e.g., Figure \ref{fig:dark_mode}). The
+numbering begins at one and is reset on each page. The prefix "Figure" can be modified with by setting
+the "prefix" option.
+
+!figure docs/media/memory_logger-darkmode.png width=250px id=fig:dark_mode prefix=Fig. caption=The "prefix" setting changes the text that proceeds the number.
+
+Secondly, the "id" setting must be supplied. This defines the name to which the figure should be referred in the text.
+
+Figures can be referenced with latex style reference commands. For example, using `\ref{fig:memory_logger}` results in a
+reference to Figure \ref{fig:memory_logger}. If an invalid "id" is supplied the reference will display question marks: \ref{fig:invalid_id}.
+
+---
+
+## Flow Charts
+The ability to include diagrams using [GraphViz](http://www.graphviz.org/) using the [dot]() language is provided.
+Simply, include the "dot" syntax in the markdown, being sure to include the keywords ("graph" or
+"digraph") on the start of a new line.
+
+* The official page for the dot language is detailed here: [dot](http://www.graphviz.org/content/dot-language)
+* There are many sites that provide examples, for example:
+    * [https://en.wikipedia.org/wiki/DOT_(graph_description_language)](https://en.wikipedia.org/wiki/DOT_(graph_description_language))
+    * [http://graphs.grevian.org/example](http://graphs.grevian.org/example)
+* There also exists live, online tools for writing dot:
+    * [http://dreampuf.github.io/GraphvizOnline/](http://dreampuf.github.io/GraphvizOnline/)
+    * [http://www.webgraphviz.com/](http://www.webgraphviz.com/)
+
+For example, the following dot syntax placed directly in the markdown produces the following graph.
+```text
+graph {
+    bgcolor="#ffffff00" // transparent background
+    a -- b -- c;
+    b -- d;
+}
+```
+
+graph {
+    bgcolor="#ffffff00" // transparent background
+    a -- b -- c;
+    b -- d;
+}
+
+
+---
+
 ## CSS Options
 
 ### In-line CSS
@@ -271,35 +320,6 @@ An empty new line, designates the end of the css block.
 !css font-size=smaller margin-left=70% color=red text-shadow=1px 1px 1px rgba(0,0,0,.4)
 Another paragraph modified by CSS.
 
----
-
-## Flow Charts
-The ability to include diagrams using [GraphViz](http://www.graphviz.org/) using the [dot]() language is provided.
-Simply, include the "dot" syntax in the markdown, being sure to include the keywords ("graph" or
-"digraph") on the start of a new line.
-
-* The official page for the dot language is detailed here: [dot](http://www.graphviz.org/content/dot-language)
-* There are many sites that provide examples, for example:
-    * [https://en.wikipedia.org/wiki/DOT_(graph_description_language)](https://en.wikipedia.org/wiki/DOT_(graph_description_language))
-    * [http://graphs.grevian.org/example](http://graphs.grevian.org/example)
-* There also exists live, online tools for writing dot:
-    * [http://dreampuf.github.io/GraphvizOnline/](http://dreampuf.github.io/GraphvizOnline/)
-    * [http://www.webgraphviz.com/](http://www.webgraphviz.com/)
-
-For example, the following dot syntax placed directly in the markdown produces the following graph.
-```text
-graph {
-    bgcolor="#ffffff00" // transparent background
-    a -- b -- c;
-    b -- d;
-}
-```
-
-graph {
-    bgcolor="#ffffff00" // transparent background
-    a -- b -- c;
-    b -- d;
-}
 
 ---
 

--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -43,3 +43,18 @@ $('.moose-figure-reference').each(function(i, e) {
     $(e).text('???');
   }
 });
+
+// Function for latex equation references
+MathJax.Hub.Queue(function(){
+  $('.moose-equation-reference').each(function(i, e) {
+    var elem = $($(e).attr('href'));
+    if (elem.length) {
+      var txt = $('.mtext', elem).text()
+      $(e).text(txt);
+      console.log('Located reference to Equation ' + txt);
+    } else {
+      console.error('Unable to located reference to equation: ' + $(e).attr('href'));
+      $(e).text('(??)');
+    }
+  });
+});

--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -31,3 +31,15 @@ MathJax.Hub.Config({
 
 // Copy code button
 var clipboard = new Clipboard('.moose-copy-button');
+
+// Function for figure references
+$('.moose-figure-reference').each(function(i, e) {
+  var elem = $($(e).attr('href').replace(':', ''));
+  if (elem.length) {
+    $(e).text(elem.data('moose-figure-number'));
+    console.log('Located reference to Figure ' + elem.data('moose-figure-number'));
+  } else {
+    console.error('Unable to located reference to figure: ' + $(e).attr('href'));
+    $(e).text('???');
+  }
+});

--- a/docs/tests/bibtex/gold/test_cite.html
+++ b/docs/tests/bibtex/gold/test_cite.html
@@ -1,4 +1,4 @@
-<p><a href="#testkey" data-moose-cite="\cite{testkey}">Smith and Doe (1980)</a>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<p><span data-moose-cite="\cite{testkey}"><a href="#testkey">Smith and Doe (1980)</a></span>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
 <li name="testkey">Jane Smith and John Doe.
 A test citation without special characters for easy testing.
 <em>A Prestigous Journal</em>, 1980.</li>

--- a/docs/tests/bibtex/gold/test_citeThree.html
+++ b/docs/tests/bibtex/gold/test_citeThree.html
@@ -1,0 +1,6 @@
+<p><span data-moose-cite="\cite{testkey, testkey, testkey}"><a href="#testkey">Smith and Doe (1980)</a>, <a href="#testkey">Smith and Doe (1980)</a>, and <a href="#testkey">Smith and Doe (1980)</a></span>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<li name="testkey">Jane Smith and John Doe.
+A test citation without special characters for easy testing.
+<em>A Prestigous Journal</em>, 1980.</li>
+</ol>
+</p>

--- a/docs/tests/bibtex/gold/test_citeTwo.html
+++ b/docs/tests/bibtex/gold/test_citeTwo.html
@@ -1,0 +1,6 @@
+<p><span data-moose-cite="\cite{testkey, testkey}"><a href="#testkey">Smith and Doe (1980)</a> and <a href="#testkey">Smith and Doe (1980)</a></span>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<li name="testkey">Jane Smith and John Doe.
+A test citation without special characters for easy testing.
+<em>A Prestigous Journal</em>, 1980.</li>
+</ol>
+</p>

--- a/docs/tests/bibtex/gold/test_citep.html
+++ b/docs/tests/bibtex/gold/test_citep.html
@@ -1,4 +1,4 @@
-<p>(<a href="#testkey" data-moose-cite="\citep{testkey}">Smith and Doe, 1980</a>)\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<p>(<span data-moose-cite="\citep{testkey}"><a href="#testkey">Smith and Doe, 1980</a></span>)\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
 <li name="testkey">Jane Smith and John Doe.
 A test citation without special characters for easy testing.
 <em>A Prestigous Journal</em>, 1980.</li>

--- a/docs/tests/bibtex/gold/test_citepThree.html
+++ b/docs/tests/bibtex/gold/test_citepThree.html
@@ -1,0 +1,6 @@
+<p>(<span data-moose-cite="\citep{testkey, testkey, testkey}"><a href="#testkey">Smith and Doe, 1980</a>; <a href="#testkey">Smith and Doe, 1980</a>; and <a href="#testkey">Smith and Doe, 1980</a></span>)\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<li name="testkey">Jane Smith and John Doe.
+A test citation without special characters for easy testing.
+<em>A Prestigous Journal</em>, 1980.</li>
+</ol>
+</p>

--- a/docs/tests/bibtex/gold/test_citepTwo.html
+++ b/docs/tests/bibtex/gold/test_citepTwo.html
@@ -1,0 +1,6 @@
+<p>(<span data-moose-cite="\citep{testkey, testkey}"><a href="#testkey">Smith and Doe, 1980</a> and <a href="#testkey">Smith and Doe, 1980</a></span>)\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<li name="testkey">Jane Smith and John Doe.
+A test citation without special characters for easy testing.
+<em>A Prestigous Journal</em>, 1980.</li>
+</ol>
+</p>

--- a/docs/tests/bibtex/gold/test_citet.html
+++ b/docs/tests/bibtex/gold/test_citet.html
@@ -1,4 +1,4 @@
-<p><a href="#testkey" data-moose-cite="\citet{testkey}">Smith and Doe (1980)</a>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<p><span data-moose-cite="\citet{testkey}"><a href="#testkey">Smith and Doe (1980)</a></span>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
 <li name="testkey">Jane Smith and John Doe.
 A test citation without special characters for easy testing.
 <em>A Prestigous Journal</em>, 1980.</li>

--- a/docs/tests/bibtex/gold/test_citetThree.html
+++ b/docs/tests/bibtex/gold/test_citetThree.html
@@ -1,0 +1,6 @@
+<p><span data-moose-cite="\citet{testkey, testkey, testkey}"><a href="#testkey">Smith and Doe (1980)</a>, <a href="#testkey">Smith and Doe (1980)</a>, and <a href="#testkey">Smith and Doe (1980)</a></span>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<li name="testkey">Jane Smith and John Doe.
+A test citation without special characters for easy testing.
+<em>A Prestigous Journal</em>, 1980.</li>
+</ol>
+</p>

--- a/docs/tests/bibtex/gold/test_citetTwo.html
+++ b/docs/tests/bibtex/gold/test_citetTwo.html
@@ -1,0 +1,6 @@
+<p><span data-moose-cite="\citet{testkey, testkey}"><a href="#testkey">Smith and Doe (1980)</a> and <a href="#testkey">Smith and Doe (1980)</a></span>\n<ol class="moose-bibliography" data-moose-bibfiles="[u'<<CWD>>/bib/moose.bib']">
+<li name="testkey">Jane Smith and John Doe.
+A test citation without special characters for easy testing.
+<em>A Prestigous Journal</em>, 1980.</li>
+</ol>
+</p>

--- a/docs/tests/bibtex/test_bibtex.py
+++ b/docs/tests/bibtex/test_bibtex.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import os
 import MooseDocs
 from MooseDocs.testing import MarkdownTestCase
@@ -21,10 +20,34 @@ class TestBibtexExtension(MarkdownTestCase):
     md = r'\cite{testkey}\n\bibliography{docs/bib/moose.bib}'
     self.assertConvert('test_cite.html', md)
 
+  def testCiteTwo(self):
+    md = r'\cite{testkey, testkey}\n\bibliography{docs/bib/moose.bib}'
+    self.assertConvert('test_citeTwo.html', md)
+
+  def testCiteThree(self):
+    md = r'\cite{testkey, testkey, testkey}\n\bibliography{docs/bib/moose.bib}'
+    self.assertConvert('test_citeThree.html', md)
+
   def testCitet(self):
     md = r'\citet{testkey}\n\bibliography{docs/bib/moose.bib}'
     self.assertConvert('test_citet.html', md)
 
+  def testCitetTwo(self):
+    md = r'\citet{testkey, testkey}\n\bibliography{docs/bib/moose.bib}'
+    self.assertConvert('test_citetTwo.html', md)
+
+  def testCitetThree(self):
+    md = r'\citet{testkey, testkey, testkey}\n\bibliography{docs/bib/moose.bib}'
+    self.assertConvert('test_citetThree.html', md)
+
   def testCitep(self):
     md = r'\citep{testkey}\n\bibliography{docs/bib/moose.bib}'
     self.assertConvert('test_citep.html', md)
+
+  def testCitepTwo(self):
+    md = r'\citep{testkey, testkey}\n\bibliography{docs/bib/moose.bib}'
+    self.assertConvert('test_citepTwo.html', md)
+
+  def testCitepThree(self):
+    md = r'\citep{testkey, testkey, testkey}\n\bibliography{docs/bib/moose.bib}'
+    self.assertConvert('test_citepThree.html', md)

--- a/docs/tests/figure/gold/test_Figure.html
+++ b/docs/tests/figure/gold/test_Figure.html
@@ -1,0 +1,11 @@
+<p>
+<div data-moose-figure-number="1" id="figure" style="">
+<div class="card">
+<div class="card-image"><img class="materialboxed" src="media/github-logo.png" /></div>
+<div>
+<p align="justify" class="moose-caption">Figure 1</p>
+</div>
+</div>
+</div>
+</p>
+<p><a class="moose-figure-reference" href="#figure"></a></p>

--- a/docs/tests/figure/test_figure.py
+++ b/docs/tests/figure/test_figure.py
@@ -1,0 +1,12 @@
+import os
+import unittest
+from MooseDocs.testing import MarkdownTestCase
+
+class TestMooseFigure(MarkdownTestCase):
+  """
+  Test commands in MooseFigure extension.
+  """
+
+  def testFigure(self):
+    md = '!figure docs/media/github-logo.png id=figure\n\n\\ref{figure}'
+    self.assertConvert('test_Figure.html', md)

--- a/python/MooseDocs/MooseApplicationSyntax.py
+++ b/python/MooseDocs/MooseApplicationSyntax.py
@@ -201,6 +201,21 @@ class MooseApplicationSyntax(object):
                                hidden=self.hidden(node['name']))
         self._actions[info.key] = info
 
+    # Create MooseActionInfo objects from the MooseObjectInfo
+    # This is needed to allow for the !systems pages to be complete for apps that
+    # do not also include the framework
+    for obj_info in self._objects.itervalues():
+      action_key = os.path.dirname(obj_info.key)
+      if action_key not in self._actions:
+        for node in self._yaml_data[action_key]:
+          info = MooseActionInfo(node,
+                                 code=[],
+                                 install=install,
+                                 group=self._group,
+                                 generate=generate,
+                                 hidden=self.hidden(node['name']))
+          self._actions[info.key] = info
+
   def name(self):
     """
     Return the name of the syntax.

--- a/python/MooseDocs/MooseApplicationSyntax.py
+++ b/python/MooseDocs/MooseApplicationSyntax.py
@@ -290,11 +290,11 @@ class MooseApplicationSyntax(object):
 
           # Update class to source definition map
           if filename.endswith('.h'):
-            for match in re.finditer(r'class\s*(?P<class>\w+)', content):
+            for match in re.finditer(r'class\s*(?P<class>\w+)\b[^;]', content):
               key = match.group('class')
               self._filenames[key] = [fullfile]
               src = fullfile.replace('/include/', '/src/')[:-2] + '.C'
-              if os.path.exists(src):
+              if os.path.exists(src) and (src not in self._filenames[key]):
                 self._filenames[key].append(src)
 
           # Map of registered objects

--- a/python/MooseDocs/commands/MooseDocsMarkdownNode.py
+++ b/python/MooseDocs/commands/MooseDocsMarkdownNode.py
@@ -43,7 +43,7 @@ class MooseDocsMarkdownNode(MooseDocsNode):
     """
 
     # Read the markdown and parse the HTML
-    log.info('Parsing markdown: {}'.format(self.__md_file))
+    log.debug('Parsing markdown: {}'.format(self.__md_file))
     content, meta = MooseDocs.read_markdown(self.__md_file)
     self.__html = self.__parser.convert(content)
 

--- a/python/MooseDocs/commands/check.py
+++ b/python/MooseDocs/commands/check.py
@@ -16,4 +16,3 @@ def check(**kwargs):
   Performs checks for missing documentation.
   """
   MooseDocs.commands.generate(generate=False, **kwargs)
-  return 0 # error handled in MooseDocs.moosedocs

--- a/python/MooseDocs/commands/serve.py
+++ b/python/MooseDocs/commands/serve.py
@@ -3,6 +3,7 @@ import sys
 import glob
 import re
 import livereload
+import multiprocessing
 import logging
 import shutil
 import MooseDocs
@@ -17,11 +18,11 @@ def serve_options(parser, subparser):
   serve_parser = subparser.add_parser('serve', help='Serve the documentation using a local server.')
   serve_parser.add_argument('--host', default='127.0.0.1', type=str, help="The local host location for live web server (default: %(default)s).")
   serve_parser.add_argument('--port', default='8000', type=str, help="The local host port for live web server (default: %(default)s).")
-  serve_parser.add_argument('--disable-threads', action='store_true', help="Disable threaded building.")
+  serve_parser.add_argument('--num-threads', '-j', type=int, default=multiprocessing.cpu_count(), help="Specify the number of threads to build pages with.")
 
   return serve_parser
 
-def serve(config_file='moosedocs.yml', host='127.0.0.1', port='8000', disable_threads=False):
+def serve(config_file='moosedocs.yml', host='127.0.0.1', port='8000', num_threads=multiprocessing.cpu_count()):
   """
   Create live server
   """
@@ -43,7 +44,7 @@ def serve(config_file='moosedocs.yml', host='127.0.0.1', port='8000', disable_th
 
   # Wrapper for building complete website
   def build_complete():
-    return build.build_site(config_file=config_file, site_dir=tempdir, disable_threads=disable_threads)
+    return build.build_site(config_file=config_file, site_dir=tempdir, num_threads=num_threads)
   config, parser, builder = build_complete()
 
   # Start the live server

--- a/python/MooseDocs/extensions/MooseActionList.py
+++ b/python/MooseDocs/extensions/MooseActionList.py
@@ -52,7 +52,7 @@ class MooseActionList(MooseSyntaxBase):
     for action in actions:
 
       # Do nothing if the syntax is hidden
-      if action.hidden and not settings['show_hidden']:
+      if (action.group in groups) and action.hidden and (not settings['show_hidden']):
         continue
 
       # Attempt to build the sub-objects table

--- a/python/MooseDocs/extensions/MooseEquationReference.py
+++ b/python/MooseDocs/extensions/MooseEquationReference.py
@@ -1,0 +1,34 @@
+import os
+from markdown.util import etree
+import logging
+log = logging.getLogger(__name__)
+
+import MooseDocs
+from markdown.inlinepatterns import Pattern
+from MooseCommonExtension import MooseCommonExtension
+
+class MooseEquationReference(MooseCommonExtension, Pattern):
+  """
+  Defines syntax for referencing MathJax equations with \label defined.
+
+  This should be handled automatically by MathJax, but I can't seem to get the \eqref stuff working via MathJax. I am
+  guessing that the python-markdown-math package is doing something to break compatibility. I also can't get
+  latex math to work without the package, so until I have more time to dig I am just building the references manually.
+  """
+
+  RE = r'(?<!`)\\eqref{(.*?)}'
+
+  def __init__(self, markdown_instance=None, **kwargs):
+    MooseCommonExtension.__init__(self, **kwargs)
+    Pattern.__init__(self, self.RE, markdown_instance)
+
+  def handleMatch(self, match):
+    """
+    Creates the <a> object with the reference that is then updated with the function in the init.js file.
+    """
+    mjx_id = 'mjx-eqn-{}'.format(match.group(2).replace(':', ''))
+    el = etree.Element('a')
+    el.set('class', 'moose-equation-reference')
+    el.set('href', '#' + mjx_id)
+    el.text = '(??)'
+    return el

--- a/python/MooseDocs/extensions/MooseFigure.py
+++ b/python/MooseDocs/extensions/MooseFigure.py
@@ -1,0 +1,53 @@
+from markdown.treeprocessors import InlineProcessor
+import logging
+log = logging.getLogger(__name__)
+
+from MooseImageFile import MooseImageFile
+
+class MooseFigure(MooseImageFile):
+  """
+  Defines syntax for adding images as numbered figures with labels that can be referenced (see MooseFigureReference)
+  """
+  RE = r'^!figure\s+(.*?)(?:$|\s+)(.*)'
+
+  def __init__(self, *args, **kwargs):
+    super(MooseFigure, self).__init__(*args, **kwargs)
+
+    self._settings['prefix'] = 'Figure'
+    self._settings['id'] = None
+    self._figure_number = 0
+
+  def initialize(self):
+    """
+    Reset the figure numbering prior to processing the markdown for this page.
+    """
+    self._figure_number = 0
+
+  def handleMatch(self, match):
+    """
+    Creates the html for a numbered MOOSE figure.
+    """
+
+    # Increment the image number
+    self._figure_number += 1
+
+    # Extract information from the regex match
+    rel_filename = match.group(2)
+    settings = self.getSettings(match.group(3))
+
+    # Error if the 'label' setting is not provided
+    if not settings['id']:
+      return self.createErrorElement("The 'id' setting must be supplied for the figure: {}".format(rel_filename))
+    else:
+      settings['id'] = settings['id'].replace(':', '')
+
+    # Update the caption to include the numbered prefix
+    if settings['caption']:
+      settings['caption'] = '{} {}: {}'.format(settings['prefix'], self._figure_number, settings['caption'])
+    else:
+      settings['caption'] = '{} {}'.format(settings['prefix'], self._figure_number)
+
+    # Create the element and store the number
+    el = self.createImageElement(rel_filename, settings)
+    el.set('data-moose-figure-number', str(self._figure_number))
+    return el

--- a/python/MooseDocs/extensions/MooseFigureReference.py
+++ b/python/MooseDocs/extensions/MooseFigureReference.py
@@ -1,0 +1,25 @@
+import os
+from markdown.util import etree
+import logging
+log = logging.getLogger(__name__)
+
+import MooseDocs
+from markdown.inlinepatterns import Pattern
+from MooseCommonExtension import MooseCommonExtension
+
+class MooseFigureReference(MooseCommonExtension, Pattern):
+  """
+  Defines syntax for referencing figures.
+  """
+
+  RE = r'(?<!`)\\ref{(.*?)}'
+
+  def __init__(self, markdown_instance=None, **kwargs):
+    MooseCommonExtension.__init__(self, **kwargs)
+    Pattern.__init__(self, self.RE, markdown_instance)
+
+  def handleMatch(self, match):
+    el = etree.Element('a')
+    el.set('class', 'moose-figure-reference')
+    el.set('href', '#' + match.group(2))
+    return el

--- a/python/MooseDocs/extensions/MooseImageFile.py
+++ b/python/MooseDocs/extensions/MooseImageFile.py
@@ -28,17 +28,17 @@ class MooseImageFile(MooseCommonExtension, Pattern):
     Pattern.__init__(self, self.RE, markdown_instance)
     self._settings['caption'] = None
 
-  def handleMatch(self, match):
+  def createImageElement(self, rel_filename, settings):
     """
-    process settings associated with !image markdown
+    Create the element containing the image, this is a separate function to allow for other objects
+    (i.e., MooseFigure) to utilize this class to build similar html.
+
+    Inputs:
+      rel_filename[str]: The path to the image relative to the git repository.
+      settings[dict]: The settings extracted via getSettings() method.
     """
-
-    # A tuple separating specific MOOSE documentation features (self._settings) from HTML styles
-    settings = self.getSettings(match.group(3))
-
     # Read the file and create element
-    rel_filename = match.group(2)
-    filename = MooseDocs.abspath(match.group(2))
+    filename = MooseDocs.abspath(rel_filename)
     if not os.path.exists(filename):
       return self.createErrorElement('File not found: {}'.format(rel_filename))
 
@@ -64,3 +64,11 @@ class MooseImageFile(MooseCommonExtension, Pattern):
       p.text = settings['caption']
 
     return el
+
+  def handleMatch(self, match):
+    """
+    process settings associated with !image markdown
+    """
+    rel_filename = match.group(2)
+    settings = self.getSettings(match.group(3))
+    return self.createImageElement(rel_filename, settings)

--- a/python/MooseDocs/extensions/MooseInlineProcessor.py
+++ b/python/MooseDocs/extensions/MooseInlineProcessor.py
@@ -1,0 +1,23 @@
+from markdown.treeprocessors import InlineProcessor
+import logging
+log = logging.getLogger(__name__)
+
+from MooseImageFile import MooseImageFile
+from MooseCommonExtension import MooseCommonExtension
+
+class MooseInlineProcessor(InlineProcessor, MooseCommonExtension):
+  """
+  Replacement for the standard InlineProcessor that includes an initialize() method.
+  """
+
+  def __init__(self, markdown_instance=None, **kwargs):
+    super(MooseInlineProcessor, self).__init__(markdown_instance)
+
+  def run(self, *args, **kwargs):
+    """
+    Adds a call to 'initialize()' prior to executing the InlineProcessor running.
+    """
+    for inline in self.inlinePatterns.itervalues():
+      if hasattr(inline, 'initialize'):
+        inline.initialize()
+    super(MooseInlineProcessor, self).run(*args, **kwargs)

--- a/python/MooseDocs/extensions/MooseMarkdown.py
+++ b/python/MooseDocs/extensions/MooseMarkdown.py
@@ -12,6 +12,7 @@ from MooseTextFile import MooseTextFile
 from MooseImageFile import MooseImageFile
 from MooseFigure import MooseFigure
 from MooseFigureReference import MooseFigureReference
+from MooseEquationReference import MooseEquationReference
 from MooseInlineProcessor import MooseInlineProcessor
 from MooseInputBlock import MooseInputBlock
 from MooseCppMethod import MooseCppMethod
@@ -136,7 +137,8 @@ class MooseMarkdown(markdown.Extension):
     md.inlinePatterns.add('moose_text', MooseTextFile(markdown_instance=md, **config), '_begin')
     md.inlinePatterns.add('moose_image', MooseImageFile(markdown_instance=md, **config), '_begin')
     md.inlinePatterns.add('moose_figure', MooseFigure(markdown_instance=md, **config), '_begin')
-    md.inlinePatterns.add('moose-figure-reference', MooseFigureReference(markdown_instance=md, **config), '>moose_figure')
+    md.inlinePatterns.add('moose_figure_reference', MooseFigureReference(markdown_instance=md, **config), '>moose_figure')
+    md.inlinePatterns.add('moose_equation_reference', MooseEquationReference(markdown_instance=md, **config), '<moose_figure_reference')
     md.inlinePatterns.add('moose_build_status', MooseBuildStatus(markdown_instance=md, **config), '_begin')
     if config['package']:
       md.inlinePatterns.add('moose_package_parser', MoosePackageParser(markdown_instance=md, **config), '_end')

--- a/python/MooseDocs/extensions/MooseMarkdown.py
+++ b/python/MooseDocs/extensions/MooseMarkdown.py
@@ -10,6 +10,9 @@ from MooseDescription import MooseDescription
 from MooseActionSyntax import MooseActionSyntax
 from MooseTextFile import MooseTextFile
 from MooseImageFile import MooseImageFile
+from MooseFigure import MooseFigure
+from MooseFigureReference import MooseFigureReference
+from MooseInlineProcessor import MooseInlineProcessor
 from MooseInputBlock import MooseInputBlock
 from MooseCppMethod import MooseCppMethod
 from MoosePackageParser import MoosePackageParser
@@ -98,6 +101,10 @@ class MooseMarkdown(markdown.Extension):
       options.setdefault('install', config['install'])
       self.syntax[key] = MooseDocs.MooseApplicationSyntax(exe_yaml, **options)
 
+    # Replace the InlineTreeprocessor with the MooseInlineProcessor, this allows
+    # for an initialize() method to be called prior to the convert for re-setting state.
+    md.treeprocessors['inline'] = MooseInlineProcessor(markdown_instance=md, **config)
+
     # Preprocessors
     md.preprocessors.add('moose_bibtex', MooseBibtex(markdown_instance=md, **config), '_end')
     if config['slides']:
@@ -128,6 +135,8 @@ class MooseMarkdown(markdown.Extension):
     md.inlinePatterns.add('moose_cpp_method', MooseCppMethod(markdown_instance=md, **config), '_begin')
     md.inlinePatterns.add('moose_text', MooseTextFile(markdown_instance=md, **config), '_begin')
     md.inlinePatterns.add('moose_image', MooseImageFile(markdown_instance=md, **config), '_begin')
+    md.inlinePatterns.add('moose_figure', MooseFigure(markdown_instance=md, **config), '_begin')
+    md.inlinePatterns.add('moose-figure-reference', MooseFigureReference(markdown_instance=md, **config), '>moose_figure')
     md.inlinePatterns.add('moose_build_status', MooseBuildStatus(markdown_instance=md, **config), '_begin')
     if config['package']:
       md.inlinePatterns.add('moose_package_parser', MoosePackageParser(markdown_instance=md, **config), '_end')

--- a/python/MooseDocs/extensions/MooseTextPatternBase.py
+++ b/python/MooseDocs/extensions/MooseTextPatternBase.py
@@ -31,6 +31,9 @@ class MooseTextPatternBase(MooseCommonExtension, Pattern):
     self._settings['label'] = True
     self._settings['language'] = 'text'
     self._settings['strip-extra-newlines'] = False
+    self._settings['prefix'] = ''
+    self._settings['suffix'] = ''
+    self._settings['indent'] = 0
 
   def prepareContent(self, content, settings):
     """
@@ -53,6 +56,20 @@ class MooseTextPatternBase(MooseCommonExtension, Pattern):
       strt = content.find('/********')
       stop = content.rfind('*******/\n')
       content = content.replace(content[strt:stop+9], '')
+
+    # Add indent
+    if settings['indent'] > 0:
+      lines = content.split('\n')
+      content = []
+      for line in lines:
+        content.append('{}{}'.format(' '*int(settings['indent']), line))
+      content = '\n'.join(content)
+
+    # Prefix/suffix
+    if settings['prefix']:
+      content = '{}\n{}'.format(settings['prefix'], content)
+    if settings['suffix']:
+      content = '{}\n{}'.format(content, settings['suffix'])
 
     return content
 

--- a/python/MooseDocs/html2latex/BasicExtension.py
+++ b/python/MooseDocs/html2latex/BasicExtension.py
@@ -40,6 +40,7 @@ class BasicExtension(Extension):
     translator.elements.add('tr', elements.tr())
     translator.elements.add('a', elements.a())
     translator.elements.add('p', elements.p())
+    translator.elements.add('span', elements.span())
     translator.elements.add('li', elements.li())
     translator.elements.add('em', elements.em())
     translator.elements.add('code', elements.code())

--- a/python/MooseDocs/html2latex/MooseExtension.py
+++ b/python/MooseDocs/html2latex/MooseExtension.py
@@ -14,7 +14,7 @@ class MooseExtension(Extension):
     translator.elements.add('moose_inline_code', moose_inline_code(), '<code')
 
     translator.elements.add('moose_bib', moose_bib(), '<ol')
-    translator.elements.add('moose_bib_a', moose_bib_a(), '<moose_internal_links')
+    translator.elements.add('moose_bib_span', moose_bib_span(), '<moose_internal_links')
     translator.elements.add('moose_slider', moose_slider(), '_begin')
     translator.elements.add('moose_buildstatus', moose_buildstatus(), '_begin')
     translator.elements.add('admonition_div', admonition_div(), '<div')

--- a/python/MooseDocs/html2latex/Translator.py
+++ b/python/MooseDocs/html2latex/Translator.py
@@ -78,7 +78,7 @@ class Translator(object):
     soup = bs4.BeautifulSoup(tex, "html.parser")
     for child in soup.children:
       if isinstance(child, bs4.element.Tag):
-        log.error('Failed to convert tag: {}'.format(child.name))
+        log.error('Failed to convert tag {}: {}'.format(child.name, str(child)))
         output += self.unknown.convert(child, self.unknown.content(child))
       else:
         output += unicode(child)

--- a/python/MooseDocs/html2latex/elements.py
+++ b/python/MooseDocs/html2latex/elements.py
@@ -194,6 +194,11 @@ class a(InlineElement):
   def preamble(self):
     return ['\\usepackage{hyperref}']
 
+class span(InlineElement):
+  name = 'span'
+  def convert(self, tag, content):
+    return content
+
 class p(InlineElement):
   name = 'p'
   def convert(self, tag, content):

--- a/python/MooseDocs/html2latex/moose_elements.py
+++ b/python/MooseDocs/html2latex/moose_elements.py
@@ -265,7 +265,7 @@ class moose_bib(elements.ol):
   def preamble(self):
     return ['\\usepackage{natbib}']
 
-class moose_bib_a(elements.a):
+class moose_bib_span(elements.span):
   """
   Convert the cite command from MooseBibtex to the proper latex cite command.
   """


### PR DESCRIPTION
I added some features and fixes that I am using to document the level set module, which I will put up a PR for shortly.

* Allows multiple names in \cite commands
* Adds ability to indent, prefix, and suffix text extracted from files
* Adds figure numbers
* Adds equation numbers

(refs #8329)