### PR TITLE
 hit: fix explode for parentless sections

### DIFF
--- a/framework/contrib/hit/chit.pxd
+++ b/framework/contrib/hit/chit.pxd
@@ -41,8 +41,8 @@ cdef extern from "parse.h" namespace "hit":
         Node * find(const string & path)
         #template <typename T> T param(std::string path = "")
 
-    Node* parse(string fname, string input) except +
-    void explode(Node * n) except +
+    Node * parse(string fname, string input) except +
+    Node * explode(Node * n) except +
     void merge(Node * src, Node * dst) except +
 
 cdef extern from "parse.h" namespace "hit::Field":

--- a/framework/contrib/hit/hit.cpp
+++ b/framework/contrib/hit/hit.cpp
@@ -4808,7 +4808,7 @@ static PyObject *__pyx_pf_3hit_4Node_34walk(struct __pyx_obj_3hit_Node *__pyx_v_
  *             child.walk(walker, node_type);
  * 
  *     def clone(self):             # <<<<<<<<<<<<<<
- *         return _initpynode(self._cnode.clone(), self._own)
+ *         return _initpynode(self._cnode.clone(), own=self._own)
  *     def root(self):
  */
 
@@ -4836,7 +4836,7 @@ static PyObject *__pyx_pf_3hit_4Node_36clone(struct __pyx_obj_3hit_Node *__pyx_v
   /* "hit.pyx":181
  * 
  *     def clone(self):
- *         return _initpynode(self._cnode.clone(), self._own)             # <<<<<<<<<<<<<<
+ *         return _initpynode(self._cnode.clone(), own=self._own)             # <<<<<<<<<<<<<<
  *     def root(self):
  *         return _initpynode(self._cnode.root())
  */
@@ -4856,7 +4856,7 @@ static PyObject *__pyx_pf_3hit_4Node_36clone(struct __pyx_obj_3hit_Node *__pyx_v
  *             child.walk(walker, node_type);
  * 
  *     def clone(self):             # <<<<<<<<<<<<<<
- *         return _initpynode(self._cnode.clone(), self._own)
+ *         return _initpynode(self._cnode.clone(), own=self._own)
  *     def root(self):
  */
 
@@ -4874,7 +4874,7 @@ static PyObject *__pyx_pf_3hit_4Node_36clone(struct __pyx_obj_3hit_Node *__pyx_v
 
 /* "hit.pyx":182
  *     def clone(self):
- *         return _initpynode(self._cnode.clone(), self._own)
+ *         return _initpynode(self._cnode.clone(), own=self._own)
  *     def root(self):             # <<<<<<<<<<<<<<
  *         return _initpynode(self._cnode.root())
  *     def parent(self):
@@ -4900,7 +4900,7 @@ static PyObject *__pyx_pf_3hit_4Node_38root(struct __pyx_obj_3hit_Node *__pyx_v_
   __Pyx_RefNannySetupContext("root", 0);
 
   /* "hit.pyx":183
- *         return _initpynode(self._cnode.clone(), self._own)
+ *         return _initpynode(self._cnode.clone(), own=self._own)
  *     def root(self):
  *         return _initpynode(self._cnode.root())             # <<<<<<<<<<<<<<
  *     def parent(self):
@@ -4915,7 +4915,7 @@ static PyObject *__pyx_pf_3hit_4Node_38root(struct __pyx_obj_3hit_Node *__pyx_v_
 
   /* "hit.pyx":182
  *     def clone(self):
- *         return _initpynode(self._cnode.clone(), self._own)
+ *         return _initpynode(self._cnode.clone(), own=self._own)
  *     def root(self):             # <<<<<<<<<<<<<<
  *         return _initpynode(self._cnode.root())
  *     def parent(self):
@@ -5428,41 +5428,53 @@ static PyObject *__pyx_pf_3hit_8parse(CYTHON_UNUSED PyObject *__pyx_self, PyObje
  *     return _initpynode(node, own=True)
  * 
  * cpdef explode(Node n):             # <<<<<<<<<<<<<<
- *     chit.explode(n._cnode)
- * 
+ *     n._cnode = chit.explode(n._cnode)
+ *     return n
  */
 
 static PyObject *__pyx_pw_3hit_11explode(PyObject *__pyx_self, PyObject *__pyx_v_n); /*proto*/
 static PyObject *__pyx_f_3hit_explode(struct __pyx_obj_3hit_Node *__pyx_v_n, CYTHON_UNUSED int __pyx_skip_dispatch) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
+  hit::Node *__pyx_t_1;
   __Pyx_RefNannySetupContext("explode", 0);
 
   /* "hit.pyx":208
  * 
  * cpdef explode(Node n):
- *     chit.explode(n._cnode)             # <<<<<<<<<<<<<<
+ *     n._cnode = chit.explode(n._cnode)             # <<<<<<<<<<<<<<
+ *     return n
  * 
- * cpdef merge(Node src, Node dst):
  */
   try {
-    hit::explode(__pyx_v_n->_cnode);
+    __pyx_t_1 = hit::explode(__pyx_v_n->_cnode);
   } catch(...) {
     __Pyx_CppExn2PyErr();
     __PYX_ERR(0, 208, __pyx_L1_error)
   }
+  __pyx_v_n->_cnode = __pyx_t_1;
+
+  /* "hit.pyx":209
+ * cpdef explode(Node n):
+ *     n._cnode = chit.explode(n._cnode)
+ *     return n             # <<<<<<<<<<<<<<
+ * 
+ * cpdef merge(Node src, Node dst):
+ */
+  __Pyx_XDECREF(__pyx_r);
+  __Pyx_INCREF(((PyObject *)__pyx_v_n));
+  __pyx_r = ((PyObject *)__pyx_v_n);
+  goto __pyx_L0;
 
   /* "hit.pyx":207
  *     return _initpynode(node, own=True)
  * 
  * cpdef explode(Node n):             # <<<<<<<<<<<<<<
- *     chit.explode(n._cnode)
- * 
+ *     n._cnode = chit.explode(n._cnode)
+ *     return n
  */
 
   /* function exit code */
-  __pyx_r = Py_None; __Pyx_INCREF(Py_None);
-  goto __pyx_L0;
   __pyx_L1_error:;
   __Pyx_AddTraceback("hit.explode", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = 0;
@@ -5513,8 +5525,8 @@ static PyObject *__pyx_pf_3hit_10explode(CYTHON_UNUSED PyObject *__pyx_self, str
   return __pyx_r;
 }
 
-/* "hit.pyx":210
- *     chit.explode(n._cnode)
+/* "hit.pyx":211
+ *     return n
  * 
  * cpdef merge(Node src, Node dst):             # <<<<<<<<<<<<<<
  *     chit.merge(src._cnode, dst._cnode)
@@ -5527,7 +5539,7 @@ static PyObject *__pyx_f_3hit_merge(struct __pyx_obj_3hit_Node *__pyx_v_src, str
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("merge", 0);
 
-  /* "hit.pyx":211
+  /* "hit.pyx":212
  * 
  * cpdef merge(Node src, Node dst):
  *     chit.merge(src._cnode, dst._cnode)             # <<<<<<<<<<<<<<
@@ -5537,11 +5549,11 @@ static PyObject *__pyx_f_3hit_merge(struct __pyx_obj_3hit_Node *__pyx_v_src, str
     hit::merge(__pyx_v_src->_cnode, __pyx_v_dst->_cnode);
   } catch(...) {
     __Pyx_CppExn2PyErr();
-    __PYX_ERR(0, 211, __pyx_L1_error)
+    __PYX_ERR(0, 212, __pyx_L1_error)
   }
 
-  /* "hit.pyx":210
- *     chit.explode(n._cnode)
+  /* "hit.pyx":211
+ *     return n
  * 
  * cpdef merge(Node src, Node dst):             # <<<<<<<<<<<<<<
  *     chit.merge(src._cnode, dst._cnode)
@@ -5591,11 +5603,11 @@ static PyObject *__pyx_pw_3hit_13merge(PyObject *__pyx_self, PyObject *__pyx_arg
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_dst)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("merge", 1, 2, 2, 1); __PYX_ERR(0, 210, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("merge", 1, 2, 2, 1); __PYX_ERR(0, 211, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "merge") < 0)) __PYX_ERR(0, 210, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "merge") < 0)) __PYX_ERR(0, 211, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
       goto __pyx_L5_argtuple_error;
@@ -5608,14 +5620,14 @@ static PyObject *__pyx_pw_3hit_13merge(PyObject *__pyx_self, PyObject *__pyx_arg
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("merge", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 210, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("merge", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 211, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("hit.merge", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_src), __pyx_ptype_3hit_Node, 1, "src", 0))) __PYX_ERR(0, 210, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_dst), __pyx_ptype_3hit_Node, 1, "dst", 0))) __PYX_ERR(0, 210, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_src), __pyx_ptype_3hit_Node, 1, "src", 0))) __PYX_ERR(0, 211, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_dst), __pyx_ptype_3hit_Node, 1, "dst", 0))) __PYX_ERR(0, 211, __pyx_L1_error)
   __pyx_r = __pyx_pf_3hit_12merge(__pyx_self, __pyx_v_src, __pyx_v_dst);
 
   /* function exit code */
@@ -5633,7 +5645,7 @@ static PyObject *__pyx_pf_3hit_12merge(CYTHON_UNUSED PyObject *__pyx_self, struc
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("merge", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_f_3hit_merge(__pyx_v_src, __pyx_v_dst, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 210, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_3hit_merge(__pyx_v_src, __pyx_v_dst, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 211, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;

--- a/framework/contrib/hit/hit.pyx
+++ b/framework/contrib/hit/hit.pyx
@@ -178,7 +178,7 @@ cdef class Node:
             child.walk(walker, node_type);
 
     def clone(self):
-        return _initpynode(self._cnode.clone(), self._own)
+        return _initpynode(self._cnode.clone(), own=self._own)
     def root(self):
         return _initpynode(self._cnode.root())
     def parent(self):
@@ -205,7 +205,8 @@ def parse(fname, input):
     return _initpynode(node, own=True)
 
 cpdef explode(Node n):
-    chit.explode(n._cnode)
+    n._cnode = chit.explode(n._cnode)
+    return n
 
 cpdef merge(Node src, Node dst):
     chit.merge(src._cnode, dst._cnode)

--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -842,7 +842,7 @@ merge(Node * from, Node * into)
   from->walk(&sw, NodeType::Section);
 }
 
-void
+Node *
 explode(Node * n)
 {
   if (n->type() == NodeType::Field || n->type() == NodeType::Section)
@@ -852,7 +852,9 @@ explode(Node * n)
     {
       auto prefix = n->path().substr(0, pos);
       auto postfix = n->path().substr(pos + 1, n->path().size() - pos - 1);
-      auto existing = n->parent()->find(prefix);
+      hit::Node * existing = nullptr;
+      if (n->parent())
+        existing = n->parent()->find(prefix);
 
       Node * newnode = nullptr;
       if (n->type() == NodeType::Field)
@@ -872,17 +874,19 @@ explode(Node * n)
       else
       {
         auto newsec = new Section(prefix);
-        n->parent()->addChild(newsec);
+        if (n->parent())
+          n->parent()->addChild(newsec);
         newsec->addChild(newnode);
       }
       explode(newnode);
       delete n;
-      return;
+      return newnode->root();
     }
   }
 
   for (auto child : n->children())
     explode(child);
+  return n->root();
 }
 
 #define EOF TMPEOF

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -412,8 +412,9 @@ void merge(Node * from, Node * into);
 /// explode walks the tree converting/exploding any fields that have path separators into them into
 /// actually sections/subsections/etc. with the final path element as the field name.  For example,
 /// "foo/bar=42" becomes nodes with the structure "[foo] bar=42 []".  If nodes for sections already
-/// exist in the tree, the fields will be moved into them rather than new sections created.
-void explode(Node * n);
+/// exist in the tree, the fields will be moved into them rather than new sections created.  The
+/// returned node is the root of the exploded tree.
+Node * explode(Node * n);
 
 } // namespace hit
 

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -109,6 +109,21 @@ struct ValCase
   hit::Field::Kind kind;
 };
 
+TEST(HitTests, ExplodeParentless)
+{
+  hit::Node * n = new hit::Section("foo/bar");
+
+  try
+  {
+    n = hit::explode(n);
+    EXPECT_EQ("[foo]\n  [bar]\n  []\n[]", n->render());
+  }
+  catch (std::exception & err)
+  {
+    FAIL() << "unexpected error: " << err.what();
+  }
+}
+
 TEST(HitTests, ParseFields)
 {
   ValCase cases[] = {


### PR DESCRIPTION
explode assumed that its argument did not need to be exploded - i.e.
all actual node exploding happens at least one level below the node
passed in.  explode(new Section("foo/bar")) would segfault.  This is
fixed by adding some parent()==nullptr checks.

A related problem is that if the node passed in needed to be split, the
function had no way to pass the new node/tree back to the caller - the
node passed in shared no nodes with the exploded tree.  Fix this by
having explode return the root of the exploded tree.
