### PR TITLE
Sync parameters when switching block types on peacock input tab.

### DIFF
--- a/python/peacock/Input/InputTreeWriter.py
+++ b/python/peacock/Input/InputTreeWriter.py
@@ -91,7 +91,7 @@ def nodeParamsString(output, entry, indent, sep, ignore_type=False):
         if not val and name != 'active': # we generally don't want to write out empty strings
             continue
         comments = info.comments
-        if info.value != info.default or info.user_added or info.set_in_input_file:
+        if info.hasChanged() or info.user_added or info.set_in_input_file:
             paramToString(output, info.name, val, comments, indent, sep)
 
     type_info = entry.parameters.get("type")

--- a/python/peacock/Input/ParameterInfo.py
+++ b/python/peacock/Input/ParameterInfo.py
@@ -102,6 +102,9 @@ class ParameterInfo(object):
     def toolTip(self):
         return self.description + "\nDefault: %s" % self.default
 
+    def hasChanged(self):
+        return self.value != self.default or self.comments
+
     def dump(self, o, indent=0, sep='  '):
         o.write("%sName: %s\n" % (indent*sep, self.name))
         o.write("%sValue: %s\n" % (indent*sep, self.value))

--- a/python/peacock/Input/ParamsByGroup.py
+++ b/python/peacock/Input/ParamsByGroup.py
@@ -95,10 +95,41 @@ class ParamsByGroup(QTabWidget, MooseWidget):
             t.reset()
 
     def findTable(self, group):
-        return self.group_table_map.get(group)
+        return self.group_table_map.get(group, None)
 
     def paramValue(self, name):
         for i in range(self.count()):
             t = self.widget(i)
             if t.paramValue(name):
                 return t.paramValue(name)
+
+    def getParamData(self):
+        """
+        Get the current parameter information.
+        This is what is shown in the widget and is
+        not necessarily the same values that would
+        be in the ParameterInfo since the values
+        might not have been saved yet.
+        """
+        param_data = {}
+        for group, t in self.group_table_map.iteritems():
+            param_data.update(t.getCurrentParamData())
+        return param_data
+
+    def syncParamsFrom(self, prev):
+        """
+        Sync changes from another ParamsByGroup object to this one.
+        Intended for use by ParamsByType. When the type changes
+        we want to copy edited parameter values and comments from
+        the previous type to this one.
+        Input:
+            prev[ParamsByGroup]: parameters to sync from
+        """
+        ignore = ["Name", "type"]
+        for name, prev_p in prev.getParamData().iteritems():
+            if name in ignore:
+                continue
+            if prev_p["changed"] and not prev_p["user_added"]:
+                t = self.findTable(prev_p["group"])
+                if t:
+                    t.setParamValue(name, prev_p["value"], prev_p["comments"])

--- a/python/peacock/Input/ParamsByType.py
+++ b/python/peacock/Input/ParamsByType.py
@@ -62,10 +62,11 @@ class ParamsByType(QWidget, MooseWidget):
         tot = to.findTable("Main")
         if not ct or not tot or ct == tot:
             return
-        # first remove user params in tot
         tot.removeUserParams()
         params = ct.getUserParams()
         tot.addUserParams(params)
+        to.syncParamsFrom(current)
+        # Make sure the name parameter stays the same
         idx = ct.findRow("Name")
         if idx >= 0:
             name = ct.item(idx, 1).text()

--- a/python/peacock/tests/input_tab/ParamsByType/test_ParamsByType.py
+++ b/python/peacock/tests/input_tab/ParamsByType/test_ParamsByType.py
@@ -42,7 +42,9 @@ class Tests(Testing.PeacockTester):
 
     def createParams(self, b):
         b.addParameter(self.createParam("%s_p0" % b.name))
+        b.addParameter(self.createParam("common"))
         b.addParameter(self.createParam("%s_p1" % b.name, group="Group1"))
+        b.addParameter(self.createParam("common_group1", group="Group1"))
         b.addParameter(self.createParam("%s_p2" % b.name, group="Group2"))
         b.addParameter(self.createParam("%s_p3" % b.name, group="Group1"))
         b.addParameter(self.createParam("%s_p4" % b.name, group="Group2"))
@@ -114,6 +116,47 @@ class Tests(Testing.PeacockTester):
         t = self.createWidget(b)
         self.assertEqual(t.combo.count(), 0)
         self.assertEqual(t.table_stack.count(), 0)
+
+    def testChangeType(self):
+        t = self.createWidget(self.createTypes(), "")
+        self.assertEqual(t.combo.count(), 4)
+        self.assertEqual(t.table_stack.count(), 1)
+
+        p0_name = "common"
+        p1_name = "common_group1"
+        data = t.getTable().getParamData()
+        self.assertIn(p0_name, data)
+        self.assertEqual(data[p0_name]["group"], "Main")
+        self.assertIn(p1_name, data)
+        self.assertEqual(data[p1_name]["group"], "Group1")
+        p0_val = "something else 0"
+        p0_comment = "some comment 0"
+        p1_val = "something else 1"
+        p1_comment = "some comment 1"
+        current = t.getTable().findTable("Main")
+        current.setParamValue(p0_name, p0_val, p0_comment)
+        current = t.getTable().findTable("Group1")
+        current.setParamValue(p1_name, p1_val, p1_comment)
+
+        data = t.getTable().getParamData()
+        self.assertEqual(data[p0_name]["value"], p0_val)
+        self.assertEqual(data[p0_name]["comments"], p0_comment)
+        self.assertEqual(data[p0_name]["changed"], True)
+        self.assertEqual(data[p1_name]["value"], p1_val)
+        self.assertEqual(data[p1_name]["comments"], p1_comment)
+        self.assertEqual(data[p1_name]["changed"], True)
+
+        # Make sure that when we switch types we copy
+        # over the values and comments from common parameters.
+        t.setBlockType("type_3")
+
+        data = t.getTable().getParamData()
+        self.assertEqual(data[p0_name]["value"], p0_val)
+        self.assertEqual(data[p0_name]["comments"], p0_comment)
+        self.assertEqual(data[p0_name]["changed"], True)
+        self.assertEqual(data[p1_name]["value"], p1_val)
+        self.assertEqual(data[p1_name]["comments"], p1_comment)
+        self.assertEqual(data[p1_name]["changed"], True)
 
 if __name__ == '__main__':
     Testing.run_tests()


### PR DESCRIPTION
closes #10109

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
