### PR TITLE
ignore the ignored

### DIFF
--- a/python/TestHarness/RunParallel.py
+++ b/python/TestHarness/RunParallel.py
@@ -75,6 +75,17 @@ class RunParallel:
         # Reporting timer which resets when ever data is printed to the screen.
         self.reported_timer = clock()
 
+    def unsatisfiedPrereqs(self, tester):
+        if tester.specs['prereq'] != None and len(set(tester.specs['prereq']) - self.finished_jobs):
+            if self.options.pbs is None and self.options.ignored_caveats is None:
+                return True
+            else:
+                if self.options.ignored_caveats:
+                    caveat_list = [x.lower() for x in self.options.ignored_caveats.split()]
+                    if 'all' not in self.options.ignored_caveats and 'prereq' not in self.options.ignored_caveats:
+                        return True
+        return False
+
     ## run the command asynchronously and call testharness.testOutputAndFinish when complete
     def run(self, tester, command, recurse=True, slot_check=True):
         # First see if any of the queued jobs can be run but only if recursion is allowed on this run
@@ -95,7 +106,7 @@ class RunParallel:
             return
 
         # Now make sure that this job doesn't have an unsatisfied prereq
-        if tester.specs['prereq'] != None and len(set(tester.specs['prereq']) - self.finished_jobs) and self.options.pbs is None:
+        if self.unsatisfiedPrereqs(tester):
             self.queue.append([tester, command, os.getcwd()])
             return
 

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -801,6 +801,7 @@ class TestHarness:
         parser.add_argument('--devel', action='store_const', dest='method', const='devel', help='test the app_name-devel binary')
         parser.add_argument('--oprof', action='store_const', dest='method', const='oprof', help='test the app_name-oprof binary')
         parser.add_argument('--pro', action='store_const', dest='method', const='pro', help='test the app_name-pro binary')
+        parser.add_argument('--ignore', nargs='?', action='store', metavar='caveat', dest='ignored_caveats', const='all', type=str, help='ignore specified caveats when checking if a test should run: (--ignore "method compiler") Using --ignore with out a conditional will ignore all caveats')
         parser.add_argument('-j', '--jobs', nargs='?', metavar='int', action='store', type=int, dest='jobs', const=1, help='run test binaries in parallel')
         parser.add_argument('-e', action='store_true', dest='extra_info', help='Display "extra" information including all caveats and deleted tests')
         parser.add_argument('-c', '--no-color', action='store_false', dest='colored', help='Do not show colored output')

--- a/python/TestHarness/tests/test_Ignore.py
+++ b/python/TestHarness/tests/test_Ignore.py
@@ -1,0 +1,66 @@
+import subprocess
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testIgnore(self):
+        """
+        Test that --ignore overrides normally skipped tests
+        """
+        # Run a skipped test
+        output = self.runTests('-i', 'ignore_skipped', '--ignore', 'skip')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_skipped.*?OK')
+
+        # Run a skipped heavy test
+        output = self.runTests('-i', 'ignore_heavy', '--ignore', 'heavy')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_heavy.*?OK')
+
+        # Run a skipped compiler test
+        output = self.runTests('-i', 'ignore_compiler', '--ignore', 'compiler')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_compiler.*?OK')
+
+        # Run a skipped platform test
+        output = self.runTests('-i', 'ignore_platform', '--ignore', 'platform')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_platform.*?OK')
+
+        # Run a skipped prereq test
+        output = self.runTests('-i', 'ignore_prereq', '--ignore', 'prereq')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?skipped')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_skipped_dependency.*?OK')
+
+        # Check that a dependency test runs when its prereq test is skipped
+        output = self.runTests('-i', 'ignore_prereq', '--ignore', 'skip')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?OK')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_skipped_dependency.*?OK')
+
+        # Run a multiple caveat skipped test by manually supplying each caveat
+        output = self.runTests('-i', 'ignore_multiple', '--ignore', 'skip heavy compiler platform')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multiple.*?OK')
+
+        # Run a multiple caveat skipped test using built in default 'all'
+        output = self.runTests('-i', 'ignore_multiple', '--ignore')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multiple.*?OK')
+
+        # Skip a multiple caveat test by not supplying enough caveats to ignore
+        output = self.runTests('-i', 'ignore_multiple', '--ignore', 'skip heavy compiler')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multiple.*?skipped')
+
+        # Run a multiple caveat prereq test using built in default 'all'
+        output = self.runTests('-i', 'ignore_multiple_prereq', '--ignore')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?OK')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*?OK')
+
+        # Run a multiple caveat prereq test by manually supplying each caveat
+        output = self.runTests('-i', 'ignore_multiple_prereq', '--ignore', 'prereq skip heavy compiler platform')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?OK')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*?OK')
+
+        # Skip a multiple caveat prereq test by not supplying enough caveats to ignore
+        output = self.runTests('-i', 'ignore_multiple_prereq', '--ignore', 'prereq skip heavy compiler')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?OK')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*?skipped')
+
+        # Check that a multiple caveat dependency test runs when its prereq test is skipped
+        # This test may seem redundant, but `prereq` is handled differently than the other caveats
+        output = self.runTests('-i', 'ignore_multiple_prereq', '--ignore', 'prereq heavy compiler platform')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?skipped')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*?OK')

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -39,4 +39,8 @@
     type = PythonUnitTest
     input = test_DisplayRequired.py
   [../]
+  [./ignore]
+    type = PythonUnitTest
+    input = test_Ignore.py
+  [../]
 []

--- a/test/tests/test_harness/ignore_compiler
+++ b/test/tests/test_harness/ignore_compiler
@@ -1,0 +1,7 @@
+[Tests]
+  [./ignore_compiler]
+    type = RunApp
+    input = good.i
+    compiler = non_existent
+  [../]
+[]

--- a/test/tests/test_harness/ignore_heavy
+++ b/test/tests/test_harness/ignore_heavy
@@ -1,0 +1,7 @@
+[Tests]
+  [./ignore_heavy]
+    type = RunApp
+    input = good.i
+    heavy = true
+  [../]
+[]

--- a/test/tests/test_harness/ignore_multiple
+++ b/test/tests/test_harness/ignore_multiple
@@ -1,0 +1,10 @@
+[Tests]
+  [./ignore_multiple]
+    type = RunApp
+    input = good.i
+    skip = "always skipped"
+    heavy = true
+    compiler = non_existent
+    platform = non_existent
+  [../]
+[]

--- a/test/tests/test_harness/ignore_multiple_prereq
+++ b/test/tests/test_harness/ignore_multiple_prereq
@@ -1,0 +1,15 @@
+[Tests]
+  [./always_skipped]
+    type = RunApp
+    input = good.i
+    skip = "always skipped"
+  [../]
+  [./ignore_multi_prereq_dependency]
+    type = RunApp
+    input = good.i
+    heavy = true
+    compiler = non_existent
+    platform = non_existent
+    prereq = always_skipped
+  [../]
+[]

--- a/test/tests/test_harness/ignore_platform
+++ b/test/tests/test_harness/ignore_platform
@@ -1,0 +1,7 @@
+[Tests]
+  [./ignore_platform]
+    type = RunApp
+    input = good.i
+    platform = non_existent
+  [../]
+[]

--- a/test/tests/test_harness/ignore_prereq
+++ b/test/tests/test_harness/ignore_prereq
@@ -1,0 +1,12 @@
+[Tests]
+  [./always_skipped]
+    type = RunApp
+    input = good.i
+    skip = "always skipped"
+  [../]
+  [./ignore_skipped_dependency]
+    type = RunApp
+    input = good.i
+    prereq = always_skipped
+  [../]
+[]

--- a/test/tests/test_harness/ignore_skipped
+++ b/test/tests/test_harness/ignore_skipped
@@ -1,0 +1,7 @@
+[Tests]
+  [./ignore_skipped]
+    type = RunApp
+    input = good.i
+    skip = "always skipped"
+  [../]
+[]


### PR DESCRIPTION
Adds ability to force a test to run while under normal circumstances would do otherwise (caveats).
Syntax supports space separated values (encapsulated in quotes).

```pre
  --ignore "compiler platform petsc_version"
```
Or if no conditionals are specified, ignore all caveats.

```pre
  --ignore
```

Closes #8954
