### PR TITLE
Make sure libmesh doesn't override Jacobian for standard FDP

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -240,6 +240,9 @@ void
 NonlinearSystem::setupStandardFiniteDifferencedPreconditioner()
 {
 #if LIBMESH_HAVE_PETSC
+  // Make sure that libMesh isn't going to override our preconditioner
+  _transient_sys.nonlinear_solver->jacobian = nullptr;
+
   PetscNonlinearSolver<Number> * petsc_nonlinear_solver =
       static_cast<PetscNonlinearSolver<Number> *>(_transient_sys.nonlinear_solver.get());
 
@@ -262,7 +265,7 @@ NonlinearSystem::setupColoringFiniteDifferencedPreconditioner()
 {
 #ifdef LIBMESH_HAVE_PETSC
   // Make sure that libMesh isn't going to override our preconditioner
-  _transient_sys.nonlinear_solver->jacobian = NULL;
+  _transient_sys.nonlinear_solver->jacobian = nullptr;
 
   PetscNonlinearSolver<Number> & petsc_nonlinear_solver =
       dynamic_cast<PetscNonlinearSolver<Number> &>(*_transient_sys.nonlinear_solver);

--- a/test/tests/preconditioners/fdp/fdp_test.i
+++ b/test/tests/preconditioners/fdp/fdp_test.i
@@ -1,95 +1,59 @@
 [Mesh]
-  file = square.e
+  type = GeneratedMesh
+  nx = 2
+  ny = 2
+  dim = 2
 []
 
 [Variables]
-  active = 'u v'
-
   [./u]
-    order = FIRST
-    family = LAGRANGE
   [../]
-
   [./v]
-    order = FIRST
-    family = LAGRANGE
   [../]
 []
 
 [Preconditioning]
-  active = 'FDP'
-
   [./FDP]
     type = FDP
-    full = true
-  #  off_diag_row    = 'v'
-  #  off_diag_column = 'u'
   [../]
 []
 
 [Kernels]
-  active = 'diff_u conv_v diff_v'
-
   [./diff_u]
     type = Diffusion
     variable = u
   [../]
-
   [./conv_v]
     type = CoupledForce
     variable = v
     v = u
   [../]
-
   [./diff_v]
     type = Diffusion
     variable = v
   [../]
 []
 
-[BCs]
-  active = 'left_u right_u left_v'
-
-  [./left_u]
-    type = DirichletBC
-    variable = u
-    boundary = 1
-    value = 0
-  [../]
-
-  [./right_u]
-    type = DirichletBC
-    variable = u
-    boundary = 2
-    value = 100
-  [../]
-
-  [./left_v]
-    type = DirichletBC
-    variable = v
-    boundary = 1
-    value = 0
-  [../]
-
-  [./right_v]
-    type = DirichletBC
-    variable = v
-    boundary = 2
-    value = 0
-  [../]
-[]
-
 [Executioner]
   type = Steady
-
-#  l_max_its = 1
-#  nl_max_its = 1
-
-  petsc_options_iname = '-pc_type'
-  petsc_options_value = 'lu'
+  solve_type = NEWTON
 []
 
 [Outputs]
-  file_base = out
-  exodus = true
+  exodus = false
+[]
+
+[ICs]
+  [./u]
+    variable = u
+    type = RandomIC
+    min = 0.1
+    max = 0.9
+  [../]
+  [./v]
+    variable = v
+    type = RandomIC
+    min = 0.1
+    max = 0.9
+  [../]
 []

--- a/test/tests/preconditioners/fdp/tests
+++ b/test/tests/preconditioners/fdp/tests
@@ -1,16 +1,27 @@
 [Tests]
-  [./test]
-    type = 'Exodiff'
-    input = 'fdp_test.i'
-    exodiff = 'out.e'
-    max_parallel = 1
+  [./jacobian_fdp_coloring_full_test]
+    type = AnalyzeJacobian
+    input = fdp_test.i
+    expect_out = '\nNo errors detected. :-\)\n'
+    recover = false
+    mesh_mode = REPLICATED
+    cli_args = 'Preconditioning/FDP/full=true'
   [../]
-  [./test_standard]
-    type = 'Exodiff'
-    input = 'fdp_test.i'
-    exodiff = 'out.e'
-    max_parallel = 1
-    prereq = 'test'
-    cli_args = "Preconditioning/FDP/finite_difference_type='standard'"
+  [./jacobian_fdp_standard_test]
+    type = AnalyzeJacobian
+    input = fdp_test.i
+    expect_out = '\nNo errors detected. :-\)\n'
+    recover = false
+    mesh_mode = REPLICATED
+    cli_args = 'Preconditioning/FDP/finite_difference_type=standard'
+    prereq = 'jacobian_fdp_coloring_full_test'
+  [../]
+  [./jacobian_fdp_coloring_diagonal_test_fail]
+    type = AnalyzeJacobian
+    input = fdp_test.i
+    expect_out = 'Off-diagonal Jacobian.*needs to be implemented'
+    recover = false
+    mesh_mode = REPLICATED
+    prereq = 'jacobian_fdp_standard_test'
   [../]
 []


### PR DESCRIPTION
- Sets user jacobian to `NULL` so `SNESSetJacobian` doesn't get called in libMesh (called from `PetscNonlinearSolver<T>::solve`)
- Re-do `FDP` tests so that the Jacobians are actually tested
    - Note that there's one test with diagonal coloring that will complain about non-implemented Jacobians
     - Another uses full coloring and the Jacobian passes
    - The last uses standard `FDP` such that the specification of blocks to include in the user matrix doesn't matter and the Jacobian passes

Closes #10373 
