### PR TITLE
Variable elasticity tensor and stress class modifications

### DIFF
--- a/modules/combined/tests/thermal_elastic/tests
+++ b/modules/combined/tests/thermal_elastic/tests
@@ -2,12 +2,21 @@
   [./test]
     type = 'Exodiff'
     input = 'thermal_elastic.i'
+    cli_args = 'Materials/stress/type=ComputeFiniteStrainElasticStress'
     exodiff = 'thermal_elastic_out.e'
+  [../]
+  [./test-deprecated-variableStress]
+    type = 'Exodiff'
+    input = 'thermal_elastic.i'
+    cli_args = 'Materials/stress/type=ComputeVariableElasticConstantStress'
+    exodiff = 'thermal_elastic_out.e'
+    prereq = test
+    allow_deprecated_until = '8/3/2017'
   [../]
   [./test_sm]
     type = 'Exodiff'
     input = 'thermal_elastic_sm.i'
     exodiff = 'thermal_elastic_out.e'
-    prereq = test
+    prereq = test-deprecated-variableStress
   [../]
 []

--- a/modules/combined/tests/thermal_elastic/thermal_elastic.i
+++ b/modules/combined/tests/thermal_elastic/thermal_elastic.i
@@ -293,7 +293,6 @@
   [../]
 
   [./stress]
-    type = ComputeVariableElasticConstantStress
   [../]
 
   [./heat]

--- a/modules/combined/tests/thermo_mech/tests
+++ b/modules/combined/tests/thermo_mech/tests
@@ -2,7 +2,16 @@
   [./youngs_modulus_func_temp]
     type = Exodiff
     input = 'youngs_modulus_function_temp.i'
+    cli_args = 'Materials/stress/type=ComputeFiniteStrainElasticStress'
     exodiff = 'youngs_modulus_function_temp_out.e'
+  [../]
+  [./youngs_modulus_func_temp-deprecated-variableStress]
+    type = Exodiff
+    input = 'youngs_modulus_function_temp.i'
+    cli_args = 'Materials/stress/type=ComputeVariableElasticConstantStress'
+    exodiff = 'youngs_modulus_function_temp_out.e'
+    prereq = youngs_modulus_func_temp
+    allow_deprecated_until = '8/3/2017'
   [../]
 
   [./thermomechanics]

--- a/modules/combined/tests/thermo_mech/youngs_modulus_function_temp.i
+++ b/modules/combined/tests/thermo_mech/youngs_modulus_function_temp.i
@@ -1,5 +1,6 @@
 # ---------------------------------------------------------------------------
-# This test is designed to verify the ComputeVariableElasticConstantStress
+# This test is designed to verify the variable elasticity tensor functionality in the
+# ComputeFiniteStrainElasticStress class with the elasticity_tensor_has_changed flag
 # by varying the young's modulus with temperature. A constant strain is applied
 # to the mesh in this case, and the stress varies with the changing elastic constants.
 #
@@ -159,7 +160,6 @@
     block = 0
   [../]
   [./stress]
-    type = ComputeVariableElasticConstantStress
     block = 0
   [../]
   [./heat1]

--- a/modules/porous_flow/tests/jacobian/phe01.i
+++ b/modules/porous_flow/tests/jacobian/phe01.i
@@ -130,9 +130,9 @@
     type = ComputePlasticHeatEnergy
   [../]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/include/materials/ComputeCosseratElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCosseratElasticityTensor.h
@@ -28,6 +28,9 @@ protected:
 
   /// Flexural rigidity tensor at the qps
   MaterialProperty<RankFourTensor> & _elastic_flexural_rigidity_tensor;
+
+  /// Flag for variable elasticity isotropic tensors
+  MaterialProperty<bool> & _elasticity_tensor_is_constant;
 };
 
 #endif // COMPUTECOSSERATELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeCosseratElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCosseratElasticityTensor.h
@@ -28,9 +28,6 @@ protected:
 
   /// Flexural rigidity tensor at the qps
   MaterialProperty<RankFourTensor> & _elastic_flexural_rigidity_tensor;
-
-  /// Flag for variable elasticity isotropic tensors
-  MaterialProperty<bool> & _elasticity_tensor_is_constant;
 };
 
 #endif // COMPUTECOSSERATELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
@@ -22,11 +22,18 @@ public:
   void initialSetup() override;
 
 protected:
+  virtual void initQpStatefulProperties() override;
   virtual void computeQpStress() override;
 
   const MaterialProperty<RankTwoTensor> & _strain_increment;
   const MaterialProperty<RankTwoTensor> & _rotation_increment;
   const MaterialProperty<RankTwoTensor> & _stress_old;
+
+  /**
+   * The old elastic strain is used to calculate the old stress in the case
+   * of variable elasticity tensors
+   */
+  const MaterialProperty<RankTwoTensor> & _elastic_strain_old;
 };
 
 #endif // COMPUTEFINITESTRAINELASTICSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
@@ -34,6 +34,9 @@ protected:
    * of variable elasticity tensors
    */
   const MaterialProperty<RankTwoTensor> & _elastic_strain_old;
+
+  /// flag for if the elasticity tensor does NOT change value over time
+  bool _is_elasticity_tensor_guaranteed_constant_in_time;
 };
 
 #endif // COMPUTEFINITESTRAINELASTICSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
@@ -36,9 +36,6 @@ protected:
 
   /// Individual elasticity tensor
   RankFourTensor _Cijkl;
-
-  /// Flag for variable elasticity isotropic tensors
-  MaterialProperty<bool> & _elasticity_tensor_is_constant;
 };
 
 #endif // COMPUTEISOTROPICELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
@@ -36,6 +36,9 @@ protected:
 
   /// Individual elasticity tensor
   RankFourTensor _Cijkl;
+
+  /// Flag for variable elasticity isotropic tensors
+  MaterialProperty<bool> & _elasticity_tensor_is_constant;
 };
 
 #endif // COMPUTEISOTROPICELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeLayeredCosseratElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeLayeredCosseratElasticityTensor.h
@@ -42,6 +42,9 @@ protected:
 
   /// Compliance tensor (_Eijkl^-1) at the qps
   MaterialProperty<RankFourTensor> & _compliance;
+
+  /// Flag for variable elasticity isotropic tensors
+  MaterialProperty<bool> & _elasticity_tensor_is_constant;
 };
 
 #endif // COMPUTELAYEREDCOSSERATELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeLayeredCosseratElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeLayeredCosseratElasticityTensor.h
@@ -42,9 +42,6 @@ protected:
 
   /// Compliance tensor (_Eijkl^-1) at the qps
   MaterialProperty<RankFourTensor> & _compliance;
-
-  /// Flag for variable elasticity isotropic tensors
-  MaterialProperty<bool> & _elasticity_tensor_is_constant;
 };
 
 #endif // COMPUTELAYEREDCOSSERATELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -144,6 +144,9 @@ protected:
 
   /// is the elasticity tensor guaranteed to be isotropic?
   bool _is_elasticity_tensor_guaranteed_isotropic;
+
+  // /// flag for if the elasticity tensor does NOT change value over time
+  // bool _is_elasticity_tensor_guaranteed_constant_in_time;
 };
 
 #endif // COMPUTEMULTIPLEINELASTICSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeVariableIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeVariableIsotropicElasticityTensor.h
@@ -30,6 +30,9 @@ protected:
   /// Material defininig the Poisson's Ratio
   const MaterialProperty<Real> & _poissons_ratio;
 
+  /// Flag for variable elasticity isotropic tensors
+  MaterialProperty<bool> & _elasticity_tensor_is_constant;
+
   /// number of variables the moduli depend on
   const unsigned int _num_args;
 

--- a/modules/tensor_mechanics/src/materials/ComputeCosseratElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCosseratElasticityTensor.C
@@ -29,18 +29,15 @@ ComputeCosseratElasticityTensor::ComputeCosseratElasticityTensor(const InputPara
     _Bijkl(getParam<std::vector<Real>>("B_ijkl"),
            (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method_bending")),
     _elastic_flexural_rigidity_tensor(
-        declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
-    _elasticity_tensor_is_constant(
-        declareProperty<bool>(_base_name + "elasticity_tensor_is_constant"))
+        declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor"))
 {
+  // all tensors created by this class are always constant in time
+  issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
 }
 
 void
 ComputeCosseratElasticityTensor::computeQpElasticityTensor()
 {
-  // Let the Stress Calculator classes know that this class only has constant values
-  _elasticity_tensor_is_constant[_qp] = true;
-
   _elasticity_tensor[_qp] = _Eijkl;
   _elastic_flexural_rigidity_tensor[_qp] = _Bijkl;
 }

--- a/modules/tensor_mechanics/src/materials/ComputeCosseratElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCosseratElasticityTensor.C
@@ -29,13 +29,18 @@ ComputeCosseratElasticityTensor::ComputeCosseratElasticityTensor(const InputPara
     _Bijkl(getParam<std::vector<Real>>("B_ijkl"),
            (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method_bending")),
     _elastic_flexural_rigidity_tensor(
-        declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor"))
+        declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
+    _elasticity_tensor_is_constant(
+        declareProperty<bool>(_base_name + "elasticity_tensor_is_constant"))
 {
 }
 
 void
 ComputeCosseratElasticityTensor::computeQpElasticityTensor()
 {
+  // Let the Stress Calculator classes know that this class only has constant values
+  _elasticity_tensor_is_constant[_qp] = true;
+
   _elasticity_tensor[_qp] = _Eijkl;
   _elastic_flexural_rigidity_tensor[_qp] = _Bijkl;
 }

--- a/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
@@ -11,7 +11,7 @@ InputParameters
 validParams<ComputeIsotropicElasticityTensor>()
 {
   InputParameters params = validParams<ComputeElasticityTensorBase>();
-  params.addClassDescription("Compute an isotropic elasticity tensor.");
+  params.addClassDescription("Compute a constant isotropic elasticity tensor.");
   params.addParam<Real>("bulk_modulus", "The bulk modulus for the material.");
   params.addParam<Real>("lambda", "Lame's first constant for the material.");
   params.addParam<Real>("poissons_ratio", "Poisson's ratio for the material.");
@@ -32,7 +32,9 @@ ComputeIsotropicElasticityTensor::ComputeIsotropicElasticityTensor(
     _lambda(_lambda_set ? getParam<Real>("lambda") : -1),
     _poissons_ratio(_poissons_ratio_set ? getParam<Real>("poissons_ratio") : -1),
     _shear_modulus(_shear_modulus_set ? getParam<Real>("shear_modulus") : -1),
-    _youngs_modulus(_youngs_modulus_set ? getParam<Real>("youngs_modulus") : -1)
+    _youngs_modulus(_youngs_modulus_set ? getParam<Real>("youngs_modulus") : -1),
+    _elasticity_tensor_is_constant(
+        declareProperty<bool>(_base_name + "elasticity_tensor_is_constant"))
 {
   unsigned int num_elastic_constants = _bulk_modulus_set + _lambda_set + _poissons_ratio_set +
                                        _shear_modulus_set + _youngs_modulus_set;
@@ -127,6 +129,9 @@ ComputeIsotropicElasticityTensor::ComputeIsotropicElasticityTensor(
 void
 ComputeIsotropicElasticityTensor::computeQpElasticityTensor()
 {
+  // Let the Stress Calculator classes know that this class only has constant values
+  _elasticity_tensor_is_constant[_qp] = true;
+
   // Assign elasticity tensor at a given quad point
   _elasticity_tensor[_qp] = _Cijkl;
 }

--- a/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
@@ -32,18 +32,18 @@ ComputeIsotropicElasticityTensor::ComputeIsotropicElasticityTensor(
     _lambda(_lambda_set ? getParam<Real>("lambda") : -1),
     _poissons_ratio(_poissons_ratio_set ? getParam<Real>("poissons_ratio") : -1),
     _shear_modulus(_shear_modulus_set ? getParam<Real>("shear_modulus") : -1),
-    _youngs_modulus(_youngs_modulus_set ? getParam<Real>("youngs_modulus") : -1),
-    _elasticity_tensor_is_constant(
-        declareProperty<bool>(_base_name + "elasticity_tensor_is_constant"))
+    _youngs_modulus(_youngs_modulus_set ? getParam<Real>("youngs_modulus") : -1)
 {
   unsigned int num_elastic_constants = _bulk_modulus_set + _lambda_set + _poissons_ratio_set +
                                        _shear_modulus_set + _youngs_modulus_set;
+  if (num_elastic_constants != 2)
+    mooseError("Exactly two elastic constants must be defined for material '" + name() + "'.");
 
   // all tensors created by this class are always isotropic
   issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);
 
-  if (num_elastic_constants != 2)
-    mooseError("Exactly two elastic constants must be defined for material '" + name() + "'.");
+  // all tensors created by this class are always constant in time
+  issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
 
   if (_bulk_modulus_set && _bulk_modulus <= 0.0)
     mooseError("Bulk modulus must be positive in material '" + name() + "'.");
@@ -129,9 +129,6 @@ ComputeIsotropicElasticityTensor::ComputeIsotropicElasticityTensor(
 void
 ComputeIsotropicElasticityTensor::computeQpElasticityTensor()
 {
-  // Let the Stress Calculator classes know that this class only has constant values
-  _elasticity_tensor_is_constant[_qp] = true;
-
   // Assign elasticity tensor at a given quad point
   _elasticity_tensor[_qp] = _Cijkl;
 }

--- a/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
@@ -36,10 +36,11 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
     _Cijkl(RankFourTensor()),
     _elastic_flexural_rigidity_tensor(
         declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
-    _compliance(declareProperty<RankFourTensor>(_base_name + "compliance_tensor")),
-    _elasticity_tensor_is_constant(
-        declareProperty<bool>(_base_name + "elasticity_tensor_is_constant"))
+    _compliance(declareProperty<RankFourTensor>(_base_name + "compliance_tensor"))
 {
+  // all tensors created by this class are always constant in time
+  issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
+
   const Real E = getParam<Real>("young");
   const Real nu = getParam<Real>("poisson");
   const Real b = getParam<Real>("layer_thickness");
@@ -102,9 +103,6 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
 void
 ComputeLayeredCosseratElasticityTensor::computeQpElasticityTensor()
 {
-  // Let the Stress Calculator classes know that this class only has constant values
-  _elasticity_tensor_is_constant[_qp] = true;
-
   _elasticity_tensor[_qp] = _Eijkl;
   _elastic_flexural_rigidity_tensor[_qp] = _Bijkl;
   _compliance[_qp] = _Cijkl;

--- a/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
@@ -36,7 +36,9 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
     _Cijkl(RankFourTensor()),
     _elastic_flexural_rigidity_tensor(
         declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
-    _compliance(declareProperty<RankFourTensor>(_base_name + "compliance_tensor"))
+    _compliance(declareProperty<RankFourTensor>(_base_name + "compliance_tensor")),
+    _elasticity_tensor_is_constant(
+        declareProperty<bool>(_base_name + "elasticity_tensor_is_constant"))
 {
   const Real E = getParam<Real>("young");
   const Real nu = getParam<Real>("poisson");
@@ -100,6 +102,9 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
 void
 ComputeLayeredCosseratElasticityTensor::computeQpElasticityTensor()
 {
+  // Let the Stress Calculator classes know that this class only has constant values
+  _elasticity_tensor_is_constant[_qp] = true;
+
   _elasticity_tensor[_qp] = _Eijkl;
   _elastic_flexural_rigidity_tensor[_qp] = _Bijkl;
   _compliance[_qp] = _Cijkl;

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
@@ -42,6 +42,9 @@ ComputeMultipleInelasticCosseratStress::initQpStatefulProperties()
 void
 ComputeMultipleInelasticCosseratStress::computeQpStress()
 {
+  if (!_elasticity_tensor_is_constant[_qp])
+    mooseError("The Cosserat stress classes assume constant elasticity tensors");
+
   ComputeMultipleInelasticStress::computeQpStress();
 
   _couple_stress[_qp] = _elastic_flexural_rigidity_tensor[_qp] * _curvature[_qp];

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
@@ -37,14 +37,14 @@ ComputeMultipleInelasticCosseratStress::initQpStatefulProperties()
 {
   ComputeMultipleInelasticStress::initQpStatefulProperties();
   _couple_stress[_qp].zero();
+
+  if (!_is_elasticity_tensor_guaranteed_constant_in_time)
+    mooseError("The Cosserat stress classes assume constant elasticity tensors");
 }
 
 void
 ComputeMultipleInelasticCosseratStress::computeQpStress()
 {
-  if (!_elasticity_tensor_is_constant[_qp])
-    mooseError("The Cosserat stress classes assume constant elasticity tensors");
-
   ComputeMultipleInelasticStress::computeQpStress();
 
   _couple_stress[_qp] = _elastic_flexural_rigidity_tensor[_qp] * _curvature[_qp];

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -115,9 +115,16 @@ ComputeMultipleInelasticStress::initialSetup()
     if (rrr)
     {
       _models.push_back(rrr);
+<<<<<<< HEAD
       if (rrr->requiresIsotropicTensor() && !_is_elasticity_tensor_guaranteed_isotropic)
         mooseError("Model " + models[i] + " requires an isotropic elasticity tensor, but the one "
                                           "supplied is not guaranteed isotropic");
+=======
+      if (rrr->requiresIsotropicTensor() && !isElasticityTensorGuaranteedIsotropic())
+        mooseError("Model " + models[i] +
+                   " requires an isotropic elasticity tensor, but the one supplied is not "
+                   "guaranteed isotropic");
+>>>>>>> Change old stress calculation based on elasticity_tensor_has_changed flag. Refs #8616
     }
     else
       mooseError("Model " + models[i] + " is not compatible with ComputeMultipleInelasticStress");
@@ -127,13 +134,26 @@ ComputeMultipleInelasticStress::initialSetup()
 void
 ComputeMultipleInelasticStress::computeQpStress()
 {
+  if ((isParamValid("initial_stress")) && !_elasticity_tensor_is_constant[_qp])
+    mooseError("A finite stress material cannot both have an initial stress and an elasticity "
+               "tensor with varying values; please use a defined constant elasticity tensor, "
+               "such as ComputeIsotropicElasticityTensor, if your model defines an initial "
+               "stress, or apply an initial strain instead.");
+
   RankTwoTensor elastic_strain_increment;
   RankTwoTensor combined_inelastic_strain_increment;
 
   if (_num_models == 0)
   {
     _elastic_strain[_qp] = _elastic_strain_old[_qp] + _strain_increment[_qp];
-    _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * _strain_increment[_qp];
+
+    // If the elasticity tensor values have changed and the tensor is isotropic,
+    // use the old strain to calculate the old stress
+    if (!_elasticity_tensor_is_constant[_qp] && isElasticityTensorGuaranteedIsotropic())
+      _stress[_qp] = _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + _strain_increment[_qp]);
+    else
+      _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * _strain_increment[_qp];
+
     if (_fe_problem.currentlyComputingJacobian())
       _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
   }
@@ -198,8 +218,12 @@ ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_inc
         if (i_rmm != j_rmm)
           elastic_strain_increment -= inelastic_strain_increment[j_rmm];
 
-      // form the trial stress
-      _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * elastic_strain_increment;
+      // form the trial stress, with the check for changed elasticity constants
+      if (!_elasticity_tensor_is_constant[_qp] && isElasticityTensorGuaranteedIsotropic())
+        _stress[_qp] =
+            _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + elastic_strain_increment);
+      else
+        _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * elastic_strain_increment;
 
       // given a trial stress (_stress[_qp]) and a strain increment (elastic_strain_increment)
       // let the i^th model produce an admissible stress (as _stress[_qp]), and decompose
@@ -298,7 +322,12 @@ ComputeMultipleInelasticStress::updateQpStateSingleModel(
 
   elastic_strain_increment = _strain_increment[_qp];
 
-  _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * elastic_strain_increment;
+  // If the elasticity tensor values have changed and the tensor is isotropic,
+  // use the old strain to calculate the old stress
+  if (!_elasticity_tensor_is_constant[_qp] && isElasticityTensorGuaranteedIsotropic())
+    _stress[_qp] = _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + elastic_strain_increment);
+  else
+    _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * elastic_strain_increment;
 
   computeAdmissibleState(model_number,
                          elastic_strain_increment,

--- a/modules/tensor_mechanics/src/materials/ComputeVariableElasticConstantStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeVariableElasticConstantStress.C
@@ -22,6 +22,10 @@ ComputeVariableElasticConstantStress::ComputeVariableElasticConstantStress(
   : ComputeFiniteStrainElasticStress(parameters),
     _elasticity_tensor_old(getMaterialPropertyOld<RankFourTensor>(_base_name + "elasticity_tensor"))
 {
+  mooseDeprecated("ComputeVariableElasticConstantStress is deprecated, and the functionality of "
+                  "this deprecated class is now available natively in the incremental form stress "
+                  "calculators.  Please use ComputeFiniteStrainElasticStress or "
+                  "ComputeMultipleInelasticStress.");
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ComputeVariableIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeVariableIsotropicElasticityTensor.C
@@ -27,6 +27,8 @@ ComputeVariableIsotropicElasticityTensor::ComputeVariableIsotropicElasticityTens
   : ComputeElasticityTensorBase(parameters),
     _youngs_modulus(getMaterialProperty<Real>("youngs_modulus")),
     _poissons_ratio(getMaterialProperty<Real>("poissons_ratio")),
+    _elasticity_tensor_is_constant(
+        declareProperty<bool>(_base_name + "elasticity_tensor_is_constant")),
     _num_args(coupledComponents("args")),
     _dyoungs_modulus(_num_args),
     _d2youngs_modulus(_num_args),
@@ -97,6 +99,9 @@ ComputeVariableIsotropicElasticityTensor::initQpStatefulProperties()
 void
 ComputeVariableIsotropicElasticityTensor::computeQpElasticityTensor()
 {
+  // Let the Stress Calculator classes know that this class changes the elasticity tensor values
+  _elasticity_tensor_is_constant[_qp] = false;
+
   _elasticity_tensor[_qp].fillFromInputVector({_youngs_modulus[_qp], _poissons_ratio[_qp]},
                                               RankFourTensor::symmetric_isotropic_E_nu);
 

--- a/modules/tensor_mechanics/tests/action/two_block_new.i
+++ b/modules/tensor_mechanics/tests/action/two_block_new.i
@@ -26,7 +26,7 @@
 
 [Modules/TensorMechanics/Master]
   # parameters that apply to all subblocks are specified at this level. They
-  # can be overwritten in teh subblocks.
+  # can be overwritten in the subblocks.
   add_variables = true
   strain = FINITE
   generate_output = 'stress_xx'

--- a/modules/tensor_mechanics/tests/capped_drucker_prager/small_deform2_inner_edge.i
+++ b/modules/tensor_mechanics/tests/capped_drucker_prager/small_deform2_inner_edge.i
@@ -218,10 +218,10 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
+    type = ComputeIsotropicElasticityTensor
     block = 0
-    fill_method = symmetric_isotropic
-    C_ijkl = '0 1E7'
+    lambda = 0.0
+    shear_modulus = 1.0e7
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/capped_drucker_prager/small_deform2_lode_zero.i
+++ b/modules/tensor_mechanics/tests/capped_drucker_prager/small_deform2_lode_zero.i
@@ -218,10 +218,10 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
+    type = ComputeIsotropicElasticityTensor
     block = 0
-    fill_method = symmetric_isotropic
-    C_ijkl = '0 1E7'
+    lambda = 0.0
+    shear_modulus = 1.0e7
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/capped_weak_plane/pull_push.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/pull_push.i
@@ -374,9 +374,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '6.4E9 6.4E9'  # young 16MPa, Poisson 0.25
+    type = ComputeIsotropicElasticityTensor
+    lambda = 6.4e9
+    shear_modulus = 6.4e9 # young 16MPa, Poisson 0.25
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/capped_weak_plane/small_deform1.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/small_deform1.i
@@ -306,4 +306,3 @@
   file_base = small_deform1
   csv = true
 []
-

--- a/modules/tensor_mechanics/tests/capped_weak_plane/small_deform11.i
+++ b/modules/tensor_mechanics/tests/capped_weak_plane/small_deform11.i
@@ -526,9 +526,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '4 4'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 4.0
+    shear_modulus = 4.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cto24.i
+++ b/modules/tensor_mechanics/tests/jacobian/cto24.i
@@ -68,10 +68,10 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
+    type = ComputeIsotropicElasticityTensor
     block = 0
-    fill_method = symmetric_isotropic
-    C_ijkl = '0.7 1'
+    lambda = 0.7
+    shear_modulus = 1.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cto25.i
+++ b/modules/tensor_mechanics/tests/jacobian/cto25.i
@@ -68,10 +68,10 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
+    type = ComputeIsotropicElasticityTensor
     block = 0
-    fill_method = symmetric_isotropic
-    C_ijkl = '0 1'
+    lambda = 0.0
+    shear_modulus = 1.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cto26.i
+++ b/modules/tensor_mechanics/tests/jacobian/cto26.i
@@ -78,10 +78,10 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
+    type = ComputeIsotropicElasticityTensor
     block = 0
-    fill_method = symmetric_isotropic
-    C_ijkl = '0.1 1'
+    lambda = 0.1
+    shear_modulus = 1.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cto27.i
+++ b/modules/tensor_mechanics/tests/jacobian/cto27.i
@@ -110,10 +110,10 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
+    type = ComputeIsotropicElasticityTensor
     block = 0
-    fill_method = symmetric_isotropic
-    C_ijkl = '0.1 1'
+    lambda = 0.1
+    shear_modulus = 1.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp01.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp01.i
@@ -78,9 +78,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp02.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp02.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp03.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp03.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp04.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp04.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp05.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp05.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp06.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp06.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp07.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp07.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp08.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp08.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '0 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 0.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp09.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp09.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp10.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp10.i
@@ -57,9 +57,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/cwp11.i
+++ b/modules/tensor_mechanics/tests/jacobian/cwp11.i
@@ -59,9 +59,9 @@
 
 [Materials]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/tests/jacobian/phe01.i
+++ b/modules/tensor_mechanics/tests/jacobian/phe01.i
@@ -72,9 +72,9 @@
     type = ComputePlasticHeatEnergy
   [../]
   [./elasticity_tensor]
-    type = ComputeElasticityTensor
-    fill_method = symmetric_isotropic
-    C_ijkl = '1 2'
+    type = ComputeIsotropicElasticityTensor
+    lambda = 1.0
+    shear_modulus = 2.0
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain


### PR DESCRIPTION
### Relevant Design Changes

The objective of this PR is to allow the standard isotropic stress calculators in tensor mechanics to handle the case when the elastic constants change during a simulations (e.g. as a function of temperature). To this end, we've added a new boolean material property, `elasticity_tensor_has_changed` to elasticity tensor classes which have variable isotropic elasticity constants.  Developers will be responsible for adding this `elasticity_tensor_has_changed` material property to new variable elasticity tensor classes.

The isotropic stress classes look for the `elasticity_tensor_has_changed` property with `getDefaultMaterialProperty`, and, if the boolean is true, these stress classes have been changed to calculate the old stress state as a function of the new elasticity tensor and the old strain.  The old variable elasticity tensor stress class has been deprecated.

This change does add a stateful rank-2 tensor `elastic_strain_old`; I'd appreciate advice on how to only add this material property if the elasticity tensor is changing.

### Test Cases
The existing varying isotropic elasticity tensor test files have been updated to use the regular `ComputeFiniteStrainElasticStress` class, and the deprecated class will remain with the `allow_deprecated_until` option for a month.

Refs #8616