### PR TITLE
Get rid of libmesh deprecation messages.

### DIFF
--- a/framework/include/base/ThreadedElementLoopBase.h
+++ b/framework/include/base/ThreadedElementLoopBase.h
@@ -173,7 +173,7 @@ ThreadedElementLoopBase<RangeType>::operator()(const RangeType & range, bool byp
                ++it)
             onBoundary(elem, side, *it);
 
-        if (elem->neighbor(side) != NULL)
+        if (elem->neighbor_ptr(side) != nullptr)
         {
           onInternalSide(elem, side);
           if (boundary_ids.size() > 0)

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -789,7 +789,7 @@ Assembly::reinit(const Elem * elem, unsigned int side)
 
   if (_current_side_elem)
     delete _current_side_elem;
-  _current_side_elem = elem->build_side(side).release();
+  _current_side_elem = elem->build_side_ptr(side).release();
 
   reinitFEFace(elem, side);
 

--- a/framework/src/base/ComputeIndicatorThread.C
+++ b/framework/src/base/ComputeIndicatorThread.C
@@ -142,7 +142,7 @@ ComputeIndicatorThread::onInternalSide(const Elem * elem, unsigned int side)
     return;
 
   // Pointer to the neighbor we are currently working on.
-  const Elem * neighbor = elem->neighbor(side);
+  const Elem * neighbor = elem->neighbor_ptr(side);
 
   // Get the global id of the element and the neighbor
   const dof_id_type elem_id = elem->id(), neighbor_id = neighbor->id();

--- a/framework/src/base/ComputeJacobianThread.C
+++ b/framework/src/base/ComputeJacobianThread.C
@@ -233,7 +233,7 @@ ComputeJacobianThread::onInternalSide(const Elem * elem, unsigned int side)
   if (_dg_kernels.hasActiveBlockObjects(_subdomain, _tid))
   {
     // Pointer to the neighbor we are currently working on.
-    const Elem * neighbor = elem->neighbor(side);
+    const Elem * neighbor = elem->neighbor_ptr(side);
 
     // Get the global id of the element and the neighbor
     const dof_id_type elem_id = elem->id(), neighbor_id = neighbor->id();
@@ -267,7 +267,7 @@ ComputeJacobianThread::onInterface(const Elem * elem, unsigned int side, Boundar
   if (_interface_kernels.hasActiveBoundaryObjects(bnd_id, _tid))
   {
     // Pointer to the neighbor we are currently working on.
-    const Elem * neighbor = elem->neighbor(side);
+    const Elem * neighbor = elem->neighbor_ptr(side);
 
     if (neighbor->active())
     {

--- a/framework/src/base/ComputeMaterialsObjectThread.C
+++ b/framework/src/base/ComputeMaterialsObjectThread.C
@@ -189,7 +189,7 @@ ComputeMaterialsObjectThread::onInternalSide(const Elem * elem, unsigned int sid
             side);
     }
 
-    const Elem * neighbor = elem->neighbor(side);
+    const Elem * neighbor = elem->neighbor_ptr(side);
     unsigned int neighbor_side = neighbor->which_neighbor_am_i(_assembly[_tid]->elem());
     const dof_id_type elem_id = elem->id(), neighbor_id = neighbor->id();
 

--- a/framework/src/base/ComputeResidualThread.C
+++ b/framework/src/base/ComputeResidualThread.C
@@ -163,7 +163,7 @@ ComputeResidualThread::onInterface(const Elem * elem, unsigned int side, Boundar
   {
 
     // Pointer to the neighbor we are currently working on.
-    const Elem * neighbor = elem->neighbor(side);
+    const Elem * neighbor = elem->neighbor_ptr(side);
 
     if (!(neighbor->level() == elem->level()))
       mooseError("Sorry, interface kernels do not work with mesh adaptivity");
@@ -198,7 +198,7 @@ ComputeResidualThread::onInternalSide(const Elem * elem, unsigned int side)
   if (_dg_kernels.hasActiveBlockObjects(_subdomain, _tid))
   {
     // Pointer to the neighbor we are currently working on.
-    const Elem * neighbor = elem->neighbor(side);
+    const Elem * neighbor = elem->neighbor_ptr(side);
 
     // Get the global id of the element and the neighbor
     const dof_id_type elem_id = elem->id(), neighbor_id = neighbor->id();

--- a/framework/src/base/ComputeUserObjectsThread.C
+++ b/framework/src/base/ComputeUserObjectsThread.C
@@ -166,7 +166,7 @@ void
 ComputeUserObjectsThread::onInternalSide(const Elem * elem, unsigned int side)
 {
   // Pointer to the neighbor we are currently working on.
-  const Elem * neighbor = elem->neighbor(side);
+  const Elem * neighbor = elem->neighbor_ptr(side);
 
   // Get the global id of the element and the neighbor
   const dof_id_type elem_id = elem->id(), neighbor_id = neighbor->id();

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -453,7 +453,7 @@ DisplacedProblem::reinitNodesNeighbor(const std::vector<dof_id_type> & nodes, TH
 void
 DisplacedProblem::reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid)
 {
-  const Elem * neighbor = elem->neighbor(side);
+  const Elem * neighbor = elem->neighbor_ptr(side);
   unsigned int neighbor_side = neighbor->which_neighbor_am_i(elem);
 
   _assembly[tid]->reinitElemAndNeighbor(elem, side, neighbor, neighbor_side);

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -1360,7 +1360,7 @@ FEProblemBase::reinitOffDiagScalars(THREAD_ID tid)
 void
 FEProblemBase::reinitNeighbor(const Elem * elem, unsigned int side, THREAD_ID tid)
 {
-  const Elem * neighbor = elem->neighbor(side);
+  const Elem * neighbor = elem->neighbor_ptr(side);
   unsigned int neighbor_side = neighbor->which_neighbor_am_i(elem);
 
   _assembly[tid]->reinitElemAndNeighbor(elem, side, neighbor, neighbor_side);

--- a/framework/src/indicators/InternalSideIndicator.C
+++ b/framework/src/indicators/InternalSideIndicator.C
@@ -112,7 +112,7 @@ InternalSideIndicator::finalize()
     // Figure out the total number of sides contributing to the error.
     // We'll scale by this so boundary elements are less penalized
     for (unsigned int side = 0; side < _current_elem->n_sides(); side++)
-      if (_current_elem->neighbor(side) != NULL)
+      if (_current_elem->neighbor_ptr(side) != nullptr)
         n_flux_faces++;
   }
   else

--- a/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
+++ b/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
@@ -67,7 +67,7 @@ AddAllSideSetsByNormals::modify()
 
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
-      if (elem->neighbor(side))
+      if (elem->neighbor_ptr(side))
         continue;
 
       _fe_face->reinit(elem, side);

--- a/framework/src/meshmodifiers/AddSideSetsBase.C
+++ b/framework/src/meshmodifiers/AddSideSetsBase.C
@@ -80,7 +80,7 @@ AddSideSetsBase::flood(const Elem * elem, Point normal, BoundaryID side_id)
   _visited[side_id].insert(elem);
   for (unsigned int side = 0; side < elem->n_sides(); ++side)
   {
-    if (elem->neighbor(side))
+    if (elem->neighbor_ptr(side))
       continue;
 
     _fe_face->reinit(elem, side);
@@ -96,7 +96,7 @@ AddSideSetsBase::flood(const Elem * elem, Point normal, BoundaryID side_id)
         // element.
         // This will allow us to tolerate small changes in the normals so we can "paint" around a
         // curve.
-        flood(elem->neighbor(neighbor), _fixed_normal ? normal : normals[0], side_id);
+        flood(elem->neighbor_ptr(neighbor), _fixed_normal ? normal : normals[0], side_id);
       }
     }
   }

--- a/framework/src/meshmodifiers/ElementDeleterBase.C
+++ b/framework/src/meshmodifiers/ElementDeleterBase.C
@@ -77,7 +77,7 @@ ElementDeleterBase::modify()
    *       but because the order of deletion might impact what happens to any existing sidesets or
    * nodesets.
    */
-  for (const auto & elem : deleteable_elems)
+  for (auto & elem : deleteable_elems)
   {
     // On distributed meshes, we'll need neighbor links to be useable
     // shortly, so we can't just leave dangling pointers.
@@ -87,13 +87,13 @@ ElementDeleterBase::modify()
     unsigned int n_sides = elem->n_sides();
     for (unsigned int n = 0; n != n_sides; ++n)
     {
-      Elem * neighbor = elem->neighbor(n);
+      Elem * neighbor = elem->neighbor_ptr(n);
       if (!neighbor || neighbor == remote_elem)
         continue;
 
       const unsigned int return_side = neighbor->which_neighbor_am_i(elem);
 
-      if (neighbor->neighbor(return_side) == elem)
+      if (neighbor->neighbor_ptr(return_side) == elem)
         neighbor->set_neighbor(return_side, nullptr);
     }
 
@@ -128,7 +128,7 @@ ElementDeleterBase::modify()
 
       const unsigned int n_sides = elem->n_sides();
       for (unsigned int n = 0; n != n_sides; ++n)
-        if (elem->neighbor(n) == remote_elem)
+        if (elem->neighbor_ptr(n) == remote_elem)
           queries[pid].push_back(std::make_pair(elem->id(), n));
     }
 
@@ -166,7 +166,7 @@ ElementDeleterBase::modify()
       {
         const Elem * elem = mesh.elem_ptr(q.first);
         const unsigned int side = q.second;
-        const Elem * neighbor = elem->neighbor(side);
+        const Elem * neighbor = elem->neighbor_ptr(side);
 
         if (neighbor == nullptr) // neighboring element was deleted!
           responses[p - 1].push_back(std::make_pair(elem->id(), side));
@@ -190,7 +190,7 @@ ElementDeleterBase::modify()
         Elem * elem = mesh.elem_ptr(r.first);
         const unsigned int side = r.second;
 
-        mooseAssert(elem->neighbor(side) == remote_elem, "element neighbor != remote_elem");
+        mooseAssert(elem->neighbor_ptr(side) == remote_elem, "element neighbor != remote_elem");
 
         elem->set_neighbor(side, nullptr);
       }

--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -121,7 +121,7 @@ SideSetsAroundSubdomain::modify()
 
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
-      const Elem * neighbor = elem->neighbor(side);
+      const Elem * neighbor = elem->neighbor_ptr(side);
 
       // On a replicated mesh, we add all subdomain sides ourselves.
       // On a distributed mesh, we may have missed sides which
@@ -185,7 +185,7 @@ SideSetsAroundSubdomain::modify()
       {
         const Elem * elem = mesh.elem_ptr(q.first);
         const unsigned int side = q.second;
-        const Elem * neighbor = elem->neighbor(side);
+        const Elem * neighbor = elem->neighbor_ptr(side);
 
         if (neighbor == NULL ||                   // element on boundary OR
             neighbor->subdomain_id() != block_id) // neighboring element is on a different subdomain

--- a/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
+++ b/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
@@ -79,7 +79,7 @@ SideSetsBetweenSubdomains::modify()
 
     for (unsigned int side = 0; side < elem->n_sides(); side++)
     {
-      const Elem * neighbor = elem->neighbor(side);
+      const Elem * neighbor = elem->neighbor_ptr(side);
 
       // On a replicated mesh, we add all subdomain sides ourselves.
       // On a distributed mesh, we may have missed sides which
@@ -132,7 +132,7 @@ SideSetsBetweenSubdomains::modify()
       {
         const Elem * elem = mesh.elem_ptr(q.first);
         const unsigned int side = q.second;
-        const Elem * neighbor = elem->neighbor(side);
+        const Elem * neighbor = elem->neighbor_ptr(side);
 
         if (neighbor != NULL && paired_ids.count(neighbor->subdomain_id()) > 0)
         {

--- a/framework/src/meshmodifiers/SideSetsFromNormals.C
+++ b/framework/src/meshmodifiers/SideSetsFromNormals.C
@@ -79,7 +79,7 @@ SideSetsFromNormals::modify()
 
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
-      if (elem->neighbor(side))
+      if (elem->neighbor_ptr(side))
         continue;
 
       _fe_face->reinit(elem, side);

--- a/framework/src/meshmodifiers/SideSetsFromPoints.C
+++ b/framework/src/meshmodifiers/SideSetsFromPoints.C
@@ -69,7 +69,7 @@ SideSetsFromPoints::modify()
 
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
-      if (elem->neighbor(side))
+      if (elem->neighbor_ptr(side))
         continue;
 
       // See if this point is on this side

--- a/framework/src/utils/RayTracing.C
+++ b/framework/src/utils/RayTracing.C
@@ -89,7 +89,7 @@ sideIntersectedByLine(const Elem * elem,
     {
       if (side_elem->contains_point(intersection_point))
       {
-        Elem * neighbor = elem->neighbor(i);
+        const Elem * neighbor = elem->neighbor_ptr(i);
 
         // If this side is on a boundary, let's do another search and see if we can find a better
         // candidate
@@ -124,7 +124,7 @@ sideNeighborIsOn(const Elem * elem, const Elem * neighbor)
 
   for (unsigned int i = 0; i < n_sides; i++)
   {
-    if (elem->neighbor(i) == neighbor)
+    if (elem->neighbor_ptr(i) == neighbor)
       return i;
   }
 
@@ -166,12 +166,12 @@ recursivelyFindElementsIntersectedByLine(const LineSegment & line_segment,
   if (intersected_side != -1) // -1 means that we didn't find any side
   {
     // Get the neighbor on that side
-    Elem * neighbor = current_elem->neighbor(intersected_side);
+    const Elem * neighbor = current_elem->neighbor_ptr(intersected_side);
 
     if (neighbor)
     {
       // Add it to the list
-      intersected_elems.push_back(neighbor);
+      intersected_elems.push_back(const_cast<Elem *>(neighbor));
 
       // Add the line segment across the element to the segments list
       segments.push_back(LineSegment(incoming_point, intersection_point));


### PR DESCRIPTION
In a few cases, the simplest fix is to use a const_cast until a more
extensive fix can be made.  These changes prevent various deprecation
warning messages from being printed while running the tutorial
examples, so I think it would be good to get them in.

Refs libMesh/libmesh#1247.
Refs #5307.
