### PR TITLE
PorousFlow: initial version of capillary pressure user objects

### DIFF
--- a/modules/porous_flow/include/materials/PorousFlowFluidStateFlashBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowFluidStateFlashBase.h
@@ -11,6 +11,7 @@
 #include "PorousFlowVariableBase.h"
 
 class PorousFlowFluidStateFlashBase;
+class PorousFlowCapillaryPressure;
 
 template <>
 InputParameters validParams<PorousFlowFluidStateFlashBase>();
@@ -129,43 +130,6 @@ protected:
    */
   Real vaporMassFraction(std::vector<Real> & Ki) const;
 
-  /**
-   * Effective saturation of liquid phase
-   * @param saturation true saturation
-   * @return effective saturation
-   */
-  virtual Real effectiveSaturation(Real saturation) const;
-
-  /**
-   * Capillary pressure as a function of saturation.
-   * Default is constant capillary pressure = 0.0.
-   * Override in derived classes to implement other capillary pressure forulations
-   *
-   * @param saturation saturation
-   * @return capillary pressure
-   */
-  virtual Real capillaryPressure(Real saturation) const;
-
-  /**
-   * Derivative of capillary pressure wrt to saturation.
-   * Default = 0 for constant capillary pressure.
-   * Override in derived classes to implement other capillary pressure forulations
-   *
-   * @param saturation saturation (-)
-   * @return derivative of capillary pressure wrt saturation
-   */
-  virtual Real dCapillaryPressure_dS(Real pressure) const;
-
-  /**
-   * Second derivative of capillary pressure wrt to saturation.
-   * Default = 0 for constant capillary pressure.
-   * Override in derived classes to implement other capillary pressure forulations
-   *
-   * @param saturation saturation (-)
-   * @return second derivative of capillary pressure wrt saturation
-   */
-  virtual Real d2CapillaryPressure_dS2(Real pressure) const;
-
   /// Porepressure
   const VariableValue & _gas_porepressure;
   /// Gradient of porepressure (only defined at the qps)
@@ -204,6 +168,8 @@ protected:
   MaterialProperty<std::vector<std::vector<RealGradient>>> * _grad_mass_frac_qp;
   /// Derivative of the mass fraction matrix with respect to the Porous Flow variables
   MaterialProperty<std::vector<std::vector<std::vector<Real>>>> & _dmass_frac_dvar;
+  /// Old value of saturation
+  const MaterialProperty<std::vector<Real>> & _saturation_old;
 
   /// Fluid density of each phase
   MaterialProperty<std::vector<Real>> & _fluid_density;
@@ -218,12 +184,6 @@ protected:
   const Real _T_c2k;
   /// Universal gas constant (J/mol/K)
   const Real _R;
-  /// Constant capillary pressure (Pa)
-  const Real _pc;
-  /// Liquid residual saturation
-  const Real _sat_lr;
-  /// Derivative of effective saturation wrt saturation
-  const Real _dseff_ds;
   /// Maximum number of iterations for the Newton-Raphson iterations
   const Real _nr_max_its;
   /// Tolerance for Newton-Raphson iterations
@@ -232,6 +192,8 @@ protected:
   bool _is_initqp;
   /// FluidStateProperties data structure
   std::vector<FluidStateProperties> _fsp;
+  /// Capillary pressure UserObject
+  const PorousFlowCapillaryPressure & _pc_uo;
 };
 
 #endif // POROUSFLOWFLUIDSTATEFLASHBASE_H

--- a/modules/porous_flow/include/userobjects/PorousFlowCapillaryPressure.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowCapillaryPressure.h
@@ -1,0 +1,93 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWCAPILLARYPRESSURE_H
+#define POROUSFLOWCAPILLARYPRESSURE_H
+
+#include "GeneralUserObject.h"
+
+class PorousFlowCapillaryPressure;
+
+template <>
+InputParameters validParams<PorousFlowCapillaryPressure>();
+
+/**
+ * Base class for capillary pressure for multiphase flow in porous media.
+ * Methods must be overriden in derived classes.
+ * Note: Capillary pressure is calculated as a function of true saturation, not
+ * effective saturation (saturation minus residual). Derivatives are returned wrt
+ * true saturation, so no scaling of them is required in objects using these methods
+ */
+class PorousFlowCapillaryPressure : public GeneralUserObject
+{
+public:
+  PorousFlowCapillaryPressure(const InputParameters & parameters);
+
+  void initialize() final{};
+  void execute() final{};
+  void finalize() final{};
+
+  /**
+   * Capillary pressure is calculated as a function of true saturation
+   * @param saturation true saturation
+   * @return capillary pressure (Pa)
+   */
+  virtual Real capillaryPressure(Real saturation) const = 0;
+
+  /**
+   * Derivative of capillary pressure wrt true saturation
+   * @param saturation true saturation
+   * @return derivative of capillary pressure with respect to true saturation
+   */
+  virtual Real dCapillaryPressure(Real saturation) const = 0;
+
+  /**
+   * Second derivative of capillary pressure wrt true saturation
+   * @param saturation true saturation
+   * @return second derivative of capillary pressure with respect to true saturation
+   */
+  virtual Real d2CapillaryPressure(Real saturation) const = 0;
+
+  /**
+   * Effective saturation as a function of capillary pressure
+   * @param pc capillary pressure (Pa)
+   * @return effective saturation
+   */
+  virtual Real effectiveSaturation(Real pc) const = 0;
+
+  /**
+   * Derivative of effective saturation wrt capillary pressure
+   * @param pc capillary pressure (Pa)
+   * @return derivative of effective saturation wrt capillary pressure
+   */
+  virtual Real dEffectiveSaturation(Real pc) const = 0;
+
+  /**
+   * Second derivative of effective saturation wrt capillary pressure
+   * @param pc capillary pressure
+   * @return second derivative of effective saturation wrt capillary pressure
+   */
+  virtual Real d2EffectiveSaturation(Real pc) const = 0;
+
+protected:
+  /**
+   * Effective saturation of liquid phase given liquid saturation and residual
+   * liquid saturation.
+   * Note: not to be mistaken with effectiveSaturation(pc) which is a function
+   * of capillary pressure.
+   * @param saturation true saturation
+   * @return effective saturation
+   */
+  Real effectiveSaturationFromSaturation(Real saturation) const;
+
+  /// Liquid residual saturation
+  const Real _sat_lr;
+  /// Derivative of effective saturation with respect to saturation
+  const Real _dseff_ds;
+};
+
+#endif // POROUSFLOWCAPILLARYPRESSURE_H

--- a/modules/porous_flow/include/userobjects/PorousFlowCapillaryPressureConst.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowCapillaryPressureConst.h
@@ -1,0 +1,73 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWCAPILLARYPRESSURECONST_H
+#define POROUSFLOWCAPILLARYPRESSURECONST_H
+
+#include "PorousFlowCapillaryPressure.h"
+
+class PorousFlowCapillaryPressureConst;
+
+template <>
+InputParameters validParams<PorousFlowCapillaryPressureConst>();
+
+/**
+ * Constant capillary pressure
+ */
+class PorousFlowCapillaryPressureConst : public PorousFlowCapillaryPressure
+{
+public:
+  PorousFlowCapillaryPressureConst(const InputParameters & parameters);
+
+  /**
+   * Capillary pressure is calculated as a function of saturation
+   * @param saturation true saturation
+   * @return capillary pressure (Pa)
+   */
+  virtual Real capillaryPressure(Real saturation) const override;
+
+  /**
+   * Derivative of capillary pressure wrt saturation
+   * @param saturation true saturation
+   * @return derivative of capillary pressure with respect to liquid saturation
+   */
+  virtual Real dCapillaryPressure(Real saturation) const override;
+
+  /**
+   * Second derivative of capillary pressure wrt saturation
+   * @param saturation true saturation
+   * @return second derivative of capillary pressure with respect to liquid saturation
+   */
+  virtual Real d2CapillaryPressure(Real saturation) const override;
+
+  /**
+   * Effective saturation as a function of capillary pressure
+   * @param pc capillary pressure (Pa)
+   * @return effective saturation
+   */
+  virtual Real effectiveSaturation(Real pc) const override;
+
+  /**
+   * Derivative of effective saturation wrt capillary pressure
+   * @param pc capillary pressure (Pa)
+   * @return derivative of effective saturation wrt capillary pressure
+   */
+  virtual Real dEffectiveSaturation(Real pc) const override;
+
+  /**
+   * Second derivative of effective saturation wrt capillary pressure
+   * @param pc capillary pressure
+   * @return second derivative of effective saturation wrt capillary pressure
+   */
+  virtual Real d2EffectiveSaturation(Real pc) const override;
+
+protected:
+  /// Constant capillary pressure (Pa)
+  const Real _pc;
+};
+
+#endif // POROUSFLOWCAPILLARYPRESSURECONST_H

--- a/modules/porous_flow/include/userobjects/PorousFlowCapillaryPressureVG.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowCapillaryPressureVG.h
@@ -1,0 +1,52 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef POROUSFLOWCAPILLARYPRESSUREVG_H
+#define POROUSFLOWCAPILLARYPRESSUREVG_H
+
+#include "PorousFlowCapillaryPressure.h"
+
+class PorousFlowCapillaryPressureVG;
+
+template <>
+InputParameters validParams<PorousFlowCapillaryPressureVG>();
+
+/**
+ * van Genuchten form of capillary pressure.
+ *
+ * From van Genuchten, M. Th., A closed for equation for predicting the
+ * hydraulic conductivity of unsaturated soils, Soil Sci. Soc., 44, 892-898 (1980)
+ */
+class PorousFlowCapillaryPressureVG : public PorousFlowCapillaryPressure
+{
+public:
+  PorousFlowCapillaryPressureVG(const InputParameters & parameters);
+
+  virtual Real capillaryPressure(Real saturation) const override;
+
+  virtual Real dCapillaryPressure(Real saturation) const override;
+
+  virtual Real d2CapillaryPressure(Real saturation) const override;
+
+  virtual Real effectiveSaturation(Real pc) const override;
+
+  virtual Real dEffectiveSaturation(Real pc) const override;
+
+  virtual Real d2EffectiveSaturation(Real pc) const override;
+
+protected:
+  /// van Genuchten exponent m
+  const Real _m;
+  /// van Genuchten capillary coefficient alpha
+  const Real _alpha;
+  /// P0 - inverse of alpha
+  const Real _p0;
+  /// Maximum capillary pressure (Pa). Note: must be <= 0
+  const Real _pc_max;
+};
+
+#endif // POROUSFLOWCAPILLARYPRESSUREVG_H

--- a/modules/porous_flow/src/base/PorousFlowApp.C
+++ b/modules/porous_flow/src/base/PorousFlowApp.C
@@ -14,6 +14,8 @@
 // UserObjects
 #include "PorousFlowDictator.h"
 #include "PorousFlowSumQuantity.h"
+#include "PorousFlowCapillaryPressureConst.h"
+#include "PorousFlowCapillaryPressureVG.h"
 
 // DiracKernels
 #include "PorousFlowSquarePulsePointSource.h"
@@ -156,6 +158,8 @@ PorousFlowApp::registerObjects(Factory & factory)
   // UserObjects
   registerUserObject(PorousFlowDictator);
   registerUserObject(PorousFlowSumQuantity);
+  registerUserObject(PorousFlowCapillaryPressureConst);
+  registerUserObject(PorousFlowCapillaryPressureVG);
 
   // DiracKernels
   registerDiracKernel(PorousFlowSquarePulsePointSource);

--- a/modules/porous_flow/src/userobjects/PorousFlowCapillaryPressure.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowCapillaryPressure.C
@@ -1,0 +1,35 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowCapillaryPressure.h"
+
+template <>
+InputParameters
+validParams<PorousFlowCapillaryPressure>()
+{
+  InputParameters params = validParams<GeneralUserObject>();
+  params.addRangeCheckedParam<Real>(
+      "sat_lr",
+      0.0,
+      "sat_lr >= 0 & sat_lr <= 1",
+      "Liquid residual saturation.  Must be between 0 and 1. Default is 0");
+  params.addClassDescription("Capillary pressure base class");
+  return params;
+}
+
+PorousFlowCapillaryPressure::PorousFlowCapillaryPressure(const InputParameters & parameters)
+  : GeneralUserObject(parameters),
+    _sat_lr(getParam<Real>("sat_lr")),
+    _dseff_ds(1.0 / (1.0 - _sat_lr))
+{
+}
+
+Real
+PorousFlowCapillaryPressure::effectiveSaturationFromSaturation(Real saturation) const
+{
+  return (saturation - _sat_lr) / (1.0 - _sat_lr);
+}

--- a/modules/porous_flow/src/userobjects/PorousFlowCapillaryPressureConst.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowCapillaryPressureConst.C
@@ -1,0 +1,43 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowCapillaryPressureConst.h"
+
+template <>
+InputParameters
+validParams<PorousFlowCapillaryPressureConst>()
+{
+  InputParameters params = validParams<PorousFlowCapillaryPressure>();
+  params.addRangeCheckedParam<Real>(
+      "pc",
+      0.0,
+      "pc <= 0",
+      "Constant capillary pressure (Pa). Default is 0. Note: capillary pressure must be negative");
+  params.addClassDescription("Constant capillary pressure");
+  return params;
+}
+
+PorousFlowCapillaryPressureConst::PorousFlowCapillaryPressureConst(
+    const InputParameters & parameters)
+  : PorousFlowCapillaryPressure(parameters), _pc(getParam<Real>("pc"))
+{
+}
+
+Real PorousFlowCapillaryPressureConst::capillaryPressure(Real /*saturation*/) const { return _pc; }
+
+Real PorousFlowCapillaryPressureConst::dCapillaryPressure(Real /*saturation*/) const { return 0.0; }
+
+Real PorousFlowCapillaryPressureConst::d2CapillaryPressure(Real /*saturation*/) const
+{
+  return 0.0;
+}
+
+Real PorousFlowCapillaryPressureConst::effectiveSaturation(Real /*pc*/) const { return 1.0; }
+
+Real PorousFlowCapillaryPressureConst::dEffectiveSaturation(Real /*pc*/) const { return 0.0; }
+
+Real PorousFlowCapillaryPressureConst::d2EffectiveSaturation(Real /*pc*/) const { return 0.0; }

--- a/modules/porous_flow/src/userobjects/PorousFlowCapillaryPressureVG.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowCapillaryPressureVG.C
@@ -1,0 +1,78 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "PorousFlowCapillaryPressureVG.h"
+#include "PorousFlowVanGenuchten.h"
+
+template <>
+InputParameters
+validParams<PorousFlowCapillaryPressureVG>()
+{
+  InputParameters params = validParams<PorousFlowCapillaryPressure>();
+  params.addRequiredRangeCheckedParam<Real>(
+      "m",
+      "m >= 0 & m <= 1",
+      "van Genuchten exponent m. Must be between 0 and 1, and optimally should be set to >0.5");
+  params.addRequiredRangeCheckedParam<Real>(
+      "alpha", "alpha > 0", "van Genuchten parameter alpha. Must be positive");
+  params.addRangeCheckedParam<Real>("pc_max",
+                                    -std::numeric_limits<Real>::max(),
+                                    "pc_max <= 0",
+                                    "Maximum capillary pressure (Pa). Must be <= 0. Default is "
+                                    "-std::numeric_limits<Real>::max()");
+  params.addClassDescription("van Genuchten capillary pressure");
+  return params;
+}
+
+PorousFlowCapillaryPressureVG::PorousFlowCapillaryPressureVG(const InputParameters & parameters)
+  : PorousFlowCapillaryPressure(parameters),
+    _m(getParam<Real>("m")),
+    _alpha(getParam<Real>("alpha")),
+    _p0(1.0 / _alpha),
+    _pc_max(getParam<Real>("pc_max"))
+{
+}
+
+Real
+PorousFlowCapillaryPressureVG::capillaryPressure(Real saturation) const
+{
+  Real seff = effectiveSaturationFromSaturation(saturation);
+  return PorousFlowVanGenuchten::capillaryPressure(seff, _m, _p0, _pc_max);
+}
+
+Real
+PorousFlowCapillaryPressureVG::dCapillaryPressure(Real saturation) const
+{
+  Real seff = effectiveSaturationFromSaturation(saturation);
+  return PorousFlowVanGenuchten::dCapillaryPressure(seff, _m, _p0, _pc_max) * _dseff_ds;
+}
+
+Real
+PorousFlowCapillaryPressureVG::d2CapillaryPressure(Real saturation) const
+{
+  Real seff = effectiveSaturationFromSaturation(saturation);
+  return PorousFlowVanGenuchten::d2CapillaryPressure(seff, _m, _p0, _pc_max) * _dseff_ds *
+         _dseff_ds;
+}
+
+Real
+PorousFlowCapillaryPressureVG::effectiveSaturation(Real pc) const
+{
+  return PorousFlowVanGenuchten::effectiveSaturation(pc, _alpha, _m);
+}
+
+Real
+PorousFlowCapillaryPressureVG::dEffectiveSaturation(Real pc) const
+{
+  return PorousFlowVanGenuchten::dEffectiveSaturation(pc, _alpha, _m);
+}
+
+Real
+PorousFlowCapillaryPressureVG::d2EffectiveSaturation(Real pc) const
+{
+  return PorousFlowVanGenuchten::d2EffectiveSaturation(pc, _alpha, _m);
+}

--- a/modules/porous_flow/tests/fluidstate/brineco2.i
+++ b/modules/porous_flow/tests/fluidstate/brineco2.i
@@ -187,6 +187,10 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureConst
+    pc = 0
+  [../]
 []
 
 [Modules]
@@ -217,6 +221,7 @@
     at_nodes = true
     temperature_unit = Celsius
     xnacl = xnacl
+    capillary_pressure = pc
   [../]
   [./brineco2_qp]
     type = PorousFlowFluidStateBrineCO2
@@ -226,6 +231,7 @@
     brine_fp = brine
     temperature_unit = Celsius
     xnacl = xnacl
+    capillary_pressure = pc
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/tests/fluidstate/theis.i
+++ b/modules/porous_flow/tests/fluidstate/theis.i
@@ -103,6 +103,10 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureConst
+    pc = 0
+  [../]
 []
 
 [Modules]
@@ -132,7 +136,7 @@
     water_fp = water
     at_nodes = true
     temperature_unit = Celsius
-    sat_lr = 0.1
+    capillary_pressure = pc
   [../]
   [./waterncg_qp]
     type = PorousFlowFluidStateWaterNCG
@@ -141,7 +145,7 @@
     gas_fp = co2
     water_fp = water
     temperature_unit = Celsius
-    sat_lr = 0.1
+    capillary_pressure = pc
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/tests/fluidstate/theis_brineco2.i
+++ b/modules/porous_flow/tests/fluidstate/theis_brineco2.i
@@ -106,6 +106,10 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureConst
+    pc = 0
+  [../]
 []
 
 [Modules]
@@ -136,7 +140,7 @@
     at_nodes = true
     temperature_unit = Celsius
     xnacl = xnacl
-    sat_lr = 0.1
+    capillary_pressure = pc
   [../]
   [./brineco2_qp]
     type = PorousFlowFluidStateBrineCO2
@@ -146,7 +150,7 @@
     brine_fp = brine
     temperature_unit = Celsius
     xnacl = xnacl
-    sat_lr = 0.1
+    capillary_pressure = pc
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/tests/fluidstate/theis_tabulated.i
+++ b/modules/porous_flow/tests/fluidstate/theis_tabulated.i
@@ -104,6 +104,10 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureConst
+    pc = 0
+  [../]
 []
 
 [Modules]
@@ -138,7 +142,7 @@
     water_fp = water
     at_nodes = true
     temperature_unit = Celsius
-    sat_lr = 0.1
+    capillary_pressure = pc
   [../]
   [./waterncg_qp]
     type = PorousFlowFluidStateWaterNCG
@@ -147,7 +151,7 @@
     gas_fp = tabulated
     water_fp = water
     temperature_unit = Celsius
-    sat_lr = 0.1
+    capillary_pressure = pc
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/tests/fluidstate/waterncg.i
+++ b/modules/porous_flow/tests/fluidstate/waterncg.i
@@ -183,6 +183,10 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureConst
+    pc = 0
+  [../]
 []
 
 [Modules]
@@ -214,6 +218,7 @@
     water_fp = water
     at_nodes = true
     temperature_unit = Celsius
+    capillary_pressure = pc
   [../]
   [./waterncg_qp]
     type = PorousFlowFluidStateWaterNCG
@@ -222,6 +227,7 @@
     gas_fp = co2
     water_fp = water
     temperature_unit = Celsius
+    capillary_pressure = pc
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/tests/jacobian/brineco2_gas.i
+++ b/modules/porous_flow/tests/jacobian/brineco2_gas.i
@@ -71,6 +71,12 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+    pc_max = -1e3
+  [../]
 []
 
 [Modules]
@@ -106,6 +112,7 @@
     at_nodes = true
     temperature_unit = Celsius
     xnacl = xnacl
+    capillary_pressure = pc
   [../]
   [./brineco2_qp]
     type = PorousFlowFluidStateBrineCO2
@@ -115,6 +122,7 @@
     brine_fp = brine
     temperature_unit = Celsius
     xnacl = xnacl
+    capillary_pressure = pc
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/tests/jacobian/brineco2_liquid.i
+++ b/modules/porous_flow/tests/jacobian/brineco2_liquid.i
@@ -71,6 +71,12 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+    pc_max = -1e4
+  [../]
 []
 
 [Modules]
@@ -106,6 +112,7 @@
     at_nodes = true
     temperature_unit = Celsius
     xnacl = xnacl
+    capillary_pressure = pc
   [../]
   [./brineco2_qp]
     type = PorousFlowFluidStateBrineCO2
@@ -115,6 +122,7 @@
     brine_fp = brine
     temperature_unit = Celsius
     xnacl = xnacl
+    capillary_pressure = pc
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/tests/jacobian/brineco2_twophase.i
+++ b/modules/porous_flow/tests/jacobian/brineco2_twophase.i
@@ -71,6 +71,13 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1e1
+    pc_max = -1e4
+    sat_lr = 0.1
+  [../]
 []
 
 [Modules]
@@ -106,6 +113,7 @@
     at_nodes = true
     temperature_unit = Celsius
     xnacl = xnacl
+    capillary_pressure = pc
   [../]
   [./brineco2_qp]
     type = PorousFlowFluidStateBrineCO2
@@ -115,6 +123,7 @@
     brine_fp = brine
     temperature_unit = Celsius
     xnacl = xnacl
+    capillary_pressure = pc
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/tests/jacobian/waterncg_gas.i
+++ b/modules/porous_flow/tests/jacobian/waterncg_gas.i
@@ -65,6 +65,12 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+    pc_max = -1e3
+  [../]
 []
 
 [Modules]
@@ -96,6 +102,7 @@
     water_fp = water
     at_nodes = true
     temperature_unit = Celsius
+    capillary_pressure = pc
   [../]
   [./waterncg_qp]
     type = PorousFlowFluidStateWaterNCG
@@ -104,6 +111,7 @@
     gas_fp = co2
     water_fp = water
     temperature_unit = Celsius
+    capillary_pressure = pc
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/tests/jacobian/waterncg_liquid.i
+++ b/modules/porous_flow/tests/jacobian/waterncg_liquid.i
@@ -65,6 +65,12 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+    pc_max = -1e4
+  [../]
 []
 
 [Modules]
@@ -96,6 +102,7 @@
     water_fp = water
     at_nodes = true
     temperature_unit = Celsius
+    capillary_pressure = pc
   [../]
   [./waterncg_qp]
     type = PorousFlowFluidStateWaterNCG
@@ -104,6 +111,7 @@
     gas_fp = co2
     water_fp = water
     temperature_unit = Celsius
+    capillary_pressure = pc
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/tests/jacobian/waterncg_twophase.i
+++ b/modules/porous_flow/tests/jacobian/waterncg_twophase.i
@@ -65,6 +65,13 @@
     number_fluid_phases = 2
     number_fluid_components = 2
   [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1e1
+    pc_max = -1e4
+    sat_lr = 0.1
+  [../]
 []
 
 [Modules]
@@ -96,6 +103,7 @@
     water_fp = water
     at_nodes = true
     temperature_unit = Celsius
+    capillary_pressure = pc
   [../]
   [./waterncg_qp]
     type = PorousFlowFluidStateWaterNCG
@@ -104,6 +112,7 @@
     gas_fp = co2
     water_fp = water
     temperature_unit = Celsius
+    capillary_pressure = pc
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst


### PR DESCRIPTION
Following discussion in #9105, this is the initial implementation of capillary pressure as a user object rather than having a separate material for each formulation.

The benefits of this is being able to only enter capillary pressure values in one place in the input, rather than in several. This will also eventually allow us to deprecate and remove a bunch of materials that have the capillary pressures hard coded in, reducing the code base in PorousFlow.

Only the constant and van Genuchten forms have been added yet, and only for the PorousFlowFluidState materials. Eventually, the remaining materials can be migrated over to this design. I just didn't want to change 200 tests right now.

Refs #9105 