### PR TITLE
NodalUserObject cannot inherit from MaterialPropertyInterface

### DIFF
--- a/framework/include/userobject/NodalUserObject.h
+++ b/framework/include/userobject/NodalUserObject.h
@@ -19,7 +19,6 @@
 #include "UserObject.h"
 #include "BlockRestrictable.h"
 #include "BoundaryRestrictable.h"
-#include "MaterialPropertyInterface.h"
 #include "UserObjectInterface.h"
 #include "Coupleable.h"
 #include "MooseVariableDependencyInterface.h"
@@ -42,7 +41,6 @@ class NodalUserObject :
   public UserObject,
   public BlockRestrictable,
   public BoundaryRestrictable,
-  public MaterialPropertyInterface,
   public UserObjectInterface,
   public Coupleable,
   public MooseVariableDependencyInterface,

--- a/framework/src/userobject/NodalUserObject.C
+++ b/framework/src/userobject/NodalUserObject.C
@@ -26,7 +26,6 @@ InputParameters validParams<NodalUserObject>()
   params += validParams<BlockRestrictable>();
   params += validParams<BoundaryRestrictable>();
   params += validParams<RandomInterface>();
-  params += validParams<MaterialPropertyInterface>();
   return params;
 }
 
@@ -34,7 +33,6 @@ NodalUserObject::NodalUserObject(const InputParameters & parameters) :
     UserObject(parameters),
     BlockRestrictable(parameters),
     BoundaryRestrictable(parameters, blockIDs(), true), // true for applying to nodesets
-    MaterialPropertyInterface(this, blockIDs(), boundaryIDs()),
     UserObjectInterface(this),
     Coupleable(this, true),
     MooseVariableDependencyInterface(),


### PR DESCRIPTION
Since material properties are not computed at nodes, inheriting from
`MaterialPropertyInterface` is wrong and needs to go away.  People are
trying to couple material properties into nodal user objects and they
are surprised that they get garbage numbers.

Fixes #8640