### PR TITLE
smeared_cracking use_old_floor, looser tolerance

### DIFF
--- a/modules/tensor_mechanics/test/tests/smeared_cracking/tests
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/tests
@@ -4,7 +4,8 @@
     input = 'cracking_exponential.i'
     exodiff = 'cracking_exponential_out.e'
     rel_err = 1.0e-03
-    abs_zero = 1.0e-5
+    abs_zero = 4.0e-4
+    use_old_floor = true
     compiler = 'GCC CLANG'
   [../]
   [./single_edge_notch]


### PR DESCRIPTION
This is partly another case of #9414, but also another "leakage" of
solver error into unaligned stress variables.  I think even the looser
floor tolerance is probably acceptable here; the magnitude of the
stress in this problem is around 1e10 times higher.