### PR TITLE
hit: fix compile/link errors due to wonky python config cflags

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -33,13 +33,9 @@ hit_deps      := $(patsubst %.cc, %.$(obj-suffix).d, $(hit_srcfiles))
 pyhit_srcfiles  := $(hit_DIR)/hit.cpp $(hit_DIR)/lex.cc $(hit_DIR)/parse.cc
 pyhit_LIB       := $(hit_DIR)/hit.so
 
-# the sed to remove arch i386 from flags is because on macs the system python is built with
-# (some?) 32 bit support and those flags cause problems when linking on systems that don't
-# have 32 bit libraries to link in for the whole stack (i.e. stdlib, etc.).  Apple - why you
-# do that?
 $(pyhit_LIB): $(pyhit_srcfiles)
 	@echo "Linking Library "$@"..."
-	@bash -c '(cd "$(hit_DIR)" && $(libmesh_CXX) -std=c++11 -w -fPIC -lstdc++ -shared -L`python-config --prefix`/lib `python-config --cflags | sed "s/-arch i386//"` `python-config --ldflags` $^ -o $@)'
+	@bash -c '(cd "$(hit_DIR)" && $(libmesh_CXX) -std=c++11 -w -fPIC -lstdc++ -shared -L`python-config --prefix`/lib `python-config --includes` `python-config --ldflags` $^ -o $@)'
 	@cp $@ $(FRAMEWORK_DIR)/../python/
 
 #


### PR DESCRIPTION
Using the Mac's default system python on a machine with no 32 bit
developer libraries installed (e.g. 32 bit compatible c++ stdlib), if
you try to build MOOSE the step that builds/links the python hit
bindings fails with linker errors. The python-config --cflags output
contains a -arch i386 entry that we don't want.  Also, on newer versions of
ubuntu, the python-config --cflags outputs some flags that didn't exist
on gcc 4.8.4.  So we switch to only using python-config --includes and
--ldflags to avoid such problems.

fixes #10102

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
