### PR TITLE
Fix bug in TabulatedFluidProperties::mu(p, T)

### DIFF
--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -276,7 +276,7 @@ Real
 TabulatedFluidProperties::mu(Real pressure, Real temperature) const
 {
   Real rho = this->rho(pressure, temperature);
-  return this->mu(rho, temperature);
+  return this->mu_from_rho_T(rho, temperature);
 }
 
 void


### PR DESCRIPTION
Fixes bug that was introduced in TabulatedFluidProperties.

Fixes #10171


