### PR TITLE
Write out alternate settings file for BackgroundPlugin testing.

### DIFF
--- a/python/peacock/tests/exodus_tab/test_BackgroundPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_BackgroundPlugin.py
@@ -18,7 +18,7 @@ class TestBackgroundPlugin(Testing.PeacockImageTestCase):
         Creates a window attached to FilePlugin widget.
         """
         message.MOOSE_TESTING_MODE = True
-        qtutils.setAppInformation()
+        qtutils.setAppInformation("peacock_backgroundplugin")
 
         settings = QtCore.QSettings()
         settings.clear()


### PR DESCRIPTION
BackgroundPlugin testing seems to be broken, probably introduced in #9144 which was merged before it was tested on the Mac.
It works locally on my machine so I think it is just the settings getting overwritten by other tests.
This just makes it so that the settings file used by the BackgroundPlugin won't be used by anything else.
