### PR TITLE
The tutorial does not require solid_mechanics.

### DIFF
--- a/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
@@ -25,14 +25,17 @@ ALL_MODULES               := no
 CHEMICAL_REACTIONS        := no
 CONTACT                   := no
 FLUID_PROPERTIES          := no
+# heat_conduction is required by Steps 5+
 HEAT_CONDUCTION           := yes
 LINEAR_ELASTICITY         := no
 MISC                      := no
 NAVIER_STOKES             := no
+# phase_field is required by Step 10.
 PHASE_FIELD               := yes
 POROUS_FLOW               := no
 RICHARDS                  := no
-SOLID_MECHANICS           := yes
+SOLID_MECHANICS           := no
+# tensor_mechanics is required by Steps 9-10.
 TENSOR_MECHANICS          := yes
 WATER_STEAM_EOS           := no
 XFEM                      := no


### PR DESCRIPTION
Not sure why @permcody specifically enabled these modules in 8980854, as they are not actually required for the tutorial, and any amount of compiling we can save users during MOOSE training is beneficial.

Refs #5307.

