### PR TITLE
Add a check for valid parameter names.

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -676,6 +676,9 @@ private:
    */
   void allowCopy(bool status) { _allow_copy = status; }
 
+  /// Make sure the parameter name doesn't have any invalid characters.
+  void checkParamName(const std::string & name) const;
+
   /// This method is called when adding a Parameter with a default value, can be specialized for non-matching types
   template <typename T, typename S>
   void setParamHelper(const std::string & name, T & l_value, const S & r_value);
@@ -763,6 +766,7 @@ template <typename T>
 T &
 InputParameters::set(const std::string & name, bool quiet_mode)
 {
+  checkParamName(name);
   checkConsistentType<T>(name);
 
   if (!this->have_parameter<T>(name))
@@ -948,6 +952,7 @@ template <typename T>
 void
 InputParameters::addRequiredParam(const std::string & name, const std::string & doc_string)
 {
+  checkParamName(name);
   checkConsistentType<T>(name);
 
   InputParameters::insert<T>(name);
@@ -969,6 +974,7 @@ template <typename T, typename S>
 void
 InputParameters::addParam(const std::string & name, const S & value, const std::string & doc_string)
 {
+  checkParamName(name);
   checkConsistentType<T>(name);
 
   T & l_value = InputParameters::set<T>(name);
@@ -987,6 +993,7 @@ template <typename T>
 void
 InputParameters::addParam(const std::string & name, const std::string & doc_string)
 {
+  checkParamName(name);
   checkConsistentType<T>(name);
 
   InputParameters::insert<T>(name);
@@ -1066,6 +1073,7 @@ template <typename T>
 void
 InputParameters::addPrivateParam(const std::string & name)
 {
+  checkParamName(name);
   checkConsistentType<T>(name);
 
   InputParameters::insert<T>(name);
@@ -1076,6 +1084,7 @@ template <typename T>
 void
 InputParameters::addPrivateParam(const std::string & name, const T & value)
 {
+  checkParamName(name);
   checkConsistentType<T>(name);
 
   InputParameters::set<T>(name) = value;

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -991,7 +991,7 @@ InputParameters::reservedValues(const std::string & name) const
 void
 InputParameters::checkParamName(const std::string & name) const
 {
-  const static pcrecpp::RE valid("\\w+");
+  const static pcrecpp::RE valid("[\\w:/]+");
   if (!valid.FullMatch(name))
     mooseError("Invalid parameter name: '", name, "'");
 }

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -20,6 +20,8 @@
 #include "MooseUtils.h"
 #include "MultiMooseEnum.h"
 
+#include "pcrecpp.h"
+
 #include <cmath>
 
 InputParameters
@@ -984,4 +986,12 @@ InputParameters::reservedValues(const std::string & name) const
     return std::set<std::string>();
   else
     return it->second;
+}
+
+void
+InputParameters::checkParamName(const std::string & name) const
+{
+  const static pcrecpp::RE valid("\\w+");
+  if (!valid.FullMatch(name))
+    mooseError("Invalid parameter name: '", name, "'");
 }

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -132,3 +132,28 @@ TEST(InputParameters, checkSetDocStringError)
         << "failed with unexpected error: " << msg;
   }
 }
+
+void
+testBadParamName(const std::string & name)
+{
+  try
+  {
+    InputParameters params = emptyInputParameters();
+    params.addParam<bool>(name, "Doc");
+    FAIL() << "failed to error on attempt to set invalid parameter name";
+  }
+  catch (const std::exception & e)
+  {
+    std::string msg(e.what());
+    ASSERT_TRUE(msg.find("Invalid parameter name") != std::string::npos)
+        << "failed with unexpected error: " << msg;
+  }
+}
+
+/// Just make sure we don't allow invalid parameter names
+TEST(InputParameters, checkParamName)
+{
+  testBadParamName("p 0");
+  testBadParamName("p-0");
+  testBadParamName("p!0");
+}

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -145,7 +145,7 @@ testBadParamName(const std::string & name)
   catch (const std::exception & e)
   {
     std::string msg(e.what());
-    ASSERT_TRUE(msg.find("Invalid parameter name") != std::string::npos)
+    EXPECT_TRUE(msg.find("Invalid parameter name") != std::string::npos)
         << "failed with unexpected error: " << msg;
   }
 }


### PR DESCRIPTION
This just checks that a parameter name consists of characters `[a-zA-Z0-9_]`.

This does not enforce @rwcarlsen suggestion in #9546 to not allow digits at the start of a parameter name. There was at least one existing parameter, "2d", that would need to be changed if we did that.

closes #9546
