### PR TITLE
fix ElementLoopUserObject along interfaces

### DIFF
--- a/modules/rdg/include/userobjects/ElementLoopUserObject.h
+++ b/modules/rdg/include/userobjects/ElementLoopUserObject.h
@@ -113,6 +113,7 @@ protected:
   virtual void computeElement();
   virtual void computeBoundary();
   virtual void computeInternalSide();
+  virtual void computeInterface();
 };
 
 #endif


### PR DESCRIPTION
ElementLoopUserObject has been modified to work along mesh interfaces in a parallel environment.  An additional callback, `computeInterface()`, has been added for future use.