### PR TITLE
Improvements to remove MultiMooseEnum for "execute_on"

### DIFF
--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -119,6 +119,11 @@ public:
   static MultiMooseEnum getExecuteOptions(std::string default_type = "");
 
   /**
+   * Return an ExecFlagEnum object with the available execution flags for Output objects.
+   */
+  static ExecFlagEnum getDefaultExecFlagEnum();
+
+  /**
    * Method for controlling the allow output state
    * @param state The state to set the allow flag to
    */

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -54,7 +54,7 @@ validParams<Output>()
 
   // Update the 'execute_on' input parameter for output
   ExecFlagEnum & exec_enum = params.set<ExecFlagEnum>("execute_on", true);
-  exec_enum.addAvailableFlags(EXEC_FAILED);
+  exec_enum = Output::getDefaultExecFlagEnum();
   exec_enum = {EXEC_INITIAL, EXEC_TIMESTEP_END};
   params.setDocString("execute_on", exec_enum.getDocString());
 
@@ -79,14 +79,22 @@ validParams<Output>()
 MultiMooseEnum
 Output::getExecuteOptions(std::string default_type)
 {
+  // TODO: ExecFlagType
   /*
-  ::mooseDeprecated("The 'getExecuteOptions' was replaced by the ExecFlagEnum class because MOOSE "
-                    "was updated to use this for the execute flags and the new function provides "
-                    "additional arguments for modification of the enum.");
+  ::mooseDeprecated("This version 'getExecuteOptions' was replaced by the "
+                    "Output::getDefaultExecFlagEnum() static function.");
   */
   ExecFlagEnum exec_enum = MooseUtils::getDefaultExecFlagEnum();
   exec_enum.addAvailableFlags(EXEC_FAILED);
   exec_enum = default_type;
+  return exec_enum;
+}
+
+ExecFlagEnum
+Output::getDefaultExecFlagEnum()
+{
+  ExecFlagEnum exec_enum = MooseUtils::getDefaultExecFlagEnum();
+  exec_enum.addAvailableFlags(EXEC_FAILED);
   return exec_enum;
 }
 

--- a/framework/src/userobject/ElementQualityChecker.C
+++ b/framework/src/userobject/ElementQualityChecker.C
@@ -49,7 +49,7 @@ validParams<ElementQualityChecker>()
   params.addParam<MooseEnum>("failure_type",
                              ElementQualityChecker::FailureMessageType(),
                              "The way how the failure of quality metric check should respond");
-  params.set<MultiMooseEnum>("execute_on") = "initial";
+  params.set<ExecFlagEnum>("execute_on") = EXEC_INITIAL;
 
   return params;
 }


### PR DESCRIPTION
This removes the ability to use MultiMooseEnum for "execute_on" and requires the type to ExecFlagEnum. Many of the apps will fail, I am working on updating them.
(refs #10363)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
