### PR TITLE
Use directory path supplied by arguments

### DIFF
--- a/scripts/cluster_launcher.py
+++ b/scripts/cluster_launcher.py
@@ -98,7 +98,7 @@ class ClusterLauncher:
         return jobs
 
     def createAndLaunchJob(self, template_dir, job_file, specs, options):
-        next_dir = getNextDirName(specs['job_name'], os.listdir('.'))
+        next_dir = getNextDirName(specs['job_name'], os.listdir(template_dir))
         os.mkdir(template_dir + next_dir)
 
         # Log it


### PR DESCRIPTION
Use directory path supplied by arguments instead of where ever the user is
currently sitting, in order to determine serialized directory creation.

Refs #8750

