### PR TITLE
OversampleOutput fixes

### DIFF
--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -128,12 +128,6 @@ private:
 
   std::unique_ptr<EquationSystems> _oversample_es;
   std::unique_ptr<MooseMesh> _cloned_mesh_ptr;
-
-  /// Oversample solution vector
-  /* Each of the MeshFunctions keeps a reference to this vector, the vector is updated for the current system
-   * and variable before the MeshFunction is applied. This allows for the same MeshFunction object to be
-   * re-used, unless the mesh has changed due to adaptivity */
-  std::unique_ptr<NumericVector<Number> > _serialized_solution;
 };
 
 #endif // OVERSAMPLEOUTPUT_H

--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -40,7 +40,7 @@ InputParameters validParams<OversampleOutput>();
  * changes to the libMesh::EquationsSystems() pointer (_es_ptr), i.e., this pointer is
  * will point to the oversampled system, if oversamping is utilized.
  *
- * Additionally, the class adds a pointer the the mesh object (_mesh_ptr) that again
+ * Additionally, the class adds a pointer to the mesh object (_mesh_ptr) that again
  * points to the correct mesh depending on the use of oversampling.
  *
  * The use of oversampling is triggered by setting the oversample input parameter to a

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -95,6 +95,10 @@ OversampleOutput::initOversample()
   if (_oversample)
   {
     MeshRefinement mesh_refinement(_mesh_ptr->getMesh());
+
+    // We want original and refined partitioning to match so we can
+    // query from one to the other safely on distributed meshes.
+    _mesh_ptr->getMesh().skip_partitioning(true);
     mesh_refinement.uniformly_refine(_refinements);
   }
 

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -194,6 +194,8 @@ OversampleOutput::updateOversample()
         for (unsigned int var_num = 0; var_num < _mesh_functions[sys_num].size(); ++var_num)
           if ((*nd)->n_dofs(sys_num, var_num))
             dest_sys.solution->set((*nd)->dof_number(sys_num, var_num, 0), (*_mesh_functions[sys_num][var_num])(**nd - _position)); // 0 value is for component
+
+      dest_sys.solution->close();
     }
   }
 


### PR DESCRIPTION
This solves the correctness issues that were causing OversampleOutput to fail with DistributedMesh, which as a side benefit allows us to strip out a chunk of code and avoid an unnecessary solution serialization.

This fixes --distributed-mesh test failures with ics/function_ic.spline_function for me.

We're not done with #1500 yet but so far these bugs are turning out to be easier to fix than I'd feared.