### PR TITLE
Fix test_json.py by using the correct path if MOOSE_DIR is not set.

### DIFF
--- a/test/run_tests
+++ b/test/run_tests
@@ -14,6 +14,7 @@ if os.environ.has_key("MOOSE_DIR"):
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
+os.environ['MOOSE_DIR'] = MOOSE_DIR
 import path_tool
 path_tool.activate_module('TestHarness')
 

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import sys, os, inspect
+import sys, os
 
 # Set the current working directory to the directory where this script is located
 os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -11,8 +11,8 @@ def find_app():
     """
     moose_dir = os.environ.get("MOOSE_DIR")
     if not moose_dir:
-        file_dir = os.dirname(os.path.abspath(__file__))
-        moose_dir = os.dirname(os.dirname(file_dir))
+        file_dir = os.path.dirname(os.path.abspath(__file__))
+        moose_dir = os.path.abspath(os.path.join(file_dir, "..", "..", "..", ".."))
     app_name = os.path.join(moose_dir, "test", "moose_test-%s" % os.environ.get("METHOD", "opt"))
     return app_name
 

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -11,8 +11,15 @@ def find_app():
     """
     moose_dir = os.environ.get("MOOSE_DIR")
     if not moose_dir:
-        file_dir = os.path.dirname(os.path.abspath(__file__))
-        moose_dir = os.path.abspath(os.path.join(file_dir, "..", "..", "..", ".."))
+        p = subprocess.Popen('git rev-parse --show-cdup', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        p.wait()
+        if p.returncode == 0:
+            git_dir = p.communicate()[0]
+            moose_dir = os.path.abspath(os.path.join(os.getcwd(), git_dir)).rstrip()
+        else:
+            print("Could not find top level moose directory. Please set the MOOSE_DIR environment variable.")
+            sys.exit(1)
+
     app_name = os.path.join(moose_dir, "test", "moose_test-%s" % os.environ.get("METHOD", "opt"))
     return app_name
 


### PR DESCRIPTION
Also adds MOOSE_DIR to the environment in run_tests.

closes #8723
