### PR TITLE
Scalar scaling fix

### DIFF
--- a/framework/include/base/MooseVariableBase.h
+++ b/framework/include/base/MooseVariableBase.h
@@ -108,9 +108,11 @@ public:
   /**
    * The DofMap associated with the system this variable is in.
    */
-  const DofMap & dofMap() { return _dof_map; }
+  const DofMap & dofMap() const { return _dof_map; }
 
   std::vector<dof_id_type> & dofIndices() { return _dof_indices; }
+
+  const std::vector<dof_id_type> & dofIndices() const { return _dof_indices; }
 
   unsigned int numberOfDofs() { return _dof_indices.size(); }
 

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -116,6 +116,16 @@ MooseVariableScalar::isNodal() const
 void
 MooseVariableScalar::setValue(unsigned int i, Number value)
 {
+  // In debug modes, we might have set a "trap" to catch reads of
+  // uninitialized values, but this trap shouldn't prevent setting
+  // values.
+#ifdef DEBUG
+  if (i >= _u.size())
+  {
+    libmesh_assert_less (i, _dof_indices.size());
+    _u.resize(i+1);
+  }
+#endif
   _u[i] = value; // update variable value
 }
 
@@ -123,6 +133,12 @@ void
 MooseVariableScalar::setValues(Number value)
 {
   unsigned int n = _dof_indices.size();
+  // In debug modes, we might have set a "trap" to catch reads of
+  // uninitialized values, but this trap shouldn't prevent setting
+  // values.
+#ifdef DEBUG
+  _u.resize(n);
+#endif
   for (unsigned int i = 0; i < n; i++)
     _u[i] = value;
 }

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -78,29 +78,29 @@ MooseVariableScalar::reinit()
   }
   else
   {
-    for (std::size_t i=0; i != n; ++i)
+    for (std::size_t i = 0; i != n; ++i)
     {
       const dof_id_type dof_index = _dof_indices[i];
       std::vector<dof_id_type> one_dof_index(1, dof_index);
       if (_dof_map.all_semilocal_indices(one_dof_index))
-        {
-          libmesh_assert_less (i, _u.size());
+      {
+        libmesh_assert_less(i, _u.size());
 
-          current_solution.get(one_dof_index, &_u[i]);
-          solution_old.get(one_dof_index, &_u_old[i]);
-          solution_older.get(one_dof_index, &_u_older[i]);
-          u_dot.get(one_dof_index, &_u_dot[i]);
-        }
+        current_solution.get(one_dof_index, &_u[i]);
+        solution_old.get(one_dof_index, &_u_old[i]);
+        solution_older.get(one_dof_index, &_u_older[i]);
+        u_dot.get(one_dof_index, &_u_dot[i]);
+      }
 #ifdef DEBUG
       else
-        {
-          // Let's make it possible to catch invalid accesses to these
-          // variables, at least with libstdc++ in dbg mode.
-          _u.resize(i);
-          _u_old.resize(i);
-          _u_older.resize(i);
-          _u_dot.resize(i);
-        }
+      {
+        // Let's make it possible to catch invalid accesses to these
+        // variables, at least with libstdc++ in dbg mode.
+        _u.resize(i);
+        _u_old.resize(i);
+        _u_older.resize(i);
+        _u_dot.resize(i);
+      }
 #endif
     }
   }

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -105,10 +105,10 @@ MooseVariableScalar::reinit()
         // If we can't catch errors at run-time, we can at least
         // propagate NaN values rather than invalid values, so that
         // users won't trust the result.
-        _u[i]       = std::numeric_limits<Real>::quiet_NaN();
-        _u_old[i]   = std::numeric_limits<Real>::quiet_NaN();
+        _u[i] = std::numeric_limits<Real>::quiet_NaN();
+        _u_old[i] = std::numeric_limits<Real>::quiet_NaN();
         _u_older[i] = std::numeric_limits<Real>::quiet_NaN();
-        _u_dot[i]   = std::numeric_limits<Real>::quiet_NaN();
+        _u_dot[i] = std::numeric_limits<Real>::quiet_NaN();
 #endif
       }
     }

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -116,14 +116,14 @@ MooseVariableScalar::isNodal() const
 void
 MooseVariableScalar::setValue(unsigned int i, Number value)
 {
-  // In debug modes, we might have set a "trap" to catch reads of
-  // uninitialized values, but this trap shouldn't prevent setting
-  // values.
+// In debug modes, we might have set a "trap" to catch reads of
+// uninitialized values, but this trap shouldn't prevent setting
+// values.
 #ifdef DEBUG
   if (i >= _u.size())
   {
-    libmesh_assert_less (i, _dof_indices.size());
-    _u.resize(i+1);
+    libmesh_assert_less(i, _dof_indices.size());
+    _u.resize(i + 1);
   }
 #endif
   _u[i] = value; // update variable value
@@ -133,9 +133,9 @@ void
 MooseVariableScalar::setValues(Number value)
 {
   unsigned int n = _dof_indices.size();
-  // In debug modes, we might have set a "trap" to catch reads of
-  // uninitialized values, but this trap shouldn't prevent setting
-  // values.
+// In debug modes, we might have set a "trap" to catch reads of
+// uninitialized values, but this trap shouldn't prevent setting
+// values.
 #ifdef DEBUG
   _u.resize(n);
 #endif

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -23,7 +23,6 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/dof_map.h"
 
-// C++
 #include <limits>
 
 MooseVariableScalar::MooseVariableScalar(unsigned int var_num,

--- a/framework/src/base/MooseVariableScalar.C
+++ b/framework/src/base/MooseVariableScalar.C
@@ -91,17 +91,26 @@ MooseVariableScalar::reinit()
         solution_older.get(one_dof_index, &_u_older[i]);
         u_dot.get(one_dof_index, &_u_dot[i]);
       }
-#ifdef DEBUG
       else
       {
+#ifdef _GLIBCXX_DEBUG
         // Let's make it possible to catch invalid accesses to these
-        // variables, at least with libstdc++ in dbg mode.
+        // variables immediately via a thrown exception, if our
+        // libstdc++ compiler flags allow for that.
         _u.resize(i);
         _u_old.resize(i);
         _u_older.resize(i);
         _u_dot.resize(i);
-      }
+#else
+        // If we can't catch errors at run-time, we can at least
+        // propagate NaN values rather than invalid values, so that
+        // users won't trust the result.
+        _u[i]       = std::numeric_limits<Real>::quiet_NaN();
+        _u_old[i]   = std::numeric_limits<Real>::quiet_NaN();
+        _u_older[i] = std::numeric_limits<Real>::quiet_NaN();
+        _u_dot[i]   = std::numeric_limits<Real>::quiet_NaN();
 #endif
+      }
     }
   }
 }

--- a/framework/src/postprocessors/ScalarVariable.C
+++ b/framework/src/postprocessors/ScalarVariable.C
@@ -18,7 +18,6 @@
 #include "MooseVariableScalar.h"
 #include "SubProblem.h"
 
-// libMesh includes
 #include "libmesh/dof_map.h"
 
 template <>

--- a/framework/src/postprocessors/ScalarVariable.C
+++ b/framework/src/postprocessors/ScalarVariable.C
@@ -59,7 +59,7 @@ ScalarVariable::getValue()
   if (dof >= dof_map.first_dof() && dof < dof_map.end_dof())
     returnval = _var.sln()[_idx];
 
-  this->comm().min(returnval);
+  gatherMin(returnval);
 
   return returnval;
 }

--- a/framework/src/postprocessors/ScalarVariable.C
+++ b/framework/src/postprocessors/ScalarVariable.C
@@ -18,6 +18,9 @@
 #include "MooseVariableScalar.h"
 #include "SubProblem.h"
 
+// libMesh includes
+#include "libmesh/dof_map.h"
+
 template <>
 InputParameters
 validParams<ScalarVariable>()
@@ -49,5 +52,14 @@ Real
 ScalarVariable::getValue()
 {
   _var.reinit();
-  return _var.sln()[_idx];
+
+  Real returnval = std::numeric_limits<Real>::max();
+  const DofMap & dof_map = _var.dofMap();
+  const dof_id_type dof = _var.dofIndices()[_idx];
+  if (dof >= dof_map.first_dof() && dof < dof_map.end_dof())
+    returnval = _var.sln()[_idx];
+
+  this->comm().min(returnval);
+
+  return returnval;
 }


### PR DESCRIPTION
I believe this should fix #9450 if my understanding of the problem is correct.

The second commit here trips _GLIBCXX_DEBUG assertion failures on the perverse N_proc > N_elem + 1 case, verifying an attempt to access uninitialized data, and the third commit fixes that failure, so there's at least a little justification for my belief.

We should change that second commit to be more robust (NaNs in opt mode?) before merging this, but I'll wait for a bit of discussion on exactly how we should do so; for now I just want to make sure that Civet doesn't think I've broken anything else.