### PR TITLE
shape_user_object parallel failure fix

### DIFF
--- a/framework/include/base/AuxiliarySystem.h
+++ b/framework/include/base/AuxiliarySystem.h
@@ -157,6 +157,7 @@ public:
   virtual TransientExplicitSystem & sys() { return _sys; }
 
   virtual System & system() override { return _sys; }
+  virtual const System & system() const override { return _sys; }
 
   virtual NumericVector<Number> * solutionPreviousNewton() override
   {

--- a/framework/include/base/DisplacedSystem.h
+++ b/framework/include/base/DisplacedSystem.h
@@ -128,6 +128,7 @@ public:
   virtual TransientExplicitSystem & sys() { return _sys; }
 
   virtual System & system() override { return _sys; }
+  virtual const System & system() const override { return _sys; }
 
 protected:
   SystemBase & _undisplaced_system;

--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -542,6 +542,8 @@ public:
 
   // NL /////
   NonlinearSystemBase & getNonlinearSystemBase() { return *_nl; }
+  const NonlinearSystemBase & getNonlinearSystemBase() const { return *_nl; }
+
   virtual NonlinearSystem & getNonlinearSystem();
 
   void addVariable(const std::string & var_name,

--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -519,7 +519,6 @@ public:
   virtual System & system() override { return _sys; }
   virtual const System & system() const override { return _sys; }
 
-
   virtual NumericVector<Number> * solutionPreviousNewton() override
   {
     return _solution_previous_nl;

--- a/framework/include/base/NonlinearSystemBase.h
+++ b/framework/include/base/NonlinearSystemBase.h
@@ -517,6 +517,8 @@ public:
   virtual NumericVector<Number> & solution() override { return *_sys.solution; }
 
   virtual System & system() override { return _sys; }
+  virtual const System & system() const override { return _sys; }
+
 
   virtual NumericVector<Number> * solutionPreviousNewton() override
   {

--- a/framework/include/base/SystemBase.h
+++ b/framework/include/base/SystemBase.h
@@ -111,6 +111,7 @@ public:
    * Get the reference to the libMesh system
    */
   virtual System & system() = 0;
+  virtual const System & system() const = 0;
 
   /**
    * Initialize the system

--- a/test/tests/userobjects/shape_element_user_object/jacobian.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian.i
@@ -6,6 +6,7 @@
   type = GeneratedMesh
   dim = 1
   nx = 2
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/userobjects/shape_element_user_object/jacobian_test.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian_test.i
@@ -2,6 +2,7 @@
   type = GeneratedMesh
   dim = 1
   nx = 2
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/userobjects/shape_element_user_object/shape_side_uo_jac_test.i
+++ b/test/tests/userobjects/shape_element_user_object/shape_side_uo_jac_test.i
@@ -3,6 +3,7 @@
   dim = 2
   nx = 2
   ny = 2
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/userobjects/shape_element_user_object/shape_side_uo_physics_test.i
+++ b/test/tests/userobjects/shape_element_user_object/shape_side_uo_physics_test.i
@@ -5,6 +5,7 @@ u_left = 0.5
   dim = 2
   nx = 10
   ny = 10
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/userobjects/shape_element_user_object/simple_shape_element_uo_test.i
+++ b/test/tests/userobjects/shape_element_user_object/simple_shape_element_uo_test.i
@@ -4,6 +4,7 @@
   nx = 2
   ny = 2
   nz = 2
+  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -4,7 +4,6 @@
     input = 'shape_element_user_object.i'
     recover = false
     allow_warnings = true
-    mesh_mode = REPLICATED
   [../]
 
   [./simple_shape_element_uo]
@@ -15,7 +14,6 @@
     difference_tol = 1E10
     recover = false
     allow_warnings = true
-    mesh_mode = REPLICATED
   [../]
 
   [./jacobian_test1]
@@ -26,7 +24,6 @@
     difference_tol = 1E10
     recover = false
     allow_warnings = true
-    mesh_mode = REPLICATED
   [../]
 
   [./jacobian_test2]
@@ -37,7 +34,6 @@
     difference_tol = 1E10
     recover = false
     allow_warnings = true
-    mesh_mode = REPLICATED
   [../]
 
   [./shape_side_uo_jac_test]
@@ -47,7 +43,6 @@
     ratio_tol = 3e-8
     recover = false
     allow_warnings = true
-    mesh_mode = REPLICATED
     # This tests sometimes reports an incorrect jacobian when run
     # with multiple threads.
     max_threads = 1
@@ -57,7 +52,6 @@
     input = 'shape_side_uo_physics_test.i'
     exodiff = 'shape_side_uo_physics_test_out.e'
     allow_warnings = true
-    mesh_mode = REPLICATED
     recover = false
   [../]
 []


### PR DESCRIPTION
This fixes the userobjects/shape_element_user_object.shape_element_user_object test for me on 13+ processors (and hopefully for Civet too - it was the nightly tests from #9430 that caught the overzealous error.

This also re-enables that suite of tests when running on DistributedMesh, which should help avoid future regressions there or in #1500.