### PR TITLE
Woot! People will find it harder to shoot selves in foot when writing multiple tests

### DIFF
--- a/python/TestHarness/testers/CSVDiff.py
+++ b/python/TestHarness/testers/CSVDiff.py
@@ -1,29 +1,23 @@
-from RunApp import RunApp
+from FileTester import FileTester
 from CSVDiffer import CSVDiffer
 import util
-import os
 
-class CSVDiff(RunApp):
+class CSVDiff(FileTester):
 
     @staticmethod
     def validParams():
-        params = RunApp.validParams()
+        params = FileTester.validParams()
         params.addRequiredParam('csvdiff',   [], "A list of files to run CSVDiff on.")
-        params.addParam('gold_dir',      'gold', "The directory where the \"golden standard\" files reside relative to the TEST_DIR: (default: ./gold/)")
-        params.addParam('abs_zero',       1e-10, "Absolute zero cutoff used in exodiff comparisons.")
-        params.addParam('rel_err',       5.5e-6, "Relative error value used in exodiff comparisons.")
-
         return params
 
     def __init__(self, name, params):
-        RunApp.__init__(self, name, params)
+        FileTester.__init__(self, name, params)
 
-    def prepare(self, options):
-        if self.specs['delete_output_before_running'] == True:
-            util.deleteFilesAndFolders(self.specs['test_dir'], self.specs['csvdiff'])
+    def getOutputFiles(self):
+        return self.specs['csvdiff']
 
     def processResults(self, moose_dir, retcode, options, output):
-        output = RunApp.processResults(self, moose_dir, retcode, options, output)
+        output = FileTester.processResults(self, moose_dir, retcode, options, output)
 
         specs = self.specs
         if self.getStatus() == self.bucket_fail or specs['skip_checks']:
@@ -35,7 +29,7 @@ class CSVDiff(RunApp):
             return output
 
         if len(specs['csvdiff']) > 0:
-            differ = CSVDiffer( specs['test_dir'], specs['csvdiff'], specs['abs_zero'], specs['rel_err'] )
+            differ = CSVDiffer(specs['test_dir'], specs['csvdiff'], specs['abs_zero'], specs['rel_err'])
             msg = differ.diff()
             output += 'Running CSVDiffer.py\n' + msg
             if msg != '':

--- a/python/TestHarness/testers/CheckFiles.py
+++ b/python/TestHarness/testers/CheckFiles.py
@@ -1,26 +1,29 @@
-from RunApp import RunApp
+from FileTester import FileTester
 import util
 import os
 
-class CheckFiles(RunApp):
+class CheckFiles(FileTester):
 
     @staticmethod
     def validParams():
-        params = RunApp.validParams()
+        params = FileTester.validParams()
         params.addParam('check_files', [], "A list of files that MUST exist.")
         params.addParam('check_not_exists', [], "A list of files that must NOT exist.")
         params.addParam('file_expect_out', "A regular expression that must occur in all of the check files in order for the test to be considered passing.")
         return params
 
     def __init__(self, name, params):
-        RunApp.__init__(self, name, params)
+        FileTester.__init__(self, name, params)
 
-    def prepare(self, options):
-        if self.specs['delete_output_before_running'] == True:
-            util.deleteFilesAndFolders(self.specs['test_dir'], self.specs['check_files'] + self.specs['check_not_exists'], self.specs['delete_output_folders'])
+        # Make sure that either input or command is supplied
+        if not (params.isValid('check_files') or params.isValid('check_not_exists')):
+            raise Exception('Either "check_files" or "check_not_exists" must be supplied for a CheckFiles test')
+
+    def getOutputFiles(self):
+        return self.specs['check_files'] + self.specs['check_not_exists']
 
     def processResults(self, moose_dir, retcode, options, output):
-        output = RunApp.processResults(self, moose_dir, retcode, options, output)
+        output = FileTester.processResults(self, moose_dir, retcode, options, output)
 
         specs = self.specs
         if self.getStatus() == self.bucket_fail or specs['skip_checks']:

--- a/python/TestHarness/testers/Exodiff.py
+++ b/python/TestHarness/testers/Exodiff.py
@@ -1,17 +1,14 @@
-from RunApp import RunApp
+from FileTester import FileTester
 import util
 import os
 
-class Exodiff(RunApp):
+class Exodiff(FileTester):
 
     @staticmethod
     def validParams():
-        params = RunApp.validParams()
+        params = FileTester.validParams()
         params.addRequiredParam('exodiff',   [], "A list of files to exodiff.")
         params.addParam('exodiff_opts',      [], "Additional arguments to be passed to invocations of exodiff.")
-        params.addParam('gold_dir',      'gold', "The directory where the \"golden standard\" files reside relative to the TEST_DIR: (default: ./gold/)")
-        params.addParam('abs_zero',       1e-10, "Absolute zero cutoff used in exodiff comparisons.")
-        params.addParam('rel_err',       5.5e-6, "Relative error value used in exodiff comparisons.")
         params.addParam('custom_cmp',            "Custom comparison file")
         params.addParam('use_old_floor',  False, "Use Exodiff old floor option")
         params.addParam('map',  True, "Use geometrical mapping to match up elements.  This is usually a good idea because it makes files comparable between runs with Serial and Parallel Mesh.")
@@ -19,11 +16,10 @@ class Exodiff(RunApp):
         return params
 
     def __init__(self, name, params):
-        RunApp.__init__(self, name, params)
+        FileTester.__init__(self, name, params)
 
-    def prepare(self, options):
-        if self.specs['delete_output_before_running'] == True:
-            util.deleteFilesAndFolders(self.specs['test_dir'], self.specs['exodiff'], self.specs['delete_output_folders'])
+    def getOutputFiles(self):
+        return self.specs['exodiff']
 
     def processResultsCommand(self, moose_dir, options):
         commands = []
@@ -48,7 +44,7 @@ class Exodiff(RunApp):
         return commands
 
     def processResults(self, moose_dir, retcode, options, output):
-        output = RunApp.processResults(self, moose_dir, retcode, options, output)
+        output = FileTester.processResults(self, moose_dir, retcode, options, output)
 
         if self.getStatus() == self.bucket_fail or self.specs['skip_checks']:
             return output

--- a/python/TestHarness/testers/FileTester.py
+++ b/python/TestHarness/testers/FileTester.py
@@ -1,0 +1,25 @@
+from RunApp import RunApp
+import util
+import os
+
+# Classes that derive from this class are expected to write
+# output files. The Tester::getOutputFiles() method should
+# be implemented for all derived classes.
+class FileTester(RunApp):
+    @staticmethod
+    def validParams():
+        params = RunApp.validParams()
+        params.addParam('gold_dir', 'gold', "The directory where the \"golden standard\" files reside relative to the TEST_DIR: (default: ./gold/)")
+        params.addParam('abs_zero',       1e-10, "Absolute zero cutoff used in exodiff comparisons.")
+        params.addParam('rel_err',       5.5e-6, "Relative error value used in exodiff comparisons.")
+        return params
+
+    def __init__(self, name, params):
+        RunApp.__init__(self, name, params)
+
+    def prepare(self, options):
+        if self.specs['delete_output_before_running'] == True:
+            util.deleteFilesAndFolders(self.specs['test_dir'], self.getOutputFiles(), self.specs['delete_output_folders'])
+
+    def processResults(self, moose_dir, retcode, options, output):
+        return RunApp.processResults(self, moose_dir, retcode, options, output)

--- a/python/TestHarness/testers/ImageDiff.py
+++ b/python/TestHarness/testers/ImageDiff.py
@@ -1,17 +1,16 @@
+from FileTester import FileTester
 import os
-import sys
 import util
-from RunApp import RunApp
+import sys
 from mooseutils.ImageDiffer import ImageDiffer
 
-class ImageDiff(RunApp):
+class ImageDiff(FileTester):
+
     @staticmethod
     def validParams():
-        params = RunApp.validParams()
+        params = FileTester.validParams()
         params.addRequiredParam('imagediff', [], 'A list of files to compare against the gold.')
-        params.addParam('gold_dir', 'gold', "The directory where the \"golden standard\" files reside relative to the TEST_DIR: (default: ./gold/)")
         params.addParam('allowed', 0.98, "Absolute zero cutoff used in exodiff comparisons.")
-        params.addParam('delete_output_before_running', True, "Delete pre-existing output files before running test. Only set to False if you know what you're doing!")
         params.addParam('allowed_linux', "Absolute zero cuttoff used for linux machines, if not provided 'allowed' is used.")
         params.addParam('allowed_darwin', "Absolute zero cuttoff used for Mac OS (Darwin) machines, if not provided 'allowed' is used.")
         # We don't want to check for any errors on the screen with this. If there are any real errors then the image test will fail.
@@ -19,14 +18,10 @@ class ImageDiff(RunApp):
         return params
 
     def __init__(self, name, params):
-        RunApp.__init__(self, name, params)
+        FileTester.__init__(self, name, params)
 
-    def prepare(self, options):
-        """
-        Cleans up image files from previous execution
-        """
-        if self.specs['delete_output_before_running'] == True:
-            util.deleteFilesAndFolders(self.specs['test_dir'], self.specs['imagediff'], self.specs['delete_output_folders'])
+    def getOutputFiles(self):
+        return self.specs['imagediff']
 
     def processResults(self, moose_dir, retcode, options, output):
         """
@@ -34,7 +29,7 @@ class ImageDiff(RunApp):
         """
 
         # Call base class processResults
-        output = RunApp.processResults(self, moose_dir, retcode, options, output)
+        output = FileTester.processResults(self, moose_dir, retcode, options, output)
         if self.getStatus() == self.bucket_fail:
             return output
 
@@ -50,7 +45,6 @@ class ImageDiff(RunApp):
 
             # Perform diff
             else:
-
                 output = 'Running ImageDiffer.py'
                 gold = os.path.join(specs['test_dir'], specs['gold_dir'], filename)
                 test = os.path.join(specs['test_dir'], filename)
@@ -69,7 +63,6 @@ class ImageDiff(RunApp):
                 if differ.fail():
                     self.setStatus('IMAGEDIFF', self.bucket_diff)
                     break
-
 
         # If status is still pending, then it is a passing test
         if self.getStatus() == self.bucket_pending:

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -70,7 +70,6 @@ class Tester(MooseObject):
         self.should_execute = self.specs['should_execute']
         self.check_input = self.specs['check_input']
 
-
         ###### bucket status discriptions
         ## The following is a list of statuses possible in the TestHarness
         ##
@@ -113,11 +112,15 @@ class Tester(MooseObject):
         # Initialize the tester with a pending status
         self.setStatus('launched', self.bucket_pending)
 
-    def getName(self):
+    def getTestName(self):
         return self.specs['test_name']
 
     def getPrereqs(self):
         return self.specs['prereq']
+
+    def getRunnable(self):
+        status = self.getStatus()
+        return not (status == self.bucket_deleted or status == self.bucket_skip or status == self.bucket_silent)
 
     # Return text color based on bucket status. Return the
     # RESET color switch in the event of an unknown status
@@ -230,14 +233,15 @@ class Tester(MooseObject):
         # Check if we only want to run failed tests
         if options.failed_tests:
             if self.specs['test_name'] not in test_list:
+                self.setStatus('not failed', self.bucket_silent)
                 return False
 
         # Are we running only tests in a specific group?
         if options.group <> 'ALL' and options.group not in self.specs['group']:
-            self.setStatus(reason, self.bucket_skip)
+            self.setStatus('unmatched group', self.bucket_silent)
             return False
         if options.not_group <> '' and options.not_group in self.specs['group']:
-            self.setStatus(reason, self.bucket_skip)
+            self.setStatus('unmatched group', self.bucket_silent)
             return False
 
         # Store regexp for matching tests if --re is used

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -113,6 +113,12 @@ class Tester(MooseObject):
         # Initialize the tester with a pending status
         self.setStatus('launched', self.bucket_pending)
 
+    def getName(self):
+        return self.specs['test_name']
+
+    def getPrereqs(self):
+        return self.specs['prereq']
+
     # Return text color based on bucket status. Return the
     # RESET color switch in the event of an unknown status
     def getColor(self, status):
@@ -123,6 +129,10 @@ class Tester(MooseObject):
     # Method to return the input file if applicable to this Tester
     def getInputFile(self):
         return None
+
+    # Method to return the output files if applicable to this Tester
+    def getOutputFiles(self):
+        return []
 
     # Method to return the successful message printed to stdout
     def getSuccessMessage(self):
@@ -211,7 +221,6 @@ class Tester(MooseObject):
     # processing should happen in this method
     def processResults(self, moose_dir, retcode, options, output):
         return
-
 
     # This is the base level runnable check common to all Testers.  DO NOT override
     # this method in any of your derived classes.  Instead see "checkRunnable"

--- a/python/TestHarness/unit_tests/test_HarnessTester.py
+++ b/python/TestHarness/unit_tests/test_HarnessTester.py
@@ -78,4 +78,20 @@ class TestHarnessTester(TestHarnessTestCase):
             self.runTests('-i', 'duplicate_outputs')
 
         e = cm.exception
+
+        # skip case
         self.assertRegexpMatches(e.output, 'FATAL TEST HARNESS ERROR')
+
+    def testDuplicateOutputsOK(self):
+        """
+        Test for duplicate output files in the same directory
+        """
+        output = self.runTests('-i', 'duplicate_outputs_ok')
+        output += self.runTests('-i', 'duplicate_outputs_ok', '--heavy')
+
+        # skip case
+        self.assertNotRegexpMatches(output, 'skipped_out.e')
+        # heavy case
+        self.assertNotRegexpMatches(output, 'heavy_out.e')
+        # all
+        self.assertNotRegexpMatches(output, 'FATAL TEST HARNESS ERROR')

--- a/python/TestHarness/unit_tests/test_HarnessTester.py
+++ b/python/TestHarness/unit_tests/test_HarnessTester.py
@@ -69,3 +69,13 @@ class TestHarnessTester(TestHarnessTestCase):
         e = cm.exception
         self.assertRegexpMatches(e.output, 'test_harness\.no_expect_err.*?FAILED \(NO EXPECTED ERR\)')
         self.assertRegexpMatches(e.output, 'test_harness\.no_expect_out.*?FAILED \(EXPECTED OUTPUT MISSING\)')
+
+    def testDuplicateOutputs(self):
+        """
+        Test for duplicate output files in the same directory
+        """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('-i', 'duplicate_outputs')
+
+        e = cm.exception
+        self.assertRegexpMatches(e.output, 'FATAL TEST HARNESS ERROR')

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -386,3 +386,29 @@ def deleteFilesAndFolders(test_dir, paths, delete_folders=True):
                     #
                     # TL;DR; Just pass...
                     pass
+
+# See http://code.activestate.com/recipes/576570-dependency-resolver/
+class DependencyResolver:
+    def __init__(self):
+        self.dependency_dict = {}
+
+    def insertDependency(self, key, values):
+        self.dependency_dict[key] = values
+
+    def getSortedValuesSets(self):
+        d = dict((k, set(self.dependency_dict[k])) for k in self.dependency_dict)
+        r = []
+        while d:
+            # values not in keys (items without dep)
+            t = set(i for v in d.values() for i in v) - set(d.keys())
+            # and keys without value (items without dep)
+            t.update(k for k, v in d.items() if not v)
+
+            if len(t) == 0 and len(d) > 0:
+              raise Exception("Cyclic or Invalid Dependency Detected!")
+
+            # can be done right away
+            r.append(t)
+            # and cleaned up
+            d = dict(((k, v-t) for k, v in d.items() if v))
+        return r

--- a/test/tests/test_harness/duplicate_outputs
+++ b/test/tests/test_harness/duplicate_outputs
@@ -1,0 +1,32 @@
+[Tests]
+  [./a]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true'
+    check_files = 'good_out.e'
+  [../]
+
+  [./b]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true'
+    check_files = 'good_out.e'
+    prereq = 'a'
+  [../]
+
+  [./c]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true'
+    check_files = 'good_out.e'
+    prereq = 'b'
+  [../]
+
+  # Missing prereq with same check_files
+  [./d]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true'
+    check_files = 'good_out.e'
+  [../]
+[]

--- a/test/tests/test_harness/duplicate_outputs
+++ b/test/tests/test_harness/duplicate_outputs
@@ -1,4 +1,7 @@
 [Tests]
+  # We have a chain of dependencies in this set (a-d)
+  # a and d can run concurrently and output to the
+  # same file
   [./a]
     type = CheckFiles
     input = good.i

--- a/test/tests/test_harness/duplicate_outputs_ok
+++ b/test/tests/test_harness/duplicate_outputs_ok
@@ -1,0 +1,61 @@
+[Tests]
+  # In this set we have a false dependency because
+  # one of the tests is skipped
+  [./a]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true Outputs/file_base=skipped_out'
+    check_files = 'skipped_out.e'
+  [../]
+
+  [./b]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true Outputs/file_base=skipped_out'
+    check_files = 'skipped_out.e'
+    skip = "Testing false dependency output to same file"
+  [../]
+
+  # In this set we have a false dependency because
+  # one of the tests is heavy
+  [./c]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true Outputs/file_base=heavy_out'
+    check_files = 'heavy_out.e'
+  [../]
+
+  [./d]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true Outputs/file_base=heavy_out'
+    check_files = 'heavy_out.e'
+    heavy = true
+  [../]
+
+  # In this set we have two tests competing for the same output file
+  # but one of them has a dependency on a skipped test
+  [./e]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true Outputs/file_base=not_used'
+    check_files = 'not_used.e'
+    skip = "Skipped Prereq"
+  [../]
+
+  [./f]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true Outputs/file_base=depend_out'
+    check_files = 'depend_out.e'
+    # Depend on a skipped test
+    prereq = e
+  [../]
+
+  [./g]
+    type = CheckFiles
+    input = good.i
+    cli_args = 'Outputs/exodus=true Outputs/file_base=depend_out'
+    check_files = 'depend_out.e'
+  [../]
+[]


### PR DESCRIPTION
This PR adds the ability to check for duplicate output files in the same directory without proper prereqs.

See `TestHarness::checkForRaceConditionOutputs()`