### PR TITLE
Apply changes on block editor on close.

### DIFF
--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -122,7 +122,8 @@ class BlockEditor(QWidget, MooseWidget):
         self.new_parameter_button = WidgetUtils.addButton(self.button_layout, self, "Add parameter", self.addUserParamPressed)
         self.new_parameter_button.setToolTip("Add a non standard parameter")
 
-        self.close_button = WidgetUtils.addButton(self.button_layout, self, "Close window", self.close)
+        self.close_button = WidgetUtils.addButton(self.button_layout, self, "Close", self._applyAndClose)
+        self.close_button.setToolTip("Apply any changes and close the window")
 
     def _findFreeParamName(self, max_params=1000):
         """
@@ -169,6 +170,14 @@ class BlockEditor(QWidget, MooseWidget):
         self.param_editor.save()
         self._blockChanged(enabled=False)
         self.blockChanged.emit(self.block)
+
+    def _applyAndClose(self):
+        """
+        Apply any changes the user has made then close the window
+        """
+        if self.apply_button.isEnabled():
+            self.applyChanges()
+        self.close()
 
     def resetChanges(self):
         """

--- a/python/peacock/Input/InputFileEditorPlugin.py
+++ b/python/peacock/Input/InputFileEditorPlugin.py
@@ -34,7 +34,6 @@ class InputFileEditorPlugin(InputFileEditor, Plugin):
         self.check_widget.needInputFile.connect(self.writeInputFile)
         self.check_widget.hide()
         self.blockChanged.connect(self._updateChanged)
-        self.blockSelected.connect(self._updateChanged)
 
         self.input_file_view = QPlainTextEdit()
         self.input_file_view.setReadOnly(True)
@@ -166,6 +165,16 @@ class InputFileEditorPlugin(InputFileEditor, Plugin):
     def clearRecentlyUsed(self):
         if self._menus_initialized:
             self._recently_used_menu.clearValues()
+
+    def onCurrentChanged(self, index):
+        """
+        This is called when the tab is changed.
+        If the block editor window is open we want to raise it
+        to the front so it doesn't get lost.
+        """
+        if index == self._index:
+            if self.block_editor:
+                self.block_editor.raise_()
 
 if __name__ == "__main__":
     from PyQt5.QtWidgets import QApplication, QMainWindow


### PR DESCRIPTION
This also shows the block editor window when switching back to the input tab.

closes #8928