### PR TITLE
Don't output parameters if the value is empty

### DIFF
--- a/python/peacock/Input/InputTreeWriter.py
+++ b/python/peacock/Input/InputTreeWriter.py
@@ -93,6 +93,8 @@ def nodeParamsString(output, entry, indent, sep, ignore_type=False):
             continue
         info = entry.parameters[name]
         val = info.inputFileValue()
+        if not val and name != 'active': # we generally don't want to write out empty strings
+            continue
         comments = info.comments
         if info.value != info.default or info.user_added or info.set_in_input_file:
             paramToString(output, info.name, val, comments, indent, sep)

--- a/python/peacock/Input/ParameterInfo.py
+++ b/python/peacock/Input/ParameterInfo.py
@@ -99,7 +99,7 @@ class ParameterInfo(object):
             return str(self.value)
 
     def toolTip(self):
-        return self.description
+        return self.description + "\nDefault: %s" % self.default
 
     def dump(self, o, indent=0, sep='  '):
         o.write("%sName: %s\n" % (indent*sep, self.name))


### PR DESCRIPTION
This allows setting an empty value in peacock and it won't get written out to the input file.