### PR TITLE
Add a TestHarness check for objects in the executable.

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -79,6 +79,7 @@ class TestHarness:
         self.checks = {}
         self.checks['platform'] = getPlatforms()
         self.checks['submodules'] = getInitializedSubmodules(self.run_tests_dir)
+        self.checks['exe_objects'] = None # This gets calculated on demand
 
         # The TestHarness doesn't strictly require the existence of libMesh in order to run. Here we allow the user
         # to select whether they want to probe for libMesh configuration options.

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -54,6 +54,7 @@ class Tester(MooseObject):
         params.addParam('env_vars',      [], "A test that only runs if all the environment variables listed exist")
         params.addParam('should_execute', True, 'Whether or not the executable needs to be run.  Use this to chain together multiple tests based off of one executeable invocation')
         params.addParam('required_submodule', [], "A list of initialized submodules for which this test requires.")
+        params.addParam('required_objects', [], "A list of required objects that are in the executable.")
         params.addParam('check_input',    False, "Check for correct input file syntax")
         params.addParam('display_required', False, "The test requires and active display for rendering (i.e., ImageDiff tests).")
         params.addParam('boost',         ['ALL'], "A test that runs only if BOOT is detected ('ALL', 'TRUE', 'FALSE')")
@@ -331,6 +332,16 @@ class Tester(MooseObject):
         for file in self.specs['depend_files']:
             if not os.path.isfile(os.path.join(self.specs['base_dir'], file)):
                 reasons['depend_files'] = 'DEPEND FILES'
+
+        # We calculate the exe_objects only if we need them
+        if self.specs["required_objects"] and checks["exe_objects"] is None:
+            checks["exe_objects"] = util.getExeObjects(self.specs["executable"])
+
+        # Check to see if we have the required object names
+        for var in self.specs['required_objects']:
+            if var not in checks["exe_objects"]:
+                reasons['required_objects'] = '%s not found in executable' % var
+                break
 
         # Check to make sure required submodules are initialized
         for var in self.specs['required_submodule']:

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import subprocess
+import re
 
 class TestHarnessTestCase(unittest.TestCase):
     """
@@ -10,3 +11,16 @@ class TestHarnessTestCase(unittest.TestCase):
     def runTests(self, *args):
         cmd = ['./run_tests'] + list(args)
         return subprocess.check_output(cmd, cwd=os.path.join(os.getenv('MOOSE_DIR'), 'test'))
+
+    def checkStatus(self, output, passed=0, skipped=0, pending=0, failed=0):
+        """
+        Make sure the TestHarness status line reports the correct counts.
+        """
+        # We need to be sure to match any of the terminal codes in the line
+        status_re = r'(?P<passed>\d+) passed.*, .*(?P<skipped>\d+) skipped.*, .*(?P<pending>\d+) pending.*, .*(?P<failed>\d+) failed'
+        match = re.search(status_re, output)
+        self.assertNotEqual(match, None)
+        self.assertEqual(match.group("passed"), str(passed))
+        self.assertEqual(match.group("failed"), str(failed))
+        self.assertEqual(match.group("skipped"), str(skipped))
+        self.assertEqual(match.group("pending"), str(pending))

--- a/python/TestHarness/tests/test_RequiredObjects.py
+++ b/python/TestHarness/tests/test_RequiredObjects.py
@@ -1,0 +1,11 @@
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testRequiredObjects(self):
+        """
+        Test that the required_objects check works
+        """
+        output = self.runTests('-i', 'required_objects')
+        self.assertRegexpMatches(output, r'test_harness\.bad_object.*?skipped \(DoesNotExist not found in executable\)')
+        self.assertRegexpMatches(output, r'test_harness\.good_objects.*?OK')
+        self.checkStatus(output, passed=1, skipped=1)

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -59,4 +59,8 @@
     type = PythonUnitTest
     input = test_Syntax.py
   [../]
+  [./required_objects]
+    type = PythonUnitTest
+    input = test_RequiredObjects.py
+  [../]
 []

--- a/test/tests/test_harness/required_objects
+++ b/test/tests/test_harness/required_objects
@@ -1,0 +1,12 @@
+[Tests]
+  [./bad_object]
+    type = RunApp
+    input = foo.i
+    required_objects = 'AnalyticalIndicator DoesNotExist'
+  [../]
+  [./good_objects]
+    type = RunApp
+    input = good.i
+    required_objects = 'AnalyticalIndicator VolumeHistogram'
+  [../]
+[]


### PR DESCRIPTION
Allows tests to be run/skipped based on objects in the JSON dump of the executable.

Although loading the JSON is relatively quick, 2-3 seconds on my Mac, the JSON dump only gets performed if the option is actually used. Then it is cached.

closes #6781