### PR TITLE
Include a scaling factor into ReferenceResidualProblem

### DIFF
--- a/modules/combined/test/tests/reference_residual/tests
+++ b/modules/combined/test/tests/reference_residual/tests
@@ -15,4 +15,14 @@
     scale_refine = 2
     prereq = test
   [../]
+    [./test_scaling]
+      type = 'Exodiff'
+      input = 'reference_residual.i'
+      exodiff = 'reference_residual_out.e'
+      cli_args = 'Variables/disp_x/scaling=2
+                  Variables/disp_y/scaling=0.1
+                  Variables/disp_z/scaling=30
+                  Variables/temp/scaling=0.001'
+      prereq = test_sm
+    [../]
 []

--- a/modules/contact/include/ReferenceResidualProblem.h
+++ b/modules/contact/include/ReferenceResidualProblem.h
@@ -73,6 +73,9 @@ protected:
   std::vector<Real> _refResid;
   std::vector<Real> _resid;
   ///@}
+
+  /// Local storage for the scaling factors applied to each of the variables to apply to _refResidVars.
+  std::vector<Real> _scaling_factors;
 };
 
 #endif /* REFERENCERESIDUALPROBLEM_H */


### PR DESCRIPTION
### Relevant design information
Uses the MooseVariable method getVariable to obtain the scaling factor for each of the variables passed into ReferenceResidualProblem.  This change assumes that the scaling factor is constant (which may be a limited time assumption) and sets a vector of scaling factors in the init method. Under this same assumption, I've used a cheat method around the required value for `_tid` (hard coded to 0) as done in [FeProblemBase](https://github.com/idaholab/moose/blob/b7d743ae472713bdaa8b745bb1387df5c3a2348f/framework/src/base/FEProblemBase.C#L4749) with this same method.

### Test cases
To test the impact of the scaling factor, I've added another test case in the tests file using cli_args to set the variables scaling factors.  ~~The scaling factors used were selected to produce a change in the number of nonlinear iterations; hence another gold file is checked in with this different number of nonlinear iterations.~~ The scaled test problem compares to the existing gold file.

Looking for feedback on the this implementation please @permcody @friedmud @bwspenc. Once we have a settled on an implementation for the residual aux variables, I'll copy that implementation for the variable in the Kernels to replace the scaling of the variables in Assembly, if that is the approach we still want to take.

Closes #10403 