### PR TITLE
Beautify output and allow customization

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -393,9 +393,7 @@ class TestHarness:
 
         return True
 
-    # Format results the way we want it
-    # TODO: refactore. It seems we only need it so the word FAILED
-    # appears before the status message.
+    # Format the caveats contained in tester so they are easy to read when printed
     def formatCaveats(self, tester):
         # PASS and DRY_RUN fall into this catagory
         if tester.didPass():

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -158,7 +158,8 @@ class Scheduler(MooseObject):
 
             for failed_job in failed_job_containers:
                 failed_tester = failed_job.getTester()
-                failed_tester.setStatus('skipped dependency', failed_tester.bucket_skip)
+                failed_tester.addCaveats('skipped dependency')
+                failed_tester.setStatus(failed_tester.bucket_skip.status, failed_tester.bucket_skip)
 
         return failed_job_containers
 
@@ -201,9 +202,11 @@ class Scheduler(MooseObject):
                 except dag.DAGEdgeIndError:
                     if not self.skipPrereqs():
                         if self.options.reg_exp:
-                            tester.setStatus('dependency does not match re', tester.bucket_skip)
+                            tester.addCaveats('dependency does not match re')
+                            tester.setStatus(tester.bucket_skip.status, tester.bucket_skip)
                         else:
-                            tester.setStatus('skipped dependency', tester.bucket_skip)
+                            tester.addCaveats('skipped dependency')
+                            tester.setStatus(tester.bucket_skip.status, tester.bucket_skip)
                         failed_or_skipped_testers.add(tester)
 
                     # Add the parent node / dependency edge to create a functional DAG now that we have caught
@@ -425,7 +428,8 @@ class Scheduler(MooseObject):
             # Check for insufficient slots -hard limit (skip this job)
             # TODO: Create a unit test for this case
             elif job_container.getSlots() > self.available_slots and not self.soft_limit:
-                tester.setStatus('insufficient slots', tester.bucket_skip)
+                tester.addCaveats('insufficient slots')
+                tester.setStatus(tester.bucket_skip.status, tester.bucket_skip)
 
             if can_run:
                 self.slots_in_use += job_container.getSlots()

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -298,7 +298,8 @@ class Scheduler(MooseObject):
         # set. We will use this set as a way to gain access to their methods.
         for tester in testers:
             if tester.getTestName() in name_to_job_container:
-                tester.setStatus('duplicate test', tester.bucket_skip)
+                tester.addCaveats('duplicate test')
+                tester.setStatus(tester.bucket_skip.status, tester.bucket_skip)
                 non_runnable_jobs.add(Job(tester, job_dag, self.options))
             else:
                 name_to_job_container[tester.getTestName()] = Job(tester, job_dag, self.options)

--- a/python/TestHarness/testers/CSVDiff.py
+++ b/python/TestHarness/testers/CSVDiff.py
@@ -25,7 +25,8 @@ class CSVDiff(FileTester):
 
         # Don't Run CSVDiff on Scaled Tests
         if options.scaling and specs['scale_refine']:
-            self.setStatus("don't run CSVDiff on Scaled Tests", self.bucket_skip)
+            self.addCaveats('SCALING=True')
+            self.setStatus(self.bucket_skip.status, self.bucket_skip)
             return output
 
         if len(specs['csvdiff']) > 0:

--- a/python/TestHarness/testers/PetscJacobianTester.py
+++ b/python/TestHarness/testers/PetscJacobianTester.py
@@ -13,7 +13,8 @@ class PetscJacobianTester(RunApp):
 
     def checkRunnable(self, options):
         if options.enable_recover:
-            self.setStatus('PetscJacTester RECOVER', self.bucket_skip)
+            self.addCaveats('PetscJacTester RECOVER')
+            self.setStatus(self.bucket_skip.status, self.bucket_skip)
             return False
         return RunApp.checkRunnable(self, options)
 

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -64,11 +64,13 @@ class RunApp(Tester):
     def checkRunnable(self, options):
         if options.enable_recover:
             if self.specs.isValid('expect_out') or self.specs.isValid('absent_out') or self.specs['should_crash'] == True:
-                self.setStatus('expect_out RECOVER', self.bucket_skip)
+                self.addCaveats('expect_out RECOVER')
+                self.setStatus(self.bucket_skip.status, self.bucket_skip)
                 return False
 
         if self.specs.isValid('executable_pattern') and re.search(self.specs['executable_pattern'], self.specs['executable']) == None:
-            self.setStatus('EXECUTABLE PATTERN', self.bucket_skip)
+            self.addCaveats('EXECUTABLE PATTERN')
+            self.setStatus(self.bucket_skip.status, self.bucket_skip)
             return False
 
         return True

--- a/python/TestHarness/testers/RunCommand.py
+++ b/python/TestHarness/testers/RunCommand.py
@@ -21,5 +21,5 @@ class RunCommand(Tester):
         if self.exit_code != 0 :
             self.setStatus('CODE %d' % self.exit_code, self.bucket_fail)
         else:
-            self.setStatus(self.exit_code, self.bucket_success)
+            self.setStatus(self.success_message, self.bucket_success)
         return output

--- a/python/TestHarness/testers/RunException.py
+++ b/python/TestHarness/testers/RunException.py
@@ -23,7 +23,8 @@ class RunException(RunApp):
 
     def checkRunnable(self, options):
         if options.enable_recover:
-            self.setStatus('RunException RECOVER', self.bucket_skip)
+            self.addCaveats('RunException RECOVER')
+            self.setStatus(self.bucket_skip.status, self.bucket_skip)
             return False
         return RunApp.checkRunnable(self, options)
 

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -609,11 +609,7 @@ class Tester(MooseObject):
                 if key.lower() not in caveat_list:
                     tmp_reason.append(value)
 
-            # Format joined reason to better fit on the screen
-            if len(', '.join(tmp_reason)) >= int(util.TERM_COLS) - (len(self.specs['test_name'])+21):
-                flat_reason = (', '.join(tmp_reason))[:(util.TERM_COLS - (len(self.specs['test_name'])+24))] + '...'
-            else:
-                flat_reason = ', '.join(tmp_reason)
+            flat_reason = ', '.join(tmp_reason)
 
             # If the test is deleted we still need to treat this differently
             self.addCaveats(flat_reason)

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -483,7 +483,7 @@ class Tester(MooseObject):
 
         # Check for deleted tests
         if self.specs.isValid('deleted'):
-            reasons['deleted'] = 'deleted ({})'.format(self.specs['deleted'])
+            reasons['deleted'] = str(self.specs['deleted'])
 
         # Skipped by external means (example: TestHarness part2 with --check-input)
         if self.isSkipped():
@@ -610,16 +610,17 @@ class Tester(MooseObject):
                     tmp_reason.append(value)
 
             # Format joined reason to better fit on the screen
-            if len(', '.join(tmp_reason)) >= util.TERM_COLS - (len(self.specs['test_name'])+21):
+            if len(', '.join(tmp_reason)) >= int(util.TERM_COLS) - (len(self.specs['test_name'])+21):
                 flat_reason = (', '.join(tmp_reason))[:(util.TERM_COLS - (len(self.specs['test_name'])+24))] + '...'
             else:
                 flat_reason = ', '.join(tmp_reason)
 
             # If the test is deleted we still need to treat this differently
+            self.addCaveats(flat_reason)
             if 'deleted' in reasons.keys():
-                self.setStatus(flat_reason, self.bucket_deleted)
+                self.setStatus(self.bucket_deleted.status, self.bucket_deleted)
             else:
-                self.setStatus(flat_reason, self.bucket_skip)
+                self.setStatus(self.bucket_skip.status, self.bucket_skip)
             return False
 
         # Check the return values of the derived classes

--- a/python/TestHarness/testers/VTKDiff.py
+++ b/python/TestHarness/testers/VTKDiff.py
@@ -62,7 +62,8 @@ class VTKDiff(RunApp):
                     output += differ.message() + '\n'
 
                     if differ.fail():
-                        self.setStatus('VTKDIFF', self.bucket_skip)
+                        self.addCaveats('VTKDIFF')
+                        self.setStatus(self.bucket_skip.status, self.bucket_skip)
                         break
 
         # If status is still pending, then it is a passing test

--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -153,7 +153,7 @@ class SpeedTest(Tester):
 
     # override
     def processResults(self, moose_dir, options, output):
-        self.setStatus(self.exit_code, self.bucket_success)
+        self.setStatus(self.success_message, self.bucket_success)
         return output
 
 class Bench:

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -9,9 +9,7 @@ class TestHarnessTestCase(unittest.TestCase):
     """
 
     def runExceptionTests(self, *args):
-        if 'MOOSE_TERM_FORMAT' in os.environ:
-            del os.environ['MOOSE_TERM_FORMAT']
-
+        os.environ['MOOSE_TERM_FORMAT'] = 'njCst'
         cmd = ['./run_tests'] + list(args)
         try:
             return subprocess.check_output(cmd, cwd=os.path.join(os.getenv('MOOSE_DIR'), 'test'))
@@ -20,9 +18,7 @@ class TestHarnessTestCase(unittest.TestCase):
             return err.output
 
     def runTests(self, *args):
-        if 'MOOSE_TERM_FORMAT' in os.environ:
-            del os.environ['MOOSE_TERM_FORMAT']
-
+        os.environ['MOOSE_TERM_FORMAT'] = 'njCst'
         cmd = ['./run_tests'] + list(args)
         return subprocess.check_output(cmd, cwd=os.path.join(os.getenv('MOOSE_DIR'), 'test'))
 

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -9,6 +9,9 @@ class TestHarnessTestCase(unittest.TestCase):
     """
 
     def runExceptionTests(self, *args):
+        if 'MOOSE_TERM_FORMAT' in os.environ:
+            del os.environ['MOOSE_TERM_FORMAT']
+
         cmd = ['./run_tests'] + list(args)
         try:
             return subprocess.check_output(cmd, cwd=os.path.join(os.getenv('MOOSE_DIR'), 'test'))
@@ -17,6 +20,9 @@ class TestHarnessTestCase(unittest.TestCase):
             return err.output
 
     def runTests(self, *args):
+        if 'MOOSE_TERM_FORMAT' in os.environ:
+            del os.environ['MOOSE_TERM_FORMAT']
+
         cmd = ['./run_tests'] + list(args)
         return subprocess.check_output(cmd, cwd=os.path.join(os.getenv('MOOSE_DIR'), 'test'))
 

--- a/python/TestHarness/tests/test_Allocations.py
+++ b/python/TestHarness/tests/test_Allocations.py
@@ -7,16 +7,17 @@ class TestHarnessTester(TestHarnessTestCase):
         resource allocation.
         """
         # Subject a normally passing test to impossible cpu allocations
-        output = self.runTests('-i', 'always_ok', '-p', '2', '-j', '1')
-        self.assertIn('skipped (insufficient slots)', output)
+        output = self.runTests('--no-color', '-i', 'always_ok', '-p', '2', '-j', '1')
+        #self.assertIn('skipped (insufficient slots)', output)
+        self.assertRegexpMatches(output, 'tests/test_harness.always_ok.*? \[INSUFFICIENT SLOTS\] SKIP')
 
         # Subject a normally passing test to impossible thread allocations
-        output = self.runTests('-i', 'always_ok', '--n-threads', '2', '-j', '1')
-        self.assertIn('skipped (insufficient slots)', output)
+        output = self.runTests('--no-color', '-i', 'always_ok', '--n-threads', '2', '-j', '1')
+        self.assertRegexpMatches(output, 'tests/test_harness.always_ok.*? \[INSUFFICIENT SLOTS\] SKIP')
 
         # A combination of threads*cpus with too low a hard limit (3*3= -j9)
-        output = self.runTests('-i', 'allocation_test', '--n-threads', '3', '-p', '3', '-j', '8')
-        self.assertIn('skipped (insufficient slots)', output)
+        output = self.runTests('--no-color', '-i', 'allocation_test', '--n-threads', '3', '-p', '3', '-j', '8')
+        self.assertRegexpMatches(output, 'tests/test_harness.allocation_test.*? \[INSUFFICIENT SLOTS\] SKIP')
 
     def testOversizedCaveat(self):
         """

--- a/python/TestHarness/tests/test_Allocations.py
+++ b/python/TestHarness/tests/test_Allocations.py
@@ -8,7 +8,6 @@ class TestHarnessTester(TestHarnessTestCase):
         """
         # Subject a normally passing test to impossible cpu allocations
         output = self.runTests('--no-color', '-i', 'always_ok', '-p', '2', '-j', '1')
-        #self.assertIn('skipped (insufficient slots)', output)
         self.assertRegexpMatches(output, 'tests/test_harness.always_ok.*? \[INSUFFICIENT SLOTS\] SKIP')
 
         # Subject a normally passing test to impossible thread allocations

--- a/python/TestHarness/tests/test_Cyclic.py
+++ b/python/TestHarness/tests/test_Cyclic.py
@@ -7,9 +7,8 @@ class TestHarnessTester(TestHarnessTestCase):
         Test cyclic dependency error.
         """
         with self.assertRaises(subprocess.CalledProcessError) as cm:
-            self.runTests('-i', 'cyclic_tests')
+            self.runTests('--no-color', '-i', 'cyclic_tests')
 
         e = cm.exception
-        self.assertRegexpMatches(e.output, r'tests/test_harness.test.*?FAILED \(Cyclic or Invalid Dependency Detected!\)')
-        self.assertRegexpMatches(e.output, r'tests/test_harness.test.*?skipped \(skipped dependency\)')
-        self.assertRegexpMatches(e.output, r'tests/test_harness.test.*?skipped \(skipped dependency\)')
+        self.assertRegexpMatches(e.output, r'tests/test_harness.testB.*? FAILED \(Cyclic or Invalid Dependency Detected!\)')
+        self.assertRegexpMatches(e.output, r'tests/test_harness.test[A|C].*? \[SKIPPED DEPENDENCY\] SKIP')

--- a/python/TestHarness/tests/test_Deleted.py
+++ b/python/TestHarness/tests/test_Deleted.py
@@ -7,7 +7,14 @@ class TestHarnessTester(TestHarnessTestCase):
         Test that deleted tests returns a failed deleted test when extra info argument is supplied
         """
         with self.assertRaises(subprocess.CalledProcessError) as cm:
-            self.runTests('-i', 'deleted', '-e')
+            self.runTests('--no-color', '-i', 'deleted', '-e')
 
         e = cm.exception
-        self.assertRegexpMatches(e.output, 'test_harness\.deleted.*?deleted \(test deleted test\)')
+        self.assertRegexpMatches(e.output, r'test_harness\.deleted.*? \[TEST DELETED TEST\] FAILED \(DELETED\)')
+
+    def testNoExtraInfo(self):
+        """
+        Test that deleted tests do not run without -e (extra) option
+        """
+        output = self.runTests('--no-color', '-i', 'deleted')
+        self.assertNotIn('tests/test_harness.deleted', output)

--- a/python/TestHarness/tests/test_DependencySkip.py
+++ b/python/TestHarness/tests/test_DependencySkip.py
@@ -4,6 +4,6 @@ class TestHarnessTester(TestHarnessTestCase):
         """
         Test skipping a test if its prereq is also skipped
         """
-        output = self.runTests('-i', 'depend_skip_tests')
-        self.assertIn('skipped (always skipped)', output)
-        self.assertIn('skipped (skipped dependency)', output)
+        output = self.runTests('--no-color', '-i', 'depend_skip_tests')
+        self.assertIn('[ALWAYS SKIPPED] SKIP', output)
+        self.assertIn('[SKIPPED DEPENDENCY] SKIP', output)

--- a/python/TestHarness/tests/test_DisplayRequired.py
+++ b/python/TestHarness/tests/test_DisplayRequired.py
@@ -11,8 +11,8 @@ class TestHarnessTester(TestHarnessTestCase):
         if display:
             os.unsetenv('DISPLAY')
 
-        output = self.runTests('-i', 'display_required')
-        self.assertRegexpMatches(output, r'test_harness\.display_required.*?skipped\s\(NO DISPLAY\)')
+        output = self.runTests('--no-color', '-i', 'display_required')
+        self.assertRegexpMatches(output, r'test_harness\.display_required.*? \[NO DISPLAY\] SKIP')
 
         if display:
             os.putenv('DISPLAY', display)

--- a/python/TestHarness/tests/test_DistributedMesh.py
+++ b/python/TestHarness/tests/test_DistributedMesh.py
@@ -7,8 +7,8 @@ class TestHarnessTester(TestHarnessTestCase):
         """
 
         # Verify the distributed mesh test is skipped
-        output = self.runExceptionTests('-i', 'mesh_mode_distributed')
-        self.assertIn('skipped (MESH_MODE!=DISTRIBUTED)', output)
+        output = self.runExceptionTests('-i', 'mesh_mode_distributed', '--no-color')
+        self.assertIn('[MESH_MODE!=DISTRIBUTED] SKIP', output)
 
         # Verify the distributed mesh test is passing when providing --distributed
         # To be acurate, test for OK rather than asserting if 'distributed' is

--- a/python/TestHarness/tests/test_DryRun.py
+++ b/python/TestHarness/tests/test_DryRun.py
@@ -12,14 +12,14 @@ class TestHarnessTester(TestHarnessTestCase):
         self.assertRegexpMatches(output, 'test_harness\.csvdiff.*?DRY RUN')
 
         # Skipped caveat test which returns skipped instead of 'DRY RUN'
-        output = self.runTests('-i', 'depend_skip_tests', '--dry-run')
-        self.assertIn('skipped (always skipped)', output)
-        self.assertIn('skipped (skipped dependency)', output)
+        output = self.runTests('--no-color', '-i', 'depend_skip_tests', '--dry-run')
+        self.assertRegexpMatches(output, r'tests/test_harness.always_skipped.*? \[ALWAYS SKIPPED\] SKIP')
+        self.assertRegexpMatches(output, r'tests/test_harness.needs_always_skipped.*? \[SKIPPED DEPENDENCY\] SKIP')
 
         # Deleted caveat test which returns a deleted failing tests while
         # performing a dry run
         with self.assertRaises(subprocess.CalledProcessError) as cm:
-            self.runTests('-i', 'deleted', '-e', '--dry-run')
+            self.runTests('--no-color', '-i', 'deleted', '-e', '--dry-run')
 
         e = cm.exception
-        self.assertRegexpMatches(e.output, 'test_harness\.deleted.*?deleted \(test deleted test\)')
+        self.assertRegexpMatches(e.output, r'test_harness\.deleted.*? \[TEST DELETED TEST\] FAILED \(DELETED\)')

--- a/python/TestHarness/tests/test_DuplicateTestNames.py
+++ b/python/TestHarness/tests/test_DuplicateTestNames.py
@@ -13,5 +13,5 @@ class TestHarnessTester(TestHarnessTestCase):
 
         e = cm.exception
 
-        self.assertRegexpMatches(e.output, r'tests/test_harness.*?skipped \(duplicate test\)')
+        self.assertRegexpMatches(e.output, r'tests/test_harness.*? \[DUPLICATE TEST\] SKIP')
         self.assertRegexpMatches(e.output, r'tests/test_harness.*?OK')

--- a/python/TestHarness/tests/test_ExtraInfo.py
+++ b/python/TestHarness/tests/test_ExtraInfo.py
@@ -33,7 +33,7 @@ class TestHarnessTester(TestHarnessTestCase):
 
         # Parse the output, and find the caveat string
         raw_caveat_string = re.findall(r'\[(.*)\]', output)
-        output_caveats = raw_caveat_string[0].split(', ')
+        output_caveats = raw_caveat_string[0].split(',')
 
         # Do the comparison and assert if different. Using a
         # differential set grants us the benifit of forcing us to

--- a/python/TestHarness/tests/test_Ignore.py
+++ b/python/TestHarness/tests/test_Ignore.py
@@ -1,48 +1,87 @@
 from TestHarnessTestCase import TestHarnessTestCase
 
 class TestHarnessTester(TestHarnessTestCase):
-    def testIgnore(self):
+    def testIgnoreSkip(self):
         """
-        Test that --ignore overrides normally skipped tests
+        Test that `--ignore skip` runs tests normally skipped
         """
         # Run a skipped test
         output = self.runTests('-i', 'ignore_skipped', '--ignore', 'skip')
         self.assertRegexpMatches(output, 'test_harness\.ignore_skipped.*?OK')
 
+    def testIgnoreHeavy(self):
+        """
+        Test that `--ignore heavy` runs tests normally skipped if heavy
+        """
         # Run a skipped heavy test
         output = self.runTests('-i', 'ignore_heavy', '--ignore', 'heavy')
         self.assertRegexpMatches(output, 'test_harness\.ignore_heavy.*?OK')
 
+    def testIgnoreCompiler(self):
+        """
+        Test that `--ignore compiler` runs tests normally skipped if compiler
+        is not available
+        """
         # Run a skipped compiler test
         output = self.runTests('-i', 'ignore_compiler', '--ignore', 'compiler')
         self.assertRegexpMatches(output, 'test_harness\.ignore_compiler.*?OK')
 
+    def testIgnorePlatform(self):
+        """
+        Test that `--ignore platform` runs tests normally skipped if platform
+        is not available
+        """
         # Run a skipped platform test
         output = self.runTests('-i', 'ignore_platform', '--ignore', 'platform')
         self.assertRegexpMatches(output, 'test_harness\.ignore_platform.*?OK')
 
+    def testIgnorePreReq(self):
+        """
+        Tests that `--ignore prereq` runs tests normally skipped if prereqs
+        are not satisfied
+        """
         # Run a skipped prereq test
-        output = self.runTests('-i', 'ignore_prereq', '--ignore', 'prereq')
-        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?skipped')
+        output = self.runTests('--no-color', '-i', 'ignore_prereq', '--ignore', 'prereq')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*? \[ALWAYS SKIPPED\] SKIP')
         self.assertRegexpMatches(output, 'test_harness\.ignore_skipped_dependency.*?OK')
 
         # Check that a dependency test runs when its prereq test is skipped
-        output = self.runTests('-i', 'ignore_prereq', '--ignore', 'skip')
+        output = self.runTests('--no-color', '-i', 'ignore_prereq', '--ignore', 'skip')
         self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?OK')
         self.assertRegexpMatches(output, 'test_harness\.ignore_skipped_dependency.*?OK')
 
+    def testIgnoreMultiple(self):
+        """
+        Test that `--ignore [list]` runs tests with multiple caveats
+        preventing the test from running
+        """
         # Run a multiple caveat skipped test by manually supplying each caveat
         output = self.runTests('-i', 'ignore_multiple', '--ignore', 'skip heavy compiler platform')
         self.assertRegexpMatches(output, 'test_harness\.ignore_multiple.*?OK')
 
+    def testIgnoreAll(self):
+        """
+        Test that the blanket option `--ignore` will run anything that would
+        normally be skipped
+        """
         # Run a multiple caveat skipped test using built in default 'all'
         output = self.runTests('-i', 'ignore_multiple', '--ignore')
         self.assertRegexpMatches(output, 'test_harness\.ignore_multiple.*?OK')
 
+    def testIgnoreMissingOne(self):
+        """
+        Test that `--ignore [list]` (but missing one) will still have that
+        test skipped (platform not ignored)
+        """
         # Skip a multiple caveat test by not supplying enough caveats to ignore
-        output = self.runTests('-i', 'ignore_multiple', '--ignore', 'skip heavy compiler')
-        self.assertRegexpMatches(output, 'test_harness\.ignore_multiple.*?skipped')
+        output = self.runTests('--no-color', '-i', 'ignore_multiple', '--ignore', 'skip heavy compiler')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multiple.*? \[PLATFORM!=NON_EXISTENT\] SKIP')
 
+    def testIgnoreMultiplePreReq(self):
+        """
+        Test that `--ignore [assorted]` on a multi-required caveat test
+        operates the way it should
+        """
         # Run a multiple caveat prereq test using built in default 'all'
         output = self.runTests('-i', 'ignore_multiple_prereq', '--ignore')
         self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?OK')
@@ -54,12 +93,18 @@ class TestHarnessTester(TestHarnessTestCase):
         self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*?OK')
 
         # Skip a multiple caveat prereq test by not supplying enough caveats to ignore
-        output = self.runTests('-i', 'ignore_multiple_prereq', '--ignore', 'prereq skip heavy compiler')
+        output = self.runTests('--no-color', '-i', 'ignore_multiple_prereq', '--ignore', 'prereq skip heavy compiler')
         self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?OK')
-        self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*?skipped')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*? \[PLATFORM!=NON_EXISTENT\] SKIP')
 
         # Check that a multiple caveat dependency test runs when its prereq test is skipped
         # This test may seem redundant, but `prereq` is handled differently than the other caveats
-        output = self.runTests('-i', 'ignore_multiple_prereq', '--ignore', 'prereq heavy compiler platform')
-        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*?skipped')
+        output = self.runTests('--no-color', '-i', 'ignore_multiple_prereq', '--ignore', 'prereq heavy compiler platform')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*? \[ALWAYS SKIPPED\] SKIP')
         self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*?OK')
+
+        # Check that by supplying a very specific set of ignored paramaters, we
+        # can properly trigger a skipped dependency scenario
+        output = self.runTests('--no-color', '-i', 'ignore_multiple_prereq', '--ignore', 'heavy compiler platform')
+        self.assertRegexpMatches(output, 'test_harness\.always_skipped.*? \[ALWAYS SKIPPED\] SKIP')
+        self.assertRegexpMatches(output, 'test_harness\.ignore_multi_prereq_dependency.*? \[SKIPPED DEPENDENCY\] SKIP')

--- a/python/TestHarness/tests/test_QueuePBS.py
+++ b/python/TestHarness/tests/test_QueuePBS.py
@@ -156,7 +156,7 @@ class TestHarnessTestCase(unittest.TestCase):
 
                 # A different method may have adjusted this tester to be
                 # skipped (jobA fails and thus skips and never runs jobB,
-                # but _occurres_ during jobA's iteration).
+                # but _occures_ during jobA's iteration).
                 elif tester.isSkipped():
                     return
 
@@ -257,7 +257,6 @@ class TestHarnessTestCase(unittest.TestCase):
                 # Join the results, because the TestHarness receives them out-of-order
                 if job_id == 0:
                     join_results = ' '.join([result_list[0], result_list[1]])
-                    print join_results
                     self.assertRegexpMatches(join_results, 'FAILED \(INVALID QSTAT RESULTS\)')
                     self.assertRegexpMatches(join_results, 'SKIP')
 

--- a/python/TestHarness/tests/test_ReportSkipped.py
+++ b/python/TestHarness/tests/test_ReportSkipped.py
@@ -7,9 +7,9 @@ class TestHarnessTester(TestHarnessTestCase):
         """
 
         # Verify the skipped test _does_ appear
-        output = self.runExceptionTests('-i', 'ignore_skipped')
-        self.assertIn('skipped (always skipped)', output)
+        output = self.runExceptionTests('--no-color', '-i', 'ignore_skipped')
+        self.assertIn('[ALWAYS SKIPPED] SKIP', output)
 
         # Verify the skipped test does _not_ appear
-        output = self.runTests('--no-report', '-i', 'ignore_skipped')
-        self.assertNotIn('skipped (always skipped)', output)
+        output = self.runTests('--no-color', '--no-report', '-i', 'ignore_skipped')
+        self.assertNotIn('[ALWAYS SKIPPED] SKIP', output)

--- a/python/TestHarness/tests/test_RequiredObjects.py
+++ b/python/TestHarness/tests/test_RequiredObjects.py
@@ -5,7 +5,7 @@ class TestHarnessTester(TestHarnessTestCase):
         """
         Test that the required_objects check works
         """
-        output = self.runTests('-i', 'required_objects')
-        self.assertRegexpMatches(output, r'test_harness\.bad_object.*?skipped \(DoesNotExist not found in executable\)')
-        self.assertRegexpMatches(output, r'test_harness\.good_objects.*?OK')
+        output = self.runTests('--no-color', '-i', 'required_objects')
+        self.assertRegexpMatches(output, r'test_harness\.bad_object.*? \[DOESNOTEXIST NOT FOUND IN EXECUTABLE\] SKIP')
+        self.assertRegexpMatches(output, r'test_harness\.good_objects.*? OK')
         self.checkStatus(output, passed=1, skipped=1)

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -241,6 +241,7 @@ def formatResult(tester_data, result, options, color=True):
                 formatted_results[format_rule] = (colorText(tester.specs['first_directory'], 'CYAN', **color_opts) +\
                                          formatted_results[format_rule][0].replace(tester.specs['first_directory'], '', 1), 'CYAN') # Strip out first occurence only
 
+    # join printable results in the order in which the user asked
     final_results = ' '.join([formatted_results[x][0] for x in terminal_format if formatted_results[x]])
 
     # Decorate debuging

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -186,7 +186,7 @@ def formatResult(tester_data, result, options, color=True):
 
     # Format the caveats if any
     if tester.getCaveats() and 'c' in terminal_format:
-        caveats = ','.join(tester.getCaveats()).upper()
+        caveats = ','.join(tester.getCaveats())
         if tester.didPass() or tester.isSkipped():
             caveat_color = 'CYAN'
         else:
@@ -195,17 +195,18 @@ def formatResult(tester_data, result, options, color=True):
         formatted_result['c'] = ('[' + caveats + ']', caveat_color)
         items_to_print = printableItems(formatted_result)
 
-        # Determine when/if/how we should trim the caveats to fit the screen
+        # Determine when/if/how we should trim the caveats to fit the screen.
+        # If extra_info, it just fits, or caveats will be printed last, we do not trim.
         if terminal_format[-1] != 'c' and len(' '.join(items_to_print)) > TERM_COLS \
            and not options.extra_info:
             over_by_amount = len(' '.join(items_to_print)) - TERM_COLS
-            caveats = '[' + caveats[:len(caveats) - (over_by_amount + 3)] + '...]'
-            formatted_result['c'] = (caveats, caveat_color)
+            formatted_result['c'] = ('[' + caveats[:len(caveats) - (over_by_amount + 3)] + '...]',
+                                     caveat_color)
 
     # Informational items created above, fill the rest with dots ' .... '
     if 'j' in terminal_format:
         items_to_print = printableItems(formatted_result)
-        character_count = len(' '.join(items_to_print)) + 1 # extra space created by joining hr
+        character_count = len(' '.join(items_to_print)) + 1 # extra space created by joining
         if character_count < TERM_COLS:
             formatted_result['j'] = ('.'*max(0, (TERM_COLS - character_count)), 'GREY')
 

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 import json
 
 TERM_COLS = int(os.getenv('MOOSE_TERM_COLS', '110'))
-TERM_FORMAT = os.getenv('MOOSE_TERM_FORMAT', 'njCst')
+TERM_FORMAT = os.getenv('MOOSE_TERM_FORMAT', 'njcst')
 
 LIBMESH_OPTIONS = {
   'mesh_mode' :    { 're_option' : r'#define\s+LIBMESH_ENABLE_PARMESH\s+(\d+)',
@@ -154,9 +154,7 @@ def formatResult(tester_data, result, options, color=True):
     color_opts = {'code' : options.code, 'colored' : options.colored}
 
     # container for every printable item
-    formatted_results = {}
-    for format_key in terminal_format:
-        formatted_results[format_key] = None
+    formatted_results = dict.fromkeys(terminal_format)
 
     # Populate formatted_results for those we support, with requested items
     # specified by the user. Caveats and justifications are parsed outside of
@@ -189,6 +187,8 @@ def formatResult(tester_data, result, options, color=True):
         if str(f_key).lower() == 'n':
             formatCase(f_key, (tester.getTestName(), None), formatted_results)
 
+        # Adjust the precision of time, so we can justify the length. The higher the
+        # seconds, the lower the decimal point, ie: [0.000s] - [100.0s]. Max: [99999s]
         if str(f_key).lower() == 't' and options.timing:
             actual = float(tester_data.getTiming())
             int_len = len(str(int(actual)))

--- a/python/mooseutils/mooseutils.py
+++ b/python/mooseutils/mooseutils.py
@@ -24,7 +24,7 @@ def colorText(string, color, **kwargs):
     colored = kwargs.pop('colored', True)
 
     # ANSI color codes for colored terminal output
-    color_codes = dict(RESET='\033[0m', BOLD='\033[1m',RED='\033[31m', MAGENTA='\033[32m', YELLOW='\033[33m', BLUE='\033[34m', GREEN='\033[35m', CYAN='\033[36m')
+    color_codes = dict(RESET='\033[0m', BOLD='\033[1m',RED='\033[31m', MAGENTA='\033[32m', YELLOW='\033[33m', BLUE='\033[34m', GREEN='\033[35m', CYAN='\033[36m', GREY='\033[90m')
     if code:
         color_codes['GREEN'] = '\033[32m'
         color_codes['CYAN']  = '\033[36m'

--- a/test/tests/test_harness/depend_skip_tests
+++ b/test/tests/test_harness/depend_skip_tests
@@ -4,7 +4,7 @@
     input = foo.i
     skip = "always skipped"
   [../]
-  [./needs_a]
+  [./needs_always_skipped]
     type = RunApp
     input = foo.i
     prereq = always_skipped


### PR DESCRIPTION
Darken the justification dots, and allow the user to apply
a format:

  export MOOSE_TERM_FORMAT='njcst'  # default config

  produces:
    simple_diffusion .... [CAVEAT] OK [0.000s]

Available formatting options:

'p' : pre result (status bucket result)
'n' : test name
'c' : caveats
'j' : justification
's' : status result
't' : test time

The skipped tests which have a reason (caveat) are now included as a caveat. The previous method looked odd.

New: 
```pre
test_name .................................... [METHOD!=DBG] SKIP
```
Old:
```pre
test_name .................................... skipped (METHOD!=DBG)
```


Closes #10453 
  