### PR TITLE
Improving coupling error checking

### DIFF
--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -21,6 +21,7 @@
 // Forward declarations
 class InputParameters;
 class MooseVariable;
+class MooseVariableScalar;
 class MooseObject;
 namespace libMesh
 {
@@ -314,6 +315,9 @@ protected:
   // Reference to the interface's input parameters
   const InputParameters & _c_parameters;
 
+  /// The name of the object this interface is part of
+  const std::string & _c_name;
+
   // Reference to FEProblemBase
   FEProblemBase & _c_fe_problem;
 
@@ -343,6 +347,14 @@ protected:
 
   /// This will always be zero because the default values for optionally coupled variables is always constant
   VariableSecond _default_second;
+
+  /**
+   * Check that the right kind of variable is being coupled in
+   *
+   * @param var_name The name of the coupled variable
+   * @param comp The component of the coupled variable
+   */
+  void checkVar(const std::string & var_name, unsigned int comp);
 
   /**
    * Extract pointer to a coupled variable
@@ -376,6 +388,9 @@ private:
 
   /// Unique indices for optionally coupled vars that weren't provided
   std::map<std::string, unsigned int> _optional_var_index;
+
+  /// Scalar variables coupled into this object (for error checking)
+  std::map<std::string, std::vector<MooseVariableScalar *>> _c_coupled_scalar_vars;
 };
 
 #endif /* COUPLEABLE_H */

--- a/framework/include/base/ScalarCoupleable.h
+++ b/framework/include/base/ScalarCoupleable.h
@@ -59,6 +59,9 @@ protected:
   // Reference to the interface's input parameters
   const InputParameters & _sc_parameters;
 
+  /// The name of the object this interface is part of
+  const std::string & _sc_name;
+
   /**
    * Returns true if a variables has been coupled_as name.
    * @param var_name The of the coupled variable
@@ -158,12 +161,24 @@ protected:
   VariableValue * getDefaultValue(const std::string & var_name);
 
   /**
+   * Check that the right kind of variable is being coupled in
+   *
+   * @param var_name The name of the coupled variable
+   * @param comp The component of the coupled variable
+   */
+  void checkVar(const std::string & var_name, unsigned int comp);
+
+  /**
    * Extract pointer to a scalar coupled variable
    * @param var_name Name of parameter desired
    * @param comp Component number of multiple coupled variables
    * @return Pointer to the desired variable
    */
   MooseVariableScalar * getScalarVar(const std::string & var_name, unsigned int comp);
+
+private:
+  /// Field variables coupled into this object (for error checking)
+  std::map<std::string, std::vector<MooseVariable *>> _sc_coupled_vars;
 };
 
 #endif // SCALARCOUPLEABLE_H

--- a/test/src/scalarkernels/ImplicitODEx.C
+++ b/test/src/scalarkernels/ImplicitODEx.C
@@ -19,7 +19,7 @@ InputParameters
 validParams<ImplicitODEx>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("y", "Y");
+  params.addRequiredsCoupledVar("y", "Y");
   return params;
 }
 

--- a/test/src/scalarkernels/ImplicitODEx.C
+++ b/test/src/scalarkernels/ImplicitODEx.C
@@ -19,7 +19,7 @@ InputParameters
 validParams<ImplicitODEx>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addRequiredsCoupledVar("y", "Y");
+  params.addRequiredCoupledVar("y", "Y");
   return params;
 }
 

--- a/test/src/scalarkernels/ImplicitODEy.C
+++ b/test/src/scalarkernels/ImplicitODEy.C
@@ -19,7 +19,7 @@ InputParameters
 validParams<ImplicitODEy>()
 {
   InputParameters params = validParams<ODEKernel>();
-  params.addCoupledVar("x", "X");
+  params.addRequiredCoupledVar("x", "X");
   return params;
 }
 

--- a/test/tests/misc/check_error/coupling_field_into_scalar.i
+++ b/test/tests/misc/check_error/coupling_field_into_scalar.i
@@ -1,0 +1,53 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Variables]
+  [./u]
+  [../]
+  [./a]
+    family = SCALAR
+    order = FIRST
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+
+  [./slm]
+    type = ScalarLagrangeMultiplier
+    variable = u
+    # this should trigger an error message, lambda is scalar
+    lambda = v
+  [../]
+[]
+
+[ScalarKernels]
+  [./alpha]
+    type = AlphaCED
+    variable = a
+    value = 1
+  [../]
+[]
+
+[BCs]
+  [./all]
+    type = DirichletBC
+    boundary = 'left right top bottom'
+    variable = u
+    value = 0
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_error/coupling_nonexistent_field.i
+++ b/test/tests/misc/check_error/coupling_nonexistent_field.i
@@ -1,0 +1,22 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./coupled]
+    type = CoupledForce
+    variable = u
+    # 'a' does not exist -> error
+    v = a
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_error/coupling_nonexistent_scalar.i
+++ b/test/tests/misc/check_error/coupling_nonexistent_scalar.i
@@ -1,0 +1,22 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./slm]
+    type = ScalarLagrangeMultiplier
+    variable = u
+    # 'b' does not exist -> error
+    lambda = b
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_error/coupling_scalar_into_field.i
+++ b/test/tests/misc/check_error/coupling_scalar_into_field.i
@@ -1,0 +1,48 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[Variables]
+  [./u]
+  [../]
+  [./a]
+    family = SCALAR
+    order = FIRST
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+
+  [./coupled]
+    type = CoupledForce
+    variable = u
+    # this should trigger an error message, 'v' should a field variable
+    v = a
+  [../]
+[]
+
+[ScalarKernels]
+  [./alpha]
+    type = AlphaCED
+    variable = a
+    value = 1
+  [../]
+[]
+
+[BCs]
+  [./all]
+    type = DirichletBC
+    boundary = 'left right top bottom'
+    variable = u
+    value = 0
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -564,4 +564,28 @@
     input = 'bad_number.i'
     expect_err = "invalid float syntax for parameter: BCs/right/value"
   [../]
+
+  [./coupling_field_into_scalar]
+    type = 'RunException'
+    input = 'coupling_field_into_scalar.i'
+    expect_err = "slm: Trying to couple a field variable where scalar variable is expected, 'lambda = v'"
+  [../]
+
+  [./coupling_scalar_into_field]
+    type = 'RunException'
+    input = 'coupling_scalar_into_field.i'
+    expect_err = "coupled: Trying to couple a scalar variable where field variable is expected, 'v = a'"
+  [../]
+
+  [./coupling_nonexistent_field]
+    type = 'RunException'
+    input = 'coupling_nonexistent_field.i'
+    expect_err = "coupled: Coupled variable 'a' was not found"
+  [../]
+
+  [./coupling_nonexistent_scalar]
+    type = 'RunException'
+    input = 'coupling_nonexistent_scalar.i'
+    expect_err = "slm: Coupled variable 'b' was not found"
+  [../]
 []


### PR DESCRIPTION
1. error out when coupling scalar variables where field ones are expected
2. error out when coupling field variables where scalar ones are expected
3. report the name of the object where the error occured
 
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
