### PR TITLE
remove declarePropertyOld from test objects

### DIFF
--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -265,11 +265,6 @@ private:
   /// Small helper function to call storeMatPropName
   void registerPropName(std::string prop_name, bool is_get, Prop_State state);
 
-  /// Small helper function to cache MaterialProperty ids while they are being declared.
-  template <typename T>
-  MaterialProperty<T> & cachePropertyIdWhileDeclaring(const std::string & prop_name,
-                                                      MaterialProperty<T> & prop);
-
   /// Check and throw an error if the execution has progerssed past the construction stage
   void checkExecutionStage();
 
@@ -332,38 +327,23 @@ Material::getMaterialPropertyByName(const std::string & prop_name)
   // same memory)
   _requested_props.insert(prop_name);
   registerPropName(prop_name, true, Material::CURRENT);
-  _fe_problem.markMatPropRequested(prop_name);
-  return _material_data->getProperty<T>(prop_name);
+  return MaterialPropertyInterface::getMaterialPropertyByName<T>(prop_name);
 }
 
 template <typename T>
 const MaterialProperty<T> &
 Material::getMaterialPropertyOldByName(const std::string & prop_name)
 {
-  _requested_props.insert(prop_name);
   registerPropName(prop_name, true, Material::OLD);
-  _fe_problem.markMatPropRequested(prop_name);
-  return _material_data->getPropertyOld<T>(prop_name);
+  return MaterialPropertyInterface::getMaterialPropertyOldByName<T>(prop_name);
 }
 
 template <typename T>
 const MaterialProperty<T> &
 Material::getMaterialPropertyOlderByName(const std::string & prop_name)
 {
-  _requested_props.insert(prop_name);
   registerPropName(prop_name, true, Material::OLDER);
-  _fe_problem.markMatPropRequested(prop_name);
-  return _material_data->getPropertyOlder<T>(prop_name);
-}
-
-template <typename T>
-MaterialProperty<T> &
-Material::cachePropertyIdWhileDeclaring(const std::string & prop_name, MaterialProperty<T> & prop)
-{
-  // Ask the Storage what id it has assigned to the MaterialProperty named prop_name
-  const MaterialPropertyStorage & storage = _fe_problem.getMaterialPropertyStorage();
-  _supplied_prop_ids.insert(storage.retrievePropertyId(prop_name));
-  return prop;
+  return MaterialPropertyInterface::getMaterialPropertyOlderByName<T>(prop_name);
 }
 
 template <typename T>
@@ -371,7 +351,7 @@ MaterialProperty<T> &
 Material::declareProperty(const std::string & prop_name)
 {
   registerPropName(prop_name, false, Material::CURRENT);
-  return cachePropertyIdWhileDeclaring(prop_name, _material_data->declareProperty<T>(prop_name));
+  return _material_data->declareProperty<T>(prop_name);
 }
 
 template <typename T>
@@ -379,7 +359,7 @@ MaterialProperty<T> &
 Material::declarePropertyOld(const std::string & prop_name)
 {
   registerPropName(prop_name, false, Material::OLD);
-  return cachePropertyIdWhileDeclaring(prop_name, _material_data->declarePropertyOld<T>(prop_name));
+  return _material_data->declarePropertyOld<T>(prop_name);
 }
 
 template <typename T>
@@ -387,8 +367,7 @@ MaterialProperty<T> &
 Material::declarePropertyOlder(const std::string & prop_name)
 {
   registerPropName(prop_name, false, Material::OLDER);
-  return cachePropertyIdWhileDeclaring(prop_name,
-                                       _material_data->declarePropertyOlder<T>(prop_name));
+  return _material_data->declarePropertyOlder<T>(prop_name);
 }
 
 template <typename T>

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -231,7 +231,7 @@ public:
   unsigned int addPropertyOlder(const std::string & prop_name);
 
   std::vector<unsigned int> & statefulProps() { return _stateful_prop_id_to_prop_id; }
-  std::map<unsigned int, std::string> statefulPropNames() { return _prop_names; }
+  const std::map<unsigned int, std::string> statefulPropNames() const { return _prop_names; }
 
   /// Returns the property ID for the given prop_name, adding the property and
   /// creating a new ID if it hasn't already been created.

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -4578,6 +4578,8 @@ void
 FEProblemBase::checkDependMaterialsHelper(
     const std::map<SubdomainID, std::vector<std::shared_ptr<Material>>> & materials_map)
 {
+  auto & prop_names = _material_props.statefulPropNames();
+
   for (const auto & it : materials_map)
   {
     /// These two sets are used to make sure that all dependent props on a block are actually supplied
@@ -4587,6 +4589,13 @@ FEProblemBase::checkDependMaterialsHelper(
     {
       const std::set<std::string> & depend_props = mat1->getRequestedItems();
       block_depend_props.insert(depend_props.begin(), depend_props.end());
+
+      auto & alldeps = mat1->getMatPropDependencies(); // includes requested stateful props
+      for (auto & dep : alldeps)
+      {
+        if (prop_names.count(dep) > 0)
+          block_depend_props.insert(prop_names.at(dep));
+      }
 
       // See if any of the active materials supply this property
       for (const auto & mat2 : it.second)

--- a/framework/src/materials/GenericFunctionMaterial.C
+++ b/framework/src/materials/GenericFunctionMaterial.C
@@ -26,7 +26,10 @@ validParams<GenericFunctionMaterial>()
                                              "The corresponding names of the "
                                              "functions that are going to provide "
                                              "the values for the variables");
-  params.addParam<bool>("enable_stateful", false, "Enable the declaration of old and older values");
+  params.addDeprecatedParam<bool>("enable_stateful",
+                                  false,
+                                  "Enable the declaration of old and older values",
+                                  "all properties can implicitly become stateful");
   return params;
 }
 
@@ -58,11 +61,6 @@ GenericFunctionMaterial::GenericFunctionMaterial(const InputParameters & paramet
   for (unsigned int i = 0; i < _num_props; i++)
   {
     _properties[i] = &declareProperty<Real>(_prop_names[i]);
-    if (_enable_stateful)
-    {
-      _properties_old[i] = &declarePropertyOld<Real>(_prop_names[i]);
-      _properties_older[i] = &declarePropertyOlder<Real>(_prop_names[i]);
-    }
     _functions[i] = &getFunctionByName(_prop_values[i]);
   }
 }

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -148,10 +148,7 @@ Material::checkStatefulSanity() const
 {
   for (const auto & it : _props_to_flags)
     if (static_cast<int>(it.second) % 2 == 0) // Only Stateful properties declared!
-      mooseError("Material '",
-                 name(),
-                 "' has stateful properties declared but not associated \"current\" properties.",
-                 it.second);
+      mooseError("Material '", name(), "' requests undefined stateful property '", it.first, "'");
 }
 
 void
@@ -159,6 +156,9 @@ Material::registerPropName(std::string prop_name, bool is_get, Material::Prop_St
 {
   if (!is_get)
   {
+    _supplied_props.insert(prop_name);
+    _supplied_prop_ids.insert(_material_data->getPropertyId(prop_name));
+
     _props_to_flags[prop_name] |= static_cast<int>(state);
     if (static_cast<int>(state) % 2 == 0)
       _has_stateful_property = true;
@@ -166,23 +166,11 @@ Material::registerPropName(std::string prop_name, bool is_get, Material::Prop_St
 
   // Store material properties for block ids
   for (const auto & block_id : blockIDs())
-  {
-    // Only save this prop as a "supplied" prop is it was registered as a result of a call to
-    // declareProperty not getMaterialProperty
-    if (!is_get)
-      _supplied_props.insert(prop_name);
     _fe_problem.storeMatPropName(block_id, prop_name);
-  }
 
   // Store material properties for the boundary ids
   for (const auto & boundary_id : boundaryIDs())
-  {
-    // Only save this prop as a "supplied" prop is it was registered as a result of a call to
-    // declareProperty not getMaterialProperty
-    if (!is_get)
-      _supplied_props.insert(prop_name);
     _fe_problem.storeMatPropName(boundary_id, prop_name);
-  }
 }
 
 std::set<OutputName>

--- a/test/include/materials/BadStatefulMaterial.h
+++ b/test/include/materials/BadStatefulMaterial.h
@@ -32,9 +32,6 @@ public:
 protected:
   virtual void initQpStatefulProperties();
   virtual void computeQpProperties();
-
-private:
-  MaterialProperty<Real> & _prop_old;
 };
 
 #endif // STATEFULMATERIAL_H

--- a/test/include/materials/BadStatefulMaterial.h
+++ b/test/include/materials/BadStatefulMaterial.h
@@ -23,7 +23,7 @@ class BadStatefulMaterial;
 template <>
 InputParameters validParams<BadStatefulMaterial>();
 
-// Only declares old or older property
+/// Tries to retrieve non-existing old/older versions of a material property.
 class BadStatefulMaterial : public Material
 {
 public:

--- a/test/include/materials/ComputingInitialTest.h
+++ b/test/include/materials/ComputingInitialTest.h
@@ -35,7 +35,7 @@ protected:
   virtual void computeQpProperties();
 
   MaterialProperty<Real> & _thermal_conductivity;
-  MaterialProperty<Real> & _thermal_conductivity_old;
+  const MaterialProperty<Real> & _thermal_conductivity_old;
 };
 
 #endif // COMPUTINGINITIALTEST_H

--- a/test/include/materials/CoupledMaterial.h
+++ b/test/include/materials/CoupledMaterial.h
@@ -30,7 +30,8 @@ public:
   CoupledMaterial(const InputParameters & parameters);
 
 protected:
-  virtual void computeQpProperties();
+  virtual void initQpStatefulProperties() override { _mat_prop[_qp] = 1.0; }
+  virtual void computeQpProperties() override;
 
   std::string _mat_prop_name;
   MaterialProperty<Real> & _mat_prop;

--- a/test/include/materials/SpatialStatefulMaterial.h
+++ b/test/include/materials/SpatialStatefulMaterial.h
@@ -42,7 +42,7 @@ private:
    * and previous material properties respectively
    */
   MaterialProperty<Real> & _diffusivity;
-  MaterialProperty<Real> & _diffusivity_old;
+  const MaterialProperty<Real> & _diffusivity_old;
 };
 
 #endif // SPATIALSTATEFULMATERIAL_H

--- a/test/include/materials/StatefulMaterial.h
+++ b/test/include/materials/StatefulMaterial.h
@@ -42,7 +42,7 @@ private:
    * and previous material properties respectively
    */
   MaterialProperty<Real> & _diffusivity;
-  MaterialProperty<Real> & _diffusivity_old;
+  const MaterialProperty<Real> & _diffusivity_old;
 };
 
 #endif // STATEFULMATERIAL_H

--- a/test/include/materials/StatefulSpatialTest.h
+++ b/test/include/materials/StatefulSpatialTest.h
@@ -35,7 +35,7 @@ protected:
   virtual void initQpStatefulProperties();
 
   MaterialProperty<Real> & _thermal_conductivity;
-  MaterialProperty<Real> & _thermal_conductivity_old;
+  const MaterialProperty<Real> & _thermal_conductivity_old;
 };
 
 #endif // STATEFULSPATIALTEST_H

--- a/test/include/materials/StatefulTest.h
+++ b/test/include/materials/StatefulTest.h
@@ -43,8 +43,8 @@ protected:
   unsigned int _num_props;
 
   std::vector<MaterialProperty<Real> *> _properties;
-  std::vector<MaterialProperty<Real> *> _properties_old;
-  std::vector<MaterialProperty<Real> *> _properties_older;
+  std::vector<const MaterialProperty<Real> *> _properties_old;
+  std::vector<const MaterialProperty<Real> *> _properties_older;
 };
 
 #endif // STATEFULTEST_H

--- a/test/include/materials/VarCouplingMaterial.h
+++ b/test/include/materials/VarCouplingMaterial.h
@@ -37,7 +37,7 @@ protected:
   Real _base;
   Real _coef;
   MaterialProperty<Real> & _diffusion;
-  MaterialProperty<Real> * const _diffusion_old;
+  const MaterialProperty<Real> * const _diffusion_old;
 };
 
 #endif // VARCOUPLINGMATERIAL_H

--- a/test/src/materials/BadStatefulMaterial.C
+++ b/test/src/materials/BadStatefulMaterial.C
@@ -18,21 +18,25 @@ template <>
 InputParameters
 validParams<BadStatefulMaterial>()
 {
-  return validParams<Material>();
+  InputParameters params = validParams<Material>();
+  params.addParam<bool>("get_older", false, "true to retrieve older property instead of old");
+  return params;
 }
 
 BadStatefulMaterial::BadStatefulMaterial(const InputParameters & parameters) : Material(parameters)
 {
+  if (getParam<bool>("get_older"))
+    getMaterialPropertyOlder<Real>("nonexistingpropertyname");
+  else
+    getMaterialPropertyOld<Real>("nonexistingpropertyname");
 }
 
 void
 BadStatefulMaterial::initQpStatefulProperties()
 {
-  // Bad Material
 }
 
 void
 BadStatefulMaterial::computeQpProperties()
 {
-  // Bad Material
 }

--- a/test/src/materials/BadStatefulMaterial.C
+++ b/test/src/materials/BadStatefulMaterial.C
@@ -18,16 +18,10 @@ template <>
 InputParameters
 validParams<BadStatefulMaterial>()
 {
-  InputParameters params = validParams<Material>();
-  params.addParam<bool>(
-      "declare_only_older", false, "Whether or not to declare the old or older property");
-  return params;
+  return validParams<Material>();
 }
 
-BadStatefulMaterial::BadStatefulMaterial(const InputParameters & parameters)
-  : Material(parameters),
-    _prop_old(getParam<bool>("declare_only_older") ? declarePropertyOlder<Real>("property")
-                                                   : declarePropertyOld<Real>("property"))
+BadStatefulMaterial::BadStatefulMaterial(const InputParameters & parameters) : Material(parameters)
 {
 }
 

--- a/test/src/materials/ComputingInitialTest.C
+++ b/test/src/materials/ComputingInitialTest.C
@@ -17,14 +17,13 @@ template <>
 InputParameters
 validParams<ComputingInitialTest>()
 {
-  InputParameters params = validParams<Material>();
-  return params;
+  return validParams<Material>();
 }
 
 ComputingInitialTest::ComputingInitialTest(const InputParameters & parameters)
   : Material(parameters),
     _thermal_conductivity(declareProperty<Real>("thermal_conductivity")),
-    _thermal_conductivity_old(declarePropertyOld<Real>("thermal_conductivity"))
+    _thermal_conductivity_old(getMaterialPropertyOld<Real>("thermal_conductivity"))
 {
 }
 

--- a/test/src/materials/SpatialStatefulMaterial.C
+++ b/test/src/materials/SpatialStatefulMaterial.C
@@ -32,10 +32,9 @@ SpatialStatefulMaterial::SpatialStatefulMaterial(const InputParameters & paramet
     // valued property named "diffusivity" that Kernels can use.
     _diffusivity(declareProperty<Real>("diffusivity")),
 
-    // Declare that we are going to have an old value of diffusivity
-    // Note: this is _expensive_ and currently means that you can't
-    // use adaptivity!  Only do this if you REALLY need it!
-    _diffusivity_old(declarePropertyOld<Real>("diffusivity"))
+    // Retrieve/use an old value of diffusivity.
+    // Note: this is _expensive_ - only do this if you REALLY need it!
+    _diffusivity_old(getMaterialPropertyOld<Real>("diffusivity"))
 {
 }
 

--- a/test/src/materials/StatefulMaterial.C
+++ b/test/src/materials/StatefulMaterial.C
@@ -32,10 +32,9 @@ StatefulMaterial::StatefulMaterial(const InputParameters & parameters)
     // valued property named "diffusivity" that Kernels can use.
     _diffusivity(declareProperty<Real>("diffusivity")),
 
-    // Declare that we are going to have an old value of diffusivity
-    // Note: this is _expensive_ and currently means that you can't
-    // use adaptivity!  Only do this if you REALLY need it!
-    _diffusivity_old(declarePropertyOld<Real>("diffusivity"))
+    // Retrieve/use an old value of diffusivity.
+    // Note: this is _expensive_ - only do this if you REALLY need it!
+    _diffusivity_old(getMaterialPropertyOld<Real>("diffusivity"))
 {
 }
 

--- a/test/src/materials/StatefulSpatialTest.C
+++ b/test/src/materials/StatefulSpatialTest.C
@@ -24,7 +24,7 @@ validParams<StatefulSpatialTest>()
 StatefulSpatialTest::StatefulSpatialTest(const InputParameters & parameters)
   : Material(parameters),
     _thermal_conductivity(declareProperty<Real>("thermal_conductivity")),
-    _thermal_conductivity_old(declarePropertyOld<Real>("thermal_conductivity"))
+    _thermal_conductivity_old(getMaterialPropertyOld<Real>("thermal_conductivity"))
 {
 }
 

--- a/test/src/materials/StatefulTest.C
+++ b/test/src/materials/StatefulTest.C
@@ -48,8 +48,8 @@ StatefulTest::StatefulTest(const InputParameters & parameters)
   for (unsigned int i = 0; i < _num_props; ++i)
   {
     _properties[i] = &declareProperty<Real>(_prop_names[i]);
-    _properties_old[i] = &declarePropertyOld<Real>(_prop_names[i]);
-    _properties_older[i] = &declarePropertyOlder<Real>(_prop_names[i]);
+    _properties_old[i] = &getMaterialPropertyOld<Real>(_prop_names[i]);
+    _properties_older[i] = &getMaterialPropertyOlder<Real>(_prop_names[i]);
   }
 }
 

--- a/test/src/materials/VarCouplingMaterial.C
+++ b/test/src/materials/VarCouplingMaterial.C
@@ -32,15 +32,15 @@ VarCouplingMaterial::VarCouplingMaterial(const InputParameters & parameters)
     _base(getParam<Real>("base")),
     _coef(getParam<Real>("coef")),
     _diffusion(declareProperty<Real>("diffusion")),
-    _diffusion_old(getParam<bool>("declare_old") ? &declarePropertyOld<Real>("diffusion") : NULL)
+    _diffusion_old(getParam<bool>("declare_old") ? &getMaterialPropertyOld<Real>("diffusion")
+                                                 : nullptr)
 {
 }
 
 void
 VarCouplingMaterial::initQpStatefulProperties()
 {
-  if (_diffusion_old)
-    _diffusion[_qp] = _var[_qp];
+  _diffusion[_qp] = _var[_qp];
 }
 
 void

--- a/test/tests/auxkernels/old_older_material_aux/old_mat_in_aux.i
+++ b/test/tests/auxkernels/old_older_material_aux/old_mat_in_aux.i
@@ -65,7 +65,6 @@
     prop_names = prop
     prop_values = func
     block = 0
-    enable_stateful = true
   [../]
 []
 

--- a/test/tests/materials/old_cyclic_dep/test.i
+++ b/test/tests/materials/old_cyclic_dep/test.i
@@ -1,0 +1,70 @@
+# This test checks that the usage of an old/older (stateful) material property
+# does not create a dependency on that property for the purposes of
+# dependency resolution for material property evaluation.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 'left'
+    value = 1
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 'right'
+    value = 2
+  [../]
+[]
+
+[Materials]
+  [./mat1]
+    type = CoupledMaterial
+    mat_prop = 'prop-a'
+    coupled_mat_prop = 'prop-b'
+    use_old_prop = true
+    block = 0
+  [../]
+
+  [./mat2]
+    type = CoupledMaterial
+    mat_prop = 'prop-b'
+    coupled_mat_prop = 'prop-a'
+    use_old_prop = false
+    block = 0
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+[]
+
+[Debug]
+  show_material_props = true
+[]

--- a/test/tests/materials/old_cyclic_dep/tests
+++ b/test/tests/materials/old_cyclic_dep/tests
@@ -1,0 +1,6 @@
+[Tests]
+  [./test]
+    type = RunApp
+    input = 'test.i'
+  [../]
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -305,14 +305,14 @@
   [./bad_stateful_material_only_old]
     type = 'RunException'
     input = 'bad_stateful_material.i'
-    expect_err = "Material '\S+' has stateful properties declared but not associated"
+    expect_err = "One or more Material Properties were not supplied on block"
   [../]
 
   [./bad_stateful_material_only_older]
     type = 'RunException'
     input = 'bad_stateful_material.i'
-    expect_err = "Material '\S+' has stateful properties declared but not associated"
-    cli_args = 'Materials/stateful_mat/declare_only_older=true'
+    expect_err = "One or more Material Properties were not supplied on block"
+    cli_args = 'Materials/stateful_mat/get_older=true'
   [../]
 
   [./missing_mesh_test]


### PR DESCRIPTION
Addresses (at least partially) #8438.  These tests could probably still use some more consolidation and housekeeping though. This also now fixes #8522, and depends on PR #8467 being merged first.  I'll rebase when that happens.  After #8467 is in, this will also probably need a ``git cherry-pick 9acbcd4`` to pull back in the cyclic-stateful-prop dependency test that was added/reverted.