### PR TITLE
use_old_floor, 1e-9 tol on another multiapp test

### DIFF
--- a/test/tests/transfers/multiapp_projection_transfer/tests
+++ b/test/tests/transfers/multiapp_projection_transfer/tests
@@ -9,6 +9,8 @@
     type = 'Exodiff'
     input = 'fromsub_master.i'
     exodiff = 'fromsub_master_out.e'
+    use_old_floor = true
+    abs_zero = 1e-9  # 6e-10 failure w/ --distributed-mesh, np 11
   [../]
 
   [./high_order]


### PR DESCRIPTION
This appears to be another combination of #9414 with a too-tight
exodiff tolerance, which thereby causes a failure on a #1500 test when
we get up to 11 processors.