### PR TITLE
Try out contact tests with new petsc

### DIFF
--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin.i
@@ -304,8 +304,8 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package -mat_superlu_dist_fact'
+  petsc_options_value = 'lu            superlu_dist               SamePattern'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
@@ -288,7 +288,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_value = 'lu            superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_template1.i
@@ -291,9 +291,6 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
-
   line_search = 'none'
 
   nl_abs_tol = 1e-7

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
@@ -3,7 +3,9 @@
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_glued_kin_check.csv cyl3_glued_kin_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic Outputs/file_base=cyl3_glued_kin_out Outputs/chkfile/file_base=cyl3_glued_kin_check'
+    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic
+                Outputs/file_base=cyl3_glued_kin_out Outputs/chkfile/file_base=cyl3_glued_kin_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
@@ -14,7 +16,11 @@
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_glued_pen_check.csv cyl3_glued_pen_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=penalty Contact/leftright/normalize_penalty=true Outputs/file_base=cyl3_glued_pen_out Outputs/chkfile/file_base=cyl3_glued_pen_check'
+    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=penalty
+                Contact/leftright/normalize_penalty=true
+                Outputs/chkfile/file_base=cyl3_glued_pen_check'
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package"
+                Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
@@ -25,20 +31,27 @@
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_frictionless_kin_check.csv cyl3_frictionless_kin_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=kinematic Outputs/file_base=cyl3_frictionless_kin_out Outputs/chkfile/file_base=cyl3_frictionless_kin_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=kinematic
+                Outputs/file_base=cyl3_frictionless_kin_out Outputs/chkfile/file_base=cyl3_frictionless_kin_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package -mat_superlu_dist_fact"
+                Executioner/petsc_options_value="lu superlu_dist SamePattern"'
     rel_err = 2e-5
     abs_zero = 1e-4
     max_parallel = 1
     superlu = true
     prereq = 'frictionless_kin_sm'
-    # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    # This test is fails reliably on INTEL compilers with PETSc 3.7.4 and 3.7.5, so restrict the test to not INTEL
+    compiler = 'GCC CLANG'
+    petsc_version = '>=3.7.5'
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_frictionless_pen_check.csv cyl3_frictionless_pen_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=penalty Contact/leftright/normalize_penalty=true Outputs/file_base=cyl3_frictionless_pen_out Outputs/chkfile/file_base=cyl3_frictionless_pen_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=penalty Contact/leftright/normalize_penalty=true
+                Outputs/file_base=cyl3_frictionless_pen_out Outputs/chkfile/file_base=cyl3_frictionless_pen_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package"
+                Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
@@ -49,7 +62,11 @@
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_frictionless_aug_check.csv cyl3_frictionless_aug_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=augmented_lagrange Contact/leftright/normalize_penalty=true Outputs/file_base=cyl3_frictionless_aug_out Outputs/chkfile/file_base=cyl3_frictionless_aug_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=augmented_lagrange
+                Contact/leftright/normalize_penalty=true Outputs/file_base=cyl3_frictionless_aug_out
+                Outputs/chkfile/file_base=cyl3_frictionless_aug_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package"
+                Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
@@ -68,7 +85,7 @@
     # This test is unstable on PETSc 3.7.4 with 64bit indices enabled.
     dof_id_bytes = 4
     # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.5'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -142,7 +159,8 @@
     # This test is unstable on PETSc 3.7.4 with 64bit indices enabled.
     dof_id_bytes = 4
     # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    skip = 'Reevaluate under PETSc 3.7.4. and PETSc 3.7.5 #8200'
+    prereq = 'mu_0_2_kin'
   [../]
   [./mu_0_2_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin.i
@@ -289,8 +289,8 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package -mat_superlu_dist_fact'
+  petsc_options_value = 'lu            superlu_dist               SamePattern'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
@@ -281,8 +281,8 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package -mat_superlu_dist_fact'
+  petsc_options_value = 'lu            superlu_dist               SamePattern'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
@@ -269,8 +269,8 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package -mat_superlu_dist_fact'
+  petsc_options_value = 'lu            superlu_dist               SamePattern'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
@@ -257,9 +257,6 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
-
   line_search = 'none'
 
   nl_abs_tol = 1e-10

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
@@ -8,8 +8,8 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    #prereq = 'glued_kin_sm' #the prereq test is also skipped
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    prereq = 'glued_kin_sm'
+    petsc_version = '>=3.7.5'
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -32,7 +32,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'frictionless_kin_sm'
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.5'
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -64,8 +64,8 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    #prereq = 'mu_0_2_kin_sm'  #Commented out because the prereq test is currently skipped #8200
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    prereq = 'mu_0_2_kin_sm'
+    petsc_version = '>=3.7.5'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -81,18 +81,23 @@
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_glued_kin_check.csv plane3_glued_kin_check_cont_press_0001.csv plane3_glued_kin_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic Outputs/file_base=plane3_glued_kin_out Outputs/chkfile/file_base=plane3_glued_kin_check'
+    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic
+                Outputs/file_base=plane3_glued_kin_out Outputs/chkfile/file_base=plane3_glued_kin_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package -mat_superlu_dist_fact"
+                Executioner/petsc_options_value="lu superlu_dist SamePattern"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.5'
   [../]
   [./glued_pen_sm]
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_glued_pen_check.csv plane3_glued_pen_check_cont_press_0001.csv plane3_glued_pen_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=penalty Outputs/file_base=plane3_glued_pen_out Outputs/chkfile/file_base=plane3_glued_pen_check'
+    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=penalty
+                Outputs/file_base=plane3_glued_pen_out Outputs/chkfile/file_base=plane3_glued_pen_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
@@ -102,7 +107,9 @@
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_frictionless_kin_check.csv plane3_frictionless_kin_check_cont_press_0001.csv plane3_frictionless_kin_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=kinematic Outputs/file_base=plane3_frictionless_kin_out Outputs/chkfile/file_base=plane3_frictionless_kin_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=kinematic
+                Outputs/file_base=plane3_frictionless_kin_out Outputs/chkfile/file_base=plane3_frictionless_kin_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
@@ -112,7 +119,9 @@
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_frictionless_pen_check.csv plane3_frictionless_pen_check_cont_press_0001.csv plane3_frictionless_pen_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=penalty Outputs/file_base=plane3_frictionless_pen_out Outputs/chkfile/file_base=plane3_frictionless_pen_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=penalty
+                Outputs/file_base=plane3_frictionless_pen_out Outputs/chkfile/file_base=plane3_frictionless_pen_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
@@ -122,7 +131,9 @@
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_frictionless_aug_check.csv plane3_frictionless_aug_check_cont_press_0001.csv plane3_frictionless_aug_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=augmented_lagrange Outputs/file_base=plane3_frictionless_aug_out Outputs/chkfile/file_base=plane3_frictionless_aug_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=augmented_lagrange
+                Outputs/file_base=plane3_frictionless_aug_out Outputs/chkfile/file_base=plane3_frictionless_aug_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
@@ -136,7 +147,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.5'
   [../]
   [./mu_0_2_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin.i
@@ -299,8 +299,8 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package -mat_superlu_dist_fact'
+  petsc_options_value = 'lu            superlu_dist               SamePattern'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
@@ -63,7 +63,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'mu_0_2_kin_sm'
-    skip = 'Reevaluate under PETSc 3.7.4. #8200.'
+    petsc_version = '>=3.7.5'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'


### PR DESCRIPTION
This commit introduces a check for the petsc version as a replacement for the skip in eight contact tests that have trouble with petsc 3.7.4.  This commit includes changes to only the tests files. @bwspenc, @acasagran.

Refs #8200