### PR TITLE
benchmarks: allow regular runtests in devel mode

### DIFF
--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -140,7 +140,7 @@ class SpeedTest(Tester):
     # override
     def run(self, timer, options):
         p = self.params
-        if options.method not in ['opt', 'oprof', 'dbg']:
+        if not self.check_only and options.method not in ['opt', 'oprof', 'dbg']:
             raise ValueError('cannot run benchmark with "' + options.method + '" build')
         t = Test(p['executable'], p['input'], args=p['cli_args'], rootdir=p['test_dir'], perflog=p['perflog'])
 


### PR DESCRIPTION
The safety check preventing benchmarks from running in non optimized or
dbg modes was triggering for a check-inputs-only run of regular
run_tests.  This fixes that behavior.

ref #9834

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
