### PR TITLE
Adding solution vector for previous Newton iterate earlier

### DIFF
--- a/framework/include/base/AuxiliarySystem.h
+++ b/framework/include/base/AuxiliarySystem.h
@@ -48,6 +48,7 @@ public:
   virtual ~AuxiliarySystem();
 
   virtual void init() override;
+  virtual void addExtraVectors() override;
 
   virtual void initialSetup();
   virtual void timestepSetup();

--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -333,6 +333,10 @@ public:
    */
   virtual std::vector<VariableName> getVariableNames();
 
+  /**
+   * A place to add extra vectors to the simulation. It is called early during initialSetup.
+   */
+  virtual void addExtraVectors();
   virtual void initialSetup();
   virtual void timestepSetup();
 

--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -65,6 +65,7 @@ public:
   virtual ~NonlinearSystemBase();
 
   virtual void init() override;
+  virtual void addExtraVectors() override;
   virtual void solve() override = 0;
   virtual void restoreSolutions() override;
 

--- a/framework/include/base/SystemBase.h
+++ b/framework/include/base/SystemBase.h
@@ -123,6 +123,12 @@ public:
   virtual void initializeObjects(){};
 
   /**
+   * Method called during initialSetup to add extra system vector if they are required by
+   * the simulation
+   */
+  virtual void addExtraVectors();
+
+  /**
    * Update the system (doing libMesh magic)
    */
   virtual void update();

--- a/framework/src/base/AuxiliarySystem.C
+++ b/framework/src/base/AuxiliarySystem.C
@@ -56,11 +56,15 @@ AuxiliarySystem::init()
 }
 
 void
-AuxiliarySystem::initialSetup()
+AuxiliarySystem::addExtraVectors()
 {
   if (_fe_problem.needsPreviousNewtonIteration())
     _solution_previous_nl = &addVector("u_previous_newton", true, GHOSTED);
+}
 
+void
+AuxiliarySystem::initialSetup()
+{
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.sort(tid);

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -410,6 +410,13 @@ FEProblemBase::setAxisymmetricCoordAxis(const MooseEnum & rz_coord_axis)
 }
 
 void
+FEProblemBase::addExtraVectors()
+{
+  _nl->addExtraVectors();
+  _aux->addExtraVectors();
+}
+
+void
 FEProblemBase::initialSetup()
 {
   Moose::perf_log.push("initialSetup()", "Setup");
@@ -417,6 +424,8 @@ FEProblemBase::initialSetup()
   // set state flag indicating that we are in or beyond initialSetup.
   // This can be used to throw errors in methods that _must_ be called at construction time.
   _started_initial_setup = true;
+
+  addExtraVectors();
 
   // Perform output related setups
   _app.getOutputWarehouse().initialSetup();

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -173,6 +173,13 @@ NonlinearSystemBase::init()
 }
 
 void
+NonlinearSystemBase::addExtraVectors()
+{
+  if (_fe_problem.needsPreviousNewtonIteration())
+    _solution_previous_nl = &addVector("u_previous_newton", true, GHOSTED);
+}
+
+void
 NonlinearSystemBase::restoreSolutions()
 {
   // call parent
@@ -184,9 +191,6 @@ NonlinearSystemBase::restoreSolutions()
 void
 NonlinearSystemBase::initialSetup()
 {
-  if (_fe_problem.needsPreviousNewtonIteration())
-    _solution_previous_nl = &addVector("u_previous_newton", true, GHOSTED);
-
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _kernels.initialSetup(tid);

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -651,6 +651,11 @@ SystemBase::copyVars(ExodusII_IO & io)
 }
 
 void
+SystemBase::addExtraVectors()
+{
+}
+
+void
 SystemBase::update()
 {
   system().update();


### PR DESCRIPTION
The vector needs to be added sooner than in initialSetup. In some
simulations it is too late and the code segfaults, because it is
accessing a non-existent vector.  It is caused by MOOSE spawning an
element loop before actually calling aux|nl system's `initialSetup`.

Refs #6101