### PR TITLE
Add C++ enum to PorousFlowPropertyAux to make code clearer. Closes #8756

### DIFF
--- a/modules/porous_flow/include/auxkernels/PorousFlowPropertyAux.h
+++ b/modules/porous_flow/include/auxkernels/PorousFlowPropertyAux.h
@@ -60,8 +60,21 @@ private:
   /// PorousFlow Dictator UserObject
   const PorousFlowDictator & _dictator;
 
-  /// MooseEnum of properties that can be accessed
-  const MooseEnum & _property_enum;
+  /// enum of properties
+  enum PropertyEnum
+  {
+    PRESSURE,
+    SATURATION,
+    TEMPERATURE,
+    DENSITY,
+    VISCOSITY,
+    MASS_FRACTION,
+    RELPERM,
+    ENTHALPY,
+    INTERNAL_ENERGY
+  };
+
+  const PropertyEnum _property_enum;
 
   /// Phase index
   unsigned int _phase;

--- a/modules/porous_flow/src/auxkernels/PorousFlowPropertyAux.C
+++ b/modules/porous_flow/src/auxkernels/PorousFlowPropertyAux.C
@@ -23,7 +23,7 @@ InputParameters validParams<PorousFlowPropertyAux>()
 PorousFlowPropertyAux::PorousFlowPropertyAux(const InputParameters & parameters) :
     AuxKernel(parameters),
     _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _property_enum(getParam<MooseEnum>("property")),
+    _property_enum(getParam<MooseEnum>("property").getEnum<PropertyEnum>()),
     _phase(getParam<unsigned int>("phase")),
     _fluid_component(getParam<unsigned int>("fluid_component"))
 {
@@ -37,38 +37,38 @@ PorousFlowPropertyAux::PorousFlowPropertyAux(const InputParameters & parameters)
   // Only get material properties required by this instance of the AuxKernel
   switch (_property_enum)
   {
-    case 0: // pressure
+    case PRESSURE:
       _pressure = &getMaterialProperty<std::vector<Real>>("PorousFlow_porepressure_qp");
       break;
 
-    case 1: // saturation
+    case SATURATION:
       _saturation = &getMaterialProperty<std::vector<Real>>("PorousFlow_saturation_qp");
       break;
 
-    case 2: // temperature
+    case TEMPERATURE:
       _temperature = &getMaterialProperty<Real>("PorousFlow_temperature_qp");
       break;
 
-    case 3: // density
+    case DENSITY:
       _fluid_density = &getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_density_qp");
       break;
 
-    case 4: // viscosity
+    case VISCOSITY:
       _fluid_viscosity = &getMaterialProperty<std::vector<Real>>("PorousFlow_viscosity_qp");
       break;
 
-    case 5: // mass fraction
+    case MASS_FRACTION:
       _mass_fractions = &getMaterialProperty<std::vector<std::vector<Real>>>("PorousFlow_mass_frac_qp");
       break;
 
-    case 6: // relative permeability
+    case RELPERM:
       _relative_permeability = &getMaterialProperty<std::vector<Real>>("PorousFlow_relative_permeability_qp");
       break;
 
-    case 7: // enthalpy
+    case ENTHALPY:
       _enthalpy = &getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_enthalpy_qp");
 
-    case 8: // internal_energy
+    case INTERNAL_ENERGY:
       _internal_energy = &getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_internal_energy_qp");
   }
 }
@@ -80,39 +80,39 @@ PorousFlowPropertyAux::computeValue()
 
   switch (_property_enum)
   {
-    case 0: // pressure
+    case PRESSURE:
       property = (*_pressure)[_qp][_phase];
       break;
 
-    case 1: // saturation
+    case SATURATION:
       property = (*_saturation)[_qp][_phase];
       break;
 
-    case 2: // temperature
+    case TEMPERATURE:
       property = (*_temperature)[_qp];
       break;
 
-    case 3: // density
+    case DENSITY:
       property = (*_fluid_density)[_qp][_phase];
       break;
 
-    case 4: // viscosity
+    case VISCOSITY:
       property = (*_fluid_viscosity)[_qp][_phase];
       break;
 
-    case 5: // mass fraction
+    case MASS_FRACTION:
       property = (*_mass_fractions)[_qp][_phase][_fluid_component];
       break;
 
-    case 6: // relative permeability
+    case RELPERM:
       property = (*_relative_permeability)[_qp][_phase];
       break;
 
-    case 7: // enthalpy
+    case ENTHALPY:
       property = (*_enthalpy)[_qp][_phase];
       break;
 
-    case 8: // internal_energy
+    case INTERNAL_ENERGY:
       property = (*_internal_energy)[_qp][_phase];
       break;
   }


### PR DESCRIPTION
Make the switch statement easier to read by using an enum.

Closes #8756