### PR TITLE
Silence Transfer Messages in opt Mode

### DIFF
--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -2815,7 +2815,9 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type, MultiAppTransfer::DIRECT
   {
     const auto & transfers = wh.getActiveObjects();
 
+    #ifndef NDEBUG
     _console << COLOR_CYAN << "\nStarting Transfers on " <<  Moose::stringify(type) << string_direction << "MultiApps" << COLOR_DEFAULT << std::endl;
+    #endif
     for (const auto & transfer : transfers)
     {
       Moose::perf_log.push(transfer->name(), "Transfers");
@@ -2823,13 +2825,19 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type, MultiAppTransfer::DIRECT
       Moose::perf_log.pop(transfer->name(), "Transfers");
     }
 
+    #ifndef NDEBUG
     _console << "Waiting For Transfers To Finish" << '\n';
     MooseUtils::parallelBarrierNotify(_communicator);
 
     _console << COLOR_CYAN << "Transfers on " <<  Moose::stringify(type) << " Are Finished\n" << COLOR_DEFAULT << std::endl;
+    #endif
   }
   else if (_multi_apps[type].getActiveObjects().size())
+  {
+    #ifndef NDEBUG
     _console << COLOR_CYAN << "\nNo Transfers on " <<  Moose::stringify(type) << " To MultiApps\n" << COLOR_DEFAULT << std::endl;
+    #endif
+  }
 }
 
 std::vector<std::shared_ptr<Transfer>>
@@ -2855,22 +2863,28 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
   // Execute MultiApps
   if (multi_apps.size())
   {
+    #ifndef NDEBUG
     _console << COLOR_CYAN << "\nExecuting MultiApps on " <<  Moose::stringify(type) << COLOR_DEFAULT << std::endl;
+    #endif
 
     bool success = true;
 
     for (const auto & multi_app : multi_apps)
       success = multi_app->solveStep(_dt, _time, auto_advance);
 
+    #ifndef NDEBUG
     _console << "Waiting For Other Processors To Finish" << '\n';
     MooseUtils::parallelBarrierNotify(_communicator);
+    #endif
 
     _communicator.max(success);
 
     if (!success)
       return false;
 
+    #ifndef NDEBUG
     _console << COLOR_CYAN << "Finished Executing MultiApps on " <<  Moose::stringify(type) << "\n" << COLOR_DEFAULT << std::endl;
+    #endif
   }
 
   // Execute Transfers _from_ MultiApps

--- a/framework/src/transfers/MultiAppCopyTransfer.C
+++ b/framework/src/transfers/MultiAppCopyTransfer.C
@@ -106,7 +106,9 @@ MultiAppCopyTransfer::transfer(FEProblemBase & to_problem, FEProblemBase & from_
 void
 MultiAppCopyTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning MultiAppCopyTransfer " << name() << std::endl;
+  #endif
 
   if (_direction == TO_MULTIAPP)
   {
@@ -124,5 +126,7 @@ MultiAppCopyTransfer::execute()
         transfer(to_problem, _multi_app->appProblemBase(i));
   }
 
+  #ifndef NDEBUG
   _console << "Finished MultiAppCopyTransfer " << name() << std::endl;
+  #endif
 }

--- a/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
@@ -60,21 +60,29 @@ MultiAppDTKUserObjectTransfer::execute()
 
     _src_to_tgt_map = new DataTransferKit::VolumeSourceMap<DataTransferKit::Box, GlobalOrdinal, DataTransferKit::MeshContainer<GlobalOrdinal> >(_comm_default, 3, true);
 
+    #ifndef NDEBUG
     _console << "--Setting Up Transfer--" << std::endl;
+    #endif
     if (_variable->isNodal())
       _src_to_tgt_map->setup(_multi_app_geom, _to_adapter->get_target_coords());
     else
       _src_to_tgt_map->setup(_multi_app_geom, _to_adapter->get_elem_target_coords());
 
+    #ifndef NDEBUG
     _console << "--Transfer Setup Complete--" << std::endl;
+    #endif
 
     _to_values = _to_adapter->get_values_to_fill(_variable->name());
 
   }
 
+  #ifndef NDEBUG
   _console << "--Mapping Values--" << std::endl;
+  #endif
   _src_to_tgt_map->apply(_field_evaluator, _to_values);
+  #ifndef NDEBUG
   _console << "--Finished Mapping--" << std::endl;
+  #endif
 
   _to_adapter->update_variable_values(_variable->name(), _src_to_tgt_map->getMissedTargetPoints());
   _multi_app->problemBase().es().update();

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -73,7 +73,9 @@ MultiAppInterpolationTransfer::initialSetup()
 void
 MultiAppInterpolationTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning InterpolationTransfer " << name() << std::endl;
+  #endif
 
   switch (_direction)
   {
@@ -446,7 +448,9 @@ MultiAppInterpolationTransfer::execute()
     }
   }
 
+  #ifndef NDEBUG
   _console << "Finished InterpolationTransfer " << name() << std::endl;
+  #endif
 }
 
 Node * MultiAppInterpolationTransfer::getNearestNode(const Point & p, Real & distance, const MeshBase::const_node_iterator & nodes_begin, const MeshBase::const_node_iterator & nodes_end)

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -60,7 +60,9 @@ MultiAppMeshFunctionTransfer::initialSetup()
 void
 MultiAppMeshFunctionTransfer::execute()
 {
-  Moose::out << "Beginning MeshFunctionTransfer " << name() << std::endl;
+  #ifndef NDEBUG
+  _console << "Beginning MeshFunctionTransfer " << name() << std::endl;
+  #endif
 
   getAppInfo();
 
@@ -415,5 +417,7 @@ MultiAppMeshFunctionTransfer::execute()
       send_ids[i_proc].wait();
   }
 
+  #ifndef NDEBUG
   _console << "Finished MeshFunctionTransfer " << name() << std::endl;
+  #endif
 }

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -71,7 +71,9 @@ MultiAppNearestNodeTransfer::initialSetup()
 void
 MultiAppNearestNodeTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning NearestNodeTransfer " << name() << std::endl;
+  #endif
 
   getAppInfo();
 
@@ -493,7 +495,9 @@ MultiAppNearestNodeTransfer::execute()
     send_evals[i_proc].wait();
   }
 
+  #ifndef NDEBUG
   _console << "Finished NearestNodeTransfer " << name() << std::endl;
+  #endif
 }
 
 Node *

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -56,7 +56,9 @@ MultiAppPostprocessorInterpolationTransfer::MultiAppPostprocessorInterpolationTr
 void
 MultiAppPostprocessorInterpolationTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning PostprocessorInterpolationTransfer " << name() << std::endl;
+  #endif
 
   switch (_direction)
   {
@@ -155,5 +157,7 @@ MultiAppPostprocessorInterpolationTransfer::execute()
     }
   }
 
+  #ifndef NDEBUG
   _console << "Finished PostprocessorInterpolationTransfer " << name() << std::endl;
+  #endif
 }

--- a/framework/src/transfers/MultiAppPostprocessorToAuxScalarTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorToAuxScalarTransfer.C
@@ -43,7 +43,9 @@ MultiAppPostprocessorToAuxScalarTransfer::MultiAppPostprocessorToAuxScalarTransf
 void
 MultiAppPostprocessorToAuxScalarTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning PostprocessorToAuxScalarTransfer " << name() << std::endl;
+  #endif
 
   // Perform action based on the transfer direction
   switch (_direction)
@@ -105,5 +107,7 @@ MultiAppPostprocessorToAuxScalarTransfer::execute()
     }
   }
 
+  #ifndef NDEBUG
   _console << "Finished PostprocessorToAuxScalarTransfer " << name() << std::endl;
+  #endif
 }

--- a/framework/src/transfers/MultiAppPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorTransfer.C
@@ -48,7 +48,9 @@ MultiAppPostprocessorTransfer::MultiAppPostprocessorTransfer(const InputParamete
 void
 MultiAppPostprocessorTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning PostprocessorTransfer " << name() << std::endl;
+  #endif
 
   switch (_direction)
   {
@@ -131,5 +133,7 @@ MultiAppPostprocessorTransfer::execute()
     }
   }
 
+  #ifndef NDEBUG
   _console << "Finished PostprocessorTransfer " << name() << std::endl;
+  #endif
 }

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -169,7 +169,9 @@ MultiAppProjectionTransfer::assembleL2(EquationSystems & es, const std::string &
 void
 MultiAppProjectionTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning projection transfer " << name() << std::endl;
+  #endif
 
   getAppInfo();
 
@@ -500,7 +502,9 @@ MultiAppProjectionTransfer::execute()
   if (_fixed_meshes)
     _qps_cached = true;
 
+  #ifndef NDEBUG
   _console << "Finished projection transfer " << name() << std::endl;
+  #endif
 }
 
 void

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -59,7 +59,9 @@ MultiAppUserObjectTransfer::initialSetup()
 void
 MultiAppUserObjectTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning MultiAppUserObjectTransfer " << name() << std::endl;
+  #endif
 
   switch (_direction)
   {
@@ -168,7 +170,9 @@ MultiAppUserObjectTransfer::execute()
 
       unsigned int to_var_num = to_sys.variable_number(to_var.name());
 
+      #ifndef NDEBUG
       _console << "Transferring to: " << to_var.name() << std::endl;
+      #endif
 
       // EquationSystems & to_es = to_sys.get_equation_systems();
 
@@ -254,5 +258,7 @@ MultiAppUserObjectTransfer::execute()
     }
   }
 
+  #ifndef NDEBUG
   _console << "Finished MultiAppUserObjectTransfer " << name() << std::endl;
+  #endif
 }

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -42,7 +42,9 @@ MultiAppVariableValueSamplePostprocessorTransfer::MultiAppVariableValueSamplePos
 void
 MultiAppVariableValueSamplePostprocessorTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning VariableValueSamplePostprocessorTransfer " << name() << std::endl;
+  #endif
 
   switch (_direction)
   {
@@ -96,5 +98,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::execute()
     }
   }
 
+  #ifndef NDEBUG
   _console << "Finished VariableValueSamplePostprocessorTransfer " << name() << std::endl;
+  #endif
 }

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -48,7 +48,9 @@ MultiAppVariableValueSampleTransfer::initialSetup()
 void
 MultiAppVariableValueSampleTransfer::execute()
 {
+  #ifndef NDEBUG
   _console << "Beginning VariableValueSampleTransfer " << name() << std::endl;
+  #endif
 
   switch (_direction)
   {
@@ -136,5 +138,7 @@ MultiAppVariableValueSampleTransfer::execute()
     }
   }
 
+  #ifndef NDEBUG
   _console << "Finished VariableValueSampleTransfer " << name() << std::endl;
+  #endif
 }


### PR DESCRIPTION
MultiApp Transfer messages in the log are suppressed in "opt" mode but are
enabled in "dbg" mode.

closes idaholab/moose#8735

This greatly simplified the log file during "opt" mode and made it much smaller in disk size.