### PR TITLE
Adding shared pointer interface

### DIFF
--- a/framework/include/base/AppFactory.h
+++ b/framework/include/base/AppFactory.h
@@ -120,6 +120,10 @@ public:
                     const std::string & name,
                     InputParameters parameters,
                     MPI_Comm COMM_WORLD_IN);
+  std::shared_ptr<MooseApp> createShared(const std::string & app_type,
+                                         const std::string & name,
+                                         InputParameters parameters,
+                                         MPI_Comm COMM_WORLD_IN);
 
   ///@{
   /**

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -88,6 +88,15 @@ AppFactory::create(const std::string & app_type,
   return (*_name_to_build_pointer[app_type])(parameters);
 }
 
+std::shared_ptr<MooseApp>
+AppFactory::createShared(const std::string & app_type,
+                         const std::string & name,
+                         InputParameters parameters,
+                         MPI_Comm COMM_WORLD_IN)
+{
+  return std::shared_ptr<MooseApp>(create(app_type, name, parameters, COMM_WORLD_IN));
+}
+
 bool
 AppFactory::isRegistered(const std::string & app_name) const
 {


### PR DESCRIPTION
This interface is temporary so that we can transition any apps that may be
calling the raw version of AppFactory::create() directly. This is normally
only needed by the Multiapp system. It is called by one or two other applications.

refs #10305

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
