### PR TITLE
NodalVariableValue fixes for DistributedMesh

### DIFF
--- a/test/tests/misc/check_error/nodal_value_off_block.i
+++ b/test/tests/misc/check_error/nodal_value_off_block.i
@@ -2,6 +2,9 @@
   type = FileMesh
   file = rectangle.e
   dim = 2
+  # This test can only be run with renumering disabled, so the
+  # NodalVariableValue postprocessor's node id is well-defined.
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/postprocessors/nodal_var_value/nodal_aux_var_value.i
+++ b/test/tests/postprocessors/nodal_var_value/nodal_aux_var_value.i
@@ -8,11 +8,9 @@
   ymin = 0
   ymax = 1
   elem_type = QUAD4
-  # This test can only be run with ReplicatedMesh since, in parallel with
-  # DistributedMesh, the nodes get renumbered and thus the
-  # NodalVariableValue postprocessor's output is necessarily
-  # different.
-  parallel_type = replicated
+  # This test can only be run with renumering disabled, so the
+  # NodalVariableValue postprocessor's node id is well-defined.
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/postprocessors/nodal_var_value/nodal_var_value.i
+++ b/test/tests/postprocessors/nodal_var_value/nodal_var_value.i
@@ -1,8 +1,7 @@
 [Mesh]
   file = square-2x2-nodeids.e
-  # This test uses a NodalVariableValue postprocessor, which
-  # only works with ReplicatedMesh
-  parallel_type = replicated
+  # NodalVariableValue is not safe on renumbered meshes
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/postprocessors/nodal_var_value/pps_output_test.i
+++ b/test/tests/postprocessors/nodal_var_value/pps_output_test.i
@@ -1,8 +1,8 @@
 [Mesh]
   file = square-2x2-nodeids.e
-  # This test uses a NodalVariableValue postprocessor, which
-  # only works with ReplicatedMesh
-  parallel_type = replicated
+  # This test can only be run with renumering disabled, so the
+  # NodalVariableValue postprocessor's node id is well-defined.
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/postprocessors/nodal_var_value/screen_output_test.i
+++ b/test/tests/postprocessors/nodal_var_value/screen_output_test.i
@@ -1,8 +1,8 @@
 [Mesh]
   file = square-2x2-nodeids.e
-  # This test uses a NodalVariableValue postprocessor, which
-  # only works with ReplicatedMesh
-  parallel_type = replicated
+  # This test can only be run with renumering disabled, so the
+  # NodalVariableValue postprocessor's node id is well-defined.
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/postprocessors/pps_interval/pps_bad_interval2.i
+++ b/test/tests/postprocessors/pps_interval/pps_bad_interval2.i
@@ -1,8 +1,8 @@
 [Mesh]
   file = square-2x2-nodeids.e
-  # This test uses a NodalVariableValue postprocessor, which
-  # only works with ReplicatedMesh
-  parallel_type = replicated
+  # This test can only be run with renumering disabled, so the
+  # NodalVariableValue postprocessor's node id is well-defined.
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/postprocessors/pps_interval/pps_bad_interval3.i
+++ b/test/tests/postprocessors/pps_interval/pps_bad_interval3.i
@@ -1,8 +1,8 @@
 [Mesh]
   file = square-2x2-nodeids.e
-  # This test uses a NodalVariableValue postprocessor, which
-  # only works with ReplicatedMesh
-  parallel_type = replicated
+  # This test can only be run with renumering disabled, so the
+  # NodalVariableValue postprocessor's node id is well-defined.
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/postprocessors/pps_interval/pps_interval_mismatch.i
+++ b/test/tests/postprocessors/pps_interval/pps_interval_mismatch.i
@@ -1,8 +1,8 @@
 [Mesh]
   file = square-2x2-nodeids.e
-  # This test uses a NodalVariableValue postprocessor, which
-  # only works with ReplicatedMesh
-  parallel_type = replicated
+  # This test can only be run with renumering disabled, so the
+  # NodalVariableValue postprocessor's node id is well-defined.
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/postprocessors/pps_interval/pps_out_interval.i
+++ b/test/tests/postprocessors/pps_interval/pps_out_interval.i
@@ -1,8 +1,8 @@
 [Mesh]
   file = square-2x2-nodeids.e
-  # This test uses a NodalVariableValue postprocessor, which
-  # only works with ReplicatedMesh
-  parallel_type = replicated
+  # This test can only be run with renumering disabled, so the
+  # NodalVariableValue postprocessor's node id is well-defined.
+  allow_renumbering = false
 []
 
 [Variables]


### PR DESCRIPTION
We just need to take a little care with the code (not all
query_node_ptr calls will succeed, and that's okay so long as *one*
does) and with the configuration (distributed or not, we can't safely
renumber ids if the user is specifying their QoI by id), and now a
bunch more #1500 --distributed-mesh tests work.