### PR TITLE
Fix building sqa docs

### DIFF
--- a/scripts/traceability_matrix.py
+++ b/scripts/traceability_matrix.py
@@ -103,7 +103,7 @@ def extractTestedRequirements(args, data):
     from TestHarness import TestHarness
 
     # Build the TestHarness object here
-    harness = TestHarness([], test_app_name, args.moose_dir)
+    harness = TestHarness([], args.moose_dir, test_app_name)
 
     # Tell it to parse the test files only, not run them
     harness.findAndRunTests(find_only=True)


### PR DESCRIPTION
#10243 changed the order of arguments to the TestHarness constructor which
broke the traceability_matrix.py script.


<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
