### PR TITLE
GlobalParams shouldn't have inactive parameter

### DIFF
--- a/framework/src/actions/GlobalParamsAction.C
+++ b/framework/src/actions/GlobalParamsAction.C
@@ -23,6 +23,7 @@ validParams<GlobalParamsAction>()
 
   /* GlobalParams should not have children or other standard public Action attributes */
   params.addPrivateParam<std::vector<std::string>>("active", blocks);
+  params.addPrivateParam<std::vector<std::string>>("inactive", blocks);
   return params;
 }
 


### PR DESCRIPTION
 #9508 introduced the `inactive` parameter. This should not be allowed on `GlobalParams`, similar to the `active` parameter.