### PR TITLE
benchmarks: fix readme instructions

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,17 +39,17 @@ along with any optional arguments.  The ``bench.list`` file has the following fo
 [benchmarks]
     [./simple_diffusion_refine3]
         binary = test/moose_test-opt
-        infile = test/tests/kernels/simple_diffusion/simple_diffusion.i
+        input = test/tests/kernels/simple_diffusion/simple_diffusion.i
         cli_args = 'Mesh/uniform_refine=3'
     [../]
     [./simple_diffusion_refine4]
         binary = test/moose_test-opt
-        infile = test/tests/kernels/simple_diffusion/simple_diffusion.i
+        input = test/tests/kernels/simple_diffusion/simple_diffusion.i
         cli_args = 'Mesh/uniform_refine=4'
     [../]
     [./simple_diffusion_ref5]
         binary = test/moose_test-opt
-        infile = test/tests/kernels/simple_diffusion/simple_diffusion.i
+        input = test/tests/kernels/simple_diffusion/simple_diffusion.i
         cli_args = 'Mesh/uniform_refine=5'
     [../]
     # ... add as many as you want

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -292,7 +292,12 @@ def read_benchmarks(benchlist):
 
     root = hit.parse(benchlist, data)
     for child in root.find('benchmarks').children():
+        if not child.param('binary'):
+            raise ValueError('missing required "binary" field')
         ex = child.param('binary').strip()
+
+        if not child.param('input'):
+            raise ValueError('missing required "input" field')
         infile = child.param('input').strip()
         args = ''
         if child.find('cli_args'):


### PR DESCRIPTION
Fix "infile" to be "input" in the script README. This got missed when
the parameter name was changed in the script. Also check for and print
useful errors for missing fields in the benchmarks spec.

ref #9834

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
