### PR TITLE
Reinit systems once

### DIFF
--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -1433,6 +1433,15 @@ protected:
   /// Objects to be notified when the mesh changes
   std::vector<MeshChangedInterface *> _notify_when_mesh_changes;
 
+  /**
+   * Helper method to update some or all data after a mesh change.
+   *
+   * Iff intermediate_change is true, only perform updates as
+   * necessary to prepare for another mesh change
+   * immediately-subsequent.
+   */
+  void meshChangedHelper(bool intermediate_change = false);
+
   /// Helper to check for duplicate variable names across systems or within a single system
   bool duplicateVariableCheck(const std::string & var_name, const FEType & type, bool is_aux);
 

--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -1094,6 +1094,9 @@ public:
   /// Update the mesh due to changing XFEM cuts
   virtual bool updateMeshXFEM();
 
+  /**
+   * Update data after a mesh change.
+   */
   virtual void meshChanged() override;
 
   /**

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -4500,7 +4500,7 @@ FEProblemBase::adaptMesh()
 
     if (_adaptivity.adaptMesh())
     {
-      meshChangedHelper(true);  // This may be an intermediate change
+      meshChangedHelper(true); // This may be an intermediate change
       _cycles_completed++;
       mesh_changed = true;
     }


### PR DESCRIPTION
This PR starts with a (small) libMesh update, required to get access to the new EquationSystems::reinit_solutions() and EquationSystems::reinit_systems() APIs there.

Other changes since the last (recent!) libMesh update:

* Fixed corner case in PetscVector<Complex>::localize_to_one
* New infinite element example miscellaneous_ex14
* DistributedMesh infinite element fixes

Then, FEProblemBase::meshChanged() is refactored to optionally allow a partial reinit using those APIs, and FEProblemBase::adaptMesh() uses those partial reinit capabilities to shave a few percent off of runtime (Refs #10256) in applications which do multiple adaptivity cycles per solve step, as discussed in https://github.com/libMesh/libmesh/pull/1497 and [on moose-users](https://groups.google.com/forum/#!msg/moose-users/ewSE3PsOkoE/FRIAu3P7CwAJ)