### PR TITLE
hit: support for canonical input syntax style/format

### DIFF
--- a/framework/contrib/hit/lex.h
+++ b/framework/contrib/hit/lex.h
@@ -16,6 +16,7 @@ namespace hit
 enum class TokType
 {
   Error,
+  EOF,
   Equals,
   LeftBracket,
   RightBracket,
@@ -25,7 +26,7 @@ enum class TokType
   String,
   Comment,
   InlineComment,
-  EOF,
+  BlankLine,
 };
 
 /// Token represents an (atomic) token/quantum of input text.

--- a/framework/contrib/hit/main.cc
+++ b/framework/contrib/hit/main.cc
@@ -4,132 +4,332 @@
 #include <sstream>
 #include <fstream>
 #include <map>
+#include <set>
 
 #include "parse.h"
 
-class MyWalker : public hit::Walker
-{
-public:
-  void walk(const std::string & fullpath, const std::string & nodepath, hit::Node * f)
-  {
-    std::cout << "    path=" << fullpath << "/" << nodepath << "\n";
-  }
-};
+class Flags;
+std::vector<std::string> parseOpts(int argc, char ** argv, Flags & flags);
 
-class DupSectionWalker : public hit::Walker
-{
-public:
-  void walk(const std::string & /*fullpath*/, const std::string & /*nodepath*/, hit::Node * n)
-  {
-    if (have.count(n->fullpath()) > 0)
-    {
-      if (duplicates.count(n->fullpath()) == 0)
-        duplicates[n->fullpath()].push_back(have[n->fullpath()]);
-      duplicates[n->fullpath()].push_back(n);
-    }
-    have[n->fullpath()] = n;
-  }
-  std::map<std::string, std::vector<hit::Node *>> duplicates;
-
-private:
-  std::map<std::string, hit::Node *> have;
-};
-
-int
-checkfiles(int argc, char ** argv)
-{
-  int ret = 0;
-  if (argc > 1)
-  {
-    for (int i = 1; i < argc; i++)
-    {
-      std::string fname(argv[i]);
-
-      std::ifstream f(fname);
-      std::stringstream ss;
-      ss << f.rdbuf();
-      std::string input = ss.str();
-
-      hit::Node * root = nullptr;
-      try
-      {
-        root = hit::parse(fname, input);
-      }
-      catch (std::exception & err)
-      {
-        std::cout << err.what() << "\n";
-        ret = 1;
-        continue;
-      }
-
-      DupSectionWalker w;
-      root->walk(&w, hit::NodeType::Section);
-
-      for (auto & it : w.duplicates)
-      {
-        for (auto sec : it.second)
-        {
-          ret = 1;
-          std::cout << fname << ":" << sec->line() << ": duplicate section name '" << it.first
-                    << "'\n";
-        }
-      }
-    }
-    return ret;
-  }
-  else
-  {
-    std::cout << "please pass in an input file argument\n";
-    return 1;
-  }
-}
+int renameParam(int argc, char ** argv);
+int findParam(int argc, char ** argv);
+int validate(int argc, char ** argv);
+int format(int argc, char ** argv);
 
 int
 main(int argc, char ** argv)
 {
-  return checkfiles(argc, argv);
-
-  if (argc > 1)
+  if (argc < 2)
   {
-    std::string fname(argv[1]);
-
-    std::ifstream f(fname);
-    std::stringstream ss;
-    ss << f.rdbuf();
-    std::string input = ss.str();
-
-    hit::Node * root = hit::parse(fname, input);
-
-    std::cout << "re-render file from AST:\n" << root->render();
-
-    // manually hop around the AST by indexing nodes' children
-    hit::Node * n = root->find("Kernels/diff");
-    for (auto child : n->children())
-      std::cout << "child=" << child->fullpath() << "\n";
-
-    // search for param values in various ways
-    std::cout << root->find("Kernels/diff/type")->param<std::string>() << "\n";
-    std::cout << root->children()[2]->find("diff")->param<std::string>("type") << "\n";
-    std::cout << root->param<std::string>("Kernels/diff/type") << "\n";
-
-    // walk the entire tree with your custom code
-    MyWalker w;
-    std::cout << "beginning tree walk:\n";
-    root->walk(&w);
-
-    delete root;
+    std::cerr << "must specify a subcommand\n";
+    return 1;
   }
 
-  auto input = "[foo] [bar] [] bar/boo=43 bam/boo=44 [] foo/bar/baz=42 vec='-42 43.2 0   44\n45\n  "
-               "  \t  46'";
-  auto root = hit::parse("testinput", input);
-  std::cout << "re-render testinput from AST:\n" << root->render();
-  hit::explode(root);
-  std::cout << "re-render testinput from explodedAST:\n" << root->render();
+  std::string subcmd(argv[1]);
 
-  auto vec = root->param<std::vector<std::string>>("vec");
-  for (int i = 0; i < vec.size(); i++)
-    std::cout << "vec[" << i << "]=" << vec[i] << "\n";
+  if (subcmd == "rename")
+    return renameParam(argc - 2, argv + 2);
+  else if (subcmd == "find")
+    return findParam(argc - 2, argv + 2);
+  else if (subcmd == "validate")
+    return validate(argc - 2, argv + 2);
+  else if (subcmd == "format")
+    return format(argc - 2, argv + 2);
 
-  return 0;
+  std::cerr << "unrecognized subcommand '" << subcmd << "'\n";
+  return 1;
+}
+
+struct Flag
+{
+  bool arg;
+  bool have;
+  std::string val;
+  std::string help;
+};
+
+class Flags
+{
+public:
+  void add(std::string name, std::string help, std::string def = "__NONE__")
+  {
+    if (def == "__NONE__")
+      flags[name] = {false, false, "", help};
+    else
+      flags[name] = {true, false, def, help};
+  }
+
+  bool have(std::string flag) { return flags.count(flag) > 0 && flags[flag].have; }
+  std::string val(std::string flag) { return flags[flag].val; }
+
+  std::map<std::string, Flag> flags;
+};
+
+std::vector<std::string>
+parseOpts(int argc, char ** argv, Flags & flags)
+{
+  int i = 0;
+  for (; i < argc; i++)
+  {
+    std::string arg = argv[i];
+    if (arg[0] != '-')
+      break;
+
+    std::string flagname = arg.substr(1);
+    if (flagname[0] == '-')
+      flagname = flagname.substr(1);
+
+    if (flags.flags.count(flagname) == 0)
+      throw std::runtime_error("unknown flag '" + arg);
+
+    auto & flag = flags.flags[flagname];
+    flag.have = true;
+    if (flag.arg)
+    {
+      i++;
+      flag.val = argv[i];
+    }
+  }
+
+  std::vector<std::string> positional;
+  for (; i < argc; i++)
+    positional.push_back(argv[i]);
+  return positional;
+}
+
+inline std::string
+errormsg(std::string /*fname*/, hit::Node * /*n*/)
+{
+  return "";
+}
+
+template <typename T, typename... Args>
+std::string
+errormsg(std::string fname, hit::Node * n, T arg, Args... args)
+{
+  std::stringstream ss;
+  if (n && fname.size() > 0)
+    ss << fname << ":" << n->line() << ": ";
+  else if (fname.size() > 0)
+    ss << fname << ":0: ";
+  ss << arg;
+  ss << errormsg("", nullptr, args...);
+  return ss.str();
+}
+
+class DupParamWalker : public hit::Walker
+{
+public:
+  DupParamWalker(std::string fname) : _fname(fname) {}
+  void walk(const std::string & fullpath, const std::string & /*nodepath*/, hit::Node * n) override
+  {
+    std::string prefix = n->type() == hit::NodeType::Field ? "parameter" : "section";
+
+    if (_have.count(fullpath) > 0)
+    {
+      auto existing = _have[fullpath];
+      if (_duplicates.count(fullpath) == 0)
+      {
+        errors.push_back(
+            errormsg(_fname, existing, prefix, " '", fullpath, "' supplied multiple times"));
+        _duplicates.insert(fullpath);
+      }
+      errors.push_back(errormsg(_fname, n, prefix, " '", fullpath, "' supplied multiple times"));
+    }
+    _have[n->fullpath()] = n;
+  }
+
+  std::vector<std::string> errors;
+
+private:
+  std::string _fname;
+  std::set<std::string> _duplicates;
+  std::map<std::string, hit::Node *> _have;
+};
+
+int
+renameParam(int argc, char ** argv)
+{
+  Flags flags;
+  flags.add("i", "modify file(s) inplace");
+  auto positional = parseOpts(argc, argv, flags);
+
+  if (positional.size() < 3)
+  {
+    std::cerr << "rename expects 2 arguments: [src-path] [dst-path] [file]...";
+    return 1;
+  }
+
+  std::string src(positional[0]);
+  std::string dst(positional[1]);
+
+  int ret = 0;
+  for (int i = 2; i < positional.size(); i++)
+  {
+    std::string fname(positional[i]);
+    std::ifstream f(fname);
+    std::string input((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    hit::Node * root = nullptr;
+    try
+    {
+      root = hit::parse(fname, input);
+    }
+    catch (std::exception & err)
+    {
+      std::cerr << err.what() << "\n";
+      return 1;
+    }
+
+    auto n = root->find(src);
+    if (n)
+    {
+      auto f = dynamic_cast<hit::Field *>(n);
+      delete n;
+
+      auto dstnode = new hit::Field(dst, f->kind(), f->val());
+      auto dstnodetree = new hit::Section("");
+      dstnodetree->addChild(dstnode);
+      hit::explode(dstnodetree);
+      hit::merge(dstnodetree, root);
+
+      std::string updated = root->render();
+      if (!flags.have("i"))
+        std::cout << updated << "\n";
+      else
+      {
+        std::ofstream f(fname);
+        f << updated;
+      }
+    }
+  }
+
+  return ret;
+}
+
+int
+findParam(int argc, char ** argv)
+{
+  Flags flags;
+  flags.add("f", "only show file name");
+  auto positional = parseOpts(argc, argv, flags);
+
+  if (positional.size() < 2)
+  {
+    std::cerr << "find expects 2 or more arguments: [parameter-path] [file]...";
+    return 1;
+  }
+
+  std::string srcpath(positional[0]);
+
+  int ret = 0;
+  for (int i = 1; i < positional.size(); i++)
+  {
+    std::string fname(positional[i]);
+    std::ifstream f(fname);
+    std::string input((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    hit::Node * root = nullptr;
+    try
+    {
+      root = hit::parse(fname, input);
+    }
+    catch (std::exception & err)
+    {
+      std::cerr << err.what() << "\n";
+      ret = 1;
+      continue;
+    }
+
+    auto n = root->find(srcpath);
+    if (n)
+    {
+      if (flags.have("f"))
+        std::cout << fname << "\n";
+      else
+        std::cout << fname << ":" << n->line() << "\n";
+    }
+  }
+
+  return ret;
+}
+
+int
+format(int argc, char ** argv)
+{
+  Flags flags;
+  flags.add("i", "modify file(s) inplace");
+  auto positional = parseOpts(argc, argv, flags);
+
+  if (positional.size() < 1)
+  {
+    std::cerr << "please pass in an input file argument\n";
+    return 1;
+  }
+
+  int ret = 0;
+  for (int i = 0; i < positional.size(); i++)
+  {
+    std::string fname(positional[i]);
+    std::ifstream f(fname);
+    std::string input((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    hit::Node * root = nullptr;
+    try
+    {
+      root = hit::parse(fname, input);
+    }
+    catch (std::exception & err)
+    {
+      std::cerr << err.what() << "\n";
+      ret = 1;
+      continue;
+    }
+
+    if (!flags.have("i"))
+      std::cout << root->render() << "\n";
+    else
+    {
+      std::ofstream f(fname);
+      f << root->render();
+    }
+  }
+
+  return ret;
+}
+
+int
+validate(int argc, char ** argv)
+{
+  if (argc < 1)
+  {
+    std::cerr << "please pass in an input file argument\n";
+    return 1;
+  }
+
+  int ret = 0;
+  for (int i = 0; i < argc; i++)
+  {
+    std::string fname(argv[i]);
+    std::ifstream f(fname);
+    std::string input((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    hit::Node * root = nullptr;
+    try
+    {
+      root = hit::parse(fname, input);
+    }
+    catch (std::exception & err)
+    {
+      std::cout << err.what() << "\n";
+      ret = 1;
+      continue;
+    }
+
+    DupParamWalker w(fname);
+    root->walk(&w, hit::NodeType::Field);
+    for (auto & msg : w.errors)
+      std::cout << msg << "\n";
+  }
+  return ret;
 }

--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -352,7 +352,7 @@ Comment::render(int indent)
 {
   if (_isinline)
     return " " + _text;
-  return strRepeat("    ", indent) + _text;
+  return "\n" + strRepeat("    ", indent) + _text;
 }
 
 Node *
@@ -382,13 +382,9 @@ Section::render(int indent)
     s += child->render(indent + 1);
 
   if (root() != this)
-  {
-    s += "\n" + strRepeat("    ", indent);
-    if (indent == 0)
-      s += "[]";
-    else
-      s += "[../]";
-  }
+    s += "\n" + strRepeat("    ", indent) + "[]";
+  else
+    s = s.substr(1);
   return s;
 }
 
@@ -679,7 +675,12 @@ parseSectionBody(Parser * p, Node * n)
     auto tok = p->next();
     auto next = p->peek();
     p->backup();
-    if (tok.type == TokType::Ident)
+    if (tok.type == TokType::BlankLine)
+    {
+      p->require(TokType::BlankLine, "parser is horribly broken");
+      n->addChild(p->emit(new Blank()));
+    }
+    else if (tok.type == TokType::Ident)
       parseField(p, n);
     else if (tok.type == TokType::Comment || tok.type == TokType::InlineComment)
       parseComment(p, n);

--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -17,6 +17,8 @@
 namespace hit
 {
 
+const std::string indentString = "  ";
+
 // split breaks input into a vector treating whitespace as a delimiter.  Consecutive whitespace
 // characters are treated as a single delimiter.
 std::vector<std::string>
@@ -352,7 +354,7 @@ Comment::render(int indent)
 {
   if (_isinline)
     return " " + _text;
-  return "\n" + strRepeat("    ", indent) + _text;
+  return "\n" + strRepeat(indentString, indent) + _text;
 }
 
 Node *
@@ -374,7 +376,7 @@ Section::render(int indent)
 {
   std::string s;
   if (root() != this)
-    s = "\n" + strRepeat("    ", indent) + "[" + _path + "]";
+    s = "\n" + strRepeat(indentString, indent) + "[" + _path + "]";
   else
     indent--; // don't indent the root section contents extra
 
@@ -382,7 +384,7 @@ Section::render(int indent)
     s += child->render(indent + 1);
 
   if (root() != this)
-    s += "\n" + strRepeat("    ", indent) + "[]";
+    s += "\n" + strRepeat(indentString, indent) + "[]";
   else
     s = s.substr(1);
   return s;
@@ -411,7 +413,7 @@ Field::path()
 std::string
 Field::render(int indent)
 {
-  return "\n" + strRepeat("    ", indent) + _field + " = " + _val;
+  return "\n" + strRepeat(indentString, indent) + _field + " = " + _val;
 }
 
 Node *

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -60,6 +60,7 @@ enum class NodeType
   Section, /// Represents hit sections (i.e. "[pathname]...[../]").
   Comment, /// Represents comments that are not directly part of the actual hit document.
   Field,   /// Represents field-value pairs (i.e. paramname=val).
+  Blank,   /// Represents a blank line
 };
 
 /// nodeTypeName returns a human-readable string representing a name for the give node type.
@@ -307,6 +308,15 @@ public:
 private:
   std::string _text;
   bool _isinline;
+};
+
+/// Blank represents a blank line in the input.  It aids in correctly re-rendering parsed input.
+class Blank : public Node
+{
+public:
+  Blank() : Node(NodeType::Blank) {}
+  virtual std::string render(int /*indent = 0*/) override { return "\n"; }
+  virtual Node * clone() override { return new Blank(); };
 };
 
 /// Section represents a hit section including the section header path and all entries inside


### PR DESCRIPTION
An attempt at addressing #9845.  Note that this just uses the hit binary built by running ``make`` in the ``contrib/hit`` directory.  I don't really care too much where we put it, but since it is useful for all hit syntax files (not necessarily just MOOSE) I think that is a good place for it.  We could potentially integrate this functionality into the moose binaries also, but I don't feel too strongly about that.

The ``hit`` binary has four subcommands:

* ``rename [srcpath] [dstpath] [file]...``: renames/moves parameters
* ``format [file]...``: formats files to canonical hit style
* ``validate [file]...``: checks files syntax errors and duplicate parameters
* ``find [param] [file]...``: searches and reports locations of the parameter in files

``rename`` and ``format`` both can take a ``-i`` option for in-place file modification.  For a formatting example:

```
[BCs]
  [./right]
    type =                                  DirichletBC
                        variable = u


    boundary = right   value = 1
  [../]
[]
# hello
# my name is


# joe

[Executioner]
  type = Steady
  solve_type = 'PJFNK' # here is an inline comment
  petsc_options_iname = '-pc_type -pc_hypre_type' # and another



  petsc_options_value = 'hypre boomeramg'
[]

[Outputs]
  exodus = true
[]
```

becomes:

```
[BCs]
  [right]
    type = DirichletBC
    variable = u

    boundary = right
    value = 1
  []
[]
# hello
# my name is

# joe

[Executioner]
  type = Steady
  solve_type = 'PJFNK' # here is an inline comment
  petsc_options_iname = '-pc_type -pc_hypre_type' # and another

  petsc_options_value = 'hypre boomeramg'
[]

[Outputs]
  exodus = true
[]
```