### PR TITLE
Fix how --recover and syntax tests behave

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -338,7 +338,7 @@ class TestHarness:
         elif self.num_failed > self.options.max_fails:
             tester.setStatus('Max Fails Exceeded', tester.bucket_fail)
         elif tester.parameters().isValid('have_errors') and tester.parameters()['have_errors']:
-            tester.setStatus('Parser Error', tester.bucket_skip)
+            tester.setStatus('Parser Error', tester.bucket_fail)
 
     # This method splits a lists of tests into two pieces each, the first piece will run the test for
     # approx. half the number of timesteps and will write out a restart file.  The second test will
@@ -347,7 +347,7 @@ class TestHarness:
         new_tests = []
 
         for part1 in testers:
-            if part1.parameters()['recover'] == True:
+            if part1.parameters()['recover'] == True and not part1.parameters()['check_input']:
                 # Clone the test specs
                 part2 = copy.deepcopy(part1)
 
@@ -370,6 +370,9 @@ class TestHarness:
                 part2.addCaveats('recover')
 
                 new_tests.append(part2)
+
+            elif part1.parameters()['recover'] == True and part1.parameters()['check_input']:
+                part1.setStatus('SYNTAX ONLY TEST', part1.bucket_silent)
 
         testers.extend(new_tests)
         return testers
@@ -720,6 +723,9 @@ class TestHarness:
         if opts.check_input and opts.no_check_input:
             print('ERROR: --check-input and --no-check-input can not be used together')
             sys.exit(1)
+        if opts.check_input and opts.enable_recover:
+            print('ERROR: --check-input and --recover can not be used together')
+            sys.exit(1)
 
         # Update any keys from the environment as necessary
         if not self.options.method:
@@ -755,4 +761,3 @@ class TestHarness:
 
     def getOptions(self):
         return self.options
-

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -430,8 +430,8 @@ class Tester(MooseObject):
             self.setStatus('no tag', self.bucket_silent)
             return False
 
-        # If the something has already deemed this test a failure, return now
-        if self.didFail():
+        # If something has already deemed this test a failure or is silent, return now
+        if self.didFail() or self.isSilent():
             return False
 
         # If --dry-run set the test status to pass and DO NOT return.
@@ -485,8 +485,11 @@ class Tester(MooseObject):
         if self.specs.isValid('deleted'):
             reasons['deleted'] = 'deleted ({})'.format(self.specs['deleted'])
 
-        # Check for skipped tests
-        if self.specs.type('skip') is bool and self.specs['skip']:
+        # Skipped by external means (example: TestHarness part2 with --check-input)
+        if self.isSkipped():
+            reasons['skip'] = self.getStatusMessage()
+        # Test is skipped
+        elif self.specs.type('skip') is bool and self.specs['skip']:
             # Backwards compatible (no reason)
             reasons['skip'] = 'no reason'
         elif self.specs.type('skip') is not bool and self.specs.isValid('skip'):

--- a/python/TestHarness/tests/test_ParserErrors.py
+++ b/python/TestHarness/tests/test_ParserErrors.py
@@ -1,0 +1,13 @@
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testSyntax(self):
+        """
+        Test for Parser Errors
+        """
+
+        # check that parser errors print correctly
+        # TODO: Are there more we can test?
+        output = self.runExceptionTests('-i', 'parse_errors')
+        self.assertIn('duplicate parameter', output)
+        self.assertIn('invalid date value', output)

--- a/python/TestHarness/tests/test_Syntax.py
+++ b/python/TestHarness/tests/test_Syntax.py
@@ -21,7 +21,3 @@ class TestHarnessTester(TestHarnessTestCase):
         # Check that _thee_ SYNTAX test is not run
         output = self.runTests('--no-check-input', '-i', 'syntax')
         self.assertNotIn('SYNTAX PASS', output)
-
-        # check that parser errors print correctly
-        output = self.runExceptionTests('--check-input', '-i', 'parse_errors')
-        self.assertIn('Parser Errors', output)

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -83,4 +83,8 @@
     type = PythonUnitTest
     input = test_ExtraInfo.py
   [../]
+  [./parser_errors]
+    type = PythonUnitTest
+    input = test_ParserErrors.py
+  [../]
 []

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -4,7 +4,7 @@ from mooseutils import colorText
 from collections import namedtuple
 import json
 
-TERM_COLS = 110
+TERM_COLS = int(os.getenv('MOOSE_TERM_COLS', '110'))
 
 LIBMESH_OPTIONS = {
   'mesh_mode' :    { 're_option' : r'#define\s+LIBMESH_ENABLE_PARMESH\s+(\d+)',

--- a/test/tests/test_harness/parse_errors
+++ b/test/tests/test_harness/parse_errors
@@ -4,5 +4,6 @@
     input = good.i
     check_input = true
     check_input = true
+    allow_deprecated_until = 13/32/2000
   [../]
 []


### PR DESCRIPTION
Do not allow syntax checking tests to run with a recover
test.

While solving the above, found an issue with the way statuses
worked for discovered parser errors in tests. Created a unit
test for this. Also instead of 'skipping' a failed parsed
test file, we will now fail that test.

Including a way to adjust the column length based on an
influential environment variable: 'MOOSE_TERM_COLS'.

Closes #10400

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
