### PR TITLE
Run RandomIC based tests in serial on one thread

### DIFF
--- a/modules/phase_field/test/tests/phase_field_crystal/PFCRFF/tests
+++ b/modules/phase_field/test/tests/phase_field_crystal/PFCRFF/tests
@@ -3,17 +3,26 @@
     type = 'Exodiff'
     input = 'PFCRFF_tolerance_test.i'
     exodiff = 'PFCRFF_tolerance_test_out.e'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
 
   [./cancelation_test]
     type = 'Exodiff'
     input = 'PFCRFF_cancelation_test.i'
     exodiff = 'PFCRFF_cancelation_test_out.e'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
 
   [./expansion_test]
     type = 'Exodiff'
     input = 'PFCRFF_expansion_test.i'
     exodiff = 'PFCRFF_expansion_test_out.e'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
 []

--- a/modules/phase_field/test/tests/phase_field_crystal/PFCTrad/tests
+++ b/modules/phase_field/test/tests/phase_field_crystal/PFCTrad/tests
@@ -3,5 +3,8 @@
     type = 'Exodiff'
     input = 'PFCTrad_test.i'
     exodiff = 'PFCTrad_test_out.e'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
 []

--- a/modules/porous_flow/test/tests/heterogeneous_materials/tests
+++ b/modules/porous_flow/test/tests/heterogeneous_materials/tests
@@ -3,11 +3,17 @@
     type = 'Exodiff'
     input = 'constant_poroperm.i'
     exodiff = 'constant_poroperm_out.e'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
   [./constant_poroperm2]
     type = 'Exodiff'
     input = 'constant_poroperm2.i'
     exodiff = 'constant_poroperm2_out.e'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
   [./vol_expansion_poroperm]
     type = Exodiff

--- a/modules/tensor_mechanics/test/tests/multi/tests
+++ b/modules/tensor_mechanics/test/tests/multi/tests
@@ -263,6 +263,9 @@
     rel_err = 1.0E-4
     abs_zero = 1.0E-4
     cli_args = '--no-trap-fpe Mesh/nx=1 Mesh/ny=12 Mesh/xmax=1 Mesh/ymax=12'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
   [./paper5]
     type = CSVDiff
@@ -280,6 +283,9 @@
     rel_err = 1.0E-4
     abs_zero = 1.0E-4
     cli_args = '--no-trap-fpe Mesh/nx=1 Mesh/ny=125 Mesh/xmax=1 Mesh/ymax=125'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
   [./special_joint1]
     type = CSVDiff
@@ -288,6 +294,9 @@
     rel_err = 1.0E-4
     abs_zero = 1.0E-4
     cli_args = '--no-trap-fpe Mesh/nx=1 Mesh/ny=125 Mesh/xmax=1 Mesh/ymax=125'
+# Run in serial so RandomIC gets fixed PRNG results
+    max_parallel = 1
+    max_threads  = 1
   [../]
     
 []


### PR DESCRIPTION
If I'm correctly understanding #5567 and the code, we still don't
expect that InitialCondition to give us reproduceable results with
more than one MPI rank or more than one thread.

There are lots of other RandomIC based tests which I'm leaving enabled
in parallel, at least for now, because they passed for me with -p 2.
The ones I glanced at are *expected* to succeed in parallel, because
they use eigensolves or only test jacobians of linear kernels or are
in some other way independent of initial conditions.  So, I'm not
going to force any RandomIC test to serial until I actually *see* it
fail in parallel.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
