### PR TITLE
Fix Postprocessor tabs resizing issue

### DIFF
--- a/python/peacock/PostprocessorViewer/plugins/FigurePlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/FigurePlugin.py
@@ -37,6 +37,7 @@ class FigurePlugin(QtWidgets.QWidget, PostprocessorPlugin):
         self.FigureCanvas.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
 
         self.MainLayout.addWidget(self.FigureCanvas)
+        self.setFixedWidth(QtWidgets.QWIDGETSIZE_MAX) # reset the fixed width so it can be resized
 
         self.setup()
 


### PR DESCRIPTION
The base class `PostprocessorPlugin` sets a fixed width which was causing the issue. We just needed to reset it on the `FigurePlugin` to allow it to resize to fill the available space.

closes #8915