### PR TITLE
Remove isotropic tensor helper functions in RadialReturnStressUpdate

### DIFF
--- a/framework/src/geomsearch/NearestNodeThread.C
+++ b/framework/src/geomsearch/NearestNodeThread.C
@@ -80,7 +80,7 @@ NearestNodeThread::operator()(const NodeIdRange & range)
         if (std::isnan((*cur_node)(0)) || std::isinf((*cur_node)(0)) ||
             std::isnan((*cur_node)(1)) || std::isinf((*cur_node)(1)) ||
             std::isnan((*cur_node)(2)) || std::isinf((*cur_node)(2)))
-          mooseError("Failure in NearestNodeThread because solution contans inf or not-a-number "
+          mooseError("Failure in NearestNodeThread because solution contains inf or not-a-number "
                      "entries.  This is likely due to a failed factorization of the Jacobian "
                      "matrix.");
       }

--- a/modules/tensor_mechanics/include/materials/ComputeMeanThermalExpansionEigenstrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMeanThermalExpansionEigenstrainBase.h
@@ -49,7 +49,7 @@ protected:
   virtual Real referenceTemperature() = 0;
 
   /*
-   * Compute the total mean thermal expansion relative to the reference temperature.
+   * Compute the mean thermal expansion coefficient relative to the reference temperature.
    * This is the linear thermal strain divided by the temperature difference:
    * \f$\bar{\alpha}=(\delta L / L)/(T - T_{ref})\f$.
    * param temperature  temperature at which this is evaluated
@@ -57,7 +57,7 @@ protected:
   virtual Real meanThermalExpansionCoefficient(const Real temperature) = 0;
 
   /*
-   * Compute the derivative of the total mean thermal expansion coefficient \f$\bar{\alpha}\f$
+   * Compute the derivative of the mean thermal expansion coefficient \f$\bar{\alpha}\f$
    * with respect to temperature, where \f$\bar{\alpha}=(\delta L / L)/(T - T_{ref})\f$.
    * param temperature  temperature at which this is evaluated
    */

--- a/modules/tensor_mechanics/include/materials/ComputeMeanThermalExpansionFunctionEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMeanThermalExpansionFunctionEigenstrain.h
@@ -32,7 +32,7 @@ protected:
   virtual Real referenceTemperature() override;
 
   /*
-   * Compute the total mean thermal expansion relative to the reference temperature.
+   * Compute the mean thermal expansion coefficient relative to the reference temperature.
    * This is the linear thermal strain divided by the temperature difference:
    * \f$\bar{\alpha}=(\delta L / L)/(T - T_{ref})\f$.
    * param temperature  temperature at which this is evaluated
@@ -40,7 +40,7 @@ protected:
   virtual Real meanThermalExpansionCoefficient(const Real temperature) override;
 
   /*
-   * Compute the derivative of the total mean thermal expansion coefficient \f$\bar{\alpha}\f$
+   * Compute the derivative of the mean thermal expansion coefficient \f$\bar{\alpha}\f$
    * with respect to temperature, where \f$\bar{\alpha}=(\delta L / L)/(T - T_{ref})\f$.
    * param temperature  temperature at which this is evaluated
    */

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -63,8 +63,6 @@ protected:
   virtual Real computeDerivative(Real /*effectiveTrialStress*/, Real /*scalar*/) { return 0; }
   virtual void iterationFinalize(Real /*scalar*/) {}
   virtual void computeStressFinalize(const RankTwoTensor & /*inelasticStrainIncrement*/) {}
-  virtual Real getIsotropicShearModulus(const RankFourTensor & elasticity_tensor);
-  virtual Real getIsotropicBulkModulus(const RankFourTensor & elasticity_tensor);
 
   const unsigned int _max_its;
   const bool _output_iteration_info;

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -177,28 +177,6 @@ RadialReturnStressUpdate::updateState(RankTwoTensor & strain_increment,
 }
 
 Real
-RadialReturnStressUpdate::getIsotropicShearModulus(const RankFourTensor & elasticity_tensor)
-{
-  const Real shear_modulus = elasticity_tensor(0, 1, 0, 1);
-  if (_mesh.dimension() == 3 && shear_modulus != elasticity_tensor(0, 2, 0, 2))
-    mooseError("Check to ensure that your Elasticity Tensor is truly Isotropic");
-  return shear_modulus;
-}
-
-Real
-RadialReturnStressUpdate::getIsotropicBulkModulus(const RankFourTensor & elasticity_tensor)
-{
-  const Real shear_modulus = getIsotropicShearModulus(elasticity_tensor);
-  // dilatational modulus is defined as lambda plus two mu
-  const Real dilatational_modulus = elasticity_tensor(0, 0, 0, 0);
-  if (_mesh.dimension() == 3 && dilatational_modulus != elasticity_tensor(2, 2, 2, 2))
-    mooseError("Check to ensure that your Elasticity Tensor is truly Isotropic");
-  const Real lambda = dilatational_modulus - 2.0 * shear_modulus;
-  const Real bulk_modulus = lambda + 2.0 * shear_modulus / 3.0;
-  return bulk_modulus;
-}
-
-Real
 RadialReturnStressUpdate::computeTimeStepLimit()
 {
   Real tmp_max_incr;

--- a/modules/tensor_mechanics/src/materials/TemperatureDependentHardeningStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/TemperatureDependentHardeningStressUpdate.C
@@ -7,6 +7,7 @@
 #include "TemperatureDependentHardeningStressUpdate.h"
 
 #include "PiecewiseLinear.h"
+#include "ElasticityTensorTools.h"
 
 template <>
 InputParameters
@@ -75,7 +76,7 @@ void
 TemperatureDependentHardeningStressUpdate::computeStressInitialize(
     Real effectiveTrialStress, const RankFourTensor & elasticity_tensor)
 {
-  _shear_modulus = getIsotropicShearModulus(elasticity_tensor);
+  _shear_modulus = ElasticityTensorTools::getIsotropicShearModulus(elasticity_tensor);
   initializeHardeningFunctions();
   computeYieldStress(elasticity_tensor);
   _yield_condition = effectiveTrialStress - _hardening_variable_old[_qp] - _yield_stress;


### PR DESCRIPTION
I switched all usage of these in BISON over to the ones in ElasticityTensorTools.

This also include a couple of other commits with minor unrelated fixes.