### PR TITLE
use_old_floor in exodiff for geomsearch tests

### DIFF
--- a/test/tests/geomsearch/patch_update_strategy/tests
+++ b/test/tests/geomsearch/patch_update_strategy/tests
@@ -3,15 +3,18 @@
     type = 'Exodiff'
     input = 'never.i'
     exodiff = 'never_out.e'
+    use_old_floor = True
   [../]
   [./auto]
     type = 'Exodiff'
     input = 'auto.i'
     exodiff = 'auto_out.e'
+    use_old_floor = True
   [../]
   [./always]
     type = 'Exodiff'
     input = 'always.i'
     exodiff = 'always_out.e'
+    use_old_floor = True
   [../]
 []


### PR DESCRIPTION
This fixes the false positives in #9414 for me, at least on the processor counts I've tested, which are twice as high as the counts which were failing before.