### PR TITLE
RayTracing requires a ReplicatedMesh

### DIFF
--- a/test/tests/vectorpostprocessors/elements_along_line/1d.i
+++ b/test/tests/vectorpostprocessors/elements_along_line/1d.i
@@ -1,5 +1,6 @@
 [Mesh]
   type = GeneratedMesh
+  parallel_type = replicated # Until RayTracing.C is fixed
   dim = 1
   nx = 10
 []

--- a/test/tests/vectorpostprocessors/elements_along_line/2d.i
+++ b/test/tests/vectorpostprocessors/elements_along_line/2d.i
@@ -1,5 +1,6 @@
 [Mesh]
   type = GeneratedMesh
+  parallel_type = replicated # Until RayTracing.C is fixed
   dim = 2
   nx = 10
   ny = 10

--- a/test/tests/vectorpostprocessors/elements_along_line/3d.i
+++ b/test/tests/vectorpostprocessors/elements_along_line/3d.i
@@ -1,5 +1,6 @@
 [Mesh]
   type = GeneratedMesh
+  parallel_type = replicated # Until RayTracing.C is fixed
   dim = 3
   nx = 10
   ny = 10

--- a/test/tests/vectorpostprocessors/line_material_sampler/line_material_real_sampler.i
+++ b/test/tests/vectorpostprocessors/line_material_sampler/line_material_real_sampler.i
@@ -1,5 +1,6 @@
 [Mesh]
   type = GeneratedMesh
+  parallel_type = replicated # Until RayTracing.C is fixed
   dim = 2
   xmin = 0
   xmax = 1


### PR DESCRIPTION
I think I could fix this myself eventually, but @friedmud has better
DistributedMesh ray tracing code under development in his thesis
application, so we might as well force the ray tracing regression
tests to run with ReplicatedMesh until he has time to merge that back
into MOOSE proper.

Workaround for #1500 failures