### PR TITLE
Remove LaTeX syntax not supported by KaTeX

### DIFF
--- a/docs/content/documentation/modules/phase_field/MultiPhase/KKSDerivations.md
+++ b/docs/content/documentation/modules/phase_field/MultiPhase/KKSDerivations.md
@@ -33,12 +33,12 @@ $\nabla \cdot M(c) \nabla \mu$, we use the [`CoupledTimeDerivative`](framework/C
 
 ## Residual
 
-In the residual routine we need to calculate the term $R= \frac{\partial F}{\partial c} - \mu$.
+In the residual routine we need to calculate the term $\mathcal{R} =  \frac{\partial F}{\partial c} - \mu$.
 We exploit the KKS identity $\frac{\partial F}{\partial c}=\frac{dF_a}{dc_a}=\frac{dF_b}{dc_b}$
 and arbitrarily use the a-phase instead.
 
 $$
-R = \frac{\partial F_a}{\partial c_a} - \mu
+\mathcal{R} = \frac{\partial F_a}{\partial c_a} - \mu
 $$
 
 ### Jacobian
@@ -56,19 +56,21 @@ with the $\frac{\partial c_a}{\partial u_j}\frac{\partial}{\partial c_a}=\phi_j 
 derivative.
 
 $$
-\begin{eqnarray*}
-J &=& \frac{\partial R}{\partial u_j} = \phi_j \frac{\partial}{\partial c_a} \left( \frac{\partial F}{\partial c_a} - \mu \right)\\
-&=& \phi_j  \frac{\partial^2F}{\partial c_a^2} \\
-\end{eqnarray*}
+J = \frac{\partial \mathcal{R}}{\partial u_j} = \phi_j \frac{\partial}{\partial c_a} \left( \frac{\partial F}{\partial c_a} - \mu \right)
+$$
+
+$$
+= \phi_j  \frac{\partial^2F}{\partial c_a^2}
 $$
 
 For $\mu$
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial \mu} \left( \frac{\partial F}{\partial c_a} - \mu \right)\\
-&=& -\phi_j \\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial \mu} \left( \frac{\partial F}{\partial c_a} - \mu \right)
+$$
+
+$$
+= -\phi_j
 $$
 
 ## KKSCHBulk
@@ -77,23 +79,23 @@ The non-linear variable for this Kernel is the concentration $c$.
 
 ### Residual
 
-In the residual routine we need to calculate the term $R=\nabla \frac{dF}{dc}$.
+In the residual routine we need to calculate the term $\mathcal{R} = \nabla \frac{dF}{dc}$.
 We exploit the KKS identity $\frac{dF}{dc}=\frac{dF_a}{dc_a}=\frac{dF_b}{dc_b}$
 and arbitrarily use the a-phase instead.
-The gradient can be calculated through the chain rule (note that $F_a(c_a, p_1,p_2,\dots,p_n)$
+The gradient can be calculated through the chain rule (note that $F_a(c_a, p_1,p_2,...,p_n)$
 is potentially a function of many variables).
 
 $$
-R = \nabla \frac{dF_a}{dc_a} = \frac{d^2F_a}{dc_a^2}\nabla c_a + \sum_i \frac{d^2F_a}{dc_adp_i}\nabla p_i
+\mathcal{R} = \nabla \frac{dF_a}{dc_a} = \frac{d^2F_a}{dc_a^2}\nabla c_a + \sum_i \frac{d^2F_a}{dc_adp_i}\nabla p_i
 $$
 
-With $a = \{c_a, p_1,p_2,\dots,p_n\}$ being the vector of all arguments to $F_a$ this simplifies to
+With $a = \{c_a, p_1,p_2,...,p_n\}$ being the vector of all arguments to $F_a$ this simplifies to
 
 $$
-R=\sum_i \frac{d^2F_a}{dc_ada_i}\nabla a_i  = \sum_i R_i \nabla a_i
+\mathcal{R} = \sum_i \frac{d^2F_a}{dc_ada_i}\nabla a_i  = \sum_i R_i \nabla a_i
 $$
 
-using $R_i$ as a shorthand for the term $\frac{d^2F_a}{dc_ada_i}$ (and represented
+using $\mathcal{R}_i$ as a shorthand for the term $\frac{d^2F_a}{dc_ada_i}$ (and represented
 in the code as the array `_second_derivatives[i]`). We do have access to the
 gradients of $a_i$ through MOOSE (stored in `_grad\_args[i]`).
 
@@ -131,7 +133,7 @@ $$
 With the rules for $\frac d{du_j}$ derivatives we get
 
 $$
-R_\text{jvar} \nabla \phi_j + \sum_i \nabla a_i \frac {dR_i}{da_\text{jvar}} \phi_j
+\mathcal{R}_\text{jvar} \nabla \phi_j + \sum_i \nabla a_i \frac {dR_i}{da_\text{jvar}} \phi_j
 $$
 
 where $j$ is `_j` in the code.
@@ -141,7 +143,7 @@ where $j$ is `_j` in the code.
 For the on diagonal terms we look at the derivative w.r.t. the components of the
 non-linear variable $c$ of this kernel. Note, that $F_a$ is only indirectly a
 function of $c$. We assume the dependence is given through $c(c_a)$. The chain
-rule will thus yield terms of this form  
+rule will thus yield terms of this form
 
 $$
 \frac{dc_a}{dc} = \frac{\frac{d^2F_b}{dc_b^2}}{[1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2}},
@@ -158,11 +160,15 @@ $$
 Let's get back to the original residual with $\frac{dF}{dc}$. Then
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{d}{dc} \nabla \frac{dF}{dc}\\
-&=& \phi_j  \nabla \frac{d^2F}{dc^2} \quad,\quad \text{with (29) from [KKS]}\\
-&=& \phi_j  \nabla \frac{\frac{d^2F_b}{dc_b^2}\frac{d^2F_a}{dc_a^2}}{  [1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2} }\\
-\end{eqnarray*}
+J = \phi_j \frac{d}{dc} \nabla \frac{dF}{dc}
+$$
+
+$$
+= \phi_j  \nabla \frac{d^2F}{dc^2} \quad,\quad \text{with (29) from [KKS]}
+$$
+
+$$
+= \phi_j  \nabla \frac{\frac{d^2F_b}{dc_b^2}\frac{d^2F_a}{dc_a^2}}{  [1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2} }
 $$
 
 # Allen-Cahn  Kernels
@@ -170,15 +176,31 @@ $$
 For the bulk Allen-Cahn residual we need to calculate the term
 
 $$
-\begin{eqnarray*}
-R=\frac{dF}{d\eta}&=&\frac{d}{d\eta}\left([1-h(\eta)]F_a + h(\eta)F_b+wg(\eta) \right)\\
-&=& \frac{dF_a}{d\eta}+\frac{d}{d\eta}\left(h(\eta)F_b-h(\eta)F_a + wg(\eta)\right)\\
-&=& \frac{dF_a}{d\eta}+F_b\frac{dh}{d\eta}-F_a\frac{dh}{d\eta}+h(\eta)\frac{dF_b}{d\eta}-h(\eta)\frac{dF_a}{d\eta} +w\frac{dg}{d\eta}\\
-&=& \frac{dF_a}{d\eta}+\frac{dh}{d\eta}(F_b-F_a)+h(\eta)\left(\frac{dF_b}{d\eta}-\frac{dF_a}{d\eta}\right) +w\frac{dg}{d\eta}\\
-&=& \frac{dh}{d\eta}(F_b-F_a) + \underbrace{[1-h(\eta)]\frac{dF_a}{d\eta} + h(\eta)\frac{dF_b}{d\eta}}_{\text{chain rule term}} +w\frac{dg}{d\eta}\\
-&=& \frac{dh}{d\eta}(F_b-F_a) + [1-h(\eta)]\frac{dF_a}{dc_a}\frac{dc_a}{d\eta} + h(\eta)\frac{dF_b}{dc_b}\frac{dc_b}{d\eta} +w\frac{dg}{d\eta}\\
-&=& \frac{dh}{d\eta}(F_b-F_a) + \frac{dF_a}{dc_a}\left([1-h(\eta)]\frac{dc_a}{d\eta} + h(\eta)\frac{dc_b}{d\eta}\right) +w\frac{dg}{d\eta}
-\end{eqnarray*}
+\mathcal{R} = \frac{dF}{d\eta}=\frac{d}{d\eta}\left([1-h(\eta)]F_a + h(\eta)F_b+wg(\eta) \right)
+$$
+
+$$
+= \frac{dF_a}{d\eta}+\frac{d}{d\eta}\left(h(\eta)F_b-h(\eta)F_a + wg(\eta)\right)
+$$
+
+$$
+= \frac{dF_a}{d\eta}+F_b\frac{dh}{d\eta}-F_a\frac{dh}{d\eta}+h(\eta)\frac{dF_b}{d\eta}-h(\eta)\frac{dF_a}{d\eta} +w\frac{dg}{d\eta}
+$$
+
+$$
+= \frac{dF_a}{d\eta}+\frac{dh}{d\eta}(F_b-F_a)+h(\eta)\left(\frac{dF_b}{d\eta}-\frac{dF_a}{d\eta}\right) +w\frac{dg}{d\eta}
+$$
+
+$$
+= \frac{dh}{d\eta}(F_b-F_a) + \underbrace{[1-h(\eta)]\frac{dF_a}{d\eta} + h(\eta)\frac{dF_b}{d\eta}}_{\text{chain rule term}} +w\frac{dg}{d\eta}
+$$
+
+$$
+= \frac{dh}{d\eta}(F_b-F_a) + [1-h(\eta)]\frac{dF_a}{dc_a}\frac{dc_a}{d\eta} + h(\eta)\frac{dF_b}{dc_b}\frac{dc_b}{d\eta} +w\frac{dg}{d\eta}
+$$
+
+$$
+= \frac{dh}{d\eta}(F_b-F_a) + \frac{dF_a}{dc_a}\left([1-h(\eta)]\frac{dc_a}{d\eta} + h(\eta)\frac{dc_b}{d\eta}\right) +w\frac{dg}{d\eta}
 $$
 
 The _chain rule term_ results from the fact that $c_a$ and $c_b$ are dependent
@@ -186,24 +208,23 @@ on $\eta$ (see eqs. (25) and (26) in [KKS]). Setting
 $\lambda = [1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2}$ we get
 
 $$
-\begin{eqnarray*}
-\frac{dc_a}{d\eta} &=& \frac1\lambda \frac{dh}{d\eta}(c_a-c_b)\frac{d^2F_b}{dc_b^2}\\
-\frac{dc_b}{d\eta} &=& \frac1\lambda \frac{dh}{d\eta}(c_a-c_b)\frac{d^2F_a}{dc_a^2}.
-\end{eqnarray*}
+\frac{dc_a}{d\eta} = \frac1\lambda \frac{dh}{d\eta}(c_a-c_b)\frac{d^2F_b}{dc_b^2}
+$$
+
+$$
+\frac{dc_b}{d\eta} = \frac1\lambda \frac{dh}{d\eta}(c_a-c_b)\frac{d^2F_a}{dc_a^2}.
 $$
 
 Substituting this in we get
 
 $$
-\begin{eqnarray*}
-R &=& \frac{dh}{d\eta}(F_b-F_a) + \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)\frac1\lambda\underbrace{\left([1-h(\eta)] \frac{d^2F_b}{dc_b^2} + h(\eta)\frac{d^2F_a}{dc_a^2}\right)}_{=\lambda} +w\frac{dg}{d\eta}.
-\end{eqnarray*}
+\mathcal{R} = \frac{dh}{d\eta}(F_b-F_a) + \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)\frac1\lambda\underbrace{\left([1-h(\eta)] \frac{d^2F_b}{dc_b^2} + h(\eta)\frac{d^2F_a}{dc_a^2}\right)}_{=\lambda} +w\frac{dg}{d\eta}.
 $$
 
 This simplifies to
 
 $$
-R=-\frac{dh}{d\eta} \left(F_a-F_b-\frac{dF_a}{dc_a}(c_a-c_b)\right) + w\frac{dg}{d\eta}.
+\mathcal{R} = -\frac{dh}{d\eta} \left(F_a-F_b-\frac{dF_a}{dc_a}(c_a-c_b)\right) + w\frac{dg}{d\eta}.
 $$
 
 We split this residual into two kernels to allow for multiple phase concentrations
@@ -216,7 +237,7 @@ in a multi component system:
 ### Residual
 
 $$
-R=-\frac{dh}{d\eta}(F_a-F_b)+w\frac{dg}{d\eta}.
+\mathcal{R} = -\frac{dh}{d\eta}(F_a-F_b)+w\frac{dg}{d\eta}.
 $$
 
 ### Jacobian
@@ -229,10 +250,11 @@ with the $\frac{\partial \eta}{\partial u_j}\frac{\partial}{\partial \eta}=\phi_
 derivative.
 
 $$
-\begin{eqnarray*}
-J &=& -\phi_j \frac{\partial}{\partial \eta}\left( \frac{dh}{d\eta}(F_a-F_b) \right) + w \phi_j \frac{\partial}{\partial \eta}\frac{dg}{d\eta} \\
-&=&-\frac{d^2h}{d\eta^2}\phi_j(F_a-F_b) + w\frac{d^2g}{d\eta^2}\phi_j \\
-\end{eqnarray*}
+J = -\phi_j \frac{\partial}{\partial \eta}\left( \frac{dh}{d\eta}(F_a-F_b) \right) + w \phi_j \frac{\partial}{\partial \eta}\frac{dg}{d\eta}
+$$
+
+$$
+=-\frac{d^2h}{d\eta^2}\phi_j(F_a-F_b) + w\frac{d^2g}{d\eta^2}\phi_j
 $$
 
 (The implicit dependence of $F_a(c_a)$ and $F_b(c_a)$ on $\eta$ through $c_a(c,\eta)$
@@ -271,10 +293,11 @@ An instance of this kernel is needed for each compnent of the problem.
 ### Residual
 
 $$
-\begin{eqnarray*}
-R&=&-\frac{dh}{d\eta}\left(-\frac{dF_a}{dc_a}(c_a-c_b)\right)\\
-&=&\frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)
-\end{eqnarray*}
+\mathcal{R} = -\frac{dh}{d\eta}\left(-\frac{dF_a}{dc_a}(c_a-c_b)\right)
+$$
+
+$$
+=\frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)
 $$
 
 ### Jacobian
@@ -287,10 +310,11 @@ with the $\frac{\partial \eta}{\partial u_j}\frac{\partial}{\partial \eta} = \ph
 derivative.
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial \eta} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
-&=& \frac{d^2h}{d\eta^2}\phi_j\frac{dF_a}{dc_a}(c_a-c_b)\\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial \eta} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)
+$$
+
+$$
+= \frac{d^2h}{d\eta^2}\phi_j\frac{dF_a}{dc_a}(c_a-c_b)
 $$
 
 #### Off-diagonal
@@ -303,27 +327,30 @@ $\frac{\partial c_a}{\partial u_j}\frac{\partial}{\partial c_a} = \phi_j \frac{\
 derivative.
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial c_a} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
-&=& \frac{dh}{d\eta} \phi_j \left( \frac{d^2 F_a}{dc_a^2}(c_a-c_b) + \frac{d F_a}{d c_a}\right)\\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial c_a} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)
+$$
+
+$$
+= \frac{dh}{d\eta} \phi_j \left( \frac{d^2 F_a}{dc_a^2}(c_a-c_b) + \frac{d F_a}{d c_a}\right)
 $$
 
 Similarly for $c_b$,
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial c_b} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
-&=& -\frac{dh}{d\eta} \phi_j  \frac{d F_a}{d c_a}\\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial c_b} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)
+$$
+
+$$
+= -\frac{dh}{d\eta} \phi_j  \frac{d F_a}{d c_a}
 $$
 
 For any variable other than $c_a$ or $c_b$, for example temperature $T$:
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial T} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
-&=& \frac{dh}{d\eta} \phi_j  \frac{\partial}{\partial T}\left(\frac{d F_a}{d c_a}\right) ( c_a - c_b)\\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial T} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)
+$$
+
+$$
+= \frac{dh}{d\eta} \phi_j  \frac{\partial}{\partial T}\left(\frac{d F_a}{d c_a}\right) ( c_a - c_b)
 $$
 
 
@@ -347,7 +374,7 @@ The non-linear variable of this Kernel is $c_a$.
 ### Residual
 
 $$
-R=\frac{dF_a}{dc_a} - \frac{dF_b}{dc_b}
+\mathcal{R} = \frac{dF_a}{dc_a} - \frac{dF_b}{dc_b}
 $$
 
 ### Jacobian
@@ -393,7 +420,7 @@ $$
 ### Residual
 
 $$
-R=[1-h(\eta)]c_a + h(\eta)c_b - c
+\mathcal{R} = [1-h(\eta)]c_a + h(\eta)c_b - c
 $$
 
 ### Jacobian
@@ -403,7 +430,7 @@ $$
 Since the non-linear variable is $c_b$,
 
 $$
-J= \phi_j \frac{\partial R}{\partial c_b} = \phi_j h(\eta)
+J = \phi_j \frac{\partial \mathcal{R}}{\partial c_b} = \phi_j h(\eta)
 $$
 
 #### Off-Diagonal
@@ -411,19 +438,19 @@ $$
 For $c_a$
 
 $$
-J= \phi_j \frac{\partial R}{\partial c_a} = \phi_j [1-h(\eta)]
+J = \phi_j \frac{\partial \mathcal{R}}{\partial c_a} = \phi_j [1-h(\eta)]
 $$
 
 For $c$
 
 $$
-J= \phi_j \frac{\partial R}{\partial c} = -\phi_j
+J = \phi_j \frac{\partial \mathcal{R}}{\partial c} = -\phi_j
 $$
 
 For $\eta$
 
 $$
-J= \phi_j \frac{\partial R}{\partial \eta} = \phi_j \frac{dh}{d\eta}(c_b-c_a)
+J= \phi_j \frac{\partial \mathcal{R}}{\partial \eta} = \phi_j \frac{dh}{d\eta}(c_b-c_a)
 $$
 
 \bibliography{phase_field.bib}

--- a/docs/content/documentation/modules/phase_field/MultiPhase/WBM.md
+++ b/docs/content/documentation/modules/phase_field/MultiPhase/WBM.md
@@ -34,10 +34,13 @@ With $a_i(\vec\eta,\vec c,v)$ being the weak form (Allen-Cahn) residual for the
 $i$th non-conserved order parameter, we need to find $(\vec\eta,\lambda)$ satisfying
 the boundary conditions and such that
 
-$$\begin{align}
-a_i(\vec\eta,\vec c,v) + \underbrace{\int_\Omega\lambda\frac{\partial k}{\partial\eta_i} v\,dx}_{L_1(\eta_i)} &=& 0 \\
-\underbrace{\int_\Omega q\frac{\partial(\lambda k)}{\partial\lambda}\,dx}_{L_2(\lambda)} &=& 0
-\end{align}$$
+$$
+a_i(\vec\eta,\vec c,v) + \underbrace{\int_\Omega\lambda\frac{\partial k}{\partial\eta_i} v\,dx}_{L_1(\eta_i)} = 0
+$$
+
+$$
+\underbrace{\int_\Omega q\frac{\partial(\lambda k)}{\partial\lambda}\,dx}_{L_2(\lambda)} = 0
+$$
 
 holds for every test function $v$ and $q$.
 

--- a/docs/content/documentation/modules/phase_field/Phase_Field_Equations.md
+++ b/docs/content/documentation/modules/phase_field/Phase_Field_Equations.md
@@ -15,7 +15,7 @@ $$
 where $c_i$ is a conserved variable and $M_i$ is the associated mobility.  The evolution of nonconserved order parameters is represented with an Allen-Cahn equation, according to
 
 $$
-\frac{\partial \eta_j}{\partial t} = - L_j \frac{\delta F}{\delta \eta_j}, \label{eq:AC}
+\frac{\partial \eta_j}{\partial t} = - L_j \frac{\delta F}{\delta \eta_j}
 $$
 
 where $\eta_j$ is an order parameter and $L_j$ is the order parameter mobility.
@@ -35,44 +35,45 @@ $$
 where $\kappa_i$ and $\kappa_j$ are gradient energy coefficients.  Finally, $E_d$ describes any additional sources of energy in the system, such as deformation or electrostatic energy.  By combining the equations listed above and evaluating the functional derivatives ([further explanations](Derivationexplanations)), the evolution of the variables is described as
 
 $$
-\begin{eqnarray}
-  \frac{\partial c_i}{\partial t} = &
-    \nabla \cdot M_i \nabla \left(
-        \frac{\partial f_{loc}}{\partial c_i}
-      + \frac{\partial E_{d}}{\partial c_i}
-      - \nabla\cdot (\kappa_i \nabla c_i)
-        \color{#AAAAAA}{\underbrace{
-          -\nabla \cdot \left(
-            \frac{\partial\kappa}{\partial\nabla c_i}
-            \frac12 |\nabla c_i|^2
-          \right)
-        }_{\text{for}\, \kappa(\nabla c)}}
-        \color{#AAAAAA}{\underbrace{
-          +\left(
-            \frac{\partial\kappa}{\partial c_i}
-            \frac12 |\nabla c_i|^2
-          \right)
-      }_{\text{for}\, \kappa(c_i)}}
-    \right) \label{eq:cons_residual_strong}\\
-  \frac{\partial \eta_j}{\partial t} = &
-    -L \left(
-        \frac{\partial f_{loc}}{\partial \eta_j}
-      + \frac{\partial E_{d}}{\partial \eta_j}
-      - \nabla\cdot (\kappa_j \nabla \eta_j)
-        \color{#AAAAAA}{\underbrace{
-          -\nabla \cdot \left(
-            \frac{\partial\kappa}{\partial\nabla\eta_j}
-            \frac12 |\nabla\eta_j|^2
-          \right)
-        }_{\text{for}\, \kappa(\nabla\eta_j)}}
-        \color{#AAAAAA}{\underbrace{
-          +\left(
-            \frac{\partial\kappa}{\partial\eta_j}
-            \frac12 |\nabla\eta_j|^2
-          \right)
-      }_{\text{for}\, \kappa(\eta)}}
-    \right).
-\end{eqnarray}
+\frac{\partial c_i}{\partial t} =
+  \nabla \cdot M_i \nabla \left(
+      \frac{\partial f_{loc}}{\partial c_i}
+    + \frac{\partial E_{d}}{\partial c_i}
+    - \nabla\cdot (\kappa_i \nabla c_i)
+      \color{#AAAAAA}{\underbrace{
+        -\nabla \cdot \left(
+          \frac{\partial\kappa}{\partial\nabla c_i}
+          \frac12 |\nabla c_i|^2
+        \right)
+      }_{\text{for}\, \kappa(\nabla c)}}
+      \color{#AAAAAA}{\underbrace{
+        +\left(
+          \frac{\partial\kappa}{\partial c_i}
+          \frac12 |\nabla c_i|^2
+        \right)
+    }_{\text{for}\, \kappa(c_i)}}
+  \right),
+$$
+
+$$
+\frac{\partial \eta_j}{\partial t} =
+  -L \left(
+      \frac{\partial f_{loc}}{\partial \eta_j}
+    + \frac{\partial E_{d}}{\partial \eta_j}
+    - \nabla\cdot (\kappa_j \nabla \eta_j)
+      \color{#AAAAAA}{\underbrace{
+        -\nabla \cdot \left(
+          \frac{\partial\kappa}{\partial\nabla\eta_j}
+          \frac12 |\nabla\eta_j|^2
+        \right)
+      }_{\text{for}\, \kappa(\nabla\eta_j)}}
+      \color{#AAAAAA}{\underbrace{
+        +\left(
+          \frac{\partial\kappa}{\partial\eta_j}
+          \frac12 |\nabla\eta_j|^2
+        \right)
+    }_{\text{for}\, \kappa(\eta)}}
+  \right).
 $$
 
 !!! warning
@@ -84,29 +85,29 @@ $$
 To prepare for the FEM discretization, we construct a residual equation (equal to zero) in weak form in the usual manner.  First, the weighted integral residual projection is constructed using test function $\psi_m$ and applying the divergence theorem to lower the derivative order. Thus, the Allen-Cahn equation yields
 
 $$
-\begin{eqnarray}
-	\boldsymbol{\mathcal{R}}_{\eta_i} &=& \left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right) + \left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right) + L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partial \eta_j}, \psi_m \right) - \left<L\kappa_j \nabla \eta_j \cdot \vec{n}, \psi_m \right>,
-\end{eqnarray}
+\mathcal{R}_{\eta_i} = \left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right) + \left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right) + L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partial \eta_j}, \psi_m \right) - \left<L\kappa_j \nabla \eta_j \cdot \vec{n}, \psi_m \right>,
 $$
 
 where the $(*,*)$ operator represents a volume integral with an inner product and the $\left<*,*\right>$ operator represents a surface integral with an inner product. Solving the Cahn-Hilliard equation with FEM is more difficult, due to the fourth order gradient. It can be solved in two ways.
 
 The first is to directly solve the equation according to
 $$
-\begin{eqnarray}
-	\boldsymbol{\mathcal{R}}_{c_i} &=& \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( \kappa_i \nabla^2 c_i, \nabla \cdot (M_i \nabla \psi_m ) \right) + \left( M_i  \nabla \left( \frac{\partial f_{loc} }{\partial c_i} + \frac{\partial E_d}{\partial c_i} \right), \nabla \psi_m \right)  - \\
-	&& \left< M_i \nabla \left(  \kappa_i \nabla^2 c_i  \right)  \cdot \vec{n}, \psi_m \right>
+\mathcal{R}_{c_i} = \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( \kappa_i \nabla^2 c_i, \nabla \cdot (M_i \nabla \psi_m ) \right) + \left( M_i  \nabla \left( \frac{\partial f_{loc} }{\partial c_i} + \frac{\partial E_d}{\partial c_i} \right), \nabla \psi_m \right)
+$$
+
+$$
+ -\left< M_i \nabla \left(  \kappa_i \nabla^2 c_i  \right)  \cdot \vec{n}, \psi_m \right>
 	+ \left< M_i \nabla \left( \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_{d}}{\partial c_i } \right)  \cdot \vec{n}, \psi_m \right> -  \left< \kappa_i \nabla^2 c_i, M_i \nabla \psi_m \cdot \vec{n} \right>.
-\end{eqnarray}
 $$
 
 The second approach is to split the fourth order equation into two second order equations, such that two variables are solved, the concentration $c_i$ and the chemical potential $\mu_i$. In this case, the two residual equations are
 
 $$
-\begin{eqnarray}
-	\boldsymbol{\mathcal{R}}_{\mu_i} &=& \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( M_i  \nabla \mu_i, \nabla \psi_m \right) - \left< M_i  \nabla \mu_i \cdot \vec{n}, \psi_m \right>\\
-  \boldsymbol{\mathcal{R}}_{c_i} &=& \left( \nabla c_i, \nabla(\kappa_i \psi_m) \right) -  \left< \nabla c_i\cdot \vec{n}, \kappa_i \psi_m \right> + \left( \left( \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_d}{\partial c_i} - \mu_i \right), \psi_m \right)
-\end{eqnarray}
+\mathcal{R}_{\mu_i} = \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( M_i  \nabla \mu_i, \nabla \psi_m \right) - \left< M_i  \nabla \mu_i \cdot \vec{n}, \psi_m \right>
+$$
+
+$$
+\mathcal{R}_{c_i} = \left( \nabla c_i, \nabla(\kappa_i \psi_m) \right) -  \left< \nabla c_i\cdot \vec{n}, \kappa_i \psi_m \right> + \left( \left( \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_d}{\partial c_i} - \mu_i \right), \psi_m \right)
 $$
 
 Note that we have reversed which equation is used to solve for each variable from what might be expected. This change improves the solve convergence and does not impact the solution.
@@ -117,9 +118,7 @@ The goal of the MOOSE phase field module is to facilitate the development of adv
 
 The Allen-Cahn residual equation, without boundary terms, is shown here:
 $$
-\begin{eqnarray}
-\boldsymbol{\mathcal{R}}_{\eta_i} &=& \left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right) + \left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right) + L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partial \eta_j}, \psi_m \right)
-\end{eqnarray}
+\mathcal{R}_{\eta_i} = \left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right) + \left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right) + L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partial \eta_j}, \psi_m \right)
 $$
 It is divided into three pieces, each implemented in their own kernel, as shown below
 
@@ -132,7 +131,7 @@ $L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partia
 The residual for the direct solution of the Cahn-Hilliard equation (without boundary terms) is
 
 $$
-\boldsymbol{\mathcal{R}}_{c_i} = \left( \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( \kappa_i \nabla^2 c_i, \nabla \cdot (M_i \nabla \psi_m ) \right) + \left( M_i \left( \nabla \frac{\partial f_{loc} }{\partial c_i} + \nabla  \frac{\partial E_d}{\partial c_i} \right), \nabla \psi_m \right)
+\mathcal{R}_{c_i} = \left( \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( \kappa_i \nabla^2 c_i, \nabla \cdot (M_i \nabla \psi_m ) \right) + \left( M_i \left( \nabla \frac{\partial f_{loc} }{\partial c_i} + \nabla  \frac{\partial E_d}{\partial c_i} \right), \nabla \psi_m \right)
 $$
 
 | Residual term | Variable | Parameters | Energy derivative | Kernel |
@@ -143,10 +142,11 @@ $\left(M_i \left( \nabla \frac{\partial f_{loc} }{\partial c_i} + \nabla  \frac{
 
 In the split form of the Cahn-Hilliard solution, the two residual equations are
 $$
-\begin{eqnarray}
-	\boldsymbol{\mathcal{R}}_{\mu_i} &=& \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( M_i  \nabla \mu_i, \nabla \psi_m \right) \\
-  \boldsymbol{\mathcal{R}}_{c_i} &=& \left( \left( -\kappa_i \nabla^2 c_i +  \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_d}{\partial c_i} - \mu_i \right), \psi_m \right)
-\end{eqnarray}
+\mathcal{R}_{\mu_i} = \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( M_i  \nabla \mu_i, \nabla \psi_m \right)
+$$
+
+$$
+\mathcal{R}_{c_i} = \left( \left( -\kappa_i \nabla^2 c_i +  \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_d}{\partial c_i} - \mu_i \right), \psi_m \right)
 $$
 
 | Residual term | Variable | Parameters | Energy derivative | Kernel |
@@ -186,11 +186,15 @@ $$
 and its derivatives are
 
 $$
-\begin{eqnarray}
-  \frac{\partial f_{loc}}{\partial c} &=& c(c^2 - 1) \\
-  \frac{\partial^2 f_{loc}}{\partial c^2} &=& 3 c^2 - 1 \\
-  \frac{\partial^3 f_{loc}}{\partial c^3} &=& 6 c.
-\end{eqnarray}
+  \frac{\partial f_{loc}}{\partial c} = c(c^2 - 1)
+$$
+
+$$
+  \frac{\partial^2 f_{loc}}{\partial c^2} = 3 c^2 - 1
+$$
+
+$$
+  \frac{\partial^3 f_{loc}}{\partial c^3} = 6 c.
 $$
 
 The second and third derivatives would be required to use the direct solution method (via [`CahnHilliard`](/CahnHilliard.md)) and the first and second derivatives would be required to use the split solution method (via [`SplitCHParsed`](/SplitCHParsed.md)). This model has been implemented in the [`MathFreeEnergy`](/phase_field/MathFreeEnergy.md) material found in the phase field module of MOOSE, inheriting from `DerivativeFunctionMaterialBase`. The code from [`MathFreeEnergy`](/phase_field/MathFreeEnergy.md) is shown below:

--- a/docs/content/documentation/systems/Kernels/phase_field/AllenCahn.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/AllenCahn.md
@@ -4,14 +4,14 @@
 Implements the term
 
 $$
-L(\eta,a,b,\dots)\frac{\delta F}{\delta\eta} = L(\eta,a,b,\dots)\frac{\partial f(\eta,a,b,\dots)}{\partial\eta}
+L(\eta,a,b,...)\frac{\delta F}{\delta\eta} = L(\eta,a,b,...)\frac{\partial f(\eta,a,b,...)}{\partial\eta}
 $$
 
 $F$ is the free energy functional of the system that is defined as $F=\int f(\eta) d\Omega$.
 
 $\eta$ is the variable the kernel is acting on, $L$ (`mob_name`) its associated mobility,
 $f$ (`f_name`) is a free energy density provided by a [function material](../../introduction/FunctionMaterials), and
-$a,b,\dots$ (`args`) are additional variable dependencies of the mobility and free energy density.
+$a,b,...$ (`args`) are additional variable dependencies of the mobility and free energy density.
 
 Note that this makes the assumption that $F$ is _not_ depending on $\nabla\eta$. The $\nabla \eta$ dependent terms
 that arise from the gradient interface energy are handled separately in the [`ACInterface`](/ACInterface.md) kernel.

--- a/docs/content/documentation/systems/Kernels/phase_field/CoupledAllenCahn.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/CoupledAllenCahn.md
@@ -4,14 +4,14 @@
 Implements the term
 
 $$
-L(\eta,a,b,\dots)\frac{\delta F}{\delta\eta} = L(\eta,a,b,\dots)\frac{\partial f(\eta,a,b,\dots)}{\partial\eta}
+L(\eta,a,b,...)\frac{\delta F}{\delta\eta} = L(\eta,a,b,...)\frac{\partial f(\eta,a,b,...)}{\partial\eta}
 $$
 
 $F$ is the free energy functional of the system that is defined as $F=\int f(\eta) d\Omega$.
 
 $\eta$ (`v`) is a coupled non-conserved order parameter, $L$ (`mob_name`) its associated mobility,
 $f$ (`f_name`) is a free energy density provided by a [function material](../../introduction/FunctionMaterials), and
-$a,b,\dots$ (`args`) are additional variable dependencied of the mobility and free energy density.
+$a,b,...$ (`args`) are additional variable dependencied of the mobility and free energy density.
 
 !syntax parameters /Kernels/CoupledAllenCahn
 

--- a/docs/content/documentation/systems/Kernels/phase_field/CoupledSusceptibilityTimeDerivative.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/CoupledSusceptibilityTimeDerivative.md
@@ -4,13 +4,13 @@
 Implements
 
 $$
-F(u,v,a,b,\dots)\cdot\frac{\partial v}{\partial t},
+F(u,v,a,b,...)\cdot\frac{\partial v}{\partial t},
 $$
 
 where $F$ (`f_name`) is a [FunctionMaterial](/FunctionMaterials.md) providing derivatives
 (for example defined using the [DerivativeParsedMaterial](/DerivativeParsedMaterial.md)),
 $u$ is the variable the kernel is acting on, $v$ (`v`) is the coupled variable the time
-derivative is taken of, and $a, b, \dots$ (`args`) are further arguments of the susceptibility
+derivative is taken of, and $a, b, ...$ (`args`) are further arguments of the susceptibility
 function $F$ which should contribute to off-diagonal Jacobian entries.
 
 See also [CoupledTimeDerivative](/CoupledTimeDerivative.md).s

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSACBulkC.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSACBulkC.md
@@ -7,26 +7,28 @@ An instance of this kernel is needed for each solute species of the problem.
 ### Residual
 
 $$
-\begin{eqnarray*}
-R&=&-\frac{dh}{d\eta}\left(-\frac{dF_a}{dc_a}(c_a-c_b)\right)\\
-&=&\frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)
-\end{eqnarray*}
+\mathcal{R} = -\frac{dh}{d\eta}\left(-\frac{dF_a}{dc_a}(c_a-c_b)\right)
+$$
+
+$$
+=\frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)
 $$
 
 ### Jacobian
 
 #### On-diagonal
 
-We are looking for the $\frac \partial{\partial u_j}$ derivative of $R$, where
+We are looking for the $\frac \partial{\partial u_j}$ derivative of $\mathcal{R}$, where
 $u\equiv\eta$. We need to apply the chain rule and will again only keep terms
 with the $\frac{\partial \eta}{\partial u_j}\frac{\partial}{\partial \eta} = \phi_j \frac{\partial}{\partial \eta}$
 derivative.
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial \eta} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
-&=& \frac{d^2h}{d\eta^2}\phi_j\frac{dF_a}{dc_a}(c_a-c_b)\\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial \eta} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)
+$$
+
+$$
+= \frac{d^2h}{d\eta^2}\phi_j\frac{dF_a}{dc_a}(c_a-c_b)
 $$
 
 #### Off-diagonal
@@ -39,29 +41,31 @@ $\frac{\partial c_a}{\partial u_j}\frac{\partial}{\partial c_a} = \phi_j \frac{\
 derivative.
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial c_a} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
-&=& \frac{dh}{d\eta} \phi_j \left( \frac{d^2 F_a}{dc_a^2}(c_a-c_b) + \frac{d F_a}{d c_a}\right)\\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial c_a} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)
+$$
+
+$$
+= \frac{dh}{d\eta} \phi_j \left( \frac{d^2 F_a}{dc_a^2}(c_a-c_b) + \frac{d F_a}{d c_a}\right)
 $$
 
 Similarly for $c_b$,
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial c_b} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
-&=& -\frac{dh}{d\eta} \phi_j  \frac{d F_a}{d c_a}\\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial c_b} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)
+$$
+
+$$
+= -\frac{dh}{d\eta} \phi_j  \frac{d F_a}{d c_a}
 $$
 
 For any variable other than $c_a$ or $c_b$, for example temperature $T$:
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial T} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
-&=& \frac{dh}{d\eta} \phi_j  \frac{\partial}{\partial T}\left(\frac{d F_a}{d c_a}\right) ( c_a - c_b)\\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial T} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)
 $$
 
+$$
+= \frac{dh}{d\eta} \phi_j  \frac{\partial}{\partial T}\left(\frac{d F_a}{d c_a}\right) ( c_a - c_b)
+$$
 
 The off-diagonal Jacobian contributions are again multiplied by the Allen-Cahn
 mobility $L$ at each point for consistency with the other terms in the Allen-Cahn

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSACBulkF.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSACBulkF.md
@@ -19,10 +19,11 @@ with the $\frac{\partial \eta}{\partial u_j}\frac{\partial}{\partial \eta}=\phi_
 derivative.
 
 $$
-\begin{eqnarray*}
-J &=& -\phi_j \frac{\partial}{\partial \eta}\left( \frac{dh}{d\eta}(F_a-F_b) \right) + w \phi_j \frac{\partial}{\partial \eta}\frac{dg}{d\eta} \\
-&=&-\frac{d^2h}{d\eta^2}\phi_j(F_a-F_b) + w\frac{d^2g}{d\eta^2}\phi_j \\
-\end{eqnarray*}
+J = -\phi_j \frac{\partial}{\partial \eta}\left( \frac{dh}{d\eta}(F_a-F_b) \right) + w \phi_j \frac{\partial}{\partial \eta}\frac{dg}{d\eta}
+$$
+
+$$
+=-\frac{d^2h}{d\eta^2}\phi_j(F_a-F_b) + w\frac{d^2g}{d\eta^2}\phi_j
 $$
 
 (The implicit dependence of $F_a(c_a)$ and $F_b(c_a)$ on $\eta$ through $c_a(c,\eta)$

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSCHBulk.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSCHBulk.md
@@ -9,14 +9,14 @@ The non-linear variable for this Kernel is the concentration $c$.
 In the residual routine we need to calculate the term $R=\nabla \frac{dF}{dc}$.
 We exploit the KKS identity $\frac{dF}{dc}=\frac{dF_a}{dc_a}=\frac{dF_b}{dc_b}$
 and arbitrarily use the a-phase instead.
-The gradient can be calculated through the chain rule (note that $F_a(c_a, p_1,p_2,\dots,p_n)$
+The gradient can be calculated through the chain rule (note that $F_a(c_a, p_1,p_2,...,p_n)$
 is potentially a function of many variables).
 
 $$
 R = \nabla \frac{dF_a}{dc_a} = \frac{d^2F_a}{dc_a^2}\nabla c_a + \sum_i \frac{d^2F_a}{dc_adp_i}\nabla p_i
 $$
 
-With $a = \{c_a, p_1,p_2,\dots,p_n\}$ being the vector of all arguments to $F_a$ this simplifies to
+With $a = \{c_a, p_1,p_2,...,p_n\}$ being the vector of all arguments to $F_a$ this simplifies to
 
 $$
 R=\sum_i \frac{d^2F_a}{dc_ada_i}\nabla a_i  = \sum_i R_i \nabla a_i
@@ -70,7 +70,7 @@ where $j$ is `_j` in the code.
 For the on diagonal terms we look at the derivative w.r.t. the components of the
 non-linear variable $c$ of this kernel. Note, that $F_a$ is only indirectly a
 function of $c$. We assume the dependence is given through $c(c_a)$. The chain
-rule will thus yield terms of this form  
+rule will thus yield terms of this form
 
 $$
 \frac{dc_a}{dc} = \frac{\frac{d^2F_b}{dc_b^2}}{[1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2}},
@@ -87,11 +87,15 @@ $$
 Let's get back to the original residual with $\frac{dF}{dc}$. Then
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{d}{dc} \nabla \frac{dF}{dc}\\
-&=& \phi_j  \nabla \frac{d^2F}{dc^2} \quad,\quad \text{with (29) from [KKS]}\\
-&=& \phi_j  \nabla \frac{\frac{d^2F_b}{dc_b^2}\frac{d^2F_a}{dc_a^2}}{  [1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2} }\\
-\end{eqnarray*}
+J = \phi_j \frac{d}{dc} \nabla \frac{dF}{dc}
+$$
+
+$$
+= \phi_j  \nabla \frac{d^2F}{dc^2} \quad,\quad \text{with (29) from [KKS]}
+$$
+
+$$
+= \phi_j  \nabla \frac{\frac{d^2F_b}{dc_b^2}\frac{d^2F_a}{dc_a^2}}{  [1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2} }
 $$
 
 !syntax parameters /Kernels/KKSCHBulk

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSMultiACBulkC.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSMultiACBulkC.md
@@ -5,7 +5,7 @@
 
 For the 3-phase KKS model, if the non-linear variable is $\eta_1$,
 $$
-R = -\frac{\partial F_1}{\partial c_1} \left( \frac{\partial h_1}{\partial \eta_1} c_1 + \frac{\partial h_2}{\partial \eta_1} c_2 + \frac{\partial h_3}{\partial \eta_1} c_3 \right)
+\mathcal{R} = -\frac{\partial F_1}{\partial c_1} \left( \frac{\partial h_1}{\partial \eta_1} c_1 + \frac{\partial h_2}{\partial \eta_1} c_2 + \frac{\partial h_3}{\partial \eta_1} c_3 \right)
 $$
 
 where $c_i$ is the phase concentration for phase $i$ and $h_i$ is the interpolation
@@ -17,55 +17,65 @@ function for phase $i$ defined in \cite{Folch05} (referred to as $g_i$ there, bu
 If the non-linear variable is $\eta_1$, the on-diagonal Jacobian is
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial \eta_1} \\
-&=& -\phi_j \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1^2} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1^2} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1^2} c_3 \right)
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial \eta_1}
+$$
+
+$$
+= -\phi_j \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1^2} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1^2} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1^2} c_3 \right)
 $$
 
 #### Off-diagonal: Phase Concentrations
 Since $\frac{\partial F_1}{\partial c_1}$ appears in the residual, the off-diagonal Jacobian for $c_1$ is a little more complicated than for $c_2$ or $c_3$.
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial c_1} \\
-&=& -\phi_j \left( \frac{\partial ^2 F_1}{\partial c_1^2} \left[ \frac{\partial  h_1}{\partial \eta_1 } c_1 + \frac{\partial  h_2}{\partial \eta_1} c_2 + \frac{\partial  h_3}{\partial \eta_1} c_3 \right] + \frac{\partial F_1}{\partial c_1} \frac{\partial h_1}{\partial \eta_1} \right)
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial c_1}
 $$
+
+$$
+= -\phi_j \left( \frac{\partial ^2 F_1}{\partial c_1^2} \left[ \frac{\partial  h_1}{\partial \eta_1 } c_1 + \frac{\partial  h_2}{\partial \eta_1} c_2 + \frac{\partial  h_3}{\partial \eta_1} c_3 \right] + \frac{\partial F_1}{\partial c_1} \frac{\partial h_1}{\partial \eta_1} \right)
+$$
+
 For $c_2$,
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial c_2} \\
-&=& -\phi_j \frac{\partial F_1}{\partial  c_1} \frac{\partial  h_2}{\partial  \eta_1}
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial c_2}
 $$
+
+$$
+= -\phi_j \frac{\partial F_1}{\partial  c_1} \frac{\partial  h_2}{\partial  \eta_1}
+$$
+
 and similarly for $c_3$. $c_1$ then $c_2$, and $c_3$ are handled first in the code. For the off-diagonal Jacobians we also need to multiply by $L$, the Allen-Cahn mobility.
 
 #### Off-diagonal: Other Coupled Variables
 
 If the non-linear variable is $\eta_1$, the off-diagonal Jacobian for $\eta_2$ is
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial \eta_2} \\
-&=& -\phi_j \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1 \partial \eta_2} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1 \partial \eta_2} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1 \partial \eta_3} c_3 \right)
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial \eta_2}
 $$
+
+$$
+= -\phi_j \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1 \partial \eta_2} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1 \partial \eta_2} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1 \partial \eta_3} c_3 \right)
+$$
+
 and similar for $\eta_3$.
 
 For any other coupled variables, for example temperature $T$
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial T} \\
-&=& -\phi_j \frac{\partial ^2 F_1}{\partial c_1 \partial T} \left( \frac{\partial  h_1}{\partial \eta_1 } c_1 + \frac{\partial  h_2}{\partial \eta_1} c_2 + \frac{\partial  h_3}{\partial \eta_1} c_3 \right)
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial T}
+$$
+
+$$
+= -\phi_j \frac{\partial ^2 F_1}{\partial c_1 \partial T} \left( \frac{\partial  h_1}{\partial \eta_1 } c_1 + \frac{\partial  h_2}{\partial \eta_1} c_2 + \frac{\partial  h_3}{\partial \eta_1} c_3 \right)
 $$
 
 What's implemented in the code for the off-diagonal Jacobian for $\eta_2$,$\eta_3$ and any other coupled variables such as $T$ is the generalization for the above two equations for non-linear variable $v$:
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial v} \\
-&=& -\phi_j \left[ \frac{\partial^2 F_1}{\partial c_1 \partial v} \left( \frac{\partial h_1}{\partial \eta_1 } c_1 + \frac{\partial h_2}{\partial \eta_1} c_2 + \frac{\partial h_3}{\partial \eta_1} c_3 \right) +  \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1 \partial v} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1 \partial v} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1 \partial v} c_3 \right) \right]
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial v}
 $$
+
+$$
+= -\phi_j \left[ \frac{\partial^2 F_1}{\partial c_1 \partial v} \left( \frac{\partial h_1}{\partial \eta_1 } c_1 + \frac{\partial h_2}{\partial \eta_1} c_2 + \frac{\partial h_3}{\partial \eta_1} c_3 \right) +  \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1 \partial v} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1 \partial v} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1 \partial v} c_3 \right) \right]
+$$
+
 (This handles everything except for $c_1$, $c_2$, $c_3$, which are handled separately first). For the off-diagonal Jacobians we also need to multiply by $L$, the Allen-Cahn mobility.
 
 !syntax parameters /Kernels/KKSMultiACBulkC

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSMultiACBulkF.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSMultiACBulkF.md
@@ -5,7 +5,7 @@
 
 For the 3-phase KKS model, if the non-linear variable is $\eta_1$,
 $$
-R = \left(\frac{\partial h_1}{\partial \eta_1} F_1 + \frac{\partial h_2}{\partial \eta_1} F_2 + \frac{\partial h_3}{\partial \eta_1} F_3 + W_1 \frac{\partial  g_1}{\partial  \eta_1} \right)
+\mathcal{R} = \left(\frac{\partial h_1}{\partial \eta_1} F_1 + \frac{\partial h_2}{\partial \eta_1} F_2 + \frac{\partial h_3}{\partial \eta_1} F_3 + W_1 \frac{\partial  g_1}{\partial  \eta_1} \right)
 $$
 where $c_i$ is the phase concentration for phase $i$ and $h_i$ is the interpolation
 function for phase $i$ defined in \cite{Folch05} (referred to as $g_i$ there, but we use $h_i$ to maintain consistency with other interpolation functions in MOOSE). Here $g_i = \eta_i^2 (1-\eta_i)^2$, also for consistency with notation in MOOSE. $W_1$ is the free energy barrier height.
@@ -15,10 +15,11 @@ function for phase $i$ defined in \cite{Folch05} (referred to as $g_i$ there, bu
 #### On-diagonal
 If the non-linear variable is $\eta_1$, the on-diagonal Jacobian is
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial \eta_1} \\
-&=& \phi_j \left( \frac{\partial ^2 h_1}{\partial  \eta_1^2} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1^2} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1^2} F_3 + W_1 \frac{\partial ^2 g}{\partial \eta_1^2} \right)
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial \eta_1}
+$$
+
+$$
+= \phi_j \left( \frac{\partial ^2 h_1}{\partial  \eta_1^2} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1^2} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1^2} F_3 + W_1 \frac{\partial ^2 g}{\partial \eta_1^2} \right)
 $$
 
 
@@ -26,27 +27,31 @@ $$
 
 Off-diagonal Jacobian for $\eta_2$ (similar for $\eta_3$):
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial \eta_2} \\
-&=& \phi_j \left( \frac{\partial ^2 h_1}{\partial  \eta_1 \partial  \eta_2} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1 \partial  \eta_2} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1 \partial  \eta_2} F_3 \right)
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial \eta_2}
+$$
+
+$$
+= \phi_j \left( \frac{\partial ^2 h_1}{\partial  \eta_1 \partial  \eta_2} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1 \partial  \eta_2} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1 \partial  \eta_2} F_3 \right)
 $$
 
 Off-diagonal Jacobian for $c_1$ (similar for $c_2, c_3$):
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial c_1} \\
-&=& \phi_j \frac{\partial  h_1}{\partial  \eta_1} \frac{\partial  F_1}{\partial  c_1}
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial c_1}
+$$
+
+$$
+= \phi_j \frac{\partial  h_1}{\partial  \eta_1} \frac{\partial  F_1}{\partial  c_1}
 $$
 
 These statements can be generalized for non-linear variable $v$ as:
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial v} \\
-&=& \left( \frac{\partial ^2 h_1}{\partial  \eta_1 \partial  v} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1 \partial  v} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1 \partial  v} F_3 + \frac{\partial  h_1}{\partial  \eta_1} \frac{\partial  F_1}{\partial  v} + \frac{\partial  h_2}{\partial  \eta_1} \frac{\partial  F_2}{\partial  v} + \frac{\partial  h_3}{\partial  \eta_1} \frac{\partial  F_3}{\partial  v}\right)
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial v}
 $$
+
+$$
+= \left( \frac{\partial ^2 h_1}{\partial  \eta_1 \partial  v} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1 \partial  v} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1 \partial  v} F_3 + \frac{\partial  h_1}{\partial  \eta_1} \frac{\partial  F_1}{\partial  v} + \frac{\partial  h_2}{\partial  \eta_1} \frac{\partial  F_2}{\partial  v} + \frac{\partial  h_3}{\partial  \eta_1} \frac{\partial  F_3}{\partial  v}\right)
+$$
+
 For the off-diagonal Jacobians we also need to multiply by $L$, the Allen-Cahn mobility.
 
 !syntax parameters /Kernels/KKSMultiACBulkF

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSMultiPhaseConcentration.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSMultiPhaseConcentration.md
@@ -4,7 +4,7 @@
 ### Residual
 For a KKS model with $n$ phases, the residual of the phase concentration constraint equation is
 $$
-R = \left( h_1 c_1 + h_2 c_2 + h_3 c_3 + \dots + h_n c_n - c  \right)
+\mathcal{R} = \left( h_1 c_1 + h_2 c_2 + h_3 c_3 + ... + h_n c_n - c  \right)
 $$
 where $c_i$ is the phase concentration for phase $i$, $c$ is the physical solute concentration, and $h_i$ is the interpolation function for phase $i$ defined in \cite{Folch05} (referred to as $g_i$ there, but we use $h_i$ to maintain consistency with other interpolation functions in MOOSE).
 
@@ -13,35 +13,41 @@ where $c_i$ is the phase concentration for phase $i$, $c$ is the physical solute
 #### On-diagonal
 Since the non-linear variable for this kernel is $c_n$, the on-diagonal Jacobian is
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial c_n} \\
-&=& \phi_j h_n
-\end{eqnarray*}
+J = \phi_j \frac{\partial R}{\partial c_n}
+$$
+
+$$
+= \phi_j h_n
 $$
 
 #### Off-diagonal
 For the physical concentration $c$, the off-diagonal Jacobian is
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial c} \\
-&=& - \phi_j
-\end{eqnarray*}
+J = \phi_j \frac{\partial R}{\partial c}
 $$
+
+$$
+= - \phi_j
+$$
+
 For phase concentrations $c_i$ other than $c_n$,:
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial c_i} \\
-&=& \phi_j h_i
-\end{eqnarray*}
+J = \phi_j \frac{\partial \mathcal{R}}{\partial c_i}
+$$
+
+$$
+= \phi_j h_i
 $$
 
 Finally for the order parameters, such as $\eta_1$,
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial R}{\partial \eta_1} \\
-&=& \phi_j \left( \frac{\partial h_1}{\partial \eta_1} c_1 + \frac{\partial h_2}{\partial \eta_1} c_2 +  \frac{\partial h_3}{\partial \eta_1} c_3      \right)
-\end{eqnarray*}
+J = \phi_j \frac{\partial R}{\partial \eta_1}
 $$
+
+$$
+= \phi_j \left( \frac{\partial h_1}{\partial \eta_1} c_1 + \frac{\partial h_2}{\partial \eta_1} c_2 +  \frac{\partial h_3}{\partial \eta_1} c_3 \right)
+$$
+
 For the off-diagonal Jacobians we also need to multiply by $L$, the Allen-Cahn mobility.
 
 

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSPhaseConcentration.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSPhaseConcentration.md
@@ -12,7 +12,7 @@ $$
 ### Residual
 
 $$
-R=[1-h(\eta)]c_a + h(\eta)c_b - c
+\mathcal{R} = [1-h(\eta)]c_a + h(\eta)c_b - c
 $$
 
 ### Jacobian
@@ -22,7 +22,7 @@ $$
 Since the non-linear variable is $c_b$,
 
 $$
-J= \phi_j \frac{\partial R}{\partial c_b} = \phi_j h(\eta)
+J= \phi_j \frac{\partial \mathcal{R}}{\partial c_b} = \phi_j h(\eta)
 $$
 
 #### Off-Diagonal
@@ -30,19 +30,19 @@ $$
 For $c_a$
 
 $$
-J= \phi_j \frac{\partial R}{\partial c_a} = \phi_j [1-h(\eta)]
+J= \phi_j \frac{\partial \mathcal{R}}{\partial c_a} = \phi_j [1-h(\eta)]
 $$
 
 For $c$
 
 $$
-J= \phi_j \frac{\partial R}{\partial c} = -\phi_j
+J= \phi_j \frac{\partial \mathcal{R}}{\partial c} = -\phi_j
 $$
 
 For $\eta$
 
 $$
-J= \phi_j \frac{\partial R}{\partial \eta} = \phi_j \frac{dh}{d\eta}(c_b-c_a)
+J= \phi_j \frac{\partial \mathcal{R}}{\partial \eta} = \phi_j \frac{dh}{d\eta}(c_b-c_a)
 $$
 
 !syntax parameters /Kernels/KKSPhaseConcentration

--- a/docs/content/documentation/systems/Kernels/phase_field/KKSSplitCHCRes.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/KKSSplitCHCRes.md
@@ -32,19 +32,21 @@ with the $\frac{\partial c_a}{\partial u_j}\frac{\partial}{\partial c_a}=\phi_j 
 derivative.
 
 $$
-\begin{eqnarray*}
-J &=& \frac{\partial R}{\partial u_j} = \phi_j \frac{\partial}{\partial c_a} \left( \frac{\partial F}{\partial c_a} - \mu \right)\\
-&=& \phi_j  \frac{\partial^2F}{\partial c_a^2} \\
-\end{eqnarray*}
+J = \frac{\partial R}{\partial u_j} = \phi_j \frac{\partial}{\partial c_a} \left( \frac{\partial F}{\partial c_a} - \mu \right)
+$$
+
+$$
+= \phi_j  \frac{\partial^2F}{\partial c_a^2}
 $$
 
 For $\mu$
 
 $$
-\begin{eqnarray*}
-J &=& \phi_j \frac{\partial}{\partial \mu} \left( \frac{\partial F}{\partial c_a} - \mu \right)\\
-&=& -\phi_j \\
-\end{eqnarray*}
+J = \phi_j \frac{\partial}{\partial \mu} \left( \frac{\partial F}{\partial c_a} - \mu \right)
+$$
+
+$$
+= -\phi_j
 $$
 
 !syntax parameters /Kernels/KKSSplitCHCRes

--- a/docs/content/documentation/systems/Kernels/phase_field/LangevinNoise.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/LangevinNoise.md
@@ -7,7 +7,7 @@ $$
 (2\chi-1)\alpha P(\vec r)\psi,
 $$
 
-where $\chi$ is a random number in $[0\dots1)$, $\alpha$ (`amplitude`) is a constant
+where $\chi$ is a random number in $[0...1)$, $\alpha$ (`amplitude`) is a constant
 amplitude factor, and $P(\vec r)$ (`multiplier`) is a material property that can be used
 as a location dependent mask for the source term.
 

--- a/docs/content/documentation/systems/Kernels/phase_field/MatDiffusion.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/MatDiffusion.md
@@ -5,13 +5,13 @@
 Implements the term
 
 $$
-\nabla D(c,a,b,\dots) \nabla c
+\nabla D(c,a,b,...) \nabla c
 $$
 
 where the diffusion coefficient $D$ (`D_name`) is provided by a
 [function material](FunctionMaterials.md), $c$ is either a coupled variable (`conc`)
 or - if not explicitly specified - the non-linear variable the kernel is operating on.
-$D$ can depend on arbitrary non-linear variables $a,b,\dots$ (`args`).
+$D$ can depend on arbitrary non-linear variables $a,b,...$ (`args`).
 The complete Jacobian contributions are provided by the kernel.
 
 !syntax parameters /Kernels/MatDiffusion

--- a/docs/content/documentation/systems/Kernels/phase_field/MatReaction.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/MatReaction.md
@@ -4,7 +4,7 @@
 Implements
 
 $$
--L(v,a,b,\dots)\cdot v,
+-L(v,a,b,...)\cdot v,
 $$
 
 where $L$ (`mob_name`) is a reaction rate, $v$ is either a coupled variable (`v`)

--- a/docs/content/documentation/systems/Kernels/phase_field/SusceptibilityTimeDerivative.md
+++ b/docs/content/documentation/systems/Kernels/phase_field/SusceptibilityTimeDerivative.md
@@ -4,12 +4,12 @@
 Implements
 
 $$
-F(u,a,b,\dots)\cdot\frac{\partial u}{\partial t},
+F(u,a,b,...)\cdot\frac{\partial u}{\partial t},
 $$
 
 where $F$ (`f_name`) is a [FunctionMaterial](/FunctionMaterials.md) providing derivatives
 (for example defined using the [DerivativeParsedMaterial](/DerivativeParsedMaterial.md)),
-$u$ is the kernel variable the time derivative is taken of, and $a, b, \dots$ (`args`)
+$u$ is the kernel variable the time derivative is taken of, and $a, b, ...$ (`args`)
 are further arguments of the susceptibility function $F$ which should contribute to
 off-diagonal Jacobian entries.
 

--- a/docs/content/documentation/systems/Materials/tensor_mechanics/LinearIsoElasticPFDamage.md
+++ b/docs/content/documentation/systems/Materials/tensor_mechanics/LinearIsoElasticPFDamage.md
@@ -17,12 +17,19 @@ idea and the procedures we follow is
 The following equations are used in this material:
 
 $$
-\begin{eqnarray}
-  \psi = [(1-c)^2 + k]{\psi}^{+}_{0} - {\psi}^{-}_{0} \\
-  {\psi}^{\pm}_{0} = \lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle^{2}_{\pm} +\mu(\langle \epsilon_1 \rangle^{2}_{\pm} +\langle \epsilon_2 \rangle^{2}_{\pm} +\langle \epsilon_3 \rangle^{2}_{\pm}) \\
-  {\sigma}^{\pm}_{0} = \frac{\partial {\psi}^{\pm}_{0}}{\partial \epsilon} = \sum \limits_{a=1}^3 [\lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle_{\pm} + 2\mu \langle \epsilon_a \rangle_{\pm} ]n_a \otimes n_a \\
-  \sigma = [(1-c)^2 + k]{\sigma}^{+}_{0} - {\sigma}^{-}_{0}
-\end{eqnarray}
+\psi = [(1-c)^2 + k]{\psi}^{+}_{0} - {\psi}^{-}_{0}
+$$
+
+$$
+{\psi}^{\pm}_{0} = \lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle^{2}_{\pm} +\mu(\langle \epsilon_1 \rangle^{2}_{\pm} +\langle \epsilon_2 \rangle^{2}_{\pm} +\langle \epsilon_3 \rangle^{2}_{\pm})
+$$
+
+$$
+{\sigma}^{\pm}_{0} = \frac{\partial {\psi}^{\pm}_{0}}{\partial \epsilon} = \sum \limits_{a=1}^3 [\lambda \langle \epsilon_1 + \epsilon_2 + \epsilon_3 \rangle_{\pm} + 2\mu \langle \epsilon_a \rangle_{\pm} ]n_a \otimes n_a
+$$
+
+$$
+\sigma = [(1-c)^2 + k]{\sigma}^{+}_{0} - {\sigma}^{-}_{0}
 $$
 
 Where


### PR DESCRIPTION
This is disappointing but a necessary compromise, I guess.

Closes #10414