### PR TITLE
Improving app revision generation

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -104,7 +104,7 @@ app_EXEC    := $(APPLICATION_DIR)/$(APPLICATION_NAME)-$(METHOD)
 # revision header
 CAMEL_CASE_NAME := $(shell echo $(APPLICATION_NAME) | perl -pe 's/(?:^|_)([a-z])/\u$$1/g')
 app_BASE_DIR    ?= base/
-app_HEADER      := $(APPLICATION_DIR)/include/$(app_BASE_DIR)$(CAMEL_CASE_NAME)Revision.h
+app_HEADER      ?= $(APPLICATION_DIR)/include/$(app_BASE_DIR)$(CAMEL_CASE_NAME)Revision.h
 # depend modules
 depend_libs  := $(foreach i, $(DEPEND_MODULES), $(MOOSE_DIR)/modules/$(i)/lib/lib$(i)-$(METHOD).la)
 


### PR DESCRIPTION
1) Allow applications to define their own header file name for revisions.
   Mostly to avoid convoluted logic of converting app name to a valid
   file name.
2) Generate <APP_NAME>_VERSION macro to provide just the version. It
   based on the tag, or SHA1 hash if not on tagged revision.
3) Drop special characters from an application name, so that correct
   preprocessor identifier is generated.

Closes #9341