### PR TITLE
Standard finite difference preconditioner: fix valgrind issues 

### DIFF
--- a/framework/include/base/NonlinearSystem.h
+++ b/framework/include/base/NonlinearSystem.h
@@ -93,6 +93,8 @@ private:
   * method.
   */
   void setupColoringFiniteDifferencedPreconditioner();
+
+  bool _use_coloring_finite_difference;
 };
 
 #endif /* NONLINEARSYSTEM_H */


### PR DESCRIPTION
Fix valgrind when using standard finite difference preconditioner. We do not need to call `MatFDColoringDestroy` for standard FDP.

Refs  #5819
