### PR TITLE
C++17 try_emplace

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -54,6 +54,29 @@ class Factory;
 #define FORTRAN_CALL(name) name##_
 #endif
 
+/**
+ * Function to mirror the behavior of the C++17 std::map::try_emplace() method (no hint).
+ * @param m The std::map
+ * @param k The key use to insert the pair
+ * @param args The value to be inserted. This can be a moveable type but won't be moved
+ *             if the insertion is successful.
+ */
+template <class M, class... Args>
+std::pair<typename M::iterator, bool>
+moose_try_emplace(M & m, const typename M::key_type & k, Args &&... args)
+{
+  auto it = m.lower_bound(k);
+  if (it == m.end() || m.key_comp()(k, it->first))
+  {
+    return {m.emplace_hint(it,
+                           std::piecewise_construct,
+                           std::forward_as_tuple(k),
+                           std::forward_as_tuple(std::forward<Args>(args)...)),
+            true};
+  }
+  return {it, false};
+}
+
 // forward declarations
 class Syntax;
 class FEProblemBase;

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -276,12 +276,9 @@ ErrorVector &
 Adaptivity::getErrorVector(const std::string & indicator_field)
 {
   // Insert or retrieve error vector
-  auto ev_pair_it = _indicator_field_to_error_vector.lower_bound(indicator_field);
-  if (ev_pair_it == _indicator_field_to_error_vector.end() || ev_pair_it->first != indicator_field)
-    ev_pair_it = _indicator_field_to_error_vector.emplace_hint(
-        ev_pair_it, indicator_field, libmesh_make_unique<ErrorVector>());
-
-  return *ev_pair_it->second;
+  auto insert_pair = moose_try_emplace(
+      _indicator_field_to_error_vector, indicator_field, libmesh_make_unique<ErrorVector>());
+  return *insert_pair.first->second;
 }
 
 void

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -5091,12 +5091,10 @@ FEProblemBase::solverParams()
 void
 FEProblemBase::registerRandomInterface(RandomInterface & random_interface, const std::string & name)
 {
-  auto rand_pair_it = _random_data_objects.lower_bound(name);
-  if (rand_pair_it == _random_data_objects.end() || rand_pair_it->first != name)
-    rand_pair_it = _random_data_objects.emplace_hint(
-        rand_pair_it, name, libmesh_make_unique<RandomData>(*this, random_interface));
+  auto insert_pair = moose_try_emplace(
+      _random_data_objects, name, libmesh_make_unique<RandomData>(*this, random_interface));
 
-  auto random_data_ptr = rand_pair_it->second.get();
+  auto random_data_ptr = insert_pair.first->second.get();
   random_interface.setRandomDataPointer(random_data_ptr);
 }
 

--- a/framework/src/outputs/TableOutput.C
+++ b/framework/src/outputs/TableOutput.C
@@ -110,11 +110,10 @@ TableOutput::outputVectorPostprocessors()
     {
       const auto & vectors = _problem_ptr->getVectorPostprocessorVectors(vpp_name);
 
-      auto table_it = _vector_postprocessor_tables.lower_bound(vpp_name);
-      if (table_it == _vector_postprocessor_tables.end() || table_it->first != vpp_name)
-        table_it = _vector_postprocessor_tables.emplace_hint(table_it, vpp_name, FormattedTable());
+      auto insert_pair =
+          moose_try_emplace(_vector_postprocessor_tables, vpp_name, FormattedTable());
 
-      FormattedTable & table = table_it->second;
+      FormattedTable & table = insert_pair.first->second;
 
       table.clear();
       table.outputTimeColumn(false);

--- a/modules/phase_field/src/postprocessors/FauxGrainTracker.C
+++ b/modules/phase_field/src/postprocessors/FauxGrainTracker.C
@@ -166,10 +166,11 @@ FauxGrainTracker::execute()
       _fe_problem.reinitElemPhys(current_elem, centroid, 0);
 
       auto entity = current_elem->id();
-      auto map_it = _entity_var_to_features.lower_bound(entity);
-      if (map_it == _entity_var_to_features.end() || map_it->first != entity)
-        map_it = _entity_var_to_features.emplace_hint(
-            map_it, entity, std::vector<unsigned int>(_n_vars, FeatureFloodCount::invalid_id));
+      auto insert_pair =
+          moose_try_emplace(_entity_var_to_features,
+                            entity,
+                            std::vector<unsigned int>(_n_vars, FeatureFloodCount::invalid_id));
+      auto & vec_ref = insert_pair.first->second;
 
       for (auto var_num = beginIndex(_vars); var_num < _n_vars; ++var_num)
       {
@@ -184,7 +185,7 @@ FauxGrainTracker::execute()
           _vol_count[var_num]++;
           // Sum the centroid values for now, we'll average them later
           _centroid[var_num] += current_elem->centroid();
-          map_it->second[var_num] = var_num;
+          vec_ref[var_num] = var_num;
           break;
         }
       }

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -958,11 +958,10 @@ FeatureFloodCount::updateFieldInfo()
       // Fill in the data structure that keeps track of all features per elem
       if (_compute_var_to_feature_map)
       {
-        auto map_it = _entity_var_to_features.lower_bound(entity);
-        if (map_it == _entity_var_to_features.end() || map_it->first != entity)
-          map_it = _entity_var_to_features.emplace_hint(
-              map_it, entity, std::vector<unsigned int>(_n_vars, invalid_id));
-        map_it->second[feature._var_index] = feature._id;
+        auto insert_pair = moose_try_emplace(
+            _entity_var_to_features, entity, std::vector<unsigned int>(_n_vars, invalid_id));
+        auto & vec_ref = insert_pair.first->second;
+        vec_ref[feature._var_index] = feature._id;
       }
     }
 

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -1349,18 +1349,18 @@ GrainTracker::updateFieldInfo()
 
       if (_compute_var_to_feature_map)
       {
-        auto map_it = _entity_var_to_features.lower_bound(entity);
-        if (map_it == _entity_var_to_features.end() || map_it->first != entity)
-        {
-          map_it = _entity_var_to_features.emplace_hint(
-              map_it, entity, std::vector<unsigned int>(_n_vars, invalid_id));
+        auto insert_pair = moose_try_emplace(
+            _entity_var_to_features, entity, std::vector<unsigned int>(_n_vars, invalid_id));
+        auto & vec_ref = insert_pair.first->second;
 
+        if (insert_pair.second)
+        {
           // insert the reserve op numbers (if appropriate)
           for (auto reserve_index = decltype(_n_reserve_ops)(0); reserve_index < _n_reserve_ops;
                ++reserve_index)
-            map_it->second[reserve_index] = _reserve_grain_first_index + reserve_index;
+            vec_ref[reserve_index] = _reserve_grain_first_index + reserve_index;
         }
-        map_it->second[grain._var_index] = grain._id;
+        vec_ref[grain._var_index] = grain._id;
       }
     }
 


### PR DESCRIPTION
This handy little function helps people insert a new key without searching through a map twice. More importantly, it allows you to insert movable types properly.

refs #9680