### PR TITLE
Only run csv_transient.i in serial, regardless

### DIFF
--- a/test/tests/outputs/csv/tests
+++ b/test/tests/outputs/csv/tests
@@ -30,6 +30,7 @@
     exodiff = 'csv_transient_out.e'
     cli_args = 'Outputs/csv=false Outputs/exodus=true'
     prereq = transient
+    max_parallel = 1
   [../]
   [./restart_part1]
     # First part of CSV restart test, CSV files should not append


### PR DESCRIPTION
I missed this modified SumNodalValuesAux test run when I was preparing
PR #9433, but we also need to disable it if we want the workaround for
the bug in #9026 to be complete.

Once this and #9451 are safely merged, I believe we'll have every
ReplicatedMesh test working on arbitrary numbers of processors, at
which point we should crank up the CI processor counts as I suggested
in #9430 to ensure that fact never changes.