### PR TITLE
Close solution in NodalNormalsPreprocessor

### DIFF
--- a/framework/src/userobject/NodalNormalsPreprocessor.C
+++ b/framework/src/userobject/NodalNormalsPreprocessor.C
@@ -60,6 +60,8 @@ NodalNormalsPreprocessor::initialize()
   _aux.system().zero_variable(sln, _aux.getVariable(_tid, "nodal_normal_x").number());
   _aux.system().zero_variable(sln, _aux.getVariable(_tid, "nodal_normal_y").number());
   _aux.system().zero_variable(sln, _aux.getVariable(_tid, "nodal_normal_z").number());
+  // After zero variables, we should close the solution
+  sln.close();
 }
 
 void


### PR DESCRIPTION
There are two stages in `NodalNormalsPreprocessor`; `initialize()` and `execute()`.

In` initialize()`, we zero variables by calling `VecSetValues` with `INSERT_VALUES` to insert values.

In `execute()`, we add values by calling `VecSetValues` with `ADD_VALUES` to add values. Before add values, we should call `solution.close()` to flush the cached values to the right place. 


Refs #9003
