### PR TITLE
Fix problem with copying from text window.

### DIFF
--- a/python/peacock/utils/TextSubWindow.py
+++ b/python/peacock/utils/TextSubWindow.py
@@ -1,11 +1,10 @@
-from PyQt5 import QtCore, QtWidgets
+from PyQt5 import QtWidgets
 class TextSubWindow(QtWidgets.QTextEdit):
     """
     TextEdit that saves it size when it closes and closes itself if the main widget disappears.
     """
     def __init__(self):
         super(TextSubWindow, self).__init__()
-        self.setWindowFlags(QtCore.Qt.SubWindow)
         self._size = None
 
     def sizeHint(self, *args):


### PR DESCRIPTION
This fixes the problem for me. Before, after you close the script window and reopen it you would no longer be able to copy from it.
@aeslaughter Is there a reason you needed these types of windows to be a `Qt.SubWindow`?

closes #9843
