### PR TITLE
Fix ComputeReducedOrderEigenstrain to work with faces of 1D elements

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeReducedOrderEigenstrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeReducedOrderEigenstrain.C
@@ -115,7 +115,7 @@ ComputeReducedOrderEigenstrain::prepareEigenstrain()
 {
   // The eigenstrains can either be constant in an element or linear in x, y, z
   // If constant, do volume averaging.
-  if (!_second_order)
+  if (!_second_order || _qrule->n_points() == 1)
   {
     // Volume average
     _adjusted_eigenstrain.zero();


### PR DESCRIPTION
The cholesky solve fails when this runs on the faces of 1D elements because there is only one Gauss point.  This adjusts the code to run volume averaging when there is only one Gauss point. #9560