### PR TITLE
FluidProperties: fix bug in BrineFluidProperties derivatives when xnacl = 0

### DIFF
--- a/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
@@ -147,10 +147,9 @@ BrineFluidProperties::rho_dpTx(Real pressure,
   Real eps = 1.0e-8;
   Real peps = pressure * eps;
   Real Teps = temperature * eps;
-  Real xeps = xnacl * eps;
   drho_dp = (this->rho(pressure + peps, temperature, xnacl) - rho) / peps;
   drho_dT = (this->rho(pressure, temperature + Teps, xnacl) - rho) / Teps;
-  drho_dx = (this->rho(pressure, temperature, xnacl + xeps) - rho) / xeps;
+  drho_dx = (this->rho(pressure, temperature, xnacl + eps) - rho) / eps;
 }
 
 Real
@@ -259,10 +258,9 @@ BrineFluidProperties::h_dpTx(Real pressure,
   Real eps = 1.0e-8;
   Real peps = pressure * eps;
   Real Teps = temperature * eps;
-  Real xeps = xnacl * eps;
   dh_dp = (this->h(pressure + peps, temperature, xnacl) - h) / peps;
   dh_dT = (this->h(pressure, temperature + Teps, xnacl) - h) / Teps;
-  dh_dx = (this->h(pressure, temperature, xnacl + xeps) - h) / xeps;
+  dh_dx = (this->h(pressure, temperature, xnacl + eps) - h) / eps;
 }
 
 Real
@@ -325,10 +323,9 @@ BrineFluidProperties::e_dpTx(Real pressure,
   Real eps = 1.0e-8;
   Real peps = pressure * eps;
   Real Teps = temperature * eps;
-  Real xeps = xnacl * eps;
   de_dp = (this->e(pressure + peps, temperature, xnacl) - e) / peps;
   de_dT = (this->e(pressure, temperature + Teps, xnacl) - e) / Teps;
-  de_dx = (this->e(pressure, temperature, xnacl + xeps) - e) / xeps;
+  de_dx = (this->e(pressure, temperature, xnacl + eps) - e) / eps;
 }
 
 Real

--- a/unit/src/BrineFluidPropertiesTest.C
+++ b/unit/src/BrineFluidPropertiesTest.C
@@ -114,9 +114,9 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   // Finite differencing parameters
   Real dp = 1.0e-2;
   Real dT = 1.0e-4;
-  Real dx = 1.0e-6;
+  Real dx = 1.0e-8;
 
-  // density
+  // Density
   Real drho_dp_fd = (_fp->rho(p + dp, T, x) - _fp->rho(p - dp, T, x)) / (2.0 * dp);
   Real drho_dT_fd = (_fp->rho(p, T + dT, x) - _fp->rho(p, T - dT, x)) / (2.0 * dT);
   Real drho_dx_fd = (_fp->rho(p, T, x + dx) - _fp->rho(p, T, x - dx)) / (2.0 * dx);
@@ -129,7 +129,7 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   REL_TEST("drho_dT", drho_dT, drho_dT_fd, 1.0e-3);
   REL_TEST("drho_dx", drho_dx, drho_dx_fd, 1.0e-3);
 
-  // enthalpy
+  // Enthalpy
   Real dh_dp_fd = (_fp->h(p + dp, T, x) - _fp->h(p - dp, T, x)) / (2.0 * dp);
   Real dh_dT_fd = (_fp->h(p, T + dT, x) - _fp->h(p, T - dT, x)) / (2.0 * dT);
   Real dh_dx_fd = (_fp->h(p, T, x + dx) - _fp->h(p, T, x - dx)) / (2.0 * dx);
@@ -142,7 +142,7 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   REL_TEST("dh_dT", dh_dT, dh_dT_fd, 1.0e-3);
   REL_TEST("dh_dx", dh_dx, dh_dx_fd, 1.0e-3);
 
-  // internal energy
+  // Internal energy
   Real de_dp_fd = (_fp->e(p + dp, T, x) - _fp->e(p - dp, T, x)) / (2.0 * dp);
   Real de_dT_fd = (_fp->e(p, T + dT, x) - _fp->e(p, T - dT, x)) / (2.0 * dT);
   Real de_dx_fd = (_fp->e(p, T, x + dx) - _fp->e(p, T, x - dx)) / (2.0 * dx);
@@ -167,5 +167,32 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   ABS_TEST("mu", mu, _fp->mu(rho, T, x), 1.0e-15);
   REL_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-3);
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-3);
+  REL_TEST("dmu_dx", dmu_dx, dmu_dx_fd, 1.0e-3);
+
+  // Verify that derivatives wrt x are defined when x = 0
+  x = 0.0;
+
+  // Density
+  _fp->rho_dpTx(p, T, x, rho, drho_dp, drho_dT, drho_dx);
+  drho_dx_fd = (_fp->rho(p, T, x + dx) - _fp->rho(p, T, x)) / dx;
+
+  REL_TEST("drho_dx", drho_dx, drho_dx_fd, 1.0e-3);
+
+  // Enthalpy
+  _fp->h_dpTx(p, T, x, h, dh_dp, dh_dT, dh_dx);
+  dh_dx_fd = (_fp->h(p, T, x + dx) - _fp->h(p, T, x)) / dx;
+
+  REL_TEST("dh_dx", dh_dx, dh_dx_fd, 1.0e-3);
+
+  // Internal energy
+  _fp->e_dpTx(p, T, x, e, de_dp, de_dT, de_dx);
+  de_dx_fd = (_fp->e(p, T, x + dx) - _fp->e(p, T, x)) / dx;
+
+  REL_TEST("de_dx", de_dx, de_dx_fd, 1.0e-3);
+
+  // Viscosity
+  dmu_dx_fd = (_fp->mu(rho, T, x + dx) - _fp->mu(rho, T, x)) / dx;
+  _fp->mu_drhoTx(rho, T, x, mu, dmu_drho, dmu_dT, dmu_dx);
+
   REL_TEST("dmu_dx", dmu_dx, dmu_dx_fd, 1.0e-3);
 }


### PR DESCRIPTION
Fixes bug in BrineFluidProperties where derivative wrt salt mass fraction was undefined when xnacl = 0.

Closes #9172