### PR TITLE
fix test harness timing printing bug

### DIFF
--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -90,6 +90,7 @@ class Job(object):
             self.__tester.setStatus(self.__tester.getSuccessMessage(), self.__tester.bucket_success)
             return
 
+        self.__start_time = clock()
         self.timer.reset()
         self.__tester.run(self.timer, self.options)
         self.__start_time = self.timer.starts[0]


### PR DESCRIPTION
This bug was introduced by #9775.  @milljm discovered that the test harness was printing pending/running job timings incorrectly.