### PR TITLE
assembly: fix case of unbounded growth of residual cache

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -420,6 +420,8 @@ public:
    */
   void cacheResidualNeighbor();
 
+  void addCachedResiduals();
+
   /**
    * Adds the values that have been cached by calling cacheResidual() and or cacheResidualNeighbor()
    * to the residual.

--- a/framework/include/base/DisplacedSystem.h
+++ b/framework/include/base/DisplacedSystem.h
@@ -35,6 +35,16 @@ public:
 
   virtual void init() override;
 
+  virtual bool hasResidualVector(Moose::KernelType type) const override
+  {
+    return _undisplaced_system.hasResidualVector(type);
+  }
+
+  virtual NumericVector<Number> & residualVector(Moose::KernelType type) override
+  {
+    return _undisplaced_system.residualVector(type);
+  }
+
   virtual NumericVector<Number> & getVector(const std::string & name) override;
 
   virtual NumericVector<Number> & serializedSolution() override

--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -322,7 +322,7 @@ public:
 
   virtual NumericVector<Number> & solutionUDot() override;
   virtual NumericVector<Number> & residualVector(Moose::KernelType type) override;
-  virtual bool hasResidualVector(Moose::KernelType type) const;
+  virtual bool hasResidualVector(Moose::KernelType type) const override;
 
   virtual const NumericVector<Number> *& currentSolution() override { return _current_solution; }
 

--- a/framework/include/base/SystemBase.h
+++ b/framework/include/base/SystemBase.h
@@ -149,6 +149,7 @@ public:
   virtual Number & duDotDu() { return _du_dot_du; }
   virtual NumericVector<Number> & solutionUDot() { return *_dummy_vec; }
   virtual NumericVector<Number> & residualVector(Moose::KernelType /*type*/) { return *_dummy_vec; }
+  virtual bool hasResidualVector(Moose::KernelType) const { return false; };
 
   virtual void saveOldSolutions();
   virtual void restoreOldSolutions();

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -577,11 +577,7 @@ DisplacedProblem::cacheResidualNeighbor(THREAD_ID tid)
 void
 DisplacedProblem::addCachedResidual(THREAD_ID tid)
 {
-  if (_mproblem.getNonlinearSystem().hasResidualVector(Moose::KT_TIME))
-    _assembly[tid]->addCachedResidual(_mproblem.residualVector(Moose::KT_TIME), Moose::KT_TIME);
-  if (_mproblem.getNonlinearSystem().hasResidualVector(Moose::KT_NONTIME))
-    _assembly[tid]->addCachedResidual(_mproblem.residualVector(Moose::KT_NONTIME),
-                                      Moose::KT_NONTIME);
+  _assembly[tid]->addCachedResiduals();
 }
 
 void

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -1022,10 +1022,7 @@ FEProblemBase::cacheResidualNeighbor(THREAD_ID tid)
 void
 FEProblemBase::addCachedResidual(THREAD_ID tid)
 {
-  if (_nl->hasResidualVector(Moose::KT_TIME))
-    _assembly[tid]->addCachedResidual(residualVector(Moose::KT_TIME), Moose::KT_TIME);
-  if (_nl->hasResidualVector(Moose::KT_NONTIME))
-    _assembly[tid]->addCachedResidual(residualVector(Moose::KT_NONTIME), Moose::KT_NONTIME);
+  _assembly[tid]->addCachedResiduals();
 
   if (_displaced_problem)
     _displaced_problem->addCachedResidual(tid);


### PR DESCRIPTION
Previously, assembly was caching residual values in vectors for both
time and non-time based kernels (KT_TIME and KT_NOTIME) regardless of whether
or not both kernel types were in use in the (nonlinear) system.  However, when
the caches were applied to actual residual vectors, they were conditionally
applied based on whether or not each kernel type was in use in the system.
Because the cache clearing/reset only occurred in conjunction with application
of the cache to actual residual vectors, simulations that used the cache but
didn't have one or more of the kernel types would have cache vectors for the
unused types grow unbounded. This change modifies the cache to only store
residual entries for kernel types that are in use.  It also clears the cache
vectors for all kernel types with the new addCachedResiduals function
regardless of which types are in use (just for safety).

This was discovered after noticing unbounded heap usage growth for
long-running rattlesnake simulations while doing memory profiling.

Fixes #9202