### PR TITLE
fixed a typo in BC box

### DIFF
--- a/modules/xfem/tests/solid_mechanics_basic/crack_propagation_2d.i
+++ b/modules/xfem/tests/solid_mechanics_basic/crack_propagation_2d.i
@@ -74,7 +74,7 @@
   [./topx]
     type = PresetBC
     boundary = top
-    variable = disp_y
+    variable = disp_x
     value = 0.0
   [../]
   [./topy]


### PR DESCRIPTION
closes #8544
closes #8546
from disp_y to disp_x on topx, works correctly 
as suggested by Wen Jiang