### PR TITLE
add a test to check PerformanceData Postprocessor for other events

### DIFF
--- a/test/tests/postprocessors/print_perf_data/tests
+++ b/test/tests/postprocessors/print_perf_data/tests
@@ -29,4 +29,11 @@
     #   Make sure that you don't cross lines by not allowing the throwaway content to have newlines.
     absent_out = '(\s(\S+)\s\|\n)[^\n]*\1'
   [../]
+
+  [./check_more_values]
+    type = RunApp
+    input = print_perf_data.i
+    cli_args = 'Outputs/exodus=false Outputs/csv=false'
+    absent_out = '(\s(\S+)\s\|\n)[^\n]*\1'
+  [../]
 []


### PR DESCRIPTION
Adds a test to check a PerformanceData Postprocessor output _value_, not just the presence of output, for an event other than runtime.

ref #10196

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
