### PR TITLE
Don't try to set a local dof if we have none

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -197,9 +197,10 @@ NonlinearSystem::stopSolve()
   // Insert a NaN into the residual vector.  As of PETSc-3.6, this
   // should make PETSc return DIVERGED_NANORINF the next time it does
   // a reduction.  We'll write to the first local dof on every
-  // processor I guess?
-  _transient_sys.rhs->set(_transient_sys.rhs->first_local_index(),
-                          std::numeric_limits<Real>::quiet_NaN());
+  // processor that has any dofs.
+  if (_transient_sys.rhs->local_size())
+    _transient_sys.rhs->set(_transient_sys.rhs->first_local_index(),
+                            std::numeric_limits<Real>::quiet_NaN());
   _transient_sys.rhs->close();
 
   // Clean up by getting other vectors into a valid state for a


### PR DESCRIPTION
This can come up in real use cases (the coarsest mesh of some drastic
AMR), but mostly it's to fix the bug that @brianmoose just caught in
misc/exception.parallel_exception_* on 16 processors in #9430.