### PR TITLE
Working around file timeout issues

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -419,7 +419,6 @@ class TestHarness:
             result = tester.getStatusMessage()
 
         self.handleTestResult(tester, output, result, start, end)
-        return did_pass
 
     def getTiming(self, output):
         time = ''

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -153,7 +153,23 @@ class Tester(MooseObject):
         self.status[reason] = bucket
         return self.getStatus()
 
+    # Method to check if a test has failed. This method will return true iff a
+    # tester has failed at any point during the processing of the test.
+    # Note: It's possible for a tester to report false for both didFail and
+    #       didPass. This will happen if the tester is in-progress for instance.
+    # See didPass()
+    def didFail(self):
+        status = self.getStatus()
+        return status == self.bucket_fail or status == self.bucket_diff
+
     # Method to check for successfull test
+    # Note: This method can return False until the tester has completely finished.
+    #       For this reason it should be used only after the tester has completed.
+    #       Instead you may want to use the didFail method which returns false
+    #       only if the tester has failed at any point during the processing
+    #       of that tester (e.g. after the main command has been run but before
+    #       output has been tested).
+    # See didFail()
     def didPass(self):
         return self.getStatus() == self.bucket_success
 


### PR DESCRIPTION
closes #8486

This will hopefully fix the issue where we get errors trying to read from files that have been redirected. No rush on merging this. I haven't even come up with a way of testing this robustly. 

Note: I did return False in the new checkOutputReady() method to see if it would report the FILE TIMEOUT error, which it did. I may just need to build in a testing branch in that method under special conditions. (tag @rwcarlsen, @brianmoose for ideas).