### PR TITLE
Tighter postprocessor_to_scalar solver tolerance

### DIFF
--- a/test/tests/transfers/multiapp_postprocessor_to_scalar/master.i
+++ b/test/tests/transfers/multiapp_postprocessor_to_scalar/master.i
@@ -50,6 +50,8 @@
   num_steps = 5
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]

--- a/test/tests/transfers/multiapp_postprocessor_to_scalar/sub.i
+++ b/test/tests/transfers/multiapp_postprocessor_to_scalar/sub.i
@@ -58,6 +58,8 @@
   dt = 1
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
+
+  nl_rel_tol = 1e-12
 []
 
 [Outputs]


### PR DESCRIPTION
This fixes an exodiff of ~1.7e-9 on 24 processors for me (when testing with --distributed-mesh --recover), which should be useful if we ever start regularly running #8410 tests so far out.