### PR TITLE
fix script now only renames macros with << operator

### DIFF
--- a/scripts/fix-errwarn-macros.sh
+++ b/scripts/fix-errwarn-macros.sh
@@ -1,20 +1,11 @@
 #!/bin/bash
 
-mac_names="mooseWarning mooseDeprecated mooseError EFAError EFAWarning mooseInfo"
-
 for i in $(seq 12); do
-    for mac in $mac_names; do
-        ag -l "$mac"' *\(' . | grep -v 'MooseError' | xargs perl -0777 -i'' -pe 's/('"$mac"' *\(((?!\) ?;).)+? *?) ?<< ?(.+?(?=\) ?;))/\1, \3/igs'
-        #grep --recursive -l "$mac"' *(' . | grep -v 'MooseError' | xargs perl -0777 -i'' -pe 's/('"$mac"' *\(((?!\) ?;).)+? *?) ?<< ?(.+?(?=\) ?;))/\1, \3/igs'
-    done
+    ag -l "(moose(Error|Warning|Info|Deprecated)|EFAError|EFAWarning)"'2* *\(' . | grep -v 'MooseError' | xargs perl -0777 -i'' -pe 's/moose((Warning|Error|Deprecated|Info)2*)( *\(((?!\) ?;).)+? *?) ?<< ?(.+?(?=\) ?;))/moose${2}2$3, $5/igs'
 done
 
-mac_names="mooseWarning mooseDeprecated mooseError mooseInfo"
+# fix leading commas to be trailing
+#ag -l "moose(Error|Warning|Info|Deprecated)" . | grep -v 'MooseError' | xargs perl -0777 -i'' -pe 's/( *\\\?)\n( *),/,\n \2/igs'
 
-for mac in $mac_names; do
-    ag -l "$mac" . | grep -v 'MooseError' | xargs sed -i'' -e 's/'"$mac"'\([^a-zA-Z0-9]\)/'"$mac"'2\1/g'
-    #grep --recursive -l "$mac" . | grep -v 'MooseError' | xargs sed -i'' -e 's/'"$mac"'\([^a-zA-Z0-9]\)/'"$mac"'2\1/g'
-done
-
-#ag -l "$mac" . | grep -v 'MooseError' | xargs perl -0777 -i'' -pe 's/( *\\\?)\n( *),/,\n \2/igs'
-
+# civet precheck regexp
+#'s/moose(Warning|Error|Deprecated|Info)( *\(((?!\) ?;).)+? *?) ?<< ?(.+?(?=\) ?;))/igs'


### PR DESCRIPTION
Thanks @dschwen for your brilliant mind and your willingness to share your sage wisdom! (i.e. good idea).