### PR TITLE
Make new JsonData python test require a display.

### DIFF
--- a/python/peacock/tests/input_tab/JsonData/tests
+++ b/python/peacock/tests/input_tab/JsonData/tests
@@ -2,5 +2,6 @@
   [./JsonData]
     type = PythonUnitTest
     input = test_JsonData.py
+    display_required = True
   [../]
 []


### PR DESCRIPTION
This got sneaked in on #8742 since previously we didn't do a python test without a display on PRs that only had python.
That test has been added to python testing.