### PR TITLE
Add a python clobber script

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -172,12 +172,7 @@ clean::
 #    dependency and object files when you upgrade OSX versions or as
 #    source files are deleted over time.
 clobber:: clean
-	$(shell find $(CURDIR) \( -path $(CURDIR)/moose -or -path $(CURDIR)/.git -or -path $(CURDIR)/.svn \) -prune -or \
-          \( -name "*~" -or -name "*.lo" -or -name "*.la" -or -name "*.dylib" -or -name "*.so*" -or -name "*.a" \
-          -or -name "*-opt" -or -name "*-dbg" -or -name "*-oprof" \
-          -or -name "*.d" -or -name "*.pyc" -or -name "*.plugin" -or -name "*.mod" -or -name "*.plist" \
-          -or -name "*.gcda" -or -name "*.gcno" -or -name "*.gcov" -or -name "*.gch" -or -name .libs -or -path "*/.libs/*" \) \
-          -delete)
+	@$(MOOSE_DIR)/scripts/clobber.py -v $(CURDIR)
 
 # cleanall runs 'make clean' in all dependent application directories
 cleanall:: clean

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -141,8 +141,8 @@ $(exodiff_APP): $(exodiff_objects)
 
 # Set up app-specific variables for MOOSE, so that it can use the same clean target as the apps
 app_EXEC := $(exodiff_APP)
-app_LIB  := $(moose_LIBS) $(pcre_LIB)
-app_objects := $(moose_objects) $(exodiff_objects)
+app_LIB  := $(moose_LIBS) $(pcre_LIB) $(gtest_LIB)
+app_objects := $(moose_objects) $(exodiff_objects) $(pcre_objects) $(gtest_objects)
 app_deps := $(moose_deps) $(exodiff_deps) $(pcre_deps) $(gtest_deps)
 
 # The clean target removes everything we can remove "easily",

--- a/scripts/clobber.py
+++ b/scripts/clobber.py
@@ -1,87 +1,106 @@
 #!/usr/bin/env python
-"""
-Script to cleanup compile artifacts.
-This can be called from a top level application so
-we ignore the following directories:
-    moose (ignore a possible MOOSE submodule)
-    .git  (don't accidentally delete any of git's metadata)
-    .svn  (don't accidentally delete any of svn's metadata)
-"""
 import os
 import argparse
 import shutil
 
-def verbose_print(s, verbose=False):
-    if verbose:
-        print(s)
-
-def ignore_dir(root, subdirs, to_ignore, verbose):
+class Clobber(object):
     """
-    Ignores a directory by removing it from the subdirs list
+    Class to cleanup compile artifacts.
+    This does not honor the METHOD environment variable.
+    It removes compile artifacts for all of them.
+    This can be called from a top level application so
+    we ignore the following directories:
+        moose (ignore a possible MOOSE submodule)
+        .git  (don't accidentally delete any of git's metadata)
+        .svn  (don't accidentally delete any of svn's metadata)
     """
-    if to_ignore in subdirs:
-        verbose_print("Ignoring %s" % os.path.join(root, to_ignore), verbose)
-        subdirs.remove(to_ignore)
+    def __init__(self, top_dir, verbose, dry_run):
+        self.top_dir = top_dir
+        self.verbose = verbose
+        self.dry_run = dry_run
 
-def remove_dir(root, subdirs, to_remove, verbose):
-    """
-    Removes a directory in the filesystem.
-    """
-    if to_remove in subdirs:
-        dir_path = os.path.join(root, to_remove)
-        verbose_print("Removing directory %s" % dir_path, verbose)
-        subdirs.remove(to_remove)
-        try:
-            shutil.rmtree(dir_path)
-        except Exception as e:
-            print("Failed to remove path: %s\nError: %s" % (dir_path, e))
+    def message(self, msg):
+        if self.verbose:
+            if self.dry_run:
+                print("DRY RUN: " + msg)
+            else:
+                print(msg)
 
-def clobber(top_dir, verbose=False):
-    """
-    Removes compilation related files and directories.
-    """
-    verbose_print("Clobbering in %s" % top_dir, verbose)
-    remove_ext = ("~",
-            ".o",
-            ".lo",
-            ".la",
-            ".dylib",
-            ".a",
-            "-opt",
-            "-dbg",
-            "-oprof",
-            "-devel",
-            ".d",
-            ".pyc",
-            ".plugin",
-            ".mod",
-            ".plist",
-            ".gcda",
-            ".gcno",
-            ".gcov",
-            ".gch",
-            )
+    def ignore_dir(self, root, subdirs, to_ignore):
+        """
+        Ignores a directory by removing it from the subdirs list
+        """
+        if to_ignore in subdirs:
+            self.message("Ignoring %s" % os.path.join(root, to_ignore))
+            subdirs.remove(to_ignore)
 
-    for root, subdirs, files in os.walk(top_dir, topdown=True):
-        ignore_dir(root, subdirs, "moose", verbose)
-        ignore_dir(root, subdirs, ".git", verbose)
-        ignore_dir(root, subdirs, ".svn", verbose)
-
-        remove_dir(root, subdirs, ".libs", verbose)
-        remove_dir(root, subdirs, ".jitcache", verbose)
-
-        for f in files:
-            if f.endswith(remove_ext) or ".so" in f:
-                fpath = os.path.join(root, f)
-                verbose_print("Removing file %s" % fpath, verbose)
+    def remove_dir(self, root, subdirs, to_remove):
+        """
+        Removes a directory in the filesystem.
+        """
+        if to_remove in subdirs:
+            dir_path = os.path.join(root, to_remove)
+            self.message("Removing directory %s" % dir_path)
+            subdirs.remove(to_remove)
+            if not self.dry_run:
                 try:
-                    os.unlink(fpath)
+                    shutil.rmtree(dir_path)
                 except Exception as e:
-                    print("Failed to remove file: %s\nError: %s" % (fpath, e))
+                    print("Failed to remove path: %s\nError: %s" % (dir_path, e))
+
+    def clobber(self):
+        """
+        Walks the directories and removes unwanted files and directories.
+        """
+        self.message("Clobbering in %s" % self.top_dir)
+        remove_file_ext = ("~",
+                ".o",
+                ".lo",
+                ".la",
+                ".dylib",
+                ".a",
+                "-opt",
+                "-dbg",
+                "-oprof",
+                "-devel",
+                ".d",
+                ".pyc",
+                ".plugin",
+                ".mod",
+                ".plist",
+                ".gcda",
+                ".gcno",
+                ".gcov",
+                ".gch",
+                )
+
+        for root, subdirs, files in os.walk(self.top_dir, topdown=True):
+            self.ignore_dir(root, subdirs, "moose")
+            self.ignore_dir(root, subdirs, ".git")
+            self.ignore_dir(root, subdirs, ".svn")
+
+            self.remove_dir(root, subdirs, ".libs")
+            self.remove_dir(root, subdirs, ".jitcache")
+
+            for f in files:
+                if f.endswith(remove_file_ext) or ".so" in f:
+                    fpath = os.path.join(root, f)
+                    self.message("Removing file %s" % fpath)
+                    if not self.dry_run:
+                        try:
+                            os.unlink(fpath)
+                        except Exception as e:
+                            print("Failed to remove file: %s\nError: %s" % (fpath, e))
+
+            for d in subdirs[:]:
+                if d.endswith(".dSYM"):
+                    self.remove_dir(root, subdirs, d)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Remove compile artifacts')
-    parser.add_argument('-v', action='store_true', dest='verbose', help='Print what is happening')
-    parser.add_argument('top_directory', help='Top directory to start with')
+    parser = argparse.ArgumentParser(description='Remove compile artifacts.')
+    parser.add_argument('-v', action='store_true', dest='verbose', help='Print what is happening.')
+    parser.add_argument('-n', action='store_true', dest='dry_run', help="Dry run. Don't actually remove anything.")
+    parser.add_argument('top_directory', help='Top directory to start with.')
     parsed = parser.parse_args()
-    clobber(parsed.top_directory, parsed.verbose)
+    c = Clobber(parsed.top_directory, parsed.verbose, parsed.dry_run)
+    c.clobber()

--- a/scripts/clobber.py
+++ b/scripts/clobber.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+Script to cleanup compile artifacts.
+This can be called from a top level application so
+we ignore the following directories:
+    moose (ignore a possible MOOSE submodule)
+    .git  (don't accidentally delete any of git's metadata)
+    .svn  (don't accidentally delete any of svn's metadata)
+"""
+import os
+import argparse
+import shutil
+
+def verbose_print(s, verbose=False):
+    if verbose:
+        print(s)
+
+def ignore_dir(root, subdirs, to_ignore, verbose):
+    """
+    Ignores a directory by removing it from the subdirs list
+    """
+    if to_ignore in subdirs:
+        verbose_print("Ignoring %s" % os.path.join(root, to_ignore), verbose)
+        subdirs.remove(to_ignore)
+
+def remove_dir(root, subdirs, to_remove, verbose):
+    """
+    Removes a directory in the filesystem.
+    """
+    if to_remove in subdirs:
+        dir_path = os.path.join(root, to_remove)
+        verbose_print("Removing directory %s" % dir_path, verbose)
+        subdirs.remove(to_remove)
+        try:
+            shutil.rmtree(dir_path)
+        except Exception as e:
+            print("Failed to remove path: %s\nError: %s" % (dir_path, e))
+
+def clobber(top_dir, verbose=False):
+    """
+    Removes compilation related files and directories.
+    """
+    verbose_print("Clobbering in %s" % top_dir, verbose)
+    remove_ext = ("~",
+            ".o",
+            ".lo",
+            ".la",
+            ".dylib",
+            ".a",
+            "-opt",
+            "-dbg",
+            "-oprof",
+            "-devel",
+            ".d",
+            ".pyc",
+            ".plugin",
+            ".mod",
+            ".plist",
+            ".gcda",
+            ".gcno",
+            ".gcov",
+            ".gch",
+            )
+
+    for root, subdirs, files in os.walk(top_dir, topdown=True):
+        ignore_dir(root, subdirs, "moose", verbose)
+        ignore_dir(root, subdirs, ".git", verbose)
+        ignore_dir(root, subdirs, ".svn", verbose)
+
+        remove_dir(root, subdirs, ".libs", verbose)
+        remove_dir(root, subdirs, ".jitcache", verbose)
+
+        for f in files:
+            if f.endswith(remove_ext) or ".so" in f:
+                fpath = os.path.join(root, f)
+                verbose_print("Removing file %s" % fpath, verbose)
+                try:
+                    os.unlink(fpath)
+                except Exception as e:
+                    print("Failed to remove file: %s\nError: %s" % (fpath, e))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Remove compile artifacts')
+    parser.add_argument('-v', action='store_true', dest='verbose', help='Print what is happening')
+    parser.add_argument('top_directory', help='Top directory to start with')
+    parsed = parser.parse_args()
+    clobber(parsed.top_directory, parsed.verbose)


### PR DESCRIPTION
Call a python script when doing `make clobber` instead of the non portable find command.
Also added some contrib objects and libraries to the `make clean`

closes #8952