### PR TITLE
Remove space in parameter name.

### DIFF
--- a/modules/phase_field/src/materials/MixedSwitchingFunctionMaterial.C
+++ b/modules/phase_field/src/materials/MixedSwitchingFunctionMaterial.C
@@ -16,7 +16,7 @@ validParams<MixedSwitchingFunctionMaterial>()
   MooseEnum h_order("MIX234=0 MIX246", "MIX234");
   params.addParam<MooseEnum>(
       "h_order", h_order, "Polynomial order of the switching function h(eta)");
-  params.set<std::string>("function_n ame") = std::string("h");
+  params.set<std::string>("function_name") = std::string("h");
 
   params.addRangeCheckedParam<Real>(
       "weight", 1.0, "weight <= 1 & weight >= 0", "Weight parameter for MIX type h(eta)");


### PR DESCRIPTION
This was introduced in #9116 
@brandonlangley noticed this in his validation

Why do we even allow spaces in parameter names?