### PR TITLE
Fix deprecated method usage, const-correctness, memory leak

### DIFF
--- a/framework/include/geomsearch/PenetrationInfo.h
+++ b/framework/include/geomsearch/PenetrationInfo.h
@@ -38,7 +38,7 @@ class PenetrationInfo
 public:
   PenetrationInfo(const Node * node,
                   const Elem * elem,
-                  Elem * side,
+                  const Elem * side,
                   unsigned int side_num,
                   RealVectorValue norm,
                   Real norm_distance,
@@ -78,7 +78,7 @@ public:
 
   const Node * _node;
   const Elem * _elem;
-  Elem * _side;
+  const Elem * _side;
   unsigned int _side_num;
   RealVectorValue _normal;
   Real _distance; // Positive distance means the node has penetrated

--- a/framework/include/geomsearch/PenetrationInfo.h
+++ b/framework/include/geomsearch/PenetrationInfo.h
@@ -53,8 +53,8 @@ public:
                   const std::vector<RealGradient> & dxyzdeta,
                   const std::vector<RealGradient> & d2xyzdxideta);
 
-// Not currently supported due to double-delete memory corruption bug
-//  PenetrationInfo(const PenetrationInfo & p);
+  // Not currently supported due to double-delete memory corruption bug
+  //  PenetrationInfo(const PenetrationInfo & p);
 
   PenetrationInfo();
 

--- a/framework/include/geomsearch/PenetrationInfo.h
+++ b/framework/include/geomsearch/PenetrationInfo.h
@@ -53,7 +53,8 @@ public:
                   const std::vector<RealGradient> & dxyzdeta,
                   const std::vector<RealGradient> & d2xyzdxideta);
 
-  PenetrationInfo(const PenetrationInfo & p);
+// Not currently supported due to double-delete memory corruption bug
+//  PenetrationInfo(const PenetrationInfo & p);
 
   PenetrationInfo();
 

--- a/framework/include/geomsearch/PenetrationThread.h
+++ b/framework/include/geomsearch/PenetrationThread.h
@@ -115,12 +115,12 @@ protected:
                              const unsigned int index1,
                              const unsigned int index2);
 
-  void getSideCornerNodes(Elem * side, std::vector<Node *> & corner_nodes);
+  void getSideCornerNodes(const Elem * side, std::vector<const Node *> & corner_nodes);
 
   bool restrictPointToSpecifiedEdgeOfFace(Point & p,
                                           const Node *& closest_node,
                                           const Elem * side,
-                                          const std::vector<Node *> & edge_nodes);
+                                          const std::vector<const Node *> & edge_nodes);
   bool restrictPointToFace(Point & p, const Node *& closest_node, const Elem * side);
 
   bool isFaceReasonableCandidate(const Elem * master_elem,

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -835,7 +835,7 @@ Assembly::reinitNeighborAtPhysical(const Elem * neighbor,
                                    const std::vector<Point> & physical_points)
 {
   delete _current_neighbor_side_elem;
-  _current_neighbor_side_elem = neighbor->build_side(neighbor_side).release();
+  _current_neighbor_side_elem = neighbor->build_side_ptr(neighbor_side).release();
 
   std::vector<Point> reference_points;
 

--- a/framework/src/constraints/FaceFaceConstraint.C
+++ b/framework/src/constraints/FaceFaceConstraint.C
@@ -95,7 +95,8 @@ FaceFaceConstraint::reinit()
 
     if (master_pinfo && slave_pinfo)
     {
-      const Elem * master_side = master_pinfo->_elem->build_side_ptr(master_pinfo->_side_num, true).release();
+      const Elem * master_side =
+          master_pinfo->_elem->build_side_ptr(master_pinfo->_side_num, true).release();
 
       std::vector<std::vector<Real>> & master_side_phi = master_pinfo->_side_phi;
       std::vector<std::vector<RealGradient>> & master_side_grad_phi = master_pinfo->_side_grad_phi;
@@ -107,7 +108,8 @@ FaceFaceConstraint::reinit()
       _elem_master = master_pinfo->_elem;
       delete master_side;
 
-      const Elem * slave_side = slave_pinfo->_elem->build_side_ptr(slave_pinfo->_side_num, true).release();
+      const Elem * slave_side =
+          slave_pinfo->_elem->build_side_ptr(slave_pinfo->_side_num, true).release();
       std::vector<std::vector<Real>> & slave_side_phi = slave_pinfo->_side_phi;
       std::vector<std::vector<RealGradient>> & slave_side_grad_phi = slave_pinfo->_side_grad_phi;
       mooseAssert(slave_side_phi.size() == slave_side_grad_phi.size(),

--- a/framework/src/constraints/FaceFaceConstraint.C
+++ b/framework/src/constraints/FaceFaceConstraint.C
@@ -95,7 +95,7 @@ FaceFaceConstraint::reinit()
 
     if (master_pinfo && slave_pinfo)
     {
-      Elem * master_side = master_pinfo->_elem->build_side(master_pinfo->_side_num, true).release();
+      const Elem * master_side = master_pinfo->_elem->build_side_ptr(master_pinfo->_side_num, true).release();
 
       std::vector<std::vector<Real>> & master_side_phi = master_pinfo->_side_phi;
       std::vector<std::vector<RealGradient>> & master_side_grad_phi = master_pinfo->_side_grad_phi;
@@ -107,7 +107,7 @@ FaceFaceConstraint::reinit()
       _elem_master = master_pinfo->_elem;
       delete master_side;
 
-      Elem * slave_side = slave_pinfo->_elem->build_side(slave_pinfo->_side_num, true).release();
+      const Elem * slave_side = slave_pinfo->_elem->build_side_ptr(slave_pinfo->_side_num, true).release();
       std::vector<std::vector<Real>> & slave_side_phi = slave_pinfo->_side_phi;
       std::vector<std::vector<RealGradient>> & slave_side_grad_phi = slave_pinfo->_side_grad_phi;
       mooseAssert(slave_side_phi.size() == slave_side_grad_phi.size(),

--- a/framework/src/geomsearch/PenetrationInfo.C
+++ b/framework/src/geomsearch/PenetrationInfo.C
@@ -25,7 +25,7 @@
 
 PenetrationInfo::PenetrationInfo(const Node * node,
                                  const Elem * elem,
-                                 Elem * side,
+                                 const Elem * side,
                                  unsigned int side_num,
                                  RealVectorValue norm,
                                  Real norm_distance,

--- a/framework/src/geomsearch/PenetrationInfo.C
+++ b/framework/src/geomsearch/PenetrationInfo.C
@@ -222,7 +222,7 @@ dataLoad(std::istream & stream, PenetrationInfo *& pinfo, void * context)
     loadHelper(stream, pinfo->_elem, context);
     loadHelper(stream, pinfo->_side_num, context);
     // Rebuild the side element.
-    pinfo->_side = pinfo->_elem->build_side(pinfo->_side_num, false).release();
+    pinfo->_side = pinfo->_elem->build_side_ptr(pinfo->_side_num, false).release();
 
     loadHelper(stream, pinfo->_normal, context);
     loadHelper(stream, pinfo->_distance, context);

--- a/framework/src/geomsearch/PenetrationInfo.C
+++ b/framework/src/geomsearch/PenetrationInfo.C
@@ -75,6 +75,7 @@ PenetrationInfo::PenetrationInfo(const Node * node,
 {
 }
 
+/*
 PenetrationInfo::PenetrationInfo(const PenetrationInfo & p)
   : _node(p._node),
     _elem(p._elem),
@@ -112,6 +113,7 @@ PenetrationInfo::PenetrationInfo(const PenetrationInfo & p)
     _slip_tol(p._slip_tol)
 {
 }
+*/
 
 PenetrationInfo::PenetrationInfo()
   : _node(NULL),

--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -127,7 +127,13 @@ PenetrationLocator::detectPenetration()
 void
 PenetrationLocator::reinit()
 {
+  // Delete the PenetrationInfo objects we own before clearing the
+  // map, or we have a memory leak.
+  for (auto & it : _penetration_info)
+    delete it.second;
+
   _penetration_info.clear();
+
   _has_penetrated.clear();
 
   detectPenetration();

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -1237,7 +1237,8 @@ PenetrationThread::computeSlip(FEBase & fe, PenetrationInfo & info)
   //   original projected position of slave node
   std::vector<Point> points(1);
   points[0] = info._starting_closest_point_ref;
-  std::unique_ptr<const Elem> side = info._starting_elem->build_side_ptr(info._starting_side_num, false);
+  std::unique_ptr<const Elem> side =
+      info._starting_elem->build_side_ptr(info._starting_side_num, false);
   fe.reinit(side.get(), &points);
   const std::vector<Point> & starting_point = fe.get_xyz();
   info._incremental_slip = info._closest_point - starting_point[0];

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -695,16 +695,16 @@ PenetrationThread::findRidgeContactPoint(Point & contact_point,
   mooseAssert(sidedim == pi2->_side->dim(), "Incompatible dimensionalities");
 
   // Nodes on faces for the two interactions
-  std::vector<Node *> side1_nodes;
+  std::vector<const Node *> side1_nodes;
   getSideCornerNodes(pi1->_side, side1_nodes);
-  std::vector<Node *> side2_nodes;
+  std::vector<const Node *> side2_nodes;
   getSideCornerNodes(pi2->_side, side2_nodes);
 
   std::sort(side1_nodes.begin(), side1_nodes.end());
   std::sort(side2_nodes.begin(), side2_nodes.end());
 
   // Find nodes shared by the two faces
-  std::vector<Node *> common_nodes;
+  std::vector<const Node *> common_nodes;
   std::set_intersection(side1_nodes.begin(),
                         side1_nodes.end(),
                         side2_nodes.begin(),
@@ -778,7 +778,7 @@ PenetrationThread::findRidgeContactPoint(Point & contact_point,
 }
 
 void
-PenetrationThread::getSideCornerNodes(Elem * side, std::vector<Node *> & corner_nodes)
+PenetrationThread::getSideCornerNodes(const Elem * side, std::vector<const Node *> & corner_nodes)
 {
   const ElemType t(side->type());
   corner_nodes.clear();
@@ -822,7 +822,7 @@ bool
 PenetrationThread::restrictPointToSpecifiedEdgeOfFace(Point & p,
                                                       const Node *& closest_node,
                                                       const Elem * side,
-                                                      const std::vector<Node *> & edge_nodes)
+                                                      const std::vector<const Node *> & edge_nodes)
 {
   const ElemType t = side->type();
   Real & xi = p(0);

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -1237,7 +1237,7 @@ PenetrationThread::computeSlip(FEBase & fe, PenetrationInfo & info)
   //   original projected position of slave node
   std::vector<Point> points(1);
   points[0] = info._starting_closest_point_ref;
-  std::unique_ptr<Elem> side = info._starting_elem->build_side(info._starting_side_num, false);
+  std::unique_ptr<const Elem> side = info._starting_elem->build_side_ptr(info._starting_side_num, false);
   fe.reinit(side.get(), &points);
   const std::vector<Point> & starting_point = fe.get_xyz();
   info._incremental_slip = info._closest_point - starting_point[0];
@@ -1677,7 +1677,7 @@ PenetrationThread::createInfoForElem(std::vector<PenetrationInfo *> & thisElemIn
     if (already_have_info_this_side)
       break;
 
-    Elem * side = (elem->build_side(sides[i], false)).release();
+    const Elem * side = (elem->build_side_ptr(sides[i], false)).release();
 
     // Only continue with creating info for this side if the side contains
     // all of the nodes in nodes_that_must_be_on_side

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1148,8 +1148,8 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
           unsigned int s_neigh =
               boundary_info.side_with_boundary_id(neigh, periodic->pairedboundary);
 
-          std::unique_ptr<Elem> elem_side = elem->build_side(s);
-          std::unique_ptr<Elem> neigh_side = neigh->build_side(s_neigh);
+          std::unique_ptr<const Elem> elem_side = elem->build_side_ptr(s);
+          std::unique_ptr<const Elem> neigh_side = neigh->build_side_ptr(s_neigh);
 
           // At this point we have matching sides - lets find matching nodes
           for (unsigned int i = 0; i < elem_side->n_nodes(); ++i)
@@ -1158,7 +1158,7 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
             Point master_point = periodic->get_corresponding_pos(*master_node);
             for (unsigned int j = 0; j < neigh_side->n_nodes(); ++j)
             {
-              Node * slave_node = neigh_side->node_ptr(j);
+              const Node * slave_node = neigh_side->node_ptr(j);
               if (master_point.absolute_fuzzy_equals(*slave_node))
               {
                 // Avoid inserting any duplicates
@@ -1347,7 +1347,7 @@ MooseMesh::detectPairedSidesets()
       // If side is on the boundary
       if (elem->neighbor_ptr(s) == nullptr)
       {
-        std::unique_ptr<Elem> side = elem->build_side(s);
+        std::unique_ptr<Elem> side = elem->build_side_ptr(s);
 
         fe_faces[side_dim]->reinit(elem, s);
 

--- a/framework/src/meshmodifiers/MeshSideSet.C
+++ b/framework/src/meshmodifiers/MeshSideSet.C
@@ -68,7 +68,7 @@ MeshSideSet::modify()
       auto s = (*it)->_side;
 
       // build element from the side
-      std::unique_ptr<Elem> side(elem->build_side(s, false));
+      std::unique_ptr<Elem> side(elem->build_side_ptr(s, false));
       side->processor_id() = elem->processor_id();
 
       // Add the side set subdomain

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -855,7 +855,7 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
             if (bc_id_set.find(boundary_id) == bc_id_set.end())
               continue;
 
-            UniquePtr<Elem> side_bdry = elem_bdry->build_side(side, false);
+            UniquePtr<const Elem> side_bdry = elem_bdry->build_side_ptr(side, false);
             evindices.clear();
             dofmap.dof_indices(side_bdry.get(), evindices, v);
             for (const auto & edof : evindices)

--- a/modules/contact/src/FrictionalContactProblem.C
+++ b/modules/contact/src/FrictionalContactProblem.C
@@ -397,7 +397,7 @@ FrictionalContactProblem::enforceRateConstraint(NumericVector<Number> & vec_solu
               // std::vector<Point>points(1);
               // points[0] = info._starting_closest_point_ref;
               // Elem *side =
-              // (info._starting_elem->build_side(info._starting_side_num,false)).release();
+              // (info._starting_elem->build_side_ptr(info._starting_side_num,false)).release();
               // FEBase &fe = *(pen_loc._fe[0]);
               // fe.reinit(side, &points);
               // RealVectorValue correction = starting_point[0] - current_coords;

--- a/modules/heat_conduction/src/bcs/GapHeatTransfer.C
+++ b/modules/heat_conduction/src/bcs/GapHeatTransfer.C
@@ -290,7 +290,7 @@ GapHeatTransfer::computeGapValues()
       _gap_distance = pinfo->_distance;
       _has_info = true;
 
-      Elem * slave_side = pinfo->_side;
+      const Elem * slave_side = pinfo->_side;
       std::vector<std::vector<Real>> & slave_side_phi = pinfo->_side_phi;
       _gap_temp = _variable->getValue(slave_side, slave_side_phi);
 

--- a/modules/heat_conduction/src/materials/GapConductance.C
+++ b/modules/heat_conduction/src/materials/GapConductance.C
@@ -389,7 +389,7 @@ GapConductance::computeGapValues()
       _gap_distance = pinfo->_distance;
       _has_info = true;
 
-      Elem * slave_side = pinfo->_side;
+      const Elem * slave_side = pinfo->_side;
       std::vector<std::vector<Real>> & slave_side_phi = pinfo->_side_phi;
       std::vector<dof_id_type> slave_side_dof_indices;
 

--- a/modules/phase_field/src/mesh/MortarPeriodicMesh.C
+++ b/modules/phase_field/src/mesh/MortarPeriodicMesh.C
@@ -71,7 +71,7 @@ MortarPeriodicMesh::buildMesh()
           auto s = (*it)->_side;
 
           // build element from the side
-          std::unique_ptr<Elem> side(elem->build_side(s, false));
+          std::unique_ptr<Elem> side(elem->build_side_ptr(s, false));
           side->processor_id() = elem->processor_id();
 
           // Add the side set subdomain


### PR DESCRIPTION
This PR is the result of climbing into and out of a deep rabbit hole.

While debugging AMR+contact failures in #6799 I discovered that libMesh ReferenceCounter caught a memory leak of Elem objects.

While investigating the memory leak I discovered that we were still constructing Elem objects (including the leaked objects) via the deprecated build_side() method rather than build_side_ptr().  This PR replaces the deprecated methods with the modern version.

While updating those calls I discovered that a lot of MOOSE code was *relying* on the const-incorrect behavior of build_side().  This PR changes a number of local variables and a few APIs to be const-correct.

While investigating the const correctness I discovered that PenetrationInfo had a copy constructor which is never used internally to MOOSE, and which is basically guaranteed to corrupt memory if it is ever used.  This PR comments that method out.

Finally while examining PenetrationInfo construction and destruction, I hit upon the PenetrationInfo memory leak which was causing the Elem memory leak.  This PR fixes the memory leak.

I think I've successfully managed to "git add --patch" and "git commit" in such a way as to keep the whole bag of changes as logically subdivided as possible and keep earlier comments free of dependencies on later commits.

A few of the API changes in this PR are not backwards-compatible, either because of flaws in C++ (we can't hand a ```vector<Node*>``` to a PenetrationThread method which now expects a ```vector<const Node*>``` because the former doesn't convert to the latter) or flaws in MOOSE (PenetrationInfo is full of raw unencapsulated pointers with nary an accessor among them, and adding const there may break users that assumed non-const).  I fixed the two lines of modules/ code which this broke, but there may be apps code affected too.

I'm still testing to see if this is the last problem with my #6799 update; if so then I'll prepare a PR to fix that shortly.