### PR TITLE
Improve camel case to space handling

### DIFF
--- a/python/MooseDocs/extensions/template.py
+++ b/python/MooseDocs/extensions/template.py
@@ -16,7 +16,6 @@
 import os
 import copy
 import logging
-import re
 
 import jinja2
 import bs4
@@ -252,14 +251,7 @@ class TemplatePostprocessorBase(Postprocessor):
         """
         Create the breadcumb display name (i.e., separate camel case).
         """
-        out = []
-        index = 0
-        text = node.display
-        for match in re.finditer(r'[A-Z](?![A-Z])', text):
-            out.append(text[index:match.start(0)])
-            index = match.start(0)
-        out.append(text[index:])
-        return ' '.join(out)
+        return mooseutils.camel_to_space(node.display)
 
 class TemplatePostprocessor(TemplatePostprocessorBase):
     """

--- a/python/MooseDocs/tests/template/test_template.py
+++ b/python/MooseDocs/tests/template/test_template.py
@@ -89,7 +89,7 @@ class TestTemplateDisplay(MarkdownTestCase):
         root = moose_docs_file_tree({'framework': config})
         node = root.findall('/KKSMultiComponentExample')[0]
         html = self.parser.convert(node)
-        self.assertIn('<a class="breadcrumb" href="index.html">KKS Multi Component Example</a>',
+        self.assertIn('<a class="breadcrumb" href="index.html">KKSMulti Component Example</a>',
                       html)
 
 

--- a/python/mooseutils/__init__.py
+++ b/python/mooseutils/__init__.py
@@ -1,4 +1,5 @@
-from mooseutils import colorText, str2bool, find_moose_executable, runExe, check_configuration, touch, unique_list, gold, make_chunks, check_file_size
+from mooseutils import colorText, str2bool, find_moose_executable, runExe, check_configuration
+from mooseutils import touch, unique_list, gold, make_chunks, check_file_size, camel_to_space
 from message import mooseDebug, mooseWarning, mooseMessage, mooseError
 from MooseException import MooseException
 try:

--- a/python/mooseutils/mooseutils.py
+++ b/python/mooseutils/mooseutils.py
@@ -220,3 +220,15 @@ def check_file_size(base=os.getcwd(), size=1, ignore=None):
             if result.st_size > size:
                 output.append(FileInfo(name=filename, size=result.st_size/(1024.**2)))
     return output
+
+def camel_to_space(text):
+    """
+    Converts the supplied camel case text to space separated words.
+    """
+    out = []
+    index = 0
+    for match in re.finditer(r'(?<=[a-z])(?=[A-Z])', text):
+        out.append(text[index:match.start(0)])
+        index = match.start(0)
+    out.append(text[index:])
+    return ' '.join(out)

--- a/python/mooseutils/tests/test_camel_to_space.py
+++ b/python/mooseutils/tests/test_camel_to_space.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import unittest
+from mooseutils import camel_to_space
+
+class TestCamelCaseToSpace(unittest.TestCase):
+    """
+    Test that the size function returns something.
+    """
+    def assertInvert(self, text, gold):
+        self.assertEqual(camel_to_space(text), gold)
+
+    def testBasic(self):
+        self.assertInvert('ThisIsSomethingLong', 'This Is Something Long')
+        self.assertInvert('EBSD', 'EBSD')
+        self.assertInvert('ICs', 'ICs')
+        self.assertInvert('lowerUpper', 'lower Upper')
+        self.assertInvert('lowerXYZupper', 'lower XYZupper')
+        self.assertInvert('UpperXYZ', 'Upper XYZ')
+
+
+if __name__ == '__main__':
+    unittest.main(module=__name__, verbosity=2, buffer=True, exit=False)

--- a/python/mooseutils/tests/tests
+++ b/python/mooseutils/tests/tests
@@ -28,4 +28,8 @@
     separate = True
   [../]
 
+  [./camel]
+    type = PythonUnitTest
+    input = test_camel_to_space.py
+  [../]
 []


### PR DESCRIPTION
The changes in #9991 didn't convert correctly certain page names ("EBSD" and "ICs"), this change fixes that and creates unittest for the conversion.
(refs #7409)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
