### PR TITLE
clang-format everything again :-(

### DIFF
--- a/framework/include/base/ExecuteMooseObjectWarehouse.h
+++ b/framework/include/base/ExecuteMooseObjectWarehouse.h
@@ -221,10 +221,12 @@ ExecuteMooseObjectWarehouse<T>::addObject(std::shared_ptr<T> object, THREAD_ID t
       _execute_objects[*it].addObject(object, tid);
   }
   else
-    mooseError("The object being added (", object->name(), ") must inherit from SetupInterface to "
-                                                           "be added to the "
-                                                           "ExecuteMooseObjectWarehouse "
-                                                           "container.");
+    mooseError("The object being added (",
+               object->name(),
+               ") must inherit from SetupInterface to "
+               "be added to the "
+               "ExecuteMooseObjectWarehouse "
+               "container.");
 }
 
 template <typename T>

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -156,9 +156,10 @@ inline void
 dataStore(std::ostream & stream, T & v, void * /*context*/)
 {
 #ifdef LIBMESH_HAVE_CXX11_TYPE_TRAITS
-  static_assert(std::is_polymorphic<T>::value == false, "Cannot serialize a class that has virtual "
-                                                        "members!\nWrite a custom dataStore() "
-                                                        "template specialization!\n\n");
+  static_assert(std::is_polymorphic<T>::value == false,
+                "Cannot serialize a class that has virtual "
+                "members!\nWrite a custom dataStore() "
+                "template specialization!\n\n");
   static_assert(std::is_trivially_copyable<T>::value || std::is_same<T, Point>::value,
                 "Cannot serialize a class that is not trivially copyable!\nWrite a custom "
                 "dataStore() template specialization!\n\n");

--- a/framework/include/utils/ColumnMajorMatrix.h
+++ b/framework/include/utils/ColumnMajorMatrix.h
@@ -608,8 +608,9 @@ inline ColumnMajorMatrix ColumnMajorMatrix::operator*(Real scalar) const
 
 inline ColumnMajorMatrix ColumnMajorMatrix::operator*(const TypeVector<Real> & rhs) const
 {
-  mooseAssert(_n_cols == LIBMESH_DIM, "Cannot perform matvec operation! The column dimension of "
-                                      "the ColumnMajorMatrix does not match the TypeVector!");
+  mooseAssert(_n_cols == LIBMESH_DIM,
+              "Cannot perform matvec operation! The column dimension of "
+              "the ColumnMajorMatrix does not match the TypeVector!");
 
   ColumnMajorMatrix ret_matrix(_n_rows, 1);
 

--- a/framework/src/actions/AddAuxVariableAction.C
+++ b/framework/src/actions/AddAuxVariableAction.C
@@ -27,9 +27,11 @@ validParams<AddAuxVariableAction>()
 
   params.addParam<MooseEnum>(
       "family", families, "Specifies the family of FE shape functions to use for this variable");
-  params.addParam<MooseEnum>("order", orders, "Specifies the order of the FE shape function to use "
-                                              "for this variable (additional orders not listed are "
-                                              "allowed)");
+  params.addParam<MooseEnum>("order",
+                             orders,
+                             "Specifies the order of the FE shape function to use "
+                             "for this variable (additional orders not listed are "
+                             "allowed)");
   params.addParam<Real>("initial_condition", "Specifies the initial condition for this variable");
   params.addParam<std::vector<SubdomainName>>("block", "The block id where this variable lives");
 

--- a/framework/src/actions/AddNodalNormalsAction.C
+++ b/framework/src/actions/AddNodalNormalsAction.C
@@ -31,9 +31,11 @@ validParams<AddNodalNormalsAction>()
       "boundary", everywhere, "The boundary ID or name where the normals will be computed");
   params.addParam<BoundaryName>("corner_boundary", "boundary ID or name with nodes at 'corners'");
   MooseEnum orders("FIRST SECOND", "FIRST");
-  params.addParam<MooseEnum>("order", orders, "Specifies the order of variables that hold the "
-                                              "nodal normals. Needs to match the order of the "
-                                              "mesh");
+  params.addParam<MooseEnum>("order",
+                             orders,
+                             "Specifies the order of variables that hold the "
+                             "nodal normals. Needs to match the order of the "
+                             "mesh");
 
   return params;
 }

--- a/framework/src/actions/AddPeriodicBCAction.C
+++ b/framework/src/actions/AddPeriodicBCAction.C
@@ -29,15 +29,17 @@ InputParameters
 validParams<AddPeriodicBCAction>()
 {
   InputParameters params = validParams<Action>();
-  params.addParam<std::vector<std::string>>("auto_direction", "If using a generated mesh, you can "
-                                                              "specifiy just the dimension(s) you "
-                                                              "want to mark as periodic");
+  params.addParam<std::vector<std::string>>("auto_direction",
+                                            "If using a generated mesh, you can "
+                                            "specifiy just the dimension(s) you "
+                                            "want to mark as periodic");
 
   params.addParam<BoundaryName>("primary", "Boundary ID associated with the primary boundary.");
   params.addParam<BoundaryName>("secondary", "Boundary ID associated with the secondary boundary.");
-  params.addParam<RealVectorValue>("translation", "Vector that translates coordinates on the "
-                                                  "primary boundary to coordinates on the "
-                                                  "secondary boundary.");
+  params.addParam<RealVectorValue>("translation",
+                                   "Vector that translates coordinates on the "
+                                   "primary boundary to coordinates on the "
+                                   "secondary boundary.");
   params.addParam<std::vector<std::string>>("transform_func",
                                             "Functions that specify the transformation");
   params.addParam<std::vector<std::string>>("inv_transform_func",

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -49,9 +49,11 @@ validParams<AddVariableAction>()
   params += validParams<OutputInterface>();
   params.addParam<MooseEnum>(
       "family", families, "Specifies the family of FE shape functions to use for this variable");
-  params.addParam<MooseEnum>("order", orders, "Specifies the order of the FE shape function to use "
-                                              "for this variable (additional orders not listed are "
-                                              "allowed)");
+  params.addParam<MooseEnum>("order",
+                             orders,
+                             "Specifies the order of the FE shape function to use "
+                             "for this variable (additional orders not listed are "
+                             "allowed)");
   params.addParam<Real>("initial_condition", "Specifies the initial condition for this variable");
   params.addParam<std::vector<SubdomainName>>("block", "The block id where this variable lives");
   params.addParam<bool>("eigen", false, "True to make this variable an eigen variable");

--- a/framework/src/actions/CheckOutputAction.C
+++ b/framework/src/actions/CheckOutputAction.C
@@ -103,9 +103,11 @@ CheckOutputAction::checkConsoleOutput()
       num_screen_outputs++;
 
   if (num_screen_outputs > 1)
-    mooseWarning("Multiple (", num_screen_outputs, ") Console output objects are writing to the "
-                                                   "screen, this will likely cause duplicate "
-                                                   "messages printed.");
+    mooseWarning("Multiple (",
+                 num_screen_outputs,
+                 ") Console output objects are writing to the "
+                 "screen, this will likely cause duplicate "
+                 "messages printed.");
 }
 
 void

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -42,8 +42,10 @@ validParams<CommonOutputAction>()
       "nemesis", false, "Output the results using the default settings for Nemesis output");
   params.addParam<bool>(
       "console", true, "Output the results using the default settings for Console output");
-  params.addParam<bool>("csv", false, "Output the scalar variable and postprocessors to a *.csv "
-                                      "file using the default CSV output.");
+  params.addParam<bool>("csv",
+                        false,
+                        "Output the scalar variable and postprocessors to a *.csv "
+                        "file using the default CSV output.");
   params.addParam<bool>(
       "vtk", false, "Output the results using the default settings for VTKOutput output");
   params.addParam<bool>(
@@ -82,16 +84,19 @@ validParams<CommonOutputAction>()
                                      "Times at which the output and solution is forced to occur");
   params.addParam<bool>(
       "append_date", false, "When true the date and time are appended to the output filename.");
-  params.addParam<std::string>("append_date_format", "The format of the date/time to append (see "
-                                                     "http://www.cplusplus.com/reference/ctime/"
-                                                     "strftime).");
+  params.addParam<std::string>("append_date_format",
+                               "The format of the date/time to append (see "
+                               "http://www.cplusplus.com/reference/ctime/"
+                               "strftime).");
 
   params.addParam<std::vector<VariableName>>(
-      "hide", "A list of the variables and postprocessors that should NOT be output to the Exodus "
-              "file (may include Variables, ScalarVariables, and Postprocessor names).");
+      "hide",
+      "A list of the variables and postprocessors that should NOT be output to the Exodus "
+      "file (may include Variables, ScalarVariables, and Postprocessor names).");
   params.addParam<std::vector<VariableName>>(
-      "show", "A list of the variables and postprocessors that should be output to the Exodus file "
-              "(may include Variables, ScalarVariables, and Postprocessor names).");
+      "show",
+      "A list of the variables and postprocessors that should be output to the Exodus file "
+      "(may include Variables, ScalarVariables, and Postprocessor names).");
 
   // Add the 'execute_on' input parameter
   params.addParam<MultiMooseEnum>(

--- a/framework/src/actions/CreateDisplacedProblemAction.C
+++ b/framework/src/actions/CreateDisplacedProblemAction.C
@@ -23,9 +23,10 @@ validParams<CreateDisplacedProblemAction>()
 {
   InputParameters params = validParams<Action>();
   params.addParam<std::vector<std::string>>(
-      "displacements", "The variables corresponding to the x y z displacements of the mesh.  If "
-                       "this is provided then the displacements will be taken into account during "
-                       "the computation.");
+      "displacements",
+      "The variables corresponding to the x y z displacements of the mesh.  If "
+      "this is provided then the displacements will be taken into account during "
+      "the computation.");
 
   return params;
 }

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -33,9 +33,11 @@ validParams<CreateProblemAction>()
   params.addParam<MooseEnum>(
       "rz_coord_axis", rz_coord_axis, "The rotation axis (X | Y) for axisymetric coordinates");
 
-  params.addParam<bool>("fe_cache", false, "Whether or not to turn on the finite element shape "
-                                           "function caching system.  This can increase speed with "
-                                           "an associated memory cost.");
+  params.addParam<bool>("fe_cache",
+                        false,
+                        "Whether or not to turn on the finite element shape "
+                        "function caching system.  This can increase speed with "
+                        "an associated memory cost.");
 
   params.addParam<bool>(
       "kernel_coverage_check", true, "Set to false to disable kernel->subdomain coverage check");
@@ -43,9 +45,10 @@ validParams<CreateProblemAction>()
                         true,
                         "Set to false to disable material->subdomain coverage check");
 
-  params.addParam<FileNameNoExtension>("restart_file_base", "File base name used for restart (e.g. "
-                                                            "<path>/<filebase> or <path>/LATEST to "
-                                                            "grab the latest file available)");
+  params.addParam<FileNameNoExtension>("restart_file_base",
+                                       "File base name used for restart (e.g. "
+                                       "<path>/<filebase> or <path>/LATEST to "
+                                       "grab the latest file available)");
 
   return params;
 }

--- a/framework/src/actions/DynamicObjectRegistrationAction.C
+++ b/framework/src/actions/DynamicObjectRegistrationAction.C
@@ -28,9 +28,11 @@ validParams<DynamicObjectRegistrationAction>()
                                             "will be registered from (dynamic registration).");
   params.addParam<std::vector<std::string>>(
       "object_names", "The names of the objects to register (Default: register all).");
-  params.addParam<std::string>("library_path", "", "Path to search for dynamic libraries (please "
-                                                   "avoid committing absolute paths in addition to "
-                                                   "MOOSE_LIBRARY_PATH)");
+  params.addParam<std::string>("library_path",
+                               "",
+                               "Path to search for dynamic libraries (please "
+                               "avoid committing absolute paths in addition to "
+                               "MOOSE_LIBRARY_PATH)");
   return params;
 }
 

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -26,9 +26,11 @@ validParams<SetupMeshAction>()
   InputParameters params = validParams<MooseObjectAction>();
   params.set<std::string>("type") = "FileMesh";
 
-  params.addParam<bool>("second_order", false, "Converts a first order mesh to a second order "
-                                               "mesh.  Note: This is NOT needed if you are reading "
-                                               "an actual first order mesh.");
+  params.addParam<bool>("second_order",
+                        false,
+                        "Converts a first order mesh to a second order "
+                        "mesh.  Note: This is NOT needed if you are reading "
+                        "an actual first order mesh.");
 
   params.addParam<std::vector<SubdomainID>>("block_id", "IDs of the block id/name pairs");
   params.addParam<std::vector<SubdomainName>>(
@@ -45,9 +47,10 @@ validParams<SetupMeshAction>()
                         "sideset");
 
   params.addParam<std::vector<std::string>>(
-      "displacements", "The variables corresponding to the x y z displacements of the mesh.  If "
-                       "this is provided then the displacements will be taken into account during "
-                       "the computation.");
+      "displacements",
+      "The variables corresponding to the x y z displacements of the mesh.  If "
+      "this is provided then the displacements will be taken into account during "
+      "the computation.");
   params.addParam<std::vector<BoundaryName>>("ghosted_boundaries",
                                              "Boundaries to be ghosted if using Nemesis");
   params.addParam<std::vector<Real>>("ghosted_boundaries_inflation",

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -43,11 +43,13 @@ validParams<AuxKernel>()
   params.addRequiredParam<AuxVariableName>("variable",
                                            "The name of the variable that this object applies to");
 
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   // This flag is set to true if the AuxKernel is being used on a boundary

--- a/framework/src/auxkernels/AuxScalarKernel.C
+++ b/framework/src/auxkernels/AuxScalarKernel.C
@@ -29,11 +29,13 @@ validParams<AuxScalarKernel>()
 
   params.addRequiredParam<AuxVariableName>("variable",
                                            "The name of the variable that this kernel operates on");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.declareControllable("enable"); // allows Control to enable/disable this type of object

--- a/framework/src/auxkernels/MaterialStdVectorAux.C
+++ b/framework/src/auxkernels/MaterialStdVectorAux.C
@@ -23,9 +23,10 @@ validParams<MaterialStdVectorAux>()
                              "variable.  If the std::vector is not of sufficient size then zero is "
                              "returned");
   params.addParam<unsigned int>(
-      "selected_qp", "Evaluate the std::vector<Real> at this quadpoint.  This only needs to be "
-                     "used if you are interested in a particular quadpoint in each element: "
-                     "otherwise do not include this parameter in your input file");
+      "selected_qp",
+      "Evaluate the std::vector<Real> at this quadpoint.  This only needs to be "
+      "used if you are interested in a particular quadpoint in each element: "
+      "otherwise do not include this parameter in your input file");
   params.addParamNamesToGroup("selected_qp", "Advanced");
   return params;
 }

--- a/framework/src/auxkernels/SpatialUserObjectAux.C
+++ b/framework/src/auxkernels/SpatialUserObjectAux.C
@@ -21,8 +21,9 @@ validParams<SpatialUserObjectAux>()
 {
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredParam<UserObjectName>(
-      "user_object", "The UserObject UserObject to get values from.  Note that the UserObject "
-                     "_must_ implement the spatialValue() virtual function!");
+      "user_object",
+      "The UserObject UserObject to get values from.  Note that the UserObject "
+      "_must_ implement the spatialValue() virtual function!");
   return params;
 }
 

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -97,9 +97,11 @@ Coupleable::isCoupled(const std::string & var_name, unsigned int i)
   {
     // Make sure the user originally requested this value in the InputParameter syntax
     if (!_coupleable_params.hasCoupledValue(var_name))
-      mooseError("The coupled variable \"", var_name, "\" was never added to this objects's "
-                                                      "InputParameters, please double-check your "
-                                                      "spelling");
+      mooseError("The coupled variable \"",
+                 var_name,
+                 "\" was never added to this objects's "
+                 "InputParameters, please double-check your "
+                 "spelling");
 
     return false;
   }

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -99,20 +99,26 @@ validParams<FEProblemBase>()
       "transpose_null_space_dimension", 0, "The dimension of the transpose nullspace");
   params.addParam<unsigned int>(
       "near_null_space_dimension", 0, "The dimension of the near nullspace");
-  params.addParam<bool>("solve", true, "Whether or not to actually solve the Nonlinear system.  "
-                                       "This is handy in the case that all you want to do is "
-                                       "execute AuxKernels, Transfers, etc. without actually "
-                                       "solving anything");
-  params.addParam<bool>("use_nonlinear", true, "Determines whether to use a Nonlinear vs a "
-                                               "Eigenvalue system (Automatically determined based "
-                                               "on executioner)");
+  params.addParam<bool>("solve",
+                        true,
+                        "Whether or not to actually solve the Nonlinear system.  "
+                        "This is handy in the case that all you want to do is "
+                        "execute AuxKernels, Transfers, etc. without actually "
+                        "solving anything");
+  params.addParam<bool>("use_nonlinear",
+                        true,
+                        "Determines whether to use a Nonlinear vs a "
+                        "Eigenvalue system (Automatically determined based "
+                        "on executioner)");
   params.addParam<bool>("error_on_jacobian_nonzero_reallocation",
                         false,
                         "This causes PETSc to error if it had to reallocate memory in the Jacobian "
                         "matrix due to not having enough nonzeros");
-  params.addParam<bool>("force_restart", false, "EXPERIMENTAL: If true, a sub_app may use a "
-                                                "restart file instead of using of using the master "
-                                                "backup file");
+  params.addParam<bool>("force_restart",
+                        false,
+                        "EXPERIMENTAL: If true, a sub_app may use a "
+                        "restart file instead of using of using the master "
+                        "backup file");
 
   return params;
 }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -138,23 +138,29 @@ validParams<MooseApp>()
       0,
       "Specify additional initial uniform refinements for automatic scaling");
 
-  params.addCommandLineParam<std::string>(
-      "recover", "--recover [file_base]", "Continue the calculation.  If file_base is omitted then "
+  params.addCommandLineParam<std::string>("recover",
+                                          "--recover [file_base]",
+                                          "Continue the calculation.  If file_base is omitted then "
                                           "the most recent recovery file will be utilized");
 
-  params.addCommandLineParam<bool>(
-      "half_transient", "--half-transient", false, "When true the simulation will only run half of "
-                                                   "its specified transient (ie half the "
-                                                   "timesteps).  This is useful for testing "
-                                                   "recovery and restart");
+  params.addCommandLineParam<bool>("half_transient",
+                                   "--half-transient",
+                                   false,
+                                   "When true the simulation will only run half of "
+                                   "its specified transient (ie half the "
+                                   "timesteps).  This is useful for testing "
+                                   "recovery and restart");
 
   // No default on these two options, they must not both be valid
   params.addCommandLineParam<bool>(
-      "trap_fpe", "--trap-fpe", "Enable Floating Point Exception handling in critical sections of "
-                                "code.  This is enabled automatically in DEBUG mode");
-  params.addCommandLineParam<bool>(
-      "no_trap_fpe", "--no-trap-fpe", "Disable Floating Point Exception handling in critical "
-                                      "sections of code when using DEBUG mode.");
+      "trap_fpe",
+      "--trap-fpe",
+      "Enable Floating Point Exception handling in critical sections of "
+      "code.  This is enabled automatically in DEBUG mode");
+  params.addCommandLineParam<bool>("no_trap_fpe",
+                                   "--no-trap-fpe",
+                                   "Disable Floating Point Exception handling in critical "
+                                   "sections of code when using DEBUG mode.");
 
   params.addCommandLineParam<bool>("error", "--error", false, "Turn all warnings into errors");
 
@@ -164,9 +170,11 @@ validParams<MooseApp>()
       false,
       "Enable all performance logging for timing purposes. This will disable all "
       "screen output of performance logs for all Console objects.");
-  params.addCommandLineParam<bool>(
-      "no_timing", "--no-timing", false, "Disabled performance logging. Overrides -t or --timing "
-                                         "if passed in conjunction with this flag");
+  params.addCommandLineParam<bool>("no_timing",
+                                   "--no-timing",
+                                   false,
+                                   "Disabled performance logging. Overrides -t or --timing "
+                                   "if passed in conjunction with this flag");
 
   // Options ignored by MOOSE but picked up by libMesh, these are here so that they are displayed in
   // the application help
@@ -1081,9 +1089,11 @@ MooseApp::executeMeshModifiers()
       auto depend_it = _mesh_modifiers.find(depend_name);
 
       if (depend_it == _mesh_modifiers.end())
-        mooseError("The MeshModifier \"", depend_name, "\" was not created, did you make a "
-                                                       "spelling mistake or forget to include it "
-                                                       "in your input file?");
+        mooseError("The MeshModifier \"",
+                   depend_name,
+                   "\" was not created, did you make a "
+                   "spelling mistake or forget to include it "
+                   "in your input file?");
 
       resolver.insertDependency(it.second, depend_it->second);
     }

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -82,9 +82,11 @@ ScalarCoupleable::isCoupledScalar(const std::string & var_name, unsigned int i)
   {
     // Make sure the user originally requested this value in the InputParameter syntax
     if (!_coupleable_params.hasCoupledValue(var_name))
-      mooseError("The coupled scalar variable \"", var_name, "\" was never added to this objects's "
-                                                             "InputParameters, please double-check "
-                                                             "your spelling");
+      mooseError("The coupled scalar variable \"",
+                 var_name,
+                 "\" was never added to this objects's "
+                 "InputParameters, please double-check "
+                 "your spelling");
 
     return false;
   }

--- a/framework/src/base/SetupInterface.C
+++ b/framework/src/base/SetupInterface.C
@@ -26,9 +26,10 @@ validParams<SetupInterface>()
   MultiMooseEnum execute_options(SetupInterface::getExecuteOptions());
 
   // Add the 'execute_on' input parameter for users to set
-  params.addParam<MultiMooseEnum>(
-      "execute_on", execute_options, "Set to (nonlinear|linear|timestep_end|timestep_begin|custom) "
-                                     "to execute only at that moment");
+  params.addParam<MultiMooseEnum>("execute_on",
+                                  execute_options,
+                                  "Set to (nonlinear|linear|timestep_end|timestep_begin|custom) "
+                                  "to execute only at that moment");
 
   // The Output system uses different options for the 'execute_on' than other systems, therefore the
   // check of the options

--- a/framework/src/bcs/BoundaryCondition.C
+++ b/framework/src/bcs/BoundaryCondition.C
@@ -28,11 +28,13 @@ validParams<BoundaryCondition>()
 
   params.addRequiredParam<NonlinearVariableName>(
       "variable", "The name of the variable that this boundary condition applies to");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.declareControllable("enable");

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -30,13 +30,15 @@ validParams<IntegratedBC>()
   params += validParams<MaterialPropertyInterface>();
 
   params.addParam<std::vector<AuxVariableName>>(
-      "save_in", "The name of auxiliary variables to save this BC's residual contributions to.  "
-                 "Everything about that variable must match everything about this variable (the "
-                 "type, what blocks it's on, etc.)");
+      "save_in",
+      "The name of auxiliary variables to save this BC's residual contributions to.  "
+      "Everything about that variable must match everything about this variable (the "
+      "type, what blocks it's on, etc.)");
   params.addParam<std::vector<AuxVariableName>>(
-      "diag_save_in", "The name of auxiliary variables to save this BC's diagonal jacobian "
-                      "contributions to.  Everything about that variable must match everything "
-                      "about this variable (the type, what blocks it's on, etc.)");
+      "diag_save_in",
+      "The name of auxiliary variables to save this BC's diagonal jacobian "
+      "contributions to.  Everything about that variable must match everything "
+      "about this variable (the type, what blocks it's on, etc.)");
 
   params.addParamNamesToGroup("diag_save_in save_in", "Advanced");
 

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -25,13 +25,15 @@ validParams<NodalBC>()
   InputParameters params = validParams<BoundaryCondition>();
   params += validParams<RandomInterface>();
   params.addParam<std::vector<AuxVariableName>>(
-      "save_in", "The name of auxiliary variables to save this BC's residual contributions to.  "
-                 "Everything about that variable must match everything about this variable (the "
-                 "type, what blocks it's on, etc.)");
+      "save_in",
+      "The name of auxiliary variables to save this BC's residual contributions to.  "
+      "Everything about that variable must match everything about this variable (the "
+      "type, what blocks it's on, etc.)");
   params.addParam<std::vector<AuxVariableName>>(
-      "diag_save_in", "The name of auxiliary variables to save this BC's diagonal jacobian "
-                      "contributions to.  Everything about that variable must match everything "
-                      "about this variable (the type, what blocks it's on, etc.)");
+      "diag_save_in",
+      "The name of auxiliary variables to save this BC's diagonal jacobian "
+      "contributions to.  Everything about that variable must match everything "
+      "about this variable (the type, what blocks it's on, etc.)");
 
   return params;
 }

--- a/framework/src/constraints/Constraint.C
+++ b/framework/src/constraints/Constraint.C
@@ -25,11 +25,13 @@ validParams<Constraint>()
 
   params.addRequiredParam<NonlinearVariableName>(
       "variable", "The name of the variable that this constraint is applied to.");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.declareControllable("enable");

--- a/framework/src/controls/RealFunctionControl.C
+++ b/framework/src/controls/RealFunctionControl.C
@@ -25,8 +25,9 @@ validParams<RealFunctionControl>()
   params.addRequiredParam<FunctionName>(
       "function", "The function to use for controlling the specified parameter.");
   params.addRequiredParam<std::string>(
-      "parameter", "The input parameter(s) to control. Specify a single parameter name and all "
-                   "parameters in all objects matching the name will be updated");
+      "parameter",
+      "The input parameter(s) to control. Specify a single parameter name and all "
+      "parameters in all objects matching the name will be updated");
   return params;
 }
 

--- a/framework/src/controls/TimePeriod.C
+++ b/framework/src/controls/TimePeriod.C
@@ -33,9 +33,11 @@ validParams<TimePeriod>()
                                      "The time at which the objects are to be enable/disabled.");
   params.addParam<bool>(
       "set_sync_times", false, "Set the start and end time as execute sync times.");
-  params.addParam<bool>("set_outside_of_range", true, "When true the disable/enable lists are set "
-                                                      "to opposite values when outside of the "
-                                                      "given time range.");
+  params.addParam<bool>("set_outside_of_range",
+                        true,
+                        "When true the disable/enable lists are set "
+                        "to opposite values when outside of the "
+                        "given time range.");
   return params;
 }
 

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -41,11 +41,13 @@ validParams<DGKernel>()
   params += validParams<MeshChangedInterface>();
   params.addRequiredParam<NonlinearVariableName>(
       "variable", "The name of the variable that this boundary condition applies to");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation. Note that in "
-                                                     "the case this is true but no displacements "
-                                                     "are provided in the Mesh block the "
-                                                     "undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation. Note that in "
+                        "the case this is true but no displacements "
+                        "are provided in the Mesh block the "
+                        "undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.declareControllable("enable");

--- a/framework/src/executioners/Executioner.C
+++ b/framework/src/executioners/Executioner.C
@@ -40,9 +40,10 @@ validParams<Executioner>()
 
   params.addParamNamesToGroup("restart_file_base", "Restart");
 
-  params.addParam<std::vector<std::string>>("splitting", "Top-level splitting defining a "
-                                                         "hierarchical decomposition into "
-                                                         "subsystems to help the solver.");
+  params.addParam<std::vector<std::string>>("splitting",
+                                            "Top-level splitting defining a "
+                                            "hierarchical decomposition into "
+                                            "subsystems to help the solver.");
 
 // Default Solver Behavior
 #ifdef LIBMESH_HAVE_PETSC

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -67,9 +67,11 @@ validParams<Transient>()
   params.addParam<int>("n_startup_steps", 0, "The number of timesteps during startup");
   params.addParam<bool>(
       "trans_ss_check", false, "Whether or not to check for steady state conditions");
-  params.addParam<Real>("ss_check_tol", 1.0e-08, "Whenever the relative residual changes by less "
-                                                 "than this the solution will be considered to be "
-                                                 "at steady state.");
+  params.addParam<Real>("ss_check_tol",
+                        1.0e-08,
+                        "Whenever the relative residual changes by less "
+                        "than this the solution will be considered to be "
+                        "at steady state.");
   params.addParam<Real>(
       "ss_tmin",
       0.0,
@@ -85,23 +87,30 @@ validParams<Transient>()
                         2.0e-14,
                         "the tolerance setting for final timestep size and sync times");
 
-  params.addParam<bool>("use_multiapp_dt", false, "If true then the dt for the simulation will be "
-                                                  "chosen by the MultiApps.  If false (the "
-                                                  "default) then the minimum over the master dt "
-                                                  "and the MultiApps is used");
+  params.addParam<bool>("use_multiapp_dt",
+                        false,
+                        "If true then the dt for the simulation will be "
+                        "chosen by the MultiApps.  If false (the "
+                        "default) then the minimum over the master dt "
+                        "and the MultiApps is used");
 
-  params.addParam<unsigned int>(
-      "picard_max_its", 1, "Number of times each timestep will be solved.  Mainly used when "
-                           "wanting to do Picard iterations with MultiApps that are set to "
-                           "execute_on timestep_end or timestep_begin");
-  params.addParam<Real>("picard_rel_tol", 1e-8, "The relative nonlinear residual drop to shoot for "
-                                                "during Picard iterations.  This check is "
-                                                "performed based on the Master app's nonlinear "
-                                                "residual.");
-  params.addParam<Real>("picard_abs_tol", 1e-50, "The absolute nonlinear residual to shoot for "
-                                                 "during Picard iterations.  This check is "
-                                                 "performed based on the Master app's nonlinear "
-                                                 "residual.");
+  params.addParam<unsigned int>("picard_max_its",
+                                1,
+                                "Number of times each timestep will be solved.  Mainly used when "
+                                "wanting to do Picard iterations with MultiApps that are set to "
+                                "execute_on timestep_end or timestep_begin");
+  params.addParam<Real>("picard_rel_tol",
+                        1e-8,
+                        "The relative nonlinear residual drop to shoot for "
+                        "during Picard iterations.  This check is "
+                        "performed based on the Master app's nonlinear "
+                        "residual.");
+  params.addParam<Real>("picard_abs_tol",
+                        1e-50,
+                        "The absolute nonlinear residual to shoot for "
+                        "during Picard iterations.  This check is "
+                        "performed based on the Master app's nonlinear "
+                        "residual.");
 
   params.addParamNamesToGroup("start_time dtmin dtmax n_startup_steps trans_ss_check ss_check_tol "
                               "ss_tmin abort_on_solve_fail timestep_tolerance use_multiapp_dt",

--- a/framework/src/functions/Axisymmetric2D3DSolutionFunction.C
+++ b/framework/src/functions/Axisymmetric2D3DSolutionFunction.C
@@ -27,8 +27,9 @@ validParams<Axisymmetric2D3DSolutionFunction>()
   params.addRequiredParam<UserObjectName>("solution",
                                           "The SolutionUserObject to extract data from.");
   params.addParam<std::vector<std::string>>(
-      "from_variables", "The names of the variables in the file that are to be extracted, in x, y "
-                        "order if they are vector components");
+      "from_variables",
+      "The names of the variables in the file that are to be extracted, in x, y "
+      "order if they are vector components");
 
   params.addParam<Real>(
       "scale_factor",

--- a/framework/src/functions/PiecewiseBilinear.C
+++ b/framework/src/functions/PiecewiseBilinear.C
@@ -33,9 +33,11 @@ validParams<PiecewiseBilinear>()
       "yaxis", -1, "The coordinate used for y-axis data (0, 1, or 2 for x, y, or z).");
   params.addParam<Real>(
       "scale_factor", 1.0, "Scale factor to be applied to the axis, yaxis, or xaxis values");
-  params.addParam<bool>("radial", false, "Set to true if you want to interpolate along a radius "
-                                         "rather that along a specific axis, and note that you "
-                                         "have to define xaxis and yaxis in the input file");
+  params.addParam<bool>("radial",
+                        false,
+                        "Set to true if you want to interpolate along a radius "
+                        "rather that along a specific axis, and note that you "
+                        "have to define xaxis and yaxis in the input file");
   return params;
 }
 

--- a/framework/src/indicators/Indicator.C
+++ b/framework/src/indicators/Indicator.C
@@ -32,11 +32,13 @@ validParams<Indicator>()
   params += validParams<OutputInterface>();
   params += validParams<MaterialPropertyInterface>();
 
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.registerBase("Indicator");

--- a/framework/src/indicators/InternalSideIndicator.C
+++ b/framework/src/indicators/InternalSideIndicator.C
@@ -36,10 +36,12 @@ validParams<InternalSideIndicator>()
   InputParameters params = validParams<Indicator>();
   params.addRequiredParam<VariableName>(
       "variable", "The name of the variable that this side indicator applies to");
-  params.addParam<bool>("scale_by_flux_faces", false, "Whether or not to scale the error values by "
-                                                      "the number of flux faces.  This attempts to "
-                                                      "not penalize elements on boundaries for "
-                                                      "having less neighbors.");
+  params.addParam<bool>("scale_by_flux_faces",
+                        false,
+                        "Whether or not to scale the error values by "
+                        "the number of flux faces.  This attempts to "
+                        "not penalize elements on boundaries for "
+                        "having less neighbors.");
 
   params.addPrivateParam<BoundaryID>("_boundary_id", InternalSideIndicator::InternalBndId);
   return params;

--- a/framework/src/kernels/KernelBase.C
+++ b/framework/src/kernels/KernelBase.C
@@ -37,20 +37,24 @@ validParams<KernelBase>()
   params.addRequiredParam<NonlinearVariableName>(
       "variable", "The name of the variable that this Kernel operates on");
   params.addParam<std::vector<AuxVariableName>>(
-      "save_in", "The name of auxiliary variables to save this Kernel's residual contributions to. "
-                 " Everything about that variable must match everything about this variable (the "
-                 "type, what blocks it's on, etc.)");
+      "save_in",
+      "The name of auxiliary variables to save this Kernel's residual contributions to. "
+      " Everything about that variable must match everything about this variable (the "
+      "type, what blocks it's on, etc.)");
   params.addParam<std::vector<AuxVariableName>>(
-      "diag_save_in", "The name of auxiliary variables to save this Kernel's diagonal Jacobian "
-                      "contributions to. Everything about that variable must match everything "
-                      "about this variable (the type, what blocks it's on, etc.)");
+      "diag_save_in",
+      "The name of auxiliary variables to save this Kernel's diagonal Jacobian "
+      "contributions to. Everything about that variable must match everything "
+      "about this variable (the type, what blocks it's on, etc.)");
   params.addParam<bool>(
       "eigen_kernel", false, "Whether or not this kernel will be used as an eigen kernel");
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation. Note that in "
-                                                     "the case this is true but no displacements "
-                                                     "are provided in the Mesh block the "
-                                                     "undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation. Note that in "
+                        "the case this is true but no displacements "
+                        "are provided in the Mesh block the "
+                        "undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.addParamNamesToGroup("diag_save_in save_in", "Advanced");

--- a/framework/src/kernels/ScalarKernel.C
+++ b/framework/src/kernels/ScalarKernel.C
@@ -29,11 +29,13 @@ validParams<ScalarKernel>()
   params.addRequiredParam<NonlinearVariableName>(
       "variable", "The name of the variable that this kernel operates on");
 
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.registerBase("ScalarKernel");

--- a/framework/src/markers/ErrorFractionMarker.C
+++ b/framework/src/markers/ErrorFractionMarker.C
@@ -22,12 +22,16 @@ InputParameters
 validParams<ErrorFractionMarker>()
 {
   InputParameters params = validParams<IndicatorMarker>();
-  params.addRangeCheckedParam<Real>(
-      "coarsen", 0, "coarsen>=0 & coarsen<=1", "Elements within this percentage of the min error "
-                                               "will be coarsened.  Must be between 0 and 1!");
-  params.addRangeCheckedParam<Real>(
-      "refine", 0, "refine>=0 & refine<=1", "Elements within this percentage of the max error will "
-                                            "be refined.  Must be between 0 and 1!");
+  params.addRangeCheckedParam<Real>("coarsen",
+                                    0,
+                                    "coarsen>=0 & coarsen<=1",
+                                    "Elements within this percentage of the min error "
+                                    "will be coarsened.  Must be between 0 and 1!");
+  params.addRangeCheckedParam<Real>("refine",
+                                    0,
+                                    "refine>=0 & refine<=1",
+                                    "Elements within this percentage of the max error will "
+                                    "be refined.  Must be between 0 and 1!");
 
   params.addClassDescription("Marks elements for refinement or coarsening based on the fraction of "
                              "the total error from the supplied indicator.");

--- a/framework/src/markers/Marker.C
+++ b/framework/src/markers/Marker.C
@@ -26,11 +26,13 @@ validParams<Marker>()
   params += validParams<BlockRestrictable>();
   params += validParams<OutputInterface>();
 
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.registerBase("Marker");

--- a/framework/src/markers/QuadraturePointMarker.C
+++ b/framework/src/markers/QuadraturePointMarker.C
@@ -31,15 +31,20 @@ validParams<QuadraturePointMarker>()
       "third_state",
       third_state,
       "The Marker state to apply to values falling in-between the coarsen and refine thresholds.");
-  params.addParam<Real>("coarsen", "The threshold value for coarsening.  Elements with variable "
-                                   "values beyond this will be marked for coarsening.");
-  params.addParam<Real>("refine", "The threshold value for refinement.  Elements with variable "
-                                  "values beyond this will be marked for refinement.");
-  params.addParam<bool>("invert", false, "If this is true then values _below_ 'refine' will be "
-                                         "refined and _above_ 'coarsen' will be coarsened.");
-  params.addRequiredParam<VariableName>("variable", "The values of this variable will be compared "
-                                                    "to 'refine' and 'coarsen' to see what should "
-                                                    "be done with the element");
+  params.addParam<Real>("coarsen",
+                        "The threshold value for coarsening.  Elements with variable "
+                        "values beyond this will be marked for coarsening.");
+  params.addParam<Real>("refine",
+                        "The threshold value for refinement.  Elements with variable "
+                        "values beyond this will be marked for refinement.");
+  params.addParam<bool>("invert",
+                        false,
+                        "If this is true then values _below_ 'refine' will be "
+                        "refined and _above_ 'coarsen' will be coarsened.");
+  params.addRequiredParam<VariableName>("variable",
+                                        "The values of this variable will be compared "
+                                        "to 'refine' and 'coarsen' to see what should "
+                                        "be done with the element");
   return params;
 }
 

--- a/framework/src/markers/ValueRangeMarker.C
+++ b/framework/src/markers/ValueRangeMarker.C
@@ -29,11 +29,15 @@ validParams<ValueRangeMarker>()
       "The Marker state to apply to values in the buffer zone (both ends of the range).");
   params.addRequiredParam<Real>("lower_bound", "The lower bound value for the range.");
   params.addRequiredParam<Real>("upper_bound", "The upper bound value for the range.");
-  params.addParam<Real>("buffer_size", 0.0, "A buffer zone value added to both ends of the range "
-                                            "where a third_state marker can be returned.");
-  params.addParam<bool>("invert", false, "If this is true then values inside the range will be "
-                                         "coarsened, and values outside the range will be "
-                                         "refined.");
+  params.addParam<Real>("buffer_size",
+                        0.0,
+                        "A buffer zone value added to both ends of the range "
+                        "where a third_state marker can be returned.");
+  params.addParam<bool>("invert",
+                        false,
+                        "If this is true then values inside the range will be "
+                        "coarsened, and values outside the range will be "
+                        "refined.");
   params.addRequiredCoupledVar("variable", "The variable whose values are used in this marker.");
   params.addClassDescription("Mark elements for adaptivity based on the supplied upper and lower "
                              "bounds and the specified variable.");

--- a/framework/src/markers/ValueThresholdMarker.C
+++ b/framework/src/markers/ValueThresholdMarker.C
@@ -27,15 +27,20 @@ validParams<ValueThresholdMarker>()
       "third_state",
       third_state,
       "The Marker state to apply to values falling in-between the coarsen and refine thresholds.");
-  params.addParam<Real>("coarsen", "The threshold value for coarsening.  Elements with variable "
-                                   "values beyond this will be marked for coarsening.");
-  params.addParam<Real>("refine", "The threshold value for refinement.  Elements with variable "
-                                  "values beyond this will be marked for refinement.");
-  params.addParam<bool>("invert", false, "If this is true then values _below_ 'refine' will be "
-                                         "refined and _above_ 'coarsen' will be coarsened.");
-  params.addRequiredCoupledVar("variable", "The values of this variable will be compared to "
-                                           "'refine' and 'coarsen' to see what should be done with "
-                                           "the element");
+  params.addParam<Real>("coarsen",
+                        "The threshold value for coarsening.  Elements with variable "
+                        "values beyond this will be marked for coarsening.");
+  params.addParam<Real>("refine",
+                        "The threshold value for refinement.  Elements with variable "
+                        "values beyond this will be marked for refinement.");
+  params.addParam<bool>("invert",
+                        false,
+                        "If this is true then values _below_ 'refine' will be "
+                        "refined and _above_ 'coarsen' will be coarsened.");
+  params.addRequiredCoupledVar("variable",
+                               "The values of this variable will be compared to "
+                               "'refine' and 'coarsen' to see what should be done with "
+                               "the element");
   params.addClassDescription(
       "The the refinement state based on a threshold value compared to the specified variable.");
   return params;

--- a/framework/src/materials/GenericFunctionMaterial.C
+++ b/framework/src/materials/GenericFunctionMaterial.C
@@ -22,9 +22,10 @@ validParams<GenericFunctionMaterial>()
   InputParameters params = validParams<Material>();
   params.addParam<std::vector<std::string>>("prop_names",
                                             "The names of the properties this material will have");
-  params.addParam<std::vector<FunctionName>>("prop_values", "The corresponding names of the "
-                                                            "functions that are going to provide "
-                                                            "the values for the variables");
+  params.addParam<std::vector<FunctionName>>("prop_values",
+                                             "The corresponding names of the "
+                                             "functions that are going to provide "
+                                             "the values for the variables");
   params.addParam<bool>("enable_stateful", false, "Enable the declaration of old and older values");
   return params;
 }

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -34,11 +34,13 @@ validParams<Material>()
   params += validParams<RandomInterface>();
   params += validParams<MaterialPropertyInterface>();
 
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParam<bool>("compute",
                         true,
                         "When false, MOOSE will not call compute methods on this material. "
@@ -54,8 +56,9 @@ validParams<Material>()
   params += validParams<OutputInterface>();
   params.set<std::vector<OutputName>>("outputs") = {"none"};
   params.addParam<std::vector<std::string>>(
-      "output_properties", "List of material properties, from this material, to output (outputs "
-                           "must also be defined to an output type)");
+      "output_properties",
+      "List of material properties, from this material, to output (outputs "
+      "must also be defined to an output type)");
 
   params.addParamNamesToGroup("outputs output_properties", "Outputs");
   params.addParamNamesToGroup("use_displaced_mesh constant_on_elem", "Advanced");

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -47,9 +47,11 @@ validParams<GeneratedMesh>()
   params.addParam<Real>("xmax", 1.0, "Upper X Coordinate of the generated mesh");
   params.addParam<Real>("ymax", 1.0, "Upper Y Coordinate of the generated mesh");
   params.addParam<Real>("zmax", 1.0, "Upper Z Coordinate of the generated mesh");
-  params.addParam<MooseEnum>("elem_type", elem_types, "The type of element from libMesh to "
-                                                      "generate (default: linear element for "
-                                                      "requested dimension)");
+  params.addParam<MooseEnum>("elem_type",
+                             elem_types,
+                             "The type of element from libMesh to "
+                             "generate (default: linear element for "
+                             "requested dimension)");
   params.addParam<bool>(
       "gauss_lobatto_grid",
       false,

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1114,8 +1114,9 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
                                 unsigned int var_number,
                                 PeriodicBoundaries * pbs) const
 {
-  mooseAssert(!Threads::in_threads, "This function should only be called outside of a threaded "
-                                    "region due to the use of PointLocator");
+  mooseAssert(!Threads::in_threads,
+              "This function should only be called outside of a threaded "
+              "region due to the use of PointLocator");
 
   periodic_node_map.clear();
 

--- a/framework/src/mesh/PatternedMesh.C
+++ b/framework/src/mesh/PatternedMesh.C
@@ -26,9 +26,10 @@ InputParameters
 validParams<PatternedMesh>()
 {
   InputParameters params = validParams<MooseMesh>();
-  params.addRequiredParam<std::vector<MeshFileName>>("files", "The name of the mesh files to read. "
-                                                              " They are automatically assigned "
-                                                              "ids starting with zero.");
+  params.addRequiredParam<std::vector<MeshFileName>>("files",
+                                                     "The name of the mesh files to read. "
+                                                     " They are automatically assigned "
+                                                     "ids starting with zero.");
 
   params.addRangeCheckedParam<Real>(
       "x_width", 0, "x_width>=0", "The tile width in the x direction");

--- a/framework/src/mesh/StitchedMesh.C
+++ b/framework/src/mesh/StitchedMesh.C
@@ -27,8 +27,9 @@ validParams<StitchedMesh>()
 {
   InputParameters params = validParams<MooseMesh>();
   params.addRequiredParam<std::vector<MeshFileName>>(
-      "files", "The name of the mesh files to read.  These mesh files will be 'stitched' into the "
-               "current mesh in this order.");
+      "files",
+      "The name of the mesh files to read.  These mesh files will be 'stitched' into the "
+      "current mesh in this order.");
 
   params.addRequiredParam<std::vector<BoundaryName>>(
       "stitch_boundaries",

--- a/framework/src/meshmodifiers/AddExtraNodeset.C
+++ b/framework/src/meshmodifiers/AddExtraNodeset.C
@@ -26,12 +26,14 @@ validParams<AddExtraNodeset>()
   params.addRequiredParam<std::vector<BoundaryName>>("new_boundary",
                                                      "The name of the boundary to create");
 
-  params.addParam<std::vector<unsigned int>>("nodes", "The nodes you want to be in the nodeset "
-                                                      "(Either this parameter or \"coord\" must be "
-                                                      "supplied).");
-  params.addParam<std::vector<Real>>("coord", "The nodes with coordinates you want to be in the "
-                                              "nodeset (Either this parameter or \"nodes\" must be "
-                                              "supplied).");
+  params.addParam<std::vector<unsigned int>>("nodes",
+                                             "The nodes you want to be in the nodeset "
+                                             "(Either this parameter or \"coord\" must be "
+                                             "supplied).");
+  params.addParam<std::vector<Real>>("coord",
+                                     "The nodes with coordinates you want to be in the "
+                                     "nodeset (Either this parameter or \"nodes\" must be "
+                                     "supplied).");
   params.addParam<Real>(
       "tolerance", TOLERANCE, "The tolerance in which two nodes are considered identical");
 

--- a/framework/src/meshmodifiers/AddSideSetsBase.C
+++ b/framework/src/meshmodifiers/AddSideSetsBase.C
@@ -31,8 +31,10 @@ validParams<AddSideSetsBase>()
   InputParameters params = validParams<MeshModifier>();
   params.addParam<Real>(
       "variance", 0.10, "The variance [0.0 - 1.0] allowed when comparing normals");
-  params.addParam<bool>("fixed_normal", false, "This Boolean determines whether we fix our normal "
-                                               "or allow it to vary to \"paint\" around curves");
+  params.addParam<bool>("fixed_normal",
+                        false,
+                        "This Boolean determines whether we fix our normal "
+                        "or allow it to vary to \"paint\" around curves");
 
   return params;
 }

--- a/framework/src/meshmodifiers/RenameBlock.C
+++ b/framework/src/meshmodifiers/RenameBlock.C
@@ -21,25 +21,29 @@ validParams<RenameBlock>()
 {
   InputParameters params = validParams<MeshModifier>();
   params.addParam<std::vector<SubdomainID>>(
-      "old_block_id", "Elements with this block number will be given the new_block_number or "
-                      "new_block_name.  You must supply either old_block_id or old_block_name.  "
-                      "You may supply a vector of old_block_id, in which case the new_block "
-                      "information must also be a vector.");
+      "old_block_id",
+      "Elements with this block number will be given the new_block_number or "
+      "new_block_name.  You must supply either old_block_id or old_block_name.  "
+      "You may supply a vector of old_block_id, in which case the new_block "
+      "information must also be a vector.");
   params.addParam<std::vector<SubdomainName>>(
-      "old_block_name", "Elements with this block name will be given the new_block_number or "
-                        "new_block_name.  You must supply either old_block_id or old_block_name.  "
-                        "You may supply a vector of old_block_name, in which case the new_block "
-                        "information must also be a vector.");
+      "old_block_name",
+      "Elements with this block name will be given the new_block_number or "
+      "new_block_name.  You must supply either old_block_id or old_block_name.  "
+      "You may supply a vector of old_block_name, in which case the new_block "
+      "information must also be a vector.");
   params.addParam<std::vector<SubdomainID>>(
-      "new_block_id", "Elements with the old block number (or name) will be given this block "
-                      "number.  You must supply either new_block_id or new_block_name.  You may "
-                      "supply a vector of new_block_id, in which case the old_block information "
-                      "must also be a vector.");
+      "new_block_id",
+      "Elements with the old block number (or name) will be given this block "
+      "number.  You must supply either new_block_id or new_block_name.  You may "
+      "supply a vector of new_block_id, in which case the old_block information "
+      "must also be a vector.");
   params.addParam<std::vector<SubdomainName>>(
-      "new_block_name", "Elements with the old block number (or name) will be given this block "
-                        "name.  You must supply either new_block_id or new_block_name.  You may "
-                        "supply a vector of new_block_id, in which case the old_block information "
-                        "must also be a vector.");
+      "new_block_name",
+      "Elements with the old block number (or name) will be given this block "
+      "name.  You must supply either new_block_id or new_block_name.  You may "
+      "supply a vector of new_block_id, in which case the old_block information "
+      "must also be a vector.");
   params.addClassDescription("RenameBlock re-numbers or re-names an old_block_id or old_block_name "
                              "with a new_block_id or new_block_name");
   return params;

--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -29,13 +29,16 @@ validParams<SideSetsAroundSubdomain>()
   params += validParams<BlockRestrictable>();
   params.addRequiredParam<std::vector<BoundaryName>>(
       "new_boundary", "The list of boundary IDs to create on the supplied subdomain");
-  params.addParam<Point>("normal", "If supplied, only faces with normal equal to this, up to "
-                                   "normal_tol, will be added to the sidesets specified");
-  params.addRangeCheckedParam<Real>(
-      "normal_tol", 0.1, "normal_tol>=0 & normal_tol<=2", "If normal is supplied then faces are "
-                                                          "only added if face_normal.normal_hat >= "
-                                                          "1 - normal_tol, where normal_hat = "
-                                                          "normal/|normal|");
+  params.addParam<Point>("normal",
+                         "If supplied, only faces with normal equal to this, up to "
+                         "normal_tol, will be added to the sidesets specified");
+  params.addRangeCheckedParam<Real>("normal_tol",
+                                    0.1,
+                                    "normal_tol>=0 & normal_tol<=2",
+                                    "If normal is supplied then faces are "
+                                    "only added if face_normal.normal_hat >= "
+                                    "1 - normal_tol, where normal_hat = "
+                                    "normal/|normal|");
 
   // We can't perform block/boundary restrictable checks on construction for MeshModifiers
   params.set<bool>("delay_initialization") = true;

--- a/framework/src/meshmodifiers/Transform.C
+++ b/framework/src/meshmodifiers/Transform.C
@@ -27,10 +27,11 @@ validParams<Transform>()
   params.addRequiredParam<MooseEnum>(
       "transform", transforms, "The type of transformation to perform (TRANSLATE, ROTATE, SCALE)");
   params.addRequiredParam<RealVectorValue>(
-      "vector_value", "The value to use for the transformation. When using TRANSLATE or SCALE, the "
-                      "xyz coordinates are applied in each direction respectively. When using "
-                      "ROTATE, the values are interpreted as the Euler angles phi, theta and psi "
-                      "given in degrees.");
+      "vector_value",
+      "The value to use for the transformation. When using TRANSLATE or SCALE, the "
+      "xyz coordinates are applied in each direction respectively. When using "
+      "ROTATE, the values are interpreted as the Euler angles phi, theta and psi "
+      "given in degrees.");
 
   return params;
 }

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -47,11 +47,13 @@ validParams<MultiApp>()
   InputParameters params = validParams<MooseObject>();
   params += validParams<SetupInterface>();
 
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   std::ostringstream app_types_strings;
@@ -60,26 +62,31 @@ validParams<MultiApp>()
     app_types_strings << it->first << " ";
   MooseEnum app_types_options(app_types_strings.str(), "", true);
 
-  params.addParam<MooseEnum>(
-      "app_type", app_types_options, "The type of application to build (applications not "
-                                     "registered can be loaded with dynamic libraries. Master "
-                                     "application type will be used if not provided.");
-  params.addParam<std::string>("library_path", "", "Path to search for dynamic libraries (please "
-                                                   "avoid committing absolute paths in addition to "
-                                                   "MOOSE_LIBRARY_PATH)");
+  params.addParam<MooseEnum>("app_type",
+                             app_types_options,
+                             "The type of application to build (applications not "
+                             "registered can be loaded with dynamic libraries. Master "
+                             "application type will be used if not provided.");
+  params.addParam<std::string>("library_path",
+                               "",
+                               "Path to search for dynamic libraries (please "
+                               "avoid committing absolute paths in addition to "
+                               "MOOSE_LIBRARY_PATH)");
   params.addParam<std::vector<Point>>(
-      "positions", "The positions of the App locations.  Each set of 3 values will represent a "
-                   "Point.  This and 'positions_file' cannot be both supplied. If this and "
-                   "'positions_file' are not supplied, a single position (0,0,0) will be used");
+      "positions",
+      "The positions of the App locations.  Each set of 3 values will represent a "
+      "Point.  This and 'positions_file' cannot be both supplied. If this and "
+      "'positions_file' are not supplied, a single position (0,0,0) will be used");
   params.addParam<std::vector<FileName>>("positions_file",
                                          "A filename that should be looked in for positions. Each "
                                          "set of 3 values in that file will represent a Point.  "
                                          "This and 'positions' cannot be both supplied");
 
   params.addRequiredParam<std::vector<FileName>>(
-      "input_files", "The input file for each App.  If this parameter only contains one input file "
-                     "it will be used for all of the Apps.  When using 'positions_from_file' it is "
-                     "also admissable to provide one input_file per file.");
+      "input_files",
+      "The input file for each App.  If this parameter only contains one input file "
+      "it will be used for all of the Apps.  When using 'positions_from_file' it is "
+      "also admissable to provide one input_file per file.");
   params.addParam<Real>("bounding_box_inflation",
                         0.01,
                         "Relative amount to 'inflate' the bounding box of this MultiApp.");
@@ -107,10 +114,11 @@ validParams<MultiApp>()
                         "modeling the insertion of 'new' material for that app.");
 
   params.addParam<std::vector<unsigned int>>(
-      "reset_apps", "The Apps that will be reset when 'reset_time' is hit.  These are the App "
-                    "'numbers' starting with 0 corresponding to the order of the App positions.  "
-                    "Resetting an App means that it is destroyed and recreated, possibly modeling "
-                    "the insertion of 'new' material for that app.");
+      "reset_apps",
+      "The Apps that will be reset when 'reset_time' is hit.  These are the App "
+      "'numbers' starting with 0 corresponding to the order of the App positions.  "
+      "Resetting an App means that it is destroyed and recreated, possibly modeling "
+      "the insertion of 'new' material for that app.");
 
   params.addParam<Real>(
       "move_time",
@@ -118,8 +126,9 @@ validParams<MultiApp>()
       "The time at which Apps designated by move_apps are moved to move_positions.");
 
   params.addParam<std::vector<unsigned int>>(
-      "move_apps", "Apps, designated by their 'numbers' starting with 0 corresponding to the order "
-                   "of the App positions, to be moved at move_time to move_positions");
+      "move_apps",
+      "Apps, designated by their 'numbers' starting with 0 corresponding to the order "
+      "of the App positions, to be moved at move_time to move_positions");
 
   params.addParam<std::vector<Point>>("move_positions",
                                       "The positions corresponding to each move_app.");

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -34,24 +34,31 @@ validParams<TransientMultiApp>()
   InputParameters params = validParams<MultiApp>();
   params += validParams<TransientInterface>();
 
-  params.addParam<bool>("sub_cycling", false, "Set to true to allow this MultiApp to take smaller "
-                                              "timesteps than the rest of the simulation.  More "
-                                              "than one timestep will be performed for each "
-                                              "'master' timestep");
+  params.addParam<bool>("sub_cycling",
+                        false,
+                        "Set to true to allow this MultiApp to take smaller "
+                        "timesteps than the rest of the simulation.  More "
+                        "than one timestep will be performed for each "
+                        "'master' timestep");
 
-  params.addParam<bool>("interpolate_transfers", false, "Only valid when sub_cycling.  This allows "
-                                                        "transferred values to be interpolated "
-                                                        "over the time frame the MultiApp is "
-                                                        "executing over when sub_cycling");
+  params.addParam<bool>("interpolate_transfers",
+                        false,
+                        "Only valid when sub_cycling.  This allows "
+                        "transferred values to be interpolated "
+                        "over the time frame the MultiApp is "
+                        "executing over when sub_cycling");
 
-  params.addParam<bool>(
-      "detect_steady_state", false, "If true then while sub_cycling a steady state check will be "
-                                    "done.  In this mode output will only be done once the "
-                                    "MultiApp reaches the target time or steady state is reached");
+  params.addParam<bool>("detect_steady_state",
+                        false,
+                        "If true then while sub_cycling a steady state check will be "
+                        "done.  In this mode output will only be done once the "
+                        "MultiApp reaches the target time or steady state is reached");
 
-  params.addParam<Real>("steady_state_tol", 1e-8, "The relative difference between the new "
-                                                  "solution and the old solution that will be "
-                                                  "considered to be at steady state");
+  params.addParam<Real>("steady_state_tol",
+                        1e-8,
+                        "The relative difference between the new "
+                        "solution and the old solution that will be "
+                        "considered to be at steady state");
 
   params.addParam<bool>("output_sub_cycles", false, "If true then every sub-cycle will be output.");
   params.addParam<bool>(
@@ -60,18 +67,22 @@ validParams<TransientMultiApp>()
   params.addParam<unsigned int>(
       "max_failures", 0, "Maximum number of solve failures tolerated while sub_cycling.");
 
-  params.addParam<bool>("tolerate_failure", false, "If true this MultiApp won't participate in dt "
-                                                   "decisions and will always be fast-forwarded to "
-                                                   "the current time.");
+  params.addParam<bool>("tolerate_failure",
+                        false,
+                        "If true this MultiApp won't participate in dt "
+                        "decisions and will always be fast-forwarded to "
+                        "the current time.");
 
   params.addParam<bool>(
       "catch_up",
       false,
       "If true this will allow failed solves to attempt to 'catch up' using smaller timesteps.");
 
-  params.addParam<Real>("max_catch_up_steps", 2, "Maximum number of steps to allow an app to take "
-                                                 "when trying to catch back up after a failed "
-                                                 "solve.");
+  params.addParam<Real>("max_catch_up_steps",
+                        2,
+                        "Maximum number of steps to allow an app to take "
+                        "when trying to catch back up after a failed "
+                        "solve.");
 
   return params;
 }

--- a/framework/src/nodalkernels/NodalKernel.C
+++ b/framework/src/nodalkernels/NodalKernel.C
@@ -33,20 +33,24 @@ validParams<NodalKernel>()
       "variable", "The name of the variable that this boundary condition applies to");
 
   params.addParam<std::vector<AuxVariableName>>(
-      "save_in", "The name of auxiliary variables to save this BC's residual contributions to.  "
-                 "Everything about that variable must match everything about this variable (the "
-                 "type, what blocks it's on, etc.)");
+      "save_in",
+      "The name of auxiliary variables to save this BC's residual contributions to.  "
+      "Everything about that variable must match everything about this variable (the "
+      "type, what blocks it's on, etc.)");
 
   params.addParam<std::vector<AuxVariableName>>(
-      "diag_save_in", "The name of auxiliary variables to save this BC's diagonal jacobian "
-                      "contributions to.  Everything about that variable must match everything "
-                      "about this variable (the type, what blocks it's on, etc.)");
+      "diag_save_in",
+      "The name of auxiliary variables to save this BC's diagonal jacobian "
+      "contributions to.  Everything about that variable must match everything "
+      "about this variable (the type, what blocks it's on, etc.)");
 
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.declareControllable("enable");

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -40,12 +40,14 @@ addAdvancedOutputParams(InputParameters & params)
 {
   // Hide/show variable output options
   params.addParam<std::vector<VariableName>>(
-      "hide", "A list of the variables and postprocessors that should NOT be output to the Exodus "
-              "file (may include Variables, ScalarVariables, and Postprocessor names).");
+      "hide",
+      "A list of the variables and postprocessors that should NOT be output to the Exodus "
+      "file (may include Variables, ScalarVariables, and Postprocessor names).");
 
   params.addParam<std::vector<VariableName>>(
-      "show", "A list of the variables and postprocessors that should be output to the Exodus file "
-              "(may include Variables, ScalarVariables, and Postprocessor names).");
+      "show",
+      "A list of the variables and postprocessors that should be output to the Exodus file "
+      "(may include Variables, ScalarVariables, and Postprocessor names).");
 
   // 'Variables' Group
   params.addParamNamesToGroup("hide show", "Variables");

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -42,14 +42,17 @@ validParams<Console>()
       "show_multiapp_name", false, "Indent multiapp output using the multiapp name");
 
   // Table fitting options
-  params.addParam<unsigned int>("max_rows", 15, "The maximum number of postprocessor/scalar values "
-                                                "displayed on screen during a timestep (set to 0 "
-                                                "for unlimited)");
-  params.addParam<MooseEnum>(
-      "fit_mode", pps_fit_mode, "Specifies the wrapping mode for post-processor tables that are "
-                                "printed to the screen (ENVIRONMENT: Read \"MOOSE_PPS_WIDTH\" for "
-                                "desired width, AUTO: Attempt to determine width automatically "
-                                "(serial only), <n>: Desired width");
+  params.addParam<unsigned int>("max_rows",
+                                15,
+                                "The maximum number of postprocessor/scalar values "
+                                "displayed on screen during a timestep (set to 0 "
+                                "for unlimited)");
+  params.addParam<MooseEnum>("fit_mode",
+                             pps_fit_mode,
+                             "Specifies the wrapping mode for post-processor tables that are "
+                             "printed to the screen (ENVIRONMENT: Read \"MOOSE_PPS_WIDTH\" for "
+                             "desired width, AUTO: Attempt to determine width automatically "
+                             "(serial only), <n>: Desired width");
 
   // Verbosity
   params.addParam<bool>("verbose", false, "Print detailed diagnostics on timestep calculation");
@@ -62,8 +65,10 @@ validParams<Console>()
       "The number of significant digits that are printed on time related outputs");
 
   // Performance Logging
-  params.addParam<bool>("perf_log", false, "If true, all performance logs will be printed. The "
-                                           "individual log settings will override this option.");
+  params.addParam<bool>("perf_log",
+                        false,
+                        "If true, all performance logs will be printed. The "
+                        "individual log settings will override this option.");
   params.addParam<unsigned int>(
       "perf_log_interval", 0, "If set, the performance log will be printed every n time steps");
   params.addDeprecatedParam<bool>("setup_log_early",
@@ -104,19 +109,22 @@ validParams<Console>()
   std::vector<Real> multiplier;
   multiplier.push_back(0.8);
   multiplier.push_back(2);
-  params.addParam<std::vector<Real>>(
-      "outlier_multiplier", multiplier, "Multiplier utilized to determine if a residual norm is an "
-                                        "outlier. If the variable residual is less than "
-                                        "multiplier[0] times the total residual it is colored red. "
-                                        "If the variable residual is less than multiplier[1] times "
-                                        "the average residual it is colored yellow.");
+  params.addParam<std::vector<Real>>("outlier_multiplier",
+                                     multiplier,
+                                     "Multiplier utilized to determine if a residual norm is an "
+                                     "outlier. If the variable residual is less than "
+                                     "multiplier[0] times the total residual it is colored red. "
+                                     "If the variable residual is less than multiplier[1] times "
+                                     "the average residual it is colored yellow.");
 
   // System information controls
   MultiMooseEnum info("framework mesh aux nonlinear execution output",
                       "framework mesh aux nonlinear execution");
-  params.addParam<MultiMooseEnum>("system_info", info, "List of information types to display "
-                                                       "('framework', 'mesh', 'aux', 'nonlinear', "
-                                                       "'execution', 'output')");
+  params.addParam<MultiMooseEnum>("system_info",
+                                  info,
+                                  "List of information types to display "
+                                  "('framework', 'mesh', 'aux', 'nonlinear', "
+                                  "'execution', 'output')");
 
   // Advanced group
   params.addParamNamesToGroup("max_rows verbose show_multiapp_name system_info", "Advanced");

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -34,13 +34,15 @@ validParams<Exodus>()
 
   // Enable sequential file output (do not set default, the use_displace criteria relies on
   // isParamValid, see Constructor)
-  params.addParam<bool>("sequence", "Enable/disable sequential file output (enabled by default "
-                                    "when 'use_displace = true', otherwise defaults to false");
+  params.addParam<bool>("sequence",
+                        "Enable/disable sequential file output (enabled by default "
+                        "when 'use_displace = true', otherwise defaults to false");
 
   // Select problem dimension for mesh output
-  params.addParam<bool>("use_problem_dimension", "Use the problem dimension to the mesh output. "
-                                                 "Set to false when outputting lower dimensional "
-                                                 "meshes embedded in a higher dimensional space.");
+  params.addParam<bool>("use_problem_dimension",
+                        "Use the problem dimension to the mesh output. "
+                        "Set to false when outputting lower dimensional "
+                        "meshes embedded in a higher dimensional space.");
 
   // Set the default padding to 3
   params.set<unsigned int>("padding") = 3;
@@ -49,8 +51,10 @@ validParams<Exodus>()
   params.addClassDescription("Object for output data in the Exodus II format");
 
   // Flag for overwriting at each timestep
-  params.addParam<bool>("overwrite", false, "When true the latest timestep will overwrite the "
-                                            "existing file, so only a single timestep exists.");
+  params.addParam<bool>("overwrite",
+                        false,
+                        "When true the latest timestep will overwrite the "
+                        "existing file, so only a single timestep exists.");
 
   // Set outputting of the input to be on by default
   params.set<MultiMooseEnum>("execute_input_on") = "initial";

--- a/framework/src/outputs/OutputInterface.C
+++ b/framework/src/outputs/OutputInterface.C
@@ -24,9 +24,10 @@ InputParameters
 validParams<OutputInterface>()
 {
   InputParameters params = emptyInputParameters();
-  params.addParam<std::vector<OutputName>>("outputs", "Vector of output names were you would like "
-                                                      "to restrict the output of variables(s) "
-                                                      "associated with this object");
+  params.addParam<std::vector<OutputName>>("outputs",
+                                           "Vector of output names were you would like "
+                                           "to restrict the output of variables(s) "
+                                           "associated with this object");
 
   params.addParamNamesToGroup("outputs", "Advanced");
 

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -31,11 +31,14 @@ validParams<OversampleOutput>()
 
   // Get the parameters from the parent object
   InputParameters params = validParams<FileOutput>();
-  params.addParam<unsigned int>("refinements", 0, "Number of uniform refinements for oversampling "
-                                                  "(refinement levels beyond any uniform "
-                                                  "refinements)");
-  params.addParam<Point>("position", "Set a positional offset, this vector will get added to the "
-                                     "nodal coordinates to move the domain.");
+  params.addParam<unsigned int>("refinements",
+                                0,
+                                "Number of uniform refinements for oversampling "
+                                "(refinement levels beyond any uniform "
+                                "refinements)");
+  params.addParam<Point>("position",
+                         "Set a positional offset, this vector will get added to the "
+                         "nodal coordinates to move the domain.");
   params.addParam<MeshFileName>("file", "The name of the mesh file to read, for oversampling");
 
   // **** DEPRECATED AND REMOVED PARAMETERS ****

--- a/framework/src/outputs/TableOutput.C
+++ b/framework/src/outputs/TableOutput.C
@@ -37,9 +37,11 @@ validParams<TableOutput>()
       AdvancedOutput<FileOutput>::enableOutputTypes("postprocessor scalar vector_postprocessor");
 
   // Option for writing vector_postprocessor time file
-  params.addParam<bool>("time_data", false, "When true and VecptorPostprocessor data exists, write "
-                                            "a csv file containing the timestep and time "
-                                            "information.");
+  params.addParam<bool>("time_data",
+                        false,
+                        "When true and VecptorPostprocessor data exists, write "
+                        "a csv file containing the timestep and time "
+                        "information.");
 
   // Add option for appending file on restart
   params.addParam<bool>("append_restart", false, "Append existing file on restart");

--- a/framework/src/postprocessors/ElementExtremeValue.C
+++ b/framework/src/postprocessors/ElementExtremeValue.C
@@ -27,9 +27,11 @@ validParams<ElementExtremeValue>()
   // Define the parameters
   InputParameters params = validParams<ElementVariablePostprocessor>();
 
-  params.addParam<MooseEnum>("value_type", type_options, "Type of extreme value to return. 'max' "
-                                                         "returns the maximum value. 'min' returns "
-                                                         "the minimum value.");
+  params.addParam<MooseEnum>("value_type",
+                             type_options,
+                             "Type of extreme value to return. 'max' "
+                             "returns the maximum value. 'min' returns "
+                             "the minimum value.");
 
   return params;
 }

--- a/framework/src/postprocessors/ExecutionerAttributeReporter.C
+++ b/framework/src/postprocessors/ExecutionerAttributeReporter.C
@@ -31,8 +31,9 @@ validParams<ExecutionerAttributeReporter>()
 ExecutionerAttributeReporter::ExecutionerAttributeReporter(const InputParameters & parameters)
   : GeneralPostprocessor(parameters),
     _value(parameters.getCheckedPointerParam<Real *>(
-        "value", "Invalid pointer to an attribute, this object should only be created via "
-                 "Executioner::addAttributeReporter"))
+        "value",
+        "Invalid pointer to an attribute, this object should only be created via "
+        "Executioner::addAttributeReporter"))
 {
 }
 

--- a/framework/src/postprocessors/NodalExtremeValue.C
+++ b/framework/src/postprocessors/NodalExtremeValue.C
@@ -26,9 +26,11 @@ validParams<NodalExtremeValue>()
 
   // Define the parameters
   InputParameters params = validParams<NodalVariablePostprocessor>();
-  params.addParam<MooseEnum>("value_type", type_options, "Type of extreme value to return. 'max' "
-                                                         "returns the maximum value. 'min' returns "
-                                                         "the minimum value.");
+  params.addParam<MooseEnum>("value_type",
+                             type_options,
+                             "Type of extreme value to return. 'max' "
+                             "returns the maximum value. 'min' returns "
+                             "the minimum value.");
   return params;
 }
 

--- a/framework/src/postprocessors/PerformanceData.C
+++ b/framework/src/postprocessors/PerformanceData.C
@@ -31,9 +31,10 @@ validParams<PerformanceData>()
   params.addParam<MooseEnum>(
       "column", column_options, "The column you want the value of (Default: total_time_with_sub).");
   params.addParam<std::string>("category", "Execution", "The category or \"Header\" for the event");
-  params.addRequiredParam<std::string>("event", "The name or \"label\" of the event (\"ALIVE\" and "
-                                                "\"ACTIVE\" are also valid events, category and "
-                                                "column are ignored for these cases).");
+  params.addRequiredParam<std::string>("event",
+                                       "The name or \"label\" of the event (\"ALIVE\" and "
+                                       "\"ACTIVE\" are also valid events, category and "
+                                       "column are ignored for these cases).");
 
   return params;
 }

--- a/framework/src/preconditioners/FieldSplitPreconditioner.C
+++ b/framework/src/preconditioners/FieldSplitPreconditioner.C
@@ -32,16 +32,19 @@ validParams<FieldSplitPreconditioner>()
   InputParameters params = validParams<MoosePreconditioner>();
 
   params.addParam<std::vector<std::string>>(
-      "off_diag_row", "The off diagonal row you want to add into the matrix, it will be associated "
-                      "with an off diagonal column from the same position in off_diag_colum.");
+      "off_diag_row",
+      "The off diagonal row you want to add into the matrix, it will be associated "
+      "with an off diagonal column from the same position in off_diag_colum.");
   params.addParam<std::vector<std::string>>("off_diag_column",
                                             "The off diagonal column you want to add into the "
                                             "matrix, it will be associated with an off diagonal "
                                             "row from the same position in off_diag_row.");
   // We should use full coupling Jacobian matrix by default
-  params.addParam<bool>("full", true, "Set to true if you want the full set of couplings.  Simply "
-                                      "for convenience so you don't have to set every off_diag_row "
-                                      "and off_diag_column combination.");
+  params.addParam<bool>("full",
+                        true,
+                        "Set to true if you want the full set of couplings.  Simply "
+                        "for convenience so you don't have to set every off_diag_row "
+                        "and off_diag_column combination.");
   params.addRequiredParam<std::vector<std::string>>(
       "topsplit", "entrance to splits, the top split will specify how splits will go.");
   return params;

--- a/framework/src/preconditioners/FiniteDifferencePreconditioner.C
+++ b/framework/src/preconditioners/FiniteDifferencePreconditioner.C
@@ -26,19 +26,23 @@ validParams<FiniteDifferencePreconditioner>()
   InputParameters params = validParams<MoosePreconditioner>();
 
   params.addParam<std::vector<std::string>>(
-      "off_diag_row", "The off diagonal row you want to add into the matrix, it will be associated "
-                      "with an off diagonal column from the same position in off_diag_colum.");
+      "off_diag_row",
+      "The off diagonal row you want to add into the matrix, it will be associated "
+      "with an off diagonal column from the same position in off_diag_colum.");
   params.addParam<std::vector<std::string>>("off_diag_column",
                                             "The off diagonal column you want to add into the "
                                             "matrix, it will be associated with an off diagonal "
                                             "row from the same position in off_diag_row.");
-  params.addParam<bool>("full", false, "Set to true if you want the full set of couplings.  Simply "
-                                       "for convenience so you don't have to set every "
-                                       "off_diag_row and off_diag_column combination.");
-  params.addParam<bool>(
-      "implicit_geometric_coupling", false, "Set to true if you want to add entries into the "
-                                            "matrix for degrees of freedom that might be coupled "
-                                            "by inspection of the geometric search objects.");
+  params.addParam<bool>("full",
+                        false,
+                        "Set to true if you want the full set of couplings.  Simply "
+                        "for convenience so you don't have to set every "
+                        "off_diag_row and off_diag_column combination.");
+  params.addParam<bool>("implicit_geometric_coupling",
+                        false,
+                        "Set to true if you want to add entries into the "
+                        "matrix for degrees of freedom that might be coupled "
+                        "by inspection of the geometric search objects.");
 
   return params;
 }

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -38,14 +38,16 @@ validParams<PhysicsBasedPreconditioner>()
   InputParameters params = validParams<MoosePreconditioner>();
 
   params.addRequiredParam<std::vector<std::string>>(
-      "solve_order", "The order the block rows will be solved in.  Put the name of variables here "
-                     "to stand for solving that variable's block row.  A variable may appear more "
-                     "than once (to create cylces if you like).");
+      "solve_order",
+      "The order the block rows will be solved in.  Put the name of variables here "
+      "to stand for solving that variable's block row.  A variable may appear more "
+      "than once (to create cylces if you like).");
   params.addRequiredParam<std::vector<std::string>>("preconditioner", "TODO: docstring");
 
   params.addParam<std::vector<std::string>>(
-      "off_diag_row", "The off diagonal row you want to add into the matrix, it will be associated "
-                      "with an off diagonal column from the same position in off_diag_colum.");
+      "off_diag_row",
+      "The off diagonal row you want to add into the matrix, it will be associated "
+      "with an off diagonal column from the same position in off_diag_colum.");
   params.addParam<std::vector<std::string>>("off_diag_column",
                                             "The off diagonal column you want to add into the "
                                             "matrix, it will be associated with an off diagonal "

--- a/framework/src/preconditioners/SingleMatrixPreconditioner.C
+++ b/framework/src/preconditioners/SingleMatrixPreconditioner.C
@@ -27,18 +27,23 @@ validParams<SingleMatrixPreconditioner>()
   InputParameters params = validParams<MoosePreconditioner>();
 
   params.addParam<std::vector<NonlinearVariableName>>(
-      "off_diag_row", "The off diagonal row you want to add into the matrix, it will be associated "
-                      "with an off diagonal column from the same position in off_diag_colum.");
+      "off_diag_row",
+      "The off diagonal row you want to add into the matrix, it will be associated "
+      "with an off diagonal column from the same position in off_diag_colum.");
   params.addParam<std::vector<NonlinearVariableName>>(
-      "off_diag_column", "The off diagonal column you want to add into the matrix, it will be "
-                         "associated with an off diagonal row from the same position in "
-                         "off_diag_row.");
+      "off_diag_column",
+      "The off diagonal column you want to add into the matrix, it will be "
+      "associated with an off diagonal row from the same position in "
+      "off_diag_row.");
   params.addParam<std::vector<NonlinearVariableName>>(
-      "coupled_groups", "List multiple space separated groups of comma separated variables. "
-                        "Off-diagonal jacobians will be generated for all pairs within a group.");
-  params.addParam<bool>("full", false, "Set to true if you want the full set of couplings.  Simply "
-                                       "for convenience so you don't have to set every "
-                                       "off_diag_row and off_diag_column combination.");
+      "coupled_groups",
+      "List multiple space separated groups of comma separated variables. "
+      "Off-diagonal jacobians will be generated for all pairs within a group.");
+  params.addParam<bool>("full",
+                        false,
+                        "Set to true if you want the full set of couplings.  Simply "
+                        "for convenience so you don't have to set every "
+                        "off_diag_row and off_diag_column combination.");
 
   return params;
 }

--- a/framework/src/timesteppers/FunctionDT.C
+++ b/framework/src/timesteppers/FunctionDT.C
@@ -29,8 +29,10 @@ validParams<FunctionDT>()
                         "Maximum ratio of new to previous timestep sizes following a step that "
                         "required the time step to be cut due to a failed solve.");
   params.addParam<Real>("min_dt", 0, "The minimal dt to take.");
-  params.addParam<bool>("interpolate", true, "Whether or not to interpolate DT between times.  "
-                                             "This is true by default for historical reasons.");
+  params.addParam<bool>("interpolate",
+                        true,
+                        "Whether or not to interpolate DT between times.  "
+                        "This is true by default for historical reasons.");
 
   return params;
 }

--- a/framework/src/timesteppers/IterationAdaptiveDT.C
+++ b/framework/src/timesteppers/IterationAdaptiveDT.C
@@ -27,34 +27,43 @@ validParams<IterationAdaptiveDT>()
   params.addClassDescription("Adjust the timestep based on the number of iterations");
   params.addParam<int>("optimal_iterations",
                        "The target number of nonlinear iterations for adaptive timestepping");
-  params.addParam<int>("iteration_window", "Attempt to grow/shrink timestep if the iteration count "
-                                           "is below/above 'optimal_iterations plus/minus "
-                                           "iteration_window' (default = optimal_iterations/5).");
-  params.addParam<unsigned>("linear_iteration_ratio", "The ratio of linear to nonlinear iterations "
-                                                      "to determine target linear iterations and "
-                                                      "window for adaptive timestepping (default = "
-                                                      "25)");
-  params.addParam<PostprocessorName>("postprocessor_dtlim", "If specified, the postprocessor value "
-                                                            "is used as an upper limit for the "
-                                                            "current time step length");
+  params.addParam<int>("iteration_window",
+                       "Attempt to grow/shrink timestep if the iteration count "
+                       "is below/above 'optimal_iterations plus/minus "
+                       "iteration_window' (default = optimal_iterations/5).");
+  params.addParam<unsigned>("linear_iteration_ratio",
+                            "The ratio of linear to nonlinear iterations "
+                            "to determine target linear iterations and "
+                            "window for adaptive timestepping (default = "
+                            "25)");
+  params.addParam<PostprocessorName>("postprocessor_dtlim",
+                                     "If specified, the postprocessor value "
+                                     "is used as an upper limit for the "
+                                     "current time step length");
   params.addParam<FunctionName>("timestep_limiting_function",
                                 "A 'Piecewise' type function used to control the timestep by "
                                 "limiting the change in the function over a timestep");
   params.addParam<Real>(
       "max_function_change",
       "The absolute value of the maximum change in timestep_limiting_function over a timestep");
-  params.addParam<bool>("force_step_every_function_point", false, "Forces the timestepper to take "
-                                                                  "a step that is consistent with "
-                                                                  "points defined in the function");
+  params.addParam<bool>("force_step_every_function_point",
+                        false,
+                        "Forces the timestepper to take "
+                        "a step that is consistent with "
+                        "points defined in the function");
   params.addRequiredParam<Real>("dt", "The default timestep size between solves");
   params.addParam<std::vector<Real>>("time_t", "The values of t");
   params.addParam<std::vector<Real>>("time_dt", "The values of dt");
-  params.addParam<Real>("growth_factor", 2.0, "Factor to apply to timestep if easy convergence (if "
-                                              "'optimal_iterations' is specified) or if recovering "
-                                              "from failed solve");
-  params.addParam<Real>("cutback_factor", 0.5, "Factor to apply to timestep if difficult "
-                                               "convergence (if 'optimal_iterations' is specified) "
-                                               "or if solution failed");
+  params.addParam<Real>("growth_factor",
+                        2.0,
+                        "Factor to apply to timestep if easy convergence (if "
+                        "'optimal_iterations' is specified) or if recovering "
+                        "from failed solve");
+  params.addParam<Real>("cutback_factor",
+                        0.5,
+                        "Factor to apply to timestep if difficult "
+                        "convergence (if 'optimal_iterations' is specified) "
+                        "or if solution failed");
   return params;
 }
 

--- a/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
@@ -32,8 +32,9 @@ validParams<MultiAppDTKUserObjectTransfer>()
   params.addRequiredParam<AuxVariableName>(
       "variable", "The auxiliary variable to store the transferred values in.");
   params.addRequiredParam<UserObjectName>(
-      "user_object", "The UserObject you want to transfer values from.  Note: This might be a "
-                     "UserObject from your MultiApp's input file!");
+      "user_object",
+      "The UserObject you want to transfer values from.  Note: This might be a "
+      "UserObject from your MultiApp's input file!");
   return params;
 }
 

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -49,9 +49,11 @@ validParams<MultiAppInterpolationTransfer>()
   MooseEnum interp_type("inverse_distance radial_basis", "inverse_distance");
   params.addParam<MooseEnum>("interp_type", interp_type, "The algorithm to use for interpolation.");
 
-  params.addParam<Real>("radius", -1, "Radius to use for radial_basis interpolation.  If negative "
-                                      "then the radius is taken as the max distance between "
-                                      "points.");
+  params.addParam<Real>("radius",
+                        -1,
+                        "Radius to use for radial_basis interpolation.  If negative "
+                        "then the radius is taken as the max distance between "
+                        "points.");
 
   return params;
 }

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -46,10 +46,12 @@ validParams<MultiAppNearestNodeTransfer>()
   params.addParam<bool>("displaced_target_mesh",
                         false,
                         "Whether or not to use the displaced mesh for the target mesh.");
-  params.addParam<bool>("fixed_meshes", false, "Set to true when the meshes are not changing (ie, "
-                                               "no movement or adaptivity).  This will cache "
-                                               "nearest node neighbors to greatly speed up the "
-                                               "transfer.");
+  params.addParam<bool>("fixed_meshes",
+                        false,
+                        "Set to true when the meshes are not changing (ie, "
+                        "no movement or adaptivity).  This will cache "
+                        "nearest node neighbors to greatly speed up the "
+                        "transfer.");
 
   return params;
 }

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -41,9 +41,11 @@ validParams<MultiAppPostprocessorInterpolationTransfer>()
 
   params.addParam<MooseEnum>("interp_type", interp_type, "The algorithm to use for interpolation.");
 
-  params.addParam<Real>("radius", -1, "Radius to use for radial_basis interpolation.  If negative "
-                                      "then the radius is taken as the max distance between "
-                                      "points.");
+  params.addParam<Real>("radius",
+                        -1,
+                        "Radius to use for radial_basis interpolation.  If negative "
+                        "then the radius is taken as the max distance between "
+                        "points.");
 
   return params;
 }

--- a/framework/src/transfers/MultiAppPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorTransfer.C
@@ -32,12 +32,14 @@ validParams<MultiAppPostprocessorTransfer>()
       "from_postprocessor",
       "The name of the Postprocessor in the Master to transfer the value from.");
   params.addRequiredParam<PostprocessorName>(
-      "to_postprocessor", "The name of the Postprocessor in the MultiApp to transfer the value to. "
-                          " This should most likely be a Reporter Postprocessor.");
+      "to_postprocessor",
+      "The name of the Postprocessor in the MultiApp to transfer the value to. "
+      " This should most likely be a Reporter Postprocessor.");
   MooseEnum reduction_type("average sum maximum minimum");
-  params.addParam<MooseEnum>(
-      "reduction_type", reduction_type, "The type of reduction to perform to reduce postprocessor "
-                                        "values from multiple SubApps to a single value");
+  params.addParam<MooseEnum>("reduction_type",
+                             reduction_type,
+                             "The type of reduction to perform to reduce postprocessor "
+                             "values from multiple SubApps to a single value");
   return params;
 }
 

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -47,9 +47,11 @@ validParams<MultiAppProjectionTransfer>()
   MooseEnum proj_type("l2", "l2");
   params.addParam<MooseEnum>("proj_type", proj_type, "The type of the projection.");
 
-  params.addParam<bool>("fixed_meshes", false, "Set to true when the meshes are not changing (ie, "
-                                               "no movement or adaptivity).  This will cache some "
-                                               "information to speed up the transfer.");
+  params.addParam<bool>("fixed_meshes",
+                        false,
+                        "Set to true when the meshes are not changing (ie, "
+                        "no movement or adaptivity).  This will cache some "
+                        "information to speed up the transfer.");
 
   return params;
 }

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -35,8 +35,9 @@ validParams<MultiAppUserObjectTransfer>()
   params.addRequiredParam<AuxVariableName>(
       "variable", "The auxiliary variable to store the transferred values in.");
   params.addRequiredParam<UserObjectName>(
-      "user_object", "The UserObject you want to transfer values from.  Note: This might be a "
-                     "UserObject from your MultiApp's input file!");
+      "user_object",
+      "The UserObject you want to transfer values from.  Note: This might be a "
+      "UserObject from your MultiApp's input file!");
 
   params.addParam<bool>("displaced_target_mesh",
                         false,

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -29,8 +29,9 @@ validParams<MultiAppVariableValueSamplePostprocessorTransfer>()
 {
   InputParameters params = validParams<MultiAppTransfer>();
   params.addRequiredParam<PostprocessorName>(
-      "postprocessor", "The name of the postprocessor in the MultiApp to transfer the value to.  "
-                       "This should most likely be a Reporter Postprocessor.");
+      "postprocessor",
+      "The name of the postprocessor in the MultiApp to transfer the value to.  "
+      "This should most likely be a Reporter Postprocessor.");
   params.addRequiredParam<VariableName>("source_variable", "The variable to transfer from.");
   return params;
 }

--- a/framework/src/transfers/Transfer.C
+++ b/framework/src/transfers/Transfer.C
@@ -31,11 +31,13 @@ InputParameters
 validParams<Transfer>()
 {
   InputParameters params = validParams<MooseObject>();
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   // Add the SetupInterface parameter, 'execute_on', and set it to a default of 'timestep_begin'
   params += validParams<SetupInterface>();
   params.set<MultiMooseEnum>("execute_on") = "timestep_begin";

--- a/framework/src/userobject/LayeredBase.C
+++ b/framework/src/userobject/LayeredBase.C
@@ -30,9 +30,10 @@ validParams<LayeredBase>()
 
   params.addRequiredParam<MooseEnum>("direction", directions, "The direction of the layers.");
   params.addParam<unsigned int>("num_layers", "The number of layers.");
-  params.addParam<std::vector<Real>>("bounds", "The 'bounding' positions of the layers i.e.: '0, "
-                                               "1.2, 3.7, 4.2' will mean 3 layers between those "
-                                               "positions.");
+  params.addParam<std::vector<Real>>("bounds",
+                                     "The 'bounding' positions of the layers i.e.: '0, "
+                                     "1.2, 3.7, 4.2' will mean 3 layers between those "
+                                     "positions.");
 
   MooseEnum sample_options("direct interpolate average", "direct");
   params.addParam<MooseEnum>("sample_type",
@@ -42,9 +43,11 @@ validParams<LayeredBase>()
                              " 'interpolate' does a linear interpolation between the two closest "
                              "layers.  'average' averages the two closest layers.");
 
-  params.addParam<unsigned int>("average_radius", 1, "When using 'average' sampling this is how "
-                                                     "the number of values both above and below "
-                                                     "the layer that will be averaged.");
+  params.addParam<unsigned int>("average_radius",
+                                1,
+                                "When using 'average' sampling this is how "
+                                "the number of values both above and below "
+                                "the layer that will be averaged.");
 
   params.addParam<bool>(
       "cumulative",

--- a/framework/src/userobject/NodalUserObject.C
+++ b/framework/src/userobject/NodalUserObject.C
@@ -23,10 +23,11 @@ InputParameters
 validParams<NodalUserObject>()
 {
   InputParameters params = validParams<UserObject>();
-  params.addParam<bool>(
-      "unique_node_execute", false, "When false (default), block restricted objects will have the "
-                                    "execute method called multiple times on a single node if the "
-                                    "node lies on a interface between two subdomains.");
+  params.addParam<bool>("unique_node_execute",
+                        false,
+                        "When false (default), block restricted objects will have the "
+                        "execute method called multiple times on a single node if the "
+                        "node lies on a interface between two subdomains.");
   params += validParams<BlockRestrictable>();
   params += validParams<BoundaryRestrictable>();
   params += validParams<RandomInterface>();

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -53,9 +53,10 @@ validParams<SolutionUserObject>()
       "system", "nl0", "The name of the system to pull values out of (xda only).");
 
   // When using ExodusII a specific time is extracted
-  params.addParam<std::string>("timestep", "Index of the single timestep used or \"LATEST\" for "
-                                           "the last timestep (exodusII only).  If not supplied, "
-                                           "time interpolation will occur.");
+  params.addParam<std::string>("timestep",
+                               "Index of the single timestep used or \"LATEST\" for "
+                               "the last timestep (exodusII only).  If not supplied, "
+                               "time interpolation will occur.");
 
   // Add ability to perform coordinate transformation: scale, factor
   params.addParam<std::vector<Real>>(

--- a/framework/src/userobject/Terminator.C
+++ b/framework/src/userobject/Terminator.C
@@ -21,8 +21,9 @@ validParams<Terminator>()
 {
   InputParameters params = validParams<GeneralUserObject>();
   params.addRequiredParam<std::string>(
-      "expression", "FParser expression to process Postprocessor values into a boolean value. "
-                    "Termination of the simulation occurs when this returns true.");
+      "expression",
+      "FParser expression to process Postprocessor values into a boolean value. "
+      "Termination of the simulation occurs when this returns true.");
   return params;
 }
 

--- a/framework/src/userobject/UserObject.C
+++ b/framework/src/userobject/UserObject.C
@@ -29,11 +29,13 @@ validParams<UserObject>()
   params += validParams<SetupInterface>();
   params.set<MultiMooseEnum>("execute_on") = "timestep_end";
 
-  params.addParam<bool>("use_displaced_mesh", false, "Whether or not this object should use the "
-                                                     "displaced mesh for computation.  Note that "
-                                                     "in the case this is true but no "
-                                                     "displacements are provided in the Mesh block "
-                                                     "the undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.declareControllable("enable");

--- a/framework/src/utils/FileRangeBuilder.C
+++ b/framework/src/utils/FileRangeBuilder.C
@@ -13,11 +13,13 @@ InputParameters
 validParams<FileRangeBuilder>()
 {
   InputParameters params = emptyInputParameters();
-  params.addParam<FileName>("file", "Name of single image file to extract mesh parameters from.  "
-                                    "If provided, a 2D mesh is created.");
-  params.addParam<FileNameNoExtension>("file_base", "Image file base to open, use this option when "
-                                                    "a stack of images must be read (ignored if "
-                                                    "'file' is given)");
+  params.addParam<FileName>("file",
+                            "Name of single image file to extract mesh parameters from.  "
+                            "If provided, a 2D mesh is created.");
+  params.addParam<FileNameNoExtension>("file_base",
+                                       "Image file base to open, use this option when "
+                                       "a stack of images must be read (ignored if "
+                                       "'file' is given)");
   params.addParam<std::vector<unsigned int>>(
       "file_range",
       "Range of images to analyze, used with 'file_base' (ignored if 'file' is given)");

--- a/modules/chemical_reactions/src/kernels/CoupledConvectionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledConvectionReactionSub.C
@@ -13,8 +13,10 @@ validParams<CoupledConvectionReactionSub>()
   InputParameters params = validParams<Kernel>();
   params.addParam<Real>("weight", 1.0, "Weight of the equilibrium species");
   params.addParam<Real>("log_k", 0.0, "Equilibrium constant of dissociation equilibrium reaction");
-  params.addParam<Real>("sto_u", 1.0, "Stoichiometric coef of the primary spceices the kernel "
-                                      "operates on in the equilibrium reaction");
+  params.addParam<Real>("sto_u",
+                        1.0,
+                        "Stoichiometric coef of the primary spceices the kernel "
+                        "operates on in the equilibrium reaction");
   params.addRequiredParam<std::vector<Real>>(
       "sto_v",
       "The stoichiometric coefficients of coupled primary species in equilibrium reaction");

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -17,8 +17,10 @@ validParams<CoupledDiffusionReactionSub>()
       "Weight of equilibrium species concentration in the primary species concentration");
   params.addParam<Real>(
       "log_k", 0.0, "Equilibrium constant of the equilbrium reaction in dissociation form");
-  params.addParam<Real>("sto_u", 1.0, "Stoichiometric coef of the primary species this kernel "
-                                      "operates on in the equilibrium reaction");
+  params.addParam<Real>("sto_u",
+                        1.0,
+                        "Stoichiometric coef of the primary species this kernel "
+                        "operates on in the equilibrium reaction");
   params.addRequiredParam<std::vector<Real>>(
       "sto_v", "The stoichiometric coefficients of coupled primary species");
   params.addCoupledVar("v", "List of coupled primary species in this equilibrium species");

--- a/modules/chemical_reactions/src/kernels/DesorptionToPorespace.C
+++ b/modules/chemical_reactions/src/kernels/DesorptionToPorespace.C
@@ -13,9 +13,10 @@ InputParameters
 validParams<DesorptionToPorespace>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addRequiredCoupledVar("conc_var", "Variable representing the concentration (kg/m^3) of "
-                                           "fluid in the matrix that will be desorped to "
-                                           "porespace");
+  params.addRequiredCoupledVar("conc_var",
+                               "Variable representing the concentration (kg/m^3) of "
+                               "fluid in the matrix that will be desorped to "
+                               "porespace");
   params.addClassDescription("Mass flow rate to the porespace from the matrix.  Add this to the "
                              "other kernels for the porepressure variable to form the complete DE");
   return params;

--- a/modules/chemical_reactions/src/materials/MollifiedLangmuirMaterial.C
+++ b/modules/chemical_reactions/src/materials/MollifiedLangmuirMaterial.C
@@ -26,13 +26,15 @@ validParams<MollifiedLangmuirMaterial>()
   params.addRequiredParam<Real>("langmuir_pressure", "Langmuir pressure.  Units Pa");
   params.addRequiredCoupledVar("conc_var", "The concentration of gas variable");
   params.addRequiredCoupledVar("pressure_var", "The gas porepressure variable");
-  params.addRangeCheckedParam<Real>(
-      "mollifier", 0.1, "mollifier > 0", "The reciprocal of time constants will be "
-                                         "one_over_time_const*tanh( |conc_var - "
-                                         "equilib_conc|/(mollifier*langmuir_density)).  So for "
-                                         "mollifier very small you will get a stepchange between "
-                                         "desorption and adsorption, but for mollifier bigger you "
-                                         "will be a gradual change");
+  params.addRangeCheckedParam<Real>("mollifier",
+                                    0.1,
+                                    "mollifier > 0",
+                                    "The reciprocal of time constants will be "
+                                    "one_over_time_const*tanh( |conc_var - "
+                                    "equilib_conc|/(mollifier*langmuir_density)).  So for "
+                                    "mollifier very small you will get a stepchange between "
+                                    "desorption and adsorption, but for mollifier bigger you "
+                                    "will be a gradual change");
   params.addClassDescription("Material type that holds info regarding MollifiedLangmuir desorption "
                              "from matrix to porespace and viceversa");
   return params;

--- a/modules/contact/src/ContactAction.C
+++ b/modules/contact/src/ContactAction.C
@@ -35,9 +35,11 @@ validParams<ContactAction>()
       1e8,
       "The penalty to apply.  This can vary depending on the stiffness of your materials");
   params.addParam<Real>("friction_coefficient", 0, "The friction coefficient");
-  params.addParam<Real>("tension_release", 0.0, "Tension release threshold.  A node in contact "
-                                                "will not be released if its tensile load is below "
-                                                "this value.  No tension release if negative.");
+  params.addParam<Real>("tension_release",
+                        0.0,
+                        "Tension release threshold.  A node in contact "
+                        "will not be released if its tensile load is below "
+                        "this value.  No tension release if negative.");
   params.addParam<std::string>("model", "frictionless", "The contact model to use");
   params.addParam<Real>("tangential_tolerance",
                         "Tangential distance to extend edges of contact surfaces");

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -26,9 +26,10 @@ validParams<ContactMaster>()
   InputParameters params = validParams<DiracKernel>();
   params.addRequiredParam<BoundaryName>("boundary", "The master boundary");
   params.addRequiredParam<BoundaryName>("slave", "The slave boundary");
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");
@@ -52,9 +53,11 @@ validParams<ContactMaster>()
                                "Method to use to smooth normals (edge_based|nodal_normal_based)");
   params.addParam<MooseEnum>("order", orders, "The finite element order");
 
-  params.addParam<Real>("tension_release", 0.0, "Tension release threshold.  A node in contact "
-                                                "will not be released if its tensile load is below "
-                                                "this value.  No tension release if negative.");
+  params.addParam<Real>("tension_release",
+                        0.0,
+                        "Tension release threshold.  A node in contact "
+                        "will not be released if its tensile load is below "
+                        "this value.  No tension release if negative.");
 
   params.addParam<std::string>("formulation", "default", "The contact formulation");
   params.addParam<bool>(

--- a/modules/contact/src/ContactSlipDamper.C
+++ b/modules/contact/src/ContactSlipDamper.C
@@ -27,11 +27,13 @@ validParams<ContactSlipDamper>()
                                     0.0,
                                     "min_damping_factor < 1.0",
                                     "Minimum permissible value for damping factor");
-  params.addParam<Real>("damping_threshold_factor", 1.0e3, "If previous iterations's slip is below "
-                                                           "the slip tolerance, only damp a slip "
-                                                           "reversal if the slip magnitude is "
-                                                           "greater than than this factor times "
-                                                           "the old slip.");
+  params.addParam<Real>("damping_threshold_factor",
+                        1.0e3,
+                        "If previous iterations's slip is below "
+                        "the slip tolerance, only damp a slip "
+                        "reversal if the slip magnitude is "
+                        "greater than than this factor times "
+                        "the old slip.");
   params.addParam<bool>("debug_output", false, "Output detailed debugging information");
   return params;
 }

--- a/modules/contact/src/GluedContactConstraint.C
+++ b/modules/contact/src/GluedContactConstraint.C
@@ -23,9 +23,10 @@ validParams<GluedContactConstraint>()
   InputParameters params = validParams<SparsityBasedContactConstraint>();
   params.addRequiredParam<BoundaryName>("boundary", "The master boundary");
   params.addRequiredParam<BoundaryName>("slave", "The slave boundary");
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");
@@ -47,9 +48,11 @@ validParams<GluedContactConstraint>()
                                "Method to use to smooth normals (edge_based|nodal_normal_based)");
   params.addParam<MooseEnum>("order", orders, "The finite element order");
 
-  params.addParam<Real>("tension_release", 0.0, "Tension release threshold.  A node in contact "
-                                                "will not be released if its tensile load is below "
-                                                "this value.  Must be positive.");
+  params.addParam<Real>("tension_release",
+                        0.0,
+                        "Tension release threshold.  A node in contact "
+                        "will not be released if its tensile load is below "
+                        "this value.  Must be positive.");
 
   params.addParam<std::string>("formulation", "default", "The contact formulation");
   return params;

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -27,9 +27,10 @@ validParams<MechanicalContactConstraint>()
   InputParameters params = validParams<NodeFaceConstraint>();
   params.addRequiredParam<BoundaryName>("boundary", "The master boundary");
   params.addRequiredParam<BoundaryName>("slave", "The slave boundary");
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");
@@ -53,9 +54,11 @@ validParams<MechanicalContactConstraint>()
                                "Method to use to smooth normals (edge_based|nodal_normal_based)");
   params.addParam<MooseEnum>("order", orders, "The finite element order");
 
-  params.addParam<Real>("tension_release", 0.0, "Tension release threshold.  A node in contact "
-                                                "will not be released if its tensile load is below "
-                                                "this value.  No tension release if negative.");
+  params.addParam<Real>("tension_release",
+                        0.0,
+                        "Tension release threshold.  A node in contact "
+                        "will not be released if its tensile load is below "
+                        "this value.  No tension release if negative.");
 
   params.addParam<std::string>("formulation", "default", "The contact formulation");
   params.addParam<bool>(
@@ -69,17 +72,21 @@ validParams<MechanicalContactConstraint>()
       "connected_slave_nodes_jacobian",
       true,
       "Whether to include jacobian entries coupling nodes connected to slave nodes.");
-  params.addParam<bool>("non_displacement_variables_jacobian", true, "Whether to include jacobian "
-                                                                     "entries coupling with "
-                                                                     "variables that are not "
-                                                                     "displacement variables.");
+  params.addParam<bool>("non_displacement_variables_jacobian",
+                        true,
+                        "Whether to include jacobian "
+                        "entries coupling with "
+                        "variables that are not "
+                        "displacement variables.");
   params.addParam<unsigned int>("stick_lock_iterations",
                                 std::numeric_limits<unsigned int>::max(),
                                 "Number of times permitted to switch between sticking and slipping "
                                 "in a solution before locking node in a sticked state.");
-  params.addParam<Real>("stick_unlock_factor", 1.5, "Factor by which frictional capacity must be "
-                                                    "exceeded to permit stick-locked node to slip "
-                                                    "again.");
+  params.addParam<Real>("stick_unlock_factor",
+                        1.5,
+                        "Factor by which frictional capacity must be "
+                        "exceeded to permit stick-locked node to slip "
+                        "again.");
   return params;
 }
 

--- a/modules/contact/src/MultiDContactConstraint.C
+++ b/modules/contact/src/MultiDContactConstraint.C
@@ -21,13 +21,16 @@ validParams<MultiDContactConstraint>()
 {
   InputParameters params = validParams<NodeFaceConstraint>();
   params.set<bool>("use_displaced_mesh") = true;
-  params.addParam<bool>("jacobian_update", false, "Whether or not to update the 'in contact' list "
-                                                  "every jacobian evaluation (by default it will "
-                                                  "happen once per timestep");
+  params.addParam<bool>("jacobian_update",
+                        false,
+                        "Whether or not to update the 'in contact' list "
+                        "every jacobian evaluation (by default it will "
+                        "happen once per timestep");
 
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");

--- a/modules/contact/src/OneDContactConstraint.C
+++ b/modules/contact/src/OneDContactConstraint.C
@@ -20,9 +20,11 @@ validParams<OneDContactConstraint>()
 {
   InputParameters params = validParams<NodeFaceConstraint>();
   params.set<bool>("use_displaced_mesh") = true;
-  params.addParam<bool>("jacobian_update", false, "Whether or not to update the 'in contact' list "
-                                                  "every jacobian evaluation (by default it will "
-                                                  "happen once per timestep");
+  params.addParam<bool>("jacobian_update",
+                        false,
+                        "Whether or not to update the 'in contact' list "
+                        "every jacobian evaluation (by default it will "
+                        "happen once per timestep");
   return params;
 }
 

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -26,9 +26,10 @@ validParams<SlaveConstraint>()
   InputParameters params = validParams<DiracKernel>();
   params.addRequiredParam<BoundaryName>("boundary", "The slave boundary");
   params.addRequiredParam<BoundaryName>("master", "The master boundary");
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addRequiredCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");

--- a/modules/heat_conduction/src/bcs/GapHeatTransfer.C
+++ b/modules/heat_conduction/src/bcs/GapHeatTransfer.C
@@ -49,10 +49,12 @@ validParams<GapHeatTransfer>()
   params.addParam<RealVectorValue>("sphere_origin", "Origin for sphere geometry");
 
   // Quadrature based
-  params.addParam<bool>("quadrature", false, "Whether or not to do Quadrature point based gap heat "
-                                             "transfer.  If this is true then gap_distance and "
-                                             "gap_temp should NOT be provided (and will be "
-                                             "ignored) however paired_boundary IS then required.");
+  params.addParam<bool>("quadrature",
+                        false,
+                        "Whether or not to do Quadrature point based gap heat "
+                        "transfer.  If this is true then gap_distance and "
+                        "gap_temp should NOT be provided (and will be "
+                        "ignored) however paired_boundary IS then required.");
   params.addParam<BoundaryName>("paired_boundary", "The boundary to be penetrated");
   params.addParam<MooseEnum>("order", orders, "The finite element order");
   params.addParam<bool>(

--- a/modules/heat_conduction/src/kernels/HomogenizedHeatConduction.C
+++ b/modules/heat_conduction/src/kernels/HomogenizedHeatConduction.C
@@ -16,8 +16,10 @@ validParams<HomogenizedHeatConduction>()
       "thermal_conductivity",
       "The diffusion coefficient for the temperature gradient (Default: thermal_conductivity)");
   params.addRequiredRangeCheckedParam<unsigned int>(
-      "component", "component < 3", "An integer corresponding to the direction the variable this "
-                                    "kernel acts in. (0 for x, 1 for y, 2 for z)");
+      "component",
+      "component < 3",
+      "An integer corresponding to the direction the variable this "
+      "kernel acts in. (0 for x, 1 for y, 2 for z)");
   return params;
 }
 

--- a/modules/heat_conduction/src/materials/GapConductance.C
+++ b/modules/heat_conduction/src/materials/GapConductance.C
@@ -39,11 +39,13 @@ validParams<GapConductance>()
                        "Variable to be used in the gap_conductivity_function in place of time");
 
   // Quadrature based
-  params.addParam<bool>("quadrature", false, "Whether or not to do quadrature point based gap heat "
-                                             "transfer.  If this is true then gap_distance and "
-                                             "gap_temp should NOT be provided (and will be "
-                                             "ignored); however, paired_boundary and variable are "
-                                             "then required.");
+  params.addParam<bool>("quadrature",
+                        false,
+                        "Whether or not to do quadrature point based gap heat "
+                        "transfer.  If this is true then gap_distance and "
+                        "gap_temp should NOT be provided (and will be "
+                        "ignored); however, paired_boundary and variable are "
+                        "then required.");
   params.addParam<BoundaryName>("paired_boundary", "The boundary to be penetrated");
   params.addParam<MooseEnum>("order", orders, "The finite element order");
   params.addParam<bool>(
@@ -84,11 +86,13 @@ validParams<GapConductance>()
                                     "emissivity_2>=0 & emissivity_2<=1",
                                     "The emissivity of the cladding surface");
 
-  params.addParam<bool>("use_displaced_mesh", true, "Whether or not this object should use the "
-                                                    "displaced mesh for computation.  Note that in "
-                                                    "the case this is true but no displacements "
-                                                    "are provided in the Mesh block the "
-                                                    "undisplaced mesh will still be used.");
+  params.addParam<bool>("use_displaced_mesh",
+                        true,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that in "
+                        "the case this is true but no displacements "
+                        "are provided in the Mesh block the "
+                        "undisplaced mesh will still be used.");
 
   return params;
 }

--- a/modules/misc/src/CoefDiffusion.C
+++ b/modules/misc/src/CoefDiffusion.C
@@ -12,9 +12,10 @@ validParams<CoefDiffusion>()
 {
   InputParameters params = validParams<Kernel>();
   params.addParam<Real>("coef", 0.0, "Diffusion coefficient");
-  params.addParam<FunctionName>("function", "If provided, the diffusion coefficient will be coef + "
-                                            "this function.  This is useful for temporally or "
-                                            "spatially varying diffusivities");
+  params.addParam<FunctionName>("function",
+                                "If provided, the diffusion coefficient will be coef + "
+                                "this function.  This is useful for temporally or "
+                                "spatially varying diffusivities");
   params.addClassDescription("Kernel for diffusion with diffusivity = coef + function");
   return params;
 }

--- a/modules/misc/src/RigidBodyModes3D.C
+++ b/modules/misc/src/RigidBodyModes3D.C
@@ -19,9 +19,10 @@ validParams<RigidBodyModes3D>()
       "subspace_indices",
       std::vector<unsigned int>(),
       "Indices of FEProblemBase subspace vectors containing rigid body modes");
-  params.addParam<std::vector<std::string>>(
-      "modes", std::vector<std::string>(), "Names of the RigidBody3D modes computed here. Select "
-                                           "from: trans_x, trans_y, trans_z, rot_x, rot_y, rot_z");
+  params.addParam<std::vector<std::string>>("modes",
+                                            std::vector<std::string>(),
+                                            "Names of the RigidBody3D modes computed here. Select "
+                                            "from: trans_x, trans_y, trans_z, rot_x, rot_y, rot_z");
   params.addRequiredCoupledVar("disp_x", "x-displacement");
   params.addRequiredCoupledVar("disp_y", "y-displacement");
   params.addRequiredCoupledVar("disp_z", "z-displacement");

--- a/modules/navier_stokes/src/actions/AddNavierStokesVariablesAction.C
+++ b/modules/navier_stokes/src/actions/AddNavierStokesVariablesAction.C
@@ -30,9 +30,11 @@ validParams<AddNavierStokesVariablesAction>()
       "block", "The list of block ids (SubdomainID) on which this action will be applied");
   params.addParam<MooseEnum>(
       "family", families, "Specifies the family of FE shape functions to use for this variable");
-  params.addParam<MooseEnum>("order", orders, "Specifies the order of the FE shape function to use "
-                                              "for this variable (additional orders not listed are "
-                                              "allowed)");
+  params.addParam<MooseEnum>("order",
+                             orders,
+                             "Specifies the order of the FE shape function to use "
+                             "for this variable (additional orders not listed are "
+                             "allowed)");
   params.addRequiredParam<std::vector<Real>>(
       "scaling", "Specifies a scaling factor to apply to this variable");
 

--- a/modules/phase_field/include/kernels/CahnHilliardBase.h
+++ b/modules/phase_field/include/kernels/CahnHilliardBase.h
@@ -57,9 +57,10 @@ CahnHilliardBase<T>::validParams()
   params.addClassDescription("Cahn-Hilliard Kernel that uses a DerivativeMaterial Free Energy");
   params.addRequiredParam<MaterialPropertyName>(
       "f_name", "Base name of the free energy function F defined in a DerivativeParsedMaterial");
-  params.addCoupledVar("displacement_gradients", "Vector of displacement gradient variables (see "
-                                                 "Modules/PhaseField/DisplacementGradients "
-                                                 "action)");
+  params.addCoupledVar("displacement_gradients",
+                       "Vector of displacement gradient variables (see "
+                       "Modules/PhaseField/DisplacementGradients "
+                       "action)");
   return params;
 }
 

--- a/modules/phase_field/include/kernels/MatDiffusionBase.h
+++ b/modules/phase_field/include/kernels/MatDiffusionBase.h
@@ -63,9 +63,10 @@ MatDiffusionBase<T>::validParams()
   InputParameters params = ::validParams<Kernel>();
   params.addParam<MaterialPropertyName>("D_name", "D", "The name of the diffusivity");
   params.addCoupledVar("args", "Vector of arguments of the diffusivity");
-  params.addCoupledVar("conc", "Coupled concentration variable for kernel to operate on; if this "
-                               "is not specified, the kernel's nonlinear variable will be used as "
-                               "usual");
+  params.addCoupledVar("conc",
+                       "Coupled concentration variable for kernel to operate on; if this "
+                       "is not specified, the kernel's nonlinear variable will be used as "
+                       "usual");
   return params;
 }
 

--- a/modules/phase_field/src/action/PolycrystalElasticDrivingForceAction.C
+++ b/modules/phase_field/src/action/PolycrystalElasticDrivingForceAction.C
@@ -21,9 +21,10 @@ validParams<PolycrystalElasticDrivingForceAction>()
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
   params.addParam<bool>(
       "use_displaced_mesh", false, "Whether to use displaced mesh in the kernels");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   return params;
 }
 

--- a/modules/phase_field/src/action/PolycrystalRandomICAction.C
+++ b/modules/phase_field/src/action/PolycrystalRandomICAction.C
@@ -17,10 +17,11 @@ validParams<PolycrystalRandomICAction>()
   params.addRequiredParam<unsigned int>("op_num", "number of order parameters to create");
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
   MooseEnum typ_options("continuous discrete");
-  params.addParam<MooseEnum>(
-      "random_type", typ_options, "The type of random polycrystal initial condition. Whether one "
-                                  "order parameter is chosen to be 1 at each node or if each order "
-                                  "parameter continuously varies from 0 to 1");
+  params.addParam<MooseEnum>("random_type",
+                             typ_options,
+                             "The type of random polycrystal initial condition. Whether one "
+                             "order parameter is chosen to be 1 at each node or if each order "
+                             "parameter continuously varies from 0 to 1");
 
   return params;
 }

--- a/modules/phase_field/src/action/PolycrystalStoredEnergyAction.C
+++ b/modules/phase_field/src/action/PolycrystalStoredEnergyAction.C
@@ -16,9 +16,10 @@ validParams<PolycrystalStoredEnergyAction>()
   InputParameters params = validParams<Action>();
   params.addClassDescription("Action that adds the contribution of stored energy associated with "
                              "dislocations to grain growth models");
-  params.addRequiredParam<unsigned int>("op_num", "specifies the total number of OPs representing "
-                                                  "all grains (deformed + undeformed "
-                                                  "(recrystallized)) to create");
+  params.addRequiredParam<unsigned int>("op_num",
+                                        "specifies the total number of OPs representing "
+                                        "all grains (deformed + undeformed "
+                                        "(recrystallized)) to create");
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
   params.addParam<VariableName>("c", "Name of coupled concentration variable");
   params.addRequiredParam<unsigned int>("deformed_grain_num",

--- a/modules/phase_field/src/action/RigidBodyMultiKernelAction.C
+++ b/modules/phase_field/src/action/RigidBodyMultiKernelAction.C
@@ -24,8 +24,9 @@ validParams<RigidBodyMultiKernelAction>()
   params.addParam<MaterialPropertyName>("mob_name", "L", "The mobility used with the kernel");
   params.addParam<MaterialPropertyName>(
       "f_name", "Base name of the free energy function F defined in a DerivativeParsedMaterial");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "type of force density under consideration");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "type of force density under consideration");
   params.addParam<Real>(
       "translation_constant", 500, "constant value characterizing grain translation");
   params.addParam<Real>("rotation_constant", 1.0, "constant value characterizing grain rotation");

--- a/modules/phase_field/src/auxkernels/CrossTermGradientFreeEnergy.C
+++ b/modules/phase_field/src/auxkernels/CrossTermGradientFreeEnergy.C
@@ -13,8 +13,9 @@ validParams<CrossTermGradientFreeEnergy>()
   InputParameters params = validParams<TotalFreeEnergyBase>();
   params.addClassDescription("Free energy contribution from the cross terms in ACMultiInetrface");
   params.addRequiredParam<std::vector<MaterialPropertyName>>(
-      "kappa_names", "Matrix of kappa names with rows and columns corresponding to each variable "
-                     "name in interfacial_vars in the same order (should be symmetric).");
+      "kappa_names",
+      "Matrix of kappa names with rows and columns corresponding to each variable "
+      "name in interfacial_vars in the same order (should be symmetric).");
   return params;
 }
 

--- a/modules/phase_field/src/auxkernels/FeatureFloodCountAux.C
+++ b/modules/phase_field/src/auxkernels/FeatureFloodCountAux.C
@@ -22,15 +22,17 @@ validParams<FeatureFloodCountAux>()
                                             "Use \"flood_counter\" instead.");
   params.addRequiredParam<UserObjectName>("flood_counter",
                                           "The FeatureFloodCount UserObject to get values from.");
-  params.addParam<unsigned int>("map_index", "The index of which map to retrieve values from when "
-                                             "using FeatureFloodCount with multiple maps.");
+  params.addParam<unsigned int>("map_index",
+                                "The index of which map to retrieve values from when "
+                                "using FeatureFloodCount with multiple maps.");
   MooseEnum field_display(
       "UNIQUE_REGION VARIABLE_COLORING GHOSTED_ENTITIES HALOS CENTROID ACTIVE_BOUNDS",
       "UNIQUE_REGION");
-  params.addParam<MooseEnum>(
-      "field_display", field_display, "Determines how the auxilary field should be colored. "
-                                      "(UNIQUE_REGION and VARIABLE_COLORING are nodal, CENTROID is "
-                                      "elemental, default: UNIQUE_REGION)");
+  params.addParam<MooseEnum>("field_display",
+                             field_display,
+                             "Determines how the auxilary field should be colored. "
+                             "(UNIQUE_REGION and VARIABLE_COLORING are nodal, CENTROID is "
+                             "elemental, default: UNIQUE_REGION)");
 
   MultiMooseEnum execute_options(SetupInterface::getExecuteOptions());
   execute_options = "initial timestep_end";

--- a/modules/phase_field/src/auxkernels/KKSGlobalFreeEnergy.C
+++ b/modules/phase_field/src/auxkernels/KKSGlobalFreeEnergy.C
@@ -13,22 +13,25 @@ validParams<KKSGlobalFreeEnergy>()
   InputParameters params = validParams<TotalFreeEnergyBase>();
   params.addClassDescription(
       "Total free energy in KKS system, including chemical, barrier and gradient terms");
-  params.addRequiredParam<MaterialPropertyName>("fa_name", "Base name of the free energy function "
-                                                           "F (f_name in the corresponding "
-                                                           "derivative function material)");
-  params.addRequiredParam<MaterialPropertyName>("fb_name", "Base name of the free energy function "
-                                                           "F (f_name in the corresponding "
-                                                           "derivative function material)");
+  params.addRequiredParam<MaterialPropertyName>("fa_name",
+                                                "Base name of the free energy function "
+                                                "F (f_name in the corresponding "
+                                                "derivative function material)");
+  params.addRequiredParam<MaterialPropertyName>("fb_name",
+                                                "Base name of the free energy function "
+                                                "F (f_name in the corresponding "
+                                                "derivative function material)");
   params.addParam<MaterialPropertyName>(
       "h_name", "h", "Base name for the switching function h(eta)");
   params.addParam<MaterialPropertyName>(
       "g_name", "g", "Base name for the double well function g(eta)");
   params.addRequiredParam<Real>("w", "Double well height parameter");
-  params.addParam<std::vector<MaterialPropertyName>>(
-      "kappa_names", std::vector<MaterialPropertyName>(), "Vector of kappa names corresponding to "
-                                                          "each variable name in interfacial_vars "
-                                                          "in the same order. For basic KKS, there "
-                                                          "is 1 kappa, 1 interfacial_var.");
+  params.addParam<std::vector<MaterialPropertyName>>("kappa_names",
+                                                     std::vector<MaterialPropertyName>(),
+                                                     "Vector of kappa names corresponding to "
+                                                     "each variable name in interfacial_vars "
+                                                     "in the same order. For basic KKS, there "
+                                                     "is 1 kappa, 1 interfacial_var.");
   return params;
 }
 

--- a/modules/phase_field/src/auxkernels/KKSMultiFreeEnergy.C
+++ b/modules/phase_field/src/auxkernels/KKSMultiFreeEnergy.C
@@ -23,10 +23,11 @@ validParams<KKSMultiFreeEnergy>()
       "gj_names",
       "Barrier Function Materials that provide g. Place in same order as Fj_names and hj_names!");
   params.addRequiredParam<Real>("w", "Double well height parameter");
-  params.addParam<std::vector<MaterialPropertyName>>(
-      "kappa_names", std::vector<MaterialPropertyName>(), "Vector of kappa names corresponding to "
-                                                          "each variable name in interfacial_vars "
-                                                          "in the same order.");
+  params.addParam<std::vector<MaterialPropertyName>>("kappa_names",
+                                                     std::vector<MaterialPropertyName>(),
+                                                     "Vector of kappa names corresponding to "
+                                                     "each variable name in interfacial_vars "
+                                                     "in the same order.");
   return params;
 }
 

--- a/modules/phase_field/src/auxkernels/TotalFreeEnergy.C
+++ b/modules/phase_field/src/auxkernels/TotalFreeEnergy.C
@@ -14,10 +14,11 @@ validParams<TotalFreeEnergy>()
   params.addClassDescription("Total free energy (both the bulk and gradient parts), where the bulk "
                              "free energy has been defined in a material");
   params.addParam<MaterialPropertyName>("f_name", "F", " Base name of the free energy function");
-  params.addParam<std::vector<MaterialPropertyName>>(
-      "kappa_names", std::vector<MaterialPropertyName>(), "Vector of kappa names corresponding to "
-                                                          "each variable name in interfacial_vars "
-                                                          "in the same order.");
+  params.addParam<std::vector<MaterialPropertyName>>("kappa_names",
+                                                     std::vector<MaterialPropertyName>(),
+                                                     "Vector of kappa names corresponding to "
+                                                     "each variable name in interfacial_vars "
+                                                     "in the same order.");
   return params;
 }
 

--- a/modules/phase_field/src/ics/BimodalSuperellipsoidsIC.C
+++ b/modules/phase_field/src/ics/BimodalSuperellipsoidsIC.C
@@ -20,8 +20,9 @@ validParams<BimodalSuperellipsoidsIC>()
   params.addRequiredParam<Real>(
       "small_spac",
       "minimum spacing between small particles, measured from closest edge to closest edge");
-  params.addRequiredParam<Real>("large_spac", "minimum spacing between large and small particles, "
-                                              "measured from closest edge to closest edge");
+  params.addRequiredParam<Real>("large_spac",
+                                "minimum spacing between large and small particles, "
+                                "measured from closest edge to closest edge");
   params.addRequiredParam<Real>(
       "small_a", "Mean semiaxis a value for the randomly placed (small) superellipsoids");
   params.addRequiredParam<Real>(
@@ -30,9 +31,11 @@ validParams<BimodalSuperellipsoidsIC>()
       "small_c", "Mean semiaxis c value for the randomly placed (small) superellipsoids");
   params.addRequiredParam<Real>("small_n",
                                 "Exponent n for the randomly placed (small) superellipsoids");
-  params.addParam<Real>("size_variation", 0.0, "Plus or minus fraction of random variation in the "
-                                               "semiaxes for uniform, standard deviation for "
-                                               "normal");
+  params.addParam<Real>("size_variation",
+                        0.0,
+                        "Plus or minus fraction of random variation in the "
+                        "semiaxes for uniform, standard deviation for "
+                        "normal");
   MooseEnum rand_options("uniform normal none", "none");
   params.addParam<MooseEnum>(
       "size_variation_type", rand_options, "Type of distribution that random semiaxes will follow");

--- a/modules/phase_field/src/ics/MultiBoundingBoxIC.C
+++ b/modules/phase_field/src/ics/MultiBoundingBoxIC.C
@@ -18,9 +18,10 @@ validParams<MultiBoundingBoxIC>()
   params.addRequiredParam<std::vector<Point>>("corners", "The corner coordinates boxes");
   params.addRequiredParam<std::vector<Point>>(
       "opposite_corners", "The coordinates of the opposite corners of the boxes");
-  params.addRequiredParam<std::vector<Real>>("inside", "The value of the variable inside each box "
-                                                       "(one value per box or a single value for "
-                                                       "all boxes)");
+  params.addRequiredParam<std::vector<Real>>("inside",
+                                             "The value of the variable inside each box "
+                                             "(one value per box or a single value for "
+                                             "all boxes)");
   params.addParam<Real>("outside", 0.0, "The value of the variable outside the box");
   return params;
 }

--- a/modules/phase_field/src/ics/MultiSmoothCircleIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothCircleIC.C
@@ -19,9 +19,11 @@ validParams<MultiSmoothCircleIC>()
                                 "minimum spacing of bubbles, measured from center to center");
   params.addParam<unsigned int>("numtries", 1000, "The number of tries");
   params.addRequiredParam<Real>("radius", "Mean radius value for the circles");
-  params.addParam<Real>("radius_variation", 0.0, "Plus or minus fraction of random variation in "
-                                                 "the bubble radius for uniform, standard "
-                                                 "deviation for normal");
+  params.addParam<Real>("radius_variation",
+                        0.0,
+                        "Plus or minus fraction of random variation in "
+                        "the bubble radius for uniform, standard "
+                        "deviation for normal");
   MooseEnum rand_options("uniform normal none", "none");
   params.addParam<MooseEnum>("radius_variation_type",
                              rand_options,

--- a/modules/phase_field/src/ics/MultiSmoothSuperellipsoidIC.C
+++ b/modules/phase_field/src/ics/MultiSmoothSuperellipsoidIC.C
@@ -50,16 +50,19 @@ validParams<MultiSmoothSuperellipsoidIC>()
                                      "Vector of plus or minus fractions of random variation in the "
                                      "bubble semiaxis in the z direction for uniform, standard "
                                      "deviation for normal. Must be set to 0 if 2D.");
-  params.addParam<bool>("check_extremes", false, "Check all Superellipsoid extremes (center +- "
-                                                 "each semiaxis) for overlap, must have "
-                                                 "prevent_overlap set to True.");
+  params.addParam<bool>("check_extremes",
+                        false,
+                        "Check all Superellipsoid extremes (center +- "
+                        "each semiaxis) for overlap, must have "
+                        "prevent_overlap set to True.");
   params.addParam<bool>("prevent_overlap",
                         false,
                         "Check all Superellipsoid centers for overlap with other Superellipsoids.");
-  params.addParam<bool>(
-      "vary_axes_independently", true, "If true the length of each semiaxis is randomly chosen "
-                                       "within the provided parameters, if false then one random "
-                                       "number is generated and applied to all semiaxes.");
+  params.addParam<bool>("vary_axes_independently",
+                        true,
+                        "If true the length of each semiaxis is randomly chosen "
+                        "within the provided parameters, if false then one random "
+                        "number is generated and applied to all semiaxes.");
   MooseEnum rand_options("uniform normal none", "none");
   params.addParam<MooseEnum>(
       "semiaxis_variation_type",

--- a/modules/phase_field/src/ics/SmoothCircleBaseIC.C
+++ b/modules/phase_field/src/ics/SmoothCircleBaseIC.C
@@ -18,9 +18,11 @@ validParams<SmoothCircleBaseIC>()
   params.addParam<Real>(
       "int_width", 0.0, "The interfacial width of the void surface.  Defaults to sharp interface");
   params.addParam<bool>("3D_spheres", true, "in 3D, whether the objects are spheres or columns");
-  params.addParam<bool>("zero_gradient", false, "Set the gradient DOFs to zero. This can avoid "
-                                                "numerical problems with higher order shape "
-                                                "functions and overlapping circles.");
+  params.addParam<bool>("zero_gradient",
+                        false,
+                        "Set the gradient DOFs to zero. This can avoid "
+                        "numerical problems with higher order shape "
+                        "functions and overlapping circles.");
   params.addParam<unsigned int>("rand_seed", 12345, "Seed value for the random number generator");
   return params;
 }

--- a/modules/phase_field/src/ics/SmoothSuperellipsoidBaseIC.C
+++ b/modules/phase_field/src/ics/SmoothSuperellipsoidBaseIC.C
@@ -20,9 +20,11 @@ validParams<SmoothSuperellipsoidBaseIC>()
       "The variable value for nested particles inside the superellipsoid in inverse configuration");
   params.addParam<Real>(
       "int_width", 0.0, "The interfacial width of the void surface.  Defaults to sharp interface");
-  params.addParam<bool>("zero_gradient", false, "Set the gradient DOFs to zero. This can avoid "
-                                                "numerical problems with higher order shape "
-                                                "functions.");
+  params.addParam<bool>("zero_gradient",
+                        false,
+                        "Set the gradient DOFs to zero. This can avoid "
+                        "numerical problems with higher order shape "
+                        "functions.");
   params.addParam<unsigned int>("rand_seed", 12345, "Seed value for the random number generator");
   return params;
 }

--- a/modules/phase_field/src/interfacekernels/EqualGradientLagrangeMultiplier.C
+++ b/modules/phase_field/src/interfacekernels/EqualGradientLagrangeMultiplier.C
@@ -15,9 +15,11 @@ validParams<EqualGradientLagrangeMultiplier>()
   params.addRequiredParam<unsigned int>("component", "Gradient component to constrain");
   params.addCoupledVar("element_var",
                        "The gradient constrained variable on this side of the interface.");
-  params.addParam<Real>("jacobian_fill", 0.0, "Compensate on diagonal Jacobian fill term when "
-                                              "using a NullKernel on the Lagrange multiplier "
-                                              "variable");
+  params.addParam<Real>("jacobian_fill",
+                        0.0,
+                        "Compensate on diagonal Jacobian fill term when "
+                        "using a NullKernel on the Lagrange multiplier "
+                        "variable");
   return params;
 }
 

--- a/modules/phase_field/src/kernels/ACGrGrMulti.C
+++ b/modules/phase_field/src/kernels/ACGrGrMulti.C
@@ -13,8 +13,9 @@ validParams<ACGrGrMulti>()
   InputParameters params = validParams<ACGrGrBase>();
   params.addClassDescription("Multi-phase poly-crystaline Allen-Cahn Kernel");
   params.addRequiredParam<std::vector<MaterialPropertyName>>(
-      "gamma_names", "List of gamma material property names for each other order parameter. Place "
-                     "in same order as order parameters (v)!");
+      "gamma_names",
+      "List of gamma material property names for each other order parameter. Place "
+      "in same order as order parameters (v)!");
   return params;
 }
 

--- a/modules/phase_field/src/kernels/ACInterface.C
+++ b/modules/phase_field/src/kernels/ACInterface.C
@@ -15,9 +15,11 @@ validParams<ACInterface>()
   params.addParam<MaterialPropertyName>("mob_name", "L", "The mobility used with the kernel");
   params.addParam<MaterialPropertyName>("kappa_name", "kappa_op", "The kappa used with the kernel");
   params.addCoupledVar("args", "Vector of nonlinear variable arguments this object depends on");
-  params.addParam<bool>("variable_L", true, "The mobility is a function of any MOOSE variable (if "
-                                            "this is set to false L must be constant over the "
-                                            "entire domain!)");
+  params.addParam<bool>("variable_L",
+                        true,
+                        "The mobility is a function of any MOOSE variable (if "
+                        "this is set to false L must be constant over the "
+                        "entire domain!)");
   return params;
 }
 

--- a/modules/phase_field/src/kernels/GrainRigidBodyMotionBase.C
+++ b/modules/phase_field/src/kernels/GrainRigidBodyMotionBase.C
@@ -16,8 +16,9 @@ validParams<GrainRigidBodyMotionBase>()
   params.addRequiredCoupledVar("c", "Concentration");
   params.addRequiredCoupledVarWithAutoBuild(
       "v", "var_name_base", "op_num", "Array of coupled variable names");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "type of force density under consideration");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "type of force density under consideration");
   params.addParam<Real>(
       "translation_constant", 500, "constant value characterizing grain translation");
   params.addParam<Real>("rotation_constant", 1.0, "constant value characterizing grain rotation");

--- a/modules/phase_field/src/kernels/KKSCHBulk.C
+++ b/modules/phase_field/src/kernels/KKSCHBulk.C
@@ -13,12 +13,14 @@ validParams<KKSCHBulk>()
   InputParameters params = CHBulk<Real>::validParams();
   params.addClassDescription("KKS model kernel for the Bulk Cahn-Hilliard term. This operates on "
                              "the concentration 'c' as the non-linear variable");
-  params.addRequiredParam<MaterialPropertyName>("fa_name", "Base name of the free energy function "
-                                                           "F (f_name in the corresponding "
-                                                           "derivative function material)");
-  params.addRequiredParam<MaterialPropertyName>("fb_name", "Base name of the free energy function "
-                                                           "F (f_name in the corresponding "
-                                                           "derivative function material)");
+  params.addRequiredParam<MaterialPropertyName>("fa_name",
+                                                "Base name of the free energy function "
+                                                "F (f_name in the corresponding "
+                                                "derivative function material)");
+  params.addRequiredParam<MaterialPropertyName>("fb_name",
+                                                "Base name of the free energy function "
+                                                "F (f_name in the corresponding "
+                                                "derivative function material)");
   params.addRequiredCoupledVar(
       "ca", "phase concentration corresponding to the non-linear variable of this kernel");
   params.addRequiredCoupledVar(

--- a/modules/phase_field/src/kernels/KKSPhaseChemicalPotential.C
+++ b/modules/phase_field/src/kernels/KKSPhaseChemicalPotential.C
@@ -19,12 +19,14 @@ validParams<KKSPhaseChemicalPotential>()
                              "kernel is ca.");
   params.addRequiredCoupledVar(
       "cb", "Phase b concentration"); // note that ca is u, the non-linear variable!
-  params.addRequiredParam<MaterialPropertyName>("fa_name", "Base name of the free energy function "
-                                                           "Fa (f_name in the corresponding "
-                                                           "derivative function material)");
-  params.addRequiredParam<MaterialPropertyName>("fb_name", "Base name of the free energy function "
-                                                           "Fb (f_name in the corresponding "
-                                                           "derivative function material)");
+  params.addRequiredParam<MaterialPropertyName>("fa_name",
+                                                "Base name of the free energy function "
+                                                "Fa (f_name in the corresponding "
+                                                "derivative function material)");
+  params.addRequiredParam<MaterialPropertyName>("fb_name",
+                                                "Base name of the free energy function "
+                                                "Fb (f_name in the corresponding "
+                                                "derivative function material)");
   params.addCoupledVar(
       "args_a",
       "Vector of further parameters to Fa (optional, to add in second cross derivatives of Fa)");

--- a/modules/phase_field/src/kernels/MatReaction.C
+++ b/modules/phase_field/src/kernels/MatReaction.C
@@ -11,8 +11,9 @@ InputParameters
 validParams<MatReaction>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addCoupledVar("v", "Set this to make v a coupled variable, otherwise it will use the "
-                            "kernel's nonlinear variable for v");
+  params.addCoupledVar("v",
+                       "Set this to make v a coupled variable, otherwise it will use the "
+                       "kernel's nonlinear variable for v");
   params.addClassDescription("Kernel to add -L*v, where L=reaction rate, v=variable");
   params.addParam<MaterialPropertyName>("mob_name", "L", "The reaction rate used with the kernel");
   params.addCoupledVar("args", "Vector of nonlinear variable arguments this object depends on");

--- a/modules/phase_field/src/kernels/SplitCHCRes.C
+++ b/modules/phase_field/src/kernels/SplitCHCRes.C
@@ -57,7 +57,7 @@ Real
 SplitCHCRes::computeQpJacobian()
 {
   Real jacobian = SplitCHBase::computeQpJacobian(); //(df_prime_zero_dc+de_prime_dc)*_test[_i][_qp];
-                                                    //from SplitCHBase
+                                                    // from SplitCHBase
 
   jacobian += _kappa[_qp] * _grad_phi[_j][_qp] * _grad_test[_i][_qp];
 

--- a/modules/phase_field/src/materials/BarrierFunctionMaterial.C
+++ b/modules/phase_field/src/materials/BarrierFunctionMaterial.C
@@ -15,9 +15,11 @@ validParams<BarrierFunctionMaterial>()
                              "polynomial.\nSIMPLE: eta^2*(1-eta)^2\nLOW: eta*(1-eta)");
   MooseEnum g_order("SIMPLE=0 LOW", "SIMPLE");
   params.addParam<MooseEnum>("g_order", g_order, "Polynomial order of the barrier function g(eta)");
-  params.addParam<bool>("well_only", false, "Make the g zero in [0:1] so it only contributes to "
-                                            "enforcing the eta range and not to the phase "
-                                            "transformation berrier.");
+  params.addParam<bool>("well_only",
+                        false,
+                        "Make the g zero in [0:1] so it only contributes to "
+                        "enforcing the eta range and not to the phase "
+                        "transformation berrier.");
   params.set<std::string>("function_name") = std::string("g");
   return params;
 }

--- a/modules/phase_field/src/materials/CrossTermBarrierFunctionBase.C
+++ b/modules/phase_field/src/materials/CrossTermBarrierFunctionBase.C
@@ -15,9 +15,10 @@ validParams<CrossTermBarrierFunctionBase>()
   MooseEnum g_order("SIMPLE=0 LOW", "SIMPLE");
   params.addParam<MooseEnum>("g_order", g_order, "Polynomial order of the barrier function g(eta)");
   params.addRequiredCoupledVar("etas", "eta_i order parameters, one for each h");
-  params.addRequiredParam<std::vector<Real>>("W_ij", "Terms controlling barrier height set W=1 in "
-                                                     "DerivativeMultiPhaseMaterial for these to "
-                                                     "apply");
+  params.addRequiredParam<std::vector<Real>>("W_ij",
+                                             "Terms controlling barrier height set W=1 in "
+                                             "DerivativeMultiPhaseMaterial for these to "
+                                             "apply");
   return params;
 }
 

--- a/modules/phase_field/src/materials/DerivativeMultiPhaseBase.C
+++ b/modules/phase_field/src/materials/DerivativeMultiPhaseBase.C
@@ -20,9 +20,10 @@ validParams<DerivativeMultiPhaseBase>()
 
   // All arguments of the phase free energies
   params.addCoupledVar("args", "Arguments of the fi free energies - use vector coupling");
-  params.addCoupledVar("displacement_gradients", "Vector of displacement gradient variables (see "
-                                                 "Modules/PhaseField/DisplacementGradients "
-                                                 "action)");
+  params.addCoupledVar("displacement_gradients",
+                       "Vector of displacement gradient variables (see "
+                       "Modules/PhaseField/DisplacementGradients "
+                       "action)");
 
   // Barrier
   params.addParam<MaterialPropertyName>(

--- a/modules/phase_field/src/materials/DerivativeSumMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeSumMaterial.C
@@ -25,9 +25,10 @@ validParams<DerivativeSumMaterial>()
   // All arguments of the free energies being summed
   params.addRequiredCoupledVar(
       "args", "Arguments of the free energy functions being summed - use vector coupling");
-  params.addCoupledVar("displacement_gradients", "Vector of displacement gradient variables (see "
-                                                 "Modules/PhaseField/DisplacementGradients "
-                                                 "action)");
+  params.addCoupledVar("displacement_gradients",
+                       "Vector of displacement gradient variables (see "
+                       "Modules/PhaseField/DisplacementGradients "
+                       "action)");
 
   // Advanced arguments to construct a sum of the form \f$ c+\gamma\sum_iF_i \f$
   params.addParam<std::vector<Real>>("prefactor", "Prefactor to multiply the sum term with.");

--- a/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
+++ b/modules/phase_field/src/materials/DerivativeTwoPhaseMaterial.C
@@ -23,9 +23,10 @@ validParams<DerivativeTwoPhaseMaterial>()
 
   // All arguments of the phase free energies
   params.addCoupledVar("args", "Arguments of fa and fb - use vector coupling");
-  params.addCoupledVar("displacement_gradients", "Vector of displacement gradient variables (see "
-                                                 "Modules/PhaseField/DisplacementGradients "
-                                                 "action)");
+  params.addCoupledVar("displacement_gradients",
+                       "Vector of displacement gradient variables (see "
+                       "Modules/PhaseField/DisplacementGradients "
+                       "action)");
 
   // Order parameter which determines the phase
   params.addRequiredCoupledVar("eta", "Order parameter");

--- a/modules/phase_field/src/materials/ElasticEnergyMaterial.C
+++ b/modules/phase_field/src/materials/ElasticEnergyMaterial.C
@@ -16,9 +16,10 @@ validParams<ElasticEnergyMaterial>()
   params.addClassDescription("Free energy material for the elastic energy contributions.");
   params.addParam<std::string>("base_name", "Material property base name");
   params.addRequiredCoupledVar("args", "Arguments of F() - use vector coupling");
-  params.addCoupledVar("displacement_gradients", "Vector of displacement gradient variables (see "
-                                                 "Modules/PhaseField/DisplacementGradients "
-                                                 "action)");
+  params.addCoupledVar("displacement_gradients",
+                       "Vector of displacement gradient variables (see "
+                       "Modules/PhaseField/DisplacementGradients "
+                       "action)");
   return params;
 }
 

--- a/modules/phase_field/src/materials/GrainAdvectionVelocity.C
+++ b/modules/phase_field/src/materials/GrainAdvectionVelocity.C
@@ -19,8 +19,9 @@ validParams<GrainAdvectionVelocity>()
   params.addParam<Real>(
       "translation_constant", 500, "constant value characterizing grain translation");
   params.addParam<Real>("rotation_constant", 1.0, "constant value characterizing grain rotation");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "type of force density under consideration");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "type of force density under consideration");
   params.addParam<UserObjectName>("grain_data",
                                   "UserObject for getting the center of mass of grains");
   params.addParam<UserObjectName>("grain_force",

--- a/modules/phase_field/src/materials/MultiBarrierFunctionMaterial.C
+++ b/modules/phase_field/src/materials/MultiBarrierFunctionMaterial.C
@@ -16,9 +16,11 @@ validParams<MultiBarrierFunctionMaterial>()
   MooseEnum h_order("SIMPLE=0", "SIMPLE");
   params.addParam<MooseEnum>(
       "g_order", h_order, "Polynomial order of the switching function h(eta)");
-  params.addParam<bool>("well_only", false, "Make the g zero in [0:1] so it only contributes to "
-                                            "enforcing the eta range and not to the phase "
-                                            "transformation berrier.");
+  params.addParam<bool>("well_only",
+                        false,
+                        "Make the g zero in [0:1] so it only contributes to "
+                        "enforcing the eta range and not to the phase "
+                        "transformation berrier.");
   params.addRequiredCoupledVar("etas", "eta_i order parameters, one for each h");
   return params;
 }

--- a/modules/phase_field/src/materials/ParsedMaterialBase.C
+++ b/modules/phase_field/src/materials/ParsedMaterialBase.C
@@ -24,10 +24,11 @@ validParams<ParsedMaterialBase>()
       "Vector of values for the constants in constant_names (can be an FParser expression)");
 
   // Variables with applied tolerances and their tolerance values
-  params.addParam<std::vector<std::string>>(
-      "tol_names", std::vector<std::string>(), "Vector of variable names to be protected from "
-                                               "being 0 or 1 within a tolerance (needed for log(c) "
-                                               "and log(1-c) terms)");
+  params.addParam<std::vector<std::string>>("tol_names",
+                                            std::vector<std::string>(),
+                                            "Vector of variable names to be protected from "
+                                            "being 0 or 1 within a tolerance (needed for log(c) "
+                                            "and log(1-c) terms)");
   params.addParam<std::vector<Real>>("tol_values",
                                      std::vector<Real>(),
                                      "Vector of tolerance values for the variables in tol_names");

--- a/modules/phase_field/src/postprocessors/GrainBoundaryArea.C
+++ b/modules/phase_field/src/postprocessors/GrainBoundaryArea.C
@@ -16,12 +16,16 @@ validParams<GrainBoundaryArea>()
   params.addClassDescription("Calculate total grain boundary length in 2D and area in 3D");
   params.addRequiredCoupledVarWithAutoBuild(
       "v", "var_name_base", "op_num", "Array of coupled variables");
-  params.addParam<Real>("grains_per_side", 2.0, "Number of order parameters contacting a boundary "
-                                                "(should be 2.0 in polycrystals and 1.0 for "
-                                                "dispersed particles)");
-  params.addParam<Real>("op_range", 1.0, "Range over which order parameters change across an "
-                                         "interface. By default order parameters are assumed to "
-                                         "vary from 0 to 1");
+  params.addParam<Real>("grains_per_side",
+                        2.0,
+                        "Number of order parameters contacting a boundary "
+                        "(should be 2.0 in polycrystals and 1.0 for "
+                        "dispersed particles)");
+  params.addParam<Real>("op_range",
+                        1.0,
+                        "Range over which order parameters change across an "
+                        "interface. By default order parameters are assumed to "
+                        "vary from 0 to 1");
   return params;
 }
 

--- a/modules/phase_field/src/postprocessors/GrainTrackerElasticity.C
+++ b/modules/phase_field/src/postprocessors/GrainTrackerElasticity.C
@@ -14,9 +14,11 @@ InputParameters
 validParams<GrainTrackerElasticity>()
 {
   InputParameters params = validParams<GrainTracker>();
-  params.addParam<bool>("random_rotations", true, "Generate random rotations when the Euler Angle "
-                                                  "provider runs out of data (otherwise error "
-                                                  "out)");
+  params.addParam<bool>("random_rotations",
+                        true,
+                        "Generate random rotations when the Euler Angle "
+                        "provider runs out of data (otherwise error "
+                        "out)");
   params.addRequiredParam<std::vector<Real>>("C_ijkl", "Unrotated stiffness tensor");
   params.addParam<MooseEnum>(
       "fill_method", RankFourTensor::fillMethodEnum() = "symmetric9", "The fill method");

--- a/modules/phase_field/src/userobjects/ComputeGrainCenterUserObject.C
+++ b/modules/phase_field/src/userobjects/ComputeGrainCenterUserObject.C
@@ -24,7 +24,7 @@ ComputeGrainCenterUserObject::ComputeGrainCenterUserObject(const InputParameters
   : ElementUserObject(parameters),
     _ncrys(coupledComponents("etas")), // determine number of grains from the number of names passed
                                        // in.  Note this is the actual number -1
-    _vals(_ncrys), // Size variable arrays
+    _vals(_ncrys),                     // Size variable arrays
     _ncomp(4 * _ncrys),
     _grain_data(_ncomp),
     _grain_volumes(_ncrys),

--- a/modules/porous_flow/src/bcs/PorousFlowHalfCubicSink.C
+++ b/modules/porous_flow/src/bcs/PorousFlowHalfCubicSink.C
@@ -14,13 +14,15 @@ validParams<PorousFlowHalfCubicSink>()
 {
   InputParameters params = validParams<PorousFlowSinkPTDefiner>();
   params.addRequiredParam<Real>(
-      "max", "Maximum of the cubic flux multiplier.  Denote x = porepressure - center (or in the "
-             "case of a heat flux with no fluid, x = temperature - center).  Then Flux out is "
-             "multiplied by (max/cutoff^3)*(2x + cutoff)(x - cutoff)^2 for cutoff < x < 0.  Flux "
-             "out is multiplied by max for x >= 0.  Flux out is multiplied by 0 for x <= cutoff.");
-  params.addRequiredParam<FunctionName>("cutoff", "Cutoff of the cubic (measured in Pa (or K for "
-                                                  "temperature BCs)).  This needs to be less than "
-                                                  "zero.");
+      "max",
+      "Maximum of the cubic flux multiplier.  Denote x = porepressure - center (or in the "
+      "case of a heat flux with no fluid, x = temperature - center).  Then Flux out is "
+      "multiplied by (max/cutoff^3)*(2x + cutoff)(x - cutoff)^2 for cutoff < x < 0.  Flux "
+      "out is multiplied by max for x >= 0.  Flux out is multiplied by 0 for x <= cutoff.");
+  params.addRequiredParam<FunctionName>("cutoff",
+                                        "Cutoff of the cubic (measured in Pa (or K for "
+                                        "temperature BCs)).  This needs to be less than "
+                                        "zero.");
   params.addRequiredParam<Real>(
       "center", "Center of the cubic flux multiplier (measured in Pa (or K for temperature BCs)).");
   return params;

--- a/modules/porous_flow/src/bcs/PorousFlowHalfGaussianSink.C
+++ b/modules/porous_flow/src/bcs/PorousFlowHalfGaussianSink.C
@@ -12,13 +12,15 @@ InputParameters
 validParams<PorousFlowHalfGaussianSink>()
 {
   InputParameters params = validParams<PorousFlowSinkPTDefiner>();
-  params.addRequiredParam<Real>("max", "Maximum of the Gaussian flux multiplier.  Flux out is "
-                                       "multiplied by max*exp((-0.5*(p - center)/sd)^2) for "
-                                       "p<center, and by = max for p>center.  Here p is the nodal "
-                                       "porepressure for the fluid_phase specified (or, for heat "
-                                       "fluxes, it is the temperature).");
-  params.addRequiredParam<Real>("sd", "Standard deviation of the Gaussian flux multiplier "
-                                      "(measured in Pa (or K for heat fluxes)).");
+  params.addRequiredParam<Real>("max",
+                                "Maximum of the Gaussian flux multiplier.  Flux out is "
+                                "multiplied by max*exp((-0.5*(p - center)/sd)^2) for "
+                                "p<center, and by = max for p>center.  Here p is the nodal "
+                                "porepressure for the fluid_phase specified (or, for heat "
+                                "fluxes, it is the temperature).");
+  params.addRequiredParam<Real>("sd",
+                                "Standard deviation of the Gaussian flux multiplier "
+                                "(measured in Pa (or K for heat fluxes)).");
   params.addRequiredParam<Real>(
       "center", "Center of the Gaussian flux multiplier (measured in Pa (or K for heat fluxes)).");
   return params;

--- a/modules/porous_flow/src/bcs/PorousFlowPiecewiseLinearSink.C
+++ b/modules/porous_flow/src/bcs/PorousFlowPiecewiseLinearSink.C
@@ -13,9 +13,10 @@ validParams<PorousFlowPiecewiseLinearSink>()
 {
   InputParameters params = validParams<PorousFlowSinkPTDefiner>();
   params.addRequiredParam<std::vector<Real>>(
-      "pt_vals", "Tuple of pressure values (for the fluid_phase specified).  Must be monotonically "
-                 "increasing.  For heat fluxes that don't involve fluids, these are temperature "
-                 "values");
+      "pt_vals",
+      "Tuple of pressure values (for the fluid_phase specified).  Must be monotonically "
+      "increasing.  For heat fluxes that don't involve fluids, these are temperature "
+      "values");
   params.addRequiredParam<std::vector<Real>>(
       "multipliers", "Tuple of multiplying values.  The flux values are multiplied by these.");
   return params;

--- a/modules/porous_flow/src/bcs/PorousFlowSink.C
+++ b/modules/porous_flow/src/bcs/PorousFlowSink.C
@@ -21,38 +21,50 @@ validParams<PorousFlowSink>()
                                 "pressure, and you can use mass_fraction_component, use_mobility, "
                                 "use_relperm, use_enthalpy and use_energy.  If not supplied, then "
                                 "this BC can only be a function of temperature");
-  params.addParam<unsigned int>("mass_fraction_component", "The index corresponding to a fluid "
-                                                           "component.  If supplied, the flux will "
-                                                           "be multiplied by the nodal mass "
-                                                           "fraction for the component");
-  params.addParam<bool>("use_mobility", false, "If true, then fluxes are multiplied by "
-                                               "(density*permeability_nn/viscosity), where the "
-                                               "'_nn' indicates the component normal to the "
-                                               "boundary.  In this case bare_flux is measured in "
-                                               "Pa.m^-1.  This can be used in conjunction with "
-                                               "other use_*");
-  params.addParam<bool>("use_relperm", false, "If true, then fluxes are multiplied by relative "
-                                              "permeability.  This can be used in conjunction with "
-                                              "other use_*");
-  params.addParam<bool>("use_enthalpy", false, "If true, then fluxes are multiplied by enthalpy.  "
-                                               "In this case bare_flux is measured in kg.m^-2.s^-1 "
-                                               "/ (J.kg).  This can be used in conjunction with "
-                                               "other use_*");
-  params.addParam<bool>(
-      "use_internal_energy", false, "If true, then fluxes are multiplied by fluid internal energy. "
-                                    " In this case bare_flux is measured in kg.m^-2.s^-1 / (J.kg). "
-                                    " This can be used in conjunction with other use_*");
-  params.addParam<bool>("use_thermal_conductivity", false, "If true, then fluxes are multiplied by "
-                                                           "thermal conductivity projected onto "
-                                                           "the normal direction.  This can be "
-                                                           "used in conjunction with other use_*");
+  params.addParam<unsigned int>("mass_fraction_component",
+                                "The index corresponding to a fluid "
+                                "component.  If supplied, the flux will "
+                                "be multiplied by the nodal mass "
+                                "fraction for the component");
+  params.addParam<bool>("use_mobility",
+                        false,
+                        "If true, then fluxes are multiplied by "
+                        "(density*permeability_nn/viscosity), where the "
+                        "'_nn' indicates the component normal to the "
+                        "boundary.  In this case bare_flux is measured in "
+                        "Pa.m^-1.  This can be used in conjunction with "
+                        "other use_*");
+  params.addParam<bool>("use_relperm",
+                        false,
+                        "If true, then fluxes are multiplied by relative "
+                        "permeability.  This can be used in conjunction with "
+                        "other use_*");
+  params.addParam<bool>("use_enthalpy",
+                        false,
+                        "If true, then fluxes are multiplied by enthalpy.  "
+                        "In this case bare_flux is measured in kg.m^-2.s^-1 "
+                        "/ (J.kg).  This can be used in conjunction with "
+                        "other use_*");
+  params.addParam<bool>("use_internal_energy",
+                        false,
+                        "If true, then fluxes are multiplied by fluid internal energy. "
+                        " In this case bare_flux is measured in kg.m^-2.s^-1 / (J.kg). "
+                        " This can be used in conjunction with other use_*");
+  params.addParam<bool>("use_thermal_conductivity",
+                        false,
+                        "If true, then fluxes are multiplied by "
+                        "thermal conductivity projected onto "
+                        "the normal direction.  This can be "
+                        "used in conjunction with other use_*");
   params.addParam<FunctionName>(
-      "flux_function", 1.0, "The flux.  The flux is OUT of the medium: hence positive values of "
-                            "this function means this BC will act as a SINK, while negative values "
-                            "indicate this flux will be a SOURCE.  The functional form is useful "
-                            "for spatially or temporally varying sinks.  Without any use_*, this "
-                            "function is measured in kg.m^-2.s^-1 (or J.m^-2.s^-1 for the case "
-                            "with only heat and no fluids)");
+      "flux_function",
+      1.0,
+      "The flux.  The flux is OUT of the medium: hence positive values of "
+      "this function means this BC will act as a SINK, while negative values "
+      "indicate this flux will be a SOURCE.  The functional form is useful "
+      "for spatially or temporally varying sinks.  Without any use_*, this "
+      "function is measured in kg.m^-2.s^-1 (or J.m^-2.s^-1 for the case "
+      "with only heat and no fluids)");
   return params;
 }
 

--- a/modules/porous_flow/src/dirackernels/PorousFlowLineSink.C
+++ b/modules/porous_flow/src/dirackernels/PorousFlowLineSink.C
@@ -14,24 +14,29 @@ validParams<PorousFlowLineSink>()
 {
   InputParameters params = validParams<PorousFlowLineGeometry>();
   MooseEnum p_or_t_choice("pressure=0 temperature=1", "pressure");
-  params.addParam<MooseEnum>(
-      "function_of", p_or_t_choice, "Modifying functions will be a function of either pressure and "
-                                    "permeability (eg, for boreholes that pump fluids) or "
-                                    "temperature and thermal conductivity (eg, for boreholes that "
-                                    "pump pure heat with no fluid flow)");
+  params.addParam<MooseEnum>("function_of",
+                             p_or_t_choice,
+                             "Modifying functions will be a function of either pressure and "
+                             "permeability (eg, for boreholes that pump fluids) or "
+                             "temperature and thermal conductivity (eg, for boreholes that "
+                             "pump pure heat with no fluid flow)");
   params.addRequiredParam<UserObjectName>(
-      "SumQuantityUO", "User Object of type=PorousFlowSumQuantity in which to place the total "
-                       "outflow from the line sink for each time step.");
+      "SumQuantityUO",
+      "User Object of type=PorousFlowSumQuantity in which to place the total "
+      "outflow from the line sink for each time step.");
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
   params.addParam<unsigned int>(
-      "fluid_phase", 0, "The fluid phase whose pressure (and potentially mobility, enthalpy, etc) "
-                        "controls the flux to the line sink.  For p_or_t=temperature, and without "
-                        "any use_*, this parameter is irrelevant");
-  params.addParam<unsigned int>("mass_fraction_component", "The index corresponding to a fluid "
-                                                           "component.  If supplied, the flux will "
-                                                           "be multiplied by the nodal mass "
-                                                           "fraction for the component");
+      "fluid_phase",
+      0,
+      "The fluid phase whose pressure (and potentially mobility, enthalpy, etc) "
+      "controls the flux to the line sink.  For p_or_t=temperature, and without "
+      "any use_*, this parameter is irrelevant");
+  params.addParam<unsigned int>("mass_fraction_component",
+                                "The index corresponding to a fluid "
+                                "component.  If supplied, the flux will "
+                                "be multiplied by the nodal mass "
+                                "fraction for the component");
   params.addParam<bool>(
       "use_relative_permeability", false, "Multiply the flux by the fluid relative permeability");
   params.addParam<bool>("use_mobility", false, "Multiply the flux by the fluid mobility");

--- a/modules/porous_flow/src/dirackernels/PorousFlowPeacemanBorehole.C
+++ b/modules/porous_flow/src/dirackernels/PorousFlowPeacemanBorehole.C
@@ -15,38 +15,43 @@ validParams<PorousFlowPeacemanBorehole>()
 {
   InputParameters params = validParams<PorousFlowLineSink>();
   params.addRequiredParam<FunctionName>(
-      "character", "If zero then borehole does nothing.  If positive the borehole acts as a sink "
-                   "(production well) for porepressure > borehole pressure, and does nothing "
-                   "otherwise.  If negative the borehole acts as a source (injection well) for "
-                   "porepressure < borehole pressure, and does nothing otherwise.  The flow rate "
-                   "to/from the borehole is multiplied by |character|, so usually character = +/- "
-                   "1, but you can specify other quantities to provide an overall scaling to the "
-                   "flow if you like.");
-  params.addRequiredParam<Real>("bottom_p_or_t", "For function_of=pressure, this parameter is the "
-                                                 "pressure at the bottom of the borehole, "
-                                                 "otherwise it is the temperature at the bottom of "
-                                                 "the borehole");
+      "character",
+      "If zero then borehole does nothing.  If positive the borehole acts as a sink "
+      "(production well) for porepressure > borehole pressure, and does nothing "
+      "otherwise.  If negative the borehole acts as a source (injection well) for "
+      "porepressure < borehole pressure, and does nothing otherwise.  The flow rate "
+      "to/from the borehole is multiplied by |character|, so usually character = +/- "
+      "1, but you can specify other quantities to provide an overall scaling to the "
+      "flow if you like.");
+  params.addRequiredParam<Real>("bottom_p_or_t",
+                                "For function_of=pressure, this parameter is the "
+                                "pressure at the bottom of the borehole, "
+                                "otherwise it is the temperature at the bottom of "
+                                "the borehole");
   params.addRequiredParam<RealVectorValue>(
-      "unit_weight", "(fluid_density*gravitational_acceleration) as a vector pointing downwards.  "
-                     "Note that the borehole pressure at a given z position is bottom_p_or_t + "
-                     "unit_weight*(q - q_bottom), where q=(x,y,z) and q_bottom=(x,y,z) of the "
-                     "bottom point of the borehole.  The analogous formula holds for "
-                     "function_of=temperature.  If you don't want bottomhole pressure (or "
-                     "temperature) to vary in the borehole just set unit_weight=0.  Typical value "
-                     "is = (0,0,-1E4), for water");
-  params.addParam<Real>(
-      "re_constant", 0.28, "The dimensionless constant used in evaluating the borehole effective "
-                           "radius.  This depends on the meshing scheme.  Peacemann "
-                           "finite-difference calculations give 0.28, while for rectangular finite "
-                           "elements the result is closer to 0.1594.  (See  Eqn(4.13) of Z Chen, Y "
-                           "Zhang, Well flow models for various numerical methods, Int J Num "
-                           "Analysis and Modeling, 3 (2008) 375-388.)");
-  params.addParam<Real>(
-      "well_constant", -1.0, "Usually this is calculated internally from the element geometry, the "
-                             "local borehole direction and segment length, and the permeability.  "
-                             "However, if this parameter is given as a positive number then this "
-                             "number is used instead of the internal calculation.  This speeds up "
-                             "computation marginally.  re_constant becomes irrelevant");
+      "unit_weight",
+      "(fluid_density*gravitational_acceleration) as a vector pointing downwards.  "
+      "Note that the borehole pressure at a given z position is bottom_p_or_t + "
+      "unit_weight*(q - q_bottom), where q=(x,y,z) and q_bottom=(x,y,z) of the "
+      "bottom point of the borehole.  The analogous formula holds for "
+      "function_of=temperature.  If you don't want bottomhole pressure (or "
+      "temperature) to vary in the borehole just set unit_weight=0.  Typical value "
+      "is = (0,0,-1E4), for water");
+  params.addParam<Real>("re_constant",
+                        0.28,
+                        "The dimensionless constant used in evaluating the borehole effective "
+                        "radius.  This depends on the meshing scheme.  Peacemann "
+                        "finite-difference calculations give 0.28, while for rectangular finite "
+                        "elements the result is closer to 0.1594.  (See  Eqn(4.13) of Z Chen, Y "
+                        "Zhang, Well flow models for various numerical methods, Int J Num "
+                        "Analysis and Modeling, 3 (2008) 375-388.)");
+  params.addParam<Real>("well_constant",
+                        -1.0,
+                        "Usually this is calculated internally from the element geometry, the "
+                        "local borehole direction and segment length, and the permeability.  "
+                        "However, if this parameter is given as a positive number then this "
+                        "number is used instead of the internal calculation.  This speeds up "
+                        "computation marginally.  re_constant becomes irrelevant");
   params.addClassDescription("Approximates a borehole in the mesh using the Peaceman approach, ie "
                              "using a number of point sinks with given radii whose positions are "
                              "read from a file");

--- a/modules/porous_flow/src/dirackernels/PorousFlowPolyLineSink.C
+++ b/modules/porous_flow/src/dirackernels/PorousFlowPolyLineSink.C
@@ -16,14 +16,15 @@ validParams<PorousFlowPolyLineSink>()
       "p_or_t_vals",
       "Tuple of pressure (or temperature) values.  Must be monotonically increasing.");
   params.addRequiredParam<std::vector<Real>>(
-      "fluxes", "Tuple of flux values (measured in kg.m^-1.s^-1 if no 'use_*' are employed).  "
-                "These flux values are multiplied by the line-segment length to achieve a flux in "
-                "kg.s^-1.  A piecewise-linear fit is performed to the (p_or_t_vals,flux) pairs to "
-                "obtain the flux at any arbitrary pressure (or temperature).  If a quad-point "
-                "pressure is less than the first pressure value, the first flux value is used.  If "
-                "quad-point pressure exceeds the final pressure value, the final flux value is "
-                "used.  This flux is OUT of the medium: hence positive values of flux means this "
-                "will be a SINK, while negative values indicate this flux will be a SOURCE.");
+      "fluxes",
+      "Tuple of flux values (measured in kg.m^-1.s^-1 if no 'use_*' are employed).  "
+      "These flux values are multiplied by the line-segment length to achieve a flux in "
+      "kg.s^-1.  A piecewise-linear fit is performed to the (p_or_t_vals,flux) pairs to "
+      "obtain the flux at any arbitrary pressure (or temperature).  If a quad-point "
+      "pressure is less than the first pressure value, the first flux value is used.  If "
+      "quad-point pressure exceeds the final pressure value, the final flux value is "
+      "used.  This flux is OUT of the medium: hence positive values of flux means this "
+      "will be a SINK, while negative values indicate this flux will be a SOURCE.");
   params.addClassDescription("Approximates a polyline sink by using a number of point sinks with "
                              "given weighting whose positions are read from a file");
   return params;

--- a/modules/porous_flow/src/functions/MovingPlanarFront.C
+++ b/modules/porous_flow/src/functions/MovingPlanarFront.C
@@ -15,14 +15,16 @@ validParams<MovingPlanarFront>()
   params.addRequiredParam<RealVectorValue>("start_posn", "Initial position of the front");
   params.addRequiredParam<RealVectorValue>("end_posn", "Final position of the front");
   params.addRequiredParam<FunctionName>(
-      "distance", "The front is an infinite plane with normal pointing from start_posn to "
-                  "end_posn.  The front's distance from start_posn is defined by distance.  You "
-                  "should ensure that distance is positive");
+      "distance",
+      "The front is an infinite plane with normal pointing from start_posn to "
+      "end_posn.  The front's distance from start_posn is defined by distance.  You "
+      "should ensure that distance is positive");
   params.addRequiredParam<Real>(
-      "active_length", "This function will return true_value at a point if: (a) t >= "
-                       "activation_time; (b) t < deactivation_time; (c) the point lies in the "
-                       "domain between start_posn and the front position; (d) the distance between "
-                       "the point and the front position <= active_length.");
+      "active_length",
+      "This function will return true_value at a point if: (a) t >= "
+      "activation_time; (b) t < deactivation_time; (c) the point lies in the "
+      "domain between start_posn and the front position; (d) the distance between "
+      "the point and the front position <= active_length.");
   params.addParam<Real>("true_value", 1.0, "Return this value if a point is in the active zone.");
   params.addParam<Real>(
       "false_value", 0.0, "Return this value if a point is not in the active zone.");

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyBase.C
@@ -14,10 +14,12 @@ validParams<PorousFlowFullySaturatedDarcyBase>()
   InputParameters params = validParams<Kernel>();
   params.addRequiredParam<RealVectorValue>("gravity",
                                            "Gravitational acceleration vector downwards (m/s^2)");
-  params.addParam<bool>("multiply_by_density", true, "If true, then this Kernel is the fluid mass "
-                                                     "flux.  If false, then this Kernel is the "
-                                                     "fluid volume flux (which is common in "
-                                                     "poro-mechanics)");
+  params.addParam<bool>("multiply_by_density",
+                        true,
+                        "If true, then this Kernel is the fluid mass "
+                        "flux.  If false, then this Kernel is the "
+                        "fluid volume flux (which is common in "
+                        "poro-mechanics)");
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
   params.addClassDescription("Darcy flux suitable for models involving a fully-saturated, single "

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedMassTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedMassTimeDerivative.C
@@ -21,10 +21,11 @@ validParams<PorousFlowFullySaturatedMassTimeDerivative>()
                              "ConstantThermalExpansionCoefficient Material");
   params.addRangeCheckedParam<Real>(
       "biot_coefficient", 1.0, "biot_coefficient>=0 & biot_coefficient<=1", "Biot coefficient");
-  params.addParam<bool>(
-      "multiply_by_density", true, "If true, then this Kernel is the time derivative of the fluid "
-                                   "mass.  If false, then this Kernel is the derivative of the "
-                                   "fluid volume (which is common in poro-mechanics)");
+  params.addParam<bool>("multiply_by_density",
+                        true,
+                        "If true, then this Kernel is the time derivative of the fluid "
+                        "mass.  If false, then this Kernel is the derivative of the "
+                        "fluid volume (which is common in poro-mechanics)");
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names.");
   params.addClassDescription("Fully-saturated version of the single-component, single-phase fluid "

--- a/modules/porous_flow/src/materials/PorousFlow1PhaseMD_Gaussian.C
+++ b/modules/porous_flow/src/materials/PorousFlow1PhaseMD_Gaussian.C
@@ -15,8 +15,10 @@ validParams<PorousFlow1PhaseMD_Gaussian>()
   params.addRequiredCoupledVar("mass_density",
                                "Variable that represents log(mass-density) of the single phase");
   params.addRequiredRangeCheckedParam<Real>(
-      "al", "al>0", "For this class, the capillary function is assumed to be saturation = "
-                    "exp(-(al*porepressure)^2) for porepressure<0.");
+      "al",
+      "al>0",
+      "For this class, the capillary function is assumed to be saturation = "
+      "exp(-(al*porepressure)^2) for porepressure<0.");
   params.addRequiredRangeCheckedParam<Real>(
       "density_P0", "density_P0>0", "The density of the fluid phase at zero porepressure");
   params.addRequiredRangeCheckedParam<Real>(

--- a/modules/porous_flow/src/materials/PorousFlow1PhaseP_BW.C
+++ b/modules/porous_flow/src/materials/PorousFlow1PhaseP_BW.C
@@ -14,19 +14,26 @@ validParams<PorousFlow1PhaseP_BW>()
 {
   InputParameters params = validParams<PorousFlow1PhaseP>();
   params.addRequiredRangeCheckedParam<Real>(
-      "Sn", "Sn >= 0", "Low saturation.  This must be < Ss, and non-negative.  This is BW's "
-                       "initial effective saturation, below which effective saturation never goes "
-                       "in their simulations/models.  If Kn=0 then Sn is the immobile saturation.  "
-                       "This form of effective saturation is only correct for Kn small.");
+      "Sn",
+      "Sn >= 0",
+      "Low saturation.  This must be < Ss, and non-negative.  This is BW's "
+      "initial effective saturation, below which effective saturation never goes "
+      "in their simulations/models.  If Kn=0 then Sn is the immobile saturation.  "
+      "This form of effective saturation is only correct for Kn small.");
   params.addRangeCheckedParam<Real>(
-      "Ss", 1.0, "Ss <= 1", "High saturation.  This must be > Sn and <= 1.  Effective saturation "
-                            "where porepressure = 0.  Effective saturation never exceeds this "
-                            "value in BW's simulations/models.");
+      "Ss",
+      1.0,
+      "Ss <= 1",
+      "High saturation.  This must be > Sn and <= 1.  Effective saturation "
+      "where porepressure = 0.  Effective saturation never exceeds this "
+      "value in BW's simulations/models.");
   params.addRequiredRangeCheckedParam<Real>(
       "C", "C > 1", "BW's C parameter.  Must be > 1.  Typical value would be 1.05.");
   params.addRequiredRangeCheckedParam<Real>(
-      "las", "las > 0", "BW's lambda_s parameter multiplied by (fluid_density * gravity).  Must be "
-                        "> 0.  Typical value would be 1E5");
+      "las",
+      "las > 0",
+      "BW's lambda_s parameter multiplied by (fluid_density * gravity).  Must be "
+      "> 0.  Typical value would be 1E5");
   params.addClassDescription("Broadbridge-white form of effective saturation for negligable Kn.  "
                              "Then porepressure = -las * ((1 - th) / th - (1 / c) * Ln((C - "
                              "th)/((C - 1) * th))), for th = (Seff - Sn) / (Ss - Sn).  A Lambert-W "

--- a/modules/porous_flow/src/materials/PorousFlow2PhasePP.C
+++ b/modules/porous_flow/src/materials/PorousFlow2PhasePP.C
@@ -13,9 +13,10 @@ validParams<PorousFlow2PhasePP>()
 {
   InputParameters params = validParams<PorousFlowVariableBase>();
 
-  params.addRequiredCoupledVar("phase0_porepressure", "Variable that is the porepressure of phase "
-                                                      "0 (eg, the water phase).  It will be <= "
-                                                      "phase1_porepressure.");
+  params.addRequiredCoupledVar("phase0_porepressure",
+                               "Variable that is the porepressure of phase "
+                               "0 (eg, the water phase).  It will be <= "
+                               "phase1_porepressure.");
   params.addRequiredCoupledVar("phase1_porepressure",
                                "Variable that is the porepressure of phase 1 (eg, the gas phase)");
   params.addClassDescription("This Material calculates the 2 porepressures and the 2 saturations "

--- a/modules/porous_flow/src/materials/PorousFlow2PhasePP_RSC.C
+++ b/modules/porous_flow/src/materials/PorousFlow2PhasePP_RSC.C
@@ -12,12 +12,14 @@ InputParameters
 validParams<PorousFlow2PhasePP_RSC>()
 {
   InputParameters params = validParams<PorousFlow2PhasePP>();
-  params.addParam<Real>("oil_viscosity", "Viscosity of oil (gas) phase.  It is assumed this is "
-                                         "double the water-phase viscosity.  (Note that this "
-                                         "effective saturation is mostly useful for 2-phase, not "
-                                         "single-phase.)");
-  params.addParam<Real>("scale_ratio", "This is porosity / permeability / beta^2, where beta may "
-                                       "be chosen by the user.  It has dimensions [time]");
+  params.addParam<Real>("oil_viscosity",
+                        "Viscosity of oil (gas) phase.  It is assumed this is "
+                        "double the water-phase viscosity.  (Note that this "
+                        "effective saturation is mostly useful for 2-phase, not "
+                        "single-phase.)");
+  params.addParam<Real>("scale_ratio",
+                        "This is porosity / permeability / beta^2, where beta may "
+                        "be chosen by the user.  It has dimensions [time]");
   params.addParam<Real>("shift", "effective saturation is a function of (Pc - shift)");
   params.addClassDescription("Rogers-Stallybrass-Clements version of effective saturation for the "
                              "water phase, valid for residual saturations = 0, and viscosityOil = "

--- a/modules/porous_flow/src/materials/PorousFlowDiffusivityBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowDiffusivityBase.C
@@ -13,9 +13,10 @@ validParams<PorousFlowDiffusivityBase>()
 {
   InputParameters params = validParams<PorousFlowMaterialVectorBase>();
   params.addRequiredParam<std::vector<Real>>(
-      "diffusion_coeff", "List of diffusion coefficients.  Order is i) component 0 in phase 0; ii) "
-                         "component 1 in phase 0 ...; component 0 in phase 1; ... component k in "
-                         "phase n (m^2/s");
+      "diffusion_coeff",
+      "List of diffusion coefficients.  Order is i) component 0 in phase 0; ii) "
+      "component 1 in phase 0 ...; component 0 in phase 1; ... component k in "
+      "phase n (m^2/s");
   params.addClassDescription("Base class for effective diffusivity for each phase");
   params.set<bool>("at_nodes") = false;
   return params;

--- a/modules/porous_flow/src/materials/PorousFlowEnthalpy.C
+++ b/modules/porous_flow/src/materials/PorousFlowEnthalpy.C
@@ -13,10 +13,11 @@ InputParameters
 validParams<PorousFlowEnthalpy>()
 {
   InputParameters params = validParams<PorousFlowFluidPropertiesBase>();
-  params.addParam<Real>(
-      "porepressure_coefficient", 1.0, "The enthalpy is internal_energy + P / density * "
-                                       "porepressure_coefficient.  Physically this should be 1.0, "
-                                       "but analytic solutions are simplified when it is zero");
+  params.addParam<Real>("porepressure_coefficient",
+                        1.0,
+                        "The enthalpy is internal_energy + P / density * "
+                        "porepressure_coefficient.  Physically this should be 1.0, "
+                        "but analytic solutions are simplified when it is zero");
   params.addClassDescription(
       "This Material calculates fluid specific enthalpy (J/kg) at the nodes or quadpoints");
   return params;

--- a/modules/porous_flow/src/materials/PorousFlowPermeabilityExponential.C
+++ b/modules/porous_flow/src/materials/PorousFlowPermeabilityExponential.C
@@ -19,10 +19,11 @@ validParams<PorousFlowPermeabilityExponential>()
                              "are: log_k (log k = A phi + B); ln_k (ln k = A phi + B); exp_k (k = "
                              "B exp(A phi)); where k is permeability, phi is porosity, A and B are "
                              "empirical constants.");
-  params.addParam<RealTensorValue>("k_anisotropy", "A tensor to multiply the calculated scalar "
-                                                   "permeability, in order to obtain anisotropy if "
-                                                   "required. Defaults to isotropic permeability "
-                                                   "if not specified.");
+  params.addParam<RealTensorValue>("k_anisotropy",
+                                   "A tensor to multiply the calculated scalar "
+                                   "permeability, in order to obtain anisotropy if "
+                                   "required. Defaults to isotropic permeability "
+                                   "if not specified.");
   params.addRequiredParam<Real>("A", "Empirical constant; see poroperm_function.");
   params.addRequiredParam<Real>("B", "Empirical constant; see poroperm_function.");
   params.addClassDescription(

--- a/modules/porous_flow/src/materials/PorousFlowPermeabilityKozenyCarman.C
+++ b/modules/porous_flow/src/materials/PorousFlowPermeabilityKozenyCarman.C
@@ -20,13 +20,16 @@ validParams<PorousFlowPermeabilityKozenyCarman>()
       "phi^n/(1-phi)^m (where phi is porosity, f is a scalar constant with typical values "
       "0.01-0.001, and d is grain size). kozeny_carman_phi0 = k0 (1-phi0)^m/phi0^n * "
       "phi^n/(1-phi)^m (where phi is porosity, and k0 is the permeability at porosity phi0)");
-  params.addRangeCheckedParam<Real>("k0", "k0 > 0", "The permeability scalar value (usually in "
-                                                    "m^2) at the reference porosity, required for "
-                                                    "kozeny_carman_phi0");
-  params.addParam<RealTensorValue>("k_anisotropy", "A tensor to multiply the calculated scalar "
-                                                   "permeability, in order to obtain anisotropy if "
-                                                   "required. Defaults to isotropic permeability "
-                                                   "if not specified.");
+  params.addRangeCheckedParam<Real>("k0",
+                                    "k0 > 0",
+                                    "The permeability scalar value (usually in "
+                                    "m^2) at the reference porosity, required for "
+                                    "kozeny_carman_phi0");
+  params.addParam<RealTensorValue>("k_anisotropy",
+                                   "A tensor to multiply the calculated scalar "
+                                   "permeability, in order to obtain anisotropy if "
+                                   "required. Defaults to isotropic permeability "
+                                   "if not specified.");
   params.addRangeCheckedParam<Real>(
       "phi0", "phi0 > 0 & phi0 < 1", "The reference porosity, required for kozeny_carman_phi0");
   params.addRangeCheckedParam<Real>(

--- a/modules/porous_flow/src/materials/PorousFlowPorosityExponentialBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityExponentialBase.C
@@ -19,9 +19,11 @@ validParams<PorousFlowPorosityExponentialBase>()
                         "is not necessary for simulations involving only linear lagrange elements. "
                         " If you set this to true, you will also want to set the same parameter to "
                         "true for related Kernels and Materials");
-  params.addParam<bool>("ensure_positive", true, "Modify the usual exponential relationships that "
-                                                 "governs porosity so that porosity is always "
-                                                 "positive");
+  params.addParam<bool>("ensure_positive",
+                        true,
+                        "Modify the usual exponential relationships that "
+                        "governs porosity so that porosity is always "
+                        "positive");
   params.addClassDescription("Base class Material for porosity that is computed via an exponential "
                              "relationship with coupled variables (strain, porepressure, "
                              "temperature)");

--- a/modules/porous_flow/src/materials/PorousFlowPorosityTHM.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityTHM.C
@@ -12,8 +12,9 @@ InputParameters
 validParams<PorousFlowPorosityTHM>()
 {
   InputParameters params = validParams<PorousFlowPorosityExponentialBase>();
-  params.addRequiredCoupledVar("porosity_zero", "The porosity at zero volumetric strain and zero "
-                                                "temperature and zero effective porepressure");
+  params.addRequiredCoupledVar("porosity_zero",
+                               "The porosity at zero volumetric strain and zero "
+                               "temperature and zero effective porepressure");
   params.addRequiredParam<Real>(
       "thermal_expansion_coeff",
       "Thermal expansion coefficient of the drained porous solid skeleton");

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityBW.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityBW.C
@@ -13,14 +13,19 @@ validParams<PorousFlowRelativePermeabilityBW>()
 {
   InputParameters params = validParams<PorousFlowRelativePermeabilityBase>();
   params.addRequiredRangeCheckedParam<Real>(
-      "Sn", "Sn >= 0", "Low saturation.  This must be < Ss, and non-negative.  This is BW's "
-                       "initial effective saturation, below which effective saturation never goes "
-                       "in their simulations/models.  If Kn=0 then Sn is the immobile saturation.  "
-                       "This form of effective saturation is only correct for Kn small.");
+      "Sn",
+      "Sn >= 0",
+      "Low saturation.  This must be < Ss, and non-negative.  This is BW's "
+      "initial effective saturation, below which effective saturation never goes "
+      "in their simulations/models.  If Kn=0 then Sn is the immobile saturation.  "
+      "This form of effective saturation is only correct for Kn small.");
   params.addRangeCheckedParam<Real>(
-      "Ss", 1.0, "Ss <= 1", "High saturation.  This must be > Sn and <= 1.  Effective saturation "
-                            "where porepressure = 0.  Effective saturation never exceeds this "
-                            "value in BW's simulations/models.");
+      "Ss",
+      1.0,
+      "Ss <= 1",
+      "High saturation.  This must be > Sn and <= 1.  Effective saturation "
+      "where porepressure = 0.  Effective saturation never exceeds this "
+      "value in BW's simulations/models.");
   params.addRequiredRangeCheckedParam<Real>(
       "Kn", "Kn >= 0", "Low relative permeability.  This must be < Ks, and non-negative.");
   params.addRequiredRangeCheckedParam<Real>(

--- a/modules/porous_flow/src/materials/PorousFlowThermalConductivityIdeal.C
+++ b/modules/porous_flow/src/materials/PorousFlowThermalConductivityIdeal.C
@@ -19,14 +19,17 @@ validParams<PorousFlowThermalConductivityIdeal>()
                                    "The thermal conductivity of the rock matrix when the aqueous "
                                    "saturation is unity.  This defaults to "
                                    "dry_thermal_conductivity.");
-  params.addParam<Real>("exponent", 1.0, "Exponent on saturation.  Thermal conductivity = "
-                                         "dry_thermal_conductivity + S^exponent * "
-                                         "(wet_thermal_conductivity - dry_thermal_conductivity), "
-                                         "where S is the aqueous saturation");
-  params.addParam<unsigned>(
-      "aqueous_phase_number", 0, "The phase number of the aqueous phase.  In simulations without "
-                                 "fluids, this parameter and the exponent parameter will not be "
-                                 "used: only the dry_thermal_conductivity will be used.");
+  params.addParam<Real>("exponent",
+                        1.0,
+                        "Exponent on saturation.  Thermal conductivity = "
+                        "dry_thermal_conductivity + S^exponent * "
+                        "(wet_thermal_conductivity - dry_thermal_conductivity), "
+                        "where S is the aqueous saturation");
+  params.addParam<unsigned>("aqueous_phase_number",
+                            0,
+                            "The phase number of the aqueous phase.  In simulations without "
+                            "fluids, this parameter and the exponent parameter will not be "
+                            "used: only the dry_thermal_conductivity will be used.");
   params.set<bool>("at_nodes") = false;
   params.addClassDescription("This Material calculates rock-fluid combined thermal conductivity by "
                              "using a weighted sum.  Thermal conductivity = "

--- a/modules/porous_flow/src/materials/PorousFlowVolumetricStrain.C
+++ b/modules/porous_flow/src/materials/PorousFlowVolumetricStrain.C
@@ -19,10 +19,12 @@ validParams<PorousFlowVolumetricStrain>()
   params.addRequiredCoupledVar(
       "displacements",
       "The displacements appropriate for the simulation geometry and coordinate system");
-  params.addParam<bool>("consistent_with_displaced_mesh", true, "The volumetric strain rate will "
-                                                                "include terms that ensure fluid "
-                                                                "mass conservation in the "
-                                                                "displaced mesh");
+  params.addParam<bool>("consistent_with_displaced_mesh",
+                        true,
+                        "The volumetric strain rate will "
+                        "include terms that ensure fluid "
+                        "mass conservation in the "
+                        "displaced mesh");
   params.addClassDescription(
       "Compute volumetric strain and the volumetric_strain rate, for use in PorousFlow.");
   params.set<bool>("stateful_displacements") = true;

--- a/modules/porous_flow/src/postprocessors/PorousFlowFluidMass.C
+++ b/modules/porous_flow/src/postprocessors/PorousFlowFluidMass.C
@@ -21,20 +21,22 @@ validParams<PorousFlowFluidMass>()
       "The index corresponding to the fluid component that this Postprocessor acts on");
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names.");
-  params.addParam<std::vector<unsigned int>>("phase", "The index of the fluid phase that this "
-                                                      "Postprocessor is restricted to.  Multiple "
-                                                      "indices can be entered");
+  params.addParam<std::vector<unsigned int>>("phase",
+                                             "The index of the fluid phase that this "
+                                             "Postprocessor is restricted to.  Multiple "
+                                             "indices can be entered");
   params.addRangeCheckedParam<Real>("saturation_threshold",
                                     1.0,
                                     "saturation_threshold >= 0 & saturation_threshold <= 1",
                                     "The saturation threshold below which the mass is calculated "
                                     "for a specific phase. Default is 1.0. Note: only one "
                                     "phase_index can be entered");
-  params.addParam<unsigned int>(
-      "kernel_variable_number", 0, "The PorousFlow variable number (according to the dictatory) of "
-                                   "the fluid-mass kernel.  This is required only in the unusual "
-                                   "situation where a variety of different finite-element "
-                                   "interpolation schemes are employed in the simulation");
+  params.addParam<unsigned int>("kernel_variable_number",
+                                0,
+                                "The PorousFlow variable number (according to the dictatory) of "
+                                "the fluid-mass kernel.  This is required only in the unusual "
+                                "situation where a variety of different finite-element "
+                                "interpolation schemes are employed in the simulation");
   params.set<bool>("use_displaced_mesh") = true;
   params.addClassDescription("Calculates the mass of a fluid component in a region");
   return params;

--- a/modules/porous_flow/src/postprocessors/PorousFlowHeatEnergy.C
+++ b/modules/porous_flow/src/postprocessors/PorousFlowHeatEnergy.C
@@ -19,15 +19,17 @@ validParams<PorousFlowHeatEnergy>()
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names.");
   params.addParam<bool>(
       "include_porous_skeleton", true, "Include the heat energy of the porous skeleton");
-  params.addParam<std::vector<unsigned int>>("phase", "The index(es) of the fluid phase that this "
-                                                      "Postprocessor is restricted to.  Multiple "
-                                                      "indices can be entered.");
+  params.addParam<std::vector<unsigned int>>("phase",
+                                             "The index(es) of the fluid phase that this "
+                                             "Postprocessor is restricted to.  Multiple "
+                                             "indices can be entered.");
   params.set<bool>("use_displaced_mesh") = true;
-  params.addParam<unsigned int>(
-      "kernel_variable_number", 0, "The PorousFlow variable number (according to the dictatory) of "
-                                   "the heat-energy kernel.  This is required only in the unusual "
-                                   "situation where a variety of different finite-element "
-                                   "interpolation schemes are employed in the simulation");
+  params.addParam<unsigned int>("kernel_variable_number",
+                                0,
+                                "The PorousFlow variable number (according to the dictatory) of "
+                                "the heat-energy kernel.  This is required only in the unusual "
+                                "situation where a variety of different finite-element "
+                                "interpolation schemes are employed in the simulation");
   params.addClassDescription("Calculates the sum of heat energy of fluid component(s) and/or the "
                              "porous skeleton in a region");
   return params;

--- a/modules/richards/src/actions/Q2PAction.C
+++ b/modules/richards/src/actions/Q2PAction.C
@@ -24,8 +24,9 @@ validParams<Q2PAction>()
       "water_density",
       "A RichardsDensity UserObject that defines the water density as a function of porepressure.");
   params.addRequiredParam<UserObjectName>(
-      "water_relperm", "A RichardsRelPerm UserObject that defines the water relative permeability "
-                       "as a function of water saturation (eg RichardsRelPermPower).");
+      "water_relperm",
+      "A RichardsRelPerm UserObject that defines the water relative permeability "
+      "as a function of water saturation (eg RichardsRelPermPower).");
   params.addParam<UserObjectName>(
       "water_relperm_for_diffusion",
       "A RichardsRelPerm UserObject that defines the water relative permeability as a function of "
@@ -36,20 +37,24 @@ validParams<Q2PAction>()
       "gas_density",
       "A RichardsDensity UserObject that defines the gas density as a function of porepressure.");
   params.addRequiredParam<UserObjectName>(
-      "gas_relperm", "A RichardsRelPerm UserObject that defines the gas relative permeability as a "
-                     "function of water saturation (eg Q2PRelPermPowerGas).");
+      "gas_relperm",
+      "A RichardsRelPerm UserObject that defines the gas relative permeability as a "
+      "function of water saturation (eg Q2PRelPermPowerGas).");
   params.addRequiredParam<Real>("gas_viscosity", "The gas viscosity");
   params.addRequiredParam<Real>("diffusivity", "The diffusivity");
   params.addParam<std::vector<OutputName>>("output_nodal_masses_to",
                                            "Output Nodal masses to this Output object.  If you "
                                            "don't want any outputs, don't input anything here");
   params.addParam<std::vector<OutputName>>(
-      "output_total_masses_to", "Output total water and gas mass to this Output object.  If you "
-                                "don't want any outputs, don't input anything here");
-  params.addParam<bool>("save_gas_flux_in_Q2PGasFluxResidual", false, "Save the residual for the "
-                                                                      "Q2PPorepressureFlux into "
-                                                                      "the AuxVariable called "
-                                                                      "Q2PGasFluxResidual");
+      "output_total_masses_to",
+      "Output total water and gas mass to this Output object.  If you "
+      "don't want any outputs, don't input anything here");
+  params.addParam<bool>("save_gas_flux_in_Q2PGasFluxResidual",
+                        false,
+                        "Save the residual for the "
+                        "Q2PPorepressureFlux into "
+                        "the AuxVariable called "
+                        "Q2PGasFluxResidual");
   params.addParam<bool>("save_water_flux_in_Q2PWaterFluxResidual",
                         false,
                         "Save the residual for the Q2PSaturationFlux into the AuxVariable called "

--- a/modules/richards/src/auxkernels/DarcyFluxComponent.C
+++ b/modules/richards/src/auxkernels/DarcyFluxComponent.C
@@ -20,8 +20,9 @@ validParams<DarcyFluxComponent>()
   MooseEnum component("x=0 y=1 z=2");
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredParam<RealVectorValue>(
-      "fluid_weight", "Fluid weight (gravity*density) as a vector pointing downwards (usually "
-                      "measured in kg.m^-2.s^-2 = Pa/m).  Eg '0 0 -10000'");
+      "fluid_weight",
+      "Fluid weight (gravity*density) as a vector pointing downwards (usually "
+      "measured in kg.m^-2.s^-2 = Pa/m).  Eg '0 0 -10000'");
   params.addRequiredParam<Real>("fluid_viscosity",
                                 "Fluid dynamic viscosity (usually measured in Pa.s)");
   params.addClassDescription("Darcy flux (in m^3.s^-1.m^-2, or m.s^-1)  -(k_ij/mu (nabla_j P - "

--- a/modules/richards/src/auxkernels/RichardsSeffPrimePrimeAux.C
+++ b/modules/richards/src/auxkernels/RichardsSeffPrimePrimeAux.C
@@ -15,10 +15,12 @@ validParams<RichardsSeffPrimePrimeAux>()
 {
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredCoupledVar("pressure_vars", "List of variables that represent the pressure");
-  params.addRequiredParam<int>("wrtnum1", "This aux kernel will return d^2(seff)/dP_wrtnum1 "
-                                          "dP_wrtnum2.  0<=wrtnum1<number_of_pressure_vars.");
-  params.addRequiredParam<int>("wrtnum2", "This aux kernel will return d^2(seff)/dP_wrtnum1 "
-                                          "dP_wrtnum2.  0<=wrtnum2<number_of_pressure_vars.");
+  params.addRequiredParam<int>("wrtnum1",
+                               "This aux kernel will return d^2(seff)/dP_wrtnum1 "
+                               "dP_wrtnum2.  0<=wrtnum1<number_of_pressure_vars.");
+  params.addRequiredParam<int>("wrtnum2",
+                               "This aux kernel will return d^2(seff)/dP_wrtnum1 "
+                               "dP_wrtnum2.  0<=wrtnum2<number_of_pressure_vars.");
   params.addRequiredParam<UserObjectName>("seff_UO",
                                           "Name of user object that defines effective saturation.");
   params.addClassDescription("auxillary variable which is 2nd derivative of effective saturation");

--- a/modules/richards/src/base/RichardsMultiphaseProblem.C
+++ b/modules/richards/src/base/RichardsMultiphaseProblem.C
@@ -17,8 +17,9 @@ validParams<RichardsMultiphaseProblem>()
   params.addRequiredParam<NonlinearVariableName>(
       "bounded_var", "Variable whose value will be constrained to be greater than lower_var");
   params.addRequiredParam<NonlinearVariableName>(
-      "lower_var", "Variable that acts as a lower bound to bounded_var.  It will not be "
-                   "constrained during the solution procedure");
+      "lower_var",
+      "Variable that acts as a lower bound to bounded_var.  It will not be "
+      "constrained during the solution procedure");
   return params;
 }
 

--- a/modules/richards/src/bcs/Q2PPiecewiseLinearSink.C
+++ b/modules/richards/src/bcs/Q2PPiecewiseLinearSink.C
@@ -15,36 +15,43 @@ validParams<Q2PPiecewiseLinearSink>()
 {
   InputParameters params = validParams<IntegratedBC>();
   params.addRequiredParam<bool>(
-      "use_mobility", "If true, then fluxes are multiplied by (density*permeability_nn/viscosity), "
-                      "where the '_nn' indicates the component normal to the boundary.  In this "
-                      "case bare_flux is measured in Pa.s^-1.  This can be used in conjunction "
-                      "with use_relperm.");
-  params.addRequiredParam<bool>("use_relperm", "If true, then fluxes are multiplied by relative "
-                                               "permeability.  This can be used in conjunction "
-                                               "with use_mobility");
+      "use_mobility",
+      "If true, then fluxes are multiplied by (density*permeability_nn/viscosity), "
+      "where the '_nn' indicates the component normal to the boundary.  In this "
+      "case bare_flux is measured in Pa.s^-1.  This can be used in conjunction "
+      "with use_relperm.");
+  params.addRequiredParam<bool>("use_relperm",
+                                "If true, then fluxes are multiplied by relative "
+                                "permeability.  This can be used in conjunction "
+                                "with use_mobility");
   params.addRequiredParam<std::vector<Real>>(
       "pressures", "Tuple of pressure values.  Must be monotonically increasing.");
   params.addRequiredParam<std::vector<Real>>(
-      "bare_fluxes", "Tuple of flux values (measured in kg.m^-2.s^-1 for use_mobility=false, and "
-                     "in Pa.s^-1 if use_mobility=true).  This flux is OUT of the medium: hence "
-                     "positive values of flux means this will be a SINK, while negative values "
-                     "indicate this flux will be a SOURCE.  A piecewise-linear fit is performed to "
-                     "the (pressure,bare_fluxes) pairs to obtain the flux at any arbitrary "
-                     "pressure, and the first or last bare_flux values are used if the quad-point "
-                     "pressure falls outside this range.");
-  params.addParam<FunctionName>("multiplying_fcn", 1.0, "If this function is provided, the flux "
-                                                        "will be multiplied by this function.  "
-                                                        "This is useful for spatially or "
-                                                        "temporally varying sinks");
+      "bare_fluxes",
+      "Tuple of flux values (measured in kg.m^-2.s^-1 for use_mobility=false, and "
+      "in Pa.s^-1 if use_mobility=true).  This flux is OUT of the medium: hence "
+      "positive values of flux means this will be a SINK, while negative values "
+      "indicate this flux will be a SOURCE.  A piecewise-linear fit is performed to "
+      "the (pressure,bare_fluxes) pairs to obtain the flux at any arbitrary "
+      "pressure, and the first or last bare_flux values are used if the quad-point "
+      "pressure falls outside this range.");
+  params.addParam<FunctionName>("multiplying_fcn",
+                                1.0,
+                                "If this function is provided, the flux "
+                                "will be multiplied by this function.  "
+                                "This is useful for spatially or "
+                                "temporally varying sinks");
   params.addRequiredParam<UserObjectName>(
       "fluid_density",
       "A RichardsDensity UserObject that defines the fluid density as a function of pressure.");
   params.addRequiredParam<UserObjectName>(
-      "fluid_relperm", "A RichardsRelPerm UserObject (eg RichardsRelPermPower) that defines the "
-                       "fluid relative permeability as a function of the saturation Variable.");
-  params.addRequiredCoupledVar("other_var", "The other variable in the 2-phase system.  If "
-                                            "Variable=porepressure, the other_var=saturation, and "
-                                            "vice-versa.");
+      "fluid_relperm",
+      "A RichardsRelPerm UserObject (eg RichardsRelPermPower) that defines the "
+      "fluid relative permeability as a function of the saturation Variable.");
+  params.addRequiredCoupledVar("other_var",
+                               "The other variable in the 2-phase system.  If "
+                               "Variable=porepressure, the other_var=saturation, and "
+                               "vice-versa.");
   params.addRequiredParam<bool>("var_is_porepressure",
                                 "This flag is needed to correctly calculate the Jacobian entries.  "
                                 "If set to true, this Sink will extract fluid from the phase with "

--- a/modules/richards/src/bcs/RichardsHalfGaussianSink.C
+++ b/modules/richards/src/bcs/RichardsHalfGaussianSink.C
@@ -15,20 +15,25 @@ InputParameters
 validParams<RichardsHalfGaussianSink>()
 {
   InputParameters params = validParams<IntegratedBC>();
-  params.addRequiredParam<Real>("max", "Maximum of the flux (measured in kg.m^-2.s^-1).  Flux out "
-                                       "= max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and Flux "
-                                       "out = max for p>centre.  Note, to make this a source "
-                                       "rather than a sink, let max<0");
-  params.addRequiredParam<Real>("sd", "Standard deviation of the Gaussian (measured in Pa).  Flux "
-                                      "out = max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and "
-                                      "Flux out = max for p>centre.");
-  params.addRequiredParam<Real>("centre", "Centre of the Gaussian (measured in Pa).  Flux out = "
-                                          "max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and "
-                                          "Flux out = max for p>centre.");
-  params.addParam<FunctionName>("multiplying_fcn", 1.0, "If this function is provided, the flux "
-                                                        "will be multiplied by this function.  "
-                                                        "This is useful for spatially or "
-                                                        "temporally varying sinks");
+  params.addRequiredParam<Real>("max",
+                                "Maximum of the flux (measured in kg.m^-2.s^-1).  Flux out "
+                                "= max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and Flux "
+                                "out = max for p>centre.  Note, to make this a source "
+                                "rather than a sink, let max<0");
+  params.addRequiredParam<Real>("sd",
+                                "Standard deviation of the Gaussian (measured in Pa).  Flux "
+                                "out = max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and "
+                                "Flux out = max for p>centre.");
+  params.addRequiredParam<Real>("centre",
+                                "Centre of the Gaussian (measured in Pa).  Flux out = "
+                                "max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and "
+                                "Flux out = max for p>centre.");
+  params.addParam<FunctionName>("multiplying_fcn",
+                                1.0,
+                                "If this function is provided, the flux "
+                                "will be multiplied by this function.  "
+                                "This is useful for spatially or "
+                                "temporally varying sinks");
   params.addRequiredParam<UserObjectName>(
       "richardsVarNames_UO", "The UserObject that holds the list of Richards variable names.");
   return params;

--- a/modules/richards/src/bcs/RichardsPiecewiseLinearSink.C
+++ b/modules/richards/src/bcs/RichardsPiecewiseLinearSink.C
@@ -15,45 +15,55 @@ validParams<RichardsPiecewiseLinearSink>()
 {
   InputParameters params = validParams<IntegratedBC>();
   params.addRequiredParam<bool>(
-      "use_mobility", "If true, then fluxes are multiplied by (density*permeability_nn/viscosity), "
-                      "where the '_nn' indicates the component normal to the boundary.  In this "
-                      "case bare_flux is measured in Pa.s^-1.  This can be used in conjunction "
-                      "with use_relperm.");
-  params.addRequiredParam<bool>("use_relperm", "If true, then fluxes are multiplied by relative "
-                                               "permeability.  This can be used in conjunction "
-                                               "with use_mobility");
-  params.addParam<std::vector<UserObjectName>>("relperm_UO", "List of names of user objects that "
-                                                             "define relative permeability.  Only "
-                                                             "needed if fully_upwind is used");
+      "use_mobility",
+      "If true, then fluxes are multiplied by (density*permeability_nn/viscosity), "
+      "where the '_nn' indicates the component normal to the boundary.  In this "
+      "case bare_flux is measured in Pa.s^-1.  This can be used in conjunction "
+      "with use_relperm.");
+  params.addRequiredParam<bool>("use_relperm",
+                                "If true, then fluxes are multiplied by relative "
+                                "permeability.  This can be used in conjunction "
+                                "with use_mobility");
+  params.addParam<std::vector<UserObjectName>>("relperm_UO",
+                                               "List of names of user objects that "
+                                               "define relative permeability.  Only "
+                                               "needed if fully_upwind is used");
   params.addParam<std::vector<UserObjectName>>(
-      "seff_UO", "List of name of user objects that define effective saturation as a function of "
-                 "pressure list.  Only needed if fully_upwind is used");
-  params.addParam<std::vector<UserObjectName>>("density_UO", "List of names of user objects that "
-                                                             "define the fluid density.  Only "
-                                                             "needed if fully_upwind is used");
+      "seff_UO",
+      "List of name of user objects that define effective saturation as a function of "
+      "pressure list.  Only needed if fully_upwind is used");
+  params.addParam<std::vector<UserObjectName>>("density_UO",
+                                               "List of names of user objects that "
+                                               "define the fluid density.  Only "
+                                               "needed if fully_upwind is used");
   params.addRequiredParam<std::vector<Real>>(
       "pressures", "Tuple of pressure values.  Must be monotonically increasing.");
   params.addRequiredParam<std::vector<Real>>(
-      "bare_fluxes", "Tuple of flux values (measured in kg.m^-2.s^-1 for use_mobility=false, and "
-                     "in Pa.s^-1 if use_mobility=true).  This flux is OUT of the medium: hence "
-                     "positive values of flux means this will be a SINK, while negative values "
-                     "indicate this flux will be a SOURCE.  A piecewise-linear fit is performed to "
-                     "the (pressure,bare_fluxes) pairs to obtain the flux at any arbitrary "
-                     "pressure, and the first or last bare_flux values are used if the quad-point "
-                     "pressure falls outside this range.");
-  params.addParam<FunctionName>("multiplying_fcn", 1.0, "If this function is provided, the flux "
-                                                        "will be multiplied by this function.  "
-                                                        "This is useful for spatially or "
-                                                        "temporally varying sinks");
+      "bare_fluxes",
+      "Tuple of flux values (measured in kg.m^-2.s^-1 for use_mobility=false, and "
+      "in Pa.s^-1 if use_mobility=true).  This flux is OUT of the medium: hence "
+      "positive values of flux means this will be a SINK, while negative values "
+      "indicate this flux will be a SOURCE.  A piecewise-linear fit is performed to "
+      "the (pressure,bare_fluxes) pairs to obtain the flux at any arbitrary "
+      "pressure, and the first or last bare_flux values are used if the quad-point "
+      "pressure falls outside this range.");
+  params.addParam<FunctionName>("multiplying_fcn",
+                                1.0,
+                                "If this function is provided, the flux "
+                                "will be multiplied by this function.  "
+                                "This is useful for spatially or "
+                                "temporally varying sinks");
   params.addRequiredParam<UserObjectName>(
       "richardsVarNames_UO", "The UserObject that holds the list of Richards variable names.");
   params.addParam<bool>("fully_upwind", false, "Use full upwinding");
   params.addParam<PostprocessorName>(
-      "area_pp", 1, "An area postprocessor.  If given, the bare_fluxes will be divided by this "
-                    "quantity.  This means the bare fluxes are measured in kg.s^-1.  This is "
-                    "useful for the case when you wish to provide the *total* flux, and let MOOSE "
-                    "proportion it uniformly across the boundary.  In that case you would have "
-                    "use_mobility=false=use_relperm, and only one bare flux should be specified");
+      "area_pp",
+      1,
+      "An area postprocessor.  If given, the bare_fluxes will be divided by this "
+      "quantity.  This means the bare fluxes are measured in kg.s^-1.  This is "
+      "useful for the case when you wish to provide the *total* flux, and let MOOSE "
+      "proportion it uniformly across the boundary.  In that case you would have "
+      "use_mobility=false=use_relperm, and only one bare flux should be specified");
   return params;
 }
 

--- a/modules/richards/src/dirackernels/PeacemanBorehole.C
+++ b/modules/richards/src/dirackernels/PeacemanBorehole.C
@@ -14,44 +14,50 @@ validParams<PeacemanBorehole>()
 {
   InputParameters params = validParams<DiracKernel>();
   params.addRequiredParam<FunctionName>(
-      "character", "If zero then borehole does nothing.  If positive the borehole acts as a sink "
-                   "(production well) for porepressure > borehole pressure, and does nothing "
-                   "otherwise.  If negative the borehole acts as a source (injection well) for "
-                   "porepressure < borehole pressure, and does nothing otherwise.  The flow rate "
-                   "to/from the borehole is multiplied by |character|, so usually character = +/- "
-                   "1, but you can specify other quantities to provide an overall scaling to the "
-                   "flow if you like.");
+      "character",
+      "If zero then borehole does nothing.  If positive the borehole acts as a sink "
+      "(production well) for porepressure > borehole pressure, and does nothing "
+      "otherwise.  If negative the borehole acts as a source (injection well) for "
+      "porepressure < borehole pressure, and does nothing otherwise.  The flow rate "
+      "to/from the borehole is multiplied by |character|, so usually character = +/- "
+      "1, but you can specify other quantities to provide an overall scaling to the "
+      "flow if you like.");
   params.addRequiredParam<Real>("bottom_pressure", "Pressure at the bottom of the borehole");
   params.addRequiredParam<RealVectorValue>(
-      "unit_weight", "(fluid_density*gravitational_acceleration) as a vector pointing downwards.  "
-                     "Note that the borehole pressure at a given z position is bottom_pressure + "
-                     "unit_weight*(p - p_bottom), where p=(x,y,z) and p_bottom=(x,y,z) of the "
-                     "bottom point of the borehole.  If you don't want bottomhole pressure to vary "
-                     "in the borehole just set unit_weight=0.  Typical value is = (0,0,-1E4)");
+      "unit_weight",
+      "(fluid_density*gravitational_acceleration) as a vector pointing downwards.  "
+      "Note that the borehole pressure at a given z position is bottom_pressure + "
+      "unit_weight*(p - p_bottom), where p=(x,y,z) and p_bottom=(x,y,z) of the "
+      "bottom point of the borehole.  If you don't want bottomhole pressure to vary "
+      "in the borehole just set unit_weight=0.  Typical value is = (0,0,-1E4)");
   params.addRequiredParam<std::string>(
-      "point_file", "The file containing the borehole radii and coordinates of the point sinks "
-                    "that approximate the borehole.  Each line in the file must contain a "
-                    "space-separated radius and coordinate.  Ie r x y z.  The last point in the "
-                    "file is defined as the borehole bottom, where the borehole pressure is "
-                    "bottom_pressure.  If your file contains just one point, you must also specify "
-                    "the borehole_length and borehole_direction.  Note that you will get "
-                    "segementation faults if your points do not lie within your mesh!");
+      "point_file",
+      "The file containing the borehole radii and coordinates of the point sinks "
+      "that approximate the borehole.  Each line in the file must contain a "
+      "space-separated radius and coordinate.  Ie r x y z.  The last point in the "
+      "file is defined as the borehole bottom, where the borehole pressure is "
+      "bottom_pressure.  If your file contains just one point, you must also specify "
+      "the borehole_length and borehole_direction.  Note that you will get "
+      "segementation faults if your points do not lie within your mesh!");
   params.addRequiredParam<UserObjectName>(
-      "SumQuantityUO", "User Object of type=RichardsSumQuantity in which to place the total "
-                       "outflow from the borehole for each time step.");
-  params.addParam<Real>(
-      "re_constant", 0.28, "The dimensionless constant used in evaluating the borehole effective "
-                           "radius.  This depends on the meshing scheme.  Peacemann "
-                           "finite-difference calculations give 0.28, while for rectangular finite "
-                           "elements the result is closer to 0.1594.  (See  Eqn(4.13) of Z Chen, Y "
-                           "Zhang, Well flow models for various numerical methods, Int J Num "
-                           "Analysis and Modeling, 3 (2008) 375-388.)");
-  params.addParam<Real>(
-      "well_constant", -1.0, "Usually this is calculated internally from the element geometry, the "
-                             "local borehole direction and segment length, and the permeability.  "
-                             "However, if this parameter is given as a positive number then this "
-                             "number is used instead of the internal calculation.  This speeds up "
-                             "computation marginally.  re_constant becomes irrelevant");
+      "SumQuantityUO",
+      "User Object of type=RichardsSumQuantity in which to place the total "
+      "outflow from the borehole for each time step.");
+  params.addParam<Real>("re_constant",
+                        0.28,
+                        "The dimensionless constant used in evaluating the borehole effective "
+                        "radius.  This depends on the meshing scheme.  Peacemann "
+                        "finite-difference calculations give 0.28, while for rectangular finite "
+                        "elements the result is closer to 0.1594.  (See  Eqn(4.13) of Z Chen, Y "
+                        "Zhang, Well flow models for various numerical methods, Int J Num "
+                        "Analysis and Modeling, 3 (2008) 375-388.)");
+  params.addParam<Real>("well_constant",
+                        -1.0,
+                        "Usually this is calculated internally from the element geometry, the "
+                        "local borehole direction and segment length, and the permeability.  "
+                        "However, if this parameter is given as a positive number then this "
+                        "number is used instead of the internal calculation.  This speeds up "
+                        "computation marginally.  re_constant becomes irrelevant");
   params.addRangeCheckedParam<Real>(
       "borehole_length",
       0.0,

--- a/modules/richards/src/dirackernels/Q2PBorehole.C
+++ b/modules/richards/src/dirackernels/Q2PBorehole.C
@@ -17,11 +17,13 @@ validParams<Q2PBorehole>()
       "fluid_density",
       "A RichardsDensity UserObject that defines the fluid density as a function of pressure.");
   params.addRequiredParam<UserObjectName>(
-      "fluid_relperm", "A RichardsRelPerm UserObject (eg RichardsRelPermPower) that defines the "
-                       "fluid relative permeability as a function of the saturation Variable.");
-  params.addRequiredCoupledVar("other_var", "The other variable in the 2-phase system.  If "
-                                            "Variable=porepressure, the other_var=saturation, and "
-                                            "vice-versa.");
+      "fluid_relperm",
+      "A RichardsRelPerm UserObject (eg RichardsRelPermPower) that defines the "
+      "fluid relative permeability as a function of the saturation Variable.");
+  params.addRequiredCoupledVar("other_var",
+                               "The other variable in the 2-phase system.  If "
+                               "Variable=porepressure, the other_var=saturation, and "
+                               "vice-versa.");
   params.addRequiredParam<bool>("var_is_porepressure",
                                 "This flag is needed to correctly calculate the Jacobian entries.  "
                                 "If set to true, this Sink will extract fluid from the phase with "

--- a/modules/richards/src/dirackernels/RichardsBorehole.C
+++ b/modules/richards/src/dirackernels/RichardsBorehole.C
@@ -15,15 +15,18 @@ validParams<RichardsBorehole>()
   InputParameters params = validParams<PeacemanBorehole>();
   params.addRequiredParam<UserObjectName>(
       "richardsVarNames_UO", "The UserObject that holds the list of Richards variable names.");
-  params.addParam<std::vector<UserObjectName>>("relperm_UO", "List of names of user objects that "
-                                                             "define relative permeability.  Only "
-                                                             "needed if fully_upwind is used");
+  params.addParam<std::vector<UserObjectName>>("relperm_UO",
+                                               "List of names of user objects that "
+                                               "define relative permeability.  Only "
+                                               "needed if fully_upwind is used");
   params.addParam<std::vector<UserObjectName>>(
-      "seff_UO", "List of name of user objects that define effective saturation as a function of "
-                 "pressure list.  Only needed if fully_upwind is used");
-  params.addParam<std::vector<UserObjectName>>("density_UO", "List of names of user objects that "
-                                                             "define the fluid density.  Only "
-                                                             "needed if fully_upwind is used");
+      "seff_UO",
+      "List of name of user objects that define effective saturation as a function of "
+      "pressure list.  Only needed if fully_upwind is used");
+  params.addParam<std::vector<UserObjectName>>("density_UO",
+                                               "List of names of user objects that "
+                                               "define the fluid density.  Only "
+                                               "needed if fully_upwind is used");
   params.addParam<bool>("fully_upwind", false, "Fully upwind the flux");
   params.addClassDescription("Approximates a borehole in the mesh with given bottomhole pressure, "
                              "and radii using a number of point sinks whose positions are read "

--- a/modules/richards/src/dirackernels/RichardsPolyLineSink.C
+++ b/modules/richards/src/dirackernels/RichardsPolyLineSink.C
@@ -15,21 +15,24 @@ validParams<RichardsPolyLineSink>()
   params.addRequiredParam<std::vector<Real>>(
       "pressures", "Tuple of pressure values.  Must be monotonically increasing.");
   params.addRequiredParam<std::vector<Real>>(
-      "fluxes", "Tuple of flux values (measured in kg.m^-3.s^-1).  A piecewise-linear fit is "
-                "performed to the (pressure,flux) pairs to obtain the flux at any arbitrary "
-                "pressure.  If a quad-point pressure is less than the first pressure value, the "
-                "first flux value is used.  If quad-point pressure exceeds the final pressure "
-                "value, the final flux value is used.  This flux is OUT of the medium: hence "
-                "positive values of flux means this will be a SINK, while negative values indicate "
-                "this flux will be a SOURCE.");
+      "fluxes",
+      "Tuple of flux values (measured in kg.m^-3.s^-1).  A piecewise-linear fit is "
+      "performed to the (pressure,flux) pairs to obtain the flux at any arbitrary "
+      "pressure.  If a quad-point pressure is less than the first pressure value, the "
+      "first flux value is used.  If quad-point pressure exceeds the final pressure "
+      "value, the final flux value is used.  This flux is OUT of the medium: hence "
+      "positive values of flux means this will be a SINK, while negative values indicate "
+      "this flux will be a SOURCE.");
   params.addRequiredParam<FileName>(
-      "point_file", "The file containing the coordinates of the point sinks that will approximate "
-                    "the polyline.  Each line in the file must contain a space-separated "
-                    "coordinate.  Note that you will get segementation faults if your points do "
-                    "not lie within your mesh!");
+      "point_file",
+      "The file containing the coordinates of the point sinks that will approximate "
+      "the polyline.  Each line in the file must contain a space-separated "
+      "coordinate.  Note that you will get segementation faults if your points do "
+      "not lie within your mesh!");
   params.addRequiredParam<UserObjectName>(
-      "SumQuantityUO", "User Object of type=RichardsSumQuantity in which to place the total "
-                       "outflow from the polylinesink for each time step.");
+      "SumQuantityUO",
+      "User Object of type=RichardsSumQuantity in which to place the total "
+      "outflow from the polylinesink for each time step.");
   params.addRequiredParam<UserObjectName>(
       "richardsVarNames_UO", "The UserObject that holds the list of Richards variable names.");
   params.addClassDescription("Approximates a polyline sink in the mesh by using a number of point "

--- a/modules/richards/src/functions/Grad2ParsedFunction.C
+++ b/modules/richards/src/functions/Grad2ParsedFunction.C
@@ -15,9 +15,10 @@ validParams<Grad2ParsedFunction>()
   InputParameters params = validParams<MooseParsedFunction>();
   params += validParams<MooseParsedFunction>();
   params.addRequiredParam<RealVectorValue>(
-      "direction", "The direction in which to take the derivative.  This must not be a zero-length "
-                   "vector.  This function returned a finite-difference approx to "
-                   "(direction.nabla)^2 function");
+      "direction",
+      "The direction in which to take the derivative.  This must not be a zero-length "
+      "vector.  This function returned a finite-difference approx to "
+      "(direction.nabla)^2 function");
   return params;
 }
 

--- a/modules/richards/src/functions/RichardsExcavGeom.C
+++ b/modules/richards/src/functions/RichardsExcavGeom.C
@@ -13,19 +13,24 @@ validParams<RichardsExcavGeom>()
 {
   InputParameters params = validParams<Function>();
   params.addRequiredParam<RealVectorValue>(
-      "start_posn", "Start point of the excavation.  This is an (x,y,z) point in the middle of the "
-                    "coal face at the very beginning of the panel.");
+      "start_posn",
+      "Start point of the excavation.  This is an (x,y,z) point in the middle of the "
+      "coal face at the very beginning of the panel.");
   params.addRequiredParam<Real>("start_time", "Commencement time of the excavation");
-  params.addRequiredParam<RealVectorValue>("end_posn", "End position of the excavation.  This is "
-                                                       "an (x,y,z) point in the middle of the coal "
-                                                       "face at the very end of the panel.");
+  params.addRequiredParam<RealVectorValue>("end_posn",
+                                           "End position of the excavation.  This is "
+                                           "an (x,y,z) point in the middle of the coal "
+                                           "face at the very end of the panel.");
   params.addRequiredParam<Real>("end_time", "Time at the completion of the excavation");
-  params.addRequiredParam<Real>("active_length", "This function is only active at a point if the "
-                                                 "distance between the point and the coal face <= "
-                                                 "active_length.");
-  params.addParam<Real>("true_value", 1.0, "Return this value if a point is in the active zone.  "
-                                           "This is usually used for controlling "
-                                           "permeability-changes");
+  params.addRequiredParam<Real>("active_length",
+                                "This function is only active at a point if the "
+                                "distance between the point and the coal face <= "
+                                "active_length.");
+  params.addParam<Real>("true_value",
+                        1.0,
+                        "Return this value if a point is in the active zone.  "
+                        "This is usually used for controlling "
+                        "permeability-changes");
   params.addParam<Real>(
       "deactivation_time", 1.0E30, "Time at which this function is totally turned off");
   params.addClassDescription("This function defines excavation geometry.  It can be used to "

--- a/modules/richards/src/kernels/DarcyFlux.C
+++ b/modules/richards/src/kernels/DarcyFlux.C
@@ -14,8 +14,9 @@ validParams<DarcyFlux>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredParam<RealVectorValue>(
-      "fluid_weight", "Fluid weight (gravity*density) as a vector pointing downwards (usually "
-                      "measured in kg.m^-2.s^-2 = Pa/m).  Eg '0 0 -10000'");
+      "fluid_weight",
+      "Fluid weight (gravity*density) as a vector pointing downwards (usually "
+      "measured in kg.m^-2.s^-2 = Pa/m).  Eg '0 0 -10000'");
   params.addRequiredParam<Real>("fluid_viscosity",
                                 "Fluid dynamic viscosity (usually measured in Pa.s)");
   params.addClassDescription("Darcy flux.  nabla_i (k_ij/mu (nabla_j P - w_j)), where k_ij is the "

--- a/modules/richards/src/kernels/Q2PNegativeNodalMassOld.C
+++ b/modules/richards/src/kernels/Q2PNegativeNodalMassOld.C
@@ -17,15 +17,17 @@ validParams<Q2PNegativeNodalMassOld>()
   params.addRequiredParam<UserObjectName>(
       "fluid_density",
       "A RichardsDensity UserObject that defines the fluid density as a function of pressure.");
-  params.addRequiredCoupledVar("other_var", "The other variable in the 2-phase system.  If "
-                                            "Variable=porepressure, then other_var should be the "
-                                            "saturation Variable, and vice-versa.");
+  params.addRequiredCoupledVar("other_var",
+                               "The other variable in the 2-phase system.  If "
+                               "Variable=porepressure, then other_var should be the "
+                               "saturation Variable, and vice-versa.");
   params.addRequiredParam<bool>(
-      "var_is_porepressure", "This flag is needed to correctly calculate the Jacobian entries.  If "
-                             "set to true, this Kernel will assume it is describing the mass of "
-                             "the phase with porepressure as its Variable (eg, the liquid phase).  "
-                             "If set to false, this Kernel will assumed it is describing the mass "
-                             "of the phase with saturation as its variable (eg, the gas phase)");
+      "var_is_porepressure",
+      "This flag is needed to correctly calculate the Jacobian entries.  If "
+      "set to true, this Kernel will assume it is describing the mass of "
+      "the phase with porepressure as its Variable (eg, the liquid phase).  "
+      "If set to false, this Kernel will assumed it is describing the mass "
+      "of the phase with saturation as its variable (eg, the gas phase)");
   params.addClassDescription("- fluid_mass");
   return params;
 }

--- a/modules/richards/src/kernels/Q2PNodalMass.C
+++ b/modules/richards/src/kernels/Q2PNodalMass.C
@@ -17,15 +17,17 @@ validParams<Q2PNodalMass>()
   params.addRequiredParam<UserObjectName>(
       "fluid_density",
       "A RichardsDensity UserObject that defines the fluid density as a function of pressure.");
-  params.addRequiredCoupledVar("other_var", "The other variable in the 2-phase system.  If "
-                                            "Variable=porepressure, then other_var should be the "
-                                            "saturation Variable, and vice-versa.");
+  params.addRequiredCoupledVar("other_var",
+                               "The other variable in the 2-phase system.  If "
+                               "Variable=porepressure, then other_var should be the "
+                               "saturation Variable, and vice-versa.");
   params.addRequiredParam<bool>(
-      "var_is_porepressure", "This flag is needed to correctly calculate the Jacobian entries.  If "
-                             "set to true, this Kernel will assume it is describing the mass of "
-                             "the phase with porepressure as its Variable (eg, the liquid phase).  "
-                             "If set to false, this Kernel will assumed it is describing the mass "
-                             "of the phase with saturation as its variable (eg, the gas phase)");
+      "var_is_porepressure",
+      "This flag is needed to correctly calculate the Jacobian entries.  If "
+      "set to true, this Kernel will assume it is describing the mass of "
+      "the phase with porepressure as its Variable (eg, the liquid phase).  "
+      "If set to false, this Kernel will assumed it is describing the mass "
+      "of the phase with saturation as its variable (eg, the gas phase)");
   params.addClassDescription("Fluid mass lumped to the nodes divided by dt");
   return params;
 }

--- a/modules/richards/src/kernels/Q2PPorepressureFlux.C
+++ b/modules/richards/src/kernels/Q2PPorepressureFlux.C
@@ -25,8 +25,9 @@ validParams<Q2PPorepressureFlux>()
       "A RichardsDensity UserObject that defines the fluid density as a function of pressure.");
   params.addRequiredCoupledVar("saturation_variable", "The variable representing fluid saturation");
   params.addRequiredParam<UserObjectName>(
-      "fluid_relperm", "A RichardsRelPerm UserObject (eg RichardsRelPermPower) that defines the "
-                       "fluid relative permeability as a function of the saturation variable");
+      "fluid_relperm",
+      "A RichardsRelPerm UserObject (eg RichardsRelPermPower) that defines the "
+      "fluid relative permeability as a function of the saturation variable");
   params.addRequiredParam<Real>("fluid_viscosity", "The fluid dynamic viscosity");
   params.addClassDescription("Flux according to Darcy-Richards flow.  The Variable for this Kernel "
                              "should be the porepressure.");

--- a/modules/richards/src/kernels/Q2PSaturationDiffusion.C
+++ b/modules/richards/src/kernels/Q2PSaturationDiffusion.C
@@ -16,8 +16,9 @@ validParams<Q2PSaturationDiffusion>()
       "fluid_density",
       "A RichardsDensity UserObject that defines the fluid density as a function of pressure.");
   params.addRequiredParam<UserObjectName>(
-      "fluid_relperm", "A RichardsRelPerm UserObject that defines the fluid relative permeability "
-                       "as a function of water saturation (eg RichardsRelPermPower)");
+      "fluid_relperm",
+      "A RichardsRelPerm UserObject that defines the fluid relative permeability "
+      "as a function of water saturation (eg RichardsRelPermPower)");
   params.addRequiredCoupledVar("porepressure_variable",
                                "The variable representing the porepressure");
   params.addRequiredParam<Real>("fluid_viscosity", "The fluid dynamic viscosity");

--- a/modules/richards/src/kernels/Q2PSaturationFlux.C
+++ b/modules/richards/src/kernels/Q2PSaturationFlux.C
@@ -26,8 +26,9 @@ validParams<Q2PSaturationFlux>()
   params.addRequiredCoupledVar("porepressure_variable",
                                "The variable representing the porepressure");
   params.addRequiredParam<UserObjectName>(
-      "fluid_relperm", "A RichardsRelPerm UserObject (eg RichardsRelPermPowerGas) that defines the "
-                       "fluid relative permeability as a function of the saturation Variable.");
+      "fluid_relperm",
+      "A RichardsRelPerm UserObject (eg RichardsRelPermPowerGas) that defines the "
+      "fluid relative permeability as a function of the saturation Variable.");
   params.addRequiredParam<Real>("fluid_viscosity", "The fluid dynamic viscosity");
   params.addClassDescription(
       "Flux according to Darcy-Richards flow.  The Variable of this Kernel must be the saturation");

--- a/modules/richards/src/kernels/RichardsFullyUpwindFlux.C
+++ b/modules/richards/src/kernels/RichardsFullyUpwindFlux.C
@@ -21,8 +21,9 @@ validParams<RichardsFullyUpwindFlux>()
   params.addRequiredParam<std::vector<UserObjectName>>(
       "relperm_UO", "List of names of user objects that define relative permeability");
   params.addRequiredParam<std::vector<UserObjectName>>(
-      "seff_UO", "List of name of user objects that define effective saturation as a function of "
-                 "pressure list");
+      "seff_UO",
+      "List of name of user objects that define effective saturation as a function of "
+      "pressure list");
   params.addRequiredParam<std::vector<UserObjectName>>(
       "density_UO", "List of names of user objects that define the fluid density");
   params.addRequiredParam<UserObjectName>(

--- a/modules/richards/src/kernels/RichardsLumpedMassChange.C
+++ b/modules/richards/src/kernels/RichardsLumpedMassChange.C
@@ -17,13 +17,15 @@ validParams<RichardsLumpedMassChange>()
   params.addRequiredParam<UserObjectName>(
       "richardsVarNames_UO", "The UserObject that holds the list of Richards variables.");
   params.addRequiredParam<std::vector<UserObjectName>>(
-      "density_UO", "List of names of user objects that define the fluid density (or densities for "
-                    "multiphase).  In the multiphase case, for ease of use, the density, Seff and "
-                    "Sat UserObjects are the same format as for RichardsMaterial, but only the one "
-                    "relevant for the specific phase is actually used.");
+      "density_UO",
+      "List of names of user objects that define the fluid density (or densities for "
+      "multiphase).  In the multiphase case, for ease of use, the density, Seff and "
+      "Sat UserObjects are the same format as for RichardsMaterial, but only the one "
+      "relevant for the specific phase is actually used.");
   params.addRequiredParam<std::vector<UserObjectName>>(
-      "seff_UO", "List of name of user objects that define effective saturation as a function of "
-                 "porepressure(s)");
+      "seff_UO",
+      "List of name of user objects that define effective saturation as a function of "
+      "porepressure(s)");
   params.addRequiredParam<std::vector<UserObjectName>>(
       "sat_UO",
       "List of names of user objects that define saturation as a function of effective saturation");

--- a/modules/richards/src/kernels/RichardsMassChange.C
+++ b/modules/richards/src/kernels/RichardsMassChange.C
@@ -15,8 +15,10 @@ InputParameters
 validParams<RichardsMassChange>()
 {
   InputParameters params = validParams<TimeDerivative>();
-  params.addParam<bool>("use_supg", false, "True for using SUPG in this kernel, false otherwise.  "
-                                           "This has no effect if the material does not use SUPG.");
+  params.addParam<bool>("use_supg",
+                        false,
+                        "True for using SUPG in this kernel, false otherwise.  "
+                        "This has no effect if the material does not use SUPG.");
   params.addRequiredParam<UserObjectName>(
       "richardsVarNames_UO", "The UserObject that holds the list of Richards variable names.");
   return params;

--- a/modules/richards/src/kernels/RichardsPPenalty.C
+++ b/modules/richards/src/kernels/RichardsPPenalty.C
@@ -15,12 +15,14 @@ validParams<RichardsPPenalty>()
 {
   InputParameters params = validParams<Kernel>();
   params.addParam<Real>(
-      "a", 1.0E-10, "Weight of the penalty.  Penalty = a*(lower - variable) for variable<lower, "
-                    "and zero otherwise.  Care should be taken with this parameter choice.  "
-                    "Determine the typical size of your residual (usually rho*perm*(gradP - "
-                    "rho*g)/visc), then typically you want the penalty to ensure p>lower*(1-1E-6), "
-                    "so for the PPP formulation you typically Penalty = a*1E-6*|p|.  I recommend "
-                    "that Penalty = 1E-3*residual, yielding a = 1E3*residual/|P|. ");
+      "a",
+      1.0E-10,
+      "Weight of the penalty.  Penalty = a*(lower - variable) for variable<lower, "
+      "and zero otherwise.  Care should be taken with this parameter choice.  "
+      "Determine the typical size of your residual (usually rho*perm*(gradP - "
+      "rho*g)/visc), then typically you want the penalty to ensure p>lower*(1-1E-6), "
+      "so for the PPP formulation you typically Penalty = a*1E-6*|p|.  I recommend "
+      "that Penalty = 1E-3*residual, yielding a = 1E3*residual/|P|. ");
   params.addRequiredCoupledVar(
       "lower_var", "Your variable will be constrained to be greater than this lower_var variable.");
   params.addClassDescription("This adds a term to the residual that attempts to enforce variable > "

--- a/modules/richards/src/materials/Q2PMaterial.C
+++ b/modules/richards/src/materials/Q2PMaterial.C
@@ -18,15 +18,18 @@ validParams<Q2PMaterial>()
       "mat_porosity",
       "mat_porosity>=0 & mat_porosity<=1",
       "The porosity of the material.  Should be between 0 and 1.  Eg, 0.1");
-  params.addCoupledVar("por_change", 0, "An auxillary variable describing porosity changes.  "
-                                        "Porosity = mat_porosity + por_change.  If this is not "
-                                        "provided, zero is used.");
+  params.addCoupledVar("por_change",
+                       0,
+                       "An auxillary variable describing porosity changes.  "
+                       "Porosity = mat_porosity + por_change.  If this is not "
+                       "provided, zero is used.");
   params.addRequiredParam<RealTensorValue>("mat_permeability", "The permeability tensor (m^2).");
-  params.addCoupledVar("perm_change", "A list of auxillary variable describing permeability "
-                                      "changes.  There must be 9 of these (in 3D), corresponding "
-                                      "to the xx, xy, xz, yx, yy, yz, zx, zy, zz components "
-                                      "respectively (in 3D).  Permeability = "
-                                      "mat_permeability*10^(perm_change).");
+  params.addCoupledVar("perm_change",
+                       "A list of auxillary variable describing permeability "
+                       "changes.  There must be 9 of these (in 3D), corresponding "
+                       "to the xx, xy, xz, yx, yy, yz, zx, zy, zz components "
+                       "respectively (in 3D).  Permeability = "
+                       "mat_permeability*10^(perm_change).");
   params.addRequiredParam<RealVectorValue>(
       "gravity",
       "Gravitational acceleration (m/s^2) as a vector pointing downwards.  Eg (0,0,-10)");

--- a/modules/richards/src/materials/RichardsMaterial.C
+++ b/modules/richards/src/materials/RichardsMaterial.C
@@ -22,21 +22,25 @@ validParams<RichardsMaterial>()
 
   params.addRequiredParam<Real>(
       "mat_porosity", "The porosity of the material.  Should be between 0 and 1.  Eg, 0.1");
-  params.addCoupledVar("por_change", 0, "An auxillary variable describing porosity changes.  "
-                                        "Porosity = mat_porosity + por_change.  If this is not "
-                                        "provided, zero is used.");
+  params.addCoupledVar("por_change",
+                       0,
+                       "An auxillary variable describing porosity changes.  "
+                       "Porosity = mat_porosity + por_change.  If this is not "
+                       "provided, zero is used.");
   params.addRequiredParam<RealTensorValue>("mat_permeability", "The permeability tensor (m^2).");
-  params.addCoupledVar("perm_change", "A list of auxillary variable describing permeability "
-                                      "changes.  There must be 9 of these, corresponding to the "
-                                      "xx, xy, xz, yx, yy, yz, zx, zy, zz components respectively. "
-                                      " Permeability = mat_permeability*10^(perm_change).");
+  params.addCoupledVar("perm_change",
+                       "A list of auxillary variable describing permeability "
+                       "changes.  There must be 9 of these, corresponding to the "
+                       "xx, xy, xz, yx, yy, yz, zx, zy, zz components respectively. "
+                       " Permeability = mat_permeability*10^(perm_change).");
   params.addRequiredParam<UserObjectName>(
       "richardsVarNames_UO", "The UserObject that holds the list of Richards variable names.");
   params.addRequiredParam<std::vector<UserObjectName>>(
       "relperm_UO", "List of names of user objects that define relative permeability");
   params.addRequiredParam<std::vector<UserObjectName>>(
-      "seff_UO", "List of name of user objects that define effective saturation as a function of "
-                 "pressure list");
+      "seff_UO",
+      "List of name of user objects that define effective saturation as a function of "
+      "pressure list");
   params.addRequiredParam<std::vector<UserObjectName>>(
       "sat_UO",
       "List of names of user objects that define saturation as a function of effective saturation");
@@ -159,9 +163,11 @@ RichardsMaterial::RichardsMaterial(const InputParameters & parameters)
         getParam<std::vector<UserObjectName>>("sat_UO").size() == _num_p &&
         getParam<std::vector<UserObjectName>>("density_UO").size() == _num_p &&
         getParam<std::vector<UserObjectName>>("SUPG_UO").size() == _num_p))
-    mooseError("There are ", _num_p, " Richards fluid variables, so you need to specify this "
-                                     "number of viscosities, relperm_UO, seff_UO, sat_UO, "
-                                     "density_UO, SUPG_UO");
+    mooseError("There are ",
+               _num_p,
+               " Richards fluid variables, so you need to specify this "
+               "number of viscosities, relperm_UO, seff_UO, sat_UO, "
+               "density_UO, SUPG_UO");
 
   _d2density.resize(_num_p);
   _d2rel_perm_dv.resize(_num_p);

--- a/modules/richards/src/postprocessors/Q2PPiecewiseLinearSinkFlux.C
+++ b/modules/richards/src/postprocessors/Q2PPiecewiseLinearSinkFlux.C
@@ -16,33 +16,37 @@ validParams<Q2PPiecewiseLinearSinkFlux>()
 {
   InputParameters params = validParams<SideIntegralPostprocessor>();
   params.addParam<UserObjectName>(
-      "fluid_density", "The fluid density as a RichardsDensity UserObject.  If this and the "
-                       "fluid_viscosity are given, then fluxes are multiplied by "
-                       "(density*permeability_nn/viscosity), where the '_nn' indicates the "
-                       "component normal to the boundary.  In this case bare_flux is measured in "
-                       "Pa.s^-1.  This can be used in conjunction with fluid_relperm.");
+      "fluid_density",
+      "The fluid density as a RichardsDensity UserObject.  If this and the "
+      "fluid_viscosity are given, then fluxes are multiplied by "
+      "(density*permeability_nn/viscosity), where the '_nn' indicates the "
+      "component normal to the boundary.  In this case bare_flux is measured in "
+      "Pa.s^-1.  This can be used in conjunction with fluid_relperm.");
   params.addParam<Real>("fluid_viscosity", "The fluid dynamic viscosity.");
   params.addParam<UserObjectName>(
-      "fluid_relperm", "The fluid density as a RichardsRelPerm UserObject (eg RichardsRelPermPower "
-                       "for water, or Q2PRelPermPostGas for gas).  If this and the saturation "
-                       "variable are defined then the flux will be motiplied by relative "
-                       "permeability.  This can be used in conjunction with fluid_density");
+      "fluid_relperm",
+      "The fluid density as a RichardsRelPerm UserObject (eg RichardsRelPermPower "
+      "for water, or Q2PRelPermPostGas for gas).  If this and the saturation "
+      "variable are defined then the flux will be motiplied by relative "
+      "permeability.  This can be used in conjunction with fluid_density");
   params.addCoupledVar("saturation", "The name of the water saturation variable");
   params.addRequiredCoupledVar("porepressure", "The name of the porepressure variable");
   params.addRequiredParam<std::vector<Real>>(
       "pressures", "Tuple of pressure values.  Must be monotonically increasing.");
   params.addRequiredParam<std::vector<Real>>(
-      "bare_fluxes", "Tuple of flux values (measured in kg.m^-2.s^-1 if not using fluid_density, "
-                     "otherwise in Pa.s^-1).  This flux is OUT of the medium: hence positive "
-                     "values of flux means this will be a SINK, while negative values indicate "
-                     "this flux will be a SOURCE.  A piecewise-linear fit is performed to the "
-                     "(pressure,bare_fluxes) pairs to obtain the flux at any arbitrary pressure, "
-                     "and the first or last bare_flux values are used if the quad-point pressure "
-                     "falls outside this range.");
-  params.addParam<FunctionName>(
-      "multiplying_fcn", 1.0, "The flux will be multiplied by this spatially-and-temporally "
-                              "varying function.  This is useful if the boundary is a moving "
-                              "boundary controlled by RichardsExcav.");
+      "bare_fluxes",
+      "Tuple of flux values (measured in kg.m^-2.s^-1 if not using fluid_density, "
+      "otherwise in Pa.s^-1).  This flux is OUT of the medium: hence positive "
+      "values of flux means this will be a SINK, while negative values indicate "
+      "this flux will be a SOURCE.  A piecewise-linear fit is performed to the "
+      "(pressure,bare_fluxes) pairs to obtain the flux at any arbitrary pressure, "
+      "and the first or last bare_flux values are used if the quad-point pressure "
+      "falls outside this range.");
+  params.addParam<FunctionName>("multiplying_fcn",
+                                1.0,
+                                "The flux will be multiplied by this spatially-and-temporally "
+                                "varying function.  This is useful if the boundary is a moving "
+                                "boundary controlled by RichardsExcav.");
   params.addClassDescription("Records the fluid flow into a sink (positive values indicate fluid "
                              "is flowing from porespace into the sink).");
   return params;

--- a/modules/richards/src/postprocessors/RichardsHalfGaussianSinkFlux.C
+++ b/modules/richards/src/postprocessors/RichardsHalfGaussianSinkFlux.C
@@ -16,16 +16,19 @@ InputParameters
 validParams<RichardsHalfGaussianSinkFlux>()
 {
   InputParameters params = validParams<SideIntegralVariablePostprocessor>();
-  params.addRequiredParam<Real>("max", "Maximum of the flux (measured in kg.m^-2.s^-1).  Flux out "
-                                       "= max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and Flux "
-                                       "out = max for p>centre.  Note, to make this a source "
-                                       "rather than a sink, let max<0");
-  params.addRequiredParam<Real>("sd", "Standard deviation of the Gaussian (measured in Pa).  Flux "
-                                      "out = max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and "
-                                      "Flux out = max for p>centre.");
-  params.addRequiredParam<Real>("centre", "Centre of the Gaussian (measured in Pa).  Flux out = "
-                                          "max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and "
-                                          "Flux out = max for p>centre.");
+  params.addRequiredParam<Real>("max",
+                                "Maximum of the flux (measured in kg.m^-2.s^-1).  Flux out "
+                                "= max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and Flux "
+                                "out = max for p>centre.  Note, to make this a source "
+                                "rather than a sink, let max<0");
+  params.addRequiredParam<Real>("sd",
+                                "Standard deviation of the Gaussian (measured in Pa).  Flux "
+                                "out = max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and "
+                                "Flux out = max for p>centre.");
+  params.addRequiredParam<Real>("centre",
+                                "Centre of the Gaussian (measured in Pa).  Flux out = "
+                                "max*exp((-0.5*(p - centre)/sd)^2) for p<centre, and "
+                                "Flux out = max for p>centre.");
   params.addParam<FunctionName>(
       "multiplying_fcn",
       1.0,

--- a/modules/richards/src/postprocessors/RichardsPiecewiseLinearSinkFlux.C
+++ b/modules/richards/src/postprocessors/RichardsPiecewiseLinearSinkFlux.C
@@ -16,29 +16,33 @@ validParams<RichardsPiecewiseLinearSinkFlux>()
 {
   InputParameters params = validParams<SideIntegralVariablePostprocessor>();
   params.addRequiredParam<bool>(
-      "use_mobility", "If true, then fluxes are multiplied by (density*permeability_nn/viscosity), "
-                      "where the '_nn' indicates the component normal to the boundary.  In this "
-                      "case bare_flux is measured in Pa.s^-1.  This can be used in conjunction "
-                      "with use_relperm.");
-  params.addRequiredParam<bool>("use_relperm", "If true, then fluxes are multiplied by relative "
-                                               "permeability.  This can be used in conjunction "
-                                               "with use_mobility");
+      "use_mobility",
+      "If true, then fluxes are multiplied by (density*permeability_nn/viscosity), "
+      "where the '_nn' indicates the component normal to the boundary.  In this "
+      "case bare_flux is measured in Pa.s^-1.  This can be used in conjunction "
+      "with use_relperm.");
+  params.addRequiredParam<bool>("use_relperm",
+                                "If true, then fluxes are multiplied by relative "
+                                "permeability.  This can be used in conjunction "
+                                "with use_mobility");
   params.addRequiredParam<std::vector<Real>>(
       "pressures", "Tuple of pressure values.  Must be monotonically increasing.");
   params.addRequiredParam<std::vector<Real>>(
-      "bare_fluxes", "Tuple of flux values (measured in kg.m^-2.s^-1 for use_mobility=false, and "
-                     "in Pa.s^-1 if use_mobility=true).  This flux is OUT of the medium: hence "
-                     "positive values of flux means this will be a SINK, while negative values "
-                     "indicate this flux will be a SOURCE.  A piecewise-linear fit is performed to "
-                     "the (pressure,bare_fluxes) pairs to obtain the flux at any arbitrary "
-                     "pressure, and the first or last bare_flux values are used if the quad-point "
-                     "pressure falls outside this range.");
+      "bare_fluxes",
+      "Tuple of flux values (measured in kg.m^-2.s^-1 for use_mobility=false, and "
+      "in Pa.s^-1 if use_mobility=true).  This flux is OUT of the medium: hence "
+      "positive values of flux means this will be a SINK, while negative values "
+      "indicate this flux will be a SOURCE.  A piecewise-linear fit is performed to "
+      "the (pressure,bare_fluxes) pairs to obtain the flux at any arbitrary "
+      "pressure, and the first or last bare_flux values are used if the quad-point "
+      "pressure falls outside this range.");
   params.addRequiredParam<UserObjectName>(
       "richardsVarNames_UO", "The UserObject that holds the list of Richards variable names.");
-  params.addParam<FunctionName>(
-      "multiplying_fcn", 1.0, "The flux will be multiplied by this spatially-and-temporally "
-                              "varying function.  This is useful if the boundary is a moving "
-                              "boundary controlled by RichardsExcav.");
+  params.addParam<FunctionName>("multiplying_fcn",
+                                1.0,
+                                "The flux will be multiplied by this spatially-and-temporally "
+                                "varying function.  This is useful if the boundary is a moving "
+                                "boundary controlled by RichardsExcav.");
   params.addClassDescription("Records the fluid flow into a sink (positive values indicate fluid "
                              "is flowing from porespace into the sink).");
   return params;

--- a/modules/richards/src/userobjects/Q2PRelPermPowerGas.C
+++ b/modules/richards/src/userobjects/Q2PRelPermPowerGas.C
@@ -15,11 +15,15 @@ validParams<Q2PRelPermPowerGas>()
 {
   InputParameters params = validParams<RichardsRelPerm>();
   params.addRequiredRangeCheckedParam<Real>(
-      "simm", "simm >= 0 & simm < 1", "Immobile saturation.  Must be between 0 and 1.   Define s = "
-                                      "seff/(1 - simm).  Then relperm = 1 - (n+1)s^n + ns^(n+1)");
-  params.addRequiredRangeCheckedParam<Real>("n", "n >= 2", "Exponent.  Must be >= 2.   Define s = "
-                                                           "(eff/(1 - simm).  Then relperm = 1 - "
-                                                           "(n+1)s^n + ns^(n+1)");
+      "simm",
+      "simm >= 0 & simm < 1",
+      "Immobile saturation.  Must be between 0 and 1.   Define s = "
+      "seff/(1 - simm).  Then relperm = 1 - (n+1)s^n + ns^(n+1)");
+  params.addRequiredRangeCheckedParam<Real>("n",
+                                            "n >= 2",
+                                            "Exponent.  Must be >= 2.   Define s = "
+                                            "(eff/(1 - simm).  Then relperm = 1 - "
+                                            "(n+1)s^n + ns^(n+1)");
   params.addClassDescription("Power form of relative permeability that might be useful for gases "
                              "as a function of water saturation in Q2P models.  Define s = seff/(1 "
                              "- simm).  Then relperm = 1 - (n+1)s^n + ns^(n+1) if seff<1-simm, "

--- a/modules/richards/src/userobjects/RichardsDensityConstBulkCut.C
+++ b/modules/richards/src/userobjects/RichardsDensityConstBulkCut.C
@@ -16,14 +16,16 @@ validParams<RichardsDensityConstBulkCut>()
   InputParameters params = validParams<RichardsDensity>();
   params.addRequiredParam<Real>("dens0", "Reference density of fluid.  Eg 1000");
   params.addRequiredParam<Real>("bulk_mod", "Bulk modulus of fluid.  Eg 2E9");
-  params.addParam<Real>(
-      "cut_limit", 1E5, "For porepressure > cut_limit, density = dens0*Exp(pressure/bulk).  For "
+  params.addParam<Real>("cut_limit",
+                        1E5,
+                        "For porepressure > cut_limit, density = dens0*Exp(pressure/bulk).  For "
                         "porepressure < cut_limie, density = cubic*dens0*Exp(pressure/bulk), where "
                         "cubic=1 for pressure=cut_limit, and cubic=0 for pressure<=zero_point");
-  params.addParam<Real>(
-      "zero_point", 0, "For porepressure > cut_limit, density = dens0*Exp(pressure/bulk).  For "
-                       "porepressure < cut_limie, density = cubic*dens0*Exp(pressure/bulk), where "
-                       "cubic=1 for pressure=cut_limit, and cubic=0 for pressure<=zero_point");
+  params.addParam<Real>("zero_point",
+                        0,
+                        "For porepressure > cut_limit, density = dens0*Exp(pressure/bulk).  For "
+                        "porepressure < cut_limie, density = cubic*dens0*Exp(pressure/bulk), where "
+                        "cubic=1 for pressure=cut_limit, and cubic=0 for pressure<=zero_point");
   params.addClassDescription(
       "Fluid density assuming constant bulk modulus.  dens0 * Exp(pressure/bulk)");
   return params;

--- a/modules/richards/src/userobjects/RichardsDensityVDW.C
+++ b/modules/richards/src/userobjects/RichardsDensityVDW.C
@@ -13,24 +13,30 @@ validParams<RichardsDensityVDW>()
 {
   InputParameters params = validParams<RichardsDensity>();
   params.addRequiredRangeCheckedParam<Real>(
-      "a", "a > 0", "Parameter 'a' in the van der Waals expression (P + n^2 a/V^2)(V - nb) = nRT.  "
-                    "Example for methane 0.2303 Pa m^6 mol^-2");
+      "a",
+      "a > 0",
+      "Parameter 'a' in the van der Waals expression (P + n^2 a/V^2)(V - nb) = nRT.  "
+      "Example for methane 0.2303 Pa m^6 mol^-2");
   params.addRequiredRangeCheckedParam<Real>(
-      "b", "b > 0", "Parameter 'b' in the van der Waals expression (P + n^2 a/V^2)(V - nb) = nRT.  "
-                    "Example for methane 4.31E-5 m^3/mol");
+      "b",
+      "b > 0",
+      "Parameter 'b' in the van der Waals expression (P + n^2 a/V^2)(V - nb) = nRT.  "
+      "Example for methane 4.31E-5 m^3/mol");
   params.addRequiredRangeCheckedParam<Real>(
       "temperature", "temperature > 0", "Temperature in Kelvin");
   params.addRequiredRangeCheckedParam<Real>(
       "molar_mass",
       "molar_mass > 0",
       "Molar mass of the gas.  Example for methane 16.04246E-3 kg/mol");
-  params.addRangeCheckedParam<Real>(
-      "infinity_ratio", 10, "infinity_ratio > 0", "For P<0 the density is not physically defined, "
-                                                  "but numerically it is advantageous to define "
-                                                  "it:  density(P=-infinity) = "
-                                                  "-infinity_ratio*molar_mass, and density tends "
-                                                  "exponentially towards this value as P -> "
-                                                  "-infinity.  (Units are mol/m^3).");
+  params.addRangeCheckedParam<Real>("infinity_ratio",
+                                    10,
+                                    "infinity_ratio > 0",
+                                    "For P<0 the density is not physically defined, "
+                                    "but numerically it is advantageous to define "
+                                    "it:  density(P=-infinity) = "
+                                    "-infinity_ratio*molar_mass, and density tends "
+                                    "exponentially towards this value as P -> "
+                                    "-infinity.  (Units are mol/m^3).");
   params.addClassDescription("Density of van der Waals gas.");
   return params;
 }

--- a/modules/richards/src/userobjects/RichardsRelPermBW.C
+++ b/modules/richards/src/userobjects/RichardsRelPermBW.C
@@ -18,21 +18,28 @@ validParams<RichardsRelPermBW>()
 {
   InputParameters params = validParams<RichardsRelPerm>();
   params.addRequiredRangeCheckedParam<Real>(
-      "Sn", "Sn >= 0", "Low saturation.  This must be < Ss, and non-negative.  This is BW's "
-                       "initial effective saturation, below which effective saturation never goes "
-                       "in their simulations/models.  If Kn=0 then Sn is the immobile saturation.");
+      "Sn",
+      "Sn >= 0",
+      "Low saturation.  This must be < Ss, and non-negative.  This is BW's "
+      "initial effective saturation, below which effective saturation never goes "
+      "in their simulations/models.  If Kn=0 then Sn is the immobile saturation.");
   params.addRangeCheckedParam<Real>(
-      "Ss", 1.0, "Ss <= 1", "High saturation.  This must be > Sn and <= 1.  Effective saturation "
-                            "where porepressure = 0.  Effective saturation never exceeds this "
-                            "value in BW's simulations/models.");
+      "Ss",
+      1.0,
+      "Ss <= 1",
+      "High saturation.  This must be > Sn and <= 1.  Effective saturation "
+      "where porepressure = 0.  Effective saturation never exceeds this "
+      "value in BW's simulations/models.");
   params.addRangeCheckedParam<Real>(
       "Kn", 0.0, "Kn >= 0", "Relative permeability at Seff = Sn.  Must be < Ks");
   params.addRangeCheckedParam<Real>(
       "Ks", 1.0, "Ks <= 1", "Relative permeability at Seff = Ss.  Must be > Kn");
   params.addRequiredRangeCheckedParam<Real>(
-      "C", "C > 1", "BW's C parameter.  Must be > 1.   Define s = (seff - Sn)/(Ss - Sn).  Then "
-                    "relperm = Kn + s^2(c-1)(Kn-Ks)/(c-s) if 0<s<1, otherwise relperm = Kn if "
-                    "s<=0, otherwise relperm = Ks if s>=1.");
+      "C",
+      "C > 1",
+      "BW's C parameter.  Must be > 1.   Define s = (seff - Sn)/(Ss - Sn).  Then "
+      "relperm = Kn + s^2(c-1)(Kn-Ks)/(c-s) if 0<s<1, otherwise relperm = Kn if "
+      "s<=0, otherwise relperm = Ks if s>=1.");
   params.addClassDescription("Broadbridge-White form of relative permeability.  Define s = (seff - "
                              "Sn)/(Ss - Sn).  Then relperm = Kn + s^2(c-1)(Kn-Ks)/(c-s) if 0<s<1, "
                              "otherwise relperm = Kn if s<=0, otherwise relperm = Ks if s>=1.");

--- a/modules/richards/src/userobjects/RichardsRelPermMonomial.C
+++ b/modules/richards/src/userobjects/RichardsRelPermMonomial.C
@@ -15,8 +15,10 @@ validParams<RichardsRelPermMonomial>()
 {
   InputParameters params = validParams<RichardsRelPerm>();
   params.addRequiredRangeCheckedParam<Real>(
-      "simm", "simm >= 0 & simm < 1", "Immobile saturation.  Must be between 0 and 1.   Define s = "
-                                      "(seff - simm)/(1 - simm).  Then relperm = s^n");
+      "simm",
+      "simm >= 0 & simm < 1",
+      "Immobile saturation.  Must be between 0 and 1.   Define s = "
+      "(seff - simm)/(1 - simm).  Then relperm = s^n");
   params.addRequiredRangeCheckedParam<Real>(
       "n",
       "n >= 0",

--- a/modules/richards/src/userobjects/RichardsRelPermPower.C
+++ b/modules/richards/src/userobjects/RichardsRelPermPower.C
@@ -15,12 +15,16 @@ validParams<RichardsRelPermPower>()
 {
   InputParameters params = validParams<RichardsRelPerm>();
   params.addRequiredRangeCheckedParam<Real>(
-      "simm", "simm >= 0 & simm < 1", "Immobile saturation.  Must be between 0 and 1.   Define s = "
-                                      "(seff - simm)/(1 - simm).  Then relperm = (n+1)s^n - "
-                                      "ns^(n+1)");
-  params.addRequiredRangeCheckedParam<Real>("n", "n >= 2", "Exponent.  Must be >= 2.   Define s = "
-                                                           "(seff - simm)/(1 - simm).  Then "
-                                                           "relperm = (n+1)s^n - ns^(n+1)");
+      "simm",
+      "simm >= 0 & simm < 1",
+      "Immobile saturation.  Must be between 0 and 1.   Define s = "
+      "(seff - simm)/(1 - simm).  Then relperm = (n+1)s^n - "
+      "ns^(n+1)");
+  params.addRequiredRangeCheckedParam<Real>("n",
+                                            "n >= 2",
+                                            "Exponent.  Must be >= 2.   Define s = "
+                                            "(seff - simm)/(1 - simm).  Then "
+                                            "relperm = (n+1)s^n - ns^(n+1)");
   params.addClassDescription("Power form of relative permeability.  Define s = (seff - simm)/(1 - "
                              "simm).  Then relperm = (n+1)s^n - ns^(n+1) if s<simm, otherwise "
                              "relperm=1");

--- a/modules/richards/src/userobjects/RichardsRelPermPowerGas.C
+++ b/modules/richards/src/userobjects/RichardsRelPermPowerGas.C
@@ -15,12 +15,16 @@ validParams<RichardsRelPermPowerGas>()
 {
   InputParameters params = validParams<RichardsRelPerm>();
   params.addRequiredRangeCheckedParam<Real>(
-      "simm", "simm >= 0 & simm < 1", "Immobile saturation.  Must be between 0 and 1.   Define s = "
-                                      "(seff - simm)/(1 - simm).  Then relperm = 1 - (n+1)(1-s)^n "
-                                      "+ n(1-s)^(n+1)");
+      "simm",
+      "simm >= 0 & simm < 1",
+      "Immobile saturation.  Must be between 0 and 1.   Define s = "
+      "(seff - simm)/(1 - simm).  Then relperm = 1 - (n+1)(1-s)^n "
+      "+ n(1-s)^(n+1)");
   params.addRequiredRangeCheckedParam<Real>(
-      "n", "n >= 2", "Exponent.  Must be >= 2.   Define s = (seff - simm)/(1 - simm).  Then "
-                     "relperm = 1 - (n+1)(1-s)^n + n(1-s)^(n+1)");
+      "n",
+      "n >= 2",
+      "Exponent.  Must be >= 2.   Define s = (seff - simm)/(1 - simm).  Then "
+      "relperm = 1 - (n+1)(1-s)^n + n(1-s)^(n+1)");
   params.addClassDescription("Power form of relative permeability that might be useful for gases.  "
                              "Define s = (seff - simm)/(1 - simm).  Then relperm = 1 - "
                              "(n+1)(1-s)^n + n(1-s)^(n+1) if s<simm, otherwise relperm=1");

--- a/modules/richards/src/userobjects/RichardsRelPermVG.C
+++ b/modules/richards/src/userobjects/RichardsRelPermVG.C
@@ -14,13 +14,17 @@ validParams<RichardsRelPermVG>()
 {
   InputParameters params = validParams<RichardsRelPerm>();
   params.addRequiredRangeCheckedParam<Real>(
-      "simm", "simm >= 0 & simm < 1", "Immobile saturation.  Must be between 0 and 1.  Define s = "
-                                      "(seff - simm)/(1 - simm).  Then relperm = s^(1/2) * (1 - (1 "
-                                      "- s^(1/m))^m)^2");
+      "simm",
+      "simm >= 0 & simm < 1",
+      "Immobile saturation.  Must be between 0 and 1.  Define s = "
+      "(seff - simm)/(1 - simm).  Then relperm = s^(1/2) * (1 - (1 "
+      "- s^(1/m))^m)^2");
   params.addRequiredRangeCheckedParam<Real>(
-      "m", "m > 0 & m < 1", "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
-                            "should be set >0.5.  Define s = (seff - simm)/(1 - simm).  Then "
-                            "relperm = s^(1/2) * (1 - (1 - s^(1/m))^m)^2");
+      "m",
+      "m > 0 & m < 1",
+      "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
+      "should be set >0.5.  Define s = (seff - simm)/(1 - simm).  Then "
+      "relperm = s^(1/2) * (1 - (1 - s^(1/m))^m)^2");
   params.addClassDescription("VG form of relative permeability.  Define s = (seff - simm)/(1 - "
                              "simm).  Then relperm = s^(1/2) * (1 - (1 - s^(1/m))^m)^2, if s>0, "
                              "and relperm=0 otherwise");

--- a/modules/richards/src/userobjects/RichardsRelPermVG1.C
+++ b/modules/richards/src/userobjects/RichardsRelPermVG1.C
@@ -15,13 +15,17 @@ validParams<RichardsRelPermVG1>()
 {
   InputParameters params = validParams<RichardsRelPermVG>();
   params.addRequiredRangeCheckedParam<Real>(
-      "simm", "simm >=0 & simm < 1", "Immobile saturation.  Must be between 0 and 1.  Define s = "
-                                     "(seff - simm)/(1 - simm).  Then relperm = s^(1/2) * (1 - (1 "
-                                     "- s^(1/m))^m)^2");
+      "simm",
+      "simm >=0 & simm < 1",
+      "Immobile saturation.  Must be between 0 and 1.  Define s = "
+      "(seff - simm)/(1 - simm).  Then relperm = s^(1/2) * (1 - (1 "
+      "- s^(1/m))^m)^2");
   params.addRequiredRangeCheckedParam<Real>(
-      "m", "m > 0 & m < 1", "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
-                            "should be set >0.5.  Define s = (seff - simm)/(1 - simm).  Then "
-                            "relperm = s^(1/2) * (1 - (1 - s^(1/m))^m)^2");
+      "m",
+      "m > 0 & m < 1",
+      "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
+      "should be set >0.5.  Define s = (seff - simm)/(1 - simm).  Then "
+      "relperm = s^(1/2) * (1 - (1 - s^(1/m))^m)^2");
   params.addRequiredRangeCheckedParam<Real>(
       "scut", "scut > 0 & scut < 1", "cutoff in effective saturation.");
   params.addClassDescription("VG1 form of relative permeability.  Define s = (seff - simm)/(1 - "

--- a/modules/richards/src/userobjects/RichardsSUPGstandard.C
+++ b/modules/richards/src/userobjects/RichardsSUPGstandard.C
@@ -14,13 +14,15 @@ validParams<RichardsSUPGstandard>()
 {
   InputParameters params = validParams<RichardsSUPG>();
   params.addRequiredRangeCheckedParam<Real>(
-      "p_SUPG", "p_SUPG > 0", "SUPG pressure.  This parameter controls the strength of the "
-                              "upwinding.  This parameter must be positive.  If you need to track "
-                              "advancing fronts in a problem, then set to less than your expected "
-                              "range of pressures in your unsaturated zone.  Otherwise, set "
-                              "larger, and then minimal upwinding will occur and convergence will "
-                              "typically be good.  If you need no SUPG, it is more efficient not "
-                              "to use this UserObject.");
+      "p_SUPG",
+      "p_SUPG > 0",
+      "SUPG pressure.  This parameter controls the strength of the "
+      "upwinding.  This parameter must be positive.  If you need to track "
+      "advancing fronts in a problem, then set to less than your expected "
+      "range of pressures in your unsaturated zone.  Otherwise, set "
+      "larger, and then minimal upwinding will occur and convergence will "
+      "typically be good.  If you need no SUPG, it is more efficient not "
+      "to use this UserObject.");
   params.addClassDescription(
       "Standard SUPG relationships for Richards flow based on Appendix A of      TJR Hughes, M "
       "Mallet and A Mizukami ``A new finite element formulation for computational fluid dynamics:: "

--- a/modules/richards/src/userobjects/RichardsSat.C
+++ b/modules/richards/src/userobjects/RichardsSat.C
@@ -19,8 +19,10 @@ validParams<RichardsSat>()
       "s_res >= 0 & s_res < 1",
       "Residual fluid saturation for the phase.  0 <= s_res < 1.");
   params.addRequiredRangeCheckedParam<Real>(
-      "sum_s_res", "sum_s_res < 1", "Sum of s_res over all phases.  s_res <= sum_s_res < 1.  It is "
-                                    "up to you to ensure the sum is done correctly.");
+      "sum_s_res",
+      "sum_s_res < 1",
+      "Sum of s_res over all phases.  s_res <= sum_s_res < 1.  It is "
+      "up to you to ensure the sum is done correctly.");
   params.addClassDescription("User object yielding saturation for a phase as a function of "
                              "effective saturation of that phase");
   return params;

--- a/modules/richards/src/userobjects/RichardsSeff1BWsmall.C
+++ b/modules/richards/src/userobjects/RichardsSeff1BWsmall.C
@@ -18,19 +18,26 @@ validParams<RichardsSeff1BWsmall>()
 {
   InputParameters params = validParams<RichardsSeff>();
   params.addRequiredRangeCheckedParam<Real>(
-      "Sn", "Sn >= 0", "Low saturation.  This must be < Ss, and non-negative.  This is BW's "
-                       "initial effective saturation, below which effective saturation never goes "
-                       "in their simulations/models.  If Kn=0 then Sn is the immobile saturation.  "
-                       "This form of effective saturation is only correct for Kn small.");
+      "Sn",
+      "Sn >= 0",
+      "Low saturation.  This must be < Ss, and non-negative.  This is BW's "
+      "initial effective saturation, below which effective saturation never goes "
+      "in their simulations/models.  If Kn=0 then Sn is the immobile saturation.  "
+      "This form of effective saturation is only correct for Kn small.");
   params.addRangeCheckedParam<Real>(
-      "Ss", 1.0, "Ss <= 1", "High saturation.  This must be > Sn and <= 1.  Effective saturation "
-                            "where porepressure = 0.  Effective saturation never exceeds this "
-                            "value in BW's simulations/models.");
+      "Ss",
+      1.0,
+      "Ss <= 1",
+      "High saturation.  This must be > Sn and <= 1.  Effective saturation "
+      "where porepressure = 0.  Effective saturation never exceeds this "
+      "value in BW's simulations/models.");
   params.addRequiredRangeCheckedParam<Real>(
       "C", "C > 1", "BW's C parameter.  Must be > 1.  Typical value would be 1.05.");
-  params.addRequiredRangeCheckedParam<Real>("las", "las > 0", "BW's lambda_s parameter multiplied "
-                                                              "by (fluiddensity*gravity).  Must be "
-                                                              "> 0.  Typical value would be 1E5");
+  params.addRequiredRangeCheckedParam<Real>("las",
+                                            "las > 0",
+                                            "BW's lambda_s parameter multiplied "
+                                            "by (fluiddensity*gravity).  Must be "
+                                            "> 0.  Typical value would be 1E5");
   params.addClassDescription("Broadbridge-white form of effective saturation for negligable Kn.  "
                              "Then porepressure = -las*( (1-th)/th - (1/c)Ln((C-th)/((C-1)th))), "
                              "for th = (Seff - Sn)/(Ss - Sn).  A Lambert-W function must be "

--- a/modules/richards/src/userobjects/RichardsSeff1RSC.C
+++ b/modules/richards/src/userobjects/RichardsSeff1RSC.C
@@ -21,12 +21,14 @@ InputParameters
 validParams<RichardsSeff1RSC>()
 {
   InputParameters params = validParams<RichardsSeff>();
-  params.addParam<Real>("oil_viscosity", "Viscosity of oil (gas) phase.  It is assumed this is "
-                                         "double the water-phase viscosity.  (Note that this "
-                                         "effective saturation is mostly useful for 2-phase, not "
-                                         "single-phase.)");
-  params.addParam<Real>("scale_ratio", "This is porosity/permeability/beta^2, where beta may be "
-                                       "chosen by the user.  It has dimensions [time]");
+  params.addParam<Real>("oil_viscosity",
+                        "Viscosity of oil (gas) phase.  It is assumed this is "
+                        "double the water-phase viscosity.  (Note that this "
+                        "effective saturation is mostly useful for 2-phase, not "
+                        "single-phase.)");
+  params.addParam<Real>("scale_ratio",
+                        "This is porosity/permeability/beta^2, where beta may be "
+                        "chosen by the user.  It has dimensions [time]");
   params.addParam<Real>("shift", "effective saturation is a function of (Pc - shift)");
   params.addClassDescription(
       "Rogers-Stallybrass-Clements version of effective saturation for the water phase, valid for "

--- a/modules/richards/src/userobjects/RichardsSeff1VG.C
+++ b/modules/richards/src/userobjects/RichardsSeff1VG.C
@@ -15,13 +15,17 @@ InputParameters
 validParams<RichardsSeff1VG>()
 {
   InputParameters params = validParams<RichardsSeff>();
-  params.addRequiredRangeCheckedParam<Real>("al", "al > 0", "van-Genuchten alpha parameter.  Must "
-                                                            "be positive.  Single-phase VG seff = "
-                                                            "(1 + (-al*c)^(1/(1-m)))^(-m)");
+  params.addRequiredRangeCheckedParam<Real>("al",
+                                            "al > 0",
+                                            "van-Genuchten alpha parameter.  Must "
+                                            "be positive.  Single-phase VG seff = "
+                                            "(1 + (-al*c)^(1/(1-m)))^(-m)");
   params.addRequiredRangeCheckedParam<Real>(
-      "m", "m > 0 & m < 1", "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
-                            "should be set to >0.5   Single-phase VG seff = (1 + "
-                            "(-al*p)^(1/(1-m)))^(-m)");
+      "m",
+      "m > 0 & m < 1",
+      "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
+      "should be set to >0.5   Single-phase VG seff = (1 + "
+      "(-al*p)^(1/(1-m)))^(-m)");
   params.addClassDescription("van-Genuchten effective saturation as a function of pressure "
                              "suitable for use in single-phase simulations..  seff = (1 + "
                              "(-al*p)^(1/(1-m)))^(-m)");

--- a/modules/richards/src/userobjects/RichardsSeff1VGcut.C
+++ b/modules/richards/src/userobjects/RichardsSeff1VGcut.C
@@ -15,9 +15,11 @@ validParams<RichardsSeff1VGcut>()
 {
   InputParameters params = validParams<RichardsSeff1VG>();
   params.addRequiredRangeCheckedParam<Real>(
-      "p_cut", "p_cut < 0", "cutoff in pressure.  Must be negative.  If p>p_cut then use "
-                            "van-Genuchten function.  Otherwise use a linear relationship which is "
-                            "chosen so the value and derivative match van-Genuchten at p=p_cut");
+      "p_cut",
+      "p_cut < 0",
+      "cutoff in pressure.  Must be negative.  If p>p_cut then use "
+      "van-Genuchten function.  Otherwise use a linear relationship which is "
+      "chosen so the value and derivative match van-Genuchten at p=p_cut");
   params.addClassDescription("cut van-Genuchten effective saturation as a function of capillary "
                              "pressure.  Single-phase  seff = (1 + (-al*p)^(1/(1-m)))^(-m) for "
                              "p>p_cut, otherwise user a a linear relationship that is chosen so "

--- a/modules/richards/src/userobjects/RichardsSeff2gasRSC.C
+++ b/modules/richards/src/userobjects/RichardsSeff2gasRSC.C
@@ -22,10 +22,11 @@ validParams<RichardsSeff2gasRSC>()
   params.addParam<Real>(
       "oil_viscosity",
       "Viscosity of oil (gas) phase.  It is assumed this is double the water-phase viscosity");
-  params.addParam<Real>("scale_ratio", "This is porosity/permeability/beta^2, where beta may be "
-                                       "chosen by the user (RSC define beta<0, but MOOSE only uses "
-                                       "beta^2, so its sign is irrelevant).  It has dimensions "
-                                       "[time]");
+  params.addParam<Real>("scale_ratio",
+                        "This is porosity/permeability/beta^2, where beta may be "
+                        "chosen by the user (RSC define beta<0, but MOOSE only uses "
+                        "beta^2, so its sign is irrelevant).  It has dimensions "
+                        "[time]");
   params.addParam<Real>("shift", "effective saturation is a function of (Pc - shift)");
   params.addClassDescription("Rogers-Stallybrass-Clements version of effective saturation for the "
                              "oil (gas) phase, valid for residual saturations = 0, and "

--- a/modules/richards/src/userobjects/RichardsSeff2gasVG.C
+++ b/modules/richards/src/userobjects/RichardsSeff2gasVG.C
@@ -15,13 +15,17 @@ InputParameters
 validParams<RichardsSeff2gasVG>()
 {
   InputParameters params = validParams<RichardsSeff>();
-  params.addRequiredRangeCheckedParam<Real>("al", "al > 0", "van-Genuchten alpha parameter.  Must "
-                                                            "be positive.  Single-phase VG seff = "
-                                                            "(1 + (-al*c)^(1/(1-m)))^(-m)");
+  params.addRequiredRangeCheckedParam<Real>("al",
+                                            "al > 0",
+                                            "van-Genuchten alpha parameter.  Must "
+                                            "be positive.  Single-phase VG seff = "
+                                            "(1 + (-al*c)^(1/(1-m)))^(-m)");
   params.addRequiredRangeCheckedParam<Real>(
-      "m", "m > 0 & m < 1", "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
-                            "should be set to >0.5   Single-phase VG seff = (1 + "
-                            "(-al*p)^(1/(1-m)))^(-m)");
+      "m",
+      "m > 0 & m < 1",
+      "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
+      "should be set to >0.5   Single-phase VG seff = (1 + "
+      "(-al*p)^(1/(1-m)))^(-m)");
   params.addClassDescription("van-Genuchten effective saturation as a function of (Pwater, Pgas) "
                              "suitable for use for the gas phase in two-phase simulations.  With "
                              "Pc=Pgas-Pwater,   seff = 1 - (1 + (al*pc)^(1/(1-m)))^(-m)");

--- a/modules/richards/src/userobjects/RichardsSeff2gasVGshifted.C
+++ b/modules/richards/src/userobjects/RichardsSeff2gasVGshifted.C
@@ -16,17 +16,23 @@ validParams<RichardsSeff2gasVGshifted>()
 {
   InputParameters params = validParams<RichardsSeff>();
   params.addRequiredRangeCheckedParam<Real>(
-      "al", "al > 0", "van-Genuchten alpha parameter.  Must be positive.   seff = (1 + "
-                      "(-al*(P0-P1-shift))^(1/(1-m)))^(-m) (then scaled to 0 to 1)");
+      "al",
+      "al > 0",
+      "van-Genuchten alpha parameter.  Must be positive.   seff = (1 + "
+      "(-al*(P0-P1-shift))^(1/(1-m)))^(-m) (then scaled to 0 to 1)");
   params.addRequiredRangeCheckedParam<Real>(
-      "m", "m > 0 & m < 1", "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
-                            "should be set to >0.5   seff = (1 + "
-                            "(-al*(P0-P1-shift)^(1/(1-m)))^(-m) (then scaled to 0 to 1)");
+      "m",
+      "m > 0 & m < 1",
+      "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
+      "should be set to >0.5   seff = (1 + "
+      "(-al*(P0-P1-shift)^(1/(1-m)))^(-m) (then scaled to 0 to 1)");
   params.addRequiredRangeCheckedParam<Real>(
-      "shift", "shift > 0", "Shift in capillary-pressure porepressure values.  Standard "
-                            "van-Genuchten Seff = Seff(Pwater-Pgas) is shifted to the right, and "
-                            "then scaled to 0<=Seff<=1.  This means that dS/dP>0 at S=1 which is "
-                            "useful to provide nonsingular Jacobians for small dt.");
+      "shift",
+      "shift > 0",
+      "Shift in capillary-pressure porepressure values.  Standard "
+      "van-Genuchten Seff = Seff(Pwater-Pgas) is shifted to the right, and "
+      "then scaled to 0<=Seff<=1.  This means that dS/dP>0 at S=1 which is "
+      "useful to provide nonsingular Jacobians for small dt.");
   params.addClassDescription("Shifted van-Genuchten effective saturation as a function of (Pwater, "
                              "Pgas) suitable for use for the gas phase in two-phase simulations.   "
                              "  seff = (1 + (-al*(P0-p1-shift))^(1/(1-m)))^(-m), then scaled so it "

--- a/modules/richards/src/userobjects/RichardsSeff2waterRSC.C
+++ b/modules/richards/src/userobjects/RichardsSeff2waterRSC.C
@@ -22,10 +22,11 @@ validParams<RichardsSeff2waterRSC>()
   params.addRequiredParam<Real>(
       "oil_viscosity",
       "Viscosity of oil (gas) phase.  It is assumed this is double the water-phase viscosity");
-  params.addRequiredParam<Real>("scale_ratio", "This is porosity/permeability/beta^2, where beta "
-                                               "may be chosen by the user (RSC define beta<0, but "
-                                               "MOOSE only uses beta^2, so its sign is "
-                                               "irrelevant).  It has dimensions [time]");
+  params.addRequiredParam<Real>("scale_ratio",
+                                "This is porosity/permeability/beta^2, where beta "
+                                "may be chosen by the user (RSC define beta<0, but "
+                                "MOOSE only uses beta^2, so its sign is "
+                                "irrelevant).  It has dimensions [time]");
   params.addRequiredParam<Real>("shift", "effective saturation is a function of (Pc - shift)");
   params.addClassDescription("Rogers-Stallybrass-Clements version of effective saturation for the "
                              "water phase, valid for residual saturations = 0, and viscosityOil = "

--- a/modules/richards/src/userobjects/RichardsSeff2waterVG.C
+++ b/modules/richards/src/userobjects/RichardsSeff2waterVG.C
@@ -15,13 +15,17 @@ InputParameters
 validParams<RichardsSeff2waterVG>()
 {
   InputParameters params = validParams<RichardsSeff>();
-  params.addRequiredRangeCheckedParam<Real>("al", "al > 0", "van-Genuchten alpha parameter.  Must "
-                                                            "be positive.  Single-phase VG seff = "
-                                                            "(1 + (-al*c)^(1/(1-m)))^(-m)");
+  params.addRequiredRangeCheckedParam<Real>("al",
+                                            "al > 0",
+                                            "van-Genuchten alpha parameter.  Must "
+                                            "be positive.  Single-phase VG seff = "
+                                            "(1 + (-al*c)^(1/(1-m)))^(-m)");
   params.addRequiredRangeCheckedParam<Real>(
-      "m", "m > 0 & m < 1", "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
-                            "should be set to >0.5   Single-phase VG seff = (1 + "
-                            "(-al*p)^(1/(1-m)))^(-m)");
+      "m",
+      "m > 0 & m < 1",
+      "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
+      "should be set to >0.5   Single-phase VG seff = (1 + "
+      "(-al*p)^(1/(1-m)))^(-m)");
   params.addClassDescription("van-Genuchten effective saturation as a function of (Pwater, Pgas) "
                              "suitable for use for the water phase in two-phase simulations.  With "
                              "Pc=Pgas-Pwater,   seff = (1 + (al*pc)^(1/(1-m)))^(-m)");

--- a/modules/richards/src/userobjects/RichardsSeff2waterVGshifted.C
+++ b/modules/richards/src/userobjects/RichardsSeff2waterVGshifted.C
@@ -16,17 +16,23 @@ validParams<RichardsSeff2waterVGshifted>()
 {
   InputParameters params = validParams<RichardsSeff>();
   params.addRequiredRangeCheckedParam<Real>(
-      "al", "al > 0", "van-Genuchten alpha parameter.  Must be positive.   seff = (1 + "
-                      "(-al*(P0-P1-shift))^(1/(1-m)))^(-m) (then scaled to 0 to 1)");
+      "al",
+      "al > 0",
+      "van-Genuchten alpha parameter.  Must be positive.   seff = (1 + "
+      "(-al*(P0-P1-shift))^(1/(1-m)))^(-m) (then scaled to 0 to 1)");
   params.addRequiredRangeCheckedParam<Real>(
-      "m", "m > 0 & m < 1", "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
-                            "should be set to >0.5   seff = (1 + "
-                            "(-al*(P0-P1-shift)^(1/(1-m)))^(-m) (then scaled to 0 to 1)");
+      "m",
+      "m > 0 & m < 1",
+      "van-Genuchten m parameter.  Must be between 0 and 1, and optimally "
+      "should be set to >0.5   seff = (1 + "
+      "(-al*(P0-P1-shift)^(1/(1-m)))^(-m) (then scaled to 0 to 1)");
   params.addRequiredRangeCheckedParam<Real>(
-      "shift", "shift > 0", "Shift in capillary-pressure porepressure values.  Standard "
-                            "van-Genuchten Seff = Seff(Pwater-Pgas) is shifted to the right, and "
-                            "then scaled to 0<=Seff<=1.  This means that dS/dP>0 at S=1 which is "
-                            "useful to provide nonsingular Jacobians for small dt.");
+      "shift",
+      "shift > 0",
+      "Shift in capillary-pressure porepressure values.  Standard "
+      "van-Genuchten Seff = Seff(Pwater-Pgas) is shifted to the right, and "
+      "then scaled to 0<=Seff<=1.  This means that dS/dP>0 at S=1 which is "
+      "useful to provide nonsingular Jacobians for small dt.");
   params.addClassDescription("Shifted van-Genuchten effective saturation as a function of (Pwater, "
                              "Pgas) suitable for use for the water phase in two-phase simulations. "
                              "    seff = (1 + (-al*(P0-p1-shift))^(1/(1-m)))^(-m), then scaled so "

--- a/modules/solid_mechanics/src/kernels/HomogenizationKernel.C
+++ b/modules/solid_mechanics/src/kernels/HomogenizationKernel.C
@@ -13,14 +13,17 @@ InputParameters
 validParams<HomogenizationKernel>()
 {
   InputParameters params = validParams<Kernel>();
+  params.addRequiredRangeCheckedParam<unsigned int>("component",
+                                                    "component >= 0 & component < 3",
+                                                    "An integer corresponding to the direction "
+                                                    "the variable this kernel acts in. (0 for x, "
+                                                    "1 for y, 2 for z)");
   params.addRequiredRangeCheckedParam<unsigned int>(
-      "component", "component >= 0 & component < 3", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
-  params.addRequiredRangeCheckedParam<unsigned int>(
-      "column", "column >= 0 & column < 6", "An integer corresponding to the direction the "
-                                            "variable this kernel acts in. (0 for xx, 1 for yy, 2 "
-                                            "for zz, 3 for xy, 4 for yz, 5 for zx)");
+      "column",
+      "column >= 0 & column < 6",
+      "An integer corresponding to the direction the "
+      "variable this kernel acts in. (0 for xx, 1 for yy, 2 "
+      "for zz, 3 for xy, 4 for yz, 5 for zx)");
   params.addParam<std::string>(
       "appended_property_name", "", "Name appended to material properties to make them unique");
 

--- a/modules/solid_mechanics/src/kernels/StressDivergence.C
+++ b/modules/solid_mechanics/src/kernels/StressDivergence.C
@@ -19,9 +19,10 @@ InputParameters
 validParams<StressDivergence>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");

--- a/modules/solid_mechanics/src/kernels/StressDivergenceRSpherical.C
+++ b/modules/solid_mechanics/src/kernels/StressDivergenceRSpherical.C
@@ -14,9 +14,10 @@ InputParameters
 validParams<StressDivergenceRSpherical>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for r, "
-                                                     "1 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for r, "
+                                        "1 for z)");
   params.addCoupledVar("disp_r", "The r displacement");
   //  params.addCoupledVar("disp_z", "The z displacement");
   params.addCoupledVar("temp", "The temperature");

--- a/modules/solid_mechanics/src/kernels/StressDivergenceRZ.C
+++ b/modules/solid_mechanics/src/kernels/StressDivergenceRZ.C
@@ -18,9 +18,10 @@ InputParameters
 validParams<StressDivergenceRZ>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for r, "
-                                                     "1 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for r, "
+                                        "1 for z)");
   params.addCoupledVar("disp_r", "The r displacement");
   params.addCoupledVar("disp_z", "The z displacement");
   params.addCoupledVar("temp", "The temperature");

--- a/modules/solid_mechanics/src/materials/RateDepSmearCrackModel.C
+++ b/modules/solid_mechanics/src/materials/RateDepSmearCrackModel.C
@@ -24,9 +24,11 @@ validParams<RateDepSmearCrackModel>()
   params.addParam<bool>("input_random_scaling_var",
                         false,
                         "Flag to specify scaling parameter to generate random stress");
-  params.addParam<Real>("random_scaling_var", 1e9, "Scaling value: Too large a value can cause "
-                                                   "non-positive definiteness - use 0.1 of young's "
-                                                   "modulus");
+  params.addParam<Real>("random_scaling_var",
+                        1e9,
+                        "Scaling value: Too large a value can cause "
+                        "non-positive definiteness - use 0.1 of young's "
+                        "modulus");
 
   return params;
 }

--- a/modules/solid_mechanics/src/materials/SolidModel.C
+++ b/modules/solid_mechanics/src/materials/SolidModel.C
@@ -79,25 +79,31 @@ validParams<SolidModel>()
       "active_crack_planes", "Planes on which cracks are allowed (0,1,2 -> x,z,theta in RZ)");
   params.addParam<unsigned int>(
       "max_cracks", 3, "The maximum number of cracks allowed at a material point.");
-  params.addParam<Real>("cracking_neg_fraction", "The fraction of the cracking strain at which a "
-                                                 "transitition begins during decreasing strain to "
-                                                 "the original stiffness.");
+  params.addParam<Real>("cracking_neg_fraction",
+                        "The fraction of the cracking strain at which a "
+                        "transitition begins during decreasing strain to "
+                        "the original stiffness.");
   params.addParam<MooseEnum>("formulation",
                              formulation,
                              "Element formulation.  Choices are: " + formulation.getRawNames());
-  params.addParam<std::string>(
-      "increment_calculation", "RashidApprox", "The algorithm to use when computing the "
-                                               "incremental strain and rotation (RashidApprox or "
-                                               "Eigen). For use with Nonlinear3D/RZ formulation.");
-  params.addParam<bool>("large_strain", false, "Whether to include large strain terms in "
-                                               "AxisymmetricRZ, SphericalR, and PlaneStrain "
-                                               "formulations.");
+  params.addParam<std::string>("increment_calculation",
+                               "RashidApprox",
+                               "The algorithm to use when computing the "
+                               "incremental strain and rotation (RashidApprox or "
+                               "Eigen). For use with Nonlinear3D/RZ formulation.");
+  params.addParam<bool>("large_strain",
+                        false,
+                        "Whether to include large strain terms in "
+                        "AxisymmetricRZ, SphericalR, and PlaneStrain "
+                        "formulations.");
   params.addParam<bool>("compute_JIntegral", false, "Whether to compute the J Integral.");
   params.addParam<bool>(
       "compute_InteractionIntegral", false, "Whether to compute the Interaction Integral.");
-  params.addParam<bool>("store_stress_older", false, "Parameter which indicates whether the older "
-                                                     "stress state, required for HHT time "
-                                                     "integration, needs to be stored");
+  params.addParam<bool>("store_stress_older",
+                        false,
+                        "Parameter which indicates whether the older "
+                        "stress state, required for HHT time "
+                        "integration, needs to be stored");
   params.addCoupledVar("disp_r", "The r displacement");
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");

--- a/modules/solid_mechanics/src/materials/abaqus/AbaqusCreepMaterial.C
+++ b/modules/solid_mechanics/src/materials/abaqus/AbaqusCreepMaterial.C
@@ -17,9 +17,10 @@ InputParameters
 validParams<AbaqusCreepMaterial>()
 {
   InputParameters params = validParams<SolidModel>();
-  params.addRequiredParam<FileName>("plugin", "The path to the compiled dynamic library for the "
-                                              "plugin you want to use (without -opt.plugin or "
-                                              "-dbg.plugin)");
+  params.addRequiredParam<FileName>("plugin",
+                                    "The path to the compiled dynamic library for the "
+                                    "plugin you want to use (without -opt.plugin or "
+                                    "-dbg.plugin)");
   params.addRequiredParam<Real>("youngs_modulus", "Young's Modulus");
   params.addRequiredParam<Real>("poissons_ratio", "Poissons Ratio");
   params.addRequiredParam<Real>("num_state_vars",
@@ -28,9 +29,11 @@ validParams<AbaqusCreepMaterial>()
       "integration_flag", "The creep integration method: Explicit = 0 and Implicit = 1");
   params.addRequiredParam<unsigned int>(
       "solve_definition", "Creep/Swell Explicit/Implicit Integration Definition to use: 1 - 5");
-  params.addParam<unsigned int>("routine_flag", 0, "The flag determining when the routine is "
-                                                   "called: Start of increment = 0 and End of "
-                                                   "Increment = 1");
+  params.addParam<unsigned int>("routine_flag",
+                                0,
+                                "The flag determining when the routine is "
+                                "called: Start of increment = 0 and End of "
+                                "Increment = 1");
   return params;
 }
 

--- a/modules/solid_mechanics/src/materials/total_strain/LinearGeneralAnisotropicMaterial.C
+++ b/modules/solid_mechanics/src/materials/total_strain/LinearGeneralAnisotropicMaterial.C
@@ -22,9 +22,10 @@ validParams<LinearGeneralAnisotropicMaterial>()
 {
   InputParameters params = validParams<SolidMechanicsMaterial>();
   params.addRequiredParam<std::vector<Real>>("C_matrix", "Stiffness tensor for matrix");
-  params.addRequiredParam<bool>("all_21", "True if all 21 independent values are given; else false "
-                                          "indicates only 9 values given (C11, C12, C13, C22, C23, "
-                                          "C33, C44, C55, C66.");
+  params.addRequiredParam<bool>("all_21",
+                                "True if all 21 independent values are given; else false "
+                                "indicates only 9 values given (C11, C12, C13, C22, C23, "
+                                "C33, C44, C55, C66.");
   params.addParam<Real>("euler_angle_1", 0.0, "Euler angle in direction 1");
   params.addParam<Real>("euler_angle_2", 0.0, "Euler angle in direction 2");
   params.addParam<Real>("euler_angle_3", 0.0, "Euler angle in direction 3");

--- a/modules/solid_mechanics/src/postprocessors/HomogenizedElasticConstants.C
+++ b/modules/solid_mechanics/src/postprocessors/HomogenizedElasticConstants.C
@@ -35,12 +35,14 @@ validParams<HomogenizedElasticConstants>()
   params.addCoupledVar("dz_zx", "solution in zx");
   params.addParam<std::string>(
       "appended_property_name", "", "Name appended to material properties to make them unique");
-  params.addRequiredParam<unsigned int>("column", "An integer corresponding to the direction the "
-                                                  "variable this kernel acts in. (0 for xx, 1 for "
-                                                  "yy, 2 for zz, 3 for xy, 4 for yz, 5 for zx)");
-  params.addRequiredParam<unsigned int>("row", "An integer corresponding to the direction the "
-                                               "variable this kernel acts in. (0 for xx, 1 for yy, "
-                                               "2 for zz, 3 for xy, 4 for yz, 5 for zx)");
+  params.addRequiredParam<unsigned int>("column",
+                                        "An integer corresponding to the direction the "
+                                        "variable this kernel acts in. (0 for xx, 1 for "
+                                        "yy, 2 for zz, 3 for xy, 4 for yz, 5 for zx)");
+  params.addRequiredParam<unsigned int>("row",
+                                        "An integer corresponding to the direction the "
+                                        "variable this kernel acts in. (0 for xx, 1 for yy, "
+                                        "2 for zz, 3 for xy, 4 for yz, 5 for zx)");
   return params;
 }
 

--- a/modules/solid_mechanics/src/postprocessors/InteractionIntegral.C
+++ b/modules/solid_mechanics/src/postprocessors/InteractionIntegral.C
@@ -18,8 +18,9 @@ validParams<InteractionIntegral>()
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");
-  params.addCoupledVar("temp", "The temperature (optional). Must be provided to correctly compute "
-                               "stress intensity factors in models with thermal strain gradients.");
+  params.addCoupledVar("temp",
+                       "The temperature (optional). Must be provided to correctly compute "
+                       "stress intensity factors in models with thermal strain gradients.");
   params.addRequiredParam<UserObjectName>("crack_front_definition",
                                           "The CrackFrontDefinition user object name");
   params.addParam<unsigned int>(
@@ -27,9 +28,10 @@ validParams<InteractionIntegral>()
       "The index of the point on the crack front corresponding to this q function");
   params.addParam<Real>(
       "K_factor", "Conversion factor between interaction integral and stress intensity factor K");
-  params.addParam<unsigned int>("symmetry_plane", "Account for a symmetry plane passing through "
-                                                  "the plane of the crack, normal to the specified "
-                                                  "axis (0=x, 1=y, 2=z)");
+  params.addParam<unsigned int>("symmetry_plane",
+                                "Account for a symmetry plane passing through "
+                                "the plane of the crack, normal to the specified "
+                                "axis (0=x, 1=y, 2=z)");
   params.addParam<bool>("t_stress", false, "Calculate T-stress");
   params.addParam<Real>("poissons_ratio", "Poisson's ratio for the material.");
   params.set<bool>("use_displaced_mesh") = false;

--- a/modules/solid_mechanics/src/postprocessors/JIntegral.C
+++ b/modules/solid_mechanics/src/postprocessors/JIntegral.C
@@ -21,9 +21,10 @@ validParams<JIntegral>()
       "The index of the point on the crack front corresponding to this q function");
   params.addParam<bool>(
       "convert_J_to_K", false, "Convert J-integral to stress intensity factor K.");
-  params.addParam<unsigned int>("symmetry_plane", "Account for a symmetry plane passing through "
-                                                  "the plane of the crack, normal to the specified "
-                                                  "axis (0=x, 1=y, 2=z)");
+  params.addParam<unsigned int>("symmetry_plane",
+                                "Account for a symmetry plane passing through "
+                                "the plane of the crack, normal to the specified "
+                                "axis (0=x, 1=y, 2=z)");
   params.addParam<Real>("poissons_ratio", "Poisson's ratio");
   params.addParam<Real>("youngs_modulus", "Young's modulus of the material.");
   params.set<bool>("use_displaced_mesh") = false;

--- a/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/solid_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -57,9 +57,10 @@ addCrackFrontDefinitionParams(InputParameters & params)
       2,
       "axis_2d>=0 & axis_2d<=2",
       "Out of plane axis for models treated as two-dimensional (0=x, 1=y, 2=z)");
-  params.addParam<unsigned int>("symmetry_plane", "Account for a symmetry plane passing through "
-                                                  "the plane of the crack, normal to the specified "
-                                                  "axis (0=x, 1=y, 2=z)");
+  params.addParam<unsigned int>("symmetry_plane",
+                                "Account for a symmetry plane passing through "
+                                "the plane of the crack, normal to the specified "
+                                "axis (0=x, 1=y, 2=z)");
   params.addParam<bool>("t_stress", false, "Calculate T-stress");
   params.addParam<bool>("q_function_rings", false, "Generate rings of nodes for q-function");
   params.addParam<unsigned int>("last_ring", "The number of rings of nodes to generate");

--- a/modules/tensor_mechanics/src/actions/DynamicTensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/DynamicTensorMechanicsAction.C
@@ -15,14 +15,18 @@ validParams<DynamicTensorMechanicsAction>()
 {
   InputParameters params = validParams<TensorMechanicsAction>();
   params.addClassDescription("Set up dynamic stress divergence kernels");
-  params.addParam<MaterialPropertyName>("zeta", 0.0, "Name of material property or a constant real "
-                                                     "number defining the zeta parameter for the "
-                                                     "Rayleigh damping.");
+  params.addParam<MaterialPropertyName>("zeta",
+                                        0.0,
+                                        "Name of material property or a constant real "
+                                        "number defining the zeta parameter for the "
+                                        "Rayleigh damping.");
   params.addParam<Real>("alpha", 0, "alpha parameter for HHT time integration");
-  params.addParam<bool>("static_initialization", false, "Set to true get the system to "
-                                                        "equillibrium under gravity by running a "
-                                                        "quasi-static analysis (by solving Ku = F) "
-                                                        "in the first time step.");
+  params.addParam<bool>("static_initialization",
+                        false,
+                        "Set to true get the system to "
+                        "equillibrium under gravity by running a "
+                        "quasi-static analysis (by solving Ku = F) "
+                        "in the first time step.");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/actions/GeneralizedPlaneStrainAction.C
+++ b/modules/tensor_mechanics/src/actions/GeneralizedPlaneStrainAction.C
@@ -23,16 +23,19 @@ validParams<GeneralizedPlaneStrainAction>()
                                                  "y direction for 1D Axisymmetric or in z "
                                                  "direction for 2D Cartesian problems)");
   params.addParam<NonlinearVariableName>("temperature", "The temperature variable");
-  params.addParam<FunctionName>("out_of_plane_pressure", "0", "Function used to prescribe pressure "
-                                                              "in the out-of-plane direction (y "
-                                                              "for 1D Axisymmetric or z for 2D "
-                                                              "Cartesian problems)");
+  params.addParam<FunctionName>("out_of_plane_pressure",
+                                "0",
+                                "Function used to prescribe pressure "
+                                "in the out-of-plane direction (y "
+                                "for 1D Axisymmetric or z for 2D "
+                                "Cartesian problems)");
   params.addParam<Real>("factor", 1.0, "Scale factor applied to prescribed pressure");
   params.addParam<bool>("use_displaced_mesh", false, "Whether to use displaced mesh");
   params.addParam<std::string>("base_name", "Material property base name");
-  params.addParam<std::vector<SubdomainName>>("block", "The list of ids of the blocks (subdomain) "
-                                                       "that the GeneralizedPlaneStrain kernels "
-                                                       "will be applied to");
+  params.addParam<std::vector<SubdomainName>>("block",
+                                              "The list of ids of the blocks (subdomain) "
+                                              "that the GeneralizedPlaneStrain kernels "
+                                              "will be applied to");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/auxkernels/RankTwoScalarAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/RankTwoScalarAux.C
@@ -19,9 +19,10 @@ validParams<RankTwoScalarAux>()
   params.addParam<MooseEnum>(
       "scalar_type", RankTwoScalarTools::scalarOptions(), "Type of scalar output");
   params.addParam<unsigned int>(
-      "selected_qp", "Evaluate the tensor at this quadpoint.  This option only needs to be used if "
-                     "you are interested in a particular quadpoint in each element: otherwise do "
-                     "not include this parameter in your input file");
+      "selected_qp",
+      "Evaluate the tensor at this quadpoint.  This option only needs to be used if "
+      "you are interested in a particular quadpoint in each element: otherwise do "
+      "not include this parameter in your input file");
   params.addParamNamesToGroup("selected_qp", "Advanced");
 
   params.addParam<Point>(

--- a/modules/tensor_mechanics/src/kernels/DynamicStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/DynamicStressDivergenceTensors.C
@@ -14,14 +14,18 @@ validParams<DynamicStressDivergenceTensors>()
   InputParameters params = validParams<StressDivergenceTensors>();
   params.addClassDescription(
       "Residual due to stress related Rayleigh damping and HHT time integration terms ");
-  params.addParam<MaterialPropertyName>("zeta", 0.0, "Name of material property or a constant real "
-                                                     "number defining the zeta parameter for the "
-                                                     "Rayleigh damping.");
+  params.addParam<MaterialPropertyName>("zeta",
+                                        0.0,
+                                        "Name of material property or a constant real "
+                                        "number defining the zeta parameter for the "
+                                        "Rayleigh damping.");
   params.addParam<Real>("alpha", 0, "alpha parameter for HHT time integration");
-  params.addParam<bool>("static_initialization", false, "Set to true to get the system to "
-                                                        "equillibrium under gravity by running a "
-                                                        "quasi-static analysis (by solving Ku = F) "
-                                                        "in the first time step");
+  params.addParam<bool>("static_initialization",
+                        false,
+                        "Set to true to get the system to "
+                        "equillibrium under gravity by running a "
+                        "quasi-static analysis (by solving Ku = F) "
+                        "in the first time step");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/kernels/InertialForce.C
+++ b/modules/tensor_mechanics/src/kernels/InertialForce.C
@@ -20,11 +20,15 @@ validParams<InertialForce>()
   params.addRequiredCoupledVar("acceleration", "acceleration variable");
   params.addRequiredParam<Real>("beta", "beta parameter for Newmark Time integration");
   params.addRequiredParam<Real>("gamma", "gamma parameter for Newmark Time integration");
-  params.addParam<MaterialPropertyName>("eta", 0.0, "Name of material property or a constant real "
-                                                    "number defining the eta parameter for the "
-                                                    "Rayleigh damping.");
-  params.addParam<Real>("alpha", 0, "alpha parameter for mass dependent numerical damping induced "
-                                    "by HHT time integration scheme");
+  params.addParam<MaterialPropertyName>("eta",
+                                        0.0,
+                                        "Name of material property or a constant real "
+                                        "number defining the eta parameter for the "
+                                        "Rayleigh damping.");
+  params.addParam<Real>("alpha",
+                        0,
+                        "alpha parameter for mass dependent numerical damping induced "
+                        "by HHT time integration scheme");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/kernels/MomentBalancing.C
+++ b/modules/tensor_mechanics/src/kernels/MomentBalancing.C
@@ -17,8 +17,10 @@ validParams<MomentBalancing>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredRangeCheckedParam<unsigned int>(
-      "component", "component<3", "An integer corresponding to the direction the variable this "
-                                  "kernel acts in. (0 for x, 1 for y, 2 for z)");
+      "component",
+      "component<3",
+      "An integer corresponding to the direction the variable this "
+      "kernel acts in. (0 for x, 1 for y, 2 for z)");
   params.addParam<std::string>(
       "appended_property_name", "", "Name appended to material properties to make them unique");
   params.addRequiredCoupledVar("Cosserat_rotations", "The 3 Cosserat rotation variables");

--- a/modules/tensor_mechanics/src/kernels/PhaseFieldFractureMechanicsOffDiag.C
+++ b/modules/tensor_mechanics/src/kernels/PhaseFieldFractureMechanicsOffDiag.C
@@ -16,9 +16,10 @@ validParams<PhaseFieldFractureMechanicsOffDiag>()
                              "diagonal damage dependent Jacobian components. To be used with "
                              "StressDivergenceTensors or DynamicStressDivergenceTensors.");
   params.addParam<std::string>("base_name", "Material property base name");
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addCoupledVar(
       "c",
       "Phase field damage variable: Used to indicate calculation of Off Diagonal Jacobian term");

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceRSphericalTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceRSphericalTensors.C
@@ -18,9 +18,10 @@ validParams<StressDivergenceRSphericalTensors>()
   params.addClassDescription(
       "Calculate stress divergence for an spherically symmetric 1D problem in polar coordinates.");
   params.addRequiredParam<unsigned int>(
-      "component", "An integer corresponding to the direction the variable this kernel acts in. (0 "
-                   "for x, 1 for y, 2 for z; note in this kernel disp_x refers to the radial "
-                   "displacement and disp_y refers to the axial displacement.)");
+      "component",
+      "An integer corresponding to the direction the variable this kernel acts in. (0 "
+      "for x, 1 for y, 2 for z; note in this kernel disp_x refers to the radial "
+      "displacement and disp_y refers to the axial displacement.)");
   params.set<bool>("use_displaced_mesh") = true;
   return params;
 }

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceRZTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceRZTensors.C
@@ -18,9 +18,10 @@ validParams<StressDivergenceRZTensors>()
   params.addClassDescription(
       "Calculate stress divergence for an axisymmetric problem in cylinderical coordinates.");
   params.addRequiredParam<unsigned int>(
-      "component", "An integer corresponding to the direction the variable this kernel acts in. (0 "
-                   "for x, 1 for y, 2 for z; note in this kernel disp_x refers to the radial "
-                   "displacement and disp_y refers to the axial displacement.)");
+      "component",
+      "An integer corresponding to the direction the variable this kernel acts in. (0 "
+      "for x, 1 for y, 2 for z; note in this kernel disp_x refers to the radial "
+      "displacement and disp_y refers to the axial displacement.)");
   params.set<bool>("use_displaced_mesh") = true;
   return params;
 }

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
@@ -17,9 +17,10 @@ validParams<StressDivergenceTensors>()
 {
   InputParameters params = validParams<ALEKernel>();
   params.addClassDescription("Stress divergence kernel for the Cartesian coordinate system");
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addRequiredCoupledVar("displacements",
                                "The string of displacements suitable for the problem statement");
   params.addCoupledVar("temp", "The temperature"); // Deprecated

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensorsTruss.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensorsTruss.C
@@ -17,9 +17,10 @@ validParams<StressDivergenceTensorsTruss>()
 {
   InputParameters params = validParams<Kernel>();
   params.addClassDescription("Kernel for truss element");
-  params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction "
-                                                     "the variable this kernel acts in. (0 for x, "
-                                                     "1 for y, 2 for z)");
+  params.addRequiredParam<unsigned int>("component",
+                                        "An integer corresponding to the direction "
+                                        "the variable this kernel acts in. (0 for x, "
+                                        "1 for y, 2 for z)");
   params.addCoupledVar("displacements",
                        "The string of displacements suitable for the problem statement");
   params.addCoupledVar("temp", "The temperature"); // Deprecated

--- a/modules/tensor_mechanics/src/materials/CompositeElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/CompositeElasticityTensor.C
@@ -13,9 +13,10 @@ validParams<CompositeElasticityTensor>()
   InputParameters params = CompositeTensorBase<RankFourTensor, Material>::validParams();
   params.addClassDescription("Assemble an elasticity tensor from multiple tensor contributions "
                              "weighted by material properties");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeCappedDruckerPragerStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCappedDruckerPragerStress.C
@@ -15,26 +15,35 @@ validParams<ComputeCappedDruckerPragerStress>()
   InputParameters params = validParams<PQPlasticModel>();
   params.addClassDescription("Capped Drucker-Prager plasticity stress calculator");
   params.addRequiredParam<UserObjectName>(
-      "DP_model", "A TensorMechanicsPlasticDruckerPrager UserObject that defines the "
-                  "Drucker-Prager parameters (cohesion, friction angle and dilation angle)");
+      "DP_model",
+      "A TensorMechanicsPlasticDruckerPrager UserObject that defines the "
+      "Drucker-Prager parameters (cohesion, friction angle and dilation angle)");
   params.addRequiredParam<UserObjectName>(
-      "tensile_strength", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                          "tensile strength.  In physical situations this is positive (and always "
-                          "must be greater than negative compressive-strength.");
+      "tensile_strength",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "tensile strength.  In physical situations this is positive (and always "
+      "must be greater than negative compressive-strength.");
   params.addRequiredParam<UserObjectName>(
-      "compressive_strength", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                              "compressive strength.  In physical situations this is positive.");
+      "compressive_strength",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "compressive strength.  In physical situations this is positive.");
   params.addRequiredRangeCheckedParam<Real>(
-      "tip_smoother", "tip_smoother>=0", "The cone vertex at J2 = 0 will be smoothed by the given "
-                                         "amount.  Typical value is 0.1*cohesion");
-  params.addParam<bool>("perfect_guess", true, "Provide a guess to the Newton-Raphson proceedure "
-                                               "that is the result from perfect plasticity.  With "
-                                               "severe hardening/softening this may be "
-                                               "suboptimal.");
-  params.addParam<bool>("small_dilation", true, "If true, and if the trial stress exceeds the "
-                                                "tensile strength, then the user gaurantees that "
-                                                "the returned stress will be independent of the "
-                                                "compressive strength.");
+      "tip_smoother",
+      "tip_smoother>=0",
+      "The cone vertex at J2 = 0 will be smoothed by the given "
+      "amount.  Typical value is 0.1*cohesion");
+  params.addParam<bool>("perfect_guess",
+                        true,
+                        "Provide a guess to the Newton-Raphson proceedure "
+                        "that is the result from perfect plasticity.  With "
+                        "severe hardening/softening this may be "
+                        "suboptimal.");
+  params.addParam<bool>("small_dilation",
+                        true,
+                        "If true, and if the trial stress exceeds the "
+                        "tensile strength, then the user gaurantees that "
+                        "the returned stress will be independent of the "
+                        "compressive strength.");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeCappedWeakPlaneStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCappedWeakPlaneStress.C
@@ -15,31 +15,38 @@ validParams<ComputeCappedWeakPlaneStress>()
   InputParameters params = validParams<PQPlasticModel>();
   params.addClassDescription("Capped weak-plane plasticity stress calculator");
   params.addRequiredParam<UserObjectName>(
-      "cohesion", "A TensorMechanicsHardening UserObject that defines hardening of the cohesion.  "
-                  "Physically the cohesion should not be negative.");
+      "cohesion",
+      "A TensorMechanicsHardening UserObject that defines hardening of the cohesion.  "
+      "Physically the cohesion should not be negative.");
   params.addRequiredParam<UserObjectName>("tan_friction_angle",
                                           "A TensorMechanicsHardening UserObject that defines "
                                           "hardening of tan(friction angle).  Physically the "
                                           "friction angle should be between 0 and 90deg.");
   params.addRequiredParam<UserObjectName>(
-      "tan_dilation_angle", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                            "tan(dilation angle).  Usually the dilation angle is not greater than "
-                            "the friction angle, and it is between 0 and 90deg.");
+      "tan_dilation_angle",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "tan(dilation angle).  Usually the dilation angle is not greater than "
+      "the friction angle, and it is between 0 and 90deg.");
   params.addRequiredParam<UserObjectName>(
-      "tensile_strength", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                          "weak-plane tensile strength.  In physical situations this is positive "
-                          "(and always must be greater than negative compressive-strength.");
+      "tensile_strength",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "weak-plane tensile strength.  In physical situations this is positive "
+      "(and always must be greater than negative compressive-strength.");
   params.addRequiredParam<UserObjectName>("compressive_strength",
                                           "A TensorMechanicsHardening UserObject that defines "
                                           "hardening of the weak-plane compressive strength.  In "
                                           "physical situations this is positive.");
   params.addRequiredRangeCheckedParam<Real>(
-      "tip_smoother", "tip_smoother>=0", "The cone vertex at shear-stress = 0 will be smoothed by "
-                                         "the given amount.  Typical value is 0.1*cohesion");
-  params.addParam<bool>("perfect_guess", true, "Provide a guess to the Newton-Raphson proceedure "
-                                               "that is the result from perfect plasticity.  With "
-                                               "severe hardening/softening this may be "
-                                               "suboptimal.");
+      "tip_smoother",
+      "tip_smoother>=0",
+      "The cone vertex at shear-stress = 0 will be smoothed by "
+      "the given amount.  Typical value is 0.1*cohesion");
+  params.addParam<bool>("perfect_guess",
+                        true,
+                        "Provide a guess to the Newton-Raphson proceedure "
+                        "that is the result from perfect plasticity.  With "
+                        "severe hardening/softening this may be "
+                        "suboptimal.");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeEigenstrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeEigenstrainBase.C
@@ -13,9 +13,10 @@ InputParameters
 validParams<ComputeEigenstrainBase>()
 {
   InputParameters params = validParams<Material>();
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   params.addRequiredParam<std::string>("eigenstrain_name",
                                        "Material property name for the eigenstrain tensor computed "
                                        "by this model. IMPORTANT: The name of this property must "

--- a/modules/tensor_mechanics/src/materials/ComputeElasticSmearedCrackingStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticSmearedCrackingStress.C
@@ -27,9 +27,11 @@ validParams<ComputeElasticSmearedCrackingStress>()
       "active_crack_planes", "Planes on which cracks are allowed (0,1,2 -> x,z,theta in RZ)");
   params.addParam<unsigned int>(
       "max_cracks", 3, "The maximum number of cracks allowed at a material point.");
-  params.addParam<Real>("cracking_neg_fraction", 0, "The fraction of the cracking strain at which "
-                                                    "a transitition begins during decreasing "
-                                                    "strain to the original stiffness.");
+  params.addParam<Real>("cracking_neg_fraction",
+                        0,
+                        "The fraction of the cracking strain at which "
+                        "a transitition begins during decreasing "
+                        "strain to the original stiffness.");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTensorBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTensorBase.C
@@ -16,9 +16,10 @@ validParams<ComputeElasticityTensorBase>()
   params.addParam<FunctionName>(
       "elasticity_tensor_prefactor",
       "Optional function to use as a scalar prefactor on the elasticity tensor.");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTensorCP.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTensorCP.C
@@ -13,9 +13,10 @@ validParams<ComputeElasticityTensorCP>()
 {
   InputParameters params = validParams<ComputeElasticityTensor>();
   params.addClassDescription("Compute an elasticity tensor for crystal plasticity.");
-  params.addParam<UserObjectName>("read_prop_user_object", "The ElementReadPropertyFile "
-                                                           "GeneralUserObject to read element "
-                                                           "specific property values from file");
+  params.addParam<UserObjectName>("read_prop_user_object",
+                                  "The ElementReadPropertyFile "
+                                  "GeneralUserObject to read element "
+                                  "specific property values from file");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeExtraStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeExtraStressBase.C
@@ -11,9 +11,10 @@ InputParameters
 validParams<ComputeExtraStressBase>()
 {
   InputParameters params = validParams<Material>();
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
@@ -24,9 +24,10 @@ validParams<ComputeMultiPlasticityStress>()
                                             20,
                                             "max_NR_iterations>0",
                                             "Maximum number of Newton-Raphson iterations allowed");
-  params.addRequiredParam<Real>("ep_plastic_tolerance", "The Newton-Raphson process is only deemed "
-                                                        "converged if the plastic strain increment "
-                                                        "constraints have L2 norm less than this.");
+  params.addRequiredParam<Real>("ep_plastic_tolerance",
+                                "The Newton-Raphson process is only deemed "
+                                "converged if the plastic strain increment "
+                                "constraints have L2 norm less than this.");
   params.addRangeCheckedParam<Real>(
       "min_stepsize",
       0.01,
@@ -54,19 +55,21 @@ validParams<ComputeMultiPlasticityStress>()
       "constraints until the solution is found.  You may specify fall-back options.  Eg "
       "optimized_to_safe: first use 'optimized', and if that fails, try the return with 'safe'.");
   params.addParam<RealVectorValue>(
-      "transverse_direction", "If this parameter is provided, before the return-map algorithm is "
-                              "called a rotation is performed so that the 'z' axis in the new "
-                              "frame lies along the transverse_direction in the original frame.  "
-                              "After returning, the inverse rotation is performed.  The "
-                              "transverse_direction will itself rotate with large strains.  This "
-                              "is so that transversely-isotropic plasticity models may be easily "
-                              "defined in the frame where the isotropy holds in the x-y plane.");
-  params.addParam<bool>(
-      "ignore_failures", false, "The return-map algorithm will return with the best admissible "
-                                "stresses and internal parameters that it can, even if they don't "
-                                "fully correspond to the applied strain increment.  To speed "
-                                "computations, this flag can be set to true, the max_NR_iterations "
-                                "set small, and the min_stepsize large.");
+      "transverse_direction",
+      "If this parameter is provided, before the return-map algorithm is "
+      "called a rotation is performed so that the 'z' axis in the new "
+      "frame lies along the transverse_direction in the original frame.  "
+      "After returning, the inverse rotation is performed.  The "
+      "transverse_direction will itself rotate with large strains.  This "
+      "is so that transversely-isotropic plasticity models may be easily "
+      "defined in the frame where the isotropy holds in the x-y plane.");
+  params.addParam<bool>("ignore_failures",
+                        false,
+                        "The return-map algorithm will return with the best admissible "
+                        "stresses and internal parameters that it can, even if they don't "
+                        "fully correspond to the applied strain increment.  To speed "
+                        "computations, this flag can be set to true, the max_NR_iterations "
+                        "set small, and the min_stepsize large.");
   MooseEnum tangent_operator("elastic linear nonlinear", "nonlinear");
   params.addParam<MooseEnum>("tangent_operator",
                              tangent_operator,
@@ -76,11 +79,13 @@ validParams<ComputeMultiPlasticityStress>()
                              "stress.  'nonlinear': return the full, general consistent tangent "
                              "operator.  The calculations assume the hardening potentials are "
                              "independent of stress and hardening parameters.");
-  params.addParam<bool>("perform_finite_strain_rotations", true, "Tensors are correctly rotated in "
-                                                                 "finite-strain simulations.  For "
-                                                                 "optimal performance you can set "
-                                                                 "this to 'false' if you are only "
-                                                                 "ever using small strains");
+  params.addParam<bool>("perform_finite_strain_rotations",
+                        true,
+                        "Tensors are correctly rotated in "
+                        "finite-strain simulations.  For "
+                        "optimal performance you can set "
+                        "this to 'false' if you are only "
+                        "ever using small strains");
   params.addClassDescription("Material for multi-surface finite-strain plasticity");
   return params;
 }

--- a/modules/tensor_mechanics/src/materials/ComputePlasticHeatEnergy.C
+++ b/modules/tensor_mechanics/src/materials/ComputePlasticHeatEnergy.C
@@ -12,9 +12,10 @@ InputParameters
 validParams<ComputePlasticHeatEnergy>()
 {
   InputParameters params = validParams<Material>();
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   params.addClassDescription("Plastic heat energy density = stress * plastic_strain_rate");
   return params;
 }

--- a/modules/tensor_mechanics/src/materials/ComputeReturnMappingStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeReturnMappingStress.C
@@ -15,22 +15,29 @@ validParams<ComputeReturnMappingStress>()
   InputParameters params = validParams<ComputeFiniteStrainElasticStress>();
   params.addClassDescription("Compute stress using a radial return mapping implementation for "
                              "creep or creep combined with plasticity");
-  params.addParam<unsigned int>("max_iterations", 30, "Maximum number of the stress update "
-                                                      "iterations over the stress change after all "
-                                                      "update materials are called");
-  params.addParam<Real>("relative_tolerance", 1e-5, "Relative convergence tolerance for the stress "
-                                                    "update iterations over the stress change "
-                                                    "after all update materials are called");
-  params.addParam<Real>("absolute_tolerance", 1e-5, "Absolute convergence tolerance for the stress "
-                                                    "update iterations over the stress change "
-                                                    "after all update materials are called");
+  params.addParam<unsigned int>("max_iterations",
+                                30,
+                                "Maximum number of the stress update "
+                                "iterations over the stress change after all "
+                                "update materials are called");
+  params.addParam<Real>("relative_tolerance",
+                        1e-5,
+                        "Relative convergence tolerance for the stress "
+                        "update iterations over the stress change "
+                        "after all update materials are called");
+  params.addParam<Real>("absolute_tolerance",
+                        1e-5,
+                        "Absolute convergence tolerance for the stress "
+                        "update iterations over the stress change "
+                        "after all update materials are called");
   params.addParam<bool>(
       "output_iteration_info",
       false,
       "Set to true to output stress update iteration information over the stress change");
   params.addRequiredParam<std::vector<MaterialName>>(
-      "return_mapping_models", "The material objects to use to calculate stress. Note: specify "
-                               "creep models first and plasticity models second.");
+      "return_mapping_models",
+      "The material objects to use to calculate stress. Note: specify "
+      "creep models first and plasticity models second.");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
@@ -17,9 +17,10 @@ validParams<ComputeStrainBase>()
   params.addRequiredCoupledVar(
       "displacements",
       "The displacements appropriate for the simulation geometry and coordinate system");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   params.addParam<bool>(
       "volumetric_locking_correction", false, "Flag to correct volumetric locking");
   params.addParam<std::vector<MaterialPropertyName>>(

--- a/modules/tensor_mechanics/src/materials/ComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStressBase.C
@@ -14,17 +14,21 @@ validParams<ComputeStressBase>()
 {
   InputParameters params = validParams<Material>();
   params.addParam<std::vector<FunctionName>>(
-      "initial_stress", "A list of functions describing the initial stress.  If provided, there "
-                        "must be 9 of these, corresponding to the xx, yx, zx, xy, yy, zy, xz, yz, "
-                        "zz components respectively.  If not provided, all components of the "
-                        "initial stress will be zero");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
-  params.addParam<bool>("store_stress_old", false, "Parameter which indicates whether the old "
-                                                   "stress state, required for the HHT time "
-                                                   "integration scheme and Rayleigh damping, needs "
-                                                   "to be stored");
+      "initial_stress",
+      "A list of functions describing the initial stress.  If provided, there "
+      "must be 9 of these, corresponding to the xx, yx, zx, xy, yy, zy, xz, yz, "
+      "zz components respectively.  If not provided, all components of the "
+      "initial stress will be zero");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
+  params.addParam<bool>("store_stress_old",
+                        false,
+                        "Parameter which indicates whether the old "
+                        "stress state, required for the HHT time "
+                        "integration scheme and Rayleigh damping, needs "
+                        "to be stored");
   params.suppressParameter<bool>("use_displaced_mesh");
   return params;
 }

--- a/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainCrystalPlasticity.C
@@ -44,9 +44,10 @@ validParams<FiniteStrainCrystalPlasticity>()
       "num_slip_sys_flowrate_props",
       2,
       "Number of flow rate properties for a slip system"); // Used for reading flow rate parameters
-  params.addParam<UserObjectName>("read_prop_user_object", "The ElementReadPropertyFile "
-                                                           "GeneralUserObject to read element "
-                                                           "specific property values from file");
+  params.addParam<UserObjectName>("read_prop_user_object",
+                                  "The ElementReadPropertyFile "
+                                  "GeneralUserObject to read element "
+                                  "specific property values from file");
   MooseEnum tan_mod_options("exact none", "none"); // Type of read
   params.addParam<MooseEnum>("tan_mod_type",
                              tan_mod_options,
@@ -56,9 +57,10 @@ validParams<FiniteStrainCrystalPlasticity>()
       "intvar_read_type",
       intvar_read_options,
       "Read from options for initial value of internal variables: Default from .i file");
-  params.addParam<unsigned int>(
-      "num_slip_sys_props", 0, "Number of slip system specific properties provided in the file "
-                               "containing slip system normals and directions");
+  params.addParam<unsigned int>("num_slip_sys_props",
+                                0,
+                                "Number of slip system specific properties provided in the file "
+                                "containing slip system normals and directions");
   params.addParam<bool>(
       "gen_random_stress_flag",
       false,

--- a/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainPlasticMaterial.C
@@ -14,8 +14,9 @@ validParams<FiniteStrainPlasticMaterial>()
   InputParameters params = validParams<ComputeStressBase>();
 
   params.addRequiredParam<std::vector<Real>>(
-      "yield_stress", "Input data as pairs of equivalent plastic strain and yield stress: Should "
-                      "start with equivalent plastic strain 0");
+      "yield_stress",
+      "Input data as pairs of equivalent plastic strain and yield stress: Should "
+      "start with equivalent plastic strain 0");
   params.addParam<Real>("rtol", 1e-8, "Plastic strain NR tolerance");
   params.addParam<Real>("ftol", 1e-4, "Consistency condition NR tolerance");
   params.addParam<Real>("eptol", 1e-7, "Equivalent plastic strain NR tolerance");

--- a/modules/tensor_mechanics/src/materials/FiniteStrainUObasedCP.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainUObasedCP.C
@@ -52,8 +52,9 @@ validParams<FiniteStrainUObasedCP>()
       "uo_state_vars",
       "List of names of user objects that define the state variable for this material.");
   params.addRequiredParam<std::vector<UserObjectName>>(
-      "uo_state_var_evol_rate_comps", "List of names of user objects that define the state "
-                                      "variable evolution rate components for this material.");
+      "uo_state_var_evol_rate_comps",
+      "List of names of user objects that define the state "
+      "variable evolution rate components for this material.");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/PQPlasticModel.C
+++ b/modules/tensor_mechanics/src/materials/PQPlasticModel.C
@@ -20,18 +20,21 @@ validParams<PQPlasticModel>()
       20,
       "max_NR_iterations>0",
       "Maximum number of Newton-Raphson iterations allowed during the return-map algorithm");
-  params.addParam<bool>("perform_finite_strain_rotations", false, "Tensors are correctly rotated "
-                                                                  "in finite-strain simulations.  "
-                                                                  "For optimal performance you can "
-                                                                  "set this to 'false' if you are "
-                                                                  "only ever using small strains");
+  params.addParam<bool>("perform_finite_strain_rotations",
+                        false,
+                        "Tensors are correctly rotated "
+                        "in finite-strain simulations.  "
+                        "For optimal performance you can "
+                        "set this to 'false' if you are "
+                        "only ever using small strains");
   params.addRequiredParam<Real>(
-      "smoothing_tol", "Intersections of the yield surfaces will be smoothed by this amount (this "
-                       "is measured in units of stress).  Often this is related to other physical "
-                       "parameters (eg, 0.1*cohesion) but it is important to set this small enough "
-                       "so that the individual yield surfaces do not mix together in the smoothing "
-                       "process to produce a result where no stress is admissible (for example, "
-                       "mixing together tensile and compressive failure envelopes).");
+      "smoothing_tol",
+      "Intersections of the yield surfaces will be smoothed by this amount (this "
+      "is measured in units of stress).  Often this is related to other physical "
+      "parameters (eg, 0.1*cohesion) but it is important to set this small enough "
+      "so that the individual yield surfaces do not mix together in the smoothing "
+      "process to produce a result where no stress is admissible (for example, "
+      "mixing together tensile and compressive failure envelopes).");
   params.addRequiredParam<Real>("yield_function_tol",
                                 "The return-map process will be deemed to have converged if all "
                                 "yield functions are within yield_function_tol of zero.  If this "
@@ -39,18 +42,22 @@ validParams<PQPlasticModel>()
                                 "code detects precision loss then it also deems the return-map "
                                 "process has converged.");
   MooseEnum tangent_operator("elastic nonlinear", "nonlinear");
-  params.addParam<MooseEnum>(
-      "tangent_operator", tangent_operator, "Type of tangent operator to return.  'elastic': "
-                                            "return the elasticity tensor.  'nonlinear': return "
-                                            "the full consistent tangent operator.");
-  params.addParam<Real>(
-      "min_step_size", 1.0, "In order to help the Newton-Raphson procedure, the applied strain "
-                            "increment may be applied in sub-increments of size greater than this "
-                            "value.  Usually it is better for Moose's nonlinear convergence to "
-                            "increase max_NR_iterations rather than decrease this parameter.");
-  params.addParam<bool>("warn_about_precision_loss", false, "Output a message to the console every "
-                                                            "time precision-loss is encountered "
-                                                            "during the Newton-Raphson process");
+  params.addParam<MooseEnum>("tangent_operator",
+                             tangent_operator,
+                             "Type of tangent operator to return.  'elastic': "
+                             "return the elasticity tensor.  'nonlinear': return "
+                             "the full consistent tangent operator.");
+  params.addParam<Real>("min_step_size",
+                        1.0,
+                        "In order to help the Newton-Raphson procedure, the applied strain "
+                        "increment may be applied in sub-increments of size greater than this "
+                        "value.  Usually it is better for Moose's nonlinear convergence to "
+                        "increase max_NR_iterations rather than decrease this parameter.");
+  params.addParam<bool>("warn_about_precision_loss",
+                        false,
+                        "Output a message to the console every "
+                        "time precision-loss is encountered "
+                        "during the Newton-Raphson process");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/materials/StressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/StressUpdateBase.C
@@ -17,9 +17,10 @@ validParams<StressUpdateBase>()
                              "return the isotropic stress state to a J2 yield surface.  This class "
                              "is intended to be a parent class for classes with specific "
                              "constitutive models.");
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   // The return stress increment classes are intended to be iterative materials, so must set compute
   // = false for all inheriting classes
   params.set<bool>("compute") = false;

--- a/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TensorMechanicsMaterial.C
@@ -29,10 +29,11 @@ validParams<TensorMechanicsMaterial>()
   params.addCoupledVar("disp_z", "The z displacement");
   params.addCoupledVar("temperature", "temperature variable");
   params.addParam<std::vector<FunctionName>>(
-      "initial_stress", "A list of functions describing the initial stress.  If provided, there "
-                        "must be 9 of these, corresponding to the xx, yx, zx, xy, yy, zy, xz, yz, "
-                        "zz components respectively.  If not provided, all components of the "
-                        "initial stress will be zero");
+      "initial_stress",
+      "A list of functions describing the initial stress.  If provided, there "
+      "must be 9 of these, corresponding to the xx, yx, zx, xy, yy, zy, xz, yz, "
+      "zz components respectively.  If not provided, all components of the "
+      "initial stress will be zero");
   params.addParam<FunctionName>(
       "elasticity_tensor_prefactor",
       "Optional function to use as a scalar prefactor on the elasticity tensor.");

--- a/modules/tensor_mechanics/src/materials/TrussMaterial.C
+++ b/modules/tensor_mechanics/src/materials/TrussMaterial.C
@@ -18,9 +18,10 @@ InputParameters
 validParams<TrussMaterial>()
 {
   InputParameters params = validParams<Material>();
-  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define "
-                                            "multiple mechanics material systems on the same "
-                                            "block, i.e. for multiple phases");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
   params.addRequiredParam<std::vector<NonlinearVariableName>>(
       "displacements",
       "The displacements appropriate for the simulation geometry and coordinate system");

--- a/modules/tensor_mechanics/src/postprocessors/TorqueReaction.C
+++ b/modules/tensor_mechanics/src/postprocessors/TorqueReaction.C
@@ -17,9 +17,10 @@ validParams<TorqueReaction>()
   params.addRequiredParam<std::vector<AuxVariableName>>("react", "The reaction variables");
   params.addParam<RealVectorValue>(
       "axis_origin", Point(), "Origin of the axis of rotation used to calculate the torque");
-  params.addRequiredParam<RealVectorValue>("direction_vector", "The direction vector of the axis "
-                                                               "of rotation about which the "
-                                                               "calculated torque is calculated");
+  params.addRequiredParam<RealVectorValue>("direction_vector",
+                                           "The direction vector of the axis "
+                                           "of rotation about which the "
+                                           "calculated torque is calculated");
   params.set<bool>("use_displaced_mesh") = true;
   return params;
 }

--- a/modules/tensor_mechanics/src/userobjects/CrystalPlasticitySlipRate.C
+++ b/modules/tensor_mechanics/src/userobjects/CrystalPlasticitySlipRate.C
@@ -12,9 +12,10 @@ InputParameters
 validParams<CrystalPlasticitySlipRate>()
 {
   InputParameters params = validParams<CrystalPlasticityUOBase>();
-  params.addParam<unsigned int>(
-      "num_slip_sys_props", 0, "Number of slip system specific properties provided in the file "
-                               "containing slip system normals and directions");
+  params.addParam<unsigned int>("num_slip_sys_props",
+                                0,
+                                "Number of slip system specific properties provided in the file "
+                                "containing slip system normals and directions");
   params.addParam<std::vector<Real>>("flowprops", "Parameters used in slip rate equations");
   params.addRequiredParam<FileName>("slip_sys_file_name",
                                     "Name of the file containing the slip system");

--- a/modules/tensor_mechanics/src/userobjects/CrystalPlasticitySlipRateGSS.C
+++ b/modules/tensor_mechanics/src/userobjects/CrystalPlasticitySlipRateGSS.C
@@ -11,9 +11,10 @@ InputParameters
 validParams<CrystalPlasticitySlipRateGSS>()
 {
   InputParameters params = validParams<CrystalPlasticitySlipRate>();
-  params.addParam<std::string>("uo_state_var_name", "Name of state variable property: Same as "
-                                                    "state variable user object specified in input "
-                                                    "file.");
+  params.addParam<std::string>("uo_state_var_name",
+                               "Name of state variable property: Same as "
+                               "state variable user object specified in input "
+                               "file.");
   params.addClassDescription("Phenomenological constitutive model slip rate class.  Override the "
                              "virtual functions in your class");
   return params;

--- a/modules/tensor_mechanics/src/userobjects/CrystalPlasticitySlipResistanceGSS.C
+++ b/modules/tensor_mechanics/src/userobjects/CrystalPlasticitySlipResistanceGSS.C
@@ -11,9 +11,10 @@ InputParameters
 validParams<CrystalPlasticitySlipResistanceGSS>()
 {
   InputParameters params = validParams<CrystalPlasticitySlipResistance>();
-  params.addParam<std::string>("uo_state_var_name", "Name of state variable property: Same as "
-                                                    "state variable user object specified in input "
-                                                    "file.");
+  params.addParam<std::string>("uo_state_var_name",
+                               "Name of state variable property: Same as "
+                               "state variable user object specified in input "
+                               "file.");
   params.addClassDescription("Phenomenological constitutive models' slip resistance base class.  "
                              "Override the virtual functions in your class");
   return params;

--- a/modules/tensor_mechanics/src/userobjects/CrystalPlasticityStateVarRateComponentGSS.C
+++ b/modules/tensor_mechanics/src/userobjects/CrystalPlasticityStateVarRateComponentGSS.C
@@ -14,9 +14,10 @@ validParams<CrystalPlasticityStateVarRateComponentGSS>()
   params.addParam<std::string>(
       "uo_slip_rate_name",
       "Name of slip rate property: Same as slip rate user object specified in input file.");
-  params.addParam<std::string>("uo_state_var_name", "Name of state variable property: Same as "
-                                                    "state variable user object specified in input "
-                                                    "file.");
+  params.addParam<std::string>("uo_state_var_name",
+                               "Name of state variable property: Same as "
+                               "state variable user object specified in input "
+                               "file.");
   params.addParam<FileName>(
       "slip_sys_hard_prop_file_name",
       "",

--- a/modules/tensor_mechanics/src/userobjects/CrystalPlasticityStateVariable.C
+++ b/modules/tensor_mechanics/src/userobjects/CrystalPlasticityStateVariable.C
@@ -20,12 +20,14 @@ validParams<CrystalPlasticityStateVariable>()
       "intvar_read_type",
       intvar_read_options,
       "Read from options for initial value of internal variables: Default from .i file");
-  params.addParam<std::vector<unsigned int>>("groups", "To group the initial values on different "
-                                                       "slip systems 'format: [start end)', i.e.'0 "
-                                                       "4 8 11' groups 0-3, 4-7 and 8-11 ");
-  params.addParam<std::vector<Real>>("group_values", "The initial values correspoinding to each "
-                                                     "group, i.e. '0.0 1.0 2.0' means 0-4 = 0.0, "
-                                                     "4-8 = 1.0 and 8-12 = 2.0 ");
+  params.addParam<std::vector<unsigned int>>("groups",
+                                             "To group the initial values on different "
+                                             "slip systems 'format: [start end)', i.e.'0 "
+                                             "4 8 11' groups 0-3, 4-7 and 8-11 ");
+  params.addParam<std::vector<Real>>("group_values",
+                                     "The initial values correspoinding to each "
+                                     "group, i.e. '0.0 1.0 2.0' means 0-4 = 0.0, "
+                                     "4-8 = 1.0 and 8-12 = 2.0 ");
   params.addParam<std::vector<std::string>>("uo_state_var_evol_rate_comp_name",
                                             "Name of state variable evolution rate component "
                                             "property: Same as state variable evolution rate "

--- a/modules/tensor_mechanics/src/userobjects/HEVPStrengthUOBase.C
+++ b/modules/tensor_mechanics/src/userobjects/HEVPStrengthUOBase.C
@@ -11,9 +11,10 @@ InputParameters
 validParams<HEVPStrengthUOBase>()
 {
   InputParameters params = validParams<DiscreteElementUserObject>();
-  params.addParam<std::string>("intvar_prop_name", "Name of internal variable property to "
-                                                   "calculate material resistance: Same as "
-                                                   "internal variable user object");
+  params.addParam<std::string>("intvar_prop_name",
+                               "Name of internal variable property to "
+                               "calculate material resistance: Same as "
+                               "internal variable user object");
   params.addClassDescription("User Object to compute material resistance");
   return params;
 }

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningConstant.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningConstant.C
@@ -12,11 +12,15 @@ InputParameters
 validParams<TensorMechanicsHardeningConstant>()
 {
   InputParameters params = validParams<TensorMechanicsHardeningModel>();
-  params.addParam<Real>("value", 1.0, "The value of the parameter for all internal parameter.  "
-                                      "This is perfect plasticity - there is no hardening.");
-  params.addParam<bool>("convert_to_radians", false, "If true, the value you entered will be "
-                                                     "multiplied by Pi/180 before passing to the "
-                                                     "Plasticity algorithms");
+  params.addParam<Real>("value",
+                        1.0,
+                        "The value of the parameter for all internal parameter.  "
+                        "This is perfect plasticity - there is no hardening.");
+  params.addParam<bool>("convert_to_radians",
+                        false,
+                        "If true, the value you entered will be "
+                        "multiplied by Pi/180 before passing to the "
+                        "Plasticity algorithms");
   params.addClassDescription(
       "No hardening - the parameter is independent of the internal parameter(s)");
   return params;

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningCubic.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningCubic.C
@@ -14,16 +14,19 @@ validParams<TensorMechanicsHardeningCubic>()
   InputParameters params = validParams<TensorMechanicsHardeningModel>();
   params.addRequiredParam<Real>(
       "value_0", "The value of the parameter for all internal_parameter <= internal_0");
-  params.addParam<Real>("value_residual", "The value of the parameter for internal_parameter >= "
-                                          "internal_limit.  Default = value_0, ie perfect "
-                                          "plasticity");
+  params.addParam<Real>("value_residual",
+                        "The value of the parameter for internal_parameter >= "
+                        "internal_limit.  Default = value_0, ie perfect "
+                        "plasticity");
   params.addParam<Real>(
       "internal_0", 0.0, "The value of the internal_parameter when hardening begins");
-  params.addParam<Real>("internal_limit", 1.0, "The value of the internal_parameter when hardening "
-                                               "ends.  This hardening forms a cubic between "
-                                               "(internal_0, value_0) and (internal_limit, "
-                                               "value_residual) that is smooth at internal_0 and "
-                                               "internal_limit");
+  params.addParam<Real>("internal_limit",
+                        1.0,
+                        "The value of the internal_parameter when hardening "
+                        "ends.  This hardening forms a cubic between "
+                        "(internal_0, value_0) and (internal_limit, "
+                        "value_residual) that is smooth at internal_0 and "
+                        "internal_limit");
   params.addClassDescription("Hardening is Cubic");
   return params;
 }

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningCutExponential.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningCutExponential.C
@@ -13,12 +13,15 @@ validParams<TensorMechanicsHardeningCutExponential>()
   InputParameters params = validParams<TensorMechanicsHardeningModel>();
   params.addRequiredParam<Real>(
       "value_0", "The value of the parameter for all internal_parameter <= internal_0");
-  params.addParam<Real>("value_residual", "The value of the parameter for internal_parameter = "
-                                          "infinity.  Default = value_0, ie perfect plasticity");
+  params.addParam<Real>("value_residual",
+                        "The value of the parameter for internal_parameter = "
+                        "infinity.  Default = value_0, ie perfect plasticity");
   params.addParam<Real>("internal_0", 0, "The cutoff of internal parameter");
-  params.addParam<Real>("rate", 0, "Let p = internal_parameter.  Then value = value_0 for "
-                                   "p<internal_0, and otherwise, value = value_residual + (value_0 "
-                                   "- value_residual)*exp(-rate*(p - internal_0)");
+  params.addParam<Real>("rate",
+                        0,
+                        "Let p = internal_parameter.  Then value = value_0 for "
+                        "p<internal_0, and otherwise, value = value_residual + (value_0 "
+                        "- value_residual)*exp(-rate*(p - internal_0)");
   params.addClassDescription("Hardening is Cut-exponential");
   return params;
 }

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningExponential.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningExponential.C
@@ -12,10 +12,13 @@ validParams<TensorMechanicsHardeningExponential>()
 {
   InputParameters params = validParams<TensorMechanicsHardeningModel>();
   params.addRequiredParam<Real>("value_0", "The value of the parameter at internal_parameter = 0");
-  params.addParam<Real>("value_residual", "The value of the parameter for internal_parameter = "
-                                          "infinity.  Default = value_0, ie perfect plasticity");
-  params.addParam<Real>("rate", 0, "Let p = internal_parameter.  Then value = value_residual + "
-                                   "(value_0 - value_residual)*exp(-rate*intnal_parameter)");
+  params.addParam<Real>("value_residual",
+                        "The value of the parameter for internal_parameter = "
+                        "infinity.  Default = value_0, ie perfect plasticity");
+  params.addParam<Real>("rate",
+                        0,
+                        "Let p = internal_parameter.  Then value = value_residual + "
+                        "(value_0 - value_residual)*exp(-rate*intnal_parameter)");
   params.addClassDescription("Hardening is Exponential");
   return params;
 }

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningGaussian.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsHardeningGaussian.C
@@ -13,13 +13,16 @@ validParams<TensorMechanicsHardeningGaussian>()
   InputParameters params = validParams<TensorMechanicsHardeningModel>();
   params.addRequiredParam<Real>(
       "value_0", "The value of the parameter for all internal_parameter <= internal_0");
-  params.addParam<Real>("value_residual", "The value of the parameter for internal_parameter = "
-                                          "infinity.  Default = value_0, ie perfect plasticity");
+  params.addParam<Real>("value_residual",
+                        "The value of the parameter for internal_parameter = "
+                        "infinity.  Default = value_0, ie perfect plasticity");
   params.addParam<Real>(
       "internal_0", 0, "The value of the internal_parameter when hardening begins");
-  params.addParam<Real>("rate", 0, "Let p = internal_parameter.  Then value = value_0 for "
-                                   "p<internal_0, and value = value_residual + (value_0 - "
-                                   "value_residual)*exp(-0.5*rate*(p - internal_0)^2)");
+  params.addParam<Real>("rate",
+                        0,
+                        "Let p = internal_parameter.  Then value = value_0 for "
+                        "p<internal_0, and value = value_residual + (value_0 - "
+                        "value_residual)*exp(-0.5*rate*(p - internal_0)^2)");
   params.addClassDescription("Hardening is Gaussian");
   return params;
 }

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticDruckerPrager.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticDruckerPrager.C
@@ -25,16 +25,19 @@ validParams<TensorMechanicsPlasticDruckerPrager>()
       "the DP circle is the largest circle that wholey fits inside the MC hex.  Native: The DP "
       "cohesion, friction angle and dilation angle are set equal to the mc_ parameters entered.");
   params.addRequiredParam<UserObjectName>(
-      "mc_cohesion", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                     "Mohr-Coulomb cohesion.  Physically this should not be negative.");
+      "mc_cohesion",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "Mohr-Coulomb cohesion.  Physically this should not be negative.");
   params.addRequiredParam<UserObjectName>(
-      "mc_friction_angle", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                           "Mohr-Coulomb friction angle (in radians).  Physically this should be "
-                           "between 0 and Pi/2.");
+      "mc_friction_angle",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "Mohr-Coulomb friction angle (in radians).  Physically this should be "
+      "between 0 and Pi/2.");
   params.addRequiredParam<UserObjectName>(
-      "mc_dilation_angle", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                           "Mohr-Coulomb dilation angle (in radians).  Usually the dilation angle "
-                           "is not greater than the friction angle, and it is between 0 and Pi/2.");
+      "mc_dilation_angle",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "Mohr-Coulomb dilation angle (in radians).  Usually the dilation angle "
+      "is not greater than the friction angle, and it is between 0 and Pi/2.");
   params.addClassDescription(
       "Non-associative Drucker Prager plasticity with no smoothing of the cone tip.");
   return params;

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticDruckerPragerHyperbolic.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticDruckerPragerHyperbolic.C
@@ -12,19 +12,25 @@ InputParameters
 validParams<TensorMechanicsPlasticDruckerPragerHyperbolic>()
 {
   InputParameters params = validParams<TensorMechanicsPlasticDruckerPrager>();
-  params.addParam<bool>("use_custom_returnMap", true, "Whether to use the custom returnMap "
-                                                      "algorithm.  Set to true if you are using "
-                                                      "isotropic elasticity.");
-  params.addParam<bool>("use_custom_cto", true, "Whether to use the custom consistent tangent "
-                                                "operator computations.  Set to true if you are "
-                                                "using isotropic elasticity.");
+  params.addParam<bool>("use_custom_returnMap",
+                        true,
+                        "Whether to use the custom returnMap "
+                        "algorithm.  Set to true if you are using "
+                        "isotropic elasticity.");
+  params.addParam<bool>("use_custom_cto",
+                        true,
+                        "Whether to use the custom consistent tangent "
+                        "operator computations.  Set to true if you are "
+                        "using isotropic elasticity.");
   params.addClassDescription("J2 plasticity, associative, with hardening");
-  params.addRangeCheckedParam<Real>(
-      "smoother", 0.0, "smoother>=0", "The cone vertex at J2=0 is smoothed.  The maximum mean "
-                                      "stress possible, which is Cohesion*Cot(friction_angle) for "
-                                      "smoother=0, becomes (Cohesion - "
-                                      "smoother/3)*Cot(friction_angle).  This is a non-hardening "
-                                      "parameter");
+  params.addRangeCheckedParam<Real>("smoother",
+                                    0.0,
+                                    "smoother>=0",
+                                    "The cone vertex at J2=0 is smoothed.  The maximum mean "
+                                    "stress possible, which is Cohesion*Cot(friction_angle) for "
+                                    "smoother=0, becomes (Cohesion - "
+                                    "smoother/3)*Cot(friction_angle).  This is a non-hardening "
+                                    "parameter");
   params.addRangeCheckedParam<unsigned>(
       "max_iterations",
       40,

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticJ2.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticJ2.C
@@ -16,12 +16,16 @@ validParams<TensorMechanicsPlasticJ2>()
       "A TensorMechanicsHardening UserObject that defines hardening of the yield strength");
   params.addRangeCheckedParam<unsigned>(
       "max_iterations", 10, "max_iterations>0", "Maximum iterations for custom J2 return map");
-  params.addParam<bool>("use_custom_returnMap", true, "Whether to use the custom returnMap "
-                                                      "algorithm.  Set to true if you are using "
-                                                      "isotropic elasticity.");
-  params.addParam<bool>("use_custom_cto", true, "Whether to use the custom consistent tangent "
-                                                "operator computations.  Set to true if you are "
-                                                "using isotropic elasticity.");
+  params.addParam<bool>("use_custom_returnMap",
+                        true,
+                        "Whether to use the custom returnMap "
+                        "algorithm.  Set to true if you are using "
+                        "isotropic elasticity.");
+  params.addParam<bool>("use_custom_cto",
+                        true,
+                        "Whether to use the custom consistent tangent "
+                        "operator computations.  Set to true if you are "
+                        "using isotropic elasticity.");
   params.addClassDescription("J2 plasticity, associative, with hardening");
 
   return params;

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMeanCapTC.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMeanCapTC.C
@@ -27,11 +27,12 @@ validParams<TensorMechanicsPlasticMeanCapTC>()
                                           "typically be positive).  Yield function = trace(stress) "
                                           "- tensile_strength for trace(stress)>tensile_strength.");
   params.addRequiredParam<UserObjectName>(
-      "compressive_strength", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                              "mean-cap compressive strength.  This should always be less than "
-                              "tensile_strength (it will typically be negative).  Yield function = "
-                              "- (trace(stress) - compressive_strength) for "
-                              "trace(stress)<compressive_strength.");
+      "compressive_strength",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "mean-cap compressive strength.  This should always be less than "
+      "tensile_strength (it will typically be negative).  Yield function = "
+      "- (trace(stress) - compressive_strength) for "
+      "trace(stress)<compressive_strength.");
   params.addClassDescription(
       "Associative mean-cap tensile and compressive plasticity with hardening/softening");
 

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulomb.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulomb.C
@@ -13,16 +13,19 @@ validParams<TensorMechanicsPlasticMohrCoulomb>()
 {
   InputParameters params = validParams<TensorMechanicsPlasticModel>();
   params.addRequiredParam<UserObjectName>(
-      "cohesion", "A TensorMechanicsHardening UserObject that defines hardening of the cohesion.  "
-                  "Physically the cohesion should not be negative.");
+      "cohesion",
+      "A TensorMechanicsHardening UserObject that defines hardening of the cohesion.  "
+      "Physically the cohesion should not be negative.");
   params.addRequiredParam<UserObjectName>(
-      "friction_angle", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                        "friction angle (in radians).  Physically the friction angle should be "
-                        "between 0 and 90deg.");
+      "friction_angle",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "friction angle (in radians).  Physically the friction angle should be "
+      "between 0 and 90deg.");
   params.addRequiredParam<UserObjectName>(
-      "dilation_angle", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                        "dilation angle (in radians).  Usually the dilation angle is not greater "
-                        "than the friction angle, and it is between 0 and 90deg.");
+      "dilation_angle",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "dilation angle (in radians).  Usually the dilation angle is not greater "
+      "than the friction angle, and it is between 0 and 90deg.");
   params.addRangeCheckedParam<Real>(
       "mc_edge_smoother",
       25.0,
@@ -31,24 +34,28 @@ validParams<TensorMechanicsPlasticMohrCoulomb>()
   MooseEnum tip_scheme("hyperbolic cap", "hyperbolic");
   params.addParam<MooseEnum>(
       "tip_scheme", tip_scheme, "Scheme by which the pyramid's tip will be smoothed.");
-  params.addRequiredRangeCheckedParam<Real>(
-      "mc_tip_smoother", "mc_tip_smoother>=0", "Smoothing parameter: the cone vertex at mean = "
-                                               "cohesion*cot(friction_angle), will be smoothed by "
-                                               "the given amount.  Typical value is 0.1*cohesion");
+  params.addRequiredRangeCheckedParam<Real>("mc_tip_smoother",
+                                            "mc_tip_smoother>=0",
+                                            "Smoothing parameter: the cone vertex at mean = "
+                                            "cohesion*cot(friction_angle), will be smoothed by "
+                                            "the given amount.  Typical value is 0.1*cohesion");
   params.addParam<Real>(
       "cap_start",
       0.0,
       "For the 'cap' tip_scheme, smoothing is performed in the stress_mean > cap_start region");
-  params.addRangeCheckedParam<Real>(
-      "cap_rate", 0.0, "cap_rate>=0", "For the 'cap' tip_scheme, this controls how quickly the cap "
-                                      "degenerates to a hemisphere: small values mean a slow "
-                                      "degeneration to a hemisphere (and zero means the 'cap' will "
-                                      "be totally inactive).  Typical value is 1/tensile_strength");
-  params.addParam<Real>("mc_lode_cutoff", "If the second invariant of stress is less than this "
-                                          "amount, the Lode angle is assumed to be zero.  This is "
-                                          "to gaurd against precision-loss problems, and this "
-                                          "parameter should be set small.  Default = "
-                                          "0.00001*((yield_Function_tolerance)^2)");
+  params.addRangeCheckedParam<Real>("cap_rate",
+                                    0.0,
+                                    "cap_rate>=0",
+                                    "For the 'cap' tip_scheme, this controls how quickly the cap "
+                                    "degenerates to a hemisphere: small values mean a slow "
+                                    "degeneration to a hemisphere (and zero means the 'cap' will "
+                                    "be totally inactive).  Typical value is 1/tensile_strength");
+  params.addParam<Real>("mc_lode_cutoff",
+                        "If the second invariant of stress is less than this "
+                        "amount, the Lode angle is assumed to be zero.  This is "
+                        "to gaurd against precision-loss problems, and this "
+                        "parameter should be set small.  Default = "
+                        "0.00001*((yield_Function_tolerance)^2)");
   params.addClassDescription("Non-associative Mohr-Coulomb plasticity with hardening/softening");
 
   return params;

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulombMulti.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulombMulti.C
@@ -18,26 +18,33 @@ validParams<TensorMechanicsPlasticMohrCoulombMulti>()
   params.addClassDescription("Non-associative Mohr-Coulomb plasticity with hardening/softening");
   params.addRequiredParam<UserObjectName>(
       "cohesion", "A TensorMechanicsHardening UserObject that defines hardening of the cohesion");
-  params.addRequiredParam<UserObjectName>("friction_angle", "A TensorMechanicsHardening UserObject "
-                                                            "that defines hardening of the "
-                                                            "friction angle (in radians)");
-  params.addRequiredParam<UserObjectName>("dilation_angle", "A TensorMechanicsHardening UserObject "
-                                                            "that defines hardening of the "
-                                                            "dilation angle (in radians)");
-  params.addParam<unsigned int>("max_iterations", 10, "Maximum number of Newton-Raphson iterations "
-                                                      "allowed in the custom return-map algorithm. "
-                                                      " For highly nonlinear hardening this may "
-                                                      "need to be higher than 10.");
-  params.addParam<Real>("shift", "Yield surface is shifted by this amount to avoid problems with "
-                                 "defining derivatives when eigenvalues are equal.  If this is "
-                                 "larger than f_tol, a warning will be issued.  This may be set "
-                                 "very small when using the custom returnMap.  Default = f_tol.");
-  params.addParam<bool>("use_custom_returnMap", true, "Use a custom return-map algorithm for this "
-                                                      "plasticity model, which may speed up "
-                                                      "computations considerably.  Set to true "
-                                                      "only for isotropic elasticity with no "
-                                                      "hardening of the dilation angle.  In this "
-                                                      "case you may set 'shift' very small.");
+  params.addRequiredParam<UserObjectName>("friction_angle",
+                                          "A TensorMechanicsHardening UserObject "
+                                          "that defines hardening of the "
+                                          "friction angle (in radians)");
+  params.addRequiredParam<UserObjectName>("dilation_angle",
+                                          "A TensorMechanicsHardening UserObject "
+                                          "that defines hardening of the "
+                                          "dilation angle (in radians)");
+  params.addParam<unsigned int>("max_iterations",
+                                10,
+                                "Maximum number of Newton-Raphson iterations "
+                                "allowed in the custom return-map algorithm. "
+                                " For highly nonlinear hardening this may "
+                                "need to be higher than 10.");
+  params.addParam<Real>("shift",
+                        "Yield surface is shifted by this amount to avoid problems with "
+                        "defining derivatives when eigenvalues are equal.  If this is "
+                        "larger than f_tol, a warning will be issued.  This may be set "
+                        "very small when using the custom returnMap.  Default = f_tol.");
+  params.addParam<bool>("use_custom_returnMap",
+                        true,
+                        "Use a custom return-map algorithm for this "
+                        "plasticity model, which may speed up "
+                        "computations considerably.  Set to true "
+                        "only for isotropic elasticity with no "
+                        "hardening of the dilation angle.  In this "
+                        "case you may set 'shift' very small.");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticSimpleTester.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticSimpleTester.C
@@ -11,28 +11,39 @@ InputParameters
 validParams<TensorMechanicsPlasticSimpleTester>()
 {
   InputParameters params = validParams<TensorMechanicsPlasticModel>();
-  params.addRequiredParam<Real>("a", "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
-                                     "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
-                                     "f*(stress_yz + stress_zy)/2 - strength");
-  params.addRequiredParam<Real>("b", "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
-                                     "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
-                                     "f*(stress_yz + stress_zy)/2 - strength");
-  params.addParam<Real>("c", 0, "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
+  params.addRequiredParam<Real>("a",
+                                "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
                                 "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
                                 "f*(stress_yz + stress_zy)/2 - strength");
-  params.addParam<Real>("d", 0, "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
+  params.addRequiredParam<Real>("b",
+                                "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
                                 "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
                                 "f*(stress_yz + stress_zy)/2 - strength");
-  params.addParam<Real>("e", 0, "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
-                                "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
-                                "f*(stress_yz + stress_zy)/2 - strength");
-  params.addParam<Real>("f", 0, "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
-                                "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
-                                "f*(stress_yz + stress_zy)/2 - strength");
-  params.addRequiredParam<Real>("strength", "Yield function = a*stress_yy + b*stress_zz + "
-                                            "c*stress_xx + d*(stress_xy + stress_yx)/2 + "
-                                            "e*(stress_xz + stress_zx)/2 + f*(stress_yz + "
-                                            "stress_zy)/2 - strength");
+  params.addParam<Real>("c",
+                        0,
+                        "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
+                        "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
+                        "f*(stress_yz + stress_zy)/2 - strength");
+  params.addParam<Real>("d",
+                        0,
+                        "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
+                        "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
+                        "f*(stress_yz + stress_zy)/2 - strength");
+  params.addParam<Real>("e",
+                        0,
+                        "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
+                        "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
+                        "f*(stress_yz + stress_zy)/2 - strength");
+  params.addParam<Real>("f",
+                        0,
+                        "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
+                        "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "
+                        "f*(stress_yz + stress_zy)/2 - strength");
+  params.addRequiredParam<Real>("strength",
+                                "Yield function = a*stress_yy + b*stress_zz + "
+                                "c*stress_xx + d*(stress_xy + stress_yx)/2 + "
+                                "e*(stress_xz + stress_zx)/2 + f*(stress_yz + "
+                                "stress_zy)/2 - strength");
   params.addClassDescription("Class that can be used for testing multi-surface plasticity models.  "
                              "Yield function = a*stress_yy + b*stress_zz + c*stress_xx + "
                              "d*(stress_xy + stress_yx)/2 + e*(stress_xz + stress_zx)/2 + "

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticTensile.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticTensile.C
@@ -33,16 +33,19 @@ validParams<TensorMechanicsPlasticTensile>()
       "cap_start",
       0.0,
       "For the 'cap' tip_scheme, smoothing is performed in the stress_mean > cap_start region");
-  params.addRangeCheckedParam<Real>(
-      "cap_rate", 0.0, "cap_rate>=0", "For the 'cap' tip_scheme, this controls how quickly the cap "
-                                      "degenerates to a hemisphere: small values mean a slow "
-                                      "degeneration to a hemisphere (and zero means the 'cap' will "
-                                      "be totally inactive).  Typical value is 1/tensile_strength");
-  params.addParam<Real>("tensile_lode_cutoff", "If the second invariant of stress is less than "
-                                               "this amount, the Lode angle is assumed to be zero. "
-                                               " This is to gaurd against precision-loss problems, "
-                                               "and this parameter should be set small.  Default = "
-                                               "0.00001*((yield_Function_tolerance)^2)");
+  params.addRangeCheckedParam<Real>("cap_rate",
+                                    0.0,
+                                    "cap_rate>=0",
+                                    "For the 'cap' tip_scheme, this controls how quickly the cap "
+                                    "degenerates to a hemisphere: small values mean a slow "
+                                    "degeneration to a hemisphere (and zero means the 'cap' will "
+                                    "be totally inactive).  Typical value is 1/tensile_strength");
+  params.addParam<Real>("tensile_lode_cutoff",
+                        "If the second invariant of stress is less than "
+                        "this amount, the Lode angle is assumed to be zero. "
+                        " This is to gaurd against precision-loss problems, "
+                        "and this parameter should be set small.  Default = "
+                        "0.00001*((yield_Function_tolerance)^2)");
   params.addClassDescription(
       "Associative tensile plasticity with hardening/softening, and tensile_strength = 1");
 

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticTensileMulti.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticTensileMulti.C
@@ -18,19 +18,26 @@ validParams<TensorMechanicsPlasticTensileMulti>()
   params.addRequiredParam<UserObjectName>(
       "tensile_strength",
       "A TensorMechanicsHardening UserObject that defines hardening of the tensile strength");
-  params.addParam<Real>("shift", "Yield surface is shifted by this amount to avoid problems with "
-                                 "defining derivatives when eigenvalues are equal.  If this is "
-                                 "larger than f_tol, a warning will be issued.  Default = f_tol.");
-  params.addParam<unsigned int>("max_iterations", 10, "Maximum number of Newton-Raphson iterations "
-                                                      "allowed in the custom return-map algorithm. "
-                                                      " For highly nonlinear hardening this may "
-                                                      "need to be higher than 10.");
-  params.addParam<bool>("use_custom_returnMap", true, "Whether to use the custom returnMap "
-                                                      "algorithm.  Set to true if you are using "
-                                                      "isotropic elasticity.");
-  params.addParam<bool>("use_custom_cto", true, "Whether to use the custom consistent tangent "
-                                                "operator computations.  Set to true if you are "
-                                                "using isotropic elasticity.");
+  params.addParam<Real>("shift",
+                        "Yield surface is shifted by this amount to avoid problems with "
+                        "defining derivatives when eigenvalues are equal.  If this is "
+                        "larger than f_tol, a warning will be issued.  Default = f_tol.");
+  params.addParam<unsigned int>("max_iterations",
+                                10,
+                                "Maximum number of Newton-Raphson iterations "
+                                "allowed in the custom return-map algorithm. "
+                                " For highly nonlinear hardening this may "
+                                "need to be higher than 10.");
+  params.addParam<bool>("use_custom_returnMap",
+                        true,
+                        "Whether to use the custom returnMap "
+                        "algorithm.  Set to true if you are using "
+                        "isotropic elasticity.");
+  params.addParam<bool>("use_custom_cto",
+                        true,
+                        "Whether to use the custom consistent tangent "
+                        "operator computations.  Set to true if you are "
+                        "using isotropic elasticity.");
   return params;
 }
 

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticWeakPlaneShear.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticWeakPlaneShear.C
@@ -13,33 +13,39 @@ validParams<TensorMechanicsPlasticWeakPlaneShear>()
 {
   InputParameters params = validParams<TensorMechanicsPlasticModel>();
   params.addRequiredParam<UserObjectName>(
-      "cohesion", "A TensorMechanicsHardening UserObject that defines hardening of the cohesion.  "
-                  "Physically the cohesion should not be negative.");
+      "cohesion",
+      "A TensorMechanicsHardening UserObject that defines hardening of the cohesion.  "
+      "Physically the cohesion should not be negative.");
   params.addRequiredParam<UserObjectName>("tan_friction_angle",
                                           "A TensorMechanicsHardening UserObject that defines "
                                           "hardening of tan(friction angle).  Physically the "
                                           "friction angle should be between 0 and 90deg.");
   params.addRequiredParam<UserObjectName>(
-      "tan_dilation_angle", "A TensorMechanicsHardening UserObject that defines hardening of the "
-                            "tan(dilation angle).  Usually the dilation angle is not greater than "
-                            "the friction angle, and it is between 0 and 90deg.");
+      "tan_dilation_angle",
+      "A TensorMechanicsHardening UserObject that defines hardening of the "
+      "tan(dilation angle).  Usually the dilation angle is not greater than "
+      "the friction angle, and it is between 0 and 90deg.");
   MooseEnum tip_scheme("hyperbolic cap", "hyperbolic");
   params.addParam<MooseEnum>(
       "tip_scheme", tip_scheme, "Scheme by which the cone's tip will be smoothed.");
   params.addRequiredRangeCheckedParam<Real>(
-      "smoother", "smoother>=0", "For the 'hyperbolic' tip_scheme, the cone vertex at shear-stress "
-                                 "= 0 will be smoothed by the given amount.  For the 'cap' "
-                                 "tip_scheme, additional smoothing will occur.  Typical value is "
-                                 "0.1*cohesion");
+      "smoother",
+      "smoother>=0",
+      "For the 'hyperbolic' tip_scheme, the cone vertex at shear-stress "
+      "= 0 will be smoothed by the given amount.  For the 'cap' "
+      "tip_scheme, additional smoothing will occur.  Typical value is "
+      "0.1*cohesion");
   params.addParam<Real>(
       "cap_start",
       0.0,
       "For the 'cap' tip_scheme, smoothing is performed in the stress_zz > cap_start region");
-  params.addRangeCheckedParam<Real>(
-      "cap_rate", 0.0, "cap_rate>=0", "For the 'cap' tip_scheme, this controls how quickly the cap "
-                                      "degenerates to a hemisphere: small values mean a slow "
-                                      "degeneration to a hemisphere (and zero means the 'cap' will "
-                                      "be totally inactive).  Typical value is 1/cohesion");
+  params.addRangeCheckedParam<Real>("cap_rate",
+                                    0.0,
+                                    "cap_rate>=0",
+                                    "For the 'cap' tip_scheme, this controls how quickly the cap "
+                                    "degenerates to a hemisphere: small values mean a slow "
+                                    "degeneration to a hemisphere (and zero means the 'cap' will "
+                                    "be totally inactive).  Typical value is 1/cohesion");
   params.addClassDescription("Non-associative finite-strain weak-plane shear perfect plasticity.  "
                              "Here cohesion = 1, tan(phi) = 1 = tan(psi)");
 

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticWeakPlaneTensile.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticWeakPlaneTensile.C
@@ -14,9 +14,10 @@ validParams<TensorMechanicsPlasticWeakPlaneTensile>()
   params.addParam<Real>("stress_coefficient",
                         1.0,
                         "The yield function is stress_coefficient * stress_zz - tensile_strength");
-  params.addRequiredParam<UserObjectName>("tensile_strength", "A TensorMechanicsHardening "
-                                                              "UserObject that defines hardening "
-                                                              "of the weak-plane tensile strength");
+  params.addRequiredParam<UserObjectName>("tensile_strength",
+                                          "A TensorMechanicsHardening "
+                                          "UserObject that defines hardening "
+                                          "of the weak-plane tensile strength");
   params.addClassDescription("Associative weak-plane tensile plasticity with hardening/softening");
 
   return params;

--- a/modules/tensor_mechanics/src/utils/MultiPlasticityDebugger.C
+++ b/modules/tensor_mechanics/src/utils/MultiPlasticityDebugger.C
@@ -13,10 +13,11 @@ validParams<MultiPlasticityDebugger>()
 {
   InputParameters params = validParams<MultiPlasticityLinearSystem>();
   MooseEnum debug_fspb_type("none crash jacobian jacobian_and_linear_system", "none");
-  params.addParam<MooseEnum>(
-      "debug_fspb", debug_fspb_type, "Debug types for use by developers when creating new "
-                                     "plasticity models, not for general use.  2 = debug Jacobian "
-                                     "entries, 3 = check the entire Jacobian, and check Ax=b");
+  params.addParam<MooseEnum>("debug_fspb",
+                             debug_fspb_type,
+                             "Debug types for use by developers when creating new "
+                             "plasticity models, not for general use.  2 = debug Jacobian "
+                             "entries, 3 = check the entire Jacobian, and check Ax=b");
   params.addParam<RealTensorValue>("debug_jac_at_stress",
                                    RealTensorValue(),
                                    "Debug Jacobian entries at this stress.  For use by developers");
@@ -444,8 +445,9 @@ MultiPlasticityDebugger::checkSolution(const RankFourTensor & E_inv)
     if (anyActiveSurfaces(model, active_not_deact))
       x[ind++] = dintnl[model];
 
-  mooseAssert(ind == orig_rhs.size(), "Incorrect extracting of changes from NR solution in the "
-                                      "finite-difference checking of nrStep");
+  mooseAssert(ind == orig_rhs.size(),
+              "Incorrect extracting of changes from NR solution in the "
+              "finite-difference checking of nrStep");
 
   Moose::err << "\nThis yields x =";
   for (unsigned i = 0; i < orig_rhs.size(); ++i)

--- a/modules/tensor_mechanics/src/utils/MultiPlasticityRawComponentAssembler.C
+++ b/modules/tensor_mechanics/src/utils/MultiPlasticityRawComponentAssembler.C
@@ -12,17 +12,19 @@ validParams<MultiPlasticityRawComponentAssembler>()
 {
   InputParameters params = emptyInputParameters();
   MooseEnum specialIC("none rock joint", "none");
-  params.addParam<MooseEnum>(
-      "specialIC", specialIC, "For certain combinations of plastic models, the set of active "
-                              "constraints can be initialized optimally.  'none': no special "
-                              "initialization is performed.  For all other choices, the "
-                              "plastic_models must be chosen to have the following types.  'rock': "
-                              "'TensileMulti MohrCoulombMulti'.  'joint': 'WeakPlaneTensile "
-                              "WeakPlaneShear'.");
+  params.addParam<MooseEnum>("specialIC",
+                             specialIC,
+                             "For certain combinations of plastic models, the set of active "
+                             "constraints can be initialized optimally.  'none': no special "
+                             "initialization is performed.  For all other choices, the "
+                             "plastic_models must be chosen to have the following types.  'rock': "
+                             "'TensileMulti MohrCoulombMulti'.  'joint': 'WeakPlaneTensile "
+                             "WeakPlaneShear'.");
   params.addParam<std::vector<UserObjectName>>(
-      "plastic_models", "List of names of user objects that define the plastic models that could "
-                        "be active for this material.  If no plastic_models are provided, only "
-                        "elasticity will be used.");
+      "plastic_models",
+      "List of names of user objects that define the plastic models that could "
+      "be active for this material.  If no plastic_models are provided, only "
+      "elasticity will be used.");
   params.addClassDescription("RawComponentAssembler class to calculate yield functions, etc, used "
                              "in multi-surface finite-strain plasticity");
   return params;

--- a/test/src/auxkernels/DriftDiffusionFluxAux.C
+++ b/test/src/auxkernels/DriftDiffusionFluxAux.C
@@ -19,9 +19,11 @@ validParams<DriftDiffusionFluxAux>()
 {
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredCoupledVar("potential", "The potential responsible for charge advection");
-  params.addParam<bool>("positive_charge", true, "Whether the potential is advecting positive "
-                                                 "charges. Should be set to false if charges are "
-                                                 "negative.");
+  params.addParam<bool>("positive_charge",
+                        true,
+                        "Whether the potential is advecting positive "
+                        "charges. Should be set to false if charges are "
+                        "negative.");
   params.addRequiredCoupledVar("u", "The drift-diffusing species.");
   params.addParam<int>("component", 0, "The flux component you want to see.");
   return params;

--- a/test/src/controls/TestControl.C
+++ b/test/src/controls/TestControl.C
@@ -25,8 +25,9 @@ validParams<TestControl>()
   params.addRequiredParam<MooseEnum>(
       "test_type", test_type, "Indicates the type of test to perform");
   params.addRequiredParam<std::string>(
-      "parameter", "The input parameter(s) to control. Specify a single parameter name and all "
-                   "parameters in all objects matching the name will be updated");
+      "parameter",
+      "The input parameter(s) to control. Specify a single parameter name and all "
+      "parameters in all objects matching the name will be updated");
 
   return params;
 }

--- a/test/src/kernels/CoupledKernelGradTest.C
+++ b/test/src/kernels/CoupledKernelGradTest.C
@@ -20,9 +20,11 @@ validParams<CoupledKernelGradTest>()
   InputParameters p = validParams<KernelGrad>();
   p.addRequiredCoupledVar("var2", "Coupled Variable");
   p.addRequiredParam<std::vector<Real>>("vel", "velocity");
-  p.addParam<bool>("test_coupling_error", false, "Set to true to verify that error messages are "
-                                                 "produced if a coupling is requested that wasn't "
-                                                 "declared");
+  p.addParam<bool>("test_coupling_error",
+                   false,
+                   "Set to true to verify that error messages are "
+                   "produced if a coupling is requested that wasn't "
+                   "declared");
   return p;
 }
 

--- a/test/src/kernels/DefaultPostprocessorDiffusion.C
+++ b/test/src/kernels/DefaultPostprocessorDiffusion.C
@@ -19,8 +19,10 @@ validParams<DefaultPostprocessorDiffusion>()
 {
   InputParameters params = validParams<Kernel>();
   params.addParam<PostprocessorName>(
-      "pps_name", 0.1, "The name of the postprocessor we are going to use, if the name is not "
-                       "found a default value of 0.1 is utlized for the postprocessor value");
+      "pps_name",
+      0.1,
+      "The name of the postprocessor we are going to use, if the name is not "
+      "found a default value of 0.1 is utlized for the postprocessor value");
   params.addParam<bool>("test_default_error",
                         false,
                         "Set this to true to test the hasDefaultPostprocessorValue error message");

--- a/test/src/kernels/PotentialAdvection.C
+++ b/test/src/kernels/PotentialAdvection.C
@@ -19,9 +19,11 @@ validParams<PotentialAdvection>()
 {
   InputParameters params = validParams<Kernel>();
   params.addCoupledVar("potential", "The potential responsible for charge advection");
-  params.addParam<bool>("positive_charge", true, "Whether the potential is advecting positive "
-                                                 "charges. Should be set to false if charges are "
-                                                 "negative.");
+  params.addParam<bool>("positive_charge",
+                        true,
+                        "Whether the potential is advecting positive "
+                        "charges. Should be set to false if charges are "
+                        "negative.");
   return params;
 }
 

--- a/test/src/materials/NewtonMaterial.C
+++ b/test/src/materials/NewtonMaterial.C
@@ -21,9 +21,10 @@ InputParameters
 validParams<NewtonMaterial>()
 {
   InputParameters params = validParams<Material>();
-  params.addRequiredParam<std::string>("f_name", "The name of the property that holds the value of "
-                                                 "the function for which the root is being "
-                                                 "computed");
+  params.addRequiredParam<std::string>("f_name",
+                                       "The name of the property that holds the value of "
+                                       "the function for which the root is being "
+                                       "computed");
   params.addRequiredParam<std::string>(
       "f_prime_name",
       "The name of the property that holds the value to of the derivative of the function");

--- a/test/src/materials/RecomputeMaterial.C
+++ b/test/src/materials/RecomputeMaterial.C
@@ -20,9 +20,10 @@ InputParameters
 validParams<RecomputeMaterial>()
 {
   InputParameters params = validParams<Material>();
-  params.addRequiredParam<std::string>("f_name", "The name of the property that holds the value to "
-                                                 "of the function for which the root is being "
-                                                 "computed");
+  params.addRequiredParam<std::string>("f_name",
+                                       "The name of the property that holds the value to "
+                                       "of the function for which the root is being "
+                                       "computed");
   params.addRequiredParam<std::string>(
       "f_prime_name",
       "The name of the property that holds the value to of the derivative of the function");

--- a/test/src/postprocessors/RealControlParameterReporter.C
+++ b/test/src/postprocessors/RealControlParameterReporter.C
@@ -23,9 +23,10 @@ InputParameters
 validParams<RealControlParameterReporter>()
 {
   InputParameters params = validParams<GeneralPostprocessor>();
-  params.addRequiredParam<std::string>("parameter", "The input parameter to control, the name must "
-                                                    "be complete (e.g. "
-                                                    "Kernels/object/param_name).");
+  params.addRequiredParam<std::string>("parameter",
+                                       "The input parameter to control, the name must "
+                                       "be complete (e.g. "
+                                       "Kernels/object/param_name).");
   return params;
 }
 

--- a/test/src/postprocessors/TestDiscontinuousValuePP.C
+++ b/test/src/postprocessors/TestDiscontinuousValuePP.C
@@ -26,9 +26,11 @@ validParams<TestDiscontinuousValuePP>()
       "variable", "The name of the variable that this postprocessor operates on.");
   params.addRequiredParam<Point>("point",
                                  "The physical point where the solution will be evaluated.");
-  params.addParam<bool>("evaluate_gradient", false, "Option to evaluate gradient instead of value. "
-                                                    "If this is true, gradient_component must be "
-                                                    "selected.");
+  params.addParam<bool>("evaluate_gradient",
+                        false,
+                        "Option to evaluate gradient instead of value. "
+                        "If this is true, gradient_component must be "
+                        "selected.");
   params.addParam<MooseEnum>(
       "gradient_component", gradient_components, "Component of gradient to be evaluated");
   params.addRequiredParam<UserObjectName>("solution",

--- a/test/src/scalarkernels/VectorPostprocessorScalarKernel.C
+++ b/test/src/scalarkernels/VectorPostprocessorScalarKernel.C
@@ -22,9 +22,10 @@ validParams<VectorPostprocessorScalarKernel>()
 
   params.addRequiredParam<VectorPostprocessorName>("vpp",
                                                    "VectorPostprocessor to pull the values out of");
-  params.addRequiredParam<std::string>("vector", "The vector to use from the VectorPostprocessor.  "
-                                                 "This vector MUST be the same size as the scalar "
-                                                 "variable's ORDER.");
+  params.addRequiredParam<std::string>("vector",
+                                       "The vector to use from the VectorPostprocessor.  "
+                                       "This vector MUST be the same size as the scalar "
+                                       "variable's ORDER.");
 
   return params;
 }


### PR DESCRIPTION
pathological case for clang-format where running twice is necessary.
Using our .clang-format, this kind of pattern requires two clang-formats
before reaching steady-state:

```
foo(foobarbaz, "asl;djfhas;hfoaiwehkc.nsk.jaliwenvlwiebfiluabweilfnjk;awebffiqweuhqipwubevipubwueifaosi;eh;ofiwneviowqiopevbipqwebvpiowqbeiuvbqwiouebviupqwbe");
```