### PR TITLE
Fixes the compile_commands.json recipe

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -219,10 +219,17 @@ clobberall:: clobber
 
 compile_commands_all_srcfiles := $(moose_srcfiles) $(srcfiles)
 compile_commands.json::
-	@echo $(CURDIR) > .compile_commands.json
-	@echo $(libmesh_CXX) >> .compile_commands.json
-	@echo $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES) >> .compile_commands.json
-	@echo $(compile_commands_all_srcfiles) >> .compile_commands.json
+	ifeq (4.0,$(firstword $(sort $(MAKE_VERSION) 4.0)))
+		$(file > .compile_commands.json,$(CURDIR))
+		$(file >> .compile_commands.json,$(libmesh_CXX))
+		$(file >> .compile_commands.json,$(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES))
+		$(file >> .compile_commands.json,$(compile_commands_all_srcfiles))
+	else
+		@echo $(CURDIR) > .compile_commands.json
+		@echo $(libmesh_CXX) >> .compile_commands.json
+		@echo $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES) >> .compile_commands.json
+		@echo $(compile_commands_all_srcfiles) >> .compile_commands.json
+	endif
 	@ $(FRAMEWORK_DIR)/scripts/compile_commands.py < .compile_commands.json > compile_commands.json
 	@rm .compile_commands.json
 


### PR DESCRIPTION
closes #9895

only modifies `framework/moose.mk`