### PR TITLE
Fixed calls to SinglePhaseFluidProperties :: gamma

### DIFF
--- a/modules/navier_stokes/include/auxkernels/CNSFVEntropyProductionAux.h
+++ b/modules/navier_stokes/include/auxkernels/CNSFVEntropyProductionAux.h
@@ -32,6 +32,7 @@ protected:
 
   const MaterialProperty<Real> & _rho;
   const MaterialProperty<Real> & _pres;
+  const MaterialProperty<Real> & _gamma;
 
   Real _inf_rho;
   Real _inf_pres;

--- a/modules/navier_stokes/include/materials/CNSFVMaterial.h
+++ b/modules/navier_stokes/include/materials/CNSFVMaterial.h
@@ -98,6 +98,8 @@ protected:
   MaterialProperty<Real> & _vadv;
   /// z-velocity
   MaterialProperty<Real> & _wadv;
+  /// gamma
+  MaterialProperty<Real> & _gamma;
 };
 
 #endif

--- a/modules/navier_stokes/include/postprocessors/CNSFVIdealGasEntropyL2Error.h
+++ b/modules/navier_stokes/include/postprocessors/CNSFVIdealGasEntropyL2Error.h
@@ -41,6 +41,7 @@ protected:
 
   const MaterialProperty<Real> & _rho;
   const MaterialProperty<Real> & _pres;
+  const MaterialProperty<Real> & _gamma;
 };
 
 #endif

--- a/modules/navier_stokes/include/postprocessors/CNSFVIdealGasTotalEnthalpyL2Error.h
+++ b/modules/navier_stokes/include/postprocessors/CNSFVIdealGasTotalEnthalpyL2Error.h
@@ -44,6 +44,7 @@ protected:
 
   const MaterialProperty<Real> & _rho;
   const MaterialProperty<Real> & _enth;
+  const MaterialProperty<Real> & _gamma;
 };
 
 #endif

--- a/modules/navier_stokes/src/auxkernels/CNSFVEntropyProductionAux.C
+++ b/modules/navier_stokes/src/auxkernels/CNSFVEntropyProductionAux.C
@@ -30,6 +30,7 @@ CNSFVEntropyProductionAux::CNSFVEntropyProductionAux(const InputParameters & par
     _fp(getUserObject<SinglePhaseFluidProperties>("fluid_properties")),
     _rho(getMaterialProperty<Real>("rho")),
     _pres(getMaterialProperty<Real>("pressure")),
+    _gamma(getMaterialProperty<Real>("gamma")),
     _inf_rho(getParam<Real>("infinity_density")),
     _inf_pres(getParam<Real>("infinity_pressure"))
 {
@@ -38,5 +39,5 @@ CNSFVEntropyProductionAux::CNSFVEntropyProductionAux(const InputParameters & par
 Real
 CNSFVEntropyProductionAux::computeValue()
 {
-  return (_pres[_qp] / _inf_pres) * std::pow(_inf_rho / _rho[_qp], _fp.gamma(0., 0.)) - 1.;
+  return (_pres[_qp] / _inf_pres) * std::pow(_inf_rho / _rho[_qp], _gamma[_qp]) - 1.;
 }

--- a/modules/navier_stokes/src/materials/CNSFVMaterial.C
+++ b/modules/navier_stokes/src/materials/CNSFVMaterial.C
@@ -59,7 +59,8 @@ CNSFVMaterial::CNSFVMaterial(const InputParameters & parameters)
     _mach(declareProperty<Real>("mach_number")),
     _uadv(declareProperty<Real>("vel_x")),
     _vadv(declareProperty<Real>("vel_y")),
-    _wadv(declareProperty<Real>("vel_z"))
+    _wadv(declareProperty<Real>("vel_z")),
+    _gamma(declareProperty<Real>("gamma"))
 {
 }
 
@@ -87,6 +88,7 @@ CNSFVMaterial::computeQpProperties()
 
   _pres[_qp] = _fp.pressure(v, e);
   _temp[_qp] = _fp.temperature(v, e);
+  _gamma[_qp] = _fp.gamma(v, e);
 
   /// interpolate variable values at face center
   if (_bnd)

--- a/modules/navier_stokes/src/postprocessors/CNSFVIdealGasEntropyL2Error.C
+++ b/modules/navier_stokes/src/postprocessors/CNSFVIdealGasEntropyL2Error.C
@@ -32,7 +32,8 @@ CNSFVIdealGasEntropyL2Error::CNSFVIdealGasEntropyL2Error(const InputParameters &
     _inf_rho(getParam<Real>("infinity_density")),
     _inf_pres(getParam<Real>("infinity_pressure")),
     _rho(getMaterialProperty<Real>("rho")),
-    _pres(getMaterialProperty<Real>("pressure"))
+    _pres(getMaterialProperty<Real>("pressure")),
+    _gamma(getMaterialProperty<Real>("gamma"))
 {
 }
 
@@ -45,7 +46,7 @@ CNSFVIdealGasEntropyL2Error::getValue()
 Real
 CNSFVIdealGasEntropyL2Error::computeQpIntegral()
 {
-  Real diff = (_pres[_qp] / _inf_pres) * std::pow(_inf_rho / _rho[_qp], _fp.gamma(0., 0.)) - 1.;
+  Real diff = (_pres[_qp] / _inf_pres) * std::pow(_inf_rho / _rho[_qp], _gamma[_qp]) - 1.;
 
   return diff * diff;
 }

--- a/modules/navier_stokes/src/postprocessors/CNSFVIdealGasTotalEnthalpyL2Error.C
+++ b/modules/navier_stokes/src/postprocessors/CNSFVIdealGasTotalEnthalpyL2Error.C
@@ -43,7 +43,8 @@ CNSFVIdealGasTotalEnthalpyL2Error::CNSFVIdealGasTotalEnthalpyL2Error(
     _inf_wadv(getParam<Real>("infinity_z_velocity")),
     _inf_pres(getParam<Real>("infinity_pressure")),
     _rho(getMaterialProperty<Real>("rho")),
-    _enth(getMaterialProperty<Real>("enthalpy"))
+    _enth(getMaterialProperty<Real>("enthalpy")),
+    _gamma(getMaterialProperty<Real>("gamma"))
 {
 }
 
@@ -56,10 +57,8 @@ CNSFVIdealGasTotalEnthalpyL2Error::getValue()
 Real
 CNSFVIdealGasTotalEnthalpyL2Error::computeQpIntegral()
 {
-  Real gamma = _fp.gamma(0., 0.);
-
   Real diff =
-      _rho[_qp] * _enth[_qp] - gamma / (gamma - 1.) * _inf_pres -
+      _rho[_qp] * _enth[_qp] - _gamma[_qp] / (_gamma[_qp] - 1.) * _inf_pres -
       0.5 * _inf_rho * (_inf_uadv * _inf_uadv + _inf_vadv * _inf_vadv + _inf_wadv * _inf_wadv);
 
   return diff * diff;

--- a/modules/navier_stokes/src/userobjects/CNSFVHLLCInflowOutflowBoundaryFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVHLLCInflowOutflowBoundaryFlux.C
@@ -55,7 +55,6 @@ CNSFVHLLCInflowOutflowBoundaryFlux::calcFlux(unsigned int iside,
                                              std::vector<Real> & flux) const
 {
   Real eps = 1e-6;
-  Real gamma = _fp.gamma(0., 0.);
 
   /// pass the inputs to local
 
@@ -83,6 +82,7 @@ CNSFVHLLCInflowOutflowBoundaryFlux::calcFlux(unsigned int iside,
   Real eint1 = rhoe1 * rhom1 - 0.5 * vdov1;
   Real pres1 = _fp.pressure(rhom1, eint1);
   Real csou1 = _fp.c(rhom1, eint1);
+  Real gamma = _fp.gamma(rhom1, eint1);
   Real mach1 = std::sqrt(vdov1) / csou1;
 
   if (mach1 > -1. && mach1 < 0.)
@@ -383,9 +383,6 @@ CNSFVHLLCInflowOutflowBoundaryFlux::calcJacobian(unsigned int iside,
                                                  DenseMatrix<Real> & jac1) const
 {
   Real eps = 1e-6;
-  Real gamma = _fp.gamma(0., 0.);
-  Real gamm1 = gamma - 1.;
-  Real gamm2 = 2. - gamma;
 
   /// pass the inputs to local
 
@@ -413,6 +410,9 @@ CNSFVHLLCInflowOutflowBoundaryFlux::calcJacobian(unsigned int iside,
   Real eint1 = rhoe1 * rhom1 - 0.5 * vdov1;
   Real pres1 = _fp.pressure(rhom1, eint1);
   Real csou1 = _fp.c(rhom1, eint1);
+  Real gamma = _fp.gamma(rhom1, eint1);
+  Real gamm1 = gamma - 1.;
+  Real gamm2 = 2. - gamma;
   Real rq051 = 0.5 * gamm1 * vdov1;
   Real mach1 = std::sqrt(vdov1) / csou1;
 

--- a/modules/navier_stokes/src/userobjects/CNSFVHLLCInternalSideFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVHLLCInternalSideFlux.C
@@ -40,7 +40,6 @@ CNSFVHLLCInternalSideFlux::calcFlux(unsigned int iside,
                                     std::vector<Real> & flux) const
 {
   Real eps = 1e-6;
-  Real gamma = _fp.gamma(0., 0.);
 
   /// pass the inputs to local
 
@@ -73,6 +72,7 @@ CNSFVHLLCInternalSideFlux::calcFlux(unsigned int iside,
   Real e1 = rhoe1 / rho1 - 0.5 * (uadv1 * uadv1 + vadv1 * vadv1 + wadv1 * wadv1);
   Real pres1 = _fp.pressure(v1, e1);
   Real csou1 = _fp.c(v1, e1);
+  Real gamma = _fp.gamma(v1, e1);
   Real enth1 = (rhoe1 + pres1) / rho1;
 
   /// derived variables on the right
@@ -285,9 +285,6 @@ CNSFVHLLCInternalSideFlux::calcJacobian(unsigned int iside,
                                         DenseMatrix<Real> & jac2) const
 {
   Real eps = 1e-6;
-  Real gamma = _fp.gamma(0., 0.);
-  Real gamm1 = gamma - 1.;
-  Real gamm2 = 2. - gamma;
 
   /// pass the inputs to local
 
@@ -322,6 +319,9 @@ CNSFVHLLCInternalSideFlux::calcJacobian(unsigned int iside,
   Real e1 = rhoe1 / rho1 - 0.5 * vdov1;
   Real pres1 = _fp.pressure(v1, e1);
   Real csou1 = _fp.c(v1, e1);
+  Real gamma = _fp.gamma(v1, e1);
+  Real gamm1 = gamma - 1.;
+  Real gamm2 = 2. - gamma;
   Real enth1 = (rhoe1 + pres1) / rho1;
   Real rq051 = 0.5 * gamm1 * vdov1;
 

--- a/modules/navier_stokes/src/userobjects/CNSFVHLLCSlipBoundaryFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVHLLCSlipBoundaryFlux.C
@@ -41,7 +41,6 @@ CNSFVHLLCSlipBoundaryFlux::calcFlux(unsigned int iside,
                                     std::vector<Real> & flux) const
 {
   Real eps = 1e-6;
-  Real gamma = _fp.gamma(0., 0.);
 
   /// pass the inputs to local
 
@@ -69,6 +68,7 @@ CNSFVHLLCSlipBoundaryFlux::calcFlux(unsigned int iside,
   Real e1 = rhoe1 / rho1 - 0.5 * vdov1;
   Real pres1 = _fp.pressure(v1, e1);
   Real csou1 = _fp.c(v1, e1);
+  Real gamma = _fp.gamma(v1, e1);
   Real enth1 = (rhoe1 + pres1) / rho1;
 
   /// status in the ghost cell
@@ -287,9 +287,6 @@ CNSFVHLLCSlipBoundaryFlux::calcJacobian(unsigned int iside,
                                         DenseMatrix<Real> & jac1) const
 {
   Real eps = 1e-6;
-  Real gamma = _fp.gamma(0., 0.);
-  Real gamm1 = gamma - 1.;
-  Real gamm2 = 2. - gamma;
 
   /// pass the inputs to local
 
@@ -317,6 +314,9 @@ CNSFVHLLCSlipBoundaryFlux::calcJacobian(unsigned int iside,
   Real e1 = rhoe1 / rho1 - 0.5 * vdov1;
   Real pres1 = _fp.pressure(v1, e1);
   Real csou1 = _fp.c(v1, e1);
+  Real gamma = _fp.gamma(v1, e1);
+  Real gamm1 = gamma - 1.;
+  Real gamm2 = 2. - gamma;
   Real enth1 = (rhoe1 + pres1) / rho1;
   Real rq051 = 0.5 * gamm1 * vdov1;
 

--- a/modules/navier_stokes/src/userobjects/CNSFVRiemannInvariantBCUserObject.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVRiemannInvariantBCUserObject.C
@@ -74,6 +74,8 @@ CNSFVRiemannInvariantBCUserObject::getGhostCellValue(unsigned int iside,
   Real vdov1 = uadv1 * uadv1 + vadv1 * vadv1 + wadv1 * wadv1;
   Real eint1 = rhoe1 * rhom1 - 0.5 * vdov1;
   Real csou1 = _fp.c(rhom1, eint1);
+  Real gamma = _fp.gamma(rhom1, eint1);
+  Real gamm1 = gamma - 1.;
   Real mach1 = std::sqrt(vdov1) / csou1;
 
   /// calc the ghost state according to local Mach number
@@ -93,9 +95,6 @@ CNSFVRiemannInvariantBCUserObject::getGhostCellValue(unsigned int iside,
   else if (mach1 > -1. && mach1 <= 0.)
   {
     /// subsonic inflow
-
-    Real gamma = _fp.gamma(0., 0.);
-    Real gamm1 = gamma - 1.;
 
     Real inf_eint = _fp.e(_inf_pres, _inf_rho);
     Real inf_csou = _fp.c(1. / _inf_rho, inf_eint);
@@ -130,9 +129,6 @@ CNSFVRiemannInvariantBCUserObject::getGhostCellValue(unsigned int iside,
   else if (mach1 > 0. && mach1 < 1.)
   {
     /// subsonic outflow
-
-    Real gamma = _fp.gamma(0., 0.);
-    Real gamm1 = gamma - 1.;
 
     Real inf_eint = _fp.e(_inf_pres, _inf_rho);
     Real inf_csou = _fp.c(1. / _inf_rho, inf_eint);

--- a/modules/navier_stokes/src/userobjects/CNSFVRiemannInvariantBoundaryFlux.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVRiemannInvariantBoundaryFlux.C
@@ -66,6 +66,8 @@ CNSFVRiemannInvariantBoundaryFlux::calcFlux(unsigned int iside,
   Real eint1 = rhoe1 * rhom1 - 0.5 * vdov1;
   Real pres1 = _fp.pressure(rhom1, eint1);
   Real csou1 = _fp.c(rhom1, eint1);
+  Real gamma = _fp.gamma(rhom1, eint1);
+  Real gamm1 = gamma - 1.;
   Real mach1 = std::sqrt(vdov1) / csou1;
 
   /// calc the flux vector according to local Mach number
@@ -73,9 +75,6 @@ CNSFVRiemannInvariantBoundaryFlux::calcFlux(unsigned int iside,
   if (std::abs(mach1) < 1.)
   {
     /// subsonic
-
-    Real gamma = _fp.gamma(0., 0.);
-    Real gamm1 = gamma - 1.;
 
     std::vector<Real> U2(5, 0.);
 
@@ -238,6 +237,9 @@ CNSFVRiemannInvariantBoundaryFlux::calcJacobian(unsigned int iside,
   Real eint1 = rhoe1 * rhom1 - 0.5 * vdov1;
   Real pres1 = _fp.pressure(rhom1, eint1);
   Real csou1 = _fp.c(rhom1, eint1);
+  Real gamma = _fp.gamma(rhom1, eint1);
+  Real gamm1 = gamma - 1.;
+  Real gamm2 = 2. - gamma;
   Real mach1 = std::sqrt(vdov1) / csou1;
 
   /// calc the flux Jacobian matrix according to local Mach number
@@ -245,9 +247,6 @@ CNSFVRiemannInvariantBoundaryFlux::calcJacobian(unsigned int iside,
   if (std::abs(mach1) < 1.)
   {
     /// subsonic
-
-    Real gamma = _fp.gamma(0., 0.);
-    Real gamm1 = gamma - 1.;
 
     std::vector<Real> U2(5, 0.);
 
@@ -604,10 +603,6 @@ CNSFVRiemannInvariantBoundaryFlux::calcJacobian(unsigned int iside,
   else if (mach1 >= 1.)
   {
     /// supersonic outflow
-
-    Real gamma = _fp.gamma(0., 0.);
-    Real gamm1 = gamma - 1.;
-    Real gamm2 = 2. - gamma;
 
     Real rq051 = 0.5 * gamm1 * vdov1;
     Real vdon1 = uadv1 * nx + vadv1 * ny + wadv1 * nz;


### PR DESCRIPTION
_fp.gamma() is called with 0 and 0 for specific volume and internal energy.  While this is fine when one is using fluid properties that have constant gamma, it is not correct.  The interface expects specific volume and specific internal energy so that these variables should be passed into these calls.

closes #8951