### PR TITLE
Disable valgrind for PythonUnitTest

### DIFF
--- a/python/TestHarness/testers/PythonUnitTest.py
+++ b/python/TestHarness/testers/PythonUnitTest.py
@@ -12,6 +12,7 @@ class PythonUnitTest(RunApp):
         params.addParam('separate', False, "Run each test in the file in a separate subprocess")
         # We don't want to check for any errors on the screen with unit tests
         params['errors'] = []
+        params['valgrind'] = 'NONE'
         return params
 
     def __init__(self, name, params):

--- a/python/TestHarness/testers/PythonUnitTest.py
+++ b/python/TestHarness/testers/PythonUnitTest.py
@@ -13,6 +13,7 @@ class PythonUnitTest(RunApp):
         # We don't want to check for any errors on the screen with unit tests
         params['errors'] = []
         params['valgrind'] = 'NONE'
+        params['recover'] = False
         return params
 
     def __init__(self, name, params):

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -108,6 +108,5 @@
   [./json]
     type = 'PythonUnitTest'
     input = 'test_json.py'
-    recover = false
   [../]
 []


### PR DESCRIPTION
Apparently the `PythonUnitTest` doesn't run well under valgrind because the test harness is looking
for an `ERROR SUMMARY` in the output.
This disables valgrind testing for all `PythonUnitTest` tests.