### PR TITLE
Adding bases classes for 2-phase flow fluid properties

### DIFF
--- a/modules/fluid_properties/include/userobjects/HEMFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/HEMFluidProperties.h
@@ -1,0 +1,200 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef HEMFLUIDPROPERTIES_H
+#define HEMFLUIDPROPERTIES_H
+
+#include "FluidProperties.h"
+
+class HEMFluidProperties;
+
+template <>
+InputParameters validParams<HEMFluidProperties>();
+
+/**
+ * Base class for fluid properties used with HEM
+ */
+class HEMFluidProperties : public FluidProperties
+{
+public:
+  HEMFluidProperties(const InputParameters & parameters);
+
+  /**
+   * Pressure as a function of specific internal energy and specific volume
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real pressure(Real v, Real e) const = 0;
+
+  /**
+   * Derivative of pressure w.r.t internal energy and specific volume
+   */
+  virtual void
+  dp_duv(Real v, Real e, Real & dp_dv, Real & dp_de, Real & dT_dv, Real & dT_de) const = 0;
+
+  /**
+   * Temperature as a function of specific internal energy and specific volume
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real temperature(Real v, Real e) const = 0;
+
+  /**
+   * Ratio of specific heats
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real gamma(Real v, Real e) const = 0;
+
+  /**
+   * Quality as a function of specific volume and specific internal energy
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real quality(Real v, Real e) const = 0;
+
+  /**
+   * Sound speed as a function of specific volume and specific internal energy
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real c(Real v, Real e) const = 0;
+
+  /**
+   * Constant pressure specific heat capacity as a function of specific volume
+   * and specific internal energy
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real cp(Real v, Real e) const = 0;
+
+  /**
+   * Constant volume specific heat capacity as a function of specific volume and
+   * specific internal energy
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real cv(Real v, Real e) const = 0;
+
+  /**
+   * Thermal expansion coefficient [1/K] as a function of pressure and
+   * temperature
+   * @param pressure pressure
+   * @param temperature temperature
+   */
+  virtual Real beta(Real pressure, Real temperature) const = 0;
+
+  /**
+   * Dynamic viscosity, [Pa-s], as a function of specific volume and specific
+   * internal energy
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real mu(Real v, Real e) const = 0;
+
+  /**
+   * Thermal conductivity, [W/K-m], as a function of specific volume and
+   * specific internal energy
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real k(Real v, Real e) const = 0;
+
+  /**
+   * Liquid Void Fraction as a function of specific volume and specific
+   * internal energy
+   * @param v Specific volume
+   * @param e Specific internal energy
+   */
+  virtual Real alpha_liquid(Real v, Real e) const = 0;
+
+  /**
+   * dT/dp along the saturation line
+   */
+  virtual Real dT_dP_saturation(Real pressure) const = 0;
+
+  /**
+   * Density as a function of pressure and temperature
+   * @param pressure pressure
+   * @param temperature temperature
+   */
+  virtual Real rho(Real pressure, Real temperature) const = 0;
+
+  /**
+   * Density derivative as a function of pressure and temperature
+   * @param pressure pressure
+   * @param temperature temperature
+   */
+  virtual void
+  rho_dpT(Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const = 0;
+
+  /**
+   * Density and internal energy as a function of pressure and temperature
+   * @param pressure pressure
+   * @param temperature temperature
+   */
+  virtual void rho_e(Real pressure, Real temperature, Real & rho, Real & e) const = 0;
+
+  /**
+   * Internal energy as a function of pressure and density
+   * @param pressure pressure
+   * @param rho density
+   */
+  virtual Real e(Real pressure, Real rho) const = 0;
+
+  /**
+   * Saturation temperature
+   * @param pressure pressure
+   */
+  virtual Real saturation_T(Real pressure) const = 0;
+
+  /**
+   * Saturation pressure
+   * @param temperature temperature
+   */
+  virtual Real saturation_P(Real temperature) const = 0;
+
+  /**
+   * Surface Tension
+   * @param temperature temperature
+   */
+  virtual Real surfaceTension(Real temperature) const = 0;
+
+  /**
+   * Enthalpy
+   * @param pressure pressure
+   * @param temperature temperature
+   */
+  virtual Real h(Real pressure, Real temperature) const = 0;
+
+  /**
+   * Derivative of Enthalpy as a function of temperature and pressure
+   * @param pressure pressure
+   * @param temperature temperature
+   */
+  virtual void
+  h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const = 0;
+
+  /**
+   * Critical pressure
+   */
+  virtual Real p_critical() const = 0;
+
+  /**
+   * Latent enthalpy as a function of temperature
+   */
+  virtual void h_lat(Real temperature, Real & hf, Real & hg, Real & hfg) const = 0;
+
+  /**
+   * Specific volume as a function of pressure and enthalpy
+   * @param pressure pressure
+   * @param enthalpy enthalpy
+   */
+  virtual Real v_ph(Real pressure, Real enthalpy) const = 0;
+};
+
+#endif /* HEMFLUIDPROPERTIES_H */

--- a/modules/fluid_properties/include/userobjects/TwoPhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TwoPhaseFluidProperties.h
@@ -1,0 +1,73 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#ifndef TWOPHASEFLUIDPROPERTIES_H
+#define TWOPHASEFLUIDPROPERTIES_H
+
+#include "FluidProperties.h"
+
+class TwoPhaseFluidProperties;
+class SinglePhaseFluidProperties;
+
+/**
+ * Base class for fluid properties used with two phase flow
+ */
+class TwoPhaseFluidProperties : public FluidProperties
+{
+public:
+  TwoPhaseFluidProperties(const InputParameters & parameters);
+
+  const UserObjectName & getLiquidName() const;
+  const UserObjectName & getVaporName() const;
+
+  /**
+   * Returns the critical pressure
+   */
+  virtual Real p_critical() const = 0;
+
+  /**
+   * Computes the saturation temperature at a pressure
+   *
+   * @param[in] p  pressure
+   */
+  virtual Real T_sat(Real p) const = 0;
+
+  /**
+   * Computes the saturation pressure at a temperature
+   *
+   * @param[in] T  temperature
+   */
+  virtual Real p_sat(Real T) const = 0;
+
+  /**
+   * Computes dT/dp along the saturation line
+   *
+   * @param[in] p  pressure
+   */
+  virtual Real dT_sat_dp(Real p) const = 0;
+
+  /**
+   * Computes latent heat of vaporization
+   *
+   * @param p  pressure
+   * @param T  temperature
+   */
+  virtual Real h_lat(Real p, Real T) const;
+
+protected:
+  /// The name of the user object that provides liquid phase fluid properties
+  UserObjectName _liquid_name;
+  /// The name of the user object that provides vapor phase fluid properties
+  UserObjectName _vapor_name;
+
+  /// The user object that provides liquid phase fluid properties
+  const SinglePhaseFluidProperties * _fp_liquid;
+  /// The user object that provides vapor phase fluid properties
+  const SinglePhaseFluidProperties * _fp_vapor;
+};
+
+#endif /* TWOPHASEFLUIDPROPERTIES_H */

--- a/modules/fluid_properties/src/userobjects/HEMFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/HEMFluidProperties.C
@@ -1,0 +1,22 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "HEMFluidProperties.h"
+#include "FluidProperties.h"
+
+template <>
+InputParameters
+validParams<HEMFluidProperties>()
+{
+  InputParameters params = validParams<FluidProperties>();
+  return params;
+}
+
+HEMFluidProperties::HEMFluidProperties(const InputParameters & parameters)
+  : FluidProperties(parameters)
+{
+}

--- a/modules/fluid_properties/src/userobjects/TwoPhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TwoPhaseFluidProperties.C
@@ -1,0 +1,58 @@
+/****************************************************************/
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*          All contents are licensed under LGPL V2.1           */
+/*             See LICENSE for full restrictions                */
+/****************************************************************/
+
+#include "TwoPhaseFluidProperties.h"
+#include "SinglePhaseFluidProperties.h"
+
+template <>
+InputParameters
+validParams<TwoPhaseFluidProperties>()
+{
+  InputParameters params = validParams<FluidProperties>();
+  return params;
+}
+
+TwoPhaseFluidProperties::TwoPhaseFluidProperties(const InputParameters & parameters)
+  : FluidProperties(parameters)
+{
+  _liquid_name = name() + ":liquid";
+  _vapor_name = name() + ":vapor";
+
+  // check that the user has not already created these single-phase properties
+  if (_fe_problem.hasUserObject(_liquid_name))
+    mooseError("The two-phase fluid properties object '" + name() + "' is ",
+               "trying to create a single-phase fluid properties object with ",
+               "name '",
+               _liquid_name,
+               "', but a single-phase fluid properties ",
+               "object with this name already exists.");
+  if (_fe_problem.hasUserObject(_vapor_name))
+    mooseError("The two-phase fluid properties object '" + name() + "' is ",
+               "trying to create a single-phase fluid properties object with ",
+               "name '",
+               _vapor_name,
+               "', but a single-phase fluid properties ",
+               "object with this name already exists.");
+}
+
+const UserObjectName &
+TwoPhaseFluidProperties::getLiquidName() const
+{
+  return _liquid_name;
+}
+
+const UserObjectName &
+TwoPhaseFluidProperties::getVaporName() const
+{
+  return _vapor_name;
+}
+
+Real
+TwoPhaseFluidProperties::h_lat(Real p, Real T) const
+{
+  return _fp_vapor->h(p, T) - _fp_liquid->h(p, T);
+}


### PR DESCRIPTION
Adding 2 base classes for different sets of equations:

  1. for HEM
  2. for seven equation model

These base classses define the API to obtain fluid properties when users
are solving 2-phase flow.  Both are in terms of internal energy and
specific volume.

Closes #10261

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
