### PR TITLE
Mesh only refactor

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -169,6 +169,7 @@ using libMesh::err;
 void registerObjects(Factory & factory);
 void addActionTypes(Syntax & syntax);
 void registerActions(Syntax & syntax, ActionFactory & action_factory);
+void populateMeshOnlyTasks(Syntax & syntax);
 
 void setSolverDefaults(FEProblemBase & problem);
 

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -553,8 +553,14 @@ protected:
   /// Constructor is protected so that this object is constructed through the AppFactory object
   MooseApp(InputParameters parameters);
 
-  /// Don't run the simulation, just complete all of the mesh preperation steps and exit
-  virtual void meshOnly(std::string mesh_file_name);
+  /// Populate the _syntax object with mesh only tasks that will be executed before writing mesh.
+  virtual void modifyMeshOnlyTasks(Syntax &) {}
+
+  /// Write out the mesh file (used by the --mesh-only command line flag).
+  virtual void writeMeshOnly(std::string mesh_file_name);
+
+  /// TODO: Deprecated, remove
+  virtual void meshOnly(std::string /*mesh_file_name*/) { mooseDeprecated("Use writeMeshOnly"); }
 
   /**
    * NOTE: This is an internal function meant for MOOSE use only!

--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -69,7 +69,7 @@ public:
                            int line = -1);
 
   /**
-   *  Registration a type with a block. For example, associate FunctionName with the Functions block
+   * Registration a type with a block. For example, associate FunctionName with the Functions block
    * @param syntax The target syntax to associate the type with
    * @param type The name of the type to associate with the syntax
    */

--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -69,7 +69,7 @@ public:
                            int line = -1);
 
   /**
-   * Registration a type with a block. For example, associate FunctionName with the Functions block
+   * Register a type with a block. For example, associate FunctionName with the Functions block.
    * @param syntax The target syntax to associate the type with
    * @param type The name of the type to associate with the syntax
    */

--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -41,6 +41,7 @@ public:
 
   void addDependency(std::string task, std::string pre_req);
   void addDependencySets(const std::string & action_sets);
+  void clearTaskDependencies();
 
   const std::vector<std::string> & getSortedTask();
   const std::vector<std::vector<std::string>> & getSortedTaskSet();

--- a/framework/include/utils/DependencyResolver.h
+++ b/framework/include/utils/DependencyResolver.h
@@ -75,6 +75,11 @@ public:
   void addItem(const T & value);
 
   /**
+   * Clear Items from the resolver
+   */
+  void clear();
+
+  /**
    * Returns a vector of sets that represent dependency resolved values.  Items in the same
    * subvector have no dependence upon one and other.
    */
@@ -215,6 +220,17 @@ DependencyResolver<T>::addItem(const T & value)
   _independent_items.push_back(value);
   if (std::find(_ordering_vector.begin(), _ordering_vector.end(), value) == _ordering_vector.end())
     _ordering_vector.push_back(value);
+}
+
+template <typename T>
+void
+DependencyResolver<T>::clear()
+{
+  _depends.clear();
+  _independent_items.clear();
+  _ordering_vector.clear();
+  _ordered_items.clear();
+  _ordered_items_vector.clear();
 }
 
 template <typename T>

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -481,13 +481,11 @@
 
 #include <unistd.h>
 
-// Define the available execute flags for MOOSE. The flags using a hex value are setup to retain
-// the same numbers that were utilized with older versions of MOOSE for keeping existing
-// applications
+// Define the available execute flags for MOOSE. The flags using a hex value are setup to retain the
+// same numbers that were utilized with older versions of MOOSE for keeping existing applications
 // working using the deprecated flags. In the future, as in the EXEC_SAME_AS_MULTIAPP flag, there is
-// no reason to keep these flags bitwise comparable or to assigned an id because
-// the MultiMooseEnum that is used to store these has convenience methods for
-// determining the what flags are active.
+// no reason to keep these flags bitwise comparable or to assigned an id because the MultiMooseEnum
+// that is used to store these has convenience methods for determining the what flags are active.
 const ExecFlagType EXEC_NONE("NONE", 0x00);                     // 0
 const ExecFlagType EXEC_INITIAL("INITIAL", 0x01);               // 1
 const ExecFlagType EXEC_LINEAR("LINEAR", 0x02);                 // 2
@@ -916,26 +914,23 @@ addActionTypes(Syntax & syntax)
   /**
    * The second param here indicates whether the task must be satisfied or not for a successful run.
    * If set to true, then the ActionWarehouse will attempt to create "Action"s automatically if they
-   * have
-   * not been explicitly created by the parser or some other mechanism.
+   * have not been explicitly created by the parser or some other mechanism.
    *
    * Note: Many of the actions in the "Minimal Problem" section are marked as false.  However, we
-   * can generally
-   * force creation of these "Action"s as needed by registering them to syntax that we expect to see
-   * even
-   * if those "Action"s  don't normally pick up parameters from the input file.
+   * can generally force creation of these "Action"s as needed by registering them to syntax that we
+   * expect to see even if those "Action"s  don't normally pick up parameters from the input file.
    */
 
   // clang-format off
   /**************************/
   /**** Register Actions ****/
   /**************************/
-  registerMooseObjectTask("create_problem",               Problem,                 false);
-  registerMooseObjectTask("setup_executioner",            Executioner,             true);
+  registerMooseObjectTask("create_problem",               Problem,                false);
+  registerMooseObjectTask("setup_executioner",            Executioner,            true);
 
   // This task does not construct an object, but it needs all of the parameters that
   // would normally be used to construct an object.
-  registerMooseObjectTask("determine_system_type",        Executioner,             true);
+  registerMooseObjectTask("determine_system_type",        Executioner,            true);
 
   registerMooseObjectTask("setup_mesh",                   MooseMesh,              false);
   registerMooseObjectTask("init_mesh",                    MooseMesh,              false);
@@ -1044,10 +1039,9 @@ addActionTypes(Syntax & syntax)
   /**************************/
   /**
    * The following is the default set of action dependencies for a basic MOOSE problem.  The
-   * formatting
-   * of this string is important.  Each line represents a set of dependencies that depend on the
-   * previous
-   * line.  Items on the same line have equal weight and can be executed in any order.
+   * formatting of this string is important.  Each line represents a set of dependencies that depend
+   * on the previous line.  Items on the same line have equal weight and can be executed in any
+   * order.
    *
    * Additional dependencies can be inserted later inside of user applications with calls to
    * ActionWarehouse::addDependency("task", "pre_req")
@@ -1130,8 +1124,9 @@ populateMeshOnlyTasks(Syntax & syntax)
 
 /**
  * Multiple Action class can be associated with a single input file section, in which case all
- * associated Actions
- * will be created and "acted" on when the associated input file section is seen.b *
+ * associated Actions will be created and "acted" on when the associated input file section is
+ * seen.b *
+ *
  * Example:
  *  "setup_mesh" <-----------> SetupMeshAction <---------
  *                                                        \
@@ -1141,8 +1136,7 @@ populateMeshOnlyTasks(Syntax & syntax)
  *
  *
  * Action classes can also be registered to act on more than one input file section for a different
- * task
- * if similar logic can work in multiple cases
+ * task if similar logic can work in multiple cases
  *
  * Example:
  * "add_variable" <-----                       -> [Variables/ *]
@@ -1153,10 +1147,8 @@ populateMeshOnlyTasks(Syntax & syntax)
  *
  *
  * Note: Placeholder "no_action" actions must be put in places where it is possible to match an
- * object
- *       with a star or a more specific parent later on. (i.e. where one needs to negate the '*'
- * matching
- *       prematurely)
+ *       object with a star or a more specific parent later on. (i.e. where one needs to negate the
+ *       '*' matching prematurely).
  */
 void
 registerActions(Syntax & syntax, ActionFactory & action_factory)

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -1125,7 +1125,7 @@ populateMeshOnlyTasks(Syntax & syntax)
 /**
  * Multiple Action class can be associated with a single input file section, in which case all
  * associated Actions will be created and "acted" on when the associated input file section is
- * seen.b *
+ * seen.*
  *
  * Example:
  *  "setup_mesh" <-----------> SetupMeshAction <---------

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -1112,6 +1112,22 @@ addActionTypes(Syntax & syntax)
                            "(check_integrity)");
 }
 
+void
+populateMeshOnlyTasks(Syntax & syntax)
+{
+  syntax.addDependencySets("(meta_action)"
+                           "(set_global_params)"
+                           "(setup_mesh)"
+                           "(add_partitioner)"
+                           "(init_mesh)"
+                           "(prepare_mesh)"
+                           "(add_mesh_modifier)"
+                           "(execute_mesh_modifiers)"
+                           "(add_mortar_interface)"
+                           "(uniform_refine_mesh)"
+                           "(setup_mesh_complete)");
+}
+
 /**
  * Multiple Action class can be associated with a single input file section, in which case all
  * associated Actions

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -77,6 +77,12 @@ Syntax::addDependencySets(const std::string & action_sets)
   }
 }
 
+void
+Syntax::clearTaskDependencies()
+{
+  _tasks.clear();
+}
+
 const std::vector<std::string> &
 Syntax::getSortedTask()
 {

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -152,7 +152,7 @@ Syntax::getSyntaxByAction(const std::string & action, const std::string & task)
   /**
    * For now we don't have a data structure that maps Actions to Syntax but this routine
    * is only used by the build full tree routine so it doesn't need to be fast.  We
-   * will do a linear search for each call to this routine
+   * will do a linear search for each call to this routine.
    */
   for (const auto & iter : _associated_actions)
     if (iter.second._action == action && (iter.second._task == task || iter.second._task == ""))
@@ -166,12 +166,10 @@ Syntax::isAssociated(const std::string & real_id, bool * is_parent)
 {
   /**
    * This implementation assumes that wildcards can occur in the place of an entire token but not as
-   * part
-   * of a token (i.e.  'Variables/ * /InitialConditions' is valid but not 'Variables/Partial*
+   * part of a token (i.e.  'Variables/ * /InitialConditions' is valid but not 'Variables/Partial*
    * /InitialConditions'.
    * Since maps are ordered, a reverse traversal through the registered list will always select a
-   * more
-   * specific match before a wildcard match ('*' == char(42))
+   * more specific match before a wildcard match ('*' == char(42)).
    */
   bool local_is_parent;
   if (is_parent == NULL)


### PR DESCRIPTION
Create a new callback so that users can modify (inject new tasks) the syntax object. This also simplifies the mesh-only logic since we can just execute all tasks once we've modified the syntax dependency sets.
 
#10434