### PR TITLE
Fix peacock trying to save an invalid input filename

### DIFF
--- a/python/peacock/Input/InputFileEditor.py
+++ b/python/peacock/Input/InputFileEditor.py
@@ -158,14 +158,14 @@ class InputFileEditor(QWidget, MooseWidget):
         Input:
             filename: Where to write the file.
         """
-        if not self.tree.app_info.valid():
+        if not self.tree.app_info.valid() or not filename:
             return
         content = self.tree.getInputFileString()
         try:
-          with open(filename, "w") as f:
-              f.write(content)
+            with open(filename, "w") as f:
+                f.write(content)
         except IOError as e:
-          mooseutils.mooseWarning("Failed to write input file %s: %s" % (filename, e))
+            mooseutils.mooseWarning("Failed to write input file %s: %s" % (filename, e))
 
 if __name__ == "__main__":
     from PyQt5.QtWidgets import QApplication, QMainWindow

--- a/python/peacock/Input/InputFileEditorPlugin.py
+++ b/python/peacock/Input/InputFileEditorPlugin.py
@@ -54,7 +54,7 @@ class InputFileEditorPlugin(InputFileEditor, Plugin):
         self.has_changed = True
 
     def _askToSave(self, app_info, reason):
-        if self.has_changed and app_info.valid():
+        if self.has_changed and app_info.valid() and self.tree and self.tree.input_filename:
             msg = "%s\nYou have unsaved changes in your input file, do you want to save?" % reason
             reply = QMessageBox.question(self, "Save?", msg, QMessageBox.Save, QMessageBox.Discard)
             if reply == QMessageBox.Save:


### PR DESCRIPTION
If the user just starts editing an input file then
does a "Save As", it passes None into the filename.
This bug was introduced in #10006

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
