### PR TITLE
Update value of universal gas constant

### DIFF
--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
@@ -17,7 +17,7 @@ validParams<SinglePhaseFluidPropertiesPT>()
 }
 
 SinglePhaseFluidPropertiesPT::SinglePhaseFluidPropertiesPT(const InputParameters & parameters)
-  : FluidProperties(parameters), _R(8.3144621), _T_c2k(273.15)
+  : FluidProperties(parameters), _R(8.3144598), _T_c2k(273.15)
 {
 }
 

--- a/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
@@ -29,7 +29,7 @@ PorousFlowFluidPropertiesBase::PorousFlowFluidPropertiesBase(const InputParamete
     _pressure_variable_name(_dictator.pressureVariableNameDummy()),
     _temperature_variable_name(_dictator.temperatureVariableNameDummy()),
     _t_c2k(getParam<MooseEnum>("temperature_unit") == 0 ? 0.0 : 273.15),
-    _R(8.3144621)
+    _R(8.3144598)
 {
 }
 

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateFlashBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateFlashBase.C
@@ -85,7 +85,7 @@ PorousFlowFluidStateFlashBase::PorousFlowFluidStateFlashBase(const InputParamete
             : declareProperty<std::vector<std::vector<Real>>>("dPorousFlow_viscosity_qp_dvar")),
 
     _T_c2k(getParam<MooseEnum>("temperature_unit") == 0 ? 0.0 : 273.15),
-    _R(8.3144621),
+    _R(8.3144598),
     _pc(getParam<Real>("pc")),
     _sat_lr(getParam<Real>("sat_lr")),
     _dseff_ds(1.0 / (1.0 - _sat_lr)),

--- a/unit/src/IdealGasFluidPropertiesPTTest.C
+++ b/unit/src/IdealGasFluidPropertiesPTTest.C
@@ -27,7 +27,7 @@ TEST_F(IdealGasFluidPropertiesPTTest, properties)
   const Real entropy = 6850.0;
   const Real viscosity = 18.23e-6;
   const Real henry = 0.0;
-  const Real R = 8.3144621;
+  const Real R = 8.3144598;
 
   const Real tol = 1.0e-8;
 


### PR DESCRIPTION
Updates the value of the universal gas constant to the 2014 CODATA recommended value in `fluid_properties` and `porous_flow`.

Closes #8938 