### PR TITLE
Restrict test that reports incorrect jacobian with multiple threads.

### DIFF
--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -48,6 +48,9 @@
     recover = false
     allow_warnings = true
     mesh_mode = REPLICATED
+    # This tests sometimes reports an incorrect jacobian when run
+    # with multiple threads.
+    max_threads = 1
   [../]
   [./shape_side_uo_physics_test]
     type = 'Exodiff'


### PR DESCRIPTION
We have seen this test error with incorrect jacobian when running with multiple threads.
There might be a better way to fix it but this just restricts it to run with `max_threads = 1`
refs #8352 
