### PR TITLE
Convert to mooseWarning when a file lock fails.

### DIFF
--- a/framework/src/utils/LockFile.C
+++ b/framework/src/utils/LockFile.C
@@ -27,7 +27,7 @@ LockFile::LockFile(const std::string & filename, bool do_lock)
     if (_fd == -1)
       mooseError("Failed to open file", filename);
     if (flock(_fd, LOCK_EX) != 0)
-      mooseError("Failed to lock file ", filename);
+      mooseWarning("Failed to lock file ", filename);
   }
 }
 
@@ -36,7 +36,7 @@ LockFile::~LockFile()
   if (_do_lock)
   {
     if (flock(_fd, LOCK_UN) != 0)
-      mooseError("Failed to unlock file ", _filename);
+      mooseWarning("Failed to unlock file ", _filename);
     close(_fd);
   }
 }


### PR DESCRIPTION
If a file lock fails, that typically means that the underlying filesystem doesn't support locking.
We really don't need to abort execution if locking fails since the reason for locking is just to coordinate reading exodus files between MOOSE and peacock.

refs #9129