### PR TITLE
Refactor Tensor Mechanics Guarantees

### DIFF
--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTensor.h
@@ -17,16 +17,11 @@ class ComputeElasticityTensor : public ComputeRotatedElasticityTensorBase
 public:
   ComputeElasticityTensor(const InputParameters & parameters);
 
-  virtual bool isGuaranteedIsotropic() const override;
-
 protected:
   virtual void computeQpElasticityTensor() override;
 
   /// Individual material information
   RankFourTensor _Cijkl;
-
-private:
-  bool _is_isotropic;
 };
 
 #endif // COMPUTEELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTensorBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTensorBase.h
@@ -10,17 +10,16 @@
 #include "DerivativeMaterialInterface.h"
 #include "Material.h"
 #include "RankFourTensor.h"
+#include "GuaranteeProvider.h"
 
 /**
  * ComputeElasticityTensorBase the base class for computing elasticity tensors
  */
-class ComputeElasticityTensorBase : public DerivativeMaterialInterface<Material>
+class ComputeElasticityTensorBase : public DerivativeMaterialInterface<Material>,
+                                    public GuaranteeProvider
 {
 public:
   ComputeElasticityTensorBase(const InputParameters & parameters);
-
-  /// is the elasticity tensor provided by this material guaranteed to be isotropic
-  virtual bool isGuaranteedIsotropic() const { return false; }
 
 protected:
   virtual void computeQpProperties();

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
@@ -8,12 +8,13 @@
 #define COMPUTEFINITESTRAINELASTICSTRESS_H
 
 #include "ComputeStressBase.h"
+#include "GuaranteeConsumer.h"
 
 /**
  * ComputeFiniteStrainElasticStress computes the stress following elasticity
  * theory for finite strains
  */
-class ComputeFiniteStrainElasticStress : public ComputeStressBase
+class ComputeFiniteStrainElasticStress : public ComputeStressBase, public GuaranteeConsumer
 {
 public:
   ComputeFiniteStrainElasticStress(const InputParameters & parameters);

--- a/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
@@ -18,8 +18,6 @@ class ComputeIsotropicElasticityTensor : public ComputeElasticityTensorBase
 public:
   ComputeIsotropicElasticityTensor(const InputParameters & parameters);
 
-  virtual bool isGuaranteedIsotropic() const override { return true; }
-
 protected:
   virtual void computeQpElasticityTensor() override;
 

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -141,6 +141,9 @@ protected:
    * inside of the yield surface in an iteration.
    */
   std::vector<StressUpdateBase *> _models;
+
+  /// is the elasticity tensor guaranteed to be isotropic?
+  bool _is_elasticity_tensor_guaranteed_isotropic;
 };
 
 #endif // COMPUTEMULTIPLEINELASTICSTRESS_H

--- a/modules/tensor_mechanics/include/materials/ComputeStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStressBase.h
@@ -26,9 +26,6 @@ protected:
   virtual void computeQpProperties() override;
   virtual void computeQpStress() = 0;
 
-  /// check if all materials responsible for providing the elasticity tensor guarantee an isotropic tensor
-  bool isElasticityTensorGuaranteedIsotropic();
-
   const std::string _base_name;
   const std::string _elasticity_tensor_name;
 
@@ -49,17 +46,6 @@ protected:
 
   /// Parameter which decides whether to store old stress. This is required for HHT time integration and Rayleigh damping
   const bool _store_stress_old;
-
-private:
-  enum class OptionalBool
-  {
-    VALUE_UNDEFINED = -1,
-    VALUE_FALSE = 0,
-    VALUE_TRUE = 1
-  };
-
-  /// store
-  OptionalBool _elasticity_tensor_isotropic_guarantee;
 };
 
 #endif // COMPUTESTRESSBASE_H

--- a/modules/tensor_mechanics/include/materials/ComputeVariableIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeVariableIsotropicElasticityTensor.h
@@ -19,8 +19,6 @@ class ComputeVariableIsotropicElasticityTensor : public ComputeElasticityTensorB
 public:
   ComputeVariableIsotropicElasticityTensor(const InputParameters & parameters);
 
-  virtual bool isGuaranteedIsotropic() const override { return true; }
-
 protected:
   virtual void initialSetup() override;
   virtual void initQpStatefulProperties() override;

--- a/modules/tensor_mechanics/include/utils/Guarantee.h
+++ b/modules/tensor_mechanics/include/utils/Guarantee.h
@@ -1,0 +1,22 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef GUARANTEE_H
+#define GUARANTEE_H
+
+/**
+ * Enum values for guarantees that can be demanded for material properties.
+ * New items can be added to this list as new guarantees become necessary.
+ */
+enum class Guarantee
+{
+  ISOTROPIC,        // applicable to RankTwo and RankFour tensors that are always isotropic
+  CONSTANT_IN_TIME, // applicable to material properties that do not change over time
+  UNIFORM_IN_SPACE  // applicable to material properties that have constant values in space
+};
+
+#endif // GUARANTEE_H

--- a/modules/tensor_mechanics/include/utils/GuaranteeConsumer.h
+++ b/modules/tensor_mechanics/include/utils/GuaranteeConsumer.h
@@ -1,0 +1,43 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef GUARANTEECONSUMER_H
+#define GUARANTEECONSUMER_H
+
+#include "Guarantee.h"
+#include "MooseTypes.h"
+
+class MooseObject;
+class FEProblemBase;
+class InputParameters;
+class BlockRestrictable;
+
+/**
+ * Add-on class that provides the functionality to check if guarantees for
+ * material properties are provided. The types of guarantees are listed in
+ * Guarantees.h
+ */
+class GuaranteeConsumer
+{
+public:
+  GuaranteeConsumer(MooseObject * moose_object);
+
+protected:
+  bool hasGuaranteedMaterialProperty(const MaterialPropertyName & prop, Guarantee guarantee);
+
+private:
+  /// Parameters of the object with this interface
+  const InputParameters & _gc_params;
+
+  /// Reference to the FEProblemBase class
+  FEProblemBase * const _gc_feproblem;
+
+  /// Access block restrictions of the object with this interface
+  BlockRestrictable * const _gc_block_restrict;
+};
+
+#endif // GUARANTEECONSUMER_H

--- a/modules/tensor_mechanics/include/utils/GuaranteeProvider.h
+++ b/modules/tensor_mechanics/include/utils/GuaranteeProvider.h
@@ -1,0 +1,38 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef GUARANTEEPROVIDER_H
+#define GUARANTEEPROVIDER_H
+
+// STL includes
+#include <map>
+
+// MOOSE includes
+#include "MooseTypes.h"
+#include "Guarantee.h"
+
+class MooseObject;
+
+/**
+ * Add-on class that provides the functionality to issue guarantees for
+ * declared material properties. The types of guarantees are listed in Guarantees.h
+ */
+class GuaranteeProvider
+{
+public:
+  GuaranteeProvider(const MooseObject * moose_object);
+
+  bool hasGuarantee(const MaterialPropertyName & prop_name, Guarantee guarantee);
+
+protected:
+  void issueGuarantee(const MaterialPropertyName & prop_name, Guarantee guarantee);
+
+private:
+  std::map<MaterialPropertyName, std::set<Guarantee>> _guarantees;
+};
+
+#endif // GUARANTEEPROVIDER_H

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTensor.C
@@ -22,10 +22,11 @@ validParams<ComputeElasticityTensor>()
 ComputeElasticityTensor::ComputeElasticityTensor(const InputParameters & parameters)
   : ComputeRotatedElasticityTensorBase(parameters),
     _Cijkl(getParam<std::vector<Real>>("C_ijkl"),
-           (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method")),
-    _is_isotropic(_Cijkl.isIsotropic())
+           (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method"))
 {
-  if (!_is_isotropic)
+  if (_Cijkl.isIsotropic())
+    issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);
+  else
   {
     // Define a rotation according to Euler angle parameters
     RotationTensor R(_Euler_angles); // R type: RealTensorValue
@@ -40,10 +41,4 @@ ComputeElasticityTensor::computeQpElasticityTensor()
 {
   // Assign elasticity tensor at a given quad point
   _elasticity_tensor[_qp] = _Cijkl;
-}
-
-bool
-ComputeElasticityTensor::isGuaranteedIsotropic() const
-{
-  return _is_isotropic;
 }

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTensorBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTensorBase.C
@@ -25,6 +25,7 @@ validParams<ComputeElasticityTensorBase>()
 
 ComputeElasticityTensorBase::ComputeElasticityTensorBase(const InputParameters & parameters)
   : DerivativeMaterialInterface<Material>(parameters),
+    GuaranteeProvider(this),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _elasticity_tensor_name(_base_name + "elasticity_tensor"),
     _elasticity_tensor(declareProperty<RankFourTensor>(_elasticity_tensor_name)),

--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrainElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrainElasticStress.C
@@ -18,6 +18,7 @@ validParams<ComputeFiniteStrainElasticStress>()
 ComputeFiniteStrainElasticStress::ComputeFiniteStrainElasticStress(
     const InputParameters & parameters)
   : ComputeStressBase(parameters),
+    GuaranteeConsumer(this),
     _strain_increment(getMaterialPropertyByName<RankTwoTensor>(_base_name + "strain_increment")),
     _rotation_increment(
         getMaterialPropertyByName<RankTwoTensor>(_base_name + "rotation_increment")),
@@ -28,7 +29,7 @@ ComputeFiniteStrainElasticStress::ComputeFiniteStrainElasticStress(
 void
 ComputeFiniteStrainElasticStress::initialSetup()
 {
-  if (!isElasticityTensorGuaranteedIsotropic())
+  if (!hasGuaranteedMaterialProperty(_elasticity_tensor_name, Guarantee::ISOTROPIC))
     mooseError("ComputeFiniteStrainElasticStress can only be used with elasticity tensor materials "
                "that guarantee isotropic tensors.");
 }

--- a/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
@@ -37,6 +37,9 @@ ComputeIsotropicElasticityTensor::ComputeIsotropicElasticityTensor(
   unsigned int num_elastic_constants = _bulk_modulus_set + _lambda_set + _poissons_ratio_set +
                                        _shear_modulus_set + _youngs_modulus_set;
 
+  // all tensors created by this class are always isotropic
+  issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);
+
   if (num_elastic_constants != 2)
     mooseError("Exactly two elastic constants must be defined for material '" + name() + "'.");
 

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -106,6 +106,8 @@ ComputeMultipleInelasticStress::initQpStatefulProperties()
 void
 ComputeMultipleInelasticStress::initialSetup()
 {
+  _is_elasticity_tensor_guaranteed_isotropic =
+      hasGuaranteedMaterialProperty(_elasticity_tensor_name, Guarantee::ISOTROPIC);
   std::vector<MaterialName> models = getParam<std::vector<MaterialName>>("inelastic_models");
   for (unsigned int i = 0; i < _num_models; ++i)
   {
@@ -113,7 +115,7 @@ ComputeMultipleInelasticStress::initialSetup()
     if (rrr)
     {
       _models.push_back(rrr);
-      if (rrr->requiresIsotropicTensor() && !isElasticityTensorGuaranteedIsotropic())
+      if (rrr->requiresIsotropicTensor() && !_is_elasticity_tensor_guaranteed_isotropic)
         mooseError("Model " + models[i] + " requires an isotropic elasticity tensor, but the one "
                                           "supplied is not guaranteed isotropic");
     }
@@ -155,7 +157,7 @@ ComputeMultipleInelasticStress::computeQpStress()
     _stress[_qp] = _rotation_increment[_qp] * _stress[_qp] * _rotation_increment[_qp].transpose();
     _inelastic_strain[_qp] =
         _rotation_increment[_qp] * _inelastic_strain[_qp] * _rotation_increment[_qp].transpose();
-    if (!(isElasticityTensorGuaranteedIsotropic() &&
+    if (!(_is_elasticity_tensor_guaranteed_isotropic &&
           (_tangent_operator_type == TangentOperatorEnum::elastic || _num_models == 0)))
       _Jacobian_mult[_qp].rotate(_rotation_increment[_qp]);
   }

--- a/modules/tensor_mechanics/src/materials/ComputeVariableIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeVariableIsotropicElasticityTensor.C
@@ -37,6 +37,9 @@ ComputeVariableIsotropicElasticityTensor::ComputeVariableIsotropicElasticityTens
     _d2elasticity_tensor(_num_args),
     _isotropic_elastic_constants(2)
 {
+  // all tensors created by this class are always isotropic
+  issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);
+
   // fetch prerequisite derivatives and build elasticity tensor derivatives and cross-derivatives
   for (unsigned int i = 0; i < _num_args; ++i)
   {

--- a/modules/tensor_mechanics/src/utils/GuaranteeConsumer.C
+++ b/modules/tensor_mechanics/src/utils/GuaranteeConsumer.C
@@ -1,0 +1,65 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "GuaranteeConsumer.h"
+#include "GuaranteeProvider.h"
+
+#include "MooseObject.h"
+#include "Material.h"
+#include "MooseMesh.h"
+#include "FEProblemBase.h"
+#include "InputParameters.h"
+#include "BlockRestrictable.h"
+
+GuaranteeConsumer::GuaranteeConsumer(MooseObject * moose_object)
+  : _gc_params(moose_object->parameters()),
+    _gc_feproblem(_gc_params.get<FEProblemBase *>("_fe_problem_base")),
+    _gc_block_restrict(dynamic_cast<BlockRestrictable *>(moose_object))
+{
+}
+
+bool
+GuaranteeConsumer::hasGuaranteedMaterialProperty(const MaterialPropertyName & prop_name,
+                                                 Guarantee guarantee)
+{
+  if (!_gc_feproblem->startedInitialSetup())
+    mooseError("hasGuaranteedMaterialProperty() needs to be called in initialSetup()");
+
+  // Reference to MaterialWarehouse for testing and retrieving block ids
+  const auto & warehouse = _gc_feproblem->getMaterialWarehouse();
+
+  // Complete set of ids that this object is active
+  const auto & ids = (_gc_block_restrict && _gc_block_restrict->blockRestricted())
+                         ? _gc_block_restrict->blockIDs()
+                         : _gc_feproblem->mesh().meshSubdomains();
+
+  // Loop over each id for this object
+  for (const auto & id : ids)
+  {
+    // If block materials exist, look if any issue the required guarantee
+    if (warehouse.hasActiveBlockObjects(id))
+    {
+      const std::vector<std::shared_ptr<Material>> & mats = warehouse.getActiveBlockObjects(id);
+      for (const auto & mat : mats)
+      {
+        const auto & mat_props = mat->getSuppliedItems();
+        if (mat_props.count(prop_name))
+        {
+          auto guarantee_mat = dynamic_cast<GuaranteeProvider *>(mat.get());
+          if (guarantee_mat && !guarantee_mat->hasGuarantee(prop_name, guarantee))
+          {
+            // we found at least one material on the set of block we operate on
+            // that does _not_ provide the requested guarantee
+            return false;
+          }
+        }
+      }
+    }
+  }
+
+  return true;
+}

--- a/modules/tensor_mechanics/src/utils/GuaranteeProvider.C
+++ b/modules/tensor_mechanics/src/utils/GuaranteeProvider.C
@@ -1,0 +1,29 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "GuaranteeProvider.h"
+#include "MooseObject.h"
+
+GuaranteeProvider::GuaranteeProvider(const MooseObject * /*moose_object*/) {}
+
+bool
+GuaranteeProvider::hasGuarantee(const MaterialPropertyName & prop_name, Guarantee guarantee)
+{
+  auto it = _guarantees.find(prop_name);
+  if (it == _guarantees.end())
+    return false;
+
+  auto it2 = it->second.find(guarantee);
+  return it2 != it->second.end();
+}
+
+void
+GuaranteeProvider::issueGuarantee(const MaterialPropertyName & prop_name, Guarantee guarantee)
+{
+  // intentional insertion
+  _guarantees[prop_name].insert(guarantee);
+}


### PR DESCRIPTION
This adds one enum class and two new classes that can be inherited from in addition to the MOOSE base classes

* `Guarantee` is an `enum class` that contains the set of valid guarantees. This can be expanded as necessary.
* `GuaranteeProvider` can be added to Material classes and provides the `void issueGuarantee(MaterialPropertyName, Guarantee)` function that add guarantee metadata to a material property declared by the class.
* `GuaranteeConsumer` can be added to Materials and kernels and provides the `bool hasGuaranteedMaterialProperty(MaterialPropertyName, Guarantee)` method that checks if all materials on each block that provide a given material property issue the required guarantee.

Closes #8881 (because this as close as we will ever get this)