### PR TITLE
Add corner case check to get_repo_revsion.py

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -166,7 +166,7 @@ app_HEADER_deps := $(wildcard $(app_GIT_DIR)/.git/HEAD $(app_GIT_DIR)/.git/index
 $(app_HEADER): curr_dir    := $(APPLICATION_DIR)
 $(app_HEADER): curr_app    := $(APPLICATION_NAME)
 $(app_HEADER): $(app_HEADER_deps)
-	@echo "MOOSE Updating header "$@"..."
+	@echo "MOOSE Checking if header needs updating: "$@"..."
 	$(shell $(FRAMEWORK_DIR)/scripts/get_repo_revision.py $(curr_dir) $@ $(curr_app))
 
 # Target-specific Variable Values (See GNU-make manual)

--- a/framework/scripts/get_repo_revision.py
+++ b/framework/scripts/get_repo_revision.py
@@ -121,6 +121,12 @@ def writeRevision( repo_location, app_name, revision_header ):
         if m is not None and m.group(1) != app_revision:
             revision_changed = True
 
+        if m is None:
+            # If the above RE doesn't match anything then we have
+            # a bad _REVISION define and we need to rewrite
+            # out a new file.
+            revision_changed = True
+
         f.close()
     else:
         # Count it as changed if the header does not exist.


### PR DESCRIPTION
If the revision header file exists but doesn't define the correct `_REVISION` then we regenerate the header file.

closes #9403