### PR TITLE
Deprecated message added to RichardsApp

### DIFF
--- a/modules/richards/src/base/RichardsApp.C
+++ b/modules/richards/src/base/RichardsApp.C
@@ -118,6 +118,9 @@ RichardsApp::RichardsApp(const InputParameters & parameters) : MooseApp(paramete
 
   Moose::associateSyntax(_syntax, _action_factory);
   RichardsApp::associateSyntax(_syntax, _action_factory);
+
+  mooseDeprecated("Please use the PorousFlow module instead.  If Richards contains functionality "
+                  "not included in PorousFlow, please contact the moose-users google group");
 }
 
 RichardsApp::~RichardsApp() {}


### PR DESCRIPTION
Richards cannot be fully deprecated yet as the BAHUN app uses it, and BAHUN is still being used to do serious work.  But the deprecated message will hopefully discourage new users.

Refs #9159
