### PR TITLE
Remaining declarePropertyOld removed from PorousFlow

### DIFF
--- a/modules/porous_flow/include/materials/PorousFlowBrine.h
+++ b/modules/porous_flow/include/materials/PorousFlowBrine.h
@@ -32,9 +32,6 @@ protected:
   /// Fluid phase density at the qps or nodes
   MaterialProperty<Real> & _density;
 
-  /// Old fluid phase density at the nodes
-  MaterialProperty<Real> * const _density_old;
-
   /// Derivative of fluid density wrt phase pore pressure at the qps or nodes
   MaterialProperty<Real> & _ddensity_dp;
 
@@ -53,9 +50,6 @@ protected:
   /// Fluid phase internal_energy at the qps or nodes
   MaterialProperty<Real> & _internal_energy;
 
-  /// Old fluid phase internal_energy at the nodes
-  MaterialProperty<Real> * const _internal_energy_old;
-
   /// Derivative of fluid internal_energy wrt phase pore pressure at the qps or nodes
   MaterialProperty<Real> & _dinternal_energy_dp;
 
@@ -64,9 +58,6 @@ protected:
 
   /// Fluid phase enthalpy at the qps or nodes
   MaterialProperty<Real> & _enthalpy;
-
-  /// Old fluid phase enthalpy at the nodes
-  MaterialProperty<Real> * const _enthalpy_old;
 
   /// Derivative of fluid enthalpy wrt phase pore pressure at the qps or nodes
   MaterialProperty<Real> & _denthalpy_dp;

--- a/modules/porous_flow/include/materials/PorousFlowDensityConstBulk.h
+++ b/modules/porous_flow/include/materials/PorousFlowDensityConstBulk.h
@@ -55,9 +55,6 @@ protected:
   /// Fluid phase density at the nodes or quadpoints
   MaterialProperty<Real> & _density;
 
-  /// Old fluid phase density at the nodes
-  MaterialProperty<Real> * const _density_old;
-
   /// Derivative of fluid density wrt phase pore pressure at the nodes or quadpoints
   MaterialProperty<Real> & _ddensity_dp;
 

--- a/modules/porous_flow/include/materials/PorousFlowEnthalpy.h
+++ b/modules/porous_flow/include/materials/PorousFlowEnthalpy.h
@@ -53,9 +53,6 @@ protected:
   /// Fluid phase enthalpy at the qps or nodes
   MaterialProperty<Real> & _enthalpy;
 
-  /// Old value of fluid phase enthalpy at the nodes
-  MaterialProperty<Real> * const _enthalpy_old;
-
   /// Derivative of fluid enthalpy wrt phase pore pressure at the qps or nodes
   MaterialProperty<Real> & _denthalpy_dp;
 

--- a/modules/porous_flow/include/materials/PorousFlowIdealGas.h
+++ b/modules/porous_flow/include/materials/PorousFlowIdealGas.h
@@ -64,9 +64,6 @@ protected:
   /// Fluid phase density at the nodes or quadpoints
   MaterialProperty<Real> & _density;
 
-  /// Old fluid phase density at the nodes
-  MaterialProperty<Real> * const _density_old;
-
   /// Derivative of fluid density wrt phase pore pressure at the nodes or quadpoints
   MaterialProperty<Real> & _ddensity_dp;
 

--- a/modules/porous_flow/include/materials/PorousFlowInternalEnergyIdeal.h
+++ b/modules/porous_flow/include/materials/PorousFlowInternalEnergyIdeal.h
@@ -34,9 +34,6 @@ protected:
   /// Fluid phase internal_energy at the qps or nodes
   MaterialProperty<Real> & _internal_energy;
 
-  /// Old value of fluid phase internal_energy at the nodes
-  MaterialProperty<Real> * const _internal_energy_old;
-
   /// Derivative of fluid internal_energy wrt phase pore pressure at the qps or nodes
   MaterialProperty<Real> & _dinternal_energy_dp;
 

--- a/modules/porous_flow/include/materials/PorousFlowSingleComponentFluid.h
+++ b/modules/porous_flow/include/materials/PorousFlowSingleComponentFluid.h
@@ -33,9 +33,6 @@ protected:
   /// Fluid phase density at the qps or nodes
   MaterialProperty<Real> & _density;
 
-  /// Old value of fluid phase density at the nodes
-  MaterialProperty<Real> * const _density_old;
-
   /// Derivative of fluid density wrt phase pore pressure at the qps or nodes
   MaterialProperty<Real> & _ddensity_dp;
 
@@ -54,9 +51,6 @@ protected:
   /// Fluid phase internal_energy at the qps or nodes
   MaterialProperty<Real> & _internal_energy;
 
-  /// Old value of fluid phase internal_energy at the nodes
-  MaterialProperty<Real> * const _internal_energy_old;
-
   /// Derivative of fluid internal_energy wrt phase pore pressure at the qps or nodes
   MaterialProperty<Real> & _dinternal_energy_dp;
 
@@ -65,9 +59,6 @@ protected:
 
   /// Fluid phase enthalpy at the qps or nodes
   MaterialProperty<Real> & _enthalpy;
-
-  /// Old value of fluid phase enthalpy at the nodes
-  MaterialProperty<Real> * const _enthalpy_old;
 
   /// Derivative of fluid enthalpy wrt phase pore pressure at the qps or nodes
   MaterialProperty<Real> & _denthalpy_dp;

--- a/modules/porous_flow/include/materials/PorousFlowTemperature.h
+++ b/modules/porous_flow/include/materials/PorousFlowTemperature.h
@@ -49,9 +49,6 @@ protected:
   /// d(computed temperature)/d(PorousFlow variable)
   MaterialProperty<std::vector<Real>> & _dtemperature_dvar;
 
-  /// Old value of computed temperature at the nodes
-  MaterialProperty<Real> * const _temperature_old;
-
   /// Grad(temperature) at the quadpoints (not needed for nodal_materials)
   MaterialProperty<RealGradient> * const _grad_temperature;
 

--- a/modules/porous_flow/include/materials/PorousFlowVariableBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowVariableBase.h
@@ -45,9 +45,6 @@ protected:
   /// d(porepressure)/d(PorousFlow variable)
   MaterialProperty<std::vector<std::vector<Real>>> & _dporepressure_dvar;
 
-  /// Old values of nodal porepressure of the phases
-  MaterialProperty<std::vector<Real>> * const _porepressure_old;
-
   /// Grad(p) at the quadpoints
   MaterialProperty<std::vector<RealGradient>> * const _gradp_qp;
 
@@ -62,9 +59,6 @@ protected:
 
   /// d(saturation)/d(PorousFlow variable)
   MaterialProperty<std::vector<std::vector<Real>>> & _dsaturation_dvar;
-
-  /// Old value of nodal saturation of the phases
-  MaterialProperty<std::vector<Real>> * const _saturation_old;
 
   /// Grad(s) at the quadpoints
   MaterialProperty<std::vector<RealGradient>> * const _grads_qp;

--- a/modules/porous_flow/src/materials/PorousFlowBrine.C
+++ b/modules/porous_flow/src/materials/PorousFlowBrine.C
@@ -20,7 +20,6 @@ PorousFlowBrine::PorousFlowBrine(const InputParameters & parameters) :
     PorousFlowFluidPropertiesBase(parameters),
 
     _density(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_density_nodal" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
-    _density_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_density_nodal" + _phase) : nullptr),
     _ddensity_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name)),
     _ddensity_dT(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _temperature_variable_name)),
 
@@ -29,12 +28,10 @@ PorousFlowBrine::PorousFlowBrine(const InputParameters & parameters) :
     _dviscosity_dT(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_viscosity_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_viscosity_qp" + _phase, _temperature_variable_name)),
 
     _internal_energy(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_internal_energy" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase)),
-    _internal_energy_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_internal_energy" + _phase) : nullptr),
     _dinternal_energy_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase, _pressure_variable_name)),
     _dinternal_energy_dT(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase, _temperature_variable_name)),
 
     _enthalpy(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_enthalpy" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase)),
-    _enthalpy_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_enthalpy" + _phase) : nullptr),
     _denthalpy_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase, _pressure_variable_name)),
     _denthalpy_dT(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase, _temperature_variable_name)),
 

--- a/modules/porous_flow/src/materials/PorousFlowDensityConstBulk.C
+++ b/modules/porous_flow/src/materials/PorousFlowDensityConstBulk.C
@@ -23,7 +23,6 @@ PorousFlowDensityConstBulk::PorousFlowDensityConstBulk(const InputParameters & p
     _dens0(getParam<Real>("density_P0")),
     _bulk(getParam<Real>("bulk_modulus")),
     _density(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_density_nodal" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
-    _density_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_density_nodal" + _phase) : nullptr),
     _ddensity_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name)),
     _ddensity_dt(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _temperature_variable_name))
 {

--- a/modules/porous_flow/src/materials/PorousFlowEnthalpy.C
+++ b/modules/porous_flow/src/materials/PorousFlowEnthalpy.C
@@ -30,7 +30,6 @@ PorousFlowEnthalpy::PorousFlowEnthalpy(const InputParameters & parameters) :
     _ddensity_dt(_nodal_material ? getMaterialPropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + Moose::stringify(_phase_num), _temperature_variable_name) : getMaterialPropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + Moose::stringify(_phase_num), _temperature_variable_name)),
 
     _enthalpy(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_enthalpy_nodal" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase)),
-    _enthalpy_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_enthalpy_nodal" + _phase) : nullptr),
     _denthalpy_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_nodal" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase, _pressure_variable_name)),
     _denthalpy_dt(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase, _temperature_variable_name))
 {

--- a/modules/porous_flow/src/materials/PorousFlowIdealGas.C
+++ b/modules/porous_flow/src/materials/PorousFlowIdealGas.C
@@ -21,7 +21,6 @@ PorousFlowIdealGas::PorousFlowIdealGas(const InputParameters & parameters) :
 
     _molar_mass(getParam<Real>("molar_mass")),
     _density(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_density_nodal" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
-    _density_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_density_nodal" + _phase) : nullptr),
     _ddensity_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name)),
     _ddensity_dt(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _temperature_variable_name))
 {

--- a/modules/porous_flow/src/materials/PorousFlowInternalEnergyIdeal.C
+++ b/modules/porous_flow/src/materials/PorousFlowInternalEnergyIdeal.C
@@ -21,7 +21,6 @@ PorousFlowInternalEnergyIdeal::PorousFlowInternalEnergyIdeal(const InputParamete
 
     _cv(getParam<Real>("specific_heat_capacity")),
     _internal_energy(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_internal_energy_nodal" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase)),
-    _internal_energy_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_internal_energy_nodal" + _phase) : nullptr),
     _dinternal_energy_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_nodal" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase, _pressure_variable_name)),
     _dinternal_energy_dt(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase, _temperature_variable_name))
 {

--- a/modules/porous_flow/src/materials/PorousFlowSingleComponentFluid.C
+++ b/modules/porous_flow/src/materials/PorousFlowSingleComponentFluid.C
@@ -20,7 +20,6 @@ PorousFlowSingleComponentFluid::PorousFlowSingleComponentFluid(const InputParame
     PorousFlowFluidPropertiesBase(parameters),
 
     _density(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_density_nodal" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_density_qp" + _phase)),
-    _density_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_density_nodal" + _phase) : nullptr),
     _ddensity_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _pressure_variable_name)),
     _ddensity_dT(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase, _temperature_variable_name)),
 
@@ -29,12 +28,10 @@ PorousFlowSingleComponentFluid::PorousFlowSingleComponentFluid(const InputParame
     _dviscosity_dT(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_viscosity_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_viscosity_qp" + _phase, _temperature_variable_name)),
 
     _internal_energy(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_internal_energy_nodal" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase)),
-    _internal_energy_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_internal_energy_nodal" + _phase) : nullptr),
     _dinternal_energy_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_nodal" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase, _pressure_variable_name)),
     _dinternal_energy_dT(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_internal_energy_qp" + _phase, _temperature_variable_name)),
 
     _enthalpy(_nodal_material ? declareProperty<Real>("PorousFlow_fluid_phase_enthalpy_nodal" + _phase) : declareProperty<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase)),
-    _enthalpy_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_fluid_phase_enthalpy_nodal" + _phase) : nullptr),
     _denthalpy_dp(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_nodal" + _phase, _pressure_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase, _pressure_variable_name)),
     _denthalpy_dT(_nodal_material ? declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_nodal" + _phase, _temperature_variable_name) : declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase, _temperature_variable_name)),
 

--- a/modules/porous_flow/src/materials/PorousFlowTemperature.C
+++ b/modules/porous_flow/src/materials/PorousFlowTemperature.C
@@ -28,7 +28,6 @@ PorousFlowTemperature::PorousFlowTemperature(const InputParameters & parameters)
 
     _temperature(_nodal_material ? declareProperty<Real>("PorousFlow_temperature_nodal") : declareProperty<Real>("PorousFlow_temperature_qp")),
     _dtemperature_dvar(_nodal_material ? declareProperty<std::vector<Real>>("dPorousFlow_temperature_nodal_dvar") : declareProperty<std::vector<Real>>("dPorousFlow_temperature_qp_dvar")),
-    _temperature_old(_nodal_material ? &declarePropertyOld<Real>("PorousFlow_temperature_nodal") : nullptr),
     _grad_temperature(_nodal_material ? nullptr : &declareProperty<RealGradient>("PorousFlow_grad_temperature_qp")),
     _dgrad_temperature_dgradv(_nodal_material ? nullptr : &declareProperty<std::vector<Real>>("dPorousFlow_grad_temperature_qp_dgradvar")),
     _dgrad_temperature_dv(_nodal_material ? nullptr : &declareProperty<std::vector<RealGradient>>("dPorousFlow_grad_temperature_qp_dvar"))

--- a/modules/porous_flow/src/materials/PorousFlowVariableBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowVariableBase.C
@@ -25,14 +25,12 @@ PorousFlowVariableBase::PorousFlowVariableBase(const InputParameters & parameter
 
     _porepressure(_nodal_material ? declareProperty<std::vector<Real>>("PorousFlow_porepressure_nodal") : declareProperty<std::vector<Real>>("PorousFlow_porepressure_qp")),
     _dporepressure_dvar(_nodal_material ? declareProperty<std::vector<std::vector<Real>>>("dPorousFlow_porepressure_nodal_dvar") : declareProperty<std::vector<std::vector<Real>>>("dPorousFlow_porepressure_qp_dvar")),
-    _porepressure_old(_nodal_material ? &declarePropertyOld<std::vector<Real>>("PorousFlow_porepressure_nodal") : nullptr),
     _gradp_qp(_nodal_material ? nullptr : &declareProperty<std::vector<RealGradient>>("PorousFlow_grad_porepressure_qp")),
     _dgradp_qp_dgradv(_nodal_material ? nullptr : &declareProperty<std::vector<std::vector<Real>>>("dPorousFlow_grad_porepressure_qp_dgradvar")),
     _dgradp_qp_dv(_nodal_material ? nullptr : &declareProperty<std::vector<std::vector<RealGradient>>>("dPorousFlow_grad_porepressure_qp_dvar")),
 
     _saturation(_nodal_material ? declareProperty<std::vector<Real>>("PorousFlow_saturation_nodal") : declareProperty<std::vector<Real>>("PorousFlow_saturation_qp")),
     _dsaturation_dvar(_nodal_material ? declareProperty<std::vector<std::vector<Real>>>("dPorousFlow_saturation_nodal_dvar") : declareProperty<std::vector<std::vector<Real>>>("dPorousFlow_saturation_qp_dvar")),
-    _saturation_old(_nodal_material ? &declarePropertyOld<std::vector<Real>>("PorousFlow_saturation_nodal") : nullptr),
     _grads_qp(_nodal_material ? nullptr : &declareProperty<std::vector<RealGradient>>("PorousFlow_grad_saturation_qp")),
     _dgrads_qp_dgradv(_nodal_material ? nullptr : &declareProperty<std::vector<std::vector<Real>>>("dPorousFlow_grad_saturation_qp_dgradvar")),
     _dgrads_qp_dv(_nodal_material ? nullptr : &declareProperty<std::vector<std::vector<RealGradient>>>("dPorousFlow_grad_saturation_qp_dv"))


### PR DESCRIPTION
Thanks to the awesome recent work of the moose-devs, Materials no longer have to declarePropertyOld.  Therefore all such lines have been removed from PorousFlow.

Would @rwcarlsen like to review?

Fixes #8513
