### PR TITLE
Time to drop the setup perf_log

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -91,10 +91,6 @@ namespace Moose
 extern PerfLog perf_log;
 
 /**
- * PerfLog to be used during setup.  This log will get printed just before the first solve. */
-extern PerfLog setup_perf_log;
-
-/**
  * Variable indicating whether we will enable FPE trapping for this run.
  */
 extern bool _trap_fpe;

--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -216,9 +216,6 @@ private:
    */
   void mooseConsole(const std::string & message);
 
-  /// State of the --timing command line argument from MooseApp
-  bool _timing;
-
   /// Reference to cached messages from calls to _console
   const std::ostringstream & _console_buffer;
 

--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -185,14 +185,8 @@ protected:
   /// State for solve performance log
   bool _solve_log;
 
-  /// State for setup performance log
-  bool _setup_log;
-
   /// Control the display libMesh performance log
   bool _libmesh_log;
-
-  /// State for early setup log printing
-  bool _setup_log_early;
 
   /// State for the performance log header information
   bool _perf_header;

--- a/framework/src/actions/CheckOutputAction.C
+++ b/framework/src/actions/CheckOutputAction.C
@@ -125,17 +125,10 @@ CheckOutputAction::checkPerfLogOutput()
     }
 
   // If a Console outputter is found then all the correct handling of performance logs are
-  //   handled within the object(s), so do nothing
+  // handled within the object(s), so do nothing
   if (!has_console)
   {
     Moose::perf_log.disable_logging();
     libMesh::perflog.disable_logging();
-  }
-
-  // If the --timing option is used from the command-line, enable all logging
-  if (_app.getParam<bool>("timing"))
-  {
-    Moose::perf_log.enable_logging();
-    libMesh::perflog.enable_logging();
   }
 }

--- a/framework/src/actions/CheckOutputAction.C
+++ b/framework/src/actions/CheckOutputAction.C
@@ -129,7 +129,6 @@ CheckOutputAction::checkPerfLogOutput()
   if (!has_console)
   {
     Moose::perf_log.disable_logging();
-    Moose::setup_perf_log.disable_logging();
     libMesh::perflog.disable_logging();
   }
 
@@ -137,7 +136,6 @@ CheckOutputAction::checkPerfLogOutput()
   if (_app.getParam<bool>("timing"))
   {
     Moose::perf_log.enable_logging();
-    Moose::setup_perf_log.enable_logging();
     libMesh::perflog.enable_logging();
   }
 }

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -689,20 +689,13 @@ FEProblemBase::initialSetup()
     backupMultiApps(EXEC_INITIAL);
     Moose::perf_log.pop("execMultiApps()", "Setup");
 
-    // Yak is currently relying on doing this after initial Transfers
-    Moose::setup_perf_log.push("computeUserObjects()", "Setup");
-
     // TODO: user object evaluation could fail.
     computeUserObjects(EXEC_INITIAL, Moose::PRE_AUX);
 
-    Moose::setup_perf_log.push("computeAux()", "Setup");
     _aux->compute(EXEC_INITIAL);
-    Moose::setup_perf_log.pop("computeAux()", "Setup");
 
     // The only user objects that should be computed here are the initial UOs
     computeUserObjects(EXEC_INITIAL, Moose::POST_AUX);
-
-    Moose::setup_perf_log.pop("computeUserObjects()", "Setup");
 
     _current_execute_on_flag = EXEC_NONE;
   }

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -1253,8 +1253,6 @@ enableFPE(bool on)
     libMesh::enableFPE(on);
 }
 
-PerfLog setup_perf_log("Setup");
-
 /**
  * Initialize global variables
  */

--- a/framework/src/base/NonlinearSystemBase.C
+++ b/framework/src/base/NonlinearSystemBase.C
@@ -156,8 +156,6 @@ NonlinearSystemBase::~NonlinearSystemBase()
 void
 NonlinearSystemBase::init()
 {
-  Moose::setup_perf_log.push("NonlinerSystem::init()", "Setup");
-
   if (_fe_problem.hasDampers())
     setupDampers();
 
@@ -168,8 +166,6 @@ NonlinearSystemBase::init()
 
   if (_need_residual_copy)
     _residual_copy.init(_sys.n_dofs(), false, SERIAL);
-
-  Moose::setup_perf_log.pop("NonlinerSystem::init()", "Setup");
 }
 
 void

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -72,19 +72,6 @@ validParams<Console>()
                         "individual log settings will override this option.");
   params.addParam<unsigned int>(
       "perf_log_interval", 0, "If set, the performance log will be printed every n time steps");
-  params.addDeprecatedParam<bool>("setup_log_early",
-                                  false,
-                                  "Specifies whether or not the Setup Performance log should be "
-                                  "printed before the first time step.  It will still be printed "
-                                  "at the end if "
-                                  "perf_log"
-                                  " is also enabled and likewise disabled if "
-                                  "perf_log"
-                                  " is false",
-                                  "This parameter is being removed due to lack of usage.");
-  params.addDeprecatedParam<bool>("setup_log",
-                                  "Toggles the printing of the 'Setup Performance' log",
-                                  "This parameter is being removed due to lack of usage.");
   params.addParam<bool>("solve_log", "Toggles the printing of the 'Moose Test Performance' log");
   params.addParam<bool>(
       "perf_header", "Print the libMesh performance log header (requires that 'perf_log = true')");
@@ -131,8 +118,7 @@ validParams<Console>()
   params.addParamNamesToGroup("max_rows verbose show_multiapp_name system_info", "Advanced");
 
   // Performance log group
-  params.addParamNamesToGroup("perf_log setup_log_early setup_log solve_log perf_header",
-                              "Perf Log");
+  params.addParamNamesToGroup("perf_log solve_log perf_header", "Perf Log");
   params.addParamNamesToGroup("libmesh_log", "Performance Log");
 
   // Variable norms group
@@ -174,9 +160,7 @@ Console::Console(const InputParameters & parameters)
     _perf_log(getParam<bool>("perf_log")),
     _perf_log_interval(getParam<unsigned int>("perf_log_interval")),
     _solve_log(isParamValid("solve_log") ? getParam<bool>("solve_log") : _perf_log),
-    _setup_log(isParamValid("setup_log") ? getParam<bool>("setup_log") : _perf_log),
     _libmesh_log(getParam<bool>("libmesh_log")),
-    _setup_log_early(getParam<bool>("setup_log_early")),
     _perf_header(isParamValid("perf_header") ? getParam<bool>("perf_header") : _perf_log),
     _all_variable_norms(getParam<bool>("all_variable_norms")),
     _outlier_variable_norms(getParam<bool>("outlier_variable_norms")),
@@ -209,19 +193,15 @@ Console::Console(const InputParameters & parameters)
   {
     _perf_log = true;
     _solve_log = true;
-    _setup_log = true;
   }
 
   if (_app.name() != "main" &&
       (_pars.isParamSetByUser("perf_log") || _pars.isParamSetByUser("perf_log_interval") ||
-       _pars.isParamSetByUser("setup_log") || _pars.isParamSetByUser("solve_log") ||
-       _pars.isParamSetByUser("perf_header") || _pars.isParamSetByUser("libmesh_log") ||
+       _pars.isParamSetByUser("solve_log") || _pars.isParamSetByUser("perf_header") ||
+       _pars.isParamSetByUser("libmesh_log") ||
        common_action->parameters().isParamSetByUser("print_perf_log")))
     mooseWarning("Performance logging cannot currently be controlled from a Multiapp, please set "
                  "all performance options in the main input file");
-
-  // Deprecate the setup perf log
-  Moose::setup_perf_log.disable_logging();
 
   // Append the common 'execute_on' to the setting for this object
   // This is unique to the Console object, all other objects inherit from the common options
@@ -282,7 +262,7 @@ Console::initialSetup()
   // Also, only allow the main app to change the perf_log settings.
   if (!_timing && _app.name() == "main")
   {
-    if (_perf_log || _setup_log || _solve_log || _perf_header || _setup_log_early)
+    if (_perf_log || _solve_log || _perf_header)
       _app.getOutputWarehouse().setLoggingRequested();
 
     // Disable performance logging if nobody needs logging


### PR DESCRIPTION
This PR drops the setup_perf_log object which has been deprecated for more than a year now. Additionally it simplifies the logic for when the perf_log gets printed. Instead of tracking the `--timing` flag separately throughout multiple Outputs object, it treats that flag _exactly_ like turning it out through normal input file flags. This fixes the duplicate output problem #8638, and makes the log consistent whether turned on through normal parameters or the special CLI flag.

refs #8638
