### PR TITLE
Try to avoid settings file clashes.

### DIFF
--- a/python/peacock/PeacockApp.py
+++ b/python/peacock/PeacockApp.py
@@ -27,7 +27,7 @@ class PeacockApp(object):
         icon_path = os.path.join(peacock_dir, "icons", "peacock_logo.ico")
         qapp.setWindowIcon(QIcon(icon_path))
 
-        qtutils.setAppInformation("peacock")
+        qtutils.setAppInformation("peacock_peacockapp")
 
         if parsed_args.exodus or parsed_args.postprocessors or parsed_args.vectorpostprocessors:
             # If the user wants to view files then don't try to automatically find an executable.

--- a/python/peacock/tests/exodus_tab/test_ExodusViewer.py
+++ b/python/peacock/tests/exodus_tab/test_ExodusViewer.py
@@ -28,7 +28,7 @@ class TestExodusViewer(Testing.PeacockImageTestCase):
         Loads an Exodus file in the VTKWindowWidget object using a structure similar to the ExodusViewer widget.
         """
         message.MOOSE_TESTING_MODE = True
-        qtutils.setAppInformation()
+        qtutils.setAppInformation("peacock_exodusviewer")
 
         settings = QtCore.QSettings()
         settings.clear()


### PR DESCRIPTION
ExodusViewer tests fail randomly. Probably started in #9144 which introduced a reliance on settings. This continues on #9194 to write out a separate settings file for each test that explicitly uses the settings.
