### PR TITLE
JIT fallback warning to info

### DIFF
--- a/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/DerivativeParsedMaterialHelper.C
@@ -174,7 +174,7 @@ DerivativeParsedMaterialHelper::assembleDerivatives()
       if (!_disable_fpoptimizer)
         newitem._F->Optimize();
       if (_enable_jit && !newitem._F->JITCompile())
-        mooseWarning("Failed to JIT compile expression, falling back to byte code interpretation.");
+        mooseInfo("Failed to JIT compile expression, falling back to byte code interpretation.");
 
       // generate material property argument vector
       std::vector<VariableName> darg_names(0);

--- a/modules/phase_field/src/materials/ParsedMaterialHelper.C
+++ b/modules/phase_field/src/materials/ParsedMaterialHelper.C
@@ -173,7 +173,7 @@ ParsedMaterialHelper::functionsOptimize()
   if (!_disable_fpoptimizer)
     _func_F->Optimize();
   if (_enable_jit && !_func_F->JITCompile())
-    mooseWarning("Failed to JIT compile expression, falling back to byte code interpretation.");
+    mooseInfo("Failed to JIT compile expression, falling back to byte code interpretation.");
 }
 
 void


### PR DESCRIPTION
Hitting the fallback does not warrant a _warning_. Changed to _info_.

Closes #9070