### PR TITLE
materials: always call initQpStatefulProperties if provided

### DIFF
--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -273,6 +273,8 @@ private:
   void checkExecutionStage();
 
   bool _has_stateful_property;
+
+  bool _overrides_init_stateful_props = true;
 };
 
 template<typename T>

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -106,25 +106,22 @@ Material::Material(const InputParameters & parameters) :
 void
 Material::initStatefulProperties(unsigned int n_points)
 {
+  for (_qp = 0; _qp < n_points; ++_qp)
+    initQpStatefulProperties();
+
   // checking for statefulness of properties via this loop is necessary
   // because owned props might have been promoted to stateful by calls to
   // getMaterialProperty[Old/Older] from other objects.  In these cases, this
   // object won't otherwise know that it owns stateful properties.
   for (auto & prop : _supplied_props)
-  {
-    if (_material_data->getMaterialPropertyStorage().isStatefulProp(prop))
-    {
-      for (_qp = 0; _qp < n_points; ++_qp)
-        initQpStatefulProperties();
-      return;
-    }
-  }
+    if (_material_data->getMaterialPropertyStorage().isStatefulProp(prop) && !_overrides_init_stateful_props)
+      mooseError(std::string("Material \"") + name() + "\" provides one or more stateful properties but initQpStatefulProperties() was not overridden in the derived class.");
 }
 
 void
 Material::initQpStatefulProperties()
 {
-  mooseError(std::string("Material \"") + name() + "\" provides one or more stateful properties but initQpStatefulProperties() was not overridden in the derived class.");
+  _overrides_init_stateful_props = false;
 }
 
 void


### PR DESCRIPTION
Sometimes, users may put important initialization code in
initQpStatefulProperties that they assume will always be run.  But the
initialization is skipped if the material was never promoted to
stateful.  This can result in problems like the one found in #8513.  So
we should always call it if provided.