### PR TITLE
contact problems with fixed new superlu_dist

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -690,9 +690,9 @@ storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params)
     pc_description += "strong_threshold: 0.7 (auto)";
   }
 
-#if !PETSC_VERSION_LESS_THAN(3, 7, 0)
+#if !PETSC_VERSION_LESS_THAN(3, 7, 0) && PETSC_VERSION_LESS_THAN(3, 7, 6)
   // In PETSc-3.7.{0--4}, there is a bug when using superlu_dist, and we have to use
-  // SamePattern_SameRowPerm
+  // SamePattern_SameRowPerm, otherwise we use whatever we have in PETSc
   if (superlu_dist_found && !fact_pattern_found)
   {
     po.inames.push_back("-mat_superlu_dist_fact");

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin.i
@@ -299,7 +299,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_value = 'lu            superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin.i
@@ -299,7 +299,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu            superlu_dist'
+  petsc_options_value = 'lu       superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
@@ -274,7 +274,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu            superlu_dist'
+  petsc_options_value = 'lu       superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
@@ -274,7 +274,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_value = 'lu            superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_template1.i
@@ -285,9 +285,6 @@
   type = Transient
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
-
   line_search = 'none'
 
   nl_abs_tol = 1e-7

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
@@ -42,7 +42,7 @@
     prereq = 'frictionless_kin_sm'
     # This test is fails reliably on INTEL compilers with PETSc 3.7.4 and 3.7.5, so restrict the test to not INTEL
     compiler = 'GCC CLANG'
-    petsc_version = '>=3.7.5'
+    petsc_version = '>=3.7.6'
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -85,7 +85,7 @@
     # This test is unstable on PETSc 3.7.4 with 64bit indices enabled.
     dof_id_bytes = 4
     # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    petsc_version = '>=3.7.5'
+    petsc_version = '>=3.7.6'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/tests
@@ -3,7 +3,9 @@
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_glued_kin_check.csv cyl3_glued_kin_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic Outputs/file_base=cyl3_glued_kin_out Outputs/chkfile/file_base=cyl3_glued_kin_check'
+    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic
+                Outputs/file_base=cyl3_glued_kin_out Outputs/chkfile/file_base=cyl3_glued_kin_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
@@ -14,7 +16,11 @@
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_glued_pen_check.csv cyl3_glued_pen_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=penalty Contact/leftright/normalize_penalty=true Outputs/file_base=cyl3_glued_pen_out Outputs/chkfile/file_base=cyl3_glued_pen_check'
+    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=penalty
+                Contact/leftright/normalize_penalty=true
+                Outputs/chkfile/file_base=cyl3_glued_pen_check'
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package"
+                Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
@@ -25,20 +31,27 @@
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_frictionless_kin_check.csv cyl3_frictionless_kin_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=kinematic Outputs/file_base=cyl3_frictionless_kin_out Outputs/chkfile/file_base=cyl3_frictionless_kin_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=kinematic
+                Outputs/file_base=cyl3_frictionless_kin_out Outputs/chkfile/file_base=cyl3_frictionless_kin_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package"
+                Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 2e-5
     abs_zero = 1e-4
     max_parallel = 1
     superlu = true
     prereq = 'frictionless_kin_sm'
-    # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    # This test is fails reliably on INTEL compilers with PETSc 3.7.4 and 3.7.5, so restrict the test to not INTEL
+    compiler = 'GCC CLANG'
+    petsc_version = '>=3.7.5'
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_frictionless_pen_check.csv cyl3_frictionless_pen_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=penalty Contact/leftright/normalize_penalty=true Outputs/file_base=cyl3_frictionless_pen_out Outputs/chkfile/file_base=cyl3_frictionless_pen_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=penalty Contact/leftright/normalize_penalty=true
+                Outputs/file_base=cyl3_frictionless_pen_out Outputs/chkfile/file_base=cyl3_frictionless_pen_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package"
+                Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
@@ -49,7 +62,11 @@
     type = 'CSVDiff'
     input = 'cyl3_template1.i'
     csvdiff = 'cyl3_frictionless_aug_check.csv cyl3_frictionless_aug_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=augmented_lagrange Contact/leftright/normalize_penalty=true Outputs/file_base=cyl3_frictionless_aug_out Outputs/chkfile/file_base=cyl3_frictionless_aug_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=augmented_lagrange
+                Contact/leftright/normalize_penalty=true Outputs/file_base=cyl3_frictionless_aug_out
+                Outputs/chkfile/file_base=cyl3_frictionless_aug_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package"
+                Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 2e-6
     max_parallel = 1
@@ -68,7 +85,7 @@
     # This test is unstable on PETSc 3.7.4 with 64bit indices enabled.
     dof_id_bytes = 4
     # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.5'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -142,7 +159,8 @@
     # This test is unstable on PETSc 3.7.4 with 64bit indices enabled.
     dof_id_bytes = 4
     # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    skip = 'Reevaluate under PETSc 3.7.4. and PETSc 3.7.5 #8200'
+    prereq = 'mu_0_2_kin'
   [../]
   [./mu_0_2_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin.i
@@ -284,7 +284,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu            superlu_dist'
+  petsc_options_value = 'lu       superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin.i
@@ -284,7 +284,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_value = 'lu            superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
@@ -266,7 +266,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_value = 'lu            superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
@@ -266,7 +266,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu            superlu_dist'
+  petsc_options_value = 'lu       superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
@@ -264,7 +264,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu            superlu_dist'
+  petsc_options_value = 'lu       superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
@@ -264,7 +264,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_value = 'lu            superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
@@ -244,9 +244,6 @@
   type = Transient
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
-
   line_search = 'none'
 
   nl_abs_tol = 1e-10

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
@@ -1,4 +1,4 @@
-[Tests]
+eTests]
   [./glued_kin]
     type = 'CSVDiff'
     input = 'plane3_template1.i'
@@ -9,7 +9,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'glued_kin_sm'
-    petsc_version = '>=3.7.5'
+    petsc_version = '>=3.7.6'
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -32,7 +32,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'frictionless_kin_sm'
-    petsc_version = '>=3.7.5'
+    petsc_version = '>=3.7.6'
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -65,7 +65,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'mu_0_2_kin_sm'
-    petsc_version = '>=3.7.5'
+    petsc_version = '>=3.7.6'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -89,7 +89,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    petsc_version = '>=3.7.5'
+    petsc_version = '>=3.7.6'
   [../]
   [./glued_pen_sm]
     type = 'CSVDiff'
@@ -147,7 +147,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    petsc_version = '>=3.7.5'
+    skip = 'Reevaluate under PETSc 3.7.4. #8200'
   [../]
   [./mu_0_2_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/tests
@@ -8,8 +8,8 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    #prereq = 'glued_kin_sm' #the prereq test is also skipped
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    prereq = 'glued_kin_sm'
+    petsc_version = '>=3.7.5'
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -32,7 +32,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'frictionless_kin_sm'
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.5'
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'
@@ -64,8 +64,8 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    #prereq = 'mu_0_2_kin_sm'  #Commented out because the prereq test is currently skipped #8200
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    prereq = 'mu_0_2_kin_sm'
+    petsc_version = '>=3.7.5'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -81,18 +81,23 @@
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_glued_kin_check.csv plane3_glued_kin_check_cont_press_0001.csv plane3_glued_kin_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic Outputs/file_base=plane3_glued_kin_out Outputs/chkfile/file_base=plane3_glued_kin_check'
+    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=kinematic
+                Outputs/file_base=plane3_glued_kin_out Outputs/chkfile/file_base=plane3_glued_kin_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package"
+                Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.5'
   [../]
   [./glued_pen_sm]
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_glued_pen_check.csv plane3_glued_pen_check_cont_press_0001.csv plane3_glued_pen_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=penalty Outputs/file_base=plane3_glued_pen_out Outputs/chkfile/file_base=plane3_glued_pen_check'
+    cli_args = 'Contact/leftright/model=glued Contact/leftright/formulation=penalty
+                Outputs/file_base=plane3_glued_pen_out Outputs/chkfile/file_base=plane3_glued_pen_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
@@ -102,7 +107,9 @@
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_frictionless_kin_check.csv plane3_frictionless_kin_check_cont_press_0001.csv plane3_frictionless_kin_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=kinematic Outputs/file_base=plane3_frictionless_kin_out Outputs/chkfile/file_base=plane3_frictionless_kin_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=kinematic
+                Outputs/file_base=plane3_frictionless_kin_out Outputs/chkfile/file_base=plane3_frictionless_kin_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
@@ -112,7 +119,9 @@
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_frictionless_pen_check.csv plane3_frictionless_pen_check_cont_press_0001.csv plane3_frictionless_pen_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=penalty Outputs/file_base=plane3_frictionless_pen_out Outputs/chkfile/file_base=plane3_frictionless_pen_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=penalty
+                Outputs/file_base=plane3_frictionless_pen_out Outputs/chkfile/file_base=plane3_frictionless_pen_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
@@ -122,7 +131,9 @@
     type = 'CSVDiff'
     input = 'plane3_template1_sm.i'
     csvdiff = 'plane3_frictionless_aug_check.csv plane3_frictionless_aug_check_cont_press_0001.csv plane3_frictionless_aug_check_x_disp_0001.csv'
-    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=augmented_lagrange Outputs/file_base=plane3_frictionless_aug_out Outputs/chkfile/file_base=plane3_frictionless_aug_check'
+    cli_args = 'Contact/leftright/model=frictionless Contact/leftright/formulation=augmented_lagrange
+                Outputs/file_base=plane3_frictionless_aug_out Outputs/chkfile/file_base=plane3_frictionless_aug_check
+                Executioner/petsc_options_iname="-pc_type -pc_factor_mat_solver_package" Executioner/petsc_options_value="lu superlu_dist"'
     rel_err = 1e-5
     abs_zero = 1e-8
     max_parallel = 1
@@ -136,7 +147,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.5'
   [../]
   [./mu_0_2_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin.i
@@ -294,7 +294,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu            superlu_dist'
+  petsc_options_value = 'lu       superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin.i
@@ -294,7 +294,7 @@
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu     superlu_dist'
+  petsc_options_value = 'lu            superlu_dist'
 
   line_search = 'none'
 

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
@@ -64,7 +64,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'mu_0_2_kin_sm'
-    petsc_version = '>=3.7.5'
+    petsc_version = '>=3.7.6'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/tests
@@ -64,7 +64,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'mu_0_2_kin_sm'
-    skip = 'Reevaluate under PETSc 3.7.4. #8200.'
+    petsc_version = '>=3.7.5'
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'


### PR DESCRIPTION
Use the PETSc default superlu_dist setup for contact problems.

Refs #8200 #8744