### PR TITLE
Enable comments in TabulatedFluidProperties csv files

### DIFF
--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -11,6 +11,7 @@
 
 // C++ includes
 #include <fstream>
+#include <ctime>
 
 template <>
 InputParameters
@@ -59,6 +60,9 @@ TabulatedFluidProperties::TabulatedFluidProperties(const InputParameters & param
     mooseError("temperature_max must be greater than temperature_min in ", name());
   if (_pressure_max <= _pressure_min)
     mooseError("pressure_max must be greater than pressure_min in ", name());
+
+  // Lines starting with # are treated as comments
+  _csv_reader.setComment("#");
 }
 
 TabulatedFluidProperties::~TabulatedFluidProperties() {}
@@ -373,6 +377,11 @@ TabulatedFluidProperties::writeTabulatedData(std::string file_name)
     MooseUtils::checkFileWriteable(file_name);
 
     std::ofstream file_out(file_name.c_str());
+
+    // Write out date and fluid type
+    time_t now = time(&now);
+    file_out << "# " << _fp.fluidName() << " properties created by TabulatedFluidProperties on "
+             << ctime(&now) << "\n";
 
     std::string column_names{"pressure, temperature, density, enthalpy, internal_energy"};
 

--- a/unit/data/csv/fluid_props.csv
+++ b/unit/data/csv/fluid_props.csv
@@ -1,3 +1,4 @@
+# Sample fluid properties for CO2
 pressure, temperature, density, enthalpy, internal_energy
 1e+06, 400, 13.4775, 85939.4, 11741.5
 1e+06, 450, 11.8993, 134995, 50956.9

--- a/unit/include/TabulatedFluidPropertiesTest.h
+++ b/unit/include/TabulatedFluidPropertiesTest.h
@@ -58,7 +58,7 @@ protected:
 
     InputParameters tab_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     tab_uo_params.set<UserObjectName>("fp") = "co2_fp";
-    tab_uo_params.set<FileName>("fluid_property_file") = "data/csv/fluid_properties.csv";
+    tab_uo_params.set<FileName>("fluid_property_file") = "data/csv/fluid_props.csv";
     _fe_problem->addUserObject("TabulatedFluidProperties", "tab_fp", tab_uo_params);
     _tab_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("tab_fp");
 

--- a/unit/src/TabulatedFluidPropertiesTest.C
+++ b/unit/src/TabulatedFluidPropertiesTest.C
@@ -13,6 +13,7 @@
 /****************************************************************/
 
 #include "TabulatedFluidPropertiesTest.h"
+#include "Utils.h"
 
 // Test data for unordered data
 TEST_F(TabulatedFluidPropertiesTest, unorderedData)
@@ -84,4 +85,18 @@ TEST_F(TabulatedFluidPropertiesTest, missingData)
                                 "by the number of unique temperature values 3");
     ASSERT_TRUE(pos != std::string::npos);
   }
+}
+
+// Test tabulated fluid properties read from file including comments
+TEST_F(TabulatedFluidPropertiesTest, fromFile)
+{
+  Real p = 1.5e6;
+  Real T = 450.0;
+
+  // Read the data file
+  const_cast<TabulatedFluidProperties *>(_tab_fp)->initialSetup();
+
+  REL_TEST("density", _tab_fp->rho(p, T), _co2_fp->rho(p, T), 1.0e-4);
+  REL_TEST("enthalpy", _tab_fp->h(p, T), _co2_fp->h(p, T), 1.0e-4);
+  REL_TEST("internal_energy", _tab_fp->e(p, T), _co2_fp->e(p, T), 1.0e-4);
 }


### PR DESCRIPTION
Also fixes a minor bug in the unit tests of this object where an incorrect file was added but never used, so never threw an error.

Closes #10212 