### PR TITLE
Rotating, straining and stressing

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -146,7 +146,7 @@ ComputeMultipleInelasticStress::computeQpStressIntermediateConfiguration()
 
     // If the elasticity tensor values have changed and the tensor is isotropic,
     // use the old strain to calculate the old stress
-    if (_is_elasticity_tensor_guaranteed_isotropic)
+    if (_is_elasticity_tensor_guaranteed_isotropic || !_perform_finite_strain_rotations)
     {
       _stress[_qp] = _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + _strain_increment[_qp]);
       // InitialStress Deprecation: remove these lines
@@ -224,7 +224,7 @@ ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_inc
           elastic_strain_increment -= inelastic_strain_increment[j_rmm];
 
       // form the trial stress, with the check for changed elasticity constants
-      if (_is_elasticity_tensor_guaranteed_isotropic)
+      if (_is_elasticity_tensor_guaranteed_isotropic || !_perform_finite_strain_rotations)
       {
         _stress[_qp] =
             _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + elastic_strain_increment);
@@ -335,7 +335,7 @@ ComputeMultipleInelasticStress::updateQpStateSingleModel(
 
   // If the elasticity tensor values have changed and the tensor is isotropic,
   // use the old strain to calculate the old stress
-  if (_is_elasticity_tensor_guaranteed_isotropic)
+  if (_is_elasticity_tensor_guaranteed_isotropic || !_perform_finite_strain_rotations)
   {
     _stress[_qp] = _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + elastic_strain_increment);
     // InitialStress Deprecation: remove these lines


### PR DESCRIPTION
strain_old is used to calculate stress when not performing finite-strain rotations.

In issue #10116 i mooted 2 possibilities for extending our use of strain_old.  This is possibility (1).  We'll see whether BISON (or anything else) failes.

Fixes #10116

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->