### PR TITLE
Don't allow malformed input (strings beginning with numbers) when we expect numbers

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -849,7 +849,7 @@ InputParameters::rangeCheck(const std::string & full_name,
         iss.seekg(short_name.size() + 1);
 
         size_t index;
-        if (iss >> index)
+        if (iss >> index && iss.eof())
         {
           if (index >= value.size())
           {

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -631,7 +631,7 @@ SystemBase::copyVars(ExodusII_IO & io)
     else
     {
       std::istringstream ss(vci._timestep);
-      if (!(ss >> timestep) || timestep > n_steps)
+      if (!((ss >> timestep) && ss.eof()) || timestep > n_steps)
         mooseError("Invalid value passed as \"initial_from_file_timestep\". Expected \"LATEST\" or "
                    "a valid integer between 1 and ",
                    n_steps,

--- a/framework/src/functions/MooseParsedFunctionWrapper.C
+++ b/framework/src/functions/MooseParsedFunctionWrapper.C
@@ -148,7 +148,7 @@ MooseParsedFunctionWrapper::initialize()
     {
       // Use istringstream to convert, if it fails produce an error, otherwise add the variable to
       // the _vals variable
-      if (!(ss >> tmp))
+      if (!(ss >> tmp) || !ss.eof())
         mooseError(
             "The input value '",
             _vals_input[i],

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1022,7 +1022,7 @@ MooseMesh::getBoundaryIDs(const std::vector<BoundaryName> & boundary_name,
     BoundaryID id;
     std::istringstream ss(boundary_name[i]);
 
-    if (!(ss >> id))
+    if (!(ss >> id) || !ss.eof())
     {
       /**
        * If the conversion from a name to a number fails, that means that this must be a named
@@ -1052,7 +1052,7 @@ MooseMesh::getSubdomainID(const SubdomainName & subdomain_name) const
   SubdomainID id = Moose::INVALID_BLOCK_ID;
   std::istringstream ss(subdomain_name);
 
-  if (!(ss >> id))
+  if (!(ss >> id) || !ss.eof())
     id = getMesh().get_id_by_name(subdomain_name);
 
   return id;
@@ -1077,7 +1077,7 @@ MooseMesh::getSubdomainIDs(const std::vector<SubdomainName> & subdomain_name) co
     SubdomainID id = Moose::INVALID_BLOCK_ID;
     std::istringstream ss(subdomain_name[i]);
 
-    if (!(ss >> id))
+    if (!(ss >> id) || !ss.eof())
       id = getMesh().get_id_by_name(subdomain_name[i]);
 
     ids[i] = id;

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -222,7 +222,7 @@ SolutionUserObject::readExodusII()
     else
     {
       std::istringstream ss(s_timestep);
-      if (!(ss >> _exodus_time_index) || _exodus_time_index > n_steps)
+      if (!((ss >> _exodus_time_index) && ss.eof()) || _exodus_time_index > n_steps)
         mooseError("Invalid value passed as \"timestep\". Expected \"LATEST\" or a valid integer "
                    "less than ",
                    n_steps,

--- a/test/include/userobjects/ToggleMeshAdaptivity.h
+++ b/test/include/userobjects/ToggleMeshAdaptivity.h
@@ -38,7 +38,7 @@ protected:
 
   MooseEnum _state;
 
-  unsigned int _steps_to_wait;
+  int _steps_to_wait;
 };
 
 #endif /* TOGGLEMESHADAPTIVITY_H */

--- a/test/src/userobjects/ToggleMeshAdaptivity.C
+++ b/test/src/userobjects/ToggleMeshAdaptivity.C
@@ -23,17 +23,16 @@ validParams<ToggleMeshAdaptivity>()
   InputParameters params = validParams<GeneralUserObject>();
   params.addRequiredParam<MooseEnum>(
       "mesh_adaptivity", state, "Control mesh adaptivity, choices are 'on' or 'off'.");
-  params.addParam<unsigned int>(
-      "apply_after_timestep",
-      0,
-      "Number of time steps to wait before applying the adaptivity state.");
+  params.addParam<int>("apply_after_timestep",
+                       0,
+                       "Number of time steps to wait before applying the adaptivity state.");
   return params;
 }
 
 ToggleMeshAdaptivity::ToggleMeshAdaptivity(const InputParameters & params)
   : GeneralUserObject(params),
     _state(getParam<MooseEnum>("mesh_adaptivity")),
-    _steps_to_wait(getParam<unsigned int>("apply_after_timestep"))
+    _steps_to_wait(getParam<int>("apply_after_timestep"))
 {
 }
 


### PR DESCRIPTION
This PR patches up several places where we could be accepting bad input where we expect an integer (e.g. 5elephant).

As a bonus, I fixed up a small sign comparison warning I noticed.