### PR TITLE
Fix side set operations on distributed meshes

### DIFF
--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -19,6 +19,7 @@
 
 // libMesh includes
 #include "libmesh/mesh.h"
+#include "libmesh/remote_elem.h"
 
 template<>
 InputParameters validParams<SideSetsAroundSubdomain>()
@@ -83,10 +84,18 @@ SideSetsAroundSubdomain::modify()
   // Get a reference to our BoundaryInfo object for later use
   BoundaryInfo & boundary_info = mesh.get_boundary_info();
 
+  // Prepare to query about sides adjacent to remote elements if we're
+  // on a distributed mesh
+  const processor_id_type my_n_proc  = mesh.n_processors();
+  const processor_id_type my_proc_id = mesh.processor_id();
+  typedef std::vector<std::pair<dof_id_type, unsigned int> > vec_type;
+  std::vector<vec_type> queries(my_n_proc);
+
   // Loop over the elements
-  MeshBase::const_element_iterator   el  = mesh.active_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_elements_end();
-  for (; el != end_el ; ++el)
+  for (MeshBase::const_element_iterator
+         el  = mesh.active_elements_begin(),
+         end_el = mesh.active_elements_end();
+         el != end_el ; ++el)
   {
     const Elem* elem = *el;
     SubdomainID curr_subdomain = elem->subdomain_id();
@@ -98,24 +107,125 @@ SideSetsAroundSubdomain::modify()
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
       const Elem * neighbor = elem->neighbor(side);
-      if (neighbor == NULL ||                   // element on boundary OR
-          neighbor->subdomain_id() != block_id) // neighboring element is on a different subdomain
+
+      // On a replicated mesh, we add all subdomain sides ourselves.
+      // On a distributed mesh, we may have missed sides which
+      // neighbor remote elements.  We should query any such cases.
+      if (neighbor == remote_elem)
+      {
+        queries[elem->processor_id()].push_back(std::make_pair(elem->id(), side));
+      }
+      else if (neighbor == NULL ||                   // element on boundary OR
+               neighbor->subdomain_id() != block_id) // neighboring element is on a different subdomain
+      {
+        if (_using_normal)
         {
-          if (_using_normal)
-          {
-            _fe_face->reinit(elem, side);
-            face_normal = _fe_face->get_normals()[0];
-            add_to_bdy = (_normal*face_normal >= 1.0 - _normal_tol);
-          }
-
-
-          // Add the boundaries, if appropriate
-          if (add_to_bdy)
-            for (const auto & boundary_id : boundary_ids)
-              boundary_info.add_side(elem, side, boundary_id);
+          _fe_face->reinit(elem, side);
+          face_normal = _fe_face->get_normals()[0];
+          add_to_bdy = (_normal*face_normal >= 1.0 - _normal_tol);
         }
+
+        // Add the boundaries, if appropriate
+        if (add_to_bdy)
+          for (const auto & boundary_id : boundary_ids)
+            boundary_info.add_side(elem, side, boundary_id);
+      }
     }
   }
+
+  if (!mesh.is_serial())
+    {
+      Parallel::MessageTag
+        queries_tag = mesh.comm().get_unique_tag(867),
+        replies_tag = mesh.comm().get_unique_tag(5309);
+
+      std::vector<Parallel::Request> side_requests(my_n_proc-1),
+                                     reply_requests(my_n_proc-1);
+
+      // Make all requests
+      for (processor_id_type p=0; p != my_n_proc; ++p)
+      {
+        if (p == my_proc_id)
+          continue;
+
+        Parallel::Request &request =
+          side_requests[p - (p > my_proc_id)];
+
+        mesh.comm().send
+          (p, queries[p], request, queries_tag);
+      }
+
+      // Reply to all requests
+      std::vector<vec_type> responses(my_n_proc-1);
+
+      for (processor_id_type p=1; p != my_n_proc; ++p)
+      {
+        vec_type query;
+
+        Parallel::Status
+          status(mesh.comm().probe (Parallel::any_source, queries_tag));
+        const processor_id_type
+          source_pid = cast_int<processor_id_type>(status.source());
+
+        mesh.comm().receive
+          (source_pid, query, queries_tag);
+
+        Parallel::Request &request =
+          reply_requests[p-1];
+
+        for (const auto & q : query)
+        {
+          const Elem * elem = mesh.elem_ptr(q.first);
+          const unsigned int side = q.second;
+          const Elem * neighbor = elem->neighbor(side);
+
+          if (neighbor == NULL ||                   // element on boundary OR
+              neighbor->subdomain_id() != block_id) // neighboring element is on a different subdomain
+          {
+            if (_using_normal)
+            {
+              _fe_face->reinit(elem, side);
+              face_normal = _fe_face->get_normals()[0];
+              add_to_bdy = (_normal*face_normal >= 1.0 - _normal_tol);
+            }
+
+            // Add the boundaries, if appropriate
+            if (add_to_bdy)
+              responses[p-1].push_back(std::make_pair(elem->id(), side));
+          }
+        }
+
+        mesh.comm().send
+          (source_pid, responses[p-1], request, replies_tag);
+      }
+
+      // Process all incoming replies
+      for (processor_id_type p=1; p != my_n_proc; ++p)
+      {
+        Parallel::Status status
+          (this->comm().probe (Parallel::any_source, replies_tag));
+        const processor_id_type
+          source_pid = cast_int<processor_id_type>(status.source());
+
+        vec_type response;
+
+        this->comm().receive
+          (source_pid, response, replies_tag);
+
+        for (const auto & r : response)
+        {
+          const Elem * elem = mesh.elem_ptr(r.first);
+          const unsigned int side = r.second;
+
+          for (const auto & boundary_id : boundary_ids)
+            boundary_info.add_side(elem, side, boundary_id);
+        }
+      }
+
+      Parallel::wait (side_requests);
+      Parallel::wait (reply_requests);
+    }
+
 
   finalize();
 


### PR DESCRIPTION
Subdomain boundaries may coincide with a boundary between ghosted and
remote elements, in which case it is not possible to assign sidesets
properly there without a communication step.

This fixes mutliple regression tests for me when I run with
--distributed-mesh as per #1500