### PR TITLE
Recovery ASCII support

### DIFF
--- a/framework/include/restart/Resurrector.h
+++ b/framework/include/restart/Resurrector.h
@@ -42,6 +42,13 @@ public:
   void setRestartFile(const std::string & file_base);
 
   /**
+   * Set the file extension from which we will restart libMesh
+   * equation systems.  The default suffix is "xdr".
+   * @param file_ext The file extension of a restart file
+   */
+  void setRestartSuffix(const std::string & file_ext);
+
+  /**
    * Perform a restart from a file
    */
   void restartFromFile();
@@ -54,6 +61,9 @@ protected:
 
   /// name of the file that we restart from
   std::string _restart_file_base;
+
+  /// name of the file extension that we restart from
+  std::string _restart_file_suffix;
 
   /// Restartable Data
   RestartableDataIO _restartable;

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -434,7 +434,11 @@ FEProblemBase::initialSetup()
   _app.getOutputWarehouse().mooseConsole();
 
   if (_app.isRecovering() && (_app.isUltimateMaster() || _force_restart))
+  {
     _resurrector->setRestartFile(_app.getRecoverFileBase());
+    if (_app.getRecoverFileSuffix() == "cpa")
+      _resurrector->setRestartSuffix("xda");
+  }
 
   if ((_app.isRestarting() || _app.isRecovering()) && (_app.isUltimateMaster() || _force_restart))
     _resurrector->restartFromFile();

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -116,9 +116,8 @@ Checkpoint::output(const ExecFlagType & /*type*/)
   // Write the checkpoint file
   io.write(current_file_struct.checkpoint);
 
-  // Write the xdr
+  // Write the system data, using ENCODE vs WRITE based on xdr vs xda
   _es_ptr->write(current_file_struct.system,
-                 ENCODE,
                  EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA |
                      EquationSystems::WRITE_PARALLEL_FILES,
                  renumber);

--- a/framework/src/restart/Resurrector.C
+++ b/framework/src/restart/Resurrector.C
@@ -52,7 +52,10 @@ Resurrector::restartFromFile()
   unsigned int read_flags = EquationSystems::READ_DATA;
   if (!_fe_problem.skipAdditionalRestartData())
     read_flags |= EquationSystems::READ_ADDITIONAL_DATA;
-  _fe_problem.es().read(file_name, DECODE, read_flags, _fe_problem.adaptivity().isOn());
+
+  // DECODE or READ based on suffix
+  _fe_problem.es().read(file_name, read_flags, _fe_problem.adaptivity().isOn());
+
   _fe_problem.getNonlinearSystemBase().update();
   Moose::perf_log.pop("restartFromFile()", "Setup");
 }

--- a/framework/src/restart/Resurrector.C
+++ b/framework/src/restart/Resurrector.C
@@ -26,7 +26,7 @@ const std::string Resurrector::MAT_PROP_EXT(".msmp");
 const std::string Resurrector::RESTARTABLE_DATA_EXT(".rd");
 
 Resurrector::Resurrector(FEProblemBase & fe_problem)
-  : _fe_problem(fe_problem), _restartable(_fe_problem)
+  : _fe_problem(fe_problem), _restart_file_suffix("xdr"), _restartable(_fe_problem)
 {
 }
 
@@ -37,10 +37,16 @@ Resurrector::setRestartFile(const std::string & file_base)
 }
 
 void
+Resurrector::setRestartSuffix(const std::string & file_ext)
+{
+  _restart_file_suffix = file_ext;
+}
+
+void
 Resurrector::restartFromFile()
 {
   Moose::perf_log.push("restartFromFile()", "Setup");
-  std::string file_name(_restart_file_base + ".xdr");
+  std::string file_name(_restart_file_base + '.' + _restart_file_suffix);
   MooseUtils::checkFileReadable(file_name);
   _restartable.readRestartableDataHeader(_restart_file_base + RESTARTABLE_DATA_EXT);
   unsigned int read_flags = EquationSystems::READ_DATA;

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -464,7 +464,7 @@ getRecoveryFileBase(const std::list<std::string> & checkpoint_files)
   for (const auto & cp_file : checkpoint_files)
   {
     // Only look at the main checkpoint file, not the mesh, or restartable data files
-    if (hasExtension(cp_file, "xdr"))
+    if (hasExtension(cp_file, "xdr") || hasExtension(cp_file, "xda"))
     {
       struct stat stats;
       stat(cp_file.c_str(), &stats);

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -379,14 +379,19 @@ class TestHarness:
                 # Part 1:
                 part1_params = part1.parameters()
                 part1_params['test_name'] += '_part1'
-                part1_params['cli_args'].append('--half-transient Outputs/checkpoint=true')
+                part1_params['cli_args'].append('--half-transient')
+                if self.options.recoversuffix == 'cpr':
+                    part1_params['cli_args'].append('Outputs/checkpoint=true')
+                if self.options.recoversuffix == 'cpa':
+                    part1_params['cli_args'].append('Outputs/out/type=Checkpoint')
+                    part1_params['cli_args'].append('Outputs/out/binary=false')
                 part1_params['skip_checks'] = True
 
                 # Part 2:
                 part2_params = part2.parameters()
                 part2_params['prereq'].append(part1.parameters()['test_name'])
                 part2_params['delete_output_before_running'] = False
-                part2_params['cli_args'].append('--recover')
+                part2_params['cli_args'].append('--recover --recoversuffix ' + self.options.recoversuffix)
                 part2_params.addParam('caveats', ['recover'], "")
 
                 new_tests.append(part2)
@@ -825,6 +830,7 @@ class TestHarness:
         parser.add_argument('--n-threads', nargs=1, action='store', type=int, dest='nthreads', default=1, help='Number of threads to use when running mpiexec')
         parser.add_argument('-d', action='store_true', dest='debug_harness', help='Turn on Test Harness debugging')
         parser.add_argument('--recover', action='store_true', dest='enable_recover', help='Run a test in recover mode')
+        parser.add_argument('--recoversuffix', action='store', type=str, default='cpr', dest='recoversuffix', help='Set the file suffix for recover mode')
         parser.add_argument('--valgrind', action='store_const', dest='valgrind_mode', const='NORMAL', help='Run normal valgrind tests')
         parser.add_argument('--valgrind-heavy', action='store_const', dest='valgrind_mode', const='HEAVY', help='Run heavy valgrind tests')
         parser.add_argument('--valgrind-max-fails', nargs=1, type=int, dest='valgrind_max_fails', default=5, help='The number of valgrind tests allowed to fail before any additional valgrind tests will run')


### PR DESCRIPTION
This adds the capability, to both the MOOSE library and test harness, to do recovery using ASCII (.xda/.cpa) rather than binary (.xdr/.cpr) files, since the former is much more helpful to use when debugging.  This was quite useful when digging into #8890 and will probably be invaluable when working on #8410.  The default behavior is still to use binary xdr/cpr files, partly because that is slightly more efficient, mostly to ensure backwards compatibility.