### PR TITLE
Remove RunParallel.py symbolic link.

### DIFF
--- a/python/TestHarness/RunParallel.py
+++ b/python/TestHarness/RunParallel.py
@@ -1,1 +1,0 @@
-schedulers/RunParallel.py


### PR DESCRIPTION
This link was needed when we were using path_tool.py and people had a
stale TestHarness/RunParallel.pyc file lying around that might
conflict with TestHarness/schedulers/RunParallel.py.
Since we no longer use path_tool.py this can now be removed.

refs #9335

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
