### PR TITLE
parser: use new param metadata API for special data

### DIFF
--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -30,14 +30,6 @@ InputParameters validParams<MooseObject>();
 // needed to avoid #include cycle with MooseApp and MooseObject
 [[noreturn]] void callMooseErrorRaw(std::string & msg, MooseApp * app);
 
-/// returns a string representing a special parameter name that the parser injects into object
-/// parameters holding the file+linenum for the parameter.
-std::string paramLocName(std::string param);
-
-/// returns a string representing a special parameter name that the parser injects into object
-/// parameters holding the file+linenum for the parameter.
-std::string paramPathName(std::string param);
-
 /**
  * Every object that can be built by the factory should be derived from this class.
  */
@@ -104,9 +96,8 @@ public:
   [[noreturn]] void paramError(const std::string & param, Args... args)
   {
     auto prefix = param + ": ";
-    if (_pars.have_parameter<std::string>(paramLocName(param)))
-      prefix = _pars.get<std::string>(paramLocName(param)) + ": (" +
-               _pars.get<std::string>(paramPathName(param)) + ") ";
+    if (!_pars.inputLocation(param).empty())
+      prefix = _pars.inputLocation(param) + ": (" + _pars.paramFullpath(param) + ") ";
     mooseError(prefix, args...);
   }
 

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -659,33 +659,49 @@ public:
    */
   std::set<std::string> reservedValues(const std::string & name) const;
 
-  /// Get/set a string representing the location (i.e. filename,linenum) in the input text for the
-  /// block containing parameters for this object.
+  /**
+   * Get/set a string representing the location (i.e. filename,linenum) in the input text for the
+   * block containing parameters for this object.
+   */
   std::string & blockLocation() { return _block_location; };
 
-  /// Get/set a string representing the full HIT parameter path from the input file (e.g.
-  /// "Mesh/foo") for the block containing parameters for this object.
+  ///@{
+  /**
+   * Get/set a string representing the full HIT parameter path from the input file (e.g.
+   * "Mesh/foo") for the block containing parameters for this object.
+   */
   std::string & blockFullpath() { return _block_fullpath; }
   const std::string & blockFullpath() const { return _block_fullpath; }
+  ///@}
 
-  /// Get/set a string representing the location in the input text the parameter originated from
-  /// (i.e. filename,linenum) for the given param.
+  ///@{
+  /**
+   * Get/set a string representing the location in the input text the parameter originated from
+   * (i.e. filename,linenum) for the given param.
+   */
   const std::string & inputLocation(const std::string & param) const
   {
     return at(param)._input_location;
   };
   std::string & inputLocation(const std::string & param) { return at(param)._input_location; };
+  ///@}
 
-  /// Get/set a string representing the full HIT parameter path from the input file (e.g.
-  /// "Mesh/foo/bar" for param "bar") for the given param.
+  ///@{
+  /**
+   * Get/set a string representing the full HIT parameter path from the input file (e.g.
+   * "Mesh/foo/bar" for param "bar") for the given param.
+   */
   const std::string & paramFullpath(const std::string & param) const
   {
     return at(param)._param_fullpath;
   };
   std::string & paramFullpath(const std::string & param) { return at(param)._param_fullpath; };
+  ///@}
 
-  /// Get/set a string representing the raw, unmodified token text for the given param.  This is
-  /// usually only set/useable for file-path type parameters.
+  /**
+   * Get/set a string representing the raw, unmodified token text for the given param.  This is
+   * usually only set/useable for file-path type parameters.
+   */
   std::string & rawParamVal(const std::string & param) { return _params[param]._raw_val; };
 
 private:

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -659,6 +659,41 @@ public:
    */
   std::set<std::string> reservedValues(const std::string & name) const;
 
+  /// Get/set a string representing the location (i.e. filename,linenum) in the input text for the
+  /// block containing parameters for this object.
+  std::string & blockLocation() { return _block_location; };
+
+  /// Get/set a string representing the full HIT parameter path from the input file (e.g.
+  /// "Mesh/foo") for the block containing parameters for this object.
+  std::string & blockFullpath() { return _block_fullpath; }
+  const std::string & blockFullpath() const { return _block_fullpath; }
+
+  /// Get/set a string representing the location in the input text the parameter originated from
+  /// (i.e. filename,linenum) for the given param.
+  const std::string & inputLocation(const std::string & param) const
+  {
+    return _params.at(param)._input_location;
+  };
+  std::string & inputLocation(const std::string & param)
+  {
+    return _params.at(param)._input_location;
+  };
+
+  /// Get/set a string representing the full HIT parameter path from the input file (e.g.
+  /// "Mesh/foo/bar" for param "bar") for the given param.
+  const std::string & paramFullpath(const std::string & param) const
+  {
+    return _params.at(param)._param_fullpath;
+  };
+  std::string & paramFullpath(const std::string & param)
+  {
+    return _params.at(param)._param_fullpath;
+  };
+
+  /// Get/set a string representing the raw, unmodified token text for the given param.  This is
+  /// usually only set/useable for file-path type parameters.
+  std::string & rawParamVal(const std::string & param) { return _params[param]._raw_val; };
+
 private:
   // Private constructor so that InputParameters can only be created in certain places.
   InputParameters();
@@ -722,6 +757,11 @@ private:
     /// raw token text for a parameter - usually only set for filepath type params.
     std::string _raw_val;
   };
+
+  /// original location of input block (i.e. filename,linenum) - used for nice error messages.
+  std::string _block_location;
+  /// full HIT path of the block from the input file - used for nice error messages.
+  std::string _block_fullpath;
 
   std::map<std::string, Metadata> _params;
 
@@ -1268,7 +1308,10 @@ template <typename T>
 const T &
 InputParameters::getParamHelper(const std::string & name, const InputParameters & pars, const T *)
 {
-  if (!pars.isParamValid(name))
+  // TODO: after updating apps (i.e. rattlesnake) remove the first if clause+body:
+  if (name == "parser_syntax")
+    return (const T &)pars.blockFullpath();
+  else if (!pars.isParamValid(name))
     mooseError("The parameter \"", name, "\" is being retrieved before being set.\n");
   return pars.get<T>(name);
 }

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -672,23 +672,17 @@ public:
   /// (i.e. filename,linenum) for the given param.
   const std::string & inputLocation(const std::string & param) const
   {
-    return _params.at(param)._input_location;
+    return at(param)._input_location;
   };
-  std::string & inputLocation(const std::string & param)
-  {
-    return _params.at(param)._input_location;
-  };
+  std::string & inputLocation(const std::string & param) { return at(param)._input_location; };
 
   /// Get/set a string representing the full HIT parameter path from the input file (e.g.
   /// "Mesh/foo/bar" for param "bar") for the given param.
   const std::string & paramFullpath(const std::string & param) const
   {
-    return _params.at(param)._param_fullpath;
+    return at(param)._param_fullpath;
   };
-  std::string & paramFullpath(const std::string & param)
-  {
-    return _params.at(param)._param_fullpath;
-  };
+  std::string & paramFullpath(const std::string & param) { return at(param)._param_fullpath; };
 
   /// Get/set a string representing the raw, unmodified token text for the given param.  This is
   /// usually only set/useable for file-path type parameters.
@@ -697,24 +691,6 @@ public:
 private:
   // Private constructor so that InputParameters can only be created in certain places.
   InputParameters();
-
-  /**
-   * Toggle the availability of the copy constructor
-   *
-   * When MooseObject is created via the Factory this flag is set to false, so when a MooseObject is
-   * created if
-   * the constructor is not a const reference an error is produced. This method allows the
-   * InputParameterWarehouse
-   * to disable copying.
-   */
-  void allowCopy(bool status) { _allow_copy = status; }
-
-  /// Make sure the parameter name doesn't have any invalid characters.
-  void checkParamName(const std::string & name) const;
-
-  /// This method is called when adding a Parameter with a default value, can be specialized for non-matching types
-  template <typename T, typename S>
-  void setParamHelper(const std::string & name, T & l_value, const S & r_value);
 
   struct Metadata
   {
@@ -757,6 +733,37 @@ private:
     /// raw token text for a parameter - usually only set for filepath type params.
     std::string _raw_val;
   };
+
+  Metadata & at(const std::string & param)
+  {
+    if (_params.count(param) == 0)
+      mooseError("param '", param, "' not present in InputParams");
+    return _params[param];
+  }
+  const Metadata & at(const std::string & param) const
+  {
+    if (_params.count(param) == 0)
+      mooseError("param '", param, "' not present in InputParams");
+    return _params.at(param);
+  }
+
+  /**
+   * Toggle the availability of the copy constructor
+   *
+   * When MooseObject is created via the Factory this flag is set to false, so when a MooseObject is
+   * created if
+   * the constructor is not a const reference an error is produced. This method allows the
+   * InputParameterWarehouse
+   * to disable copying.
+   */
+  void allowCopy(bool status) { _allow_copy = status; }
+
+  /// Make sure the parameter name doesn't have any invalid characters.
+  void checkParamName(const std::string & name) const;
+
+  /// This method is called when adding a Parameter with a default value, can be specialized for non-matching types
+  template <typename T, typename S>
+  void setParamHelper(const std::string & name, T & l_value, const S & r_value);
 
   /// original location of input block (i.e. filename,linenum) - used for nice error messages.
   std::string _block_location;

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -377,8 +377,8 @@ ActionWarehouse::printInputFile(std::ostream & out)
   for (const auto & act : ordered_actions)
   {
     std::string name;
-    if (act->isParamValid("parser_syntax"))
-      name = act->getParam<std::string>("parser_syntax");
+    if (act->parameters().blockFullpath() != "")
+      name = act->parameters().blockFullpath();
     else
       name = act->name();
     const std::set<std::string> & tasks = act->getAllTasks();

--- a/framework/src/actions/AddICAction.C
+++ b/framework/src/actions/AddICAction.C
@@ -31,7 +31,7 @@ void
 AddICAction::act()
 {
   std::vector<std::string> elements;
-  MooseUtils::tokenize<std::string>(getParam<std::string>("parser_syntax"), elements);
+  MooseUtils::tokenize<std::string>(_pars.blockFullpath(), elements);
 
   // The variable name will be the second to last element in the path name
   std::string & var_name = elements[elements.size() - 2];

--- a/framework/src/actions/MooseObjectAction.C
+++ b/framework/src/actions/MooseObjectAction.C
@@ -37,7 +37,5 @@ MooseObjectAction::MooseObjectAction(InputParameters params)
                            ? _factory.getValidParams(_type)
                            : validParams<MooseObject>())
 {
-  if (params.have_parameter<std::string>("parser_syntax"))
-    _moose_object_pars.addPrivateParam<std::string>("parser_syntax",
-                                                    params.get<std::string>("parser_syntax"));
+  _moose_object_pars.blockFullpath() = params.blockFullpath();
 }

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -17,18 +17,6 @@
 #include "MooseApp.h"
 #include "MooseUtils.h"
 
-std::string
-paramLocName(std::string param)
-{
-  return "_" + param + "_fileloc";
-}
-
-std::string
-paramPathName(std::string param)
-{
-  return "_" + param + "_fullpath";
-}
-
 template <>
 InputParameters
 validParams<MooseObject>()

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -331,25 +331,25 @@
   [./missing_req_par_action_obj_test]
     type = 'RunException'
     input = 'missing_req_par_action_obj_test.i'
-    expect_err = "The following required parameters are missing:\n\s*ConvectionDiffusion/variables"
+    expect_err = "missing required parameter 'ConvectionDiffusion/variables'"
   [../]
 
   [./missing_req_par_mesh_block_test]
     type = 'RunException'
     input = 'missing_req_par_mesh_block_test.i'
-    expect_err = "The following required parameters are missing:\n\s*Mesh/stripes"
+    expect_err = "missing required parameter 'Mesh/stripes'"
   [../]
 
   [./missing_req_par_moose_obj_test]
     type = 'RunException'
     input = 'missing_req_par_moose_obj_test.i'
-    expect_err = "The following required parameters are missing:\n\s*Kernels/diff/variable"
+    expect_err = "missing required parameter 'Kernels/diff/variable'"
   [../]
 
   [./missing_required_coupled_test]
     type = 'RunException'
     input = 'missing_required_coupled.i'
-    expect_err = "The following required parameters are missing:\n\s*Kernels/conv_v/velocity_vector"
+    expect_err = "missing required parameter 'Kernels/conv_v/velocity_vector'"
   [../]
 
   [./multi_precond_test]
@@ -481,7 +481,7 @@
   [./ics_missing_variable]
     type = 'RunException'
     input = 'ic_variable_not_specified.i'
-    expect_err = "The following required parameters are missing:\n\s*ICs/u_ic/variable"
+    expect_err = "missing required parameter 'ICs/u_ic/variable'"
   [../]
 
   [./ic_bnd_for_non_nodal]

--- a/test/tests/multiapps/check_error/tests
+++ b/test/tests/multiapps/check_error/tests
@@ -2,7 +2,7 @@
   [./input_file]
     type = 'RunException'
     input = 'check_error.i'
-    expect_err = 'The following required'
+    expect_err = 'missing required parameter'
   [../]
 
   [./unused_subapp_param]

--- a/test/tests/userobjects/side_user_object_no_boundary_error/tests
+++ b/test/tests/userobjects/side_user_object_no_boundary_error/tests
@@ -2,6 +2,6 @@
   [./test]
     type = RunException
     input = side_no_boundary.i
-    expect_err = "The following required parameters are missing:\n\s*Postprocessors/avg/boundary"
+    expect_err = "missing required parameter 'Postprocessors/avg/boundary'"
   [../]
 []

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -30,7 +30,7 @@ TEST(InputParameters, checkControlParamPrivateError)
   catch (const std::exception & e)
   {
     std::string msg(e.what());
-    ASSERT_TRUE(msg.find("is a private param") != std::string::npos)
+    ASSERT_TRUE(msg.find("private parameter '' marked controllable") != std::string::npos)
         << "failed with unexpected error: " << msg;
   }
 }
@@ -68,7 +68,7 @@ TEST(InputParameters, checkControlParamTypeError)
   catch (const std::exception & e)
   {
     std::string msg(e.what());
-    ASSERT_TRUE(msg.find("cannot be marked as controllable because its type") != std::string::npos)
+    ASSERT_TRUE(msg.find("non-controllable type") != std::string::npos)
         << "failed with unexpected error:" << msg;
   }
 }
@@ -85,7 +85,7 @@ TEST(InputParameters, checkControlParamValidError)
   catch (const std::exception & e)
   {
     std::string msg(e.what());
-    ASSERT_TRUE(msg.find("The parameter 'not_valid'") != std::string::npos)
+    ASSERT_TRUE(msg.find("invalid parameter '' marked controllable") != std::string::npos)
         << "failed with unexpected error: " << msg;
   }
 }


### PR DESCRIPTION
The parser previously injected extra metadata about parsed parameters
into InputParameters objects as specially named parameters.  A recent
refactor of the InputParameters class made it desirable to change this
to use an explicit param metadata API approach.  This is the final
enabling change in preparation for addressing #10357.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
