### PR TITLE
clean up multi-app creation and naming

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -42,6 +42,7 @@ class MeshModifier;
 class InputParameterWarehouse;
 class SystemInfo;
 class CommandLine;
+class MultiApp;
 
 template <>
 InputParameters validParams<MooseApp>();
@@ -120,15 +121,9 @@ public:
    */
   std::string getInputFileName() { return _input_filename; }
 
-  /**
-   * Override the selection of the output file base name.
-   */
-  void setOutputFileBase(std::string output_file_base) { _output_file_base = output_file_base; }
-
-  /**
-   * Override the selection of the output file base name.
-   */
-  std::string getOutputFileBase();
+  /// Returns a string identifying the nesting of this app with MultiApp and
+  /// subapp levels will be encoded into it.
+  std::string levelString();
 
   /**
    * Tell the app to output in a specific position.
@@ -140,12 +135,6 @@ public:
    * @param files A Set of checkpoint filenames to populate
    */
   std::list<std::string> getCheckpointFiles();
-
-  /**
-   * Whether or not an output position has been set.
-   * @return True if it has
-   */
-  bool hasOutputPosition() { return _output_position_set; }
 
   /**
    * Get the output position.
@@ -312,30 +301,12 @@ public:
 
   /**
    * Store a map of outputter names and file numbers
-   * The MultiApp system requires this to get the file numbering to propagate down through the
-   * Multiapps.
-   * @param numbers Map of outputter names and file numbers
-   *
-   * @see MultiApp TransientMultiApp OutputWarehouse
-   */
-  void setOutputFileNumbers(std::map<std::string, unsigned int> numbers)
-  {
-    _output_file_numbers = numbers;
-  }
-
-  /**
-   * Store a map of outputter names and file numbers
    * The MultiApp system requires this to get the file numbering to propogate down through the
    * multiapps.
    *
    * @see MultiApp TransientMultiApp
    */
-  std::map<std::string, unsigned int> & getOutputFileNumbers() { return _output_file_numbers; }
-
-  /**
-   * Return true if the output position has been set
-   */
-  bool hasOutputWarehouse() { return _output_position_set; }
+  std::map<std::string, unsigned int> getOutputFileNumbers();
 
   /**
    * Get the OutputWarehouse objects
@@ -430,22 +401,11 @@ public:
    */
   virtual std::string header() const;
 
-  /**
-   * The MultiApp Level
-   * @return The current number of levels from the master app
-   */
-  unsigned int multiAppLevel() const { return _multiapp_level; }
+  /// The number of (MultiApp) levels from master - master is zero.
+  unsigned int multiAppLevel() const;
 
-  /**
-   * Set the MultiApp Level
-   * @param level The level to assign to this app.
-   */
-  void setMultiAppLevel(const unsigned int level) { _multiapp_level = level; }
-
-  /**
-   * Whether or not this app is the ultimate master app. (ie level == 0)
-   */
-  bool isUltimateMaster() { return !_multiapp_level; }
+  /// Returns true if this app is the root master app (i.e. level == 0).
+  bool isUltimateMaster() const { return _parent == nullptr; }
 
   /**
    * Add a mesh modifier that will act on the meshes in the system
@@ -469,17 +429,14 @@ public:
    */
   void executeMeshModifiers();
 
-  ///@{
-  /**
-   * Sets the restart/recover flags
-   * @param state The state to set the flag to
-   */
-  void setRestart(const bool & value);
-  void setRecover(const bool & value);
-  ///@}
+  /// Sets the restart flag to true.
+  void setRestart() { _restart = true; }
 
   /// Returns whether the Application is running in check input mode
   bool checkInput() const { return _check_input; }
+
+  /// Returns the root app for this app or itself if it has no parent.
+  const MooseApp & root() const;
 
 protected:
   /**
@@ -535,12 +492,6 @@ protected:
 
   /// Input file name used
   std::string _input_filename;
-
-  /// The output file basename
-  std::string _output_file_base;
-
-  /// Whether or not an output position has been set for this app
-  bool _output_position_set;
 
   /// The output position
   Point _output_position;
@@ -619,8 +570,11 @@ protected:
   /// Whether or not this simulation should only run half its transient (useful for testing recovery)
   bool _half_transient;
 
-  /// Map of outputer name and file number (used by MultiApps to propagate file numbers down through the multiapps)
-  std::map<std::string, unsigned int> _output_file_numbers;
+  /// Legacy Uo Aux computation flag
+  bool _legacy_uo_aux_computation_default;
+
+  /// Legacy Uo Initialization flag
+  bool _legacy_uo_initialization_default;
 
   /// true if we want to just check the input file
   bool _check_input;
@@ -629,6 +583,9 @@ protected:
   std::map<std::pair<std::string, std::string>, void *> _lib_handles;
 
 private:
+  /// pointer to the parent/owning MultiApp object if any.
+  MooseApp * _parent = nullptr;
+
   /** Method for creating the minimum required actions for an application (no input file)
    *
    * Mimics the following input file:
@@ -668,9 +625,6 @@ private:
     OBJECT,
     SYNTAX
   };
-
-  /// Level of multiapp, the master is level 0. This used by the Console to indent output
-  unsigned int _multiapp_level;
 
   /// Holds the mesh modifiers until they have completed, then this structure is cleared
   std::map<std::string, std::shared_ptr<MeshModifier>> _mesh_modifiers;

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -66,7 +66,7 @@ public:
    * Get the name of the object
    * @return The name of the object
    */
-  const std::string & name() { return _name; }
+  const std::string & name() const { return _name; }
 
   /**
    * Get the parameters of the object
@@ -306,7 +306,7 @@ public:
    *
    * @see MultiApp TransientMultiApp
    */
-  std::map<std::string, unsigned int> getOutputFileNumbers();
+  std::map<std::string, unsigned int> getOutputFileNumbers() const;
 
   /**
    * Get the OutputWarehouse objects
@@ -434,9 +434,6 @@ public:
 
   /// Returns whether the Application is running in check input mode
   bool checkInput() const { return _check_input; }
-
-  /// Returns the root app for this app or itself if it has no parent.
-  const MooseApp & root() const;
 
 protected:
   /**
@@ -583,8 +580,13 @@ protected:
   std::map<std::pair<std::string, std::string>, void *> _lib_handles;
 
 private:
-  /// pointer to the parent/owning MultiApp object if any.
-  MooseApp * _parent = nullptr;
+  /// Returns the root app for this app or itself if it has no parent.
+  const MooseApp & root() const;
+
+  /// Pointer to the parent/owning MooseApp object if any.
+  /// It is important that this stay const and private to preserve multi-app
+  /// isolation.
+  const MooseApp * _parent = nullptr;
 
   /** Method for creating the minimum required actions for an application (no input file)
    *

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -95,7 +95,7 @@ public:
    * Extracts the file numbers from the output objects
    * @return Map of file numbers for the output objects
    */
-  std::map<std::string, unsigned int> getFileNumbers();
+  std::map<std::string, unsigned int> getFileNumbers() const;
 
   /**
    * Stores the common InputParameters object

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -4752,7 +4752,7 @@ FEProblemBase::serializeSolution()
 void
 FEProblemBase::setRestartFile(const std::string & file_name)
 {
-  _app.setRestart(true);
+  _app.setRestart();
   _resurrector->setRestartFile(file_name);
 }
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -212,7 +212,6 @@ MooseApp::MooseApp(InputParameters parameters)
     _pars(parameters),
     _type(getParam<std::string>("_type")),
     _comm(getParam<std::shared_ptr<Parallel::Communicator>>("_comm")),
-    _output_position_set(false),
     _start_time_set(false),
     _start_time(0.0),
     _global_time_offset(0.0),
@@ -233,9 +232,17 @@ MooseApp::MooseApp(InputParameters parameters)
     _recover_suffix("cpr"),
     _half_transient(false),
     _check_input(getParam<bool>("check_input")),
-    _restartable_data(libMesh::n_threads()),
-    _multiapp_level(0)
+    _restartable_data(libMesh::n_threads())
 {
+  if (isParamValid("_parent"))
+  {
+    _parent = parameters.getCheckedPointerParam<MooseApp *>("_parent");
+    _restart = _parent->isRestarting();
+    _recover = _parent->isRecovering();
+    if (_parent->multiAppLevel() > 0)
+      _name = _parent->name() + "_" + _name;
+  }
+
   if (isParamValid("_argc") && isParamValid("_argv"))
   {
     int argc = getParam<int>("_argc");
@@ -272,7 +279,7 @@ MooseApp::setupOptions()
   // Print the header, this is as early as possible
   std::string hdr(header() + "\n");
   if (multiAppLevel() > 0)
-    MooseUtils::indentMessage(_name, hdr);
+    MooseUtils::indentMessage(name(), hdr);
   Moose::out << hdr << std::flush;
 
   if (getParam<bool>("error_unused"))
@@ -481,10 +488,22 @@ MooseApp::setInputFileName(std::string input_filename)
   _input_filename = input_filename;
 }
 
-std::string
-MooseApp::getOutputFileBase()
+const MooseApp &
+MooseApp::root() const
 {
-  return _output_file_base;
+  if (!_parent)
+    return *this;
+  return _parent->root();
+}
+
+std::string
+MooseApp::levelString()
+{
+  if (isUltimateMaster())
+    return "";
+  std::string base = root().getFileName();
+  size_t pos = base.find_last_of('.');
+  return base.substr(0, pos) + "_out_" + _name;
 }
 
 void
@@ -706,7 +725,6 @@ MooseApp::run()
 void
 MooseApp::setOutputPosition(Point p)
 {
-  _output_position_set = true;
   _output_position = p;
   _output_warehouse.meshChanged();
 
@@ -731,11 +749,11 @@ MooseApp::getCheckpointFiles()
   if (common->isParamValid("file_base"))
     checkpoint_dirs.push_back(common->getParam<std::string>("file_base") + "_cp");
   // Case for normal application or master in a Multiapp setting
-  else if (getOutputFileBase().empty())
+  else if (levelString().empty())
     checkpoint_dirs.push_back(FileOutput::getOutputFileBase(*this, "_out_cp"));
   // Case for a sub app in a Multiapp setting
   else
-    checkpoint_dirs.push_back(getOutputFileBase() + "_cp");
+    checkpoint_dirs.push_back(levelString() + "_cp");
 
   // Add the directories from any existing checkpoint objects
   const auto & actions = _action_warehouse.getActionListByName("add_output");
@@ -1140,20 +1158,6 @@ MooseApp::clearMeshModifiers()
 }
 
 void
-MooseApp::setRestart(const bool & value)
-{
-  _restart = value;
-
-  std::shared_ptr<FEProblemBase> fe_problem = _action_warehouse.problemBase();
-}
-
-void
-MooseApp::setRecover(const bool & value)
-{
-  _recover = value;
-}
-
-void
 MooseApp::restoreCachedBackup()
 {
   if (!_cached_backup.get())
@@ -1253,4 +1257,20 @@ MooseApp::createMinimalApp()
   }
 
   _action_warehouse.build();
+}
+
+unsigned int
+MooseApp::multiAppLevel() const
+{
+  if (!_parent)
+    return 0;
+  return _parent->multiAppLevel() + 1;
+}
+
+std::map<std::string, unsigned int>
+MooseApp::getOutputFileNumbers()
+{
+  if (isUltimateMaster())
+    return _output_warehouse.getFileNumbers();
+  return _parent->getOutputFileNumbers();
 }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -236,7 +236,7 @@ MooseApp::MooseApp(InputParameters parameters)
 {
   if (isParamValid("_parent"))
   {
-    _parent = parameters.getCheckedPointerParam<MooseApp *>("_parent");
+    _parent = parameters.getCheckedPointerParam<const MooseApp *>("_parent");
     _restart = _parent->isRestarting();
     _recover = _parent->isRecovering();
     if (_parent->multiAppLevel() > 0)
@@ -1268,7 +1268,7 @@ MooseApp::multiAppLevel() const
 }
 
 std::map<std::string, unsigned int>
-MooseApp::getOutputFileNumbers()
+MooseApp::getOutputFileNumbers() const
 {
   if (isUltimateMaster())
     return _output_warehouse.getFileNumbers();

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -531,18 +531,12 @@ MultiApp::createApp(unsigned int i, Real start_time)
 
   // Define the app name
   std::ostringstream multiapp_name;
-  std::string full_name;
   multiapp_name << name() << std::setw(std::ceil(std::log10(_total_num_apps)))
                 << std::setprecision(0) << std::setfill('0') << std::right << _first_local_app + i;
-
-  // Only add parent name if it the parent is not the main app
-  if (_app.multiAppLevel() > 0)
-    full_name = _app.name() + "_" + multiapp_name.str();
-  else
-    full_name = multiapp_name.str();
+  std::string full_name = multiapp_name.str();
 
   InputParameters app_params = AppFactory::instance().getValidParams(_app_type);
-  app_params.set<FEProblemBase *>("_parent_fep") = &_fe_problem;
+  app_params.set<MooseApp *>("_parent") = &_app;
   app_params.set<std::shared_ptr<CommandLine>>("_command_line") = _app.commandLine();
   MooseApp * app = AppFactory::instance().create(_app_type, full_name, app_params, _my_comm);
   _apps[i] = app;
@@ -553,27 +547,8 @@ MultiApp::createApp(unsigned int i, Real start_time)
   else
     input_file = _input_files[_first_local_app + i];
 
-  std::ostringstream output_base;
-
-  // Create an output base by taking the output base of the master problem and appending
-  // the name of the multiapp + a number to it
-  if (!_app.getOutputFileBase().empty())
-    output_base << _app.getOutputFileBase() + "_";
-  else
-  {
-    std::string base = _app.getFileName();
-    size_t pos = base.find_last_of('.');
-    output_base << base.substr(0, pos) + "_out_";
-  }
-
-  // Append the sub app name to the output file base
-  output_base << multiapp_name.str();
   app->setGlobalTimeOffset(start_time);
   app->setInputFileName(input_file);
-  app->setOutputFileBase(output_base.str());
-  app->setOutputFileNumbers(_app.getOutputWarehouse().getFileNumbers());
-  app->setRestart(_app.isRestarting());
-  app->setRecover(_app.isRecovering());
 
   // This means we have a backup of this app that we need to give to it
   // Note: This won't do the restoration immediately.  The Backup
@@ -582,11 +557,9 @@ MultiApp::createApp(unsigned int i, Real start_time)
   if (_app.isRestarting() || _app.isRecovering())
     app->restore(_backups[i]);
 
-  if (getParam<bool>("output_in_position"))
+  if (_output_in_position)
     app->setOutputPosition(_app.getOutputPosition() + _positions[_first_local_app + i]);
 
-  // Update the MultiApp level for the app that was just created
-  app->setMultiAppLevel(_app.multiAppLevel() + 1);
   app->setupOptions();
   preRunInputFile();
   app->runInputFile();

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -536,7 +536,7 @@ MultiApp::createApp(unsigned int i, Real start_time)
   std::string full_name = multiapp_name.str();
 
   InputParameters app_params = AppFactory::instance().getValidParams(_app_type);
-  app_params.set<MooseApp *>("_parent") = &_app;
+  app_params.set<const MooseApp *>("_parent") = &_app;
   app_params.set<std::shared_ptr<CommandLine>>("_command_line") = _app.commandLine();
   MooseApp * app = AppFactory::instance().create(_app_type, full_name, app_params, _my_comm);
   _apps[i] = app;

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -302,8 +302,7 @@ Exodus::output(const ExecFlagType & type)
   outputSetup();
 
   // Adjust the position of the output
-  if (_app.hasOutputPosition())
-    _exodus_io_ptr->set_coordinate_offset(_app.getOutputPosition());
+  _exodus_io_ptr->set_coordinate_offset(_app.getOutputPosition());
 
   // Clear the global variables (postprocessors and scalars)
   _global_names.clear();

--- a/framework/src/outputs/FileOutput.C
+++ b/framework/src/outputs/FileOutput.C
@@ -112,8 +112,8 @@ std::string
 FileOutput::getOutputFileBase(MooseApp & app, std::string suffix)
 {
   // If the App has an outputfile, then use it (MultiApp scenario)
-  if (!app.getOutputFileBase().empty())
-    return app.getOutputFileBase();
+  if (!app.levelString().empty())
+    return app.levelString();
 
   // If the output base is not set it must be determined from the input file
   /* This will only return a non-empty string if the setInputFileName() was called, which is

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -233,7 +233,7 @@ OutputWarehouse::setFileNumbers(std::map<std::string, unsigned int> input, unsig
 }
 
 std::map<std::string, unsigned int>
-OutputWarehouse::getFileNumbers()
+OutputWarehouse::getFileNumbers() const
 {
 
   std::map<std::string, unsigned int> output;


### PR DESCRIPTION
And other multi-app house-keeping.  This helps create some infrastructure for dealing with the app hierarchy cleanly and simplifies interfaces related to (multi) app creation.

fixes #8460 
