### PR TITLE
Only look at "xdr" files for recovery

### DIFF
--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -472,6 +472,9 @@ getRecoveryFileBase(const std::list<std::string> & checkpoint_files)
   // Loop through all possible files and store the newest
   for (const auto & cp_file : checkpoint_files)
   {
+    // Only look at the main checkpoint file, not the mesh, or restartable data files
+    if (hasExtension(cp_file, "xdr"))
+    {
       struct stat stats;
       stat(cp_file.c_str(), &stats);
 
@@ -484,6 +487,7 @@ getRecoveryFileBase(const std::list<std::string> & checkpoint_files)
 
       if (mod_time == newest_time)
         newest_restart_files.push_back(cp_file);
+    }
   }
 
   // Loop through all of the newest files according the number in the file name


### PR DESCRIPTION
Do not look at all of the auxiliary files for recovery
such as the mesh or restartable data files.

closes #8625

This code was incorrectly formatted so my patch is really small!