### PR TITLE
BoundingBoxNodeSet may not find nodes on all procs

### DIFF
--- a/framework/src/meshmodifiers/BoundingBoxNodeSet.C
+++ b/framework/src/meshmodifiers/BoundingBoxNodeSet.C
@@ -74,6 +74,10 @@ BoundingBoxNodeSet::modify()
     }
   }
 
+  // Unless at least one processor found a node in the bounding box,
+  // the user probably specified it incorrectly.
+  this->comm().max(found_node);
+
   if (!found_node)
     mooseError("No nodes found within the bounding box");
 


### PR DESCRIPTION
And if it doesn't, that's not an error, so long as it finds nodes on
at least *some* processor.

This fixes another #1500 test failure
(block_deleter.BlockDeleterTest8_part1, on 13+ processors) for me.