### PR TITLE
More exodiff robustness

### DIFF
--- a/test/include/materials/ThrowMaterial.h
+++ b/test/include/materials/ThrowMaterial.h
@@ -33,6 +33,9 @@ public:
 protected:
   virtual void computeQpProperties() override;
 
+  /// Keeps _has_thrown synchronized between processors
+  virtual void residualSetup() override;
+
   /// The MaterialProperty value we are responsible for computing
   MaterialProperty<Real> & _prop_value;
 

--- a/test/src/materials/ThrowMaterial.C
+++ b/test/src/materials/ThrowMaterial.C
@@ -34,6 +34,12 @@ ThrowMaterial::ThrowMaterial(const InputParameters & parameters)
 }
 
 void
+ThrowMaterial::residualSetup()
+{
+  this->comm().max(_has_thrown);
+}
+
+void
 ThrowMaterial::computeQpProperties()
 {
   // 1 + current value squared

--- a/test/tests/auxkernels/constant_scalar_aux/tests
+++ b/test/tests/auxkernels/constant_scalar_aux/tests
@@ -3,5 +3,7 @@
     type = 'Exodiff'
     input = 'constant_scalar_aux.i'
     exodiff = 'constant_scalar_aux_out.e'
+    use_old_floor = true
+    abs_zero = 1e-9
   [../]
 []

--- a/test/tests/auxkernels/function_scalar_aux/tests
+++ b/test/tests/auxkernels/function_scalar_aux/tests
@@ -3,5 +3,7 @@
     type = 'Exodiff'
     input = 'function_scalar_aux.i'
     exodiff = 'function_scalar_aux_out.e'
+    use_old_floor = true
+    abs_zero = 1e-9
   [../]
 []

--- a/test/tests/auxkernels/grad_component/tests
+++ b/test/tests/auxkernels/grad_component/tests
@@ -4,5 +4,6 @@
     input = 'grad_component.i'
     exodiff = 'grad_component_out.e'
     use_old_floor = true
+    abs_zero = 1e-09
   [../]
 []

--- a/test/tests/auxkernels/grad_component/tests
+++ b/test/tests/auxkernels/grad_component/tests
@@ -3,5 +3,6 @@
     type = 'Exodiff'
     input = 'grad_component.i'
     exodiff = 'grad_component_out.e'
+    use_old_floor = true
   [../]
 []

--- a/test/tests/bcs/periodic/tests
+++ b/test/tests/bcs/periodic/tests
@@ -43,6 +43,7 @@
     type = 'Exodiff'
     input = 'orthogonal_pbc_on_square.i'
     exodiff = 'orthogonal_pbc_on_square_out.e'
+    use_old_floor = true
     group = 'periodic'
   [../]
 

--- a/test/tests/executioners/eigen_executioners/tests
+++ b/test/tests/executioners/eigen_executioners/tests
@@ -7,6 +7,7 @@
     rel_err = 5e-05
     recover = false
     allow_warnings = true
+    use_old_floor = true
   [../]
   [./test_nonlinear_eigen]
     type = 'Exodiff'

--- a/test/tests/executioners/eigen_executioners/tests
+++ b/test/tests/executioners/eigen_executioners/tests
@@ -3,7 +3,7 @@
     type = 'Exodiff'
     input = 'ipm.i'
     exodiff = 'ipm.e'
-    abs_zero = 1e-09
+    abs_zero = 2e-09
     rel_err = 5e-05
     recover = false
     allow_warnings = true

--- a/test/tests/misc/exception/tests
+++ b/test/tests/misc/exception/tests
@@ -18,6 +18,7 @@
     petsc_version = '>=3.6.0'
     cli_args = 'Kernels/exception/rank=1'
     exodiff = 'parallel_exception_residual_transient_out.e'
+    use_old_floor = true
     prereq = 'parallel_exception_residual_transient'
     min_parallel = 2
   [../]
@@ -39,6 +40,7 @@
     petsc_version = '>=3.6.0'
     cli_args = 'Kernels/exception/rank=1'
     exodiff = 'parallel_exception_jacobian_transient_out.e'
+    use_old_floor = true
     prereq = 'parallel_exception_jacobian_transient'
     min_parallel = 2
   [../]

--- a/test/tests/misc/exception/tests
+++ b/test/tests/misc/exception/tests
@@ -9,6 +9,7 @@
     input = 'parallel_exception_residual_transient.i'
     petsc_version = '>=3.6.0'
     exodiff = 'parallel_exception_residual_transient_out.e'
+    use_old_floor = true
   [../]
 
   [./parallel_exception_residual_transient_non_zero_rank]
@@ -29,6 +30,7 @@
     input = 'parallel_exception_jacobian_transient.i'
     petsc_version = '>=3.6.0'
     exodiff = 'parallel_exception_jacobian_transient_out.e'
+    use_old_floor = true
   [../]
 
   [./parallel_exception_jacobian_transient_non_zero_rank]

--- a/test/tests/multiapps/multilevel/tests
+++ b/test/tests/multiapps/multilevel/tests
@@ -9,6 +9,7 @@
     input = 'time_dt_from_master_master.i'
     exodiff = 'time_dt_from_master_master_out.e time_dt_from_master_master_out_sub0.e time_dt_from_master_master_out_sub0_sub0.e time_dt_from_master_master_out_sub0_sub1.e time_dt_from_master_master_out_sub1.e time_dt_from_master_master_out_sub1_sub0.e time_dt_from_master_master_out_sub1_sub1.e'
     abs_zero = 5e-7
+    use_old_floor = true
   [../]
   [./dt_from_sub]
     type = 'Exodiff'

--- a/test/tests/time_integrators/implicit-euler/tests
+++ b/test/tests/time_integrators/implicit-euler/tests
@@ -4,6 +4,8 @@
     input = 'ie.i'
     exodiff = 'ie_out.e'
     group = 'requirements'
+    use_old_floor = true
+    abs_zero = 1e-9
   [../]
 
   [./adapt]

--- a/test/tests/utils/spline_interpolation/bicubic_spline_interpolation.cmp
+++ b/test/tests/utils/spline_interpolation/bicubic_spline_interpolation.cmp
@@ -24,7 +24,7 @@ COORDINATES absolute 1.e-6    # min separation not calculated
 
 TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:               1 @ t2
 
-GLOBAL VARIABLES relative 1.e-6 floor 4e-9
+GLOBAL VARIABLES relative 1.e-6 floor 1e-8
 	nodal_l2_err_analytic  # min:   2.2922372e-12 @ t2	max:       402.80268 @ t1
 	nodal_l2_err_spline    # min:   2.2921862e-12 @ t2	max:       402.80268 @ t1
 

--- a/test/tests/utils/spline_interpolation/bicubic_spline_interpolation.cmp
+++ b/test/tests/utils/spline_interpolation/bicubic_spline_interpolation.cmp
@@ -24,7 +24,7 @@ COORDINATES absolute 1.e-6    # min separation not calculated
 
 TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:               1 @ t2
 
-GLOBAL VARIABLES relative 1.e-6 floor 2e-9
+GLOBAL VARIABLES relative 1.e-6 floor 4e-9
 	nodal_l2_err_analytic  # min:   2.2922372e-12 @ t2	max:       402.80268 @ t1
 	nodal_l2_err_spline    # min:   2.2921862e-12 @ t2	max:       402.80268 @ t1
 


### PR DESCRIPTION
A swath of #9414 case fixes.  These are intended to correct some of the regressions @brianmoose is uncovering in his tests on #9430.  Since we're getting different FP behavior from system to system, I can't swear that all of these are sufficient, but they fix some errors at higher processor counts for me so they're a good start.