### PR TITLE
Skipped re dependencies

### DIFF
--- a/python/FactorySystem/InputParameters.py
+++ b/python/FactorySystem/InputParameters.py
@@ -45,6 +45,11 @@ class InputParameters:
     def __contains__(self, item):
         return item in self.desc
 
+    def get(self, key, default=None):
+        if self.isValid(key):
+            return self[key]
+        return default
+
     def __getitem__(self, key):
         return self.valid[key]
 

--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -1,7 +1,14 @@
 #!/usr/bin/python
 
-import os, re, time
-import hit
+from __future__ import print_function
+
+import os, re, time, sys
+
+try:
+    import hit
+except:
+    print('failed to import hit - you may need to (re)build moose.', file=sys.stderr)
+    sys.exit(1)
 
 class DupWalker(object):
     def __init__(self, fname):
@@ -41,55 +48,36 @@ class Parser:
         self.params_ignored = set()
         self._check_for_type = check_for_type
         self.root = None
-
-    """
-    Parse the passed filename filling the warehouse with populated InputParameter objects
-    Error codes:
-      0x00 - Success
-      0x01 - pyGetpot parsing error
-      0x02 - Unrecogonized Boolean key/value pair
-      0x04 - Missing required parameter
-      0x08 - Bad value
-      0x10 - Mismatched type
-      0x20 - Missing Node type parameter
-      0x40 - Tester creation failed
-
-      If new error codes are added, the static mask value needs to be adjusted
-    """
-    @staticmethod
-    def getErrorCodeMask():
-        # See Error codes description above for mask calculation
-        return 0x7F
+        self.errors = []
+        self.fname = ''
 
     def parse(self, filename):
-        error_code = 0x00
-
         with open(filename, 'r') as f:
             data = f.read()
+
+        self.fname = os.path.abspath(filename)
 
         try:
             root = hit.parse(os.path.abspath(filename), data)
         except Exception as err:
-            print(err)
-            return 0x01 # Parse Error
+            self.errors.append('{}'.format(err))
+            return
         self.root = root
 
         w = DupWalker(os.path.abspath(filename))
         root.walk(w, hit.NodeType.All)
-        for err in w.errors:
-            print err
-            error_code = 1
+        self.errors.extend(w.errors)
 
-        error_code = self._parseNode(filename, root)
+        self._parseNode(filename, root)
 
-        if len(self.params_ignored):
-            print 'Warning detected when parsing file "' + os.path.join(os.getcwd(), filename) + '"'
-            print '       Ignored Parameter(s): ', self.params_ignored
+        if len(self.params_ignored) > 0:
+            self.error('unused parameter(s): {}'.format(self.params_ignored))
 
-        return error_code
+    def error(self, msg):
+        self.errors.append(self.fname + ": " + msg)
 
     def extractParams(self, filename, params, getpot_node):
-        error_code = 0x00
+        have_err = False
         full_name = getpot_node.fullpath()
 
         # Populate all of the parameters of this test node
@@ -119,13 +107,11 @@ class Parser:
                                 try:
                                     params[key] = time.strptime(value, "%m/%d/%Y")
                                 except ValueError:
-                                    print "Bad Value for key '" + full_name + '/' + key + "': " + value
-                                    params['error_code'] = 0x08
-                                    error_code = error_code | params['error_code']
+                                    self.error("bad Value for key '" + full_name + '/' + key + "': " + value)
+                                    have_err = True
                             elif strict_type != type(value):
-                                print "Mismatched type for key '" + full_name + '/' + key + "': " + value
-                                params['error_code'] = 0x10
-                                error_code = error_code | params['error_code']
+                                self.error("mismatched type for key '" + full_name + '/' + key + "': " + value)
+                                have_err = True
 
                         # Prevent bool types from being stored as strings.  This can lead to the
                         # strange situation where string('False') evaluates to true...
@@ -136,9 +122,8 @@ class Parser:
                             elif (value.lower()=='false') or (value=='0'):
                                 params[key] = False
                             else:
-                                print "Unrecognized (key,value) pair: (", key, ',', value, ")"
-                                params['error_code'] = 0x02
-                                error_code = error_code | params['error_code']
+                                self.error("unrecognized (key,value) pair: ({},{})".format(key, value))
+                                have_err = True
                         else:
                             # Otherwise, just do normal assignment
                             params[key] = value
@@ -147,18 +132,14 @@ class Parser:
 
         # Make sure that all required parameters are supplied
         required_params_missing = params.required_keys() - local_parsed
-        if len(required_params_missing):
-            print 'Error detected when parsing file "' + os.path.join(os.getcwd(), filename) + '"'
-            print '       Required Missing Parameter(s): ', required_params_missing
-            params['error_code'] = 0x04 # Missing required params
-            error_code = params['error_code']
+        if len(required_params_missing) > 0:
+            self.error('required missing parameter(s): {}'.format(required_params_missing))
+            have_err = True
 
-        return error_code
+        params['have_errors'] = have_err
 
     # private:
     def _parseNode(self, filename, node):
-        error_code = 0x00
-
         if node.find('type'):
             moose_type = node.param('type')
 
@@ -166,7 +147,7 @@ class Parser:
             params = self.factory.validParams(moose_type)
 
             # Extract the parameters from the Getpot node
-            error_code = error_code | self.extractParams(filename, params, node)
+            self.extractParams(filename, params, node)
 
             # Add factory and warehouse as private params of the object
             params.addPrivateParam('_factory', self.factory)
@@ -181,24 +162,19 @@ class Parser:
                 # Put it in the warehouse
                 self.warehouse.addObject(moose_object)
             except Exception as e:
-                print 'Error creating Tester in "' + os.path.join(os.getcwd(), filename) + '": ', e
-                error_code = error_code | 0x40
+                self.error('failed to create Tester: {}'.format(e))
 
         # Are we in a tree node that "looks" like it should contain a buildable object?
-        elif self._check_for_type and self._looksLikeValidSubBlock(node):
-            print 'Error detected when parsing file "' + os.path.join(os.getcwd(), filename) + '"'
-            print '       Missing "type" parameter in block'
-            error_code = error_code | 0x20
+        elif node.parent().fullpath() == 'Tests' and self._check_for_type and not self._looksLikeValidSubBlock(node):
+            self.error('missing "type" parameter in block "{}"'.format(node.fullpath()))
 
         # Loop over the section names and parse them
         for child in node.children(node_type=hit.NodeType.Section):
-            error_code = error_code | self._parseNode(filename, child)
-
-        return error_code
+            self._parseNode(filename, child)
 
     # This routine returns a Boolean indicating whether a given block
     # looks like a valid subblock. In the Testing system, a valid subblock
     # has a "type" and no children blocks.
     def _looksLikeValidSubBlock(self, node):
-        return len(node.children(node_type=hit.NodeType.Field)) \
-            and len(node.children(node_type=hit.NodeType.Section)) == 0
+        fields = [n.path() for n in node.children()]
+        return 'type' in fields and len(node.children(node_type=hit.NodeType.Section)) == 0

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -47,6 +47,7 @@ class TestHarness:
         # Finally load the plugins!
         self.factory.loadPlugins(dirs, 'testers', "IS_TESTER")
 
+        self.parse_errors = []
         self.test_table = []
         self.num_passed = 0
         self.num_failed = 0
@@ -142,7 +143,6 @@ class TestHarness:
     Recursively walks the current tree looking for tests to run
     Error codes:
     0x0  - Success
-    0x7F - Parser error (any flag in this range)
     0x80 - TestHarness error
     """
     def findAndRunTests(self, find_only=False):
@@ -200,7 +200,7 @@ class TestHarness:
 
             self.cleanup()
 
-            # Flags for the parser start at the low bit, flags for the TestHarness start at the high bit
+            # flags for the TestHarness start at the high bit
             if self.num_failed:
                 self.error_code = self.error_code | 0x80
 
@@ -222,7 +222,8 @@ class TestHarness:
         parser = Parser(self.factory, self.warehouse)
 
         # Parse it
-        self.error_code = self.error_code | parser.parse(file)
+        parser.parse(file)
+        self.parse_errors.extend(parser.errors)
 
         # Retrieve the tests from the warehouse
         testers = self.warehouse.getActiveObjects()
@@ -300,7 +301,7 @@ class TestHarness:
             tester.setStatus('Max Fails Exceeded', tester.bucket_fail)
         elif self.num_failed > self.options.max_fails:
             tester.setStatus('Max Fails Exceeded', tester.bucket_fail)
-        elif tester.parameters().isValid('error_code'):
+        elif tester.parameters().get('have_errors'):
             tester.setStatus('Parser Error', tester.bucket_skip)
 
     # This method splits a lists of tests into two pieces each, the first piece will run the test for
@@ -450,6 +451,11 @@ class TestHarness:
     def cleanup(self):
         # Print the results table again if a bunch of output was spewed to the screen between
         # tests as they were running
+        if len(self.parse_errors) > 0:
+            print('\n\nParser Errors:\n' + ('-' * (util.TERM_COLS-1)))
+            for err in self.parse_errors:
+                print(util.colorText(err, 'RED', html=True, colored=self.options.colored, code=self.options.code))
+
         if (self.options.verbose or (self.num_failed != 0 and not self.options.quiet)) and not self.options.dry_run:
             print('\n\nFinal Test Results:\n' + ('-' * (util.TERM_COLS-1)))
             for (tester_data, result, timing) in sorted(self.test_table, key=lambda x: x[1], reverse=True):
@@ -461,10 +467,11 @@ class TestHarness:
 
         # Mask off TestHarness error codes to report parser errors
         fatal_error = ''
-        if self.error_code & Parser.getErrorCodeMask():
-            fatal_error += ', <r>FATAL PARSER ERROR</r>'
-        if self.error_code & ~Parser.getErrorCodeMask():
+        if self.error_code:
             fatal_error += ', <r>FATAL TEST HARNESS ERROR</r>'
+        if len(self.parse_errors) > 0:
+            fatal_error += ', <r>FATAL PARSER ERROR</r>'
+            self.error_code = 1
 
         # Alert the user to their session file
         if self.options.queueing:

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -181,7 +181,10 @@ class Scheduler(MooseObject):
                 # Skipped Dependencies
                 except dag.DAGEdgeIndError:
                     if not self.skipPrereqs():
-                        tester.setStatus('skipped dependency', tester.bucket_skip)
+                        if self.options.reg_exp:
+                            tester.setStatus('dependency does not match re', tester.bucket_skip)
+                        else:
+                            tester.setStatus('skipped dependency', tester.bucket_skip)
                         failed_or_skipped_testers.add(tester)
 
                     # Add the parent node / dependency edge to create a functional DAG now that we have caught

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -8,6 +8,14 @@ class TestHarnessTestCase(unittest.TestCase):
     TestCase class for running TestHarness commands.
     """
 
+    def runExceptionTests(self, *args):
+        cmd = ['./run_tests'] + list(args)
+        try:
+            return subprocess.check_output(cmd, cwd=os.path.join(os.getenv('MOOSE_DIR'), 'test'))
+            raise RuntimeError('test failed to fail')
+        except Exception as err:
+            return err.output
+
     def runTests(self, *args):
         cmd = ['./run_tests'] + list(args)
         return subprocess.check_output(cmd, cwd=os.path.join(os.getenv('MOOSE_DIR'), 'test'))

--- a/python/TestHarness/tests/test_Syntax.py
+++ b/python/TestHarness/tests/test_Syntax.py
@@ -17,3 +17,7 @@ class TestHarnessTester(TestHarnessTestCase):
         # Check that SYNTAX PASS test was not run
         output = self.runTests('--check-input', '-i', 'no_syntax')
         self.assertNotIn('SYNTAX PASS', output)
+
+        # check that parser errors print correctly
+        output = self.runExceptionTests('--check-input', '-i', 'parse_errors')
+        self.assertIn('Parser Errors', output)


### PR DESCRIPTION
Print a more descriptive 'skipped dependency' message when this occurrence happens when 'silent' tests are the cause of the skipped dependency (--re options)