### PR TITLE
Set MOOSE_DIR if the user doesn't have it

### DIFF
--- a/python/MooseDocs/common/moose_docs_file_tree.py
+++ b/python/MooseDocs/common/moose_docs_file_tree.py
@@ -74,6 +74,12 @@ def moose_docs_file_tree(config):
         config[dict]: Contains key value pairs, with each value containing another dict() with
                       key value pairs that are passed to moose_docs_import function.
     """
+
+    # Set the MOOSE_DIR if it does not exists so that the root_dir can always use it
+    if 'MOOSE_DIR' not in os.environ:
+        os.environ['MOOSE_DIR'] = MooseDocs.MOOSE_DIR
+
+    # Build the file tree
     node = DirectoryNode('')
     for value in config.itervalues():
         value.setdefault('include', [])


### PR DESCRIPTION
(closes #9502)

@sapitts Once this is merged we can change your content.yml file to use $MOOSE_DIR and it should work for both types of workflows: submodule and side-by-side directories, without actually setting MOOSE_DIR in your environment.