### PR TITLE
Add --no-check-input (no syntax tests) feature

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -420,10 +420,14 @@ class Tester(MooseObject):
                 return False
 
         # Check if we only want to run syntax tests
-        if options.check_input:
-            if not self.specs['check_input']:
-                self.setStatus('not check_input', self.bucket_silent)
-                return False
+        if options.check_input and not self.specs['check_input']:
+            self.setStatus('not check_input', self.bucket_silent)
+            return False
+
+        # Check if we want to exclude syntax tests
+        if options.no_check_input and self.specs['check_input']:
+            self.setStatus('is check_input', self.bucket_silent)
+            return False
 
         # Are we running only tests in a specific group?
         if options.group <> 'ALL' and options.group not in self.specs['group']:

--- a/python/TestHarness/tests/test_ReportSkipped.py
+++ b/python/TestHarness/tests/test_ReportSkipped.py
@@ -1,0 +1,15 @@
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testSyntax(self):
+        """
+        Test for --no-report (do not report skipped tests)
+        """
+
+        # Verify the skipped test _does_ appear
+        output = self.runExceptionTests('-i', 'ignore_skipped')
+        self.assertIn('skipped (always skipped)', output)
+
+        # Verify the skipped test does _not_ appear
+        output = self.runTests('--no-report', '-i', 'ignore_skipped')
+        self.assertNotIn('skipped (always skipped)', output)

--- a/python/TestHarness/tests/test_Syntax.py
+++ b/python/TestHarness/tests/test_Syntax.py
@@ -14,8 +14,12 @@ class TestHarnessTester(TestHarnessTestCase):
         output = self.runTests('--check-input', '-i', 'syntax')
         self.assertIn('SYNTAX PASS', output)
 
-        # Check that SYNTAX PASS test was not run
+        # Check that the _non_ SYNTAX test was not run
         output = self.runTests('--check-input', '-i', 'no_syntax')
+        self.assertNotIn('SYNTAX PASS', output)
+
+        # Check that _thee_ SYNTAX test is not run
+        output = self.runTests('--no-check-input', '-i', 'syntax')
         self.assertNotIn('SYNTAX PASS', output)
 
         # check that parser errors print correctly

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -67,4 +67,8 @@
     type = PythonUnitTest
     input = test_QueuePBS.py
   [../]
+  [./report_skipped]
+    type = PythonUnitTest
+    input = test_ReportSkipped.py
+  [../]
 []


### PR DESCRIPTION
Added ability for the user to skip all syntax tests. As
well as a unittest for this test case.

Fixed (added) an advertised non-existent feature; do no report
skipped tests (--no-report). It was never working until
now. Including a unittest for this test case.

Closes #9359