### PR TITLE
Filter out PETSc WARNING messages for the Json test

### DIFF
--- a/python/peacock/Input/JsonData.py
+++ b/python/peacock/Input/JsonData.py
@@ -40,7 +40,9 @@ class JsonData(object):
         Return:
             the data
         """
-        data = ExeLauncher.runExe(app_path, "--json")
+        #  "-options_left 0" is used to stop the debug version of PETSc from printing
+        # out WARNING messages that sometime confuse the json parser
+        data = ExeLauncher.runExe(app_path, ["-options_left","0","--json"] )
         data = data.split('**START JSON DATA**\n')[1]
         data = data.split('**END JSON DATA**')[0]
         return data

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -31,6 +31,10 @@ def run_app(args=[]):
     proc = None
     app_name = find_app()
     args.insert(0, app_name)
+    #  "-options_left 0" is used to stop the debug version of PETSc from printing
+    # out WARNING messages that sometime confuse the json parser
+    args.insert(1, "-options_left")
+    args.insert(2, "0")
     cmd_line = ' '.join(args)
     try:
         proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
The debug version of PETSc prints out WARNING messages by default if there are some unused options left. This confuses the Json test, and we therefore filter out those for the Json test. 

Closes  #9031
