### PR TITLE
Switch to gtest for MOOSE workshop tutorial unit tests

### DIFF
--- a/tutorials/darcy_thermo_mech/step01_diffusion/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/unit/Makefile
@@ -40,10 +40,9 @@ XFEM                      := no
 include           $(MOOSE_DIR)/modules/modules.mk
 ###############################################################################
 
-# Extra stuff for CPPUNIT
-CPPUNIT_DIR 		?= $(PACKAGES_DIR)/cppunit
-ADDITIONAL_INCLUDES 	:= -I$(CPPUNIT_DIR)/include
-ADDITIONAL_LIBS 	:= -L$(CPPUNIT_DIR)/lib -lcppunit
+# Extra stuff for GTEST
+ADDITIONAL_INCLUDES	:= -I$(FRAMEWORK_DIR)/contrib/gtest
+ADDITIONAL_LIBS 	:= $(FRAMEWORK_DIR)/contrib/gtest/libgtest.la
 
 # dep apps
 APPLICATION_DIR    := $(CURRENT_DIR)/..

--- a/tutorials/darcy_thermo_mech/step01_diffusion/unit/src/SampleTest.C
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/unit/src/SampleTest.C
@@ -12,28 +12,26 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-// Tutorial Includes
-#include "DarcyThermoMechApp.h"
-
-// Moose Includes
-#include "MooseInit.h"
-#include "Factory.h"
-#include "AppFactory.h"
-
-// Google Test includes
 #include "gtest/gtest.h"
 
-PerfLog Moose::perf_log("gtest");
-
-GTEST_API_ int
-main(int argc, char ** argv)
+TEST(MySampleTests, descriptiveTestName)
 {
-  // gtest removes (only) its args from argc and argv - so this must be before MooseInit
-  testing::InitGoogleTest(&argc, argv);
+  // compare equality
+  EXPECT_EQ(2, 1 + 1);
+  EXPECT_DOUBLE_EQ(2 * 3.5, 1.0 * 8 - 1);
 
-  MooseInit init(argc, argv);
-  registerApp(DarcyThermoMechApp);
-  Moose::_throw_on_error = true;
+  // compare equality and immediately terminate this test if it fails
+  // ASSERT_EQ(2, 1);
 
-  return RUN_ALL_TESTS();
+  // this won't run if you uncomment the above test because above assert will fail
+  ASSERT_NO_THROW(1 + 1);
+
+  // for a complete list of assertions and for more unit testing documentation see:
+  // https://github.com/google/googletest/blob/master/googletest/docs/Primer.md
+}
+
+TEST(MySampleTests, anotherTest)
+{
+  EXPECT_LE(1, 2);
+  // ...
 }

--- a/tutorials/darcy_thermo_mech/step02_darcy_pressure/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step02_darcy_pressure/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step02_darcy_pressure/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step02_darcy_pressure/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/unit/src/LinearInterpolationTest.C
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/unit/src/LinearInterpolationTest.C
@@ -1,0 +1,40 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+// MOOSE Includes
+#include "LinearInterpolation.h"
+
+// Google Test includes
+#include "gtest/gtest.h"
+
+TEST(LinearInterpolationTest, verifyLinearInterpolationObject)
+{
+  // Verify that the LinearInterpolation object in MOOSE works
+  // correctly for the parameter range of interest in this problem.
+  std::vector<double> x = {1, 3};
+  std::vector<double> y = {0.8451e-9, 8.968e-9};
+  LinearInterpolation interp(x, y);
+
+  // Make sure the number of samples matches.
+  ASSERT_EQ(interp.getSampleSize(), x.size());
+
+  // The linear interpolation should match at the endpoints.
+  EXPECT_DOUBLE_EQ(interp.sample(1.), 0.8451e-9);
+  EXPECT_DOUBLE_EQ(interp.sample(3.), 8.968e-9);
+
+  // Verify that the midpoint value is correct. This verification
+  // value is something we computed independently and are checking
+  // here.
+  EXPECT_DOUBLE_EQ(interp.sample(2), 4.90655e-09);
+}

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests

--- a/tutorials/darcy_thermo_mech/step09_mechanics/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step09_mechanics/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests

--- a/tutorials/darcy_thermo_mech/step10_multiapps/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/unit/Makefile
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/Makefile
+../../step01_diffusion/unit/Makefile

--- a/tutorials/darcy_thermo_mech/step10_multiapps/unit/run_tests
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/unit/run_tests
@@ -1,1 +1,1 @@
-../step01_diffusion/unit/run_tests
+../../step01_diffusion/unit/run_tests


### PR DESCRIPTION
Also fix broken links in the unit test directories of all the steps, guess we never actually used these before!

Continuation of work in #8897.
