### PR TITLE
Restrict setup_interface_count tests to serial

### DIFF
--- a/test/tests/userobjects/setup_interface_count/tests
+++ b/test/tests/userobjects/setup_interface_count/tests
@@ -1,8 +1,15 @@
 # The following tests are designed to count how often the setup methods are called (initialSetup, etc.),
 # which requires that the threading be disabeled because the counts can differ.
 #
-# Also, GeneralUserObject must also be restricted for a certain MPI because their methods will be called
-# on each processor, since they are not distributed in any fashion.
+# GeneralUserObject must also be restricted for a certain MPI because
+# their methods will be called on each processor, since they are not
+# distributed in any fashion.
+#
+# Other UserObject tests here include a subdomainSetup count, which
+# depends on the number of transitions between subdomains while
+# iterating over local elements, which depend on how mesh
+# partitioning assigns local elements.  We'll just run them all in
+# serial.
 [Tests]
   [./GeneralUserObject]
     type = CSVDiff
@@ -17,23 +24,27 @@
     input = element.i
     csvdiff = element_out.csv
     max_threads = 1
+    max_parallel = 1
   [../]
   [./SideUserObject]
     type = CSVDiff
     input = side.i
     csvdiff = side_out.csv
     max_threads = 1
+    max_parallel = 1
   [../]
   [./InternalSideUserObject]
     type = CSVDiff
     input = internal_side.i
     csvdiff = internal_side_out.csv
     max_threads = 1
+    max_parallel = 1
   [../]
   [./NodalSideUserObject]
     type = CSVDiff
     input = nodal.i
     csvdiff = nodal_out.csv
     max_threads = 1
+    max_parallel = 1
   [../]
 []


### PR DESCRIPTION
If we want to run these in parallel, we'll need to modify the object
to make it stop counting subdomainSetup counts, which we don't expect
to be consistent from partitioning to partitioning.

This fixes #9422 for me.