### PR TITLE
Remove use of path_tool

### DIFF
--- a/modules/chemical_reactions/run_tests
+++ b/modules/chemical_reactions/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/combined/run_tests
+++ b/modules/combined/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/contact/run_tests
+++ b/modules/contact/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/fluid_properties/run_tests
+++ b/modules/fluid_properties/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/heat_conduction/run_tests
+++ b/modules/heat_conduction/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/level_set/run_tests
+++ b/modules/level_set/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/misc/run_tests
+++ b/modules/misc/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/navier_stokes/run_tests
+++ b/modules/navier_stokes/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/phase_field/run_tests
+++ b/modules/phase_field/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/porous_flow/run_tests
+++ b/modules/porous_flow/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/rdg/run_tests
+++ b/modules/rdg/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/richards/run_tests
+++ b/modules/richards/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/run_tests
+++ b/modules/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/solid_mechanics/run_tests
+++ b/modules/solid_mechanics/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/stochastic_tools/run_tests
+++ b/modules/stochastic_tools/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/tensor_mechanics/run_tests
+++ b/modules/tensor_mechanics/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/water_steam_eos/run_tests
+++ b/modules/water_steam_eos/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/modules/xfem/run_tests
+++ b/modules/xfem/run_tests
@@ -14,8 +14,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -5,15 +5,10 @@ if sys.version_info[0:2] != (2, 7):
 
 import os, re, inspect, errno, time, copy
 
-import path_tool
-path_tool.activate_module('FactorySystem')
-
 from socket import gethostname
-from Scheduler import Scheduler
-from Tester import Tester
-from Factory import Factory
-from Parser import Parser
-from Warehouse import Warehouse
+from FactorySystem.Factory import Factory
+from FactorySystem.Parser import Parser
+from FactorySystem.Warehouse import Warehouse
 import util
 
 import argparse
@@ -50,7 +45,7 @@ class TestHarness:
         dirs.extend([os.path.join(my_dir, 'scripts', 'TestHarness') for my_dir in depend_app_dirs.split('\n')])
 
         # Finally load the plugins!
-        self.factory.loadPlugins(dirs, 'testers', Tester)
+        self.factory.loadPlugins(dirs, 'testers', "IS_TESTER")
 
         self.test_table = []
         self.num_passed = 0
@@ -503,7 +498,7 @@ class TestHarness:
 
     def initialize(self, argv, app_name):
         # Load the scheduler plugins
-        self.factory.loadPlugins([os.path.join(self.moose_dir, 'python', 'TestHarness')], 'schedulers', Scheduler)
+        self.factory.loadPlugins([os.path.join(self.moose_dir, 'python', 'TestHarness')], 'schedulers', "IS_SCHEDULER")
 
         # Add our scheduler plugins
         # Note: for now, we only have one: 'RunParallel'. In the future this will be an options.argument

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -1,5 +1,5 @@
-from Scheduler import Scheduler
-import util
+from TestHarness.schedulers.Scheduler import Scheduler
+from TestHarness import util
 
 class RunParallel(Scheduler):
     """

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -1,5 +1,5 @@
 from time import sleep
-from MooseObject import MooseObject
+from FactorySystem.MooseObject import MooseObject
 from TesterData import TesterData
 import os
 from contrib import dag
@@ -35,6 +35,9 @@ class Scheduler(MooseObject):
         params.addRequiredParam('max_processes', None, "Hard limit of maxium processes to use")
 
         return params
+
+    # This is what will be checked for when we look for valid schedulers
+    IS_SCHEDULER = True
 
     def __init__(self, harness, params):
         MooseObject.__init__(self, harness, params)

--- a/python/TestHarness/schedulers/TesterData.py
+++ b/python/TestHarness/schedulers/TesterData.py
@@ -1,7 +1,7 @@
 import re, os, platform
 from timeit import default_timer as clock
 from signal import SIGTERM
-import util
+from TestHarness import util
 
 class TesterData(object):
     """

--- a/python/TestHarness/testers/AnalyzeJacobian.py
+++ b/python/TestHarness/testers/AnalyzeJacobian.py
@@ -1,5 +1,5 @@
 import os, sys
-import util
+from TestHarness import util
 from Tester import Tester
 
 class AnalyzeJacobian(Tester):

--- a/python/TestHarness/testers/CSVDiff.py
+++ b/python/TestHarness/testers/CSVDiff.py
@@ -1,5 +1,5 @@
 from FileTester import FileTester
-from CSVDiffer import CSVDiffer
+from TestHarness.CSVDiffer import CSVDiffer
 
 class CSVDiff(FileTester):
 

--- a/python/TestHarness/testers/CheckFiles.py
+++ b/python/TestHarness/testers/CheckFiles.py
@@ -1,5 +1,5 @@
 from FileTester import FileTester
-import util
+from TestHarness import util
 import os
 
 class CheckFiles(FileTester):

--- a/python/TestHarness/testers/Exodiff.py
+++ b/python/TestHarness/testers/Exodiff.py
@@ -1,5 +1,5 @@
 from FileTester import FileTester
-import util
+from TestHarness import util
 import os
 
 class Exodiff(FileTester):

--- a/python/TestHarness/testers/FileTester.py
+++ b/python/TestHarness/testers/FileTester.py
@@ -1,5 +1,5 @@
 from RunApp import RunApp
-import util
+from TestHarness import util
 
 # Classes that derive from this class are expected to write
 # output files. The Tester::getOutputFiles() method should

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -1,6 +1,6 @@
 import re, os, time
 from Tester import Tester
-import util
+from TestHarness import util
 
 class RunApp(Tester):
 

--- a/python/TestHarness/testers/RunException.py
+++ b/python/TestHarness/testers/RunException.py
@@ -1,4 +1,4 @@
-import util
+from TestHarness import util
 from RunApp import RunApp
 
 class RunException(RunApp):

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -1,6 +1,6 @@
 import re, os
-import util
-from MooseObject import MooseObject
+from TestHarness import util
+from FactorySystem.MooseObject import MooseObject
 
 class Tester(MooseObject):
     """
@@ -62,6 +62,9 @@ class Tester(MooseObject):
         params.addParam('boost',         ['ALL'], "A test that runs only if BOOT is detected ('ALL', 'TRUE', 'FALSE')")
 
         return params
+
+    # This is what will be checked for when we look for valid testers
+    IS_TESTER = True
 
     def __init__(self, name, params):
         MooseObject.__init__(self, name, params)

--- a/python/TestHarness/testers/VTKDiff.py
+++ b/python/TestHarness/testers/VTKDiff.py
@@ -1,7 +1,7 @@
 from RunApp import RunApp
-import util
+from TestHarness import util
 import os
-from XMLDiffer import XMLDiffer
+from TestHarness.XMLDiffer import XMLDiffer
 
 class VTKDiff(RunApp):
 

--- a/python/run_tests
+++ b/python/run_tests
@@ -16,8 +16,5 @@ if "MOOSE_DIR" in os.environ:
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
 
-import path_tool
-path_tool.activate_module('TestHarness')
-
 from TestHarness import TestHarness
 TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)

--- a/scripts/traceability_matrix.py
+++ b/scripts/traceability_matrix.py
@@ -2,8 +2,7 @@
 
 import re, os, sys, argparse
 from reportlab.lib import colors
-from reportlab.lib.units import cm
-from reportlab.lib.pagesizes import A4, inch, landscape
+from reportlab.lib.pagesizes import A4, landscape
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph
 from reportlab.lib.styles import getSampleStyleSheet
 
@@ -100,11 +99,8 @@ def extractTestedRequirements(args, data):
     os.chdir(test_app_dir)
 
     sys.path.append(os.path.join(args.moose_dir, 'python'))
-    import path_tool
-    path_tool.activate_module('TestHarness')
 
     from TestHarness import TestHarness
-    from Tester import Tester
 
     # Build the TestHarness object here
     harness = TestHarness([], test_app_name, args.moose_dir)

--- a/stork/run_tests.app
+++ b/stork/run_tests.app
@@ -16,8 +16,6 @@ if os.environ.has_key("MOOSE_DIR"):
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 from TestHarness import TestHarness
 # Run the tests!

--- a/stork/run_tests.module
+++ b/stork/run_tests.module
@@ -14,8 +14,6 @@ if os.environ.has_key("MOOSE_DIR"):
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 from TestHarness import TestHarness
 # Run the tests!

--- a/test/run_tests
+++ b/test/run_tests
@@ -15,8 +15,6 @@ if "MOOSE_DIR" in os.environ:
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
 os.environ['MOOSE_DIR'] = MOOSE_DIR
-import path_tool
-path_tool.activate_module('TestHarness')
 
 # Append error flag when running tests
 sys.argv.insert(1, "--error")

--- a/tutorials/darcy_thermo_mech/step01_diffusion/run_tests
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/run_tests
@@ -17,8 +17,6 @@ if "MOOSE_DIR" in os.environ:
   MOOSE_DIR = os.environ['MOOSE_DIR']
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 from TestHarness import TestHarness
 # Run the tests!


### PR DESCRIPTION
Get rid of path_tool and do proper python imports.

The major change is in Factory.py where we can no longer use `__subclasses__()` to find valid `Tester` classes since it doesn't work with different import paths.
Instead, I used a slightly ugly workaround. The `Tester` base class has an attribute `IS_TESTER` that we check for instead of inheritance. Similarly for the `Scheduler`

I left `path_tool.py` in place so that apps won't break. They can be migrated in the future.

refs #5434
