### PR TITLE
hit: fix use-after-free memory error in explode

### DIFF
--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -878,9 +878,9 @@ explode(Node * n)
           n->parent()->addChild(newsec);
         newsec->addChild(newnode);
       }
-      explode(newnode);
+      auto newroot = explode(newnode);
       delete n;
-      return newnode->root();
+      return newroot->root();
     }
   }
 

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -108,7 +108,11 @@ std::string pathNorm(const std::string & path);
 /// pathJoin a joined version of the given hit (relative) paths as single hit path.
 std::string pathJoin(const std::vector<std::string> & paths);
 
-/// Node represents an object in a parsed hit tree.
+/// Node represents an object in a parsed hit tree.  Each node manages the memory for its child
+/// nodes.  It is safe to delete any node in the tree; doing so will also delete that node's
+/// children recursively.  It is not safe to place a single node in multiple trees.  Instead, use
+/// the node's clone function (which operates recursively) to create a new (sub)tree for placement
+/// in alternate trees.
 class Node
 {
 public:


### PR DESCRIPTION
This bug was introduced by #10161.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
