### PR TITLE
Fix typo in Adaptivity.h

### DIFF
--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -158,7 +158,7 @@ public:
    * Allow adaptivity to be toggled programatically.
    * @param state The adaptivity state (on/off).
    */
-  void setAdpaptivityOn(bool state) { _mesh_refinement_on = state; }
+  void setAdaptivityOn(bool state) { _mesh_refinement_on = state; }
 
   /**
    * Is adaptivity on?

--- a/modules/level_set/src/transfers/LevelSetMeshRefinementTransfer.C
+++ b/modules/level_set/src/transfers/LevelSetMeshRefinementTransfer.C
@@ -52,7 +52,7 @@ LevelSetMeshRefinementTransfer::initialSetup()
       adapt.init(0, 0);
       adapt.setUseNewSystem();
       adapt.setMaxHLevel(from_problem.adaptivity().getMaxHLevel());
-      adapt.setAdpaptivityOn(false);
+      adapt.setAdaptivityOn(false);
     }
 }
 
@@ -66,8 +66,8 @@ LevelSetMeshRefinementTransfer::execute()
     {
       FEProblemBase & to_problem = _multi_app->appProblemBase(i);
       Adaptivity & adapt = to_problem.adaptivity();
-      adapt.setAdpaptivityOn(true);
+      adapt.setAdaptivityOn(true);
       to_problem.adaptMesh();
-      adapt.setAdpaptivityOn(false);
+      adapt.setAdaptivityOn(false);
     }
 }


### PR DESCRIPTION
Simple typo fix. Really just a cheap attempt to get more lines associated with my name.

closes #9597