### PR TITLE
Temporarily disable checkpoint tests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -64,3 +64,5 @@ MOOSE <bounces@inl.gov>
 Mudasar Zahoor <mudasar.zahoor@inl.gov>
 Alain B. Giorla <giorlaab@ornl.gov>
 Adam Cahill <adam.cahill.ctr@afit.edu>
+Nicolo Grilli <ngrilli@purdue.edu>
+Andrew Franklin <andrew.franklin@inl.gov>

--- a/test/tests/mesh/checkpoint/tests
+++ b/test/tests/mesh/checkpoint/tests
@@ -6,6 +6,7 @@
     cli_args = 'Outputs/file_base=test_2  Mesh/file=checkpoint_split_in.2.cpr'
     max_parallel = 2  # workaround until libMesh/libmesh#1408
     min_parallel = 2  # workaround until libMesh/libmesh#1409
+    skip = 'Requires libMesh/libmesh#1409'
   [../]
   [./test_2a]
     type = 'Exodiff'
@@ -22,6 +23,7 @@
     cli_args = 'Outputs/file_base=test_4  Mesh/file=checkpoint_split_in.4.cpr'
     max_parallel = 4  # workaround until libMesh/libmesh#1408
     min_parallel = 4  # workaround until libMesh/libmesh#1409
+    skip = 'Requires libMesh/libmesh#1409'
   [../]
   [./test_4a]
     type = 'Exodiff'
@@ -38,6 +40,7 @@
     cli_args = 'Outputs/file_base=test_8  Mesh/file=checkpoint_split_in.8.cpr'
     max_parallel = 8  # workaround until libMesh/libmesh#1408
     min_parallel = 8  # workaround until libMesh/libmesh#1409
+    skip = 'Requires libMesh/libmesh#1409'
   [../]
   [./test_8a]
     type = 'Exodiff'


### PR DESCRIPTION
These tests were created with a libmesh build that used different id
sizes than our Mac test box. This requires a libmesh update to fix
completely, so we are temporarily disabling them for the time being.

Refs libMesh/libmesh#1409.