### PR TITLE
Added missing include guards to CSVReader.h

### DIFF
--- a/framework/include/vectorpostprocessors/CSVReader.h
+++ b/framework/include/vectorpostprocessors/CSVReader.h
@@ -12,6 +12,9 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+#ifndef CSVREADER_H
+#define CSVREADER_H
+
 // MOOSE includes
 #include "GeneralVectorPostprocessor.h"
 #include "DelimitedFileReader.h"
@@ -37,3 +40,5 @@ protected:
   /// is possible for the file to change and add new vectors during the simulation.
   std::map<std::string, VectorPostprocessorValue *> _column_data;
 };
+
+#endif // CSVREADER_H


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Added the missing include guards in CSVReader.h, allowing for users to build an application which registers multiple VectorPostprocessors which inherit from CSVReader.

Closes #10388.