### PR TITLE
Add min_damping option and test

### DIFF
--- a/framework/include/dampers/Damper.h
+++ b/framework/include/dampers/Damper.h
@@ -40,9 +40,19 @@ class Damper : public MooseObject,
 public:
   Damper(const InputParameters & parameters);
 
+  /**
+   * Check whether damping is below the user-specified minimum value,
+   * and throw an exception if it is.
+   * @param cur_damping The computed damping to be checked against that minimum
+   */
+  void checkMinDamping(const Real cur_damping) const;
+
 protected:
   SubProblem & _subproblem;
   SystemBase & _sys;
+
+  /// Minimum allowable value of damping
+  const Real & _min_damping;
 };
 
 #endif

--- a/framework/src/base/ComputeElemDampingThread.C
+++ b/framework/src/base/ComputeElemDampingThread.C
@@ -61,6 +61,7 @@ ComputeElemDampingThread::onElement(const Elem * elem)
   for (const auto & obj : objects)
   {
     Real cur_damping = obj->computeDamping();
+    obj->checkMinDamping(cur_damping);
     if (cur_damping < _damping)
       _damping = cur_damping;
   }

--- a/framework/src/base/ComputeNodalDampingThread.C
+++ b/framework/src/base/ComputeNodalDampingThread.C
@@ -58,6 +58,7 @@ ComputeNodalDampingThread::onNode(ConstNodeRange::const_iterator & node_it)
   for (const auto & obj : objects)
   {
     Real cur_damping = obj->computeDamping();
+    obj->checkMinDamping(cur_damping);
     if (cur_damping < _damping)
       _damping = cur_damping;
   }

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -2284,6 +2284,14 @@ NonlinearSystemBase::computeDamping(const NumericVector<Number> & solution,
     for (const auto & damper : gdampers)
     {
       Real gd_damping = damper->computeDamping(solution, update);
+      try
+      {
+        damper->checkMinDamping(gd_damping);
+      }
+      catch (MooseException & e)
+      {
+        _fe_problem.setException(e.what());
+      }
       damping = std::min(gd_damping, damping);
     }
   }

--- a/test/tests/dampers/min_damping/min_elem_damping.i
+++ b/test/tests/dampers/min_damping/min_elem_damping.i
@@ -1,0 +1,46 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./u_dt]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./u_source]
+    type = BodyForce
+    variable = u
+    value = 1
+  [../]
+[]
+
+[Dampers]
+  [./limit]
+    type = BoundingValueElementDamper
+    variable = u
+    max_value = 1.5
+    min_value = -1.5
+    min_damping = 0.001
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 2
+[]
+
+[Postprocessors]
+  [./u_avg]
+    type = ElementAverageValue
+    variable = u
+  [../]
+  [./dt]
+    type = TimestepSize
+  [../]
+[]

--- a/test/tests/dampers/min_damping/min_general_damping.i
+++ b/test/tests/dampers/min_damping/min_general_damping.i
@@ -1,0 +1,46 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./u_dt]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./u_source]
+    type = BodyForce
+    variable = u
+    value = 1
+  [../]
+[]
+
+[Dampers]
+  [./limit]
+    type = ConstantDamper
+    damping = 0.25
+    min_damping = 0.5
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 2
+  dt = 1.0
+  dtmin = 0.5
+[]
+
+[Postprocessors]
+  [./u_avg]
+    type = ElementAverageValue
+    variable = u
+  [../]
+  [./dt]
+    type = TimestepSize
+  [../]
+[]

--- a/test/tests/dampers/min_damping/min_nodal_damping.i
+++ b/test/tests/dampers/min_damping/min_nodal_damping.i
@@ -1,0 +1,46 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./u_dt]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./u_source]
+    type = BodyForce
+    variable = u
+    value = 1
+  [../]
+[]
+
+[Dampers]
+  [./limit]
+    type = BoundingValueNodalDamper
+    variable = u
+    max_value = 1.5
+    min_value = -1.5
+    min_damping = 0.001
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 2
+[]
+
+[Postprocessors]
+  [./u_avg]
+    type = ElementAverageValue
+    variable = u
+  [../]
+  [./dt]
+    type = TimestepSize
+  [../]
+[]

--- a/test/tests/dampers/min_damping/tests
+++ b/test/tests/dampers/min_damping/tests
@@ -1,0 +1,17 @@
+[Tests]
+  [./min_nodal_damping]
+    type = 'RunApp'
+    input = 'min_nodal_damping.i'
+    expect_out = "From damper: 'limit' damping below min_damping"
+  [../]
+  [./min_elem_damping]
+    type = 'RunApp'
+    input = 'min_elem_damping.i'
+    expect_out = "From damper: 'limit' damping below min_damping"
+  [../]
+  [./min_general_damping]
+    type = 'RunException'
+    input = 'min_general_damping.i'
+    expect_err = "Solve failed and timestep already at or below dtmin"
+  [../]
+[]


### PR DESCRIPTION
This adds an input parameter `min_damping` to the Damper base class and a function to check whether the damping for that specific Damper is below that value. If it is, and exception is thrown, which results in the time step being cut.

closes #10015