### PR TITLE
Ask to save input file when reloading syntax or changing input file.

### DIFF
--- a/python/peacock/Input/InputFileEditor.py
+++ b/python/peacock/Input/InputFileEditor.py
@@ -111,6 +111,7 @@ class InputFileEditor(QWidget, MooseWidget):
             app_info[ExecutableInfo]: The new information
         """
         if app_info.valid():
+            self._closeBlockEditor()
             input_filename = self.tree.input_filename
             input_tree = InputTree(app_info)
             self.tree = input_tree

--- a/python/peacock/Input/InputFileEditorPlugin.py
+++ b/python/peacock/Input/InputFileEditorPlugin.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from PyQt5.QtWidgets import QFileDialog, QPlainTextEdit, QSizePolicy
+from PyQt5.QtWidgets import QFileDialog, QPlainTextEdit, QSizePolicy, QMessageBox
 from PyQt5.QtCore import Qt, pyqtSignal
 from peacock.utils import WidgetUtils
 from peacock.base.Plugin import Plugin
@@ -53,12 +53,21 @@ class InputFileEditorPlugin(InputFileEditor, Plugin):
     def _updateChanged(self, block, tree):
         self.has_changed = True
 
+    def _askToSave(self, app_info, reason):
+        if self.has_changed and app_info.valid():
+            msg = "%s\nYou have unsaved changes in your input file, do you want to save?" % reason
+            reply = QMessageBox.question(self, "Save?", msg, QMessageBox.Save, QMessageBox.Discard)
+            if reply == QMessageBox.Save:
+                self._saveInputFile()
+
     def executableInfoChanged(self, app_info):
+        self._askToSave(app_info, "Reloading syntax from executable.")
         super(InputFileEditorPlugin, self).executableInfoChanged(app_info)
         self._setMenuStatus()
         self.has_changed = False
 
     def setInputFile(self, input_file):
+        self._askToSave(self.tree.app_info, "Changing input files.")
         val = super(InputFileEditorPlugin, self).setInputFile(input_file)
         if self._menus_initialized:
             path = os.path.abspath(input_file)


### PR DESCRIPTION
Previously we would just silently discard all changes.

This just saves it to the current input file.
Do we want a "Save As" button on the dialog as well?

closes #9974

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
