### PR TITLE
Initial version of chemical reactions documentation

### DIFF
--- a/docs/content/bib/chemical_reactions.bib
+++ b/docs/content/bib/chemical_reactions.bib
@@ -1,0 +1,17 @@
+@article{guo2013,
+  title={{A parallel, fully coupled, fully implicit solution to reactive transport in porous media using the preconditioned Jacobian-Free Newton-Krylov Method}},
+  author={Guo, Luanjing and Huang, Hai and Gaston, Derek R and Permann, Cody J and Andrs, David and Redden, George D and Lu, Chuan and Fox, Don T and Fujita, Yoshiko},
+  journal={Advances in Water Resources},
+  volume={53},
+  pages={101--108},
+  year={2013}
+}
+
+@article{lichtner1996,
+  title={Continuum formulation of multicomponent-multiphase reactive transport},
+  author={Lichtner, Peter C},
+  journal={Reviews in Mineralogy and Geochemistry},
+  volume={34},
+  pages={1--81},
+  year={1996}
+}

--- a/docs/content/documentation/modules/chemical_reactions/index.md
+++ b/docs/content/documentation/modules/chemical_reactions/index.md
@@ -1,0 +1,173 @@
+# Chemical reactions module
+
+The chemical reactions module provides a set of tools for the calculation of
+multicomponent aqueous reactive transport in porous media, originally developed as
+the [MOOSE] application RAT \citep{guo2013}.
+
+## Theory
+
+The first part of defining the chemistry of a problem is to choose a set of independent
+*primary* species from which every other species (including minerals) can be expressed
+in terms of. Other chemical species that can be expressed as combinations of primary
+species are termed *secondary* species.
+
+Following \citet{lichtner1996}, the mass conservation equation is formulated in
+terms of the total concentration of a primary species $j$, $\Psi_j$, and has the form
+\begin{equation}
+\frac{\partial}{\partial t} \left(\phi \Psi_j \right) + \nabla \cdot \left(\mathbf{q}
+  - \phi D \nabla \right)\Psi_j + \sum_{m=1}^{N_m} \nu_{jm} I_m - Q_j= 0,  \quad j = 1, 2, \ldots, N_c,
+\end{equation}
+where $\phi$ is porosity, $\mathbf{q}$ is fluid velocity, $D$ is the hydrodynamic
+dispersion tensor, $N_m$ is the number of minerals formed by kinetic reactions,
+$\nu_{jm}$ is the stoichiometric coefficient for the $j^{\mathrm{th}}$ species in the
+$m^{\mathrm{th}}$ kinetic reaction, $I_m$ is the reaction rate for the $m^{\mathrm{th}}$
+mineral, and $Q_j$ is a source (sink) of the $j^{\mathrm{th}}$ species.
+
+The total concentration of the $j^{\mathrm{th}}$ primary species, $\Psi_j$, is defined as
+\begin{equation}
+\Psi_j = C_j + \sum_{i=1}^{N_s} \nu_{ji} C_i,
+\end{equation}
+where $C_j$ is the concentration of the primary species, $C_i$ is the concentration
+of the $i^{\mathrm{th}}$ secondary species, $N_s$ is the total number of secondary species,
+and $\nu_{ji}$ are the stoichiometric coefficients.
+
+### Aqueous equilibrium reactions
+The concentration of the $i^{\mathrm{th}}$ secondary species, $C_i$, is calculated from mass
+action equations corresponding to equilibrium reactions
+\begin{equation}
+\sum_j \nu_{ji} \mathcal{A}_j \rightleftharpoons \mathcal{A}_i,
+\end{equation}
+where $\mathcal{A}_j$ refers to the $j^{\mathrm{th}}$ species. This yields
+\begin{equation}
+C_i = \frac{K_i}{\gamma_i} \prod_{j=1}^{N_c} \left(\gamma_j C_j\right)^{\nu_{ji}},
+\end{equation}
+where $K_i$ is equilibrium constant, $\gamma_i$ is the activity coefficient, and
+$N_c$ is the number of primary species.
+
+### Solid kinetic reactions
+Mineral precipitation/dissolution is possible via kinetic reactions of the form
+\begin{equation}
+\sum_j \nu_{ji} \mathcal{A}_j \rightleftharpoons \mathcal{M}_m,
+\end{equation}
+where $\mathcal{M}_m$ refers to the $m^{\mathrm{th}}$ mineral species.
+
+The reaction rate $I_m$ is based on transition state theory, a simple form of which
+gives
+\begin{equation}
+I_m = \pm k_m a_m \left|1 - \Omega_m^{\theta}\right|^{\eta},
+\end{equation}
+where $I_m$ is positive for dissolution and negative for precipitation, $k_m$ is
+the rate constant, $a_m$ is the specific reactive surface area, $\Omega_m$ is termed
+the mineral saturation ratio, expressed as
+\begin{equation}
+\Omega_m = \frac{1}{K_m} \prod_{j}(\gamma_j C_j)^{\nu_{jm}},
+\end{equation}
+where $K_m$ is the equilibrium constant for mineral $m$.
+
+The rate constant $k_m$ is typically reported at a reference temperature (commonly
+25$^{\circ}$C). Using an Arrhenius relation, the temperature dependence of $k_m$ is
+given as
+\begin{equation}
+k_m(T) = k_{m,0} \exp\left[\frac{E_a}{R} \left(\frac{1}{T_0} - \frac{1}{T}\right)\right],
+\end{equation}
+where $k_{m,0}$ is the rate constant at reference temperature $T_0$, $E_a$ is the activation
+energy, $R$ is the gas constant.
+
+The exponents $\theta$ and $\eta$ in the reaction rate equation are specific to each mineral
+reaction, and should be measured experimentally. For simplicity, they are set to unity in this
+module.
+
+## Implementation details
+
+The physics described above is implemented in a number of `Kernels` and `AuxKernels`
+
+### Kernels
+The transport of each primary species is calculated using the following `Kernels`:
+
+- [`PrimaryTimeDerivative`](/chemical_reactions/PrimaryTimeDerivative.md) Rate of change of
+primary species concentration
+- [`PrimaryConvection`](/chemical_reactions/PrimaryConvection.md) Convective flux of primary
+species
+- [`PrimaryDiffusion`](/chemical_reactions/PrimaryDiffusion.md) Diffusion of primary species
+
+The transport of primary species present in a secondary species is included using:
+
+- [`CoupledBEEquilibriumSub`](/chemical_reactions/CoupledBEEquilibriumSub.md) Rate of change of
+primary species concentration in an equilibrium secondary species
+- [`CoupledConvectionReactionSub`](/chemical_reactions/CoupledConvectionReactionSub.md)
+Convection of primary species concentration in an equilibrium secondary species
+- [`CoupledDiffusionReactionSub`](/chemical_reactions/CoupledDiffusionReactionSub.md) Diffusion
+of primary species concentration in an equilibrium secondary species
+
+The amount of primary species converted to an immobile mineral phase is given by
+
+- [`CoupledBEKinetic`](/chemical_reactions/CoupledBEKinetic.md) Rate of change of primary
+species concentration in mineral species due to dissolution or precipitation
+
+### AuxKernels
+The following `AuxKernels` are used to calculate secondary species and mineral
+concentrations.
+
+- [`AqueousEquilibriumRxnAux`](/chemical_reactions/AqueousEquilibriumRxnAux.md) The concentration
+of secondary species $C_i$ for equilibrium reaction
+- [`KineticDisPreRateAux`](/chemical_reactions/KineticDisPreRateAux.md) The kinetic rate $I_m$
+of kinetic reaction
+- [`KineticDisPreConcAux`](/chemical_reactions/KineticDisPreConcAux.md) The concentration of mineral species
+
+### Material properties
+The `Kernels` above require several material properties to be defined using the
+following names: porosity, diffusivity and conductivity. These can be defined using
+one of the `Materials` available in the framework. For example, constant properties
+can be implemented using a [`GenericConstantMaterial`](/framework/GenericConstantMaterial.md)
+with the following:
+
+!listing modules/chemical_reactions/test/tests/aqueous_equilibrium/1species.i block=Materials caption=Required material properties
+
+More complicated formulations can be added by creating new `Materials` as required.
+
+### Boundary condition
+A flux boundary condition, [`ChemicalOutFlowBC`](/chemical_reactions/ChemicalOutFlowBC.md) is
+provided to define $\nabla u$ on a boundary.
+
+## Reaction network parser
+
+The chemical reactions module includes a reaction network parser in the `Actions`
+system that enables chemical reactions to be specified in a natural form in the input
+file. The parser then adds all required `Variables`, `AuxVariables`, `Kernels` and
+`AuxKernels` to represent the total geochemical model. To use the reaction network
+parser, a `ReactionNetwork` block can be added to the input file.
+
+Equilibrium reactions can be entered in the `ReactionNetwork` block using an
+`AqueousEquilibriumReactions` sub-block, while kinetic reactions are entered in
+a `SolidKineticReactions` sub-block.
+
+To demonstrate the use of the reaction network parser, consider the geochemical model
+used in \citet{guo2013}, which features aqueous equilibrium reactions as well as kinetic
+mineral dissolution and precipitation.
+
+Equilibrium reactions:
+\begin{align*}
+H^+ + HCO_3^- &\rightleftharpoons CO_2(aq)  & K_{eq} &= 10^{6.341} \\
+HCO_3^- &\rightleftharpoons H^+ + CO_3^{2-} & K_{eq} &= 10^{-10.325} \\
+Ca^{2+} + HCO_3^- &\rightleftharpoons H^+ + CaCO_3(aq) & K_{eq} &= 10^{-7.009} \\
+Ca^{2+} + HCO_3^- &\rightleftharpoons CaHCO_3^+ & K_{eq} &= 10^{-0.653} \\
+Ca^{2+} &\rightleftharpoons H^+ + CaOH^+ & K_{eq} &= 10^{-12.85} \\
+- H^+ &\rightleftharpoons OH^- & K_{eq} &= 10^{-13.991}
+\end{align*}
+
+Kinetic reaction:
+\begin{equation*}
+Ca^{2+} + HCO_3^- \rightleftharpoons H^+ + CaCO_3(s) \qquad K_{eq} = 10^{1.8487}
+\end{equation*}
+with specific reactive surface area $a_m = 0.461$ m$^2$/L, kinetic rate constant
+$k_m = 6.456542 \times 10^{-2}$ mol/m$^2$ and activation energy $E_a = 15,000$ J/mol.
+
+!listing modules/chemical_reactions/examples/calcium_bicarbonate/calcium_bicarbonate.i block=ReactionNetwork caption=Example of AqueousEquilibriumReactions action
+
+The reactive transport system above can be provided in the input file without using the
+reaction network parser. However, this adds more than 400 lines of input in this case,
+due to the large number of kernels that have to be provided!
+
+##References
+\bibliographystyle{unsrt}
+\bibliography{chemical_reactions.bib}

--- a/docs/content/documentation/modules/index.md
+++ b/docs/content/documentation/modules/index.md
@@ -10,6 +10,7 @@ MOOSE includes a set of community developed physics modules that you can build o
 * [Fluid Properties](modules/fluid_properties/index.md)
 * [Stochastic Tools](modules/stochastic_tools/index.md)
 * [Porous Flow](modules/porous_flow/index.md)
+* [Chemical reactions](modules/chemical_reactions/index.md)
 
 The purpose of the modules is to encapsulate common kernels, boundary conditions, etc. to prevent code duplication.
 Examples include: heat conduction, solid mechanics, Navier-Stokes, and others. The modules are organized so that your

--- a/docs/content/documentation/systems/AuxKernels/chemical_reactions/AqueousEquilibriumRxnAux.md
+++ b/docs/content/documentation/systems/AuxKernels/chemical_reactions/AqueousEquilibriumRxnAux.md
@@ -1,7 +1,17 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # AqueousEquilibriumRxnAux
 !syntax description /AuxKernels/AqueousEquilibriumRxnAux
+
+Calculates the concentration of the $i^{\mathrm{th}}$ secondary species, $C_i$ in terms of
+primary species concentration $C_j$ using the mass action equation
+
+\begin{equation}
+C_i = \frac{K_i}{\gamma_i} \prod_{j=1}^{N_c} \left(\gamma_j C_j\right)^{\nu_{ji}},
+\end{equation}
+where $K_i$ is equilibrium constant, $\gamma_i$ is the activity coefficient, and
+$N_c$ is the number of primary species.
+
+!!! note:
+    Currently, $\gamma_i$ is fixed as unity in the calculation
 
 !syntax parameters /AuxKernels/AqueousEquilibriumRxnAux
 

--- a/docs/content/documentation/systems/AuxKernels/chemical_reactions/KineticDisPreConcAux.md
+++ b/docs/content/documentation/systems/AuxKernels/chemical_reactions/KineticDisPreConcAux.md
@@ -1,7 +1,11 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # KineticDisPreConcAux
 !syntax description /AuxKernels/KineticDisPreConcAux
+
+Calculates the concentration of mineral using the kinetic reaction rate $I_m$
+(calculated using [`KineticDisPreRateAux`](/chemical_reactions/KineticDisPreRateAux.md)),
+\begin{equation}
+\frac{d C_m}{d t} = I_m.
+\end{equation}
 
 !syntax parameters /AuxKernels/KineticDisPreConcAux
 

--- a/docs/content/documentation/systems/AuxKernels/chemical_reactions/KineticDisPreRateAux.md
+++ b/docs/content/documentation/systems/AuxKernels/chemical_reactions/KineticDisPreRateAux.md
@@ -1,7 +1,32 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # KineticDisPreRateAux
 !syntax description /AuxKernels/KineticDisPreRateAux
+
+Calculates the kinetic reaction rate based on transition state theory
+\begin{equation}
+I_m = \pm k_m a_m \left|1 - \Omega_m^{\theta}\right|^{\eta},
+\end{equation}
+where $I_m$ is positive for dissolution and negative for precipitation, $k_m$ is
+the rate constant, $a_m$ is the specific reactive surface area, $\Omega_m$ is termed
+the mineral saturation ratio, expressed as
+\begin{equation}
+\Omega_m = \frac{1}{K_m} \prod_{j}(\gamma_j C_j)^{\nu_{jm}},
+\end{equation}
+where $K_m$ is the equilibrium constant for mineral $m$, $\gamma_j$ is the activity
+coefficient, $C_j$ is the concentration of the $j^{\mathrm{th}}$ primary species
+and $\nu_{jm}$ is the stoichiometric coefficient.
+
+The rate constant $k_m$ is typically reported at a reference temperature (commonly
+25$^{\circ}$C). Using an Arrhenius relation, the temperature dependence of $k_m$ is
+given as
+\begin{equation}
+k_m(T) = k_{m,0} \exp\left[\frac{E_a}{R} \left(\frac{1}{T_0} - \frac{1}{T}\right)\right],
+\end{equation}
+where $k_{m,0}$ is the rate constant at reference temperature $T_0$, $E_a$ is the activation
+energy, $R$ is the gas constant.
+
+The exponents $\theta$ and $\eta$ in the reaction rate equation are specific to each mineral
+reaction, and should be measured experimentally. For simplicity, they are set to unity in this
+module.
 
 !syntax parameters /AuxKernels/KineticDisPreRateAux
 

--- a/docs/content/documentation/systems/BCs/chemical_reactions/ChemicalOutFlowBC.md
+++ b/docs/content/documentation/systems/BCs/chemical_reactions/ChemicalOutFlowBC.md
@@ -1,7 +1,12 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # ChemicalOutFlowBC
 !syntax description /BCs/ChemicalOutFlowBC
+
+Integrated boundary condition to specify $\nabla u$ on the boundary, which arises
+from integation by parts on the diffusion term
+\begin{equation}
+\nabla \cdot \left(\phi D \nabla C_j \right)
+\end{equation}
+where $\phi$ is porosity and $D$ is the diffusivity.
 
 !syntax parameters /BCs/ChemicalOutFlowBC
 

--- a/docs/content/documentation/systems/Kernels/chemical_reactions/CoupledBEEquilibriumSub.md
+++ b/docs/content/documentation/systems/Kernels/chemical_reactions/CoupledBEEquilibriumSub.md
@@ -1,7 +1,13 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # CoupledBEEquilibriumSub
 !syntax description /Kernels/CoupledBEEquilibriumSub
+
+Derivative of concentration of $j^{\mathrm{th}}$ primary species present in the
+secondary equilibrium species wrt time. Implements the weak form of
+\begin{equation}
+\frac{\partial}{\partial t} \left(\phi \sum_i \nu_{ji} C_i\right),
+\end{equation}
+where $\phi$ is porosity, $\nu_{ji}$ are the stoichiometric coefficients, and
+$C_i$ is the concentration of the $i^{\mathrm{th}}$ secondary equilibrium species.
 
 !syntax parameters /Kernels/CoupledBEEquilibriumSub
 

--- a/docs/content/documentation/systems/Kernels/chemical_reactions/CoupledBEKinetic.md
+++ b/docs/content/documentation/systems/Kernels/chemical_reactions/CoupledBEKinetic.md
@@ -1,7 +1,13 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # CoupledBEKinetic
 !syntax description /Kernels/CoupledBEKinetic
+
+Derivative of concentration of $j^{\mathrm{th}}$ primary species present in the
+mineral species wrt time. Implements the weak form of
+\begin{equation}
+\frac{\partial}{\partial t} \left(\phi \sum_m C_m \right),
+\end{equation}
+where $\phi$ is porosity and $C_m$ is the concentration of the $m^{\mathrm{th}}$
+mineral species.
 
 !syntax parameters /Kernels/CoupledBEKinetic
 

--- a/docs/content/documentation/systems/Kernels/chemical_reactions/CoupledConvectionReactionSub.md
+++ b/docs/content/documentation/systems/Kernels/chemical_reactions/CoupledConvectionReactionSub.md
@@ -1,7 +1,22 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # CoupledConvectionReactionSub
 !syntax description /Kernels/CoupledConvectionReactionSub
+
+Convective flux of concentration of the $j^{\mathrm{th}}$ primary species present in the
+secondary equilibrium species. Implements the weak form of
+\begin{equation}
+\mathbf{q} \cdot \left[ \nabla \left(\sum_i \nu_{ji} C_i\right) \right]
+\end{equation}
+where $\nu_{ji}$ are the stoichiometric coefficients, $C_i$ is the concentration of the
+$i^{\mathrm{th}}$ secondary equilibrium species, and $\mathbf{q}$ is the Darcy velocity
+\begin{equation}
+\mathbf{q} = - \frac{K}{\mu} \left(\nabla P - \rho \mathbf{g}\right),
+\end{equation}
+where $K$ is the permeability tensor, $\mu$ is fluid viscosity, $P$ is pressure,
+$\rho$ is fluid density, and $\mathbf{g}$ is gravity.
+
+!!!note:
+    Currently, gravity is ignored in calculation of the Darcy velocity, and $K/\mu$
+    is provided as the hydraulic conductivity
 
 !syntax parameters /Kernels/CoupledConvectionReactionSub
 

--- a/docs/content/documentation/systems/Kernels/chemical_reactions/CoupledDiffusionReactionSub.md
+++ b/docs/content/documentation/systems/Kernels/chemical_reactions/CoupledDiffusionReactionSub.md
@@ -1,7 +1,14 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # CoupledDiffusionReactionSub
 !syntax description /Kernels/CoupledDiffusionReactionSub
+
+Diffusive flux of the $j^{\mathrm{th}}$ primary species present in the
+secondary equilibrium species. Implements the weak form of
+\begin{equation}
+\nabla \cdot \left[\phi D \nabla \left(\sum_i \nu_{ji} C_i\right) \right]
+\end{equation}
+where $\phi$ is porosity, $D$ is the diffusivity, $\nu_{ji}$ are the stoichiometric
+coefficients, $C_i$ is the concentration of the $i^{\mathrm{th}}$ secondary
+equilibrium species.
 
 !syntax parameters /Kernels/CoupledDiffusionReactionSub
 

--- a/docs/content/documentation/systems/Kernels/chemical_reactions/PrimaryConvection.md
+++ b/docs/content/documentation/systems/Kernels/chemical_reactions/PrimaryConvection.md
@@ -1,7 +1,21 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PrimaryConvection
 !syntax description /Kernels/PrimaryConvection
+
+Convective flux of concentration of the $j^{\mathrm{th}}$ primary species.
+Implements the weak form of
+\begin{equation}
+\mathbf{q} \cdot \left(\nabla C_j \right)
+\end{equation}
+where $\mathbf{q}$ is the Darcy velocity
+\begin{equation}
+\mathbf{q} = - \frac{K}{\mu} \left(\nabla P - \rho \mathbf{g}\right),
+\end{equation}
+where $K$ is the permeability tensor, $\mu$ is fluid viscosity, $P$ is pressure,
+$\rho$ is fluid density, and $\mathbf{g}$ is gravity.
+
+!!!note:
+    Currently, gravity is ignored in calculation of the Darcy velocity, and $K/\mu$
+    is provided as the hydraulic conductivity
 
 !syntax parameters /Kernels/PrimaryConvection
 

--- a/docs/content/documentation/systems/Kernels/chemical_reactions/PrimaryDiffusion.md
+++ b/docs/content/documentation/systems/Kernels/chemical_reactions/PrimaryDiffusion.md
@@ -1,7 +1,11 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PrimaryDiffusion
 !syntax description /Kernels/PrimaryDiffusion
+
+Diffusive flux of the $j^{\mathrm{th}}$ primary species. Implements the weak form of
+\begin{equation}
+\nabla \cdot \left(\phi D \nabla C_j \right)
+\end{equation}
+where $\phi$ is porosity and $D$ is the diffusivity.
 
 !syntax parameters /Kernels/PrimaryDiffusion
 

--- a/docs/content/documentation/systems/Kernels/chemical_reactions/PrimaryTimeDerivative.md
+++ b/docs/content/documentation/systems/Kernels/chemical_reactions/PrimaryTimeDerivative.md
@@ -1,7 +1,12 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PrimaryTimeDerivative
 !syntax description /Kernels/PrimaryTimeDerivative
+
+Derivative of concentration of the $j^{\mathrm{th}}$ primary species wrt time.
+Implements the weak form of
+\begin{equation}
+\phi \frac{\partial C_j}{\partial t},
+\end{equation}
+where $\phi$ is porosity.
 
 !syntax parameters /Kernels/PrimaryTimeDerivative
 

--- a/docs/website.yml
+++ b/docs/website.yml
@@ -11,17 +11,19 @@
     links:
         Tests:
             - test/tests
-            - modules/phase_field/tests
-            - modules/tensor_mechanics/tests
-            - modules/heat_conduction/tests
-            - modules/level_set/tests
-            - modules/fluid_properties/tests
-            - modules/porous_flow/tests
+            - modules/phase_field/test/tests
+            - modules/tensor_mechanics/test/tests
+            - modules/heat_conduction/test/tests
+            - modules/level_set/test/tests
+            - modules/fluid_properties/test/tests
+            - modules/porous_flow/test/tests
+            - modules/chemical_reactions/test/tests
         Examples:
             - examples
             - modules/phase_field/examples
             - modules/combined/examples
             - modules/level_set/examples
+            - modules/chemical_reactions/examples
         Tutorials:
             - tutorials
             - modules/tensor_mechanics/tutorials

--- a/modules/chemical_reactions/examples/calcium_bicarbonate/calcium_bicarbonate.i
+++ b/modules/chemical_reactions/examples/calcium_bicarbonate/calcium_bicarbonate.i
@@ -1,0 +1,274 @@
+# Example of reactive transport model with precipitation and dissolution.
+# Calcium (ca2) and bicarbonate (hco3) reaction to form calcite (CaCO3).
+# Models bicarbonate injection following calcium injection, so that a
+# moving reaction front forms a calcite precipitation zone. As the front moves,
+# the upstream side of the front continues to form calcite via precipitation,
+# while at the downstream side, dissolution of the solid calcite occurs.
+#
+# The reaction network considered is as follows:
+# Aqueous equilibrium reactions:
+# a)  h + hco3 = CO2(aq),             Keq = 10^(6.341)
+# b)  hco3 = h + CO23-,               Keq = 10^(-10.325)
+# c)  ca2 + hco3 = h + CaCO3(aq),    Keq = 10^(-7.009)
+# d)  ca2 + hco3 = cahco3,           Keq = 10^(-0.653)
+# e)  ca2 = h + CaOh,                Keq = 10^(-12.85)
+# f)  -h = oh,                        Keq = 10^(-13.991)
+#
+# Kinetic reactions
+# g)  ca2 + hco3 = h + CaCO3(s),    A = 0.461 m^2/L, k = 6.456542e-2 mol/m^2 s,
+#                                      Keq = 10^(1.8487)
+#
+# The primary chemical species are h, hco3 and ca2. The pressure gradient is fixed,
+# and a conservative tracer is also included.
+#
+# This example is taken from:
+# Guo et al, A parallel, fully coupled, fully implicit solution to reactive
+# transport in porous media using the preconditioned Jacobian-Free Newton-Krylov
+# Method, Advances in Water Resources, 53, 101-108 (2013).
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 100
+  xmax = 1
+  ymax = 0.25
+[]
+
+[Variables]
+  [./tracer]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./ca2]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./h]
+    order = FIRST
+    family = LAGRANGE
+    initial_condition = 1.0e-7
+  [../]
+  [./hco3]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./pressure]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[ICs]
+  [./pressure_ic]
+    type = FunctionIC
+    variable = pressure
+    function = pic
+  [../]
+  [./hco3_ic]
+    type = BoundingBoxIC
+    variable = hco3
+    x1 = 0.0
+    y1 = 0.0
+    x2 = 1.0e-10
+    y2 = 0.25
+    inside = 5.0e-2
+    outside = 1.0e-6
+  [../]
+  [./ca2_ic]
+    type = BoundingBoxIC
+    variable = ca2
+    x1 = 0.0
+    y1 = 0.0
+    x2 = 1.0e-10
+    y2 = 0.25
+    inside = 1.0e-6
+    outside = 5.0e-2
+  [../]
+  [./tracer_ic]
+    type = BoundingBoxIC
+    variable = tracer
+    x1 = 0.0
+    y1 = 0.0
+    x2 = 1.0e-10
+    y2 = 0.25
+    inside = 1.0
+    outside = 0.0
+  [../]
+[]
+
+[Functions]
+  [./pic]
+    type = ParsedFunction
+    value = 60-50*x
+  [../]
+[]
+
+[ReactionNetwork]
+  primary_species = 'ca2 hco3 h'
+  [./AqueousEquilibriumReactions]
+    primary_species = 'ca2 hco3 h'
+    secondary_species = 'co2_aq co32 caco3_aq cahco3 caoh oh'
+    pressure = pressure
+    reactions = 'h + hco3 = co2_aq 6.341
+                 hco3 - h = co32 -10.325
+                 ca2 + hco3 - h = caco3_aq -7.009
+                 ca2 + hco3 = cahco3 -0.653
+                 ca2 - h = caoh -12.85
+                 - h = oh -13.991'
+  [../]
+  [./SolidKineticReactions]
+    primary_species = 'ca2 hco3 h'
+    kin_reactions = '(1.0)ca2+(1.0)hco3+(-1.0)h=caco3_s'
+    secondary_species = caco3_s
+    log10_keq = 1.8487
+    reference_temperature = 298.15
+    system_temperature = 298.15
+    gas_constant = 8.314
+    specific_reactive_surface_area = 4.61e-4
+    kinetic_rate_constant = 6.456542e-7
+    activation_energy = 1.5e4
+  [../]
+[]
+
+[Kernels]
+  [./tracer_ie]
+    type = PrimaryTimeDerivative
+    variable = tracer
+  [../]
+  [./tracer_pd]
+    type = PrimaryDiffusion
+    variable = tracer
+  [../]
+  [./tracer_conv]
+    type = PrimaryConvection
+    variable = tracer
+    p = pressure
+  [../]
+  [./ca2_ie]
+    type = PrimaryTimeDerivative
+    variable = ca2
+  [../]
+  [./ca2_pd]
+    type = PrimaryDiffusion
+    variable = ca2
+  [../]
+  [./ca2_conv]
+    type = PrimaryConvection
+    variable = ca2
+    p = pressure
+  [../]
+  [./h_ie]
+    type = PrimaryTimeDerivative
+    variable = h
+  [../]
+  [./h_pd]
+    type = PrimaryDiffusion
+    variable = h
+  [../]
+  [./h_conv]
+    type = PrimaryConvection
+    variable = h
+    p = pressure
+  [../]
+  [./hco3_ie]
+    type = PrimaryTimeDerivative
+    variable = hco3
+  [../]
+  [./hco3_pd]
+    type = PrimaryDiffusion
+    variable = hco3
+  [../]
+  [./hco3_conv]
+    type = PrimaryConvection
+    variable = hco3
+    p = pressure
+  [../]
+[]
+
+[BCs]
+  [./tracer_left]
+    type = DirichletBC
+    variable = tracer
+    boundary = left
+    value = 1.0
+  [../]
+  [./tracer_right]
+    type = ChemicalOutFlowBC
+    variable = tracer
+    boundary = right
+  [../]
+  [./ca2_left]
+    type = SinDirichletBC
+    variable = ca2
+    boundary = left
+    initial = 5.0e-2
+    final = 1.0e-6
+    duration = 1
+  [../]
+  [./ca2_right]
+    type = ChemicalOutFlowBC
+    variable = ca2
+    boundary = right
+  [../]
+  [./hco3_left]
+    type = SinDirichletBC
+    variable = hco3
+    boundary = left
+    initial = 1.0e-6
+    final = 5.0e-2
+    duration = 1
+  [../]
+  [./hco3_right]
+    type = ChemicalOutFlowBC
+    variable = hco3
+    boundary = right
+  [../]
+  [./h_left]
+    type = DirichletBC
+    variable = h
+    boundary = left
+    value = 1.0e-7
+  [../]
+  [./h_right]
+    type = ChemicalOutFlowBC
+    variable = h
+    boundary = right
+  [../]
+[]
+
+[Materials]
+  [./porous]
+    type = GenericConstantMaterial
+    prop_names = 'diffusivity conductivity porosity'
+    prop_values = '1e-7 2e-4 0.2'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = PJFNK
+  l_max_its = 50
+  l_tol = 1e-5
+  nl_max_its = 10
+  nl_rel_tol = 1e-5
+  end_time = 10
+  [./TimeStepper]
+    type = ConstantDT
+    dt = 0.1
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Outputs]
+  print_perf_log = true
+  exodus = true
+[]

--- a/modules/chemical_reactions/examples/calcium_bicarbonate/tests
+++ b/modules/chemical_reactions/examples/calcium_bicarbonate/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./calcium_bicarbonite]
+    type = RunApp
+    input = 'calcium_bicarbonate.i'
+    check_input = true
+  [../]
+[]

--- a/modules/chemical_reactions/src/actions/AddCoupledEqSpeciesAuxKernelsAction.C
+++ b/modules/chemical_reactions/src/actions/AddCoupledEqSpeciesAuxKernelsAction.C
@@ -32,6 +32,7 @@ validParams<AddCoupledEqSpeciesAuxKernelsAction>()
   params.addParam<std::string>("reactions", "The list of aqueous equilibrium reactions");
   params.addParam<std::vector<std::string>>(
       "secondary_species", "The list of aqueous equilibrium species to be output as aux variables");
+  params.addClassDescription("Adds AuxKernels for secondary equilibrium species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/actions/AddCoupledEqSpeciesKernelsAction.C
+++ b/modules/chemical_reactions/src/actions/AddCoupledEqSpeciesKernelsAction.C
@@ -33,6 +33,7 @@ validParams<AddCoupledEqSpeciesKernelsAction>()
       "primary_species", "The list of primary variables to add");
   params.addParam<std::string>("reactions", "The list of aqueous equilibrium reactions");
   params.addParam<std::string>("pressure", "Checks if pressure is a primary variable");
+  params.addClassDescription("Adds Kernels for primary species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/actions/AddCoupledSolidKinSpeciesAuxKernelsAction.C
+++ b/modules/chemical_reactions/src/actions/AddCoupledSolidKinSpeciesAuxKernelsAction.C
@@ -42,6 +42,7 @@ validParams<AddCoupledSolidKinSpeciesAuxKernelsAction>()
       "reference_temperature", "The list of reference temperatures for all reactions, (K)");
   params.addRequiredParam<std::vector<Real>>(
       "system_temperature", "The list of system temperatures for all reactions, (K)");
+  params.addClassDescription("Adds AuxKernels for solid kinetic secondary species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/actions/AddCoupledSolidKinSpeciesKernelsAction.C
+++ b/modules/chemical_reactions/src/actions/AddCoupledSolidKinSpeciesKernelsAction.C
@@ -30,6 +30,7 @@ validParams<AddCoupledSolidKinSpeciesKernelsAction>()
                                                               "The list of primary species to add");
   params.addRequiredParam<std::vector<std::string>>("kin_reactions",
                                                     "The list of solid kinetic reactions");
+  params.addClassDescription("Adds Kernels for primary kinetic species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/actions/AddPrimarySpeciesAction.C
+++ b/modules/chemical_reactions/src/actions/AddPrimarySpeciesAction.C
@@ -28,6 +28,7 @@ validParams<AddPrimarySpeciesAction>()
   InputParameters params = validParams<Action>();
   params.addRequiredParam<std::vector<NonlinearVariableName>>(
       "primary_species", "The list of primary variables to add");
+  params.addClassDescription("Adds Variables for all primary species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/actions/AddSecondarySpeciesAction.C
+++ b/modules/chemical_reactions/src/actions/AddSecondarySpeciesAction.C
@@ -30,6 +30,7 @@ validParams<AddSecondarySpeciesAction>()
   params.addParam<std::vector<AuxVariableName>>("secondary_species",
                                                 "The list of secondary species to add");
   params.addParam<std::vector<std::string>>("kin_reactions", "The list of solid kinetic reactions");
+  params.addClassDescription("Adds AuxVariables for all secondary species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/auxkernels/AqueousEquilibriumRxnAux.C
+++ b/modules/chemical_reactions/src/auxkernels/AqueousEquilibriumRxnAux.C
@@ -16,6 +16,7 @@ validParams<AqueousEquilibriumRxnAux>()
                                              "The stoichiometric coefficient of reactants");
   params.addCoupledVar("v",
                        "The list of primary species participating in this equilibrium species");
+  params.addClassDescription("Concentration of secondary equilibrium species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/auxkernels/KineticDisPreConcAux.C
+++ b/modules/chemical_reactions/src/auxkernels/KineticDisPreConcAux.C
@@ -21,6 +21,7 @@ validParams<KineticDisPreConcAux>()
   params.addParam<Real>("ref_temp", 298.15, "Reference temperature, K");
   params.addParam<Real>("sys_temp", 298.15, "System temperature, K");
   params.addCoupledVar("v", "The list of reactant species");
+  params.addClassDescription("Concentration of secondary kinetic species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/auxkernels/KineticDisPreRateAux.C
+++ b/modules/chemical_reactions/src/auxkernels/KineticDisPreRateAux.C
@@ -21,6 +21,7 @@ validParams<KineticDisPreRateAux>()
   params.addParam<Real>("ref_temp", 298.15, "Reference temperature, K");
   params.addParam<Real>("sys_temp", 298.15, "System temperature, K");
   params.addCoupledVar("v", "The list of reactant species");
+  params.addClassDescription("Kinetic rate of secondary kinetic species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/bcs/ChemicalOutFlowBC.C
+++ b/modules/chemical_reactions/src/bcs/ChemicalOutFlowBC.C
@@ -11,6 +11,7 @@ InputParameters
 validParams<ChemicalOutFlowBC>()
 {
   InputParameters params = validParams<IntegratedBC>();
+  params.addClassDescription("Chemical flux boundary condition");
   return params;
 }
 

--- a/modules/chemical_reactions/src/kernels/CoupledBEEquilibriumSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledBEEquilibriumSub.C
@@ -23,6 +23,7 @@ validParams<CoupledBEEquilibriumSub>()
   params.addRequiredParam<std::vector<Real>>(
       "sto_v", "The stoichiometric coefficients of coupled primary species");
   params.addCoupledVar("v", "Coupled primary species constituting the equilibrium species");
+  params.addClassDescription("Derivative of equilibrium species concentration wrt time");
   return params;
 }
 

--- a/modules/chemical_reactions/src/kernels/CoupledBEKinetic.C
+++ b/modules/chemical_reactions/src/kernels/CoupledBEKinetic.C
@@ -14,6 +14,7 @@ validParams<CoupledBEKinetic>()
   params.addRequiredParam<std::vector<Real>>("weight",
                                              "The weight of kinetic species concentration");
   params.addCoupledVar("v", "List of kinetic species being coupled by concentration");
+  params.addClassDescription("Derivative of kinetic species concentration wrt time");
   return params;
 }
 

--- a/modules/chemical_reactions/src/kernels/CoupledConvectionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledConvectionReactionSub.C
@@ -15,13 +15,14 @@ validParams<CoupledConvectionReactionSub>()
   params.addParam<Real>("log_k", 0.0, "Equilibrium constant of dissociation equilibrium reaction");
   params.addParam<Real>("sto_u",
                         1.0,
-                        "Stoichiometric coef of the primary spceices the kernel "
+                        "Stoichiometric coef of the primary species the kernel "
                         "operates on in the equilibrium reaction");
   params.addRequiredParam<std::vector<Real>>(
       "sto_v",
       "The stoichiometric coefficients of coupled primary species in equilibrium reaction");
   params.addRequiredCoupledVar("p", "Pressure");
   params.addCoupledVar("v", "List of coupled primary species");
+  params.addClassDescription("Convection of equilibrium species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -24,6 +24,7 @@ validParams<CoupledDiffusionReactionSub>()
   params.addRequiredParam<std::vector<Real>>(
       "sto_v", "The stoichiometric coefficients of coupled primary species");
   params.addCoupledVar("v", "List of coupled primary species in this equilibrium species");
+  params.addClassDescription("Diffusion of equilibrium species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/kernels/DesorptionFromMatrix.C
+++ b/modules/chemical_reactions/src/kernels/DesorptionFromMatrix.C
@@ -17,7 +17,7 @@ validParams<DesorptionFromMatrix>()
       "pressure_var",
       "Variable representing the porepressure of the fluid adsorbed into the matrix");
   params.addClassDescription("Mass flow rate from the matrix to the porespace.  Add this to "
-                             "TimeDerivative kernel to get complete DE for the fluid in adsorbed "
+                             "TimeDerivative kernel to get complete DE for the fluid adsorbed "
                              "in the matrix");
   return params;
 }

--- a/modules/chemical_reactions/src/kernels/PrimaryConvection.C
+++ b/modules/chemical_reactions/src/kernels/PrimaryConvection.C
@@ -12,6 +12,7 @@ validParams<PrimaryConvection>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredCoupledVar("p", "Pressure");
+  params.addClassDescription("Convection of primary species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/kernels/PrimaryDiffusion.C
+++ b/modules/chemical_reactions/src/kernels/PrimaryDiffusion.C
@@ -11,6 +11,7 @@ InputParameters
 validParams<PrimaryDiffusion>()
 {
   InputParameters params = validParams<Diffusion>();
+  params.addClassDescription("Diffusion of primary species");
   return params;
 }
 

--- a/modules/chemical_reactions/src/kernels/PrimaryTimeDerivative.C
+++ b/modules/chemical_reactions/src/kernels/PrimaryTimeDerivative.C
@@ -11,6 +11,7 @@ InputParameters
 validParams<PrimaryTimeDerivative>()
 {
   InputParameters params = validParams<TimeDerivative>();
+  params.addClassDescription("Derivative of primary species concentration wrt time");
   return params;
 }
 


### PR DESCRIPTION
Adds some documentation for the chemical reactions module, including some theory, description of objects, and example of using the action system.

Also adds an example based on the geochemistry in [Guo et al](https://www.researchgate.net/publication/255812656_A_Parallel_Fully_Coupled_Fully_Implicit_Solution_to_Reactive_Transport_in_Porous_Media_Using_the_Preconditioned_Jacobian-Free_Newton-Krylov_Method).

The only change to code is the addition of class descriptions in the various objects that didn't have them (and one typo fix). 

I also slipped in a fix to website.yml in 80b6e80 so that the test input files were automatically linked to in the MooseDocs website.

Refs #9769 