### PR TITLE
Supress error message if git is not available

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -194,7 +194,7 @@ endif
 
 BUILD_EXEC :=
 
-app_GIT_DIR := $(shell cd "$(APPLICATION_DIR)" && git rev-parse --show-toplevel)
+app_GIT_DIR := $(shell cd "$(APPLICATION_DIR)" && which git &> /dev/null && git rev-parse --show-toplevel)
 # Use wildcard in case the files don't exist
 app_HEADER_deps := $(wildcard $(app_GIT_DIR)/.git/HEAD $(app_GIT_DIR)/.git/index)
 # Target-specific Variable Values (See GNU-make manual)


### PR DESCRIPTION
It can happen that git may not be available when building the code, then
users will see about 6 error messages that git is not available.  This
is supressing the messages.

Closes #10429

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
