### PR TITLE
Only ask the user to save input file changes if the syntax changed.

### DIFF
--- a/python/peacock/Input/InputFile.py
+++ b/python/peacock/Input/InputFile.py
@@ -60,8 +60,11 @@ class InputFile(object):
 
         with open(filename, 'r') as f:
             data = f.read()
+        self.readInputData(data, filename)
 
+    def readInputData(self, data, filename):
         try:
+            self.filename = os.path.abspath(filename)
             root = hit.parse(os.path.abspath(filename), data)
             hit.explode(root)
             w = DupWalker(os.path.abspath(filename))

--- a/python/peacock/Input/InputFileEditor.py
+++ b/python/peacock/Input/InputFileEditor.py
@@ -112,10 +112,12 @@ class InputFileEditor(QWidget, MooseWidget):
         """
         if app_info.valid():
             self._closeBlockEditor()
-            input_filename = self.tree.input_filename
-            input_tree = InputTree(app_info)
-            self.tree = input_tree
-            self.tree.setInputFile(input_filename)
+            old_tree = self.tree
+            self.tree = InputTree(app_info)
+            if old_tree.root:
+                self.tree.setInputFileData(old_tree.getInputFileString(), old_tree.input_filename)
+            else:
+                self.tree.setInputFile(old_tree.input_filename)
             self.block_tree.setInputTree(self.tree)
 
     def setInputFile(self, input_file):

--- a/python/peacock/Input/InputFileEditorPlugin.py
+++ b/python/peacock/Input/InputFileEditorPlugin.py
@@ -54,7 +54,7 @@ class InputFileEditorPlugin(InputFileEditor, Plugin):
         self.has_changed = True
 
     def _askToSave(self, app_info, reason):
-        if self.has_changed and app_info.valid() and self.tree and self.tree.input_filename:
+        if self.has_changed and app_info.valid() and self.tree and self.tree.input_filename and self.tree.incompatibleChanges(app_info):
             msg = "%s\nYou have unsaved changes in your input file, do you want to save?" % reason
             reply = QMessageBox.question(self, "Save?", msg, QMessageBox.Save, QMessageBox.Discard)
             if reply == QMessageBox.Save:


### PR DESCRIPTION
When the executable changes and peacock automatically loads the new syntax, we only want to ask the user to save changes if there are incompatibilities with the current input file. Otherwise we should just use the current changes without asking.
closes #9974

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
