### PR TITLE
Dofmap output fix

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -221,6 +221,14 @@ public:
   virtual dof_id_type nElem() const;
 
   /**
+   * Calls max_node/elem_id() on the underlying libMesh mesh object.
+   * This may be larger than n_nodes/elem() in cases where the id
+   * numbering is not contiguous.
+   */
+  virtual dof_id_type maxNodeId() const;
+  virtual dof_id_type maxElemId() const;
+
+  /**
    * Various accessors (pointers/references) for Node "i".
    */
   virtual const Node & node (const dof_id_type i) const;

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -230,6 +230,9 @@ public:
 
   /**
    * Various accessors (pointers/references) for Node "i".
+   *
+   * If the requested node is a remote node on a distributed mesh,
+   * only the query accessors are valid to call, and they return NULL.
    */
   virtual const Node & node (const dof_id_type i) const;
   virtual Node & node (const dof_id_type i);
@@ -237,14 +240,21 @@ public:
   virtual Node & nodeRef (const dof_id_type i);
   virtual const Node* nodePtr(const dof_id_type i) const;
   virtual Node* nodePtr(const dof_id_type i);
+  virtual const Node* queryNodePtr(const dof_id_type i) const;
+  virtual Node* queryNodePtr(const dof_id_type i);
 
   /**
    * Various accessors (pointers/references) for Elem "i".
+   *
+   * If the requested elem is a remote element on a distributed mesh,
+   * only the query accessors are valid to call, and they return NULL.
    */
   virtual Elem * elem(const dof_id_type i);
   virtual const Elem * elem(const dof_id_type i) const;
   virtual Elem * elemPtr(const dof_id_type i);
   virtual const Elem * elemPtr(const dof_id_type i) const;
+  virtual Elem * queryElemPtr(const dof_id_type i);
+  virtual const Elem * queryElemPtr(const dof_id_type i) const;
 
   /**
    * Setter/getter for the _is_changed flag.

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -428,6 +428,25 @@ MooseMesh::nodePtr(const dof_id_type i)
   return getMesh().node_ptr(i);
 }
 
+
+const Node*
+MooseMesh::queryNodePtr(const dof_id_type i) const
+{
+  if (i > getMesh().max_node_id())
+    return (*_quadrature_nodes.find(i)).second;
+
+  return getMesh().query_node_ptr(i);
+}
+
+Node*
+MooseMesh::queryNodePtr(const dof_id_type i)
+{
+  if (i > getMesh().max_node_id())
+    return _quadrature_nodes[i];
+
+  return getMesh().query_node_ptr(i);
+}
+
 void
 MooseMesh::meshChanged()
 {
@@ -1995,6 +2014,18 @@ const Elem *
 MooseMesh::elemPtr(const dof_id_type i) const
 {
   return getMesh().elem_ptr(i);
+}
+
+Elem *
+MooseMesh::queryElemPtr(const dof_id_type i)
+{
+  return getMesh().query_elem_ptr(i);
+}
+
+const Elem *
+MooseMesh::queryElemPtr(const dof_id_type i) const
+{
+  return getMesh().query_elem_ptr(i);
 }
 
 bool

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1959,6 +1959,18 @@ MooseMesh::nElem() const
   return getMesh().n_elem();
 }
 
+dof_id_type
+MooseMesh::maxNodeId() const
+{
+  return getMesh().max_node_id();
+}
+
+dof_id_type
+MooseMesh::maxElemId() const
+{
+  return getMesh().max_elem_id();
+}
+
 Elem *
 MooseMesh::elem(const dof_id_type i)
 {

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -589,7 +589,7 @@ SolutionUserObject::pointValueWrapper(Real t, const Point & p, const std::string
     case 4:
     {
       Real smallest_elem_id_value = std::numeric_limits<Real>::max();
-      dof_id_type smallest_elem_id = _fe_problem.mesh().nElem();
+      dof_id_type smallest_elem_id = _fe_problem.mesh().maxElemId();
       for (auto & v : values)
         if (v.first->id() < smallest_elem_id)
         {
@@ -736,7 +736,7 @@ SolutionUserObject::pointValueGradientWrapper(Real t, const Point & p, const std
     case 4:
     {
       RealGradient smallest_elem_id_value;
-      dof_id_type smallest_elem_id = _fe_problem.mesh().nElem();
+      dof_id_type smallest_elem_id = _fe_problem.mesh().maxElemId();
       for (auto & v : values)
         if (v.first->id() < smallest_elem_id)
         {


### PR DESCRIPTION
This fixes 4 tests which fail with --distributed-mesh in parallel (we're still a couple dozen tests away from closing #1500 though), fixes one unrelated bug I noticed while grepping through the source code for other possible locations of the DistributedMesh-incompatible algorithm, and adds 4 utility methods that were missing from the MooseMesh shim (only one of which I ended up needing right away, but all of which I suspect will be necessary before we're done with #1500).