### PR TITLE
Nearest node error

### DIFF
--- a/framework/src/geomsearch/NearestNodeThread.C
+++ b/framework/src/geomsearch/NearestNodeThread.C
@@ -18,6 +18,8 @@
 // libmesh includes
 #include "libmesh/threads.h"
 
+#include <cmath>
+
 NearestNodeThread::NearestNodeThread(const MooseMesh & mesh,
                                      std::map<dof_id_type, std::vector<dof_id_type> > & neighbor_nodes) :
   _max_patch_percentage(0.0),
@@ -72,7 +74,17 @@ NearestNodeThread::operator() (const NodeIdRange & range)
     }
 
     if (closest_distance == std::numeric_limits<Real>::max())
+    {
+      for (unsigned int k=0; k<n_neighbor_nodes; k++)
+      {
+        const Node * cur_node = &_mesh.nodeRef(neighbor_nodes[k]);
+        if (isnan((*cur_node)(0)) ||
+            isnan((*cur_node)(1)) ||
+            isnan((*cur_node)(2)))
+          mooseError("Failure in NearestNodeThread because solution contans not-a-number entries");
+      }
       mooseError("Unable to find nearest node!");
+    }
 
     NearestNodeLocator::NearestNodeInfo & info = _nearest_node_info[node.id()];
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
@@ -8,7 +8,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    prereq = 'glued_kin_sm'
+    #prereq = 'glued_kin_sm' #the prereq test is also skipped
     skip = 'Reevaluate under PETSc 3.7.4. #8200'
   [../]
   [./glued_pen]
@@ -86,6 +86,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
+    skip = 'Reevaluate under PETSc 3.7.4. #8200'
   [../]
   [./glued_pen_sm]
     type = 'CSVDiff'


### PR DESCRIPTION
Add a more descriptive error when the geometric search encounters nans.
Skip another test that is failing on PETSc 3.7.4

ref #8200