### PR TITLE
Make ExodusViewer side widgets scrollable

### DIFF
--- a/python/peacock/ExodusViewer/ExodusPluginManager.py
+++ b/python/peacock/ExodusViewer/ExodusPluginManager.py
@@ -1,5 +1,5 @@
 import re
-from PyQt5 import QtWidgets
+from PyQt5 import QtWidgets, QtCore
 import peacock
 import mooseutils
 from plugins.ExodusPlugin import ExodusPlugin
@@ -13,23 +13,38 @@ class ExodusPluginManager(QtWidgets.QWidget, peacock.base.PluginManager):
         self.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred)
         self.MainLayout = QtWidgets.QHBoxLayout()
 
+        self.LeftScrollArea = QtWidgets.QScrollArea()
+        self.LeftScrollArea.setWidgetResizable(True)
+        #self.LeftScrollArea.setFrameShadow(QtWidgets.QFrame.Plain)
+        #self.LeftScrollArea.setFrameShape(QtWidgets.QFrame.NoFrame)
+        self.LeftScrollArea.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.LeftScrollContent = QtWidgets.QWidget()
+        self.LeftScrollArea.setWidget(self.LeftScrollContent)
         self.LeftLayout = QtWidgets.QVBoxLayout()
+        self.LeftScrollContent.setLayout(self.LeftLayout)
+        margins = self.LeftLayout.contentsMargins()
+        self.LeftLayout.setContentsMargins(0, 0, margins.right(), 0) # leave some room for the vertical scrollbar
         self.RightLayout = QtWidgets.QVBoxLayout()
         self.WindowLayout = QtWidgets.QHBoxLayout()
 
         self.setLayout(self.MainLayout)
-        self.MainLayout.addLayout(self.LeftLayout)
+        self.MainLayout.addWidget(self.LeftScrollArea)
         self.MainLayout.addLayout(self.RightLayout)
         self.RightLayout.addLayout(self.WindowLayout)
-
         self.setup()
         self.LeftLayout.addStretch(1)
 
         # Set the width of the left-side widgets to that the VTK window gets the space
         self.fixLayoutWidth('LeftLayout')
+        self.LeftScrollContent.setFixedWidth(self.LeftLayout.sizeHint().width())
+        self.LeftScrollArea.setFixedWidth(self.LeftScrollContent.width())
 
         if 'BlockPlugin' in self:
             self['BlockPlugin'].setCollapsed(True)
+        if 'BackgroundPlugin' in self:
+            self['BackgroundPlugin'].setCollapsed(True)
+        if 'CameraPlugin' in self:
+            self['CameraPlugin'].setCollapsed(True)
 
     def repr(self):
         """

--- a/python/peacock/ExodusViewer/ExodusPluginManager.py
+++ b/python/peacock/ExodusViewer/ExodusPluginManager.py
@@ -15,15 +15,16 @@ class ExodusPluginManager(QtWidgets.QWidget, peacock.base.PluginManager):
 
         self.LeftScrollArea = QtWidgets.QScrollArea()
         self.LeftScrollArea.setWidgetResizable(True)
-        #self.LeftScrollArea.setFrameShadow(QtWidgets.QFrame.Plain)
-        #self.LeftScrollArea.setFrameShape(QtWidgets.QFrame.NoFrame)
+        self.LeftScrollArea.setFrameShadow(QtWidgets.QFrame.Plain)
+        self.LeftScrollArea.setStyleSheet("QScrollArea { background: transparent; }");
+        self.LeftScrollArea.viewport().setStyleSheet(".QWidget { background: transparent; }");
+        self.LeftScrollArea.setFrameShape(QtWidgets.QFrame.NoFrame)
         self.LeftScrollArea.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.LeftScrollContent = QtWidgets.QWidget()
         self.LeftScrollArea.setWidget(self.LeftScrollContent)
         self.LeftLayout = QtWidgets.QVBoxLayout()
         self.LeftScrollContent.setLayout(self.LeftLayout)
-        margins = self.LeftLayout.contentsMargins()
-        self.LeftLayout.setContentsMargins(0, 0, margins.right(), 0) # leave some room for the vertical scrollbar
+        self.LeftLayout.setContentsMargins(0, 0, 0, 0)
         self.RightLayout = QtWidgets.QVBoxLayout()
         self.WindowLayout = QtWidgets.QHBoxLayout()
 
@@ -37,7 +38,7 @@ class ExodusPluginManager(QtWidgets.QWidget, peacock.base.PluginManager):
         # Set the width of the left-side widgets to that the VTK window gets the space
         self.fixLayoutWidth('LeftLayout')
         self.LeftScrollContent.setFixedWidth(self.LeftLayout.sizeHint().width())
-        self.LeftScrollArea.setFixedWidth(self.LeftScrollContent.width())
+        self.LeftScrollArea.setFixedWidth(self.LeftScrollContent.width() + 15) # This gets rid of the horizontal "wiggle"
 
         if 'BlockPlugin' in self:
             self['BlockPlugin'].setCollapsed(True)

--- a/python/peacock/ExodusViewer/ExodusViewer.py
+++ b/python/peacock/ExodusViewer/ExodusViewer.py
@@ -23,9 +23,9 @@ class ExodusViewer(peacock.base.ViewerBase):
     def commandLineArgs(parser):
         parser.add_argument('--exodus', '-r', nargs='*', default=[], help="A list of ExodusII files to open.")
 
-    def __init__(self, plugins=[VTKWindowPlugin, FilePlugin, GoldDiffPlugin, VariablePlugin, \
+    def __init__(self, plugins=[FilePlugin, GoldDiffPlugin, VariablePlugin, \
                                 MeshPlugin, BackgroundPlugin, ClipPlugin, ContourPlugin, CameraPlugin, \
-                                OutputPlugin, MediaControlPlugin,
+                                OutputPlugin, VTKWindowPlugin, MediaControlPlugin,
                                 lambda: BlockPlugin(layout='RightLayout')]):
         super(ExodusViewer, self).__init__(manager=ExodusPluginManager, plugins=plugins)
 

--- a/python/peacock/ExodusViewer/plugins/GoldDiffPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/GoldDiffPlugin.py
@@ -100,7 +100,7 @@ class GoldDiffPlugin(peacock.base.PeacockCollapsibleWidget, ExodusPlugin):
         is available on the parent.
         """
         # Enable/disable the link camera toggle based on the existence of the main window.
-        if hasattr(self.parent(), 'VTKWindowPlugin'):
+        if self._plugin_manager and 'VTKWindowPlugin' in self._plugin_manager:
             self.LinkToggle.clicked.connect(self._callbackLinkToggle)
             self.LinkToggle.setChecked(True)
             self.LinkToggle.clicked.emit(True)
@@ -229,11 +229,11 @@ class GoldDiffPlugin(peacock.base.PeacockCollapsibleWidget, ExodusPlugin):
         """
         Connect/disconnect the cameras between windows.
 
-        NOTE: This doesn't get called (b/c the button is disabled) if VTKWindowPlugin does not exist on parent.
+        NOTE: This doesn't get called (b/c the button is disabled) if VTKWindowPlugin does not exist on the plugin manager.
         see initialization
         """
         self.store(self._filename, 'Filename')
-        master = self.parent().VTKWindowPlugin
+        master = self._plugin_manager.VTKWindowPlugin
         slaves = [self.GoldVTKWindow, self.DiffVTKWindow]
         if value:
             for slave in slaves:

--- a/python/peacock/base/OutputWidgetBase.py
+++ b/python/peacock/base/OutputWidgetBase.py
@@ -36,8 +36,8 @@ class OutputWidgetBase(QtWidgets.QWidget):
         """
         Updates the live script view.
         """
-        if self.LiveScript.isVisible():
-            s = self.parent().repr()
+        if self.LiveScript.isVisible() and hasattr(self, "_plugin_manager"):
+            s = self._plugin_manager.repr()
             self.LiveScript.setText(s)
 
     def _setupPythonButton(self, qobject):

--- a/python/peacock/base/Plugin.py
+++ b/python/peacock/base/Plugin.py
@@ -28,6 +28,7 @@ class Plugin(MooseWidget):
 
         # The Peacock tab index
         self._index = None
+        self._plugin_manager = None
 
     @staticmethod
     def commandLineArgs(parser):

--- a/python/peacock/base/PluginManager.py
+++ b/python/peacock/base/PluginManager.py
@@ -126,6 +126,7 @@ class PluginManager(MooseWidget):
 
         # Connect signal/slots of plugins
         for plugin0 in self._all_plugins:
+            plugin0._plugin_manager = self
             for plugin1 in self._all_plugins:
                 plugin0.connect(plugin1)
 


### PR DESCRIPTION
Even with #8855, on lower resolution displays the widgets could get messed up when expanding widgets. Expanding widgets also increased the window size which could cause part of the peacock window to be inaccessible.
This turns the whole area into a QSrollArea so that if the window is resized or the widgets need more room, the area becomes scrollable.

Also set a PluginManager variable on each plugin. This is not a very good thing to do since ideally each plugin would have no need to know its PluginManager or other plugins but there are a couple cases where this is extremely helpful.