### PR TITLE
Remove initialSetup() and make init() virtual in MooseMesh class (#8157)

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -98,12 +98,7 @@ public:
    *
    * However, during Recovery this will read the CPA file...
    */
-  void init();
-
-  /**
-   * Perform initial setup on the mesh object.
-   */
-  virtual void initialSetup();
+  virtual void init();
 
   /**
    * Must be overridden by child classes.

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -364,10 +364,6 @@ void FEProblemBase::initialSetup()
   if (_app.isRecovering() && (_app.isUltimateMaster() || _force_restart))
     _resurrector->setRestartFile(_app.getRecoverFileBase());
 
-  _mesh.initialSetup();
-  if (_displaced_problem)
-    _displaced_mesh->initialSetup();
-
   if ((_app.isRestarting() || _app.isRecovering()) && (_app.isUltimateMaster() || _force_restart))
     _resurrector->restartFromFile();
   else

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1875,9 +1875,6 @@ MooseMesh::init()
     buildMesh();
 }
 
-void
-MooseMesh::initialSetup() {}
-
 unsigned int
 MooseMesh::dimension() const
 {


### PR DESCRIPTION
Virtualize MooseMesh::init() method and override it in peridynamic mesh classes solved the problem described in ref #8157