### PR TITLE
deprecate and remove declarePropertyOld (from modules)

### DIFF
--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -360,6 +360,8 @@ template <typename T>
 MaterialProperty<T> &
 Material::declarePropertyOld(const std::string & prop_name)
 {
+  mooseDoOnce(mooseDeprecated("declarePropertyOld is deprecated and not needed anymore.\nUse "
+                              "getPropertyOld (only) if a reference is required in this class."));
   registerPropName(prop_name, false, Material::OLD);
   return _material_data->declarePropertyOld<T>(prop_name);
 }
@@ -368,6 +370,8 @@ template <typename T>
 MaterialProperty<T> &
 Material::declarePropertyOlder(const std::string & prop_name)
 {
+  mooseDoOnce(mooseDeprecated("declarePropertyOlder is deprecated and not needed anymore.  Use "
+                              "getPropertyOlder (only) if a reference is required in this class."));
   registerPropName(prop_name, false, Material::OLDER);
   return _material_data->declarePropertyOlder<T>(prop_name);
 }

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -139,6 +139,13 @@ public:
   TypeVector<Real> column(const unsigned int c) const;
 
   /**
+   * Returns a rotated version of the tensor data given a rank two tensor rotation tensor
+   * _vals[i][j] = R_ij * R_jl * _vals[k][l]
+   * @param R rotation matrix as a RealTensorValue
+   */
+  RankTwoTensor rotated(const RealTensorValue & R) const;
+
+  /**
    * rotates the tensor data given a rank two tensor rotation tensor
    * _vals[i][j] = R_ij * R_jl * _vals[k][l]
    * @param R rotation matrix as a RealTensorValue

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -227,6 +227,14 @@ RankTwoTensor::column(const unsigned int c) const
   return result;
 }
 
+RankTwoTensor
+RankTwoTensor::rotated(const RealTensorValue & R) const
+{
+  RankTwoTensor result(*this);
+  result.rotate(R);
+  return result;
+}
+
 void
 RankTwoTensor::rotate(const RealTensorValue & R)
 {

--- a/modules/misc/include/Density.h
+++ b/modules/misc/include/Density.h
@@ -28,7 +28,6 @@ protected:
 
   const Real _orig_density;
   MaterialProperty<Real> & _density;
-  MaterialProperty<Real> & _density_old;
 };
 
 template <>

--- a/modules/misc/src/Density.C
+++ b/modules/misc/src/Density.C
@@ -33,8 +33,7 @@ Density::Density(const InputParameters & parameters)
     _disp_r(isCoupled("displacements") ? coupledValue("displacements", 0)
                                        : (isCoupled("disp_r") ? coupledValue("disp_r") : _zero)),
     _orig_density(getParam<Real>("density")),
-    _density(declareProperty<Real>("density")),
-    _density_old(declarePropertyOld<Real>("density"))
+    _density(declareProperty<Real>("density"))
 {
   // new parameter scheme
   if (isCoupled("displacements"))

--- a/modules/richards/include/materials/PoroFullSatMaterial.h
+++ b/modules/richards/include/materials/PoroFullSatMaterial.h
@@ -59,9 +59,6 @@ protected:
   /// volumetric strain = strain_ii
   MaterialProperty<Real> & _vol_strain;
 
-  /// old value of volumetric strain
-  MaterialProperty<Real> & _vol_strain_old;
-
   /// Biot coefficient
   MaterialProperty<Real> & _biot_coefficient;
 

--- a/modules/richards/src/materials/PoroFullSatMaterial.C
+++ b/modules/richards/src/materials/PoroFullSatMaterial.C
@@ -54,7 +54,6 @@ PoroFullSatMaterial::PoroFullSatMaterial(const InputParameters & parameters)
     _grad_disp(_ndisp),
 
     _vol_strain(declareProperty<Real>("volumetric_strain")),
-    _vol_strain_old(declarePropertyOld<Real>("volumetric_strain")),
 
     _biot_coefficient(declareProperty<Real>("biot_coefficient")),
 

--- a/modules/solid_mechanics/include/materials/CLSHPlasticModel.h
+++ b/modules/solid_mechanics/include/materials/CLSHPlasticModel.h
@@ -38,9 +38,9 @@ protected:
   Real _xphidp;
 
   MaterialProperty<Real> & _hardening_variable;
-  MaterialProperty<Real> & _hardening_variable_old;
+  const MaterialProperty<Real> & _hardening_variable_old;
   MaterialProperty<SymmTensor> & _plastic_strain;
-  MaterialProperty<SymmTensor> & _plastic_strain_old;
+  const MaterialProperty<SymmTensor> & _plastic_strain_old;
 };
 
 template <>

--- a/modules/solid_mechanics/include/materials/IsotropicPlasticity.h
+++ b/modules/solid_mechanics/include/materials/IsotropicPlasticity.h
@@ -44,10 +44,10 @@ protected:
   Real _hardening_slope;
 
   MaterialProperty<SymmTensor> & _plastic_strain;
-  MaterialProperty<SymmTensor> & _plastic_strain_old;
+  const MaterialProperty<SymmTensor> & _plastic_strain_old;
 
   MaterialProperty<Real> & _hardening_variable;
-  MaterialProperty<Real> & _hardening_variable_old;
+  const MaterialProperty<Real> & _hardening_variable_old;
 };
 
 template <>

--- a/modules/solid_mechanics/include/materials/PLC_LSH.h
+++ b/modules/solid_mechanics/include/materials/PLC_LSH.h
@@ -46,13 +46,13 @@ protected:
   Real _absolute_stress_tolerance;
 
   MaterialProperty<SymmTensor> & _creep_strain;
-  MaterialProperty<SymmTensor> & _creep_strain_old;
+  const MaterialProperty<SymmTensor> & _creep_strain_old;
 
   MaterialProperty<SymmTensor> & _plastic_strain;
-  MaterialProperty<SymmTensor> & _plastic_strain_old;
+  const MaterialProperty<SymmTensor> & _plastic_strain_old;
 
   MaterialProperty<Real> & _hardening_variable;
-  MaterialProperty<Real> & _hardening_variable_old;
+  const MaterialProperty<Real> & _hardening_variable_old;
 
   const PostprocessorValue * const _output;
 

--- a/modules/solid_mechanics/include/materials/PowerLawCreepModel.h
+++ b/modules/solid_mechanics/include/materials/PowerLawCreepModel.h
@@ -37,7 +37,7 @@ protected:
   Real _expTime;
 
   MaterialProperty<SymmTensor> & _creep_strain;
-  MaterialProperty<SymmTensor> & _creep_strain_old;
+  const MaterialProperty<SymmTensor> & _creep_strain_old;
 
 private:
 };

--- a/modules/solid_mechanics/include/materials/RateDepSmearCrackModel.h
+++ b/modules/solid_mechanics/include/materials/RateDepSmearCrackModel.h
@@ -104,10 +104,10 @@ protected:
   Real _rndm_scale_var;       ///Variable value
 
   MaterialProperty<std::vector<Real>> & _intvar;
-  MaterialProperty<std::vector<Real>> & _intvar_old;
+  const MaterialProperty<std::vector<Real>> & _intvar_old;
 
   MaterialProperty<SymmTensor> & _stress_undamaged;
-  MaterialProperty<SymmTensor> & _stress_undamaged_old;
+  const MaterialProperty<SymmTensor> & _stress_undamaged_old;
 
   std::vector<Real> _intvar_incr;
   std::vector<Real> _intvar_tmp, _intvar_old_tmp;
@@ -118,7 +118,7 @@ protected:
   SymmElasticityTensor _elasticity;
   SymmTensor _stress_old, _dstrain, _stress_new;
   SymmTensor _stress0, _dstress0;
-  bool _nconv; ///Convergence flag
+  bool _nconv;   ///Convergence flag
   bool _err_tol; ///Flag to indicate that increment size has exceeded tolerance and needs cutback
 
 private:

--- a/modules/solid_mechanics/include/materials/RateDepSmearIsoCrackModel.h
+++ b/modules/solid_mechanics/include/materials/RateDepSmearIsoCrackModel.h
@@ -41,7 +41,7 @@ protected:
   Real _upper_lim_damage;
 
   MaterialProperty<Real> & _energy;
-  MaterialProperty<Real> & _energy_old;
+  const MaterialProperty<Real> & _energy_old;
 
   Real _ddamage;
   Real _ddamagerate_drs;

--- a/modules/solid_mechanics/include/materials/ReturnMappingModel.h
+++ b/modules/solid_mechanics/include/materials/ReturnMappingModel.h
@@ -81,7 +81,7 @@ protected:
   Real _three_shear_modulus;
 
   MaterialProperty<Real> & _effective_inelastic_strain;
-  MaterialProperty<Real> & _effective_inelastic_strain_old;
+  const MaterialProperty<Real> & _effective_inelastic_strain_old;
   Real _max_inelastic_increment;
 };
 

--- a/modules/solid_mechanics/include/materials/SolidModel.h
+++ b/modules/solid_mechanics/include/materials/SolidModel.h
@@ -105,32 +105,31 @@ protected:
   MaterialProperty<SymmTensor> & _stress;
 
 private:
-  MaterialProperty<SymmTensor> & _stress_old_prop;
+  const MaterialProperty<SymmTensor> & _stress_old_prop;
 
 protected:
   SymmTensor _stress_old;
 
   MaterialProperty<SymmTensor> & _total_strain;
-  MaterialProperty<SymmTensor> & _total_strain_old;
+  const MaterialProperty<SymmTensor> & _total_strain_old;
 
   MaterialProperty<SymmTensor> & _elastic_strain;
-  MaterialProperty<SymmTensor> & _elastic_strain_old;
+  const MaterialProperty<SymmTensor> & _elastic_strain_old;
 
   MaterialProperty<RealVectorValue> * _crack_flags;
-  MaterialProperty<RealVectorValue> * _crack_flags_old;
+  const MaterialProperty<RealVectorValue> * _crack_flags_old;
   RealVectorValue _crack_flags_local;
   MaterialProperty<RealVectorValue> * _crack_count;
-  MaterialProperty<RealVectorValue> * _crack_count_old;
+  const MaterialProperty<RealVectorValue> * _crack_count_old;
   MaterialProperty<ColumnMajorMatrix> * _crack_rotation;
-  MaterialProperty<ColumnMajorMatrix> * _crack_rotation_old;
+  const MaterialProperty<ColumnMajorMatrix> * _crack_rotation_old;
   MaterialProperty<RealVectorValue> * _crack_strain;
-  MaterialProperty<RealVectorValue> * _crack_strain_old;
+  const MaterialProperty<RealVectorValue> * _crack_strain_old;
   MaterialProperty<RealVectorValue> * _crack_max_strain;
-  MaterialProperty<RealVectorValue> * _crack_max_strain_old;
+  const MaterialProperty<RealVectorValue> * _crack_max_strain_old;
   ColumnMajorMatrix _principal_strain;
 
   MaterialProperty<SymmElasticityTensor> & _elasticity_tensor;
-  MaterialProperty<SymmElasticityTensor> & _elasticity_tensor_old;
   MaterialProperty<SymmElasticityTensor> & _Jacobian_mult;
 
   // Accumulate derivatives of strain tensors with respect to Temperature into this
@@ -148,7 +147,7 @@ protected:
 
   // These are used in calculation of the J integral
   MaterialProperty<Real> * _SED;
-  MaterialProperty<Real> * _SED_old;
+  const MaterialProperty<Real> * _SED_old;
   MaterialProperty<ColumnMajorMatrix> * _Eshelby_tensor;
   MaterialProperty<RealVectorValue> * _J_thermal_term_vec;
 
@@ -228,10 +227,10 @@ protected:
   }
 
   template <typename T>
-  MaterialProperty<T> & createPropertyOld(const std::string & prop_name)
+  const MaterialProperty<T> & getPropertyOld(const std::string & prop_name)
   {
     std::string name(prop_name + _appended_property_name);
-    return declarePropertyOld<T>(name);
+    return getMaterialPropertyOld<T>(name);
   }
 
   virtual void checkElasticConstants();

--- a/modules/solid_mechanics/include/materials/abaqus/AbaqusCreepMaterial.h
+++ b/modules/solid_mechanics/include/materials/abaqus/AbaqusCreepMaterial.h
@@ -81,23 +81,23 @@ protected:
   void computeStress();
 
   MaterialProperty<std::vector<Real>> & _state_var;
-  MaterialProperty<std::vector<Real>> & _state_var_old;
+  const MaterialProperty<std::vector<Real>> & _state_var_old;
   MaterialProperty<SymmTensor> & _trial_stress;
-  MaterialProperty<SymmTensor> & _trial_stress_old;
+  const MaterialProperty<SymmTensor> & _trial_stress_old;
   MaterialProperty<SymmTensor> & _dev_trial_stress;
-  MaterialProperty<SymmTensor> & _dev_trial_stress_old;
+  const MaterialProperty<SymmTensor> & _dev_trial_stress_old;
   MaterialProperty<Real> & _ets;
-  MaterialProperty<Real> & _ets_old;
+  const MaterialProperty<Real> & _ets_old;
   MaterialProperty<SymmTensor> & _stress;
-  MaterialProperty<SymmTensor> & _stress_old;
+  const MaterialProperty<SymmTensor> & _stress_old;
   MaterialProperty<Real> & _creep_inc;
-  MaterialProperty<Real> & _creep_inc_old;
+  const MaterialProperty<Real> & _creep_inc_old;
   MaterialProperty<Real> & _total_creep;
-  MaterialProperty<Real> & _total_creep_old;
+  const MaterialProperty<Real> & _total_creep_old;
   MaterialProperty<Real> & _swell_inc;
-  MaterialProperty<Real> & _swell_inc_old;
+  const MaterialProperty<Real> & _swell_inc_old;
   MaterialProperty<Real> & _total_swell;
-  MaterialProperty<Real> & _total_swell_old;
+  const MaterialProperty<Real> & _total_swell_old;
 };
 
 #endif // ABAQUSCREEPMATERIAL_H

--- a/modules/solid_mechanics/include/materials/abaqus/AbaqusUmatMaterial.h
+++ b/modules/solid_mechanics/include/materials/abaqus/AbaqusUmatMaterial.h
@@ -93,9 +93,9 @@ protected:
   const VariableGradient & _grad_disp_y_old;
   const VariableGradient & _grad_disp_z_old;
   MaterialProperty<std::vector<Real>> & _state_var;
-  MaterialProperty<std::vector<Real>> & _state_var_old;
+  const MaterialProperty<std::vector<Real>> & _state_var_old;
   MaterialProperty<ColumnMajorMatrix> & _Fbar;
-  MaterialProperty<ColumnMajorMatrix> & _Fbar_old;
+  const MaterialProperty<ColumnMajorMatrix> & _Fbar_old;
   MaterialProperty<Real> & _elastic_strain_energy;
   MaterialProperty<Real> & _plastic_dissipation;
   MaterialProperty<Real> & _creep_dissipation;

--- a/modules/solid_mechanics/include/materials/total_strain/SolidMechanicsMaterial.h
+++ b/modules/solid_mechanics/include/materials/total_strain/SolidMechanicsMaterial.h
@@ -60,10 +60,10 @@ protected:
   }
 
   template <typename T>
-  MaterialProperty<T> & createPropertyOld(const std::string & prop_name)
+  const MaterialProperty<T> & getPropertyOld(const std::string & prop_name)
   {
     std::string name(prop_name + _appended_property_name);
-    return declarePropertyOld<T>(name);
+    return getMaterialPropertyOld<T>(name);
   }
 };
 

--- a/modules/solid_mechanics/src/materials/CLSHPlasticModel.C
+++ b/modules/solid_mechanics/src/materials/CLSHPlasticModel.C
@@ -29,9 +29,9 @@ CLSHPlasticModel::CLSHPlasticModel(const InputParameters & parameters)
     _c_alpha(parameters.get<Real>("c_alpha")),
     _c_beta(parameters.get<Real>("c_beta")),
     _hardening_variable(declareProperty<Real>("hardening_variable")),
-    _hardening_variable_old(declarePropertyOld<Real>("hardening_variable")),
+    _hardening_variable_old(getMaterialPropertyOld<Real>("hardening_variable")),
     _plastic_strain(declareProperty<SymmTensor>("plastic_strain")),
-    _plastic_strain_old(declarePropertyOld<SymmTensor>("plastic_strain"))
+    _plastic_strain_old(getMaterialPropertyOld<SymmTensor>("plastic_strain"))
 {
 }
 
@@ -39,7 +39,6 @@ void
 CLSHPlasticModel::initQpStatefulProperties()
 {
   _hardening_variable[_qp] = 0;
-  _hardening_variable_old[_qp] = 0;
   ReturnMappingModel::initQpStatefulProperties();
 }
 

--- a/modules/solid_mechanics/src/materials/IsotropicPlasticity.C
+++ b/modules/solid_mechanics/src/materials/IsotropicPlasticity.C
@@ -39,10 +39,10 @@ IsotropicPlasticity::IsotropicPlasticity(const InputParameters & parameters)
                             : NULL),
 
     _plastic_strain(declareProperty<SymmTensor>("plastic_strain")),
-    _plastic_strain_old(declarePropertyOld<SymmTensor>("plastic_strain")),
+    _plastic_strain_old(getMaterialPropertyOld<SymmTensor>("plastic_strain")),
 
     _hardening_variable(declareProperty<Real>("hardening_variable")),
-    _hardening_variable_old(declarePropertyOld<Real>("hardening_variable"))
+    _hardening_variable_old(getMaterialPropertyOld<Real>("hardening_variable"))
 {
   if (isParamValid("yield_stress") && _yield_stress <= 0)
     mooseError("Yield stress must be greater than zero");

--- a/modules/solid_mechanics/src/materials/PLC_LSH.C
+++ b/modules/solid_mechanics/src/materials/PLC_LSH.C
@@ -64,13 +64,13 @@ PLC_LSH::PLC_LSH(const InputParameters & parameters)
     _absolute_stress_tolerance(parameters.get<Real>("absolute_stress_tolerance")),
 
     _creep_strain(declareProperty<SymmTensor>("creep_strain")),
-    _creep_strain_old(declarePropertyOld<SymmTensor>("creep_strain")),
+    _creep_strain_old(getMaterialPropertyOld<SymmTensor>("creep_strain")),
 
     _plastic_strain(declareProperty<SymmTensor>("plastic_strain")),
-    _plastic_strain_old(declarePropertyOld<SymmTensor>("plastic_strain")),
+    _plastic_strain_old(getMaterialPropertyOld<SymmTensor>("plastic_strain")),
 
     _hardening_variable(declareProperty<Real>("hardening_variable")),
-    _hardening_variable_old(declarePropertyOld<Real>("hardening_variable")),
+    _hardening_variable_old(getMaterialPropertyOld<Real>("hardening_variable")),
 
     _output(getParam<PostprocessorName>("output") != "" ? &getPostprocessorValue("output") : NULL)
 
@@ -84,7 +84,7 @@ PLC_LSH::PLC_LSH(const InputParameters & parameters)
 void
 PLC_LSH::initQpStatefulProperties()
 {
-  _hardening_variable[_qp] = _hardening_variable_old[_qp] = 0;
+  _hardening_variable[_qp] = 0;
   SolidModel::initQpStatefulProperties();
 }
 

--- a/modules/solid_mechanics/src/materials/PowerLawCreepModel.C
+++ b/modules/solid_mechanics/src/materials/PowerLawCreepModel.C
@@ -35,7 +35,7 @@ PowerLawCreepModel::PowerLawCreepModel(const InputParameters & parameters)
     _gas_constant(parameters.get<Real>("gas_constant")),
     _start_time(getParam<Real>("start_time")),
     _creep_strain(declareProperty<SymmTensor>("creep_strain")),
-    _creep_strain_old(declarePropertyOld<SymmTensor>("creep_strain"))
+    _creep_strain_old(getMaterialPropertyOld<SymmTensor>("creep_strain"))
 {
 }
 

--- a/modules/solid_mechanics/src/materials/RateDepSmearCrackModel.C
+++ b/modules/solid_mechanics/src/materials/RateDepSmearCrackModel.C
@@ -45,9 +45,9 @@ RateDepSmearCrackModel::RateDepSmearCrackModel(const InputParameters & parameter
     _input_rndm_scale_var(getParam<bool>("input_random_scaling_var")),
     _rndm_scale_var(getParam<Real>("random_scaling_var")),
     _intvar(declareProperty<std::vector<Real>>("intvar")),
-    _intvar_old(declarePropertyOld<std::vector<Real>>("intvar")),
+    _intvar_old(getMaterialPropertyOld<std::vector<Real>>("intvar")),
     _stress_undamaged(declareProperty<SymmTensor>("stress_undamaged")),
-    _stress_undamaged_old(declarePropertyOld<SymmTensor>("stress_undamaged"))
+    _stress_undamaged_old(getMaterialPropertyOld<SymmTensor>("stress_undamaged"))
 {
 
   _intvar_incr.resize(_nstate, 0.0);
@@ -64,7 +64,7 @@ void
 RateDepSmearCrackModel::initQpStatefulProperties()
 {
   _intvar[_qp].resize(_nstate, 0.0);
-  _intvar_old[_qp].resize(_nstate, 0.0);
+  const_cast<MaterialProperty<std::vector<Real>> &>(_intvar_old)[_qp].resize(_nstate, 0.0);
 }
 
 void

--- a/modules/solid_mechanics/src/materials/RateDepSmearIsoCrackModel.C
+++ b/modules/solid_mechanics/src/materials/RateDepSmearIsoCrackModel.C
@@ -28,7 +28,7 @@ RateDepSmearIsoCrackModel::RateDepSmearIsoCrackModel(const InputParameters & par
     _kfail(getParam<Real>("k_fail")),
     _upper_lim_damage(getParam<Real>("upper_limit_damage")),
     _energy(declareProperty<Real>("energy")),
-    _energy_old(declarePropertyOld<Real>("energy"))
+    _energy_old(getMaterialPropertyOld<Real>("energy"))
 {
 
   if (_nstate != 2)
@@ -40,10 +40,10 @@ RateDepSmearIsoCrackModel::initQpStatefulProperties()
 {
   RateDepSmearCrackModel::initQpStatefulProperties();
 
-  _intvar[_qp][1] = _intvar_old[_qp][1] = _crit_energy;
+  _intvar[_qp][1] = const_cast<MaterialProperty<std::vector<Real>> &>(_intvar_old)[_qp][1] =
+      _crit_energy;
 
   _energy[_qp] = 0.0;
-  _energy_old[_qp] = 0.0;
 }
 
 void

--- a/modules/solid_mechanics/src/materials/ReturnMappingModel.C
+++ b/modules/solid_mechanics/src/materials/ReturnMappingModel.C
@@ -29,7 +29,7 @@ ReturnMappingModel::ReturnMappingModel(const InputParameters & parameters,
     _effective_inelastic_strain(
         declareProperty<Real>("effective_" + inelastic_strain_name + "_strain")),
     _effective_inelastic_strain_old(
-        declarePropertyOld<Real>("effective_" + inelastic_strain_name + "_strain")),
+        getMaterialPropertyOld<Real>("effective_" + inelastic_strain_name + "_strain")),
     _max_inelastic_increment(parameters.get<Real>("max_inelastic_increment"))
 {
 }

--- a/modules/solid_mechanics/src/materials/abaqus/AbaqusCreepMaterial.C
+++ b/modules/solid_mechanics/src/materials/abaqus/AbaqusCreepMaterial.C
@@ -47,23 +47,23 @@ AbaqusCreepMaterial::AbaqusCreepMaterial(const InputParameters & parameters)
     _solve_definition(getParam<unsigned int>("solve_definition")),
     _routine_flag(getParam<unsigned int>("routine_flag")),
     _state_var(declareProperty<std::vector<Real>>("state_var")),
-    _state_var_old(declarePropertyOld<std::vector<Real>>("state_var")),
+    _state_var_old(getMaterialPropertyOld<std::vector<Real>>("state_var")),
     _trial_stress(declareProperty<SymmTensor>("trial_stress")),
-    _trial_stress_old(declarePropertyOld<SymmTensor>("trial_stress")),
+    _trial_stress_old(getMaterialPropertyOld<SymmTensor>("trial_stress")),
     _dev_trial_stress(declareProperty<SymmTensor>("dev_trial_stress")),
-    _dev_trial_stress_old(declarePropertyOld<SymmTensor>("dev_trial_stress")),
+    _dev_trial_stress_old(getMaterialPropertyOld<SymmTensor>("dev_trial_stress")),
     _ets(declareProperty<Real>("effective_trial_stress")),
-    _ets_old(declarePropertyOld<Real>("effective_trial_stress")),
+    _ets_old(getMaterialPropertyOld<Real>("effective_trial_stress")),
     _stress(declareProperty<SymmTensor>("stress")),
-    _stress_old(declarePropertyOld<SymmTensor>("stress")),
+    _stress_old(getMaterialPropertyOld<SymmTensor>("stress")),
     _creep_inc(declareProperty<Real>("creep_inc")),
-    _creep_inc_old(declarePropertyOld<Real>("creep_inc")),
+    _creep_inc_old(getMaterialPropertyOld<Real>("creep_inc")),
     _total_creep(declareProperty<Real>("total_creep")),
-    _total_creep_old(declarePropertyOld<Real>("total_creep")),
+    _total_creep_old(getMaterialPropertyOld<Real>("total_creep")),
     _swell_inc(declareProperty<Real>("swell_inc")),
-    _swell_inc_old(declarePropertyOld<Real>("swell_inc")),
+    _swell_inc_old(getMaterialPropertyOld<Real>("swell_inc")),
     _total_swell(declareProperty<Real>("total_swell")),
-    _total_swell_old(declarePropertyOld<Real>("total_swell"))
+    _total_swell_old(getMaterialPropertyOld<Real>("total_swell"))
 {
 #if defined(METHOD)
   _plugin += std::string("-") + QUOTE(METHOD) + ".plugin";
@@ -131,11 +131,9 @@ AbaqusCreepMaterial::initStatefulProperties(unsigned n_points)
   {
     // Initialize state variable vector
     _state_var[qp].resize(_num_state_vars);
-    _state_var_old[qp].resize(_num_state_vars);
     for (unsigned int i = 0; i < _num_state_vars; i++)
     {
       _state_var[qp][i] = 0.0;
-      _state_var_old[qp][i] = 0.0;
     }
   }
 }

--- a/modules/solid_mechanics/src/materials/abaqus/AbaqusUmatMaterial.C
+++ b/modules/solid_mechanics/src/materials/abaqus/AbaqusUmatMaterial.C
@@ -40,9 +40,9 @@ AbaqusUmatMaterial::AbaqusUmatMaterial(const InputParameters & parameters)
     _grad_disp_y_old(coupledGradientOld("disp_y")),
     _grad_disp_z_old(coupledGradientOld("disp_z")),
     _state_var(declareProperty<std::vector<Real>>("state_var")),
-    _state_var_old(declarePropertyOld<std::vector<Real>>("state_var")),
+    _state_var_old(getMaterialPropertyOld<std::vector<Real>>("state_var")),
     _Fbar(declareProperty<ColumnMajorMatrix>("Fbar")),
-    _Fbar_old(declarePropertyOld<ColumnMajorMatrix>("Fbar")),
+    _Fbar_old(getMaterialPropertyOld<ColumnMajorMatrix>("Fbar")),
     _elastic_strain_energy(declareProperty<Real>("elastic_strain_energy")),
     _plastic_dissipation(declareProperty<Real>("plastic_dissipation")),
     _creep_dissipation(declareProperty<Real>("creep_dissipation"))
@@ -170,12 +170,8 @@ AbaqusUmatMaterial::initQpStatefulProperties()
 {
   // Initialize state variable vector
   _state_var[_qp].resize(_num_state_vars);
-  _state_var_old[_qp].resize(_num_state_vars);
   for (unsigned int i = 0; i < _num_state_vars; ++i)
-  {
     _state_var[_qp][i] = 0.0;
-    _state_var_old[_qp][i] = 0.0;
-  }
 }
 
 void

--- a/modules/tensor_mechanics/include/materials/CappedWeakInclinedPlaneStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedWeakInclinedPlaneStressUpdate.h
@@ -45,7 +45,7 @@ protected:
   MaterialProperty<RealVectorValue> & _n;
 
   /// Old value of the normal
-  MaterialProperty<RealVectorValue> & _n_old;
+  const MaterialProperty<RealVectorValue> & _n_old;
 
   /// Rotation matrix that rotates _n to "z"
   RealTensorValue _rot_n_to_z;

--- a/modules/tensor_mechanics/include/materials/ComputeCosseratIncrementalSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCosseratIncrementalSmallStrain.h
@@ -42,7 +42,7 @@ protected:
   std::vector<const VariableGradient *> _grad_wc_old;
 
   /// the Cosserat curvature strain: curvature_ij = nabla_j CosseratRotation_i
-  MaterialProperty<RankTwoTensor> & _curvature_old;
+  const MaterialProperty<RankTwoTensor> & _curvature_old;
 
   /// _curvature_increment = (curvature - _curvature_old)
   MaterialProperty<RankTwoTensor> & _curvature_increment;

--- a/modules/tensor_mechanics/include/materials/ComputeEigenstrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeEigenstrainBase.h
@@ -39,7 +39,7 @@ protected:
   MaterialProperty<RankTwoTensor> & _eigenstrain;
 
   ///Stores the total eigenstrain in the previous step (only for incremental form)
-  MaterialProperty<RankTwoTensor> * _eigenstrain_old;
+  const MaterialProperty<RankTwoTensor> * _eigenstrain_old;
 
   /**
    * Helper function for models that compute the eigenstrain based on a volumetric

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
@@ -26,7 +26,7 @@ protected:
 
   const MaterialProperty<RankTwoTensor> & _strain_increment;
   const MaterialProperty<RankTwoTensor> & _rotation_increment;
-  MaterialProperty<RankTwoTensor> & _stress_old;
+  const MaterialProperty<RankTwoTensor> & _stress_old;
 };
 
 #endif // COMPUTEFINITESTRAINELASTICSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeInstantaneousThermalExpansionFunctionEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeInstantaneousThermalExpansionFunctionEigenstrain.h
@@ -35,7 +35,7 @@ protected:
   /// Stores the thermal strain as a scalar for use in computing an incremental update to this.
   //@{
   MaterialProperty<Real> & _thermal_strain;
-  MaterialProperty<Real> & _thermal_strain_old;
+  const MaterialProperty<Real> & _thermal_strain_old;
   //@}
 
   /// Indicates whether we are on the first step, avoiding false positives when restarting

--- a/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
@@ -99,13 +99,13 @@ protected:
   MaterialProperty<RankTwoTensor> & _plastic_strain;
 
   /// Old value of plastic strain
-  MaterialProperty<RankTwoTensor> & _plastic_strain_old;
+  const MaterialProperty<RankTwoTensor> & _plastic_strain_old;
 
   /// internal parameters
   MaterialProperty<std::vector<Real>> & _intnl;
 
   /// old values of internal parameters
-  MaterialProperty<std::vector<Real>> & _intnl_old;
+  const MaterialProperty<std::vector<Real>> & _intnl_old;
 
   /// yield functions
   MaterialProperty<std::vector<Real>> & _yf;
@@ -126,7 +126,7 @@ protected:
   MaterialProperty<RealVectorValue> & _n;
 
   /// old value of transverse direction
-  MaterialProperty<RealVectorValue> & _n_old;
+  const MaterialProperty<RealVectorValue> & _n_old;
 
   /// strain increment (coming from ComputeIncrementalSmallStrain, for example)
   const MaterialProperty<RankTwoTensor> & _strain_increment;
@@ -138,10 +138,10 @@ protected:
   const MaterialProperty<RankTwoTensor> & _rotation_increment;
 
   /// Old value of stress
-  MaterialProperty<RankTwoTensor> & _stress_old;
+  const MaterialProperty<RankTwoTensor> & _stress_old;
 
   /// Old value of elastic strain
-  MaterialProperty<RankTwoTensor> & _elastic_strain_old;
+  const MaterialProperty<RankTwoTensor> & _elastic_strain_old;
 
   /// whether Cosserat mechanics should be used
   bool _cosserat;
@@ -156,7 +156,7 @@ protected:
   MaterialProperty<RankTwoTensor> * _couple_stress;
 
   /// the old value of Cosserat couple-stress
-  MaterialProperty<RankTwoTensor> * _couple_stress_old;
+  const MaterialProperty<RankTwoTensor> * _couple_stress_old;
 
   /// derivative of couple-stress w.r.t. curvature
   MaterialProperty<RankFourTensor> * _Jacobian_mult_couple;
@@ -588,6 +588,8 @@ private:
   /// This boolean is delcared as a reference so that the variable is restartable
   /// data:  if we restart, the code will not think it is the first timestep again.
   bool & _step_one;
+
+  RankTwoTensor rot(const RankTwoTensor & tens);
 };
 
 #endif // COMPUTEMULTIPLASTICITYSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeStrainIncrementBasedStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainIncrementBasedStress.h
@@ -23,7 +23,7 @@ protected:
   virtual void computeQpStress();
   virtual void computeQpJacobian();
 
-  MaterialProperty<RankTwoTensor> & _stress_old;
+  const MaterialProperty<RankTwoTensor> & _stress_old;
   const MaterialProperty<RankTwoTensor> & _mechanical_strain;
   const MaterialProperty<RankTwoTensor> & _mechanical_strain_old;
   std::vector<const MaterialProperty<RankTwoTensor> *> _inelastic_strains;

--- a/modules/tensor_mechanics/include/materials/ComputeVariableIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeVariableIsotropicElasticityTensor.h
@@ -24,9 +24,6 @@ protected:
   virtual void initQpStatefulProperties() override;
   virtual void computeQpElasticityTensor() override;
 
-  /// Store the old elasticity tensor to compute the stress correctly for incremental formulations
-  MaterialProperty<RankFourTensor> & _elasticity_tensor_old;
-
   /// Material defininig the Young's Modulus
   const MaterialProperty<Real> & _youngs_modulus;
 

--- a/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
@@ -298,15 +298,15 @@ protected:
   MooseEnum _lsrch_method;
 
   MaterialProperty<RankTwoTensor> & _fp;
-  MaterialProperty<RankTwoTensor> & _fp_old;
+  const MaterialProperty<RankTwoTensor> & _fp_old;
   MaterialProperty<RankTwoTensor> & _pk2;
-  MaterialProperty<RankTwoTensor> & _pk2_old;
+  const MaterialProperty<RankTwoTensor> & _pk2_old;
   MaterialProperty<RankTwoTensor> & _lag_e;
-  MaterialProperty<RankTwoTensor> & _lag_e_old;
+  const MaterialProperty<RankTwoTensor> & _lag_e_old;
   MaterialProperty<std::vector<Real>> & _gss;
-  MaterialProperty<std::vector<Real>> & _gss_old;
+  const MaterialProperty<std::vector<Real>> & _gss_old;
   MaterialProperty<Real> & _acc_slip;
-  MaterialProperty<Real> & _acc_slip_old;
+  const MaterialProperty<Real> & _acc_slip_old;
   MaterialProperty<RankTwoTensor> & _update_rot;
 
   const MaterialProperty<RankTwoTensor> & _deformation_gradient;

--- a/modules/tensor_mechanics/include/materials/FiniteStrainHyperElasticViscoPlastic.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainHyperElasticViscoPlastic.h
@@ -56,7 +56,7 @@ protected:
   template <typename T>
   void initPropOld(const std::vector<UserObjectName> &,
                    unsigned int,
-                   std::vector<MaterialProperty<T> *> &);
+                   std::vector<const MaterialProperty<T> *> &);
 
   /// This function initializes user objects
   template <typename T>
@@ -191,7 +191,7 @@ protected:
   std::string _pk2_prop_name;
   MaterialProperty<RankTwoTensor> & _pk2;
   MaterialProperty<RankTwoTensor> & _fp;
-  MaterialProperty<RankTwoTensor> & _fp_old;
+  const MaterialProperty<RankTwoTensor> & _fp_old;
   MaterialProperty<RankTwoTensor> & _ce;
 
   const MaterialProperty<RankTwoTensor> & _deformation_gradient;
@@ -201,7 +201,7 @@ protected:
   std::vector<MaterialProperty<Real> *> _flow_rate_prop;
   std::vector<MaterialProperty<Real> *> _strength_prop;
   std::vector<MaterialProperty<Real> *> _int_var_stateful_prop;
-  std::vector<MaterialProperty<Real> *> _int_var_stateful_prop_old;
+  std::vector<const MaterialProperty<Real> *> _int_var_stateful_prop_old;
   std::vector<MaterialProperty<Real> *> _int_var_rate_prop;
   std::vector<Real> _int_var_old;
 

--- a/modules/tensor_mechanics/include/materials/FiniteStrainPlasticMaterial.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainPlasticMaterial.h
@@ -35,10 +35,10 @@ protected:
 
   std::vector<Real> _yield_stress_vector;
   MaterialProperty<RankTwoTensor> & _plastic_strain;
-  MaterialProperty<RankTwoTensor> & _plastic_strain_old;
+  const MaterialProperty<RankTwoTensor> & _plastic_strain_old;
   MaterialProperty<Real> & _eqv_plastic_strain;
-  MaterialProperty<Real> & _eqv_plastic_strain_old;
-  MaterialProperty<RankTwoTensor> & _stress_old;
+  const MaterialProperty<Real> & _eqv_plastic_strain_old;
+  const MaterialProperty<RankTwoTensor> & _stress_old;
   const MaterialProperty<RankTwoTensor> & _strain_increment;
   const MaterialProperty<RankTwoTensor> & _rotation_increment;
   const MaterialProperty<RankFourTensor> & _elasticity_tensor;

--- a/modules/tensor_mechanics/include/materials/FiniteStrainUObasedCP.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainUObasedCP.h
@@ -172,7 +172,7 @@ protected:
   std::vector<MaterialProperty<std::vector<Real>> *> _mat_prop_state_vars;
 
   /// Old state variable material property
-  std::vector<MaterialProperty<std::vector<Real>> *> _mat_prop_state_vars_old;
+  std::vector<const MaterialProperty<std::vector<Real>> *> _mat_prop_state_vars_old;
 
   /// State variable evolution rate component material property
   std::vector<MaterialProperty<std::vector<Real>> *> _mat_prop_state_var_evol_rate_comps;
@@ -237,12 +237,12 @@ protected:
   MooseEnum _lsrch_method;
 
   MaterialProperty<RankTwoTensor> & _fp;
-  MaterialProperty<RankTwoTensor> & _fp_old;
+  const MaterialProperty<RankTwoTensor> & _fp_old;
   MaterialProperty<RankTwoTensor> & _pk2;
-  MaterialProperty<RankTwoTensor> & _pk2_old;
+  const MaterialProperty<RankTwoTensor> & _pk2_old;
   MaterialProperty<RankTwoTensor> & _lag_e;
   MaterialProperty<RankTwoTensor> & _update_rot;
-  MaterialProperty<RankTwoTensor> & _update_rot_old;
+  const MaterialProperty<RankTwoTensor> & _update_rot_old;
 
   const MaterialProperty<RankTwoTensor> & _deformation_gradient;
   const MaterialProperty<RankTwoTensor> & _deformation_gradient_old;

--- a/modules/tensor_mechanics/include/materials/HyperbolicViscoplasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/HyperbolicViscoplasticityStressUpdate.h
@@ -63,7 +63,7 @@ protected:
   ///@}
 
   MaterialProperty<Real> & _hardening_variable;
-  MaterialProperty<Real> & _hardening_variable_old;
+  const MaterialProperty<Real> & _hardening_variable_old;
 
   /// plastic strain of this model
   MaterialProperty<RankTwoTensor> & _plastic_strain;

--- a/modules/tensor_mechanics/include/materials/IsotropicPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/IsotropicPlasticityStressUpdate.h
@@ -65,7 +65,7 @@ protected:
   const MaterialProperty<RankTwoTensor> & _plastic_strain_old;
 
   MaterialProperty<Real> & _hardening_variable;
-  MaterialProperty<Real> & _hardening_variable_old;
+  const MaterialProperty<Real> & _hardening_variable_old;
   const VariableValue & _temperature;
 };
 

--- a/modules/tensor_mechanics/include/materials/PowerLawCreepStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/PowerLawCreepStressUpdate.h
@@ -53,7 +53,7 @@ protected:
 
   const VariableValue & _temperature;
   MaterialProperty<RankTwoTensor> & _creep_strain;
-  MaterialProperty<RankTwoTensor> & _creep_strain_old;
+  const MaterialProperty<RankTwoTensor> & _creep_strain_old;
 
   Real _max_creep_incr;
 };

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -71,7 +71,7 @@ protected:
   const Real _absolute_tolerance;
 
   MaterialProperty<Real> & _effective_inelastic_strain;
-  MaterialProperty<Real> & _effective_inelastic_strain_old;
+  const MaterialProperty<Real> & _effective_inelastic_strain_old;
   Real _max_inelastic_increment;
 };
 

--- a/modules/tensor_mechanics/include/materials/SumTensorIncrements.h
+++ b/modules/tensor_mechanics/include/materials/SumTensorIncrements.h
@@ -29,7 +29,7 @@ protected:
   unsigned int _num_property;
 
   MaterialProperty<RankTwoTensor> & _tensor;
-  MaterialProperty<RankTwoTensor> & _tensor_old;
+  const MaterialProperty<RankTwoTensor> & _tensor_old;
   MaterialProperty<RankTwoTensor> & _tensor_increment;
 
   std::vector<const MaterialProperty<RankTwoTensor> *> _coupled_tensor_increments;

--- a/modules/tensor_mechanics/src/materials/CappedWeakInclinedPlaneStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedWeakInclinedPlaneStressUpdate.C
@@ -23,7 +23,7 @@ CappedWeakInclinedPlaneStressUpdate::CappedWeakInclinedPlaneStressUpdate(
   : CappedWeakPlaneStressUpdate(parameters),
     _n_input(getParam<RealVectorValue>("normal_vector")),
     _n(declareProperty<RealVectorValue>("weak_plane_normal")),
-    _n_old(declarePropertyOld<RealVectorValue>("weak_plane_normal")),
+    _n_old(getMaterialProperty<RealVectorValue>("weak_plane_normal")),
     _rot_n_to_z(RealTensorValue()),
     _rot_z_to_n(RealTensorValue()),
     _rotated_trial(RankTwoTensor()),

--- a/modules/tensor_mechanics/src/materials/ComputeCosseratIncrementalSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCosseratIncrementalSmallStrain.C
@@ -32,7 +32,7 @@ ComputeCosseratIncrementalSmallStrain::ComputeCosseratIncrementalSmallStrain(
     _wc_old(_nrots),
     _grad_wc(_nrots),
     _grad_wc_old(_nrots),
-    _curvature_old(declarePropertyOld<RankTwoTensor>("curvature")),
+    _curvature_old(getMaterialPropertyOld<RankTwoTensor>("curvature")),
     _curvature_increment(declareProperty<RankTwoTensor>("curvature_increment"))
 {
   if (_nrots != 3)

--- a/modules/tensor_mechanics/src/materials/ComputeCosseratStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCosseratStressBase.C
@@ -24,11 +24,6 @@ ComputeCosseratStressBase::ComputeCosseratStressBase(const InputParameters & par
     _stress_couple(declareProperty<RankTwoTensor>("couple_stress")),
     _Jacobian_mult_couple(declareProperty<RankFourTensor>("couple_Jacobian_mult"))
 {
-  if (_store_stress_old)
-  {
-    declarePropertyOld<RankTwoTensor>("couple_stress");
-    declarePropertyOlder<RankTwoTensor>("couple_stress");
-  }
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ComputeEigenstrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeEigenstrainBase.C
@@ -33,7 +33,7 @@ ComputeEigenstrainBase::ComputeEigenstrainBase(const InputParameters & parameter
     _eigenstrain_name(_base_name + getParam<std::string>("eigenstrain_name")),
     _incremental_form(getParam<bool>("incremental_form")),
     _eigenstrain(declareProperty<RankTwoTensor>(_eigenstrain_name)),
-    _eigenstrain_old(_incremental_form ? &declarePropertyOld<RankTwoTensor>(_eigenstrain_name)
+    _eigenstrain_old(_incremental_form ? &getMaterialPropertyOld<RankTwoTensor>(_eigenstrain_name)
                                        : NULL),
     _step_zero(declareRestartableData<bool>("step_zero", true))
 {

--- a/modules/tensor_mechanics/src/materials/ComputeElasticSmearedCrackingStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticSmearedCrackingStress.C
@@ -73,8 +73,8 @@ ComputeElasticSmearedCrackingStress::ComputeElasticSmearedCrackingStress(
     _strain_increment(getDefaultMaterialProperty<RankTwoTensor>(_base_name + "strain_increment")),
     _rotation_increment(
         getDefaultMaterialProperty<RankTwoTensor>(_base_name + "rotation_increment")),
-    _stress_old(declarePropertyOld<RankTwoTensor>(_base_name + "stress")),
-    _elastic_strain_old(declarePropertyOld<RankTwoTensor>(_base_name + "elastic_strain")),
+    _stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "stress")),
+    _elastic_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "elastic_strain")),
     _cracking_release(getCrackingModel(getParam<std::string>("cracking_release"))),
     _cracking_residual_stress(getParam<Real>("cracking_residual_stress")),
     _cracking_stress_function(getFunction("cracking_stress")),
@@ -85,21 +85,21 @@ ComputeElasticSmearedCrackingStress::ComputeElasticSmearedCrackingStress(
     _cracking_beta(getParam<Real>("cracking_beta")),
     _shear_retention(getParam<bool>("shear_retention")),
     _crack_flags(declareProperty<RealVectorValue>(_base_name + "crack_flags")),
-    _crack_flags_old(declarePropertyOld<RealVectorValue>(_base_name + "crack_flags")),
+    _crack_flags_old(getMaterialPropertyOld<RealVectorValue>(_base_name + "crack_flags")),
     _crack_count(NULL),
     _crack_count_old(NULL),
     _crack_rotation(declareProperty<RankTwoTensor>(_base_name + "crack_rotation")),
-    _crack_rotation_old(declarePropertyOld<RankTwoTensor>(_base_name + "crack_rotation")),
+    _crack_rotation_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "crack_rotation")),
     _crack_strain(declareProperty<RealVectorValue>(_base_name + "crack_strain")),
-    _crack_strain_old(declarePropertyOld<RealVectorValue>(_base_name + "crack_strain")),
+    _crack_strain_old(getMaterialPropertyOld<RealVectorValue>(_base_name + "crack_strain")),
     _crack_max_strain(declareProperty<RealVectorValue>(_base_name + "crack_max_strain")),
-    _crack_max_strain_old(declarePropertyOld<RealVectorValue>(_base_name + "crack_max_strain")),
+    _crack_max_strain_old(getMaterialPropertyOld<RealVectorValue>(_base_name + "crack_max_strain")),
     _principal_strain(3, 1)
 {
   if (_cracking_release == CR_POWER)
   {
     _crack_count = &declareProperty<RealVectorValue>(_base_name + "crack_count");
-    _crack_count_old = &declarePropertyOld<RealVectorValue>(_base_name + "crack_count");
+    _crack_count_old = &getMaterialPropertyOld<RealVectorValue>(_base_name + "crack_count");
   }
 
   if (parameters.isParamValid("active_crack_planes"))

--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrainElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrainElasticStress.C
@@ -22,7 +22,7 @@ ComputeFiniteStrainElasticStress::ComputeFiniteStrainElasticStress(
     _strain_increment(getMaterialPropertyByName<RankTwoTensor>(_base_name + "strain_increment")),
     _rotation_increment(
         getMaterialPropertyByName<RankTwoTensor>(_base_name + "rotation_increment")),
-    _stress_old(declarePropertyOld<RankTwoTensor>(_base_name + "stress"))
+    _stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "stress"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeIncrementalStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIncrementalStrainBase.C
@@ -23,8 +23,8 @@ ComputeIncrementalStrainBase::ComputeIncrementalStrainBase(const InputParameters
     _strain_increment(declareProperty<RankTwoTensor>(_base_name + "strain_increment")),
     _rotation_increment(declareProperty<RankTwoTensor>(_base_name + "rotation_increment")),
     _deformation_gradient(declareProperty<RankTwoTensor>(_base_name + "deformation_gradient")),
-    _mechanical_strain_old(declarePropertyOld<RankTwoTensor>(_base_name + "mechanical_strain")),
-    _total_strain_old(declarePropertyOld<RankTwoTensor>(_base_name + "total_strain")),
+    _mechanical_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "mechanical_strain")),
+    _total_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "total_strain")),
     _eigenstrains_old(_eigenstrain_names.size())
 {
   for (unsigned int i = 0; i < _eigenstrains_old.size(); ++i)

--- a/modules/tensor_mechanics/src/materials/ComputeInstantaneousThermalExpansionFunctionEigenstrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeInstantaneousThermalExpansionFunctionEigenstrain.C
@@ -31,7 +31,7 @@ ComputeInstantaneousThermalExpansionFunctionEigenstrain::
     _thermal_expansion_function(getFunction("thermal_expansion_function")),
     _thermal_strain(declareProperty<Real>("InstantaneousThermalExpansionFunction_thermal_strain")),
     _thermal_strain_old(
-        declarePropertyOld<Real>("InstantaneousThermalExpansionFunction_thermal_strain")),
+        getMaterialPropertyOld<Real>("InstantaneousThermalExpansionFunction_thermal_strain")),
     _step_one(declareRestartableData<bool>("step_one", true))
 {
 }

--- a/modules/tensor_mechanics/src/materials/ComputeStrainIncrementBasedStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStrainIncrementBasedStress.C
@@ -21,7 +21,7 @@ validParams<ComputeStrainIncrementBasedStress>()
 ComputeStrainIncrementBasedStress::ComputeStrainIncrementBasedStress(
     const InputParameters & parameters)
   : ComputeStressBase(parameters),
-    _stress_old(declarePropertyOld<RankTwoTensor>(_base_name + "stress")),
+    _stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "stress")),
     _mechanical_strain(getMaterialPropertyByName<RankTwoTensor>(_base_name + "mechanical_strain")),
     _mechanical_strain_old(
         getMaterialPropertyOldByName<RankTwoTensor>(_base_name + "mechanical_strain")),

--- a/modules/tensor_mechanics/src/materials/ComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStressBase.C
@@ -49,12 +49,6 @@ ComputeStressBase::ComputeStressBase(const InputParameters & parameters)
   // Declares old stress and older stress if the parameter _store_stress_old is true. This parameter
   // can be set from the input file using any of the child classes of ComputeStressBase.
 
-  if (_store_stress_old)
-  {
-    declarePropertyOld<RankTwoTensor>(_base_name + "stress");
-    declarePropertyOlder<RankTwoTensor>(_base_name + "stress");
-  }
-
   const std::vector<FunctionName> & fcn_names(
       getParam<std::vector<FunctionName>>("initial_stress"));
   const unsigned num = fcn_names.size();

--- a/modules/tensor_mechanics/src/materials/ComputeVariableIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeVariableIsotropicElasticityTensor.C
@@ -25,7 +25,6 @@ validParams<ComputeVariableIsotropicElasticityTensor>()
 ComputeVariableIsotropicElasticityTensor::ComputeVariableIsotropicElasticityTensor(
     const InputParameters & parameters)
   : ComputeElasticityTensorBase(parameters),
-    _elasticity_tensor_old(declarePropertyOld<RankFourTensor>(_elasticity_tensor_name)),
     _youngs_modulus(getMaterialProperty<Real>("youngs_modulus")),
     _poissons_ratio(getMaterialProperty<Real>("poissons_ratio")),
     _num_args(coupledComponents("args")),

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -120,19 +120,20 @@ FiniteStrainCrystalPlasticity::FiniteStrainCrystalPlasticity(const InputParamete
     _lsrch_max_iter(getParam<unsigned int>("line_search_maxiter")),
     _lsrch_method(getParam<MooseEnum>("line_search_method")),
     _fp(declareProperty<RankTwoTensor>("fp")), // Plastic deformation gradient
-    _fp_old(declarePropertyOld<RankTwoTensor>(
+    _fp_old(getMaterialPropertyOld<RankTwoTensor>(
         "fp")), // Plastic deformation gradient of previous increment
     _pk2(declareProperty<RankTwoTensor>("pk2")), // 2nd Piola Kirchoff Stress
-    _pk2_old(declarePropertyOld<RankTwoTensor>(
+    _pk2_old(getMaterialPropertyOld<RankTwoTensor>(
         "pk2")), // 2nd Piola Kirchoff Stress of previous increment
     _lag_e(declareProperty<RankTwoTensor>("lage")), // Lagrangian strain
     _lag_e_old(
-        declarePropertyOld<RankTwoTensor>("lage")),  // Lagrangian strain of previous increment
-    _gss(declareProperty<std::vector<Real>>("gss")), // Slip system resistances
-    _gss_old(declarePropertyOld<std::vector<Real>>(
+        getMaterialPropertyOld<RankTwoTensor>("lage")), // Lagrangian strain of previous increment
+    _gss(declareProperty<std::vector<Real>>("gss")),    // Slip system resistances
+    _gss_old(getMaterialPropertyOld<std::vector<Real>>(
         "gss")),                                  // Slip system resistances of previous increment
     _acc_slip(declareProperty<Real>("acc_slip")), // Accumulated slip
-    _acc_slip_old(declarePropertyOld<Real>("acc_slip")), // Accumulated alip of previous increment
+    _acc_slip_old(
+        getMaterialPropertyOld<Real>("acc_slip")), // Accumulated alip of previous increment
     _update_rot(declareProperty<RankTwoTensor>(
         "update_rot")), // Rotation tensor considering material rotation and crystal orientation
     _deformation_gradient(getMaterialProperty<RankTwoTensor>("deformation_gradient")),
@@ -155,7 +156,6 @@ FiniteStrainCrystalPlasticity::FiniteStrainCrystalPlasticity(const InputParamete
     _slip_sys_props.resize(_nss * _num_slip_sys_props);
 
   _pk2_tmp.zero();
-  _pk2_tmp_old.zero();
   _delta_dfgrd.zero();
 
   _first_step_iter = false;
@@ -225,10 +225,9 @@ void
 FiniteStrainCrystalPlasticity::assignSlipSysRes()
 {
   _gss[_qp].resize(_nss);
-  _gss_old[_qp].resize(_nss);
 
   for (unsigned int i = 0; i < _nss; ++i)
-    _gss[_qp][i] = _gss_old[_qp][i] = _slip_sys_props(i);
+    _gss[_qp][i] = _slip_sys_props(i);
 }
 
 // Read initial slip system resistances  from .txt file. See test.
@@ -236,7 +235,6 @@ void
 FiniteStrainCrystalPlasticity::readFileInitSlipSysRes()
 {
   _gss[_qp].resize(_nss);
-  _gss_old[_qp].resize(_nss);
 
   MooseUtils::checkFileReadable(_slip_sys_res_prop_file_name);
 
@@ -259,7 +257,6 @@ FiniteStrainCrystalPlasticity::getInitSlipSysRes()
                "Specify input in .i file or in slip_sys_res_prop_file or in slip_sys_file");
 
   _gss[_qp].resize(_nss, 0.0);
-  _gss_old[_qp].resize(_nss, 0.0);
 
   unsigned int num_data_grp = 3; // Number of data per group e.g. start_slip_sys, end_slip_sys,
                                  // value

--- a/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
@@ -29,10 +29,10 @@ FiniteStrainPlasticMaterial::FiniteStrainPlasticMaterial(const InputParameters &
   : ComputeStressBase(parameters),
     _yield_stress_vector(getParam<std::vector<Real>>("yield_stress")), // Read from input file
     _plastic_strain(declareProperty<RankTwoTensor>("plastic_strain")),
-    _plastic_strain_old(declarePropertyOld<RankTwoTensor>("plastic_strain")),
+    _plastic_strain_old(getMaterialPropertyOld<RankTwoTensor>("plastic_strain")),
     _eqv_plastic_strain(declareProperty<Real>("eqv_plastic_strain")),
-    _eqv_plastic_strain_old(declarePropertyOld<Real>("eqv_plastic_strain")),
-    _stress_old(declarePropertyOld<RankTwoTensor>("stress")),
+    _eqv_plastic_strain_old(getMaterialPropertyOld<Real>("eqv_plastic_strain")),
+    _stress_old(getMaterialPropertyOld<RankTwoTensor>("stress")),
     _strain_increment(getMaterialProperty<RankTwoTensor>("strain_increment")),
     _rotation_increment(getMaterialProperty<RankTwoTensor>("rotation_increment")),
     _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
@@ -48,11 +48,7 @@ void
 FiniteStrainPlasticMaterial::initQpStatefulProperties()
 {
   ComputeStressBase::initQpStatefulProperties();
-  _stress_old[_qp] = _stress[_qp];
-
   _plastic_strain[_qp].zero();
-  _plastic_strain_old[_qp].zero();
-
   _eqv_plastic_strain[_qp] = 0.0;
 }
 

--- a/modules/tensor_mechanics/src/materials/HyperbolicViscoplasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/HyperbolicViscoplasticityStressUpdate.C
@@ -43,7 +43,7 @@ HyperbolicViscoplasticityStressUpdate::HyperbolicViscoplasticityStressUpdate(
     _c_alpha(parameters.get<Real>("c_alpha")),
     _c_beta(parameters.get<Real>("c_beta")),
     _hardening_variable(declareProperty<Real>("hardening_variable")),
-    _hardening_variable_old(declarePropertyOld<Real>("hardening_variable")),
+    _hardening_variable_old(getMaterialPropertyOld<Real>("hardening_variable")),
 
     _plastic_strain(declareProperty<RankTwoTensor>(_plastic_prepend + "plastic_strain")),
     _plastic_strain_old(getMaterialPropertyOld<RankTwoTensor>(_plastic_prepend + "plastic_strain"))
@@ -57,7 +57,6 @@ HyperbolicViscoplasticityStressUpdate::initQpStatefulProperties()
   // later on
   _yield_condition = -1.0;
   _hardening_variable[_qp] = 0.0;
-  _hardening_variable_old[_qp] = 0.0;
   _plastic_strain[_qp].zero();
 }
 

--- a/modules/tensor_mechanics/src/materials/IsotropicPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/IsotropicPlasticityStressUpdate.C
@@ -48,7 +48,7 @@ IsotropicPlasticityStressUpdate::IsotropicPlasticityStressUpdate(const InputPara
     _plastic_strain_old(getMaterialPropertyOld<RankTwoTensor>(_plastic_prepend + "plastic_strain")),
 
     _hardening_variable(declareProperty<Real>("hardening_variable")),
-    _hardening_variable_old(declarePropertyOld<Real>("hardening_variable")),
+    _hardening_variable_old(getMaterialPropertyOld<Real>("hardening_variable")),
     _temperature(coupledValue("temperature"))
 {
   if (parameters.isParamSetByUser("yield_stress") && _yield_stress <= 0.0)
@@ -72,7 +72,6 @@ IsotropicPlasticityStressUpdate::initQpStatefulProperties()
   // later on
   _yield_condition = -1.0;
   _hardening_variable[_qp] = 0.0;
-  _hardening_variable_old[_qp] = 0.0;
   _hardening_slope = 0.0;
   _plastic_strain[_qp].zero();
 }

--- a/modules/tensor_mechanics/src/materials/PowerLawCreepStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/PowerLawCreepStressUpdate.C
@@ -45,7 +45,7 @@ PowerLawCreepStressUpdate::PowerLawCreepStressUpdate(const InputParameters & par
     _has_temp(isCoupled("temperature")),
     _temperature(_has_temp ? coupledValue("temperature") : _zero),
     _creep_strain(declareProperty<RankTwoTensor>(_creep_prepend + "creep_strain")),
-    _creep_strain_old(declarePropertyOld<RankTwoTensor>(_creep_prepend + "creep_strain"))
+    _creep_strain_old(getMaterialPropertyOld<RankTwoTensor>(_creep_prepend + "creep_strain"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -53,7 +53,7 @@ RadialReturnStressUpdate::RadialReturnStressUpdate(const InputParameters & param
     _effective_inelastic_strain(
         declareProperty<Real>("effective_" + inelastic_strain_name + "_strain")),
     _effective_inelastic_strain_old(
-        declarePropertyOld<Real>("effective_" + inelastic_strain_name + "_strain")),
+        getMaterialPropertyOld<Real>("effective_" + inelastic_strain_name + "_strain")),
     _max_inelastic_increment(parameters.get<Real>("max_inelastic_increment"))
 {
 }

--- a/modules/tensor_mechanics/src/materials/SumTensorIncrements.C
+++ b/modules/tensor_mechanics/src/materials/SumTensorIncrements.C
@@ -23,7 +23,8 @@ SumTensorIncrements::SumTensorIncrements(const InputParameters & parameters)
   : DerivativeMaterialInterface<Material>(parameters),
     _property_names(getParam<std::vector<MaterialPropertyName>>("coupled_tensor_increment_names")),
     _tensor(declareProperty<RankTwoTensor>(getParam<MaterialPropertyName>("tensor_name"))),
-    _tensor_old(declarePropertyOld<RankTwoTensor>(getParam<MaterialPropertyName>("tensor_name"))),
+    _tensor_old(
+        getMaterialPropertyOld<RankTwoTensor>(getParam<MaterialPropertyName>("tensor_name"))),
     _tensor_increment(declareProperty<RankTwoTensor>(getParam<MaterialPropertyName>("tensor_name") +
                                                      "_increment"))
 {


### PR DESCRIPTION
This deprecates ``declareProperty[Old/Older]`` and depends on #8519 to resolve cyclic dependency issues.

If you apply this patch (EDIT: patch no longer needed - and BISON tests now pass):

```diff
diff --git a/framework/include/materials/Material.h b/framework/include/materials/Material.h
index 8639b6c..36706b0 100644
--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -338,7 +338,7 @@ template<typename T>
 const MaterialProperty<T> &
 Material::getMaterialPropertyOldByName(const std::string & prop_name)
 {
-  _requested_props.insert(prop_name);
+  //_requested_props.insert(prop_name);
   registerPropName(prop_name, true, Material::OLD);
   _fe_problem.markMatPropRequested(prop_name);
   return _material_data->getPropertyOld<T>(prop_name);
@@ -348,7 +348,7 @@ template<typename T>
 const MaterialProperty<T> &
 Material::getMaterialPropertyOlderByName(const std::string & prop_name)
 {
-  _requested_props.insert(prop_name);
+  //_requested_props.insert(prop_name);
   registerPropName(prop_name, true, Material::OLDER);
   _fe_problem.markMatPropRequested(prop_name);
   return _material_data->getPropertyOlder<T>(prop_name);
```

You can build and run the tests.  Five tensor mechanics tests fail.  These tests use two material classes that both were mutating stateful old material properties (bad).  Removing declarePropertyOld usage requires the removal of stateful (old/older) property mutation.  I tried several things (educated guess style) to try to fix the issues but failed.  @bwspenc or @gambka or other BISON folks - would be great if you could chime in about a way to remove declarePropertyOld from:

* modules/tensor_mechanics/src/materials/FiniteStrainHyperElasticViscoPlastic.C
* modules/tensor_mechanics/src/materials/FiniteStrainUObasedCP.C

that doesn't break tensor mechanics tests.

[EDIT] BISON tests now pass - but tensor mechanics tests still fail.
