### PR TITLE
Make sure that boundary restricted objects don't report that they cover blocks too

### DIFF
--- a/framework/include/userobject/NodalNormalsPreprocessor.h
+++ b/framework/include/userobject/NodalNormalsPreprocessor.h
@@ -32,7 +32,7 @@ InputParameters validParams<NodalNormalsPreprocessor>();
  * An ElementUserObject that prepares MOOSE for computing nodal
  * normals.
  */
-class NodalNormalsPreprocessor : public ElementUserObject, public BoundaryRestrictable
+class NodalNormalsPreprocessor : public ElementUserObject
 {
 public:
   NodalNormalsPreprocessor(const InputParameters & parameters);
@@ -47,21 +47,19 @@ public:
    *
    * This object inherits from BoundaryRestrictable to utilize the "boundary" parameter and other
    * methods that come with this interface class. However, this object is an ElementUserObject and
-   * must
-   * execute on each element (see ComputeUserObjectsThread::onElement).
+   * must execute on each element (see ComputeUserObjectsThread::onElement).
    *
    * The MooseObjectWarehouseBase object that stores the objects uses this method to determine
-   * whether
-   * the object should be stored as boundary or block. Since this object needs to execute on
-   * elements, it must
-   * be stored as a block object, overloading this method to always return false has such effect.
+   * whether the object should be stored as boundary or block. Since this object needs to execute on
+   * elements, it must be stored as a block object, overloading this method to always return false
+   * has such effect.
    */
-  virtual bool boundaryRestricted() const override { return false; }
 
 protected:
   AuxiliarySystem & _aux;
   FEType _fe_type;
   bool _has_corners;
+  std::vector<BoundaryID> _boundaries;
   BoundaryID _corner_boundary_id;
 
   const VariablePhiGradient & _grad_phi;

--- a/framework/src/actions/AddNodalNormalsAction.C
+++ b/framework/src/actions/AddNodalNormalsAction.C
@@ -75,7 +75,7 @@ AddNodalNormalsAction::act()
     pars.set<Order>("fe_order") = order;
     pars.set<FEFamily>("fe_family") = family;
     pars.set<MultiMooseEnum>("execute_on") = execute_options;
-    pars.set<std::vector<BoundaryName>>("boundary") = _boundary;
+    pars.set<std::vector<BoundaryName>>("surface_boundary") = _boundary;
 
     if (_has_corners)
       pars.set<BoundaryName>("corner_boundary") = _corner_boundary;

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -122,7 +122,7 @@ BlockRestrictable::initializeBlockRestrictable(const MooseObject * moose_object)
                  "' to a block, but the object is already restricted by boundary");
 
   // If no blocks were defined above, specify that it is valid on all blocks
-  if (_blk_ids.empty())
+  if (_blk_ids.empty() && !moose_object->isParamValid("boundary"))
   {
     _blk_ids.insert(Moose::ANY_BLOCK_ID);
     _blocks = {"ANY_BLOCK_ID"};

--- a/framework/src/userobject/NodalNormalsEvaluator.C
+++ b/framework/src/userobject/NodalNormalsEvaluator.C
@@ -26,6 +26,7 @@ validParams<NodalNormalsEvaluator>()
 {
   InputParameters params = validParams<NodalUserObject>();
   params.set<bool>("_dual_restrictable") = true;
+  params.set<std::vector<SubdomainName>>("block") = {"ANY_BLOCK_ID"};
   return params;
 }
 

--- a/framework/src/userobject/NodalNormalsPreprocessor.C
+++ b/framework/src/userobject/NodalNormalsPreprocessor.C
@@ -30,7 +30,8 @@ InputParameters
 validParams<NodalNormalsPreprocessor>()
 {
   InputParameters params = validParams<ElementUserObject>();
-  params += validParams<BoundaryRestrictable>();
+  params.addRequiredParam<std::vector<BoundaryName>>(
+      "surface_boundary", "The list of boundary IDs where nodal normals are computed");
   params.addParam<BoundaryName>("corner_boundary",
                                 "Node set ID which contains the nodes that are in 'corners'.");
   params.addPrivateParam<FEFamily>("fe_family", LAGRANGE);
@@ -39,12 +40,33 @@ validParams<NodalNormalsPreprocessor>()
   return params;
 }
 
+/**
+ * Local function to check to see if any intersection occurs between two vectors. Neither can be
+ * assumed to be sorted but both are generally very short (just 1 or 2 entries) so doing an explicit
+ * double loop is probably the easiest.
+ */
+bool
+hasBoundary(const std::vector<BoundaryID> & boundary_ids1,
+            const std::vector<BoundaryID> & boundary_ids2)
+{
+  for (auto id1 : boundary_ids1)
+  {
+    if (id1 == Moose::ANY_BOUNDARY_ID)
+      return true;
+
+    for (auto id2 : boundary_ids2)
+      if (id1 == id2 || id2 == Moose::ANY_BOUNDARY_ID)
+        return true;
+  }
+  return false;
+}
+
 NodalNormalsPreprocessor::NodalNormalsPreprocessor(const InputParameters & parameters)
   : ElementUserObject(parameters),
-    BoundaryRestrictable(this, true), // true for applying to nodesets
     _aux(_fe_problem.getAuxiliarySystem()),
     _fe_type(getParam<Order>("fe_order"), getParam<FEFamily>("fe_family")),
     _has_corners(isParamValid("corner_boundary")),
+    _boundaries(_mesh.getBoundaryIDs(getParam<std::vector<BoundaryName>>("surface_boundary"))),
     _corner_boundary_id(_has_corners
                             ? _mesh.getBoundaryID(getParam<BoundaryName>("corner_boundary"))
                             : static_cast<BoundaryID>(-1)),
@@ -89,7 +111,7 @@ NodalNormalsPreprocessor::execute()
       // Perform the calculation, the node must be:
       //    (1) On a boundary to which the object is restricted
       //    (2) Not on a corner of the boundary
-      if (hasBoundary(node_boundary_ids, ANY) &&
+      if (hasBoundary(node_boundary_ids, _boundaries) &&
           (!_has_corners || !boundary_info.has_boundary_id(node, _corner_boundary_id)))
       {
         // Perform the caluation of the normal

--- a/test/tests/materials/material/material_block_bound_check.i
+++ b/test/tests/materials/material/material_block_bound_check.i
@@ -1,0 +1,67 @@
+###########################################################
+# This is a simple test of the Material System. A
+# user-defined Material (MTMaterial) is providing a
+# Real property named "matp" that varies spatially
+# throughout the domain. This property is used as a
+# coefficient by MatDiffusion.
+#
+# This test verifies that when a material is restricted
+# to a boundary, that MOOSE correctly reports that the
+# volumetric material is missing.
+###########################################################
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  nx = 4
+  ny = 4
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = MatDiffusion
+    variable = u
+    prop_name = matp
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 'left'
+    value = 1
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 'right'
+    value = 2
+  [../]
+[]
+
+# Materials System
+[Materials]
+  [./mat]
+    type = MTMaterial
+    boundary = 'bottom'
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+# No output, this test is designed to produce an error

--- a/test/tests/materials/material/tests
+++ b/test/tests/materials/material/tests
@@ -39,6 +39,12 @@
     expect_err = 'Cyclic dependency detected in object ordering:\nmat2 -> mat1'
   [../]
 
+  [./mat_block_boundary_check]
+    type = 'RunException'
+    input = 'material_block_bound_check.i'
+    expect_err = 'Material property \S+, requested by \S+ is not defined on block \S'
+  [../]
+
   [./three_coupled_mat_test]
     type = 'Exodiff'
     input = 'three_coupled_mat_test.i'


### PR DESCRIPTION
Fixes a bug where errors weren't reported when an object was restricted to a boundary. Without this patch, said object also reports that it's active on ANY_BLOCK. This is not a fix, but more of a workaround. We need a redesign of Block/Boundary restrictable.

references #10285.