### PR TITLE
DistributedMesh test workarounds

### DIFF
--- a/test/tests/materials/stateful_prop/spatial_adaptivity_test.i
+++ b/test/tests/materials/stateful_prop/spatial_adaptivity_test.i
@@ -6,6 +6,9 @@
   uniform_refine = 3
   # This option is necessary if you have uniform refinement + stateful material properties + adaptivity
   skip_partitioning = true
+  # stateful material properties + adaptivity are not yet compatible
+  # with distributed meshes
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/materials/stateful_prop/stateful_prop_adaptivity_test.i
+++ b/test/tests/materials/stateful_prop/stateful_prop_adaptivity_test.i
@@ -7,6 +7,9 @@
   uniform_refine = 2
   # This option is necessary if you have uniform refinement + stateful material properties + adaptivity
   skip_partitioning = true
+  # stateful material properties + adaptivity are not yet compatible
+  # with distributed meshes
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/outputs/oversample/over_sampling_second_file.i
+++ b/test/tests/outputs/oversample/over_sampling_second_file.i
@@ -1,7 +1,11 @@
 [Mesh]
   type = FileMesh
-  file = wedge18_mesh.e
   # Read in and work with a second order mesh
+  file = wedge18_mesh.e
+  # If we have an oversample mesh file, we haven not yet implemented
+  # synchronization of its partitioning with the problem mesh, so we
+  # need to keep the problem mesh replicated.
+  parallel_type = replicated
 []
 
 [Functions]

--- a/test/tests/transfers/multiapp_nearest_node_transfer/fromsub_displaced_sub.i
+++ b/test/tests/transfers/multiapp_nearest_node_transfer/fromsub_displaced_sub.i
@@ -4,6 +4,9 @@
   nx = 10
   ny = 10
   displacements = 'disp_x disp_y'
+  # Transferring data from a sub application is currently only
+  # supported with a ReplicatedMesh
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/transfers/multiapp_variable_value_sample_transfer/master.i
+++ b/test/tests/transfers/multiapp_variable_value_sample_transfer/master.i
@@ -4,6 +4,9 @@
   # Yes we want a slightly irregular grid
   nx = 11
   ny = 11
+  # We will transfer data to the sub app, and that is currently only
+  # supported from a replicated mesh
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/vectorpostprocessors/intersection_points_along_line/1d.i
+++ b/test/tests/vectorpostprocessors/intersection_points_along_line/1d.i
@@ -2,6 +2,8 @@
   type = GeneratedMesh
   dim = 1
   nx = 10
+  # Ray tracing code is not yet compatible with DistributedMesh
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/vectorpostprocessors/intersection_points_along_line/2d.i
+++ b/test/tests/vectorpostprocessors/intersection_points_along_line/2d.i
@@ -3,6 +3,8 @@
   dim = 2
   nx = 10
   ny = 10
+  # Ray tracing code is not yet compatible with DistributedMesh
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/vectorpostprocessors/intersection_points_along_line/3d.i
+++ b/test/tests/vectorpostprocessors/intersection_points_along_line/3d.i
@@ -4,6 +4,8 @@
   nx = 10
   ny = 10
   nz = 10
+  # Ray tracing code is not yet compatible with DistributedMesh
+  parallel_type = replicated
 []
 
 [Variables]


### PR DESCRIPTION
This disables a few more of the remaining failing tests in #1500, and adds comments about why specifically each is disabled.

We're down to about 20 as-yet-unexplained failures, but I expect them to be slow going.  I do want to *understand* each failure before just marking it as "doesn't work yet", to make sure that they correspond to unsupported features rather than to features-we-incorrectly-think-are-supported.