### PR TITLE
Minor adjustment to water eos to handle case near triple point.

### DIFF
--- a/modules/water_steam_eos/src/IAPWS97.f90
+++ b/modules/water_steam_eos/src/IAPWS97.f90
@@ -167,7 +167,8 @@ recursive logical function cowat(t,p,d,h)
   integer:: i
   ! This tolerance allows cowat to be called just outside its
   ! nominal operating range when doing transitions to supercritical:
-  double precision, parameter:: ttol=1.0d-3
+  !double precision, parameter:: ttol=1.0d-3
+  double precision, parameter:: ttol=2.0d0
 
   ! Check input:
   if ((t<=350.0d0+ttol).and.(p<=100.d6)) then

--- a/modules/water_steam_eos/src/water_steam_phase_prop.f90
+++ b/modules/water_steam_eos/src/water_steam_phase_prop.f90
@@ -26,13 +26,18 @@ recursive Subroutine wateos_PH(p, h, T, dw, hx, energyscale, tolerance, ierr)
   dt=-1D-7
 
   do
-   succ= cowat(tx, p, dw, hw)
+   succ = cowat(tx, p, dw, hw)
    hx= hw * energyscale
 !   if(dabs((hx-h)/h)<= 1D-14) exit
     if(dabs((hx-h))<= tolerance) exit
    txd = tx + dt
-   succ = cowat(txd, p, dw, hw)
+   succ = succ .and. cowat(txd, p, dw, hw)
    hxd= hw * energyscale
+   if ( .not. succ ) then
+      print *, 'Wateos_PH: Error calling cowat. STOP'
+      print *, p, h, t, tx, txd, hx, hxd
+      stop
+   endif
    tx = tx + ( h - hx)*dt / (hxd-hx)
 !   print *, itr, tx, h,hx, hxd
    itr =itr+1


### PR DESCRIPTION
Closes #9222

Needed only to allow a slightly higher temperature when computing water properties.