### PR TITLE
Initial FluidProperties documentation

### DIFF
--- a/docs/app_syntax.yml
+++ b/docs/app_syntax.yml
@@ -8,6 +8,7 @@ links:
         - modules/tensor_mechanics/tests
         - modules/heat_conduction/tests
         - modules/level_set/tests
+        - modules/fluid_properties/tests
     Examples:
         - examples
         - modules/phase_field/examples
@@ -21,6 +22,7 @@ links:
         - modules/tensor_mechanics/include
         - modules/heat_conduction/include
         - modules/level_set/include
+        - modules/fluid_properties/include
 locations:
     - framework:
         doxygen: http://mooseframework.org/docs/doxygen/moose/
@@ -198,3 +200,16 @@ locations:
             - /Postprocessors
             - /Kernels
             - /Materials
+    - fluid_properties:
+        name: Fluid_properties
+        doxygen: http://mooseframework.org/docs/doxygen/modules/
+        paths:
+            - modules/fluid_properties/src
+            - modules/fluid_properties/include
+        hide:
+            - /UserObjects
+            - /Materials
+            - /Modules
+            - /AuxKernels
+            - /Bounds
+            - /Utils

--- a/docs/bib/fluid_properties.bib
+++ b/docs/bib/fluid_properties.bib
@@ -1,0 +1,166 @@
+@article{anderko1992,
+  author = {A. Anderko and K. S. Pitzer},
+  title = {Equation of state for pure sodium chloride},
+  journal = {Fluid Phase Equilibria},
+  volume = {79},
+  pages = {103--112},
+  year = {1992}
+}
+
+@article{driesner2007a,
+  author = {T. Driesner and C. A. Heinrich},
+  title = {{The system H$_2$O-NaCl. Part I: Correlation formulae for phase relations in temperature–pressure–composition space
+from 0 to 1000 C, 0 to 5000 bar, and 0 to 1 X$_{NaCl}$}},
+  journal = {Geochimica et Cosmochimica Acta},
+  volume = {71},
+  pages = {4880--4901},
+  year = {2007}
+}
+
+@article{driesner2007b,
+  author = {T. Driesner},
+  title = {{The system H$_2$O-NaCl. Part II: Correlations for molar volume, enthalpy, and isobaric heat capacity
+  from 0 to 1000 C, 1 to 5000 bar, and 0 to 1 X$_{NaCl}$}},
+  journal = {Geochimica et Cosmochimica Acta},
+  volume = {71},
+  pages = {4902--4919},
+  year = {2007}
+}
+
+@article{fenghour1998,
+  author = {A. Fenghour and W. A. Wakeham and V. Vesovic},
+  title = {The viscosity of carbon dioxide},
+  journal = {J. Phys. Chem. Ref. Data},
+  volume = {27},
+  pages = {31--44},
+  year = {1998}
+}
+
+@techreport{haas1976,
+  author = {Haas Jr, J. L.},
+  title = {{Physical properties of the coexisting phases and thermochemical properties
+  of the H$_2$O component in boiling NaCl solutions}},
+  institution = {United States Geological Survey},
+  number = {USGS Bulletin 1421-A},
+  year = {1976}
+}
+
+@techreport{iapws1997,
+  title = {{Revised Release on the IAPWS Industrial Formulation 1997 for the
+  Thermodynamic Properties of Water and Steam}},
+  author = {IAPWS},
+  institution = {IAPWS},
+  url = {www.iapws.org/relguide/IF97-Rev.pdf},
+  year = {2007}
+}
+
+@techreport{iapws1997region3,
+  title = {{Revised Supplementary Release on Backward Equations for Specific Volume
+  as a Function of Pressure and Temperature v(p,T) for Region 3 of the
+  IAPWS Industrial Formulation 1997 for the Thermodynamic Properties of Water
+  and Steam}},
+  author = {IAPWS},
+  institution = {IAPWS},
+  url = {www.iapws.org/relguide/Supp-VPT3-2016.pdf},
+  type = { },
+  year = {2014}
+}
+
+@techreport{iapws2008,
+  title = {{Release on the IAPWS Formulation 2008 for the Viscosity of Ordinary Water Substance}},
+  author = {IAPWS},
+  institution = {IAPWS},
+  url = {www.iapws.org/relguide/visc.pdf},
+  year = {2008}
+}
+
+@techreport{iaps1985,
+  title = {{Revised Release on the IAPS Formulation 1985 for the Thermal Conductivity of
+  Ordinary Water Substance}},
+  author = {IAPS},
+  institution = {IAPWS},
+  year = {1985}
+}
+
+@techreport{iapws2011,
+  title = {{Release on the IAPWS Formulation 2011 for the Thermal Conductivity of Ordinary Water Substance}},
+  author = {IAPWS},
+  institution = {IAPWS},
+  url = {www.iapws.org/relguide/ThCond.pdf},
+  year = {2011}
+}
+
+@techreport{iapws2004,
+  title = {{Guidelines on the Henry's constant and vapour liquid distribution constant for gases in
+  H$_2$O and D$_2$O at high temperatures}},
+  author = {IAPWS},
+  institution = {IAPWS},
+  year = {2004}
+}
+
+@book{irvine1984,
+  author = {Irvine Jr, T. F. and P. E. Liley},
+  title = {Steam and gas tables with computer equations},
+  publisher = {Academic Press Inc.},
+  address = {Orlando},
+  year = {1984}
+}
+
+@article{metayer2004,
+  author = {O. L. M{\'e}tayer and J. Massoni and R. Saurel},
+  title = {Elaborating equations of state of a liquid and its vapor for two-phase
+  flow models},
+  journal = {Int. J. Therm. Sci.},
+  volume = {43},
+  pages = {265--276},
+  year = {2004}
+}
+
+@techreport{phillips1981,
+  author = {S. L. Phillips and A. Igbene and J. A. Fair and H. Ozbek and M. Tavana},
+  title = {A technical databook for geothermal energy utilization},
+  institution = {Lawrence Berkeley National Laboratory},
+  address = {Berkeley CA, USA},
+  number = {LBL-12810},
+  year = {1981}
+}
+
+@article{potter1977,
+  author = {R. W. Potter and R. S. Babcock and D. L. Brown},
+  title = {A new method for determining the solubility of salts in aqueous solutions
+  at elevated temperatures},
+  journal = {J. Res. US Geol. Surv.},
+  volume = {5},
+  pages = {389--395},
+  year = {1977}
+}
+
+@article{scalabrin2006,
+  author = {G. Scalabrin and P. Marchi and F. Finezzo and R. Span},
+  title = {A Reference Multiparameter Thermal Conductivity Equation for Carbon
+  Dioxide with an Optimized Functional Form},
+  journal = {J. Phys. Chem. Ref. Data},
+  volume = {35},
+  pages = {1549--1575},
+  year = {2006}
+}
+
+@article{spanwagner1996,
+  author = {R. Span and W. Wagner},
+  title = {{A new equation of state for carbon dioxide covering the fluid region
+  from the triple-point temperature to 1100 K at pressures up to 800 MPa}},
+  journal = {J. Phys. Chem. Ref. Data},
+  volume = {25},
+  pages = {1509--1596},
+  year = {1996}
+}
+
+@article{urqhart2015,
+  author = {A. Urqhart and S. Bauer},
+  title = {{Experimental determination of single-crystal halite thermal conductivity,
+  diffusivity and specific heat from -75 C to 300 C}},
+  journal = {Int. J. Rock Mech. and Mining Sci.},
+  volume = {78},
+  pages = {350--352},
+  year = {2015}
+}

--- a/docs/content/documentation/modules/fluid_properties/index.md
+++ b/docs/content/documentation/modules/fluid_properties/index.md
@@ -1,0 +1,144 @@
+# Fluid Properties Module
+The Fluid Properties module provides a consistent interface to fluid properties such as
+density, viscosity, enthalpy and many others, as well as derivatives with respect to the
+primary variables. This allows different fluids to be used in the input files by simply
+swapping the name of the Fluid Properties UserObject in a plug-and-play manner.
+
+!!! note
+    Fluid properties are implemented in GeneralUserObjects that have empty initialize(),
+    execute() and finalize() methods, so do nothing during a simulation. Their purpose is
+    to provide convenient access to fluid properties through the UserObject interface.
+
+Two formulations are provided: a formulation base on internal energy and specific volume as the primary variables, and one based on pressure and temperature.
+
+##Energy-volume formulation
+For the energy-specific volume formulation, the following properties (with
+corresponding method names) are provided:
+
+* Pressure: `pressure(volume, energy)`
+* Temperature: `temperature(volume, energy)`
+* Speed of sound: `c(volume, energy)`
+* Isobaric specific heat: `cp(volume, energy)`
+* Isochoric specific heat: `cp(volume, energy)`
+* Ratio of specific heats: `gamma(volume, energy)`
+* Dynamic viscosity: `mu(volume, energy)`
+* Thermal conductivity: `k(volume, energy)`
+* Specific entropy: `s(volume, energy)`
+* Density: `rho(pressure, temperature)`
+* Enthalpy: `h(pressure, temperature)`
+* Internal energy: `e(pressure, density)`
+* Thermal expansion coefficient: `beta(pressure, temperature)`
+* Pressure (from enthalpy and entropy): `p_from_hs(enthalpy, entropy)`
+
+UserObjects available in the FluidProperties module that use the internal energy-volume
+formulation are
+
+* [Ideal gas](/IdealGasFluidProperties.md)
+* [Stiffened gas](/StiffenedGasFluidProperties.md)
+
+This formulation is useful for the [Navier-Stokes](modules/navier_stokes/index.md) module.
+
+##Pressure-temperature formulation
+A separate formulation based on pressure (Pa) and temperature (K) is also provided.
+For the pressure-temperature formulation, the available properties (with corresponding
+method names) are:
+
+* String representing fluid name: `fluidName()`
+* Molar mass (kg/mol): `molarMass()`
+* Density (kg/m$^3$): `rho(pressure, temperature)`
+* Internal energy (J/kg): `e(pressure, temperature)`
+* Enthalpy (J/kg): `h(pressure, temperature)`
+* Specific entropy (J/kg/K): `s(pressure, temperature)`
+* Dynamic viscosity (Pa.s): `mu(density, temperature)`
+* Thermal conductivity (W/m/K): `k(density, temperature)`
+* Isobaric specific heat (J/kg/K): `cp(pressure, temperature)`
+* Isochoric specific heat (J/kg/K): `cv(pressure, temperature)`
+* Ratio of heat capacites (-): `gamma(pressure, temperature)`
+* Thermal expansion coefficient (-): `beta(pressure, temperature)`
+* Henry's law constant (1/Pa): `henry(temperature)`
+
+Available fluids are:
+
+* [Ideal gas](/IdealGasFluidPropertiesPT.md)
+* [Simple fluid](/SimpleFluidProperties.md)
+* [Water](/Water97FluidProperties.md)
+* [Methane](/MethaneFluidProperties.md)
+* [Carbon dioxide](/CO2FluidProperties.md)
+* [NaCl](/NaClFluidProperties.md)
+* [Brine (water and salt)](/BrineFluidProperties.md)
+* [Tabulated](/TabulatedFluidProperties.md)
+
+These fluid properties can be used directly in the [Porous Flow](modules/porous_flow/index.md) module.
+
+## Usage
+All Fluid Properties UserObjects can be accessed in MOOSE objects through the usual
+UserObject interface. The following example provides a detailed explanation of the steps
+involved to use the Fluid Properties UserObjects in other MOOSE objects, and the syntax
+required in the input file.
+
+This example is for a problem that has energy-volume as the primary variables. A material is
+provided to calculate fluid properties at the quadrature points.
+
+For problems that use the pressure-temperature formulation, the procedure for using
+the Fluid Properties UserObjects is identical, apart from a change in the base class name
+(from `SinglePhaseFluidProperties` to `SinglePhaseFluidPropertiesPT`).
+
+###Source
+To access the fluid properties defined in the Fluid Properties module in a MOOSE object,
+the source code of the object must include the following lines of code.
+
+In the header file of the material, a `const` reference to
+the base `SinglePhaseFluidProperties` object is required:
+
+!listing modules/fluid_properties/include/materials/FluidPropertiesMaterial.h line=SinglePhaseFluidProperties
+
+Note: a forward declaration to the `SinglePhaseFluidProperties` class is required at
+the beginning of the header file.
+
+!listing modules/fluid_properties/include/materials/FluidPropertiesMaterial.h line=class SinglePhaseFluidProperties
+
+In the source file, the `SinglePhaseFluidProperties` class must be included
+
+!listing modules/fluid_properties/src/materials/FluidPropertiesMaterial.C line= "SinglePhaseFluidProperties.h"
+
+The Fluid Properties UserObject is passed to this material in the input file by adding
+a UserObject name parameters in the input parameters:
+
+!listing modules/fluid_properties/src/materials/FluidPropertiesMaterial.C line=addRequiredParam
+
+The reference to the UserObject is then initialized in the constructor using
+
+!listing modules/fluid_properties/src/materials/FluidPropertiesMaterial.C line=getUserObject
+
+The properties defined in the Fluid Properties UserObject can now be accessed through
+the reference. In this material, the `computeQpProperties` method calculates a number of
+properties at the quadrature points using the values of `_v[_qp]` and `_e[_qp]`.
+
+!listing modules/fluid_properties/src/materials/FluidPropertiesMaterial.C start=computeQpProperties
+
+###Input file syntax
+The Fluid Properties UserObjects are implemented in an input file in the `Modules` block.
+For example, to use the ideal gas formulation for specific volume and energy, the input
+file syntax would be:
+
+!listing modules/fluid_properties/tests/ideal_gas/test.i block=Modules label=False
+
+In this example, the user has specified a value for `gamma` (the ratio of isobaric
+to isochoric specific heat capacites), and `R`, the universal gas constant.
+
+The fluid properties can then be accessed by other MOOSE objects through the name
+given in the input file.
+
+!listing modules/fluid_properties/tests/ideal_gas/test.i block=Materials label=False
+
+Due to the consistent interface for fluid properties, a different fluid can be substituted
+in the input file be changing the type of the UserObject. For example, to use a stiffened
+gas instead of an ideal gas, the only modification required in the input file is
+
+!listing modules/fluid_properties/tests/stiffened_gas/test.i block=Modules label=False
+
+## Creating additional fluids
+New fluids can be added to the Fluid Properties module by inheriting from the
+base class appropriate to the formulation and overriding the methods that describe
+the fluid properties. These can then be used in an identical manner as all other
+Fluid Properties UserObjects.

--- a/docs/content/documentation/modules/index.md
+++ b/docs/content/documentation/modules/index.md
@@ -7,6 +7,7 @@ MOOSE includes a set of community developed physics modules that you can build o
 * [Reconstructed Discontinous Galerkin](modules/rdg/index.md)
 * [Navier-Stokes](modules/navier_stokes/index.md)
 * [Level Set](modules/level_set/index.md)
+* [Fluid Properties](modules/fluid_properties/index.md)
 
 The purpose of the modules is to encapsulate common kernels, boundary conditions, etc. to prevent code duplication.
 Examples include: heat conduction, solid mechanics, Navier-Stokes, and others. The modules are organized so that your

--- a/docs/content/documentation/modules/porous_flow/index.md
+++ b/docs/content/documentation/modules/porous_flow/index.md
@@ -1,0 +1,1 @@
+#Porous Flow Module

--- a/docs/content/documentation/systems/Modules/FluidProperties/BrineFluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/BrineFluidProperties.md
@@ -1,0 +1,32 @@
+# BrineFluidProperties
+!description /Modules/FluidProperties/BrineFluidProperties
+
+
+A high-precision and consistent formulation for fluid properties for binary salt (NaCl) and water
+mixtures at pressures and temperatures of interest.
+
+Density, enthalpy, internal energy and specific heat capacity are
+calculated using the formulations provided in \citet{driesner2007a} and \citet{driesner2007b}.
+
+Viscosity and thermal conductivity of brine are calculated using the formulation of \citet{phillips1981}.
+
+Brine vapor pressure is calculated using the formulation presented in \citet{haas1976}.
+
+Solubility of solid salt (halite) in water is given by \citet{potter1977}.
+
+##Range of validity
+The BrineFluidProperties UserObject is valid for:
+
+- 273.15 K $\le$ T $\le$ 1273.15 K,
+- 0.1 MPa $\le$ p $\le$ 50 MPa,
+- 0 $\le$ x$_{\mathrm{nacl}}$ $\le$ 1
+
+!parameters /Modules/FluidProperties/BrineFluidProperties
+
+!inputfiles /Modules/FluidProperties/BrineFluidProperties
+
+!childobjects /Modules/FluidProperties/BrineFluidProperties
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{docs/bib/fluid_properties.bib}

--- a/docs/content/documentation/systems/Modules/FluidProperties/CO2FluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/CO2FluidProperties.md
@@ -1,0 +1,41 @@
+#CO2FluidProperties
+!description /Modules/FluidProperties/CO2FluidProperties
+
+Fluid properties for CO$_2$ are mainly calculated using the Span and Wagner equation of state \citep{spanwagner1996}. This
+formulation uses density and temperature as the primary variables with which to calculate properties
+such as density, enthalpy and internal energy. However, the Fluid Properties module uses pressure and
+temperature in its interface, which is suitable for use in the Porous Flow module. As a result, CO$_2$
+properties are typically calculated by first calculating density iteratively for a given pressure and temperature. This density is then used to calculate the other properties, such as internal energy, directly.
+
+Viscosity is calculated using the formulation presented in \citet{fenghour1998}, while
+thermal conductivity is taken from \citet{scalabrin2006}.
+
+Dissolution of CO$_2$ into water is calculated using Henry's law \citep{iapws2004}.
+
+##Properties of CO$_2$
+
+!table
+| Property             | value |
+| --- | --- |
+| Molar mass           | 0.0440098 kg/mol |
+| Critical temperature | 304.1282 K       |
+| Critical pressure    | 7.3773 MPa        |
+| Critical density     | 467.6 kg/m$^3$ |
+| Triple point temperature | 216.592 K |
+| Triple point pressure | 0.51795 MPa |
+
+##Range of validity
+The CO2FluidProperties UserObject is valid for:
+
+- 216.592 K $\le$ T $\le$ 1100 K for p $\le$ 800 MPa
+
+
+!parameters /Modules/FluidProperties/CO2FluidProperties
+
+!inputfiles /Modules/FluidProperties/CO2FluidProperties
+
+!childobjects /Modules/FluidProperties/CO2FluidProperties
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{docs/bib/fluid_properties.bib}

--- a/docs/content/documentation/systems/Modules/FluidProperties/IdealGasFluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/IdealGasFluidProperties.md
@@ -1,0 +1,19 @@
+#IdealGasFluidProperties
+!description /Modules/FluidProperties/IdealGasFluidProperties
+
+A simple formulation that is suitable for ideal gases, where properties are derived from
+the ideal gas law
+\begin{equation}
+  P = \rho R T.
+\end{equation}
+
+Temperature is calculated using the internal energy of an ideal gas
+\begin{equation}
+  u = c_v T.
+\end{equation}
+
+!parameters /Modules/FluidProperties/IdealGasFluidProperties
+
+!inputfiles /Modules/FluidProperties/IdealGasFluidProperties
+
+!childobjects /Modules/FluidProperties/IdealGasFluidProperties

--- a/docs/content/documentation/systems/Modules/FluidProperties/IdealGasFluidPropertiesPT.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/IdealGasFluidPropertiesPT.md
@@ -1,0 +1,27 @@
+#IdealGasFluidPropertiesPT
+!description /Modules/FluidProperties/IdealGasFluidPropertiesPT
+
+A simple formulation that is suitable for ideal gases, where properties are derived from
+the ideal gas law
+\begin{equation}
+  P = \rho R T.
+\end{equation}
+
+Internal energy of an ideal gas is
+\begin{equation}
+  e = c_v T
+\end{equation}
+
+while enthalpy is
+\begin{equation}
+  h = c_p T.
+\end{equation}
+
+All other properties (such as viscosity or thermal conductivity) are assumed to be constant
+in this fluid, and must be provided in the input file (see below).
+
+!parameters /Modules/FluidProperties/IdealGasFluidPropertiesPT
+
+!inputfiles /Modules/FluidProperties/IdealGasFluidPropertiesPT
+
+!childobjects /Modules/FluidProperties/IdealGasFluidPropertiesPT

--- a/docs/content/documentation/systems/Modules/FluidProperties/MethaneFluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/MethaneFluidProperties.md
@@ -1,0 +1,35 @@
+# MethaneFluidProperties
+!description /Modules/FluidProperties/MethaneFluidProperties
+
+Density of methane is calculated assuming an ideal gas, while all other properties are calculated using
+the formulations provided in \citet{irvine1984}.
+
+Dissolution of methane into water is calculated using Henry's law \citep{iapws2004}.
+
+##Properties of methane
+
+!table
+| Property             | value |
+| --- | --- |
+| Molar mass           | 0.0160425 kg/mol |
+| Critical temperature | 190.564 K       |
+| Critical pressure    | 4.5992 MPa        |
+| Critical density     | 162.66 kg/m$^3$ |
+| Triple point temperature | 90.67 K |
+| Triple point pressure | 0.01169 MPa |
+
+##Range of validity
+The MethaneFluidProperties UserObject is valid for:
+
+- 280.0 K $\le$ T $\le$ 1080 K
+
+!parameters /Modules/FluidProperties/MethaneFluidProperties
+
+!inputfiles /Modules/FluidProperties/MethaneFluidProperties
+
+!childobjects /Modules/FluidProperties/MethaneFluidProperties
+
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{docs/bib/fluid_properties.bib}

--- a/docs/content/documentation/systems/Modules/FluidProperties/NaClFluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/NaClFluidProperties.md
@@ -1,0 +1,37 @@
+#NaClFluidProperties
+!description /Modules/FluidProperties/NaClFluidProperties
+
+NaCl fluid properties as a function of pressure (Pa) and temperature (K).
+!!! note
+    Only solid state (halite) properties are currently implemented to use in brine formulation
+
+Properties for halite given by \citet{Driesner2007b}, apart from thermal conductivity,
+which is calculated using the data of \citet{urqhart2015}. Critical values are taken
+from \citet{Anderko1992}.
+
+##Properties of NaCl
+
+!table
+| Property             | value |
+| --- | --- |
+| Molar mass           | 0.058443 kg/mol |
+| Critical temperature | 3841.15 K       |
+| Critical pressure    | 18.2 MPa        |
+| Critical density     | 108.43 kg/m$^3$ |
+| Triple point temperature | 1073.85 K |
+| Triple point pressure | 50 Pa |
+
+##Range of validity
+The NaClFluidProperties UserObject is valid for the solid phase region only
+
+
+
+!parameters /Modules/FluidProperties/NaClFluidProperties
+
+!inputfiles /Modules/FluidProperties/NaClFluidProperties
+
+!childobjects /Modules/FluidProperties/NaClFluidProperties
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{docs/bib/fluid_properties.bib}

--- a/docs/content/documentation/systems/Modules/FluidProperties/SimpleFluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/SimpleFluidProperties.md
@@ -1,0 +1,28 @@
+#SimpleFluidProperties
+!description /Modules/FluidProperties/SimpleFluidProperties
+
+This is a computationally simple fluid based on a constant bulk modulus density fluid,
+with density given by
+\begin{equation}
+  \rho = \rho_{0}\exp(P/K_{f} - \alpha_{f} T),
+  \label{eq:simplifiedfluid}
+\end{equation}
+where $K_{f}$ (the bulk modulus) and $\alpha_{f}$ (the thermal expansion coefficient) are
+constants.
+
+In this formulation, viscosity and thermal conductivity are constant (with values specified
+in the input file), while internal energy and enthalpy are given by
+\begin{equation}
+  e = c_v T
+\end{equation}
+and
+\begin{equation}
+  h = e + \frac{p}{\rho}
+\end{equation}
+respectively.
+
+!parameters /Modules/FluidProperties/SimpleFluidProperties
+
+!inputfiles /Modules/FluidProperties/SimpleFluidProperties
+
+!childobjects /Modules/FluidProperties/SimpleFluidProperties

--- a/docs/content/documentation/systems/Modules/FluidProperties/StiffenedGasFluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/StiffenedGasFluidProperties.md
@@ -1,0 +1,22 @@
+#StiffenedGasFluidProperties
+!description /Modules/FluidProperties/StiffenedGasFluidProperties
+
+A simple fluid class that implements a stiffened equation of state \citep{metayer2004}
+\begin{equation}
+  p = (\gamma - 1) \rho (e - q) - \gamma p_{\infty},
+\end{equation}
+where $\gamma = c_p/c_v$ is the ratio of specific heat capacities, $q$
+is a constant that defines the zero reference state for internal energy, and
+$p_{\infty}$ is a constant representing the attraction between fluid molecules
+that makes the fluid *stiff* in comparison to an ideal gas. This equation of state
+is typically used to represent water that is under very high pressure.
+
+!parameters /Modules/FluidProperties/StiffenedGasFluidProperties
+
+!inputfiles /Modules/FluidProperties/StiffenedGasFluidProperties
+
+!childobjects /Modules/FluidProperties/StiffenedGasFluidProperties
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{docs/bib/fluid_properties.bib}

--- a/docs/content/documentation/systems/Modules/FluidProperties/TabulatedFluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/TabulatedFluidProperties.md
@@ -1,0 +1,65 @@
+#TabulatedFluidProperties
+!description /Modules/FluidProperties/TabulatedFluidProperties
+
+The TabulatedFluidProperties UserObject calculates the density, internal energy
+and enthalpy of the fluid using bicubic spline interpolation on data provided
+in a text file. All other properties are calculated using a provided FluidProperties
+UserObject.
+
+Property values are read from a file containing keywords followed by data.
+Monotonically increasing values of pressure and temperature must be included in
+the data file, specifying the phase space where tabulated fluid properties will
+be defined. An error is thrown if either temperature or pressure data is not
+included or not monotonic, and an error is also thrown if this UserObject is
+requested to provide a fluid property outside this phase space.
+
+This class is intended to be used when complicated formulations for density,
+internal energy or enthalpy are required, which can be computationally expensive.
+This is particularly the case where the fluid equation of state is based on a
+Helmholtz free energy that is a function of density and temperature, like that
+used in CO2FluidProperties. In this case, density must be solved iteratively using
+pressure and temperature, which increases the computational burden.
+
+In these cases, using an interpolation of the tabulated fluid properties can
+significantly reduce the computational time for computing density, internal energy,
+and enthalpy.
+
+##File format
+The expected file format for the tabulated fluid properties is now described.
+Lines beginning with # are ignored, so comments can be included.
+Keywords 'pressure' and 'temperature' must be included, each followed by numerical data
+that increases monotonically. A blank line signifies the end of the data for the
+preceding keyword.
+
+Fluid properties for density, internal energy, and enthalpy can be included, with
+the keyword 'density', 'internal_energy', or 'enthalpy' followed by data that cycles
+first by temperature then pressure. If any of these properties are not supplied,
+this UserObject will generate it using the pressure and temperature values provided.
+An error is thrown if an incorrect number of property values has been supplied.
+
+If no tabulated fluid property data file exists, then data for density, internal energy
+and enthalpy will be generated using the pressure and temperature ranges specified
+in the input file at the beginning of the simulation.
+
+This tabulated data will be written to file in the correct format,
+enabling suitable data files to be created for future use. There is an upfront
+computational expense required for this initial data generation, depending on the
+required number of pressure and temperature points. However, provided that the
+number of data points required to generate the tabulated data is smaller than the
+number of times the property members in the FluidProperties UserObject are used,
+the initial time to generate the data and the subsequent interpolation time can be much
+less than using the original FluidProperties UserObject.
+
+Density, internal_energy and enthalpy and their derivatives with respect to pressure and
+temperature are always calculated using bicubic spline interpolation, while all
+remaining fluid properties are calculated using the provided FluidProperties UserObject.
+
+A function to write generated data to file using the correct format is provided
+to allow suitable files of fluid property data to be generated using the FluidProperties
+module UserObjects.
+
+!parameters /Modules/FluidProperties/TabulatedFluidProperties
+
+!inputfiles /Modules/FluidProperties/TabulatedFluidProperties
+
+!childobjects /Modules/FluidProperties/TabulatedFluidProperties

--- a/docs/content/documentation/systems/Modules/FluidProperties/Water97FluidProperties.md
+++ b/docs/content/documentation/systems/Modules/FluidProperties/Water97FluidProperties.md
@@ -1,0 +1,48 @@
+#Water97FluidProperties
+!description /Modules/FluidProperties/Water97FluidProperties
+
+The water implementation in Fluid Properties is the IAPWS Industrial Formulation 1997
+for the Thermodynamic Properties of Water and Steam. This formulation calculates
+properties of water and steam using pressure and temperature as inputs. The IAPWS-IF97
+formulation is split into five different regions in the phase diagram.
+
+All five regions are implemented in the Fluid Properties module. To avoid iteration
+in region 3 of the IAPWS-IF97 formulation, the backwards equations from \citet{iapws1997region3}
+are implemented.
+
+Viscosity is calculated using the IAPWS 2008 formulation \citep{iapws2008}. Note that the critical
+enhancement has not been implemented.
+
+Thermal conductivity is calculated using the IAPS 1985 formulation \citep{iaps1985}. Although there
+is a newer formulation available \citep{iapws2011}, it is significantly more complicated, so has not
+been implemented yet.
+
+Dissolution of a dilute gas into water is calculated using Henry's law \citep{iapws2004}.
+
+##Properties of water
+
+!table
+| Property             | value |
+| --- | --- |
+| Molar mass           | 0.018015 kg/mol |
+| Critical temperature | 647.096 K       |
+| Critical pressure    | 22.064 MPa        |
+| Critical density     | 322.0 kg/m$^3$ |
+| Triple point temperature | 273.16 K |
+| Triple point pressure | 611.657 Pa |
+
+##Range of validity
+The Water97FluidProperties UserObject is valid for:
+
+- 273.15 K $\le$ T $\le$ 1073.15 K for p $\le$ 100 MPa
+- 1073.15 K $\le$ T $\le$ 2273.15 K for p $\le$ 50 MPa
+
+!parameters /Modules/FluidProperties/Water97FluidProperties
+
+!inputfiles /Modules/FluidProperties/Water97FluidProperties
+
+!childobjects /Modules/FluidProperties/Water97FluidProperties
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{docs/bib/fluid_properties.bib}

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -24,19 +24,20 @@ public:
   IdealGasFluidProperties(const InputParameters & parameters);
   virtual ~IdealGasFluidProperties();
 
-  virtual Real pressure(Real v, Real u) const;
-  virtual Real temperature(Real v, Real u) const;
-  virtual Real c(Real v, Real u) const;
-  virtual Real cp(Real v = 0., Real u = 0.) const;
-  virtual Real cv(Real v = 0., Real u = 0.) const;
-  virtual Real gamma(Real v = 0., Real u = 0.) const;
-  virtual Real mu(Real v, Real u) const;
-  virtual Real k(Real v, Real u) const;
-  virtual Real s(Real v, Real u) const;
-  virtual void dp_duv(Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const;
+  virtual Real pressure(Real v, Real u) const override;
+  virtual Real temperature(Real v, Real u) const override;
+  virtual Real c(Real v, Real u) const override;
+  virtual Real cp(Real v = 0., Real u = 0.) const override;
+  virtual Real cv(Real v = 0., Real u = 0.) const override;
+  virtual Real gamma(Real v = 0., Real u = 0.) const override;
+  virtual Real mu(Real v, Real u) const override;
+  virtual Real k(Real v, Real u) const override;
+  virtual Real s(Real v, Real u) const override;
+  virtual void
+  dp_duv(Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const override;
 
   /// Compute internal energy and density from specific entropy and pressure
-  virtual void rho_e_ps(Real pressure, Real entropy, Real & rho, Real & e) const;
+  virtual void rho_e_ps(Real pressure, Real entropy, Real & rho, Real & e) const override;
   virtual void rho_e_dps(Real pressure,
                          Real entropy,
                          Real & rho,
@@ -44,24 +45,26 @@ public:
                          Real & drho_ds,
                          Real & e,
                          Real & de_dp,
-                         Real & de_ds) const;
+                         Real & de_ds) const override;
 
-  virtual Real beta(Real p, Real T) const;
+  virtual Real beta(Real p, Real T) const override;
 
-  virtual void rho_e(Real pressure, Real temperature, Real & rho, Real & e) const;
-  virtual Real rho(Real pressure, Real temperature) const;
-  virtual void
-  rho_dpT(Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const;
+  virtual void rho_e(Real pressure, Real temperature, Real & rho, Real & e) const override;
+  virtual Real rho(Real pressure, Real temperature) const override;
+  virtual void rho_dpT(
+      Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const override;
   virtual void e_dpT(Real pressure, Real temperature, Real & e, Real & de_dp, Real & de_dT) const;
 
-  virtual Real e(Real pressure, Real rho) const;
-  virtual void e_dprho(Real pressure, Real rho, Real & e, Real & de_dp, Real & de_drho) const;
+  virtual Real e(Real pressure, Real rho) const override;
+  virtual void
+  e_dprho(Real pressure, Real rho, Real & e, Real & de_dp, Real & de_drho) const override;
 
-  virtual Real h(Real pressure, Real temperature) const;
-  virtual void h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const;
+  virtual Real h(Real pressure, Real temperature) const override;
+  virtual void
+  h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const override;
 
-  virtual Real p_from_h_s(Real h, Real s) const;
-  virtual Real dpdh_from_h_s(Real h, Real s) const;
+  virtual Real p_from_h_s(Real h, Real s) const override;
+  virtual Real dpdh_from_h_s(Real h, Real s) const override;
 
 protected:
   Real _gamma;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
@@ -44,7 +44,7 @@ public:
   virtual Real c(Real pressure, Real temperature) const override;
 
   /// Thermal conductivity (W/m/K)
-  virtual Real k(Real pressure, Real temperature) const override;
+  virtual Real k(Real density, Real temperature) const override;
 
   /// Specific entropy (J/kg/K)
   virtual Real s(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
@@ -175,15 +175,15 @@ public:
       Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
 
   /**
-   * Thermal conductivity as a function of pressure and temperature.
+   * Thermal conductivity as a function of density and temperature.
    * From Irvine Jr, T. F. and Liley, P. E. (1984) Steam and Gas Tables with
    * Computer Equations.
    *
-   * @param pressure fluid pressure (Pa)
+   * @param density fluid density (kg/m^3)
    * @param temperature fluid temperature (K)
    * @return k (W/m/K)
    */
-  virtual Real k(Real pressure, Real temperature) const override;
+  virtual Real k(Real density, Real temperature) const override;
 
   /**
    * Specific entropy as a function of pressure and temperature.

--- a/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
@@ -71,7 +71,7 @@ public:
                       Real & de_dT,
                       Real & de_dx) const = 0;
   /// Thermal conductivity (W/m/K)
-  virtual Real k(Real pressure, Real temperature, Real xmass) const = 0;
+  virtual Real k(Real density, Real temperature, Real xmass) const = 0;
   /// Get UserObject for specified component
   virtual const SinglePhaseFluidPropertiesPT & getComponent(unsigned int component) const = 0;
 

--- a/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
@@ -179,18 +179,18 @@ public:
       Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
 
   /**
-   * Thermal conductivity as a function of pressure and temperature
+   * Thermal conductivity
    * From Urqhart and Bauer, Experimental determination of single-crystal halite
    * thermal conductivity, diffusivity and specific heat from -75 C to 300 C,
    * Int. J. Rock Mech. and Mining Sci., 78 (2015)
    * Note: The function given in this reference doesn't satisfactorily match their
    * experimental data, so the data was refitted using a third order polynomial
    *
-   * @param pressure fluid pressure (Pa)
+   * @param density fluid density (kg/m^3)
    * @param temperature fluid temperature (K)
    * @return k (W/m/K)
    */
-  virtual Real k(Real pressure, Real temperature) const override;
+  virtual Real k(Real density, Real temperature) const override;
 
   /**
    * Specific entropy as a function of pressure and temperature

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -54,7 +54,7 @@ public:
   virtual Real c(Real pressure, Real temperature) const override;
 
   /// Thermal conductivity (W/m/K)
-  virtual Real k(Real pressure, Real temperature) const override;
+  virtual Real k(Real density, Real temperature) const override;
 
   /// Specific entropy (J/kg/K)
   virtual Real s(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -65,7 +65,7 @@ public:
   /// Computes density and internal energy from pressure and temperature
   virtual void rho_e(Real pressure, Real temperature, Real & rho, Real & e) const = 0;
 
-  /// Computes internal energy from pressure and temperature
+  /// Computes internal energy from pressure and density
   virtual Real e(Real pressure, Real rho) const = 0;
   /// Computes internal energy and its derivatives of internal energy w.r.t. pressure and density
   virtual void e_dprho(Real pressure, Real rho, Real & e, Real & de_dp, Real & de_drho) const = 0;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -62,7 +62,7 @@ public:
   virtual void
   mu_drhoT(Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const = 0;
   /// Thermal conductivity (W/m/K)
-  virtual Real k(Real pressure, Real temperature) const = 0;
+  virtual Real k(Real density, Real temperature) const = 0;
   /// Specific entropy (J/kg/K)
   virtual Real s(Real pressure, Real temperature) const = 0;
   /// Specific enthalpy (J/kg)

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -16,7 +16,7 @@ template <>
 InputParameters validParams<StiffenedGasFluidProperties>();
 
 /**
- *
+ * Stiffened gas fluid properties
  */
 class StiffenedGasFluidProperties : public SinglePhaseFluidProperties
 {
@@ -24,19 +24,20 @@ public:
   StiffenedGasFluidProperties(const InputParameters & parameters);
   virtual ~StiffenedGasFluidProperties();
 
-  virtual Real pressure(Real v, Real u) const;
-  virtual Real temperature(Real v, Real u) const;
-  virtual Real c(Real v, Real u) const;
-  virtual Real cp(Real v, Real u) const;
-  virtual Real cv(Real v, Real u) const;
-  virtual Real gamma(Real v, Real u) const;
-  virtual Real mu(Real v, Real u) const;
-  virtual Real k(Real v, Real u) const;
-  virtual Real s(Real v, Real u) const;
-  virtual void dp_duv(Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const;
+  virtual Real pressure(Real v, Real u) const override;
+  virtual Real temperature(Real v, Real u) const override;
+  virtual Real c(Real v, Real u) const override;
+  virtual Real cp(Real v, Real u) const override;
+  virtual Real cv(Real v, Real u) const override;
+  virtual Real gamma(Real v, Real u) const override;
+  virtual Real mu(Real v, Real u) const override;
+  virtual Real k(Real v, Real u) const override;
+  virtual Real s(Real v, Real u) const override;
+  virtual void
+  dp_duv(Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const override;
 
   /// Compute internal energy and density from specific entropy and pressure
-  virtual void rho_e_ps(Real pressure, Real entropy, Real & rho, Real & e) const;
+  virtual void rho_e_ps(Real pressure, Real entropy, Real & rho, Real & e) const override;
   virtual void rho_e_dps(Real pressure,
                          Real entropy,
                          Real & rho,
@@ -44,24 +45,26 @@ public:
                          Real & drho_ds,
                          Real & e,
                          Real & de_dp,
-                         Real & de_ds) const;
+                         Real & de_ds) const override;
 
-  virtual Real beta(Real p, Real T) const;
+  virtual Real beta(Real p, Real T) const override;
 
-  virtual void rho_e(Real pressure, Real temperature, Real & rho, Real & e) const;
-  virtual Real rho(Real pressure, Real temperature) const;
-  virtual void
-  rho_dpT(Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const;
+  virtual void rho_e(Real pressure, Real temperature, Real & rho, Real & e) const override;
+  virtual Real rho(Real pressure, Real temperature) const override;
+  virtual void rho_dpT(
+      Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const override;
   virtual void e_dpT(Real pressure, Real temperature, Real & e, Real & de_dp, Real & de_dT) const;
 
-  virtual Real e(Real pressure, Real rho) const;
-  virtual void e_dprho(Real pressure, Real rho, Real & e, Real & de_dp, Real & de_drho) const;
+  virtual Real e(Real pressure, Real rho) const override;
+  virtual void
+  e_dprho(Real pressure, Real rho, Real & e, Real & de_dp, Real & de_drho) const override;
 
-  virtual Real h(Real pressure, Real temperature) const;
-  virtual void h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const;
+  virtual Real h(Real pressure, Real temperature) const override;
+  virtual void
+  h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const override;
 
-  virtual Real p_from_h_s(Real h, Real s) const;
-  virtual Real dpdh_from_h_s(Real h, Real s) const;
+  virtual Real p_from_h_s(Real h, Real s) const override;
+  virtual Real dpdh_from_h_s(Real h, Real s) const override;
 
   virtual Real c2_from_p_rho(Real pressure, Real rho) const;
 

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -63,8 +63,8 @@ InputParameters validParams<TabulatedFluidProperties>();
  * the initial time to generate the data and the subsequent interpolation time can be much
  * less than using the original FluidProperties UserObject.
  *
- * Density, internal_energy and enthalpy and there derivatives wrt pressure and
- * temperature are always calculated using bicubic spline interpolatio, while all
+ * Density, internal_energy and enthalpy and their derivatives wrt pressure and
+ * temperature are always calculated using bicubic spline interpolation, while all
  * remaining fluid properties are calculated using the FluidProperties UserObject _fp.
  *
  * A function to write generated data to file using the correct format is provided

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -14,11 +14,10 @@ validParams<IdealGasFluidProperties>()
   InputParameters params = validParams<SinglePhaseFluidProperties>();
   params.addRequiredParam<Real>("gamma", "gamma value (cp/cv)");
   params.addRequiredParam<Real>("R", "Gas constant");
-
   params.addParam<Real>("beta", 0, "Coefficient of thermal expansion");
   params.addParam<Real>("mu", 0, "Dynamic viscosity, Pa.s");
   params.addParam<Real>("k", 0, "Thermal conductivity, W/(m-K)");
-
+  params.addClassDescription("Fluid properties for an ideal gas");
   return params;
 }
 
@@ -26,7 +25,6 @@ IdealGasFluidProperties::IdealGasFluidProperties(const InputParameters & paramet
   : SinglePhaseFluidProperties(parameters),
     _gamma(getParam<Real>("gamma")),
     _R(getParam<Real>("R")),
-
     _beta(getParam<Real>("beta")),
     _mu(getParam<Real>("mu")),
     _k(getParam<Real>("k"))

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
@@ -69,7 +69,7 @@ IdealGasFluidPropertiesPT::c(Real /*pressure*/, Real temperature) const
   return std::sqrt(_cp * _R * temperature / (_cv * _molar_mass));
 }
 
-Real IdealGasFluidPropertiesPT::k(Real /*pressure*/, Real /*temperature*/) const
+Real IdealGasFluidPropertiesPT::k(Real /*density*/, Real /*temperature*/) const
 {
   return _thermal_conductivity;
 }

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -181,7 +181,7 @@ MethaneFluidProperties::mu_drhoT(
 }
 
 Real
-MethaneFluidProperties::k(Real /*pressure*/, Real temperature) const
+MethaneFluidProperties::k(Real /*density*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (200 K <= T <= 1000 K)
   if (temperature <= 200.0 || temperature >= 1000.0)

--- a/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
@@ -178,7 +178,7 @@ NaClFluidProperties::mu_drhoT(Real /*density*/,
 }
 
 Real
-NaClFluidProperties::k(Real /*pressure*/, Real temperature) const
+NaClFluidProperties::k(Real /*density*/, Real temperature) const
 {
   // Correlation requires temperature in Celcius
   Real Tc = temperature - _T_c2k;

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -31,9 +31,7 @@ validParams<SimpleFluidProperties>()
                         "The enthalpy is internal_energy + P / density * "
                         "porepressure_coefficient.  Physically this should be 1.0, "
                         "but analytic solutions are simplified when it is zero");
-  params.addClassDescription("Fluid properties for a simple fluid.  density=density0 * exp(P / "
-                             "bulk_modulus - thermal_expansion * T), internal_energy = cv * T, "
-                             "enthalpy = cp * T");
+  params.addClassDescription("Fluid properties for a simple fluid with a constant bulk density");
   return params;
 }
 
@@ -82,7 +80,7 @@ SimpleFluidProperties::c(Real pressure, Real temperature) const
   return std::sqrt(_bulk_modulus / rho(pressure, temperature));
 }
 
-Real SimpleFluidProperties::k(Real /*pressure*/, Real /*temperature*/) const
+Real SimpleFluidProperties::k(Real /*density*/, Real /*temperature*/) const
 {
   return _thermal_conductivity;
 }

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -12,16 +12,14 @@ InputParameters
 validParams<StiffenedGasFluidProperties>()
 {
   InputParameters params = validParams<SinglePhaseFluidProperties>();
-
   params.addRequiredParam<Real>("gamma", "Heat capacity ratio");
   params.addRequiredParam<Real>("cv", "Constant volume specific heat");
-  params.addRequiredParam<Real>("q", "");
-  params.addRequiredParam<Real>("p_inf", "");
+  params.addRequiredParam<Real>("q", "Parameter defining zero point of internal energy");
+  params.addRequiredParam<Real>("p_inf", "Stiffness parameter");
   params.addParam<Real>("q_prime", 0, "Parameter");
-
   params.addParam<Real>("mu", 1.e-3, "Dynamic viscosity, Pa.s");
   params.addParam<Real>("k", 0.6, "Thermal conductivity, W/(m-K)");
-
+  params.addClassDescription("Fluid properties for a stiffened gas");
   return params;
 }
 
@@ -32,7 +30,6 @@ StiffenedGasFluidProperties::StiffenedGasFluidProperties(const InputParameters &
     _q(getParam<Real>("q")),
     _q_prime(getParam<Real>("q_prime")),
     _p_inf(getParam<Real>("p_inf")),
-
     _mu(getParam<Real>("mu")),
     _k(getParam<Real>("k"))
 {

--- a/python/MooseDocs/extensions/bibtex.py
+++ b/python/MooseDocs/extensions/bibtex.py
@@ -223,4 +223,12 @@ class BibtexPreprocessor(MooseMarkdownCommon, Preprocessor):
         umlaut_re = re.compile(r"\{\\\"([aouAOU])\}")
         html = umlaut_re.sub('&\\1uml;', html)
 
+        # substitute acutes
+        acute_re = re.compile(r"\{\\\'([aeiouyAEIOUY])\}")
+        html = acute_re.sub('&\\1acute;', html)
+
+        # substitute graves
+        grave_re = re.compile(r"\{\\\`([aeiouAEIOU])\}")
+        html = grave_re.sub('&\\1grave;', html)
+
         return self.markdown.htmlStash.store(html, safe=True)


### PR DESCRIPTION
Hopefully this works - a bit of a cut and paste from documentation from my personal moose app into the documentation system. 

New content visible from `Documentation > Modules > Fluid Properties` on the site that moosebuild will hopefully post.

There are a couple of issues with the referencing

- I can't get a LaTeX subscript to work in the references (e.g. H$_2$O), see bottom of http://mooseframework.org/docs/PRs/9127/site/documentation/systems/Modules/FluidProperties/CO2FluidProperties/index.html
-  ~~and an accent isn't working in the `\cite{}` command, see http://mooseframework.org/docs/PRs/9127/site/documentation/systems/Modules/FluidProperties/StiffenedGasFluidProperties/index.html~~


Refs #9126 