### PR TITLE
Fixing petsc_version_release with --skip-config-checks

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -80,7 +80,7 @@ class TestHarness:
         if self.options.skip_config_checks:
             checks['compiler'] = set(['ALL'])
             checks['petsc_version'] = 'N/A'
-            checks['petsc_version_release'] = 'N/A'
+            checks['petsc_version_release'] = set(['ALL'])
             checks['slepc_version'] = 'N/A'
             checks['library_mode'] = set(['ALL'])
             checks['mesh_mode'] = set(['ALL'])


### PR DESCRIPTION
Restore functionality of not checking configuration before running tests.

closes #9654
