### PR TITLE
Fix mesh_mode options

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -128,7 +128,7 @@ class TestHarness:
               (self.options.cli_args != None and \
                (self.options.cli_args.find('--parallel-mesh') != -1 or self.options.cli_args.find('--distributed-mesh') != -1)):
 
-            option_set = set(['ALL', 'PARALLEL'])
+            option_set = set(['ALL', 'DISTRIBUTED'])
             checks['mesh_mode'] = option_set
 
         method = set(['ALL', self.options.method.upper()])

--- a/python/TestHarness/tests/test_DistributedMesh.py
+++ b/python/TestHarness/tests/test_DistributedMesh.py
@@ -1,0 +1,17 @@
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testSyntax(self):
+        """
+        Test for correct operation with distributed mesh tests
+        """
+
+        # Verify the distributed mesh test is skipped
+        output = self.runExceptionTests('-i', 'mesh_mode_distributed')
+        self.assertIn('skipped (MESH_MODE!=DISTRIBUTED)', output)
+
+        # Verify the distributed mesh test is passing when providing --distributed
+        # To be acurate, test for OK rather than asserting if 'distributed' is
+        # missing from the output.
+        output = self.runTests('--distributed', '-i', 'mesh_mode_distributed')
+        self.assertRegexpMatches(output, 'test_harness.distributed_mesh.*?OK')

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -71,4 +71,8 @@
     type = PythonUnitTest
     input = test_ReportSkipped.py
   [../]
+  [./distributed_mesh]
+    type = PythonUnitTest
+    input = test_DistributedMesh.py
+  [../]
 []

--- a/test/tests/test_harness/mesh_mode_distributed
+++ b/test/tests/test_harness/mesh_mode_distributed
@@ -1,0 +1,7 @@
+[Tests]
+  [./distributed_mesh]
+    type = RunApp
+    input = good.i
+    mesh_mode = distributed
+  [../]
+[]


### PR DESCRIPTION
We were setting mesh_mode to an outdated 'parallel' parameter.

Include a unittest to verify this option continues to function
in the future.

Closes #9181
