### PR TITLE
In INS, switch from Real properties (mu, rho, k, cp...) to MaterialProperty<Real>

### DIFF
--- a/modules/navier_stokes/include/bcs/INSMomentumNoBCBCBase.h
+++ b/modules/navier_stokes/include/bcs/INSMomentumNoBCBCBase.h
@@ -50,12 +50,12 @@ protected:
   unsigned _w_vel_var_number;
   unsigned _p_var_number;
 
-  const MaterialProperty<Real> & _mu;
-  const MaterialProperty<Real> & _rho;
   RealVectorValue _gravity;
-
   unsigned _component;
   bool _integrate_p_by_parts;
+
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif

--- a/modules/navier_stokes/include/bcs/INSMomentumNoBCBCBase.h
+++ b/modules/navier_stokes/include/bcs/INSMomentumNoBCBCBase.h
@@ -50,8 +50,8 @@ protected:
   unsigned _w_vel_var_number;
   unsigned _p_var_number;
 
-  Real _mu;
-  Real _rho;
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
   RealVectorValue _gravity;
 
   unsigned _component;

--- a/modules/navier_stokes/include/bcs/INSTemperatureNoBCBC.h
+++ b/modules/navier_stokes/include/bcs/INSTemperatureNoBCBC.h
@@ -31,7 +31,7 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
-  Real _k;
+  const MaterialProperty<Real> & _k;
 };
 
 #endif // INSTEMPERATURENOBCBC_H

--- a/modules/navier_stokes/include/kernels/INSChorinCorrector.h
+++ b/modules/navier_stokes/include/kernels/INSChorinCorrector.h
@@ -45,11 +45,11 @@ protected:
   unsigned _w_vel_star_var_number;
   unsigned _p_var_number;
 
-  // Material properties
-  const MaterialProperty<Real> & _rho;
-
   // Parameters
   unsigned _component;
+
+  // Material properties
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif // INSCHORINCORRECTOR_H

--- a/modules/navier_stokes/include/kernels/INSChorinCorrector.h
+++ b/modules/navier_stokes/include/kernels/INSChorinCorrector.h
@@ -46,7 +46,7 @@ protected:
   unsigned _p_var_number;
 
   // Material properties
-  Real _rho;
+  const MaterialProperty<Real> & _rho;
 
   // Parameters
   unsigned _component;

--- a/modules/navier_stokes/include/kernels/INSChorinPredictor.h
+++ b/modules/navier_stokes/include/kernels/INSChorinPredictor.h
@@ -71,10 +71,6 @@ protected:
   unsigned _v_vel_star_var_number;
   unsigned _w_vel_star_var_number;
 
-  // Material properties
-  const MaterialProperty<Real> & _mu;
-  const MaterialProperty<Real> & _rho;
-
   // Parameters
   unsigned _component;
 
@@ -97,6 +93,10 @@ protected:
     NEW = 1,
     STAR = 2
   };
+
+  // Material properties
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif // INSCHORINPREDICTOR_H

--- a/modules/navier_stokes/include/kernels/INSChorinPredictor.h
+++ b/modules/navier_stokes/include/kernels/INSChorinPredictor.h
@@ -72,8 +72,8 @@ protected:
   unsigned _w_vel_star_var_number;
 
   // Material properties
-  Real _mu;
-  Real _rho;
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
 
   // Parameters
   unsigned _component;

--- a/modules/navier_stokes/include/kernels/INSChorinPressurePoisson.h
+++ b/modules/navier_stokes/include/kernels/INSChorinPressurePoisson.h
@@ -43,7 +43,7 @@ protected:
   unsigned _w_vel_star_var_number;
 
   // Material properties
-  Real _rho;
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif // INSCHORINPRESSUREPOISSON_H

--- a/modules/navier_stokes/include/kernels/INSMomentumBase.h
+++ b/modules/navier_stokes/include/kernels/INSMomentumBase.h
@@ -65,8 +65,8 @@ protected:
 
   // Material properties
   // MaterialProperty<Real> & _dynamic_viscosity;
-  Real _mu;
-  Real _rho;
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
   RealVectorValue _gravity;
 
   // Parameters

--- a/modules/navier_stokes/include/kernels/INSMomentumBase.h
+++ b/modules/navier_stokes/include/kernels/INSMomentumBase.h
@@ -63,15 +63,14 @@ protected:
   unsigned _w_vel_var_number;
   unsigned _p_var_number;
 
-  // Material properties
-  // MaterialProperty<Real> & _dynamic_viscosity;
-  const MaterialProperty<Real> & _mu;
-  const MaterialProperty<Real> & _rho;
-  RealVectorValue _gravity;
-
   // Parameters
+  RealVectorValue _gravity;
   unsigned _component;
   bool _integrate_p_by_parts;
+
+  // Material properties
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif

--- a/modules/navier_stokes/include/kernels/INSMomentumTimeDerivative.h
+++ b/modules/navier_stokes/include/kernels/INSMomentumTimeDerivative.h
@@ -33,7 +33,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Parameters
-  Real _rho;
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif // INSMOMENTUMTIMEDERIVATIVE_H

--- a/modules/navier_stokes/include/kernels/INSPressurePoisson.h
+++ b/modules/navier_stokes/include/kernels/INSPressurePoisson.h
@@ -45,7 +45,7 @@ protected:
   unsigned _a3_var_number;
 
   // Material properties
-  Real _rho;
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif // INSPRESSUREPOISSON_H

--- a/modules/navier_stokes/include/kernels/INSProjection.h
+++ b/modules/navier_stokes/include/kernels/INSProjection.h
@@ -48,11 +48,11 @@ protected:
   unsigned _a3_var_number;
   unsigned _p_var_number;
 
-  // Material properties
-  const MaterialProperty<Real> & _rho;
-
   // Parameters
   unsigned _component;
+
+  // Material properties
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif // INSPROJECTION_H

--- a/modules/navier_stokes/include/kernels/INSProjection.h
+++ b/modules/navier_stokes/include/kernels/INSProjection.h
@@ -49,7 +49,7 @@ protected:
   unsigned _p_var_number;
 
   // Material properties
-  Real _rho;
+  const MaterialProperty<Real> & _rho;
 
   // Parameters
   unsigned _component;

--- a/modules/navier_stokes/include/kernels/INSSplitMomentum.h
+++ b/modules/navier_stokes/include/kernels/INSSplitMomentum.h
@@ -61,13 +61,13 @@ protected:
   unsigned _a2_var_number;
   unsigned _a3_var_number;
 
+  // Parameters
+  RealVectorValue _gravity;
+  unsigned _component;
+
   // Material properties
   const MaterialProperty<Real> & _mu;
   const MaterialProperty<Real> & _rho;
-  RealVectorValue _gravity;
-
-  // Parameters
-  unsigned _component;
 };
 
 #endif // INSSPLITMOMENTUM_H

--- a/modules/navier_stokes/include/kernels/INSSplitMomentum.h
+++ b/modules/navier_stokes/include/kernels/INSSplitMomentum.h
@@ -62,8 +62,8 @@ protected:
   unsigned _a3_var_number;
 
   // Material properties
-  Real _mu;
-  Real _rho;
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
   RealVectorValue _gravity;
 
   // Parameters

--- a/modules/navier_stokes/include/kernels/INSTemperature.h
+++ b/modules/navier_stokes/include/kernels/INSTemperature.h
@@ -42,9 +42,9 @@ protected:
   unsigned _w_vel_var_number;
 
   // Required parameters
-  Real _rho;
-  Real _k;
-  Real _cp;
+  const MaterialProperty<Real> & _rho;
+  const MaterialProperty<Real> & _k;
+  const MaterialProperty<Real> & _cp;
 };
 
 #endif // INSTEMPERATURE_H

--- a/modules/navier_stokes/include/kernels/INSTemperatureTimeDerivative.h
+++ b/modules/navier_stokes/include/kernels/INSTemperatureTimeDerivative.h
@@ -33,8 +33,8 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Parameters
-  Real _rho;
-  Real _cp;
+  const MaterialProperty<Real> & _rho;
+  const MaterialProperty<Real> & _cp;
 };
 
 #endif // INSTEMPERATURETIMEDERIVATIVE_H

--- a/modules/navier_stokes/include/postprocessors/INSExplicitTimestepSelector.h
+++ b/modules/navier_stokes/include/postprocessors/INSExplicitTimestepSelector.h
@@ -38,8 +38,8 @@ protected:
 
   /// Material properties:  the explicit time scheme limit for the viscous
   /// problem also depends on the kinematic viscosity.
-  Real _mu;
-  Real _rho;
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
 
   /// We can compute maximum stable timesteps based on the linearized
   /// theory, but even those timesteps are sometimes still too large

--- a/modules/navier_stokes/include/postprocessors/INSExplicitTimestepSelector.h
+++ b/modules/navier_stokes/include/postprocessors/INSExplicitTimestepSelector.h
@@ -36,17 +36,17 @@ protected:
   /// Velocity magnitude.  Hint: Use VectorMagnitudeAux in Moose for this
   const VariableValue & _vel_mag;
 
-  /// Material properties:  the explicit time scheme limit for the viscous
-  /// problem also depends on the kinematic viscosity.
-  const MaterialProperty<Real> & _mu;
-  const MaterialProperty<Real> & _rho;
-
   /// We can compute maximum stable timesteps based on the linearized
   /// theory, but even those timesteps are sometimes still too large
   /// for explicit timestepping in a "real" problem.  Therefore, we
   /// provide an additional "fudge" factor, 0 < beta < 1, that can be
   /// used to reduce the selected timestep even further.
   Real _beta;
+
+  /// Material properties:  the explicit time scheme limit for the viscous
+  /// problem also depends on the kinematic viscosity.
+  const MaterialProperty<Real> & _mu;
+  const MaterialProperty<Real> & _rho;
 };
 
 #endif /* INSEXPLICITTIMESTEPSELECTOR_H */

--- a/modules/navier_stokes/src/bcs/INSMomentumNoBCBCBase.C
+++ b/modules/navier_stokes/src/bcs/INSMomentumNoBCBCBase.C
@@ -22,8 +22,6 @@ validParams<INSMomentumNoBCBCBase>()
   params.addRequiredCoupledVar("p", "pressure");
 
   // Required parameters
-  params.addRequiredParam<Real>("mu", "dynamic viscosity");
-  params.addRequiredParam<Real>("rho", "density");
   params.addRequiredParam<RealVectorValue>("gravity", "Direction of the gravity vector");
   params.addRequiredParam<unsigned>(
       "component",
@@ -31,6 +29,10 @@ validParams<INSMomentumNoBCBCBase>()
   params.addParam<bool>("integrate_p_by_parts",
                         true,
                         "Allows simulations to be run with pressure BC if set to false");
+
+  // Optional parameters
+  params.addParam<MaterialPropertyName>("mu_name", "mu", "The name of the dynamic viscosity");
+  params.addParam<MaterialPropertyName>("rho_name", "rho", "The name of the density");
 
   return params;
 }
@@ -56,10 +58,12 @@ INSMomentumNoBCBCBase::INSMomentumNoBCBCBase(const InputParameters & parameters)
     _p_var_number(coupled("p")),
 
     // Required parameters
-    _mu(getParam<Real>("mu")),
-    _rho(getParam<Real>("rho")),
     _gravity(getParam<RealVectorValue>("gravity")),
     _component(getParam<unsigned>("component")),
-    _integrate_p_by_parts(getParam<bool>("integrate_p_by_parts"))
+    _integrate_p_by_parts(getParam<bool>("integrate_p_by_parts")),
+
+    // Material properties
+    _mu(getMaterialProperty<Real>("mu_name")),
+    _rho(getMaterialProperty<Real>("rho_name"))
 {
 }

--- a/modules/navier_stokes/src/bcs/INSMomentumNoBCBCLaplaceForm.C
+++ b/modules/navier_stokes/src/bcs/INSMomentumNoBCBCLaplaceForm.C
@@ -28,7 +28,7 @@ Real
 INSMomentumNoBCBCLaplaceForm::computeQpResidual()
 {
   // -mu * (grad(u).n) * test
-  Real viscous_part = -_mu * (_grad_u[_qp] * _normals[_qp]) * _test[_i][_qp];
+  Real viscous_part = -_mu[_qp] * (_grad_u[_qp] * _normals[_qp]) * _test[_i][_qp];
 
   // pIn * test
   Real pressure_part = 0.;
@@ -41,7 +41,7 @@ INSMomentumNoBCBCLaplaceForm::computeQpResidual()
 Real
 INSMomentumNoBCBCLaplaceForm::computeQpJacobian()
 {
-  return -_mu * (_grad_phi[_j][_qp] * _normals[_qp]) * _test[_i][_qp];
+  return -_mu[_qp] * (_grad_phi[_j][_qp] * _normals[_qp]) * _test[_i][_qp];
 }
 
 Real

--- a/modules/navier_stokes/src/bcs/INSMomentumNoBCBCTractionForm.C
+++ b/modules/navier_stokes/src/bcs/INSMomentumNoBCBCTractionForm.C
@@ -31,19 +31,19 @@ INSMomentumNoBCBCTractionForm::computeQpResidual()
   RealTensorValue sigma;
 
   // First row
-  sigma(0, 0) = 2. * _mu * _grad_u_vel[_qp](0);
-  sigma(0, 1) = _mu * (_grad_u_vel[_qp](1) + _grad_v_vel[_qp](0));
-  sigma(0, 2) = _mu * (_grad_u_vel[_qp](2) + _grad_w_vel[_qp](0));
+  sigma(0, 0) = 2. * _mu[_qp] * _grad_u_vel[_qp](0);
+  sigma(0, 1) = _mu[_qp] * (_grad_u_vel[_qp](1) + _grad_v_vel[_qp](0));
+  sigma(0, 2) = _mu[_qp] * (_grad_u_vel[_qp](2) + _grad_w_vel[_qp](0));
 
   // Second row
-  sigma(1, 0) = _mu * (_grad_v_vel[_qp](0) + _grad_u_vel[_qp](1));
-  sigma(1, 1) = 2. * _mu * _grad_v_vel[_qp](1);
-  sigma(1, 2) = _mu * (_grad_v_vel[_qp](2) + _grad_w_vel[_qp](1));
+  sigma(1, 0) = _mu[_qp] * (_grad_v_vel[_qp](0) + _grad_u_vel[_qp](1));
+  sigma(1, 1) = 2. * _mu[_qp] * _grad_v_vel[_qp](1);
+  sigma(1, 2) = _mu[_qp] * (_grad_v_vel[_qp](2) + _grad_w_vel[_qp](1));
 
   // Third row
-  sigma(2, 0) = _mu * (_grad_w_vel[_qp](0) + _grad_u_vel[_qp](2));
-  sigma(2, 1) = _mu * (_grad_w_vel[_qp](1) + _grad_v_vel[_qp](2));
-  sigma(2, 2) = 2. * _mu * _grad_w_vel[_qp](2);
+  sigma(2, 0) = _mu[_qp] * (_grad_w_vel[_qp](0) + _grad_u_vel[_qp](2));
+  sigma(2, 1) = _mu[_qp] * (_grad_w_vel[_qp](1) + _grad_v_vel[_qp](2));
+  sigma(2, 2) = 2. * _mu[_qp] * _grad_w_vel[_qp](2);
 
   // If the pressure term is integrated by parts, it is part of the
   // no-BC-BC, otherwise, it is not.
@@ -65,8 +65,8 @@ Real
 INSMomentumNoBCBCTractionForm::computeQpJacobian()
 {
   // The extra contribution comes from the "2" on the diagonal of the viscous stress tensor
-  return -_mu * (_grad_phi[_j][_qp] * _normals[_qp] +
-                 _grad_phi[_j][_qp](_component) * _normals[_qp](_component)) *
+  return -_mu[_qp] * (_grad_phi[_j][_qp] * _normals[_qp] +
+                      _grad_phi[_j][_qp](_component) * _normals[_qp](_component)) *
          _test[_i][_qp];
 }
 
@@ -74,13 +74,13 @@ Real
 INSMomentumNoBCBCTractionForm::computeQpOffDiagJacobian(unsigned jvar)
 {
   if (jvar == _u_vel_var_number)
-    return -_mu * _grad_phi[_j][_qp](_component) * _normals[_qp](0) * _test[_i][_qp];
+    return -_mu[_qp] * _grad_phi[_j][_qp](_component) * _normals[_qp](0) * _test[_i][_qp];
 
   else if (jvar == _v_vel_var_number)
-    return -_mu * _grad_phi[_j][_qp](_component) * _normals[_qp](1) * _test[_i][_qp];
+    return -_mu[_qp] * _grad_phi[_j][_qp](_component) * _normals[_qp](1) * _test[_i][_qp];
 
   else if (jvar == _w_vel_var_number)
-    return -_mu * _grad_phi[_j][_qp](_component) * _normals[_qp](2) * _test[_i][_qp];
+    return -_mu[_qp] * _grad_phi[_j][_qp](_component) * _normals[_qp](2) * _test[_i][_qp];
 
   else if (jvar == _p_var_number)
   {

--- a/modules/navier_stokes/src/bcs/INSTemperatureNoBCBC.C
+++ b/modules/navier_stokes/src/bcs/INSTemperatureNoBCBC.C
@@ -15,15 +15,15 @@ validParams<INSTemperatureNoBCBC>()
   params.addClassDescription("This class implements the 'No BC' boundary condition discussed by "
                              "Griffiths, Papanastiou, and others.");
   // Required parameters
-  params.addRequiredParam<Real>("k", "thermal conductivity");
+  params.addParam<MaterialPropertyName>("k_name", "k", "thermal conductivity_name");
 
   return params;
 }
 
 INSTemperatureNoBCBC::INSTemperatureNoBCBC(const InputParameters & parameters)
   : IntegratedBC(parameters),
-    // Required parameters
-    _k(getParam<Real>("k"))
+    // Material property
+    _k(getMaterialProperty<Real>("k_name"))
 {
 }
 
@@ -31,13 +31,13 @@ Real
 INSTemperatureNoBCBC::computeQpResidual()
 {
   // k * (grad_T.n) * test
-  return _k * _grad_u[_qp] * _normals[_qp] * _test[_i][_qp];
+  return _k[_qp] * _grad_u[_qp] * _normals[_qp] * _test[_i][_qp];
 }
 
 Real
 INSTemperatureNoBCBC::computeQpJacobian()
 {
-  return _k * (_grad_phi[_j][_qp] * _normals[_qp]) * _test[_i][_qp];
+  return _k[_qp] * (_grad_phi[_j][_qp] * _normals[_qp]) * _test[_i][_qp];
 }
 
 Real

--- a/modules/navier_stokes/src/kernels/INSChorinPressurePoisson.C
+++ b/modules/navier_stokes/src/kernels/INSChorinPressurePoisson.C
@@ -22,8 +22,8 @@ validParams<INSChorinPressurePoisson>()
   params.addCoupledVar("v_star", "star y-velocity"); // only required in 2D and 3D
   params.addCoupledVar("w_star", "star z-velocity"); // only required in 3D
 
-  // Required parameters
-  params.addRequiredParam<Real>("rho", "density");
+  // Optional parameters
+  params.addParam<MaterialPropertyName>("rho_name", "rho", "density_name");
 
   return params;
 }
@@ -41,8 +41,8 @@ INSChorinPressurePoisson::INSChorinPressurePoisson(const InputParameters & param
     _v_vel_star_var_number(_mesh.dimension() >= 2 ? coupled("v_star") : libMesh::invalid_uint),
     _w_vel_star_var_number(_mesh.dimension() == 3 ? coupled("w_star") : libMesh::invalid_uint),
 
-    // Required parameters
-    _rho(getParam<Real>("rho"))
+    // Material properties
+    _rho(getMaterialProperty<Real>("rho_name"))
 {
 }
 
@@ -53,7 +53,7 @@ INSChorinPressurePoisson::computeQpResidual()
   Real laplacian_part = _grad_u[_qp] * _grad_test[_i][_qp];
 
   // Divergence part, don't forget to *divide* by _dt
-  Real div_part = (_rho / _dt) *
+  Real div_part = (_rho[_qp] / _dt) *
                   (_grad_u_star[_qp](0) + _grad_v_star[_qp](1) + _grad_w_star[_qp](2)) *
                   _test[_i][_qp];
 
@@ -71,13 +71,13 @@ Real
 INSChorinPressurePoisson::computeQpOffDiagJacobian(unsigned jvar)
 {
   if (jvar == _u_vel_star_var_number)
-    return (_rho / _dt) * _grad_phi[_j][_qp](0) * _test[_i][_qp];
+    return (_rho[_qp] / _dt) * _grad_phi[_j][_qp](0) * _test[_i][_qp];
 
   else if (jvar == _v_vel_star_var_number)
-    return (_rho / _dt) * _grad_phi[_j][_qp](1) * _test[_i][_qp];
+    return (_rho[_qp] / _dt) * _grad_phi[_j][_qp](1) * _test[_i][_qp];
 
   else if (jvar == _w_vel_star_var_number)
-    return (_rho / _dt) * _grad_phi[_j][_qp](2) * _test[_i][_qp];
+    return (_rho[_qp] / _dt) * _grad_phi[_j][_qp](2) * _test[_i][_qp];
 
   else
     return 0;

--- a/modules/navier_stokes/src/kernels/INSMomentumLaplaceForm.C
+++ b/modules/navier_stokes/src/kernels/INSMomentumLaplaceForm.C
@@ -25,14 +25,14 @@ Real
 INSMomentumLaplaceForm::computeQpResidualViscousPart()
 {
   // Simplified version: mu * Laplacian(u_component)
-  return _mu * (_grad_u[_qp] * _grad_test[_i][_qp]);
+  return _mu[_qp] * (_grad_u[_qp] * _grad_test[_i][_qp]);
 }
 
 Real
 INSMomentumLaplaceForm::computeQpJacobianViscousPart()
 {
   // Viscous part, Laplacian version
-  return _mu * (_grad_phi[_j][_qp] * _grad_test[_i][_qp]);
+  return _mu[_qp] * (_grad_phi[_j][_qp] * _grad_test[_i][_qp]);
 }
 
 Real

--- a/modules/navier_stokes/src/kernels/INSMomentumLaplaceFormRZ.C
+++ b/modules/navier_stokes/src/kernels/INSMomentumLaplaceFormRZ.C
@@ -35,7 +35,7 @@ INSMomentumLaplaceFormRZ::computeQpResidual()
 
     // If this is the radial component of momentum, there is an extra term for RZ.
     // The only difference between this and the traction form is a factor of 2.
-    res_base += _mu * _u_vel[_qp] / (r * r) * _test[_i][_qp];
+    res_base += _mu[_qp] * _u_vel[_qp] / (r * r) * _test[_i][_qp];
 
     // If the pressure is also integrated by parts, there is an extra term in RZ.
     if (_integrate_p_by_parts)
@@ -56,7 +56,7 @@ INSMomentumLaplaceFormRZ::computeQpJacobian()
   {
     const Real r = _q_point[_qp](0);
     // The only difference between this and the traction form is a factor of 2.
-    jac_base += _mu * _phi[_j][_qp] * _test[_i][_qp] / (r * r);
+    jac_base += _mu[_qp] * _phi[_j][_qp] * _test[_i][_qp] / (r * r);
   }
 
   return jac_base;

--- a/modules/navier_stokes/src/kernels/INSMomentumTimeDerivative.C
+++ b/modules/navier_stokes/src/kernels/INSMomentumTimeDerivative.C
@@ -13,25 +13,25 @@ validParams<INSMomentumTimeDerivative>()
   InputParameters params = validParams<TimeDerivative>();
   params.addClassDescription("This class computes the time derivative for the incompressible "
                              "Navier-Stokes momentum equation.");
-  params.addRequiredParam<Real>("rho", "density");
+  params.addParam<MaterialPropertyName>("rho_name", "rho", "density name");
   return params;
 }
 
 INSMomentumTimeDerivative::INSMomentumTimeDerivative(const InputParameters & parameters)
-  : TimeDerivative(parameters), _rho(getParam<Real>("rho"))
+  : TimeDerivative(parameters), _rho(getMaterialProperty<Real>("rho_name"))
 {
 }
 
 Real
 INSMomentumTimeDerivative::computeQpResidual()
 {
-  return _rho * TimeDerivative::computeQpResidual();
+  return _rho[_qp] * TimeDerivative::computeQpResidual();
 }
 
 Real
 INSMomentumTimeDerivative::computeQpJacobian()
 {
-  return _rho * TimeDerivative::computeQpJacobian();
+  return _rho[_qp] * TimeDerivative::computeQpJacobian();
 }
 
 Real

--- a/modules/navier_stokes/src/kernels/INSMomentumTractionForm.C
+++ b/modules/navier_stokes/src/kernels/INSMomentumTractionForm.C
@@ -51,8 +51,8 @@ INSMomentumTractionForm::computeQpResidualViscousPart()
       mooseError("Unrecognized _component requested.");
   }
 
-  // The viscous part, _mu * tau : grad(v)
-  return _mu * (tau_row * _grad_test[_i][_qp]);
+  // The viscous part, _mu[_qp] * tau : grad(v)
+  return _mu[_qp] * (tau_row * _grad_test[_i][_qp]);
 }
 
 Real
@@ -60,8 +60,8 @@ INSMomentumTractionForm::computeQpJacobianViscousPart()
 {
   // Viscous part, full stress tensor.  The extra contribution comes from the "2"
   // on the diagonal of the viscous stress tensor.
-  return _mu * (_grad_phi[_j][_qp] * _grad_test[_i][_qp] +
-                _grad_phi[_j][_qp](_component) * _grad_test[_i][_qp](_component));
+  return _mu[_qp] * (_grad_phi[_j][_qp] * _grad_test[_i][_qp] +
+                     _grad_phi[_j][_qp](_component) * _grad_test[_i][_qp](_component));
 }
 
 Real
@@ -69,13 +69,13 @@ INSMomentumTractionForm::computeQpOffDiagJacobianViscousPart(unsigned jvar)
 {
   // In Stokes/Laplacian version, off-diag Jacobian entries wrt u,v,w are zero
   if (jvar == _u_vel_var_number)
-    return _mu * _grad_phi[_j][_qp](_component) * _grad_test[_i][_qp](0);
+    return _mu[_qp] * _grad_phi[_j][_qp](_component) * _grad_test[_i][_qp](0);
 
   else if (jvar == _v_vel_var_number)
-    return _mu * _grad_phi[_j][_qp](_component) * _grad_test[_i][_qp](1);
+    return _mu[_qp] * _grad_phi[_j][_qp](_component) * _grad_test[_i][_qp](1);
 
   else if (jvar == _w_vel_var_number)
-    return _mu * _grad_phi[_j][_qp](_component) * _grad_test[_i][_qp](2);
+    return _mu[_qp] * _grad_phi[_j][_qp](_component) * _grad_test[_i][_qp](2);
 
   else
     return 0;

--- a/modules/navier_stokes/src/kernels/INSMomentumTractionFormRZ.C
+++ b/modules/navier_stokes/src/kernels/INSMomentumTractionFormRZ.C
@@ -33,7 +33,7 @@ INSMomentumTractionFormRZ::computeQpResidual()
     const Real r = _q_point[_qp](0);
 
     // If this is the radial component of momentum, there is an extra term for RZ.
-    res_base += 2. * _mu * _u_vel[_qp] / (r * r) * _test[_i][_qp];
+    res_base += 2. * _mu[_qp] * _u_vel[_qp] / (r * r) * _test[_i][_qp];
 
     // If the pressure is also integrated by parts, there is an extra term in RZ.
     if (_integrate_p_by_parts)
@@ -53,7 +53,7 @@ INSMomentumTractionFormRZ::computeQpJacobian()
   if (_component == 0)
   {
     const Real r = _q_point[_qp](0);
-    jac_base += 2. * _mu * _phi[_j][_qp] * _test[_i][_qp] / (r * r);
+    jac_base += 2. * _mu[_qp] * _phi[_j][_qp] * _test[_i][_qp] / (r * r);
   }
 
   return jac_base;

--- a/modules/navier_stokes/src/kernels/INSPressurePoisson.C
+++ b/modules/navier_stokes/src/kernels/INSPressurePoisson.C
@@ -22,8 +22,8 @@ validParams<INSPressurePoisson>()
   params.addCoupledVar("a2", "y-acceleration"); // only required in 2D and 3D
   params.addCoupledVar("a3", "z-acceleration"); // only required in 3D
 
-  // Required parameters
-  params.addRequiredParam<Real>("rho", "density");
+  // Optional parameters
+  params.addParam<MaterialPropertyName>("rho_name", "rho", "density_name");
 
   return params;
 }
@@ -41,8 +41,8 @@ INSPressurePoisson::INSPressurePoisson(const InputParameters & parameters)
     _a2_var_number(_mesh.dimension() >= 2 ? coupled("a2") : libMesh::invalid_uint),
     _a3_var_number(_mesh.dimension() == 3 ? coupled("a3") : libMesh::invalid_uint),
 
-    // Required parameters
-    _rho(getParam<Real>("rho"))
+    // Material Properties
+    _rho(getMaterialProperty<Real>("rho_name"))
 {
 }
 
@@ -53,7 +53,8 @@ INSPressurePoisson::computeQpResidual()
   Real laplacian_part = _grad_u[_qp] * _grad_test[_i][_qp];
 
   // Divergence part
-  Real div_part = _rho * (_grad_a1[_qp](0) + _grad_a2[_qp](1) + _grad_a3[_qp](2)) * _test[_i][_qp];
+  Real div_part =
+      _rho[_qp] * (_grad_a1[_qp](0) + _grad_a2[_qp](1) + _grad_a3[_qp](2)) * _test[_i][_qp];
 
   // Return the result
   return laplacian_part + div_part;
@@ -69,13 +70,13 @@ Real
 INSPressurePoisson::computeQpOffDiagJacobian(unsigned jvar)
 {
   if (jvar == _a1_var_number)
-    return _rho * _grad_phi[_j][_qp](0) * _test[_i][_qp];
+    return _rho[_qp] * _grad_phi[_j][_qp](0) * _test[_i][_qp];
 
   else if (jvar == _a2_var_number)
-    return _rho * _grad_phi[_j][_qp](1) * _test[_i][_qp];
+    return _rho[_qp] * _grad_phi[_j][_qp](1) * _test[_i][_qp];
 
   else if (jvar == _a3_var_number)
-    return _rho * _grad_phi[_j][_qp](2) * _test[_i][_qp];
+    return _rho[_qp] * _grad_phi[_j][_qp](2) * _test[_i][_qp];
 
   else
     return 0;

--- a/modules/navier_stokes/src/kernels/INSTemperatureTimeDerivative.C
+++ b/modules/navier_stokes/src/kernels/INSTemperatureTimeDerivative.C
@@ -13,26 +13,28 @@ validParams<INSTemperatureTimeDerivative>()
   InputParameters params = validParams<TimeDerivative>();
   params.addClassDescription("This class computes the time derivative for the incompressible "
                              "Navier-Stokes momentum equation.");
-  params.addRequiredParam<Real>("rho", "density");
-  params.addRequiredParam<Real>("cp", "specific heat");
+  params.addParam<MaterialPropertyName>("rho_name", "rho", "density name");
+  params.addParam<MaterialPropertyName>("cp_name", "cp", "specific heat name");
   return params;
 }
 
 INSTemperatureTimeDerivative::INSTemperatureTimeDerivative(const InputParameters & parameters)
-  : TimeDerivative(parameters), _rho(getParam<Real>("rho")), _cp(getParam<Real>("cp"))
+  : TimeDerivative(parameters),
+    _rho(getMaterialProperty<Real>("rho_name")),
+    _cp(getMaterialProperty<Real>("cp_name"))
 {
 }
 
 Real
 INSTemperatureTimeDerivative::computeQpResidual()
 {
-  return _rho * _cp * TimeDerivative::computeQpResidual();
+  return _rho[_qp] * _cp[_qp] * TimeDerivative::computeQpResidual();
 }
 
 Real
 INSTemperatureTimeDerivative::computeQpJacobian()
 {
-  return _rho * _cp * TimeDerivative::computeQpJacobian();
+  return _rho[_qp] * _cp[_qp] * TimeDerivative::computeQpJacobian();
 }
 
 Real

--- a/modules/navier_stokes/tests/ins/RZ_cone/RZ_cone_by_parts.i
+++ b/modules/navier_stokes/tests/ins/RZ_cone/RZ_cone_by_parts.i
@@ -4,8 +4,6 @@
 # .) Integrating the pressure by parts.
 # .) Natural boundary condition at the outlet.
 [GlobalParams]
-  rho = 1
-  mu = 1
   gravity = '0 0 0'
 []
 
@@ -130,6 +128,15 @@
     v = vel_y
     p = p
     component = 1
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu'
+    prop_values = '1  1'
   [../]
 []
 

--- a/modules/navier_stokes/tests/ins/RZ_cone/RZ_cone_no_parts.i
+++ b/modules/navier_stokes/tests/ins/RZ_cone/RZ_cone_no_parts.i
@@ -4,8 +4,6 @@
 # .) Not integrating the pressure by parts, thereby requiring a pressure pin.
 # .) Natural boundary condition at the outlet.
 [GlobalParams]
-  rho = 1
-  mu = 1
   integrate_p_by_parts = false
   gravity = '0 0 0'
 []
@@ -156,6 +154,15 @@
     v = vel_y
     p = p
     component = 1
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu'
+    prop_values = '1  1'
   [../]
 []
 

--- a/modules/navier_stokes/tests/ins/jeffery_hamel/wedge_dirichlet.i
+++ b/modules/navier_stokes/tests/ins/jeffery_hamel/wedge_dirichlet.i
@@ -2,8 +2,6 @@
 # solution for flow in a 2D wedge.
 [GlobalParams]
   gravity = '0 0 0'
-  rho = 1
-  mu = 1
 
   # Params used by the WedgeFunction for computing the exact solution.
   # The value of K is only required for comparing the pressure to the
@@ -118,6 +116,15 @@
   [../]
 []
 
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 1
+    prop_names = 'rho mu'
+    prop_values = '1  1'
+  [../]
+[]
+
 [Preconditioning]
   [./SMP_PJFNK]
     type = SMP
@@ -159,14 +166,20 @@
   [./vel_x_exact]
     type = WedgeFunction
     var_num = 0
+    mu = 1
+    rho = 1
   [../]
   [./vel_y_exact]
     type = WedgeFunction
     var_num = 1
+    mu = 1
+    rho = 1
   [../]
   [./p_exact]
     type = WedgeFunction
     var_num = 2
+    mu = 1
+    rho = 1
   [../]
 []
 

--- a/modules/navier_stokes/tests/ins/jeffery_hamel/wedge_natural.i
+++ b/modules/navier_stokes/tests/ins/jeffery_hamel/wedge_natural.i
@@ -4,8 +4,6 @@
 # outlet still "looks" reasonable.
 [GlobalParams]
   gravity = '0 0 0'
-  rho = 1
-  mu = 1
 
   # Params used by the WedgeFunction for computing the exact solution.
   # The value of K is only required for comparing the pressure to the
@@ -97,8 +95,17 @@
   [../]
 []
 
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 1
+    prop_names = 'rho mu'
+    prop_values = '1  1'
+  [../]
+[]
+
 [Preconditioning]
-  [./SMP_PJFNK]
+  [./SMP_NEWTON]
     type = SMP
     full = true
     solve_type = NEWTON
@@ -138,9 +145,13 @@
   [./vel_x_exact]
     type = WedgeFunction
     var_num = 0
+    mu = 1
+    rho = 1
   [../]
   [./vel_y_exact]
     type = WedgeFunction
     var_num = 1
+    mu = 1
+    rho = 1
   [../]
 []

--- a/modules/navier_stokes/tests/ins/lid_driven/lid_driven.i
+++ b/modules/navier_stokes/tests/ins/lid_driven/lid_driven.i
@@ -1,9 +1,5 @@
 [GlobalParams]
   gravity = '0 0 0'
-  rho = 1
-  mu = 1
-  cp = 1
-  k = .01
 []
 
 [Mesh]
@@ -150,6 +146,15 @@
     variable = p
     boundary = 'pinned_node'
     value = 0
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu cp k'
+    prop_values = '1  1  1  .01'
   [../]
 []
 

--- a/modules/navier_stokes/tests/ins/lid_driven/lid_driven_chorin.i
+++ b/modules/navier_stokes/tests/ins/lid_driven/lid_driven_chorin.i
@@ -1,15 +1,5 @@
 [GlobalParams]
-  # rho = 1000    # kg/m^3
-  # mu = 0.798e-3 # Pa-s at 30C
-  # cp = 4.179e3  # J/kg-K at 30C
-  # k = 0.58      # W/m-K at ?C
   gravity = '0 0 0'
-
-  # Dummy parameters
-  rho = 1
-  mu = 1
-  cp = 1
-  k = 1
 []
 
 
@@ -142,9 +132,6 @@
   [../]
 []
 
-
-
-
 [BCs]
   [./u_no_slip]
     type = DirichletBC
@@ -202,7 +189,20 @@
   [../]
 []
 
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    # rho = 1000    # kg/m^3
+    # mu = 0.798e-3 # Pa-s at 30C
+    # cp = 4.179e3  # J/kg-K at 30C
+    # k = 0.58      # W/m-K at ?C
 
+    # Dummy parameters
+    prop_names = 'rho mu cp k'
+    prop_values = '1  1  1  1'
+  [../]
+[]
 
 [Preconditioning]
 #active = 'FDP_Newton'

--- a/modules/navier_stokes/tests/ins/lid_driven/lid_driven_split.i
+++ b/modules/navier_stokes/tests/ins/lid_driven/lid_driven_split.i
@@ -1,18 +1,6 @@
 [GlobalParams]
-  # rho = 1000    # kg/m^3
-  # mu = 0.798e-3 # Pa-s at 30C
-  # cp = 4.179e3  # J/kg-K at 30C
-  # k = 0.58      # W/m-K at ?C
   gravity = '0 0 0'
-
-  # Dummy parameters
-  rho = 1
-  mu = 1
-  cp = 1
-  k = 1
 []
-
-
 
 [Mesh]
   type = GeneratedMesh
@@ -214,7 +202,20 @@
   [../]
 []
 
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    # rho = 1000    # kg/m^3
+    # mu = 0.798e-3 # Pa-s at 30C
+    # cp = 4.179e3  # J/kg-K at 30C
+    # k = 0.58      # W/m-K at ?C
 
+    # Dummy parameters
+    prop_names = 'rho mu cp k'
+    prop_values = '1  1  1  1'
+  [../]
+[]
 
 [Preconditioning]
 # [./FDP_Newton]

--- a/modules/navier_stokes/tests/ins/pressure_channel/open_bc_pressure_BC.i
+++ b/modules/navier_stokes/tests/ins/pressure_channel/open_bc_pressure_BC.i
@@ -1,8 +1,6 @@
 # This input file tests Dirichlet pressure in/outflow boundary conditions for the incompressible NS equations.
 [GlobalParams]
   gravity = '0 0 0'
-  rho = 1
-  mu = 1
 []
 
 [Mesh]
@@ -84,6 +82,15 @@
     variable = p
     boundary = right
     value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu'
+    prop_values = '1  1'
   [../]
 []
 

--- a/modules/navier_stokes/tests/ins/pressure_channel/open_bc_pressure_BC_fieldSplit.i
+++ b/modules/navier_stokes/tests/ins/pressure_channel/open_bc_pressure_BC_fieldSplit.i
@@ -1,8 +1,6 @@
 # This input file tests Dirichlet pressure in/outflow boundary conditions for the incompressible NS equations.
 [GlobalParams]
   gravity = '0 0 0'
-  rho = 1
-  mu = 1
 []
 
 [Mesh]
@@ -84,6 +82,15 @@
     variable = p
     boundary = right
     value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu'
+    prop_values = '1  1'
   [../]
 []
 

--- a/modules/navier_stokes/tests/ins/stagnation/stagnation.i
+++ b/modules/navier_stokes/tests/ins/stagnation/stagnation.i
@@ -1,6 +1,4 @@
 [GlobalParams]
-  rho = 1
-  mu = .01389 # ~2/144
   gravity = '0 0 0'
 []
 
@@ -130,6 +128,15 @@
     v = vel_y
     p = p
     component = 1
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu'
+    prop_values = '1 .01389' # 2/144
   [../]
 []
 

--- a/modules/navier_stokes/tests/ins/velocity_channel/velocity_inletBC_by_parts.i
+++ b/modules/navier_stokes/tests/ins/velocity_channel/velocity_inletBC_by_parts.i
@@ -2,8 +2,6 @@
 
 [GlobalParams]
   gravity = '0 0 0'
-  rho = 1
-  mu = 1
   integrate_p_by_parts = true
 []
 
@@ -79,6 +77,15 @@
     variable = vel_x
     boundary = 'left'
     function = 'inlet_func'
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu'
+    prop_values = '1  1'
   [../]
 []
 

--- a/modules/navier_stokes/tests/ins/velocity_channel/velocity_inletBC_no_parts.i
+++ b/modules/navier_stokes/tests/ins/velocity_channel/velocity_inletBC_no_parts.i
@@ -2,8 +2,6 @@
 
 [GlobalParams]
   gravity = '0 0 0'
-  rho = 1
-  mu = 1
   integrate_p_by_parts = false
 []
 
@@ -96,6 +94,15 @@
     boundary = top_right
     value = 0
     variable = p
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu'
+    prop_values = '1  1'
   [../]
 []
 


### PR DESCRIPTION
Switching from type `Real` and input file supplied values for properties like viscosity, density, conductivity, and heat capacity to type `MaterialProperty<Real>` and material supplied values. This allows greater flexibility in how these properties are defined, e.g. constants, functions of space and time, and/or functions of nonlinear variables.

Closes #9008 