### PR TITLE
Test min_damping with parallel and threads

### DIFF
--- a/test/tests/dampers/min_damping/min_elem_damping.i
+++ b/test/tests/dampers/min_damping/min_elem_damping.i
@@ -1,6 +1,7 @@
 [Mesh]
   type = GeneratedMesh
   dim = 1
+  nx = 10
 []
 
 [Variables]
@@ -17,6 +18,15 @@
     type = BodyForce
     variable = u
     value = 1
+  [../]
+[]
+
+[BCs]
+  [./u_left]
+    type = DirichletBC
+    boundary = left
+    variable = u
+    value = 0.0
   [../]
 []
 

--- a/test/tests/dampers/min_damping/min_nodal_damping.i
+++ b/test/tests/dampers/min_damping/min_nodal_damping.i
@@ -1,6 +1,7 @@
 [Mesh]
   type = GeneratedMesh
   dim = 1
+  nx = 10
 []
 
 [Variables]
@@ -17,6 +18,15 @@
     type = BodyForce
     variable = u
     value = 1
+  [../]
+[]
+
+[BCs]
+  [./u_left]
+    type = DirichletBC
+    boundary = left
+    variable = u
+    value = 0.0
   [../]
 []
 

--- a/test/tests/dampers/min_damping/tests
+++ b/test/tests/dampers/min_damping/tests
@@ -3,11 +3,15 @@
     type = 'RunApp'
     input = 'min_nodal_damping.i'
     expect_out = "From damper: 'limit' damping below min_damping"
+    min_threads = 2
+    min_parallel = 2
   [../]
   [./min_elem_damping]
     type = 'RunApp'
     input = 'min_elem_damping.i'
     expect_out = "From damper: 'limit' damping below min_damping"
+    min_threads = 2
+    min_parallel = 2
   [../]
   [./min_general_damping]
     type = 'RunException'


### PR DESCRIPTION
 closes #10015

This makes the solutions vary spatially, so that the min_damping value won't be hit simultaneously everywhere in the domain.  I have these then run in parallel and with threads to ensure that it is handled in those cases.