### PR TITLE
Scalar output fix

### DIFF
--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -265,7 +265,7 @@ Exodus::outputScalarVariables()
     value.resize(n);
 
     const DofMap & dof_map = scalar_var.sys().dofMap();
-    for (unsigned int i=0; i != n; ++i)
+    for (unsigned int i = 0; i != n; ++i)
     {
       const processor_id_type pid = dof_map.dof_owner(dof_indices[i]);
       this->comm().broadcast(value[i], pid);

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -252,14 +252,30 @@ Exodus::outputScalarVariables()
   // Append the scalar to the global output lists
   for (const auto & out_name : out)
   {
-    VariableValue & variable = _problem_ptr->getScalarVariable(0, out_name).sln();
-    unsigned int n = variable.size();
+    // Make sure scalar values are in sync with the solution vector
+    // and are visible on this processor.  See TableOutput.C for
+    // TableOutput::outputScalarVariables() explanatory comments
+
+    MooseVariableScalar & scalar_var = _problem_ptr->getScalarVariable(0, out_name);
+    scalar_var.reinit();
+    VariableValue value = scalar_var.sln();
+
+    const std::vector<dof_id_type> & dof_indices = scalar_var.dofIndices();
+    const unsigned int n = dof_indices.size();
+    value.resize(n);
+
+    const DofMap & dof_map = scalar_var.sys().dofMap();
+    for (unsigned int i=0; i != n; ++i)
+    {
+      const processor_id_type pid = dof_map.dof_owner(dof_indices[i]);
+      this->comm().broadcast(value[i], pid);
+    }
 
     // If the scalar has a single component, output the name directly
     if (n == 1)
     {
       _global_names.push_back(out_name);
-      _global_values.push_back(variable[0]);
+      _global_values.push_back(value[0]);
     }
 
     // If the scalar as many components add indices to the end of the name
@@ -270,7 +286,7 @@ Exodus::outputScalarVariables()
         std::ostringstream os;
         os << out_name << "_" << i;
         _global_names.push_back(os.str());
-        _global_values.push_back(variable[i]);
+        _global_values.push_back(value[i]);
       }
     }
   }

--- a/framework/src/outputs/Nemesis.C
+++ b/framework/src/outputs/Nemesis.C
@@ -19,8 +19,10 @@
 #include "MooseApp.h"
 #include "MooseMesh.h"
 #include "MooseVariableScalar.h"
+#include "SystemBase.h"
 
 // libMesh includes
+#include "libmesh/dof_map.h"
 #include "libmesh/nemesis_io.h"
 
 template <>
@@ -102,14 +104,30 @@ Nemesis::outputScalarVariables()
   // Append the scalar to the global output lists
   for (const auto & out_name : out)
   {
-    VariableValue & variable = _problem_ptr->getScalarVariable(0, out_name).sln();
-    unsigned int n = variable.size();
+    // Make sure scalar values are in sync with the solution vector
+    // and are visible on this processor.  See TableOutput.C for
+    // TableOutput::outputScalarVariables() explanatory comments
+
+    MooseVariableScalar & scalar_var = _problem_ptr->getScalarVariable(0, out_name);
+    scalar_var.reinit();
+    VariableValue value = scalar_var.sln();
+
+    const std::vector<dof_id_type> & dof_indices = scalar_var.dofIndices();
+    const unsigned int n = dof_indices.size();
+    value.resize(n);
+
+    const DofMap & dof_map = scalar_var.sys().dofMap();
+    for (unsigned int i=0; i != n; ++i)
+    {
+      const processor_id_type pid = dof_map.dof_owner(dof_indices[i]);
+      this->comm().broadcast(value[i], pid);
+    }
 
     // If the scalar has a single component, output the name directly
     if (n == 1)
     {
       _global_names.push_back(out_name);
-      _global_values.push_back(variable[0]);
+      _global_values.push_back(value[0]);
     }
 
     // If the scalar as many components add indices to the end of the name
@@ -120,7 +138,7 @@ Nemesis::outputScalarVariables()
         std::ostringstream os;
         os << out_name << "_" << i;
         _global_names.push_back(os.str());
-        _global_values.push_back(variable[i]);
+        _global_values.push_back(value[i]);
       }
     }
   }

--- a/framework/src/outputs/Nemesis.C
+++ b/framework/src/outputs/Nemesis.C
@@ -117,7 +117,7 @@ Nemesis::outputScalarVariables()
     value.resize(n);
 
     const DofMap & dof_map = scalar_var.sys().dofMap();
-    for (unsigned int i=0; i != n; ++i)
+    for (unsigned int i = 0; i != n; ++i)
     {
       const processor_id_type pid = dof_map.dof_owner(dof_indices[i]);
       this->comm().broadcast(value[i], pid);

--- a/framework/src/outputs/TableOutput.C
+++ b/framework/src/outputs/TableOutput.C
@@ -176,7 +176,7 @@ TableOutput::outputScalarVariables()
     // code path shouldn't be hit often enough for that to matter.
 
     const DofMap & dof_map = scalar_var.sys().dofMap();
-    for (unsigned int i=0; i != n; ++i)
+    for (unsigned int i = 0; i != n; ++i)
     {
       const processor_id_type pid = dof_map.dof_owner(dof_indices[i]);
       this->comm().broadcast(value[i], pid);


### PR DESCRIPTION
This fix depends on the libMesh updates in #9633, and shouldn't be merged until/unless that is.

This fixes a CSVDIFF failure for me on 15 processors in
postprocessors/scalar_coupled_postprocessor.test, when a processor
with no nodes thus also has no direct access to SCALAR variable
values.  This fixes the last #1500 failure I can see.  This should
also fix (rare!) real-world use cases of restricted SCALAR coupling as
described in #9450.