### PR TITLE
Fix AssignElementSubdomainID on distributed meshes

### DIFF
--- a/framework/src/meshmodifiers/AssignElementSubdomainID.C
+++ b/framework/src/meshmodifiers/AssignElementSubdomainID.C
@@ -51,7 +51,15 @@ AssignElementSubdomainID::modify()
     for (const auto & dof : elemids)
     {
       Elem * elem = mesh.query_elem_ptr(dof);
-      if (!elem)
+      bool has_elem = elem;
+
+      // If no processor sees this element, something must be wrong
+      // with the specified ID.  If another processor sees this
+      // element but we don't, we'll insert NULL into our elements
+      // vector anyway so as to keep the indexing matching our bids
+      // vector.
+      this->comm().max(has_elem);
+      if (!has_elem)
         mooseError("invalid element ID is in element_ids");
       else
         elements.push_back(elem);
@@ -60,17 +68,45 @@ AssignElementSubdomainID::modify()
   else
   {
     bool has_warned_remapping = false;
-    MeshBase::const_element_iterator el = mesh.elements_begin();
-    const MeshBase::const_element_iterator end_el = mesh.elements_end();
-    for (dof_id_type e = 0; el != end_el; ++el, ++e)
+
+    // On a distributed mesh, iterating over all elements in
+    // increasing order is tricky.  We have to consider element ids
+    // which aren't on a particular processor because they're remote,
+    // *and* elements which aren't on a particular processor because
+    // there's a hole in the current numbering.
+    //
+    // I don't see how to do this without a ton of communication,
+    // which is hopefully okay because it only happens at mesh setup,
+    // and because nobody who is here trying to use
+    // AssignElementSubdomainID to hand write every single element's
+    // subdomain ID will have a huge number of elements on their
+    // initial mesh.
+
+    // Using plain max_elem_id() currently gives the same result on
+    // every processor, but that isn't guaranteed by the libMesh
+    // documentation, so let's be paranoid.
+    dof_id_type end_id = mesh.max_elem_id();
+    this->comm().max(end_id);
+
+    for (dof_id_type e = 0; e != end_id; ++e)
     {
-      Elem * elem = *el;
-      if (elem->id() != e && (!has_warned_remapping))
+      // This is O(1) on ReplicatedMesh but O(log(N_elem)) on
+      // DistributedMesh.  We can switch to more complicated but
+      // asymptotically faster code if my "nobody who is here ... will
+      // have a huge number of elements" claim turns out to be false.
+      Elem * elem = mesh.query_elem_ptr(e);
+      bool someone_has_elem = elem;
+      if (!mesh.is_replicated())
+        this->comm().max(someone_has_elem);
+
+      if (elem && elem->id() != e && (!has_warned_remapping))
       {
         mooseWarning("AssignElementSubdomainID will ignore the element remapping");
         has_warned_remapping = true;
       }
-      elements.push_back(elem);
+
+      if (someone_has_elem)
+        elements.push_back(elem);
     }
   }
 
@@ -82,7 +118,12 @@ AssignElementSubdomainID::modify()
   std::map<ElemType, std::set<SubdomainID>> type2blocks;
   for (dof_id_type e = 0; e < elements.size(); ++e)
   {
+    // Get the element we need to assign, or skip it if we just have a
+    // nullptr placeholder indicating a remote element.
     Elem * elem = elements[e];
+    if (!elem)
+      continue;
+
     ElemType type = elem->type();
     SubdomainID newid = bids[e];
 

--- a/test/tests/mesh_modifiers/assign_element_subdomain_id/quad_with_subdomainid_test.i
+++ b/test/tests/mesh_modifiers/assign_element_subdomain_id/quad_with_subdomainid_test.i
@@ -7,9 +7,6 @@
   zmin = 0
   zmax = 0
   elem_type = QUAD4
-  # AssignElementSubdomainID only works with ReplicatedMesh and/or
-  # with element_ids set.
-  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/assign_element_subdomain_id/tri_with_subdomainid_test.i
+++ b/test/tests/mesh_modifiers/assign_element_subdomain_id/tri_with_subdomainid_test.i
@@ -7,9 +7,6 @@
   zmin = 0
   zmax = 0
   elem_type = TRI3
-  # AssignElementSubdomainID only works with ReplicatedMesh and/or
-  # with element_ids set.
-  parallel_type = replicated
 []
 
 [MeshModifiers]

--- a/test/tests/mesh_modifiers/sidesets_between_subdomains/sidesets_between_vectors_of_subdomains.i
+++ b/test/tests/mesh_modifiers/sidesets_between_subdomains/sidesets_between_vectors_of_subdomains.i
@@ -7,9 +7,6 @@
   zmin = 0
   zmax = 0
   elem_type = QUAD4
-  # AssignElementSubdomainID only works with ReplicatedMesh and/or
-  # with element_ids set.
-  parallel_type = replicated
 []
 
 [MeshModifiers]


### PR DESCRIPTION
This corrects another #1500 regression for me:
mesh_modifiers/assign_element_subdomain_id.quad_elementid_test
previously failed on 5 processors with --distributed-mesh, and now
works on 1 through 24 processors.

The algorithm here is awful.  I *feel* like we ought to be able to do
this in the distributed case in O(N_elem/N_proc), like most
DistributedMesh operations, but I can't figure out exactly how.  The
code for replicated meshes here is O(N_elem), just as fast as before,
but the DistributedMesh code path is now O(N_elem log(N_elem)), plus
another O(N_elem) term with an ugly constant in front if the mesh is
actually distributed.

If that shows up in anybody's profiling then open an issue and we can
at least shave it down to O(N_elem) at the cost of code legibility.