### PR TITLE
Only show valid rendering in ExodusViewer

### DIFF
--- a/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
@@ -65,6 +65,7 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
             self.__qvtkinteractor = RetinaQVTKRenderWindowInteractor(self)
         else:
             self.__qvtkinteractor = QVTKRenderWindowInteractor(self)
+        self.__qvtkinteractor.hide()
 
         # Member variables
         self._highlight = None
@@ -107,6 +108,7 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
         self._initialized = False
         self._reset_required = False
         self._adjustTimers(start=['initialize'], stop=['update'])
+        self.__qvtkinteractor.hide()
         self.windowReset.emit()
 
     def onReloadWindow(self):
@@ -152,6 +154,7 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
                 self.reset()
                 return
 
+        self.__qvtkinteractor.show()
         # Call the base class initialization (this enables the plugin)
         super(VTKWindowPlugin, self).initialize()
 

--- a/python/peacock/tests/peacock_app/check_result/test_check_result.py
+++ b/python/peacock/tests/peacock_app/check_result/test_check_result.py
@@ -26,6 +26,7 @@ class Tests(Testing.PeacockTester):
         Testing.process_events(self.qapp, t=5)
         app.main_widget.setTab(result_plugin.tabName())
         Testing.set_window_size(vtkwin)
+        Testing.process_events(self.qapp, t=1)
         vtkwin.onWrite(filename)
         self.assertFalse(Testing.gold_diff(filename))
         return app


### PR DESCRIPTION
Just opening up peacock with no arguments, the ExodusViewer generally shows garbage in the render window. The same for when it is initially waiting for data to be populated in an exodus file after starting a run.
This just hides the internal rendering until there is something to actually render.
Makes it look much nicer.