### PR TITLE
standard finite difference preconditioner

### DIFF
--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -73,6 +73,26 @@ public:
 
 protected:
   TransientNonlinearImplicitSystem & _transient_sys;
+
+private:
+  /**
+  * Form preconditioning matrix via a standard finite difference method
+  * column-by-column. This method computes both diagonal and off-diagonal
+  * entrices regardless of the structure pattern of the Jacobian matrix.
+  */
+  void setupStandardFiniteDifferencedPreconditioner();
+
+  /**
+  * According to the nonzero pattern provided in the matrix, a graph is constructed.
+  * A coloring algorithm is applied to the graph. The graph is partitioned into several
+  * independent subgraphs (colors), and a finte difference method is applied color-by-color
+  * to form a preconditioning matrix. If the number of colors is small, this method is much
+  * faster than the standard FD. But there is an issue. If the matrix provided by users does not
+  * represent the actual structure of the true Jacobian, the matrix computed via coloring could
+  * be wrong or inaccurate. In this case, users should switch to the standard finite difference
+  * method.
+  */
+  void setupColoringFiniteDifferencedPreconditioner();
 };
 
 #endif /* NONLINEARSYSTEM_H */

--- a/framework/include/preconditioners/FiniteDifferencePreconditioner.h
+++ b/framework/include/preconditioners/FiniteDifferencePreconditioner.h
@@ -16,6 +16,7 @@
 #define FINITEDIFFERENCEPRECONDITIONER_H
 
 #include "MoosePreconditioner.h"
+#include "MooseEnum.h"
 
 class FiniteDifferencePreconditioner;
 
@@ -29,6 +30,10 @@ class FiniteDifferencePreconditioner : public MoosePreconditioner
 {
 public:
   FiniteDifferencePreconditioner(const InputParameters & params);
+  MooseEnum & finiteDifferenceType() { return _finite_difference_type; }
+
+private:
+  MooseEnum _finite_difference_type;
 };
 
 #endif /* FINITEDIFFERENCEPRECONDITIONER_H */

--- a/test/tests/preconditioners/fdp/tests
+++ b/test/tests/preconditioners/fdp/tests
@@ -4,13 +4,13 @@
     input = 'fdp_test.i'
     exodiff = 'out.e'
     max_parallel = 1
-    deleted = '#5153'
   [../]
   [./test_standard]
     type = 'Exodiff'
     input = 'fdp_test.i'
     exodiff = 'out.e'
     max_parallel = 1
+    prereq = 'test'
     cli_args = "Preconditioning/FDP/finite_difference_type='standard'"
   [../]
 []

--- a/test/tests/preconditioners/fdp/tests
+++ b/test/tests/preconditioners/fdp/tests
@@ -6,4 +6,11 @@
     max_parallel = 1
     deleted = '#5153'
   [../]
+  [./test_standard]
+    type = 'Exodiff'
+    input = 'fdp_test.i'
+    exodiff = 'out.e'
+    max_parallel = 1
+    cli_args = "Preconditioning/FDP/finite_difference_type='standard'"
+  [../]
 []

--- a/test/tests/preconditioners/pbp/pbp_test.i
+++ b/test/tests/preconditioners/pbp/pbp_test.i
@@ -86,8 +86,8 @@
 [Executioner]
   type = Steady
 
-  l_max_its = 1
-  nl_max_its = 1
+  l_max_its = 10
+  nl_max_its = 10
 
   solve_type = JFNK
 []

--- a/test/tests/preconditioners/pbp/tests
+++ b/test/tests/preconditioners/pbp/tests
@@ -4,7 +4,6 @@
     input = 'pbp_test.i'
     exodiff = 'out.e'
     max_parallel = 1
-    deleted = '#5153'
   [../]
 
   [./pbp_adapt_test]


### PR DESCRIPTION
Added a `standard` finite difference preconditioner.  There are two finite difference types: `coloring` and `standard`.  In the `coloring` method, the graph from the Jacobian matrix is colored, and a finite difference is applied color-by-color.  The issue of this method is that the matrix may be not good enough if the sparsity pattern is not set completely. Joshua encountered this issue already. He did not implement off-diagonal Jacobian in kernel, and the Jacobian computed using coloring missed the off-diagonal part. The Newton could not converge.    The `standard` finite difference does not require such info, and it computes Jacobian column-by-column.  The benefit of the `standard` finite difference is that an exact Jacobian is computed (in theory) if the function is continuous.  It is good for debug. The `standard` finite difference does not require users to implement the off-diagonal Jacobian. Also note that the `standard` finite difference is slower than the `coloring` method. 

`solve_type=fd` equals to `standard FDP`. So it is possible to remove this solver option, but not sure if people like or not. I did not remove this option in this PR.

Refs #5819