### PR TITLE
Don't override more restrictive app level settings

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -674,7 +674,7 @@ MooseApp::setCheckUnusedFlag(bool warn_is_error)
 {
   /**
    * _enable_unused_check is initialized to WARN_UNUSED. If an application chooses to promote
-   * this value to ERROR_UNUSED pragmatically prior to running the simulation, we certainly
+   * this value to ERROR_UNUSED programmatically prior to running the simulation, we certainly
    * don't want to allow it to fall back. Therefore, we won't set it if it's already at the
    * highest value (i.e. error). If however a developer turns it off, it can still be turned on.
    */


### PR DESCRIPTION
This patch prevents users from overridding application level settings
for parameter errors.

closes #9795
