### PR TITLE
Capture class name associated with an object name

### DIFF
--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -32,7 +32,13 @@ class InputParameters;
  */
 #define stringifyName(name) #name
 #define registerObject(name) factory.reg<name>(stringifyName(name), __FILE__, __LINE__)
-#define registerNamedObject(obj, name) factory.reg<obj>(name, __FILE__, __LINE__)
+#define registerNamedObject(obj, name)                                                             \
+  do                                                                                               \
+  {                                                                                                \
+    factory.reg<obj>(name, __FILE__, __LINE__);                                                    \
+    factory.associateNameToClass(name, stringifyName(obj));                                        \
+  } while (0)
+
 #define registerDeprecatedObject(name, time)                                                       \
   factory.regDeprecated<name>(stringifyName(name), time, __FILE__, __LINE__)
 
@@ -186,6 +192,20 @@ public:
   FileLineInfo getLineInfo(const std::string & name) const;
 
   /**
+   * Associates an object name with a class name.
+   * Primarily used with the registerNamed* macros to store the
+   * mapping between the object name and the class that implements the object.
+   */
+  void associateNameToClass(const std::string & name, const std::string & class_name);
+
+  /**
+   * Get the associated class name for an object name.
+   * This will return an empty string if the name was not previously
+   * associated with a class name via associateNameToClass()
+   */
+  std::string associatedClassName(const std::string & name) const;
+
+  /**
    * Register a deprecated object that expires
    * @param obj_name The name of the object to register
    * @param t_str String containing the expiration date for the object
@@ -325,6 +345,9 @@ protected:
   std::map<std::string, paramsPtr> _name_to_params_pointer;
 
   FileLineInfoMap _name_to_line;
+
+  /// Object name to class name association
+  std::map<std::string, std::string> _name_to_class;
 
   /// Storage for deprecated object experiation dates
   std::map<std::string, time_t> _deprecated_time;

--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -47,7 +47,8 @@ public:
                      const std::string & action,
                      bool is_action,
                      InputParameters * params,
-                     const FileLineInfo & lineinfo);
+                     const FileLineInfo & lineinfo,
+                     const std::string & classname);
 
   /**
    * Add a task to the tree

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -189,3 +189,19 @@ Factory::getLineInfo(const std::string & name) const
 {
   return _name_to_line.getInfo(name);
 }
+
+void
+Factory::associateNameToClass(const std::string & name, const std::string & class_name)
+{
+  _name_to_class[name] = class_name;
+}
+
+std::string
+Factory::associatedClassName(const std::string & name) const
+{
+  auto it = _name_to_class.find(name);
+  if (it == _name_to_class.end())
+    return "";
+  else
+    return it->second;
+}

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -595,7 +595,8 @@ Parser::buildJsonSyntaxTree(JsonSyntaxTree & root) const
                                            action,
                                            true,
                                            &action_obj_params,
-                                           _syntax.getLineInfo(act_name, action, ""));
+                                           _syntax.getLineInfo(act_name, action, ""),
+                                           "");
 
     if (params_added)
     {
@@ -657,13 +658,15 @@ Parser::buildJsonSyntaxTree(JsonSyntaxTree & root) const
           moose_obj_params.set<std::string>("type") = moose_obj->first;
 
           auto lineinfo = _factory.getLineInfo(moose_obj->first);
+          std::string classname = _factory.associatedClassName(moose_obj->first);
           root.addParameters(act_name,
                              name,
                              is_type,
                              moose_obj->first,
                              is_action_params,
                              &moose_obj_params,
-                             lineinfo);
+                             lineinfo,
+                             classname);
         }
       }
     }

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -143,7 +143,8 @@ JsonSyntaxTree::addParameters(const std::string & parent,
                               const std::string & action,
                               bool is_action,
                               InputParameters * params,
-                              const FileLineInfo & lineinfo)
+                              const FileLineInfo & lineinfo,
+                              const std::string & classname)
 {
   if (action == "EmptyAction")
     return false;
@@ -174,7 +175,11 @@ JsonSyntaxTree::addParameters(const std::string & parent,
     json["parent_syntax"] = parent;
     json["description"] = params->getClassDescription();
     if (lineinfo.isValid())
+    {
       json["file_info"][lineinfo.file()] = lineinfo.line();
+      if (!classname.empty())
+        json["file_info"]["class"] = classname;
+    }
   }
   return true;
 }

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -178,7 +178,7 @@ JsonSyntaxTree::addParameters(const std::string & parent,
     {
       json["file_info"][lineinfo.file()] = lineinfo.line();
       if (!classname.empty())
-        json["file_info"]["class"] = classname;
+        json["class"] = classname;
     }
   }
   return true;

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -104,6 +104,7 @@ class TestJSON(unittest.TestCase):
         f = data["Functions"]["star"]
         self.assertIn("associated_types", f)
         self.assertEquals(["FunctionName"], f["associated_types"])
+        self.assertEqual(f["subblock_types"]["ParsedFunction"]["file_info"]["class"], "MooseParsedFunction")
 
         a = data["Adaptivity"]
         i = a["subblocks"]["Indicators"]["star"]["subblock_types"]["AnalyticalIndicator"]

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -104,7 +104,7 @@ class TestJSON(unittest.TestCase):
         f = data["Functions"]["star"]
         self.assertIn("associated_types", f)
         self.assertEquals(["FunctionName"], f["associated_types"])
-        self.assertEqual(f["subblock_types"]["ParsedFunction"]["file_info"]["class"], "MooseParsedFunction")
+        self.assertEqual(f["subblock_types"]["ParsedFunction"]["class"], "MooseParsedFunction")
 
         a = data["Adaptivity"]
         i = a["subblocks"]["Indicators"]["star"]["subblock_types"]["AnalyticalIndicator"]


### PR DESCRIPTION
For the registerNamed* macros, the documentation system needs to capture the mapping between the object name and the class name.
For example, for the type "ParsedFunction", the documentation system needs to know that the class for it is "MooseParsedFunction".

refs #7855