### PR TITLE
DependencyResolverComparator for ordering

### DIFF
--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -42,7 +42,7 @@ public:
   void addDependencySets(const std::string & action_sets);
 
   const std::vector<std::string> & getSortedTask();
-  const std::vector<std::set<std::string> > & getSortedTaskSet();
+  const std::vector<std::set<std::string, DependencyResolverComparator<std::string> > > & getSortedTaskSet();
 
   bool hasTask(const std::string & task);
 

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -243,7 +243,7 @@ ActionWarehouse::printActionDependencySets() const
    */
   std::ostringstream oss;
 
-  const std::vector<std::set<std::string> > & ordered_names = _syntax.getSortedTaskSet();
+  const auto & ordered_names = _syntax.getSortedTaskSet();
   for (const auto & task_set : ordered_names)
   {
     oss << "[DBG][ACT] (" << COLOR_YELLOW;

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -86,7 +86,7 @@ Syntax::getSortedTask()
   return _tasks.getSortedValues();
 }
 
-const std::vector<std::set<std::string> > &
+const std::vector<std::set<std::string, DependencyResolverComparator<std::string> > > &
 Syntax::getSortedTaskSet()
 {
   return _tasks.getSortedValuesSets();


### PR DESCRIPTION
This fixes #8659 and gets another #1500 test working for me...
probably.  Since the bug here wasn't deterministic, I'm less confident
than usual that I've definitively fixed it.

This *breaks* the Syntax::getSortedTaskSet() API.  I've updated
ActionWarehouse.C to use the new API; hopefully there aren't any apps
using it except via "auto".

This changes the default sorting that DependencyResolver uses when two
objects have no interdependencies.  Hopefully there won't be any
regressions due to that...

Closes #8659