### PR TITLE
Finalized output not sorting correctly

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -454,7 +454,7 @@ class TestHarness:
         # tests as they were running
         if (self.options.verbose or (self.num_failed != 0 and not self.options.quiet)) and not self.options.dry_run:
             print('\n\nFinal Test Results:\n' + ('-' * (util.TERM_COLS-1)))
-            for (tester_data, result, timing) in sorted(self.test_table, key=lambda x: x[2], reverse=True):
+            for (tester_data, result, timing) in sorted(self.test_table, key=lambda x: x[1], reverse=True):
                 print(util.formatResult(tester_data, result, self.options))
 
         time = clock() - self.start_time

--- a/python/TestHarness/schedulers/TesterData.py
+++ b/python/TestHarness/schedulers/TesterData.py
@@ -113,7 +113,7 @@ class TesterData(object):
             return self.getActiveTime()
         elif self.getEndTime() and self.getStartTime():
             return self.getEndTime() - self.getStartTime()
-        elif self.getStartTime():
+        elif self.getStartTime() and self.__tester.isPending():
             # If the test is still running, return current run time instead
             return max(0.0, clock() - self.getStartTime())
         else:


### PR DESCRIPTION
Tests which fail was not being sorted correctly.
Timing on skipped tests is incorrect when printed to the screen a second
time (during finalized output).

Refs #9683

