### PR TITLE
RandomHitSolutionModifier enable_out_of_mesh_mode

### DIFF
--- a/test/src/userobjects/RandomHitSolutionModifier.C
+++ b/test/src/userobjects/RandomHitSolutionModifier.C
@@ -41,6 +41,7 @@ void
 RandomHitSolutionModifier::execute()
 {
   UniquePtr<PointLocatorBase> pl = _mesh.getMesh().sub_point_locator();
+  pl->enable_out_of_mesh_mode();
 
   const std::vector<Point> & hits = _random_hits.hits();
 


### PR DESCRIPTION
This fixes a test or two with distributed meshes, as per #1500