### PR TITLE
Move check input

### DIFF
--- a/examples/ex01_inputfile/src/main.C
+++ b/examples/ex01_inputfile/src/main.C
@@ -38,14 +38,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex02_kernel/src/main.C
+++ b/examples/ex02_kernel/src/main.C
@@ -38,14 +38,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex03_coupling/src/main.C
+++ b/examples/ex03_coupling/src/main.C
@@ -40,14 +40,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex04_bcs/src/main.C
+++ b/examples/ex04_bcs/src/main.C
@@ -39,14 +39,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex05_amr/src/main.C
+++ b/examples/ex05_amr/src/main.C
@@ -39,14 +39,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex06_transient/src/main.C
+++ b/examples/ex06_transient/src/main.C
@@ -40,14 +40,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex07_ics/src/main.C
+++ b/examples/ex07_ics/src/main.C
@@ -38,14 +38,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex08_materials/src/main.C
+++ b/examples/ex08_materials/src/main.C
@@ -38,14 +38,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex09_stateful_materials/src/main.C
+++ b/examples/ex09_stateful_materials/src/main.C
@@ -40,14 +40,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex10_aux/src/main.C
+++ b/examples/ex10_aux/src/main.C
@@ -38,14 +38,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex11_prec/src/main.C
+++ b/examples/ex11_prec/src/main.C
@@ -38,14 +38,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex12_pbp/src/main.C
+++ b/examples/ex12_pbp/src/main.C
@@ -37,14 +37,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex13_functions/src/main.C
+++ b/examples/ex13_functions/src/main.C
@@ -35,14 +35,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex14_pps/src/main.C
+++ b/examples/ex14_pps/src/main.C
@@ -42,14 +42,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex15_actions/src/main.C
+++ b/examples/ex15_actions/src/main.C
@@ -39,14 +39,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex16_timestepper/src/main.C
+++ b/examples/ex16_timestepper/src/main.C
@@ -39,14 +39,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex17_dirac/src/main.C
+++ b/examples/ex17_dirac/src/main.C
@@ -35,14 +35,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex18_scalar_kernel/src/main.C
+++ b/examples/ex18_scalar_kernel/src/main.C
@@ -35,14 +35,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex19_dampers/src/main.C
+++ b/examples/ex19_dampers/src/main.C
@@ -35,14 +35,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex20_user_objects/src/main.C
+++ b/examples/ex20_user_objects/src/main.C
@@ -35,14 +35,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/examples/ex21_debugging/src/main.C
+++ b/examples/ex21_debugging/src/main.C
@@ -37,14 +37,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ExampleApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ExampleApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ExampleApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/framework/include/base/AppFactory.h
+++ b/framework/include/base/AppFactory.h
@@ -28,19 +28,26 @@ class InputParameters;
 #define registerApp(name) AppFactory::instance().reg<name>(#name)
 
 /**
- * Typedef for function to build objects
+ * alias to wrap shared pointer type
+ * TODO: Convert to shared pointer by default in the future
+ * using MooseAppPtr = std::shared_ptr<MooseApp>;
  */
-typedef MooseApp * (*appBuildPtr)(const InputParameters & parameters);
+using MooseAppPtr = MooseApp *;
 
 /**
- * Typedef for validParams
+ * alias for validParams function
  */
-typedef InputParameters (*paramsPtr)();
+using paramsPtr = InputParameters (*)();
 
 /**
- * Typedef for registered Object iterator
+ * alias for method to build objects
  */
-typedef std::map<std::string, paramsPtr>::iterator registeredMooseAppIterator;
+using appBuildPtr = MooseAppPtr (*)(const InputParameters & parameters);
+
+/**
+ * alias for registered Object iterator
+ */
+using registeredMooseAppIterator = std::map<std::string, paramsPtr>::iterator;
 
 /**
  * Build an object of type T
@@ -50,6 +57,12 @@ MooseApp *
 buildApp(const InputParameters & parameters)
 {
   return new T(parameters);
+}
+template <class T>
+MooseApp *
+buildAppSharedPtr(const InputParameters & parameters)
+{
+  return std::make_shared<T>(parameters);
 }
 
 /**
@@ -70,6 +83,8 @@ public:
    * Helper function for creating a MooseApp from command-line arguments.
    */
   static MooseApp * createApp(std::string app_type, int argc, char ** argv);
+  static std::shared_ptr<MooseApp>
+  createAppShared(const std::string & app_type, int argc, char ** argv);
 
   /**
    * Register a new object

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -59,7 +59,6 @@ class MultiApp : public MooseObject, public SetupInterface, public Restartable
 {
 public:
   MultiApp(const InputParameters & parameters);
-  virtual ~MultiApp();
 
   virtual void initialSetup() override;
 
@@ -331,7 +330,7 @@ protected:
   int _my_rank;
 
   /// Pointers to each of the Apps
-  std::vector<MooseApp *> _apps;
+  std::vector<std::shared_ptr<MooseApp>> _apps;
 
   /// Relative bounding box inflation
   Real _inflation;

--- a/framework/include/multiapps/TransientMultiApp.h
+++ b/framework/include/multiapps/TransientMultiApp.h
@@ -33,8 +33,6 @@ class TransientMultiApp : public MultiApp
 public:
   TransientMultiApp(const InputParameters & parameters);
 
-  virtual ~TransientMultiApp();
-
   virtual NumericVector<Number> & appTransferVector(unsigned int app,
                                                     std::string var_name) override;
 

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -40,6 +40,12 @@ AppFactory::createApp(std::string app_type, int argc, char ** argv)
   return app;
 }
 
+std::shared_ptr<MooseApp>
+AppFactory::createAppShared(const std::string & app_type, int argc, char ** argv)
+{
+  return std::shared_ptr<MooseApp>(createApp(app_type, argc, argv));
+}
+
 InputParameters
 AppFactory::getValidParams(const std::string & name)
 {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -554,12 +554,6 @@ MooseApp::executeExecutioner()
     Moose::PetscSupport::petscSetupOutput(_command_line.get());
 #endif
     _executioner->init();
-    if (_check_input)
-    {
-      // Output to stderr, so it is easier for peacock to get the result
-      Moose::err << "Syntax OK" << std::endl;
-      return;
-    }
     _executioner->execute();
   }
   else
@@ -699,7 +693,12 @@ MooseApp::run()
   runInputFile();
   Moose::perf_log.pop("Application Setup", "Setup");
 
-  executeExecutioner();
+  if (!_check_input)
+    executeExecutioner();
+  else
+    // Output to stderr, so it is easier for peacock to get the result
+    Moose::err << "Syntax OK" << std::endl;
+
   Moose::perf_log.pop("Full Runtime", "Application");
 }
 

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -46,7 +46,7 @@ FullSolveMultiApp::initialSetup()
     // Grab Executioner from each app
     for (unsigned int i = 0; i < _my_num_apps; i++)
     {
-      MooseApp * app = _apps[i];
+      auto & app = _apps[i];
       Executioner * ex = app->getExecutioner();
 
       if (!ex)

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -116,24 +116,6 @@ TransientMultiApp::TransientMultiApp(const InputParameters & parameters)
                " sub_cycling and catch_up cannot both be set to true simultaneously.");
 }
 
-TransientMultiApp::~TransientMultiApp()
-{
-  if (!_has_an_app)
-    return;
-
-  MPI_Comm swapped = Moose::swapLibMeshComm(_my_comm);
-
-  for (unsigned int i = 0; i < _my_num_apps; i++)
-  {
-    Transient * ex = _transient_executioners[i];
-
-    ex->postExecute();
-  }
-
-  // Swap back
-  Moose::swapLibMeshComm(swapped);
-}
-
 NumericVector<Number> &
 TransientMultiApp::appTransferVector(unsigned int app, std::string var_name)
 {
@@ -536,7 +518,7 @@ void TransientMultiApp::resetApp(
 
 void TransientMultiApp::setupApp(unsigned int i, Real /*time*/) // FIXME: Should we be passing time?
 {
-  MooseApp * app = _apps[i];
+  auto & app = _apps[i];
   Transient * ex = dynamic_cast<Transient *>(app->getExecutioner());
   if (!ex)
     mooseError("MultiApp ", name(), " is not using a Transient Executioner!");

--- a/modules/chemical_reactions/src/main.C
+++ b/modules/chemical_reactions/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ChemicalReactionsApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ChemicalReactionsApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ChemicalReactionsApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/combined/examples/phase_field-mechanics/tests
+++ b/modules/combined/examples/phase_field-mechanics/tests
@@ -27,21 +27,21 @@
   [./grain_texture]
     type = RunApp
     input = 'grain_texture.i'
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
   [./hex_grain_growth_2D_eldrforce]
     type = RunApp
     input = 'hex_grain_growth_2D_eldrforce.i'
     cli_args = 'Executioner/Adaptivity/initial_adaptivity=0'
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
   [./poly_grain_growth_2D_eldrforce]
     type = RunApp
     input = 'poly_grain_growth_2D_eldrforce.i'
     cli_args = 'Executioner/Adaptivity/initial_adaptivity=0'
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
 []

--- a/modules/combined/src/main.C
+++ b/modules/combined/src/main.C
@@ -28,17 +28,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   CombinedApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("CombinedApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("CombinedApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/contact/src/main.C
+++ b/modules/contact/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   ContactApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("ContactApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("ContactApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/fluid_properties/src/main.C
+++ b/modules/fluid_properties/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   FluidPropertiesApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("FluidPropertiesApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("FluidPropertiesApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/heat_conduction/src/main.C
+++ b/modules/heat_conduction/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   HeatConductionApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("HeatConductionApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("HeatConductionApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/level_set/src/main.C
+++ b/modules/level_set/src/main.C
@@ -24,14 +24,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   LevelSetApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("LevelSetApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("LevelSetApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/misc/src/main.C
+++ b/modules/misc/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   MiscApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("MiscApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("MiscApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/navier_stokes/src/main.C
+++ b/modules/navier_stokes/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   NavierStokesApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("NavierStokesApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("NavierStokesApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/phase_field/examples/anisotropic_interfaces/tests
+++ b/modules/phase_field/examples/anisotropic_interfaces/tests
@@ -3,6 +3,7 @@
     type = RunApp
     input = 'snow.i'
     cli_args = 'Executioner/Adaptivity/initial_adaptivity=0'
+    method = '!DBG'
     check_input = True
   [../]
 []

--- a/modules/phase_field/examples/ebsd_reconstruction/tests
+++ b/modules/phase_field/examples/ebsd_reconstruction/tests
@@ -3,7 +3,7 @@
     type = RunApp
     input = 'IN100-111grn.i'
     cli_args = 'Executioner/Adaptivity/initial_adaptivity=0'
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
 []

--- a/modules/phase_field/examples/grain_growth/tests
+++ b/modules/phase_field/examples/grain_growth/tests
@@ -2,36 +2,34 @@
   [./grain_growth_2D_graintracker]
     type = RunApp
     input = 'grain_growth_2D_graintracker.i'
-    cli_args = 'Executioner/Adaptivity/initial_adaptivity=0'
     # Only run in opt mode to avoid timeouts in dbg.
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
   [./grain_growth_2D_random]
     type = RunApp
     input = 'grain_growth_2D_random.i'
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
   [./grain_growth_2D_voronoi]
     type = RunApp
     input = 'grain_growth_2D_voronoi.i'
-    cli_args = 'Mesh/uniform_refine=0 Executioner/Adaptivity/initial_adaptivity=0'
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
   [./grain_growth_2D_voronoi_newadapt]
     type = RunApp
     input = 'grain_growth_2D_voronoi_newadapt.i'
     cli_args = 'Adaptivity/max_h_level=0'
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
   [./grain_growth_3D]
     type = RunApp
     input = 'grain_growth_3D.i'
     # Only run in opt mode to avoid timeouts in dbg.
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
   [./really_small_problem]
@@ -43,7 +41,7 @@
     type = RunApp
     input = 'test_problem.i'
     cli_args = 'Executioner/Adaptivity/initial_adaptivity=0'
-    method = 'OPT'
+    method = '!DBG'
     check_input = True
   [../]
 []

--- a/modules/phase_field/src/main.C
+++ b/modules/phase_field/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   PhaseFieldApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("PhaseFieldApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("PhaseFieldApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/porous_flow/src/main.C
+++ b/modules/porous_flow/src/main.C
@@ -17,14 +17,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   PorousFlowApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("PorousFlowApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("PorousFlowApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/rdg/src/main.C
+++ b/modules/rdg/src/main.C
@@ -24,14 +24,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   RdgApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("RdgApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("RdgApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/richards/src/main.C
+++ b/modules/richards/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   RichardsApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("RichardsApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("RichardsApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/solid_mechanics/src/main.C
+++ b/modules/solid_mechanics/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   SolidMechanicsApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("SolidMechanicsApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("SolidMechanicsApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/stochastic_tools/src/main.C
+++ b/modules/stochastic_tools/src/main.C
@@ -17,14 +17,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   StochasticToolsApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("StochasticToolsApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("StochasticToolsApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/tensor_mechanics/src/main.C
+++ b/modules/tensor_mechanics/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   TensorMechanicsApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("TensorMechanicsApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("TensorMechanicsApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/water_steam_eos/src/main.C
+++ b/modules/water_steam_eos/src/main.C
@@ -23,17 +23,14 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   WaterSteamEOSApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("WaterSteamEOSApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("WaterSteamEOSApp", argc, argv);
 
   app->setCheckUnusedFlag(true);
   app->setErrorOverridden();
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/modules/xfem/src/main.C
+++ b/modules/xfem/src/main.C
@@ -24,14 +24,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   XFEMApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("XFEMApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("XFEMApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/stork/src/main.C
+++ b/stork/src/main.C
@@ -8,7 +8,8 @@
 PerfLog Moose::perf_log("Stork");
 
 // Begin the main program.
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
   // Initialize MPI, solvers and MOOSE
   MooseInit init(argc, argv);
@@ -16,14 +17,11 @@ int main(int argc, char *argv[])
   // Register this application's MooseApp and any it depends on
   StorkApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("StorkApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("StorkApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/test/src/main.C
+++ b/test/src/main.C
@@ -29,14 +29,11 @@ main(int argc, char * argv[])
   // Register this application's MooseApp and any it depends on
   MooseTestApp::registerApps();
 
-  // This creates dynamic memory that we're responsible for deleting
-  MooseApp * app = AppFactory::createApp("MooseTestApp", argc, argv);
+  // Create an instance of the application and store it in a smart pointer for easy cleanup
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("MooseTestApp", argc, argv);
 
   // Execute the application
   app->run();
-
-  // Free up the memory we created earlier
-  delete app;
 
   return 0;
 }

--- a/tutorials/darcy_thermo_mech/step01_diffusion/src/main.C
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/src/main.C
@@ -33,7 +33,7 @@ main(int argc, char * argv[])
   DarcyThermoMechApp::registerApps();
 
   // The unique_ptr will automatically free memory allocated by the AppFactory.
-  std::unique_ptr<MooseApp> app(AppFactory::createApp("DarcyThermoMechApp", argc, argv));
+  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("DarcyThermoMechApp", argc, argv);
 
   // Execute the application
   app->run();


### PR DESCRIPTION
So it seems to me that syntax check should terminate after successfully reading the input file and running the Actions. Prior to this PR we were also initializing the Executioner which would run `initialSetup` which does several more things:

 - projects ICs
 - executes all "execute_on = initial" objects
 - runs execute on multiapps (including FullSolveMultiApp)
 - outputs on initial (initial condition)


