### PR TITLE
Clear caches in DiracKernel::meshChanged()

### DIFF
--- a/framework/include/dirackernels/DiracKernel.h
+++ b/framework/include/dirackernels/DiracKernel.h
@@ -115,6 +115,13 @@ public:
    */
   void clearPoints();
 
+  /**
+   * Clear point cache when the mesh changes, so that element
+   * coarsening, element deletion, and distributed mesh repartitioning
+   * don't leave this with an invalid cache.
+   */
+  virtual void meshChanged() override;
+
 protected:
   /**
    * This is the virtual that derived classes should override for computing the residual.

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -435,6 +435,13 @@ DiracKernel::clearPoints()
   _local_dirac_kernel_info.clearPoints();
 }
 
+void
+DiracKernel::meshChanged()
+{
+  _point_cache.clear();
+  _reverse_point_cache.clear();
+}
+
 MooseVariable &
 DiracKernel::variable()
 {


### PR DESCRIPTION
This prevents our caches from ending up with dangling pointers to
coarsened, remoted, or otherwise deleted Elem objects.

This fixes #9592 for me -
dirackernels/point_caching.point_caching_adaptive_refinement now works
for me on 1 through 24 processors.