### PR TITLE
Minor cleanup of fluid_properties

### DIFF
--- a/modules/fluid_properties/include/auxkernels/SpecificEnthalpyAux.h
+++ b/modules/fluid_properties/include/auxkernels/SpecificEnthalpyAux.h
@@ -25,7 +25,7 @@ public:
   SpecificEnthalpyAux(const InputParameters & parameters);
 
 protected:
-  virtual Real computeValue();
+  virtual Real computeValue() override;
 
   const VariableValue & _pressure;
   const VariableValue & _temperature;

--- a/modules/fluid_properties/include/auxkernels/StagnationPressureAux.h
+++ b/modules/fluid_properties/include/auxkernels/StagnationPressureAux.h
@@ -25,7 +25,7 @@ public:
   StagnationPressureAux(const InputParameters & parameters);
 
 protected:
-  virtual Real computeValue();
+  virtual Real computeValue() override;
 
   const VariableValue & _specific_volume;
   const VariableValue & _specific_internal_energy;

--- a/modules/fluid_properties/include/auxkernels/StagnationTemperatureAux.h
+++ b/modules/fluid_properties/include/auxkernels/StagnationTemperatureAux.h
@@ -25,7 +25,7 @@ public:
   StagnationTemperatureAux(const InputParameters & parameters);
 
 protected:
-  virtual Real computeValue();
+  virtual Real computeValue() override;
 
   const VariableValue & _specific_volume;
   const VariableValue & _specific_internal_energy;

--- a/modules/fluid_properties/include/materials/FluidPropertiesMaterial.h
+++ b/modules/fluid_properties/include/materials/FluidPropertiesMaterial.h
@@ -17,7 +17,7 @@ template <>
 InputParameters validParams<FluidPropertiesMaterial>();
 
 /**
- * Computes values of pressure and its derivatives using (u, v) formulation
+ * Computes fluid properties using (u, v) formulation
  */
 class FluidPropertiesMaterial : public Material
 {
@@ -26,7 +26,7 @@ public:
   virtual ~FluidPropertiesMaterial();
 
 protected:
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
 
   /// Specific internal energy
   const VariableValue & _e;
@@ -36,11 +36,15 @@ protected:
   MaterialProperty<Real> & _p;
   /// Temperature
   MaterialProperty<Real> & _T;
-  /// Sound speed
+  /// Speed of sound
   MaterialProperty<Real> & _c;
+  /// Isobaric specific heat capacity
   MaterialProperty<Real> & _cp;
+  /// Isochoric specific heat capacity
   MaterialProperty<Real> & _cv;
+  /// Dynamic viscosity
   MaterialProperty<Real> & _mu;
+  /// Thermal conductivity
   MaterialProperty<Real> & _k;
 
   /// Fluid properties

--- a/modules/fluid_properties/include/materials/FluidPropertiesMaterialPT.h
+++ b/modules/fluid_properties/include/materials/FluidPropertiesMaterialPT.h
@@ -17,7 +17,7 @@ template <>
 InputParameters validParams<FluidPropertiesMaterialPT>();
 
 /**
- * Computes values of pressure and its derivatives using (pressure, temperature) formulation
+ * Computes fluid properties using (pressure, temperature) formulation
  */
 class FluidPropertiesMaterialPT : public Material
 {
@@ -30,7 +30,7 @@ protected:
 
   /// Pressure (Pa)
   const VariableValue & _pressure;
-  /// Temperature (C)
+  /// Temperature (K)
   const VariableValue & _temperature;
   /// Density (kg/m^3)
   MaterialProperty<Real> & _rho;

--- a/modules/fluid_properties/include/materials/MultiComponentFluidPropertiesMaterialPT.h
+++ b/modules/fluid_properties/include/materials/MultiComponentFluidPropertiesMaterialPT.h
@@ -17,10 +17,9 @@ template <>
 InputParameters validParams<MultiComponentFluidPropertiesMaterialPT>();
 
 /**
- * Material for testing the BrineFluidProperties UserObject.
- * Note: This material is for testing purposes only and shouldn't be
- * used for actual simulations. It provides access to internal functions
- * as well as the functions provided by the base FluidProperties class
+ * Material for calculating fluid properties for a fluid comprised of two components:
+ * the solute (eg, NaCl), and the solution (eg, water). This material uses the
+ * pressure - temperature formulation.
  */
 class MultiComponentFluidPropertiesMaterialPT : public Material
 {
@@ -35,8 +34,8 @@ protected:
   const VariableValue & _pressure;
   /// Temperature (K)
   const VariableValue & _temperature;
-  /// Mass fraction (-)
-  const VariableValue & _xnacl;
+  /// Mass fraction of solute (-)
+  const VariableValue & _xmass;
   /// Density (kg/m^3)
   MaterialProperty<Real> & _rho;
   /// Enthalpy (kJ/kg)

--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -242,7 +242,7 @@ public:
    */
   Real haliteSolubility(Real temperature) const;
 
-  /// Proved access to UserObject for specified component
+  /// Provides access to UserObject for specified component
   virtual const SinglePhaseFluidPropertiesPT & getComponent(unsigned int component) const override;
 
   /// Fluid component numbers for water and NaCl

--- a/modules/fluid_properties/src/auxkernels/SpecificEnthalpyAux.C
+++ b/modules/fluid_properties/src/auxkernels/SpecificEnthalpyAux.C
@@ -16,7 +16,7 @@ validParams<SpecificEnthalpyAux>()
   params.addRequiredCoupledVar("p", "Pressure");
   params.addRequiredCoupledVar("T", "Temperature");
   params.addRequiredParam<UserObjectName>("fp", "The name of the user object for fluid properties");
-
+  params.addClassDescription("Computes specific enthalpy from pressure and temperature");
   return params;
 }
 

--- a/modules/fluid_properties/src/auxkernels/StagnationPressureAux.C
+++ b/modules/fluid_properties/src/auxkernels/StagnationPressureAux.C
@@ -17,7 +17,8 @@ validParams<StagnationPressureAux>()
   params.addRequiredCoupledVar("v", "Specific volume");
   params.addRequiredCoupledVar("vel", "Velocity");
   params.addRequiredParam<UserObjectName>("fp", "The name of the user object for fluid properties");
-
+  params.addClassDescription(
+      "Computes stagnation pressure from specific volume, specific internal energy, and velocity");
   return params;
 }
 

--- a/modules/fluid_properties/src/auxkernels/StagnationTemperatureAux.C
+++ b/modules/fluid_properties/src/auxkernels/StagnationTemperatureAux.C
@@ -17,7 +17,8 @@ validParams<StagnationTemperatureAux>()
   params.addRequiredCoupledVar("v", "Specific volume");
   params.addRequiredCoupledVar("vel", "Velocity");
   params.addRequiredParam<UserObjectName>("fp", "The name of the user object for fluid properties");
-
+  params.addClassDescription("Computes stagnation temperature from specific volume, specific "
+                             "internal energy, and velocity");
   return params;
 }
 

--- a/modules/fluid_properties/src/materials/FluidPropertiesMaterial.C
+++ b/modules/fluid_properties/src/materials/FluidPropertiesMaterial.C
@@ -16,6 +16,7 @@ validParams<FluidPropertiesMaterial>()
   params.addRequiredCoupledVar("e", "Specific internal energy");
   params.addRequiredCoupledVar("v", "Specific volume");
   params.addRequiredParam<UserObjectName>("fp", "The name of the user object for fluid properties");
+  params.addClassDescription("Computes fluid properties using (u, v) formulation");
   return params;
 }
 

--- a/modules/fluid_properties/src/materials/FluidPropertiesMaterialPT.C
+++ b/modules/fluid_properties/src/materials/FluidPropertiesMaterialPT.C
@@ -13,10 +13,9 @@ validParams<FluidPropertiesMaterialPT>()
 {
   InputParameters params = validParams<Material>();
   params.addRequiredCoupledVar("pressure", "Fluid pressure (Pa)");
-  params.addRequiredCoupledVar("temperature", "Fluid temperature (C)");
+  params.addRequiredCoupledVar("temperature", "Fluid temperature (K)");
   params.addRequiredParam<UserObjectName>("fp", "The name of the user object for fluid properties");
-  params.addClassDescription(
-      "Material properties for a fluid using the (pressure, temperature) formulation");
+  params.addClassDescription("Fluid properties using the (pressure, temperature) formulation");
   return params;
 }
 

--- a/modules/fluid_properties/src/materials/MultiComponentFluidPropertiesMaterialPT.C
+++ b/modules/fluid_properties/src/materials/MultiComponentFluidPropertiesMaterialPT.C
@@ -14,10 +14,11 @@ validParams<MultiComponentFluidPropertiesMaterialPT>()
   InputParameters params = validParams<Material>();
   params.addRequiredCoupledVar("pressure", "pressure (Pa)");
   params.addRequiredCoupledVar("temperature", "temperature (K)");
-  params.addRequiredCoupledVar("xnacl", "NaCl mass fraction (-)");
+  params.addRequiredCoupledVar("xmass", "Solute mass fraction (-)");
   params.addRequiredParam<UserObjectName>("fp", "The name of the user object for fluid properties");
   params.addParam<bool>("vapor", false, "Flag to calculate vapor pressure");
-  params.addClassDescription("Material to test brine properties");
+  params.addClassDescription(
+      "Fluid properties of a multicomponent fluid using the (pressure, temperature) formulation");
   return params;
 }
 
@@ -26,7 +27,7 @@ MultiComponentFluidPropertiesMaterialPT::MultiComponentFluidPropertiesMaterialPT
   : Material(parameters),
     _pressure(coupledValue("pressure")),
     _temperature(coupledValue("temperature")),
-    _xnacl(coupledValue("xnacl")),
+    _xmass(coupledValue("xmass")),
 
     _rho(declareProperty<Real>("density")),
     _h(declareProperty<Real>("enthalpy")),
@@ -42,8 +43,8 @@ MultiComponentFluidPropertiesMaterialPT::~MultiComponentFluidPropertiesMaterialP
 void
 MultiComponentFluidPropertiesMaterialPT::computeQpProperties()
 {
-  _rho[_qp] = _fp.rho(_pressure[_qp], _temperature[_qp], _xnacl[_qp]);
-  _h[_qp] = _fp.h(_pressure[_qp], _temperature[_qp], _xnacl[_qp]);
-  _cp[_qp] = _fp.cp(_pressure[_qp], _temperature[_qp], _xnacl[_qp]);
-  _e[_qp] = _fp.e(_pressure[_qp], _temperature[_qp], _xnacl[_qp]);
+  _rho[_qp] = _fp.rho(_pressure[_qp], _temperature[_qp], _xmass[_qp]);
+  _h[_qp] = _fp.h(_pressure[_qp], _temperature[_qp], _xmass[_qp]);
+  _cp[_qp] = _fp.cp(_pressure[_qp], _temperature[_qp], _xmass[_qp]);
+  _e[_qp] = _fp.e(_pressure[_qp], _temperature[_qp], _xmass[_qp]);
 }

--- a/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
@@ -150,7 +150,7 @@ CO2FluidProperties::phiSW(Real delta, Real tau) const
 {
   // Ideal gas component of the Helmholtz free energy
   Real sum0 = 0.0;
-  for (unsigned int i = 0; i < _a0.size(); ++i)
+  for (std::size_t i = 0; i < _a0.size(); ++i)
     sum0 += _a0[i] * std::log(1.0 - std::exp(-_theta0[i] * tau));
 
   Real phi0 = std::log(delta) + 8.37304456 - 3.70454304 * tau + 2.5 * std::log(tau) + sum0;
@@ -158,19 +158,19 @@ CO2FluidProperties::phiSW(Real delta, Real tau) const
   // Residual component of the Helmholtz free energy
   Real theta, Delta, Psi;
   Real phir = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     phir += _n1[i] * std::pow(delta, _d1[i]) * std::pow(tau, _t1[i]);
 
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     phir += _n2[i] * std::pow(delta, _d2[i]) * std::pow(tau, _t2[i]) *
             std::exp(-std::pow(delta, _c2[i]));
 
-  for (unsigned int i = 0; i < _n3.size(); ++i)
+  for (std::size_t i = 0; i < _n3.size(); ++i)
     phir += _n3[i] * std::pow(delta, _d3[i]) * std::pow(tau, _t3[i]) *
             std::exp(-_alpha3[i] * std::pow(delta - _eps3[i], 2.0) -
                      _beta3[i] * std::pow(tau - _gamma3[i], 2.0));
 
-  for (unsigned int i = 0; i < _n4.size(); ++i)
+  for (std::size_t i = 0; i < _n4.size(); ++i)
   {
     theta = 1.0 - tau + _A4[i] * std::pow(std::pow(delta - 1.0, 2.0), 1.0 / (2.0 * _beta4[i]));
     Delta = std::pow(theta, 2) + _B4[i] * std::pow(std::pow(delta - 1.0, 2.0), _a4[i]);
@@ -192,21 +192,21 @@ CO2FluidProperties::dphiSW_dd(Real delta, Real tau) const
   Real theta, Delta, Psi, dDelta_dd, dPsi_dd;
   Real dphirdd = 0.0;
 
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     dphirdd += _n1[i] * _d1[i] * std::pow(delta, _d1[i] - 1.0) * std::pow(tau, _t1[i]);
 
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     dphirdd += _n2[i] * std::exp(-std::pow(delta, _c2[i])) *
                (std::pow(delta, _d2[i] - 1.0) * std::pow(tau, _t2[i]) *
                 (_d2[i] - _c2[i] * std::pow(delta, _c2[i])));
 
-  for (unsigned int i = 0; i < _n3.size(); ++i)
+  for (std::size_t i = 0; i < _n3.size(); ++i)
     dphirdd += _n3[i] * std::pow(delta, _d3[i]) * std::pow(tau, _t3[i]) *
                std::exp(-_alpha3[i] * std::pow(delta - _eps3[i], 2.0) -
                         _beta3[i] * std::pow(tau - _gamma3[i], 2.0)) *
                (_d3[i] / delta - 2.0 * _alpha3[i] * (delta - _eps3[i]));
 
-  for (unsigned int i = 0; i < _n4.size(); ++i)
+  for (std::size_t i = 0; i < _n4.size(); ++i)
   {
     theta = 1.0 - tau + _A4[i] * std::pow(std::pow(delta - 1.0, 2.0), 1.0 / (2.0 * _beta4[i]));
     Delta = std::pow(theta, 2.0) + _B4[i] * std::pow(std::pow(delta - 1.0, 2.0), _a4[i]);
@@ -230,7 +230,7 @@ CO2FluidProperties::dphiSW_dt(Real delta, Real tau) const
 {
   // Derivative of the ideal gas component wrt tau
   Real sum0 = 0.0;
-  for (unsigned int i = 0; i < _a0.size(); ++i)
+  for (std::size_t i = 0; i < _a0.size(); ++i)
     sum0 += _a0[i] * _theta0[i] * (1.0 / (1.0 - std::exp(-_theta0[i] * tau)) - 1.0);
 
   Real dphi0dt = -3.70454304 + 2.5 / tau + sum0;
@@ -238,20 +238,20 @@ CO2FluidProperties::dphiSW_dt(Real delta, Real tau) const
   // Derivative of the residual component wrt tau
   Real theta, Delta, Psi, dDelta_dt, dPsi_dt;
   Real dphirdt = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     dphirdt += _n1[i] * _t1[i] * std::pow(delta, _d1[i]) * std::pow(tau, _t1[i] - 1.0);
 
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     dphirdt += _n2[i] * _t2[i] * std::pow(delta, _d2[i]) * std::pow(tau, _t2[i] - 1.0) *
                std::exp(-std::pow(delta, _c2[i]));
 
-  for (unsigned int i = 0; i < _n3.size(); ++i)
+  for (std::size_t i = 0; i < _n3.size(); ++i)
     dphirdt += _n3[i] * std::pow(delta, _d3[i]) * std::pow(tau, _t3[i]) *
                std::exp(-_alpha3[i] * std::pow(delta - _eps3[i], 2.0) -
                         _beta3[i] * std::pow(tau - _gamma3[i], 2.0)) *
                (_t3[i] / tau - 2.0 * _beta3[i] * (tau - _gamma3[i]));
 
-  for (unsigned int i = 0; i < _n4.size(); ++i)
+  for (std::size_t i = 0; i < _n4.size(); ++i)
   {
     theta = 1.0 - tau + _A4[i] * std::pow(std::pow(delta - 1.0, 2.0), 1.0 / (2.0 * _beta4[i]));
     Delta = std::pow(theta, 2.0) + _B4[i] * std::pow(std::pow(delta - 1.0, 2.0), _a4[i]);
@@ -276,17 +276,17 @@ CO2FluidProperties::d2phiSW_dd2(Real delta, Real tau) const
   Real d2phirdd2 = 0.0;
   Real theta, Delta, Psi, dDelta_dd, dPsi_dd, d2Delta_dd2, d2Psi_dd2;
 
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     d2phirdd2 +=
         _n1[i] * _d1[i] * (_d1[i] - 1.0) * std::pow(delta, _d1[i] - 2.0) * std::pow(tau, _t1[i]);
 
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     d2phirdd2 += _n2[i] * std::exp(-std::pow(delta, _c2[i])) * std::pow(delta, _d2[i] - 2.0) *
                  std::pow(tau, _t2[i]) * ((_d2[i] - _c2[i] * std::pow(delta, _c2[i])) *
                                               (_d2[i] - 1.0 - _c2[i] * std::pow(delta, _c2[i])) -
                                           _c2[i] * _c2[i] * std::pow(delta, _c2[i]));
 
-  for (unsigned int i = 0; i < _n3.size(); ++i)
+  for (std::size_t i = 0; i < _n3.size(); ++i)
     d2phirdd2 +=
         _n3[i] * std::pow(tau, _t3[i]) * std::exp(-_alpha3[i] * std::pow(delta - _eps3[i], 2.0) -
                                                   _beta3[i] * std::pow(tau - _gamma3[i], 2.0)) *
@@ -295,7 +295,7 @@ CO2FluidProperties::d2phiSW_dd2(Real delta, Real tau) const
          4.0 * _d3[i] * _alpha3[i] * std::pow(delta, _d3[i] - 1.0) * (delta - _eps3[i]) +
          _d3[i] * (_d3[i] - 1.0) * std::pow(delta, _d3[i] - 2.0));
 
-  for (unsigned int i = 0; i < _n4.size(); ++i)
+  for (std::size_t i = 0; i < _n4.size(); ++i)
   {
     theta = 1.0 - tau + _A4[i] * std::pow(std::pow(delta - 1.0, 2.0), 1.0 / (2.0 * _beta4[i]));
     Delta = std::pow(theta, 2.0) + _B4[i] * std::pow(std::pow(delta - 1.0, 2.0), _a4[i]);
@@ -334,7 +334,7 @@ CO2FluidProperties::d2phiSW_dt2(Real delta, Real tau) const
 {
   // Second derivative of the ideal gas component wrt tau
   Real sum0 = 0.0;
-  for (unsigned int i = 0; i < _a0.size(); ++i)
+  for (std::size_t i = 0; i < _a0.size(); ++i)
     sum0 += _a0[i] * _theta0[i] * _theta0[i] * std::exp(-_theta0[i] * tau) *
             std::pow(1.0 - std::exp(-_theta0[i] * tau), -2.0);
 
@@ -344,22 +344,22 @@ CO2FluidProperties::d2phiSW_dt2(Real delta, Real tau) const
   Real d2phirdt2 = 0.0;
   Real theta, Delta, Psi, dPsi_dt, dDelta_dt, d2Delta_dt2, d2Psi_dt2;
 
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     d2phirdt2 +=
         _n1[i] * _t1[i] * (_t1[i] - 1.0) * std::pow(delta, _d1[i]) * std::pow(tau, _t1[i] - 2.0);
 
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     d2phirdt2 += _n2[i] * _t2[i] * (_t2[i] - 1.0) * std::pow(delta, _d2[i]) *
                  std::exp(-std::pow(delta, _c2[i])) * std::pow(tau, _t2[i] - 2.0);
 
-  for (unsigned int i = 0; i < _n3.size(); ++i)
+  for (std::size_t i = 0; i < _n3.size(); ++i)
     d2phirdt2 += _n3[i] * std::pow(delta, _d3[i]) * std::pow(tau, _t3[i]) *
                  std::exp(-_alpha3[i] * std::pow(delta - _eps3[i], 2.0) -
                           _beta3[i] * std::pow(tau - _gamma3[i], 2.0)) *
                  (std::pow(_t3[i] / tau - 2.0 * _beta3[i] * (tau - _gamma3[i]), 2.0) -
                   _t3[i] / tau / tau - 2.0 * _beta3[i]);
 
-  for (unsigned int i = 0; i < _n4.size(); ++i)
+  for (std::size_t i = 0; i < _n4.size(); ++i)
   {
     theta = 1.0 - tau + _A4[i] * std::pow(std::pow(delta - 1.0, 2.0), 1.0 / (2.0 * _beta4[i]));
     Delta = std::pow(theta, 2.0) + _B4[i] * std::pow(std::pow(delta - 1.0, 2.0), _a4[i]);
@@ -384,23 +384,23 @@ CO2FluidProperties::d2phiSW_ddt(Real delta, Real tau) const
   // Derivative of the residual component wrt gamma
   Real theta, Delta, Psi, dDelta_dd, dPsi_dd, dDelta_dt, dPsi_dt, d2Delta_ddt, d2Psi_ddt;
   Real d2phirddt = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     d2phirddt +=
         _n1[i] * _d1[i] * _t1[i] * std::pow(delta, _d1[i] - 1.0) * std::pow(tau, _t1[i] - 1.0);
 
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     d2phirddt += _n2[i] * std::exp(-std::pow(delta, _c2[i])) *
                  (std::pow(delta, _d2[i] - 1.0) * _t2[i] * std::pow(tau, _t2[i] - 1.0) *
                   (_d2[i] - _c2[i] * std::pow(delta, _c2[i])));
 
-  for (unsigned int i = 0; i < _n3.size(); ++i)
+  for (std::size_t i = 0; i < _n3.size(); ++i)
     d2phirddt += _n3[i] * std::pow(delta, _d3[i]) * std::pow(tau, _t3[i]) *
                  std::exp(-_alpha3[i] * std::pow(delta - _eps3[i], 2.0) -
                           _beta3[i] * std::pow(tau - _gamma3[i], 2.0)) *
                  (_d3[i] / delta - 2.0 * _alpha3[i] * (delta - _eps3[i])) *
                  (_t3[i] / tau - 2.0 * _beta3[i] * (tau - _gamma3[i]));
 
-  for (unsigned int i = 0; i < _n4.size(); ++i)
+  for (std::size_t i = 0; i < _n4.size(); ++i)
   {
     theta = 1.0 - tau + _A4[i] * std::pow(std::pow(delta - 1.0, 2.0), 1.0 / (2.0 * _beta4[i]));
     Delta = std::pow(theta, 2.0) + _B4[i] * std::pow(std::pow(delta - 1.0, 2.0), _a4[i]);
@@ -522,7 +522,7 @@ CO2FluidProperties::mu(Real density, Real temperature) const
   // Viscosity in the zero-density limit
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     sum += a[i] * std::pow(std::log(Tstar), i);
 
   Real mu0 = 1.00697 * std::sqrt(temperature) / std::exp(sum);
@@ -532,7 +532,7 @@ CO2FluidProperties::mu(Real density, Real temperature) const
              d[2] * std::pow(density, 6) / std::pow(Tstar, 3) + d[3] * std::pow(density, 8) +
              d[4] * std::pow(density, 8) / Tstar;
 
-  return (mu0 + mue) * 1e-6; // convert to Pa.s
+  return (mu0 + mue) * 1.0e-6; // convert to Pa.s
 }
 
 void
@@ -551,7 +551,7 @@ CO2FluidProperties::mu_drhoT(
   // Viscosity in the zero-density limit. Note this is only a function of T
   Real sum0 = 0.0;
 
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     sum0 += a[i] * std::pow(std::log(Tstar), i);
 
   Real mu0 = 1.00697 * std::sqrt(temperature) / std::exp(sum0);
@@ -572,8 +572,8 @@ CO2FluidProperties::mu_drhoT(
   Real mu2T = this->mu(density, temperature + Teps);
 
   // Viscosity in Pa.s is
-  mu = (mu0 + mue) * 1e-6;
-  dmu_drho = dmuedrho * 1e-6;
+  mu = (mu0 + mue) * 1.0e-6;
+  dmu_drho = dmuedrho * 1.0e-6;
   dmu_dT = (mu2T - mu) / Teps;
 }
 
@@ -585,7 +585,7 @@ CO2FluidProperties::partialDensity(Real temperature) const
   // The parial volume
   Real V = 37.51 - 9.585e-2 * Tc + 8.74e-4 * Tc * Tc - 5.044e-7 * Tc * Tc * Tc;
 
-  return 1.e6 * _Mco2 / V;
+  return 1.0e6 * _Mco2 / V;
 }
 
 Real
@@ -714,11 +714,11 @@ CO2FluidProperties::k(Real density, Real temperature) const
   Real rhor = density / _critical_density;
 
   Real sum1 = 0.0;
-  for (unsigned int i = 0; i < n1.size(); ++i)
+  for (std::size_t i = 0; i < n1.size(); ++i)
     sum1 += n1[i] * std::pow(Tr, g1[i]) * std::pow(rhor, h1[i]);
 
   Real sum2 = 0.0;
-  for (unsigned int i = 0; i < n2.size(); ++i)
+  for (std::size_t i = 0; i < n2.size(); ++i)
     sum2 += n2[i] * std::pow(Tr, g2[i]) * std::pow(rhor, h2[i]);
 
   // Near-critical enhancement

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -29,7 +29,7 @@ IdealGasFluidProperties::IdealGasFluidProperties(const InputParameters & paramet
     _mu(getParam<Real>("mu")),
     _k(getParam<Real>("k"))
 {
-  _cp = _gamma * _R / (_gamma - 1);
+  _cp = _gamma * _R / (_gamma - 1.0);
   _cv = _cp / _gamma;
 }
 
@@ -43,7 +43,7 @@ IdealGasFluidProperties::pressure(Real v, Real u) const
 
   // The std::max function serves as a hard limiter, which will guarantee non-negative pressure
   // when resolving strongly nonlinear waves
-  return std::max(1e-8, (_gamma - 1.) * u / v);
+  return std::max(1.0e-8, (_gamma - 1.0) * u / v);
 }
 
 Real
@@ -57,9 +57,8 @@ IdealGasFluidProperties::c(Real v, Real u) const
 {
   Real temp = temperature(v, u);
   // The std::max function serves as a hard limiter, which will guarantee non-negative speed of
-  // sound
-  // when resolving strongly nonlinear waves
-  return std::sqrt(std::max(1e-8, _gamma * _R * temp));
+  // sound when resolving strongly nonlinear waves
+  return std::sqrt(std::max(1.0e-8, _gamma * _R * temp));
 }
 
 Real IdealGasFluidProperties::cp(Real, Real) const { return _cp; }
@@ -75,17 +74,17 @@ Real IdealGasFluidProperties::k(Real, Real) const { return _k; }
 Real IdealGasFluidProperties::s(Real, Real) const
 {
   mooseError(name(), ": s() not implemented.");
-  return 0;
+  return 0.0;
 }
 
 void
 IdealGasFluidProperties::dp_duv(
     Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const
 {
-  dp_dv = -(_gamma - 1) * u / v / v;
-  dp_du = (_gamma - 1) / v;
-  dT_dv = 0;
-  dT_du = 1 / _cv;
+  dp_dv = -(_gamma - 1.0) * u / v / v;
+  dp_du = (_gamma - 1.0) / v;
+  dT_dv = 0.0;
+  dT_du = 1.0 / _cv;
 }
 
 void
@@ -112,7 +111,7 @@ IdealGasFluidProperties::rho_e(Real pressure, Real temperature, Real & rho, Real
 Real
 IdealGasFluidProperties::rho(Real pressure, Real temperature) const
 {
-  if ((_gamma - 1) * pressure == 0.)
+  if ((_gamma - 1.0) * pressure == 0.0)
     mooseError(name(),
                ": Invalid gamma or pressure detected in rho(pressure = ",
                pressure,
@@ -129,7 +128,7 @@ IdealGasFluidProperties::rho_dpT(
 {
   Real temp2 = temperature * temperature;
   rho = pressure / (_gamma - 1.0) / _cv / temperature;
-  drho_dp = 1 / (_gamma - 1.0) / _cv / temperature;
+  drho_dp = 1.0 / (_gamma - 1.0) / _cv / temperature;
   drho_dT = -pressure / (_gamma - 1.0) / _cv / temp2;
 }
 
@@ -137,14 +136,14 @@ void
 IdealGasFluidProperties::e_dpT(Real, Real temperature, Real & e, Real & de_dp, Real & de_dT) const
 {
   e = temperature * _cv;
-  de_dp = 0;
+  de_dp = 0.0;
   de_dT = _cv;
 }
 
 Real
 IdealGasFluidProperties::e(Real pressure, Real rho) const
 {
-  return pressure / (_gamma - 1) / rho;
+  return pressure / (_gamma - 1.0) / rho;
 }
 
 void
@@ -152,8 +151,8 @@ IdealGasFluidProperties::e_dprho(
     Real pressure, Real rho, Real & e, Real & de_dp, Real & de_drho) const
 {
   e = this->e(pressure, rho);
-  de_dp = 1 / (_gamma - 1) / rho;
-  de_drho = -pressure / (_gamma - 1) / rho / rho;
+  de_dp = 1.0 / (_gamma - 1.0) / rho;
+  de_drho = -pressure / (_gamma - 1.0) / rho / rho;
 }
 
 Real
@@ -170,18 +169,18 @@ IdealGasFluidProperties::h_dpT(
 {
   h = this->h(pressure, temperature);
   Real rho = this->rho(pressure, temperature);
-  dh_dp = 0;
+  dh_dp = 0.0;
   dh_dT = _cv + pressure / rho / temperature;
 }
 
 Real IdealGasFluidProperties::p_from_h_s(Real /*h*/, Real /*s*/) const
 {
   mooseError(name(), ": p_from_h_s() not implemented.");
-  return 0;
+  return 0.0;
 }
 
 Real IdealGasFluidProperties::dpdh_from_h_s(Real /*h*/, Real /*s*/) const
 {
   mooseError(name(), ": dpdh_from_h_s() not implemented.");
-  return 0;
+  return 0.0;
 }

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -134,7 +134,7 @@ MethaneFluidProperties::cp(Real /*pressure*/, Real temperature) const
     a = {1.04356e1, -4.2025284e-2, 8.849006e-5, -8.4304566e-8, 3.9030203e-11, -7.1345169e-15, 0.0};
 
   Real specific_heat = 0.0;
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     specific_heat += a[i] * std::pow(temperature, i);
 
   // convert to J/kg/K by multiplying by 1000
@@ -158,7 +158,7 @@ MethaneFluidProperties::mu(Real /*density*/, Real temperature) const
       2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11, -2.7237166e-14};
 
   Real viscosity = 0.0;
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     viscosity += a[i] * std::pow(temperature, i);
 
   return viscosity * 1.e-6;
@@ -175,7 +175,7 @@ MethaneFluidProperties::mu_drhoT(
   dmu_drho = 0.0;
 
   Real dmudt = 0.0;
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     dmudt += i * a[i] * std::pow(temperature, i - 1.0);
   dmu_dT = dmudt * 1.e-6;
 }
@@ -196,7 +196,7 @@ MethaneFluidProperties::k(Real /*density*/, Real temperature) const
                             -1.95048736e-18};
 
   Real kt = 0.0;
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     kt += a[i] * std::pow(temperature, i);
 
   return kt;
@@ -216,7 +216,7 @@ MethaneFluidProperties::s(Real /*pressure*/, Real temperature) const
     a = {1.04356e1, -4.2025284e-2, 8.849006e-5, -8.4304566e-8, 3.9030203e-11, -7.1345169e-15, 0.0};
 
   Real entropy = a[0] * std::log(temperature);
-  for (unsigned int i = 1; i < a.size(); ++i)
+  for (std::size_t i = 1; i < a.size(); ++i)
     entropy += a[i] * std::pow(temperature, i) / static_cast<Real>(i);
 
   // convert to J/kg/K by multiplying by 1000
@@ -237,7 +237,7 @@ MethaneFluidProperties::h(Real /*pressure*/, Real temperature) const
     a = {1.04356e1, -4.2025284e-2, 8.849006e-5, -8.4304566e-8, 3.9030203e-11, -7.1345169e-15, 0.0};
 
   Real enthalpy = 0.0;
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     enthalpy += a[i] * std::pow(temperature, i + 1) / (i + 1.0);
 
   // convert to J/kg by multiplying by 1000
@@ -259,7 +259,7 @@ MethaneFluidProperties::h_dpT(
     a = {1.04356e1, -4.2025284e-2, 8.849006e-5, -8.4304566e-8, 3.9030203e-11, -7.1345169e-15, 0.0};
 
   Real dhdt = 0.0;
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     dhdt += a[i] * std::pow(temperature, i);
 
   // convert to J/kg/K by multiplying by 1000

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
@@ -42,7 +42,7 @@ SinglePhaseFluidPropertiesPT::henryConstantIAPWS(Real temperature, Real A, Real 
   std::vector<Real> b{1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     sum += a[i] * std::pow(tau, b[i]);
 
   return 22.064e6 * std::exp(sum / Tr) * std::exp(lnkh);
@@ -70,7 +70,7 @@ SinglePhaseFluidPropertiesPT::henryConstantIAPWS_dT(
   Real sum = 0.0;
   Real dsum = 0.0;
 
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
   {
     sum += a[i] * std::pow(tau, b[i]);
     dsum += a[i] * b[i] * std::pow(tau, b[i] - 1.0);

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -43,13 +43,13 @@ StiffenedGasFluidProperties::~StiffenedGasFluidProperties() {}
 Real
 StiffenedGasFluidProperties::pressure(Real v, Real u) const
 {
-  return (_gamma - 1) * (u - _q) / v - _gamma * _p_inf;
+  return (_gamma - 1.0) * (u - _q) / v - _gamma * _p_inf;
 }
 
 Real
 StiffenedGasFluidProperties::temperature(Real v, Real u) const
 {
-  return (1 / _cv) * (u - _q - _p_inf * v);
+  return (1.0 / _cv) * (u - _q - _p_inf * v);
 }
 
 Real
@@ -71,8 +71,8 @@ StiffenedGasFluidProperties::s(Real v, Real u) const
 {
   Real T = this->temperature(v, u);
   Real p = this->pressure(v, u);
-  Real n = std::pow(T, _gamma) / std::pow(p + _p_inf, _gamma - 1);
-  if (n <= 0)
+  Real n = std::pow(T, _gamma) / std::pow(p + _p_inf, _gamma - 1.0);
+  if (n <= 0.0)
     mooseError(name(), ": Negative argument in the ln() function.");
   return _cv * std::log(n) + _q_prime;
 }
@@ -81,17 +81,17 @@ void
 StiffenedGasFluidProperties::dp_duv(
     Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const
 {
-  dp_dv = -(_gamma - 1) * (u - _q) / v / v;
-  dp_du = (_gamma - 1) / v;
+  dp_dv = -(_gamma - 1.0) * (u - _q) / v / v;
+  dp_du = (_gamma - 1.0) / v;
   dT_dv = -_p_inf / _cv;
-  dT_du = 1 / _cv;
+  dT_du = 1.0 / _cv;
 }
 
 void
 StiffenedGasFluidProperties::rho_e_ps(Real pressure, Real entropy, Real & rho, Real & e) const
 {
-  Real a = (entropy - _q_prime + _cv * std::log(std::pow(pressure + _p_inf, _gamma - 1))) / _cv;
-  Real T = std::pow(std::exp(a), 1 / _gamma);
+  Real a = (entropy - _q_prime + _cv * std::log(std::pow(pressure + _p_inf, _gamma - 1.0))) / _cv;
+  Real T = std::pow(std::exp(a), 1.0 / _gamma);
   rho = this->rho(pressure, T);
   e = this->e(pressure, rho);
 }
@@ -111,7 +111,7 @@ StiffenedGasFluidProperties::rho_e_dps(Real pressure,
 
   // compute temperature
   const Real aux =
-      (entropy - _q_prime + _cv * std::log(std::pow(pressure + _p_inf, _gamma - 1))) / _cv;
+      (entropy - _q_prime + _cv * std::log(std::pow(pressure + _p_inf, _gamma - 1.0))) / _cv;
   const Real T = std::pow(std::exp(aux), 1 / _gamma);
 
   // dT/dp
@@ -165,20 +165,20 @@ StiffenedGasFluidProperties::rho_e(Real pressure, Real temperature, Real & rho, 
 Real
 StiffenedGasFluidProperties::rho(Real pressure, Real temperature) const
 {
-  mooseAssert(((_gamma - 1) * _cv * temperature) != 0.0,
+  mooseAssert(((_gamma - 1.0) * _cv * temperature) != 0.0,
               "Invalid gamma or cv or temperature detected!");
-  return (pressure + _p_inf) / ((_gamma - 1) * _cv * temperature);
+  return (pressure + _p_inf) / ((_gamma - 1.0) * _cv * temperature);
 }
 
 void
 StiffenedGasFluidProperties::rho_dpT(
     Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
 {
-  mooseAssert(((_gamma - 1) * _cv * temperature) != 0.0,
+  mooseAssert(((_gamma - 1.0) * _cv * temperature) != 0.0,
               "Invalid gamma or cv or temperature detected!");
   rho = (pressure + _p_inf) / ((_gamma - 1) * _cv * temperature);
-  drho_dp = 1. / ((_gamma - 1) * _cv * temperature);
-  drho_dT = -(pressure + _p_inf) / ((_gamma - 1) * _cv * temperature * temperature);
+  drho_dp = 1. / ((_gamma - 1.0) * _cv * temperature);
+  drho_dT = -(pressure + _p_inf) / ((_gamma - 1.0) * _cv * temperature * temperature);
 }
 
 void
@@ -190,18 +190,18 @@ StiffenedGasFluidProperties::e_dpT(Real, Real, Real &, Real &, Real &) const
 Real
 StiffenedGasFluidProperties::e(Real pressure, Real rho) const
 {
-  mooseAssert((_gamma - 1) * rho != 0., "Invalid gamma or density detected!");
-  return (pressure + _gamma * _p_inf) / ((_gamma - 1) * rho) + _q;
+  mooseAssert((_gamma - 1.0) * rho != 0., "Invalid gamma or density detected!");
+  return (pressure + _gamma * _p_inf) / ((_gamma - 1.0) * rho) + _q;
 }
 
 void
 StiffenedGasFluidProperties::e_dprho(
     Real pressure, Real rho, Real & e, Real & de_dp, Real & de_drho) const
 {
-  mooseAssert((_gamma - 1) * rho != 0., "Invalid gamma or density detected!");
+  mooseAssert((_gamma - 1.0) * rho != 0., "Invalid gamma or density detected!");
   e = this->e(pressure, rho);
-  de_dp = 1. / ((_gamma - 1) * rho);
-  de_drho = -(pressure + _gamma * _p_inf) / ((_gamma - 1) * rho * rho);
+  de_dp = 1.0 / ((_gamma - 1.0) * rho);
+  de_drho = -(pressure + _gamma * _p_inf) / ((_gamma - 1.0) * rho * rho);
 }
 
 Real
@@ -215,15 +215,15 @@ StiffenedGasFluidProperties::h_dpT(
     Real, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const
 {
   h = _gamma * _cv * temperature + _q;
-  dh_dp = 0;
+  dh_dp = 0.0;
   dh_dT = _gamma * _cv;
 }
 
 Real
 StiffenedGasFluidProperties::p_from_h_s(Real h, Real s) const
 {
-  return std::pow((h - _q) / (_gamma * _cv), _gamma / (_gamma - 1)) *
-             std::exp((_q_prime - s) / ((_gamma - 1) * _cv)) -
+  return std::pow((h - _q) / (_gamma * _cv), _gamma / (_gamma - 1.0)) *
+             std::exp((_q_prime - s) / ((_gamma - 1.0) * _cv)) -
          _p_inf;
 }
 

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -489,14 +489,14 @@ Water97FluidProperties::mu(Real density, Real temperature) const
 
   // Viscosity in limit of zero density
   Real sum0 = 0.0;
-  for (unsigned int i = 0; i < H0.size(); ++i)
+  for (std::size_t i = 0; i < H0.size(); ++i)
     sum0 += H0[i] / std::pow(Tbar, i);
 
   Real mu0 = 100.0 * std::sqrt(Tbar) / sum0;
 
   // Residual component due to finite density
   Real sum1 = 0.0;
-  for (unsigned int i = 0; i < H1.size(); ++i)
+  for (std::size_t i = 0; i < H1.size(); ++i)
     sum1 += std::pow(1.0 / Tbar - 1.0, I[i]) * H1[i] * std::pow(rhobar - 1.0, J[i]);
 
   Real mu1 = std::exp(rhobar * sum1);
@@ -526,7 +526,7 @@ Water97FluidProperties::mu_drhoT(
 
   // Limit of zero density. Derivative wrt rho is 0
   Real sum0 = 0.0;
-  for (unsigned int i = 0; i < H0.size(); ++i)
+  for (std::size_t i = 0; i < H0.size(); ++i)
     sum0 += H0[i] / std::pow(Tbar, i);
 
   Real mu0 = 100.0 * std::sqrt(Tbar) / sum0;
@@ -534,7 +534,7 @@ Water97FluidProperties::mu_drhoT(
   // Residual component due to finite density
   Real sum1 = 0.0;
   Real dsum1_drho = 0.0;
-  for (unsigned int i = 0; i < H1.size(); ++i)
+  for (std::size_t i = 0; i < H1.size(); ++i)
   {
     sum1 += std::pow(1.0 / Tbar - 1.0, I[i]) * H1[i] * std::pow(rhobar - 1.0, J[i]);
     dsum1_drho +=
@@ -568,7 +568,7 @@ Water97FluidProperties::k(Real density, Real temperature) const
   // Ideal gas component
   Real sum0 = 0.0;
 
-  for (unsigned int i = 0; i < a.size(); ++i)
+  for (std::size_t i = 0; i < a.size(); ++i)
     sum0 += a[i] * std::pow(Tbar, i);
 
   Real lambda0 = std::sqrt(Tbar) * sum0;
@@ -939,7 +939,7 @@ Real
 Water97FluidProperties::gamma1(Real pi, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     sum += _n1[i] * std::pow(7.1 - pi, _I1[i]) * std::pow(tau - 1.222, _J1[i]);
 
   return sum;
@@ -949,7 +949,7 @@ Real
 Water97FluidProperties::dgamma1_dpi(Real pi, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     sum += -_n1[i] * _I1[i] * std::pow(7.1 - pi, _I1[i] - 1) * std::pow(tau - 1.222, _J1[i]);
 
   return sum;
@@ -959,7 +959,7 @@ Real
 Water97FluidProperties::d2gamma1_dpi2(Real pi, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     sum += _n1[i] * _I1[i] * (_I1[i] - 1) * std::pow(7.1 - pi, _I1[i] - 2) *
            std::pow(tau - 1.222, _J1[i]);
 
@@ -970,7 +970,7 @@ Real
 Water97FluidProperties::dgamma1_dtau(Real pi, Real tau) const
 {
   Real g = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     g += _n1[i] * _J1[i] * std::pow(7.1 - pi, _I1[i]) * std::pow(tau - 1.222, _J1[i] - 1);
 
   return g;
@@ -980,7 +980,7 @@ Real
 Water97FluidProperties::d2gamma1_dtau2(Real pi, Real tau) const
 {
   Real dg = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     dg += _n1[i] * _J1[i] * (_J1[i] - 1) * std::pow(7.1 - pi, _I1[i]) *
           std::pow(tau - 1.222, _J1[i] - 2);
 
@@ -991,7 +991,7 @@ Real
 Water97FluidProperties::d2gamma1_dpitau(Real pi, Real tau) const
 {
   Real dg = 0.0;
-  for (unsigned int i = 0; i < _n1.size(); ++i)
+  for (std::size_t i = 0; i < _n1.size(); ++i)
     dg += -_n1[i] * _I1[i] * _J1[i] * std::pow(7.1 - pi, _I1[i] - 1) *
           std::pow(tau - 1.222, _J1[i] - 1);
 
@@ -1003,14 +1003,14 @@ Water97FluidProperties::gamma2(Real pi, Real tau) const
 {
   // Ideal gas part of the Gibbs free energy
   Real sum0 = 0.0;
-  for (unsigned int i = 0; i < _n02.size(); ++i)
+  for (std::size_t i = 0; i < _n02.size(); ++i)
     sum0 += _n02[i] * std::pow(tau, _J02[i]);
 
   Real g0 = std::log(pi) + sum0;
 
   // Residual part of the Gibbs free energy
   Real gr = 0.0;
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     gr += _n2[i] * std::pow(pi, _I2[i]) * std::pow(tau - 0.5, _J2[i]);
 
   return g0 + gr;
@@ -1024,7 +1024,7 @@ Water97FluidProperties::dgamma2_dpi(Real pi, Real tau) const
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     dgr += _n2[i] * _I2[i] * std::pow(pi, _I2[i] - 1) * std::pow(tau - 0.5, _J2[i]);
 
   return dg0 + dgr;
@@ -1038,7 +1038,7 @@ Water97FluidProperties::d2gamma2_dpi2(Real pi, Real tau) const
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     dgr += _n2[i] * _I2[i] * (_I2[i] - 1) * std::pow(pi, _I2[i] - 2) * std::pow(tau - 0.5, _J2[i]);
 
   return dg0 + dgr;
@@ -1049,12 +1049,12 @@ Water97FluidProperties::dgamma2_dtau(Real pi, Real tau) const
 {
   // Ideal gas part of the Gibbs free energy
   Real dg0 = 0.0;
-  for (unsigned int i = 0; i < _n02.size(); ++i)
+  for (std::size_t i = 0; i < _n02.size(); ++i)
     dg0 += _n02[i] * _J02[i] * std::pow(tau, _J02[i] - 1);
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     dgr += _n2[i] * _J2[i] * std::pow(pi, _I2[i]) * std::pow(tau - 0.5, _J2[i] - 1);
 
   return dg0 + dgr;
@@ -1065,12 +1065,12 @@ Water97FluidProperties::d2gamma2_dtau2(Real pi, Real tau) const
 {
   // Ideal gas part of the Gibbs free energy
   Real dg0 = 0.0;
-  for (unsigned int i = 0; i < _n02.size(); ++i)
+  for (std::size_t i = 0; i < _n02.size(); ++i)
     dg0 += _n02[i] * _J02[i] * (_J02[i] - 1) * std::pow(tau, _J02[i] - 2);
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     dgr += _n2[i] * _J2[i] * (_J2[i] - 1) * std::pow(pi, _I2[i]) * std::pow(tau - 0.5, _J2[i] - 2);
 
   return dg0 + dgr;
@@ -1084,7 +1084,7 @@ Water97FluidProperties::d2gamma2_dpitau(Real pi, Real tau) const
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n2.size(); ++i)
+  for (std::size_t i = 0; i < _n2.size(); ++i)
     dgr += _n2[i] * _I2[i] * _J2[i] * std::pow(pi, _I2[i] - 1) * std::pow(tau - 0.5, _J2[i] - 1);
 
   return dg0 + dgr;
@@ -1094,7 +1094,7 @@ Real
 Water97FluidProperties::phi3(Real delta, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 1; i < _n3.size(); ++i)
+  for (std::size_t i = 1; i < _n3.size(); ++i)
     sum += _n3[i] * std::pow(delta, _I3[i]) * std::pow(tau, _J3[i]);
 
   return _n3[0] * std::log(delta) + sum;
@@ -1104,7 +1104,7 @@ Real
 Water97FluidProperties::dphi3_ddelta(Real delta, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 1; i < _n3.size(); ++i)
+  for (std::size_t i = 1; i < _n3.size(); ++i)
     sum += _n3[i] * _I3[i] * std::pow(delta, _I3[i] - 1) * std::pow(tau, _J3[i]);
 
   return _n3[0] / delta + sum;
@@ -1114,7 +1114,7 @@ Real
 Water97FluidProperties::d2phi3_ddelta2(Real delta, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 1; i < _n3.size(); ++i)
+  for (std::size_t i = 1; i < _n3.size(); ++i)
     sum += _n3[i] * _I3[i] * (_I3[i] - 1) * std::pow(delta, _I3[i] - 2) * std::pow(tau, _J3[i]);
 
   return -_n3[0] / delta / delta + sum;
@@ -1124,7 +1124,7 @@ Real
 Water97FluidProperties::dphi3_dtau(Real delta, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 1; i < _n3.size(); ++i)
+  for (std::size_t i = 1; i < _n3.size(); ++i)
     sum += _n3[i] * _J3[i] * std::pow(delta, _I3[i]) * std::pow(tau, _J3[i] - 1);
 
   return sum;
@@ -1134,7 +1134,7 @@ Real
 Water97FluidProperties::d2phi3_dtau2(Real delta, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 1; i < _n3.size(); ++i)
+  for (std::size_t i = 1; i < _n3.size(); ++i)
     sum += _n3[i] * _J3[i] * (_J3[i] - 1) * std::pow(delta, _I3[i]) * std::pow(tau, _J3[i] - 2);
 
   return sum;
@@ -1144,7 +1144,7 @@ Real
 Water97FluidProperties::d2phi3_ddeltatau(Real delta, Real tau) const
 {
   Real sum = 0.0;
-  for (unsigned int i = 1; i < _n3.size(); ++i)
+  for (std::size_t i = 1; i < _n3.size(); ++i)
     sum += _n3[i] * _I3[i] * _J3[i] * std::pow(delta, _I3[i] - 1) * std::pow(tau, _J3[i] - 1);
 
   return sum;
@@ -1155,14 +1155,14 @@ Water97FluidProperties::gamma5(Real pi, Real tau) const
 {
   // Ideal gas part of the Gibbs free energy
   Real sum0 = 0.0;
-  for (unsigned int i = 0; i < _n05.size(); ++i)
+  for (std::size_t i = 0; i < _n05.size(); ++i)
     sum0 += _n05[i] * std::pow(tau, _J05[i]);
 
   Real g0 = std::log(pi) + sum0;
 
   // Residual part of the Gibbs free energy
   Real gr = 0.0;
-  for (unsigned int i = 0; i < _n5.size(); ++i)
+  for (std::size_t i = 0; i < _n5.size(); ++i)
     gr += _n5[i] * std::pow(pi, _I5[i]) * std::pow(tau, _J5[i]);
 
   return g0 + gr;
@@ -1176,7 +1176,7 @@ Water97FluidProperties::dgamma5_dpi(Real pi, Real tau) const
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n5.size(); ++i)
+  for (std::size_t i = 0; i < _n5.size(); ++i)
     dgr += _n5[i] * _I5[i] * std::pow(pi, _I5[i] - 1) * std::pow(tau, _J5[i]);
 
   return dg0 + dgr;
@@ -1190,7 +1190,7 @@ Water97FluidProperties::d2gamma5_dpi2(Real pi, Real tau) const
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n5.size(); ++i)
+  for (std::size_t i = 0; i < _n5.size(); ++i)
     dgr += _n5[i] * _I5[i] * (_I5[i] - 1) * std::pow(pi, _I5[i] - 2) * std::pow(tau, _J5[i]);
 
   return dg0 + dgr;
@@ -1201,12 +1201,12 @@ Water97FluidProperties::dgamma5_dtau(Real pi, Real tau) const
 {
   // Ideal gas part of the Gibbs free energy
   Real dg0 = 0.0;
-  for (unsigned int i = 0; i < _n05.size(); ++i)
+  for (std::size_t i = 0; i < _n05.size(); ++i)
     dg0 += _n05[i] * _J05[i] * std::pow(tau, _J05[i] - 1);
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n5.size(); ++i)
+  for (std::size_t i = 0; i < _n5.size(); ++i)
     dgr += _n5[i] * _J5[i] * std::pow(pi, _I5[i]) * std::pow(tau, _J5[i] - 1);
 
   return dg0 + dgr;
@@ -1217,12 +1217,12 @@ Water97FluidProperties::d2gamma5_dtau2(Real pi, Real tau) const
 {
   // Ideal gas part of the Gibbs free energy
   Real dg0 = 0.0;
-  for (unsigned int i = 0; i < _n05.size(); ++i)
+  for (std::size_t i = 0; i < _n05.size(); ++i)
     dg0 += _n05[i] * _J05[i] * (_J05[i] - 1) * std::pow(tau, _J05[i] - 2);
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n5.size(); ++i)
+  for (std::size_t i = 0; i < _n5.size(); ++i)
     dgr += _n5[i] * _J5[i] * (_J5[i] - 1) * std::pow(pi, _I5[i]) * std::pow(tau, _J5[i] - 2);
 
   return dg0 + dgr;
@@ -1236,7 +1236,7 @@ Water97FluidProperties::d2gamma5_dpitau(Real pi, Real tau) const
 
   // Residual part of the Gibbs free energy
   Real dgr = 0.0;
-  for (unsigned int i = 0; i < _n5.size(); ++i)
+  for (std::size_t i = 0; i < _n5.size(); ++i)
     dgr += _n5[i] * _I5[i] * _J5[i] * std::pow(pi, _I5[i] - 1) * std::pow(tau, _J5[i] - 1);
 
   return dg0 + dgr;
@@ -1530,12 +1530,12 @@ Water97FluidProperties::tempXY(Real pressure, subregionEnum xy) const
   Real sum = 0.0;
 
   if (xy == AB || xy == OP || xy == WX)
-    for (unsigned int i = 0; i < n[row].size(); ++i)
+    for (std::size_t i = 0; i < n[row].size(); ++i)
       sum += n[row][i] * std::pow(std::log(pi), I[row][i]);
   else if (xy == EF)
     sum += 3.727888004 * (pi - _p_critical / 1.0e6) + _T_critical;
   else
-    for (unsigned int i = 0; i < n[row].size(); ++i)
+    for (std::size_t i = 0; i < n[row].size(); ++i)
       sum += n[row][i] * std::pow(pi, I[row][i]);
 
   return sum;
@@ -1547,7 +1547,7 @@ Water97FluidProperties::subregionVolume(
 {
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < _n3s[sid].size(); ++i)
+  for (std::size_t i = 0; i < _n3s[sid].size(); ++i)
     sum += _n3s[sid][i] * std::pow(std::pow(pi - a, c), _I3s[sid][i]) *
            std::pow(std::pow(theta - b, d), _J3s[sid][i]);
 
@@ -1581,7 +1581,7 @@ Water97FluidProperties::densityRegion3(Real pressure, Real temperature) const
   // Note that subregion 13 is the only different formulation
   if (sid == 13)
   {
-    for (unsigned int i = 0; i < N; ++i)
+    for (std::size_t i = 0; i < N; ++i)
       sum += _n3s[sid][i] * std::pow(pi - a, _I3s[sid][i]) * std::pow(theta - b, _J3s[sid][i]);
 
     volume = vstar * std::exp(sum);
@@ -1761,7 +1761,7 @@ Water97FluidProperties::temperature_from_ph1(Real pressure, Real enthalpy) const
   Real eta = enthalpy / 2500.0e3;
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < _nph1.size(); ++i)
+  for (std::size_t i = 0; i < _nph1.size(); ++i)
     sum += _nph1[i] * std::pow(pi, _Iph1[i]) * std::pow(eta + 1.0, _Jph1[i]);
 
   return sum;
@@ -1774,7 +1774,7 @@ Water97FluidProperties::temperature_from_ph2a(Real pressure, Real enthalpy) cons
   Real eta = enthalpy / 2000.0e3;
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < _nph2a.size(); ++i)
+  for (std::size_t i = 0; i < _nph2a.size(); ++i)
     sum += _nph2a[i] * std::pow(pi, _Iph2a[i]) * std::pow(eta - 2.1, _Jph2a[i]);
 
   return sum;
@@ -1787,7 +1787,7 @@ Water97FluidProperties::temperature_from_ph2b(Real pressure, Real enthalpy) cons
   Real eta = enthalpy / 2000.0e3;
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < _nph2b.size(); ++i)
+  for (std::size_t i = 0; i < _nph2b.size(); ++i)
     sum += _nph2b[i] * std::pow(pi - 2.0, _Iph2b[i]) * std::pow(eta - 2.6, _Jph2b[i]);
 
   return sum;
@@ -1800,7 +1800,7 @@ Water97FluidProperties::temperature_from_ph2c(Real pressure, Real enthalpy) cons
   Real eta = enthalpy / 2000.0e3;
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < _nph2c.size(); ++i)
+  for (std::size_t i = 0; i < _nph2c.size(); ++i)
     sum += _nph2c[i] * std::pow(pi + 25.0, _Iph2c[i]) * std::pow(eta - 1.8, _Jph2c[i]);
 
   return sum;
@@ -1828,7 +1828,7 @@ Water97FluidProperties::temperature_from_ph3a(Real pressure, Real enthalpy) cons
   Real eta = enthalpy / 2300.0e3;
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < _nph3a.size(); ++i)
+  for (std::size_t i = 0; i < _nph3a.size(); ++i)
     sum += _nph3a[i] * std::pow(pi + 0.24, _Iph3a[i]) * std::pow(eta - 0.615, _Jph3a[i]);
 
   return sum * 760.0;
@@ -1841,7 +1841,7 @@ Water97FluidProperties::temperature_from_ph3b(Real pressure, Real enthalpy) cons
   Real eta = enthalpy / 2800.0e3;
   Real sum = 0.0;
 
-  for (unsigned int i = 0; i < _nph3b.size(); ++i)
+  for (std::size_t i = 0; i < _nph3b.size(); ++i)
     sum += _nph3b[i] * std::pow(pi + 0.298, _Iph3b[i]) * std::pow(eta - 0.72, _Jph3b[i]);
 
   return sum * 860.0;

--- a/modules/fluid_properties/tests/brine/brine.i
+++ b/modules/fluid_properties/tests/brine/brine.i
@@ -136,7 +136,7 @@
     type = MultiComponentFluidPropertiesMaterialPT
     pressure = pressure
     temperature = temperature
-    xnacl = xnacl
+    xmass = xnacl
     fp = brine
   [../]
 []


### PR DESCRIPTION
Just some small edits that I have been accumulating. Basically:

- Add `override` to methods that don't yet have it
- Add missing class descriptions in the aux kernels
- Fix a few typos and errors in comments
- Use decimals explicitly in calculations consistently throughout - e.g.: sometimes had `1/ x`, which have been replaced with `1.0/x` etc
- Use std::size_t in loops over vectors - basically `'s/for (unsigned int /for (std::size_t /g'`

Closes #9353 