### PR TITLE
Always enable the FilePlugin on ExodusViewer.

### DIFF
--- a/python/peacock/ExodusViewer/ExodusViewer.py
+++ b/python/peacock/ExodusViewer/ExodusViewer.py
@@ -36,7 +36,7 @@ class ExodusViewer(peacock.base.ViewerBase):
         Args:
             options: Complete parsed command line parameters from argparse.
         """
-        filenames = peacock.utils.getOptionFilenames(options, 'exodus', '.e')
+        filenames = peacock.utils.getOptionFilenames(options, 'exodus', ['.*\.e', '.*\.e-s[0-9]+'])
         self.onSetFilenames(filenames)
 
     def onClone(self):

--- a/python/peacock/ExodusViewer/plugins/FilePlugin.py
+++ b/python/peacock/ExodusViewer/plugins/FilePlugin.py
@@ -179,6 +179,12 @@ class FilePlugin(peacock.base.PeacockCollapsibleWidget, ExodusPlugin):
         if index != self.AvailableFiles.currentIndex():
             self.AvailableFiles.setCurrentIndex(index)
 
+    def onWindowReset(self):
+        """
+        We want to the user to always be able to open files.
+        """
+        super(FilePlugin, self).onWindowReset()
+        self.setEnabled(True)
 
 def main(size=None):
     """

--- a/python/peacock/PostprocessorViewer/PostprocessorViewer.py
+++ b/python/peacock/PostprocessorViewer/PostprocessorViewer.py
@@ -64,7 +64,7 @@ class PostprocessorViewer(peacock.base.ViewerBase):
         Args:
             filenames[list]: A list of filenames to load.
         """
-        filenames = peacock.utils.getOptionFilenames(options, 'postprocessors', '.csv')
+        filenames = peacock.utils.getOptionFilenames(options, 'postprocessors', '.*\.csv')
         self.onSetFilenames(filenames)
 
     def onClone(self):

--- a/python/peacock/PostprocessorViewer/VectorPostprocessorViewer.py
+++ b/python/peacock/PostprocessorViewer/VectorPostprocessorViewer.py
@@ -43,7 +43,7 @@ class VectorPostprocessorViewer(PostprocessorViewer):
         """
         Initialize the manager by appending supplied files from parser.
         """
-        filenames = peacock.utils.getOptionFilenames(options, 'vectorpostprocessors', '*.csv')
+        filenames = peacock.utils.getOptionFilenames(options, 'vectorpostprocessors', '.*\*\.csv')
         self.onSetFilenames(filenames)
 
 def main():

--- a/python/peacock/utils/__init__.py
+++ b/python/peacock/utils/__init__.py
@@ -1,5 +1,7 @@
 import os
-def getOptionFilenames(options, base, extension=None):
+import re
+
+def getOptionFilenames(options, base, extensions=[]):
     """
     Return a list of filenames with correct absolute path.
 
@@ -9,11 +11,15 @@ def getOptionFilenames(options, base, extension=None):
         extension: (Optional) The file extension to parse from 'arguments' command-line option.
     """
     # Complete list of Exodus files to open
+    if not isinstance(extensions, list):
+        extensions = [extensions]
+
     filenames = getattr(options, base)
-    if extension:
+    if extensions:
         for arg in options.arguments:
-            if arg.endswith(extension):
-                filenames.append(arg)
+            for e in extensions:
+                if re.match(e, arg):
+                    filenames.append(arg)
 
     # Make all paths absolute
     for i, fname in enumerate(filenames):


### PR DESCRIPTION
Allow `*.e-s[0-9]+`adaptive exodus files on the command line.

closes #9111
