### PR TITLE
Force some tests to ReplicatedMesh

### DIFF
--- a/test/tests/constraints/coupled_tied_value_constraint/coupled_tied_value_constraint.i
+++ b/test/tests/constraints/coupled_tied_value_constraint/coupled_tied_value_constraint.i
@@ -1,6 +1,9 @@
 [Mesh]
   type = FileMesh
   file = split_blocks.e
+  # NearestNodeLocator, which is needed by CoupledTiedValueConstraint,
+  # only works with ReplicatedMesh currently
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/controls/time_periods/constraints/constraints.i
+++ b/test/tests/controls/time_periods/constraints/constraints.i
@@ -1,6 +1,9 @@
 [Mesh]
   type = FileMesh
   file = constraints.e
+  # NearestNodeLocator, which is needed by TiedValueConstraint,
+  # only works with ReplicatedMesh currently
+  parallel_type = replicated
 [../]
 
 [Variables]

--- a/test/tests/mesh_modifiers/assign_element_subdomain_id/quad_with_subdomainid_test.i
+++ b/test/tests/mesh_modifiers/assign_element_subdomain_id/quad_with_subdomainid_test.i
@@ -7,6 +7,9 @@
   zmin = 0
   zmax = 0
   elem_type = QUAD4
+  # AssignElementSubdomainID only works with ReplicatedMesh and/or
+  # with element_ids set.
+  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/assign_element_subdomain_id/tri_with_subdomainid_test.i
+++ b/test/tests/mesh_modifiers/assign_element_subdomain_id/tri_with_subdomainid_test.i
@@ -7,6 +7,9 @@
   zmin = 0
   zmax = 0
   elem_type = TRI3
+  # AssignElementSubdomainID only works with ReplicatedMesh and/or
+  # with element_ids set.
+  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/sidesets_between_subdomains/sidesets_between_vectors_of_subdomains.i
+++ b/test/tests/mesh_modifiers/sidesets_between_subdomains/sidesets_between_vectors_of_subdomains.i
@@ -7,6 +7,9 @@
   zmin = 0
   zmax = 0
   elem_type = QUAD4
+  # AssignElementSubdomainID only works with ReplicatedMesh and/or
+  # with element_ids set.
+  parallel_type = replicated
 []
 
 [MeshModifiers]


### PR DESCRIPTION
We're getting close enough to full --distributed-mesh compatibility
that we should start disabling the straggling tests, so we can get
this into CI and avoid regressions on the things that have already
been fixed.

Workaround for some #1500 failures