### PR TITLE
Cover OffDiagJacobian for dg kernels

### DIFF
--- a/test/include/dgkernels/DGCoupledDiffusion.h
+++ b/test/include/dgkernels/DGCoupledDiffusion.h
@@ -30,13 +30,9 @@ public:
 
 protected:
   virtual Real computeQpResidual(Moose::DGResidualType type) override;
-  virtual Real computeQpJacobian(Moose::DGJacobianType /*type*/) override;
+  virtual Real computeQpJacobian(Moose::DGJacobianType type) override;
   virtual Real computeQpOffDiagJacobian(Moose::DGJacobianType type, unsigned int jvar) override;
 
-  Real _epsilon;
-  Real _sigma;
-  const MaterialProperty<Real> & _diff;
-  const MaterialProperty<Real> & _diff_neighbor;
   MooseVariable & _v_var;
   const VariableValue & _v;
   const VariableValue & _v_neighbor;

--- a/test/include/dgkernels/DGCoupledDiffusion.h
+++ b/test/include/dgkernels/DGCoupledDiffusion.h
@@ -1,0 +1,48 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef DGCOUPLEDDIFFUSION_H
+#define DGCOUPLEDDIFFUSION_H
+
+#include "DGKernel.h"
+
+// Forward Declarations
+class DGCoupledDiffusion;
+
+template <>
+InputParameters validParams<DGCoupledDiffusion>();
+
+class DGCoupledDiffusion : public DGKernel
+{
+public:
+  DGCoupledDiffusion(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual(Moose::DGResidualType type) override;
+  virtual Real computeQpJacobian(Moose::DGJacobianType /*type*/) override;
+  virtual Real computeQpOffDiagJacobian(Moose::DGJacobianType type, unsigned int jvar) override;
+
+  Real _epsilon;
+  Real _sigma;
+  const MaterialProperty<Real> & _diff;
+  const MaterialProperty<Real> & _diff_neighbor;
+  MooseVariable & _v_var;
+  const VariableValue & _v;
+  const VariableValue & _v_neighbor;
+  const VariableGradient & _grad_v;
+  const VariableGradient & _grad_v_neighbor;
+  unsigned int _v_id;
+};
+
+#endif

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -126,6 +126,9 @@
 #include "TestLapBC.h"
 #include "ExampleShapeSideIntegratedBC.h"
 
+// dg kernels
+#include "DGCoupledDiffusion.h"
+
 // ICs
 #include "TEIC.h"
 #include "MTICSum.h"
@@ -448,6 +451,9 @@ MooseTestApp::registerObjects(Factory & factory)
   registerBoundaryCondition(MatDivergenceBC);
   registerBoundaryCondition(CoupledDirichletBC);
   registerBoundaryCondition(TestLapBC);
+
+  // dg kernels
+  registerDGKernel(DGCoupledDiffusion);
 
   // Initial conditions
   registerInitialCondition(TEIC);

--- a/test/src/dgkernels/DGCoupledDiffusion.C
+++ b/test/src/dgkernels/DGCoupledDiffusion.C
@@ -16,31 +16,18 @@
 
 // MOOSE includes
 #include "MooseVariable.h"
-#include "SystemBase.h"
-
-// libMesh includes
-#include "libmesh/utility.h"
 
 template <>
 InputParameters
 validParams<DGCoupledDiffusion>()
 {
   InputParameters params = validParams<DGKernel>();
-  // See header file for sigma and epsilon
-  params.addRequiredParam<Real>("sigma", "sigma");
-  params.addRequiredParam<Real>("epsilon", "epsilon");
-  params.addParam<MaterialPropertyName>(
-      "diff", 1., "The diffusion (or thermal conductivity or viscosity) coefficient.");
   params.addRequiredCoupledVar("v", "The governing variable that controls diffusion of u.");
   return params;
 }
 
 DGCoupledDiffusion::DGCoupledDiffusion(const InputParameters & parameters)
   : DGKernel(parameters),
-    _epsilon(getParam<Real>("epsilon")),
-    _sigma(getParam<Real>("sigma")),
-    _diff(getMaterialProperty<Real>("diff")),
-    _diff_neighbor(getNeighborMaterialProperty<Real>("diff")),
     _v_var(*getVar("v", 0)),
     _v(_v_var.sln()),
     _v_neighbor(_v_var.slnNeighbor()),
@@ -55,28 +42,16 @@ DGCoupledDiffusion::computeQpResidual(Moose::DGResidualType type)
 {
   Real r = 0;
 
-  const unsigned int elem_b_order = _v_var.order();
-  const double h_elem =
-      _current_elem->volume() / _current_side_elem->volume() * 1. / Utility::pow<2>(elem_b_order);
-
   switch (type)
   {
     case Moose::Element:
-      r -= 0.5 * (_diff[_qp] * _grad_v[_qp] * _normals[_qp] +
-                  _diff_neighbor[_qp] * _grad_v_neighbor[_qp] * _normals[_qp]) *
-           _test[_i][_qp];
-      r += _epsilon * 0.5 * (_v[_qp] - _v_neighbor[_qp]) * _diff[_qp] * _grad_test[_i][_qp] *
-           _normals[_qp];
-      r += _sigma / h_elem * (_v[_qp] - _v_neighbor[_qp]) * _test[_i][_qp];
+      r -= _normals[_qp] * (_grad_v[_qp] - _grad_v_neighbor[_qp]) * _test[_i][_qp] +
+           (_v[_qp] - _v_neighbor[_qp]) * _grad_test[_i][_qp] * _normals[_qp];
       break;
 
     case Moose::Neighbor:
-      r += 0.5 * (_diff[_qp] * _grad_v[_qp] * _normals[_qp] +
-                  _diff_neighbor[_qp] * _grad_v_neighbor[_qp] * _normals[_qp]) *
-           _test_neighbor[_i][_qp];
-      r += _epsilon * 0.5 * (_v[_qp] - _v_neighbor[_qp]) * _diff_neighbor[_qp] *
-           _grad_test_neighbor[_i][_qp] * _normals[_qp];
-      r -= _sigma / h_elem * (_v[_qp] - _v_neighbor[_qp]) * _test_neighbor[_i][_qp];
+      r += _normals[_qp] * (_grad_v[_qp] - _grad_v_neighbor[_qp]) * _test[_i][_qp] +
+           (_v[_qp] - _v_neighbor[_qp]) * _grad_test[_i][_qp] * _normals[_qp];
       break;
   }
 
@@ -92,39 +67,26 @@ DGCoupledDiffusion::computeQpOffDiagJacobian(Moose::DGJacobianType type, unsigne
 
   if (jvar == _v_id)
   {
-    const unsigned int elem_b_order = _v_var.order();
-    const double h_elem =
-        _current_elem->volume() / _current_side_elem->volume() * 1. / Utility::pow<2>(elem_b_order);
-
     switch (type)
     {
       case Moose::ElementElement:
-        r -= 0.5 * _diff[_qp] * _grad_phi[_j][_qp] * _normals[_qp] * _test[_i][_qp];
-        r += _epsilon * 0.5 * _phi[_j][_qp] * _diff[_qp] * _grad_test[_i][_qp] * _normals[_qp];
-        r += _sigma / h_elem * _phi[_j][_qp] * _test[_i][_qp];
+        r -= _normals[_qp] * (_grad_phi[_j][_qp]) * _test[_i][_qp] +
+             (_phi[_j][_qp]) * _grad_test[_i][_qp] * _normals[_qp];
         break;
 
       case Moose::ElementNeighbor:
-        r -= 0.5 * _diff_neighbor[_qp] * _grad_phi_neighbor[_j][_qp] * _normals[_qp] *
-             _test[_i][_qp];
-        r += _epsilon * 0.5 * -_phi_neighbor[_j][_qp] * _diff[_qp] * _grad_test[_i][_qp] *
-             _normals[_qp];
-        r += _sigma / h_elem * -_phi_neighbor[_j][_qp] * _test[_i][_qp];
+        r -= _normals[_qp] * (-_grad_phi_neighbor[_j][_qp]) * _test[_i][_qp] +
+             (-_phi_neighbor[_j][_qp]) * _grad_test[_i][_qp] * _normals[_qp];
         break;
 
       case Moose::NeighborElement:
-        r += 0.5 * _diff[_qp] * _grad_phi[_j][_qp] * _normals[_qp] * _test_neighbor[_i][_qp];
-        r += _epsilon * 0.5 * _phi[_j][_qp] * _diff_neighbor[_qp] * _grad_test_neighbor[_i][_qp] *
-             _normals[_qp];
-        r -= _sigma / h_elem * _phi[_j][_qp] * _test_neighbor[_i][_qp];
+        r += _normals[_qp] * (_grad_phi[_j][_qp]) * _test[_i][_qp] +
+             (_phi[_j][_qp]) * _grad_test[_i][_qp] * _normals[_qp];
         break;
 
       case Moose::NeighborNeighbor:
-        r += 0.5 * _diff_neighbor[_qp] * _grad_phi_neighbor[_j][_qp] * _normals[_qp] *
-             _test_neighbor[_i][_qp];
-        r += _epsilon * 0.5 * -_phi_neighbor[_j][_qp] * _diff_neighbor[_qp] *
-             _grad_test_neighbor[_i][_qp] * _normals[_qp];
-        r -= _sigma / h_elem * -_phi_neighbor[_j][_qp] * _test_neighbor[_i][_qp];
+        r += _normals[_qp] * (-_grad_phi_neighbor[_j][_qp]) * _test[_i][_qp] +
+             (-_phi_neighbor[_j][_qp]) * _grad_test[_i][_qp] * _normals[_qp];
         break;
     }
   }

--- a/test/src/dgkernels/DGCoupledDiffusion.C
+++ b/test/src/dgkernels/DGCoupledDiffusion.C
@@ -1,0 +1,133 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "DGCoupledDiffusion.h"
+
+// MOOSE includes
+#include "MooseVariable.h"
+#include "SystemBase.h"
+
+// libMesh includes
+#include "libmesh/utility.h"
+
+template <>
+InputParameters
+validParams<DGCoupledDiffusion>()
+{
+  InputParameters params = validParams<DGKernel>();
+  // See header file for sigma and epsilon
+  params.addRequiredParam<Real>("sigma", "sigma");
+  params.addRequiredParam<Real>("epsilon", "epsilon");
+  params.addParam<MaterialPropertyName>(
+      "diff", 1., "The diffusion (or thermal conductivity or viscosity) coefficient.");
+  params.addRequiredCoupledVar("v", "The governing variable that controls diffusion of u.");
+  return params;
+}
+
+DGCoupledDiffusion::DGCoupledDiffusion(const InputParameters & parameters)
+  : DGKernel(parameters),
+    _epsilon(getParam<Real>("epsilon")),
+    _sigma(getParam<Real>("sigma")),
+    _diff(getMaterialProperty<Real>("diff")),
+    _diff_neighbor(getNeighborMaterialProperty<Real>("diff")),
+    _v_var(*getVar("v", 0)),
+    _v(_v_var.sln()),
+    _v_neighbor(_v_var.slnNeighbor()),
+    _grad_v(_v_var.gradSln()),
+    _grad_v_neighbor(_v_var.gradSlnNeighbor()),
+    _v_id(coupled("v"))
+{
+}
+
+Real
+DGCoupledDiffusion::computeQpResidual(Moose::DGResidualType type)
+{
+  Real r = 0;
+
+  const unsigned int elem_b_order = _v_var.order();
+  const double h_elem =
+      _current_elem->volume() / _current_side_elem->volume() * 1. / Utility::pow<2>(elem_b_order);
+
+  switch (type)
+  {
+    case Moose::Element:
+      r -= 0.5 * (_diff[_qp] * _grad_v[_qp] * _normals[_qp] +
+                  _diff_neighbor[_qp] * _grad_v_neighbor[_qp] * _normals[_qp]) *
+           _test[_i][_qp];
+      r += _epsilon * 0.5 * (_v[_qp] - _v_neighbor[_qp]) * _diff[_qp] * _grad_test[_i][_qp] *
+           _normals[_qp];
+      r += _sigma / h_elem * (_v[_qp] - _v_neighbor[_qp]) * _test[_i][_qp];
+      break;
+
+    case Moose::Neighbor:
+      r += 0.5 * (_diff[_qp] * _grad_v[_qp] * _normals[_qp] +
+                  _diff_neighbor[_qp] * _grad_v_neighbor[_qp] * _normals[_qp]) *
+           _test_neighbor[_i][_qp];
+      r += _epsilon * 0.5 * (_v[_qp] - _v_neighbor[_qp]) * _diff_neighbor[_qp] *
+           _grad_test_neighbor[_i][_qp] * _normals[_qp];
+      r -= _sigma / h_elem * (_v[_qp] - _v_neighbor[_qp]) * _test_neighbor[_i][_qp];
+      break;
+  }
+
+  return r;
+}
+
+Real DGCoupledDiffusion::computeQpJacobian(Moose::DGJacobianType /*type*/) { return 0; }
+
+Real
+DGCoupledDiffusion::computeQpOffDiagJacobian(Moose::DGJacobianType type, unsigned int jvar)
+{
+  Real r = 0;
+
+  if (jvar == _v_id)
+  {
+    const unsigned int elem_b_order = _v_var.order();
+    const double h_elem =
+        _current_elem->volume() / _current_side_elem->volume() * 1. / Utility::pow<2>(elem_b_order);
+
+    switch (type)
+    {
+      case Moose::ElementElement:
+        r -= 0.5 * _diff[_qp] * _grad_phi[_j][_qp] * _normals[_qp] * _test[_i][_qp];
+        r += _epsilon * 0.5 * _phi[_j][_qp] * _diff[_qp] * _grad_test[_i][_qp] * _normals[_qp];
+        r += _sigma / h_elem * _phi[_j][_qp] * _test[_i][_qp];
+        break;
+
+      case Moose::ElementNeighbor:
+        r -= 0.5 * _diff_neighbor[_qp] * _grad_phi_neighbor[_j][_qp] * _normals[_qp] *
+             _test[_i][_qp];
+        r += _epsilon * 0.5 * -_phi_neighbor[_j][_qp] * _diff[_qp] * _grad_test[_i][_qp] *
+             _normals[_qp];
+        r += _sigma / h_elem * -_phi_neighbor[_j][_qp] * _test[_i][_qp];
+        break;
+
+      case Moose::NeighborElement:
+        r += 0.5 * _diff[_qp] * _grad_phi[_j][_qp] * _normals[_qp] * _test_neighbor[_i][_qp];
+        r += _epsilon * 0.5 * _phi[_j][_qp] * _diff_neighbor[_qp] * _grad_test_neighbor[_i][_qp] *
+             _normals[_qp];
+        r -= _sigma / h_elem * _phi[_j][_qp] * _test_neighbor[_i][_qp];
+        break;
+
+      case Moose::NeighborNeighbor:
+        r += 0.5 * _diff_neighbor[_qp] * _grad_phi_neighbor[_j][_qp] * _normals[_qp] *
+             _test_neighbor[_i][_qp];
+        r += _epsilon * 0.5 * -_phi_neighbor[_j][_qp] * _diff_neighbor[_qp] *
+             _grad_test_neighbor[_i][_qp] * _normals[_qp];
+        r -= _sigma / h_elem * -_phi_neighbor[_j][_qp] * _test_neighbor[_i][_qp];
+        break;
+    }
+  }
+
+  return r;
+}

--- a/test/tests/dgkernels/jacobian_testing/coupled_dg_jac_test.i
+++ b/test/tests/dgkernels/jacobian_testing/coupled_dg_jac_test.i
@@ -1,0 +1,67 @@
+###########################################################
+# This is a test of the off diagonal jacobian machinery of
+# the Discontinuous Galerkin System.
+###########################################################
+
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 2
+  elem_type = EDGE2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = MONOMIAL
+  [../]
+  [./v]
+    order = FIRST
+    family = MONOMIAL
+  [../]
+[]
+
+[DGKernels]
+  [./dg_diff]
+    type = DGCoupledDiffusion
+    variable = u
+    v = v
+    epsilon = -1
+    sigma = 6
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+  petsc_options_iname = '-snes_type'
+  petsc_options_value = 'test'
+  petsc_options = '-snes_test_display'
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Problem]
+  kernel_coverage_check = false
+[]
+
+[ICs]
+  [./u]
+    type = RandomIC
+    min = 0.1
+    max = 0.9
+    variable = u
+  [../]
+  [./v]
+    type = RandomIC
+    min = 0.1
+    max = 0.9
+    variable = v
+  [../]
+[]

--- a/test/tests/dgkernels/jacobian_testing/coupled_dg_jac_test.i
+++ b/test/tests/dgkernels/jacobian_testing/coupled_dg_jac_test.i
@@ -27,17 +27,12 @@
     type = DGCoupledDiffusion
     variable = u
     v = v
-    epsilon = -1
-    sigma = 6
   [../]
 []
 
 [Executioner]
   type = Steady
   solve_type = 'NEWTON'
-  petsc_options_iname = '-snes_type'
-  petsc_options_value = 'test'
-  petsc_options = '-snes_test_display'
 []
 
 [Preconditioning]

--- a/test/tests/dgkernels/jacobian_testing/tests
+++ b/test/tests/dgkernels/jacobian_testing/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [./jacobian_test]
+    type = AnalyzeJacobian
+    input = coupled_dg_jac_test.i
+    expect_out = '\nNo errors detected. :-\)\n'
+    recover = false
+    mesh_mode = REPLICATED
+  [../]
+[]


### PR DESCRIPTION
- Creates a dummy test class for testing the off-diagonal Jacobian machinery of `DGKernel`s. 
- Add `AnalyzeJacobian` test

Closes #629 