### PR TITLE
Make TestHarness call findDepApps only for current directory

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -41,7 +41,7 @@ class TestHarness:
 
         # Use the find_dep_apps script to get the dependant applications for an app
         import find_dep_apps
-        depend_app_dirs = find_dep_apps.findDepApps(app_name)
+        depend_app_dirs = find_dep_apps.findDepApps(app_name, use_current_only=True)
         dirs.extend([os.path.join(my_dir, 'scripts', 'TestHarness') for my_dir in depend_app_dirs.split('\n')])
 
         # Finally load the plugins!


### PR DESCRIPTION
@jasondhales found a problem with the TestHarness and its use of `find_dep_apps.findDepApps()`.

He had directories `bison` and `test_bison` at the save directory level, both BISON repositories.
`findDepApps` would find `test_bison` as a dependent app when running within `bison`. Then it would use TestHarness Testers in `test_bison` rather than the same Testers in `bison`

This just sets `findDepApps` to look in the current directory only.

Mainly just want to see what this breaks.
