### PR TITLE
BreakBoundaryOnSubdomain support for distributed meshes

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1003,7 +1003,8 @@ MooseMesh::getBoundaryIDs(const std::vector<BoundaryName> & boundary_name,
 
   // On a distributed mesh we may have boundary ids that only exist on
   // other processors.
-  _communicator.set_union(boundary_ids);
+  if (!this->getMesh().is_replicated())
+    _communicator.set_union(boundary_ids);
 
   BoundaryID max_boundary_id = boundary_ids.empty() ? 0 : *(boundary_ids.rbegin());
 

--- a/test/tests/dgkernels/dg_block_restrict/2d_dg_diffusion_block_restrict.i
+++ b/test/tests/dgkernels/dg_block_restrict/2d_dg_diffusion_block_restrict.i
@@ -5,7 +5,6 @@
   nx = 10
   ymax = 2
   ny = 10
-  parallel_type = replicated
 []
 
 [MeshModifiers]


### PR DESCRIPTION
This should fix #9700 once we can merge it.

It depends on the new libMesh method added in libMesh/libmesh#1415, however, so we'll need to wait until after MOOSE's next libMesh update (hopefully ASAP, but I have one more PR to slip in there first) before Civet will even be able to compile it.