### PR TITLE
Option to set stress free temperature with AuxVariable

### DIFF
--- a/modules/tensor_mechanics/include/materials/ComputeMeanThermalExpansionEigenstrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMeanThermalExpansionEigenstrainBase.h
@@ -31,8 +31,6 @@ public:
   ComputeMeanThermalExpansionEigenstrainBase(const InputParameters & parameters);
 
 protected:
-  virtual void initialSetup() override;
-
   /*
    * Compute the total thermal strain relative to the stress-free temperature at the
    * current temperature, as well as the current instantaneous thermal expansion coefficient.
@@ -62,16 +60,6 @@ protected:
    * param temperature  temperature at which this is evaluated
    */
   virtual Real meanThermalExpansionCoefficientDerivative(const Real temperature) = 0;
-
-  /// Mean linear thermal expansion coefficient relative to the reference temperature
-  /// evaluated at stress_free_temperature.  This is
-  /// \f$\bar{\alpha} = (\delta L(T_{sf}) / L) / (T_{sf} - T_{ref})\f$
-  /// where \f$T_sf\f$ is the stress-free temperature and \f$T_{ref}\f$ is the reference temperature.
-  Real _alphabar_stress_free_temperature;
-
-  /// Thermal expansion relative to the reference temperature evaluated at stress_free_temperature
-  /// \f$(\delta L(T_sf) / L)\f$, where \f$T_sf\f$ is the stress-free temperature.
-  Real _thexp_stress_free_temperature;
 };
 
 #endif // COMPUTEMEANTHERMALEXPANSIONEIGENSTRAINBASE_H

--- a/modules/tensor_mechanics/include/materials/ComputeThermalExpansionEigenstrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeThermalExpansionEigenstrainBase.h
@@ -29,17 +29,20 @@ public:
 protected:
   virtual void computeQpEigenstrain() override;
   /*
-   * Compute the total thermal strain relative to the stress-free temperature at the
-   * current temperature, as well as the current instantaneous thermal expansion coefficient.
-   * param thermal_strain    The current total linear thermal strain (\delta L / L)
-   * param instantaneous_cte The current instantaneous coefficient of thermal expansion
-   *                         (derivative of thermal_strain wrt temperature
+   * Compute the total thermal strain relative to the stress-free temperature at
+   * the current temperature, as well as the current instantaneous thermal
+   * expansion coefficient.
+   * param thermal_strain    The current total linear thermal strain
+   *                         (\delta L / L)
+   * param instantaneous_cte The current instantaneous coefficient of thermal
+   *                         expansion (derivative of thermal_strain wrt
+   *                         temperature
    */
   virtual void computeThermalStrain(Real & thermal_strain, Real & instantaneous_cte) = 0;
 
   const VariableValue & _temperature;
   MaterialProperty<RankTwoTensor> & _deigenstrain_dT;
-  Real _stress_free_temperature;
+  const VariableValue & _stress_free_temperature;
 };
 
 #endif // COMPUTETHERMALEXPANSIONEIGENSTRAINBASE_H

--- a/modules/tensor_mechanics/src/materials/ComputeInstantaneousThermalExpansionFunctionEigenstrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeInstantaneousThermalExpansionFunctionEigenstrain.C
@@ -53,7 +53,7 @@ ComputeInstantaneousThermalExpansionFunctionEigenstrain::computeThermalStrain(
 
   const Real & old_thermal_strain = _thermal_strain_old[_qp];
 
-  const Real & old_temp = (_step_one ? _stress_free_temperature : _temperature_old[_qp]);
+  const Real & old_temp = (_step_one ? _stress_free_temperature[_qp] : _temperature_old[_qp]);
   const Real delta_T = current_temp - old_temp;
 
   const Point p;

--- a/modules/tensor_mechanics/src/materials/ComputeMeanThermalExpansionEigenstrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMeanThermalExpansionEigenstrainBase.C
@@ -19,21 +19,8 @@ validParams<ComputeMeanThermalExpansionEigenstrainBase>()
 
 ComputeMeanThermalExpansionEigenstrainBase::ComputeMeanThermalExpansionEigenstrainBase(
     const InputParameters & parameters)
-  : ComputeThermalExpansionEigenstrainBase(parameters),
-    _alphabar_stress_free_temperature(0.0),
-    _thexp_stress_free_temperature(0.0)
+  : ComputeThermalExpansionEigenstrainBase(parameters)
 {
-}
-
-void
-ComputeMeanThermalExpansionEigenstrainBase::initialSetup()
-{
-  _alphabar_stress_free_temperature = meanThermalExpansionCoefficient(_stress_free_temperature);
-  _thexp_stress_free_temperature =
-      _alphabar_stress_free_temperature * (_stress_free_temperature - referenceTemperature());
-
-  // Evaluate the derivative so it will error out early on if there are any issues with that
-  meanThermalExpansionCoefficientDerivative(_stress_free_temperature);
 }
 
 void
@@ -47,18 +34,31 @@ ComputeMeanThermalExpansionEigenstrainBase::computeThermalStrain(Real & thermal_
   const Real current_alphabar = meanThermalExpansionCoefficient(current_temp);
   const Real thexp_current_temp = current_alphabar * (current_temp - reference_temperature);
 
-  // Per M. Niffenegger and K. Reichlin (2012), thermal_strain should be divided by
-  // (1.0 + _thexp_stress_free_temperature) to account for the ratio of the length at the
-  // stress-free temperature to the length at the reference temperature. It can be neglected
-  // because it is very close to 1, but we include it for completeness here.
+  // Mean linear thermal expansion coefficient relative to the reference temperature
+  // evaluated at stress_free_temperature.  This is
+  // \f$\bar{\alpha} = (\delta L(T_{sf}) / L) / (T_{sf} - T_{ref})\f$
+  // where \f$T_sf\f$ is the stress-free temperature and \f$T_{ref}\f$ is the reference temperature.
+  const Real alphabar_stress_free_temperature =
+      meanThermalExpansionCoefficient(_stress_free_temperature[_qp]);
+  // Thermal expansion relative to the reference temperature evaluated at stress_free_temperature
+  // \f$(\delta L(T_sf) / L)\f$, where \f$T_sf\f$ is the stress-free temperature.
+  const Real thexp_stress_free_temperature =
+      alphabar_stress_free_temperature * (_stress_free_temperature[_qp] - referenceTemperature());
 
-  thermal_strain = (thexp_current_temp - _thexp_stress_free_temperature) /
-                   (1.0 + _thexp_stress_free_temperature);
+  // Per M. Niffenegger and K. Reichlin (2012), thermal_strain should be divided
+  // by (1.0 + thexp_stress_free_temperature) to account for the ratio of
+  // the length at the stress-free temperature to the length at the reference
+  // temperature. It can be neglected because it is very close to 1,
+  // but we include it for completeness here.
+
+  thermal_strain =
+      (thexp_current_temp - thexp_stress_free_temperature) / (1.0 + thexp_stress_free_temperature);
 
   const Real dalphabar_dT = meanThermalExpansionCoefficientDerivative(current_temp);
   const Real numerator = dalphabar_dT * (current_temp - reference_temperature) + current_alphabar;
   const Real denominator =
-      1.0 + _alphabar_stress_free_temperature * (_stress_free_temperature - reference_temperature);
+      1.0 +
+      alphabar_stress_free_temperature * (_stress_free_temperature[_qp] - reference_temperature);
   if (denominator < small)
     mooseError("Denominator too small in thermal strain calculation");
   instantaneous_cte = numerator / denominator;

--- a/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrain.C
@@ -11,8 +11,8 @@ InputParameters
 validParams<ComputeThermalExpansionEigenstrain>()
 {
   InputParameters params = validParams<ComputeThermalExpansionEigenstrainBase>();
-  params.addClassDescription(
-      "Computes eigenstrain due to thermal expansion with a constant coefficient");
+  params.addClassDescription("Computes eigenstrain due to thermal expansion "
+                             "with a constant coefficient");
   params.addParam<Real>("thermal_expansion_coeff", "Thermal expansion coefficient");
 
   return params;
@@ -29,6 +29,6 @@ void
 ComputeThermalExpansionEigenstrain::computeThermalStrain(Real & thermal_strain,
                                                          Real & instantaneous_cte)
 {
-  thermal_strain = _thermal_expansion_coeff * (_temperature[_qp] - _stress_free_temperature);
+  thermal_strain = _thermal_expansion_coeff * (_temperature[_qp] - _stress_free_temperature[_qp]);
   instantaneous_cte = _thermal_expansion_coeff;
 }

--- a/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrainBase.C
@@ -13,11 +13,10 @@ validParams<ComputeThermalExpansionEigenstrainBase>()
 {
   InputParameters params = validParams<ComputeEigenstrainBase>();
   params.addCoupledVar("temperature", "Coupled temperature");
-  params.addParam<Real>("stress_free_temperature",
-                        "Reference temperature at which there is no "
-                        "thermal expansion for thermal eigenstrain "
-                        "calculation");
-
+  params.addCoupledVar("stress_free_temperature",
+                       "Reference temperature at which there is no "
+                       "thermal expansion for thermal eigenstrain "
+                       "calculation");
   return params;
 }
 
@@ -26,12 +25,9 @@ ComputeThermalExpansionEigenstrainBase::ComputeThermalExpansionEigenstrainBase(
   : DerivativeMaterialInterface<ComputeEigenstrainBase>(parameters),
     _temperature(coupledValue("temperature")),
     _deigenstrain_dT(declarePropertyDerivative<RankTwoTensor>(_eigenstrain_name,
-                                                              getVar("temperature", 0)->name()))
+                                                              getVar("temperature", 0)->name())),
+    _stress_free_temperature(coupledValue("stress_free_temperature"))
 {
-  if (isParamValid("stress_free_temperature"))
-    _stress_free_temperature = getParam<Real>("stress_free_temperature");
-  else
-    mooseError("Please specify 'stress_free_temperature'.");
 }
 
 void
@@ -39,6 +35,7 @@ ComputeThermalExpansionEigenstrainBase::computeQpEigenstrain()
 {
   Real thermal_strain = 0.0;
   Real instantaneous_cte = 0.0;
+
   computeThermalStrain(thermal_strain, instantaneous_cte);
 
   _eigenstrain[_qp].zero();


### PR DESCRIPTION
Modifies TensorMechanics thermal strain materials to allow users to set
some non-uniform thermal strain distribution via an AuxVariable,
initialized with an AuxKernel

closes #9291 