### PR TITLE
modules: fix heavy tests with bad float syntax

### DIFF
--- a/examples/ex07_ics/steady.i
+++ b/examples/ex07_ics/steady.i
@@ -11,7 +11,7 @@
     # for which we want to apply this initial condition
     [./InitialCondition]
       type = ExampleIC
-      coefficient = 2.0;
+      coefficient = 2.0
     [../]
   [../]
 []

--- a/examples/ex07_ics/transient.i
+++ b/examples/ex07_ics/transient.i
@@ -11,7 +11,7 @@
     # for which we want to apply this initial condition
     [./InitialCondition]
       type = ExampleIC
-      coefficient = 2.0;
+      coefficient = 2.0
     [../]
   [../]
 []

--- a/modules/richards/test/tests/buckley_leverett/bl22.i
+++ b/modules/richards/test/tests/buckley_leverett/bl22.i
@@ -157,7 +157,7 @@
     type = DirichletBC
     variable = pgas
     boundary = left
-    value = 1E6+1000
+    value = 1E6
   [../]
   [./right_w]
     type = DirichletBC
@@ -169,7 +169,7 @@
     type = DirichletBC
     variable = pgas
     boundary = right
-    value = 0+1000
+    value = 0
   [../]
 []
 

--- a/modules/richards/test/tests/buckley_leverett/bl22_lumped.i
+++ b/modules/richards/test/tests/buckley_leverett/bl22_lumped.i
@@ -174,7 +174,7 @@
     type = DirichletBC
     variable = pgas
     boundary = right
-    value = 0+1000
+    value = 0
   [../]
 []
 

--- a/modules/richards/test/tests/buckley_leverett/bl22_lumped_fu.i
+++ b/modules/richards/test/tests/buckley_leverett/bl22_lumped_fu.i
@@ -174,7 +174,7 @@
     type = DirichletBC
     variable = pgas
     boundary = right
-    value = 0+1000
+    value = 0
   [../]
 []
 


### PR DESCRIPTION
Broken by idaholab/moose#10312.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
