### PR TITLE
Only test NODAL FeatureFloodCount in serial

### DIFF
--- a/modules/phase_field/test/tests/MultiSmoothCircleIC/tests
+++ b/modules/phase_field/test/tests/MultiSmoothCircleIC/tests
@@ -13,6 +13,7 @@
     exodiff = 'multismoothcircleIC_normal_test_out.e'
     scale_refine = 1
     valgrind = 'HEAVY'
+    max_parallel = 1 # See #9886
   [../]
 
   [./lattice_bounds]
@@ -28,6 +29,7 @@
     exodiff = 'latticesmoothcircleIC_test_out.e'
     scale_refine = 1
     valgrind = 'HEAVY'
+    max_parallel = 1 # See #9886
   [../]
 
   [./lattice_normal_test]
@@ -36,6 +38,7 @@
     exodiff = 'latticesmoothcircleIC_normal_test_out.e'
     scale_refine = 1
     valgrind = 'HEAVY'
+    max_parallel = 1 # See #9886
   [../]
 
   [./lattice_small_invalue_test]

--- a/modules/phase_field/test/tests/boundary_intersecting_features/tests
+++ b/modules/phase_field/test/tests/boundary_intersecting_features/tests
@@ -5,6 +5,5 @@
     csvdiff = boundary_intersecting_features_out_grain_volumes_0000.csv
     # This test requires VTK because it uses the ImageFunction class
     vtk = true
-    max_parallel = 1 # See #9886
   [../]
 []

--- a/modules/phase_field/test/tests/boundary_intersecting_features/tests
+++ b/modules/phase_field/test/tests/boundary_intersecting_features/tests
@@ -5,5 +5,6 @@
     csvdiff = boundary_intersecting_features_out_grain_volumes_0000.csv
     # This test requires VTK because it uses the ImageFunction class
     vtk = true
+    max_parallel = 1 # See #9886
   [../]
 []

--- a/modules/phase_field/test/tests/flood_counter_aux_test/tests
+++ b/modules/phase_field/test/tests/flood_counter_aux_test/tests
@@ -18,8 +18,6 @@
     type = 'Exodiff'
     input = 'simple.i'
     exodiff = 'simple_out.e'
-    input = 'simple_test.i'
-    exodiff = 'simple_test_out.e'
     #max_parallel = 4                     # Only 4 elements
     max_parallel = 1 # See #9886
   [../]

--- a/modules/phase_field/test/tests/flood_counter_aux_test/tests
+++ b/modules/phase_field/test/tests/flood_counter_aux_test/tests
@@ -4,6 +4,7 @@
     input = 'flood_aux.i'
     exodiff = 'out.e'
     allow_test_objects = true
+    max_parallel = 1 # See #9886
   [../]
 
   [./test_elemental]
@@ -17,7 +18,10 @@
     type = 'Exodiff'
     input = 'simple.i'
     exodiff = 'simple_out.e'
-    max_parallel = 4                     # Only 4 elements
+    input = 'simple_test.i'
+    exodiff = 'simple_test_out.e'
+    #max_parallel = 4                     # Only 4 elements
+    max_parallel = 1 # See #9886
   [../]
 
   [./two_var]
@@ -25,5 +29,6 @@
     input = 'nodal_flood_periodic_2var.i'
     exodiff = 'out_2var.e'
     allow_test_objects = true
+    max_parallel = 1 # See #9886
   [../]
 []

--- a/modules/phase_field/test/tests/flood_counter_periodic_test/tests
+++ b/modules/phase_field/test/tests/flood_counter_periodic_test/tests
@@ -4,5 +4,6 @@
     input = 'nodal_flood_periodic.i'
     exodiff = 'out.e out.e-s005'
     allow_test_objects = true
+    max_parallel = 1 # See #9886
   [../]
 []


### PR DESCRIPTION
It's currently failing in parallel, and using the (default) ELEMENTAL
option ought to be an adequate workaround so we aren't likely to fix
NODAL any time soon.

Workaround for #9886

### Complete each of the following items before creating a PR

- Include any relevant design information for your change
- Follow [Coding Standards](http://mooseframework.org/wiki/CodeStandards/)
- Submit one or more [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/) or modify existing test cases
- Reference or close a specific issue (refs # or closes #)