### PR TITLE
unskipping test

### DIFF
--- a/modules/phase_field/test/tests/grain_growth_test/tests
+++ b/modules/phase_field/test/tests/grain_growth_test/tests
@@ -35,7 +35,6 @@
     type = 'Exodiff'
     input = 'GrGr_boundingbox_test.i'
     exodiff = 'bounding_box.e-s003'
-    recover = false # See 5207
   [../]
 
   [./GBEvolution_test]


### PR DESCRIPTION
closes #5207

This issue appears to have been fixed. At least it works properly on my mac. Let's see if it'll pass CIVET.