### PR TITLE
parser: make suggestions for misspelled parameters

### DIFF
--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -173,6 +173,8 @@ public:
 
   void errorCheck(const Parallel::Communicator & comm, bool warn_unused, bool err_unused);
 
+  std::vector<std::string> listValidParams(std::string & section_name);
+
 protected:
   /**
    * Helper functions for setting parameters of arbitrary types - bodies are in the .C file

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -38,6 +38,10 @@ class Communicator;
 
 namespace MooseUtils
 {
+
+/// Computes and returns the Levenshtein distance between strings s1 and s2.
+int levenshteinDist(const std::string & s1, const std::string & s2);
+
 /**
  * This function will escape all of the standard C++ escape characters so that they can be printed.
  * The

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -36,6 +36,8 @@
 namespace MooseUtils
 {
 
+// this implementation is copied from
+// https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C.2B.2B
 int
 levenshteinDist(const std::string & s1, const std::string & s2)
 {

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -31,9 +31,41 @@
 
 // System includes
 #include <sys/stat.h>
+#include <numeric>
 
 namespace MooseUtils
 {
+
+int
+levenshteinDist(const std::string & s1, const std::string & s2)
+{
+  // To change the type this function manipulates and returns, change
+  // the return type and the types of the two variables below.
+  auto s1len = s1.size();
+  auto s2len = s2.size();
+
+  auto column_start = (decltype(s1len))1;
+
+  auto column = new decltype(s1len)[s1len + 1];
+  std::iota(column + column_start, column + s1len + 1, column_start);
+
+  for (auto x = column_start; x <= s2len; x++)
+  {
+    column[0] = x;
+    auto last_diagonal = x - column_start;
+    for (auto y = column_start; y <= s1len; y++)
+    {
+      auto old_diagonal = column[y];
+      auto possibilities = {
+          column[y] + 1, column[y - 1] + 1, last_diagonal + (s1[y - 1] == s2[x - 1] ? 0 : 1)};
+      column[y] = std::min(possibilities);
+      last_diagonal = old_diagonal;
+    }
+  }
+  auto result = column[s1len];
+  delete[] column;
+  return result;
+}
 
 void
 escape(std::string & str)

--- a/unit/src/MooseUtilsTests.C
+++ b/unit/src/MooseUtilsTests.C
@@ -1,0 +1,25 @@
+
+#include "gtest/gtest.h"
+
+#include "MooseUtils.h"
+
+struct TestCase
+{
+  std::string a;
+  std::string b;
+  int dist;
+};
+
+TEST(MooseUtilsTests, levenshteinDist)
+{
+  TestCase cases[] = {
+      {"hello", "hell", 1}, {"flood", "foods", 2}, {"fandango", "odanget", 5},
+  };
+
+  for (size_t i = 0; i < sizeof(cases) / sizeof(TestCase); i++)
+  {
+    auto test = cases[i];
+    int got = MooseUtils::levenshteinDist(test.a, test.b);
+    EXPECT_EQ(test.dist, got) << "case " << i + 1 << " FAILED: a=" << test.a << ", b=" << test.b;
+  }
+}


### PR DESCRIPTION
```
$ moose_test-opt -i foo.i --warn-unused Mesh/dispalcments='bla'
...
*** Warning ***
CLI_ARG:1: unused parameter 'Mesh/dispalcments'
    Did you mean 'displacements'?
```

I don't think we want to print out the entire parameter list - that list could be super long and then the user would have to sift through it all visually.

fixes #980