### PR TITLE
Fix the test fail on 64-bit linux for subdomain partitioner

### DIFF
--- a/test/tests/mesh/subdomain_partitioner/tests
+++ b/test/tests/mesh/subdomain_partitioner/tests
@@ -4,6 +4,7 @@
     input = 'subdomain_partitioner.i'
     exodiff = 'subdomain_partitioner_out.e'
     platform = DARWIN
+    dof_id_bytes = 4
     min_parallel = 4
     max_parallel = 4
   [../]
@@ -13,6 +14,7 @@
     exodiff = 'subdomain_partitioner_out_linux.e'
     cli_args = 'Outputs/file_base=subdomain_partitioner_out_linux'
     platform = LINUX
+    dof_id_bytes = 4
     min_parallel = 4
     max_parallel = 4
   [../]


### PR DESCRIPTION
The metis  generates different partitions using different dof-id types 

Refs #8672
