### PR TITLE
--recoversuffix option for MooseApp

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -295,6 +295,16 @@ public:
   void setRecoverFileBase(std::string recover_base) { _recover_base = recover_base; }
 
   /**
+   * The suffix for the recovery file.
+   */
+  std::string getRecoverFileSuffix() { return _recover_suffix; }
+
+  /**
+   * mutator for recover_suffix
+   */
+  void setRecoverFileSuffix(std::string recover_suffix) { _recover_suffix = recover_suffix; }
+
+  /**
    *  Whether or not this simulation should only run half its transient (useful for testing
    * recovery)
    */
@@ -602,6 +612,9 @@ protected:
 
   /// The base name to recover from.  If blank then we will find the newest recovery file.
   std::string _recover_base;
+
+  /// The file suffix to recover from.  If blank then we will use "cpr" for binary CheckpointIO.
+  std::string _recover_suffix;
 
   /// Whether or not this simulation should only run half its transient (useful for testing recovery)
   bool _half_transient;

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -143,6 +143,11 @@ validParams<MooseApp>()
                                           "Continue the calculation.  If file_base is omitted then "
                                           "the most recent recovery file will be utilized");
 
+  params.addCommandLineParam<std::string>("recoversuffix",
+                                          "--recoversuffix [suffix]",
+                                          "Use a different file extension, other than cpr, "
+                                          "for a recovery file");
+
   params.addCommandLineParam<bool>("half_transient",
                                    "--half-transient",
                                    false,
@@ -225,6 +230,7 @@ MooseApp::MooseApp(InputParameters parameters)
     _distributed_mesh_on_command_line(false),
     _recover(false),
     _restart(false),
+    _recover_suffix("cpr"),
     _half_transient(false),
     _check_input(getParam<bool>("check_input")),
     _restartable_data(libMesh::n_threads()),
@@ -444,6 +450,13 @@ MooseApp::setupOptions()
       // a dash then we are going to eventually find the newest recovery file to use
       if (!(recover_following_arg.empty() || (recover_following_arg.find('-') == 0)))
         _recover_base = recover_following_arg;
+
+      // Optionally get command line argument following
+      // --recoversuffix on command line
+      if (isParamValid("recoversuffix"))
+      {
+        _recover_suffix = getParam<std::string>("recoversuffix");
+      }
     }
 
     _parser.parse(_input_filename);

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1961,7 +1961,7 @@ MooseMesh::init()
   if (_app.isRecovering() && _allow_recovery && _app.isUltimateMaster())
     // For now, only read the recovery mesh on the Ultimate Master.. sub-apps need to just build
     // their mesh like normal
-    getMesh().read(_app.getRecoverFileBase() + "_mesh.cpr");
+    getMesh().read(_app.getRecoverFileBase() + "_mesh." + _app.getRecoverFileSuffix());
   else // Normally just build the mesh
     buildMesh();
 }


### PR DESCRIPTION
I'm using this to debug ASCII CheckpointIO based recovery, but it could be useful to people who want to try a wider variety of file formats as well.

This doesn't yet fix #8410 but it's making it much easier for me to see the problems with my in-progress fix.