### PR TITLE
Libmesh update

### DIFF
--- a/modules/phase_field/src/auxkernels/EulerAngleProvider2RGBAux.C
+++ b/modules/phase_field/src/auxkernels/EulerAngleProvider2RGBAux.C
@@ -41,8 +41,8 @@ void
 EulerAngleProvider2RGBAux::precalculateValue()
 {
   // ID of unique grain at current point
-  const int grain_id = _grain_tracker.getEntityValue((isNodal() ? _current_node->id() : _current_elem->id()),
-                                                              FeatureFloodCount::FieldType::UNIQUE_REGION, 0);
+  const Real grain_id = _grain_tracker.getEntityValue((isNodal() ? _current_node->id() : _current_elem->id()),
+                                                      FeatureFloodCount::FieldType::UNIQUE_REGION, 0);
 
   // Recover Euler angles for current grain and assign correct
   // RGB value either from euler2RGB or from _no_grain_color


### PR DESCRIPTION
As requested by @permcody, this gives us a libmesh update independent of the other changes in #8472.  It updates to  libMesh/libmesh@cc49a536e6, the same version as in #8472, so it should not conflict.

Brief summary of changes included in this update:
* Add evaluable_nodes iterators.
* Fix several issues in CheckPointIO.
* Misc. Doxygen updates, fix issue with missing libmesh_final classes.
* int -> PetscBLASInt in BLAS/LAPACK routines.
* AdjointRefinement ghosted adjoint compatibility.
* Fixes for multisystem XDA reads.
* Fix gmsh numbering and node ordering for PRISM15.
* PointLocator fixes and updates for "truss-like" meshes.
* Add extra package search paths in trilinos.m4.
* inverse_map() fixes for infinite elements.
* Update AutoPtr unit test to test UniquePtr.
* Adjust tolerance in Edge3::volume().
* Update fix for errno.h inclusion in a namespace.
* Reorder paths starting with /lib to the end of the linking list.
* Fix misc. documentation typos and wording in geom, quadrature, partitioning.
* Use the -fno-limit-debug-info flag in dbg/devel mode for clang.
* Use the '-Wunused -Wunused-parameter' flags for clang in all modes.
* Avoid printing unprintable [unsigned] char Parameters.
* Only serialize the Mesh to processor 0 for Exodus.
* Add a barrier() to ~LibMeshInit to avoid missing potential error messages.
* Misc. DistributedMesh fixes.
* Fixes for MeshTools::n*levels().

Refs #000.
