### PR TITLE
EqualValueBoundaryConstraint on distributed meshes

### DIFF
--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -651,7 +651,7 @@ protected:
   /// If there is a nodal BC having diag_save_in
   bool _has_nodalbc_diag_save_in;
 
-  void getNodeDofs(unsigned int node_id, std::vector<dof_id_type> & dofs);
+  void getNodeDofs(dof_id_type node_id, std::vector<dof_id_type> & dofs);
 
   std::vector<dof_id_type> _var_all_dof_indices;
 };

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -1279,13 +1279,29 @@ NonlinearSystemBase::findImplicitGeometricCouplingEntries(GeometricSearchData & 
   {
     std::vector<dof_id_type> master_dofs;
     std::vector<dof_id_type> & master_node_ids = nc->getMasterNodeId();
-    for (const auto & dof : master_node_ids)
-      getNodeDofs(dof, master_dofs);
+    for (const auto & node_id : master_node_ids)
+    {
+      Node * node = _mesh.queryNodePtr(node_id);
+      if (node && node->processor_id() == this->processor_id())
+      {
+        getNodeDofs(node_id, master_dofs);
+      }
+    }
+
+    _communicator.allgather(master_dofs);
 
     std::vector<dof_id_type> slave_dofs;
     std::vector<dof_id_type> & slave_node_ids = nc->getSlaveNodeId();
-    for (const auto & dof : slave_node_ids)
-      getNodeDofs(dof, slave_dofs);
+    for (const auto & node_id : slave_node_ids)
+    {
+      Node * node = _mesh.queryNodePtr(node_id);
+      if (node && node->processor_id() == this->processor_id())
+      {
+        getNodeDofs(node_id, slave_dofs);
+      }
+    }
+
+    _communicator.allgather(slave_dofs);
 
     for (const auto & master_id : master_dofs)
       for (const auto & slave_id : slave_dofs)

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -1202,7 +1202,7 @@ NonlinearSystemBase::computeNodalBCs(NumericVector<Number> & residual)
 }
 
 void
-NonlinearSystemBase::getNodeDofs(unsigned int node_id, std::vector<dof_id_type> & dofs)
+NonlinearSystemBase::getNodeDofs(dof_id_type node_id, std::vector<dof_id_type> & dofs)
 {
   const Node & node = _mesh.nodeRef(node_id);
   unsigned int s = number();

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -310,8 +310,8 @@ MooseMesh::prepare(bool force)
 {
   if (dynamic_cast<DistributedMesh *>(&getMesh()) && !_is_nemesis)
   {
-    // Call prepare_for_use() and allow renumbering
-    getMesh().allow_renumbering(true);
+    // Call prepare_for_use() and don't mess with the renumbering
+    // setting
     if (force || _needs_prepare_for_use)
       getMesh().prepare_for_use();
   }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -77,6 +77,9 @@ InputParameters validParams<MooseMesh>()
                              "REPLICATED: Always use libMesh::ReplicatedMesh "
                              "DEFAULT: Use libMesh::ReplicatedMesh unless --distributed-mesh is specified on the command line");
 
+  params.addParam<bool>("allow_renumbering", true,
+                        "If allow_renumbering=false, node and element numbers are kept fixed until deletion");
+
   params.addParam<bool>("nemesis", false,
                         "If nemesis=true and file=foo.e, actually reads "
                         "foo.e.N.0, foo.e.N.1, ... foo.e.N.N-1, "
@@ -216,6 +219,9 @@ MooseMesh::MooseMesh(const InputParameters & parameters) :
   }
   else
     _mesh = libmesh_make_unique<ReplicatedMesh>(_communicator, dim);
+
+  if (!getParam<bool>("allow_renumbering"))
+    _mesh->allow_renumbering(false);
 }
 
 MooseMesh::MooseMesh(const MooseMesh & other_mesh) :

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -98,6 +98,10 @@ OversampleOutput::initOversample()
     mesh_refinement.uniformly_refine(_refinements);
   }
 
+  // We can't allow renumbering if we want to output multiple time
+  // steps to the same Exodus file
+  _mesh_ptr->getMesh().allow_renumbering(false);
+
   // Create the new EquationSystems
   _oversample_es = libmesh_make_unique<EquationSystems>(_mesh_ptr->getMesh());
   _es_ptr = _oversample_es.get();

--- a/test/tests/constraints/equal_value_boundary_constraint/equal_value_boundary_constraint_test.i
+++ b/test/tests/constraints/equal_value_boundary_constraint/equal_value_boundary_constraint_test.i
@@ -13,6 +13,7 @@
   nx = 6
   ny = 6
   elem_type = QUAD4
+  allow_renumbering = false
 []
 
 [Variables]


### PR DESCRIPTION
This upgrades the EqualValueBoundaryConstraint code to work on distributed meshes, and upgrades the code which that code depended on, then upgrades the code which *that* code depended on...

This gets at least one more #1500 test, constraints/equal_value_boundary_constraint, working for me with ---distributed-mesh in parallel.