### PR TITLE
DistributedMesh OversampleOutput

### DIFF
--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -40,7 +40,7 @@ InputParameters validParams<OversampleOutput>();
  * changes to the libMesh::EquationsSystems() pointer (_es_ptr), i.e., this pointer is
  * will point to the oversampled system, if oversamping is utilized.
  *
- * Additionally, the class adds a pointer the the mesh object (_mesh_ptr) that again
+ * Additionally, the class adds a pointer to the mesh object (_mesh_ptr) that again
  * points to the correct mesh depending on the use of oversampling.
  *
  * The use of oversampling is triggered by setting the oversample input parameter to a

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2223,7 +2223,13 @@ MooseMesh::ghostGhostedBoundaries()
 
   DistributedMesh & mesh = dynamic_cast<DistributedMesh &>(getMesh());
 
-  mesh.clear_extra_ghost_elems();
+  // We would like to clear ghosted elements that were added by
+  // previous invocations of this method; however we can't do so
+  // simply without also clearing ghosted elements that were added by
+  // other code; e.g.  OversampleOutput.  So for now we'll just
+  // swallow the inefficiency that can come from leaving unnecessary
+  // elements ghosted after AMR.
+//  mesh.clear_extra_ghost_elems();
 
   mesh.get_boundary_info().build_side_list(elems, sides, ids);
 

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -95,6 +95,10 @@ OversampleOutput::initOversample()
   if (_oversample)
   {
     MeshRefinement mesh_refinement(_mesh_ptr->getMesh());
+
+    // We want original and refined partitioning to match so we can
+    // query from one to the other safely on distributed meshes.
+    _mesh_ptr->getMesh().skip_partitioning(true);
     mesh_refinement.uniformly_refine(_refinements);
   }
 

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -20,6 +20,7 @@
 #include "MooseApp.h"
 
 // libMesh includes
+#include "libmesh/distributed_mesh.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/mesh_function.h"
 

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -198,6 +198,8 @@ OversampleOutput::updateOversample()
         for (unsigned int var_num = 0; var_num < _mesh_functions[sys_num].size(); ++var_num)
           if ((*nd)->n_dofs(sys_num, var_num))
             dest_sys.solution->set((*nd)->dof_number(sys_num, var_num, 0), (*_mesh_functions[sys_num][var_num])(**nd - _position)); // 0 value is for component
+
+      dest_sys.solution->close();
     }
   }
 

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -113,6 +113,24 @@ OversampleOutput::initOversample()
   // Reference the system from which we are copying
   EquationSystems & source_es = _problem_ptr->es();
 
+  // If we're going to be copying from that system later, we need to keep its
+  // original elements as ghost elements even if it gets grossly
+  // repartitioned, since we can't repartition the oversample mesh to
+  // match.
+  DistributedMesh * dist_mesh = dynamic_cast<DistributedMesh *>(&source_es.get_mesh());
+  if (dist_mesh)
+  {
+    for (MeshBase::element_iterator
+           it = dist_mesh->active_local_elements_begin(),
+           end = dist_mesh->active_local_elements_end();
+         it != end; ++it)
+    {
+      Elem * elem = *it;
+
+      dist_mesh->add_extra_ghost_elem(elem);
+    }
+  }
+
   // Initialize the _mesh_functions vector
   unsigned int num_systems = source_es.n_systems();
   _mesh_functions.resize(num_systems);


### PR DESCRIPTION
This, along with the changes in https://github.com/libMesh/libmesh/pull/1280 (as well as a ton of already-merged PRs), appears to be enough to get the OversampleOutput feature working for me with DistributedMesh.

OversampleOutput still definitely *won't* scale well; for that we need to also replace the serial solution vector with a custom send_list ghosted vector.  But this gets us correctness; we can work on efficiency later.