### PR TITLE
Loosen rel_tol on xfem.pressure_bc.2d_pressure_displaced_mesh

### DIFF
--- a/modules/xfem/tests/pressure_bc/2d_pressure_displaced_mesh.i
+++ b/modules/xfem/tests/pressure_bc/2d_pressure_displaced_mesh.i
@@ -158,7 +158,7 @@
 
 # controls for nonlinear iterations
   nl_max_its = 15
-  nl_rel_tol = 1e-12
+  nl_rel_tol = 1e-10
   nl_abs_tol = 1e-14
 
 # time control


### PR DESCRIPTION
The Clang target on master seems to fail intermittently on this test. For example, https://www.moosebuild.org/job/101742/

I could reproduce the issue and loosening the tolerance a bit allowed it to pass without having to regold.

@bwspenc 