### PR TITLE
Do not report CVSDIFF when files are missing

### DIFF
--- a/python/TestHarness/testers/CSVDiff.py
+++ b/python/TestHarness/testers/CSVDiff.py
@@ -33,7 +33,12 @@ class CSVDiff(FileTester):
             msg = differ.diff()
             output += 'Running CSVDiffer.py\n' + msg
             if msg != '':
-                self.setStatus('CSVDIFF', self.bucket_diff)
+                if msg.find("Gold file does not exist!") != -1:
+                    self.setStatus('MISSING GOLD FILE', self.bucket_fail)
+                elif msg.find("File does not exist!") != -1:
+                    self.setStatus('FILE DOES NOT EXIST', self.bucket_fail)
+                else:
+                    self.setStatus('CSVDIFF', self.bucket_diff)
                 return output
 
         self.setStatus(self.success_message, self.bucket_success)


### PR DESCRIPTION
When a gold file or a result file was missing, CSVDiff reported a diff
status. That is confusing, thus now we report the actual problem.

Refs #1877

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
