### PR TITLE
Check tortuosity provided by user

### DIFF
--- a/docs/content/documentation/modules/porous_flow/governing_equations.md
+++ b/docs/content/documentation/modules/porous_flow/governing_equations.md
@@ -199,6 +199,10 @@ the longitudinal and transverse dispersivities.  It is common to set the
 hydrodynamic dispersion to zero by setting $\alpha_{\beta, T} = 0 =
 \alpha_{\beta, L}$.
 
+!!!note:
+    Multiple definitions of tortuosity appear in the literature. In PorousFlow, tortuosity
+    is defined as the ratio of the shortest path to the effective path, so that $0 < \tau \leq 1$. 
+
 ##Heat flow
 
 Energy conservation for heat is described by the continuity

--- a/docs/content/documentation/systems/Materials/porous_flow/PorousFlowDiffusivityConst.md
+++ b/docs/content/documentation/systems/Materials/porous_flow/PorousFlowDiffusivityConst.md
@@ -1,6 +1,9 @@
 # PorousFlowDiffusivityConst
 !syntax description /Materials/PorousFlowDiffusivityConst
 
+Tortuosity is defined as the ratio of the shortest path to the effective path,
+such that $0 < \tau \leq 1$.
+
 !syntax parameters /Materials/PorousFlowDiffusivityConst
 
 !syntax inputs /Materials/PorousFlowDiffusivityConst

--- a/modules/porous_flow/src/materials/PorousFlowDiffusivityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowDiffusivityConst.C
@@ -27,6 +27,14 @@ PorousFlowDiffusivityConst::PorousFlowDiffusivityConst(const InputParameters & p
   if (_input_tortuosity.size() != _num_phases)
     mooseError("The number of tortuosity values entered is not equal to the number of phases "
                "specified in the Dictator");
+
+  // Check that all tortuosities are (0, 1]
+  for (unsigned int i = 0; i < _num_phases; ++i)
+    if (_input_tortuosity[i] <= 0.0 || _input_tortuosity[i] > 1)
+      mooseError("All tortuosities must be greater than zero and less than (or equal to) one in ",
+                 _name,
+                 ".\nNote: the definition of tortuosity used is l/le, where l is the straight line "
+                 "length and le is the effective flow length");
 }
 
 void

--- a/modules/porous_flow/test/tests/jacobian/disp01.i
+++ b/modules/porous_flow/test/tests/jacobian/disp01.i
@@ -121,7 +121,7 @@
     type = PorousFlowDiffusivityConst
     at_nodes = false
     diffusion_coeff = '1e-2 1e-1'
-    tortuosity = '0'
+    tortuosity = 1
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/test/tests/jacobian/disp03.i
+++ b/modules/porous_flow/test/tests/jacobian/disp03.i
@@ -118,7 +118,7 @@
     type = PorousFlowDiffusivityConst
     at_nodes = false
     diffusion_coeff = '1e-2 1e-1'
-    tortuosity = '0'
+    tortuosity = 1
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst


### PR DESCRIPTION
PorousFlow uses a definition of tortuosity where it must be (0, 1]. Add
a range check, and update documentation.
Fixes #10170
