### PR TITLE
Added documentation for function objects used by BISON

### DIFF
--- a/docs/content/documentation/systems/Functions/framework/CompositeFunction.md
+++ b/docs/content/documentation/systems/Functions/framework/CompositeFunction.md
@@ -1,7 +1,18 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # CompositeFunction
+
 !description /Functions/CompositeFunction
+
+## Description
+
+The `CompositeFunction` type takes an arbitrary set of functions, provided in
+the `functions` parameter, evaluates each of them at the appropriate time
+and position, and multiplies them together.  The function can optionally be
+multiplied by a scale factor, which is specified using the `scale_factor`
+parameter.
+
+## Example Input Syntax
+
+!listing test/tests/bcs/function_dirichlet_bc/function_dirichlet_bc_test.i block=Functions
 
 !parameters /Functions/CompositeFunction
 

--- a/docs/content/documentation/systems/Functions/framework/ParsedFunction.md
+++ b/docs/content/documentation/systems/Functions/framework/ParsedFunction.md
@@ -1,7 +1,22 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # ParsedFunction
+
 !description /Functions/ParsedFunction
+
+## Description
+
+The `ParsedFunction` function takes a mathematical expression in `value`.  The
+expression can be a function of time (t) or coordinate (x, y, or z).  The expression
+can include common mathematical functions.  Examples include `4e4+1e2*t`,
+`sqrt(x*x+y*y+z*z)`, and `if(t\textless=1.0, 0.1*t, (1.0+0.1)*cos(pi/2*(t-1.0)) - 1.0)`.
+
+Constant variables may be used in the expression if they have been declared with `vars`
+and defined with `vals`.
+
+Further information can be found at the
+[function parser site](http://warp.povusers.org/FunctionParser/).
+
+## Example Input Syntax
+!listing examples/ex04_bcs/trapezoid.i block=Functions
 
 !parameters /Functions/ParsedFunction
 

--- a/docs/content/documentation/systems/Functions/framework/PiecewiseBilinear.md
+++ b/docs/content/documentation/systems/Functions/framework/PiecewiseBilinear.md
@@ -1,7 +1,18 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PiecewiseBilinear
+
 !description /Functions/PiecewiseBilinear
+
+## Description
+
+The `PiecewiseBilinear` function reads a csv file and interpolates values based on the
+data in the file.  The interpolation is based on x-y pairs.  If `axis` is given, time is
+used as the y index.  Either `xaxis` or `yaxis` or both may be given.  Time is used as
+the other index if one of them is not given.  If `radius` is given, `xaxis` and `yaxis`
+are used to orient a cylindrical coordinate system, and the x-y pair used in the query
+will be the radial coordinate and time.
+
+## Example Input Syntax
+!listing test/tests/utils/2d_linear_interpolation/xyz_error.i block=Functions
 
 !parameters /Functions/PiecewiseBilinear
 

--- a/docs/content/documentation/systems/Functions/framework/PiecewiseConstant.md
+++ b/docs/content/documentation/systems/Functions/framework/PiecewiseConstant.md
@@ -1,7 +1,17 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PiecewiseConstant
+
 !description /Functions/PiecewiseConstant
+
+## Description
+
+The `PiecewiseConstant` function defines the data using a set of x-y data pairs.  Instead
+of linearly interpolating between the values, however, the `PiecewiseConstant` function
+is constant when the abscissa is between the values provided by the user.  The `direction`
+parameter controls whether the function takes the value of the abscissa of the
+user-provided point to the right or left of the value at which the function is evaluated.
+
+## Example Input Syntax
+!listing test/tests/functions/piecewise_constant/piecewise_constant.i block=Functions
 
 !parameters /Functions/PiecewiseConstant
 

--- a/docs/content/documentation/systems/Functions/framework/PiecewiseLinear.md
+++ b/docs/content/documentation/systems/Functions/framework/PiecewiseLinear.md
@@ -1,7 +1,26 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PiecewiseLinear
+
 !description /Functions/PiecewiseLinear
+
+## Description
+
+The `PiecewiseLinear` function performs linear interpolations between user-provided
+pairs of x-y data.  The x-y data can be provided in three ways. The first way is through
+a combination of the `x` and `y` paramaters, which are lists of the x and y coordinates
+of the data points that make up the function.  The second way is in the `xy_data`
+parameter, which is a list of pairs of x-y data that make up the points of the
+function.  This allows for the function data to be specified in columns by inserting line
+breaks after each x-y data point.  Finally, the x-y data can be provided in an external
+file containing comma-separated values.  The file name is provided in `data_file`,
+and the data can be provided in either rows (default) or columns, as specified in the
+`format` parameter.
+
+By default, the x-data corresponds to time, but this can be changed to correspond to x, y,
+or z coordinate with the `axis` line.  If the function is queried outside of its range of
+x data, it returns the y value associated with the closest x data point.
+
+## Example Input Syntax
+!listing test/tests/misc/check_error/function_file_test1.i block=Functions
 
 !parameters /Functions/PiecewiseLinear
 


### PR DESCRIPTION
I know that these are hidden for the time being, but I did these for BISON.  The BISON
team thought it best to put these in MOOSE, and then when the import feature is ready, we
can import such from MOOSE to keep the documentation centralized and non-redundant.

refs #6699

### Complete each of the following items before creating a PR

- Include any relevant design information for your change
- Follow [Coding Standards](http://mooseframework.org/wiki/CodeStandards/)
- Submit one or more [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/) or modify existing test cases
- Reference or close a specific issue (refs # or closes #)