### PR TITLE
Modify Jacobian tests for brineco2 and waterncg

### DIFF
--- a/modules/porous_flow/tests/jacobian/brineco2_gas.i
+++ b/modules/porous_flow/tests/jacobian/brineco2_gas.i
@@ -1,0 +1,189 @@
+# Tests correct calculation of properties derivatives in PorousFlowFluidStateBrineCO2
+# for conditions that give a single gas phase
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+  gravity = '0 0 0'
+[]
+
+[AuxVariables]
+  [./xnacl]
+    initial_condition = 0.05
+  [../]
+[]
+
+[Variables]
+  [./pgas]
+  [../]
+  [./zi]
+  [../]
+[]
+
+[ICs]
+  [./pgas]
+    type = RandomIC
+    min = 5e4
+    max = 1e5
+    variable = pgas
+  [../]
+  [./z]
+    type = RandomIC
+    min = 0.9
+    max = 0.99
+    variable = zi
+  [../]
+[]
+
+[Kernels]
+  [./mass0]
+    type = PorousFlowMassTimeDerivative
+    variable = pgas
+    fluid_component = 0
+  [../]
+  [./mass1]
+    type = PorousFlowMassTimeDerivative
+    variable = zi
+    fluid_component = 1
+  [../]
+  [./adv0]
+    type = PorousFlowAdvectiveFlux
+    variable = pgas
+    fluid_component = 0
+  [../]
+  [./adv1]
+    type = PorousFlowAdvectiveFlux
+    variable = zi
+    fluid_component = 1
+  [../]
+[]
+
+[UserObjects]
+  [./dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pgas zi'
+    number_fluid_phases = 2
+    number_fluid_components = 2
+  [../]
+[]
+
+[Modules]
+  [./FluidProperties]
+    [./co2]
+      type = CO2FluidProperties
+    [../]
+    [./brine]
+      type = BrineFluidProperties
+    [../]
+    [./water]
+      type = Water97FluidProperties
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./temperature]
+    type = PorousFlowTemperature
+    temperature = 50
+  [../]
+  [./temperature_nodal]
+    type = PorousFlowTemperature
+    temperature = 50
+    at_nodes = true
+  [../]
+  [./brineco2]
+    type = PorousFlowFluidStateBrineCO2
+    gas_porepressure = pgas
+    z = zi
+    co2_fp = co2
+    brine_fp = brine
+    at_nodes = true
+    temperature_unit = Celsius
+    xnacl = xnacl
+  [../]
+  [./brineco2_qp]
+    type = PorousFlowFluidStateBrineCO2
+    gas_porepressure = pgas
+    z = zi
+    co2_fp = co2
+    brine_fp = brine
+    temperature_unit = Celsius
+    xnacl = xnacl
+  [../]
+  [./permeability]
+    type = PorousFlowPermeabilityConst
+    permeability = '1e-12 0 0 0 1e-12 0 0 0 1e-12'
+  [../]
+  [./relperm0]
+    type = PorousFlowRelativePermeabilityCorey
+    n = 2
+    phase = 0
+    at_nodes = true
+  [../]
+  [./relperm1]
+    type = PorousFlowRelativePermeabilityCorey
+    n = 3
+    phase = 1
+    at_nodes = true
+  [../]
+  [./relperm_all]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_relative_permeability_nodal
+    at_nodes = true
+  [../]
+  [./porosity]
+    type = PorousFlowPorosityConst
+    porosity = 0.1
+    at_nodes = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  dt = 1
+  end_time = 1
+  nl_abs_tol = 1e-12
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[AuxVariables]
+  [./sgas]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+[]
+
+[AuxKernels]
+  [./sgas]
+    type = PorousFlowPropertyAux
+    property = saturation
+    phase = 1
+    variable = sgas
+  [../]
+[]
+
+[Postprocessors]
+  [./sgas_min]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = min
+  [../]
+  [./sgas_max]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = max
+  [../]
+[]

--- a/modules/porous_flow/tests/jacobian/brineco2_liquid.i
+++ b/modules/porous_flow/tests/jacobian/brineco2_liquid.i
@@ -1,0 +1,189 @@
+# Tests correct calculation of properties derivatives in PorousFlowFluidStateBrineCO2
+# for conditions that give a single liquid phase
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+  gravity = '0 0 0'
+[]
+
+[AuxVariables]
+  [./xnacl]
+    initial_condition = 0.05
+  [../]
+[]
+
+[Variables]
+  [./pgas]
+  [../]
+  [./zi]
+  [../]
+[]
+
+[ICs]
+  [./pgas]
+    type = RandomIC
+    min = 5e6
+    max = 8e6
+    variable = pgas
+  [../]
+  [./z_liquid]
+    type = RandomIC
+    min = 0.01
+    max = 0.03
+    variable = zi
+  [../]
+[]
+
+[Kernels]
+  [./mass0]
+    type = PorousFlowMassTimeDerivative
+    variable = pgas
+    fluid_component = 0
+  [../]
+  [./mass1]
+    type = PorousFlowMassTimeDerivative
+    variable = zi
+    fluid_component = 1
+  [../]
+  [./adv0]
+    type = PorousFlowAdvectiveFlux
+    variable = pgas
+    fluid_component = 0
+  [../]
+  [./adv1]
+    type = PorousFlowAdvectiveFlux
+    variable = zi
+    fluid_component = 1
+  [../]
+[]
+
+[UserObjects]
+  [./dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pgas zi'
+    number_fluid_phases = 2
+    number_fluid_components = 2
+  [../]
+[]
+
+[Modules]
+  [./FluidProperties]
+    [./co2]
+      type = CO2FluidProperties
+    [../]
+    [./brine]
+      type = BrineFluidProperties
+    [../]
+    [./water]
+      type = Water97FluidProperties
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./temperature]
+    type = PorousFlowTemperature
+    temperature = 50
+  [../]
+  [./temperature_nodal]
+    type = PorousFlowTemperature
+    temperature = 50
+    at_nodes = true
+  [../]
+  [./brineco2]
+    type = PorousFlowFluidStateBrineCO2
+    gas_porepressure = pgas
+    z = zi
+    co2_fp = co2
+    brine_fp = brine
+    at_nodes = true
+    temperature_unit = Celsius
+    xnacl = xnacl
+  [../]
+  [./brineco2_qp]
+    type = PorousFlowFluidStateBrineCO2
+    gas_porepressure = pgas
+    z = zi
+    co2_fp = co2
+    brine_fp = brine
+    temperature_unit = Celsius
+    xnacl = xnacl
+  [../]
+  [./permeability]
+    type = PorousFlowPermeabilityConst
+    permeability = '1e-12 0 0 0 1e-12 0 0 0 1e-12'
+  [../]
+  [./relperm0]
+    type = PorousFlowRelativePermeabilityCorey
+    n = 2
+    phase = 0
+    at_nodes = true
+  [../]
+  [./relperm1]
+    type = PorousFlowRelativePermeabilityCorey
+    n = 3
+    phase = 1
+    at_nodes = true
+  [../]
+  [./relperm_all]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_relative_permeability_nodal
+    at_nodes = true
+  [../]
+  [./porosity]
+    type = PorousFlowPorosityConst
+    porosity = 0.1
+    at_nodes = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  dt = 1
+  end_time = 1
+  nl_abs_tol = 1e-12
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[AuxVariables]
+  [./sgas]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+[]
+
+[AuxKernels]
+  [./sgas]
+    type = PorousFlowPropertyAux
+    property = saturation
+    phase = 1
+    variable = sgas
+  [../]
+[]
+
+[Postprocessors]
+  [./sgas_min]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = min
+  [../]
+  [./sgas_max]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = max
+  [../]
+[]

--- a/modules/porous_flow/tests/jacobian/brineco2_twophase.i
+++ b/modules/porous_flow/tests/jacobian/brineco2_twophase.i
@@ -1,13 +1,11 @@
-# Tests correct calculation of properties derivatives in PorousFlowFluidStateBrineCO2.
-# This test is run three times, with the initial condition of z (the total mass
-# fraction of CO2 in all phases) varied to give either a single phase liquid, a
-# single phase gas, or two phases.
+# Tests correct calculation of properties derivatives in PorousFlowFluidStateBrineCO2
+# for conditions that are appropriate for two phases
 
 [Mesh]
   type = GeneratedMesh
   dim = 2
-  nx = 1
-  ny = 1
+  nx = 2
+  ny = 2
 []
 
 [GlobalParams]
@@ -29,29 +27,16 @@
 []
 
 [ICs]
-  active = 'pgas z_twophase'
   [./pgas]
     type = RandomIC
     min = 1e6
-    max = 2e6
+    max = 4e6
     variable = pgas
   [../]
-  [./z_twophase]
+  [./z]
     type = RandomIC
     min = 0.2
     max = 0.8
-    variable = zi
-  [../]
-  [./z_liquid]
-    type = RandomIC
-    min = 0.001
-    max = 0.005
-    variable = zi
-  [../]
-  [./z_gas]
-    type = RandomIC
-    min = 0.995
-    max = 0.999
     variable = zi
   [../]
 []
@@ -171,5 +156,34 @@
   [./smp]
     type = SMP
     full = true
+  [../]
+[]
+
+[AuxVariables]
+  [./sgas]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+[]
+
+[AuxKernels]
+  [./sgas]
+    type = PorousFlowPropertyAux
+    property = saturation
+    phase = 1
+    variable = sgas
+  [../]
+[]
+
+[Postprocessors]
+  [./sgas_min]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = min
+  [../]
+  [./sgas_max]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = max
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/tests
+++ b/modules/porous_flow/tests/jacobian/tests
@@ -394,43 +394,44 @@
 
   [./waterncg_twophase]
     type = 'PetscJacobianTester'
-    input = 'waterncg.i'
-    ratio_tol = 1e-5 # Lots of chain rule derivatives
+    input = 'waterncg_twophase.i'
+    ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds'
   [../]
   [./waterncg_liqiud]
     type = 'PetscJacobianTester'
-    input = 'waterncg.i'
-    ratio_tol = 1e-8
+    input = 'waterncg_liquid.i'
+    ratio_tol = 1e-6
     difference_tol = 1e10
-    cli_args = 'ICs/active='pgas z_liquid''
+    cli_args = '-mat_fd_type ds'
   [../]
   [./waterncg_gas]
     type = 'PetscJacobianTester'
-    input = 'waterncg.i'
+    input = 'waterncg_gas.i'
     ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
-    cli_args = 'ICs/active='pgas z_gas' -mat_fd_type ds'
+    cli_args = '-mat_fd_type ds'
   [../]
   [./brineco2_twophase]
     type = 'PetscJacobianTester'
-    input = 'brineco2.i'
-    ratio_tol = 1e-5 # Lots of chain rule derivatives
+    input = 'brineco2_twophase.i'
+    ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds'
   [../]
   [./brineco2_liquid]
     type = 'PetscJacobianTester'
-    input = 'brineco2.i'
-    ratio_tol = 1e-5 # Lots of chain rule derivatives
+    input = 'brineco2_liquid.i'
+    ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
-    cli_args = 'ICs/active='pgas z_liquid''
+    cli_args = '-mat_fd_type ds'
   [../]
   [./brineco2_gas]
     type = 'PetscJacobianTester'
-    input = 'brineco2.i'
+    input = 'brineco2_gas.i'
+    ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
-    cli_args = 'ICs/active='pgas z_gas' -mat_fd_type ds'
+    cli_args = '-mat_fd_type ds'
   [../]
 []

--- a/modules/porous_flow/tests/jacobian/waterncg_gas.i
+++ b/modules/porous_flow/tests/jacobian/waterncg_gas.i
@@ -1,0 +1,178 @@
+# Tests correct calculation of properties derivatives in PorousFlowFluidStateWaterNCG
+# for conditions that give a single gas phase
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+  gravity = '0 0 0'
+[]
+
+[Variables]
+  [./pgas]
+  [../]
+  [./z]
+  [../]
+[]
+
+[ICs]
+  [./pgas]
+    type = RandomIC
+    min = 3e4
+    max = 1e5
+    variable = pgas
+  [../]
+  [./z]
+    type = RandomIC
+    min = 0.88
+    max = 0.98
+    variable = z
+  [../]
+[]
+
+[Kernels]
+  [./mass0]
+    type = PorousFlowMassTimeDerivative
+    variable = pgas
+    fluid_component = 0
+  [../]
+  [./mass1]
+    type = PorousFlowMassTimeDerivative
+    variable = z
+    fluid_component = 1
+  [../]
+  [./adv0]
+    type = PorousFlowAdvectiveFlux
+    variable = pgas
+    fluid_component = 0
+  [../]
+  [./adv1]
+    type = PorousFlowAdvectiveFlux
+    variable = z
+    fluid_component = 1
+  [../]
+[]
+
+[UserObjects]
+  [./dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pgas z'
+    number_fluid_phases = 2
+    number_fluid_components = 2
+  [../]
+[]
+
+[Modules]
+  [./FluidProperties]
+    [./co2]
+      type = CO2FluidProperties
+    [../]
+    [./water]
+      type = Water97FluidProperties
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./temperature]
+    type = PorousFlowTemperature
+    temperature = 50
+  [../]
+  [./temperature_nodal]
+    type = PorousFlowTemperature
+    temperature = 50
+    at_nodes = true
+  [../]
+  [./waterncg]
+    type = PorousFlowFluidStateWaterNCG
+    gas_porepressure = pgas
+    z = z
+    gas_fp = co2
+    water_fp = water
+    at_nodes = true
+    temperature_unit = Celsius
+  [../]
+  [./waterncg_qp]
+    type = PorousFlowFluidStateWaterNCG
+    gas_porepressure = pgas
+    z = z
+    gas_fp = co2
+    water_fp = water
+    temperature_unit = Celsius
+  [../]
+  [./permeability]
+    type = PorousFlowPermeabilityConst
+    permeability = '1e-12 0 0 0 1e-12 0 0 0 1e-12'
+  [../]
+  [./relperm0]
+    type = PorousFlowRelativePermeabilityCorey
+    n = 2
+    phase = 0
+    at_nodes = true
+  [../]
+  [./relperm1]
+    type = PorousFlowRelativePermeabilityCorey
+    n = 3
+    phase = 1
+    at_nodes = true
+  [../]
+  [./relperm_all]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_relative_permeability_nodal
+    at_nodes = true
+  [../]
+  [./porosity]
+    type = PorousFlowPorosityConst
+    porosity = 0.1
+    at_nodes = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  dt = 1
+  end_time = 1
+  nl_abs_tol = 1e-12
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[AuxVariables]
+  [./sgas]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+[]
+
+[AuxKernels]
+  [./sgas]
+    type = PorousFlowPropertyAux
+    property = saturation
+    phase = 1
+    variable = sgas
+  [../]
+[]
+
+[Postprocessors]
+  [./sgas_min]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = min
+  [../]
+  [./sgas_max]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = max
+  [../]
+[]

--- a/modules/porous_flow/tests/jacobian/waterncg_liquid.i
+++ b/modules/porous_flow/tests/jacobian/waterncg_liquid.i
@@ -1,0 +1,178 @@
+# Tests correct calculation of properties derivatives in PorousFlowFluidStateWaterNCG
+# for conditions that give a single liquid phase
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+  gravity = '0 0 0'
+[]
+
+[Variables]
+  [./pgas]
+  [../]
+  [./z]
+  [../]
+[]
+
+[ICs]
+  [./pgas]
+    type = RandomIC
+    min = 6e6
+    max = 8e6
+    variable = pgas
+  [../]
+  [./z]
+    type = RandomIC
+    min = 0.01
+    max = 0.05
+    variable = z
+  [../]
+[]
+
+[Kernels]
+  [./mass0]
+    type = PorousFlowMassTimeDerivative
+    variable = pgas
+    fluid_component = 0
+  [../]
+  [./mass1]
+    type = PorousFlowMassTimeDerivative
+    variable = z
+    fluid_component = 1
+  [../]
+  [./adv0]
+    type = PorousFlowAdvectiveFlux
+    variable = pgas
+    fluid_component = 0
+  [../]
+  [./adv1]
+    type = PorousFlowAdvectiveFlux
+    variable = z
+    fluid_component = 1
+  [../]
+[]
+
+[UserObjects]
+  [./dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pgas z'
+    number_fluid_phases = 2
+    number_fluid_components = 2
+  [../]
+[]
+
+[Modules]
+  [./FluidProperties]
+    [./co2]
+      type = CO2FluidProperties
+    [../]
+    [./water]
+      type = Water97FluidProperties
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./temperature]
+    type = PorousFlowTemperature
+    temperature = 50
+  [../]
+  [./temperature_nodal]
+    type = PorousFlowTemperature
+    temperature = 50
+    at_nodes = true
+  [../]
+  [./waterncg]
+    type = PorousFlowFluidStateWaterNCG
+    gas_porepressure = pgas
+    z = z
+    gas_fp = co2
+    water_fp = water
+    at_nodes = true
+    temperature_unit = Celsius
+  [../]
+  [./waterncg_qp]
+    type = PorousFlowFluidStateWaterNCG
+    gas_porepressure = pgas
+    z = z
+    gas_fp = co2
+    water_fp = water
+    temperature_unit = Celsius
+  [../]
+  [./permeability]
+    type = PorousFlowPermeabilityConst
+    permeability = '1e-12 0 0 0 1e-12 0 0 0 1e-12'
+  [../]
+  [./relperm0]
+    type = PorousFlowRelativePermeabilityCorey
+    n = 2
+    phase = 0
+    at_nodes = true
+  [../]
+  [./relperm1]
+    type = PorousFlowRelativePermeabilityCorey
+    n = 3
+    phase = 1
+    at_nodes = true
+  [../]
+  [./relperm_all]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_relative_permeability_nodal
+    at_nodes = true
+  [../]
+  [./porosity]
+    type = PorousFlowPorosityConst
+    porosity = 0.1
+    at_nodes = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  dt = 1
+  end_time = 1
+  nl_abs_tol = 1e-12
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[AuxVariables]
+  [./sgas]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+[]
+
+[AuxKernels]
+  [./sgas]
+    type = PorousFlowPropertyAux
+    property = saturation
+    phase = 1
+    variable = sgas
+  [../]
+[]
+
+[Postprocessors]
+  [./sgas_min]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = min
+  [../]
+  [./sgas_max]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = max
+  [../]
+[]

--- a/modules/porous_flow/tests/jacobian/waterncg_twophase.i
+++ b/modules/porous_flow/tests/jacobian/waterncg_twophase.i
@@ -1,7 +1,5 @@
-# Tests correct calculation of properties derivatives in PorousFlowFluidStateWaterNCG.
-# This test is run three times, with the initial condition of z (the total mass
-# fraction of NCG in all phases) varied to give either a single phase liquid, a
-# single phase gas, or two phases.
+# Tests correct calculation of properties derivatives in PorousFlowFluidStateWaterNCG
+# for conditions for two phases
 
 [Mesh]
   type = GeneratedMesh
@@ -23,29 +21,16 @@
 []
 
 [ICs]
-  active = 'pgas z_twophase'
   [./pgas]
     type = RandomIC
     min = 1e5
-    max = 2e5
+    max = 5e5
     variable = pgas
   [../]
-  [./z_twophase]
+  [./z]
     type = RandomIC
-    min = 0.2
-    max = 0.8
-    variable = z
-  [../]
-  [./z_liquid]
-    type = RandomIC
-    min = 0.0001
-    max = 0.0005
-    variable = z
-  [../]
-  [./z_gas]
-    type = RandomIC
-    min = 0.97
-    max = 0.99
+    min = 0.01
+    max = 0.2
     variable = z
   [../]
 []
@@ -160,5 +145,34 @@
   [./smp]
     type = SMP
     full = true
+  [../]
+[]
+
+[AuxVariables]
+  [./sgas]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
+[]
+
+[AuxKernels]
+  [./sgas]
+    type = PorousFlowPropertyAux
+    property = saturation
+    phase = 1
+    variable = sgas
+  [../]
+[]
+
+[Postprocessors]
+  [./sgas_min]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = min
+  [../]
+  [./sgas_max]
+    type = ElementExtremeValue
+    variable = sgas
+    value_type = max
   [../]
 []


### PR DESCRIPTION
Tweak the variable values for these tests so that the finite difference Jacobian calculation on Pearcey and intel boxes is correctly calculated. 

I ended up duplicating the tests for each of gas, liquid and two phase regimes, as it was getting messy changing several values on the command line. 

This works on Pearcey, and hopefully passes here as well

Fixes #9286
