### PR TITLE
Make sure we have an input file before trying to return it.

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -56,7 +56,10 @@ class RunApp(Tester):
             raise Exception('Either "input" or "command" must be supplied for a RunApp test')
 
     def getInputFile(self):
-        return self.specs['input'].strip()
+        if self.specs.isValid('input'):
+            return self.specs['input'].strip()
+        else:
+            return None # Not all testers that inherit from RunApp have an input file
 
     def checkRunnable(self, options):
         if options.enable_recover:


### PR DESCRIPTION
Grizzly has a tester that inherits from CSVDiff (which inherits from RunApp ) and hides the "input" param since it doesn't use
an input file. Calling `RunApp.getInputFile()` then throws an exception.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
