### PR TITLE
Improve the block editor window behavior

### DIFF
--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -50,6 +50,7 @@ class BlockEditor(QWidget, MooseWidget):
         self.reset_button = None
         self.new_parameter_button = None
         self.param_editor = None
+        self.setWindowTitle(block.path)
 
         if block.types:
             self.param_editor = ParamsByType(block)
@@ -90,6 +91,7 @@ class BlockEditor(QWidget, MooseWidget):
         """
         self.apply_button.setEnabled(enabled)
         self.reset_button.setEnabled(enabled)
+        self.setWindowTitle(self.block.path)
 
     def setWatchedBlockList(self, path, children):
         self.param_editor.setWatchedBlockList(path, children)


### PR DESCRIPTION
The block editor window on the input tab can easily have  the much larger peacock window cover it up, completely hiding it. When this happens, clicking on any of the blocks does not pop up a window to edit it because there is an existing window already open, it just can't be seen.
Additionally, this window stays open even on a change of input file which can seemingly cause the new input file to not being editable.

This PR destroys the block editor on a change of input file if one is opened.
It also raises the block editor window when the user clicks on the tree.
It also shows the path of what is being edited in the block editor window as the window title to make it clear what is being edited.

closes #8811 