### PR TITLE
Fixup RegEx to handle contiguous caps at the beginning of word

### DIFF
--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -242,7 +242,7 @@ camelCaseToUnderscore(const std::string & camel_case_name)
 {
   string replaced = camel_case_name;
   // Put underscores in front of each contiguous set of capital letters
-  pcrecpp::RE("(?!^)([A-Z]+)").GlobalReplace("_\\1", &replaced);
+  pcrecpp::RE("(?!^)(?<![A-Z])([A-Z]+)").GlobalReplace("_\\1", &replaced);
 
   // Convert all capital letters to lower case
   std::transform(replaced.begin(), replaced.end(), replaced.begin(), ::tolower);

--- a/unit/src/MooseUtilsTest.C
+++ b/unit/src/MooseUtilsTest.C
@@ -22,6 +22,12 @@ TEST(MooseUtils, camelCaseToUnderscore)
   EXPECT_EQ(MooseUtils::camelCaseToUnderscore("Foo"), "foo");
   EXPECT_EQ(MooseUtils::camelCaseToUnderscore("FooBar"), "foo_bar");
   EXPECT_EQ(MooseUtils::camelCaseToUnderscore("fooBar"), "foo_bar");
+
+  EXPECT_EQ(MooseUtils::camelCaseToUnderscore("FOObar"), "foobar");
+  EXPECT_EQ(MooseUtils::camelCaseToUnderscore("fooBAR"), "foo_bar");
+
+  EXPECT_EQ(MooseUtils::camelCaseToUnderscore("PhaseFieldApp"), "phase_field_app");
+  EXPECT_EQ(MooseUtils::camelCaseToUnderscore("XFEMApp"), "xfemapp");
 }
 
 TEST(MooseUtils, underscoreToCamelCase)


### PR DESCRIPTION
This PR adds a negative lookbehind to make sure that we don't
start matching in the middle of a string of cap characters.

closes #9492
