### PR TITLE
use_old_floor in exodiff of restart_elem_var tests

### DIFF
--- a/test/tests/restart/restart/tests
+++ b/test/tests/restart/restart/tests
@@ -45,11 +45,15 @@
     type = 'Exodiff'
     input = 'elem_part1.i'
     exodiff = 'elem_part1_out.e'
+    use_old_floor = true
+    abs_zero = 1e-09
   [../]
   [./elem_var_2]
     type = 'Exodiff'
     input = 'elem_part2.i'
     exodiff = 'elem_part2_out.e'
+    use_old_floor = true
+    abs_zero = 1e-09
     max_parallel = 1
     prereq = 'elem_var_1'
   [../]


### PR DESCRIPTION
This appears to be another instance of the false-positives bug
described in #9414, and it triggers what might be the last bug (though
don't bet on it; I still have to see if any more have been
introduced during the past few months...) in DistributedMesh tests as
in #1500.

Previously, I would get an error in --distributed-mesh runs on only a
handful of processors, when exodiff complained that 1.5e-10 wasn't
*nearly* the same as -1e12, as if that was a thing we should be upset
by.  After this change, I can run these two tests out to 24 processors
with no failures.