### PR TITLE
File extension is after the last dot, not first

### DIFF
--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -604,7 +604,7 @@ getLatestCheckpointFileHelper(const std::list<std::string> & checkpoint_files,
   // Now, out of the newest files find the one with the largest number in it
   for (const auto & res_file : newest_restart_files)
   {
-    auto dot_pos = res_file.find_first_of(".");
+    auto dot_pos = res_file.find_last_of(".");
     auto the_base = res_file.substr(0, dot_pos);
     int file_num = 0;
 


### PR DESCRIPTION
When figuring file base, the file extension is after the last dot, not
first. This resulted in incorrect file_base detection and failed all
recover tests that had dot in their input file names.

Refs #6153

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
