### PR TITLE
adds barebones RankThreeTensor support (general fill method only) for…

### DIFF
--- a/framework/include/utils/RankThreeTensor.h
+++ b/framework/include/utils/RankThreeTensor.h
@@ -1,0 +1,215 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef RANKTHREETENSOR_H
+#define RANKTHREETENSOR_H
+
+// MOOSE includes
+#include "DataIO.h"
+
+// libMesh includes
+#include "libmesh/tensor_value.h"
+#include "libmesh/libmesh.h"
+#include "libmesh/vector_value.h"
+
+// Forward declarations
+class MooseEnum;
+class RankTwoTensor;
+class RankThreeTensor;
+
+template <typename T>
+void mooseSetToZero(T & v);
+
+/**
+ * Helper function template specialization to set an object to zero.
+ * Needed by DerivativeMaterialInterface
+ */
+template <>
+void mooseSetToZero<RankThreeTensor>(RankThreeTensor & v);
+
+/**
+ * RankThreeTensor is designed to handle any N-dimensional third order tensor, r.
+ *
+ */
+class RankThreeTensor
+{
+public:
+ /// Initialization method
+  enum InitMethod
+  {
+    initNone
+  };
+
+  /**
+   * To fill up the 18 entries in the 3rd-order tensor, fillFromInputVector
+   * is called with one of the following fill_methods.
+   * See the fill*FromInputVector functions for more details
+   */
+  enum FillMethod
+  {
+    general
+  };
+
+  /// Default constructor; fills to zero
+  RankThreeTensor();
+
+  /// Select specific initialization pattern
+  RankThreeTensor(const InitMethod);
+
+  /// Fill from vector
+  RankThreeTensor(const std::vector<Real> &, FillMethod);
+
+  // Named constructors
+//  static RankThreeTensor Identity() { return RankThreeTensor(initIdentity); }
+//  static RankThreeTensor IdentityFour() { return RankThreeTensor(initIdentityFour); };
+
+  /// Gets the value for the index specified.  Takes index = 0,1,2
+  Real & operator()(unsigned int i, unsigned int j, unsigned int k);
+
+  /**
+   * Gets the value for the index specified.  Takes index = 0,1,2
+   * used for const
+   */
+  Real operator()(unsigned int i, unsigned int j, unsigned int k) const;
+
+  /// Zeros out the tensor.
+  void zero();
+
+  /// Print the rank four tensor
+  void print(std::ostream & stm = Moose::out) const;
+
+  /// copies values from a into this tensor
+  RankThreeTensor & operator=(const RankThreeTensor & a);
+
+  /// r_ijk*a_kl
+  //RankTwoTensor operator*(const RankTwoTensor & a) const;
+
+  /// r_ijk*a_kl
+  //RealTensorValue operator*(const RealTensorValue & a) const;
+
+  /// r_ijk*a
+  RankThreeTensor operator*(const Real a) const;
+
+  /// r_ijk *= a
+  RankThreeTensor & operator*=(const Real a);
+
+  /// r_ijk/a
+  RankThreeTensor operator/(const Real a) const;
+
+  /// r_ijk /= a  for all i, j, k
+  RankThreeTensor & operator/=(const Real a);
+
+  /// r_ijk += a_ijk  for all i, j, k
+  RankThreeTensor & operator+=(const RankThreeTensor & a);
+
+  /// r_ijkl + a_ijk
+  RankThreeTensor operator+(const RankThreeTensor & a) const;
+
+  /// r_ijk -= a_ijk
+  RankThreeTensor & operator-=(const RankThreeTensor & a);
+
+  /// r_ijk - a_ijk
+  RankThreeTensor operator-(const RankThreeTensor & a) const;
+
+  /// -r_ijk
+  RankThreeTensor operator-() const;
+
+
+  /// sqrt(C_ijkl*C_ijkl)
+  Real L2norm() const;
+
+
+  /**
+   * Rotate the tensor using
+   * r_ijk = R_im R_in R_ko r_mno
+   */
+  template <class T>
+  void rotate(const T & R);
+
+  /**
+   * Rotate the tensor using
+   * r_ijk = R_im R_in R_ko r_mno
+   */
+  void rotate(const RealTensorValue & R);
+
+  /**
+   * Rotate the tensor using
+   * r_ijk = R_im R_in R_ko R_lp r_mno
+   */
+  void rotate(const RankTwoTensor & R);
+
+  /// Static method for use in validParams for getting the "fill_method"
+  static MooseEnum fillMethodEnum();
+
+  /**
+   * fillFromInputVector takes some number of inputs to fill
+   * the Rank-4 tensor.
+   * @param input the numbers that will be placed in the tensor
+   * @param fill_method this can be:
+   *             antisymmetric (use fillAntisymmetricFromInputVector)
+   *             symmetric9 (use fillSymmetricFromInputVector with all=false)
+   *             symmetric21 (use fillSymmetricFromInputVector with all=true)
+   *             general_isotropic (use fillGeneralIsotropicFrominputVector)
+   *             symmetric_isotropic (use fillSymmetricIsotropicFromInputVector)
+   *             antisymmetric_isotropic (use fillAntisymmetricIsotropicFromInputVector)
+   *             axisymmetric_rz (use fillAxisymmetricRZFromInputVector)
+   *             general (use fillGeneralFromInputVector)
+   *             principal (use fillPrincipalFromInputVector)
+   */
+  void fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method);
+
+protected:
+  /// Dimensionality of rank-four tensor
+  static const unsigned int N = LIBMESH_DIM;
+
+  /// The values of the rank-three tensor
+  Real _vals[N][N][N];
+
+  /**
+   * fillAxisymmetricRZFromInputVector takes 5 inputs to fill the axisymmetric
+   * Rank-4 tensor with the appropriate symmetries maintatined for use with
+   * axisymmetric problems using coord_type = RZ.
+   * I.e. C1111 = C2222, C1133 = C2233, C2323 = C3131 and C1212 = 0.5*(C1111-C1122)
+   * @param input this is C1111, C1122, C1133, C3333, C2323.
+   */
+  void fillGeneralFromInputVector(const std::vector<Real> & input);
+
+  template <class T>
+  friend void dataStore(std::ostream &, T &, void *);
+
+  template <class T>
+  friend void dataLoad(std::istream &, T &, void *);
+};
+
+template <>
+void dataStore(std::ostream &, RankThreeTensor &, void *);
+
+template <>
+void dataLoad(std::istream &, RankThreeTensor &, void *);
+
+inline RankThreeTensor operator*(Real a, const RankThreeTensor & b) { return b * a; }
+
+template <class T>
+void
+RankThreeTensor::rotate(const T & R)
+{
+  RankThreeTensor old = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        {
+          Real sum = 0.0;
+          for (unsigned int m = 0; m < N; ++m)
+            for (unsigned int n = 0; n < N; ++n)
+              for (unsigned int o = 0; o < N; ++o)
+                  sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
+
+          _vals[i][j][k] = sum;
+        }
+}
+
+#endif // RANKTHREETENSOR_H

--- a/framework/include/utils/RankThreeTensor.h
+++ b/framework/include/utils/RankThreeTensor.h
@@ -37,7 +37,7 @@ void mooseSetToZero<RankThreeTensor>(RankThreeTensor & v);
 class RankThreeTensor
 {
 public:
- /// Initialization method
+  /// Initialization method
   enum InitMethod
   {
     initNone
@@ -63,8 +63,8 @@ public:
   RankThreeTensor(const std::vector<Real> &, FillMethod);
 
   // Named constructors
-//  static RankThreeTensor Identity() { return RankThreeTensor(initIdentity); }
-//  static RankThreeTensor IdentityFour() { return RankThreeTensor(initIdentityFour); };
+  //  static RankThreeTensor Identity() { return RankThreeTensor(initIdentity); }
+  //  static RankThreeTensor IdentityFour() { return RankThreeTensor(initIdentityFour); };
 
   /// Gets the value for the index specified.  Takes index = 0,1,2
   Real & operator()(unsigned int i, unsigned int j, unsigned int k);
@@ -85,10 +85,10 @@ public:
   RankThreeTensor & operator=(const RankThreeTensor & a);
 
   /// r_ijk*a_kl
-  //RankTwoTensor operator*(const RankTwoTensor & a) const;
+  // RankTwoTensor operator*(const RankTwoTensor & a) const;
 
   /// r_ijk*a_kl
-  //RealTensorValue operator*(const RealTensorValue & a) const;
+  // RealTensorValue operator*(const RealTensorValue & a) const;
 
   /// r_ijk*a
   RankThreeTensor operator*(const Real a) const;
@@ -117,10 +117,8 @@ public:
   /// -r_ijk
   RankThreeTensor operator-() const;
 
-
   /// sqrt(C_ijkl*C_ijkl)
   Real L2norm() const;
-
 
   /**
    * Rotate the tensor using
@@ -201,15 +199,15 @@ RankThreeTensor::rotate(const T & R)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-        {
-          Real sum = 0.0;
-          for (unsigned int m = 0; m < N; ++m)
-            for (unsigned int n = 0; n < N; ++n)
-              for (unsigned int o = 0; o < N; ++o)
-                  sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
+      {
+        Real sum = 0.0;
+        for (unsigned int m = 0; m < N; ++m)
+          for (unsigned int n = 0; n < N; ++n)
+            for (unsigned int o = 0; o < N; ++o)
+              sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
 
-          _vals[i][j][k] = sum;
-        }
+        _vals[i][j][k] = sum;
+      }
 }
 
 #endif // RANKTHREETENSOR_H

--- a/framework/include/utils/RankThreeTensor.h
+++ b/framework/include/utils/RankThreeTensor.h
@@ -44,7 +44,7 @@ public:
   };
 
   /**
-   * To fill up the 18 entries in the 3rd-order tensor, fillFromInputVector
+   * To fill up the 27 entries in the 3rd-order tensor, fillFromInputVector
    * is called with one of the following fill_methods.
    * See the fill*FromInputVector functions for more details
    */

--- a/framework/include/utils/RankThreeTensor.h
+++ b/framework/include/utils/RankThreeTensor.h
@@ -62,10 +62,6 @@ public:
   /// Fill from vector
   RankThreeTensor(const std::vector<Real> &, FillMethod);
 
-  // Named constructors
-  //  static RankThreeTensor Identity() { return RankThreeTensor(initIdentity); }
-  //  static RankThreeTensor IdentityFour() { return RankThreeTensor(initIdentityFour); };
-
   /// Gets the value for the index specified.  Takes index = 0,1,2
   Real & operator()(unsigned int i, unsigned int j, unsigned int k);
 
@@ -78,7 +74,7 @@ public:
   /// Zeros out the tensor.
   void zero();
 
-  /// Print the rank four tensor
+  /// Print the rank three tensor
   void print(std::ostream & stm = Moose::out) const;
 
   /// copies values from a into this tensor
@@ -117,7 +113,7 @@ public:
   /// -r_ijk
   RankThreeTensor operator-() const;
 
-  /// sqrt(C_ijkl*C_ijkl)
+  /// \sqrt(r_ijk*r_ijk)
   Real L2norm() const;
 
   /**
@@ -144,35 +140,21 @@ public:
 
   /**
    * fillFromInputVector takes some number of inputs to fill
-   * the Rank-4 tensor.
+   * the Rank-3 tensor.
    * @param input the numbers that will be placed in the tensor
    * @param fill_method this can be:
-   *             antisymmetric (use fillAntisymmetricFromInputVector)
-   *             symmetric9 (use fillSymmetricFromInputVector with all=false)
-   *             symmetric21 (use fillSymmetricFromInputVector with all=true)
-   *             general_isotropic (use fillGeneralIsotropicFrominputVector)
-   *             symmetric_isotropic (use fillSymmetricIsotropicFromInputVector)
-   *             antisymmetric_isotropic (use fillAntisymmetricIsotropicFromInputVector)
-   *             axisymmetric_rz (use fillAxisymmetricRZFromInputVector)
    *             general (use fillGeneralFromInputVector)
-   *             principal (use fillPrincipalFromInputVector)
+   *             more fill_methods to be implemented soon!
    */
   void fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method);
 
 protected:
-  /// Dimensionality of rank-four tensor
+  /// Dimensionality of rank-three tensor
   static const unsigned int N = LIBMESH_DIM;
 
   /// The values of the rank-three tensor
   Real _vals[N][N][N];
 
-  /**
-   * fillAxisymmetricRZFromInputVector takes 5 inputs to fill the axisymmetric
-   * Rank-4 tensor with the appropriate symmetries maintatined for use with
-   * axisymmetric problems using coord_type = RZ.
-   * I.e. C1111 = C2222, C1133 = C2233, C2323 = C3131 and C1212 = 0.5*(C1111-C1122)
-   * @param input this is C1111, C1122, C1133, C3333, C2323.
-   */
   void fillGeneralFromInputVector(const std::vector<Real> & input);
 
   template <class T>

--- a/framework/src/utils/RankThreeTensor.C
+++ b/framework/src/utils/RankThreeTensor.C
@@ -1,0 +1,326 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#include "RankThreeTensor.h"
+#include "RankTwoTensor.h"
+#include "RankFourTensor.h"
+
+// MOOSE includes
+#include "MooseEnum.h"
+#include "MooseException.h"
+#include "MooseUtils.h"
+#include "MatrixTools.h"
+#include "MaterialProperty.h"
+#include "PermutationTensor.h"
+
+// libMesh includes
+#include "libmesh/utility.h"
+
+// C++ includes
+#include <iomanip>
+#include <ostream>
+
+template <>
+void
+mooseSetToZero<RankThreeTensor>(RankThreeTensor & v)
+{
+  v.zero();
+}
+
+template <>
+void
+dataStore(std::ostream & stream, RankThreeTensor & rtht, void * context)
+{
+  dataStore(stream, rtht._vals, context);
+}
+
+template <>
+void
+dataLoad(std::istream & stream, RankThreeTensor & rtht, void * context)
+{
+  dataLoad(stream, rtht._vals, context);
+}
+
+MooseEnum
+RankThreeTensor::fillMethodEnum()   //TODO: Need new fillMethodEnum() -- for now we will just use general (at most 18 components)
+{
+  return MooseEnum("general");
+}
+
+RankThreeTensor::RankThreeTensor()
+{
+  mooseAssert(N == 3, "RankThreeTensor is currently only tested for 3 dimensions.");
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          _vals[i][j][k] = 0.0;
+}
+
+RankThreeTensor::RankThreeTensor(const InitMethod init)
+{
+  switch (init)
+  {
+    case initNone:
+      break;
+
+    default:
+      mooseError("Unknown RankThreeTensor initialization pattern.");
+  }
+}
+
+RankThreeTensor::RankThreeTensor(const std::vector<Real> & input, FillMethod fill_method)
+{
+  fillFromInputVector(input, fill_method);
+}
+
+Real &
+RankThreeTensor::operator()(unsigned int i, unsigned int j, unsigned int k)
+{
+  return _vals[i][j][k];
+}
+
+Real
+RankThreeTensor::operator()(unsigned int i, unsigned int j, unsigned int k) const
+{
+  return _vals[i][j][k];
+}
+
+void
+RankThreeTensor::zero()
+{
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          _vals[i][j][k] = 0.0;
+}
+
+RankThreeTensor &
+RankThreeTensor::operator=(const RankThreeTensor & a)
+{
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          _vals[i][j][k] = a(i, j, k);
+
+  return *this;
+}
+
+//RankTwoTensor RankFourTensor::operator*(const RankTwoTensor & b) const TODO: Need contraction of RealVectorValue on RankThreetensor
+
+RankThreeTensor RankThreeTensor::operator*(const Real b) const
+{
+  RankThreeTensor result;
+  const RankThreeTensor & a = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          result(i, j, k) = a(i, j, k) * b;
+
+  return result;
+}
+
+RankThreeTensor &
+RankThreeTensor::operator*=(const Real a)
+{
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          _vals[i][j][k] *= a;
+
+  return *this;
+}
+
+RankThreeTensor
+RankThreeTensor::operator/(const Real b) const
+{
+  RankThreeTensor result;
+  const RankThreeTensor & a = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          result(i, j, k) = a(i, j, k) / b;
+
+  return result;
+}
+
+RankThreeTensor &
+RankThreeTensor::operator/=(const Real a)
+{
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          _vals[i][j][k] /= a;
+
+  return *this;
+}
+
+RankThreeTensor &
+RankThreeTensor::operator+=(const RankThreeTensor & a)
+{
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          _vals[i][j][k] += a(i, j, k);
+
+  return *this;
+}
+
+RankThreeTensor
+RankThreeTensor::operator+(const RankThreeTensor & b) const
+{
+  RankThreeTensor result;
+  const RankThreeTensor & a = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          result(i, j, k) = a(i, j, k) + b(i, j, k);
+
+  return result;
+}
+
+RankThreeTensor &
+RankThreeTensor::operator-=(const RankThreeTensor & a)
+{
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          _vals[i][j][k] -= a(i, j, k);
+
+  return *this;
+}
+
+RankThreeTensor
+RankThreeTensor::operator-(const RankThreeTensor & b) const
+{
+  RankThreeTensor result;
+  const RankThreeTensor & a = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          result(i, j, k) = a(i, j, k) - b(i, j, k);
+
+  return result;
+}
+
+RankThreeTensor
+RankThreeTensor::operator-() const
+{
+  RankThreeTensor result;
+  const RankThreeTensor & a = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          result(i, j, k) = -a(i, j, k);
+
+  return result;
+}
+
+// RankThreeTensor RankThreeTensor::operator*(const RankFourTensor & b) const
+// {
+//   RankThreeTensor result;
+//   const RankThreeTensor & a = *this;
+//
+//   for (unsigned int i = 0; i < N; ++i)
+//     for (unsigned int j = 0; j < N; ++j)
+//       for (unsigned int k = 0; k < N; ++k)
+//           for (unsigned int p = 0; p < N; ++p)
+//             for (unsigned int q = 0; q < N; ++q)
+//               result(i, j, k) += a(i, j, p, q) * b(p, q, k, l);
+//
+//   return result;
+// }
+
+Real
+RankThreeTensor::L2norm() const
+{
+  Real l2 = 0;
+  const RankThreeTensor & a = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+          l2 += Utility::pow<2>(a(i, j, k));
+
+  return std::sqrt(l2);
+}
+
+void
+RankThreeTensor::fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method)
+{
+  zero();
+
+  switch (fill_method)
+  {
+    case general:
+      fillGeneralFromInputVector(input);
+      break;
+    default:
+      mooseError("fillFromInputVector called with unknown fill_method of ", fill_method);
+  }
+}
+
+
+
+void
+RankThreeTensor::rotate(const RealTensorValue & R)
+{
+  RankThreeTensor old = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        {
+          Real sum = 0.0;
+          for (unsigned int m = 0; m < N; ++m)
+            for (unsigned int n = 0; n < N; ++n)
+              for (unsigned int o = 0; o < N; ++o)
+                  sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
+
+          _vals[i][j][k] = sum;
+        }
+}
+
+void
+RankThreeTensor::rotate(const RankTwoTensor & R)
+{
+  RankThreeTensor old = *this;
+
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        {
+          Real sum = 0.0;
+          for (unsigned int m = 0; m < N; ++m)
+            for (unsigned int n = 0; n < N; ++n)
+              for (unsigned int o = 0; o < N; ++o)
+                  sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
+
+          _vals[i][j][k] = sum;
+        }
+}
+
+void
+RankThreeTensor::fillGeneralFromInputVector(const std::vector<Real> & input)
+{
+  if (input.size() != 18)
+    mooseError("To use fillGeneralFromInputVector, your input must have size 18. Yours has size ",
+               input.size());
+
+  int ind;
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      for (unsigned int k = 0; k < N; ++k)
+        {
+          ind = i * N * N + j * N + k;
+          _vals[i][j][k] = input[ind];
+        }
+}

--- a/framework/src/utils/RankThreeTensor.C
+++ b/framework/src/utils/RankThreeTensor.C
@@ -44,8 +44,8 @@ dataLoad(std::istream & stream, RankThreeTensor & rtht, void * context)
   dataLoad(stream, rtht._vals, context);
 }
 
-MooseEnum
-RankThreeTensor::fillMethodEnum()   //TODO: Need new fillMethodEnum() -- for now we will just use general (at most 18 components)
+MooseEnum RankThreeTensor::fillMethodEnum() // TODO: Need new fillMethodEnum() -- for now we will
+                                            // just use general (at most 18 components)
 {
   return MooseEnum("general");
 }
@@ -57,7 +57,7 @@ RankThreeTensor::RankThreeTensor()
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          _vals[i][j][k] = 0.0;
+        _vals[i][j][k] = 0.0;
 }
 
 RankThreeTensor::RankThreeTensor(const InitMethod init)
@@ -95,7 +95,7 @@ RankThreeTensor::zero()
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          _vals[i][j][k] = 0.0;
+        _vals[i][j][k] = 0.0;
 }
 
 RankThreeTensor &
@@ -104,12 +104,13 @@ RankThreeTensor::operator=(const RankThreeTensor & a)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          _vals[i][j][k] = a(i, j, k);
+        _vals[i][j][k] = a(i, j, k);
 
   return *this;
 }
 
-//RankTwoTensor RankFourTensor::operator*(const RankTwoTensor & b) const TODO: Need contraction of RealVectorValue on RankThreetensor
+// RankTwoTensor RankFourTensor::operator*(const RankTwoTensor & b) const TODO: Need contraction of
+// RealVectorValue on RankThreetensor
 
 RankThreeTensor RankThreeTensor::operator*(const Real b) const
 {
@@ -119,7 +120,7 @@ RankThreeTensor RankThreeTensor::operator*(const Real b) const
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          result(i, j, k) = a(i, j, k) * b;
+        result(i, j, k) = a(i, j, k) * b;
 
   return result;
 }
@@ -130,7 +131,7 @@ RankThreeTensor::operator*=(const Real a)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          _vals[i][j][k] *= a;
+        _vals[i][j][k] *= a;
 
   return *this;
 }
@@ -144,7 +145,7 @@ RankThreeTensor::operator/(const Real b) const
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          result(i, j, k) = a(i, j, k) / b;
+        result(i, j, k) = a(i, j, k) / b;
 
   return result;
 }
@@ -155,7 +156,7 @@ RankThreeTensor::operator/=(const Real a)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          _vals[i][j][k] /= a;
+        _vals[i][j][k] /= a;
 
   return *this;
 }
@@ -166,7 +167,7 @@ RankThreeTensor::operator+=(const RankThreeTensor & a)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          _vals[i][j][k] += a(i, j, k);
+        _vals[i][j][k] += a(i, j, k);
 
   return *this;
 }
@@ -180,7 +181,7 @@ RankThreeTensor::operator+(const RankThreeTensor & b) const
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          result(i, j, k) = a(i, j, k) + b(i, j, k);
+        result(i, j, k) = a(i, j, k) + b(i, j, k);
 
   return result;
 }
@@ -191,7 +192,7 @@ RankThreeTensor::operator-=(const RankThreeTensor & a)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          _vals[i][j][k] -= a(i, j, k);
+        _vals[i][j][k] -= a(i, j, k);
 
   return *this;
 }
@@ -205,7 +206,7 @@ RankThreeTensor::operator-(const RankThreeTensor & b) const
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          result(i, j, k) = a(i, j, k) - b(i, j, k);
+        result(i, j, k) = a(i, j, k) - b(i, j, k);
 
   return result;
 }
@@ -219,7 +220,7 @@ RankThreeTensor::operator-() const
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          result(i, j, k) = -a(i, j, k);
+        result(i, j, k) = -a(i, j, k);
 
   return result;
 }
@@ -248,7 +249,7 @@ RankThreeTensor::L2norm() const
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-          l2 += Utility::pow<2>(a(i, j, k));
+        l2 += Utility::pow<2>(a(i, j, k));
 
   return std::sqrt(l2);
 }
@@ -268,8 +269,6 @@ RankThreeTensor::fillFromInputVector(const std::vector<Real> & input, FillMethod
   }
 }
 
-
-
 void
 RankThreeTensor::rotate(const RealTensorValue & R)
 {
@@ -278,15 +277,15 @@ RankThreeTensor::rotate(const RealTensorValue & R)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-        {
-          Real sum = 0.0;
-          for (unsigned int m = 0; m < N; ++m)
-            for (unsigned int n = 0; n < N; ++n)
-              for (unsigned int o = 0; o < N; ++o)
-                  sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
+      {
+        Real sum = 0.0;
+        for (unsigned int m = 0; m < N; ++m)
+          for (unsigned int n = 0; n < N; ++n)
+            for (unsigned int o = 0; o < N; ++o)
+              sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
 
-          _vals[i][j][k] = sum;
-        }
+        _vals[i][j][k] = sum;
+      }
 }
 
 void
@@ -297,15 +296,15 @@ RankThreeTensor::rotate(const RankTwoTensor & R)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-        {
-          Real sum = 0.0;
-          for (unsigned int m = 0; m < N; ++m)
-            for (unsigned int n = 0; n < N; ++n)
-              for (unsigned int o = 0; o < N; ++o)
-                  sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
+      {
+        Real sum = 0.0;
+        for (unsigned int m = 0; m < N; ++m)
+          for (unsigned int n = 0; n < N; ++n)
+            for (unsigned int o = 0; o < N; ++o)
+              sum += R(i, m) * R(j, n) * R(k, o) * old(m, n, o);
 
-          _vals[i][j][k] = sum;
-        }
+        _vals[i][j][k] = sum;
+      }
 }
 
 void
@@ -319,8 +318,8 @@ RankThreeTensor::fillGeneralFromInputVector(const std::vector<Real> & input)
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
       for (unsigned int k = 0; k < N; ++k)
-        {
-          ind = i * N * N + j * N + k;
-          _vals[i][j][k] = input[ind];
-        }
+      {
+        ind = i * N * N + j * N + k;
+        _vals[i][j][k] = input[ind];
+      }
 }

--- a/framework/src/utils/RankThreeTensor.C
+++ b/framework/src/utils/RankThreeTensor.C
@@ -109,9 +109,6 @@ RankThreeTensor::operator=(const RankThreeTensor & a)
   return *this;
 }
 
-// RankTwoTensor RankFourTensor::operator*(const RankTwoTensor & b) const TODO: Need contraction of
-// RealVectorValue on RankThreetensor
-
 RankThreeTensor RankThreeTensor::operator*(const Real b) const
 {
   RankThreeTensor result;
@@ -224,21 +221,6 @@ RankThreeTensor::operator-() const
 
   return result;
 }
-
-// RankThreeTensor RankThreeTensor::operator*(const RankFourTensor & b) const
-// {
-//   RankThreeTensor result;
-//   const RankThreeTensor & a = *this;
-//
-//   for (unsigned int i = 0; i < N; ++i)
-//     for (unsigned int j = 0; j < N; ++j)
-//       for (unsigned int k = 0; k < N; ++k)
-//           for (unsigned int p = 0; p < N; ++p)
-//             for (unsigned int q = 0; q < N; ++q)
-//               result(i, j, k) += a(i, j, p, q) * b(p, q, k, l);
-//
-//   return result;
-// }
 
 Real
 RankThreeTensor::L2norm() const

--- a/framework/src/utils/RankThreeTensor.C
+++ b/framework/src/utils/RankThreeTensor.C
@@ -45,7 +45,7 @@ dataLoad(std::istream & stream, RankThreeTensor & rtht, void * context)
 }
 
 MooseEnum RankThreeTensor::fillMethodEnum() // TODO: Need new fillMethodEnum() -- for now we will
-                                            // just use general (at most 18 components)
+                                            // just use general (at most 27 components)
 {
   return MooseEnum("general");
 }

--- a/framework/src/utils/RankThreeTensor.C
+++ b/framework/src/utils/RankThreeTensor.C
@@ -292,8 +292,8 @@ RankThreeTensor::rotate(const RankTwoTensor & R)
 void
 RankThreeTensor::fillGeneralFromInputVector(const std::vector<Real> & input)
 {
-  if (input.size() != 18)
-    mooseError("To use fillGeneralFromInputVector, your input must have size 18. Yours has size ",
+  if (input.size() != 27)
+    mooseError("To use fillGeneralFromInputVector, your input must have size 27. Yours has size ",
                input.size());
 
   int ind;


### PR DESCRIPTION
Closes #8963

I'm going to be adding to this class as I'm developing its use in Ferret. Currently, we only are going to have `general` `fill_method` but more fill methods will be added as they are needed, perhaps depending on material point symmetries. 

Note it is basically the same structure as RankTwo and RankFour tensor classes but I removed things like inverting since I'm not sure its possible to invert these n x m objects elegantly.