### PR TITLE
Clang format stork/unit

### DIFF
--- a/stork/unit/src/SampleTest.C
+++ b/stork/unit/src/SampleTest.C
@@ -4,14 +4,14 @@
 TEST(MySampleTests, descriptiveTestName)
 {
   // compare equality
-  EXPECT_EQ(2, 1+1);
-  EXPECT_DOUBLE_EQ(2*3.5, 1.0*8-1);
+  EXPECT_EQ(2, 1 + 1);
+  EXPECT_DOUBLE_EQ(2 * 3.5, 1.0 * 8 - 1);
 
   // compare equality and immediately terminate this test if it fails
-  //ASSERT_EQ(2, 1);
+  // ASSERT_EQ(2, 1);
 
   // this won't run if you uncomment the above test because above assert will fail
-  ASSERT_NO_THROW(1+1);
+  ASSERT_NO_THROW(1 + 1);
 
   // for a complete list of assertions and for more unit testing documentation see:
   // https://github.com/google/googletest/blob/master/googletest/docs/Primer.md


### PR DESCRIPTION
looks like #9102 missed formatting the source in `stork/unit`