### PR TITLE
Output array type in Json basic_type output

### DIFF
--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -237,12 +237,20 @@ JsonSyntaxTree::basicCppType(const std::string & cpp_type)
 {
   std::string s = "String";
   if (cpp_type.find("std::vector") != std::string::npos ||
-      cpp_type.find("MultiMooseEnum") != std::string::npos ||
-      cpp_type.find("VectorPostprocessorName") != std::string::npos ||
-      cpp_type.find("libMesh::Point") != std::string::npos ||
       cpp_type.find("libMesh::VectorValue") != std::string::npos ||
       cpp_type.find("libMesh::TensorValue") != std::string::npos)
-    s = "Array";
+  {
+    // Get the template type and use its basic type for the array type
+    pcrecpp::RE r("^[^<]+<\\s*(.*)\\s*>$");
+    std::string t;
+    r.FullMatch(cpp_type, &t);
+    s = "Array:" + basicCppType(t);
+  }
+  else if (cpp_type.find("MultiMooseEnum") != std::string::npos ||
+           cpp_type.find("VectorPostprocessorName") != std::string::npos)
+    s = "Array:String";
+  else if (cpp_type.find("libMesh::Point") != std::string::npos)
+    s = "Array:Real";
   else if (cpp_type == "int" || cpp_type == "unsigned int" || cpp_type == "short" ||
            cpp_type == "unsigned short" || cpp_type == "char" || cpp_type == "unsigned char" ||
            cpp_type == "long" || cpp_type == "unsigned long")

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -84,7 +84,7 @@ class TestJSON(unittest.TestCase):
 
         params = exe["actions"]["CreateExecutionerAction"]["parameters"]
         self.assertEqual(params["active"]["cpp_type"], "std::vector<std::string>")
-        self.assertEqual(params["active"]["basic_type"], "Array")
+        self.assertEqual(params["active"]["basic_type"], "Array:String")
         self.assertEqual(params["type"]["cpp_type"], "std::string")
         self.assertEqual(params["type"]["basic_type"], "String")
 


### PR DESCRIPTION
Instead of a simple "Array" type we add what it is an array of.
Running
`./moose_test-opt --json | grep basic_type | cut -d':' -f2- | sort | uniq -c | sort -n`
results in
```
   1  "Array:Array:Array:String",
   6  "Array:Array:Integer",
  11  "Array:Array:Real",
  14  "Array:Array:String",
  31  "Array:Integer",
 171  "Array:Real",
 630  "Integer",
 702  "Real",
1795  "String",
2342  "Boolean",
2907  "Array:String",
```
@brandonlangley Does this work for you?

refs #7660