### PR TITLE
benchmarking: fix script MOOSE_DIR guessing

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -10,13 +10,8 @@ import collections
 import matplotlib.pyplot as plt
 import jinja2
 
-defaultdir = os.path.abspath(os.path.dirname(sys.argv[0]))
-MOOSE_DIR = os.path.abspath(os.path.join(defaultdir, '..', 'python'))
-if "MOOSE_DIR" in os.environ:
-  MOOSE_DIR = os.environ['MOOSE_DIR']
-else:
-  os.environ['MOOSE_DIR'] = MOOSE_DIR
-
+MOOSE_DIR = os.environ.get('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+os.environ['MOOSE_DIR'] = MOOSE_DIR
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
 


### PR DESCRIPTION
Use the benchmark.py's path directly rather than assuming we can get it
from sys.argv - which breaks when doing e.g. "python benchmark.py"
instead of "./benchmark.py".

ref #9834

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
