### PR TITLE
make verbose and dry-run options work together. Refs #8864

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -268,10 +268,7 @@ class TestHarness:
                         # This method spawns another process and allows this loop to continue looking for tests
                         # RunParallel will call self.testOutputAndFinish when the test has completed running
                         # This method will block when the maximum allowed parallel processes are running
-                        if self.options.dry_run:
-                            self.handleTestStatus(tester)
-                        else:
-                            self.runner.run(tester, command)
+                        self.runner.run(tester, command)
                     else: # This job is skipped - notify the runner
                         status = tester.getStatus()
                         if status != tester.bucket_silent: # SILENT occurs when a user is using --re options

--- a/python/TestHarness/tests/test_DryRun.py
+++ b/python/TestHarness/tests/test_DryRun.py
@@ -14,12 +14,7 @@ class TestHarnessTester(TestHarnessTestCase):
         # Skipped caveat test which returns skipped instead of 'DRY RUN'
         output = self.runTests('-i', 'depend_skip_tests', '--dry-run')
         self.assertIn('skipped (always skipped)', output)
-
-        # NOTE: This test normally returns (skipped dependency). However
-        # with dry run, the TestHarness has no idea that this is the case
-        # because in order to figure that out, the test has to 'run' and we are
-        # not running any tests (its a dry run after all)!
-        self.assertRegexpMatches(output, 'test_harness\.needs_a.*?DRY RUN')
+        self.assertIn('skipped (skipped dependency)', output)
 
         # Deleted caveat test which returns a deleted failing tests while
         # performing a dry run


### PR DESCRIPTION
Allow the runner to handle dry-run tests.
Refs #8864