### PR TITLE
Properly handle duplicate test names

### DIFF
--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -294,8 +294,12 @@ class Scheduler(MooseObject):
         # Create a local dictionary of tester names to job containers. Add this dictionary to a
         # set. We will use this set as a way to gain access to their methods.
         for tester in testers:
-            name_to_job_container[tester.getTestName()] = Job(tester, job_dag, self.options)
-            self.tester_datas.add(name_to_job_container[tester.getTestName()])
+            if tester.getTestName() in name_to_job_container:
+                tester.setStatus('duplicate test', tester.bucket_skip)
+                non_runnable_jobs.add(Job(tester, job_dag, self.options))
+            else:
+                name_to_job_container[tester.getTestName()] = Job(tester, job_dag, self.options)
+                self.tester_datas.add(name_to_job_container[tester.getTestName()])
 
         # Populate job_dag with testers. This method will also return any testers which caused failures
         # while building the DAG.

--- a/python/TestHarness/tests/test_DuplicateTestNames.py
+++ b/python/TestHarness/tests/test_DuplicateTestNames.py
@@ -1,0 +1,17 @@
+import subprocess
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testDuplicateTestNames(self):
+        """
+        Test for duplicate test names
+        """
+
+        # Duplicate tests are considered a Fatal Parser Error, hence the 'with assertRaises'
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('-i', 'duplicate_test_names', '--no-color')
+
+        e = cm.exception
+
+        self.assertRegexpMatches(e.output, r'tests/test_harness.*?skipped \(duplicate test\)')
+        self.assertRegexpMatches(e.output, r'tests/test_harness.*?OK')

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -87,4 +87,8 @@
     type = PythonUnitTest
     input = test_ParserErrors.py
   [../]
+  [./duplicate_test_names]
+    type = PythonUnitTest
+    input = test_DuplicateTestNames.py
+  [../]
 []

--- a/test/tests/test_harness/duplicate_test_names
+++ b/test/tests/test_harness/duplicate_test_names
@@ -1,0 +1,10 @@
+[Tests]
+  [./duplicate_test_name]
+    type = RunApp
+    input = good.i
+  [../]
+  [./duplicate_test_name]
+    type = RunApp
+    input = good.i
+  [../]
+[]


### PR DESCRIPTION
Tests having the same name within the same 'test' file will
now be skipped and provide an accurate caveat for doing so.

Add unittest to test this behavior.

Closes #10424 