### PR TITLE
Write out the inactive parameter in the input file

### DIFF
--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -202,7 +202,6 @@ class BlockEditor(QWidget, MooseWidget):
         """
         self.editingFinished.emit()
 
-
 if __name__ == "__main__":
     from PyQt5.QtWidgets import QApplication, QMainWindow
     from InputTree import InputTree

--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -168,6 +168,7 @@ class BlockEditor(QWidget, MooseWidget):
         """
         self.block.comments = self.comment_edit.getComments()
         self.param_editor.save()
+        self.block.changed_by_user = True
         self._blockChanged(enabled=False)
         self.blockChanged.emit(self.block)
 

--- a/python/peacock/Input/BlockInfo.py
+++ b/python/peacock/Input/BlockInfo.py
@@ -382,3 +382,41 @@ class BlockInfo(object):
         for t in self.types.values():
             o.write(t.dump(indent+1, sep))
         return o.getvalue()
+
+    def getParamNames(self):
+        """
+        Get the parameter names in the required order.
+        Parameter names specified in the input file are printed
+        out in the same order as in the original input file,
+        followed by any other parameters that were changed.
+        Return:
+            list[str]: List of parameter names
+        """
+        return self._orderedNames(self.parameters_write_first, self.parameters_list)
+
+    def getChildNames(self):
+        """
+        Get the child names in the required order.
+        Child names specified in the input file are printed
+        out in the same order as in the original input file,
+        followed by any other children that were changed.
+        Return:
+            list[str]: List of child names
+        """
+        return self._orderedNames(self.children_write_first, self.children_list)
+
+    def _orderedNames(self, first, complete):
+        """
+        Add in elements from the list "complete" to the end
+        of the "first" if they are not already in "first"
+        Input:
+            first[list]: These elements will be first in the returned list
+            complete[list]: These elements will come after first
+        Return:
+            list: The elements in "complete" with elements in "first" first.
+        """
+        l = first[:]
+        for x in complete:
+            if x not in l:
+                l.append(x)
+        return l

--- a/python/peacock/Input/BlockInfo.py
+++ b/python/peacock/Input/BlockInfo.py
@@ -34,6 +34,19 @@ class BlockInfo(object):
         self.hard = hard
         self.description = ""
         self.parent = parent
+        self.changed_by_user = False
+
+    def checkInactive(self):
+        return not self.included and self.wantsToSave()
+
+    def wantsToSave(self):
+        return self.changed_by_user or self.user_added or self.included or self.childrenWantToSave()
+
+    def childrenWantToSave(self):
+        for key in self.children_list:
+            if self.children[key].wantsToSave():
+                return True
+        return False
 
     def getParamInfo(self, param):
         """

--- a/python/peacock/Input/BlockTree.py
+++ b/python/peacock/Input/BlockTree.py
@@ -284,6 +284,7 @@ class BlockTree(QTreeWidget, MooseWidget):
         self.blockSignals(True)
         self.expandItem(item)
         new_block.included = True
+        print(new_block.path)
         self.addBlock(new_block, True)
         self.blockSignals(False)
 

--- a/python/peacock/Input/BlockTree.py
+++ b/python/peacock/Input/BlockTree.py
@@ -284,7 +284,6 @@ class BlockTree(QTreeWidget, MooseWidget):
         self.blockSignals(True)
         self.expandItem(item)
         new_block.included = True
-        print(new_block.path)
         self.addBlock(new_block, True)
         self.blockSignals(False)
 

--- a/python/peacock/Input/InputTree.py
+++ b/python/peacock/Input/InputTree.py
@@ -131,6 +131,7 @@ class InputTree(object):
             else:
                 param_info.value = param_node.raw()
             param_info.set_in_input_file = True
+            param_info.parent.changed_by_user = True
             if param_info.name not in param_info.parent.parameters_write_first:
                 param_info.parent.parameters_write_first.append(param_info.name)
             param_info.comments = self._getComments(param_node)

--- a/python/peacock/Input/InputTreeWriter.py
+++ b/python/peacock/Input/InputTreeWriter.py
@@ -16,6 +16,15 @@ def mergeWriteFirstLists(first, complete):
             l.append(x)
     return l
 
+def writeInactive(output, parent, children, indent, sep):
+    inactive = []
+    for child in children:
+        entry = parent.children.get(child, None)
+        if entry and entry.checkInactive():
+            inactive.append(entry.name)
+    if inactive:
+        output.write("%sinactive = '%s'\n" % (indent*sep, ' '.join(inactive)))
+
 def inputTreeToString(root, sep="  "):
     """
     Main access point to write an InputTree to a string.
@@ -29,9 +38,10 @@ def inputTreeToString(root, sep="  "):
         commentString(output, root.comments, 0, sep)
     children = mergeWriteFirstLists(root.children_write_first, root.children_list)
     last_child = children[-1]
+    writeInactive(output, root, children, 0, sep)
     for child in children:
         entry = root.children.get(child, None)
-        if entry and entry.included:
+        if entry and entry.wantsToSave():
             writeToString(output, entry, 0, sep, child == last_child)
     return output.getvalue()
 
@@ -47,9 +57,10 @@ def writeToString(output, entry, indent, sep="  ", is_last=False):
     nodeHeaderString(output, entry, indent, sep)
     nodeParamsString(output, entry, indent+1, sep)
     children = mergeWriteFirstLists(entry.children_write_first, entry.children_list)
+    writeInactive(output, entry, children, indent+1, sep)
     for child in children:
         child_entry = entry.children.get(child, None)
-        if child_entry and child_entry.included:
+        if child_entry and child_entry.wantsToSave():
             writeToString(output, child_entry, indent+1, sep)
     nodeCloseString(output, entry, indent, sep, is_last)
 

--- a/python/peacock/Input/InputTreeWriter.py
+++ b/python/peacock/Input/InputTreeWriter.py
@@ -1,21 +1,5 @@
 import cStringIO
 
-def mergeWriteFirstLists(first, complete):
-    """
-    Add in elements from the list "complete" to the end
-    of the "first" if they are not already in "first"
-    Input:
-        first[list]: These elements will be first in the returned list
-        complete[list]: These elements will come after first
-    Return:
-        list: The elements in "complete" with elements in "first" first.
-    """
-    l = first[:]
-    for x in complete:
-        if x not in l:
-            l.append(x)
-    return l
-
 def writeInactive(output, parent, children, indent, sep):
     inactive = []
     for child in children:
@@ -36,7 +20,7 @@ def inputTreeToString(root, sep="  "):
     output = cStringIO.StringIO()
     if root.comments:
         commentString(output, root.comments, 0, sep)
-    children = mergeWriteFirstLists(root.children_write_first, root.children_list)
+    children = root.getChildNames()
     last_child = children[-1]
     writeInactive(output, root, children, 0, sep)
     for child in children:
@@ -56,7 +40,7 @@ def writeToString(output, entry, indent, sep="  ", is_last=False):
     """
     nodeHeaderString(output, entry, indent, sep)
     nodeParamsString(output, entry, indent+1, sep)
-    children = mergeWriteFirstLists(entry.children_write_first, entry.children_list)
+    children = entry.getChildNames()
     writeInactive(output, entry, children, indent+1, sep)
     for child in children:
         child_entry = entry.children.get(child, None)
@@ -98,7 +82,7 @@ def nodeCloseString(output, entry, indent, sep, is_last):
         output.write("[]\n\n")
 
 def nodeParamsString(output, entry, indent, sep, ignore_type=False):
-    params = mergeWriteFirstLists(entry.parameters_write_first, entry.parameters_list)
+    params = entry.getParamNames()
     for name in params:
         if ignore_type and name == "type":
             continue

--- a/python/peacock/Input/ParamsTable.py
+++ b/python/peacock/Input/ParamsTable.py
@@ -353,6 +353,7 @@ class ParamsTable(QtWidgets.QTableWidget, MooseWidget):
         p = name_item.data(Qt.UserRole)
         self.removed_params.append(p)
         self.removeRow(row)
+        self.changed.emit()
 
     def createRow(self, param, name_editable=False, value_editable=True, comments_editable=True, index=-1):
         """

--- a/python/peacock/tests/input_tab/BlockEditor/test_BlockEditor.py
+++ b/python/peacock/tests/input_tab/BlockEditor/test_BlockEditor.py
@@ -204,8 +204,8 @@ class Tests(Testing.PeacockTester):
         self.checkAddParam("/GlobalParams", False, False)
         # Has types
         self.checkAddParam("/Mesh", True, True)
-        # Is star node, has an existing 'active' parameter
-        self.checkAddParam("/Kernels", False, True)
+        # Is star node, had an 'active' parameter but we get rid of it
+        self.checkAddParam("/Kernels", False, False)
         # Is user block
         self.checkAddParam("/Kernels/diff_u", True, True, True)
 

--- a/python/peacock/tests/input_tab/InputFileEditor/gold/fsp_test.i
+++ b/python/peacock/tests/input_tab/InputFileEditor/gold/fsp_test.i
@@ -6,7 +6,6 @@
 []
 
 [Variables]
-  active = 'u v'
   [./u]
     order = FIRST
     family = LAGRANGE
@@ -18,7 +17,6 @@
 []
 
 [Kernels]
-  active = 'diff_u conv_v diff_v'
   [./diff_u]
     type = Diffusion
     variable = u
@@ -35,7 +33,7 @@
 []
 
 [BCs]
-  active = 'left_u right_u left_v'
+  inactive = 'right_v'
   [./left_u]
     type = DirichletBC
     variable = u
@@ -71,7 +69,6 @@
 []
 
 [Preconditioning]
-  active = 'FSP'
   [./FSP]
     # It is the starting point of splitting
     type = FSP

--- a/python/peacock/tests/input_tab/InputFileEditorWithMesh/test_InputFileEditorWithMesh.py
+++ b/python/peacock/tests/input_tab/InputFileEditorWithMesh/test_InputFileEditorWithMesh.py
@@ -212,18 +212,21 @@ class Tests(BaseTests):
 
         b = tree.getBlockInfo("/AuxVariables")
         self.assertNotEqual(b, None)
+        self.assertFalse(b.wantsToSave())
         w.InputFileEditorPlugin.block_tree.copyBlock(b)
+        self.assertTrue(b.wantsToSave())
         self.assertEqual(w.InputFileEditorPlugin.has_changed, True)
         self.assertEqual(w.canClose(), False)
 
         mock_q.return_value = QMessageBox.Yes # The user wants to ignore changes
         self.assertEqual(w.canClose(), True)
 
+        new_block = "[AuxVariables]\n  [./New_0]\n  [../]\n[]\n\n"
         s = tree.getInputFileString()
-        self.assertEqual("", s) # AuxVariables isn't included
+        self.assertEqual("inactive = 'AuxVariables'\n%s" % new_block, s) # AuxVariables is inactive
         b.included = True
         s = tree.getInputFileString()
-        self.assertEqual("[AuxVariables]\n  [./New_0]\n  [../]\n[]\n\n", s)
+        self.assertEqual(new_block, s)
 
     def testBlockHighlight(self):
         main_win, w = self.newWidget()

--- a/python/peacock/tests/input_tab/InputTree/gold/fsp_test.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/fsp_test.i
@@ -6,7 +6,6 @@
 []
 
 [Variables]
-  active = 'u v'
   [./u]
     order = FIRST
     family = LAGRANGE
@@ -18,7 +17,6 @@
 []
 
 [Kernels]
-  active = 'diff_u conv_v diff_v'
   [./diff_u]
     type = Diffusion
     variable = u
@@ -35,7 +33,7 @@
 []
 
 [BCs]
-  active = 'left_u right_u left_v'
+  inactive = 'right_v'
   [./left_u]
     type = DirichletBC
     variable = u
@@ -71,7 +69,6 @@
 []
 
 [Preconditioning]
-  active = 'FSP'
   [./FSP]
     # It is the starting point of splitting
     type = FSP

--- a/python/peacock/tests/input_tab/InputTree/gold/transient.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/transient.i
@@ -17,7 +17,6 @@
 []
 
 [Variables]
-  active = 'u'
   [./u]
     order = FIRST
     family = LAGRANGE
@@ -41,7 +40,6 @@
 []
 
 [Kernels]
-  active = 'diff ie ffn'
   [./ie]
     type = TimeDerivative
     variable = u
@@ -58,7 +56,7 @@
 []
 
 [BCs]
-  active = 'all'
+  inactive = 'left right'
   [./all]
     type = FunctionDirichletBC
     variable = u

--- a/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion_inactive.i
+++ b/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion_inactive.i
@@ -1,0 +1,48 @@
+inactive = 'Kernels BCs Executioner'
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  inactive = 'diff'
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 'left'
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 'right'
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Steady
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]
+

--- a/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion_no_diff.i
+++ b/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion_no_diff.i
@@ -1,0 +1,47 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  inactive = 'diff'
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 'left'
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 'right'
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  # Preconditioned JFNK (default)
+  type = Steady
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]
+

--- a/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
+++ b/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
@@ -24,5 +24,27 @@ class Tests(Testing.PeacockTester):
         s = InputTreeWriter.inputTreeToString(t.root)
         self.checkFile(s, "gold/simple_diffusion.i")
 
+    def testInactive(self):
+        t = self.createBasic()
+        d = t.getBlockInfo("/Kernels/diff")
+        d.included = False
+        s = InputTreeWriter.inputTreeToString(t.root)
+        self.checkFile(s, "gold/simple_diffusion_no_diff.i", True)
+        k = t.getBlockInfo("/Kernels")
+        k.included = False
+        b = t.getBlockInfo("/BCs")
+        b.included = False
+        e = t.getBlockInfo("/Executioner")
+        e.included = False
+        s = InputTreeWriter.inputTreeToString(t.root)
+        self.checkFile(s, "gold/simple_diffusion_inactive.i", True)
+
+        d.included = True
+        k.included = True
+        b.included = True
+        e.included = True
+        s = InputTreeWriter.inputTreeToString(t.root)
+        self.checkFile(s, "gold/simple_diffusion.i", True)
+
 if __name__ == '__main__':
     Testing.run_tests()

--- a/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
+++ b/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
@@ -29,7 +29,7 @@ class Tests(Testing.PeacockTester):
         d = t.getBlockInfo("/Kernels/diff")
         d.included = False
         s = InputTreeWriter.inputTreeToString(t.root)
-        self.checkFile(s, "gold/simple_diffusion_no_diff.i", True)
+        self.checkFile(s, "gold/simple_diffusion_no_diff.i")
         k = t.getBlockInfo("/Kernels")
         k.included = False
         b = t.getBlockInfo("/BCs")
@@ -37,14 +37,14 @@ class Tests(Testing.PeacockTester):
         e = t.getBlockInfo("/Executioner")
         e.included = False
         s = InputTreeWriter.inputTreeToString(t.root)
-        self.checkFile(s, "gold/simple_diffusion_inactive.i", True)
+        self.checkFile(s, "gold/simple_diffusion_inactive.i")
 
         d.included = True
         k.included = True
         b.included = True
         e.included = True
         s = InputTreeWriter.inputTreeToString(t.root)
-        self.checkFile(s, "gold/simple_diffusion.i", True)
+        self.checkFile(s, "gold/simple_diffusion.i")
 
 if __name__ == '__main__':
     Testing.run_tests()


### PR DESCRIPTION
The old behavior was to simply not write out a block if the user
deselects it in the input tab of peacock. Now we put that block in the 
"inactive" parameter.
This also applies to top level blocks. For example, deselecting "Kernels" puts 
`inactive = 'Kernels'` at the top of the input file.
This only happens for blocks that the user has changed in some way. Either it was
in the original input file or in a block that the user has edited and saved.

closes #9976

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
