### PR TITLE
Nonlinear eigenvalue solvers 

### DIFF
--- a/framework/contrib/nleigen/include/monolith.h
+++ b/framework/contrib/nleigen/include/monolith.h
@@ -1,0 +1,28 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef MONOLITH_H
+#define MONOLITH_H
+
+#include "libmesh/libmesh_config.h"
+
+#if LIBMESH_HAVE_SLEPC
+
+#include <slepc/private/epsimpl.h> /*I "slepceps.h" I*/
+
+PETSC_EXTERN PetscErrorCode EPSCreate_Monolith(EPS);
+
+#endif
+
+#endif

--- a/framework/contrib/nleigen/include/nleigenUtility.h
+++ b/framework/contrib/nleigen/include/nleigenUtility.h
@@ -21,5 +21,6 @@
 
 PETSC_EXTERN PetscErrorCode EPSGetOperators_Moose(EPS,Mat*,Mat*);
 PETSC_EXTERN PetscErrorCode EPSGetStartVector_Moose(EPS,PetscInt,PetscBool*);
+
 #endif
 #endif

--- a/framework/contrib/nleigen/include/nleigenUtility.h
+++ b/framework/contrib/nleigen/include/nleigenUtility.h
@@ -1,0 +1,25 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef NLEIGENUTILITY_H
+#define NLEIGENUTILITY_H
+
+#include "libmesh/libmesh_config.h"
+
+#if LIBMESH_HAVE_SLEPC
+
+PETSC_EXTERN PetscErrorCode EPSGetOperators_Moose(EPS,Mat*,Mat*);
+PETSC_EXTERN PetscErrorCode EPSGetStartVector_Moose(EPS,PetscInt,PetscBool*);
+#endif
+#endif

--- a/framework/contrib/nleigen/include/nleigenUtility.h
+++ b/framework/contrib/nleigen/include/nleigenUtility.h
@@ -21,6 +21,7 @@
 
 PETSC_EXTERN PetscErrorCode EPSGetOperators_Moose(EPS,Mat*,Mat*);
 PETSC_EXTERN PetscErrorCode EPSGetStartVector_Moose(EPS,PetscInt,PetscBool*);
+PETSC_EXTERN PetscErrorCode EPSCreateSubIS(Vec vec, IS *sub_is);
 
 #endif
 #endif

--- a/framework/contrib/nleigen/include/nlpower.h
+++ b/framework/contrib/nleigen/include/nlpower.h
@@ -1,0 +1,27 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef NLPOWER_H
+#define NLPOWER_H
+
+#include "libmesh/libmesh_config.h"
+
+#if LIBMESH_HAVE_SLEPC
+
+#include <slepc/private/epsimpl.h> /*I "slepceps.h" I*/
+
+PETSC_EXTERN PetscErrorCode EPSCreate_NLPower(EPS eps);
+
+#endif
+#endif

--- a/framework/contrib/nleigen/src/monolith.c
+++ b/framework/contrib/nleigen/src/monolith.c
@@ -1,0 +1,440 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "libmesh/libmesh_config.h"
+
+#if LIBMESH_HAVE_SLEPC
+
+#include <slepc/private/epsimpl.h> /*I "slepceps.h" I*/
+#include <slepc/private/stimpl.h>  /*I "slepcst.h" I*/
+#include <slepcblaslapack.h>
+#include <petscsnes.h>
+#include "nleigenUtility.h"
+
+typedef struct {
+  EPSPowerShiftType shift_type;
+  Vec               y_tmp; /* temporary work vectors */
+  Vec               res;
+  SNES              snes;
+  void *jacobianctxA;
+  void *functionctxA;
+  PetscErrorCode (*formFunctionA)(SNES, Vec, Vec, void *);
+  PetscErrorCode (*formJacobianA)(SNES, Vec, Mat, Mat, void *);
+  void *jacobianctxB;
+  void *functionctxB;
+  PetscErrorCode (*formFunctionB)(SNES, Vec, Vec, void *);
+  PetscErrorCode (*formJacobianB)(SNES, Vec, Mat, Mat, void *);
+  PetscBool      eps_composed; /* compose eps */
+  PetscBool      initialed; /* initialize snes */
+} EPS_MONOLITH;
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSetUp_Monolith"
+PetscErrorCode EPSSetUp_Monolith(EPS eps)
+{
+  PetscErrorCode ierr;
+  EPS_MONOLITH   *monolith = (EPS_MONOLITH *)eps->data;
+  PetscBool      flg, istrivial;
+  STMatMode      mode;
+
+  PetscFunctionBegin;
+  if (eps->ncv) {
+    if (eps->ncv < eps->nev) SETERRQ(PetscObjectComm((PetscObject)eps), 1, "The value of ncv must be at least nev");
+  } else eps->ncv = eps->nev;
+  if (eps->mpd) {
+    ierr = PetscInfo(eps, "Warning: parameter mpd ignored\n");CHKERRQ(ierr);
+  }
+  if (!eps->max_it) eps->max_it = PetscMax(2000, 100 * eps->n);
+  if (!eps->which) {
+    ierr = EPSSetWhichEigenpairs_Default(eps);CHKERRQ(ierr);
+  }
+  if (eps->which != EPS_SMALLEST_MAGNITUDE && eps->which != EPS_TARGET_MAGNITUDE)
+    SETERRQ(PetscObjectComm((PetscObject)eps), 1, "Wrong value of eps->which");
+  if (monolith->shift_type != EPS_POWER_SHIFT_CONSTANT) {
+    ierr = PetscObjectTypeCompareAny((PetscObject)eps->st, &flg, STSINVERT, STCAYLEY, "");CHKERRQ(ierr);
+    if (!flg) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "Variable shifts only allowed in shift-and-invert or Cayley ST");
+    ierr = STGetMatMode(eps->st, &mode); CHKERRQ(ierr);
+    if (mode == ST_MATMODE_INPLACE) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "ST matrix mode inplace does not work with variable shifts");
+  }
+  if (eps->extraction) {
+    ierr = PetscInfo(eps, "Warning: extraction type ignored\n"); CHKERRQ(ierr);
+  }
+  if (eps->balance != EPS_BALANCE_NONE)
+    SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "Balancing not supported in this solver");
+  if (eps->arbitrary) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "Arbitrary selection of eigenpairs not supported in this solver");
+  ierr = RGIsTrivial(eps->rg, &istrivial);CHKERRQ(ierr);
+  if (!istrivial) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "This solver does not support region filtering");
+  ierr = EPSAllocateSolution(eps, 0);CHKERRQ(ierr);
+  ierr = EPS_SetInnerProduct(eps);CHKERRQ(ierr);
+  ierr = EPSSetWorkVecs(eps, 2);CHKERRQ(ierr);
+  if (!monolith->snes) {
+    ierr = SNESCreate(PetscObjectComm((PetscObject)eps), &monolith->snes);CHKERRQ(ierr);
+  }
+  /* to avoid slepc setup preconditioner too early */
+  if (eps->st->P) eps->st->P = NULL;
+  eps->st->transform = PETSC_FALSE;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "SNESLineSearchPreCheckFunction_Monolith"
+
+PetscErrorCode SNESLineSearchPreCheckFunction_Monolith(SNESLineSearch snes,Vec x, Vec y, PetscBool *changed, void * ctx)
+{
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+
+  ierr = VecNormalize(x, PETSC_NULL);CHKERRQ(ierr);
+  *changed = PETSC_TRUE;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "FormFunction_Monolith"
+
+PetscErrorCode FormFunction_Monolith(SNES snes, Vec x, Vec y, void *ctx)
+{
+  PetscErrorCode ierr;
+  EPS eps;
+  EPS_MONOLITH *monolith = 0;
+  PetscScalar lambda_right = 0, lambda_left = 0;
+
+  PetscFunctionBegin;
+  ierr = PetscObjectQuery((PetscObject)snes, "eps", (PetscObject *)&eps);CHKERRQ(ierr);
+  monolith = (EPS_MONOLITH *)eps->data;
+  if (!monolith->y_tmp) {
+    ierr = VecDuplicate(y, &monolith->y_tmp);CHKERRQ(ierr);
+  }
+  ierr = VecSet(monolith->y_tmp, 0.0);CHKERRQ(ierr);
+
+  ierr = monolith->formFunctionB(monolith->snes, x, monolith->y_tmp, monolith->functionctxB);CHKERRQ(ierr);
+  ierr = VecDot(x, monolith->y_tmp, &lambda_right);CHKERRQ(ierr);
+
+  ierr = monolith->formFunctionA(monolith->snes, x, y, monolith->functionctxA);CHKERRQ(ierr);
+  ierr = VecDot(x, y, &lambda_left);CHKERRQ(ierr);
+
+  ierr = VecAXPY(y, -1.0 * lambda_left / lambda_right, monolith->y_tmp);CHKERRQ(ierr);
+
+  eps->eigr[eps->nconv] = lambda_left / lambda_right;
+
+  ierr = VecNorm(y, NORM_2, &lambda_right);CHKERRQ(ierr);
+  eps->errest[eps->nconv] = lambda_right;
+
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "FormJacobian_Monolith"
+
+PetscErrorCode FormJacobian_Monolith(SNES snes, Vec x, Mat J, Mat T, void *ctx)
+{
+  PetscErrorCode ierr;
+  Mat A, B;
+  EPS eps;
+  EPS_MONOLITH *monolith = 0;
+
+  PetscFunctionBegin;
+  ierr = PetscObjectQuery((PetscObject)snes, "eps", (PetscObject *)&eps);CHKERRQ(ierr);
+  monolith = (EPS_MONOLITH *)eps->data;
+  ierr = EPSGetOperators_Moose(eps, &A, &B);CHKERRQ(ierr);
+
+  ierr = monolith->formJacobianA(monolith->snes, x, A, A, monolith->functionctxA);CHKERRQ(ierr);
+  ierr = monolith->formJacobianB(monolith->snes, x, B, B, monolith->functionctxB);CHKERRQ(ierr);
+
+  if (A != T) SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_INCOMP, "A != T \n");
+
+  /*ierr = MatAXPY(T, -0.0 * eps->eigr[eps->nconv], B, SAME_NONZERO_PATTERN);CHKERRQ(ierr);*/
+
+  ierr = MatAssemblyBegin(T, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  ierr = MatAssemblyEnd(T, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  if (J != T) {
+    ierr = MatAssemblyBegin(J, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(J, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  }
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSNESInit_Monolith"
+
+PetscErrorCode EPSSNESInit_Monolith(EPS eps, Vec x, Vec y)
+{
+  PetscErrorCode ierr;
+  Mat A, B;
+  EPS_MONOLITH *nlpower = (EPS_MONOLITH *)eps->data;
+  SNESLineSearch linesearch;
+  PetscContainer container;
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(eps, EPS_CLASSID, 1);
+  PetscValidHeaderSpecific(x, VEC_CLASSID, 2);
+  PetscValidHeaderSpecific(y, VEC_CLASSID, 3);
+  if (x == y) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_IDN, "x and y must be different vectors");
+  ierr = EPSGetOperators_Moose(eps, &A, &B);CHKERRQ(ierr);
+  if (A) {
+    ierr = PetscObjectQueryFunction((PetscObject)A, "formFunctionA", &(nlpower->formFunctionA));CHKERRQ(ierr);
+    ierr = PetscObjectQueryFunction((PetscObject)A, "formJacobianA", &(nlpower->formJacobianA));CHKERRQ(ierr);
+    ierr = PetscObjectQuery((PetscObject)A, "AppCtx", (PetscObject *)&container);CHKERRQ(ierr);
+    ierr = PetscContainerGetPointer(container, &nlpower->functionctxA);CHKERRQ(ierr);
+    ierr = PetscContainerGetPointer(container, &nlpower->jacobianctxA);CHKERRQ(ierr);
+    if (B) {
+      ierr = PetscObjectQueryFunction((PetscObject)B, "formFunctionB",
+                                      &(nlpower->formFunctionB));
+      CHKERRQ(ierr);
+      ierr = PetscObjectQueryFunction((PetscObject)B, "formJacobianB", &(nlpower->formJacobianB));CHKERRQ(ierr);
+      ierr = PetscObjectQuery((PetscObject)B, "AppCtx", (PetscObject *)&container);CHKERRQ(ierr);
+      ierr = PetscContainerGetPointer(container, &nlpower->functionctxB);CHKERRQ(ierr);
+      ierr = PetscContainerGetPointer(container, &nlpower->jacobianctxB);CHKERRQ(ierr);
+    }
+  } else {
+    SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_NULL, "operator is null, please set operators properly \n");
+  }
+  if (!nlpower->y_tmp) {
+    ierr = VecDuplicate(y, &nlpower->y_tmp);CHKERRQ(ierr);
+  }
+  ierr = VecSet(nlpower->y_tmp, 0.0);CHKERRQ(ierr);
+  if (!nlpower->res) {
+    ierr = VecDuplicate(y, &nlpower->res);CHKERRQ(ierr);
+  }
+  ierr = VecSet(nlpower->res, 0.0);CHKERRQ(ierr);
+  if (!nlpower->snes) {
+    ierr = SNESCreate(PetscObjectComm((PetscObject)eps), &nlpower->snes);CHKERRQ(ierr);
+  }
+  if (!nlpower->eps_composed) {
+    ierr = PetscObjectCompose((PetscObject)nlpower->snes, "eps", (PetscObject)eps);CHKERRQ(ierr);
+    nlpower->eps_composed = PETSC_TRUE;
+  }
+  ierr = SNESSetFunction(nlpower->snes, nlpower->res, FormFunction_Monolith, nlpower->functionctxA);CHKERRQ(ierr);
+  ierr = SNESSetJacobian(nlpower->snes, A, A, FormJacobian_Monolith,nlpower->jacobianctxA);CHKERRQ(ierr);
+
+  ierr = SNESSetFromOptions(nlpower->snes);CHKERRQ(ierr);
+  ierr = SNESSetUp(nlpower->snes);CHKERRQ(ierr);
+  ierr = SNESGetLineSearch(nlpower->snes, &linesearch);CHKERRQ(ierr);
+  ierr = SNESLineSearchSetPreCheck(linesearch, SNESLineSearchPreCheckFunction_Monolith, nlpower->jacobianctxA);CHKERRQ(ierr);
+  nlpower->initialed = PETSC_TRUE;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSNESSolve_Monolith"
+
+PetscErrorCode EPSSNESSolve_Monolith(EPS eps, Vec x, Vec y)
+{
+  PetscErrorCode ierr;
+  Mat A, B;
+  EPS_MONOLITH *nlpower = (EPS_MONOLITH *)eps->data;
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(eps, EPS_CLASSID, 1);
+  PetscValidHeaderSpecific(x, VEC_CLASSID, 2);
+  PetscValidHeaderSpecific(y, VEC_CLASSID, 3);
+  if (x == y) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_IDN, "x and y must be different vectors");
+  ierr = EPSGetOperators_Moose(eps, &A, &B);CHKERRQ(ierr);
+  if (!nlpower->initialed) {
+    ierr = EPSSNESInit_Monolith(eps, x, y);CHKERRQ(ierr);
+  }
+  ierr = VecCopy(x, y);CHKERRQ(ierr);
+  ierr = SNESSolve(nlpower->snes, NULL, y);CHKERRQ(ierr);
+  ierr = nlpower->formJacobianA(nlpower->snes, y, A, A, nlpower->jacobianctxA);CHKERRQ(ierr);
+  ierr = nlpower->formJacobianB(nlpower->snes, y, B, B, nlpower->jacobianctxB);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSolve_Monolith"
+PetscErrorCode EPSSolve_Monolith(EPS eps)
+{
+  PetscErrorCode ierr;
+  PetscInt k;
+  Vec v, y, e;
+  PetscReal relerr, norm;
+  PetscScalar rho, sigma;
+  PetscBool breakdown;
+  EPS_MONOLITH *monolith = (EPS_MONOLITH *)eps->data;
+  ST st;
+
+  PetscFunctionBegin;
+  y = eps->work[1];
+  e = eps->work[0];
+
+  ierr = EPSGetStartVector_Moose(eps, 0, NULL);CHKERRQ(ierr);
+  ierr = STGetShift(eps->st, &sigma);CHKERRQ(ierr); /* original shift */
+  rho = sigma;
+
+  while (eps->reason == EPS_CONVERGED_ITERATING) {
+    eps->its++;
+    k = eps->nconv;
+
+    /* y = OP v */
+    ierr = BVGetColumn(eps->V, k, &v);CHKERRQ(ierr);
+    ierr = EPSSNESSolve_Monolith(eps, v, y);CHKERRQ(ierr);
+    ierr = BVRestoreColumn(eps->V, k, &v);CHKERRQ(ierr);
+
+    ierr = BVSetActiveColumns(eps->V, k, k + 1);CHKERRQ(ierr);
+
+    relerr = eps->errest[eps->nconv];
+
+    /* purge previously converged eigenvectors */
+    ierr = BVInsertVec(eps->V, k, y);CHKERRQ(ierr);
+    ierr = BVOrthogonalizeColumn(eps->V, k, NULL, &norm, NULL);CHKERRQ(ierr);
+    ierr = BVScaleColumn(eps->V, k, 1.0 / norm);CHKERRQ(ierr);
+
+    /* if relerr<tol, accept eigenpair */
+    if (relerr < eps->tol) {
+      eps->nconv = eps->nconv + 1;
+      if (eps->nconv < eps->nev) {
+        ierr = EPSGetStartVector_Moose(eps, eps->nconv, &breakdown);CHKERRQ(ierr);
+        if (breakdown) {
+          eps->reason = EPS_DIVERGED_BREAKDOWN;
+          ierr = PetscInfo(eps, "Unable to generate more start vectors\n");CHKERRQ(ierr);
+          break;
+        }
+      }
+    }
+    ierr = EPSMonitor(eps, eps->its, eps->nconv, eps->eigr, eps->eigi,
+                      eps->errest, eps->nconv + 1);CHKERRQ(ierr);
+    ierr = (*eps->stopping)(eps, eps->its, eps->max_it, eps->nconv, eps->nev,
+                            &eps->reason, eps->stoppingctx);CHKERRQ(ierr);
+  }
+  if (monolith->eps_composed) {
+    ierr = PetscObjectCompose((PetscObject)(monolith->snes), "eps", NULL);CHKERRQ(ierr);
+    monolith->eps_composed = PETSC_FALSE;
+  }
+  ierr = EPSGetST(eps,&st);CHKERRQ(ierr);
+  st->Astate[0] = ((PetscObject)st->A[0])->state;
+  st->Astate[1] = ((PetscObject)st->A[1])->state;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSetFromOptions_Monolith"
+PetscErrorCode EPSSetFromOptions_Monolith(PetscOptionItems *PetscOptionsObject, EPS eps)
+{
+  PetscErrorCode ierr;
+  EPS_MONOLITH *monolith = (EPS_MONOLITH *)eps->data;
+  PetscBool flg;
+  EPSPowerShiftType shift;
+
+  PetscFunctionBegin;
+  ierr = PetscOptionsHead(PetscOptionsObject, "EPS Power Options");CHKERRQ(ierr);
+  ierr = PetscOptionsEnum("-eps_power_shift_type", "Shift type",
+                          "EPSPowerSetShiftType", EPSPowerShiftTypes,
+                          (PetscEnum)monolith->shift_type, (PetscEnum *)&shift,
+                          &flg);CHKERRQ(ierr);
+  if (flg) {
+    ierr = EPSPowerSetShiftType(eps, shift);CHKERRQ(ierr);
+  }
+  if (monolith->shift_type != EPS_POWER_SHIFT_CONSTANT) {
+    ierr = STSetType(eps->st, STSINVERT);CHKERRQ(ierr);
+  }
+  ierr = PetscOptionsTail();CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSPowerSetShiftType_Monolith"
+static PetscErrorCode EPSPowerSetShiftType_Monolith(EPS eps, EPSPowerShiftType shift)
+{
+  EPS_MONOLITH *monolith = (EPS_MONOLITH *)eps->data;
+
+  PetscFunctionBegin;
+  switch (shift) {
+  case EPS_POWER_SHIFT_CONSTANT:
+  case EPS_POWER_SHIFT_RAYLEIGH:
+  case EPS_POWER_SHIFT_WILKINSON:
+    monolith->shift_type = shift;
+    break;
+  default:
+    SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_OUTOFRANGE,"Invalid shift type");
+  }
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSPowerGetShiftType_Monolith"
+static PetscErrorCode EPSPowerGetShiftType_Monolith(EPS eps, EPSPowerShiftType *shift)
+{
+  EPS_MONOLITH *monolith = (EPS_MONOLITH *)eps->data;
+
+  PetscFunctionBegin;
+  *shift = monolith->shift_type;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSDestroy_Monolith"
+PetscErrorCode EPSDestroy_Monolith(EPS eps)
+{
+  EPS_MONOLITH *monolith = (EPS_MONOLITH *)eps->data;
+  PetscErrorCode ierr;
+
+  PetscFunctionBegin;
+  if (monolith->snes) {
+    ierr = SNESDestroy(&monolith->snes);CHKERRQ(ierr);
+  }
+  if (monolith->res) {
+    ierr = VecDestroy(&monolith->res);CHKERRQ(ierr);
+  }
+  if (monolith->y_tmp) {
+    ierr = VecDestroy(&monolith->y_tmp);CHKERRQ(ierr);
+  }
+  ierr = PetscFree(eps->data);CHKERRQ(ierr);
+  ierr = PetscObjectComposeFunction((PetscObject)eps, "EPSPowerSetShiftType_C", NULL);CHKERRQ(ierr);
+  ierr = PetscObjectComposeFunction((PetscObject)eps, "EPSPowerGetShiftType_C", NULL);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSView_Monolith"
+PetscErrorCode EPSView_Monolith(EPS eps, PetscViewer viewer)
+{
+  PetscErrorCode ierr;
+  EPS_MONOLITH *monolith = (EPS_MONOLITH *)eps->data;
+  PetscBool isascii;
+
+  PetscFunctionBegin;
+  ierr = PetscObjectTypeCompare((PetscObject)viewer, PETSCVIEWERASCII, &isascii);CHKERRQ(ierr);
+  if (isascii) {
+    ierr = PetscViewerASCIIPrintf(viewer, "  Monolith newton: %s shifts\n",
+                                  EPSPowerShiftTypes[monolith->shift_type]);CHKERRQ(ierr);
+  }
+  if (monolith->snes) {
+    ierr = SNESView(monolith->snes, viewer);CHKERRQ(ierr);
+  }
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSCreate_Monolith"
+PETSC_EXTERN PetscErrorCode EPSCreate_Monolith(EPS eps)
+{
+  EPS_MONOLITH *ctx;
+  PetscErrorCode ierr;
+
+  PetscFunctionBegin;
+  ierr = PetscNewLog(eps, &ctx);CHKERRQ(ierr);
+  eps->data = (void *)ctx;
+
+  eps->ops->setup = EPSSetUp_Monolith;
+  eps->ops->solve = EPSSolve_Monolith;
+  eps->ops->setfromoptions = EPSSetFromOptions_Monolith;
+  eps->ops->destroy = EPSDestroy_Monolith;
+  eps->ops->view = EPSView_Monolith;
+  eps->ops->backtransform = NULL;
+  ierr = PetscObjectComposeFunction((PetscObject)eps, "EPSPowerSetShiftType_C", EPSPowerSetShiftType_Monolith);CHKERRQ(ierr);
+  ierr = PetscObjectComposeFunction((PetscObject)eps, "EPSPowerGetShiftType_C", EPSPowerGetShiftType_Monolith);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#endif

--- a/framework/contrib/nleigen/src/nleigenUtility.c
+++ b/framework/contrib/nleigen/src/nleigenUtility.c
@@ -45,7 +45,7 @@ PetscErrorCode EPSGetOperators_Moose(EPS eps,Mat *A,Mat *B)
 #undef __FUNCT__
 #define __FUNCT__ "EPSGetStartVector_Moose"
 /*
-  This function is copied over from SLEEP because SLEPc claims this as a n internal subroutine
+  This function is copied over from SLEPc because SLEPc claims this as an internal subroutine
 */
 PetscErrorCode EPSGetStartVector_Moose(EPS eps,PetscInt i,PetscBool *breakdown)
 {
@@ -84,4 +84,33 @@ PetscErrorCode EPSGetStartVector_Moose(EPS eps,PetscInt i,PetscBool *breakdown)
   PetscFunctionReturn(0);
 }
 
+#undef __FUNCT__
+#define __FUNCT__ "EPSCreateSubIS"
+
+/*
+   This is a toy function,
+
+   TODO: a better  way to compute indices
+*/
+PetscErrorCode EPSCreateSubIS(Vec vec, IS *sub_is)
+{
+  PetscErrorCode ierr;
+  PetscInt       localsize, low, high, i, is_local_size;
+  PetscInt       *sub_indices;
+
+
+  PetscFunctionBegin;
+
+  ierr = VecGetLocalSize(vec, &localsize);CHKERRQ(ierr);
+  ierr = VecGetOwnershipRange(vec, &low, &high);CHKERRQ(ierr);
+  is_local_size = localsize/2;
+  ierr = PetscCalloc1(is_local_size,&sub_indices);CHKERRQ(ierr);
+
+  for (i=0; i<localsize; i+=2)
+  {
+    sub_indices[i/2] = low+i;
+  }
+  ierr = ISCreateGeneral(PetscObjectComm((PetscObject)vec),is_local_size,sub_indices,PETSC_OWN_POINTER,sub_is);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
 #endif

--- a/framework/contrib/nleigen/src/nleigenUtility.c
+++ b/framework/contrib/nleigen/src/nleigenUtility.c
@@ -1,0 +1,87 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "libmesh/libmesh_config.h"
+
+#if LIBMESH_HAVE_SLEPC
+
+#include <slepc/private/epsimpl.h> /*I "slepceps.h" I*/
+#include <slepc/private/stimpl.h>  /*I "slepcst.h" I*/
+#include "nleigenUtility.h"
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSGetOperators_Moose"
+PetscErrorCode EPSGetOperators_Moose(EPS eps,Mat *A,Mat *B)
+{
+  PetscErrorCode ierr;
+  ST             st;
+  PetscInt       k;
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(eps,EPS_CLASSID,1);
+  ierr = EPSGetST(eps,&st);CHKERRQ(ierr);
+  if (A) { *A = st->A[0]; st->Astate[0] = ((PetscObject)st->A[0])->state;}
+  if (B) {
+    ierr = STGetNumMatrices(st,&k);CHKERRQ(ierr);
+    if (k==1) B = NULL;
+    else {
+      *B = st->A[1]; st->Astate[1] = ((PetscObject)st->A[1])->state;
+    }
+  }
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSGetStartVector_Moose"
+/*
+  This function is copied over from SLEEP because SLEPc claims this as a n internal subroutine
+*/
+PetscErrorCode EPSGetStartVector_Moose(EPS eps,PetscInt i,PetscBool *breakdown)
+{
+  PetscErrorCode ierr;
+  PetscReal      norm;
+  PetscBool      lindep;
+  Vec            w,z;
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(eps,EPS_CLASSID,1);
+  PetscValidLogicalCollectiveInt(eps,i,2);
+
+  /* For the first step, use the first initial vector, otherwise a random one */
+  if (i>0 || eps->nini==0) {
+    ierr = BVSetRandomColumn(eps->V,i);CHKERRQ(ierr);
+  }
+
+  /* Force the vector to be in the range of OP for definite generalized problems */
+  if (eps->ispositive || (eps->isgeneralized && eps->ishermitian)) {
+    ierr = BVCreateVec(eps->V,&w);CHKERRQ(ierr);
+    ierr = BVCopyVec(eps->V,i,w);CHKERRQ(ierr);
+    ierr = BVGetColumn(eps->V,i,&z);CHKERRQ(ierr);
+    ierr = STApply(eps->st,w,z);CHKERRQ(ierr);
+    ierr = BVRestoreColumn(eps->V,i,&z);CHKERRQ(ierr);
+    ierr = VecDestroy(&w);CHKERRQ(ierr);
+  }
+
+  /* Orthonormalize the vector with respect to previous vectors */
+  ierr = BVOrthogonalizeColumn(eps->V,i,NULL,&norm,&lindep);CHKERRQ(ierr);
+  if (breakdown) *breakdown = lindep;
+  else if (lindep || norm == 0.0) {
+    if (i==0) SETERRQ(PetscObjectComm((PetscObject)eps),1,"Initial vector is zero or belongs to the deflation space");
+    else SETERRQ(PetscObjectComm((PetscObject)eps),1,"Unable to generate more start vectors");
+  }
+  ierr = BVScaleColumn(eps->V,i,1.0/norm);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#endif

--- a/framework/contrib/nleigen/src/nlpower.c
+++ b/framework/contrib/nleigen/src/nlpower.c
@@ -58,9 +58,8 @@ PetscErrorCode EPSSetUp_NLPower(EPS eps)
   }
   if (!eps->max_it) eps->max_it = PetscMax(2000, 100 * eps->n);
 
-  if (!eps->which) {
-    ierr = EPSSetWhichEigenpairs_Default(eps); CHKERRQ(ierr);
-  }
+  /* The smallest eigenvalue is taken care by default */
+  if (!eps->which)  eps->which = EPS_SMALLEST_MAGNITUDE;
 
   if (eps->which != EPS_SMALLEST_MAGNITUDE && eps->which != EPS_TARGET_MAGNITUDE)
     SETERRQ(PetscObjectComm((PetscObject)eps), 1, "Wrong value of eps->which");

--- a/framework/contrib/nleigen/src/nlpower.c
+++ b/framework/contrib/nleigen/src/nlpower.c
@@ -1,0 +1,379 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "libmesh/libmesh_config.h"
+
+#if LIBMESH_HAVE_SLEPC
+
+#include <slepc/private/epsimpl.h> /*I "slepceps.h" I*/
+#include <slepc/private/stimpl.h>  /*I "slepcst.h" I*/
+#include <slepcblaslapack.h>
+#include <petscsnes.h>
+#include "nleigenUtility.h"
+
+typedef struct {
+  EPSPowerShiftType shift_type;
+  Vec         y_tmp;
+  Vec         res;
+  SNES        snes;
+  void *jacobianctxA;
+  void *functionctxA;
+  PetscErrorCode (*formFunctionA)(SNES, Vec, Vec, void *);
+  PetscErrorCode (*formJacobianA)(SNES, Vec, Mat, Mat, void *);
+  void *jacobianctxB;
+  void *functionctxB;
+  PetscErrorCode (*formFunctionB)(SNES, Vec, Vec, void *);
+  PetscErrorCode (*formJacobianB)(SNES, Vec, Mat, Mat, void *);
+  PetscBool initialized;
+} EPS_NLPOWER;
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSetUp_NLPower"
+PetscErrorCode EPSSetUp_NLPower(EPS eps)
+{
+  PetscErrorCode ierr;
+  EPS_NLPOWER    *power = (EPS_NLPOWER *)eps->data;
+  PetscBool      flg, istrivial;
+  STMatMode      mode;
+
+  PetscFunctionBegin;
+  if (eps->ncv)
+  {
+    if (eps->ncv < eps->nev)
+      SETERRQ(PetscObjectComm((PetscObject)eps), 1, "The value of ncv must be at least nev");
+  } else eps->ncv = eps->nev;
+  if (eps->mpd) {
+    ierr = PetscInfo(eps, "Warning: parameter mpd ignored\n");CHKERRQ(ierr);
+  }
+  if (!eps->max_it) eps->max_it = PetscMax(2000, 100 * eps->n);
+
+  if (!eps->which) {
+    ierr = EPSSetWhichEigenpairs_Default(eps); CHKERRQ(ierr);
+  }
+
+  if (eps->which != EPS_SMALLEST_MAGNITUDE && eps->which != EPS_TARGET_MAGNITUDE)
+    SETERRQ(PetscObjectComm((PetscObject)eps), 1, "Wrong value of eps->which");
+
+  if (power->shift_type != EPS_POWER_SHIFT_CONSTANT) {
+    ierr = PetscObjectTypeCompareAny((PetscObject)eps->st, &flg, STSINVERT, STCAYLEY, "");CHKERRQ(ierr);
+    if (!flg) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "Variable shifts only allowed in shift-and-invert or Cayley ST");
+    ierr = STGetMatMode(eps->st, &mode);CHKERRQ(ierr);
+    if (mode == ST_MATMODE_INPLACE) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "ST matrix mode inplace does not work with variable shifts");
+  }
+
+  if (eps->extraction) {
+    ierr = PetscInfo(eps, "Warning: extraction type ignored\n");CHKERRQ(ierr);
+  }
+
+  if (eps->balance != EPS_BALANCE_NONE) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "Balancing not supported in this solver");
+  if (eps->arbitrary) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "Arbitrary selection of eigenpairs not supported in this solver");
+
+  ierr = RGIsTrivial(eps->rg, &istrivial); CHKERRQ(ierr);
+  if (!istrivial) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_SUP, "This solver does not support region filtering");
+
+  ierr = EPSAllocateSolution(eps, 0);CHKERRQ(ierr);
+  ierr = EPS_SetInnerProduct(eps);CHKERRQ(ierr);
+  ierr = EPSSetWorkVecs(eps, 2);CHKERRQ(ierr);
+
+  if (!power->snes) {
+    ierr = SNESCreate(PetscObjectComm((PetscObject)eps), &power->snes);CHKERRQ(ierr);
+  }
+  /* to avoid slepc setup preconditioner too early */
+  if (eps->st->P) eps->st->P = NULL;
+  /* do not do any transform */
+  eps->st->transform = PETSC_FALSE;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSNESInit_NLPower"
+
+PetscErrorCode EPSSNESInit_NLPower(EPS eps, Vec x, Vec y) {
+  PetscErrorCode ierr;
+  Mat A, B;
+  EPS_NLPOWER *nlpower = (EPS_NLPOWER *)eps->data;
+  PetscContainer container;
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(eps, EPS_CLASSID, 1);
+  PetscValidHeaderSpecific(x, VEC_CLASSID, 2);
+  PetscValidHeaderSpecific(y, VEC_CLASSID, 3);
+  if (x == y) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_IDN, "x and y must be different vectors");
+  ierr = EPSGetOperators_Moose(eps, &A, &B);CHKERRQ(ierr);
+  if (A) {
+    ierr = PetscObjectQueryFunction((PetscObject)A, "formFunctionA", &(nlpower->formFunctionA));CHKERRQ(ierr);
+    ierr = PetscObjectQueryFunction((PetscObject)A, "formJacobianA", &(nlpower->formJacobianA));CHKERRQ(ierr);
+    ierr = PetscObjectQuery((PetscObject)A, "AppCtx", (PetscObject *)&container);CHKERRQ(ierr);
+    ierr = PetscContainerGetPointer(container, &nlpower->functionctxA);CHKERRQ(ierr);
+    ierr = PetscContainerGetPointer(container, &nlpower->jacobianctxA);CHKERRQ(ierr);
+    if (B) {
+      ierr = PetscObjectQueryFunction((PetscObject)B, "formFunctionB", &(nlpower->formFunctionB));CHKERRQ(ierr);
+      ierr = PetscObjectQueryFunction((PetscObject)B, "formJacobianB", &(nlpower->formJacobianB));CHKERRQ(ierr);
+      ierr = PetscObjectQuery((PetscObject)B, "AppCtx", (PetscObject *)&container);CHKERRQ(ierr);
+      ierr = PetscContainerGetPointer(container, &nlpower->functionctxB);CHKERRQ(ierr);
+      ierr = PetscContainerGetPointer(container, &nlpower->jacobianctxB);CHKERRQ(ierr);
+    }
+  } else {
+    SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_NULL, "operators are NULL, please set operators properly \n");
+  }
+  if (!nlpower->y_tmp) {
+    ierr = VecDuplicate(y, &nlpower->y_tmp);CHKERRQ(ierr);
+  }
+  ierr = VecSet(nlpower->y_tmp, 0.0);CHKERRQ(ierr);
+  if (!nlpower->res) {
+    ierr = VecDuplicate(y, &nlpower->res);CHKERRQ(ierr);
+  }
+  ierr = VecSet(nlpower->res, 0.0);CHKERRQ(ierr);
+  if (!nlpower->snes) {
+    ierr = SNESCreate(PetscObjectComm((PetscObject)eps), &nlpower->snes);CHKERRQ(ierr);
+  }
+  if (nlpower->formFunctionA && nlpower->formJacobianA) {
+    ierr = SNESSetFunction(nlpower->snes, nlpower->res, nlpower->formFunctionA, nlpower->functionctxA);CHKERRQ(ierr);
+    ierr = SNESSetJacobian(nlpower->snes, A, A, nlpower->formJacobianA, nlpower->jacobianctxA);CHKERRQ(ierr);
+  } else SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_NULL, "did not set functions for evaluating Jacobian and residual \n");
+  ierr = SNESSetFromOptions(nlpower->snes);CHKERRQ(ierr);
+  ierr = SNESSetUp(nlpower->snes);CHKERRQ(ierr);
+  nlpower->initialized = PETSC_TRUE;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSNESSolve_NLPower"
+
+PetscErrorCode EPSSNESSolve_NLPower(EPS eps, Vec x, Vec y)
+{
+  PetscErrorCode ierr;
+  EPS_NLPOWER *nlpower = (EPS_NLPOWER *)eps->data;
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(eps, EPS_CLASSID, 1);
+  PetscValidHeaderSpecific(x, VEC_CLASSID, 2);
+  PetscValidHeaderSpecific(y, VEC_CLASSID, 3);
+  if (x == y) SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_IDN, "x and y must be different vectors");
+  if (!nlpower->initialized) {
+    ierr = EPSSNESInit_NLPower(eps, x, y);CHKERRQ(ierr);
+  }
+  // Evaluate B*x
+  ierr = nlpower->formFunctionB(nlpower->snes, x, nlpower->y_tmp, nlpower->functionctxB);CHKERRQ(ierr);
+  ierr = VecCopy(x, y);CHKERRQ(ierr);
+  ierr = SNESSolve(nlpower->snes, nlpower->y_tmp, y);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSolve_NLPower"
+PetscErrorCode EPSSolve_NLPower(EPS eps)
+{
+  PetscErrorCode ierr;
+  EPS_NLPOWER *power = (EPS_NLPOWER *)eps->data;
+  PetscInt k;
+  Vec v, y, e;
+  PetscReal relerr, norm;
+  PetscScalar theta, rho, sigma;
+  PetscBool breakdown;
+  ST st;
+
+  PetscFunctionBegin;
+  y = eps->work[1];
+  e = eps->work[0];
+
+  ierr = EPSGetStartVector_Moose(eps, 0, NULL);CHKERRQ(ierr);
+  ierr = STGetShift(eps->st, &sigma);CHKERRQ(ierr); /* original shift */
+  rho = sigma;
+
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "EPSSolve_NLPower \n");CHKERRQ(ierr);
+
+  while (eps->reason == EPS_CONVERGED_ITERATING) {
+    eps->its++;
+    k = eps->nconv;
+
+    /* y = OP v */
+    ierr = BVGetColumn(eps->V, k, &v);CHKERRQ(ierr);
+
+    ierr = EPSSNESSolve_NLPower(eps, v, y);CHKERRQ(ierr);
+    ierr = BVRestoreColumn(eps->V, k, &v);CHKERRQ(ierr);
+
+    /* theta = (v,y)_B */
+    ierr = BVSetActiveColumns(eps->V, k, k + 1);CHKERRQ(ierr);
+    ierr = BVDotVec(eps->V, y, &theta);CHKERRQ(ierr);
+
+    if (power->shift_type == EPS_POWER_SHIFT_CONSTANT) { /* direct & inverse iteration */
+
+      /* approximate eigenvalue is the Rayleigh quotient */
+      eps->eigr[eps->nconv] = theta;
+
+      /* compute relative error as ||y-theta v||_2/|theta| */
+      ierr = VecCopy(y, e);CHKERRQ(ierr);
+      ierr = BVGetColumn(eps->V, k, &v);CHKERRQ(ierr);
+      ierr = VecAXPY(e, -theta, v);CHKERRQ(ierr);
+      ierr = BVRestoreColumn(eps->V, k, &v);CHKERRQ(ierr);
+      ierr = VecNorm(e, NORM_2, &norm);CHKERRQ(ierr);
+      relerr = norm / PetscAbsScalar(theta);
+
+    } else {
+      SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_NULL, "do not support shift type \n");
+    }
+    eps->errest[eps->nconv] = relerr;
+
+    /* purge previously converged eigenvectors */
+    ierr = BVInsertVec(eps->V, k, y);
+    CHKERRQ(ierr);
+    ierr = BVOrthogonalizeColumn(eps->V, k, NULL, &norm, NULL);
+    CHKERRQ(ierr);
+    ierr = BVScaleColumn(eps->V, k, 1.0 / norm);
+    CHKERRQ(ierr);
+
+    /* if relerr<tol, accept eigenpair */
+    if (relerr < eps->tol) {
+      eps->nconv = eps->nconv + 1;
+      if (eps->nconv < eps->nev) {
+        ierr = EPSGetStartVector_Moose(eps, eps->nconv, &breakdown);
+        CHKERRQ(ierr);
+        if (breakdown) {
+          eps->reason = EPS_DIVERGED_BREAKDOWN;
+          ierr = PetscInfo(eps, "Unable to generate more start vectors\n");
+          CHKERRQ(ierr);
+          break;
+        }
+      }
+    }
+    ierr = EPSMonitor(eps, eps->its, eps->nconv, eps->eigr, eps->eigi, eps->errest, eps->nconv + 1);CHKERRQ(ierr);
+    ierr = (*eps->stopping)(eps, eps->its, eps->max_it, eps->nconv, eps->nev, &eps->reason, eps->stoppingctx);CHKERRQ(ierr);
+  }
+  ierr = EPSGetST(eps,&st);CHKERRQ(ierr);
+  st->Astate[0] = ((PetscObject)st->A[0])->state;
+  st->Astate[1] = ((PetscObject)st->A[1])->state;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSSetFromOptions_NLPower"
+PetscErrorCode EPSSetFromOptions_NLPower(PetscOptionItems *PetscOptionsObject, EPS eps)
+{
+  PetscErrorCode ierr;
+  EPS_NLPOWER   *power = (EPS_NLPOWER *)eps->data;
+  PetscBool      flg;
+  EPSPowerShiftType shift;
+
+  PetscFunctionBegin;
+  ierr = PetscOptionsHead(PetscOptionsObject, "EPS Power Options");CHKERRQ(ierr);
+  ierr = PetscOptionsEnum("-eps_power_shift_type", "Shift type",
+                       "EPSPowerSetShiftType", EPSPowerShiftTypes,
+                       (PetscEnum)power->shift_type, (PetscEnum *)&shift, &flg);CHKERRQ(ierr);
+  if (flg) {
+    ierr = EPSPowerSetShiftType(eps, shift);CHKERRQ(ierr);
+  }
+  if (power->shift_type != EPS_POWER_SHIFT_CONSTANT) {
+    ierr = STSetType(eps->st, STSINVERT);CHKERRQ(ierr);
+  }
+  ierr = PetscOptionsTail();CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSPowerSetShiftType_NLPower"
+static PetscErrorCode EPSPowerSetShiftType_NLPower(EPS eps, EPSPowerShiftType shift)
+{
+  EPS_NLPOWER *power = (EPS_NLPOWER *)eps->data;
+
+  PetscFunctionBegin;
+  switch (shift) {
+  case EPS_POWER_SHIFT_CONSTANT:
+  case EPS_POWER_SHIFT_RAYLEIGH:
+  case EPS_POWER_SHIFT_WILKINSON:
+    power->shift_type = shift;
+    break;
+  default:
+    SETERRQ(PetscObjectComm((PetscObject)eps), PETSC_ERR_ARG_OUTOFRANGE,
+            "Invalid shift type");
+  }
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSPowerGetShiftType_NLPower"
+static PetscErrorCode EPSPowerGetShiftType_NLPower(EPS eps,EPSPowerShiftType *shift)
+{
+  EPS_NLPOWER *power = (EPS_NLPOWER *)eps->data;
+
+  PetscFunctionBegin;
+  *shift = power->shift_type;
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSDestroy_NLPower"
+PetscErrorCode EPSDestroy_NLPower(EPS eps)
+{
+  EPS_NLPOWER *power = (EPS_NLPOWER *)eps->data;
+  PetscErrorCode ierr;
+
+  PetscFunctionBegin;
+  if (power->snes) {
+    ierr = SNESDestroy(&power->snes);CHKERRQ(ierr);
+  }
+  if (power->res) {
+    ierr = VecDestroy(&power->res);CHKERRQ(ierr);
+  }
+  if (power->y_tmp) {
+    ierr = VecDestroy(&power->y_tmp);CHKERRQ(ierr);
+  }
+  ierr = PetscFree(eps->data);CHKERRQ(ierr);
+  ierr = PetscObjectComposeFunction((PetscObject)eps, "EPSPowerSetShiftType_C", NULL);CHKERRQ(ierr);
+  ierr = PetscObjectComposeFunction((PetscObject)eps, "EPSPowerGetShiftType_C", NULL);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSView_NLPower"
+PetscErrorCode EPSView_NLPower(EPS eps, PetscViewer viewer)
+{
+  PetscErrorCode ierr;
+  EPS_NLPOWER   *power = (EPS_NLPOWER *)eps->data;
+  PetscBool      isascii;
+
+  PetscFunctionBegin;
+  ierr = PetscObjectTypeCompare((PetscObject)viewer, PETSCVIEWERASCII, &isascii);CHKERRQ(ierr);
+  if (isascii) {
+    ierr = PetscViewerASCIIPrintf(viewer, " Nonlinear Power: %s shifts\n", EPSPowerShiftTypes[power->shift_type]);CHKERRQ(ierr);
+  }
+  if (power->snes) {
+    ierr = SNESView(power->snes, viewer);CHKERRQ(ierr);
+  }
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "EPSCreate_NLPower"
+PETSC_EXTERN PetscErrorCode EPSCreate_NLPower(EPS eps)
+{
+  EPS_NLPOWER *ctx;
+  PetscErrorCode ierr;
+
+  PetscFunctionBegin;
+  ierr = PetscNewLog(eps, &ctx);CHKERRQ(ierr);
+  eps->data = (void *)ctx;
+
+  eps->ops->setup = EPSSetUp_NLPower;
+  eps->ops->solve = EPSSolve_NLPower;
+  eps->ops->setfromoptions = EPSSetFromOptions_NLPower;
+  eps->ops->destroy = EPSDestroy_NLPower;
+  eps->ops->view = EPSView_NLPower;
+  eps->ops->backtransform = NULL;
+  ierr = PetscObjectComposeFunction((PetscObject)eps, "EPSPowerSetShiftType_C", EPSPowerSetShiftType_NLPower);CHKERRQ(ierr);
+  ierr = PetscObjectComposeFunction((PetscObject)eps, "EPSPowerGetShiftType_C", EPSPowerGetShiftType_NLPower);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+#endif

--- a/framework/include/kernels/CoupledForce.h
+++ b/framework/include/kernels/CoupledForce.h
@@ -41,6 +41,7 @@ protected:
 private:
   unsigned int _v_var;
   const VariableValue & _v;
+  Real _cof;
 };
 
 #endif // COUPLEDFORCE_H

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -254,11 +254,12 @@ enum SolveType
  */
 enum EigenSolveType
 {
-  EST_POWER,          ///< Power / Inverse / RQI
-  EST_ARNOLDI,        ///< Arnoldi
-  EST_KRYLOVSCHUR,    ///< Krylov-Schur
-  EST_JACOBI_DAVIDSON,///< Jacobi-Davidson
-  EST_NONLINEAR_POWER
+  EST_POWER,           ///< Power / Inverse / RQI
+  EST_ARNOLDI,         ///< Arnoldi
+  EST_KRYLOVSCHUR,     ///< Krylov-Schur
+  EST_JACOBI_DAVIDSON, ///< Jacobi-Davidson
+  EST_NONLINEAR_POWER, ///< Nonlinear inverse power
+  EST_MONOLITH_NEWTON  ///< Newton-based eigen solver
 };
 
 /**

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -257,7 +257,8 @@ enum EigenSolveType
   EST_POWER,          ///< Power / Inverse / RQI
   EST_ARNOLDI,        ///< Arnoldi
   EST_KRYLOVSCHUR,    ///< Krylov-Schur
-  EST_JACOBI_DAVIDSON ///< Jacobi-Davidson
+  EST_JACOBI_DAVIDSON,///< Jacobi-Davidson
+  EST_NONLINEAR_POWER
 };
 
 /**

--- a/framework/include/utils/SlepcSupport.h
+++ b/framework/include/utils/SlepcSupport.h
@@ -39,6 +39,11 @@ InputParameters getSlepcEigenProblemValidParams();
 void storeSlepcOptions(FEProblemBase & fe_problem, const InputParameters & params);
 void storeSlepcEigenProblemOptions(EigenProblem & eigen_problem, const InputParameters & params);
 void slepcSetOptions(FEProblemBase & problem);
+
+PetscErrorCode moose_slepc_eigen_formJacobianA(SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
+PetscErrorCode moose_slepc_eigen_formJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
+PetscErrorCode moose_slepc_eigen_formFunctionA(SNES snes, Vec x, Vec r, void * ctx);
+PetscErrorCode moose_slepc_eigen_formFunctionB(SNES snes, Vec x, Vec r, void * ctx);
 } // namespace SlepcSupport
 } // namespace moose
 

--- a/framework/include/utils/SlepcSupport.h
+++ b/framework/include/utils/SlepcSupport.h
@@ -44,6 +44,7 @@ PetscErrorCode moose_slepc_eigen_formJacobianA(SNES snes, Vec x, Mat jac, Mat pc
 PetscErrorCode moose_slepc_eigen_formJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
 PetscErrorCode moose_slepc_eigen_formFunctionA(SNES snes, Vec x, Vec r, void * ctx);
 PetscErrorCode moose_slepc_eigen_formFunctionB(SNES snes, Vec x, Vec r, void * ctx);
+void registerEigenSolvers();
 } // namespace SlepcSupport
 } // namespace moose
 

--- a/framework/src/base/NonlinearEigenSystem.C
+++ b/framework/src/base/NonlinearEigenSystem.C
@@ -23,7 +23,6 @@
 #include "TimeIntegrator.h"
 #include "SlepcSupport.h"
 
-
 // libmesh includes
 #include "libmesh/eigen_system.h"
 #include "libmesh/libmesh_config.h"

--- a/framework/src/kernels/CoupledForce.C
+++ b/framework/src/kernels/CoupledForce.C
@@ -21,19 +21,20 @@ validParams<CoupledForce>()
   InputParameters params = validParams<Kernel>();
 
   params.addRequiredCoupledVar("v", "The coupled variable which provides the force");
+  params.addParam<Real>("cof", 1.0, "Coefficent to multiply by the coupled force term");
 
   return params;
 }
 
 CoupledForce::CoupledForce(const InputParameters & parameters)
-  : Kernel(parameters), _v_var(coupled("v")), _v(coupledValue("v"))
+  : Kernel(parameters), _v_var(coupled("v")), _v(coupledValue("v")), _cof(getParam<Real>("cof"))
 {
 }
 
 Real
 CoupledForce::computeQpResidual()
 {
-  return -_v[_qp] * _test[_i][_qp];
+  return _cof * -_v[_qp] * _test[_i][_qp];
 }
 
 Real

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -98,6 +98,7 @@ initEigenSolveType()
     eigen_solve_type_to_enum["KRYLOVSCHUR"] = EST_KRYLOVSCHUR;
     eigen_solve_type_to_enum["JACOBI_DAVIDSON"] = EST_JACOBI_DAVIDSON;
     eigen_solve_type_to_enum["NONLINEAR_POWER"] = EST_NONLINEAR_POWER;
+    eigen_solve_type_to_enum["MONOLITH_NEWTON"] = EST_MONOLITH_NEWTON;
   }
 }
 

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -97,6 +97,7 @@ initEigenSolveType()
     eigen_solve_type_to_enum["ARNOLDI"] = EST_ARNOLDI;
     eigen_solve_type_to_enum["KRYLOVSCHUR"] = EST_KRYLOVSCHUR;
     eigen_solve_type_to_enum["JACOBI_DAVIDSON"] = EST_JACOBI_DAVIDSON;
+    eigen_solve_type_to_enum["NONLINEAR_POWER"] = EST_NONLINEAR_POWER;
   }
 }
 

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -250,7 +250,6 @@ setEigenSolverOptions(SolverParams & solver_params)
 
     case Moose::EST_NONLINEAR_POWER:
       Moose::PetscSupport::setSinglePetscOption("-eps_type", "nlpower");
-      Moose::PetscSupport::setSinglePetscOption("-st_type", "sinvert");
       break;
 
     case Moose::EST_MONOLITH_NEWTON:

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -25,6 +25,11 @@
 #include "InputParameters.h"
 #include "EigenProblem.h"
 #include "Conversion.h"
+#include "EigenProblem.h"
+#include "NonlinearSystemBase.h"
+
+#include "libmesh/petsc_vector.h"
+#include "libmesh/petsc_matrix.h"
 
 namespace Moose
 {
@@ -36,7 +41,7 @@ getSlepcValidParams()
 {
   InputParameters params = emptyInputParameters();
 
-  MooseEnum eigen_solve_type("POWER ARNOLDI KRYLOVSCHUR JACOBI_DAVIDSON");
+  MooseEnum eigen_solve_type("POWER ARNOLDI KRYLOVSCHUR JACOBI_DAVIDSON NONLINEAR_POWER");
   params.addParam<MooseEnum>("eigen_solve_type",
                              eigen_solve_type,
                              "POWER: Power / Inverse / RQI "
@@ -231,6 +236,10 @@ setEigenSolverOptions(SolverParams & solver_params)
       Moose::PetscSupport::setSinglePetscOption("-eps_type", "jd");
       break;
 
+    case Moose::EST_NONLINEAR_POWER:
+      Moose::PetscSupport::setSinglePetscOption("-eps_type", "nlpower");
+      break;
+
     default:
       mooseError("Unknown eigen solver type \n");
   }
@@ -247,6 +256,95 @@ slepcSetOptions(FEProblemBase & problem)
   Moose::PetscSupport::addPetscOptionsFromCommandline();
 }
 
+ void
+ moose_petsc_snes_formJacobian(SNES /*snes*/, Vec x, Mat jac, Mat pc, void * ctx, Moose::KernelType type)
+ {
+   EigenProblem  * eigen_problem = static_cast<EigenProblem *> (ctx);
+   NonlinearSystemBase & nl = eigen_problem->getNonlinearSystemBase();
+   System              & sys = nl.system();
+
+   PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
+   PetscVector<Number> X_global(x, sys.comm());
+
+   // update local solution
+   X_global.swap(X_sys);
+   sys.update();
+   X_global.swap(X_sys);
+
+   PetscMatrix<Number> PC(pc, sys.comm());
+   PetscMatrix<Number> Jac(jac, sys.comm());
+
+   // Set the dof maps
+   PC.attach_dof_map(sys.get_dof_map());
+   Jac.attach_dof_map(sys.get_dof_map());
+
+   PC.zero();
+   Jac.zero();
+
+   eigen_problem->computeJacobian(*sys.current_local_solution.get(), PC, type);
+
+   PC.close();
+   if (jac != pc)
+     Jac.close();
+ }
+
+ PetscErrorCode
+ moose_slepc_eigen_formJacobianA(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
+ {
+   PetscFunctionBegin;
+
+   moose_petsc_snes_formJacobian(snes, x, jac, pc, ctx, Moose::KT_NONEIGEN);
+   PetscFunctionReturn(0);
+ }
+
+ PetscErrorCode
+ moose_slepc_eigen_formJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
+ {
+   PetscFunctionBegin;
+
+   moose_petsc_snes_formJacobian(snes, x, jac, pc, ctx, Moose::KT_EIGEN);
+   PetscFunctionReturn(0);
+ }
+
+ void
+ moose_petsc_snes_formFunction(SNES /*snes*/, Vec x, Vec r, void * ctx, Moose::KernelType type)
+ {
+   EigenProblem  * eigen_problem = static_cast<EigenProblem *> (ctx);
+   NonlinearSystemBase & nl = eigen_problem->getNonlinearSystemBase();
+   System              & sys = nl.system();
+
+   PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
+   PetscVector<Number> X_global(x, sys.comm()), R(r, sys.comm());
+
+   // update local solution
+   X_global.swap(X_sys);
+   sys.update();
+   X_global.swap(X_sys);
+
+   R.zero();
+
+   eigen_problem->computeResidualType(*sys.current_local_solution.get(), R, type);
+
+   R.close();
+ }
+
+ PetscErrorCode
+ moose_slepc_eigen_formFunctionA(SNES snes, Vec x, Vec r, void * ctx)
+ {
+   PetscFunctionBegin;
+
+   moose_petsc_snes_formFunction(snes, x, r, ctx, Moose::KT_NONEIGEN);
+   PetscFunctionReturn(0);
+ }
+
+ PetscErrorCode
+ moose_slepc_eigen_formFunctionB(SNES snes, Vec x, Vec r, void * ctx)
+ {
+   PetscFunctionBegin;
+
+   moose_petsc_snes_formFunction(snes, x, r, ctx, Moose::KT_EIGEN);
+   PetscFunctionReturn(0);
+ }
 } // namespace SlepcSupport
 } // namespace moose
 

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -27,6 +27,8 @@
 #include "Conversion.h"
 #include "EigenProblem.h"
 #include "NonlinearSystemBase.h"
+#include "nlpower.h"
+#include "monolith.h"
 
 #include "libmesh/petsc_vector.h"
 #include "libmesh/petsc_matrix.h"
@@ -41,7 +43,8 @@ getSlepcValidParams()
 {
   InputParameters params = emptyInputParameters();
 
-  MooseEnum eigen_solve_type("POWER ARNOLDI KRYLOVSCHUR JACOBI_DAVIDSON NONLINEAR_POWER");
+  MooseEnum eigen_solve_type("POWER ARNOLDI KRYLOVSCHUR JACOBI_DAVIDSON "
+                             "NONLINEAR_POWER  MONOLITH_NEWTON");
   params.addParam<MooseEnum>("eigen_solve_type",
                              eigen_solve_type,
                              "POWER: Power / Inverse / RQI "
@@ -49,6 +52,13 @@ getSlepcValidParams()
                              "KRYLOVSCHUR: Krylov-Schur "
                              "JACOBI_DAVIDSON: Jacobi-Davidson ");
   return params;
+}
+
+void
+registerEigenSolvers()
+{
+  EPSRegister("nlpower", EPSCreate_NLPower);
+  EPSRegister("monolith", EPSCreate_Monolith);
 }
 
 InputParameters
@@ -89,6 +99,8 @@ getSlepcEigenProblemValidParams()
                              "TARGET_REAL "
                              "TARGET_IMAGINARY "
                              "ALL_EIGENVALUES ");
+  // Register solvers as early as possible
+  registerEigenSolvers();
   return params;
 }
 
@@ -238,6 +250,11 @@ setEigenSolverOptions(SolverParams & solver_params)
 
     case Moose::EST_NONLINEAR_POWER:
       Moose::PetscSupport::setSinglePetscOption("-eps_type", "nlpower");
+      Moose::PetscSupport::setSinglePetscOption("-st_type", "sinvert");
+      break;
+
+    case Moose::EST_MONOLITH_NEWTON:
+      Moose::PetscSupport::setSinglePetscOption("-eps_type", "monolith");
       break;
 
     default:
@@ -256,95 +273,103 @@ slepcSetOptions(FEProblemBase & problem)
   Moose::PetscSupport::addPetscOptionsFromCommandline();
 }
 
- void
- moose_petsc_snes_formJacobian(SNES /*snes*/, Vec x, Mat jac, Mat pc, void * ctx, Moose::KernelType type)
- {
-   EigenProblem  * eigen_problem = static_cast<EigenProblem *> (ctx);
-   NonlinearSystemBase & nl = eigen_problem->getNonlinearSystemBase();
-   System              & sys = nl.system();
+void
+moose_petsc_snes_formJacobian(
+    SNES /*snes*/, Vec x, Mat jac, Mat pc, void * ctx, Moose::KernelType type)
+{
+  EigenProblem * eigen_problem = static_cast<EigenProblem *>(ctx);
+  NonlinearSystemBase & nl = eigen_problem->getNonlinearSystemBase();
+  System & sys = nl.system();
 
-   PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
-   PetscVector<Number> X_global(x, sys.comm());
+  PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
+  PetscVector<Number> X_global(x, sys.comm());
 
-   // update local solution
-   X_global.swap(X_sys);
-   sys.update();
-   X_global.swap(X_sys);
+  // update local solution
+  X_global.swap(X_sys);
+  sys.update();
+  X_global.swap(X_sys);
 
-   PetscMatrix<Number> PC(pc, sys.comm());
-   PetscMatrix<Number> Jac(jac, sys.comm());
+  PetscMatrix<Number> PC(pc, sys.comm());
+  PetscMatrix<Number> Jac(jac, sys.comm());
 
-   // Set the dof maps
-   PC.attach_dof_map(sys.get_dof_map());
-   Jac.attach_dof_map(sys.get_dof_map());
+  // Set the dof maps
+  PC.attach_dof_map(sys.get_dof_map());
+  Jac.attach_dof_map(sys.get_dof_map());
 
-   PC.zero();
-   Jac.zero();
+  PC.zero();
 
-   eigen_problem->computeJacobian(*sys.current_local_solution.get(), PC, type);
+  eigen_problem->computeJacobian(*sys.current_local_solution.get(), PC, type);
 
-   PC.close();
-   if (jac != pc)
-     Jac.close();
- }
+  PC.close();
+  if (jac != pc)
+    Jac.close();
+}
 
- PetscErrorCode
- moose_slepc_eigen_formJacobianA(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
- {
-   PetscFunctionBegin;
+#undef __FUNCT__
+#define __FUNCT__ "moose_slepc_eigen_formJacobianA"
+PetscErrorCode
+moose_slepc_eigen_formJacobianA(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
+{
+  PetscFunctionBegin;
 
-   moose_petsc_snes_formJacobian(snes, x, jac, pc, ctx, Moose::KT_NONEIGEN);
-   PetscFunctionReturn(0);
- }
+  moose_petsc_snes_formJacobian(snes, x, jac, pc, ctx, Moose::KT_NONEIGEN);
+  PetscFunctionReturn(0);
+}
 
- PetscErrorCode
- moose_slepc_eigen_formJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
- {
-   PetscFunctionBegin;
+#undef __FUNCT__
+#define __FUNCT__ "moose_slepc_eigen_formJacobianB"
+PetscErrorCode
+moose_slepc_eigen_formJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
+{
+  PetscFunctionBegin;
 
-   moose_petsc_snes_formJacobian(snes, x, jac, pc, ctx, Moose::KT_EIGEN);
-   PetscFunctionReturn(0);
- }
+  moose_petsc_snes_formJacobian(snes, x, jac, pc, ctx, Moose::KT_EIGEN);
+  PetscFunctionReturn(0);
+}
 
- void
- moose_petsc_snes_formFunction(SNES /*snes*/, Vec x, Vec r, void * ctx, Moose::KernelType type)
- {
-   EigenProblem  * eigen_problem = static_cast<EigenProblem *> (ctx);
-   NonlinearSystemBase & nl = eigen_problem->getNonlinearSystemBase();
-   System              & sys = nl.system();
+void
+moose_petsc_snes_formFunction(SNES /*snes*/, Vec x, Vec r, void * ctx, Moose::KernelType type)
+{
+  EigenProblem * eigen_problem = static_cast<EigenProblem *>(ctx);
+  NonlinearSystemBase & nl = eigen_problem->getNonlinearSystemBase();
+  System & sys = nl.system();
 
-   PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
-   PetscVector<Number> X_global(x, sys.comm()), R(r, sys.comm());
+  PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
+  PetscVector<Number> X_global(x, sys.comm()), R(r, sys.comm());
 
-   // update local solution
-   X_global.swap(X_sys);
-   sys.update();
-   X_global.swap(X_sys);
+  // update local solution
+  X_global.swap(X_sys);
+  sys.update();
+  X_global.swap(X_sys);
 
-   R.zero();
+  R.zero();
 
-   eigen_problem->computeResidualType(*sys.current_local_solution.get(), R, type);
+  eigen_problem->computeResidualType(*sys.current_local_solution.get(), R, type);
 
-   R.close();
- }
+  R.close();
+}
 
- PetscErrorCode
- moose_slepc_eigen_formFunctionA(SNES snes, Vec x, Vec r, void * ctx)
- {
-   PetscFunctionBegin;
+#undef __FUNCT__
+#define __FUNCT__ "moose_slepc_eigen_formFunctionA"
+PetscErrorCode
+moose_slepc_eigen_formFunctionA(SNES snes, Vec x, Vec r, void * ctx)
+{
+  PetscFunctionBegin;
 
-   moose_petsc_snes_formFunction(snes, x, r, ctx, Moose::KT_NONEIGEN);
-   PetscFunctionReturn(0);
- }
+  moose_petsc_snes_formFunction(snes, x, r, ctx, Moose::KT_NONEIGEN);
+  PetscFunctionReturn(0);
+}
 
- PetscErrorCode
- moose_slepc_eigen_formFunctionB(SNES snes, Vec x, Vec r, void * ctx)
- {
-   PetscFunctionBegin;
+#undef __FUNCT__
+#define __FUNCT__ "moose_slepc_eigen_formFunctionB"
+PetscErrorCode
+moose_slepc_eigen_formFunctionB(SNES snes, Vec x, Vec r, void * ctx)
+{
+  PetscFunctionBegin;
 
-   moose_petsc_snes_formFunction(snes, x, r, ctx, Moose::KT_EIGEN);
-   PetscFunctionReturn(0);
- }
+  moose_petsc_snes_formFunction(snes, x, r, ctx, Moose::KT_EIGEN);
+  PetscFunctionReturn(0);
+}
 } // namespace SlepcSupport
 } // namespace moose
 

--- a/test/include/kernels/PMassKernel.h
+++ b/test/include/kernels/PMassKernel.h
@@ -1,0 +1,42 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#ifndef PMASSKERNEL_H
+#define PMASSKERNEL_H
+
+#include "Kernel.h"
+
+// Forward Declarations
+class PMassKernel;
+
+template <>
+InputParameters validParams<PMassKernel>();
+
+/**
+ * This kernel implements (v, |u|^(p-2) u)/k, where u is the variable, v is the test function
+ * and k is the eigenvalue. When p=2, this kernel is equivalent with MassEigenKernel.
+ */
+
+class PMassKernel : public Kernel
+{
+public:
+  PMassKernel(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+
+  Real _p;
+};
+
+#endif // PMASSKERNEL_H

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -71,6 +71,7 @@
 #include "MaterialEigenKernel.h"
 #include "PHarmonic.h"
 #include "PMassEigenKernel.h"
+#include "PMassKernel.h"
 #include "CoupledEigenKernel.h"
 #include "ConsoleMessageKernel.h"
 #include "WrongJacobianDiffusion.h"
@@ -367,6 +368,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerKernel(MaterialEigenKernel);
   registerKernel(PHarmonic);
   registerKernel(PMassEigenKernel);
+  registerKernel(PMassKernel);
   registerKernel(CoupledEigenKernel);
   registerKernel(ConsoleMessageKernel);
   registerKernel(WrongJacobianDiffusion);

--- a/test/src/kernels/PMassKernel.C
+++ b/test/src/kernels/PMassKernel.C
@@ -1,0 +1,41 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#include "PMassKernel.h"
+
+template <>
+InputParameters
+validParams<PMassKernel>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addRangeCheckedParam<Real>("p", 2.0, "p>=1.0", "The exponent p");
+  return params;
+}
+
+PMassKernel::PMassKernel(const InputParameters & parameters)
+  : Kernel(parameters), _p(getParam<Real>("p") - 2.0)
+{
+}
+
+Real
+PMassKernel::computeQpResidual()
+{
+  return std::pow(std::fabs(_u[_qp]), _p) * _u[_qp] * _test[_i][_qp];
+}
+
+Real
+PMassKernel::computeQpJacobian()
+{
+  // Note: this jacobian evaluation is not exact when p!=2.
+  return std::pow(std::fabs(_phi[_j][_qp]), _p) * _phi[_j][_qp] * _test[_i][_qp];
+}

--- a/test/tests/problems/eigen_problem/ane.i
+++ b/test/tests/problems/eigen_problem/ane.i
@@ -1,0 +1,84 @@
+[Mesh]
+ type = GeneratedMesh
+ dim = 2
+ xmin = 0
+ xmax = 10
+ ymin = 0
+ ymax = 10
+ elem_type = QUAD4
+ nx = 8
+ ny = 8
+
+ uniform_refine = 0
+[]
+
+# the minimum eigenvalue is (2*PI*(p-1)^(1/p)/a/p/sin(PI/p))^p;
+# Its inverse is 35.349726539758187. Here a is equal to 10.
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+
+[Kernels]
+  [./diff]
+    type = PHarmonic
+    variable = u
+    p = 3
+  [../]
+
+  [./rhs]
+    type = PMassKernel
+    eigen_kernel = true
+    variable = u
+    p = 3
+  [../]
+[]
+
+[BCs]
+  [./homogeneous]
+    type = DirichletBC
+    variable = u
+    boundary = '0 2'
+    value = 0
+  [../]
+[]
+
+[Problem]
+  type = EigenProblem
+  eigen_problem_type = gen_non_hermitian
+  n_eigen_pairs = 1
+  n_basis_vectors = 18
+[]
+
+
+[Executioner]
+  type = Steady
+  eigen_solve_type = MONOLITH_NEWTON
+#  petsc_options_iname = '-snes_mf_operator'
+#  petsc_options_value = '1'
+[]
+
+
+[VectorPostprocessors]
+  [./eigenvalues]
+    type = Eigenvalues
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = ane
+  execute_on = 'timestep_end'
+  [./console]
+    type = Console
+    outlier_variable_norms = false
+  [../]
+[]
+
+# 0.0287721
+# 0.02876678286685

--- a/test/tests/problems/eigen_problem/gold/ane_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/ane_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.028766782679823
+

--- a/test/tests/problems/eigen_problem/gold/monolith_newton_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/monolith_newton_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.19743172114775
+

--- a/test/tests/problems/eigen_problem/gold/ne_coupled_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/ne_coupled_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.27676227513127
+

--- a/test/tests/problems/eigen_problem/gold/ne_deficient_b_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/ne_deficient_b_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.039921417075235
+

--- a/test/tests/problems/eigen_problem/gold/nonlinear_power_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/nonlinear_power_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,5.0650424081549
+

--- a/test/tests/problems/eigen_problem/gold/nonlinear_power_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/nonlinear_power_eigenvalues_0001.csv
@@ -1,3 +1,3 @@
 eigen_values_imag,eigen_values_real
-0,5.0650424081549
+0,0.19743171290588
 

--- a/test/tests/problems/eigen_problem/ne.i
+++ b/test/tests/problems/eigen_problem/ne.i
@@ -1,0 +1,78 @@
+[Mesh]
+ type = GeneratedMesh
+ dim = 2
+ xmin = 0
+ xmax = 10
+ ymin = 0
+ ymax = 10
+ elem_type = QUAD4
+ nx = 64
+ ny = 64
+
+ uniform_refine = 0
+[]
+
+# the minimum eigenvalue of this problem is 2*(PI/a)^2;
+# Its inverse is 0.5*(a/PI)^2 = 5.0660591821169. Here a is equal to 10.
+
+[Variables]
+  active = 'u'
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+
+  [./rhs]
+    type = Reaction
+    variable = u
+    eigen_kernel = true
+  [../]
+[]
+
+[BCs]
+  [./homogeneous]
+    type = DirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    value = 0
+    use_displaced_mesh = true
+  [../]
+[]
+
+[Problem]
+  type = EigenProblem
+  eigen_problem_type = gen_non_hermitian
+  n_eigen_pairs = 1
+  n_basis_vectors = 18
+[]
+
+[Executioner]
+  type = Steady
+  eigen_solve_type = MONOLITH_NEWTON
+  petsc_options_iname = '-snes_mf_operator'
+  petsc_options_value = '0'
+[]
+
+[VectorPostprocessors]
+  [./eigenvalues]
+    type = Eigenvalues
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = monolith_newton
+  execute_on = 'timestep_end'
+  [./console]
+    type = Console
+    outlier_variable_norms = false
+  [../]
+[]

--- a/test/tests/problems/eigen_problem/ne_coupled.i
+++ b/test/tests/problems/eigen_problem/ne_coupled.i
@@ -1,0 +1,135 @@
+[Mesh]
+ type = GeneratedMesh
+ dim = 2
+ xmin = 0
+ xmax = 10
+ ymin = 0
+ ymax = 10
+ elem_type = QUAD4
+ nx = 8
+ ny = 8
+
+ uniform_refine = 0
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+
+  [./T]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./power]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = DiffMKernel
+    variable = u
+    mat_prop = diffusion
+    offset = 0.0
+  [../]
+
+  [./rhs]
+    type = Reaction
+    variable = u
+    eigen_kernel = true
+  [../]
+
+  [./diff_T]
+    type = Diffusion
+    variable = T
+  [../]
+  [./src_T]
+    type = CoupledForce
+    variable = T
+    v = power
+  [../]
+[]
+
+[AuxKernels]
+  [./power_ak]
+    type = NormalizationAux
+    variable = power
+    source_variable = u
+    normalization = unorm
+# this coefficient will affect the eigenvalue.
+    normal_factor = 10
+    execute_on = linear
+  [../]
+[]
+
+[BCs]
+  [./homogeneous]
+    type = DirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+
+  [./homogeneousT]
+    type = DirichletBC
+    variable = T
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+[]
+
+[Materials]
+  [./dc]
+    type = VarCouplingMaterial
+    var = T
+    block = 0
+    base = 1.0
+    coef = 1.0
+  [../]
+[]
+
+[Problem]
+  type = EigenProblem
+  eigen_problem_type = gen_non_hermitian
+  n_eigen_pairs = 1
+  n_basis_vectors = 18
+[]
+
+
+[Executioner]
+  type = Steady
+  eigen_solve_type = MONOLITH_NEWTON
+#  petsc_options_iname = '-snes_mf_operator'
+#  petsc_options_value = '1'
+[]
+
+[Postprocessors]
+  [./unorm]
+    type = ElementIntegralVariablePostprocessor
+    variable = u
+    execute_on = linear
+  [../]
+[]
+
+[VectorPostprocessors]
+  [./eigenvalues]
+    type = Eigenvalues
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = ne_coupled
+  execute_on = 'timestep_end'
+  [./console]
+    type = Console
+    outlier_variable_norms = false
+  [../]
+[]

--- a/test/tests/problems/eigen_problem/ne_deficient_b.i
+++ b/test/tests/problems/eigen_problem/ne_deficient_b.i
@@ -1,0 +1,101 @@
+[Mesh]
+ type = GeneratedMesh
+ dim = 2
+ xmin = 0
+ xmax = 10
+ ymin = 0
+ ymax = 10
+ elem_type = QUAD4
+ nx = 8
+ ny = 8
+
+ uniform_refine = 0
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./v]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = Diffusion
+    variable = u
+  [../]
+  [./diff_v]
+    type = Diffusion
+    variable = v
+  [../]
+
+  [./rhs]
+    type = CoupledForce
+    variable = u
+    v = v
+    eigen_kernel = true
+    cof = -1.0
+  [../]
+  [./src_v]
+    type = CoupledForce
+    variable = v
+    v = u
+    eigen_kernel = true
+    cof = -1.0
+  [../]
+[]
+
+[BCs]
+  [./homogeneous_u]
+    type = DirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+  [./homogeneous_v]
+    type = DirichletBC
+    variable = v
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+[]
+
+[Problem]
+  type = EigenProblem
+  eigen_problem_type = gen_non_hermitian
+  n_eigen_pairs = 1
+  n_basis_vectors = 18
+[]
+
+[Executioner]
+  type = Steady
+  eigen_solve_type = MONOLITH_NEWTON
+  petsc_options_iname = '-snes_mf_operator -monolith_n_free_power -initial_snes_mf_operator  -monolith_set_sub_eigen -nlpower_set_sub_eigen'
+  petsc_options_value = '1                  4                      1                          1                         1'
+  petsc_options = '-initial_eps_monitor -snes_monitor -eps_monitor'
+[]
+
+
+[VectorPostprocessors]
+  [./eigenvalues]
+    type = Eigenvalues
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = ne_deficient_b
+  execute_on = 'timestep_end'
+  [./console]
+    type = Console
+    outlier_variable_norms = false
+  [../]
+[]
+
+# 16: eigenvalue: 0.03921472186593  0.039149639134272 0.03894906835492
+# 64: 0.03897928685185  0.038975079139526 0.038961476514996 0.038961476514993

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -58,4 +58,12 @@
     csvdiff = 'monolith_newton_eigenvalues_0001.csv'
     slepc = true
   [../]
+
+  [./rank_deficient]
+    type = 'CSVDiff'
+    input = 'ne_deficient_b.i'
+    rel_err = 1e-2
+    csvdiff = 'ne_deficient_b_eigenvalues_0001.csv'
+    slepc = true
+  [../]
 []

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -73,4 +73,11 @@
     csvdiff = 'ane_eigenvalues_0001.csv'
     slepc = true
   [../]
+
+  [./coupled_nonlinear_eigenvalue]
+    type = 'CSVDiff'
+    input = 'ne_coupled.i'
+    csvdiff = 'ne_coupled_eigenvalues_0001.csv'
+    slepc = true
+  [../]
 []

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -42,4 +42,20 @@
     expect_err = "Need to install SLEPc to solve eigenvalue problems, please reconfigure libMesh."
     slepc = false
   [../]
+
+  [./nonlinear_power]
+    type = 'CSVDiff'
+    input = 'ne.i'
+    cli_args = 'Executioner/eigen_solve_type=NONLINEAR_POWER Outputs/file_base=nonlinear_power'
+    csvdiff = 'nonlinear_power_eigenvalues_0001.csv'
+    slepc = true
+  [../]
+
+  [./monolith_newton]
+    type = 'CSVDiff'
+    input = 'ne.i'
+    cli_args = 'Executioner/eigen_solve_type=MONOLITH_NEWTON Outputs/file_base=monolith_newton'
+    csvdiff = 'monolith_newton_eigenvalues_0001.csv'
+    slepc = true
+  [../]
 []

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -66,4 +66,11 @@
     csvdiff = 'ne_deficient_b_eigenvalues_0001.csv'
     slepc = true
   [../]
+
+  [./real_nonlinear_eigenvalue]
+    type = 'CSVDiff'
+    input = 'ane.i'
+    csvdiff = 'ane_eigenvalues_0001.csv'
+    slepc = true
+  [../]
 []


### PR DESCRIPTION
I am implementing two nonlinear eigenvalue solvers, nonlinear inverse power and Newton, which are not supported in SLEPc. Two algorithms  are moose-specific, and SLEPc developers may not accept them as new solvers.  

Using PETSc-based code in this implementation is to make sure the two new solvers have the same interface as the existing ones.  The advantage is  that we do not need to change much in the moose side.  The disadvantage is that the code looks really different from the existing moose code.

The implementation is not done yet.  Pushing up here is just for @permcody  to take a quick look at the interfaces.

@YaqiWang  may be also interested. 