### PR TITLE
Allow user specified body force in INSMomentumBase

### DIFF
--- a/modules/navier_stokes/include/kernels/INSBase.h
+++ b/modules/navier_stokes/include/kernels/INSBase.h
@@ -49,8 +49,7 @@ protected:
   virtual RealVectorValue dStrongPressureDPressure();
   virtual Real dWeakPressureDPressure();
 
-  virtual RealVectorValue bodyForcesTerm();
-  virtual RealVectorValue gravity();
+  virtual RealVectorValue gravityTerm();
 
   virtual RealVectorValue timeDerivativeTerm();
   virtual RealVectorValue dTimeDerivativeDUComp(unsigned comp);

--- a/modules/navier_stokes/src/kernels/BodyForceSUPG.C
+++ b/modules/navier_stokes/src/kernels/BodyForceSUPG.C
@@ -33,10 +33,11 @@ Real
 BodyForceSUPG::computeQpResidual()
 {
   RealVectorValue U(_u_vel[_qp], _v_vel[_qp], _w_vel[_qp]);
+  Real r = -_test[_i][_qp] * _function.value(_t, _q_point[_qp]);
   if (_tau_type == "opt")
-    return -tauNodal() * U * _grad_test[_i][_qp] * _function.value(_t, _q_point[_qp]);
+    return r - tauNodal() * U * _grad_test[_i][_qp] * _function.value(_t, _q_point[_qp]);
   else
-    return -tau() * U * _grad_test[_i][_qp] * _function.value(_t, _q_point[_qp]);
+    return r - tau() * U * _grad_test[_i][_qp] * _function.value(_t, _q_point[_qp]);
 }
 
 Real

--- a/modules/navier_stokes/src/kernels/INSBase.C
+++ b/modules/navier_stokes/src/kernels/INSBase.C
@@ -233,13 +233,7 @@ INSBase::dWeakPressureDPressure()
 }
 
 RealVectorValue
-INSBase::bodyForcesTerm()
-{
-  return gravity();
-}
-
-RealVectorValue
-INSBase::gravity()
+INSBase::gravityTerm()
 {
   return -_rho[_qp] * _gravity;
 }

--- a/modules/navier_stokes/src/kernels/INSMass.C
+++ b/modules/navier_stokes/src/kernels/INSMass.C
@@ -57,10 +57,10 @@ INSMass::computeQpPGResidual()
       _transient_term ? timeDerivativeTerm() : RealVectorValue(0, 0, 0);
   RealVectorValue convective_term = _convective_term ? convectiveTerm() : RealVectorValue(0, 0, 0);
   Real r = -1. / _rho[_qp] * tau() * _grad_test[_i][_qp] *
-           (strongPressureTerm() + bodyForcesTerm() + viscous_term + convective_term +
-            transient_term - RealVectorValue(_x_ffn.value(_t, _q_point[_qp]),
-                                             _y_ffn.value(_t, _q_point[_qp]),
-                                             _z_ffn.value(_t, _q_point[_qp])));
+           (strongPressureTerm() + gravityTerm() + viscous_term + convective_term + transient_term -
+            RealVectorValue(_x_ffn.value(_t, _q_point[_qp]),
+                            _y_ffn.value(_t, _q_point[_qp]),
+                            _z_ffn.value(_t, _q_point[_qp])));
 
   return r;
 }
@@ -134,7 +134,7 @@ INSMass::computeQpPGOffDiagJacobian(unsigned comp)
              (d_convective_term_d_u_comp + d_viscous_term_d_u_comp + d_transient_term_d_u_comp) -
          1. / _rho[_qp] * dTauDUComp(comp) * _grad_test[_i][_qp] *
              (convective_term + viscous_term + transient_term + strongPressureTerm() +
-              bodyForcesTerm() - RealVectorValue(_x_ffn.value(_t, _q_point[_qp]),
-                                                 _y_ffn.value(_t, _q_point[_qp]),
-                                                 _z_ffn.value(_t, _q_point[_qp])));
+              gravityTerm() - RealVectorValue(_x_ffn.value(_t, _q_point[_qp]),
+                                              _y_ffn.value(_t, _q_point[_qp]),
+                                              _z_ffn.value(_t, _q_point[_qp])));
 }

--- a/modules/navier_stokes/src/kernels/INSMomentumBase.C
+++ b/modules/navier_stokes/src/kernels/INSMomentumBase.C
@@ -48,7 +48,7 @@ INSMomentumBase::computeQpResidual()
     r += _test[_i][_qp] * strongPressureTerm()(_component);
 
   // body force term
-  r += _test[_i][_qp] * bodyForcesTerm()(_component);
+  r += _test[_i][_qp] * (gravityTerm()(_component) - _ffn.value(_t, _q_point[_qp]));
 
   // convective term
   if (_convective_term)
@@ -73,7 +73,7 @@ INSMomentumBase::computeQpPGResidual()
 
   return tau() * U * _grad_test[_i][_qp] *
          ((convective_term + viscous_term + transient_term + strongPressureTerm() +
-           bodyForcesTerm())(_component)-_ffn.value(_t, _q_point[_qp]));
+           gravityTerm())(_component)-_ffn.value(_t, _q_point[_qp]));
 
   // For GLS as opposed to SUPG stabilization, one would need to modify the test function functional
   // space to include second derivatives of the Galerkin test functions corresponding to the viscous
@@ -83,7 +83,7 @@ INSMomentumBase::computeQpPGResidual()
 
   // Real pg_viscous_r = -_mu[_qp] * lap_test * tau() *
   //                     (convective_term + viscous_term + strongPressureTerm()(_component) +
-  //                      bodyForcesTerm())(_component);
+  //                      gravityTerm())(_component);
 }
 
 Real
@@ -122,10 +122,10 @@ INSMomentumBase::computeQpPGJacobian(unsigned comp)
 
   return dTauDUComp(comp) * U * _grad_test[_i][_qp] *
              (convective_term + viscous_term + strongPressureTerm()(_component) +
-              bodyForcesTerm()(_component) + transient_term - _ffn.value(_t, _q_point[_qp])) +
+              gravityTerm()(_component) + transient_term - _ffn.value(_t, _q_point[_qp])) +
          tau() * d_U_d_U_comp * _grad_test[_i][_qp] *
              (convective_term + viscous_term + strongPressureTerm()(_component) +
-              bodyForcesTerm()(_component) + transient_term - _ffn.value(_t, _q_point[_qp])) +
+              gravityTerm()(_component) + transient_term - _ffn.value(_t, _q_point[_qp])) +
          tau() * U * _grad_test[_i][_qp] *
              (d_convective_term_d_u_comp + d_viscous_term_d_u_comp + d_transient_term_d_u_comp);
 }

--- a/modules/navier_stokes/test/tests/ins/mms/pspg/pspg_mms_test.i
+++ b/modules/navier_stokes/test/tests/ins/mms/pspg/pspg_mms_test.i
@@ -60,6 +60,7 @@ rho=2.5
     type = INSMomentumLaplaceForm
     variable = vel_x
     component = 0
+    forcing_func = vel_x_source_func
   [../]
 
   # y-momentum, space
@@ -67,18 +68,7 @@ rho=2.5
     type = INSMomentumLaplaceForm
     variable = vel_y
     component = 1
-  [../]
-
-  [./vel_x_source]
-    type = BodyForce
-    function = vel_x_source_func
-    variable = vel_x
-  [../]
-
-  [./vel_y_source]
-    type = BodyForce
-    function = vel_y_source_func
-    variable = vel_y
+    forcing_func = vel_y_source_func
   [../]
 
   [./p_source]

--- a/modules/navier_stokes/test/tests/ins/mms/supg/supg_adv_dominated_mms.i
+++ b/modules/navier_stokes/test/tests/ins/mms/supg/supg_adv_dominated_mms.i
@@ -80,17 +80,6 @@ rho=2.5
     forcing_func = vel_y_source_func
   [../]
 
-  [./vel_x_source]
-    type = BodyForce
-    function = vel_x_source_func
-    variable = vel_x
-  [../]
-  [./vel_y_source]
-    type = BodyForce
-    function = vel_y_source_func
-    variable = vel_y
-  [../]
-
   [./p_source]
     type = BodyForce
     function = p_source_func

--- a/modules/navier_stokes/test/tests/ins/mms/supg/supg_mms_test.i
+++ b/modules/navier_stokes/test/tests/ins/mms/supg/supg_mms_test.i
@@ -70,17 +70,6 @@ rho=2.5
     forcing_func = vel_y_source_func
   [../]
 
-  [./vel_x_source]
-    type = BodyForce
-    function = vel_x_source_func
-    variable = vel_x
-  [../]
-  [./vel_y_source]
-    type = BodyForce
-    function = vel_y_source_func
-    variable = vel_y
-  [../]
-
   [./p_source]
     type = BodyForce
     function = p_source_func

--- a/modules/navier_stokes/test/tests/ins/mms/supg/supg_pspg_adv_dominated_mms.i
+++ b/modules/navier_stokes/test/tests/ins/mms/supg/supg_pspg_adv_dominated_mms.i
@@ -83,17 +83,6 @@ rho=2.5
     forcing_func = vel_y_source_func
   [../]
 
-  [./vel_x_source]
-    type = BodyForce
-    function = vel_x_source_func
-    variable = vel_x
-  [../]
-  [./vel_y_source]
-    type = BodyForce
-    function = vel_y_source_func
-    variable = vel_y
-  [../]
-
   [./p_source]
     type = BodyForce
     function = p_source_func

--- a/modules/navier_stokes/test/tests/scalar_adr/supg/2d_advection_error_testing.i
+++ b/modules/navier_stokes/test/tests/scalar_adr/supg/2d_advection_error_testing.i
@@ -31,11 +31,6 @@ ay=1
     type = Advection
     variable = u
   [../]
-  [./frc]
-    type = BodyForce
-    variable = u
-    function = 'ffn'
-  [../]
   [./adv_supg]
     type = AdvectionSUPG
     variable = u

--- a/modules/navier_stokes/test/tests/scalar_adr/supg/advection_error_testing.i
+++ b/modules/navier_stokes/test/tests/scalar_adr/supg/advection_error_testing.i
@@ -26,11 +26,6 @@ velocity=1
     type = Advection
     variable = u
   [../]
-  [./frc]
-    type = BodyForce
-    variable = u
-    function = 'ffn'
-  [../]
   [./adv_supg]
     type = AdvectionSUPG
     variable = u

--- a/modules/navier_stokes/test/tests/scalar_adr/supg/tests
+++ b/modules/navier_stokes/test/tests/scalar_adr/supg/tests
@@ -3,12 +3,13 @@
     type = 'Exodiff'
     input = 'tauOpt.i'
     exodiff = 'tauOpt_out.e'
+    cli_args = "Kernels/active='adv adv_supg body_force_supg'"
   [../]
   [./tauMod]
     type = 'Exodiff'
     input = 'tauOpt.i'
     exodiff = 'tauMod_out.e'
-    cli_args = 'GlobalParams/tau_type=mod Outputs/file_base=tauMod_out'
+    cli_args = "Kernels/active='adv adv_supg body_force_supg' GlobalParams/tau_type=mod Outputs/file_base=tauMod_out"
   [../]
   [./inconsistent]
     type = 'Exodiff'


### PR DESCRIPTION
- Eliminates need for additional BodyForce Kernel
- User has to specify a forcing_function for the INSMomentum* kernel in order to consistently include the body force in stabilization terms anyways
- Doesn't make any sense to have the user specify an additional kernel when the body force is already necessary for the INSMomentum* kernel

Closes #10138
