### PR TITLE
Fix issue with a bad mesh on the input tab

### DIFF
--- a/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
@@ -188,6 +188,13 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
             self._window.update()
             self.setEnabled(False)
 
+    def setLoadingMessage(self, msg):
+        """
+        Set the text shown when there isn't a file.
+        """
+        self._peacock_text.update(text=msg)
+        self._window.update()
+
     def onInputFileChanged(self, *args):
         """
         Force window to reset on the next update b/c the input file has changed.

--- a/python/peacock/Input/BCHighlighter.py
+++ b/python/peacock/Input/BCHighlighter.py
@@ -5,7 +5,7 @@ def highlightBlock(block, vtkwindow):
         block[BlockInfo]: This block will be a child of /BCs
         vtkwindow[VTKWindowPlugin]: The vtk window to set the highlights on
     """
-    if not vtkwindow.isVisible():
+    if not vtkwindow.isVisible() or not vtkwindow.isEnabled():
         return
 
     if not block.path.startswith("/BCs/"):

--- a/python/peacock/Input/MeshViewerPlugin.py
+++ b/python/peacock/Input/MeshViewerPlugin.py
@@ -43,6 +43,8 @@ class MeshViewerPlugin(VTKWindowPlugin):
         # if we aren't writing out the mesh node then don't show it
         mesh_node = tree.getBlockInfo("/Mesh")
         if not mesh_node or not mesh_node.included:
+            self.onFileChanged()
+            self.setLoadingMessage("Mesh block not included")
             return
         exe_path = tree.app_info.path
         self._removeFileNoError(self.current_temp_mesh_file)
@@ -58,13 +60,11 @@ class MeshViewerPlugin(VTKWindowPlugin):
             self.onFileChanged(self.current_temp_mesh_file)
         except Exception:
             self.meshEnabled.emit(False)
+            self.onFileChanged()
+            self.setLoadingMessage("Error producing mesh")
             self._removeFileNoError(self.current_temp_mesh_file)
 
         self._removeFileNoError(input_file) # we need the mesh file since it is in use but not the input file
-
-    def onBlockChanged(self, block, tree):
-        if block.path == "/Mesh" or block.path.startswith("/Mesh/"):
-            self.meshChanged(tree)
 
     def closing(self):
         self._removeFileNoError(self.temp_input_file)

--- a/python/peacock/PeacockApp.py
+++ b/python/peacock/PeacockApp.py
@@ -36,7 +36,6 @@ class PeacockApp(object):
 
         self.main_widget = PeacockMainWindow()
         self.main_widget.initialize(parsed_args)
-        self.main_widget.setWindowTitle("Peacock")
         self.main_widget.show()
         self.main_widget.raise_()
 

--- a/python/peacock/PeacockMainWindow.py
+++ b/python/peacock/PeacockMainWindow.py
@@ -23,6 +23,7 @@ class PeacockMainWindow(BasePeacockMainWindow):
     def __init__(self, **kwds):
         super(PeacockMainWindow, self).__init__(plugins=self.PLUGINS, **kwds)
         self.setObjectName("PeacockMainWindow")
+        self.setWindowTitle("Peacock")
         self.console = PythonConsoleWidget()
         self.exe_path = ""
         self.input_file_path = ""
@@ -49,6 +50,7 @@ class PeacockMainWindow(BasePeacockMainWindow):
             # if the input file is set then it will change directory to where
             # it exists. We need to honor the command line switch for the working dir.
             self.tab_plugin.ExecuteTabPlugin.ExecuteOptionsPlugin.setWorkingDir(curr_dir)
+        self._setTitle()
 
     def _showConsole(self):
         """

--- a/python/peacock/tests/common/bad_mesh.i
+++ b/python/peacock/tests/common/bad_mesh.i
@@ -1,0 +1,48 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 20
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -148,5 +148,36 @@ class Tests(Testing.PeacockTester):
         self.check_current_tab(tabs, self.result.tabName())
         self.check_result()
 
+    def testBadMesh(self):
+        self.create_app(["../../common/bad_mesh.i", Testing.find_moose_test_exe(), "-w", os.getcwd()])
+        tabs = self.app.main_widget.tab_plugin
+        t = self.input.InputFileEditorPlugin.tree
+        self.check_current_tab(tabs, self.input.tabName())
+        self.assertEqual(self.input.vtkwin.isEnabled(), False)
+
+        # make sure highlighting doesn't crash peacock
+        bc = t.getBlockInfo("/BCs/left")
+        self.input.highlightChanged(bc)
+
+        # Disable the mesh block
+        mesh = t.getBlockInfo("/Mesh")
+        mesh.included = False
+        self.input.blockChanged(mesh)
+        self.assertEqual(self.input.vtkwin.isEnabled(), False) # still disabled
+
+        mesh.included = True
+        self.input.blockChanged(mesh)
+        self.assertEqual(self.input.vtkwin.isEnabled(), False) # still disabled
+
+        p = mesh.getParamInfo("dim")
+        p.value = '2'
+        self.input.blockChanged(mesh)
+        self.assertEqual(self.input.vtkwin.isEnabled(), True) # Mesh should be good now
+
+        # Disabling the mesh block should disable the mesh view
+        mesh.included = False
+        self.input.blockChanged(mesh)
+        self.assertEqual(self.input.vtkwin.isEnabled(), False)
+
 if __name__ == '__main__':
     Testing.run_tests()


### PR DESCRIPTION
On the peacock Input tab, previously when `--mesh-only` failed you got a message saying "No file selected" in the mesh window, which was confusing. Now it says "Error producing mesh". It also now correctly shows the loading screen when the mesh block is toggled off.

Fixed a bug when the mesh wasn't produced and the highlighter still trying to highlight. Since the renderer wasn't active it crashed.

Also fixed setting the window title when the executable and input file are specified on the command line.

closes #8975