### PR TITLE
Handle bad input files better in peacock

### DIFF
--- a/python/peacock/Input/InputFile.py
+++ b/python/peacock/Input/InputFile.py
@@ -39,12 +39,21 @@ class InputFile(object):
         self.changed = False
         self.root_node = GPNode("/", None)
 
+        # Do some basic checks on the filename to make sure
+        # it is probably a real input file since the GetPot
+        # parser doesn't do any checks.
         if not path.exists(filename):
             msg = "Input file %s does not exist" % filename
             mooseutils.mooseError(msg)
             raise PeacockException(msg)
+
         if not path.isfile(filename):
             msg = "Input file %s is not a file" % filename
+            mooseutils.mooseError(msg)
+            raise PeacockException(msg)
+
+        if not filename.endswith(".i"):
+            msg = "Input file %s does not have the proper extension" % filename
             mooseutils.mooseError(msg)
             raise PeacockException(msg)
 

--- a/python/peacock/LogWidget.py
+++ b/python/peacock/LogWidget.py
@@ -42,10 +42,10 @@ class LogWidget(QWidget, MooseWidget):
             msg: The message to write
             color: The color to write the text in.
         """
-        msg = str(msg)
-
         if not msg:
             return
+
+        msg = msg.encode('utf-8') # make sure if there are bad characters in the message that we can show them.
 
         if not color or color == "None":
             color = "white"

--- a/python/peacock/tests/peacock_app/LogWidget/test_LogWidget.py
+++ b/python/peacock/tests/peacock_app/LogWidget/test_LogWidget.py
@@ -23,5 +23,12 @@ class Tests(Testing.PeacockTester):
         self.assertIn("bar", w.log.toHtml())
         self.assertEqual("Foo\nbar\n\n", w.log.toPlainText())
 
+    def testUnicode(self):
+        w = LogWidget()
+        w.show()
+        mooseutils.mooseMessage("Foo \xe0\xe0 bar", color="RED")
+        self.assertIn("Foo", w.log.toHtml())
+        self.assertIn("bar", w.log.toHtml())
+
 if __name__ == '__main__':
     Testing.run_tests()

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -136,6 +136,11 @@ class Tests(Testing.PeacockTester):
         self.assertEqual(tab.MeshPlugin.isEnabled(), False)
         self.assertEqual(tab.vtkwin.isVisible(), False)
 
+    def testBadInput(self):
+        self.create_app(["-i", "../../common/out_transient.e", Testing.find_moose_test_exe()])
+        tabs = self.app.main_widget.tab_plugin
+        self.check_current_tab(tabs, self.exe.tabName())
+
     def testClearSettings(self):
         args = ["--clear-settings"]
         self.create_app(args)


### PR DESCRIPTION
closes #8774 

Passing an exodus file as an input file crashed for me in the `LogWidget.py` because it was trying to output non-ascii characters. The python GetPot parser has no problem parsing an exodus file, it just has non-ascii characters for paths and peacock can't create them because it doesn't match anything in the moose dump.

Since checking to see if a file is binary or plain text relies on heuristics, I am just checking the filename extension. This should catch 99% of the time somebody passes a non input file with `-i`.
