### PR TITLE
10083 petsc

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -854,8 +854,11 @@ colorAdjacencyMatrix(PetscScalar * adjacency_matrix,
 #endif
              &A);
 
-  MatColoring mc;
   ISColoring iscoloring;
+#if PETSC_VERSION_LESS_THAN(3, 5, 0)
+  MatGetColoring(A, coloring_algorithm, &iscoloring);
+#else
+  MatColoring mc;
   MatColoringCreate(A, &mc);
   MatColoringSetType(mc, coloring_algorithm);
   MatColoringSetMaxColors(mc, static_cast<PetscInt>(colors));
@@ -864,6 +867,7 @@ colorAdjacencyMatrix(PetscScalar * adjacency_matrix,
   MatColoringSetDistance(mc, 1);
   MatColoringSetFromOptions(mc);
   MatColoringApply(mc, &iscoloring);
+#endif
 
   PetscInt nn;
   IS * is;
@@ -885,7 +889,9 @@ colorAdjacencyMatrix(PetscScalar * adjacency_matrix,
   }
 
   MatDestroy(&A);
+#if !PETSC_VERSION_LESS_THAN(3, 5, 0)
   MatColoringDestroy(&mc);
+#endif
   ISColoringDestroy(&iscoloring);
 }
 

--- a/test/tests/mesh/subdomain_partitioner/tests
+++ b/test/tests/mesh/subdomain_partitioner/tests
@@ -21,5 +21,6 @@
     min_parallel = 4
     max_parallel = 4
     petsc_version_release = true
+    petsc_version = '>=3.5.0'
   [../]
 []

--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -46,6 +46,7 @@
     # This tests sometimes reports an incorrect jacobian when run
     # with multiple threads.
     max_threads = 1
+    petsc_version = '>=3.5.0'
   [../]
   [./shape_side_uo_physics_test]
     type = 'Exodiff'


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
These changes allow a stable but older version of Petsc (v3.4.5) to be used by Moose. This version of Petsc is needed for coupling work between Moose and the Proteus-SN solver (Argonne National Lab). The changes include:

- Updating the Matrix Coloring routine to support v3.4.5
- Modifying the tolerances of the FD Jacobian test
- Modifying the subdomain partitioner test to be skipped when using a Petsc version less than 3.5.0.

closes issue #10083 