### PR TITLE
Use libMesh's point_value logic rather than re-implementing

### DIFF
--- a/framework/include/base/DisplacedProblem.h
+++ b/framework/include/base/DisplacedProblem.h
@@ -112,6 +112,8 @@ public:
   virtual bool hasScalarVariable(const std::string & var_name) override;
   virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid,
                                                   const std::string & var_name) override;
+  virtual System & getSystem(const std::string & var_name) override;
+
   virtual void addVariable(const std::string & var_name,
                            const FEType & type,
                            Real scale_factor,

--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -226,6 +226,7 @@ public:
   virtual bool hasScalarVariable(const std::string & var_name) override;
   virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid,
                                                   const std::string & var_name) override;
+  virtual System & getSystem(const std::string & var_name) override;
 
   /**
    * Set the MOOSE variables to be reinited on each element.

--- a/framework/include/base/SubProblem.h
+++ b/framework/include/base/SubProblem.h
@@ -40,6 +40,7 @@ template <typename T>
 class SparseMatrix;
 template <typename T>
 class NumericVector;
+class System;
 }
 
 template <>
@@ -77,9 +78,18 @@ public:
 
   // Variables /////
   virtual bool hasVariable(const std::string & var_name) = 0;
+
+  /// Returns the variable reference for requested variable which may be in any system
   virtual MooseVariable & getVariable(THREAD_ID tid, const std::string & var_name) = 0;
+
+  /// Returns a Boolean indicating whether any system contains a variable with the name provided
   virtual bool hasScalarVariable(const std::string & var_name) = 0;
+
+  /// Returns the scalar variable reference from whichever system contains it
   virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid, const std::string & var_name) = 0;
+
+  /// Returns the equation system containing the variable provided
+  virtual System & getSystem(const std::string & var_name) = 0;
 
   /**
    * Set the MOOSE variables to be reinited on each element.

--- a/framework/include/postprocessors/PointValue.h
+++ b/framework/include/postprocessors/PointValue.h
@@ -32,54 +32,25 @@ InputParameters validParams<PointValue>();
 class PointValue : public GeneralPostprocessor
 {
 public:
-  /**
-   * Constructor.
-   * @param parameters The input file parameters for this object
-   */
   PointValue(const InputParameters & parameters);
 
-  /**
-   * Empty method, no initialization needed
-   */
   virtual void initialize() override {}
-
-  /**
-   * Determines what element contains the specified point
-   */
   virtual void execute() override;
-
-  /**
-   * Returns the value of the variable at the specified location
-   */
+  virtual void finalize() override {}
   virtual Real getValue() override;
 
-  /**
-   * Performs the necessary parallel communication as well as computes
-   * the value to return in the getValue method.
-   */
-  virtual void finalize() override;
-
 protected:
-  /// The variable from which a values is to be extracted
-  MooseVariable & _var;
+  /// The variable number of the variable we are operating on
+  const unsigned int _var_number;
 
-  /// The value of the desired variable
-  const VariableValue & _u;
+  /// A reference to the system containing the variable
+  const System & _system;
 
-  /// A convenience reference to the Mesh this object operates on
-  MooseMesh & _mesh;
-
-  /// The point to locate, stored as a vector for use with reinitElemPhys
-  std::vector<Point> _point_vec;
+  /// The point to locate
+  const Point & _point;
 
   /// The value of the variable at the desired location
   Real _value;
-
-  /// The processor id that owns the element that the point is located
-  processor_id_type _root_id;
-
-  /// The element that contains the located point
-  dof_id_type _elem_id;
 };
 
 #endif /* POINTVALUE_H */

--- a/framework/src/base/DisplacedProblem.C
+++ b/framework/src/base/DisplacedProblem.C
@@ -285,6 +285,17 @@ DisplacedProblem::getScalarVariable(THREAD_ID tid, const std::string & var_name)
     mooseError("No variable with name '" + var_name + "'");
 }
 
+System &
+DisplacedProblem::getSystem(const std::string & var_name)
+{
+  if (_displaced_nl.hasVariable(var_name))
+    return _displaced_nl.system();
+  else if (_displaced_aux.hasVariable(var_name))
+    return _displaced_aux.system();
+  else
+    mooseError("Unable to find a system containing the variable " + var_name);
+}
+
 void
 DisplacedProblem::addVariable(const std::string & var_name,
                               const FEType & type,

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -3452,6 +3452,17 @@ FEProblemBase::getScalarVariable(THREAD_ID tid, const std::string & var_name)
     mooseError("Unknown variable " + var_name);
 }
 
+System &
+FEProblemBase::getSystem(const std::string & var_name)
+{
+  if (_nl->hasVariable(var_name))
+    return _nl->system();
+  else if (_aux->hasVariable(var_name))
+    return _aux->system();
+  else
+    mooseError("Unable to find a system containing the variable " + var_name);
+}
+
 void
 FEProblemBase::setActiveElementalMooseVariables(const std::set<MooseVariable *> & moose_vars,
                                                 THREAD_ID tid)


### PR DESCRIPTION
- Adds a new `getSystem()` call to SubProblem and derived classes. We don't have any good
way of obtaining a reference to the system through our problem classes. You can retrieve
systems by name, but in objects that can work on multiple systems, this leads to a lot of 
extra code to figure out the correct system. This new method simplifies this process.

- Added a few doco strings while I was in SubProblem

- Consolidated PointValue Postprocessor logic to use libMesh's implementation

closes #8655
