### PR TITLE
Divide by zero fix

### DIFF
--- a/scripts/memory_logger.py
+++ b/scripts/memory_logger.py
@@ -783,7 +783,7 @@ class MemoryPlotter:
         suffixes = ["Terabytes", "Gigabytes", "Megabytes", "Kilobytes", "Bytes"]
         multiplier = 1 << 40;
         index = 0
-        while largest_memory[-1] < multiplier and multiplier >= 1:
+        while largest_memory[-1] < multiplier and multiplier > 1:
             multiplier = multiplier >> 10
             index = index + 1
         self.multiples = multiplier


### PR DESCRIPTION
Sometimes the memory logger will take a sample of a binary which has already
exited. This is treated as using zero bytes (which is correct after all).

However, if the binary's largest recorded memory usage is in fact 0 bytes,
which can happen if the binary started, performed its function, and exited all
before memory logger had a change to 'watch' it, the script will not be able
to scale the graph (bytes, megabytes, gigabytes, etc).

If 0 is detected, do not try to scale this number. Just plot the usage as a
literal zero bytes used.

Refs #8392