### PR TITLE
Enable contact verification tests with 64bit indices

### DIFF
--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_kin_sm.i
@@ -275,6 +275,7 @@
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu       superlu_dist'
+  petsc_options = '-mat_superlu_dist_iterrefine -mat_superlu_dist_replacetinypivot'
 
   line_search = 'none'
 

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
@@ -156,10 +156,9 @@
     max_parallel = 1
     superlu = true
 
-    # This test is unstable on PETSc 3.7.4 with 64bit indices enabled.
-    dof_id_bytes = 4
     # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    skip = 'Reevaluate under PETSc 3.7.4. and PETSc 3.7.5 #8200'
+    compiler = 'GCC CLANG'
+    petsc_version = '>=3.7.6'
     prereq = 'mu_0_2_kin'
   [../]
   [./mu_0_2_pen_sm]

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_kin_sm.i
@@ -267,6 +267,7 @@
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu       superlu_dist'
+  petsc_options = '-mat_superlu_dist_iterrefine -mat_superlu_dist_replacetinypivot'
 
   line_search = 'none'
 

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
@@ -147,7 +147,7 @@ eTests]
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    skip = 'Reevaluate under PETSc 3.7.4. #8200'
+    petsc_version = '>=3.7.6'
   [../]
   [./mu_0_2_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template1.i
@@ -274,6 +274,7 @@
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu     superlu_dist'
+  petsc_options = '-mat_superlu_dist_iterrefine -mat_superlu_dist_replacetinypivot'
 
   line_search = 'none'
 

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/tests
@@ -31,7 +31,7 @@
     max_parallel = 1
     superlu = true
     prereq = 'frictionless_kin_sm'
-    skip = 'Reevaluate under PETSc 3.7.4. #8200.'
+    petsc_version = '>=3.7.6'
   [../]
   [./frictionless_pen]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
@@ -10,13 +10,13 @@
     max_parallel = 1
     superlu = true
     prereq = 'glued_kin_sm'
-    skip = 'Reevaluate under PETSc 3.7.4. #8200.'
+    petsc_version = '>=3.7.6'
   [../]
   [./glued_pen]
     type = 'CSVDiff'
     input = 'single_point_2d.i'
     csvdiff = 'single_point_2d_out_glued_pen.csv'
-    cli_args = 'Executioner/end_time=0.002 Executioner/l_tol=1e-4 Executioner/nl_rel_tol=1e-8 Executioner/nl_abs_tol=1e-10 
+    cli_args = 'Executioner/end_time=0.002 Executioner/l_tol=1e-4 Executioner/nl_rel_tol=1e-8 Executioner/nl_abs_tol=1e-10
     Contact/leftright/formulation=penalty Contact/leftright/penalty=2.0e12 Outputs/file_base=single_point_2d_out_glued_pen'
     rel_err = 5e-4
     abs_zero = 3e-5
@@ -72,7 +72,7 @@
 #    type = 'CSVDiff'
 #    input = 'single_point_2d_frictional.i'
 #    csvdiff = 'single_point_2d_out_fric_1_0_kin.csv'
-#    cli_args = 'Executioner/end_time=0.002 Executioner/nl_rel_tol=1e-7 Executioner/nl_abs_tol=1e-9 
+#    cli_args = 'Executioner/end_time=0.002 Executioner/nl_rel_tol=1e-7 Executioner/nl_abs_tol=1e-9
 #    Contact/leftright/model=coulomb Contact/leftright/formulation=kinematic Contact/leftright/friction_coefficient=1.0e2 Outputs/file_base=single_point_2d_out_fric_1_0_kin'
 #    rel_err = 1e-4
 #    abs_zero = 1e-5
@@ -117,7 +117,7 @@
     type = 'CSVDiff'
     input = 'single_point_2d_sm.i'
     csvdiff = 'single_point_2d_out_glued_pen_sm.csv'
-    cli_args = 'Executioner/end_time=0.002 Executioner/l_tol=1e-4 Executioner/nl_rel_tol=1e-8 Executioner/nl_abs_tol=1e-10 
+    cli_args = 'Executioner/end_time=0.002 Executioner/l_tol=1e-4 Executioner/nl_rel_tol=1e-8 Executioner/nl_abs_tol=1e-10
     Contact/leftright/formulation=penalty Contact/leftright/penalty=5.0e12 Outputs/file_base=single_point_2d_out_glued_pen_sm'
     rel_err = 1e-4
     abs_zero = 3e-5
@@ -168,7 +168,7 @@
 #    type = 'CSVDiff'
 #    input = 'single_point_2d_frictional.i'
 #    csvdiff = 'single_point_2d_out_fric_1_0_kin.csv'
-#    cli_args = 'Executioner/end_time=0.002 Executioner/nl_rel_tol=1e-7 Executioner/nl_abs_tol=1e-9 
+#    cli_args = 'Executioner/end_time=0.002 Executioner/nl_rel_tol=1e-7 Executioner/nl_abs_tol=1e-9
 #    Contact/leftright/model=coulomb Contact/leftright/formulation=kinematic Contact/leftright/friction_coefficient=1.0e2 Outputs/file_base=single_point_2d_out_fric_1_0_kin'
 #    rel_err = 1e-4
 #    abs_zero = 1e-5

--- a/modules/combined/test/tests/frictional_contact/single_point_2d/single_point_2d.i
+++ b/modules/combined/test/tests/frictional_contact/single_point_2d/single_point_2d.i
@@ -184,6 +184,7 @@
 
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
   petsc_options_value = 'lu    superlu_dist'
+  petsc_options = '-mat_superlu_dist_iterrefine -mat_superlu_dist_replacetinypivot'
 
   line_search = 'none'
 

--- a/modules/combined/test/tests/frictional_contact/single_point_2d/tests
+++ b/modules/combined/test/tests/frictional_contact/single_point_2d/tests
@@ -5,6 +5,7 @@
     exodiff = 'single_point_2d_out.e'
     custom_cmp = 'single_point_2d.cmp'
     superlu = true
+    compiler = 'GCC CLANG'
   [../]
   [./fcp]
     type = 'Exodiff'

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -61,6 +61,9 @@ LIBMESH_OPTIONS = {
   'petsc_minor' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_PETSC_VERSION_MINOR\s+(\d+)',
                      'default'   : '1'
                    },
+  'petsc_subminor' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_PETSC_VERSION_SUBMINOR\s+(\d+)',
+                     'default'   : '1'
+                   },
   'petsc_version_release' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_PETSC_VERSION_RELEASE\s+(\d+)',
                      'default'   : 'TRUE',
                      'options'   : {'TRUE'  : '1', 'FALSE' : '0'}
@@ -239,11 +242,12 @@ def getCompilers(libmesh_dir):
 def getPetscVersion(libmesh_dir):
     major_version = getLibMeshConfigOption(libmesh_dir, 'petsc_major')
     minor_version = getLibMeshConfigOption(libmesh_dir, 'petsc_minor')
+    subminor_version = getLibMeshConfigOption(libmesh_dir, 'petsc_subminor')
     if len(major_version) != 1 or len(minor_version) != 1:
         print "Error determining PETSC version"
         exit(1)
 
-    return major_version.pop() + '.' + minor_version.pop()
+    return major_version.pop() + '.' + minor_version.pop() + '.' + subminor_version.pop()
 
 def getSlepcVersion(libmesh_dir):
     major_version = getLibMeshConfigOption(libmesh_dir, 'slepc_major')
@@ -270,13 +274,13 @@ def checkPetscVersion(checks, test):
             else:
                 return (False, '!=', version)
         # Logical match
-        if logic == '>' and checks['petsc_version'][0:3] > version[0:3]:
+        if logic == '>' and checks['petsc_version'][0:5] > version[0:5]:
             return (True, None, version)
-        elif logic == '>=' and checks['petsc_version'][0:3] >= version[0:3]:
+        elif logic == '>=' and checks['petsc_version'][0:5] >= version[0:5]:
             return (True, None, version)
-        elif logic == '<' and checks['petsc_version'][0:3] < version[0:3]:
+        elif logic == '<' and checks['petsc_version'][0:5] < version[0:5]:
             return (True, None, version)
-        elif logic == '<=' and checks['petsc_version'][0:3] <= version[0:3]:
+        elif logic == '<=' and checks['petsc_version'][0:5] <= version[0:5]:
             return (True, None, version)
     return (False, logic, version)
 


### PR DESCRIPTION
Some tests that failed with old PETSc should work with PETSc-3.7.6

Close #8200
