### PR TITLE
Contact tests: remove the option 'compiler' in tests 

### DIFF
--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
@@ -155,9 +155,6 @@
     abs_zero = 3e-6
     max_parallel = 1
     superlu = true
-
-    # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
-    compiler = 'GCC CLANG'
     petsc_version = '>=3.7.6'
     prereq = 'mu_0_2_kin'
   [../]

--- a/modules/combined/test/tests/frictional_contact/single_point_2d/tests
+++ b/modules/combined/test/tests/frictional_contact/single_point_2d/tests
@@ -5,7 +5,6 @@
     exodiff = 'single_point_2d_out.e'
     custom_cmp = 'single_point_2d.cmp'
     superlu = true
-    compiler = 'GCC CLANG'
   [../]
   [./fcp]
     type = 'Exodiff'


### PR DESCRIPTION


Closes #8200

