### PR TITLE
Initialize _default_value_zero

### DIFF
--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -65,7 +65,7 @@ Coupleable::Coupleable(const MooseObject * moose_object, bool nodal)
           std::numeric_limits<unsigned int>::max() - _optional_var_index.size();
   }
 
-  _default_value_zero.resize(_coupleable_max_qps);
+  _default_value_zero.resize(_coupleable_max_qps, 0);
   _default_gradient.resize(_coupleable_max_qps);
   _default_second.resize(_coupleable_max_qps);
 }


### PR DESCRIPTION
Initialize `_default_value_zero` in `Coupleable` which was previously never initialized before use.

Closes #10047 
