### PR TITLE
Move patch_size parameter from action to MooseMesh

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -433,9 +433,8 @@ public:
   void ghostGhostedBoundaries();
 
   /**
-   * Getter/setter for the patch_size parameter.
+   * Getter for the patch_size parameter.
    */
-  void setPatchSize(const unsigned int patch_size);
   unsigned int getPatchSize() const;
 
   /**

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -58,12 +58,9 @@ validParams<SetupMeshAction>()
                                      "this value to a vector of amounts to inflate the bounding "
                                      "boxes by.  ie if you are running a 3D problem you might set "
                                      "it to '0.2 0.1 0.4'");
-  params.addParam<unsigned int>(
-      "patch_size", 40, "The number of nodes to consider in the NearestNode neighborhood.");
 
   params.addParam<unsigned int>(
       "uniform_refine", 0, "Specify the level of uniform refinement applied to the initial mesh");
-
   params.addParam<bool>("skip_partitioning",
                         false,
                         "If true the mesh won't be partitioned. This may cause large load "
@@ -72,8 +69,8 @@ validParams<SetupMeshAction>()
                         "material properties");
 
   // groups
-  params.addParamNamesToGroup(
-      "displacements ghosted_boundaries ghosted_boundaries_inflation patch_size", "Advanced");
+  params.addParamNamesToGroup("displacements ghosted_boundaries ghosted_boundaries_inflation",
+                              "Advanced");
   params.addParamNamesToGroup("second_order construct_side_list_from_node_list skip_partitioning",
                               "Advanced");
   params.addParamNamesToGroup("block_id block_name boundary_id boundary_name", "Add Names");
@@ -91,8 +88,6 @@ SetupMeshAction::setupMesh(MooseMesh * mesh)
 
   for (const auto & bnd_name : ghosted_boundaries)
     mesh->addGhostedBoundary(mesh->getBoundaryID(bnd_name));
-
-  mesh->setPatchSize(getParam<unsigned int>("patch_size"));
 
   if (isParamValid("ghosted_boundaries_inflation"))
   {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -138,13 +138,15 @@ validParams<MooseMesh>()
                         false,
                         "Boolean to specify whether or not all point neighbors are ghosted"
                         " when DistributedMesh is used. Value is ignored in ReplicatedMesh mode");
+  params.addParam<unsigned int>(
+      "patch_size", 40, "The number of nodes to consider in the NearestNode neighborhood.");
 
   params.registerBase("MooseMesh");
 
   // groups
   params.addParamNamesToGroup(
       "dim nemesis patch_update_strategy construct_node_list_from_side_list num_ghosted_layers"
-      " ghost_point_neighbors",
+      " ghost_point_neighbors patch_size",
       "Advanced");
   params.addParamNamesToGroup("partitioner centroid_partitioner_direction", "Partitioning");
 
@@ -168,7 +170,7 @@ MooseMesh::MooseMesh(const InputParameters & parameters)
     _needs_prepare_for_use(false),
     _node_to_elem_map_built(false),
     _node_to_active_semilocal_elem_map_built(false),
-    _patch_size(40),
+    _patch_size(getParam<unsigned int>("patch_size")),
     _patch_update_strategy(getParam<MooseEnum>("patch_update_strategy")),
     _regular_orthogonal_mesh(false),
     _allow_recovery(true),
@@ -273,7 +275,7 @@ MooseMesh::MooseMesh(const MooseMesh & other_mesh)
     _is_prepared(false),
     _needs_prepare_for_use(false),
     _node_to_elem_map_built(false),
-    _patch_size(40),
+    _patch_size(other_mesh._patch_size),
     _patch_update_strategy(other_mesh._patch_update_strategy),
     _regular_orthogonal_mesh(false),
     _construct_node_list_from_side_list(other_mesh._construct_node_list_from_side_list)
@@ -2351,12 +2353,6 @@ MooseMesh::ghostGhostedBoundaries()
                                      boundary_elems_to_ghost.begin(),
                                      boundary_elems_to_ghost.end(),
                                      extra_ghost_elem_inserter<Elem>(mesh));
-}
-
-void
-MooseMesh::setPatchSize(const unsigned int patch_size)
-{
-  _patch_size = patch_size;
 }
 
 unsigned int


### PR DESCRIPTION
### Design Information
Moves the input parameter `patch_size` from `SetupMeshAction` to the `MooseMesh` class to enable classes inheriting from `MooseMesh` to set and suppress the parameter.

Closes #9197