### PR TITLE
Fix doc equations for katex in tensor mechanics

### DIFF
--- a/docs/content/documentation/modules/tensor_mechanics/Convergence.md
+++ b/docs/content/documentation/modules/tensor_mechanics/Convergence.md
@@ -3,18 +3,15 @@
 It is important to set appropriate convergence criteria.  If the tolerances are too tight, models will never converge.  If the tolerances are too weak, models will yield incorrect answers.
 
 ##Global Nonlinear Convergence Criteria
-Regardless of whether plasticity or only elasticity is used, MOOSE needs to know what you mean by "converged".  You must place a tolerance on the nonlinear residual.  In TensorMechanics this comes from integrating $\nabla\sigma$ over an element, and for an element of side length $L$$ the integral cannot be less than
-
-$$
+Regardless of whether plasticity or only elasticity is used, MOOSE needs to know what you mean by "converged".  You must place a tolerance on the nonlinear residual.  In TensorMechanics this comes from integrating $\nabla \sigma$ over an element, and for an element of side length $L$ the integral cannot be less than
+\begin{equation}
 R > 10^{-P}L^{d-2}\sigma
-$$
-
+\end{equation}
 where $P$ is the precision of MOOSE (15 for double precision), $d$ is the dimensionality of the problem (TensorMechanics currently only works for $d=3$), and $\sigma$ is the rough size of stress.
 
 For example, for J2 plasticity, $\sigma$ will be roughly the yield strength of the material, say $10^6$.  For a element of size 0.1, this yields $R \sim 10^{-15}\times 0.1 \times 10^{6} = 10^{-10}$.
 
 However, you should set your nonlinear residual tolerance **substantially larger than this estimate**.  This is because error is likely to be spread over the entire mesh, not just one element, so $R$ should be multiplied by the number of elements, and also that setting $R$ this small is risky because it relies on maintaining full precision throughout all computations.
-
 Instead, identify the crucial region of interest.  Denote its volume by $V$.  Usually this will be less than the entire mesh.  Then identify the error in $\nabla\sigma$ that you are willing to accept.  Denote this by $E_{\nabla\sigma}$.  It will depend on the typical size of $\sigma$, and the length scale in the problem.  Then set $R = VE_{\nabla\sigma}$.
 
 
@@ -32,26 +29,21 @@ These are somewhat interconnected.
 Firstly, let us  explore lower bounds on the tolerance for the yield function(s).  Consider the stress tensor, $\sigma$.  I want to calculate $E_{\sigma}$: any changes of $\sigma$ smaller than $E_{\sigma}$ will be unnoticeable due to precision loss.   
 
 Imagine that $\sigma$ has $P$ digits of precision.  For standard MOOSE with double precision, $P=15$.  In models containing plasticity, the stress will often reside on the yield surface(s).  This gives an estimate of the magnitude of $\sigma$.  For instance, with Mohr-Coulomb plasticity, stresses will be of order $C\cot(\phi)$, where $C$ is the cohesion, and $\phi$ is the friction angle, so $C\cot(\phi)$ is at the apex of the hexagonal pyramid.  Denote this magnitude of $\sigma$ by $f$.  For complicated multi-surface plasticity models, $f$ may be hard to estimate, but only order-of-magnitude calculations are appropriate here.  Therefore,
-
-$$
+\begin{equation}
 E_{\sigma} = 10^{-P}f
-$$
-
+\end{equation}
 For example, with $P=15$, and Mohr-Coulomb plasticity with $C=10^{6}$ and friction angle 30deg, $E_{\sigma} = 10^{-9}$.  Changes of $\sigma$ smaller than this value will be unnoticeable due to precision loss.
 
 There is also another lower bound.  This comes from evaluating the trial stress and returned stress using the strain: $\sigma \sim C\epsilon$, where $C$ is the elasticity tensor, and $\epsilon$ is the strain.  This means that
-
-$$
+\begin{equation}
 E_{\sigma} = 10^{-P}C\epsilon
-$$
-
+\end{equation}
 For example, suppose strains of order $10^{-1}$ are applied, and the elasticity tensor is order $10^{10}$.  This means trial stresses will be of order $10^{9}$, so with $P=15$, we get $E_{\sigma} = 10^{-6}$.
 
 In conclusion, changes of $\sigma$ smaller than $E_{\sigma}$ will be unnoticeable due to precision loss, where $E_{\sigma}$ is
-
-$$
+\begin{equation}
 E_{\sigma} = 10^{-P}\max(f, C\epsilon)
-$$
+\end{equation}
 
 Knowing this allows straightforward estimation of the **lowest possible** tolerance on the yield functions.  **However, it is unwise to use this tolerance!**  This is because roundoff errors can accrue within the internal workings of the plasticity algorithms.  For instance, calculating eigenvalues of $\sigma$ might effectively reduce $P$ by 1.
 

--- a/docs/content/documentation/modules/tensor_mechanics/FractureIntegrals.md
+++ b/docs/content/documentation/modules/tensor_mechanics/FractureIntegrals.md
@@ -1,67 +1,58 @@
 #Fracture Integrals
 
-## $J$-integral
+## J-Integral
 A finite element calculation in which a crack is represented in the mesh geometry can be used to calculate the displacement and stress fields in the vicinity of the crack.  One straightforward way to evaluate the stress intensity from a finite element solution is through the $J$-integral \cite{rice_path_1968}, which provides the mechanical energy release rate. If the crack is subjected to pure mode-$I$ loading, $K_I$ can be calculated from $J$ using the following relationship:
-
-$$
+\begin{equation}
 J=
 \begin{cases}
 \frac{1-\nu^2}{E}K_I^2 & \text{plane strain}\\
 \frac{1}{E}K_I^2 & \text{plane stress}
 \end{cases}
-$$
-
+\end{equation}
 where $E$ is the Young's modulus and $\nu$ is the Poisson's ratio.
-
 The $J$-integral was originally formulated as an integral over a closed curve around the crack tip in 2D.  It can alternatively be expressed as an integral over a surface in 2D or a volume in 3D using the method of \cite{li_comparison_1985}, which is more convenient for implementation within a finite element code.
 
 Following the terminology of \cite{warp3d_17.3.1}, the integrated value of the $J$-integral over a segment of a crack front, represented as $\bar{J}$, can be expressed as a summation of four terms:
-
-$$
+\begin{equation}
 \bar{J}=\bar{J}_1+\bar{J}_2+\bar{J}_3+\bar{J}_4
-$$
-
+\end{equation}
 where the individual terms are defined as:
-
-$$
+\begin{equation}
 \bar{J}_1=\int_{V_0}\biggl(
 P_{ji}\frac{\partial u_i}{\partial X_k}\frac{\partial q_k}{\partial X_j}
 -W\frac{\partial q_k}{\partial X_k}
 \biggr) dV_0
-$$
+\end{equation}
 
-$$
+\begin{equation}
 \bar{J}_2=-\int_{V_0}\biggl(
 \frac{\partial W}{\partial X_k} -
 P_{ji}\frac{\partial^2u_i}{\partial X_j\partial X_k}
 \biggr) q_k dV_0
-$$
+\end{equation}
 
-$$
+\begin{equation}
 \bar{J}_3=-\int_{V_0}\biggl(
 T\frac{\partial q_k}{\partial X_k} -
 \rho \frac{\partial^2 u_i}{\partial t^2} \frac{\partial u_i}{\partial X_k} q_k +
 \rho \frac{\partial u_i}{\partial t} \frac{\partial^2 u_i}{\partial t \partial X_k} q_k
 \biggr) dV_0
-$$
+\end{equation}
 
-$$
+\begin{equation}
 \bar{J}_4=-\int_{A_0}
 t_i\frac{\partial u_i}{\partial X_k} q_k
 dA_0
-$$
-
+\end{equation}
 In these equations, $V_0$ is the undeformed volume, $A_0$ is the combined area of the two crack faces, $P_{ji}$ is the 1st Piola-Kirchoff stress tensor, $u_i$ is the displacement vector, $X_k$ is the undeformed coordinate vector, $W$ is the stress-work density, $T$ is the kinetic energy density, $t$ is time, $\rho$ is the material density, and $t_i$ is the vector of tractions applied to the crack face.
 
 The vector field $q_k$ is a vector field that is oriented in the crack normal direction. This field has a magnitude of 1 between the crack tip and the inner radius of the ring over which the integral is to be performed, and drops from 1 to 0 between the inner and outer radius of that ring, and has a value of 0 elsewhere. In 3D, $J$ is evaluated by calculating the integral $\bar{J}$ over a segment of the crack front. A separate $q$ field is formed for each
 segment along the crack front, and for each ring over which the integral is to be evaluated. Each of those $q$ fields is multiplied by a weighting function that varies from a value of 0 at the ends to a finite value in the middle of the segment. The value of $J$ at each point on the curve is evaluated by dividing $\bar{J}$ by the integrated value of the weighting function over the segment containing that point.
 
 The first term in $\bar{J}$, $\bar{J}_1$, represents the effects of strain energy in homogeneous material in the absence of thermal strains or inertial effects. The second term, $\bar{J}_2$, accounts for the effects of material inhomogenieties and gradients of thermal strain.  For small strains, this term can be represented as:
-
-$$
+\begin{equation}
 \bar{J}_2 = \int_{V_0} \sigma_{ij} \left [ \alpha_{ij} \frac{\partial \bar{\theta}}{\partial X_k} + \frac{\partial \alpha_{ij}}{\partial X_k} \bar{\theta} \right] q_k dV_0
-$$
-
+\end{equation}
 where $\sigma_{ij}$, $\alpha_{ij}$ and $\bar{\theta}$ are the Cauchy stress, thermal conductivity, and difference between the current temperature and a reference temperature, respectively.
 
 The third term in $\bar{J}$, $\bar{J}_3$, accounts for inertial effects in a dynamic analysis, and the fourth term, $\bar{J}_4$ accounts for the effects of surface tractions on the crack face.
@@ -69,54 +60,52 @@ The third term in $\bar{J}$, $\bar{J}_3$, accounts for inertial effects in a dyn
 The MOOSE implementation of the $J$-integral calculator can be used for arbitrary curved 3D crack fronts, and includes the $\bar{J}_1$ and $\bar{J}_2$ terms to account for the effects of quasistatic mechanically and thermally induced strains. The last two terms have not been implemented. For quasistatic loading conditions, there are no inertial effects, so $\bar{J}_3=0$. $\bar{J}_4$ would be nonzero for pressurized cracks, and should be implemented in the future to consider such cases.
 
 Pointwise values $J(s)$ are calculated from the $J$-integral over a crack front segment $\bar{J}$ using the expression
-
-$$
-J(s) = \frac{\bar{J}(s)}{\int q(s) ds}.
-$$
-
+\begin{equation}
+J(s) = \frac{\bar{J}(s)}{\int q(s) ds}
+\end{equation}
 To use the $J$-integral capability in MOOSE, a user specifies a set of nodes along the crack front, information used to calculate the crack normal directions along the crack front, and the inner and outer radii of the set of rings over which the integral is to be performed. The code automatically defines the full set of $q$ functions for each point along the crack front, and outputs either the value of $J$ or $K_I$ at each of those points. In addition, the user can ask for any other variable in the model to be output at points corresponding to those where $J$ is evaluated along the crack front.
 
-## Interaction integral
+## Interaction Integral
 
 The interaction integral method is based on the $J$-integral and makes it possible to evaluate mixed-mode stress intensity factors $K_I$, $K_{II}$ and $K_{III}$, as well as the T-stress, in the vicinity of three-dimensional cracks. The formulation relies on superimposing Williams' solution for stress and displacement around a crack (in this context called 'auxiliary fields') and the computed finite element stress and displacement fields (called 'actual fields'). The total superimposed $J$ can be separated into three parts: the $J$ of the actual fields, the $J$ of the auxiliary fields, and an interaction part containing the terms with both actual and auxiliary field quantities. The last part is called the interaction integral and for a fairly straight crack without body forces, thermal loading or crack face tractions, the interaction integral over a crack front segment can be written \cite{walters_interaction_2005}:
-
-$$
-\bar{I}(s) = \int_V \left[ \sigma_{ij} u_{j,1}^{\mbox{aux}} + \sigma_{ij}^{\mbox{aux}} u_{j,1} - \sigma_{jk} \epsilon_{jk}^{\mbox{aux}} \delta_{1i} \right] q_{,i} \, \mathrm{d}V
-$$
-
+\begin{equation}
+\bar{I}(s) = \int_V \left[ \sigma_{ij} u_{j,1}^{(aux)} + \sigma_{ij}^{(aux)} u_{j,1} - \sigma_{jk} \epsilon_{jk}^{(aux)} \delta_{1i} \right] q_{,i} \, \mathrm{d}V
+\end{equation}
 where $\sigma$ is the stress, $u$ is the displacement, and $q$ is identical to the $q$-functions used for $J$-integrals. This is the formulation of the interaction integral used currently in MOOSE. It is not recommended to use the interaction integral method in analyses where body forces or crack face tractions are important, as the code does not include the necessary correction terms in the integral.
 
 In the same way as for the $J$-integral, the pointwise value $I(s)$ at location $s$ is obtained from $\bar{I}(s)$ using:
-
-$$
-I(s) = \frac{\bar{I}(s)}{\int q(s) \mathrm{d}s}.
-$$
-
+\begin{equation}
+I(s) = \frac{\bar{I}(s)}{\int q(s) \mathrm{d}s}
+\end{equation}
 Next, we relate the interaction integral $I(s)$ to stress intensity factors. By writing $J^S$, with actual and auxiliary fields superimposed, in terms of the mixed-mode stress intensity factors
-
-$$
-J^S(s) = \frac{1-\nu^2}{E} \left[ \left( K_I+ K_I^{\mbox{aux}} \right)^2 + \left( K_{II} + K_{II}^{\mbox{aux}} \right)^2 \right] + \frac{1+\nu}{E} \left( K_{III}+ K_{III}^{\mbox{aux}} \right)^2
-= J(s) + J^{\mbox{aux}}(s) + I(s)
-$$
-
+\begin{equation}
+\begin{aligned}
+J^S(s) &= \frac{1-\nu^2}{E} \left[ \left( K_I+ K_I^{(aux)} \right)^2 + \left( K_{II} + K_{II}^{(aux)} \right)^2 \right] \\
+&+ \frac{1+\nu}{E} \left( K_{III}+ K_{III}^{(aux)} \right)^2 \\
+& = J(s) + J^{(aux)}(s) + I(s)
+\end{aligned}
+\end{equation}
 the interaction integral part evaluates to
-
-$$
-I(s) = \frac{1-\nu^2}{E} \left( 2 K_I K_I^{\mbox{aux}} + 2 K_{II} K_{II}^{\mbox{aux}} \right) + \frac{1+\nu}{E} \left( K_{III} K_{III}^{\mbox{aux}} \right)
-$$
-
-To obtain individual stress intensity factors, the interaction integral is evaluated with different auxiliary fields. For instance, by choosing $K_I^{\mbox{aux}} = 1.0$ and $K_{II}^{\mbox{aux}} = K_{III}^{\mbox{aux}} = 0$ and computing the volume integral $I(s)$ over the actual and auxiliary fields, $K_I$ can be solved for.
+\begin{equation}
+\begin{aligned}
+I(s) &= \frac{1-\nu^2}{E} \left( 2 K_I K_I^{(aux)} + 2 K_{II} K_{II}^{(aux)} \right) \\
+& + \frac{1+\nu}{E} \left( K_{III} K_{III}^{(aux)} \right)
+\end{aligned}
+\end{equation}
+To obtain individual stress intensity factors, the interaction integral is evaluated with different auxiliary fields. For instance, by choosing $K_I^{(aux)} = 1.0$ and $K_{II}^{(aux)} = K_{III}^{(aux)} = 0$ and computing the volume integral $I(s)$ over the actual and auxiliary fields, $K_I$ can be solved for.
 
 If all three interaction integral stress intensity factors are computed, there is an option to output an equivalent stress intensity factor computed by:
-
-$$
+\begin{equation}
 K_{eq} = \sqrt{ K_I^2 + K_{II}^2 + \frac{K_{III}^2}{1-\nu}}.
-$$
-
+\end{equation}
 The $T$-stress is the first second-order parameter in Williams' expansion of stress at a crack tip and is a constant stress parallel to the crack \cite{larsson_influence_1973}, \cite{rice_limitations_1974}. Contrary to $J$, $T$-stress depends on geometry and size and can give a more accurate description of the stresses and strains around a crack tip than $J$ alone. The $T$-stress characterizes the crack-tip constraint and a negative $T$-stress is associated with loss of constraint and a higher fracture toughness than would be predicted from a one-parameter $J$ description of the load on the crack. $T$-stresses can be calculated with the interaction integral methodology using appropriate auxiliary fields \cite{toshio_determination_1992}. The current implementation of the $T$-stress computation is valid for two-dimensional and three-dimensional cracks under Mode I loading.
 
 ## Usage
 
-The MOOSE implementation of the capability to compute these fracture integrals is provided using a variety of MOOSE objects, which are quite complex to define manually, especially for 3D simulations. For this reason, the to compute $J$-integrals or interaction integrals, the [DomainIntegralAction](/DomainIntegralAction.md) should be used to set up all of the required objects.
+The MOOSE implementation of the capability to compute these fracture integrals is provided using a variety of MOOSE objects, which are quite complex to define manually, especially for 3D simulations. For this reason, the to compute $J$-integrals or interaction integrals, the [DomainIntegral Action](/DomainIntegralAction.md) should be used to set up all of the required objects.
+
+!listing modules/tensor_mechanics/test/tests/j_integral/j_integral_3d.i block=DomainIntegral
+
+##References
 
 \bibliography{tensor_mechanics.bib}

--- a/docs/content/documentation/modules/tensor_mechanics/Strains.md
+++ b/docs/content/documentation/modules/tensor_mechanics/Strains.md
@@ -6,59 +6,51 @@ The tensor mechanics module offers three different types of strain calculation: 
 For linear elasticity problems, the Tensor Mechanics module includes a small strain and total strain material [ComputeSmallStrain](/ComputeSmallStrain.md).  This material is useful for verifying material models with hand calculations because of the simplified strain calculations.
 
 Linearized small strain theory assumes that the gradient of displacement with respect to position is much smaller than unity, and the squared displacement gradient term is neglected in the small strain definition to give:
-
-$$
+\begin{equation}
 \epsilon = \frac{1}{2} \left( u \nabla + \nabla u \right) \quad when \quad \frac{\partial u}{ \partial x} << 1
-$$
-
+\end{equation}
 For more details on the linearized small strain assumption and derivation, see a Continuum Mechanics text such as Malvern (1969) or [Bower(2012)](http://solidmechanics.org/Text/Chapter2_1/Chapter2_1.php#Sect2_1_7).
 
 Total strain theories are path independent: in MOOSE, path independence means that the total strain, from the beginning of the entire simulation, is used to calculate stress and other material properties.  Incremental theories, on the other hand, use the increment of strain at timestep to calculate stress.  Because the total strain formulation `ComputeSmallStrain` is path independent, no old values of strain or stress from the previous timestep are stored in MOOSE.  For a comparison of total strain vs incremental strain theories with experimental data, see [Shammamy and Sidebottom (1966)](http://link.springer.com/article/10.1007/BF02326324).
 
 The input file syntax for small strain is
 
-!listing modules/tensor_mechanics/tutorials/basics/part_1.1.i start=strain
+!listing modules/tensor_mechanics/tutorials/basics/part_1.1.i block=Modules/TensorMechanics/Master
 end=stress
 
 ##Incremental Small Strains
 Applicable for small linearized strains, MOOSE includes an incremental small strain material, [ComputeIncrementalSmallStrain](/ComputeIncrementalSmallStrain.md).  As in the small strain material, the incremental small strain class assumes the gradient of displacement with respect to position is much smaller than unity, and the squared displacement gradient term is neglected in the small strain definition to give:
-
-$$
+\begin{equation}
 \epsilon = \frac{1}{2} \left( u \nabla + \nabla u \right) \quad when \quad \frac{\partial u}{ \partial x} << 1
-$$
-
+\end{equation}
 As the class name suggests, `ComputeIncrementalSmallStrain` is an incremental formulation.  The stress increment is calculated from the current strain increment at each time step.  In this class, the rotation tensor is defined to be the rank-2 Identity tensor: no rotations are allowed in the model. Stateful properties, including `strain_old` and `stress_old`, are stored. This incremental small strain material is useful as a component of verifying more complex finite incremental strain-stress calculations.
 
 The input file syntax for incremental small strain is
 
-!listing modules/tensor_mechanics/test/tests/thermal_expansion/constant_expansion_coeff.i start=small_strain end=small_stress
+!listing modules/tensor_mechanics/test/tests/thermal_expansion/constant_expansion_coeff.i block=Modules/TensorMechanics
 
 
 ##Finite Large Strains
 For finite strains, use [ComputeFiniteStrain](/ComputeFiniteStrain.md) in which an incremental form is employed such that the strain_increment and rotation_increment are calculated.
 The finite strain mechanics approach used in the MOOSE tensor_mechanics module is the incremental corotational form from [Rashid 1993](http://onlinelibrary.wiley.com/doi/10.1002/nme.1620362302/abstract). In this form, the generic time increment under consideration is such that $t \in [t_n, t_{n+1}]$. The configurations of the material element under consideration at $t = t_n$ and $t = t_{n+1}$ are denoted by $\kappa_n$, and $\kappa_{n + 1}$, respectively. The incremental motion over the time increment is assumed to be given in the form of the inverse of the deformation gradient $\hat{\mathbf{F}}$ of $\kappa_{n + 1}$ with respect to $\kappa_n$, which may be written as
-
-$$
+\begin{equation}
 \hat{\mathbf{F}}^{-1} = 1 - \frac{\partial \hat{\mathbf{u}}}{\partial \mathbf{x}},
-$$
-
+\end{equation}
 where $\hat{\mathbf{u}}(\mathbf{x})$ is the incremental displacement field for the time step, and $\mathbf{x}$ is the position vector of materials points in $\kappa_{n+1}$. Note that $\hat{\mathbf{F}}$ is NOT the deformation gradient, but rather the incremental deformation gradient of $\kappa_{n+1}$ with respect to $\kappa_n$. Thus, $\hat{\mathbf{F}} = \mathbf{F}_{n+1} \mathbf{F}_n^{-1}$, where $\mathbf{F}_n$ is the total deformation gradient at time $t_n$.
-
 For this form, we assume
-$$
-\begin{eqnarray}
-\dot{\mathbf{F}} \mathbf{F}^{-1} &=& \mathbf{D}\ \mathrm{(constant\ and\ symmetric),\ } t_n<t<t_{n+1}\\
-\mathbf{F}(t^{-}_{n+1}) &=& \hat{\mathbf{U}}\ \mathrm{(symmetric\ positive\ definite)}\\
-\mathbf{F}(t_{n+1}) &=& \hat{\mathbf{R}} \hat{\mathbf{U}} = \hat{\mathbf{F}}\ (\hat{\mathbf{R}}\ \mathrm{proper\ orthogonal})
-\end{eqnarray}
-$$
-
+\begin{equation}
+\begin{aligned}
+\dot{\mathbf{F}} \mathbf{F}^{-1} =& \mathbf{D}\ \mathrm{(constant\ and\ symmetric),\ } t_n<t<t_{n+1}\\
+\mathbf{F}(t^{-}_{n+1}) =& \hat{\mathbf{U}}\ \mathrm{(symmetric\ positive\ definite)}\\
+\mathbf{F}(t_{n+1}) =& \hat{\mathbf{R}} \hat{\mathbf{U}} = \hat{\mathbf{F}}\ (\hat{\mathbf{R}}\ \mathrm{proper\ orthogonal})
+\end{aligned}
+\end{equation}
 In `ComputeFiniteStrain`, $\hat{\mathbf{F}}$ is calculated in the computeStrain method, including a volumetric locking correction of
-$$
+\begin{equation}
 \hat{\mathbf{F}}_{corr} = \hat{\mathbf{F}} \left( \frac{|\mathrm{av}_{el}(\hat{\mathbf{F}})|}{|\hat{\mathbf{F}}|} \right)^{\frac{1}{3}},
-$$
+\end{equation}
 where $\mathrm{av}_{el}()$ is the average value for the entire element. The strain increment and the rotation increment are calculated in `computeQpStrain()`. Once the strain increment is calculated, it is added to the total strain from $t_n$. The total strain from $$t_{n+1}$$ must then be rotated using the rotation increment.
 
 The input file syntax for a finite incremental strain material is
 
-!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i start=strain end=stress
+!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i block=Modules/TensorMechanics

--- a/docs/content/documentation/modules/tensor_mechanics/StressDivergence.md
+++ b/docs/content/documentation/modules/tensor_mechanics/StressDivergence.md
@@ -2,9 +2,12 @@
 
 Within the tensor mechanics module, we have three separate ways to calculate the strain and stress:
 
-1. Linearized elasticity total small strain problems: use [ComputeSmallStrain](/ComputeSmallStrain.md) and [ComputeLinearElasticStress](/ComputeLinearElasticStress.md)
-2. Linearized elasticity incremental small strain: use [ComputeIncrementalSmallStrain](/ComputeIncrementalSmallStrain.md) and [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md)
-3. Large deformation problems, including elasticity and/or plasticity: use [ComputeFiniteStrain](/ComputeFiniteStrain.md) and [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md)
+!table id=strain_formulations caption=Consistent Strain and Stress Formulations
+| Theoretical Formulation                           | Tensor Mechanics Classes    |
+|---------------------------------------------------|-----------------------------|
+| Linearized elasticity total small strain problems | [ComputeLinearElasticStress](/ComputeLinearElasticStress.md) and [ComputeSmallStrain](/ComputeSmallStrain.md) (in the Tensor Mechanics master action use the argument `strain = SMALL`) |
+| Linearized elasticity incremental small strain    | [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md) and [ComputeIncrementalSmallStrain](/ComputeIncrementalSmallStrain.md) (in the Tensor Mechanics master action `strain = SMALL` and `incremental = true` )|
+| Large deformation problems, including elasticity and/or plasticity | [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md), or other inelastic stress material class, and [ComputeFiniteStrain](/ComputeFiniteStrain.md) (in the Tensor Mechanics master action use `strain = FINITE`) |
 
 The linearized elasticity problems are calculated on the reference mesh.  In the linearized elasticity total small strain formulation, [ComputeSmallStrain](/ComputeSmallStrain.md) a rotation increment is not used; in [ComputeIncrementalSmallStrain](/ComputeIncrementalSmallStrain.md) the rotation increment is defined as the identity tensor.  Both the total small strain and the incremental small strain classes pass to the stress divergence kernel a stress calculated on the reference mesh ( $ \sigma(X) $ ).
 
@@ -12,22 +15,23 @@ In the third set of the plug-and-play tensor mechanics classes, the large deform
 
 As users and developers, we must take care to ensure consistency in the mesh used to calculate the strain and stress and the mesh used to calculate the residual from the stress divergence equation.  In the [StressDivergenceTensors](/StressDivergenceTensors.md) kernel, or the various stress divergence actions, the parameter `use_displaced_mesh` is used to determine if the deformed or the reference mesh should be used:
 
-| Simulation Formulation | Governing Equation Form  | Correct Kernel Parameter | Mesh Configuration Used |
+!table id=governing_equation_mesh_formulation caption=Stress Divergence Governing Equation and Mesh Configuration Correspondence
+| Simulation Formulation | Governing Equation  | Correct Kernel Parameter | Mesh Configuration |
 | - | - | - | - |
-| Linearized Elasticity | $ \nabla_X \cdot \sigma (X) $ | `use_displaced_mesh = false` | Reference (undeformed) mesh |
-| Large Deformation (Elasticity and Plasticity) | $ \nabla_x \cdot \sigma (x) $ | `use_displaced_mesh = true ` | Deformed (current) mesh |
+| Linearized Elasticity | $ \nabla_X \cdot \sigma (X) = 0 $ | `use_displaced_mesh = false` | Reference mesh (undeformed) |
+| Large Deformation (both Elasticity and Inelasticity) | $ \nabla_x \cdot \sigma (x) = 0 $ | `use_displaced_mesh = true ` | Deformed mesh (current)  |
 
 In the stress divergence kernel, nabla is given by the gradients of the test functions, and the mesh, to which the gradients are taken with respect to, is determined by the `use_displaced_mesh` parameter setting.  A source of confusion can be that the `use_displaced_mesh` parameter is not used in the materials, which compute strain and stress, but this parameter does play a large role in the calculations of the stress divergence kernel.
 
-!!! info
-    The `use_displaced_mesh` parameter must be set correcting to ensure consistency in the equilibrium equation:  if the stress is calculated with respect to the deformed mesh, the test function gradients must also be calculated with respect to the deformed mesh.
+!!! info "Use of the Tensor Mechanics Master Action Recommended"
+    The `use_displaced_mesh` parameter must be set correcting to ensure consistency in the equilibrium equation:  if the stress is calculated with respect to the deformed mesh, the test function gradients must also be calculated with respect to the deformed mesh. The Tensor Mechanics master action is designed to automatically determine and set the flag for the `use_displaced_mesh` parameter correctly for the selected strain formulation.
+    We recommend that users employ the Tensor Mechanics master action whenever possible to ensure consistency between the test function gradients and the strain formulation selected.
 
 Small strain linearized elasticity problems should be run with the parameter `use_displaced_mesh = false` in the kernel to ensure all calculations across all three classes (strain, stress, and kernel) are computed with respect to the reference mesh.
 
-!listing modules/tensor_mechanics/tutorials/basics/part_1.1.i block=Kernels
+!listing modules/tensor_mechanics/tutorials/basics/part_1.1.i block=Modules/TensorMechanics/Master
 
-!!! important
-    Large deformation problems should be run with the parameter setting `use_displaced_mesh = true` in the kernel so that the kernel and the materials all compute variables with respect to the deformed mesh.
+Large deformation problems should be run with the parameter setting `use_displaced_mesh = true` in the kernel so that the kernel and the materials all compute variables with respect to the deformed mesh.
 
 The input file syntax to set the Stress Divergence kernel for large deformation (finite strain) problems is
 

--- a/docs/content/documentation/modules/tensor_mechanics/Stresses.md
+++ b/docs/content/documentation/modules/tensor_mechanics/Stresses.md
@@ -2,43 +2,44 @@
 
 ## Some Identities involving the Stress Tensor
 Denote the stress tensor by $\sigma_{ij}$.  Assume it is symmetric.  A useful quantity, called the "mean stress", is
-$$
-\sigma_{m} = \mbox{Tr}\sigma/3 = \sigma_{ii}/3 \ .
-$$
+\begin{equation}
+\sigma_{m} = Tr\left( \sigma/3 \right) = \sigma_{ii}/3 \ .
+\end{equation}
 Another useful quantity is the traceless part of $\sigma$, which is called the deviatoric stress, denoted by $s_{ij}$:
-$$
+\begin{equation}
 s_{ij} = \sigma_{ij} - \delta_{ij}\sigma_{m} = \sigma_{ij} - \delta_{ij}\sigma_{kk}/3 \ .
-$$
+\end{equation}
 In many calculations it is useful to use the invariants of $s$, which are
-$$
-\begin{array}{rcl}
-J_{2} & = & \frac{1}{2}s_{ij}s_{ij} \ , \\
-J_{3} & = & \mbox{det}s \ .
-\end{array}
-$$
+\begin{equation}
+\begin{aligned}
+J_1 = & Tr\left( s_{kk} \right) \\
+J_{2} = & \frac{1}{2}s_{ij}s_{ij} \\
+J_{3} = & det \left(s \right)
+\end{aligned}
+\end{equation}
 Clearly $J_{2} \geq 0$, and
 often the square-root of $J_{2}$ is written as:
-$$
-\bar{\sigma} = \sqrt{J_{2}} \ .
-$$
+\begin{equation}
+\bar{\sigma} = \sqrt{J_{2}}
+\end{equation}
 Alternative forms for $J_{3}$ are
-$$
-\begin{array}{rcl}
-J_{3} & = & \mbox{det}s \\
-& = & \frac{1}{6}\epsilon_{ijk}\epsilon_{mnp}s_{im}s_{jn}s_{kp} \\
-& = & \frac{1}{3}s_{ij}s_{jk}s_{ki}
-\end{array}
-$$
+\begin{equation}
+\begin{aligned}
+J_{3} = & det \left(s \right)\\
+      = & \frac{1}{6}\epsilon_{ijk}\epsilon_{mnp}s_{im}s_{jn}s_{kp} \\
+      = & \frac{1}{3}s_{ij}s_{jk}s_{ki}
+\end{aligned}
+\end{equation}
 All scalar functions of the stress tensor can be written in terms of its invariants.  For instance,
-$$
+\begin{equation}
 s_{ij}s_{jk}s_{kl}s_{li} = 2J_{2}^{2}
-$$
+\end{equation}
 
 ## Elasticity
 Elastic materials do not experience permanent deformation, and all elastic strain and elastic stress is recoverable.  Elastic stress is related to elastic strain through the elasticity tensor
-$$
+\begin{equation}
 \sigma_{ij} = C_{ijkl} \epsilon_{kl}
-$$.
+\end{equation}
 The two simplified elastic stress materials in Tensor Mechanics are
 
 1. [ComputeLinearElasticStress](/ComputeLinearElasticStress.md) for small total strain formulations, and
@@ -50,13 +51,13 @@ This approach to modeling plasticity problems uses as stress material to call se
 
 ### MultiSurface Plasticity
 In MOOSE, multi-surface plasticity is implemented through the [ComputeMultiPlasticityStress](/ComputeMultiPlasticityStress.md) Material. This assumes that there is exactly one internal parameter per single-surface plasticity model, and that the functions for single-surface plasticity model depend only on its internal parameter: there must not be 2 or more internal parameters per single-surface plasticity model.)  In this case
-$$
+\begin{equation}
 \begin{array}{rcll}
 f_{\alpha} & = & f_{\alpha}(\sigma, q_{\alpha}) & \text{yield functions} \\
 r^{\alpha}_{ij} & = & r^{\alpha}_{ij}(\sigma, q_{\alpha}) & \text{flow potentials} \\
 h^{\alpha}_{a} & = & \delta^{\alpha}_{a}h^{\alpha}(\sigma, q_{\alpha} & \text{hardening potentials})
 \end{array}
-$$
+\end{equation}
 where there is no sum on $\alpha$.
 
 The Newton-Raphson procedure attempts to solve three types of equation:
@@ -79,11 +80,9 @@ The `UserObject` based crystal plasticity system is designed to facilitate the i
 
 ### Hyperelastic Viscoplastic
 The Hyperelastic Viscoplastic model is based on the multiplicative decomposition of the total deformation ($\underline{F}$) gradient into an elastic ($\underline{F}^e$) and viscoplastic ($\underline{F}^{vp}$) component. The viscoplastic component of deformation is evolved in the intermediate configuration following
-
-$$
+\begin{equation}
 \dot{\underline{F}}^{vp}\underline{F}^{vp-1} = \sum_{i=1}^{N} \dot{\lambda^i}\underline{r}^i
-$$
-
+\end{equation}
 where $\dot{\lambda^i}$ and $\underline{r}^i$ are the flow rate and flow directions, respectively, and, $N$ is the number of flow rates. This representation allows different flow rates and directions to be superimposed to obtain an effective viscoplastic deformation of the material.
 
 
@@ -108,13 +107,13 @@ For **isotropic materials** the radial return approach offers distinct advantage
 
 
 The stress update materials each individually calculate, using the [Newton Method](http://mathworld.wolfram.com/NewtonsMethod.html), the amount of effective inelastic strain required to return the stress state to the yield surface.
-$$
+\begin{equation}
 \Delta p^{(t+1)} = \Delta p^t + d \Delta p
-$$
+\end{equation}
 where the change in the iterative effective inelastic strain is defined as the yield surface over the derivative of the yield surface with respect to the inelastic strain increment. In the case of isotropic linear hardening plasticity, with the hardening function $$ r = hp$$, the effective plastic strain increment has the form:
-$$
+\begin{equation}
  d \Delta p = \frac{\sigma^{trial}_{effective} - 3 G \Delta p - r - \sigma_{yield}}{3G + h}
-$$
-where G is the isotropic shear modulus, and $\sigma^{trial}_{effective}$ is the scalar von Mises trial stress.
+\end{equation}
+where $G$ is the isotropic shear modulus, and $\sigma^{trial}_{effective}$ is the scalar von Mises trial stress.
 
 When more than one stress update material is included in the simulation `ComputeMultipleInelasticStress` will iterate over the change in the calculated stress until the return stress has reached a stable value.

--- a/docs/content/documentation/modules/tensor_mechanics/VisualizingTensors.md
+++ b/docs/content/documentation/modules/tensor_mechanics/VisualizingTensors.md
@@ -1,54 +1,23 @@
-#Visualization of stresses and strains and other tensor components
+#Visualization of Tensor Components
 
-To visualize stresses, strains, and elasticity tensor components, the material objects must be outputted to auxiliary variables using auxiliary kernels available. RankTwoAux is used to output a RankTwoTensor component, and RankFourAux is used to output a RankFourTensor component.  For example, $\sigma_{11}, \epsilon_{22}$, and $C_{1122}$ can be visualized by first declaring auxiliary variables for them in the input file:
+To visualize stresses, strains, and elasticity tensor components, the material objects must be outputted to auxiliary variables using auxiliary kernels available. RankTwoAux is used to output a RankTwoTensor component, and RankFourAux is used to output a RankFourTensor component.  For example, $\sigma_{11}, \epsilon_{22}$, and $C_{1122}$ can be visualized by first declaring auxiliary variables for them in the input file.
 
-```
-    [AuxVariables]
-      [./s11_aux]
-        order = CONSTANT
-        family = MONOMIAL
-      [../]
+Stress $\sigma_{xx}$ component:
+!listing modules/combined/test/tests/eigenstrain/inclusion.i block=AuxVariables/s11_aux
 
-      [./e22_aux]
-        order = CONSTANT
-        family = MONOMIAL
-      [../]
+Strain $\epsilon_{yy}$ component:
+!listing modules/combined/test/tests/eigenstrain/variable.i block=AuxVariables/e22_aux
 
-      [./C1122_aux]
-        order = CONSTANT
-        family = MONOMIAL
-      [../]
-    []
-```
- 
-Next, the appropriate auxiliary kernels are used.  They require the name of the material property that you wish to see the field value for, and the indices of the tensor value (either 0, 1, or 2).  For example, 
+Elasticity Tensor $C_{1133}$ component:
+!listing modules/combined/test/tests/elasticitytensor/composite.i block=AuxVariables/C1133_aux
 
-```
-    [AuxKernels]
-      [./report_s11]
-        type = RankTwoAux
-        rank_two_tensor = stress      # this is the name of the material property
-        index_i = 0                   # this is the first index, i, from 0 to 2
-        index_j = 0                   # this is the 2nd index, j, from 0 to 2
-        variable = s11_aux            # auxilliary variable declared previously
-      [../]
+Next, the appropriate auxiliary kernels are used.  These elements require the name of the material property of which you wish to see the field value and the indices of the tensor value (either 0, 1, or 2) in addition to the name of the output AuxVariable.  The corresponding AuxKernels blocks for each of the AuxVariables are given below.
 
-      [./report_e22]
-        type = RankTwoAux
-        rank_two_tensor = elastic_strain
-        index_i = 1
-        index_j = 1
-        variable = e22_aux
-      [../]
+Stress $\sigma_{xx}$ component:
+!listing modules/combined/test/tests/eigenstrain/inclusion.i block=AuxKernels/matl_s11
 
-      [./report_C1122]
-        type = RankFourAux
-        rank_four_tensor = elasticity_tensor
-        index_i = 0
-        index_j = 0
-        index_k = 1
-        index_l = 1
-        variable = C1122_aux
-      [../]
-    []
-```
+Strain $\epsilon_{yy}$ component:
+!listing modules/combined/test/tests/eigenstrain/variable.i block=AuxKernels/matl_e22
+
+Elasticity Tensor $C_{1133}$ component:
+!listing modules/combined/test/tests/elasticitytensor/composite.i block=AuxKernels/matl_C1133

--- a/docs/content/documentation/modules/tensor_mechanics/VolumetricLocking.md
+++ b/docs/content/documentation/modules/tensor_mechanics/VolumetricLocking.md
@@ -1,60 +1,52 @@
-#Volumetric locking correction
+#Volumetric Locking Correction
 
 Volumetric locking is the over stiffening of elements when the material is close to being incompressible (Poisson's ratio $\nu$ nearing 0.5). This happens when a fully integrated element (such as Hex8 elements with 8 quadrature points or Quad4 elements with 4 quadrature points) is used. This is a numerical artifact introduced because shape functions used in finite element analysis cannot properly approximate the incompressibility condition throughout the element. To avoid this locking of elements, B-bar correction \citep{hughes1987finite} is implemented in MOOSE.
 
+## Theory
 In this method, both the strain ($\epsilon$) and the virtual strain ($\delta \epsilon$) in an element are separated into volumetric and deviatoric components. The volumetric component is then replaced with an element averaged volumetric strain. This ensures that the volumetric strain remains constant throughout the element.
 
 For example, in the case of small strain linear elasticity, the equation of motion is:
-
-$$
+\begin{equation}
 \begin{aligned}
 \int_V \sigma(\epsilon)\delta \epsilon dV - \int_V b \delta v dV - \int_{\partial V} t \delta v dA = 0
 \end{aligned}
-$$
-
+\end{equation}
 The element averaged volumetric strain (assuming small strain formulation) is:
-
-$$
+\begin{equation}
 \begin{aligned}
  w=\frac{1}{V_e} \int_{V_e} \frac{1}{3} tr(\epsilon) dV,
 \end{aligned}
-$$
-
+\end{equation}
 where $V_e$ is the volume of the element and tr(.) is the trace of the matrix.
 
 The strain in each element is replaced by the approximation:
-
-$$
+\begin{equation}
 \begin{aligned}
-\bar{\epsilon} = \epsilon +(w - \frac{tr(\epsilon)}{3})I,
+\bar{\epsilon} = \epsilon +(w - \frac{tr(\epsilon)}{3})I
 \end{aligned}
-$$
-
+\end{equation}
 where $I$ is the $3 \times 3$ identity matrix. Similarly, the virtual strain is also approximated by:
-
-$$
+\begin{equation}
 \begin{aligned}
 \bar{\delta \epsilon} = \delta \epsilon + (\delta w - \frac{tr(\delta \epsilon)}{3})I
 \end{aligned}
-$$
-
+\end{equation}
 The modified equation of motion is:
-$$
+\begin{equation}
 \begin{aligned}
 \int_V \sigma(\bar{\epsilon})\bar{\delta \epsilon} dV - \int_V b \delta v dV - \int_{\partial V} t \delta v dA = 0
 \end{aligned}
-$$
-
+\end{equation}
 More details about this method can be found in section 8.6 of \citet{bower2009applied}.
 
 When finite strain formulation is used, the volumetric component of the strain is separated using the determinant of the deformation matrix.
 
-### Usage
-
-Volumetric locking correction is set to false by default in tensor mechanics. When dealing with problems involving plasticity or incompressible materials, it can be turned on by setting `volumetic_locking_correction=true` in both the stress divergence kernel (or TensorMechanicsAction) and the strain calculator. It can also be turned on by setting `volumetric_locking_correction=true` in the GlobalParams.
+## Usage
+Volumetric locking correction is set to false by default in tensor mechanics. When dealing with problems involving plasticity or incompressible materials, it can be turned on by setting `volumetric_locking_correction=true` in both the stress divergence kernel and the strain calculator or in the Tensor Mechanics master action.
 
 When volumetric locking correction is turned on, using a SMP preconditioner with coupled displacement variables may help with convergence. For a 3-D problem with only displacement as unknown variables, the following pre-conditioner block may be used:
 
 !listing modules/tensor_mechanics/test/tests/finite_strain_elastic/elastic_rotation_test.i start=Preconditioning end=Executioner
 
+## References
 \bibliography{tensor_mechanics.bib}

--- a/docs/content/documentation/modules/tensor_mechanics/common/supplementalAxisymmetricRZStrain.md
+++ b/docs/content/documentation/modules/tensor_mechanics/common/supplementalAxisymmetricRZStrain.md
@@ -7,18 +7,17 @@ Axisymmetric (cylindrical) materials are included in Tensor Mechanics for revolv
 
 The axisymmetric model employs the cylindrical coordinates, $r$, $z$, and $\theta$, where the planar cross section is rotated about the $z$ axis.  The cylindrical coordinate system strain tensor for axisymmetric problems has the form
 
-$$
+\begin{equation}
 \begin{bmatrix}
 \epsilon_{rr} & \epsilon_{rz} & 0 \\
 \epsilon_{zr} & \epsilon_{zz} & 0 \\
 0 & 0 & \epsilon_{\theta \theta}
 \end{bmatrix}
-$$
-
+\end{equation}
 where the value of the strain $\epsilon_{\theta \theta}$ depends on the displacement and position in the radial direction
-$$
+\begin{equation}
 \epsilon_{\theta \theta} = \frac{u_r}{X_r}.
-$$
+\end{equation}
 Although axisymmetric problems solve for 3D stress and strain fields, the problem is mathematically 2D. Using an appropriate set of geometry and boundary conditions, these types of problems have strain and stress fields which are not functions of the out of plane coordinate variable.  In the Cylindrical coordinate axisymmetric system, the values of stress and strain in the $\theta$ direction do not depend on the $\theta$ coordinate.
 
 !!! note

--- a/docs/content/documentation/modules/tensor_mechanics/common/supplementalRadialReturnStressUpdate.md
+++ b/docs/content/documentation/modules/tensor_mechanics/common/supplementalRadialReturnStressUpdate.md
@@ -1,14 +1,12 @@
 In this numerical approach, a trial stress is calculated at the start of each simulation time increment; the trial stress calculation assumed all of the new strain increment is elastic strain:
-$$
+\begin{equation}
 \sigma_{trial} = C_{ijkl} \left( \Delta \epsilon_{assumed-elastic} + \epsilon_{elastic}^{old} \right)
-$$
-
+\end{equation}
 The algorithms checks to see if the trial stress state is outside of the yield surface, as shown in the figure to the right. If the stress state is outside of the yield surface, the algorithm recomputes the scalar effective inelastic strain required to return the stress state to the yield surface. This approach is given the name _Radial Return_ because the yield surface used is the [von Mises yield surface](https://en.wikipedia.org/wiki/Von_Mises_yield_criterion): in the [devitoric stress space ](https://en.wikipedia.org/wiki/Cauchy_stress_tensor#Stress_deviator_tensor), this yield surface has the shape of a circle, and the scalar inelastic strain is assumed to always be directed at the circle center.
-
 
 ###Recompute Iterations on the Effective Plastic Strain Increment
 The recompute radial return materials each individually calculate, using the [Newton Method](http://mathworld.wolfram.com/NewtonsMethod.html), the amount of effective inelastic strain required to return the stress state to the yield surface.
-$$
+\begin{equation}
 \Delta p^{(t+1)} = \Delta p^t + d \Delta p
-$$
+\end{equation}
 where the change in the iterative effective inelastic strain is defined as the yield surface over the derivative of the yield surface with respect to the inelastic strain increment.

--- a/docs/content/documentation/modules/tensor_mechanics/common/supplementalStressDivergenceKernels.md
+++ b/docs/content/documentation/modules/tensor_mechanics/common/supplementalStressDivergenceKernels.md
@@ -1,20 +1,18 @@
 The stress divergence kernel handles the calculation of the residual, $\mathbb{R}$, from the governing equation and the calculation of the Jacobian.
-
 From the strong form of the governing equation for mechanics, neglecting body forces,
-$$
+\begin{equation}
 \nabla \cdot \sigma = 0
-$$
-
+\end{equation}
 the weak form, using Galerkin's method and the Gauss divergence theorem, becomes
-$$
+\begin{equation}
 \int_S n \cdot (\sigma \psi) dS - \int_V \sigma \cdot \nabla \psi dV = 0
-$$
+\end{equation}
 in which $\psi$ is the test function.  The second term of the weak form equation is the residual contribution calculated by the stress divergence kernel.
 
 The calculation of the Jacobian can be approximated with the elasticity tensor if the simulation solve type is **JFNK**:
-$$
+\begin{equation}
 \frac{d(\sigma_{ij} \cdot d(\psi) / dx_j)}{du_k} = \frac{d(C_{ijmn} \cdot du_m / dx_n \cdot d\psi /dx_j)}{du_k}
-$$
+\end{equation}
 which is nonzero for $m == k$.
 
 If the solve type for the simulation is set to **NEWTON** the finite deformation Jacobian will need to be calculated.  Set the parameter `use_finite_deform_jacobian = true` in this case.

--- a/docs/content/documentation/modules/tensor_mechanics/index.md
+++ b/docs/content/documentation/modules/tensor_mechanics/index.md
@@ -18,62 +18,57 @@ The tensor mechanics module provides a powerful system for solving solid mechani
 
 A material varies from its rest shape due to stress. This departure from the rest shape is called deformation or displacement, and the proportion of deformation to original size is called strain. To determine the deformed shape and the stress, a governing equation is solved to determine the displacement vector $\mathbf{u}$.
 
-The strong form of the governing equation on the domain $\Omega$ and boundary $\Gamma=\Gamma_{\mathit{\iota_i}}\cup\Gamma_{\mathit{g_i}}$
+The strong form of the governing equation on the domain $\Omega$ and boundary $\Gamma=\Gamma_{\mathit{t_i}}\cup\Gamma_{\mathit{g_i}}$
 can be stated as follows:
-$$
-\begin{eqnarray}
-\nabla \cdot (\boldsymbol{\sigma} + \boldsymbol{\sigma}_0) + \mathbf{b} &=& \mathbf{0} \;\mathrm{in}\;\Omega \\
-\mathbf{u} &=& \mathbf{g}\;\mathrm{in}\;\Gamma_{ \mathbf{g}} \\
-\boldsymbol{\sigma} \cdot \mathbf{n}&=&\boldsymbol{\iota}\;\mathrm{in}\;\Gamma_{ \boldsymbol{\iota}}
-\end{eqnarray}
-$$
-where $\boldsymbol{\sigma}$  is the Cauchy stress tensor, $\boldsymbol{\sigma}_0$ is an additional source of stress (such as pore pressure), $\mathbf{u}$ is the displacement vector, $\mathbf{b}$ is the body force, $\mathbf{n}$ is the unit normal to the boundary, $\mathbf{g}$ is the prescribed displacement on the boundary and $\boldsymbol{\iota}$ is the prescribed traction on the boundary. The weak form of the residual equation is expressed as:
-$$
-\begin{eqnarray}
-  \mathbb{R} = \left( \boldsymbol{\sigma} + \boldsymbol{\sigma}_0), \nabla \phi_m \right) - \left< \boldsymbol{\iota}, \phi_m \right> - \left( \mathbf{b}, \phi_m \right)  = \mathbf{0},
-\end{eqnarray}
-$$
+\begin{equation}
+\begin{aligned}
+\nabla \cdot (\mathbf{\sigma} + \mathbf{\sigma}_0) + \mathbf{b} =& \mathbf{0} \;\mathrm{in}\;\Omega \\
+\mathbf{u} =& \mathbf{g}\;\mathrm{in}\;\Gamma_{ \mathbf{g}} \\
+\mathbf{\sigma} \cdot \mathbf{n}=&\mathbf{t}\;\mathrm{in}\;\Gamma_{ \mathbf{t}}
+\end{aligned}
+\end{equation}
+where $\mathbf{\sigma}$  is the Cauchy stress tensor, $\mathbf{\sigma}_0$ is an additional source of stress (such as pore pressure), $\mathbf{u}$ is the displacement vector, $\mathbf{b}$ is the body force, $\mathbf{n}$ is the unit normal to the boundary, $\mathbf{g}$ is the prescribed displacement on the boundary and $\mathbf{t}$ is the prescribed traction on the boundary. The weak form of the residual equation is expressed as:
+\begin{equation}
+  \mathbb{R} = \left( \mathbf{\sigma} + \mathbf{\sigma}_0), \nabla \phi_m \right) - \left< \mathbf{t}, \phi_m \right> - \left( \mathbf{b}, \phi_m \right)  = \mathbf{0}
+\end{equation}
 where $(\cdot)$ and $\left< \cdot \right>$ represent volume and boundary integrals, respectively. The solution of the residual equation with Newton's method requires the Jacobian of the residual equation, which can be expressed as (ignoring boundary terms)
-$$
-\begin{eqnarray}
-  \mathbb{J} = \left( \frac{\partial \boldsymbol{\sigma}}{\partial \nabla \mathbf{u}} , \nabla \phi_m \right),
-\end{eqnarray}
-$$
-assuming $\boldsymbol{\sigma}_0$ is independent of the strain.
+\begin{equation}
+  \mathbb{J} = \left( \frac{\partial \mathbf{\sigma}}{\partial \nabla \mathbf{u}} , \nabla \phi_m \right),
+\end{equation}
+assuming $\mathbf{\sigma}_0$ is independent of the strain.
 
-The material stress response is described by the constitutive model, where the stress is determined as a function of the strain, i.e. $\tilde{\boldsymbol{\sigma}}( \boldsymbol{\epsilon} - \boldsymbol{\epsilon}_0)$, where $\boldsymbol{\epsilon}$ is the strain and $\boldsymbol{\epsilon}_0$ is a stress free strain. For example, in linear elasticity (only valid for small strains), the material response is linear, i.e.
-$\boldsymbol{\sigma} = \boldsymbol{\mathcal{C}}(\boldsymbol{\epsilon} - \boldsymbol{\epsilon}_0)$.
+The material stress response is described by the constitutive model, where the stress is determined as a function of the strain, i.e. $\tilde{\mathbf{\sigma}}( \mathbf{\epsilon} - \mathbf{\epsilon}_0)$, where $\mathbf{\epsilon}$ is the strain and $\mathbf{\epsilon}_0$ is a stress free strain. For example, in linear elasticity (only valid for small strains), the material response is linear, i.e.
+$\mathbf{\sigma} = \mathbf{\mathcal{C}}(\mathbf{\epsilon} - \mathbf{\epsilon}_0)$.
 
 The tensor mechanics system can handle linear elasticity and finite strain mechanics, including elasticity, plasticity, creep, and damage.
 
-##Using TensorMechanics Materials
+## Using Materials in Tensor Mechanics
 
 The tensor mechanics materials use a modular system where the main tensors used in the residual equation are defined in individual material classes in MOOSE. The plug-and-play approach used in the Tensor Mechanics module requires at least three separate classes to fully describe a material model.
 
 !!! info "Three Tensors Are Required for a Mechanics Problem"
-    The three tensors that must be defined for any mechanics problem are the the strain $\boldsymbol{\epsilon}$ or strain increment, elasticity tensor $\boldsymbol{\mathcal{C}}$, and the stress $\boldsymbol{\sigma}$. Optional tensors include stress-free strain (also known as an eigenstrain) $\boldsymbol{\epsilon}_0$ and additional stress $\boldsymbol{\sigma}_0$.
+    The three tensors that must be defined for any mechanics problem are the the strain $\mathbf{\epsilon}$ or strain increment, elasticity tensor $\mathbf{\mathcal{C}}$, and the stress $\mathbf{\sigma}$. Optional tensors include stress-free strain (also known as an eigenstrain) $\mathbf{\epsilon}_0$ and additional stress $\mathbf{\sigma}_0$.
 
 !media media/tensor_mechanics-IntroPlugNPlay.png width=800 float=right caption=Figure 1: Tensors required to fully describe a mechanics material.
 
 
 At times, a user may need to define multiple mechanics properties over a single block. For this reason, all material properties can be prepended by a name defined by the input parameter `base_name`.
 
-###Strain or Strain increment
-The base material class to create strains ($\boldsymbol{\epsilon}$) or strain increments is ComputeStrainBase](/ComputeStrainBase.md). `ComputeStrainBase` is a pure virtual class, requiring that all children override the `computeQpProperties()` method.
-
-For all strain this class defines the property `total_strain`.  For incremental strains, both finite and small, the compute strain base class defines the properties
+##Strain Materials
+The base material class to create strains ($\mathbf{\epsilon}$) or strain increments is `ComputeStrainBase`; this class is a pure virtual class, requiring that all children override the `computeQpProperties()` method.
+For all strains the base class defines the property `total_strain`.  For incremental strains, both finite and small, the compute strain base class defines the properties
 `strain_rate`, `strain_increment`, `rotation_increment`, and `deformation_gradient`. A discussion of the different types of strain formulations is available on the [Strains](tensor_mechanics/Strains.md) page.
 
-For small strains, use [ComputeSmallStrain](/ComputeSmallStrain.md) in which $\boldsymbol{\epsilon} = (\nabla \mathbf{u} + \nabla \mathbf{u}^T)/2$. For finite strains, use [ComputeFiniteStrain](/ComputeFiniteStrain.md) in which an incremental form is employed such that the strain_increment and rotation_increment are calculated. The input file syntax for a finite incremental strain material is
+For small strains, use [ComputeSmallStrain](/ComputeSmallStrain.md) in which $\mathbf{\epsilon} = (\nabla \mathbf{u} + \nabla \mathbf{u}^T)/2$. For finite strains, use [ComputeFiniteStrain](/ComputeFiniteStrain.md) in which an incremental form is employed such that the strain_increment and rotation_increment are calculated.
 
-!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i start=strain end=stress
+With the TensorMechanics master action, the strain formulation can be set with the `strain= SMALL | FINITE` parameter, as shown below.
+!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i block=Modules/TensorMechanics
 
 
-###Elasticity Tensor
+##Elasticity Tensor Materials
 
-The primary class for creating elasticity tensors ($\boldsymbol{\mathcal{C_{ijkl}}}$) is [ComputeElasticityTensor](/ComputeElasticityTensor.md). This class defines the property
-`_elasticity_tensor`. Given the elastic constants required for the applicable symmetry, such as `symmetric9`, this material calculates the elasticity tensor. If you wish to rotate the elasticity tensor, constant Euler angles can be provided. The elasticity tensor can also be scaled with a function, if desired. The input file syntax to create an elasticity tensor is
-
+The primary class for creating elasticity tensors ($\mathbf{\mathcal{C_{ijkl}}}$) is [ComputeElasticityTensor](/ComputeElasticityTensor.md). This class defines the property
+`_elasticity_tensor`. Given the elastic constants required for the applicable symmetry, such as `symmetric9`, this material calculates the elasticity tensor. If you wish to rotate the elasticity tensor, constant Euler angles can be provided. The elasticity tensor can also be scaled with a function, if desired.
 `ComputeElasticityTensor` also serves as a base class for specialized elasticity tensors, including:
 
 * An elasticity tensor for crystal plasticity, [ComputeElasticityTensorCP](/ComputeElasticityTensorCP.md),
@@ -82,54 +77,54 @@ The primary class for creating elasticity tensors ($\boldsymbol{\mathcal{C_{ijkl
 
 The input file syntax for the isotropic elasticity tensor is
 
-!listing modules/tensor_mechanics/tutorials/basics/part_1.1.i start=elasticity_tensor end=strain
+!listing modules/tensor_mechanics/tutorials/basics/part_1.1.i block=Materials/elasticity_tensor
 
 and for an orthotropic material, such as a metal crystal, is
 
-!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i start=elasticity_tensor end=strain
+!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i block=Materials/elasticity_tensor
 
-###Stress
-The base class for constitutive equations to compute a stress ($\boldsymbol{\sigma}$) is `ComputeStressBase`. The `ComputeStressBase` class defines the properties `stress` and `elastic_strain`. It is a pure virtual class, requiring all children to override the method `computeQpStress()`.
+##Stress Materials
+The base class for constitutive equations to compute a stress ($\mathbf{\sigma}$) is `ComputeStressBase`. The `ComputeStressBase` class defines the properties `stress` and `elastic_strain`. It is a pure virtual class, requiring all children to override the method `computeQpStress()`.
 
 Two elastic constitutive models have been developed, one that assumes small strains [ComputeLinearElasticStress](/ComputeLinearElasticStress.md), and a second which assumes finite strains and rotations increments [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md) The input file syntax for these materials is
 
-!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i block=stress
+!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i block=Materials/stress
 
 There are a number of other constitutive models that have been implemented to calculate more complex elasticity problems, plasticity, and creep.  An overview of these different materials is available on the [Stresses](tensor_mechanics/Stresses.md) page.
 
-### Stress-Free Strains (Eigenstrains)
+## Eigenstrain Materials
 
-Eigenstrain is the term given to a strain which does not result directly from an applied force. Eigenstrains are also referred to as residual strains, stress-free strains, or intrinsic strains; translated from German, [Eigen](http://dict.tu-chemnitz.de/deutsch-englisch/Eigen....html) means own or intrinsic in English.  The term eigenstrain was introduced by [T. Mura in 1982](http://link.springer.com/chapter/10.1007/978-94-011-9306-1_1):
+Eigenstrain is the term given to a strain which does not result directly from an applied force. The base class for eigenstrains is `ComputeEigenstrainBase`. It computes an eigenstrain, which is subtracted from the total strain in the Compute Strain classes.
+\begin{equation}
+\epsilon_{mechanical} = \epsilon_{total} - \epsilon_{eigen}
+\end{equation}
+[Chapter 3](http://onlinelibrary.wiley.com/doi/10.1002/9780470117835.ch3/pdf) of **Fundamentals of Micromechanics of Solids** describes the relationship between total, elastic, and eigen- strains and provides examples using thermal expansion and dislocations.
+
+Eigenstrains are also referred to as residual strains, stress-free strains, or intrinsic strains; translated from German, [Eigen](http://dict.tu-chemnitz.de/deutsch-englisch/Eigen....html) means own or intrinsic in English.  The term eigenstrain was introduced by [T. Mura in 1982](http://link.springer.com/chapter/10.1007/978-94-011-9306-1_1):
 
 > Eigenstrain is a generic name given to such nonelastic strains as thermal expansion, phase transformation, initial strains, plastic, misfit strains. Eigenstress is a generic name given to self-equilibrated internal stresses caused by one or several of these eigenstrains in bodies which are free from any other external force and surface constraint.  The eigenstress fields are created by the incompatibility of the eigenstrains.  This new English terminology was adapted from the German "Eigenspannungen and Eigenspannungsquellen," which is the title of H. Reissner's paper (1931) on residual stresses.
 
-The base class for eigenstrains is `ComputeEigenstrainBase`. It computes an eigenstrain, which is subtracted from the total strain in the Compute Strain classes. Eigenstrains are calculated separately from `mechanical_strains`: elastic, plastic, and creep strains are considered mechanical strains in Tensor Mechanics.
+Thermal strains are a volumetric change resulting from a change in temperature of the material.  The change in strains can be either a simple linear function of thermal change, e.g. ($\mathbf{\epsilon}_T = \alpha \Delta T$) or a more complex function of temperature.
+The thermal expansion class, [ComputeThermalExpansionEigenstrain](/ComputeThermalExpansionEigenstrain.md) computes the thermal strain  as a linear function of temperature.  The input file syntax is
+!listing modules/tensor_mechanics/test/tests/thermal_expansion/constant_expansion_coeff.i block=Materials/thermal_expansion_strain
 
-$$
-\epsilon_{mechanical} = \epsilon_{total} - \epsilon_{eigen}
-$$
+The eigenstrain material block name must also be added as an input parameter, `eigenstrain_names` to the strain material or TensorMechanics master action block. An example of the additional parameter in the TensorMechanics master action is shown below.
+!listing modules/tensor_mechanics/test/tests/thermal_expansion/constant_expansion_coeff.i block=Modules/TensorMechanics
 
-The mechanical strain is passed to the `Compute*Stress` methods to calculate the stress for the current iteration.  [Chapter 3](http://onlinelibrary.wiley.com/doi/10.1002/9780470117835.ch3/pdf) of **Fundamentals of Micromechanics of Solids** describes the relationship between total, elastic, and eigen strains and provides examples with thermal expansion and dislocations.
+Other eigenstrains could be caused by defects such as over-sized or under-sized second phase particles. Such an eigenstrain material is [ComputeVariableEigenstrain](/ComputeVariableEigenstrain.md). This class computes a lattice mismatch due to a secondary phase, where the form of the tensor is defined by an input vector, and the scalar dependence on a phase variable is defined in another material. The input file syntax is
 
-Thermal strains are a volumetric change resulting from a change in temperature of the material.  The change in strains can be either a simple linear function of thermal change, e.g. ($\boldsymbol{\epsilon}_T = \alpha \Delta T$) or a more complex function of temperature.   Besides thermal expansion, some models employ other stress-free strains ($\boldsymbol{\epsilon}_0$) to provide inherit strains in the material.
-
-The thermal expansion class, [ComputeThermalExpansionEigenstrain](/ComputeThermalExpansionEigenstrain.md) computes the thermal strains for both small total strains and for incremental strains as a linear function of temperature.  The input file syntax is
-
-!listing modules/tensor_mechanics/test/tests/thermal_expansion/constant_expansion_coeff.i block=thermal_expansion_strain
-
-Other eigenstrains could be caused by defects such as over-sized or under-sized second phase particles. Another stress-free strain material that has been implemented is [ComputeVariableEigenstrain](/ComputeVariableEigenstrain.md). This class computes a lattice mismatch due to a secondary phase, where the form of the tensor is defined by an input vector, and the scalar dependence on a phase variable is defined in another material. The input file syntax is
-
-!listing modules/combined/test/tests/eigenstrain/inclusion.i block=var_dependence
-
-!listing modules/combined/test/tests/eigenstrain/inclusion.i block=eigenstrain
+!listing modules/combined/test/tests/eigenstrain/inclusion.i block=Materials/eigenstrain
 
 Note the `DerivativeParsedMaterial`,  which evaluates an expression given in the input file, and its automatically generated derivatives, at each quadrature point.
+!listing modules/combined/test/tests/eigenstrain/inclusion.i block=Materials/var_dependence
 
-### Extra Stresses
+## Extra Stress Materials
 
-Extra stresses ($\boldsymbol{\sigma}_0$) can also be pulled into the residual calculation after the constitutive model calculation of the stress. The extra stress is added to the stress value
-```
-  _stress[_qp] += _extra_stress[_qp];
-```
+Extra stresses ($\mathbf{\sigma}_0$) can also be pulled into the residual calculation after the constitutive model calculation of the stress. The extra stress material property, `extra_stress` is defined in the `ComputeExtraStressBase` class and is added to the stress value.
+\begin{equation}
+  \sigma_{ij} = \sigma_{ij} + \sigma^{exta}_{ij}
+\end{equation}
 
- Though no base class has been created for this, it would be straight forward to do so and it would need to define the property `extra_stress`.
+An extra stress may be a residual stress, such as in large civil engineering simulations.
+An example of an extra stress material used in an input file is:
+!listing modules/combined/test/tests/linear_elasticity/extra_stress.i block=Materials/const_stress


### PR DESCRIPTION
This commit updates the tensor mechanics introduction pages to correctly render the equations in katex and to correctly include only the relevant sections of the input files.  Where appropriate, I have changed wording to encourage the use of the tensor mechanic master action over the strain + kernel blocks.

Documentation only update: no source code changes. Pinging @aeslaughter for review please.
Refs #9638
