### PR TITLE
Remove y data monotone checking for MonotoneCubicInterpolation

### DIFF
--- a/framework/include/utils/MonotoneCubicInterpolation.h
+++ b/framework/include/utils/MonotoneCubicInterpolation.h
@@ -91,15 +91,6 @@ protected:
   // Error check routines run during initialization
   virtual void errorCheck();
   Real sign(const Real & x) const;
-  enum MonotonicStatus
-  {
-    monotonic_increase,
-    monotonic_decrease,
-    monotonic_constant,
-    monotonic_not
-  };
-  MonotonicStatus _monotonic_status;
-  void checkMonotone();
 
   // Building blocks of Hermite polynomials
   Real phi(const Real & t) const;

--- a/framework/include/utils/MonotoneCubicInterpolation.h
+++ b/framework/include/utils/MonotoneCubicInterpolation.h
@@ -163,6 +163,7 @@ protected:
 
   unsigned int _n_knots;
   unsigned int _n_intervals;
+  unsigned int _internal_knots;
 };
 
 #endif

--- a/framework/src/utils/MonotoneCubicInterpolation.C
+++ b/framework/src/utils/MonotoneCubicInterpolation.C
@@ -53,11 +53,6 @@ MonotoneCubicInterpolation::errorCheck()
 
   if (error)
     throw std::domain_error("x-values are not strictly increasing");
-
-  // checkMonotone();
-  // if (_monotonic_status == monotonic_not)
-  //   throw std::domain_error("Don't ask for a monotonic interpolation routine if your dependent "
-  //                           "variable data isn't monotonic.");
 }
 
 Real
@@ -69,30 +64,6 @@ MonotoneCubicInterpolation::sign(const Real & x) const
     return 1;
   else
     return 0;
-}
-
-void
-MonotoneCubicInterpolation::checkMonotone()
-{
-  Real y_diff = _y[1] - _y[0];
-  Real s = sign(y_diff);
-  for (unsigned int i = 1; i < _y.size() - 1; ++i)
-  {
-    y_diff = _y[i + 1] - _y[i];
-    if (s == 0)
-      s = sign(y_diff);
-    if (s * y_diff < 0)
-    {
-      _monotonic_status = monotonic_not;
-      return;
-    }
-  }
-  if (s > 0)
-    _monotonic_status = monotonic_increase;
-  else if (s < 0)
-    _monotonic_status = monotonic_decrease;
-  else
-    _monotonic_status = monotonic_constant;
 }
 
 Real

--- a/framework/src/utils/MonotoneCubicInterpolation.C
+++ b/framework/src/utils/MonotoneCubicInterpolation.C
@@ -54,10 +54,10 @@ MonotoneCubicInterpolation::errorCheck()
   if (error)
     throw std::domain_error("x-values are not strictly increasing");
 
-  checkMonotone();
-  if (_monotonic_status == monotonic_not)
-    throw std::domain_error("Don't ask for a monotonic interpolation routine if your dependent "
-                            "variable data isn't monotonic.");
+  // checkMonotone();
+  // if (_monotonic_status == monotonic_not)
+  //   throw std::domain_error("Don't ask for a monotonic interpolation routine if your dependent "
+  //                           "variable data isn't monotonic.");
 }
 
 Real
@@ -310,7 +310,7 @@ MonotoneCubicInterpolation::modify_derivs(
 void
 MonotoneCubicInterpolation::solve()
 {
-  _n_knots = _x.size(), _n_intervals = _x.size() - 1;
+  _n_knots = _x.size(), _n_intervals = _x.size() - 1, _internal_knots = _x.size() - 2;
   _h.resize(_n_intervals);
   _yp.resize(_n_knots);
   _delta.resize(_n_intervals);
@@ -327,20 +327,23 @@ MonotoneCubicInterpolation::solve()
     _yp[0] = 0;
   if (sign(_delta[_n_intervals - 1]) != sign(_yp[_n_knots - 1]))
     _yp[_n_knots - 1] = 0;
+  for (unsigned int i = 0; i < _internal_knots; ++i)
+    if (sign(_delta[i + 1]) == 0 || sign(_delta[i]) == 0 || sign(_delta[i + 1]) != sign(_delta[i]))
+      _yp[1 + i] = 0;
 
   for (unsigned int i = 0; i < _n_intervals; ++i)
   {
     // Test for zero slope
-    if (_yp[i] == 0 && _delta[i] == 0)
-      _alpha[i] = 1;
+    if (_yp[i] == 0)
+      _alpha[i] = 0;
     else if (_delta[i] == 0)
       _alpha[i] = 4;
     else
       _alpha[i] = _yp[i] / _delta[i];
 
     // Test for zero slope
-    if (_yp[i + 1] == 0 && _delta[i] == 0)
-      _beta[i] = 1;
+    if (_yp[i + 1] == 0)
+      _beta[i] = 0;
     else if (_delta[i] == 0)
       _beta[i] = 4;
     else

--- a/unit/src/MonotoneCubicInterpolationTest.C
+++ b/unit/src/MonotoneCubicInterpolationTest.C
@@ -25,44 +25,44 @@ TEST(MonotoneCubicInterpolationTest, fitQuadraticFunction)
   std::vector<double> x(6);
   std::vector<double> y(6);
 
-  x[0] = 0.;
-  y[0] = 0.;
-  x[1] = 2.;
-  y[1] = 4.;
-  x[2] = 4.;
-  y[2] = 16.;
-  x[3] = 6.;
-  y[3] = 36.;
-  x[4] = 8.;
-  y[4] = 64.;
-  x[5] = 10.;
-  y[5] = 100.;
+  x[0] = 0;
+  y[0] = 5;
+  x[1] = 2;
+  y[1] = 1;
+  x[2] = 4;
+  y[2] = 5;
+  x[3] = 6;
+  y[3] = 17;
+  x[4] = 8;
+  y[4] = 37;
+  x[5] = 10;
+  y[5] = 65;
 
   MonotoneCubicInterpolation interp(x, y);
 
-  EXPECT_NEAR(interp.sample(0.), 0., tol);
-  EXPECT_NEAR(interp.sample(1.), 1., tol);
-  EXPECT_NEAR(interp.sample(2.), 4., tol);
-  EXPECT_NEAR(interp.sample(3.), 9., tol);
-  EXPECT_NEAR(interp.sample(4.), 16., tol);
-  EXPECT_NEAR(interp.sample(5.), 25., tol);
-  EXPECT_NEAR(interp.sample(6.), 36., tol);
-  EXPECT_NEAR(interp.sample(7.), 49., tol);
-  EXPECT_NEAR(interp.sample(8.), 64., tol);
-  EXPECT_NEAR(interp.sample(9.), 81., tol);
-  EXPECT_NEAR(interp.sample(10.), 100., tol);
+  EXPECT_NEAR(interp.sample(0.), 5., tol);
+  EXPECT_NEAR(interp.sample(1.), 2., tol);
+  EXPECT_NEAR(interp.sample(2.), 1., tol);
+  EXPECT_NEAR(interp.sample(3.), 2., tol);
+  EXPECT_NEAR(interp.sample(4.), 5., tol);
+  EXPECT_NEAR(interp.sample(5.), 10., tol);
+  EXPECT_NEAR(interp.sample(6.), 17., tol);
+  EXPECT_NEAR(interp.sample(7.), 26., tol);
+  EXPECT_NEAR(interp.sample(8.), 37., tol);
+  EXPECT_NEAR(interp.sample(9.), 50., tol);
+  EXPECT_NEAR(interp.sample(10.), 65., tol);
 
-  EXPECT_NEAR(interp.sampleDerivative(0.), 0., tol);
-  EXPECT_NEAR(interp.sampleDerivative(1.), 2., tol);
-  EXPECT_NEAR(interp.sampleDerivative(2.), 4., tol);
-  EXPECT_NEAR(interp.sampleDerivative(3.), 6., tol);
-  EXPECT_NEAR(interp.sampleDerivative(4.), 8., tol);
-  EXPECT_NEAR(interp.sampleDerivative(5.), 10., tol);
-  EXPECT_NEAR(interp.sampleDerivative(6.), 12., tol);
-  EXPECT_NEAR(interp.sampleDerivative(7.), 14., tol);
-  EXPECT_NEAR(interp.sampleDerivative(8.), 16., tol);
-  EXPECT_NEAR(interp.sampleDerivative(9.), 18., tol);
-  EXPECT_NEAR(interp.sampleDerivative(10.), 20., tol);
+  EXPECT_NEAR(interp.sampleDerivative(0.), -4., tol);
+  EXPECT_NEAR(interp.sampleDerivative(1.), -2., tol);
+  EXPECT_NEAR(interp.sampleDerivative(2.), 0., tol);
+  EXPECT_NEAR(interp.sampleDerivative(3.), 2., tol);
+  EXPECT_NEAR(interp.sampleDerivative(4.), 4., tol);
+  EXPECT_NEAR(interp.sampleDerivative(5.), 6., tol);
+  EXPECT_NEAR(interp.sampleDerivative(6.), 8., tol);
+  EXPECT_NEAR(interp.sampleDerivative(7.), 10., tol);
+  EXPECT_NEAR(interp.sampleDerivative(8.), 12., tol);
+  EXPECT_NEAR(interp.sampleDerivative(9.), 14., tol);
+  EXPECT_NEAR(interp.sampleDerivative(10.), 16., tol);
 
   EXPECT_NEAR(interp.sample2ndDerivative(0.), 2., tol);
   EXPECT_NEAR(interp.sample2ndDerivative(1.), 2., tol);
@@ -121,6 +121,53 @@ TEST(MonotoneCubicInterpolationTest, fitAkimaDataSet)
 
   for (double z = 0; z <= 15.; z += .1)
     EXPECT_GE(interp.sampleDerivative(z), -tol);
+}
+
+TEST(MonotoneCubicInterpolationTest, monotoneIntervals)
+{
+  std::vector<double> x(11);
+  std::vector<double> y(11);
+
+  x[0] = 0;
+  y[0] = 5;
+  x[1] = 2;
+  y[1] = 1;
+  x[2] = 4;
+  y[2] = 5;
+  x[3] = 6;
+  y[3] = 17;
+  x[4] = 8;
+  y[4] = 37;
+  x[5] = 10;
+  y[5] = 65;
+  x[6] = 12;
+  y[6] = 65;
+  x[7] = 14;
+  y[7] = 65;
+  x[8] = 16;
+  y[8] = 100;
+  x[9] = 20;
+  y[9] = 80;
+  x[10] = 23;
+  y[10] = 110;
+
+  MonotoneCubicInterpolation interp(x, y);
+
+  for (double z = 0; z < 2.; z += .1)
+    EXPECT_LT(interp.sampleDerivative(z), 0);
+  EXPECT_NEAR(interp.sampleDerivative(2.), 0, tol);
+  for (double z = 2.1; z < 10; z += .1)
+    EXPECT_GT(interp.sampleDerivative(z), 0);
+  for (double z = 10.; z <= 14.; z += .1)
+    EXPECT_NEAR(interp.sampleDerivative(z), 0, tol);
+  for (double z = 14.1; z < 16.; z += .1)
+    EXPECT_GT(interp.sampleDerivative(z), 0);
+  EXPECT_NEAR(interp.sampleDerivative(16.), 0, tol);
+  for (double z = 16.1; z < 20.; z += .1)
+    EXPECT_LT(interp.sampleDerivative(z), 0);
+  EXPECT_NEAR(interp.sampleDerivative(20), 0, tol);
+  for (double z = 20.1; z <= 23; z += .1)
+    EXPECT_GT(interp.sampleDerivative(z), 0);
 }
 
 TEST(MonotoneCubicInterpolationTest, getSampleSize)


### PR DESCRIPTION
This PR modifies the `MonotoneCubicInterpolation` class to ensure monotonicity on intervals as opposed to monotonicity over the entire range. So this functionality is a superset of the original functionality, e.g. if your data is monotone over the whole range, you can still be sure that your interpolant is also monotone over the whole range. Two unit tests have been added/modified for this new functionality:

- `fitQuadraticFunction`: The input data follows the curve (x - 2)^2 + 1 on the domain 0 <= x <= 10. Consequently there are both increasing and decreasing ranges which the interpolant captures. This test also demonstrates the interpolants ability to perfectly reconstruct a second-order polynomial which the `pchip` routines in SciPy and MatLab (tested through Octave) cannot
- `monotoneIntervals`: This is a rigorous test that ensures the interpolant's slope is zero at any knot where the secant lines have different slopes on either side or either secant line has zero slope. Moreover, the monotonicity in each interval is ensured.

Some plots of the latter test:

### Whole domain (y)
![image](https://user-images.githubusercontent.com/10248304/30926148-7385c0ac-a371-11e7-802f-1597fb956ebc.png)

### Around x = 16 (y')
![image](https://user-images.githubusercontent.com/10248304/30926201-98fe333c-a371-11e7-94bd-e8885fe94b8e.png)

### Around x = 16 (y)
![image](https://user-images.githubusercontent.com/10248304/30926239-b4869d38-a371-11e7-9d47-80c4b65812ef.png)

### Around x = 20 (y')
![image](https://user-images.githubusercontent.com/10248304/30926245-bbd70b90-a371-11e7-8ba2-a601df93c95d.png)

### Around x = 20 (y)
![image](https://user-images.githubusercontent.com/10248304/30926249-c1476606-a371-11e7-9f2b-8baf87744352.png)

Closes #8970 