### PR TITLE
Add ability to provide a custom CSS

### DIFF
--- a/docs/templates/include/head.html
+++ b/docs/templates/include/head.html
@@ -9,7 +9,7 @@
 <link type="text/css" rel="stylesheet" href="{{load(materialize_css|default('contrib/materialize/materialize.min.css'))}}"/>
 <link type="text/css" rel="stylesheet" href="{{load(prism_css|default('contrib/prisim/prism.min.css'))}}"/>
 <link type="text/css" rel="stylesheet" href="{{load(katex_css|default('contrib/katex/katex.min.css'))}}"/>
-<link type="text/css" rel="stylesheet" href="{{load('css/moose.css')}}"/>
+<link type="text/css" rel="stylesheet" href="{{load(moose_css|default('css/moose.css'))}}"/>
 
 <!-- JS -->
 <script type="text/javascript" src="{{load(katex_js|default('contrib/katex/katex.min.js'))}}"></script>

--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -63,13 +63,17 @@ def build_options(parser):
                              "ignored for this case.")
     parser.add_argument('--no-livereload', action='store_true',
                         help="When --serve is used this flag disables the live reloading.")
+    parser.add_argument('--css', type=str, metavar='*.css', help="Path to custom CSS to use. "
+                             "Important: You should continue to import the default within your "
+                             "custom css file for best results. To do so, add the following "
+                             "line to the top of your css: @import url(\"moose.css\");")
 
 class WebsiteBuilder(common.Builder):
     """
     Builder object for creating websites.
     """
 
-    def __init__(self, content=None, **kwargs):
+    def __init__(self, content=None, custom_css=None, **kwargs):
         super(WebsiteBuilder, self).__init__(**kwargs)
 
         if (content is None) or (not os.path.isfile(content)):
@@ -81,6 +85,7 @@ class WebsiteBuilder(common.Builder):
             content = MooseDocs.yaml_load(content)
 
         self._content = content
+        self._custom_css = custom_css
 
     def buildNodes(self):
         return common.moose_docs_file_tree(self._content)
@@ -100,6 +105,8 @@ class WebsiteBuilder(common.Builder):
                     shutil.rmtree(dest)
                 shutil.copytree(loc, dest)
 
+        if self._custom_css and os.path.exists(self._custom_css):
+            shutil.copy(self._custom_css, os.path.join(self._site_dir, 'css'))
 
 class MooseDocsWatcher(livereload.watcher.Watcher):
     """
@@ -196,10 +203,18 @@ def build(config_file=None, site_dir=None, num_threads=None, no_livereload=False
 
     # Create the markdown parser
     config = MooseDocs.load_config(config_file, template=template, template_args=template_args)
+
+    # Add custom CSS to the config
+    if template_args['css']:
+        if os.path.exists(template_args['css']):
+            config['MooseDocs.extensions.template']['template_args']['moose_css'] = 'css/' + os.path.basename(template_args['css'])
+        else:
+            LOG.warning("supplied css file does not exist")
+
     parser = MooseMarkdown(config)
 
     # Create the builder object and build the pages
-    builder = WebsiteBuilder(parser=parser, site_dir=site_dir, content=content)
+    builder = WebsiteBuilder(parser=parser, site_dir=site_dir, content=content, custom_css=template_args['css'])
     builder.init()
     if dump:
         print builder

--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -63,10 +63,11 @@ def build_options(parser):
                              "ignored for this case.")
     parser.add_argument('--no-livereload', action='store_true',
                         help="When --serve is used this flag disables the live reloading.")
-    parser.add_argument('--css', type=str, metavar='*.css', help="Path to custom CSS to use. "
-                             "Important: You should continue to import the default within your "
-                             "custom css file for best results. To do so, add the following "
-                             "line to the top of your css: @import url(\"moose.css\");")
+    parser.add_argument('--css', type=str, metavar='*.css',
+                        help="Path to custom CSS to use. Important: You should continue to "
+                             "import the default within your custom css file for best results. "
+                             "To do so, add the following line to the top of your css: @import "
+                             "url(\"moose.css\");")
 
 class WebsiteBuilder(common.Builder):
     """

--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -208,14 +208,18 @@ def build(config_file=None, site_dir=None, num_threads=None, no_livereload=False
     # Add custom CSS to the config
     if template_args['css']:
         if os.path.exists(template_args['css']):
-            config['MooseDocs.extensions.template']['template_args']['moose_css'] = 'css/' + os.path.basename(template_args['css'])
+            config['MooseDocs.extensions.template']['template_args']['moose_css'] = 'css/' +\
+                os.path.basename(template_args['css'])
         else:
             LOG.warning("supplied css file does not exist")
 
     parser = MooseMarkdown(config)
 
     # Create the builder object and build the pages
-    builder = WebsiteBuilder(parser=parser, site_dir=site_dir, content=content, custom_css=template_args['css'])
+    builder = WebsiteBuilder(parser=parser,
+                             site_dir=site_dir,
+                             content=content,
+                             custom_css=template_args['css'])
     builder.init()
     if dump:
         print builder


### PR DESCRIPTION
This commit adds the ability to more easily provide a custom
css file for the moose documentation system.

Closes #10431
