### PR TITLE
Only update python script window if it is changed.

### DIFF
--- a/python/peacock/base/OutputWidgetBase.py
+++ b/python/peacock/base/OutputWidgetBase.py
@@ -37,8 +37,10 @@ class OutputWidgetBase(QtWidgets.QWidget):
         Updates the live script view.
         """
         if self.LiveScript.isVisible() and hasattr(self, "_plugin_manager"):
+            # don't reset the text if it is the same. This allows for easier select/copy
             s = self._plugin_manager.repr()
-            self.LiveScript.setText(s)
+            if s != self.LiveScript.toPlainText():
+                self.LiveScript.setText(s)
 
     def _setupPythonButton(self, qobject):
         """


### PR DESCRIPTION
When the python script window is visible it gets updated every second (however often the ExodusViewer checks file changes). On each update it calls `setText()` which clears anything selected, making selecting and copying difficult.
This just makes it call `setText()` if it has actually changed and so you can actually select/copy.

closes #9052