### PR TITLE
hit: update build rules to allow easy manual clean and rebuild

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -31,12 +31,11 @@ hit_deps      := $(patsubst %.cc, %.$(obj-suffix).d, $(hit_srcfiles))
 # hit python bindings
 #
 pyhit_srcfiles  := $(hit_DIR)/hit.cpp $(hit_DIR)/lex.cc $(hit_DIR)/parse.cc
-pyhit_LIB       := $(hit_DIR)/hit.so
+pyhit_LIB       := $(FRAMEWORK_DIR)/../python/hit.so
 
-$(pyhit_LIB): $(pyhit_srcfiles)
-	@echo "Linking Library "$@"..."
-	@bash -c '(cd "$(hit_DIR)" && $(libmesh_CXX) -std=c++11 -w -fPIC -lstdc++ -shared -L`python-config --prefix`/lib `python-config --includes` `python-config --ldflags` $^ -o $@)'
-	@cp $@ $(FRAMEWORK_DIR)/../python/
+hit $(pyhit_LIB): $(pyhit_srcfiles)
+	@echo "Building and linking "$@"..."
+	@bash -c '(cd "$(hit_DIR)" && $(libmesh_CXX) -std=c++11 -w -fPIC -lstdc++ -shared -L`python-config --prefix`/lib `python-config --includes` `python-config --ldflags` $^ -o $(pyhit_LIB))'
 
 #
 # gtest
@@ -167,11 +166,11 @@ $(exodiff_APP): $(exodiff_objects)
 #
 # Clean targets
 #
-.PHONY: clean clobber cleanall echo_include echo_library libmesh_submodule_status
+.PHONY: clean clobber cleanall echo_include echo_library libmesh_submodule_status hit
 
 # Set up app-specific variables for MOOSE, so that it can use the same clean target as the apps
 app_EXEC := $(exodiff_APP)
-app_LIB  := $(moose_LIBS) $(pcre_LIB) $(gtest_LIB) $(hit_LIB)
+app_LIB  := $(moose_LIBS) $(pcre_LIB) $(gtest_LIB) $(hit_LIB) $(pyhit_LIB)
 app_objects := $(moose_objects) $(exodiff_objects) $(pcre_objects) $(gtest_objects) $(hit_objects)
 app_deps := $(moose_deps) $(exodiff_deps) $(pcre_deps) $(gtest_deps) $(hit_deps)
 

--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -7,7 +7,7 @@ import os, re, time, sys
 try:
     import hit
 except:
-    print('failed to import hit - you may need to (re)build moose.', file=sys.stderr)
+    print('failed to import hit - try running "make hit" in the $MOOSE_DIR/test directory.', file=sys.stderr)
     sys.exit(1)
 
 class DupWalker(object):


### PR DESCRIPTION
Allow a "make hit" to trigger a forced rebuild of the hit python
bindings.  The hit.so target has been updated to build directly inside
the moose python directory instead of the separate build and copy.
Modify the failed import message to suggest running "make hit".

ref #10007

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
