### PR TITLE
Fixing up rDG API

### DIFF
--- a/modules/navier_stokes/include/userobjects/CNSFVCharacteristicBCUserObject.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVCharacteristicBCUserObject.h
@@ -26,7 +26,7 @@ public:
   CNSFVCharacteristicBCUserObject(const InputParameters & parameters);
 
   virtual std::vector<Real> getGhostCellValue(unsigned int iside,
-                                              unsigned int ielem,
+                                              dof_id_type ielem,
                                               const std::vector<Real> & uvec1,
                                               const RealVectorValue & dwave) const;
 

--- a/modules/navier_stokes/include/userobjects/CNSFVFreeInflowBCUserObject.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVFreeInflowBCUserObject.h
@@ -26,7 +26,7 @@ public:
   CNSFVFreeInflowBCUserObject(const InputParameters & parameters);
 
   virtual std::vector<Real> getGhostCellValue(unsigned int iside,
-                                              unsigned int ielem,
+                                              dof_id_type ielem,
                                               const std::vector<Real> & uvec1,
                                               const RealVectorValue & dwave) const;
 

--- a/modules/navier_stokes/include/userobjects/CNSFVFreeInflowBoundaryFlux.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVFreeInflowBoundaryFlux.h
@@ -29,13 +29,13 @@ public:
   virtual ~CNSFVFreeInflowBoundaryFlux();
 
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
+                        dof_id_type ielem,
                         const std::vector<Real> & uvec1,
                         const RealVectorValue & dwave,
                         std::vector<Real> & flux) const;
 
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
+                            dof_id_type ielem,
                             const std::vector<Real> & uvec1,
                             const RealVectorValue & dwave,
                             DenseMatrix<Real> & jac1) const;

--- a/modules/navier_stokes/include/userobjects/CNSFVFreeOutflowBCUserObject.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVFreeOutflowBCUserObject.h
@@ -26,7 +26,7 @@ public:
   CNSFVFreeOutflowBCUserObject(const InputParameters & parameters);
 
   virtual std::vector<Real> getGhostCellValue(unsigned int iside,
-                                              unsigned int ielem,
+                                              dof_id_type ielem,
                                               const std::vector<Real> & uvec1,
                                               const RealVectorValue & dwave) const;
 

--- a/modules/navier_stokes/include/userobjects/CNSFVFreeOutflowBoundaryFlux.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVFreeOutflowBoundaryFlux.h
@@ -28,13 +28,13 @@ public:
   virtual ~CNSFVFreeOutflowBoundaryFlux();
 
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
+                        dof_id_type ielem,
                         const std::vector<Real> & uvec1,
                         const RealVectorValue & dwave,
                         std::vector<Real> & flux) const;
 
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
+                            dof_id_type ielem,
                             const std::vector<Real> & uvec1,
                             const RealVectorValue & dwave,
                             DenseMatrix<Real> & jac1) const;

--- a/modules/navier_stokes/include/userobjects/CNSFVHLLCInflowOutflowBoundaryFlux.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVHLLCInflowOutflowBoundaryFlux.h
@@ -28,13 +28,13 @@ public:
   virtual ~CNSFVHLLCInflowOutflowBoundaryFlux();
 
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
+                        dof_id_type ielem,
                         const std::vector<Real> & uvec1,
                         const RealVectorValue & dwave,
                         std::vector<Real> & flux) const;
 
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
+                            dof_id_type ielem,
                             const std::vector<Real> & uvec1,
                             const RealVectorValue & dwave,
                             DenseMatrix<Real> & jac1) const;

--- a/modules/navier_stokes/include/userobjects/CNSFVHLLCInternalSideFlux.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVHLLCInternalSideFlux.h
@@ -34,16 +34,16 @@ public:
   virtual ~CNSFVHLLCInternalSideFlux();
 
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
-                        unsigned int ineig,
+                        dof_id_type ielem,
+                        dof_id_type ineig,
                         const std::vector<Real> & uvec1,
                         const std::vector<Real> & uvec2,
                         const RealVectorValue & dwave,
                         std::vector<Real> & flux) const;
 
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
-                            unsigned int ineig,
+                            dof_id_type ielem,
+                            dof_id_type ineig,
                             const std::vector<Real> & uvec1,
                             const std::vector<Real> & uvec2,
                             const RealVectorValue & dwave,

--- a/modules/navier_stokes/include/userobjects/CNSFVHLLCSlipBoundaryFlux.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVHLLCSlipBoundaryFlux.h
@@ -29,13 +29,13 @@ public:
   virtual ~CNSFVHLLCSlipBoundaryFlux();
 
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
+                        dof_id_type ielem,
                         const std::vector<Real> & uvec1,
                         const RealVectorValue & dwave,
                         std::vector<Real> & flux) const;
 
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
+                            dof_id_type ielem,
                             const std::vector<Real> & uvec1,
                             const RealVectorValue & dwave,
                             DenseMatrix<Real> & jac1) const;

--- a/modules/navier_stokes/include/userobjects/CNSFVRiemannInvariantBCUserObject.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVRiemannInvariantBCUserObject.h
@@ -26,7 +26,7 @@ public:
   CNSFVRiemannInvariantBCUserObject(const InputParameters & parameters);
 
   virtual std::vector<Real> getGhostCellValue(unsigned int iside,
-                                              unsigned int ielem,
+                                              dof_id_type ielem,
                                               const std::vector<Real> & uvec1,
                                               const RealVectorValue & dwave) const;
 

--- a/modules/navier_stokes/include/userobjects/CNSFVRiemannInvariantBoundaryFlux.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVRiemannInvariantBoundaryFlux.h
@@ -29,13 +29,13 @@ public:
   virtual ~CNSFVRiemannInvariantBoundaryFlux();
 
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
+                        dof_id_type ielem,
                         const std::vector<Real> & uvec1,
                         const RealVectorValue & dwave,
                         std::vector<Real> & flux) const;
 
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
+                            dof_id_type ielem,
                             const std::vector<Real> & uvec1,
                             const RealVectorValue & dwave,
                             DenseMatrix<Real> & jac1) const;

--- a/modules/navier_stokes/include/userobjects/CNSFVSlipBCUserObject.h
+++ b/modules/navier_stokes/include/userobjects/CNSFVSlipBCUserObject.h
@@ -26,7 +26,7 @@ public:
   CNSFVSlipBCUserObject(const InputParameters & parameters);
 
   virtual std::vector<Real> getGhostCellValue(unsigned int iside,
-                                              unsigned int ielem,
+                                              dof_id_type ielem,
                                               const std::vector<Real> & uvec1,
                                               const RealVectorValue & dwave) const;
 

--- a/modules/navier_stokes/src/userobjects/CNSFVCharacteristicBCUserObject.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVCharacteristicBCUserObject.C
@@ -48,7 +48,7 @@ CNSFVCharacteristicBCUserObject::CNSFVCharacteristicBCUserObject(const InputPara
 
 std::vector<Real>
 CNSFVCharacteristicBCUserObject::getGhostCellValue(unsigned int iside,
-                                                   unsigned int ielem,
+                                                   dof_id_type ielem,
                                                    const std::vector<Real> & uvec1,
                                                    const RealVectorValue & /*dwave*/) const
 {

--- a/modules/navier_stokes/src/userobjects/CNSFVFreeInflowBCUserObject.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVFreeInflowBCUserObject.C
@@ -48,7 +48,7 @@ CNSFVFreeInflowBCUserObject::CNSFVFreeInflowBCUserObject(const InputParameters &
 
 std::vector<Real>
 CNSFVFreeInflowBCUserObject::getGhostCellValue(unsigned int /*iside*/,
-                                               unsigned int /*ielem*/,
+                                               dof_id_type /*ielem*/,
                                                const std::vector<Real> & /*uvec1*/,
                                                const RealVectorValue & /*dwave*/) const
 {

--- a/modules/navier_stokes/src/userobjects/CNSFVFreeInflowBoundaryFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVFreeInflowBoundaryFlux.C
@@ -36,7 +36,7 @@ CNSFVFreeInflowBoundaryFlux::~CNSFVFreeInflowBoundaryFlux()
 
 void
 CNSFVFreeInflowBoundaryFlux::calcFlux(unsigned int iside,
-                                      unsigned int ielem,
+                                      dof_id_type ielem,
                                       const std::vector<Real> & uvec1,
                                       const RealVectorValue & dwave,
                                       std::vector<Real> & flux) const
@@ -80,7 +80,7 @@ CNSFVFreeInflowBoundaryFlux::calcFlux(unsigned int iside,
 
 void
 CNSFVFreeInflowBoundaryFlux::calcJacobian(unsigned int /*iside*/,
-                                          unsigned int /*ielem*/,
+                                          dof_id_type /*ielem*/,
                                           const std::vector<Real> & /*uvec1*/,
                                           const RealVectorValue & /*dwave*/,
                                           DenseMatrix<Real> & /*jac1*/) const

--- a/modules/navier_stokes/src/userobjects/CNSFVFreeOutflowBCUserObject.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVFreeOutflowBCUserObject.C
@@ -28,7 +28,7 @@ CNSFVFreeOutflowBCUserObject::CNSFVFreeOutflowBCUserObject(const InputParameters
 
 std::vector<Real>
 CNSFVFreeOutflowBCUserObject::getGhostCellValue(unsigned int /*iside*/,
-                                                unsigned int /*ielem*/,
+                                                dof_id_type /*ielem*/,
                                                 const std::vector<Real> & uvec1,
                                                 const RealVectorValue & /*dwave*/) const
 {

--- a/modules/navier_stokes/src/userobjects/CNSFVFreeOutflowBoundaryFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVFreeOutflowBoundaryFlux.C
@@ -32,7 +32,7 @@ CNSFVFreeOutflowBoundaryFlux::~CNSFVFreeOutflowBoundaryFlux()
 
 void
 CNSFVFreeOutflowBoundaryFlux::calcFlux(unsigned int /*iside*/,
-                                       unsigned int /*ielem*/,
+                                       dof_id_type /*ielem*/,
                                        const std::vector<Real> & uvec1,
                                        const RealVectorValue & dwave,
                                        std::vector<Real> & flux) const
@@ -73,7 +73,7 @@ CNSFVFreeOutflowBoundaryFlux::calcFlux(unsigned int /*iside*/,
 
 void
 CNSFVFreeOutflowBoundaryFlux::calcJacobian(unsigned int /*iside*/,
-                                           unsigned int /*ielem*/,
+                                           dof_id_type /*ielem*/,
                                            const std::vector<Real> & /*uvec1*/,
                                            const RealVectorValue & /*dwave*/,
                                            DenseMatrix<Real> & /*jac1*/) const

--- a/modules/navier_stokes/src/userobjects/CNSFVHLLCInflowOutflowBoundaryFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVHLLCInflowOutflowBoundaryFlux.C
@@ -52,7 +52,7 @@ CNSFVHLLCInflowOutflowBoundaryFlux::~CNSFVHLLCInflowOutflowBoundaryFlux()
 
 void
 CNSFVHLLCInflowOutflowBoundaryFlux::calcFlux(unsigned int iside,
-                                             unsigned int ielem,
+                                             dof_id_type ielem,
                                              const std::vector<Real> & uvec1,
                                              const RealVectorValue & dwave,
                                              std::vector<Real> & flux) const
@@ -311,7 +311,7 @@ CNSFVHLLCInflowOutflowBoundaryFlux::calcFlux(unsigned int iside,
 
 void
 CNSFVHLLCInflowOutflowBoundaryFlux::calcJacobian(unsigned int iside,
-                                                 unsigned int ielem,
+                                                 dof_id_type ielem,
                                                  const std::vector<Real> & uvec1,
                                                  const RealVectorValue & dwave,
                                                  DenseMatrix<Real> & jac1) const

--- a/modules/navier_stokes/src/userobjects/CNSFVHLLCInternalSideFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVHLLCInternalSideFlux.C
@@ -32,8 +32,8 @@ CNSFVHLLCInternalSideFlux::~CNSFVHLLCInternalSideFlux()
 
 void
 CNSFVHLLCInternalSideFlux::calcFlux(unsigned int iside,
-                                    unsigned int ielem,
-                                    unsigned int ineig,
+                                    dof_id_type ielem,
+                                    dof_id_type ineig,
                                     const std::vector<Real> & uvec1,
                                     const std::vector<Real> & uvec2,
                                     const RealVectorValue & dwave,
@@ -216,8 +216,8 @@ CNSFVHLLCInternalSideFlux::calcFlux(unsigned int iside,
 
 void
 CNSFVHLLCInternalSideFlux::calcJacobian(unsigned int iside,
-                                        unsigned int ielem,
-                                        unsigned int ineig,
+                                        dof_id_type ielem,
+                                        dof_id_type ineig,
                                         const std::vector<Real> & uvec1,
                                         const std::vector<Real> & uvec2,
                                         const RealVectorValue & dwave,

--- a/modules/navier_stokes/src/userobjects/CNSFVHLLCSlipBoundaryFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVHLLCSlipBoundaryFlux.C
@@ -36,7 +36,7 @@ CNSFVHLLCSlipBoundaryFlux::~CNSFVHLLCSlipBoundaryFlux()
 
 void
 CNSFVHLLCSlipBoundaryFlux::calcFlux(unsigned int iside,
-                                    unsigned int ielem,
+                                    dof_id_type ielem,
                                     const std::vector<Real> & uvec1,
                                     const RealVectorValue & dwave,
                                     std::vector<Real> & flux) const
@@ -224,7 +224,7 @@ CNSFVHLLCSlipBoundaryFlux::calcFlux(unsigned int iside,
 
 void
 CNSFVHLLCSlipBoundaryFlux::calcJacobian(unsigned int iside,
-                                        unsigned int ielem,
+                                        dof_id_type ielem,
                                         const std::vector<Real> & uvec1,
                                         const RealVectorValue & dwave,
                                         DenseMatrix<Real> & jac1) const

--- a/modules/navier_stokes/src/userobjects/CNSFVRiemannInvariantBCUserObject.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVRiemannInvariantBCUserObject.C
@@ -48,7 +48,7 @@ CNSFVRiemannInvariantBCUserObject::CNSFVRiemannInvariantBCUserObject(const Input
 
 std::vector<Real>
 CNSFVRiemannInvariantBCUserObject::getGhostCellValue(unsigned int iside,
-                                                     unsigned int ielem,
+                                                     dof_id_type ielem,
                                                      const std::vector<Real> & uvec1,
                                                      const RealVectorValue & dwave) const
 {

--- a/modules/navier_stokes/src/userobjects/CNSFVRiemannInvariantBoundaryFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVRiemannInvariantBoundaryFlux.C
@@ -36,7 +36,7 @@ CNSFVRiemannInvariantBoundaryFlux::~CNSFVRiemannInvariantBoundaryFlux()
 
 void
 CNSFVRiemannInvariantBoundaryFlux::calcFlux(unsigned int iside,
-                                            unsigned int ielem,
+                                            dof_id_type ielem,
                                             const std::vector<Real> & uvec1,
                                             const RealVectorValue & dwave,
                                             std::vector<Real> & flux) const
@@ -198,7 +198,7 @@ CNSFVRiemannInvariantBoundaryFlux::calcFlux(unsigned int iside,
 
 void
 CNSFVRiemannInvariantBoundaryFlux::calcJacobian(unsigned int iside,
-                                                unsigned int ielem,
+                                                dof_id_type ielem,
                                                 const std::vector<Real> & uvec1,
                                                 const RealVectorValue & dwave,
                                                 DenseMatrix<Real> & jac1) const

--- a/modules/navier_stokes/src/userobjects/CNSFVSlipBCUserObject.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVSlipBCUserObject.C
@@ -28,7 +28,7 @@ CNSFVSlipBCUserObject::CNSFVSlipBCUserObject(const InputParameters & parameters)
 
 std::vector<Real>
 CNSFVSlipBCUserObject::getGhostCellValue(unsigned int /*iside*/,
-                                         unsigned int /*ielem*/,
+                                         dof_id_type /*ielem*/,
                                          const std::vector<Real> & uvec1,
                                          const RealVectorValue & dwave) const
 {

--- a/modules/rdg/include/userobjects/AEFVUpwindInternalSideFlux.h
+++ b/modules/rdg/include/userobjects/AEFVUpwindInternalSideFlux.h
@@ -29,16 +29,16 @@ public:
   virtual ~AEFVUpwindInternalSideFlux();
 
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
-                        unsigned int ineig,
+                        dof_id_type ielem,
+                        dof_id_type ineig,
                         const std::vector<Real> & uvec1,
                         const std::vector<Real> & uvec2,
                         const RealVectorValue & dwave,
                         std::vector<Real> & flux) const override;
 
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
-                            unsigned int ineig,
+                            dof_id_type ielem,
+                            dof_id_type ineig,
                             const std::vector<Real> & uvec1,
                             const std::vector<Real> & uvec2,
                             const RealVectorValue & dwave,

--- a/modules/rdg/include/userobjects/BCUserObject.h
+++ b/modules/rdg/include/userobjects/BCUserObject.h
@@ -56,8 +56,8 @@ public:
    * @param[in]   uvec1     vector of variables on the host side
    * @param[in]   dwave     vector of unit normal
    */
-  virtual std::vector<Real> getGhostCellValue(dof_id_type iside,
-                                              unsigned int ielem,
+  virtual std::vector<Real> getGhostCellValue(unsigned int iside,
+                                              dof_id_type ielem,
                                               const std::vector<Real> & uvec1,
                                               const RealVectorValue & dwave) const = 0;
 };

--- a/modules/rdg/include/userobjects/InternalSideFluxBase.h
+++ b/modules/rdg/include/userobjects/InternalSideFluxBase.h
@@ -48,8 +48,8 @@ public:
    * @param[in]   dwave     vector of unit normal
    */
   virtual const std::vector<Real> & getFlux(unsigned int iside,
-                                            unsigned int ielem,
-                                            unsigned int ineig,
+                                            dof_id_type ielem,
+                                            dof_id_type ineig,
                                             const std::vector<Real> & uvec1,
                                             const std::vector<Real> & uvec2,
                                             const RealVectorValue & dwave,
@@ -66,8 +66,8 @@ public:
    * @param[out]  flux      flux vector across the side
    */
   virtual void calcFlux(unsigned int iside,
-                        unsigned int ielem,
-                        unsigned int ineig,
+                        dof_id_type ielem,
+                        dof_id_type ineig,
                         const std::vector<Real> & uvec1,
                         const std::vector<Real> & uvec2,
                         const RealVectorValue & dwave,
@@ -84,8 +84,8 @@ public:
    */
   virtual const DenseMatrix<Real> & getJacobian(Moose::DGResidualType type,
                                                 unsigned int iside,
-                                                unsigned int ielem,
-                                                unsigned int ineig,
+                                                dof_id_type ielem,
+                                                dof_id_type ineig,
                                                 const std::vector<Real> & uvec1,
                                                 const std::vector<Real> & uvec2,
                                                 const RealVectorValue & dwave,
@@ -103,8 +103,8 @@ public:
    * @param[out]  jac2      Jacobian matrix contribution to the "right" cell
    */
   virtual void calcJacobian(unsigned int iside,
-                            unsigned int ielem,
-                            unsigned int ineig,
+                            dof_id_type ielem,
+                            dof_id_type ineig,
                             const std::vector<Real> & uvec1,
                             const std::vector<Real> & uvec2,
                             const RealVectorValue & dwave,

--- a/modules/rdg/src/userobjects/AEFVUpwindInternalSideFlux.C
+++ b/modules/rdg/src/userobjects/AEFVUpwindInternalSideFlux.C
@@ -26,8 +26,8 @@ AEFVUpwindInternalSideFlux::~AEFVUpwindInternalSideFlux()
 
 void
 AEFVUpwindInternalSideFlux::calcFlux(unsigned int /*iside*/,
-                                     unsigned int /*ielem*/,
-                                     unsigned int /*ineig*/,
+                                     dof_id_type /*ielem*/,
+                                     dof_id_type /*ineig*/,
                                      const std::vector<Real> & uvec1,
                                      const std::vector<Real> & uvec2,
                                      const RealVectorValue & dwave,
@@ -59,8 +59,8 @@ AEFVUpwindInternalSideFlux::calcFlux(unsigned int /*iside*/,
 
 void
 AEFVUpwindInternalSideFlux::calcJacobian(unsigned int /*iside*/,
-                                         unsigned int /*ielem*/,
-                                         unsigned int /*ineig*/,
+                                         dof_id_type /*ielem*/,
+                                         dof_id_type /*ineig*/,
                                          const std::vector<Real> & libmesh_dbg_var(uvec1),
                                          const std::vector<Real> & libmesh_dbg_var(uvec2),
                                          const RealVectorValue & dwave,

--- a/modules/rdg/src/userobjects/InternalSideFluxBase.C
+++ b/modules/rdg/src/userobjects/InternalSideFluxBase.C
@@ -45,8 +45,8 @@ InternalSideFluxBase::finalize()
 
 const std::vector<Real> &
 InternalSideFluxBase::getFlux(unsigned int iside,
-                              unsigned int ielem,
-                              unsigned int ineig,
+                              dof_id_type ielem,
+                              dof_id_type ineig,
                               const std::vector<Real> & uvec1,
                               const std::vector<Real> & uvec2,
                               const RealVectorValue & dwave,
@@ -72,8 +72,8 @@ InternalSideFluxBase::getFlux(unsigned int iside,
 const DenseMatrix<Real> &
 InternalSideFluxBase::getJacobian(Moose::DGResidualType type,
                                   unsigned int iside,
-                                  unsigned int ielem,
-                                  unsigned int ineig,
+                                  dof_id_type ielem,
+                                  dof_id_type ineig,
                                   const std::vector<Real> & uvec1,
                                   const std::vector<Real> & uvec2,
                                   const RealVectorValue & dwave,


### PR DESCRIPTION
Element and neighbor IDs has to be passed as `dof_id_type`.

Refs #8228