### PR TITLE
Minor fix to avoid having two problems

### DIFF
--- a/examples/ex21_debugging/include/kernels/ExampleDiffusion.h
+++ b/examples/ex21_debugging/include/kernels/ExampleDiffusion.h
@@ -44,6 +44,6 @@ protected:
    * Do NOT copy this line of code!
    */
 
-  VariableValue _coupled_coef;
+  const VariableValue _coupled_coef;
 };
 #endif // EXAMPLEDIFFUSION_H


### PR DESCRIPTION
This example is supposed to illustrate a forgotten ampersand. I'm adding
const so that the users don't have to fix two problems

refs #9269