### PR TITLE
Allow keyboard selection on some widgets

### DIFF
--- a/python/peacock/ExodusViewer/plugins/VariablePlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VariablePlugin.py
@@ -43,10 +43,12 @@ class VariablePlugin(QtWidgets.QGroupBox, ExodusPlugin):
         # Variable selection
         self.VariableListLayout = QtWidgets.QHBoxLayout()
         self.VariableList = QtWidgets.QComboBox()
+        self.VariableList.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.VariableListLayout.addWidget(self.VariableList)
 
         # Component selection
         self.ComponentList = QtWidgets.QComboBox()
+        self.ComponentList.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.VariableListLayout.addWidget(self.ComponentList)
 
         # Min. value selection
@@ -59,6 +61,7 @@ class VariablePlugin(QtWidgets.QGroupBox, ExodusPlugin):
 
         # Colormap
         self.ColorMapList = QtWidgets.QComboBox()
+        self.ColorMapList.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.ReverseColorMap = QtWidgets.QCheckBox("Reverse Colormap")
 
         # Colorbar toggle

--- a/python/peacock/PostprocessorViewer/plugins/LineGroupWidget.py
+++ b/python/peacock/PostprocessorViewer/plugins/LineGroupWidget.py
@@ -62,6 +62,7 @@ class LineGroupWidget(peacock.base.MooseWidget, QtWidgets.QGroupBox):
         self.AxisSelectLayout.setContentsMargins(0, 0, 0, 0)
         self.AxisVariableLabel = QtWidgets.QLabel('Primary Variable:')
         self.AxisVariable = QtWidgets.QComboBox()
+        self.AxisVariable.setFocusPolicy(QtCore.Qt.StrongFocus)
 
         self.AxisSelectLayout.addWidget(self.AxisVariableLabel)
         self.AxisSelectLayout.addWidget(self.AxisVariable)


### PR DESCRIPTION
Set `StrongFocus` on some widgets in peacock to allow for keyboard selection.

If further widgets are desired to be able to be tabbed to, `StrongFocus` needs to be set on them as well.

closes #8777 