### PR TITLE
Handle FunctionExpression in peacock

### DIFF
--- a/python/peacock/Input/ParameterInfo.py
+++ b/python/peacock/Input/ParameterInfo.py
@@ -74,6 +74,7 @@ class ParameterInfo(object):
             self.user_added or
             ("basic_string" in self.cpp_type and self.name == "value") or
             ("std::string" in self.cpp_type and self.name == "value") or
+            self.cpp_type == "FunctionExpression" or
             ' ' in self.value or
             ';' in self.value or
             '=' in self.value or


### PR DESCRIPTION
We need to make sure we quote parameter values with type `FunctionExpression`

refs #9752