### PR TITLE
Have option of running each python unittest in its own process

### DIFF
--- a/python/TestHarness/testers/AnalyzeJacobian.py
+++ b/python/TestHarness/testers/AnalyzeJacobian.py
@@ -34,7 +34,7 @@ class AnalyzeJacobian(Tester):
     def getCommand(self, options):
         specs = self.specs
         # Create the command line string to run
-        command = specs['moose_dir'] + '/python/jacobiandebug/analyzejacobian.py'
+        command = os.path.join(specs['moose_dir'], 'python', 'jacobiandebug', 'analyzejacobian.py')
 
         # Check for built application
         if not options.dry_run and not os.path.exists(command):

--- a/python/TestHarness/testers/PythonUnitTest.py
+++ b/python/TestHarness/testers/PythonUnitTest.py
@@ -27,7 +27,7 @@ class PythonUnitTest(RunApp):
             use_buffer = " -b "
 
         if self.specs["separate"]:
-            cmd = self.specs['moose_dir'] + '/scripts/separate_unittests.py -f ' + module_name + use_buffer
+            cmd = os.path.join(self.specs['moose_dir'], 'scripts', 'separate_unittests.py') + ' -f ' + module_name + use_buffer
         else:
             cmd = "python -m unittest" + use_buffer + "-v " + module_name
 

--- a/python/TestHarness/testers/PythonUnitTest.py
+++ b/python/TestHarness/testers/PythonUnitTest.py
@@ -9,6 +9,7 @@ class PythonUnitTest(RunApp):
         # Input is optional in the base class. Make it required here
         params.addRequiredParam('input', "The python input file to use for this test.")
         params.addParam('buffer', False, "Equivalent to passing -b or --buffer to the unittest.")
+        params.addParam('separate', False, "Run each test in the file in a separate subprocess")
         # We don't want to check for any errors on the screen with unit tests
         params['errors'] = []
         return params
@@ -21,8 +22,13 @@ class PythonUnitTest(RunApp):
         Returns the python command that executes unit tests
         """
         module_name = os.path.splitext(self.specs['input'])[0]
-        cmd = 'python -m unittest '
+        use_buffer = " "
         if self.specs['buffer']:
-            cmd += '-b '
+            use_buffer = " -b "
 
-        return cmd + module_name + ' ' + ' '.join(self.specs['cli_args'])
+        if self.specs["separate"]:
+            cmd = self.specs['moose_dir'] + '/scripts/separate_unittests.py -f ' + module_name + use_buffer
+        else:
+            cmd = "python -m unittest" + use_buffer + "-v " + module_name
+
+        return cmd  + ' '.join(self.specs['cli_args'])

--- a/python/mooseutils/unit_tests/tests
+++ b/python/mooseutils/unit_tests/tests
@@ -1,32 +1,29 @@
 [Tests]
   [./mooseMessage]
-    type = RunPythonApp
+    type = PythonUnitTest
     input = 'test_mooseMessage.py'
-    unittest = true
+    buffer = True
   [../]
 
   [./mooseMessageDialog]
-    type = RunPythonApp
+    type = PythonUnitTest
     input = test_mooseMessageDialog.py
-    unittest = true
   [../]
 
   [./moose_data_frame]
-    type = RunPythonApp
+    type = PythonUnitTest
     input = test_MooseDataFrame.py
-    unittest = true
   [../]
 
   [./postprocessors]
-    type = RunPythonApp
+    type = PythonUnitTest
     input = test_PostprocessorReader.py
-    unittest = true
+    buffer = True
   [../]
 
   [./vector_postprocessors]
-    type = RunPythonApp
+    type = PythonUnitTest
     input = test_VectorPostprocessorReader.py
-    unittest = true
   [../]
 
 []

--- a/scripts/separate_unittests.py
+++ b/scripts/separate_unittests.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""
+With only a filename given, this script runs each unittest in a file in a separate process.
+If the test name is given as well, it will only run that test.
+"""
+import sys, os
+import unittest
+from importlib import import_module
+import argparse
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--file", "-f", dest="pyfile", help="File to load tests from. Should be in the current working directory.", required=True)
+parser.add_argument("--buffer", "-b", dest="buffer", action="store_true", help="Buffer stdout")
+parser.add_argument("--verbosity", "-v", dest="verbosity", type=int, default=2, help="Set the verbosity level")
+parser.add_argument("--test", "-t", dest="test", help="Run an individual test")
+
+parsed = parser.parse_args(sys.argv[1:])
+module_name = os.path.splitext(parsed.pyfile)[0]
+# make sure we can load the file
+sys.path.insert(0, os.getcwd())
+mod = import_module(module_name)
+loader = unittest.TestLoader()
+tests = loader.loadTestsFromModule(mod)
+
+if tests.countTestCases() == 0:
+    print("%s had no unit tests" % parsed.pyfile)
+    sys.exit(1)
+
+all_tests = {}
+for test in tests:
+    for t in test:
+        all_tests[str(t)] = t
+
+if parsed.test:
+    # A test name was passed in, so just try to run it.
+    if parsed.test in all_tests:
+        test_to_run = all_tests[parsed.test]
+        # Apparently the setupClass/tearDownClass aren't called when running an individual test
+        test_to_run.setUpClass()
+        runner = unittest.TextTestRunner(verbosity=parsed.verbosity, buffer=parsed.buffer)
+        results = runner.run(test_to_run)
+        test_to_run.tearDownClass()
+        sys.exit(int(not results.wasSuccessful()))
+    else:
+        print("%s not found in %s" % (parsed.test, parsed.pyfile))
+        sys.exit(1)
+else:
+    # No test name passed in. Break out each test and run them in their own process
+    final_code = 0
+    for name in all_tests.keys():
+        cmd = [__file__, "-f", parsed.pyfile, "-v", str(parsed.verbosity), "-t", str(t)]
+        if parsed.buffer:
+            cmd.append("-b")
+        ret = subprocess.call(cmd)
+        if ret != 0:
+            print("%s exited %s" % (t, ret))
+            final_code = 1
+    sys.exit(final_code)


### PR DESCRIPTION
Some of the chigger unittests on linux pass all the tests but get a `GLXBadDrawable` while it is cleaning up, which causes a non zero exit status. This doesn't happen if each test is run individually.
This is mostly likely due to some VTK thing, either a bug in the python VTK or our use of the renderer.
This PR allows to run each test in those troublesome test files in a separate process which allows them to exit without problems.

refs #7451