### PR TITLE
hit: speed up parsing hugely by fixing line-number calculation

### DIFF
--- a/framework/contrib/hit/Makefile
+++ b/framework/contrib/hit/Makefile
@@ -2,7 +2,7 @@
 CXX ?= g++
 
 hit: main.cc parse.cc lex.cc lex.h parse.h
-	$(CXX) -std=c++11 -g $< parse.cc lex.cc -o $@
+	$(CXX) -std=c++11 -g $(CXXFLAGS) $< parse.cc lex.cc -o $@
 
 bindings: hit.so
 

--- a/framework/contrib/hit/lex.cc
+++ b/framework/contrib/hit/lex.cc
@@ -30,16 +30,16 @@ charIn(char c, const std::string & valid)
 #undef EOF
 
 int
-lineNum(size_t offset, const std::string & input)
+lineCount(const std::string & input)
 {
-  int line = 0;
-  size_t pos = input.find("\n", 0); // fist occurrence
-  while (pos < offset)
+  int n = 0;
+  size_t pos = input.find("\n", 0); // first occurrence
+  while (pos < std::string::npos)
   {
-    line++;
+    n++;
     pos = input.find("\n", pos + 1);
   }
-  return line + 1;
+  return n;
 }
 
 std::string
@@ -99,15 +99,24 @@ Lexer::run(LexFunc start)
 void
 Lexer::emit(TokType type)
 {
-  _tokens.push_back(
-      Token(type, _input.substr(_start, _pos - _start), _start, lineNum(_start, _input)));
+  auto substr = _input.substr(_start, _pos - _start);
+  _tokens.push_back(Token(type, substr, _start, _line_count));
+  _line_count += lineCount(substr);
+  _start = _pos;
+}
+
+void
+Lexer::ignore()
+{
+  auto substr = _input.substr(_start, _pos - _start);
+  _line_count += lineCount(substr);
   _start = _pos;
 }
 
 LexFunc
 Lexer::error(const std::string & msg)
 {
-  _tokens.push_back(Token(TokType::Error, msg, _start, lineNum(_start, _input)));
+  _tokens.push_back(Token(TokType::Error, msg, _start, _line_count));
   return nullptr;
 }
 
@@ -158,11 +167,6 @@ Lexer::peek()
   return c;
 }
 
-void
-Lexer::ignore()
-{
-  _start = _pos;
-}
 void
 Lexer::backup()
 {

--- a/framework/contrib/hit/lex.h
+++ b/framework/contrib/hit/lex.h
@@ -138,6 +138,7 @@ public:
   size_t pos();
 
 private:
+  int _line_count = 1;
   std::string _name;
   std::string _input;
   size_t _start = 0;


### PR DESCRIPTION
This changes the naive N^2 algorithm during lexing where we read through the
entire file to calculate the line number for every token we emit.  Instead, we
now keep a running total line count and don't have to ready through the file
more than once.

Fixes #10091

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
