### PR TITLE
Consistent nomenclature

### DIFF
--- a/modules/fluid_properties/include/materials/FluidPropertiesMaterial.h
+++ b/modules/fluid_properties/include/materials/FluidPropertiesMaterial.h
@@ -46,7 +46,7 @@ protected:
   MaterialProperty<Real> & _mu;
   /// Thermal conductivity
   MaterialProperty<Real> & _k;
-  /// Gibbs free enthalpy
+  /// Gibbs free energy
   MaterialProperty<Real> & _g;
 
   /// Fluid properties

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -81,7 +81,7 @@ public:
   /// Derivative of pressure wrt specific enthalpy
   virtual Real dpdh_from_h_s(Real h, Real s) const = 0;
 
-  /// Gibbs free enthalpy
+  /// Gibbs free energy
   virtual Real g(Real v, Real e) const = 0;
 
   /// Thermal expansion coefficient


### PR DESCRIPTION
Using Gibbs free energy instead of enthalpy to be conststent within the
module.

Refs #9613