### PR TITLE
Pass --allow-test-objects when executing and generating mesh.

### DIFF
--- a/python/peacock/Execute/ExecuteOptionsPlugin.py
+++ b/python/peacock/Execute/ExecuteOptionsPlugin.py
@@ -19,6 +19,7 @@ class ExecuteOptionsPlugin(QWidget, Plugin):
     executableChanged = pyqtSignal(str)
     executableInfoChanged = pyqtSignal(ExecutableInfo)
     workingDirChanged = pyqtSignal(str)
+    useTestObjectsChanged = pyqtSignal(bool)
 
     def __init__(self, **kwds):
         super(ExecuteOptionsPlugin, self).__init__(**kwds)
@@ -191,6 +192,7 @@ class ExecuteOptionsPlugin(QWidget, Plugin):
         """
         Reload the ExecutableInfo based on whether we are allowing test objects or not.
         """
+        self.useTestObjectsChanged.emit(self.test_checkbox.isChecked())
         self.setExecutablePath(self.exe_line.text())
 
     def _workingDirChanged(self):

--- a/python/peacock/Execute/ExecuteTabPlugin.py
+++ b/python/peacock/Execute/ExecuteTabPlugin.py
@@ -70,6 +70,8 @@ class ExecuteTabPlugin(QWidget, PluginManager, TabPlugin):
     def onNeedCommand(self):
         cmd, args = self.ExecuteOptionsPlugin.buildCommandWithNoInputFile()
         csv = self.ExecuteOptionsPlugin.csv_checkbox.isChecked()
+        if self.ExecuteOptionsPlugin.test_checkbox.isChecked():
+            args.append("--allow-test-objects")
         self.ExecuteRunnerPlugin.setCommand(cmd, args, csv)
 
     def onNumTimeStepsChanged(self, num_steps):

--- a/python/peacock/Input/InputFileEditorWithMesh.py
+++ b/python/peacock/Input/InputFileEditorWithMesh.py
@@ -237,6 +237,12 @@ class InputFileEditorWithMesh(QWidget, PluginManager, TabPlugin):
         """
         self.InputFileEditorPlugin.clearRecentlyUsed()
 
+    def onUseTestObjectsChanged(self, use_test_objs):
+        """
+        Pass along whether to use test objects.
+        """
+        self.MeshViewerPlugin.useTestObjects(use_test_objs)
+
 if __name__ == "__main__":
     from PyQt5.QtWidgets import QApplication, QMainWindow
     from ExecutableInfo import ExecutableInfo

--- a/python/peacock/Input/MeshViewerPlugin.py
+++ b/python/peacock/Input/MeshViewerPlugin.py
@@ -19,6 +19,7 @@ class MeshViewerPlugin(VTKWindowPlugin):
         self.temp_input_file = "peacock_run_mesh_tmp.i"
         self.temp_mesh_file = "peacock_run_mesh_tmp.e"
         self.current_temp_mesh_file = os.path.abspath(self.temp_mesh_file)
+        self._use_test_objects = True
 
     def _removeFileNoError(self, fname):
         """
@@ -31,6 +32,12 @@ class MeshViewerPlugin(VTKWindowPlugin):
             os.remove(path)
         except:
             pass
+
+    def useTestObjects(self, use_test_objs):
+        """
+        Set to pass the --allow-test-objects flag while generating the mesh
+        """
+        self._use_test_objects = use_test_objs
 
     def meshChanged(self, tree):
         """
@@ -55,6 +62,8 @@ class MeshViewerPlugin(VTKWindowPlugin):
         self.needInputFile.emit(input_file)
         try:
             args = ["-i", input_file, "--mesh-only", self.current_temp_mesh_file]
+            if self._use_test_objects:
+                args.append("--allow-test-objects")
             ExeLauncher.runExe(exe_path, args, print_errors=False)
             self.meshEnabled.emit(True)
             self.onFileChanged(self.current_temp_mesh_file)

--- a/python/peacock/PeacockMainWindow.py
+++ b/python/peacock/PeacockMainWindow.py
@@ -32,6 +32,7 @@ class PeacockMainWindow(BasePeacockMainWindow):
         self.tab_plugin.ExecuteTabPlugin.needInputFile.connect(self.tab_plugin.InputFileEditorWithMesh.InputFileEditorPlugin.writeInputFile)
         self.tab_plugin.InputFileEditorWithMesh.inputFileChanged.connect(self._inputFileChanged)
         self.tab_plugin.ExecuteTabPlugin.ExecuteOptionsPlugin.workingDirChanged.connect(self.tab_plugin.InputFileEditorWithMesh.onWorkingDirChanged)
+        self.tab_plugin.ExecuteTabPlugin.ExecuteOptionsPlugin.useTestObjectsChanged.connect(self.tab_plugin.InputFileEditorWithMesh.onUseTestObjectsChanged)
         self.setPythonVariable('main_window', self)
         self.setPythonVariable('tabs', self.tab_plugin)
         self.setup()


### PR DESCRIPTION
A continuation of #9716

Toggles adding --allow-test-objects to the command line when doing a run based on whether the checkbox is checked.
Toggles adding --allow-test-objects to the command line when generating the mesh for the input tab.
