### PR TITLE
Fix NavBar width

### DIFF
--- a/docs/templates/include/header.html
+++ b/docs/templates/include/header.html
@@ -7,7 +7,7 @@ Page header including the top and sidebar navigation.
     {% set drop_id=prefix + '-' + nav_key.replace(' ', '-') %}
     {% set nav_value=nav.values()[0] %}
     {% if nav_value is iterable and nav_value is not string %}
-      <li><a class="dropdown-button" href="#!" data-activates="{{drop_id}}">{{nav_key}}<i class="material-icons right">arrow_drop_down</i></a></li>
+      <li><a class="dropdown-button" href="#!" data-activates="{{drop_id}}" data-constrainwidth="false">{{nav_key}}<i class="material-icons right">arrow_drop_down</i></a></li>
       <ul id="{{drop_id}}" class="dropdown-content">
       {% for item in nav_value %}
         <li><a href="{{item.values()[0]}}">{{item.keys()[0]}}</a></li>


### PR DESCRIPTION
Fix the issue with the navbar providing only the same
amount of width as the characters representing it. It
should size to the width of the items contained within
it instead.

Also,
Include a CSS change that clears any floating div object
for '##' headings. This allows what ever is between two
'##' headings (H2) to not overlap. This helps when
dealing with images floating around text in a section.

See:

  http://mooseframework.org/moose/documentation/modules/phase_field/index.html

and compare to this PR. The image should remain within
"Multiple Phase Modules" and not start to 'bleed' into
other sections.

Closes #10386