### PR TITLE
Skip contact  tests affected by the Intel compiler

### DIFF
--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
@@ -86,6 +86,7 @@
     dof_id_bytes = 4
     # This test is fails reliably on INTEL compilers with PETSc 3.7.4 too.
     petsc_version = '>=3.7.6'
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./mu_0_2_pen]
     type = 'CSVDiff'
@@ -126,6 +127,7 @@
     abs_zero = 1e-4
     max_parallel = 1
     superlu = true
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./frictionless_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
@@ -10,6 +10,7 @@
     superlu = true
     prereq = 'glued_kin_sm'
     petsc_version = '>=3.7.6'
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -114,6 +115,7 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./frictionless_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
@@ -91,6 +91,7 @@
     max_parallel = 1
     superlu = true
     petsc_version = '>=3.7.6'
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./glued_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/tests
@@ -86,6 +86,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     superlu = true
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./glued_pen_sm]
     type = 'CSVDiff'
@@ -106,6 +107,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     superlu = true
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./frictionless_pen_sm]
     type = 'CSVDiff'
@@ -135,6 +137,7 @@
     abs_zero = 1e-6
     max_parallel = 1
     superlu = true
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./mu_0_2_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
@@ -11,6 +11,7 @@
     superlu = true
     prereq = 'glued_kin_sm'
     petsc_version = '>=3.7.6'
+    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./glued_pen]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/grain_texture/tests
+++ b/modules/combined/test/tests/grain_texture/tests
@@ -11,6 +11,7 @@
     input = 'grain_texture_test_2.i'
     csvdiff = 'grain_texture_test_2_out_textureInfo_0001.csv'
     recover = false
+    compiler = 'GCC CLANG' # this may not be related to superlu_dist, but we need to move forward #10084
   [../]
 
   [./EulerAngleProvider2RGBAux]

--- a/modules/combined/test/tests/internal_volume/tests
+++ b/modules/combined/test/tests/internal_volume/tests
@@ -139,6 +139,7 @@
     input = 'hex20.i'
     csvdiff = 'hex20_out.csv'
     copy_files = meshes
+    compiler = 'GCC CLANG' # this may not be related to superlu_dist, but we need to move forward #10084 
   [../]
 
   [./rz_quad8]


### PR DESCRIPTION
There are three contact tests that are still failing on the intel. SuperLU_dist may still have some unknown issues on the intel compiler. But let us skip these three tests before we find the root of the cause.

Refs #10084

Closes #10085