### PR TITLE
Increase multiapp test solver tolerance

### DIFF
--- a/test/tests/transfers/multiapp_variable_value_sample_transfer/master_quad.i
+++ b/test/tests/transfers/multiapp_variable_value_sample_transfer/master_quad.i
@@ -67,6 +67,7 @@
   solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]

--- a/test/tests/transfers/multiapp_variable_value_sample_transfer/quad_sub.i
+++ b/test/tests/transfers/multiapp_variable_value_sample_transfer/quad_sub.i
@@ -54,6 +54,7 @@
   solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]


### PR DESCRIPTION
This fixes the parallel exodiff test failure I reported in #9430 -
instead of seeing sporadic failures with as few as 5 processors, I now
see tests pass with 1 through 24.