### PR TITLE
errors: helper for parameter-related errors

### DIFF
--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -111,6 +111,12 @@ namespace moose
 namespace internal
 {
 
+/// Builds and returns a string of the form:
+///
+///     [var1-elemtype],ORDER[var1-order] != [var2-elemtype],ORDER[var2-order]
+///
+/// This is a convenience function to be used when error messages (especially with paramError)
+/// need to report that variable types are incompatible (e.g. with residual save-in).
 std::string incompatVarMsg(MooseVariable & var1, MooseVariable & var2);
 
 std::string

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -104,10 +104,14 @@
 template <typename... Args>
 [[noreturn]] void mooseError(Args &&... args);
 
+class MooseVariable;
+
 namespace moose
 {
 namespace internal
 {
+
+std::string incompatVarMsg(MooseVariable & var1, MooseVariable & var2);
 
 std::string
 mooseMsgFmt(const std::string & msg, const std::string & title, const std::string & color);

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -18,7 +18,6 @@
 // MOOSE includes
 #include "InputParameters.h"
 #include "ConsoleStreamInterface.h"
-#include "Parser.h"
 
 #include "libmesh/parallel_object.h"
 
@@ -30,6 +29,14 @@ InputParameters validParams<MooseObject>();
 
 // needed to avoid #include cycle with MooseApp and MooseObject
 [[noreturn]] void callMooseErrorRaw(std::string & msg, MooseApp * app);
+
+/// returns a string representing a special parameter name that the parser injects into object
+/// parameters holding the file+linenum for the parameter.
+std::string paramLocName(std::string param);
+
+/// returns a string representing a special parameter name that the parser injects into object
+/// parameters holding the file+linenum for the parameter.
+std::string paramPathName(std::string param);
 
 /**
  * Every object that can be built by the factory should be derived from this class.
@@ -79,10 +86,12 @@ public:
 
   /**
    * Emits an error prefixed with the file and line number of the given param (from the input
-   * file) with the given args as the message.
+   * file) along with the full parameter path+name followed by the given args as the message.
+   * If this object's parameters were not created directly by the Parser, then this function falls
+   * back to the normal behavior of mooseError - only printing a message using the given args.
    */
   template <typename... Args>
-  [[noreturn]] void paramError(std::string param, Args... args)
+  [[noreturn]] void paramError(const std::string & param, Args... args)
   {
     auto prefix = param + ": ";
     if (_pars.have_parameter<std::string>(paramLocName(param)))

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -18,6 +18,7 @@
 // MOOSE includes
 #include "InputParameters.h"
 #include "ConsoleStreamInterface.h"
+#include "Parser.h"
 
 #include "libmesh/parallel_object.h"
 
@@ -75,6 +76,20 @@ public:
    * Return the enabled status of the object.
    */
   virtual bool enabled() { return _enabled; }
+
+  /**
+   * Emits an error prefixed with the file and line number of the given param (from the input
+   * file) with the given args as the message.
+   */
+  template <typename... Args>
+  [[noreturn]] void paramError(std::string param, Args... args)
+  {
+    auto prefix = param + ": ";
+    if (_pars.have_parameter<std::string>(paramLocName(param)))
+      prefix = _pars.get<std::string>(paramLocName(param)) + ": (" +
+               _pars.get<std::string>(paramPathName(param)) + ") ";
+    mooseError(prefix, args...);
+  }
 
   template <typename... Args>
   [[noreturn]] void mooseError(Args &&... args) const

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -35,6 +35,9 @@ class ActionFactory;
 class GlobalParamsAction;
 class JsonSyntaxTree;
 
+std::string paramLocName(std::string param);
+std::string paramPathName(std::string param);
+
 inline std::string
 errormsg(std::string /*fname*/, hit::Node * /*n*/)
 {

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -35,9 +35,6 @@ class ActionFactory;
 class GlobalParamsAction;
 class JsonSyntaxTree;
 
-std::string paramLocName(std::string param);
-std::string paramPathName(std::string param);
-
 inline std::string
 errormsg(std::string /*fname*/, hit::Node * /*n*/)
 {

--- a/framework/src/base/MooseError.C
+++ b/framework/src/base/MooseError.C
@@ -14,11 +14,25 @@
 
 #include "MooseError.h"
 #include "MooseUtils.h"
+#include "MooseVariable.h"
+
+#include "libmesh/string_to_enum.h"
 
 namespace moose
 {
 namespace internal
 {
+
+std::string
+incompatVarMsg(MooseVariable & var1, MooseVariable & var2)
+{
+  std::stringstream ss;
+  ss << libMesh::Utility::enum_to_string<FEFamily>(var1.feType().family) << ",ORDER"
+     << var1.feType().order
+     << " != " << libMesh::Utility::enum_to_string<FEFamily>(var2.feType().family) << ",ORDER"
+     << var2.feType().order;
+  return ss.str();
+}
 
 std::string
 mooseMsgFmt(const std::string & msg, const std::string & title, const std::string & color)

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -17,6 +17,18 @@
 #include "MooseApp.h"
 #include "MooseUtils.h"
 
+std::string
+paramLocName(std::string param)
+{
+  return "_" + param + "_fileloc";
+}
+
+std::string
+paramPathName(std::string param)
+{
+  return "_" + param + "_fullpath";
+}
+
 template <>
 InputParameters
 validParams<MooseObject>()

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -88,10 +88,10 @@ IntegratedBC::IntegratedBC(const InputParameters & parameters)
     MooseVariable * var = &_subproblem.getVariable(_tid, _save_in_strings[i]);
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving residual values in an Auxiliary variable "
-                                        "the AuxVariable must be the same type as the nonlinear "
-                                        "variable the object is acting on.");
-
+      paramError(
+          "save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
     _save_in[i] = var;
     var->sys().addVariableToZeroOnResidual(_save_in_strings[i]);
     addMooseVariableDependency(var);
@@ -104,9 +104,10 @@ IntegratedBC::IntegratedBC(const InputParameters & parameters)
     MooseVariable * var = &_subproblem.getVariable(_tid, _diag_save_in_strings[i]);
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving diagonal Jacobian values in an Auxiliary "
-                                        "variable the AuxVariable must be the same type as the "
-                                        "nonlinear variable the object is acting on.");
+      paramError(
+          "diag_save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _diag_save_in[i] = var;
     var->sys().addVariableToZeroOnJacobian(_diag_save_in_strings[i]);

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -56,9 +56,10 @@ NodalBC::NodalBC(const InputParameters & parameters)
     MooseVariable * var = &_subproblem.getVariable(_tid, _save_in_strings[i]);
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving residual values in an Auxiliary variable "
-                                        "the AuxVariable must be the same type as the nonlinear "
-                                        "variable the object is acting on.");
+      paramError(
+          "save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _save_in[i] = var;
     var->sys().addVariableToZeroOnResidual(_save_in_strings[i]);
@@ -72,9 +73,10 @@ NodalBC::NodalBC(const InputParameters & parameters)
     MooseVariable * var = &_subproblem.getVariable(_tid, _diag_save_in_strings[i]);
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving diagonal Jacobian values in an Auxiliary "
-                                        "variable the AuxVariable must be the same type as the "
-                                        "nonlinear variable the object is acting on.");
+      paramError(
+          "diag_save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _diag_save_in[i] = var;
     var->sys().addVariableToZeroOnJacobian(_diag_save_in_strings[i]);

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -139,9 +139,10 @@ DGKernel::DGKernel(const InputParameters & parameters)
                  " as a save_in variable in " + name());
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving residual values in an Auxiliary variable "
-                                        "the AuxVariable must be the same type as the nonlinear "
-                                        "variable the object is acting on.");
+      paramError(
+          "save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _save_in[i] = var;
     var->sys().addVariableToZeroOnResidual(_save_in_strings[i]);
@@ -159,9 +160,10 @@ DGKernel::DGKernel(const InputParameters & parameters)
                  " as a diag_save_in variable in " + name());
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving diagonal Jacobian values in an Auxiliary "
-                                        "variable the AuxVariable must be the same type as the "
-                                        "nonlinear variable the object is acting on.");
+      paramError(
+          "diag_save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _diag_save_in[i] = var;
     var->sys().addVariableToZeroOnJacobian(_diag_save_in_strings[i]);

--- a/framework/src/kernels/KernelBase.C
+++ b/framework/src/kernels/KernelBase.C
@@ -114,13 +114,13 @@ KernelBase::KernelBase(const InputParameters & parameters)
     MooseVariable * var = &_subproblem.getVariable(_tid, _save_in_strings[i]);
 
     if (_fe_problem.getNonlinearSystemBase().hasVariable(_save_in_strings[i]))
-      mooseError("Trying to use solution variable " + _save_in_strings[i] +
-                 " as a save_in variable in " + name());
+      paramError("save_in", "cannot use solution variable as save-in variable");
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving residual values in an Auxiliary variable "
-                                        "the AuxVariable must be the same type as the nonlinear "
-                                        "variable the object is acting on.");
+      paramError(
+          "save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _save_in[i] = var;
     var->sys().addVariableToZeroOnResidual(_save_in_strings[i]);
@@ -134,13 +134,13 @@ KernelBase::KernelBase(const InputParameters & parameters)
     MooseVariable * var = &_subproblem.getVariable(_tid, _diag_save_in_strings[i]);
 
     if (_fe_problem.getNonlinearSystemBase().hasVariable(_diag_save_in_strings[i]))
-      mooseError("Trying to use solution variable " + _diag_save_in_strings[i] +
-                 " as a diag_save_in variable in " + name());
+      paramError("diag_save_in", "cannot use solution variable as diag save-in variable");
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving diagonal Jacobian values in an Auxiliary "
-                                        "variable the AuxVariable must be the same type as the "
-                                        "nonlinear variable the object is acting on.");
+      paramError(
+          "diag_save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _diag_save_in[i] = var;
     var->sys().addVariableToZeroOnJacobian(_diag_save_in_strings[i]);

--- a/framework/src/kernels/NodalEqualValueConstraint.C
+++ b/framework/src/kernels/NodalEqualValueConstraint.C
@@ -31,7 +31,7 @@ NodalEqualValueConstraint::NodalEqualValueConstraint(const InputParameters & par
   : NodalScalarKernel(parameters)
 {
   if (_node_ids.size() != 2)
-    mooseError(name(), ": The number of nodes has to be 2, but it is ", _node_ids.size(), ".");
+    paramError("nodes", "invalid number of nodes: want 2, got ", _node_ids.size());
 
   unsigned int n = coupledComponents("var");
   _value.resize(n);

--- a/framework/src/nodalkernels/NodalKernel.C
+++ b/framework/src/nodalkernels/NodalKernel.C
@@ -101,9 +101,10 @@ NodalKernel::NodalKernel(const InputParameters & parameters)
     MooseVariable * var = &_subproblem.getVariable(_tid, _save_in_strings[i]);
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving residual values in an Auxiliary variable "
-                                        "the AuxVariable must be the same type as the nonlinear "
-                                        "variable the object is acting on.");
+      paramError(
+          "save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _save_in[i] = var;
     var->sys().addVariableToZeroOnResidual(_save_in_strings[i]);
@@ -117,9 +118,10 @@ NodalKernel::NodalKernel(const InputParameters & parameters)
     MooseVariable * var = &_subproblem.getVariable(_tid, _diag_save_in_strings[i]);
 
     if (var->feType() != _var.feType())
-      mooseError("Error in " + name() + ". When saving diagonal Jacobian values in an Auxiliary "
-                                        "variable the AuxVariable must be the same type as the "
-                                        "nonlinear variable the object is acting on.");
+      paramError(
+          "diag_save_in",
+          "saved-in auxiliary variable is incompatible with the object's nonlinear variable: ",
+          moose::internal::incompatVarMsg(*var, _var));
 
     _diag_save_in[i] = var;
     var->sys().addVariableToZeroOnJacobian(_diag_save_in_strings[i]);

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -52,18 +52,6 @@
 #include <algorithm>
 #include <cstdlib>
 
-std::string
-paramLocName(std::string param)
-{
-  return "_" + param + "_fileloc";
-}
-
-std::string
-paramPathName(std::string param)
-{
-  return "_" + param + "_fullpath";
-}
-
 Parser::Parser(MooseApp & app, ActionWarehouse & action_wh)
   : ConsoleStreamInterface(app),
     _app(app),

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -52,6 +52,18 @@
 #include <algorithm>
 #include <cstdlib>
 
+std::string
+paramLocName(std::string param)
+{
+  return "_" + param + "_fileloc";
+}
+
+std::string
+paramPathName(std::string param)
+{
+  return "_" + param + "_fullpath";
+}
+
 Parser::Parser(MooseApp & app, ActionWarehouse & action_wh)
   : ConsoleStreamInterface(app),
     _app(app),
@@ -956,6 +968,9 @@ Parser::extractParams(const std::string & prefix, InputParameters & p)
       _extracted_vars.insert(
           full_name); // Keep track of all variables extracted from the input file
       found = true;
+      p.set<std::string>(paramLocName(it.first)) =
+          _input_filename + ":" + std::to_string(_root->find(full_name)->line());
+      p.set<std::string>(paramPathName(it.first)) = full_name;
     }
     // Wait! Check the GlobalParams section
     else if (global_params_block)
@@ -968,6 +983,9 @@ Parser::extractParams(const std::string & prefix, InputParameters & p)
             full_name); // Keep track of all variables extracted from the input file
         found = true;
         in_global = true;
+        p.set<std::string>(paramLocName(it.first)) =
+            _input_filename + ":" + std::to_string(_root->find(full_name)->line());
+        p.set<std::string>(paramPathName(it.first)) = full_name;
       }
     }
 

--- a/framework/src/transfers/MultiAppCopyTransfer.C
+++ b/framework/src/transfers/MultiAppCopyTransfer.C
@@ -25,6 +25,7 @@
 
 #include "libmesh/system.h"
 #include "libmesh/id_types.h"
+#include "libmesh/string_to_enum.h"
 
 template <>
 InputParameters
@@ -81,9 +82,23 @@ MultiAppCopyTransfer::transfer(FEProblemBase & to_problem, FEProblemBase & from_
   MooseVariable & from_var = from_problem.getVariable(0, _from_var_name);
   MeshBase & from_mesh = from_problem.mesh().getMesh();
 
+  auto from = libMesh::Utility::enum_to_string<FEFamily>(from_var.feType().family);
+  auto to = libMesh::Utility::enum_to_string<FEFamily>(to_var.feType().family);
+  auto from_order = from_var.feType().order;
+  auto to_order = to_var.feType().order;
+
   // Check integrity
   if (to_var.feType() != from_var.feType())
-    mooseError("The variables must be the same type (order and family).");
+    paramError("variable",
+               "'variable' and 'source_variable' must be the same type (order and family): ",
+               to,
+               ",ORDER",
+               to_order,
+               " != ",
+               from,
+               ",ORDER",
+               from_order);
+  // mooseError("The variables must be the same type (order and family).");
 
   if ((to_mesh.n_nodes() != from_mesh.n_nodes()) || (to_mesh.n_elem() != from_mesh.n_elem()))
     mooseError("The meshes must be identical to utilize MultiAppCopyTransfer.");

--- a/framework/src/transfers/MultiAppCopyTransfer.C
+++ b/framework/src/transfers/MultiAppCopyTransfer.C
@@ -82,23 +82,12 @@ MultiAppCopyTransfer::transfer(FEProblemBase & to_problem, FEProblemBase & from_
   MooseVariable & from_var = from_problem.getVariable(0, _from_var_name);
   MeshBase & from_mesh = from_problem.mesh().getMesh();
 
-  auto from = libMesh::Utility::enum_to_string<FEFamily>(from_var.feType().family);
-  auto to = libMesh::Utility::enum_to_string<FEFamily>(to_var.feType().family);
-  auto from_order = from_var.feType().order;
-  auto to_order = to_var.feType().order;
-
   // Check integrity
   if (to_var.feType() != from_var.feType())
     paramError("variable",
                "'variable' and 'source_variable' must be the same type (order and family): ",
-               to,
-               ",ORDER",
-               to_order,
-               " != ",
-               from,
-               ",ORDER",
-               from_order);
-  // mooseError("The variables must be the same type (order and family).");
+               libMesh::Utility::enum_to_string<FEFamily>(to_var.feType().family),
+               moose::internal::incompatVarMsg(to_var, from_var));
 
   if ((to_mesh.n_nodes() != from_mesh.n_nodes()) || (to_mesh.n_elem() != from_mesh.n_elem()))
     mooseError("The meshes must be identical to utilize MultiAppCopyTransfer.");

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -516,7 +516,7 @@
     type = 'RunException'
     input = 'check_syntax_error.i'
     cli_args = '--check-input'
-    expect_err = 'ced: The number of nodes has to be 2, but it is 3.'
+    expect_err = 'invalid number of nodes: want 2, got 3'
   [../]
 
   [./check_syntax_no_input]

--- a/test/tests/misc/save_in/tests
+++ b/test/tests/misc/save_in/tests
@@ -10,12 +10,12 @@
   [./test_soln_var_err]
     type = RunException
     input = 'save_in_soln_var_err_test.i'
-    expect_err = 'Trying to use solution variable u as a save_in variable in diff'
+    expect_err = 'diff/save_in\) cannot use solution variable as save-in variable'
   [../]
   [./test_diag_sol_var_err]
     type = RunException
     input = 'diag_save_in_soln_var_err_test.i'
-    expect_err = 'Trying to use solution variable u as a diag_save_in variable in diff'
+    expect_err = 'diff/diag_save_in\) cannot use solution variable as diag save-in variable'
   [../]
   [./test_dg]
     type = 'Exodiff'

--- a/test/tests/misc/save_in/tests
+++ b/test/tests/misc/save_in/tests
@@ -15,7 +15,7 @@
   [./test_diag_sol_var_err]
     type = RunException
     input = 'diag_save_in_soln_var_err_test.i'
-    expect_err = 'diff/diag_save_in\) cannot use solution variable as diag save-in variable'
+    expect_err = '\(.*diff/diag_save_in\) cannot use solution variable as diag save-in variable'
   [../]
   [./test_dg]
     type = 'Exodiff'

--- a/test/tests/transfers/multiapp_copy_transfer/errors/tests
+++ b/test/tests/transfers/multiapp_copy_transfer/errors/tests
@@ -9,6 +9,6 @@
     type = RunException
     input = master.i
     cli_args = 'sub0:Mesh/elem_type=QUAD8 sub0:Variables/u/order=SECOND'
-    expect_err = 'The variables must be the same type \(order and family\)'
+    expect_err = 'must be the same type \(order and family\)'
   [../]
 []


### PR DESCRIPTION
Provides a helper function ``paramError([param-name], [msg])`` for emitting moose errors related to input parameters.  The error will automatically be formatted with a prefix that includes the full parameter path (including the object name) and the input file name and line number of corresponding to the bad value.

For example:

```c++
// ... inside a moose object constructor:
if (getParam<int>("myparam") <= 42)
  paramError("myparam", "value must be greater than 42");
```

with this input file:

```
[Foo]
  [bar]
    myparam = 41
  []
[]
```

gives this error:

```
*** ERROR ***
/path/to/infile.i:3: (Foo/bar/myparam) value must be greater than 42
```

I plan on working converting more moose error's to use paramError off and on in coming weeks.  Others are welcome to as well.
