### PR TITLE
Changes to DynamicStressDivergenceTensors to enable use of rayleigh d…

### DIFF
--- a/modules/combined/tests/phase_field_fracture/crack2d.i
+++ b/modules/combined/tests/phase_field_fracture/crack2d.i
@@ -48,18 +48,20 @@
     G0_var = 'G0_pos'
     dG0_dstrain_var = 'dG0_pos_dstrain'
   [../]
+  [./DynamicTensorMechanics]
+    displacements = 'disp_x disp_y'
+    save_in = 'resid_x resid_y'
+  [../]
   [./solid_x]
-    type = StressDivergencePFFracTensors
+    type = PhaseFieldFractureMechanicsOffDiag
     variable = disp_x
     component = 0
-    save_in = resid_x
     c = c
   [../]
   [./solid_y]
-    type = StressDivergencePFFracTensors
+    type = PhaseFieldFractureMechanicsOffDiag
     variable = disp_y
     component = 1
-    save_in = resid_y
     c = c
   [../]
   [./dcdt]

--- a/modules/combined/tests/phase_field_fracture/crack2d_aniso.i
+++ b/modules/combined/tests/phase_field_fracture/crack2d_aniso.i
@@ -31,14 +31,17 @@
     variable = c
     beta = b
   [../]
+  [./TensorMechanics]
+    displacements = 'disp_x disp_y'
+  [../]
   [./solid_x]
-    type = StressDivergencePFFracTensors
+    type = PhaseFieldFractureMechanicsOffDiag
     variable = disp_x
     component = 0
     c = c
   [../]
   [./solid_y]
-    type = StressDivergencePFFracTensors
+    type = PhaseFieldFractureMechanicsOffDiag
     variable = disp_y
     component = 1
     c = c

--- a/modules/combined/tests/phase_field_fracture/void2d.i
+++ b/modules/combined/tests/phase_field_fracture/void2d.i
@@ -47,18 +47,20 @@
     G0_var = 'G0_pos'
     dG0_dstrain_var = 'dG0_pos_dstrain'
   [../]
+  [./TensorMechanics]
+    displacements = 'disp_x disp_y'
+    save_in = 'resid_x resid_y'
+  [../]
   [./solid_x]
-    type = StressDivergencePFFracTensors
+    type = PhaseFieldFractureMechanicsOffDiag
     variable = disp_x
     component = 0
-    save_in = resid_x
     c = c
   [../]
   [./solid_y]
-    type = StressDivergencePFFracTensors
+    type = PhaseFieldFractureMechanicsOffDiag
     variable = disp_y
     component = 1
-    save_in = resid_y
     c = c
   [../]
   [./dcdt]

--- a/modules/combined/tests/phase_field_fracture_viscoplastic/crack2d.i
+++ b/modules/combined/tests/phase_field_fracture_viscoplastic/crack2d.i
@@ -49,19 +49,22 @@
     G0_var = 'G0'
     dG0_dstrain_var = 'dG0_dstrain'
   [../]
+  [./TensorMechanics]
+    displacements = 'disp_x disp_y'
+    save_in = 'resid_x resid_y'
+    use_displaced_mesh = true
+  [../]
   [./solid_x]
-    type = StressDivergencePFFracTensors
+    type = PhaseFieldFractureMechanicsOffDiag
     variable = disp_x
     component = 0
-    save_in = resid_x
     c = c
     use_displaced_mesh = true
   [../]
   [./solid_y]
-    type = StressDivergencePFFracTensors
+    type = PhaseFieldFractureMechanicsOffDiag
     variable = disp_y
     component = 1
-    save_in = resid_y
     c = c
     use_displaced_mesh = true
   [../]

--- a/modules/tensor_mechanics/include/kernels/PhaseFieldFractureMechanicsOffDiag.h
+++ b/modules/tensor_mechanics/include/kernels/PhaseFieldFractureMechanicsOffDiag.h
@@ -1,0 +1,46 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef PHASEFIELDFRACTUREMECHANICSOFFDIAG_H
+#define PHASEFIELDFRACTUREMECHANICSOFFDIAG_H
+
+#include "Kernel.h"
+#include "RankTwoTensor.h"
+#include "DerivativeMaterialInterface.h"
+
+/**
+ * This class computes the off-diagonal Jacobian component of stress divergence residual system
+ * Contribution from damage order parameter c
+ * Useful if user wants to add the off diagonal Jacobian term
+ */
+
+class PhaseFieldFractureMechanicsOffDiag;
+class RankTwoTensor;
+
+template<>
+InputParameters validParams<PhaseFieldFractureMechanicsOffDiag>();
+
+class PhaseFieldFractureMechanicsOffDiag : public DerivativeMaterialInterface<Kernel>
+{
+public:
+  PhaseFieldFractureMechanicsOffDiag(const InputParameters & parameters);
+
+protected:
+  Real computeQpResidual() override {return 0.0; }
+
+  Real computeQpJacobian() override {return 0.0; }
+
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+
+  std::string _base_name;
+  const unsigned int _component;
+
+  const bool _c_coupled;
+  const unsigned int _c_var;
+  const MaterialProperty<RankTwoTensor> & _d_stress_dc;
+};
+
+#endif //PHASEFIELDFRACTUREMECHANICSOFFDIAG_H

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -31,6 +31,7 @@
 #include "GeneralizedPlaneStrainOffDiag.h"
 #include "WeakPlaneStress.h"
 #include "PlasticHeatEnergy.h"
+#include "PhaseFieldFractureMechanicsOffDiag.h"
 
 #include "LinearElasticTruss.h"
 #include "FiniteStrainPlasticMaterial.h"
@@ -213,7 +214,7 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerKernel(StressDivergenceRZTensors);
   registerKernel(StressDivergenceRSphericalTensors);
   registerKernel(MomentBalancing);
-  registerKernel(StressDivergencePFFracTensors);
+  registerDeprecatedObject(StressDivergencePFFracTensors, "06/01/2017 09:00");
   registerKernel(PoroMechanicsCoupling);
   registerKernel(InertialForce);
   registerKernel(Gravity);
@@ -223,6 +224,7 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerKernel(GeneralizedPlaneStrainOffDiag);
   registerKernel(WeakPlaneStress);
   registerKernel(PlasticHeatEnergy);
+  registerKernel(PhaseFieldFractureMechanicsOffDiag);
 
   registerMaterial(LinearElasticTruss);
   registerMaterial(FiniteStrainPlasticMaterial);

--- a/modules/tensor_mechanics/src/kernels/PhaseFieldFractureMechanicsOffDiag.C
+++ b/modules/tensor_mechanics/src/kernels/PhaseFieldFractureMechanicsOffDiag.C
@@ -1,0 +1,45 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PhaseFieldFractureMechanicsOffDiag.h"
+
+template<>
+InputParameters validParams<PhaseFieldFractureMechanicsOffDiag>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addClassDescription("Stress divergence kernel for phase-field fracture: Computes off diagonal damage dependent Jacobian components. To be used with StressDivergenceTensors or DynamicStressDivergenceTensors.");
+  params.addParam<std::string>("base_name", "Material property base name");
+  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction the variable this kernel acts in. (0 for x, 1 for y, 2 for z)");
+  params.addCoupledVar("c", "Phase field damage variable: Used to indicate calculation of Off Diagonal Jacobian term");
+  return params;
+}
+
+
+PhaseFieldFractureMechanicsOffDiag::PhaseFieldFractureMechanicsOffDiag(const InputParameters & parameters) :
+    DerivativeMaterialInterface<Kernel>(parameters),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _component(getParam<unsigned int>("component")),
+    _c_coupled(isCoupled("c")),
+    _c_var(_c_coupled ? coupled("c") : 0),
+    _d_stress_dc(getMaterialPropertyDerivative<RankTwoTensor>(_base_name + "stress", getVar("c", 0)->name()))
+{
+}
+
+Real
+PhaseFieldFractureMechanicsOffDiag::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  if (_c_coupled && jvar == _c_var)
+  {
+    Real val = 0.0;
+    for (unsigned int k = 0;k < 3; ++k)
+      val += _d_stress_dc[_qp](_component, k) * _grad_test[_i][_qp](k);
+    return val * _phi[_j][_qp];
+  }
+
+  // Returns if coupled variable is not c (damage variable)
+  return 0.0;
+}

--- a/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergencePFFracTensors.C
@@ -23,6 +23,7 @@ StressDivergencePFFracTensors::StressDivergencePFFracTensors(const InputParamete
     _c_var(_c_coupled ? coupled("c") : 0),
     _d_stress_dc(getMaterialPropertyDerivative<RankTwoTensor>(_base_name + "stress", getVar("c", 0)->name()))
 {
+  mooseDeprecated("StressDivergencePFFracTensors is deprecated. Please use PhaseFieldFractureMechanicsOffDiag and StressDivergenceTensors instead.");
 }
 
 Real


### PR DESCRIPTION
…amping with StressDivergencePFFracTensors #8351

DynamicStressDivergenceTensors is edited so that it derives from StressDivergencePFFracTensors instead of StressDivergenceTensors. 

combined/tests/phase_field_fracture/crack2d.i is modified to demonstrate the syntax if DynamicTensorMechanicsAction is used to set up the stress divergence kernels. Adding zeta = some real number to this action would turn on stiffness proportional Rayleigh damping.

closes #8351