### PR TITLE
Silence unused parameter warning in unit test of Brents method

### DIFF
--- a/unit/src/BrentsMethodTest.C
+++ b/unit/src/BrentsMethodTest.C
@@ -86,7 +86,7 @@ BrentsMethodTest::root()
   {
     // Trigger no bracketing interval error
     x2 = 1.0;
-    Real x = BrentsMethod::root(func, x1, x2);
+    BrentsMethod::root(func, x1, x2);
   }
   catch (const std::exception & e)
   {


### PR DESCRIPTION
Compiling the unit tests with clang on my mac gives me an unused parameter warning in BrentsMethodTest. 

Refs #1777