### PR TITLE
remove "2" version of error/warn functions

### DIFF
--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -193,11 +193,4 @@ mooseInfo(Args && ... args)
   moose::internal::mooseInfoStream(Moose::out, std::forward<Args>(args)...);
 }
 
-// TODO: Delete these after all apps have been transitioned to the new "not
-// 2" versions of these functions.
-template <typename... Args> [[ noreturn ]] void mooseError2(Args && ... args) { mooseError(std::forward<Args>(args)...); }
-template <typename... Args> void mooseWarning2(Args && ... args) { mooseWarning(std::forward<Args>(args)...); }
-template <typename... Args> void mooseDeprecated2(Args && ... args) { mooseDeprecated(std::forward<Args>(args)...); }
-template <typename... Args> void mooseInfo2(Args && ... args) { mooseInfo(std::forward<Args>(args)...); }
-
 #endif /* MOOSEERRORS_H */

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -97,17 +97,6 @@ public:
   template <typename... Args>
   void mooseInfo(Args && ... args) const { moose::internal::mooseInfoStream(_console, std::forward<Args>(args)...); }
 
-  /// TODO: Delete these after all apps have been transitioned to the new "not
-  /// 2" versions of these functions.
-  template <typename... Args>
-  [[ noreturn ]] void mooseError2(Args && ... args) const { mooseError(std::forward<Args>(args)...); }
-  template <typename... Args>
-  void mooseWarning2(Args && ... args) const { mooseWarning(std::forward<Args>(args)...); }
-  template <typename... Args>
-  void mooseDeprecated2(Args && ... args) const { mooseDeprecated(std::forward<Args>(args)...); }
-  template <typename... Args>
-  void mooseInfo2(Args && ... args) const { mooseInfo(std::forward<Args>(args)...); }
-
 protected:
 
   /// The MooseApp this object is associated with


### PR DESCRIPTION
When this passes, it means all apps have been updated/renamed to regular error/warning names (without the "2" suffix).