### PR TITLE
Fix top level block name in --dump

### DIFF
--- a/framework/src/outputs/formatters/JsonInputFileFormatter.C
+++ b/framework/src/outputs/formatters/JsonInputFileFormatter.C
@@ -77,7 +77,11 @@ JsonInputFileFormatter::addBlock(const std::string & name,
                                  bool toplevel)
 {
   addLine("");
-  addLine("[./" + name + "]");
+  if (toplevel)
+    addLine("[" + name + "]");
+  else
+    addLine("[./" + name + "]");
+
   _level++;
   if (block.isMember("description") && !block["description"].asString().empty())
     addLine("", 0, block["description"].asString());


### PR DESCRIPTION
Changes top level block name from `[./Name]` to the correct `[Name]`.
The python GetPotParser apparently doesn't care, it just gives the name regardless. This is why the testing worked for this.