### PR TITLE
Suppress use displaced mesh

### DIFF
--- a/modules/combined/examples/phase_field-mechanics/poly_grain_growth_2D_eldrforce.i
+++ b/modules/combined/examples/phase_field-mechanics/poly_grain_growth_2D_eldrforce.i
@@ -15,7 +15,6 @@
   op_num = 8
   var_name_base = gr
   grain_num = 36
-  use_displaced_mesh = true
 []
 
 [Variables]
@@ -83,6 +82,7 @@
   [./PolycrystalElasticDrivingForce]
   [../]
   [./TensorMechanics]
+    use_displaced_mesh = true
     displacements = 'disp_x disp_y'
   [../]
 []
@@ -249,8 +249,7 @@
 [Preconditioning]
   [./SMP]
     type = SMP
-    off_diag_row = 'disp_x disp_y'
-    off_diag_column = 'disp_y disp_x'
+    coupled_groups = 'disp_x,disp_y'
   [../]
 []
 

--- a/modules/porous_flow/tests/jacobian/phe01.i
+++ b/modules/porous_flow/tests/jacobian/phe01.i
@@ -5,8 +5,6 @@
 []
 
 [GlobalParams]
-  block = 0
-  use_displaced_mesh = false
   displacements = 'disp_x disp_y disp_z'
   PorousFlowDictator = dictator
 []

--- a/modules/porous_flow/tests/plastic_heating/compressive01.i
+++ b/modules/porous_flow/tests/plastic_heating/compressive01.i
@@ -18,8 +18,6 @@
 []
 
 [GlobalParams]
-  block = 0
-  use_displaced_mesh = false
   displacements = 'disp_x disp_y disp_z'
   PorousFlowDictator = dictator
 []

--- a/modules/porous_flow/tests/plastic_heating/shear01.i
+++ b/modules/porous_flow/tests/plastic_heating/shear01.i
@@ -20,8 +20,6 @@
 []
 
 [GlobalParams]
-  block = 0
-  use_displaced_mesh = false
   displacements = 'disp_x disp_y disp_z'
   PorousFlowDictator = dictator
 []

--- a/modules/porous_flow/tests/plastic_heating/tensile01.i
+++ b/modules/porous_flow/tests/plastic_heating/tensile01.i
@@ -18,8 +18,6 @@
 []
 
 [GlobalParams]
-  block = 0
-  use_displaced_mesh = false
   displacements = 'disp_x disp_y disp_z'
   PorousFlowDictator = dictator
 []

--- a/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
@@ -17,6 +17,7 @@ InputParameters validParams<ComputeStrainBase>()
   params.addParam<std::string>("base_name", "Optional parameter that allows the user to define multiple mechanics material systems on the same block, i.e. for multiple phases");
   params.addParam<bool>("volumetric_locking_correction", false, "Flag to correct volumetric locking");
   params.addParam<std::vector<MaterialPropertyName>>("eigenstrain_names", "List of eigenstrains to be applied in this strain calculation");
+  params.suppressParameter<bool>("use_displaced_mesh");
   return params;
 }
 
@@ -59,6 +60,9 @@ ComputeStrainBase::ComputeStrainBase(const InputParameters & parameters) :
 
   if (_ndisp == 1 && _volumetric_locking_correction)
     mooseError("Volumetric locking correction have to be set to false for 1-D problems.");
+
+  if (getParam<bool>("use_displaced_mesh"))
+    mooseError("The strain calculator needs to run on the undisplaced mesh.");
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStressBase.C
@@ -15,6 +15,7 @@ InputParameters validParams<ComputeStressBase>()
   params.addParam<std::vector<FunctionName> >("initial_stress", "A list of functions describing the initial stress.  If provided, there must be 9 of these, corresponding to the xx, yx, zx, xy, yy, zy, xz, yz, zz components respectively.  If not provided, all components of the initial stress will be zero");
   params.addParam<std::string>("base_name", "Optional parameter that allows the user to define multiple mechanics material systems on the same block, i.e. for multiple phases");
   params.addParam<bool>("store_stress_old", false, "Parameter which indicates whether the old stress state, required for the HHT time integration scheme and Rayleigh damping, needs to be stored");
+  params.suppressParameter<bool>("use_displaced_mesh");
   return params;
 }
 
@@ -46,6 +47,9 @@ ComputeStressBase::ComputeStressBase(const InputParameters & parameters) :
   _initial_stress.resize(num);
   for (unsigned i = 0; i < num; ++i)
     _initial_stress[i] = &getFunctionByName(fcn_names[i]);
+
+  if (getParam<bool>("use_displaced_mesh"))
+    mooseError("The stress calculator needs to run on the undisplaced mesh.");
 }
 
 void

--- a/modules/tensor_mechanics/tests/capped_weak_plane/beam.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/beam.i
@@ -15,7 +15,6 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  use_displaced_mesh = false
 []
 
 [Variables]
@@ -32,6 +31,7 @@
   [../]
   [./gravity_y]
     type = Gravity
+    use_displaced_mesh = false
     variable = disp_y
     value = -10
   [../]
@@ -442,4 +442,3 @@
   exodus = true
   csv = true
 []
-

--- a/modules/tensor_mechanics/tests/capped_weak_plane/pull_and_shear.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/pull_and_shear.i
@@ -56,7 +56,6 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  use_displaced_mesh = false
   beta = 0.25 # Newmark time integration
   gamma = 0.5 # Newmark time integration
   eta = 1E3 #0.3E4 # higher values mean more damping via density
@@ -73,24 +72,26 @@
 
 [Kernels]
   [./DynamicTensorMechanics] # zeta*K*vel + K * disp
-    displacements = 'disp_x disp_y disp_z'
     zeta = 1E-2 # higher values mean more damping via stiffness
     alpha = 0 # better nonlinear convergence than for alpha>0
   [../]
   [./inertia_x] # M*accel + eta*M*vel
     type = InertialForce
+    use_displaced_mesh = false
     variable = disp_x
     velocity = vel_x
     acceleration = accel_x
   [../]
   [./inertia_y]
     type = InertialForce
+    use_displaced_mesh = false
     variable = disp_y
     velocity = vel_y
     acceleration = accel_y
   [../]
   [./inertia_z]
     type = InertialForce
+    use_displaced_mesh = false
     variable = disp_z
     velocity = vel_z
     acceleration = accel_z
@@ -550,4 +551,3 @@
   exodus = true
   csv = true
 []
-

--- a/modules/tensor_mechanics/tests/capped_weak_plane/pull_and_shear_1step.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/pull_and_shear_1step.i
@@ -31,7 +31,6 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  use_displaced_mesh = false
 []
 
 [Variables]
@@ -452,4 +451,3 @@
   file_base = pull_and_shear_1step
   exodus = true
 []
-

--- a/modules/tensor_mechanics/tests/capped_weak_plane/pull_push.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/pull_push.i
@@ -15,7 +15,6 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  use_displaced_mesh = false
 []
 
 [Variables]
@@ -430,4 +429,3 @@
   exodus = true
   csv = true
 []
-

--- a/modules/tensor_mechanics/tests/capped_weak_plane/pull_push_h.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/pull_push_h.i
@@ -17,7 +17,6 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  use_displaced_mesh = false
 []
 
 [Variables]
@@ -433,4 +432,3 @@
   exodus = true
   csv = true
 []
-

--- a/modules/tensor_mechanics/tests/capped_weak_plane/push_and_shear.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/push_and_shear.i
@@ -56,7 +56,6 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  use_displaced_mesh = false
   beta = 0.25 # Newmark time integration
   gamma = 0.5 # Newmark time integration
   eta = 1E3 #0.3E4 # higher values mean more damping via density
@@ -79,18 +78,21 @@
   [../]
   [./inertia_x] # M*accel + eta*M*vel
     type = InertialForce
+    use_displaced_mesh = false
     variable = disp_x
     velocity = vel_x
     acceleration = accel_x
   [../]
   [./inertia_y]
     type = InertialForce
+    use_displaced_mesh = false
     variable = disp_y
     velocity = vel_y
     acceleration = accel_y
   [../]
   [./inertia_z]
     type = InertialForce
+    use_displaced_mesh = false
     variable = disp_z
     velocity = vel_z
     acceleration = accel_z
@@ -550,4 +552,3 @@
   exodus = true
   csv = true
 []
-

--- a/modules/tensor_mechanics/tests/dynamics/acceleration_bc/AccelerationBC_test.i
+++ b/modules/tensor_mechanics/tests/dynamics/acceleration_bc/AccelerationBC_test.i
@@ -25,7 +25,7 @@
 []
 
 [GlobalParams]
-  use_displaced_mesh = false
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
@@ -63,7 +63,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    displacements = 'disp_x disp_y disp_z'
   [../]
   [./inertia_x]
     type = InertialForce
@@ -202,24 +201,19 @@
 [Materials]
   [./Elasticity_tensor]
     type = ComputeElasticityTensor
-    block = 0
     fill_method = symmetric_isotropic
     C_ijkl = '210e9 0'
   [../]
 
   [./strain]
     type = ComputeSmallStrain
-    block = 0
-    displacements = 'disp_x disp_y disp_z'
   [../]
 
   [./stress]
     type = ComputeLinearElasticStress
-    block = 0
   [../]
   [./density]
     type = GenericConstantMaterial
-    block = 0
     prop_names = 'density'
     prop_values = '7750'
   [../]

--- a/modules/tensor_mechanics/tests/jacobian/cwp11.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp11.i
@@ -6,8 +6,7 @@
 []
 
 [GlobalParams]
-  block = 0
-  use_displaced_mesh = false
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
@@ -21,7 +20,6 @@
 
 [Kernels]
   [./TensorMechanics]
-    displacements = 'disp_x disp_y disp_z'
   [../]
 []
 
@@ -67,7 +65,6 @@
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain
-    displacements = 'disp_x disp_y disp_z'
   [../]
   [./mc]
     type = ComputeCappedWeakPlaneStress

--- a/modules/tensor_mechanics/tests/jacobian/phe01.i
+++ b/modules/tensor_mechanics/tests/jacobian/phe01.i
@@ -5,8 +5,6 @@
 []
 
 [GlobalParams]
-  block = 0
-  use_displaced_mesh = false
   displacements = 'disp_x disp_y disp_z'
 []
 

--- a/modules/tensor_mechanics/tests/static_deformations/beam_cosserat_02_apply_stress.i
+++ b/modules/tensor_mechanics/tests/static_deformations/beam_cosserat_02_apply_stress.i
@@ -47,7 +47,7 @@
 []
 
 [GlobalParams]
-  use_displaced_mesh = false
+  #use_displaced_mesh = false
   displacements = 'disp_x disp_y disp_z'
   Cosserat_rotations = 'wc_x wc_y wc_z'
 []


### PR DESCRIPTION
Suppress `use_displaced_mesh` parameter for tensor mechanics stress and strain calculators. This fails a few tests (because it errors out even if `use_displaced_mesh` is specified in `[GlobalParams]` - this seems wrong @permcody). I fixed <s>some</s> tests<s>, but I'll need help with a few more @WilkAndy</s>.

Closes #8708 