### PR TITLE
Move the try/exception to include unknown prereqs

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -946,17 +946,17 @@ class TestHarness:
             name_to_object[tester.getTestName()] = tester
 
         # Now build up our tester dependencies
-        for tester in testers:
-            # Now we need to see which dependencies are real
-            # We don't really care about skipped tests, heavy tests, etc.
-            for name in tester.getPrereqs():
-                if not name_to_object[name].getRunnable():
-                    tester.setStatus('skipped dependency', tester.bucket_skip)
-
-            prereq_objects = [name_to_object[name] for name in tester.getPrereqs()]
-            d.insertDependency(tester, prereq_objects)
-
         try:
+            for tester in testers:
+                # Now we need to see which dependencies are real
+                # We don't really care about skipped tests, heavy tests, etc.
+                for name in tester.getPrereqs():
+                    if not name_to_object[name].getRunnable():
+                        tester.setStatus('skipped dependency', tester.bucket_skip)
+
+                prereq_objects = [name_to_object[name] for name in tester.getPrereqs()]
+                d.insertDependency(tester, prereq_objects)
+
             concurrent_tester_sets = d.getSortedValuesSets()
             for concurrent_testers in concurrent_tester_sets:
                 output_files_in_dir = set()

--- a/python/TestHarness/tests/test_UnknownPrereq.py
+++ b/python/TestHarness/tests/test_UnknownPrereq.py
@@ -1,0 +1,14 @@
+import subprocess
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testUnknownPrereq(self):
+        """
+        Test for Unknown Prereq (cyclic error)
+        """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('-i', 'unknown_prereq')
+
+        e = cm.exception
+        self.assertEqual(e.returncode, 1)
+        self.assertIn('Cyclic or Invalid Dependency Detected!', e.output)

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -51,4 +51,8 @@
     type = PythonUnitTest
     input = test_utils.py
   [../]
+  [./unknown_prereq]
+    type = PythonUnitTest
+    input = test_UnknownPrereq.py
+  [../]
 []

--- a/test/tests/test_harness/unknown_prereq
+++ b/test/tests/test_harness/unknown_prereq
@@ -1,0 +1,7 @@
+[Tests]
+  [./foo]
+    type = RunApp
+    input = foo.i
+    prereq = non_existent
+  [../]
+[]


### PR DESCRIPTION
We were building a dictionary of tests and then comparing those against user-generated
list of prereqs. Typos ensued, and we ran into a dictionary KeyError exception.

Include the dictionary comparison in a try/except to catch this error, and handle it
accordingly.

Add a unit test to test for this issue.

Refs #9224