### PR TITLE
Initialize the StateVariableUO based on q_point coordinates in Crystal Plasticity

### DIFF
--- a/modules/tensor_mechanics/include/userobjects/CrystalPlasticityStateVariable.h
+++ b/modules/tensor_mechanics/include/userobjects/CrystalPlasticityStateVariable.h
@@ -23,12 +23,15 @@ public:
   CrystalPlasticityStateVariable(const InputParameters & parameters);
 
   virtual bool updateStateVariable(unsigned int qp, Real dt, std::vector<Real> & val) const;
-  virtual void initSlipSysProps(std::vector<Real> & val) const;
+  virtual void initSlipSysProps(std::vector<Real> & val, const Point & q_point) const;
 
 protected:
   virtual void readInitialValueFromFile(std::vector<Real> & val) const;
 
   virtual void readInitialValueFromInline(std::vector<Real> & val) const;
+
+  virtual void provideInitialValueByUser(std::vector<Real> & /*val*/,
+                                         const Point & /*q_point*/) const;
 
   unsigned int _num_mat_state_var_evol_rate_comps;
 

--- a/modules/tensor_mechanics/src/materials/FiniteStrainUObasedCP.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainUObasedCP.C
@@ -194,7 +194,7 @@ FiniteStrainUObasedCP::initQpStatefulProperties()
   for (unsigned int i = 0; i < _num_uo_state_vars; ++i)
   {
     // Initializes slip system related properties
-    _uo_state_vars[i]->initSlipSysProps((*_mat_prop_state_vars[i])[_qp]);
+    _uo_state_vars[i]->initSlipSysProps((*_mat_prop_state_vars[i])[_qp], _q_point[_qp]);
     (*_mat_prop_state_vars_old[i])[_qp] = (*_mat_prop_state_vars[i])[_qp];
   }
 }

--- a/modules/tensor_mechanics/src/userobjects/CrystalPlasticityStateVariable.C
+++ b/modules/tensor_mechanics/src/userobjects/CrystalPlasticityStateVariable.C
@@ -15,7 +15,7 @@ validParams<CrystalPlasticityStateVariable>()
       "state_variable_file_name",
       "",
       "Name of the file containing the initial values of slip system resistances");
-  MooseEnum intvar_read_options("file_input inline_input ", "inline_input");
+  MooseEnum intvar_read_options("file_input inline_input user_input", "inline_input");
   params.addParam<MooseEnum>(
       "intvar_read_type",
       intvar_read_options,
@@ -64,7 +64,8 @@ CrystalPlasticityStateVariable::CrystalPlasticityStateVariable(const InputParame
 }
 
 void
-CrystalPlasticityStateVariable::initSlipSysProps(std::vector<Real> & val) const
+CrystalPlasticityStateVariable::initSlipSysProps(std::vector<Real> & val,
+                                                 const Point & q_point) const
 {
   switch (_intvar_read_type)
   {
@@ -73,6 +74,9 @@ CrystalPlasticityStateVariable::initSlipSysProps(std::vector<Real> & val) const
       break;
     case 1:
       readInitialValueFromInline(val);
+      break;
+    case 2:
+      provideInitialValueByUser(val, q_point);
       break;
     default:
       mooseError("CrystalPlasticityStateVariable: Read option for initial value of internal "
@@ -126,6 +130,15 @@ CrystalPlasticityStateVariable::readInitialValueFromInline(std::vector<Real> & v
     for (unsigned int j = is; j <= ie; ++j)
       val[j] = _group_values[i];
   }
+}
+
+void
+CrystalPlasticityStateVariable::provideInitialValueByUser(std::vector<Real> & /*val*/,
+                                                          const Point & /*q_point*/) const
+{
+  mooseError("Error CrystalPlasticityStateVariable: User has to overwrite "
+             "'provideInitialValueByUser' function"
+             "in order to provide specific initial values based on quadrature point location.");
 }
 
 bool


### PR DESCRIPTION
Added capability to allow users to initialize the state variable in crystal plasticity code based on the spatial coordinates.

Ref #8843 