### PR TITLE
Output a basic_type and pretty up the cpp_type in Json output.

### DIFF
--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -76,6 +76,9 @@ public:
 protected:
   std::string buildOptions(const std::iterator_traits<InputParameters::iterator>::value_type & p);
 
+  std::string prettyCppType(const std::string & cpp_type);
+  std::string basicCppType(const std::string & cpp_type);
+
   std::string
   buildOutputString(const std::iterator_traits<InputParameters::iterator>::value_type & p);
   static std::vector<std::string> splitPath(const std::string & path);

--- a/python/peacock/Input/ParameterInfo.py
+++ b/python/peacock/Input/ParameterInfo.py
@@ -72,6 +72,7 @@ class ParameterInfo(object):
             "Point" in self.cpp_type or
             self.user_added or
             ("basic_string" in self.cpp_type and self.name == "value") or
+            ("std::string" in self.cpp_type and self.name == "value") or
             ' ' in self.value or
             ';' in self.value or
             '=' in self.value or

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -82,6 +82,12 @@ class TestJSON(unittest.TestCase):
         self.assertIn("Transient", exe["types"])
         self.assertNotIn("subblock_types", exe)
 
+        params = exe["actions"]["CreateExecutionerAction"]["parameters"]
+        self.assertEqual(params["active"]["cpp_type"], "std::vector<std::string>")
+        self.assertEqual(params["active"]["basic_type"], "Array")
+        self.assertEqual(params["type"]["cpp_type"], "std::string")
+        self.assertEqual(params["type"]["basic_type"], "String")
+
         # Preconditioning has a Preconditioning/*/* syntax which is unusual
         self.assertIn("Preconditioning", data)
         p = data["Preconditioning"]


### PR DESCRIPTION
This adds another field to each parameter specifying a basic type: Array, Integer, Real, Boolean, String.
It has several hardcoded entries to determine this basic type. It seems like the tools that use the dump information all do this same thing so we might as well put it in moose.

I also cleaned up the cpp_type to make it a little prettier. Get rid of inline namespaces and pretty up std::string and std::vector. So instead of 
`std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >`

we get `std::vector<std::string>`

refs #7660

