### PR TITLE
Re-enable ElementsAlongPlane with DistributedMesh

### DIFF
--- a/framework/src/vectorpostprocessors/ElementsAlongPlane.C
+++ b/framework/src/vectorpostprocessors/ElementsAlongPlane.C
@@ -34,7 +34,6 @@ ElementsAlongPlane::ElementsAlongPlane(const InputParameters & parameters)
     _normal(getParam<Point>("normal")),
     _elem_ids(declareVector("elem_ids"))
 {
-  _fe_problem.mesh().errorIfDistributedMesh("ElementsAlongPlane");
 }
 
 void

--- a/test/tests/vectorpostprocessors/elements_along_plane/1d.i
+++ b/test/tests/vectorpostprocessors/elements_along_plane/1d.i
@@ -2,6 +2,8 @@
   type = GeneratedMesh
   dim = 1
   nx = 10
+  # Our CSV diffs here depend on a fixed element id numbering
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/vectorpostprocessors/elements_along_plane/2d.i
+++ b/test/tests/vectorpostprocessors/elements_along_plane/2d.i
@@ -3,6 +3,8 @@
   dim = 2
   nx = 10
   ny = 10
+  # Our CSV diffs here depend on a fixed element id numbering
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/vectorpostprocessors/elements_along_plane/3d.i
+++ b/test/tests/vectorpostprocessors/elements_along_plane/3d.i
@@ -4,6 +4,8 @@
   nx = 10
   ny = 10
   nz = 10
+  # Our CSV diffs here depend on a fixed element id numbering
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/vectorpostprocessors/elements_along_plane/tests
+++ b/test/tests/vectorpostprocessors/elements_along_plane/tests
@@ -3,20 +3,17 @@
     type = 'CSVDiff'
     input = '1d.i'
     csvdiff = '1d_out_elems_0001.csv'
-    mesh_mode = replicated
   [../]
 
   [./2d]
     type = 'CSVDiff'
     input = '2d.i'
     csvdiff = '2d_out_elems_0001.csv'
-    mesh_mode = replicated
   [../]
 
   [./3d]
     type = 'CSVDiff'
     input = '3d.i'
     csvdiff = '3d_out_elems_0001.csv'
-    mesh_mode = replicated
 [../]
 []


### PR DESCRIPTION
This restores more #1500 test cases.

The code here actually works with any number of processors; we just need to turn of mesh renumbering to make sure CSV results from unit tests match.