### PR TITLE
Change default font size for execute output

### DIFF
--- a/python/peacock/Execute/TerminalTextEdit.py
+++ b/python/peacock/Execute/TerminalTextEdit.py
@@ -10,7 +10,7 @@ class TerminalTextEdit(QTextEdit):
     def __init__(self, **kwds):
         super(TerminalTextEdit, self).__init__(**kwds)
 
-        self.setStyleSheet("TerminalTextEdit { background: black; color: white; }")
+        self.setStyleSheet("TerminalTextEdit { background: black; color: white; font-size: 10px;}")
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.setReadOnly(True)
 


### PR DESCRIPTION
This just changes the default font size on the execute output to a 10px font.

closes #9122