### PR TITLE
 testharness: only run tests in CWD subtree

### DIFF
--- a/modules/chemical_reactions/run_tests
+++ b/modules/chemical_reactions/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/chemical_reactions/run_tests
+++ b/modules/chemical_reactions/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'chemical_reactions'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/chemical_reactions/testroot
+++ b/modules/chemical_reactions/testroot
@@ -1,0 +1,2 @@
+app_name = chemical_reactions
+cli_args = '--error'

--- a/modules/combined/run_tests
+++ b/modules/combined/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/combined/run_tests
+++ b/modules/combined/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'combined'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/combined/testroot
+++ b/modules/combined/testroot
@@ -1,0 +1,2 @@
+app_name = combined
+cli_args = '--error'

--- a/modules/contact/run_tests
+++ b/modules/contact/run_tests
@@ -1,23 +1,9 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'contact'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+

--- a/modules/contact/run_tests
+++ b/modules/contact/run_tests
@@ -1,9 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
-
+../../scripts/run_tests

--- a/modules/contact/testroot
+++ b/modules/contact/testroot
@@ -1,0 +1,2 @@
+app_name = contact
+cli_args = '--error'

--- a/modules/fluid_properties/run_tests
+++ b/modules/fluid_properties/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/fluid_properties/run_tests
+++ b/modules/fluid_properties/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'fluid_properties'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/fluid_properties/testroot
+++ b/modules/fluid_properties/testroot
@@ -1,0 +1,2 @@
+app_name = fluid_properties
+cli_args = '--error'

--- a/modules/heat_conduction/run_tests
+++ b/modules/heat_conduction/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/heat_conduction/run_tests
+++ b/modules/heat_conduction/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'heat_conduction'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/heat_conduction/testroot
+++ b/modules/heat_conduction/testroot
@@ -1,0 +1,2 @@
+app_name = heat_conduction
+cli_args = '--error'

--- a/modules/level_set/run_tests
+++ b/modules/level_set/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/level_set/run_tests
+++ b/modules/level_set/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'level_set'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/level_set/testroot
+++ b/modules/level_set/testroot
@@ -1,0 +1,2 @@
+app_name = level_set
+cli_args = '--error'

--- a/modules/misc/run_tests
+++ b/modules/misc/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/misc/run_tests
+++ b/modules/misc/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'misc'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/misc/testroot
+++ b/modules/misc/testroot
@@ -1,0 +1,2 @@
+app_name = misc
+cli_args = '--error'

--- a/modules/navier_stokes/run_tests
+++ b/modules/navier_stokes/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join('..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/navier_stokes/run_tests
+++ b/modules/navier_stokes/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'navier_stokes'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join('..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/navier_stokes/testroot
+++ b/modules/navier_stokes/testroot
@@ -1,0 +1,2 @@
+app_name = navier_stokes
+cli_args = '--error'

--- a/modules/phase_field/run_tests
+++ b/modules/phase_field/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/phase_field/run_tests
+++ b/modules/phase_field/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'phase_field'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/phase_field/testroot
+++ b/modules/phase_field/testroot
@@ -1,0 +1,2 @@
+app_name = phase_field
+cli_args = '--error'

--- a/modules/porous_flow/run_tests
+++ b/modules/porous_flow/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/porous_flow/run_tests
+++ b/modules/porous_flow/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'porous_flow'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/porous_flow/testroot
+++ b/modules/porous_flow/testroot
@@ -1,0 +1,2 @@
+app_name = porous_flow
+cli_args = '--error'

--- a/modules/rdg/run_tests
+++ b/modules/rdg/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/rdg/run_tests
+++ b/modules/rdg/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'rdg'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/rdg/testroot
+++ b/modules/rdg/testroot
@@ -1,0 +1,2 @@
+app_name = rdg
+cli_args = '--error'

--- a/modules/richards/run_tests
+++ b/modules/richards/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/richards/run_tests
+++ b/modules/richards/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'richards'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/richards/testroot
+++ b/modules/richards/testroot
@@ -1,0 +1,2 @@
+app_name = richards
+cli_args = '--error'

--- a/modules/run_tests
+++ b/modules/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../scripts/run_tests

--- a/modules/run_tests
+++ b/modules/run_tests
@@ -1,26 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'combined/combined'
-
-MODULE_DIR = os.path.abspath('.')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
-# Append color first directory flag when running tests for modules
-sys.argv.insert(1, "--color-first-directory")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/solid_mechanics/run_tests
+++ b/modules/solid_mechanics/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/solid_mechanics/run_tests
+++ b/modules/solid_mechanics/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'solid_mechanics'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/solid_mechanics/testroot
+++ b/modules/solid_mechanics/testroot
@@ -1,0 +1,2 @@
+app_name = solid_mechanics
+cli_args = '--error'

--- a/modules/stochastic_tools/run_tests
+++ b/modules/stochastic_tools/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/stochastic_tools/run_tests
+++ b/modules/stochastic_tools/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'stochastic_tools'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/stochastic_tools/testroot
+++ b/modules/stochastic_tools/testroot
@@ -1,0 +1,2 @@
+app_name = stochastic_tools
+cli_args = '--error'

--- a/modules/tensor_mechanics/run_tests
+++ b/modules/tensor_mechanics/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/tensor_mechanics/run_tests
+++ b/modules/tensor_mechanics/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'tensor_mechanics'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/tensor_mechanics/testroot
+++ b/modules/tensor_mechanics/testroot
@@ -1,0 +1,2 @@
+app_name = tensor_mechanics
+cli_args = '--error'

--- a/modules/testroot
+++ b/modules/testroot
@@ -1,0 +1,2 @@
+app_name = combined/combined
+cli_args = '--color-first-directory --error'

--- a/modules/water_steam_eos/run_tests
+++ b/modules/water_steam_eos/run_tests
@@ -1,23 +1,9 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'water_steam_eos'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+

--- a/modules/water_steam_eos/run_tests
+++ b/modules/water_steam_eos/run_tests
@@ -1,9 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
-
+../../scripts/run_tests

--- a/modules/water_steam_eos/testroot
+++ b/modules/water_steam_eos/testroot
@@ -1,0 +1,2 @@
+app_name = water_steam_eos
+cli_args = '--error'

--- a/modules/xfem/run_tests
+++ b/modules/xfem/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../scripts/run_tests

--- a/modules/xfem/run_tests
+++ b/modules/xfem/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'xfem'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/modules/xfem/testroot
+++ b/modules/xfem/testroot
@@ -1,0 +1,2 @@
+app_name = xfem
+cli_args = '--error'

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -4,32 +4,63 @@ if sys.version_info[0:2] != (2, 7):
     sys.exit(1)
 
 import os, re, inspect, errno, time, copy
+import shlex
 
 from socket import gethostname
 from FactorySystem.Factory import Factory
 from FactorySystem.Parser import Parser
 from FactorySystem.Warehouse import Warehouse
 import util
+import hit
 
 import argparse
 from timeit import default_timer as clock
+
+def findTestRoot(start=os.getcwd(), method=os.environ.get('METHOD', 'opt')):
+    rootdir = os.path.abspath(start)
+    while os.path.dirname(rootdir) != rootdir:
+        fname = os.path.join(rootdir, 'testroot')
+        if os.path.exists(fname):
+            with open(fname, 'r') as f:
+                data = f.read()
+            root = hit.parse(fname, data)
+            args = []
+            if root.find('cli_args'):
+                args = shlex.split(root.param('cli_args'))
+            appname = root.param('app_name') + '-' + method
+            if os.path.exists(os.path.join(rootdir, appname)) or appname.startswith('moose_python'):
+                return rootdir, root.param('app_name'), args
+        rootdir = os.path.dirname(rootdir)
+    raise RuntimeError('test root directory not found')
 
 class TestHarness:
 
     @staticmethod
     def buildAndRun(argv, app_name, moose_dir):
         if '--store-timing' in argv:
-            harness = TestTimer(argv, app_name, moose_dir)
+            harness = TestTimer(argv, moose_dir, app_name=app_name)
         else:
-            harness = TestHarness(argv, app_name, moose_dir)
+            harness = TestHarness(argv, moose_dir, app_name=app_name)
 
         harness.findAndRunTests()
-
         sys.exit(harness.error_code)
 
+    def __init__(self, argv, moose_dir, app_name=None):
+        os.environ['MOOSE_DIR'] = moose_dir
+        os.environ['PYTHONPATH'] = os.path.join(moose_dir, 'python') + ':' + os.environ.get('PYTHONPATH', '')
 
-    def __init__(self, argv, app_name, moose_dir):
+        if app_name:
+            rootdir, app_name, args = '.', app_name, []
+        else:
+            rootdir, app_name, args = findTestRoot(start=os.getcwd())
+
+        orig_cwd = os.getcwd()
+        os.chdir(rootdir)
+        argv = argv[:1] + args + argv[1:]
+
         self.factory = Factory()
+
+        self.app_name = app_name
 
         # Build a Warehouse to hold the MooseObjects
         self.warehouse = Warehouse()
@@ -139,6 +170,8 @@ class TestHarness:
         self.options._checks = checks
 
         self.initialize(argv, app_name)
+
+        os.chdir(orig_cwd)
 
     """
     Recursively walks the current tree looking for tests to run
@@ -759,15 +792,14 @@ CREATE_TABLE = """create table timing
 );"""
 
 class TestTimer(TestHarness):
-    def __init__(self, argv, app_name, moose_dir):
-        TestHarness.__init__(self, argv, app_name, moose_dir)
+    def __init__(self, argv, moose_dir, app_name=None):
+        TestHarness.__init__(self, argv, app_name=app_name)
         try:
             from sqlite3 import dbapi2 as sqlite
             assert sqlite # silence pyflakes warning
         except:
             print('Error: --store-timing requires the sqlite3 python module.')
             sys.exit(1)
-        self.app_name = app_name
         self.db_file = self.options.dbFile
         if not self.db_file:
             home = os.environ['HOME']

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -27,9 +27,10 @@ def findTestRoot(start=os.getcwd(), method=os.environ.get('METHOD', 'opt')):
             args = []
             if root.find('cli_args'):
                 args = shlex.split(root.param('cli_args'))
-            appname = root.param('app_name') + '-' + method
-            if os.path.exists(os.path.join(rootdir, appname)) or appname.startswith('moose_python'):
-                return rootdir, root.param('app_name'), args
+            # TODO: add check to see if the binary exists before returning. This can be used to
+            # allow users to control fallthrough for e.g. individual module binaries vs. the
+            # combined binary.
+            return rootdir, root.param('app_name'), args
         rootdir = os.path.dirname(rootdir)
     raise RuntimeError('test root directory not found')
 

--- a/python/TestHarness/tests/test_QueuePBS.py
+++ b/python/TestHarness/tests/test_QueuePBS.py
@@ -41,7 +41,7 @@ class HarnessAndDAG(object):
         os.chdir(run_tests_dir)
 
         # Instance the TestHarness
-        self.harness = TestHarness(['foo', '--pbs', self.pbs_session_file], 'moose_test', os.getenv('MOOSE_DIR'))
+        self.harness = TestHarness(['foo', '--pbs', self.pbs_session_file], os.getenv('MOOSE_DIR'), app_name='moose_test')
 
         ### With the TestHarness properly instanced we now need to simulate
         ### what findAndRunTests does by changing into each tester directory
@@ -416,7 +416,7 @@ class TestHarnessTestCase(unittest.TestCase):
 
         # See if we actually made a mess, like we should have
         if os.path.exists(self.session_dir):
-            harness = TestHarness(['foo', '--queue-cleanup', self.pbs_session_file], 'moose', os.getenv('MOOSE_DIR'))
+            harness = TestHarness(['foo', '--queue-cleanup', self.pbs_session_file], os.getenv('MOOSE_DIR'), app_name='moose')
 
             # Perform the clean up code
             harness.scheduler.cleanUp()

--- a/python/run_tests
+++ b/python/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.environ.get('MOOSE_DIR', '..')
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../scripts/run_tests

--- a/python/run_tests
+++ b/python/run_tests
@@ -1,20 +1,8 @@
 #!/usr/bin/env python
-import sys
-import os
+import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.dirname(__file__))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'moose_python'
-
-MOOSE_DIR = os.path.abspath(os.path.join('..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-    MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.environ.get('MOOSE_DIR', '..')
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
 
 from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/python/testroot
+++ b/python/testroot
@@ -1,0 +1,1 @@
+app_name = moose_python

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.environ.get('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-MOOSE_DIR = os.environ.get('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+MOOSE_DIR = os.environ.get('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
 from TestHarness import TestHarness

--- a/stork/run_tests.app
+++ b/stork/run_tests.app
@@ -1,22 +1,12 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'stork'
-
-MOOSE_DIR = os.path.abspath(os.path.join('..', 'moose'))
-#### See if a submodule is available
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', 'moose')))
 if os.path.exists(os.path.abspath(os.path.join('moose', 'framework', 'Makefile'))):
   MOOSE_DIR = os.path.abspath('moose')
-#### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
-  MOOSE_DIR = os.environ['MOOSE_DIR']
+MOOSE_DIR = os.environ.get('MOOSE_DIR', MOOSE_DIR)
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/stork/run_tests.module
+++ b/stork/run_tests.module
@@ -1,20 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'stork'
-
-MODULE_DIR = os.path.abspath('..')
-MOOSE_DIR = os.path.abspath(os.path.join(MODULE_DIR, '..'))
-#### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/stork/testroot
+++ b/stork/testroot
@@ -1,0 +1,2 @@
+app_name = stork
+cli_args = '--error'

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../scripts/run_tests

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,24 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'moose_test'
-
-MOOSE_DIR = os.path.abspath(os.path.join('..'))
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
-os.environ['MOOSE_DIR'] = MOOSE_DIR
 
-# Append error flag when running tests
-sys.argv.insert(1, "--error")
-
-# Run the tests!
 from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/test/testroot
+++ b/test/testroot
@@ -1,0 +1,2 @@
+app_name = moose_test
+cli_args = '--error'

--- a/tutorials/darcy_thermo_mech/step01_diffusion/run_tests
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/run_tests
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
-
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'darcy_thermo_mech'
-
-#### Three directories up
-MOOSE_DIR = os.path.abspath(os.path.join('..', '..', '..'))
-#### See if a submodule is available
-if os.path.exists(os.path.abspath(os.path.join('moose', 'framework', 'Makefile'))):
-  MOOSE_DIR = os.path.abspath('moose')
-#### See if MOOSE_DIR is already in the environment instead
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step01_diffusion/run_tests
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step01_diffusion/testroot
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/testroot
@@ -1,0 +1,1 @@
+app_name = darcy_thermo_mech

--- a/tutorials/darcy_thermo_mech/step02_darcy_pressure/run_tests
+++ b/tutorials/darcy_thermo_mech/step02_darcy_pressure/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step02_darcy_pressure/run_tests
+++ b/tutorials/darcy_thermo_mech/step02_darcy_pressure/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step02_darcy_pressure/testroot
+++ b/tutorials/darcy_thermo_mech/step02_darcy_pressure/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/run_tests
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/run_tests
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/testroot
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/run_tests
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/run_tests
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/testroot
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/run_tests
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/run_tests
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/testroot
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/run_tests
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/run_tests
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/testroot
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/run_tests
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/run_tests
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/testroot
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/run_tests
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/run_tests
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/testroot
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot

--- a/tutorials/darcy_thermo_mech/step09_mechanics/run_tests
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step09_mechanics/run_tests
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step09_mechanics/testroot
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot

--- a/tutorials/darcy_thermo_mech/step10_multiapps/run_tests
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/run_tests
@@ -1,1 +1,8 @@
-../step01_diffusion/run_tests
+#!/usr/bin/env python
+import sys, os
+
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+sys.path.append(os.path.join(MOOSE_DIR, 'python'))
+
+from TestHarness import TestHarness
+TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)

--- a/tutorials/darcy_thermo_mech/step10_multiapps/run_tests
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/run_tests
@@ -1,8 +1,1 @@
-#!/usr/bin/env python
-import sys, os
-
-MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-
-from TestHarness import TestHarness
-TestHarness.buildAndRun(sys.argv, None, MOOSE_DIR)
+../../../scripts/run_tests

--- a/tutorials/darcy_thermo_mech/step10_multiapps/testroot
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/testroot
@@ -1,0 +1,1 @@
+../step01_diffusion/testroot


### PR DESCRIPTION
Instead of the run_tests script running all tests in its dir subtree
using a specific named binary, modify the test harness to just run tests
in the current working directory's subtree.  The binary is discovered
walking of the parent directory hierarchy looking for a "testroot" file.
This file contains the name of the binary to be used.  "run_tests"
scripts now can all be identical with no app-specific content.

Also provide a "moosetest" script that users can add to their path that
will always run tests in the CWD for *any* moose app/binary - it just
hunts for a "testroot" file.

fixes #10209
