### PR TITLE
Use old exodiff floor option, looser abs tolerance

### DIFF
--- a/test/tests/nodalkernels/constant_rate/tests
+++ b/test/tests/nodalkernels/constant_rate/tests
@@ -4,6 +4,8 @@
     input = 'constant_rate.i'
     exodiff = 'constant_rate_out.e'
     rel_err = 1e-05
+    use_old_floor = True
+    abs_zero = 1e-08
   [../]
 
   [./threaded]
@@ -13,5 +15,7 @@
     min_threads = '3'
     prereq = 'test' # Force ordering since they output the same files
     rel_err = 1e-05
+    use_old_floor = True
+    abs_zero = 1e-08
   [../]
 []


### PR DESCRIPTION
This fixes what I believe to be a false positive error as described in
issue #9414, this time triggered by
./run_tests -p 4 --recover --re 'nodalkernels/constant_rate.test

With the tolerance rule made more sane and the tolerance turned up to
1e-8, I get success on 1 through 18 processors; with the old settings
I get a failure (of one node value in one timestep, with about a
1.02e-9 error) on 4 processors.

This fixes one of the last test failures (on 4 processors) for #8410