### PR TITLE
Fix PBS relaunch issue

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -474,6 +474,9 @@ class TestHarness:
             for job in batch_list:
                 file = '/'.join(job[2].split('/')[:-2]) + '/' + job[3]
 
+                # Populate the input_file_name argument so augmentParameters can format the test_name
+                self.options.input_file_name = job[-1]
+
                 # Build a Warehouse to hold the MooseObjects
                 warehouse = Warehouse()
 


### PR DESCRIPTION
When launching the TestHarness with PBS options a first time, supplying
an input file other than the default "tests", test_name no longer
matches when launching the TestHarness a second time with out suppling
the same input file argument. eg:
```bash
./run_tests --pbs -i examples
```
succeeded at launching all jobs and correctly concludes a status report.
```bash
./run_tests --pbs <pbs_file>
```
fails to find any jobs, because all the test_names are preceded by
'examples/' in their names.

Refs: #8706