### PR TITLE
Clean up header files in example mains.

### DIFF
--- a/examples/ex01_inputfile/src/main.C
+++ b/examples/ex01_inputfile/src/main.C
@@ -19,9 +19,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex02_kernel/src/main.C
+++ b/examples/ex02_kernel/src/main.C
@@ -19,9 +19,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex03_coupling/src/main.C
+++ b/examples/ex03_coupling/src/main.C
@@ -21,9 +21,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex04_bcs/src/main.C
+++ b/examples/ex04_bcs/src/main.C
@@ -20,9 +20,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex05_amr/src/main.C
+++ b/examples/ex05_amr/src/main.C
@@ -20,9 +20,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex06_transient/src/main.C
+++ b/examples/ex06_transient/src/main.C
@@ -21,9 +21,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex07_ics/src/main.C
+++ b/examples/ex07_ics/src/main.C
@@ -19,9 +19,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex08_materials/src/main.C
+++ b/examples/ex08_materials/src/main.C
@@ -19,9 +19,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex09_stateful_materials/src/main.C
+++ b/examples/ex09_stateful_materials/src/main.C
@@ -21,9 +21,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex10_aux/src/main.C
+++ b/examples/ex10_aux/src/main.C
@@ -19,9 +19,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex11_prec/src/main.C
+++ b/examples/ex11_prec/src/main.C
@@ -19,9 +19,9 @@
  */
 
 #include "ExampleApp.h"
+
 // Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex12_pbp/src/main.C
+++ b/examples/ex12_pbp/src/main.C
@@ -19,8 +19,9 @@
  */
 
 #include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex13_functions/src/main.C
+++ b/examples/ex13_functions/src/main.C
@@ -17,8 +17,9 @@
  */
 
 #include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex14_pps/src/main.C
+++ b/examples/ex14_pps/src/main.C
@@ -24,8 +24,9 @@
  */
 
 #include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex15_actions/src/main.C
+++ b/examples/ex15_actions/src/main.C
@@ -20,11 +20,12 @@
  * It also shows how to inherit from MooseApp and use it.
  */
 
+#include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
-#include "ExampleApp.h"
 
 // Create a performance log
 PerfLog Moose::perf_log("Example");

--- a/examples/ex16_timestepper/src/main.C
+++ b/examples/ex16_timestepper/src/main.C
@@ -21,7 +21,8 @@
  */
 
 #include "MooseInit.h"
-#include "Moose.h"
+
+// MOOSE Includes
 #include "MooseApp.h"
 #include "AppFactory.h"
 #include "ExampleApp.h"

--- a/examples/ex17_dirac/src/main.C
+++ b/examples/ex17_dirac/src/main.C
@@ -17,8 +17,9 @@
  */
 
 #include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex18_scalar_kernel/src/main.C
+++ b/examples/ex18_scalar_kernel/src/main.C
@@ -17,8 +17,9 @@
  */
 
 #include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex19_dampers/src/main.C
+++ b/examples/ex19_dampers/src/main.C
@@ -17,6 +17,8 @@
  */
 
 #include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
 #include "Moose.h"
 #include "MooseApp.h"

--- a/examples/ex20_user_objects/src/main.C
+++ b/examples/ex20_user_objects/src/main.C
@@ -17,8 +17,9 @@
  */
 
 #include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 

--- a/examples/ex21_debugging/src/main.C
+++ b/examples/ex21_debugging/src/main.C
@@ -19,8 +19,9 @@
  */
 
 #include "ExampleApp.h"
+
+// Moose Includes
 #include "MooseInit.h"
-#include "Moose.h"
 #include "MooseApp.h"
 #include "AppFactory.h"
 


### PR DESCRIPTION
Follow-on to related work in #8944.  This is all that is left of my
original std::unique_ptr changes after we decided to go with
std::shared_ptr instead and #8948 was merged.
