### PR TITLE
Check that mesh adaptivity can be used before turning on

### DIFF
--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -158,14 +158,22 @@ public:
    * Allow adaptivity to be toggled programatically.
    * @param state The adaptivity state (on/off).
    */
-  void setAdaptivityOn(bool state) { _mesh_refinement_on = state; }
+  void setAdaptivityOn(bool state);
 
   /**
    * Is adaptivity on?
    *
-   * @return true if we do mesh adaptivity, otherwise false
+   * @return true if mesh adaptivity is on, otherwise false
    */
   bool isOn() { return _mesh_refinement_on; }
+
+  /**
+   * Returns whether or not Adaptivity::init() has ran. Can
+   * be used to indicate if mesh adaptivity is available.
+   *
+   * @return true if the Adaptivity system is ready to be used, otherwise false
+   */
+  bool isInitialized() { return _initialized; }
 
   /**
    * Sets the time when the adaptivity is active
@@ -240,6 +248,8 @@ protected:
 
   /// on/off flag reporting if the adaptivity is being used
   bool _mesh_refinement_on;
+  /// on/off flag reporting if the adaptivity system has been initialized
+  bool _initialized;
   /// A mesh refinement object to be used either with initial refinement or with Adaptivity.
   std::unique_ptr<MeshRefinement> _mesh_refinement;
   /// Error estimator to be used by the apps.

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -37,6 +37,7 @@ Adaptivity::Adaptivity(FEProblemBase & subproblem)
     _subproblem(subproblem),
     _mesh(_subproblem.mesh()),
     _mesh_refinement_on(false),
+    _initialized(false),
     _initial_steps(0),
     _steps(0),
     _print_mesh_changed(false),
@@ -94,6 +95,9 @@ Adaptivity::init(unsigned int steps, unsigned int initial_steps)
     // TODO: This is currently an empty function on the DisplacedProblem... could it be removed?
     _displaced_problem->initAdaptivity();
   }
+
+  // indicate the Adaptivity system has been initialized
+  _initialized = true;
 }
 
 void
@@ -231,6 +235,16 @@ Adaptivity::uniformRefineWithProjection()
       displaced_mesh_refinement.uniformly_refine(1);
     _subproblem.meshChanged();
   }
+}
+
+void
+Adaptivity::setAdaptivityOn(bool state)
+{
+  // check if Adaptivity has been initialized before turning on
+  if (state == true && !_initialized)
+    mooseError("Mesh adaptivity system not available");
+
+  _mesh_refinement_on = state;
 }
 
 void


### PR DESCRIPTION
Added a method to the Adaptivity class that indicates if the system has been initialized, i.e. if `Adaptivity::init()` has run. Also added a check in `Adaptivity::setAdaptivityOn()` to check that the Adaptivity system is available (initialized) before turning it on.

The wording is open for discussion. I debated calling the method `isAvailable()` because that describes how I want to use it, or `isInitialized()` because that is really what it means. I went with the latter.

Closes #9605 