### PR TITLE
Reset highlighting during a VTKWindowPlugin reset

### DIFF
--- a/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
@@ -110,6 +110,7 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
         self._window.update()
         self._initialized = False
         self._reset_required = False
+        self._highlight = None
         self._adjustTimers(start=['initialize'], stop=['update'])
         self.windowReset.emit()
 


### PR DESCRIPTION
High lighting was not getting reset so it was always showing the first file that was opened.

closes #10039

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
