### PR TITLE
Fix XFEM memory leak

### DIFF
--- a/modules/xfem/src/efa/EFAElement2D.C
+++ b/modules/xfem/src/efa/EFAElement2D.C
@@ -1018,6 +1018,7 @@ EFAElement2D::createChild(const std::set<EFAElement *> & CrackTipElements,
             {
               EFANode * local = this->createLocalNodeFromGlobalNode(master_nodes[k]);
               coor += _local_node_coor[local->id()] * master_weights[k];
+              delete local;
             }
             local_embedded_node_coor.push_back(coor);
           }

--- a/modules/xfem/src/efa/EFAElement3D.C
+++ b/modules/xfem/src/efa/EFAElement3D.C
@@ -971,6 +971,7 @@ EFAElement3D::createChild(const std::set<EFAElement *> & CrackTipElements,
           {
             EFANode * local = this->createLocalNodeFromGlobalNode(master_nodes[i]);
             coor += _local_node_coor[local->id()] * master_weights[i];
+            delete local;
           }
           cut_plane_points.push_back(coor);
         }


### PR DESCRIPTION
The code has been tested on 'rod' machine with valgrind and shows no memory leak. Please turn on the valgrind test option for this PR.

Ref #8820