### PR TITLE
add .failed_tests to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ temp_print_trace.*
 *.bak
 *.processor.*
 .clang_complete
+.failed_tests
 
 # Allow certain files in gold directories
 !**/gold/*.e


### PR DESCRIPTION
Add .failed_tests to the .gitignore file. Was an oversight that it was
not included in the PR responsible for implementing --failed-tests feature.

Refs #8509 
