### PR TITLE
Added s(h,p) interface to single-phase fluid properties

### DIFF
--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -33,6 +33,7 @@ public:
   virtual Real mu(Real v, Real u) const override;
   virtual Real k(Real v, Real u) const override;
   virtual Real s(Real v, Real u) const override;
+  virtual void s_from_h_p(Real h, Real p, Real & s, Real & ds_dh, Real & ds_dp) const override;
   virtual void
   dp_duv(Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const override;
 

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -42,6 +42,8 @@ public:
   virtual Real k(Real v, Real u) const = 0;
   /// Specific entropy [ J / kg K ]
   virtual Real s(Real v, Real u) const = 0;
+  /// Specific entropy from enthalpy and pressure
+  virtual void s_from_h_p(Real h, Real p, Real & s, Real & ds_dh, Real & ds_dp) const = 0;
   /// The derivative of pressure wrt specific volume and specific internal energy
   virtual void
   dp_duv(Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const = 0;

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -33,6 +33,7 @@ public:
   virtual Real mu(Real v, Real u) const override;
   virtual Real k(Real v, Real u) const override;
   virtual Real s(Real v, Real u) const override;
+  virtual void s_from_h_p(Real h, Real p, Real & s, Real & ds_dh, Real & ds_dp) const override;
   virtual void
   dp_duv(Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const override;
 

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -78,6 +78,22 @@ Real IdealGasFluidProperties::s(Real, Real) const
 }
 
 void
+IdealGasFluidProperties::s_from_h_p(Real h, Real p, Real & s, Real & ds_dh, Real & ds_dp) const
+{
+  const Real aux = p * std::pow(h / (_gamma * _cv), -_gamma / (_gamma - 1));
+  if (aux <= 0.0)
+    mooseError(name(), ": Non-positive argument in the ln() function.");
+
+  const Real daux_dh = p * std::pow(h / (_gamma * _cv), -_gamma / (_gamma - 1) - 1) *
+                       (-_gamma / (_gamma - 1)) / (_gamma * _cv);
+  const Real daux_dp = std::pow(h / (_gamma * _cv), -_gamma / (_gamma - 1));
+
+  s = -(_gamma - 1) * _cv * std::log(aux);
+  ds_dh = -(_gamma - 1) * _cv / aux * daux_dh;
+  ds_dp = -(_gamma - 1) * _cv / aux * daux_dp;
+}
+
+void
 IdealGasFluidProperties::dp_duv(
     Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const
 {

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -78,6 +78,23 @@ StiffenedGasFluidProperties::s(Real v, Real u) const
 }
 
 void
+StiffenedGasFluidProperties::s_from_h_p(Real h, Real p, Real & s, Real & ds_dh, Real & ds_dp) const
+{
+  const Real aux = (p + _p_inf) * std::pow((h - _q) / (_gamma * _cv), -_gamma / (_gamma - 1));
+  if (aux <= 0.0)
+    mooseError(name(), ": Non-positive argument in the ln() function.");
+
+  const Real daux_dh = (p + _p_inf) *
+                       std::pow((h - _q) / (_gamma * _cv), -_gamma / (_gamma - 1) - 1) *
+                       (-_gamma / (_gamma - 1)) / (_gamma * _cv);
+  const Real daux_dp = std::pow((h - _q) / (_gamma * _cv), -_gamma / (_gamma - 1));
+
+  s = _q_prime - (_gamma - 1) * _cv * std::log(aux);
+  ds_dh = -(_gamma - 1) * _cv / aux * daux_dh;
+  ds_dp = -(_gamma - 1) * _cv / aux * daux_dp;
+}
+
+void
 StiffenedGasFluidProperties::dp_duv(
     Real v, Real u, Real & dp_dv, Real & dp_du, Real & dT_dv, Real & dT_du) const
 {

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -121,4 +121,27 @@ TEST_F(IdealGasFluidPropertiesTest, testAll)
     ABS_TEST("dh_dp", dh_dp, dh_dp_fd, 1e-12);
     ABS_TEST("dh_dT", dh_dT, dh_dT_fd, 6e-7);
   }
+
+  {
+    // entropy from enthalpy and pressure
+    const Real rel_diff = 1e-6;
+    const Real h = 1e5;
+    const Real p = 1e5;
+    const Real dh = h * rel_diff;
+    const Real dp = p * rel_diff;
+
+    Real s, ds_dh, ds_dp;
+    _fp->s_from_h_p(h, p, s, ds_dh, ds_dp);
+
+    Real s_dh, s_dp, ds_dh_dummy, ds_dp_dummy;
+    _fp->s_from_h_p(h + dh, p, s_dh, ds_dh_dummy, ds_dp_dummy);
+    _fp->s_from_h_p(h, p + dp, s_dp, ds_dh_dummy, ds_dp_dummy);
+
+    const Real ds_dh_fd = (s_dh - s) / dh;
+    const Real ds_dp_fd = (s_dp - s) / dp;
+
+    const Real rel_tol = 1e-5;
+    REL_TEST("ds_dh", ds_dh, ds_dh_fd, rel_tol);
+    REL_TEST("ds_dp", ds_dp, ds_dp_fd, rel_tol);
+  }
 }

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -142,4 +142,27 @@ TEST_F(StiffenedGasFluidPropertiesTest, testAll)
     REL_TEST("de_dp", de_dp, de_dp_fd, 2e-4);
     REL_TEST("de_ds", de_ds, de_ds_fd, 3e-8);
   }
+
+  {
+    // entropy from enthalpy and pressure
+    const Real rel_diff = 1e-6;
+    const Real h = 1e5;
+    const Real p = 1e5;
+    const Real dh = h * rel_diff;
+    const Real dp = p * rel_diff;
+
+    Real s, ds_dh, ds_dp;
+    _fp->s_from_h_p(h, p, s, ds_dh, ds_dp);
+
+    Real s_dh, s_dp, ds_dh_dummy, ds_dp_dummy;
+    _fp->s_from_h_p(h + dh, p, s_dh, ds_dh_dummy, ds_dp_dummy);
+    _fp->s_from_h_p(h, p + dp, s_dp, ds_dh_dummy, ds_dp_dummy);
+
+    const Real ds_dh_fd = (s_dh - s) / dh;
+    const Real ds_dp_fd = (s_dp - s) / dp;
+
+    const Real rel_tol = 1e-5;
+    REL_TEST("ds_dh", ds_dh, ds_dh_fd, rel_tol);
+    REL_TEST("ds_dp", ds_dp, ds_dp_fd, rel_tol);
+  }
 }


### PR DESCRIPTION
This adds an interface for entropy as a function of enthalpy and
pressure to single-phase fluid property classes.

Closes #10094
