### PR TITLE
Split meshOnly function into two parts

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -188,6 +188,16 @@ public:
   MooseApp & mooseApp() { return _app; }
   const std::string & getCurrentTaskName() const { return _current_task; }
 
+  /**
+   * Mark tasks as one of the mesh-only tasks
+   */
+  void registerMeshOnlyTasks(const std::vector<std::string> & tasks);
+
+  /**
+   * Execute mesh-only tasks in the correct order
+   */
+  void executeMeshOnlyActions();
+
 protected:
   /**
    * This method auto-builds all Actions that needs to be built and adds them to ActionWarehouse.
@@ -210,6 +220,8 @@ protected:
   std::map<std::string, std::list<Action *>> _action_blocks;
   /// Action blocks that have been requested
   std::map<std::string, std::vector<Action *>> _requested_action_blocks;
+  /// mesh-only tasks
+  std::set<std::string> _mesh_only_tasks;
   /// The container that holds the sorted action names from the DependencyResolver
   std::vector<std::string> _ordered_names;
   /// Use to store the current list of unsatisfied dependencies

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -553,8 +553,14 @@ protected:
   /// Constructor is protected so that this object is constructed through the AppFactory object
   MooseApp(InputParameters parameters);
 
+  /**
+   * Register tasks required by mesh-only
+   * Note: applications can override this function to add more tasks for mesh-only.
+   */
+  virtual void registerMeshOnlyTasks();
+
   /// Don't run the simulation, just complete all of the mesh preperation steps and exit
-  virtual void meshOnly(std::string mesh_file_name);
+  void meshOnly(std::string mesh_file_name);
 
   /**
    * NOTE: This is an internal function meant for MOOSE use only!

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -363,6 +363,29 @@ ActionWarehouse::executeActionsWithAction(const std::string & task)
 }
 
 void
+ActionWarehouse::registerMeshOnlyTasks(const std::vector<std::string> & tasks)
+{
+  for (auto & task : tasks)
+    _mesh_only_tasks.insert(task);
+}
+
+void
+ActionWarehouse::executeMeshOnlyActions()
+{
+  if (_show_actions)
+  {
+    _console << "[DBG][ACT] Action Dependency Sets:\n";
+    printActionDependencySets();
+
+    _console << "\n[DBG][ACT] Executing actions:" << std::endl;
+  }
+
+  for (const auto & task : _ordered_names)
+    if (_mesh_only_tasks.count(task) > 0)
+      executeActionsWithAction(task);
+}
+
+void
 ActionWarehouse::printInputFile(std::ostream & out)
 {
   InputFileFormatter tree(false);

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -549,6 +549,7 @@ MooseApp::runInputFile()
   std::string mesh_file_name;
   if (!_ready_to_exit && isParamValid("mesh_only"))
   {
+    registerMeshOnlyTasks();
     meshOnly(getParam<std::string>("mesh_only"));
     _ready_to_exit = true;
   }
@@ -626,22 +627,31 @@ MooseApp::hasRecoverFileBase()
 }
 
 void
-MooseApp::meshOnly(std::string mesh_file_name)
+MooseApp::registerMeshOnlyTasks()
 {
   /**
-   * These actions should be the minimum set necessary to generate and output
-   * a Mesh.
+   * These actions should be the minimum set necessary to generate and output a Mesh.
    */
-  _action_warehouse.executeActionsWithAction("meta_action");
-  _action_warehouse.executeActionsWithAction("set_global_params");
-  _action_warehouse.executeActionsWithAction("setup_mesh");
-  _action_warehouse.executeActionsWithAction("add_partitioner");
-  _action_warehouse.executeActionsWithAction("init_mesh");
-  _action_warehouse.executeActionsWithAction("prepare_mesh");
-  _action_warehouse.executeActionsWithAction("add_mesh_modifier");
-  _action_warehouse.executeActionsWithAction("execute_mesh_modifiers");
-  _action_warehouse.executeActionsWithAction("uniform_refine_mesh");
-  _action_warehouse.executeActionsWithAction("setup_mesh_complete");
+  std::vector<std::string> tasks;
+
+  tasks.push_back("meta_action");
+  tasks.push_back("set_global_params");
+  tasks.push_back("setup_mesh");
+  tasks.push_back("add_partitioner");
+  tasks.push_back("init_mesh");
+  tasks.push_back("prepare_mesh");
+  tasks.push_back("add_mesh_modifier");
+  tasks.push_back("execute_mesh_modifiers");
+  tasks.push_back("uniform_refine_mesh");
+  tasks.push_back("setup_mesh_complete");
+
+  _action_warehouse.registerMeshOnlyTasks(tasks);
+}
+
+void
+MooseApp::meshOnly(std::string mesh_file_name)
+{
+  _action_warehouse.executeMeshOnlyActions();
 
   std::shared_ptr<MooseMesh> & mesh = _action_warehouse.mesh();
 


### PR DESCRIPTION
This will enable more flexible override in the derived apps. Close #10434.
