### PR TITLE
Optimize computeElemValues for constant monomials

### DIFF
--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -345,15 +345,15 @@ public:
   /**
    * Compute values at facial quadrature points
    */
-  void computeElemValuesFace();
+  virtual void computeElemValuesFace();
   /**
    * Compute values at facial quadrature points for the neighbor
    */
-  void computeNeighborValuesFace();
+  virtual void computeNeighborValuesFace();
   /**
    * Compute values at quadrature points for the neighbor
    */
-  void computeNeighborValues();
+  virtual void computeNeighborValues();
   /**
    * Compute nodal values of this variable
    */

--- a/framework/include/base/MooseVariable.h
+++ b/framework/include/base/MooseVariable.h
@@ -341,7 +341,7 @@ public:
   /**
    * Compute values at interior quadrature points
    */
-  void computeElemValues();
+  virtual void computeElemValues();
   /**
    * Compute values at facial quadrature points
    */

--- a/framework/include/base/MooseVariableConstMonomial.h
+++ b/framework/include/base/MooseVariableConstMonomial.h
@@ -1,0 +1,33 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef MOOSEVARIABLECONSTMONOMIAL_H
+#define MOOSEVARIABLECONSTMONOMIAL_H
+
+#include "MooseTypes.h"
+#include "MooseVariable.h"
+
+class MooseVariableConstMonomial : public MooseVariable
+{
+public:
+  MooseVariableConstMonomial(unsigned int var_num,
+                             const FEType & fe_type,
+                             SystemBase & sys,
+                             Assembly & assembly,
+                             Moose::VarKindType var_kind);
+
+  virtual void computeElemValues() override;
+};
+
+#endif /* MOOSEVARIABLECONSTMONOMIAL_H */

--- a/framework/include/base/MooseVariableConstMonomial.h
+++ b/framework/include/base/MooseVariableConstMonomial.h
@@ -28,6 +28,12 @@ public:
                              Moose::VarKindType var_kind);
 
   virtual void computeElemValues() override;
+  virtual void computeElemValuesFace() override;
+  virtual void computeNeighborValuesFace() override;
+  virtual void computeNeighborValues() override;
+
+  virtual void computeElemValuesHelper(const unsigned & nqp, const Real & phi);
+  virtual void computeNeighborValuesHelper(const unsigned & nqp, const Real & phi);
 };
 
 #endif /* MOOSEVARIABLECONSTMONOMIAL_H */

--- a/framework/src/base/MooseVariableConstMonomial.C
+++ b/framework/src/base/MooseVariableConstMonomial.C
@@ -1,0 +1,196 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "MooseVariableConstMonomial.h"
+#include "SubProblem.h"
+#include "SystemBase.h"
+#include "Assembly.h"
+
+#include "libmesh/quadrature.h"
+
+MooseVariableConstMonomial::MooseVariableConstMonomial(unsigned int var_num,
+                                                       const FEType & fe_type,
+                                                       SystemBase & sys,
+                                                       Assembly & assembly,
+                                                       Moose::VarKindType var_kind)
+  : MooseVariable(var_num, fe_type, sys, assembly, var_kind)
+{
+}
+
+void
+MooseVariableConstMonomial::computeElemValues()
+{
+
+  bool is_transient = _subproblem.isTransient();
+  unsigned int nqp = _qrule->n_points();
+
+  _u.resize(nqp);
+  _grad_u.resize(nqp);
+
+  if (_need_second)
+    _second_u.resize(nqp);
+
+  if (_need_u_previous_nl)
+    _u_previous_nl.resize(nqp);
+
+  if (_need_grad_previous_nl)
+    _grad_u_previous_nl.resize(nqp);
+
+  if (_need_second_previous_nl)
+    _second_u_previous_nl.resize(nqp);
+
+  if (is_transient)
+  {
+    _u_dot.resize(nqp);
+    _du_dot_du.resize(nqp);
+
+    if (_need_u_old)
+      _u_old.resize(nqp);
+
+    if (_need_u_older)
+      _u_older.resize(nqp);
+
+    if (_need_grad_old)
+      _grad_u_old.resize(nqp);
+
+    if (_need_grad_older)
+      _grad_u_older.resize(nqp);
+
+    if (_need_second_old)
+      _second_u_old.resize(nqp);
+
+    if (_need_second_older)
+      _second_u_older.resize(nqp);
+  }
+
+  if (_need_nodal_u)
+    _nodal_u.resize(1);
+
+  if (_need_nodal_u_previous_nl)
+    _nodal_u_previous_nl.resize(1);
+
+  if (is_transient)
+  {
+    if (_need_nodal_u_old)
+      _nodal_u_old.resize(1);
+    if (_need_nodal_u_older)
+      _nodal_u_older.resize(1);
+    if (_need_nodal_u_dot)
+      _nodal_u_dot.resize(1);
+  }
+
+  if (_need_solution_dofs)
+    _solution_dofs.resize(1);
+
+  if (_need_solution_dofs_old)
+    _solution_dofs_old.resize(1);
+
+  if (_need_solution_dofs_older)
+    _solution_dofs_older.resize(1);
+
+  const NumericVector<Real> & current_solution = *_sys.currentSolution();
+  const NumericVector<Real> & solution_old = _sys.solutionOld();
+  const NumericVector<Real> & solution_older = _sys.solutionOlder();
+  const NumericVector<Real> * solution_prev_nl = _sys.solutionPreviousNewton();
+  const NumericVector<Real> & u_dot = _sys.solutionUDot();
+  const Real & du_dot_du = _sys.duDotDu();
+
+  dof_id_type idx = 0;
+  Real soln_local = 0;
+  Real soln_old_local = 0;
+  Real soln_older_local = 0;
+  Real soln_previous_nl_local = 0;
+  Real u_dot_local = 0;
+
+  Real phi_local = 0;
+
+  idx = _dof_indices[0];
+  soln_local = current_solution(idx);
+
+  if (_need_nodal_u)
+    _nodal_u[0] = soln_local;
+
+  if (_need_u_previous_nl || _need_grad_previous_nl || _need_second_previous_nl ||
+      _need_nodal_u_previous_nl)
+    soln_previous_nl_local = (*solution_prev_nl)(idx);
+
+  if (_need_nodal_u_previous_nl)
+    _nodal_u_previous_nl[0] = soln_previous_nl_local;
+
+  if (_need_solution_dofs)
+    _solution_dofs(0) = soln_local;
+
+  if (is_transient)
+  {
+    if (_need_u_old || _need_grad_old || _need_second_old || _need_nodal_u_old)
+      soln_old_local = solution_old(idx);
+
+    if (_need_u_older || _need_grad_older || _need_second_older || _need_nodal_u_older)
+      soln_older_local = solution_older(idx);
+
+    if (_need_nodal_u_old)
+      _nodal_u_old[0] = soln_old_local;
+    if (_need_nodal_u_older)
+      _nodal_u_older[0] = soln_older_local;
+
+    u_dot_local = u_dot(idx);
+    if (_need_nodal_u_dot)
+      _nodal_u_dot[0] = u_dot_local;
+
+    if (_need_solution_dofs_old)
+      _solution_dofs_old(0) = solution_old(idx);
+
+    if (_need_solution_dofs_older)
+      _solution_dofs_older(0) = solution_older(idx);
+  }
+
+  phi_local = _phi[0][0];
+
+  _u[0] = phi_local * soln_local;
+
+  if (_need_u_previous_nl)
+    _u_previous_nl[0] = phi_local * soln_previous_nl_local;
+
+  if (is_transient)
+  {
+    _u_dot[0] = phi_local * u_dot_local;
+    _du_dot_du[0] = du_dot_du;
+
+    if (_need_u_old)
+      _u_old[0] = phi_local * soln_old_local;
+
+    if (_need_u_older)
+      _u_older[0] = phi_local * soln_older_local;
+  }
+
+  for (unsigned qp = 1; qp < nqp; ++qp)
+  {
+    _u[qp] = _u[0];
+
+    if (_need_u_previous_nl)
+      _u_previous_nl[qp] = _u_previous_nl[0];
+
+    if (is_transient)
+    {
+      _u_dot[qp] = _u_dot[0];
+      _du_dot_du[qp] = _du_dot_du[0];
+
+      if (_need_u_old)
+        _u_old[qp] = _u_old[0];
+
+      if (_need_u_older)
+        _u_older[qp] = _u_older[qp];
+    }
+  }
+}

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -18,6 +18,7 @@
 #include "SubProblem.h"
 #include "MooseVariable.h"
 #include "MooseVariableScalar.h"
+#include "MooseVariableConstMonomial.h"
 #include "Conversion.h"
 #include "Parser.h"
 #include "AllLocalDofIndicesThread.h"
@@ -506,8 +507,11 @@ SystemBase::addVariable(const std::string & var_name,
   {
     // FIXME: we cannot refer fetype in libMesh at this point, so we will just make a copy in
     // MooseVariableBase.
-    MooseVariable * var =
-        new MooseVariable(var_num, type, *this, _subproblem.assembly(tid), _var_kind);
+    auto * var =
+        (type == (FEType(0, MONOMIAL)))
+            ? new MooseVariableConstMonomial(
+                  var_num, type, *this, _subproblem.assembly(tid), _var_kind)
+            : new MooseVariable(var_num, type, *this, _subproblem.assembly(tid), _var_kind);
     var->scalingFactor(scale_factor);
     _vars[tid].add(var_name, var);
   }

--- a/framework/src/base/SystemBase.C
+++ b/framework/src/base/SystemBase.C
@@ -507,11 +507,13 @@ SystemBase::addVariable(const std::string & var_name,
   {
     // FIXME: we cannot refer fetype in libMesh at this point, so we will just make a copy in
     // MooseVariableBase.
-    auto * var =
-        (type == (FEType(0, MONOMIAL)))
-            ? new MooseVariableConstMonomial(
-                  var_num, type, *this, _subproblem.assembly(tid), _var_kind)
-            : new MooseVariable(var_num, type, *this, _subproblem.assembly(tid), _var_kind);
+    MooseVariableBase * var;
+    if (type == FEType(0, MONOMIAL))
+      var = new MooseVariableConstMonomial(
+          var_num, type, *this, _subproblem.assembly(tid), _var_kind);
+    else
+      var = new MooseVariable(var_num, type, *this, _subproblem.assembly(tid), _var_kind);
+
     var->scalingFactor(scale_factor);
     _vars[tid].add(var_name, var);
   }


### PR DESCRIPTION
- Create `MooseVariableConstMonomial` that overrides `computeElemValues` and makes use of fact that there's only one DOF per element and the elemental value is the same at every quadrature point

Performance summary (with iprofiler) for following input file:

- Old code:
    - Total run time: 7.745 s
    - Time in `MooseVariable::computeElemValues`: 1.256 s
    - % of calculation: 16

- New code:
    - Total run time: 5.766 s
    - Time in `MooseVariableConstMonomial::computeElemValues`: 0.624 s
    - % of calculation : 11

So looks about like a 2x speed-up.

```
[Mesh]
  type = GeneratedMesh
  dim = 2
  nx = 10
  ny = 10
[]

[Variables]
  [./u]
    family = MONOMIAL
    order = CONSTANT
  [../]
[]

[Kernels]
  [./rxn]
    type = Reaction
    variable = u
  [../]
  [./ffn]
    type = UserForcingFunction
    variable = u
    function = 1
  [../]
[]

[Executioner]
  type = Steady

  # Preconditioned JFNK (default)
  solve_type = 'JFNK'
[]

[LotsOfAuxVariables]
  [./avar]
    number = 20000
    family = MONOMIAL
    order = CONSTANT
  [../]
[]
```

Targets #9836 