### PR TITLE
Smeared cracking refinements

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeSmearedCrackingStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeSmearedCrackingStress.C
@@ -51,6 +51,7 @@ validParams<ComputeSmearedCrackingStress>()
       0.0,
       "shear_retention_factor>=0 & shear_retention_factor<=1.0",
       "Fraction of original shear stiffness to be retained after cracking");
+  params.set<std::vector<MaterialName>>("inelastic_models") = {};
 
   return params;
 }

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking.i
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking.i
@@ -62,7 +62,6 @@
   [./elastic_stress]
     type = ComputeSmearedCrackingStress
     cracking_stress = 1.68e6
-    inelastic_models = ''
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_exponential.i
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_exponential.i
@@ -90,7 +90,6 @@
     type = ComputeSmearedCrackingStress
     cracking_release = exponential
     cracking_stress = 119.3e6
-    inelastic_models = ''
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_function.cmp
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_function.cmp
@@ -8,7 +8,7 @@ GLOBAL VARIABLES relative 1.e-6 floor 1.e-10
 	elem_stress_xx      # min:               0 @ t1	max:       999750.08 @ t21
 
 NODAL VARIABLES relative 1.e-6 floor 1.e-10
-	disp_x  # min:               0 @ t1,n1	max:           0.001 @ t41,n7
+	disp_x  floor 1.e-9 # min:               0 @ t1,n1	max:           0.001 @ t41,n7
 	disp_y  # min:               0 @ t1,n1	max:   7.4709978e-20 @ t23,n8
 
 ELEMENT VARIABLES relative 1.e-6 floor 1.e-10

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_function.i
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_function.i
@@ -91,7 +91,6 @@
     type = ComputeSmearedCrackingStress
     cracking_stress = cracking_stress_fn
     cracking_residual_stress = 0.0
-    inelastic_models = ''
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_plane_stress.i
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_plane_stress.i
@@ -102,7 +102,6 @@
     cracking_residual_stress = 0.1
     cracking_beta = 0.1
     shear_retention_factor = 0.1
-    inelastic_models = ''
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rotation.i
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rotation.i
@@ -135,7 +135,6 @@
     cracking_release = exponential
     shear_retention_factor = 0.1
     cracking_stress = 3.e9
-    inelastic_models = ''
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rz.i
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rz.i
@@ -58,7 +58,6 @@
   [./elastic_stress]
     type = ComputeSmearedCrackingStress
     cracking_stress = 1.68e6
-    inelastic_models = ''
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rz_exponential.i
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rz_exponential.i
@@ -68,7 +68,6 @@
     type = ComputeSmearedCrackingStress
     cracking_release = exponential
     cracking_stress = 119.3e6
-    inelastic_models = ''
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_xyz.i
+++ b/modules/tensor_mechanics/test/tests/smeared_cracking/cracking_xyz.i
@@ -85,7 +85,6 @@
     type = ComputeSmearedCrackingStress
     cracking_release = exponential
     cracking_stress = 119.3e6
-    inelastic_models = ''
   [../]
 []
 


### PR DESCRIPTION
Set the 'inelastic_models' parameter to empty by default in the smeared
cracking model so you no longer need to supply this if there are none.  closes #9227

Fix the diffing cracking_function test on falcon ref #7387