### PR TITLE
Nonlinear eigenvalue solver interface

### DIFF
--- a/framework/include/base/ComputeFullJacobianThread.h
+++ b/framework/include/base/ComputeFullJacobianThread.h
@@ -24,7 +24,9 @@ class NonlinearSystemBase;
 class ComputeFullJacobianThread : public ComputeJacobianThread
 {
 public:
-  ComputeFullJacobianThread(FEProblemBase & fe_problem, SparseMatrix<Number> & jacobian);
+  ComputeFullJacobianThread(FEProblemBase & fe_problem,
+                            SparseMatrix<Number> & jacobian,
+                            Moose::KernelType kernel_type = Moose::KT_ALL);
 
   // Splitting Constructor
   ComputeFullJacobianThread(ComputeFullJacobianThread & x, Threads::split split);
@@ -50,8 +52,9 @@ protected:
   // Reference to interface kernel storage
   const MooseObjectWarehouse<InterfaceKernel> & _interface_kernels;
 
-  // Reference to Kernel storage
-  const KernelWarehouse & _kernels;
+  Moose::KernelType _kernel_type;
+
+  const KernelWarehouse * _warehouse;
 };
 
 #endif // COMPUTEFULLJACOBIANTHREAD_H

--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -548,7 +548,7 @@ protected:
    * Enforces nodal boundary conditions
    * @param residual Residual where nodal BCs are enforced (input/output)
    */
-  void computeNodalBCs(NumericVector<Number> & residual);
+  void computeNodalBCs(NumericVector<Number> & residual, Moose::KernelType type = Moose::KT_ALL);
 
   void computeJacobianInternal(SparseMatrix<Number> & jacobian, Moose::KernelType kernel_type);
 

--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -484,13 +484,10 @@ public:
    * Access functions to Warehouses from outside NonlinearSystemBase
    */
   const KernelWarehouse & getKernelWarehouse() { return _kernels; }
-  const MooseObjectWarehouse<KernelBase> & getTimeKernelWarehouse() { return _time_kernels; }
-  const MooseObjectWarehouse<KernelBase> & getNonTimeKernelWarehouse() { return _non_time_kernels; }
-  const MooseObjectWarehouse<KernelBase> & getEigenKernelWarehouse() { return _eigen_kernels; }
-  const MooseObjectWarehouse<KernelBase> & getNonEigenKernelWarehouse()
-  {
-    return _non_eigen_kernels;
-  }
+  const KernelWarehouse & getTimeKernelWarehouse() { return _time_kernels; }
+  const KernelWarehouse & getNonTimeKernelWarehouse() { return _non_time_kernels; }
+  const KernelWarehouse & getEigenKernelWarehouse() { return _eigen_kernels; }
+  const KernelWarehouse & getNonEigenKernelWarehouse() { return _non_eigen_kernels; }
   const MooseObjectWarehouse<DGKernel> & getDGKernelWarehouse() { return _dg_kernels; }
   const MooseObjectWarehouse<InterfaceKernel> & getInterfaceKernelWarehouse()
   {
@@ -598,10 +595,10 @@ protected:
   MooseObjectWarehouse<ScalarKernel> _non_time_scalar_kernels;
   MooseObjectWarehouse<DGKernel> _dg_kernels;
   MooseObjectWarehouse<InterfaceKernel> _interface_kernels;
-  MooseObjectWarehouse<KernelBase> _time_kernels;
-  MooseObjectWarehouse<KernelBase> _non_time_kernels;
-  MooseObjectWarehouse<KernelBase> _eigen_kernels;
-  MooseObjectWarehouse<KernelBase> _non_eigen_kernels;
+  KernelWarehouse _time_kernels;
+  KernelWarehouse _non_time_kernels;
+  KernelWarehouse _eigen_kernels;
+  KernelWarehouse _non_eigen_kernels;
 
   ///@}
 

--- a/framework/include/bcs/NodalBC.h
+++ b/framework/include/bcs/NodalBC.h
@@ -46,6 +46,8 @@ public:
   virtual void computeJacobian();
   virtual void computeOffDiagJacobian(unsigned int jvar);
 
+  void setBCOnEigen(bool iseigen) { _is_eigen = iseigen; }
+
 protected:
   /// current node being processed
   const Node *& _current_node;
@@ -64,6 +66,10 @@ protected:
   bool _has_diag_save_in;
   std::vector<MooseVariable *> _diag_save_in;
   std::vector<AuxVariableName> _diag_save_in_strings;
+
+  /// Indicate whether or not the boundary condition is applied to the right
+  /// hand side of eigenvalue problems
+  bool _is_eigen;
 
   virtual Real computeQpResidual() = 0;
 

--- a/framework/include/kernels/CoupledForce.h
+++ b/framework/include/kernels/CoupledForce.h
@@ -41,6 +41,7 @@ protected:
 private:
   unsigned int _v_var;
   const VariableValue & _v;
+  Real _coef;
 };
 
 #endif // COUPLEDFORCE_H

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -255,12 +255,14 @@ enum SolveType
  */
 enum EigenSolveType
 {
-  EST_POWER,           ///< Power / Inverse / RQI
-  EST_ARNOLDI,         ///< Arnoldi
-  EST_KRYLOVSCHUR,     ///< Krylov-Schur
-  EST_JACOBI_DAVIDSON, ///< Jacobi-Davidson
-  EST_NONLINEAR_POWER, ///< Nonlinear inverse power
-  EST_MONOLITH_NEWTON  ///< Newton-based eigen solver
+  EST_POWER,              ///< Power / Inverse / RQI
+  EST_ARNOLDI,            ///< Arnoldi
+  EST_KRYLOVSCHUR,        ///< Krylov-Schur
+  EST_JACOBI_DAVIDSON,    ///< Jacobi-Davidson
+  EST_NONLINEAR_POWER,    ///< Nonlinear inverse power
+  EST_MF_NONLINEAR_POWER, ///< Matrix-free nonlinear inverse power
+  EST_MONOLITH_NEWTON,    ///< Newton-based eigen solver
+  EST_MF_MONOLITH_NEWTON, ///< Matrix-free Newton-based eigen solver
 };
 
 /**

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -255,10 +255,12 @@ enum SolveType
  */
 enum EigenSolveType
 {
-  EST_POWER,          ///< Power / Inverse / RQI
-  EST_ARNOLDI,        ///< Arnoldi
-  EST_KRYLOVSCHUR,    ///< Krylov-Schur
-  EST_JACOBI_DAVIDSON ///< Jacobi-Davidson
+  EST_POWER,           ///< Power / Inverse / RQI
+  EST_ARNOLDI,         ///< Arnoldi
+  EST_KRYLOVSCHUR,     ///< Krylov-Schur
+  EST_JACOBI_DAVIDSON, ///< Jacobi-Davidson
+  EST_NONLINEAR_POWER, ///< Nonlinear inverse power
+  EST_MONOLITH_NEWTON  ///< Newton-based eigen solver
 };
 
 /**

--- a/framework/include/utils/SlepcSupport.h
+++ b/framework/include/utils/SlepcSupport.h
@@ -39,6 +39,11 @@ InputParameters getSlepcEigenProblemValidParams();
 void storeSlepcOptions(FEProblemBase & fe_problem, const InputParameters & params);
 void storeSlepcEigenProblemOptions(EigenProblem & eigen_problem, const InputParameters & params);
 void slepcSetOptions(FEProblemBase & problem);
+
+PetscErrorCode mooseSlepcEigenFormJacobianA(SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
+PetscErrorCode mooseSlepcEigenFormJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
+PetscErrorCode mooseSlepcEigenFormFunctionA(SNES snes, Vec x, Vec r, void * ctx);
+PetscErrorCode mooseSlepcEigenFormFunctionB(SNES snes, Vec x, Vec r, void * ctx);
 } // namespace SlepcSupport
 } // namespace moose
 

--- a/framework/src/base/NonlinearEigenSystem.C
+++ b/framework/src/base/NonlinearEigenSystem.C
@@ -21,6 +21,7 @@
 #include "KernelBase.h"
 #include "NodalBC.h"
 #include "TimeIntegrator.h"
+#include "SlepcSupport.h"
 
 // libmesh includes
 #include "libmesh/eigen_system.h"
@@ -42,14 +43,46 @@ assemble_matrix(EquationSystems & es, const std::string & system_name)
   p->computeJacobian(
       *eigen_system.current_local_solution.get(), *eigen_system.matrix_A, Moose::KT_NONEIGEN);
 
+  Mat petsc_mat_A = static_cast<PetscMatrix<Number> &>(*eigen_system.matrix_A).mat();
+
+  PetscObjectComposeFunction(
+      (PetscObject)petsc_mat_A, "formJacobian", Moose::SlepcSupport::mooseSlepcEigenFormJacobianA);
+  PetscObjectComposeFunction(
+      (PetscObject)petsc_mat_A, "formFunction", Moose::SlepcSupport::mooseSlepcEigenFormFunctionA);
+
+  PetscContainer container;
+  PetscContainerCreate(eigen_system.comm().get(), &container);
+  PetscContainerSetPointer(container, p);
+  PetscObjectCompose((PetscObject)petsc_mat_A, "formJacobianCtx", nullptr);
+  PetscObjectCompose((PetscObject)petsc_mat_A, "formJacobianCtx", (PetscObject)container);
+  PetscObjectCompose((PetscObject)petsc_mat_A, "formFunctionCtx", nullptr);
+  PetscObjectCompose((PetscObject)petsc_mat_A, "formFunctionCtx", (PetscObject)container);
+
   if (eigen_system.generalized())
   {
     if (eigen_system.matrix_B)
+    {
       p->computeJacobian(
           *eigen_system.current_local_solution.get(), *eigen_system.matrix_B, Moose::KT_EIGEN);
+
+      Mat petsc_mat_B = static_cast<PetscMatrix<Number> &>(*eigen_system.matrix_B).mat();
+
+      PetscObjectComposeFunction((PetscObject)petsc_mat_B,
+                                 "formJacobian",
+                                 Moose::SlepcSupport::mooseSlepcEigenFormJacobianB);
+      PetscObjectComposeFunction((PetscObject)petsc_mat_B,
+                                 "formFunction",
+                                 Moose::SlepcSupport::mooseSlepcEigenFormFunctionB);
+
+      PetscObjectCompose((PetscObject)petsc_mat_B, "formFunctionCtx", nullptr);
+      PetscObjectCompose((PetscObject)petsc_mat_B, "formFunctionCtx", (PetscObject)container);
+      PetscObjectCompose((PetscObject)petsc_mat_B, "formJacobianCtx", nullptr);
+      PetscObjectCompose((PetscObject)petsc_mat_B, "formJacobianCtx", (PetscObject)container);
+    }
     else
       mooseError("It is a generalized eigenvalue problem but matrix B is empty\n");
   }
+  PetscContainerDestroy(&container);
 }
 }
 

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -1851,7 +1851,7 @@ NonlinearSystemBase::computeJacobianInternal(SparseMatrix<Number> & jacobian,
       default:
       case Moose::COUPLING_CUSTOM:
       {
-        ComputeFullJacobianThread cj(_fe_problem, jacobian);
+        ComputeFullJacobianThread cj(_fe_problem, jacobian, kernel_type);
         Threads::parallel_reduce(elem_range, cj);
         unsigned int n_threads = libMesh::n_threads();
 

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -547,7 +547,7 @@ NonlinearSystemBase::computeResidual(NumericVector<Number> & residual, Moose::Ke
       residual += *_Re_non_time;
     residual.close();
 
-    computeNodalBCs(residual);
+    computeNodalBCs(residual, type);
 
     // If we are debugging residuals we need one more assignment to have the ghosted copy up to date
     if (_need_residual_ghosted && _debugging_residuals)
@@ -1231,7 +1231,8 @@ NonlinearSystemBase::computeResidualInternal(Moose::KernelType type)
 }
 
 void
-NonlinearSystemBase::computeNodalBCs(NumericVector<Number> & residual)
+NonlinearSystemBase::computeNodalBCs(NumericVector<Number> & residual,
+                                     Moose::KernelType kernel_type)
 {
   // We need to close the diag_save_in variables on the aux system before NodalBCs clear the dofs on
   // boundary nodes
@@ -1261,7 +1262,14 @@ NonlinearSystemBase::computeNodalBCs(NumericVector<Number> & residual)
             const auto & bcs = _nodal_bcs.getActiveBoundaryObjects(boundary_id);
             for (const auto & nbc : bcs)
               if (nbc->shouldApply())
+              {
+                if (kernel_type == Moose::KT_EIGEN)
+                  nbc->setBCOnEigen(true);
+                else
+                  nbc->setBCOnEigen(false);
+
                 nbc->computeResidual(residual);
+              }
           }
         }
       }

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -45,7 +45,8 @@ NodalBC::NodalBC(const InputParameters & parameters)
     _current_node(_var.node()),
     _u(_var.nodalSln()),
     _save_in_strings(parameters.get<std::vector<AuxVariableName>>("save_in")),
-    _diag_save_in_strings(parameters.get<std::vector<AuxVariableName>>("diag_save_in"))
+    _diag_save_in_strings(parameters.get<std::vector<AuxVariableName>>("diag_save_in")),
+    _is_eigen(false)
 {
   _save_in.resize(_save_in_strings.size());
   _diag_save_in.resize(_diag_save_in_strings.size());
@@ -90,7 +91,11 @@ NodalBC::computeResidual(NumericVector<Number> & residual)
   {
     dof_id_type & dof_idx = _var.nodalDofIndex();
     _qp = 0;
-    Real res = computeQpResidual();
+    Real res = 0;
+
+    if (!_is_eigen)
+      res = computeQpResidual();
+
     residual.set(dof_idx, res);
 
     if (_has_save_in)

--- a/framework/src/kernels/CoupledForce.C
+++ b/framework/src/kernels/CoupledForce.C
@@ -21,19 +21,20 @@ validParams<CoupledForce>()
   InputParameters params = validParams<Kernel>();
 
   params.addRequiredCoupledVar("v", "The coupled variable which provides the force");
+  params.addParam<Real>("coef", 1.0, "Coefficent to multiply the coupled force term by");
 
   return params;
 }
 
 CoupledForce::CoupledForce(const InputParameters & parameters)
-  : Kernel(parameters), _v_var(coupled("v")), _v(coupledValue("v"))
+  : Kernel(parameters), _v_var(coupled("v")), _v(coupledValue("v")), _coef(getParam<Real>("coef"))
 {
 }
 
 Real
 CoupledForce::computeQpResidual()
 {
-  return -_v[_qp] * _test[_i][_qp];
+  return -_coef * _v[_qp] * _test[_i][_qp];
 }
 
 Real
@@ -46,6 +47,6 @@ Real
 CoupledForce::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _v_var)
-    return -_phi[_j][_qp] * _test[_i][_qp];
+    return -_coef * _phi[_j][_qp] * _test[_i][_qp];
   return 0.0;
 }

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -16,6 +16,7 @@
 #include "Console.h"
 #include "ConsoleUtils.h"
 #include "FEProblem.h"
+#include "EigenProblem.h"
 #include "Postprocessor.h"
 #include "PetscSupport.h"
 #include "Executioner.h"
@@ -483,6 +484,11 @@ Console::writeVariableNorms()
   // if we are not priting anything, let's not waste time computing the norms below and just exit
   // this call
   if ((_all_variable_norms == false) && (_outlier_variable_norms == false))
+    return;
+
+  // if it is an eigenvalue prolblem, we do not know to define RHS,
+  // and then we do not know how to compute variable norms
+  if (dynamic_cast<EigenProblem *>(_problem_ptr) != nullptr)
     return;
 
   // Flag set when header prints

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -97,6 +97,8 @@ initEigenSolveType()
     eigen_solve_type_to_enum["ARNOLDI"] = EST_ARNOLDI;
     eigen_solve_type_to_enum["KRYLOVSCHUR"] = EST_KRYLOVSCHUR;
     eigen_solve_type_to_enum["JACOBI_DAVIDSON"] = EST_JACOBI_DAVIDSON;
+    eigen_solve_type_to_enum["NONLINEAR_POWER"] = EST_NONLINEAR_POWER;
+    eigen_solve_type_to_enum["MONOLITH_NEWTON"] = EST_MONOLITH_NEWTON;
   }
 }
 

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -98,7 +98,9 @@ initEigenSolveType()
     eigen_solve_type_to_enum["KRYLOVSCHUR"] = EST_KRYLOVSCHUR;
     eigen_solve_type_to_enum["JACOBI_DAVIDSON"] = EST_JACOBI_DAVIDSON;
     eigen_solve_type_to_enum["NONLINEAR_POWER"] = EST_NONLINEAR_POWER;
+    eigen_solve_type_to_enum["MF_NONLINEAR_POWER"] = EST_MF_NONLINEAR_POWER;
     eigen_solve_type_to_enum["MONOLITH_NEWTON"] = EST_MONOLITH_NEWTON;
+    eigen_solve_type_to_enum["MF_MONOLITH_NEWTON"] = EST_MF_MONOLITH_NEWTON;
   }
 }
 

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -43,7 +43,8 @@ getSlepcValidParams()
   InputParameters params = emptyInputParameters();
 
   MooseEnum eigen_solve_type("POWER ARNOLDI KRYLOVSCHUR JACOBI_DAVIDSON "
-                             "NONLINEAR_POWER MONOLITH_NEWTON");
+                             "NONLINEAR_POWER MF_NONLINEAR_POWER "
+                             "MONOLITH_NEWTON MF_MONOLITH_NEWTON");
   params.addParam<MooseEnum>("eigen_solve_type",
                              eigen_solve_type,
                              "POWER: Power / Inverse / RQI "
@@ -247,6 +248,16 @@ setEigenSolverOptions(SolverParams & solver_params)
 #endif
       break;
 
+    case Moose::EST_MF_NONLINEAR_POWER:
+#if !SLEPC_VERSION_LESS_THAN(3, 7, 3)
+      Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
+      Moose::PetscSupport::setSinglePetscOption("-eps_power_nonlinear", "1");
+      Moose::PetscSupport::setSinglePetscOption("-eps_power_snes_mf_operator", "1");
+#else
+      mooseError("Matrix-free nonlinear Inverse Power requires SLEPc 3.7.3 or higher");
+#endif
+      break;
+
     case Moose::EST_MONOLITH_NEWTON:
 #if !SLEPC_VERSION_LESS_THAN(3, 7, 3)
       Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
@@ -254,6 +265,18 @@ setEigenSolverOptions(SolverParams & solver_params)
       Moose::PetscSupport::setSinglePetscOption("-eps_power_update", "1");
 #else
       mooseError("Newton-based eigenvalue solver requires SLEPc 3.7.3 or higher");
+#endif
+      break;
+
+    case Moose::EST_MF_MONOLITH_NEWTON:
+#if !SLEPC_VERSION_LESS_THAN(3, 7, 3)
+      Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
+      Moose::PetscSupport::setSinglePetscOption("-eps_power_nonlinear", "1");
+      Moose::PetscSupport::setSinglePetscOption("-eps_power_update", "1");
+      Moose::PetscSupport::setSinglePetscOption("-eps_power_snes_mf_operator", "1");
+      Moose::PetscSupport::setSinglePetscOption("-init_eps_power_snes_mf_operator", "1");
+#else
+      mooseError("Matrix-free Newton-based eigenvalue solver requires SLEPc 3.7.3 or higher");
 #endif
       break;
 

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -86,6 +86,7 @@ class TestHarness:
         if self.options.skip_config_checks:
             self.checks['compiler'] = set(['ALL'])
             self.checks['petsc_version'] = 'N/A'
+            self.checks['petsc_version_release'] = 'N/A'
             self.checks['slepc_version'] = 'N/A'
             self.checks['library_mode'] = set(['ALL'])
             self.checks['mesh_mode'] = set(['ALL'])
@@ -105,6 +106,7 @@ class TestHarness:
         else:
             self.checks['compiler'] = getCompilers(self.libmesh_dir)
             self.checks['petsc_version'] = getPetscVersion(self.libmesh_dir)
+            self.checks['petsc_version_release'] = getLibMeshConfigOption(self.libmesh_dir, 'petsc_version_release')
             self.checks['slepc_version'] = getSlepcVersion(self.libmesh_dir)
             self.checks['library_mode'] = getSharedOption(self.libmesh_dir)
             self.checks['mesh_mode'] = getLibMeshConfigOption(self.libmesh_dir, 'mesh_mode')

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -86,6 +86,7 @@ class TestHarness:
         if self.options.skip_config_checks:
             self.checks['compiler'] = set(['ALL'])
             self.checks['petsc_version'] = 'N/A'
+            self.checks['slepc_version'] = 'N/A'
             self.checks['library_mode'] = set(['ALL'])
             self.checks['mesh_mode'] = set(['ALL'])
             self.checks['dtk'] = set(['ALL'])
@@ -104,6 +105,7 @@ class TestHarness:
         else:
             self.checks['compiler'] = getCompilers(self.libmesh_dir)
             self.checks['petsc_version'] = getPetscVersion(self.libmesh_dir)
+            self.checks['slepc_version'] = getSlepcVersion(self.libmesh_dir)
             self.checks['library_mode'] = getSharedOption(self.libmesh_dir)
             self.checks['mesh_mode'] = getLibMeshConfigOption(self.libmesh_dir, 'mesh_mode')
             self.checks['dtk'] =  getLibMeshConfigOption(self.libmesh_dir, 'dtk')
@@ -404,7 +406,7 @@ class TestHarness:
         # PASS and DRY_RUN fall into this catagory
         if did_pass:
             if self.options.extra_info:
-                checks = ['platform', 'compiler', 'petsc_version', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids']
+                checks = ['platform', 'compiler', 'petsc_version', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'slepc_version']
                 for check in checks:
                     if not 'ALL' in test[check]:
                         caveats.append(', '.join(test[check]))

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -31,6 +31,7 @@ class Tester(MooseObject):
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")
         params.addParam('compiler',      ['ALL'], "A list of compilers for which this test is valid on. ('ALL', 'GCC', 'INTEL', 'CLANG')")
         params.addParam('petsc_version', ['ALL'], "A list of petsc versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
+        params.addParam('petsc_version_release', ['ALL'], "A test that runs against PETSc master if FALSE ('ALL', 'TRUE', 'FALSE')")
         params.addParam('slepc_version', [], "A list of slepc versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
         params.addParam('mesh_mode',     ['ALL'], "A list of mesh modes for which this test will run ('DISTRIBUTED', 'REPLICATED')")
         params.addParam('method',        ['ALL'], "A test that runs under certain executable configurations ('ALL', 'OPT', 'DBG', 'DEVEL', 'OPROF', 'PRO')")
@@ -286,7 +287,7 @@ class Tester(MooseObject):
 
         # PETSc and SLEPc is being explicitly checked above
         local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot', \
-                        'petsc_debug', 'curl', 'tbb', 'superlu', 'cxx11', 'asio', 'unique_id', 'slepc']
+                        'petsc_debug', 'curl', 'tbb', 'superlu', 'cxx11', 'asio', 'unique_id', 'slepc', 'petsc_version_release']
         for check in local_checks:
             test_platforms = set()
             operator_display = '!='

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -31,6 +31,7 @@ class Tester(MooseObject):
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")
         params.addParam('compiler',      ['ALL'], "A list of compilers for which this test is valid on. ('ALL', 'GCC', 'INTEL', 'CLANG')")
         params.addParam('petsc_version', ['ALL'], "A list of petsc versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
+        params.addParam('slepc_version', [], "A list of slepc versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
         params.addParam('mesh_mode',     ['ALL'], "A list of mesh modes for which this test will run ('DISTRIBUTED', 'REPLICATED')")
         params.addParam('method',        ['ALL'], "A test that runs under certain executable configurations ('ALL', 'OPT', 'DBG', 'DEVEL', 'OPROF', 'PRO')")
         params.addParam('library_mode',  ['ALL'], "A test that only runs when libraries are built under certain configurations ('ALL', 'STATIC', 'DYNAMIC')")
@@ -275,7 +276,15 @@ class Tester(MooseObject):
         if not petsc_status:
             reasons['petsc_version'] = 'using PETSc ' + str(checks['petsc_version']) + ' REQ: ' + logic_reason + ' ' + petsc_version
 
-        # PETSc is being explicitly checked above
+        # Check for SLEPc versions
+        (slepc_status, logic_reason, slepc_version) = util.checkSlepcVersion(checks, self.specs)
+        if not slepc_status and len(self.specs['slepc_version']) != 0:
+            if slepc_version != None:
+                reasons['slepc_version'] = 'using SLEPc ' + str(checks['slepc_version']) + ' REQ: ' + logic_reason + ' ' + slepc_version
+            elif slepc_version == None:
+                reasons['slepc_version'] = 'SLEPc is not installed'
+
+        # PETSc and SLEPc is being explicitly checked above
         local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot', \
                         'petsc_debug', 'curl', 'tbb', 'superlu', 'cxx11', 'asio', 'unique_id', 'slepc']
         for check in local_checks:

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -52,6 +52,10 @@ LIBMESH_OPTIONS = {
   'petsc_minor' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_PETSC_VERSION_MINOR\s+(\d+)',
                      'default'   : '1'
                    },
+  'petsc_version_release' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_PETSC_VERSION_RELEASE\s+(\d+)',
+                     'default'   : 'TRUE',
+                     'options'   : {'TRUE'  : '1', 'FALSE' : '0'}
+                   },
   'slepc_major' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_SLEPC_VERSION_MAJOR\s+(\d+)',
                      'default'   : '1'
                    },

--- a/test/include/kernels/PMassKernel.h
+++ b/test/include/kernels/PMassKernel.h
@@ -1,0 +1,41 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#ifndef PMASSKERNEL_H
+#define PMASSKERNEL_H
+
+#include "Kernel.h"
+
+// Forward Declarations
+class PMassKernel;
+
+template <>
+InputParameters validParams<PMassKernel>();
+
+/**
+ * This kernel implements (v, |u|^(p-2) u)/k, where u is the variable, v is the test function
+ * and k is the eigenvalue. When p=2, this kernel is equivalent with MassEigenKernel.
+ */
+class PMassKernel : public Kernel
+{
+public:
+  PMassKernel(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+
+  Real _p;
+};
+
+#endif // PMASSKERNEL_H

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -71,6 +71,7 @@
 #include "MaterialEigenKernel.h"
 #include "PHarmonic.h"
 #include "PMassEigenKernel.h"
+#include "PMassKernel.h"
 #include "CoupledEigenKernel.h"
 #include "ConsoleMessageKernel.h"
 #include "WrongJacobianDiffusion.h"
@@ -371,6 +372,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerKernel(MaterialEigenKernel);
   registerKernel(PHarmonic);
   registerKernel(PMassEigenKernel);
+  registerKernel(PMassKernel);
   registerKernel(CoupledEigenKernel);
   registerKernel(ConsoleMessageKernel);
   registerKernel(WrongJacobianDiffusion);

--- a/test/src/kernels/PMassKernel.C
+++ b/test/src/kernels/PMassKernel.C
@@ -1,0 +1,41 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+#include "PMassKernel.h"
+
+template <>
+InputParameters
+validParams<PMassKernel>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addRangeCheckedParam<Real>("p", 2.0, "p>=1.0", "The actual exponent is p-2");
+  return params;
+}
+
+PMassKernel::PMassKernel(const InputParameters & parameters)
+  : Kernel(parameters), _p(getParam<Real>("p") - 2.0)
+{
+}
+
+Real
+PMassKernel::computeQpResidual()
+{
+  return std::pow(std::fabs(_u[_qp]), _p) * _u[_qp] * _test[_i][_qp];
+}
+
+Real
+PMassKernel::computeQpJacobian()
+{
+  // Note: this jacobian evaluation is not exact when p!=2.
+  return std::pow(std::fabs(_phi[_j][_qp]), _p) * _phi[_j][_qp] * _test[_i][_qp];
+}

--- a/test/tests/mesh/subdomain_partitioner/tests
+++ b/test/tests/mesh/subdomain_partitioner/tests
@@ -7,6 +7,9 @@
     dof_id_bytes = 4
     min_parallel = 4
     max_parallel = 4
+    # do not run this test against development version of PETSc
+    # metis and parmetis will generate different partitions
+    petsc_version_release = true
   [../]
   [./subdomain_partitioner_linux]
     type = 'Exodiff'
@@ -17,5 +20,6 @@
     dof_id_bytes = 4
     min_parallel = 4
     max_parallel = 4
+    petsc_version_release = true
   [../]
 []

--- a/test/tests/postprocessors/all_print_pps/tests
+++ b/test/tests/postprocessors/all_print_pps/tests
@@ -5,5 +5,10 @@
     csvdiff = 'out.csv'
     max_parallel=2
     min_parallel=2
+    # Do not test this against PETSc-master because
+    # PETSc-master has a little better convergence in terms of the number
+    # of iterations.  And then the number of residuals is reduced by 1,
+    # and this causes CSV diff. 
+    petsc_version_release = true
   [../]
 []

--- a/test/tests/preconditioners/pbp/tests
+++ b/test/tests/preconditioners/pbp/tests
@@ -32,5 +32,9 @@
     method = 'OPT OPROF'
     valgrind = 'HEAVY'
     min_reported_time = 20
+    # this test has unknown issue with PETSc-master
+    # It is related to communcators in VTK
+    # We will fix it in the new release
+    petsc_version_release = true
   [../]
 []

--- a/test/tests/problems/eigen_problem/ane.i
+++ b/test/tests/problems/eigen_problem/ane.i
@@ -54,9 +54,7 @@
 
 [Executioner]
   type = Steady
-  eigen_solve_type = MONOLITH_NEWTON
-  petsc_options_iname = '-eps_power_snes_mf_operator'
-  petsc_options_value = '1'
+  eigen_solve_type = MF_MONOLITH_NEWTON
 []
 
 

--- a/test/tests/problems/eigen_problem/ane.i
+++ b/test/tests/problems/eigen_problem/ane.i
@@ -1,0 +1,78 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 10
+  ymin = 0
+  ymax = 10
+  elem_type = QUAD4
+  nx = 8
+  ny = 8
+[]
+
+# the minimum eigenvalue is (2*PI*(p-1)^(1/p)/a/p/sin(PI/p))^p;
+# Its inverse is 35.349726539758187. Here a is equal to 10.
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+
+[Kernels]
+  [./diff]
+    type = PHarmonic
+    variable = u
+    p = 3
+  [../]
+
+  [./rhs]
+    type = PMassKernel
+    eigen_kernel = true
+    variable = u
+    p = 3
+  [../]
+[]
+
+[BCs]
+  [./homogeneous]
+    type = DirichletBC
+    variable = u
+    boundary = '0 2'
+    value = 0
+  [../]
+[]
+
+[Problem]
+  type = EigenProblem
+  eigen_problem_type = gen_non_hermitian
+  which_eigen_pairs = LARGEST_MAGNITUDE
+[]
+
+
+[Executioner]
+  type = Steady
+  eigen_solve_type = MONOLITH_NEWTON
+  petsc_options_iname = '-eps_power_snes_mf_operator'
+  petsc_options_value = '1'
+[]
+
+
+[VectorPostprocessors]
+  [./eigenvalues]
+    type = Eigenvalues
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = ane
+  execute_on = 'timestep_end'
+  [./console]
+    type = Console
+    outlier_variable_norms = false
+  [../]
+[]

--- a/test/tests/problems/eigen_problem/ane.i
+++ b/test/tests/problems/eigen_problem/ane.i
@@ -69,8 +69,4 @@
   csv = true
   file_base = ane
   execute_on = 'timestep_end'
-  [./console]
-    type = Console
-    outlier_variable_norms = false
-  [../]
 []

--- a/test/tests/problems/eigen_problem/gold/ane_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/ane_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.028766782866964
+

--- a/test/tests/problems/eigen_problem/gold/monolith_newton_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/monolith_newton_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.19994161312388
+

--- a/test/tests/problems/eigen_problem/gold/ne_coupled_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/ne_coupled_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.27676227502278
+

--- a/test/tests/problems/eigen_problem/gold/ne_deficient_b_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/ne_deficient_b_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.039976648659005
+

--- a/test/tests/problems/eigen_problem/gold/nonlinear_power_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/gold/nonlinear_power_eigenvalues_0001.csv
@@ -1,0 +1,3 @@
+eigen_values_imag,eigen_values_real
+0,0.19994159676689
+

--- a/test/tests/problems/eigen_problem/ne.i
+++ b/test/tests/problems/eigen_problem/ne.i
@@ -1,0 +1,71 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 10
+  ymin = 0
+  ymax = 10
+  elem_type = QUAD4
+  nx = 8
+  ny = 8
+[]
+
+# the minimum eigenvalue of this problem is 2*(PI/a)^2;
+# Its inverse is 0.5*(a/PI)^2 = 5.0660591821169. Here a is equal to 10.
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+
+  [./rhs]
+    type = Reaction
+    variable = u
+    eigen_kernel = true
+  [../]
+[]
+
+[BCs]
+  [./homogeneous]
+    type = DirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+[]
+
+[Problem]
+  type = EigenProblem
+  eigen_problem_type = gen_non_hermitian
+  which_eigen_pairs = TARGET_MAGNITUDE
+[]
+
+[Executioner]
+  type = Steady
+  eigen_solve_type = MONOLITH_NEWTON
+[]
+
+[VectorPostprocessors]
+  [./eigenvalues]
+    type = Eigenvalues
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = monolith_newton
+  execute_on = 'timestep_end'
+  [./console]
+    type = Console
+    outlier_variable_norms = false
+  [../]
+[]

--- a/test/tests/problems/eigen_problem/ne.i
+++ b/test/tests/problems/eigen_problem/ne.i
@@ -64,8 +64,4 @@
   csv = true
   file_base = monolith_newton
   execute_on = 'timestep_end'
-  [./console]
-    type = Console
-    outlier_variable_norms = false
-  [../]
 []

--- a/test/tests/problems/eigen_problem/ne.i
+++ b/test/tests/problems/eigen_problem/ne.i
@@ -50,7 +50,7 @@
 
 [Executioner]
   type = Steady
-  eigen_solve_type = MONOLITH_NEWTON
+  eigen_solve_type = MF_MONOLITH_NEWTON
 []
 
 [VectorPostprocessors]

--- a/test/tests/problems/eigen_problem/ne_coupled.i
+++ b/test/tests/problems/eigen_problem/ne_coupled.i
@@ -101,9 +101,7 @@
 
 [Executioner]
   type = Steady
-  eigen_solve_type = MONOLITH_NEWTON
-  petsc_options_iname = '-eps_power_snes_mf_operator'
-  petsc_options_value = '1'
+  eigen_solve_type = MF_MONOLITH_NEWTON
 []
 
 [Postprocessors]

--- a/test/tests/problems/eigen_problem/ne_coupled.i
+++ b/test/tests/problems/eigen_problem/ne_coupled.i
@@ -123,8 +123,4 @@
   csv = true
   file_base = ne_coupled
   execute_on = 'timestep_end'
-  [./console]
-    type = Console
-    outlier_variable_norms = false
-  [../]
 []

--- a/test/tests/problems/eigen_problem/ne_coupled.i
+++ b/test/tests/problems/eigen_problem/ne_coupled.i
@@ -1,0 +1,132 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 10
+  ymin = 0
+  ymax = 10
+  elem_type = QUAD4
+  nx = 8
+  ny = 8
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+
+  [./T]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./power]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = DiffMKernel
+    variable = u
+    mat_prop = diffusion
+    offset = 0.0
+  [../]
+
+  [./rhs]
+    type = Reaction
+    variable = u
+    eigen_kernel = true
+  [../]
+
+  [./diff_T]
+    type = Diffusion
+    variable = T
+  [../]
+  [./src_T]
+    type = CoupledForce
+    variable = T
+    v = power
+  [../]
+[]
+
+[AuxKernels]
+  [./power_ak]
+    type = NormalizationAux
+    variable = power
+    source_variable = u
+    normalization = unorm
+    # this coefficient will affect the eigenvalue.
+    normal_factor = 10
+    execute_on = linear
+  [../]
+[]
+
+[BCs]
+  [./homogeneous]
+    type = DirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+
+  [./homogeneousT]
+    type = DirichletBC
+    variable = T
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+[]
+
+[Materials]
+  [./dc]
+    type = VarCouplingMaterial
+    var = T
+    block = 0
+    base = 1.0
+    coef = 1.0
+  [../]
+[]
+
+[Problem]
+  type = EigenProblem
+  eigen_problem_type = gen_non_hermitian
+  which_eigen_pairs = TARGET_MAGNITUDE
+[]
+
+
+[Executioner]
+  type = Steady
+  eigen_solve_type = MONOLITH_NEWTON
+  petsc_options_iname = '-eps_power_snes_mf_operator'
+  petsc_options_value = '1'
+[]
+
+[Postprocessors]
+  [./unorm]
+    type = ElementIntegralVariablePostprocessor
+    variable = u
+    execute_on = linear
+  [../]
+[]
+
+[VectorPostprocessors]
+  [./eigenvalues]
+    type = Eigenvalues
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = ne_coupled
+  execute_on = 'timestep_end'
+  [./console]
+    type = Console
+    outlier_variable_norms = false
+  [../]
+[]

--- a/test/tests/problems/eigen_problem/ne_deficient_b.i
+++ b/test/tests/problems/eigen_problem/ne_deficient_b.i
@@ -90,8 +90,4 @@
   csv = true
   file_base = ne_deficient_b
   execute_on = 'timestep_end'
-  [./console]
-    type = Console
-    outlier_variable_norms = false
-  [../]
 []

--- a/test/tests/problems/eigen_problem/ne_deficient_b.i
+++ b/test/tests/problems/eigen_problem/ne_deficient_b.i
@@ -1,0 +1,99 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 10
+  ymin = 0
+  ymax = 10
+  elem_type = QUAD4
+  nx = 8
+  ny = 8
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./v]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = Diffusion
+    variable = u
+  [../]
+  [./diff_v]
+    type = Diffusion
+    variable = v
+  [../]
+
+  [./rhs]
+    type = CoupledForce
+    variable = u
+    v = v
+    eigen_kernel = true
+    coef = -1.0
+  [../]
+  [./src_v]
+    type = CoupledForce
+    variable = v
+    v = u
+  [../]
+[]
+
+[BCs]
+  [./homogeneous_u]
+    type = DirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+  [./homogeneous_v]
+    type = DirichletBC
+    variable = v
+    boundary = '0 1 2 3'
+    value = 0
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Problem]
+  type = EigenProblem
+  eigen_problem_type = gen_non_hermitian
+  which_eigen_pairs = TARGET_MAGNITUDE
+[]
+
+[Executioner]
+  type = Steady
+  eigen_solve_type = MONOLITH_NEWTON
+  petsc_options_iname = '-eps_power_snes_mf_operator'
+  petsc_options_value = '1'
+[]
+
+
+[VectorPostprocessors]
+  [./eigenvalues]
+    type = Eigenvalues
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  file_base = ne_deficient_b
+  execute_on = 'timestep_end'
+  [./console]
+    type = Console
+    outlier_variable_norms = false
+  [../]
+[]

--- a/test/tests/problems/eigen_problem/ne_deficient_b.i
+++ b/test/tests/problems/eigen_problem/ne_deficient_b.i
@@ -75,9 +75,7 @@
 
 [Executioner]
   type = Steady
-  eigen_solve_type = MONOLITH_NEWTON
-  petsc_options_iname = '-eps_power_snes_mf_operator'
-  petsc_options_value = '1'
+  eigen_solve_type = MF_MONOLITH_NEWTON
 []
 
 

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -46,7 +46,7 @@
   [./nonlinear_power]
     type = 'CSVDiff'
     input = 'ne.i'
-    cli_args = 'Executioner/eigen_solve_type=NONLINEAR_POWER Outputs/file_base=nonlinear_power'
+    cli_args = 'Executioner/eigen_solve_type=MF_NONLINEAR_POWER Outputs/file_base=nonlinear_power'
     csvdiff = 'nonlinear_power_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
     petsc_version_release = false
@@ -55,7 +55,7 @@
   [./monolith_newton]
     type = 'CSVDiff'
     input = 'ne.i'
-    cli_args = 'Executioner/eigen_solve_type=MONOLITH_NEWTON Outputs/file_base=monolith_newton'
+    cli_args = 'Executioner/eigen_solve_type=MF_MONOLITH_NEWTON Outputs/file_base=monolith_newton'
     csvdiff = 'monolith_newton_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
     petsc_version_release = false

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -66,5 +66,11 @@
     slepc_version = '>=3.7.4'
   [../]
 
-  
+  [./nonlinear_laplace]
+    type = 'CSVDiff'
+    input = 'ane.i'
+    csvdiff = 'ane_eigenvalues_0001.csv'
+    slepc_version = '>=3.7.4'
+  [../]
+
 []

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -49,6 +49,7 @@
     cli_args = 'Executioner/eigen_solve_type=NONLINEAR_POWER Outputs/file_base=nonlinear_power'
     csvdiff = 'nonlinear_power_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
+    petsc_version_release = false
   [../]
 
   [./monolith_newton]
@@ -57,6 +58,7 @@
     cli_args = 'Executioner/eigen_solve_type=MONOLITH_NEWTON Outputs/file_base=monolith_newton'
     csvdiff = 'monolith_newton_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
+    petsc_version_release = false
   [../]
 
   [./ne_deficient]
@@ -64,6 +66,7 @@
     input = 'ne_deficient_b.i'
     csvdiff = 'ne_deficient_b_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
+    petsc_version_release = false
   [../]
 
   [./nonlinear_laplace]
@@ -71,11 +74,13 @@
     input = 'ane.i'
     csvdiff = 'ane_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
+    petsc_version_release = false
   [../]
   [./coupled_system]
     type = 'CSVDiff'
     input = 'ne_coupled.i'
     csvdiff = 'ne_coupled_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
+    petsc_version_release = false
   [../]
 []

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -72,5 +72,10 @@
     csvdiff = 'ane_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
   [../]
-
+  [./coupled_system]
+    type = 'CSVDiff'
+    input = 'ne_coupled.i'
+    csvdiff = 'ne_coupled_eigenvalues_0001.csv'
+    slepc_version = '>=3.7.4'
+  [../]
 []

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -58,4 +58,13 @@
     csvdiff = 'monolith_newton_eigenvalues_0001.csv'
     slepc_version = '>=3.7.4'
   [../]
+
+  [./ne_deficient]
+    type = 'CSVDiff'
+    input = 'ne_deficient_b.i'
+    csvdiff = 'ne_deficient_b_eigenvalues_0001.csv'
+    slepc_version = '>=3.7.4'
+  [../]
+
+  
 []

--- a/test/tests/problems/eigen_problem/tests
+++ b/test/tests/problems/eigen_problem/tests
@@ -42,4 +42,20 @@
     expect_err = "Need to install SLEPc to solve eigenvalue problems, please reconfigure libMesh."
     slepc = false
   [../]
+
+  [./nonlinear_power]
+    type = 'CSVDiff'
+    input = 'ne.i'
+    cli_args = 'Executioner/eigen_solve_type=NONLINEAR_POWER Outputs/file_base=nonlinear_power'
+    csvdiff = 'nonlinear_power_eigenvalues_0001.csv'
+    slepc_version = '>=3.7.4'
+  [../]
+
+  [./monolith_newton]
+    type = 'CSVDiff'
+    input = 'ne.i'
+    cli_args = 'Executioner/eigen_solve_type=MONOLITH_NEWTON Outputs/file_base=monolith_newton'
+    csvdiff = 'monolith_newton_eigenvalues_0001.csv'
+    slepc_version = '>=3.7.4'
+  [../]
 []

--- a/test/tests/time_integrators/rk-2/tests
+++ b/test/tests/time_integrators/rk-2/tests
@@ -17,6 +17,7 @@
     type = 'Exodiff'
     input = '2d-quadratic.i'
     exodiff = '2d-quadratic_out.e'
+    abs_zero = 1e-8
   [../]
 
   [./2d-quadratic_num-of-jacobian-calls]

--- a/test/tests/time_integrators/tvdrk2/tests
+++ b/test/tests/time_integrators/tvdrk2/tests
@@ -17,6 +17,7 @@
     type = 'Exodiff'
     input = '2d-quadratic.i'
     exodiff = '2d-quadratic_out.e'
+    abs_zero = 1e-8
   [../]
 
   [./2d-quadratic_num-of-jacobian-calls]


### PR DESCRIPTION
The implementation of nonlinear eigenvalue solvers is in SLEPc, and we have the interface only at the moose side. Keep moose simple by avoiding having logic algebra calculations in moose.

Nonlinear eigenvalue solvers are already merged into SLEPc/master, and we test the moose interface against SLEPc/master. If it passes, we should merge this interface.