### PR TITLE
Point locator fixes

### DIFF
--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -98,6 +98,10 @@ DiracKernelInfo::updatePointLocator(const MooseMesh& mesh)
     // can't skip building it just becuase our local _elements is
     // empty, it might be non-empty on some other processor!
     _point_locator = PointLocatorBase::build(TREE_LOCAL_ELEMENTS, mesh);
+
+    // We may be querying for points which are not in the semilocal
+    // part of a distributed mesh.
+    _point_locator->enable_out_of_mesh_mode();
   }
   else
   {

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -123,7 +123,10 @@ DiracKernelInfo::findPoint(Point p, const MooseMesh& mesh)
   // CAN'T DO THIS if findPoint() is only called on some processors,
   // PointLocatorBase::build() is a 'parallel_only' method!
   if (_point_locator.get() == NULL)
-    _point_locator = PointLocatorBase::build(TREE_LOCAL_ELEMENTS, mesh);
+    {
+      _point_locator = PointLocatorBase::build(TREE_LOCAL_ELEMENTS, mesh);
+      _point_locator->enable_out_of_mesh_mode();
+    }
 
   // Check that the PointLocator is ready to start locating points.
   // So far I do not have any tests that trip this...

--- a/framework/src/meshmodifiers/AddExtraNodeset.C
+++ b/framework/src/meshmodifiers/AddExtraNodeset.C
@@ -74,13 +74,16 @@ AddExtraNodeset::modify()
   unsigned int dim = _mesh_ptr->dimension();
   unsigned int n_nodes = coord.size() / dim;
 
+  UniquePtr<PointLocatorBase> locator = _mesh_ptr->getMesh().sub_point_locator();
+  locator->enable_out_of_mesh_mode();
+
   for (unsigned int i = 0; i < n_nodes; ++i)
   {
     Point p;
     for (unsigned int j = 0; j < dim; ++j)
       p(j) = coord[i*dim+j];
 
-    const Elem * elem = _mesh_ptr->getMesh().point_locator() (p);
+    const Elem * elem = (*locator)(p);
     if (!elem)
       mooseError("Unable to locate the following point within the domain, please check its coordinates:\n", p);
 

--- a/framework/src/postprocessors/FindValueOnLine.C
+++ b/framework/src/postprocessors/FindValueOnLine.C
@@ -51,6 +51,7 @@ FindValueOnLine::initialize()
 {
   // We do this here just in case it's been destroyed and recreated becaue of mesh adaptivity.
   _pl = _mesh.getPointLocator();
+  _pl->enable_out_of_mesh_mode();
 }
 
 void

--- a/framework/src/postprocessors/PointValue.C
+++ b/framework/src/postprocessors/PointValue.C
@@ -45,6 +45,7 @@ PointValue::execute()
   // Locate the element and store the id
   // We can't store the actual Element pointer here b/c PointLocatorBase returns a const Elem *
   std::unique_ptr<PointLocatorBase> pl = _mesh.getPointLocator();
+  pl->enable_out_of_mesh_mode();
   const Elem * elem = (*pl)(_point_vec[0]);
 
   // Error if the element cannot be located

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -57,6 +57,8 @@ MultiAppVariableValueSamplePostprocessorTransfer::execute()
 
       std::unique_ptr<PointLocatorBase> pl = from_mesh.getPointLocator();
 
+      pl->enable_out_of_mesh_mode();
+
       for (unsigned int i=0; i<_multi_app->numGlobalApps(); i++)
       {
         Real value = -std::numeric_limits<Real>::max();

--- a/framework/src/vectorpostprocessors/IntersectionPointsAlongLine.C
+++ b/framework/src/vectorpostprocessors/IntersectionPointsAlongLine.C
@@ -63,6 +63,11 @@ IntersectionPointsAlongLine::execute()
   std::vector<LineSegment> segments;
 
   std::unique_ptr<PointLocatorBase> pl = _fe_problem.mesh().getPointLocator();
+
+  // We may not have any elements along the given line; if so then
+  // that shouldn't throw a libMesh error.
+  pl->enable_out_of_mesh_mode();
+
   Moose::elementsIntersectedByLine(_start, _end, _fe_problem.mesh(), *pl, intersected_elems, segments);
 
   const unsigned int num_elems = intersected_elems.size();

--- a/framework/src/vectorpostprocessors/PointSamplerBase.C
+++ b/framework/src/vectorpostprocessors/PointSamplerBase.C
@@ -54,6 +54,10 @@ PointSamplerBase::initialize()
   // We do this here just in case it's been destroyed and recreated because of mesh adaptivity.
   _pl = _mesh.getPointLocator();
 
+  // We may not find a requested point on a distributed mesh, and
+  // that's okay.
+  _pl->enable_out_of_mesh_mode();
+
   // Reset the point arrays
   _found_points.assign(_points.size(), false);
 


### PR DESCRIPTION
Set out_of_mesh_mode in more use cases; hopefully these are the last fixes required for forwards compatibility with https://github.com/libMesh/libmesh/pull/1240

Properly handle the out-of-mesh NULL return value when we're on a DistributedMesh and we're querying for data which might not be semilocal on each processor's part of the mesh; this fixes a #1500 regression failure in postprocessors/findvalueonline.line_out_of_bound for me.