### PR TITLE
Add one option to allow users ignore zeros in Jacobian

### DIFF
--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -1197,6 +1197,10 @@ public:
     _error_on_jacobian_nonzero_reallocation = state;
   }
 
+  bool ignoreZerosInJacobian() { return _ignore_zeros_in_jacobian; }
+
+  void setIgnoreZerosInJacobian(bool state) { _ignore_zeros_in_jacobian = state; }
+
   /// Returns whether or not this Problem has a TimeIntegrator
   bool hasTimeIntegrator() const { return _has_time_integrator; }
 
@@ -1504,6 +1508,7 @@ protected:
 
 private:
   bool _error_on_jacobian_nonzero_reallocation;
+  bool _ignore_zeros_in_jacobian;
   bool _force_restart;
   bool _fail_next_linear_convergence_check;
 

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -129,6 +129,10 @@ validParams<FEProblemBase>()
                         false,
                         "This causes PETSc to error if it had to reallocate memory in the Jacobian "
                         "matrix due to not having enough nonzeros");
+  params.addParam<bool>("ignore_zeros_in_jacobian",
+                        false,
+                        "Do not explicitly store zero values in "
+                        "the Jacobian matrix if true");
   params.addParam<bool>("force_restart",
                         false,
                         "EXPERIMENTAL: If true, a sub_app may use a "
@@ -197,6 +201,7 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _current_execute_on_flag(EXEC_NONE),
     _error_on_jacobian_nonzero_reallocation(
         getParam<bool>("error_on_jacobian_nonzero_reallocation")),
+    _ignore_zeros_in_jacobian(getParam<bool>("ignore_zeros_in_jacobian")),
     _force_restart(getParam<bool>("force_restart")),
     _fail_next_linear_convergence_check(false),
     _currently_computing_jacobian(false),

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -1398,6 +1398,9 @@ NonlinearSystemBase::constraintJacobians(SparseMatrix<Number> & jacobian, bool d
     MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
                  MAT_NEW_NONZERO_ALLOCATION_ERR,
                  PETSC_FALSE);
+  if (_fe_problem.ignoreZerosInJacobian())
+    MatSetOption(
+        static_cast<PetscMatrix<Number> &>(jacobian).mat(), MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
 #endif
 
   std::vector<numeric_index_type> zero_rows;


### PR DESCRIPTION
Users may add a lot of zeros into matrix. Add one option here to allow users ignore zeros in Jacobian if they want. It will save memory and also may prevent some allocation calls. 

Closes #9033
