### PR TITLE
use CNSFV slope limiters on interfaces

### DIFF
--- a/modules/navier_stokes/src/userobjects/CNSFVGreenGaussSlopeReconstruction.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVGreenGaussSlopeReconstruction.C
@@ -37,8 +37,8 @@ CNSFVGreenGaussSlopeReconstruction::CNSFVGreenGaussSlopeReconstruction(
   : SlopeReconstructionMultiD(parameters),
     _rho(getVar("rho", 0)),
     _rhou(getVar("rhou", 0)),
-    _rhov(isCoupled("rhov") ? getVar("rhov", 0) : NULL),
-    _rhow(isCoupled("rhow") ? getVar("rhow", 0) : NULL),
+    _rhov(isCoupled("rhov") ? getVar("rhov", 0) : nullptr),
+    _rhow(isCoupled("rhow") ? getVar("rhow", 0) : nullptr),
     _rhoe(getVar("rhoe", 0)),
     _fp(getUserObject<SinglePhaseFluidProperties>("fluid_properties"))
 {
@@ -85,9 +85,9 @@ CNSFVGreenGaussSlopeReconstruction::reconstructElementSlope()
   Real rhovc = 0.;
   Real rhowc = 0.;
   Real rhoec = _rhoe->getElementalValue(elem);
-  if (_rhov != NULL)
+  if (_rhov != nullptr)
     rhovc = _rhov->getElementalValue(elem);
-  if (_rhow != NULL)
+  if (_rhow != nullptr)
     rhowc = _rhow->getElementalValue(elem);
 
   ucell[0][1] = rhouc * rhomc;
@@ -114,12 +114,12 @@ CNSFVGreenGaussSlopeReconstruction::reconstructElementSlope()
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
+    const Elem * neig = elem->neighbor_ptr(is);
 
     /// for internal side
 
-    if (elem->neighbor(is) != NULL)
+    if (neig != nullptr && this->hasBlocks(neig->subdomain_id()))
     {
-      const Elem * neig = elem->neighbor(is);
       dof_id_type neigID = neig->id();
 
       if (_side_geoinfo_cached)
@@ -147,9 +147,9 @@ CNSFVGreenGaussSlopeReconstruction::reconstructElementSlope()
       Real v = 1. / _rho->getElementalValue(neig);
 
       ucell[in][1] = _rhou->getElementalValue(neig) * v;
-      if (_rhov != NULL)
+      if (_rhov != nullptr)
         ucell[in][2] = _rhov->getElementalValue(neig) * v;
-      if (_rhow != NULL)
+      if (_rhow != nullptr)
         ucell[in][3] = _rhow->getElementalValue(neig) * v;
 
       Real e = _rhoe->getElementalValue(neig) * v -

--- a/modules/navier_stokes/src/userobjects/CNSFVLeastSquaresSlopeReconstruction.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVLeastSquaresSlopeReconstruction.C
@@ -37,8 +37,8 @@ CNSFVLeastSquaresSlopeReconstruction::CNSFVLeastSquaresSlopeReconstruction(
   : SlopeReconstructionMultiD(parameters),
     _rho(getVar("rho", 0)),
     _rhou(getVar("rhou", 0)),
-    _rhov(isCoupled("rhov") ? getVar("rhov", 0) : NULL),
-    _rhow(isCoupled("rhow") ? getVar("rhow", 0) : NULL),
+    _rhov(isCoupled("rhov") ? getVar("rhov", 0) : nullptr),
+    _rhow(isCoupled("rhow") ? getVar("rhow", 0) : nullptr),
     _rhoe(getVar("rhoe", 0)),
     _fp(getUserObject<SinglePhaseFluidProperties>("fluid_properties"))
 {
@@ -82,9 +82,9 @@ CNSFVLeastSquaresSlopeReconstruction::reconstructElementSlope()
   Real rhovc = 0.;
   Real rhowc = 0.;
   Real rhoec = _rhoe->getElementalValue(elem);
-  if (_rhov != NULL)
+  if (_rhov != nullptr)
     rhovc = _rhov->getElementalValue(elem);
-  if (_rhow != NULL)
+  if (_rhow != nullptr)
     rhowc = _rhow->getElementalValue(elem);
 
   u[0][1] = rhouc * rhomc;
@@ -125,11 +125,11 @@ CNSFVLeastSquaresSlopeReconstruction::reconstructElementSlope()
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
-    const Elem * neig = elem->neighbor(is);
+    const Elem * neig = elem->neighbor_ptr(is);
 
     /// for internal side
 
-    if (neig != NULL && this->hasBlocks(neig->subdomain_id()))
+    if (neig != nullptr && this->hasBlocks(neig->subdomain_id()))
     {
       dof_id_type neigID = neig->id();
 
@@ -146,9 +146,9 @@ CNSFVLeastSquaresSlopeReconstruction::reconstructElementSlope()
       Real v = 1. / _rho->getElementalValue(neig);
 
       u[in][1] = _rhou->getElementalValue(neig) * v;
-      if (_rhov != NULL)
+      if (_rhov != nullptr)
         u[in][2] = _rhov->getElementalValue(neig) * v;
-      if (_rhow != NULL)
+      if (_rhow != nullptr)
         u[in][3] = _rhow->getElementalValue(neig) * v;
 
       Real e = _rhoe->getElementalValue(neig) * v -

--- a/modules/navier_stokes/src/userobjects/CNSFVMinmaxSlopeLimiting.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVMinmaxSlopeLimiting.C
@@ -26,7 +26,6 @@ std::vector<RealGradient>
 CNSFVMinmaxSlopeLimiting::limitElementSlope() const
 {
   const Elem * elem = _current_elem;
-  const Elem * neighbor;
 
   /// current element id
   dof_id_type _elementID = elem->id();
@@ -74,9 +73,9 @@ CNSFVMinmaxSlopeLimiting::limitElementSlope() const
 
   for (unsigned int is = 0; is < nside; is++)
   {
-    neighbor = elem->neighbor_ptr(is);
+    const Elem * neighbor = elem->neighbor_ptr(is);
 
-    if (neighbor != NULL && this->hasBlocks(neighbor->subdomain_id()))
+    if (neighbor != nullptr && this->hasBlocks(neighbor->subdomain_id()))
     {
       dof_id_type _neighborID = neighbor->id();
       uelem = _rslope.getElementAverageValue(_neighborID);

--- a/modules/navier_stokes/src/userobjects/CNSFVMinmaxSlopeLimiting.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVMinmaxSlopeLimiting.C
@@ -26,6 +26,7 @@ std::vector<RealGradient>
 CNSFVMinmaxSlopeLimiting::limitElementSlope() const
 {
   const Elem * elem = _current_elem;
+  const Elem * neighbor;
 
   /// current element id
   dof_id_type _elementID = elem->id();
@@ -73,9 +74,11 @@ CNSFVMinmaxSlopeLimiting::limitElementSlope() const
 
   for (unsigned int is = 0; is < nside; is++)
   {
-    if (elem->neighbor(is) != NULL)
+    neighbor = elem->neighbor_ptr(is);
+
+    if (neighbor != NULL && this->hasBlocks(neighbor->subdomain_id()))
     {
-      dof_id_type _neighborID = elem->neighbor(is)->id();
+      dof_id_type _neighborID = neighbor->id();
       uelem = _rslope.getElementAverageValue(_neighborID);
       scent[is] = _rslope.getSideCentroid(_elementID, _neighborID);
     }

--- a/modules/navier_stokes/src/userobjects/CNSFVWENOSlopeLimiting.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVWENOSlopeLimiting.C
@@ -34,6 +34,7 @@ std::vector<RealGradient>
 CNSFVWENOSlopeLimiting::limitElementSlope() const
 {
   const Elem * elem = _current_elem;
+  const Elem * neighbor;
 
   /// current element id
   dof_id_type _elementID = elem->id();
@@ -78,10 +79,11 @@ CNSFVWENOSlopeLimiting::limitElementSlope() const
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
+    neighbor = elem->neighbor_ptr(is);
 
-    if (elem->neighbor(is) != NULL)
+    if (neighbor != NULL && this->hasBlocks(neighbor->subdomain_id()))
     {
-      dof_id_type _neighborID = elem->neighbor(is)->id();
+      dof_id_type _neighborID = neighbor->id();
       rugrad = _rslope.getElementSlope(_neighborID);
 
       for (unsigned int iv = 0; iv < nvars; iv++)
@@ -103,8 +105,9 @@ CNSFVWENOSlopeLimiting::limitElementSlope() const
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
+    neighbor = elem->neighbor_ptr(is);
 
-    if (elem->neighbor(is) != NULL)
+    if (neighbor != NULL && this->hasBlocks(neighbor->subdomain_id()))
       for (unsigned int iv = 0; iv < nvars; iv++)
         weig[in][iv] = weig[in][iv] / summ[iv];
   }
@@ -119,10 +122,11 @@ CNSFVWENOSlopeLimiting::limitElementSlope() const
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
+    neighbor = elem->neighbor_ptr(is);
 
-    if (elem->neighbor(is) != NULL)
+    if (neighbor != NULL && this->hasBlocks(neighbor->subdomain_id()))
     {
-      dof_id_type _neighborID = elem->neighbor(is)->id();
+      dof_id_type _neighborID = neighbor->id();
       rugrad = _rslope.getElementSlope(_neighborID);
 
       for (unsigned int iv = 0; iv < nvars; iv++)

--- a/modules/navier_stokes/src/userobjects/CNSFVWENOSlopeLimiting.C
+++ b/modules/navier_stokes/src/userobjects/CNSFVWENOSlopeLimiting.C
@@ -34,7 +34,6 @@ std::vector<RealGradient>
 CNSFVWENOSlopeLimiting::limitElementSlope() const
 {
   const Elem * elem = _current_elem;
-  const Elem * neighbor;
 
   /// current element id
   dof_id_type _elementID = elem->id();
@@ -79,9 +78,9 @@ CNSFVWENOSlopeLimiting::limitElementSlope() const
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
-    neighbor = elem->neighbor_ptr(is);
+    const Elem * neighbor = elem->neighbor_ptr(is);
 
-    if (neighbor != NULL && this->hasBlocks(neighbor->subdomain_id()))
+    if (neighbor != nullptr && this->hasBlocks(neighbor->subdomain_id()))
     {
       dof_id_type _neighborID = neighbor->id();
       rugrad = _rslope.getElementSlope(_neighborID);
@@ -105,9 +104,9 @@ CNSFVWENOSlopeLimiting::limitElementSlope() const
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
-    neighbor = elem->neighbor_ptr(is);
+    const Elem * neighbor = elem->neighbor_ptr(is);
 
-    if (neighbor != NULL && this->hasBlocks(neighbor->subdomain_id()))
+    if (neighbor != nullptr && this->hasBlocks(neighbor->subdomain_id()))
       for (unsigned int iv = 0; iv < nvars; iv++)
         weig[in][iv] = weig[in][iv] / summ[iv];
   }
@@ -122,9 +121,9 @@ CNSFVWENOSlopeLimiting::limitElementSlope() const
   for (unsigned int is = 0; is < nside; is++)
   {
     unsigned int in = is + 1;
-    neighbor = elem->neighbor_ptr(is);
+    const Elem * neighbor = elem->neighbor_ptr(is);
 
-    if (neighbor != NULL && this->hasBlocks(neighbor->subdomain_id()))
+    if (neighbor != nullptr && this->hasBlocks(neighbor->subdomain_id()))
     {
       dof_id_type _neighborID = neighbor->id();
       rugrad = _rslope.getElementSlope(_neighborID);


### PR DESCRIPTION
The slope limiters now check if they should operate in the subdomain of neighboring elements.  If the limiter is block restricted, the neighboring element may be outside of the limiter's domain and should be skipped as is done for exterior boundaries.  This is analogous to #9046.

`CNSFVGreenGaussSlopeReconstruction` has been corrected as `CNSFVLeaseSquaresSlopeRecontruction` was in #9046.