### PR TITLE
Allow mesh adaptivity to be skipped if not needed

### DIFF
--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -127,7 +127,8 @@ public:
   void setRecomputeMarkersFlag(const bool flag) { _recompute_markers_during_cycles = flag; }
 
   /**
-   * Pull out the _check_markers_before_adapting_mesh flag previously set through the AdaptivityAction
+   * Pull out the _check_markers_before_adapting_mesh flag previously set through the
+   * AdaptivityAction
    *
    * @return the flag to check markers before running mesh adaptivity
    */

--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -127,6 +127,19 @@ public:
   void setRecomputeMarkersFlag(const bool flag) { _recompute_markers_during_cycles = flag; }
 
   /**
+   * Pull out the _check_markers_before_adapting_mesh flag previously set through the AdaptivityAction
+   *
+   * @return the flag to check markers before running mesh adaptivity
+   */
+  bool getCheckMarkersFlag() const { return _check_markers_before_adapting_mesh; }
+
+  /**
+   * Set the flag to check markers before running mesh adaptivity
+   * @param flag The flag to check markers before running mesh adaptivity
+   */
+  void setCheckMarkersFlag(const bool flag) { _check_markers_before_adapting_mesh = flag; }
+
+  /**
    * Adapts the mesh based on the error estimator used
    *
    * @return a boolean that indicates whether the mesh was changed
@@ -298,6 +311,12 @@ protected:
   /// Whether or not to recompute markers during adaptivity cycles
   bool _recompute_markers_during_cycles;
 
+  /// Flag to check markers before running mesh adaptivity
+  bool _check_markers_before_adapting_mesh;
+
+  /// Flag indicating mesh needs adapting
+  bool _mesh_adaptivity_needed;
+
   /// Stores pointers to ErrorVectors associated with indicator field names
   std::map<std::string, std::unique_ptr<ErrorVector>> _indicator_field_to_error_vector;
 };
@@ -328,6 +347,8 @@ Adaptivity::setParam(const std::string & param_name, const T & param_value)
     _cycles_per_step = param_value;
   else if (param_name == "recompute_markers_during_cycles")
     _recompute_markers_during_cycles = param_value;
+  else if (param_name == "check_markers_before_adapting_mesh")
+    _check_markers_before_adapting_mesh = param_value;
   else
     mooseError("Invalid Param in adaptivity object");
 }

--- a/framework/include/base/FlagElementsThread.h
+++ b/framework/include/base/FlagElementsThread.h
@@ -36,7 +36,9 @@ public:
 
   virtual void onElement(const Elem * elem) override;
 
-  void join(const FlagElementsThread & /*y*/);
+  void join(const FlagElementsThread & y);
+
+  bool meshNeedsAdapting() const { return _num_elements_needing_adapting > 0; }
 
 protected:
   FEProblemBase & _fe_problem;
@@ -48,6 +50,7 @@ protected:
   unsigned int _field_var_number;
   std::vector<Number> & _serialized_solution;
   unsigned int _max_h_level;
+  unsigned int _num_elements_needing_adapting;
 };
 
 #endif // FLAGELEMENTSTHREAD_H

--- a/framework/src/actions/AdaptivityAction.C
+++ b/framework/src/actions/AdaptivityAction.C
@@ -76,6 +76,8 @@ validParams<AdaptivityAction>()
       "show_initial_progress", true, "Show the progress of the initial adaptivity");
   params.addParam<bool>(
       "recompute_markers_during_cycles", false, "Recompute markers during adaptivity cycles");
+  params.addParam<bool>(
+      "check_markers_before_adapting_mesh", false, "Check adaptivity markers before performing mesh adaptivity.");
   return params;
 }
 
@@ -98,6 +100,8 @@ AdaptivityAction::act()
   adapt.setParam("max h-level", getParam<unsigned int>("max_h_level"));
   adapt.setParam("recompute_markers_during_cycles",
                  getParam<bool>("recompute_markers_during_cycles"));
+  adapt.setParam("check_markers_before_adapting_mesh",
+                 getParam<bool>("check_markers_before_adapting_mesh"));
 
   adapt.setPrintMeshChanged(getParam<bool>("print_changed_info"));
 

--- a/framework/src/actions/AdaptivityAction.C
+++ b/framework/src/actions/AdaptivityAction.C
@@ -76,8 +76,9 @@ validParams<AdaptivityAction>()
       "show_initial_progress", true, "Show the progress of the initial adaptivity");
   params.addParam<bool>(
       "recompute_markers_during_cycles", false, "Recompute markers during adaptivity cycles");
-  params.addParam<bool>(
-      "check_markers_before_adapting_mesh", false, "Check adaptivity markers before performing mesh adaptivity.");
+  params.addParam<bool>("check_markers_before_adapting_mesh",
+                        false,
+                        "Check adaptivity markers before performing mesh adaptivity.");
   return params;
 }
 

--- a/framework/src/actions/SetAdaptivityOptionsAction.C
+++ b/framework/src/actions/SetAdaptivityOptionsAction.C
@@ -47,8 +47,9 @@ validParams<SetAdaptivityOptionsAction>()
       "The number of adaptive steps to use when on each timestep during a Transient simulation.");
   params.addParam<bool>(
       "recompute_markers_during_cycles", false, "Recompute markers during adaptivity cycles");
-  params.addParam<bool>(
-      "check_markers_before_adapting_mesh", false, "Check markers before performing mesh adaptivity.");
+  params.addParam<bool>("check_markers_before_adapting_mesh",
+                        false,
+                        "Check markers before performing mesh adaptivity.");
   return params;
 }
 

--- a/framework/src/actions/SetAdaptivityOptionsAction.C
+++ b/framework/src/actions/SetAdaptivityOptionsAction.C
@@ -47,6 +47,8 @@ validParams<SetAdaptivityOptionsAction>()
       "The number of adaptive steps to use when on each timestep during a Transient simulation.");
   params.addParam<bool>(
       "recompute_markers_during_cycles", false, "Recompute markers during adaptivity cycles");
+  params.addParam<bool>(
+      "check_markers_before_adapting_mesh", false, "Check markers before performing mesh adaptivity.");
   return params;
 }
 
@@ -72,4 +74,5 @@ SetAdaptivityOptionsAction::act()
   adapt.setTimeActive(getParam<Real>("start_time"), getParam<Real>("stop_time"));
 
   adapt.setRecomputeMarkersFlag(getParam<bool>("recompute_markers_during_cycles"));
+  adapt.setCheckMarkersFlag(getParam<bool>("check_markers_before_adapting_mesh"));
 }

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -172,7 +172,9 @@ Adaptivity::adaptMesh(std::string marker_name /*=std::string()*/)
     _displaced_problem->undisplaceMesh();
 
   // Perform refinement and coarsening
+  Moose::perf_log.push("Adaptivity: refine_and_coarsen_elements()", "Execution");
   mesh_changed = _mesh_refinement->refine_and_coarsen_elements();
+  Moose::perf_log.pop("Adaptivity: refine_and_coarsen_elements()", "Execution");
 
   if (_displaced_problem && mesh_changed)
   {

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -49,7 +49,9 @@ Adaptivity::Adaptivity(FEProblemBase & subproblem)
     _cycles_per_step(1),
     _use_new_system(false),
     _max_h_level(0),
-    _recompute_markers_during_cycles(false)
+    _recompute_markers_during_cycles(false),
+    _check_markers_before_adapting_mesh(false),
+    _mesh_adaptivity_needed(true)
 {
 }
 
@@ -130,6 +132,9 @@ Adaptivity::adaptMesh(std::string marker_name /*=std::string()*/)
 
   bool mesh_changed = false;
 
+  // by default, assume mesh adaptivity is needed
+  _mesh_adaptivity_needed = true;
+
   if (_use_new_system)
   {
     if (!marker_name.empty()) // Only flag if a marker variable name has been set
@@ -145,6 +150,15 @@ Adaptivity::adaptMesh(std::string marker_name /*=std::string()*/)
                                _subproblem.mesh().getMesh().active_elements_end(),
                                1);
       Threads::parallel_reduce(all_elems, fet);
+
+      // check if any elements were flagged to be coarsened or refined
+      if (_check_markers_before_adapting_mesh)
+      {
+        _mesh_adaptivity_needed = fet.meshNeedsAdapting();
+        // check other processors too
+        _subproblem.comm().max(_mesh_adaptivity_needed);
+      }
+
       _subproblem.getAuxiliarySystem().solution().close();
     }
   }
@@ -171,10 +185,15 @@ Adaptivity::adaptMesh(std::string marker_name /*=std::string()*/)
   if (_displaced_problem)
     _displaced_problem->undisplaceMesh();
 
-  // Perform refinement and coarsening
-  Moose::perf_log.push("Adaptivity: refine_and_coarsen_elements()", "Execution");
-  mesh_changed = _mesh_refinement->refine_and_coarsen_elements();
-  Moose::perf_log.pop("Adaptivity: refine_and_coarsen_elements()", "Execution");
+  // Perform refinement and coarsening if needed
+  if (_mesh_adaptivity_needed)
+  {
+    Moose::perf_log.push("Adaptivity: refine_and_coarsen_elements()", "Execution");
+    mesh_changed = _mesh_refinement->refine_and_coarsen_elements();
+    Moose::perf_log.pop("Adaptivity: refine_and_coarsen_elements()", "Execution");
+  }
+  else
+    _console << "Mesh does not need adapting..." << std::endl;
 
   if (_displaced_problem && mesh_changed)
   {

--- a/test/tests/markers/uniform_marker/uniform_marker_adapt_nothing.i
+++ b/test/tests/markers/uniform_marker/uniform_marker_adapt_nothing.i
@@ -1,0 +1,61 @@
+###########################################################
+# This is a test of the Mesh Marker System. It marks
+# elements with flags indicating whether they should be
+# refined, coarsened, or left alone. This system
+# has the ability to use the Mesh Indicator System.
+#
+# @Requirement F2.50
+###########################################################
+
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 50
+  ny = 50
+  nz = 50
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 10
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+[]
+
+# Mesh Marker System
+[Adaptivity]
+  marker = uniform
+  cycles_per_step = 1
+
+  # set this to true to skip the call to refine_and_coarsen_elements()
+  check_markers_before_adapting_mesh = false
+
+  [./Markers]
+    [./uniform]
+      type = UniformMarker
+      mark = do_nothing
+    [../]
+  [../]
+[]
+
+[Outputs]
+  print_perf_log = true
+[]


### PR DESCRIPTION
Adds the ability skip mesh adaptivity if there are no elements that need it. I set it up so you need to set a parameter to do the check, leaving the default behavior unchanged. Could also set the parameter by default if this turns out to be something useful.

It works by counting up elements that are marked REFINE or COARSEN and if any are found, the call to refine_and_coarsen_elements() is skipped. Hopefully I got all the parallel logic right.

There is little to no speed up for most cases, but I can easily dream up cases in which problems run 30% faster with this patch. One such case is included. _The real question though is why is libmesh taking so long to do nothing._

Here are some speedup numbers (times in seconds and percent). The first few lines are down in the weeds but the numbers become significant as you move down and right. Maybe someone could check my numbers, though I got similar values on both my work machine and Falcon.

nx=ny=nz | 1 cpu | 8 cpus | 24 cpus
--- | --- | --- | ---
10 | 0.0032 (2.7%) | 0.0052 (5.5%) | 0.0070 (6.1%)
20 | 0.0237 (3.5%) | 0.031 (9.1%) | 0.0351 (10.7%)
50 | 1.113 (8.1%) | 1.75 (25%) | 2.05 (30.6%)
80 | 6.4 (10.1%) | 8.2 (27.6%) | 8.8 (30.6%)
100 | 10.7 (8.9%) | 12.2 (22.6%) | 17.6 (30.5%)



I'm not sure of a good test for this. Is there a way to check that a line is NOT in the performance log? With the included test case, the refine_and_coarsen_elements() function should never be called, so it shouldn't be in the performance log.

I did change the marking behavior slightly in that level-0 elements that are set to COARSEN are switched to DO_NOTHING, so if there are any exodiff tests out there with marker information in them, they might have to be regolded. Or I could switch the behavior back. Either way.

closes #10024 

tagging @permcody , and also @roystgnr because of the dig to libmesh