### PR TITLE
MultiParameterPlasticityStressUpdate added

### DIFF
--- a/modules/tensor_mechanics/examples/coal_mining/cosserat_elastic.i
+++ b/modules/tensor_mechanics/examples/coal_mining/cosserat_elastic.i
@@ -478,7 +478,7 @@
     warn_about_precision_loss = false
     host_youngs_modulus = 8E3
     host_poissons_ratio = 0.25
-    name_prepender = dp
+    base_name = dp
     DP_model = drucker_prager_model
     tensile_strength = dp_tensile_str_strong_harden
     compressive_strength = dp_compressive_str
@@ -493,7 +493,7 @@
     type = CappedWeakPlaneCosseratStressUpdate
     block = 0
     warn_about_precision_loss = false
-    name_prepender = wp
+    base_name = wp
     cohesion = wp_coh
     tan_friction_angle = wp_tan_fric
     tan_dilation_angle = wp_tan_dil

--- a/modules/tensor_mechanics/examples/coal_mining/cosserat_wp_only.i
+++ b/modules/tensor_mechanics/examples/coal_mining/cosserat_wp_only.i
@@ -447,7 +447,7 @@
     warn_about_precision_loss = false
     host_youngs_modulus = 8E3
     host_poissons_ratio = 0.25
-    name_prepender = dp
+    base_name = dp
     DP_model = drucker_prager_model
     tensile_strength = dp_tensile_str_strong_harden
     compressive_strength = dp_compressive_str
@@ -462,7 +462,7 @@
     type = CappedWeakPlaneCosseratStressUpdate
     block = 0
     warn_about_precision_loss = false
-    name_prepender = wp
+    base_name = wp
     cohesion = wp_coh_harden
     tan_friction_angle = wp_tan_fric
     tan_dilation_angle = wp_tan_dil

--- a/modules/tensor_mechanics/include/materials/CappedDruckerPragerCosseratStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedDruckerPragerCosseratStressUpdate.h
@@ -73,7 +73,7 @@ protected:
                                     Real q_ok,
                                     Real gaE,
                                     const std::vector<Real> & intnl,
-                                    const f_and_derivs & smoothed_q,
+                                    const yieldAndFlow & smoothed_q,
                                     const RankFourTensor & Eijkl,
                                     RankTwoTensor & stress) const override;
 
@@ -84,7 +84,7 @@ protected:
                                          Real p,
                                          Real q,
                                          Real gaE,
-                                         const f_and_derivs & smoothed_q,
+                                         const yieldAndFlow & smoothed_q,
                                          const RankFourTensor & Eijkl,
                                          bool compute_full_tangent_operator,
                                          RankFourTensor & cto) const override;

--- a/modules/tensor_mechanics/include/materials/CappedDruckerPragerStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedDruckerPragerStressUpdate.h
@@ -119,7 +119,7 @@ protected:
   virtual void computeAllQ(Real p,
                            Real q,
                            const std::vector<Real> & intnl,
-                           std::vector<f_and_derivs> & all_q) const override;
+                           std::vector<yieldAndFlow> & all_q) const override;
 
   virtual void preReturnMap(Real p_trial,
                             Real q_trial,
@@ -163,7 +163,7 @@ protected:
                                     Real q_ok,
                                     Real gaE,
                                     const std::vector<Real> & intnl,
-                                    const f_and_derivs & smoothed_q,
+                                    const yieldAndFlow & smoothed_q,
                                     const RankFourTensor & Eijkl,
                                     RankTwoTensor & stress) const override;
 
@@ -174,7 +174,7 @@ protected:
                                          Real p,
                                          Real q,
                                          Real gaE,
-                                         const f_and_derivs & smoothed_q,
+                                         const yieldAndFlow & smoothed_q,
                                          const RankFourTensor & Eijkl,
                                          bool compute_full_tangent_operator,
                                          RankFourTensor & cto) const override;

--- a/modules/tensor_mechanics/include/materials/CappedWeakInclinedPlaneStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedWeakInclinedPlaneStressUpdate.h
@@ -78,7 +78,7 @@ protected:
                                     Real q_ok,
                                     Real gaE,
                                     const std::vector<Real> & intnl,
-                                    const f_and_derivs & smoothed_q,
+                                    const yieldAndFlow & smoothed_q,
                                     const RankFourTensor & Eijkl,
                                     RankTwoTensor & stress) const override;
 
@@ -89,7 +89,7 @@ protected:
                                          Real p,
                                          Real q,
                                          Real gaE,
-                                         const f_and_derivs & smoothed_q,
+                                         const yieldAndFlow & smoothed_q,
                                          const RankFourTensor & Eijkl,
                                          bool compute_full_tangent_operator,
                                          RankFourTensor & cto) const override;

--- a/modules/tensor_mechanics/include/materials/CappedWeakPlaneCosseratStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedWeakPlaneCosseratStressUpdate.h
@@ -41,7 +41,7 @@ protected:
                                          Real p,
                                          Real q,
                                          Real gaE,
-                                         const f_and_derivs & smoothed_q,
+                                         const yieldAndFlow & smoothed_q,
                                          const RankFourTensor & Eijkl,
                                          bool compute_full_tangent_operator,
                                          RankFourTensor & cto) const override;
@@ -51,7 +51,7 @@ protected:
                                     Real q_ok,
                                     Real gaE,
                                     const std::vector<Real> & intnl,
-                                    const f_and_derivs & smoothed_q,
+                                    const yieldAndFlow & smoothed_q,
                                     const RankFourTensor & Eijkl,
                                     RankTwoTensor & stress) const override;
 

--- a/modules/tensor_mechanics/include/materials/CappedWeakPlaneStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedWeakPlaneStressUpdate.h
@@ -95,7 +95,7 @@ protected:
   virtual void computeAllQ(Real p,
                            Real q,
                            const std::vector<Real> & intnl,
-                           std::vector<f_and_derivs> & all_q) const override;
+                           std::vector<yieldAndFlow> & all_q) const override;
 
   virtual void consistentTangentOperator(const RankTwoTensor & stress_trial,
                                          Real p_trial,
@@ -104,7 +104,7 @@ protected:
                                          Real p,
                                          Real q,
                                          Real gaE,
-                                         const f_and_derivs & smoothed_q,
+                                         const yieldAndFlow & smoothed_q,
                                          const RankFourTensor & Eijkl,
                                          bool compute_full_tangent_operator,
                                          RankFourTensor & cto) const override;
@@ -114,7 +114,7 @@ protected:
                                     Real q_ok,
                                     Real gaE,
                                     const std::vector<Real> & intnl,
-                                    const f_and_derivs & smoothed_q,
+                                    const yieldAndFlow & smoothed_q,
                                     const RankFourTensor & Eijkl,
                                     RankTwoTensor & stress) const override;
 

--- a/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
@@ -1,0 +1,625 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+#ifndef MULTIPARAMETERPLASTICITYSTRESSUPDATE_H
+#define MULTIPARAMETERPLASTICITYSTRESSUPDATE_H
+
+#include "StressUpdateBase.h"
+
+#include <array>
+
+class MultiParameterPlasticityStressUpdate;
+
+template <>
+InputParameters validParams<MultiParameterPlasticityStressUpdate>();
+
+/**
+ * MultiParameterPlasticityStressUpdate performs the return-map
+ * algorithm and associated stress updates for plastic
+ * models where the yield function and flow directions
+ * depend on multiple parameters (called "stress_params" in the
+ * documentation and sp in the code) that
+ * are themselves functions of stress.
+ *
+ * Let the stress_params be S = {S[0], S[1], ... S[N-1]}
+ * and define _num_sp = N.
+ *
+ * For instance, CappedDruckerPrager plasticity has _num_sp = 2
+ * and defines
+ * S[0] = p = stress.trace()
+ * S[1] = q = sqrt(stress.secondInvariant())
+ *
+ * The point of the stress_params is to reduce the number of
+ * degrees of freedom involved in the return-map algorithm
+ * (for computational efficiency as all the intensive computation
+ * occurs in "stress_param space") and to allow users to
+ * write their yield functions, etc, in forms that are
+ * clear to them to avoid errors.
+ *
+ * Derived classes can describe plasticity via multiple yield
+ * functions.  The number of yield function is _num_yf.
+ * The yield function(s) and flow potential(s)
+ * must be functions of the stress_params.
+ *
+ * Derived classes can use any number of internal parameters.
+ * The number of internal parameters is _num_intnl.  The
+ * derived classes must define the evolution of these internal
+ * parameters, which are typically functions of certain
+ * "distances" in the return-mapping procedure.
+ *
+ * For instance, CappedDruckerPrager plasticity has three
+ * yield functions (a smoothed DruckerPrager cone, a tensile failure
+ * envelope, and a compressive failure envelope) and two
+ * internal parameters (plastic shear strain and plastic tensile strain).
+ * The strength parameters (cohesion, friction angle,
+ * dilation angle, tensile strength, compressive strength)
+ * are functions of these internal parameters.
+ *
+ * A novel smoothing procedure is used to smooth the derived class's
+ * yield functions into a single, smooth yield function.  The
+ * smoothing is also performed for the flow potential.  All
+ * return-mapping, etc, processes are performed on this single
+ * yield function and flow potential.
+ *
+ * The return-map algorithm implements the updateState method of
+ * StressUpdateBase.  In particular, the following system of
+ * equations is solved:
+ * 0 = _rhs[0] = S[0] - S[0]^trial + ga * E[0, j] * dg/dS[j]
+ * 0 = _rhs[1] = S[1] - S[1]^trial + ga * E[1, j] * dg/dS[j]
+ * ...
+ * 0 = _rhs[N-1] = S[N-1] - S[N-1]^trial + ga * E[N-1, j] * dg/dS[j]
+ * 0 = _rhs[N] = f(S, intnl)
+ * (here there is an implied sum over j)
+ * for the _num_sp stress_params S, and the single scalar ga
+ * (actually I solve for gaE = ga * _En, where _En is a normalising
+ * factor so that gaE is of similar magnitude to the S variables).
+ * There are N+1 rhs equations to solve.  Here f is
+ * the smoothed yield function, so the last equation is the admissibility
+ * condition (the returned stress lies on the yield surface) and g
+ * is the flow potential so the other conditions implement the normality
+ * condition.  It is up to the derived classes to defined E[i, j]
+ * so that the rhs really represents the normality condition.
+ *
+ * For instance, CappedDruckerPrager has (with Eijkl being the elasticity
+ * tensor):
+ * E[0, 0] = _Epp = Eijkl.sum3x3()
+ * E[0, 1] = 0
+ * E[1, 0] = 0
+ * E[1, 1] = Eijkl(0, 1, 0, 1)
+ */
+class MultiParameterPlasticityStressUpdate : public StressUpdateBase
+{
+public:
+  MultiParameterPlasticityStressUpdate(const InputParameters & parameters,
+                                       unsigned num_sp,
+                                       unsigned num_yf,
+                                       unsigned num_intnl);
+
+protected:
+  virtual void initQpStatefulProperties() override;
+  virtual void updateState(RankTwoTensor & strain_increment,
+                           RankTwoTensor & inelastic_strain_increment,
+                           const RankTwoTensor & rotation_increment,
+                           RankTwoTensor & stress_new,
+                           const RankTwoTensor & stress_old,
+                           const RankFourTensor & elasticity_tensor,
+                           const RankTwoTensor & elastic_strain_old,
+                           bool compute_full_tangent_operator,
+                           RankFourTensor & tangent_operator) override;
+
+  virtual void propagateQpStatefulProperties() override;
+
+  /// Internal dimensionality of tensors (currently this is 3 throughout tensor_mechanics)
+  constexpr static unsigned _tensor_dimensionality = 3;
+
+  /// Number of stress parameters
+  const unsigned _num_sp;
+
+  /// An admissible value of stress_params at the initial time
+  const std::vector<Real> _definitely_ok_sp;
+
+  /// E[i, j] in the system of equations to be solved
+  std::vector<std::vector<Real>> _Eij;
+
+  /// normalising factor
+  Real _En;
+
+  /// _Cij[i, j] * _Eij[j, k] = 1 iff j == k
+  std::vector<std::vector<Real>> _Cij;
+
+  /// Number of yield functions
+  const unsigned _num_yf;
+
+  /// Number of internal parameters
+  const unsigned _num_intnl;
+
+  /// String prepended to various MaterialProperties that are defined by this class
+  const std::string _name_prepender;
+
+  /// Maximum number of Newton-Raphson iterations allowed in the return-map process
+  const unsigned _max_nr_its;
+
+  /// Whether to perform finite-strain rotations
+  const bool _perform_finite_strain_rotations;
+
+  /// Smoothing tolerance: edges of the yield surface get smoothed by this amount
+  const Real _smoothing_tol;
+
+  /// The yield-function tolerance
+  const Real _f_tol;
+
+  /// Square of the yield-function tolerance
+  const Real _f_tol2;
+
+  /**
+   * In order to help the Newton-Raphson procedure, the applied
+   * strain increment may be applied in sub-increments of size
+   * greater than this value.
+   */
+  const Real _min_step_size;
+
+  /// handles case of initial_stress that is inadmissible being supplied
+  bool _step_one;
+
+  /// Output a warning message if precision loss is encountered during the return-map process
+  const bool _warn_about_precision_loss;
+
+  /// plastic strain
+  MaterialProperty<RankTwoTensor> & _plastic_strain;
+
+  /// Old value of plastic strain
+  const MaterialProperty<RankTwoTensor> & _plastic_strain_old;
+
+  /// internal parameters
+  MaterialProperty<std::vector<Real>> & _intnl;
+
+  /// old values of internal parameters
+  const MaterialProperty<std::vector<Real>> & _intnl_old;
+
+  /// yield functions
+  MaterialProperty<std::vector<Real>> & _yf;
+
+  /// Number of Newton-Raphson iterations used in the return-map
+  MaterialProperty<Real> & _iter;
+
+  /// Whether a line-search was needed in the latest Newton-Raphson process (1 if true, 0 otherwise)
+  MaterialProperty<Real> & _linesearch_needed;
+
+  /**
+   * Struct designed to hold info about a single yield function
+   * and its derivatives, as well as the flow directions
+   */
+  struct yieldAndFlow
+  {
+    Real f;                                // yield function value
+    std::vector<Real> df;                  // df/d(stress_param[i])
+    std::vector<Real> df_di;               // df/d(intnl_variable[a])
+    std::vector<Real> dg;                  // d(flow)/d(stress_param[i])
+    std::vector<std::vector<Real>> d2g;    // d^2(flow)/d(sp[i])/d(sp[j])
+    std::vector<std::vector<Real>> d2g_di; // d^2(flow)/d(sp[i])/d(intnl[a])
+
+    yieldAndFlow() : yieldAndFlow(0, 0) {}
+
+    yieldAndFlow(unsigned num_var, unsigned num_intnl)
+      : f(0.0),
+        df(num_var),
+        df_di(num_intnl),
+        dg(num_var),
+        d2g(num_var, std::vector<Real>(num_var, 0.0)),
+        d2g_di(num_var, std::vector<Real>(num_intnl, 0.0))
+    {
+    }
+
+    // this is involved in the smoothing of a group of yield functions
+    bool operator<(const yieldAndFlow & fd) const { return f < fd.f; }
+  };
+
+  /**
+   * Computes the smoothed yield function
+   * @param stress_params The stress parameters (eg stress_params[0] = stress_zz and
+   * stress_params[1] = sqrt(stress_zx^2 + stress_zy^2))
+   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
+   * @return The smoothed yield function value
+   */
+  Real yieldF(const std::vector<Real> & stress_params, const std::vector<Real> & intnl) const;
+
+  /**
+   * Smooths yield functions
+   */
+  Real ismoother(Real f_diff) const;
+
+  /**
+   * Derivative of ismoother
+   */
+  Real smoother(Real f_diff) const;
+
+  /**
+   * Derivative of smoother
+   */
+  Real dsmoother(Real f_diff) const;
+
+  /**
+   * Calculates all yield functions and derivatives, and then performs the smoothing scheme
+   * @param stress_params[in] The stress parameters (eg stress_params[0] = stress_zz and
+   * stress_params[1] = sqrt(stress_zx^2 + stress_zy^2))
+   * @param intnl[in] Internal parameters
+   * @return The smoothed yield function and derivatives
+   */
+  yieldAndFlow smoothAllQuantities(const std::vector<Real> & stress_params,
+                                   const std::vector<Real> & intnl) const;
+
+  /**
+   * Performs a line-search to find stress_params and gaE
+   * Upon entry:
+   *  - rhs contains the *solution* to the Newton-Raphson (ie nrStep should have been called).  If a
+   * full
+   *    Newton step is used then stress_params[:] += rhs[0:_num_sp-1] and gaE += rhs[_num_sp]
+   *  - res2 contains the residual-squared before applying any of solution
+   *  - stress_params contains the stress_params before applying any of the solution
+   *  - gaE contains gaE before applying any of the solution (that is contained in rhs)
+   * Upon exit:
+   *  - stress_params will be the stress_params after applying the solution
+   *  - gaE will be the stress_params after applying the solution
+   *  - rhs will contain the updated rhs values (after applying the solution) ready for the next
+   * Newton-Raphson step,
+   *  - res2 will be the residual-squared after applying the solution
+   *  - intnl will contain the internal variables corresponding to the return from
+   * trial_stress_params to stress_params
+   *    (and starting from intnl_ok)
+   *  - linesearch_needed will be 1.0 if a linesearch was needed
+   *  - smoothed_q will contain the value of the yield function and its derivatives, etc, at
+   * (stress_params, intnl)
+   * @param res2[in,out] the residual-squared, both as an input and output
+   * @param stress_params[in,out] Upon input the value of the stress_params before the current
+   * Newton-Raphson process was initiated.
+   * Upon exit this will hold the values coming from the line search.
+   * @param trial_stress_params[in] Trial value for the stress_params for this (sub)strain increment
+   * @param gaE[in,out] Upon input the value of gaE before the current Newton-Raphson iteration was
+   * initiated.  Upon exit this will hold
+   * the value coming from the line-search
+   * @param smoothed_q[in,out] Upon input, the value of the smoothed yield function and derivatives
+   * at the
+   * prior-to-Newton configuration.  Upon exit this is evaluated at the new (stress_params, intnl)
+   * @param intnl_ok[in] The value of the internal parameters from the start of this (sub)strain
+   * increment
+   * @param intnl[in,out] The value of the internal parameters after the line-search has converged
+   * @param rhs[in,out] Upon entry this contains the solution to the Newton-Raphson.  Upon exit this
+   * contains the updated rhs values
+   * @return 0 if successful, 1 otherwise
+   */
+  int lineSearch(Real & res2,
+                 std::vector<Real> & stress_params,
+                 Real & gaE,
+                 const std::vector<Real> & trial_stress_params,
+                 yieldAndFlow & smoothed_q,
+                 const std::vector<Real> & intnl_ok,
+                 std::vector<Real> & intnl,
+                 std::vector<Real> & rhs,
+                 Real & linesearch_needed) const;
+
+  /**
+   * Performs a Newton-Raphson step to attempt to zero rhs
+   * Upon return, rhs will contain the solution.
+   * @param smoothed_q[in] The value of the smoothed yield function and derivatives prior to this
+   * Newton-Raphson step
+   * @param trial_stress_params[in] Trial value for the stress_params for this (sub)strain increment
+   * @param stress_params[in] The current value of the stress_params
+   * @param intnl[in] The current value of the internal parameters
+   * @param gaE[in] The current value of gaE
+   * @param rhs[in,out] Upon entry, the rhs to zero using Newton-Raphson.  Upon exit, the solution
+   * to the Newton-Raphson problem
+   * @return 0 if successful, 1 otherwise
+   */
+  int nrStep(const yieldAndFlow & smoothed_q,
+             const std::vector<Real> & trial_stress_params,
+             const std::vector<Real> & stress_params,
+             const std::vector<Real> & intnl,
+             Real gaE,
+             std::vector<Real> & rhs) const;
+
+  /**
+   * Calculates the residual-squared for the Newton-Raphson + line-search
+   * @param rhs[in] The RHS vector
+   * @return sum_i (rhs[i] * rhs[i])
+   */
+  Real calculateRes2(const std::vector<Real> & rhs) const;
+
+  /**
+   * Calculates the RHS in the following
+   * 0 = rhs[0] = S[0] - S[0]^trial + ga * E[0, j] * dg/dS[j]
+   * 0 = rhs[1] = S[1] - S[1]^trial + ga * E[1, j] * dg/dS[j]
+   * ...
+   * 0 = rhs[N-1] = S[N-1] - S[N-1]^trial + ga * E[N-1, j] * dg/dS[j]
+   * 0 = rhs[N] = f(S, intnl)
+   * where N = _num_sp
+   * @param trial_stress_params[in] The trial stress parameters for this (sub)strain increment,
+   * S[:]^trial
+   * @param stress_params[in] The current stress parameters, S[:]
+   * @param gaE[in] ga*_En (the normalisation with _En is so that gaE is of similar magnitude to S)
+   * @param smoothed_q[in] Holds the current value of yield function and derivatives evaluated at
+   * the current stress parameters and the current internal parameters
+   * @param rhs[out] The result
+   */
+  void calculateRHS(const std::vector<Real> & trial_stress_params,
+                    const std::vector<Real> & stress_params,
+                    Real gaE,
+                    const yieldAndFlow & smoothed_q,
+                    std::vector<Real> & rhs) const;
+
+  /**
+   * Derivative of -RHS with respect to the stress_params and gaE, placed
+   * into an array ready for solving the linear system using
+   * LAPACK gsev
+   * @param smoothed_q[in] Holds the current value of yield function and derivatives evaluated at
+   * the
+   * current values of the stress_params and the internal parameters
+   * @param dintnl[in] The derivatives of the internal parameters wrt the stress_params
+   * @param stress_params[in] The current value of the stress_params during the Newton-Raphson
+   * process
+   * @param gaE[in] The current value of gaE
+   * @param jac[out] The outputted derivatives
+   */
+  void dnRHSdVar(const yieldAndFlow & smoothed_q,
+                 const std::vector<std::vector<Real>> & dintnl,
+                 const std::vector<Real> & stress_params,
+                 Real gaE,
+                 std::vector<double> & jac) const;
+
+  /**
+   * Performs any necessary cleaning-up, then throw MooseException(message)
+   * @param message The message to using in MooseException
+   */
+  virtual void errorHandler(const std::string & message) const;
+
+  /**
+   * Computes the values of the yield functions, given stress_params and intnl parameters.
+   * Derived classes must override this, to provide the values of the yield functions
+   * in yf.
+   * @param stress_params[in] The stress parameters
+   * @param intnl[in] The internal parameters
+   * @param[out] yf The yield function values
+   */
+  virtual void yieldFunctionValuesV(const std::vector<Real> & stress_params,
+                                    const std::vector<Real> & intnl,
+                                    std::vector<Real> & yf) const = 0;
+
+  /**
+   * Completely fills all_q with correct values.  These values are:
+   * (1) the yield function values, yf[i]
+   * (2) d(yf[i])/d(stress_params[j])
+   * (3) d(yf[i])/d(intnl[j])
+   * (4) d(flowPotential[i])/d(stress_params[j])
+   * (5) d2(flowPotential[i])/d(stress_params[j])/d(stress_params[k])
+   * (6) d2(flowPotential[i])/d(stress_params[j])/d(intnl[k])
+   * @param stress_params[in] The stress parameters
+   * @param intnl[in] The internal parameters
+   * @param[out] all_q All the desired quantities
+   */
+  virtual void computeAllQV(const std::vector<Real> & stress_params,
+                            const std::vector<Real> & intnl,
+                            std::vector<yieldAndFlow> & all_q) const = 0;
+
+  /**
+   * Derived classes may employ this function to record stuff or do
+   * other computations prior to the return-mapping algorithm.  We
+   * know that (trial_stress_params, intnl_old) is inadmissible when
+   * this is called
+   * @param trial_stress_params[in] The trial values of the stress parameters
+   * @param stress_trial[in] Trial stress tensor
+   * @param intnl_old[in] Old value of the internal parameters.
+   * @param yf[in] The yield functions at (p_trial, q_trial, intnl_old)
+   * @param Eijkl[in] The elasticity tensor
+   */
+  virtual void preReturnMapV(const std::vector<Real> & trial_stress_params,
+                             const RankTwoTensor & stress_trial,
+                             const std::vector<Real> & intnl_old,
+                             const std::vector<Real> & yf,
+                             const RankFourTensor & Eijkl);
+
+  /**
+   * Sets (stress_params, intnl) at "good guesses" of the solution to the Return-Map algorithm.
+   * The purpose of these "good guesses" is to speed up the Newton-Raphson process by providing
+   * it with a good initial guess.
+   * Derived classes may choose to override this if their plastic models are easy
+   * enough to solve approximately.
+   * The default values, provided by this class, are simply gaE = 0, stress_params =
+   * trial_stress_params,
+   * that is, the "good guess" is just the trial point for this (sub)strain increment.
+   * @param trial_stress_params[in] The stress_params at the trial point
+   * @param intnl_old[in] The internal parameters before applying the (sub)strain increment
+   * @param stress_params[out] The "good guess" value of the stress_params
+   * @param gaE[out] The "good guess" value of gaE
+   * @param intnl[out] The "good guess" value of the internal parameters
+   */
+  virtual void initialiseVarsV(const std::vector<Real> & trial_stress_params,
+                               const std::vector<Real> & intnl_old,
+                               std::vector<Real> & stress_params,
+                               Real & gaE,
+                               std::vector<Real> & intnl) const;
+
+  /**
+   * Sets the internal parameters based on the trial values of
+   * stress_params, their current values, and the old values of the
+   * internal parameters.
+   * Derived classes must override this.
+   * @param trial_stress_params[in] The trial stress parameters (eg trial_p and trial_q)
+   * @param current_stress_params[in] The current stress parameters (eg p and q)
+   * @param intnl_old[out] Old value of internal parameters
+   * @param intnl[out] The value of internal parameters to be set
+   */
+  virtual void setIntnlValuesV(const std::vector<Real> & trial_stress_params,
+                               const std::vector<Real> & current_stress_params,
+                               const std::vector<Real> & intnl_old,
+                               std::vector<Real> & intnl) const = 0;
+
+  /**
+   * Sets the derivatives of internal parameters, based on the trial values of
+   * stress_params, their current values, and the old values of the
+   * internal parameters.
+   * Derived classes must override this.
+   * @param trial_stress_params[in] The trial stress parameters
+   * @param current_stress_params[in] The current stress parameters
+   * @param intnl[in] The current value of the internal parameters
+   * @param dintnl[out] The derivatives dintnl[i][j] = d(intnl[i])/d(stress_param j)
+   */
+  virtual void setIntnlDerivativesV(const std::vector<Real> & trial_stress_params,
+                                    const std::vector<Real> & current_stress_params,
+                                    const std::vector<Real> & intnl,
+                                    std::vector<std::vector<Real>> & dintnl) const = 0;
+
+  /**
+   * Computes stress_params, given stress.  Derived classes must
+   * override this
+   * @param stress[in] Stress tensor
+   * @param stress_params[out] The compute stress_params
+   */
+  virtual void computeStressParams(const RankTwoTensor & stress,
+                                   std::vector<Real> & stress_params) const = 0;
+
+  /**
+   * Derived classes may use this to perform calculations before
+   * any return-map process is performed, for instance, to initialise
+   * variables.
+   * This is called at the very start of updateState, even before
+   * any checking for admissible stresses, etc, is performed
+   */
+  virtual void initialiseReturnProcess();
+
+  /**
+   * Derived classes may use this to perform calculations after the
+   * return-map process has completed successfully in stress_param space
+   * but before the returned stress tensor has been calculcated.
+   * @param rotation_increment[in] The large-strain rotation increment
+   */
+  virtual void finalizeReturnProcess(const RankTwoTensor & rotation_increment);
+
+  /**
+   * Sets stress from the admissible parameters.
+   * This is called after the return-map process has completed
+   * successfully in stress_param space, just after finalizeReturnProcess
+   * has been called.
+   * Derived classes may override this function
+   * @param stress_trial[in] The trial value of stress
+   * @param stress_params[in] The value of the stress_params after the return-map process has
+   * completed successfully
+   * @param gaE[in] The value of gaE after the return-map process has completed successfully
+   * @param intnl[in] The value of the internal parameters after the return-map process has
+   * completed successfully
+   * @param smoothed_q[in] Holds the current value of yield function and derivatives evaluated at
+   * the returned state
+   * @param Eijkl[in] The elasticity tensor
+   * @param stress[out] The returned value of the stress tensor
+   */
+  virtual void setStressAfterReturnV(const RankTwoTensor & stress_trial,
+                                     const std::vector<Real> & stress_params,
+                                     Real gaE,
+                                     const std::vector<Real> & intnl,
+                                     const yieldAndFlow & smoothed_q,
+                                     const RankFourTensor & Eijkl,
+                                     RankTwoTensor & stress) const;
+
+  /**
+   * Sets inelastic strain increment from the returned configuration
+   * This is called after the return-map process has completed
+   * successfully in stress_param space, just after finalizeReturnProcess
+   * has been called.
+   * Derived classes may override this function
+   * @param stress_trial[in] The trial value of stress
+   * @param gaE[in] The value of gaE after the return-map process has completed successfully
+   * @param smoothed_q[in] Holds the current value of yield function and derivatives evaluated at
+   * the returned configuration
+   * @param elasticity_tensor[in] The elasticity tensor
+   * @param returned_stress[in] The stress after the return-map process
+   * @param inelastic_strain_increment[out] The inelastic strain increment resulting from this
+   * return-map
+   */
+  virtual void
+  setInelasticStrainIncrementAfterReturn(const RankTwoTensor & stress_trial,
+                                         Real gaE,
+                                         const yieldAndFlow & smoothed_q,
+                                         const RankFourTensor & elasticity_tensor,
+                                         const RankTwoTensor & returned_stress,
+                                         RankTwoTensor & inelastic_strain_increment) const;
+
+  /**
+   * Calculates the consistent tangent operator.
+   * Derived classes may choose to override this for computational
+   * efficiency.  The implementation in this class is quite expensive,
+   * even though it looks compact and clean, because of all the
+   * manipulations of RankFourTensors involved.
+   * @param stress_trial[in] the trial value of the stress tensor for this strain increment
+   * @param trial_stress_params[in] the trial values of the stress_params for this strain increment
+   * @param stress[in] the returned value of the stress tensor for this strain increment
+   * @param stress_params[in] the returned value of the stress_params for this strain increment
+   * @param gaE[in] the total value of that came from this strain increment
+   * @param smoothed_q[in] contains the yield function and derivatives evaluated at (p, q)
+   * @param Eijkl[in] The elasticity tensor
+   * @param compute_full_tangent_operator[in] true if the full consistent tangent operator is
+   * needed,
+   * otherwise false
+   * @param dvar_dtrial[in] dvar_dtrial[i][j] = d({stress_param[i],gaE})/d(trial_stress_param[j])
+   * for
+   * this strain increment
+   * @param[out] cto The consistent tangent operator
+   */
+  virtual void consistentTangentOperatorV(const RankTwoTensor & stress_trial,
+                                          const std::vector<Real> & trial_stress_params,
+                                          const RankTwoTensor & stress,
+                                          const std::vector<Real> & stress_params,
+                                          Real gaE,
+                                          const yieldAndFlow & smoothed_q,
+                                          const RankFourTensor & Eijkl,
+                                          bool compute_full_tangent_operator,
+                                          const std::vector<std::vector<Real>> & dvar_dtrial,
+                                          RankFourTensor & cto);
+
+  /**
+   * d(stress_param[i])/d(stress) at given stress
+   * @param stress stress tensor
+   * @return d(stress_param[:])/d(stress)
+   */
+  virtual std::vector<RankTwoTensor> dstress_param_dstress(const RankTwoTensor & stress) const = 0;
+
+  /**
+   * d2(stress_param[i])/d(stress)/d(stress) at given stress
+   * @param stress stress tensor
+   * @return d2(stress_param[:])/d(stress)/d(stress)
+   */
+  virtual std::vector<RankFourTensor>
+  d2stress_param_dstress(const RankTwoTensor & stress) const = 0;
+
+  /// Sets _Eij and _En and _Cij
+  virtual void setEffectiveElasticity(const RankFourTensor & Eijkl) = 0;
+
+  /**
+   * Calculates derivatives of the stress_params and gaE with repect to the
+   * trial values of the stress_params for the (sub)strain increment
+   * @param elastic_only[in] whether this was an elastic step: if so then the updates to dvar_dtrial
+   * are fairly trivial
+   * @param trial_stress_params[in] Trial values of stress_params for this (sub)strain increment
+   * @param stress_params[in] Returned values of stress_params for this (sub)strain increment
+   * @param gaE[in] the value of gaE that came from this (sub)strain increment
+   * @param intnl[in] the value of the internal parameters at the returned position
+   * @param smoothed_q[in] contains the yield function and derivatives evaluated at (stress_params,
+   * intnl)
+   * @param step_size[in] size of this (sub)strain increment
+   * @param compute_full_tangent_operator[in] true if the full consistent tangent operator is
+   * needed,
+   * otherwise false
+   * @param dvar_dtrial[out] dvar_dtrial[i][j] = d({stress_param[i],gaE})/d(stress_param[j])
+   */
+  void dVardTrial(bool elastic_only,
+                  const std::vector<Real> & trial_stress_params,
+                  const std::vector<Real> & stress_params,
+                  Real gaE,
+                  const std::vector<Real> & intnl,
+                  const yieldAndFlow & smoothed_q,
+                  Real step_size,
+                  bool compute_full_tangent_operator,
+                  std::vector<std::vector<Real>> & dvar_dtrial) const;
+};
+
+#endif // MULTIPARAMETERPLASTICITYSTRESSUPDATE_H

--- a/modules/tensor_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
@@ -7,7 +7,7 @@
 #ifndef TWOPARAMETERPLASTICITYSTRESSUPDATE_H
 #define TWOPARAMETERPLASTICITYSTRESSUPDATE_H
 
-#include "StressUpdateBase.h"
+#include "MultiParameterPlasticityStressUpdate.h"
 
 #include <array>
 
@@ -22,9 +22,9 @@ InputParameters validParams<TwoParameterPlasticityStressUpdate>();
  * models that describe (p, q) plasticity.  That is,
  * for plastic models where the yield function and flow
  * directions only depend on two parameters, p and q, that
- * are themselves functions of stress
+ * are themselves functions of stress.
  */
-class TwoParameterPlasticityStressUpdate : public StressUpdateBase
+class TwoParameterPlasticityStressUpdate : public MultiParameterPlasticityStressUpdate
 {
 public:
   TwoParameterPlasticityStressUpdate(const InputParameters & parameters,
@@ -32,92 +32,8 @@ public:
                                      unsigned num_intnl);
 
 protected:
-  virtual void initQpStatefulProperties() override;
-  virtual void updateState(RankTwoTensor & strain_increment,
-                           RankTwoTensor & inelastic_strain_increment,
-                           const RankTwoTensor & rotation_increment,
-                           RankTwoTensor & stress_new,
-                           const RankTwoTensor & stress_old,
-                           const RankFourTensor & elasticity_tensor,
-                           const RankTwoTensor & elastic_strain_old,
-                           bool compute_full_tangent_operator,
-                           RankFourTensor & tangent_operator) override;
-
-  virtual void propagateQpStatefulProperties() override;
-
   /// Number of variables = 2 = (p, q)
   constexpr static int _num_pq = 2;
-
-  /// Number of equations in the Return-map Newton-Raphson
-  constexpr static int _num_rhs = 3;
-
-  /// Internal dimensionality of tensors (currently this is 3 throughout tensor_mechanics)
-  constexpr static unsigned _tensor_dimensionality = 3;
-
-  /// Number of yield functions
-  const unsigned _num_yf;
-
-  /// Number of internal parameters
-  const unsigned _num_intnl;
-
-  /// String prepended to various MaterialProperties that are defined by this class
-  const std::string _name_prepender;
-
-  /// Maximum number of Newton-Raphson iterations allowed in the return-map process
-  const unsigned _max_nr_its;
-
-  /// Whether to perform finite-strain rotations
-  const bool _perform_finite_strain_rotations;
-
-  /// Smoothing tolerance: edges of the yield surface get smoothed by this amount
-  const Real _smoothing_tol;
-
-  /// The yield-function tolerance
-  const Real _f_tol;
-
-  /// Square of the yield-function tolerance
-  const Real _f_tol2;
-
-  /// The type of tangent operator to return.  tangent operator = d(stress_rate)/d(strain_rate).
-  enum class TangentOperatorEnum
-  {
-    elastic,
-    nonlinear
-  } _tangent_operator_type;
-
-  /**
-   * In order to help the Newton-Raphson procedure, the applied
-   * strain increment may be applied in sub-increments of size
-   * greater than this value.
-   */
-  const Real _min_step_size;
-
-  /// handles case of initial_stress that is inadmissible being supplied
-  bool _step_one;
-
-  /// Output a warning message if precision loss is encountered during the return-map process
-  const bool _warn_about_precision_loss;
-
-  /// plastic strain
-  MaterialProperty<RankTwoTensor> & _plastic_strain;
-
-  /// Old value of plastic strain
-  const MaterialProperty<RankTwoTensor> & _plastic_strain_old;
-
-  /// internal parameters.  intnl[0] = shear.  intnl[1] = tensile.
-  MaterialProperty<std::vector<Real>> & _intnl;
-
-  /// old values of internal parameters
-  const MaterialProperty<std::vector<Real>> & _intnl_old;
-
-  /// yield functions
-  MaterialProperty<std::vector<Real>> & _yf;
-
-  /// Number of Newton-Raphson iterations used in the return-map
-  MaterialProperty<Real> & _iter;
-
-  /// Whether a line-search was needed in the latest Newton-Raphson process (1 if true, 0 otherwise)
-  MaterialProperty<Real> & _linesearch_needed;
 
   /// Trial value of p
   Real _p_trial;
@@ -125,210 +41,25 @@ protected:
   /// Trial value of q
   Real _q_trial;
 
-  /// State at (p_ok, q_ok, _intnl_ok) is known to be admissible
-  std::vector<Real> _intnl_ok;
-
-  /// _dintnl[i][j] = d(intnl[i])/d(variable j), where variable0=p and variable1=q
-  std::vector<std::vector<Real>> _dintnl;
-
   /// elasticity tensor in p direction
   Real _Epp;
 
   /// elasticity tensor in q direction
   Real _Eqq;
 
-  struct f_and_derivs
-  {
-    Real f;
-    std::vector<Real> df;
-    std::vector<Real> df_di;
-    std::vector<Real> dg;
-    std::vector<std::vector<Real>> d2g;
-    std::vector<std::vector<Real>> d2g_di;
-
-    f_and_derivs() : f_and_derivs(0, 0) {}
-
-    f_and_derivs(unsigned num_var, unsigned num_intnl)
-      : f(0.0), df(num_var), df_di(num_intnl), dg(num_var), d2g(num_var), d2g_di(num_var)
-    {
-      for (unsigned i = 0; i < num_var; ++i)
-      {
-        d2g[i].assign(num_var, 0.0);
-        d2g_di[i].assign(num_intnl, 0.0);
-      }
-    }
-
-    bool operator<(const f_and_derivs & fd) const { return f < fd.f; }
-  };
-
-  /**
-   * Computes the smoothed yield function
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl The internal parameters (intnl[0] is shear, intnl[1] is tensile)
-   * @return The smoothed yield function value
-   */
-  Real yieldF(Real p, Real q, const std::vector<Real> & intnl) const;
-
-  /**
-   * Smooths yield functions
-   */
-  Real ismoother(Real f_diff) const;
-
-  /**
-   * Derivative of ismoother
-   */
-  Real smoother(Real f_diff) const;
-
-  /**
-   * Derivative of smoother
-   */
-  Real dsmoother(Real f_diff) const;
-
-  /**
-   * Calculates _all_q, and then performs the smoothing scheme
-   * @param p stress_zz
-   * @param q sqrt(stress_zx^2 + stress_zy^2)
-   * @param intnl Internal parameters
-   * @return The smoothed yield function and derivatives
-   */
-  f_and_derivs smoothAllQuantities(Real p, Real q, const std::vector<Real> & intnl);
-
-  /**
-   * Calculates _dp_dpt, _dp_dqt, etc for the (sub)strain increment
-   * @param elastic_only whether this was an elastic step: if so then the updates to _dp_dpt, etc
-   * are fairly trivial
-   * @param p_trial the trial value of p for this (sub)strain increment
-   * @param q_trial the trial value of q for this (sub)strain increment
-   * @param p the returned value of p for this (sub)strain increment
-   * @param q the returned value of q for this (sub)strain increment
-   * @param gaE the value of gaE that came from this (sub)strain increment
-   * @param intnl the value of the internal parameters at the returned position
-   * @param smoothed_q contains the yield function and derivatives evaluated at (p, q)
-   * @param step_size size of this (sub)strain increment
-   * @param compute_full_tangent_operator true if the full consistent tangent operator is needed,
-   * otherwise false
-   */
-  void dVardTrial(bool elastic_only,
-                  Real p_trial,
-                  Real q_trial,
-                  Real p,
-                  Real q,
-                  Real gaE,
-                  const std::vector<Real> & intnl,
-                  const f_and_derivs & smoothed_q,
-                  Real step_size,
-                  bool compute_full_tangent_operator);
-
-  /**
-   * Performs a line-search to find (p, q)
-   * Upon entry, this assumes that _rhs contains the Newton-Raphson full step (ie nrStep should have
-   * been called)
-   * Upon exit, _rhs will contain the updated _rhs values ready for the next Newton-Raphson step,
-   * Also _all_q and _intnl will be calculated at the new (p, q)
-   * @param res2 the residual-squared, both as an input and output
-   * @param gaE Upon input the value of gaE predicted from Newton Raphson.  Upon exit this will hold
-   * the value coming from the line-search
-   * @param p Upon input the value of p predicted from Newton Raphson.  Upon exit this will be p
-   * coming from the line-search
-   * @param q Upon input the value of q predicted from Newton Raphson.  Upon exit this will be q
-   * coming from the line-search
-   * @param p_trial Trial value of p for this (sub)strain increment
-   * @param q_trial Trial value of q for this (sub)strain increment
-   * @param smoothed_q Upon input, the value of the smoothed yield function and derivatives at the
-   * prior-to-Newton configuration.  Upon exit this is evaluated at the new (p, q, intnl)
-   * @param intnl_ok The value of _intnl from either the start of this (sub)strain increment
-   */
-  int lineSearch(Real & res2,
-                 Real & gaE,
-                 Real & p,
-                 Real & q,
-                 Real p_trial,
-                 Real q_trial,
-                 f_and_derivs & smoothed_q,
-                 const std::vector<Real> & intnl_ok);
-
-  /**
-   * Performs a Newton-Raphson step to attempt to zero _rhs
-   * Upon return, _rhs will contain the solution.
-   * @param smoothed_q The value of the smoothed yield function and derivatives prior to this
-   * Newton-Raphson step
-   * @param p_trial The trial value of p for this (sub)strain increment
-   * @param q_trial The trial value of q for this (sub)strain increment
-   * @param p The current value of p during the Newton-Raphson process
-   * @param q The current value of q during the Newton-Raphson process
-   * @param gaE The current value of ga during the Newton-Raphson process
-   */
-  int nrStep(const f_and_derivs & smoothed_q, Real p_trial, Real q_trial, Real p, Real q, Real gaE);
-
-  /**
-   * Calculates _rhs
-   * 0 = _rhs[0] = f(p, q, intnl) = yield function
-   * 0 = _rhs[1] = p - p_trial + Epp * ga * dg/dp = normality in p direction
-   * 0 = _rhs[2] = q - q_trial + Eqq * ga * dg/dq = normality in q direction
-   * @param p_trial The trial value of p for this (sub)strain increment
-   * @param q_trial The trial value of q for this (sub)strain increment
-   * @param p The current value of p during the Newton-Raphson process
-   * @param q The current value of q during the Newton-Raphson process
-   * @param gaE The current value of ga during the Newton-Raphson process
-   * @param smoothed_q Holds the current value of yield function and derivatives evaluated at (p, q,
-   * _intnl)
-   */
-  Real calculateRHS(
-      Real p_trial, Real q_trial, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q);
-
-  /**
-   * Derivative of -RHS with respect to the variables, placed
-   * into an array ready for solving the linear system using
-   * LAPACK gsev
-   * @param smoothed_q Holds the current value of yield function and derivatives evaluated at (p, q,
-   * _intnl)
-   * @param dintnl The derivatives of the internal parameters wrt p and q
-   * @param gaE The current value of ga during the Newton-Raphson process
-   * @param jac The outputted derivatives
-   */
-  void dnRHSdVar(const f_and_derivs & smoothed_q,
-                 const std::vector<std::vector<Real>> & dintnl,
-                 Real gaE,
-                 std::array<double, _num_rhs * _num_rhs> & jac) const;
-
-  /**
-   * Performs any necessary cleaning-up, then throw MooseException(message)
-   * @param message The message to using in MooseException
-   */
-  virtual void errorHandler(const std::string & message);
-
   /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
   Real _dgaE_dpt;
+  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
+  Real _dgaE_dqt;
   /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
   Real _dp_dpt;
   /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
   Real _dq_dpt;
   /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
-  Real _dgaE_dqt;
-  /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
   Real _dp_dqt;
   /// derivative of Variable with respect to trial variable (used in consistent-tangent-operator calculation)
   Real _dq_dqt;
 
-  /** A Newton-Raphson-with-linesearch is used for the return-map
-   * process.  Three equations must be solved:
-   * 0 = _rhs[0] = f(p, q, intnl) = yield function
-   * 0 = _rhs[1] = p - p_trial + Ezzzz * ga * dg/dp = normality in p direction
-   * 0 = _rhs[2] = q - q_trial + Ezxzx * ga * dg/dq = normality in q direction
-   * Not only does _rhs hold the current value of the right-hand-side
-   * in these equations, but the PETSc-LAPACK gesv routine puts the
-   * changes of the variables into the _rhs too
-   */
-  std::array<Real, _num_rhs> _rhs;
-
-  /** Holds the yield function, derivatives and flow information for the
-   * three yield functions of this model
-   */
-  std::vector<f_and_derivs> _all_q;
-
-  /// An admissible value of (p, q)
-  const std::vector<Real> _pq_ok;
 
   /**
    * Computes the values of the yield functions, given p, q and intnl parameters.
@@ -343,6 +74,9 @@ protected:
                                    Real q,
                                    const std::vector<Real> & intnl,
                                    std::vector<Real> & yf) const = 0;
+  void yieldFunctionValuesV(const std::vector<Real> & stress_params,
+                            const std::vector<Real> & intnl,
+                            std::vector<Real> & yf) const override;
 
   /**
    * Completely fills all_q with correct values.  These values are:
@@ -360,7 +94,10 @@ protected:
   virtual void computeAllQ(Real p,
                            Real q,
                            const std::vector<Real> & intnl,
-                           std::vector<f_and_derivs> & all_q) const = 0;
+                           std::vector<yieldAndFlow> & all_q) const = 0;
+  void computeAllQV(const std::vector<Real> & stress_params,
+                    const std::vector<Real> & intnl,
+                    std::vector<yieldAndFlow> & all_q) const override;
 
   /**
    * Derived classes may employ this function to record stuff or do
@@ -379,6 +116,11 @@ protected:
                             const std::vector<Real> & intnl_old,
                             const std::vector<Real> & yf,
                             const RankFourTensor & Eijkl);
+  void preReturnMapV(const std::vector<Real> & trial_stress_params,
+                     const RankTwoTensor & stress_trial,
+                     const std::vector<Real> & intnl_old,
+                     const std::vector<Real> & yf,
+                     const RankFourTensor & Eijkl) override;
 
   /**
    * Sets (p, q, gaE, intnl) at "good guesses" of the solution to the Return-Map algorithm.
@@ -403,6 +145,11 @@ protected:
                               Real & q,
                               Real & gaE,
                               std::vector<Real> & intnl) const;
+  void initialiseVarsV(const std::vector<Real> & trial_stress_params,
+                       const std::vector<Real> & intnl_old,
+                       std::vector<Real> & stress_params,
+                       Real & gaE,
+                       std::vector<Real> & intnl) const override;
 
   /**
    * Sets the internal parameters based on the trial values of
@@ -422,6 +169,10 @@ protected:
                               Real q,
                               const std::vector<Real> & intnl_old,
                               std::vector<Real> & intnl) const = 0;
+  void setIntnlValuesV(const std::vector<Real> & trial_stress_params,
+                       const std::vector<Real> & current_stress_params,
+                       const std::vector<Real> & intnl_old,
+                       std::vector<Real> & intnl) const override;
 
   /**
    * Sets the derivatives of internal parameters, based on the trial values of
@@ -442,6 +193,10 @@ protected:
                                    Real q,
                                    const std::vector<Real> & intnl,
                                    std::vector<std::vector<Real>> & dintnl) const = 0;
+  virtual void setIntnlDerivativesV(const std::vector<Real> & trial_stress_params,
+                                    const std::vector<Real> & current_stress_params,
+                                    const std::vector<Real> & intnl,
+                                    std::vector<std::vector<Real>> & dintnl) const override;
 
   /**
    * Computes p and q, given stress.  Derived classes must
@@ -451,6 +206,8 @@ protected:
    * @param q q q stress
    */
   virtual void computePQ(const RankTwoTensor & stress, Real & p, Real & q) const = 0;
+  virtual void computeStressParams(const RankTwoTensor & stress,
+                                   std::vector<Real> & stress_params) const override;
 
   /**
    * Set Epp and Eqq based on the elasticity tensor
@@ -460,23 +217,7 @@ protected:
    * @param[out] Eqq Eqq value
    */
   virtual void setEppEqq(const RankFourTensor & Eijkl, Real & Epp, Real & Eqq) const = 0;
-
-  /**
-   * Derived classes may use this to perform calculations before
-   * any return-map process is performed, for instance, to initialise
-   * variables.
-   * This is called at the very start of updateState, even before
-   * any checking for admissible stresses, etc, is performed
-   */
-  virtual void initialiseReturnProcess();
-
-  /**
-   * Derived classes may use this to perform calculations after the
-   * return-map process has completed successfully in (p, q) space
-   * but before the returned stress tensor has been performed.
-   * @param rotation_increment The large-strain rotation increment
-   */
-  virtual void finalizeReturnProcess(const RankTwoTensor & rotation_increment);
+  virtual void setEffectiveElasticity(const RankFourTensor & Eijkl) override;
 
   /**
    * Sets stress from the admissible parameters.
@@ -498,32 +239,24 @@ protected:
                                     Real q_ok,
                                     Real gaE,
                                     const std::vector<Real> & intnl,
-                                    const f_and_derivs & smoothed_q,
+                                    const yieldAndFlow & smoothed_q,
                                     const RankFourTensor & Eijkl,
                                     RankTwoTensor & stress) const;
+  void setStressAfterReturnV(const RankTwoTensor & stress_trial,
+                             const std::vector<Real> & stress_params,
+                             Real gaE,
+                             const std::vector<Real> & intnl,
+                             const yieldAndFlow & smoothed_q,
+                             const RankFourTensor & Eijkl,
+                             RankTwoTensor & stress) const override;
 
-  /**
-   * Sets inelastic strain increment from the returned configuration
-   * This is called after the return-map process has completed
-   * successfully in (p, q) space, just after finalizeReturnProcess
-   * has been called.
-   * Derived classes may override this function
-   * @param stress_trial The trial value of stress
-   * @param gaE Value of gaE induced by the return (gaE = gamma * Epp)
-   * @param smoothed_q Holds the current value of yield function and derivatives evaluated at
-   * the returned configuration
-   * @param Eijkl The elasticity tensor
-   * @param returned_stress The stress after the return-map process
-   * @param inelastic_strain_increment[out] The inelastic strain increment resulting from this
-   * return-map
-   */
-  virtual void
+  void
   setInelasticStrainIncrementAfterReturn(const RankTwoTensor & stress_trial,
                                          Real gaE,
-                                         const f_and_derivs & smoothed_q,
+                                         const yieldAndFlow & smoothed_q,
                                          const RankFourTensor & elasticity_tensor,
                                          const RankTwoTensor & returned_stress,
-                                         RankTwoTensor & inelastic_strain_increment) const;
+                                         RankTwoTensor & inelastic_strain_increment) const override;
 
   /**
    * Calculates the consistent tangent operator.
@@ -551,11 +284,26 @@ protected:
                                          Real p,
                                          Real q,
                                          Real gaE,
-                                         const f_and_derivs & smoothed_q,
+                                         const yieldAndFlow & smoothed_q,
                                          const RankFourTensor & Eijkl,
                                          bool compute_full_tangent_operator,
                                          RankFourTensor & cto) const;
 
+  void consistentTangentOperatorV(const RankTwoTensor & stress_trial,
+                                  const std::vector<Real> & trial_stress_params,
+                                  const RankTwoTensor & stress,
+                                  const std::vector<Real> & stress_params,
+                                  Real gaE,
+                                  const yieldAndFlow & smoothed_q,
+                                  const RankFourTensor & Eijkl,
+                                  bool compute_full_tangent_operator,
+                                  const std::vector<std::vector<Real>> & dvar_dtrial,
+                                  RankFourTensor & cto) override;
+
+  virtual std::vector<RankTwoTensor>
+  dstress_param_dstress(const RankTwoTensor & stress) const override;
+  virtual std::vector<RankFourTensor>
+  d2stress_param_dstress(const RankTwoTensor & stress) const override;
   /**
    * d(p)/d(stress)
    * Derived classes must override this

--- a/modules/tensor_mechanics/src/materials/CappedDruckerPragerCosseratStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedDruckerPragerCosseratStressUpdate.C
@@ -52,7 +52,7 @@ CappedDruckerPragerCosseratStressUpdate::setStressAfterReturn(const RankTwoTenso
                                                               Real q_ok,
                                                               Real /*gaE*/,
                                                               const std::vector<Real> & /*intnl*/,
-                                                              const f_and_derivs & /*smoothed_q*/,
+                                                              const yieldAndFlow & /*smoothed_q*/,
                                                               const RankFourTensor & /*Eijkl*/,
                                                               RankTwoTensor & stress) const
 {
@@ -77,7 +77,7 @@ CappedDruckerPragerCosseratStressUpdate::consistentTangentOperator(
     Real /*p*/,
     Real q,
     Real gaE,
-    const f_and_derivs & smoothed_q,
+    const yieldAndFlow & smoothed_q,
     const RankFourTensor & Eijkl,
     bool compute_full_tangent_operator,
     RankFourTensor & cto) const

--- a/modules/tensor_mechanics/src/materials/CappedDruckerPragerStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedDruckerPragerStressUpdate.C
@@ -154,7 +154,7 @@ void
 CappedDruckerPragerStressUpdate::computeAllQ(Real p,
                                              Real q,
                                              const std::vector<Real> & intnl,
-                                             std::vector<f_and_derivs> & all_q) const
+                                             std::vector<yieldAndFlow> & all_q) const
 {
   Real aaa;
   Real bbb;
@@ -371,7 +371,7 @@ CappedDruckerPragerStressUpdate::setStressAfterReturn(const RankTwoTensor & stre
                                                       Real q_ok,
                                                       Real /*gaE*/,
                                                       const std::vector<Real> & /*intnl*/,
-                                                      const f_and_derivs & /*smoothed_q*/,
+                                                      const yieldAndFlow & /*smoothed_q*/,
                                                       const RankFourTensor & /*Eijkl*/,
                                                       RankTwoTensor & stress) const
 {
@@ -425,7 +425,7 @@ CappedDruckerPragerStressUpdate::consistentTangentOperator(const RankTwoTensor &
                                                            Real /*p*/,
                                                            Real q,
                                                            Real gaE,
-                                                           const f_and_derivs & smoothed_q,
+                                                           const yieldAndFlow & smoothed_q,
                                                            const RankFourTensor & Eijkl,
                                                            bool compute_full_tangent_operator,
                                                            RankFourTensor & cto) const

--- a/modules/tensor_mechanics/src/materials/CappedWeakInclinedPlaneStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedWeakInclinedPlaneStressUpdate.C
@@ -119,7 +119,7 @@ CappedWeakInclinedPlaneStressUpdate::setStressAfterReturn(const RankTwoTensor & 
                                                           Real q_ok,
                                                           Real gaE,
                                                           const std::vector<Real> & /*intnl*/,
-                                                          const f_and_derivs & smoothed_q,
+                                                          const yieldAndFlow & smoothed_q,
                                                           const RankFourTensor & /*Eijkl*/,
                                                           RankTwoTensor & stress) const
 {
@@ -150,7 +150,7 @@ CappedWeakInclinedPlaneStressUpdate::consistentTangentOperator(const RankTwoTens
                                                                Real p,
                                                                Real q,
                                                                Real gaE,
-                                                               const f_and_derivs & smoothed_q,
+                                                               const yieldAndFlow & smoothed_q,
                                                                const RankFourTensor & Eijkl,
                                                                bool compute_full_tangent_operator,
                                                                RankFourTensor & cto) const

--- a/modules/tensor_mechanics/src/materials/CappedWeakPlaneCosseratStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedWeakPlaneCosseratStressUpdate.C
@@ -29,7 +29,7 @@ CappedWeakPlaneCosseratStressUpdate::setStressAfterReturn(const RankTwoTensor & 
                                                           Real q_ok,
                                                           Real gaE,
                                                           const std::vector<Real> & /*intnl*/,
-                                                          const f_and_derivs & smoothed_q,
+                                                          const yieldAndFlow & smoothed_q,
                                                           const RankFourTensor & Eijkl,
                                                           RankTwoTensor & stress) const
 {
@@ -57,7 +57,7 @@ CappedWeakPlaneCosseratStressUpdate::consistentTangentOperator(
     Real /*p*/,
     Real q,
     Real gaE,
-    const f_and_derivs & smoothed_q,
+    const yieldAndFlow & smoothed_q,
     const RankFourTensor & Eijkl,
     bool compute_full_tangent_operator,
     RankFourTensor & cto) const

--- a/modules/tensor_mechanics/src/materials/CappedWeakPlaneStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/CappedWeakPlaneStressUpdate.C
@@ -132,7 +132,7 @@ CappedWeakPlaneStressUpdate::setStressAfterReturn(const RankTwoTensor & stress_t
                                                   Real q_ok,
                                                   Real gaE,
                                                   const std::vector<Real> & /*intnl*/,
-                                                  const f_and_derivs & smoothed_q,
+                                                  const yieldAndFlow & smoothed_q,
                                                   const RankFourTensor & Eijkl,
                                                   RankTwoTensor & stress) const
 {
@@ -175,7 +175,7 @@ CappedWeakPlaneStressUpdate::consistentTangentOperator(const RankTwoTensor & /*s
                                                        Real /*p*/,
                                                        Real q,
                                                        Real gaE,
-                                                       const f_and_derivs & smoothed_q,
+                                                       const yieldAndFlow & smoothed_q,
                                                        const RankFourTensor & Eijkl,
                                                        bool compute_full_tangent_operator,
                                                        RankFourTensor & cto) const
@@ -280,7 +280,7 @@ void
 CappedWeakPlaneStressUpdate::computeAllQ(Real p,
                                          Real q,
                                          const std::vector<Real> & intnl,
-                                         std::vector<f_and_derivs> & all_q) const
+                                         std::vector<yieldAndFlow> & all_q) const
 {
   // yield function values
   all_q[0].f = std::sqrt(Utility::pow<2>(q) + _small_smoother2) + p * _tan_phi.value(intnl[0]) -

--- a/modules/tensor_mechanics/src/materials/TwoParameterPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/TwoParameterPlasticityStressUpdate.C
@@ -13,736 +13,60 @@ template <>
 InputParameters
 validParams<TwoParameterPlasticityStressUpdate>()
 {
-  InputParameters params = validParams<StressUpdateBase>();
+  InputParameters params = validParams<MultiParameterPlasticityStressUpdate>();
   params.addClassDescription("Return-map and Jacobian algorithms for (P, Q) plastic models");
-  params.addParam<std::string>("name_prepender",
-                               "Optional parameter that allows the user to define "
-                               "multiple plastic models on the same block, and the "
-                               "plastic_internal_parameter, plastic_yield_function, "
-                               "plastic_NR_iterations and plastic_linesearch_needed Material "
-                               "Properties will be prepended by this string");
-  params.addRangeCheckedParam<unsigned int>(
-      "max_NR_iterations",
-      20,
-      "max_NR_iterations>0",
-      "Maximum number of Newton-Raphson iterations allowed during the return-map algorithm");
-  params.addParam<bool>("perform_finite_strain_rotations",
-                        false,
-                        "Tensors are correctly rotated "
-                        "in finite-strain simulations.  "
-                        "For optimal performance you can "
-                        "set this to 'false' if you are "
-                        "only ever using small strains");
-  params.addRequiredParam<Real>(
-      "smoothing_tol",
-      "Intersections of the yield surfaces will be smoothed by this amount (this "
-      "is measured in units of stress).  Often this is related to other physical "
-      "parameters (eg, 0.1*cohesion) but it is important to set this small enough "
-      "so that the individual yield surfaces do not mix together in the smoothing "
-      "process to produce a result where no stress is admissible (for example, "
-      "mixing together tensile and compressive failure envelopes).");
-  params.addRequiredParam<Real>("yield_function_tol",
-                                "The return-map process will be deemed to have converged if all "
-                                "yield functions are within yield_function_tol of zero.  If this "
-                                "is set very low then precision-loss might be encountered: if the "
-                                "code detects precision loss then it also deems the return-map "
-                                "process has converged.");
-  MooseEnum tangent_operator("elastic nonlinear", "nonlinear");
-  params.addParam<Real>("min_step_size",
-                        1.0,
-                        "In order to help the Newton-Raphson procedure, the applied strain "
-                        "increment may be applied in sub-increments of size greater than this "
-                        "value.  Usually it is better for Moose's nonlinear convergence to "
-                        "increase max_NR_iterations rather than decrease this parameter.");
-  params.addParam<bool>("warn_about_precision_loss",
-                        false,
-                        "Output a message to the console every "
-                        "time precision-loss is encountered "
-                        "during the Newton-Raphson process");
-  params.addParam<std::vector<Real>>(
-      "admissible_stress",
-      std::vector<Real>{0.0, 0.0},
-      "A single admissible value of the value of (p, q) for internal parameters = 0.  This is used "
-      "to initialise the return-mapping algorithm during the first nonlinear iteration");
   return params;
 }
 
 TwoParameterPlasticityStressUpdate::TwoParameterPlasticityStressUpdate(
     const InputParameters & parameters, unsigned num_yf, unsigned num_intnl)
-  : StressUpdateBase(parameters),
-    _num_yf(num_yf),
-    _num_intnl(num_intnl),
-    _name_prepender(isParamValid("name_prepender") ? getParam<std::string>("name_prepender") + "_"
-                                                   : ""),
-    _max_nr_its(getParam<unsigned>("max_NR_iterations")),
-    _perform_finite_strain_rotations(getParam<bool>("perform_finite_strain_rotations")),
-    _smoothing_tol(getParam<Real>("smoothing_tol")),
-    _f_tol(getParam<Real>("yield_function_tol")),
-    _f_tol2(Utility::pow<2>(getParam<Real>("yield_function_tol"))),
-    _min_step_size(getParam<Real>("min_step_size")),
-    _step_one(declareRestartableData<bool>("step_one", true)),
-    _warn_about_precision_loss(getParam<bool>("warn_about_precision_loss")),
-
-    _plastic_strain(declareProperty<RankTwoTensor>(_name_prepender + "plastic_strain")),
-    _plastic_strain_old(getMaterialPropertyOld<RankTwoTensor>(_name_prepender + "plastic_strain")),
-    _intnl(declareProperty<std::vector<Real>>(_name_prepender + "plastic_internal_parameter")),
-    _intnl_old(
-        getMaterialPropertyOld<std::vector<Real>>(_name_prepender + "plastic_internal_parameter")),
-    _yf(declareProperty<std::vector<Real>>(_name_prepender + "plastic_yield_function")),
-    _iter(declareProperty<Real>(_name_prepender +
-                                "plastic_NR_iterations")), // this is really an unsigned int, but
-                                                           // for visualisation i convert it to Real
-    _linesearch_needed(
-        declareProperty<Real>(_name_prepender + "plastic_linesearch_needed")), // this is really a
-                                                                               // boolean, but for
-                                                                               // visualisation i
-                                                                               // convert it to Real
-
+  : MultiParameterPlasticityStressUpdate(parameters, _num_pq, num_yf, num_intnl),
     _p_trial(0.0),
     _q_trial(0.0),
-    _intnl_ok(_num_intnl),
-    _dintnl(_num_intnl),
     _Epp(0.0),
     _Eqq(0.0),
-
     _dgaE_dpt(0.0),
+    _dgaE_dqt(0.0),
     _dp_dpt(0.0),
     _dq_dpt(0.0),
-    _dgaE_dqt(0.0),
     _dp_dqt(0.0),
-    _dq_dqt(0.0),
-    _all_q(_num_yf),
-
-    _pq_ok(getParam<std::vector<Real>>("admissible_stress"))
+    _dq_dqt(0.0)
 {
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    _dintnl[i].resize(_num_pq);
-  for (unsigned i = 0; i < _num_yf; ++i)
-    _all_q[i] = f_and_derivs(_num_pq, _num_intnl);
-  if (_pq_ok.size() != 2)
-    mooseError(
-        "TwoParameterPlasticityStressUpdate: admissible_stress parameter must be two numbers");
 }
 
 void
-TwoParameterPlasticityStressUpdate::initQpStatefulProperties()
+TwoParameterPlasticityStressUpdate::yieldFunctionValuesV(const std::vector<Real> & stress_params,
+                                                         const std::vector<Real> & intnl,
+                                                         std::vector<Real> & yf) const
 {
-  _plastic_strain[_qp].zero();
-  _intnl[_qp].assign(_num_intnl, 0);
-  _yf[_qp].assign(_num_yf, 0);
-  _iter[_qp] = 0.0;
-  _linesearch_needed[_qp] = 0.0;
+  const Real p = stress_params[0];
+  const Real q = stress_params[1];
+  yieldFunctionValues(p, q, intnl, yf);
 }
 
 void
-TwoParameterPlasticityStressUpdate::propagateQpStatefulProperties()
+TwoParameterPlasticityStressUpdate::setEffectiveElasticity(const RankFourTensor & Eijkl)
 {
-  _plastic_strain[_qp] = _plastic_strain_old[_qp];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    _intnl[_qp][i] = _intnl_old[_qp][i];
+  setEppEqq(Eijkl, _Epp, _Eqq);
+  _Eij[0][0] = _Epp;
+  _Eij[1][0] = _Eij[0][1] = 0.0;
+  _Eij[1][1] = _Eqq;
+  _En = _Epp;
+  _Cij[0][0] = 1.0 / _Epp;
+  _Cij[1][0] = _Cij[0][1] = 0.0;
+  _Cij[1][1] = 1.0 / _Eqq;
 }
 
 void
-TwoParameterPlasticityStressUpdate::updateState(RankTwoTensor & strain_increment,
-                                                RankTwoTensor & inelastic_strain_increment,
-                                                const RankTwoTensor & rotation_increment,
-                                                RankTwoTensor & stress_new,
-                                                const RankTwoTensor & stress_old,
-                                                const RankFourTensor & elasticity_tensor,
-                                                const RankTwoTensor & /*elastic_strain_old*/,
-                                                bool compute_full_tangent_operator,
-                                                RankFourTensor & tangent_operator)
+TwoParameterPlasticityStressUpdate::preReturnMapV(const std::vector<Real> & trial_stress_params,
+                                                  const RankTwoTensor & stress_trial,
+                                                  const std::vector<Real> & intnl_old,
+                                                  const std::vector<Real> & yf,
+                                                  const RankFourTensor & Eijkl)
 {
-  initialiseReturnProcess();
-
-  if (_t_step >= 2)
-    _step_one = false;
-
-  // initially assume an elastic deformation
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    _intnl[_qp][i] = _intnl_old[_qp][i];
-  _iter[_qp] = 0.0;
-  _linesearch_needed[_qp] = 0.0;
-
-  computePQ(stress_new, _p_trial, _q_trial);
-  yieldFunctionValues(_p_trial, _q_trial, _intnl[_qp], _yf[_qp]);
-
-  /* Need to consider smoothing_tol, not just yf<=0, because
-   * some yield functions might mix.  However, if some yield
-   * functions are -smoothing_tol <= yf, then the smoothed
-   * yield function must be computed and checked vs f_tol
-   */
-  bool elastic = true;
-  for (auto yf : _yf[_qp])
-    if (yf > -_smoothing_tol)
-      elastic = false;
-  if (!elastic && yieldF(_p_trial, _q_trial, _intnl[_qp]) <= _f_tol)
-    elastic = true;
-  if (elastic)
-  {
-    _plastic_strain[_qp] = _plastic_strain_old[_qp];
-    if (_fe_problem.currentlyComputingJacobian())
-    {
-      inelastic_strain_increment.zero();
-      tangent_operator = elasticity_tensor;
-    }
-    return;
-  }
-
-  const RankTwoTensor stress_trial = stress_new;
-  /* The trial stress must be inadmissible
-   * so we need to return to the yield surface.  The following
-   * equations must be satisfied.
-   *
-   * 0 = f(p, q, intnl)                  = rhs[0]
-   * 0 = p - p^trial + Epp * ga * dg/dp  = rhs[1]
-   * 0 = q - q^trial + Eqq * ga * dg/dq  = rhs[2]
-   * Equations defining intnl parameters as functions of (p, q, p_trial, q_trial, intnl_old)
-   *
-   * The unknowns are p, q, ga, and intnl.
-   * I find it convenient to solve the first three equations for p, q and ga*Epp=gaE,
-   * while substituting the "intnl parameters" equations into these during the solve process
-   */
-
-  preReturnMap(_p_trial, _q_trial, stress_new, _intnl_old[_qp], _yf[_qp], elasticity_tensor);
-  setEppEqq(elasticity_tensor, _Epp, _Eqq);
-
-  // values of p, q  and intnl we know to be admissible
-  Real p_ok;
-  Real q_ok;
-  computePQ(stress_old, p_ok, q_ok);
-  std::copy(_intnl_old[_qp].begin(), _intnl_old[_qp].end(), _intnl_ok.begin());
-  // note that _intnl[_qp] is the "running" intnl variable that gets updated every NR iteration
-  // if (isParamValid("initial_stress") && _step_one)
-  if (_step_one)
-  {
-    // the initial stress might be inadmissible
-    p_ok = _pq_ok[0];
-    q_ok = _pq_ok[1];
-  }
-
-  _dgaE_dpt = 0.0;
-  _dp_dpt = 0.0;
-  _dq_dpt = 0.0;
-  _dgaE_dqt = 0.0;
-  _dp_dqt = 0.0;
-  _dq_dqt = 0.0;
-
-  // Return-map problem: must apply the following changes in p and q, and find the returned p and q.
-  const Real del_p = _p_trial - p_ok;
-  const Real del_q = _q_trial - q_ok;
-
-  Real step_taken =
-      0.0; // amount of (del_p, del_q) that we've applied and the return-map problem has succeeded
-  Real step_size = 1.0; // potentially can apply (del_p, del_q) in substeps
-  Real gaE_total = 0.0;
-
-  // current values of the yield function, derivatives, etc
-  f_and_derivs smoothed_q;
-
-  // In the following sub-stepping procedure it is possible that
-  // the last step is an elastic step, and therefore smoothed_q won't
-  // be computed on the last step, so we have to compute it.
-  bool smoothed_q_calculated = false;
-
-  while (step_taken < 1.0 && step_size >= _min_step_size)
-  {
-    if (1.0 - step_taken < step_size)
-      // prevent over-shoots of substepping
-      step_size = 1.0 - step_taken;
-
-    // trial variables in terms of admissible variables
-    _p_trial = p_ok + step_size * del_p;
-    _q_trial = q_ok + step_size * del_q;
-
-    // initialise (p, q, gaE)
-    Real p = _p_trial;
-    Real q = _q_trial;
-    Real gaE = 0.0;
-
-    // flags indicating failure of newton-raphson and line-search
-    int nr_failure = 0;
-    int ls_failure = 0;
-
-    // NR iterations taken in this substep
-    Real step_iter = 0.0;
-
-    // The residual-squared for the line-search
-    Real res2 = 0.0;
-
-    if (step_size < 1.0 && yieldF(_p_trial, _q_trial, _intnl[_qp]) <= _f_tol)
-      // This is an elastic step
-      // The "step_size < 1.0" in above condition is for efficiency: we definitely
-      // know that this is a plastic step if step_size = 1.0
-      smoothed_q_calculated = false;
-    else
-    {
-      // this is a plastic step
-
-      // initialise p, q and gaE using a good guess based on the non-smoothed situation
-      initialiseVars(_p_trial, _q_trial, _intnl_ok, p, q, gaE, _intnl[_qp]);
-      smoothed_q = smoothAllQuantities(p, q, _intnl[_qp]);
-      smoothed_q_calculated = true;
-      res2 = calculateRHS(_p_trial, _q_trial, p, q, gaE, smoothed_q);
-
-      // Perform a Newton-Raphson with linesearch to get p, q, gaE, and also smoothed_q
-      while (res2 > _f_tol2 && step_iter < (float)_max_nr_its && nr_failure == 0 && ls_failure == 0)
-      {
-        // solve the linear system and store the answer (the "updates") in _rhs
-        nr_failure = nrStep(smoothed_q, _p_trial, _q_trial, p, q, gaE);
-        if (nr_failure != 0)
-          break;
-
-        // check for precision loss
-        if (std::abs(_rhs[0]) <= 1E-13 * std::abs(gaE) &&
-            std::abs(_rhs[1]) <= 1E-13 * std::abs(p) && std::abs(_rhs[2]) <= 1E-13 * std::abs(q))
-        {
-          if (_warn_about_precision_loss)
-            Moose::err << "TwoParameterPlasticityStressUpdate: precision-loss in element "
-                       << _current_elem->id() << " quadpoint=" << _qp << " p=" << p << " q=" << q
-                       << " gaE=" << gaE << "\n";
-          res2 = 0.0;
-          break;
-        }
-        // apply (parts of) the updates, re-calculate smoothed_q, and res2
-        ls_failure = lineSearch(res2, gaE, p, q, _p_trial, _q_trial, smoothed_q, _intnl_ok);
-        step_iter++;
-      }
-    }
-
-    if (res2 <= _f_tol2 && step_iter < (float)_max_nr_its && nr_failure == 0 && ls_failure == 0 &&
-        gaE >= 0.0)
-    {
-      // this Newton-Raphson worked fine, or this was an elastic step
-      p_ok = p;
-      q_ok = q;
-      step_taken += step_size;
-      gaE_total += gaE;
-      setIntnlValues(_p_trial, _q_trial, p_ok, q_ok, _intnl_ok, _intnl[_qp]);
-      std::copy(_intnl[_qp].begin(), _intnl[_qp].end(), _intnl_ok.begin());
-      // calculate dp/dp_trial, dp/dq_trial, etc, for Jacobian
-      dVardTrial(!smoothed_q_calculated,
-                 _p_trial,
-                 _q_trial,
-                 p_ok,
-                 q_ok,
-                 gaE,
-                 _intnl_ok,
-                 smoothed_q,
-                 step_size,
-                 compute_full_tangent_operator);
-      if (step_iter > _iter[_qp])
-        _iter[_qp] = step_iter;
-      step_size *= 1.1;
-    }
-    else
-    {
-      // Newton-Raphson + line-search process failed
-      std::copy(_intnl_ok.begin(), _intnl_ok.end(), _intnl[_qp].begin());
-      step_size *= 0.5;
-    }
-  }
-
-  if (step_size < _min_step_size)
-    errorHandler("TwoParameterPlasticityStressUpdate: Minimum step-size violated");
-
-  // success!
-  finalizeReturnProcess(rotation_increment);
-  yieldFunctionValues(p_ok, q_ok, _intnl[_qp], _yf[_qp]);
-
-  if (!smoothed_q_calculated)
-    smoothed_q = smoothAllQuantities(p_ok, q_ok, _intnl[_qp]);
-
-  setStressAfterReturn(
-      stress_trial, p_ok, q_ok, gaE_total, _intnl[_qp], smoothed_q, elasticity_tensor, stress_new);
-
-  setInelasticStrainIncrementAfterReturn(stress_trial,
-                                         gaE_total,
-                                         smoothed_q,
-                                         elasticity_tensor,
-                                         stress_new,
-                                         inelastic_strain_increment);
-
-  strain_increment = strain_increment - inelastic_strain_increment;
-  _plastic_strain[_qp] = _plastic_strain_old[_qp] + inelastic_strain_increment;
-
-  consistentTangentOperator(stress_trial,
-                            _p_trial,
-                            _q_trial,
-                            stress_new,
-                            p_ok,
-                            q_ok,
-                            gaE_total,
-                            smoothed_q,
-                            elasticity_tensor,
-                            compute_full_tangent_operator,
-                            tangent_operator);
-}
-
-void
-TwoParameterPlasticityStressUpdate::dVardTrial(bool elastic_only,
-                                               Real p_trial,
-                                               Real q_trial,
-                                               Real p,
-                                               Real q,
-                                               Real gaE,
-                                               const std::vector<Real> & intnl,
-                                               const f_and_derivs & smoothed_q,
-                                               Real step_size,
-                                               bool compute_full_tangent_operator)
-{
-  if (!_fe_problem.currentlyComputingJacobian())
-    return;
-
-  if (!compute_full_tangent_operator)
-    return;
-
-  if (elastic_only)
-  {
-    // no change to gaE, and dp_dqt and dq_dpt are unchanged from previous step
-    _dp_dpt = step_size + _dp_dpt;
-    _dq_dqt = step_size + _dq_dqt;
-    return;
-  }
-
-  setIntnlDerivatives(p_trial, q_trial, p, q, intnl, _dintnl);
-
-  // _rhs is defined above, the following are changes in rhs wrt the trial p and q values
-  // In the following we use d(intnl)/d(trial variable) = - d(intnl)/d(variable)
-  std::array<Real, _num_pq * _num_rhs> rhs_cto{{0.0}};
-
-  // change in p_trial
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    rhs_cto[0] -= smoothed_q.df_di[i] * _dintnl[i][0];
-  rhs_cto[1] = -1.0;
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    rhs_cto[1] -= gaE * smoothed_q.d2g_di[0][i] * _dintnl[i][0];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    rhs_cto[2] -= _Eqq * gaE / _Epp * smoothed_q.d2g_di[1][i] * _dintnl[i][0];
-
-  // change in q_trial
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    rhs_cto[3] -= smoothed_q.df_di[i] * _dintnl[i][1];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    rhs_cto[4] -= gaE * smoothed_q.d2g_di[0][i] * _dintnl[i][1];
-  rhs_cto[5] = -1.0;
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    rhs_cto[5] -= _Eqq * gaE / _Epp * smoothed_q.d2g_di[1][i] * _dintnl[i][1];
-
-  // jac = d(-rhs)/d(var), where var[0] = gaE, var[1] = p, var[2] = q.
-  std::array<double, _num_rhs * _num_rhs> jac;
-  dnRHSdVar(smoothed_q, _dintnl, gaE, jac);
-
-  std::array<int, _num_rhs> ipiv;
-  int info;
-  const int gesv_num_rhs = _num_rhs;
-  const int gesv_num_pq = _num_pq;
-  LAPACKgesv_(&gesv_num_rhs,
-              &gesv_num_pq,
-              &jac[0],
-              &gesv_num_rhs,
-              &ipiv[0],
-              &rhs_cto[0],
-              &gesv_num_rhs,
-              &info);
-  if (info != 0)
-    errorHandler(
-        "TwoParameterPlasticityStressUpdate: PETSC LAPACK gsev routine returned with error code " +
-        Moose::stringify(info));
-
-  const Real dgaEn_dptn = rhs_cto[0];
-  const Real dpn_dptn = rhs_cto[1];
-  const Real dqn_dptn = rhs_cto[2];
-  const Real dgaEn_dqtn = rhs_cto[3];
-  const Real dpn_dqtn = rhs_cto[4];
-  const Real dqn_dqtn = rhs_cto[5];
-
-  const Real dp_dpt_old = _dp_dpt;
-  const Real dq_dpt_old = _dq_dpt;
-  const Real dp_dqt_old = _dp_dqt;
-  const Real dq_dqt_old = _dq_dqt;
-
-  _dgaE_dpt += dgaEn_dptn * (step_size + dp_dpt_old) + dgaEn_dqtn * dq_dpt_old;
-  _dp_dpt = dpn_dptn * (step_size + dp_dpt_old) + dpn_dqtn * dq_dpt_old;
-  _dq_dpt = dqn_dptn * (step_size + dp_dpt_old) + dqn_dqtn * dq_dpt_old;
-  _dgaE_dqt += dgaEn_dqtn * (step_size + dq_dqt_old) + dgaEn_dptn * dp_dqt_old;
-  _dp_dqt = dpn_dqtn * (step_size + dq_dqt_old) + dpn_dptn * dp_dqt_old;
-  _dq_dqt = dqn_dqtn * (step_size + dq_dqt_old) + dqn_dptn * dp_dqt_old;
-}
-
-TwoParameterPlasticityStressUpdate::f_and_derivs
-TwoParameterPlasticityStressUpdate::smoothAllQuantities(Real p,
-                                                        Real q,
-                                                        const std::vector<Real> & intnl)
-{
-  for (unsigned i = _all_q.size(); i < _num_yf; ++i)
-    _all_q.push_back(f_and_derivs(_num_pq, _num_intnl));
-
-  computeAllQ(p, q, intnl, _all_q);
-
-  std::sort(_all_q.begin(), _all_q.end());
-
-  /* This is the key to my smoothing strategy.  While the two
-   * biggest yield functions are closer to each other than
-   * _smoothing_tol, make a linear combination of them:
-   * _all_q[num - 2].f = the second-biggest yield function
-   * = _all_q[num - 1].f + ismoother(_all_q[num - 2].f - _all_q[num - 1].f);
-   * = biggest yield function + ismoother(second-biggest - biggest)
-   * Then pop off the biggest yield function, and repeat this
-   * strategy.
-   * Of course all the derivatives must also be smoothed.
-   * I assume that d(flow potential)/dstress gets smoothed by the *yield function*, viz
-   * d(second-biggest-g) = d(biggest-g) + smoother(second-biggest-f -
-   * biggest-f)*(d(second-biggest-g) - d(biggest-g))
-   * Only time will tell whether this is a good strategy.
-   */
-  unsigned num = _all_q.size();
-  while (num > 1 && _all_q[num - 1].f < _all_q[num - 2].f + _smoothing_tol)
-  {
-    const Real ism = ismoother(_all_q[num - 2].f - _all_q[num - 1].f);
-    const Real sm = smoother(_all_q[num - 2].f - _all_q[num - 1].f);
-    const Real dsm = dsmoother(_all_q[num - 2].f - _all_q[num - 1].f);
-    for (unsigned i = 0; i < _num_pq; ++i)
-    {
-      for (unsigned j = 0; j < _num_pq; ++j)
-        _all_q[num - 2].d2g[i][j] = _all_q[num - 1].d2g[i][j] +
-                                    dsm * (_all_q[num - 2].df[j] - _all_q[num - 1].df[j]) *
-                                        (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]) +
-                                    sm * (_all_q[num - 2].d2g[i][j] - _all_q[num - 1].d2g[i][j]);
-      for (unsigned j = 0; j < _num_intnl; ++j)
-        _all_q[num - 2].d2g_di[i][j] =
-            _all_q[num - 1].d2g_di[i][j] +
-            dsm * (_all_q[num - 2].df_di[j] - _all_q[num - 1].df_di[j]) *
-                (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]) +
-            sm * (_all_q[num - 2].d2g_di[i][j] - _all_q[num - 1].d2g_di[i][j]);
-    }
-    for (unsigned i = 0; i < _num_pq; ++i)
-    {
-      _all_q[num - 2].dg[i] =
-          _all_q[num - 1].dg[i] + sm * (_all_q[num - 2].dg[i] - _all_q[num - 1].dg[i]);
-      _all_q[num - 2].df[i] =
-          _all_q[num - 1].df[i] + sm * (_all_q[num - 2].df[i] - _all_q[num - 1].df[i]);
-    }
-    for (unsigned i = 0; i < _num_intnl; ++i)
-      _all_q[num - 2].df_di[i] =
-          _all_q[num - 1].df_di[i] + sm * (_all_q[num - 2].df_di[i] - _all_q[num - 1].df_di[i]);
-    _all_q[num - 2].f = _all_q[num - 1].f + ism;
-    _all_q.pop_back();
-    num = _all_q.size();
-  }
-  return _all_q.back();
-}
-
-Real
-TwoParameterPlasticityStressUpdate::ismoother(Real f_diff) const
-{
-  mooseAssert(f_diff <= 0.0,
-              "TwoParameterPlasticityStressUpdate: ismoother called with positive argument");
-  if (f_diff <= -_smoothing_tol)
-    return 0.0;
-  return 0.5 * (f_diff + _smoothing_tol) -
-         _smoothing_tol / M_PI * std::cos(0.5 * M_PI * f_diff / _smoothing_tol);
-}
-
-Real
-TwoParameterPlasticityStressUpdate::smoother(Real f_diff) const
-{
-  if (f_diff >= _smoothing_tol)
-    return 1.0;
-  else if (f_diff <= -_smoothing_tol)
-    return 0.0;
-  return 0.5 * (1.0 + std::sin(f_diff * M_PI * 0.5 / _smoothing_tol));
-}
-
-Real
-TwoParameterPlasticityStressUpdate::dsmoother(Real f_diff) const
-{
-  if (f_diff >= _smoothing_tol)
-    return 0.0;
-  else if (f_diff <= -_smoothing_tol)
-    return 0.0;
-  return 0.25 * M_PI / _smoothing_tol * std::cos(f_diff * M_PI * 0.5 / _smoothing_tol);
-}
-
-int
-TwoParameterPlasticityStressUpdate::lineSearch(Real & res2,
-                                               Real & gaE,
-                                               Real & p,
-                                               Real & q,
-                                               Real p_trial,
-                                               Real q_trial,
-                                               f_and_derivs & smoothed_q,
-                                               const std::vector<Real> & intnl_ok)
-{
-  const Real res2_old = res2;
-  const Real gaE_old = gaE;
-  const Real p_old = p;
-  const Real q_old = q;
-  const Real de_gaE = _rhs[0];
-  const Real de_p = _rhs[1];
-  const Real de_q = _rhs[2];
-
-  Real lam = 1.0;                     // line-search parameter
-  const Real lam_min = 1E-10;         // minimum value of lam allowed
-  const Real slope = -2.0 * res2_old; // "Numerical Recipes" uses -b*A*x, in order to check for
-                                      // roundoff, but i hope the nrStep would warn if there were
-                                      // problems
-  Real tmp_lam;                       // cached value of lam used in quadratic & cubic line search
-  Real f2 = res2_old; // cached value of f = residual2 used in the cubic in the line search
-  Real lam2 = lam;    // cached value of lam used in the cubic in the line search
-
-  while (true)
-  {
-    // update variables using the current line-search parameter
-    gaE = gaE_old + lam * de_gaE;
-    p = p_old + lam * de_p;
-    q = q_old + lam * de_q;
-
-    // and internal parameters
-    setIntnlValues(_p_trial, _q_trial, p, q, intnl_ok, _intnl[_qp]);
-
-    smoothed_q = smoothAllQuantities(p, q, _intnl[_qp]);
-
-    // update rhs for next-time through
-    res2 = calculateRHS(p_trial, q_trial, p, q, gaE, smoothed_q);
-
-    // do the line-search
-    if (res2 < res2_old + 1E-4 * lam * slope)
-      break;
-    else if (lam < lam_min)
-      return 1;
-    else if (lam == 1.0)
-    {
-      // model as a quadratic
-      tmp_lam = -0.5 * slope / (res2 - res2_old - slope);
-    }
-    else
-    {
-      // model as a cubic
-      const Real rhs1 = res2 - res2_old - lam * slope;
-      const Real rhs2 = f2 - res2_old - lam2 * slope;
-      const Real a = (rhs1 / Utility::pow<2>(lam) - rhs2 / Utility::pow<2>(lam2)) / (lam - lam2);
-      const Real b =
-          (-lam2 * rhs1 / Utility::pow<2>(lam) + lam * rhs2 / Utility::pow<2>(lam2)) / (lam - lam2);
-      if (a == 0.0)
-        tmp_lam = -slope / (2.0 * b);
-      else
-      {
-        const Real disc = Utility::pow<2>(b) - 3.0 * a * slope;
-        if (disc < 0)
-          tmp_lam = 0.5 * lam;
-        else if (b <= 0)
-          tmp_lam = (-b + std::sqrt(disc)) / (3.0 * a);
-        else
-          tmp_lam = -slope / (b + std::sqrt(disc));
-      }
-      if (tmp_lam > 0.5 * lam)
-        tmp_lam = 0.5 * lam;
-    }
-    lam2 = lam;
-    f2 = res2;
-    lam = std::max(tmp_lam, 0.1 * lam);
-  }
-
-  if (lam < 1.0)
-    _linesearch_needed[_qp] = 1.0;
-  return 0;
-}
-
-void
-TwoParameterPlasticityStressUpdate::dnRHSdVar(const f_and_derivs & smoothed_q,
-                                              const std::vector<std::vector<Real>> & dintnl,
-                                              Real gaE,
-                                              std::array<double, _num_rhs * _num_rhs> & jac) const
-{
-  // LAPACK gsev stores the matrix in the following way:
-
-  // d(-yieldF)/d(gaE)
-  jac[0] = 0;
-
-  // d(-rhs[1])/d(gaE)
-  jac[1] = -smoothed_q.dg[0];
-
-  // d(-rhs[2])/d(gaE))
-  jac[2] = -_Eqq * smoothed_q.dg[1] / _Epp;
-
-  // d(-yieldF)/d(p)
-  jac[3] = -smoothed_q.df[0];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    jac[3] -= smoothed_q.df_di[i] * dintnl[i][0];
-
-  // d(-rhs[1])/d(p)
-  jac[4] = -1.0 - gaE * smoothed_q.d2g[0][0];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    jac[4] -= gaE * smoothed_q.d2g_di[0][i] * dintnl[i][0];
-
-  // d(-rhs[2])/d(p)
-  jac[5] = -_Eqq * gaE / _Epp * smoothed_q.d2g[1][0];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    jac[5] -= _Eqq * gaE / _Epp * smoothed_q.d2g_di[1][i] * dintnl[i][0];
-
-  // d(-yieldF)/d(q)
-  jac[6] = -smoothed_q.df[1];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    jac[6] -= smoothed_q.df_di[i] * dintnl[i][1];
-
-  // d(-rhs[1])/d(q)
-  jac[7] = -gaE * smoothed_q.d2g[0][1];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    jac[7] -= gaE * smoothed_q.d2g_di[0][i] * dintnl[i][1];
-
-  // d(-rhs[2])/d(q)
-  jac[8] = -1.0 - _Eqq * gaE / _Epp * smoothed_q.d2g[1][1];
-  for (unsigned i = 0; i < _num_intnl; ++i)
-    jac[8] -= _Eqq * gaE / _Epp * smoothed_q.d2g_di[1][i] * dintnl[i][1];
-}
-
-int
-TwoParameterPlasticityStressUpdate::nrStep(
-    const f_and_derivs & smoothed_q, Real p_trial, Real q_trial, Real p, Real q, Real gaE)
-{
-  setIntnlDerivatives(p_trial, q_trial, p, q, _intnl[_qp], _dintnl);
-
-  std::array<double, _num_rhs * _num_rhs> jac;
-  dnRHSdVar(smoothed_q, _dintnl, gaE, jac);
-
-  // use LAPACK to solve the linear system
-  const int nrhs = 1;
-  std::array<int, _num_rhs> ipiv;
-  int info;
-  const int gesv_num_rhs = _num_rhs;
-  LAPACKgesv_(
-      &gesv_num_rhs, &nrhs, &jac[0], &gesv_num_rhs, &ipiv[0], &_rhs[0], &gesv_num_rhs, &info);
-  return info;
-}
-
-Real
-TwoParameterPlasticityStressUpdate::calculateRHS(
-    Real p_trial, Real q_trial, Real p, Real q, Real gaE, const f_and_derivs & smoothed_q)
-{
-  _rhs[0] = smoothed_q.f;
-  _rhs[1] = p - p_trial + gaE * smoothed_q.dg[0];
-  _rhs[2] = q - q_trial + _Eqq * gaE / _Epp * smoothed_q.dg[1];
-  return _rhs[0] * _rhs[0] + _rhs[1] * _rhs[1] + _rhs[2] * _rhs[2];
-}
-
-void
-TwoParameterPlasticityStressUpdate::errorHandler(const std::string & message)
-{
-  throw MooseException(message);
-}
-
-void
-TwoParameterPlasticityStressUpdate::initialiseReturnProcess()
-{
-  return;
-}
-
-void
-TwoParameterPlasticityStressUpdate::finalizeReturnProcess(
-    const RankTwoTensor & /*rotation_increment*/)
-{
-  return;
+  const Real p_trial = trial_stress_params[0];
+  const Real q_trial = trial_stress_params[1];
+  preReturnMap(p_trial, q_trial, stress_trial, intnl_old, yf, Eijkl);
 }
 
 void
@@ -754,22 +78,6 @@ TwoParameterPlasticityStressUpdate::preReturnMap(Real /*p_trial*/,
                                                  const RankFourTensor & /*Eijkl*/)
 {
   return;
-}
-
-Real
-TwoParameterPlasticityStressUpdate::yieldF(Real p, Real q, const std::vector<Real> & intnl) const
-{
-  std::vector<Real> yf(_num_yf);
-  yieldFunctionValues(p, q, intnl, yf);
-  std::sort(yf.begin(), yf.end());
-  unsigned num = yf.size();
-  while (num > 1 && yf[num - 1] < yf[num - 2] + _smoothing_tol)
-  {
-    yf[num - 2] = yf[num - 1] + ismoother(yf[num - 2] - yf[num - 1]);
-    yf.pop_back();
-    num = yf.size();
-  }
-  return yf.back();
 }
 
 void
@@ -788,6 +96,106 @@ TwoParameterPlasticityStressUpdate::initialiseVars(Real p_trial,
 }
 
 void
+TwoParameterPlasticityStressUpdate::computeAllQV(const std::vector<Real> & stress_params,
+                                                 const std::vector<Real> & intnl,
+                                                 std::vector<yieldAndFlow> & all_q) const
+{
+  const Real p = stress_params[0];
+  const Real q = stress_params[1];
+  computeAllQ(p, q, intnl, all_q);
+}
+
+void
+TwoParameterPlasticityStressUpdate::initialiseVarsV(const std::vector<Real> & trial_stress_params,
+                                                    const std::vector<Real> & intnl_old,
+                                                    std::vector<Real> & stress_params,
+                                                    Real & gaE,
+                                                    std::vector<Real> & intnl) const
+{
+  const Real p_trial = trial_stress_params[0];
+  const Real q_trial = trial_stress_params[1];
+  Real p;
+  Real q;
+  initialiseVars(p_trial, q_trial, intnl_old, p, q, gaE, intnl);
+  stress_params[0] = p;
+  stress_params[1] = q;
+}
+
+void
+TwoParameterPlasticityStressUpdate::setIntnlValuesV(const std::vector<Real> & trial_stress_params,
+                                                    const std::vector<Real> & current_stress_params,
+                                                    const std::vector<Real> & intnl_old,
+                                                    std::vector<Real> & intnl) const
+{
+  const Real p_trial = trial_stress_params[0];
+  const Real q_trial = trial_stress_params[1];
+  const Real p = current_stress_params[0];
+  const Real q = current_stress_params[1];
+  setIntnlValues(p_trial, q_trial, p, q, intnl_old, intnl);
+}
+
+void
+TwoParameterPlasticityStressUpdate::setIntnlDerivativesV(
+    const std::vector<Real> & trial_stress_params,
+    const std::vector<Real> & current_stress_params,
+    const std::vector<Real> & intnl_old,
+    std::vector<std::vector<Real>> & dintnl) const
+{
+  const Real p_trial = trial_stress_params[0];
+  const Real q_trial = trial_stress_params[1];
+  const Real p = current_stress_params[0];
+  const Real q = current_stress_params[1];
+  setIntnlDerivatives(p_trial, q_trial, p, q, intnl_old, dintnl);
+}
+
+void
+TwoParameterPlasticityStressUpdate::computeStressParams(const RankTwoTensor & stress,
+                                                        std::vector<Real> & stress_params) const
+{
+  Real p;
+  Real q;
+  computePQ(stress, p, q);
+  stress_params[0] = p;
+  stress_params[1] = q;
+}
+
+void
+TwoParameterPlasticityStressUpdate::consistentTangentOperatorV(
+    const RankTwoTensor & stress_trial,
+    const std::vector<Real> & trial_stress_params,
+    const RankTwoTensor & stress,
+    const std::vector<Real> & stress_params,
+    Real gaE,
+    const yieldAndFlow & smoothed_q,
+    const RankFourTensor & Eijkl,
+    bool compute_full_tangent_operator,
+    const std::vector<std::vector<Real>> & dvar_dtrial,
+    RankFourTensor & cto)
+{
+  const Real p_trial = trial_stress_params[0];
+  const Real q_trial = trial_stress_params[1];
+  const Real p = stress_params[0];
+  const Real q = stress_params[1];
+  _dp_dpt = dvar_dtrial[0][0];
+  _dp_dqt = dvar_dtrial[0][1];
+  _dq_dpt = dvar_dtrial[1][0];
+  _dq_dqt = dvar_dtrial[1][1];
+  _dgaE_dpt = dvar_dtrial[2][0];
+  _dgaE_dqt = dvar_dtrial[2][1];
+  consistentTangentOperator(stress_trial,
+                            p_trial,
+                            q_trial,
+                            stress,
+                            p,
+                            q,
+                            gaE,
+                            smoothed_q,
+                            Eijkl,
+                            compute_full_tangent_operator,
+                            cto);
+}
+
+void
 TwoParameterPlasticityStressUpdate::consistentTangentOperator(
     const RankTwoTensor & stress_trial,
     Real /*p_trial*/,
@@ -796,7 +204,7 @@ TwoParameterPlasticityStressUpdate::consistentTangentOperator(
     Real /*p*/,
     Real /*q*/,
     Real gaE,
-    const f_and_derivs & smoothed_q,
+    const yieldAndFlow & smoothed_q,
     const RankFourTensor & elasticity_tensor,
     bool compute_full_tangent_operator,
     RankFourTensor & cto) const
@@ -853,12 +261,25 @@ TwoParameterPlasticityStressUpdate::consistentTangentOperator(
 }
 
 void
+TwoParameterPlasticityStressUpdate::setStressAfterReturnV(const RankTwoTensor & stress_trial,
+                                                          const std::vector<Real> & stress_params,
+                                                          Real gaE,
+                                                          const std::vector<Real> & intnl,
+                                                          const yieldAndFlow & smoothed_q,
+                                                          const RankFourTensor & Eijkl,
+                                                          RankTwoTensor & stress) const
+{
+  const Real p_ok = stress_params[0];
+  const Real q_ok = stress_params[1];
+  setStressAfterReturn(stress_trial, p_ok, q_ok, gaE, intnl, smoothed_q, Eijkl, stress);
+}
+void
 TwoParameterPlasticityStressUpdate::setStressAfterReturn(const RankTwoTensor & stress_trial,
                                                          Real /*p_ok*/,
                                                          Real /*q_ok*/,
                                                          Real gaE,
                                                          const std::vector<Real> & /*intnl*/,
-                                                         const f_and_derivs & smoothed_q,
+                                                         const yieldAndFlow & smoothed_q,
                                                          const RankFourTensor & elasticity_tensor,
                                                          RankTwoTensor & stress) const
 {
@@ -871,11 +292,29 @@ void
 TwoParameterPlasticityStressUpdate::setInelasticStrainIncrementAfterReturn(
     const RankTwoTensor & /*stress_trial*/,
     Real gaE,
-    const f_and_derivs & smoothed_q,
+    const yieldAndFlow & smoothed_q,
     const RankFourTensor & /*elasticity_tensor*/,
     const RankTwoTensor & returned_stress,
     RankTwoTensor & inelastic_strain_increment) const
 {
   inelastic_strain_increment = (gaE / _Epp) * (smoothed_q.dg[0] * dpdstress(returned_stress) +
                                                smoothed_q.dg[1] * dqdstress(returned_stress));
+}
+
+std::vector<RankTwoTensor>
+TwoParameterPlasticityStressUpdate::dstress_param_dstress(const RankTwoTensor & stress) const
+{
+  std::vector<RankTwoTensor> dsp(_num_pq, RankTwoTensor());
+  dsp[0] = dpdstress(stress);
+  dsp[1] = dqdstress(stress);
+  return dsp;
+}
+
+std::vector<RankFourTensor>
+TwoParameterPlasticityStressUpdate::d2stress_param_dstress(const RankTwoTensor & stress) const
+{
+  std::vector<RankFourTensor> d2(_num_pq, RankFourTensor());
+  d2[0] = d2pdstress2(stress);
+  d2[1] = d2qdstress2(stress);
+  return d2;
 }

--- a/modules/tensor_mechanics/tests/jacobian/cdp_cwp_coss02.i
+++ b/modules/tensor_mechanics/tests/jacobian/cdp_cwp_coss02.i
@@ -155,7 +155,7 @@
     type = CappedDruckerPragerCosseratStressUpdate
     host_youngs_modulus = 10.0
     host_poissons_ratio = 0.25
-    name_prepender = dp
+    base_name = dp
     DP_model = dp
     tensile_strength = ts
     compressive_strength = cs
@@ -165,7 +165,7 @@
   [../]
   [./wp]
     type = CappedWeakPlaneCosseratStressUpdate
-    name_prepender = wp
+    base_name = wp
     cohesion = coh
     tan_friction_angle = tanphi
     tan_dilation_angle = tanpsi

--- a/modules/tensor_mechanics/tests/jacobian/cdpc01.i
+++ b/modules/tensor_mechanics/tests/jacobian/cdpc01.i
@@ -133,7 +133,7 @@
     type = CappedDruckerPragerCosseratStressUpdate
     host_youngs_modulus = 10.0
     host_poissons_ratio = 0.25
-    name_prepender = dp
+    base_name = dp
     DP_model = dp
     tensile_strength = ts
     compressive_strength = cs

--- a/modules/tensor_mechanics/tests/jacobian/cdpc02.i
+++ b/modules/tensor_mechanics/tests/jacobian/cdpc02.i
@@ -133,7 +133,7 @@
     type = CappedDruckerPragerCosseratStressUpdate
     host_youngs_modulus = 10.0
     host_poissons_ratio = 0.25
-    name_prepender = dp
+    base_name = dp
     DP_model = dp
     tensile_strength = ts
     compressive_strength = cs

--- a/modules/tensor_mechanics/tests/jacobian/cto27.i
+++ b/modules/tensor_mechanics/tests/jacobian/cto27.i
@@ -129,7 +129,7 @@
   [../]
   [./dp]
     type = CappedDruckerPragerStressUpdate
-    name_prepender = cdp
+    base_name = cdp
     DP_model = dp
     tensile_strength = ts
     compressive_strength = cs
@@ -139,7 +139,7 @@
   [../]
   [./wp]
     type = CappedWeakPlaneStressUpdate
-    name_prepender = cwp
+    base_name = cwp
     cohesion = wp_coh
     tan_friction_angle = wp_tanphi
     tan_dilation_angle = wp_tanpsi

--- a/modules/tensor_mechanics/tests/jacobian/cto28.i
+++ b/modules/tensor_mechanics/tests/jacobian/cto28.i
@@ -15,7 +15,6 @@
 
 [GlobalParams]
   displacements = 'disp_x disp_y disp_z'
-  Cosserat_rotations = 'wc_x wc_y wc_z'
 []
 
 [Variables]
@@ -25,56 +24,23 @@
   [../]
   [./disp_z]
   [../]
-  [./wc_x]
-  [../]
-  [./wc_y]
-  [../]
 []
 
 [Kernels]
   [./cx_elastic]
-    type = CosseratStressDivergenceTensors
+    type = StressDivergenceTensors
     variable = disp_x
     component = 0
   [../]
   [./cy_elastic]
-    type = CosseratStressDivergenceTensors
+    type = StressDivergenceTensors
     variable = disp_y
     component = 1
   [../]
   [./cz_elastic]
-    type = CosseratStressDivergenceTensors
+    type = StressDivergenceTensors
     variable = disp_z
     component = 2
-  [../]
-  [./x_couple]
-    type = StressDivergenceTensors
-    variable = wc_x
-    displacements = 'wc_x wc_y wc_z'
-    component = 0
-    base_name = couple
-  [../]
-  [./y_couple]
-    type = StressDivergenceTensors
-    variable = wc_y
-    displacements = 'wc_x wc_y wc_z'
-    component = 1
-    base_name = couple
-  [../]
-  [./x_moment]
-    type = MomentBalancing
-    variable = wc_x
-    component = 0
-  [../]
-  [./y_moment]
-    type = MomentBalancing
-    variable = wc_y
-    component = 1
-  [../]
-[]
-
-[AuxVariables]
-  [./wc_z]
   [../]
 []
 
@@ -107,54 +73,27 @@
     yield_function_tolerance = 1E-11     # irrelevant here
     internal_constraint_tolerance = 1E-9 # irrelevant here
   [../]
-
-  [./coh]
-    type = TensorMechanicsHardeningConstant
-    value = 2
-  [../]
-  [./tanphi]
-    type = TensorMechanicsHardeningConstant
-    value = 0.5
-  [../]
-  [./tanpsi]
-    type = TensorMechanicsHardeningConstant
-    value = 2.055555555556E-01
-  [../]
-  [./t_strength]
-    type = TensorMechanicsHardeningConstant
-    value = 1
-  [../]
-  [./c_strength]
-    type = TensorMechanicsHardeningConstant
-    value = 100
-  [../]
-
 []
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeLayeredCosseratElasticityTensor
-    young = 10.0
-    poisson = 0.25
-    layer_thickness = 10.0
-    joint_normal_stiffness = 2.5
-    joint_shear_stiffness = 2.0
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 10.0
+    poissons_ratio = 0.25
   [../]
   [./strain]
-    type = ComputeCosseratIncrementalSmallStrain
+    type = ComputeIncrementalSmallStrain
   [../]
   [./admissible]
-    type = ComputeMultipleInelasticCosseratStress
-    inelastic_models = 'dp wp'
+    type = ComputeMultipleInelasticStress
+    inelastic_models = 'dp'
     initial_stress = '10 0 0  0 10 0  0 0 10'
     relative_tolerance = 2.0
     absolute_tolerance = 1E6
     max_iterations = 1
   [../]
   [./dp]
-    type = CappedDruckerPragerCosseratStressUpdate
-    host_youngs_modulus = 10.0
-    host_poissons_ratio = 0.25
+    type = CappedDruckerPragerStressUpdate
     base_name = dp
     DP_model = dp
     tensile_strength = ts
@@ -163,25 +102,12 @@
     tip_smoother = 1
     smoothing_tol = 1
   [../]
-  [./wp]
-    type = CappedWeakPlaneCosseratStressUpdate
-    base_name = wp
-    cohesion = coh
-    tan_friction_angle = tanphi
-    tan_dilation_angle = tanpsi
-    tensile_strength = t_strength
-    compressive_strength = c_strength
-    tip_smoother = 0.1
-    smoothing_tol = 0.1
-    yield_function_tol = 1E-11
-  [../]
 []
 
 [Preconditioning]
   [./andy]
     type = SMP
     full = true
-    #petsc_options = '-snes_test_display'
     petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
     petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
   [../]

--- a/modules/tensor_mechanics/tests/multiple_two_parameter_plasticity/cycled_dp_then_wp.i
+++ b/modules/tensor_mechanics/tests/multiple_two_parameter_plasticity/cycled_dp_then_wp.i
@@ -295,7 +295,7 @@
   [../]
   [./cdp]
     type = CappedDruckerPragerStressUpdate
-    name_prepender = cdp
+    base_name = cdp
     DP_model = dp
     tensile_strength = ts
     compressive_strength = cs
@@ -305,7 +305,7 @@
   [../]
   [./cwp]
     type = CappedWeakPlaneStressUpdate
-    name_prepender = cwp
+    base_name = cwp
     cohesion = wp_coh
     tan_friction_angle = wp_tanphi
     tan_dilation_angle = wp_tanpsi

--- a/modules/tensor_mechanics/tests/multiple_two_parameter_plasticity/dp_and_wp.i
+++ b/modules/tensor_mechanics/tests/multiple_two_parameter_plasticity/dp_and_wp.i
@@ -278,7 +278,7 @@
   [../]
   [./cdp]
     type = CappedDruckerPragerStressUpdate
-    name_prepender = cdp
+    base_name = cdp
     DP_model = dp
     tensile_strength = ts
     compressive_strength = cs
@@ -288,7 +288,7 @@
   [../]
   [./cwp]
     type = CappedWeakPlaneStressUpdate
-    name_prepender = cwp
+    base_name = cwp
     cohesion = wp_coh
     tan_friction_angle = wp_tanphi
     tan_dilation_angle = wp_tanpsi

--- a/modules/tensor_mechanics/tests/multiple_two_parameter_plasticity/dp_then_wp.i
+++ b/modules/tensor_mechanics/tests/multiple_two_parameter_plasticity/dp_then_wp.i
@@ -270,7 +270,7 @@
   [../]
   [./cdp]
     type = CappedDruckerPragerStressUpdate
-    name_prepender = cdp
+    base_name = cdp
     DP_model = dp
     tensile_strength = ts
     compressive_strength = cs
@@ -280,7 +280,7 @@
   [../]
   [./cwp]
     type = CappedWeakPlaneStressUpdate
-    name_prepender = cwp
+    base_name = cwp
     cohesion = wp_coh
     tan_friction_angle = wp_tanphi
     tan_dilation_angle = wp_tanpsi


### PR DESCRIPTION
This paves the way for ThreeParameterPlasticityStressUpdate, and others too
(SixParam will be needed for general symmetric plasticity models, and
higher number of params will be needed for Cosserat models).

TwoParam is now acts as a lightweight translator between MultiParam
and the classes derived from TwoParam

Refs #9337

### Complete each of the following items before creating a PR

- Include any relevant design information for your change
- Follow [Coding Standards](http://mooseframework.org/wiki/CodeStandards/)
- Submit one or more [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/) or modify existing test cases
- Reference or close a specific issue (refs # or closes #)