### PR TITLE
Fix VTKWindowPlugin window update.

### DIFF
--- a/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
@@ -293,7 +293,7 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
 
         if self._window.needsUpdate():
             # Update the result first to avoid another when colorbar updates:
-            if self._result.needsUpdate():
+            if self._result and self._result.needsUpdate():
                 self._result.update()
             self._window.update()
             self.windowUpdated.emit()


### PR DESCRIPTION
Got this on one of the peacock tests:
```
Traceback (most recent call last):
  File "/opt/civet/build_0/moose/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py", line 296, in onWindowRequiresUpdate
    if self._result.needsUpdate():
AttributeError: 'NoneType' object has no attribute 'needsUpdate'
```

refs #10338

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
