### PR TITLE
Use libMesh::BoundingBox, not libMesh::MeshTools::BoundingBox

### DIFF
--- a/framework/include/base/OrientedBoxInterface.h
+++ b/framework/include/base/OrientedBoxInterface.h
@@ -76,7 +76,7 @@ private:
   std::unique_ptr<RealTensorValue> _rot_matrix;
 
   /// The bounding box used to test if the point is contained within
-  std::unique_ptr<MeshTools::BoundingBox> _bounding_box;
+  std::unique_ptr<BoundingBox> _bounding_box;
 };
 
 #endif // ORIENTEDBOXINTERFACE_H

--- a/framework/include/base/OrientedBoxInterface.h
+++ b/framework/include/base/OrientedBoxInterface.h
@@ -18,8 +18,7 @@
 // MOOSE includes
 #include "MooseTypes.h"
 
-#include "libmesh/mesh_base.h"
-#include "libmesh/mesh_tools.h"
+#include "libmesh/bounding_box.h" // For destructor
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_value.h"
 

--- a/framework/include/markers/BoxMarker.h
+++ b/framework/include/markers/BoxMarker.h
@@ -35,7 +35,7 @@ protected:
   MarkerValue _inside;
   MarkerValue _outside;
 
-  MeshTools::BoundingBox _bounding_box;
+  BoundingBox _bounding_box;
 };
 
 #endif /* BOXMARKER_H */

--- a/framework/include/markers/BoxMarker.h
+++ b/framework/include/markers/BoxMarker.h
@@ -17,7 +17,7 @@
 
 #include "Marker.h"
 
-#include "libmesh/mesh_tools.h"
+#include "libmesh/bounding_box.h"
 
 class BoxMarker;
 

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -453,7 +453,7 @@ public:
    * @param inflation_multiplier This amount will be multiplied by the length of the diagonal of the
    * bounding box to find the amount to inflate the bounding box by in all directions.
    */
-  MeshTools::BoundingBox getInflatedProcessorBoundingBox(Real inflation_multiplier = 0.01) const;
+  BoundingBox getInflatedProcessorBoundingBox(Real inflation_multiplier = 0.01) const;
 
   /**
    * Implicit conversion operator from MooseMesh -> libMesh::MeshBase.

--- a/framework/include/meshmodifiers/BoundingBoxNodeSet.h
+++ b/framework/include/meshmodifiers/BoundingBoxNodeSet.h
@@ -45,7 +45,7 @@ private:
   MooseEnum _location;
 
   /// Bounding box for testing element centroids against. Note that
-  MeshTools::BoundingBox _bounding_box;
+  BoundingBox _bounding_box;
 };
 
 #endif // BOUNDINGBOXNODESET_H

--- a/framework/include/meshmodifiers/BoundingBoxNodeSet.h
+++ b/framework/include/meshmodifiers/BoundingBoxNodeSet.h
@@ -23,7 +23,7 @@
 class BoundingBoxNodeSet;
 namespace libMesh
 {
-  class BoundingBox;
+class BoundingBox;
 }
 
 template <>

--- a/framework/include/meshmodifiers/BoundingBoxNodeSet.h
+++ b/framework/include/meshmodifiers/BoundingBoxNodeSet.h
@@ -19,10 +19,12 @@
 #include "MeshModifier.h"
 #include "MooseEnum.h"
 
-#include "libmesh/mesh_tools.h"
-
 // Forward Declaration
 class BoundingBoxNodeSet;
+namespace libMesh
+{
+  class BoundingBox;
+}
 
 template <>
 InputParameters validParams<BoundingBoxNodeSet>();

--- a/framework/include/meshmodifiers/SubdomainBoundingBox.h
+++ b/framework/include/meshmodifiers/SubdomainBoundingBox.h
@@ -19,13 +19,16 @@
 #include "MooseEnum.h"
 #include "MeshModifier.h"
 
-#include "libmesh/mesh_tools.h"
-
 // Forward declerations
 class SubdomainBoundingBox;
 
 template <>
 InputParameters validParams<SubdomainBoundingBox>();
+
+namespace libMesh
+{
+  class BoundingBox;
+}
 
 /**
  * MeshModifier for defining a Subdomain inside or outside of a bounding box

--- a/framework/include/meshmodifiers/SubdomainBoundingBox.h
+++ b/framework/include/meshmodifiers/SubdomainBoundingBox.h
@@ -27,7 +27,7 @@ InputParameters validParams<SubdomainBoundingBox>();
 
 namespace libMesh
 {
-  class BoundingBox;
+class BoundingBox;
 }
 
 /**

--- a/framework/include/meshmodifiers/SubdomainBoundingBox.h
+++ b/framework/include/meshmodifiers/SubdomainBoundingBox.h
@@ -49,7 +49,7 @@ private:
   SubdomainID _block_id;
 
   /// Bounding box for testing element centroids against
-  MeshTools::BoundingBox _bounding_box;
+  BoundingBox _bounding_box;
 };
 
 #endif // SUBDOMAINBOUDINGBOX_H

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -29,6 +29,7 @@ class Backup;
 // libMesh forward declarations
 namespace libMesh
 {
+class BoundingBox;
 namespace MeshTools
 {
 class BoundingBox;

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -137,7 +137,7 @@ public:
    * the geometry around the axis to create the 3D geometry).
    * @param app The global app number you want to get the bounding box for
    */
-  virtual MeshTools::BoundingBox getBoundingBox(unsigned int app);
+  virtual BoundingBox getBoundingBox(unsigned int app);
 
   /**
    * Get the FEProblemBase this MultiApp is part of.

--- a/framework/include/transfers/MultiAppInterpolationTransfer.h
+++ b/framework/include/transfers/MultiAppInterpolationTransfer.h
@@ -18,6 +18,8 @@
 // MOOSE includes
 #include "MultiAppTransfer.h"
 
+#include "libmesh/mesh_base.h"
+
 // Forward declarations
 class MultiAppInterpolationTransfer;
 

--- a/framework/include/transfers/MultiAppNearestNodeTransfer.h
+++ b/framework/include/transfers/MultiAppNearestNodeTransfer.h
@@ -55,7 +55,7 @@ protected:
    * @return The maximum distance between the point p and the eight corners of
    * the bounding box bbox.
    */
-  Real bboxMaxDistance(Point p, MeshTools::BoundingBox bbox);
+  Real bboxMaxDistance(Point p, BoundingBox bbox);
 
   /**
    * Return the distance between the given point and the nearest corner of the
@@ -65,7 +65,7 @@ protected:
    * @return The minimum distance between the point p and the eight corners of
    * the bounding box bbox.
    */
-  Real bboxMinDistance(Point p, MeshTools::BoundingBox bbox);
+  Real bboxMinDistance(Point p, BoundingBox bbox);
 
   void getLocalNodes(MooseMesh * mesh, std::vector<Node *> & local_nodes);
 

--- a/framework/include/transfers/MultiAppTransfer.h
+++ b/framework/include/transfers/MultiAppTransfer.h
@@ -19,7 +19,7 @@
 #include "Transfer.h"
 #include "MooseEnum.h"
 
-#include "libmesh/mesh_tools.h"
+#include "libmesh/bounding_box.h"
 
 // Forward declarations
 class MultiAppTransfer;

--- a/framework/include/transfers/MultiAppTransfer.h
+++ b/framework/include/transfers/MultiAppTransfer.h
@@ -95,7 +95,7 @@ protected:
    * Return the bounding boxes of all the "from" domains, including all the
    * domains not local to this processor.
    */
-  std::vector<MeshTools::BoundingBox> getFromBoundingBoxes();
+  std::vector<BoundingBox> getFromBoundingBoxes();
 
   /**
    * Return the number of "from" domains that each processor owns.

--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -158,7 +158,7 @@ private:
 #endif
 
   /// Bounding box for testing points
-  MeshTools::BoundingBox _bounding_box;
+  BoundingBox _bounding_box;
 
   /// Parameters for interface
   const InputParameters & _is_pars;

--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -19,7 +19,7 @@
 #include "FileRangeBuilder.h"
 #include "ConsoleStream.h"
 
-#include "libmesh/mesh_tools.h"
+#include "libmesh/bounding_box.h"
 
 // VTK includes
 #ifdef LIBMESH_HAVE_VTK

--- a/framework/src/base/OrientedBoxInterface.C
+++ b/framework/src/base/OrientedBoxInterface.C
@@ -51,7 +51,7 @@ OrientedBoxInterface::OrientedBoxInterface(const InputParameters & parameters)
   Point bottom_left(-xmax, -ymax, -zmax);
   Point top_right(xmax, ymax, zmax);
 
-  _bounding_box = libmesh_make_unique<MeshTools::BoundingBox>(bottom_left, top_right);
+  _bounding_box = libmesh_make_unique<BoundingBox>(bottom_left, top_right);
 
   /*
    * now create the rotation matrix that rotates the oriented

--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -85,14 +85,14 @@ NearestNodeLocator::findNodes()
     std::vector<dof_id_type> trial_master_nodes;
 
     // Build a bounding box.  No reason to consider nodes outside of our inflated BB
-    MeshTools::BoundingBox * my_inflated_box = NULL;
+    BoundingBox * my_inflated_box = NULL;
 
     const std::vector<Real> & inflation = _mesh.getGhostedBoundaryInflation();
 
     // This means there was a user specified inflation... so we can build a BB
     if (inflation.size() > 0)
     {
-      MeshTools::BoundingBox my_box = MeshTools::create_local_bounding_box(_mesh);
+      BoundingBox my_box = MeshTools::create_local_bounding_box(_mesh);
 
       Real distance_x = 0;
       Real distance_y = 0;
@@ -106,12 +106,12 @@ NearestNodeLocator::findNodes()
       if (inflation.size() > 2)
         distance_z = inflation[2];
 
-      my_inflated_box = new MeshTools::BoundingBox(Point(my_box.first(0) - distance_x,
-                                                         my_box.first(1) - distance_y,
-                                                         my_box.first(2) - distance_z),
-                                                   Point(my_box.second(0) + distance_x,
-                                                         my_box.second(1) + distance_y,
-                                                         my_box.second(2) + distance_z));
+      my_inflated_box = new BoundingBox(Point(my_box.first(0) - distance_x,
+                                              my_box.first(1) - distance_y,
+                                              my_box.first(2) - distance_z),
+                                        Point(my_box.second(0) + distance_x,
+                                              my_box.second(1) + distance_y,
+                                              my_box.second(2) + distance_z));
     }
 
     // Data structures to hold the Nodal Boundary conditions

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -18,6 +18,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/periodic_boundary_base.h"
+#include "libmesh/unstructured_mesh.h"
 
 // C++ includes
 #include <cmath> // provides round, not std::round (see http://www.cplusplus.com/reference/cmath/round/)

--- a/framework/src/mesh/ImageMesh.C
+++ b/framework/src/mesh/ImageMesh.C
@@ -20,6 +20,7 @@
 #include <fstream>
 
 #include "libmesh/mesh_generation.h"
+#include "libmesh/unstructured_mesh.h"
 
 template <>
 InputParameters

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2384,7 +2384,7 @@ MooseMesh::getPatchUpdateStrategy() const
   return _patch_update_strategy;
 }
 
-MeshTools::BoundingBox
+BoundingBox
 MooseMesh::getInflatedProcessorBoundingBox(Real inflation_multiplier) const
 {
   // Grab a bounding box to speed things up.  Note that

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -358,7 +358,7 @@ MultiApp::restore()
     _apps[i]->restore(_backups[i]);
 }
 
-MeshTools::BoundingBox
+BoundingBox
 MultiApp::getBoundingBox(unsigned int app)
 {
   if (!_has_an_app)
@@ -369,7 +369,7 @@ MultiApp::getBoundingBox(unsigned int app)
   MPI_Comm swapped = Moose::swapLibMeshComm(_my_comm);
 
   MooseMesh & mesh = problem.mesh();
-  MeshTools::BoundingBox bbox = MeshTools::bounding_box(mesh);
+  BoundingBox bbox = MeshTools::create_bounding_box(mesh);
 
   Moose::swapLibMeshComm(swapped);
 
@@ -404,7 +404,7 @@ MultiApp::getBoundingBox(unsigned int app)
   shifted_min += p;
   shifted_max += p;
 
-  return MeshTools::BoundingBox(shifted_min, shifted_max);
+  return BoundingBox(shifted_min, shifted_max);
 }
 
 FEProblemBase &

--- a/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectEvaluator.C
@@ -82,7 +82,7 @@ MultiAppDTKUserObjectEvaluator::createSourceGeometry(
   {
     unsigned int global_app = _multi_app.firstLocalApp() + app;
 
-    MeshTools::BoundingBox bbox = _multi_app.getBoundingBox(global_app);
+    BoundingBox bbox = _multi_app.getBoundingBox(global_app);
 
     _boxes[app] = DataTransferKit::Box(
         bbox.min()(0), bbox.min()(1), bbox.min()(2), bbox.max()(0), bbox.max()(1), bbox.max()(2));

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -83,7 +83,7 @@ MultiAppMeshFunctionTransfer::execute()
    */
 
   // Get the bounding boxes for the "from" domains.
-  std::vector<MeshTools::BoundingBox> bboxes = getFromBoundingBoxes();
+  std::vector<BoundingBox> bboxes = getFromBoundingBoxes();
 
   // Figure out how many "from" domains each processor owns.
   std::vector<unsigned int> froms_per_proc = getFromsPerProc();
@@ -182,7 +182,7 @@ MultiAppMeshFunctionTransfer::execute()
    */
 
   // Get the local bounding boxes.
-  std::vector<MeshTools::BoundingBox> local_bboxes(froms_per_proc[processor_id()]);
+  std::vector<BoundingBox> local_bboxes(froms_per_proc[processor_id()]);
   {
     // Find the index to the first of this processor's local bounding boxes.
     unsigned int local_start = 0;

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -94,7 +94,7 @@ MultiAppNearestNodeTransfer::execute()
   getAppInfo();
 
   // Get the bounding boxes for the "from" domains.
-  std::vector<MeshTools::BoundingBox> bboxes = getFromBoundingBoxes();
+  std::vector<BoundingBox> bboxes = getFromBoundingBoxes();
 
   // Figure out how many "from" domains each processor owns.
   std::vector<unsigned int> froms_per_proc = getFromsPerProc();
@@ -584,7 +584,7 @@ MultiAppNearestNodeTransfer::getNearestNode(const Point & p,
 }
 
 Real
-MultiAppNearestNodeTransfer::bboxMaxDistance(Point p, MeshTools::BoundingBox bbox)
+MultiAppNearestNodeTransfer::bboxMaxDistance(Point p, BoundingBox bbox)
 {
   std::vector<Point> source_points = {bbox.first, bbox.second};
 
@@ -607,7 +607,7 @@ MultiAppNearestNodeTransfer::bboxMaxDistance(Point p, MeshTools::BoundingBox bbo
 }
 
 Real
-MultiAppNearestNodeTransfer::bboxMinDistance(Point p, MeshTools::BoundingBox bbox)
+MultiAppNearestNodeTransfer::bboxMinDistance(Point p, BoundingBox bbox)
 {
   std::vector<Point> source_points = {bbox.first, bbox.second};
 

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -218,7 +218,7 @@ MultiAppProjectionTransfer::execute()
   ////////////////////
 
   // Get the bounding boxes for the "from" domains.
-  std::vector<MeshTools::BoundingBox> bboxes = getFromBoundingBoxes();
+  std::vector<BoundingBox> bboxes = getFromBoundingBoxes();
 
   // Figure out how many "from" domains each processor owns.
   std::vector<unsigned int> froms_per_proc = getFromsPerProc();
@@ -304,7 +304,7 @@ MultiAppProjectionTransfer::execute()
         _communicator.send(i_proc, outgoing_qps[i_proc], send_qps[i_proc]);
 
   // Get the local bounding boxes.
-  std::vector<MeshTools::BoundingBox> local_bboxes(froms_per_proc[processor_id()]);
+  std::vector<BoundingBox> local_bboxes(froms_per_proc[processor_id()]);
   {
     // Find the index to the first of this processor's local bounding boxes.
     unsigned int local_start = 0;

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -169,7 +169,7 @@ MultiAppTransfer::getAppInfo()
   }
 }
 
-std::vector<MeshTools::BoundingBox>
+std::vector<BoundingBox>
 MultiAppTransfer::getFromBoundingBoxes()
 {
   std::vector<std::pair<Point, Point>> bb_points(_from_meshes.size());
@@ -177,8 +177,8 @@ MultiAppTransfer::getFromBoundingBoxes()
   {
     // Get a bounding box around the mesh elements that are local to the current
     // processor.
-    MeshTools::BoundingBox bbox =
-        MeshTools::processor_bounding_box(*_from_meshes[i], _from_meshes[i]->comm().rank());
+    BoundingBox bbox =
+        MeshTools::create_local_bounding_box(*_from_meshes[i]);
 
     // Translate the bounding box to the from domain's position.
     bbox.first += _from_positions[i];
@@ -193,9 +193,9 @@ MultiAppTransfer::getFromBoundingBoxes()
   _communicator.allgather(bb_points);
 
   // Recast the points back into bounding boxes and return.
-  std::vector<MeshTools::BoundingBox> bboxes(bb_points.size());
+  std::vector<BoundingBox> bboxes(bb_points.size());
   for (unsigned int i = 0; i < bb_points.size(); i++)
-    bboxes[i] = static_cast<MeshTools::BoundingBox>(bb_points[i]);
+    bboxes[i] = static_cast<BoundingBox>(bb_points[i]);
 
   return bboxes;
 }

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -177,8 +177,7 @@ MultiAppTransfer::getFromBoundingBoxes()
   {
     // Get a bounding box around the mesh elements that are local to the current
     // processor.
-    BoundingBox bbox =
-        MeshTools::create_local_bounding_box(*_from_meshes[i]);
+    BoundingBox bbox = MeshTools::create_local_bounding_box(*_from_meshes[i]);
 
     // Translate the bounding box to the from domain's position.
     bbox.first += _from_positions[i];

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -201,7 +201,7 @@ MultiAppUserObjectTransfer::execute()
           continue;
 
         Point app_position = _multi_app->position(i);
-        MeshTools::BoundingBox app_box = _multi_app->getBoundingBox(i);
+        BoundingBox app_box = _multi_app->getBoundingBox(i);
         const UserObject & user_object = _multi_app->appUserObjectBase(i, _user_object_name);
 
         if (is_nodal)

--- a/framework/src/userobject/LayeredBase.C
+++ b/framework/src/userobject/LayeredBase.C
@@ -95,7 +95,7 @@ LayeredBase::LayeredBase(const InputParameters & parameters)
   if (!_interval_based && _sample_type == 1)
     mooseError("'sample_type = interpolate' not supported with 'bounds' in ", _layered_base_name);
 
-  MeshTools::BoundingBox bounding_box = MeshTools::bounding_box(_layered_base_subproblem.mesh());
+  BoundingBox bounding_box = MeshTools::create_bounding_box(_layered_base_subproblem.mesh());
   _layer_values.resize(_num_layers);
   _layer_has_value.resize(_num_layers);
 

--- a/framework/src/utils/ImageSampler.C
+++ b/framework/src/utils/ImageSampler.C
@@ -83,7 +83,7 @@ ImageSampler::setupImageSampler(MooseMesh & mesh)
 
 #ifdef LIBMESH_HAVE_VTK
   // Get access to the Mesh object
-  MeshTools::BoundingBox bbox = MeshTools::bounding_box(mesh.getMesh());
+  BoundingBox bbox = MeshTools::bounding_box(mesh.getMesh());
 
   // Set the dimensions from the Mesh if not set by the User
   if (_is_pars.isParamValid("dimensions"))

--- a/framework/src/utils/ImageSampler.C
+++ b/framework/src/utils/ImageSampler.C
@@ -17,6 +17,8 @@
 #include "MooseApp.h"
 #include "ImageMesh.h"
 
+#include "libmesh/mesh_tools.h"
+
 template <>
 InputParameters
 validParams<ImageSampler>()
@@ -83,7 +85,7 @@ ImageSampler::setupImageSampler(MooseMesh & mesh)
 
 #ifdef LIBMESH_HAVE_VTK
   // Get access to the Mesh object
-  BoundingBox bbox = MeshTools::bounding_box(mesh.getMesh());
+  BoundingBox bbox = MeshTools::create_bounding_box(mesh.getMesh());
 
   // Set the dimensions from the Mesh if not set by the User
   if (_is_pars.isParamValid("dimensions"))

--- a/framework/src/vectorpostprocessors/PointSamplerBase.C
+++ b/framework/src/vectorpostprocessors/PointSamplerBase.C
@@ -72,7 +72,7 @@ PointSamplerBase::initialize()
 void
 PointSamplerBase::execute()
 {
-  MeshTools::BoundingBox bbox = _mesh.getInflatedProcessorBoundingBox();
+  BoundingBox bbox = _mesh.getInflatedProcessorBoundingBox();
 
   /// So we don't have to create and destroy this
   std::vector<Point> point_vec(1);

--- a/modules/misc/src/CoupledDirectionalMeshHeightInterpolation.C
+++ b/modules/misc/src/CoupledDirectionalMeshHeightInterpolation.C
@@ -30,7 +30,7 @@ CoupledDirectionalMeshHeightInterpolation::CoupledDirectionalMeshHeightInterpola
     _coupled_val(coupledValue("coupled_var")),
     _direction(getParam<MooseEnum>("direction"))
 {
-  MeshTools::BoundingBox bounding_box = MeshTools::bounding_box(_subproblem.mesh());
+  BoundingBox bounding_box = MeshTools::create_bounding_box(_subproblem.mesh());
 
   _direction_min = bounding_box.min()(_direction);
   _direction_max = bounding_box.max()(_direction);

--- a/modules/phase_field/src/ics/ClosePackIC.C
+++ b/modules/phase_field/src/ics/ClosePackIC.C
@@ -30,7 +30,7 @@ void
 ClosePackIC::computeCircleCenters()
 {
   // Determine the extents of the mesh
-  MeshTools::BoundingBox bbox = MeshTools::bounding_box(_fe_problem.mesh().getMesh());
+  BoundingBox bbox = MeshTools::create_bounding_box(_fe_problem.mesh().getMesh());
   const Point & min = bbox.min();
   const Point & max = bbox.max();
 

--- a/modules/phase_field/src/utils/PolycrystalICTools.C
+++ b/modules/phase_field/src/utils/PolycrystalICTools.C
@@ -11,6 +11,7 @@
 #include "MooseMesh.h"
 #include "MooseVariable.h"
 
+#include "libmesh/mesh_tools.h"
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/point_locator_base.h"
 


### PR DESCRIPTION
This fixes a #1500 bug (w.r.t. efficiency, not necessarily correctness), by using the new create_local_bounding_box() API instead of misusing the old processor_bounding_box() API.  But since we're switching to new APIs anyway, we might as well replace all the other deprecated BoundingBox usage with its newer version.

The header refactor which that enables is significant, but as with any #8730 operation it's possible it will break things downstream which had been inappropriately relying on indirectly included headers.  If there is much breakage, then we might just merge the first two commits of this PR right away but leave the third as a longer-term update.