### PR TITLE
Fix locking around making documentation directories

### DIFF
--- a/python/MooseDocs/commands/MooseDocsMarkdownNode.py
+++ b/python/MooseDocs/commands/MooseDocsMarkdownNode.py
@@ -2,8 +2,6 @@ import os
 import copy
 import bs4
 import jinja2
-import re
-import multiprocessing
 import logging
 log = logging.getLogger(__name__)
 
@@ -37,7 +35,7 @@ class MooseDocsMarkdownNode(MooseDocsNode):
     """
     return self.__md_file
 
-  def build(self):
+  def build(self, lock):
     """
     Converts the markdown to html.
     """
@@ -62,7 +60,7 @@ class MooseDocsMarkdownNode(MooseDocsNode):
     # Make sure the destination directory exists, if it already does do nothing. If it does not exist try to create
     # it, but include a try statement because it might get created by another process.
     destination = self.path()
-    with multiprocessing.Lock():
+    with lock:
       if not os.path.exists(destination):
         os.makedirs(destination)
 

--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -91,13 +91,14 @@ class Builder(object):
       for i in range(0, len(l), n):
         yield l[i:i + n]
 
-    def build_pages(pages):
+    def build_pages(pages, lock):
       for page in pages:
-        page.build()
+        page.build(lock)
 
     jobs = []
+    lock = multiprocessing.Lock()
     for chunk in make_chunks(self._pages, num_threads):
-      p = multiprocessing.Process(target=build_pages, args=(chunk,))
+      p = multiprocessing.Process(target=build_pages, args=(chunk, lock))
       p.start()
       jobs.append(p)
 


### PR DESCRIPTION
I wrote a small python script to confirm that the old way of locking wouldn't actually do anything.
The lock needs to be shared across all processes.