### PR TITLE
Add revokeGuarante, add constant in time to ComputeElasticityTensor

### DIFF
--- a/modules/tensor_mechanics/include/utils/GuaranteeProvider.h
+++ b/modules/tensor_mechanics/include/utils/GuaranteeProvider.h
@@ -30,6 +30,7 @@ public:
 
 protected:
   void issueGuarantee(const MaterialPropertyName & prop_name, Guarantee guarantee);
+  void revokeGuarantee(const MaterialPropertyName & prop_name, Guarantee guarantee);
 
 private:
   std::map<MaterialPropertyName, std::set<Guarantee>> _guarantees;

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTensor.C
@@ -24,6 +24,9 @@ ComputeElasticityTensor::ComputeElasticityTensor(const InputParameters & paramet
     _Cijkl(getParam<std::vector<Real>>("C_ijkl"),
            (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method"))
 {
+  // all tensors created by this class are always constant in time
+  issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
+
   if (_Cijkl.isIsotropic())
     issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);
   else

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTensorCP.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTensorCP.C
@@ -29,6 +29,9 @@ ComputeElasticityTensorCP::ComputeElasticityTensorCP(const InputParameters & par
     _crysrot(declareProperty<RankTwoTensor>("crysrot")),
     _R(_Euler_angles)
 {
+  // the base class guarantees constant in time, but in this derived class the
+  // tensor will rotate over time once plastic deformation sets in
+  revokeGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
@@ -39,10 +39,8 @@ ComputeIsotropicElasticityTensor::ComputeIsotropicElasticityTensor(
   if (num_elastic_constants != 2)
     mooseError("Exactly two elastic constants must be defined for material '" + name() + "'.");
 
-  // all tensors created by this class are always isotropic
+  // all tensors created by this class are always isotropic and constant in time
   issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);
-
-  // all tensors created by this class are always constant in time
   issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
 
   if (_bulk_modulus_set && _bulk_modulus <= 0.0)

--- a/modules/tensor_mechanics/src/utils/GuaranteeProvider.C
+++ b/modules/tensor_mechanics/src/utils/GuaranteeProvider.C
@@ -27,3 +27,11 @@ GuaranteeProvider::issueGuarantee(const MaterialPropertyName & prop_name, Guaran
   // intentional insertion
   _guarantees[prop_name].insert(guarantee);
 }
+
+void
+GuaranteeProvider::revokeGuarantee(const MaterialPropertyName & prop_name, Guarantee guarantee)
+{
+  auto it = _guarantees.find(prop_name);
+  if (it != _guarantees.end())
+    it->second.erase(guarantee);
+}


### PR DESCRIPTION
This fixes the broken Falcon test. We can guarantee that tensors created by `ComputeElasticityTensor` are constant in time. However, the derived class `ComputeElasticityTensorCP` can rotate over time. I had to add a `revokeGuarantee` method to `GuaranteeProvider` to take back guarantees given in parent classes.

Refs #8881