### PR TITLE
Modify mesh_mode in tests

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -30,7 +30,7 @@ class Tester(MooseObject):
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")
         params.addParam('compiler',      ['ALL'], "A list of compilers for which this test is valid on. ('ALL', 'GCC', 'INTEL', 'CLANG')")
         params.addParam('petsc_version', ['ALL'], "A list of petsc versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
-        params.addParam('mesh_mode',     ['ALL'], "A list of mesh modes for which this test will run ('DISTRIBUTED', 'REPLICATED'), PARALLEL and SERIAL are deprecated")
+        params.addParam('mesh_mode',     ['ALL'], "A list of mesh modes for which this test will run ('DISTRIBUTED', 'REPLICATED')")
         params.addParam('method',        ['ALL'], "A test that runs under certain executable configurations ('ALL', 'OPT', 'DBG', 'DEVEL', 'OPROF', 'PRO')")
         params.addParam('library_mode',  ['ALL'], "A test that only runs when libraries are built under certain configurations ('ALL', 'STATIC', 'DYNAMIC')")
         params.addParam('dtk',           ['ALL'], "A test that runs only if DTK is detected ('ALL', 'TRUE', 'FALSE')")
@@ -58,16 +58,6 @@ class Tester(MooseObject):
     def __init__(self, name, params):
         MooseObject.__init__(self, name, params)
         self.specs = params
-
-        # mesh_mode has a few deprecated options
-        # TODO: We need to print out a deprecated warning in the future
-        mesh_mode = self.specs['mesh_mode']
-        replacement_list = []
-        for i, item in enumerate(mesh_mode):
-            if item.upper() == 'PARALLEL':
-                mesh_mode[i] = 'DISTRIBUTED'
-            if item.upper() == 'SERIAL':
-                mesh_mode[i] = 'REPLICATED'
 
         # Set the status message
         if self.specs['check_input']:

--- a/test/tests/interfacekernels/2d_interface/tests
+++ b/test/tests/interfacekernels/2d_interface/tests
@@ -3,7 +3,7 @@
     type = 'Exodiff'
     input = 'coupled_value_coupled_flux.i'
     exodiff = 'coupled_value_coupled_flux_out.e'
-    mesh_mode = SERIAL
+    mesh_mode = REPLICATED
   [../]
 
   [./jacobian_test]
@@ -11,7 +11,7 @@
     input = coupled_value_coupled_flux.i
     expect_out = '\nNo errors detected. :-\)\n'
     recover = false
-    mesh_mode = SERIAL
+    mesh_mode = REPLICATED
     prereq = test
   []
 []

--- a/test/tests/interfacekernels/3d_interface/tests
+++ b/test/tests/interfacekernels/3d_interface/tests
@@ -3,6 +3,6 @@
     type = 'Exodiff'
     input = 'coupled_value_coupled_flux.i'
     exodiff = 'coupled_value_coupled_flux_out.e'
-    mesh_mode = SERIAL
+    mesh_mode = REPLICATED
   [../]
 []

--- a/test/tests/mesh_modifiers/break_boundary/tests
+++ b/test/tests/mesh_modifiers/break_boundary/tests
@@ -5,7 +5,7 @@
     exodiff = 'break_boundary_on_subdomain_in.e'
     cli_args = '--mesh-only'
     recover = false
-    mesh_mode = SERIAL
+    mesh_mode = REPLICATED
   [../]
 
   [./break_bottom]
@@ -14,6 +14,6 @@
     exodiff = 'break_bottom_interface_on_subdomain_in.e'
     cli_args = '--mesh-only'
     recover = false
-    mesh_mode = SERIAL
+    mesh_mode = REPLICATED
   [../]
 []


### PR DESCRIPTION
Anywhere we see SERIAL/PARALLEL, needs to be changed to
REPLICATED/DISTRIBUTED. I only found tests with SERIAL
mesh modes.

Refs #7941