### PR TITLE
MooseSharedPointer -> std::shared_ptr in framework

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -126,14 +126,14 @@ protected:
   /// The current action (even though we have seperate instances for each action)
   const std::string & _current_task;
 
-  MooseSharedPointer<MooseMesh> & _mesh;
-  MooseSharedPointer<MooseMesh> & _displaced_mesh;
+  std::shared_ptr<MooseMesh> & _mesh;
+  std::shared_ptr<MooseMesh> & _displaced_mesh;
 
   /// Convenience reference to a problem this action works on
-  MooseSharedPointer<FEProblemBase> & _problem;
+  std::shared_ptr<FEProblemBase> & _problem;
 
   /// Convenience reference to an executioner
-  MooseSharedPointer<Executioner> & _executioner;
+  std::shared_ptr<Executioner> & _executioner;
 
 };
 

--- a/framework/include/actions/ActionFactory.h
+++ b/framework/include/actions/ActionFactory.h
@@ -41,7 +41,7 @@ class MooseApp;
 /**
  * Typedef for function to build objects
  */
-typedef MooseSharedPointer<Action> (*buildActionPtr)(InputParameters parameters);
+typedef std::shared_ptr<Action> (*buildActionPtr)(InputParameters parameters);
 
 
 /**
@@ -54,9 +54,9 @@ typedef InputParameters (*paramsActionPtr)();
  * Build an object of type T
  */
 template<class T>
-MooseSharedPointer<Action> buildAction(InputParameters parameters)
+std::shared_ptr<Action> buildAction(InputParameters parameters)
 {
-  return MooseSharedPointer<Action>(new T(parameters));
+  return std::shared_ptr<Action>(new T(parameters));
 }
 
 /**
@@ -83,7 +83,7 @@ public:
 
   std::string getTaskName(const std::string & action);
 
-  MooseSharedPointer<Action> create(const std::string & action, const std::string & action_name, InputParameters parameters);
+  std::shared_ptr<Action> create(const std::string & action, const std::string & action_name, InputParameters parameters);
 
   InputParameters getValidParams(const std::string & name);
 

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -63,7 +63,7 @@ public:
   /**
    * This method add an \p Action instance to the warehouse.
    */
-  void addActionBlock(MooseSharedPointer<Action> blk);
+  void addActionBlock(std::shared_ptr<Action> blk);
 
   /**
    * This method checks the actions stored in the warehouse against the list of required registered
@@ -180,12 +180,12 @@ public:
   // shared pointers here, just their memory management capability.
   // Therefore, _mesh is actually being used more like a unique_ptr in
   // this context.  Since full support for unique_ptr is not quite
-  // available yet, we've implemented it as a MooseSharedPointer.
-  MooseSharedPointer<MooseMesh> & mesh() { return _mesh; }
-  MooseSharedPointer<MooseMesh> & displacedMesh() { return _displaced_mesh; }
+  // available yet, we've implemented it as a std::shared_ptr.
+  std::shared_ptr<MooseMesh> & mesh() { return _mesh; }
+  std::shared_ptr<MooseMesh> & displacedMesh() { return _displaced_mesh; }
 
-  MooseSharedPointer<FEProblemBase> & problemBase() { return _problem; }
-  MooseSharedPointer<FEProblem>  problem();
+  std::shared_ptr<FEProblemBase> & problemBase() { return _problem; }
+  std::shared_ptr<FEProblem>  problem();
   MooseApp & mooseApp() { return _app; }
   const std::string & getCurrentTaskName() const { return _current_task; }
 
@@ -199,7 +199,7 @@ protected:
    */
   void buildBuildableActions(const std::string &task);
 
-  std::vector<MooseSharedPointer<Action> > _all_ptrs;
+  std::vector<std::shared_ptr<Action> > _all_ptrs;
 
   /// The MooseApp this Warehouse is associated with
   MooseApp & _app;
@@ -236,13 +236,13 @@ protected:
   //
 
   /// Mesh class
-  MooseSharedPointer<MooseMesh> _mesh;
+  std::shared_ptr<MooseMesh> _mesh;
 
   /// Possible mesh for displaced problem
-  MooseSharedPointer<MooseMesh> _displaced_mesh;
+  std::shared_ptr<MooseMesh> _displaced_mesh;
 
   /// Problem class
-  MooseSharedPointer<FEProblemBase> _problem;
+  std::shared_ptr<FEProblemBase> _problem;
 };
 
 #endif // ACTIONWAREHOUSE_H

--- a/framework/include/actions/MaterialOutputAction.h
+++ b/framework/include/actions/MaterialOutputAction.h
@@ -69,7 +69,7 @@ private:
    * act() method.
    */
   template<typename T>
-  void materialOutputHelper(const std::string & property_name, MooseSharedPointer<Material> material);
+  void materialOutputHelper(const std::string & property_name, std::shared_ptr<Material> material);
 
   /**
    * A method for creating an AuxVariable and associated action
@@ -78,14 +78,14 @@ private:
    * @param variable_name The AuxVariable name to create
    * @param material A pointer to the Material object containing the property of interest
    */
-  MooseSharedPointer<MooseObjectAction> createAction(const std::string & type, const std::string & property_name,
-                                                     const std::string & variable_name, MooseSharedPointer<Material> material);
+  std::shared_ptr<MooseObjectAction> createAction(const std::string & type, const std::string & property_name,
+                                                     const std::string & variable_name, std::shared_ptr<Material> material);
 
   /// Pointer the MaterialData object storing the block restricted materials
-  MooseSharedPointer<MaterialData> _block_material_data;
+  std::shared_ptr<MaterialData> _block_material_data;
 
   /// Pointer the MaterialData object storing the boundary restricted materials
-  MooseSharedPointer<MaterialData> _boundary_material_data;
+  std::shared_ptr<MaterialData> _boundary_material_data;
 
   /// Map of variable name that contains the blocks to which the variable should be restricted
   std::map<std::string, std::set<SubdomainID> > _block_variable_map;
@@ -106,7 +106,7 @@ private:
 
 template<typename T>
 void
-MaterialOutputAction::materialOutputHelper(const std::string & /*property_name*/, MooseSharedPointer<Material> /*material*/)
+MaterialOutputAction::materialOutputHelper(const std::string & /*property_name*/, std::shared_ptr<Material> /*material*/)
 {
   mooseError("Unknown type, you must create a specialization of materialOutputHelper");
 }

--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -233,7 +233,7 @@ protected:
   /// Error vector for use with the error estimator.
   std::unique_ptr<ErrorVector> _error;
 
-  MooseSharedPointer<DisplacedProblem> _displaced_problem;
+  std::shared_ptr<DisplacedProblem> _displaced_problem;
 
   /// A mesh refinement object for displaced mesh
   std::unique_ptr<MeshRefinement> _displaced_mesh_refinement;

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -515,7 +515,7 @@ public:
   /**
    * Set the pointer to the XFEM controller object
    */
-  void setXFEM(MooseSharedPointer<XFEMInterface> xfem) { _xfem = xfem; }
+  void setXFEM(std::shared_ptr<XFEMInterface> xfem) { _xfem = xfem; }
 
 protected:
   /**
@@ -594,7 +594,7 @@ protected:
   unsigned int _mesh_dimension;
 
   /// The XFEM controller
-  MooseSharedPointer<XFEMInterface> _xfem;
+  std::shared_ptr<XFEMInterface> _xfem;
 
   /// The "volume" fe object that matches the current elem
   std::map<FEType, FEBase *> _current_fe;

--- a/framework/include/base/AuxGroupExecuteMooseObjectWarehouse.h
+++ b/framework/include/base/AuxGroupExecuteMooseObjectWarehouse.h
@@ -95,7 +95,7 @@ AuxGroupExecuteMooseObjectWarehouse<T>::updateDependObjects(const std::set<std::
 {
   checkThreadID(tid);
 
-  for (typename std::vector<MooseSharedPointer<T> >::const_iterator it = _all_objects[tid].begin(); it != _all_objects[tid].end(); ++it)
+  for (typename std::vector<std::shared_ptr<T> >::const_iterator it = _all_objects[tid].begin(); it != _all_objects[tid].end(); ++it)
   {
     if (depend_uo.find((*it)->name()) != depend_uo.end())
       _group_objects[Moose::PRE_AUX].addObject(*it, tid);

--- a/framework/include/base/AuxGroupExecuteMooseObjectWarehouse.h
+++ b/framework/include/base/AuxGroupExecuteMooseObjectWarehouse.h
@@ -95,12 +95,12 @@ AuxGroupExecuteMooseObjectWarehouse<T>::updateDependObjects(const std::set<std::
 {
   checkThreadID(tid);
 
-  for (typename std::vector<std::shared_ptr<T> >::const_iterator it = _all_objects[tid].begin(); it != _all_objects[tid].end(); ++it)
+  for (const auto & object_ptr: _all_objects[tid])
   {
-    if (depend_uo.find((*it)->name()) != depend_uo.end())
-      _group_objects[Moose::PRE_AUX].addObject(*it, tid);
+    if (depend_uo.find(object_ptr->name()) != depend_uo.end())
+      _group_objects[Moose::PRE_AUX].addObject(object_ptr, tid);
     else
-      _group_objects[Moose::POST_AUX].addObject(*it, tid);
+      _group_objects[Moose::POST_AUX].addObject(object_ptr, tid);
   }
 }
 

--- a/framework/include/base/AuxiliarySystem.h
+++ b/framework/include/base/AuxiliarySystem.h
@@ -156,7 +156,7 @@ protected:
   /// Serialized version of the solution vector
   NumericVector<Number> & _serialized_solution;
   /// Time integrator
-  MooseSharedPointer<TimeIntegrator> _time_integrator;
+  std::shared_ptr<TimeIntegrator> _time_integrator;
   /// solution vector for u^dot
   NumericVector<Number> & _u_dot;
 

--- a/framework/include/base/BlockRestrictable.h
+++ b/framework/include/base/BlockRestrictable.h
@@ -187,7 +187,7 @@ public:
 protected:
 
   /// Pointer to the MaterialData class for this object
-  MooseSharedPointer<MaterialData> _blk_material_data;
+  std::shared_ptr<MaterialData> _blk_material_data;
 
   /**
    * A helper method to allow the Material object to specialize the behavior

--- a/framework/include/base/BoundaryRestrictable.h
+++ b/framework/include/base/BoundaryRestrictable.h
@@ -200,7 +200,7 @@ private:
   THREAD_ID _bnd_tid;
 
   /// Pointer to MaterialData for boundary (@see hasBoundaryMaterialProperty)
-  MooseSharedPointer<MaterialData> _bnd_material_data;
+  std::shared_ptr<MaterialData> _bnd_material_data;
 
   /// Whether or not this object is restricted to nodesets
   bool _bnd_nodal;

--- a/framework/include/base/ComputeMaterialsObjectThread.h
+++ b/framework/include/base/ComputeMaterialsObjectThread.h
@@ -31,9 +31,9 @@ class ComputeMaterialsObjectThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
   ComputeMaterialsObjectThread(FEProblemBase & fe_problem,
-                               std::vector<std::shared_ptr<MaterialData> > & material_data,
-                               std::vector<std::shared_ptr<MaterialData> > & bnd_material_data,
-                               std::vector<std::shared_ptr<MaterialData> > & neighbor_material_data,
+                               std::vector<std::shared_ptr<MaterialData>> & material_data,
+                               std::vector<std::shared_ptr<MaterialData>> & bnd_material_data,
+                               std::vector<std::shared_ptr<MaterialData>> & neighbor_material_data,
                                MaterialPropertyStorage & material_props,
                                MaterialPropertyStorage & bnd_material_props,
                                std::vector<Assembly *> & assembly);
@@ -54,9 +54,9 @@ public:
 protected:
   FEProblemBase & _fe_problem;
   NonlinearSystemBase & _nl;
-  std::vector<std::shared_ptr<MaterialData> > & _material_data;
-  std::vector<std::shared_ptr<MaterialData> > & _bnd_material_data;
-  std::vector<std::shared_ptr<MaterialData> > & _neighbor_material_data;
+  std::vector<std::shared_ptr<MaterialData>> & _material_data;
+  std::vector<std::shared_ptr<MaterialData>> & _bnd_material_data;
+  std::vector<std::shared_ptr<MaterialData>> & _neighbor_material_data;
   MaterialPropertyStorage & _material_props;
   MaterialPropertyStorage & _bnd_material_props;
 

--- a/framework/include/base/ComputeMaterialsObjectThread.h
+++ b/framework/include/base/ComputeMaterialsObjectThread.h
@@ -31,9 +31,9 @@ class ComputeMaterialsObjectThread : public ThreadedElementLoop<ConstElemRange>
 {
 public:
   ComputeMaterialsObjectThread(FEProblemBase & fe_problem,
-                               std::vector<MooseSharedPointer<MaterialData> > & material_data,
-                               std::vector<MooseSharedPointer<MaterialData> > & bnd_material_data,
-                               std::vector<MooseSharedPointer<MaterialData> > & neighbor_material_data,
+                               std::vector<std::shared_ptr<MaterialData> > & material_data,
+                               std::vector<std::shared_ptr<MaterialData> > & bnd_material_data,
+                               std::vector<std::shared_ptr<MaterialData> > & neighbor_material_data,
                                MaterialPropertyStorage & material_props,
                                MaterialPropertyStorage & bnd_material_props,
                                std::vector<Assembly *> & assembly);
@@ -54,9 +54,9 @@ public:
 protected:
   FEProblemBase & _fe_problem;
   NonlinearSystemBase & _nl;
-  std::vector<MooseSharedPointer<MaterialData> > & _material_data;
-  std::vector<MooseSharedPointer<MaterialData> > & _bnd_material_data;
-  std::vector<MooseSharedPointer<MaterialData> > & _neighbor_material_data;
+  std::vector<std::shared_ptr<MaterialData> > & _material_data;
+  std::vector<std::shared_ptr<MaterialData> > & _bnd_material_data;
+  std::vector<std::shared_ptr<MaterialData> > & _neighbor_material_data;
   MaterialPropertyStorage & _material_props;
   MaterialPropertyStorage & _bnd_material_props;
 

--- a/framework/include/base/ExecuteMooseObjectWarehouse.h
+++ b/framework/include/base/ExecuteMooseObjectWarehouse.h
@@ -50,7 +50,7 @@ public:
    * Adds an object to the storage structure.
    * @param object A shared pointer to the object being added
    */
-  virtual void addObject(MooseSharedPointer<T> object, THREAD_ID tid = 0);
+  virtual void addObject(std::shared_ptr<T> object, THREAD_ID tid = 0);
 
   ///@{
   /**
@@ -215,13 +215,13 @@ ExecuteMooseObjectWarehouse<T>::setup(ExecFlagType exec_flag, THREAD_ID tid/* = 
 
 template<typename T>
 void
-ExecuteMooseObjectWarehouse<T>::addObject(MooseSharedPointer<T> object, THREAD_ID tid/*=0*/)
+ExecuteMooseObjectWarehouse<T>::addObject(std::shared_ptr<T> object, THREAD_ID tid/*=0*/)
 {
   // Update list of all objects
   MooseObjectWarehouse<T>::addObject(object, tid);
 
   // Update the execute flag lists of objects
-  MooseSharedPointer<SetupInterface> ptr = MooseSharedNamespace::dynamic_pointer_cast<SetupInterface>(object);
+  std::shared_ptr<SetupInterface> ptr = MooseSharedNamespace::dynamic_pointer_cast<SetupInterface>(object);
   if (ptr)
   {
     const std::vector<ExecFlagType> flags = ptr->execFlags();

--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -546,7 +546,7 @@ public:
   const T & getUserObject(const std::string & name, unsigned int tid = 0)
   {
     if (_all_user_objects.hasActiveObject(name, tid))
-      return *(MooseSharedNamespace::dynamic_pointer_cast<T>(_all_user_objects.getActiveObject(name, tid)));
+      return *(std::dynamic_pointer_cast<T>(_all_user_objects.getActiveObject(name, tid)));
 
 
     mooseError("Unable to find user object with name '" + name + "'");
@@ -1333,9 +1333,9 @@ FEProblemBase::initializeUserObjects(const MooseObjectWarehouse<T> & warehouse)
   {
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
     {
-      const std::vector<std::shared_ptr<T> > & objects = warehouse.getActiveObjects(tid);
-      for (typename std::vector<std::shared_ptr<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
-        (*it)->initialize();
+      const auto & objects = warehouse.getActiveObjects(tid);
+      for (const auto & object : objects)
+        object->initialize();
     }
   }
 }
@@ -1363,7 +1363,7 @@ FEProblemBase::finalizeUserObjects(const MooseObjectWarehouse<T> & warehouse)
     {
       object->finalize();
 
-      auto pp = MooseSharedNamespace::dynamic_pointer_cast<Postprocessor>(object);
+      auto pp = std::dynamic_pointer_cast<Postprocessor>(object);
 
       if (pp)
         _pps_data.storeValue(pp->PPName(), pp->getValue());

--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -662,7 +662,7 @@ public:
   /**
    * Get a MultiApp object by name.
    */
-  MooseSharedPointer<MultiApp> getMultiApp(const std::string & multi_app_name);
+  std::shared_ptr<MultiApp> getMultiApp(const std::string & multi_app_name);
 
   /**
    * Execute the MultiApps associated with the ExecFlagType
@@ -820,8 +820,8 @@ public:
   virtual void prepareNeighborShapes(unsigned int var, THREAD_ID tid) override;
 
   // Displaced problem /////
-  virtual void addDisplacedProblem(MooseSharedPointer<DisplacedProblem> displaced_problem);
-  virtual MooseSharedPointer<DisplacedProblem> getDisplacedProblem() { return _displaced_problem; }
+  virtual void addDisplacedProblem(std::shared_ptr<DisplacedProblem> displaced_problem);
+  virtual std::shared_ptr<DisplacedProblem> getDisplacedProblem() { return _displaced_problem; }
 
   virtual void updateGeomSearch(GeometricSearchData::GeometricSearchType type = GeometricSearchData::ALL) override;
 
@@ -875,10 +875,10 @@ public:
 #endif //LIBMESH_ENABLE_AMR
 
   /// Create XFEM controller object
-  void initXFEM(MooseSharedPointer<XFEMInterface> xfem);
+  void initXFEM(std::shared_ptr<XFEMInterface> xfem);
 
   /// Get a pointer to the XFEM controller object
-  MooseSharedPointer<XFEMInterface> getXFEM(){return _xfem;}
+  std::shared_ptr<XFEMInterface> getXFEM(){return _xfem;}
 
   /// Find out whether the current analysis is using XFEM
   bool haveXFEM() { return _xfem != NULL; }
@@ -985,12 +985,12 @@ public:
    *
    * This will return enabled or disabled objects, the main purpose is for iterative materials.
    */
-  MooseSharedPointer<Material> getMaterial(std::string name, Moose::MaterialDataType type, THREAD_ID tid = 0);
+  std::shared_ptr<Material> getMaterial(std::string name, Moose::MaterialDataType type, THREAD_ID tid = 0);
 
   /*
    * Return a pointer to the MaterialData
    */
-  MooseSharedPointer<MaterialData> getMaterialData(Moose::MaterialDataType type, THREAD_ID tid = 0);
+  std::shared_ptr<MaterialData> getMaterialData(Moose::MaterialDataType type, THREAD_ID tid = 0);
 
   /**
    * Will return True if the user wants to get an error when
@@ -1199,7 +1199,7 @@ protected:
    *
    * @see checkProblemIntegrity
    */
-  void checkDependMaterialsHelper(const std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > > & materials_map);
+  void checkDependMaterialsHelper(const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & materials_map);
 
   /// Verify that there are no element type/coordinate type conflicts
   void checkCoordinateSystems();
@@ -1215,11 +1215,11 @@ protected:
 #endif
 
   /// Pointer to XFEM controller
-  MooseSharedPointer<XFEMInterface> _xfem;
+  std::shared_ptr<XFEMInterface> _xfem;
 
   // Displaced mesh /////
   MooseMesh * _displaced_mesh;
-  MooseSharedPointer<DisplacedProblem> _displaced_problem;
+  std::shared_ptr<DisplacedProblem> _displaced_problem;
   GeometricSearchData _geometric_search_data;
 
   bool _reinit_displaced_elem;
@@ -1333,8 +1333,8 @@ FEProblemBase::initializeUserObjects(const MooseObjectWarehouse<T> & warehouse)
   {
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
     {
-      const std::vector<MooseSharedPointer<T> > & objects = warehouse.getActiveObjects(tid);
-      for (typename std::vector<MooseSharedPointer<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+      const std::vector<std::shared_ptr<T> > & objects = warehouse.getActiveObjects(tid);
+      for (typename std::vector<std::shared_ptr<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
         (*it)->initialize();
     }
   }

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -104,7 +104,7 @@
 /**
  * Typedef to wrap shared pointer type
  */
-typedef MooseSharedPointer<MooseObject> MooseObjectPtr;
+typedef std::shared_ptr<MooseObject> MooseObjectPtr;
 
 /**
  * Typedef for function to build objects
@@ -215,7 +215,7 @@ public:
    * @param print_deprecated controls the deprecated message
    * @return The created object
    */
-  MooseSharedPointer<MooseObject> create(const std::string & obj_name, const std::string & name, InputParameters parameters,
+  std::shared_ptr<MooseObject> create(const std::string & obj_name, const std::string & name, InputParameters parameters,
                                          THREAD_ID tid = 0, bool print_deprecated = true);
 
   /**
@@ -227,10 +227,10 @@ public:
    * @return The created object
    */
   template<typename T>
-  MooseSharedPointer<T>
+  std::shared_ptr<T>
   create(const std::string & obj_name, const std::string & name, InputParameters parameters, THREAD_ID tid = 0)
   {
-    MooseSharedPointer<T> new_object = MooseSharedNamespace::dynamic_pointer_cast<T>(create(obj_name, name, parameters, tid, false));
+    std::shared_ptr<T> new_object = MooseSharedNamespace::dynamic_pointer_cast<T>(create(obj_name, name, parameters, tid, false));
     if (!new_object)
       mooseError("We expected to create an object of type '" + demangle(typeid(T).name())
                  + "'.\nInstead we received a parameters object for type '" + obj_name

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -102,25 +102,24 @@
 #define registerNamedPartitioner(obj, name)         registerNamedObject(obj, name)
 
 /**
- * Typedef to wrap shared pointer type
+ * alias to wrap shared pointer type
  */
-typedef std::shared_ptr<MooseObject> MooseObjectPtr;
+using MooseObjectPtr = std::shared_ptr<MooseObject>;
 
 /**
- * Typedef for function to build objects
+ * alias for validParams function
  */
-typedef MooseObjectPtr (*buildPtr)(const InputParameters & parameters);
-typedef MooseObjectPtr (*buildLegacyPtr)(const std::string & name, InputParameters parameters);
+using paramsPtr = InputParameters (*)();
 
 /**
- * Typedef for validParams
+ * alias for method to build objects
  */
-typedef InputParameters (*paramsPtr)();
+using buildPtr = MooseObjectPtr (*)(const InputParameters & parameters);
 
 /**
- * Typedef for registered Object iterator
+ * alias for registered Object iterator
  */
-typedef std::map<std::string, paramsPtr>::iterator registeredMooseObjectIterator;
+using registeredMooseObjectIterator = std::map<std::string, paramsPtr>::iterator;
 
 /**
  * Build an object of type T
@@ -216,7 +215,7 @@ public:
    * @return The created object
    */
   std::shared_ptr<MooseObject> create(const std::string & obj_name, const std::string & name, InputParameters parameters,
-                                         THREAD_ID tid = 0, bool print_deprecated = true);
+                                      THREAD_ID tid = 0, bool print_deprecated = true);
 
   /**
    * Build an object (must be registered)
@@ -230,7 +229,7 @@ public:
   std::shared_ptr<T>
   create(const std::string & obj_name, const std::string & name, InputParameters parameters, THREAD_ID tid = 0)
   {
-    std::shared_ptr<T> new_object = MooseSharedNamespace::dynamic_pointer_cast<T>(create(obj_name, name, parameters, tid, false));
+    std::shared_ptr<T> new_object = std::dynamic_pointer_cast<T>(create(obj_name, name, parameters, tid, false));
     if (!new_object)
       mooseError("We expected to create an object of type '" + demangle(typeid(T).name())
                  + "'.\nInstead we received a parameters object for type '" + obj_name

--- a/framework/include/base/FlagElementsThread.h
+++ b/framework/include/base/FlagElementsThread.h
@@ -38,7 +38,7 @@ public:
 
 protected:
   FEProblemBase & _fe_problem;
-  MooseSharedPointer<DisplacedProblem> _displaced_problem;
+  std::shared_ptr<DisplacedProblem> _displaced_problem;
   AuxiliarySystem & _aux_sys;
   unsigned int _system_number;
   Adaptivity & _adaptivity;

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -224,7 +224,7 @@ public:
   /**
    * Retrieve the Executioner shared pointer for this App
    */
-  MooseSharedPointer<Executioner> & executioner() { return _executioner; }
+  std::shared_ptr<Executioner> & executioner() { return _executioner; }
 
   /**
    * Set a Boolean indicating whether this app will use a Nonlinear or Eigen System.
@@ -246,7 +246,7 @@ public:
    * @return The reference to the command line object
    * Setup options based on InputParameters.
    */
-  MooseSharedPointer<CommandLine> commandLine() { return _command_line; }
+  std::shared_ptr<CommandLine> commandLine() { return _command_line; }
 
   /**
    * This method is here so we can determine whether or not we need to
@@ -404,7 +404,7 @@ public:
    * Create a Backup from the current App.  A Backup contains all the data necessary to be able
    * to restore the state of an App.
    */
-  MooseSharedPointer<Backup> backup();
+  std::shared_ptr<Backup> backup();
 
   /**
    * Restore a Backup.  This sets the App's state.
@@ -412,7 +412,7 @@ public:
    * @param backup The Backup holding the data for the app
    * @param for_restart Whether this restoration is explicitly for the first restoration of restart data
    */
-  void restore(MooseSharedPointer<Backup> backup, bool for_restart = false);
+  void restore(std::shared_ptr<Backup> backup, bool for_restart = false);
 
   /**
    * Returns a string to be printed at the beginning of a simulation
@@ -518,7 +518,7 @@ protected:
   const std::string _type;
 
   /// The MPI communicator this App is going to use
-  const MooseSharedPointer<Parallel::Communicator> _comm;
+  const std::shared_ptr<Parallel::Communicator> _comm;
 
   /// Input file name used
   std::string _input_filename;
@@ -542,7 +542,7 @@ protected:
   Real _global_time_offset;
 
   /// Command line object
-  MooseSharedPointer<CommandLine> _command_line;
+  std::shared_ptr<CommandLine> _command_line;
 
   /// Syntax of the input file
   Syntax _syntax;
@@ -563,13 +563,13 @@ protected:
   Parser _parser;
 
   /// Pointer to the executioner of this run (typically build by actions)
-  MooseSharedPointer<Executioner> _executioner;
+  std::shared_ptr<Executioner> _executioner;
 
   /// Boolean to indicate whether to use a Nonlinear or EigenSystem (inspected by actions)
   bool _use_nonlinear;
 
   /// System Information
-  MooseSharedPointer<SystemInfo> _sys_info;
+  std::shared_ptr<SystemInfo> _sys_info;
 
   /// Indicates whether warnings, errors, or no output is displayed when unused parameters are detected
   enum UNUSED_CHECK { OFF, WARN_UNUSED, ERROR_UNUSED } _enable_unused_check;
@@ -655,10 +655,10 @@ private:
   unsigned int _multiapp_level;
 
   /// Holds the mesh modifiers until they have completed, then this structure is cleared
-  std::map<std::string, MooseSharedPointer<MeshModifier> > _mesh_modifiers;
+  std::map<std::string, std::shared_ptr<MeshModifier> > _mesh_modifiers;
 
   /// Cache for a Backup to use for restart / recovery
-  MooseSharedPointer<Backup> _cached_backup;
+  std::shared_ptr<Backup> _cached_backup;
 
   // Allow FEProblemBase to set the recover/restart state, so make it a friend
   friend class FEProblemBase;

--- a/framework/include/base/MooseObjectWarehouse.h
+++ b/framework/include/base/MooseObjectWarehouse.h
@@ -65,9 +65,8 @@ void
 MooseObjectWarehouse<T>::initialSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<std::shared_ptr<T> >::const_iterator it;
-  for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    (*it)->initialSetup();
+  for (const auto & object : _active_objects[tid])
+    object->initialSetup();
 }
 
 
@@ -76,9 +75,8 @@ void
 MooseObjectWarehouse<T>::timestepSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<std::shared_ptr<T> >::const_iterator it;
-  for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    (*it)->timestepSetup();
+  for (const auto & object : _active_objects[tid])
+    object->timestepSetup();
 }
 
 
@@ -89,9 +87,9 @@ MooseObjectWarehouse<T>::subdomainSetup(SubdomainID id, THREAD_ID tid/* = 0*/) c
   checkThreadID(tid);
   if (hasActiveBlockObjects(id, tid))
   {
-    const std::vector<std::shared_ptr<T> > & objects = getActiveBlockObjects(id, tid);
-    for (typename std::vector<std::shared_ptr<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
-      (*it)->subdomainSetup();
+    const auto & objects = getActiveBlockObjects(id, tid);
+    for (const auto & object : objects)
+      object->subdomainSetup();
   }
 }
 
@@ -101,9 +99,8 @@ void
 MooseObjectWarehouse<T>::subdomainSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<std::shared_ptr<T> >::const_iterator it;
-  for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    (*it)->subdomainSetup();
+  for (const auto & object : _active_objects[tid])
+    object->subdomainSetup();
 }
 
 
@@ -112,9 +109,8 @@ void
 MooseObjectWarehouse<T>::jacobianSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<std::shared_ptr<T> >::const_iterator it;
-  for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    (*it)->jacobianSetup();
+  for (const auto & object : _active_objects[tid])
+    object->jacobianSetup();
 }
 
 
@@ -123,9 +119,8 @@ void
 MooseObjectWarehouse<T>::residualSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<std::shared_ptr<T> >::const_iterator it;
-  for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    (*it)->residualSetup();
+  for (const auto & object : _active_objects[tid])
+    object->residualSetup();
 }
 
 #endif // MOOSEOBJECTWAREHOUSE_H

--- a/framework/include/base/MooseObjectWarehouse.h
+++ b/framework/include/base/MooseObjectWarehouse.h
@@ -65,7 +65,7 @@ void
 MooseObjectWarehouse<T>::initialSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<MooseSharedPointer<T> >::const_iterator it;
+  typename std::vector<std::shared_ptr<T> >::const_iterator it;
   for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
     (*it)->initialSetup();
 }
@@ -76,7 +76,7 @@ void
 MooseObjectWarehouse<T>::timestepSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<MooseSharedPointer<T> >::const_iterator it;
+  typename std::vector<std::shared_ptr<T> >::const_iterator it;
   for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
     (*it)->timestepSetup();
 }
@@ -89,8 +89,8 @@ MooseObjectWarehouse<T>::subdomainSetup(SubdomainID id, THREAD_ID tid/* = 0*/) c
   checkThreadID(tid);
   if (hasActiveBlockObjects(id, tid))
   {
-    const std::vector<MooseSharedPointer<T> > & objects = getActiveBlockObjects(id, tid);
-    for (typename std::vector<MooseSharedPointer<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+    const std::vector<std::shared_ptr<T> > & objects = getActiveBlockObjects(id, tid);
+    for (typename std::vector<std::shared_ptr<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
       (*it)->subdomainSetup();
   }
 }
@@ -101,7 +101,7 @@ void
 MooseObjectWarehouse<T>::subdomainSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<MooseSharedPointer<T> >::const_iterator it;
+  typename std::vector<std::shared_ptr<T> >::const_iterator it;
   for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
     (*it)->subdomainSetup();
 }
@@ -112,7 +112,7 @@ void
 MooseObjectWarehouse<T>::jacobianSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<MooseSharedPointer<T> >::const_iterator it;
+  typename std::vector<std::shared_ptr<T> >::const_iterator it;
   for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
     (*it)->jacobianSetup();
 }
@@ -123,7 +123,7 @@ void
 MooseObjectWarehouse<T>::residualSetup(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<MooseSharedPointer<T> >::const_iterator it;
+  typename std::vector<std::shared_ptr<T> >::const_iterator it;
   for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
     (*it)->residualSetup();
 }

--- a/framework/include/base/MooseObjectWarehouseBase.h
+++ b/framework/include/base/MooseObjectWarehouseBase.h
@@ -45,18 +45,18 @@ public:
    * Adds an object to the storage structure.
    * @param object A shared pointer to the object being added
    */
-  virtual void addObject(MooseSharedPointer<T> object, THREAD_ID tid = 0);
+  virtual void addObject(std::shared_ptr<T> object, THREAD_ID tid = 0);
 
   ///@{
   /**
    * Retrieve complete vector to the all/block/boundary restricted objects for a given thread.
    * @param tid The thread id to retrieve objects from
    */
-  const std::vector<MooseSharedPointer<T> > & getObjects(THREAD_ID tid = 0) const;
-  const std::map<SubdomainID, std::vector<MooseSharedPointer<T> > > & getBlockObjects(THREAD_ID tid = 0) const;
-  const std::vector<MooseSharedPointer<T> > & getBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
-  const std::map<BoundaryID, std::vector<MooseSharedPointer<T> > > & getBoundaryObjects(THREAD_ID tid = 0) const;
-  const std::vector<MooseSharedPointer<T> > & getBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T> > & getObjects(THREAD_ID tid = 0) const;
+  const std::map<SubdomainID, std::vector<std::shared_ptr<T> > > & getBlockObjects(THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T> > & getBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
+  const std::map<BoundaryID, std::vector<std::shared_ptr<T> > > & getBoundaryObjects(THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T> > & getBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
   ///@}
 
   ///@{
@@ -64,11 +64,11 @@ public:
    * Retrieve complete vector to the active all/block/boundary restricted objects for a given thread.
    * @param tid The thread id to retrieve objects from
    */
-  const std::vector<MooseSharedPointer<T> > & getActiveObjects(THREAD_ID tid = 0) const;
-  const std::map<SubdomainID, std::vector<MooseSharedPointer<T> > > & getActiveBlockObjects(THREAD_ID tid = 0) const;
-  const std::vector<MooseSharedPointer<T> > & getActiveBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
-  const std::map<BoundaryID, std::vector<MooseSharedPointer<T> > > & getActiveBoundaryObjects(THREAD_ID tid = 0) const;
-  const std::vector<MooseSharedPointer<T> > & getActiveBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T> > & getActiveObjects(THREAD_ID tid = 0) const;
+  const std::map<SubdomainID, std::vector<std::shared_ptr<T> > > & getActiveBlockObjects(THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T> > & getActiveBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
+  const std::map<BoundaryID, std::vector<std::shared_ptr<T> > > & getActiveBoundaryObjects(THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T> > & getActiveBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
   ///@}
 
   ///@{
@@ -92,7 +92,7 @@ public:
    * Convenience functions for checking/getting specific objects
    */
   bool hasActiveObject(const std::string & name, THREAD_ID tid = 0) const;
-  MooseSharedPointer<T> getActiveObject(const std::string & name, THREAD_ID tid = 0) const;
+  std::shared_ptr<T> getActiveObject(const std::string & name, THREAD_ID tid = 0) const;
   ///@}
 
   /**
@@ -127,38 +127,38 @@ protected:
   const THREAD_ID _num_threads;
 
   /// Storage container for the ALL pointers (THREAD_ID on outer vector)
-  std::vector<std::vector<MooseSharedPointer<T> > > _all_objects;
+  std::vector<std::vector<std::shared_ptr<T> > > _all_objects;
 
   /// All active objects (THREAD_ID on outer vector)
-  std::vector<std::vector<MooseSharedPointer<T> > > _active_objects;
+  std::vector<std::vector<std::shared_ptr<T> > > _active_objects;
 
   // All block restricted objects (THREAD_ID on outer vector)
-  std::vector<std::map<SubdomainID, std::vector<MooseSharedPointer<T> > > > _all_block_objects;
+  std::vector<std::map<SubdomainID, std::vector<std::shared_ptr<T> > > > _all_block_objects;
 
   /// Active block restricted objects (THREAD_ID on outer vector)
-  std::vector<std::map<SubdomainID, std::vector<MooseSharedPointer<T> > > > _active_block_objects;
+  std::vector<std::map<SubdomainID, std::vector<std::shared_ptr<T> > > > _active_block_objects;
 
   // All boundary restricted objects (THREAD_ID on outer vector)
-  std::vector<std::map<BoundaryID, std::vector<MooseSharedPointer<T> > > > _all_boundary_objects;
+  std::vector<std::map<BoundaryID, std::vector<std::shared_ptr<T> > > > _all_boundary_objects;
 
   /// Active boundary restricted objects (THREAD_ID on outer vector)
-  std::vector<std::map<BoundaryID, std::vector<MooseSharedPointer<T> > > > _active_boundary_objects;
+  std::vector<std::map<BoundaryID, std::vector<std::shared_ptr<T> > > > _active_boundary_objects;
 
   /**
    * Helper method for updating active vectors
    */
-  static void updateActiveHelper(std::vector<MooseSharedPointer<T> > & active, const std::vector<MooseSharedPointer<T> > & all);
+  static void updateActiveHelper(std::vector<std::shared_ptr<T> > & active, const std::vector<std::shared_ptr<T> > & all);
 
   /**
    * Helper method for sorting vectors of objects.
    */
-  static void sortHelper(std::vector<MooseSharedPointer<T> > & objects);
+  static void sortHelper(std::vector<std::shared_ptr<T> > & objects);
 
   /**
    * Helper method for updating variable dependency vector
    */
   static void updateVariableDependencyHelper(std::set<MooseVariable *> & needed_moose_vars,
-                                             const std::vector<MooseSharedPointer<T> > & objects);
+                                             const std::vector<std::shared_ptr<T> > & objects);
 
   /**
    * Calls assert on thread id.
@@ -189,7 +189,7 @@ MooseObjectWarehouseBase<T>::~MooseObjectWarehouseBase()
 
 template<typename T>
 void
-MooseObjectWarehouseBase<T>::addObject(MooseSharedPointer<T> object, THREAD_ID tid /*= 0*/)
+MooseObjectWarehouseBase<T>::addObject(std::shared_ptr<T> object, THREAD_ID tid /*= 0*/)
 {
   checkThreadID(tid);
 
@@ -202,8 +202,8 @@ MooseObjectWarehouseBase<T>::addObject(MooseSharedPointer<T> object, THREAD_ID t
     _active_objects[tid].push_back(object);
 
   // Perform casts to the Block/BoundaryRestrictable
-  MooseSharedPointer<BoundaryRestrictable> bnd = MooseSharedNamespace::dynamic_pointer_cast<BoundaryRestrictable>(object);
-  MooseSharedPointer<BlockRestrictable> blk = MooseSharedNamespace::dynamic_pointer_cast<BlockRestrictable>(object);
+  std::shared_ptr<BoundaryRestrictable> bnd = MooseSharedNamespace::dynamic_pointer_cast<BoundaryRestrictable>(object);
+  std::shared_ptr<BlockRestrictable> blk = MooseSharedNamespace::dynamic_pointer_cast<BlockRestrictable>(object);
 
   // Boundary Restricted
   if (bnd && bnd->boundaryRestricted())
@@ -232,7 +232,7 @@ MooseObjectWarehouseBase<T>::addObject(MooseSharedPointer<T> object, THREAD_ID t
 
 
 template<typename T>
-inline const std::vector<MooseSharedPointer<T> > &
+inline const std::vector<std::shared_ptr<T> > &
 MooseObjectWarehouseBase<T>::getObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
@@ -241,7 +241,7 @@ MooseObjectWarehouseBase<T>::getObjects(THREAD_ID tid/* = 0*/) const
 
 
 template<typename T>
-inline const std::map<BoundaryID, std::vector<MooseSharedPointer<T> > > &
+inline const std::map<BoundaryID, std::vector<std::shared_ptr<T> > > &
 MooseObjectWarehouseBase<T>::getBoundaryObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
@@ -250,18 +250,18 @@ MooseObjectWarehouseBase<T>::getBoundaryObjects(THREAD_ID tid/* = 0*/) const
 
 
 template<typename T>
-const std::vector<MooseSharedPointer<T> > &
+const std::vector<std::shared_ptr<T> > &
 MooseObjectWarehouseBase<T>::getBoundaryObjects(BoundaryID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<BoundaryID, std::vector<MooseSharedPointer<T> > >::const_iterator iter = _all_boundary_objects[tid].find(id);
+  typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _all_boundary_objects[tid].find(id);
   mooseAssert(iter != _all_boundary_objects[tid].end(), "Unable to located active boundary objects for the given id: " << id << ".");
   return iter->second;
 }
 
 
 template<typename T>
-inline const std::map<SubdomainID, std::vector<MooseSharedPointer<T> > > &
+inline const std::map<SubdomainID, std::vector<std::shared_ptr<T> > > &
 MooseObjectWarehouseBase<T>::getBlockObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
@@ -270,18 +270,18 @@ MooseObjectWarehouseBase<T>::getBlockObjects(THREAD_ID tid/* = 0*/) const
 
 
 template<typename T>
-const std::vector<MooseSharedPointer<T> > &
+const std::vector<std::shared_ptr<T> > &
 MooseObjectWarehouseBase<T>::getBlockObjects(SubdomainID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<SubdomainID, std::vector<MooseSharedPointer<T> > >::const_iterator iter = _all_block_objects[tid].find(id);
+  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _all_block_objects[tid].find(id);
   mooseAssert(iter != _all_block_objects[tid].end(), "Unable to located active block objects for the given id: " << id << ".");
   return iter->second;
 }
 
 
 template<typename T>
-inline const std::vector<MooseSharedPointer<T> > &
+inline const std::vector<std::shared_ptr<T> > &
 MooseObjectWarehouseBase<T>::getActiveObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
@@ -290,7 +290,7 @@ MooseObjectWarehouseBase<T>::getActiveObjects(THREAD_ID tid/* = 0*/) const
 
 
 template<typename T>
-inline const std::map<BoundaryID, std::vector<MooseSharedPointer<T> > > &
+inline const std::map<BoundaryID, std::vector<std::shared_ptr<T> > > &
 MooseObjectWarehouseBase<T>::getActiveBoundaryObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
@@ -299,18 +299,18 @@ MooseObjectWarehouseBase<T>::getActiveBoundaryObjects(THREAD_ID tid/* = 0*/) con
 
 
 template<typename T>
-const std::vector<MooseSharedPointer<T> > &
+const std::vector<std::shared_ptr<T> > &
 MooseObjectWarehouseBase<T>::getActiveBoundaryObjects(BoundaryID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<BoundaryID, std::vector<MooseSharedPointer<T> > >::const_iterator iter = _active_boundary_objects[tid].find(id);
+  typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _active_boundary_objects[tid].find(id);
   mooseAssert(iter != _active_boundary_objects[tid].end(), "Unable to located active boundary objects for the given id: " << id << ".");
   return iter->second;
 }
 
 
 template<typename T>
-inline const std::map<SubdomainID, std::vector<MooseSharedPointer<T> > > &
+inline const std::map<SubdomainID, std::vector<std::shared_ptr<T> > > &
 MooseObjectWarehouseBase<T>::getActiveBlockObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
@@ -319,11 +319,11 @@ MooseObjectWarehouseBase<T>::getActiveBlockObjects(THREAD_ID tid/* = 0*/) const
 
 
 template<typename T>
-const std::vector<MooseSharedPointer<T> > &
+const std::vector<std::shared_ptr<T> > &
 MooseObjectWarehouseBase<T>::getActiveBlockObjects(SubdomainID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<SubdomainID, std::vector<MooseSharedPointer<T> > >::const_iterator iter = _active_block_objects[tid].find(id);
+  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _active_block_objects[tid].find(id);
   mooseAssert(iter != _active_block_objects[tid].end(), "Unable to located active block objects for the given id: " << id << ".");
   return iter->second;
 }
@@ -344,7 +344,7 @@ MooseObjectWarehouseBase<T>::hasActiveBlockObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   bool has_active_block_objects = false;
-  typename std::map<SubdomainID, std::vector<MooseSharedPointer<T> > >::const_iterator it;
+  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator it;
   for (it = _active_block_objects[tid].begin(); it != _active_block_objects[tid].end(); ++it)
     has_active_block_objects |= !(it->second.empty());
   return has_active_block_objects;
@@ -356,7 +356,7 @@ bool
 MooseObjectWarehouseBase<T>::hasActiveBlockObjects(SubdomainID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<SubdomainID, std::vector<MooseSharedPointer<T> > >::const_iterator iter = _active_block_objects[tid].find(id);
+  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _active_block_objects[tid].find(id);
   return iter != _active_block_objects[tid].end();
 }
 
@@ -367,7 +367,7 @@ MooseObjectWarehouseBase<T>::hasActiveBoundaryObjects(THREAD_ID tid/* = 0*/) con
 {
   checkThreadID(tid);
   bool has_active_boundary_objects = false;
-  typename std::map<BoundaryID, std::vector<MooseSharedPointer<T> > >::const_iterator it;
+  typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator it;
   for (it = _active_boundary_objects[tid].begin(); it != _active_boundary_objects[tid].end(); ++it)
     has_active_boundary_objects |= !(it->second.empty());
   return has_active_boundary_objects;
@@ -379,7 +379,7 @@ bool
 MooseObjectWarehouseBase<T>::hasActiveBoundaryObjects(BoundaryID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<BoundaryID, std::vector<MooseSharedPointer<T> > >::const_iterator iter = _active_boundary_objects[tid].find(id);
+  typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _active_boundary_objects[tid].find(id);
   return iter != _active_boundary_objects[tid].end();
 }
 
@@ -389,7 +389,7 @@ bool
 MooseObjectWarehouseBase<T>::hasActiveObject(const std::string & name, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<MooseSharedPointer<T> >::const_iterator it;
+  typename std::vector<std::shared_ptr<T> >::const_iterator it;
   for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
     if ((*it)->name() == name)
       return true;
@@ -398,11 +398,11 @@ MooseObjectWarehouseBase<T>::hasActiveObject(const std::string & name, THREAD_ID
 
 
 template<typename T>
-MooseSharedPointer<T>
+std::shared_ptr<T>
 MooseObjectWarehouseBase<T>::getActiveObject(const std::string & name, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<MooseSharedPointer<T> >::const_iterator it;
+  typename std::vector<std::shared_ptr<T> >::const_iterator it;
   for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
     if ((*it)->name() == name)
       return *it;
@@ -416,7 +416,7 @@ MooseObjectWarehouseBase<T>::getActiveBlocks(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   std::set<SubdomainID> ids;
-  typename std::map<SubdomainID, std::vector<MooseSharedPointer<T> > >::const_iterator it;
+  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator it;
   for (it = _active_block_objects[tid].begin(); it != _active_block_objects[tid].end(); ++it)
     ids.insert(it->first);
   return ids;
@@ -432,13 +432,13 @@ MooseObjectWarehouseBase<T>::updateActive(THREAD_ID tid /*= 0*/)
   updateActiveHelper(_active_objects[tid], _all_objects[tid]);
 
   {
-    typename std::map<SubdomainID, std::vector<MooseSharedPointer<T> > >::const_iterator it;
+    typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator it;
     for (it = _all_block_objects[tid].begin(); it != _all_block_objects[tid].end(); ++it)
       updateActiveHelper(_active_block_objects[tid][it->first], it->second);
   }
 
   {
-    typename std::map<BoundaryID, std::vector<MooseSharedPointer<T> > >::const_iterator it;
+    typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator it;
     for (it = _all_boundary_objects[tid].begin(); it != _all_boundary_objects[tid].end(); ++it)
       updateActiveHelper(_active_boundary_objects[tid][it->first], it->second);
   }
@@ -448,9 +448,9 @@ MooseObjectWarehouseBase<T>::updateActive(THREAD_ID tid /*= 0*/)
 
 template<typename T>
 void
-MooseObjectWarehouseBase<T>::updateActiveHelper(std::vector<MooseSharedPointer<T> > & active, const std::vector<MooseSharedPointer<T> > & all)
+MooseObjectWarehouseBase<T>::updateActiveHelper(std::vector<std::shared_ptr<T> > & active, const std::vector<std::shared_ptr<T> > & all)
 {
-  typename std::vector<MooseSharedPointer<T> >::const_iterator iter;
+  typename std::vector<std::shared_ptr<T> >::const_iterator iter;
 
   // Clear the active list
   active.clear();
@@ -469,13 +469,13 @@ MooseObjectWarehouseBase<T>::sort(THREAD_ID tid/* = 0*/)
   checkThreadID(tid);
 
   {
-    typename std::map<SubdomainID, std::vector<MooseSharedPointer<T> > >::iterator iter;
+    typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::iterator iter;
     for (iter = _all_block_objects[tid].begin(); iter != _all_block_objects[tid].end(); ++iter)
       sortHelper(iter->second);
   }
 
   {
-    typename std::map<BoundaryID, std::vector<MooseSharedPointer<T> > >::iterator iter;
+    typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::iterator iter;
     for (iter = _all_boundary_objects[tid].begin(); iter != _all_boundary_objects[tid].end(); ++iter)
       sortHelper(iter->second);
   }
@@ -511,7 +511,7 @@ MooseObjectWarehouseBase<T>::updateBoundaryVariableDependency(std::set<MooseVari
 {
   if (hasActiveBoundaryObjects(tid))
   {
-    typename std::map<BoundaryID, std::vector<MooseSharedPointer<T> > >::const_iterator it;
+    typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator it;
     for (it = _active_boundary_objects[tid].begin(); it != _active_boundary_objects[tid].end(); ++it)
       updateVariableDependencyHelper(needed_moose_vars, it->second);
   }
@@ -530,9 +530,9 @@ MooseObjectWarehouseBase<T>::updateBoundaryVariableDependency(BoundaryID id, std
 template<typename T>
 void
 MooseObjectWarehouseBase<T>::updateVariableDependencyHelper(std::set<MooseVariable *> & needed_moose_vars,
-                                                                    const std::vector<MooseSharedPointer<T> > & objects)
+                                                                    const std::vector<std::shared_ptr<T> > & objects)
 {
-  for (typename std::vector<MooseSharedPointer<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+  for (typename std::vector<std::shared_ptr<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
   {
     const std::set<MooseVariable *> & mv_deps = (*it)->getMooseVariableDependencies();
     needed_moose_vars.insert(mv_deps.begin(), mv_deps.end());
@@ -544,10 +544,10 @@ template<typename T>
 void
 MooseObjectWarehouseBase<T>::subdomainsCovered(std::set<SubdomainID> & subdomains_covered, std::set<std::string> & unique_variables, THREAD_ID tid/*=0*/) const
 {
-  for (typename std::vector<MooseSharedPointer<T> >::const_iterator it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
+  for (typename std::vector<std::shared_ptr<T> >::const_iterator it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
     unique_variables.insert((*it)->variable().name());
 
-  typename std::map<SubdomainID, std::vector<MooseSharedPointer<T> > >::const_iterator it;
+  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator it;
   for (it = _active_block_objects[tid].begin(); it != _active_block_objects[tid].end(); ++it)
     subdomains_covered.insert(it->first);
 }
@@ -555,7 +555,7 @@ MooseObjectWarehouseBase<T>::subdomainsCovered(std::set<SubdomainID> & subdomain
 
 template<typename T>
 void
-MooseObjectWarehouseBase<T>::sortHelper(std::vector<MooseSharedPointer<T> > & objects)
+MooseObjectWarehouseBase<T>::sortHelper(std::vector<std::shared_ptr<T> > & objects)
 {
   // Do nothing if the vector is empty
   if (objects.empty())
@@ -567,11 +567,11 @@ MooseObjectWarehouseBase<T>::sortHelper(std::vector<MooseSharedPointer<T> > & ob
   try
   {
     // Sort based on dependencies
-    DependencyResolverInterface::sort<MooseSharedPointer<T> >(objects);
+    DependencyResolverInterface::sort<std::shared_ptr<T> >(objects);
   }
-  catch(CyclicDependencyException<MooseSharedPointer<T> > & e)
+  catch(CyclicDependencyException<std::shared_ptr<T> > & e)
   {
-    DependencyResolverInterface::cyclicDependencyError<MooseSharedPointer<T> >(e, "Cyclic dependency detected in object ordering");
+    DependencyResolverInterface::cyclicDependencyError<std::shared_ptr<T> >(e, "Cyclic dependency detected in object ordering");
   }
 }
 

--- a/framework/include/base/MooseObjectWarehouseBase.h
+++ b/framework/include/base/MooseObjectWarehouseBase.h
@@ -52,11 +52,11 @@ public:
    * Retrieve complete vector to the all/block/boundary restricted objects for a given thread.
    * @param tid The thread id to retrieve objects from
    */
-  const std::vector<std::shared_ptr<T> > & getObjects(THREAD_ID tid = 0) const;
-  const std::map<SubdomainID, std::vector<std::shared_ptr<T> > > & getBlockObjects(THREAD_ID tid = 0) const;
-  const std::vector<std::shared_ptr<T> > & getBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
-  const std::map<BoundaryID, std::vector<std::shared_ptr<T> > > & getBoundaryObjects(THREAD_ID tid = 0) const;
-  const std::vector<std::shared_ptr<T> > & getBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T>> & getObjects(THREAD_ID tid = 0) const;
+  const std::map<SubdomainID, std::vector<std::shared_ptr<T>>> & getBlockObjects(THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T>> & getBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
+  const std::map<BoundaryID, std::vector<std::shared_ptr<T>>> & getBoundaryObjects(THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T>> & getBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
   ///@}
 
   ///@{
@@ -64,11 +64,11 @@ public:
    * Retrieve complete vector to the active all/block/boundary restricted objects for a given thread.
    * @param tid The thread id to retrieve objects from
    */
-  const std::vector<std::shared_ptr<T> > & getActiveObjects(THREAD_ID tid = 0) const;
-  const std::map<SubdomainID, std::vector<std::shared_ptr<T> > > & getActiveBlockObjects(THREAD_ID tid = 0) const;
-  const std::vector<std::shared_ptr<T> > & getActiveBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
-  const std::map<BoundaryID, std::vector<std::shared_ptr<T> > > & getActiveBoundaryObjects(THREAD_ID tid = 0) const;
-  const std::vector<std::shared_ptr<T> > & getActiveBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T>> & getActiveObjects(THREAD_ID tid = 0) const;
+  const std::map<SubdomainID, std::vector<std::shared_ptr<T>>> & getActiveBlockObjects(THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T>> & getActiveBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
+  const std::map<BoundaryID, std::vector<std::shared_ptr<T>>> & getActiveBoundaryObjects(THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<T>> & getActiveBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
   ///@}
 
   ///@{
@@ -127,38 +127,38 @@ protected:
   const THREAD_ID _num_threads;
 
   /// Storage container for the ALL pointers (THREAD_ID on outer vector)
-  std::vector<std::vector<std::shared_ptr<T> > > _all_objects;
+  std::vector<std::vector<std::shared_ptr<T>>> _all_objects;
 
   /// All active objects (THREAD_ID on outer vector)
-  std::vector<std::vector<std::shared_ptr<T> > > _active_objects;
+  std::vector<std::vector<std::shared_ptr<T>>> _active_objects;
 
   // All block restricted objects (THREAD_ID on outer vector)
-  std::vector<std::map<SubdomainID, std::vector<std::shared_ptr<T> > > > _all_block_objects;
+  std::vector<std::map<SubdomainID, std::vector<std::shared_ptr<T>>>> _all_block_objects;
 
   /// Active block restricted objects (THREAD_ID on outer vector)
-  std::vector<std::map<SubdomainID, std::vector<std::shared_ptr<T> > > > _active_block_objects;
+  std::vector<std::map<SubdomainID, std::vector<std::shared_ptr<T>>>> _active_block_objects;
 
   // All boundary restricted objects (THREAD_ID on outer vector)
-  std::vector<std::map<BoundaryID, std::vector<std::shared_ptr<T> > > > _all_boundary_objects;
+  std::vector<std::map<BoundaryID, std::vector<std::shared_ptr<T>>>> _all_boundary_objects;
 
   /// Active boundary restricted objects (THREAD_ID on outer vector)
-  std::vector<std::map<BoundaryID, std::vector<std::shared_ptr<T> > > > _active_boundary_objects;
+  std::vector<std::map<BoundaryID, std::vector<std::shared_ptr<T>>>> _active_boundary_objects;
 
   /**
    * Helper method for updating active vectors
    */
-  static void updateActiveHelper(std::vector<std::shared_ptr<T> > & active, const std::vector<std::shared_ptr<T> > & all);
+  static void updateActiveHelper(std::vector<std::shared_ptr<T>> & active, const std::vector<std::shared_ptr<T>> & all);
 
   /**
    * Helper method for sorting vectors of objects.
    */
-  static void sortHelper(std::vector<std::shared_ptr<T> > & objects);
+  static void sortHelper(std::vector<std::shared_ptr<T>> & objects);
 
   /**
    * Helper method for updating variable dependency vector
    */
   static void updateVariableDependencyHelper(std::set<MooseVariable *> & needed_moose_vars,
-                                             const std::vector<std::shared_ptr<T> > & objects);
+                                             const std::vector<std::shared_ptr<T>> & objects);
 
   /**
    * Calls assert on thread id.
@@ -180,12 +180,10 @@ MooseObjectWarehouseBase<T>::MooseObjectWarehouseBase(bool threaded /*=true*/) :
 {
 }
 
-
 template<typename T>
 MooseObjectWarehouseBase<T>::~MooseObjectWarehouseBase()
 {
 }
-
 
 template<typename T>
 void
@@ -202,8 +200,8 @@ MooseObjectWarehouseBase<T>::addObject(std::shared_ptr<T> object, THREAD_ID tid 
     _active_objects[tid].push_back(object);
 
   // Perform casts to the Block/BoundaryRestrictable
-  std::shared_ptr<BoundaryRestrictable> bnd = MooseSharedNamespace::dynamic_pointer_cast<BoundaryRestrictable>(object);
-  std::shared_ptr<BlockRestrictable> blk = MooseSharedNamespace::dynamic_pointer_cast<BlockRestrictable>(object);
+  std::shared_ptr<BoundaryRestrictable> bnd = std::dynamic_pointer_cast<BoundaryRestrictable>(object);
+  std::shared_ptr<BlockRestrictable> blk = std::dynamic_pointer_cast<BlockRestrictable>(object);
 
   // Boundary Restricted
   if (bnd && bnd->boundaryRestricted())
@@ -230,104 +228,93 @@ MooseObjectWarehouseBase<T>::addObject(std::shared_ptr<T> object, THREAD_ID tid 
   }
 }
 
-
 template<typename T>
-inline const std::vector<std::shared_ptr<T> > &
+inline const std::vector<std::shared_ptr<T>> &
 MooseObjectWarehouseBase<T>::getObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   return _all_objects[tid];
 }
 
-
 template<typename T>
-inline const std::map<BoundaryID, std::vector<std::shared_ptr<T> > > &
+inline const std::map<BoundaryID, std::vector<std::shared_ptr<T>>> &
 MooseObjectWarehouseBase<T>::getBoundaryObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   return _all_boundary_objects[tid];
 }
 
-
 template<typename T>
-const std::vector<std::shared_ptr<T> > &
+const std::vector<std::shared_ptr<T>> &
 MooseObjectWarehouseBase<T>::getBoundaryObjects(BoundaryID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _all_boundary_objects[tid].find(id);
+  const auto iter = _all_boundary_objects[tid].find(id);
   mooseAssert(iter != _all_boundary_objects[tid].end(), "Unable to located active boundary objects for the given id: " << id << ".");
   return iter->second;
 }
 
-
 template<typename T>
-inline const std::map<SubdomainID, std::vector<std::shared_ptr<T> > > &
+inline const std::map<SubdomainID, std::vector<std::shared_ptr<T>>> &
 MooseObjectWarehouseBase<T>::getBlockObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   return _all_block_objects[tid];
 }
 
-
 template<typename T>
-const std::vector<std::shared_ptr<T> > &
+const std::vector<std::shared_ptr<T>> &
 MooseObjectWarehouseBase<T>::getBlockObjects(SubdomainID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _all_block_objects[tid].find(id);
+  const auto iter = _all_block_objects[tid].find(id);
   mooseAssert(iter != _all_block_objects[tid].end(), "Unable to located active block objects for the given id: " << id << ".");
   return iter->second;
 }
 
-
 template<typename T>
-inline const std::vector<std::shared_ptr<T> > &
+inline const std::vector<std::shared_ptr<T>> &
 MooseObjectWarehouseBase<T>::getActiveObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   return _active_objects[tid];
 }
 
-
 template<typename T>
-inline const std::map<BoundaryID, std::vector<std::shared_ptr<T> > > &
+inline const std::map<BoundaryID, std::vector<std::shared_ptr<T>>> &
 MooseObjectWarehouseBase<T>::getActiveBoundaryObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   return _active_boundary_objects[tid];
 }
 
-
 template<typename T>
-const std::vector<std::shared_ptr<T> > &
+const std::vector<std::shared_ptr<T>> &
 MooseObjectWarehouseBase<T>::getActiveBoundaryObjects(BoundaryID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _active_boundary_objects[tid].find(id);
+  const auto iter = _active_boundary_objects[tid].find(id);
   mooseAssert(iter != _active_boundary_objects[tid].end(), "Unable to located active boundary objects for the given id: " << id << ".");
   return iter->second;
 }
 
-
 template<typename T>
-inline const std::map<SubdomainID, std::vector<std::shared_ptr<T> > > &
+inline const std::map<SubdomainID, std::vector<std::shared_ptr<T>>> &
 MooseObjectWarehouseBase<T>::getActiveBlockObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   return _active_block_objects[tid];
 }
 
-
 template<typename T>
-const std::vector<std::shared_ptr<T> > &
+const std::vector<std::shared_ptr<T>> &
 MooseObjectWarehouseBase<T>::getActiveBlockObjects(SubdomainID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _active_block_objects[tid].find(id);
+  const auto iter = _active_block_objects[tid].find(id);
   mooseAssert(iter != _active_block_objects[tid].end(), "Unable to located active block objects for the given id: " << id << ".");
   return iter->second;
 }
-
 
 template<typename T>
 bool
@@ -337,29 +324,25 @@ MooseObjectWarehouseBase<T>::hasActiveObjects(THREAD_ID tid/* = 0*/) const
   return !_active_objects[tid].empty();
 }
 
-
 template<typename T>
 bool
 MooseObjectWarehouseBase<T>::hasActiveBlockObjects(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   bool has_active_block_objects = false;
-  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator it;
-  for (it = _active_block_objects[tid].begin(); it != _active_block_objects[tid].end(); ++it)
-    has_active_block_objects |= !(it->second.empty());
+  for (const auto & object_pair : _active_block_objects[tid])
+    has_active_block_objects |= !(object_pair.second.empty());
   return has_active_block_objects;
 }
-
 
 template<typename T>
 bool
 MooseObjectWarehouseBase<T>::hasActiveBlockObjects(SubdomainID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _active_block_objects[tid].find(id);
+  const auto iter = _active_block_objects[tid].find(id);
   return iter != _active_block_objects[tid].end();
 }
-
 
 template<typename T>
 bool
@@ -367,48 +350,41 @@ MooseObjectWarehouseBase<T>::hasActiveBoundaryObjects(THREAD_ID tid/* = 0*/) con
 {
   checkThreadID(tid);
   bool has_active_boundary_objects = false;
-  typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator it;
-  for (it = _active_boundary_objects[tid].begin(); it != _active_boundary_objects[tid].end(); ++it)
-    has_active_boundary_objects |= !(it->second.empty());
+  for (const auto & object_pair : _active_boundary_objects[tid])
+    has_active_boundary_objects |= !(object_pair.second.empty());
   return has_active_boundary_objects;
 }
-
 
 template<typename T>
 bool
 MooseObjectWarehouseBase<T>::hasActiveBoundaryObjects(BoundaryID id, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator iter = _active_boundary_objects[tid].find(id);
+  const auto iter = _active_boundary_objects[tid].find(id);
   return iter != _active_boundary_objects[tid].end();
 }
-
 
 template<typename T>
 bool
 MooseObjectWarehouseBase<T>::hasActiveObject(const std::string & name, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<std::shared_ptr<T> >::const_iterator it;
-  for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    if ((*it)->name() == name)
+  for (const auto & object : _active_objects[tid])
+    if (object->name() == name)
       return true;
   return false;
 }
-
 
 template<typename T>
 std::shared_ptr<T>
 MooseObjectWarehouseBase<T>::getActiveObject(const std::string & name, THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
-  typename std::vector<std::shared_ptr<T> >::const_iterator it;
-  for (it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    if ((*it)->name() == name)
-      return *it;
+  for (const auto & object : _active_objects[tid])
+    if (object->name() == name)
+      return object;
   mooseError("Unable to locate active object: " << name << ".");
 }
-
 
 template<typename T>
 std::set<SubdomainID>
@@ -416,12 +392,10 @@ MooseObjectWarehouseBase<T>::getActiveBlocks(THREAD_ID tid/* = 0*/) const
 {
   checkThreadID(tid);
   std::set<SubdomainID> ids;
-  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator it;
-  for (it = _active_block_objects[tid].begin(); it != _active_block_objects[tid].end(); ++it)
-    ids.insert(it->first);
+  for (const auto & object_pair: _active_block_objects[tid])
+    ids.insert(object_pair.first);
   return ids;
 }
-
 
 template<typename T>
 void
@@ -431,36 +405,26 @@ MooseObjectWarehouseBase<T>::updateActive(THREAD_ID tid /*= 0*/)
 
   updateActiveHelper(_active_objects[tid], _all_objects[tid]);
 
-  {
-    typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator it;
-    for (it = _all_block_objects[tid].begin(); it != _all_block_objects[tid].end(); ++it)
-      updateActiveHelper(_active_block_objects[tid][it->first], it->second);
-  }
+  for (const auto & object_pair : _all_block_objects[tid])
+    updateActiveHelper(_active_block_objects[tid][object_pair.first], object_pair.second);
 
-  {
-    typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator it;
-    for (it = _all_boundary_objects[tid].begin(); it != _all_boundary_objects[tid].end(); ++it)
-      updateActiveHelper(_active_boundary_objects[tid][it->first], it->second);
-  }
-
+  for (const auto & object_pair : _all_boundary_objects[tid])
+    updateActiveHelper(_active_boundary_objects[tid][object_pair.first], object_pair.second);
 }
-
 
 template<typename T>
 void
-MooseObjectWarehouseBase<T>::updateActiveHelper(std::vector<std::shared_ptr<T> > & active, const std::vector<std::shared_ptr<T> > & all)
+MooseObjectWarehouseBase<T>::updateActiveHelper(std::vector<std::shared_ptr<T>> & active, const std::vector<std::shared_ptr<T> > & all)
 {
-  typename std::vector<std::shared_ptr<T> >::const_iterator iter;
-
   // Clear the active list
   active.clear();
 
-  // Add "enabled" objects to the active list
-  for (iter = all.begin(); iter != all.end(); ++iter)
-    if ( (*iter)->enabled() )
-      active.push_back(*iter);
+  std::copy_if(all.begin(), all.end(), std::back_inserter(active),
+               [](const std::shared_ptr<T> & object)
+               {
+                 return object->enabled();
+               });
 }
-
 
 template<typename T>
 void
@@ -468,24 +432,17 @@ MooseObjectWarehouseBase<T>::sort(THREAD_ID tid/* = 0*/)
 {
   checkThreadID(tid);
 
-  {
-    typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::iterator iter;
-    for (iter = _all_block_objects[tid].begin(); iter != _all_block_objects[tid].end(); ++iter)
-      sortHelper(iter->second);
-  }
+  for (auto & object_pair : _all_block_objects[tid])
+    sortHelper(object_pair.second);
 
-  {
-    typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::iterator iter;
-    for (iter = _all_boundary_objects[tid].begin(); iter != _all_boundary_objects[tid].end(); ++iter)
-      sortHelper(iter->second);
-  }
+  for (auto & object_pair : _all_boundary_objects[tid])
+    sortHelper(object_pair.second);
 
   sortHelper(_all_objects[tid]);
 
   // The active lists now must be update to reflect the order changes
   updateActive(tid);
 }
-
 
 template<typename T>
 void
@@ -495,7 +452,6 @@ MooseObjectWarehouseBase<T>::updateVariableDependency(std::set<MooseVariable *> 
     updateVariableDependencyHelper(needed_moose_vars, _all_objects[tid]);
 }
 
-
 template<typename T>
 void
 MooseObjectWarehouseBase<T>::updateBlockVariableDependency(SubdomainID id, std::set<MooseVariable *> & needed_moose_vars, THREAD_ID tid/* = 0*/) const
@@ -504,7 +460,6 @@ MooseObjectWarehouseBase<T>::updateBlockVariableDependency(SubdomainID id, std::
     updateVariableDependencyHelper(needed_moose_vars, getActiveBlockObjects(id, tid));
 }
 
-
 template<typename T>
 void
 MooseObjectWarehouseBase<T>::updateBoundaryVariableDependency(std::set<MooseVariable *> & needed_moose_vars, THREAD_ID tid/* = 0*/) const
@@ -512,11 +467,10 @@ MooseObjectWarehouseBase<T>::updateBoundaryVariableDependency(std::set<MooseVari
   if (hasActiveBoundaryObjects(tid))
   {
     typename std::map<BoundaryID, std::vector<std::shared_ptr<T> > >::const_iterator it;
-    for (it = _active_boundary_objects[tid].begin(); it != _active_boundary_objects[tid].end(); ++it)
-      updateVariableDependencyHelper(needed_moose_vars, it->second);
+    for (const auto & object_pair : _active_boundary_objects[tid])
+      updateVariableDependencyHelper(needed_moose_vars, object_pair.second);
   }
 }
-
 
 template<typename T>
 void
@@ -526,52 +480,48 @@ MooseObjectWarehouseBase<T>::updateBoundaryVariableDependency(BoundaryID id, std
     updateVariableDependencyHelper(needed_moose_vars, getActiveBoundaryObjects(id, tid));
 }
 
-
 template<typename T>
 void
 MooseObjectWarehouseBase<T>::updateVariableDependencyHelper(std::set<MooseVariable *> & needed_moose_vars,
-                                                                    const std::vector<std::shared_ptr<T> > & objects)
+                                                            const std::vector<std::shared_ptr<T>> & objects)
 {
-  for (typename std::vector<std::shared_ptr<T> >::const_iterator it = objects.begin(); it != objects.end(); ++it)
+  for (const auto & object : objects)
   {
-    const std::set<MooseVariable *> & mv_deps = (*it)->getMooseVariableDependencies();
+    const auto & mv_deps = object->getMooseVariableDependencies();
     needed_moose_vars.insert(mv_deps.begin(), mv_deps.end());
   }
 }
-
 
 template<typename T>
 void
 MooseObjectWarehouseBase<T>::subdomainsCovered(std::set<SubdomainID> & subdomains_covered, std::set<std::string> & unique_variables, THREAD_ID tid/*=0*/) const
 {
-  for (typename std::vector<std::shared_ptr<T> >::const_iterator it = _active_objects[tid].begin(); it != _active_objects[tid].end(); ++it)
-    unique_variables.insert((*it)->variable().name());
+  for (const auto & object : _active_objects[tid])
+    unique_variables.insert(object->variable().name());
 
-  typename std::map<SubdomainID, std::vector<std::shared_ptr<T> > >::const_iterator it;
-  for (it = _active_block_objects[tid].begin(); it != _active_block_objects[tid].end(); ++it)
-    subdomains_covered.insert(it->first);
+  for (const auto & object_pair : _active_block_objects[tid])
+    subdomains_covered.insert(object_pair.first);
 }
-
 
 template<typename T>
 void
-MooseObjectWarehouseBase<T>::sortHelper(std::vector<std::shared_ptr<T> > & objects)
+MooseObjectWarehouseBase<T>::sortHelper(std::vector<std::shared_ptr<T>> & objects)
 {
   // Do nothing if the vector is empty
   if (objects.empty())
     return;
 
   // Make sure the object is sortable
-  mooseAssert(MooseSharedNamespace::dynamic_pointer_cast<DependencyResolverInterface>(objects[0]), "Objects must inhert from DependencyResolverInterface to be sorted.");
+  mooseAssert(std::dynamic_pointer_cast<DependencyResolverInterface>(objects[0]), "Objects must inhert from DependencyResolverInterface to be sorted.");
 
   try
   {
     // Sort based on dependencies
-    DependencyResolverInterface::sort<std::shared_ptr<T> >(objects);
+    DependencyResolverInterface::sort<std::shared_ptr<T>>(objects);
   }
-  catch(CyclicDependencyException<std::shared_ptr<T> > & e)
+  catch(CyclicDependencyException<std::shared_ptr<T>> & e)
   {
-    DependencyResolverInterface::cyclicDependencyError<std::shared_ptr<T> >(e, "Cyclic dependency detected in object ordering");
+    DependencyResolverInterface::cyclicDependencyError<std::shared_ptr<T>>(e, "Cyclic dependency detected in object ordering");
   }
 }
 

--- a/framework/include/base/NonlinearEigenSystem.h
+++ b/framework/include/base/NonlinearEigenSystem.h
@@ -73,7 +73,7 @@ public:
   // return all converged eigenvalues
   virtual const std::vector<std::pair<Real, Real> > & getAllConvergedEigenvalues() { return _eigen_values; }
 
-  virtual void addEigenKernels(MooseSharedPointer<KernelBase> kernel, THREAD_ID tid) override;
+  virtual void addEigenKernels(std::shared_ptr<KernelBase> kernel, THREAD_ID tid) override;
 
   // For eigenvalue problems (including standard and generalized), inhomogeneous (Dirichlet or Neumann)
   // boundary conditions are  not allowed.

--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -113,7 +113,7 @@ public:
    */
   virtual void addKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters);
 
-  virtual void addEigenKernels(MooseSharedPointer<KernelBase> /*kernel*/, THREAD_ID /*tid*/) {};
+  virtual void addEigenKernels(std::shared_ptr<KernelBase> /*kernel*/, THREAD_ID /*tid*/) {};
 
   /**
    * Adds a NodalKernel
@@ -191,7 +191,7 @@ public:
    * Retrieves a split by name
    * @param name The name of the split
    */
-  MooseSharedPointer<Split> getSplit(const std::string & name);
+  std::shared_ptr<Split> getSplit(const std::string & name);
 
   void zeroVectorForResidual(const std::string & vector_name);
 
@@ -318,7 +318,7 @@ public:
    * Sets a preconditioner
    * @param pc The preconditioner to be set
    */
-  void setPreconditioner(MooseSharedPointer<MoosePreconditioner> pc);
+  void setPreconditioner(std::shared_ptr<MoosePreconditioner> pc);
 
   /**
    * If called with true this system will use a finite differenced form of
@@ -412,7 +412,7 @@ public:
 
   unsigned int _num_residual_evaluations;
 
-  void setPredictor(MooseSharedPointer<Predictor> predictor);
+  void setPredictor(std::shared_ptr<Predictor> predictor);
   Predictor * getPredictor() { return _predictor.get(); }
 
   TimeIntegrator * getTimeIntegrator() { return _time_integrator.get(); }
@@ -526,7 +526,7 @@ protected:
   NumericVector<Number> & _residual_copy;
 
   /// Time integrator
-  MooseSharedPointer<TimeIntegrator> _time_integrator;
+  std::shared_ptr<TimeIntegrator> _time_integrator;
   /// solution vector for u^dot
   NumericVector<Number> & _u_dot;
   /// \f$ {du^dot}\over{du} \f$
@@ -586,7 +586,7 @@ protected:
   /// The difference of current and old solutions
   NumericVector<Number> & _sln_diff;
   /// Preconditioner
-  MooseSharedPointer<MoosePreconditioner> _preconditioner;
+  std::shared_ptr<MoosePreconditioner> _preconditioner;
   /// Preconditioning side
   Moose::PCSideType _pc_side;
 
@@ -633,7 +633,7 @@ protected:
   Real _final_residual;
 
   /// If predictor is active, this is non-NULL
-  MooseSharedPointer<Predictor> _predictor;
+  std::shared_ptr<Predictor> _predictor;
 
   bool _computing_initial_residual;
 

--- a/framework/include/base/ProjectMaterialProperties.h
+++ b/framework/include/base/ProjectMaterialProperties.h
@@ -32,8 +32,8 @@ class ProjectMaterialProperties : public ThreadedElementLoop<ConstElemPointerRan
 public:
   ProjectMaterialProperties(bool refine,
                             FEProblemBase & fe_problem, NonlinearSystemBase & sys,
-                            std::vector<std::shared_ptr<MaterialData> > & material_data,
-                            std::vector<std::shared_ptr<MaterialData> > & bnd_material_data,
+                            std::vector<std::shared_ptr<MaterialData>> & material_data,
+                            std::vector<std::shared_ptr<MaterialData>> & bnd_material_data,
                             MaterialPropertyStorage & material_props,
                             MaterialPropertyStorage & bnd_material_props,
                             std::vector<Assembly *> & assembly);
@@ -55,8 +55,8 @@ protected:
   bool _refine;
   FEProblemBase & _fe_problem;
   NonlinearSystemBase & _sys;
-  std::vector<std::shared_ptr<MaterialData> > & _material_data;
-  std::vector<std::shared_ptr<MaterialData> > & _bnd_material_data;
+  std::vector<std::shared_ptr<MaterialData>> & _material_data;
+  std::vector<std::shared_ptr<MaterialData>> & _bnd_material_data;
   MaterialPropertyStorage & _material_props;
   MaterialPropertyStorage & _bnd_material_props;
   std::vector<Assembly *> & _assembly;

--- a/framework/include/base/ProjectMaterialProperties.h
+++ b/framework/include/base/ProjectMaterialProperties.h
@@ -32,8 +32,8 @@ class ProjectMaterialProperties : public ThreadedElementLoop<ConstElemPointerRan
 public:
   ProjectMaterialProperties(bool refine,
                             FEProblemBase & fe_problem, NonlinearSystemBase & sys,
-                            std::vector<MooseSharedPointer<MaterialData> > & material_data,
-                            std::vector<MooseSharedPointer<MaterialData> > & bnd_material_data,
+                            std::vector<std::shared_ptr<MaterialData> > & material_data,
+                            std::vector<std::shared_ptr<MaterialData> > & bnd_material_data,
                             MaterialPropertyStorage & material_props,
                             MaterialPropertyStorage & bnd_material_props,
                             std::vector<Assembly *> & assembly);
@@ -55,8 +55,8 @@ protected:
   bool _refine;
   FEProblemBase & _fe_problem;
   NonlinearSystemBase & _sys;
-  std::vector<MooseSharedPointer<MaterialData> > & _material_data;
-  std::vector<MooseSharedPointer<MaterialData> > & _bnd_material_data;
+  std::vector<std::shared_ptr<MaterialData> > & _material_data;
+  std::vector<std::shared_ptr<MaterialData> > & _bnd_material_data;
   MaterialPropertyStorage & _material_props;
   MaterialPropertyStorage & _bnd_material_props;
   std::vector<Assembly *> & _assembly;

--- a/framework/include/base/XFEMInterface.h
+++ b/framework/include/base/XFEMInterface.h
@@ -85,7 +85,7 @@ public:
   /**
    * Set the pointer to the MaterialData
    */
-  void setMaterialData(std::vector<MooseSharedPointer<MaterialData> > * material_data)
+  void setMaterialData(std::vector<std::shared_ptr<MaterialData> > * material_data)
   {
     _material_data = material_data;
   }
@@ -93,7 +93,7 @@ public:
   /**
    * Set the pointer to the Boundary MaterialData
    */
-  void setBoundaryMaterialData(std::vector<MooseSharedPointer<MaterialData> > * bnd_material_data)
+  void setBoundaryMaterialData(std::vector<std::shared_ptr<MaterialData> > * bnd_material_data)
   {
     _bnd_material_data = bnd_material_data;
   }
@@ -116,8 +116,8 @@ public:
 
 protected:
   FEProblemBase * _fe_problem;
-  std::vector<MooseSharedPointer<MaterialData> > * _material_data;
-  std::vector<MooseSharedPointer<MaterialData> > * _bnd_material_data;
+  std::vector<std::shared_ptr<MaterialData> > * _material_data;
+  std::vector<std::shared_ptr<MaterialData> > * _bnd_material_data;
 
   MeshBase * _mesh;
   MeshBase * _mesh2;

--- a/framework/include/base/XFEMInterface.h
+++ b/framework/include/base/XFEMInterface.h
@@ -85,7 +85,7 @@ public:
   /**
    * Set the pointer to the MaterialData
    */
-  void setMaterialData(std::vector<std::shared_ptr<MaterialData> > * material_data)
+  void setMaterialData(std::vector<std::shared_ptr<MaterialData>> * material_data)
   {
     _material_data = material_data;
   }
@@ -93,7 +93,7 @@ public:
   /**
    * Set the pointer to the Boundary MaterialData
    */
-  void setBoundaryMaterialData(std::vector<std::shared_ptr<MaterialData> > * bnd_material_data)
+  void setBoundaryMaterialData(std::vector<std::shared_ptr<MaterialData>> * bnd_material_data)
   {
     _bnd_material_data = bnd_material_data;
   }
@@ -116,8 +116,8 @@ public:
 
 protected:
   FEProblemBase * _fe_problem;
-  std::vector<std::shared_ptr<MaterialData> > * _material_data;
-  std::vector<std::shared_ptr<MaterialData> > * _bnd_material_data;
+  std::vector<std::shared_ptr<MaterialData>> * _material_data;
+  std::vector<std::shared_ptr<MaterialData>> * _bnd_material_data;
 
   MeshBase * _mesh;
   MeshBase * _mesh2;

--- a/framework/include/constraints/ConstraintWarehouse.h
+++ b/framework/include/constraints/ConstraintWarehouse.h
@@ -35,19 +35,19 @@ public:
 
   /**
    * Add Constraint object to the warehouse.
-   * @param object A MooseSharedPointer of the object
+   * @param object A std::shared_ptr of the object
    * @param tid Not used.
    */
-  void addObject(MooseSharedPointer<Constraint> object, THREAD_ID tid = 0);
+  void addObject(std::shared_ptr<Constraint> object, THREAD_ID tid = 0);
 
   ///@{
   /**
    * Access methods for active objects.
    */
-  const std::vector<MooseSharedPointer<NodalConstraint> > & getActiveNodalConstraints() const;
-  const std::vector<MooseSharedPointer<FaceFaceConstraint> > & getActiveFaceFaceConstraints(const std::string & interface) const;
-  const std::vector<MooseSharedPointer<ElemElemConstraint> > & getActiveElemElemConstraints(InterfaceID interface_id) const;
-  const std::vector<MooseSharedPointer<NodeFaceConstraint> > & getActiveNodeFaceConstraints(BoundaryID boundary_id, bool displaced);
+  const std::vector<std::shared_ptr<NodalConstraint> > & getActiveNodalConstraints() const;
+  const std::vector<std::shared_ptr<FaceFaceConstraint> > & getActiveFaceFaceConstraints(const std::string & interface) const;
+  const std::vector<std::shared_ptr<ElemElemConstraint> > & getActiveElemElemConstraints(InterfaceID interface_id) const;
+  const std::vector<std::shared_ptr<NodeFaceConstraint> > & getActiveNodeFaceConstraints(BoundaryID boundary_id, bool displaced);
   ///@}
 
   ///@{

--- a/framework/include/constraints/ConstraintWarehouse.h
+++ b/framework/include/constraints/ConstraintWarehouse.h
@@ -44,10 +44,10 @@ public:
   /**
    * Access methods for active objects.
    */
-  const std::vector<std::shared_ptr<NodalConstraint> > & getActiveNodalConstraints() const;
-  const std::vector<std::shared_ptr<FaceFaceConstraint> > & getActiveFaceFaceConstraints(const std::string & interface) const;
-  const std::vector<std::shared_ptr<ElemElemConstraint> > & getActiveElemElemConstraints(InterfaceID interface_id) const;
-  const std::vector<std::shared_ptr<NodeFaceConstraint> > & getActiveNodeFaceConstraints(BoundaryID boundary_id, bool displaced);
+  const std::vector<std::shared_ptr<NodalConstraint>> & getActiveNodalConstraints() const;
+  const std::vector<std::shared_ptr<FaceFaceConstraint>> & getActiveFaceFaceConstraints(const std::string & interface) const;
+  const std::vector<std::shared_ptr<ElemElemConstraint>> & getActiveElemElemConstraints(InterfaceID interface_id) const;
+  const std::vector<std::shared_ptr<NodeFaceConstraint>> & getActiveNodeFaceConstraints(BoundaryID boundary_id, bool displaced);
   ///@}
 
   ///@{

--- a/framework/include/controls/ControllableParameter.h
+++ b/framework/include/controls/ControllableParameter.h
@@ -70,7 +70,7 @@ public:
    *
    * @see ControlInterface
    */
-  void insert(const MooseObjectParameterName & name, MooseSharedPointer<InputParameters> param_object);
+  void insert(const MooseObjectParameterName & name, std::shared_ptr<InputParameters> param_object);
 
 private:
 
@@ -89,7 +89,7 @@ ControllableParameter<T>::ControllableParameter()
 
 template<typename T>
 void
-ControllableParameter<T>::insert(const MooseObjectParameterName & name, MooseSharedPointer<InputParameters> param_object)
+ControllableParameter<T>::insert(const MooseObjectParameterName & name, std::shared_ptr<InputParameters> param_object)
 {
   // Get a pointer to the Parameter
   T* param_ptr = &param_object-> template set<T>(name.parameter());

--- a/framework/include/executioners/Transient.h
+++ b/framework/include/executioners/Transient.h
@@ -128,7 +128,7 @@ public:
    *
    * @param ts The TimeStepper to use
    */
-  void setTimeStepper(MooseSharedPointer<TimeStepper> ts) { _time_stepper = ts; }
+  void setTimeStepper(std::shared_ptr<TimeStepper> ts) { _time_stepper = ts; }
 
   /**
    * Get the timestepper.
@@ -216,7 +216,7 @@ protected:
   FEProblemBase & _problem;
 
   MooseEnum _time_scheme;
-  MooseSharedPointer<TimeStepper> _time_stepper;
+  std::shared_ptr<TimeStepper> _time_stepper;
 
   /// Current timestep.
   int & _t_step;

--- a/framework/include/geomsearch/GeometricSearchData.h
+++ b/framework/include/geomsearch/GeometricSearchData.h
@@ -58,7 +58,7 @@ public:
   NearestNodeLocator & getMortarNearestNodeLocator(const BoundaryName & domain, const BoundaryName & slave, Moose::ConstraintType side_type);
   NearestNodeLocator & getMortarNearestNodeLocator(const unsigned int master_id, const unsigned int slave_id, Moose::ConstraintType side_type);
 
-  void addElementPairLocator(const unsigned int & interface_id, MooseSharedPointer<ElementPairLocator> epl);
+  void addElementPairLocator(const unsigned int & interface_id, std::shared_ptr<ElementPairLocator> epl);
 
   /**
    * Update all of the search objects.
@@ -87,7 +87,7 @@ public:
   MooseMesh & _mesh;
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> _penetration_locators;
   std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *> _nearest_node_locators;
-  std::map<unsigned int, MooseSharedPointer<ElementPairLocator> > _element_pair_locators;
+  std::map<unsigned int, std::shared_ptr<ElementPairLocator> > _element_pair_locators;
 
 protected:
 

--- a/framework/include/geomsearch/GeometricSearchData.h
+++ b/framework/include/geomsearch/GeometricSearchData.h
@@ -87,7 +87,7 @@ public:
   MooseMesh & _mesh;
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> _penetration_locators;
   std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *> _nearest_node_locators;
-  std::map<unsigned int, std::shared_ptr<ElementPairLocator> > _element_pair_locators;
+  std::map<unsigned int, std::shared_ptr<ElementPairLocator>> _element_pair_locators;
 
 protected:
 

--- a/framework/include/ics/InitialConditionWarehouse.h
+++ b/framework/include/ics/InitialConditionWarehouse.h
@@ -35,7 +35,7 @@ public:
   /**
    * Add object to the warehouse.
    */
-  void addObject(MooseSharedPointer<InitialCondition> object, THREAD_ID tid);
+  void addObject(std::shared_ptr<InitialCondition> object, THREAD_ID tid);
 
 
 protected:

--- a/framework/include/kernels/KernelWarehouse.h
+++ b/framework/include/kernels/KernelWarehouse.h
@@ -36,14 +36,14 @@ public:
   /**
    * Add Kernel to the storage structure
    */
-  void addObject(MooseSharedPointer<KernelBase> object, THREAD_ID tid = 0) override;
+  void addObject(std::shared_ptr<KernelBase> object, THREAD_ID tid = 0) override;
 
   ///@{
   /**
    * Methods for checking/getting variable kernels for a variable and SubdomainID
    */
   bool hasActiveVariableBlockObjects(unsigned int variable_id, SubdomainID block_id, THREAD_ID tid = 0) const;
-  const std::vector<MooseSharedPointer<KernelBase> > & getActiveVariableBlockObjects(unsigned int variable_id, SubdomainID block_id, THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<KernelBase> > & getActiveVariableBlockObjects(unsigned int variable_id, SubdomainID block_id, THREAD_ID tid = 0) const;
   ///@}
 
   /**

--- a/framework/include/kernels/KernelWarehouse.h
+++ b/framework/include/kernels/KernelWarehouse.h
@@ -43,7 +43,7 @@ public:
    * Methods for checking/getting variable kernels for a variable and SubdomainID
    */
   bool hasActiveVariableBlockObjects(unsigned int variable_id, SubdomainID block_id, THREAD_ID tid = 0) const;
-  const std::vector<std::shared_ptr<KernelBase> > & getActiveVariableBlockObjects(unsigned int variable_id, SubdomainID block_id, THREAD_ID tid = 0) const;
+  const std::vector<std::shared_ptr<KernelBase>> & getActiveVariableBlockObjects(unsigned int variable_id, SubdomainID block_id, THREAD_ID tid = 0) const;
   ///@}
 
   /**

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -80,10 +80,10 @@ public:
   void swap(const Elem & elem, unsigned int side = 0);
 
   /// Reinit material properties for given element (and possible side)
-  void reinit(const std::vector<MooseSharedPointer<Material> > & mats);
+  void reinit(const std::vector<std::shared_ptr<Material> > & mats);
 
   /// Calls the reset method of Materials to ensure that they are in a proper state.
-  void reset(const std::vector<MooseSharedPointer<Material> > & mats);
+  void reset(const std::vector<std::shared_ptr<Material> > & mats);
 
   /// material properties for given element (and possible side)
   void swapBack(const Elem & elem, unsigned int side = 0);

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -80,10 +80,10 @@ public:
   void swap(const Elem & elem, unsigned int side = 0);
 
   /// Reinit material properties for given element (and possible side)
-  void reinit(const std::vector<std::shared_ptr<Material> > & mats);
+  void reinit(const std::vector<std::shared_ptr<Material>> & mats);
 
   /// Calls the reset method of Materials to ensure that they are in a proper state.
-  void reset(const std::vector<std::shared_ptr<Material> > & mats);
+  void reset(const std::vector<std::shared_ptr<Material>> & mats);
 
   /// material properties for given element (and possible side)
   void swapBack(const Elem & elem, unsigned int side = 0);

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -108,7 +108,8 @@ public:
    * @param elem Element we are on
    * @param side Side of the element 'elem' (0 for volumetric material properties)
    */
-  void initStatefulProps(MaterialData & material_data, const std::vector<std::shared_ptr<Material> > & mats, unsigned int n_qpoints, const Elem & elem, unsigned int side = 0);
+  void initStatefulProps(MaterialData & material_data, const std::vector<std::shared_ptr<Material>> & mats, unsigned int n_qpoints,
+                         const Elem & elem, unsigned int side = 0);
 
   /**
    * Shift the material properties in time.

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -108,7 +108,7 @@ public:
    * @param elem Element we are on
    * @param side Side of the element 'elem' (0 for volumetric material properties)
    */
-  void initStatefulProps(MaterialData & material_data, const std::vector<MooseSharedPointer<Material> > & mats, unsigned int n_qpoints, const Elem & elem, unsigned int side = 0);
+  void initStatefulProps(MaterialData & material_data, const std::vector<std::shared_ptr<Material> > & mats, unsigned int n_qpoints, const Elem & elem, unsigned int side = 0);
 
   /**
    * Shift the material properties in time.

--- a/framework/include/materials/MaterialWarehouse.h
+++ b/framework/include/materials/MaterialWarehouse.h
@@ -49,7 +49,7 @@ public:
   /**
    * A special method unique to this class for adding Block, Neighbor, and Face material objects.
    */
-  void addObjects(MooseSharedPointer<Material> block, MooseSharedPointer<Material> neighbor, MooseSharedPointer<Material> face, THREAD_ID tid = 0);
+  void addObjects(std::shared_ptr<Material> block, std::shared_ptr<Material> neighbor, std::shared_ptr<Material> face, THREAD_ID tid = 0);
 
 protected:
   /// Stroage for neighbor material objects (Block are stored in the base class)

--- a/framework/include/materials/TwoMaterialPropertyInterface.h
+++ b/framework/include/materials/TwoMaterialPropertyInterface.h
@@ -56,7 +56,7 @@ public:
   const MaterialProperty<T> & getNeighborMaterialPropertyOlder(const std::string & name);
 
 protected:
-  MooseSharedPointer<MaterialData> _neighbor_material_data;
+  std::shared_ptr<MaterialData> _neighbor_material_data;
 };
 
 

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -39,7 +39,7 @@ InputParameters validParams<MultiApp>();
 /**
  * Helper class for holding Sub-app backups
  */
-class SubAppBackups : public std::vector<MooseSharedPointer<Backup> >
+class SubAppBackups : public std::vector<std::shared_ptr<Backup> >
 {};
 
 /**

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -39,7 +39,7 @@ InputParameters validParams<MultiApp>();
 /**
  * Helper class for holding Sub-app backups
  */
-class SubAppBackups : public std::vector<std::shared_ptr<Backup> >
+class SubAppBackups : public std::vector<std::shared_ptr<Backup>>
 {};
 
 /**

--- a/framework/include/outputs/AdvancedOutput.h
+++ b/framework/include/outputs/AdvancedOutput.h
@@ -361,11 +361,11 @@ AdvancedOutput<T>::initPostprocessorOrVectorPostprocessorLists(const std::string
   bool has_limited_pps = false;
 
   // Loop through each of the execution flags
-  const std::vector<MooseSharedPointer<UserObject> > & objects = warehouse.getActiveObjects();
-  for (std::vector<MooseSharedPointer<UserObject> >::const_iterator it = objects.begin(); it != objects.end(); ++ it)
+  const std::vector<std::shared_ptr<UserObject> > & objects = warehouse.getActiveObjects();
+  for (std::vector<std::shared_ptr<UserObject> >::const_iterator it = objects.begin(); it != objects.end(); ++ it)
   {
     // Store the name in the available postprocessors, if it does not already exist in the list
-    MooseSharedPointer<postprocessor_type> pps = MooseSharedNamespace::dynamic_pointer_cast<postprocessor_type>(*it);
+    std::shared_ptr<postprocessor_type> pps = MooseSharedNamespace::dynamic_pointer_cast<postprocessor_type>(*it);
     if (!pps)
       continue;
 

--- a/framework/include/outputs/AdvancedOutput.h
+++ b/framework/include/outputs/AdvancedOutput.h
@@ -361,18 +361,18 @@ AdvancedOutput<T>::initPostprocessorOrVectorPostprocessorLists(const std::string
   bool has_limited_pps = false;
 
   // Loop through each of the execution flags
-  const std::vector<std::shared_ptr<UserObject> > & objects = warehouse.getActiveObjects();
-  for (std::vector<std::shared_ptr<UserObject> >::const_iterator it = objects.begin(); it != objects.end(); ++ it)
+  const auto & objects = warehouse.getActiveObjects();
+  for (const auto & object : objects)
   {
     // Store the name in the available postprocessors, if it does not already exist in the list
-    std::shared_ptr<postprocessor_type> pps = MooseSharedNamespace::dynamic_pointer_cast<postprocessor_type>(*it);
+    std::shared_ptr<postprocessor_type> pps = std::dynamic_pointer_cast<postprocessor_type>(object);
     if (!pps)
       continue;
 
     execute_data.available.insert(pps->PPName());
 
     // Extract the list of outputs
-    std::set<OutputName> pps_outputs = pps->getOutputs();
+    const auto & pps_outputs = pps->getOutputs();
 
     // Check that the outputs lists are valid
     T::_app.getOutputWarehouse().checkOutputs(pps_outputs);

--- a/framework/include/outputs/MaterialPropertyDebugOutput.h
+++ b/framework/include/outputs/MaterialPropertyDebugOutput.h
@@ -59,7 +59,7 @@ protected:
    * @param output The output stream to populate
    * @param materials Vector of pointers to the Material objects of interest
    */
-  void printMaterialProperties(std::stringstream & output, const std::vector<std::shared_ptr<Material> > & materials) const;
+  void printMaterialProperties(std::stringstream & output, const std::vector<std::shared_ptr<Material>> & materials) const;
 
 };
 

--- a/framework/include/outputs/MaterialPropertyDebugOutput.h
+++ b/framework/include/outputs/MaterialPropertyDebugOutput.h
@@ -59,7 +59,7 @@ protected:
    * @param output The output stream to populate
    * @param materials Vector of pointers to the Material objects of interest
    */
-  void printMaterialProperties(std::stringstream & output, const std::vector<MooseSharedPointer<Material> > & materials) const;
+  void printMaterialProperties(std::stringstream & output, const std::vector<std::shared_ptr<Material> > & materials) const;
 
 };
 

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -227,7 +227,7 @@ private:
    * We are using std::shared_ptr to handle the cleanup of the pointers at the end of execution.
    * This is necessary since several warehouses might be sharing a single instance of a MooseObject.
    */
-  std::vector<std::shared_ptr<Output> > _all_ptrs;
+  std::vector<std::shared_ptr<Output>> _all_ptrs;
 
   /**
    * Adds the file name to the list of filenames being output

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -46,7 +46,7 @@ public:
    * It is the responsibility of the OutputWarehouse to delete the output objects
    * add using this method
    */
-  void addOutput(MooseSharedPointer<Output> & output);
+  void addOutput(std::shared_ptr<Output> & output);
 
   /**
    * Get a complete set of all output object names
@@ -224,10 +224,10 @@ private:
   void forceOutput();
 
   /**
-   * We are using MooseSharedPointer to handle the cleanup of the pointers at the end of execution.
+   * We are using std::shared_ptr to handle the cleanup of the pointers at the end of execution.
    * This is necessary since several warehouses might be sharing a single instance of a MooseObject.
    */
-  std::vector<MooseSharedPointer<Output> > _all_ptrs;
+  std::vector<std::shared_ptr<Output> > _all_ptrs;
 
   /**
    * Adds the file name to the list of filenames being output

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -103,7 +103,7 @@ public:
    * This function checks to see if there are unidentified variables in the input file (i.e. unused)
    * If the warn_is_error is set, then the program will abort if unidentified parameters are found
    */
-  void checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_on_warn, bool in_input_file, MooseSharedPointer<FEProblemBase> fe_problem) const;
+  void checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_on_warn, bool in_input_file, std::shared_ptr<FEProblemBase> fe_problem) const;
 
   /**
    * This function checks to see if there were any overridden parameters in the input file.

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -63,7 +63,7 @@ inline void storeHelper(std::ostream & stream, std::vector<P> & data, void * con
  * Shared pointer helper routine
  */
 template<typename P>
-inline void storeHelper(std::ostream & stream, MooseSharedPointer<P> & data, void * context);
+inline void storeHelper(std::ostream & stream, std::shared_ptr<P> & data, void * context);
 
 /**
  * Unique pointer helper routine
@@ -111,7 +111,7 @@ inline void loadHelper(std::istream & stream, std::vector<P> & data, void * cont
  * Shared Pointer helper routine
  */
 template<typename P>
-inline void loadHelper(std::istream & stream, MooseSharedPointer<P> & data, void * context);
+inline void loadHelper(std::istream & stream, std::shared_ptr<P> & data, void * context);
 
 /**
  * Unique Pointer helper routine
@@ -193,7 +193,7 @@ dataStore(std::ostream & stream, std::vector<T> & v, void * context)
 
 template<typename T>
 inline void
-dataStore(std::ostream & stream, MooseSharedPointer<T> & v, void * context)
+dataStore(std::ostream & stream, std::shared_ptr<T> & v, void * context)
 {
   T * tmp = v.get();
 
@@ -364,7 +364,7 @@ dataLoad(std::istream & stream, std::vector<T> & v, void * context)
 
 template<typename T>
 inline void
-dataLoad(std::istream & stream, MooseSharedPointer<T> & v, void * context)
+dataLoad(std::istream & stream, std::shared_ptr<T> & v, void * context)
 {
   T * tmp = v.get();
 
@@ -503,10 +503,10 @@ storeHelper(std::ostream & stream, std::vector<P> & data, void * context)
   dataStore(stream, data, context);
 }
 
-// MooseSharedPointer Helper Function
+// std::shared_ptr Helper Function
 template<typename P>
 inline void
-storeHelper(std::ostream & stream, MooseSharedPointer<P> & data, void * context)
+storeHelper(std::ostream & stream, std::shared_ptr<P> & data, void * context)
 {
   dataStore(stream, data, context);
 }
@@ -567,10 +567,10 @@ loadHelper(std::istream & stream, std::vector<P> & data, void * context)
   dataLoad(stream, data, context);
 }
 
-// MooseSharedPointer Helper Function
+// std::shared_ptr Helper Function
 template<typename P>
 inline void
-loadHelper(std::istream & stream, MooseSharedPointer<P> & data, void * context)
+loadHelper(std::istream & stream, std::shared_ptr<P> & data, void * context)
 {
   dataLoad(stream, data, context);
 }

--- a/framework/include/restart/RestartableDataIO.h
+++ b/framework/include/restart/RestartableDataIO.h
@@ -59,12 +59,12 @@ public:
   /**
    * Create a Backup for the current system.
    */
-  MooseSharedPointer<Backup> createBackup();
+  std::shared_ptr<Backup> createBackup();
 
   /**
    * Restore a Backup for the current system.
    */
-  void restoreBackup(MooseSharedPointer<Backup> backup, bool for_restart = false);
+  void restoreBackup(std::shared_ptr<Backup> backup, bool for_restart = false);
 
 private:
   /**
@@ -91,7 +91,7 @@ private:
   FEProblemBase & _fe_problem;
 
   /// A vector of file handles, one per thread
-  std::vector<MooseSharedPointer<std::ifstream> > _in_file_handles;
+  std::vector<std::shared_ptr<std::ifstream> > _in_file_handles;
 };
 
 #endif /* RESTARTABLEDATAIO_H */

--- a/framework/include/restart/RestartableDataIO.h
+++ b/framework/include/restart/RestartableDataIO.h
@@ -91,7 +91,7 @@ private:
   FEProblemBase & _fe_problem;
 
   /// A vector of file handles, one per thread
-  std::vector<std::shared_ptr<std::ifstream> > _in_file_handles;
+  std::vector<std::shared_ptr<std::ifstream>> _in_file_handles;
 };
 
 #endif /* RESTARTABLEDATAIO_H */

--- a/framework/include/timeintegrators/AStableDirk4.h
+++ b/framework/include/timeintegrators/AStableDirk4.h
@@ -101,7 +101,7 @@ protected:
   bool _safe_start;
 
   // A pointer to the "bootstrapping" method to use if _safe_start==true.
-  MooseSharedPointer<LStableDirk4> _bootstrap_method;
+  std::shared_ptr<LStableDirk4> _bootstrap_method;
 };
 
 

--- a/framework/include/transfers/MultiAppTransfer.h
+++ b/framework/include/transfers/MultiAppTransfer.h
@@ -62,14 +62,14 @@ public:
   void variableIntegrityCheck(const AuxVariableName & var_name) const;
 
   /// Return the MultiApp that this transfer belongs to
-  const MooseSharedPointer<MultiApp> getMultiApp() const { return _multi_app; }
+  const std::shared_ptr<MultiApp> getMultiApp() const { return _multi_app; }
 
   /// Return the execution flags, handling "same_as_multiapp"
   virtual const std::vector<ExecFlagType> & execFlags() const;
 
 protected:
   /// The MultiApp this Transfer is transferring data to or from
-  MooseSharedPointer<MultiApp> _multi_app;
+  std::shared_ptr<MultiApp> _multi_app;
 
   /// Whether we're transferring to or from the MultiApp
   MooseEnum _direction;

--- a/framework/include/utils/FunctionParserUtils.h
+++ b/framework/include/utils/FunctionParserUtils.h
@@ -32,7 +32,7 @@ public:
   typedef FunctionParserADBase<Real> ADFunction;
 
   /// Shorthand for an smart pointer to an autodiff function parser object.
-  typedef MooseSharedPointer<ADFunction> ADFunctionPtr;
+  typedef std::shared_ptr<ADFunction> ADFunctionPtr;
 
   /// apply input paramters to internal feature flags of the parser object
   void setParserFeatureFlags(ADFunctionPtr &);

--- a/framework/include/utils/InputParameterWarehouse.h
+++ b/framework/include/utils/InputParameterWarehouse.h
@@ -60,7 +60,7 @@ public:
   /**
    * Return const reference to the map containing the InputParameter objects
    */
-  const std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> > & getInputParameters(THREAD_ID tid = 0) const;
+  const std::multimap<MooseObjectName, std::shared_ptr<InputParameters> > & getInputParameters(THREAD_ID tid = 0) const;
 
   /**
    * Returns a ControllableParameter object
@@ -78,13 +78,13 @@ public:
 private:
 
   /// Storage for the InputParameters objects
-  std::vector<std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> > > _input_parameters;
+  std::vector<std::multimap<MooseObjectName, std::shared_ptr<InputParameters> > > _input_parameters;
 
   /// InputParameter links
   std::map<MooseObjectParameterName, std::vector<MooseObjectParameterName> > _input_parameter_links;
 
   /// A list of parameters that were controlled (only used for output)
-  std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectParameterName> > _controlled_parameters;
+  std::map<std::shared_ptr<InputParameters>, std::set<MooseObjectParameterName> > _controlled_parameters;
 
   /**
    * Method for adding a new InputParameters object
@@ -122,7 +122,7 @@ private:
    * Return the list of controlled parameters (used for output)
    * @see ControlOutput
    */
-  const std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectParameterName> > & getControlledParameters() { return _controlled_parameters; }
+  const std::map<std::shared_ptr<InputParameters>, std::set<MooseObjectParameterName> > & getControlledParameters() { return _controlled_parameters; }
   void clearControlledParameters() { _controlled_parameters.clear(); }
 
   friend class Factory;
@@ -150,7 +150,7 @@ InputParameterWarehouse::getControllableParameter(const MooseObjectParameterName
     params.insert(params.end(), link_it->second.begin(), link_it->second.end());
 
   // Parameter object iterator
-  std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> >::const_iterator iter;
+  std::multimap<MooseObjectName, std::shared_ptr<InputParameters> >::const_iterator iter;
 
   // Loop over all threads
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -30,11 +30,11 @@
 
 #ifdef LIBMESH_HAVE_CXX11_SHARED_PTR
 #  include <memory>
-#  define MooseSharedPointer std::shared_ptr
+#  define std::shared_ptr std::shared_ptr
 #  define MooseSharedNamespace std
 #else
 #  include "boost/shared_ptr.hpp"
-#  define MooseSharedPointer boost::shared_ptr
+#  define std::shared_ptr boost::shared_ptr
 #  define MooseSharedNamespace boost
 #endif
 

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -27,16 +27,11 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
-#ifdef LIBMESH_HAVE_CXX11_SHARED_PTR
-#  include <memory>
-#  define std::shared_ptr std::shared_ptr
-#  define MooseSharedNamespace std
-#else
-#  include "boost/shared_ptr.hpp"
-#  define std::shared_ptr boost::shared_ptr
-#  define MooseSharedNamespace boost
-#endif
+// DO NOT USE (Deprecated)
+#define MooseSharedPointer std::shared_ptr
+#define MooseSharedNamespace std
 
 /**
  * Macro for inferring the proper type of a normal loop index compatible

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -27,7 +27,7 @@ ActionFactory::~ActionFactory()
 {
 }
 
-MooseSharedPointer<Action>
+std::shared_ptr<Action>
 ActionFactory::create(const std::string & action, const std::string & action_name, InputParameters parameters)
 {
   parameters.addPrivateParam("_moose_app", &_app);
@@ -61,7 +61,7 @@ ActionFactory::create(const std::string & action, const std::string & action_nam
 
   // Add the name to the parameters and create the object
   parameters.set<std::string>("_action_name") = action_name;
-  MooseSharedPointer<Action> action_obj = (*build_info->_build_pointer)(parameters);
+  std::shared_ptr<Action> action_obj = (*build_info->_build_pointer)(parameters);
 
   if (parameters.get<std::string>("task") == "")
     action_obj->appendTask(build_info->_task);

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -67,7 +67,7 @@ ActionWarehouse::clear()
 }
 
 void
-ActionWarehouse::addActionBlock(MooseSharedPointer<Action> action)
+ActionWarehouse::addActionBlock(std::shared_ptr<Action> action)
 {
   /**
    * Note: This routine uses the XTerm colors directly which is not advised for general purpose output coloring.
@@ -123,7 +123,7 @@ ActionWarehouse::addActionBlock(MooseSharedPointer<Action> action)
 
     // Make sure that the ObjectAction task and Action task are consistent
     // otherwise that means that is action was built by the wrong type
-    MooseSharedPointer<MooseObjectAction> moa = MooseSharedNamespace::dynamic_pointer_cast<MooseObjectAction>(action);
+    std::shared_ptr<MooseObjectAction> moa = MooseSharedNamespace::dynamic_pointer_cast<MooseObjectAction>(action);
     if (moa.get())
     {
       const InputParameters & mparams = moa->getObjectParams();
@@ -370,7 +370,7 @@ ActionWarehouse::printInputFile(std::ostream & out)
   out << tree.print("");
 }
 
-MooseSharedPointer<FEProblem>
+std::shared_ptr<FEProblem>
 ActionWarehouse::problem()
 {
   mooseDeprecated("ActionWarehouse::problem() is deprecated, please use ActionWarehouse::problemBase() \n");

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -123,7 +123,7 @@ ActionWarehouse::addActionBlock(std::shared_ptr<Action> action)
 
     // Make sure that the ObjectAction task and Action task are consistent
     // otherwise that means that is action was built by the wrong type
-    std::shared_ptr<MooseObjectAction> moa = MooseSharedNamespace::dynamic_pointer_cast<MooseObjectAction>(action);
+    std::shared_ptr<MooseObjectAction> moa = std::dynamic_pointer_cast<MooseObjectAction>(action);
     if (moa.get())
     {
       const InputParameters & mparams = moa->getObjectParams();

--- a/framework/src/actions/AddControlAction.C
+++ b/framework/src/actions/AddControlAction.C
@@ -34,6 +34,6 @@ void
 AddControlAction::act()
 {
   _moose_object_pars.addPrivateParam<FEProblemBase *>("_fe_problem_base", _problem.get());
-  MooseSharedPointer<Control> control = _factory.create<Control>(_type, _name, _moose_object_pars);
+  std::shared_ptr<Control> control = _factory.create<Control>(_type, _name, _moose_object_pars);
   _problem->getControlWarehouse().addObject(control);
 }

--- a/framework/src/actions/AddOutputAction.C
+++ b/framework/src/actions/AddOutputAction.C
@@ -88,6 +88,6 @@ AddOutputAction::act()
     _moose_object_pars.set<std::string>("suffix") = "auto_recovery";
 
   // Create the object and add it to the warehouse
-  MooseSharedPointer<Output> output = _factory.create<Output>(_type, _name, _moose_object_pars);
+  std::shared_ptr<Output> output = _factory.create<Output>(_type, _name, _moose_object_pars);
   output_warehouse.addOutput(output);
 }

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -113,7 +113,7 @@ AddVariableAction::createInitialConditionAction()
     action_params.set<std::string>("type") = "ConstantIC";
 
   // Create the action
-  MooseSharedPointer<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddInitialConditionAction", long_name, action_params));
+  std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddInitialConditionAction", long_name, action_params));
 
   // Set the required parameters for the object to be created
   action->getObjectParams().set<VariableName>("variable") = var_name;

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -113,7 +113,7 @@ AddVariableAction::createInitialConditionAction()
     action_params.set<std::string>("type") = "ConstantIC";
 
   // Create the action
-  std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddInitialConditionAction", long_name, action_params));
+  std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddInitialConditionAction", long_name, action_params));
 
   // Set the required parameters for the object to be created
   action->getObjectParams().set<VariableName>("variable") = var_name;

--- a/framework/src/actions/CheckOutputAction.C
+++ b/framework/src/actions/CheckOutputAction.C
@@ -77,7 +77,7 @@ CheckOutputAction::checkMaterialOutput()
     return;
 
   // A complete list of all Material objects
-  const std::vector<std::shared_ptr<Material> > & materials = _problem->getMaterialWarehouse().getActiveObjects();
+  const auto & materials = _problem->getMaterialWarehouse().getActiveObjects();
 
   // TODO include boundary materials
 

--- a/framework/src/actions/CheckOutputAction.C
+++ b/framework/src/actions/CheckOutputAction.C
@@ -77,7 +77,7 @@ CheckOutputAction::checkMaterialOutput()
     return;
 
   // A complete list of all Material objects
-  const std::vector<MooseSharedPointer<Material> > & materials = _problem->getMaterialWarehouse().getActiveObjects();
+  const std::vector<std::shared_ptr<Material> > & materials = _problem->getMaterialWarehouse().getActiveObjects();
 
   // TODO include boundary materials
 

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -163,7 +163,7 @@ CommonOutputAction::create(std::string object_type)
   std::transform(object_type.begin(), object_type.end(), object_type.begin(), ::tolower);
 
   // Create the action
-  MooseSharedPointer<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddOutputAction", object_type, _action_params));
+  std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddOutputAction", object_type, _action_params));
 
   // Set flag indicating that the object to be created was created with short-cut syntax
   action->getObjectParams().set<bool>("_built_by_moose") = true;

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -163,7 +163,7 @@ CommonOutputAction::create(std::string object_type)
   std::transform(object_type.begin(), object_type.end(), object_type.begin(), ::tolower);
 
   // Create the action
-  std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddOutputAction", object_type, _action_params));
+  std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddOutputAction", object_type, _action_params));
 
   // Set flag indicating that the object to be created was created with short-cut syntax
   action->getObjectParams().set<bool>("_built_by_moose") = true;

--- a/framework/src/actions/CreateDisplacedProblemAction.C
+++ b/framework/src/actions/CreateDisplacedProblemAction.C
@@ -46,7 +46,7 @@ CreateDisplacedProblemAction::act()
     object_params.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
 
     // Create the object
-    MooseSharedPointer<DisplacedProblem> disp_problem = _factory.create<DisplacedProblem>("DisplacedProblem", "DisplacedProblem", object_params);
+    std::shared_ptr<DisplacedProblem> disp_problem = _factory.create<DisplacedProblem>("DisplacedProblem", "DisplacedProblem", object_params);
 
     // Add the Displaced Problem to FEProblemBase
     _problem->addDisplacedProblem(disp_problem);

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -37,7 +37,7 @@ CreateExecutionerAction::act()
 {
   _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
   _moose_object_pars.set<FEProblem *>("_fe_problem") = (std::dynamic_pointer_cast<FEProblem>(_problem)).get();
-  MooseSharedPointer<Executioner> executioner = _factory.create<Executioner>(_type, "Executioner", _moose_object_pars);
+  std::shared_ptr<Executioner> executioner = _factory.create<Executioner>(_type, "Executioner", _moose_object_pars);
 
   _app.executioner() = executioner;
 }

--- a/framework/src/actions/MaterialOutputAction.C
+++ b/framework/src/actions/MaterialOutputAction.C
@@ -21,13 +21,13 @@
 
 // Declare the output helper specializations
 template<>
-void MaterialOutputAction::materialOutputHelper<Real>(const std::string & material_name, MooseSharedPointer<Material> material);
+void MaterialOutputAction::materialOutputHelper<Real>(const std::string & material_name, std::shared_ptr<Material> material);
 
 template<>
-void MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & material_name, MooseSharedPointer<Material> material);
+void MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & material_name, std::shared_ptr<Material> material);
 
 template<>
-void MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & material_name, MooseSharedPointer<Material> material);
+void MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & material_name, std::shared_ptr<Material> material);
 
 
 template<>
@@ -65,7 +65,7 @@ MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
   _boundary_material_data = problem_ptr->getMaterialData(Moose::BOUNDARY_MATERIAL_DATA);
 
   // A complete list of all Material objects
-  const std::vector<MooseSharedPointer<Material> > & materials = problem_ptr->getMaterialWarehouse().getObjects();
+  const std::vector<std::shared_ptr<Material> > & materials = problem_ptr->getMaterialWarehouse().getObjects();
 
   // Handle setting of material property output in [Outputs] sub-blocks
   // Output objects can enable material property output, the following code examines the parameters
@@ -162,9 +162,9 @@ MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
   }
 }
 
-MooseSharedPointer<MooseObjectAction>
+std::shared_ptr<MooseObjectAction>
 MaterialOutputAction::createAction(const std::string & type, const std::string & property_name,
-                                   const std::string & variable_name, MooseSharedPointer<Material> material)
+                                   const std::string & variable_name, std::shared_ptr<Material> material)
 {
   // Append the list of variables to create
   _variable_names.insert(variable_name);
@@ -183,7 +183,7 @@ MaterialOutputAction::createAction(const std::string & type, const std::string &
   action_params.set<std::string>("task") = "add_aux_kernel";
 
   // Create the action
-  MooseSharedPointer<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddKernelAction", name.str(), action_params));
+  std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddKernelAction", name.str(), action_params));
 
   // Set the object parameters
   InputParameters & object_params = action->getObjectParams();
@@ -202,14 +202,14 @@ MaterialOutputAction::createAction(const std::string & type, const std::string &
 
 template<>
 void
-MaterialOutputAction::materialOutputHelper<Real>(const std::string & property_name, MooseSharedPointer<Material> material)
+MaterialOutputAction::materialOutputHelper<Real>(const std::string & property_name, std::shared_ptr<Material> material)
 {
   _awh.addActionBlock(createAction("MaterialRealAux", property_name, property_name, material));
 }
 
 template<>
 void
-MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & property_name, MooseSharedPointer<Material> material)
+MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & property_name, std::shared_ptr<Material> material)
 {
   char suffix[3] = {'x','y','z'};
 
@@ -218,7 +218,7 @@ MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & 
     std::ostringstream oss;
     oss << property_name << "_" << suffix[i];
 
-    MooseSharedPointer<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(createAction("MaterialRealVectorValueAux", property_name, oss.str(), material));
+    std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(createAction("MaterialRealVectorValueAux", property_name, oss.str(), material));
     action->getObjectParams().set<unsigned int>("component") = i;
     _awh.addActionBlock(action);
   }
@@ -227,7 +227,7 @@ MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & 
 
 template<>
 void
-MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & property_name, MooseSharedPointer<Material> material)
+MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & property_name, std::shared_ptr<Material> material)
 {
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
@@ -235,7 +235,7 @@ MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & 
       std::ostringstream oss;
       oss << property_name << "_" << i << j;
 
-      MooseSharedPointer<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(createAction("MaterialRealTensorValueAux", property_name, oss.str(), material));
+      std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(createAction("MaterialRealTensorValueAux", property_name, oss.str(), material));
       action->getObjectParams().set<unsigned int>("row") = i;
       action->getObjectParams().set<unsigned int>("column") = j;
       _awh.addActionBlock(action);

--- a/framework/src/actions/MaterialOutputAction.C
+++ b/framework/src/actions/MaterialOutputAction.C
@@ -183,7 +183,7 @@ MaterialOutputAction::createAction(const std::string & type, const std::string &
   action_params.set<std::string>("task") = "add_aux_kernel";
 
   // Create the action
-  std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddKernelAction", name.str(), action_params));
+  std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddKernelAction", name.str(), action_params));
 
   // Set the object parameters
   InputParameters & object_params = action->getObjectParams();
@@ -218,7 +218,7 @@ MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & 
     std::ostringstream oss;
     oss << property_name << "_" << suffix[i];
 
-    std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(createAction("MaterialRealVectorValueAux", property_name, oss.str(), material));
+    std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(createAction("MaterialRealVectorValueAux", property_name, oss.str(), material));
     action->getObjectParams().set<unsigned int>("component") = i;
     _awh.addActionBlock(action);
   }
@@ -235,7 +235,7 @@ MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & 
       std::ostringstream oss;
       oss << property_name << "_" << i << j;
 
-      std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(createAction("MaterialRealTensorValueAux", property_name, oss.str(), material));
+      std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(createAction("MaterialRealTensorValueAux", property_name, oss.str(), material));
       action->getObjectParams().set<unsigned int>("row") = i;
       action->getObjectParams().set<unsigned int>("column") = j;
       _awh.addActionBlock(action);

--- a/framework/src/actions/PartitionerAction.C
+++ b/framework/src/actions/PartitionerAction.C
@@ -35,7 +35,7 @@ void
 PartitionerAction::act()
 {
   _mesh->setIsCustomPartitionerRequested(true);
-  MooseSharedPointer<MoosePartitioner> mp = _factory.create<MoosePartitioner>(_type, _name, _moose_object_pars);
+  std::shared_ptr<MoosePartitioner> mp = _factory.create<MoosePartitioner>(_type, _name, _moose_object_pars);
   _mesh->setCustomPartitioner(mp.get());
   if (_displaced_mesh)
   {

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -71,7 +71,7 @@ SetupDebugAction::createOutputAction(const std::string & type, const std::string
   _action_params.set<std::string>("type") = type;
 
   // Create the action
-  std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddOutputAction", name, _action_params));
+  std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddOutputAction", name, _action_params));
 
   // Set the object parameters
   InputParameters & object_params = action->getObjectParams();

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -71,7 +71,7 @@ SetupDebugAction::createOutputAction(const std::string & type, const std::string
   _action_params.set<std::string>("type") = type;
 
   // Create the action
-  MooseSharedPointer<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddOutputAction", name, _action_params));
+  std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddOutputAction", name, _action_params));
 
   // Set the object parameters
   InputParameters & object_params = action->getObjectParams();

--- a/framework/src/actions/SetupPreconditionerAction.C
+++ b/framework/src/actions/SetupPreconditionerAction.C
@@ -43,7 +43,7 @@ SetupPreconditionerAction::act()
   {
     // build the preconditioner
     _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
-    MooseSharedPointer<MoosePreconditioner> pc = _factory.create<MoosePreconditioner>(_type, _name, _moose_object_pars);
+    std::shared_ptr<MoosePreconditioner> pc = _factory.create<MoosePreconditioner>(_type, _name, _moose_object_pars);
 
     _problem->getNonlinearSystemBase().setPreconditioner(pc);
 

--- a/framework/src/actions/SetupPredictorAction.C
+++ b/framework/src/actions/SetupPredictorAction.C
@@ -43,7 +43,7 @@ SetupPredictorAction::act()
 
     _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
     _moose_object_pars.set<Transient *>("_executioner") = transient;
-    MooseSharedPointer<Predictor> predictor = _factory.create<Predictor>(_type, "Predictor", _moose_object_pars);
+    std::shared_ptr<Predictor> predictor = _factory.create<Predictor>(_type, "Predictor", _moose_object_pars);
     _problem->getNonlinearSystemBase().setPredictor(predictor);
   }
 }

--- a/framework/src/actions/SetupTimeStepperAction.C
+++ b/framework/src/actions/SetupTimeStepperAction.C
@@ -41,7 +41,7 @@ SetupTimeStepperAction::act()
 
     _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
     _moose_object_pars.set<Transient *>("_executioner") = transient;
-    MooseSharedPointer<TimeStepper> ts = _factory.create<TimeStepper>(_type, "TimeStepper", _moose_object_pars);
+    std::shared_ptr<TimeStepper> ts = _factory.create<TimeStepper>(_type, "TimeStepper", _moose_object_pars);
     transient->setTimeStepper(ts);
   }
 }

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -29,12 +29,12 @@ AppFactory::~AppFactory()
 MooseApp *
 AppFactory::createApp(std::string app_type, int argc, char ** argv)
 {
-  std::shared_ptr<CommandLine> command_line(new CommandLine(argc, argv));
+  auto command_line = std::make_shared<CommandLine>(argc, argv);
   InputParameters app_params = AppFactory::instance().getValidParams(app_type);
 
   app_params.set<int>("_argc") = argc;
   app_params.set<char**>("_argv") = argv;
-  app_params.set<std::shared_ptr<CommandLine> >("_command_line") = command_line;
+  app_params.set<std::shared_ptr<CommandLine>>("_command_line") = command_line;
 
   MooseApp * app = AppFactory::instance().create(app_type, "main", app_params, MPI_COMM_WORLD);
   return app;
@@ -63,15 +63,15 @@ AppFactory::create(const std::string & app_type, const std::string & name, Input
   // Check to make sure that all required parameters are supplied
   parameters.checkParams("");
 
-  std::shared_ptr<Parallel::Communicator> comm(new Parallel::Communicator(COMM_WORLD_IN));
+  auto comm = std::make_shared<Parallel::Communicator>(COMM_WORLD_IN);
 
-  parameters.set<std::shared_ptr<Parallel::Communicator> >("_comm") = comm;
+  parameters.set<std::shared_ptr<Parallel::Communicator>>("_comm") = comm;
   parameters.set<std::string>("_app_name") = name;
 
   if (!parameters.isParamValid("_command_line"))
     mooseError("Valid CommandLine object required");
 
-  std::shared_ptr<CommandLine> command_line = parameters.get<std::shared_ptr<CommandLine> >("_command_line");
+  std::shared_ptr<CommandLine> command_line = parameters.get<std::shared_ptr<CommandLine>>("_command_line");
   command_line->addCommandLineOptionsFromParams(parameters);
   command_line->populateInputParams(parameters);
 

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -29,12 +29,12 @@ AppFactory::~AppFactory()
 MooseApp *
 AppFactory::createApp(std::string app_type, int argc, char ** argv)
 {
-  MooseSharedPointer<CommandLine> command_line(new CommandLine(argc, argv));
+  std::shared_ptr<CommandLine> command_line(new CommandLine(argc, argv));
   InputParameters app_params = AppFactory::instance().getValidParams(app_type);
 
   app_params.set<int>("_argc") = argc;
   app_params.set<char**>("_argv") = argv;
-  app_params.set<MooseSharedPointer<CommandLine> >("_command_line") = command_line;
+  app_params.set<std::shared_ptr<CommandLine> >("_command_line") = command_line;
 
   MooseApp * app = AppFactory::instance().create(app_type, "main", app_params, MPI_COMM_WORLD);
   return app;
@@ -63,15 +63,15 @@ AppFactory::create(const std::string & app_type, const std::string & name, Input
   // Check to make sure that all required parameters are supplied
   parameters.checkParams("");
 
-  MooseSharedPointer<Parallel::Communicator> comm(new Parallel::Communicator(COMM_WORLD_IN));
+  std::shared_ptr<Parallel::Communicator> comm(new Parallel::Communicator(COMM_WORLD_IN));
 
-  parameters.set<MooseSharedPointer<Parallel::Communicator> >("_comm") = comm;
+  parameters.set<std::shared_ptr<Parallel::Communicator> >("_comm") = comm;
   parameters.set<std::string>("_app_name") = name;
 
   if (!parameters.isParamValid("_command_line"))
     mooseError("Valid CommandLine object required");
 
-  MooseSharedPointer<CommandLine> command_line = parameters.get<MooseSharedPointer<CommandLine> >("_command_line");
+  std::shared_ptr<CommandLine> command_line = parameters.get<std::shared_ptr<CommandLine> >("_command_line");
   command_line->addCommandLineOptionsFromParams(parameters);
   command_line->populateInputParams(parameters);
 

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -156,7 +156,7 @@ AuxiliarySystem::addKernel(const std::string & kernel_name, const std::string & 
 
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
-    MooseSharedPointer<AuxKernel> kernel = _factory.create<AuxKernel>(kernel_name, name, parameters, tid);
+    std::shared_ptr<AuxKernel> kernel = _factory.create<AuxKernel>(kernel_name, name, parameters, tid);
     if (kernel->isNodal())
       _nodal_aux_storage.addObject(kernel, tid);
     else
@@ -169,7 +169,7 @@ AuxiliarySystem::addScalarKernel(const std::string & kernel_name, const std::str
 {
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
-    MooseSharedPointer<AuxScalarKernel> kernel = _factory.create<AuxScalarKernel>(kernel_name, name, parameters, tid);
+    std::shared_ptr<AuxScalarKernel> kernel = _factory.create<AuxScalarKernel>(kernel_name, name, parameters, tid);
     _aux_scalar_storage.addObject(kernel, tid);
   }
 }
@@ -285,7 +285,7 @@ AuxiliarySystem::getDependObjects(ExecFlagType type)
 
   // Elemental AuxKernels
   {
-    const std::vector<MooseSharedPointer<AuxKernel> > & auxs = _elemental_aux_storage[type].getActiveObjects();
+    const std::vector<std::shared_ptr<AuxKernel> > & auxs = _elemental_aux_storage[type].getActiveObjects();
     for (const auto & aux : auxs)
     {
       const std::set<std::string> & uo = aux->getDependObjects();
@@ -295,7 +295,7 @@ AuxiliarySystem::getDependObjects(ExecFlagType type)
 
   // Nodal AuxKernels
   {
-    const std::vector<MooseSharedPointer<AuxKernel> > & auxs = _nodal_aux_storage[type].getActiveObjects();
+    const std::vector<std::shared_ptr<AuxKernel> > & auxs = _nodal_aux_storage[type].getActiveObjects();
     for (const auto & aux : auxs)
     {
       const std::set<std::string> & uo = aux->getDependObjects();
@@ -313,7 +313,7 @@ AuxiliarySystem::getDependObjects()
 
   // Elemental AuxKernels
   {
-    const std::vector<MooseSharedPointer<AuxKernel> > & auxs = _elemental_aux_storage.getActiveObjects();
+    const std::vector<std::shared_ptr<AuxKernel> > & auxs = _elemental_aux_storage.getActiveObjects();
     for (const auto & aux : auxs)
     {
       const std::set<std::string> & uo = aux->getDependObjects();
@@ -323,7 +323,7 @@ AuxiliarySystem::getDependObjects()
 
   // Nodal AuxKernels
   {
-    const std::vector<MooseSharedPointer<AuxKernel> > & auxs = _nodal_aux_storage.getActiveObjects();
+    const std::vector<std::shared_ptr<AuxKernel> > & auxs = _nodal_aux_storage.getActiveObjects();
     for (const auto & aux : auxs)
     {
       const std::set<std::string> & uo = aux->getDependObjects();
@@ -366,7 +366,7 @@ AuxiliarySystem::computeScalarVars(ExecFlagType type)
         _fe_problem.reinitScalars(tid);
 
         // Call compute() method on all active AuxScalarKernel objects
-        const std::vector<MooseSharedPointer<AuxScalarKernel> > & objects = storage.getActiveObjects(tid);
+        const std::vector<std::shared_ptr<AuxScalarKernel> > & objects = storage.getActiveObjects(tid);
         for (const auto & obj : objects)
           obj->compute();
 

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -285,7 +285,7 @@ AuxiliarySystem::getDependObjects(ExecFlagType type)
 
   // Elemental AuxKernels
   {
-    const std::vector<std::shared_ptr<AuxKernel> > & auxs = _elemental_aux_storage[type].getActiveObjects();
+    const std::vector<std::shared_ptr<AuxKernel>> & auxs = _elemental_aux_storage[type].getActiveObjects();
     for (const auto & aux : auxs)
     {
       const std::set<std::string> & uo = aux->getDependObjects();
@@ -295,7 +295,7 @@ AuxiliarySystem::getDependObjects(ExecFlagType type)
 
   // Nodal AuxKernels
   {
-    const std::vector<std::shared_ptr<AuxKernel> > & auxs = _nodal_aux_storage[type].getActiveObjects();
+    const std::vector<std::shared_ptr<AuxKernel>> & auxs = _nodal_aux_storage[type].getActiveObjects();
     for (const auto & aux : auxs)
     {
       const std::set<std::string> & uo = aux->getDependObjects();
@@ -313,7 +313,7 @@ AuxiliarySystem::getDependObjects()
 
   // Elemental AuxKernels
   {
-    const std::vector<std::shared_ptr<AuxKernel> > & auxs = _elemental_aux_storage.getActiveObjects();
+    const std::vector<std::shared_ptr<AuxKernel>> & auxs = _elemental_aux_storage.getActiveObjects();
     for (const auto & aux : auxs)
     {
       const std::set<std::string> & uo = aux->getDependObjects();
@@ -323,7 +323,7 @@ AuxiliarySystem::getDependObjects()
 
   // Nodal AuxKernels
   {
-    const std::vector<std::shared_ptr<AuxKernel> > & auxs = _nodal_aux_storage.getActiveObjects();
+    const std::vector<std::shared_ptr<AuxKernel>> & auxs = _nodal_aux_storage.getActiveObjects();
     for (const auto & aux : auxs)
     {
       const std::set<std::string> & uo = aux->getDependObjects();
@@ -366,7 +366,7 @@ AuxiliarySystem::computeScalarVars(ExecFlagType type)
         _fe_problem.reinitScalars(tid);
 
         // Call compute() method on all active AuxScalarKernel objects
-        const std::vector<std::shared_ptr<AuxScalarKernel> > & objects = storage.getActiveObjects(tid);
+        const std::vector<std::shared_ptr<AuxScalarKernel>> & objects = storage.getActiveObjects(tid);
         for (const auto & obj : objects)
           obj->compute();
 

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -311,7 +311,7 @@ BlockRestrictable::hasBlockMaterialPropertyHelper(const std::string & prop_name)
     // If block materials exist, populated the set of properties that were declared
     if (warehouse.hasActiveBlockObjects(id))
     {
-      const std::vector<std::shared_ptr<Material> > & mats = warehouse.getActiveBlockObjects(id);
+      const std::vector<std::shared_ptr<Material>> & mats = warehouse.getActiveBlockObjects(id);
       for (const auto & mat : mats)
       {
         const std::set<std::string> & mat_props = mat->getSuppliedItems();

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -311,7 +311,7 @@ BlockRestrictable::hasBlockMaterialPropertyHelper(const std::string & prop_name)
     // If block materials exist, populated the set of properties that were declared
     if (warehouse.hasActiveBlockObjects(id))
     {
-      const std::vector<MooseSharedPointer<Material> > & mats = warehouse.getActiveBlockObjects(id);
+      const std::vector<std::shared_ptr<Material> > & mats = warehouse.getActiveBlockObjects(id);
       for (const auto & mat : mats)
       {
         const std::set<std::string> & mat_props = mat->getSuppliedItems();

--- a/framework/src/base/BoundaryRestrictable.C
+++ b/framework/src/base/BoundaryRestrictable.C
@@ -268,7 +268,7 @@ BoundaryRestrictable::hasBoundaryMaterialPropertyHelper(const std::string & prop
     // If boundary materials exist, populated the set of properties that were declared
     if (warehouse.hasActiveBoundaryObjects(id))
     {
-      const std::vector<std::shared_ptr<Material> > & mats = warehouse.getActiveBoundaryObjects(id);
+      const std::vector<std::shared_ptr<Material>> & mats = warehouse.getActiveBoundaryObjects(id);
       for (const auto & mat : mats)
       {
         const std::set<std::string> & mat_props = mat->getSuppliedItems();

--- a/framework/src/base/BoundaryRestrictable.C
+++ b/framework/src/base/BoundaryRestrictable.C
@@ -268,7 +268,7 @@ BoundaryRestrictable::hasBoundaryMaterialPropertyHelper(const std::string & prop
     // If boundary materials exist, populated the set of properties that were declared
     if (warehouse.hasActiveBoundaryObjects(id))
     {
-      const std::vector<MooseSharedPointer<Material> > & mats = warehouse.getActiveBoundaryObjects(id);
+      const std::vector<std::shared_ptr<Material> > & mats = warehouse.getActiveBoundaryObjects(id);
       for (const auto & mat : mats)
       {
         const std::set<std::string> & mat_props = mat->getSuppliedItems();

--- a/framework/src/base/ComputeBoundaryInitialConditionThread.C
+++ b/framework/src/base/ComputeBoundaryInitialConditionThread.C
@@ -40,7 +40,7 @@ ComputeBoundaryInitialConditionThread::onNode(ConstBndNodeRange::const_iterator 
 
   if (warehouse.hasActiveBoundaryObjects(boundary_id, _tid))
   {
-    const std::vector<MooseSharedPointer<InitialCondition> > & ics = warehouse.getActiveBoundaryObjects(boundary_id, _tid);
+    const std::vector<std::shared_ptr<InitialCondition> > & ics = warehouse.getActiveBoundaryObjects(boundary_id, _tid);
     for (const auto & ic : ics)
     {
       if (node->processor_id() == _fe_problem.processor_id())

--- a/framework/src/base/ComputeBoundaryInitialConditionThread.C
+++ b/framework/src/base/ComputeBoundaryInitialConditionThread.C
@@ -40,7 +40,7 @@ ComputeBoundaryInitialConditionThread::onNode(ConstBndNodeRange::const_iterator 
 
   if (warehouse.hasActiveBoundaryObjects(boundary_id, _tid))
   {
-    const std::vector<std::shared_ptr<InitialCondition> > & ics = warehouse.getActiveBoundaryObjects(boundary_id, _tid);
+    const std::vector<std::shared_ptr<InitialCondition>> & ics = warehouse.getActiveBoundaryObjects(boundary_id, _tid);
     for (const auto & ic : ics)
     {
       if (node->processor_id() == _fe_problem.processor_id())

--- a/framework/src/base/ComputeDiracThread.C
+++ b/framework/src/base/ComputeDiracThread.C
@@ -72,7 +72,7 @@ ComputeDiracThread::onElement(const Elem * elem)
     return;
 
   std::set<MooseVariable *> needed_moose_vars;
-  const std::vector<MooseSharedPointer<DiracKernel> > & dkernels = _dirac_kernels.getActiveObjects(_tid);
+  const std::vector<std::shared_ptr<DiracKernel> > & dkernels = _dirac_kernels.getActiveObjects(_tid);
 
   // Only call reinitMaterials() if one or more DiracKernels has
   // actually called getMaterialProperty().  Loop over all the

--- a/framework/src/base/ComputeDiracThread.C
+++ b/framework/src/base/ComputeDiracThread.C
@@ -72,7 +72,7 @@ ComputeDiracThread::onElement(const Elem * elem)
     return;
 
   std::set<MooseVariable *> needed_moose_vars;
-  const std::vector<std::shared_ptr<DiracKernel> > & dkernels = _dirac_kernels.getActiveObjects(_tid);
+  const std::vector<std::shared_ptr<DiracKernel>> & dkernels = _dirac_kernels.getActiveObjects(_tid);
 
   // Only call reinitMaterials() if one or more DiracKernels has
   // actually called getMaterialProperty().  Loop over all the

--- a/framework/src/base/ComputeElemAuxBcsThread.C
+++ b/framework/src/base/ComputeElemAuxBcsThread.C
@@ -47,7 +47,7 @@ ComputeElemAuxBcsThread::operator() (const ConstBndElemRange & range)
   _tid = puid.id;
 
   // Reference to all boundary restricted AuxKernels for the current thread
-  const std::map<BoundaryID, std::vector<MooseSharedPointer<AuxKernel> > > & boundary_kernels = _storage.getActiveBoundaryObjects(_tid);
+  const std::map<BoundaryID, std::vector<std::shared_ptr<AuxKernel> > > & boundary_kernels = _storage.getActiveBoundaryObjects(_tid);
 
   for (const auto & belem : range)
   {
@@ -65,7 +65,7 @@ ComputeElemAuxBcsThread::operator() (const ConstBndElemRange & range)
       }
 
       // Locate the AuxKernel objects for the current BoundaryID
-      const std::map<BoundaryID, std::vector<MooseSharedPointer<AuxKernel> > >::const_iterator iter = boundary_kernels.find(boundary_id);
+      const std::map<BoundaryID, std::vector<std::shared_ptr<AuxKernel> > >::const_iterator iter = boundary_kernels.find(boundary_id);
 
       if (iter != boundary_kernels.end() && !(iter->second.empty()) )
       {

--- a/framework/src/base/ComputeElemAuxBcsThread.C
+++ b/framework/src/base/ComputeElemAuxBcsThread.C
@@ -47,7 +47,7 @@ ComputeElemAuxBcsThread::operator() (const ConstBndElemRange & range)
   _tid = puid.id;
 
   // Reference to all boundary restricted AuxKernels for the current thread
-  const std::map<BoundaryID, std::vector<std::shared_ptr<AuxKernel> > > & boundary_kernels = _storage.getActiveBoundaryObjects(_tid);
+  const auto & boundary_kernels = _storage.getActiveBoundaryObjects(_tid);
 
   for (const auto & belem : range)
   {
@@ -65,7 +65,7 @@ ComputeElemAuxBcsThread::operator() (const ConstBndElemRange & range)
       }
 
       // Locate the AuxKernel objects for the current BoundaryID
-      const std::map<BoundaryID, std::vector<std::shared_ptr<AuxKernel> > >::const_iterator iter = boundary_kernels.find(boundary_id);
+      const auto iter = boundary_kernels.find(boundary_id);
 
       if (iter != boundary_kernels.end() && !(iter->second.empty()) )
       {

--- a/framework/src/base/ComputeElemAuxVarsThread.C
+++ b/framework/src/base/ComputeElemAuxVarsThread.C
@@ -57,7 +57,7 @@ ComputeElemAuxVarsThread::subdomainChanged()
 
   if (_aux_kernels.hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<std::shared_ptr<AuxKernel> > & kernels = _aux_kernels.getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<AuxKernel>> & kernels = _aux_kernels.getActiveBlockObjects(_subdomain, _tid);
     for (const auto & aux : kernels)
     {
       aux->subdomainSetup();
@@ -75,7 +75,7 @@ ComputeElemAuxVarsThread::onElement(const Elem * elem)
 {
   if (_aux_kernels.hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<std::shared_ptr<AuxKernel> > & kernels = _aux_kernels.getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<AuxKernel>> & kernels = _aux_kernels.getActiveBlockObjects(_subdomain, _tid);
     _fe_problem.prepare(elem, _tid);
     _fe_problem.reinitElem(elem, _tid);
 

--- a/framework/src/base/ComputeElemAuxVarsThread.C
+++ b/framework/src/base/ComputeElemAuxVarsThread.C
@@ -57,7 +57,7 @@ ComputeElemAuxVarsThread::subdomainChanged()
 
   if (_aux_kernels.hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<MooseSharedPointer<AuxKernel> > & kernels = _aux_kernels.getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<AuxKernel> > & kernels = _aux_kernels.getActiveBlockObjects(_subdomain, _tid);
     for (const auto & aux : kernels)
     {
       aux->subdomainSetup();
@@ -75,7 +75,7 @@ ComputeElemAuxVarsThread::onElement(const Elem * elem)
 {
   if (_aux_kernels.hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<MooseSharedPointer<AuxKernel> > & kernels = _aux_kernels.getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<AuxKernel> > & kernels = _aux_kernels.getActiveBlockObjects(_subdomain, _tid);
     _fe_problem.prepare(elem, _tid);
     _fe_problem.reinitElem(elem, _tid);
 

--- a/framework/src/base/ComputeElemDampingThread.C
+++ b/framework/src/base/ComputeElemDampingThread.C
@@ -51,13 +51,13 @@ ComputeElemDampingThread::onElement(const Elem *elem)
 
   std::set<MooseVariable *> damped_vars;
 
-  const std::vector<std::shared_ptr<ElementDamper> > & edampers = _nl.getElementDamperWarehouse().getActiveObjects(_tid);
+  const std::vector<std::shared_ptr<ElementDamper>> & edampers = _nl.getElementDamperWarehouse().getActiveObjects(_tid);
   for (const auto & damper : edampers)
     damped_vars.insert(damper->getVariable());
 
   _nl.reinitIncrementAtQpsForDampers(_tid, damped_vars);
 
-  const std::vector<std::shared_ptr<ElementDamper> > & objects = _element_dampers.getActiveObjects(_tid);
+  const std::vector<std::shared_ptr<ElementDamper>> & objects = _element_dampers.getActiveObjects(_tid);
   for (const auto & obj : objects)
   {
     Real cur_damping = obj->computeDamping();

--- a/framework/src/base/ComputeElemDampingThread.C
+++ b/framework/src/base/ComputeElemDampingThread.C
@@ -51,13 +51,13 @@ ComputeElemDampingThread::onElement(const Elem *elem)
 
   std::set<MooseVariable *> damped_vars;
 
-  const std::vector<MooseSharedPointer<ElementDamper> > & edampers = _nl.getElementDamperWarehouse().getActiveObjects(_tid);
+  const std::vector<std::shared_ptr<ElementDamper> > & edampers = _nl.getElementDamperWarehouse().getActiveObjects(_tid);
   for (const auto & damper : edampers)
     damped_vars.insert(damper->getVariable());
 
   _nl.reinitIncrementAtQpsForDampers(_tid, damped_vars);
 
-  const std::vector<MooseSharedPointer<ElementDamper> > & objects = _element_dampers.getActiveObjects(_tid);
+  const std::vector<std::shared_ptr<ElementDamper> > & objects = _element_dampers.getActiveObjects(_tid);
   for (const auto & obj : objects)
   {
     Real cur_damping = obj->computeDamping();

--- a/framework/src/base/ComputeFullJacobianThread.C
+++ b/framework/src/base/ComputeFullJacobianThread.C
@@ -64,7 +64,7 @@ ComputeFullJacobianThread::computeJacobian()
     if (ivariable.activeOnSubdomain(_subdomain) && jvariable.activeOnSubdomain(_subdomain) && _kernels.hasActiveVariableBlockObjects(ivar, _subdomain, _tid))
     {
       // only if there are dofs for j-variable (if it is subdomain restricted var, there may not be any)
-      const std::vector<std::shared_ptr<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivar, _subdomain, _tid);
+      const std::vector<std::shared_ptr<KernelBase>> & kernels = _kernels.getActiveVariableBlockObjects(ivar, _subdomain, _tid);
       for (const auto & kernel : kernels)
         if ((kernel->variable().number() == ivar) && kernel->isImplicit())
         {
@@ -88,10 +88,10 @@ ComputeFullJacobianThread::computeJacobian()
 
       if (ivariable.activeOnSubdomain(_subdomain) && jvariable.activeOnSubdomain(_subdomain) && _kernels.hasActiveVariableBlockObjects(ivar, _subdomain, _tid))
       {
-        const std::vector<std::shared_ptr<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivar, _subdomain, _tid);
+        const std::vector<std::shared_ptr<KernelBase>> & kernels = _kernels.getActiveVariableBlockObjects(ivar, _subdomain, _tid);
         for (const auto & kernel : kernels)
         {
-          std::shared_ptr<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
+          std::shared_ptr<NonlocalKernel> nonlocal_kernel = std::dynamic_pointer_cast<NonlocalKernel>(kernel);
           if (nonlocal_kernel)
             if ((kernel->variable().number() == ivar) && kernel->isImplicit())
             {
@@ -112,7 +112,7 @@ ComputeFullJacobianThread::computeJacobian()
       if (ivariable->activeOnSubdomain(_subdomain) > 0 && _kernels.hasActiveVariableBlockObjects(ivariable->number(), _subdomain, _tid))
       {
         // for each variable get the list of active kernels
-        const std::vector<std::shared_ptr<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivariable->number(), _subdomain, _tid);
+        const std::vector<std::shared_ptr<KernelBase>> & kernels = _kernels.getActiveVariableBlockObjects(ivariable->number(), _subdomain, _tid);
         for (const auto & kernel : kernels)
           if (kernel->isImplicit())
           {
@@ -139,7 +139,7 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
     if (ivar.activeOnSubdomain(_subdomain) && jvar.activeOnSubdomain(_subdomain) && _integrated_bcs.hasActiveBoundaryObjects(bnd_id, _tid))
     {
       // only if there are dofs for j-variable (if it is subdomain restricted var, there may not be any)
-      const std::vector<std::shared_ptr<IntegratedBC> > & bcs = _integrated_bcs.getBoundaryObjects(bnd_id, _tid);
+      const std::vector<std::shared_ptr<IntegratedBC>> & bcs = _integrated_bcs.getBoundaryObjects(bnd_id, _tid);
       for (const auto & bc : bcs)
         if (bc->shouldApply() && bc->variable().number() == ivar.number() && bc->isImplicit())
         {
@@ -163,10 +163,10 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
 
       if (ivariable.activeOnSubdomain(_subdomain) && jvariable.activeOnSubdomain(_subdomain) && _integrated_bcs.hasActiveBoundaryObjects(bnd_id, _tid))
       {
-        const std::vector<std::shared_ptr<IntegratedBC> > & integrated_bcs = _integrated_bcs.getBoundaryObjects(bnd_id, _tid);
+        const std::vector<std::shared_ptr<IntegratedBC>> & integrated_bcs = _integrated_bcs.getBoundaryObjects(bnd_id, _tid);
         for (const auto & integrated_bc : integrated_bcs)
         {
-          std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(integrated_bc);
+          std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = std::dynamic_pointer_cast<NonlocalIntegratedBC>(integrated_bc);
           if (nonlocal_integrated_bc)
             if ((integrated_bc->variable().number() == ivar) && integrated_bc->isImplicit())
             {
@@ -187,7 +187,7 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
       if (ivar->activeOnSubdomain(_subdomain) > 0 && _integrated_bcs.hasActiveBoundaryObjects(bnd_id, _tid))
       {
         // for each variable get the list of active kernels
-        const std::vector<std::shared_ptr<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
+        const std::vector<std::shared_ptr<IntegratedBC>> & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
         for (const auto & bc : bcs)
           if (bc->variable().number() == ivar->number() && bc->isImplicit())
           {
@@ -208,10 +208,10 @@ ComputeFullJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
 {
   if (_dg_kernels.hasActiveBlockObjects(_subdomain, _tid))
   {
-    std::vector<std::pair<MooseVariable *, MooseVariable *> > & ce = _fe_problem.couplingEntries(_tid);
+    const auto & ce = _fe_problem.couplingEntries(_tid);
     for (const auto & it : ce)
     {
-      const std::vector<std::shared_ptr<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<DGKernel>> & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & dg : dgks)
       {
         MooseVariable & ivariable = *(it.first);
@@ -236,10 +236,10 @@ ComputeFullJacobianThread::computeInternalInterFaceJacobian(BoundaryID bnd_id)
 {
   if (_interface_kernels.hasActiveBoundaryObjects(bnd_id, _tid))
   {
-    std::vector<std::pair<MooseVariable *, MooseVariable *> > & ce = _fe_problem.couplingEntries(_tid);
+    const auto & ce = _fe_problem.couplingEntries(_tid);
     for (const auto & it : ce)
     {
-      const std::vector<std::shared_ptr<InterfaceKernel> > & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
+      const std::vector<std::shared_ptr<InterfaceKernel>> & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
       for (const auto & interface_kernel : int_ks)
       {
         if (!interface_kernel->isImplicit())

--- a/framework/src/base/ComputeFullJacobianThread.C
+++ b/framework/src/base/ComputeFullJacobianThread.C
@@ -64,7 +64,7 @@ ComputeFullJacobianThread::computeJacobian()
     if (ivariable.activeOnSubdomain(_subdomain) && jvariable.activeOnSubdomain(_subdomain) && _kernels.hasActiveVariableBlockObjects(ivar, _subdomain, _tid))
     {
       // only if there are dofs for j-variable (if it is subdomain restricted var, there may not be any)
-      const std::vector<MooseSharedPointer<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivar, _subdomain, _tid);
+      const std::vector<std::shared_ptr<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivar, _subdomain, _tid);
       for (const auto & kernel : kernels)
         if ((kernel->variable().number() == ivar) && kernel->isImplicit())
         {
@@ -88,10 +88,10 @@ ComputeFullJacobianThread::computeJacobian()
 
       if (ivariable.activeOnSubdomain(_subdomain) && jvariable.activeOnSubdomain(_subdomain) && _kernels.hasActiveVariableBlockObjects(ivar, _subdomain, _tid))
       {
-        const std::vector<MooseSharedPointer<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivar, _subdomain, _tid);
+        const std::vector<std::shared_ptr<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivar, _subdomain, _tid);
         for (const auto & kernel : kernels)
         {
-          MooseSharedPointer<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
+          std::shared_ptr<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
           if (nonlocal_kernel)
             if ((kernel->variable().number() == ivar) && kernel->isImplicit())
             {
@@ -112,7 +112,7 @@ ComputeFullJacobianThread::computeJacobian()
       if (ivariable->activeOnSubdomain(_subdomain) > 0 && _kernels.hasActiveVariableBlockObjects(ivariable->number(), _subdomain, _tid))
       {
         // for each variable get the list of active kernels
-        const std::vector<MooseSharedPointer<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivariable->number(), _subdomain, _tid);
+        const std::vector<std::shared_ptr<KernelBase> > & kernels = _kernels.getActiveVariableBlockObjects(ivariable->number(), _subdomain, _tid);
         for (const auto & kernel : kernels)
           if (kernel->isImplicit())
           {
@@ -139,7 +139,7 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
     if (ivar.activeOnSubdomain(_subdomain) && jvar.activeOnSubdomain(_subdomain) && _integrated_bcs.hasActiveBoundaryObjects(bnd_id, _tid))
     {
       // only if there are dofs for j-variable (if it is subdomain restricted var, there may not be any)
-      const std::vector<MooseSharedPointer<IntegratedBC> > & bcs = _integrated_bcs.getBoundaryObjects(bnd_id, _tid);
+      const std::vector<std::shared_ptr<IntegratedBC> > & bcs = _integrated_bcs.getBoundaryObjects(bnd_id, _tid);
       for (const auto & bc : bcs)
         if (bc->shouldApply() && bc->variable().number() == ivar.number() && bc->isImplicit())
         {
@@ -163,10 +163,10 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
 
       if (ivariable.activeOnSubdomain(_subdomain) && jvariable.activeOnSubdomain(_subdomain) && _integrated_bcs.hasActiveBoundaryObjects(bnd_id, _tid))
       {
-        const std::vector<MooseSharedPointer<IntegratedBC> > & integrated_bcs = _integrated_bcs.getBoundaryObjects(bnd_id, _tid);
+        const std::vector<std::shared_ptr<IntegratedBC> > & integrated_bcs = _integrated_bcs.getBoundaryObjects(bnd_id, _tid);
         for (const auto & integrated_bc : integrated_bcs)
         {
-          MooseSharedPointer<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(integrated_bc);
+          std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(integrated_bc);
           if (nonlocal_integrated_bc)
             if ((integrated_bc->variable().number() == ivar) && integrated_bc->isImplicit())
             {
@@ -187,7 +187,7 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
       if (ivar->activeOnSubdomain(_subdomain) > 0 && _integrated_bcs.hasActiveBoundaryObjects(bnd_id, _tid))
       {
         // for each variable get the list of active kernels
-        const std::vector<MooseSharedPointer<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
+        const std::vector<std::shared_ptr<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
         for (const auto & bc : bcs)
           if (bc->variable().number() == ivar->number() && bc->isImplicit())
           {
@@ -211,7 +211,7 @@ ComputeFullJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
     std::vector<std::pair<MooseVariable *, MooseVariable *> > & ce = _fe_problem.couplingEntries(_tid);
     for (const auto & it : ce)
     {
-      const std::vector<MooseSharedPointer<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & dg : dgks)
       {
         MooseVariable & ivariable = *(it.first);
@@ -239,7 +239,7 @@ ComputeFullJacobianThread::computeInternalInterFaceJacobian(BoundaryID bnd_id)
     std::vector<std::pair<MooseVariable *, MooseVariable *> > & ce = _fe_problem.couplingEntries(_tid);
     for (const auto & it : ce)
     {
-      const std::vector<MooseSharedPointer<InterfaceKernel> > & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
+      const std::vector<std::shared_ptr<InterfaceKernel> > & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
       for (const auto & interface_kernel : int_ks)
       {
         if (!interface_kernel->isImplicit())

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -88,7 +88,7 @@ ComputeIndicatorThread::onElement(const Elem *elem)
   {
     if (_indicator_whs.hasActiveBlockObjects(_subdomain, _tid))
     {
-      const std::vector<MooseSharedPointer<Indicator> > & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<Indicator> > & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & indicator : indicators)
         indicator->computeIndicator();
     }
@@ -99,14 +99,14 @@ ComputeIndicatorThread::onElement(const Elem *elem)
   {
     if (_indicator_whs.hasActiveBlockObjects(_subdomain, _tid))
     {
-      const std::vector<MooseSharedPointer<Indicator> > & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<Indicator> > & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & indicator : indicators)
         indicator->finalize();
     }
 
     if (_internal_side_indicators.hasActiveBlockObjects(_subdomain, _tid))
     {
-      const std::vector<MooseSharedPointer<InternalSideIndicator> > & internal_indicators = _internal_side_indicators.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<InternalSideIndicator> > & internal_indicators = _internal_side_indicators.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & internal_indicator : internal_indicators)
         internal_indicator->finalize();
     }
@@ -163,7 +163,7 @@ ComputeIndicatorThread::onInternalSide(const Elem *elem, unsigned int side)
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblemBase::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
-      const std::vector<MooseSharedPointer<InternalSideIndicator> > & indicators = _internal_side_indicators.getActiveBlockObjects(block_id, _tid);
+      const std::vector<std::shared_ptr<InternalSideIndicator> > & indicators = _internal_side_indicators.getActiveBlockObjects(block_id, _tid);
       for (const auto & indicator : indicators)
         indicator->computeIndicator();
     }

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -88,7 +88,7 @@ ComputeIndicatorThread::onElement(const Elem *elem)
   {
     if (_indicator_whs.hasActiveBlockObjects(_subdomain, _tid))
     {
-      const std::vector<std::shared_ptr<Indicator> > & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<Indicator>> & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & indicator : indicators)
         indicator->computeIndicator();
     }
@@ -99,14 +99,14 @@ ComputeIndicatorThread::onElement(const Elem *elem)
   {
     if (_indicator_whs.hasActiveBlockObjects(_subdomain, _tid))
     {
-      const std::vector<std::shared_ptr<Indicator> > & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<Indicator>> & indicators = _indicator_whs.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & indicator : indicators)
         indicator->finalize();
     }
 
     if (_internal_side_indicators.hasActiveBlockObjects(_subdomain, _tid))
     {
-      const std::vector<std::shared_ptr<InternalSideIndicator> > & internal_indicators = _internal_side_indicators.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<InternalSideIndicator>> & internal_indicators = _internal_side_indicators.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & internal_indicator : internal_indicators)
         internal_indicator->finalize();
     }
@@ -163,7 +163,7 @@ ComputeIndicatorThread::onInternalSide(const Elem *elem, unsigned int side)
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblemBase::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
-      const std::vector<std::shared_ptr<InternalSideIndicator> > & indicators = _internal_side_indicators.getActiveBlockObjects(block_id, _tid);
+      const std::vector<std::shared_ptr<InternalSideIndicator>> & indicators = _internal_side_indicators.getActiveBlockObjects(block_id, _tid);
       for (const auto & indicator : indicators)
         indicator->computeIndicator();
     }

--- a/framework/src/base/ComputeInitialConditionThread.C
+++ b/framework/src/base/ComputeInitialConditionThread.C
@@ -43,9 +43,9 @@ ComputeInitialConditionThread::operator() (const ConstElemRange & range)
 
     if (warehouse.hasActiveBlockObjects(subdomain, _tid))
     {
-      const std::vector<std::shared_ptr<InitialCondition> > & ics = warehouse.getActiveBlockObjects(subdomain, _tid);
-      for (std::vector<std::shared_ptr<InitialCondition> >::const_iterator it = ics.begin(); it != ics.end(); ++it)
-        (*it)->compute();
+      const auto & ics = warehouse.getActiveBlockObjects(subdomain, _tid);
+      for (const auto & ic : ics)
+        ic->compute();
     }
   }
 }

--- a/framework/src/base/ComputeInitialConditionThread.C
+++ b/framework/src/base/ComputeInitialConditionThread.C
@@ -43,8 +43,8 @@ ComputeInitialConditionThread::operator() (const ConstElemRange & range)
 
     if (warehouse.hasActiveBlockObjects(subdomain, _tid))
     {
-      const std::vector<MooseSharedPointer<InitialCondition> > & ics = warehouse.getActiveBlockObjects(subdomain, _tid);
-      for (std::vector<MooseSharedPointer<InitialCondition> >::const_iterator it = ics.begin(); it != ics.end(); ++it)
+      const std::vector<std::shared_ptr<InitialCondition> > & ics = warehouse.getActiveBlockObjects(subdomain, _tid);
+      for (std::vector<std::shared_ptr<InitialCondition> >::const_iterator it = ics.begin(); it != ics.end(); ++it)
         (*it)->compute();
     }
   }

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -90,7 +90,7 @@ ComputeJacobianThread::computeJacobian()
 
   if (warehouse->hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<MooseSharedPointer<KernelBase> > & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<KernelBase> > & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
     for (const auto & kernel : kernels)
       if (kernel->isImplicit())
       {
@@ -99,7 +99,7 @@ ComputeJacobianThread::computeJacobian()
         /// done only when nonlocal kernels exist in the system
         if (_fe_problem.checkNonlocalCouplingRequirement())
         {
-          MooseSharedPointer<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
+          std::shared_ptr<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
           if (nonlocal_kernel)
             kernel->computeNonlocalJacobian();
         }
@@ -110,7 +110,7 @@ ComputeJacobianThread::computeJacobian()
 void
 ComputeJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
 {
-  const std::vector<MooseSharedPointer<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
+  const std::vector<std::shared_ptr<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
   for (const auto & bc : bcs)
     if (bc->shouldApply() && bc->isImplicit())
     {
@@ -119,7 +119,7 @@ ComputeJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
       /// done only when nonlocal integrated_bcs exist in the system
       if (_fe_problem.checkNonlocalCouplingRequirement())
       {
-        MooseSharedPointer<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(bc);
+        std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(bc);
         if (nonlocal_integrated_bc)
           bc->computeNonlocalJacobian();
       }
@@ -130,7 +130,7 @@ void
 ComputeJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
 {
   // No need to call hasActiveObjects, this is done in the calling method (see onInternalSide)
-  const std::vector<MooseSharedPointer<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
+  const std::vector<std::shared_ptr<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
   for (const auto & dg : dgks)
     if (dg->isImplicit())
     {
@@ -145,7 +145,7 @@ void
 ComputeJacobianThread::computeInternalInterFaceJacobian(BoundaryID bnd_id)
 {
   // No need to call hasActiveObjects, this is done in the calling method (see onInterface)
-  const std::vector<MooseSharedPointer<InterfaceKernel> > & intks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
+  const std::vector<std::shared_ptr<InterfaceKernel> > & intks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
   for (const auto & intk : intks)
     if (intk->isImplicit())
     {

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -90,7 +90,7 @@ ComputeJacobianThread::computeJacobian()
 
   if (warehouse->hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<std::shared_ptr<KernelBase> > & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<KernelBase>> & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
     for (const auto & kernel : kernels)
       if (kernel->isImplicit())
       {
@@ -99,7 +99,7 @@ ComputeJacobianThread::computeJacobian()
         /// done only when nonlocal kernels exist in the system
         if (_fe_problem.checkNonlocalCouplingRequirement())
         {
-          std::shared_ptr<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
+          std::shared_ptr<NonlocalKernel> nonlocal_kernel = std::dynamic_pointer_cast<NonlocalKernel>(kernel);
           if (nonlocal_kernel)
             kernel->computeNonlocalJacobian();
         }
@@ -110,7 +110,7 @@ ComputeJacobianThread::computeJacobian()
 void
 ComputeJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
 {
-  const std::vector<std::shared_ptr<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
+  const std::vector<std::shared_ptr<IntegratedBC>> & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
   for (const auto & bc : bcs)
     if (bc->shouldApply() && bc->isImplicit())
     {
@@ -119,7 +119,7 @@ ComputeJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
       /// done only when nonlocal integrated_bcs exist in the system
       if (_fe_problem.checkNonlocalCouplingRequirement())
       {
-        std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(bc);
+        std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = std::dynamic_pointer_cast<NonlocalIntegratedBC>(bc);
         if (nonlocal_integrated_bc)
           bc->computeNonlocalJacobian();
       }
@@ -130,7 +130,7 @@ void
 ComputeJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
 {
   // No need to call hasActiveObjects, this is done in the calling method (see onInternalSide)
-  const std::vector<std::shared_ptr<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
+  const std::vector<std::shared_ptr<DGKernel>> & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
   for (const auto & dg : dgks)
     if (dg->isImplicit())
     {

--- a/framework/src/base/ComputeMarkerThread.C
+++ b/framework/src/base/ComputeMarkerThread.C
@@ -77,7 +77,7 @@ ComputeMarkerThread::onElement(const Elem *elem)
 
   if (_marker_whs.hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<MooseSharedPointer<Marker> > & markers = _marker_whs.getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<Marker> > & markers = _marker_whs.getActiveBlockObjects(_subdomain, _tid);
     for (const auto & marker : markers)
       marker->computeMarker();
   }

--- a/framework/src/base/ComputeMarkerThread.C
+++ b/framework/src/base/ComputeMarkerThread.C
@@ -77,7 +77,7 @@ ComputeMarkerThread::onElement(const Elem *elem)
 
   if (_marker_whs.hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<std::shared_ptr<Marker> > & markers = _marker_whs.getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<Marker>> & markers = _marker_whs.getActiveBlockObjects(_subdomain, _tid);
     for (const auto & marker : markers)
       marker->computeMarker();
   }

--- a/framework/src/base/ComputeMaterialsObjectThread.C
+++ b/framework/src/base/ComputeMaterialsObjectThread.C
@@ -28,9 +28,9 @@
 #include "libmesh/quadrature.h"
 
 ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(FEProblemBase & fe_problem,
-                                                           std::vector<MooseSharedPointer<MaterialData> > & material_data,
-                                                           std::vector<MooseSharedPointer<MaterialData> > & bnd_material_data,
-                                                           std::vector<MooseSharedPointer<MaterialData> > & neighbor_material_data,
+                                                           std::vector<std::shared_ptr<MaterialData> > & material_data,
+                                                           std::vector<std::shared_ptr<MaterialData> > & bnd_material_data,
+                                                           std::vector<std::shared_ptr<MaterialData> > & neighbor_material_data,
                                                            MaterialPropertyStorage & material_props,
                                                            MaterialPropertyStorage & bnd_material_props,
                                                            std::vector<Assembly *> & assembly) :

--- a/framework/src/base/ComputeMaterialsObjectThread.C
+++ b/framework/src/base/ComputeMaterialsObjectThread.C
@@ -28,9 +28,9 @@
 #include "libmesh/quadrature.h"
 
 ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(FEProblemBase & fe_problem,
-                                                           std::vector<std::shared_ptr<MaterialData> > & material_data,
-                                                           std::vector<std::shared_ptr<MaterialData> > & bnd_material_data,
-                                                           std::vector<std::shared_ptr<MaterialData> > & neighbor_material_data,
+                                                           std::vector<std::shared_ptr<MaterialData>> & material_data,
+                                                           std::vector<std::shared_ptr<MaterialData>> & bnd_material_data,
+                                                           std::vector<std::shared_ptr<MaterialData>> & neighbor_material_data,
                                                            MaterialPropertyStorage & material_props,
                                                            MaterialPropertyStorage & bnd_material_props,
                                                            std::vector<Assembly *> & assembly) :

--- a/framework/src/base/ComputeNodalAuxBcsThread.C
+++ b/framework/src/base/ComputeNodalAuxBcsThread.C
@@ -57,10 +57,10 @@ ComputeNodalAuxBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
   if (node->processor_id() == _fe_problem.processor_id())
   {
     // Get a map of all active block restricted AuxKernel objects
-    const std::map<BoundaryID, std::vector<MooseSharedPointer<AuxKernel> > > & kernels = _storage.getActiveBoundaryObjects(_tid);
+    const std::map<BoundaryID, std::vector<std::shared_ptr<AuxKernel> > > & kernels = _storage.getActiveBoundaryObjects(_tid);
 
     // Operate on the node BoundaryID only
-    const std::map<BoundaryID, std::vector<MooseSharedPointer<AuxKernel> > >::const_iterator iter = kernels.find(boundary_id);
+    const std::map<BoundaryID, std::vector<std::shared_ptr<AuxKernel> > >::const_iterator iter = kernels.find(boundary_id);
     if (iter != kernels.end())
     {
       _fe_problem.reinitNodeFace(node, boundary_id, _tid);

--- a/framework/src/base/ComputeNodalAuxBcsThread.C
+++ b/framework/src/base/ComputeNodalAuxBcsThread.C
@@ -57,10 +57,10 @@ ComputeNodalAuxBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
   if (node->processor_id() == _fe_problem.processor_id())
   {
     // Get a map of all active block restricted AuxKernel objects
-    const std::map<BoundaryID, std::vector<std::shared_ptr<AuxKernel> > > & kernels = _storage.getActiveBoundaryObjects(_tid);
+    const auto & kernels = _storage.getActiveBoundaryObjects(_tid);
 
     // Operate on the node BoundaryID only
-    const std::map<BoundaryID, std::vector<std::shared_ptr<AuxKernel> > >::const_iterator iter = kernels.find(boundary_id);
+    const auto iter = kernels.find(boundary_id);
     if (iter != kernels.end())
     {
       _fe_problem.reinitNodeFace(node, boundary_id, _tid);

--- a/framework/src/base/ComputeNodalAuxVarsThread.C
+++ b/framework/src/base/ComputeNodalAuxVarsThread.C
@@ -51,13 +51,13 @@ ComputeNodalAuxVarsThread::onNode(ConstNodeRange::const_iterator & node_it)
   _fe_problem.reinitNode(node, _tid);
 
   // Get a map of all active block restricted AuxKernel objects
-  const std::map<SubdomainID, std::vector<MooseSharedPointer<AuxKernel> > > & block_kernels = _storage.getActiveBlockObjects(_tid);
+  const std::map<SubdomainID, std::vector<std::shared_ptr<AuxKernel> > > & block_kernels = _storage.getActiveBlockObjects(_tid);
 
   // Loop over all SubdomainIDs for the curnent node, if an AuxKernel is active on this block then compute it.
   const std::set<SubdomainID> & block_ids = _aux_sys.mesh().getNodeBlockIds(*node);
   for (const auto & block : block_ids)
   {
-    std::map<SubdomainID, std::vector<MooseSharedPointer<AuxKernel> > >::const_iterator iter = block_kernels.find(block);
+    std::map<SubdomainID, std::vector<std::shared_ptr<AuxKernel> > >::const_iterator iter = block_kernels.find(block);
 
     if (iter != block_kernels.end())
       for (const auto & aux : iter->second)

--- a/framework/src/base/ComputeNodalAuxVarsThread.C
+++ b/framework/src/base/ComputeNodalAuxVarsThread.C
@@ -51,13 +51,13 @@ ComputeNodalAuxVarsThread::onNode(ConstNodeRange::const_iterator & node_it)
   _fe_problem.reinitNode(node, _tid);
 
   // Get a map of all active block restricted AuxKernel objects
-  const std::map<SubdomainID, std::vector<std::shared_ptr<AuxKernel> > > & block_kernels = _storage.getActiveBlockObjects(_tid);
+  const auto & block_kernels = _storage.getActiveBlockObjects(_tid);
 
   // Loop over all SubdomainIDs for the curnent node, if an AuxKernel is active on this block then compute it.
-  const std::set<SubdomainID> & block_ids = _aux_sys.mesh().getNodeBlockIds(*node);
+  const auto & block_ids = _aux_sys.mesh().getNodeBlockIds(*node);
   for (const auto & block : block_ids)
   {
-    std::map<SubdomainID, std::vector<std::shared_ptr<AuxKernel> > >::const_iterator iter = block_kernels.find(block);
+    const auto iter = block_kernels.find(block);
 
     if (iter != block_kernels.end())
       for (const auto & aux : iter->second)

--- a/framework/src/base/ComputeNodalDampingThread.C
+++ b/framework/src/base/ComputeNodalDampingThread.C
@@ -50,13 +50,13 @@ ComputeNodalDampingThread::onNode(ConstNodeRange::const_iterator & node_it)
 
   std::set<MooseVariable *> damped_vars;
 
-  const std::vector<MooseSharedPointer<NodalDamper> > & ndampers = _nl.getNodalDamperWarehouse().getActiveObjects(_tid);
+  const std::vector<std::shared_ptr<NodalDamper> > & ndampers = _nl.getNodalDamperWarehouse().getActiveObjects(_tid);
   for (const auto & damper : ndampers)
     damped_vars.insert(damper->getVariable());
 
   _nl.reinitIncrementAtNodeForDampers(_tid, damped_vars);
 
-  const std::vector<MooseSharedPointer<NodalDamper> > & objects = _nodal_dampers.getActiveObjects(_tid);
+  const std::vector<std::shared_ptr<NodalDamper> > & objects = _nodal_dampers.getActiveObjects(_tid);
   for (const auto & obj : objects)
   {
     Real cur_damping = obj->computeDamping();

--- a/framework/src/base/ComputeNodalDampingThread.C
+++ b/framework/src/base/ComputeNodalDampingThread.C
@@ -50,13 +50,13 @@ ComputeNodalDampingThread::onNode(ConstNodeRange::const_iterator & node_it)
 
   std::set<MooseVariable *> damped_vars;
 
-  const std::vector<std::shared_ptr<NodalDamper> > & ndampers = _nl.getNodalDamperWarehouse().getActiveObjects(_tid);
+  const auto & ndampers = _nl.getNodalDamperWarehouse().getActiveObjects(_tid);
   for (const auto & damper : ndampers)
     damped_vars.insert(damper->getVariable());
 
   _nl.reinitIncrementAtNodeForDampers(_tid, damped_vars);
 
-  const std::vector<std::shared_ptr<NodalDamper> > & objects = _nodal_dampers.getActiveObjects(_tid);
+  const auto & objects = _nodal_dampers.getActiveObjects(_tid);
   for (const auto & obj : objects)
   {
     Real cur_damping = obj->computeDamping();

--- a/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
@@ -69,7 +69,7 @@ ComputeNodalKernelBCJacobiansThread::onNode(ConstBndNodeRange::const_iterator & 
     if (_nodal_kernels.hasActiveBoundaryObjects(boundary_id, _tid))
     {
       // Loop over each NodalKernel to see if it's involved with the jvar
-      const std::vector<std::shared_ptr<NodalKernel> > & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
+      const auto & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
       for (const auto & nodal_kernel : objects)
       {
         // If this NodalKernel isn't operating on this ivar... skip it

--- a/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
@@ -64,12 +64,12 @@ ComputeNodalKernelBCJacobiansThread::onNode(ConstBndNodeRange::const_iterator & 
     unsigned int jvar = jvariable.number();
 
     // The NodalKernels that are active and are coupled to the jvar in question
-    std::vector<MooseSharedPointer<NodalKernel> > active_involved_kernels;
+    std::vector<std::shared_ptr<NodalKernel> > active_involved_kernels;
 
     if (_nodal_kernels.hasActiveBoundaryObjects(boundary_id, _tid))
     {
       // Loop over each NodalKernel to see if it's involved with the jvar
-      const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
+      const std::vector<std::shared_ptr<NodalKernel> > & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
       for (const auto & nodal_kernel : objects)
       {
         // If this NodalKernel isn't operating on this ivar... skip it

--- a/framework/src/base/ComputeNodalKernelBcsThread.C
+++ b/framework/src/base/ComputeNodalKernelBcsThread.C
@@ -65,7 +65,7 @@ ComputeNodalKernelBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
     if (node->processor_id() == _fe_problem.processor_id())
     {
       _fe_problem.reinitNodeFace(node, boundary_id, _tid);
-      const std::vector<std::shared_ptr<NodalKernel> > & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
+      const auto & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
       for (const auto & nodal_kernel : objects)
         nodal_kernel->computeResidual();
 

--- a/framework/src/base/ComputeNodalKernelBcsThread.C
+++ b/framework/src/base/ComputeNodalKernelBcsThread.C
@@ -65,7 +65,7 @@ ComputeNodalKernelBcsThread::onNode(ConstBndNodeRange::const_iterator & node_it)
     if (node->processor_id() == _fe_problem.processor_id())
     {
       _fe_problem.reinitNodeFace(node, boundary_id, _tid);
-      const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
+      const std::vector<std::shared_ptr<NodalKernel> > & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
       for (const auto & nodal_kernel : objects)
         nodal_kernel->computeResidual();
 

--- a/framework/src/base/ComputeNodalKernelJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelJacobiansThread.C
@@ -71,7 +71,7 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
       if (_nodal_kernels.hasActiveBlockObjects(block, _tid))
       {
         // Loop over each NodalKernel to see if it's involved with the jvar
-        const std::vector<std::shared_ptr<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
+        const auto & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
         for (const auto & nodal_kernel : objects)
         {
           // If this NodalKernel isn't operating on this ivar... skip it

--- a/framework/src/base/ComputeNodalKernelJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelJacobiansThread.C
@@ -63,7 +63,7 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
     unsigned int jvar = jvariable.number();
 
     // The NodalKernels that are active and are coupled to the jvar in question
-    std::vector<MooseSharedPointer<NodalKernel> > active_involved_kernels;
+    std::vector<std::shared_ptr<NodalKernel> > active_involved_kernels;
 
     const std::set<SubdomainID> & block_ids = _aux_sys.mesh().getNodeBlockIds(*node);
     for (const auto & block : block_ids)
@@ -71,7 +71,7 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
       if (_nodal_kernels.hasActiveBlockObjects(block, _tid))
       {
         // Loop over each NodalKernel to see if it's involved with the jvar
-        const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
+        const std::vector<std::shared_ptr<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
         for (const auto & nodal_kernel : objects)
         {
           // If this NodalKernel isn't operating on this ivar... skip it

--- a/framework/src/base/ComputeNodalKernelsThread.C
+++ b/framework/src/base/ComputeNodalKernelsThread.C
@@ -62,7 +62,7 @@ ComputeNodalKernelsThread::onNode(ConstNodeRange::const_iterator & node_it)
   for (const auto & block : block_ids)
     if (_nodal_kernels.hasActiveBlockObjects(block, _tid))
     {
-      const std::vector<std::shared_ptr<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
+      const auto & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
       for (const auto & nodal_kernel : objects)
         nodal_kernel->computeResidual();
     }

--- a/framework/src/base/ComputeNodalKernelsThread.C
+++ b/framework/src/base/ComputeNodalKernelsThread.C
@@ -62,7 +62,7 @@ ComputeNodalKernelsThread::onNode(ConstNodeRange::const_iterator & node_it)
   for (const auto & block : block_ids)
     if (_nodal_kernels.hasActiveBlockObjects(block, _tid))
     {
-      const std::vector<MooseSharedPointer<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
+      const std::vector<std::shared_ptr<NodalKernel> > & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
       for (const auto & nodal_kernel : objects)
         nodal_kernel->computeResidual();
     }

--- a/framework/src/base/ComputeNodalUserObjectsThread.C
+++ b/framework/src/base/ComputeNodalUserObjectsThread.C
@@ -50,7 +50,7 @@ ComputeNodalUserObjectsThread::onNode(ConstNodeRange::const_iterator & node_it)
   {
     if (_user_objects.hasActiveBoundaryObjects(bnd, _tid))
     {
-      const std::vector<std::shared_ptr<NodalUserObject> > & objects = _user_objects.getActiveBoundaryObjects(bnd, _tid);
+      const auto & objects = _user_objects.getActiveBoundaryObjects(bnd, _tid);
       for (const auto & uo : objects)
         uo->execute();
     }
@@ -68,7 +68,7 @@ ComputeNodalUserObjectsThread::onNode(ConstNodeRange::const_iterator & node_it)
   for (const auto & block : block_ids)
     if (_user_objects.hasActiveBlockObjects(block, _tid))
     {
-      const std::vector<std::shared_ptr<NodalUserObject> > & objects = _user_objects.getActiveBlockObjects(block, _tid);
+      const auto & objects = _user_objects.getActiveBlockObjects(block, _tid);
       for (const auto & uo : objects)
         if (!uo->isUniqueNodeExecute() || std::count(computed.begin(), computed.end(), uo) == 0)
         {

--- a/framework/src/base/ComputeNodalUserObjectsThread.C
+++ b/framework/src/base/ComputeNodalUserObjectsThread.C
@@ -50,7 +50,7 @@ ComputeNodalUserObjectsThread::onNode(ConstNodeRange::const_iterator & node_it)
   {
     if (_user_objects.hasActiveBoundaryObjects(bnd, _tid))
     {
-      const std::vector<MooseSharedPointer<NodalUserObject> > & objects = _user_objects.getActiveBoundaryObjects(bnd, _tid);
+      const std::vector<std::shared_ptr<NodalUserObject> > & objects = _user_objects.getActiveBoundaryObjects(bnd, _tid);
       for (const auto & uo : objects)
         uo->execute();
     }
@@ -62,13 +62,13 @@ ComputeNodalUserObjectsThread::onNode(ConstNodeRange::const_iterator & node_it)
   // "unique_node_execute = true".
 
   // To inforce the unique execution this vector is populated and checked if the unique flag is enabled.
-  std::vector<MooseSharedPointer<NodalUserObject> > computed;
+  std::vector<std::shared_ptr<NodalUserObject> > computed;
 
   const std::set<SubdomainID> & block_ids = _fe_problem.mesh().getNodeBlockIds(*node);
   for (const auto & block : block_ids)
     if (_user_objects.hasActiveBlockObjects(block, _tid))
     {
-      const std::vector<MooseSharedPointer<NodalUserObject> > & objects = _user_objects.getActiveBlockObjects(block, _tid);
+      const std::vector<std::shared_ptr<NodalUserObject> > & objects = _user_objects.getActiveBlockObjects(block, _tid);
       for (const auto & uo : objects)
         if (!uo->isUniqueNodeExecute() || std::count(computed.begin(), computed.end(), uo) == 0)
         {

--- a/framework/src/base/ComputeResidualThread.C
+++ b/framework/src/base/ComputeResidualThread.C
@@ -114,7 +114,7 @@ ComputeResidualThread::onElement(const Elem *elem)
 
   if (warehouse->hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<MooseSharedPointer<KernelBase> > & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<KernelBase> > & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
     for (const auto & kernel : kernels)
       kernel->computeResidual();
   }
@@ -125,7 +125,7 @@ ComputeResidualThread::onBoundary(const Elem *elem, unsigned int side, BoundaryI
 {
   if (_integrated_bcs.hasActiveBoundaryObjects(bnd_id, _tid))
   {
-    const std::vector<MooseSharedPointer<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
+    const std::vector<std::shared_ptr<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
 
     _fe_problem.reinitElemFace(elem, side, bnd_id, _tid);
 
@@ -174,7 +174,7 @@ ComputeResidualThread::onInterface(const Elem *elem, unsigned int side, Boundary
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
-      const std::vector<MooseSharedPointer<InterfaceKernel> > & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
+      const std::vector<std::shared_ptr<InterfaceKernel> > & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
       for (const auto & interface_kernel : int_ks)
         interface_kernel->computeResidual();
 
@@ -211,7 +211,7 @@ ComputeResidualThread::onInternalSide(const Elem *elem, unsigned int side)
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
-      const std::vector<MooseSharedPointer<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & dg_kernel : dgks)
         if (dg_kernel->hasBlocks(neighbor->subdomain_id()))
           dg_kernel->computeResidual();

--- a/framework/src/base/ComputeResidualThread.C
+++ b/framework/src/base/ComputeResidualThread.C
@@ -114,7 +114,7 @@ ComputeResidualThread::onElement(const Elem *elem)
 
   if (warehouse->hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<std::shared_ptr<KernelBase> > & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
+    const auto & kernels = warehouse->getActiveBlockObjects(_subdomain, _tid);
     for (const auto & kernel : kernels)
       kernel->computeResidual();
   }
@@ -125,7 +125,7 @@ ComputeResidualThread::onBoundary(const Elem *elem, unsigned int side, BoundaryI
 {
   if (_integrated_bcs.hasActiveBoundaryObjects(bnd_id, _tid))
   {
-    const std::vector<std::shared_ptr<IntegratedBC> > & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
+    const auto & bcs = _integrated_bcs.getActiveBoundaryObjects(bnd_id, _tid);
 
     _fe_problem.reinitElemFace(elem, side, bnd_id, _tid);
 
@@ -174,7 +174,7 @@ ComputeResidualThread::onInterface(const Elem *elem, unsigned int side, Boundary
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
-      const std::vector<std::shared_ptr<InterfaceKernel> > & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
+      const auto & int_ks = _interface_kernels.getActiveBoundaryObjects(bnd_id, _tid);
       for (const auto & interface_kernel : int_ks)
         interface_kernel->computeResidual();
 
@@ -211,7 +211,7 @@ ComputeResidualThread::onInternalSide(const Elem *elem, unsigned int side)
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
-      const std::vector<std::shared_ptr<DGKernel> > & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
+      const auto & dgks = _dg_kernels.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & dg_kernel : dgks)
         if (dg_kernel->hasBlocks(neighbor->subdomain_id()))
           dg_kernel->computeResidual();

--- a/framework/src/base/ComputeUserObjectsThread.C
+++ b/framework/src/base/ComputeUserObjectsThread.C
@@ -82,7 +82,7 @@ ComputeUserObjectsThread::onElement(const Elem * elem)
 
   if (_elemental_user_objects.hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<std::shared_ptr<ElementUserObject> > & objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
+    const auto & objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
     for (const auto & uo : objects)
       uo->execute();
   }
@@ -100,10 +100,10 @@ ComputeUserObjectsThread::onElement(const Elem * elem)
 
         _fe_problem.prepareShapes(jvar_id, _tid);
 
-        const std::vector<std::shared_ptr<ElementUserObject> > & e_objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
+        const auto & e_objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
         for (const auto & uo : e_objects)
         {
-          std::shared_ptr<ShapeElementUserObject> shape_element_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeElementUserObject>(uo);
+          std::shared_ptr<ShapeElementUserObject> shape_element_uo = std::dynamic_pointer_cast<ShapeElementUserObject>(uo);
           if (shape_element_uo)
             shape_element_uo->executeJacobianWrapper(jvar_id, dof_indices);
         }
@@ -126,7 +126,7 @@ ComputeUserObjectsThread::onBoundary(const Elem *elem, unsigned int side, Bounda
 
     _fe_problem.setCurrentBoundaryID(bnd_id);
 
-    const std::vector<std::shared_ptr<SideUserObject> > & objects = _side_user_objects.getActiveBoundaryObjects(bnd_id, _tid);
+    const auto & objects = _side_user_objects.getActiveBoundaryObjects(bnd_id, _tid);
     for (const auto & uo : objects)
       uo->execute();
 
@@ -144,7 +144,7 @@ ComputeUserObjectsThread::onBoundary(const Elem *elem, unsigned int side, Bounda
 ;
         for (const auto & uo : objects)
         {
-          std::shared_ptr<ShapeSideUserObject> shape_side_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeSideUserObject>(uo);
+          std::shared_ptr<ShapeSideUserObject> shape_side_uo = std::dynamic_pointer_cast<ShapeSideUserObject>(uo);
           if (shape_side_uo)
             shape_side_uo->executeJacobianWrapper(jvar_id, dof_indices);
         }
@@ -181,7 +181,7 @@ ComputeUserObjectsThread::onInternalSide(const Elem *elem, unsigned int side)
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
-      const std::vector<std::shared_ptr<InternalSideUserObject> > & objects = _internal_side_user_objects.getActiveBlockObjects(_subdomain, _tid);
+      const auto & objects = _internal_side_user_objects.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & uo : objects)
       {
         if (!uo->blockRestricted())

--- a/framework/src/base/ComputeUserObjectsThread.C
+++ b/framework/src/base/ComputeUserObjectsThread.C
@@ -82,7 +82,7 @@ ComputeUserObjectsThread::onElement(const Elem * elem)
 
   if (_elemental_user_objects.hasActiveBlockObjects(_subdomain, _tid))
   {
-    const std::vector<MooseSharedPointer<ElementUserObject> > & objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
+    const std::vector<std::shared_ptr<ElementUserObject> > & objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
     for (const auto & uo : objects)
       uo->execute();
   }
@@ -100,10 +100,10 @@ ComputeUserObjectsThread::onElement(const Elem * elem)
 
         _fe_problem.prepareShapes(jvar_id, _tid);
 
-        const std::vector<MooseSharedPointer<ElementUserObject> > & e_objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
+        const std::vector<std::shared_ptr<ElementUserObject> > & e_objects = _elemental_user_objects.getActiveBlockObjects(_subdomain, _tid);
         for (const auto & uo : e_objects)
         {
-          MooseSharedPointer<ShapeElementUserObject> shape_element_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeElementUserObject>(uo);
+          std::shared_ptr<ShapeElementUserObject> shape_element_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeElementUserObject>(uo);
           if (shape_element_uo)
             shape_element_uo->executeJacobianWrapper(jvar_id, dof_indices);
         }
@@ -126,7 +126,7 @@ ComputeUserObjectsThread::onBoundary(const Elem *elem, unsigned int side, Bounda
 
     _fe_problem.setCurrentBoundaryID(bnd_id);
 
-    const std::vector<MooseSharedPointer<SideUserObject> > & objects = _side_user_objects.getActiveBoundaryObjects(bnd_id, _tid);
+    const std::vector<std::shared_ptr<SideUserObject> > & objects = _side_user_objects.getActiveBoundaryObjects(bnd_id, _tid);
     for (const auto & uo : objects)
       uo->execute();
 
@@ -144,7 +144,7 @@ ComputeUserObjectsThread::onBoundary(const Elem *elem, unsigned int side, Bounda
 ;
         for (const auto & uo : objects)
         {
-          MooseSharedPointer<ShapeSideUserObject> shape_side_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeSideUserObject>(uo);
+          std::shared_ptr<ShapeSideUserObject> shape_side_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeSideUserObject>(uo);
           if (shape_side_uo)
             shape_side_uo->executeJacobianWrapper(jvar_id, dof_indices);
         }
@@ -181,7 +181,7 @@ ComputeUserObjectsThread::onInternalSide(const Elem *elem, unsigned int side)
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
 
-      const std::vector<MooseSharedPointer<InternalSideUserObject> > & objects = _internal_side_user_objects.getActiveBlockObjects(_subdomain, _tid);
+      const std::vector<std::shared_ptr<InternalSideUserObject> > & objects = _internal_side_user_objects.getActiveBlockObjects(_subdomain, _tid);
       for (const auto & uo : objects)
       {
         if (!uo->blockRestricted())

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -741,10 +741,10 @@ FEProblemBase::checkNonlocalCoupling()
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
     const KernelWarehouse & all_kernels = _nl->getKernelWarehouse();
-    const std::vector<std::shared_ptr<KernelBase> > & kernels = all_kernels.getObjects(tid);
+    const auto & kernels = all_kernels.getObjects(tid);
     for (const auto & kernel : kernels)
     {
-      std::shared_ptr<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
+      std::shared_ptr<NonlocalKernel> nonlocal_kernel = std::dynamic_pointer_cast<NonlocalKernel>(kernel);
       if (nonlocal_kernel)
       {
         if (_calculate_jacobian_in_uo)
@@ -753,10 +753,10 @@ FEProblemBase::checkNonlocalCoupling()
       }
     }
     const MooseObjectWarehouse<IntegratedBC> & all_integrated_bcs = _nl->getIntegratedBCWarehouse();
-    const std::vector<std::shared_ptr<IntegratedBC> > & integrated_bcs = all_integrated_bcs.getObjects(tid);
+    const auto & integrated_bcs = all_integrated_bcs.getObjects(tid);
     for (const auto & integrated_bc : integrated_bcs)
     {
-      std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(integrated_bc);
+      std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = std::dynamic_pointer_cast<NonlocalIntegratedBC>(integrated_bc);
       if (nonlocal_integrated_bc)
       {
         if (_calculate_jacobian_in_uo)
@@ -771,10 +771,10 @@ void
 FEProblemBase::checkUserObjectJacobianRequirement(THREAD_ID tid)
 {
   std::set<MooseVariable *> uo_jacobian_moose_vars;
-  const std::vector<std::shared_ptr<ElementUserObject> > & e_objects = _elemental_user_objects.getActiveObjects(tid);
+  const auto & e_objects = _elemental_user_objects.getActiveObjects(tid);
   for (const auto & uo : e_objects)
   {
-    std::shared_ptr<ShapeElementUserObject> shape_element_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeElementUserObject>(uo);
+    std::shared_ptr<ShapeElementUserObject> shape_element_uo = std::dynamic_pointer_cast<ShapeElementUserObject>(uo);
     if (shape_element_uo)
     {
       _calculate_jacobian_in_uo = shape_element_uo->computeJacobianFlag();
@@ -782,10 +782,10 @@ FEProblemBase::checkUserObjectJacobianRequirement(THREAD_ID tid)
       uo_jacobian_moose_vars.insert(mv_deps.begin(), mv_deps.end());
     }
   }
-  const std::vector<std::shared_ptr<SideUserObject> > & s_objects = _side_user_objects.getActiveObjects(tid);
+  const auto & s_objects = _side_user_objects.getActiveObjects(tid);
   for (const auto & uo : s_objects)
   {
-    std::shared_ptr<ShapeSideUserObject> shape_side_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeSideUserObject>(uo);
+    std::shared_ptr<ShapeSideUserObject> shape_side_uo = std::dynamic_pointer_cast<ShapeSideUserObject>(uo);
     if (shape_side_uo)
     {
       _calculate_jacobian_in_uo = shape_side_uo->computeJacobianFlag();
@@ -1857,7 +1857,7 @@ FEProblemBase::projectSolution()
   // processor with highest ID
   if (processor_id() == (n_processors()-1) && _scalar_ics.hasActiveObjects())
   {
-    const std::vector<std::shared_ptr<ScalarInitialCondition> > & ics = _scalar_ics.getActiveObjects();
+    const auto & ics = _scalar_ics.getActiveObjects();
     for (const auto & ic : ics)
     {
       MooseVariableScalar & var = ic->variable();
@@ -2149,33 +2149,33 @@ std::shared_ptr<Postprocessor>
 getPostprocessorPointer(std::shared_ptr<MooseObject> mo)
 {
   {
-    std::shared_ptr<ElementPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<ElementPostprocessor>(mo);
+    std::shared_ptr<ElementPostprocessor> intermediate = std::dynamic_pointer_cast<ElementPostprocessor>(mo);
     if (intermediate.get())
-      return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
+      return std::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   {
-    std::shared_ptr<NodalPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<NodalPostprocessor>(mo);
+    std::shared_ptr<NodalPostprocessor> intermediate = std::dynamic_pointer_cast<NodalPostprocessor>(mo);
     if (intermediate.get())
-      return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
+      return std::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   {
-    std::shared_ptr<InternalSidePostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<InternalSidePostprocessor>(mo);
+    std::shared_ptr<InternalSidePostprocessor> intermediate = std::dynamic_pointer_cast<InternalSidePostprocessor>(mo);
     if (intermediate.get())
-      return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
+      return std::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   {
-    std::shared_ptr<SidePostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<SidePostprocessor>(mo);
+    std::shared_ptr<SidePostprocessor> intermediate = std::dynamic_pointer_cast<SidePostprocessor>(mo);
     if (intermediate.get())
-      return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
+      return std::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   {
-    std::shared_ptr<GeneralPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<GeneralPostprocessor>(mo);
+    std::shared_ptr<GeneralPostprocessor> intermediate = std::dynamic_pointer_cast<GeneralPostprocessor>(mo);
     if (intermediate.get())
-      return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
+      return std::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   return std::shared_ptr<Postprocessor>();
@@ -2248,11 +2248,11 @@ FEProblemBase::addUserObject(std::string user_object_name, const std::string & n
     _all_user_objects.addObject(user_object, tid);
 
     // Attempt to create all the possible UserObject types
-    std::shared_ptr<ElementUserObject> euo = MooseSharedNamespace::dynamic_pointer_cast<ElementUserObject>(user_object);
-    std::shared_ptr<SideUserObject> suo = MooseSharedNamespace::dynamic_pointer_cast<SideUserObject>(user_object);
-    std::shared_ptr<InternalSideUserObject> isuo = MooseSharedNamespace::dynamic_pointer_cast<InternalSideUserObject>(user_object);
-    std::shared_ptr<NodalUserObject> nuo = MooseSharedNamespace::dynamic_pointer_cast<NodalUserObject>(user_object);
-    std::shared_ptr<GeneralUserObject> guo = MooseSharedNamespace::dynamic_pointer_cast<GeneralUserObject>(user_object);
+    std::shared_ptr<ElementUserObject> euo = std::dynamic_pointer_cast<ElementUserObject>(user_object);
+    std::shared_ptr<SideUserObject> suo = std::dynamic_pointer_cast<SideUserObject>(user_object);
+    std::shared_ptr<InternalSideUserObject> isuo = std::dynamic_pointer_cast<InternalSideUserObject>(user_object);
+    std::shared_ptr<NodalUserObject> nuo = std::dynamic_pointer_cast<NodalUserObject>(user_object);
+    std::shared_ptr<GeneralUserObject> guo = std::dynamic_pointer_cast<GeneralUserObject>(user_object);
 
     // Account for displaced mesh use
     if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
@@ -2360,7 +2360,7 @@ FEProblemBase::parentOutputPositionChanged()
 {
   for (const auto & it : _multi_apps)
   {
-    const std::vector<std::shared_ptr<MultiApp> > & objects = it.second.getActiveObjects();
+    const auto & objects = it.second.getActiveObjects();
     for (const auto & obj : objects)
       obj->parentOutputPositionChanged();
   }
@@ -2384,12 +2384,12 @@ FEProblemBase::computeIndicators()
     std::vector<std::string> fields;
 
     // Indicator Fields
-    const std::vector<std::shared_ptr<Indicator> > & indicators = _indicators.getActiveObjects();
+    const auto & indicators = _indicators.getActiveObjects();
     for (const auto & indicator : indicators)
       fields.push_back(indicator->name());
 
     // InternalSideIndicator Fields
-    const std::vector<std::shared_ptr<InternalSideIndicator> > & internal_indicators = _internal_side_indicators.getActiveObjects();
+    const auto & internal_indicators = _internal_side_indicators.getActiveObjects();
     for (const auto & internal_indicator : internal_indicators)
       fields.push_back(internal_indicator->name());
 
@@ -2420,7 +2420,7 @@ FEProblemBase::computeMarkers()
     std::vector<std::string> fields;
 
     // Marker Fields
-    const std::vector<std::shared_ptr<Marker> > & markers = _markers.getActiveObjects();
+    const auto & markers = _markers.getActiveObjects();
     for (const auto & marker : markers)
       fields.push_back(marker->name());
 
@@ -2430,7 +2430,7 @@ FEProblemBase::computeMarkers()
 
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
     {
-      const std::vector<std::shared_ptr<Marker> > & markers = _markers.getActiveObjects(tid);
+      const auto & markers = _markers.getActiveObjects(tid);
       for (const auto & marker : markers)
         marker->markerSetup();
     }
@@ -2583,14 +2583,14 @@ FEProblemBase::computeUserObjects(const ExecFlagType & type, const Moose::AuxGro
   // Execute GeneralUserObjects
   if (general.hasActiveObjects())
   {
-    const std::vector<std::shared_ptr<GeneralUserObject> > & objects = general.getActiveObjects();
+    const auto & objects = general.getActiveObjects();
     for (const auto & obj : objects)
     {
       obj->initialize();
       obj->execute();
       obj->finalize();
 
-      std::shared_ptr<Postprocessor> pp = MooseSharedNamespace::dynamic_pointer_cast<Postprocessor>(obj);
+      std::shared_ptr<Postprocessor> pp = std::dynamic_pointer_cast<Postprocessor>(obj);
       if (pp)
         _pps_data.storeValue(obj->name(), pp->getValue());
     }
@@ -2602,7 +2602,7 @@ FEProblemBase::computeUserObjects(const ExecFlagType & type, const Moose::AuxGro
 void
 FEProblemBase::executeControls(const ExecFlagType & exec_type)
 {
-  const std::vector<std::shared_ptr<Control> > & objects = _control_warehouse[exec_type].getActiveObjects();
+  const auto & objects = _control_warehouse[exec_type].getActiveObjects();
 
   if (!objects.empty())
   {
@@ -2716,7 +2716,7 @@ FEProblemBase::addIndicator(std::string indicator_name, const std::string & name
   {
     std::shared_ptr<Indicator> indicator = _factory.create<Indicator>(indicator_name, name, parameters, tid);
 
-    std::shared_ptr<InternalSideIndicator> isi = MooseSharedNamespace::dynamic_pointer_cast<InternalSideIndicator>(indicator);
+    std::shared_ptr<InternalSideIndicator> isi = std::dynamic_pointer_cast<InternalSideIndicator>(indicator);
     if (isi)
       _internal_side_indicators.addObject(isi, tid);
     else
@@ -2763,7 +2763,7 @@ FEProblemBase::addMultiApp(const std::string & multi_app_name, const std::string
 {
   setInputParametersFEProblem(parameters);
   parameters.set<MPI_Comm>("_mpi_comm") = _communicator.get();
-  parameters.set<std::shared_ptr<CommandLine> >("_command_line") = _app.commandLine();
+  parameters.set<std::shared_ptr<CommandLine>>("_command_line") = _app.commandLine();
 
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
@@ -2792,7 +2792,7 @@ FEProblemBase::addMultiApp(const std::string & multi_app_name, const std::string
   _multi_apps.addObject(multi_app);
 
   // Store TranseintMultiApp objects in another container, this is needed for calling computeDT
-  std::shared_ptr<TransientMultiApp> trans_multi_app = MooseSharedNamespace::dynamic_pointer_cast<TransientMultiApp>(multi_app);
+  std::shared_ptr<TransientMultiApp> trans_multi_app = std::dynamic_pointer_cast<TransientMultiApp>(multi_app);
   if (trans_multi_app)
     _transient_multi_apps.addObject(trans_multi_app);
 }
@@ -2814,7 +2814,7 @@ bool
 FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
 {
   // Active MultiApps
-  const std::vector<std::shared_ptr<MultiApp> > & multi_apps = _multi_apps[type].getActiveObjects();
+  const auto & multi_apps = _multi_apps[type].getActiveObjects();
 
   // Do anything that needs to be done to Apps before transfers
   for (const auto & multi_app : multi_apps)
@@ -2823,7 +2823,7 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
   // Execute Transfers _to_ MultiApps
   if (_to_multi_app_transfers[type].hasActiveObjects())
   {
-    const std::vector<std::shared_ptr<Transfer> > & transfers = _to_multi_app_transfers[type].getActiveObjects();
+    const auto & transfers = _to_multi_app_transfers[type].getActiveObjects();
 
     _console << COLOR_CYAN << "\nStarting Transfers on " <<  Moose::stringify(type) << " To MultiApps" << COLOR_DEFAULT << std::endl;
     for (const auto & transfer : transfers)
@@ -2866,7 +2866,7 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
   // Execute Transfers _from_ MultiApps
   if (_from_multi_app_transfers[type].hasActiveObjects())
   {
-    const std::vector<std::shared_ptr<Transfer> > & transfers = _from_multi_app_transfers[type].getActiveObjects();
+    const auto & transfers = _from_multi_app_transfers[type].getActiveObjects();
 
     _console << COLOR_CYAN << "\nStarting Transfers on " <<  Moose::stringify(type) << " From MultiApps" << COLOR_DEFAULT << std::endl;
     for (const auto & transfer : transfers)
@@ -2892,7 +2892,7 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
 void
 FEProblemBase::advanceMultiApps(ExecFlagType type)
 {
-  const std::vector<std::shared_ptr<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
+  const auto & multi_apps = _multi_apps[type].getActiveObjects();
 
   if (multi_apps.size())
   {
@@ -2911,7 +2911,7 @@ FEProblemBase::advanceMultiApps(ExecFlagType type)
 void
 FEProblemBase::backupMultiApps(ExecFlagType type)
 {
-  const std::vector<std::shared_ptr<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
+  const auto & multi_apps = _multi_apps[type].getActiveObjects();
 
   if (multi_apps.size())
   {
@@ -2930,7 +2930,7 @@ FEProblemBase::backupMultiApps(ExecFlagType type)
 void
 FEProblemBase::restoreMultiApps(ExecFlagType type, bool force)
 {
-  const std::vector<std::shared_ptr<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
+  const auto & multi_apps = _multi_apps[type].getActiveObjects();
 
   if (multi_apps.size())
   {
@@ -2953,7 +2953,7 @@ FEProblemBase::restoreMultiApps(ExecFlagType type, bool force)
 Real
 FEProblemBase::computeMultiAppsDT(ExecFlagType type)
 {
-  const std::vector<std::shared_ptr<TransientMultiApp> > & multi_apps = _transient_multi_apps[type].getActiveObjects();
+  const auto & multi_apps = _transient_multi_apps[type].getActiveObjects();
 
   Real smallest_dt = std::numeric_limits<Real>::max();
 
@@ -2969,7 +2969,7 @@ FEProblemBase::execTransfers(ExecFlagType type)
 {
   if (_transfers[type].hasActiveObjects())
   {
-    const std::vector<std::shared_ptr<Transfer> > & transfers = _transfers[type].getActiveObjects();
+    const auto & transfers = _transfers[type].getActiveObjects();
     for (const auto & transfer : transfers)
       transfer->execute();
   }
@@ -3006,7 +3006,7 @@ FEProblemBase::addTransfer(const std::string & transfer_name, const std::string 
   std::shared_ptr<Transfer> transfer = _factory.create<Transfer>(transfer_name, name, parameters);
 
   // Add MultiAppTransfer object
-  std::shared_ptr<MultiAppTransfer> multi_app_transfer = MooseSharedNamespace::dynamic_pointer_cast<MultiAppTransfer>(transfer);
+  std::shared_ptr<MultiAppTransfer> multi_app_transfer = std::dynamic_pointer_cast<MultiAppTransfer>(transfer);
   if (multi_app_transfer)
   {
     if (multi_app_transfer->direction() == MultiAppTransfer::TO_MULTIAPP)
@@ -3164,9 +3164,9 @@ FEProblemBase::setNonlocalCouplingMatrix()
 {
   unsigned int n_vars = _nl->nVariables();
   _nonlocal_cm.resize(n_vars);
-  const std::vector<MooseVariable *> & vars = _nl->getVariables(0);
-  const std::vector<std::shared_ptr<KernelBase> > & nonlocal_kernel = _nonlocal_kernels.getObjects();
-  const std::vector<std::shared_ptr<IntegratedBC> > & nonlocal_integrated_bc = _nonlocal_integrated_bcs.getObjects();
+  const auto & vars = _nl->getVariables(0);
+  const auto & nonlocal_kernel = _nonlocal_kernels.getObjects();
+  const auto & nonlocal_integrated_bc = _nonlocal_integrated_bcs.getObjects();
   for (const auto & ivar : vars)
   {
     for (const auto & kernel : nonlocal_kernel)
@@ -4190,7 +4190,7 @@ FEProblemBase::checkProblemIntegrity()
     //checkBoundaryMatProps();
 
     // Check that material properties exist when requested by other properties on a given block
-    const std::vector<std::shared_ptr<Material> > & materials = _all_materials.getActiveObjects();
+    const auto & materials = _all_materials.getActiveObjects();
     for (const auto & material : materials)
       material->checkStatefulSanity();
 
@@ -4259,7 +4259,7 @@ FEProblemBase::checkUserObjects()
   // and the blocks that they are defined on
   std::set<std::string> names;
 
-  const std::vector<std::shared_ptr<UserObject> > & objects = _all_user_objects.getActiveObjects();
+  const auto & objects = _all_user_objects.getActiveObjects();
   for (const auto & obj : objects)
     names.insert(obj->name());
 
@@ -4288,7 +4288,7 @@ FEProblemBase::checkUserObjects()
 
 
 void
-FEProblemBase::checkDependMaterialsHelper(const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & materials_map)
+FEProblemBase::checkDependMaterialsHelper(const std::map<SubdomainID, std::vector<std::shared_ptr<Material>>> & materials_map)
 {
   for (const auto & it : materials_map)
   {
@@ -4330,7 +4330,7 @@ FEProblemBase::checkDependMaterialsHelper(const std::map<SubdomainID, std::vecto
   // This loop checks that materials are not supplied by multiple Material objects
   for (const auto & it : materials_map)
   {
-    const std::vector<std::shared_ptr<Material> > & materials = it.second;
+    const auto & materials = it.second;
     std::set<std::string> inner_supplied, outer_supplied;
 
     for (const auto & outer_mat : materials)

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -741,10 +741,10 @@ FEProblemBase::checkNonlocalCoupling()
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
     const KernelWarehouse & all_kernels = _nl->getKernelWarehouse();
-    const std::vector<MooseSharedPointer<KernelBase> > & kernels = all_kernels.getObjects(tid);
+    const std::vector<std::shared_ptr<KernelBase> > & kernels = all_kernels.getObjects(tid);
     for (const auto & kernel : kernels)
     {
-      MooseSharedPointer<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
+      std::shared_ptr<NonlocalKernel> nonlocal_kernel = MooseSharedNamespace::dynamic_pointer_cast<NonlocalKernel>(kernel);
       if (nonlocal_kernel)
       {
         if (_calculate_jacobian_in_uo)
@@ -753,10 +753,10 @@ FEProblemBase::checkNonlocalCoupling()
       }
     }
     const MooseObjectWarehouse<IntegratedBC> & all_integrated_bcs = _nl->getIntegratedBCWarehouse();
-    const std::vector<MooseSharedPointer<IntegratedBC> > & integrated_bcs = all_integrated_bcs.getObjects(tid);
+    const std::vector<std::shared_ptr<IntegratedBC> > & integrated_bcs = all_integrated_bcs.getObjects(tid);
     for (const auto & integrated_bc : integrated_bcs)
     {
-      MooseSharedPointer<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(integrated_bc);
+      std::shared_ptr<NonlocalIntegratedBC> nonlocal_integrated_bc = MooseSharedNamespace::dynamic_pointer_cast<NonlocalIntegratedBC>(integrated_bc);
       if (nonlocal_integrated_bc)
       {
         if (_calculate_jacobian_in_uo)
@@ -771,10 +771,10 @@ void
 FEProblemBase::checkUserObjectJacobianRequirement(THREAD_ID tid)
 {
   std::set<MooseVariable *> uo_jacobian_moose_vars;
-  const std::vector<MooseSharedPointer<ElementUserObject> > & e_objects = _elemental_user_objects.getActiveObjects(tid);
+  const std::vector<std::shared_ptr<ElementUserObject> > & e_objects = _elemental_user_objects.getActiveObjects(tid);
   for (const auto & uo : e_objects)
   {
-    MooseSharedPointer<ShapeElementUserObject> shape_element_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeElementUserObject>(uo);
+    std::shared_ptr<ShapeElementUserObject> shape_element_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeElementUserObject>(uo);
     if (shape_element_uo)
     {
       _calculate_jacobian_in_uo = shape_element_uo->computeJacobianFlag();
@@ -782,10 +782,10 @@ FEProblemBase::checkUserObjectJacobianRequirement(THREAD_ID tid)
       uo_jacobian_moose_vars.insert(mv_deps.begin(), mv_deps.end());
     }
   }
-  const std::vector<MooseSharedPointer<SideUserObject> > & s_objects = _side_user_objects.getActiveObjects(tid);
+  const std::vector<std::shared_ptr<SideUserObject> > & s_objects = _side_user_objects.getActiveObjects(tid);
   for (const auto & uo : s_objects)
   {
-    MooseSharedPointer<ShapeSideUserObject> shape_side_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeSideUserObject>(uo);
+    std::shared_ptr<ShapeSideUserObject> shape_side_uo = MooseSharedNamespace::dynamic_pointer_cast<ShapeSideUserObject>(uo);
     if (shape_side_uo)
     {
       _calculate_jacobian_in_uo = shape_side_uo->computeJacobianFlag();
@@ -1398,7 +1398,7 @@ FEProblemBase::addFunction(std::string type, const std::string & name, InputPara
 
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
-    MooseSharedPointer<Function> func = _factory.create<Function>(type, name, parameters, tid);
+    std::shared_ptr<Function> func = _factory.create<Function>(type, name, parameters, tid);
     _functions.addObject(func, tid);
   }
 }
@@ -1811,7 +1811,7 @@ FEProblemBase::addInitialCondition(const std::string & ic_name, const std::strin
     {
       MooseVariable & var = getVariable(tid, var_name);
       parameters.set<SystemBase *>("_sys") = &var.sys();
-      MooseSharedPointer<InitialCondition> ic = _factory.create<InitialCondition>(ic_name, name, parameters, tid);
+      std::shared_ptr<InitialCondition> ic = _factory.create<InitialCondition>(ic_name, name, parameters, tid);
       _ics.addObject(ic, tid);
     }
   }
@@ -1821,7 +1821,7 @@ FEProblemBase::addInitialCondition(const std::string & ic_name, const std::strin
   {
     MooseVariableScalar & var = getScalarVariable(0, var_name);
     parameters.set<SystemBase *>("_sys") = &var.sys();
-    MooseSharedPointer<ScalarInitialCondition> ic = _factory.create<ScalarInitialCondition>(ic_name, name, parameters);
+    std::shared_ptr<ScalarInitialCondition> ic = _factory.create<ScalarInitialCondition>(ic_name, name, parameters);
     _scalar_ics.addObject(ic);
   }
 
@@ -1857,7 +1857,7 @@ FEProblemBase::projectSolution()
   // processor with highest ID
   if (processor_id() == (n_processors()-1) && _scalar_ics.hasActiveObjects())
   {
-    const std::vector<MooseSharedPointer<ScalarInitialCondition> > & ics = _scalar_ics.getActiveObjects();
+    const std::vector<std::shared_ptr<ScalarInitialCondition> > & ics = _scalar_ics.getActiveObjects();
     for (const auto & ic : ics)
     {
       MooseVariableScalar & var = ic->variable();
@@ -1888,7 +1888,7 @@ FEProblemBase::projectSolution()
 }
 
 
-MooseSharedPointer<Material>
+std::shared_ptr<Material>
 FEProblemBase::getMaterial(std::string name, Moose::MaterialDataType type, THREAD_ID tid)
 {
   switch (type)
@@ -1903,7 +1903,7 @@ FEProblemBase::getMaterial(std::string name, Moose::MaterialDataType type, THREA
     break;
   }
 
-  MooseSharedPointer<Material> material = _all_materials[type].getActiveObject(name, tid);
+  std::shared_ptr<Material> material = _all_materials[type].getActiveObject(name, tid);
   if (material->getParam<bool>("compute") && type == Moose::BLOCK_MATERIAL_DATA)
     mooseWarning("You are retrieving a Material object (" << material->name() << "), but its compute flag is not set to true. This indicates that MOOSE is computing this property which may not be desired and produce un-expected results.");
 
@@ -1911,10 +1911,10 @@ FEProblemBase::getMaterial(std::string name, Moose::MaterialDataType type, THREA
 }
 
 
-MooseSharedPointer<MaterialData>
+std::shared_ptr<MaterialData>
 FEProblemBase::getMaterialData(Moose::MaterialDataType type, THREAD_ID tid)
 {
-  MooseSharedPointer<MaterialData> output;
+  std::shared_ptr<MaterialData> output;
   switch (type)
   {
   case Moose::BLOCK_MATERIAL_DATA:
@@ -1959,7 +1959,7 @@ FEProblemBase::addMaterial(const std::string & mat_name, const std::string & nam
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
     // Create the general Block/Boundary Material object
-    MooseSharedPointer<Material> material = _factory.create<Material>(mat_name, name, parameters, tid);
+    std::shared_ptr<Material> material = _factory.create<Material>(mat_name, name, parameters, tid);
     bool discrete = !material->getParam<bool>("compute");
 
     // If the object is boundary restricted do not create the neighbor and face objects
@@ -1984,13 +1984,13 @@ FEProblemBase::addMaterial(const std::string & mat_name, const std::string & nam
       // face material
       current_parameters.set<Moose::MaterialDataType>("_material_data_type") = Moose::FACE_MATERIAL_DATA;
       object_name = name + "_face";
-      MooseSharedPointer<Material> face_material = _factory.create<Material>(mat_name, object_name, current_parameters, tid);
+      std::shared_ptr<Material> face_material = _factory.create<Material>(mat_name, object_name, current_parameters, tid);
 
       // neighbor material
       current_parameters.set<Moose::MaterialDataType>("_material_data_type") = Moose::NEIGHBOR_MATERIAL_DATA;
       current_parameters.set<bool>("_neighbor") = true;
       object_name = name + "_neighbor";
-      MooseSharedPointer<Material> neighbor_material = _factory.create<Material>(mat_name, object_name, current_parameters, tid);
+      std::shared_ptr<Material> neighbor_material = _factory.create<Material>(mat_name, object_name, current_parameters, tid);
 
       // Store the material objects
       _all_materials.addObjects(material, neighbor_material, face_material, tid);
@@ -2145,40 +2145,40 @@ FEProblemBase::swapBackMaterialsNeighbor(THREAD_ID tid)
 /**
  * Small helper function used by addPostprocessor to try to get a Postprocessor pointer from a MooseObject
  */
-MooseSharedPointer<Postprocessor>
-getPostprocessorPointer(MooseSharedPointer<MooseObject> mo)
+std::shared_ptr<Postprocessor>
+getPostprocessorPointer(std::shared_ptr<MooseObject> mo)
 {
   {
-    MooseSharedPointer<ElementPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<ElementPostprocessor>(mo);
+    std::shared_ptr<ElementPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<ElementPostprocessor>(mo);
     if (intermediate.get())
       return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   {
-    MooseSharedPointer<NodalPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<NodalPostprocessor>(mo);
+    std::shared_ptr<NodalPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<NodalPostprocessor>(mo);
     if (intermediate.get())
       return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   {
-    MooseSharedPointer<InternalSidePostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<InternalSidePostprocessor>(mo);
+    std::shared_ptr<InternalSidePostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<InternalSidePostprocessor>(mo);
     if (intermediate.get())
       return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   {
-    MooseSharedPointer<SidePostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<SidePostprocessor>(mo);
+    std::shared_ptr<SidePostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<SidePostprocessor>(mo);
     if (intermediate.get())
       return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
   }
 
   {
-    MooseSharedPointer<GeneralPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<GeneralPostprocessor>(mo);
+    std::shared_ptr<GeneralPostprocessor> intermediate = MooseSharedNamespace::dynamic_pointer_cast<GeneralPostprocessor>(mo);
     if (intermediate.get())
       return MooseSharedNamespace::static_pointer_cast<Postprocessor>(intermediate);
   }
 
-  return MooseSharedPointer<Postprocessor>();
+  return std::shared_ptr<Postprocessor>();
 }
 
 template <typename UO_TYPE, typename PP_TYPE>
@@ -2244,15 +2244,15 @@ FEProblemBase::addUserObject(std::string user_object_name, const std::string & n
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
   {
     // Create the UserObject
-    MooseSharedPointer<UserObject> user_object = _factory.create<UserObject>(user_object_name, name, parameters, tid);
+    std::shared_ptr<UserObject> user_object = _factory.create<UserObject>(user_object_name, name, parameters, tid);
     _all_user_objects.addObject(user_object, tid);
 
     // Attempt to create all the possible UserObject types
-    MooseSharedPointer<ElementUserObject> euo = MooseSharedNamespace::dynamic_pointer_cast<ElementUserObject>(user_object);
-    MooseSharedPointer<SideUserObject> suo = MooseSharedNamespace::dynamic_pointer_cast<SideUserObject>(user_object);
-    MooseSharedPointer<InternalSideUserObject> isuo = MooseSharedNamespace::dynamic_pointer_cast<InternalSideUserObject>(user_object);
-    MooseSharedPointer<NodalUserObject> nuo = MooseSharedNamespace::dynamic_pointer_cast<NodalUserObject>(user_object);
-    MooseSharedPointer<GeneralUserObject> guo = MooseSharedNamespace::dynamic_pointer_cast<GeneralUserObject>(user_object);
+    std::shared_ptr<ElementUserObject> euo = MooseSharedNamespace::dynamic_pointer_cast<ElementUserObject>(user_object);
+    std::shared_ptr<SideUserObject> suo = MooseSharedNamespace::dynamic_pointer_cast<SideUserObject>(user_object);
+    std::shared_ptr<InternalSideUserObject> isuo = MooseSharedNamespace::dynamic_pointer_cast<InternalSideUserObject>(user_object);
+    std::shared_ptr<NodalUserObject> nuo = MooseSharedNamespace::dynamic_pointer_cast<NodalUserObject>(user_object);
+    std::shared_ptr<GeneralUserObject> guo = MooseSharedNamespace::dynamic_pointer_cast<GeneralUserObject>(user_object);
 
     // Account for displaced mesh use
     if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
@@ -2360,7 +2360,7 @@ FEProblemBase::parentOutputPositionChanged()
 {
   for (const auto & it : _multi_apps)
   {
-    const std::vector<MooseSharedPointer<MultiApp> > & objects = it.second.getActiveObjects();
+    const std::vector<std::shared_ptr<MultiApp> > & objects = it.second.getActiveObjects();
     for (const auto & obj : objects)
       obj->parentOutputPositionChanged();
   }
@@ -2384,12 +2384,12 @@ FEProblemBase::computeIndicators()
     std::vector<std::string> fields;
 
     // Indicator Fields
-    const std::vector<MooseSharedPointer<Indicator> > & indicators = _indicators.getActiveObjects();
+    const std::vector<std::shared_ptr<Indicator> > & indicators = _indicators.getActiveObjects();
     for (const auto & indicator : indicators)
       fields.push_back(indicator->name());
 
     // InternalSideIndicator Fields
-    const std::vector<MooseSharedPointer<InternalSideIndicator> > & internal_indicators = _internal_side_indicators.getActiveObjects();
+    const std::vector<std::shared_ptr<InternalSideIndicator> > & internal_indicators = _internal_side_indicators.getActiveObjects();
     for (const auto & internal_indicator : internal_indicators)
       fields.push_back(internal_indicator->name());
 
@@ -2420,7 +2420,7 @@ FEProblemBase::computeMarkers()
     std::vector<std::string> fields;
 
     // Marker Fields
-    const std::vector<MooseSharedPointer<Marker> > & markers = _markers.getActiveObjects();
+    const std::vector<std::shared_ptr<Marker> > & markers = _markers.getActiveObjects();
     for (const auto & marker : markers)
       fields.push_back(marker->name());
 
@@ -2430,7 +2430,7 @@ FEProblemBase::computeMarkers()
 
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
     {
-      const std::vector<MooseSharedPointer<Marker> > & markers = _markers.getActiveObjects(tid);
+      const std::vector<std::shared_ptr<Marker> > & markers = _markers.getActiveObjects(tid);
       for (const auto & marker : markers)
         marker->markerSetup();
     }
@@ -2583,14 +2583,14 @@ FEProblemBase::computeUserObjects(const ExecFlagType & type, const Moose::AuxGro
   // Execute GeneralUserObjects
   if (general.hasActiveObjects())
   {
-    const std::vector<MooseSharedPointer<GeneralUserObject> > & objects = general.getActiveObjects();
+    const std::vector<std::shared_ptr<GeneralUserObject> > & objects = general.getActiveObjects();
     for (const auto & obj : objects)
     {
       obj->initialize();
       obj->execute();
       obj->finalize();
 
-      MooseSharedPointer<Postprocessor> pp = MooseSharedNamespace::dynamic_pointer_cast<Postprocessor>(obj);
+      std::shared_ptr<Postprocessor> pp = MooseSharedNamespace::dynamic_pointer_cast<Postprocessor>(obj);
       if (pp)
         _pps_data.storeValue(obj->name(), pp->getValue());
     }
@@ -2602,7 +2602,7 @@ FEProblemBase::computeUserObjects(const ExecFlagType & type, const Moose::AuxGro
 void
 FEProblemBase::executeControls(const ExecFlagType & exec_type)
 {
-  const std::vector<MooseSharedPointer<Control> > & objects = _control_warehouse[exec_type].getActiveObjects();
+  const std::vector<std::shared_ptr<Control> > & objects = _control_warehouse[exec_type].getActiveObjects();
 
   if (!objects.empty())
   {
@@ -2714,9 +2714,9 @@ FEProblemBase::addIndicator(std::string indicator_name, const std::string & name
 
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
-    MooseSharedPointer<Indicator> indicator = _factory.create<Indicator>(indicator_name, name, parameters, tid);
+    std::shared_ptr<Indicator> indicator = _factory.create<Indicator>(indicator_name, name, parameters, tid);
 
-    MooseSharedPointer<InternalSideIndicator> isi = MooseSharedNamespace::dynamic_pointer_cast<InternalSideIndicator>(indicator);
+    std::shared_ptr<InternalSideIndicator> isi = MooseSharedNamespace::dynamic_pointer_cast<InternalSideIndicator>(indicator);
     if (isi)
       _internal_side_indicators.addObject(isi, tid);
     else
@@ -2753,7 +2753,7 @@ FEProblemBase::addMarker(std::string marker_name, const std::string & name, Inpu
 
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
-    MooseSharedPointer<Marker> marker = _factory.create<Marker>(marker_name, name, parameters, tid);
+    std::shared_ptr<Marker> marker = _factory.create<Marker>(marker_name, name, parameters, tid);
     _markers.addObject(marker, tid);
   }
 }
@@ -2763,7 +2763,7 @@ FEProblemBase::addMultiApp(const std::string & multi_app_name, const std::string
 {
   setInputParametersFEProblem(parameters);
   parameters.set<MPI_Comm>("_mpi_comm") = _communicator.get();
-  parameters.set<MooseSharedPointer<CommandLine> >("_command_line") = _app.commandLine();
+  parameters.set<std::shared_ptr<CommandLine> >("_command_line") = _app.commandLine();
 
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
@@ -2787,12 +2787,12 @@ FEProblemBase::addMultiApp(const std::string & multi_app_name, const std::string
     parameters.set<SystemBase *>("_sys") = _aux;
   }
 
-  MooseSharedPointer<MultiApp> multi_app = _factory.create<MultiApp>(multi_app_name, name, parameters);
+  std::shared_ptr<MultiApp> multi_app = _factory.create<MultiApp>(multi_app_name, name, parameters);
 
   _multi_apps.addObject(multi_app);
 
   // Store TranseintMultiApp objects in another container, this is needed for calling computeDT
-  MooseSharedPointer<TransientMultiApp> trans_multi_app = MooseSharedNamespace::dynamic_pointer_cast<TransientMultiApp>(multi_app);
+  std::shared_ptr<TransientMultiApp> trans_multi_app = MooseSharedNamespace::dynamic_pointer_cast<TransientMultiApp>(multi_app);
   if (trans_multi_app)
     _transient_multi_apps.addObject(trans_multi_app);
 }
@@ -2804,7 +2804,7 @@ FEProblemBase::hasMultiApp(const std::string & multi_app_name)
 }
 
 
-MooseSharedPointer<MultiApp>
+std::shared_ptr<MultiApp>
 FEProblemBase::getMultiApp(const std::string & multi_app_name)
 {
   return _multi_apps.getActiveObject(multi_app_name);
@@ -2814,7 +2814,7 @@ bool
 FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
 {
   // Active MultiApps
-  const std::vector<MooseSharedPointer<MultiApp> > & multi_apps = _multi_apps[type].getActiveObjects();
+  const std::vector<std::shared_ptr<MultiApp> > & multi_apps = _multi_apps[type].getActiveObjects();
 
   // Do anything that needs to be done to Apps before transfers
   for (const auto & multi_app : multi_apps)
@@ -2823,7 +2823,7 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
   // Execute Transfers _to_ MultiApps
   if (_to_multi_app_transfers[type].hasActiveObjects())
   {
-    const std::vector<MooseSharedPointer<Transfer> > & transfers = _to_multi_app_transfers[type].getActiveObjects();
+    const std::vector<std::shared_ptr<Transfer> > & transfers = _to_multi_app_transfers[type].getActiveObjects();
 
     _console << COLOR_CYAN << "\nStarting Transfers on " <<  Moose::stringify(type) << " To MultiApps" << COLOR_DEFAULT << std::endl;
     for (const auto & transfer : transfers)
@@ -2866,7 +2866,7 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
   // Execute Transfers _from_ MultiApps
   if (_from_multi_app_transfers[type].hasActiveObjects())
   {
-    const std::vector<MooseSharedPointer<Transfer> > & transfers = _from_multi_app_transfers[type].getActiveObjects();
+    const std::vector<std::shared_ptr<Transfer> > & transfers = _from_multi_app_transfers[type].getActiveObjects();
 
     _console << COLOR_CYAN << "\nStarting Transfers on " <<  Moose::stringify(type) << " From MultiApps" << COLOR_DEFAULT << std::endl;
     for (const auto & transfer : transfers)
@@ -2892,7 +2892,7 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
 void
 FEProblemBase::advanceMultiApps(ExecFlagType type)
 {
-  const std::vector<MooseSharedPointer<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
+  const std::vector<std::shared_ptr<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
 
   if (multi_apps.size())
   {
@@ -2911,7 +2911,7 @@ FEProblemBase::advanceMultiApps(ExecFlagType type)
 void
 FEProblemBase::backupMultiApps(ExecFlagType type)
 {
-  const std::vector<MooseSharedPointer<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
+  const std::vector<std::shared_ptr<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
 
   if (multi_apps.size())
   {
@@ -2930,7 +2930,7 @@ FEProblemBase::backupMultiApps(ExecFlagType type)
 void
 FEProblemBase::restoreMultiApps(ExecFlagType type, bool force)
 {
-  const std::vector<MooseSharedPointer<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
+  const std::vector<std::shared_ptr<MultiApp> > multi_apps = _multi_apps[type].getActiveObjects();
 
   if (multi_apps.size())
   {
@@ -2953,7 +2953,7 @@ FEProblemBase::restoreMultiApps(ExecFlagType type, bool force)
 Real
 FEProblemBase::computeMultiAppsDT(ExecFlagType type)
 {
-  const std::vector<MooseSharedPointer<TransientMultiApp> > & multi_apps = _transient_multi_apps[type].getActiveObjects();
+  const std::vector<std::shared_ptr<TransientMultiApp> > & multi_apps = _transient_multi_apps[type].getActiveObjects();
 
   Real smallest_dt = std::numeric_limits<Real>::max();
 
@@ -2969,7 +2969,7 @@ FEProblemBase::execTransfers(ExecFlagType type)
 {
   if (_transfers[type].hasActiveObjects())
   {
-    const std::vector<MooseSharedPointer<Transfer> > & transfers = _transfers[type].getActiveObjects();
+    const std::vector<std::shared_ptr<Transfer> > & transfers = _transfers[type].getActiveObjects();
     for (const auto & transfer : transfers)
       transfer->execute();
   }
@@ -3003,10 +3003,10 @@ FEProblemBase::addTransfer(const std::string & transfer_name, const std::string 
   }
 
   // Create the Transfer objects
-  MooseSharedPointer<Transfer> transfer = _factory.create<Transfer>(transfer_name, name, parameters);
+  std::shared_ptr<Transfer> transfer = _factory.create<Transfer>(transfer_name, name, parameters);
 
   // Add MultiAppTransfer object
-  MooseSharedPointer<MultiAppTransfer> multi_app_transfer = MooseSharedNamespace::dynamic_pointer_cast<MultiAppTransfer>(transfer);
+  std::shared_ptr<MultiAppTransfer> multi_app_transfer = MooseSharedNamespace::dynamic_pointer_cast<MultiAppTransfer>(transfer);
   if (multi_app_transfer)
   {
     if (multi_app_transfer->direction() == MultiAppTransfer::TO_MULTIAPP)
@@ -3165,8 +3165,8 @@ FEProblemBase::setNonlocalCouplingMatrix()
   unsigned int n_vars = _nl->nVariables();
   _nonlocal_cm.resize(n_vars);
   const std::vector<MooseVariable *> & vars = _nl->getVariables(0);
-  const std::vector<MooseSharedPointer<KernelBase> > & nonlocal_kernel = _nonlocal_kernels.getObjects();
-  const std::vector<MooseSharedPointer<IntegratedBC> > & nonlocal_integrated_bc = _nonlocal_integrated_bcs.getObjects();
+  const std::vector<std::shared_ptr<KernelBase> > & nonlocal_kernel = _nonlocal_kernels.getObjects();
+  const std::vector<std::shared_ptr<IntegratedBC> > & nonlocal_integrated_bc = _nonlocal_integrated_bcs.getObjects();
   for (const auto & ivar : vars)
   {
     for (const auto & kernel : nonlocal_kernel)
@@ -3525,7 +3525,7 @@ FEProblemBase::addPredictor(const std::string & type, const std::string & name, 
 {
   setInputParametersFEProblem(parameters);
   parameters.set<SubProblem *>("_subproblem") = this;
-  MooseSharedPointer<Predictor> predictor = _factory.create<Predictor>(type, name, parameters);
+  std::shared_ptr<Predictor> predictor = _factory.create<Predictor>(type, name, parameters);
   _nl->setPredictor(predictor);
 }
 
@@ -3907,7 +3907,7 @@ FEProblemBase::predictorCleanup(NumericVector<Number>& /*ghosted_solution*/)
 }
 
 void
-FEProblemBase::addDisplacedProblem(MooseSharedPointer<DisplacedProblem> displaced_problem)
+FEProblemBase::addDisplacedProblem(std::shared_ptr<DisplacedProblem> displaced_problem)
 {
   _displaced_mesh = &displaced_problem->mesh();
   _displaced_problem = displaced_problem;
@@ -4022,7 +4022,7 @@ FEProblemBase::adaptMesh()
 #endif //LIBMESH_ENABLE_AMR
 
 void
-FEProblemBase::initXFEM(MooseSharedPointer<XFEMInterface> xfem)
+FEProblemBase::initXFEM(std::shared_ptr<XFEMInterface> xfem)
 {
   _xfem = xfem;
   _xfem->setMesh(&_mesh.getMesh());
@@ -4190,7 +4190,7 @@ FEProblemBase::checkProblemIntegrity()
     //checkBoundaryMatProps();
 
     // Check that material properties exist when requested by other properties on a given block
-    const std::vector<MooseSharedPointer<Material> > & materials = _all_materials.getActiveObjects();
+    const std::vector<std::shared_ptr<Material> > & materials = _all_materials.getActiveObjects();
     for (const auto & material : materials)
       material->checkStatefulSanity();
 
@@ -4259,7 +4259,7 @@ FEProblemBase::checkUserObjects()
   // and the blocks that they are defined on
   std::set<std::string> names;
 
-  const std::vector<MooseSharedPointer<UserObject> > & objects = _all_user_objects.getActiveObjects();
+  const std::vector<std::shared_ptr<UserObject> > & objects = _all_user_objects.getActiveObjects();
   for (const auto & obj : objects)
     names.insert(obj->name());
 
@@ -4288,7 +4288,7 @@ FEProblemBase::checkUserObjects()
 
 
 void
-FEProblemBase::checkDependMaterialsHelper(const std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > > & materials_map)
+FEProblemBase::checkDependMaterialsHelper(const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & materials_map)
 {
   for (const auto & it : materials_map)
   {
@@ -4330,7 +4330,7 @@ FEProblemBase::checkDependMaterialsHelper(const std::map<SubdomainID, std::vecto
   // This loop checks that materials are not supplied by multiple Material objects
   for (const auto & it : materials_map)
   {
-    const std::vector<MooseSharedPointer<Material> > & materials = it.second;
+    const std::vector<std::shared_ptr<Material> > & materials = it.second;
     std::set<std::string> inner_supplied, outer_supplied;
 
     for (const auto & outer_mat : materials)

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -112,19 +112,19 @@ InputParameters validParams<MooseApp>()
   params.addPrivateParam<std::string>("_type");
   params.addPrivateParam<int>("_argc");
   params.addPrivateParam<char**>("_argv");
-  params.addPrivateParam<std::shared_ptr<CommandLine> >("_command_line");
-  params.addPrivateParam<std::shared_ptr<Parallel::Communicator> >("_comm");
+  params.addPrivateParam<std::shared_ptr<CommandLine>>("_command_line");
+  params.addPrivateParam<std::shared_ptr<Parallel::Communicator>>("_comm");
 
   return params;
 }
 
 MooseApp::MooseApp(InputParameters parameters) :
     ConsoleStreamInterface(*this),
-    ParallelObject(*parameters.get<std::shared_ptr<Parallel::Communicator> >("_comm")), // Can't call getParam() before pars is set
+    ParallelObject(*parameters.get<std::shared_ptr<Parallel::Communicator>>("_comm")), // Can't call getParam() before pars is set
     _name(parameters.get<std::string>("_app_name")),
     _pars(parameters),
     _type(getParam<std::string>("_type")),
-    _comm(getParam<std::shared_ptr<Parallel::Communicator> >("_comm")),
+    _comm(getParam<std::shared_ptr<Parallel::Communicator>>("_comm")),
     _output_position_set(false),
     _start_time_set(false),
     _start_time(0.0),
@@ -158,7 +158,7 @@ MooseApp::MooseApp(InputParameters parameters) :
     _sys_info = std::make_shared<SystemInfo>(argc, argv);
   }
   if (isParamValid("_command_line"))
-    _command_line = getParam<std::shared_ptr<CommandLine> >("_command_line");
+    _command_line = getParam<std::shared_ptr<CommandLine>>("_command_line");
   else
     mooseError("Valid CommandLine object required");
 
@@ -932,7 +932,7 @@ MooseApp::getMeshModifier(const std::string & name) const
 void
 MooseApp::executeMeshModifiers()
 {
-  DependencyResolver<std::shared_ptr<MeshModifier> > resolver;
+  DependencyResolver<std::shared_ptr<MeshModifier>> resolver;
 
   // Add all of the dependencies into the resolver and sort them
   for (const auto & it : _mesh_modifiers)
@@ -943,7 +943,7 @@ MooseApp::executeMeshModifiers()
     std::vector<std::string> & modifiers = it.second->getDependencies();
     for (const auto & depend_name : modifiers)
     {
-      std::map<std::string, std::shared_ptr<MeshModifier> >::const_iterator depend_it = _mesh_modifiers.find(depend_name);
+      auto depend_it = _mesh_modifiers.find(depend_name);
 
       if (depend_it == _mesh_modifiers.end())
         mooseError("The MeshModifier \"" << depend_name << "\" was not created, did you make a spelling mistake or forget to include it in your input file?");
@@ -952,7 +952,7 @@ MooseApp::executeMeshModifiers()
     }
   }
 
-  const std::vector<std::shared_ptr<MeshModifier> > & ordered_modifiers = resolver.getSortedValues();
+  const auto & ordered_modifiers = resolver.getSortedValues();
 
   if (ordered_modifiers.size())
   {
@@ -1018,7 +1018,7 @@ MooseApp::createMinimalApp()
     action_params.set<std::string>("task") = "setup_mesh";
 
     // Create The Action
-    std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("SetupMeshAction", "Mesh", action_params));
+    std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(_action_factory.create("SetupMeshAction", "Mesh", action_params));
 
     // Set the object parameters
     InputParameters & params = action->getObjectParams();
@@ -1048,7 +1048,7 @@ MooseApp::createMinimalApp()
     action_params.set<std::string>("type") = "Transient";
 
     // Create the action
-    std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("CreateExecutionerAction", "Executioner", action_params));
+    std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(_action_factory.create("CreateExecutionerAction", "Executioner", action_params));
 
     // Set the object parameters
     InputParameters & params = action->getObjectParams();
@@ -1066,7 +1066,7 @@ MooseApp::createMinimalApp()
     action_params.set<std::string>("type") = "FEProblem";
 
     // Create the action
-    std::shared_ptr<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("CreateProblemAction", "Problem", action_params));
+    std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(_action_factory.create("CreateProblemAction", "Problem", action_params));
 
     // Set the object parameters
     InputParameters & params = action->getObjectParams();

--- a/framework/src/base/MooseEigenSystem.C
+++ b/framework/src/base/MooseEigenSystem.C
@@ -40,7 +40,7 @@ MooseEigenSystem::addKernel(const std::string & kernel_name, const std::string &
       {
         // EigenKernel
         parameters.set<bool>("implicit") = true;
-        MooseSharedPointer<KernelBase> ekernel = _factory.create<KernelBase>(kernel_name, name, parameters, tid);
+        std::shared_ptr<KernelBase> ekernel = _factory.create<KernelBase>(kernel_name, name, parameters, tid);
         if (parameters.get<bool>("eigen"))
           markEigenVariable(parameters.get<NonlinearVariableName>("variable"));
         _kernels.addObject(ekernel, tid);
@@ -51,7 +51,7 @@ MooseEigenSystem::addKernel(const std::string & kernel_name, const std::string &
         parameters.set<bool>("implicit") = false;
         std::string old_name(name + "_old");
 
-        MooseSharedPointer<KernelBase> ekernel = _factory.create<KernelBase>(kernel_name, old_name, parameters, tid);
+        std::shared_ptr<KernelBase> ekernel = _factory.create<KernelBase>(kernel_name, old_name, parameters, tid);
         _eigen_var_names.insert(parameters.get<NonlinearVariableName>("variable"));
         _kernels.addObject(ekernel, tid);
         ++_eigen_kernel_counter;
@@ -60,7 +60,7 @@ MooseEigenSystem::addKernel(const std::string & kernel_name, const std::string &
     else // Standard nonlinear system kernel
     {
       // Create the kernel object via the factory
-      MooseSharedPointer<KernelBase> kernel = _factory.create<KernelBase>(kernel_name, name, parameters, tid);
+      std::shared_ptr<KernelBase> kernel = _factory.create<KernelBase>(kernel_name, name, parameters, tid);
       _kernels.addObject(kernel, tid);
     }
   }

--- a/framework/src/base/NonlinearEigenSystem.C
+++ b/framework/src/base/NonlinearEigenSystem.C
@@ -147,7 +147,7 @@ NonlinearEigenSystem::getNthConvergedEigenvalue(dof_id_type n)
 }
 
 void
-NonlinearEigenSystem::addEigenKernels(MooseSharedPointer<KernelBase> kernel, THREAD_ID tid)
+NonlinearEigenSystem::addEigenKernels(std::shared_ptr<KernelBase> kernel, THREAD_ID tid)
 {
   if (kernel->isEigenKernel())
     _eigen_kernels.addObject(kernel, tid);
@@ -163,10 +163,10 @@ NonlinearEigenSystem::checkIntegrity()
 
   if (_nodal_bcs.hasActiveObjects())
   {
-    const std::vector<MooseSharedPointer<NodalBC> > & nodal_bcs = _nodal_bcs.getActiveObjects();
+    const std::vector<std::shared_ptr<NodalBC> > & nodal_bcs = _nodal_bcs.getActiveObjects();
     for (const auto & nodal_bc : nodal_bcs)
     {
-      MooseSharedPointer<DirichletBC> nbc = MooseSharedNamespace::dynamic_pointer_cast<DirichletBC>(nodal_bc);
+      std::shared_ptr<DirichletBC> nbc = MooseSharedNamespace::dynamic_pointer_cast<DirichletBC>(nodal_bc);
       if (nbc && nbc->getParam<Real>("value"))
         mooseError("Can't set an inhomogeneous Dirichlet boundary condition for eigenvalue problems.");
       else if (!nbc)

--- a/framework/src/base/NonlinearEigenSystem.C
+++ b/framework/src/base/NonlinearEigenSystem.C
@@ -163,10 +163,10 @@ NonlinearEigenSystem::checkIntegrity()
 
   if (_nodal_bcs.hasActiveObjects())
   {
-    const std::vector<std::shared_ptr<NodalBC> > & nodal_bcs = _nodal_bcs.getActiveObjects();
+    const auto & nodal_bcs = _nodal_bcs.getActiveObjects();
     for (const auto & nodal_bc : nodal_bcs)
     {
-      std::shared_ptr<DirichletBC> nbc = MooseSharedNamespace::dynamic_pointer_cast<DirichletBC>(nodal_bc);
+      std::shared_ptr<DirichletBC> nbc = std::dynamic_pointer_cast<DirichletBC>(nodal_bc);
       if (nbc && nbc->getParam<Real>("value"))
         mooseError("Can't set an inhomogeneous Dirichlet boundary condition for eigenvalue problems.");
       else if (!nbc)

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -273,7 +273,7 @@ NonlinearSystemBase::addKernel(const std::string & kernel_name, const std::strin
     _kernels.addObject(kernel, tid);
 
     // Store time/non-time kernels separately
-    std::shared_ptr<TimeKernel> t_kernel = MooseSharedNamespace::dynamic_pointer_cast<TimeKernel>(kernel);
+    std::shared_ptr<TimeKernel> t_kernel = std::dynamic_pointer_cast<TimeKernel>(kernel);
     if (t_kernel)
       _time_kernels.addObject(kernel, tid);
     else
@@ -307,8 +307,7 @@ NonlinearSystemBase::addNodalKernel(const std::string & kernel_name, const std::
 void
 NonlinearSystemBase::addScalarKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters)
 {
-  std::shared_ptr<ScalarKernel> kernel =
-    _factory.create<ScalarKernel>(kernel_name, name, parameters);
+  std::shared_ptr<ScalarKernel> kernel = _factory.create<ScalarKernel>(kernel_name, name, parameters);
   _scalar_kernels.addObject(kernel);
 
   // Store time/non-time ScalarKernels separately
@@ -334,8 +333,8 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name, const std
   _vars[tid].addBoundaryVar(boundary_ids, &bc->variable());
 
   // Cast to the various types of BCs
-  std::shared_ptr<NodalBC> nbc = MooseSharedNamespace::dynamic_pointer_cast<NodalBC>(bc);
-  std::shared_ptr<IntegratedBC> ibc = MooseSharedNamespace::dynamic_pointer_cast<IntegratedBC>(bc);
+  std::shared_ptr<NodalBC> nbc = std::dynamic_pointer_cast<NodalBC>(bc);
+  std::shared_ptr<IntegratedBC> ibc = std::dynamic_pointer_cast<IntegratedBC>(bc);
 
   // NodalBC
   if (nbc)
@@ -349,7 +348,7 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name, const std
       _has_nodalbc_diag_save_in = true;
 
     // PresetNodalBC
-    std::shared_ptr<PresetNodalBC> pnbc = MooseSharedNamespace::dynamic_pointer_cast<PresetNodalBC>(bc);
+    std::shared_ptr<PresetNodalBC> pnbc = std::dynamic_pointer_cast<PresetNodalBC>(bc);
     if (pnbc)
       _preset_nodal_bcs.addObject(pnbc);
   }
@@ -374,7 +373,7 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name, const std
       const std::set<BoundaryID> & boundary_ids = bc->boundaryIDs();
       _vars[tid].addBoundaryVar(boundary_ids, &bc->variable());
 
-      ibc = MooseSharedNamespace::static_pointer_cast<IntegratedBC>(bc);
+      ibc = std::static_pointer_cast<IntegratedBC>(bc);
 
       _integrated_bcs.addObject(ibc, tid);
       _vars[tid].addBoundaryVars(boundary_ids, ibc->getCoupledVars());
@@ -442,9 +441,9 @@ NonlinearSystemBase::addDamper(const std::string & damper_name, const std::strin
     std::shared_ptr<Damper> damper = _factory.create<Damper>(damper_name, name, parameters, tid);
 
     // Attempt to cast to the damper types
-    std::shared_ptr<ElementDamper> ed = MooseSharedNamespace::dynamic_pointer_cast<ElementDamper>(damper);
-    std::shared_ptr<NodalDamper> nd = MooseSharedNamespace::dynamic_pointer_cast<NodalDamper>(damper);
-    std::shared_ptr<GeneralDamper> gd = MooseSharedNamespace::dynamic_pointer_cast<GeneralDamper>(damper);
+    std::shared_ptr<ElementDamper> ed = std::dynamic_pointer_cast<ElementDamper>(damper);
+    std::shared_ptr<NodalDamper> nd = std::dynamic_pointer_cast<NodalDamper>(damper);
+    std::shared_ptr<GeneralDamper> gd = std::dynamic_pointer_cast<GeneralDamper>(damper);
 
     if (gd)
     {
@@ -571,7 +570,7 @@ NonlinearSystemBase::setInitialSolution()
 
       if (_preset_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
       {
-        const std::vector<std::shared_ptr<PresetNodalBC> > & preset_bcs = _preset_nodal_bcs.getActiveBoundaryObjects(boundary_id);
+        const auto & preset_bcs = _preset_nodal_bcs.getActiveBoundaryObjects(boundary_id);
         for (const auto & preset_bc : preset_bcs)
           preset_bc->computeValue(initial_solution);
       }
@@ -635,7 +634,7 @@ NonlinearSystemBase::enforceNodalConstraintsResidual(NumericVector<Number> & res
   residual.close();
   if (_constraints.hasActiveNodalConstraints())
   {
-    const std::vector<std::shared_ptr<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
+    const auto & ncs = _constraints.getActiveNodalConstraints();
     for (const auto & nc : ncs)
     {
       std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
@@ -660,7 +659,7 @@ NonlinearSystemBase::enforceNodalConstraintsJacobian(SparseMatrix<Number> & jaco
   jacobian.close();
   if (_constraints.hasActiveNodalConstraints())
   {
-    const std::vector<std::shared_ptr<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
+    const auto & ncs = _constraints.getActiveNodalConstraints();
     for (const auto & nc : ncs)
     {
       std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
@@ -706,7 +705,7 @@ NonlinearSystemBase::setConstraintSlaveValues(NumericVector<Number> & solution, 
 
     if (_constraints.hasActiveNodeFaceConstraints(slave_boundary, displaced))
     {
-      const std::vector<std::shared_ptr<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
+      const auto & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
 
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
@@ -792,7 +791,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
 
     if (_constraints.hasActiveNodeFaceConstraints(slave_boundary, displaced))
     {
-      const std::vector<std::shared_ptr<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
+      const auto & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
 
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
@@ -895,7 +894,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
   {
     if (_constraints.hasActiveFaceFaceConstraints(iface->_name))
     {
-      const std::vector<std::shared_ptr<FaceFaceConstraint> > & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
+      const auto & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
 
       // go over elements on that interface
       const std::vector<Elem *> & elems = iface->_elems;
@@ -929,7 +928,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
   }
 
   // go over element-element constraint interface
-  std::map<unsigned int, std::shared_ptr<ElementPairLocator> > * element_pair_locators = NULL;
+  std::map<unsigned int, std::shared_ptr<ElementPairLocator>> * element_pair_locators = nullptr;
 
   if (!displaced)
   {
@@ -949,7 +948,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
     if (_constraints.hasActiveElemElemConstraints(it.first))
     {
       // ElemElemConstraint objects
-      const std::vector<std::shared_ptr<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
+      const auto & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
 
       // go over pair elements
       const std::list<std::pair<const Elem*, const Elem*> > & elem_pairs = elem_pair_loc.getElemPairs();
@@ -1184,7 +1183,7 @@ NonlinearSystemBase::computeNodalBCs(NumericVector<Number> & residual)
 
           if (_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
           {
-            const std::vector<std::shared_ptr<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
+            const auto & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
             for (const auto & nbc : bcs)
               if (nbc->shouldApply())
                 nbc->computeResidual(residual);
@@ -1275,7 +1274,7 @@ NonlinearSystemBase::findImplicitGeometricCouplingEntries(GeometricSearchData & 
   }
 
   // handle node-to-node constraints
-  const std::vector<std::shared_ptr<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
+  const auto & ncs = _constraints.getActiveNodalConstraints();
   for (const auto & nc : ncs)
   {
     std::vector<dof_id_type> master_dofs;
@@ -1366,7 +1365,7 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
     zero_rows.clear();
     if (_constraints.hasActiveNodeFaceConstraints(slave_boundary, displaced))
     {
-      const std::vector<std::shared_ptr<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
+      const auto & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
 
       for (const auto & slave_node_num : slave_nodes)
       {
@@ -1534,7 +1533,7 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
     if (_constraints.hasActiveFaceFaceConstraints(iface->_name))
     {
       // FaceFaceConstraint objects
-      const std::vector<std::shared_ptr<FaceFaceConstraint> > & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
+      const auto & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
 
       // go over elements on that interface
       const std::vector<Elem *> & elems = iface->_elems;
@@ -1565,7 +1564,7 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
   }
 
   // go over element-element constraint interface
-  std::map<unsigned int, std::shared_ptr<ElementPairLocator> > * element_pair_locators = NULL;
+  std::map<unsigned int, std::shared_ptr<ElementPairLocator>> * element_pair_locators = nullptr;
 
   if (!displaced)
   {
@@ -1585,7 +1584,7 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
     if (_constraints.hasActiveElemElemConstraints(it.first))
     {
       // ElemElemConstraint objects
-      const std::vector<std::shared_ptr<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
+      const auto & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
 
       // go over pair elements
       const std::list<std::pair<const Elem*, const Elem*> > & elem_pairs = elem_pair_loc.getElemPairs();
@@ -1625,7 +1624,7 @@ NonlinearSystemBase::computeScalarKernelsJacobians(SparseMatrix<Number> & jacobi
   // Compute the diagonal block for scalar variables
   if (_scalar_kernels.hasActiveObjects())
   {
-    const std::vector<std::shared_ptr<ScalarKernel> > & scalars = _scalar_kernels.getActiveObjects();
+    const auto & scalars = _scalar_kernels.getActiveObjects();
 
     _fe_problem.reinitScalars(/*tid=*/0);
     for (const auto & kernel : scalars)
@@ -1814,7 +1813,7 @@ NonlinearSystemBase::computeJacobianInternal(SparseMatrix<Number> & jacobian, Mo
       // safe if there are NodalBCs there to be gotten...
       if (_nodal_bcs.hasActiveBoundaryObjects(bid))
       {
-        const std::vector<std::shared_ptr<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(bid);
+        const auto & bcs = _nodal_bcs.getActiveBoundaryObjects(bid);
         for (const auto & bc : bcs)
         {
           const std::vector<MooseVariable *> & coupled_moose_vars = bc->getCoupledMooseVars();
@@ -1848,7 +1847,7 @@ NonlinearSystemBase::computeJacobianInternal(SparseMatrix<Number> & jacobian, Mo
       {
         _fe_problem.reinitNodeFace(node, boundary_id, 0);
 
-        const std::vector<std::shared_ptr<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
+        const auto & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
         for (const auto & bc : bcs)
         {
           // Get the set of involved MOOSE vars for this BC
@@ -1998,7 +1997,7 @@ NonlinearSystemBase::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks
 
         if (_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
         {
-          const std::vector<std::shared_ptr<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
+          const auto & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
 
           if (node->processor_id() == processor_id())
           {
@@ -2085,7 +2084,7 @@ NonlinearSystemBase::computeDamping(const NumericVector<Number> & solution,
   if (_general_dampers.hasActiveObjects())
   {
     has_active_dampers = true;
-    const std::vector<std::shared_ptr<GeneralDamper> > & gdampers = _general_dampers.getActiveObjects();
+    const auto & gdampers = _general_dampers.getActiveObjects();
     for (const auto & damper : gdampers)
     {
       Real gd_damping = damper->computeDamping(solution, update);
@@ -2117,7 +2116,7 @@ NonlinearSystemBase::computeDiracContributions(SparseMatrix<Number> * jacobian)
     // TODO: Need a threading fix... but it's complicated!
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
     {
-      const std::vector<std::shared_ptr<DiracKernel> > & dkernels = _dirac_kernels.getActiveObjects(tid);
+      const auto & dkernels = _dirac_kernels.getActiveObjects(tid);
       for (const auto & dkernel : dkernels)
       {
         dkernel->clearPoints();
@@ -2260,7 +2259,7 @@ NonlinearSystemBase::serializedSolution()
 void
 NonlinearSystemBase::setPreconditioner(std::shared_ptr<MoosePreconditioner> pc)
 {
-  if (_preconditioner.get() != NULL)
+  if (_preconditioner.get() != nullptr)
     mooseError("More than one active Preconditioner detected");
 
   _preconditioner = pc;

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -249,7 +249,7 @@ NonlinearSystemBase::setupFieldDecomposition()
   if (!_have_decomposition)
     return;
 
-  MooseSharedPointer<Split> top_split = getSplit(_decomposition_split);
+  std::shared_ptr<Split> top_split = getSplit(_decomposition_split);
   top_split->setup();
 }
 
@@ -259,7 +259,7 @@ NonlinearSystemBase::addTimeIntegrator(const std::string & type, const std::stri
 {
   parameters.set<SystemBase *>("_sys") = this;
 
-  MooseSharedPointer<TimeIntegrator> ti = _factory.create<TimeIntegrator>(type, name, parameters);
+  std::shared_ptr<TimeIntegrator> ti = _factory.create<TimeIntegrator>(type, name, parameters);
   _time_integrator = ti;
 }
 
@@ -269,11 +269,11 @@ NonlinearSystemBase::addKernel(const std::string & kernel_name, const std::strin
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
     // Create the kernel object via the factory and add to warehouse
-    MooseSharedPointer<KernelBase> kernel = _factory.create<KernelBase>(kernel_name, name, parameters, tid);
+    std::shared_ptr<KernelBase> kernel = _factory.create<KernelBase>(kernel_name, name, parameters, tid);
     _kernels.addObject(kernel, tid);
 
     // Store time/non-time kernels separately
-    MooseSharedPointer<TimeKernel> t_kernel = MooseSharedNamespace::dynamic_pointer_cast<TimeKernel>(kernel);
+    std::shared_ptr<TimeKernel> t_kernel = MooseSharedNamespace::dynamic_pointer_cast<TimeKernel>(kernel);
     if (t_kernel)
       _time_kernels.addObject(kernel, tid);
     else
@@ -294,7 +294,7 @@ NonlinearSystemBase::addNodalKernel(const std::string & kernel_name, const std::
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
     // Create the kernel object via the factory and add to the warehouse
-    MooseSharedPointer<NodalKernel> kernel = _factory.create<NodalKernel>(kernel_name, name, parameters, tid);
+    std::shared_ptr<NodalKernel> kernel = _factory.create<NodalKernel>(kernel_name, name, parameters, tid);
     _nodal_kernels.addObject(kernel, tid);
   }
 
@@ -307,7 +307,7 @@ NonlinearSystemBase::addNodalKernel(const std::string & kernel_name, const std::
 void
 NonlinearSystemBase::addScalarKernel(const std::string & kernel_name, const std::string & name, InputParameters parameters)
 {
-  MooseSharedPointer<ScalarKernel> kernel =
+  std::shared_ptr<ScalarKernel> kernel =
     _factory.create<ScalarKernel>(kernel_name, name, parameters);
   _scalar_kernels.addObject(kernel);
 
@@ -327,15 +327,15 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name, const std
   THREAD_ID tid = 0;
 
   // Create the object
-  MooseSharedPointer<BoundaryCondition> bc = _factory.create<BoundaryCondition>(bc_name, name, parameters, tid);
+  std::shared_ptr<BoundaryCondition> bc = _factory.create<BoundaryCondition>(bc_name, name, parameters, tid);
 
   // Active BoundaryIDs for the object
   const std::set<BoundaryID> & boundary_ids = bc->boundaryIDs();
   _vars[tid].addBoundaryVar(boundary_ids, &bc->variable());
 
   // Cast to the various types of BCs
-  MooseSharedPointer<NodalBC> nbc = MooseSharedNamespace::dynamic_pointer_cast<NodalBC>(bc);
-  MooseSharedPointer<IntegratedBC> ibc = MooseSharedNamespace::dynamic_pointer_cast<IntegratedBC>(bc);
+  std::shared_ptr<NodalBC> nbc = MooseSharedNamespace::dynamic_pointer_cast<NodalBC>(bc);
+  std::shared_ptr<IntegratedBC> ibc = MooseSharedNamespace::dynamic_pointer_cast<IntegratedBC>(bc);
 
   // NodalBC
   if (nbc)
@@ -349,7 +349,7 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name, const std
       _has_nodalbc_diag_save_in = true;
 
     // PresetNodalBC
-    MooseSharedPointer<PresetNodalBC> pnbc = MooseSharedNamespace::dynamic_pointer_cast<PresetNodalBC>(bc);
+    std::shared_ptr<PresetNodalBC> pnbc = MooseSharedNamespace::dynamic_pointer_cast<PresetNodalBC>(bc);
     if (pnbc)
       _preset_nodal_bcs.addObject(pnbc);
   }
@@ -388,7 +388,7 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name, const std
 void
 NonlinearSystemBase::addConstraint(const std::string & c_name, const std::string & name, InputParameters parameters)
 {
-  MooseSharedPointer<Constraint> constraint = _factory.create<Constraint>(c_name, name, parameters);
+  std::shared_ptr<Constraint> constraint = _factory.create<Constraint>(c_name, name, parameters);
   _constraints.addObject(constraint);
 
   if (constraint && constraint->addCouplingEntriesToJacobian())
@@ -400,7 +400,7 @@ NonlinearSystemBase::addDiracKernel(const  std::string & kernel_name, const std:
 {
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
-    MooseSharedPointer<DiracKernel> kernel = _factory.create<DiracKernel>(kernel_name, name, parameters, tid);
+    std::shared_ptr<DiracKernel> kernel = _factory.create<DiracKernel>(kernel_name, name, parameters, tid);
     _dirac_kernels.addObject(kernel, tid);
   }
 }
@@ -410,7 +410,7 @@ NonlinearSystemBase::addDGKernel(std::string dg_kernel_name, const std::string &
 {
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
   {
-    MooseSharedPointer<DGKernel> dg_kernel = _factory.create<DGKernel>(dg_kernel_name, name, parameters, tid);
+    std::shared_ptr<DGKernel> dg_kernel = _factory.create<DGKernel>(dg_kernel_name, name, parameters, tid);
     _dg_kernels.addObject(dg_kernel, tid);
   }
 
@@ -422,7 +422,7 @@ NonlinearSystemBase::addInterfaceKernel(std::string interface_kernel_name, const
 {
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
   {
-    MooseSharedPointer<InterfaceKernel> interface_kernel = _factory.create<InterfaceKernel>(interface_kernel_name, name, parameters, tid);
+    std::shared_ptr<InterfaceKernel> interface_kernel = _factory.create<InterfaceKernel>(interface_kernel_name, name, parameters, tid);
 
     const std::set<BoundaryID> & boundary_ids = interface_kernel->boundaryIDs();
     _vars[tid].addBoundaryVar(boundary_ids, &interface_kernel->variable());
@@ -439,12 +439,12 @@ NonlinearSystemBase::addDamper(const std::string & damper_name, const std::strin
 {
   for (THREAD_ID tid=0; tid < libMesh::n_threads(); ++tid)
   {
-    MooseSharedPointer<Damper> damper = _factory.create<Damper>(damper_name, name, parameters, tid);
+    std::shared_ptr<Damper> damper = _factory.create<Damper>(damper_name, name, parameters, tid);
 
     // Attempt to cast to the damper types
-    MooseSharedPointer<ElementDamper> ed = MooseSharedNamespace::dynamic_pointer_cast<ElementDamper>(damper);
-    MooseSharedPointer<NodalDamper> nd = MooseSharedNamespace::dynamic_pointer_cast<NodalDamper>(damper);
-    MooseSharedPointer<GeneralDamper> gd = MooseSharedNamespace::dynamic_pointer_cast<GeneralDamper>(damper);
+    std::shared_ptr<ElementDamper> ed = MooseSharedNamespace::dynamic_pointer_cast<ElementDamper>(damper);
+    std::shared_ptr<NodalDamper> nd = MooseSharedNamespace::dynamic_pointer_cast<NodalDamper>(damper);
+    std::shared_ptr<GeneralDamper> gd = MooseSharedNamespace::dynamic_pointer_cast<GeneralDamper>(damper);
 
     if (gd)
     {
@@ -463,11 +463,11 @@ NonlinearSystemBase::addDamper(const std::string & damper_name, const std::strin
 void
 NonlinearSystemBase::addSplit(const  std::string & split_name, const std::string & name, InputParameters parameters)
 {
-  MooseSharedPointer<Split> split = _factory.create<Split>(split_name, name, parameters);
+  std::shared_ptr<Split> split = _factory.create<Split>(split_name, name, parameters);
   _splits.addObject(split);
 }
 
-MooseSharedPointer<Split>
+std::shared_ptr<Split>
 NonlinearSystemBase::getSplit(const std::string & name)
 {
   return _splits.getActiveObject(name);
@@ -571,7 +571,7 @@ NonlinearSystemBase::setInitialSolution()
 
       if (_preset_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
       {
-        const std::vector<MooseSharedPointer<PresetNodalBC> > & preset_bcs = _preset_nodal_bcs.getActiveBoundaryObjects(boundary_id);
+        const std::vector<std::shared_ptr<PresetNodalBC> > & preset_bcs = _preset_nodal_bcs.getActiveBoundaryObjects(boundary_id);
         for (const auto & preset_bc : preset_bcs)
           preset_bc->computeValue(initial_solution);
       }
@@ -588,7 +588,7 @@ NonlinearSystemBase::setInitialSolution()
     setConstraintSlaveValues(initial_solution, true);
 }
 
-void NonlinearSystemBase::setPredictor(MooseSharedPointer<Predictor> predictor)
+void NonlinearSystemBase::setPredictor(std::shared_ptr<Predictor> predictor)
 {
   _predictor = predictor;
 }
@@ -635,7 +635,7 @@ NonlinearSystemBase::enforceNodalConstraintsResidual(NumericVector<Number> & res
   residual.close();
   if (_constraints.hasActiveNodalConstraints())
   {
-    const std::vector<MooseSharedPointer<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
+    const std::vector<std::shared_ptr<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
     for (const auto & nc : ncs)
     {
       std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
@@ -660,7 +660,7 @@ NonlinearSystemBase::enforceNodalConstraintsJacobian(SparseMatrix<Number> & jaco
   jacobian.close();
   if (_constraints.hasActiveNodalConstraints())
   {
-    const std::vector<MooseSharedPointer<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
+    const std::vector<std::shared_ptr<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
     for (const auto & nc : ncs)
     {
       std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
@@ -706,7 +706,7 @@ NonlinearSystemBase::setConstraintSlaveValues(NumericVector<Number> & solution, 
 
     if (_constraints.hasActiveNodeFaceConstraints(slave_boundary, displaced))
     {
-      const std::vector<MooseSharedPointer<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
+      const std::vector<std::shared_ptr<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
 
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
@@ -792,7 +792,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
 
     if (_constraints.hasActiveNodeFaceConstraints(slave_boundary, displaced))
     {
-      const std::vector<MooseSharedPointer<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
+      const std::vector<std::shared_ptr<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
 
       for (unsigned int i=0; i<slave_nodes.size(); i++)
       {
@@ -895,7 +895,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
   {
     if (_constraints.hasActiveFaceFaceConstraints(iface->_name))
     {
-      const std::vector<MooseSharedPointer<FaceFaceConstraint> > & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
+      const std::vector<std::shared_ptr<FaceFaceConstraint> > & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
 
       // go over elements on that interface
       const std::vector<Elem *> & elems = iface->_elems;
@@ -929,7 +929,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
   }
 
   // go over element-element constraint interface
-  std::map<unsigned int, MooseSharedPointer<ElementPairLocator> > * element_pair_locators = NULL;
+  std::map<unsigned int, std::shared_ptr<ElementPairLocator> > * element_pair_locators = NULL;
 
   if (!displaced)
   {
@@ -949,7 +949,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
     if (_constraints.hasActiveElemElemConstraints(it.first))
     {
       // ElemElemConstraint objects
-      const std::vector<MooseSharedPointer<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
+      const std::vector<std::shared_ptr<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
 
       // go over pair elements
       const std::list<std::pair<const Elem*, const Elem*> > & elem_pairs = elem_pair_loc.getElemPairs();
@@ -1035,7 +1035,7 @@ NonlinearSystemBase::computeResidualInternal(Moose::KernelType type)
     {
       Moose::perf_log.push("computScalarKernels()", "Execution");
 
-      const std::vector<MooseSharedPointer<ScalarKernel> > * scalars;
+      const std::vector<std::shared_ptr<ScalarKernel> > * scalars;
 
       // Use the right subset of ScalarKernels depending on the KernelType.
       switch (type)
@@ -1184,7 +1184,7 @@ NonlinearSystemBase::computeNodalBCs(NumericVector<Number> & residual)
 
           if (_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
           {
-            const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
+            const std::vector<std::shared_ptr<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
             for (const auto & nbc : bcs)
               if (nbc->shouldApply())
                 nbc->computeResidual(residual);
@@ -1275,7 +1275,7 @@ NonlinearSystemBase::findImplicitGeometricCouplingEntries(GeometricSearchData & 
   }
 
   // handle node-to-node constraints
-  const std::vector<MooseSharedPointer<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
+  const std::vector<std::shared_ptr<NodalConstraint> > & ncs = _constraints.getActiveNodalConstraints();
   for (const auto & nc : ncs)
   {
     std::vector<dof_id_type> master_dofs;
@@ -1366,7 +1366,7 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
     zero_rows.clear();
     if (_constraints.hasActiveNodeFaceConstraints(slave_boundary, displaced))
     {
-      const std::vector<MooseSharedPointer<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
+      const std::vector<std::shared_ptr<NodeFaceConstraint> > & constraints = _constraints.getActiveNodeFaceConstraints(slave_boundary, displaced);
 
       for (const auto & slave_node_num : slave_nodes)
       {
@@ -1534,7 +1534,7 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
     if (_constraints.hasActiveFaceFaceConstraints(iface->_name))
     {
       // FaceFaceConstraint objects
-      const std::vector<MooseSharedPointer<FaceFaceConstraint> > & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
+      const std::vector<std::shared_ptr<FaceFaceConstraint> > & face_constraints = _constraints.getActiveFaceFaceConstraints(iface->_name);
 
       // go over elements on that interface
       const std::vector<Elem *> & elems = iface->_elems;
@@ -1565,7 +1565,7 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
   }
 
   // go over element-element constraint interface
-  std::map<unsigned int, MooseSharedPointer<ElementPairLocator> > * element_pair_locators = NULL;
+  std::map<unsigned int, std::shared_ptr<ElementPairLocator> > * element_pair_locators = NULL;
 
   if (!displaced)
   {
@@ -1585,7 +1585,7 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
     if (_constraints.hasActiveElemElemConstraints(it.first))
     {
       // ElemElemConstraint objects
-      const std::vector<MooseSharedPointer<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
+      const std::vector<std::shared_ptr<ElemElemConstraint> > & _element_constraints = _constraints.getActiveElemElemConstraints(it.first);
 
       // go over pair elements
       const std::list<std::pair<const Elem*, const Elem*> > & elem_pairs = elem_pair_loc.getElemPairs();
@@ -1625,7 +1625,7 @@ NonlinearSystemBase::computeScalarKernelsJacobians(SparseMatrix<Number> & jacobi
   // Compute the diagonal block for scalar variables
   if (_scalar_kernels.hasActiveObjects())
   {
-    const std::vector<MooseSharedPointer<ScalarKernel> > & scalars = _scalar_kernels.getActiveObjects();
+    const std::vector<std::shared_ptr<ScalarKernel> > & scalars = _scalar_kernels.getActiveObjects();
 
     _fe_problem.reinitScalars(/*tid=*/0);
     for (const auto & kernel : scalars)
@@ -1814,7 +1814,7 @@ NonlinearSystemBase::computeJacobianInternal(SparseMatrix<Number> & jacobian, Mo
       // safe if there are NodalBCs there to be gotten...
       if (_nodal_bcs.hasActiveBoundaryObjects(bid))
       {
-        const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(bid);
+        const std::vector<std::shared_ptr<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(bid);
         for (const auto & bc : bcs)
         {
           const std::vector<MooseVariable *> & coupled_moose_vars = bc->getCoupledMooseVars();
@@ -1848,7 +1848,7 @@ NonlinearSystemBase::computeJacobianInternal(SparseMatrix<Number> & jacobian, Mo
       {
         _fe_problem.reinitNodeFace(node, boundary_id, 0);
 
-        const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
+        const std::vector<std::shared_ptr<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
         for (const auto & bc : bcs)
         {
           // Get the set of involved MOOSE vars for this BC
@@ -1998,7 +1998,7 @@ NonlinearSystemBase::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks
 
         if (_nodal_bcs.hasActiveBoundaryObjects(boundary_id))
         {
-          const std::vector<MooseSharedPointer<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
+          const std::vector<std::shared_ptr<NodalBC> > & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
 
           if (node->processor_id() == processor_id())
           {
@@ -2085,7 +2085,7 @@ NonlinearSystemBase::computeDamping(const NumericVector<Number> & solution,
   if (_general_dampers.hasActiveObjects())
   {
     has_active_dampers = true;
-    const std::vector<MooseSharedPointer<GeneralDamper> > & gdampers = _general_dampers.getActiveObjects();
+    const std::vector<std::shared_ptr<GeneralDamper> > & gdampers = _general_dampers.getActiveObjects();
     for (const auto & damper : gdampers)
     {
       Real gd_damping = damper->computeDamping(solution, update);
@@ -2117,7 +2117,7 @@ NonlinearSystemBase::computeDiracContributions(SparseMatrix<Number> * jacobian)
     // TODO: Need a threading fix... but it's complicated!
     for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
     {
-      const std::vector<MooseSharedPointer<DiracKernel> > & dkernels = _dirac_kernels.getActiveObjects(tid);
+      const std::vector<std::shared_ptr<DiracKernel> > & dkernels = _dirac_kernels.getActiveObjects(tid);
       for (const auto & dkernel : dkernels)
       {
         dkernel->clearPoints();
@@ -2258,7 +2258,7 @@ NonlinearSystemBase::serializedSolution()
 }
 
 void
-NonlinearSystemBase::setPreconditioner(MooseSharedPointer<MoosePreconditioner> pc)
+NonlinearSystemBase::setPreconditioner(std::shared_ptr<MoosePreconditioner> pc)
 {
   if (_preconditioner.get() != NULL)
     mooseError("More than one active Preconditioner detected");

--- a/framework/src/base/ProjectMaterialProperties.C
+++ b/framework/src/base/ProjectMaterialProperties.C
@@ -28,8 +28,8 @@
 
 ProjectMaterialProperties::ProjectMaterialProperties(bool refine,
                                                      FEProblemBase & fe_problem, NonlinearSystemBase & sys,
-                                                     std::vector<MooseSharedPointer<MaterialData> > & material_data,
-                                                     std::vector<MooseSharedPointer<MaterialData> > & bnd_material_data,
+                                                     std::vector<std::shared_ptr<MaterialData> > & material_data,
+                                                     std::vector<std::shared_ptr<MaterialData> > & bnd_material_data,
                                                      MaterialPropertyStorage & material_props,
                                                      MaterialPropertyStorage & bnd_material_props, std::vector<Assembly *> & assembly) :
     ThreadedElementLoop<ConstElemPointerRange>(fe_problem),

--- a/framework/src/base/ProjectMaterialProperties.C
+++ b/framework/src/base/ProjectMaterialProperties.C
@@ -28,8 +28,8 @@
 
 ProjectMaterialProperties::ProjectMaterialProperties(bool refine,
                                                      FEProblemBase & fe_problem, NonlinearSystemBase & sys,
-                                                     std::vector<std::shared_ptr<MaterialData> > & material_data,
-                                                     std::vector<std::shared_ptr<MaterialData> > & bnd_material_data,
+                                                     std::vector<std::shared_ptr<MaterialData>> & material_data,
+                                                     std::vector<std::shared_ptr<MaterialData>> & bnd_material_data,
                                                      MaterialPropertyStorage & material_props,
                                                      MaterialPropertyStorage & bnd_material_props, std::vector<Assembly *> & assembly) :
     ThreadedElementLoop<ConstElemPointerRange>(fe_problem),

--- a/framework/src/constraints/ConstraintWarehouse.C
+++ b/framework/src/constraints/ConstraintWarehouse.C
@@ -26,16 +26,16 @@ ConstraintWarehouse::ConstraintWarehouse() :
 
 
 void
-ConstraintWarehouse::addObject(MooseSharedPointer<Constraint> object, THREAD_ID /*tid = 0*/)
+ConstraintWarehouse::addObject(std::shared_ptr<Constraint> object, THREAD_ID /*tid = 0*/)
 {
   // Adds to the storage of _all_objects
   MooseObjectWarehouse<Constraint>::addObject(object);
 
   // Cast the the possible Contraint types
-  MooseSharedPointer<NodeFaceConstraint> nfc = MooseSharedNamespace::dynamic_pointer_cast<NodeFaceConstraint>(object);
-  MooseSharedPointer<FaceFaceConstraint> ffc = MooseSharedNamespace::dynamic_pointer_cast<FaceFaceConstraint>(object);
-  MooseSharedPointer<NodalConstraint>    nc =  MooseSharedNamespace::dynamic_pointer_cast<NodalConstraint>(object);
-  MooseSharedPointer<ElemElemConstraint>  ec = MooseSharedNamespace::dynamic_pointer_cast<ElemElemConstraint>(object);
+  std::shared_ptr<NodeFaceConstraint> nfc = MooseSharedNamespace::dynamic_pointer_cast<NodeFaceConstraint>(object);
+  std::shared_ptr<FaceFaceConstraint> ffc = MooseSharedNamespace::dynamic_pointer_cast<FaceFaceConstraint>(object);
+  std::shared_ptr<NodalConstraint>    nc =  MooseSharedNamespace::dynamic_pointer_cast<NodalConstraint>(object);
+  std::shared_ptr<ElemElemConstraint>  ec = MooseSharedNamespace::dynamic_pointer_cast<ElemElemConstraint>(object);
 
   // NodeFaceConstraint
   if (nfc)
@@ -73,14 +73,14 @@ ConstraintWarehouse::addObject(MooseSharedPointer<Constraint> object, THREAD_ID 
 }
 
 
-const std::vector<MooseSharedPointer<NodalConstraint> > &
+const std::vector<std::shared_ptr<NodalConstraint> > &
 ConstraintWarehouse::getActiveNodalConstraints() const
 {
   return _nodal_constraints.getActiveObjects();
 }
 
 
-const std::vector<MooseSharedPointer<NodeFaceConstraint> > &
+const std::vector<std::shared_ptr<NodeFaceConstraint> > &
 ConstraintWarehouse::getActiveNodeFaceConstraints(BoundaryID boundary_id, bool displaced)
 {
   std::map<BoundaryID, MooseObjectWarehouse<NodeFaceConstraint> >::const_iterator it, end_it;
@@ -102,7 +102,7 @@ ConstraintWarehouse::getActiveNodeFaceConstraints(BoundaryID boundary_id, bool d
 }
 
 
-const std::vector<MooseSharedPointer<FaceFaceConstraint> > &
+const std::vector<std::shared_ptr<FaceFaceConstraint> > &
 ConstraintWarehouse::getActiveFaceFaceConstraints(const std::string & interface) const
 {
   std::map<std::string, MooseObjectWarehouse<FaceFaceConstraint> >::const_iterator it = _face_face_constraints.find(interface);
@@ -110,7 +110,7 @@ ConstraintWarehouse::getActiveFaceFaceConstraints(const std::string & interface)
   return it->second.getActiveObjects();
 }
 
-const std::vector<MooseSharedPointer<ElemElemConstraint> > &
+const std::vector<std::shared_ptr<ElemElemConstraint> > &
 ConstraintWarehouse::getActiveElemElemConstraints(const InterfaceID interface_id) const
 {
   std::map<unsigned int, MooseObjectWarehouse<ElemElemConstraint> >::const_iterator it = _element_constraints.find(interface_id);
@@ -187,7 +187,7 @@ ConstraintWarehouse::subdomainsCovered(std::set<SubdomainID> & subdomains_covere
 {
   for (const auto & it : _face_face_constraints)
   {
-    const std::vector<MooseSharedPointer<FaceFaceConstraint> > & objects = it.second.getActiveObjects();
+    const std::vector<std::shared_ptr<FaceFaceConstraint> > & objects = it.second.getActiveObjects();
     for (const auto & ffc : objects)
     {
       MooseVariable & var = ffc->variable();

--- a/framework/src/constraints/ConstraintWarehouse.C
+++ b/framework/src/constraints/ConstraintWarehouse.C
@@ -32,10 +32,10 @@ ConstraintWarehouse::addObject(std::shared_ptr<Constraint> object, THREAD_ID /*t
   MooseObjectWarehouse<Constraint>::addObject(object);
 
   // Cast the the possible Contraint types
-  std::shared_ptr<NodeFaceConstraint> nfc = MooseSharedNamespace::dynamic_pointer_cast<NodeFaceConstraint>(object);
-  std::shared_ptr<FaceFaceConstraint> ffc = MooseSharedNamespace::dynamic_pointer_cast<FaceFaceConstraint>(object);
-  std::shared_ptr<NodalConstraint>    nc =  MooseSharedNamespace::dynamic_pointer_cast<NodalConstraint>(object);
-  std::shared_ptr<ElemElemConstraint>  ec = MooseSharedNamespace::dynamic_pointer_cast<ElemElemConstraint>(object);
+  std::shared_ptr<NodeFaceConstraint> nfc = std::dynamic_pointer_cast<NodeFaceConstraint>(object);
+  std::shared_ptr<FaceFaceConstraint> ffc = std::dynamic_pointer_cast<FaceFaceConstraint>(object);
+  std::shared_ptr<NodalConstraint> nc = std::dynamic_pointer_cast<NodalConstraint>(object);
+  std::shared_ptr<ElemElemConstraint> ec = std::dynamic_pointer_cast<ElemElemConstraint>(object);
 
   // NodeFaceConstraint
   if (nfc)
@@ -73,14 +73,14 @@ ConstraintWarehouse::addObject(std::shared_ptr<Constraint> object, THREAD_ID /*t
 }
 
 
-const std::vector<std::shared_ptr<NodalConstraint> > &
+const std::vector<std::shared_ptr<NodalConstraint>> &
 ConstraintWarehouse::getActiveNodalConstraints() const
 {
   return _nodal_constraints.getActiveObjects();
 }
 
 
-const std::vector<std::shared_ptr<NodeFaceConstraint> > &
+const std::vector<std::shared_ptr<NodeFaceConstraint>> &
 ConstraintWarehouse::getActiveNodeFaceConstraints(BoundaryID boundary_id, bool displaced)
 {
   std::map<BoundaryID, MooseObjectWarehouse<NodeFaceConstraint> >::const_iterator it, end_it;
@@ -102,7 +102,7 @@ ConstraintWarehouse::getActiveNodeFaceConstraints(BoundaryID boundary_id, bool d
 }
 
 
-const std::vector<std::shared_ptr<FaceFaceConstraint> > &
+const std::vector<std::shared_ptr<FaceFaceConstraint>> &
 ConstraintWarehouse::getActiveFaceFaceConstraints(const std::string & interface) const
 {
   std::map<std::string, MooseObjectWarehouse<FaceFaceConstraint> >::const_iterator it = _face_face_constraints.find(interface);
@@ -110,7 +110,7 @@ ConstraintWarehouse::getActiveFaceFaceConstraints(const std::string & interface)
   return it->second.getActiveObjects();
 }
 
-const std::vector<std::shared_ptr<ElemElemConstraint> > &
+const std::vector<std::shared_ptr<ElemElemConstraint>> &
 ConstraintWarehouse::getActiveElemElemConstraints(const InterfaceID interface_id) const
 {
   std::map<unsigned int, MooseObjectWarehouse<ElemElemConstraint> >::const_iterator it = _element_constraints.find(interface_id);
@@ -187,7 +187,7 @@ ConstraintWarehouse::subdomainsCovered(std::set<SubdomainID> & subdomains_covere
 {
   for (const auto & it : _face_face_constraints)
   {
-    const std::vector<std::shared_ptr<FaceFaceConstraint> > & objects = it.second.getActiveObjects();
+    const auto & objects = it.second.getActiveObjects();
     for (const auto & ffc : objects)
     {
       MooseVariable & var = ffc->variable();

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -678,14 +678,6 @@ Transient::lastSolveConverged()
 void
 Transient::preExecute()
 {
-  // Add time period start times to sync times
-  // const std::vector<std::shared_ptr<Control> > & controls = _problem.getControlWarehouse().getActiveObjects();
-  // for (auto & control : controls)
-  // {
-  //   std::shared_ptr<TimePeriod> tp = MooseSharedNamespace::dynamic_pointer_cast<TimePeriod>(control);
-  //   if (tp)
-  //     _time_stepper->addSyncTime(tp->getSyncTimes());
-  // }
   _time_stepper->preExecute();
 }
 

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -679,10 +679,10 @@ void
 Transient::preExecute()
 {
   // Add time period start times to sync times
-  // const std::vector<MooseSharedPointer<Control> > & controls = _problem.getControlWarehouse().getActiveObjects();
+  // const std::vector<std::shared_ptr<Control> > & controls = _problem.getControlWarehouse().getActiveObjects();
   // for (auto & control : controls)
   // {
-  //   MooseSharedPointer<TimePeriod> tp = MooseSharedNamespace::dynamic_pointer_cast<TimePeriod>(control);
+  //   std::shared_ptr<TimePeriod> tp = MooseSharedNamespace::dynamic_pointer_cast<TimePeriod>(control);
   //   if (tp)
   //     _time_stepper->addSyncTime(tp->getSyncTimes());
   // }

--- a/framework/src/geomsearch/GeometricSearchData.C
+++ b/framework/src/geomsearch/GeometricSearchData.C
@@ -88,10 +88,9 @@ GeometricSearchData::update(GeometricSearchType type)
 
   if (type == ALL || type == PENETRATION)
   {
-    for (std::map<unsigned int, std::shared_ptr<ElementPairLocator> >::iterator epl_it = _element_pair_locators.begin();
-         epl_it != _element_pair_locators.end(); ++epl_it)
+    for (auto & elem_pair_locator_pair : _element_pair_locators)
     {
-      ElementPairLocator & epl = *epl_it->second;
+      ElementPairLocator & epl = (*elem_pair_locator_pair.second);
       epl.update();
     }
   }
@@ -352,8 +351,7 @@ GeometricSearchData::getMortarNearestNodeLocator(const unsigned int master_id, c
 }
 
 void
-GeometricSearchData::addElementPairLocator(const unsigned int & interface_id,
-                                           std::shared_ptr<ElementPairLocator> epl)
+GeometricSearchData::addElementPairLocator(const unsigned int & interface_id, std::shared_ptr<ElementPairLocator> epl)
 {
   _element_pair_locators[interface_id] = epl;
 }

--- a/framework/src/geomsearch/GeometricSearchData.C
+++ b/framework/src/geomsearch/GeometricSearchData.C
@@ -88,7 +88,7 @@ GeometricSearchData::update(GeometricSearchType type)
 
   if (type == ALL || type == PENETRATION)
   {
-    for (std::map<unsigned int, MooseSharedPointer<ElementPairLocator> >::iterator epl_it = _element_pair_locators.begin();
+    for (std::map<unsigned int, std::shared_ptr<ElementPairLocator> >::iterator epl_it = _element_pair_locators.begin();
          epl_it != _element_pair_locators.end(); ++epl_it)
     {
       ElementPairLocator & epl = *epl_it->second;
@@ -353,7 +353,7 @@ GeometricSearchData::getMortarNearestNodeLocator(const unsigned int master_id, c
 
 void
 GeometricSearchData::addElementPairLocator(const unsigned int & interface_id,
-                                           MooseSharedPointer<ElementPairLocator> epl)
+                                           std::shared_ptr<ElementPairLocator> epl)
 {
   _element_pair_locators[interface_id] = epl;
 }

--- a/framework/src/ics/InitialConditionWarehouse.C
+++ b/framework/src/ics/InitialConditionWarehouse.C
@@ -32,7 +32,7 @@ InitialConditionWarehouse::initialSetup(THREAD_ID tid)
 
 
 void
-InitialConditionWarehouse::addObject(MooseSharedPointer<InitialCondition> object, THREAD_ID tid)
+InitialConditionWarehouse::addObject(std::shared_ptr<InitialCondition> object, THREAD_ID tid)
 {
   // Check that when object is boundary restricted that the variable is nodal
   const MooseVariable & var = object->variable();

--- a/framework/src/kernels/KernelWarehouse.C
+++ b/framework/src/kernels/KernelWarehouse.C
@@ -25,7 +25,7 @@ KernelWarehouse::KernelWarehouse() :
 
 
 void
-KernelWarehouse::addObject(MooseSharedPointer<KernelBase> object, THREAD_ID tid)
+KernelWarehouse::addObject(std::shared_ptr<KernelBase> object, THREAD_ID tid)
 {
   // Add object to the general storage
   MooseObjectWarehouse<KernelBase>::addObject(object, tid);
@@ -44,7 +44,7 @@ KernelWarehouse::hasActiveVariableBlockObjects(unsigned int variable_id, Subdoma
 }
 
 
-const std::vector<MooseSharedPointer<KernelBase> > &
+const std::vector<std::shared_ptr<KernelBase> > &
 KernelWarehouse::getActiveVariableBlockObjects(unsigned int variable_id, SubdomainID block_id, THREAD_ID tid) const
 {
   checkThreadID(tid);

--- a/framework/src/kernels/KernelWarehouse.C
+++ b/framework/src/kernels/KernelWarehouse.C
@@ -44,11 +44,11 @@ KernelWarehouse::hasActiveVariableBlockObjects(unsigned int variable_id, Subdoma
 }
 
 
-const std::vector<std::shared_ptr<KernelBase> > &
+const std::vector<std::shared_ptr<KernelBase>> &
 KernelWarehouse::getActiveVariableBlockObjects(unsigned int variable_id, SubdomainID block_id, THREAD_ID tid) const
 {
   checkThreadID(tid);
-  std::map<unsigned int, MooseObjectWarehouse<KernelBase> >::const_iterator iter = _variable_kernel_storage.find(variable_id);
+  const auto iter = _variable_kernel_storage.find(variable_id);
   mooseAssert(iter != _variable_kernel_storage.end(), "Unable to located variable kernels for the given variable id: " << variable_id << ".");
   return iter->second.getActiveBlockObjects(block_id, tid);
 }

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -74,14 +74,14 @@ MaterialData::swap(const Elem & elem, unsigned int side/* = 0*/)
 }
 
 void
-MaterialData::reinit(const std::vector<std::shared_ptr<Material> > & mats)
+MaterialData::reinit(const std::vector<std::shared_ptr<Material>> & mats)
 {
   for (const auto & mat : mats)
     mat->computeProperties();
 }
 
 void
-MaterialData::reset(const std::vector<std::shared_ptr<Material> > & mats)
+MaterialData::reset(const std::vector<std::shared_ptr<Material>> & mats)
 {
   for (const auto & mat : mats)
     mat->resetProperties();

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -74,14 +74,14 @@ MaterialData::swap(const Elem & elem, unsigned int side/* = 0*/)
 }
 
 void
-MaterialData::reinit(const std::vector<MooseSharedPointer<Material> > & mats)
+MaterialData::reinit(const std::vector<std::shared_ptr<Material> > & mats)
 {
   for (const auto & mat : mats)
     mat->computeProperties();
 }
 
 void
-MaterialData::reset(const std::vector<MooseSharedPointer<Material> > & mats)
+MaterialData::reset(const std::vector<std::shared_ptr<Material> > & mats)
 {
   for (const auto & mat : mats)
     mat->resetProperties();

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -197,7 +197,7 @@ MaterialPropertyInterface::getMaterial(const std::string & name)
 Material &
 MaterialPropertyInterface::getMaterialByName(const std::string & name)
 {
-  MooseSharedPointer<Material> discrete = _mi_feproblem.getMaterial(name, _material_data_type, _mi_tid);
+  std::shared_ptr<Material> discrete = _mi_feproblem.getMaterial(name, _material_data_type, _mi_tid);
 
   // Check block compatibility
   if (!discrete->hasBlocks(_mi_block_ids))

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -216,7 +216,8 @@ MaterialPropertyStorage::restrictStatefulProps(const std::vector<std::pair<unsig
 }
 
 void
-MaterialPropertyStorage::initStatefulProps(MaterialData & material_data, const std::vector<std::shared_ptr<Material> > & mats, unsigned int n_qpoints, const Elem & elem, unsigned int side/* = 0*/)
+MaterialPropertyStorage::initStatefulProps(MaterialData & material_data, const std::vector<std::shared_ptr<Material>> & mats,
+                                           unsigned int n_qpoints, const Elem & elem, unsigned int side/* = 0*/)
 {
   // NOTE: since materials are storing their computed properties in MaterialData class, we need to
   // juggle the memory between MaterialData and MaterialProperyStorage classes

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -216,7 +216,7 @@ MaterialPropertyStorage::restrictStatefulProps(const std::vector<std::pair<unsig
 }
 
 void
-MaterialPropertyStorage::initStatefulProps(MaterialData & material_data, const std::vector<MooseSharedPointer<Material> > & mats, unsigned int n_qpoints, const Elem & elem, unsigned int side/* = 0*/)
+MaterialPropertyStorage::initStatefulProps(MaterialData & material_data, const std::vector<std::shared_ptr<Material> > & mats, unsigned int n_qpoints, const Elem & elem, unsigned int side/* = 0*/)
 {
   // NOTE: since materials are storing their computed properties in MaterialData class, we need to
   // juggle the memory between MaterialData and MaterialProperyStorage classes

--- a/framework/src/materials/MaterialWarehouse.C
+++ b/framework/src/materials/MaterialWarehouse.C
@@ -17,7 +17,7 @@
 #include "Material.h"
 
 void
-MaterialWarehouse::addObjects(MooseSharedPointer<Material> block, MooseSharedPointer<Material> neighbor, MooseSharedPointer<Material> face, THREAD_ID tid /*=0*/)
+MaterialWarehouse::addObjects(std::shared_ptr<Material> block, std::shared_ptr<Material> neighbor, std::shared_ptr<Material> face, THREAD_ID tid /*=0*/)
 {
   MooseObjectWarehouse<Material>::addObject(block, tid);
   _neighbor_materials.addObject(neighbor, tid);

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -475,7 +475,7 @@ MultiApp::createApp(unsigned int i, Real start_time)
 
   InputParameters app_params = AppFactory::instance().getValidParams(_app_type);
   app_params.set<FEProblemBase *>("_parent_fep") = &_fe_problem;
-  app_params.set<std::shared_ptr<CommandLine> >("_command_line") = _app.commandLine();
+  app_params.set<std::shared_ptr<CommandLine>>("_command_line") = _app.commandLine();
   MooseApp * app = AppFactory::instance().create(_app_type, full_name, app_params, _my_comm);
   _apps[i] = app;
 

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -475,7 +475,7 @@ MultiApp::createApp(unsigned int i, Real start_time)
 
   InputParameters app_params = AppFactory::instance().getValidParams(_app_type);
   app_params.set<FEProblemBase *>("_parent_fep") = &_fe_problem;
-  app_params.set<MooseSharedPointer<CommandLine> >("_command_line") = _app.commandLine();
+  app_params.set<std::shared_ptr<CommandLine> >("_command_line") = _app.commandLine();
   MooseApp * app = AppFactory::instance().create(_app_type, full_name, app_params, _my_comm);
   _apps[i] = app;
 

--- a/framework/src/outputs/ControlOutput.C
+++ b/framework/src/outputs/ControlOutput.C
@@ -63,10 +63,10 @@ ControlOutput::outputActiveObjects()
 {
   // Extract InputParameter objects from warehouse
   InputParameterWarehouse & wh = _app.getInputParameterWarehouse();
-  const std::multimap<MooseObjectName, std::shared_ptr<InputParameters> > & params = wh.getInputParameters();
+  const auto & params = wh.getInputParameters();
 
   // Populate a map based on unique InputParameter objects
-  std::map<std::shared_ptr<InputParameters>, std::set<MooseObjectName> > objects;
+  std::map<std::shared_ptr<InputParameters>, std::set<MooseObjectName>> objects;
   for (const auto & iter : params)
     objects[iter.second].insert(iter.first);
 
@@ -105,7 +105,7 @@ ControlOutput::outputControls()
 
   // Extract InputParameter objects from warehouse
   InputParameterWarehouse & wh = _app.getInputParameterWarehouse();
-  const std::multimap<MooseObjectName, std::shared_ptr<InputParameters> > & params = wh.getInputParameters();
+  const auto & params = wh.getInputParameters();
 
   // The stream to build
   std::stringstream oss;
@@ -159,7 +159,7 @@ ControlOutput::outputChangedControls()
 {
   // Extract InputParameter objects from warehouse
   InputParameterWarehouse & wh = _app.getInputParameterWarehouse();
-  const std::map<std::shared_ptr<InputParameters>, std::set<MooseObjectParameterName> > & controls = wh.getControlledParameters();
+  const auto & controls = wh.getControlledParameters();
 
   // The stream to build
   std::stringstream oss;
@@ -172,7 +172,7 @@ ControlOutput::outputChangedControls()
   // Loop over the controlled parameters
   for (const auto & iter : controls)
   {
-    const std::shared_ptr<InputParameters> ptr = iter.first;
+    const auto ptr = iter.first;
     oss << "  " << COLOR_YELLOW << ptr->get<std::string>("_object_name") << COLOR_DEFAULT << '\n';
 
     // Tag(s)

--- a/framework/src/outputs/ControlOutput.C
+++ b/framework/src/outputs/ControlOutput.C
@@ -63,10 +63,10 @@ ControlOutput::outputActiveObjects()
 {
   // Extract InputParameter objects from warehouse
   InputParameterWarehouse & wh = _app.getInputParameterWarehouse();
-  const std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> > & params = wh.getInputParameters();
+  const std::multimap<MooseObjectName, std::shared_ptr<InputParameters> > & params = wh.getInputParameters();
 
   // Populate a map based on unique InputParameter objects
-  std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectName> > objects;
+  std::map<std::shared_ptr<InputParameters>, std::set<MooseObjectName> > objects;
   for (const auto & iter : params)
     objects[iter.second].insert(iter.first);
 
@@ -78,7 +78,7 @@ ControlOutput::outputActiveObjects()
   oss << "Active Objects:\n" << COLOR_DEFAULT;
   for (const auto & iter : objects)
   {
-    MooseSharedPointer<InputParameters> ptr = iter.first;
+    std::shared_ptr<InputParameters> ptr = iter.first;
     if (ptr->get<bool>("enable"))
     {
       // We print slightly differently in the first iteration of the loop.
@@ -105,14 +105,14 @@ ControlOutput::outputControls()
 
   // Extract InputParameter objects from warehouse
   InputParameterWarehouse & wh = _app.getInputParameterWarehouse();
-  const std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> > & params = wh.getInputParameters();
+  const std::multimap<MooseObjectName, std::shared_ptr<InputParameters> > & params = wh.getInputParameters();
 
   // The stream to build
   std::stringstream oss;
   oss << std::left;
 
   // Populate a map based on unique InputParameter objects
-  std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectName> > objects;
+  std::map<std::shared_ptr<InputParameters>, std::set<MooseObjectName> > objects;
   for (const auto & iter : params)
     objects[iter.second].insert(iter.first);
 
@@ -120,7 +120,7 @@ ControlOutput::outputControls()
   oss << "Controls:\n";
   for (const auto & iter : objects)
   {
-    MooseSharedPointer<InputParameters> ptr = iter.first;
+    std::shared_ptr<InputParameters> ptr = iter.first;
 
     const std::set<std::string> & names = ptr->getControllableParameters();
 
@@ -159,7 +159,7 @@ ControlOutput::outputChangedControls()
 {
   // Extract InputParameter objects from warehouse
   InputParameterWarehouse & wh = _app.getInputParameterWarehouse();
-  const std::map<MooseSharedPointer<InputParameters>, std::set<MooseObjectParameterName> > & controls = wh.getControlledParameters();
+  const std::map<std::shared_ptr<InputParameters>, std::set<MooseObjectParameterName> > & controls = wh.getControlledParameters();
 
   // The stream to build
   std::stringstream oss;
@@ -172,7 +172,7 @@ ControlOutput::outputChangedControls()
   // Loop over the controlled parameters
   for (const auto & iter : controls)
   {
-    const MooseSharedPointer<InputParameters> ptr = iter.first;
+    const std::shared_ptr<InputParameters> ptr = iter.first;
     oss << "  " << COLOR_YELLOW << ptr->get<std::string>("_object_name") << COLOR_DEFAULT << '\n';
 
     // Tag(s)

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -162,7 +162,7 @@ DOFMapOutput::output(const ExecFlagType & /*type*/)
         // if this variable has active kernels output them
         if (kernels.hasActiveVariableBlockObjects(var, *sd))
         {
-          const std::vector<std::shared_ptr<KernelBase> > & active_kernels = kernels.getActiveVariableBlockObjects(var, *sd);
+          const auto & active_kernels = kernels.getActiveVariableBlockObjects(var, *sd);
           for (unsigned i = 0; i<active_kernels.size(); ++i)
           {
             KernelBase & kb = *(active_kernels[i].get());

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -162,7 +162,7 @@ DOFMapOutput::output(const ExecFlagType & /*type*/)
         // if this variable has active kernels output them
         if (kernels.hasActiveVariableBlockObjects(var, *sd))
         {
-          const std::vector<MooseSharedPointer<KernelBase> > & active_kernels = kernels.getActiveVariableBlockObjects(var, *sd);
+          const std::vector<std::shared_ptr<KernelBase> > & active_kernels = kernels.getActiveVariableBlockObjects(var, *sd);
           for (unsigned i = 0; i<active_kernels.size(); ++i)
           {
             KernelBase & kb = *(active_kernels[i].get());

--- a/framework/src/outputs/MaterialPropertyDebugOutput.C
+++ b/framework/src/outputs/MaterialPropertyDebugOutput.C
@@ -56,7 +56,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
   // Active materials on block
   {
-    const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & objects = warehouse.getBlockObjects();
+    const auto & objects = warehouse.getBlockObjects();
     for (const auto & it : objects)
     {
       active_block << "    Block ID " << it.first << ":\n";
@@ -66,7 +66,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
   // Active face materials on blocks
   {
-    const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & objects = warehouse[Moose::FACE_MATERIAL_DATA].getBlockObjects();
+    const auto & objects = warehouse[Moose::FACE_MATERIAL_DATA].getBlockObjects();
     for (const auto & it : objects)
     {
       active_face << "    Block ID " << it.first << ":\n";
@@ -76,7 +76,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
   // Active neighbor materials on blocks
   {
-    const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & objects = warehouse[Moose::NEIGHBOR_MATERIAL_DATA].getBlockObjects();
+    const auto & objects = warehouse[Moose::NEIGHBOR_MATERIAL_DATA].getBlockObjects();
     for (const auto & it : objects)
     {
       active_neighbor << "    Block ID " << it.first << ":\n";
@@ -86,7 +86,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
   // Active boundary materials
   {
-    const std::map<BoundaryID, std::vector<std::shared_ptr<Material> > > & objects = warehouse.getBoundaryObjects();
+    const auto & objects = warehouse.getBoundaryObjects();
     for (const auto & it : objects)
     {
       active_boundary << "    Boundary ID " << it.first << ":\n";
@@ -110,7 +110,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 }
 
 void
-MaterialPropertyDebugOutput::printMaterialProperties(std::stringstream & output, const std::vector<std::shared_ptr<Material> > & materials) const
+MaterialPropertyDebugOutput::printMaterialProperties(std::stringstream & output, const std::vector<std::shared_ptr<Material>> & materials) const
 {
   // Loop through all material objects
   for (const auto & mat : materials)

--- a/framework/src/outputs/MaterialPropertyDebugOutput.C
+++ b/framework/src/outputs/MaterialPropertyDebugOutput.C
@@ -56,7 +56,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
   // Active materials on block
   {
-    const std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > > & objects = warehouse.getBlockObjects();
+    const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & objects = warehouse.getBlockObjects();
     for (const auto & it : objects)
     {
       active_block << "    Block ID " << it.first << ":\n";
@@ -66,7 +66,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
   // Active face materials on blocks
   {
-    const std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > > & objects = warehouse[Moose::FACE_MATERIAL_DATA].getBlockObjects();
+    const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & objects = warehouse[Moose::FACE_MATERIAL_DATA].getBlockObjects();
     for (const auto & it : objects)
     {
       active_face << "    Block ID " << it.first << ":\n";
@@ -76,7 +76,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
   // Active neighbor materials on blocks
   {
-    const std::map<SubdomainID, std::vector<MooseSharedPointer<Material> > > & objects = warehouse[Moose::NEIGHBOR_MATERIAL_DATA].getBlockObjects();
+    const std::map<SubdomainID, std::vector<std::shared_ptr<Material> > > & objects = warehouse[Moose::NEIGHBOR_MATERIAL_DATA].getBlockObjects();
     for (const auto & it : objects)
     {
       active_neighbor << "    Block ID " << it.first << ":\n";
@@ -86,7 +86,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
   // Active boundary materials
   {
-    const std::map<BoundaryID, std::vector<MooseSharedPointer<Material> > > & objects = warehouse.getBoundaryObjects();
+    const std::map<BoundaryID, std::vector<std::shared_ptr<Material> > > & objects = warehouse.getBoundaryObjects();
     for (const auto & it : objects)
     {
       active_boundary << "    Boundary ID " << it.first << ":\n";
@@ -110,7 +110,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 }
 
 void
-MaterialPropertyDebugOutput::printMaterialProperties(std::stringstream & output, const std::vector<MooseSharedPointer<Material> > & materials) const
+MaterialPropertyDebugOutput::printMaterialProperties(std::stringstream & output, const std::vector<std::shared_ptr<Material> > & materials) const
 {
   // Loop through all material objects
   for (const auto & mat : materials)

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -87,7 +87,7 @@ OutputWarehouse::subdomainSetup()
 }
 
 void
-OutputWarehouse::addOutput(MooseSharedPointer<Output> & output)
+OutputWarehouse::addOutput(std::shared_ptr<Output> & output)
 {
   _all_ptrs.push_back(output);
 

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -249,7 +249,7 @@ Parser::parse(const std::string &input_filename)
           std::shared_ptr<Action> action_obj = _action_factory.create(it->second._action, MooseUtils::shortName(curr_identifier), params);
 
           // extract the MooseObject params if necessary
-          std::shared_ptr<MooseObjectAction> object_action = MooseSharedNamespace::dynamic_pointer_cast<MooseObjectAction>(action_obj);
+          std::shared_ptr<MooseObjectAction> object_action = std::dynamic_pointer_cast<MooseObjectAction>(action_obj);
           if (object_action)
           {
             extractParams(curr_identifier, object_action->getObjectParams());
@@ -431,8 +431,7 @@ Parser::appendAndReorderSectionNames(std::vector<std::string> & section_names)
    * here or not.
    */
   std::shared_ptr<CommandLine> cmd_line;
-//  if (_app.name() == "main") // See AppFactory::createApp
-    cmd_line = _app.commandLine();
+  cmd_line = _app.commandLine();
 
   if (cmd_line.get())
   {

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -246,10 +246,10 @@ Parser::parse(const std::string &input_filename)
           params.addPrivateParam<std::string>("parser_syntax", curr_identifier);
 
           // Create the Action
-          MooseSharedPointer<Action> action_obj = _action_factory.create(it->second._action, MooseUtils::shortName(curr_identifier), params);
+          std::shared_ptr<Action> action_obj = _action_factory.create(it->second._action, MooseUtils::shortName(curr_identifier), params);
 
           // extract the MooseObject params if necessary
-          MooseSharedPointer<MooseObjectAction> object_action = MooseSharedNamespace::dynamic_pointer_cast<MooseObjectAction>(action_obj);
+          std::shared_ptr<MooseObjectAction> object_action = MooseSharedNamespace::dynamic_pointer_cast<MooseObjectAction>(action_obj);
           if (object_action)
           {
             extractParams(curr_identifier, object_action->getObjectParams());
@@ -303,7 +303,7 @@ Parser::checkActiveUsed(std::vector<std::string > & sections,
 }
 
 void
-Parser::checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_on_warn, bool in_input_file, MooseSharedPointer<FEProblemBase> fe_problem) const
+Parser::checkUnidentifiedParams(std::vector<std::string> & all_vars, bool error_on_warn, bool in_input_file, std::shared_ptr<FEProblemBase> fe_problem) const
 {
   // Make sure that multiapp overrides were processed properly
   int last = all_vars.size() - 1;                      // last is allowed to go negative
@@ -430,7 +430,7 @@ Parser::appendAndReorderSectionNames(std::vector<std::string> & section_names)
    * name of the controlling application to determine whether to use the command line
    * here or not.
    */
-  MooseSharedPointer<CommandLine> cmd_line;
+  std::shared_ptr<CommandLine> cmd_line;
 //  if (_app.name() == "main") // See AppFactory::createApp
     cmd_line = _app.commandLine();
 

--- a/framework/src/restart/RestartableDataIO.C
+++ b/framework/src/restart/RestartableDataIO.C
@@ -224,7 +224,7 @@ RestartableDataIO::readRestartableDataHeader(std::string base_file_name)
 
     const unsigned int file_version = 2;
 
-    _in_file_handles[tid] = MooseSharedPointer<std::ifstream>(new std::ifstream(file_name.c_str(), std::ios::in | std::ios::binary));
+    _in_file_handles[tid] = std::shared_ptr<std::ifstream>(new std::ifstream(file_name.c_str(), std::ios::in | std::ios::binary));
 
     // header
     char id[2];
@@ -277,10 +277,10 @@ RestartableDataIO::readRestartableData(const RestartableDatas & restartable_data
   }
 }
 
-MooseSharedPointer<Backup>
+std::shared_ptr<Backup>
 RestartableDataIO::createBackup()
 {
-  MooseSharedPointer<Backup> backup(new Backup);
+  std::shared_ptr<Backup> backup(new Backup);
 
   serializeSystems(backup->_system_data);
 
@@ -297,7 +297,7 @@ RestartableDataIO::createBackup()
 }
 
 void
-RestartableDataIO::restoreBackup(MooseSharedPointer<Backup> backup, bool for_restart)
+RestartableDataIO::restoreBackup(std::shared_ptr<Backup> backup, bool for_restart)
 {
   unsigned int n_threads = libMesh::n_threads();
 

--- a/framework/src/restart/RestartableDataIO.C
+++ b/framework/src/restart/RestartableDataIO.C
@@ -224,7 +224,7 @@ RestartableDataIO::readRestartableDataHeader(std::string base_file_name)
 
     const unsigned int file_version = 2;
 
-    _in_file_handles[tid] = std::shared_ptr<std::ifstream>(new std::ifstream(file_name.c_str(), std::ios::in | std::ios::binary));
+    _in_file_handles[tid] = std::make_shared<std::ifstream>(file_name.c_str(), std::ios::in | std::ios::binary);
 
     // header
     char id[2];
@@ -280,7 +280,7 @@ RestartableDataIO::readRestartableData(const RestartableDatas & restartable_data
 std::shared_ptr<Backup>
 RestartableDataIO::createBackup()
 {
-  std::shared_ptr<Backup> backup(new Backup);
+  std::shared_ptr<Backup> backup = std::make_shared<Backup>();
 
   serializeSystems(backup->_system_data);
 

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -265,7 +265,7 @@ Split::setup(const std::string& prefix)
     // Finally, recursively configure the splits contained within this split.
     for (unsigned int i = 0; i < _splitting.size(); ++i)
     {
-      MooseSharedPointer<Split> split = _fe_problem.getNonlinearSystemBase().getSplit(_splitting[i]);
+      std::shared_ptr<Split> split = _fe_problem.getNonlinearSystemBase().getSplit(_splitting[i]);
       std::string sprefix = prefix + "fieldsplit_" + _splitting[i] + "_";
       split->setup(sprefix);
     }

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -17,7 +17,7 @@
 #include "MooseTypes.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
-#include "MooseTypes.h" // for MooseSharedPointer
+#include "MooseTypes.h" // for std::shared_ptr
 #include "MooseMesh.h"
 
 // libMesh includes
@@ -191,7 +191,7 @@ MultiAppMeshFunctionTransfer::execute()
   }
 
   // Setup the local mesh functions.
-  std::vector<MooseSharedPointer<MeshFunction> > local_meshfuns;
+  std::vector<std::shared_ptr<MeshFunction> > local_meshfuns;
   for (unsigned int i_from = 0; i_from < _from_problems.size(); i_from++)
   {
     FEProblemBase & from_problem = *_from_problems[i_from];
@@ -199,7 +199,7 @@ MultiAppMeshFunctionTransfer::execute()
     System & from_sys = from_var.sys().system();
     unsigned int from_var_num = from_sys.variable_number(from_var.name());
 
-    MooseSharedPointer<MeshFunction> from_func;
+    std::shared_ptr<MeshFunction> from_func;
     //TODO: make MultiAppTransfer give me the right es
     if (_displaced_source_mesh && from_problem.getDisplacedProblem())
       from_func.reset(new MeshFunction(from_problem.getDisplacedProblem()->es(),

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -17,7 +17,6 @@
 #include "MooseTypes.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
-#include "MooseTypes.h" // for std::shared_ptr
 #include "MooseMesh.h"
 
 // libMesh includes
@@ -191,7 +190,7 @@ MultiAppMeshFunctionTransfer::execute()
   }
 
   // Setup the local mesh functions.
-  std::vector<std::shared_ptr<MeshFunction> > local_meshfuns;
+  std::vector<std::shared_ptr<MeshFunction>> local_meshfuns;
   for (unsigned int i_from = 0; i_from < _from_problems.size(); i_from++)
   {
     FEProblemBase & from_problem = *_from_problems[i_from];

--- a/framework/src/utils/InputParameterWarehouse.C
+++ b/framework/src/utils/InputParameterWarehouse.C
@@ -29,7 +29,7 @@ InputParameterWarehouse::addInputParameters(const std::string & name, InputParam
     mooseError("The object name may not contain '::' in the name: " << name);
 
   // Create the actual InputParameters object that will be reference by the objects
-  std::shared_ptr<InputParameters> ptr(new InputParameters(parameters));
+  std::shared_ptr<InputParameters> ptr = std::make_shared<InputParameters>(parameters);
 
   // Set the name parameter to the object being created
   ptr->set<std::string>("_object_name") = name;
@@ -43,14 +43,14 @@ InputParameterWarehouse::addInputParameters(const std::string & name, InputParam
     mooseError("A '" << unique_name.tag() << "' object already exists with the name '" << unique_name.name() << "'.\n");
 
   // Store the parameters according to the base name
-  _input_parameters[tid].insert(std::pair<MooseObjectName, std::shared_ptr<InputParameters> >(unique_name, ptr));
+  _input_parameters[tid].insert(std::pair<MooseObjectName, std::shared_ptr<InputParameters>>(unique_name, ptr));
 
   // Store the object according to the control tags
   if (ptr->isParamValid("control_tags"))
   {
     const std::vector<std::string> & tags = ptr->get<std::vector<std::string> >("control_tags");
     for (const auto & tag : tags)
-      _input_parameters[tid].insert(std::pair<MooseObjectName, std::shared_ptr<InputParameters> >(MooseObjectName(tag, name),  ptr));
+      _input_parameters[tid].insert(std::pair<MooseObjectName, std::shared_ptr<InputParameters>>(MooseObjectName(tag, name),  ptr));
   }
 
   // Set the name and tid parameters
@@ -101,8 +101,7 @@ InputParameters &
 InputParameterWarehouse::getInputParameters(const MooseObjectName & object_name, THREAD_ID tid) const
 {
   // Locate the InputParameters object and error if it was not located
-  std::multimap<MooseObjectName, std::shared_ptr<InputParameters> >::const_iterator iter;
-  iter = _input_parameters[tid].find(object_name);
+  const auto iter = _input_parameters[tid].find(object_name);
   if (iter == _input_parameters[tid].end())
     mooseError("Unknown InputParameters object " << object_name);
 
@@ -111,7 +110,7 @@ InputParameterWarehouse::getInputParameters(const MooseObjectName & object_name,
 }
 
 
-const std::multimap<MooseObjectName, std::shared_ptr<InputParameters> > &
+const std::multimap<MooseObjectName, std::shared_ptr<InputParameters>> &
 InputParameterWarehouse::getInputParameters(THREAD_ID tid) const
 {
   return _input_parameters[tid];

--- a/framework/src/utils/InputParameterWarehouse.C
+++ b/framework/src/utils/InputParameterWarehouse.C
@@ -29,7 +29,7 @@ InputParameterWarehouse::addInputParameters(const std::string & name, InputParam
     mooseError("The object name may not contain '::' in the name: " << name);
 
   // Create the actual InputParameters object that will be reference by the objects
-  MooseSharedPointer<InputParameters> ptr(new InputParameters(parameters));
+  std::shared_ptr<InputParameters> ptr(new InputParameters(parameters));
 
   // Set the name parameter to the object being created
   ptr->set<std::string>("_object_name") = name;
@@ -43,14 +43,14 @@ InputParameterWarehouse::addInputParameters(const std::string & name, InputParam
     mooseError("A '" << unique_name.tag() << "' object already exists with the name '" << unique_name.name() << "'.\n");
 
   // Store the parameters according to the base name
-  _input_parameters[tid].insert(std::pair<MooseObjectName, MooseSharedPointer<InputParameters> >(unique_name, ptr));
+  _input_parameters[tid].insert(std::pair<MooseObjectName, std::shared_ptr<InputParameters> >(unique_name, ptr));
 
   // Store the object according to the control tags
   if (ptr->isParamValid("control_tags"))
   {
     const std::vector<std::string> & tags = ptr->get<std::vector<std::string> >("control_tags");
     for (const auto & tag : tags)
-      _input_parameters[tid].insert(std::pair<MooseObjectName, MooseSharedPointer<InputParameters> >(MooseObjectName(tag, name),  ptr));
+      _input_parameters[tid].insert(std::pair<MooseObjectName, std::shared_ptr<InputParameters> >(MooseObjectName(tag, name),  ptr));
   }
 
   // Set the name and tid parameters
@@ -101,7 +101,7 @@ InputParameters &
 InputParameterWarehouse::getInputParameters(const MooseObjectName & object_name, THREAD_ID tid) const
 {
   // Locate the InputParameters object and error if it was not located
-  std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> >::const_iterator iter;
+  std::multimap<MooseObjectName, std::shared_ptr<InputParameters> >::const_iterator iter;
   iter = _input_parameters[tid].find(object_name);
   if (iter == _input_parameters[tid].end())
     mooseError("Unknown InputParameters object " << object_name);
@@ -111,7 +111,7 @@ InputParameterWarehouse::getInputParameters(const MooseObjectName & object_name,
 }
 
 
-const std::multimap<MooseObjectName, MooseSharedPointer<InputParameters> > &
+const std::multimap<MooseObjectName, std::shared_ptr<InputParameters> > &
 InputParameterWarehouse::getInputParameters(THREAD_ID tid) const
 {
   return _input_parameters[tid];

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -679,7 +679,7 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
             PenetrationLocator * locator;
             if (displaced)
             {
-              MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
+              std::shared_ptr<DisplacedProblem> displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
               if (!displaced_problem)
               {
                 std::ostringstream err;
@@ -780,7 +780,7 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
             PenetrationLocator * locator;
             if (displaced)
             {
-              MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
+              std::shared_ptr<DisplacedProblem> displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
               if (!displaced_problem)
               {
                 std::ostringstream err;
@@ -2021,7 +2021,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
   ierr = PetscFree(sides);
   CHKERRQ(ierr);
   PetscInt maxcontacts = dmm->_nl->_fe_problem.geomSearchData()._penetration_locators.size();
-  MooseSharedPointer<DisplacedProblem> displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
+  std::shared_ptr<DisplacedProblem> displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
   if (displaced_problem)
     maxcontacts = PetscMax(maxcontacts,(PetscInt)displaced_problem->geomSearchData()._penetration_locators.size());
 

--- a/test/src/actions/ApplyCoupledVariablesTestAction.C
+++ b/test/src/actions/ApplyCoupledVariablesTestAction.C
@@ -45,7 +45,7 @@ ApplyCoupledVariablesTestAction::act()
 
   // Create the action
   std::string long_name = "Kernels/_coef_diffusion";
-  MooseSharedPointer<MooseObjectAction> action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddKernelAction", long_name, action_params));
+  std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(_action_factory.create("AddKernelAction", long_name, action_params));
 
   // Apply the parameters from the this action to the object being created
   action->getObjectParams().applyParameters(_pars);

--- a/test/src/actions/ConvDiffMetaAction.C
+++ b/test/src/actions/ConvDiffMetaAction.C
@@ -38,8 +38,8 @@ ConvDiffMetaAction::ConvDiffMetaAction(const InputParameters & params) :
 void
 ConvDiffMetaAction::act()
 {
-  MooseSharedPointer<Action> action;
-  MooseSharedPointer<MooseObjectAction> moose_object_action;
+  std::shared_ptr<Action> action;
+  std::shared_ptr<MooseObjectAction> moose_object_action;
 
   std::vector<NonlinearVariableName> variables = getParam<std::vector<NonlinearVariableName> > ("variables");
 


### PR DESCRIPTION
Getting rid of MooseSharedPointer everywhere in the framework and modernizing affected lines.

closes #8501 