### PR TITLE
benchmarking: relocate numpy import

### DIFF
--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -2,7 +2,6 @@
 
 import subprocess
 import time
-import numpy
 import sqlite3
 import os
 import gc
@@ -233,6 +232,7 @@ class BenchComp:
 
 def _iqr(a, frac=1000):
     """return elements of a within frac*iqr of the the interquartile range (inclusive)"""
+    import numpy
     qup, qlow = numpy.percentile(a, [75 ,25])
 
     iqr = qup - qlow


### PR DESCRIPTION
Move numpy import down to be local where it is used (for analysis only)
so tests/benchmarks can be run without it installed on a system.

ref #9834

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
