### PR TITLE
Constant-in-time guarantee fixed

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeCosseratElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCosseratElasticityTensor.C
@@ -31,8 +31,8 @@ ComputeCosseratElasticityTensor::ComputeCosseratElasticityTensor(const InputPara
     _elastic_flexural_rigidity_tensor(
         declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor"))
 {
-  // all tensors created by this class are always constant in time
-  issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
+  if (!isParamValid("elasticity_tensor_prefactor"))
+    issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTensor.C
@@ -24,8 +24,8 @@ ComputeElasticityTensor::ComputeElasticityTensor(const InputParameters & paramet
     _Cijkl(getParam<std::vector<Real>>("C_ijkl"),
            (RankFourTensor::FillMethod)(int)getParam<MooseEnum>("fill_method"))
 {
-  // all tensors created by this class are always constant in time
-  issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
+  if (!isParamValid("elasticity_tensor_prefactor"))
+    issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
 
   if (_Cijkl.isIsotropic())
     issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);

--- a/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIsotropicElasticityTensor.C
@@ -39,9 +39,10 @@ ComputeIsotropicElasticityTensor::ComputeIsotropicElasticityTensor(
   if (num_elastic_constants != 2)
     mooseError("Exactly two elastic constants must be defined for material '" + name() + "'.");
 
-  // all tensors created by this class are always isotropic and constant in time
+  // all tensors created by this class are always isotropic
   issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);
-  issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
+  if (!isParamValid("elasticity_tensor_prefactor"))
+    issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
 
   if (_bulk_modulus_set && _bulk_modulus <= 0.0)
     mooseError("Bulk modulus must be positive in material '" + name() + "'.");

--- a/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLayeredCosseratElasticityTensor.C
@@ -38,8 +38,8 @@ ComputeLayeredCosseratElasticityTensor::ComputeLayeredCosseratElasticityTensor(
         declareProperty<RankFourTensor>("elastic_flexural_rigidity_tensor")),
     _compliance(declareProperty<RankFourTensor>(_base_name + "compliance_tensor"))
 {
-  // all tensors created by this class are always constant in time
-  issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
+  if (!isParamValid("elasticity_tensor_prefactor"))
+    issueGuarantee(_elasticity_tensor_name, Guarantee::CONSTANT_IN_TIME);
 
   const Real E = getParam<Real>("young");
   const Real nu = getParam<Real>("poisson");


### PR DESCRIPTION
Now elasticity tensors only issue the CONSTANT_IN_TIME Guarantee if they have no prefactor.

Fixes #9749