### PR TITLE
DistributedMesh restart should skip partitioning and renumbering

### DIFF
--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -4881,6 +4881,8 @@ FEProblemBase::setRestartFile(const std::string & file_name)
 {
   _app.setRestart(true);
   _resurrector->setRestartFile(file_name);
+  if (_app.getRecoverFileSuffix() == "cpa")
+    _resurrector->setRestartSuffix("xda");
 }
 
 std::vector<VariableName>

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -458,13 +458,14 @@ MooseApp::setupOptions()
       // a dash then we are going to eventually find the newest recovery file to use
       if (!(recover_following_arg.empty() || (recover_following_arg.find('-') == 0)))
         _recover_base = recover_following_arg;
+    }
 
-      // Optionally get command line argument following
-      // --recoversuffix on command line
-      if (isParamValid("recoversuffix"))
-      {
-        _recover_suffix = getParam<std::string>("recoversuffix");
-      }
+    // Optionally get command line argument following --recoversuffix
+    // on command line.  Currently this argument applies to both
+    // recovery and restart files.
+    if (isParamValid("recoversuffix"))
+    {
+      _recover_suffix = getParam<std::string>("recoversuffix");
     }
 
     _parser.parse(_input_filename);

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -92,7 +92,29 @@ FileMesh::buildMesh()
       getMesh().prepare_for_use();
     }
     else
+    {
+      // If we are reading a mesh while restarting, then we might have
+      // a solution file that relies on that mesh partitioning and/or
+      // numbering.  In that case, we need to turn off repartitioning
+      // and renumbering, at least at first.
+      const bool restarting = _app.isRestarting();
+      const bool skip_partitioning_later = restarting && getMesh().skip_partitioning();
+      const bool allow_renumbering_later = restarting && getMesh().allow_renumbering();
+
+      if (restarting)
+        {
+          getMesh().skip_partitioning(true);
+          getMesh().allow_renumbering(false);
+        }
+
       getMesh().read(_file_name);
+
+      if (restarting)
+        {
+          getMesh().allow_renumbering(allow_renumbering_later);
+          getMesh().skip_partitioning(skip_partitioning_later);
+        }
+    }
   }
 
   Moose::perf_log.pop("Read Mesh", "Setup");

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -97,7 +97,8 @@ FileMesh::buildMesh()
       // a solution file that relies on that mesh partitioning and/or
       // numbering.  In that case, we need to turn off repartitioning
       // and renumbering, at least at first.
-      const bool restarting = _app.isRestarting();
+      const bool restarting = _file_name.rfind(".cpa") < _file_name.size() ||
+                              _file_name.rfind(".cpr") < _file_name.size();
       const bool skip_partitioning_later = restarting && getMesh().skip_partitioning();
       const bool allow_renumbering_later = restarting && getMesh().allow_renumbering();
 

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -102,18 +102,18 @@ FileMesh::buildMesh()
       const bool allow_renumbering_later = restarting && getMesh().allow_renumbering();
 
       if (restarting)
-        {
-          getMesh().skip_partitioning(true);
-          getMesh().allow_renumbering(false);
-        }
+      {
+        getMesh().skip_partitioning(true);
+        getMesh().allow_renumbering(false);
+      }
 
       getMesh().read(_file_name);
 
       if (restarting)
-        {
-          getMesh().allow_renumbering(allow_renumbering_later);
-          getMesh().skip_partitioning(skip_partitioning_later);
-        }
+      {
+        getMesh().allow_renumbering(allow_renumbering_later);
+        getMesh().skip_partitioning(skip_partitioning_later);
+      }
     }
   }
 


### PR DESCRIPTION
This fixes occasional bugs when parallel restart meshes are hit by
non-idempotent repartitioning.  In particular it fixes the
restart/new_dt.test_restart test with --distributed-mesh --recover
settings.  That test is an example of #5877, mixing recovery with
restarts, and it now works on 1 through 24 processors, so there's a
chance that that capability is working now.

This fixes some but not all of the potential DistributedMesh restart
problems discussed in #8410.  I'll open a new ticket for the remaining
issue.