### PR TITLE
Build compile_commands.json 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ temp_print_trace.*
 *.processor.*
 .clang_complete
 .failed_tests
+compile_commands.json
 
 # Allow certain files in gold directories
 !**/gold/*.e

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -186,3 +186,5 @@ $(app_EXEC): $(app_LIBS) $(mesh_library) $(main_object)
 
 # Clang static analyzer
 sa:: $(app_analyzer)
+
+compile_commands_all_srcfiles += $(srcfiles)

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -179,13 +179,22 @@ clobberall:: clobber
         done
 
 # clang_complete builds a clang configuration file for various clang-based autocompletion plugins
-clang_complete:
+.clang_complete::
 	@echo "Building .clang_complete file"
 	@echo "-xc++" > .clang_complete
 	@echo "-std=c++11" >> .clang_complete
 	@for item in $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES); do \
           echo $$item >> .clang_complete;  \
         done
+
+compile_commands_all_srcfiles := $(moose_srcfiles) $(srcfiles)
+compile_commands.json::
+	@echo $(CURDIR) > .compile_commands.json
+	@echo $(libmesh_CXX) >> .compile_commands.json
+	@echo $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES) >> .compile_commands.json
+	@echo $(compile_commands_all_srcfiles) >> .compile_commands.json
+	@ $(FRAMEWORK_DIR)/scripts/compile_commands.py < .compile_commands.json > compile_commands.json
+	@rm .compile_commands.json
 
 # Debugging stuff
 echo_include:

--- a/framework/scripts/compile_commands.py
+++ b/framework/scripts/compile_commands.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+
+# This script is used by the `make compile_commands.json` build command.
+# It reformats the raw dump of current directory, compiler command, compiler
+# options, and list of source files into a well formed JSON file that adheres to
+# the format specified in https://clang.llvm.org/docs/JSONCompilationDatabase.html
+
 import sys, os
 import json
 

--- a/framework/scripts/compile_commands.py
+++ b/framework/scripts/compile_commands.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import sys, os
+import json
+
+lines = [line.rstrip() for line in sys.stdin]
+
+commands = []
+for file in lines[3].split() :
+  commands.append({
+    'directory' : lines[0],
+    'command' : "%s %s -c %s" % (lines[1], lines[2], file),
+    'file' : file
+  })
+
+print json.dumps(commands, indent=2)


### PR DESCRIPTION
This adds a make rule to build a `compile_commands.json` file for the current app. I have verified this on Marmot and it includes framework, selected modules, and the app files. Running `rc -J .` picks this file up and initializes the rtags database.

Closes #8770