### PR TITLE
CNSFV block restriction

### DIFF
--- a/modules/navier_stokes/src/userobjects/CNSFVLeastSquaresSlopeReconstruction.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVLeastSquaresSlopeReconstruction.C
@@ -125,12 +125,12 @@ CNSFVLeastSquaresSlopeReconstruction::reconstructElementSlope()
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
+    const Elem * neig = elem->neighbor(is);
 
     /// for internal side
 
-    if (elem->neighbor(is) != NULL)
+    if (neig != NULL && this->hasBlocks(neig->subdomain_id()))
     {
-      const Elem * neig = elem->neighbor(is);
       dof_id_type neigID = neig->id();
 
       if (!_side_geoinfo_cached)


### PR DESCRIPTION
Let's try this again.

A change to CNSFVLeastSquaresSlopeReconstruction.C redefines an internal side to be a boundary for which a neighboring element exists and is a member of the subdomain. Internal boundaries between subdomains are now handled in the same manner as external boundaries. This permits CNSFV variables to be restricted to specific subdomains of the problem.

closes #8851 