### PR TITLE
Added interface for dp/ds from (h,s) in single-phase fluid properties

### DIFF
--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -65,6 +65,7 @@ public:
 
   virtual Real p_from_h_s(Real h, Real s) const override;
   virtual Real dpdh_from_h_s(Real h, Real s) const override;
+  virtual Real dpds_from_h_s(Real h, Real s) const override;
 
   virtual Real g(Real v, Real e) const override;
 

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -80,6 +80,8 @@ public:
   virtual Real p_from_h_s(Real h, Real s) const = 0;
   /// Derivative of pressure wrt specific enthalpy
   virtual Real dpdh_from_h_s(Real h, Real s) const = 0;
+  /// Derivative of pressure wrt specific entropy
+  virtual Real dpds_from_h_s(Real h, Real s) const = 0;
 
   /// Gibbs free energy
   virtual Real g(Real v, Real e) const = 0;

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -65,6 +65,7 @@ public:
 
   virtual Real p_from_h_s(Real h, Real s) const override;
   virtual Real dpdh_from_h_s(Real h, Real s) const override;
+  virtual Real dpds_from_h_s(Real h, Real s) const override;
 
   virtual Real g(Real v, Real e) const override;
 

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -185,6 +185,12 @@ Real IdealGasFluidProperties::dpdh_from_h_s(Real /*h*/, Real /*s*/) const
   return 0.0;
 }
 
+Real IdealGasFluidProperties::dpds_from_h_s(Real /*h*/, Real /*s*/) const
+{
+  mooseError(name(), ": dpds_from_h_s() not implemented.");
+  return 0;
+}
+
 Real
 IdealGasFluidProperties::g(Real v, Real e) const
 {

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -236,6 +236,13 @@ StiffenedGasFluidProperties::dpdh_from_h_s(Real h, Real s) const
 }
 
 Real
+StiffenedGasFluidProperties::dpds_from_h_s(Real h, Real s) const
+{
+  return std::pow((h - _q) / (_gamma * _cv), _gamma / (_gamma - 1)) *
+         std::exp((_q_prime - s) / ((_gamma - 1) * _cv)) / ((1 - _gamma) * _cv);
+}
+
+Real
 StiffenedGasFluidProperties::g(Real v, Real e) const
 {
   // g(p,T) for SGEOS is given by Equation (37) in the following reference:

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -88,19 +88,26 @@ TEST_F(StiffenedGasFluidPropertiesTest, testAll)
     ABS_TEST("dh_dT", dh_dT, dh_dT_fd, 2e-6);
   }
 
-  // dp/dh for p(h,s)
+  // dp/dh and dp/ds for p(h,s)
   {
     Real h = 400.0;
     Real s = 1.0;
 
     Real dh = 1e-2 * h;
+    Real ds = 1e-2 * s;
 
     Real dp_dh = _fp->dpdh_from_h_s(h, s);
-    Real p_forward = _fp->p_from_h_s(h + dh, s);
-    Real p_backward = _fp->p_from_h_s(h - dh, s);
-    Real dp_dh_fd = (p_forward - p_backward) / (2 * dh);
+    Real dp_ds = _fp->dpds_from_h_s(h, s);
 
-    REL_TEST("dp_dh", dp_dh, dp_dh_fd, 6e-8);
+    Real p_h_forward = _fp->p_from_h_s(h + dh, s);
+    Real p_s_forward = _fp->p_from_h_s(h, s + ds);
+    Real p_h_backward = _fp->p_from_h_s(h - dh, s);
+    Real p_s_backward = _fp->p_from_h_s(h, s - ds);
+    Real dp_dh_fd = (p_h_forward - p_h_backward) / (2 * dh);
+    Real dp_ds_fd = (p_s_forward - p_s_backward) / (2 * ds);
+
+    REL_TEST("dp_dh", dp_dh, dp_dh_fd, 1e-6);
+    REL_TEST("dp_ds", dp_ds, dp_ds_fd, 1e-6);
   }
 
   // drho/dp, drho/ds, de/dp, and de/ds for rho(p,s) and e(p,s)


### PR DESCRIPTION
Closes #9984

This adds a required interface for the derivative of pressure with respect to specific entropy, as described in Issue #9984.
