### PR TITLE
retry auto-detect environment for (not) using color output

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -80,11 +80,6 @@ extern PerfLog setup_perf_log;
 extern bool _trap_fpe;
 
 /**
- * Variable indicating whether Console coloring will be turned on (default: true).
- */
-extern bool _color_console;
-
-/**
  * Variable to toggle any warning into an error (includes deprecated code warnings)
  */
 extern bool _warnings_are_errors;
@@ -103,15 +98,24 @@ extern bool _throw_on_error;
 /**
  * Macros for coloring any output stream (_console, std::ostringstream, etc.)
  */
-#define COLOR_BLACK   (Moose::_color_console ? XTERM_BLACK : "")
-#define COLOR_RED     (Moose::_color_console ? XTERM_RED : "")
-#define COLOR_GREEN   (Moose::_color_console ? XTERM_GREEN : "")
-#define COLOR_YELLOW  (Moose::_color_console ? XTERM_YELLOW : "")
-#define COLOR_BLUE    (Moose::_color_console ? XTERM_BLUE : "")
-#define COLOR_MAGENTA (Moose::_color_console ? XTERM_MAGENTA : "")
-#define COLOR_CYAN    (Moose::_color_console ? XTERM_CYAN : "")
-#define COLOR_WHITE   (Moose::_color_console ? XTERM_WHITE : "")
-#define COLOR_DEFAULT (Moose::_color_console ? XTERM_DEFAULT : "")
+#define COLOR_BLACK   (Moose::colorConsole() ? XTERM_BLACK : "")
+#define COLOR_RED     (Moose::colorConsole() ? XTERM_RED : "")
+#define COLOR_GREEN   (Moose::colorConsole() ? XTERM_GREEN : "")
+#define COLOR_YELLOW  (Moose::colorConsole() ? XTERM_YELLOW : "")
+#define COLOR_BLUE    (Moose::colorConsole() ? XTERM_BLUE : "")
+#define COLOR_MAGENTA (Moose::colorConsole() ? XTERM_MAGENTA : "")
+#define COLOR_CYAN    (Moose::colorConsole() ? XTERM_CYAN : "")
+#define COLOR_WHITE   (Moose::colorConsole() ? XTERM_WHITE : "")
+#define COLOR_DEFAULT (Moose::colorConsole() ? XTERM_DEFAULT : "")
+
+
+
+/// Returns whether Console coloring is turned on (default: true).
+bool colorConsole();
+
+/// Turns color escape sequences on/off for info written to stdout.
+/// Returns the the set value which may be different than use_color.
+bool setColorConsole(bool use_color, bool force = false);
 
 /**
  * Import libMesh::out, and libMesh::err for use in MOOSE.

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -269,6 +269,11 @@ namespace MooseUtils
   void indentMessage(const std::string & prefix, std::string & message, const char* color = COLOR_CYAN);
 
   /**
+   * remove ANSI escape sequences for teminal color from msg
+   */
+  std::string & removeColor(std::string & msg);
+
+  /**
    * Retrieves the names of all of the files contained within the list of directories passed into the routine.
    * The names returned will be the paths to the files relative to the current directory.
    * @param directory_list The list of directories to retrieve files from.

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -150,7 +150,7 @@ CommonOutputAction::act()
     create("ControlOutput");
 
   if (!getParam<bool>("color"))
-    Moose::_color_console = false;
+    Moose::setColorConsole(false);
 }
 
 void

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -452,6 +452,8 @@
 #include "TimeDerivativeNodalKernel.h"
 #include "UserForcingFunctionNodalKernel.h"
 
+#include <unistd.h>
+
 namespace Moose {
 
 static bool registered = false;
@@ -1192,7 +1194,20 @@ bool _trap_fpe = true;
 bool _trap_fpe = false;
 #endif
 
-bool _color_console = true;
+static bool _color_console = isatty(fileno(stdout));
+
+bool
+colorConsole()
+{
+  return _color_console;
+}
+
+bool
+setColorConsole(bool use_color, bool force)
+{
+  _color_console = (isatty(fileno(stdout)) || force) && use_color;
+  return _color_console;
+}
 
 bool _warnings_are_errors = false;
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -228,15 +228,20 @@ MooseApp::setupOptions()
   if (getParam<bool>("no_color"))
     Moose::setColorConsole(false);
 
-  std::string color = getParam<std::string>("color");
-  if (color == "auto")
-    Moose::setColorConsole(true);
-  else if (color == "on")
-    Moose::setColorConsole(true, true);
-  else if (color == "off")
-    Moose::setColorConsole(false, true);
-  else
-    mooseWarning("ignoring invalid --color arg (want 'auto', 'on', or 'off')");
+  if (isUltimateMaster()) // makes sure coloring isn't reset incorrectly in multi-app settings
+  {
+    std::string color = getParam<std::string>("color");
+    if (color == "auto")
+      // force true if parallel run - because MPI makes it seem like we aren't
+      // writing to interactive terminal, but we probably are indirectly.
+      Moose::setColorConsole(true, comm().size() > 1);
+    else if (color == "on")
+      Moose::setColorConsole(true, true);
+    else if (color == "off")
+      Moose::setColorConsole(false, true);
+    else
+      mooseWarning("ignoring invalid --color arg (want 'auto', 'on', or 'off')");
+  }
 
   // this warning goes below --color processing to honor that setting for
   // the warning. And below settings for warnings/error setup.

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -65,6 +65,7 @@ InputParameters validParams<MooseApp>()
   params.addCommandLineParam<bool>("show_controls", "--show-controls", false, "Shows the Control logic available and executed.");
 
   params.addCommandLineParam<bool>("no_color", "--no-color", false, "Disable coloring of all Console outputs.");
+  params.addCommandLineParam<std::string>("color", "--color [auto,on,off]", "auto", "Whether to use color in console output.");
 
   params.addCommandLineParam<bool>("help", "-h --help", false, "Displays CLI usage statement.");
   params.addCommandLineParam<bool>("minimal", "--minimal", false, "Ignore input file and build a minimal application with Transient executioner.");
@@ -224,7 +225,23 @@ MooseApp::setupOptions()
     Moose::_deprecated_is_error = false;
 
   // Toggle the color console off
-  Moose::_color_console = !getParam<bool>("no_color");
+  if (getParam<bool>("no_color"))
+    Moose::setColorConsole(false);
+
+  std::string color = getParam<std::string>("color");
+  if (color == "auto")
+    Moose::setColorConsole(true);
+  else if (color == "on")
+    Moose::setColorConsole(true, true);
+  else if (color == "off")
+    Moose::setColorConsole(false, true);
+  else
+    mooseWarning("ignoring invalid --color arg (want 'auto', 'on', or 'off')");
+
+  // this warning goes below --color processing to honor that setting for
+  // the warning. And below settings for warnings/error setup.
+  if (getParam<bool>("no_color"))
+    mooseDeprecated("The --no-color flag is deprecated. Use '--color off' instead.");
 
   // If there's no threading model active, but the user asked for
   // --n-threads > 1 on the command line, throw a mooseError2.  This is

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -240,13 +240,13 @@ MooseApp::setupOptions()
     else if (color == "off")
       Moose::setColorConsole(false, true);
     else
-      mooseWarning("ignoring invalid --color arg (want 'auto', 'on', or 'off')");
+      mooseWarning2("ignoring invalid --color arg (want 'auto', 'on', or 'off')");
   }
 
   // this warning goes below --color processing to honor that setting for
   // the warning. And below settings for warnings/error setup.
   if (getParam<bool>("no_color"))
-    mooseDeprecated("The --no-color flag is deprecated. Use '--color off' instead.");
+    mooseDeprecated2("The --no-color flag is deprecated. Use '--color off' instead.");
 
   // If there's no threading model active, but the user asked for
   // --n-threads > 1 on the command line, throw a mooseError2.  This is

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -358,8 +358,9 @@ Console::writeStreamToFile(bool append)
   else
     output.open(filename().c_str(), std::ios::trunc);
 
+  std::string s = _file_output_stream.str();
   // Write contents of file output stream and close the file
-  output << _file_output_stream.str();
+  output << MooseUtils::removeColor(s);
   output.close();
 
   // Clear the file output stream

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -179,14 +179,14 @@ Console::Console(const InputParameters & parameters) :
     _system_info_flags.push_back("output");
 
   // Set output coloring
-  if (Moose::_color_console)
+  if (Moose::colorConsole())
   {
     char * term_env = getenv("TERM");
     if (term_env)
     {
       std::string term(term_env);
       if (term != "xterm-256color" && term != "xterm")
-        Moose::_color_console = false;
+        Moose::setColorConsole(false);
     }
   }
 }

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -52,17 +52,6 @@ DOFMapOutput::DOFMapOutput(const InputParameters & parameters) :
     _system_name(getParam<std::string>("system_name")),
     _mesh(_problem_ptr->mesh())
 {
-  // Set output coloring
-  if (Moose::_color_console)
-  {
-    char * term_env = getenv("TERM");
-    if (term_env)
-    {
-      std::string term(term_env);
-      if (term != "xterm-256color" && term != "xterm")
-        Moose::_color_console = false;
-    }
-  }
 }
 
 std::string

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -372,6 +372,14 @@ MaterialPropertyStorageDump(const HashMap<const libMesh::Elem *, HashMap<unsigne
   }
 }
 
+std::string &
+removeColor(std::string & msg)
+{
+  pcrecpp::RE re("(\\33\\[3[0-7]m))", pcrecpp::DOTALL());
+  re.GlobalReplace(std::string(""), &msg);
+  return msg;
+}
+
 void
 indentMessage(const std::string & prefix, std::string & message, const char* color/*= COLOR_CYAN*/)
 {

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -117,7 +117,9 @@ class RunApp(Tester):
             specs['cli_args'].append('Outputs/print_perf_log=true')
 
         if options.colored == False:
-            specs['cli_args'].append('--no-color')
+            specs['cli_args'].append('--color off')
+        else:
+            specs['cli_args'].append('--color on')
 
         if options.cli_args:
             specs['cli_args'].insert(0, options.cli_args)

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -118,8 +118,6 @@ class RunApp(Tester):
 
         if options.colored == False:
             specs['cli_args'].append('--color off')
-        else:
-            specs['cli_args'].append('--color on')
 
         if options.cli_args:
             specs['cli_args'].insert(0, options.cli_args)


### PR DESCRIPTION
Small tweaks to #7825.  The objection/problem with the previous PR was no color was output in MPI runs.  This (mostly) fixes that.  The only case where you still wouldn't get color in MPI is if the number of processors is equal to one.  Feel free to merge or close as desired.