### PR TITLE
Add file lock around reading/writing exodus files.

### DIFF
--- a/framework/include/utils/LockFile.h
+++ b/framework/include/utils/LockFile.h
@@ -1,0 +1,40 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef LOCKFILE_H
+#define LOCKFILE_H
+
+#include <string>
+
+/**
+ * Gets an exclusive lock on a file.
+ * This uses RAII to obtain the lock in the constructor and release
+ * the lock in the destructor.
+ * Additionally, to allow for easier use as a stack variable, an optional
+ * bool is allowed to specify that no locking is actually done. This is useful
+ * for the case where only certain processors need to obtain the lock.
+ */
+class LockFile
+{
+public:
+  LockFile(const std::string & filename, bool do_lock = true);
+  ~LockFile();
+
+protected:
+  const bool _do_lock;
+  int _fd;
+  const std::string _filename;
+};
+
+#endif // LOCKFILE_H

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -21,6 +21,7 @@
 #include "FileMesh.h"
 #include "MooseApp.h"
 #include "MooseVariableScalar.h"
+#include "LockFile.h"
 
 // libMesh includes
 #include "libmesh/exodusII_io.h"
@@ -300,6 +301,7 @@ Exodus::output(const ExecFlagType & type)
 
   // Prepare the ExodusII_IO object
   outputSetup();
+  LockFile lf(filename(), processor_id() == 0);
 
   // Adjust the position of the output
   if (_app.hasOutputPosition())

--- a/framework/src/utils/LockFile.C
+++ b/framework/src/utils/LockFile.C
@@ -15,6 +15,7 @@
 #include "LockFile.h"
 #include "MooseError.h"
 #include <fcntl.h>
+#include <sys/file.h>
 #include <unistd.h>
 
 LockFile::LockFile(const std::string & filename, bool do_lock)

--- a/framework/src/utils/LockFile.C
+++ b/framework/src/utils/LockFile.C
@@ -1,0 +1,41 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "LockFile.h"
+#include "MooseError.h"
+#include <fcntl.h>
+#include <unistd.h>
+
+LockFile::LockFile(const std::string & filename, bool do_lock)
+  : _do_lock(do_lock), _fd(-1), _filename(filename)
+{
+  if (_do_lock)
+  {
+    _fd = open(filename.c_str(), O_RDWR | O_CREAT, 0666);
+    if (_fd == -1)
+      mooseError("Failed to open file", filename);
+    if (flock(_fd, LOCK_EX) != 0)
+      mooseError("Failed to lock file ", filename);
+  }
+}
+
+LockFile::~LockFile()
+{
+  if (_do_lock)
+  {
+    if (flock(_fd, LOCK_UN) != 0)
+      mooseError("Failed to unlock file ", _filename);
+    close(_fd);
+  }
+}

--- a/python/chigger/exodus/ExodusReader.py
+++ b/python/chigger/exodus/ExodusReader.py
@@ -15,16 +15,16 @@
 import os
 import collections
 import bisect
+import contextlib
+import fcntl
 import vtk
 
 import mooseutils
 from .. import utils
 from .. import base
-import contextlib
-import fcntl
 
 @contextlib.contextmanager
-def lockFile(filename):
+def lock_file(filename):
     """
     Locks a file so that the exodus reader can safely read
     a file without MOOSE writing to it while we do it.
@@ -171,7 +171,7 @@ class ExodusReader(base.ChiggerObject):
         self.__initializeTimeInformation()
         self.__current = self.__getTimeInformation()
         self.__vtkreader.SetFileName(None) # http://vtk.1045678.n5.nabble.com/How-to-re-load-time-information-in-ExodusIIReader-tp5741615.html pylint: disable=line-too-long
-        with lockFile(self.__current.filename):
+        with lock_file(self.__current.filename):
             self.__vtkreader.SetFileName(self.__current.filename)
             self.__vtkreader.SetTimeStep(self.__current.index)
             self.__vtkreader.UpdateInformation()
@@ -194,18 +194,18 @@ class ExodusReader(base.ChiggerObject):
                     else:
                         self.__vtkreader.SetObjectStatus(data.object_type, data.object_index, 0)
 
-            # According to the VTK documentation setting this to False (not the default) speeds up data
-            # loading. In my testing I was seeing load times cut in half or more with "squeezing"
-            # disabled. I am leaving this as an option just in case we discover some reason it shouldn't
-            # be disabled.
+            # According to the VTK documentation setting this to False (not the default) speeds
+            # up data loading. In my testing I was seeing load times cut in half or more with
+            # "squeezing" disabled. I am leaving this as an option just in case we discover some
+            # reason it shouldn't be disabled.
             self.__vtkreader.SetSqueezePoints(self.getOption('squeeze'))
 
             # Set the data arrays to load
             #
-            # If the object has not been initialized then all of the variables should be enabled so that
-            # the block and variable information are complete when populated. After this only the
-            # variables listed in the 'variables' options, if any, are activated, which reduces loading
-            # times. If 'variables' is not given, all the variables are loaded.
+            # If the object has not been initialized then all of the variables should be enabled
+            # so that the block and variable information are complete when populated. After this
+            # only the variables listed in the 'variables' options, if any, are activated, which
+            # reduces loading times. If 'variables' is not given, all the variables are loaded.
             variables = self.getOption('variables')
             variable_info = self.getVariableInformation()
             for vinfo in variable_info.itervalues():
@@ -428,17 +428,19 @@ class ExodusReader(base.ChiggerObject):
             if tinfo and (tinfo.modified == current_modified):
                 continue
 
-            with lockFile(filename):
+            with lock_file(filename):
                 self.__vtkreader.SetFileName(filename)
                 self.__vtkreader.Modified()
                 self.__vtkreader.UpdateInformation()
 
                 vtkinfo = self.__vtkreader.GetExecutive().GetOutputInformation(0)
-                times = [vtkinfo.Get(key, i) for i in range(self.__vtkreader.GetNumberOfTimeSteps())]
+                steps = range(self.__vtkreader.GetNumberOfTimeSteps())
+                times = [vtkinfo.Get(key, i) for i in steps]
 
                 if not times:
                     times = [None] # When --mesh-only is used, not time information is written
-                self.__fileinfo[filename] = ExodusReader.FileInformation(filename=filename, times=times,
+                self.__fileinfo[filename] = ExodusReader.FileInformation(filename=filename,
+                                                                         times=times,
                                                                          modified=current_modified)
 
         # Re-populate the time data

--- a/python/chigger/exodus/ExodusReader.py
+++ b/python/chigger/exodus/ExodusReader.py
@@ -20,6 +20,19 @@ import vtk
 import mooseutils
 from .. import utils
 from .. import base
+import contextlib
+import fcntl
+
+@contextlib.contextmanager
+def lockFile(filename):
+    """
+    Locks a file so that the exodus reader can safely read
+    a file without MOOSE writing to it while we do it.
+    """
+    with open(filename, "a+") as f: # "a+" to make sure it gets created
+        fcntl.flock(f, fcntl.LOCK_SH)
+        yield
+        fcntl.flock(f, fcntl.LOCK_UN)
 
 class ExodusReaderErrorObserver(object):
     """
@@ -158,49 +171,50 @@ class ExodusReader(base.ChiggerObject):
         self.__initializeTimeInformation()
         self.__current = self.__getTimeInformation()
         self.__vtkreader.SetFileName(None) # http://vtk.1045678.n5.nabble.com/How-to-re-load-time-information-in-ExodusIIReader-tp5741615.html pylint: disable=line-too-long
-        self.__vtkreader.SetFileName(self.__current.filename)
-        self.__vtkreader.SetTimeStep(self.__current.index)
-        self.__vtkreader.UpdateInformation()
-        self.__vtkreader.Modified()
+        with lockFile(self.__current.filename):
+            self.__vtkreader.SetFileName(self.__current.filename)
+            self.__vtkreader.SetTimeStep(self.__current.index)
+            self.__vtkreader.UpdateInformation()
+            self.__vtkreader.Modified()
 
-        # Displacement Settings
-        if self.getOption('displacements'):
-            self.__vtkreader.ApplyDisplacementsOn()
-            self.__vtkreader.SetDisplacementMagnitude(self.getOption('displacement_magnitude'))
-        else:
-            self.__vtkreader.ApplyDisplacementsOff()
-
-        # Set the geometric objects to load (i.e., subdomains, nodesets, sidesets)
-        active_blockinfo = self.__getActiveBlocks()
-        blockinfo = self.getBlockInformation()
-        for object_type in ExodusReader.BLOCK_TYPES:
-            for data in blockinfo[object_type].itervalues():
-                if (not active_blockinfo) or (data in active_blockinfo):
-                    self.__vtkreader.SetObjectStatus(data.object_type, data.object_index, 1)
-                else:
-                    self.__vtkreader.SetObjectStatus(data.object_type, data.object_index, 0)
-
-        # According to the VTK documentation setting this to False (not the default) speeds up data
-        # loading. In my testing I was seeing load times cut in half or more with "squeezing"
-        # disabled. I am leaving this as an option just in case we discover some reason it shouldn't
-        # be disabled.
-        self.__vtkreader.SetSqueezePoints(self.getOption('squeeze'))
-
-        # Set the data arrays to load
-        #
-        # If the object has not been initialized then all of the variables should be enabled so that
-        # the block and variable information are complete when populated. After this only the
-        # variables listed in the 'variables' options, if any, are activated, which reduces loading
-        # times. If 'variables' is not given, all the variables are loaded.
-        variables = self.getOption('variables')
-        variable_info = self.getVariableInformation()
-        for vinfo in variable_info.itervalues():
-            if (not variables) or (vinfo.name in variables):
-                self.__vtkreader.SetObjectArrayStatus(vinfo.object_type, vinfo.name, 1)
+            # Displacement Settings
+            if self.getOption('displacements'):
+                self.__vtkreader.ApplyDisplacementsOn()
+                self.__vtkreader.SetDisplacementMagnitude(self.getOption('displacement_magnitude'))
             else:
-                self.__vtkreader.SetObjectArrayStatus(vinfo.object_type, vinfo.name, 0)
+                self.__vtkreader.ApplyDisplacementsOff()
 
-        self.__vtkreader.Update()
+            # Set the geometric objects to load (i.e., subdomains, nodesets, sidesets)
+            active_blockinfo = self.__getActiveBlocks()
+            blockinfo = self.getBlockInformation()
+            for object_type in ExodusReader.BLOCK_TYPES:
+                for data in blockinfo[object_type].itervalues():
+                    if (not active_blockinfo) or (data in active_blockinfo):
+                        self.__vtkreader.SetObjectStatus(data.object_type, data.object_index, 1)
+                    else:
+                        self.__vtkreader.SetObjectStatus(data.object_type, data.object_index, 0)
+
+            # According to the VTK documentation setting this to False (not the default) speeds up data
+            # loading. In my testing I was seeing load times cut in half or more with "squeezing"
+            # disabled. I am leaving this as an option just in case we discover some reason it shouldn't
+            # be disabled.
+            self.__vtkreader.SetSqueezePoints(self.getOption('squeeze'))
+
+            # Set the data arrays to load
+            #
+            # If the object has not been initialized then all of the variables should be enabled so that
+            # the block and variable information are complete when populated. After this only the
+            # variables listed in the 'variables' options, if any, are activated, which reduces loading
+            # times. If 'variables' is not given, all the variables are loaded.
+            variables = self.getOption('variables')
+            variable_info = self.getVariableInformation()
+            for vinfo in variable_info.itervalues():
+                if (not variables) or (vinfo.name in variables):
+                    self.__vtkreader.SetObjectArrayStatus(vinfo.object_type, vinfo.name, 1)
+                else:
+                    self.__vtkreader.SetObjectArrayStatus(vinfo.object_type, vinfo.name, 0)
+
+            self.__vtkreader.Update()
 
     def needsUpdate(self):
         """ Determine the status of the object to indicate if the "update" method should be called.
@@ -414,17 +428,18 @@ class ExodusReader(base.ChiggerObject):
             if tinfo and (tinfo.modified == current_modified):
                 continue
 
-            self.__vtkreader.SetFileName(filename)
-            self.__vtkreader.Modified()
-            self.__vtkreader.UpdateInformation()
+            with lockFile(filename):
+                self.__vtkreader.SetFileName(filename)
+                self.__vtkreader.Modified()
+                self.__vtkreader.UpdateInformation()
 
-            vtkinfo = self.__vtkreader.GetExecutive().GetOutputInformation(0)
-            times = [vtkinfo.Get(key, i) for i in range(self.__vtkreader.GetNumberOfTimeSteps())]
+                vtkinfo = self.__vtkreader.GetExecutive().GetOutputInformation(0)
+                times = [vtkinfo.Get(key, i) for i in range(self.__vtkreader.GetNumberOfTimeSteps())]
 
-            if not times:
-                times = [None] # When --mesh-only is used, not time information is written
-            self.__fileinfo[filename] = ExodusReader.FileInformation(filename=filename, times=times,
-                                                                     modified=current_modified)
+                if not times:
+                    times = [None] # When --mesh-only is used, not time information is written
+                self.__fileinfo[filename] = ExodusReader.FileInformation(filename=filename, times=times,
+                                                                         modified=current_modified)
 
         # Re-populate the time data
         self.__timedata = []

--- a/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
@@ -144,7 +144,7 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
                 self.reset()
 
         # Display Exodus result
-        if file_exists:
+        if file_exists and os.path.getsize(self._filename) > 0:
             # Clear any-existing VTK objects on the window
             self._window.clear()
 


### PR DESCRIPTION
This adds an `flock` around reading and writing exodus files so that peacock won't crash.
I ran `grain_growth_2D_graintracker.i` in a loop over the weekend while running the script in #9128 without any crashes.

closes #9128

@permcody Can you try this out to see if you can still crash peacock?
