### PR TITLE
Allow exodus and postprocessor files on the command line without switches

### DIFF
--- a/python/peacock/ExodusViewer/ExodusPluginManager.py
+++ b/python/peacock/ExodusViewer/ExodusPluginManager.py
@@ -24,12 +24,6 @@ class ExodusPluginManager(QtWidgets.QWidget, peacock.base.PluginManager):
         self.setup()
         self.LeftLayout.addStretch(1)
 
-    def initialize(self, *args, **kwargs):
-        """
-        Fixes the widget widths after they have appeared to allow VTK window to maximize space.
-        """
-        super(ExodusPluginManager, self).initialize(*args, **kwargs)
-
         # Set the width of the left-side widgets to that the VTK window gets the space
         width = 0
         for child in self._plugins.itervalues():

--- a/python/peacock/ExodusViewer/ExodusViewer.py
+++ b/python/peacock/ExodusViewer/ExodusViewer.py
@@ -13,6 +13,7 @@ from plugins.OutputPlugin import OutputPlugin
 from plugins.CameraPlugin import CameraPlugin
 from plugins.MediaControlPlugin import MediaControlPlugin
 from plugins.BlockPlugin import BlockPlugin
+import os
 
 class ExodusViewer(peacock.base.ViewerBase):
     """
@@ -42,6 +43,10 @@ class ExodusViewer(peacock.base.ViewerBase):
         options = kwargs.pop('cmd_line_options', None)
         if options:
             filenames += options.exodus
+            for arg in options.arguments:
+                if arg.endswith(".e"):
+                    filenames.append(os.path.abspath(arg))
+            options.exodus = filenames # so that we can switch to this tab automatically
 
         if len(filenames) == 0:
             return

--- a/python/peacock/PostprocessorViewer/PostprocessorViewer.py
+++ b/python/peacock/PostprocessorViewer/PostprocessorViewer.py
@@ -1,4 +1,4 @@
-import sys
+import sys, os
 from PyQt5 import QtWidgets
 
 import peacock
@@ -68,6 +68,10 @@ class PostprocessorViewer(peacock.base.ViewerBase):
         options = kwargs.pop('cmd_line_options', None)
         if options:
             filenames += options.postprocessors
+            for arg in options.arguments:
+                if arg.endswith(".csv"):
+                    filenames.append(os.path.abspath(arg))
+            options.postprocessors = filenames # so that we can switch to this tab automatically
 
         if len(filenames) == 0:
             return

--- a/python/peacock/base/ViewerBase.py
+++ b/python/peacock/base/ViewerBase.py
@@ -41,7 +41,6 @@ class ViewerBase(QtWidgets.QTabWidget, TabPlugin):
         for i in range(self.count()):
             self.widget(i).initialize(*args, **kwargs)
         self._data = args
-        self.setMinimumSize(self.size())
 
     def onClose(self):
         """

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -50,6 +50,12 @@ class Tests(Testing.PeacockTester):
         self.check_current_tab(tabs, self.result.tabName())
         self.check_result()
 
+    def testResultsNoOption(self):
+        self.create_app(["gold/out_transient.e"])
+        tabs = self.app.main_widget.tab_plugin
+        self.check_current_tab(tabs, self.result.tabName())
+        self.check_result()
+
     def check_postprocessor(self):
         fname = "peacock_postprocessor.png"
         Testing.remove_file(fname)
@@ -75,6 +81,18 @@ class Tests(Testing.PeacockTester):
         Testing.set_window_size(w.FigurePlugin)
         w.FigurePlugin.onWrite(fname)
         self.assertFalse(Testing.gold_diff(fname))
+
+    def testPostprocessor(self):
+        self.create_app(["-p", "../gold/out_transient.csv"])
+        tabs = self.app.main_widget.tab_plugin
+        self.check_current_tab(tabs, self.postprocessor.tabName())
+        self.check_postprocessor()
+
+    def testPostprocessorNoOption(self):
+        self.create_app(["../gold/out_transient.csv"])
+        tabs = self.app.main_widget.tab_plugin
+        self.check_current_tab(tabs, self.postprocessor.tabName())
+        self.check_postprocessor()
 
     def testAllCommandLine(self):
         d = os.getcwd()


### PR DESCRIPTION
This also fixes some sizing issues with ExodusViewer that showed up when having an exodus file on the command line.