### PR TITLE
Fix render delay when changing timesteps.

### DIFF
--- a/python/peacock/ExodusViewer/plugins/MediaControlPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/MediaControlPlugin.py
@@ -59,8 +59,8 @@ class MediaControlPlugin(QtWidgets.QGroupBox, peacock.base.MediaControlWidgetBas
         if 'time' in kwargs:
             self.readerOptionsChanged.emit({'time':kwargs.get('time')})
 
-        self.windowRequiresUpdate.emit()
         self.timeChanged.emit()
+        self.windowRequiresUpdate.emit()
 
 def main(size=None):
     """


### PR DESCRIPTION
On the ExodusViewer, if the variable min/max changed between timesteps there was a noticeable delay between switching timesteps and the render window getting updated.
An example input file would be
 `modules/phase_field/tests/grain_tracker_test/grain_tracker_remapping_test.i`
on the first and second time steps.

@permcody This seemed to fix it for me....