### PR TITLE
Fix Qt widgets on low res displays

### DIFF
--- a/python/peacock/Execute/ExecuteOptionsPlugin.py
+++ b/python/peacock/Execute/ExecuteOptionsPlugin.py
@@ -210,10 +210,12 @@ class ExecuteOptionsPlugin(QWidget, Plugin):
         args = []
         if self.mpi_checkbox.isChecked():
             mpi_args = shlex.split(str(self.mpi_line.text()))
-            cmd = mpi_args[0]
-            args = mpi_args[1:]
-            args.append(str(self.exe_line.text()))
-        else:
+            if mpi_args:
+                cmd = mpi_args[0]
+                args = mpi_args[1:]
+                args.append(str(self.exe_line.text()))
+
+        if not cmd:
             cmd = str(self.exe_line.text())
 
         args += shlex.split(str(self.args_line.text()))
@@ -307,7 +309,6 @@ if __name__ == "__main__":
     w = ExecuteOptionsPlugin()
     main_win.setCentralWidget(w)
     main_win.show()
-    w.initialize()
     menubar = main_win.menuBar()
     menubar.setNativeMenuBar(False)
     executeMenu = menubar.addMenu("E&xecute")

--- a/python/peacock/Execute/ExecuteRunnerPlugin.py
+++ b/python/peacock/Execute/ExecuteRunnerPlugin.py
@@ -173,12 +173,11 @@ if __name__ == "__main__":
     qapp = QApplication(sys.argv)
     exe = Testing.find_moose_test_exe()
     w = ExecuteRunnerPlugin()
-    w.onCommandChanged(exe, [], False)
+    w.setCommand(exe, [], False)
     def needInputFile(input_file):
         this_dir = os.path.dirname(os.path.abspath(__file__))
         peacock_dir = os.path.dirname(this_dir)
-        chigger_dir = os.path.dirname(peacock_dir)
-        test_file = os.path.join(chigger_dir, "tests", "peacock", "common", "transient.i")
+        test_file = os.path.join(peacock_dir, "tests", "common", "transient.i")
         with open(test_file, "r") as fin:
             data = fin.read()
             with open(input_file, "w") as fout:

--- a/python/peacock/Execute/ExecuteTabPlugin.py
+++ b/python/peacock/Execute/ExecuteTabPlugin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from peacock.base.PluginManager import PluginManager
 from peacock.base.TabPlugin import TabPlugin
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout
+from PyQt5.QtWidgets import QWidget, QVBoxLayout
 from PyQt5.QtCore import pyqtSignal
 from peacock.utils import ExeFinder
 from ExecuteOptionsPlugin import ExecuteOptionsPlugin
@@ -43,14 +43,8 @@ class ExecuteTabPlugin(QWidget, PluginManager, TabPlugin):
     def __init__(self, plugins=[ExecuteOptionsPlugin, ExecuteRunnerPlugin, ConsoleOutputViewerPlugin]):
         super(ExecuteTabPlugin, self).__init__(plugins=plugins)
         self.MainLayout = QVBoxLayout()
-        self.LeftLayout = QHBoxLayout()
-        self.RightLayout = QVBoxLayout()
-        self.WindowLayout = QHBoxLayout()
 
         self.setLayout(self.MainLayout)
-        self.MainLayout.addLayout(self.WindowLayout)
-        self.MainLayout.addLayout(self.LeftLayout)
-        self.MainLayout.addLayout(self.RightLayout)
 
         self.setup()
         self.ExecuteOptionsPlugin.executableInfoChanged.connect(self.onExecutableInfoChanged)
@@ -144,8 +138,7 @@ if __name__ == "__main__":
     def needInputFile(input_file):
         this_dir = os.path.dirname(os.path.abspath(__file__))
         peacock_dir = os.path.dirname(this_dir)
-        chigger_dir = os.path.dirname(peacock_dir)
-        test_file = os.path.join(chigger_dir, "tests", "peacock", "common", "transient.i")
+        test_file = os.path.join(peacock_dir, "tests", "common", "transient.i")
         with open(test_file, "r") as fin:
             data = fin.read()
             with open(input_file, "w") as fout:
@@ -160,5 +153,5 @@ if __name__ == "__main__":
     menubar.setNativeMenuBar(False)
     w.addToMainMenu(menubar)
     main_win.show()
-    w.initialize(cmd_line_options=parsed)
+    w.initialize(parsed)
     sys.exit(qapp.exec_())

--- a/python/peacock/Input/TimeStepEstimate.py
+++ b/python/peacock/Input/TimeStepEstimate.py
@@ -44,8 +44,7 @@ if __name__ == "__main__":
     exe = Testing.find_moose_test_exe()
     this_dir = os.path.dirname(os.path.abspath(__file__))
     peacock_dir = os.path.dirname(this_dir)
-    chigger_dir = os.path.dirname(peacock_dir)
-    test_file = os.path.join(chigger_dir, "tests", "peacock", "common", "transient.i")
+    test_file = os.path.join(peacock_dir, "tests", "common", "transient.i")
     exe_info = ExecutableInfo()
     exe_info.path = exe
     tree = InputTree(exe_info)

--- a/python/peacock/PeacockApp.py
+++ b/python/peacock/PeacockApp.py
@@ -46,6 +46,19 @@ class PeacockApp(object):
         pp_plugin = self.main_widget.tab_plugin.PostprocessorViewer
         vpp_plugin = self.main_widget.tab_plugin.VectorPostprocessorViewer
 
+        # issue #9255
+        # For some unknown reason, the Execute tab doesn't work
+        # properly on low resolution displays (and some widgets
+        # on the input tab ).
+        # If you switch to the ExodusViewer tab then back again, it works.
+        # If the Execute tab is created after the ExodusViewer
+        # tab, it works. If the VTKWindowPlugin of the ExodusViewer
+        # tab is removed, it works. So there is some resizing issue
+        # or something.
+        # This ugly hack seems to fix the immediate problem.
+        for idx in range(self.main_widget.tab_plugin.count()):
+            self.main_widget.tab_plugin.setCurrentIndex(idx)
+
         if parsed_args.vectorpostprocessors:
             self.main_widget.setTab(vpp_plugin.tabName())
         elif parsed_args.postprocessors:

--- a/python/peacock/PeacockApp.py
+++ b/python/peacock/PeacockApp.py
@@ -1,6 +1,6 @@
 from PyQt5.QtGui import QIcon
 from PeacockMainWindow import PeacockMainWindow
-import argparse, os
+import argparse, os, sys
 from peacock.utils import qtutils
 
 class PeacockApp(object):
@@ -48,7 +48,7 @@ class PeacockApp(object):
 
         # issue #9255
         # For some unknown reason, the Execute tab doesn't work
-        # properly on low resolution displays (and some widgets
+        # properly on Mac low resolution displays (and some widgets
         # on the input tab ).
         # If you switch to the ExodusViewer tab then back again, it works.
         # If the Execute tab is created after the ExodusViewer
@@ -56,8 +56,9 @@ class PeacockApp(object):
         # tab is removed, it works. So there is some resizing issue
         # or something.
         # This ugly hack seems to fix the immediate problem.
-        for idx in range(self.main_widget.tab_plugin.count()):
-            self.main_widget.tab_plugin.setCurrentIndex(idx)
+        if sys.platform == 'darwin':
+            for idx in range(self.main_widget.tab_plugin.count()):
+                self.main_widget.tab_plugin.setCurrentIndex(idx)
 
         if parsed_args.vectorpostprocessors:
             self.main_widget.setTab(vpp_plugin.tabName())


### PR DESCRIPTION
It seems there is some resizing/update issues or something with Qt on low resolution displays.
Several buttons, line edits, check boxes on both the Input tab and the Execute tab don't seem to work, while others do. Switching to the ExodusViewer tab and back again seems to fix the problem. 

closes #9255 

This also fixes  some of the `__main__` parts of files so they work properly.