### PR TITLE
Add remove block option to right click on Input tab.

### DIFF
--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -103,14 +103,6 @@ class BlockEditor(QWidget, MooseWidget):
         """
         self.button_layout = WidgetUtils.addLayout()
 
-        if self.block.user_added:
-            self.clone_button = WidgetUtils.addButton(self.button_layout, self, "Clone Block", self._cloneBlock)
-            self.clone_shortcut = WidgetUtils.addShortcut(self, "Ctrl+N", self._cloneBlock, shortcut_with_children=True)
-            self.clone_button.setToolTip("Clone this block with the same parameters")
-
-            self.remove_button = WidgetUtils.addButton(self.button_layout, self, "Remove Block", self._removeBlock)
-            self.remove_button.setToolTip("Remove this block")
-
         self.close_button = WidgetUtils.addButton(self.button_layout, self, "Apply && Close", self._applyAndClose)
         self.close_button.setToolTip("Apply any changes and close the window")
 
@@ -125,6 +117,13 @@ class BlockEditor(QWidget, MooseWidget):
         self.new_parameter_button = WidgetUtils.addButton(self.button_layout, self, "Add parameter", self.addUserParamPressed)
         self.new_parameter_button.setToolTip("Add a non standard parameter")
 
+        if self.block.user_added:
+            self.clone_button = WidgetUtils.addButton(self.button_layout, self, "Clone Block", self._cloneBlock)
+            self.clone_shortcut = WidgetUtils.addShortcut(self, "Ctrl+N", self._cloneBlock, shortcut_with_children=True)
+            self.clone_button.setToolTip("Clone this block with the same parameters")
+
+            self.remove_button = WidgetUtils.addButton(self.button_layout, self, "Remove Block", self._removeBlock)
+            self.remove_button.setToolTip("Remove this block")
 
     def _findFreeParamName(self, max_params=1000):
         """

--- a/python/peacock/tests/input_tab/BlockTree/test_BlockTree.py
+++ b/python/peacock/tests/input_tab/BlockTree/test_BlockTree.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from PyQt5.QtCore import Qt, QMimeData
-from PyQt5.QtWidgets import QMenu, QApplication
+from PyQt5.QtWidgets import QMenu, QApplication, QMessageBox
 from PyQt5.QtGui import QDragEnterEvent, QDropEvent
 from peacock.Input.ExecutableInfo import ExecutableInfo
 from peacock.Input.InputTree import InputTree
@@ -156,15 +156,36 @@ class Tests(Testing.PeacockTester):
         b1 = w.tree.getBlockInfo("/Variables/foo")
         self.assertEqual(b1, b)
 
-    def testRemove(self):
+    @patch.object(QMenu, "exec_")
+    @patch.object(QMessageBox, "question")
+    def testRemove(self, mock_question, mock_exec):
         w = self.newWidget()
         b = w.tree.getBlockInfo("/Variables/u")
         parent = b.parent
+        self.assertEqual(len(parent.children_list), 2)
         w.removeBlock(b)
         self.assertEqual(b.parent, None)
         self.assertNotIn(b.name, parent.children_list)
         item = w._path_item_map.get("/Variables/u")
         self.assertEqual(item, None)
+        self.assertEqual(len(parent.children_list), 1)
+
+        b = w.tree.getBlockInfo("/Variables/v")
+        mock_exec.return_value = w.remove_action
+        mock_question.return_value = QMessageBox.No
+        item = w._path_item_map.get(b.path)
+        self.assertNotEqual(item, None)
+        w.scrollToItem(item)
+        point = w.visualItemRect(item).center()
+        w._treeContextMenu(point)
+        self.assertEqual(len(parent.children_list), 1)
+
+        mock_question.return_value = QMessageBox.Yes
+        w._treeContextMenu(point)
+        self.assertEqual(len(parent.children_list), 0)
+        item = w._path_item_map.get("/Variables/v")
+        self.assertEqual(item, None)
+
 
     @patch.object(QMenu, "exec_")
     def testCopy(self, mock_exec):
@@ -183,7 +204,8 @@ class Tests(Testing.PeacockTester):
         item = w._path_item_map.get("/Variables/New_0/InitialCondition")
         self.assertNotEqual(item, None)
 
-        mock_exec.return_value = 0
+        # simulate them not choosing any of the menu options
+        mock_exec.return_value = None
         nchilds = len(v.children_list)
         item = w._path_item_map.get(b.path)
         w.scrollToItem(item)
@@ -193,9 +215,10 @@ class Tests(Testing.PeacockTester):
         self.assertEqual(nchilds, len(v.children_list))
         self.assertEqual(self.changed_count, 1)
 
-        mock_exec.return_value = 1
+        mock_exec.return_value = w.add_action
         w._treeContextMenu(point)
 
+        # simulate choosing the add menu option
         self.assertEqual(nchilds+1, len(v.children_list))
         self.assertEqual(self.changed_count, 2)
 
@@ -212,7 +235,7 @@ class Tests(Testing.PeacockTester):
         item = w._path_item_map.get("%s/InitialCondition" % p)
         self.assertNotEqual(item, None)
 
-        mock_exec.return_value = 0
+        mock_exec.return_value = None
         nchilds = len(v.children_list)
         item = w._path_item_map.get(v.path)
         w.scrollToItem(item)
@@ -222,7 +245,7 @@ class Tests(Testing.PeacockTester):
         self.assertEqual(nchilds, len(v.children_list))
         self.assertEqual(self.changed_count, 3)
 
-        mock_exec.return_value = 1
+        mock_exec.return_value = w.add_action
         w._treeContextMenu(point)
 
         self.assertEqual(nchilds+1, len(v.children_list))


### PR DESCRIPTION
Add/clone was already an existing right click option, so I just had to add "remove".

Also reorganize buttons on the parameter editor so
that "Apply & Close" is always in the left bottom of the window.

I left the "Remove Block" and "Clone Block" buttons on the parameter editor because I have found them useful. Also, if I removed them I know the next peacock issue would be "Why do I have to close the parameter editor then right click on a name to remove/clone a block?".

closes #9975
closes #9973

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
