### PR TITLE
Skip frictional_mu02_penalty test

### DIFF
--- a/modules/combined/tests/sliding_block/sliding/constraint/tests
+++ b/modules/combined/tests/sliding_block/sliding/constraint/tests
@@ -8,6 +8,7 @@
     min_parallel = 4
     abs_zero = 1e-7
     max_time = 800
+    skip = 'see #8649'
   [../]
 
   [./frictional_mu04_penalty]


### PR DESCRIPTION
combined:sliding_block/sliding/constraint.frictional_mu02_penalty
has been failing for some time now. This skips it.

refs #8649