### PR TITLE
Fully coupling matrix is set as default if a pure Newton is chosen

### DIFF
--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -3670,6 +3670,10 @@ FEProblemBase::init()
 {
   if (_initialized)
     return;
+  // Use full coupling if Newton method is used, otherwise
+  // Newton may diverge for many applications
+  if (solverParams()._type == Moose::ST_NEWTON && _coupling != Moose::COUPLING_CUSTOM)
+    _coupling = Moose::COUPLING_FULL;
 
   unsigned int n_vars = _nl->nVariables();
   switch (_coupling)


### PR DESCRIPTION
Looks like users usually forget to use a full coupling matrix
when they are trying to use pure Newton.
Newton depends on the accuracy of Jacobian.
If some entires are ignored automatically, a bad convergence may occur.

Closes #9968
