### PR TITLE
check unused petsc options 

### DIFF
--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -452,6 +452,7 @@ public:
    * Retrieve a writable reference the PETSc options (used by PetscSupport)
    */
   Moose::PetscSupport::PetscOptions & getPetscOptions(){ return _petsc_options; }
+  Moose::PetscSupport::PetscOptions & getMooseNativeOptions(){ return _moose_native_options; }
 #endif //LIBMESH_HAVE_PETSC
 
   // Function /////
@@ -1287,6 +1288,7 @@ protected:
 #ifdef LIBMESH_HAVE_PETSC
   /// PETSc option storage
   Moose::PetscSupport::PetscOptions _petsc_options;
+  Moose::PetscSupport::PetscOptions _moose_native_options;
 #endif //LIBMESH_HAVE_PETSC
 
 /**

--- a/framework/include/userobject/PetscOptionsChecker.h
+++ b/framework/include/userobject/PetscOptionsChecker.h
@@ -1,0 +1,40 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#ifndef PETSCOPTIONSCHECKER_H
+#define PETSCOPTIONSCHECKER_H
+
+#include "GeneralUserObject.h"
+#include "libmesh/fparser.hh"
+
+class PetscOptionsChecker;
+
+template<>
+InputParameters validParams<PetscOptionsChecker>();
+
+/**
+  * This Userobject is used to check if any petsc options are unused at certain
+  * stage
+  */
+class PetscOptionsChecker : public GeneralUserObject
+{
+public:
+  PetscOptionsChecker(const InputParameters & parameters);
+
+  virtual void initialize() override {}
+  virtual void execute() override;
+  virtual void finalize() override {}
+
+};
+
+#endif //PETSCOPTIONSCHECKER_H

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -114,6 +114,10 @@ void setSinglePetscOption(const std::string & name, const std::string & value = 
 
 void addPetscOptionsFromCommandline();
 
+void storeMooseNativeOptions(FEProblemBase & fe_problem);
+
+bool isUnusedPetscOptions(FEProblemBase & fe_problem);
+
 }
 }
 

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -263,6 +263,7 @@
 #ifdef LIBMESH_HAVE_FPARSER
 #include "Terminator.h"
 #endif
+#include "PetscOptionsChecker.h"
 
 // preconditioners
 #include "PhysicsBasedPreconditioner.h"
@@ -696,6 +697,7 @@ registerObjects(Factory & factory)
 #ifdef LIBMESH_HAVE_FPARSER
   registerUserObject(Terminator);
 #endif
+  registerUserObject(PetscOptionsChecker);
 
   // preconditioners
   registerNamedPreconditioner(PhysicsBasedPreconditioner, "PBP");

--- a/framework/src/userobject/PetscOptionsChecker.C
+++ b/framework/src/userobject/PetscOptionsChecker.C
@@ -1,0 +1,42 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#include "PetscOptionsChecker.h"
+#include "MooseApp.h"
+#include "Executioner.h"
+#include "PetscSupport.h"
+
+template<>
+InputParameters validParams<PetscOptionsChecker>()
+{
+  InputParameters params = validParams<GeneralUserObject>();
+  params.addParam<bool>  ("petsc_option_check_err", false, "Specifies whether or not to throw out an error if there are unused petsc options \n");
+  return params;
+}
+
+PetscOptionsChecker::PetscOptionsChecker(const InputParameters & parameters) :
+    GeneralUserObject(parameters)
+{
+}
+
+void
+PetscOptionsChecker::execute()
+{
+  if(Moose::PetscSupport::isUnusedPetscOptions(_fe_problem))
+  {
+    std::cout<<"unused petsc options "<<std::endl;
+  } else
+  {
+    std::cout<<" used all petsc options "<<std::endl;
+  }
+}

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -693,6 +693,58 @@ setSinglePetscOption(const std::string & name, const std::string & value)
     mooseError2("Error setting PETSc option.");
 }
 
+void
+storeMooseNativeOptions(FEProblemBase & fe_problem)
+{
+   PetscOptions & moose_native_options = fe_problem.getMooseNativeOptions();
+   MooseApp & moose_app = fe_problem.getMooseApp();
+   InputParameters & moose_app_parameters = moose_app.parameters();
+   for (const auto & it : moose_app_parameters)
+   {
+     std::vector<std::string> syntaxs;
+     std::string orig_name = it.first;
+     syntaxs = moose_app_parameters.getSyntax(orig_name);
+     for (const auto & syntax : syntaxs)
+       moose_native_options.inames.push_back(syntax);
+   }
+}
+
+bool
+isUnusedPetscOptions(FEProblemBase & fe_problem)
+{
+#if !PETSC_VERSION_LESS_THAN(3,7,5)
+  PetscInt N=0, left=0;
+  PetscErrorCode ierr;
+  char ** names = 0, **values = 0;
+
+  PetscOptions & moose_native_options = fe_problem.getMooseNativeOptions();
+
+  ierr = PetscOptionsLeftOptions(NULL, &N, &names, &values);
+
+  left = N;
+  for (PetscInt i=0; i<N; i++)
+  {
+    for (const auto & moose_option : moose_native_options.inames)
+    {
+      std::string petsc_option_iname = std::string(names[i]);
+      std::string petsc_option_ivalue = std::string(values[i]);
+      if (moose_option.find(petsc_option_iname) != std::string::npos)
+      {
+        left--;
+        std::cout<<" petsc_option_iname "<< petsc_option_iname<<std::endl;
+      }
+      else
+        mooseWarning2("Unused petsc options: ", "-", petsc_option_iname, " value: ", petsc_option_ivalue, "\n");
+    }
+    ierr = PetscFree(names[i]);
+  }
+  ierr = PetscFree(names);
+  return left;
+#else
+  return false;
+#endif
+}
+
 
 } // Namespace PetscSupport
 } // Namespace MOOSE


### PR DESCRIPTION
Implement a petsc option checker. This could be carried out right after the first nonlinear iteration or the first time step. We are actually going to support execute_on = 'linear nonlinear timestep_end timestep_begin'.

This require API changes in PETSc, and so please do not review right now. NOT REVIEW!