### PR TITLE
Add ability to turn on/off test objects

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -181,6 +181,9 @@ validParams<MooseApp>()
                                    "Disabled performance logging. Overrides -t or --timing "
                                    "if passed in conjunction with this flag");
 
+  params.addCommandLineParam<bool>(
+      "allow_test_objects", "--allow-test-objects", false, "Register test objects and syntax.");
+
   // Options ignored by MOOSE but picked up by libMesh, these are here so that they are displayed in
   // the application help
   params.addCommandLineParam<bool>(

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -38,7 +38,9 @@ CommandLine::addCommandLineOptionsFromParams(InputParameters & params)
     std::string orig_name = it.first;
 
     cli_opt.description = params.getDocString(orig_name);
-    syntax = params.getSyntax(orig_name);
+    if (!params.isPrivate(orig_name))
+      // If a param is private then it shouldn't have any command line syntax.
+      syntax = params.getSyntax(orig_name);
     cli_opt.cli_syntax = syntax;
     cli_opt.required = false;
     InputParameters::Parameter<bool> * bool_type =
@@ -136,7 +138,7 @@ CommandLine::search(const std::string & option_name)
     }
   }
   else
-    mooseError("Unrecognized option name");
+    mooseError("Unrecognized option name: ", option_name);
 
   return false;
 }

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -282,16 +282,27 @@ InputParameters
 validParams<MooseTestApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  /* MooseTestApp is special because it will have its own
+   * binary and we want the default to allow test objects.
+   */
+  params.addCommandLineParam<bool>(
+      "disallow_test_objects",
+      "--disallow-test-objects",
+      false,
+      "Don't register test objects and syntax. This overrides --allow-test-objects");
   return params;
 }
 
 MooseTestApp::MooseTestApp(const InputParameters & parameters) : MooseApp(parameters)
 {
+  bool use_test_objs = !getParam<bool>("disallow_test_objects");
   Moose::registerObjects(_factory);
-  MooseTestApp::registerObjects(_factory);
+  if (use_test_objs)
+    MooseTestApp::registerObjects(_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
-  MooseTestApp::associateSyntax(_syntax, _action_factory);
+  if (use_test_objs)
+    MooseTestApp::associateSyntax(_syntax, _action_factory);
 }
 
 MooseTestApp::~MooseTestApp() {}

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -285,11 +285,11 @@ validParams<MooseTestApp>()
   /* MooseTestApp is special because it will have its own
    * binary and we want the default to allow test objects.
    */
-  params.addCommandLineParam<bool>(
-      "disallow_test_objects",
-      "--disallow-test-objects",
-      false,
-      "Don't register test objects and syntax. This overrides --allow-test-objects");
+  params.suppressParameter<bool>("allow_test_objects");
+  params.addCommandLineParam<bool>("disallow_test_objects",
+                                   "--disallow-test-objects",
+                                   false,
+                                   "Don't register test objects and syntax");
   return params;
 }
 

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -66,14 +66,7 @@ class TestJSON(unittest.TestCase):
         data = json.loads(output)
         return data
 
-    def testJson(self):
-        """
-        Some basic checks to see if some data
-        is there and is in the right location.
-        """
-        all_data = self.getJsonData()
-        self.assertIn("active", all_data["global"]["parameters"])
-        data = all_data["blocks"]
+    def check_basic_json(self, data):
         self.assertIn("Executioner", data)
         self.assertIn("BCs", data)
         bcs = data["BCs"]
@@ -110,6 +103,26 @@ class TestJSON(unittest.TestCase):
         i = a["subblocks"]["Indicators"]["star"]["subblock_types"]["AnalyticalIndicator"]
         self.assertIn("all", i["parameters"]["outputs"]["reserved_values"])
         self.assertIn("none", i["parameters"]["outputs"]["reserved_values"])
+
+    def testJson(self):
+        """
+        Some basic checks to see if some data
+        is there and is in the right location.
+        """
+        all_data = self.getJsonData()
+        self.assertIn("active", all_data["global"]["parameters"])
+        data = all_data["blocks"]
+        self.check_basic_json(data)
+        # Make sure the default dump has test objects
+        self.assertIn("ApplyInputParametersTest", data)
+
+    def testNoTestObjects(self):
+        # Make sure test objects are removed from the output
+        all_data = self.getJsonData(["--disallow-test-objects"])
+        self.assertIn("active", all_data["global"]["parameters"])
+        data = all_data["blocks"]
+        self.check_basic_json(data)
+        self.assertNotIn("ApplyInputParametersTest", data)
 
     def testJsonSearch(self):
         """
@@ -177,6 +190,9 @@ class TestJSON(unittest.TestCase):
         # the comments got split and there is a unmatched " on a line of the comment.
         # This breaks the parser and it doesn't read in all the parameters.
         # self.assertIn("petsc_options", split.params_list)
+
+        # Make sure the default dump has test objects
+        self.assertIn("ApplyInputParametersTest", root.children)
 
     def testInputFileFormatSearch(self):
         """


### PR DESCRIPTION
This is a pretty simple PR to start to enable #7347 and to start a discussion on the best way to do
things.

It just adds a `--allow-test-objects` command line option to `MooseApp`, so the default would be to not allow test objects.

It is up to individual apps to query this flag and conditionally register objects.

Using something like `registerTestKernel` was not deemed a good idea.
We can't easily auto register test objects by filename since we don't have filename information when we register objects.

I made `MooseTestApp` default to allowing test objects for backward compatibility. I did add an option so that you can turn off test objects in the `moose_test-$METHOD` binary.

For individual tests, adding `--allow-test-objects` to `cli_args` in the `tests` file would allow that test to use test objects. We could add a more user friendly option in the TestHarness, if desired.

This is completely separate from the other objectives in #7347  ie separation of test objects into their own directory,  separate library/exe for the test objects, etc.
