### PR TITLE
make Output::outputStep public

### DIFF
--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -66,7 +66,6 @@ public:
    */
   std::string directory();
 
-protected:
   /**
    * Outputs a checkpoint file.
    * Each call to this function creates various files associated with

--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -129,7 +129,6 @@ public:
    */
   static void addDeprecatedInputParameters(InputParameters & params);
 
-protected:
   /**
    * A single call to this function should output all the necessary data for a single timestep.
    * @param type The type execution flag (see Moose.h)
@@ -138,6 +137,7 @@ protected:
    */
   virtual void outputStep(const ExecFlagType & type);
 
+protected:
   /**
    * Overload this function with the desired output activities
    */

--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -73,13 +73,13 @@ public:
    */
   virtual void meshChanged() override;
 
+  virtual void outputStep(const ExecFlagType & type) override;
+
 protected:
   /**
    * Performs the update of the solution vector for the oversample/re-positioned mesh
    */
   virtual void updateOversample();
-
-  virtual void outputStep(const ExecFlagType & type) override;
 
   /**
    * A convenience pointer to the current mesh (reference or displaced depending on "use_displaced")


### PR DESCRIPTION
This is necessary as a followup to #9198.  This fix enables a
corresponding fix in CASL/Tiamat.