### PR TITLE
Make the test harness require python 2.7

### DIFF
--- a/modules/chemical_reactions/run_tests
+++ b/modules/chemical_reactions/run_tests
@@ -10,7 +10,7 @@ app_name = 'chemical_reactions'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/combined/run_tests
+++ b/modules/combined/run_tests
@@ -10,7 +10,7 @@ app_name = 'combined'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/contact/run_tests
+++ b/modules/contact/run_tests
@@ -10,7 +10,7 @@ app_name = 'contact'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/fluid_properties/run_tests
+++ b/modules/fluid_properties/run_tests
@@ -10,7 +10,7 @@ app_name = 'fluid_properties'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/heat_conduction/run_tests
+++ b/modules/heat_conduction/run_tests
@@ -10,7 +10,7 @@ app_name = 'heat_conduction'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/level_set/run_tests
+++ b/modules/level_set/run_tests
@@ -10,7 +10,7 @@ app_name = 'level_set'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/misc/run_tests
+++ b/modules/misc/run_tests
@@ -10,7 +10,7 @@ app_name = 'misc'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/navier_stokes/run_tests
+++ b/modules/navier_stokes/run_tests
@@ -10,7 +10,7 @@ app_name = 'navier_stokes'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/phase_field/run_tests
+++ b/modules/phase_field/run_tests
@@ -10,7 +10,7 @@ app_name = 'phase_field'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/porous_flow/run_tests
+++ b/modules/porous_flow/run_tests
@@ -10,7 +10,7 @@ app_name = 'porous_flow'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/rdg/run_tests
+++ b/modules/rdg/run_tests
@@ -10,7 +10,7 @@ app_name = 'rdg'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/richards/run_tests
+++ b/modules/richards/run_tests
@@ -10,7 +10,7 @@ app_name = 'richards'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/run_tests
+++ b/modules/run_tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import sys, os, inspect
+import sys, os
 
 # Set the current working directory to the directory where this script is located
 os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
@@ -10,7 +10,7 @@ app_name = 'combined/combined'
 MODULE_DIR = os.path.abspath('.')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/solid_mechanics/run_tests
+++ b/modules/solid_mechanics/run_tests
@@ -10,7 +10,7 @@ app_name = 'solid_mechanics'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/stochastic_tools/run_tests
+++ b/modules/stochastic_tools/run_tests
@@ -10,7 +10,7 @@ app_name = 'stochastic_tools'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/tensor_mechanics/run_tests
+++ b/modules/tensor_mechanics/run_tests
@@ -10,7 +10,7 @@ app_name = 'tensor_mechanics'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/water_steam_eos/run_tests
+++ b/modules/water_steam_eos/run_tests
@@ -10,7 +10,7 @@ app_name = 'water_steam_eos'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/modules/xfem/run_tests
+++ b/modules/xfem/run_tests
@@ -10,7 +10,7 @@ app_name = 'xfem'
 MODULE_DIR = os.path.abspath('..')
 MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/python/path_tool.py
+++ b/python/path_tool.py
@@ -10,7 +10,7 @@ def activate_module(module):
     module_dir = os.path.join(base_dir, module)
 
     if not os.path.exists(module_dir):
-        print '"' + module_dir + '" is not a valid module'
+        print('"' + module_dir + '" is not a valid module')
         sys.exit(1)
 
     # Add all directories within the requested module to the system path

--- a/python/run_tests
+++ b/python/run_tests
@@ -10,7 +10,7 @@ app_name = 'moose_python'
 
 MOOSE_DIR = os.path.abspath(os.path.join('..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
     MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))

--- a/test/run_tests
+++ b/test/run_tests
@@ -9,7 +9,7 @@ app_name = 'moose_test'
 
 MOOSE_DIR = os.path.abspath(os.path.join('..'))
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
@@ -21,6 +21,6 @@ path_tool.activate_module('TestHarness')
 # Append error flag when running tests
 sys.argv.insert(1, "--error")
 
-from TestHarness import TestHarness
 # Run the tests!
+from TestHarness import TestHarness
 TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step01_diffusion/run_tests
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/run_tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import sys, os, inspect
+import sys, os
 
 # Set the current working directory to the directory where this script is located
 os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
@@ -13,7 +13,7 @@ MOOSE_DIR = os.path.abspath(os.path.join('..', '..', '..'))
 if os.path.exists(os.path.abspath(os.path.join('moose', 'framework', 'Makefile'))):
   MOOSE_DIR = os.path.abspath('moose')
 #### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
+if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))


### PR DESCRIPTION
This just adds a hard check in TestHarness to make sure we are running with python 2.7.
For python 3, `run_tests` wasn't even getting to the check due to `has_key` and old style `print` (without parenthesis) being removed.
Python 3 compatible changes were made just enough so that `python3 run_tests` hits the check.

closes #9326 #4169

We might still run into problems in subscripts (for example `analyzejacobian.py`). For example, if the default python is python 3 and somebody runs `python2.7 run_tests`, other python scripts that use `#!/usr/bin/env python` would still use python 3.