### PR TITLE
make required field in Json output a proper bool

### DIFF
--- a/framework/src/outputs/formatters/JsonInputFileFormatter.C
+++ b/framework/src/outputs/formatters/JsonInputFileFormatter.C
@@ -160,7 +160,7 @@ JsonInputFileFormatter::addParameters(const moosecontrib::Json::Value & params)
       def = "'" + def + "'";
     std::string indent(max_name - name.size(), ' ');
     std::string required;
-    if (param["required"].asString() == "Yes")
+    if (param["required"].asBool())
       required = "(required)";
     std::string l = name + indent + " = " + def + required;
     if (l.size() > max_len)

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -106,10 +106,7 @@ JsonSyntaxTree::addParameters(const std::string & parent,
     ++count;
     moosecontrib::Json::Value param_json;
 
-    // Block params may be required and will have a doc string
-    std::string required = params->isParamRequired(iter.first) ? "Yes" : "No";
-
-    param_json["required"] = required;
+    param_json["required"] = params->isParamRequired(iter.first);
 
     // Only output default if it has one
     if (params->isParamValid(iter.first))

--- a/python/peacock/Input/ParameterInfo.py
+++ b/python/peacock/Input/ParameterInfo.py
@@ -34,7 +34,7 @@ class ParameterInfo(object):
         self.group_name = data["group_name"]
         if not self.group_name:
             self.group_name = "Main"
-        self.required = data["required"] == "Yes"
+        self.required = data["required"]
         self.name = data["name"]
         self.options = data.get("options", "")
         if self.options:

--- a/python/peacock/tests/input_tab/ParameterInfo/test_ParameterInfo.py
+++ b/python/peacock/tests/input_tab/ParameterInfo/test_ParameterInfo.py
@@ -11,7 +11,7 @@ class Tests(Testing.PeacockTester):
             basic_type="String",
             description="",
             group_name="",
-            required="Yes",
+            required=True,
             options="",
             ):
         return {"name": name,
@@ -48,7 +48,7 @@ class Tests(Testing.PeacockTester):
 
     def testBasic(self):
         p = ParameterInfo(None, "p0")
-        y = self.createData("p1", default="foo", cpp_type="some type", description="description", group_name="group", required="Yes")
+        y = self.createData("p1", default="foo", cpp_type="some type", description="description", group_name="group", required=True)
         p.setFromData(y)
         y["default"] = "foo"
         self.checkParameter(p, "p1", value="foo", default="foo", cpp_type="some type", description="description", group_name="group", required=True)


### PR DESCRIPTION
Currently the `required` field in the Json output is set to Yes/No which was copied over from the YAML output. It makes a lot more sense to make it a proper boolean.