### PR TITLE
Fix name in FluidProperties perf log

### DIFF
--- a/modules/fluid_properties/src/main.C
+++ b/modules/fluid_properties/src/main.C
@@ -11,7 +11,7 @@
 #include "AppFactory.h"
 
 // Create a performance log
-PerfLog Moose::perf_log("HeatConduction");
+PerfLog Moose::perf_log("FluidProperties");
 
 // Begin the main program.
 int


### PR DESCRIPTION
`HeatConduction`  -> `FluidProperties` in performance log.
Closes #8968