### PR TITLE
Skip tests affected by superlu bug on Intel

### DIFF
--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
@@ -126,6 +126,7 @@
     abs_zero = 1e-4
     max_parallel = 1
     superlu = true
+    ignore_compiler = 'INTEL' #superlu bug, see MOOSE issue #10084
   [../]
   [./frictionless_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
@@ -114,6 +114,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
+    ignore_compiler = 'INTEL' #superlu bug, see MOOSE issue #10084
   [../]
   [./frictionless_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
@@ -11,6 +11,7 @@
     superlu = true
     prereq = 'glued_kin_sm'
     petsc_version = '>=3.7.6'
+    ignore_compiler = 'INTEL' #superlu bug, see MOOSE issue #10084
   [../]
   [./glued_pen]
     type = 'CSVDiff'


### PR DESCRIPTION
 ref #10084
This is just a temporary fix, and does not address the underlying issue.