### PR TITLE
Testharness fixes

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -240,7 +240,7 @@ class TestHarness:
         # Note: The warehouse will accumulate all testers in this mode
         if find_only:
             self.warehouse.markAllObjectsInactive()
-            return
+            return []
 
         # Clear out the testers, we won't need them to stick around in the warehouse
         self.warehouse.clear()

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -3,7 +3,7 @@ if sys.version_info[0:2] != (2, 7):
     print("python 2.7 is required to run the test harness")
     sys.exit(1)
 
-import os, re, inspect, errno, subprocess, shutil, time, copy
+import os, re, inspect, errno, time, copy
 
 import path_tool
 path_tool.activate_module('FactorySystem')
@@ -16,7 +16,6 @@ from Parser import Parser
 from Warehouse import Warehouse
 import util
 
-from multiprocessing import Process
 import argparse
 from timeit import default_timer as clock
 
@@ -617,7 +616,6 @@ class TestHarness:
         # Convert all list based options of length one to scalars
         for key, value in vars(self.options).items():
             if type(value) == list and len(value) == 1:
-                tmp_str = getattr(self.options, key)
                 setattr(self.options, key, value[0])
 
         # If attempting to test only failed_tests, open the .failed_tests file and create a list object
@@ -705,6 +703,7 @@ class TestTimer(TestHarness):
         TestHarness.__init__(self, argv, app_name, moose_dir)
         try:
             from sqlite3 import dbapi2 as sqlite
+            assert sqlite # silence pyflakes warning
         except:
             print('Error: --store-timing requires the sqlite3 python module.')
             sys.exit(1)

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -426,6 +426,7 @@ class TestHarness:
             # Store these results to a table we will use when we print final results
             self.test_table.append( (tester_data, result, timing) )
 
+            self.postRun(tester.specs, timing)
             # Tally the results of this test to be used in our Final Test Results footer
             if tester.isSkipped():
                 self.num_skipped += 1
@@ -747,7 +748,6 @@ class TestTimer(TestHarness):
         data = []
         sum_time = 0
         num = 0
-        parse_failed = False
         # Were only interested in storing scaled data
         if timing != None and test['scale_refine'] != 0:
             sum_time += float(timing)

--- a/python/TestHarness/XMLDiffer.py
+++ b/python/TestHarness/XMLDiffer.py
@@ -1,4 +1,4 @@
-import os, sys, traceback
+import os, traceback
 import xml.etree.ElementTree as xml
 
 ##
@@ -129,7 +129,6 @@ class XMLDiffer(object):
 
         # Define local variables
         root = [self._root1, self._root2]
-        name = ['file 1', 'file 2']
 
         # Do nothing if the objects do not exist
         if root[0] == None or root[1] == None:

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -1,7 +1,7 @@
 from time import sleep
 from MooseObject import MooseObject
 from TesterData import TesterData
-import os, sys
+import os
 from contrib import dag
 from timeit import default_timer as clock
 

--- a/python/TestHarness/testers/AnalyzeJacobian.py
+++ b/python/TestHarness/testers/AnalyzeJacobian.py
@@ -1,4 +1,4 @@
-import re, os, sys
+import os, sys
 import util
 from Tester import Tester
 
@@ -25,8 +25,9 @@ class AnalyzeJacobian(Tester):
     def checkRunnable(self, options):
         try:
             import numpy
+            assert numpy # silence pyflakes warning
             return (True, '')
-        except Exception as e:
+        except Exception:
             return (False, 'skipped (no numpy)')
 
 

--- a/python/TestHarness/testers/CSVDiff.py
+++ b/python/TestHarness/testers/CSVDiff.py
@@ -1,6 +1,5 @@
 from FileTester import FileTester
 from CSVDiffer import CSVDiffer
-import util
 
 class CSVDiff(FileTester):
 

--- a/python/TestHarness/testers/FileTester.py
+++ b/python/TestHarness/testers/FileTester.py
@@ -1,6 +1,5 @@
 from RunApp import RunApp
 import util
-import os
 
 # Classes that derive from this class are expected to write
 # output files. The Tester::getOutputFiles() method should

--- a/python/TestHarness/testers/ImageDiff.py
+++ b/python/TestHarness/testers/ImageDiff.py
@@ -1,6 +1,5 @@
 from FileTester import FileTester
 import os
-import util
 import sys
 from mooseutils.ImageDiffer import ImageDiffer
 

--- a/python/TestHarness/testers/PetscJacobianTester.py
+++ b/python/TestHarness/testers/PetscJacobianTester.py
@@ -1,5 +1,5 @@
 from RunApp import RunApp
-import os, re
+import re
 
 class PetscJacobianTester(RunApp):
 

--- a/python/TestHarness/testers/RunCommand.py
+++ b/python/TestHarness/testers/RunCommand.py
@@ -1,4 +1,3 @@
-import re, os, sys, time
 from Tester import Tester
 
 class RunCommand(Tester):

--- a/python/TestHarness/tests/test_Ignore.py
+++ b/python/TestHarness/tests/test_Ignore.py
@@ -1,4 +1,3 @@
-import subprocess
 from TestHarnessTestCase import TestHarnessTestCase
 
 class TestHarnessTester(TestHarnessTestCase):


### PR DESCRIPTION
Recent changes in the TestHarness from #9335 caused a couple of minor problems.

Building the SQA documentation [failed](https://www.moosebuild.org/job/109267/)

Generating the test timing [failed](https://www.moosebuild.org/job/109262/)

This PR fixes those two issues.
It also makes `python/TestHarness` pyflakes clean so that we can start enforcing it.