### PR TITLE
benchmarking: move scipy import

### DIFF
--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -2,7 +2,6 @@
 
 import subprocess
 import time
-from scipy.stats import mannwhitneyu
 import numpy
 import sqlite3
 import os
@@ -121,7 +120,7 @@ class SpeedTest(Tester):
 
         self.params = params
         self.benchmark = None
-        self.db = 'speedtests.sqlite'
+        self.db = os.environ.get('MOOSE_SPEED_DB', 'speedtests.sqlite')
 
     # override
     def getMaxTime(self):
@@ -193,6 +192,8 @@ class BenchComp:
 
         self.iqr_old = _iqr(self.old)
         self.iqr_new = _iqr(self.new)
+
+        from scipy.stats import mannwhitneyu
         try:
             result = mannwhitneyu(self.iqr_old, self.iqr_new, alternative='two-sided')
             self.pvalue = result.pvalue


### PR DESCRIPTION
We don't need it unless running benchmark analysis code - not
benchmark/test running code. Move the import into the benchmark
comparison class where it is used.

ref #9834

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
