### PR TITLE
Call ModulesApp register/associate in StorkTestApp

### DIFF
--- a/stork/test/src/base/StorkTestApp.C
+++ b/stork/test/src/base/StorkTestApp.C
@@ -3,6 +3,7 @@
 #include "Moose.h"
 #include "AppFactory.h"
 #include "MooseSyntax.h"
+#include "ModulesApp.h"
 
 template <>
 InputParameters
@@ -15,10 +16,12 @@ validParams<StorkTestApp>()
 StorkTestApp::StorkTestApp(InputParameters parameters) : MooseApp(parameters)
 {
   Moose::registerObjects(_factory);
+  ModulesApp::registerObjects(_factory);
   StorkApp::registerObjectDepends(_factory);
   StorkApp::registerObjects(_factory);
 
   Moose::associateSyntax(_syntax, _action_factory);
+  ModulesApp::associateSyntax(_syntax, _action_factory);
   StorkApp::associateSyntaxDepends(_syntax, _action_factory);
   StorkApp::associateSyntax(_syntax, _action_factory);
 


### PR DESCRIPTION
This allows the user to just turn on modules in the app Makefile and everything just works.

I tested this by changing the Makefile to use all modules, building, and running a module test with the app executable.

refs #9601

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
