### PR TITLE
add_output may not be available in action warehouse

### DIFF
--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -124,7 +124,7 @@ OutputWarehouse::hasOutput(const std::string & name) const
 const std::set<OutputName> &
 OutputWarehouse::getOutputNames()
 {
-  if (_object_names.empty())
+  if (_object_names.empty() && _app.actionWarehouse().hasActions("add_output"))
   {
     const auto & actions = _app.actionWarehouse().getActionListByName("add_output");
     for (const auto & act : actions)


### PR DESCRIPTION
So add a protection of getting action in task of `add_output`. This fixes #10352.