### PR TITLE
Add TestHarness testers from chigger

### DIFF
--- a/python/TestHarness/testers/ImageDiff.py
+++ b/python/TestHarness/testers/ImageDiff.py
@@ -1,0 +1,78 @@
+import os
+import sys
+
+from RunPythonApp import RunPythonApp
+from mooseutils.ImageDiffer import ImageDiffer
+
+class ImageDiff(RunPythonApp):
+
+
+    @staticmethod
+    def validParams():
+        params = RunPythonApp.validParams()
+        params.addRequiredParam('imagediff', [], 'A list of files to compare against the gold.')
+        params.addParam('gold_dir', 'gold', "The directory where the \"golden standard\" files reside relative to the TEST_DIR: (default: ./gold/)")
+        params.addParam('allowed', 0.98, "Absolute zero cutoff used in exodiff comparisons.")
+        params.addParam('delete_output_before_running', True, "Delete pre-existing output files before running test. Only set to False if you know what you're doing!")
+        params.addParam('allowed_linux', "Absolute zero cuttoff used for linux machines, if not provided 'allowed' is used.")
+        params.addParam('allowed_darwin', "Absolute zero cuttoff used for Mac OS (Darwin) machines, if not provided 'allowed' is used.")
+        return params
+
+    def __init__(self, name, params):
+        RunPythonApp.__init__(self, name, params)
+
+    def prepare(self, options):
+        """
+        Cleans up image files from previous execution
+        """
+        if self.specs['delete_output_before_running'] == True:
+            for file in self.specs['imagediff']:
+                try:
+                    os.remove(os.path.join(self.specs['test_dir'], file))
+                except:
+                    pass
+
+    def processResults(self, moose_dir, retcode, options, output):
+        """
+        Perform image diff
+        """
+
+        # Call base class processResults
+        (reason, output) = RunPythonApp.processResults(self, moose_dir, retcode, options, output)
+        if reason:
+            return (reason, output)
+
+        # Loop through files
+        specs = self.specs
+        for filename in specs['imagediff']:
+
+            # Error if gold file does not exist
+            if not os.path.exists(os.path.join(specs['test_dir'], specs['gold_dir'], filename)):
+                output += "File Not Found: " + os.path.join(specs['test_dir'], specs['gold_dir'], filename)
+                reason = 'MISSING GOLD FILE'
+                break
+
+            # Perform diff
+            else:
+
+                output = 'Running ImageDiffer.py'
+                gold = os.path.join(specs['test_dir'], specs['gold_dir'], filename)
+                test = os.path.join(specs['test_dir'], filename)
+
+                if sys.platform in ['linux', 'linux2']:
+                    name = 'allowed_linux'
+                elif sys.platform == 'darwin':
+                    name = 'allowed_darwin'
+                allowed = specs[name] if specs.isValid(name) else specs['allowed']
+                differ = ImageDiffer(gold, test, allowed=allowed)
+
+                # Update golds (e.g., uncomment this to re-gold for new system or new defaults)
+                #import shutil; shutil.copy(test, gold)
+
+                output += differ.message()
+                if differ.fail():
+                    reason = 'IMAGEDIFF'
+                    break
+
+        # Return the reason and command output
+        return (reason, output)

--- a/python/TestHarness/testers/RunPythonApp.py
+++ b/python/TestHarness/testers/RunPythonApp.py
@@ -1,0 +1,61 @@
+import os, re
+from Tester import Tester
+
+class RunPythonApp(Tester):
+
+    @staticmethod
+    def validParams():
+        params = Tester.validParams()
+        params.addRequiredParam('input', "The python input file to use for this test.")
+        params.addParam('expect_out', "Search for the supplied string in the output.")
+        params.addParam('match_literal', False, "Treat expect_out as a string not a regular expression.")
+        params.addParam('unittest', False, "This uses unittest.")
+        params.addParam('cli_args', '', "String of additional options to pass to Python executable.")
+        return params
+
+    def __init__(self, name, params):
+        Tester.__init__(self, name, params)
+
+    def getCommand(self, options):
+        """
+        Returns the python script to execute
+        """
+        return os.path.join(self.specs['test_dir'], self.specs['input']) + ' ' + self.specs['cli_args']
+
+    def processResults(self, moose_dir, retcode, options, output):
+
+        specs = self.specs
+
+        # Initialize reason output
+        reason = ''
+
+        if specs.isValid('expect_out'):
+            if specs['match_literal']:
+                out_ok = self.checkOutputForLiteral(output, specs['expect_out'])
+            else:
+                out_ok = self.checkOutputForPattern(output, specs['expect_out'])
+
+            # Process out_ok
+            if (out_ok and retcode != 0):
+                reason = 'OUT FOUND BUT CRASH'
+            elif (not out_ok):
+                reason = 'NO EXPECTED OUT'
+        elif specs['unittest']:
+            out_ok = self.checkOutputForPattern(output, "^OK$") or self.checkOutputForPattern(output, "^OK\s\(skipped=\d+\)$")
+            if not out_ok:
+                reason = 'FAILED'
+
+        # Return the reason and command output
+        return (reason, output)
+
+    def checkOutputForPattern(self, output, re_pattern):
+        if re.search(re_pattern, output, re.MULTILINE | re.DOTALL) == None:
+            return False
+        else:
+            return True
+
+    def checkOutputForLiteral(self, output, literal):
+        if output.find(literal) == -1:
+            return False
+        else:
+            return True

--- a/python/TestHarness/testers/RunPythonException.py
+++ b/python/TestHarness/testers/RunPythonException.py
@@ -1,0 +1,32 @@
+from RunPythonApp import RunPythonApp
+
+class RunPythonException(RunPythonApp):
+
+    @staticmethod
+    def validParams():
+        params = RunPythonApp.validParams()
+        params.addParam('expect_err', "Search for the supplied string in the output.")
+        return params
+
+    def __init__(self, name, params):
+        RunPythonApp.__init__(self, name, params)
+
+    def processResults(self, moose_dir, retcode, options, output):
+
+        specs = self.specs
+
+        # Initialize reason output
+        reason = 'NO EXPECTED ERROR'
+
+        if specs.isValid('expect_err'):
+            if specs['match_literal']:
+                out_ok = self.checkOutputForLiteral(output, specs['expect_err'])
+            else:
+                out_ok = self.checkOutputForPattern(output, specs['expect_err'])
+
+            # Process out_ok
+            if out_ok:
+                reason = ''
+
+        # Return the reason and command output
+        return (reason, output)

--- a/python/run_tests
+++ b/python/run_tests
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import sys, os
+
+# Set the current working directory to the directory where this script is located
+os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
+
+#### Set the name of the application here and moose directory relative to the application
+app_name = 'moose_test'
+
+MOOSE_DIR = os.path.abspath(os.path.join(os.environ['HOME'], 'projects', 'moose'))
+#### See if MOOSE_DIR is already in the environment instead
+if os.environ.has_key("MOOSE_DIR"):
+  MOOSE_DIR = os.environ['MOOSE_DIR']
+
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+import path_tool
+path_tool.activate_module('TestHarness')
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, 'moose_python', MOOSE_DIR)


### PR DESCRIPTION
refs #7451 
These are copied over from `chigger/scripts/TestHarness/testers`

This also adds a `run_tests` to the `python` directory to allow to run unit tests.

The `RunPythonApp` and `RunPythonException` are not named all that great since they mostly don't have anything specific to python in them. The exception would be the `unittest` parameter which looks for a specific string in the output. @aeslaughter Is there a reason why we are checking the output and not the return code for unittests?