### PR TITLE
materials: fix deprecation message in declarePropertyOld[er]

### DIFF
--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -377,8 +377,9 @@ template <typename T>
 MaterialProperty<T> &
 Material::declarePropertyOld(const std::string & prop_name)
 {
-  mooseDoOnce(mooseDeprecated("declarePropertyOld is deprecated and not needed anymore.\nUse "
-                              "getPropertyOld (only) if a reference is required in this class."));
+  mooseDoOnce(
+      mooseDeprecated("declarePropertyOld is deprecated and not needed anymore.\nUse "
+                      "getMaterialPropertyOld (only) if a reference is required in this class."));
   registerPropName(prop_name, false, Material::OLD);
   return _material_data->declarePropertyOld<T>(prop_name);
 }
@@ -387,8 +388,9 @@ template <typename T>
 MaterialProperty<T> &
 Material::declarePropertyOlder(const std::string & prop_name)
 {
-  mooseDoOnce(mooseDeprecated("declarePropertyOlder is deprecated and not needed anymore.  Use "
-                              "getPropertyOlder (only) if a reference is required in this class."));
+  mooseDoOnce(
+      mooseDeprecated("declarePropertyOlder is deprecated and not needed anymore.  Use "
+                      "getMaterialPropertyOlder (only) if a reference is required in this class."));
   registerPropName(prop_name, false, Material::OLDER);
   return _material_data->declarePropertyOlder<T>(prop_name);
 }


### PR DESCRIPTION
fixes #10089

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
