### PR TITLE
Deprecate old disp_[xyz] parameters in contact

### DIFF
--- a/modules/combined/tests/catch_release/catch_release.i
+++ b/modules/combined/tests/catch_release/catch_release.i
@@ -1,6 +1,9 @@
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
 [Mesh]
   file = catch_release.e
-  displacements = 'disp_x disp_y disp_z'
 []
 
 [Functions]
@@ -27,15 +30,13 @@
     order = FIRST
     family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./stress_yy]
     order = CONSTANT
     family = MONOMIAL
   [../]
-
 []
 
 [SolidMechanics]
@@ -47,30 +48,24 @@
 []
 
 [AuxKernels]
-
   [./stress_yy]
     type = MaterialTensorAux
     tensor = stress
     variable = stress_yy
     index = 1
   [../]
-
 []
 
 [Contact]
   [./dummy_name]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     penalty = 1e6
     model = frictionless
   [../]
 []
 
 [BCs]
-
   [./lateral]
     type = PresetBC
     variable = disp_x
@@ -98,11 +93,9 @@
     boundary = 4
     value = 0.0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -126,37 +119,29 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.3
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-
-
+  #petsc_options_iname = '-pc_type -snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart'
+  #petsc_options_value = 'ilu      ls         basic    basic                    101'
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg      101'
 
-
   line_search = 'none'
-
-#  petsc_options_iname = '-pc_type -snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart'
-#  petsc_options_value = 'ilu      ls         basic    basic                    101'
 
   nl_abs_tol = 1e-8
   nl_rel_tol = 1e-4
   l_tol = 1e-4
 
   l_max_its = 100
-#  nl_max_its = 10
   nl_max_its = 20
   dt = 1.0
   end_time = 4.0
-#  predictor_scale = 1.0
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/contact/4ElemTensionRelease.i
+++ b/modules/combined/tests/contact/4ElemTensionRelease.i
@@ -1,9 +1,9 @@
 [Mesh]
   file = 4ElemTensionRelease.e
-  displacements = 'disp_x disp_y'
 []
+
 [GlobalParams]
-#  volumetric_locking_correction = false
+  displacements = 'disp_x disp_y'
 []
 
 [Functions]
@@ -16,15 +16,10 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -37,8 +32,6 @@
   [./dummy_name]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
     model = frictionless
     tangential_tolerance = 0.01
@@ -46,7 +39,6 @@
 []
 
 [BCs]
-
   [./lateral]
     type = PresetBC
     variable = disp_x
@@ -67,11 +59,9 @@
     boundary = 4
     value = 0.0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -93,12 +83,10 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.3
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg      101'
@@ -118,8 +106,8 @@
     type = SimplePredictor
     scale = 1.0
   [../]
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/contact/4ElemTensionRelease_mechanical_constraint.i
+++ b/modules/combined/tests/contact/4ElemTensionRelease_mechanical_constraint.i
@@ -1,6 +1,9 @@
 # This is a mechanical constraint (contact formulation) version of 4ElemTensionRelease.i
 [Mesh]
   file = 4ElemTensionRelease.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -14,15 +17,10 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -35,8 +33,6 @@
   [./dummy_name]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
     model = frictionless
     tangential_tolerance = 0.01
@@ -45,7 +41,6 @@
 []
 
 [BCs]
-
   [./lateral]
     type = PresetBC
     variable = disp_x
@@ -66,11 +61,9 @@
     boundary = 4
     value = 0.0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -92,13 +85,12 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.3
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
+
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg      101'
 
@@ -117,8 +109,8 @@
     type = SimplePredictor
     scale = 1.0
   [../]
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/contact/8ElemTensionRelease.i
+++ b/modules/combined/tests/contact/8ElemTensionRelease.i
@@ -1,8 +1,11 @@
 [Mesh]
   file = 8ElemTensionRelease.e
-  displacements = 'disp_x disp_y'
   partitioner = centroid
   centroid_partitioner_direction = x
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Functions]
@@ -15,20 +18,13 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [AuxVariables]
   [./status]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./pid]
     order = CONSTANT
@@ -47,8 +43,6 @@
   [./dummy_name]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
     model = frictionless
     tangential_tolerance = 0.01
@@ -72,7 +66,6 @@
 []
 
 [BCs]
-
   [./lateral]
     type = PresetBC
     variable = disp_x
@@ -93,11 +86,9 @@
     boundary = 4
     value = 0.0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -119,12 +110,10 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.3
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg      101'
@@ -143,8 +132,8 @@
     type = SimplePredictor
     scale = 1.0
   [../]
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Output
+[]

--- a/modules/combined/tests/contact/pressureAugLag.i
+++ b/modules/combined/tests/contact/pressureAugLag.i
@@ -1,40 +1,31 @@
-
 [GlobalParams]
   disp_x = disp_x
   disp_y = disp_y
   disp_z = disp_z
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Mesh]
   file = pressure.e
-  displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
     order = FIRST
     family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./stress_yy]
     order = CONSTANT
     family = MONOMIAL
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -47,7 +38,6 @@
     slave = 10
     penalty = 1e7
     formulation = augmented_lagrange
-#    model = glued
     tangential_tolerance = 1e-3
   [../]
 []
@@ -60,7 +50,7 @@
     index = 1
     execute_on = timestep_end
   [../]
-[] # AuxKernels
+[]
 
 [BCs]
   [./left_x]
@@ -97,11 +87,9 @@
     boundary = 8
     value = -2e-3
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -116,7 +104,7 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.0
   [../]
-[] # Materials
+[]
 
 [Dampers]
   [./limitX]
@@ -135,20 +123,14 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-
-
-#  petsc_options_iname = '-pc_type -pc_hypre_type -snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart'
-#  petsc_options_value = 'hypre    boomeramg      ls         basic    basic                    101'
+  #petsc_options_iname = '-pc_type -pc_hypre_type -snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart'
+  #petsc_options_value = 'hypre    boomeramg      ls         basic    basic                    101'
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'lu       101'
 
-
   line_search = 'none'
-
 
   nl_rel_tol = 1e-5
   nl_abs_tol = 1e-6
@@ -156,11 +138,11 @@
   l_tol = 1e-8
 
   l_max_its = 100
-  nl_max_its = 20 #10
+  nl_max_its = 20
   dt = 1.0
   num_steps = 1
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/contact/pressurePenalty.i
+++ b/modules/combined/tests/contact/pressurePenalty.i
@@ -3,38 +3,28 @@
   disp_x = disp_x
   disp_y = disp_y
   disp_z = disp_z
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Mesh]
   file = pressure.e
-  displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./stress_yy]
     order = CONSTANT
     family = MONOMIAL
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -47,7 +37,6 @@
     slave = 10
     penalty = 1e8
     formulation = penalty
-#    model = glued
     tangential_tolerance = 1e-3
     tension_release = -1
   [../]
@@ -61,7 +50,7 @@
     index = 1
     execute_on = timestep_end
   [../]
-[] # AuxKernels
+[]
 
 [BCs]
   [./left_x]
@@ -98,11 +87,9 @@
     boundary = 8
     value = -2e-3
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -117,22 +104,16 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.0
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'lu       101'
 
-
   line_search = 'none'
-
 
   nl_rel_tol = 1e-9
   nl_abs_tol = 1e-9
@@ -141,8 +122,8 @@
   nl_max_its = 10
   dt = 1.0
   num_steps = 1
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Output
+[]

--- a/modules/combined/tests/contact/pressurePenalty_mechanical_constraint.i
+++ b/modules/combined/tests/contact/pressurePenalty_mechanical_constraint.i
@@ -3,38 +3,28 @@
   disp_x = disp_x
   disp_y = disp_y
   disp_z = disp_z
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Mesh]
   file = pressure.e
-  displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./stress_yy]
     order = CONSTANT
     family = MONOMIAL
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -47,7 +37,6 @@
     slave = 10
     penalty = 1e8
     formulation = penalty
-#    model = glued
     tangential_tolerance = 1e-3
     system = constraint
     tension_release = -1
@@ -62,7 +51,7 @@
     index = 1
     execute_on = timestep_end
   [../]
-[] # AuxKernels
+[]
 
 [BCs]
   [./left_x]
@@ -99,11 +88,9 @@
     boundary = 8
     value = -2e-3
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -118,22 +105,16 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.0
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'lu       101'
 
-
   line_search = 'none'
-
 
   nl_rel_tol = 1e-9
   nl_abs_tol = 1e-9
@@ -142,8 +123,8 @@
   nl_max_its = 10
   dt = 1.0
   num_steps = 1
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Output
+[]

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template1.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template1.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []
@@ -17,12 +15,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -413,8 +407,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     normalize_penalty = true
     tangential_tolerance = 1e-3
     penalty = 1e+10

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template1_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template1_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = hertz_cyl_half_1deg.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -370,8 +369,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     normalize_penalty = true
     tangential_tolerance = 1e-3
     penalty = 1e+10

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template2_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template2_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = hertz_cyl_half_1deg.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -30,12 +33,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -389,8 +388,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     system = constraint
     model = coulomb
     formulation = kinematic

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template3_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template3_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = hertz_cyl_half_1deg.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -370,8 +369,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = coulomb
     friction_coefficient = 0.0
     system = constraint

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template1.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []
@@ -324,8 +323,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -409,9 +406,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     normalize_penalty = true
     tangential_tolerance = 1e-3
     penalty = 1e+10

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template1_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template1_sm.i
@@ -1,12 +1,11 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
+  displacements = 'disp_x disp_y'
   volumetric_locking_correction = true
 []
 
 [Mesh]
   file = hertz_cyl_half_1deg.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -294,8 +293,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -379,9 +376,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     normalize_penalty = true
     tangential_tolerance = 1e-3
     penalty = 1e+10

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template2.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template2.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []
@@ -343,8 +342,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -433,9 +430,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = kinematic

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template2_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template2_sm.i
@@ -1,12 +1,11 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
+  displacements = 'disp_x disp_y'
   volumetric_locking_correction = true
 []
 
 [Mesh]
   file = hertz_cyl_half_1deg.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -403,9 +402,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = kinematic

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template3.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template3.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []
@@ -324,8 +323,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -409,9 +406,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     model = coulomb
     friction_coefficient = 0.0
     system = constraint

--- a/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template3_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template3_sm.i
@@ -1,12 +1,11 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
+  displacements = 'disp_x disp_y'
   volumetric_locking_correction = true
 []
 
 [Mesh]
   file = hertz_cyl_half_1deg.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -294,8 +293,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -379,9 +376,6 @@
   [./interface]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     model = coulomb
     friction_coefficient = 0.0
     system = constraint

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_mu_1_0_kin_q4_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_mu_1_0_kin_q4_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = hertz_cyl_qsym_1deg_q4.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -31,12 +34,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -277,8 +276,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -297,7 +294,6 @@
   num_steps = 10
   end_time = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -351,8 +347,6 @@
   [./interface]
     master = 3
     slave = 4
-    disp_x = disp_x
-    disp_y = disp_y
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_template1.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_template1.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []
@@ -281,8 +279,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -352,8 +348,6 @@
   [./interface]
     master = 3
     slave = 4
-    disp_x = disp_x
-    disp_y = disp_y
     system = constraint
     model = glued
     formulation = kinematic

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_template1_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_template1_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = hertz_cyl_qsym_1deg_q4.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -257,8 +256,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -328,8 +325,6 @@
   [./interface]
     master = 3
     slave = 4
-    disp_x = disp_x
-    disp_y = disp_y
     system = constraint
     model = glued
     formulation = kinematic

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_mu_1_0_kin_q8.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_mu_1_0_kin_q8.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []
@@ -292,9 +291,6 @@
 [Executioner]
   type = Transient
 
-  #Preconditioned JFNK (default)
-  solve_type = 'PJFNK'
-
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu     superlu_dist'
 
@@ -311,7 +307,6 @@
   num_steps = 10
   end_time = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -365,9 +360,6 @@
   [./interface]
     master = 3
     slave = 4
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_mu_1_0_kin_q8_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_mu_1_0_kin_q8_sm.i
@@ -1,12 +1,11 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
+  displacements = 'disp_x disp_y'
 []
 
 [Mesh]
   file = hertz_cyl_qsym_1deg_q8.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -273,8 +272,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -293,7 +290,6 @@
   num_steps = 10
   end_time = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -347,9 +343,6 @@
   [./interface]
     master = 3
     slave = 4
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_template1.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []
@@ -271,8 +270,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -342,9 +339,6 @@
   [./interface]
     master = 3
     slave = 4
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_template1_sm.i
+++ b/modules/combined/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_template1_sm.i
@@ -1,12 +1,11 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
+  displacements = 'disp_x disp_y'
 []
 
 [Mesh]
   file = hertz_cyl_qsym_1deg_q8.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -253,8 +252,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -324,9 +321,6 @@
   [./interface]
     master = 3
     slave = 4
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_kin.i
@@ -1,12 +1,10 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Mesh]
   file = brick1_mesh.e
-  displacements = 'disp_x disp_y disp_z'
 []
 
 [Problem]
@@ -414,9 +412,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_kin_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = brick1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -35,16 +38,10 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -402,9 +399,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen.i
@@ -1,12 +1,10 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Mesh]
   file = brick1_mesh.e
-  displacements = 'disp_x disp_y disp_z'
 []
 
 [Problem]
@@ -78,7 +76,6 @@
 [Kernels]
   [./TensorMechanics]
     use_displaced_mesh = true
-    displacements = 'disp_x disp_y disp_z'
     save_in = 'saved_x saved_y saved_z'
   [../]
 []
@@ -293,7 +290,6 @@
   [../]
   [./bot_strain]
     type = ComputeFiniteStrain
-    displacements = 'disp_x disp_y disp_z'
     block = '1'
   [../]
   [./bot_stress]
@@ -308,7 +304,6 @@
   [../]
   [./top_strain]
     type = ComputeFiniteStrain
-    displacements = 'disp_x disp_y disp_z'
     block = '2'
   [../]
   [./top_stress]
@@ -319,8 +314,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -337,7 +330,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -389,9 +381,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = brick1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -11,16 +14,10 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -42,8 +39,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -377,9 +372,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_template1.i
@@ -1,12 +1,10 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Mesh]
   file = brick1_mesh.e
-  displacements = 'disp_x disp_y disp_z'
 []
 
 [Problem]
@@ -72,7 +70,6 @@
 [Kernels]
   [./TensorMechanics]
     use_displaced_mesh = true
-    displacements = 'disp_x disp_y disp_z'
     save_in = 'saved_x saved_y saved_z'
   [../]
 []
@@ -273,7 +270,6 @@
   [../]
   [./bot_strain]
     type = ComputeFiniteStrain
-    displacements = 'disp_x disp_y disp_z'
     block = '1'
   [../]
   [./bot_stress]
@@ -288,7 +284,6 @@
   [../]
   [./top_strain]
     type = ComputeFiniteStrain
-    displacements = 'disp_x disp_y disp_z'
     block = '2'
   [../]
   [./top_stress]
@@ -299,8 +294,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -317,7 +310,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -367,9 +359,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
     system = constraint
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_1/brick1_template1_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = brick1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -11,16 +14,10 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -42,8 +39,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -356,9 +351,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
     system = constraint
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_kin.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_kin_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = brick2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -35,16 +38,10 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -66,8 +63,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -311,8 +306,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -329,7 +322,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -382,9 +374,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = brick2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -11,16 +14,10 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -42,8 +39,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -287,8 +282,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -305,7 +298,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -357,9 +349,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_template1.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_2/brick2_template1_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = brick2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -11,16 +14,10 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -42,8 +39,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -267,8 +262,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -285,7 +278,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -335,9 +327,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
     system = constraint
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_kin.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_kin_sm.i
@@ -1,6 +1,10 @@
 [Mesh]
   file = brick3_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
+  order = SECOND
 []
 
 [Problem]
@@ -35,16 +39,10 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -66,53 +64,36 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./saved_z]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./diag_saved_z]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./inc_slip_z]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_z]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
   [./tang_force_z]
-    order = SECOND
   [../]
 []
 
@@ -326,8 +307,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -344,7 +323,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -396,11 +374,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = brick3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -11,16 +15,10 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -42,53 +40,36 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./saved_z]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./diag_saved_z]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./inc_slip_z]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_z]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
   [./tang_force_z]
-    order = SECOND
   [../]
 []
 
@@ -302,8 +283,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -320,7 +299,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -372,11 +350,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_3/brick3_template1_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = brick3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -11,16 +15,10 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -42,44 +40,30 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./saved_z]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./diag_saved_z]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./inc_slip_z]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_z]
-    order = SECOND
   [../]
 []
 
@@ -279,8 +263,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -297,7 +279,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -347,9 +328,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
     order = SECOND
     system = constraint

--- a/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_kin.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_kin_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = brick4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -35,16 +39,10 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -66,53 +64,36 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./saved_z]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./diag_saved_z]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./inc_slip_z]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_z]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
   [./tang_force_z]
-    order = SECOND
   [../]
 []
 
@@ -326,8 +307,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -344,7 +323,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -396,11 +374,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = brick4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -11,16 +15,10 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -42,53 +40,36 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./saved_z]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./diag_saved_z]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./inc_slip_z]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_z]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
   [./tang_force_z]
-    order = SECOND
   [../]
 []
 
@@ -372,11 +353,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y disp_z'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/brick_4/brick4_template1_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = brick4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -11,16 +15,10 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -42,44 +40,30 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./saved_z]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./diag_saved_z]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./inc_slip_z]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_z]
-    order = SECOND
   [../]
 []
 
@@ -279,8 +263,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -297,7 +279,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -347,11 +328,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     master = 4
-    order = SECOND
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_kin.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_kin_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = cyl1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -30,12 +33,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -57,8 +56,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -273,8 +270,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -291,7 +286,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -338,8 +332,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_y = disp_y
-    disp_x = disp_x
     model = coulomb
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_pen.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_pen_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = cyl1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -255,8 +258,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -273,7 +274,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -319,8 +319,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_template1.i
@@ -6,8 +6,6 @@
 #
 
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_1/cyl1_template1_sm.i
@@ -7,6 +7,9 @@
 
 [Mesh]
   file = cyl1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -17,12 +20,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -44,8 +43,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -262,8 +259,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -280,7 +275,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -324,8 +318,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_kin.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_kin_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = cyl2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -30,12 +33,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -57,8 +56,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -273,8 +270,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -291,7 +286,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -338,8 +332,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_y = disp_y
-    disp_x = disp_x
     system = constraint
     model = coulomb
     formulation = kinematic

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_pen.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_pen_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = cyl2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +13,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -37,8 +36,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -319,8 +316,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_template1.i
@@ -6,8 +6,6 @@
 #
 
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_2/cyl2_template1_sm.i
@@ -7,6 +7,9 @@
 
 [Mesh]
   file = cyl2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -17,12 +20,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -44,8 +43,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -324,8 +321,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = cyl3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -30,12 +34,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -57,38 +57,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -283,8 +271,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -301,7 +287,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -348,9 +333,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_y = disp_y
-    disp_x = disp_x
-    order = SECOND
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_pen.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_pen_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = cyl3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -37,38 +37,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -265,8 +253,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -283,7 +269,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -329,10 +314,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_template1.i
@@ -7,7 +7,6 @@
 
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_3/cyl3_template1_sm.i
@@ -7,6 +7,10 @@
 
 [Mesh]
   file = cyl3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -17,12 +21,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -44,38 +44,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -272,8 +260,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -290,7 +276,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -334,10 +319,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     tangential_tolerance = 1e-3
     penalty = 1e+9

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_kin.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_kin_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = cyl4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -30,12 +34,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -57,38 +57,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -283,8 +271,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -301,7 +287,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -347,14 +332,9 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = glued
-#    model = coulomb
-#    formulation = kinematic
     tangential_tolerance = 1e-3
     penalty = 1e+9
   [../]

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_pen.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_pen_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = cyl4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -37,38 +37,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -265,8 +253,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -283,7 +269,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -329,10 +314,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/cyl_4/cyl4_template1_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = cyl4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -37,38 +37,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -265,8 +253,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -283,7 +269,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -327,10 +312,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     tangential_tolerance = 1e-3
     penalty = 1e+9

--- a/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_kin.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_kin_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = plane1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -31,12 +34,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -58,8 +57,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -262,8 +259,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -280,7 +275,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -326,8 +320,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = plane1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -38,8 +37,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -262,8 +259,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -280,7 +275,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -326,8 +320,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_template1.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_1/plane1_template1_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = plane1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -38,8 +37,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -304,8 +301,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_kin.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_kin_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = plane2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -31,12 +34,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -58,8 +57,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -262,8 +259,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -280,7 +275,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -326,8 +320,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = plane2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -38,8 +37,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -262,8 +259,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -280,7 +275,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -326,8 +320,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     model = coulomb

--- a/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_template1.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_2/plane2_template1_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = plane2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -38,8 +37,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -242,8 +239,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -260,7 +255,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -304,8 +298,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
     system = constraint
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
@@ -1,10 +1,11 @@
 [GlobalParams]
+  order = SECOND
   volumetric_locking_correction = true
+  displacements = 'disp_x disp_y'
 []
 
 [Mesh]
   file = plane3_mesh.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -35,12 +36,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -62,37 +59,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -277,8 +263,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -295,7 +279,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -341,10 +324,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = plane3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +15,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -38,37 +38,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -269,8 +258,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -287,7 +274,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -333,10 +319,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = plane3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +15,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -38,37 +38,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -253,8 +242,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -271,7 +258,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -315,10 +301,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_kin.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_kin_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = plane4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -31,12 +35,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -58,40 +58,27 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
-[]
-
 [SolidMechanics]
   [./solid]
     disp_x = disp_x
@@ -273,8 +260,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -291,7 +276,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -337,10 +321,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = plane4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +15,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -38,37 +38,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -269,8 +258,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -287,7 +274,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -333,10 +319,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/plane_4/plane4_template1_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = plane4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -11,12 +15,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -38,37 +38,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -253,8 +242,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -271,7 +258,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-3
-
 []
 
 [VectorPostprocessors]
@@ -315,10 +301,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_kin.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_kin_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = ring1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -31,12 +34,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -58,8 +57,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -268,8 +265,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -286,7 +281,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -333,8 +327,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_y = disp_y
-    disp_x = disp_x
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_pen.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_pen_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = ring1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +13,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -37,8 +36,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -250,8 +247,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -268,7 +263,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -315,8 +309,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_y = disp_y
-    disp_x = disp_x
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_1/ring1_template1_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = ring1_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +13,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -37,8 +36,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -250,8 +247,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -268,7 +263,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -313,8 +307,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_y = disp_y
-    disp_x = disp_x
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_kin.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_kin_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = ring2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -31,12 +34,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -58,8 +57,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -269,8 +266,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -287,7 +282,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -334,8 +328,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_x = disp_x
-    disp_y = disp_y
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_pen.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_pen_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = ring2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +13,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -37,8 +36,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -315,8 +312,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_x = disp_x
-    disp_y = disp_y
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_template1.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_2/ring2_template1_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = ring2_mesh.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +13,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -37,8 +36,6 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -249,8 +246,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -267,7 +262,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -312,8 +306,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_x = disp_x
-    disp_y = disp_y
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_kin_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = ring3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -31,12 +35,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -58,38 +58,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -278,8 +266,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -296,7 +282,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-4
-
 []
 
 [VectorPostprocessors]
@@ -342,10 +327,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_pen.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_pen_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = ring3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -37,44 +37,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./inc_slip_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./accum_slip_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./accum_slip_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./tang_force_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./tang_force_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -263,8 +245,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -281,7 +261,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -327,10 +306,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_3/ring3_template1_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = ring3_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -37,38 +37,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -257,8 +245,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -275,7 +261,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -320,9 +305,6 @@
   [./leftright]
     slave = 3
     master = 4
-    disp_x = disp_x
-    disp_y = disp_y
-    order = SECOND
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_kin.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_kin.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_kin_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_kin_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = ring4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -31,12 +35,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -58,38 +58,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -278,8 +266,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -296,7 +282,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -342,10 +327,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     normalize_penalty = true

--- a/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_pen.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_pen.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_pen_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_pen_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = ring4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -37,44 +37,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./inc_slip_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./accum_slip_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./accum_slip_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./tang_force_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./tang_force_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -265,8 +247,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -283,7 +263,6 @@
   num_steps = 10
   dtmin = 1.0
   l_tol = 1e-5
-
 []
 
 [VectorPostprocessors]
@@ -329,10 +308,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     model = coulomb
     formulation = penalty

--- a/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_template1.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_template1.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_template1_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/ring_4/ring4_template1_sm.i
@@ -1,5 +1,9 @@
 [Mesh]
   file = ring4_mesh.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'disp_x disp_y'
 []
 
@@ -10,12 +14,8 @@
 
 [Variables]
   [./disp_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -37,38 +37,26 @@
     family = MONOMIAL
   [../]
   [./penetration]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./saved_x]
-    order = SECOND
   [../]
   [./saved_y]
-    order = SECOND
   [../]
   [./diag_saved_x]
-    order = SECOND
   [../]
   [./diag_saved_y]
-    order = SECOND
   [../]
   [./inc_slip_x]
-    order = SECOND
   [../]
   [./inc_slip_y]
-    order = SECOND
   [../]
   [./accum_slip_x]
-    order = SECOND
   [../]
   [./accum_slip_y]
-    order = SECOND
   [../]
   [./tang_force_x]
-    order = SECOND
   [../]
   [./tang_force_y]
-    order = SECOND
   [../]
 []
 
@@ -321,10 +309,7 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 4
-    order = SECOND
     system = constraint
     normalize_penalty = true
     tangential_tolerance = 1e-3

--- a/modules/combined/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d.i
+++ b/modules/combined/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_frictional.i
+++ b/modules/combined/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_frictional.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   volumetric_locking_correction = true
   displacements = 'disp_x disp_y'
 []

--- a/modules/combined/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_frictional_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_frictional_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = single_point_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -190,8 +191,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -226,8 +225,6 @@
   [./leftright]
     master = 2
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     model = coulomb
     system = constraint
     formulation = kinematic

--- a/modules/combined/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_sm.i
+++ b/modules/combined/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_sm.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = single_point_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -190,8 +191,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
@@ -236,4 +235,3 @@
     tangential_tolerance = 1e-3
   [../]
 []
-

--- a/modules/combined/tests/fdp_geometric_coupling/fdp_geometric_coupling_test.i
+++ b/modules/combined/tests/fdp_geometric_coupling/fdp_geometric_coupling_test.i
@@ -1,32 +1,22 @@
-
 [Mesh]
   file = twoBlocksContactDiceSlave2OffsetGap.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./temp]
-    order = FIRST
-    family = LAGRANGE
     initial_condition = 100.0
   [../]
-
-[] # Variables
+[]
 
 [Functions]
   [./pressure]
@@ -41,8 +31,7 @@
     x = '0. 3.'
     y = '100.0 440.0'
   [../]
-
-[] # Functions
+[]
 
 [SolidMechanics]
   [./solid]
@@ -54,14 +43,11 @@
 []
 
 [Kernels]
-
   [./heat]
     type = HeatConduction
     variable = temp
   [../]
-
-[] # Kernels
-
+[]
 
 [BCs]
   [./left_x]
@@ -112,22 +98,17 @@
     boundary = '2 3'
     function = tempFunc
   [../]
-
-[] # BCs
+[]
 
 [Contact]
   [./dummy_name]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     penalty = 1e6
   [../]
 []
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -173,12 +154,9 @@
     disp_y = disp_y
     disp_z = disp_z
   [../]
-
-[] # Materials
+[]
 
 [Preconditioning]
-  active = 'FDP'
-
   [./FDP]
     type = FDP
     full = true
@@ -188,11 +166,7 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -mat_fd_coloring_err -mat_fd_type'
   petsc_options_value = 'lu       1e-8                 ds'
@@ -203,9 +177,9 @@
   nl_max_its = 3
   dt = 1.0e-1
   num_steps = 10
-[] # Executioner
+[]
 
 [Outputs]
   file_base = out
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/fieldsplit_contact/2blocks3d.i
+++ b/modules/combined/tests/fieldsplit_contact/2blocks3d.i
@@ -1,14 +1,12 @@
 [GlobalParams]
-  order = FIRST
-  family = LAGRANGE
   disp_x = disp_x
   disp_y = disp_y
   disp_z = disp_z
+  displacements = 'disp_x disp_y disp_z'
 []
 
 [Mesh]
   file = 2blocks3d.e
-  displacements = 'disp_x disp_y disp_z'
   patch_size = 5
 []
 
@@ -106,8 +104,6 @@
 []
 
 [Preconditioning]
-  active = 'FSP'
-
   [./FSP]
     type = FSP
     # It is the starting point of splitting

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = single_point_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -179,15 +180,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu    superlu_dist'
-
 
   line_search = 'none'
 
@@ -217,8 +213,6 @@
   [./leftright]
     master = 2
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     model = coulomb
     system = constraint
     friction_coefficient = '0.25'

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_fcp.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_fcp.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = single_point_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -179,15 +180,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu    superlu_dist'
-
 
   line_search = 'none'
 
@@ -217,8 +213,6 @@
   [./leftright]
     master = 2
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     model = coulomb
     system = constraint
   [../]

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_fcp_predictor.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_fcp_predictor.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = single_point_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -179,15 +180,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu    superlu_dist'
-
 
   line_search = 'none'
 
@@ -222,8 +218,6 @@
   [./leftright]
     master = 2
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     model = coulomb
     system = constraint
   [../]

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_predictor.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_predictor.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = single_point_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -179,15 +180,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu    superlu_dist'
-
 
   line_search = 'none'
 
@@ -222,8 +218,6 @@
   [./leftright]
     master = 2
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     model = coulomb
     system = constraint
     friction_coefficient = '0.25'

--- a/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_tp.i
+++ b/modules/combined/tests/frictional_contact/single_point_2d/single_point_2d_tp.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = single_point_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -179,15 +180,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu    superlu_dist'
-
 
   line_search = 'none'
 
@@ -217,8 +213,6 @@
   [./leftright]
     master = 2
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     model = coulomb
     system = constraint
     friction_coefficient = '0.25'

--- a/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
+++ b/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
@@ -1,8 +1,10 @@
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
 
 [Variables]
   [./disp_x]
@@ -13,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -205,15 +205,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu     superlu_dist'
-
 
   line_search = 'none'
 
@@ -250,8 +245,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = coulomb
     system = constraint
@@ -263,7 +256,7 @@
 [Dampers]
   [./contact_slip]
     type = ContactSlipDamper
-    master = '2'
-    slave = '3'
+    slave = 3
+    master = 2
   [../]
 []

--- a/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d_fcp.i
+++ b/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d_fcp.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = sliding_elastic_blocks_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -36,8 +39,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -171,15 +172,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg      101'
-
 
   line_search = 'none'
 
@@ -214,8 +210,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = glued
     penalty = 1e+6

--- a/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d_tp.i
+++ b/modules/combined/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d_tp.i
@@ -1,8 +1,10 @@
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
 []
 
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
 
 [Variables]
   [./disp_x]
@@ -13,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_x]
   [../]
@@ -205,15 +205,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu     superlu_dist'
-
 
   line_search = 'none'
 
@@ -250,8 +245,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = coulomb
     system = constraint
@@ -264,7 +257,7 @@
 [Dampers]
   [./contact_slip]
     type = ContactSlipDamper
-    master = '2'
-    slave = '3'
+    slave = 3
+    master = 2
   [../]
 []

--- a/modules/combined/tests/glued_contact/glued_contact_mechanical_constraint_test.i
+++ b/modules/combined/tests/glued_contact/glued_contact_mechanical_constraint_test.i
@@ -1,6 +1,9 @@
 # This is a mechanical constraint (contact formulation) version of glued_contact_mechanical_constraint.i
 [Mesh]
   file = glued_contact_test.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -21,20 +24,12 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -48,9 +43,6 @@
   [./dummy_name]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     penalty = 1e6
     model = glued
     formulation = kinematic
@@ -87,11 +79,9 @@
     boundary = 4
     value = 0.0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -115,24 +105,18 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.3
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-
-
-#  petsc_options_iname = '-pc_type -pc_hypre_type -snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart'
-#  petsc_options_value = 'hypre    boomeramg      ls         basic    basic                    101'
+  #petsc_options_iname = '-pc_type -pc_hypre_type -snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart'
+  #petsc_options_value = 'hypre    boomeramg      ls         basic    basic                    101'
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'ilu      101'
 
-
   line_search = 'none'
-
 
   nl_abs_tol = 1e-8
   nl_rel_tol = 1e-8
@@ -147,7 +131,7 @@
     type = SimplePredictor
     scale = 1.0
   [../]
-[] # Executioner
+[]
 
 [Postprocessors]
   active = ''
@@ -162,4 +146,4 @@
 [Outputs]
   file_base = mechanical_constraint_out
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/glued_contact/glued_contact_test.i
+++ b/modules/combined/tests/glued_contact/glued_contact_test.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = glued_contact_test.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
@@ -20,20 +23,12 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -47,9 +42,6 @@
   [./dummy_name]
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     penalty = 1e6
     model = glued
     formulation = kinematic
@@ -57,7 +49,6 @@
 []
 
 [BCs]
-
   [./bottom_lateral]
     type = FunctionPresetBC
     variable = disp_x
@@ -85,11 +76,9 @@
     boundary = 4
     value = 0.0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -113,24 +102,18 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.3
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-
-
-#  petsc_options_iname = '-pc_type -pc_hypre_type -snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart'
-#  petsc_options_value = 'hypre    boomeramg      ls         basic    basic                    101'
+  #petsc_options_iname = '-pc_type -pc_hypre_type -snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart'
+  #petsc_options_value = 'hypre    boomeramg      ls         basic    basic                    101'
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'ilu      101'
 
-
   line_search = 'none'
-
 
   nl_abs_tol = 1e-8
   nl_rel_tol = 1e-8
@@ -145,7 +128,7 @@
     type = SimplePredictor
     scale = 1.0
   [../]
-[] # Executioner
+[]
 
 [Postprocessors]
   active = ''
@@ -160,4 +143,4 @@
 [Outputs]
   file_base = out
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/glued_contact_constraint/glued_contact_constraint.i
+++ b/modules/combined/tests/glued_contact_constraint/glued_contact_constraint.i
@@ -1,26 +1,21 @@
 [Mesh]
   type = FileMesh
   file = simplest_contact.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
 [Variables]
-  # Variables
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
 [AuxVariables]
-  # AuxVariables
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -48,8 +43,6 @@
     component = 0
     slave = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
     nodal_area = penetration
     boundary = 2
@@ -61,8 +54,6 @@
     component = 1
     slave = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
     nodal_area = penetration
     boundary = 3
@@ -70,7 +61,6 @@
 []
 
 [BCs]
-  # BCs
   [./left_x]
     type = DirichletBC
     variable = disp_x
@@ -98,7 +88,6 @@
 []
 
 [Materials]
-  # Materials
   [./stiffStuff1]
     type = LinearIsotropicMaterial
     block = 1

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = blocks_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -164,8 +165,6 @@
     system = Constraint
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = frictionless
     formulation = default
     penalty = 1e+6

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic_dirac.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_kinematic_dirac.i
@@ -1,6 +1,9 @@
 # This is a dirac (contact formulation) version of frictionless_kinematic.i
 [Mesh]
   file = blocks_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -13,8 +16,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -162,11 +163,8 @@
 
 [Contact]
   [./leftright]
-#    system = Constraint
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = frictionless
     formulation = default
     penalty = 1e+6

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = blocks_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -164,8 +165,6 @@
     system = Constraint
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = frictionless
     formulation = penalty
     penalty = 1e+7

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty_dirac.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/frictionless_penalty_dirac.i
@@ -1,6 +1,9 @@
 # This is a dirac (contact formulation) version of frictionless_penalty.i
 [Mesh]
   file = blocks_2d.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -13,8 +16,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -162,11 +163,8 @@
 
 [Contact]
   [./leftright]
-#    system = Constraint
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = frictionless
     formulation = penalty
     penalty = 1e+7

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = blocks_2d_nogap.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -164,8 +165,6 @@
     system = Constraint
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = glued
     formulation = default
     penalty = 1e+6

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic_dirac.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_kinematic_dirac.i
@@ -1,6 +1,9 @@
 # This is a dirac (contact formulation) version of glued_kinematic.i
 [Mesh]
   file = blocks_2d_nogap.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -13,8 +16,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -165,8 +166,6 @@
 #    system = Constraint
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = glued
     formulation = default
     penalty = 1e+6

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = blocks_2d_nogap.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -12,8 +15,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -164,8 +165,6 @@
     system = Constraint
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = glued
     formulation = penalty
     penalty = 1e+7

--- a/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty_dirac.i
+++ b/modules/combined/tests/mechanical_contact_constraint/blocks_2d/glued_penalty_dirac.i
@@ -1,6 +1,9 @@
 # This is a dirac (contact formulation) version of glued_penalty.i
 [Mesh]
   file = blocks_2d_nogap.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -13,8 +16,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -162,11 +163,8 @@
 
 [Contact]
   [./leftright]
-#    system = Constraint
     master = 2
     slave = 3
-    disp_x = disp_x
-    disp_y = disp_y
     model = glued
     formulation = penalty
     penalty = 1e+7

--- a/modules/combined/tests/nodal_area/nodal_area_2D.i
+++ b/modules/combined/tests/nodal_area/nodal_area_2D.i
@@ -1,19 +1,17 @@
-[Mesh]#Comment
+[Mesh]
   file = nodal_area_2D.e
-[] # Mesh
+[]
 
 [Problem]
   coord_type = RZ
 []
 
 [Variables]
-
   [./dummy]
     order = FIRST
     family = LAGRANGE
   [../]
-
-[] # Variables
+[]
 
 [AuxVariables]
   [./nodal_area]
@@ -23,13 +21,11 @@
 []
 
 [Kernels]
-
   [./dummy]
     type = Diffusion
     variable = dummy
   [../]
-
-[] # Kernels
+[]
 
 [UserObjects]
   [./nodal_area]
@@ -41,40 +37,29 @@
 []
 
 [BCs]
-
   [./dummy]
     type = DirichletBC
     variable = dummy
     boundary = 1
     value = 100
   [../]
-
-[] # BCs
+[]
 
 [Executioner]
-
   type = Steady
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'jacobi   101'
 
-
   line_search = 'none'
-
 
   nl_abs_tol = 1e-11
   nl_rel_tol = 1e-10
 
-
   l_max_its = 20
-
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/nodal_area/nodal_area_3D.i
+++ b/modules/combined/tests/nodal_area/nodal_area_3D.i
@@ -1,15 +1,11 @@
-[Mesh]#Comment
+[Mesh]
   file = nodal_area_3D.e
-[] # Mesh
+[]
 
 [Variables]
-
   [./dummy]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
-[] # Variables
+[]
 
 [AuxVariables]
   [./nodal_area]
@@ -19,13 +15,11 @@
 []
 
 [Kernels]
-
   [./dummy]
     type = Diffusion
     variable = dummy
   [../]
-
-[] # Kernels
+[]
 
 [UserObjects]
   [./nodal_area]
@@ -37,40 +31,29 @@
 []
 
 [BCs]
-
   [./dummy]
     type = DirichletBC
     variable = dummy
     boundary = 1
     value = 100
   [../]
-
-[] # BCs
+[]
 
 [Executioner]
-
   type = Steady
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'jacobi   101'
 
-
   line_search = 'none'
-
 
   nl_abs_tol = 1e-11
   nl_rel_tol = 1e-10
 
-
   l_max_its = 20
-
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Output
+[]

--- a/modules/combined/tests/nodal_area/nodal_area_Hex20.i
+++ b/modules/combined/tests/nodal_area/nodal_area_Hex20.i
@@ -1,32 +1,26 @@
 [Mesh]
   file = nodal_area_Hex20.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'displ_x displ_y displ_z'
 []
 
 [Functions]
-
   [./disp]
     type = PiecewiseLinear
     x = '0     1'
     y = '0  20e-6'
   [../]
-
 []
 
 [Variables]
   [./displ_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
-
   [./displ_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
-
   [./displ_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -36,16 +30,10 @@
     family = MONOMIAL
   [../]
   [./react_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./react_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./react_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -70,7 +58,6 @@
 []
 
 [BCs]
-
   [./move_right]
     type = FunctionPresetBC
     boundary = '1'
@@ -98,25 +85,18 @@
     variable = displ_z
     value = 0
   [../]
-
 []
 
 [Contact]
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = displ_x
-    disp_y = displ_y
-    disp_z = displ_z
     penalty = 1e7
-    order = SECOND
     tangential_tolerance = 1e-5
   [../]
 []
 
-
 [Materials]
-
   [./dummy]
     type = Elastic
     block = '1 2'
@@ -128,14 +108,12 @@
     youngs_modulus = 1e6
     poissons_ratio = 0
   [../]
-
 []
 
 [Executioner]
   type = Transient
-
-  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
+
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre    boomeramg      4'
 

--- a/modules/combined/tests/nodal_area/nodal_area_Hex20_2.i
+++ b/modules/combined/tests/nodal_area/nodal_area_Hex20_2.i
@@ -1,32 +1,26 @@
 [Mesh]
   file = nodal_area_Hex20.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'displ_x displ_y displ_z'
 []
 
 [Functions]
-
   [./disp]
     type = PiecewiseLinear
     x = '0     1'
     y = '0  20e-6'
   [../]
-
 []
 
 [Variables]
   [./displ_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
-
   [./displ_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
-
   [./displ_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -36,16 +30,10 @@
     family = MONOMIAL
   [../]
   [./react_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./react_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./react_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -70,7 +58,6 @@
 []
 
 [BCs]
-
   [./move_right]
     type = FunctionPresetBC
     boundary = '1'
@@ -98,26 +85,19 @@
     variable = displ_z
     value = 0
   [../]
-
 []
 
 [Contact]
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = displ_x
-    disp_y = displ_y
-    disp_z = displ_z
     model = frictionless
     penalty = 1e7
-    order = SECOND
     tangential_tolerance = 1e-5
   [../]
 []
 
-
 [Materials]
-
   [./dummy]
     type = Elastic
     block = '1 2'
@@ -129,14 +109,12 @@
     youngs_modulus = 1e6
     poissons_ratio = 0
   [../]
-
 []
 
 [Executioner]
   type = Transient
-
-  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
+
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre    boomeramg      4'
 

--- a/modules/combined/tests/nodal_area/nodal_area_Hex20_3.i
+++ b/modules/combined/tests/nodal_area/nodal_area_Hex20_3.i
@@ -1,32 +1,26 @@
 [Mesh]
   file = nodal_area_Hex20.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'displ_x displ_y displ_z'
 []
 
 [Functions]
-
   [./disp]
     type = PiecewiseLinear
     x = '0     1'
     y = '0  20e-6'
   [../]
-
 []
 
 [Variables]
   [./displ_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
-
   [./displ_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
-
   [./displ_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -36,16 +30,10 @@
     family = MONOMIAL
   [../]
   [./react_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./react_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./react_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -70,7 +58,6 @@
 []
 
 [BCs]
-
   [./move_right]
     type = FunctionPresetBC
     boundary = '1'
@@ -98,26 +85,19 @@
     variable = displ_z
     value = 0
   [../]
-
 []
 
 [Contact]
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = displ_x
-    disp_y = displ_y
-    disp_z = displ_z
     formulation = penalty
     penalty = 1e9
-    order = SECOND
     tangential_tolerance = 1e-5
   [../]
 []
 
-
 [Materials]
-
   [./dummy]
     type = Elastic
     block = '1 2'
@@ -129,14 +109,12 @@
     youngs_modulus = 1e6
     poissons_ratio = 0
   [../]
-
 []
 
 [Executioner]
   type = Transient
-
-  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
+
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre    boomeramg      4'
 

--- a/modules/combined/tests/nodal_area/nodal_area_Hex27.i
+++ b/modules/combined/tests/nodal_area/nodal_area_Hex27.i
@@ -1,32 +1,26 @@
 [Mesh]
   file = nodal_area_Hex27.e
+[]
+
+[GlobalParams]
+  order = SECOND
   displacements = 'displ_x displ_y displ_z'
 []
 
 [Functions]
-
   [./disp]
     type = PiecewiseLinear
     x = '0     1'
     y = '0  20e-6'
   [../]
-
 []
 
 [Variables]
   [./displ_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
-
   [./displ_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
-
   [./displ_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -36,16 +30,10 @@
     family = MONOMIAL
   [../]
   [./react_x]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./react_y]
-    order = SECOND
-    family = LAGRANGE
   [../]
   [./react_z]
-    order = SECOND
-    family = LAGRANGE
   [../]
 []
 
@@ -70,7 +58,6 @@
 []
 
 [BCs]
-
   [./move_right]
     type = FunctionPresetBC
     boundary = '1'
@@ -98,25 +85,18 @@
     variable = displ_z
     value = 0
   [../]
-
 []
 
 [Contact]
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = displ_x
-    disp_y = displ_y
-    disp_z = displ_z
     penalty = 1e8
-    order = SECOND
     tangential_tolerance = 1e-4
   [../]
 []
 
-
 [Materials]
-
   [./dummy]
     type = Elastic
     block = '1 2'
@@ -128,26 +108,18 @@
     youngs_modulus = 1e6
     poissons_ratio = 0
   [../]
-
 []
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-
-
-#  petsc_options_iname = '-snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart -pc_type'
-#  petsc_options_value = 'ls         basic    basic                    201                lu'
-
+  #petsc_options_iname = '-snes_type -snes_ls -snes_linesearch_type -ksp_gmres_restart -pc_type'
+  #petsc_options_value = 'ls         basic    basic                    201                lu'
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre    boomeramg      4'
 
-
   line_search = 'none'
-
 
   nl_abs_tol = 1e-7
   nl_rel_tol = 1e-6

--- a/modules/combined/tests/normalized_penalty/normalized_penalty.i
+++ b/modules/combined/tests/normalized_penalty/normalized_penalty.i
@@ -1,11 +1,11 @@
 [GlobalParams]
   disp_x = disp_x
   disp_y = disp_y
+  displacements = 'disp_x disp_y'
 []
 
 [Mesh]
   file = normalized_penalty.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -24,34 +24,21 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./stress_xx]
     order = CONSTANT
     family = MONOMIAL
   [../]
-
   [./saved_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -79,7 +66,7 @@
     index = 0
     execute_on = timestep_end
   [../]
-[] # AuxKernels
+[]
 
 [BCs]
   [./left_x]
@@ -102,8 +89,7 @@
     boundary = '3 4'
     value = 0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
   [./stiffStuff1]
@@ -114,22 +100,16 @@
     poissons_ratio = 0.0
 
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'lu       101'
 
-
   line_search = 'none'
-
 
   nl_rel_tol = 1e-12
   nl_abs_tol = 1e-10
@@ -138,8 +118,8 @@
   nl_max_its = 10
   dt = 1.0
   num_steps = 2
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Output
+[]

--- a/modules/combined/tests/normalized_penalty/normalized_penalty_Q8.i
+++ b/modules/combined/tests/normalized_penalty/normalized_penalty_Q8.i
@@ -2,12 +2,11 @@
   disp_x = disp_x
   disp_y = disp_y
   order = SECOND
-  family = LAGRANGE
+  displacements = 'disp_x disp_y'
 []
 
 [Mesh]
   file = normalized_penalty_Q8.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -27,25 +26,20 @@
 [Variables]
   [./disp_x]
   [../]
-
   [./disp_y]
   [../]
-
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./stress_xx]
     order = CONSTANT
     family = MONOMIAL
   [../]
-
   [./saved_x]
   [../]
   [./saved_y]
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -73,7 +67,7 @@
     index = 0
     execute_on = timestep_end
   [../]
-[] # AuxKernels
+[]
 
 [BCs]
   [./left_x]
@@ -96,8 +90,7 @@
     boundary = '3 4'
     value = 0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
   [./stiffStuff1]
@@ -106,24 +99,17 @@
 
     youngs_modulus = 3e8
     poissons_ratio = 0.0
-
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'lu       101'
 
-
   line_search = 'none'
-
 
   nl_rel_tol = 1e-12
   nl_abs_tol = 1e-8
@@ -132,8 +118,8 @@
   nl_max_its = 10
   dt = 1.0
   num_steps = 2
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Output
+[]

--- a/modules/combined/tests/normalized_penalty/normalized_penalty_kin.i
+++ b/modules/combined/tests/normalized_penalty/normalized_penalty_kin.i
@@ -1,11 +1,11 @@
 [GlobalParams]
   disp_x = disp_x
   disp_y = disp_y
+  displacements = 'disp_x disp_y'
 []
 
 [Mesh]
   file = normalized_penalty.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -24,34 +24,21 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./stress_xx]
     order = CONSTANT
     family = MONOMIAL
   [../]
-
   [./saved_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./saved_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -78,7 +65,7 @@
     index = 0
     execute_on = timestep_end
   [../]
-[] # AuxKernels
+[]
 
 [BCs]
   [./left_x]
@@ -101,8 +88,7 @@
     boundary = '3 4'
     value = 0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
   [./stiffStuff1]
@@ -111,24 +97,17 @@
 
     youngs_modulus = 3e8
     poissons_ratio = 0.0
-
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'lu       101'
 
-
   line_search = 'none'
-
 
   nl_rel_tol = 1e-12
   nl_abs_tol = 1e-10
@@ -137,8 +116,8 @@
   nl_max_its = 10
   dt = 1.0
   num_steps = 2
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Output
+[]

--- a/modules/combined/tests/normalized_penalty/normalized_penalty_kin_Q8.i
+++ b/modules/combined/tests/normalized_penalty/normalized_penalty_kin_Q8.i
@@ -2,12 +2,11 @@
   disp_x = disp_x
   disp_y = disp_y
   order = SECOND
-  family = LAGRANGE
+  displacements = 'disp_x disp_y'
 []
 
 [Mesh]
   file = normalized_penalty_Q8.e
-  displacements = 'disp_x disp_y'
 []
 
 [Problem]
@@ -27,25 +26,20 @@
 [Variables]
   [./disp_x]
   [../]
-
   [./disp_y]
   [../]
-
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./stress_xx]
     order = CONSTANT
     family = MONOMIAL
   [../]
-
   [./saved_x]
   [../]
   [./saved_y]
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -72,7 +66,7 @@
     index = 0
     execute_on = timestep_end
   [../]
-[] # AuxKernels
+[]
 
 [BCs]
   [./left_x]
@@ -95,8 +89,7 @@
     boundary = '3 4'
     value = 0
   [../]
-
-[] # BCs
+[]
 
 [Materials]
   [./stiffStuff1]
@@ -105,24 +98,17 @@
 
     youngs_modulus = 3e8
     poissons_ratio = 0.0
-
   [../]
-[] # Materials
+[]
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
   petsc_options_value = 'lu       101'
 
-
   line_search = 'none'
-
 
   nl_rel_tol = 1e-12
   nl_abs_tol = 1e-9
@@ -131,8 +117,8 @@
   nl_max_its = 10
   dt = 1.0
   num_steps = 2
-[] # Executioner
+[]
 
 [Outputs]
   exodus = true
-[] # Output
+[]

--- a/modules/combined/tests/ring_contact/ring_contact.i
+++ b/modules/combined/tests/ring_contact/ring_contact.i
@@ -6,25 +6,21 @@
 
 [GlobalParams]
   order = SECOND
-  family = LAGRANGE
+  displacements = 'disp_x disp_y disp_z'
 []
-
 
 [Mesh]
   file = ring_contact.e
-  displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
   [./disp_x]
   [../]
-
   [./disp_y]
   [../]
-
   [./disp_z]
   [../]
-[] # Variables
+[]
 
 [Functions]
   [./ring_y]
@@ -97,11 +93,9 @@
     boundary = 4
     function = ring_y
   [../]
-
-[] # BCs
+[]
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = 1
@@ -124,7 +118,7 @@
     youngs_modulus = 1e3
     poissons_ratio = 0.3
   [../]
-[] # Materials
+[]
 
 [Preconditioning]
   [./SMP]
@@ -135,8 +129,6 @@
 
 [Executioner]
   type = Transient
-
-  # Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'
@@ -152,10 +144,9 @@
   [./Quadrature]
     order = THIRD
   [../]
-
-[] # Executioner
+[]
 
 [Outputs]
   file_base = out
   exodus = true
-[] # Outputs
+[]

--- a/modules/combined/tests/simple_contact/merged.i
+++ b/modules/combined/tests/simple_contact/merged.i
@@ -5,18 +5,12 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
 
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -67,9 +61,6 @@
     component = 0
     boundary = 3
     slave = 2
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
   [../]
 
   [./master_y]
@@ -78,9 +69,6 @@
     component = 1
     boundary = 3
     slave = 2
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
   [../]
 
   [./master_z]
@@ -89,9 +77,6 @@
     component = 2
     boundary = 3
     slave = 2
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
   [../]
 
   [./slave_x]
@@ -100,9 +85,6 @@
     component = 0
     boundary = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
   [../]
 
   [./slave_y]
@@ -111,9 +93,6 @@
     component = 1
     boundary = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
   [../]
 
   [./slave_z]
@@ -122,9 +101,6 @@
     component = 2
     boundary = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
   [../]
 []
 

--- a/modules/combined/tests/simple_contact/merged_rz.i
+++ b/modules/combined/tests/simple_contact/merged_rz.i
@@ -1,5 +1,8 @@
 [Mesh]
   file = merged_rz.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -161,7 +164,6 @@
 
 [Executioner]
   type = Transient
-
   solve_type = 'PJFNK'
 
   petsc_options = '-snes_ksp_ew'

--- a/modules/combined/tests/simple_contact/simple_contact_dirac_test.i
+++ b/modules/combined/tests/simple_contact/simple_contact_dirac_test.i
@@ -3,23 +3,18 @@
 
 [Mesh]
   file = contact.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -42,9 +37,6 @@
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     penalty = 1e5
     formulation = kinematic
   [../]
@@ -131,7 +123,6 @@
 
 [Executioner]
   type = Transient
-
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'

--- a/modules/combined/tests/simple_contact/simple_contact_rspherical.i
+++ b/modules/combined/tests/simple_contact/simple_contact_rspherical.i
@@ -18,6 +18,9 @@
 [Mesh]
   file = simple_contact_rspherical.e
   construct_side_list_from_node_list = true
+[]
+
+[GlobalParams]
   displacements = 'disp_x'
 []
 
@@ -30,8 +33,6 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -94,7 +95,6 @@
   [./fred]
     master = 2
     slave = 3
-    disp_x = disp_x
     system = constraint
   [../]
 []
@@ -113,7 +113,6 @@
 
 [Executioner]
   type = Transient
-
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'

--- a/modules/combined/tests/simple_contact/simple_contact_rspherical_dirac.i
+++ b/modules/combined/tests/simple_contact/simple_contact_rspherical_dirac.i
@@ -18,6 +18,9 @@
 [Mesh]
   file = simple_contact_rspherical.e
   construct_side_list_from_node_list = true
+[]
+
+[GlobalParams]
   displacements = 'disp_x'
 []
 
@@ -30,8 +33,6 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -94,12 +95,10 @@
   [./fred]
     master = 2
     slave = 3
-    disp_x = disp_x
   [../]
 []
 
 [Materials]
-
   [./stiffStuff1]
     type = Elastic
     block = '1 2 3'
@@ -109,13 +108,10 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.25
   [../]
-
 []
 
 [Executioner]
-
   type = Transient
-
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -ksp_gmres_restart'

--- a/modules/combined/tests/simple_contact/simple_contact_rz_dirac_test.i
+++ b/modules/combined/tests/simple_contact/simple_contact_rz_dirac_test.i
@@ -9,6 +9,9 @@
 
 [Mesh]
   file = contact_rz.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -27,13 +30,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -80,8 +78,6 @@
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e5
   [../]
 []
@@ -181,7 +177,6 @@
 
 [Executioner]
   type = Transient
-
   solve_type = 'PJFNK'
 
   petsc_options = '-snes_ksp_ew'

--- a/modules/combined/tests/simple_contact/simple_contact_rz_test.i
+++ b/modules/combined/tests/simple_contact/simple_contact_rz_test.i
@@ -9,6 +9,9 @@
 
 [Mesh]
   file = contact_rz.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
@@ -27,13 +30,8 @@
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -80,8 +78,6 @@
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e5
     system = constraint
   [../]
@@ -182,7 +178,6 @@
 
 [Executioner]
   type = Transient
-
   solve_type = 'PJFNK'
 
   petsc_options = '-snes_ksp_ew'

--- a/modules/combined/tests/simple_contact/simple_contact_test.i
+++ b/modules/combined/tests/simple_contact/simple_contact_test.i
@@ -2,23 +2,18 @@
 
 [Mesh]
   file = contact.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -41,9 +36,6 @@
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     penalty = 1e5
     formulation = kinematic
     system = constraint
@@ -131,7 +123,6 @@
 
 [Executioner]
   type = Transient
-
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'

--- a/modules/combined/tests/simple_contact/simple_contact_test2.i
+++ b/modules/combined/tests/simple_contact/simple_contact_test2.i
@@ -1,22 +1,17 @@
 [Mesh]
   file = contact.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y disp_z'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_z]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
@@ -39,9 +34,6 @@
   [./dummy_name]
     master = 3
     slave = 2
-    disp_x = disp_x
-    disp_y = disp_y
-    disp_z = disp_z
     penalty = 5e6
     formulation = penalty
     system = constraint
@@ -131,7 +123,6 @@
 
 [Executioner]
   type = Transient
-
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'

--- a/modules/combined/tests/simplest_contact/simplest_contact_skew_test.i
+++ b/modules/combined/tests/simplest_contact/simplest_contact_skew_test.i
@@ -1,28 +1,24 @@
 [Mesh]
   file = simplest_contact_skew.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
-    order = FIRST
-    family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./penetration]
     order = FIRST
     family = LAGRANGE
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -48,8 +44,6 @@
     component = 0
     slave = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
   [../]
 
@@ -60,8 +54,6 @@
     component = 1
     slave = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
   [../]
 []
@@ -94,7 +86,7 @@
     boundary = 4
     value = 0.0
   [../]
-[] # BCs
+[]
 
 [Materials]
   [./stiffStuff1]
@@ -107,26 +99,19 @@
     youngs_modulus = 1e6
     poissons_ratio = 0.3
   [../]
-[] # Materials
+[]
 
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-
-
+  #petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
+  #petsc_options_value = 'hypre    boomeramg      101'
   petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg      101'
 
-
   line_search = 'none'
-
-
-#  petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
-#  petsc_options_value = 'hypre    boomeramg      101'
 
   nl_abs_tol = 1e-8
 
@@ -134,7 +119,7 @@
   nl_max_its = 10
   dt = 1.0
   num_steps = 1
-[] # Executioner
+[]
 
 [Outputs]
   file_base = out_skew
@@ -142,4 +127,4 @@
     type = Exodus
     elemental_as_nodal = true
   [../]
-[] # Outputs
+[]

--- a/modules/combined/tests/simplest_contact/simplest_contact_test.i
+++ b/modules/combined/tests/simplest_contact/simplest_contact_test.i
@@ -1,28 +1,24 @@
 [Mesh]
   file = simplest_contact.e
+[]
+
+[GlobalParams]
   displacements = 'disp_x disp_y'
 []
 
 [Variables]
   [./disp_x]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./disp_y]
     order = FIRST
     family = LAGRANGE
   [../]
-[] # Variables
+[]
 
 [AuxVariables]
-
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
-[] # AuxVariables
+[]
 
 [SolidMechanics]
   [./solid]
@@ -48,8 +44,6 @@
     component = 0
     slave = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
   [../]
 
@@ -60,8 +54,6 @@
     component = 1
     slave = 2
     master = 3
-    disp_x = disp_x
-    disp_y = disp_y
     penalty = 1e6
   [../]
 []

--- a/modules/combined/tests/sliding_block/in_and_out/constraint/frictional_02_penalty.i
+++ b/modules/combined/tests/sliding_block/in_and_out/constraint/frictional_02_penalty.i
@@ -12,8 +12,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -25,8 +28,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -155,15 +156,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -ksp_gmres_restart'
   petsc_options_value = 'asm     lu    20    101'
-
 
   line_search = 'none'
 
@@ -184,7 +180,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictional_02_penalty_out
   interval = 10
   [./exodus]
@@ -200,8 +195,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = coulomb
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/in_and_out/constraint/frictional_04_penalty.i
+++ b/modules/combined/tests/sliding_block/in_and_out/constraint/frictional_04_penalty.i
@@ -12,8 +12,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -25,8 +28,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -156,15 +157,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -ksp_gmres_restart'
   petsc_options_value = 'asm     lu    20    101'
-
 
   line_search = 'none'
 
@@ -201,8 +197,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = coulomb
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/in_and_out/constraint/frictionless_kinematic.i
+++ b/modules/combined/tests/sliding_block/in_and_out/constraint/frictionless_kinematic.i
@@ -12,8 +12,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -25,8 +28,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -156,15 +157,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -ksp_gmres_restart'
   petsc_options_value = 'asm     lu    20    101'
-
 
   line_search = 'none'
 
@@ -185,7 +181,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictionless_kinematic_out
   interval = 10
   [./exodus]
@@ -201,8 +196,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+6

--- a/modules/combined/tests/sliding_block/in_and_out/constraint/frictionless_penalty.i
+++ b/modules/combined/tests/sliding_block/in_and_out/constraint/frictionless_penalty.i
@@ -12,8 +12,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -25,8 +28,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -163,15 +164,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -ksp_gmres_restart'
   petsc_options_value = 'asm     lu    20    101'
-
 
   line_search = 'none'
 
@@ -192,7 +188,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictionless_penalty_out
   interval = 10
   [./exodus]
@@ -208,8 +203,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/in_and_out/dirac/frictional_02_penalty.i
+++ b/modules/combined/tests/sliding_block/in_and_out/dirac/frictional_02_penalty.i
@@ -12,8 +12,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -25,8 +28,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -156,15 +157,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg  4    101'
-
 
   line_search = 'none'
 
@@ -185,7 +181,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictional_02_penalty_out
   interval = 10
   [./exodus]
@@ -201,8 +196,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = coulomb
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/in_and_out/dirac/frictional_04_penalty.i
+++ b/modules/combined/tests/sliding_block/in_and_out/dirac/frictional_04_penalty.i
@@ -12,8 +12,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -25,8 +28,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -156,15 +157,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg  4    101'
-
 
   line_search = 'none'
 
@@ -185,7 +181,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictional_04_penalty_out
   interval = 10
   [./exodus]
@@ -201,8 +196,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/in_and_out/dirac/frictionless_kinematic.i
+++ b/modules/combined/tests/sliding_block/in_and_out/dirac/frictionless_kinematic.i
@@ -12,8 +12,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -25,8 +28,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -156,15 +157,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg  4    101'
-
 
   line_search = 'none'
 
@@ -185,7 +181,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictionless_kinematic_out
   interval = 10
   [./exodus]
@@ -201,8 +196,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+6

--- a/modules/combined/tests/sliding_block/in_and_out/dirac/frictionless_penalty.i
+++ b/modules/combined/tests/sliding_block/in_and_out/dirac/frictionless_penalty.i
@@ -12,8 +12,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -25,8 +28,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -157,15 +158,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg  4    101'
-
 
   line_search = 'none'
 
@@ -186,7 +182,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictionless_penalty_out
   interval = 10
   [./exodus]
@@ -202,8 +197,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/sliding/constraint/frictional_02_penalty.i
+++ b/modules/combined/tests/sliding_block/sliding/constraint/frictional_02_penalty.i
@@ -10,8 +10,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -23,8 +26,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -150,15 +151,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -ksp_gmres_restart'
   petsc_options_value = 'asm     lu    20    101'
-
 
   line_search = 'none'
 
@@ -179,7 +175,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictional_02_penalty_out
   interval = 10
   [./exodus]
@@ -195,8 +190,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = coulomb
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/sliding/constraint/frictional_04_penalty.i
+++ b/modules/combined/tests/sliding_block/sliding/constraint/frictional_04_penalty.i
@@ -10,8 +10,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -23,8 +26,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -150,15 +151,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -ksp_gmres_restart'
   petsc_options_value = 'asm     lu    20    101'
-
 
   line_search = 'none'
 
@@ -179,7 +175,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictional_04_penalty_out
   interval = 10
   [./exodus]
@@ -195,8 +190,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = coulomb
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/sliding/constraint/frictionless_kinematic.i
+++ b/modules/combined/tests/sliding_block/sliding/constraint/frictionless_kinematic.i
@@ -10,8 +10,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -23,8 +26,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -150,15 +151,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -ksp_gmres_restart'
   petsc_options_value = 'asm     lu    20    101'
-
 
   line_search = 'none'
 
@@ -179,7 +175,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictionless_kinematic_out
   interval = 10
   [./exodus]
@@ -195,8 +190,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+6

--- a/modules/combined/tests/sliding_block/sliding/constraint/frictionless_penalty.i
+++ b/modules/combined/tests/sliding_block/sliding/constraint/frictionless_penalty.i
@@ -10,8 +10,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -23,8 +26,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -150,15 +151,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -ksp_gmres_restart'
   petsc_options_value = 'asm     lu    20    101'
-
 
   line_search = 'none'
 
@@ -179,7 +175,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictionless_penalty_out
   interval = 10
   [./exodus]
@@ -195,8 +190,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/sliding/dirac/frictional_02_penalty.i
+++ b/modules/combined/tests/sliding_block/sliding/dirac/frictional_02_penalty.i
@@ -10,8 +10,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -23,8 +26,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -150,15 +151,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg  4    101'
-
 
   line_search = 'none'
 
@@ -179,7 +175,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictional_02_penalty_out
   interval = 10
   [./exodus]
@@ -195,8 +190,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = coulomb
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/sliding/dirac/frictional_04_penalty.i
+++ b/modules/combined/tests/sliding_block/sliding/dirac/frictional_04_penalty.i
@@ -10,8 +10,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -23,8 +26,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -150,15 +151,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg  4    101'
-
 
   line_search = 'none'
 
@@ -179,7 +175,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictional_04_penalty_out
   interval = 10
   [./exodus]
@@ -195,8 +190,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+7

--- a/modules/combined/tests/sliding_block/sliding/dirac/frictionless_kinematic.i
+++ b/modules/combined/tests/sliding_block/sliding/dirac/frictionless_kinematic.i
@@ -10,8 +10,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -23,8 +26,6 @@
 
 [AuxVariables]
   [./penetration]
-    order = FIRST
-    family = LAGRANGE
   [../]
   [./inc_slip_x]
   [../]
@@ -150,15 +151,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg  4    101'
-
 
   line_search = 'none'
 
@@ -179,7 +175,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictionless_kinematic_out
   interval = 10
   [./exodus]
@@ -195,8 +190,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+6

--- a/modules/combined/tests/sliding_block/sliding/dirac/frictionless_penalty.i
+++ b/modules/combined/tests/sliding_block/sliding/dirac/frictionless_penalty.i
@@ -10,8 +10,11 @@
 
 [Mesh]
   file = sliding_elastic_blocks_2d.e
-  displacements = 'disp_x disp_y'
   patch_size = 80
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
 []
 
 [Variables]
@@ -150,15 +153,10 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-
-
 
   petsc_options_iname = '-pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter -ksp_gmres_restart'
   petsc_options_value = 'hypre    boomeramg  4    101'
-
 
   line_search = 'none'
 
@@ -179,7 +177,6 @@
 []
 
 [Outputs]
-  # csv = true
   file_base = frictionless_penalty_out
   interval = 10
   [./exodus]
@@ -195,8 +192,6 @@
 [Contact]
   [./leftright]
     slave = 3
-    disp_y = disp_y
-    disp_x = disp_x
     master = 2
     model = frictionless
     penalty = 1e+7

--- a/modules/contact/src/ContactAction.C
+++ b/modules/contact/src/ContactAction.C
@@ -115,6 +115,9 @@ ContactAction::act()
       if (isParamValid("disp_z"))
         displacements.push_back(getParam<NonlinearVariableName>("disp_z"));
     }
+
+    mooseDeprecated("use the `displacements` parameter rather than the `disp_*` parameters (those "
+                    "will go away with the deprecation of the Solid Mechanics module).");
   }
 
   // Determine number of dimensions

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -110,6 +110,9 @@ ContactMaster::ContactMaster(const InputParameters & parameters)
       _vars[1] = coupled("disp_y");
     if (isParamValid("disp_z"))
       _vars[2] = coupled("disp_z");
+
+    mooseDeprecated("use the `displacements` parameter rather than the `disp_*` parameters (those "
+                    "will go away with the deprecation of the Solid Mechanics module).");
   }
 
   if (parameters.isParamValid("tangential_tolerance"))

--- a/modules/contact/src/GluedContactConstraint.C
+++ b/modules/contact/src/GluedContactConstraint.C
@@ -33,6 +33,10 @@ validParams<GluedContactConstraint>()
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");
 
+  params.addCoupledVar(
+      "displacements",
+      "The displacements appropriate for the simulation geometry and coordinate system");
+
   params.addRequiredCoupledVar("nodal_area", "The nodal area");
   params.addParam<std::string>("model", "frictionless", "The contact model to use");
 
@@ -101,6 +105,9 @@ GluedContactConstraint::GluedContactConstraint(const InputParameters & parameter
       _vars[1] = coupled("disp_y");
     if (isParamValid("disp_z"))
       _vars[2] = coupled("disp_z");
+
+    mooseDeprecated("use the `displacements` parameter rather than the `disp_*` parameters (those "
+                    "will go away with the deprecation of the Solid Mechanics module).");
   }
 
   _penetration_locator.setUpdate(false);

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -137,6 +137,9 @@ MechanicalContactConstraint::MechanicalContactConstraint(const InputParameters &
       _vars[1] = coupled("disp_y");
     if (isParamValid("disp_z"))
       _vars[2] = coupled("disp_z");
+
+    mooseDeprecated("use the `displacements` parameter rather than the `disp_*` parameters (those "
+                    "will go away with the deprecation of the Solid Mechanics module).");
   }
 
   if (parameters.isParamValid("tangential_tolerance"))

--- a/modules/contact/src/MultiDContactConstraint.C
+++ b/modules/contact/src/MultiDContactConstraint.C
@@ -34,6 +34,11 @@ validParams<MultiDContactConstraint>()
   params.addCoupledVar("disp_x", "The x displacement");
   params.addCoupledVar("disp_y", "The y displacement");
   params.addCoupledVar("disp_z", "The z displacement");
+
+  params.addCoupledVar(
+      "displacements",
+      "The displacements appropriate for the simulation geometry and coordinate system");
+
   params.addParam<std::string>("model", "frictionless", "The contact model to use");
   params.addParam<Real>(
       "penalty",
@@ -73,6 +78,9 @@ MultiDContactConstraint::MultiDContactConstraint(const InputParameters & paramet
       _vars[1] = coupled("disp_y");
     if (isParamValid("disp_z"))
       _vars[2] = coupled("disp_z");
+
+    mooseDeprecated("use the `displacements` parameter rather than the `disp_*` parameters (those "
+                    "will go away with the deprecation of the Solid Mechanics module).");
   }
 }
 

--- a/modules/contact/src/SlaveConstraint.C
+++ b/modules/contact/src/SlaveConstraint.C
@@ -98,6 +98,9 @@ SlaveConstraint::SlaveConstraint(const InputParameters & parameters)
       _vars[1] = coupled("disp_y");
     if (isParamValid("disp_z"))
       _vars[2] = coupled("disp_z");
+
+    mooseDeprecated("use the `displacements` parameter rather than the `disp_*` parameters (those "
+                    "will go away with the deprecation of the Solid Mechanics module).");
   }
 
   if (parameters.isParamValid("tangential_tolerance"))


### PR DESCRIPTION
Refs #8814

This will probably break most app tests. Just getting this out here to get an idea of how big the fallout is.