### PR TITLE
LibMesh update 

### DIFF
--- a/framework/src/base/FEProblem.C
+++ b/framework/src/base/FEProblem.C
@@ -43,10 +43,7 @@ FEProblem::FEProblem(const InputParameters & parameters)
   _eq.parameters.set<FEProblem *>("_fe_problem") = this;
 }
 
-FEProblem::~FEProblem()
-{
-  FEProblemBase::deleteAssemblyArray();
-}
+FEProblem::~FEProblem() { FEProblemBase::deleteAssemblyArray(); }
 
 void
 FEProblem::setInputParametersFEProblem(InputParameters & parameters)

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -4918,16 +4918,13 @@ FEProblemBase::checkDependMaterialsHelper(
 void
 FEProblemBase::checkCoordinateSystems()
 {
-  MeshBase::const_element_iterator it = _mesh.getMesh().elements_begin();
-  MeshBase::const_element_iterator it_end = _mesh.getMesh().elements_end();
-
-  for (; it != it_end; ++it)
+  for (const auto & elem : _mesh.getMesh().element_ptr_range())
   {
-    SubdomainID sid = (*it)->subdomain_id();
-    if (_coord_sys[sid] == Moose::COORD_RZ && (*it)->dim() == 3)
+    SubdomainID sid = elem->subdomain_id();
+    if (_coord_sys[sid] == Moose::COORD_RZ && elem->dim() == 3)
       mooseError("An RZ coordinate system was requested for subdomain " + Moose::stringify(sid) +
                  " which contains 3D elements.");
-    if (_coord_sys[sid] == Moose::COORD_RSPHERICAL && (*it)->dim() > 1)
+    if (_coord_sys[sid] == Moose::COORD_RSPHERICAL && elem->dim() > 1)
       mooseError("An RSPHERICAL coordinate system was requested for subdomain " +
                  Moose::stringify(sid) + " which contains 2D or 3D elements.");
   }

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -233,12 +233,9 @@ GeneratedMesh::buildMesh()
     }
 
     // Loop over the nodes and move them to the desired location
-    MeshBase::node_iterator node_it = mesh.nodes_begin();
-    const MeshBase::node_iterator node_end = mesh.nodes_end();
-
-    for (; node_it != node_end; ++node_it)
+    for (auto & node_ptr : mesh.node_ptr_range())
     {
-      Node & node = **node_it;
+      Node & node = *node_ptr;
 
       for (unsigned int dir = 0; dir < LIBMESH_DIM; ++dir)
       {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1251,12 +1251,12 @@ MooseMesh::detectOrthogonalDimRanges(Real tol)
 
     for (unsigned int i = 0; i < dim; ++i)
     {
-      if (std::abs((*node)(i) - min[i]) < tol)
+      if (std::abs((*node)(i)-min[i]) < tol)
       {
         comp_map[i] = MIN;
         ++coord_match;
       }
-      else if (std::abs((*node)(i) - max[i]) < tol)
+      else if (std::abs((*node)(i)-max[i]) < tol)
       {
         comp_map[i] = MAX;
         ++coord_match;

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -365,11 +365,9 @@ MooseMesh::prepare(bool force)
   }
 
   // Collect (local) subdomain IDs
-  const MeshBase::element_iterator el_end = getMesh().elements_end();
-
   _mesh_subdomains.clear();
-  for (MeshBase::element_iterator el = getMesh().elements_begin(); el != el_end; ++el)
-    _mesh_subdomains.insert((*el)->subdomain_id());
+  for (const auto & elem : getMesh().element_ptr_range())
+    _mesh_subdomains.insert(elem->subdomain_id());
 
   // Make sure nodesets have been generated
   buildNodeListFromSideList();
@@ -787,13 +785,9 @@ MooseMesh::getBoundaryElementRange()
 void
 MooseMesh::cacheInfo()
 {
-  const MeshBase::element_iterator end = getMesh().elements_end();
-
   // TODO: Thread this!
-  for (MeshBase::element_iterator el = getMesh().elements_begin(); el != end; ++el)
+  for (const auto & elem : getMesh().element_ptr_range())
   {
-    Elem * elem = *el;
-
     SubdomainID subdomain_id = elem->subdomain_id();
 
     for (unsigned int side = 0; side < elem->n_sides(); side++)
@@ -1530,16 +1524,12 @@ MooseMesh::getPairedBoundaryMapping(unsigned int component)
 void
 MooseMesh::buildRefinementAndCoarseningMaps(Assembly * assembly)
 {
-  MeshBase::const_element_iterator el = getMesh().elements_begin();
-  const MeshBase::const_element_iterator end_el = getMesh().elements_end();
-
   std::map<ElemType, Elem *> canonical_elems;
 
   // First, loop over all elements and find a canonical element for each type
   // Doing it this way guarantees that this is going to work in parallel
-  for (; el != end_el; ++el) // TODO: Thread this
+  for (const auto & elem : getMesh().element_ptr_range()) // TODO: Thread this
   {
-    Elem * elem = *el;
     ElemType type = elem->type();
 
     if (canonical_elems.find(type) ==

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -685,12 +685,9 @@ MooseMesh::nodeToElemMap()
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
     if (!_node_to_elem_map_built)
     {
-      MeshBase::const_element_iterator el = getMesh().active_elements_begin();
-      const MeshBase::const_element_iterator end = getMesh().active_elements_end();
-
-      for (; el != end; ++el)
-        for (unsigned int n = 0; n < (*el)->n_nodes(); n++)
-          _node_to_elem_map[(*el)->node(n)].push_back((*el)->id());
+      for (const auto & elem : getMesh().active_element_ptr_range())
+        for (unsigned int n = 0; n < elem->n_nodes(); n++)
+          _node_to_elem_map[elem->node(n)].push_back(elem->id());
 
       _node_to_elem_map_built = true; // MUST be set at the end for double-checked locking to work!
     }
@@ -1136,8 +1133,6 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
 
   periodic_node_map.clear();
 
-  MeshBase::const_element_iterator it = getMesh().active_elements_begin();
-  MeshBase::const_element_iterator it_end = getMesh().active_elements_end();
   std::unique_ptr<PointLocatorBase> point_locator = getMesh().sub_point_locator();
 
   // Get a const reference to the BoundaryInfo object that we will use several times below...
@@ -1149,9 +1144,7 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
   // Container to catch IDs passed back from the BoundaryInfo object
   std::vector<boundary_id_type> bc_ids;
 
-  for (; it != it_end; ++it)
-  {
-    const Elem * elem = *it;
+  for (const auto & elem : getMesh().active_element_ptr_range())
     for (unsigned int s = 0; s < elem->n_sides(); ++s)
     {
       if (elem->neighbor_ptr(s))
@@ -1198,7 +1191,6 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
         }
       }
     }
-  }
 }
 
 void

--- a/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
+++ b/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
@@ -58,12 +58,7 @@ AddAllSideSetsByNormals::modify()
 
   // We'll need to loop over all of the elements to find ones that match this normal.
   // We can't rely on flood catching them all here...
-  MeshBase::const_element_iterator el = _mesh_ptr->getMesh().elements_begin();
-  const MeshBase::const_element_iterator end_el = _mesh_ptr->getMesh().elements_end();
-  for (; el != end_el; ++el)
-  {
-    const Elem * elem = *el;
-
+  for (const auto & elem : _mesh_ptr->getMesh().element_ptr_range())
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
       if (elem->neighbor_ptr(side))
@@ -83,16 +78,15 @@ AddAllSideSetsByNormals::modify()
           }
 
         if (item)
-          flood(*el, normals[0], item->first);
+          flood(elem, normals[0], item->first);
         else
         {
           BoundaryID id = getNextBoundaryID();
           (*boundary_map)[id] = normals[0];
-          flood(*el, normals[0], id);
+          flood(elem, normals[0], id);
         }
       }
     }
-  }
 
   finalize();
 

--- a/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
+++ b/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
@@ -84,28 +84,26 @@ AddSideSetsFromBoundingBox::modify()
   if (!_boundary_id_overlap)
   {
     // Loop over the elements
-    for (MeshBase::element_iterator el = mesh.active_elements_begin();
-         el != mesh.active_elements_end();
-         ++el)
+    for (const auto & elem : mesh.active_element_ptr_range())
     {
       // boolean if element centroid is in bounding box
-      bool contains = _bounding_box.contains_point((*el)->centroid());
+      bool contains = _bounding_box.contains_point(elem->centroid());
 
       // check if active elements are found in the bounding box
       if (contains)
       {
         found_element = true;
         // loop over sides of elements within bounding box
-        for (unsigned int side = 0; side < (*el)->n_sides(); side++)
+        for (unsigned int side = 0; side < elem->n_sides(); side++)
           // loop over provided boundary vector to check all side sets for all boundary ids
           for (unsigned int boundary_id_number = 0; boundary_id_number < _boundary_id_old.size();
                boundary_id_number++)
             // check if side has same boundary id that you are looking for
             if (boundary_info.has_boundary_id(
-                    *el, side, boundary_info.get_id_by_name(_boundary_id_old[boundary_id_number])))
+                    elem, side, boundary_info.get_id_by_name(_boundary_id_old[boundary_id_number])))
             {
               // assign new boundary value to boundary which meets meshmodifier criteria
-              boundary_info.add_side(*el, side, _boundary_id_new);
+              boundary_info.add_side(elem, side, _boundary_id_new);
               found_side_sets = true;
             }
       }

--- a/framework/src/meshmodifiers/AssignSubdomainID.C
+++ b/framework/src/meshmodifiers/AssignSubdomainID.C
@@ -32,15 +32,6 @@ AssignSubdomainID::AssignSubdomainID(const InputParameters & parameters)
 void
 AssignSubdomainID::modify()
 {
-  auto & mesh = _mesh_ptr->getMesh();
-
-  auto elem_it = mesh.elements_begin();
-  const auto end_it = mesh.elements_end();
-
-  for (; elem_it != end_it; ++elem_it)
-  {
-    auto elem = *elem_it;
-
+  for (auto & elem : _mesh_ptr->getMesh().element_ptr_range())
     elem->subdomain_id() = _subdomain_id;
-  }
 }

--- a/framework/src/meshmodifiers/BreakBoundaryOnSubdomain.C
+++ b/framework/src/meshmodifiers/BreakBoundaryOnSubdomain.C
@@ -59,13 +59,10 @@ BreakBoundaryOnSubdomain::modify()
       this->comm().set_union(breaking_boundary_ids);
   }
 
-  auto end_el = mesh.active_elements_end();
-
   // create a list of new boundary names
   std::set<std::string> new_boundary_name_set;
-  for (auto el = mesh.active_elements_begin(); el != end_el; ++el)
+  for (const auto & elem : mesh.active_element_ptr_range())
   {
-    auto elem = *el;
     auto subdomain_id = elem->subdomain_id();
     auto subdomain_name = mesh.subdomain_name(subdomain_id);
     if (subdomain_name == "")
@@ -100,9 +97,8 @@ BreakBoundaryOnSubdomain::modify()
   }
 
   // add sides into the side sets
-  for (auto el = mesh.active_elements_begin(); el != end_el; ++el)
+  for (const auto & elem : mesh.active_element_ptr_range())
   {
-    auto elem = *el;
     auto subdomain_id = elem->subdomain_id();
     auto subdomain_name = mesh.subdomain_name(subdomain_id);
     if (subdomain_name == "")

--- a/framework/src/meshmodifiers/ElementDeleterBase.C
+++ b/framework/src/meshmodifiers/ElementDeleterBase.C
@@ -49,10 +49,8 @@ ElementDeleterBase::modify()
   std::set<Elem *> deleteable_elems;
 
   // First let's figure out which elements need to be deleted
-  const MeshBase::const_element_iterator end = mesh.elements_end();
-  for (MeshBase::const_element_iterator elem_it = mesh.elements_begin(); elem_it != end; ++elem_it)
+  for (auto & elem : mesh.element_ptr_range())
   {
-    Elem * elem = *elem_it;
     if (shouldDelete(elem))
       deleteable_elems.insert(elem);
   }
@@ -135,11 +133,8 @@ ElementDeleterBase::modify()
     // The ghost_elements iterators in libMesh need to be updated
     // before we can use them safely here, so we'll test for
     // ghost-vs-local manually.
-    for (MeshBase::const_element_iterator el = mesh.elements_begin(), end_el = mesh.elements_end();
-         el != end_el;
-         ++el)
+    for (const auto & elem : mesh.element_ptr_range())
     {
-      const Elem * elem = *el;
       const processor_id_type pid = elem->processor_id();
       if (pid == my_proc_id)
         continue;

--- a/framework/src/meshmodifiers/ImageSubdomain.C
+++ b/framework/src/meshmodifiers/ImageSubdomain.C
@@ -50,11 +50,9 @@ ImageSubdomain::modify()
 
   // Loop over the elements and sample the image at the element centroid and use the value for the
   // subdomain id
-  for (MeshBase::element_iterator el = mesh.active_elements_begin();
-       el != mesh.active_elements_end();
-       ++el)
+  for (auto & elem : mesh.active_element_ptr_range())
   {
-    SubdomainID id = static_cast<SubdomainID>(round(sample((*el)->centroid())));
-    (*el)->subdomain_id() = id;
+    SubdomainID id = static_cast<SubdomainID>(round(sample(elem->centroid())));
+    elem->subdomain_id() = id;
   }
 }

--- a/framework/src/meshmodifiers/OrientedSubdomainBoundingBox.C
+++ b/framework/src/meshmodifiers/OrientedSubdomainBoundingBox.C
@@ -47,18 +47,13 @@ OrientedSubdomainBoundingBox::modify()
   if (!_mesh_ptr)
     mooseError("_mesh_ptr must be initialized before calling SubdomainBoundingBox::modify()");
 
-  // Reference the the libMesh::MeshBase
-  MeshBase & mesh = _mesh_ptr->getMesh();
-
   // Loop over the elements
-  for (MeshBase::element_iterator el = mesh.active_elements_begin();
-       el != mesh.active_elements_end();
-       ++el)
+  for (const auto & elem : _mesh_ptr->getMesh().active_element_ptr_range())
   {
-    bool contains = containsPoint((*el)->centroid());
+    bool contains = containsPoint(elem->centroid());
     if (contains && _location == "INSIDE")
-      (*el)->subdomain_id() = _block_id;
+      elem->subdomain_id() = _block_id;
     else if (!contains && _location == "OUTSIDE")
-      (*el)->subdomain_id() = _block_id;
+      elem->subdomain_id() = _block_id;
   }
 }

--- a/framework/src/meshmodifiers/ParsedAddSideset.C
+++ b/framework/src/meshmodifiers/ParsedAddSideset.C
@@ -100,12 +100,8 @@ ParsedAddSideset::modify()
   std::vector<BoundaryID> boundary_ids = _mesh_ptr->getBoundaryIDs({_sideset_name}, true);
   mooseAssert(boundary_ids.size() == 1, "Length of boundary_ids should be one");
 
-  MeshBase::const_element_iterator el = mesh.active_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_elements_end();
-
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.active_element_ptr_range())
   {
-    const Elem * elem = *el;
     SubdomainID curr_subdomain = elem->subdomain_id();
 
     // check if the element is included

--- a/framework/src/meshmodifiers/ParsedSubdomainMeshModifier.C
+++ b/framework/src/meshmodifiers/ParsedSubdomainMeshModifier.C
@@ -84,23 +84,18 @@ ParsedSubdomainMeshModifier::modify()
     mooseError(
         "_mesh_ptr must be initialized before calling ParsedSubdomainMeshModifier::modify()");
 
-  // Reference the the libMesh::MeshBase
-  MeshBase & mesh = _mesh_ptr->getMesh();
-
   // Loop over the elements
-  for (MeshBase::element_iterator el = mesh.active_elements_begin();
-       el != mesh.active_elements_end();
-       ++el)
+  for (const auto & elem : _mesh_ptr->getMesh().active_element_ptr_range())
   {
-    _func_params[0] = (*el)->centroid()(0);
-    _func_params[1] = (*el)->centroid()(1);
-    _func_params[2] = (*el)->centroid()(2);
+    _func_params[0] = elem->centroid()(0);
+    _func_params[1] = elem->centroid()(1);
+    _func_params[2] = elem->centroid()(2);
     bool contains = evaluate(_func_F);
 
     if (contains &&
-        std::find(_excluded_ids.begin(), _excluded_ids.end(), (*el)->subdomain_id()) ==
+        std::find(_excluded_ids.begin(), _excluded_ids.end(), elem->subdomain_id()) ==
             _excluded_ids.end())
-      (*el)->subdomain_id() = _block_id;
+      elem->subdomain_id() = _block_id;
   }
 
   // Assign block name, if provided

--- a/framework/src/meshmodifiers/RenameBlock.C
+++ b/framework/src/meshmodifiers/RenameBlock.C
@@ -89,12 +89,10 @@ RenameBlock::modify()
     if (_new_block_id.size() != _old_block_id.size())
       mooseError("RenameBlock: The vector of old_block information must have the same length as "
                  "the vector of new_block information\n");
-    for (MeshBase::element_iterator el = _mesh_ptr->getMesh().active_elements_begin();
-         el != _mesh_ptr->getMesh().active_elements_end();
-         ++el)
+    for (const auto & elem : _mesh_ptr->getMesh().active_element_ptr_range())
       for (unsigned i = 0; i < _old_block_id.size(); ++i)
-        if ((*el)->subdomain_id() == _old_block_id[i])
-          (*el)->subdomain_id() = _new_block_id[i];
+        if (elem->subdomain_id() == _old_block_id[i])
+          elem->subdomain_id() = _new_block_id[i];
   }
   else // must have supplied new_block_name
   {

--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -90,12 +90,8 @@ SideSetsAroundSubdomain::modify()
   std::vector<vec_type> queries(my_n_proc);
 
   // Loop over the elements
-  for (MeshBase::const_element_iterator el = mesh.active_elements_begin(),
-                                        end_el = mesh.active_elements_end();
-       el != end_el;
-       ++el)
+  for (const auto & elem : mesh.active_element_ptr_range())
   {
-    const Elem * elem = *el;
     SubdomainID curr_subdomain = elem->subdomain_id();
 
     // We only need to loop over elements in the source subdomain

--- a/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
+++ b/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
@@ -64,12 +64,8 @@ SideSetsBetweenSubdomains::modify()
   typedef std::vector<std::pair<dof_id_type, unsigned int>> vec_type;
   std::vector<vec_type> queries(my_n_proc);
 
-  MeshBase::const_element_iterator el = mesh.active_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_elements_end();
-
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.active_element_ptr_range())
   {
-    const Elem * elem = *el;
     SubdomainID curr_subdomain = elem->subdomain_id();
 
     // We only need to loop over elements in the master subdomain

--- a/framework/src/meshmodifiers/SideSetsFromNormals.C
+++ b/framework/src/meshmodifiers/SideSetsFromNormals.C
@@ -72,12 +72,7 @@ SideSetsFromNormals::modify()
 
   // We'll need to loop over all of the elements to find ones that match this normal.
   // We can't rely on flood catching them all here...
-  MeshBase::const_element_iterator el = _mesh_ptr->getMesh().elements_begin();
-  const MeshBase::const_element_iterator end_el = _mesh_ptr->getMesh().elements_end();
-  for (; el != end_el; ++el)
-  {
-    const Elem * elem = *el;
-
+  for (const auto & elem : _mesh_ptr->getMesh().element_ptr_range())
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
       if (elem->neighbor_ptr(side))
@@ -89,10 +84,9 @@ SideSetsFromNormals::modify()
       for (unsigned int i = 0; i < boundary_ids.size(); ++i)
       {
         if (std::abs(1.0 - _normals[i] * normals[0]) < 1e-5)
-          flood(*el, _normals[i], boundary_ids[i]);
+          flood(elem, _normals[i], boundary_ids[i]);
       }
     }
-  }
 
   finalize();
 

--- a/framework/src/meshmodifiers/SubdomainBoundingBox.C
+++ b/framework/src/meshmodifiers/SubdomainBoundingBox.C
@@ -55,19 +55,14 @@ SubdomainBoundingBox::modify()
   if (!_mesh_ptr)
     mooseError("_mesh_ptr must be initialized before calling SubdomainBoundingBox::modify()");
 
-  // Reference the the libMesh::MeshBase
-  MeshBase & mesh = _mesh_ptr->getMesh();
-
   // Loop over the elements
-  for (MeshBase::element_iterator el = mesh.active_elements_begin();
-       el != mesh.active_elements_end();
-       ++el)
+  for (const auto & elem : _mesh_ptr->getMesh().active_element_ptr_range())
   {
-    bool contains = _bounding_box.contains_point((*el)->centroid());
+    bool contains = _bounding_box.contains_point(elem->centroid());
     if (contains && _location == "INSIDE")
-      (*el)->subdomain_id() = _block_id;
+      elem->subdomain_id() = _block_id;
     else if (!contains && _location == "OUTSIDE")
-      (*el)->subdomain_id() = _block_id;
+      elem->subdomain_id() = _block_id;
   }
 
   // Assign block name, if provided

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -124,10 +124,8 @@ OversampleOutput::initOversample()
 
   // Re-position the oversampled mesh
   if (_change_position)
-    for (MeshBase::node_iterator nd = _mesh_ptr->getMesh().nodes_begin();
-         nd != _mesh_ptr->getMesh().nodes_end();
-         ++nd)
-      *(*nd) += _position;
+    for (auto & node : _mesh_ptr->getMesh().node_ptr_range())
+      *node += _position;
 
   // Perform the mesh refinement
   if (_oversample)

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -176,4 +176,3 @@ CommandLine::printUsage() const
   Moose::out << "\nSolver Options:\n"
              << "  See solver manual for details (Petsc or Trilinos)\n";
 }
-

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -565,19 +565,18 @@ MultiAppNearestNodeTransfer::getNearestNode(const Point & p,
   }
   else
   {
-    MeshBase::const_node_iterator nodes_begin =
-        local ? mesh->localNodesBegin() : mesh->getMesh().nodes_begin();
-    MeshBase::const_node_iterator nodes_end =
-        local ? mesh->localNodesEnd() : mesh->getMesh().nodes_end();
+    SimpleRange<MeshBase::const_node_iterator> range(
+        local ? mesh->localNodesBegin() : mesh->getMesh().nodes_begin(),
+        local ? mesh->localNodesEnd() : mesh->getMesh().nodes_end());
 
-    for (MeshBase::const_node_iterator node_it = nodes_begin; node_it != nodes_end; ++node_it)
+    for (auto & node : range)
     {
-      Real current_distance = (p - *(*node_it)).norm();
+      Real current_distance = (p - *node).norm();
 
       if (current_distance < distance)
       {
         distance = current_distance;
-        nearest = *node_it;
+        nearest = node;
       }
     }
   }

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -135,11 +135,8 @@ MultiAppProjectionTransfer::assembleL2(EquationSystems & es, const std::string &
   const std::vector<Real> & JxW = fe->get_JxW();
   const std::vector<std::vector<Real>> & phi = fe->get_phi();
 
-  const MeshBase::const_element_iterator end_el = to_mesh.active_local_elements_end();
-  for (MeshBase::const_element_iterator el = to_mesh.active_local_elements_begin(); el != end_el;
-       ++el)
+  for (const auto & elem : to_mesh.active_local_element_ptr_range())
   {
-    const Elem * elem = *el;
     fe->reinit(elem);
 
     dof_map.dof_indices(elem, dof_indices);
@@ -420,12 +417,8 @@ MultiAppProjectionTransfer::execute()
     fe->attach_quadrature_rule(&qrule);
     const std::vector<Point> & xyz = fe->get_xyz();
 
-    MeshBase::const_element_iterator el = to_mesh.local_elements_begin();
-    const MeshBase::const_element_iterator end_el = to_mesh.local_elements_end();
-
-    for (el = to_mesh.active_local_elements_begin(); el != end_el; el++)
+    for (const auto & elem : to_mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
       fe->reinit(elem);
 
       bool element_is_evaled = false;
@@ -550,20 +543,13 @@ MultiAppProjectionTransfer::projectSolution(unsigned int i_to)
       }
     }
   }
-  {
-    MeshBase::const_element_iterator it = to_mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_it = to_mesh.active_local_elements_end();
-    for (; it != end_it; ++it)
+  for (const auto & elem : to_mesh.active_local_element_ptr_range())
+    for (unsigned int comp = 0; comp < elem->n_comp(to_sys.number(), to_var.number()); comp++)
     {
-      const Elem * elem = *it;
-      for (unsigned int comp = 0; comp < elem->n_comp(to_sys.number(), to_var.number()); comp++)
-      {
-        const dof_id_type proj_index = elem->dof_number(ls.number(), _proj_var_num, comp);
-        const dof_id_type to_index = elem->dof_number(to_sys.number(), to_var.number(), comp);
-        to_solution->set(to_index, (*ls.solution)(proj_index));
-      }
+      const dof_id_type proj_index = elem->dof_number(ls.number(), _proj_var_num, comp);
+      const dof_id_type to_index = elem->dof_number(to_sys.number(), to_var.number(), comp);
+      to_solution->set(to_index, (*ls.solution)(proj_index));
     }
-  }
 
   to_solution->close();
   to_sys.update();

--- a/framework/src/utils/ElementsIntersectedByPlane.C
+++ b/framework/src/utils/ElementsIntersectedByPlane.C
@@ -31,11 +31,8 @@ findElementsIntersectedByPlane(const Plane & plane,
                                std::vector<const Elem *> & intersected_elems)
 {
   // Loop over all elements to find elements intersected by the plane
-  MeshBase::const_element_iterator el = mesh.elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.elements_end();
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.element_ptr_range())
   {
-    const Elem * elem = *el;
     bool intersected = false;
 
     // Check whether the first node of this element is below or above the plane

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1713,10 +1713,8 @@ DMMooseGetMeshBlocks_Private(DM dm, std::set<subdomain_id_type> & blocks)
   /* The following effectively is a verbatim copy of MeshBase::n_subdomains(). */
   // This requires an inspection on every processor
   libmesh_parallel_only(mesh.comm());
-  MeshBase::const_element_iterator el = mesh.active_elements_begin();
-  const MeshBase::const_element_iterator end = mesh.active_elements_end();
-  for (; el != end; ++el)
-    blocks.insert((*el)->subdomain_id());
+  for (const auto & elem : mesh.active_element_ptr_range())
+    blocks.insert(elem->subdomain_id());
   // Some subdomains may only live on other processors
   mesh.comm().set_union(blocks);
   PetscFunctionReturn(0);

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -351,6 +351,9 @@ setWhichEigenPairsOptions(SolverParams & solver_params)
 void
 setEigenSolverOptions(SolverParams & solver_params, const InputParameters & params)
 {
+  // Avoid unused variable warnings when you have SLEPc but not PETSc-dev.
+  libmesh_ignore(params);
+
   switch (solver_params._eigen_solve_type)
   {
     case Moose::EST_POWER:


### PR DESCRIPTION
It has been a while, so we should probably do one of these...

I am also waiting for libmesh/libmesh#1482 to be merged so that we are sure the optimized PerfLog is also bug-free, but I wanted to get the testing going sooner rather than later.

Brief summary of changes in this update:

* libMesh now requires a C++11-conforming compiler.
* Updates to TypeNTensor required for vector-valued elements.
* Use new Mesh and Elem ranges in for-loops.
* dof_indices() optimization.
* Fix issue with writing solution vectors containing both scalar and vector FE DOFs.
* Misc. infinite elements updates/optimizations/fixes.
* The LIBMESH_BEST_UNORDERED_XYZ macros correspond only to std::unordered containers.
* Improve PerfLog performance by storing char*s instead of std::strings.
* Deprecate Node/DofObject copy methods.
* Avoid closing matrices unnecessarily in EigenSolver.
* Optimization: cache FEMContext::point_value() FE Objects.
* Fix ExodusII_IO::copy_elemental_solution() to work in parallel.
* Add SHELL8 element and associated example, misc_ex13.
* Add --disable-deprecated option; generates compiler errors when deprecated code is used.
* Avoid using deprecated code in several places.
* Update DifferentiableQoI to handle more complex derivatives.
* Optimization: Add possible early return from refine_and_coarsen_elements().
* Add SparseMatrix::flush() API.
* Add DofMap::semilocal_index().
* Fix XDR output of 64-bit int, long.
* libmesh-config: Move libmesh library PATH to beginning of --libs.
* Add configure test for C++17 [[fallthrough]] attribute.
* Optimization: UnstructuredMesh::stitch_meshes().


