### PR TITLE
Delete initial Multiapps after initial execution

### DIFF
--- a/framework/include/base/ExecuteMooseObjectWarehouse.h
+++ b/framework/include/base/ExecuteMooseObjectWarehouse.h
@@ -54,8 +54,10 @@ public:
    * Clears all of the objects in the warehouse for the given exec_flag. Since we are using
    * shared pointers to hold objects. The actual objects themselves will not be released
    * unless they are only being held by a single warehouse.
+   * The removed_objects_names argument can be passed in to catch the names of all of the
+   * deleted objects.
    */
-  void clear(ExecFlagType exec_flag);
+  void clear(ExecFlagType exec_flag, std::vector<std::string> * removed_object_names = nullptr);
 
   ///@{
   /**
@@ -227,7 +229,7 @@ ExecuteMooseObjectWarehouse<T>::addObject(std::shared_ptr<T> object, THREAD_ID t
 
 template<typename T>
 void
-ExecuteMooseObjectWarehouse<T>::clear(ExecFlagType exec_flag)
+ExecuteMooseObjectWarehouse<T>::clear(ExecFlagType exec_flag, std::vector<std::string> * removed_object_names)
 {
   const auto all_objects = MooseObjectWarehouse<T>::getObjects();
   const auto all_flags = Moose::vectorStringsToEnum<ExecFlagType>(SetupInterface::getExecuteOptions());
@@ -255,6 +257,10 @@ ExecuteMooseObjectWarehouse<T>::clear(ExecFlagType exec_flag)
 
     if (!multiple_execute_on)
     {
+      // Make sure we save the name _before_ we delete the object!
+      if (removed_object_names)
+        removed_object_names->push_back(object->getRestartPrefix());
+
       // Remove the object from the "all objects" warehouse
       MooseObjectWarehouse<T>::deleteObject(object);
 

--- a/framework/include/base/ExecuteMooseObjectWarehouse.h
+++ b/framework/include/base/ExecuteMooseObjectWarehouse.h
@@ -18,6 +18,7 @@
 // MOOSE includes
 #include "MooseObjectWarehouse.h"
 #include "SetupInterface.h"
+#include "Conversion.h"
 
 /**
  * A class for storing MooseObjects based on execution flag.
@@ -48,6 +49,13 @@ public:
    * @param object A shared pointer to the object being added
    */
   virtual void addObject(std::shared_ptr<T> object, THREAD_ID tid = 0);
+
+  /**
+   * Clears all of the objects in the warehouse for the given exec_flag. Since we are using
+   * shared pointers to hold objects. The actual objects themselves will not be released
+   * unless they are only being held by a single warehouse.
+   */
+  void clear(ExecFlagType exec_flag);
 
   ///@{
   /**
@@ -215,6 +223,45 @@ ExecuteMooseObjectWarehouse<T>::addObject(std::shared_ptr<T> object, THREAD_ID t
   }
   else
     mooseError2("The object being added (", object->name(), ") must inherit from SetupInterface to be added to the ExecuteMooseObjectWarehouse container.");
+}
+
+template<typename T>
+void
+ExecuteMooseObjectWarehouse<T>::clear(ExecFlagType exec_flag)
+{
+  const auto all_objects = MooseObjectWarehouse<T>::getObjects();
+  const auto all_flags = Moose::vectorStringsToEnum<ExecFlagType>(SetupInterface::getExecuteOptions());
+
+  for (const auto & object : all_objects)
+  {
+    const auto & name = object->name();
+    bool multiple_execute_on = false;
+
+    // We want to see if this object is any of the other execute warehouses.
+    // If it isn't, we'll remove it from all_objects as well so that the
+    // shared pointer reference count goes to zero and the object is destroyed
+    for (const auto & flag : all_flags)
+    {
+      // We ignore the matching case since we are only focused on objects in multiple warehouses
+      if (flag == exec_flag)
+        continue;
+
+      if (_execute_objects[flag].hasObject(name))
+      {
+        multiple_execute_on = true;
+        break;
+      }
+    }
+
+    if (!multiple_execute_on)
+    {
+      // Remove the object from the "all objects" warehouse
+      MooseObjectWarehouse<T>::deleteObject(object);
+
+      // Remove the object from this execute warehouse
+      _execute_objects[exec_flag].deleteObject(object);
+    }
+  }
 }
 
 template<typename T>

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -388,6 +388,8 @@ public:
    */
   virtual void registerRestartableData(std::string name, RestartableDataValue * data, THREAD_ID tid);
 
+  void deleteRestartableData(const std::vector<std::string> & names);
+
   /**
    * Return reference to the restatable data object
    * @return A const reference to the restatable data object

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -676,6 +676,14 @@ void FEProblemBase::initialSetup()
     for (THREAD_ID tid = 0; tid < n_threads; ++tid)
         _assembly[tid]->initNonlocalCoupling();
   }
+
+  // Remove some of the heavier objects that are only needed during initial
+  // Several other types of objects may be added here in the future.
+  _multi_apps.clear(EXEC_INITIAL);
+  _transient_multi_apps.clear(EXEC_INITIAL);
+  _transfers.clear(EXEC_INITIAL);
+  _to_multi_app_transfers.clear(EXEC_INITIAL);
+  _from_multi_app_transfers.clear(EXEC_INITIAL);
 }
 
 void FEProblemBase::timestepSetup()

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -102,7 +102,7 @@ InputParameters validParams<FEProblemBase>()
 
 FEProblemBase::FEProblemBase(const InputParameters & parameters) :
     SubProblem(parameters),
-    Restartable(parameters, "FEProblemBase", this),
+    Restartable(parameters.get<std::string>("_object_name"), "FEProblemBase", *this),
     _mesh(*parameters.get<MooseMesh *>("mesh")),
     _eq(_mesh),
     _initialized(false),
@@ -677,13 +677,25 @@ void FEProblemBase::initialSetup()
         _assembly[tid]->initNonlocalCoupling();
   }
 
-  // Remove some of the heavier objects that are only needed during initial
-  // Several other types of objects may be added here in the future.
-  _multi_apps.clear(EXEC_INITIAL);
-  _transient_multi_apps.clear(EXEC_INITIAL);
-  _transfers.clear(EXEC_INITIAL);
-  _to_multi_app_transfers.clear(EXEC_INITIAL);
-  _from_multi_app_transfers.clear(EXEC_INITIAL);
+//  // Remove some of the heavier objects that are only needed during initial
+//  // Several other types of objects may be added here in the future.
+//  std::vector<std::string> removed_object_names;
+//
+//  _multi_apps.clear(EXEC_INITIAL, &removed_object_names);
+//  _transient_multi_apps.clear(EXEC_INITIAL, &removed_object_names);
+//
+//  /**
+//   * In the case of multiapps, the multiapp itself registers the SubAppsBackup object
+//   * with _this_ app. That doesn't get cleaned up when we delete the MultiApp.
+//   * We still need to find and delete that backup.
+//   */
+//  for (auto & removed_object_name : removed_object_names)
+//    removed_object_name += "backups";
+//  _app.deleteRestartableData(removed_object_names);
+//
+//  _transfers.clear(EXEC_INITIAL);
+//  _to_multi_app_transfers.clear(EXEC_INITIAL);
+//  _from_multi_app_transfers.clear(EXEC_INITIAL);
 }
 
 void FEProblemBase::timestepSetup()

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -689,6 +689,20 @@ MooseApp::registerRestartableData(std::string name, RestartableDataValue * data,
 }
 
 void
+MooseApp::deleteRestartableData(const std::vector<std::string> & names)
+{
+  for (const auto & name : names)
+  {
+    for (auto & restartable_map : _restartable_data)
+    {
+      auto it = restartable_map.find(name);
+      if (it != restartable_map.end())
+        restartable_map.erase(it);
+    }
+  }
+}
+
+void
 MooseApp::dynamicAppRegistration(const std::string & app_name, std::string library_path)
 {
   Parameters params;

--- a/framework/src/base/SubProblem.C
+++ b/framework/src/base/SubProblem.C
@@ -357,11 +357,11 @@ SubProblem::getAxisymmetricRadialCoord()
 void
 SubProblem::registerRestartableData(std::string name, RestartableDataValue * data, THREAD_ID tid)
 {
-  _app.registerRestartableData(this->name() + "/" + name, data, tid);
+  _app.registerRestartableData(name, data, tid);
 }
 
 void
 SubProblem::registerRecoverableData(std::string name)
 {
-  _app.registerRecoverableData(this->name() + "/" + name);
+  _app.registerRecoverableData(name);
 }

--- a/test/include/multiapps/EarlyDeleteMultiApp.h
+++ b/test/include/multiapps/EarlyDeleteMultiApp.h
@@ -1,0 +1,44 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef EARLYDELETEMULTIAPP_H
+#define EARLYDELETEMULTIAPP_H
+
+#include "MultiApp.h"
+
+// Forward declarations
+class EarlyDeleteMultiApp;
+class Executioner;
+
+template<>
+InputParameters validParams<EarlyDeleteMultiApp>();
+
+/**
+ * This Multiapp simply prints to the console when it's deleted.
+ */
+class EarlyDeleteMultiApp :
+  public MultiApp
+{
+public:
+  EarlyDeleteMultiApp(const InputParameters & parameters);
+
+  virtual ~EarlyDeleteMultiApp() { _console << "******* Early delete multiapp \"" << name() << "\" deleted! *******" << std::endl; }
+
+  // Dummy overrides
+  virtual bool solveStep(Real /*dt*/, Real /*target_time*/, bool /*auto_advance=true*/) override { return true; }
+  virtual void advanceStep() override {}
+
+};
+
+#endif // EARLYDELETEMULTIAPP_H

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -269,6 +269,9 @@
 // Indicators
 #include "MaterialTestIndicator.h"
 
+// MultiApps
+#include "EarlyDeleteMultiApp.h"
+
 template<>
 InputParameters validParams<MooseTestApp>()
 {
@@ -552,6 +555,9 @@ MooseTestApp::registerObjects(Factory & factory)
 
   // Indicators
   registerIndicator(MaterialTestIndicator);
+
+  // MultiApps
+  registerMultiApp(EarlyDeleteMultiApp);
 }
 
 // External entry point for dynamic syntax association

--- a/test/src/multiapps/EarlyDeleteMultiApp.C
+++ b/test/src/multiapps/EarlyDeleteMultiApp.C
@@ -1,0 +1,27 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "EarlyDeleteMultiApp.h"
+
+template<>
+InputParameters validParams<EarlyDeleteMultiApp>()
+{
+  InputParameters params = validParams<MultiApp>();
+  return params;
+}
+
+EarlyDeleteMultiApp::EarlyDeleteMultiApp(const InputParameters & parameters):
+    MultiApp(parameters)
+{
+}

--- a/test/tests/multiapps/early_delete_multiapp/early_delete_master.i
+++ b/test/tests/multiapps/early_delete_multiapp/early_delete_master.i
@@ -1,0 +1,64 @@
+# This test is here to verify that we can delete a Multiapp
+# Early after initialSetup. In order for a multiapp to be
+# deleted early it must be set to execute_on = initial ONLY.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 1
+  num_steps = 3
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[MultiApps]
+  [./early_delete]
+    type = EarlyDeleteMultiApp
+
+    # Must be initial ONLY!
+    execute_on = initial
+    positions = '0 0 0'
+    input_files = sub.i
+  [../]
+[]

--- a/test/tests/multiapps/early_delete_multiapp/sub.i
+++ b/test/tests/multiapps/early_delete_multiapp/sub.i
@@ -1,0 +1,53 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./td]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+  dt = 0.01
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/multiapps/early_delete_multiapp/tests
+++ b/test/tests/multiapps/early_delete_multiapp/tests
@@ -1,0 +1,38 @@
+[Tests]
+  [./test_early_delete]
+    type = 'RunApp'
+    input = 'early_delete_master.i'
+
+    # This RE looks for the message from the destructor of the EarlyDeleteMultiApp
+    # to appear before the master app's first time step indicator. To make
+    # sure we are matching the master app's output we anchor the "Time Step"
+    # expression to the left-hand border.
+    #
+    # ******* Early delete multiapp "full_solve" deleted! *******
+    # early_delete0:
+    #
+    # Time Step  0, time = 0
+    #
+    expect_out = 'Early delete multiapp \S+ deleted.*^Time Step\s+0, time = 0'
+    recover = false
+  [../]
+
+  [./test_no_early_delete]
+    type = 'RunApp'
+    input = 'early_delete_master.i'
+    cli_args = 'MultiApps/early_delete/execute_on="initial timestep_begin"'
+
+    # This RE looks for the message from the destructor of the EarlyDeleteMultiApp
+    # to appear before the master app's first time step indicator. To make
+    # sure we are matching the master app's output we anchor the "Time Step"
+    # expression to the left-hand border.
+    #
+    # ******* Early delete multiapp "full_solve" deleted! *******
+    # early_delete0:
+    #
+    # Time Step  0, time = 0
+    #
+    absent_out = 'Early delete multiapp \S+ deleted.*^Time Step\s+0, time = 0'
+    recover = false
+  [../]
+[]


### PR DESCRIPTION
We now delete multiapps and transfers that are only needed for initial execute. This case arises with `FullSolveMultiApp` in Rattlesnake quite often. This capability is being added to reduce memory overhead. 