### PR TITLE
Add --definition feature for validation schema

### DIFF
--- a/framework/include/outputs/formatters/SONDefinitionFormatter.h
+++ b/framework/include/outputs/formatters/SONDefinitionFormatter.h
@@ -1,0 +1,93 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef SONDEFINITIONFORMATTER_H
+#define SONDEFINITIONFORMATTER_H
+#include "json/json.h"
+#include <map>
+#include <string>
+#include <vector>
+
+typedef moosecontrib::Json::Value JsonVal;
+
+/**
+ * This class produces a dump of the InputFileParameters in the Standard Object
+ * Notation (SON) format for use by the Hierarchical Input Validation Engine
+ * (HIVE) in the NEAMS Workbench. It takes its input from JsonSyntaxTree.
+ */
+class SONDefinitionFormatter
+{
+
+public:
+  SONDefinitionFormatter();
+
+  /**
+   * returns a string representation of the tree in input file format
+   * @param root - the root node of the tree to output
+   */
+  std::string toString(const JsonVal & root);
+
+protected:
+  /**
+   * adds a line to the output with the proper indentation automatically
+   * @param line - the line to add
+   */
+  void addLine(const std::string & line);
+
+  /**
+   * adds a new block to the output
+   * @param block_name    - name of the block
+   * @param block         - json holding data for the block
+   * @param parameters_in - if a typeblock, the parameters for inheritance
+   * @param subblocks_in  - if a typeblock, the subblocks for inheritance
+   * @param is_typeblock  - true only if block being added is a typeblock
+   */
+  void addBlock(const std::string & block_name,
+                const JsonVal & block,
+                bool is_typeblock = false,
+                const std::string & parent_name = "",
+                const JsonVal & parameters_in = JsonVal::null,
+                const JsonVal & subblocks_in = JsonVal::null);
+
+  /**
+   * adds all parameters from a given block
+   * @param params - json holding data for all of the given block's parameters
+   */
+  void addParameters(const JsonVal & params);
+
+  /**
+   * return backtrack relative path from the current level to the document root
+   */
+  std::string backtrack()
+  {
+    std::string backtrack_path;
+    for (size_t i = 0; i < _level; ++i)
+      backtrack_path += "../";
+    return backtrack_path;
+  }
+
+  JsonVal _globalparams;
+  const int _spaces;
+  int _level;
+  std::ostringstream _stream;
+  std::map<std::string, std::vector<std::string>> _assoc_types_map;
+  std::map<std::string, std::string> _json_path_regex_replacement_map = {
+      {"/star/subblock_types/([A-Za-z0-9_]*)/", "/\\1_type/"},
+      {"[A-Za-z0-9_]*/types/([A-Za-z0-9_]*)/", "\\1_type/"},
+      {"/actions/[A-Za-z0-9_]*/parameters/", "/"},
+      {"/parameters/", "/"},
+      {"/subblocks/", "/"}};
+};
+
+#endif /* SONDEFINITIONFORMATTER_H */

--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -80,7 +80,8 @@ public:
   void addGlobal();
 
 protected:
-  std::string buildOptions(const std::iterator_traits<InputParameters::iterator>::value_type & p);
+  std::string buildOptions(const std::iterator_traits<InputParameters::iterator>::value_type & p,
+                           bool & out_of_range_allowed);
 
   std::string prettyCppType(const std::string & cpp_type);
   std::string basicCppType(const std::string & cpp_type);

--- a/framework/include/utils/MooseEnumBase.h
+++ b/framework/include/utils/MooseEnumBase.h
@@ -76,6 +76,12 @@ public:
    */
   virtual bool isValid() const = 0;
 
+  /**
+   * isOutOfRangeAllowed
+   * @return - a Boolean indicating whether enum names out of range are allowed
+   */
+  bool isOutOfRangeAllowed() const { return _out_of_range_index; }
+
 protected:
   MooseEnumBase();
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -35,6 +35,7 @@
 #include "ConsoleUtils.h"
 #include "JsonSyntaxTree.h"
 #include "JsonInputFileFormatter.h"
+#include "SONDefinitionFormatter.h"
 
 // Regular expression includes
 #include "pcrecpp.h"
@@ -86,6 +87,8 @@ validParams<MooseApp>()
       false,
       "Ignore input file and build a minimal application with Transient executioner.");
 
+  params.addCommandLineParam<std::string>(
+      "definition", "--definition", "Shows a SON style input definition dump for input validation");
   params.addCommandLineParam<std::string>(
       "dump", "--dump [search_string]", "Shows a dump of available input file syntax.");
   params.addCommandLineParam<std::string>(
@@ -387,6 +390,15 @@ MooseApp::setupOptions()
     JsonSyntaxTree tree(param_search);
     _parser.buildJsonSyntaxTree(tree);
     JsonInputFileFormatter formatter;
+    Moose::out << formatter.toString(tree.getRoot()) << "\n";
+    _ready_to_exit = true;
+  }
+  else if (isParamValid("definition"))
+  {
+    Moose::perf_log.disable_logging();
+    JsonSyntaxTree tree("");
+    _parser.buildJsonSyntaxTree(tree);
+    SONDefinitionFormatter formatter;
     Moose::out << formatter.toString(tree.getRoot()) << "\n";
     _ready_to_exit = true;
   }

--- a/framework/src/outputs/formatters/SONDefinitionFormatter.C
+++ b/framework/src/outputs/formatters/SONDefinitionFormatter.C
@@ -1,0 +1,337 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "SONDefinitionFormatter.h"
+#include "MooseUtils.h"
+#include "pcrecpp.h"
+
+SONDefinitionFormatter::SONDefinitionFormatter() : _spaces(2), _level(0) {}
+
+// ******************************** toString ************************************ //
+// traverse the associated types array of cpp_types and absolute lookup paths and //
+// transform the paths to work with our parsed hierarchy and store pairs in a map //
+// of types to paths for use by the ExistsIn rule and store the global/parameters //
+// object then add root blocks recursively and return constructed stream's string //
+// ****************************************************************************** //
+std::string
+SONDefinitionFormatter::toString(const JsonVal & root)
+{
+  for (const auto & type : root["global"]["associated_types"].getMemberNames())
+    for (const auto & path_iter : root["global"]["associated_types"][type])
+    {
+      std::string path = path_iter.asString();
+      for (auto map_iter : _json_path_regex_replacement_map)
+        pcrecpp::RE(map_iter.first).GlobalReplace(map_iter.second, &path);
+      _assoc_types_map[type].push_back(path);
+    }
+
+  _globalparams = root["global"]["parameters"];
+  _stream.clear();
+  _stream.str("");
+  for (const auto & name : root["blocks"].getMemberNames())
+    addBlock(name, root["blocks"][name]);
+  return _stream.str();
+}
+
+// ******************************** addLine ************************************* //
+// add a single new-line-terminated and indented line to the stream               //
+// ****************************************************************************** //
+void
+SONDefinitionFormatter::addLine(const std::string & line)
+{
+  _stream << std::string(!line.empty() * _level * _spaces, ' ') << line << "\n";
+  return;
+}
+
+// ******************************* addBlock ************************************* //
+// add parameters and recursively add NormalBlock children and TypeBlock children //
+// ****************************************************************************** //
+void
+SONDefinitionFormatter::addBlock(const std::string & block_name,
+                                 const JsonVal & block,
+                                 bool is_typeblock,
+                                 const std::string & parent_name,
+                                 const JsonVal & parameters_in,
+                                 const JsonVal & subblocks_in)
+{
+
+  // open block with "_type" appended to the name if this is a TypeBlock because the
+  // parser appends "_type" to the name of blocks with a "type=" parameter specified
+  addLine("'" + block_name + (is_typeblock ? "_type" : "") + "'{");
+  _level++;
+
+  // decide the actual block [./declarator] name that will be specified later unless
+  // this is a StarBlock and then decide if this is a StarBlock or not for later use
+  //  - if TypeBlock   : this will be the parent block name
+  //  - if NormalBlock : this will be this block name
+  std::string block_decl = (is_typeblock ? parent_name : block_name);
+  bool is_starblock = (block_decl == "*" ? true : false);
+
+  // - add InputTmpl    : the autocomplete template that is used for all block types
+  // - add InputName    : if is_typeblock then this will be dropped in after "type="
+  // - add InputType    : block type - normal_top / normal_sub / type_top / type_sub
+  // - add InputDefault : block [./declarator] name from above that will be used for
+  //                      autocompletion of this block unless it is a StarBlock then
+  //                      [./insert_name_here] will be used because any name is okay
+  addLine("InputTmpl=MooseBlock");
+  addLine("InputName=\"" + block_name + "\"");
+  if (!is_typeblock)
+    addLine(_level == 1 ? "InputType=normal_top" : "InputType=normal_sub");
+  else
+    addLine(_level == 1 ? "InputType=type_top" : "InputType=type_sub");
+  if (!is_starblock)
+    addLine("InputDefault=\"" + block_decl + "\"");
+  else
+    addLine("InputDefault=\"insert_name_here\"");
+
+  // add Description of block if it exists
+  std::string description = block["description"].asString();
+  pcrecpp::RE("\"").GlobalReplace("'", &description);
+  pcrecpp::RE("[\r\n]").GlobalReplace(" ", &description);
+  if (!description.empty())
+    addLine("Description=\"" + description + "\"");
+
+  // add MinOccurs : optional because nothing available to specify block requirement
+  addLine("MinOccurs=0");
+
+  // add MaxOccurs : if a StarBlock then no limit / otherwise maximum one occurrence
+  addLine(is_starblock ? "MaxOccurs=NoLimit" : "MaxOccurs=1");
+
+  // ensure block has one string declarator node and if this is not a StarBlock then
+  // also ensure that the block [./declarator] is the expected block_decl from above
+  addLine("decl{");
+  _level++;
+  addLine("MinOccurs=1");
+  addLine("MaxOccurs=1");
+  addLine("ValType=String");
+  if (!is_starblock)
+    addLine("ValEnums=[ \"" + block_decl + "\" ]");
+  _level--;
+  addLine("}");
+
+  // if this block is the GlobalParams block then add a add "*/value" level
+  if (block_name == "GlobalParams")
+  {
+    addLine("'*'{");
+    _level++;
+    addLine("'value'{");
+    addLine("}");
+    _level--;
+    addLine("} % end *");
+  }
+
+  // store parameters ---
+  // first  : start with global parameters as a base
+  // second : add or overwrite with any parameter inheritance
+  // third  : add or overwrite with any local RegularParameters
+  // fourth : add or overwrite with any local ActionParameters
+  JsonVal parameters = _globalparams;
+  for (const auto & name : parameters_in.getMemberNames())
+    parameters[name] = parameters_in[name];
+  for (const auto & name : block["parameters"].getMemberNames())
+    parameters[name] = block["parameters"][name];
+  for (const auto & act : block["actions"].getMemberNames())
+    for (const auto & param : block["actions"][act]["parameters"].getMemberNames())
+      parameters[param] = block["actions"][act]["parameters"][param];
+
+  // store NormalBlock children ---
+  // first  : start with any NormalBlock inheritance passed in as a base
+  // second : add or overwrite these with any local NormalBlock children
+  // third  : add star named child block if it exists
+  JsonVal subblocks = subblocks_in;
+  for (const auto & name : block["subblocks"].getMemberNames())
+    subblocks[name] = block["subblocks"][name];
+  if (block.isMember("star"))
+    subblocks["*"] = block["star"];
+
+  // store TypeBlock children ---
+  // first  : start with ["types"] child block as a base
+  // second : add ["subblock_types"] child block
+  JsonVal typeblocks = block["types"];
+  for (const auto & name : block["subblock_types"].getMemberNames())
+    typeblocks[name] = block["subblock_types"][name];
+
+  // add parameters ---
+  // if this block has a "type=" parameter with a specified default "type=" name and
+  // if that default is also the name of a ["types"] child block then the parameters
+  // belonging to that default ["types"] child block are added to this block as well
+  // first  : start with default ["types"] child block's RegularParameters as a base
+  // second : add or overwrite with default ["types"] child block's ActionParameters
+  // third  : add or overwrite with parameters that were stored above for this block
+  // fourth : either add newly stored parameters or add previously stored parameters
+  if (parameters.isMember("type") && parameters["type"].isMember("default") &&
+      block["types"].isMember(parameters["type"]["default"].asString()))
+  {
+    std::string type_default = parameters["type"]["default"].asString();
+    const JsonVal & default_block = block["types"][type_default];
+    JsonVal default_child_params = default_block["parameters"];
+    const JsonVal & default_actions = default_block["actions"];
+    for (const auto & act : default_actions.getMemberNames())
+      for (const auto & param : default_actions[act]["parameters"].getMemberNames())
+        default_child_params[param] = default_actions[act]["parameters"][param];
+    for (const auto & name : parameters.getMemberNames())
+      default_child_params[name] = parameters[name];
+    addParameters(default_child_params);
+  }
+  else
+    addParameters(parameters);
+
+  // add previously stored NormalBlocks children recursively
+  for (const auto & name : subblocks.getMemberNames())
+    addBlock(name, subblocks[name]);
+
+  // close block now because the parser stores TypeBlock children at this same level
+  _level--;
+  addLine("} % end block " + block_name + (is_typeblock ? "_type" : ""));
+
+  // add all previously stored TypeBlock children recursively and pass the parameter
+  // and NormalBlock children added at this level in as inheritance to all TypeBlock
+  // children so that they may each also add them and pass in the name of this block
+  // as well so that all TypeBlock children can add a rule ensuring that their block
+  // [./declarator] is the name of this parent block unless this block is named star
+  for (const auto & name : typeblocks.getMemberNames())
+    addBlock(name, typeblocks[name], true, block_name, parameters, subblocks);
+}
+
+// ***************************** addParameters ********************************** //
+// add all of the information for each parameter of a block
+// - parameter         :: add ChildAtLeastOne
+// - parameter         :: add InputTmpl
+// - parameter         :: add InputType
+// - parameter         :: add InputName
+// - parameter         :: add Description
+// - parameter         :: add MinOccurs
+// - parameter         :: add MaxOccurs
+// - parameter's value :: add MinOccurs
+// - parameter's value :: add MaxOccurs
+// - parameter's value :: add ValType
+// - parameter's value :: add ValEnums
+// - parameter's value :: add InputChoices
+// - parameter's value :: add ExistsIn
+// - parameter's value :: add MinValInc
+// - parameter's value :: add InputDefault
+// ****************************************************************************** //
+void
+SONDefinitionFormatter::addParameters(const JsonVal & params)
+{
+  for (const auto & param_name : params.getMemberNames())
+  {
+
+    JsonVal param = params[param_name];
+
+    // *** ChildAtLeastOne of parameter
+    // if parameter is required and no default exists then outside its level specify
+    //   ChildAtLeastOne = [ GlobalParams/param_name/value /param_name/value ]
+    bool required = param["required"].asBool();
+    std::string def = MooseUtils::trim(param["default"].asString());
+    if (required && def.empty())
+      addLine("ChildAtLeastOne=[  \"" + backtrack() + "GlobalParams/" + param_name +
+              "/value\"  \"" + param_name + "/value\"" + "  ]");
+
+    // *** open parameter
+    addLine("'" + param_name + "'" + "{");
+    _level++;
+
+    // *** InputTmpl of parameter
+    addLine("InputTmpl=MooseParam");
+
+    // *** InputType of parameter
+    std::string basic_type = param["basic_type"].asString();
+    bool is_array = (basic_type.find("Array") == std::string::npos ? false : true);
+    if (is_array)
+      addLine("InputType=key_array");
+    else
+      addLine("InputType=key_value");
+
+    // *** InputName of parameter
+    addLine("InputName=\"" + param_name + "\"");
+
+    // *** Description of parameter
+    std::string description = param["description"].asString();
+    pcrecpp::RE("\"").GlobalReplace("'", &description);
+    pcrecpp::RE("[\r\n]").GlobalReplace(" ", &description);
+    if (!description.empty())
+      addLine("Description=\"" + description + "\"");
+
+    // *** MinOccurs / MaxOccurs of parameter
+    addLine("MinOccurs=0");
+    addLine("MaxOccurs=1");
+
+    // *** open parameter's value
+    addLine("'value'{");
+    _level++;
+
+    // *** MinOccurs / MaxOccurs of parameter's value
+    addLine("MinOccurs=1");
+    addLine(is_array ? "MaxOccurs=NoLimit" : "MaxOccurs=1");
+
+    // *** ValType of parameter's value
+    if (basic_type.find("Integer") != std::string::npos)
+      addLine("ValType=Int");
+    else if (basic_type.find("Real") != std::string::npos)
+      addLine("ValType=Real");
+    else
+      addLine("ValType=String");
+
+    // *** ValEnums / InputChoices of parameter's value
+    if (basic_type.find("Boolean") != std::string::npos)
+      addLine("ValEnums=[ true false 1 0 ]");
+    else
+    {
+      std::string options = param["options"].asString();
+      if (!options.empty())
+      {
+        pcrecpp::RE(" ").GlobalReplace("\" \"", &options);
+        if (!param["out_of_range_allowed"].asBool())
+          addLine("ValEnums=[ \"" + options + "\" ]");
+        else
+          addLine("InputChoices=[ \"" + options + "\" ]");
+      }
+    }
+
+    // *** ExistsIn of parameter's value
+    // add any reserved_values and get the cpp_type and if this parameter's cpp_type
+    // is FunctionName then add a NumericalConstants flag and check if there are any
+    // paths associated with the cpp_type in the map that was built before traversal
+    // then add those paths relative to this node here as well
+    std::string paths;
+    for (const auto & reserved : param["reserved_values"])
+      paths += "EXTRA:\"" + reserved.asString() + "\" ";
+    std::string cpp_type = param["cpp_type"].asString();
+    pcrecpp::RE(".+<([A-Za-z0-9_' ':]*)>.*").GlobalReplace("\\1", &cpp_type);
+    if (cpp_type == "FunctionName")
+      paths += "EXTRA:\"NumericalConstants\" ";
+    for (auto path : _assoc_types_map[cpp_type])
+      paths += "\"" + backtrack() + path + "/decl\" ";
+    if (!paths.empty())
+      addLine("ExistsIn=[ " + paths + "]");
+
+    // *** MinValInc of parameter's value
+    if (basic_type.find("Integer") != std::string::npos &&
+        cpp_type.find("unsigned") != std::string::npos)
+      addLine("MinValInc=0");
+
+    // *** InputDefault of parameter's value
+    if (!def.empty())
+      addLine("InputDefault=\"" + def + "\"");
+
+    // *** close parameter's value
+    _level--;
+    addLine("}");
+
+    // *** close parameter
+    _level--;
+    addLine("} % end parameter " + param_name);
+  }
+}

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -111,4 +111,60 @@
     type = 'PythonUnitTest'
     input = 'test_json.py'
   [../]
+
+  [./definition_existsin_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = 'ExistsIn=\[\s*EXTRA:"all"\s*EXTRA:"none"\s*"../../../../../Outputs/["*"]/decl"\s*\]'
+    cli_args = '--definition'
+  [../]
+
+  [./definition_childatleastone_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = 'ChildAtLeastOne=\[\s*"../../../GlobalParams/inside/value"\s*"inside/value"\s*\]'
+    cli_args = '--definition'
+  [../]
+
+  [./definition_valenum_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'execute_on\'{.*\'value\'{.*ValEnums=\[ "none" "ini.*gin" "custom" \].*}.*} % end parameter execute_on'
+    cli_args = '--definition'
+  [../]
+
+  [./definition_active_parameter_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'active\'{.*Description="If specified.*made active".*\'value\'{.*InputDefault="__all__".*} % end parameter active'
+    cli_args = '--definition'
+  [../]
+
+  [./definition_normal_sub_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'Indicators\'{.*InputTmpl=MooseBlock.*InputName="Indicators".*InputType=normal_sub.*InputDefault="Indicators"'
+    cli_args = '--definition'
+  [../]
+
+  [./definition_type_sub_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'CircleMarker_type\'{.*InputType=type_sub.*InputDefault="insert_name_here".*} % end block CircleMarker_type'
+    cli_args = '--definition'
+  [../]
+
+  [./definition_default_type_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'BoxMarker_type\'{.*\'type\'{.*\'value\'{.*InputDefault="BoxMarker".*}.*} % end parameter type.*} % end block BoxMarker_type'
+    cli_args = '--definition'
+  [../]
+
+  [./definition_minvalinc_inputdefault_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'cycles_per_step\'{.*'value'{.*MinValInc=0.*InputDefault="1".*} % end parameter cycles_per_step'
+    cli_args = '--definition'
+  [../]
 []


### PR DESCRIPTION
Added the new --definition schema dump that formats the JsonSyntaxTree in a Standard Object Notation format with a different hierarchy structure than the current JSON dump so that it can be used by the NEAMS Workbench Hierarchical Input Validation Engine for validating the input of MOOSE applications.

closes #9651

### Complete each of the following items before creating a PR

- Include any relevant design information for your change
- Follow [Coding Standards](http://mooseframework.org/wiki/CodeStandards/)
- Submit one or more [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/) or modify existing test cases
- Reference or close a specific issue (refs # or closes #)