### PR TITLE
Put string guards around the dump output.

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -419,7 +419,8 @@ MooseApp::setupOptions()
     JsonSyntaxTree tree(param_search);
     _parser.buildJsonSyntaxTree(tree);
     JsonInputFileFormatter formatter;
-    Moose::out << formatter.toString(tree.getRoot()) << "\n";
+    Moose::out << "### START DUMP DATA ###\n"
+               << formatter.toString(tree.getRoot()) << "\n### END DUMP DATA ###\n";
     _ready_to_exit = true;
   }
   else if (isParamValid("definition"))

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -155,6 +155,12 @@ class TestJSON(unittest.TestCase):
         """
         args = ["--disable-refcount-printing", "--dump"] + extra
         output = run_app(args)
+        self.assertIn("### START DUMP DATA ###\n", output)
+        self.assertIn("### END DUMP DATA ###\n", output)
+
+        output = output.split('### START DUMP DATA ###\n')[1]
+        output = output.split('### END DUMP DATA ###')[0]
+
         self.assertNotEqual(len(output), 0)
         root = hit.parse("dump.i", output)
         hit.explode(root)


### PR DESCRIPTION
This puts similar guards around the `--dump` output so that it is possible to grab only the dump data even if there is extra data printed before or after.

@milljm saw a case where openmpi was printing out some information before the dump which
then caused the test_json.py test to fail.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
