### PR TITLE
Improve variable selection in ExodusViewer

### DIFF
--- a/python/peacock/ExodusViewer/plugins/VariablePlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VariablePlugin.py
@@ -315,17 +315,27 @@ class VariablePlugin(QtWidgets.QGroupBox, ExodusPlugin):
         Helper for updating the variable list while maintaining the current selection
         """
         variables = self._reader.getVariableInformation(var_types=[self._reader.NODAL, self._reader.ELEMENTAL])
-        current = self.VariableList.currentText()
-        self.VariableList.clear()
-        for vinfo in variables.itervalues():
-            self.VariableList.addItem(vinfo.name, vinfo)
 
-        # Set the current variable
-        idx = self.VariableList.findText(current)
-        if idx > -1:
-            self.VariableList.setCurrentIndex(idx)
+        # We want to avoid clearing the list and rebuilding it as that
+        # can cause confusion if somebody is in the middle of a selection
+        new_vars = {v.name for v in variables.values()}
+        cur_vars = {self.VariableList.itemText(i) for i in range(self.VariableList.count())}
+        if new_vars == cur_vars:
+            for vinfo in variables.itervalues():
+                idx = self.VariableList.findText(vinfo.name) # should always return a valid index
+                self.VariableList.setItemData(idx, vinfo)
         else:
-            self.VariableList.setCurrentIndex(0)
+            current = self.VariableList.currentText()
+            self.VariableList.clear()
+            for vinfo in variables.itervalues():
+                self.VariableList.addItem(vinfo.name, vinfo)
+
+            # Set the current variable
+            idx = self.VariableList.findText(current)
+            if idx > -1:
+                self.VariableList.setCurrentIndex(idx)
+            else:
+                self.VariableList.setCurrentIndex(0)
 
 def main(size=None):
     """


### PR DESCRIPTION
This just tries to not reload the variable combo box if the variables haven't changed.
This was causing problems when a user was in the middle of selecting a variable. It would just clear and repopulate the combo and no selection would be made.

closes #8809 