### PR TITLE
Remove unnecessary SLEPc safeguards

### DIFF
--- a/framework/include/base/EigenProblem.h
+++ b/framework/include/base/EigenProblem.h
@@ -38,9 +38,8 @@ public:
   virtual ~EigenProblem();
 
   virtual void solve() override;
-#if LIBMESH_HAVE_SLEPC
+
   virtual bool converged() override;
-#endif
 
   virtual unsigned int getNEigenPairsRequired() { return _n_eigen_pairs_required; }
   virtual bool isGeneralizedEigenvalueProblem() { return _generalized_eigenvalue_problem; }

--- a/framework/src/base/EigenProblem.C
+++ b/framework/src/base/EigenProblem.C
@@ -128,11 +128,8 @@ void
 EigenProblem::checkProblemIntegrity()
 {
   FEProblemBase::checkProblemIntegrity();
-#if LIBMESH_HAVE_SLEPC
   _nl_eigen->checkIntegrity();
-#endif
 }
-
 
 void
 EigenProblem::solve()
@@ -154,11 +151,8 @@ EigenProblem::solve()
   Moose::perf_log.pop("Eigen_solve()", "Execution");
 }
 
-
-#if LIBMESH_HAVE_SLEPC
 bool
 EigenProblem::converged()
 {
   return _nl_eigen->converged();
 }
-#endif

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -35,4 +35,11 @@
     expect_err = "Invalid NodalBC for eigenvalue problems, please use homogeneous Dirichlet."
     slepc = true
   [../]
+
+  [./no_slepc]
+    type = 'RunException'
+    input = 'gipm.i'
+    expect_err = "Need to install SLEPc to solve eigenvalue problems, please reconfigure libMesh."
+    slepc = false
+  [../]
 []


### PR DESCRIPTION
Many `#if ... #endif`s harm the readability of the code. We remove some  unnecessary `SLEPc` safeguards for `EigenProblems`

Refs #7398 
