### PR TITLE
Add porepressure_coefficient to SimpleFluidProperties enthalpy

### DIFF
--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -130,6 +130,9 @@ protected:
 
   /// Henry constant
   const Real _henry_constant;
+
+  /// Porepressure coefficient: enthalpy = internal_energy + porepressure / density * _pp_coeff
+  const Real _pp_coeff;
 };
 
 #endif /* SIMPLEFLUIDPROPERTIES_H */

--- a/modules/porous_flow/tests/newton_cooling/nc06.i
+++ b/modules/porous_flow/tests/newton_cooling/nc06.i
@@ -67,6 +67,7 @@
       thermal_expansion = 0
       viscosity = 1e-3
       cv = 1e6
+      porepressure_coefficient = 0
     [../]
   [../]
 []

--- a/unit/include/SimpleFluidPropertiesTest.h
+++ b/unit/include/SimpleFluidPropertiesTest.h
@@ -54,9 +54,14 @@ protected:
     problem_params.set<std::string>("_object_name") = "name2";
     _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
 
-    InputParameters uo_pars = _factory->getValidParams("SimpleFluidProperties");
-    _fe_problem->addUserObject("SimpleFluidProperties", "fp", uo_pars);
+    InputParameters uo_params = _factory->getValidParams("SimpleFluidProperties");
+    _fe_problem->addUserObject("SimpleFluidProperties", "fp", uo_params);
     _fp = &_fe_problem->getUserObject<SimpleFluidProperties>("fp");
+
+    InputParameters uo2_params = _factory->getValidParams("SimpleFluidProperties");
+    uo2_params.set<Real>("porepressure_coefficient") = 0.0;
+    _fe_problem->addUserObject("SimpleFluidProperties", "fp2", uo2_params);
+    _fp2 = &_fe_problem->getUserObject<SimpleFluidProperties>("fp2");
   }
 
   std::unique_ptr<MooseApp> _app;
@@ -64,6 +69,7 @@ protected:
   std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const SimpleFluidProperties * _fp;
+  const SimpleFluidProperties * _fp2;
 };
 
 #endif // SIMPLEFLUIDPROPERTIESTEST_H

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -28,6 +28,7 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   const Real visc = 1.0E-3;
   const Real density0 = 1000.0;
   const Real henry = 0.0;
+  const Real pp_coef = 0.0;
 
   Real P, T;
 
@@ -43,6 +44,7 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
   REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
   REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
+  REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
   ABS_TEST("henry", _fp->henryConstant(T), henry, 1.0E-8);
 
   P = 1E7;
@@ -57,6 +59,7 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
   REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
   REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
+  REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
   ABS_TEST("henry", _fp->henryConstant(T), henry, 1.0E-8);
 }
 
@@ -132,6 +135,11 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   REL_TEST("dh_dP", dh_dp, fd, 1.0E-8);
   fd = (_fp->h(P, T + dT) - _fp->h(P, T - dT)) / (2.0 * dT);
   REL_TEST("dh_dT", dh_dT, fd, 1.0E-8);
+  _fp2->h_dpT(P, T, h, dh_dp, dh_dT);
+  fd = (_fp2->h(P + dP, T) - _fp2->h(P - dP, T)) / (2.0 * dP);
+  ABS_TEST("dh_dP", dh_dp, fd, 1.0E-8);
+  fd = (_fp2->h(P, T + dT) - _fp2->h(P, T - dT)) / (2.0 * dT);
+  REL_TEST("dh_dT", dh_dT, fd, 1.0E-8);
 
   P = 4E6;
   T = 90;
@@ -139,5 +147,10 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   fd = (_fp->h(P + dP, T) - _fp->h(P - dP, T)) / (2.0 * dP);
   REL_TEST("dh_dP", dh_dp, fd, 1.0E-8);
   fd = (_fp->h(P, T + dT) - _fp->h(P, T - dT)) / (2.0 * dT);
+  REL_TEST("dh_dT", dh_dT, fd, 1.0E-8);
+  _fp2->h_dpT(P, T, h, dh_dp, dh_dT);
+  fd = (_fp2->h(P + dP, T) - _fp2->h(P - dP, T)) / (2.0 * dP);
+  ABS_TEST("dh_dP", dh_dp, fd, 1.0E-8);
+  fd = (_fp2->h(P, T + dT) - _fp2->h(P, T - dT)) / (2.0 * dT);
   REL_TEST("dh_dT", dh_dT, fd, 1.0E-8);
 }


### PR DESCRIPTION
Following discussion in #8973, adds an optional coefficient in `SimpleFluidProperties` that scales the `pressure / density` term in the enthalpy calculation, allowing a simplified enthalpy to be calculated. This is useful for comparison to analytical solutions.

The unit test for `SimpleFluidProperties` is also updated to verify that the enthalpy and its derivatives wrt pressure and temperature are correctly calculated.

I also added `porepressure_coefficient = 0` back in `porous_flow/tests/newton_cooling/nco6.i` (which was removed in #8973). Due to the size of `cv`, however, the `pressure / density` contribution to enthalpy is small, and this test doesn't diff when this is included. But it is noted in the documentation that this has enthalpy = internal energy, so it should be in the test for consistency.

Refs #8962