### PR TITLE
Make MooseApp::errorCheck() protected (instead of private)

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -525,6 +525,12 @@ protected:
    */
   virtual void registerRecoverableData(std::string name);
 
+  /**
+   * Runs post-initialization error checking that cannot be run correctly unless the simulation
+   * has been fully set up and initialized.
+   */
+  void errorCheck();
+
   /// The name of this object
   std::string _name;
 
@@ -661,10 +667,6 @@ private:
    * []
    */
   void createMinimalApp();
-
-  /// Runs post-initialization error checking that cannot be run correctly unless the simulation
-  /// has been fully set up and initialized.
-  void errorCheck();
 
   /// Where the restartable data is held (indexed on tid)
   RestartableDatas _restartable_data;


### PR DESCRIPTION
closes #10002

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
