### PR TITLE
negative Jacobian tests in 2D

### DIFF
--- a/test/tests/misc/jacobian/no_negative_jacobian_2D.i
+++ b/test/tests/misc/jacobian/no_negative_jacobian_2D.i
@@ -1,0 +1,42 @@
+# The mesh is inverted using a prescribed displacement.
+# However, due to use_displaced_mesh = false in the Kernel,
+# libMesh does not throw a "negative jacobian" error
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  displacements = 'disp_x disp_y'
+[]
+
+[AuxVariables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+[]
+
+[AuxKernels]
+  [./disp_x]
+    variable = disp_x
+    type = FunctionAux
+    function = '-x*t'
+  [../]
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+    use_displaced_mesh = false
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 0.5
+  end_time = 1.5
+[]

--- a/test/tests/misc/jacobian/tests
+++ b/test/tests/misc/jacobian/tests
@@ -41,4 +41,23 @@
     cli_args = 'Kernels/diff/use_displaced_mesh=true Executioner/dt=0.8'
     expect_err = 'ERROR: negative Jacobian -0.0625 at point \(x,y,z\)=\(-0.105662, 0.211325, 0.211325\) in element 0'
   [../]
+
+  [./no_negative_jacobian_2D]
+    type = RunApp
+    input = no_negative_jacobian_2D.i
+  [../]
+  [./jacobian_2D_zero]
+    type = RunException
+    input = no_negative_jacobian_2D.i
+    prereq = no_negative_jacobian_2D
+    cli_args = 'Kernels/diff/use_displaced_mesh=true'
+    expect_err = 'ERROR: negative Jacobian 0 at point \(x,y,z\)=\(       0, 0.211325,        0\) in element 0'
+  [../]
+  #[./jacobian_2D_negative]
+  #  type = RunException
+  #  input = no_negative_jacobian_2D.i
+  #  prereq = no_negative_jacobian_2D
+  #  cli_args = 'Kernels/diff/use_displaced_mesh=true Executioner/dt=0.8'
+  #  expect_err = 'ERROR: negative Jacobian -0.0625 at point \(x,y,z\)=\(-0.105662, 0.211325, 0.211325\) in element 0'
+  #[../]
 []


### PR DESCRIPTION
Refs #9740

I need help with this.  @jwpeterson ?

This PR contains a single 2D input file that illustrates:
 (1) MOOSE does not fail if an element is inverted, if the kernels use_displaced_mesh=false
 (2) MOOSE does fail (correctly) if an element is deformed such that Jacobian=0, if the kernels use_displaced_mesh=true

But, i can't get MOOSE to fail if:
 (3) an element is deformed such that Jacobian < 0, if the kernels use_displaced_mesh=true

There is already a 3D test (in the same directory) that illustrate (1), (2) and (3) work in 3D.

The question is: why is Libmesh not producing an error in 2D when Jacobian < 0.  From line 736 of ```libmesh/src/fe/fe_map.C``` i believe that it should.