### PR TITLE
Fix TestHarness reprint output.

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -690,7 +690,7 @@ class TestHarness:
                 print(output)
 
                 # Print result line again at the bottom of the output for failed tests
-                print(printResult(tester, result, timing, start, end, self.options), "(reprint)")
+                print("%s(reprint)" % printResult(tester, result, timing, start, end, self.options))
 
         if status != tester.bucket_skip:
             if not did_pass and not self.options.failed_tests:


### PR DESCRIPTION
Looks #9330 broke the TestHarness output of the "reprint" line. The color codes weren't getting output properly.
For example, after the crash on https://www.moosebuild.org/job/95517/

Note that, despite its name, `printResult` doesn't actually print anything, it just returns a string.