### PR TITLE
Improve generation of the revision file.

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -159,13 +159,14 @@ endif
 
 BUILD_EXEC :=
 
-$(app_objects): $(app_HEADER)
-
+app_GIT_DIR := $(shell cd "$(APPLICATION_DIR)" && git rev-parse --show-toplevel)
+# Use wildcard in case the files don't exist
+app_HEADER_deps := $(wildcard $(app_GIT_DIR)/.git/HEAD $(app_GIT_DIR)/.git/index)
 # Target-specific Variable Values (See GNU-make manual)
 $(app_HEADER): curr_dir    := $(APPLICATION_DIR)
 $(app_HEADER): curr_app    := $(APPLICATION_NAME)
-$(app_HEADER):
-	@echo "MOOSE Generating Header "$@"..."
+$(app_HEADER): $(app_HEADER_deps)
+	@echo "MOOSE Updating header "$@"..."
 	$(shell $(FRAMEWORK_DIR)/scripts/get_repo_revision.py $(curr_dir) $@ $(curr_app))
 
 # Target-specific Variable Values (See GNU-make manual)
@@ -173,7 +174,7 @@ $(app_LIB): curr_objs := $(app_objects)
 $(app_LIB): curr_dir  := $(APPLICATION_DIR)
 $(app_LIB): curr_deps := $(depend_libs)
 $(app_LIB): curr_libs := $(depend_libs_flags)
-$(app_LIB): $(app_objects) $(app_plugin_deps) $(app_HEADER) $(depend_libs)
+$(app_LIB): $(app_HEADER) $(app_plugin_deps) $(depend_libs) $(app_objects)
 	@echo "Linking Library "$@"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
 	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(curr_objs) $(libmesh_LDFLAGS) $(EXTERNAL_FLAGS) -rpath $(curr_dir)/lib $(curr_libs)


### PR DESCRIPTION
`app_HEADER` now depends on `.git/HEAD` and `.git/index`

closes #6307 

I played around with this a bit and it seems to do the correct things for apps (tested with BISON) and modules. There might be some cases I missed though.