### PR TITLE
Document isotropic phase field fracture of brittle materials

### DIFF
--- a/docs/bib/phase_field.bib
+++ b/docs/bib/phase_field.bib
@@ -1,3 +1,18 @@
+@article {Miehe10,
+  author = {Miehe, C. and Welschinger, F. and Hofacker, M.},
+  title = {Thermodynamically consistent phase-field models of fracture: Variational principles and multi-field FE implementations},
+  journal = {International Journal for Numerical Methods in Engineering},
+  volume = {83},
+  number = {10},
+  publisher = {John Wiley & Sons, Ltd.},
+  issn = {1097-0207},
+  url = {http://dx.doi.org/10.1002/nme.2861},
+  doi = {10.1002/nme.2861},
+  pages = {1273--1311},
+  keywords = {fracture, crack propagation, phase-fields, gradient-type damage, incremental variational principles, finite elements, coupled multi-field problems},
+  year = {2010},
+}
+
 @article{kim_phase-field_1999,
   title = {Phase-field model for binary alloys},
   volume = {60},

--- a/docs/content/documentation/systems/Kernels/phase_field/PFFracBulkRate.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/PFFracBulkRate.md
@@ -1,27 +1,29 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PFFracBulkRate
 !description /Kernels/PFFracBulkRate
 
-This kernel solves the second part of evolution function, in which the first part of the evolution function is solved with time derivative function.
+The kernel implements second equation substituted into the third equation in (63)
+from \cite{Miehe10}
+
+$$
+- \frac1\eta \langle l \cdot \beta + 2 (1-c) \frac{\psi^+_0}{g_c} - \frac cl \rangle_+,
+$$
+
+where $c$ is the variable the kernel is operating on, $\beta$ (`beta`) is $\nabla^2c$
+(computed using [LaplacianSplit](/LaplacianSplit.md)), $l$ (`l`) is the crack width,
+$\psi^+_0$ (`G0_var`) is the stored _tensile_ elastic energy, and $\eta$ (`visco`) the viscosity.
+
+$$
+\langle x\rangle_+ = \frac{|x| + x}2
+$$
+
+Note that $\beta$ is defined differently in the paper, $\eta$ in the paper corresponds
+to $\frac{\eta}{g_c}$ in MOOSE, and $\dot d$ in the paper corresponds
+to [TimeDerivative](/TimeDerivative.md) on the kernel variable $c$.
 
 !parameters /Kernels/PFFracBulkRate
-{\bf beta} Auxiliary variable, which is the laplacian operator of c
-{\bf l} Length parameter, which determines the width of crack
-{\bf visco} the viscosity parameter, which reflects the transition right at crack stress
-{\bf c} Damage variable continuous between 0 and 1, 0 represents no damage, 1 represents fully cracked
-
-!parameters /Kernels/PFFracBulkRate
-## Material property
-{\bf gc\_prop\_var} Material property name with gc value, which determines the maximum stress/crack stress
-
-The equation related in this kernel is shown below, which is a little different from the publication shows:
-
-\begin{eqnarray}
-- \frac{1}{\eta} \langle l * \beta + 2.0 * (1.0-c)* {\psi}^{+}_{0}/g_c - \frac{c}{l} \rangle_{+}
-\end{eqnarray}
 
 !inputfiles /Kernels/PFFracBulkRate
-Please look at crack_2d.i under the folder moose/modules/combined/tests/phase_field_fracture/
 
 !childobjects /Kernels/PFFracBulkRate
+
+\bibliography{docs/bib/phase_field.bib}

--- a/docs/content/documentation/systems/Kernels/phase_field/PFFracBulkRate.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/PFFracBulkRate.md
@@ -3,8 +3,25 @@
 # PFFracBulkRate
 !description /Kernels/PFFracBulkRate
 
+This kernel solves the second part of evolution function, in which the first part of the evolution function is solved with time derivative function.
+
 !parameters /Kernels/PFFracBulkRate
+{\bf beta} Auxiliary variable, which is the laplacian operator of c
+{\bf l} Length parameter, which determines the width of crack
+{\bf visco} the viscosity parameter, which reflects the transition right at crack stress
+{\bf c} Damage variable continuous between 0 and 1, 0 represents no damage, 1 represents fully cracked
+
+!parameters /Kernels/PFFracBulkRate
+## Material property
+{\bf gc\_prop\_var} Material property name with gc value, which determines the maximum stress/crack stress
+
+The equation related in this kernel is shown below, which is a little different from the publication shows:
+
+\begin{eqnarray}
+- \frac{1}{\eta} \langle l * \beta + 2.0 * (1.0-c)* {\psi}^{+}_{0}/g_c - \frac{c}{l} \rangle_{+}
+\end{eqnarray}
 
 !inputfiles /Kernels/PFFracBulkRate
+Please look at crack_2d.i under the folder moose/modules/combined/tests/phase_field_fracture/
 
 !childobjects /Kernels/PFFracBulkRate

--- a/docs/content/documentation/systems/Kernels/phase_field/PFFracCoupledInterface.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/PFFracCoupledInterface.md
@@ -1,14 +1,3 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PFFracCoupledInterface
-!description /Kernels/PFFracCoupledInterface
-This kernel solves the laplacian operator of damage parameter c, and gets its residual.
 
-!parameters /Kernels/PFFracCoupledInterface
-
-{\bf c} Damage variable continuous between 0 and 1, 0 represents no damage, 1 represents fully cracked
-{\bf beta} Auxiliary variable, which is the laplacian operator of c
-
-!inputfiles /Kernels/PFFracCoupledInterface
-
-!childobjects /Kernels/PFFracCoupledInterface
+Deprecated, use [LaplacianSplit](/LaplacianSplit.md) instead.

--- a/docs/content/documentation/systems/Kernels/phase_field/PFFracCoupledInterface.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/PFFracCoupledInterface.md
@@ -2,8 +2,12 @@
 
 # PFFracCoupledInterface
 !description /Kernels/PFFracCoupledInterface
+This kernel solves the laplacian operator of damage parameter c, and gets its residual.
 
 !parameters /Kernels/PFFracCoupledInterface
+
+{\bf c} Damage variable continuous between 0 and 1, 0 represents no damage, 1 represents fully cracked
+{\bf beta} Auxiliary variable, which is the laplacian operator of c
 
 !inputfiles /Kernels/PFFracCoupledInterface
 

--- a/docs/content/documentation/systems/Kernels/phase_field/PFFracCoupledInterface.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/PFFracCoupledInterface.md
@@ -1,3 +1,0 @@
-# PFFracCoupledInterface
-
-Deprecated, use [LaplacianSplit](/LaplacianSplit.md) instead.

--- a/docs/content/documentation/systems/Materials/tensor_mechanics/LinearIsoElasticPFDamage.md
+++ b/docs/content/documentation/systems/Materials/tensor_mechanics/LinearIsoElasticPFDamage.md
@@ -1,28 +1,41 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # LinearIsoElasticPFDamage
 !description /Materials/LinearIsoElasticPFDamage
 
-This part defines the positive part of strain energy and positive part of stress that drive the crack propagation, and total stress is represented as a function of damage parameter c, tensile part and compressive part of stress. The basic idea and the procedures we follow are shown here: 1, EigenDecompose the strain/ or called spectral decomposition of strain tensor; 2, Define the positive and negative part of strain energy due to tensile and compressive stress; 3, Find the tensile/compressive stress which are the derivatives of positive/negative part of strain energy wrt strain tensor; 4, Get the final stress which is a function of tensile compressive stress and damage parameter.
+This part defines the positive part of strain energy and positive part of stress
+that drive the crack propagation, and total stress is represented as a function
+of damage parameter $c$, tensile part and compressive part of stress. The basic
+idea and the procedures we follow is
 
-!parameters /Materials/LinearIsoElasticPFDamage
+1. EigenDecompose the strain or called spectral decomposition of strain tensor
+2. Define the positive and negative part of strain energy due to tensile and
+   compressive stress
+3. Find the tensile/compressive stress which are the derivatives of positive/negative
+   part of strain energy wrt strain tensor
+4. Get the final stress which is a function of tensile compressive stress and
+   damage parameter.
 
-{\bf c} Damage variable continuous between 0 and 1, 0 represents no damage, 1 represents fully cracked
+The following equations are used in this material:
 
-##Material Properties
-{\bf G0\_pos} Positive part of strain energy
-{\bf dG0\_pos\_dstrain} Tensile stress, which is the derivative of positive part of strain energy wrt strain tensor
-
-The following equations are used when defining this material class.
 $$
 \begin{eqnarray}
-\psi = [(1-c)^2 + k]{\psi}^{+}_{0} - {\psi}^{-}_{0} \\
-{\psi}^{\pm}_{0} = \lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle^{2}_{\pm} +\mu(\langle \epsilon_1 \rangle^{2}_{\pm} +\langle \epsilon_2 \rangle^{2}_{\pm} +\langle \epsilon_3 \rangle^{2}_{\pm}) \\
-{\sigma}^{\pm}_{0} = \frac{\partial {\psi}^{\pm}_{0}}{\partial \epsilon} = \sum \limits_{a=1}^3 [\lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle_{\pm} + 2\mu \langle \epsilon_a \rangle_{\pm} ]n_a \otimes n_a \\
-\sigma = [(1-c)^2 + k]{\sigma}^{+}_{0} - {\sigma}^{-}_{0} \\
-Where \\
-\langle x \rangle_{\pm} = (x \pm |x|)/2
+  \psi = [(1-c)^2 + k]{\psi}^{+}_{0} - {\psi}^{-}_{0} \\
+  {\psi}^{\pm}_{0} = \lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle^{2}_{\pm} +\mu(\langle \epsilon_1 \rangle^{2}_{\pm} +\langle \epsilon_2 \rangle^{2}_{\pm} +\langle \epsilon_3 \rangle^{2}_{\pm}) \\
+  {\sigma}^{\pm}_{0} = \frac{\partial {\psi}^{\pm}_{0}}{\partial \epsilon} = \sum \limits_{a=1}^3 [\lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle_{\pm} + 2\mu \langle \epsilon_a \rangle_{\pm} ]n_a \otimes n_a \\
+  \sigma = [(1-c)^2 + k]{\sigma}^{+}_{0} - {\sigma}^{-}_{0}
+\end{eqnarray}
 $$
+
+Where
+$$
+\langle x \rangle_{\pm} = \frac{x \pm |x|}2
+$$
+
+The material provides the following material properties:
+
+* `G0_pos` Positive part of strain energy
+* `dG0_pos_dstrain` Tensile stress, which is the derivative of positive part of strain energy wrt strain tensor
+
+!parameters /Materials/LinearIsoElasticPFDamage
 
 !inputfiles /Materials/LinearIsoElasticPFDamage
 

--- a/docs/content/documentation/systems/Materials/tensor_mechanics/LinearIsoElasticPFDamage.md
+++ b/docs/content/documentation/systems/Materials/tensor_mechanics/LinearIsoElasticPFDamage.md
@@ -3,7 +3,26 @@
 # LinearIsoElasticPFDamage
 !description /Materials/LinearIsoElasticPFDamage
 
+This part defines the positive part of strain energy and positive part of stress that drive the crack propagation, and total stress is represented as a function of damage parameter c, tensile part and compressive part of stress. The basic idea and the procedures we follow are shown here: 1, EigenDecompose the strain/ or called spectral decomposition of strain tensor; 2, Define the positive and negative part of strain energy due to tensile and compressive stress; 3, Find the tensile/compressive stress which are the derivatives of positive/negative part of strain energy wrt strain tensor; 4, Get the final stress which is a function of tensile compressive stress and damage parameter.
+
 !parameters /Materials/LinearIsoElasticPFDamage
+
+{\bf c} Damage variable continuous between 0 and 1, 0 represents no damage, 1 represents fully cracked
+
+##Material Properties
+{\bf G0\_pos} Positive part of strain energy
+{\bf dG0\_pos\_dstrain} Tensile stress, which is the derivative of positive part of strain energy wrt strain tensor
+
+The following equations are used when defining this material class.
+$$
+\begin{eqnarray}
+\psi = [(1-c)^2 + k]{\psi}^{+}_{0} - {\psi}^{-}_{0} \\
+{\psi}^{\pm}_{0} = \lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle^{2}_{\pm} +\mu(\langle \epsilon_1 \rangle^{2}_{\pm} +\langle \epsilon_2 \rangle^{2}_{\pm} +\langle \epsilon_3 \rangle^{2}_{\pm}) \\
+{\sigma}^{\pm}_{0} = \frac{\partial {\psi}^{\pm}_{0}}{\partial \epsilon} = \sum \limits_{a=1}^3 [\lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle_{\pm} + 2\mu \langle \epsilon_a \rangle_{\pm} ]n_a \otimes n_a \\
+\sigma = [(1-c)^2 + k]{\sigma}^{+}_{0} - {\sigma}^{-}_{0} \\
+Where \\
+\langle x \rangle_{\pm} = (x \pm |x|)/2
+$$
 
 !inputfiles /Materials/LinearIsoElasticPFDamage
 

--- a/modules/combined/tests/phase_field_fracture/crack2d.i
+++ b/modules/combined/tests/phase_field_fracture/crack2d.i
@@ -73,7 +73,7 @@
     variable = b
   [../]
   [./pfintcoupled]
-    type = PFFracCoupledInterface
+    type = LaplacianSplit
     variable = b
     c = c
   [../]

--- a/modules/combined/tests/phase_field_fracture/void2d.i
+++ b/modules/combined/tests/phase_field_fracture/void2d.i
@@ -72,7 +72,7 @@
     variable = b
   [../]
   [./pfintcoupled]
-    type = PFFracCoupledInterface
+    type = LaplacianSplit
     variable = b
     c = c
   [../]

--- a/modules/combined/tests/phase_field_fracture_viscoplastic/crack2d.i
+++ b/modules/combined/tests/phase_field_fracture_viscoplastic/crack2d.i
@@ -77,7 +77,7 @@
     variable = b
   [../]
   [./pfintcoupled]
-    type = PFFracCoupledInterface
+    type = LaplacianSplit
     variable = b
     c = c
   [../]

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -354,8 +354,7 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerKernel(MatReaction);
   registerKernel(MultiGrainRigidBodyMotion);
   registerKernel(PFFracBulkRate);
-  registerDeprecatedObjectWithReplacement(
-      PFFracCoupledInterface, "LaplacianSplit", "07/14/2017 16:00");
+  registerKernel(PFFracCoupledInterface);
   registerKernel(SimpleACInterface);
   registerKernel(SimpleCHInterface);
   registerKernel(SimpleCoupledACInterface);

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -354,7 +354,8 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerKernel(MatReaction);
   registerKernel(MultiGrainRigidBodyMotion);
   registerKernel(PFFracBulkRate);
-  registerKernel(PFFracCoupledInterface);
+  registerDeprecatedObjectWithReplacement(
+      PFFracCoupledInterface, "LaplacianSplit", "07/14/2017 16:00");
   registerKernel(SimpleACInterface);
   registerKernel(SimpleCHInterface);
   registerKernel(SimpleCoupledACInterface);

--- a/modules/phase_field/src/kernels/PFFracBulkRate.C
+++ b/modules/phase_field/src/kernels/PFFracBulkRate.C
@@ -14,19 +14,24 @@ validParams<PFFracBulkRate>()
   InputParameters params = validParams<KernelValue>();
   params.addClassDescription(
       "Kernel to compute bulk energy contribution to damage order parameter residual equation");
-  params.addRequiredParam<Real>("l", "Interface width");
-  params.addRequiredParam<Real>("visco", "Viscosity parameter");
-  params.addRequiredParam<MaterialPropertyName>("gc_prop_var",
-                                                "Material property name with gc value");
+  params.addRequiredParam<Real>("l", "Width of the smooth crack representation");
+  params.addRequiredParam<Real>(
+      "visco", "Viscosity parameter, which reflects the transition right at crack stress");
+  params.addRequiredParam<MaterialPropertyName>(
+      "gc_prop_var", "Material property which provides the maximum stress/crack stress");
   params.addRequiredParam<MaterialPropertyName>(
       "G0_var", "Material property name with undamaged strain energy driving damage (G0_pos)");
   params.addParam<MaterialPropertyName>(
       "dG0_dstrain_var", "Material property name with derivative of G0_pos with strain");
-  params.addRequiredCoupledVar("beta", "Auxiliary variable");
+  params.addRequiredCoupledVar("beta", "Laplacian of the kernel variable");
 
-  params.addCoupledVar("displacements",
-                       "The string of displacements suitable for the problem statement");
-  params.addParam<std::string>("base_name", "Material property base name");
+  params.addCoupledVar(
+      "displacements",
+      "The displacements appropriate for the simulation geometry and coordinate system");
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
 
   return params;
 }

--- a/modules/tensor_mechanics/src/materials/LinearIsoElasticPFDamage.C
+++ b/modules/tensor_mechanics/src/materials/LinearIsoElasticPFDamage.C
@@ -15,7 +15,9 @@ validParams<LinearIsoElasticPFDamage>()
   params.addClassDescription("Phase-field fracture model energy contribution to damage "
                              "growth-isotropic elasticity and undamaged stress under compressive "
                              "strain");
-  params.addRequiredCoupledVar("c", "Order parameter for damage");
+  params.addRequiredCoupledVar("c",
+                               "Order parameter for damage, continuous between 0 and 1, 0 "
+                               "represents no damage, 1 represents fully cracked");
   params.addParam<Real>("kdamage", 1e-6, "Stiffness of damaged matrix");
 
   return params;


### PR DESCRIPTION
Also deprecate `PFFracCoupledInterface` in favor of `LaplacianSplit` which does the exact same thing and has a more general name, reflecting the wide application of this kernel.

Replaces #9302 
Closes #9263