### PR TITLE
Remove an extra  matrix evaluation for nonlinear eigenvalue problems 

### DIFF
--- a/framework/include/base/EigenProblem.h
+++ b/framework/include/base/EigenProblem.h
@@ -42,6 +42,7 @@ public:
 
   virtual unsigned int getNEigenPairsRequired() { return _n_eigen_pairs_required; }
   virtual bool isGeneralizedEigenvalueProblem() { return _generalized_eigenvalue_problem; }
+  virtual bool isNonlinearEigenvalueSolver();
 
   // silences warning in debug mode about the other computeJacobian signature being hidden
   using FEProblemBase::computeJacobian;

--- a/framework/src/base/EigenProblem.C
+++ b/framework/src/base/EigenProblem.C
@@ -162,3 +162,12 @@ EigenProblem::converged()
 {
   return _nl_eigen->converged();
 }
+
+bool
+EigenProblem::isNonlinearEigenvalueSolver()
+{
+  return solverParams()._eigen_solve_type == Moose::EST_NONLINEAR_POWER ||
+         solverParams()._eigen_solve_type == Moose::EST_MF_NONLINEAR_POWER ||
+         solverParams()._eigen_solve_type == Moose::EST_MONOLITH_NEWTON ||
+         solverParams()._eigen_solve_type == Moose::EST_MF_MONOLITH_NEWTON;
+}


### PR DESCRIPTION
For linear problems, it is unnecessary to attach the compute Jacobian and residual
callbacks.

For nonlinear problems, we should not assembly the matrix at the beginning of solve.
The Jacobian matrix and the residual are assembled by the callbacks.

Refs #7398

