### PR TITLE
parser: more robust handling of number syntax errors

### DIFF
--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_without_action.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_without_action.i
@@ -73,7 +73,7 @@
     variable = pab
     v = 'a b'
     sto_v = '1 1'
-    log_k = '-2 -2'
+    log_k = -2
   [../]
 []
 

--- a/modules/combined/examples/phase_field-mechanics/grain_texture.i
+++ b/modules/combined/examples/phase_field-mechanics/grain_texture.i
@@ -152,7 +152,7 @@
   nl_abs_tol = 1e-11 # Relative tolerance for nonlinear solves
   nl_rel_tol = 1e-10 # Absolute tolerance for nonlinear solves
   start_time = 0.0
-  num_steps = 50.0
+  num_steps = 50
   [./TimeStepper]
     type = IterationAdaptiveDT
     dt = 25 # Initial time step.  In this simulation it changes.

--- a/modules/combined/test/tests/grain_texture/grain_texture_test_1.i
+++ b/modules/combined/test/tests/grain_texture/grain_texture_test_1.i
@@ -113,7 +113,7 @@
   nl_abs_tol = 1e-11 # Relative tolerance for nonlinear solves
   nl_rel_tol = 1e-10 # Absolute tolerance for nonlinear solves
   start_time = 0.0
-  num_steps = 1.0
+  num_steps = 1
 []
 
 [Outputs]

--- a/modules/combined/test/tests/grain_texture/grain_texture_test_2.i
+++ b/modules/combined/test/tests/grain_texture/grain_texture_test_2.i
@@ -117,7 +117,7 @@
   nl_abs_tol = 1e-11 # Relative tolerance for nonlinear solves
   nl_rel_tol = 1e-10 # Absolute tolerance for nonlinear solves
   start_time = 0.0
-  num_steps = 1.0
+  num_steps = 1
 []
 
 [Outputs]

--- a/modules/combined/test/tests/solid_mechanics/spherical_shell/1D-SPH_test.i
+++ b/modules/combined/test/tests/solid_mechanics/spherical_shell/1D-SPH_test.i
@@ -145,7 +145,7 @@
     type = IterationAdaptiveDT
     dt = 1
     optimal_iterations = 6
-    iteration_window = 0.4
+    iteration_window = 0
     linear_iteration_ratio = 100
   [../]
 

--- a/modules/combined/test/tests/solid_mechanics/spherical_shell/2D-RZ_test.i
+++ b/modules/combined/test/tests/solid_mechanics/spherical_shell/2D-RZ_test.i
@@ -185,7 +185,7 @@
     type = IterationAdaptiveDT
     dt = 1
     optimal_iterations = 6
-    iteration_window = 0.4
+    iteration_window = 0
     linear_iteration_ratio = 100
   [../]
 

--- a/modules/combined/test/tests/solid_mechanics/spherical_shell/3D_test.i
+++ b/modules/combined/test/tests/solid_mechanics/spherical_shell/3D_test.i
@@ -208,7 +208,7 @@
     type = IterationAdaptiveDT
     dt = 1
     optimal_iterations = 6
-    iteration_window = 0.4
+    iteration_window = 0
     linear_iteration_ratio = 100
   [../]
 

--- a/modules/phase_field/examples/rigidbodymotion/grain_forcedensity_ext.i
+++ b/modules/phase_field/examples/rigidbodymotion/grain_forcedensity_ext.i
@@ -131,7 +131,7 @@
     type = BndsCalcAux
     variable = bnds
     var_name_base = eta
-    op_num = 2.0
+    op_num = 2
     v = 'eta0 eta1'
   [../]
   [./df01]

--- a/modules/phase_field/test/tests/initial_conditions/RndSmoothCircleIC.i
+++ b/modules/phase_field/test/tests/initial_conditions/RndSmoothCircleIC.i
@@ -24,7 +24,7 @@
     radius = 6.0
     invalue = 1.0
     variation_invalue = 0.0
-    outvalue = -0.8;
+    outvalue = -0.8
     variation_outvalue = 0.2
     int_width = 5
   [../]

--- a/modules/phase_field/test/tests/rigidbodymotion/grain_appliedforcedensity.i
+++ b/modules/phase_field/test/tests/rigidbodymotion/grain_appliedforcedensity.i
@@ -113,7 +113,7 @@
     type = BndsCalcAux
     variable = bnds
     var_name_base = eta
-    op_num = 2.0
+    op_num = 2
     v = 'eta0 eta1'
   [../]
 []

--- a/modules/phase_field/test/tests/rigidbodymotion/grain_forcedensity.i
+++ b/modules/phase_field/test/tests/rigidbodymotion/grain_forcedensity.i
@@ -178,7 +178,7 @@
     type = BndsCalcAux
     variable = bnds
     var_name_base = eta
-    op_num = 2.0
+    op_num = 2
     v = 'eta0 eta1'
   [../]
   [./df01]

--- a/modules/phase_field/test/tests/rigidbodymotion/grain_maskedforce.i
+++ b/modules/phase_field/test/tests/rigidbodymotion/grain_maskedforce.i
@@ -102,7 +102,7 @@
     type = BndsCalcAux
     variable = bnds
     var_name_base = eta
-    op_num = 2.0
+    op_num = 2
     v = 'eta0 eta1'
     block = 0
   [../]

--- a/modules/phase_field/test/tests/rigidbodymotion/grain_motion_fauxGT.i
+++ b/modules/phase_field/test/tests/rigidbodymotion/grain_motion_fauxGT.i
@@ -178,7 +178,7 @@
     type = BndsCalcAux
     variable = bnds
     var_name_base = eta
-    op_num = 2.0
+    op_num = 2
     v = 'eta0 eta1'
   [../]
   [./df01]

--- a/modules/phase_field/test/tests/rigidbodymotion/polycrystal_action.i
+++ b/modules/phase_field/test/tests/rigidbodymotion/polycrystal_action.i
@@ -129,7 +129,7 @@
     type = BndsCalcAux
     variable = bnds
     var_name_base = eta
-    op_num = 2.0
+    op_num = 2
     v = 'eta0 eta1'
   [../]
   [./MaterialVectorGradAuxKernel]

--- a/modules/richards/test/tests/buckley_leverett/bl20.i
+++ b/modules/richards/test/tests/buckley_leverett/bl20.i
@@ -156,7 +156,7 @@
     type = DirichletBC
     variable = pgas
     boundary = left
-    value = 1E6+1000
+    value = 1E6
   [../]
   [./right_w]
     type = DirichletBC
@@ -168,7 +168,7 @@
     type = DirichletBC
     variable = pgas
     boundary = right
-    value = 0+1000
+    value = 0
   [../]
 []
 

--- a/modules/richards/test/tests/buckley_leverett/bl20_lumped.i
+++ b/modules/richards/test/tests/buckley_leverett/bl20_lumped.i
@@ -155,7 +155,7 @@
     type = DirichletBC
     variable = pgas
     boundary = right
-    value = 0+1000
+    value = 0
   [../]
 []
 

--- a/modules/richards/test/tests/buckley_leverett/bl20_lumped_fu.i
+++ b/modules/richards/test/tests/buckley_leverett/bl20_lumped_fu.i
@@ -155,7 +155,7 @@
     type = DirichletBC
     variable = pgas
     boundary = right
-    value = 0+1000
+    value = 0
   [../]
 []
 

--- a/modules/stochastic_tools/test/tests/state_sim/time_step_vs_next.i
+++ b/modules/stochastic_tools/test/tests/state_sim/time_step_vs_next.i
@@ -22,7 +22,7 @@
   [./cur_Sim]
     type = StateSimRunner
     model_path = 'path/to/model'
-    seed = 7;
+    seed = 7
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/2D_geometries/2D-RZ_test.i
+++ b/modules/tensor_mechanics/test/tests/2D_geometries/2D-RZ_test.i
@@ -147,7 +147,7 @@
     type = IterationAdaptiveDT
     dt = 1
     optimal_iterations = 6
-    iteration_window = 0.4
+    iteration_window = 0
     linear_iteration_ratio = 100
   [../]
 

--- a/modules/tensor_mechanics/test/tests/isotropic_elasticity_tensor/2D-axisymmetric_rz_test.i
+++ b/modules/tensor_mechanics/test/tests/isotropic_elasticity_tensor/2D-axisymmetric_rz_test.i
@@ -108,7 +108,7 @@
     type = IterationAdaptiveDT
     dt = 1
     optimal_iterations = 6
-    iteration_window = 0.4
+    iteration_window = 0
     linear_iteration_ratio = 100
   [../]
 

--- a/test/tests/misc/check_error/bad_number.i
+++ b/test/tests/misc/check_error/bad_number.i
@@ -1,0 +1,43 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1.2eE
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -558,4 +558,10 @@
     expect_out = "Function name 'x' could evaluate as a ParsedFunction"
     allow_warnings = true
   [../]
+
+  [./bad_number]
+    type = 'RunException'
+    input = 'bad_number.i'
+    expect_err = "invalid float syntax for parameter: BCs/right/value"
+  [../]
 []


### PR DESCRIPTION
stoi and stod functions are quite permissive and can ignore part of the
input string leaving it not entirely parsed.  Sometimes this could
result in invalid number strings being parsed as valid.  For example
"3ee10" is parsed as the value "3".  This change fixes that and requires
sto[i/d] to parse the entire string.  Any corresponding errors are not
added to the _errmsg collection variable and printed together with
other errors all at once instead of one at a time.

fixes #10310

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
