### PR TITLE
Libmesh update

### DIFF
--- a/framework/include/preconditioners/PhysicsBasedPreconditioner.h
+++ b/framework/include/preconditioners/PhysicsBasedPreconditioner.h
@@ -81,7 +81,7 @@ protected:
   /// List of linear system that build up the preconditioner
   std::vector<LinearImplicitSystem *> _systems;
   /// Holds one Preconditioner object per small system to solve.
-  std::vector<Preconditioner<Number> *> _preconditioners;
+  std::vector<std::unique_ptr<Preconditioner<Number>>> _preconditioners;
   /// Holds the order the blocks are solved for.
   std::vector<unsigned int> _solve_order;
   /// Which preconditioner to use for each solve.

--- a/framework/include/utils/KDTree.h
+++ b/framework/include/utils/KDTree.h
@@ -114,7 +114,7 @@ public:
 
 protected:
   PointListAdaptor<LIBMESH_DIM> _point_list_adaptor;
-  UniquePtr<KdTreeT> _kd_tree;
+  std::unique_ptr<KdTreeT> _kd_tree;
 };
 
 #endif // KDTREE_H

--- a/framework/src/meshmodifiers/AddExtraNodeset.C
+++ b/framework/src/meshmodifiers/AddExtraNodeset.C
@@ -80,7 +80,7 @@ AddExtraNodeset::modify()
   unsigned int dim = _mesh_ptr->dimension();
   unsigned int n_nodes = coord.size() / dim;
 
-  UniquePtr<PointLocatorBase> locator = _mesh_ptr->getMesh().sub_point_locator();
+  std::unique_ptr<PointLocatorBase> locator = _mesh_ptr->getMesh().sub_point_locator();
   locator->enable_out_of_mesh_mode();
 
   for (unsigned int i = 0; i < n_nodes; ++i)

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -146,9 +146,6 @@ PhysicsBasedPreconditioner::PhysicsBasedPreconditioner(const InputParameters & p
 PhysicsBasedPreconditioner::~PhysicsBasedPreconditioner()
 {
   this->clear();
-
-  for (auto & pc : _preconditioners)
-    delete pc;
 }
 
 void
@@ -204,11 +201,11 @@ PhysicsBasedPreconditioner::init()
 
     if (!_preconditioners[system_var])
       _preconditioners[system_var] =
-          Preconditioner<Number>::build(MoosePreconditioner::_communicator);
+          Preconditioner<Number>::build_preconditioner(MoosePreconditioner::_communicator);
 
     // we have to explicitly set the matrix in the preconditioner, because h-adaptivity could have
     // changed it and we have to work with the current one
-    Preconditioner<Number> * preconditioner = _preconditioners[system_var];
+    Preconditioner<Number> * preconditioner = _preconditioners[system_var].get();
     preconditioner->set_matrix(*u_system.matrix);
     preconditioner->set_type(_pre_type[system_var]);
 

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -854,7 +854,7 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
             if (bc_id_set.find(boundary_id) == bc_id_set.end())
               continue;
 
-            UniquePtr<const Elem> side_bdry = elem_bdry->build_side_ptr(side, false);
+            std::unique_ptr<const Elem> side_bdry = elem_bdry->build_side_ptr(side, false);
             evindices.clear();
             dofmap.dof_indices(side_bdry.get(), evindices, v);
             for (const auto & edof : evindices)

--- a/modules/solid_mechanics/src/postprocessors/InteractionIntegralSM.C
+++ b/modules/solid_mechanics/src/postprocessors/InteractionIntegralSM.C
@@ -250,7 +250,7 @@ InteractionIntegralSM::computeIntegral()
   FEType fe_type(Utility::string_to_enum<Order>("first"),
                  Utility::string_to_enum<FEFamily>("lagrange"));
   const unsigned int dim = _current_elem->dim();
-  UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+  std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
   fe->attach_quadrature_rule(_qrule);
   _phi_curr_elem = &fe->get_phi();
   _dphi_curr_elem = &fe->get_dphi();

--- a/modules/tensor_mechanics/src/postprocessors/InteractionIntegral.C
+++ b/modules/tensor_mechanics/src/postprocessors/InteractionIntegral.C
@@ -249,7 +249,7 @@ InteractionIntegral::computeIntegral()
   FEType fe_type(Utility::string_to_enum<Order>("first"),
                  Utility::string_to_enum<FEFamily>("lagrange"));
   const unsigned int dim = _current_elem->dim();
-  UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+  std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
   fe->attach_quadrature_rule(_qrule);
   _phi_curr_elem = &fe->get_phi();
   _dphi_curr_elem = &fe->get_dphi();

--- a/modules/tensor_mechanics/src/postprocessors/JIntegral.C
+++ b/modules/tensor_mechanics/src/postprocessors/JIntegral.C
@@ -134,7 +134,7 @@ JIntegral::computeIntegral()
   FEType fe_type(Utility::string_to_enum<Order>("first"),
                  Utility::string_to_enum<FEFamily>("lagrange"));
   const unsigned int dim = _current_elem->dim();
-  UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+  std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
   fe->attach_quadrature_rule(_qrule);
   _phi_curr_elem = &fe->get_phi();
   _dphi_curr_elem = &fe->get_dphi();

--- a/modules/xfem/src/materials/ComputeCrackTipEnrichmentSmallStrain.C
+++ b/modules/xfem/src/materials/ComputeCrackTipEnrichmentSmallStrain.C
@@ -119,7 +119,7 @@ ComputeCrackTipEnrichmentSmallStrain::computeProperties()
   FEType fe_type(Utility::string_to_enum<Order>("first"),
                  Utility::string_to_enum<FEFamily>("lagrange"));
   const unsigned int dim = _current_elem->dim();
-  UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+  std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
   fe->attach_quadrature_rule(_qrule);
   _fe_phi = &(fe->get_phi());
   _fe_dphi = &(fe->get_dphi());

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -95,6 +95,7 @@ if [ -z "$go_fast" ]; then
                --enable-openmp \
                --disable-maintainer-mode \
                --enable-petsc-required \
+               --disable-metaphysicl \
                $DISABLE_TIMESTAMPS $VTK_OPTIONS $* || exit 1
 else
   # The build directory must already exist: you can't do --fast for

--- a/test/src/userobjects/RandomHitSolutionModifier.C
+++ b/test/src/userobjects/RandomHitSolutionModifier.C
@@ -43,7 +43,7 @@ RandomHitSolutionModifier::RandomHitSolutionModifier(const InputParameters & par
 void
 RandomHitSolutionModifier::execute()
 {
-  UniquePtr<PointLocatorBase> pl = _mesh.getMesh().sub_point_locator();
+  std::unique_ptr<PointLocatorBase> pl = _mesh.getMesh().sub_point_locator();
   pl->enable_out_of_mesh_mode();
 
   const std::vector<Point> & hits = _random_hits.hits();


### PR DESCRIPTION
Brief summary of changes in this update:

* DistributedMesh fixes in InfElem examples
* Add new InfElem example, miscellaneous_ex14
* Fix check in `PetscVector<Complex>::localize_to_one`
* Break EqSys::reinit() into solutions,systems parts
* Misc. fixes for --disable-amr/optional builds
* configure support for Intel 18 compiler
* Add MetaPhysicL 0.2.0 (with patches) to contrib
* Add "projection matrix" unit tests for several element types
* Fparser: Add registered derivatives to hash
* Replace UniquePtr macro with std::unique_ptr
* Use libmesh_make_unique instead of raw new when possible
* Use std containers of std::unique_ptrs when possible
* Remove build/release/reset cruft when working with std::unique_ptrs
* Drop auto_ptr.h includes where it does not affect backwards compatibility
* Fix/restrict Partitioners for use with DistributedMesh
* JumpErrorEstimator fix for non-zero-norm SCALAR
* Support changing number of ghosted layers in splitter app
* Drop autoconf support for older compilers
* Deprecate Preconditioner::build()
* Add ASPECT_RATIO, STRETCH, SHAPE, SKEW quality metrics for Quad4

Refs #000.