### PR TITLE
Fix pylint warnings in python/MooseDocs

### DIFF
--- a/python/MooseDocs/tests/bibtex/test_bibtex.py
+++ b/python/MooseDocs/tests/bibtex/test_bibtex.py
@@ -14,10 +14,8 @@
 #                               See COPYRIGHT for full restrictions                                #
 ####################################################################################################
 
-import os
 import unittest
 
-import MooseDocs
 from MooseDocs.testing import MarkdownTestCase
 
 class TestBibtexExtension(MarkdownTestCase):


### PR DESCRIPTION
We now do a pylint check in python/MooseDocs but the recent #9050 wasn't quite clean.