### PR TITLE
parser: make filepaths in input relative to input file dir

### DIFF
--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -204,6 +204,27 @@ protected:
                           GlobalParamsAction * global_block);
 
   /**
+   * Sets an input parameter representing a file path using input file data.  The file path is
+   * modified to be relative to the directory this application's input file is in.
+   */
+  template <typename T>
+  void setFilePathParam(const std::string & full_name,
+                        const std::string & short_name,
+                        InputParameters::Parameter<T> * param,
+                        bool in_global,
+                        GlobalParamsAction * global_block);
+
+  /**
+   * Sets an input parameter representing a vector of file paths using input file data.  The file
+   * paths are modified to be relative to the directory this application's input file is in.
+   */
+  template <typename T>
+  void setVectorFilePathParam(const std::string & full_name,
+                              const std::string & short_name,
+                              InputParameters::Parameter<std::vector<T>> * param,
+                              bool in_global,
+                              GlobalParamsAction * global_block);
+  /**
    * Template method for setting any double indexed type parameter read from the input file or
    * command line.
    */

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -211,6 +211,7 @@ protected:
   void setFilePathParam(const std::string & full_name,
                         const std::string & short_name,
                         InputParameters::Parameter<T> * param,
+                        InputParameters & params,
                         bool in_global,
                         GlobalParamsAction * global_block);
 
@@ -222,6 +223,7 @@ protected:
   void setVectorFilePathParam(const std::string & full_name,
                               const std::string & short_name,
                               InputParameters::Parameter<std::vector<T>> * param,
+                              InputParameters & params,
                               bool in_global,
                               GlobalParamsAction * global_block);
   /**

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -373,7 +373,10 @@ enum MffdType
 
 // Instantiate new Types
 
-/// This type is for expected filenames, it can be used to trigger open file dialogs in the GUI
+/// This type is for expected (i.e. input) file names or paths that your simulation needs.  If
+/// relative paths are assigned to this type, they are treated/modified to be relative to the
+/// location of the simulation's main input file's directory.  It can be used to trigger open file
+/// dialogs in the GUI.
 DerivativeStringClass(FileName);
 
 /// This type is for expected filenames where the extension is unwanted, it can be used to trigger open file dialogs in the GUI

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -1025,6 +1025,7 @@ Parser::extractParams(const std::string & prefix, InputParameters & p)
       setFilePathParam<ptype>(full_name,                                                           \
                               short_name,                                                          \
                               dynamic_cast<InputParameters::Parameter<ptype> *>(par),              \
+                              p,                                                                   \
                               in_global,                                                           \
                               global_params_block)
 #define setvector(ptype, base)                                                                     \
@@ -1041,6 +1042,7 @@ Parser::extractParams(const std::string & prefix, InputParameters & p)
           full_name,                                                                               \
           short_name,                                                                              \
           dynamic_cast<InputParameters::Parameter<std::vector<ptype>> *>(par),                     \
+          p,                                                                                       \
           in_global,                                                                               \
           global_params_block)
 #define setvectorvector(ptype)                                                                     \
@@ -1296,6 +1298,7 @@ void
 Parser::setFilePathParam(const std::string & full_name,
                          const std::string & short_name,
                          InputParameters::Parameter<T> * param,
+                         InputParameters & params,
                          bool in_global,
                          GlobalParamsAction * global_block)
 {
@@ -1305,6 +1308,7 @@ Parser::setFilePathParam(const std::string & full_name,
   if (pos != std::string::npos && postfix[0] != '/' && !postfix.empty())
     prefix = _input_filename.substr(0, pos + 1);
 
+  params.set<std::string>("_raw_" + short_name) = postfix;
   param->set() = prefix + postfix;
 
   if (in_global)
@@ -1363,10 +1367,12 @@ void
 Parser::setVectorFilePathParam(const std::string & full_name,
                                const std::string & short_name,
                                InputParameters::Parameter<std::vector<T>> * param,
+                               InputParameters & params,
                                bool in_global,
                                GlobalParamsAction * global_block)
 {
   std::vector<T> vec;
+  std::vector<std::string> rawvec;
   if (_root->find(full_name))
   {
     auto tmp = _root->param<std::vector<std::string>>(full_name);
@@ -1377,10 +1383,12 @@ Parser::setVectorFilePathParam(const std::string & full_name,
       size_t pos = _input_filename.find_last_of('/');
       if (pos != std::string::npos && postfix[0] != '/')
         prefix = _input_filename.substr(0, pos + 1);
+      rawvec.push_back(postfix);
       vec.push_back(prefix + postfix);
     }
   }
 
+  params.set<std::vector<std::string>>("_raw_" + short_name) = rawvec;
   param->set() = vec;
 
   if (in_global)

--- a/modules/richards/test/tests/dirac/tests
+++ b/modules/richards/test/tests/dirac/tests
@@ -154,13 +154,13 @@
     type = 'RunException'
     input = 'st01.i'
     cli_args = 'DiracKernels/stream/point_file=does_not_exist Outputs/file_base=except01'
-    expect_err = 'Error opening file \'does_not_exist\' from RichardsPolyLineSink.'
+    expect_err = 'Error opening file \'.*does_not_exist\' from RichardsPolyLineSink.'
   [../]
   [./except02]
     type = 'RunException'
     input = 'bh02.i'
     cli_args = 'DiracKernels/bh/point_file=does_not_exist Outputs/file_base=except02'
-    expect_err = 'Error opening file \'does_not_exist\' from a Peaceman-type Borehole.'
+    expect_err = 'Error opening file \'.*does_not_exist\' from a Peaceman-type Borehole.'
   [../]
   [./except03]
     type = 'RunException'

--- a/test/tests/functions/piecewise_multilinear/tests
+++ b/test/tests/functions/piecewise_multilinear/tests
@@ -2,7 +2,7 @@
   [./except1]
     type = 'RunException'
     input = 'except1.i'
-    expect_err = "Error opening file 'except1.txt' from GriddedData."
+    expect_err = "Error opening file .* from GriddedData."
     max_parallel = 1
   [../]
   [./except2]


### PR DESCRIPTION
All input parameters that are typed FileName, FileNameNoExtension, or
MeshFileName (and vectors of these types) are treated as relative to the
directory the input file itself resides in.  The parser now prepends a
file path prefix to enforce this.

This will help with benchmarking and also pave the way for sandboxing of
tests/benchmarks in the future if we decide it is worth while.

ref #9834

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
