### PR TITLE
Add a no_timing flag to override timing flag

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -99,7 +99,9 @@ InputParameters validParams<MooseApp>()
 
   params.addCommandLineParam<bool>("error", "--error", false, "Turn all warnings into errors");
 
-  params.addCommandLineParam<bool>("timing", "-t --timing", false, "Enable all performance logging for timing purposes. This will disable all screen output of performance logs for all Console objects.");
+  params.addCommandLineParam<bool>("timing", "-t --timing", false, "Enable all performance logging for timing purposes. This will disable all "
+                                   "screen output of performance logs for all Console objects.");
+  params.addCommandLineParam<bool>("no_timing", "--no-timing", false, "Disabled performance logging. Overrides -t or --timing if passed in conjunction with this flag");
 
   // Legacy Flags
   params.addParam<bool>("use_legacy_uo_aux_computation", false, "Set to true to have MOOSE recompute *all* AuxKernel types every time *any* UserObject type is executed.\nThis behavoir is non-intuitive and will be removed late fall 2014, The default is controlled through MooseApp");
@@ -202,7 +204,10 @@ MooseApp::setupOptions()
   _distributed_mesh_on_command_line = getParam<bool>("distributed_mesh");
 
   _half_transient = getParam<bool>("half_transient");
-  _pars.set<bool>("timing") = getParam<bool>("timing");
+
+  // The no_timing flag takes precedence over the timing flag.
+  if (getParam<bool>("no_timing"))
+    _pars.set<bool>("timing") = false;
 
   if (isParamValid("trap_fpe") && isParamValid("no_trap_fpe"))
     mooseError2("Cannot use both \"--trap-fpe\" and \"--no-trap-fpe\" flags.");

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -141,8 +141,8 @@
     absent_out = 'Alive time'
     valgrind = NONE
     # Note the "--disable-perflog" cli option is for libMesh currently NOT MOOSE
-    cli_args = '--disable-perflog Outputs/print_perf_log=true Outputs/console/perf_log=false'
-    method = 'opt oprof' # debug prints some extra stuff at the end that messes up the regex
+    cli_args = '--disable-perflog Outputs/print_perf_log=true Outputs/console/perf_log=false --no-timing'
+    method = 'opt oprof devel' # debug prints some extra stuff at the end that messes up the regex
   [../]
   [./additional_output_on]
     # Test use of 'additional_output_on' parameter


### PR DESCRIPTION
This aids us in testing. We want to verify that we can shutoff
timing through the normal input parameters but we sometimes pass
--timing to the app through the TestHarness. This flag is here
so that we don't have to fundamentally change the way we toggle
parameters, it simply takes precendence over --timing to allow
input file options to be tested.

closes #8493
