### PR TITLE
Show file and line information in json output

### DIFF
--- a/examples/ex15_actions/src/base/ExampleApp.C
+++ b/examples/ex15_actions/src/base/ExampleApp.C
@@ -75,5 +75,5 @@ ExampleApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
    * contain a leading slash.  Wildcard characters can be used to replace a piece of the
    * path.
    */
-  syntax.registerActionSyntax("ConvectionDiffusionAction", "ConvectionDiffusion");
+  registerSyntax("ConvectionDiffusionAction", "ConvectionDiffusion");
 }

--- a/framework/include/actions/ActionFactory.h
+++ b/framework/include/actions/ActionFactory.h
@@ -21,6 +21,7 @@
 
 #include "Action.h" // Technically required for std::shared_ptr<Action>(Action*) constructor
 #include "InputParameters.h"
+#include "FileLineInfo.h"
 
 /**
  * Macros
@@ -86,16 +87,16 @@ public:
     build_info._unique_id = _unique_id++;
     _name_to_build_info.insert(std::make_pair(name, build_info));
     _task_to_action_map.insert(std::make_pair(task, name));
-    if (!file.empty() && line >= 0)
-      _name_to_line.insert(std::make_pair(std::make_pair(name, task), std::make_pair(file, line)));
+    _name_to_line.addInfo(name, task, file, line);
   }
 
   /**
    * Gets file and line information where an action was registered.
    * @param name Action name
    * @param task task name
+   * @return A FileLineInfo associated with the name/task pair
    */
-  std::pair<std::string, int> getLineInfo(const std::string & name, const std::string & task) const;
+  FileLineInfo getLineInfo(const std::string & name, const std::string & task) const;
 
   std::string getTaskName(const std::string & action);
 
@@ -134,7 +135,7 @@ protected:
 
   std::multimap<std::string, BuildInfo> _name_to_build_info;
 
-  std::map<std::pair<std::string, std::string>, std::pair<std::string, int>> _name_to_line;
+  FileLineInfoMap _name_to_line;
   std::multimap<std::string, std::string> _task_to_action_map;
 
   // TODO: I don't think we need this anymore

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -22,6 +22,7 @@
 // MOOSE includes
 #include "MooseObject.h"
 #include "MooseTypes.h"
+#include "FileLineInfo.h"
 
 // Forward declarations
 class InputParameters;
@@ -171,15 +172,15 @@ public:
       else
         mooseError("Object '" + obj_name + "' already registered.");
     }
-    if (!file.empty() && line >= 0)
-      _name_to_line[obj_name] = std::make_pair(file, line);
+    _name_to_line.addInfo(obj_name, file, line);
     // TODO: Possibly store and print information about objects that are skipped here?
   }
   /**
    * Gets file and line information where an object was initially registered.
    * @param name Object name
+   * @return The FileLineInfo associated with name
    */
-  std::pair<std::string, int> getLineInfo(const std::string & name) const;
+  FileLineInfo getLineInfo(const std::string & name) const;
 
   /**
    * Register a deprecated object that expires
@@ -316,7 +317,7 @@ protected:
   /// Storage for pointers to the parameters objects
   std::map<std::string, paramsPtr> _name_to_params_pointer;
 
-  std::map<std::string, std::pair<std::string, int>> _name_to_line;
+  FileLineInfoMap _name_to_line;
 
   /// Storage for deprecated object experiation dates
   std::map<std::string, time_t> _deprecated_time;

--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -51,7 +51,9 @@ public:
   // Registration function for associating Moose Actions with syntax
   void registerActionSyntax(const std::string & action,
                             const std::string & syntax,
-                            const std::string & task = "");
+                            const std::string & task = "",
+                            const std::string & file = "",
+                            int line = -1);
 
   /**
    *  Registration function that replaces existing Moose Actions with a completely new action
@@ -60,7 +62,9 @@ public:
    */
   void replaceActionSyntax(const std::string & action,
                            const std::string & syntax,
-                           const std::string & task);
+                           const std::string & task,
+                           const std::string & file = "",
+                           int line = -1);
 
   /**
    *  Registration a type with a block. For example, associate FunctionName with the Functions block
@@ -107,6 +111,16 @@ public:
 
   bool verifyMooseObjectTask(const std::string & base, const std::string & task) const;
 
+  /**
+   * Gets the file and line where the syntax/action/task combo was registered.
+   * @param syntax Syntax name
+   * @param action Action name
+   * @param task Task name
+   */
+  std::pair<std::string, int> getLineInfo(const std::string & syntax,
+                                          const std::string & action,
+                                          const std::string & task) const;
+
 protected:
   /// The list of registered tasks and a flag indicating whether or not they are required
   std::map<std::string, bool> _registered_tasks;
@@ -124,6 +138,8 @@ protected:
   std::multimap<std::string, std::string> _associated_types;
 
   std::set<std::string> _deprecated_syntax;
+  typedef std::tuple<std::string, std::string, std::string, int> ActionTaskLineInfo;
+  std::multimap<std::string, ActionTaskLineInfo> _syntax_to_line;
 };
 
 #endif // MOOSESYNTAX_H

--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <map>
 #include "DependencyResolver.h"
+#include "FileLineInfo.h"
 
 /**
  * Holding syntax for parsing input files
@@ -116,10 +117,11 @@ public:
    * @param syntax Syntax name
    * @param action Action name
    * @param task Task name
+   * @return A FileLineInfo associated with the syntax/action/task triplet
    */
-  std::pair<std::string, int> getLineInfo(const std::string & syntax,
-                                          const std::string & action,
-                                          const std::string & task) const;
+  FileLineInfo getLineInfo(const std::string & syntax,
+                           const std::string & action,
+                           const std::string & task) const;
 
 protected:
   /// The list of registered tasks and a flag indicating whether or not they are required
@@ -138,8 +140,7 @@ protected:
   std::multimap<std::string, std::string> _associated_types;
 
   std::set<std::string> _deprecated_syntax;
-  typedef std::tuple<std::string, std::string, std::string, int> ActionTaskLineInfo;
-  std::multimap<std::string, ActionTaskLineInfo> _syntax_to_line;
+  FileLineInfoMap _syntax_to_line;
 };
 
 #endif // MOOSESYNTAX_H

--- a/framework/include/utils/FileLineInfo.h
+++ b/framework/include/utils/FileLineInfo.h
@@ -1,0 +1,120 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef FILELINEINFO_H
+#define FILELINEINFO_H
+
+#include <string>
+#include <map>
+
+/**
+ * Holds file and line information.
+ */
+class FileLineInfo
+{
+public:
+  FileLineInfo();
+  FileLineInfo(const std::string & f, int l);
+  /**
+   * @return Whether this holds valid file line information.
+   */
+  bool isValid() const;
+  int line() const;
+  std::string file() const;
+
+protected:
+  int _line;
+  std::string _file;
+};
+
+/**
+ * A mapping between a series of keys to a FileLineInfo.
+ * This is intended to replace having a std::pair or a std::tuple
+ * as a key to a map holding the FileLineInfo.
+ */
+class FileLineInfoMap
+{
+public:
+  /**
+   * Associate a key with file/line info
+   * @param key0 Key
+   * @param file file
+   * @param line line number
+   */
+  void addInfo(const std::string & key0, const std::string & file, int line);
+
+  /**
+   * Associate a key with file/line info
+   * @param key0 Key
+   * @param key1 Key
+   * @param file file
+   * @param line line number
+   */
+  void
+  addInfo(const std::string & key0, const std::string & key1, const std::string & file, int line);
+
+  /**
+   * Associate a key with file/line info
+   * @param key0 Key
+   * @param key1 Key
+   * @param key2 Key
+   * @param file file
+   * @param line line number
+   */
+  void addInfo(const std::string & key0,
+               const std::string & key1,
+               const std::string & key2,
+               const std::string & file,
+               int line);
+
+  /**
+   * Get file/line info for a key
+   * @param key0 Key
+   * @return FileLineInfo
+   */
+  FileLineInfo getInfo(const std::string & key0) const;
+
+  /**
+   * Get file/line info for a pair of keys.
+   * @param key0 Key
+   * @param key1 Key
+   * @return FileLineInfo
+   */
+  FileLineInfo getInfo(const std::string & key0, const std::string & key1) const;
+
+  /**
+   * Get file/line info for a pair of keys.
+   * @param key0 Key
+   * @param key1 Key
+   * @param key2 Key
+   * @return FileLineInfo
+   */
+  FileLineInfo
+  getInfo(const std::string & key0, const std::string & key1, const std::string & key2) const;
+
+protected:
+  /**
+   * Makes a unique key for the map given two strings
+   */
+  std::string makeKey(const std::string & key0, const std::string & key1) const;
+
+  /**
+   * Makes a unique key given three strings
+   */
+  std::string
+  makeKey(const std::string & key0, const std::string & key1, const std::string & key2) const;
+  std::map<std::string, FileLineInfo> _map;
+};
+
+#endif // FILELINEINFO_H

--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -16,6 +16,7 @@
 #define JSONSYNTAXTREE_H
 
 #include "InputParameters.h"
+#include "FileLineInfo.h"
 #include "json/json.h"
 #include <string>
 #include <vector>
@@ -37,6 +38,8 @@ public:
    * @param action Name of the action
    * @param is_action Wheter it is an action
    * @param params The InputParameters to add to the tree
+   * @param lineinfo The FileLineInfo where the action/path was registered
+   * @return Whether the parameters were added to the tree (ie if it matched the search string).
    */
   bool addParameters(const std::string & parent_path,
                      const std::string & path,
@@ -44,13 +47,23 @@ public:
                      const std::string & action,
                      bool is_action,
                      InputParameters * params,
-                     const std::pair<std::string, int> & lineinfo);
+                     const FileLineInfo & lineinfo);
 
+  /**
+   * Add a task to the tree
+   * @param path The path of the action
+   * @param action Name of the action
+   * @param task Name of the task
+   * @param lineinfo The FileLineInfo where the action/task was registered
+   */
   void addActionTask(const std::string & path,
                      const std::string & action,
                      const std::string & task,
-                     const std::pair<std::string, int> & lineinfo);
-
+                     const FileLineInfo & lineinfo);
+  /**
+   * Get the root of the tree.
+   * @return The top level Json::Value holding the tree.
+   */
   const moosecontrib::Json::Value & getRoot() const { return _root; }
 
   /**

--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -35,17 +35,21 @@ public:
    * @param path The path of the action
    * @param is_type Whether this belongs to a "<type>" or not
    * @param action Name of the action
-   * @param task_name Task name associated with these parameters
    * @param is_action Wheter it is an action
    * @param params The InputParameters to add to the tree
    */
-  void addParameters(const std::string & parent_path,
+  bool addParameters(const std::string & parent_path,
                      const std::string & path,
                      bool is_type,
                      const std::string & action,
-                     const std::string & task_name,
                      bool is_action,
-                     InputParameters * params);
+                     InputParameters * params,
+                     const std::pair<std::string, int> & lineinfo);
+
+  void addActionTask(const std::string & path,
+                     const std::string & action,
+                     const std::string & task,
+                     const std::pair<std::string, int> & lineinfo);
 
   const moosecontrib::Json::Value & getRoot() const { return _root; }
 

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -149,3 +149,11 @@ ActionFactory::getTasksByAction(const std::string & action) const
 
   return tasks;
 }
+std::pair<std::string, int>
+ActionFactory::getLineInfo(const std::string & name, const std::string & task) const
+{
+  auto iter = _name_to_line.find(std::make_pair(name, task));
+  if (iter == _name_to_line.end())
+    return std::make_pair("", -1);
+  return iter->second;
+}

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -149,11 +149,8 @@ ActionFactory::getTasksByAction(const std::string & action) const
 
   return tasks;
 }
-std::pair<std::string, int>
+FileLineInfo
 ActionFactory::getLineInfo(const std::string & name, const std::string & task) const
 {
-  auto iter = _name_to_line.find(std::make_pair(name, task));
-  if (iter == _name_to_line.end())
-    return std::make_pair("", -1);
-  return iter->second;
+  return _name_to_line.getInfo(name, task);
 }

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -183,11 +183,9 @@ Factory::getConstructedObjects() const
     list.push_back(name);
   return list;
 }
-std::pair<std::string, int>
+
+FileLineInfo
 Factory::getLineInfo(const std::string & name) const
 {
-  auto it = _name_to_line.find(name);
-  if (it == _name_to_line.end())
-    return std::make_pair("", -1);
-  return it->second;
+  return _name_to_line.getInfo(name);
 }

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -183,3 +183,11 @@ Factory::getConstructedObjects() const
     list.push_back(name);
   return list;
 }
+std::pair<std::string, int>
+Factory::getLineInfo(const std::string & name) const
+{
+  auto it = _name_to_line.find(name);
+  if (it == _name_to_line.end())
+    return std::make_pair("", -1);
+  return it->second;
+}

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -1084,7 +1084,8 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
 {
 
 #undef registerAction
-#define registerAction(tplt, action) action_factory.reg<tplt>(stringifyName(tplt), action)
+#define registerAction(tplt, action)                                                               \
+  action_factory.reg<tplt>(stringifyName(tplt), action, __FILE__, __LINE__)
 
   registerAction(SetupPostprocessorDataAction, "setup_postprocessor_data");
 

--- a/framework/src/parser/MooseSyntax.C
+++ b/framework/src/parser/MooseSyntax.C
@@ -69,6 +69,8 @@ associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   //  syntax.registerActionSyntax("AddVariableAction", "Variables/*", "add_ic");
 
   registerSyntax("AddICAction", "Variables/*/InitialCondition");
+
+  registerSyntax("AddAuxVariableAction", "AuxVariables/*");
   syntax.registerSyntaxType("AuxVariables/*", "VariableName");
   syntax.registerSyntaxType("AuxVariables/*", "AuxVariableName");
   //  syntax.registerActionSyntax("AddAuxVariableAction", "AuxVariables/*", "add_aux_variable");

--- a/framework/src/parser/MooseSyntax.C
+++ b/framework/src/parser/MooseSyntax.C
@@ -15,6 +15,7 @@
 #include "MooseSyntax.h"
 #include "Syntax.h"
 #include "Moose.h"
+#include "ActionFactory.h"
 
 namespace Moose
 {
@@ -27,131 +28,128 @@ associateSyntax(Syntax & syntax, ActionFactory & action_factory)
    * satisfied based on the syntax encountered for classes which are registered
    * to satisfy more than one task
    */
-  syntax.registerActionSyntax("CopyNodalVarsAction", "Variables/*", "check_copy_nodal_vars");
-  syntax.registerActionSyntax("CopyNodalVarsAction", "Variables/*", "copy_nodal_vars");
-  syntax.registerActionSyntax("CopyNodalVarsAction", "AuxVariables/*", "check_copy_nodal_vars");
-  syntax.registerActionSyntax("CopyNodalVarsAction", "AuxVariables/*", "copy_nodal_aux_vars");
+  registerSyntaxTask("CopyNodalVarsAction", "Variables/*", "check_copy_nodal_vars");
+  registerSyntaxTask("CopyNodalVarsAction", "Variables/*", "copy_nodal_vars");
+  registerSyntaxTask("CopyNodalVarsAction", "AuxVariables/*", "check_copy_nodal_vars");
+  registerSyntaxTask("CopyNodalVarsAction", "AuxVariables/*", "copy_nodal_aux_vars");
 
-  syntax.registerActionSyntax("AddKernelAction", "Kernels/*", "add_kernel");
-  syntax.registerActionSyntax("AddNodalKernelAction", "NodalKernels/*", "add_nodal_kernel");
-  syntax.registerActionSyntax("AddKernelAction", "AuxKernels/*", "add_aux_kernel");
-  syntax.registerActionSyntax("AddKernelAction", "Bounds/*", "add_aux_kernel");
+  registerSyntaxTask("AddKernelAction", "Kernels/*", "add_kernel");
+  registerSyntaxTask("AddNodalKernelAction", "NodalKernels/*", "add_nodal_kernel");
+  registerSyntaxTask("AddKernelAction", "AuxKernels/*", "add_aux_kernel");
+  registerSyntaxTask("AddKernelAction", "Bounds/*", "add_aux_kernel");
 
-  syntax.registerActionSyntax("AddScalarKernelAction", "ScalarKernels/*", "add_scalar_kernel");
-  syntax.registerActionSyntax(
-      "AddScalarKernelAction", "AuxScalarKernels/*", "add_aux_scalar_kernel");
+  registerSyntaxTask("AddScalarKernelAction", "ScalarKernels/*", "add_scalar_kernel");
+  registerSyntaxTask("AddScalarKernelAction", "AuxScalarKernels/*", "add_aux_scalar_kernel");
 
-  syntax.registerActionSyntax("AddBCAction", "BCs/*", "add_bc");
+  registerSyntaxTask("AddBCAction", "BCs/*", "add_bc");
 
-  syntax.registerActionSyntax("CreateProblemAction", "Problem");
-  syntax.registerActionSyntax("DynamicObjectRegistrationAction", "Problem");
-  syntax.registerActionSyntax("SetupMeshAction", "Mesh");
-  syntax.registerActionSyntax("SetupMeshCompleteAction", "Mesh");
-  //  syntax.registerActionSyntax("SetupMeshCompleteAction", "Mesh", "prepare_mesh");
-  //  syntax.registerActionSyntax("SetupMeshCompleteAction", "Mesh", "setup_mesh_complete");
-  syntax.registerActionSyntax("CreateDisplacedProblemAction", "Mesh");
-  syntax.registerActionSyntax("AddMeshModifierAction", "MeshModifiers/*");
-  syntax.registerActionSyntax("AddMortarInterfaceAction", "Mesh/MortarInterfaces/*");
+  registerSyntax("CreateProblemAction", "Problem");
+  registerSyntax("DynamicObjectRegistrationAction", "Problem");
+  registerSyntax("SetupMeshAction", "Mesh");
+  registerSyntax("SetupMeshCompleteAction", "Mesh");
+  //  registerSyntaxTask("SetupMeshCompleteAction", "Mesh", "prepare_mesh");
+  //  registerSyntaxTask("SetupMeshCompleteAction", "Mesh", "setup_mesh_complete");
+  registerSyntax("CreateDisplacedProblemAction", "Mesh");
+  registerSyntax("AddMeshModifierAction", "MeshModifiers/*");
+  registerSyntax("AddMortarInterfaceAction", "Mesh/MortarInterfaces/*");
 
-  syntax.registerActionSyntax("AddFunctionAction", "Functions/*");
+  registerSyntax("AddFunctionAction", "Functions/*");
   syntax.registerSyntaxType("Functions/*", "FunctionName");
 
-  syntax.registerActionSyntax("GlobalParamsAction", "GlobalParams");
+  registerSyntax("GlobalParamsAction", "GlobalParams");
 
-  syntax.registerActionSyntax("SetupDebugAction", "Debug");
-  syntax.registerActionSyntax("SetupResidualDebugAction", "Debug");
+  registerSyntax("SetupDebugAction", "Debug");
+  registerSyntax("SetupResidualDebugAction", "Debug");
 
   /// Variable/AuxVariable Actions
-  syntax.registerActionSyntax("AddVariableAction", "Variables/*");
+  registerSyntax("AddVariableAction", "Variables/*");
   syntax.registerSyntaxType("Variables/*", "VariableName");
   syntax.registerSyntaxType("Variables/*", "NonlinearVariableName");
   //  syntax.registerActionSyntax("AddVariableAction", "Variables/*", "add_variable");
   //  syntax.registerActionSyntax("AddVariableAction", "Variables/*", "add_ic");
 
-  syntax.registerActionSyntax("AddICAction", "Variables/*/InitialCondition");
-
-  syntax.registerActionSyntax("AddAuxVariableAction", "AuxVariables/*");
+  registerSyntax("AddICAction", "Variables/*/InitialCondition");
   syntax.registerSyntaxType("AuxVariables/*", "VariableName");
   syntax.registerSyntaxType("AuxVariables/*", "AuxVariableName");
   //  syntax.registerActionSyntax("AddAuxVariableAction", "AuxVariables/*", "add_aux_variable");
   //  syntax.registerActionSyntax("AddAuxVariableAction", "AuxVariables/*", "add_ic");
 
-  syntax.registerActionSyntax("AddICAction", "AuxVariables/*/InitialCondition");
+  registerSyntax("AddICAction", "AuxVariables/*/InitialCondition");
 
-  syntax.registerActionSyntax("EmptyAction", "BCs/Periodic", "no_action"); // placeholder
-  syntax.registerActionSyntax("AddPeriodicBCAction", "BCs/Periodic/*");
+  registerSyntaxTask("EmptyAction", "BCs/Periodic", "no_action"); // placeholder
+  registerSyntax("AddPeriodicBCAction", "BCs/Periodic/*");
 
-  syntax.registerActionSyntax("AddInitialConditionAction", "ICs/*", "add_ic");
+  registerSyntaxTask("AddInitialConditionAction", "ICs/*", "add_ic");
 
-  syntax.registerActionSyntax("AddMaterialAction", "Materials/*");
+  registerSyntax("AddMaterialAction", "Materials/*");
 
-  syntax.registerActionSyntax("SetupPostprocessorDataAction", "Postprocessors/*");
-  syntax.registerActionSyntax("AddPostprocessorAction", "Postprocessors/*");
+  registerSyntax("SetupPostprocessorDataAction", "Postprocessors/*");
+  registerSyntax("AddPostprocessorAction", "Postprocessors/*");
   syntax.registerSyntaxType("Postprocessors/*", "PostprocessorName");
   syntax.registerSyntaxType("Postprocessors/*", "UserObjectName");
 
-  syntax.registerActionSyntax("AddVectorPostprocessorAction", "VectorPostprocessors/*");
+  registerSyntax("AddVectorPostprocessorAction", "VectorPostprocessors/*");
   syntax.registerSyntaxType("VectorPostprocessors/*", "VectorPostprocessorName");
 
-  syntax.registerActionSyntax("AddDamperAction", "Dampers/*");
+  registerSyntax("AddDamperAction", "Dampers/*");
 
-  syntax.registerActionSyntax("AddOutputAction", "Outputs/*");
-  syntax.registerActionSyntax("CommonOutputAction", "Outputs");
+  registerSyntax("AddOutputAction", "Outputs/*");
+  registerSyntax("CommonOutputAction", "Outputs");
 
   // Note: Preconditioner Actions will be built by this setup action
-  syntax.registerActionSyntax("SetupPreconditionerAction", "Preconditioning/*");
-  syntax.registerActionSyntax("AddFieldSplitAction", "Preconditioning/*/*");
+  registerSyntax("SetupPreconditionerAction", "Preconditioning/*");
+  registerSyntax("AddFieldSplitAction", "Preconditioning/*/*");
 
-  syntax.registerActionSyntax("DetermineSystemType", "Executioner");
-  syntax.registerActionSyntax("CreateExecutionerAction", "Executioner");
-  syntax.registerActionSyntax("SetupTimeStepperAction", "Executioner/TimeStepper");
-  syntax.registerActionSyntax("SetupTimeIntegratorAction", "Executioner/TimeIntegrator");
+  registerSyntax("DetermineSystemType", "Executioner");
+  registerSyntax("CreateExecutionerAction", "Executioner");
+  registerSyntax("SetupTimeStepperAction", "Executioner/TimeStepper");
+  registerSyntax("SetupTimeIntegratorAction", "Executioner/TimeIntegrator");
 
-  syntax.registerActionSyntax("SetupQuadratureAction", "Executioner/Quadrature");
-  syntax.registerActionSyntax("SetupPredictorAction", "Executioner/Predictor");
+  registerSyntax("SetupQuadratureAction", "Executioner/Quadrature");
+  registerSyntax("SetupPredictorAction", "Executioner/Predictor");
 #ifdef LIBMESH_ENABLE_AMR
-  syntax.registerActionSyntax("AdaptivityAction", "Executioner/Adaptivity");
+  registerSyntax("AdaptivityAction", "Executioner/Adaptivity");
 #endif
 
-  syntax.registerActionSyntax("PartitionerAction", "Mesh/Partitioner");
+  registerSyntax("PartitionerAction", "Mesh/Partitioner");
 
-  syntax.registerActionSyntax("AddDiracKernelAction", "DiracKernels/*");
+  registerSyntax("AddDiracKernelAction", "DiracKernels/*");
 
-  syntax.registerActionSyntax("AddDGKernelAction", "DGKernels/*");
+  registerSyntax("AddDGKernelAction", "DGKernels/*");
 
-  syntax.registerActionSyntax("AddInterfaceKernelAction", "InterfaceKernels/*");
+  registerSyntax("AddInterfaceKernelAction", "InterfaceKernels/*");
 
-  syntax.registerActionSyntax("AddConstraintAction", "Constraints/*");
+  registerSyntax("AddConstraintAction", "Constraints/*");
 
-  syntax.registerActionSyntax("AddUserObjectAction", "UserObjects/*");
+  registerSyntax("AddUserObjectAction", "UserObjects/*");
   syntax.registerSyntaxType("UserObjects/*", "UserObjectName");
-  syntax.registerActionSyntax("AddControlAction", "Controls/*");
-  syntax.registerActionSyntax("AddBoundsVectorsAction", "Bounds");
+  registerSyntax("AddControlAction", "Controls/*");
+  registerSyntax("AddBoundsVectorsAction", "Bounds");
 
-  syntax.registerActionSyntax("AddNodalNormalsAction", "NodalNormals");
-  //  syntax.registerActionSyntax("AddNodalNormalsAction", "NodalNormals", "add_aux_variable");
-  //  syntax.registerActionSyntax("AddNodalNormalsAction", "NodalNormals", "add_postprocessor");
-  //  syntax.registerActionSyntax("AddNodalNormalsAction", "NodalNormals", "add_user_object");
+  registerSyntax("AddNodalNormalsAction", "NodalNormals");
+  //  registerSyntaxTask("AddNodalNormalsAction", "NodalNormals", "add_aux_variable");
+  //  registerSyntaxTask("AddNodalNormalsAction", "NodalNormals", "add_postprocessor");
+  //  registerSyntaxTask("AddNodalNormalsAction", "NodalNormals", "add_user_object");
 
   // Indicator
-  syntax.registerActionSyntax("AddElementalFieldAction", "Adaptivity/Indicators/*");
-  syntax.registerActionSyntax("AddIndicatorAction", "Adaptivity/Indicators/*");
+  registerSyntax("AddElementalFieldAction", "Adaptivity/Indicators/*");
+  registerSyntax("AddIndicatorAction", "Adaptivity/Indicators/*");
 
   // Marker
-  syntax.registerActionSyntax("AddElementalFieldAction", "Adaptivity/Markers/*");
-  syntax.registerActionSyntax("AddMarkerAction", "Adaptivity/Markers/*");
+  registerSyntax("AddElementalFieldAction", "Adaptivity/Markers/*");
+  registerSyntax("AddMarkerAction", "Adaptivity/Markers/*");
 
   // New Adaptivity System
-  syntax.registerActionSyntax("SetAdaptivityOptionsAction", "Adaptivity");
+  registerSyntax("SetAdaptivityOptionsAction", "Adaptivity");
 
   // Deprecated Block
-  syntax.registerActionSyntax("DeprecatedBlockAction", "DeprecatedBlock");
+  registerSyntax("DeprecatedBlockAction", "DeprecatedBlock");
 
   // Multi Apps
-  syntax.registerActionSyntax("AddMultiAppAction", "MultiApps/*");
+  registerSyntax("AddMultiAppAction", "MultiApps/*");
 
   // Transfers
-  syntax.registerActionSyntax("AddTransferAction", "Transfers/*");
+  registerSyntax("AddTransferAction", "Transfers/*");
 
   addActionTypes(syntax);
   registerActions(syntax, action_factory);

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -579,22 +579,35 @@ Parser::buildJsonSyntaxTree(JsonSyntaxTree & root) const
     if (act_info._task == "")
       act_info._task = _action_factory.getTaskName(act_info._action);
 
-    all_names.push_back(std::pair<std::string, Syntax::ActionInfo>(iter.first, act_info));
+    all_names.push_back(std::make_pair(iter.first, act_info));
   }
 
   for (const auto & act_names : all_names)
   {
-    InputParameters action_obj_params = _action_factory.getValidParams(act_names.second._action);
-    root.addParameters("",
-                       act_names.first,
-                       false,
-                       act_names.second._action,
-                       act_names.second._task,
-                       true,
-                       &action_obj_params);
+    const auto & act_info = act_names.second;
+    const std::string & action = act_info._action;
+    const std::string & task = act_info._task;
+    const std::string act_name = act_names.first;
+    InputParameters action_obj_params = _action_factory.getValidParams(action);
+    // all_names.push_back(std::make_tuple(iter.first, act_info,
+    // _syntax.getLineInfo(act_info._action, act_info._task)));
+    bool params_added = root.addParameters("",
+                                           act_name,
+                                           false,
+                                           action,
+                                           true,
+                                           &action_obj_params,
+                                           _syntax.getLineInfo(act_name, action, ""));
 
-    const std::string & task = act_names.second._task;
-    std::string act_name = act_names.first;
+    if (params_added)
+    {
+      auto tasks = _action_factory.getTasksByAction(action);
+      for (auto && t : tasks)
+      {
+        auto info = _action_factory.getLineInfo(action, t);
+        root.addActionTask(act_name, action, t, info);
+      }
+    }
 
     // We need to see if this action is inherited from MooseObjectAction
     // If it is, then we will loop over all the Objects in MOOSE's Factory object to print them out
@@ -645,13 +658,14 @@ Parser::buildJsonSyntaxTree(JsonSyntaxTree & root) const
 
           moose_obj_params.set<std::string>("type") = moose_obj->first;
 
-          root.addParameters(act_names.first,
+          auto lineinfo = _factory.getLineInfo(moose_obj->first);
+          root.addParameters(act_name,
                              name,
                              is_type,
                              moose_obj->first,
-                             "",
                              is_action_params,
-                             &moose_obj_params);
+                             &moose_obj_params,
+                             lineinfo);
         }
       }
     }

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -589,8 +589,6 @@ Parser::buildJsonSyntaxTree(JsonSyntaxTree & root) const
     const std::string & task = act_info._task;
     const std::string act_name = act_names.first;
     InputParameters action_obj_params = _action_factory.getValidParams(action);
-    // all_names.push_back(std::make_tuple(iter.first, act_info,
-    // _syntax.getLineInfo(act_info._action, act_info._task)));
     bool params_added = root.addParameters("",
                                            act_name,
                                            false,
@@ -602,7 +600,7 @@ Parser::buildJsonSyntaxTree(JsonSyntaxTree & root) const
     if (params_added)
     {
       auto tasks = _action_factory.getTasksByAction(action);
-      for (auto && t : tasks)
+      for (auto & t : tasks)
       {
         auto info = _action_factory.getLineInfo(action, t);
         root.addActionTask(act_name, action, t, info);

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -113,8 +113,7 @@ Syntax::registerActionSyntax(const std::string & action,
   action_info._task = task;
 
   _associated_actions.insert(std::make_pair(syntax, action_info));
-  if (!file.empty() && line >= 0)
-    _syntax_to_line.insert(std::make_pair(syntax, std::make_tuple(action, task, file, line)));
+  _syntax_to_line.addInfo(syntax, action, task, file, line);
 }
 
 void
@@ -249,16 +248,10 @@ Syntax::registerSyntaxType(const std::string & syntax, const std::string & type)
   _associated_types.insert(std::make_pair(syntax, type));
 }
 
-std::pair<std::string, int>
+FileLineInfo
 Syntax::getLineInfo(const std::string & syntax,
                     const std::string & action,
                     const std::string & task) const
 {
-  auto iters = _syntax_to_line.equal_range(syntax);
-  if (iters.first != iters.second)
-    for (auto && it = iters.first; it != iters.second; ++it)
-      if (std::get<0>(it->second) == action && std::get<1>(it->second) == task)
-        return std::make_pair(std::get<2>(it->second), std::get<3>(it->second));
-
-  return std::make_pair("", -1);
+  return _syntax_to_line.getInfo(syntax, action, task);
 }

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -104,22 +104,28 @@ Syntax::isActionRequired(const std::string & task)
 void
 Syntax::registerActionSyntax(const std::string & action,
                              const std::string & syntax,
-                             const std::string & task)
+                             const std::string & task,
+                             const std::string & file,
+                             int line)
 {
   ActionInfo action_info;
   action_info._action = action;
   action_info._task = task;
 
   _associated_actions.insert(std::make_pair(syntax, action_info));
+  if (!file.empty() && line >= 0)
+    _syntax_to_line.insert(std::make_pair(syntax, std::make_tuple(action, task, file, line)));
 }
 
 void
 Syntax::replaceActionSyntax(const std::string & action,
                             const std::string & syntax,
-                            const std::string & task)
+                            const std::string & task,
+                            const std::string & file,
+                            int line)
 {
   _associated_actions.erase(syntax);
-  registerActionSyntax(action, syntax, task);
+  registerActionSyntax(action, syntax, task, file, line);
 }
 
 void
@@ -241,4 +247,18 @@ void
 Syntax::registerSyntaxType(const std::string & syntax, const std::string & type)
 {
   _associated_types.insert(std::make_pair(syntax, type));
+}
+
+std::pair<std::string, int>
+Syntax::getLineInfo(const std::string & syntax,
+                    const std::string & action,
+                    const std::string & task) const
+{
+  auto iters = _syntax_to_line.equal_range(syntax);
+  if (iters.first != iters.second)
+    for (auto && it = iters.first; it != iters.second; ++it)
+      if (std::get<0>(it->second) == action && std::get<1>(it->second) == task)
+        return std::make_pair(std::get<2>(it->second), std::get<3>(it->second));
+
+  return std::make_pair("", -1);
 }

--- a/framework/src/utils/FileLineInfo.C
+++ b/framework/src/utils/FileLineInfo.C
@@ -1,0 +1,84 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "FileLineInfo.h"
+
+FileLineInfo::FileLineInfo()
+  : _line(-1)
+{
+}
+
+FileLineInfo::FileLineInfo(const std::string & f, int l) : _line(l), _file(f)
+{
+}
+
+bool FileLineInfo::isValid() const
+{
+  return !_file.empty() && _line >= 0;
+}
+
+int FileLineInfo::line() const
+{
+  return _line;
+}
+
+std::string FileLineInfo::file() const
+{
+  return _file;
+}
+
+void FileLineInfoMap::addInfo(const std::string & key0, const std::string & file, int line)
+{
+  FileLineInfo f(file, line);
+  if (f.isValid())
+    _map[key0] = f;
+}
+
+void FileLineInfoMap::addInfo(const std::string & key0, const std::string & key1, const std::string & file, int line)
+{
+  addInfo(makeKey(key0, key1), file, line);
+}
+
+void FileLineInfoMap::addInfo(const std::string & key0, const std::string & key1, const std::string & key2, const std::string & file, int line)
+{
+  addInfo(makeKey(key0, key1, key2), file, line);
+}
+
+std::string FileLineInfoMap::makeKey(const std::string & key0, const std::string & key1) const
+{
+  return key0 + "%" + key1;
+}
+
+std::string FileLineInfoMap::makeKey(const std::string & key0, const std::string & key1, const std::string & key2) const
+{
+  return key0 + "%" + key1 + "%" + key2;
+}
+
+FileLineInfo FileLineInfoMap::getInfo(const std::string & key0) const
+{
+  auto it = _map.find(key0);
+  if (it == _map.end())
+    return FileLineInfo();
+  return it->second;
+}
+
+FileLineInfo FileLineInfoMap::getInfo(const std::string & key0, const std::string & key1) const
+{
+  return getInfo(makeKey(key0, key1));
+}
+
+FileLineInfo FileLineInfoMap::getInfo(const std::string & key0, const std::string & key1, const std::string & key2) const
+{
+  return getInfo(makeKey(key0, key1, key2));
+}

--- a/framework/src/utils/FileLineInfo.C
+++ b/framework/src/utils/FileLineInfo.C
@@ -14,58 +14,71 @@
 
 #include "FileLineInfo.h"
 
-FileLineInfo::FileLineInfo()
-  : _line(-1)
-{
-}
+FileLineInfo::FileLineInfo() : _line(-1) {}
 
-FileLineInfo::FileLineInfo(const std::string & f, int l) : _line(l), _file(f)
-{
-}
+FileLineInfo::FileLineInfo(const std::string & f, int l) : _line(l), _file(f) {}
 
-bool FileLineInfo::isValid() const
+bool
+FileLineInfo::isValid() const
 {
   return !_file.empty() && _line >= 0;
 }
 
-int FileLineInfo::line() const
+int
+FileLineInfo::line() const
 {
   return _line;
 }
 
-std::string FileLineInfo::file() const
+std::string
+FileLineInfo::file() const
 {
   return _file;
 }
 
-void FileLineInfoMap::addInfo(const std::string & key0, const std::string & file, int line)
+void
+FileLineInfoMap::addInfo(const std::string & key0, const std::string & file, int line)
 {
   FileLineInfo f(file, line);
   if (f.isValid())
     _map[key0] = f;
 }
 
-void FileLineInfoMap::addInfo(const std::string & key0, const std::string & key1, const std::string & file, int line)
+void
+FileLineInfoMap::addInfo(const std::string & key0,
+                         const std::string & key1,
+                         const std::string & file,
+                         int line)
 {
   addInfo(makeKey(key0, key1), file, line);
 }
 
-void FileLineInfoMap::addInfo(const std::string & key0, const std::string & key1, const std::string & key2, const std::string & file, int line)
+void
+FileLineInfoMap::addInfo(const std::string & key0,
+                         const std::string & key1,
+                         const std::string & key2,
+                         const std::string & file,
+                         int line)
 {
   addInfo(makeKey(key0, key1, key2), file, line);
 }
 
-std::string FileLineInfoMap::makeKey(const std::string & key0, const std::string & key1) const
+std::string
+FileLineInfoMap::makeKey(const std::string & key0, const std::string & key1) const
 {
   return key0 + "%" + key1;
 }
 
-std::string FileLineInfoMap::makeKey(const std::string & key0, const std::string & key1, const std::string & key2) const
+std::string
+FileLineInfoMap::makeKey(const std::string & key0,
+                         const std::string & key1,
+                         const std::string & key2) const
 {
   return key0 + "%" + key1 + "%" + key2;
 }
 
-FileLineInfo FileLineInfoMap::getInfo(const std::string & key0) const
+FileLineInfo
+FileLineInfoMap::getInfo(const std::string & key0) const
 {
   auto it = _map.find(key0);
   if (it == _map.end())
@@ -73,12 +86,16 @@ FileLineInfo FileLineInfoMap::getInfo(const std::string & key0) const
   return it->second;
 }
 
-FileLineInfo FileLineInfoMap::getInfo(const std::string & key0, const std::string & key1) const
+FileLineInfo
+FileLineInfoMap::getInfo(const std::string & key0, const std::string & key1) const
 {
   return getInfo(makeKey(key0, key1));
 }
 
-FileLineInfo FileLineInfoMap::getInfo(const std::string & key0, const std::string & key1, const std::string & key2) const
+FileLineInfo
+FileLineInfoMap::getInfo(const std::string & key0,
+                         const std::string & key1,
+                         const std::string & key2) const
 {
   return getInfo(makeKey(key0, key1, key2));
 }

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -82,7 +82,7 @@ JsonSyntaxTree::addParameters(const std::string & parent,
                               const std::string & action,
                               bool is_action,
                               InputParameters * params,
-                              const std::pair<std::string, int> & lineinfo)
+                              const FileLineInfo & lineinfo)
 {
   moosecontrib::Json::Value all_params;
   if (action == "EmptyAction")
@@ -133,9 +133,8 @@ JsonSyntaxTree::addParameters(const std::string & parent,
     json[action]["parameters"] = all_params;
     json[action]["description"] = params->getClassDescription();
     json[action]["action_path"] = path;
-    auto & fi = json[action]["file_info"];
-    if (lineinfo.second >= 0)
-      fi[lineinfo.first] = lineinfo.second;
+    if (lineinfo.isValid())
+      json[action]["file_info"][lineinfo.file()] = lineinfo.line();
   }
   else if (params)
   {
@@ -143,9 +142,8 @@ JsonSyntaxTree::addParameters(const std::string & parent,
     json["syntax_path"] = path;
     json["parent_syntax"] = parent;
     json["description"] = params->getClassDescription();
-    auto & fi = json["file_info"];
-    if (lineinfo.second >= 0)
-      fi[lineinfo.first] = lineinfo.second;
+    if (lineinfo.isValid())
+      json["file_info"][lineinfo.file()] = lineinfo.line();
   }
   return true;
 }
@@ -220,13 +218,13 @@ JsonSyntaxTree::addSyntaxType(const std::string & path, const std::string type)
   }
 }
 
+void
 JsonSyntaxTree::addActionTask(const std::string & path,
                               const std::string & action,
                               const std::string & task_name,
-                              const std::pair<std::string, int> & lineinfo)
+                              const FileLineInfo & lineinfo)
 {
   moosecontrib::Json::Value & json = getJson("", path, false);
-  auto & fi = json[action]["tasks"][task_name]["file_info"];
-  if (lineinfo.second >= 0)
-    fi[lineinfo.first] = lineinfo.second;
+  if (lineinfo.isValid())
+    json[action]["tasks"][task_name]["file_info"][lineinfo.file()] = lineinfo.line();
 }

--- a/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
+++ b/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
@@ -106,18 +106,15 @@ ChemicalReactionsApp__associateSyntax(Syntax & syntax, ActionFactory & action_fa
 void
 ChemicalReactionsApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  syntax.registerActionSyntax("AddPrimarySpeciesAction", "ReactionNetwork");
-  syntax.registerActionSyntax("AddSecondarySpeciesAction",
-                              "ReactionNetwork/AqueousEquilibriumReactions");
-  syntax.registerActionSyntax("AddSecondarySpeciesAction", "ReactionNetwork/SolidKineticReactions");
-  syntax.registerActionSyntax("AddCoupledEqSpeciesKernelsAction",
-                              "ReactionNetwork/AqueousEquilibriumReactions");
-  syntax.registerActionSyntax("AddCoupledEqSpeciesAuxKernelsAction",
-                              "ReactionNetwork/AqueousEquilibriumReactions");
-  syntax.registerActionSyntax("AddCoupledSolidKinSpeciesKernelsAction",
-                              "ReactionNetwork/SolidKineticReactions");
-  syntax.registerActionSyntax("AddCoupledSolidKinSpeciesAuxKernelsAction",
-                              "ReactionNetwork/SolidKineticReactions");
+  registerSyntax("AddPrimarySpeciesAction", "ReactionNetwork");
+  registerSyntax("AddSecondarySpeciesAction", "ReactionNetwork/AqueousEquilibriumReactions");
+  registerSyntax("AddSecondarySpeciesAction", "ReactionNetwork/SolidKineticReactions");
+  registerSyntax("AddCoupledEqSpeciesKernelsAction", "ReactionNetwork/AqueousEquilibriumReactions");
+  registerSyntax("AddCoupledEqSpeciesAuxKernelsAction",
+                 "ReactionNetwork/AqueousEquilibriumReactions");
+  registerSyntax("AddCoupledSolidKinSpeciesKernelsAction", "ReactionNetwork/SolidKineticReactions");
+  registerSyntax("AddCoupledSolidKinSpeciesAuxKernelsAction",
+                 "ReactionNetwork/SolidKineticReactions");
   registerAction(AddPrimarySpeciesAction, "add_variable");
   registerAction(AddSecondarySpeciesAction, "add_aux_variable");
   registerAction(AddCoupledEqSpeciesKernelsAction, "add_kernel");

--- a/modules/contact/src/base/ContactApp.C
+++ b/modules/contact/src/base/ContactApp.C
@@ -95,16 +95,16 @@ ContactApp__associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 void
 ContactApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  syntax.registerActionSyntax("ContactAction", "Contact/*");
+  registerSyntax("ContactAction", "Contact/*");
 
-  syntax.registerActionSyntax("ContactPenetrationAuxAction", "Contact/*");
-  syntax.registerActionSyntax("ContactPenetrationVarAction", "Contact/*");
+  registerSyntax("ContactPenetrationAuxAction", "Contact/*");
+  registerSyntax("ContactPenetrationVarAction", "Contact/*");
 
-  syntax.registerActionSyntax("ContactPressureAuxAction", "Contact/*");
-  syntax.registerActionSyntax("ContactPressureVarAction", "Contact/*");
+  registerSyntax("ContactPressureAuxAction", "Contact/*");
+  registerSyntax("ContactPressureVarAction", "Contact/*");
 
-  syntax.registerActionSyntax("NodalAreaAction", "Contact/*");
-  syntax.registerActionSyntax("NodalAreaVarAction", "Contact/*");
+  registerSyntax("NodalAreaAction", "Contact/*");
+  registerSyntax("NodalAreaVarAction", "Contact/*");
 
   registerAction(ContactAction, "add_aux_kernel");
   registerAction(ContactAction, "add_aux_variable");

--- a/modules/fluid_properties/src/base/FluidPropertiesApp.C
+++ b/modules/fluid_properties/src/base/FluidPropertiesApp.C
@@ -99,7 +99,7 @@ FluidPropertiesApp__associateSyntax(Syntax & syntax, ActionFactory & action_fact
 void
 FluidPropertiesApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  syntax.registerActionSyntax(
+  registerSyntaxTask(
       "AddFluidPropertiesAction", "Modules/FluidProperties/*", "add_fluid_properties");
 
   registerMooseObjectTask("add_fluid_properties", FluidProperties, false);

--- a/modules/heat_conduction/src/base/HeatConductionApp.C
+++ b/modules/heat_conduction/src/base/HeatConductionApp.C
@@ -118,15 +118,13 @@ HeatConductionApp::associateSyntax(Syntax & syntax, ActionFactory & action_facto
   addTaskDependency("add_slave_flux_vector", "ready_to_init");
   addTaskDependency("init_problem", "add_slave_flux_vector");
   registerAction(AddSlaveFluxVectorAction, "add_slave_flux_vector");
-  syntax.registerActionSyntax("AddSlaveFluxVectorAction", "ThermalContact/*");
+  registerSyntax("AddSlaveFluxVectorAction", "ThermalContact/*");
 
-  syntax.registerActionSyntax("ThermalContactAuxBCsAction", "ThermalContact/*", "add_aux_kernel");
-  syntax.registerActionSyntax(
-      "ThermalContactAuxVarsAction", "ThermalContact/*", "add_aux_variable");
-  syntax.registerActionSyntax("ThermalContactBCsAction", "ThermalContact/*", "add_bc");
-  syntax.registerActionSyntax(
-      "ThermalContactDiracKernelsAction", "ThermalContact/*", "add_dirac_kernel");
-  syntax.registerActionSyntax("ThermalContactMaterialsAction", "ThermalContact/*", "add_material");
+  registerSyntaxTask("ThermalContactAuxBCsAction", "ThermalContact/*", "add_aux_kernel");
+  registerSyntaxTask("ThermalContactAuxVarsAction", "ThermalContact/*", "add_aux_variable");
+  registerSyntaxTask("ThermalContactBCsAction", "ThermalContact/*", "add_bc");
+  registerSyntaxTask("ThermalContactDiracKernelsAction", "ThermalContact/*", "add_dirac_kernel");
+  registerSyntaxTask("ThermalContactMaterialsAction", "ThermalContact/*", "add_material");
 
   registerAction(ThermalContactAuxBCsAction, "add_aux_kernel");
   registerAction(ThermalContactAuxVarsAction, "add_aux_variable");

--- a/modules/navier_stokes/src/base/NavierStokesApp.C
+++ b/modules/navier_stokes/src/base/NavierStokesApp.C
@@ -341,13 +341,14 @@ void
 NavierStokesApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
 #undef registerAction
-#define registerAction(type, action) action_factory.reg<type>(stringifyName(type), action)
+#define registerAction(type, action)                                                               \
+  action_factory.reg<type>(stringifyName(type), action, __FILE__, __LINE__)
 
   // Create the syntax
-  syntax.registerActionSyntax("AddNavierStokesVariablesAction", "Modules/NavierStokes/Variables");
-  syntax.registerActionSyntax("AddNavierStokesICsAction", "Modules/NavierStokes/ICs");
-  syntax.registerActionSyntax("AddNavierStokesKernelsAction", "Modules/NavierStokes/Kernels");
-  syntax.registerActionSyntax("AddNavierStokesBCsAction", "Modules/NavierStokes/BCs/*");
+  registerSyntax("AddNavierStokesVariablesAction", "Modules/NavierStokes/Variables");
+  registerSyntax("AddNavierStokesICsAction", "Modules/NavierStokes/ICs");
+  registerSyntax("AddNavierStokesKernelsAction", "Modules/NavierStokes/Kernels");
+  registerSyntax("AddNavierStokesBCsAction", "Modules/NavierStokes/BCs/*");
 
   // add variables action
   registerTask("add_navier_stokes_variables", /*is_required=*/false);

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -500,43 +500,32 @@ PhaseFieldApp__associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 void
 PhaseFieldApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  syntax.registerActionSyntax("BicrystalBoundingBoxICAction",
-                              "ICs/PolycrystalICs/BicrystalBoundingBoxIC");
-  syntax.registerActionSyntax("BicrystalCircleGrainICAction",
-                              "ICs/PolycrystalICs/BicrystalCircleGrainIC");
-  syntax.registerActionSyntax("CHPFCRFFSplitKernelAction", "Kernels/CHPFCRFFSplitKernel");
-  syntax.registerActionSyntax("CHPFCRFFSplitVariablesAction", "Variables/CHPFCRFFSplitVariables");
-  syntax.registerActionSyntax("DisplacementGradientsAction",
-                              "Modules/PhaseField/DisplacementGradients");
-  syntax.registerActionSyntax("EmptyAction", "ICs/PolycrystalICs"); // placeholder
-  syntax.registerActionSyntax("EulerAngle2RGBAction", "Modules/PhaseField/EulerAngles2RGB");
-  syntax.registerActionSyntax("HHPFCRFFSplitKernelAction", "Kernels/HHPFCRFFSplitKernel");
-  syntax.registerActionSyntax("HHPFCRFFSplitVariablesAction", "Variables/HHPFCRFFSplitVariables");
-  syntax.registerActionSyntax("MatVecRealGradAuxKernelAction",
-                              "AuxKernels/MatVecRealGradAuxKernel");
-  syntax.registerActionSyntax("MaterialVectorAuxKernelAction",
-                              "AuxKernels/MaterialVectorAuxKernel");
-  syntax.registerActionSyntax("MaterialVectorGradAuxKernelAction",
-                              "AuxKernels/MaterialVectorGradAuxKernel");
-  syntax.registerActionSyntax("MortarPeriodicAction", "Modules/PhaseField/MortarPeriodicity/*");
-  syntax.registerActionSyntax("MultiAuxVariablesAction", "AuxVariables/MultiAuxVariables");
-  syntax.registerActionSyntax("PFCRFFKernelAction", "Kernels/PFCRFFKernel");
-  syntax.registerActionSyntax("PFCRFFVariablesAction", "Variables/PFCRFFVariables");
-  syntax.registerActionSyntax("PolycrystalElasticDrivingForceAction",
-                              "Kernels/PolycrystalElasticDrivingForce");
-  syntax.registerActionSyntax("PolycrystalHexGrainICAction",
-                              "ICs/PolycrystalICs/PolycrystalHexGrainIC");
-  syntax.registerActionSyntax("PolycrystalKernelAction", "Kernels/PolycrystalKernel");
-  syntax.registerActionSyntax("PolycrystalRandomICAction",
-                              "ICs/PolycrystalICs/PolycrystalRandomIC");
-  syntax.registerActionSyntax("PolycrystalStoredEnergyAction", "Kernels/PolycrystalStoredEnergy");
-  syntax.registerActionSyntax("PolycrystalVariablesAction", "Variables/PolycrystalVariables");
-  syntax.registerActionSyntax("PolycrystalVoronoiICAction",
-                              "ICs/PolycrystalICs/PolycrystalVoronoiIC");
-  syntax.registerActionSyntax("ReconVarICAction", "ICs/PolycrystalICs/ReconVarIC");
-  syntax.registerActionSyntax("RigidBodyMultiKernelAction", "Kernels/RigidBodyMultiKernel");
-  syntax.registerActionSyntax("Tricrystal2CircleGrainsICAction",
-                              "ICs/PolycrystalICs/Tricrystal2CircleGrainsIC");
+  registerSyntax("BicrystalBoundingBoxICAction", "ICs/PolycrystalICs/BicrystalBoundingBoxIC");
+  registerSyntax("BicrystalCircleGrainICAction", "ICs/PolycrystalICs/BicrystalCircleGrainIC");
+  registerSyntax("CHPFCRFFSplitKernelAction", "Kernels/CHPFCRFFSplitKernel");
+  registerSyntax("CHPFCRFFSplitVariablesAction", "Variables/CHPFCRFFSplitVariables");
+  registerSyntax("DisplacementGradientsAction", "Modules/PhaseField/DisplacementGradients");
+  registerSyntax("EmptyAction", "ICs/PolycrystalICs"); // placeholder
+  registerSyntax("EulerAngle2RGBAction", "Modules/PhaseField/EulerAngles2RGB");
+  registerSyntax("HHPFCRFFSplitKernelAction", "Kernels/HHPFCRFFSplitKernel");
+  registerSyntax("HHPFCRFFSplitVariablesAction", "Variables/HHPFCRFFSplitVariables");
+  registerSyntax("MatVecRealGradAuxKernelAction", "AuxKernels/MatVecRealGradAuxKernel");
+  registerSyntax("MaterialVectorAuxKernelAction", "AuxKernels/MaterialVectorAuxKernel");
+  registerSyntax("MaterialVectorGradAuxKernelAction", "AuxKernels/MaterialVectorGradAuxKernel");
+  registerSyntax("MortarPeriodicAction", "Modules/PhaseField/MortarPeriodicity/*");
+  registerSyntax("MultiAuxVariablesAction", "AuxVariables/MultiAuxVariables");
+  registerSyntax("PFCRFFKernelAction", "Kernels/PFCRFFKernel");
+  registerSyntax("PFCRFFVariablesAction", "Variables/PFCRFFVariables");
+  registerSyntax("PolycrystalElasticDrivingForceAction", "Kernels/PolycrystalElasticDrivingForce");
+  registerSyntax("PolycrystalHexGrainICAction", "ICs/PolycrystalICs/PolycrystalHexGrainIC");
+  registerSyntax("PolycrystalKernelAction", "Kernels/PolycrystalKernel");
+  registerSyntax("PolycrystalRandomICAction", "ICs/PolycrystalICs/PolycrystalRandomIC");
+  registerSyntax("PolycrystalStoredEnergyAction", "Kernels/PolycrystalStoredEnergy");
+  registerSyntax("PolycrystalVariablesAction", "Variables/PolycrystalVariables");
+  registerSyntax("PolycrystalVoronoiICAction", "ICs/PolycrystalICs/PolycrystalVoronoiIC");
+  registerSyntax("ReconVarICAction", "ICs/PolycrystalICs/ReconVarIC");
+  registerSyntax("RigidBodyMultiKernelAction", "Kernels/RigidBodyMultiKernel");
+  registerSyntax("Tricrystal2CircleGrainsICAction", "ICs/PolycrystalICs/Tricrystal2CircleGrainsIC");
 
   registerAction(BicrystalBoundingBoxICAction, "add_ic");
   registerAction(BicrystalCircleGrainICAction, "add_ic");

--- a/modules/richards/src/base/RichardsApp.C
+++ b/modules/richards/src/base/RichardsApp.C
@@ -225,10 +225,10 @@ RichardsApp::registerObjects(Factory & factory)
 void
 RichardsApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  syntax.registerActionSyntax("Q2PAction", "Q2P", "add_kernel");
-  syntax.registerActionSyntax("Q2PAction", "Q2P", "add_aux_variable");
-  syntax.registerActionSyntax("Q2PAction", "Q2P", "add_function");
-  syntax.registerActionSyntax("Q2PAction", "Q2P", "add_postprocessor");
+  registerSyntaxTask("Q2PAction", "Q2P", "add_kernel");
+  registerSyntaxTask("Q2PAction", "Q2P", "add_aux_variable");
+  registerSyntaxTask("Q2PAction", "Q2P", "add_function");
+  registerSyntaxTask("Q2PAction", "Q2P", "add_postprocessor");
 
   registerAction(Q2PAction, "add_kernel");
   registerAction(Q2PAction, "add_aux_variable");

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -156,14 +156,14 @@ SolidMechanicsApp__associateSyntax(Syntax & syntax, ActionFactory & action_facto
 void
 SolidMechanicsApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  syntax.registerActionSyntax("SolidMechanicsAction", "SolidMechanics/*");
+  registerSyntax("SolidMechanicsAction", "SolidMechanics/*");
 
-  syntax.registerActionSyntax("DomainIntegralAction", "DomainIntegral", "add_user_object");
-  syntax.registerActionSyntax("DomainIntegralAction", "DomainIntegral", "add_aux_variable");
-  syntax.registerActionSyntax("DomainIntegralAction", "DomainIntegral", "add_aux_kernel");
-  syntax.registerActionSyntax("DomainIntegralAction", "DomainIntegral", "add_postprocessor");
-  syntax.registerActionSyntax("DomainIntegralAction", "DomainIntegral", "add_vector_postprocessor");
-  syntax.registerActionSyntax("DomainIntegralAction", "DomainIntegral", "add_material");
+  registerSyntaxTask("DomainIntegralAction", "DomainIntegral", "add_user_object");
+  registerSyntaxTask("DomainIntegralAction", "DomainIntegral", "add_aux_variable");
+  registerSyntaxTask("DomainIntegralAction", "DomainIntegral", "add_aux_kernel");
+  registerSyntaxTask("DomainIntegralAction", "DomainIntegral", "add_postprocessor");
+  registerSyntaxTask("DomainIntegralAction", "DomainIntegral", "add_vector_postprocessor");
+  registerSyntaxTask("DomainIntegralAction", "DomainIntegral", "add_material");
 
   registerAction(SolidMechanicsAction, "add_kernel");
   registerAction(DomainIntegralAction, "add_user_object");

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -381,22 +381,22 @@ TensorMechanicsApp__associateSyntax(Syntax & syntax, ActionFactory & action_fact
 void
 TensorMechanicsApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  syntax.registerActionSyntax("EmptyAction", "BCs/CavityPressure");
-  syntax.registerActionSyntax("CavityPressureAction", "BCs/CavityPressure/*");
-  syntax.registerActionSyntax("CavityPressurePPAction", "BCs/CavityPressure/*");
-  syntax.registerActionSyntax("CavityPressureUOAction", "BCs/CavityPressure/*");
+  registerSyntax("EmptyAction", "BCs/CavityPressure");
+  registerSyntax("CavityPressureAction", "BCs/CavityPressure/*");
+  registerSyntax("CavityPressurePPAction", "BCs/CavityPressure/*");
+  registerSyntax("CavityPressureUOAction", "BCs/CavityPressure/*");
 
-  syntax.registerActionSyntax("LegacyTensorMechanicsAction", "Kernels/TensorMechanics");
-  syntax.registerActionSyntax("DynamicTensorMechanicsAction", "Kernels/DynamicTensorMechanics");
-  syntax.registerActionSyntax("PoroMechanicsAction", "Kernels/PoroMechanics");
+  registerSyntax("LegacyTensorMechanicsAction", "Kernels/TensorMechanics");
+  registerSyntax("DynamicTensorMechanicsAction", "Kernels/DynamicTensorMechanics");
+  registerSyntax("PoroMechanicsAction", "Kernels/PoroMechanics");
 
-  syntax.registerActionSyntax("EmptyAction", "BCs/Pressure");
-  syntax.registerActionSyntax("PressureAction", "BCs/Pressure/*");
+  registerSyntax("EmptyAction", "BCs/Pressure");
+  registerSyntax("PressureAction", "BCs/Pressure/*");
 
-  syntax.registerActionSyntax("GeneralizedPlaneStrainAction",
-                              "Modules/TensorMechanics/GeneralizedPlaneStrain/*");
-  syntax.registerActionSyntax("CommonTensorMechanicsAction", "Modules/TensorMechanics/Master");
-  syntax.registerActionSyntax("TensorMechanicsAction", "Modules/TensorMechanics/Master/*");
+  registerSyntax("GeneralizedPlaneStrainAction",
+                 "Modules/TensorMechanics/GeneralizedPlaneStrain/*");
+  registerSyntax("CommonTensorMechanicsAction", "Modules/TensorMechanics/Master");
+  registerSyntax("TensorMechanicsAction", "Modules/TensorMechanics/Master/*");
 
   registerTask("validate_coordinate_systems", /*is_required=*/false);
   addTaskDependency("validate_coordinate_systems", "create_problem");

--- a/modules/xfem/src/base/XFEMApp.C
+++ b/modules/xfem/src/base/XFEMApp.C
@@ -97,5 +97,5 @@ XFEMApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   registerAction(XFEMAction, "add_aux_variable");
   registerAction(XFEMAction, "add_aux_kernel");
 
-  syntax.registerActionSyntax("XFEMAction", "XFEM");
+  registerSyntax("XFEMAction", "XFEM");
 }

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -585,19 +585,18 @@ MooseTestApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 
   registerAction(TestGetActionsAction, "meta_action");
 
-  syntax.registerActionSyntax("ConvDiffMetaAction", "ConvectionDiffusion");
-  syntax.registerActionSyntax("AddAuxVariableAction", "MoreAuxVariables/*", "add_aux_variable");
-  syntax.registerActionSyntax(
-      "AddLotsOfAuxVariablesAction", "LotsOfAuxVariables/*", "add_variable");
+  registerSyntax("ConvDiffMetaAction", "ConvectionDiffusion");
+  registerSyntaxTask("AddAuxVariableAction", "MoreAuxVariables/*", "add_aux_variable");
+  registerSyntaxTask("AddLotsOfAuxVariablesAction", "LotsOfAuxVariables/*", "add_variable");
 
   registerAction(ApplyCoupledVariablesTestAction, "meta_action");
-  syntax.registerActionSyntax("ApplyCoupledVariablesTestAction", "ApplyInputParametersTest");
-  syntax.registerActionSyntax("AddLotsOfDiffusion", "Testing/LotsOfDiffusion/*");
-  syntax.registerActionSyntax("TestGetActionsAction", "TestGetActions");
-  syntax.registerActionSyntax("BadAddKernelAction", "BadKernels/*");
+  registerSyntax("ApplyCoupledVariablesTestAction", "ApplyInputParametersTest");
+  registerSyntax("AddLotsOfDiffusion", "Testing/LotsOfDiffusion/*");
+  registerSyntax("TestGetActionsAction", "TestGetActions");
+  registerSyntax("BadAddKernelAction", "BadKernels/*");
 
   registerAction(AddMatAndKernel, "add_kernel");
   registerAction(AddMatAndKernel, "add_material");
   registerAction(AddMatAndKernel, "add_variable");
-  syntax.registerActionSyntax("AddMatAndKernel", "AddMatAndKernel");
+  registerSyntax("AddMatAndKernel", "AddMatAndKernel");
 }

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -155,7 +155,7 @@ class TestJSON(unittest.TestCase):
         # There is a problem with the GetPotParser parsing this because
         # the comments got split and there is a unmatched " on a line of the comment.
         # This breaks the parser and it doesn't read in all the parameters.
-        #self.assertIn("petsc_options", split.params_list)
+        # self.assertIn("petsc_options", split.params_list)
 
     def testInputFileFormatSearch(self):
         """
@@ -168,6 +168,26 @@ class TestJSON(unittest.TestCase):
         self.assertEqual(len(root.children_list), 1)
         self.assertIn("initial_steps", root.children["Adaptivity"].params_list)
         self.assertEqual(len(root.children["Adaptivity"].params_list), 1)
+
+    def testLineInfo(self):
+        """
+        Make sure file/line information works
+        """
+        data = self.getJsonData()
+        adapt = data["Adaptivity"]["actions"]["SetAdaptivityOptionsAction"]
+        fi = adapt["file_info"]
+        self.assertEqual(len(fi.keys()), 1)
+        fname = fi.keys()[0]
+        # Clang seems to have the full path name for __FILE__
+        # gcc seems to just use the path that is given on the command line, which won't include "framework"
+        self.assertTrue(fname.endswith(os.path.join("src", "parser", "MooseSyntax.C")))
+        self.assertGreater(fi[fname], 0)
+
+        fi = adapt["tasks"]["set_adaptivity_options"]["file_info"]
+        self.assertEqual(len(fi.keys()), 1)
+        fname = fi.keys()[0]
+        self.assertTrue(fname.endswith(os.path.join("src", "base", "Moose.C")))
+        self.assertGreater(fi[fname], 0)
 
 if __name__ == '__main__':
     unittest.main(module=__name__, verbosity=2)


### PR DESCRIPTION
This stores file and line information in `Factory`, `ActionFactory`, and `Syntax` by modifying the various register macros.
To get the info for `Syntax` I added a couple of macros that can be used instead of the `syntax.registerActionSyntax()`.
I made it so that this is not required so that existing code should still work.
This is mainly for #7855 . @aeslaughter Does this work for you?