### PR TITLE
Cosserat 'update' plasticity added

### DIFF
--- a/modules/tensor_mechanics/include/materials/CappedDruckerPragerCosseratStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedDruckerPragerCosseratStressUpdate.h
@@ -1,0 +1,88 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef CAPPEDDRUCKERPRAGERCOSSERATSTRESSUPDATE_H
+#define CAPPEDDRUCKERPRAGERCOSSERATSTRESSUPDATE_H
+
+#include "CappedDruckerPragerStressUpdate.h"
+
+class CappedDruckerPragerCosseratStressUpdate;
+
+template <>
+InputParameters validParams<CappedDruckerPragerCosseratStressUpdate>();
+
+/**
+ * CappedDruckerPragerCosseratStressUpdate performs the return-map
+ * algorithm and associated stress updates for plastic
+ * models that describe capped Drucker-Prager plasticity in the
+ * layered Cosserat setting
+ *
+ * This plastic model is ideally suited to a material (eg rock)
+ * that has different compressive, tensile and shear
+ * strengths.  Any of these strengths may be set large to
+ * accommodate special situations.  For instance, setting
+ * the compressive strength large is appropriate if there
+ * is no chance of compressive failure in a model.
+ *
+ * This plastic model has two internal parameters:
+ *  - a "shear" internal parameter which parameterises the
+ *    amount of shear plastic strain.  The cohesion, friction
+ *    angle, and dilation angle are assumed to be functions
+ *    of this internal parameter.
+ *  - a "tensile" internal parameter which parameterises the
+ *    amount of tensile plastic strain.  The tensile strength
+ *    and compressive strength are assumed to be functions of
+ *    this internal parameter.  This means, for instance, that
+ *    failure in tension can cause the compressive strenght
+ *    to soften, as would be expected in rock-mechanics
+ *    scenarios.
+ *
+ * This plasticity model assumes that the flow rule involves an
+ * isotropic built from the user-supplied Young and Poisson.
+ * That is, the return-map process does NOT flow using the
+ * elasticity tensor in the stress-strain law, which is unsymmetric
+ * in general (in the Cosserat setting).  Physically this corresponds
+ * to the notion that the "host" medium for the Cosserat grains/layers
+ * is failing via Drucker-Prager, and not the Cosserat grains/layers
+ * themselves.
+ */
+class CappedDruckerPragerCosseratStressUpdate : public CappedDruckerPragerStressUpdate
+{
+public:
+  CappedDruckerPragerCosseratStressUpdate(const InputParameters & parameters);
+
+protected:
+  /// Shear modulus for the host medium
+  const Real _shear;
+
+  /// Isotropic elasticity tensor for the host medium
+  RankFourTensor _Ehost;
+
+  virtual void setEppEqq(const RankFourTensor & Eijkl, Real & Epp, Real & Eqq) const override;
+
+  virtual void setStressAfterReturn(const RankTwoTensor & stress_trial,
+                                    Real p_ok,
+                                    Real q_ok,
+                                    Real gaE,
+                                    const std::vector<Real> & intnl,
+                                    const f_and_derivs & smoothed_q,
+                                    const RankFourTensor & Eijkl,
+                                    RankTwoTensor & stress) const override;
+
+  virtual void consistentTangentOperator(const RankTwoTensor & stress_trial,
+                                         Real p_trial,
+                                         Real q_trial,
+                                         const RankTwoTensor & stress,
+                                         Real p,
+                                         Real q,
+                                         Real gaE,
+                                         const f_and_derivs & smoothed_q,
+                                         const RankFourTensor & Eijkl,
+                                         bool compute_full_tangent_operator,
+                                         RankFourTensor & cto) const override;
+};
+
+#endif // CAPPEDDRUCKERPRAGERCOSSERATSTRESSUPDATE_H

--- a/modules/tensor_mechanics/include/materials/CappedWeakPlaneCosseratStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedWeakPlaneCosseratStressUpdate.h
@@ -29,25 +29,6 @@ public:
   CappedWeakPlaneCosseratStressUpdate(const InputParameters & parameters);
 
 protected:
-  /// The Cosserat curvature strain
-  const MaterialProperty<RankTwoTensor> & _curvature;
-
-  /// The Cosserat elastic flexural rigidity tensor
-  const MaterialProperty<RankFourTensor> & _elastic_flexural_rigidity_tensor;
-
-  /// the Cosserat couple-stress
-  MaterialProperty<RankTwoTensor> & _couple_stress;
-
-  /// the old value of Cosserat couple-stress
-  MaterialProperty<RankTwoTensor> & _couple_stress_old;
-
-  /// derivative of couple-stress w.r.t. curvature
-  MaterialProperty<RankFourTensor> & _Jacobian_mult_couple;
-
-  virtual void initQpStatefulProperties() override;
-
-  virtual void initialiseReturnProcess() override;
-
   virtual void consistentTangentOperator(const RankTwoTensor & stress_trial,
                                          Real p_trial,
                                          Real q_trial,

--- a/modules/tensor_mechanics/include/materials/ComputeLayeredCosseratElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeLayeredCosseratElasticityTensor.h
@@ -30,8 +30,18 @@ protected:
   /// Flexural rigidity tensor
   RankFourTensor _Bijkl;
 
+  /**
+   * Inverse of elasticity tensor.
+   * The usual _Eijkl.invSymm() cannot be used here as _Eijkl
+   * does not possess the usual symmetries
+   */
+  RankFourTensor _Cijkl;
+
   /// Flexural rigidity tensor at the qps
   MaterialProperty<RankFourTensor> & _elastic_flexural_rigidity_tensor;
+
+  /// Compliance tensor (_Eijkl^-1) at the qps
+  MaterialProperty<RankFourTensor> & _compliance;
 };
 
 #endif // COMPUTELAYEREDCOSSERATELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticCosseratStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticCosseratStress.h
@@ -46,7 +46,10 @@ protected:
    * elastic/inelastic strain decomposition.  Overriding this
    * method allows the correction to be made.
    */
-  virtual void computeAdmissibleState(unsigned model_number, RankTwoTensor & elastic_strain_increment, RankTwoTensor & inelastic_strain_increment, RankFourTensor & consistent_tangent_operator) override;
+  virtual void computeAdmissibleState(unsigned model_number,
+                                      RankTwoTensor & elastic_strain_increment,
+                                      RankTwoTensor & inelastic_strain_increment,
+                                      RankFourTensor & consistent_tangent_operator) override;
 
   /// The Cosserat curvature strain
   const MaterialProperty<RankTwoTensor> & _curvature;
@@ -64,7 +67,7 @@ protected:
   MaterialProperty<RankFourTensor> & _Jacobian_mult_couple;
 
   /// Inverse of the elasticity tensor
-  const  MaterialProperty<RankFourTensor> & _compliance;
+  const MaterialProperty<RankFourTensor> & _compliance;
 };
 
 #endif // COMPUTEMULTIPLEINELASTICCOSSERATSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticCosseratStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticCosseratStress.h
@@ -1,0 +1,70 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef COMPUTEMULTIPLEINELASTICCOSSERATSTRESS_H
+#define COMPUTEMULTIPLEINELASTICCOSSERATSTRESS_H
+
+#include "ComputeMultipleInelasticStress.h"
+
+class ComputeMultipleInelasticCosseratStress;
+
+/**
+ * ComputeMultipleInelasticStress computes the stress, the consistent tangent
+ * operator (or an approximation to it), and a decomposition of the strain
+ * into elastic and inelastic parts.  By default finite strains are assumed.
+ *
+ * Cosserat couple-stress, and the cosserat version of the consistent
+ * tangent operator are also computed, but only using Cosserat elasticity.
+ *
+ * The elastic strain is calculated by subtracting the computed inelastic strain
+ * increment tensor from the mechanical strain tensor.  Mechanical strain is
+ * considered as the sum of the elastic and inelastic (plastic, creep, ect) strains.
+ *
+ * This material is used to call the recompute iterative materials of a number
+ * of specified inelastic models that inherit from StressUpdateBase.  It iterates
+ * over the specified inelastic models until the change in stress is within
+ * a user-specified tolerance, in order to produce the stress, the consistent
+ * tangent operator and the elastic and inelastic strains for the time increment.
+ */
+
+class ComputeMultipleInelasticCosseratStress : public ComputeMultipleInelasticStress
+{
+public:
+  ComputeMultipleInelasticCosseratStress(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties() override;
+  virtual void computeQpStress() override;
+  virtual void computeQpJacobianMult() override;
+  /**
+   * The current Cosserat models do not know they might be using the
+   * "host" version of the elasticity tensor during the
+   * return-map process.  Therefore, they compute the incorrect
+   * elastic/inelastic strain decomposition.  Overriding this
+   * method allows the correction to be made.
+   */
+  virtual void computeAdmissibleState(unsigned model_number, RankTwoTensor & elastic_strain_increment, RankTwoTensor & inelastic_strain_increment, RankFourTensor & consistent_tangent_operator) override;
+
+  /// The Cosserat curvature strain
+  const MaterialProperty<RankTwoTensor> & _curvature;
+
+  /// The Cosserat elastic flexural rigidity tensor
+  const MaterialProperty<RankFourTensor> & _elastic_flexural_rigidity_tensor;
+
+  /// the Cosserat couple-stress
+  MaterialProperty<RankTwoTensor> & _couple_stress;
+
+  /// the old value of Cosserat couple-stress
+  const MaterialProperty<RankTwoTensor> & _couple_stress_old;
+
+  /// derivative of couple-stress w.r.t. curvature
+  MaterialProperty<RankFourTensor> & _Jacobian_mult_couple;
+
+  /// Inverse of the elasticity tensor
+  const  MaterialProperty<RankFourTensor> & _compliance;
+};
+
+#endif // COMPUTEMULTIPLEINELASTICCOSSERATSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -74,15 +74,23 @@ protected:
 
   /**
    * Given a trial stress (_stress[_qp]) and a strain increment (elastic_strain_increment)
-   * let the model_number model produce an admissible stress (gets placed back in _stress[_qp]), and decompose
-   * the strain increment into an elastic part (gets placed back into elastic_strain_increment) and an
-   * inelastic part (inelastic_strain_increment), as well as computing the consistent_tangent_operator
+   * let the model_number model produce an admissible stress (gets placed back in _stress[_qp]), and
+   * decompose
+   * the strain increment into an elastic part (gets placed back into elastic_strain_increment) and
+   * an
+   * inelastic part (inelastic_strain_increment), as well as computing the
+   * consistent_tangent_operator
    * @param model_number The inelastic model to use
-   * @param elastic_strain_increment Upon input, this is the strain increment.  Upon output, it is the elastic part of the strain increment
-   * @param inelastic_strain_increment The inelastic strain increment corresponding to the supplied strain increment
+   * @param elastic_strain_increment Upon input, this is the strain increment.  Upon output, it is
+   * the elastic part of the strain increment
+   * @param inelastic_strain_increment The inelastic strain increment corresponding to the supplied
+   * strain increment
    * @param consistent_tangent_operator The consistent tangent operator
    */
-  virtual void computeAdmissibleState(unsigned model_number, RankTwoTensor & elastic_strain_increment, RankTwoTensor & inelastic_strain_increment, RankFourTensor & consistent_tangent_operator);
+  virtual void computeAdmissibleState(unsigned model_number,
+                                      RankTwoTensor & elastic_strain_increment,
+                                      RankTwoTensor & inelastic_strain_increment,
+                                      RankFourTensor & consistent_tangent_operator);
 
   ///@{Input parameters associated with the recompute iteration to return the stress state to the yield surface
   const unsigned int _max_iterations;

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -65,6 +65,25 @@ protected:
   virtual void updateQpStateSingleModel(RankTwoTensor & elastic_strain_increment,
                                         RankTwoTensor & combined_inelastic_strain_increment);
 
+  /**
+   * Using _elasticity_tensor[_qp] and the consistent tangent operators,
+   * _comsistent_tangent_operator[...] computed by the inelastic models,
+   * compute _Jacobian_mult[_qp]
+   */
+  virtual void computeQpJacobianMult();
+
+  /**
+   * Given a trial stress (_stress[_qp]) and a strain increment (elastic_strain_increment)
+   * let the model_number model produce an admissible stress (gets placed back in _stress[_qp]), and decompose
+   * the strain increment into an elastic part (gets placed back into elastic_strain_increment) and an
+   * inelastic part (inelastic_strain_increment), as well as computing the consistent_tangent_operator
+   * @param model_number The inelastic model to use
+   * @param elastic_strain_increment Upon input, this is the strain increment.  Upon output, it is the elastic part of the strain increment
+   * @param inelastic_strain_increment The inelastic strain increment corresponding to the supplied strain increment
+   * @param consistent_tangent_operator The consistent tangent operator
+   */
+  virtual void computeAdmissibleState(unsigned model_number, RankTwoTensor & elastic_strain_increment, RankTwoTensor & inelastic_strain_increment, RankFourTensor & consistent_tangent_operator);
+
   ///@{Input parameters associated with the recompute iteration to return the stress state to the yield surface
   const unsigned int _max_iterations;
   const Real _relative_tolerance;

--- a/modules/tensor_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
@@ -512,14 +512,17 @@ protected:
    * the returned configuration
    * @param Eijkl The elasticity tensor
    * @param returned_stress The stress after the return-map process
-   * @param inelastic_strain_increment[out] The inelastic strain increment resulting from this return-map
+   * @param inelastic_strain_increment[out] The inelastic strain increment resulting from this
+   * return-map
    */
-  virtual void setInelasticStrainIncrementAfterReturn(const RankTwoTensor & stress_trial,
-                                                         Real gaE,
-                                                         const f_and_derivs & smoothed_q,
-                                                         const RankFourTensor & elasticity_tensor,
-                                                      const RankTwoTensor & returned_stress, RankTwoTensor & inelastic_strain_increment) const;
-  
+  virtual void
+  setInelasticStrainIncrementAfterReturn(const RankTwoTensor & stress_trial,
+                                         Real gaE,
+                                         const f_and_derivs & smoothed_q,
+                                         const RankFourTensor & elasticity_tensor,
+                                         const RankTwoTensor & returned_stress,
+                                         RankTwoTensor & inelastic_strain_increment) const;
+
   /**
    * Calculates the consistent tangent operator.
    * Derived classes may choose to override this for computational

--- a/modules/tensor_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
@@ -325,6 +325,9 @@ protected:
    */
   std::vector<f_and_derivs> _all_q;
 
+  /// An admissible value of (p, q)
+  const std::vector<Real> _pq_ok;
+
   /**
    * Computes the values of the yield functions, given p, q and intnl parameters.
    * Derived classes must override this, to provide the values of the yield functions
@@ -497,6 +500,26 @@ protected:
                                     const RankFourTensor & Eijkl,
                                     RankTwoTensor & stress) const;
 
+  /**
+   * Sets inelastic strain increment from the returned configuration
+   * This is called after the return-map process has completed
+   * successfully in (p, q) space, just after finalizeReturnProcess
+   * has been called.
+   * Derived classes may override this function
+   * @param stress_trial The trial value of stress
+   * @param gaE Value of gaE induced by the return (gaE = gamma * Epp)
+   * @param smoothed_q Holds the current value of yield function and derivatives evaluated at
+   * the returned configuration
+   * @param Eijkl The elasticity tensor
+   * @param returned_stress The stress after the return-map process
+   * @param inelastic_strain_increment[out] The inelastic strain increment resulting from this return-map
+   */
+  virtual void setInelasticStrainIncrementAfterReturn(const RankTwoTensor & stress_trial,
+                                                         Real gaE,
+                                                         const f_and_derivs & smoothed_q,
+                                                         const RankFourTensor & elasticity_tensor,
+                                                      const RankTwoTensor & returned_stress, RankTwoTensor & inelastic_strain_increment) const;
+  
   /**
    * Calculates the consistent tangent operator.
    * Derived classes may choose to override this for computational

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -43,6 +43,7 @@
 #include "CappedWeakInclinedPlaneStressUpdate.h"
 #include "CappedWeakPlaneCosseratStressUpdate.h"
 #include "CappedDruckerPragerStressUpdate.h"
+#include "CappedDruckerPragerCosseratStressUpdate.h"
 #include "ComputeMultiPlasticityStress.h"
 #include "ComputeCosseratLinearElasticStress.h"
 #include "ComputeCosseratSmallStrain.h"
@@ -89,6 +90,7 @@
 #include "ComputeDeformGradBasedStress.h"
 #include "VolumeDeformGradCorrectedStress.h"
 #include "ComputeMultipleInelasticStress.h"
+#include "ComputeMultipleInelasticCosseratStress.h"
 #include "RadialReturnStressUpdate.h"
 #include "IsotropicPlasticityStressUpdate.h"
 #include "IsotropicPowerLawHardeningStressUpdate.h"
@@ -245,6 +247,7 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerMaterial(CappedWeakInclinedPlaneStressUpdate);
   registerMaterial(CappedWeakPlaneCosseratStressUpdate);
   registerMaterial(CappedDruckerPragerStressUpdate);
+  registerMaterial(CappedDruckerPragerCosseratStressUpdate);
   registerMaterial(ComputeMultiPlasticityStress);
   registerMaterial(ComputeCosseratLinearElasticStress);
   registerMaterial(ComputeCosseratSmallStrain);
@@ -291,6 +294,7 @@ TensorMechanicsApp::registerObjects(Factory & factory)
   registerMaterial(ComputeDeformGradBasedStress);
   registerMaterial(VolumeDeformGradCorrectedStress);
   registerMaterial(ComputeMultipleInelasticStress);
+  registerMaterial(ComputeMultipleInelasticCosseratStress);
   registerMaterial(RadialReturnStressUpdate);
   registerMaterial(IsotropicPlasticityStressUpdate);
   registerMaterial(IsotropicPowerLawHardeningStressUpdate);

--- a/modules/tensor_mechanics/src/materials/CappedDruckerPragerCosseratStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedDruckerPragerCosseratStressUpdate.C
@@ -1,0 +1,128 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#include "CappedDruckerPragerCosseratStressUpdate.h"
+
+template <>
+InputParameters
+validParams<CappedDruckerPragerCosseratStressUpdate>()
+{
+  InputParameters params = validParams<CappedDruckerPragerStressUpdate>();
+  params.addClassDescription("Capped Drucker-Prager plasticity stress calculator for the Cosserat situation where the host medium (ie, the limit where all Cosserat effects are zero) is isotropic.  Note that the return-map flow rule uses an isotropic elasticity tensor built with the 'host' properties defined by the user.");
+  params.addRequiredRangeCheckedParam<Real>("host_youngs_modulus", "host_youngs_modulus>0", "Young's modulus for the isotropic host medium");
+  params.addRequiredRangeCheckedParam<Real>("host_poissons_ratio", "host_poissons_ratio>=0", "Poisson's ratio for the isotropic host medium");
+  return params;
+}
+
+CappedDruckerPragerCosseratStressUpdate::CappedDruckerPragerCosseratStressUpdate(const InputParameters & parameters)
+  : CappedDruckerPragerStressUpdate(parameters),
+    _shear(getParam<Real>("host_youngs_modulus") / (2.0 * (1.0 + getParam<Real>("host_poissons_ratio"))))
+{
+  const Real young = getParam<Real>("host_youngs_modulus");
+  const Real poisson = getParam<Real>("host_poissons_ratio");
+  const Real lambda = young * poisson / ((1.0 + poisson) * (1.0 - 2.0 * poisson));
+  _Ehost.fillFromInputVector({lambda, _shear}, RankFourTensor::symmetric_isotropic);
+}
+
+void
+CappedDruckerPragerCosseratStressUpdate::setEppEqq(const RankFourTensor & /*Eijkl*/,
+                                           Real & Epp,
+                                           Real & Eqq) const
+{
+  Epp = _Ehost.sum3x3();
+  Eqq = _shear;
+}
+
+void
+CappedDruckerPragerCosseratStressUpdate::setStressAfterReturn(const RankTwoTensor & stress_trial,
+                                                      Real p_ok,
+                                                      Real q_ok,
+                                                      Real /*gaE*/,
+                                                      const std::vector<Real> & /*intnl*/,
+                                                      const f_and_derivs & /*smoothed_q*/,
+                                                      const RankFourTensor & /*Eijkl*/,
+                                                      RankTwoTensor & stress) const
+{
+  // symm_stress is the symmetric part of the stress tensor.
+  // symm_stress = (s_ij+s_ji)/2 + de_ij tr(stress) / 3
+  //             = q / q_trial * (s_ij^trial+s_ji^trial)/2 + de_ij p / 3
+  //             = q / q_trial * (symm_stress_ij^trial - de_ij tr(stress^trial) / 3) + de_ij p / 3
+  const Real p_trial = stress_trial.trace();
+  RankTwoTensor symm_stress = RankTwoTensor(RankTwoTensor::initIdentity) / 3.0 *
+           (p_ok - (_in_q_trial == 0.0 ? 0.0 : p_trial * q_ok / _in_q_trial));
+  if (_in_q_trial > 0)
+    symm_stress += q_ok / _in_q_trial * 0.5 * (stress_trial + stress_trial.transpose());
+  stress = symm_stress + 0.5 * (stress_trial - stress_trial.transpose());
+}
+
+void
+CappedDruckerPragerCosseratStressUpdate::consistentTangentOperator(const RankTwoTensor & /*stress_trial*/,
+                                                           Real /*p_trial*/,
+                                                           Real /*q_trial*/,
+                                                           const RankTwoTensor & stress,
+                                                           Real /*p*/,
+                                                           Real q,
+                                                           Real gaE,
+                                                           const f_and_derivs & smoothed_q,
+                                                           const RankFourTensor & Eijkl,
+                                                           bool compute_full_tangent_operator,
+                                                           RankFourTensor & cto) const
+{
+  if (!_fe_problem.currentlyComputingJacobian())
+    return;
+
+  if (!compute_full_tangent_operator)
+  {
+    cto = Eijkl;
+    return;
+  }
+
+  RankFourTensor EAijkl;
+  for (unsigned i = 0; i < _tensor_dimensionality; ++i)
+    for (unsigned j = 0; j < _tensor_dimensionality; ++j)
+      for (unsigned k = 0; k < _tensor_dimensionality; ++k)
+        for (unsigned l = 0; l < _tensor_dimensionality; ++l)
+        {
+          cto(i, j, k, l) = 0.5 * (Eijkl(i, j, k, l) + Eijkl(j, i, k, l));
+          EAijkl(i, j, k, l) = 0.5 * (Eijkl(i, j, k, l) - Eijkl(j, i, k, l));
+        }
+
+  
+  const RankTwoTensor s_over_q =
+      (q == 0.0 ? RankTwoTensor()
+       : (0.5 * (stress + stress.transpose()) - stress.trace() * RankTwoTensor(RankTwoTensor::initIdentity) / 3.0) / q);
+  const RankTwoTensor E_s_over_q = Eijkl.innerProductTranspose(s_over_q);  // not symmetric in kl
+  const RankTwoTensor Ekl = RankTwoTensor(RankTwoTensor::initIdentity).initialContraction(Eijkl); // symmetric in kl
+
+  for (unsigned i = 0; i < _tensor_dimensionality; ++i)
+    for (unsigned j = 0; j < _tensor_dimensionality; ++j)
+      for (unsigned k = 0; k < _tensor_dimensionality; ++k)
+        for (unsigned l = 0; l < _tensor_dimensionality; ++l)
+        {
+          cto(i, j, k, l) -= (i == j) * (1.0 / 3.0) * (Ekl(k, l) * (1.0 - _dp_dpt) +
+                                                       0.5 * E_s_over_q(k, l) * (-_dp_dqt));
+          cto(i, j, k, l) -= s_over_q(i, j) * (Ekl(k, l) * (-_dq_dpt) +
+                                               0.5 * E_s_over_q(k, l) * (1.0 - _dq_dqt));
+        }
+
+  if (smoothed_q.dg[1] != 0.0)
+  {
+    const RankFourTensor Tijab = _Ehost * (gaE / _Epp) * smoothed_q.dg[1] * d2qdstress2(stress);
+    RankFourTensor inv = RankFourTensor(RankFourTensor::initIdentitySymmetricFour) + Tijab;
+    try
+    {
+      inv = inv.transposeMajor().invSymm();
+    }
+    catch (const MooseException & e)
+    {
+      // Cannot form the inverse, so probably at some degenerate place in stress space.
+      // Just return with the "best estimate" of the cto.
+      return;
+    }
+    cto = (cto.transposeMajor() * inv).transposeMajor();
+  }
+  cto += EAijkl;
+}

--- a/modules/tensor_mechanics/src/materials/CappedDruckerPragerStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedDruckerPragerStressUpdate.C
@@ -464,6 +464,11 @@ CappedDruckerPragerStressUpdate::consistentTangentOperator(const RankTwoTensor &
     {
       // Cannot form the inverse, so probably at some degenerate place in stress space.
       // Just return with the "best estimate" of the cto.
+      mooseWarning("CappedDruckerPragerStressUpdate: Cannot invert 1+T in consistent tangent "
+                   "operator computation at quadpoint ",
+                   _qp,
+                   " of element ",
+                   _current_elem->id());
       return;
     }
     cto = (cto.transposeMajor() * inv).transposeMajor();

--- a/modules/tensor_mechanics/src/materials/CappedWeakPlaneCosseratStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedWeakPlaneCosseratStressUpdate.C
@@ -19,30 +19,8 @@ validParams<CappedWeakPlaneCosseratStressUpdate>()
 
 CappedWeakPlaneCosseratStressUpdate::CappedWeakPlaneCosseratStressUpdate(
     const InputParameters & parameters)
-  : CappedWeakPlaneStressUpdate(parameters),
-    _curvature(getMaterialPropertyByName<RankTwoTensor>("curvature")),
-    _elastic_flexural_rigidity_tensor(
-        getMaterialPropertyByName<RankFourTensor>("elastic_flexural_rigidity_tensor")),
-    _couple_stress(declareProperty<RankTwoTensor>("couple_stress")),
-    _couple_stress_old(declarePropertyOld<RankTwoTensor>("couple_stress")),
-    _Jacobian_mult_couple(declareProperty<RankFourTensor>("couple_Jacobian_mult"))
+  : CappedWeakPlaneStressUpdate(parameters)
 {
-}
-
-void
-CappedWeakPlaneCosseratStressUpdate::initQpStatefulProperties()
-{
-  CappedWeakPlaneStressUpdate::initQpStatefulProperties();
-  _couple_stress[_qp].zero();
-}
-
-void
-CappedWeakPlaneCosseratStressUpdate::initialiseReturnProcess()
-{
-  CappedWeakPlaneStressUpdate::initialiseReturnProcess();
-  _couple_stress[_qp] = _elastic_flexural_rigidity_tensor[_qp] * _curvature[_qp];
-  if (_fe_problem.currentlyComputingJacobian())
-    _Jacobian_mult_couple[_qp] = _elastic_flexural_rigidity_tensor[_qp];
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
@@ -35,7 +35,7 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
     _Bijkl(RankFourTensor()),
     _Cijkl(RankFourTensor()),
     _elastic_flexural_rigidity_tensor(
-                                      declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
+        declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
     _compliance(declareProperty<RankFourTensor>(_base_name + "compliance_tensor"))
 {
   const Real E = getParam<Real>("young");
@@ -83,18 +83,18 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
   // this is the main reason it is calculated here, since we can't use
   // _Eijkl.invSymm()
   const Real pre = (nu - 1.0) / (a0000 * (nu - 1.0) + 2.0 * a2222 * Utility::pow<2>(nu));
-  const Real cp0000 = ((a2222 - a0000) * nu * nu + 2.0 * a0000 * nu - a0000) / (2.0 * a0000 * nu - a0000);
-  const Real cp0011 = - ((a0000 + a2222) * nu * nu - a0000 * nu) / (2.0 * a0000 * nu - a0000);
+  const Real cp0000 =
+      ((a2222 - a0000) * nu * nu + 2.0 * a0000 * nu - a0000) / (2.0 * a0000 * nu - a0000);
+  const Real cp0011 = -((a0000 + a2222) * nu * nu - a0000 * nu) / (2.0 * a0000 * nu - a0000);
   _Cijkl(0, 0, 0, 0) = _Cijkl(1, 1, 1, 1) = pre * cp0000;
   _Cijkl(0, 0, 1, 1) = _Cijkl(1, 1, 0, 0) = pre * cp0011;
   _Cijkl(2, 2, 2, 2) = pre * a0000 / a2222;
-  _Cijkl(0, 0, 2, 2) = _Cijkl(1, 1, 2, 2) = _Cijkl(2, 2, 0, 0) = _Cijkl(2, 2, 1, 1) = - nu * pre;
+  _Cijkl(0, 0, 2, 2) = _Cijkl(1, 1, 2, 2) = _Cijkl(2, 2, 0, 0) = _Cijkl(2, 2, 1, 1) = -nu * pre;
   _Cijkl(0, 1, 0, 1) = _Cijkl(0, 1, 1, 0) = _Cijkl(1, 0, 0, 1) = _Cijkl(1, 0, 1, 0) = 0.25 / a0101;
   const Real slip = 2.0 / (G - Gprime);
-  _Cijkl(0, 2, 2, 0) = _Cijkl(2, 0, 0, 2) = _Cijkl(1, 2, 2, 1) = _Cijkl(2, 1, 1, 2) = - slip;
+  _Cijkl(0, 2, 2, 0) = _Cijkl(2, 0, 0, 2) = _Cijkl(1, 2, 2, 1) = _Cijkl(2, 1, 1, 2) = -slip;
   _Cijkl(0, 2, 0, 2) = _Cijkl(1, 2, 1, 2) = (G + Gprime) * slip / 2.0 / Gprime;
   _Cijkl(2, 0, 2, 0) = _Cijkl(2, 1, 2, 1) = slip;
-
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
@@ -6,6 +6,8 @@
 /****************************************************************/
 #include "ComputeLayeredCosseratElasticityTensor.h"
 #include "libmesh/utility.h"
+#include "Function.h"
+#include "RankTwoTensor.h"
 
 template <>
 InputParameters
@@ -31,8 +33,10 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
   : ComputeElasticityTensorBase(parameters),
     _Eijkl(RankFourTensor()),
     _Bijkl(RankFourTensor()),
+    _Cijkl(RankFourTensor()),
     _elastic_flexural_rigidity_tensor(
-        declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor"))
+                                      declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
+    _compliance(declareProperty<RankFourTensor>(_base_name + "compliance_tensor"))
 {
   const Real E = getParam<Real>("young");
   const Real nu = getParam<Real>("poisson");
@@ -74,6 +78,23 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
   const Real b0110 = -nu * b0101;
   _Bijkl(0, 1, 0, 1) = _Bijkl(1, 0, 1, 0) = b0101;
   _Bijkl(0, 1, 1, 0) = _Bijkl(1, 0, 0, 1) = b0110;
+
+  // The compliance tensor also does not obey the usual symmetries, and
+  // this is the main reason it is calculated here, since we can't use
+  // _Eijkl.invSymm()
+  const Real pre = (nu - 1.0) / (a0000 * (nu - 1.0) + 2.0 * a2222 * Utility::pow<2>(nu));
+  const Real cp0000 = ((a2222 - a0000) * nu * nu + 2.0 * a0000 * nu - a0000) / (2.0 * a0000 * nu - a0000);
+  const Real cp0011 = - ((a0000 + a2222) * nu * nu - a0000 * nu) / (2.0 * a0000 * nu - a0000);
+  _Cijkl(0, 0, 0, 0) = _Cijkl(1, 1, 1, 1) = pre * cp0000;
+  _Cijkl(0, 0, 1, 1) = _Cijkl(1, 1, 0, 0) = pre * cp0011;
+  _Cijkl(2, 2, 2, 2) = pre * a0000 / a2222;
+  _Cijkl(0, 0, 2, 2) = _Cijkl(1, 1, 2, 2) = _Cijkl(2, 2, 0, 0) = _Cijkl(2, 2, 1, 1) = - nu * pre;
+  _Cijkl(0, 1, 0, 1) = _Cijkl(0, 1, 1, 0) = _Cijkl(1, 0, 0, 1) = _Cijkl(1, 0, 1, 0) = 0.25 / a0101;
+  const Real slip = 2.0 / (G - Gprime);
+  _Cijkl(0, 2, 2, 0) = _Cijkl(2, 0, 0, 2) = _Cijkl(1, 2, 2, 1) = _Cijkl(2, 1, 1, 2) = - slip;
+  _Cijkl(0, 2, 0, 2) = _Cijkl(1, 2, 1, 2) = (G + Gprime) * slip / 2.0 / Gprime;
+  _Cijkl(2, 0, 2, 0) = _Cijkl(2, 1, 2, 1) = slip;
+
 }
 
 void
@@ -81,4 +102,8 @@ ComputeLayeredCosseratElasticityTensor::computeQpElasticityTensor()
 {
   _elasticity_tensor[_qp] = _Eijkl;
   _elastic_flexural_rigidity_tensor[_qp] = _Bijkl;
+  _compliance[_qp] = _Cijkl;
+
+  if (_prefactor_function)
+    _compliance[_qp] /= _prefactor_function->value(_t, _q_point[_qp]);
 }

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
@@ -1,0 +1,81 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#include "ComputeMultipleInelasticCosseratStress.h"
+
+template <>
+InputParameters
+validParams<ComputeMultipleInelasticCosseratStress>()
+{
+  InputParameters params = validParams<ComputeMultipleInelasticStress>();
+  params.addClassDescription("Compute state (stress and other quantities such as plastic "
+                             "strains and internal parameters) using an iterative process, as well as Cosserat versions of these quantities.  Only elasticity is currently implemented for the Cosserat versions."
+                             "Combinations of creep models and plastic models may be used");
+  return params;
+}
+
+ComputeMultipleInelasticCosseratStress::ComputeMultipleInelasticCosseratStress(const InputParameters & parameters)
+  : ComputeMultipleInelasticStress(parameters),
+    _curvature(getMaterialProperty<RankTwoTensor>("curvature")),
+    _elastic_flexural_rigidity_tensor(
+        getMaterialProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
+    _couple_stress(declareProperty<RankTwoTensor>("couple_stress")),
+    _couple_stress_old(getMaterialPropertyOld<RankTwoTensor>("couple_stress")),
+    _Jacobian_mult_couple(declareProperty<RankFourTensor>("couple_Jacobian_mult")),
+    _compliance(getMaterialProperty<RankFourTensor>(_base_name + "compliance_tensor"))
+{
+}
+
+void
+ComputeMultipleInelasticCosseratStress::initQpStatefulProperties()
+{
+  ComputeMultipleInelasticStress::initQpStatefulProperties();
+  _couple_stress[_qp].zero();
+}
+
+void
+ComputeMultipleInelasticCosseratStress::computeQpStress()
+{
+  ComputeMultipleInelasticStress::computeQpStress();
+
+  _couple_stress[_qp] = _elastic_flexural_rigidity_tensor[_qp] * _curvature[_qp];
+  if (_fe_problem.currentlyComputingJacobian())
+    _Jacobian_mult_couple[_qp] = _elastic_flexural_rigidity_tensor[_qp];
+
+  if (_perform_finite_strain_rotations)
+  {
+    _couple_stress[_qp] = _rotation_increment[_qp] * _couple_stress[_qp] * _rotation_increment[_qp].transpose();
+    _Jacobian_mult_couple[_qp].rotate(_rotation_increment[_qp]);
+  }
+}
+
+void
+ComputeMultipleInelasticCosseratStress::computeQpJacobianMult()
+{
+  if (_tangent_operator_type == TangentOperatorEnum::elastic)
+    _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
+  else
+  {
+    _Jacobian_mult[_qp] = _consistent_tangent_operator[0];
+    for (unsigned i_rmm = 1; i_rmm < _num_models; ++i_rmm)
+      _Jacobian_mult[_qp] = _consistent_tangent_operator[i_rmm] * _compliance[_qp] * _Jacobian_mult[_qp];
+  }
+}
+
+
+void
+ComputeMultipleInelasticCosseratStress::computeAdmissibleState(unsigned model_number, RankTwoTensor & elastic_strain_increment, RankTwoTensor & inelastic_strain_increment, RankFourTensor & consistent_tangent_operator)
+{
+  const RankTwoTensor trial_stress = _stress[_qp];
+  const RankTwoTensor applied_strain_increment = elastic_strain_increment;
+
+  ComputeMultipleInelasticStress::computeAdmissibleState(model_number, elastic_strain_increment, inelastic_strain_increment, consistent_tangent_operator);
+
+  inelastic_strain_increment = _compliance[_qp] * (trial_stress - _stress[_qp]);
+  elastic_strain_increment = applied_strain_increment - inelastic_strain_increment;
+}
+
+

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
@@ -12,12 +12,15 @@ validParams<ComputeMultipleInelasticCosseratStress>()
 {
   InputParameters params = validParams<ComputeMultipleInelasticStress>();
   params.addClassDescription("Compute state (stress and other quantities such as plastic "
-                             "strains and internal parameters) using an iterative process, as well as Cosserat versions of these quantities.  Only elasticity is currently implemented for the Cosserat versions."
+                             "strains and internal parameters) using an iterative process, as well "
+                             "as Cosserat versions of these quantities.  Only elasticity is "
+                             "currently implemented for the Cosserat versions."
                              "Combinations of creep models and plastic models may be used");
   return params;
 }
 
-ComputeMultipleInelasticCosseratStress::ComputeMultipleInelasticCosseratStress(const InputParameters & parameters)
+ComputeMultipleInelasticCosseratStress::ComputeMultipleInelasticCosseratStress(
+    const InputParameters & parameters)
   : ComputeMultipleInelasticStress(parameters),
     _curvature(getMaterialProperty<RankTwoTensor>("curvature")),
     _elastic_flexural_rigidity_tensor(
@@ -47,7 +50,8 @@ ComputeMultipleInelasticCosseratStress::computeQpStress()
 
   if (_perform_finite_strain_rotations)
   {
-    _couple_stress[_qp] = _rotation_increment[_qp] * _couple_stress[_qp] * _rotation_increment[_qp].transpose();
+    _couple_stress[_qp] =
+        _rotation_increment[_qp] * _couple_stress[_qp] * _rotation_increment[_qp].transpose();
     _Jacobian_mult_couple[_qp].rotate(_rotation_increment[_qp]);
   }
 }
@@ -61,21 +65,26 @@ ComputeMultipleInelasticCosseratStress::computeQpJacobianMult()
   {
     _Jacobian_mult[_qp] = _consistent_tangent_operator[0];
     for (unsigned i_rmm = 1; i_rmm < _num_models; ++i_rmm)
-      _Jacobian_mult[_qp] = _consistent_tangent_operator[i_rmm] * _compliance[_qp] * _Jacobian_mult[_qp];
+      _Jacobian_mult[_qp] =
+          _consistent_tangent_operator[i_rmm] * _compliance[_qp] * _Jacobian_mult[_qp];
   }
 }
 
-
 void
-ComputeMultipleInelasticCosseratStress::computeAdmissibleState(unsigned model_number, RankTwoTensor & elastic_strain_increment, RankTwoTensor & inelastic_strain_increment, RankFourTensor & consistent_tangent_operator)
+ComputeMultipleInelasticCosseratStress::computeAdmissibleState(
+    unsigned model_number,
+    RankTwoTensor & elastic_strain_increment,
+    RankTwoTensor & inelastic_strain_increment,
+    RankFourTensor & consistent_tangent_operator)
 {
   const RankTwoTensor trial_stress = _stress[_qp];
   const RankTwoTensor applied_strain_increment = elastic_strain_increment;
 
-  ComputeMultipleInelasticStress::computeAdmissibleState(model_number, elastic_strain_increment, inelastic_strain_increment, consistent_tangent_operator);
+  ComputeMultipleInelasticStress::computeAdmissibleState(model_number,
+                                                         elastic_strain_increment,
+                                                         inelastic_strain_increment,
+                                                         consistent_tangent_operator);
 
   inelastic_strain_increment = _compliance[_qp] * (trial_stress - _stress[_qp]);
   elastic_strain_increment = applied_strain_increment - inelastic_strain_increment;
 }
-
-

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -182,7 +182,10 @@ ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_inc
       // let the i^th model produce an admissible stress (as _stress[_qp]), and decompose
       // the strain increment into an elastic part (elastic_strain_increment) and an
       // inelastic part (inelastic_strain_increment[i_rmm])
-      computeAdmissibleState(i_rmm, elastic_strain_increment, inelastic_strain_increment[i_rmm], _consistent_tangent_operator[i_rmm]);
+      computeAdmissibleState(i_rmm,
+                             elastic_strain_increment,
+                             inelastic_strain_increment[i_rmm],
+                             _consistent_tangent_operator[i_rmm]);
 
       if (i_rmm == 0)
       {
@@ -238,7 +241,7 @@ ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_inc
         _inelastic_weights[i_rmm] * inelastic_strain_increment[i_rmm];
 
   if (_fe_problem.currentlyComputingJacobian())
-      computeQpJacobianMult();
+    computeQpJacobianMult();
 }
 
 void
@@ -265,19 +268,23 @@ ComputeMultipleInelasticStress::updateQpStateSingleModel(
 
   _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * elastic_strain_increment;
 
-  computeAdmissibleState(0, elastic_strain_increment, combined_inelastic_strain_increment, _Jacobian_mult[_qp]);
+  computeAdmissibleState(
+      0, elastic_strain_increment, combined_inelastic_strain_increment, _Jacobian_mult[_qp]);
 }
 
 void
-ComputeMultipleInelasticStress::computeAdmissibleState(unsigned model_number, RankTwoTensor & elastic_strain_increment, RankTwoTensor & inelastic_strain_increment, RankFourTensor & consistent_tangent_operator)
+ComputeMultipleInelasticStress::computeAdmissibleState(unsigned model_number,
+                                                       RankTwoTensor & elastic_strain_increment,
+                                                       RankTwoTensor & inelastic_strain_increment,
+                                                       RankFourTensor & consistent_tangent_operator)
 {
   _models[model_number]->updateState(elastic_strain_increment,
-                              inelastic_strain_increment,
-                              _rotation_increment[_qp],
-                              _stress[_qp],
-                              _stress_old[_qp],
-                              _elasticity_tensor[_qp],
-                              _elastic_strain_old[_qp],
-                              _tangent_operator_type == TangentOperatorEnum::nonlinear,
-                              consistent_tangent_operator);
+                                     inelastic_strain_increment,
+                                     _rotation_increment[_qp],
+                                     _stress[_qp],
+                                     _stress_old[_qp],
+                                     _elasticity_tensor[_qp],
+                                     _elastic_strain_old[_qp],
+                                     _tangent_operator_type == TangentOperatorEnum::nonlinear,
+                                     consistent_tangent_operator);
 }

--- a/modules/tensor_mechanics/src/materials/TwoParameterPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/TwoParameterPlasticityStressUpdate.C
@@ -59,7 +59,11 @@ validParams<TwoParameterPlasticityStressUpdate>()
                         "Output a message to the console every "
                         "time precision-loss is encountered "
                         "during the Newton-Raphson process");
-  params.addParam<std::vector<Real>>("admissible_stress", std::vector<Real>{0.0, 0.0}, "A single admissible value of the value of (p, q) for internal parameters = 0.  This is used to initialise the return-mapping algorithm during the first nonlinear iteration");
+  params.addParam<std::vector<Real>>(
+      "admissible_stress",
+      std::vector<Real>{0.0, 0.0},
+      "A single admissible value of the value of (p, q) for internal parameters = 0.  This is used "
+      "to initialise the return-mapping algorithm during the first nonlinear iteration");
   return params;
 }
 
@@ -116,7 +120,8 @@ TwoParameterPlasticityStressUpdate::TwoParameterPlasticityStressUpdate(
   for (unsigned i = 0; i < _num_yf; ++i)
     _all_q[i] = f_and_derivs(_num_pq, _num_intnl);
   if (_pq_ok.size() != 2)
-    mooseError("TwoParameterPlasticityStressUpdate: admissible_stress parameter must be two numbers");
+    mooseError(
+        "TwoParameterPlasticityStressUpdate: admissible_stress parameter must be two numbers");
 }
 
 void
@@ -200,7 +205,7 @@ TwoParameterPlasticityStressUpdate::updateState(RankTwoTensor & strain_increment
   computePQ(stress_old, p_ok, q_ok);
   std::copy(_intnl_old[_qp].begin(), _intnl_old[_qp].end(), _intnl_ok.begin());
   // note that _intnl[_qp] is the "running" intnl variable that gets updated every NR iteration
-  //if (isParamValid("initial_stress") && _step_one)
+  // if (isParamValid("initial_stress") && _step_one)
   if (_step_one)
   {
     // the initial stress might be inadmissible
@@ -343,7 +348,12 @@ TwoParameterPlasticityStressUpdate::updateState(RankTwoTensor & strain_increment
   setStressAfterReturn(
       stress_trial, p_ok, q_ok, gaE_total, _intnl[_qp], smoothed_q, elasticity_tensor, stress_new);
 
-  setInelasticStrainIncrementAfterReturn(stress_trial, gaE_total, smoothed_q, elasticity_tensor, stress_new, inelastic_strain_increment);
+  setInelasticStrainIncrementAfterReturn(stress_trial,
+                                         gaE_total,
+                                         smoothed_q,
+                                         elasticity_tensor,
+                                         stress_new,
+                                         inelastic_strain_increment);
 
   strain_increment = strain_increment - inelastic_strain_increment;
   _plastic_strain[_qp] = _plastic_strain_old[_qp] + inelastic_strain_increment;
@@ -823,6 +833,11 @@ TwoParameterPlasticityStressUpdate::consistentTangentOperator(
   {
     // Cannot form the inverse, so probably at some degenerate place in stress space.
     // Just return with the "best estimate" of the cto.
+    mooseWarning("TwoParameterPlasticityStressUpdate: Cannot invert 1+T in consistent tangent "
+                 "operator computation at quadpoint ",
+                 _qp,
+                 " of element ",
+                 _current_elem->id());
     return;
   }
 
@@ -845,12 +860,14 @@ TwoParameterPlasticityStressUpdate::setStressAfterReturn(const RankTwoTensor & s
 }
 
 void
-TwoParameterPlasticityStressUpdate::setInelasticStrainIncrementAfterReturn(const RankTwoTensor & /*stress_trial*/,
-                                                         Real gaE,
-                                                         const f_and_derivs & smoothed_q,
-                                                         const RankFourTensor & /*elasticity_tensor*/,
-                                                                           const RankTwoTensor & returned_stress, RankTwoTensor & inelastic_strain_increment) const
+TwoParameterPlasticityStressUpdate::setInelasticStrainIncrementAfterReturn(
+    const RankTwoTensor & /*stress_trial*/,
+    Real gaE,
+    const f_and_derivs & smoothed_q,
+    const RankFourTensor & /*elasticity_tensor*/,
+    const RankTwoTensor & returned_stress,
+    RankTwoTensor & inelastic_strain_increment) const
 {
   inelastic_strain_increment = (gaE / _Epp) * (smoothed_q.dg[0] * dpdstress(returned_stress) +
-                                                     smoothed_q.dg[1] * dqdstress(returned_stress));
+                                               smoothed_q.dg[1] * dqdstress(returned_stress));
 }

--- a/modules/tensor_mechanics/tests/capped_weak_plane/small_deform_cosserat1.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/small_deform_cosserat1.i
@@ -885,7 +885,7 @@
     type = ComputeCosseratIncrementalSmallStrain
   [../]
   [./admissible]
-    type = ComputeMultipleInelasticStress
+    type = ComputeMultipleInelasticCosseratStress
     inelastic_models = stress
     perform_finite_strain_rotations = false
   [../]

--- a/modules/tensor_mechanics/tests/capped_weak_plane/small_deform_cosserat2.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/small_deform_cosserat2.i
@@ -885,7 +885,7 @@
     type = ComputeCosseratIncrementalSmallStrain
   [../]
   [./admissible]
-    type = ComputeMultipleInelasticStress
+    type = ComputeMultipleInelasticCosseratStress
     inelastic_models = stress
     perform_finite_strain_rotations = false
   [../]

--- a/modules/tensor_mechanics/tests/capped_weak_plane/small_deform_cosserat3.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/small_deform_cosserat3.i
@@ -920,7 +920,7 @@
     type = ComputeCosseratIncrementalSmallStrain
   [../]
   [./admissible]
-    type = ComputeMultipleInelasticStress
+    type = ComputeMultipleInelasticCosseratStress
     inelastic_models = stress
     perform_finite_strain_rotations = false
   [../]

--- a/modules/tensor_mechanics/tests/capped_weak_plane/small_deform_cosserat4.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/small_deform_cosserat4.i
@@ -923,7 +923,7 @@
     type = ComputeCosseratIncrementalSmallStrain
   [../]
   [./admissible]
-    type = ComputeMultipleInelasticStress
+    type = ComputeMultipleInelasticCosseratStress
     inelastic_models = stress
     perform_finite_strain_rotations = false
   [../]

--- a/modules/tensor_mechanics/tests/jacobian/cdp_cwp_coss01.i
+++ b/modules/tensor_mechanics/tests/jacobian/cdp_cwp_coss01.i
@@ -1,3 +1,4 @@
+#Cosserat capped weak plane and capped drucker prager
 [Mesh]
   type = GeneratedMesh
   dim = 3
@@ -78,9 +79,38 @@
 []
 
 [UserObjects]
+  [./ts]
+    type = TensorMechanicsHardeningConstant
+    value = 10
+  [../]
+  [./cs]
+    type = TensorMechanicsHardeningConstant
+    value = 10
+  [../]
+  [./mc_coh]
+    type = TensorMechanicsHardeningConstant
+    value = 10
+  [../]
+  [./phi]
+    type = TensorMechanicsHardeningConstant
+    value = 0.8
+  [../]
+  [./psi]
+    type = TensorMechanicsHardeningConstant
+    value = 0.4
+  [../]
+  [./dp]
+    type = TensorMechanicsPlasticDruckerPragerHyperbolic
+    mc_cohesion = mc_coh
+    mc_friction_angle = phi
+    mc_dilation_angle = psi
+    yield_function_tolerance = 1E-11     # irrelevant here
+    internal_constraint_tolerance = 1E-9 # irrelevant here
+  [../]
+
   [./coh]
     type = TensorMechanicsHardeningConstant
-    value = 1
+    value = 2
   [../]
   [./tanphi]
     type = TensorMechanicsHardeningConstant
@@ -98,6 +128,7 @@
     type = TensorMechanicsHardeningConstant
     value = 100
   [../]
+
 []
 
 [Materials]
@@ -114,11 +145,27 @@
   [../]
   [./admissible]
     type = ComputeMultipleInelasticCosseratStress
-    inelastic_models = stress
-    initial_stress = '1 0.1 0.2  0.1 1 0.3  0 0 2' # not symmetric
+    inelastic_models = 'dp wp'
+    initial_stress = '10 0 0  0 10 0  0 0 10'
+    relative_tolerance = 2.0
+    absolute_tolerance = 1E6
+    max_iterations = 1
   [../]
-  [./stress]
+  [./dp]
+    type = CappedDruckerPragerCosseratStressUpdate
+    host_youngs_modulus = 10.0
+    host_poissons_ratio = 0.25
+    name_prepender = dp
+    DP_model = dp
+    tensile_strength = ts
+    compressive_strength = cs
+    yield_function_tol = 1E-11
+    tip_smoother = 1
+    smoothing_tol = 1
+  [../]
+  [./wp]
     type = CappedWeakPlaneCosseratStressUpdate
+    name_prepender = wp
     cohesion = coh
     tan_friction_angle = tanphi
     tan_dilation_angle = tanpsi
@@ -126,7 +173,7 @@
     compressive_strength = c_strength
     tip_smoother = 0.1
     smoothing_tol = 0.1
-    yield_function_tol = 1E-5
+    yield_function_tol = 1E-11
   [../]
 []
 
@@ -134,6 +181,7 @@
   [./andy]
     type = SMP
     full = true
+    #petsc_options = '-snes_test_display'
     petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
     petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
   [../]

--- a/modules/tensor_mechanics/tests/jacobian/cdpc01.i
+++ b/modules/tensor_mechanics/tests/jacobian/cdpc01.i
@@ -1,3 +1,4 @@
+#Cosserat capped weak plane and capped drucker prager
 [Mesh]
   type = GeneratedMesh
   dim = 3
@@ -78,25 +79,33 @@
 []
 
 [UserObjects]
-  [./coh]
+  [./ts]
     type = TensorMechanicsHardeningConstant
-    value = 1
+    value = 10
   [../]
-  [./tanphi]
+  [./cs]
     type = TensorMechanicsHardeningConstant
-    value = 0.5
+    value = 10
   [../]
-  [./tanpsi]
+  [./mc_coh]
     type = TensorMechanicsHardeningConstant
-    value = 2.055555555556E-01
+    value = 10
   [../]
-  [./t_strength]
+  [./phi]
     type = TensorMechanicsHardeningConstant
-    value = 1
+    value = 0.8
   [../]
-  [./c_strength]
+  [./psi]
     type = TensorMechanicsHardeningConstant
-    value = 100
+    value = 0.4
+  [../]
+  [./dp]
+    type = TensorMechanicsPlasticDruckerPragerHyperbolic
+    mc_cohesion = mc_coh
+    mc_friction_angle = phi
+    mc_dilation_angle = psi
+    yield_function_tolerance = 1E-11     # irrelevant here
+    internal_constraint_tolerance = 1E-9 # irrelevant here
   [../]
 []
 
@@ -114,19 +123,23 @@
   [../]
   [./admissible]
     type = ComputeMultipleInelasticCosseratStress
-    inelastic_models = stress
-    initial_stress = '1 0.1 0.2  0.1 1 0.3  0 0 2' # not symmetric
+    inelastic_models = 'dp'
+    initial_stress = '10 0 0  0 10 0  0 0 10'
+    relative_tolerance = 2.0
+    absolute_tolerance = 1E6
+    max_iterations = 1
   [../]
-  [./stress]
-    type = CappedWeakPlaneCosseratStressUpdate
-    cohesion = coh
-    tan_friction_angle = tanphi
-    tan_dilation_angle = tanpsi
-    tensile_strength = t_strength
-    compressive_strength = c_strength
-    tip_smoother = 0.1
-    smoothing_tol = 0.1
-    yield_function_tol = 1E-5
+  [./dp]
+    type = CappedDruckerPragerCosseratStressUpdate
+    host_youngs_modulus = 10.0
+    host_poissons_ratio = 0.25
+    name_prepender = dp
+    DP_model = dp
+    tensile_strength = ts
+    compressive_strength = cs
+    yield_function_tol = 1E-11
+    tip_smoother = 1
+    smoothing_tol = 1
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/jacobian/cdpc02.i
+++ b/modules/tensor_mechanics/tests/jacobian/cdpc02.i
@@ -1,3 +1,4 @@
+#Cosserat capped weak plane and capped drucker prager
 [Mesh]
   type = GeneratedMesh
   dim = 3
@@ -78,25 +79,33 @@
 []
 
 [UserObjects]
-  [./coh]
+  [./ts]
     type = TensorMechanicsHardeningConstant
-    value = 1
+    value = 10
   [../]
-  [./tanphi]
+  [./cs]
     type = TensorMechanicsHardeningConstant
-    value = 0.5
+    value = 10
   [../]
-  [./tanpsi]
+  [./mc_coh]
     type = TensorMechanicsHardeningConstant
-    value = 2.055555555556E-01
+    value = 4
   [../]
-  [./t_strength]
+  [./phi]
     type = TensorMechanicsHardeningConstant
-    value = 1
+    value = 0.8
   [../]
-  [./c_strength]
+  [./psi]
     type = TensorMechanicsHardeningConstant
-    value = 100
+    value = 0.4
+  [../]
+  [./dp]
+    type = TensorMechanicsPlasticDruckerPragerHyperbolic
+    mc_cohesion = mc_coh
+    mc_friction_angle = phi
+    mc_dilation_angle = psi
+    yield_function_tolerance = 1E-11     # irrelevant here
+    internal_constraint_tolerance = 1E-9 # irrelevant here
   [../]
 []
 
@@ -114,19 +123,23 @@
   [../]
   [./admissible]
     type = ComputeMultipleInelasticCosseratStress
-    inelastic_models = stress
-    initial_stress = '1 0.1 0.2  0.1 1 0.3  0 0 2' # not symmetric
+    inelastic_models = 'dp'
+    initial_stress = '5 1 2  1 4 3  2.1 3.1 1'
+    relative_tolerance = 2.0
+    absolute_tolerance = 1E6
+    max_iterations = 1
   [../]
-  [./stress]
-    type = CappedWeakPlaneCosseratStressUpdate
-    cohesion = coh
-    tan_friction_angle = tanphi
-    tan_dilation_angle = tanpsi
-    tensile_strength = t_strength
-    compressive_strength = c_strength
-    tip_smoother = 0.1
-    smoothing_tol = 0.1
-    yield_function_tol = 1E-5
+  [./dp]
+    type = CappedDruckerPragerCosseratStressUpdate
+    host_youngs_modulus = 10.0
+    host_poissons_ratio = 0.25
+    name_prepender = dp
+    DP_model = dp
+    tensile_strength = ts
+    compressive_strength = cs
+    yield_function_tol = 1E-11
+    tip_smoother = 1
+    smoothing_tol = 1
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/jacobian/cto15.i
+++ b/modules/tensor_mechanics/tests/jacobian/cto15.i
@@ -47,29 +47,6 @@
   [../]
 []
 
-[BCs]
-  active = ''
-  [./dum1]
-    type = PresetBC
-    variable = disp_x
-    value = 0
-    boundary = 'top bottom'
-  [../]
-  [./dum2]
-    type = PresetBC
-    variable = disp_y
-    value = 0
-    boundary = 'top bottom'
-  [../]
-  [./dum3]
-    type = PresetBC
-    variable = disp_z
-    value = 0
-    boundary = 'top bottom'
-  [../]
-[]
-
-
 [AuxVariables]
   [./stress_xx]
     order = CONSTANT

--- a/modules/tensor_mechanics/tests/jacobian/cto29.i
+++ b/modules/tensor_mechanics/tests/jacobian/cto29.i
@@ -1,3 +1,5 @@
+# CappedDruckerPragerCosserat
+
 [Mesh]
   type = GeneratedMesh
   dim = 3
@@ -29,6 +31,7 @@
   [./wc_y]
   [../]
 []
+
 
 [Kernels]
   [./cx_elastic]
@@ -78,55 +81,73 @@
 []
 
 [UserObjects]
-  [./coh]
-    type = TensorMechanicsHardeningConstant
-    value = 1
+  [./ts]
+    type = TensorMechanicsHardeningCubic
+    value_0 = 1
+    value_residual = 2
+    internal_limit = 100
   [../]
-  [./tanphi]
-    type = TensorMechanicsHardeningConstant
-    value = 0.5
+  [./cs]
+    type = TensorMechanicsHardeningCubic
+    value_0 = 5
+    value_residual = 3
+    internal_limit = 100
   [../]
-  [./tanpsi]
-    type = TensorMechanicsHardeningConstant
-    value = 2.055555555556E-01
+  [./mc_coh]
+    type = TensorMechanicsHardeningCubic
+    value_0 = 10
+    value_residual = 1
+    internal_limit = 100
   [../]
-  [./t_strength]
-    type = TensorMechanicsHardeningConstant
-    value = 1
+  [./phi]
+    type = TensorMechanicsHardeningCubic
+    value_0 = 0.8
+    value_residual = 0.4
+    internal_limit = 50
   [../]
-  [./c_strength]
-    type = TensorMechanicsHardeningConstant
-    value = 100
+  [./psi]
+    type = TensorMechanicsHardeningCubic
+    value_0 = 0.4
+    value_residual = 0
+    internal_limit = 10
+  [../]
+  [./dp]
+    type = TensorMechanicsPlasticDruckerPragerHyperbolic
+    mc_cohesion = mc_coh
+    mc_friction_angle = phi
+    mc_dilation_angle = psi
+    yield_function_tolerance = 1E-11     # irrelevant here
+    internal_constraint_tolerance = 1E-9 # irrelevant here
   [../]
 []
 
 [Materials]
   [./elasticity_tensor]
     type = ComputeLayeredCosseratElasticityTensor
-    young = 10.0
-    poisson = 0.25
-    layer_thickness = 10.0
-    joint_normal_stiffness = 2.5
-    joint_shear_stiffness = 2.0
+    young = 2.1
+    poisson = 0.1
+    layer_thickness = 1.0
+    joint_normal_stiffness = 3.0
+    joint_shear_stiffness = 2.5
   [../]
   [./strain]
     type = ComputeCosseratIncrementalSmallStrain
   [../]
   [./admissible]
     type = ComputeMultipleInelasticCosseratStress
-    inelastic_models = stress
-    initial_stress = '1 0.1 0.2  0.1 1 0.3  0 0 2' # not symmetric
+    inelastic_models = dp
+    initial_stress = '6 5 4  5.1 7 2  4 2.1 2'
   [../]
-  [./stress]
-    type = CappedWeakPlaneCosseratStressUpdate
-    cohesion = coh
-    tan_friction_angle = tanphi
-    tan_dilation_angle = tanpsi
-    tensile_strength = t_strength
-    compressive_strength = c_strength
+  [./dp]
+    type = CappedDruckerPragerCosseratStressUpdate
+    host_youngs_modulus = 2.1
+    host_poissons_ratio = 0.1
+    DP_model = dp
+    tensile_strength = ts
+    compressive_strength = cs
+    yield_function_tol = 1E-11
     tip_smoother = 0.1
     smoothing_tol = 0.1
-    yield_function_tol = 1E-5
   [../]
 []
 
@@ -140,8 +161,6 @@
 []
 
 [Executioner]
-  solve_type = 'NEWTON'
-  end_time = 1
-  dt = 1
   type = Transient
+  solve_type = Newton
 []

--- a/modules/tensor_mechanics/tests/jacobian/cwpc01.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwpc01.i
@@ -72,46 +72,6 @@
   [../]
 []
 
-[BCs]
-  [./bottomx]
-    type = PresetBC
-    variable = disp_x
-    boundary = back
-    value = 0.0
-  [../]
-  [./bottomy]
-    type = PresetBC
-    variable = disp_y
-    boundary = back
-    value = 0.0
-  [../]
-  [./bottomz]
-    type = PresetBC
-    variable = disp_z
-    boundary = back
-    value = 0.0
-  [../]
-
-  [./topx]
-    type = FunctionPresetBC
-    variable = disp_x
-    boundary = front
-    function = 32*t/3.333333333333E+00
-  [../]
-  [./topy]
-    type = FunctionPresetBC
-    variable = disp_y
-    boundary = front
-    function = 24*t/3.333333333333E+00
-  [../]
-  [./topz]
-    type = FunctionPresetBC
-    variable = disp_z
-    boundary = front
-    function = 10*t/8.108108108108E+00
-  [../]
-[]
-
 [AuxVariables]
   [./wc_z]
   [../]
@@ -132,7 +92,7 @@
   [../]
   [./t_strength]
     type = TensorMechanicsHardeningConstant
-    value = 100
+    value = 1
   [../]
   [./c_strength]
     type = TensorMechanicsHardeningConstant
@@ -153,8 +113,10 @@
     type = ComputeCosseratIncrementalSmallStrain
   [../]
   [./admissible]
-    type = ComputeMultipleInelasticStress
+    type = ComputeMultipleInelasticCosseratStress
+    initial_stress = '10 0 0  0 10 0  0 0 10'
     inelastic_models = stress
+    perform_finite_strain_rotations = false
   [../]
   [./stress]
     type = CappedWeakPlaneCosseratStressUpdate
@@ -163,9 +125,9 @@
     tan_dilation_angle = tanpsi
     tensile_strength = t_strength
     compressive_strength = c_strength
-    tip_smoother = 0
-    smoothing_tol = 0
-    yield_function_tol = 1E-5
+    tip_smoother = 1
+    smoothing_tol = 1
+    yield_function_tol = 1E-11
   [../]
 []
 

--- a/modules/tensor_mechanics/tests/jacobian/tests
+++ b/modules/tensor_mechanics/tests/jacobian/tests
@@ -229,6 +229,13 @@
     difference_tol = 1E10
   [../]
 
+  [./cto29]
+    type = 'PetscJacobianTester'
+    input = 'cto29.i'
+    ratio_tol = 1E-4
+    difference_tol = 1E10
+  [../]
+
   [./poro01]
     type = 'PetscJacobianTester'
     input = 'poro01.i'
@@ -320,6 +327,32 @@
     type = 'PetscJacobianTester'
     input = 'phe01.i'
     ratio_tol = 1E-7
+    difference_tol = 1E10
+  [../]
+
+  [./cdpc01]
+    type = 'PetscJacobianTester'
+    input = 'cdpc01.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+  [../]
+  [./cdpc02]
+    type = 'PetscJacobianTester'
+    input = 'cdpc02.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+  [../]
+
+  [./cdp_cwp_coss01]
+    type = 'PetscJacobianTester'
+    input = 'cdp_cwp_coss01.i'
+    ratio_tol = 1E-6
+    difference_tol = 1E10
+  [../]
+  [./cdp_cwp_coss02]
+    type = 'PetscJacobianTester'
+    input = 'cdp_cwp_coss02.i'
+    ratio_tol = 1E-6
     difference_tol = 1E10
   [../]
 []


### PR DESCRIPTION
MODIFICATION TO EXISTING STUFF

ComputeMultipleInelasticStress: has a new method called computeAdmissibleState that was necessary to create because of Cosserat complications, but also has allowed removal of a few lines of code

TwoParameterPlasticityStressUpdate: pq_ok user parameter added because although i previously assumed that stress=0 was admissible that's not necessarily true.  Also, a new method - setInelasticStrainIncrementAfterReturn - added because of need to override when doing Cosserat

CappedWeakPlaneCosseratStressUpdate: now derives from CappedWeakPlaneStressUpdate which allows removal of some code

ComputeLayeredCosseratElasticityTensor: now computes "compliance" which is the inverse of the elasticity tensor.  The reason for this is two-fold: (1) the usual RankTwoTensor.invSymm() does not work in this case because the elasticity tensor is unsymmetric; (2) computing compliance once in the constructor is so much cheaper than computing it on-the-fly every time it's needed.

NEW ADDITIONS

CappedDruckerPragerCosseratStressUpdate: this is the Cosserat equivalent of the CappedDruckerPrager plasticity model.  It is complicated because its flow rule uses a different elasticity tensor than the stress-strain relation.  This is the core reason behind some of the above modifications.

ComputeMultipleInelasticCosseratStress: this is the Cosserat equivalent of ComputeMultipleInelasticStress.  Currently it does only Cosserat elasticity, because the Cosserat plasticity models (CappedDruckerPragerCosseratStressUpdate and CappedWeakPlaneCosseratStressUpdate) do not involve the moment-stress in their yield functions or flow potentials.

Fixes #9067

