### PR TITLE
Fix Factory Deprecated Registration

### DIFF
--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -35,8 +35,9 @@ class InputParameters;
 #define registerNamedObject(obj, name) factory.reg<obj>(name, __FILE__, __LINE__)
 #define registerDeprecatedObject(name, time)                                                       \
   factory.regDeprecated<name>(stringifyName(name), time, __FILE__, __LINE__)
-#define registerDeprecatedObjectName(obj, name, time)                                              \
-  factory.regReplaced<obj>(stringifyName(obj), name, time, __FILE__, __LINE__)
+
+#define registerDeprecatedObjectWithReplacement(dep_obj, replacement_name, time)                   \
+  factory.regReplaced<dep_obj>(stringifyName(dep_obj), replacement_name, time, __FILE__, __LINE__)
 
 // for backward compatibility
 #define registerKernel(name) registerObject(name)
@@ -188,6 +189,8 @@ public:
    * Register a deprecated object that expires
    * @param obj_name The name of the object to register
    * @param t_str String containing the expiration date for the object
+   *
+   * Note: Params file and line are supplied by the macro
    */
   template <typename T>
   void regDeprecated(const std::string & obj_name,
@@ -203,23 +206,25 @@ public:
   }
 
   /**
-   * Register a deprecated object that expires and has a replacement object
-   * @param obj_name The name of the object to register (the new object you want people to use)
-   * @param name The name of the object that is deprecated
-   * @param t_str String containing the expiration date for the object
+   * Registers an object as deprecated and associates it with the replacement name.
+   * @param dep_obj - The name (type) of the object being registered (the deprecated type)
+   * @param replacement_name - The name of the object replacing the deprecated object (new name)
+   * @param time_str - Time at which the deprecated message prints as  an error "MM/DD/YYYY HH:MM"
+   *
+   * Note: Params file and line are supplied by the macro
    */
   template <typename T>
-  void regReplaced(const std::string & obj_name,
-                   const std::string & name,
-                   const std::string t_str,
+  void regReplaced(const std::string & dep_obj,
+                   const std::string & replacement_name,
+                   const std::string time_str,
                    const std::string & file,
                    int line)
   {
     // Register the name
-    regDeprecated<T>(name, t_str, file, line);
+    regDeprecated<T>(dep_obj, time_str, file, line);
 
     // Store the new name
-    _deprecated_name[name] = obj_name;
+    _deprecated_name[dep_obj] = replacement_name;
   }
 
   /**

--- a/modules/navier_stokes/src/base/NavierStokesApp.C
+++ b/modules/navier_stokes/src/base/NavierStokesApp.C
@@ -247,12 +247,6 @@ NavierStokesApp::registerObjects(Factory & factory)
   registerKernel(INSMass);
   registerKernel(INSMassRZ);
   registerKernel(INSMomentumTimeDerivative);
-  // INSMomentum is now deprecated, convert input files to use
-  // INSMomentumLaplaceForm or INSMomentumTractionForm instead.
-  registerDeprecatedObjectName(INSMomentumTractionForm, "INSMomentum", "10/07/2017 12:00");
-  // INSMomentumRZ has been renamed, convert input files to use
-  // INSMomentumTractionFormRZ.
-  registerDeprecatedObjectName(INSMomentumTractionFormRZ, "INSMomentumRZ", "10/07/2017 12:00");
   registerKernel(INSMomentumTractionForm);
   registerKernel(INSMomentumTractionFormRZ);
   registerKernel(INSMomentumLaplaceForm);
@@ -268,10 +262,6 @@ NavierStokesApp::registerObjects(Factory & factory)
   registerKernel(INSCompressibilityPenalty);
 
   // BCs
-  // Register the newly-named class with the old name for a while in
-  // case anyone is using this in their app.
-  registerDeprecatedObjectName(
-      INSMomentumNoBCBCTractionForm, "INSMomentumNoBCBC", "10/07/2017 12:00");
   registerBoundaryCondition(INSMomentumNoBCBCTractionForm);
   registerBoundaryCondition(INSMomentumNoBCBCLaplaceForm);
   registerBoundaryCondition(INSTemperatureNoBCBC);

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -372,7 +372,6 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerKernel(SwitchingFunctionConstraintEta);
   registerKernel(SwitchingFunctionConstraintLagrange);
   registerKernel(SwitchingFunctionPenalty);
-  registerDeprecatedObjectName(LaplacianSplit, "CHSplitVar", "07/01/2017 00:00");
 
   registerInitialCondition(BimodalInverseSuperellipsoidsIC);
   registerInitialCondition(BimodalSuperellipsoidsIC);

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -377,7 +377,7 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerInitialCondition(BimodalSuperellipsoidsIC);
   registerInitialCondition(ClosePackIC);
   registerInitialCondition(CrossIC);
-  registerDeprecatedObjectName(PolycrystalHex, "HexPolycrystalIC", "07/01/2017 00:00");
+  registerDeprecatedObjectWithReplacement(HexPolycrystalIC, "PolycrystalHex", "07/01/2017 00:00");
   registerInitialCondition(LatticeSmoothCircleIC);
   registerInitialCondition(MultiBoundingBoxIC);
   registerInitialCondition(MultiSmoothCircleIC);

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -279,8 +279,6 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerMaterial(ComputeExtraStressConstant);
   registerMaterial(ComputeVariableBaseEigenStrain);
   registerMaterial(ComputeVariableEigenstrain);
-  registerDeprecatedObjectName(
-      ComputeThermalExpansionEigenstrain, "ComputeThermalExpansionEigenStrain", "12/19/2016 00:00");
   registerMaterial(ComputeThermalExpansionEigenstrain);
   registerMaterial(ComputeMeanThermalExpansionFunctionEigenstrain);
   registerMaterial(ComputeInstantaneousThermalExpansionFunctionEigenstrain);


### PR DESCRIPTION
Specifically, I'm reversing the parameters to the existing method (and giving it a better name). We should be registering the old class but providing the new name as a string that is givin in the error message. If you register the new method, you get the new `validParams()` which might be very wrong.

closes #9035

