### PR TITLE
parser: fix unused parameter error checking

### DIFF
--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -1295,6 +1295,8 @@ public:
    */
   void reportMooseObjectDependency(MooseObject * a, MooseObject * b);
 
+  ExecuteMooseObjectWarehouse<MultiApp> & getMultiAppWarehouse() { return _multi_apps; }
+
 protected:
   ///@{
   /**

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -662,6 +662,10 @@ private:
    */
   void createMinimalApp();
 
+  /// Runs post-initialization error checking that cannot be run correctly unless the simulation
+  /// has been fully set up and initialized.
+  void errorCheck();
+
   /// Where the restartable data is held (indexed on tid)
   RestartableDatas _restartable_data;
 

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -189,7 +189,7 @@ public:
   /**
    * @return Number of Apps on local processor.
    */
-  unsigned int numLocalApps() { return _my_num_apps; }
+  unsigned int numLocalApps() { return _apps.size(); }
 
   /**
    * @return The global number of the first app on the local processor.

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -136,7 +136,7 @@ private:
 };
 
 std::vector<std::string>
-findSimilar(std::string param, std::vector<std::string> options, int dist_cutoff = 3)
+findSimilar(std::string param, std::vector<std::string> options)
 {
   std::vector<std::string> candidates;
   if (options.size() == 0)
@@ -146,6 +146,8 @@ findSimilar(std::string param, std::vector<std::string> options, int dist_cutoff
   for (auto & opt : options)
   {
     int dist = MooseUtils::levenshteinDist(opt, param);
+    // magic number heuristics to get similarity distance cutoff
+    int dist_cutoff = 1 + param.size() / 5;
     if (dist > dist_cutoff || dist > mindist)
       continue;
 

--- a/test/tests/multiapps/check_error/sub_unused.i
+++ b/test/tests/multiapps/check_error/sub_unused.i
@@ -1,0 +1,53 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+  foo = bar
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Transient
+  num_steps = 20
+  dt = 0.1
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/multiapps/check_error/tests
+++ b/test/tests/multiapps/check_error/tests
@@ -5,6 +5,13 @@
     expect_err = 'The following required'
   [../]
 
+  [./unused_subapp_param]
+    type = 'RunException'
+    input = 'check_error.i'
+    cli_args = 'MultiApps/multi/input_files="sub_unused.i"'
+    expect_err = 'unused parameter'
+  [../]
+
   [./positions]
     type = 'RunException'
     input = 'check_error.i'


### PR DESCRIPTION
Partially address #9928. Three mods:

* Because some parameter usage occurs really late, we can't check for
unused parameter errors until after executioner initialization/setup.
To make sure this always happens, the MooseApp::executeExecutioner was
responsible for firing off the unused check.  But for multiapps, this is
never called.  We can't put the check other places because none of the
multiapps can do the error checking until all of the multiapps have been
initialized otherwise the multiapps will think cli parameters for other
subapps are unused when they really just haven't been initialized yet.
This change makes unused param checking cascade down the (sub)app tree
after everything has been initialized.

* Do unused parameter checking for --check-input runs - this will have
false posities since some parameters don't get used until during
simulation init/setup.

* The did-you-mean functionality for misspelled params has been
improved to have smarter levenshtein distance cutoffs so you don't get
"did you mean 'n'?" for typing "foo" as your parameter.
