### PR TITLE
Allow an association between syntax and a type.

### DIFF
--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -63,6 +63,21 @@ public:
                            const std::string & task);
 
   /**
+   *  Registration a type with a block. For example, associate FunctionName with the Functions block
+   * @param syntax The target syntax to associate the type with
+   * @param type The name of the type to associate with the syntax
+   */
+  void registerSyntaxType(const std::string & syntax, const std::string & type);
+
+  /**
+   * Get a multimap of registered associations of syntax with type.
+   */
+  const std::multimap<std::string, std::string> & getAssociatedTypes() const
+  {
+    return _associated_types;
+  }
+
+  /**
    * This method deprecates previously registered syntax. You should use the exact form that you
    * want deprecated
    * in the passed in parameter.
@@ -104,6 +119,9 @@ protected:
 
   /// Actions/Syntax association
   std::multimap<std::string, ActionInfo> _associated_actions;
+
+  /// Syntax/Type association
+  std::multimap<std::string, std::string> _associated_types;
 
   std::set<std::string> _deprecated_syntax;
 };

--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -46,7 +46,15 @@ public:
                      const std::string & task_name,
                      bool is_action,
                      InputParameters * params);
+
   const moosecontrib::Json::Value & getRoot() const { return _root; }
+
+  /**
+   * Add an associated type to a block
+   * @param path Path of the block
+   * @param type Type name to associate the block with
+   */
+  void addSyntaxType(const std::string & path, const std::string type);
 
 protected:
   std::string buildOptions(const std::iterator_traits<InputParameters::iterator>::value_type & p);

--- a/framework/src/parser/MooseSyntax.C
+++ b/framework/src/parser/MooseSyntax.C
@@ -54,6 +54,7 @@ associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("AddMortarInterfaceAction", "Mesh/MortarInterfaces/*");
 
   syntax.registerActionSyntax("AddFunctionAction", "Functions/*");
+  syntax.registerSyntaxType("Functions/*", "FunctionName");
 
   syntax.registerActionSyntax("GlobalParamsAction", "GlobalParams");
 
@@ -62,12 +63,16 @@ associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 
   /// Variable/AuxVariable Actions
   syntax.registerActionSyntax("AddVariableAction", "Variables/*");
+  syntax.registerSyntaxType("Variables/*", "VariableName");
+  syntax.registerSyntaxType("Variables/*", "NonlinearVariableName");
   //  syntax.registerActionSyntax("AddVariableAction", "Variables/*", "add_variable");
   //  syntax.registerActionSyntax("AddVariableAction", "Variables/*", "add_ic");
 
   syntax.registerActionSyntax("AddICAction", "Variables/*/InitialCondition");
 
   syntax.registerActionSyntax("AddAuxVariableAction", "AuxVariables/*");
+  syntax.registerSyntaxType("AuxVariables/*", "VariableName");
+  syntax.registerSyntaxType("AuxVariables/*", "AuxVariableName");
   //  syntax.registerActionSyntax("AddAuxVariableAction", "AuxVariables/*", "add_aux_variable");
   //  syntax.registerActionSyntax("AddAuxVariableAction", "AuxVariables/*", "add_ic");
 
@@ -82,8 +87,11 @@ associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 
   syntax.registerActionSyntax("SetupPostprocessorDataAction", "Postprocessors/*");
   syntax.registerActionSyntax("AddPostprocessorAction", "Postprocessors/*");
+  syntax.registerSyntaxType("Postprocessors/*", "PostprocessorName");
+  syntax.registerSyntaxType("Postprocessors/*", "UserObjectName");
 
   syntax.registerActionSyntax("AddVectorPostprocessorAction", "VectorPostprocessors/*");
+  syntax.registerSyntaxType("VectorPostprocessors/*", "VectorPostprocessorName");
 
   syntax.registerActionSyntax("AddDamperAction", "Dampers/*");
 
@@ -116,6 +124,7 @@ associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("AddConstraintAction", "Constraints/*");
 
   syntax.registerActionSyntax("AddUserObjectAction", "UserObjects/*");
+  syntax.registerSyntaxType("UserObjects/*", "UserObjectName");
   syntax.registerActionSyntax("AddControlAction", "Controls/*");
   syntax.registerActionSyntax("AddBoundsVectorsAction", "Bounds");
 

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -567,6 +567,9 @@ Parser::buildJsonSyntaxTree(JsonSyntaxTree & root) const
 {
   std::vector<std::pair<std::string, Syntax::ActionInfo>> all_names;
 
+  for (const auto & iter : _syntax.getAssociatedTypes())
+    root.addSyntaxType(iter.first, iter.second);
+
   for (const auto & iter : _syntax.getAssociatedActions())
   {
     Syntax::ActionInfo act_info = iter.second;

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -236,3 +236,9 @@ Syntax::verifyMooseObjectTask(const std::string & base, const std::string & task
 
   return false;
 }
+
+void
+Syntax::registerSyntaxType(const std::string & syntax, const std::string & type)
+{
+  _associated_types.insert(std::make_pair(syntax, type));
+}

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -201,3 +201,13 @@ JsonSyntaxTree::buildOutputString(
       ch = ' ';
   return tmp_str;
 }
+
+void
+JsonSyntaxTree::addSyntaxType(const std::string & path, const std::string type)
+{
+  if (MooseUtils::wildCardMatch(path, _search))
+  {
+    auto & j = getJson(path);
+    j["associated_types"].append(type);
+  }
+}

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -89,6 +89,10 @@ class TestJSON(unittest.TestCase):
         self.assertIn("petsc_options", split["parameters"])
         self.assertIn("splitting_type", split["parameters"])
 
+        f = data["Functions"]["star"]
+        self.assertIn("associated_types", f)
+        self.assertEquals(["FunctionName"], f["associated_types"])
+
     def testJsonSearch(self):
         """
         Make sure parameter search works


### PR DESCRIPTION

In the various tools that use the dump information, it is useful to have certain cpp_types associated with blocks. This allows for validation or auto completion of allowed names.
Currently each tool has to hard code the same rules, like FunctionName -> Function block.
This is error prone since each tool has to maintain this association on its own. It also doesn't easily allow for new assocations.
This puts the information inside MOOSE and outputs it in the Json dump so that tools can build the associations by reading the dump.

This still hard codes the associations in MOOSE, so if somebody knows how to generate this information automatically, that would be great. Something like, given Functions/* then use FunctionName. Or alternatively, given FunctionName look in Functions/*.

For  #7658 , I would imagine that BISON would register the BurnupFunction with the Burnup block and tools would automatically pick that up.

I only added the associations that were in atom, there could be other useful ones.