### PR TITLE
Try killing nicely before doing a hard kill.

### DIFF
--- a/python/peacock/Execute/JobRunner.py
+++ b/python/peacock/Execute/JobRunner.py
@@ -98,8 +98,12 @@ class JobRunner(QObject, MooseWidget):
         """
         self.killed = True
         mooseutils.mooseMessage("Killing")
-        self.process.kill()
-        self.process.waitForFinished()
+        self.process.terminate()
+        self.process.waitForFinished(1000)
+        if self.isRunning():
+            mooseutils.mooseMessage("Failed to terminate job cleanly. Doing a hard kill.")
+            self.process.kill()
+            self.process.waitForFinished()
 
     @pyqtSlot()
     def _readOutput(self):


### PR DESCRIPTION
To kill a running job in peacock we need to send a `SIGTERM`. Then if that doesn't work use a `SIGKILL`.

closes #8923