### PR TITLE
Correct logic with checkRunnable

### DIFF
--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/gold/single_point_2d_out_glued_kin_sm.csv
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/gold/single_point_2d_out_glued_kin_sm.csv
@@ -1,0 +1,1 @@
+single_point_2d_out_glued_kin.csv

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
@@ -105,9 +105,10 @@
   [./glued_kin_sm]
     type = 'CSVDiff'
     input = 'single_point_2d_sm.i'
-    csvdiff = 'single_point_2d_out_glued_kin.csv'
+    csvdiff = 'single_point_2d_out_glued_kin_sm.csv'
     cli_args = 'Executioner/end_time=0.002 Executioner/l_tol=1e-3
-    Executioner/nl_rel_tol=1e-10 Executioner/nl_abs_tol=1e-12 Contact/leftright/model=glued Contact/leftright/formulation=kinematic'
+    Executioner/nl_rel_tol=1e-10 Executioner/nl_abs_tol=1e-12 Contact/leftright/model=glued Contact/leftright/formulation=kinematic
+    Outputs/file_base=single_point_2d_out_glued_kin_sm'
     rel_err = 5e-5
     abs_zero = 3e-5
     max_parallel = 1

--- a/modules/solid_mechanics/test/tests/interaction_integral/gold/interaction_integral_3d_noq_out.e
+++ b/modules/solid_mechanics/test/tests/interaction_integral/gold/interaction_integral_3d_noq_out.e
@@ -1,0 +1,1 @@
+interaction_integral_3d_out.e

--- a/modules/solid_mechanics/test/tests/interaction_integral/tests
+++ b/modules/solid_mechanics/test/tests/interaction_integral/tests
@@ -31,8 +31,8 @@
  [./ii_3d_noq]
    type = 'Exodiff'
    input = 'interaction_integral_3d.i'
-   cli_args = 'DomainIntegral/output_q=false'
-   exodiff = 'interaction_integral_3d_out.e'
+   cli_args = 'DomainIntegral/output_q=false Outputs/file_base=interaction_integral_3d_noq_out'
+   exodiff = 'interaction_integral_3d_noq_out.e'
    abs_zero = 1e-7
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    exodiff_opts = '-allow_name_mismatch'

--- a/modules/solid_mechanics/test/tests/j_integral/gold/j_integral_3d_noq_out.e
+++ b/modules/solid_mechanics/test/tests/j_integral/gold/j_integral_3d_noq_out.e
@@ -1,0 +1,1 @@
+j_integral_3d_out.e

--- a/modules/solid_mechanics/test/tests/j_integral/tests
+++ b/modules/solid_mechanics/test/tests/j_integral/tests
@@ -39,8 +39,8 @@
  [./j_3d_noq]
    type = 'Exodiff'
    input = 'j_integral_3d.i'
-   cli_args = 'DomainIntegral/output_q=false'
-   exodiff = 'j_integral_3d_out.e'
+   cli_args = 'DomainIntegral/output_q=false Outputs/file_base=j_integral_3d_noq_out'
+   exodiff = 'j_integral_3d_noq_out.e'
    exodiff_opts = '-allow_name_mismatch'
    prereq = j_3d
  [../]

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -467,7 +467,7 @@ class TestHarness:
             fatal_error += ', <r>FATAL TEST HARNESS ERROR</r>'
 
         # Alert the user to their session file
-        if self.queueing:
+        if self.options.queueing:
             print 'Your session file is %s' % self.options.session_file
 
         # Print a different footer when performing a dry run
@@ -512,10 +512,10 @@ class TestHarness:
         self.factory.loadPlugins([os.path.join(self.moose_dir, 'python', 'TestHarness')], 'schedulers', "IS_SCHEDULER")
 
         # Set a global queueing flag
-        self.queueing = False
+        self.options.queueing = False
 
         if self.options.pbs:
-            self.queueing = True
+            self.options.queueing = True
             scheduler_plugin = 'RunPBS'
 
             # Unify the queueing file

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -560,7 +560,7 @@ class Tester(MooseObject):
             reasons['display_required'] = 'NO DISPLAY'
 
         # Check for queueing
-        if not self.specs['queue_scheduler']:
+        if not self.specs['queue_scheduler'] and options.queueing:
             reasons['queue_scheduler'] = 'NO QUEUE'
 
         # Remove any matching user supplied caveats from accumulated checkRunnable caveats that


### PR DESCRIPTION
Correct the logic for tests that can not run with a third
party queueing system, being skipped all the time even when
queueing was not enabled.

Watch for the 'outputs/format.json' test being skipped. This
PR should see that test running again.

Closes #9900
