### PR TITLE
Update links to Phase_Field_Equations.md

### DIFF
--- a/docs/content/documentation/modules/phase_field/Multi Phase/KKS Derivations.md
+++ b/docs/content/documentation/modules/phase_field/Multi Phase/KKS Derivations.md
@@ -29,7 +29,7 @@ in material properties and follow a naming scheme that is defined in `KKSBaseMat
 $\mu$ from $\frac{\partial F}{\partial c}$. The non-linear variable for this Kernel
 is the concentration $c$. To calculate $\frac{\partial c}{\partial t}$ and
 $\nabla \cdot M(c) \nabla \mu$, we use the [`CoupledTimeDerivative`](framework/CoupledTimeDerivative.md) and
-[`SplitCHWRes`](phase_field/SplitCHWRes.md) kernels, respectively, as described [here](phase_field/Phase Field Equations.md).
+[`SplitCHWRes`](phase_field/SplitCHWRes.md) kernels, respectively, as described [here](phase_field/Phase_Field_Equations.md).
 
 ## Residual
 

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSSplitCHCRes.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSSplitCHCRes.md
@@ -5,7 +5,7 @@
 $\mu$ from $\frac{\partial F}{\partial c}$. The non-linear variable for this Kernel
 is the concentration $c$. To calculate $\frac{\partial c}{\partial t}$ and
 $\nabla \cdot M(c) \nabla \mu$, we use the [`CoupledTimeDerivative`](framework/CoupledTimeDerivative.md) and
-[`SplitCHWRes`](phase_field/SplitCHWRes.md) kernels, respectively, as described [here](phase_field/Phase Field Equations.md).
+[`SplitCHWRes`](phase_field/SplitCHWRes.md) kernels, respectively, as described [here](phase_field/Phase_Field_Equations.md).
 
 ## Residual
 


### PR DESCRIPTION
### Design information
Correct an incomplete updating of the referenced file name from `Phase Field Equations.md` to `Phase_Field_Equations.md` from #9797 to allow the BISON documentation system to build successfully.

This is a documentation system change only; no tests are modified.

@aeslaughter and @lindsayad would one of you review and merge this please?

Refs #9638