### PR TITLE
hit: fix minor tree rendering issues

### DIFF
--- a/framework/contrib/hit/lex.cc
+++ b/framework/contrib/hit/lex.cc
@@ -257,12 +257,16 @@ consumeToNewline(Lexer * l)
 void
 lexComments(Lexer * l)
 {
-  l->acceptRun(space);
-  l->ignore();
-  if (l->accept("#"))
+  // The first comment in a file can't be an inline comment.
+  if (l->start() > 0)
   {
-    consumeToNewline(l);
-    l->emit(TokType::InlineComment);
+    l->acceptRun(space);
+    l->ignore();
+    if (l->accept("#"))
+    {
+      consumeToNewline(l);
+      l->emit(TokType::InlineComment);
+    }
   }
 
   while (true)

--- a/python/MooseDocs/tests/listings/gold/testInputListing.html
+++ b/python/MooseDocs/tests/listings/gold/testInputListing.html
@@ -2,10 +2,10 @@
 <div class="moose-float-div moose-listing-div" data-moose-float-name="Listing" id="diffusion_block">
 <p class="moose-float-caption"><span class="moose-float-caption-heading"><span class="moose-float-caption-heading-label">Listing </span><span class="moose-float-caption-heading-number">1</span><span class="moose-float-caption-heading-suffix">: </span></span><span class="moose-float-caption-text">Diffusion Kernel Input Syntax</span></p>
 <pre style="overflow-y:scroll;max-height:350px"><code class="language-text">[Kernels]
-  [diff]
+  [./diff]
     type = Diffusion
     variable = u
-  []
+  [../]
 []
 </code></pre>
 <div><a class="moose-listing-link tooltipped" data-tooltip="test/tests/kernels/simple_diffusion/simple_diffusion.i" href="https://github.com/idaholab/moose/blob/master/test/tests/kernels/simple_diffusion/simple_diffusion.i">(simple_diffusion.i)</a></div>

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -310,9 +310,9 @@ TEST(HitTests, RenderCases)
 {
   RenderCase cases[] = {
       {"root level fields", "foo=bar boo=far", "foo = bar\nboo = far"},
-      {"single section", "[foo]bar=baz[../]", "[foo]\n  bar = baz\n[]"},
-      {"remove leading newline", "\n[foo]bar=baz[../]", "[foo]\n  bar = baz\n[]"},
-      {"preserve consecutive newline", "[foo]\n\nbar=baz[../]", "[foo]\n\n  bar = baz\n[]"},
+      {"single section", "[foo]bar=baz[../]", "[foo]\n  bar = baz\n[../]"},
+      {"remove leading newline", "\n[foo]bar=baz[../]", "[foo]\n  bar = baz\n[../]"},
+      {"preserve consecutive newline", "[foo]\n\nbar=baz[../]", "[foo]\n\n  bar = baz\n[../]"},
   };
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(RenderCase); i++)


### PR DESCRIPTION
Fix missing blanks between top-level sections. Fix first-line-comments
being misinterpreted as inline comments (and so incorrectly were
rendered with an extra space prefix). Capture section tokens better
during parsing and use them (if available) when rendering section closes
preserving any "[../]" or "[]" detail.

Addresses issues brough up in #10370.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
