### PR TITLE
Adjust font on colorbar based on pixel ratio

### DIFF
--- a/python/peacock/ExodusViewer/plugins/VariablePlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VariablePlugin.py
@@ -109,6 +109,7 @@ class VariablePlugin(QtWidgets.QGroupBox, ExodusPlugin):
 
         # Create the colorbar
         self._colorbar = chigger.exodus.ExodusColorBar(result)
+        self._colorbar.setOptions(font_size=12*self.devicePixelRatio())
 
         # Populate variable list with nodal/elemental variables
         self.VariableList.blockSignals(True)

--- a/python/peacock/PeacockApp.py
+++ b/python/peacock/PeacockApp.py
@@ -24,8 +24,7 @@ class PeacockApp(object):
         parsed_args = parser.parse_args(args)
 
         peacock_dir = os.path.dirname(os.path.realpath(__file__))
-        chigger_dir = os.path.dirname(peacock_dir)
-        icon_path = os.path.join(chigger_dir, "icons", "peacock_logo.ico")
+        icon_path = os.path.join(peacock_dir, "icons", "peacock_logo.ico")
         qapp.setWindowIcon(QIcon(icon_path))
 
         qtutils.setAppInformation("peacock")


### PR DESCRIPTION
On high DPI screens we need to adjust the font on the ExodusViewer colorbar to make it readable.

Also sneak in a fix for the peacock application icon which wasn't displaying properly because it had the wrong path name after the move into MOOSE.

closes #8807