### PR TITLE
hit: fix empty parentless section render bugs

### DIFF
--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -375,17 +375,19 @@ std::string
 Section::render(int indent)
 {
   std::string s;
-  if (root() != this)
+  if (path() != "")
     s = "\n" + strRepeat(indentString, indent) + "[" + _path + "]";
-  else
-    indent--; // don't indent the root section contents extra
 
   for (auto child : children())
-    s += child->render(indent + 1);
+    if (path() == "")
+      s += child->render(indent);
+    else
+      s += child->render(indent + 1);
 
-  if (root() != this)
+  if (path() != "")
     s += "\n" + strRepeat(indentString, indent) + "[]";
-  else
+
+  if (indent == 0 && s[0] == '\n')
     s = s.substr(1);
   return s;
 }


### PR DESCRIPTION
Rendering sections inccorrectly assumed that all parentless
sections had a non-empty body.  It also assumed that all parentless
sections were the root section and therefore did not render their
opening/closing path blocks.  Fix this and add a bunch of tests.

fixes #10155

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
