### PR TITLE
Displace mesh consistently

### DIFF
--- a/framework/include/base/AllNodesSendListThread.h
+++ b/framework/include/base/AllNodesSendListThread.h
@@ -12,16 +12,12 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef UPDATEDISPLACEDMESHTHREAD_H
-#define UPDATEDISPLACEDMESHTHREAD_H
+#ifndef ALLNODESSENDLISTTHREAD_H
+#define ALLNODESSENDLISTTHREAD_H
 
 // MOOSE includes
 #include "MooseMesh.h"
 #include "ThreadedNodeLoop.h"
-
-// Forward declarations
-class DisplacedProblem;
-class AllNodesSendListThread;
 
 // libMesh forward declarations
 namespace libMesh
@@ -31,16 +27,16 @@ class NumericVector;
 }
 
 class AllNodesSendListThread
-    : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>
+    : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
 {
 public:
-  AllNodesSendListThread(FEProblemBase & fe_problem, MooseMesh & mesh,
+  AllNodesSendListThread(FEProblemBase & fe_problem, const MooseMesh & mesh,
                          const std::vector<unsigned int> & var_nums,
-                         unsigned int system_number);
+                         const System &system);
 
   AllNodesSendListThread(AllNodesSendListThread & x, Threads::split split);
 
-  virtual void onNode(NodeRange::const_iterator & nd) override;
+  virtual void onNode(ConstNodeRange::const_iterator & nd) override;
 
   void join(const AllNodesSendListThread & y);
 
@@ -51,14 +47,18 @@ public:
   const std::vector<dof_id_type> & send_list() const;
 
 protected:
-  MooseMesh & _ref_mesh;
+  const MooseMesh & _ref_mesh;
 
 private:
-  const std::vector<unsigned int> & _var_nums;
+  std::vector<unsigned int> _var_nums;
+
+  const System & _system;
 
   const unsigned int _system_number;
+
+  const dof_id_type _first_dof, _end_dof;
 
   std::vector<dof_id_type> _send_list;
 };
 
-#endif /* UPDATEDISPLACEDMESHTHREAD_H */
+#endif /* ALLNODESSENDLISTTHREAD_H */

--- a/framework/include/base/AllNodesSendListThread.h
+++ b/framework/include/base/AllNodesSendListThread.h
@@ -30,9 +30,10 @@ class AllNodesSendListThread
     : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
 {
 public:
-  AllNodesSendListThread(FEProblemBase & fe_problem, const MooseMesh & mesh,
+  AllNodesSendListThread(FEProblemBase & fe_problem,
+                         const MooseMesh & mesh,
                          const std::vector<unsigned int> & var_nums,
-                         const System &system);
+                         const System & system);
 
   AllNodesSendListThread(AllNodesSendListThread & x, Threads::split split);
 

--- a/framework/include/base/AllNodesSendListThread.h
+++ b/framework/include/base/AllNodesSendListThread.h
@@ -1,0 +1,64 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef UPDATEDISPLACEDMESHTHREAD_H
+#define UPDATEDISPLACEDMESHTHREAD_H
+
+// MOOSE includes
+#include "MooseMesh.h"
+#include "ThreadedNodeLoop.h"
+
+// Forward declarations
+class DisplacedProblem;
+class AllNodesSendListThread;
+
+// libMesh forward declarations
+namespace libMesh
+{
+template <typename T>
+class NumericVector;
+}
+
+class AllNodesSendListThread
+    : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>
+{
+public:
+  AllNodesSendListThread(FEProblemBase & fe_problem, MooseMesh & mesh,
+                         const std::vector<unsigned int> & var_nums,
+                         unsigned int system_number);
+
+  AllNodesSendListThread(AllNodesSendListThread & x, Threads::split split);
+
+  virtual void onNode(NodeRange::const_iterator & nd) override;
+
+  void join(const AllNodesSendListThread & y);
+
+  // Make the list sorted and ensure each entry is unique
+  void unique();
+
+  // Return the send_list
+  const std::vector<dof_id_type> & send_list() const;
+
+protected:
+  MooseMesh & _ref_mesh;
+
+private:
+  const std::vector<unsigned int> & _var_nums;
+
+  const unsigned int _system_number;
+
+  std::vector<dof_id_type> _send_list;
+};
+
+#endif /* UPDATEDISPLACEDMESHTHREAD_H */

--- a/framework/include/base/UpdateDisplacedMeshThread.h
+++ b/framework/include/base/UpdateDisplacedMeshThread.h
@@ -30,8 +30,7 @@ template <typename T>
 class NumericVector;
 }
 
-class UpdateDisplacedMeshThread
-    : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>
+class UpdateDisplacedMeshThread : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>
 {
 public:
   UpdateDisplacedMeshThread(FEProblemBase & fe_problem, DisplacedProblem & displaced_problem);
@@ -43,7 +42,6 @@ public:
   void join(const UpdateDisplacedMeshThread & /*y*/);
 
 protected:
-
   void init();
 
   DisplacedProblem & _displaced_problem;
@@ -54,8 +52,8 @@ protected:
   // Solution vectors with expanded ghosting, for ReplicatedMesh or
   // for DistributedMesh cases where the standard algebraic ghosting
   // doesn't reach as far as the geometric ghosting
-  std::shared_ptr<NumericVector<Number> > _nl_ghosted_soln;
-  std::shared_ptr<NumericVector<Number> > _aux_ghosted_soln;
+  std::shared_ptr<NumericVector<Number>> _nl_ghosted_soln;
+  std::shared_ptr<NumericVector<Number>> _aux_ghosted_soln;
 
 private:
   std::vector<unsigned int> _var_nums;

--- a/framework/include/base/UpdateDisplacedMeshThread.h
+++ b/framework/include/base/UpdateDisplacedMeshThread.h
@@ -31,24 +31,31 @@ class NumericVector;
 }
 
 class UpdateDisplacedMeshThread
-    : public ThreadedNodeLoop<SemiLocalNodeRange, SemiLocalNodeRange::const_iterator>
+    : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>
 {
 public:
   UpdateDisplacedMeshThread(FEProblemBase & fe_problem, DisplacedProblem & displaced_problem);
 
   UpdateDisplacedMeshThread(UpdateDisplacedMeshThread & x, Threads::split split);
 
-  virtual void pre() override;
-
-  virtual void onNode(SemiLocalNodeRange::const_iterator & nd) override;
+  virtual void onNode(NodeRange::const_iterator & nd) override;
 
   void join(const UpdateDisplacedMeshThread & /*y*/);
 
 protected:
+
+  void init();
+
   DisplacedProblem & _displaced_problem;
   MooseMesh & _ref_mesh;
   const NumericVector<Number> & _nl_soln;
   const NumericVector<Number> & _aux_soln;
+
+  // Solution vectors with expanded ghosting, for ReplicatedMesh or
+  // for DistributedMesh cases where the standard algebraic ghosting
+  // doesn't reach as far as the geometric ghosting
+  std::shared_ptr<NumericVector<Number> > _nl_ghosted_soln;
+  std::shared_ptr<NumericVector<Number> > _aux_ghosted_soln;
 
 private:
   std::vector<unsigned int> _var_nums;

--- a/framework/src/base/AllNodesSendListThread.C
+++ b/framework/src/base/AllNodesSendListThread.C
@@ -32,19 +32,15 @@ AllNodesSendListThread::AllNodesSendListThread(FEProblemBase & fe_problem,
 {
   // We may use the same _var_num multiple times, but it's inefficient
   // to examine it multiple times.
-  std::sort(this->_var_nums.begin(),
-            this->_var_nums.end());
+  std::sort(this->_var_nums.begin(), this->_var_nums.end());
 
   std::vector<dof_id_type>::iterator new_end =
-    std::unique (this->_var_nums.begin(),
-                 this->_var_nums.end());
+      std::unique(this->_var_nums.begin(), this->_var_nums.end());
 
-  std::vector<dof_id_type>
-    (this->_var_nums.begin(), new_end).swap (this->_var_nums);
+  std::vector<dof_id_type>(this->_var_nums.begin(), new_end).swap(this->_var_nums);
 }
 
-AllNodesSendListThread::AllNodesSendListThread(AllNodesSendListThread & x,
-                                               Threads::split split)
+AllNodesSendListThread::AllNodesSendListThread(AllNodesSendListThread & x, Threads::split split)
   : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(x, split),
     _ref_mesh(x._ref_mesh),
     _var_nums(x._var_nums),
@@ -76,9 +72,7 @@ void
 AllNodesSendListThread::join(const AllNodesSendListThread & y)
 {
   // Joining simply requires I add the dof indices from the other object
-  this->_send_list.insert(this->_send_list.end(),
-                          y._send_list.begin(),
-                          y._send_list.end());
+  this->_send_list.insert(this->_send_list.end(), y._send_list.begin(), y._send_list.end());
 }
 
 void
@@ -86,8 +80,7 @@ AllNodesSendListThread::unique()
 {
   // Sort the send list.  After this duplicated
   // elements will be adjacent in the vector
-  std::sort(this->_send_list.begin(),
-            this->_send_list.end());
+  std::sort(this->_send_list.begin(), this->_send_list.end());
 
   // Now use std::unique to remove any duplicate entries.  There
   // actually shouldn't be any, since we're hitting each node exactly

--- a/framework/src/base/AllNodesSendListThread.C
+++ b/framework/src/base/AllNodesSendListThread.C
@@ -1,0 +1,90 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "AllNodesSendListThread.h"
+#include "DisplacedProblem.h"
+#include "MooseMesh.h"
+#include "SubProblem.h"
+
+AllNodesSendListThread::AllNodesSendListThread(FEProblemBase & fe_problem,
+                                               MooseMesh & mesh,
+                                               const std::vector<unsigned int> & var_nums,
+                                               unsigned int system_number)
+  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>(fe_problem),
+    _ref_mesh(mesh),
+    _var_nums(var_nums),
+    _system_number(system_number),
+    _send_list()
+{
+}
+
+AllNodesSendListThread::AllNodesSendListThread(AllNodesSendListThread & x,
+                                               Threads::split split)
+  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>(x, split),
+    _ref_mesh(x._ref_mesh),
+    _var_nums(x._var_nums),
+    _system_number(x._system_number),
+    _send_list()
+{
+}
+
+void
+AllNodesSendListThread::onNode(NodeRange::const_iterator & nd)
+{
+  Node & displaced_node = *(*nd);
+
+  Node & reference_node = _ref_mesh.nodeRef(displaced_node.id());
+
+  for (unsigned int i = 0; i < _var_nums.size(); i++)
+  {
+    if (reference_node.n_dofs(_system_number, _var_nums[i]) > 0)
+      this->_send_list.push_back(reference_node.dof_number(_system_number, _var_nums[i], 0));
+  }
+}
+
+void
+AllNodesSendListThread::join(const AllNodesSendListThread & y)
+{
+  // Joining simply requires I add the dof indices from the other object
+  this->_send_list.insert(this->_send_list.end(),
+                          y._send_list.begin(),
+                          y._send_list.end());
+}
+
+void
+AllNodesSendListThread::unique()
+{
+  // Sort the send list.  After this duplicated
+  // elements will be adjacent in the vector
+  std::sort(this->_send_list.begin(),
+            this->_send_list.end());
+
+  // Now use std::unique to remove any duplicate entries?  There actually
+  // shouldn't be any, since we're hitting each node exactly once.
+  // std::vector<dof_id_type>::iterator new_end =
+  //   std::unique (this->_send_list.begin(),
+  //                this->_send_list.end());
+
+  // If we *do* need to remove duplicate entries, then afterward we should
+  // remove the end of the send_list, using the "swap trick" from Effective
+  // STL.
+  // std::vector<dof_id_type>
+  //  (this->send_list.begin(), new_end).swap (this->send_list);
+}
+
+const std::vector<dof_id_type> &
+AllNodesSendListThread::send_list() const
+{
+  return this->_send_list;
+}

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -188,12 +188,10 @@ DisplacedProblem::updateMesh()
   // the reference mesh to be also.  For that matter, did anyone
   // somehow serialize the whole mesh?  Hopefully not but let's avoid
   // causing errors if so.
-  if (_mesh.getMesh().is_serial() &&
-      !this->refMesh().getMesh().is_serial())
+  if (_mesh.getMesh().is_serial() && !this->refMesh().getMesh().is_serial())
     this->refMesh().getMesh().allgather();
 
-  if (_mesh.getMesh().is_serial_on_zero() &&
-      !this->refMesh().getMesh().is_serial_on_zero())
+  if (_mesh.getMesh().is_serial_on_zero() && !this->refMesh().getMesh().is_serial_on_zero())
     this->refMesh().getMesh().gather_to_zero();
 
   UpdateDisplacedMeshThread udmt(_mproblem, *this);

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -198,7 +198,13 @@ DisplacedProblem::updateMesh()
 
   UpdateDisplacedMeshThread udmt(_mproblem, *this);
 
-  Threads::parallel_reduce(*_mesh.getActiveSemiLocalNodeRange(), udmt);
+  // We displace all nodes, not just semilocal nodes, because
+  // parallel-inconsistent mesh geometry makes libMesh cry.
+  NodeRange node_range(_mesh.getMesh().nodes_begin(),
+                       _mesh.getMesh().nodes_end(),
+                       /*grainsize=*/1);
+
+  Threads::parallel_reduce(node_range, udmt);
 
   // Update the geometric searches that depend on the displaced mesh
   _geometric_search_data.update();
@@ -227,7 +233,13 @@ DisplacedProblem::updateMesh(const NumericVector<Number> & soln,
 
   UpdateDisplacedMeshThread udmt(_mproblem, *this);
 
-  Threads::parallel_reduce(*_mesh.getActiveSemiLocalNodeRange(), udmt);
+  // We displace all nodes, not just semilocal nodes, because
+  // parallel-inconsistent mesh geometry makes libMesh cry.
+  NodeRange node_range(_mesh.getMesh().nodes_begin(),
+                       _mesh.getMesh().nodes_end(),
+                       /*grainsize=*/1);
+
+  Threads::parallel_reduce(node_range, udmt);
 
   // Update the geometric searches that depend on the displaced mesh
   _geometric_search_data.update();

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -183,6 +183,19 @@ DisplacedProblem::updateMesh()
   _nl_solution = _mproblem.getNonlinearSystemBase().currentSolution();
   _aux_solution = _mproblem.getAuxiliarySystem().currentSolution();
 
+  // If the displaced mesh has been serialized to one processor (as
+  // may have occurred if it was used for Exodus output), then we need
+  // the reference mesh to be also.  For that matter, did anyone
+  // somehow serialize the whole mesh?  Hopefully not but let's avoid
+  // causing errors if so.
+  if (_mesh.getMesh().is_serial() &&
+      !this->refMesh().getMesh().is_serial())
+    this->refMesh().getMesh().allgather();
+
+  if (_mesh.getMesh().is_serial_on_zero() &&
+      !this->refMesh().getMesh().is_serial_on_zero())
+    this->refMesh().getMesh().gather_to_zero();
+
   UpdateDisplacedMeshThread udmt(_mproblem, *this);
 
   Threads::parallel_reduce(*_mesh.getActiveSemiLocalNodeRange(), udmt);

--- a/framework/src/base/UpdateDisplacedMeshThread.C
+++ b/framework/src/base/UpdateDisplacedMeshThread.C
@@ -96,23 +96,25 @@ UpdateDisplacedMeshThread::init()
   _num_var_nums = _var_nums.size();
   _num_aux_var_nums = _aux_var_nums.size();
 
-  ConstNodeRange node_range (_ref_mesh.getMesh().nodes_begin(), _ref_mesh.getMesh().nodes_end());
+  ConstNodeRange node_range(_ref_mesh.getMesh().nodes_begin(), _ref_mesh.getMesh().nodes_end());
 
   {
-    AllNodesSendListThread nl_send_list(this->_fe_problem, _ref_mesh, _var_nums, _displaced_problem._displaced_nl.sys());
+    AllNodesSendListThread nl_send_list(
+        this->_fe_problem, _ref_mesh, _var_nums, _displaced_problem._displaced_nl.sys());
     Threads::parallel_reduce(node_range, nl_send_list);
     nl_send_list.unique();
-    _nl_ghosted_soln->init (_nl_soln.size(), _nl_soln.local_size(),
-                            nl_send_list.send_list(), GHOSTED);
+    _nl_ghosted_soln->init(
+        _nl_soln.size(), _nl_soln.local_size(), nl_send_list.send_list(), GHOSTED);
     _nl_soln.localize(*_nl_ghosted_soln, nl_send_list.send_list());
   }
 
   {
-    AllNodesSendListThread aux_send_list(this->_fe_problem, _ref_mesh, _aux_var_nums, _displaced_problem._displaced_aux.sys());
+    AllNodesSendListThread aux_send_list(
+        this->_fe_problem, _ref_mesh, _aux_var_nums, _displaced_problem._displaced_aux.sys());
     Threads::parallel_reduce(node_range, aux_send_list);
     aux_send_list.unique();
-    _aux_ghosted_soln->init (_aux_soln.size(), _aux_soln.local_size(),
-                            aux_send_list.send_list(), GHOSTED);
+    _aux_ghosted_soln->init(
+        _aux_soln.size(), _aux_soln.local_size(), aux_send_list.send_list(), GHOSTED);
     _aux_soln.localize(*_aux_ghosted_soln, aux_send_list.send_list());
   }
 }

--- a/framework/src/base/UpdateDisplacedMeshThread.C
+++ b/framework/src/base/UpdateDisplacedMeshThread.C
@@ -13,48 +13,56 @@
 /****************************************************************/
 
 #include "UpdateDisplacedMeshThread.h"
+
+#include "AllNodesSendListThread.h"
 #include "DisplacedProblem.h"
 #include "MooseMesh.h"
-#include "SubProblem.h"
+
+#include "libmesh/numeric_vector.h"
 
 UpdateDisplacedMeshThread::UpdateDisplacedMeshThread(FEProblemBase & fe_problem,
                                                      DisplacedProblem & displaced_problem)
-  : ThreadedNodeLoop<SemiLocalNodeRange, SemiLocalNodeRange::const_iterator>(fe_problem),
+  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>(fe_problem),
     _displaced_problem(displaced_problem),
     _ref_mesh(_displaced_problem.refMesh()),
     _nl_soln(*_displaced_problem._nl_solution),
     _aux_soln(*_displaced_problem._aux_solution),
+    _nl_ghosted_soln(NumericVector<Number>::build(_nl_soln.comm()).release()),
+    _aux_ghosted_soln(NumericVector<Number>::build(_aux_soln.comm()).release()),
     _var_nums(0),
     _var_nums_directions(0),
     _aux_var_nums(0),
     _aux_var_nums_directions(0),
     _num_var_nums(0),
     _num_aux_var_nums(0),
-    _nonlinear_system_number(0),
-    _aux_system_number(0)
+    _nonlinear_system_number(_displaced_problem._displaced_nl.sys().number()),
+    _aux_system_number(_displaced_problem._displaced_aux.sys().number())
 {
+  this->init();
 }
 
 UpdateDisplacedMeshThread::UpdateDisplacedMeshThread(UpdateDisplacedMeshThread & x,
                                                      Threads::split split)
-  : ThreadedNodeLoop<SemiLocalNodeRange, SemiLocalNodeRange::const_iterator>(x, split),
+  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>(x, split),
     _displaced_problem(x._displaced_problem),
     _ref_mesh(x._ref_mesh),
     _nl_soln(x._nl_soln),
     _aux_soln(x._aux_soln),
-    _var_nums(0),
-    _var_nums_directions(0),
-    _aux_var_nums(0),
-    _aux_var_nums_directions(0),
-    _num_var_nums(0),
-    _num_aux_var_nums(0),
-    _nonlinear_system_number(0),
-    _aux_system_number(0)
+    _nl_ghosted_soln(x._nl_ghosted_soln),
+    _aux_ghosted_soln(x._aux_ghosted_soln),
+    _var_nums(x._var_nums),
+    _var_nums_directions(x._var_nums_directions),
+    _aux_var_nums(x._aux_var_nums),
+    _aux_var_nums_directions(x._aux_var_nums_directions),
+    _num_var_nums(x._num_var_nums),
+    _num_aux_var_nums(x._num_aux_var_nums),
+    _nonlinear_system_number(x._nonlinear_system_number),
+    _aux_system_number(x._aux_system_number)
 {
 }
 
 void
-UpdateDisplacedMeshThread::pre()
+UpdateDisplacedMeshThread::init()
 {
   std::vector<std::string> & displacement_variables = _displaced_problem._displacements;
   unsigned int num_displacements = displacement_variables.size();
@@ -88,12 +96,29 @@ UpdateDisplacedMeshThread::pre()
   _num_var_nums = _var_nums.size();
   _num_aux_var_nums = _aux_var_nums.size();
 
-  _nonlinear_system_number = _displaced_problem._displaced_nl.sys().number();
-  _aux_system_number = _displaced_problem._displaced_aux.sys().number();
+  ConstNodeRange node_range (_ref_mesh.getMesh().nodes_begin(), _ref_mesh.getMesh().nodes_end());
+
+  {
+    AllNodesSendListThread nl_send_list(this->_fe_problem, _ref_mesh, _var_nums, _displaced_problem._displaced_nl.sys());
+    Threads::parallel_reduce(node_range, nl_send_list);
+    nl_send_list.unique();
+    _nl_ghosted_soln->init (_nl_soln.size(), _nl_soln.local_size(),
+                            nl_send_list.send_list(), GHOSTED);
+    _nl_soln.localize(*_nl_ghosted_soln, nl_send_list.send_list());
+  }
+
+  {
+    AllNodesSendListThread aux_send_list(this->_fe_problem, _ref_mesh, _aux_var_nums, _displaced_problem._displaced_aux.sys());
+    Threads::parallel_reduce(node_range, aux_send_list);
+    aux_send_list.unique();
+    _aux_ghosted_soln->init (_aux_soln.size(), _aux_soln.local_size(),
+                            aux_send_list.send_list(), GHOSTED);
+    _aux_soln.localize(*_aux_ghosted_soln, aux_send_list.send_list());
+  }
 }
 
 void
-UpdateDisplacedMeshThread::onNode(SemiLocalNodeRange::const_iterator & nd)
+UpdateDisplacedMeshThread::onNode(NodeRange::const_iterator & nd)
 {
   Node & displaced_node = *(*nd);
 
@@ -105,7 +130,7 @@ UpdateDisplacedMeshThread::onNode(SemiLocalNodeRange::const_iterator & nd)
     if (reference_node.n_dofs(_nonlinear_system_number, _var_nums[i]) > 0)
       displaced_node(direction) =
           reference_node(direction) +
-          _nl_soln(reference_node.dof_number(_nonlinear_system_number, _var_nums[i], 0));
+          (*_nl_ghosted_soln)(reference_node.dof_number(_nonlinear_system_number, _var_nums[i], 0));
   }
 
   for (unsigned int i = 0; i < _num_aux_var_nums; i++)
@@ -114,7 +139,7 @@ UpdateDisplacedMeshThread::onNode(SemiLocalNodeRange::const_iterator & nd)
     if (reference_node.n_dofs(_aux_system_number, _aux_var_nums[i]) > 0)
       displaced_node(direction) =
           reference_node(direction) +
-          _aux_soln(reference_node.dof_number(_aux_system_number, _aux_var_nums[i], 0));
+          (*_aux_ghosted_soln)(reference_node.dof_number(_aux_system_number, _aux_var_nums[i], 0));
   }
 }
 


### PR DESCRIPTION
This incorporates a necessary libMesh submodule update from #9633, and shouldn't be merged until/unless that is.

The rest of this PR changes the behavior of updateDisplacedMesh to fix the bugs reported (and the bugs speculated about, hopefully) in #9626.  The remote-vs-serialized status of reference mesh entities is now kept more closely in sync with displaced mesh entities, and the position of all displaced mesh nodes is now kept perfectly in sync between processors.  We create a custom send_list for displacement variables and use it to create temporary ghosted vectors, to avoid any overcommunication during the displacement update step.

This fixes #9626 in my materials/output.block_displaced recovery tests, on 1 through 24 processors.