### PR TITLE
Adds x y or z based spline interpolation in SplineFunction. Closes #9106

### DIFF
--- a/framework/include/functions/SplineFunction.h
+++ b/framework/include/functions/SplineFunction.h
@@ -39,6 +39,9 @@ public:
 
 protected:
   SplineInterpolation _ipol;
+
+  /// Desired component
+  int _component;
 };
 
 #endif /* SPLINEFUNCTION_H */

--- a/framework/src/functions/SplineFunction.C
+++ b/framework/src/functions/SplineFunction.C
@@ -19,6 +19,9 @@ InputParameters
 validParams<SplineFunction>()
 {
   InputParameters params = validParams<Function>();
+  MooseEnum component("x=0 y=1 z=2", "x");
+  params.addParam<MooseEnum>(
+      "component", component, "The component of the geometry point to interpolate with");
   params.addRequiredParam<std::vector<Real>>("x", "The abscissa values");
   params.addRequiredParam<std::vector<Real>>("y", "The ordinate values");
   params.addParam<Real>(
@@ -34,14 +37,15 @@ SplineFunction::SplineFunction(const InputParameters & parameters)
     _ipol(getParam<std::vector<Real>>("x"),
           getParam<std::vector<Real>>("y"),
           getParam<Real>("yp1"),
-          getParam<Real>("ypn"))
+          getParam<Real>("ypn")),
+    _component(getParam<MooseEnum>("component"))
 {
 }
 
 Real
 SplineFunction::value(Real /*t*/, const Point & p)
 {
-  return _ipol.sample(p(0));
+  return _ipol.sample(p(_component));
 }
 
 RealGradient
@@ -55,11 +59,11 @@ SplineFunction::gradient(Real /*t*/, const Point & p)
 Real
 SplineFunction::derivative(const Point & p)
 {
-  return _ipol.sampleDerivative(p(0));
+  return _ipol.sampleDerivative(p(_component));
 }
 
 Real
 SplineFunction::secondDerivative(const Point & p)
 {
-  return _ipol.sample2ndDerivative(p(0));
+  return _ipol.sample2ndDerivative(p(_component));
 }


### PR DESCRIPTION
Added a "component" input param for SplineFunction that access x y or z and uses that component as the interpolation point for the function. Defaults to the original behavior of component = x. Closes #9106 

Does this need an additional test? If so, for all 3 directions?