### PR TITLE
Use a different combined test for peacock wrong exe test.

### DIFF
--- a/python/peacock/tests/common/transient_heat_test.i
+++ b/python/peacock/tests/common/transient_heat_test.i
@@ -1,0 +1,70 @@
+[Mesh]
+  file = cube.e
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./heat]
+    type = HeatConduction
+    variable = u
+  [../]
+
+  [./ie]
+    type = SpecificHeatConductionTimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./bottom]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0.0
+  [../]
+
+  [./top]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1.0
+  [../]
+[]
+
+[Materials]
+  [./constant]
+    type = HeatConductionMaterial
+    block = 1
+    thermal_conductivity = 1
+    specific_heat = 1
+  [../]
+  [./density]
+    type = Density
+    block = 1
+    density = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  #Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+
+
+  start_time = 0.0
+  num_steps = 5
+  dt = .1
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -128,7 +128,7 @@ class Tests(Testing.PeacockTester):
 
     def testWrongExe(self):
         # use the test/moose_test-opt to try to process a modules/combined input file
-        input_file = os.path.join(os.environ["MOOSE_DIR"], "modules", "combined", "tests", "thermal_strain", "thermal_strain_test.i")
+        input_file = os.path.join("../../common/transient_heat_test.i")
         self.create_app([input_file, Testing.find_moose_test_exe()])
         tabs = self.app.main_widget.tab_plugin
         self.check_current_tab(tabs, self.input.tabName())


### PR DESCRIPTION
It seems the `thermal_strain_test.i` test got moved which causes a test in peacock that uses it to fail.
I just copied a test that uses stuff in modules into the `common` directory so we don't have this problem in the future.