### PR TITLE
Tighten multiapp test solver tolerance

### DIFF
--- a/test/tests/controls/time_periods/transfers/master.i
+++ b/test/tests/controls/time_periods/transfers/master.i
@@ -50,6 +50,8 @@
   solve_type = 'PJFNK'
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]

--- a/test/tests/controls/time_periods/transfers/sub.i
+++ b/test/tests/controls/time_periods/transfers/sub.i
@@ -61,6 +61,8 @@
 
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]

--- a/test/tests/transfers/multiapp_postprocessor_to_scalar/master2.i
+++ b/test/tests/transfers/multiapp_postprocessor_to_scalar/master2.i
@@ -73,6 +73,8 @@
   solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]

--- a/test/tests/transfers/multiapp_postprocessor_to_scalar/sub2.i
+++ b/test/tests/transfers/multiapp_postprocessor_to_scalar/sub2.i
@@ -53,6 +53,8 @@
   solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]

--- a/test/tests/transfers/multiapp_postprocessor_transfer/master.i
+++ b/test/tests/transfers/multiapp_postprocessor_transfer/master.i
@@ -53,6 +53,8 @@
 
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]

--- a/test/tests/transfers/multiapp_postprocessor_transfer/sub.i
+++ b/test/tests/transfers/multiapp_postprocessor_transfer/sub.i
@@ -53,6 +53,8 @@
 
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]


### PR DESCRIPTION
This fixes another #1500 regression; previously --distributed-mesh runs of this test would fail on 12 processors for me, but now they work through at least 24.