### PR TITLE
Fix failing heavy test in PorousFlow

### DIFF
--- a/modules/porous_flow/tests/dispersion/disp01_heavy.i
+++ b/modules/porous_flow/tests/dispersion/disp01_heavy.i
@@ -8,13 +8,13 @@
   dim = 1
   nx = 200
   xmax = 10
-  compute_enthalpy = false
-  compute_internal_energy = false
 []
 
 [GlobalParams]
   PorousFlowDictator = dictator
   gravity = '0 0 0'
+  compute_enthalpy = false
+  compute_internal_energy = false
 []
 
 [Variables]


### PR DESCRIPTION
Two parameters were accidentally pasted into the Mesh block instead of GlobalParams block of one of the heavy tests as part of the changes to the tests in #8962 - causing an unused parameter error when run with the `--error` flag.

Thanks @brianmoose for pointing this out
Refs #8962  