### PR TITLE
Standardise implementation of vapour pressure in FluidProperties

### DIFF
--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -224,7 +224,7 @@ public:
    * @param xnacl salt mass fraction (-)
    * @return brine vapour pressure (Pa)
    */
-  Real pSat(Real temperature, Real xnacl) const;
+  Real vaporPressure(Real temperature, Real xnacl) const;
 
   /**
    * Solubility of halite (solid NaCl) in water

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -258,7 +258,7 @@ public:
    * @param temperature water temperature (K)
    * @return saturation pressure (Pa)
    */
-  Real pSat(Real temperature) const;
+  Real vaporPressure(Real temperature) const;
 
   /**
    * Saturation pressure as a function of temperature and derivative
@@ -274,7 +274,7 @@ public:
    * @param[out] saturation pressure (Pa)
    * @param[out] derivative of saturation pressure wrt temperature (Pa/K)
    */
-  void pSat_dT(Real temperature, Real & psat, Real & dpsat_dT) const;
+  void vaporPressure_dT(Real temperature, Real & psat, Real & dpsat_dT) const;
 
   /**
    * Saturation temperature as a function of pressure.
@@ -288,7 +288,7 @@ public:
    * @param pressure water pressure (Pa)
    * @return saturation temperature (K)
    */
-  Real TSat(Real pressure) const;
+  Real vaporTemperature(Real pressure) const;
 
   /**
    * Auxillary equation for the boundary between regions 2 and 3.

--- a/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
@@ -19,7 +19,7 @@ validParams<BrineFluidProperties>()
 BrineFluidProperties::BrineFluidProperties(const InputParameters & parameters)
   : MultiComponentFluidPropertiesPT(parameters), _Mnacl(58.443e-3)
 {
-  // Water97FluidProperties UserObject for water (needed to access pSat)
+  // Water97FluidProperties UserObject for water (needed to access vapor pressure)
   std::string water97_name = name() + ":water97";
   {
     std::string class_name = "Water97FluidProperties";
@@ -348,7 +348,7 @@ BrineFluidProperties::k(Real water_density, Real temperature, Real xnacl) const
 }
 
 Real
-BrineFluidProperties::pSat(Real temperature, Real xnacl) const
+BrineFluidProperties::vaporPressure(Real temperature, Real xnacl) const
 {
   // Correlation requires molal concentration (mol/kg)
   Real mol = massFractionToMolalConc(xnacl);
@@ -364,7 +364,7 @@ BrineFluidProperties::pSat(Real temperature, Real xnacl) const
 
   // The brine vapour pressure is then found by evaluating the saturation pressure for pure water
   // using this effective temperature. Note: requires _water97_fp UserObject
-  return _water97_fp->pSat(th20);
+  return _water97_fp->vaporPressure(th20);
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -743,13 +743,13 @@ Real Water97FluidProperties::beta(Real /*pressure*/, Real /*temperature*/) const
 }
 
 Real
-Water97FluidProperties::pSat(Real temperature) const
+Water97FluidProperties::vaporPressure(Real temperature) const
 {
   // Check whether the input temperature is within the region of validity of this equation.
   // Valid for 273.15 K <= t <= 647.096 K
   if (temperature < 273.15 || temperature > _T_critical)
-    mooseError(
-        "Water97FluidProperties::pSat: Temperature is outside range 273.15 K <= T <= 647.096 K");
+    mooseError("Water97FluidProperties::vaporPressure: Temperature is outside range 273.15 K <= T "
+               "<= 647.096 K");
 
   // Constants for region 4 (the saturation curve up to the critical point)
   const std::vector<Real> n4{0.11670521452767e4,
@@ -775,13 +775,13 @@ Water97FluidProperties::pSat(Real temperature) const
 }
 
 void
-Water97FluidProperties::pSat_dT(Real temperature, Real & psat, Real & dpsat_dT) const
+Water97FluidProperties::vaporPressure_dT(Real temperature, Real & psat, Real & dpsat_dT) const
 {
   // Check whether the input temperature is within the region of validity of this equation.
   // Valid for 273.15 K <= t <= 647.096 K
   if (temperature < 273.15 || temperature > _T_critical)
-    mooseError(
-        "Water97FluidProperties::pSat_dT: Temperature is outside range 273.15 K <= T <= 647.096 K");
+    mooseError("Water97FluidProperties::vaporPressure_dT: Temperature is outside range 273.15 K <= "
+               "T <= 647.096 K");
 
   // Constants for region 4 (the saturation curve up to the critical point)
   const std::vector<Real> n4{0.11670521452767e4,
@@ -823,13 +823,13 @@ Water97FluidProperties::pSat_dT(Real temperature, Real & psat, Real & dpsat_dT) 
 }
 
 Real
-Water97FluidProperties::TSat(Real pressure) const
+Water97FluidProperties::vaporTemperature(Real pressure) const
 {
   // Check whether the input pressure is within the region of validity of this equation.
   // Valid for 611.213 Pa <= p <= 22.064 MPa
   if (pressure < 611.23 || pressure > _p_critical)
-    mooseError(
-        "Water97FluidProperties::TSat: Pressure is outside range 611.213 Pa <= p <= 22.064 MPa");
+    mooseError("Water97FluidProperties::vaporTemperature: Pressure is outside range 611.213 Pa <= "
+               "p <= 22.064 MPa");
 
   // Constants for region 4 (the saturation curve up to the critical point)
   const std::vector<Real> n4{0.11670521452767e4,
@@ -899,7 +899,7 @@ Water97FluidProperties::inRegion(Real pressure, Real temperature) const
   //          1073.15 K <= T <= 2273.15 K, p <= 50 Mpa
   if (temperature >= 273.15 && temperature <= 1073.15)
   {
-    if (pressure < pSat(273.15) || pressure > 100.0e6)
+    if (pressure < vaporPressure(273.15) || pressure > 100.0e6)
       mooseError("Pressure ", pressure, " is out of range in Water97FluidProperties::inRegion");
   }
   else if (temperature > 1073.15 && temperature <= 2273.15)
@@ -915,7 +915,7 @@ Water97FluidProperties::inRegion(Real pressure, Real temperature) const
 
   if (temperature >= 273.15 && temperature <= 623.15)
   {
-    if (pressure > pSat(temperature) && pressure <= 100.0e6)
+    if (pressure > vaporPressure(temperature) && pressure <= 100.0e6)
       region = 1;
     else
       region = 2;
@@ -1316,7 +1316,8 @@ Water97FluidProperties::subregion3(Real pressure, Real temperature) const
     else // (temperature > tempXY(pressure, JK))
       subregion = 10;
   }
-  else if (pMPa > pSat(643.15) * 1.0e-6 && pMPa <= 22.5) // pSat(643.15) = 21.04 MPa
+  else if (pMPa > vaporPressure(643.15) * 1.0e-6 &&
+           pMPa <= 22.5) // vaporPressure(643.15) = 21.04 MPa
   {
     if (temperature <= tempXY(pressure, CD))
       subregion = 2;
@@ -1346,17 +1347,17 @@ Water97FluidProperties::subregion3(Real pressure, Real temperature) const
         else // (temperature > tempXY(pressure, WX) && temperature <= tempXY(pressure, RX))
           subregion = 23;
       }
-      else if (temperature <= TSat(pressure))
+      else if (temperature <= vaporTemperature(pressure))
       {
         if (pMPa > 21.93161551 && pMPa <= 22.064)
           if (temperature > tempXY(pressure, QU) && temperature <= tempXY(pressure, UV))
             subregion = 20;
           else
             subregion = 24;
-        else // (pMPa > pSat(643.15) * 1.0e-6 && pMPa <= 21.93161551)
+        else // (pMPa > vaporPressure(643.15) * 1.0e-6 && pMPa <= 21.93161551)
           subregion = 20;
       }
-      else if (temperature > TSat(pressure))
+      else if (temperature > vaporTemperature(pressure))
       {
         if (pMPa > 21.90096265 && pMPa <= 22.064)
         {
@@ -1374,13 +1375,14 @@ Water97FluidProperties::subregion3(Real pressure, Real temperature) const
     else
       subregion = 10;
   }
-  else if (pMPa > 20.5 && pMPa <= pSat(643.15) * 1.0e-6) // pSat(643.15) = 21.04 MPa
+  else if (pMPa > 20.5 &&
+           pMPa <= vaporPressure(643.15) * 1.0e-6) // vaporPressure(643.15) = 21.04 MPa
   {
     if (temperature <= tempXY(pressure, CD))
       subregion = 2;
-    else if (temperature > tempXY(pressure, CD) && temperature <= TSat(pressure))
+    else if (temperature > tempXY(pressure, CD) && temperature <= vaporTemperature(pressure))
       subregion = 16;
-    else if (temperature > TSat(pressure) && temperature <= tempXY(pressure, JK))
+    else if (temperature > vaporTemperature(pressure) && temperature <= tempXY(pressure, JK))
       subregion = 17;
     else // (temperature > tempXY(pressure, JK))
       subregion = 10;
@@ -1389,14 +1391,14 @@ Water97FluidProperties::subregion3(Real pressure, Real temperature) const
   {
     if (temperature <= tempXY(pressure, CD))
       subregion = 2;
-    else if (temperature > tempXY(pressure, CD) && temperature <= TSat(pressure))
+    else if (temperature > tempXY(pressure, CD) && temperature <= vaporTemperature(pressure))
       subregion = 18;
     else
       subregion = 19;
   }
-  else if (pMPa > pSat(623.15) * 1.0e-6 && pMPa <= P3cd)
+  else if (pMPa > vaporPressure(623.15) * 1.0e-6 && pMPa <= P3cd)
   {
-    if (temperature < TSat(pressure))
+    if (temperature < vaporTemperature(pressure))
       subregion = 2;
     else
       subregion = 19;
@@ -1611,14 +1613,14 @@ Water97FluidProperties::inRegionPH(Real pressure, Real enthalpy) const
   unsigned int region;
 
   // Need to calculate enthalpies at the boundaries to delineate regions
-  Real p273 = pSat(273.15);
-  Real p623 = pSat(623.15);
+  Real p273 = vaporPressure(273.15);
+  Real p623 = vaporPressure(623.15);
 
   if (pressure >= p273 && pressure <= p623)
   {
-    if (enthalpy >= h(pressure, 273.15) && enthalpy <= h(pressure, TSat(pressure)))
+    if (enthalpy >= h(pressure, 273.15) && enthalpy <= h(pressure, vaporTemperature(pressure)))
       region = 1;
-    else if (enthalpy > h(pressure, TSat(pressure)) && enthalpy <= h(pressure, 1073.15))
+    else if (enthalpy > h(pressure, vaporTemperature(pressure)) && enthalpy <= h(pressure, 1073.15))
       region = 2;
     else if (enthalpy > h(pressure, 1073.15) && enthalpy <= h(pressure, 2273.15))
       region = 5;

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateWaterNCG.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateWaterNCG.C
@@ -39,7 +39,7 @@ PorousFlowFluidStateWaterNCG::thermophysicalProperties() const
   // component, and Raoult's law for water).
   // Note: these are in terms of mole fraction
   Real K0 = _ncg_fp.henryConstant(Tk) / _gas_porepressure[_qp];
-  Real K1 = _water_fp.pSat(Tk) / _gas_porepressure[_qp];
+  Real K1 = _water_fp.vaporPressure(Tk) / _gas_porepressure[_qp];
 
   // The mole fractions for the NCG component in the two component
   // case can be expressed in terms of the equilibrium constants only
@@ -112,7 +112,7 @@ PorousFlowFluidStateWaterNCG::thermophysicalProperties() const
     Real dK0_dT = dKh_dT / _gas_porepressure[_qp];
 
     Real psat, dpsat_dT;
-    _water_fp.pSat_dT(Tk, psat, dpsat_dT);
+    _water_fp.vaporPressure_dT(Tk, psat, dpsat_dT);
     Real dK1_dp = -psat / _gas_porepressure[_qp] / _gas_porepressure[_qp];
     Real dK1_dT = dpsat_dT / _gas_porepressure[_qp];
 
@@ -262,7 +262,7 @@ PorousFlowFluidStateWaterNCG::thermophysicalProperties() const
       Real dK0_dT = dKh_dT / _gas_porepressure[_qp];
 
       Real psat, dpsat_dT;
-      _water_fp.pSat_dT(Tk, psat, dpsat_dT);
+      _water_fp.vaporPressure_dT(Tk, psat, dpsat_dT);
       Real dK1_dp = -psat / _gas_porepressure[_qp] / _gas_porepressure[_qp];
       Real dK1_dT = dpsat_dT / _gas_porepressure[_qp];
 

--- a/unit/src/BrineFluidPropertiesTest.C
+++ b/unit/src/BrineFluidPropertiesTest.C
@@ -22,9 +22,9 @@
  */
 TEST_F(BrineFluidPropertiesTest, vapor)
 {
-  REL_TEST("vapor", _fp->pSat(473.15, 0.185), 1.34e6, 1.0e-2);
-  REL_TEST("vapor", _fp->pSat(473.15, 0.267), 1.21e6, 1.0e-2);
-  REL_TEST("vapor", _fp->pSat(473.15, 0.312), 1.13e6, 1.0e-2);
+  REL_TEST("vapor", _fp->vaporPressure(473.15, 0.185), 1.34e6, 1.0e-2);
+  REL_TEST("vapor", _fp->vaporPressure(473.15, 0.267), 1.21e6, 1.0e-2);
+  REL_TEST("vapor", _fp->vaporPressure(473.15, 0.312), 1.13e6, 1.0e-2);
 }
 
 /**

--- a/unit/src/Water97FluidPropertiesTest.C
+++ b/unit/src/Water97FluidPropertiesTest.C
@@ -132,11 +132,11 @@ TEST_F(Water97FluidPropertiesTest, b3ab)
  * Revised Release on the IAPWS Industrial Formulation 1997 for the
  * Thermodynamic Properties of Water and Steam, IAPWS 2007
  */
-TEST_F(Water97FluidPropertiesTest, pSat)
+TEST_F(Water97FluidPropertiesTest, vaporPressure)
 {
-  REL_TEST("pSat", _fp->pSat(300), 3.53658941e3, 1.0e-8);
-  REL_TEST("pSat", _fp->pSat(500), 2.63889776e6, 1.0e-8);
-  REL_TEST("pSat", _fp->pSat(600), 12.3443146e6, 1.0e-8);
+  REL_TEST("vaporPressure", _fp->vaporPressure(300), 3.53658941e3, 1.0e-8);
+  REL_TEST("vaporPressure", _fp->vaporPressure(500), 2.63889776e6, 1.0e-8);
+  REL_TEST("vaporPressure", _fp->vaporPressure(600), 12.3443146e6, 1.0e-8);
 }
 
 /**
@@ -145,11 +145,11 @@ TEST_F(Water97FluidPropertiesTest, pSat)
  * Revised Release on the IAPWS Industrial Formulation 1997 for the
  * Thermodynamic Properties of Water and Steam, IAPWS 2007
  */
-TEST_F(Water97FluidPropertiesTest, TSat)
+TEST_F(Water97FluidPropertiesTest, vaporTemperature)
 {
-  REL_TEST("pSat", _fp->TSat(0.1e6), 372.755919, 1.0e-8);
-  REL_TEST("pSat", _fp->TSat(1.0e6), 453.035632, 1.0e-8);
-  REL_TEST("pSat", _fp->TSat(10.0e6), 584.149488, 1.0e-8);
+  REL_TEST("vaporPressure", _fp->vaporTemperature(0.1e6), 372.755919, 1.0e-8);
+  REL_TEST("vaporPressure", _fp->vaporTemperature(1.0e6), 453.035632, 1.0e-8);
+  REL_TEST("vaporPressure", _fp->vaporTemperature(10.0e6), 584.149488, 1.0e-8);
 }
 
 /**
@@ -483,11 +483,11 @@ TEST_F(Water97FluidPropertiesTest, derivatives)
   T = 300.0;
   Real dT = 1.0e-4;
 
-  Real dpSat_dT_fd = (_fp->pSat(T + dT) - _fp->pSat(T - dT)) / (2.0 * dT);
+  Real dpSat_dT_fd = (_fp->vaporPressure(T + dT) - _fp->vaporPressure(T - dT)) / (2.0 * dT);
   Real pSat = 0.0, dpSat_dT = 0.0;
-  _fp->pSat_dT(T, pSat, dpSat_dT);
+  _fp->vaporPressure_dT(T, pSat, dpSat_dT);
 
-  REL_TEST("dpSat_dT", dpSat_dT, dpSat_dT_fd, 1.0e-6);
+  REL_TEST("dvaporPressure_dT", dpSat_dT, dpSat_dT_fd, 1.0e-6);
 
   // Region 5
   p = 30.0e6;
@@ -509,4 +509,3 @@ TEST_F(Water97FluidPropertiesTest, derivatives)
   REL_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-6);
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
 }
-


### PR DESCRIPTION
Basically `pSat() -> vaporPressure()` in `fluid_propertis` and `porous_flow`.

Also changed `TSat() -> vaporTemperature()` in `Water97FluidProperties` for consistency.

Closes #9146