### PR TITLE
Don't build moose/test/ test library

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -215,6 +215,11 @@ $(app_LIB): $(app_HEADER) $(app_plugin_deps) $(depend_libs) $(app_objects)
 	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(curr_objs) $(libmesh_LDFLAGS) $(EXTERNAL_FLAGS) -rpath $(curr_dir)/lib $(curr_libs)
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 
+ifeq ($(BUILD_TEST_OBJECTS_LIB),no)
+  app_test_LIB :=
+  depend_test_libs :=
+  depend_test_libs_flags :=
+else
 # Target-specific Variable Values (See GNU-make manual)
 $(app_test_LIB): curr_objs := $(app_test_objects)
 $(app_test_LIB): curr_dir  := $(APPLICATION_DIR)/test
@@ -225,6 +230,7 @@ $(app_test_LIB): $(app_HEADER) $(app_plugin_deps) $(depend_libs) $(app_test_obje
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
 	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(curr_objs) $(libmesh_LDFLAGS) $(EXTERNAL_FLAGS) -rpath $(curr_dir)/lib $(curr_libs)
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
+endif
 
 $(app_EXEC): $(app_LIBS) $(mesh_library) $(main_object) $(app_test_LIB) $(depend_test_libs)
 	@echo "Linking Executable "$@"..."

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,6 +19,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MOOSE_DIR)/test
 APPLICATION_NAME   := moose_test
 BUILD_EXEC         := yes
+BUILD_TEST_OBJECTS_LIB := no
 # Note: There are no applications that depend on moose_test so the test_up and up
 # targets are not very useful here.  Instead we will test up like this is MOOSE
 DEP_APPS           ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py moose)


### PR DESCRIPTION
The Makefile changes from #9601 also built a test library for `moose/test` which is not what we wanted.