### PR TITLE
More ElementDeleterBase fixes

### DIFF
--- a/framework/src/meshmodifiers/ElementDeleterBase.C
+++ b/framework/src/meshmodifiers/ElementDeleterBase.C
@@ -120,14 +120,6 @@ ElementDeleterBase::modify()
     std::vector<Parallel::Request> query_requests(my_n_proc-1),
                                    reply_requests(my_n_proc-1);
 
-    const MeshBase::const_element_iterator end = mesh.elements_end();
-    for (MeshBase::const_element_iterator elem_it = mesh.elements_begin(); elem_it != end; ++elem_it)
-    {
-      Elem * elem = *elem_it;
-      if (shouldDelete(elem))
-        deleteable_elems.insert(elem);
-    }
-
     // Make all requests
     for (processor_id_type p=0; p != my_n_proc; ++p)
     {

--- a/framework/src/meshmodifiers/ElementDeleterBase.C
+++ b/framework/src/meshmodifiers/ElementDeleterBase.C
@@ -157,7 +157,7 @@ ElementDeleterBase::modify()
         const unsigned int side = q.second;
         const Elem * neighbor = elem->neighbor(side);
 
-        if (neighbor == NULL) // neighboring element was deleted!
+        if (neighbor == nullptr) // neighboring element was deleted!
           responses[p-1].push_back(std::make_pair(elem->id(), side));
       }
 
@@ -183,7 +183,9 @@ ElementDeleterBase::modify()
         Elem * elem = mesh.elem_ptr(r.first);
         const unsigned int side = r.second;
 
-        elem->set_neighbor(side, libmesh_nullptr);
+        libmesh_assert(elem->neighbor(side) == remote_elem);
+
+        elem->set_neighbor(side, nullptr);
       }
     }
 


### PR DESCRIPTION
Another swath of fixes for #1500 regressions.

All of the block_deleter tests now pass for me with --distributed-mesh on 2 or 3 processors.  Test 11 is still failing on 12 processors, but we're making process.