### PR TITLE
Additional DependencyResolver ordering fixes

### DIFF
--- a/framework/include/utils/DependencyResolver.h
+++ b/framework/include/utils/DependencyResolver.h
@@ -179,8 +179,12 @@ void
 DependencyResolver<T>::insertDependency(const T & key, const T & value)
 {
   _depends.insert(std::make_pair(key, value));
-  _ordering_vector.push_back(key);
-  _ordering_vector.push_back(value);
+  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), key) ==
+      _ordering_vector.end())
+    _ordering_vector.push_back(key);
+  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), value) ==
+      _ordering_vector.end())
+    _ordering_vector.push_back(value);
 }
 
 template <typename T>
@@ -188,7 +192,9 @@ void
 DependencyResolver<T>::addItem(const T & value)
 {
   _independent_items.push_back(value);
-  _ordering_vector.push_back(value);
+  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), value) ==
+      _ordering_vector.end())
+    _ordering_vector.push_back(value);
 }
 
 template <typename T>

--- a/framework/include/utils/DependencyResolver.h
+++ b/framework/include/utils/DependencyResolver.h
@@ -201,23 +201,28 @@ template <typename T>
 const std::vector<std::vector<T>> &
 DependencyResolver<T>::getSortedValuesSets()
 {
-  /* Make a copy of the map to work on since we will remove values from the map*/
-  std::multimap<T, T> depends = _depends;
-
   // Use the original ordering for ordering subvectors
   DependencyResolverComparator<T> comp(_ordering_vector);
+
+  /**
+   * Make a copy of the map to work on since:
+   * 1) we will remove values from the map
+   * 2) We need the copy to be sorted in an unambiguous order.
+   */
+  typedef std::multimap<T, T, DependencyResolverComparator<T> > dep_multimap;
+  dep_multimap depends (_depends.begin(), _depends.end(), comp);
 
   // Build up a set of all keys in depends that have nothing depending on them,
   // and put it in the nodepends set.  These are the leaves of the dependency tree.
   std::set<T> nodepends;
-  for (typename std::multimap<T, T>::iterator i = depends.begin(); i != depends.end(); ++i)
+  for (auto i : depends)
   {
-    T key = i->first;
+    T key = i.first;
 
     bool founditem = false;
-    for (typename std::multimap<T, T>::iterator i2 = depends.begin(); i2 != depends.end(); ++i2)
+    for (auto i2 : depends)
     {
-      if (i2->second == key)
+      if (i2.second == key)
       {
         founditem = true;
         break;
@@ -232,9 +237,9 @@ DependencyResolver<T>::getSortedValuesSets()
   {
     T key = *siter;
     bool founditem = false;
-    for (typename std::multimap<T, T>::iterator i2 = depends.begin(); i2 != depends.end(); ++i2)
+    for (auto i2 : depends)
     {
-      if (i2->first == key || i2->second == key)
+      if (i2.first == key || i2.second == key)
       {
         founditem = true;
         break;
@@ -259,14 +264,13 @@ DependencyResolver<T>::getSortedValuesSets()
      * to duplicate keys
      */
     std::set<T, DependencyResolverComparator<T>> keys(
-        typename DependencyResolver<T>::template key_iterator<std::multimap<T, T>>(depends.begin()),
-        typename DependencyResolver<T>::template key_iterator<std::multimap<T, T>>(depends.end()),
+        typename DependencyResolver<T>::template key_iterator<dep_multimap>(depends.begin()),
+        typename DependencyResolver<T>::template key_iterator<dep_multimap>(depends.end()),
         comp);
 
     std::set<T, DependencyResolverComparator<T>> values(
-        typename DependencyResolver<T>::template value_iterator<std::multimap<T, T>>(
-            depends.begin()),
-        typename DependencyResolver<T>::template value_iterator<std::multimap<T, T>>(depends.end()),
+        typename DependencyResolver<T>::template value_iterator<dep_multimap>(depends.begin()),
+        typename DependencyResolver<T>::template value_iterator<dep_multimap>(depends.end()),
         comp);
 
     std::vector<T> current_set(next_set);
@@ -285,7 +289,7 @@ DependencyResolver<T>::getSortedValuesSets()
     /* Now remove items from the temporary map that have been "resolved" */
     if (!difference.empty())
     {
-      for (typename std::multimap<T, T>::iterator iter = depends.begin(); iter != depends.end();)
+      for (auto iter = depends.begin(); iter != depends.end();)
       {
         if (difference.find(iter->second) != difference.end())
         {
@@ -316,9 +320,12 @@ DependencyResolver<T>::getSortedValuesSets()
       {
         std::ostringstream oss;
         oss << "Cyclic dependency detected in the Dependency Resolver.  Remaining items are:\n";
-        for (typename std::multimap<T, T>::iterator j = depends.begin(); j != depends.end(); ++j)
-          oss << j->first << " -> " << j->second << "\n";
-        throw CyclicDependencyException<T>(oss.str(), depends);
+        for (auto j : depends)
+          oss << j.first << " -> " << j.second << "\n";
+        // Return a multimap without a weird comparator, to avoid
+        // dangling reference problems and for backwards compatibility
+        std::multimap<T, T> cyclic_deps(depends.begin(), depends.end());
+        throw CyclicDependencyException<T>(oss.str(), cyclic_deps);
       }
     }
   }

--- a/framework/include/utils/DependencyResolver.h
+++ b/framework/include/utils/DependencyResolver.h
@@ -179,11 +179,9 @@ void
 DependencyResolver<T>::insertDependency(const T & key, const T & value)
 {
   _depends.insert(std::make_pair(key, value));
-  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), key) ==
-      _ordering_vector.end())
+  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), key) == _ordering_vector.end())
     _ordering_vector.push_back(key);
-  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), value) ==
-      _ordering_vector.end())
+  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), value) == _ordering_vector.end())
     _ordering_vector.push_back(value);
 }
 
@@ -192,8 +190,7 @@ void
 DependencyResolver<T>::addItem(const T & value)
 {
   _independent_items.push_back(value);
-  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), value) ==
-      _ordering_vector.end())
+  if (std::find(_ordering_vector.begin(), _ordering_vector.end(), value) == _ordering_vector.end())
     _ordering_vector.push_back(value);
 }
 
@@ -209,8 +206,8 @@ DependencyResolver<T>::getSortedValuesSets()
    * 1) we will remove values from the map
    * 2) We need the copy to be sorted in an unambiguous order.
    */
-  typedef std::multimap<T, T, DependencyResolverComparator<T> > dep_multimap;
-  dep_multimap depends (_depends.begin(), _depends.end(), comp);
+  typedef std::multimap<T, T, DependencyResolverComparator<T>> dep_multimap;
+  dep_multimap depends(_depends.begin(), _depends.end(), comp);
 
   // Build up a set of all keys in depends that have nothing depending on them,
   // and put it in the nodepends set.  These are the leaves of the dependency tree.

--- a/framework/src/meshmodifiers/ElementDeleterBase.C
+++ b/framework/src/meshmodifiers/ElementDeleterBase.C
@@ -53,21 +53,20 @@ ElementDeleterBase::modify()
       deleteable_elems.insert(elem);
   }
 
-  /**
-   * If we are in parallel we'd better have a consistent idea of what
-   * should be deleted.  This can't be checked cheaply.
-   */
+/**
+ * If we are in parallel we'd better have a consistent idea of what
+ * should be deleted.  This can't be checked cheaply.
+ */
 #ifdef DEBUG
   dof_id_type pmax_elem_id = mesh.max_elem_id();
   mesh.comm().max(pmax_elem_id);
 
-  for (dof_id_type i=0; i != pmax_elem_id; ++i)
+  for (dof_id_type i = 0; i != pmax_elem_id; ++i)
   {
-    Elem *elem = mesh.query_elem_ptr(i);
+    Elem * elem = mesh.query_elem_ptr(i);
     bool is_deleteable = elem && deleteable_elems.count(elem);
 
-    libmesh_assert(mesh.comm().semiverify
-      (elem ? &is_deleteable : libmesh_nullptr));
+    libmesh_assert(mesh.comm().semiverify(elem ? &is_deleteable : libmesh_nullptr));
   }
 #endif
 

--- a/framework/src/meshmodifiers/ElementDeleterBase.C
+++ b/framework/src/meshmodifiers/ElementDeleterBase.C
@@ -33,6 +33,8 @@ ElementDeleterBase::ElementDeleterBase(const InputParameters & parameters)
 void
 ElementDeleterBase::modify()
 {
+  libmesh_assert(this->comm().verify(this->name()));
+
   // Check that we have access to the mesh
   if (!_mesh_ptr)
     mooseError("_mesh_ptr must be initialized before calling ElementDeleterBase::modify()");
@@ -50,6 +52,24 @@ ElementDeleterBase::modify()
     if (shouldDelete(elem))
       deleteable_elems.insert(elem);
   }
+
+  /**
+   * If we are in parallel we'd better have a consistent idea of what
+   * should be deleted.  This can't be checked cheaply.
+   */
+#ifdef DEBUG
+  dof_id_type pmax_elem_id = mesh.max_elem_id();
+  mesh.comm().max(pmax_elem_id);
+
+  for (dof_id_type i=0; i != pmax_elem_id; ++i)
+  {
+    Elem *elem = mesh.query_elem_ptr(i);
+    bool is_deleteable = elem && deleteable_elems.count(elem);
+
+    libmesh_assert(mesh.comm().semiverify
+      (elem ? &is_deleteable : libmesh_nullptr));
+  }
+#endif
 
   /**
    * Delete all of the elements


### PR DESCRIPTION
This should complete the fixes that I *thought* I had finished in
PR #8674, thereby resolving #8659.  Now we have a consistent ordering
for *every* set produced by a resolver, not just every set except the
last.

This appears to fix intermittent #1500 failures for me.  As with the
previous #8659 fix it's hard to be certain, since there's always a
high chance that the previous broken code will work correctly via dumb
luck.