### PR TITLE
Add a global parameters block to the json dump

### DIFF
--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -78,6 +78,8 @@ protected:
 
   std::string prettyCppType(const std::string & cpp_type);
   std::string basicCppType(const std::string & cpp_type);
+  size_t
+  setParams(InputParameters * params, bool search_match, moosecontrib::Json::Value & all_params);
 
   std::string
   buildOutputString(const std::iterator_traits<InputParameters::iterator>::value_type & p);

--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -73,6 +73,11 @@ public:
    */
   void addSyntaxType(const std::string & path, const std::string type);
 
+  /**
+   * Add the global section to the output
+   */
+  void addGlobal();
+
 protected:
   std::string buildOptions(const std::iterator_traits<InputParameters::iterator>::value_type & p);
 

--- a/framework/src/outputs/formatters/JsonInputFileFormatter.C
+++ b/framework/src/outputs/formatters/JsonInputFileFormatter.C
@@ -24,8 +24,8 @@ JsonInputFileFormatter::toString(const moosecontrib::Json::Value & root)
 {
   _stream.clear();
   _stream.str("");
-  for (auto && name : root.getMemberNames())
-    addBlock(name, root[name], true);
+  for (auto && name : root["blocks"].getMemberNames())
+    addBlock(name, root["blocks"][name], true);
   return _stream.str();
 }
 

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -668,6 +668,7 @@ Parser::buildJsonSyntaxTree(JsonSyntaxTree & root) const
       }
     }
   }
+  root.addGlobal();
 }
 
 void

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -43,7 +43,7 @@ JsonSyntaxTree::getJson(const std::string & path)
 {
   auto paths = splitPath(path);
   mooseAssert(paths.size() > 0, "path is empty");
-  moosecontrib::Json::Value * next = &_root[paths[0]];
+  moosecontrib::Json::Value * next = &_root["blocks"][paths[0]];
 
   for (auto pit = paths.begin() + 1; pit != paths.end(); ++pit)
   {
@@ -117,6 +117,19 @@ JsonSyntaxTree::setParams(InputParameters * params,
     all_params[iter.first] = param_json;
   }
   return count;
+}
+
+void
+JsonSyntaxTree::addGlobal()
+{
+  // If they are doing a search they probably don't want to see this
+  if (_search.empty())
+  {
+    auto params = validParams<Action>();
+    moosecontrib::Json::Value jparams;
+    setParams(&params, true, jparams);
+    _root["global"]["parameters"] = jparams;
+  }
 }
 
 bool

--- a/python/peacock/Input/ExecutableInfo.py
+++ b/python/peacock/Input/ExecutableInfo.py
@@ -146,7 +146,7 @@ class ExecutableInfo(object):
     def _createPathMap(self):
         self.path_map = {}
         self.root_info = BlockInfo(None, "/", False, "root node")
-        for name, block in self.json_data.json_data.iteritems():
+        for name, block in self.json_data.json_data["blocks"].iteritems():
             block["name"] = name
             block_info = self._processChild(self.root_info, block, True)
             self.root_info.addChildBlock(block_info)

--- a/python/peacock/Input/JsonData.py
+++ b/python/peacock/Input/JsonData.py
@@ -42,7 +42,7 @@ class JsonData(object):
         """
         #  "-options_left 0" is used to stop the debug version of PETSc from printing
         # out WARNING messages that sometime confuse the json parser
-        data = ExeLauncher.runExe(app_path, ["-options_left","0","--json"] )
+        data = ExeLauncher.runExe(app_path, ["-options_left", "0", "--json"] )
         data = data.split('**START JSON DATA**\n')[1]
         data = data.split('**END JSON DATA**')[0]
         return data

--- a/python/peacock/tests/input_tab/JsonData/test_JsonData.py
+++ b/python/peacock/tests/input_tab/JsonData/test_JsonData.py
@@ -25,7 +25,9 @@ class Tests(Testing.PeacockTester):
         path = Testing.find_moose_test_exe()
         y.appChanged(path)
         self.assertNotEqual(y.json_data, None)
-        self.assertIn("Variables", y.json_data.keys())
+        self.assertIn("blocks", y.json_data.keys())
+        self.assertIn("global", y.json_data.keys())
+        self.assertIn("Variables", y.json_data["blocks"].keys())
 
     def testPickle(self):
         y = JsonData()

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -71,7 +71,9 @@ class TestJSON(unittest.TestCase):
         Some basic checks to see if some data
         is there and is in the right location.
         """
-        data = self.getJsonData()
+        all_data = self.getJsonData()
+        self.assertIn("active", all_data["global"]["parameters"])
+        data = all_data["blocks"]
         self.assertIn("Executioner", data)
         self.assertIn("BCs", data)
         bcs = data["BCs"]
@@ -107,7 +109,9 @@ class TestJSON(unittest.TestCase):
         """
         Make sure parameter search works
         """
-        data = self.getJsonData(["initial_marker"])
+        all_data = self.getJsonData(["initial_marker"])
+        self.assertNotIn("global", all_data)
+        data = all_data["blocks"]
         self.assertNotIn("Executioner", data)
         self.assertNotIn("BCs", data)
         self.assertIn("Adaptivity", data)
@@ -117,7 +121,8 @@ class TestJSON(unittest.TestCase):
         self.assertEqual(len(params.keys()), 1)
 
         # test to make sure it matches blocks as well
-        data = self.getJsonData(["diffusion"])
+        all_data = self.getJsonData(["diffusion"])
+        data = all_data["blocks"]
         self.assertEqual(len(data.keys()), 2)
         self.assertIn("BadKernels", data)
         self.assertIn("Kernels", data)
@@ -183,7 +188,8 @@ class TestJSON(unittest.TestCase):
         """
         Make sure file/line information works
         """
-        data = self.getJsonData()
+        all_data = self.getJsonData()
+        data = all_data["blocks"]
         adapt = data["Adaptivity"]["actions"]["SetAdaptivityOptionsAction"]
         fi = adapt["file_info"]
         self.assertEqual(len(fi.keys()), 1)


### PR DESCRIPTION
We need to indicate that the "active" parameter can occur in any block of an input file.
Instead of adding "active" to every block in the output, this creates a new "global/parameters".
This section is intended to indicate that each specified parameter can be used anywhere.

This also puts all the blocks under the "blocks" key, so anything currently using the JSON output will break.  This opens up the ability to easily add other non-block information to the output file (although I don't currently know what that might be).

closes #9047