### PR TITLE
Return correct bool value for default input params in website

### DIFF
--- a/python/MooseDocs/extensions/MooseObjectParameterTable.py
+++ b/python/MooseDocs/extensions/MooseObjectParameterTable.py
@@ -126,6 +126,6 @@ class MooseObjectParameterTable(object):
 
         elif key == 'default':
             if ptype == 'bool':
-                param = repr(bool(param))
+                param = repr(param in ['True', '1'])
 
         return param


### PR DESCRIPTION
Not sure whether the bool params are always integer representations or actual words, so checked for them both.

Closes #9141