### PR TITLE
Add ability to set reserved parameter values.

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -649,6 +649,17 @@ public:
    */
   const std::set<std::string> & getControllableParameters() const { return _controllable_params; }
 
+  /**
+   * Provide a set of reserved values for a parameter. These are values that are in addition
+   * to the normal set of values the parameter can take.
+   */
+  void setReservedValues(const std::string & name, const std::set<std::string> & reserved);
+
+  /**
+   * Get a set of reserved parameter values
+   */
+  std::set<std::string> reservedValues(const std::string & name) const;
+
 private:
   // Private constructor so that InputParameters can only be created in certain places.
   InputParameters();
@@ -727,6 +738,9 @@ private:
 
   /// A list of parameters declared as controllable
   std::set<std::string> _controllable_params;
+
+  /// The reserved option names for a parameter
+  std::map<std::string, std::set<std::string>> _reserved_values;
 
   /// Flag for disabling deprecated parameters message, this is used by applyParameters to avoid dumping messages
   bool _show_deprecated_message;

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -656,7 +656,8 @@ public:
   void setReservedValues(const std::string & name, const std::set<std::string> & reserved);
 
   /**
-   * Get a set of reserved parameter values
+   * Get a set of reserved parameter values.
+   * Returns a set by value since we can return an empty set.
    */
   std::set<std::string> reservedValues(const std::string & name) const;
 

--- a/framework/src/outputs/OutputInterface.C
+++ b/framework/src/outputs/OutputInterface.C
@@ -30,6 +30,8 @@ validParams<OutputInterface>()
                                            "associated with this object");
 
   params.addParamNamesToGroup("outputs", "Advanced");
+  std::set<std::string> reserved = {"all", "none"};
+  params.setReservedValues("outputs", reserved);
 
   return params;
 }

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -157,6 +157,7 @@ InputParameters::operator=(const InputParameters & rhs)
   _set_by_add_param = rhs._set_by_add_param;
   _allow_copy = rhs._allow_copy;
   _controllable_params = rhs._controllable_params;
+  _reserved_values = rhs._reserved_values;
 
   return *this;
 }
@@ -185,6 +186,7 @@ InputParameters::operator+=(const InputParameters & rhs)
                                       rhs._default_postprocessor_value.end());
   _set_by_add_param.insert(rhs._set_by_add_param.begin(), rhs._set_by_add_param.end());
   _controllable_params.insert(rhs._controllable_params.begin(), rhs._controllable_params.end());
+  _reserved_values.insert(rhs._reserved_values.begin(), rhs._reserved_values.end());
   return *this;
 }
 
@@ -966,4 +968,20 @@ InputParameters::getParamHelper<MultiMooseEnum>(const std::string & name,
                                                 const MultiMooseEnum *)
 {
   return pars.get<MultiMooseEnum>(name);
+}
+
+void
+InputParameters::setReservedValues(const std::string & name, const std::set<std::string> & reserved)
+{
+  _reserved_values.insert(std::make_pair(name, reserved));
+}
+
+std::set<std::string>
+InputParameters::reservedValues(const std::string & name) const
+{
+  auto it = _reserved_values.find(name);
+  if (it == _reserved_values.end())
+    return std::set<std::string>();
+  else
+    return it->second;
 }

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -106,7 +106,7 @@ JsonSyntaxTree::setParams(InputParameters * params,
 
     param_json["options"] = buildOptions(iter);
     auto reserved_values = params->reservedValues(iter.first);
-    for (auto & reserved : reserved_values)
+    for (const auto & reserved : reserved_values)
       param_json["reserved_values"].append(reserved);
 
     std::string t = prettyCppType(params->type(iter.first));

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -105,6 +105,10 @@ JsonSyntaxTree::setParams(InputParameters * params,
       param_json["default"] = params->defaultCoupledValue(iter.first);
 
     param_json["options"] = buildOptions(iter);
+    auto reserved_values = params->reservedValues(iter.first);
+    for (auto & reserved : reserved_values)
+      param_json["reserved_values"].append(reserved);
+
     std::string t = prettyCppType(params->type(iter.first));
     param_json["cpp_type"] = t;
     param_json["basic_type"] = basicCppType(t);

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -105,6 +105,11 @@ class TestJSON(unittest.TestCase):
         self.assertIn("associated_types", f)
         self.assertEquals(["FunctionName"], f["associated_types"])
 
+        a = data["Adaptivity"]
+        i = a["subblocks"]["Indicators"]["star"]["subblock_types"]["AnalyticalIndicator"]
+        self.assertIn("all", i["parameters"]["outputs"]["reserved_values"])
+        self.assertIn("none", i["parameters"]["outputs"]["reserved_values"])
+
     def testJsonSearch(self):
         """
         Make sure parameter search works


### PR DESCRIPTION
`OutputInterface` has a couple of reserved parameter values: `all` and `none`. These can appear in the input file but the NEAMS IPL validator has no way of knowing about them.
This PR adds a "reserved_values" key with a list of reserved values for a parameter.

Not sure if there are other instances of types that have reserved values.

Note that in the case of `OutputInterface`, these reserved values also restrict the allowed block names. Ie, you can't have a block named `all` or `none`. I don't know if we want to capture that information at the block level as well.

closes #9048