### PR TITLE
FluidProperties: tabulated version of CO2 properties

### DIFF
--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -1,0 +1,240 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef TABULATEDFLUIDPROPERTIES_H
+#define TABULATEDFLUIDPROPERTIES_H
+
+#include "SinglePhaseFluidPropertiesPT.h"
+
+class SinglePhaseFluidPropertiesPT;
+class BicubicSplineInterpolation;
+class TabulatedFluidProperties;
+
+template <>
+InputParameters validParams<TabulatedFluidProperties>();
+
+/**
+ * Class for fluid properties read from a file.
+ *
+ * Property values are read from a file containing keywords followed by data.
+ * Monotonically increasing values of pressure and temperature must be included in
+ * the data file, specifying the phase space where tabulated fluid properties will
+ * be defined. An error is thrown if either temperature or pressure data is not
+ * included or not monotonic, and an error is also thrown if this UserObject is
+ * requested to provide a fluid property outside this phase space.
+ *
+ * This class is intended to be used when complicated formulations for density,
+ * internal energy or enthalpy are required, which can be computationally expensive.
+ * This is particularly the case where the fluid equation of state is based on a
+ * Helmholtz free energy that is a function of density and temperature, like that
+ * used in CO2FluidProperties. In this case, density must be solved iteratively using
+ * pressure and temperature, which increases the computational burden.
+ *
+ * In these cases, using an interpolation of the tabulated fluid properties can
+ * significantly reduce the computational time for computing density, internal energy,
+ * and enthalpy.
+ *
+ * The expected file format for the tabulated fluid properties is now described.
+ * Lines beginning with # are ignored, so comments can be included.
+ * Keywords 'pressure' and 'temperature' must be included, each followed by numerical data
+ * that increases monotonically. A blank line signifies the end of the data for the
+ * preceding keyword.
+ *
+ * Fluid properties for density, internal energy, and enthalpy can be included, with
+ * the keyword 'density', 'internal_energy', or 'enthalpy' followed by data that cycles
+ * first by temperature then pressure. If any of these properties are not supplied,
+ * this UserObject will generate it using the pressure and temperature values provided.
+ * An error is thrown if an incorrect number of property values has been supplied.
+ *
+ * If no tabulated fluid property data file exists, then data for density, internal energy
+ * and enthalpy will be generated using the pressure and temperature ranges specified
+ * in the input file at the beginning of the simulation.
+ *
+ * This tabulated data will be written to file in the correct format,
+ * enabling suitable data files to be created for future use. There is an upfront
+ * computational expense required for this initial data generation, depending on the
+ * required number of pressure and temperature points. However, provided that the
+ * number of data points required to generate the tabulated data is smaller than the
+ * number of times the property members in the FluidProperties UserObject are used,
+ * the initial time to generate the data and the subsequent interpolation time can be much
+ * less than using the original FluidProperties UserObject.
+ *
+ * Density, internal_energy and enthalpy and there derivatives wrt pressure and
+ * temperature are always calculated using bicubic spline interpolatio, while all
+ * remaining fluid properties are calculated using the FluidProperties UserObject _fp.
+ *
+ * A function to write generated data to file using the correct format is provided
+ * to allow suitable files of fluid property data to be generated using the FluidProperties
+ * module UserObjects.
+ */
+class TabulatedFluidProperties : public SinglePhaseFluidPropertiesPT
+{
+public:
+  TabulatedFluidProperties(const InputParameters & parameters);
+  virtual ~TabulatedFluidProperties();
+
+  virtual void initialSetup() override;
+
+  /// Molar mass
+  virtual Real molarMass() const override;
+  /// Density
+  virtual Real rho(Real pressure, Real temperature) const override;
+  /// Density and its derivatives wrt pressure and temperature
+  virtual void rho_dpT(
+      Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  /// Internal energy
+  virtual Real e(Real pressure, Real temperature) const override;
+  /// Internal energy and its derivatives wrt pressure and temperature
+  virtual void
+  e_dpT(Real pressure, Real temperature, Real & e, Real & de_dp, Real & de_dT) const override;
+  /// Density and internal energy, and derivatives wrt pressure and temperature
+  virtual void rho_e_dpT(Real pressure,
+                         Real temperature,
+                         Real & rho,
+                         Real & drho_dp,
+                         Real & drho_dT,
+                         Real & e,
+                         Real & de_dp,
+                         Real & de_dT) const override;
+  /// Enthalpy
+  virtual Real h(Real p, Real T) const override;
+  /// Enthalpy and its derivatives wrt pressure and temperature
+  virtual void
+  h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const override;
+  /// Viscosity
+  virtual Real mu(Real density, Real temperature) const override;
+  /// Derivatives of viscosity wrt density and temperature
+  virtual void mu_drhoT(
+      Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  /// Specific isobaric heat capacity
+  virtual Real cp(Real pressure, Real temperature) const override;
+  /// Specific isochoric heat capacity
+  virtual Real cv(Real pressure, Real temperature) const override;
+  /// Speed of sound
+  virtual Real c(Real pressure, Real temperature) const override;
+  /// Thermal conductivity
+  virtual Real k(Real density, Real temperature) const override;
+  /// Specific entropy
+  virtual Real s(Real pressure, Real temperature) const override;
+  /// Thermal expansion coefficient
+  virtual Real beta(Real pressure, Real temperature) const override;
+  /// Henry's law constant for dissolution in water
+  virtual Real henryConstant(Real temperature) const override;
+  /// Henry's law constant for dissolution in water and derivative wrt temperature
+  virtual void henryConstant_dT(Real temperature, Real & Kh, Real & dKh_dT) const override;
+
+protected:
+  /**
+   * Read tabulated data from a file and store it in vectors
+   * @param file_name name of the file to be read
+   */
+  void parseTabulatedData(std::string file_name);
+
+  /**
+   * Helper function to parse lines of data read from file.
+   * @param line line to be parsed
+   * @param[out] data vector of data parsed from line
+   */
+  void parseData(std::string line, std::vector<Real> & data);
+
+  /**
+   * Writes tabulated data to a file.
+   * @param file_name name of the file to be written
+   */
+  void writeTabulatedData(std::string file_name);
+
+  /**
+   * Checks that the inputs are within the range of the tabulated data, and throws
+   * an error if they are not.
+   * @param pressure input pressure (Pa)
+   * @param temperature input temperature (K)
+   */
+  void checkInputVariables(Real pressure, Real temperature) const;
+
+  /**
+   * Generates a table of fluid properties by looping over pressure and temperature
+   * and calculating properties using the FluidProperties UserObject _fp.
+   */
+  virtual void generateAllTabulatedData();
+
+  /**
+   * Generates any missing data that has been parsed from an input file. For example,
+   * if one of the required properties has not been included, then it is generated using
+   * the FluidProperties UserObject at the pressure and temperature points given in the
+   * data file.
+   */
+  virtual void generateMissingTabulatedData();
+
+  /**
+   * Forms a 2D matrix from a single std::vector.
+   * @param nrow number of rows in the matrix
+   * @param ncol number of columns in the matrix
+   * @param vec 1D vector to reshape into a 2D matrix
+   * @param[out] 2D matrix formed by reshaping vec
+   */
+  void reshapeData2D(unsigned int nrow,
+                     unsigned int ncol,
+                     std::vector<Real> & vec,
+                     std::vector<std::vector<Real>> & mat);
+
+  /**
+   * Forms a 1D vector from a 2D matrix.
+   * @param mat 2D matrix
+   * @return 1D vector containing elements of mat
+   */
+  std::vector<Real> flattenData(std::vector<std::vector<Real>> & mat);
+
+  /// File name of tabulated data file
+  FileName _file_name;
+  /// Pressure vector
+  std::vector<Real> _pressure;
+  /// Temperature vector
+  std::vector<Real> _temperature;
+  /// Tabulated density
+  std::vector<std::vector<Real>> _density;
+  /// Tabulated internal energy
+  std::vector<std::vector<Real>> _internal_energy;
+  /// Tabulated enthalpy
+  std::vector<std::vector<Real>> _enthalpy;
+  /// Interpoled density
+  std::unique_ptr<BicubicSplineInterpolation> _density_ipol;
+  /// Interpoled internal energy
+  std::unique_ptr<BicubicSplineInterpolation> _internal_energy_ipol;
+  /// Interpoled enthalpy
+  std::unique_ptr<BicubicSplineInterpolation> _enthalpy_ipol;
+  /// Derivatives along the boundary
+  std::vector<Real> _drho_dp_0, _drho_dp_n, _drho_dT_0, _drho_dT_n;
+  std::vector<Real> _de_dp_0, _de_dp_n, _de_dT_0, _de_dT_n;
+  std::vector<Real> _dh_dp_0, _dh_dp_n, _dh_dT_0, _dh_dT_n;
+
+  /// Minimum temperature in tabulated data
+  Real _temperature_min;
+  /// Maximum temperature in tabulated data
+  Real _temperature_max;
+  /// Minimum pressure in tabulated data
+  Real _pressure_min;
+  /// Maximum pressure in tabulated data
+  Real _pressure_max;
+  /// Number of temperature points in the tabulated data
+  unsigned int _num_T;
+  /// Number of pressure points in the tabulated data
+  unsigned int _num_p;
+  /// Index for derivatives wrt pressure
+  const unsigned int _wrt_p = 1;
+  /// Index for derivatives wrt temperature
+  const unsigned int _wrt_T = 2;
+
+  /// SinglePhaseFluidPropertiesPT UserObject
+  const SinglePhaseFluidPropertiesPT & _fp;
+
+  /// List of reuired axes names to be read
+  const std::vector<std::string> _required_axes{"pressure", "temperature"};
+  /// List of valid fluid property names that can be read
+  const std::vector<std::string> _valid_props{"density", "enthalpy", "internal_energy"};
+};
+
+#endif /* TABULATEDFLUIDPROPERTIES_H */

--- a/modules/fluid_properties/src/base/FluidPropertiesApp.C
+++ b/modules/fluid_properties/src/base/FluidPropertiesApp.C
@@ -23,6 +23,7 @@
 #include "NaClFluidProperties.h"
 #include "BrineFluidProperties.h"
 #include "SimpleFluidProperties.h"
+#include "TabulatedFluidProperties.h"
 
 #include "SpecificEnthalpyAux.h"
 #include "StagnationPressureAux.h"
@@ -85,6 +86,7 @@ FluidPropertiesApp::registerObjects(Factory & factory)
   registerUserObject(NaClFluidProperties);
   registerUserObject(BrineFluidProperties);
   registerUserObject(SimpleFluidProperties);
+  registerUserObject(TabulatedFluidProperties);
 
   registerAuxKernel(SpecificEnthalpyAux);
   registerAuxKernel(StagnationPressureAux);

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -1,0 +1,563 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "TabulatedFluidProperties.h"
+#include "BicubicSplineInterpolation.h"
+#include "MooseUtils.h"
+
+// C++ includes
+#include <fstream>
+#include <ctime>
+
+template <>
+InputParameters
+validParams<TabulatedFluidProperties>()
+{
+  InputParameters params = validParams<SinglePhaseFluidPropertiesPT>();
+  params.addParam<FileName>("fluid_property_file",
+                            "fluid_properties.txt",
+                            "Name of the file containing the tabulated fluid property data");
+  params.addRangeCheckedParam<Real>("temperature_min",
+                                    300.0,
+                                    "temperature_min >= 273.15",
+                                    "Minimum temperature for tabulated data. Default is 300 K)");
+  params.addRangeCheckedParam<Real>("temperature_max",
+                                    500.0,
+                                    "temperature_max <= 1000.0",
+                                    "Maximum temperature for tabulated data. Default is 500 K");
+  params.addRangeCheckedParam<Real>("pressure_min",
+                                    1.0e5,
+                                    "pressure_min >= 1.0e5",
+                                    "Minimum pressure for tabulated data. Default is 0.1 MPa)");
+  params.addRangeCheckedParam<Real>("pressure_max",
+                                    50.0e6,
+                                    "pressure_max <= 800.0e6",
+                                    "Maximum pressure for tabulated data. Default is 50 MPa");
+  params.addRangeCheckedParam<unsigned int>(
+      "num_T", 100, "num_T > 0", "Number of points to divide temperature range. Default is 100");
+  params.addRangeCheckedParam<unsigned int>(
+      "num_p", 100, "num_p > 0", "Number of points to divide pressure range. Default is 100");
+  params.addRequiredParam<UserObjectName>("fp", "The name of the FluidProperties UserObject");
+  params.addClassDescription(
+      "Fluid properties using bicubic spline interpolation on tabulated values provided");
+  return params;
+}
+
+TabulatedFluidProperties::TabulatedFluidProperties(const InputParameters & parameters)
+  : SinglePhaseFluidPropertiesPT(parameters),
+    _file_name(getParam<FileName>("fluid_property_file")),
+    _temperature_min(getParam<Real>("temperature_min")),
+    _temperature_max(getParam<Real>("temperature_max")),
+    _pressure_min(getParam<Real>("pressure_min")),
+    _pressure_max(getParam<Real>("pressure_max")),
+    _num_T(getParam<unsigned int>("num_T")),
+    _num_p(getParam<unsigned int>("num_p")),
+    _fp(getUserObject<SinglePhaseFluidPropertiesPT>("fp"))
+{
+  // Sanity check on minimum and maximum temperatures and pressures
+  if (_temperature_max <= _temperature_min)
+    mooseError("temperature_max must be greater than temperature_min in ", name());
+  if (_pressure_max <= _pressure_min)
+    mooseError("pressure_max must be greater than pressure_min in ", name());
+}
+
+TabulatedFluidProperties::~TabulatedFluidProperties() {}
+
+void
+TabulatedFluidProperties::initialSetup()
+{
+  // Check to see if _file_name supplied exists. If it does, that data
+  // will be used. If it does not exist, data will be generated and then
+  // written to _file_name.
+  std::ifstream file(_file_name.c_str());
+  if (file.good())
+  {
+    _console << "Reading tabulated properties from " << _file_name << "\n";
+    parseTabulatedData(_file_name);
+
+    // If any required tabulated data is missing (eg, the data file did not include
+    // one of the required properties), then generate property data for that property
+    // so that spline interpolation can be used
+    generateMissingTabulatedData();
+  }
+  else
+  {
+    _console << "No tabulated properties file named " << _file_name << " exists.\n"
+             << "Generating tabulated data and writing output to " << _file_name << "\n";
+    generateAllTabulatedData();
+    // Write tabulated data to file
+    writeTabulatedData(_file_name);
+  }
+
+  // Construct bicubic splines from tabulated data
+  _density_ipol = libmesh_make_unique<BicubicSplineInterpolation>();
+  _internal_energy_ipol = libmesh_make_unique<BicubicSplineInterpolation>();
+  _enthalpy_ipol = libmesh_make_unique<BicubicSplineInterpolation>();
+
+  _density_ipol->setData(
+      _pressure, _temperature, _density, _drho_dp_0, _drho_dp_n, _drho_dT_0, _drho_dT_n);
+
+  _internal_energy_ipol->setData(
+      _pressure, _temperature, _internal_energy, _de_dp_0, _de_dp_n, _de_dT_0, _de_dT_n);
+
+  _enthalpy_ipol->setData(
+      _pressure, _temperature, _enthalpy, _dh_dp_0, _dh_dp_n, _dh_dT_0, _dh_dT_n);
+}
+
+Real
+TabulatedFluidProperties::molarMass() const
+{
+  return _fp.molarMass();
+}
+
+Real
+TabulatedFluidProperties::rho(Real pressure, Real temperature) const
+{
+  checkInputVariables(pressure, temperature);
+  return _density_ipol->sample(pressure, temperature);
+}
+
+void
+TabulatedFluidProperties::rho_dpT(
+    Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
+{
+  checkInputVariables(pressure, temperature);
+  rho = _density_ipol->sample(pressure, temperature);
+  drho_dp = _density_ipol->sampleDerivative(pressure, temperature, _wrt_p);
+  drho_dT = _density_ipol->sampleDerivative(pressure, temperature, _wrt_T);
+}
+
+Real
+TabulatedFluidProperties::e(Real pressure, Real temperature) const
+{
+  checkInputVariables(pressure, temperature);
+  return _internal_energy_ipol->sample(pressure, temperature);
+}
+
+void
+TabulatedFluidProperties::e_dpT(
+    Real pressure, Real temperature, Real & e, Real & de_dp, Real & de_dT) const
+{
+  checkInputVariables(pressure, temperature);
+  e = _internal_energy_ipol->sample(pressure, temperature);
+  de_dp = _internal_energy_ipol->sampleDerivative(pressure, temperature, _wrt_p);
+  de_dT = _internal_energy_ipol->sampleDerivative(pressure, temperature, _wrt_T);
+}
+
+void
+TabulatedFluidProperties::rho_e_dpT(Real pressure,
+                                    Real temperature,
+                                    Real & rho,
+                                    Real & drho_dp,
+                                    Real & drho_dT,
+                                    Real & e,
+                                    Real & de_dp,
+                                    Real & de_dT) const
+{
+  checkInputVariables(pressure, temperature);
+  rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+  e_dpT(pressure, temperature, e, de_dp, de_dT);
+}
+
+Real
+TabulatedFluidProperties::h(Real pressure, Real temperature) const
+{
+  checkInputVariables(pressure, temperature);
+  return _enthalpy_ipol->sample(pressure, temperature);
+}
+
+void
+TabulatedFluidProperties::h_dpT(
+    Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const
+{
+  checkInputVariables(pressure, temperature);
+  h = _enthalpy_ipol->sample(pressure, temperature);
+  dh_dp = _enthalpy_ipol->sampleDerivative(pressure, temperature, _wrt_p);
+  dh_dT = _enthalpy_ipol->sampleDerivative(pressure, temperature, _wrt_T);
+}
+
+Real
+TabulatedFluidProperties::mu(Real density, Real temperature) const
+{
+  return _fp.mu(density, temperature);
+}
+
+void
+TabulatedFluidProperties::mu_drhoT(
+    Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const
+{
+  _fp.mu_drhoT(density, temperature, mu, dmu_drho, dmu_dT);
+}
+
+Real
+TabulatedFluidProperties::c(Real pressure, Real temperature) const
+{
+  return _fp.c(pressure, temperature);
+}
+
+Real
+TabulatedFluidProperties::cp(Real pressure, Real temperature) const
+{
+  return _fp.cp(pressure, temperature);
+}
+
+Real
+TabulatedFluidProperties::cv(Real pressure, Real temperature) const
+{
+  return _fp.cv(pressure, temperature);
+}
+
+Real
+TabulatedFluidProperties::k(Real density, Real temperature) const
+{
+  return _fp.k(density, temperature);
+}
+
+Real
+TabulatedFluidProperties::s(Real pressure, Real temperature) const
+{
+  return _fp.s(pressure, temperature);
+}
+
+Real
+TabulatedFluidProperties::beta(Real pressure, Real temperature) const
+{
+  return _fp.beta(pressure, temperature);
+}
+
+Real
+TabulatedFluidProperties::henryConstant(Real temperature) const
+{
+  return _fp.henryConstant(temperature);
+}
+
+void
+TabulatedFluidProperties::henryConstant_dT(Real temperature, Real & Kh, Real & dKh_dT) const
+{
+  _fp.henryConstant_dT(temperature, Kh, dKh_dT);
+}
+
+void
+TabulatedFluidProperties::parseTabulatedData(std::string file_name)
+{
+  MooseUtils::checkFileReadable(file_name);
+
+  /// List of axes names read from file
+  std::vector<std::string> axes_names;
+  /// Data for axes
+  std::vector<std::vector<Real>> axes;
+  /// List of property names read from file
+  std::vector<std::string> property_names;
+  /// Data for each fluid property
+  std::vector<std::vector<Real>> properties;
+
+  std::ifstream file_in(file_name.c_str());
+  std::string line;
+
+  while (getline(file_in, line))
+  {
+    // Skip empty lines
+    if (line.empty())
+      continue;
+
+    // Skip lines containing whitespace only
+    if (std::all_of(line.begin(), line.end(), isspace))
+      continue;
+
+    // Skip lines starting with # (treat as comments)
+    if (line.find("#") == 0)
+      continue;
+
+    // Found an axes keyword
+    else if (std::find(_required_axes.begin(), _required_axes.end(), line) != _required_axes.end())
+    {
+      auto it = std::find(_required_axes.begin(), _required_axes.end(), line);
+      auto index = std::distance(_required_axes.begin(), it);
+      axes_names.push_back(_required_axes[index]);
+
+      std::vector<Real> data;
+      while (getline(file_in, line))
+      {
+        if (!line.empty())
+          parseData(line, data);
+        else
+          break;
+      }
+      axes.push_back(data);
+    }
+
+    // Found a fluid properties keyword
+    else if (std::find(_valid_props.begin(), _valid_props.end(), line) != _valid_props.end())
+    {
+      auto it = std::find(_valid_props.begin(), _valid_props.end(), line);
+      auto index = std::distance(_valid_props.begin(), it);
+      property_names.push_back(_valid_props[index]);
+
+      std::vector<Real> data;
+
+      while (getline(file_in, line))
+      {
+        if (!line.empty())
+          parseData(line, data);
+        else
+          break;
+      }
+      properties.push_back(data);
+    }
+
+    // Found an invalid keyword, so ignore data
+    else if (std::find(_valid_props.begin(), _valid_props.end(), line) == _valid_props.end())
+    {
+      while (getline(file_in, line))
+        if (!line.empty())
+          continue;
+        else
+          break;
+    }
+  }
+
+  // Check that axes data has been provided in ascending order
+  for (unsigned int i = 0; i < axes.size(); ++i)
+    if (!std::is_sorted(axes[i].begin(), axes[i].end()))
+      mooseError(
+          "The axes data for ", axes_names[i], " is not monotonically ascending in ", file_name);
+
+  // Check that the correct number of data points have been provided for each property
+  unsigned int num_data = 1;
+  for (auto ax : axes)
+    num_data *= ax.size();
+
+  for (unsigned int i = 0; i < properties.size(); ++i)
+    if (properties[i].size() != num_data)
+      mooseError(
+          "The number of supplied ", property_names[i], " values is not correct in ", file_name);
+
+  for (unsigned int i = 0; i < axes_names.size(); ++i)
+  {
+    if (axes_names[i] == "pressure")
+      _pressure = axes[i];
+
+    else // (axes_names[i] == "temperature")
+      _temperature = axes[i];
+  }
+
+  // Both pressure and temperature data must be provided
+  if (_pressure.empty())
+    mooseError("No pressure axes data read in ", file_name);
+  if (_temperature.empty())
+    mooseError("No temperature axes data read in ", file_name);
+
+  // Number of pressure and temperature data points
+  _num_T = _temperature.size();
+  _num_p = _pressure.size();
+
+  // Minimum and maximum pressure and temperature. Note that _pressure and
+  // _temperature are sorted
+  _pressure_min = _pressure.front();
+  _pressure_max = _pressure.back();
+  _temperature_min = _temperature.front();
+  _temperature_max = _temperature.back();
+
+  for (unsigned int i = 0; i < property_names.size(); ++i)
+  {
+    if (property_names[i] == "density")
+      reshapeData2D(_num_p, _num_T, properties[i], _density);
+
+    else if (property_names[i] == "internal_energy")
+      reshapeData2D(_num_p, _num_T, properties[i], _internal_energy);
+
+    else // (property_names[i] == "enthalpy")
+      reshapeData2D(_num_p, _num_T, properties[i], _enthalpy);
+  }
+}
+
+void
+TabulatedFluidProperties::parseData(std::string line, std::vector<Real> & data)
+{
+  std::istringstream linestream(line);
+  std::string item;
+
+  while (getline(linestream, item, ' '))
+  {
+    std::istringstream iss(item);
+    Real value;
+    iss >> value;
+    data.push_back(value);
+  }
+}
+
+void
+TabulatedFluidProperties::writeTabulatedData(std::string file_name)
+{
+  MooseUtils::checkFileWriteable(file_name);
+
+  std::ofstream file_out(file_name.c_str());
+
+  std::vector<std::string> axes_names{"pressure", "temperature"};
+  std::vector<std::vector<Real>> axes_data;
+  axes_data.push_back(_pressure);
+  axes_data.push_back(_temperature);
+
+  std::vector<std::string> property_names{"density", "internal_energy", "enthalpy"};
+  std::vector<std::vector<Real>> property_data;
+  property_data.push_back(flattenData(_density));
+  property_data.push_back(flattenData(_internal_energy));
+  property_data.push_back(flattenData(_enthalpy));
+
+  // Write out date and object created
+  time_t now = time(&now);
+  file_out << "# Created by TabulatedFluidProperties on " << ctime(&now) << "\n";
+
+  // Write out axes
+  for (unsigned int i = 0; i < axes_names.size(); ++i)
+  {
+    file_out << axes_names[i] << "\n";
+    for (auto item : axes_data[i])
+      file_out << item << "\n";
+
+    file_out << "\n";
+  }
+
+  // Write out the fluid property data
+  for (unsigned int i = 0; i < property_names.size(); ++i)
+  {
+    file_out << property_names[i] << "\n";
+
+    unsigned int item_count = 0;
+    for (auto item : property_data[i])
+    {
+      file_out << item << " ";
+      ++item_count;
+      if (item_count % 10 == 0)
+        file_out << "\n";
+    }
+    file_out << "\n";
+  }
+}
+
+void
+TabulatedFluidProperties::generateAllTabulatedData()
+{
+  _pressure.resize(_num_p);
+  _temperature.resize(_num_T);
+
+  _density.resize(_num_p);
+  _internal_energy.resize(_num_p);
+  _enthalpy.resize(_num_p);
+
+  for (unsigned int i = 0; i < _num_p; ++i)
+  {
+    _density[i].resize(_num_T);
+    _internal_energy[i].resize(_num_T);
+    _enthalpy[i].resize(_num_T);
+  }
+
+  // Temperature is divided equally into _num_T segments
+  Real delta_T = (_temperature_max - _temperature_min) / static_cast<Real>(_num_T - 1);
+
+  for (unsigned int j = 0; j < _num_T; ++j)
+    _temperature[j] = _temperature_min + j * delta_T;
+
+  // Divide the pressure into _num_p equal segments
+  Real delta_p = (_pressure_max - _pressure_min) / static_cast<Real>(_num_p - 1);
+
+  for (unsigned int i = 0; i < _num_p; ++i)
+    _pressure[i] = _pressure_min + i * delta_p;
+
+  // Generate the tabulated data at the pressure and temperature points
+  for (unsigned int i = 0; i < _num_p; ++i)
+    for (unsigned int j = 0; j < _num_T; ++j)
+    {
+      _density[i][j] = _fp.rho(_pressure[i], _temperature[j]);
+      _internal_energy[i][j] = _fp.e(_pressure[i], _temperature[j]);
+      _enthalpy[i][j] = _fp.h(_pressure[i], _temperature[j]);
+    }
+}
+
+void
+TabulatedFluidProperties::generateMissingTabulatedData()
+{
+  // Generate tabulated data for any property that is missing
+  if (_density.empty())
+  {
+    _density.resize(_num_p);
+    for (unsigned int i = 0; i < _num_p; ++i)
+      for (unsigned int j = 0; j < _num_T; ++j)
+        _density[i].push_back(_fp.rho(_pressure[i], _temperature[j]));
+  }
+
+  if (_internal_energy.empty())
+  {
+    _internal_energy.resize(_num_p);
+    for (unsigned int i = 0; i < _num_p; ++i)
+      for (unsigned int j = 0; j < _num_T; ++j)
+        _internal_energy[i].push_back(_fp.e(_pressure[i], _temperature[j]));
+  }
+
+  if (_enthalpy.empty())
+  {
+    _enthalpy.resize(_num_p);
+    for (unsigned int i = 0; i < _num_p; ++i)
+      for (unsigned int j = 0; j < _num_T; ++j)
+        _enthalpy[i].push_back(_fp.h(_pressure[i], _temperature[j]));
+  }
+}
+
+void
+TabulatedFluidProperties::reshapeData2D(unsigned int nrow,
+                                        unsigned int ncol,
+                                        std::vector<Real> & vec,
+                                        std::vector<std::vector<Real>> & mat)
+{
+  if (!vec.empty())
+  {
+    mat.resize(nrow);
+
+    for (unsigned int i = 0; i < nrow; ++i)
+      for (unsigned int j = 0; j < ncol; ++j)
+        mat[i].push_back(vec[i * ncol + j]);
+  }
+}
+
+std::vector<Real>
+TabulatedFluidProperties::flattenData(std::vector<std::vector<Real>> & mat)
+{
+  std::vector<Real> vec;
+
+  if (!mat.empty())
+  {
+    const unsigned int n = mat.size();
+    const unsigned int m = mat[0].size();
+
+    for (unsigned int i = 0; i < n; ++i)
+      for (unsigned int j = 0; j < m; ++j)
+        vec.push_back(mat[i][j]);
+  }
+  return vec;
+}
+
+void
+TabulatedFluidProperties::checkInputVariables(Real pressure, Real temperature) const
+{
+  if (pressure < _pressure_min || pressure > _pressure_max)
+    mooseError("Pressure ",
+               pressure,
+               " is outside the range of tabulated pressure (",
+               _pressure_min,
+               ", ",
+               _pressure_max,
+               ".");
+
+  if (temperature < _temperature_min || temperature > _temperature_max)
+    mooseError("Temperature ",
+               temperature,
+               " is outside the range of tabulated temperature (",
+               _temperature_min,
+               ", ",
+               _temperature_max,
+               ".");
+}

--- a/modules/fluid_properties/tests/co2/tabulated.i
+++ b/modules/fluid_properties/tests/co2/tabulated.i
@@ -1,0 +1,322 @@
+# Test thermophysical property calculations using TabulatedFluidProperties.
+# Calculations for density, internal energy and enthalpy using bicubic spline
+# interpolation of data generated using CO2FluidProperties.
+#
+# The fluid properties calculated using this test are compared with the results
+# using the CO2FluidProperties test co2.i.
+#
+# Comparison with values from Span and Wagner, "A New Equation of State for
+# Carbon Dioxide Covering the Fluid Region from the Triple-Point Temperature
+# to 1100K at Pressures up to 800 MPa", J. Phys. Chem. Ref. Data, 25 (1996)
+#
+# Viscosity values from Fenghour et al., "The viscosity of carbon dioxide",
+# J. Phys. Chem. Ref. Data, 27, 31-44 (1998)
+#
+#  --------------------------------------------------------------
+#  Pressure (Mpa)             |   1       |    1      |   1
+#  Temperature (K)            |  280      |  360      |  500
+#  --------------------------------------------------------------
+#  Expected values
+#  --------------------------------------------------------------
+#  Density (kg/m^3)           |  20.199   |  15.105   |  10.664
+#  Internal energy (kJ/kg/K)  |  -75.892  |  -18.406  |  91.829
+#  Enthalpy (kJ/kg)           |  -26.385  |  47.797   |  185.60
+#  Entropy (kJ/kg/K)          |  -0.51326 |  -0.28033 |  0.04225
+#  cv (kJ/kg/K)               |  0.67092  |  0.72664  |  0.82823
+#  cp (kJ/kg/K)               |  0.92518  |  0.94206  |  1.0273
+#  Speed of sound (m/s)       |  252.33   |  289.00   |  339.81
+#  Viscosity (1e-6Pa.s)       |  14.15    |  17.94    |  24.06
+#  --------------------------------------------------------------
+#  Calculated values
+#  --------------------------------------------------------------
+#  Density (kg/m^3)           |  20.199   |  15.105   |  10.664
+#  Internal energy (kJ/kg/K)  |  -75.892  |  -18.406  |  91.829
+#  Enthalpy (kJ/kg)           |  -26.385  |  47.797   |  185.60
+#  Entropy (kJ/kg/K)          |  -0.51326 |  -0.28033 |  0.04225
+#  cv (kJ/kg/K)               |  0.67092  |  0.72664  |  0.82823
+#  cp (kJ/kg/K)               |  0.92518  |  0.94206  |  1.0273
+#  Speed of sound (m/s)       |  252.33   |  289.00   |  339.81
+#  Viscosity (1e-6 Pa.s)      |  14.15    |  17.94    |  24.06
+#  --------------------------------------------------------------
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 3
+  xmax = 3
+[]
+
+[Variables]
+  [./dummy]
+  [../]
+[]
+
+[AuxVariables]
+  [./pressure]
+    initial_condition = 1e6
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./temperature]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./rho]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./mu]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./e]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./h]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./s]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./cv]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./cp]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+  [./c]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+[]
+
+[Functions]
+  [./tic]
+    type = ParsedFunction
+    value = if(x<1,280,if(x<2,360,500))
+  [../]
+[]
+
+[ICs]
+  [./t_ic]
+    type = FunctionIC
+    function = tic
+    variable = temperature
+  [../]
+[]
+
+[AuxKernels]
+  [./rho]
+    type = MaterialRealAux
+    variable = rho
+    property = density
+  [../]
+  [./my]
+    type = MaterialRealAux
+    variable = mu
+    property = viscosity
+  [../]
+  [./internal_energy]
+    type = MaterialRealAux
+    variable = e
+    property = e
+  [../]
+  [./enthalpy]
+    type = MaterialRealAux
+    variable = h
+    property = h
+  [../]
+  [./entropy]
+    type = MaterialRealAux
+    variable = s
+    property = s
+  [../]
+  [./cv]
+    type = MaterialRealAux
+    variable = cv
+    property = cv
+  [../]
+  [./cp]
+    type = MaterialRealAux
+    variable = cp
+    property = cp
+  [../]
+  [./c]
+    type = MaterialRealAux
+    variable = c
+    property = c
+  [../]
+[]
+
+[Modules]
+  [./FluidProperties]
+    [./co2]
+      type = CO2FluidProperties
+    [../]
+    [./tabulated]
+      type = TabulatedFluidProperties
+      fp = co2
+      fluid_property_file = co2_properties.txt
+      temperature_min = 275
+      temperature_max = 510
+      pressure_min = 2e5
+      pressure_max = 2e6
+    [../]
+  []
+[]
+
+[Materials]
+  [./fp_mat]
+    type = FluidPropertiesMaterialPT
+    pressure = pressure
+    temperature = temperature
+    fp = tabulated
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = dummy
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+[]
+
+[Postprocessors]
+  [./rho0]
+    type = ElementalVariableValue
+    elementid = 0
+    variable = rho
+  [../]
+  [./rho1]
+    type = ElementalVariableValue
+    elementid = 1
+    variable = rho
+  [../]
+  [./rho2]
+    type = ElementalVariableValue
+    elementid = 2
+    variable = rho
+  [../]
+  [./mu0]
+    type = ElementalVariableValue
+    elementid = 0
+    variable = mu
+  [../]
+  [./mu1]
+    type = ElementalVariableValue
+    elementid = 1
+    variable = mu
+  [../]
+  [./mu2]
+    type = ElementalVariableValue
+    elementid = 2
+    variable = mu
+  [../]
+  [./e0]
+    type = ElementalVariableValue
+    elementid = 0
+    variable = e
+  [../]
+  [./e1]
+    type = ElementalVariableValue
+    elementid = 1
+    variable = e
+  [../]
+  [./e2]
+    type = ElementalVariableValue
+    elementid = 2
+    variable = e
+  [../]
+  [./h0]
+    type = ElementalVariableValue
+    elementid = 0
+    variable = h
+  [../]
+  [./h1]
+    type = ElementalVariableValue
+    elementid = 1
+    variable = h
+  [../]
+  [./h2]
+    type = ElementalVariableValue
+    elementid = 2
+    variable = h
+  [../]
+  [./s0]
+    type = ElementalVariableValue
+    elementid = 0
+    variable = s
+  [../]
+  [./s1]
+    type = ElementalVariableValue
+    elementid = 1
+    variable = s
+  [../]
+  [./s2]
+    type = ElementalVariableValue
+    elementid = 2
+    variable = s
+  [../]
+  [./cv0]
+    type = ElementalVariableValue
+    elementid = 0
+    variable = cv
+  [../]
+  [./cv1]
+    type = ElementalVariableValue
+    elementid = 1
+    variable = cv
+  [../]
+  [./cv2]
+    type = ElementalVariableValue
+    elementid = 2
+    variable = cv
+  [../]
+  [./cp0]
+    type = ElementalVariableValue
+    elementid = 0
+    variable = cp
+  [../]
+  [./cp1]
+    type = ElementalVariableValue
+    elementid = 1
+    variable = cp
+  [../]
+  [./cp2]
+    type = ElementalVariableValue
+    elementid = 2
+    variable = cp
+  [../]
+  [./c0]
+    type = ElementalVariableValue
+    elementid = 0
+    variable = c
+  [../]
+  [./c1]
+    type = ElementalVariableValue
+    elementid = 1
+    variable = c
+  [../]
+  [./c2]
+    type = ElementalVariableValue
+    elementid = 2
+    variable = c
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = sweos_out
+  execute_on = 'TIMESTEP_END'
+  print_perf_log = true
+[]

--- a/modules/fluid_properties/tests/co2/tests
+++ b/modules/fluid_properties/tests/co2/tests
@@ -4,4 +4,11 @@
     input = 'sweos.i'
     csvdiff = 'sweos_out.csv'
   [../]
+  [./tabulated]
+    type = CSVDiff
+    input = 'tabulated.i'
+    csvdiff = 'sweos_out.csv'
+    prereq = 'sweos'
+    rel_err = '1e-4'
+  [../]
 []

--- a/modules/porous_flow/tests/fluidstate/tests
+++ b/modules/porous_flow/tests/fluidstate/tests
@@ -21,4 +21,10 @@
     input = 'theis.i'
     csvdiff = "theis_csvout.csv"
   [../]
+  [./theis_tabulated]
+    type = 'CSVDiff'
+    input = 'theis_tabulated.i'
+    csvdiff = "theis_csvout.csv"
+    prereq = 'theis'
+  [../]
 []

--- a/modules/porous_flow/tests/fluidstate/theis_tabulated.i
+++ b/modules/porous_flow/tests/fluidstate/theis_tabulated.i
@@ -1,0 +1,296 @@
+# Two phase Theis problem: Flow from single source using WaterNCG fluidstate.
+# Constant rate injection 0.5 kg/s
+# 1D cylindrical mesh
+# Initially, system has only a liquid phase, until enough gas is injected
+# to form a gas phase, in which case the system becomes two phase.
+# Note: this test is the same as theis.i, but uses the tabulated version of the CO2FluidProperties
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 100
+  xmax = 2000
+  bias_x = 1.05
+[]
+
+[Problem]
+  type = FEProblem
+  coord_type = RZ
+  rz_coord_axis = Y
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+  gravity = '0 0 0'
+[]
+
+[AuxVariables]
+  [./saturation_gas]
+    order = FIRST
+    family = MONOMIAL
+  [../]
+  [./x1]
+    order = FIRST
+    family = MONOMIAL
+  [../]
+  [./y0]
+    order = FIRST
+    family = MONOMIAL
+  [../]
+  [./pgas2]
+    order = FIRST
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./saturation_gas]
+    type = PorousFlowPropertyAux
+    variable = saturation_gas
+    property = saturation
+    phase = 1
+    execute_on = timestep_end
+  [../]
+  [./x1]
+    type = PorousFlowPropertyAux
+    variable = x1
+    property = mass_fraction
+    phase = 0
+    fluid_component = 1
+    execute_on = timestep_end
+  [../]
+  [./y0]
+    type = PorousFlowPropertyAux
+    variable = y0
+    property = mass_fraction
+    phase = 1
+    fluid_component = 0
+    execute_on = timestep_end
+  [../]
+  [./pgas2]
+    type = PorousFlowPropertyAux
+    variable = pgas2
+    property = pressure
+    phase = 1
+    execute_on = timestep_end
+  [../]
+[]
+
+[Variables]
+  [./pgas]
+    initial_condition = 20e6
+  [../]
+  [./zi]
+    initial_condition = 0
+  [../]
+[]
+
+[Kernels]
+  [./mass0]
+    type = PorousFlowMassTimeDerivative
+    fluid_component = 0
+    variable = pgas
+  [../]
+  [./flux0]
+    type = PorousFlowAdvectiveFlux
+    fluid_component = 0
+    variable = pgas
+  [../]
+  [./mass1]
+    type = PorousFlowMassTimeDerivative
+    fluid_component = 1
+    variable = zi
+  [../]
+  [./flux1]
+    type = PorousFlowAdvectiveFlux
+    fluid_component = 1
+    variable = zi
+  [../]
+[]
+
+[UserObjects]
+  [./dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pgas zi'
+    number_fluid_phases = 2
+    number_fluid_components = 2
+  [../]
+[]
+
+[Modules]
+  [./FluidProperties]
+    [./co2]
+      type = CO2FluidProperties
+    [../]
+    [./tabulated]
+      type = TabulatedFluidProperties
+      fp = co2
+      temperature_min = 280
+      temperature_max = 350
+      pressure_min = 19e6
+      pressure_max = 22e6
+      num_T = 50
+      num_p = 50
+    [../]
+    [./water]
+      type = Water97FluidProperties
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./temperature]
+    type = PorousFlowTemperature
+    at_nodes = true
+  [../]
+  [./temperature_qp]
+    type = PorousFlowTemperature
+  [../]
+  [./waterncg]
+    type = PorousFlowFluidStateWaterNCG
+    gas_porepressure = pgas
+    z = zi
+    gas_fp = tabulated
+    water_fp = water
+    at_nodes = true
+    temperature_unit = Celsius
+    sat_lr = 0.1
+  [../]
+  [./waterncg_qp]
+    type = PorousFlowFluidStateWaterNCG
+    gas_porepressure = pgas
+    z = zi
+    gas_fp = tabulated
+    water_fp = water
+    temperature_unit = Celsius
+    sat_lr = 0.1
+  [../]
+  [./porosity]
+    type = PorousFlowPorosityConst
+    at_nodes = true
+    porosity = 0.2
+  [../]
+  [./permeability]
+    type = PorousFlowPermeabilityConst
+    permeability = '1e-12 0 0 0 1e-12 0 0 0 1e-12'
+  [../]
+  [./relperm_water]
+    type = PorousFlowRelativePermeabilityCorey
+    at_nodes = true
+    n = 2
+    phase = 0
+    s_res = 0.1
+    sum_s_res = 0.1
+  [../]
+  [./relperm_gas]
+    type = PorousFlowRelativePermeabilityCorey
+    at_nodes = true
+    n = 2
+    phase = 1
+  [../]
+  [./relperm_all]
+    type = PorousFlowJoiner
+    at_nodes = true
+    material_property = PorousFlow_relative_permeability_nodal
+  [../]
+[]
+
+[BCs]
+  [./rightwater]
+    type = DirichletBC
+    boundary = right
+    value = 20e6
+    variable = pgas
+  [../]
+[]
+
+[DiracKernels]
+  [./source]
+    type = PorousFlowSquarePulsePointSource
+    point = '0 0 0'
+    mass_flux = 2
+    variable = zi
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+    petsc_options = '-snes_converged_reason -ksp_diagonal_scale -ksp_diagonal_scale_fix -ksp_gmres_modifiedgramschmidt -snes_linesearch_monitor'
+    petsc_options_iname = '-ksp_type -pc_type -sub_pc_type -sub_pc_factor_shift_type -pc_asm_overlap -snes_atol -snes_rtol -snes_max_it'
+    petsc_options_value = 'gmres      asm      lu           NONZERO                   2               1E-8       1E-10 20'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  end_time = 1e5
+  dtmax = 1e5
+  [./TimeStepper]
+    type = IterationAdaptiveDT
+    dt = 1
+    growth_factor = 1.5
+  [../]
+[]
+
+[VectorPostprocessors]
+  [./line]
+    type = NodalValueSampler
+    sort_by = x
+    variable = 'pgas zi'
+    execute_on = 'timestep_end'
+  [../]
+  [./line2]
+    type = LineValueSampler
+    sort_by = x
+    start_point = '0 0 0'
+    end_point = '1000 0 0'
+    num_points = 1500
+    variable = 'saturation_gas x1 pgas'
+  [../]
+[]
+
+[Postprocessors]
+  [./pgas]
+    type = PointValue
+    point =  '4 0 0'
+    variable = pgas
+  [../]
+  [./sgas]
+    type = PointValue
+    point =  '4 0 0'
+    variable = saturation_gas
+  [../]
+  [./zi]
+    type = PointValue
+    point = '4 0 0'
+    variable = zi
+  [../]
+  [./massgas]
+    type = PorousFlowFluidMass
+    fluid_component = 1
+  [../]
+  [./x1]
+    type = PointValue
+    point =  '4 0 0'
+    variable = x1
+  [../]
+  [./y0]
+    type = PointValue
+    point =  '4 0 0'
+    variable = y0
+  [../]
+[]
+
+[Outputs]
+  print_linear_residuals = false
+  print_perf_log = true
+  [./csvout]
+    type = CSV
+    file_base = theis_csvout
+    execute_on = timestep_end
+    execute_vector_postprocessors_on = final
+  [../]
+[]


### PR DESCRIPTION
The `CO2FluidProperties` formulation in `fluid_properties` requires iterations to calculate properties as a function of pressure and temperature. To speed up calculation, interpolation is used on tabulated data.

This adds a base class in utils to read and write tabulated data files, and a tabulated version of `CO2FluidProperties`.

Refs #9016 