### PR TITLE
Rank4 fill method specific to Young's modulus and Poisson's ratio

### DIFF
--- a/framework/include/utils/RankFourTensor.h
+++ b/framework/include/utils/RankFourTensor.h
@@ -64,6 +64,7 @@ public:
     symmetric21,
     general_isotropic,
     symmetric_isotropic,
+    symmetric_isotropic_E_nu,
     antisymmetric_isotropic,
     axisymmetric_rz,
     general,
@@ -238,19 +239,19 @@ protected:
   Real _vals[N4];
 
   /**
-  * fillSymmetricFromInputVector takes either 21 (all=true) or 9 (all=false) inputs to fill in
-  * the Rank-4 tensor with the appropriate crystal symmetries maintained. I.e., C_ijkl = C_klij,
-  * C_ijkl = C_ijlk, C_ijkl = C_jikl
-  * @param input If all==true then this is
-  *                C1111 C1122 C1133 C2222 C2233 C3333 C2323 C1313 C1212
-  *                In the isotropic case this is (la is first Lame constant, mu is second (shear)
-  * Lame constant)
-  *                la+2mu la la la+2mu la la+2mu mu mu mu
-  *              If all==false then this is
-  *                C1111 C1122 C1133 C1123 C1113 C1112 C2222 C2233 C2223 C2213 C2212 C3333 C3323
-  * C3313 C3312 C2323 C2313 C2312 C1313 C1312 C1212
-  * @param all Determines the compoinents passed in vis the input parameter
-  */
+   * fillSymmetricFromInputVector takes either 21 (all=true) or 9 (all=false) inputs to fill in
+   * the Rank-4 tensor with the appropriate crystal symmetries maintained. I.e., C_ijkl = C_klij,
+   * C_ijkl = C_ijlk, C_ijkl = C_jikl
+   * @param input If all==true then this is
+   *                C1111 C1122 C1133 C2222 C2233 C3333 C2323 C1313 C1212
+   *                In the isotropic case this is (la is first Lame constant, mu is second (shear)
+   * Lame constant)
+   *                la+2mu la la la+2mu la la+2mu mu mu mu
+   *              If all==false then this is
+   *                C1111 C1122 C1133 C1123 C1113 C1112 C2222 C2233 C2223 C2213 C2212 C3333 C3323
+   * C3313 C3312 C2323 C2313 C2312 C1313 C1312 C1212
+   * @param all Determines the compoinents passed in vis the input parameter
+   */
   void fillSymmetricFromInputVector(const std::vector<Real> & input, bool all);
 
   /**
@@ -282,11 +283,22 @@ protected:
   /**
    * fillSymmetricIsotropicFromInputVector takes 2 inputs to fill the
    * the symmetric Rank-4 tensor with the appropriate symmetries maintained.
-   * C_ijkl = la*de_ij*de_kl + mu*(de_ik*de_jl + de_il*de_jk)
-   * where la is the first Lame modulus, mu is the second (shear) Lame modulus,
-   * @param input this is la and mu in the above formula
+   * C_ijkl = lambda*de_ij*de_kl + mu*(de_ik*de_jl + de_il*de_jk)
+   * where lambda is the first Lame modulus, mu is the second (shear) Lame modulus,
+   * @param input this is lambda and mu in the above formula
    */
   void fillSymmetricIsotropicFromInputVector(const std::vector<Real> & input);
+
+  /**
+   * fillSymmetricIsotropicEandNuFromInputVector is a variation of the
+   * fillSymmetricIsotropicFromInputVector which takes as inputs the
+   * more commonly used Young's modulus (E) and Poissin's ratio (nu)
+   * constants to fill the isotropic elasticity tensor. Using well-known formulas,
+   * E and nu are used to calculate lambda and mu and then the vector is passed
+   * to fillSymmetricIsotropicFromInputVector.
+   * @param input Young's modulus (E) and Poisson's ratio (nu)
+   */
+  void fillSymmetricIsotropicEandNuFromInputVector(const std::vector<Real> & input);
 
   /**
    * fillGeneralFromInputVector takes 81 inputs to fill the Rank-4 tensor

--- a/framework/src/utils/RankFourTensor.C
+++ b/framework/src/utils/RankFourTensor.C
@@ -47,7 +47,8 @@ MooseEnum
 RankFourTensor::fillMethodEnum()
 {
   return MooseEnum("antisymmetric symmetric9 symmetric21 general_isotropic symmetric_isotropic "
-                   "antisymmetric_isotropic axisymmetric_rz general principal");
+                   "symmetric_isotropic_E_nu antisymmetric_isotropic axisymmetric_rz general "
+                   "principal");
 }
 
 RankFourTensor::RankFourTensor()
@@ -575,6 +576,9 @@ RankFourTensor::fillFromInputVector(const std::vector<Real> & input, FillMethod 
     case symmetric_isotropic:
       fillSymmetricIsotropicFromInputVector(input);
       break;
+    case symmetric_isotropic_E_nu:
+      fillSymmetricIsotropicEandNuFromInputVector(input);
+      break;
     case antisymmetric_isotropic:
       fillAntisymmetricIsotropicFromInputVector(input);
       break;
@@ -737,6 +741,23 @@ RankFourTensor::fillSymmetricIsotropicFromInputVector(const std::vector<Real> & 
                "has size ",
                input.size());
   fillGeneralIsotropicFromInputVector({input[0], input[1], 0.0});
+}
+
+void
+RankFourTensor::fillSymmetricIsotropicEandNuFromInputVector(const std::vector<Real> & input)
+{
+  if (input.size() != 2)
+    mooseError(
+        "To use fillSymmetricIsotropicEandNuFromInputVector, your input must have size 2. Yours "
+        "has size ",
+        input.size());
+
+  // Calculate lambda and the shear modulus from the given young's modulus and poisson's ratio
+  std::vector<Real> isotropic_constants(2);
+  isotropic_constants[0] = input[0] * input[1] / ((1.0 + input[1]) * (1.0 - 2.0 * input[1]));
+  isotropic_constants[1] = input[0] / (2.0 * (1.0 + input[1]));
+
+  fillGeneralIsotropicFromInputVector({isotropic_constants[0], isotropic_constants[1], 0.0});
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
@@ -54,18 +54,19 @@ ComputeIsotropicElasticityTensor::ComputeIsotropicElasticityTensor(
   if (_youngs_modulus_set && _youngs_modulus <= 0.0)
     mooseError("Youngs modulus must be positive in material '" + name() + "'.");
 
+  if (_youngs_modulus_set && _poissons_ratio_set)
+  {
+    _Cijkl.fillFromInputVector({_youngs_modulus, _poissons_ratio},
+                               RankFourTensor::symmetric_isotropic_E_nu);
+    return;
+  }
+
   std::vector<Real> iso_const(2);
 
   if (_lambda_set && _shear_modulus_set)
   {
     iso_const[0] = _lambda;
     iso_const[1] = _shear_modulus;
-  }
-  else if (_youngs_modulus_set && _poissons_ratio_set)
-  {
-    iso_const[0] = _youngs_modulus * _poissons_ratio /
-                   ((1.0 + _poissons_ratio) * (1.0 - 2.0 * _poissons_ratio));
-    iso_const[1] = _youngs_modulus / (2.0 * (1.0 + _poissons_ratio));
   }
   else if (_shear_modulus_set && _bulk_modulus_set)
   {

--- a/modules/tensor_mechanics/src/materials/ComputeVariableIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeVariableIsotropicElasticityTensor.C
@@ -95,15 +95,8 @@ ComputeVariableIsotropicElasticityTensor::initQpStatefulProperties()
 void
 ComputeVariableIsotropicElasticityTensor::computeQpElasticityTensor()
 {
-  // lambda
-  _isotropic_elastic_constants[0] =
-      _youngs_modulus[_qp] * _poissons_ratio[_qp] /
-      ((1.0 + _poissons_ratio[_qp]) * (1.0 - 2.0 * _poissons_ratio[_qp]));
-  // shear modulus
-  _isotropic_elastic_constants[1] = _youngs_modulus[_qp] / (2.0 * (1.0 + _poissons_ratio[_qp]));
-
-  _elasticity_tensor[_qp].fillFromInputVector(_isotropic_elastic_constants,
-                                              RankFourTensor::symmetric_isotropic);
+  _elasticity_tensor[_qp].fillFromInputVector({_youngs_modulus[_qp], _poissons_ratio[_qp]},
+                                              RankFourTensor::symmetric_isotropic_E_nu);
 
   // Define derivatives of the elasticity tensor
   for (unsigned int i = 0; i < _num_args; ++i)


### PR DESCRIPTION
### Design Information
This commit moves the common code for an isotropic elasticity tensor to calculate lambda and the shear modulus from the Young's modulus and Poisson's ratio from the individual material classes to the RankFourTensor utility class.

### Test Cases
The existing tests which use the variable elasticity tensor material class continue to match the existing gold files.

Closes #9442