### PR TITLE
Initialize Tester variable before using it.

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -80,6 +80,7 @@ class Tester(MooseObject):
         self.outfile = None
         self.std_out = ''
         self.exit_code = 0
+        self.process = None
 
         # Bool if test can run
         self._runnable = None
@@ -324,6 +325,7 @@ class Tester(MooseObject):
         cmd = self.getCommand(options)
         cwd = self.getTestDir()
 
+        self.process = None
         try:
             f = TemporaryFile()
             # On Windows, there is an issue with path translation when the command is passed in


### PR DESCRIPTION
Saw an error pop up when looking at https://www.moosebuild.org/job/119008/ 
It was running `Tester.killCommand()` but `self.process` wasn't there.
This just initializes `self.process` in the constructor and also clears it before launching a new process.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
