### PR TITLE
Peacock fixes

### DIFF
--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -111,6 +111,9 @@ class BlockEditor(QWidget, MooseWidget):
             self.remove_button = WidgetUtils.addButton(self.button_layout, self, "Remove Block", self._removeBlock)
             self.remove_button.setToolTip("Remove this block")
 
+        self.close_button = WidgetUtils.addButton(self.button_layout, self, "Apply && Close", self._applyAndClose)
+        self.close_button.setToolTip("Apply any changes and close the window")
+
         self.apply_button = WidgetUtils.addButton(self.button_layout, self, "Apply", self.applyChanges)
         self.apply_button.setEnabled(False)
         self.apply_button.setToolTip("Apply changes made")
@@ -122,8 +125,6 @@ class BlockEditor(QWidget, MooseWidget):
         self.new_parameter_button = WidgetUtils.addButton(self.button_layout, self, "Add parameter", self.addUserParamPressed)
         self.new_parameter_button.setToolTip("Add a non standard parameter")
 
-        self.close_button = WidgetUtils.addButton(self.button_layout, self, "Close", self._applyAndClose)
-        self.close_button.setToolTip("Apply any changes and close the window")
 
     def _findFreeParamName(self, max_params=1000):
         """

--- a/python/peacock/Input/InputFile.py
+++ b/python/peacock/Input/InputFile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from os import path
-from FactorySystem.ParseGetPot import readInputFile, GPNode
+from FactorySystem.ParseGetPot import readInputFile, GPNode, ParseException
 import mooseutils
 from peacock.PeacockException import PeacockException
 
@@ -62,8 +62,12 @@ class InputFile(object):
             with open(filename, "r") as f:
                 self.original_text = f.read()
             self.changed = False
+        except ParseException as e:
+            msg = "Failed to parse input file %s:\n%s\n" % (filename, e.msg)
+            mooseutils.mooseWarning(msg)
+            raise e
         except Exception as e:
-            msg = "Failed to parse input file %s:\n%s\n" % (filename, e)
+            msg = "Error occurred while parsing input file %s:\n%s\n" % (filename, e)
             mooseutils.mooseWarning(msg)
             raise e
 

--- a/python/peacock/PeacockApp.py
+++ b/python/peacock/PeacockApp.py
@@ -62,10 +62,8 @@ class PeacockApp(object):
                 qapp.processEvents()
                 self.main_widget.setTab(exodus_plugin.tabName())
                 qapp.processEvents()
-            elif tree.input_filename:
-                self.main_widget.setTab(input_plugin.tabName())
             else:
-                self.main_widget.setTab(exe_plugin.tabName())
+                self.main_widget.setTab(input_plugin.tabName())
         else:
             self.main_widget.setTab(exe_plugin.tabName())
         self.main_widget.setPythonVariable("PeacockApp", self)

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -26,7 +26,7 @@ class Tests(Testing.PeacockTester):
     def testPeacockAppWithExe(self):
         self.create_app([Testing.find_moose_test_exe()])
         tabs = self.app.main_widget.tab_plugin
-        self.check_current_tab(tabs, self.exe.tabName())
+        self.check_current_tab(tabs, self.input.tabName())
 
     def testPeacockAppWithInput(self):
         self.create_app(["../../common/transient.i", Testing.find_moose_test_exe()])
@@ -135,7 +135,7 @@ class Tests(Testing.PeacockTester):
     def testBadInput(self):
         self.create_app(["-i", "../../common/out_transient.e", Testing.find_moose_test_exe()])
         tabs = self.app.main_widget.tab_plugin
-        self.check_current_tab(tabs, self.exe.tabName())
+        self.check_current_tab(tabs, self.input.tabName())
 
     def testClearSettings(self):
         args = ["--clear-settings"]


### PR DESCRIPTION
Show the ParseGetPot error if it fails to parse an input file. closes #9120 
On the block editor, rename "Close" to "Apply & Close" and move it to the left. closes #8928 
If an executable is found and nothing else, the default tab should be the Input tab. closes #9118