### PR TITLE
Add an adjustable framerate to the media player

### DIFF
--- a/python/peacock/base/MediaControlWidgetBase.py
+++ b/python/peacock/base/MediaControlWidgetBase.py
@@ -165,6 +165,7 @@ class MediaControlWidgetBase(object):
         self.TimeSlider.setEnabled(False)
 
         self._playing = True
+        self._callbackFramerateDisplay()
         self.start()
 
     def _callbackPauseButton(self):

--- a/python/peacock/base/MediaControlWidgetBase.py
+++ b/python/peacock/base/MediaControlWidgetBase.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtWidgets, QtCore
+from PyQt5 import QtWidgets, QtCore, QtGui
 from peacock.utils import WidgetUtils
 
 class MediaControlWidgetBase(object):
@@ -45,8 +45,10 @@ class MediaControlWidgetBase(object):
         self.ButtonLayout.insertStretch(6)
 
         # TimeStep display/edit
-        self.__addEditBox('TimeStepDisplay', 'Timestep:', "Set the simulation timestep.")
+        self.__addEditBox('TimeStepDisplay', 'Timestep:', "Set the simulation timestep.", True)
         self.__addEditBox('TimeDisplay', 'Time:', "Set the simulation time.")
+        self.__addEditBox('FramerateDisplay', 'Framerate:', "Set the framerate of playback, in milliseconds.", True)
+        self.FramerateDisplay.setText("100")
 
         # Slider
         self.TimeSlider = QtWidgets.QSlider()
@@ -102,10 +104,10 @@ class MediaControlWidgetBase(object):
         self.TimeSlider.setRange(0, self._num_steps - 1)
         self.TimeSlider.setValue(step)
 
-        #if not self.TimeStepDisplay.hasFocus():
-        self.TimeStepDisplay.setText(str(step))
-        #if not self.TimeDisplay.hasFocus():
-        self.TimeDisplay.setText(str(self._times[step]))
+        if not self.TimeStepDisplay.hasFocus():
+            self.TimeStepDisplay.setText(str(step))
+        if not self.TimeDisplay.hasFocus():
+            self.TimeDisplay.setText(str(self._times[step]))
 
     def start(self):
         """
@@ -202,6 +204,9 @@ class MediaControlWidgetBase(object):
         self._callbackPauseButton()
         self.updateControls(time=float(self.TimeDisplay.text()), timestep=None)
 
+    def _callbackFramerateDisplay(self):
+        self.Timer.setInterval(int(self.FramerateDisplay.text()))
+
     def _setupTimeSlider(self, qobject):
         qobject.setOrientation(QtCore.Qt.Horizontal)
         qobject.sliderReleased.connect(self._callbackTimeSlider)
@@ -220,8 +225,15 @@ class MediaControlWidgetBase(object):
         self.ButtonLayout.addWidget(qobject)
         setattr(self, name, qobject)
 
-    def __addEditBox(self, name, label, tooltip):
+    def __addEditBox(self, name, label, tooltip, int_validate=False):
         edit = QtWidgets.QLineEdit()
+
+        if int_validate:
+            validate = QtGui.QIntValidator()
+        else:
+            validate = QtGui.QDoubleValidator()
+        validate.setBottom(0)
+        edit.setValidator(validate)
         edit.setToolTip(tooltip)
         edit.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Maximum)
         edit.editingFinished.connect(getattr(self, '_callback' + name))

--- a/python/peacock/base/MediaControlWidgetBase.py
+++ b/python/peacock/base/MediaControlWidgetBase.py
@@ -47,8 +47,8 @@ class MediaControlWidgetBase(object):
         # TimeStep display/edit
         self.__addEditBox('TimeStepDisplay', 'Timestep:', "Set the simulation timestep.", True)
         self.__addEditBox('TimeDisplay', 'Time:', "Set the simulation time.")
-        self.__addEditBox('FramerateDisplay', 'Framerate:', "Set the framerate of playback, in milliseconds.", True)
-        self.FramerateDisplay.setText("100")
+        self.__addEditBox('FrameDelayDisplay', 'Frame delay:', "Set the delay of playback, in milliseconds.", True)
+        self.FrameDelayDisplay.setText("100")
 
         # Slider
         self.TimeSlider = QtWidgets.QSlider()
@@ -165,7 +165,7 @@ class MediaControlWidgetBase(object):
         self.TimeSlider.setEnabled(False)
 
         self._playing = True
-        self._callbackFramerateDisplay()
+        self._callbackFrameDelayDisplay()
         self.start()
 
     def _callbackPauseButton(self):
@@ -205,8 +205,8 @@ class MediaControlWidgetBase(object):
         self._callbackPauseButton()
         self.updateControls(time=float(self.TimeDisplay.text()), timestep=None)
 
-    def _callbackFramerateDisplay(self):
-        self.Timer.setInterval(int(self.FramerateDisplay.text()))
+    def _callbackFrameDelayDisplay(self):
+        self.Timer.setInterval(int(self.FrameDelayDisplay.text()))
 
     def _setupTimeSlider(self, qobject):
         qobject.setOrientation(QtCore.Qt.Horizontal)


### PR DESCRIPTION
Adds a widget to the media control player to adjust the framerate (in milliseconds).

I also added validation on the Time* input boxes so that you can't enter "foo" in the box and cause things to crash.

@aeslaughter I uncommented your code to not update the Time* input boxes if they have focus. This allows me to actually edit them without it being immediately overwritten. But I assume there was a reason it was commented out...

closes #8922