### PR TITLE
Adds error checking for negative number of moles

### DIFF
--- a/modules/combined/test/tests/cavity_pressure/cavity_pressure_negative_volume.i
+++ b/modules/combined/test/tests/cavity_pressure/cavity_pressure_negative_volume.i
@@ -1,0 +1,141 @@
+#
+# Cavity Pressure Test
+#
+# This test is designed to compute a negative number of moles
+# to trigger an error check in the CavityPressureUserObject.
+# The negative number of moles is achieved by supplying an
+# open volume to the InternalVolume postprocessor, which
+# calculates a negative volume.
+
+[Problem]
+  coord_type = RZ
+[]
+
+[GlobalParams]
+  displacements = 'disp_r disp_z'
+  order = FIRST
+  family = LAGRANGE
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 1
+  ny = 2
+[]
+
+[Functions]
+  [./temperature]
+    type = PiecewiseLinear
+    x = '0 1'
+    y = '1 2'
+    scale_factor = 100
+  [../]
+[]
+
+[Variables]
+  [./temperature]
+    initial_condition = 100
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./block]
+    strain = FINITE
+    add_variables = true
+  [../]
+[]
+
+[Kernels]
+  [./heat]
+    type = HeatConduction
+    variable = temperature
+  [../]
+[]
+
+[BCs]
+  [./no_x]
+    type = PresetBC
+    variable = disp_r
+    boundary = left
+    value = 0.0
+  [../]
+  [./no_y]
+    type = PresetBC
+    variable = disp_z
+    boundary = bottom
+    value = 0.0
+  [../]
+  [./temperatureInterior]
+    type = FunctionDirichletBC
+    boundary = 2
+    function = temperature
+    variable = temperature
+  [../]
+  [./CavityPressure]
+    [./pressure]
+      boundary = 'top bottom right'
+      initial_pressure = 10e5
+      R = 8.3143
+      output_initial_moles = initial_moles
+      temperature = aveTempInterior
+      volume = internalVolume
+      startup_time = 0.5
+      output = ppress
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./elastic_tensor]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 1e6
+    poissons_ratio = 0.3
+  [../]
+  [./stress1]
+    type = ComputeFiniteStrainElasticStress
+  [../]
+  [./heatconduction]
+    type = HeatConductionMaterial
+    thermal_conductivity = 1.0
+    specific_heat = 1.0
+  [../]
+  [./density]
+    type = Density
+    density = 1.0
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  #Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type -sub_pc_type'
+  petsc_options_value = 'asm       lu'
+
+  nl_abs_tol = 1e-10
+  l_max_its = 20
+  start_time = 0.0
+  dt = 0.5
+  end_time = 1.0
+[]
+
+[Postprocessors]
+  [./internalVolume]
+    type = InternalVolume
+    boundary = 'top bottom right'
+    execute_on = 'initial linear'
+  [../]
+  [./aveTempInterior]
+    type = AxisymmetricCenterlineAverageValue
+    boundary = left
+    variable = temperature
+    execute_on = 'initial linear'
+  [../]
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/combined/test/tests/cavity_pressure/tests
+++ b/modules/combined/test/tests/cavity_pressure/tests
@@ -38,4 +38,10 @@
     exodiff = 'cavity_pressure_rz_out.e'
     delete_output_before_running = false
   [../]
+
+  [./rz_negative_moles_check]
+    type = RunException
+    input = 'cavity_pressure_negative_volume.i'
+    expect_err = 'Negative number of moles calculated as an input for the cavity pressure'
+  [../]
 []

--- a/modules/tensor_mechanics/src/userobjects/CavityPressureUserObject.C
+++ b/modules/tensor_mechanics/src/userobjects/CavityPressureUserObject.C
@@ -64,7 +64,12 @@ CavityPressureUserObject::getValue(const std::string & quantity) const
 {
   Real value = 0;
   if ("initial_moles" == quantity)
+  {
+    if (_n0 < 0.0)
+      mooseError("Negative number of moles calculated as an input for the cavity pressure");
+
     value = _n0;
+  }
   else if ("cavity_pressure" == quantity)
     value = _cavity_pressure;
   else


### PR DESCRIPTION
### Relevant design information
The cavity pressure action includes an option to calculate the number of moles. In some instances, such as when the supplied volume is not closed, the number of moles calculated is negative. This commit adds a check and error message for when a negative number of moles are calculated.

### Test cases
A new test case in the RZ system with an open volume is added to the existing cases in the cavity pressure folder.

NOTE: This change is expected to cause failures in some of the BISON assessment cases.  
ping @gardnerru @bwspenc 

Refs #6898
