### PR TITLE
Allow the TestHarness to always import bench.py 

### DIFF
--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -2,7 +2,6 @@
 
 import subprocess
 import time
-import sqlite3
 import os
 import gc
 import shutil
@@ -277,6 +276,10 @@ class DB:
         );'''
 
         self.fname = fname
+
+        # python might not have sqlite3 builtin, so do the import here so
+        # that the TestHarness can always import this file
+        import sqlite3
         self.conn = sqlite3.connect(fname)
         c = self.conn.cursor()
         c.execute(CREATE_BENCH_TABLE)


### PR DESCRIPTION
Python might not have sqlite3 builtin which causes the TestHarness to fail to import bench.py
This just moves the "import sqlite3" to inside the class that uses it.

closes #10416

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
