### PR TITLE
Add custom type FunctionExpression to a few parameters.

### DIFF
--- a/framework/src/auxkernels/ParsedAux.C
+++ b/framework/src/auxkernels/ParsedAux.C
@@ -22,7 +22,8 @@ validParams<ParsedAux>()
   params += validParams<FunctionParserUtils>();
   params.addClassDescription("Parsed function AuxKernel.");
 
-  params.addRequiredParam<std::string>("function", "function expression");
+  params.addRequiredCustomTypeParam<std::string>(
+      "function", "FunctionExpression", "function expression");
   params.addCoupledVar("args", "coupled variables");
   params.addParam<std::vector<std::string>>(
       "constant_names", "Vector of constants used in the parsed function (use this for kB etc.)");

--- a/framework/src/functions/MooseParsedFunction.C
+++ b/framework/src/functions/MooseParsedFunction.C
@@ -25,7 +25,8 @@ validParams<MooseParsedFunction>()
 {
   InputParameters params = validParams<Function>();
   params += validParams<MooseParsedFunctionBase>();
-  params.addRequiredParam<std::string>("value", "The user defined function.");
+  params.addRequiredCustomTypeParam<std::string>(
+      "value", "FunctionExpression", "The user defined function.");
   return params;
 }
 

--- a/framework/src/userobject/Terminator.C
+++ b/framework/src/userobject/Terminator.C
@@ -20,8 +20,9 @@ InputParameters
 validParams<Terminator>()
 {
   InputParameters params = validParams<GeneralUserObject>();
-  params.addRequiredParam<std::string>(
+  params.addRequiredCustomTypeParam<std::string>(
       "expression",
+      "FunctionExpression",
       "FParser expression to process Postprocessor values into a boolean value. "
       "Termination of the simulation occurs when this returns true.");
   return params;


### PR DESCRIPTION
The NEAMS validation engine was having some issues knowing when to allow splitting a parameter value string on spaces. @brandonlangley identified `Terminator/expression`, `ParsedFunction/value`, and `ParsedAux/function` as troublesome parameters.
This PR just sets the `cpp_type` of these parameters to `FunctionExpression`. This should
only affect things that parse the `--json` dump.

I had tried to change the actual type, ie `params.addRequiredParam<FunctionExpression>(...)` with a new type `FunctionExpression` but there are a lot of places that access these parameters that use `std::string` which causes an error. It is probably doable but it would require changes in more places and probably break lots of apps, so I went the `CustomType` route.
