### PR TITLE
benchmarking capability

### DIFF
--- a/docs/content/documentation/systems/UserObjects/framework/PerflogDumper.md
+++ b/docs/content/documentation/systems/UserObjects/framework/PerflogDumper.md
@@ -1,0 +1,14 @@
+
+# PerflogDumper
+!syntax description /UserObjects/PerflogDumper
+
+## Description
+
+Use this to collect MOOSE's performance log information in a structured CSV format for further
+extra-MOOSE analysis.
+
+!syntax parameters /UserObjects/PerflogDumper
+
+!syntax inputs /UserObjects/PerflogDumper
+
+!syntax children /UserObjects/PerflogDumper

--- a/framework/include/userobject/PerflogDumper.h
+++ b/framework/include/userobject/PerflogDumper.h
@@ -12,31 +12,25 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-// STL includes
-#include <vector>
+#ifndef PERFLOGDUMPER_H
+#define PERFLOGDUMPER_H
 
-// MOOSE includes
-#include "MooseTypes.h"
+#include "GeneralUserObject.h"
 
-namespace Moose
+class PerflogDumper;
+
+template <>
+InputParameters validParams<PerflogDumper>();
+
+/// Records all post processor data in a CSV file.
+class PerflogDumper : public GeneralUserObject
 {
+public:
+  PerflogDumper(const InputParameters & parameters);
 
-// Currently there are 7 exec types (See MooseTypes.h)
-const std::vector<ExecFlagType>
-populateExecTypes()
-{
-  std::vector<ExecFlagType> exec_types(8);
-  exec_types[0] = EXEC_INITIAL;
-  exec_types[1] = EXEC_TIMESTEP_BEGIN;
-  exec_types[2] = EXEC_NONLINEAR;
-  exec_types[3] = EXEC_LINEAR;
-  exec_types[4] = EXEC_TIMESTEP_END;
-  exec_types[5] = EXEC_CUSTOM;
-  exec_types[6] = EXEC_SUBDOMAIN;
-  exec_types[7] = EXEC_FINAL;
-  return exec_types;
-}
+  virtual void initialize() override{};
+  virtual void execute() override;
+  virtual void finalize() override{};
+};
 
-const std::vector<ExecFlagType> exec_types = populateExecTypes();
-
-} // namespace Moose
+#endif

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -277,6 +277,7 @@
 #include "NodalNormalsCorner.h"
 #include "NodalNormalsPreprocessor.h"
 #include "SolutionUserObject.h"
+#include "PerflogDumper.h"
 #ifdef LIBMESH_HAVE_FPARSER
 #include "Terminator.h"
 #endif
@@ -737,6 +738,7 @@ registerObjects(Factory & factory)
   registerUserObject(NodalNormalsCorner);
   registerUserObject(NodalNormalsEvaluator);
   registerUserObject(SolutionUserObject);
+  registerUserObject(PerflogDumper);
 #ifdef LIBMESH_HAVE_FPARSER
   registerUserObject(Terminator);
 #endif

--- a/framework/src/base/SetupInterface.C
+++ b/framework/src/base/SetupInterface.C
@@ -110,6 +110,6 @@ MultiMooseEnum
 SetupInterface::getExecuteOptions()
 {
   return MultiMooseEnum("none=0x00 initial=0x01 linear=0x02 nonlinear=0x04 timestep_end=0x08 "
-                        "timestep_begin=0x10 custom=0x100",
+                        "timestep_begin=0x10 final=0x20 custom=0x100",
                         "linear");
 }

--- a/framework/src/executioners/Steady.C
+++ b/framework/src/executioners/Steady.C
@@ -112,6 +112,8 @@ Steady::execute()
   }
 #endif
 
+  _problem.execute(EXEC_FINAL);
+
   postExecute();
 }
 

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -331,7 +331,10 @@ Transient::execute()
   }
 
   if (!_app.halfTransient())
+  {
     _problem.outputStep(EXEC_FINAL);
+    _problem.execute(EXEC_FINAL);
+  }
 
   // This method is to finalize anything else we want to do on the problem side.
   _problem.postExecute();

--- a/framework/src/userobject/PerflogDumper.C
+++ b/framework/src/userobject/PerflogDumper.C
@@ -1,0 +1,54 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "PerflogDumper.h"
+#include "libmesh/perf_log.h"
+
+#include <ostream>
+
+template <>
+InputParameters
+validParams<PerflogDumper>()
+{
+  InputParameters params = validParams<GeneralUserObject>();
+  params.set<MultiMooseEnum>("execute_on") = "final";
+  params.addParam<std::string>("outfile", "perflog.csv", "name of perf log output file");
+  params.addClassDescription("Dumps perlog information to a csv file for further analysis.");
+  return params;
+}
+
+PerflogDumper::PerflogDumper(const InputParameters & parameters) : GeneralUserObject(parameters) {}
+
+void
+PerflogDumper::execute()
+{
+  auto & log = Moose::perf_log.get_log_raw();
+  std::ofstream f(_pars.get<std::string>("outfile"));
+  if (!f.good())
+    mooseError("PerfLogDumper: error opening file '", _pars.get<std::string>("outfile"), "'");
+
+  f << "category,subcategory,n_calls,tot_time_self,tot_time_cum\n";
+  for (auto & entry : log)
+  {
+    const std::string & cat = entry.first.first;
+    const std::string & subcat = entry.first.second;
+    const PerfData & data = entry.second;
+
+    f << "\"" << cat << "\""
+      << ",\"" << subcat << "\""
+      << "," << data.count << "," << data.tot_time << "," << data.tot_time_incl_sub << "\n";
+  }
+  if (!f.good())
+    mooseError("PerfLogDumper: error writing file '", _pars.get<std::string>("outfile"), "'");
+}

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -45,6 +45,7 @@ initExecStoreType()
     execstore_type_to_enum["NONLINEAR"] = EXEC_NONLINEAR;
     execstore_type_to_enum["TIMESTEP_END"] = EXEC_TIMESTEP_END;
     execstore_type_to_enum["TIMESTEP_BEGIN"] = EXEC_TIMESTEP_BEGIN;
+    execstore_type_to_enum["FINAL"] = EXEC_FINAL;
     execstore_type_to_enum["CUSTOM"] = EXEC_CUSTOM;
   }
 }

--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python
+
+import subprocess
+import time
+from scipy.stats import mannwhitneyu
+import numpy
+import sqlite3
+import os
+import gc
+import shutil
+import csv
+import tempfile
+import threading
+import resource
+
+from Tester import Tester
+
+def process_timeout(proc, timeout_sec):
+  kill_proc = lambda p: p.kill()
+  timer = threading.Timer(timeout_sec, kill_proc, [proc])
+  try:
+    timer.start()
+    proc.wait()
+  finally:
+    timer.cancel()
+
+class Test:
+    def __init__(self, executable, infile, rootdir='.', args=None, perflog=False):
+        self.rootdir = rootdir
+        self.executable = executable
+        self.infile = infile
+        self.args = args
+        self.dur_secs = 0
+        self.perflog = []
+        self.getpot_options = ['Outputs/console=false', 'Outputs/exodus=false', 'Outputs/csv=false']
+        self.have_perflog = perflog
+        if self.have_perflog:
+            self.getpot_options.append('UserObjects/perflog/type=PerflogDumper')
+
+    def _buildcmd(self):
+        cmdpath = os.path.abspath(os.path.join(self.rootdir, self.executable))
+        infilepath = os.path.abspath(os.path.join(self.rootdir, self.infile))
+        cmd = [cmdpath, '-i', infilepath]
+        if self.args is not None:
+            cmd.extend(self.args)
+        cmd.extend(self.getpot_options)
+
+        # check for linux cpu isolation
+        isolpath = '/sys/devices/system/cpu/isolated'
+        cpuid = None
+        if os.path.exists(isolpath):
+            with open(isolpath, 'r') as f:
+                cpus = f.read().split(',')
+                if len(cpus[0].strip()) > 0:
+                    cpuid = cpus[0]
+        if cpuid:
+            cmd = ['taskset', '-c', cpuid] + cmd
+        return cmd
+
+    def reset(self):
+        self.perflog = []
+        self.dur_secs = 0
+
+    def run(self, timer=None, timeout=300):
+        self.reset()
+        cmd = self._buildcmd()
+
+        tmpdir =  tempfile.mkdtemp()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        os.makedirs(tmpdir)
+
+        rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        start = rusage.ru_utime
+        gc.disable()
+        with open(os.devnull, 'w') as devnull:
+            if timer:
+                timer.start()
+            p = subprocess.Popen(cmd, cwd=tmpdir, stdout=devnull, stderr=devnull)
+            process_timeout(p, timeout)
+            if timer:
+                timer.stop()
+        gc.enable()
+        rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        end = rusage.ru_utime
+
+        if p.returncode != 0:
+            raise RuntimeError('command {} returned nonzero exit code'.format(cmd))
+
+        self.dur_secs = end - start
+
+        # write perflog
+        if self.have_perflog:
+            with open(os.path.join(tmpdir, 'perflog.csv'), 'r') as csvfile:
+                reader = csv.reader(csvfile)
+                skip = True # use to skip header line
+                for row in reader:
+                    if not skip:
+                        self.perflog.append(row)
+                    else:
+                        skip = False
+
+        shutil.rmtree(tmpdir)
+
+class SpeedTest(Tester):
+    @staticmethod
+    def validParams():
+        params = Tester.validParams()
+        params.addParam('input',              'The input file to use for this test.')
+        params.addParam('test_name',          'The name of the test - populated automatically')
+        params.addParam('cumulative_dur', 60, 'cumulative time (secs) to run each benchmark')
+        params.addParam('min_runs', 40,       'minimum number of runs for each benchmark')
+        params.addParam('max_runs', 400,      'maximum number of runs for each benchmark')
+        params.addParam('perflog', False,     'true to enable perflog and store its output')
+        return params
+
+    def __init__(self, name, params):
+        Tester.__init__(self, name, params)
+        self.tags.append('speedtests')
+        self.timeout = max(3600, float(params['max_time']))
+        self.check_only = False
+
+        self.params = params
+        self.benchmark = None
+        self.db = 'speedtests.sqlite'
+
+    # override
+    def getMaxTime(self):
+        return self.timeout
+
+    # override
+    def checkRunnable(self, options):
+        # if user is not explicitly running benchmarks, we only run moose once and just check
+        # input - to make sure the benchmark isn't broken.
+        if 'speedtests' not in options.runtags:
+            self.params['max_runs'] = 1
+            self.params['cli_args'].insert(0, '--check-input')
+            self.check_only = True
+        return True
+
+    # override
+    def run(self, timer, options):
+        p = self.params
+        if options.method not in ['opt', 'oprof', 'dbg']:
+            raise ValueError('cannot run benchmark with "' + options.method + '" build')
+        t = Test(p['executable'], p['input'], args=p['cli_args'], rootdir=p['test_dir'], perflog=p['perflog'])
+
+        if self.check_only:
+            t.run(timer, timeout=p['max_time'])
+            return
+
+        name = p['test_name'].split('.')[-1]
+        self.benchmark = Bench(name, test=t, cum_dur=float(p['cumulative_dur']), min_runs=int(p['min_runs']), max_runs=int(p['max_runs']))
+        self.benchmark.run(timer, timeout=self.timeout)
+        with DB(self.db) as db:
+            db.store(self.benchmark)
+
+    # override
+    def processResults(self, moose_dir, options, output):
+        self.setStatus(self.exit_code, self.bucket_success)
+        return output
+
+class Bench:
+    def __init__(self, name, realruns=None, test=None, cum_dur=60, min_runs=40, max_runs=400):
+        self.name = name
+        self.test = test
+        self.realruns = []
+        self.perflogruns = []
+        if realruns is not None:
+            self.realruns.extend(realruns)
+        self._cum_dur = cum_dur
+        self._min_runs = min_runs
+        self._max_runs = max_runs
+
+    def run(self, timer=None, timeout=3600):
+        tot = 0.0
+        start = time.time()
+        while (len(self.realruns) < self._min_runs or tot < self._cum_dur) and len(self.realruns) < self._max_runs:
+            dt = time.time() - start
+            if dt >= timeout:
+                raise RuntimeError('benchmark timed out after {} with {} runs'.format(dt, len(self.realruns)))
+
+            self.test.run(timer, timeout=timeout - dt)
+            self.realruns.append(self.test.dur_secs)
+            self.perflogruns.append(self.test.perflog)
+            tot += self.test.dur_secs
+
+class BenchComp:
+    def __init__(self, oldbench, newbench, psig=0.01):
+        self.name = oldbench.name
+        self.psig = psig
+        self.old = oldbench.realruns
+        self.new = newbench.realruns
+
+        self.iqr_old = _iqr(self.old)
+        self.iqr_new = _iqr(self.new)
+        try:
+            result = mannwhitneyu(self.iqr_old, self.iqr_new, alternative='two-sided')
+            self.pvalue = result.pvalue
+        except:
+            self.pvalue = 1.0
+
+        self.u = result[0]
+        self.avg_old = float(sum(self.iqr_old))/len(self.iqr_old)
+        self.avg_new = float(sum(self.iqr_new))/len(self.iqr_new)
+        self.speed_change = (self.avg_new - self.avg_old) / self.avg_old
+
+    @classmethod
+    def header(cls, revold, revnew):
+        oldstr, newstr = revold, revnew
+        if len(oldstr) > 12:
+            oldstr = oldstr[:12]
+        if len(newstr) > 12:
+            newstr = newstr[:12]
+        revstr = ' {} to {} '.format(oldstr, newstr)
+        revstr = revstr.center(30,'-')
+        return '' \
+            + '--------------------------------{}--------------------------------'.format(revstr) \
+            + '\n{:^30s}   {:^15s}   {:^15s}   {:5s}'.format('benchmark', 'old (sec/run)', 'new (sec/run)', 'speedup (pvalue, nsamples)') \
+            + '\n----------------------------------------------------------------------------------------------'
+    @classmethod
+    def footer(cls):
+        return '----------------------------------------------------------------------------------------------'
+
+    def __str__(self):
+        name = self.name
+        if len(name) > 30:
+            name = name[:27] + '...'
+        if self.pvalue <= self.psig:
+            return '{:>30s}:   {:^15f}   {:^15f}   {:+5.1f}% (p={:.4f},n={}+{})'.format(name, self.avg_old, self.avg_new, self.speed_change*100, self.pvalue, len(self.iqr_old), len(self.iqr_new))
+        else:
+            return '{:>30s}:   {:^15f}   {:^15f}      ~   (p={:.4f},n={}+{})'.format(name, self.avg_old, self.avg_new, self.pvalue, len(self.iqr_old), len(self.iqr_new))
+
+def _iqr(a, frac=1000):
+    """return elements of a within frac*iqr of the the interquartile range (inclusive)"""
+    qup, qlow = numpy.percentile(a, [75 ,25])
+
+    iqr = qup - qlow
+    clean = []
+    for val in a:
+        if qlow - frac*iqr <= val and val <= qup + frac*iqr:
+            clean.append(val)
+    return clean
+
+class DB:
+    def __init__(self, fname):
+        CREATE_BENCH_TABLE = '''CREATE TABLE IF NOT EXISTS benchmarks
+        (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT,
+          executable TEXT,
+          executable_name TEXT,
+          executable_method TEXT,
+          input_file TEXT,
+          timestamp INTEGER,
+          revision TEXT,
+          date INTEGER,
+          load REAL
+        );'''
+
+        CREATE_TIMES_TABLE = '''CREATE TABLE IF NOT EXISTS timings
+        (
+          benchmark_id INTEGER,
+          run INTEGER,
+          realtime_secs REAL
+        );'''
+
+        CREATE_PERFLOG_TABLE = '''CREATE TABLE IF NOT EXISTS perflog
+        (
+          benchmark_id INTEGER,
+          run INTEGER,
+          field TEXT,
+          subfield TEXT,
+          exec_count INTEGER,
+          self_time_secs REAL,
+          cum_time_secs REAL
+        );'''
+
+        self.fname = fname
+        self.conn = sqlite3.connect(fname)
+        c = self.conn.cursor()
+        c.execute(CREATE_BENCH_TABLE)
+        c.execute(CREATE_TIMES_TABLE)
+        c.execute(CREATE_PERFLOG_TABLE)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def revisions(self, method='opt'):
+        c = self.conn.cursor()
+        c.execute('SELECT revision,date FROM benchmarks WHERE executable_method=? GROUP BY revision ORDER BY date ASC', (method,))
+        rows = c.fetchall()
+        revs = []
+        times = []
+        for r in rows:
+            revs.append(r[0])
+            times.append(r[1])
+        return revs, times
+
+    def bench_names(self, method='opt'):
+        c = self.conn.cursor()
+        c.execute('SELECT DISTINCT name FROM benchmarks WHERE executable_method=?', (method,))
+        rows = c.fetchall()
+        names = []
+        for r in rows:
+            names.append(r[0])
+        return names
+
+    def list(self, revision, benchmark='', method='opt'):
+        c = self.conn.cursor()
+        if benchmark == '':
+            c.execute('SELECT id,name,executable,input_file FROM benchmarks WHERE INSTR(revision,?) AND executable_method=? ORDER BY date ASC', (revision,method))
+        else:
+            c.execute('SELECT id,name,executable,input_file FROM benchmarks WHERE INSTR(revision,?) AND name=? AND executable_method=? ORDER BY date ASC', (revision,benchmark,method))
+        benchmarks = c.fetchall()
+        return benchmarks
+
+    def load_times(self, bench_id):
+        c = self.conn.cursor()
+        c.execute('SELECT realtime_secs FROM timings WHERE benchmark_id=?', (bench_id,))
+        ents = c.fetchall()
+        real = []
+        for ent in ents:
+            real.append(float(ent[0]))
+        return real
+
+    def load(self, revision, bench_name, method='opt'):
+        """loads and returns a Bench object for the given revision and benchmark name"""
+        entries = self.list(revision, benchmark=bench_name, method=method)
+        if len(entries) < 1:
+            raise RuntimeError('load: no benchamrk for revision="{}",bench_name="{}"'.format(revision, bench_name))
+        b = entries[0]
+        real = self.load_times(b[0])
+        return Bench(b[1], test=Test(b[2], b[3]), realruns=real)
+
+    def store(self, benchmark, rev=None):
+        """stores a (run/executed) Bench in the database. if rev is None, git revision is retrieved from git"""
+        ex = benchmark.test.executable
+        (ex_name, ex_method) = os.path.basename(ex).rsplit('-', 1)
+        infile = benchmark.test.infile
+        timestamp = time.time()
+        date = timestamp
+        if rev is None:
+            if 'MOOSE_REVISION' in os.environ:
+                rev = os.environ['MOOSE_REVISION']
+            else:
+                rev, date = git_revision()
+        load = os.getloadavg()[0]
+
+        c = self.conn.cursor()
+        c.execute('INSERT INTO benchmarks (name,executable,executable_name,executable_method,input_file,timestamp,revision,date,load) VALUES (?,?,?,?,?,?,?,?,?)',
+                (benchmark.name, ex, ex_name, ex_method, infile, timestamp, rev, date, load))
+        bench_id = c.lastrowid
+        self.conn.commit()
+
+        i = 0
+        for real, perflog in zip(benchmark.realruns, benchmark.perflogruns):
+            c.execute('INSERT INTO timings (benchmark_id, run, realtime_secs) VALUES (?,?,?)', (bench_id, i, real))
+            i += 1
+            for entry in perflog:
+                cat, subcat, nruns, selftime, cumtime = entry
+                c.execute('INSERT INTO perflog (benchmark_id, run, field, subfield, exec_count, self_time_secs, cum_time_secs) VALUES (?,?,?,?,?,?,?)',
+                        (bench_id, i, cat, subcat, nruns, selftime, cumtime))
+
+        return bench_id
+
+    def close(self):
+        self.conn.commit()
+        self.conn.close()
+
+def git_revision(dir='.'):
+    # return hash and (unix secs since epoch) date
+    cmd = ['git', 'log', '--date', 'raw', '--pretty=format:%H %ad', '-n', '1']
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=dir)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+        raise RuntimeError('failed to retrieve git revision')
+    commit = stdout.strip().split(' ')[0]
+    date = int(stdout.strip().split(' ')[1])
+    return commit, date
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,117 @@
+
+benchmark.py
+-------------------
+
+This script provides functionality for benchmarking and tracking MOOSE performance.  It can be
+used to run benchmarks, generate trend visualizations, and look at stats comparing bencharks
+between various revisions.  Normally, benchmarks should be run through the test harness (i.e.
+using the ``run_tests`` script) by doing e.g. ``./run_tests --run speedtests``
+
+In order to obtain accurate results, you need to run the benchmark process(es)
+as close to isolated as possible.  On a linux system, you should e.g. use cpu
+isolation via setting kernel boot parameters:
+
+ ```
+isolcpus=[n] rcu_nocbs=[n]
+```
+
+in your boot loader (e.g. grub).  The benchmarking tools should automatically
+detect CPU isolation on Linux and schedule benchmark jobs to those CPUs.You
+should also disable any turbo functionality.  For example on ``intel_pstate``
+driver cpus:
+
+```
+$ echo "1" > /sys/devices/system/cpu/intel_pstate/no_turbo
+```
+
+This will need to be done on every boot.  You can use the sysfsutils package
+and its ``/etc/sysfs.conf`` configuration file to do this.
+
+Manual/Direct Benchmarks
+++++++++++++++++++++++++++
+
+This script can also be used to manually list and directly run benchmarks without the
+test harness (for hacking, debugging, etc.).  To do this, the script reads a ``bench.list`` text
+file that specifies which input files should be run and corresponding (benchmark) names for them
+along with any optional arguments.  The ``bench.list`` file has the following format:
+
+```
+[benchmarks]
+    [./simple_diffusion_refine3]
+        binary = test/moose_test-opt
+        infile = test/tests/kernels/simple_diffusion/simple_diffusion.i
+        cli_args = 'Mesh/uniform_refine=3'
+    [../]
+    [./simple_diffusion_refine4]
+        binary = test/moose_test-opt
+        infile = test/tests/kernels/simple_diffusion/simple_diffusion.i
+        cli_args = 'Mesh/uniform_refine=4'
+    [../]
+    [./simple_diffusion_ref5]
+        binary = test/moose_test-opt
+        infile = test/tests/kernels/simple_diffusion/simple_diffusion.i
+        cli_args = 'Mesh/uniform_refine=5'
+    [../]
+    # ... add as many as you want
+[]
+
+```
+
+To run the manual benchmarks directly, do this:
+
+```
+$ ./benchmark.py --run
+```
+
+When benchmarks are run, the binaries specified in ``bench.list`` must already exist.  Benchmark
+data are then stored in a sqlite database (default name ``speedtests.sqlite``).  You can specify
+the minimum number of runs for each benchmark problem/simulation with the ``--min-runs`` (default
+10).  Each benchmark will be run as many times as possible within 1 minute (customizable via the
+``--cum-dur`` flag) or the specified minimum number of times (whichever is larger). 
+
+Analyzing Results
+++++++++++++++++++++++
+
+Regardless of how you ran the benchmarks (either by this script or using the test harness), MOOSE
+revisions with available benchmark data can be listed (from the database) by running:
+
+```
+$ ./benchmark.py --list-revs
+44d2f3434b3346dc14fc9e86aa99ec433c1bbf10	2016-09-07 19:36:16
+86ced0d0c959c9bdc59497f0bc9324c5cdcd7e8f	2016-09-08 09:29:17
+447b455f1e2d8eda649468ed03ef792504d4b467	2016-09-08 09:43:56
+...
+```
+
+To look at stats comparing benchmark data from two revisions, run:
+
+```
+$ ./benchmark.py # defaults to using the most recent two revisions of benchmark data
+-------------------------------- 871c98630c98 to 38bb6f5ebe5f --------------------------------
+          benchmark               old (sec/run)     new (sec/run)    speedup (pvalue,nsamples)
+----------------------------------------------------------------------------------------------
+    simple diffusion (refine3):      0.408034          0.408034          ~   (p=0.996 n=36+36)
+    simple diffusion (refine4):      1.554724          1.561682          ~   (p=0.571 n=10+10)
+    simple diffusion (refine5):      6.592326          6.592326          ~   (p=0.882 n=4+4)
+----------------------------------------------------------------------------------------------
+
+$ ./benchmark.py -old 44d2f34 -new 447b455 # or specify revisions to compare manually
+------------------------------------- 44d2f34 to 447b455 -------------------------------------
+          benchmark               old (sec/run)     new (sec/run)    speedup (pvalue,nsamples)
+----------------------------------------------------------------------------------------------
+    simple diffusion (refine3):      0.416574          0.411435        -1.2% (p=0.000 n=37+37)
+    simple diffusion (refine4):      1.554724          1.497379        -3.7% (p=0.000 n=10+11)
+    simple diffusion (refine5):      6.553244          6.360004        -2.9% (p=0.030 n=4+4)
+----------------------------------------------------------------------------------------------
+```
+
+To generate visualizations, run:
+
+```
+$ ./benchmark.py --trends
+```
+
+This will generate an svg box plot for each benchmark over time/revision in a ``trends``
+subdirectory.  An ``index.html`` file is also generated that embeds all the svg plots for
+convenient viewing all together in a browser.
+

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python
+
+import datetime
+import time
+import argparse
+import os
+import os.path
+import sys
+import collections
+import matplotlib.pyplot as plt
+import jinja2
+
+defaultdir = os.path.abspath(os.path.dirname(sys.argv[0]))
+MOOSE_DIR = os.path.abspath(os.path.join(defaultdir, '..', 'python'))
+if "MOOSE_DIR" in os.environ:
+  MOOSE_DIR = os.environ['MOOSE_DIR']
+else:
+  os.environ['MOOSE_DIR'] = MOOSE_DIR
+
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
+
+from TestHarness.testers.bench import *
+import hit
+
+def find_moose_python():
+    moosedir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    if 'MOOSE_DIR' in os.environ:
+        moosedir = os.environ['MOOSE_DIR']
+    moosepython = os.path.join(moosedir, 'python')
+
+    if not os.path.exists(moosepython):
+        raise Exception('Unable to locate moose/python directory, please set MOOSE_DIR environment variable')
+    sys.path.append(moosepython)
+
+find_moose_python()
+
+def build_args():
+    p = argparse.ArgumentParser()
+    p.add_argument('--db', type=str, default='speedtests.sqlite', help='benchmark timings database')
+
+    # options for comparing benchmarks
+    p.add_argument('--old', type=str, default='', help='compare benchmark runs from the given revision (default prev of most recent)')
+    p.add_argument('--new', type=str, default='', help='compare benchmark runs to the given revision (default most recent)')
+
+    # options for running benchmarks
+    p.add_argument('--run', action='store_true', help='run all benchmarks on the current checked out revision')
+    p.add_argument('--perflog', action='store_true', help='store perflog benchmark info')
+    p.add_argument('--rev', type=str, default='', help='manually specify git revision for this set of benchmarks')
+    p.add_argument('--benchlist', type=str, default='bench.list', help='run all benchmarks on the current checked out revision')
+    p.add_argument('--cum-dur', type=float, default=60, help='cumulative time (secs) to run each benchmark')
+    p.add_argument('--min-runs', type=int, default=40, help='minimum number of runs for each benchmark')
+    p.add_argument('--list-revs', action='store_true', help='list all benchmarked revisions in the db')
+    p.add_argument('--trends', action='store_true', help='generate plots of historical trends of all benchmarks')
+    p.add_argument('--psig', type=float, default=0.01, help='the p-value cutoffused to determine comparison significance')
+    return p
+
+def main():
+    p = build_args()
+    args = p.parse_args()
+
+    method = os.environ.get('METHOD', 'opt')
+
+    if args.list_revs: # list all revisions for which there are benchmarks
+        with DB(args.db) as db:
+            revs, times = db.revisions(method=method)
+            printed = set()
+            for rev,t in zip(revs, times):
+                if rev in printed:
+                    continue
+                printed.add(rev)
+                tm = datetime.datetime.fromtimestamp(t)
+                print('{}\t{}'.format(rev,tm))
+
+    elif args.run: # run all benchmarks
+        benches = read_benchmarks(args.benchlist)
+        rootdir = os.path.dirname(args.benchlist)
+        with DB(args.db) as db:
+            for bench in benches:
+                print('running "{}"...'.format(bench.name))
+                t = Test(bench.executable, bench.infile, args=bench.args, rootdir=rootdir, perflog=bool(args.perflog))
+                b = Bench(bench.name, test=t, cum_dur=args.cum_dur, min_runs=args.min_runs)
+                b.run()
+                if args.rev != '':
+                    db.store(b, rev=args.rev)
+                else:
+                    db.store(b)
+
+    elif args.trends: # generate print plots of benchmark runs over time
+        with DB(args.db) as db:
+            subdir = 'trends'
+            if not os.path.exists(subdir):
+                os.mkdir(subdir)
+            benchnames = db.bench_names(method=method)
+            buildpage(os.path.join(subdir, 'index.html'), benchnames, db, args.psig, method=method)
+            for bname in db.bench_names(method=method):
+                benches, revs = [], []
+                dbrevs, _ = db.revisions(method=method)
+                for rev in dbrevs:
+                    try:
+                        bench = db.load(rev, bname, method=method)
+                        benches.append(bench)
+                        revs.append(rev)
+                    except:
+                        pass
+                if len(revs) > 25:
+                    revs = revs[-25:]
+                    benches = benches[-25:]
+                plot(revs, benches, subdir=subdir)
+
+    else: # compare two benchmarks
+        with DB(args.db) as db:
+            revs, _ = db.revisions(method=method)
+            revold, revnew = revs[-min(len(revs), 2)], revs[-1]
+            if args.old != '':
+                revold = args.old
+            if args.new != '':
+                revnew = args.new
+
+            # load benchmark objects for each revision+bench_name combo for
+            cmps = compare(db, revold, revnew, args.psig, method=method)
+            print(BenchComp.header(revold, revnew))
+            for cmp in cmps:
+                print(cmp)
+            print(BenchComp.footer())
+
+def buildpage(fname, plotnames, db, psig, lastn=60, method='opt'):
+    figpage = """
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<head>
+    <style>
+        .flex-grid {
+            display: flex;
+            flex-wrap: wrap;
+        }
+        .center {
+            text-align: center;
+        }
+        img.center {
+            display: block;
+            margin-left: auto;
+            margin-right: auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="flex-grid">
+        {% for name in benchnames %}
+        <div>
+            <object data="{{name}}.svg" type="image/svg+xml"> </object>
+            <h2 class="center">{{name}}</h2>
+        </div>
+        {% endfor %}
+    </div>
+
+    <br><br><br>
+    <div style="width:1700px; margin:auto auto; padding:50px;">
+    <div style="width:800px; float:left; clear:left;">
+        <h1>Progress Comparisons</h1>
+        {% for c in comparisons %}
+        <h3>Revision <a href="{{c.link1}}">{{c.revision1[:7]}}</a> to <a href="{{c.link2}}">{{c.revision2[:7]}}</a> ({{c.date1}} to {{c.date2}})</h3>
+        <pre>{{c.text}}</pre>
+        <br>
+        {% endfor %}
+    </div>
+
+    <div style="width:800px; float:left">
+        <h1>Reference Comparisons</h1>
+        {% for c in refcomparisons %}
+        <h3>Revision <a href="{{c.link1}}">{{c.revision1[:7]}}</a> to <a href="{{c.link2}}">{{c.revision2[:7]}}</a> ({{c.date1}} to {{c.date2}})</h3>
+        <pre>{{c.text}}</pre>
+        <br>
+        {% endfor %}
+    </div>
+    </div>
+</body>
+</html>
+"""
+
+    revs, times = db.revisions(method=method)
+    if len(revs) > lastn:
+        revs = revs[-lastn:]
+        times = times[-lastn:]
+
+    tformat = '%Y/%m/%d-%H:%M'
+    comparisons = []
+    refcomparisons = []
+
+    if len(revs) > 0:
+        Comp = collections.namedtuple('Comp', 'revision1 revision2 date1 date2 link1 link2 text')
+        for rev1, t1, rev2, t2 in zip(revs[:-1], times[:-1], revs[1:], times[1:]):
+            s = BenchComp.header(rev1, rev2)
+            cmps = compare(db, rev1, rev2, psig, method=method)
+            for cmp in cmps:
+                s += '\n' + cmp.__str__()
+            s += '\n' + BenchComp.footer()
+
+            t1 = datetime.datetime.fromtimestamp(t1).strftime(tformat)
+            t2 = datetime.datetime.fromtimestamp(t2).strftime(tformat)
+            link1 = "https://github.com/idaholab/moose/commit/" + rev1
+            link2 = "https://github.com/idaholab/moose/commit/" + rev2
+            c = Comp(rev1, rev2, t1, t2, link1, link2, s)
+            comparisons.append(c)
+
+        rev1, t1 = revs[0], datetime.datetime.fromtimestamp(times[0]).strftime(tformat)
+        for rev2, t2 in zip(revs[1:], times[1:]):
+            s = BenchComp.header(rev1, rev2)
+            cmps = compare(db, rev1, rev2, psig, method=method)
+            for cmp in cmps:
+                s += '\n' + cmp.__str__()
+            s += '\n' + BenchComp.footer()
+
+            t2 = datetime.datetime.fromtimestamp(t2).strftime(tformat)
+            link1 = "https://github.com/idaholab/moose/commit/" + rev1
+            link2 = "https://github.com/idaholab/moose/commit/" + rev2
+            c = Comp(rev1, rev2, t1, t2, link1, link2, s)
+            refcomparisons.append(c)
+
+    comparisons.reverse()
+    refcomparisons.reverse()
+
+    t = jinja2.Template(figpage)
+    data = t.render(benchnames=plotnames, comparisons=comparisons, refcomparisons=refcomparisons)
+    with open(fname, 'w') as f:
+        f.write(data)
+
+def compare(db, rev1, rev2, psig, method='opt'):
+    # generate benchcomp comparison results
+    bench_from = db.list(rev1, method=method)
+    bench_to = db.list(rev2, method=method)
+
+    old_times = collections.OrderedDict()
+    new_times = collections.OrderedDict()
+    for old, new in zip(bench_from, bench_to):
+        old_times[old[1]] = db.load(rev1, old[1], method=method)
+        new_times[new[1]] = db.load(rev2, new[1], method=method)
+
+    cmps = []
+    for name in old_times:
+        if name not in new_times:
+            continue
+
+        old = old_times[name]
+        new = new_times[name]
+        if len(old.realruns) > 0 and len(new.realruns) > 0:
+            cmp = BenchComp(old, new, psig=psig)
+            cmps.append(cmp)
+    return cmps
+
+def plot(revisions, benchmarks, subdir='.'):
+    data = []
+    labels = []
+    for rev, bench in zip(revisions, benchmarks):
+        data.append(bench.realruns)
+        labels.append(rev[:7])
+
+    plt.boxplot(data, labels=labels, whis=1.5)
+    plt.xticks(rotation=90)
+    plt.ylabel('Time (seconds)')
+
+    fig = plt.gcf()
+
+    ax = fig.axes[0]
+    labels = ax.get_xticklabels()
+    for label in labels:
+        label.set_url("https://github.com/idaholab/moose/commit/" + label.get_text())
+
+    fig.subplots_adjust(bottom=.15)
+    fig.savefig(os.path.join(subdir, benchmarks[0].name + '.svg'))
+    plt.clf()
+    #plt.show()
+
+class BenchEntry:
+    def __init__(self, name, executable, input_file, args):
+        self.name = name
+        self.executable = executable
+        self.infile = input_file
+        self.args = args.split(' ')
+
+def read_benchmarks(benchlist):
+    if not os.path.exists(benchlist):
+        raise ValueError('benchmark list file "{}" does not exist'.format(benchlist))
+
+    benches = []
+
+    with open(benchlist, 'r') as f:
+        data = f.read()
+
+    root = hit.parse(benchlist, data)
+    for child in root.find('benchmarks').children():
+        ex = child.param('binary').strip()
+        infile = child.param('input').strip()
+        args = ''
+        if child.find('cli_args'):
+            args = child.param('cli_args')
+        benches.append(BenchEntry(child.path(), ex, infile, args))
+    return benches
+
+if __name__ == '__main__':
+    main()
+

--- a/test/tests/kernels/simple_diffusion/speedtests
+++ b/test/tests/kernels/simple_diffusion/speedtests
@@ -1,0 +1,17 @@
+[Benchmarks]
+    [./diffusion_100x100]
+        type = SpeedTest
+        input = simple_diffusion.i
+        cli_args = 'Mesh/nx=100 Mesh/ny=100'
+    [../]
+    [./diffusion_200x200]
+        type = SpeedTest
+        input = simple_diffusion.i
+        cli_args = 'Mesh/nx=200 Mesh/ny=200'
+    [../]
+    [./uniform_refine_4]
+        type = SpeedTest
+        input = simple_diffusion.i
+        cli_args = 'Mesh/uniform_refine=4'
+    [../]
+[]

--- a/test/tests/kernels/simple_transient_diffusion/speedtests
+++ b/test/tests/kernels/simple_transient_diffusion/speedtests
@@ -1,0 +1,12 @@
+[Benchmarks]
+    [./trans_diffusion_100x100_t5]
+        type = SpeedTest
+        input = simple_transient_diffusion.i
+        cli_args = 'Mesh/nx=100 Mesh/ny=100 Executioner/num_steps=5'
+    [../]
+    [./trans_diffusion_100x100_t10]
+        type = SpeedTest
+        input = simple_transient_diffusion.i
+        cli_args = 'Mesh/nx=100 Mesh/ny=100 Executioner/num_steps=10'
+    [../]
+[]

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -130,7 +130,7 @@
   [./definition_valenum_test]
     type = 'RunApp'
     input = 'IGNORED'
-    expect_out = '\'execute_on\'{.*?\'value\'{.*?ValEnums=\[ "none" "ini.*?gin" "custom" \].*}?.*?} % end parameter execute_on'
+    expect_out = '\'execute_on\'{.*?\'value\'{.*?ValEnums=\[ "none" "ini.*?nal" "custom" \].*}?.*?} % end parameter execute_on'
     cli_args = '--definition'
   [../]
 


### PR DESCRIPTION
Rework of #9407.  I left the benchmark.py script in and it basically does the same stuff it did in #9407.  But the benchmark running code has been refactored and a new Benchmark tester for the test harness has been created.  The simple diffusion tests file has an example benchmark added.  To run benchmarks with the test harness you ```./run_tests --run benchmarks```.

I implemented it through a "tagging" functionality - I don't have any particular strong feelings about the details flag names, etc.  Feel free to make suggestions.  I figured it would be useful to be able to tag tests in ``tests`` files and the have ``--run`` and ``--skip`` flags on the harness that are lists of tags to include/exclude.  I'm also open to building a tagging sort of functionality out in another PR before we put this in.  ``checkRunnableBase`` could benefit from some refactoring I think.

You can still use the benchmark list file like the previous PR, but it is bonus functionality you can ignore; this PR allows you to specify benchmarks in the tests files.  To create a benchmark, you add this sort of thing to a ``tests`` file:

```
...
[my-bench-name]
  type = Benchmark
  input = "foo.i"
  cli_args = "..."
[../]
...
```

All the benchmarking data is stored in a ``benchmarks.sqlite`` file.