### PR TITLE
Make MultiMooseEnum print out current value rather than options

### DIFF
--- a/framework/include/outputs/formatters/SONDefinitionFormatter.h
+++ b/framework/include/outputs/formatters/SONDefinitionFormatter.h
@@ -72,7 +72,7 @@ protected:
   std::string backtrack()
   {
     std::string backtrack_path;
-    for (size_t i = 0; i < _level; ++i)
+    for (int i = 0; i < _level; ++i)
       backtrack_path += "../";
     return backtrack_path;
   }

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -16,6 +16,7 @@
 #include "MooseUtils.h"
 #include "MooseError.h"
 #include "InfixIterator.h"
+#include "Conversion.h"
 
 #include <sstream>
 #include <algorithm>
@@ -256,6 +257,6 @@ MultiMooseEnum::checkDeprecated() const
 std::ostream &
 operator<<(std::ostream & out, const MultiMooseEnum & obj)
 {
-  out << obj.getRawNames();
+  out << Moose::stringify(obj._current, " ");
   return out;
 }


### PR DESCRIPTION
`operator<<` for `MultiMooseEnum` was printing out all options rather than the current value.
`--json` and `--dump` use this to print out the default value.

@aeslaughter This was introduced in #9242 , was there a reason you used `getRawNames()`?

In the case of #9747 it was causing the `--dump` to use really short comment lines. This should
fix the immediate problem there but somebody needs to decide the best way to format comments in blocks that have long name=value pairs in the dump output.