### PR TITLE
Rename method to avoid error prone "hidden" method problems.

### DIFF
--- a/modules/phase_field/include/userobjects/PolycrystalEBSD.h
+++ b/modules/phase_field/include/userobjects/PolycrystalEBSD.h
@@ -24,7 +24,7 @@ public:
   virtual void getGrainsBasedOnPoint(const Point & point,
                                      std::vector<unsigned int> & grains) const override;
   virtual Real getVariableValue(unsigned int op_index, const Point & p) const override;
-  virtual Real getVariableValue(unsigned int op_index, const Node & n) const override;
+  virtual Real getNodalVariableValue(unsigned int op_index, const Node & n) const override;
   virtual unsigned int getNumGrains() const override;
 
 protected:

--- a/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
+++ b/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
@@ -58,8 +58,19 @@ public:
    */
   virtual unsigned int getNumGrains() const = 0;
 
+  /**
+   * Returns the variable value for a given op_index and mesh point. This is the method used by the
+   * initial condition after the Polycrystal grain structure has be setup. Those grains are
+   * then distributed to the typically smaller number of order parameters by this class.
+   * This method is then used to return those values but it may be overridden in a derived class.
+   */
   virtual Real getVariableValue(unsigned int op_index, const Point & p) const = 0;
-  virtual Real getVariableValue(unsigned int op_index, const Node & n) const
+
+  /**
+   * Similarly to the getVariableValue method, this method also returns values but may be optimized
+   * for returning nodal values.
+   */
+  virtual Real getNodalVariableValue(unsigned int op_index, const Node & n) const
   {
     return getVariableValue(op_index, static_cast<const Point &>(n));
   }

--- a/modules/phase_field/include/userobjects/PolycrystalVoronoi.h
+++ b/modules/phase_field/include/userobjects/PolycrystalVoronoi.h
@@ -24,6 +24,7 @@ public:
   virtual void getGrainsBasedOnPoint(const Point & point,
                                      std::vector<unsigned int> & grains) const override;
   virtual Real getVariableValue(unsigned int op_index, const Point & p) const override;
+
   virtual unsigned int getNumGrains() const override { return _grain_num; }
 
 protected:

--- a/modules/phase_field/src/ics/PolycrystalColoringIC.C
+++ b/modules/phase_field/src/ics/PolycrystalColoringIC.C
@@ -37,7 +37,7 @@ Real
 PolycrystalColoringIC::value(const Point & p)
 {
   if (_current_node)
-    return _poly_ic_uo.getVariableValue(_op_index, *_current_node);
+    return _poly_ic_uo.getNodalVariableValue(_op_index, *_current_node);
   else
     return _poly_ic_uo.getVariableValue(_op_index, p);
 }

--- a/modules/phase_field/src/userobjects/PolycrystalEBSD.C
+++ b/modules/phase_field/src/userobjects/PolycrystalEBSD.C
@@ -58,7 +58,7 @@ PolycrystalEBSD::getNumGrains() const
 }
 
 Real
-PolycrystalEBSD::getVariableValue(unsigned int op_index, const Node & n) const
+PolycrystalEBSD::getNodalVariableValue(unsigned int op_index, const Node & n) const
 {
   // Make sure the _current_node is in the node_to_grain_weight_map (return error if not in map)
   const auto it = _node_to_grain_weight_map.find(n.id());

--- a/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
+++ b/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
@@ -71,6 +71,7 @@ PolycrystalUserObjectBase::initialSetup()
   for (unsigned int dim = 0; dim < _dim; ++dim)
   {
     bool first_variable_value = _mesh.isTranslatedPeriodic(_vars[0]->number(), dim);
+
     for (unsigned int i = 1; i < _vars.size(); ++i)
       if (_mesh.isTranslatedPeriodic(_vars[i]->number(), dim) != first_variable_value)
         mooseError("Coupled polycrystal variables differ in periodicity");


### PR DESCRIPTION
Right now the PolycrystalUserObjectBase object has two methods with the same name
but different signatures. Most derived objects will only override one of these
methods. However, this can cause problems with hidden methods and virtual lookup
problems if developers fail to heed compiler warnings. A better solution is to
avoid using the same name for these methods in this case.

closes #9345

