### PR TITLE
Make SinglePhaseFluidPropertiesPT interface consistent

### DIFF
--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -96,7 +96,7 @@ public:
    * @param xnacl salt mass fraction (-)
    * @return viscosity (Pa.s)
    */
-  virtual Real mu(Real water_density, Real temperature, Real xnacl) const override;
+  virtual Real mu_from_rho_T(Real water_density, Real temperature, Real xnacl) const override;
 
   /**
    * Viscosity of brine and derivatives wrt pressure, temperature and mass fraction
@@ -214,7 +214,7 @@ public:
    * @param xnacl NaCl mass fraction (-)
    * @return thermal conductivity (W/m/K)
    */
-  virtual Real k(Real water_density, Real temperature, Real xnacl) const override;
+  virtual Real k_from_rho_T(Real water_density, Real temperature, Real xnacl) const override;
 
   /**
    * Brine vapour pressure

--- a/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
@@ -68,7 +68,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return viscosity (Pa.s)
    */
-  virtual Real mu(Real density, Real temperature) const override;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
 
   /**
    * CO2 viscosity and derivatives wrt density and temperature
@@ -84,12 +84,12 @@ public:
    * @param[out] dmu_drho derivative of viscosity wrt density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    */
-  virtual void mu_drhoT(Real density,
-                        Real temperature,
-                        Real ddensity_dT,
-                        Real & mu,
-                        Real & dmu_drho,
-                        Real & dmu_dT) const override;
+  virtual void mu_drhoT_from_rho_T(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const override;
 
   /**
    * Fluid name
@@ -357,7 +357,7 @@ public:
    * @param temperature CO2 temperature (K)
    * @return thermal conductivity (W/m/K)
    */
-  virtual Real k(Real density, Real temperature) const override;
+  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /**
    * Specific entropy

--- a/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
@@ -57,6 +57,11 @@ public:
   virtual void rho_dpT(
       Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const override;
 
+  virtual Real mu(Real pressure, Real temperature) const override;
+
+  virtual void
+  mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
+
   /**
    * CO2 viscosity
    * From Fenghour et al., The viscosity of carbon dioxide, J. Phys. Chem. Ref.
@@ -346,6 +351,11 @@ public:
    * @return isochoric specific heat capacity (J/kg/K)
    */
   virtual Real cv(Real pressure, Real temperature) const override;
+
+  virtual Real k(Real pressure, Real temperature) const override;
+
+  virtual void
+  k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
   /**
    * Thermal conductivity

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
@@ -44,7 +44,7 @@ public:
   virtual Real c(Real pressure, Real temperature) const override;
 
   /// Thermal conductivity (W/m/K)
-  virtual Real k(Real density, Real temperature) const override;
+  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /// Specific entropy (J/kg/K)
   virtual Real s(Real pressure, Real temperature) const override;
@@ -74,15 +74,15 @@ public:
                          Real & de_dT) const override;
 
   /// Dynamic viscosity (Pa s)
-  virtual Real mu(Real density, Real temperature) const override;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
 
   /// Dynamic viscosity and its derivatives wrt density and temperature
-  virtual void mu_drhoT(Real density,
-                        Real temperature,
-                        Real ddensity_dT,
-                        Real & mu,
-                        Real & dmu_drho,
-                        Real & dmu_dT) const override;
+  virtual void mu_drhoT_from_rho_T(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const override;
 
   /// Specific enthalpy (J/kg)
   virtual Real h(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
@@ -44,6 +44,12 @@ public:
   virtual Real c(Real pressure, Real temperature) const override;
 
   /// Thermal conductivity (W/m/K)
+  virtual Real k(Real pressure, Real temperature) const override;
+  /// Thermal conductivity and its derivatives wrt pressure and temperature
+  virtual void
+  k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
+
+  /// Thermal conductivity (W/m/K)
   virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /// Specific entropy (J/kg/K)
@@ -72,6 +78,11 @@ public:
                          Real & e,
                          Real & de_dp,
                          Real & de_dT) const override;
+
+  virtual Real mu(Real pressure, Real temperature) const override;
+
+  virtual void
+  mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
 
   /// Dynamic viscosity (Pa s)
   virtual Real mu_from_rho_T(Real density, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
@@ -149,6 +149,11 @@ public:
    */
   virtual Real cv(Real pressure, Real temperature) const override;
 
+  virtual Real mu(Real pressure, Real temperature) const override;
+
+  virtual void
+  mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
+
   /**
    * Methane gas viscosity as a function of density and temperature.
    * From Irvine Jr, T. F. and Liley, P. E. (1984) Steam and Gas Tables with
@@ -177,6 +182,12 @@ public:
                                    Real & mu,
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
+
+  /// Thermal conductivity (W/m/K)
+  virtual Real k(Real pressure, Real temperature) const override;
+  /// Thermal conductivity and its derivatives wrt pressure and temperature
+  virtual void
+  k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
   /**
    * Thermal conductivity as a function of density and temperature.

--- a/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
@@ -158,7 +158,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return viscosity (Pa.s)
    */
-  virtual Real mu(Real density, Real temperature) const override;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
 
   /**
    * Methane gas viscosity and derivatives wrt density and temperature.
@@ -171,12 +171,12 @@ public:
    * @param[out] dmu_drho derivative of viscosity wrt density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    */
-  virtual void mu_drhoT(Real density,
-                        Real temperature,
-                        Real ddensity_dT,
-                        Real & mu,
-                        Real & dmu_drho,
-                        Real & dmu_dT) const override;
+  virtual void mu_drhoT_from_rho_T(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const override;
 
   /**
    * Thermal conductivity as a function of density and temperature.
@@ -187,7 +187,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return k (W/m/K)
    */
-  virtual Real k(Real density, Real temperature) const override;
+  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /**
    * Specific entropy as a function of pressure and temperature.

--- a/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
@@ -39,7 +39,7 @@ public:
                         Real & drho_dT,
                         Real & drho_dx) const = 0;
   /// Dynamic viscosity (Pa s)
-  virtual Real mu(Real density, Real temperature, Real xmass) const = 0;
+  virtual Real mu_from_rho_T(Real density, Real temperature, Real xmass) const = 0;
   /// Dynamic viscosity and its derivatives wrt pressure, temperature and mass fraction
   virtual void mu_drhoTx(Real density,
                          Real temperature,
@@ -72,7 +72,7 @@ public:
                       Real & de_dT,
                       Real & de_dx) const = 0;
   /// Thermal conductivity (W/m/K)
-  virtual Real k(Real density, Real temperature, Real xmass) const = 0;
+  virtual Real k_from_rho_T(Real density, Real temperature, Real xmass) const = 0;
   /// Get UserObject for specified component
   virtual const SinglePhaseFluidPropertiesPT & getComponent(unsigned int component) const = 0;
 

--- a/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
@@ -164,7 +164,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return viscosity (Pa.s)
    */
-  virtual Real mu(Real density, Real temperature) const override;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
 
   /**
    * NaCl viscosity and derivatives wrt density and temperature
@@ -175,12 +175,12 @@ public:
    * @param[out] dmu_drho derivative of viscosity wrt density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    */
-  virtual void mu_drhoT(Real density,
-                        Real temperature,
-                        Real ddensity_dT,
-                        Real & mu,
-                        Real & dmu_drho,
-                        Real & dmu_dT) const override;
+  virtual void mu_drhoT_from_rho_T(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const override;
 
   /**
    * Thermal conductivity
@@ -194,7 +194,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return k (W/m/K)
    */
-  virtual Real k(Real density, Real temperature) const override;
+  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /**
    * Specific entropy as a function of pressure and temperature

--- a/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
@@ -157,6 +157,11 @@ public:
    */
   virtual Real cv(Real pressure, Real temperature) const override;
 
+  virtual Real mu(Real pressure, Real temperature) const override;
+
+  virtual void
+  mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
+
   /**
    * NaCl viscosity
    *
@@ -181,6 +186,12 @@ public:
                                    Real & mu,
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
+
+  /// Thermal conductivity (W/m/K)
+  virtual Real k(Real pressure, Real temperature) const override;
+  /// Thermal conductivity and its derivatives wrt pressure and temperature
+  virtual void
+  k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
   /**
    * Thermal conductivity

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -54,7 +54,7 @@ public:
   virtual Real c(Real pressure, Real temperature) const override;
 
   /// Thermal conductivity (W/m/K)
-  virtual Real k(Real density, Real temperature) const override;
+  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /// Specific entropy (J/kg/K)
   virtual Real s(Real pressure, Real temperature) const override;
@@ -84,15 +84,15 @@ public:
                          Real & de_dT) const override;
 
   /// Dynamic viscosity (Pa s)
-  virtual Real mu(Real density, Real temperature) const override;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
 
   /// Dynamic viscosity and its derivatives wrt density and temperature
-  virtual void mu_drhoT(Real density,
-                        Real temperature,
-                        Real ddensity_dT,
-                        Real & mu,
-                        Real & dmu_drho,
-                        Real & dmu_dT) const override;
+  virtual void mu_drhoT_from_rho_T(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const override;
 
   /// Specific enthalpy (J/kg)
   virtual Real h(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -54,6 +54,12 @@ public:
   virtual Real c(Real pressure, Real temperature) const override;
 
   /// Thermal conductivity (W/m/K)
+  virtual Real k(Real pressure, Real temperature) const override;
+  /// Thermal conductivity and its derivatives wrt pressure and temperature
+  virtual void
+  k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
+
+  /// Thermal conductivity (W/m/K)
   virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /// Specific entropy (J/kg/K)
@@ -82,6 +88,11 @@ public:
                          Real & e,
                          Real & de_dp,
                          Real & de_dT) const override;
+
+  virtual Real mu(Real pressure, Real temperature) const override;
+
+  virtual void
+  mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
 
   /// Dynamic viscosity (Pa s)
   virtual Real mu_from_rho_T(Real density, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -57,16 +57,16 @@ public:
   /// Adiabatic index - ratio of specific heats (-)
   virtual Real gamma(Real pressure, Real temperature) const;
   /// Dynamic viscosity (Pa s)
-  virtual Real mu(Real density, Real temperature) const = 0;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const = 0;
   /// Dynamic viscosity and its derivatives wrt density and temperature
-  virtual void mu_drhoT(Real density,
-                        Real temperature,
-                        Real ddensity_dT,
-                        Real & mu,
-                        Real & dmu_drho,
-                        Real & dmu_dT) const = 0;
+  virtual void mu_drhoT_from_rho_T(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const = 0;
   /// Thermal conductivity (W/m/K)
-  virtual Real k(Real density, Real temperature) const = 0;
+  virtual Real k_from_rho_T(Real density, Real temperature) const = 0;
   /// Specific entropy (J/kg/K)
   virtual Real s(Real pressure, Real temperature) const = 0;
   /// Specific enthalpy (J/kg)

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -57,6 +57,11 @@ public:
   /// Adiabatic index - ratio of specific heats (-)
   virtual Real gamma(Real pressure, Real temperature) const;
   /// Dynamic viscosity (Pa s)
+  virtual Real mu(Real pressure, Real temperature) const = 0;
+  /// Dynamic viscosity and its derivatives wrt pressure and temperature
+  virtual void
+  mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const = 0;
+  /// Dynamic viscosity (Pa s)
   virtual Real mu_from_rho_T(Real density, Real temperature) const = 0;
   /// Dynamic viscosity and its derivatives wrt density and temperature
   virtual void mu_drhoT_from_rho_T(Real density,
@@ -65,6 +70,11 @@ public:
                                    Real & mu,
                                    Real & dmu_drho,
                                    Real & dmu_dT) const = 0;
+  /// Thermal conductivity (W/m/K)
+  virtual Real k(Real pressure, Real temperature) const = 0;
+  /// Thermal conductivity and its derivatives wrt pressure and temperature
+  virtual void
+  k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const = 0;
   /// Thermal conductivity (W/m/K)
   virtual Real k_from_rho_T(Real density, Real temperature) const = 0;
   /// Specific entropy (J/kg/K)

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -121,14 +121,14 @@ public:
   virtual void
   h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const override;
   /// Viscosity
-  virtual Real mu(Real density, Real temperature) const override;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
   /// Derivatives of viscosity wrt density and temperature
-  virtual void mu_drhoT(Real density,
-                        Real temperature,
-                        Real ddensity_dT,
-                        Real & mu,
-                        Real & dmu_drho,
-                        Real & dmu_dT) const override;
+  virtual void mu_drhoT_from_rho_T(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const override;
   /// Specific isobaric heat capacity
   virtual Real cp(Real pressure, Real temperature) const override;
   /// Specific isochoric heat capacity
@@ -136,7 +136,7 @@ public:
   /// Speed of sound
   virtual Real c(Real pressure, Real temperature) const override;
   /// Thermal conductivity
-  virtual Real k(Real density, Real temperature) const override;
+  virtual Real k_from_rho_T(Real density, Real temperature) const override;
   /// Specific entropy
   virtual Real s(Real pressure, Real temperature) const override;
   /// Thermal expansion coefficient

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -120,6 +120,11 @@ public:
   /// Enthalpy and its derivatives wrt pressure and temperature
   virtual void
   h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const override;
+
+  virtual Real mu(Real pressure, Real temperature) const override;
+
+  virtual void
+  mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
   /// Viscosity
   virtual Real mu_from_rho_T(Real density, Real temperature) const override;
   /// Derivatives of viscosity wrt density and temperature
@@ -135,6 +140,11 @@ public:
   virtual Real cv(Real pressure, Real temperature) const override;
   /// Speed of sound
   virtual Real c(Real pressure, Real temperature) const override;
+  /// Thermal conductivity (W/m/K)
+  virtual Real k(Real pressure, Real temperature) const override;
+  /// Thermal conductivity and its derivatives wrt pressure and temperature
+  virtual void
+  k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
   /// Thermal conductivity
   virtual Real k_from_rho_T(Real density, Real temperature) const override;
   /// Specific entropy

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -183,7 +183,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return viscosity (Pa.s)
    */
-  virtual Real mu(Real density, Real temperature) const override;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
 
   /**
    * Water viscosity and derivatives wrt density and temperature
@@ -195,12 +195,12 @@ public:
    * @param[out] dmu_drho derivative of viscosity wrt density
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    */
-  virtual void mu_drhoT(Real density,
-                        Real temperature,
-                        Real ddensity_dT,
-                        Real & mu,
-                        Real & dmu_drho,
-                        Real & dmu_dT) const override;
+  virtual void mu_drhoT_from_rho_T(Real density,
+                                   Real temperature,
+                                   Real ddensity_dT,
+                                   Real & mu,
+                                   Real & dmu_drho,
+                                   Real & dmu_dT) const override;
 
   /**
    * Thermal conductivity as a function of density and temperature
@@ -210,7 +210,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return k (W/m/K)
    */
-  virtual Real k(Real density, Real temperature) const override;
+  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /**
    * Specific entropy as a function of pressure and temperature

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -173,6 +173,11 @@ public:
    */
   virtual Real cv(Real pressure, Real temperature) const override;
 
+  virtual Real mu(Real pressure, Real temperature) const override;
+
+  virtual void
+  mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
+
   /**
    * Water viscosity as a function of density and temperature.
    * Eq. (10) from Release on the IAPWS Formulation 2008 for the
@@ -201,6 +206,12 @@ public:
                                    Real & mu,
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
+
+  /// Thermal conductivity (W/m/K)
+  virtual Real k(Real pressure, Real temperature) const override;
+  /// Thermal conductivity and its derivatives wrt pressure and temperature
+  virtual void
+  k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
   /**
    * Thermal conductivity as a function of density and temperature

--- a/modules/fluid_properties/src/materials/FluidPropertiesMaterialPT.C
+++ b/modules/fluid_properties/src/materials/FluidPropertiesMaterialPT.C
@@ -44,10 +44,10 @@ void
 FluidPropertiesMaterialPT::computeQpProperties()
 {
   _rho[_qp] = _fp.rho(_pressure[_qp], _temperature[_qp]);
-  _mu[_qp] = _fp.mu(_rho[_qp], _temperature[_qp]);
+  _mu[_qp] = _fp.mu_from_rho_T(_rho[_qp], _temperature[_qp]);
   _cp[_qp] = _fp.cp(_pressure[_qp], _temperature[_qp]);
   _cv[_qp] = _fp.cv(_pressure[_qp], _temperature[_qp]);
-  _k[_qp] = _fp.k(_rho[_qp], _temperature[_qp]);
+  _k[_qp] = _fp.k_from_rho_T(_rho[_qp], _temperature[_qp]);
   _h[_qp] = _fp.h(_pressure[_qp], _temperature[_qp]);
   _e[_qp] = _fp.e(_pressure[_qp], _temperature[_qp]);
   _s[_qp] = _fp.s(_pressure[_qp], _temperature[_qp]);

--- a/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
@@ -153,7 +153,7 @@ BrineFluidProperties::rho_dpTx(Real pressure,
 }
 
 Real
-BrineFluidProperties::mu(Real water_density, Real temperature, Real xnacl) const
+BrineFluidProperties::mu_from_rho_T(Real water_density, Real temperature, Real xnacl) const
 {
   // Correlation requires molal concentration (mol/kg)
   Real mol = massFractionToMolalConc(xnacl);
@@ -166,7 +166,7 @@ BrineFluidProperties::mu(Real water_density, Real temperature, Real xnacl) const
   Real a = 1.0 + 0.0816 * mol + 0.0122 * mol2 + 0.128e-3 * mol3 +
            0.629e-3 * Tc * (1.0 - std::exp(-0.7 * mol));
 
-  return a * _water_fp->mu(water_density, temperature);
+  return a * _water_fp->mu_from_rho_T(water_density, temperature);
 }
 
 void
@@ -181,7 +181,8 @@ BrineFluidProperties::mu_drhoTx(Real water_density,
 {
   // Viscosity of water and derivatives wrt water density and temperature
   Real muw, dmuw_drhow, dmuw_dT;
-  _water_fp->mu_drhoT(water_density, temperature, dwater_density_dT, muw, dmuw_drhow, dmuw_dT);
+  _water_fp->mu_drhoT_from_rho_T(
+      water_density, temperature, dwater_density_dT, muw, dmuw_drhow, dmuw_dT);
 
   // Correlation requires molal concentration (mol/kg)
   Real mol = massFractionToMolalConc(xnacl);
@@ -325,7 +326,7 @@ BrineFluidProperties::e_dpTx(Real pressure,
 }
 
 Real
-BrineFluidProperties::k(Real water_density, Real temperature, Real xnacl) const
+BrineFluidProperties::k_from_rho_T(Real water_density, Real temperature, Real xnacl) const
 {
   // Correlation requires molal concentration (mol/kg)
   Real mol = massFractionToMolalConc(xnacl);
@@ -333,7 +334,7 @@ BrineFluidProperties::k(Real water_density, Real temperature, Real xnacl) const
   Real Tc = temperature - _T_c2k;
 
   Real S = 100.0 * _Mnacl * mol / (1.0 + _Mnacl * mol);
-  Real lambdaw = _water_fp->k(water_density, temperature);
+  Real lambdaw = _water_fp->k_from_rho_T(water_density, temperature);
   Real lambda = 1.0 - (2.3434e-3 - 7.924e-6 * Tc + 3.924e-8 * Tc * Tc) * S +
                 (1.06e-5 - 2.0e-8 * Tc - 1.2e-10 * Tc * Tc) * S * S;
 

--- a/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
@@ -508,7 +508,7 @@ CO2FluidProperties::rho_dpT(
 }
 
 Real
-CO2FluidProperties::mu(Real density, Real temperature) const
+CO2FluidProperties::mu_from_rho_T(Real density, Real temperature) const
 {
   // Check that the input parameters are within the region of validity
   if (temperature < 216.0 || temperature > 1000.0 || density > 1400.0)
@@ -536,12 +536,12 @@ CO2FluidProperties::mu(Real density, Real temperature) const
 }
 
 void
-CO2FluidProperties::mu_drhoT(Real density,
-                             Real temperature,
-                             Real ddensity_dT,
-                             Real & mu,
-                             Real & dmu_drho,
-                             Real & dmu_dT) const
+CO2FluidProperties::mu_drhoT_from_rho_T(Real density,
+                                        Real temperature,
+                                        Real ddensity_dT,
+                                        Real & mu,
+                                        Real & dmu_drho,
+                                        Real & dmu_dT) const
 {
   // Check that the input parameters are within the region of validity
   if (temperature < 216.0 || temperature > 1000.0 || density > 1400.0)
@@ -703,7 +703,7 @@ CO2FluidProperties::cv(Real pressure, Real temperature) const
 }
 
 Real
-CO2FluidProperties::k(Real density, Real temperature) const
+CO2FluidProperties::k_from_rho_T(Real density, Real temperature) const
 {
   // Check the temperature is in the range of validity (216.592 K <= T <= 1000 K)
   if (temperature <= _triple_point_temperature || temperature >= 1000.0)

--- a/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
@@ -508,6 +508,25 @@ CO2FluidProperties::rho_dpT(
 }
 
 Real
+CO2FluidProperties::mu(Real pressure, Real temperature) const
+{
+  Real rho = this->rho(pressure, temperature);
+  return this->mu_from_rho_T(rho, temperature);
+}
+
+void
+CO2FluidProperties::mu_dpT(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  Real rho, drho_dp, drho_dT;
+  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+
+  Real dmu_drho;
+  mu_drhoT_from_rho_T(rho, temperature, drho_dT, mu, dmu_drho, dmu_dT);
+  dmu_dp = dmu_drho * drho_dp;
+}
+
+Real
 CO2FluidProperties::mu_from_rho_T(Real density, Real temperature) const
 {
   // Check that the input parameters are within the region of validity
@@ -700,6 +719,20 @@ CO2FluidProperties::cv(Real pressure, Real temperature) const
   Real tau = _critical_temperature / temperature;
 
   return -_Rco2 * tau * tau * d2phiSW_dt2(delta, tau);
+}
+
+Real
+CO2FluidProperties::k(Real pressure, Real temperature) const
+{
+  Real rho = this->rho(pressure, temperature);
+  return this->k_from_rho_T(rho, temperature);
+}
+
+void
+CO2FluidProperties::k_dpT(
+    Real /*pressure*/, Real /*temperature*/, Real & /*k*/, Real & /*dk_dp*/, Real & /*dk_dT*/) const
+{
+  mooseError(name(), "k_dpT() is not implemented");
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
@@ -69,7 +69,7 @@ IdealGasFluidPropertiesPT::c(Real /*pressure*/, Real temperature) const
   return std::sqrt(_cp * _R * temperature / (_cv * _molar_mass));
 }
 
-Real IdealGasFluidPropertiesPT::k(Real /*density*/, Real /*temperature*/) const
+Real IdealGasFluidPropertiesPT::k_from_rho_T(Real /*density*/, Real /*temperature*/) const
 {
   return _thermal_conductivity;
 }
@@ -132,20 +132,20 @@ IdealGasFluidPropertiesPT::rho_e_dpT(Real pressure,
   de_dT = denergy_dT;
 }
 
-Real IdealGasFluidPropertiesPT::mu(Real /*density*/, Real /*temperature*/) const
+Real IdealGasFluidPropertiesPT::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const
 {
   return _viscosity;
 }
 
 void
-IdealGasFluidPropertiesPT::mu_drhoT(Real density,
-                                    Real temperature,
-                                    Real /*ddensity_dT*/,
-                                    Real & mu,
-                                    Real & dmu_drho,
-                                    Real & dmu_dT) const
+IdealGasFluidPropertiesPT::mu_drhoT_from_rho_T(Real density,
+                                               Real temperature,
+                                               Real /*ddensity_dT*/,
+                                               Real & mu,
+                                               Real & dmu_drho,
+                                               Real & dmu_dT) const
 {
-  mu = this->mu(density, temperature);
+  mu = this->mu_from_rho_T(density, temperature);
   dmu_drho = 0.0;
   dmu_dT = 0.0;
 }

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
@@ -69,6 +69,20 @@ IdealGasFluidPropertiesPT::c(Real /*pressure*/, Real temperature) const
   return std::sqrt(_cp * _R * temperature / (_cv * _molar_mass));
 }
 
+Real IdealGasFluidPropertiesPT::k(Real /*pressure*/, Real /*temperature*/) const
+{
+  return _thermal_conductivity;
+}
+
+void
+IdealGasFluidPropertiesPT::k_dpT(
+    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+{
+  k = this->k(pressure, temperature);
+  dk_dp = 0;
+  dk_dT = 0;
+}
+
 Real IdealGasFluidPropertiesPT::k_from_rho_T(Real /*density*/, Real /*temperature*/) const
 {
   return _thermal_conductivity;
@@ -130,6 +144,20 @@ IdealGasFluidPropertiesPT::rho_e_dpT(Real pressure,
   e = energy;
   de_dp = denergy_dp;
   de_dT = denergy_dT;
+}
+
+Real IdealGasFluidPropertiesPT::mu(Real /*pressure*/, Real /*temperature*/) const
+{
+  return _viscosity;
+}
+
+void
+IdealGasFluidPropertiesPT::mu_dpT(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  mu = this->mu(pressure, temperature);
+  dmu_dp = 0.0;
+  dmu_dT = 0.0;
 }
 
 Real IdealGasFluidPropertiesPT::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -148,11 +148,15 @@ MethaneFluidProperties::cv(Real pressure, Real temperature) const
 }
 
 Real
-MethaneFluidProperties::mu(Real /*density*/, Real temperature) const
+MethaneFluidProperties::mu_from_rho_T(Real /*density*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (200 K <= T <= 1000 K)
   if (temperature <= 200.0 || temperature >= 1000.0)
-    mooseError("Temperature ", temperature, "K out of range (200K, 1000K) in ", name(), ":mu()");
+    mooseError("Temperature ",
+               temperature,
+               "K out of range (200K, 1000K) in ",
+               name(),
+               ":mu_from_rho_T()");
 
   const std::vector<Real> a{
       2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11, -2.7237166e-14};
@@ -165,17 +169,17 @@ MethaneFluidProperties::mu(Real /*density*/, Real temperature) const
 }
 
 void
-MethaneFluidProperties::mu_drhoT(Real density,
-                                 Real temperature,
-                                 Real /*ddensity_dT*/,
-                                 Real & mu,
-                                 Real & dmu_drho,
-                                 Real & dmu_dT) const
+MethaneFluidProperties::mu_drhoT_from_rho_T(Real density,
+                                            Real temperature,
+                                            Real /*ddensity_dT*/,
+                                            Real & mu,
+                                            Real & dmu_drho,
+                                            Real & dmu_dT) const
 {
   const std::vector<Real> a{
       2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11, -2.7237166e-14};
 
-  mu = this->mu(density, temperature);
+  mu = this->mu_from_rho_T(density, temperature);
   dmu_drho = 0.0;
 
   Real dmudt = 0.0;
@@ -185,7 +189,7 @@ MethaneFluidProperties::mu_drhoT(Real density,
 }
 
 Real
-MethaneFluidProperties::k(Real /*density*/, Real temperature) const
+MethaneFluidProperties::k_from_rho_T(Real /*density*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (200 K <= T <= 1000 K)
   if (temperature <= 200.0 || temperature >= 1000.0)

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -148,6 +148,24 @@ MethaneFluidProperties::cv(Real pressure, Real temperature) const
 }
 
 Real
+MethaneFluidProperties::mu(Real pressure, Real temperature) const
+{
+  Real rho = this->rho(pressure, temperature);
+  return this->mu_from_rho_T(rho, temperature);
+}
+
+void
+MethaneFluidProperties::mu_dpT(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  Real rho, drho_dp, drho_dT;
+  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+  Real dmu_drho;
+  this->mu_drhoT_from_rho_T(rho, temperature, drho_dT, mu, dmu_drho, dmu_dT);
+  dmu_dp = dmu_drho * drho_dp;
+}
+
+Real
 MethaneFluidProperties::mu_from_rho_T(Real /*density*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (200 K <= T <= 1000 K)
@@ -186,6 +204,20 @@ MethaneFluidProperties::mu_drhoT_from_rho_T(Real density,
   for (std::size_t i = 0; i < a.size(); ++i)
     dmudt += i * a[i] * std::pow(temperature, i - 1.0);
   dmu_dT = dmudt * 1.e-6;
+}
+
+Real
+MethaneFluidProperties::k(Real pressure, Real temperature) const
+{
+  Real rho = this->rho(pressure, temperature);
+  return this->k_from_rho_T(rho, temperature);
+}
+
+void
+MethaneFluidProperties::k_dpT(
+    Real /*pressure*/, Real /*temperature*/, Real & /*k*/, Real & /*dk_dp*/, Real & /*dk_dT*/) const
+{
+  mooseError(name(), "k_dpT() is not implemented");
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
@@ -161,6 +161,21 @@ NaClFluidProperties::cv(Real pressure, Real temperature) const
   return e(pressure, temperature) / temperature;
 }
 
+Real NaClFluidProperties::mu(Real /*pressure*/, Real /*temperature*/) const
+{
+  mooseError(name(), ": mu() is not implemented.");
+}
+
+void
+NaClFluidProperties::mu_dpT(Real /*pressure*/,
+                            Real /*temperature*/,
+                            Real & /*mu*/,
+                            Real & /*dmu_dp*/,
+                            Real & /*dmu_dT*/) const
+{
+  mooseError(name(), ": mu_dpT() is not implemented.");
+}
+
 Real NaClFluidProperties::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const
 {
   mooseError("NaClFluidProperties::mu not implemented");
@@ -176,6 +191,18 @@ NaClFluidProperties::mu_drhoT_from_rho_T(Real /*density*/,
                                          Real & /*dmu_dT*/) const
 {
   mooseError("NaClFluidProperties::mu_drhoT not implemented");
+}
+
+Real NaClFluidProperties::k(Real /*pressure*/, Real /*temperature*/) const
+{
+  mooseError(name(), "k() is not implemented");
+}
+
+void
+NaClFluidProperties::k_dpT(
+    Real /*pressure*/, Real /*temperature*/, Real & /*k*/, Real & /*dk_dp*/, Real & /*dk_dT*/) const
+{
+  mooseError(name(), "k_dpT() is not implemented");
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
@@ -161,25 +161,25 @@ NaClFluidProperties::cv(Real pressure, Real temperature) const
   return e(pressure, temperature) / temperature;
 }
 
-Real NaClFluidProperties::mu(Real /*density*/, Real /*temperature*/) const
+Real NaClFluidProperties::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const
 {
   mooseError("NaClFluidProperties::mu not implemented");
   return 0.0;
 }
 
 void
-NaClFluidProperties::mu_drhoT(Real /*density*/,
-                              Real /*temperature*/,
-                              Real /*ddensity_dT*/,
-                              Real & /*mu*/,
-                              Real & /*dmu_drho*/,
-                              Real & /*dmu_dT*/) const
+NaClFluidProperties::mu_drhoT_from_rho_T(Real /*density*/,
+                                         Real /*temperature*/,
+                                         Real /*ddensity_dT*/,
+                                         Real & /*mu*/,
+                                         Real & /*dmu_drho*/,
+                                         Real & /*dmu_dT*/) const
 {
   mooseError("NaClFluidProperties::mu_drhoT not implemented");
 }
 
 Real
-NaClFluidProperties::k(Real /*density*/, Real temperature) const
+NaClFluidProperties::k_from_rho_T(Real /*density*/, Real temperature) const
 {
   // Correlation requires temperature in Celcius
   Real Tc = temperature - _T_c2k;

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -80,6 +80,20 @@ SimpleFluidProperties::c(Real pressure, Real temperature) const
   return std::sqrt(_bulk_modulus / rho(pressure, temperature));
 }
 
+Real SimpleFluidProperties::k(Real /*pressure*/, Real /*temperature*/) const
+{
+  return _thermal_conductivity;
+}
+
+void
+SimpleFluidProperties::k_dpT(
+    Real /*pressure*/, Real /*temperature*/, Real & k, Real & dk_dp, Real & dk_dT) const
+{
+  k = _thermal_conductivity;
+  dk_dp = 0;
+  dk_dT = 0;
+}
+
 Real SimpleFluidProperties::k_from_rho_T(Real /*density*/, Real /*temperature*/) const
 {
   return _thermal_conductivity;
@@ -141,6 +155,17 @@ SimpleFluidProperties::rho_e_dpT(Real pressure,
   e = energy;
   de_dp = denergy_dp;
   de_dT = denergy_dT;
+}
+
+Real SimpleFluidProperties::mu(Real /*pressure*/, Real /*temperature*/) const { return _viscosity; }
+
+void
+SimpleFluidProperties::mu_dpT(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  mu = this->mu(pressure, temperature);
+  dmu_dp = 0.0;
+  dmu_dT = 0.0;
 }
 
 Real SimpleFluidProperties::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -80,7 +80,7 @@ SimpleFluidProperties::c(Real pressure, Real temperature) const
   return std::sqrt(_bulk_modulus / rho(pressure, temperature));
 }
 
-Real SimpleFluidProperties::k(Real /*density*/, Real /*temperature*/) const
+Real SimpleFluidProperties::k_from_rho_T(Real /*density*/, Real /*temperature*/) const
 {
   return _thermal_conductivity;
 }
@@ -143,17 +143,20 @@ SimpleFluidProperties::rho_e_dpT(Real pressure,
   de_dT = denergy_dT;
 }
 
-Real SimpleFluidProperties::mu(Real /*density*/, Real /*temperature*/) const { return _viscosity; }
+Real SimpleFluidProperties::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const
+{
+  return _viscosity;
+}
 
 void
-SimpleFluidProperties::mu_drhoT(Real density,
-                                Real temperature,
-                                Real /*ddensity_dT*/,
-                                Real & mu,
-                                Real & dmu_drho,
-                                Real & dmu_dT) const
+SimpleFluidProperties::mu_drhoT_from_rho_T(Real density,
+                                           Real temperature,
+                                           Real /*ddensity_dT*/,
+                                           Real & mu,
+                                           Real & dmu_drho,
+                                           Real & dmu_dT) const
 {
-  mu = this->mu(density, temperature);
+  mu = this->mu_from_rho_T(density, temperature);
   dmu_drho = 0.0;
   dmu_dT = 0.0;
 }

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -273,20 +273,20 @@ TabulatedFluidProperties::h_dpT(
 }
 
 Real
-TabulatedFluidProperties::mu(Real density, Real temperature) const
+TabulatedFluidProperties::mu_from_rho_T(Real density, Real temperature) const
 {
-  return _fp.mu(density, temperature);
+  return _fp.mu_from_rho_T(density, temperature);
 }
 
 void
-TabulatedFluidProperties::mu_drhoT(Real density,
-                                   Real temperature,
-                                   Real ddensity_dT,
-                                   Real & mu,
-                                   Real & dmu_drho,
-                                   Real & dmu_dT) const
+TabulatedFluidProperties::mu_drhoT_from_rho_T(Real density,
+                                              Real temperature,
+                                              Real ddensity_dT,
+                                              Real & mu,
+                                              Real & dmu_drho,
+                                              Real & dmu_dT) const
 {
-  _fp.mu_drhoT(density, temperature, ddensity_dT, mu, dmu_drho, dmu_dT);
+  _fp.mu_drhoT_from_rho_T(density, temperature, ddensity_dT, mu, dmu_drho, dmu_dT);
 }
 
 Real
@@ -308,9 +308,9 @@ TabulatedFluidProperties::cv(Real pressure, Real temperature) const
 }
 
 Real
-TabulatedFluidProperties::k(Real density, Real temperature) const
+TabulatedFluidProperties::k_from_rho_T(Real density, Real temperature) const
 {
-  return _fp.k(density, temperature);
+  return _fp.k_from_rho_T(density, temperature);
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -273,6 +273,24 @@ TabulatedFluidProperties::h_dpT(
 }
 
 Real
+TabulatedFluidProperties::mu(Real pressure, Real temperature) const
+{
+  Real rho = this->rho(pressure, temperature);
+  return this->mu(rho, temperature);
+}
+
+void
+TabulatedFluidProperties::mu_dpT(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  Real rho, drho_dp, drho_dT;
+  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+  Real dmu_drho;
+  this->mu_drhoT_from_rho_T(rho, temperature, drho_dT, mu, dmu_drho, dmu_dT);
+  dmu_dp = dmu_drho * drho_dp;
+}
+
+Real
 TabulatedFluidProperties::mu_from_rho_T(Real density, Real temperature) const
 {
   return _fp.mu_from_rho_T(density, temperature);
@@ -305,6 +323,20 @@ Real
 TabulatedFluidProperties::cv(Real pressure, Real temperature) const
 {
   return _fp.cv(pressure, temperature);
+}
+
+Real
+TabulatedFluidProperties::k(Real pressure, Real temperature) const
+{
+  Real rho = this->rho(pressure, temperature);
+  return this->k_from_rho_T(rho, temperature);
+}
+
+void
+TabulatedFluidProperties::k_dpT(
+    Real /*pressure*/, Real /*temperature*/, Real & /*k*/, Real & /*dk_dp*/, Real & /*dk_dT*/) const
+{
+  mooseError(name(), "k_dpT() is not implemented");
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -471,7 +471,7 @@ Water97FluidProperties::cv(Real pressure, Real temperature) const
 }
 
 Real
-Water97FluidProperties::mu(Real density, Real temperature) const
+Water97FluidProperties::mu_from_rho_T(Real density, Real temperature) const
 {
   // Constants from Release on the IAPWS Formulation 2008 for the Viscosity of
   // Ordinary Water Substance
@@ -506,12 +506,12 @@ Water97FluidProperties::mu(Real density, Real temperature) const
 }
 
 void
-Water97FluidProperties::mu_drhoT(Real density,
-                                 Real temperature,
-                                 Real ddensity_dT,
-                                 Real & mu,
-                                 Real & dmu_drho,
-                                 Real & dmu_dT) const
+Water97FluidProperties::mu_drhoT_from_rho_T(Real density,
+                                            Real temperature,
+                                            Real ddensity_dT,
+                                            Real & mu,
+                                            Real & dmu_drho,
+                                            Real & dmu_dT) const
 {
   // Constants from Release on the IAPWS Formulation 2008 for the Viscosity of
   // Ordinary Water Substance
@@ -563,7 +563,7 @@ Water97FluidProperties::mu_drhoT(Real density,
 }
 
 Real
-Water97FluidProperties::k(Real density, Real temperature) const
+Water97FluidProperties::k_from_rho_T(Real density, Real temperature) const
 {
   // Scale the density and temperature. Note that the scales are slightly
   // different to the critical values used in IAPWS-IF97

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -471,6 +471,24 @@ Water97FluidProperties::cv(Real pressure, Real temperature) const
 }
 
 Real
+Water97FluidProperties::mu(Real pressure, Real temperature) const
+{
+  Real rho = this->rho(pressure, temperature);
+  return this->mu_from_rho_T(rho, temperature);
+}
+
+void
+Water97FluidProperties::mu_dpT(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  Real rho, drho_dp, drho_dT;
+  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+  Real dmu_drho;
+  this->mu_drhoT_from_rho_T(rho, temperature, drho_dT, mu, dmu_drho, dmu_dT);
+  dmu_dp = dmu_drho * drho_dp;
+}
+
+Real
 Water97FluidProperties::mu_from_rho_T(Real density, Real temperature) const
 {
   // Constants from Release on the IAPWS Formulation 2008 for the Viscosity of
@@ -560,6 +578,20 @@ Water97FluidProperties::mu_drhoT_from_rho_T(Real density,
   mu = mu_star * mu0 * mu1;
   dmu_drho = mu_star * mu0 * dmu1_drho * drhobar_drho;
   dmu_dT = mu_star * (dmu0_dTbar * mu1 + mu0 * dmu1_dTbar) * dTbar_dT + dmu_drho * ddensity_dT;
+}
+
+Real
+Water97FluidProperties::k(Real pressure, Real temperature) const
+{
+  Real rho = this->rho(pressure, temperature);
+  return this->k_from_rho_T(rho, temperature);
+}
+
+void
+Water97FluidProperties::k_dpT(
+    Real /*pressure*/, Real /*temperature*/, Real & /*k*/, Real & /*dk_dp*/, Real & /*dk_dT*/) const
+{
+  mooseError(name(), "k_dpT() is not implemented");
 }
 
 Real

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateBrineCO2.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateBrineCO2.C
@@ -150,7 +150,7 @@ PorousFlowFluidStateBrineCO2::thermophysicalProperties()
     dgas_density_dz = 0.0;
 
     Real co2_viscosity, dco2_viscosity_drho, dco2_viscosity_dT;
-    _co2_fp.mu_drhoT(
+    _co2_fp.mu_drhoT_from_rho_T(
         co2_density, Tk, dco2_density_dT, co2_viscosity, dco2_viscosity_drho, dco2_viscosity_dT);
 
     // Assume that the viscosity of the gas phase is a weighted sum of the

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateWaterNCG.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateWaterNCG.C
@@ -174,14 +174,14 @@ PorousFlowFluidStateWaterNCG::thermophysicalProperties()
 
     Real ncg_viscosity, dncg_viscosity_drho, dncg_viscosity_dT;
     Real vapor_viscosity, dvapor_viscosity_drho, dvapor_viscosity_dT;
-    _ncg_fp.mu_drhoT(
+    _ncg_fp.mu_drhoT_from_rho_T(
         ncg_density, Tk, dncg_density_dT, ncg_viscosity, dncg_viscosity_drho, dncg_viscosity_dT);
-    _water_fp.mu_drhoT(vapor_density,
-                       Tk,
-                       dvapor_density_dT,
-                       vapor_viscosity,
-                       dvapor_viscosity_drho,
-                       dvapor_viscosity_dT);
+    _water_fp.mu_drhoT_from_rho_T(vapor_density,
+                                  Tk,
+                                  dvapor_density_dT,
+                                  vapor_viscosity,
+                                  dvapor_viscosity_drho,
+                                  dvapor_viscosity_dT);
 
     // Assume that the viscosity of the gas phase is a weighted sum of the
     // individual viscosities
@@ -234,12 +234,12 @@ PorousFlowFluidStateWaterNCG::thermophysicalProperties()
     Real dliquid_viscosity_drho;
     _water_fp.rho_dpT(
         liquid_porepressure, Tk, liquid_density, dliquid_density_dp, dliquid_density_dT);
-    _water_fp.mu_drhoT(liquid_density,
-                       Tk,
-                       dliquid_density_dT,
-                       liquid_viscosity,
-                       dliquid_viscosity_drho,
-                       dliquid_viscosity_dT);
+    _water_fp.mu_drhoT_from_rho_T(liquid_density,
+                                  Tk,
+                                  dliquid_density_dT,
+                                  liquid_viscosity,
+                                  dliquid_viscosity_drho,
+                                  dliquid_viscosity_dT);
 
     // The derivative of viscosity wrt pressure is given by the chain rule
     dliquid_viscosity_dp = dliquid_viscosity_drho * dliquid_density_dp;

--- a/modules/porous_flow/src/materials/PorousFlowSingleComponentFluid.C
+++ b/modules/porous_flow/src/materials/PorousFlowSingleComponentFluid.C
@@ -151,7 +151,7 @@ PorousFlowSingleComponentFluid::computeQpProperties()
     // Viscosity and derivatives wrt pressure and temperature at the nodes.
     // Note that dmu_dp = dmu_drho * drho_dp
     Real mu, dmu_drho, dmu_dT;
-    _fp.mu_drhoT(rho, Tk, drho_dT, mu, dmu_drho, dmu_dT);
+    _fp.mu_drhoT_from_rho_T(rho, Tk, drho_dT, mu, dmu_drho, dmu_dT);
     (*_viscosity)[_qp] = mu;
     (*_dviscosity_dp)[_qp] = dmu_drho * drho_dp;
     (*_dviscosity_dT)[_qp] = dmu_dT;

--- a/unit/src/BrineFluidPropertiesTest.C
+++ b/unit/src/BrineFluidPropertiesTest.C
@@ -75,14 +75,17 @@ TEST_F(BrineFluidPropertiesTest, properties)
   REL_TEST("density", _fp->rho(p1, T1, x1), 1065.58, 1.0e-2);
 
   // Viscosity
-  REL_TEST("viscosity", _fp->mu(_water_fp->rho(p0, T0), T0, x0), 679.8e-6, 2.0e-2);
-  REL_TEST("viscosity", _fp->mu(_water_fp->rho(p0, T1), T1, x0), 180.0e-6, 2.0e-2);
-  REL_TEST("viscosity", _fp->mu(_water_fp->rho(p1, T1), T1, x1), 263.1e-6, 2.0e-2);
+  REL_TEST("viscosity", _fp->mu_from_rho_T(_water_fp->rho(p0, T0), T0, x0), 679.8e-6, 2.0e-2);
+  REL_TEST("viscosity", _fp->mu_from_rho_T(_water_fp->rho(p0, T1), T1, x0), 180.0e-6, 2.0e-2);
+  REL_TEST("viscosity", _fp->mu_from_rho_T(_water_fp->rho(p1, T1), T1, x1), 263.1e-6, 2.0e-2);
 
   // Thermal conductivity
-  REL_TEST("thermal conductivity", _fp->k(_water_fp->rho(p0, T0), T0, x0), 0.630, 4.0e-2);
-  REL_TEST("thermal conductivity", _fp->k(_water_fp->rho(p0, T1), T1, x0), 0.649, 4.0e-2);
-  REL_TEST("thermal conductivity", _fp->k(_water_fp->rho(p1, T1), T1, x1), 0.633, 4.0e-2);
+  REL_TEST(
+      "thermal conductivity", _fp->k_from_rho_T(_water_fp->rho(p0, T0), T0, x0), 0.630, 4.0e-2);
+  REL_TEST(
+      "thermal conductivity", _fp->k_from_rho_T(_water_fp->rho(p0, T1), T1, x0), 0.649, 4.0e-2);
+  REL_TEST(
+      "thermal conductivity", _fp->k_from_rho_T(_water_fp->rho(p1, T1), T1, x1), 0.633, 4.0e-2);
 
   // Enthalpy
   p0 = 10.0e6;
@@ -158,12 +161,14 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   // Viscosity
   Real drho = 1.0e-4;
 
-  Real dmu_drho_fd = (_fp->mu(rho + drho, T, x) - _fp->mu(rho - drho, T, x)) / (2.0 * drho);
-  Real dmu_dx_fd = (_fp->mu(rho, T, x + dx) - _fp->mu(rho, T, x - dx)) / (2.0 * dx);
+  Real dmu_drho_fd =
+      (_fp->mu_from_rho_T(rho + drho, T, x) - _fp->mu_from_rho_T(rho - drho, T, x)) / (2.0 * drho);
+  Real dmu_dx_fd =
+      (_fp->mu_from_rho_T(rho, T, x + dx) - _fp->mu_from_rho_T(rho, T, x - dx)) / (2.0 * dx);
   Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0, dmu_dx = 0.0;
   _fp->mu_drhoTx(rho, T, x, drho_dT, mu, dmu_drho, dmu_dT, dmu_dx);
 
-  ABS_TEST("mu", mu, _fp->mu(rho, T, x), 1.0e-15);
+  ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T, x), 1.0e-15);
   REL_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-6);
   REL_TEST("dmu_dx", dmu_dx, dmu_dx_fd, 1.0e-6);
 
@@ -171,9 +176,9 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   // so that the change in density wrt temperature is included
   _fp->rho_dpTx(p, T, x, rho, drho_dp, drho_dT, drho_dx);
   _fp->mu_drhoTx(rho, T, x, drho_dT, mu, dmu_drho, dmu_dT, dmu_dx);
-  Real dmu_dT_fd =
-      (_fp->mu(_fp->rho(p, T + dT, x), T + dT, x) - _fp->mu(_fp->rho(p, T - dT, x), T - dT, x)) /
-      (2.0 * dT);
+  Real dmu_dT_fd = (_fp->mu_from_rho_T(_fp->rho(p, T + dT, x), T + dT, x) -
+                    _fp->mu_from_rho_T(_fp->rho(p, T - dT, x), T - dT, x)) /
+                   (2.0 * dT);
 
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
 
@@ -199,7 +204,7 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   REL_TEST("de_dx", de_dx, de_dx_fd, 1.0e-3);
 
   // Viscosity
-  dmu_dx_fd = (_fp->mu(rho, T, x + dx) - _fp->mu(rho, T, x)) / dx;
+  dmu_dx_fd = (_fp->mu_from_rho_T(rho, T, x + dx) - _fp->mu_from_rho_T(rho, T, x)) / dx;
   _fp->mu_drhoTx(rho, T, x, drho_dT, mu, dmu_drho, dmu_dT, dmu_dx);
 
   REL_TEST("dmu_dx", dmu_dx, dmu_dx_fd, 1.0e-3);

--- a/unit/src/CO2FluidPropertiesTest.C
+++ b/unit/src/CO2FluidPropertiesTest.C
@@ -109,6 +109,13 @@ TEST_F(CO2FluidPropertiesTest, thermalConductivity)
   REL_TEST("thermal conductivity", _fp->k_from_rho_T(11.899, 450.0), 29.377e-3, 1.0e-3);
 }
 
+TEST_F(CO2FluidPropertiesTest, thermalConductivity2)
+{
+  REL_TEST("thermal conductivity", _fp->k(1.0e6, 250.0), 1.34504e-2, 1.0e-6);
+  REL_TEST("thermal conductivity", _fp->k(1.0e6, 300.0), 1.72483e-2, 3.0e-6);
+  REL_TEST("thermal conductivity", _fp->k(1.0e6, 450.0), 2.93767e-2, 1.0e-6);
+}
+
 /**
  * Verify calculation of viscosity using data from
  * Fenghour et al., The viscosity of carbon dioxide,
@@ -119,6 +126,13 @@ TEST_F(CO2FluidPropertiesTest, viscosity)
   REL_TEST("viscosity", _fp->mu_from_rho_T(20.199, 280.0), 14.15e-6, 1.0e-3);
   REL_TEST("viscosity", _fp->mu_from_rho_T(15.105, 360.0), 17.94e-6, 1.0e-3);
   REL_TEST("viscosity", _fp->mu_from_rho_T(10.664, 500.0), 24.06e-6, 1.0e-3);
+}
+
+TEST_F(CO2FluidPropertiesTest, viscosity2)
+{
+  REL_TEST("viscosity", _fp->mu(1.0e6, 280.0), 1.41505e-05, 3.0e-6);
+  REL_TEST("viscosity", _fp->mu(1.0e6, 360.0), 1.79395e-05, 2.0e-6);
+  REL_TEST("viscosity", _fp->mu(1.0e6, 500.0), 2.40643e-05, 1.0e-6);
 }
 
 /**
@@ -217,7 +231,7 @@ TEST_F(CO2FluidPropertiesTest, derivatives)
   _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
   ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
-  REL_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-6);
+  REL_TEST("dmu_drho", dmu_drho, dmu_drho_fd, 1.0e-6);
 
   // To properly test derivative wrt temperature, use p and T and calculate density,
   // so that the change in density wrt temperature is included
@@ -227,6 +241,18 @@ TEST_F(CO2FluidPropertiesTest, derivatives)
   Real dmu_dT_fd = (_fp->mu_from_rho_T(_fp->rho(p, T + dT), T + dT) -
                     _fp->mu_from_rho_T(_fp->rho(p, T - dT), T - dT)) /
                    (2.0 * dT);
+
+  REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
+
+  Real dmu_dp_fd = (_fp->mu(p + dp, T) - _fp->mu(p - dp, T)) / (2.0 * dp);
+  Real dmu_dp = 0.0;
+  _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
+
+  ABS_TEST("mu", mu, _fp->mu(p, T), 1.0e-15);
+  REL_TEST("dmu_dp", dmu_dp, dmu_dp_fd, 1.0e-6);
+
+  _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
+  dmu_dT_fd = (_fp->mu(p, T + dT) - _fp->mu(p, T - dT)) / (2.0 * dT);
 
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
 

--- a/unit/src/CO2FluidPropertiesTest.C
+++ b/unit/src/CO2FluidPropertiesTest.C
@@ -104,9 +104,9 @@ TEST_F(CO2FluidPropertiesTest, henry)
  */
 TEST_F(CO2FluidPropertiesTest, thermalConductivity)
 {
-  REL_TEST("thermal conductivity", _fp->k(23.435, 250.0), 13.45e-3, 1.0e-3);
-  REL_TEST("thermal conductivity", _fp->k(18.579, 300.0), 17.248e-3, 1.0e-3);
-  REL_TEST("thermal conductivity", _fp->k(11.899, 450.0), 29.377e-3, 1.0e-3);
+  REL_TEST("thermal conductivity", _fp->k_from_rho_T(23.435, 250.0), 13.45e-3, 1.0e-3);
+  REL_TEST("thermal conductivity", _fp->k_from_rho_T(18.579, 300.0), 17.248e-3, 1.0e-3);
+  REL_TEST("thermal conductivity", _fp->k_from_rho_T(11.899, 450.0), 29.377e-3, 1.0e-3);
 }
 
 /**
@@ -116,9 +116,9 @@ TEST_F(CO2FluidPropertiesTest, thermalConductivity)
  */
 TEST_F(CO2FluidPropertiesTest, viscosity)
 {
-  REL_TEST("viscosity", _fp->mu(20.199, 280.0), 14.15e-6, 1.0e-3);
-  REL_TEST("viscosity", _fp->mu(15.105, 360.0), 17.94e-6, 1.0e-3);
-  REL_TEST("viscosity", _fp->mu(10.664, 500.0), 24.06e-6, 1.0e-3);
+  REL_TEST("viscosity", _fp->mu_from_rho_T(20.199, 280.0), 14.15e-6, 1.0e-3);
+  REL_TEST("viscosity", _fp->mu_from_rho_T(15.105, 360.0), 17.94e-6, 1.0e-3);
+  REL_TEST("viscosity", _fp->mu_from_rho_T(10.664, 500.0), 24.06e-6, 1.0e-3);
 }
 
 /**
@@ -211,20 +211,22 @@ TEST_F(CO2FluidPropertiesTest, derivatives)
   Real drho = 1.0e-4;
   _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
 
-  Real dmu_drho_fd = (_fp->mu(rho + drho, T) - _fp->mu(rho - drho, T)) / (2.0 * drho);
+  Real dmu_drho_fd =
+      (_fp->mu_from_rho_T(rho + drho, T) - _fp->mu_from_rho_T(rho - drho, T)) / (2.0 * drho);
   Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0;
-  _fp->mu_drhoT(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
+  _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
-  ABS_TEST("mu", mu, _fp->mu(rho, T), 1.0e-15);
+  ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
   REL_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-6);
 
   // To properly test derivative wrt temperature, use p and T and calculate density,
   // so that the change in density wrt temperature is included
   p = 1.0e6;
   _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
-  _fp->mu_drhoT(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
-  Real dmu_dT_fd =
-      (_fp->mu(_fp->rho(p, T + dT), T + dT) - _fp->mu(_fp->rho(p, T - dT), T - dT)) / (2.0 * dT);
+  _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
+  Real dmu_dT_fd = (_fp->mu_from_rho_T(_fp->rho(p, T + dT), T + dT) -
+                    _fp->mu_from_rho_T(_fp->rho(p, T - dT), T - dT)) /
+                   (2.0 * dT);
 
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
 

--- a/unit/src/IdealGasFluidPropertiesPTTest.C
+++ b/unit/src/IdealGasFluidPropertiesPTTest.C
@@ -40,10 +40,12 @@ TEST_F(IdealGasFluidPropertiesPTTest, properties)
   REL_TEST("cv", _fp->cv(p, T), cv, tol);
   REL_TEST("c", _fp->c(p, T), std::sqrt(cp * R * T / (cv * molar_mass)), tol);
   REL_TEST("k", _fp->k(p, T), thermal_conductivity, tol);
+  REL_TEST("k", _fp->k_from_rho_T(_fp->rho(p, T), T), thermal_conductivity, tol);
   REL_TEST("s", _fp->s(p, T), entropy, tol);
   REL_TEST("rho", _fp->rho(p, T), p * molar_mass / (R * T), tol);
   REL_TEST("e", _fp->e(p, T), cv * T, tol);
   REL_TEST("mu", _fp->mu(p, T), viscosity, tol);
+  REL_TEST("mu", _fp->mu_from_rho_T(_fp->rho(p, T), T), viscosity, tol);
   REL_TEST("h", _fp->h(p, T), cp * T, tol);
   ABS_TEST("henry", _fp->henryConstant(T), henry, tol);
 }
@@ -82,4 +84,11 @@ TEST_F(IdealGasFluidPropertiesPTTest, derivatives)
   ABS_TEST("dh_dp", dh_dp, 0.0, tol);
   fd = (_fp->h(p, T + dT) - _fp->h(p, T - dT)) / (2.0 * dT);
   REL_TEST("dh_dT", dh_dT, fd, tol);
+
+  Real mu, dmu_dp, dmu_dT;
+  _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
+  fd = (_fp->mu(p + dp, T) - _fp->mu(p - dp, T)) / (2.0 * dp);
+  ABS_TEST("dmu_dp", dmu_dp, fd, tol);
+  fd = (_fp->mu(p, T + dT) - _fp->mu(p, T - dT)) / (2.0 * dT);
+  ABS_TEST("dh_dT", dmu_dT, fd, tol);
 }

--- a/unit/src/MethaneFluidPropertiesTest.C
+++ b/unit/src/MethaneFluidPropertiesTest.C
@@ -104,7 +104,16 @@ TEST_F(MethaneFluidPropertiesTest, derivatives)
   _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
   ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
-  ABS_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-15);
+  ABS_TEST("dmu_drho", dmu_drho, dmu_drho_fd, 1.0e-15);
+  REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
+
+  Real dmu_dp_fd = (_fp->mu(p + dp, T) - _fp->mu(p - dp, T)) / (2.0 * dp);
+  dmu_dT_fd = (_fp->mu(p, T + dT) - _fp->mu(p, T - dT)) / (2.0 * dT);
+  Real dmu_dp = 0.0;
+  _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
+
+  ABS_TEST("mu", mu, _fp->mu(p, T), 1.0e-15);
+  ABS_TEST("dmu_dp", dmu_dp, dmu_dp_fd, 1.0e-15);
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
 
   // Henry's constant

--- a/unit/src/MethaneFluidPropertiesTest.C
+++ b/unit/src/MethaneFluidPropertiesTest.C
@@ -46,8 +46,8 @@ TEST_F(MethaneFluidPropertiesTest, properties)
   REL_TEST("cp", _fp->cp(p, T), 2.375e3, 1.0e-3);
   REL_TEST("cv", _fp->cv(p, T), 1.857e3, 1.0e-3);
   REL_TEST("c", _fp->c(p, T), 481.7, 1.0e-3);
-  REL_TEST("mu", _fp->mu(0.0, T), 0.01276e-3, 1.0e-3);
-  REL_TEST("thermal conductivity", _fp->k(0.0, T), 0.04113, 1.0e-3);
+  REL_TEST("mu", _fp->mu_from_rho_T(0.0, T), 0.01276e-3, 1.0e-3);
+  REL_TEST("thermal conductivity", _fp->k_from_rho_T(0.0, T), 0.04113, 1.0e-3);
 }
 
 /**
@@ -97,12 +97,13 @@ TEST_F(MethaneFluidPropertiesTest, derivatives)
   rho = 1.0; // Not used in correlations
   Real drho = 1.0e-4;
 
-  Real dmu_drho_fd = (_fp->mu(rho + drho, T) - _fp->mu(rho - drho, T)) / (2.0 * drho);
-  Real dmu_dT_fd = (_fp->mu(rho, T + dT) - _fp->mu(rho, T - dT)) / (2.0 * dT);
+  Real dmu_drho_fd =
+      (_fp->mu_from_rho_T(rho + drho, T) - _fp->mu_from_rho_T(rho - drho, T)) / (2.0 * drho);
+  Real dmu_dT_fd = (_fp->mu_from_rho_T(rho, T + dT) - _fp->mu_from_rho_T(rho, T - dT)) / (2.0 * dT);
   Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0;
-  _fp->mu_drhoT(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
+  _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
-  ABS_TEST("mu", mu, _fp->mu(rho, T), 1.0e-15);
+  ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
   ABS_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-15);
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
 

--- a/unit/src/NaClFluidPropertiesTest.C
+++ b/unit/src/NaClFluidPropertiesTest.C
@@ -54,9 +54,9 @@ TEST_F(NaClFluidPropertiesTest, halite)
   REL_TEST("enthalpy", _fp->h(pt, 673.15), 366.55e3, 1.0e-3);
 
   // Thermal conductivity (function of T only)
-  REL_TEST("k", _fp->k(p0, 323.15), 5.488, 1.0e-2);
-  REL_TEST("k", _fp->k(p0, 423.15), 3.911, 1.0e-2);
-  REL_TEST("k", _fp->k(p0, 523.15), 3.024, 2.0e-2);
+  REL_TEST("k", _fp->k_from_rho_T(p0, 323.15), 5.488, 1.0e-2);
+  REL_TEST("k", _fp->k_from_rho_T(p0, 423.15), 3.911, 1.0e-2);
+  REL_TEST("k", _fp->k_from_rho_T(p0, 523.15), 3.024, 2.0e-2);
 }
 
 /**

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -30,34 +30,36 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   const Real henry = 0.0;
   const Real pp_coef = 0.0;
 
-  Real P, T;
+  Real P, T, rho;
 
   P = 1E3;
   T = 200;
+  rho = _fp->rho(P, T);
   REL_TEST("beta", _fp->beta(P, T), thermal_exp, 1.0E-8);
   REL_TEST("cp", _fp->cp(P, T), cp, 1.0E-8);
   REL_TEST("cv", _fp->cv(P, T), cv, 1.0E-8);
   REL_TEST("c", _fp->c(P, T), std::sqrt(bulk_modulus / _fp->rho(P, T)), 1.0E-8);
-  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
+  REL_TEST("k", _fp->k_from_rho_T(rho, T), thermal_cond, 1.0E-8);
   REL_TEST("s", _fp->s(P, T), entropy, 1.0E-8);
   REL_TEST("rho", _fp->rho(P, T), density0 * std::exp(P / bulk_modulus - thermal_exp * T), 1.0E-8);
   REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
-  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
+  REL_TEST("mu", _fp->mu_from_rho_T(rho, T), visc, 1.0E-8);
   REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
   REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
   ABS_TEST("henry", _fp->henryConstant(T), henry, 1.0E-8);
 
   P = 1E7;
   T = 300;
+  rho = _fp->rho(P, T);
   REL_TEST("beta", _fp->beta(P, T), thermal_exp, 1.0E-8);
   REL_TEST("cp", _fp->cp(P, T), cp, 1.0E-8);
   REL_TEST("cv", _fp->cv(P, T), cv, 1.0E-8);
   REL_TEST("c", _fp->c(P, T), std::sqrt(bulk_modulus / _fp->rho(P, T)), 1.0E-8);
-  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
+  REL_TEST("k", _fp->k_from_rho_T(rho, T), thermal_cond, 1.0E-8);
   REL_TEST("s", _fp->s(P, T), entropy, 1.0E-8);
   REL_TEST("rho", _fp->rho(P, T), density0 * std::exp(P / bulk_modulus - thermal_exp * T), 1.0E-8);
   REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
-  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
+  REL_TEST("mu", _fp->mu_from_rho_T(rho, T), visc, 1.0E-8);
   REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
   REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
   ABS_TEST("henry", _fp->henryConstant(T), henry, 1.0E-8);
@@ -113,18 +115,18 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   Real mu, dmu_drho, dmu_dT;
   dens = 1000;
   T = 10;
-  _fp->mu_drhoT(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
-  fd = (_fp->mu(dens + ddens, T) - _fp->mu(dens - ddens, T)) / (2.0 * ddens);
+  _fp->mu_drhoT_from_rho_T(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
+  fd = (_fp->mu_from_rho_T(dens + ddens, T) - _fp->mu_from_rho_T(dens - ddens, T)) / (2.0 * ddens);
   ABS_TEST("dmu_ddens", dmu_drho, fd, 1.0E-8);
-  fd = (_fp->mu(dens, T + dT) - _fp->mu(dens, T - dT)) / (2.0 * dT);
+  fd = (_fp->mu_from_rho_T(dens, T + dT) - _fp->mu_from_rho_T(dens, T - dT)) / (2.0 * dT);
   ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
 
   dens = 2000;
   T = 80;
-  _fp->mu_drhoT(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
-  fd = (_fp->mu(dens + ddens, T) - _fp->mu(dens - ddens, T)) / (2.0 * ddens);
+  _fp->mu_drhoT_from_rho_T(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
+  fd = (_fp->mu_from_rho_T(dens + ddens, T) - _fp->mu_from_rho_T(dens - ddens, T)) / (2.0 * ddens);
   ABS_TEST("dmu_ddens", dmu_drho, fd, 1.0E-8);
-  fd = (_fp->mu(dens, T + dT) - _fp->mu(dens, T - dT)) / (2.0 * dT);
+  fd = (_fp->mu_from_rho_T(dens, T + dT) - _fp->mu_from_rho_T(dens, T - dT)) / (2.0 * dT);
   ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
 
   Real h, dh_dp, dh_dT;

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -39,10 +39,12 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   REL_TEST("cp", _fp->cp(P, T), cp, 1.0E-8);
   REL_TEST("cv", _fp->cv(P, T), cv, 1.0E-8);
   REL_TEST("c", _fp->c(P, T), std::sqrt(bulk_modulus / _fp->rho(P, T)), 1.0E-8);
+  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
   REL_TEST("k", _fp->k_from_rho_T(rho, T), thermal_cond, 1.0E-8);
   REL_TEST("s", _fp->s(P, T), entropy, 1.0E-8);
   REL_TEST("rho", _fp->rho(P, T), density0 * std::exp(P / bulk_modulus - thermal_exp * T), 1.0E-8);
   REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
+  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
   REL_TEST("mu", _fp->mu_from_rho_T(rho, T), visc, 1.0E-8);
   REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
   REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
@@ -55,10 +57,12 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   REL_TEST("cp", _fp->cp(P, T), cp, 1.0E-8);
   REL_TEST("cv", _fp->cv(P, T), cv, 1.0E-8);
   REL_TEST("c", _fp->c(P, T), std::sqrt(bulk_modulus / _fp->rho(P, T)), 1.0E-8);
+  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
   REL_TEST("k", _fp->k_from_rho_T(rho, T), thermal_cond, 1.0E-8);
   REL_TEST("s", _fp->s(P, T), entropy, 1.0E-8);
   REL_TEST("rho", _fp->rho(P, T), density0 * std::exp(P / bulk_modulus - thermal_exp * T), 1.0E-8);
   REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
+  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
   REL_TEST("mu", _fp->mu_from_rho_T(rho, T), visc, 1.0E-8);
   REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
   REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
@@ -121,6 +125,20 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   fd = (_fp->mu_from_rho_T(dens, T + dT) - _fp->mu_from_rho_T(dens, T - dT)) / (2.0 * dT);
   ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
 
+  Real dmu_dp;
+  _fp->mu_dpT(P, T, mu, dmu_dp, dmu_dT);
+  fd = (_fp->mu(P + dP, T) - _fp->mu(P - dP, T)) / (2.0 * dP);
+  ABS_TEST("dmu_dp", dmu_dp, fd, 1.0E-8);
+  fd = (_fp->mu(P, T + dT) - _fp->mu(P, T - dT)) / (2.0 * dT);
+  ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
+
+  Real k, dk_dp, dk_dT;
+  _fp->k_dpT(P, T, k, dk_dp, dk_dT);
+  fd = (_fp->k(P + dP, T) - _fp->k(P - dP, T)) / (2.0 * dP);
+  ABS_TEST("dk_dp", dk_dp, fd, 1.0E-8);
+  fd = (_fp->k(P, T + dT) - _fp->k(P, T - dT)) / (2.0 * dT);
+  ABS_TEST("dk_dT", dk_dT, fd, 1.0E-8);
+
   dens = 2000;
   T = 80;
   _fp->mu_drhoT_from_rho_T(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
@@ -128,6 +146,18 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   ABS_TEST("dmu_ddens", dmu_drho, fd, 1.0E-8);
   fd = (_fp->mu_from_rho_T(dens, T + dT) - _fp->mu_from_rho_T(dens, T - dT)) / (2.0 * dT);
   ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
+
+  _fp->mu_dpT(P, T, mu, dmu_dp, dmu_dT);
+  fd = (_fp->mu(P + dP, T) - _fp->mu(P - dP, T)) / (2.0 * dP);
+  ABS_TEST("dmu_dp", dmu_dp, fd, 1.0E-8);
+  fd = (_fp->mu(P, T + dT) - _fp->mu(P, T - dT)) / (2.0 * dT);
+  ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
+
+  _fp->k_dpT(P, T, k, dk_dp, dk_dT);
+  fd = (_fp->k(P + dP, T) - _fp->k(P - dP, T)) / (2.0 * dP);
+  ABS_TEST("dk_dp", dk_dp, fd, 1.0E-8);
+  fd = (_fp->k(P, T + dT) - _fp->k(P, T - dT)) / (2.0 * dT);
+  ABS_TEST("dk_dT", dk_dT, fd, 1.0E-8);
 
   Real h, dh_dp, dh_dT;
   P = 1E6;

--- a/unit/src/Water97FluidPropertiesTest.C
+++ b/unit/src/Water97FluidPropertiesTest.C
@@ -419,12 +419,27 @@ TEST_F(Water97FluidPropertiesTest, properties)
   REL_TEST("mu", _fp->mu_from_rho_T(100.0, 1173.15), 47.640433e-6, 1.0e-8);
   REL_TEST("mu", _fp->mu_from_rho_T(400.0, 1173.15), 64.154608e-6, 1.0e-8);
 
+  ABS_TEST("mu", _fp->mu(1e6, 298.15), 889.898581797e-6, 2e-8);
+  ABS_TEST("mu", _fp->mu(2e6, 298.15), 889.763899645e-6, 1e-8);
+  ABS_TEST("mu", _fp->mu(1e6, 373.15), 281.825180491e-6, 1e-8);
+  ABS_TEST("mu", _fp->mu(2e6, 373.15), 282.09550632e-6, 1e-8);
+  ABS_TEST("mu", _fp->mu(1e6, 433.15), 170.526801634e-6, 1e-8);
+  ABS_TEST("mu", _fp->mu(2e6, 433.15), 170.780193827e-6, 1e-8);
+  ABS_TEST("mu", _fp->mu(1e6, 873.15), 3.2641885983e-5, 1e-12);
+  ABS_TEST("mu", _fp->mu(2e6, 873.15), 3.26820969808e-5, 1e-12);
+  ABS_TEST("mu", _fp->mu(1e6, 1173.15), 4.42374919686e-5, 1e-12);
+  ABS_TEST("mu", _fp->mu(2e6, 1173.15), 4.42823959629e-5, 1e-12);
+
   // Thermal conductivity
   // Note: data is given for pressure and temperature, but k requires density
   // and temperature
   REL_TEST("k", _fp->k_from_rho_T(_fp->rho(1.0e6, 323.15), 323.15), 0.641, 1.0e-4);
   REL_TEST("k", _fp->k_from_rho_T(_fp->rho(20.0e6, 623.15), 623.15), 0.4541, 1.0e-4);
   REL_TEST("k", _fp->k_from_rho_T(_fp->rho(50.0e6, 773.15), 773.15), 0.2055, 1.0e-4);
+
+  ABS_TEST("k", _fp->k(1.0e6, 323.15), 0.640972, 5e-7);
+  ABS_TEST("k", _fp->k(20.0e6, 623.15), 0.454131, 7e-7);
+  ABS_TEST("k", _fp->k(50.0e6, 773.15), 0.205485, 5e-7);
 
   // Backwards equation T(p,h)
   // Region 1


### PR DESCRIPTION
This adds 2 functions:

1. k(p, T)
2. mu(p, T)

The interface already has computation of k and mu, but in terms for density and temperature.  This stays, but  under different names: `k_from_rho_T` and `mu_from_rho_T`.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
