### PR TITLE
Add quadrature point dependent Rayleigh damping #8727

### DIFF
--- a/modules/tensor_mechanics/include/kernels/DynamicStressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/DynamicStressDivergenceTensors.h
@@ -26,7 +26,7 @@ protected:
   const MaterialProperty<RankTwoTensor> & _stress_old;
 
   // Rayleigh damping parameter _zeta and HHT time integration parameter _alpha
-  const Real _zeta;
+  const MaterialProperty<Real> & _zeta;
   const Real _alpha;
   const bool _static_initialization;
 };

--- a/modules/tensor_mechanics/include/kernels/InertialForce.h
+++ b/modules/tensor_mechanics/include/kernels/InertialForce.h
@@ -34,9 +34,8 @@ private:
   const VariableValue & _accel_old;
   const Real _beta;
   const Real _gamma;
-  const Real _eta;
+  const MaterialProperty<Real> & _eta;
   const Real _alpha;
-
 };
 
 #endif //INERTIALFORCE_H

--- a/modules/tensor_mechanics/src/actions/DynamicTensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/DynamicTensorMechanicsAction.C
@@ -15,7 +15,7 @@ validParams<DynamicTensorMechanicsAction>()
 {
   InputParameters params = validParams<TensorMechanicsAction>();
   params.addClassDescription("Set up dynamic stress divergence kernels");
-  params.addParam<Real>("zeta", 0, "zeta parameter for the Rayleigh damping");
+  params.addParam<MaterialPropertyName>("zeta", 0.0, "Name of material property or a constant real number defining the zeta parameter for the Rayleigh damping.");
   params.addParam<Real>("alpha", 0, "alpha parameter for HHT time integration");
   params.addParam<bool>("static_initialization", false, "Set to true get the system to equillibrium under gravity by running a quasi-static analysis (by solving Ku = F) in the first time step.");
   return params;

--- a/modules/tensor_mechanics/tests/dynamics/rayleigh_damping/rayleigh_newmark_material_dependent.i
+++ b/modules/tensor_mechanics/tests/dynamics/rayleigh_damping/rayleigh_newmark_material_dependent.i
@@ -1,0 +1,307 @@
+# Test for rayleigh damping implemented using Newmark time integration
+
+# The test is for an 1D bar element of  unit length fixed on one end
+# with a ramped pressure boundary condition applied to the other end.
+# zeta and eta correspond to the stiffness and mass proportional rayleigh damping
+# beta and gamma are Newmark time integration parameters
+# The equation of motion in terms of matrices is:
+#
+# M*accel + eta*M*vel + zeta*K*vel + K*disp = P*Area
+#
+# Here M is the mass matrix, K is the stiffness matrix, P is the applied pressure
+#
+# This equation is equivalent to:
+#
+# density*accel + eta*density*vel + zeta*d/dt(Div stress) + Div stress = P
+#
+# The first two terms on the left are evaluated using the Inertial force kernel
+# The next two terms on the left involving zeta are evaluated using the
+# DynamicStressDivergenceTensors Kernel
+# The residual due to Pressure is evaluated using Pressure boundary condition
+#
+# The system will come to steady state slowly after the pressure becomes constant.
+# The store_stress_old flag in the ComputeStressBase material model needs to be
+# turned on to store stress old. In this example, this flag is turned on using
+# the child class ComputeLinearElasticStress.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1
+  ny = 1
+  nz = 1
+  xmin = 0.0
+  xmax = 0.1
+  ymin = 0.0
+  ymax = 1.0
+  zmin = 0.0
+  zmax = 0.1
+[]
+
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+[]
+
+[AuxVariables]
+  [./vel_x]
+  [../]
+  [./accel_x]
+  [../]
+  [./vel_y]
+  [../]
+  [./accel_y]
+  [../]
+  [./vel_z]
+  [../]
+  [./accel_z]
+  [../]
+  [./stress_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./strain_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+
+[]
+
+[Kernels]
+  [./DynamicTensorMechanics]
+    displacements = 'disp_x disp_y disp_z'
+    zeta = 'zeta_rayleigh'
+  [../]
+  [./inertia_x]
+    type = InertialForce
+    variable = disp_x
+    velocity = vel_x
+    acceleration = accel_x
+    beta = 0.25
+    gamma = 0.5
+    eta = 'eta_rayleigh'
+  [../]
+  [./inertia_y]
+    type = InertialForce
+    variable = disp_y
+    velocity = vel_y
+    acceleration = accel_y
+    beta = 0.25
+    gamma = 0.5
+    eta = 'eta_rayleigh'
+  [../]
+  [./inertia_z]
+    type = InertialForce
+    variable = disp_z
+    velocity = vel_z
+    acceleration = accel_z
+    beta = 0.25
+    gamma = 0.5
+    eta = 'eta_rayleigh'
+  [../]
+[]
+
+[AuxKernels]
+  [./accel_x]
+    type = NewmarkAccelAux
+    variable = accel_x
+    displacement = disp_x
+    velocity = vel_x
+    beta = 0.25
+    execute_on = timestep_end
+  [../]
+  [./vel_x]
+    type = NewmarkVelAux
+    variable = vel_x
+    acceleration = accel_x
+    gamma = 0.5
+    execute_on = timestep_end
+  [../]
+  [./accel_y]
+    type = NewmarkAccelAux
+    variable = accel_y
+    displacement = disp_y
+    velocity = vel_y
+    beta = 0.25
+    execute_on = timestep_end
+  [../]
+  [./vel_y]
+    type = NewmarkVelAux
+    variable = vel_y
+    acceleration = accel_y
+    gamma = 0.5
+    execute_on = timestep_end
+  [../]
+  [./accel_z]
+    type = NewmarkAccelAux
+    variable = accel_z
+    displacement = disp_z
+    velocity = vel_z
+    beta = 0.25
+    execute_on = timestep_end
+  [../]
+  [./vel_z]
+    type = NewmarkVelAux
+    variable = vel_z
+    acceleration = accel_z
+    gamma = 0.5
+    execute_on = timestep_end
+  [../]
+  [./stress_yy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yy
+    index_i = 0
+    index_j = 1
+  [../]
+  [./strain_yy]
+    type = RankTwoAux
+    rank_two_tensor = total_strain
+    variable = strain_yy
+    index_i = 0
+    index_j = 1
+  [../]
+
+[]
+
+
+[BCs]
+  [./top_y]
+    type = DirichletBC
+    variable = disp_y
+    boundary = top
+    value=0.0
+  [../]
+  [./top_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = top
+    value=0.0
+  [../]
+  [./top_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = top
+    value=0.0
+  [../]
+  [./bottom_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = bottom
+    value=0.0
+  [../]
+  [./bottom_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = bottom
+    value=0.0
+  [../]
+  [./Pressure]
+    [./Side1]
+      boundary = bottom
+      function = pressure
+      disp_x = disp_x
+      disp_y = disp_y
+      disp_z = disp_z
+      factor = 1
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./Elasticity_tensor]
+    type = ComputeElasticityTensor
+    block = 0
+    fill_method = symmetric_isotropic
+    C_ijkl = '210e9 0'
+  [../]
+
+  [./strain]
+    type = ComputeSmallStrain
+    block = 0
+    displacements = 'disp_x disp_y disp_z'
+  [../]
+
+  [./stress]
+    type = ComputeLinearElasticStress
+    store_stress_old = True
+    block = 0
+  [../]
+
+  [./density]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'density'
+    prop_values = '7750'
+  [../]
+  [./material_zeta]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'zeta_rayleigh'
+    prop_values = '0.1'
+  [../]
+  [./material_eta]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'eta_rayleigh'
+    prop_values = '0.1'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  start_time = 0
+  end_time = 2
+  dt = 0.1
+[]
+
+
+[Functions]
+  [./pressure]
+    type = PiecewiseLinear
+    x = '0.0 0.1 0.2 1.0 2.0 5.0'
+    y = '0.0 0.1 0.2 1.0 1.0 1.0'
+    scale_factor = 1e9
+  [../]
+[]
+
+[Postprocessors]
+  [./_dt]
+    type = TimestepSize
+  [../]
+  [./disp]
+    type = NodalMaxValue
+    variable = disp_y
+    boundary = bottom
+  [../]
+  [./vel]
+    type = NodalMaxValue
+    variable = vel_y
+    boundary = bottom
+  [../]
+  [./accel]
+    type = NodalMaxValue
+    variable = accel_y
+    boundary = bottom
+  [../]
+  [./stress_yy]
+    type = ElementAverageValue
+    variable = stress_yy
+  [../]
+  [./strain_yy]
+    type = ElementAverageValue
+    variable = strain_yy
+  [../]
+
+[]
+
+[Outputs]
+  file_base = 'rayleigh_newmark_out'
+  exodus = true
+  print_perf_log = true
+[]

--- a/modules/tensor_mechanics/tests/dynamics/rayleigh_damping/tests
+++ b/modules/tensor_mechanics/tests/dynamics/rayleigh_damping/tests
@@ -13,4 +13,12 @@
     abs_zero = 1e-09
     compiler = 'GCC CLANG'
   [../]
+  [./newmark_material]
+    type = 'Exodiff'
+    input = 'rayleigh_newmark_material_dependent.i'
+    exodiff = 'rayleigh_newmark_out.e'
+    abs_zero = 1e-09
+    compiler = 'GCC CLANG'
+    prereq = 'newmark'
+  [../]
 []


### PR DESCRIPTION
This commit adds a flag 'material_rayleigh_damping' to DynamicTensorMechanicsTensors.C and InertialForce.C 

When this flag is set to true in the corresponding blocks, it uses eta and zeta values from the material properties 'eta_rayleigh' and 'zeta_rayleigh', respectively. 

If material_rayleigh_damping is turned on and a non-zero value is prescribed for the constant real parameter eta or zeta, an error is produced. 

closes #8727 

@bwspenc, @dschwen 