### PR TITLE
Fix 'oversized' caveat

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -362,11 +362,8 @@ class TestHarness:
 
     # Format the status message to make any caveats easy to read when they are printed
     def formatCaveats(self, tester):
-        caveats = []
         result = ''
-
-        if tester.specs.isValid('caveats'):
-            caveats = tester.specs['caveats']
+        caveats = list(tester.getCaveats())
 
         # PASS and DRY_RUN fall into this catagory
         if tester.didPass():

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -44,7 +44,7 @@ class Job(object):
         self.__end_time = None
         self.__std_out = ''
         self.report_timer = None
-        self.__processors = None
+        self.__slots = None
         self.__unique_identifier = os.path.join(tester.getTestDir(), tester.getTestName())
 
     def getTester(self):
@@ -67,16 +67,16 @@ class Job(object):
         """ A unique identifier for this job object """
         return self.__unique_identifier
 
-    def getProcessors(self):
-        """ Return the number of processors this job consumes """
-        if self.__processors == None:
-            return self.setProcessors(self.__tester.getProcs(self.options))
-        return self.__processors
+    def getSlots(self):
+        """ Return the number of slots this job consumes """
+        if self.__slots == None:
+            return self.setSlots(self.__tester.getSlots(self.options))
+        return self.__slots
 
-    def setProcessors(self, procs):
+    def setSlots(self, slots):
         """ Set the number of processors this job consumes """
-        self.__processors = int(procs)
-        return self.__processors
+        self.__slots = int(slots)
+        return self.__slots
 
     def run(self):
         """

--- a/python/TestHarness/schedulers/QueueManager.py
+++ b/python/TestHarness/schedulers/QueueManager.py
@@ -279,10 +279,10 @@ class QueueManager(Scheduler):
             template[param] = self.params[param]
 
         # Set CPU request count
-        # NOTE: we are calling tester.getProcs specifically, instead of through
+        # NOTE: we are calling tester.getSlots specifically, instead of through
         # the job class here, because we have altered each job to only require 1
-        # process.
-        template['mpi_procs'] = tester.getProcs(self.options)
+        # slot.
+        template['mpi_procs'] = tester.getSlots(self.options)
 
         # Set a path friendly job name
         template['job_name'] = ''.join(txt for txt in tester.specs['test_name'] if txt.isalnum() or txt in ['_', '-'])
@@ -324,7 +324,7 @@ class QueueManager(Scheduler):
         QueueManager only executes third party queueing commands. So
         modify every job to only require 1 process.
         """
-        job.setProcessors(1)
+        job.setSlots(1)
         return Scheduler.reserveSlots(self, job)
 
     def testOutput(self, job):

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -410,22 +410,21 @@ class Scheduler(MooseObject):
 
         with self.slot_lock:
             can_run = False
-            if self.slots_in_use + job_container.getProcessors() <= self.available_slots:
+            if self.slots_in_use + job_container.getSlots() <= self.available_slots:
                 can_run = True
 
             # Check for insufficient slots -soft limit
-            # TODO: Create a unit test for this case
-            elif job_container.getProcessors() > self.available_slots and self.soft_limit:
-                tester.specs.addParam('caveats', ['OVERSIZED'], "")
+            elif job_container.getSlots() > self.available_slots and self.soft_limit:
+                tester.addCaveats('OVERSIZED')
                 can_run = True
 
             # Check for insufficient slots -hard limit (skip this job)
             # TODO: Create a unit test for this case
-            elif job_container.getProcessors() > self.available_slots and not self.soft_limit:
+            elif job_container.getSlots() > self.available_slots and not self.soft_limit:
                 tester.setStatus('insufficient slots', tester.bucket_skip)
 
             if can_run:
-                self.slots_in_use += job_container.getProcessors()
+                self.slots_in_use += job_container.getSlots()
 
         return can_run
 
@@ -484,7 +483,7 @@ class Scheduler(MooseObject):
                     self.harness.handleTestStatus(job_container)
 
                     # ...And then set the finished caveat now that the running status has printed
-                    tester.specs.addParam('caveats', ['FINISHED'], "")
+                    tester.addCaveats('FINISHED')
 
                     # Add this job to the reported container so it does not happen again
                     self.jobs_reported.add(job_container)
@@ -563,7 +562,7 @@ class Scheduler(MooseObject):
 
                 # Recover worker count before attempting to queue more jobs
                 with self.slot_lock:
-                    self.slots_in_use = max(0, self.slots_in_use - job_container.getProcessors())
+                    self.slots_in_use = max(0, self.slots_in_use - job_container.getSlots())
 
                 # Queue this new batch of runnable jobs
                 self.queueJobs(run_jobs=next_job_group)

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -167,8 +167,7 @@ class RunApp(Tester):
         elif ncpus < default_ncpus:
             caveats.append('max_cpus=' + str(ncpus))
 
-        if len(caveats) > 0:
-            self.specs['caveats'] = caveats
+        self.addCaveats(caveats)
 
         if self.force_mpi or options.parallel or ncpus > 1 or nthreads > 1:
             command = self.mpi_command + ' -n ' + str(ncpus) + ' ' + specs['executable'] + ' --n-threads=' + str(nthreads) + ' ' + specs['input_switch'] + ' ' + specs['input'] + ' ' +  ' '.join(cli_args)

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -167,7 +167,7 @@ class RunApp(Tester):
         elif ncpus < default_ncpus:
             caveats.append('max_cpus=' + str(ncpus))
 
-        self.addCaveats(caveats)
+        self.addCaveats(*caveats)
 
         if self.force_mpi or options.parallel or ncpus > 1 or nthreads > 1:
             command = self.mpi_command + ' -n ' + str(ncpus) + ' ' + specs['executable'] + ' --n-threads=' + str(nthreads) + ' ' + specs['input_switch'] + ' ' + specs['input'] + ' ' +  ' '.join(cli_args)

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -83,6 +83,7 @@ class Tester(MooseObject):
         self.exit_code = 0
         self.process = None
         self.tags = params['tags']
+        self.__caveats = set([])
 
         # Bool if test can run
         self._runnable = None
@@ -312,6 +313,10 @@ class Tester(MooseObject):
         """ return number of processors to use for this tester """
         return 1
 
+    def getSlots(self, options):
+        """ return number of slots to use for this tester """
+        return int(self.getThreads(options)) * int(self.getProcs(options))
+
     def getCommand(self, options):
         """ return the executable command that will be executed by the tester """
         return ''
@@ -396,6 +401,18 @@ class Tester(MooseObject):
     def getRedirectedOutputFiles(self, options):
         """ return a list of redirected output """
         return [os.path.join(self.getTestDir(), self.name() + '.processor.{}'.format(p)) for p in xrange(self.getProcs(options))]
+
+    def addCaveats(self, caveats):
+        """ Add caveat(s) which will be displayed with the final test status """
+        if type(caveats) == type([]):
+            self.__caveats.update(caveats)
+        else:
+            self.__caveats.add(caveats)
+        return self.getCaveats()
+
+    def getCaveats(self):
+        """ Return caveats accumalted by this tester """
+        return self.__caveats
 
     def checkRunnableBase(self, options):
         """

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -315,7 +315,7 @@ class Tester(MooseObject):
 
     def getSlots(self, options):
         """ return number of slots to use for this tester """
-        return int(self.getThreads(options)) * int(self.getProcs(options))
+        return self.getThreads(options) * self.getProcs(options)
 
     def getCommand(self, options):
         """ return the executable command that will be executed by the tester """
@@ -402,12 +402,9 @@ class Tester(MooseObject):
         """ return a list of redirected output """
         return [os.path.join(self.getTestDir(), self.name() + '.processor.{}'.format(p)) for p in xrange(self.getProcs(options))]
 
-    def addCaveats(self, caveats):
+    def addCaveats(self, *kwargs):
         """ Add caveat(s) which will be displayed with the final test status """
-        if type(caveats) == type([]):
-            self.__caveats.update(caveats)
-        else:
-            self.__caveats.add(caveats)
+        self.__caveats.update(kwargs)
         return self.getCaveats()
 
     def getCaveats(self):

--- a/python/TestHarness/tests/test_Allocations.py
+++ b/python/TestHarness/tests/test_Allocations.py
@@ -1,0 +1,95 @@
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testSkippedAllocations(self):
+        """
+        Scenarios which trigger skipped tests due to insufficient
+        resource allocation.
+        """
+        # Subject a normally passing test to impossible cpu allocations
+        output = self.runTests('-i', 'always_ok', '-p', '2', '-j', '1')
+        self.assertIn('skipped (insufficient slots)', output)
+
+        # Subject a normally passing test to impossible thread allocations
+        output = self.runTests('-i', 'always_ok', '--n-threads', '2', '-j', '1')
+        self.assertIn('skipped (insufficient slots)', output)
+
+        # A combination of threads*cpus with too low a hard limit (3*3= -j9)
+        output = self.runTests('-i', 'allocation_test', '--n-threads', '3', '-p', '3', '-j', '8')
+        self.assertIn('skipped (insufficient slots)', output)
+
+    def testOversizedCaveat(self):
+        """
+        Scenario which trigger only the 'oversized' caveat.
+        """
+        # A test which has no min/max cpu parameters should print oversized
+        # when subjected to -p 2
+        output = self.runTests('-i', 'always_ok', '-p', '2')
+        self.assertNotIn('CPUS', output)
+        self.assertIn('OVERSIZED', output)
+
+        # A test which has no min/max thread parameters should print oversized
+        # when subjected to --n-threads 2
+        output = self.runTests('-i', 'always_ok', '--n-threads', '2')
+        self.assertNotIn('THREADS', output)
+        self.assertIn('OVERSIZED', output)
+
+    def testCpuCaveats(self):
+        """
+        Scenarios which trigger min/max CPU caveats.
+        Note: --n-threads is present to suppress the threading
+              caveat for more accurate caveat detection.
+        """
+        # Test MIN CPUs / Oversized caveat using soft limit (no -j) on a test
+        # having a minimum cpu parameter of 2.
+        output = self.runTests('-i', 'allocation_test', '--n-threads', '2')
+        self.assertNotIn('MIN_THREADS', output)
+        self.assertIn('MIN_CPUS=2', output)
+        self.assertIn('OVERSIZED', output)
+
+        # Test MAX CPUs / Oversized caveat on a test having a maximum cpu
+        # parameter of 3 (and we subjected it to 4).
+        output = self.runTests('-i', 'allocation_test', '-p', '4', '--n-threads', '2')
+        self.assertNotIn('MIN_THREADS', output)
+        self.assertIn('MAX_CPUS=3', output)
+        self.assertIn('OVERSIZED', output)
+
+    def testThreadCaveats(self):
+        """
+        Scenarios which trigger min/max threading caveats.
+        Note: -j/p is present to suppress the min/max cpu oversize
+              caveat for more accurate treading caveat detection.
+        """
+        # MIN Threads caveat
+        # Note: 1*2 should be -j 2 but the test minimum is 2 threads, so we need
+        # to use -j 4 to suppress any cpu caveats. Oversized will not trigger as
+        # -j4 satisfies this test's requirements.
+        output = self.runTests('-i', 'allocation_test', '-j', '4', '-p', '2', '--n-threads', '1')
+        self.assertNotIn('CPUS', output)
+        self.assertNotIn('OVERSIZED', output)
+        self.assertIn('MIN_THREADS', output)
+
+        # MAX Threads caveat
+        # Note: 2*4 should be -j 8 but the test maximum is 3 threads, so we
+        # are specifically testing that setting a lower j does _not_ trigger an
+        # insufficient skipped test scenario. Oversized will not trigger as
+        # -j6 satisfies this test's requirements.
+        output = self.runTests('-i', 'allocation_test', '-j', '6', '-p', '2', '--n-threads', '4')
+        self.assertNotIn('CPUS', output)
+        self.assertNotIn('OVERSIZED', output)
+        self.assertIn('MAX_THREADS', output)
+
+    def testPerfectAllocation(self):
+        """
+        Scenario which trigger no caveats in a test that otherwise
+        would have caveats due to incorrect allocations.
+        """
+        # Passing test triggering no caveats, as supplied allocations satisfies
+        # the test's requirements
+        output = self.runTests('-i', 'allocation_test', '-j', '4', '-p', '2', '--n-threads', '2')
+        self.assertNotIn('MIN_THREADS', output)
+        self.assertNotIn('MAX_THREADS', output)
+        self.assertNotIn('MIN_CPUS', output)
+        self.assertNotIn('MAX_CPUS', output)
+        self.assertNotIn('OVERSIZED', output)
+        self.assertRegexpMatches(output, 'tests/test_harness.allocation_test.*OK')

--- a/python/TestHarness/tests/test_Allocations.py
+++ b/python/TestHarness/tests/test_Allocations.py
@@ -20,7 +20,7 @@ class TestHarnessTester(TestHarnessTestCase):
 
     def testOversizedCaveat(self):
         """
-        Scenario which trigger only the 'oversized' caveat.
+        Scenarios which trigger only the 'oversized' caveat.
         """
         # A test which has no min/max cpu parameters should print oversized
         # when subjected to -p 2
@@ -36,7 +36,7 @@ class TestHarnessTester(TestHarnessTestCase):
 
     def testCpuCaveats(self):
         """
-        Scenarios which trigger min/max CPU caveats.
+        Scenarios which trigger the min/max CPU caveat.
         Note: --n-threads is present to suppress the threading
               caveat for more accurate caveat detection.
         """
@@ -56,9 +56,9 @@ class TestHarnessTester(TestHarnessTestCase):
 
     def testThreadCaveats(self):
         """
-        Scenarios which trigger min/max threading caveats.
+        Scenarios which trigger the min/max threading caveat.
         Note: -j/p is present to suppress the min/max cpu oversize
-              caveat for more accurate treading caveat detection.
+              caveat for more accurate caveat detection.
         """
         # MIN Threads caveat
         # Note: 1*2 should be -j 2 but the test minimum is 2 threads, so we need
@@ -67,7 +67,7 @@ class TestHarnessTester(TestHarnessTestCase):
         output = self.runTests('-i', 'allocation_test', '-j', '4', '-p', '2', '--n-threads', '1')
         self.assertNotIn('CPUS', output)
         self.assertNotIn('OVERSIZED', output)
-        self.assertIn('MIN_THREADS', output)
+        self.assertIn('MIN_THREADS=2', output)
 
         # MAX Threads caveat
         # Note: 2*4 should be -j 8 but the test maximum is 3 threads, so we
@@ -77,12 +77,11 @@ class TestHarnessTester(TestHarnessTestCase):
         output = self.runTests('-i', 'allocation_test', '-j', '6', '-p', '2', '--n-threads', '4')
         self.assertNotIn('CPUS', output)
         self.assertNotIn('OVERSIZED', output)
-        self.assertIn('MAX_THREADS', output)
+        self.assertIn('MAX_THREADS=3', output)
 
     def testPerfectAllocation(self):
         """
-        Scenario which trigger no caveats in a test that otherwise
-        would have caveats due to incorrect allocations.
+        Scenario which trigger no caveats.
         """
         # Passing test triggering no caveats, as supplied allocations satisfies
         # the test's requirements

--- a/python/TestHarness/tests/test_ExtraInfo.py
+++ b/python/TestHarness/tests/test_ExtraInfo.py
@@ -1,0 +1,41 @@
+from TestHarnessTestCase import TestHarnessTestCase
+import re
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testExtraInfo(self):
+        """
+        Test for the presence of -e (Extra Info) caveats when
+        requested.
+
+        Note: This test is really not demonstrating any of the
+        special 'checks' contained within it. We are simply
+        testing the TestHarness's ability to print that caveat.
+
+        Because the TestHarness joins all caveats, this is going
+        to run as one test, in which we will regexp through a huge
+        single caveat line.
+        """
+
+        # All the caveats we will verify that should exist in the
+        # output
+        caveats = ['ASIO', 'DTK', 'UNIQUE_IDS', 'CXX11', 'SUPERLU',
+                   'DOF_ID_BYTES', 'TECPLOT', 'PETSC_VERSION_RELEASE',
+                   'SLEPC_VERSION', 'MESH_MODE', 'METHOD', 'BOOST',
+                   'PETSC_DEBUG', 'LIBRARY_MODE', 'PETSC_VERSION',
+                   'CURL', 'TBB', 'SLEPC', 'VTK', 'UNIQUE_ID',
+                   'COMPILER']
+
+        # Verify all special TestHarness 'checks' are printed. We
+        # will use the --ignore feature to force the test to run
+        # regardless if that check(s) would otherwise cause this
+        # test to be skipped.
+        output = self.runTests('-c', '-i', 'extra_info', '--ignore', '-e')
+
+        # Parse the output, and find the caveat string
+        raw_caveat_string = re.findall(r'\[(.*)\]', output)
+        output_caveats = raw_caveat_string[0].split(', ')
+
+        # Do the comparison and assert if different. Using a
+        # differential set grants us the benifit of forcing us to
+        # keep this unittest up to date.
+        self.assertEqual(set(caveats), set(output_caveats))

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -75,4 +75,8 @@
     type = PythonUnitTest
     input = test_DistributedMesh.py
   [../]
+  [./allocations]
+    type = PythonUnitTest
+    input = test_Allocations.py
+  [../]
 []

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -79,4 +79,8 @@
     type = PythonUnitTest
     input = test_Allocations.py
   [../]
+  [./exra_info]
+    type = PythonUnitTest
+    input = test_ExtraInfo.py
+  [../]
 []

--- a/test/tests/test_harness/allocation_test
+++ b/test/tests/test_harness/allocation_test
@@ -1,0 +1,10 @@
+[Tests]
+  [./allocation_test]
+    type = RunApp
+    input = good.i
+    max_parallel = 3
+    min_parallel = 2
+    max_threads = 3
+    min_threads = 2
+  [../]
+[]

--- a/test/tests/test_harness/always_ok
+++ b/test/tests/test_harness/always_ok
@@ -1,0 +1,6 @@
+[Tests]
+  [./always_ok]
+    type = RunApp
+    input = good.i
+  [../]
+[]

--- a/test/tests/test_harness/extra_info
+++ b/test/tests/test_harness/extra_info
@@ -1,0 +1,27 @@
+[Tests]
+  [./extra_info_caveats]
+    type = RunApp
+    input = good.i
+    compiler = 'GCC'
+    method = 'OPT OPROF'
+    petsc_version = '3.7.5'
+    petsc_version_release = true
+    petsc_debug = true
+    slepc_version = '>=3.7.4'
+    library_mode = true
+    mesh_mode = 'distributed'
+    dtk = true
+    unique_ids = true
+    vtk = true
+    tecplot = true
+    dof_id_bytes = 4
+    curl = true
+    tbb = true
+    superlu = true
+    slepc = true
+    unique_id = true
+    cxx11 = true
+    asio = true
+    boost = true
+  [../]
+[]


### PR DESCRIPTION
getCommand was clobbering any previously set
caveats.

Scheduler was only taking into account CPUs and
not a combination of CPUs and Threads when
performing slot availability.

Add unittests to verify resource allocation caveats
are generated when they should be.

Closes #10272