### PR TITLE
Distributed getboundaryids

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -122,7 +122,10 @@ public:
 
   /**
    * Returns a const reference to a set of all user-specified
-   * boundary IDs.
+   * boundary IDs.  On a distributed mesh this will *only* include
+   * boundary IDs which exist on local or ghosted elements; a copy and
+   * a call to _communicator.set_union() will be necessary to get the
+   * global ID set.
    */
   const std::set<BoundaryID> & getBoundaryIDs() const;
 

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -941,6 +941,11 @@ MooseMesh::getBoundaryIDs(const std::vector<BoundaryName> & boundary_name, bool 
   const std::map<BoundaryID, std::string> & nodeset_map = boundary_info.get_nodeset_name_map();
 
   std::set<BoundaryID> boundary_ids = boundary_info.get_boundary_ids();
+
+  // On a distributed mesh we may have boundary ids that only exist on
+  // other processors.
+  _communicator.set_union(boundary_ids);
+
   BoundaryID max_boundary_id = boundary_ids.empty() ? 0 : *(boundary_ids.rbegin());
 
   std::vector<BoundaryID> ids(boundary_name.size());


### PR DESCRIPTION
We may not have all our boundary IDs locally, but userspace code is
probably expecting (in some cases definitely expecting) to be querying
the global boundary ID set, so let's use a global union to get it.

This fixes a dgkernels/dg_block_restrict.1D_test #1500 regression for
me with --distributed-mesh on 2 processors.

One of the other getBoundaryIDs overloads is just a shim to the libMesh set of semilocal IDs, so we can't change that easily, and I've just updated the documentation to make users aware of it.