### PR TITLE
mooseError to MooseException in fluid_properties

### DIFF
--- a/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
@@ -7,6 +7,7 @@
 
 #include "CO2FluidProperties.h"
 #include "BrentsMethod.h"
+#include "Conversion.h"
 
 template <>
 InputParameters
@@ -71,8 +72,8 @@ Real
 CO2FluidProperties::meltingPressure(Real temperature) const
 {
   if (temperature < _triple_point_temperature)
-    mooseError(
-        "Temperature is below the triple point temperature in ", name(), ": meltingPressure()");
+    throw MooseException("Temperature is below the triple point temperature in " + name() +
+                         ": meltingPressure()");
 
   Real Tstar = temperature / _triple_point_temperature;
 
@@ -84,8 +85,8 @@ Real
 CO2FluidProperties::sublimationPressure(Real temperature) const
 {
   if (temperature > _triple_point_temperature)
-    mooseError(
-        "Temperature is above the triple point temperature in ", name(), ": sublimationPressure()");
+    throw MooseException("Temperature is above the triple point temperature in " + name() +
+                         ": sublimationPressure()");
 
   Real Tstar = temperature / _triple_point_temperature;
 
@@ -101,7 +102,7 @@ Real
 CO2FluidProperties::vaporPressure(Real temperature) const
 {
   if (temperature < _triple_point_temperature || temperature > _critical_temperature)
-    mooseError("Temperature is out of range in ", name(), ": vaporPressure()");
+    throw MooseException("Temperature is out of range in " + name() + ": vaporPressure()");
 
   Real Tstar = temperature / _critical_temperature;
 
@@ -117,7 +118,7 @@ Real
 CO2FluidProperties::saturatedLiquidDensity(Real temperature) const
 {
   if (temperature < _triple_point_temperature || temperature > _critical_temperature)
-    mooseError("Temperature is out of range in ", name(), ": saturatedLiquiDensity()");
+    throw MooseException("Temperature is out of range in " + name() + ": saturatedLiquiDensity()");
 
   Real Tstar = temperature / _critical_temperature;
 
@@ -133,7 +134,7 @@ Real
 CO2FluidProperties::saturatedVaporDensity(Real temperature) const
 {
   if (temperature < _triple_point_temperature || temperature > _critical_temperature)
-    mooseError("Temperature is out of range in ", name(), ": saturatedVaporDensity()");
+    throw MooseException("Temperature is out of range in " + name() + ": saturatedVaporDensity()");
 
   Real Tstar = temperature / _critical_temperature;
 
@@ -441,7 +442,7 @@ CO2FluidProperties::pressure(Real density, Real temperature) const
 {
   // Check that the input parameters are within the region of validity
   if (temperature < 216.0 || temperature > 1100.0 || density <= 0.0)
-    mooseError("Parameters out of range in ", name(), ": pressure()");
+    throw MooseException("Parameters out of range in " + name() + ": pressure()");
 
   Real pressure = 0.0;
 
@@ -466,13 +467,13 @@ CO2FluidProperties::rho(Real pressure, Real temperature) const
 {
   // Check that the input parameters are within the region of validity
   if (temperature < 216.0 || temperature > 1100.0 || pressure <= 0.0)
-    mooseError("Parameters out of range in ", name(), ": rho()");
+    throw MooseException("Parameters out of range in " + name() + ": rho()");
 
   // Also check that the pressure and temperature are not in the solid phase region
   if (((temperature > _triple_point_temperature) && (pressure > meltingPressure(temperature))) ||
       ((temperature < _triple_point_temperature) && (pressure > sublimationPressure(temperature))))
-    mooseError(
-        "Input pressure and temperature in ", name(), ": rho() correspond to solid CO2 phase");
+    throw MooseException("Input pressure and temperature in " + name() +
+                         ": rho() correspond to solid CO2 phase");
 
   Real density;
   // Initial estimate of a bracketing interval for the density
@@ -531,7 +532,7 @@ CO2FluidProperties::mu_from_rho_T(Real density, Real temperature) const
 {
   // Check that the input parameters are within the region of validity
   if (temperature < 216.0 || temperature > 1000.0 || density > 1400.0)
-    mooseError("Parameters out of range in ", name(), ": mu()");
+    throw MooseException("Parameters out of range in " + name() + ": mu()");
 
   Real Tstar = temperature / 251.196;
   const std::vector<Real> a{0.235156, -0.491266, 5.211155e-2, 5.347906e-2, -1.537102e-2};
@@ -564,7 +565,7 @@ CO2FluidProperties::mu_drhoT_from_rho_T(Real density,
 {
   // Check that the input parameters are within the region of validity
   if (temperature < 216.0 || temperature > 1000.0 || density > 1400.0)
-    mooseError("Parameters out of range in ", name(), ": mu_drhoT()");
+    throw MooseException("Parameters out of range in " + name() + ": mu_drhoT()");
 
   Real Tstar = temperature / 251.196;
   Real dTstar_dT = 1.0 / 251.196;
@@ -740,7 +741,8 @@ CO2FluidProperties::k_from_rho_T(Real density, Real temperature) const
 {
   // Check the temperature is in the range of validity (216.592 K <= T <= 1000 K)
   if (temperature <= _triple_point_temperature || temperature >= 1000.0)
-    mooseError("Temperature ", temperature, "K out of range (200K, 1000K) in ", name(), ": k()");
+    throw MooseException("Temperature " + Moose::stringify(temperature) +
+                         "K out of range (200K, 1000K) in " + name() + ": k()");
 
   const std::vector<Real> g1{0.0, 0.0, 1.5};
   const std::vector<Real> g2{0.0, 1.0, 1.5, 1.5, 1.5, 3.5, 5.5};

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -6,6 +6,7 @@
 /****************************************************************/
 
 #include "IdealGasFluidProperties.h"
+#include "Conversion.h"
 
 template <>
 InputParameters
@@ -39,7 +40,8 @@ Real
 IdealGasFluidProperties::pressure(Real v, Real u) const
 {
   if (v == 0.0)
-    mooseError(name(), ": Invalid value of specific volume detected (v = ", v, ").");
+    throw MooseException(name() + ": Invalid value of specific volume detected (v = " +
+                         Moose::stringify(v) + ").");
 
   // The std::max function serves as a hard limiter, which will guarantee non-negative pressure
   // when resolving strongly nonlinear waves
@@ -78,7 +80,7 @@ IdealGasFluidProperties::s_from_h_p(Real h, Real p, Real & s, Real & ds_dh, Real
 {
   const Real aux = p * std::pow(h / (_gamma * _cv), -_gamma / (_gamma - 1));
   if (aux <= 0.0)
-    mooseError(name(), ": Non-positive argument in the ln() function.");
+    throw MooseException(name() + ": Non-positive argument in the ln() function.");
 
   const Real daux_dh = p * std::pow(h / (_gamma * _cv), -_gamma / (_gamma - 1) - 1) *
                        (-_gamma / (_gamma - 1)) / (_gamma * _cv);
@@ -124,12 +126,9 @@ Real
 IdealGasFluidProperties::rho(Real pressure, Real temperature) const
 {
   if ((_gamma - 1.0) * pressure == 0.0)
-    mooseError(name(),
-               ": Invalid gamma or pressure detected in rho(pressure = ",
-               pressure,
-               ", gamma = ",
-               _gamma,
-               ")");
+    throw MooseException(name() + ": Invalid gamma or pressure detected in rho(pressure = " +
+                         Moose::stringify(pressure) + ", gamma = " + Moose::stringify(_gamma) +
+                         ")");
 
   return pressure / (_gamma - 1.0) / _cv / temperature;
 }

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -6,6 +6,7 @@
 /****************************************************************/
 
 #include "MethaneFluidProperties.h"
+#include "Conversion.h"
 
 template <>
 InputParameters
@@ -125,7 +126,8 @@ MethaneFluidProperties::cp(Real /*pressure*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (280 K <= T <= 1080 K)
   if (temperature <= 280.0 || temperature >= 1080.0)
-    mooseError("Temperature ", temperature, "K out of range (280K, 1080K) in ", name(), ": cp()");
+    throw MooseException("Temperature " + Moose::stringify(temperature) +
+                         "K out of range (280K, 1080K) in " + name() + ": cp()");
 
   std::vector<Real> a;
   if (temperature < 755.0)
@@ -170,11 +172,8 @@ MethaneFluidProperties::mu_from_rho_T(Real /*density*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (200 K <= T <= 1000 K)
   if (temperature <= 200.0 || temperature >= 1000.0)
-    mooseError("Temperature ",
-               temperature,
-               "K out of range (200K, 1000K) in ",
-               name(),
-               ": mu_from_rho_T()");
+    throw MooseException("Temperature " + Moose::stringify(temperature) +
+                         "K out of range (200K, 1000K) in " + name() + ": mu_from_rho_T()");
 
   const std::vector<Real> a{
       2.968267e-1, 3.711201e-2, 1.218298e-5, -7.02426e-8, 7.543269e-11, -2.7237166e-14};
@@ -225,7 +224,8 @@ MethaneFluidProperties::k_from_rho_T(Real /*density*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (200 K <= T <= 1000 K)
   if (temperature <= 200.0 || temperature >= 1000.0)
-    mooseError("Temperature ", temperature, "K out of range (200K, 1000K) in ", name(), ": k()");
+    throw MooseException("Temperature " + Moose::stringify(temperature) +
+                         "K out of range (200K, 1000K) in " + name() + ": k()");
 
   const std::vector<Real> a{-1.3401499e-2,
                             3.663076e-4,
@@ -247,7 +247,8 @@ MethaneFluidProperties::s(Real /*pressure*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (280 K <= t <= 1080 K)
   if (temperature <= 280.0 || temperature >= 1080.0)
-    mooseError("Temperature ", temperature, "K out of range (280K, 1080K) in ", name(), ": s()");
+    throw MooseException("Temperature " + Moose::stringify(temperature) +
+                         "K out of range (280K, 1080K) in " + name() + ": s()");
 
   std::vector<Real> a;
   if (temperature < 755.0)
@@ -268,7 +269,8 @@ MethaneFluidProperties::h(Real /*pressure*/, Real temperature) const
 {
   // Check the temperature is in the range of validity (280 K <= t <= 1080 K)
   if (temperature <= 280.0 || temperature >= 1080.0)
-    mooseError("Temperature ", temperature, "K out of range (280K, 1080K) in ", name(), ": cp()");
+    throw MooseException("Temperature " + Moose::stringify(temperature) +
+                         "K out of range (280K, 1080K) in " + name() + ": cp()");
 
   std::vector<Real> a;
   if (temperature < 755.0)

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -73,7 +73,7 @@ StiffenedGasFluidProperties::s(Real v, Real u) const
   Real p = this->pressure(v, u);
   Real n = std::pow(T, _gamma) / std::pow(p + _p_inf, _gamma - 1.0);
   if (n <= 0.0)
-    mooseError(name(), ": Negative argument in the ln() function.");
+    throw MooseException(name() + ": Negative argument in the ln() function.");
   return _cv * std::log(n) + _q_prime;
 }
 
@@ -82,7 +82,7 @@ StiffenedGasFluidProperties::s_from_h_p(Real h, Real p, Real & s, Real & ds_dh, 
 {
   const Real aux = (p + _p_inf) * std::pow((h - _q) / (_gamma * _cv), -_gamma / (_gamma - 1));
   if (aux <= 0.0)
-    mooseError(name(), ": Non-positive argument in the ln() function.");
+    throw MooseException(name() + ": Non-positive argument in the ln() function.");
 
   const Real daux_dh = (p + _p_inf) *
                        std::pow((h - _q) / (_gamma * _cv), -_gamma / (_gamma - 1) - 1) *

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -8,6 +8,7 @@
 #include "TabulatedFluidProperties.h"
 #include "BicubicSplineInterpolation.h"
 #include "MooseUtils.h"
+#include "Conversion.h"
 
 // C++ includes
 #include <fstream>
@@ -455,20 +456,13 @@ void
 TabulatedFluidProperties::checkInputVariables(Real pressure, Real temperature) const
 {
   if (pressure < _pressure_min || pressure > _pressure_max)
-    mooseError("Pressure ",
-               pressure,
-               " is outside the range of tabulated pressure (",
-               _pressure_min,
-               ", ",
-               _pressure_max,
-               ".");
+    throw MooseException(
+        "Pressure " + Moose::stringify(pressure) + " is outside the range of tabulated pressure (" +
+        Moose::stringify(_pressure_min) + ", " + Moose::stringify(_pressure_max) + ".");
 
   if (temperature < _temperature_min || temperature > _temperature_max)
-    mooseError("Temperature ",
-               temperature,
-               " is outside the range of tabulated temperature (",
-               _temperature_min,
-               ", ",
-               _temperature_max,
-               ".");
+    throw MooseException("Temperature " + Moose::stringify(temperature) +
+                         " is outside the range of tabulated temperature (" +
+                         Moose::stringify(_temperature_min) + ", " +
+                         Moose::stringify(_temperature_max) + ".");
 }

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -6,6 +6,7 @@
 /****************************************************************/
 
 #include "Water97FluidProperties.h"
+#include "Conversion.h"
 
 template <>
 InputParameters
@@ -785,9 +786,8 @@ Water97FluidProperties::vaporPressure(Real temperature) const
   // Check whether the input temperature is within the region of validity of this equation.
   // Valid for 273.15 K <= t <= 647.096 K
   if (temperature < 273.15 || temperature > _T_critical)
-    mooseError(name(),
-               ": vaporPressure(): Temperature is outside range 273.15 K <= T "
-               "<= 647.096 K");
+    throw MooseException(name() + ": vaporPressure(): Temperature is outside range 273.15 K <= T "
+                                  "<= 647.096 K");
 
   // Constants for region 4 (the saturation curve up to the critical point)
   const std::vector<Real> n4{0.11670521452767e4,
@@ -818,9 +818,8 @@ Water97FluidProperties::vaporPressure_dT(Real temperature, Real & psat, Real & d
   // Check whether the input temperature is within the region of validity of this equation.
   // Valid for 273.15 K <= t <= 647.096 K
   if (temperature < 273.15 || temperature > _T_critical)
-    mooseError(name(),
-               ": vaporPressure_dT(): Temperature is outside range 273.15 K <= "
-               "T <= 647.096 K");
+    throw MooseException(name() + ": vaporPressure_dT(): Temperature is outside range 273.15 K <= "
+                                  "T <= 647.096 K");
 
   // Constants for region 4 (the saturation curve up to the critical point)
   const std::vector<Real> n4{0.11670521452767e4,
@@ -867,9 +866,8 @@ Water97FluidProperties::vaporTemperature(Real pressure) const
   // Check whether the input pressure is within the region of validity of this equation.
   // Valid for 611.213 Pa <= p <= 22.064 MPa
   if (pressure < 611.23 || pressure > _p_critical)
-    mooseError(name(),
-               ": vaporTemperature(): Pressure is outside range 611.213 Pa <= "
-               "p <= 22.064 MPa");
+    throw MooseException(name() + ": vaporTemperature(): Pressure is outside range 611.213 Pa <= "
+                                  "p <= 22.064 MPa");
 
   // Constants for region 4 (the saturation curve up to the critical point)
   const std::vector<Real> n4{0.11670521452767e4,
@@ -900,7 +898,8 @@ Water97FluidProperties::b23p(Real temperature) const
   // Check whether the input temperature is within the region of validity of this equation.
   // Valid for 623.15 K <= t <= 863.15 K
   if (temperature < 623.15 || temperature > 863.15)
-    mooseError(name(), ": b23p(): Temperature is outside range of 623.15 K <= T <= 863.15 K");
+    throw MooseException(name() +
+                         ": b23p(): Temperature is outside range of 623.15 K <= T <= 863.15 K");
 
   // Constants for the boundary between regions 2 and 3
   const std::vector<Real> n23{0.34805185628969e3,
@@ -918,7 +917,7 @@ Water97FluidProperties::b23T(Real pressure) const
   // Check whether the input pressure is within the region of validity of this equation.
   // Valid for 16.529 MPa <= p <= 100 MPa
   if (pressure < 16.529e6 || pressure > 100.0e6)
-    mooseError(name(), ": b23T(): Pressure is outside range 16.529 MPa <= p <= 100 MPa");
+    throw MooseException(name() + ": b23T(): Pressure is outside range 16.529 MPa <= p <= 100 MPa");
 
   // Constants for the boundary between regions 2 and 3
   const std::vector<Real> n23{0.34805185628969e3,
@@ -938,15 +937,18 @@ Water97FluidProperties::inRegion(Real pressure, Real temperature) const
   if (temperature >= 273.15 && temperature <= 1073.15)
   {
     if (pressure < vaporPressure(273.15) || pressure > 100.0e6)
-      mooseError("Pressure ", pressure, " is out of range in ", name(), ": inRegion()");
+      throw MooseException("Pressure " + Moose::stringify(pressure) + " is out of range in " +
+                           name() + ": inRegion()");
   }
   else if (temperature > 1073.15 && temperature <= 2273.15)
   {
     if (pressure < 0.0 || pressure > 50.0e6)
-      mooseError("Pressure ", pressure, " is out of range in ", name(), ": inRegion()");
+      throw MooseException("Pressure " + Moose::stringify(pressure) + " is out of range in " +
+                           name() + ": inRegion()");
   }
   else
-    mooseError("Temperature ", temperature, " is out of range in ", name(), ": inRegion()");
+    throw MooseException("Temperature " + Moose::stringify(temperature) + " is out of range in " +
+                         name() + ": inRegion()");
 
   // Determine the phase region that the (P, T) point lies in
   unsigned int region;
@@ -1662,7 +1664,8 @@ Water97FluidProperties::inRegionPH(Real pressure, Real enthalpy) const
     else if (enthalpy > h(pressure, 1073.15) && enthalpy <= h(pressure, 2273.15))
       region = 5;
     else
-      mooseError("Enthalpy ", enthalpy, " is out of range in ", name(), ": inRegionPH()");
+      throw MooseException("Enthalpy " + Moose::stringify(enthalpy) + " is out of range in " +
+                           name() + ": inRegionPH()");
   }
   else if (pressure > p623 && pressure <= 50.0e6)
   {
@@ -1675,7 +1678,8 @@ Water97FluidProperties::inRegionPH(Real pressure, Real enthalpy) const
     else if (enthalpy > h(pressure, 1073.15) && enthalpy <= h(pressure, 2273.15))
       region = 5;
     else
-      mooseError("Enthalpy ", enthalpy, " is out of range in ", name(), ": inRegionPH()");
+      throw MooseException("Enthalpy " + Moose::stringify(enthalpy) + " is out of range in " +
+                           name() + ": inRegionPH()");
   }
   else if (pressure > 50.0e6 && pressure <= 100.0e6)
   {
@@ -1686,10 +1690,12 @@ Water97FluidProperties::inRegionPH(Real pressure, Real enthalpy) const
     else if (enthalpy > h(pressure, b23T(pressure)) && enthalpy <= h(pressure, 1073.15))
       region = 2;
     else
-      mooseError("Enthalpy ", enthalpy, " is out of range in ", name(), ": inRegionPH()");
+      throw MooseException("Enthalpy " + Moose::stringify(enthalpy) + " is out of range in " +
+                           name() + ": inRegionPH()");
   }
   else
-    mooseError("Pressure ", pressure, " is out of range in ", name(), ": inRegionPH()");
+    throw MooseException("Pressure " + Moose::stringify(pressure) + " is out of range in " +
+                         name() + ": inRegionPH()");
 
   return region;
 }
@@ -1732,7 +1738,8 @@ Water97FluidProperties::b2bc(Real pressure) const
 {
   // Check whether the input pressure is within the region of validity of this equation.
   if (pressure < 6.5467e6 || pressure > 100.0e6)
-    mooseError(name(), ": b2bc(): Pressure is outside range of 6.5467 MPa <= p <= 100 MPa");
+    throw MooseException(name() +
+                         ": b2bc(): Pressure is outside range of 6.5467 MPa <= p <= 100 MPa");
 
   Real pi = pressure / 1.0e6;
 
@@ -1847,7 +1854,8 @@ Water97FluidProperties::b3ab(Real pressure) const
 {
   // Check whether the input pressure is within the region of validity of this equation.
   if (pressure < b23p(623.15) || pressure > 100.0e6)
-    mooseError(name(), ": b3ab(): Pressure is outside range of 16.529 MPa <= p <= 100 MPa");
+    throw MooseException(name() +
+                         ": b3ab(): Pressure is outside range of 16.529 MPa <= p <= 100 MPa");
 
   Real pi = pressure / 1.0e6;
   Real eta = 0.201464004206875e4 + 0.374696550136983e1 * pi - 0.219921901054187e-1 * pi * pi +

--- a/modules/fluid_properties/src/utils/BrentsMethod.C
+++ b/modules/fluid_properties/src/utils/BrentsMethod.C
@@ -7,6 +7,7 @@
 
 #include "BrentsMethod.h"
 #include "MooseError.h"
+#include "Conversion.h"
 
 namespace BrentsMethod
 {
@@ -23,7 +24,7 @@ bracket(std::function<Real(Real)> const & f, Real & x1, Real & x2)
 
   // If the initial guesses are identical
   if (x1 == x2)
-    mooseError("Bad initial range (0) used in BrentsMethod::bracket");
+    throw MooseException("Bad initial range (0) used in BrentsMethod::bracket");
 
   f1 = f(x1);
   f2 = f(x2);
@@ -48,8 +49,8 @@ bracket(std::function<Real(Real)> const & f, Real & x1, Real & x2)
       /// Increment counter
       iter++;
       if (iter >= n)
-        mooseError(
-            "No bracketing interval found by BrentsMethod::bracket after ", n, " iterations");
+        throw MooseException("No bracketing interval found by BrentsMethod::bracket after " +
+                             Moose::stringify(n) + " iterations");
     }
   }
 }
@@ -65,7 +66,7 @@ root(std::function<Real(Real)> const & f, Real x1, Real x2, Real tol)
   Real eps = 1.0e-12;
 
   if (fa * fb > 0.0)
-    mooseError("Root must be bracketed in BrentsMethod::root");
+    throw MooseException("Root must be bracketed in BrentsMethod::root");
 
   fc = fb;
   for (unsigned int i = 1; i <= iter_max; ++i)
@@ -151,7 +152,7 @@ root(std::function<Real(Real)> const & f, Real x1, Real x2, Real tol)
     fb = f(b);
   }
 
-  mooseError("Maximum number of iterations exceeded in BrentsMethod::root");
+  throw MooseException("Maximum number of iterations exceeded in BrentsMethod::root");
   return 0.0; // Should never get here
 }
 } // namespace BrentsMethod


### PR DESCRIPTION
Not all mooseErrors have been switched to MooseException - just the ones i thought relevant.
I don't think returning quiet_NaN, as discussed in the github issue, is possible in some cases.

Fixes #10166

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
