### PR TITLE
FluidProperties: implement correct analytical derivatives of viscosity wrt temperature

### DIFF
--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -106,6 +106,7 @@ public:
    * @param water_density water density (kg/m^3)
    * @param temperature brine temperature (K)
    * @param xnacl salt mass fraction (-)
+   * @param dwater_density_dT derivative of water density wrt temperature
    * @param[out] mu viscosity (Pa.s)
    * @param[out] dmu_drho derivative of viscosity wrt water density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
@@ -114,6 +115,7 @@ public:
   virtual void mu_drhoTx(Real water_density,
                          Real temperature,
                          Real xnacl,
+                         Real dwater_density_dT,
                          Real & mu,
                          Real & dmu_drho,
                          Real & dmu_dT,

--- a/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
@@ -79,12 +79,17 @@ public:
    *
    * @param density fluid density (kg/m^3)
    * @param temperature fluid temperature (K)
+   * @param ddensity_dT derivative of density wrt temperature
    * @param[out] mu viscosity (Pa.s)
    * @param[out] dmu_drho derivative of viscosity wrt density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    */
-  virtual void mu_drhoT(
-      Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  virtual void mu_drhoT(Real density,
+                        Real temperature,
+                        Real ddensity_dT,
+                        Real & mu,
+                        Real & dmu_drho,
+                        Real & dmu_dT) const override;
 
   /**
    * Fluid name

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
@@ -77,8 +77,12 @@ public:
   virtual Real mu(Real density, Real temperature) const override;
 
   /// Dynamic viscosity and its derivatives wrt density and temperature
-  virtual void mu_drhoT(
-      Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  virtual void mu_drhoT(Real density,
+                        Real temperature,
+                        Real ddensity_dT,
+                        Real & mu,
+                        Real & dmu_drho,
+                        Real & dmu_dT) const override;
 
   /// Specific enthalpy (J/kg)
   virtual Real h(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
@@ -171,8 +171,12 @@ public:
    * @param[out] dmu_drho derivative of viscosity wrt density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    */
-  virtual void mu_drhoT(
-      Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  virtual void mu_drhoT(Real density,
+                        Real temperature,
+                        Real ddensity_dT,
+                        Real & mu,
+                        Real & dmu_drho,
+                        Real & dmu_dT) const override;
 
   /**
    * Thermal conductivity as a function of density and temperature.

--- a/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
@@ -44,6 +44,7 @@ public:
   virtual void mu_drhoTx(Real density,
                          Real temperature,
                          Real xmass,
+                         Real ddensity_dT,
                          Real & mu,
                          Real & dmu_dp,
                          Real & dmu_dT,

--- a/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
@@ -175,8 +175,12 @@ public:
    * @param[out] dmu_drho derivative of viscosity wrt density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    */
-  virtual void mu_drhoT(
-      Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  virtual void mu_drhoT(Real density,
+                        Real temperature,
+                        Real ddensity_dT,
+                        Real & mu,
+                        Real & dmu_drho,
+                        Real & dmu_dT) const override;
 
   /**
    * Thermal conductivity

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -87,8 +87,12 @@ public:
   virtual Real mu(Real density, Real temperature) const override;
 
   /// Dynamic viscosity and its derivatives wrt density and temperature
-  virtual void mu_drhoT(
-      Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  virtual void mu_drhoT(Real density,
+                        Real temperature,
+                        Real ddensity_dT,
+                        Real & mu,
+                        Real & dmu_drho,
+                        Real & dmu_dT) const override;
 
   /// Specific enthalpy (J/kg)
   virtual Real h(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -59,8 +59,12 @@ public:
   /// Dynamic viscosity (Pa s)
   virtual Real mu(Real density, Real temperature) const = 0;
   /// Dynamic viscosity and its derivatives wrt density and temperature
-  virtual void
-  mu_drhoT(Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const = 0;
+  virtual void mu_drhoT(Real density,
+                        Real temperature,
+                        Real ddensity_dT,
+                        Real & mu,
+                        Real & dmu_drho,
+                        Real & dmu_dT) const = 0;
   /// Thermal conductivity (W/m/K)
   virtual Real k(Real density, Real temperature) const = 0;
   /// Specific entropy (J/kg/K)

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -123,8 +123,12 @@ public:
   /// Viscosity
   virtual Real mu(Real density, Real temperature) const override;
   /// Derivatives of viscosity wrt density and temperature
-  virtual void mu_drhoT(
-      Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  virtual void mu_drhoT(Real density,
+                        Real temperature,
+                        Real ddensity_dT,
+                        Real & mu,
+                        Real & dmu_drho,
+                        Real & dmu_dT) const override;
   /// Specific isobaric heat capacity
   virtual Real cp(Real pressure, Real temperature) const override;
   /// Specific isochoric heat capacity

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -190,12 +190,17 @@ public:
    *
    * @param density fluid density (kg/m^3)
    * @param temperature fluid temperature (K)
+   * @param ddensity_dT derivative of density wrt temperature
    * @param[out] mu viscosity (Pa.s)
    * @param[out] dmu_drho derivative of viscosity wrt density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    */
-  virtual void mu_drhoT(
-      Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  virtual void mu_drhoT(Real density,
+                        Real temperature,
+                        Real ddensity_dT,
+                        Real & mu,
+                        Real & dmu_drho,
+                        Real & dmu_dT) const override;
 
   /**
    * Thermal conductivity as a function of density and temperature

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
@@ -138,8 +138,12 @@ Real IdealGasFluidPropertiesPT::mu(Real /*density*/, Real /*temperature*/) const
 }
 
 void
-IdealGasFluidPropertiesPT::mu_drhoT(
-    Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const
+IdealGasFluidPropertiesPT::mu_drhoT(Real density,
+                                    Real temperature,
+                                    Real /*ddensity_dT*/,
+                                    Real & mu,
+                                    Real & dmu_drho,
+                                    Real & dmu_dT) const
 {
   mu = this->mu(density, temperature);
   dmu_drho = 0.0;

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -165,8 +165,12 @@ MethaneFluidProperties::mu(Real /*density*/, Real temperature) const
 }
 
 void
-MethaneFluidProperties::mu_drhoT(
-    Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const
+MethaneFluidProperties::mu_drhoT(Real density,
+                                 Real temperature,
+                                 Real /*ddensity_dT*/,
+                                 Real & mu,
+                                 Real & dmu_drho,
+                                 Real & dmu_dT) const
 {
   const std::vector<Real> a{
       2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11, -2.7237166e-14};

--- a/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
@@ -170,6 +170,7 @@ Real NaClFluidProperties::mu(Real /*density*/, Real /*temperature*/) const
 void
 NaClFluidProperties::mu_drhoT(Real /*density*/,
                               Real /*temperature*/,
+                              Real /*ddensity_dT*/,
                               Real & /*mu*/,
                               Real & /*dmu_drho*/,
                               Real & /*dmu_dT*/) const

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -146,8 +146,12 @@ SimpleFluidProperties::rho_e_dpT(Real pressure,
 Real SimpleFluidProperties::mu(Real /*density*/, Real /*temperature*/) const { return _viscosity; }
 
 void
-SimpleFluidProperties::mu_drhoT(
-    Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const
+SimpleFluidProperties::mu_drhoT(Real density,
+                                Real temperature,
+                                Real /*ddensity_dT*/,
+                                Real & mu,
+                                Real & dmu_drho,
+                                Real & dmu_dT) const
 {
   mu = this->mu(density, temperature);
   dmu_drho = 0.0;

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -279,10 +279,14 @@ TabulatedFluidProperties::mu(Real density, Real temperature) const
 }
 
 void
-TabulatedFluidProperties::mu_drhoT(
-    Real density, Real temperature, Real & mu, Real & dmu_drho, Real & dmu_dT) const
+TabulatedFluidProperties::mu_drhoT(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const
 {
-  _fp.mu_drhoT(density, temperature, mu, dmu_drho, dmu_dT);
+  _fp.mu_drhoT(density, temperature, ddensity_dT, mu, dmu_drho, dmu_dT);
 }
 
 Real

--- a/modules/porous_flow/src/materials/PorousFlowBrine.C
+++ b/modules/porous_flow/src/materials/PorousFlowBrine.C
@@ -126,7 +126,7 @@ PorousFlowBrine::computeQpProperties()
   // Viscosity calculation requires water density
   Real rhow, drhow_dp, drhow_dT;
   _water_fp->rho_dpT(_porepressure[_qp][_phase_num], Tk, rhow, drhow_dp, drhow_dT);
-  _brine_fp->mu_drhoTx(rhow, Tk, _xnacl[_qp], mu, dmu_drho, dmu_dT, dmu_dx);
+  _brine_fp->mu_drhoTx(rhow, Tk, _xnacl[_qp], drhow_dT, mu, dmu_drho, dmu_dT, dmu_dx);
   _viscosity[_qp] = mu;
   _dviscosity_dp[_qp] = dmu_drho * drhow_dp;
   _dviscosity_dT[_qp] = dmu_dT;

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateBrineCO2.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateBrineCO2.C
@@ -150,7 +150,8 @@ PorousFlowFluidStateBrineCO2::thermophysicalProperties()
     dgas_density_dz = 0.0;
 
     Real co2_viscosity, dco2_viscosity_drho, dco2_viscosity_dT;
-    _co2_fp.mu_drhoT(co2_density, Tk, co2_viscosity, dco2_viscosity_drho, dco2_viscosity_dT);
+    _co2_fp.mu_drhoT(
+        co2_density, Tk, dco2_density_dT, co2_viscosity, dco2_viscosity_drho, dco2_viscosity_dT);
 
     // Assume that the viscosity of the gas phase is a weighted sum of the
     // individual viscosities
@@ -228,6 +229,7 @@ PorousFlowFluidStateBrineCO2::thermophysicalProperties()
     _brine_fp.mu_drhoTx(water_density,
                         Tk,
                         xnacl,
+                        dwater_density_dT,
                         liquid_viscosity,
                         dliquid_viscosity_drho,
                         dliquid_viscosity_dT,

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateWaterNCG.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateWaterNCG.C
@@ -174,9 +174,14 @@ PorousFlowFluidStateWaterNCG::thermophysicalProperties()
 
     Real ncg_viscosity, dncg_viscosity_drho, dncg_viscosity_dT;
     Real vapor_viscosity, dvapor_viscosity_drho, dvapor_viscosity_dT;
-    _ncg_fp.mu_drhoT(ncg_density, Tk, ncg_viscosity, dncg_viscosity_drho, dncg_viscosity_dT);
-    _water_fp.mu_drhoT(
-        vapor_density, Tk, vapor_viscosity, dvapor_viscosity_drho, dvapor_viscosity_dT);
+    _ncg_fp.mu_drhoT(
+        ncg_density, Tk, dncg_density_dT, ncg_viscosity, dncg_viscosity_drho, dncg_viscosity_dT);
+    _water_fp.mu_drhoT(vapor_density,
+                       Tk,
+                       dvapor_density_dT,
+                       vapor_viscosity,
+                       dvapor_viscosity_drho,
+                       dvapor_viscosity_dT);
 
     // Assume that the viscosity of the gas phase is a weighted sum of the
     // individual viscosities
@@ -229,8 +234,12 @@ PorousFlowFluidStateWaterNCG::thermophysicalProperties()
     Real dliquid_viscosity_drho;
     _water_fp.rho_dpT(
         liquid_porepressure, Tk, liquid_density, dliquid_density_dp, dliquid_density_dT);
-    _water_fp.mu_drhoT(
-        liquid_density, Tk, liquid_viscosity, dliquid_viscosity_drho, dliquid_viscosity_dT);
+    _water_fp.mu_drhoT(liquid_density,
+                       Tk,
+                       dliquid_density_dT,
+                       liquid_viscosity,
+                       dliquid_viscosity_drho,
+                       dliquid_viscosity_dT);
 
     // The derivative of viscosity wrt pressure is given by the chain rule
     dliquid_viscosity_dp = dliquid_viscosity_drho * dliquid_density_dp;

--- a/modules/porous_flow/src/materials/PorousFlowSingleComponentFluid.C
+++ b/modules/porous_flow/src/materials/PorousFlowSingleComponentFluid.C
@@ -151,7 +151,7 @@ PorousFlowSingleComponentFluid::computeQpProperties()
     // Viscosity and derivatives wrt pressure and temperature at the nodes.
     // Note that dmu_dp = dmu_drho * drho_dp
     Real mu, dmu_drho, dmu_dT;
-    _fp.mu_drhoT(rho, Tk, mu, dmu_drho, dmu_dT);
+    _fp.mu_drhoT(rho, Tk, drho_dT, mu, dmu_drho, dmu_dT);
     (*_viscosity)[_qp] = mu;
     (*_dviscosity_dp)[_qp] = dmu_drho * drho_dp;
     (*_dviscosity_dT)[_qp] = dmu_dT;

--- a/unit/src/CO2FluidPropertiesTest.C
+++ b/unit/src/CO2FluidPropertiesTest.C
@@ -209,14 +209,23 @@ TEST_F(CO2FluidPropertiesTest, derivatives)
   rho = 15.105;
   T = 360.0;
   Real drho = 1.0e-4;
+  _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
 
   Real dmu_drho_fd = (_fp->mu(rho + drho, T) - _fp->mu(rho - drho, T)) / (2.0 * drho);
-  Real dmu_dT_fd = (_fp->mu(rho, T + dT) - _fp->mu(rho, T - dT)) / (2.0 * dT);
   Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0;
-  _fp->mu_drhoT(rho, T, mu, dmu_drho, dmu_dT);
+  _fp->mu_drhoT(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
   ABS_TEST("mu", mu, _fp->mu(rho, T), 1.0e-15);
   REL_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-6);
+
+  // To properly test derivative wrt temperature, use p and T and calculate density,
+  // so that the change in density wrt temperature is included
+  p = 1.0e6;
+  _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
+  _fp->mu_drhoT(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
+  Real dmu_dT_fd =
+      (_fp->mu(_fp->rho(p, T + dT), T + dT) - _fp->mu(_fp->rho(p, T - dT), T - dT)) / (2.0 * dT);
+
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
 
   // Henry's constant

--- a/unit/src/MethaneFluidPropertiesTest.C
+++ b/unit/src/MethaneFluidPropertiesTest.C
@@ -100,7 +100,7 @@ TEST_F(MethaneFluidPropertiesTest, derivatives)
   Real dmu_drho_fd = (_fp->mu(rho + drho, T) - _fp->mu(rho - drho, T)) / (2.0 * drho);
   Real dmu_dT_fd = (_fp->mu(rho, T + dT) - _fp->mu(rho, T - dT)) / (2.0 * dT);
   Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0;
-  _fp->mu_drhoT(rho, T, mu, dmu_drho, dmu_dT);
+  _fp->mu_drhoT(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
   ABS_TEST("mu", mu, _fp->mu(rho, T), 1.0e-15);
   ABS_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-15);

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -113,7 +113,7 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   Real mu, dmu_drho, dmu_dT;
   dens = 1000;
   T = 10;
-  _fp->mu_drhoT(dens, T, mu, dmu_drho, dmu_dT);
+  _fp->mu_drhoT(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
   fd = (_fp->mu(dens + ddens, T) - _fp->mu(dens - ddens, T)) / (2.0 * ddens);
   ABS_TEST("dmu_ddens", dmu_drho, fd, 1.0E-8);
   fd = (_fp->mu(dens, T + dT) - _fp->mu(dens, T - dT)) / (2.0 * dT);
@@ -121,7 +121,7 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
 
   dens = 2000;
   T = 80;
-  _fp->mu_drhoT(dens, T, mu, dmu_drho, dmu_dT);
+  _fp->mu_drhoT(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
   fd = (_fp->mu(dens + ddens, T) - _fp->mu(dens - ddens, T)) / (2.0 * ddens);
   ABS_TEST("dmu_ddens", dmu_drho, fd, 1.0E-8);
   fd = (_fp->mu(dens, T + dT) - _fp->mu(dens, T - dT)) / (2.0 * dT);

--- a/unit/src/Water97FluidPropertiesTest.C
+++ b/unit/src/Water97FluidPropertiesTest.C
@@ -495,17 +495,25 @@ TEST_F(Water97FluidPropertiesTest, derivatives)
   regionDerivatives(p, T, 1.0e-6);
 
   // Viscosity
-  Real rho = 998.0;
+  Real rho = 998.0, drho_dp = 0.0, drho_dT = 0.0;
   T = 298.15;
   Real drho = 1.0e-4;
-  dT = 1.0e-4;
 
   Real dmu_drho_fd = (_fp->mu(rho + drho, T) - _fp->mu(rho - drho, T)) / (2.0 * drho);
-  Real dmu_dT_fd = (_fp->mu(rho, T + dT) - _fp->mu(rho, T - dT)) / (2.0 * dT);
   Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0;
-  _fp->mu_drhoT(rho, T, mu, dmu_drho, dmu_dT);
+  _fp->mu_drhoT(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
   ABS_TEST("mu", mu, _fp->mu(rho, T), 1.0e-15);
   REL_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-6);
+
+  // To properly test derivative wrt temperature, use p and T and calculate density,
+  // so that the change in density wrt temperature is included
+  p = 1.0e6;
+  dT = 1.0e-4;
+  _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
+  _fp->mu_drhoT(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
+  Real dmu_dT_fd =
+      (_fp->mu(_fp->rho(p, T + dT), T + dT) - _fp->mu(_fp->rho(p, T - dT), T - dT)) / (2.0 * dT);
+
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
 }


### PR DESCRIPTION
Remove the approximate finite difference derivatives in water, brine and CO2 fluid properties, and replace them with analytical versions that include the temperature dependence of fluid density.

This required passing an additional argument (derivative of fluid density wrt temperature), but this would always be calculated if the derivatives of viscosity are required, so no big deal.

Also updates the `porous_flow` materials that are used to provide material properties, and update the unit tests so that they correctly test the derivative of fluid viscosity wrt temperature, including the effect of temperature on the fluid density.

Closes #9469 