### PR TITLE
Fix LaTeX errors in Porous Flow docs

### DIFF
--- a/docs/content/documentation/modules/porous_flow/boundaries.md
+++ b/docs/content/documentation/modules/porous_flow/boundaries.md
@@ -22,7 +22,7 @@ This basic sink boundary condition is implemented in [`PorousFlowSink`](/porous_
 The basic sink may be multiplied by a MOOSE Function of the pressure
 of a fluid phase *or* the temperature:
 \begin{equation}
-s = f(t, x) \times g(P^{\beta}) \ \ \ \mbox{or}\ \ \ s = f(t, x)
+s = f(t, x) \times g(P^{\beta}) \ \ \ \textrm{or}\ \ \ s = f(t, x)
 \times g(T) \ .
 \end{equation}
 Here the units of $f\times g$ are kg.m$^{-2}$.s$^{-1}$ (for fluids) or

--- a/docs/content/documentation/modules/porous_flow/capillary_pressure.md
+++ b/docs/content/documentation/modules/porous_flow/capillary_pressure.md
@@ -40,25 +40,22 @@ This formulation is useful for testing purposes.
 
 van Genuchten's capillary-pressure relationship is \citep{vangenuchten1980}
 
-\begin{eqnarray}
-S_{\mathrm{eff}} & = & \left\{
-\begin{array}{ll}
-1 & \mbox{if } P \geq 0 \ , \\
-(1 + (-\alpha P)^{1/(1-m)})^{-m} & \mbox{if } P < 0\ .
+\begin{equation}
+S_{\mathrm{eff}} =
+\begin{cases}
+1 & \textrm{if } P \geq 0 \ , \\
+(1 + (-\alpha P)^{1/(1-m)})^{-m} & \textrm{if } P < 0 \ .
+\end{cases}
 \label{eq:vg_cap}
-\end{array}
-\right.
-\end{eqnarray}
+\end{equation}
 or
-\begin{eqnarray}
-P_{c} & = & \left\{
-\begin{array}{ll}
-0 & \mbox{if } S_{\mathrm{eff}} >= 1.0 \ , \\
-\frac{1}{\alpha} (S_{\mathrm{eff}}^{-1/m} - 1)^{1 - m} & \mbox{if }
-S_{\mathrm{eff}} < 1
-\end{array}
-\right.
-\end{eqnarray}
+\begin{equation}
+P_{c} =
+\begin{cases}
+0 & \textrm{if } S_{\mathrm{eff}} >= 1.0 \ , \\
+\frac{1}{\alpha} (S_{\mathrm{eff}}^{-1/m} - 1)^{1 - m} & \textrm{if } S_{\mathrm{eff}} < 1
+\end{cases}
+\end{equation}
 
 The effective saturation has been denoted by $S_{\mathrm{eff}}$ and
 $P$ is the porepressure, which is the  *negative* of the capillary

--- a/docs/content/documentation/modules/porous_flow/convergence.md
+++ b/docs/content/documentation/modules/porous_flow/convergence.md
@@ -84,10 +84,15 @@ The nonlinear residual will be \begin{equation} R \approx V|\epsilon| \ ,
 
 Often it is appropriate to scale the variables in order to weight their
 contributions to the overall nonlinear residual appropriately. For instance,
-suppose the previous arguments provided \begin{eqnarray} R_{\mathrm{fluid}} &
-\sim & 10^{-9}V \ , \nonumber \\ R_{\mathrm{heat}} & \sim & (10^{-3} +
-10^{6}\times 10^{-9}) V \ , \nonumber \\ R_{\mathrm{mech}} & \sim & V \ ,
-\end{eqnarray} (with the same $V$ in each case).  Then, a scaling of around
+suppose the previous arguments provided
+\begin{equation*}
+\begin{aligned}
+R_{\mathrm{fluid}} & \sim 10^{-9}V \ , \\
+R_{\mathrm{heat}} & \sim (10^{-3} + 10^{6}\times 10^{-9}) V \ , \\
+R_{\mathrm{mech}} & \sim V \ ,
+\end{aligned}
+\end{equation*}
+(with the same $V$ in each case).  Then, a scaling of around
 $10^9$ on the porepressure variable (or whatever MOOSE variable is associated to
 the fluid equation) would be appropriate.  Similarly, a scaling of around $10^3$
 on the temperature variable would be appropriate.

--- a/docs/content/documentation/modules/porous_flow/diffusivity.md
+++ b/docs/content/documentation/modules/porous_flow/diffusivity.md
@@ -19,8 +19,10 @@ A simple model where the diffusion constants and tortuosity are constant.
 [`PorousFlowDiffusivityMillingtonQuirk`](/porous_flow/PorousFlowDiffusivityMillingtonQuirk.md)
 
 A saturation dependent model proposed by \citet{millington-quirk1961}, where the
-diffusion coefficients are constant but the tortuosity is \begin{equation}
-\tau_0 \tau_{\beta}(S_{\beta}) = \phi^{1/3} S_{\beta}^{10/3}. \end{equation}
+diffusion coefficients are constant but the tortuosity is
+\begin{equation}
+\tau_0 \tau_{\beta}(S_{\beta}) = \phi^{1/3} S_{\beta}^{10/3}.
+\end{equation}
 
 ##References
 \bibliographystyle{unsrt}

--- a/docs/content/documentation/modules/porous_flow/governing_equations.md
+++ b/docs/content/documentation/modules/porous_flow/governing_equations.md
@@ -57,11 +57,13 @@ but may also depend on mass fraction of individual components, as described by
 the equation of state used.
 
 The saturation and mass fractions must obey
-\begin{eqnarray}
-\sum_{\beta}S_{\beta} & = & 1 \ , \\
-\sum_{\kappa}\chi_{\beta}^{\kappa} & = & 1 \ \ \ \forall
+$$
+\begin{aligned}
+\sum_{\beta}S_{\beta} & =  1 \ , \\
+\sum_{\kappa}\chi_{\beta}^{\kappa} & =  1 \ \ \ \forall
 \beta \ .
-\end{eqnarray}
+\end{aligned}
+$$
 
 ###Flux
 The flux is a sum of advective flux and diffusive-and-dispersive flux:
@@ -181,14 +183,12 @@ T}^{\kappa}}{\mathbf{v}_{\beta}^{2}}\mathbf{v}_{\beta}\mathbf{v}_{\beta} \ ,
 \label{eq:hydro_disp}
 \end{equation}
 where
-\begin{eqnarray}
-D_{\beta,L}^{\kappa} & = &
-\phi\tau_{0}\tau_{\beta}d_{\beta}^{\kappa} + \alpha_{\beta,
-L}\left|\mathbf{v}\right|_{\beta} \ , \label{eq:dl} \\
-D_{\beta,T}^{\kappa} & = &
-\phi\tau_{0}\tau_{\beta}d_{\beta}^{\kappa} + \alpha_{\beta,
-T}\left|\mathbf{v}\right|_{\beta}  \ . \label{eq:dt}
-\end{eqnarray}
+\begin{equation}
+\begin{aligned}
+D_{\beta,L}^{\kappa} & = \phi \tau_0 \tau_{\beta} d_{\beta}^{\kappa} + \alpha_{\beta,L} \left| \mathbf{v} \right|_{\beta}, \\
+D_{\beta,T}^{\kappa} & = \phi \tau_0 \tau_{\beta} d_{\beta}^{\kappa} + \alpha_{\beta,T}\left| \mathbf{v} \right|_{\beta}.
+\end{aligned}
+\end{equation}
 
 These are called the longitudinal and transverse dispersion coefficients.
 $d_{\beta}^{\kappa}$ is the molecular diffusion coefficient for component
@@ -409,11 +409,11 @@ follows.
   defined: one for desorption, and one for adsorption, so
 \begin{equation}
 \tau_{L} = \left\{
-\begin{array}{ll}
-\tau_{L,\ \mathrm{desorption}} & \mbox{ if }
+\begin{aligned}
+\tau_{L,\ \mathrm{desorption}} & \textrm{ if }
 C>\frac{\rho_{L}P}{P_{L}+P} \\
-\tau_{L,\ \mathrm{adsorption}} & \mbox{ otherwise}
-\end{array}
+\tau_{L,\ \mathrm{adsorption}} & \textrm{ otherwise}
+\end{aligned}
 \right.
 \end{equation}
 A mollifier may also be defined to mollify the step-change between

--- a/docs/content/documentation/modules/porous_flow/porosity.md
+++ b/docs/content/documentation/modules/porous_flow/porosity.md
@@ -118,7 +118,7 @@ In most instances it is appropriate to write this equation as
 \end{equation}
 where the total mechanical pressure is
 \begin{equation}
-P_{\mathrm{mech}} = - \mbox{Tr}\sigma/3 \ .
+P_{\mathrm{mech}} = - \textrm{Tr}\sigma/3 \ .
 \end{equation}
 and $K$ is the so-called *drained* bulk modulus $K = \delta_{ij}C_{ijkl}\delta_{kl}$.
 To find the evolution equation for porosity, a similar equation for
@@ -141,18 +141,14 @@ The work increment is
 So during some deformation that takes $P_{\mathrm{mech}}$ from
 $P_{\mathrm{mech}}^{i}$ to $P_{\mathrm{mech}}^{f}$, and $P_{\mathrm{f}}$ from
 $P_{\mathrm{f}}^{i}$ to $P_{\mathrm{f}}^{f}$, the total work is
-\begin{eqnarray}
-W & = & -\int P_{\mathrm{mech}} \mathrm{d}V + \int P_{\mathrm{f}} \mathrm{d}V_{\mathrm{f}}
-\ , \nonumber \\ & = &
-\frac{V}{K}\int_{P_{\mathrm{mech}}^{i}}^{P_{\mathrm{mech}}^{f}}P_{\mathrm{mech}}
-\mathrm{d}P_{\mathrm{mech}} -
-\frac{V{\alpha_{B}}}{K}\int_{P_{\mathrm{f}}^{i}}^{P_{\mathrm{f}}^{f}}P_{\mathrm{mech}}
-\mathrm{d}P_{\mathrm{f}} +
-V_{\mathrm{f}}A_{ii}\int_{P_{\mathrm{mech}}^{i}}^{P_{\mathrm{mech}}^{f}}P_{\mathrm{f}}
-\mathrm{d}P_{\mathrm{mech}} +
-V_{\mathrm{f}}A_{ii}B\int_{P_{\mathrm{f}}^{i}}^{P_{\mathrm{f}}^{f}}
-P_{\mathrm{f}} \mathrm{d}P_{\mathrm{f}} \ .
-\end{eqnarray}
+\begin{equation}
+\begin{aligned}
+W & = -\int P_{\mathrm{mech}} \mathrm{d}V + \int P_{\mathrm{f}} \mathrm{d}V_{\mathrm{f}}\ ,\\
+& = \frac{V}{K}\int_{P_{\mathrm{mech}}^{i}}^{P_{\mathrm{mech}}^{f}}P_{\mathrm{mech}} \mathrm{d}P_{\mathrm{mech}} - \frac{V{\alpha_{B}}}{K}\int_{P_{\mathrm{f}}^{i}}^{P_{\mathrm{f}}^{f}}P_{\mathrm{mech}} \mathrm{d}P_{\mathrm{f}} \\
+& + V_{\mathrm{f}}A_{ii}\int_{P_{\mathrm{mech}}^{i}}^{P_{\mathrm{mech}}^{f}}P_{\mathrm{f}} \mathrm{d}P_{\mathrm{mech}} + V_{\mathrm{f}}A_{ii}B\int_{P_{\mathrm{f}}^{i}}^{P_{\mathrm{f}}^{f}} P_{\mathrm{f}} \mathrm{d}P_{\mathrm{f}} \ .
+\end{aligned}
+\end{equation}
+
 Now consider two experiments:
 
 - First take $P_{\mathrm{mech}}$ from $0$ to $P_{\mathrm{mech}}$ with

--- a/docs/content/documentation/modules/porous_flow/relative_permeability.md
+++ b/docs/content/documentation/modules/porous_flow/relative_permeability.md
@@ -52,12 +52,11 @@ $S_{\mathrm{eff}}=1$ do not converge well.
 Therefore, a *cut* version of the van Genuchten expression is also offered, which is
 almost definitely indistinguishable experimentally from the original expression:
 \begin{equation}
-k_{\mathrm{r}} = \left\{
-\begin{array}{ll}
-\mbox{van Genuchten} & \mbox{ for } S_{\mathrm{eff}} < S_{c} \\
-\mbox{cubic} & \mbox{ for } S_{\mathrm{eff}} \geq S_{c}.
-\end{array}
-\right.
+k_{\mathrm{r}} =
+\begin{cases}
+\textrm{van Genuchten} & \textrm{for } S_{\mathrm{eff}} < S_{c} \\
+\textrm{cubic} & \textrm{for } S_{\mathrm{eff}} \geq S_{c}.
+\end{cases}
 \end{equation}
 Here the cubic is chosen so that its value and derivative match the
 van Genuchten expression at $S=S_{c}$, and so that it is unity at

--- a/docs/content/documentation/modules/porous_flow/sinks.md
+++ b/docs/content/documentation/modules/porous_flow/sinks.md
@@ -13,7 +13,7 @@ continues to act indefinitely.
 
 Polyline sinks and sources are modelled as sequences of discrete points:
 \begin{equation}
-\mbox{polyline}\sim \left\{x_{0},\ x_{1},\ x_{2},\ldots,x_{N}\right\} \ .
+\textrm{polyline}\sim \left\{x_{0},\ x_{1},\ x_{2},\ldots,x_{N}\right\} \ .
 \end{equation}
 The sink is
 \begin{equation}
@@ -51,8 +51,8 @@ The basic sink may be multiplied by any or all of the following quantities
 - Fluid internal energy
 
 That is, $f$ in Eq. \eqref{eq:line_sink} may be replaced by $fk_{r}$,
-$f\times\mbox{mobility}$, etc.  (The units of $fk_{r}$,
-$f\times\mbox{mobility}$, etc, are kg.s$^{-1}$ for fluid flow, or J.s$^{-1}$ for
+$f\times\textrm{mobility}$, etc.  (The units of $fk_{r}$,
+$f\times\textrm{mobility}$, etc, are kg.s$^{-1}$ for fluid flow, or J.s$^{-1}$ for
 heat flow.)  All these additional multiplicative factors are evaluated at the
 nodal positions, not at point $x_{i}$, to ensure superior numerical convergence
 (see [upwinding](/porous_flow/upwinding.md)).

--- a/docs/content/documentation/modules/porous_flow/upwinding.md
+++ b/docs/content/documentation/modules/porous_flow/upwinding.md
@@ -49,7 +49,7 @@ $\tilde{R}$ is not exactly $R$, but note:
 
 This leads to the following definition of upwinding:
 \begin{equation}
-R_{a} \equiv m_{a}I_{a} \ \ \ \mbox{if}\ \ \ I_{a}\geq 0 \ .
+R_{a} \equiv m_{a}I_{a} \ \ \ \textrm{if}\ \ \ I_{a}\geq 0 \ .
 \end{equation}
 
 The nodes for which $I_{a}\geq 0$ are called *upwind nodes*, since fluid is
@@ -59,13 +59,13 @@ by \citet{dalen1979}.
 The residual at the downwind nodes is determined by conserving mass.
 Specifically, let
 \begin{equation}
-I_{\mathrm{up}} = \sum_{I_{a}\geq 0}I_{a} \ \ \ \mbox{and}\ \ \
+I_{\mathrm{up}} = \sum_{I_{a}\geq 0}I_{a} \ \ \ \textrm{and}\ \ \
 I_{\mathrm{down}} = -\sum_{I_{a}<0} I_{a} \ .
 \end{equation}
 Then
 \begin{equation}
 R_{a} = I_{a}\frac{I_{\mathrm{up}}}{I_{\mathrm{down}}}
-\ \ \ \mbox{for}\ \ \ I_{a}<0 \ .
+\ \ \ \textrm{for}\ \ \ I_{a}<0 \ .
 \end{equation}
 Then $\sum_{a} R_{a} = 0$ as required by mass conservation within the element (which originates from $\sum_{a} \psi_{a} = 1$).
 
@@ -73,7 +73,7 @@ The fully-upwind method is extremely advantageous to use if fluid saturations
 ever approach residual saturation (where $\kappa_{\mathrm{rel}}=0$) or zero
 density, for then the mobility is zero and it becomes impossible to withdraw
 fluid from such a node (in practice this may still happen due to precision loss
-or other related nasty artifacts).
+or other related nasty artefacts).
 
 Prescribed sinks, either from the boundary or from internal objects such as
 wellbores, are also fully-upwinded in PorousFlow since they also potentially

--- a/docs/content/documentation/systems/AuxKernels/porous_flow/PorousFlowDarcyVelocityComponent.md
+++ b/docs/content/documentation/systems/AuxKernels/porous_flow/PorousFlowDarcyVelocityComponent.md
@@ -2,10 +2,9 @@
 !syntax description /AuxKernels/PorousFlowDarcyVelocityComponent
 
 This `AuxKernel` calculates the *x*, *y*, or *z* component of the Darcy velocity
-\begin{equation}
+\begin{equation*}
   -\frac{k\,k_{\mathrm{r,}\beta}}{\mu_{\beta}}(\nabla P_{\beta} - \rho_{\beta} \mathbf{g})
-  \nonumber
-\end{equation}
+\end{equation*}
 for fluid phase $\beta$. All parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !!! note:

--- a/docs/content/documentation/systems/BCs/porous_flow/PorousFlowHalfCubicSink.md
+++ b/docs/content/documentation/systems/BCs/porous_flow/PorousFlowHalfCubicSink.md
@@ -3,18 +3,17 @@
 
 The basic sink $f(x,t)$ is scaled by a cubic flux multiplier of the pressure
 of a fluid phase *or* the temperature $g(v)$:
-\begin{equation}
-  s = f(t, x) \times g(v) \nonumber \,
-\end{equation}
+\begin{equation*}
+  s = f(t, x) \times g(v) \,
+\end{equation*}
 where
-\begin{equation}
+\begin{equation*}
   g(v) =
   \begin{cases}
     g_{\mathrm{max}}, & \text{if}\ v < v - v_{\mathrm{center}} \\
     \frac{2 g_{\mathrm{max}} \left(2[v - v_{\mathrm{center}}] + v_{\mathrm{cutoff}}\right) (v - v_{\mathrm{center}} - v_{\mathrm{cutoff}})^2}{v_{\mathrm{cutoff}}^3},  & \text{otherwise}
   \end{cases}
- \nonumber
-\end{equation}
+\end{equation*}
 Here the units of $f\times g$ are kg.m$^{-2}$.s$^{-1}$ (for fluids) or
 J.m$^{-1}$.s$^{-1}$ (for heat). The parameters $g_{\mathrm{max}}$, $v_{\mathrm{center}}$ and $v_{\mathrm{cutoff}}$ are given in the input file using the `max`, `center` and `cutoff` options, respectively.
 

--- a/docs/content/documentation/systems/BCs/porous_flow/PorousFlowHalfGaussianSink.md
+++ b/docs/content/documentation/systems/BCs/porous_flow/PorousFlowHalfGaussianSink.md
@@ -3,18 +3,17 @@
 
 The basic sink $f(x,t)$ is scaled by a Gaussian flux multiplier of the pressure
 of a fluid phase *or* the temperature $g(v)$:
-\begin{equation}
-  s = f(t, x) \times g(v) \nonumber \,
-\end{equation}
+\begin{equation*}
+  s = f(t, x) \times g(v) \,
+\end{equation*}
 where
-\begin{equation}
+\begin{equation*}
   g(v) =
   \begin{cases}
     g_{\mathrm{max}} \exp((-0.5 (v - v_{\mathrm{center}}) / sd)^2), & \text{if}\ v < v_{\mathrm{center}} \\
     g_{\mathrm{max}},  & \text{otherwise}
   \end{cases}
- \nonumber
-\end{equation}
+\end{equation*}
 Here the units of $f\times g$ are kg.m$^{-2}$.s$^{-1}$ (for fluids) or
 J.m$^{-1}$.s$^{-1}$ (for heat). The parameters $g_{\mathrm{max}}$, $v_{\mathrm{center}}$ and $sd$ are given in the input file using the `max`, `center` and `sd` options, respectively.
 

--- a/docs/content/documentation/systems/BCs/porous_flow/PorousFlowPiecewiseLinearSink.md
+++ b/docs/content/documentation/systems/BCs/porous_flow/PorousFlowPiecewiseLinearSink.md
@@ -3,10 +3,10 @@
 
 The basic sink $f(x,t)$ is multiplied by a piecewise linear MOOSE Function of the pressure
 of a fluid phase $g(P^{\beta})$ *or* the temperature $g(T)$:
-\begin{equation}
-s = f(t, x) \times g(P^{\beta}) \ \ \ \mbox{or}\ \ \ s = f(t, x)
-\times g(T) \nonumber \ .
-\end{equation}
+\begin{equation*}
+s = f(t, x) \times g(P^{\beta}) \ \ \ \textrm{or}\ \ \ s = f(t, x)
+\times g(T) \ .
+\end{equation*}
 Here the units of $f\times g$ are kg.m$^{-2}$.s$^{-1}$ (for fluids) or
 J.m$^{-1}$.s$^{-1}$ (for heat).
 

--- a/docs/content/documentation/systems/BCs/porous_flow/PorousFlowSink.md
+++ b/docs/content/documentation/systems/BCs/porous_flow/PorousFlowSink.md
@@ -2,9 +2,9 @@
 !syntax description /BCs/PorousFlowSink
 
 This sink is
-\begin{equation}
-s = f(t, x) \nonumber \ ,
-\end{equation}
+\begin{equation*}
+s = f(t, x) \ ,
+\end{equation*}
 where $f$ is a MOOSE Function of time and position on the boundary.
 
 If $f>0$ then the boundary condition will act as a sink, while if $f<0$ the boundary condition acts as a source.  If applied to a fluid-component equation, the function $f$ has units kg.m$^{-2}$.s$^{-1}$.  If applied to the heat equation, the function $f$ has units J.m$^{-2}$.s$^{-1}$.  These units are potentially modified if the extra building blocks enumerated below are used.

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowAdvectiveFlux.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowAdvectiveFlux.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowAdvectiveFlux
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   -\nabla\cdot \sum_{\beta}\chi_{\beta}^{\kappa} \rho_{\beta}\frac{k\,k_{\mathrm{r,}\beta}}{\mu_{\beta}}(\nabla P_{\beta} - \rho_{\beta} \mathbf{g})
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !!! note

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowDesorpedMassTimeDerivative.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowDesorpedMassTimeDerivative.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowDesorpedMassTimeDerivative
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   \frac{\partial}{\partial t}\left((1 - \phi)C^{\kappa}\right)
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !syntax parameters /Kernels/PorousFlowDesorpedMassTimeDerivative

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowDesorpedMassVolumetricExpansion.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowDesorpedMassVolumetricExpansion.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowDesorpedMassVolumetricExpansion
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   \left((1 - \phi)C^{\kappa}\right)\nabla\cdot\mathbf{v}_{s}
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !syntax /Kernels/PorousFlowDesorpedMassVolumetricExpansion

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowDispersiveFlux.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowDispersiveFlux.md
@@ -2,24 +2,23 @@
 !syntax description /Kernels/PorousFlowDispersiveFlux
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   -\nabla\cdot \sum_{\beta}\rho_{\beta}{\mathcal{D}}_{\beta}^{\kappa}\nabla \chi_{\beta}^{\kappa}
-  \nonumber
-\end{equation}
+\end{equation*}
 where the hydrodynamic dispersion tensor is
-\begin{equation}
+\begin{equation*}
 {\mathcal{D}}_{\beta}^{\kappa} = D_{\beta,T}^{\kappa}{\mathcal{I}} +
 \frac{D_{\beta,L}^{\kappa} - D_{\beta,
     T}^{\kappa}}{\mathbf{v}_{\beta}^{2}}\mathbf{v}_{\beta}\mathbf{v}_{\beta}
 \ ,
-\nonumber
-\end{equation}
+\end{equation*}
 where
-\begin{eqnarray}
-D_{\beta,L}^{\kappa} & = & \phi\tau_{0}\tau_{\beta}d_{\beta}^{\kappa} + \alpha_{\beta, L}\left|\mathbf{v}\right|_{\beta} \ , \nonumber \\
-D_{\beta,T}^{\kappa} & = & \phi\tau_{0}\tau_{\beta}d_{\beta}^{\kappa} + \alpha_{\beta, T}\left|\mathbf{v}\right|_{\beta}  \ .
-\nonumber
-\end{eqnarray}
+\begin{equation*}
+\begin{aligned}
+D_{\beta,L}^{\kappa} & = \phi\tau_{0}\tau_{\beta}d_{\beta}^{\kappa} + \alpha_{\beta, L}\left|\mathbf{v}\right|_{\beta} \ , \\
+D_{\beta,T}^{\kappa} & = \phi\tau_{0}\tau_{\beta}d_{\beta}^{\kappa} + \alpha_{\beta, T}\left|\mathbf{v}\right|_{\beta} \ .
+\end{aligned}
+\end{equation*}
 All parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !syntax parameters /Kernels/PorousFlowDispersiveFlux

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowEnergyTimeDerivative.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowEnergyTimeDerivative.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowEnergyTimeDerivative
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   \frac{\partial}{\partial t}\left((1-\phi)\rho_{R}C_{R}T + \phi\sum_{\beta}S_{\beta}\rho_{\beta}\mathcal{E}_{\beta}\right)
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !!! note

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowHeatAdvection.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowHeatAdvection.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowHeatAdvection
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   -\nabla\cdot \sum_{\beta}h_{\beta} \rho_{\beta}\frac{k\,k_{\mathrm{r,}\beta}}{\mu_{\beta}}(\nabla P_{\beta} - \rho_{\beta} \mathbf{g})
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !!! note

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowHeatConduction.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowHeatConduction.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowHeatConduction
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   -\nabla\cdot \left(\lambda \nabla T\right)
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !syntax parameters /Kernels/PorousFlowHeatConduction

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowHeatVolumetricExpansion.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowHeatVolumetricExpansion.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowHeatVolumetricExpansion
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   \mathcal{E}\nabla\cdot\mathbf{v}_{s}
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !syntax parameters /Kernels/PorousFlowHeatVolumetricExpansion

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowMassRadioactiveDecay.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowMassRadioactiveDecay.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowMassRadioactiveDecay
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   \Lambda \phi\sum_{\beta}S_{\beta}\rho_{\beta}\chi_{\beta}^{\kappa}
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !syntax parameters /Kernels/PorousFlowMassRadioactiveDecay

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowMassTimeDerivative.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowMassTimeDerivative.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowMassTimeDerivative
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   \frac{\partial}{\partial t}\left(\phi\sum_{\beta}S_{\beta}\rho_{\beta}\chi_{\beta}^{\kappa}\right)
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !!! note

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowMassVolumetricExpansion.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowMassVolumetricExpansion.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowMassVolumetricExpansion
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   \phi\sum_{\beta}S_{\beta}\rho_{\beta}\chi_{\beta}^{\kappa}\nabla\cdot\mathbf{v}_{s}
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !syntax parameters /Kernels/PorousFlowMassVolumetricExpansion

--- a/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowPlasticHeatEnergy.md
+++ b/docs/content/documentation/systems/Kernels/porous_flow/PorousFlowPlasticHeatEnergy.md
@@ -2,10 +2,9 @@
 !syntax description /Kernels/PorousFlowPlasticHeatEnergy
 
 This `Kernel` implements the weak form of
-\begin{equation}
+\begin{equation*}
   -\nu (1-\phi)\sigma^{\mathrm{eff}}_{ij}\frac{\partial}{\partial t}\epsilon_{ij}^{\mathrm{plastic}}
-  \nonumber
-\end{equation}
+\end{equation*}
 where all parameters are defined in the [nomenclature](/porous_flow/nomenclature.md).
 
 !syntax parameters /Kernels/PorousFlowPlasticHeatEnergy

--- a/docs/content/documentation/systems/Materials/porous_flow/PorousFlowPermeabilityExponential.md
+++ b/docs/content/documentation/systems/Materials/porous_flow/PorousFlowPermeabilityExponential.md
@@ -2,9 +2,9 @@
 !syntax description /Materials/PorousFlowPermeabilityExponential
 
 A simple porosity-permeability model where
-\begin{equation}
-k_{ij} = B k_{ij}^{0} e^{A \phi}, \nonumber
-\end{equation}
+\begin{equation*}
+k_{ij} = B k_{ij}^{0} e^{A \phi},
+\end{equation*}
 where $\phi$ is the porosity, and $A$ and $B$ are user-defined constant.
 
 Input can be entered in any of three forms depending on the value of `poroperm_function`

--- a/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityBC.md
+++ b/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityBC.md
@@ -2,18 +2,18 @@
 !syntax description /Materials/PorousFlowRelativePermeabilityBC
 
 The \citet{brookscorey1966} relative permeability model is an extension of the previous  \citet{corey1954} formulation where the relative permeability of the wetting phase is given by
-\begin{equation}
+\begin{equation*}
 k_{\mathrm{r, w}} = \left(S_{\mathrm{eff}}\right)^{(2 + 3 \lambda)/\lambda},
-\end{equation}
+\end{equation*}
 and the relative permeability of the non-wetting phase is
-\begin{equation}
+\begin{equation*}
 k_{\mathrm{r, nw}} = (1 - S_{\mathrm{eff}})^2 \left[1 - \left(S_{\mathrm{eff}}\right)^{(2 + \lambda)/\lambda}\right],
-\end{equation}
+\end{equation*}
 where the effective saturation is
-\begin{equation}
+\begin{equation*}
 S_{\mathrm{eff}}(S) = \frac{S - S_{\mathrm{res}}^{\beta}}{1 -
-  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}, \nonumber
-\end{equation}
+  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}},
+\end{equation*}
 and $\lambda$ is a user-defined exponent.
 
 !syntax parameters /Materials/PorousFlowRelativePermeabilityBC

--- a/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityBW.md
+++ b/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityBW.md
@@ -2,15 +2,15 @@
 !syntax description /Materials/PorousFlowRelativePermeabilityBW
 
 The relative permeability of the phase is
-\begin{equation}
+\begin{equation*}
 k_{\mathrm{r}} = K_{n} + \frac{K_{s} - K_{n}}{(c - 1)(c -
-  S_{\mathrm{eff}})}S_{\mathrm{eff}}^{2}, \nonumber
-\end{equation}
+  S_{\mathrm{eff}})}S_{\mathrm{eff}}^{2},
+\end{equation*}
 where the effective saturation is
-\begin{equation}
+\begin{equation*}
 S_{\mathrm{eff}}(S) = \frac{S - S_{\mathrm{res}}^{\beta}}{1 -
-  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}. \nonumber
-\end{equation}
+  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}.
+\end{equation*}
 
 !syntax parameters /Materials/PorousFlowRelativePermeabilityBW
 

--- a/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityCorey.md
+++ b/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityCorey.md
@@ -2,14 +2,14 @@
 !syntax description /Materials/PorousFlowRelativePermeabilityCorey
 
 The relative permeability of the phase is
-\begin{equation}
-k_{\mathrm{r}} = S_{\mathrm{eff}}^{n}, \nonumber
-\end{equation}
+\begin{equation*}
+k_{\mathrm{r}} = S_{\mathrm{eff}}^{n},
+\end{equation*}
 where the effective saturation is
-\begin{equation}
+\begin{equation*}
 S_{\mathrm{eff}}(S) = \frac{S - S_{\mathrm{res}}^{\beta}}{1 -
-  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}. \nonumber
-\end{equation}
+  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}.
+\end{equation*}
 
 !syntax parameters /Materials/PorousFlowRelativePermeabilityCorey
 

--- a/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityFLAC.md
+++ b/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityFLAC.md
@@ -2,14 +2,14 @@
 !syntax description /Materials/PorousFlowRelativePermeabilityFLAC
 
 The relative permeability of the phase is
-\begin{equation}
-k_{\mathrm{r}} = (m + 1)S_{\mathrm{eff}}^{m} - m S_{\mathrm{eff}}^{m + 1}, \nonumber
-\end{equation}
+\begin{equation*}
+k_{\mathrm{r}} = (m + 1)S_{\mathrm{eff}}^{m} - m S_{\mathrm{eff}}^{m + 1},
+\end{equation*}
 where the effective saturation is
-\begin{equation}
+\begin{equation*}
 S_{\mathrm{eff}}(S) = \frac{S - S_{\mathrm{res}}^{\beta}}{1 -
-  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}. \nonumber
-\end{equation}
+  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}.
+\end{equation*}
 
 !syntax parameters /Materials/PorousFlowRelativePermeabilityFLAC
 

--- a/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityVG.md
+++ b/docs/content/documentation/systems/Materials/porous_flow/PorousFlowRelativePermeabilityVG.md
@@ -2,26 +2,25 @@
 !syntax description /Materials/PorousFlowRelativePermeabilityVG
 
 The relative permeability of the phase is
-\begin{equation}
+\begin{equation*}
 k_{\mathrm{r}} = \sqrt{S_{\mathrm{eff}}} \left(1 - (1 -
-S_{\mathrm{eff}}^{1/m})^{m} \right)^{2}, \nonumber
-\end{equation}
+S_{\mathrm{eff}}^{1/m})^{m} \right)^{2},
+\end{equation*}
 where the effective saturation is
-\begin{equation}
+\begin{equation*}
 S_{\mathrm{eff}}(S) = \frac{S - S_{\mathrm{res}}^{\beta}}{1 -
-  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}. \nonumber
-\end{equation}
+  \sum_{\beta'}S_{\mathrm{res}}^{\beta'}}.
+\end{equation*}
 
 A *cut* version of the van Genuchten expression is also offered, which is
 almost definitely indistinguishable experimentally from the original expression:
-\begin{equation}
-k_{\mathrm{r}} = \left\{
-\begin{array}{ll}
-\mbox{van Genuchten} & \mbox{ for } S_{\mathrm{eff}} < S_{c} \\
-\mbox{cubic} & \mbox{ for } S_{\mathrm{eff}} \geq S_{c}. \nonumber
-\end{array}
-\right.
-\end{equation}
+\begin{equation*}
+k_{\mathrm{r}} =
+\begin{cases}
+\textrm{van Genuchten} & \textrm{for } S_{\mathrm{eff}} < S_{c} \\
+\textrm{cubic} & \textrm{for } S_{\mathrm{eff}} \geq S_{c}.
+\end{cases}
+\end{equation*}
 Here the cubic is chosen so that its value and derivative match the
 van Genuchten expression at $S=S_{c}$, and so that it is unity at
 $S_{\mathrm{eff}}=1$.

--- a/docs/content/documentation/systems/Postprocessors/porous_flow/PorousFlowFluidMass.md
+++ b/docs/content/documentation/systems/Postprocessors/porous_flow/PorousFlowFluidMass.md
@@ -2,9 +2,9 @@
 !syntax description /Postprocessors/PorousFlowFluidMass
 
 This `Postprocessor` calculates the mass of a fluid component $\kappa$ using
-\begin{equation}
-M^{\kappa} = \phi \sum_{\beta} \chi^{\kappa}_{\beta} \rho_{\beta} S_{\beta}, \nonumber
-\end{equation}
+\begin{equation*}
+M^{\kappa} = \phi \sum_{\beta} \chi^{\kappa}_{\beta} \rho_{\beta} S_{\beta},
+\end{equation*}
 where all variables are defined in [`nomenclature`](/porous_flow/nomenclature.md).
 
 The fluid component $\kappa$ is specified in the input parameter `fluid_component`.

--- a/docs/content/documentation/systems/Postprocessors/porous_flow/PorousFlowHeatEnergy.md
+++ b/docs/content/documentation/systems/Postprocessors/porous_flow/PorousFlowHeatEnergy.md
@@ -2,18 +2,18 @@
 !syntax description /Postprocessors/PorousFlowHeatEnergy
 
 This `Postprocessor` calculates the heat energy of fluid phase(s) $\beta$ using
-\begin{equation}
-\mathcal{E} = \phi\sum_{\beta}S_{\beta}\rho_{\beta}\mathcal{E}_{\beta}, \nonumber
-\end{equation}
+\begin{equation*}
+\mathcal{E} = \phi\sum_{\beta}S_{\beta}\rho_{\beta}\mathcal{E}_{\beta},
+\end{equation*}
 where all variables are defined in [`nomenclature`](/porous_flow/nomenclature.md).
 
 The phases that the heat energy is summed over can be entered in the `phase` input
 parameter. Multiple indices can be entered.
 
 By default, the additional heat energy due to the porous material
-\begin{equation}
-(1-\phi)\rho_{R}C_{R}T \nonumber
-\end{equation}
+\begin{equation*}
+(1-\phi)\rho_{R}C_{R}T
+\end{equation*}
 is added to the heat energy of the fluid phase(s). This contribution can be ignored
 by setting `include_porous_skeleton = false`.
 

--- a/docs/content/documentation/systems/UserObjects/porous_flow/PorousFlowCapillaryPressureVG.md
+++ b/docs/content/documentation/systems/UserObjects/porous_flow/PorousFlowCapillaryPressureVG.md
@@ -3,25 +3,22 @@
 
 van Genuchten's capillary-pressure relationship \citep{vangenuchten1980}
 
-\begin{eqnarray}
-S_{\mathrm{eff}} & = & \left\{
-\begin{array}{ll}
-1 & \mbox{if } P \geq 0 \ , \\
-(1 + (-\alpha P)^{1/(1-m)})^{-m} & \mbox{if } P < 0\ .
+\begin{equation}
+S_{\mathrm{eff}} =
+\begin{cases}
+1 & \textrm{if } P \geq 0 \ , \\
+(1 + (-\alpha P)^{1/(1-m)})^{-m} & \textrm{if } P < 0 \ .
+\end{cases}
 \label{eq:vg_cap}
-\end{array}
-\right.
-\end{eqnarray}
+\end{equation}
 or
-\begin{eqnarray}
-P_{c} & = & \left\{
-\begin{array}{ll}
-0 & \mbox{if } S_{\mathrm{eff}} >= 1.0 \ , \\
-\frac{1}{\alpha} (S_{\mathrm{eff}}^{-1/m} - 1)^{1 - m} & \mbox{if }
-S_{\mathrm{eff}} < 1
-\end{array}
-\right.
-\end{eqnarray}
+\begin{equation}
+P_{c} =
+\begin{cases}
+0 & \textrm{if } S_{\mathrm{eff}} >= 1.0 \ , \\
+\frac{1}{\alpha} (S_{\mathrm{eff}}^{-1/m} - 1)^{1 - m} & \textrm{if } S_{\mathrm{eff}} < 1
+\end{cases}
+\end{equation}
 
 The effective saturation has been denoted by $S_{\mathrm{eff}}$ and
 $P$ is the porepressure, which is the *negative* of the capillary


### PR DESCRIPTION
Replace LaTeX commands with working equivalents.

Basically
`\begin{eqnarray} ... \end{eqnarray}` to `\begin{aligned} ... \end{aligned}`
`\mbox` to `\textrm`
and `equation` to `equation*` instead of using `\nonumber`

Closes #10023