### PR TITLE
ElementalVariableValue works with DistributedMesh

### DIFF
--- a/framework/src/postprocessors/ElementalVariableValue.C
+++ b/framework/src/postprocessors/ElementalVariableValue.C
@@ -36,9 +36,11 @@ ElementalVariableValue::ElementalVariableValue(const InputParameters & parameter
     _var_name(parameters.get<VariableName>("variable")),
     _element(_mesh.getMesh().query_elem_ptr(parameters.get<unsigned int>("elementid")))
 {
-  // This class only works with ReplicatedMesh, since it relies on a
-  // specific element numbering that we can't guarantee with DistributedMesh
-  _mesh.errorIfDistributedMesh("ElementalVariableValue");
+  // This class may be too dangerous to use if renumbering is enabled,
+  // as the nodeid parameter obviously depends on a particular
+  // numbering.
+  if (_mesh.getMesh().allow_renumbering())
+    mooseError("ElementalVariableValue should only be used when node renumbering is disabled.");
 }
 
 Real

--- a/modules/combined/test/tests/internal_volume/rz_displaced.i
+++ b/modules/combined/test/tests/internal_volume/rz_displaced.i
@@ -42,6 +42,9 @@
 
 [Mesh]
   file = meshes/rz_displaced.e
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Functions]

--- a/modules/combined/test/tests/internal_volume/rz_displaced_sm.i
+++ b/modules/combined/test/tests/internal_volume/rz_displaced_sm.i
@@ -42,6 +42,9 @@
 [Mesh]
   file = meshes/rz_displaced.e
   displacements = 'disp_x disp_y'
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Functions]

--- a/modules/fluid_properties/test/tests/brine/brine.i
+++ b/modules/fluid_properties/test/tests/brine/brine.i
@@ -38,6 +38,9 @@
   nx = 3
   ny = 1
   xmax = 3
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/modules/fluid_properties/test/tests/co2/co2.i
+++ b/modules/fluid_properties/test/tests/co2/co2.i
@@ -40,6 +40,9 @@
   dim = 2
   nx = 3
   xmax = 3
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/modules/fluid_properties/test/tests/tabulated/tabulated.i
+++ b/modules/fluid_properties/test/tests/tabulated/tabulated.i
@@ -5,6 +5,9 @@
 [Mesh]
   type = GeneratedMesh
   dim = 2
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/modules/fluid_properties/test/tests/water/water.i
+++ b/modules/fluid_properties/test/tests/water/water.i
@@ -7,6 +7,9 @@
   dim = 2
   nx = 3
   xmax = 3
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/modules/porous_flow/test/tests/density/GravDensity01.i
+++ b/modules/porous_flow/test/tests/density/GravDensity01.i
@@ -23,6 +23,9 @@
   nx = 1
   ny = 1
   nz = 1
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [GlobalParams]

--- a/modules/porous_flow/test/tests/thermal_conductivity/ThermalCondPorosity01.i
+++ b/modules/porous_flow/test/tests/thermal_conductivity/ThermalCondPorosity01.i
@@ -16,6 +16,9 @@
   nx = 1
   ny = 1
   nz = 1
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [GlobalParams]

--- a/modules/solid_mechanics/test/tests/cracking/cracking_exponential.i
+++ b/modules/solid_mechanics/test/tests/cracking/cracking_exponential.i
@@ -12,6 +12,9 @@
 [Mesh]
   file = cracking_test.e
   displacements = 'disp_x disp_y disp_z'
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/modules/solid_mechanics/test/tests/cracking/cracking_function.i
+++ b/modules/solid_mechanics/test/tests/cracking/cracking_function.i
@@ -5,6 +5,9 @@
 [Mesh]
    file = plate.e
    displacements = 'disp_x disp_y'
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/modules/solid_mechanics/test/tests/cracking/cracking_plane_stress.i
+++ b/modules/solid_mechanics/test/tests/cracking/cracking_plane_stress.i
@@ -28,6 +28,9 @@
 [Mesh]
   file = cube.e
   displacements = 'disp_x disp_y disp_z'
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/modules/solid_mechanics/test/tests/cracking/cracking_rz_exponential.i
+++ b/modules/solid_mechanics/test/tests/cracking/cracking_rz_exponential.i
@@ -11,6 +11,9 @@
 
 [Mesh]
   file = cracking_rz_test.e
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Problem]

--- a/modules/solid_mechanics/test/tests/temperature_dependent_hardening/temp_dep_hardening.i
+++ b/modules/solid_mechanics/test/tests/temperature_dependent_hardening/temp_dep_hardening.i
@@ -36,6 +36,9 @@
   nx = 1
   ny = 1
   nz = 1
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [GlobalParams]

--- a/modules/tensor_mechanics/test/tests/jacobian_damper/cube_load.i
+++ b/modules/tensor_mechanics/test/tests/jacobian_damper/cube_load.i
@@ -5,6 +5,9 @@
   ny = 1
   nz = 1
   displacements = 'disp_x disp_y disp_z'
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/modules/tensor_mechanics/test/tests/recompute_radial_return/affine_plasticity.i
+++ b/modules/tensor_mechanics/test/tests/recompute_radial_return/affine_plasticity.i
@@ -66,6 +66,9 @@
   nx = 1
   ny = 1
   nz = 1
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Functions]

--- a/modules/tensor_mechanics/test/tests/temperature_dependent_hardening/temp_dep_hardening.i
+++ b/modules/tensor_mechanics/test/tests/temperature_dependent_hardening/temp_dep_hardening.i
@@ -36,6 +36,9 @@
   nx = 1
   ny = 1
   nz = 1
+  # This test uses ElementalVariableValue postprocessors on specific
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [GlobalParams]

--- a/test/tests/auxkernels/element_var/element_var_test.i
+++ b/test/tests/auxkernels/element_var/element_var_test.i
@@ -9,8 +9,8 @@
   ny = 10
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
-  # elements, if you use DistributedMesh the elements get renumbered.
-  parallel_type = replicated
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Functions]

--- a/test/tests/outputs/console/console_final.i
+++ b/test/tests/outputs/console/console_final.i
@@ -18,8 +18,8 @@
   ny = 10
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
-  # elements, if you use DistributedMesh the elements get renumbered.
-  parallel_type = replicated
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Functions]

--- a/test/tests/outputs/postprocessor/output_pps_hidden_shown_check.i
+++ b/test/tests/outputs/postprocessor/output_pps_hidden_shown_check.i
@@ -12,8 +12,8 @@
   ny = 10
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
-  # elements, if you use DistributedMesh the elements get renumbered.
-  parallel_type = replicated
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Variables]

--- a/test/tests/outputs/postprocessor/show_hide.i
+++ b/test/tests/outputs/postprocessor/show_hide.i
@@ -12,8 +12,8 @@
   ny = 10
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
-  # elements, if you use DistributedMesh the elements get renumbered.
-  parallel_type = replicated
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Functions]

--- a/test/tests/outputs/variables/show_single_vars.i
+++ b/test/tests/outputs/variables/show_single_vars.i
@@ -9,8 +9,8 @@
   ny = 10
   elem_type = QUAD4
   # This test uses ElementalVariableValue postprocessors on specific
-  # elements, if you use DistributedMesh the elements get renumbered.
-  parallel_type = replicated
+  # elements, so element numbering needs to stay unchanged
+  allow_renumbering = false
 []
 
 [Functions]


### PR DESCRIPTION
So long as mesh renumbering is disabled so the specified element ids
can't be changed, that is.

This fixes at least one --distributed-mesh test run for me, solid_mechanics cracking_exponential.

Refs #1500

### Complete each of the following items before creating a PR

- Include any relevant design information for your change
- Follow [Coding Standards](http://mooseframework.org/wiki/CodeStandards/)
- Submit one or more [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/) or modify existing test cases
- Reference or close a specific issue (refs # or closes #)