### PR TITLE
Allow users to specify sub communicator

### DIFF
--- a/framework/include/base/AppFactory.h
+++ b/framework/include/base/AppFactory.h
@@ -82,7 +82,9 @@ public:
   /**
    * Helper function for creating a MooseApp from command-line arguments.
    */
-  static MooseApp * createApp(std::string app_type, int argc, char ** argv);
+  static MooseApp *
+  createApp(std::string app_type, int argc, char ** argv, MPI_Comm COMM_WORLD_IN = MPI_COMM_WORLD);
+
   static std::shared_ptr<MooseApp>
   createAppShared(const std::string & app_type, int argc, char ** argv);
 

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -27,7 +27,7 @@ AppFactory::instance()
 AppFactory::~AppFactory() {}
 
 MooseApp *
-AppFactory::createApp(std::string app_type, int argc, char ** argv)
+AppFactory::createApp(std::string app_type, int argc, char ** argv, MPI_Comm COMM_WORLD_IN)
 {
   auto command_line = std::make_shared<CommandLine>(argc, argv);
   InputParameters app_params = AppFactory::instance().getValidParams(app_type);
@@ -36,7 +36,7 @@ AppFactory::createApp(std::string app_type, int argc, char ** argv)
   app_params.set<char **>("_argv") = argv;
   app_params.set<std::shared_ptr<CommandLine>>("_command_line") = command_line;
 
-  MooseApp * app = AppFactory::instance().create(app_type, "main", app_params, MPI_COMM_WORLD);
+  MooseApp * app = AppFactory::instance().create(app_type, "main", app_params, COMM_WORLD_IN);
   return app;
 }
 


### PR DESCRIPTION
This PR allows users to specify a sub communicator when creating
the master (or first) MooseApp. This is useful for cases where
MOOSE is coupled into an external driver.

closes #6221
