### PR TITLE
PBS tests not failing when they should

### DIFF
--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -121,13 +121,24 @@ class RunPBS(QueueManager):
         if job_state:
             # Job is finished
             if job_state.group(1) == 'F':
-                reason = 'WAITING'
-
                 # The exit code PBS recorded when the application exited
-                tester.exit_code = re.search(r'Exit_status = (\d+)', output)
+                tester.exit_code = re.search(r'Exit_status = (\d+)', output).group(1)
+
+                # non-zero exit codes are handled properly elsewhere (as a CRASH). So do not set any
+                # failed bucket here. Instead, add a message (caveat) as to why it crashed (if we know).
+                # additional info in next TL;DR note.
 
                 # Set the bucket that allows processResults to commence
+                reason = 'WAITING'
                 bucket = tester.bucket_waiting_processing
+
+                # NOTE:
+                # Setting a failed bucket in RunPBS derived scheduler will cause the TestHarness to assume
+                # there is no output from the job we launched. but we do have output in this case. And it
+                # contains valuable information as to why PBS killed the job. So just set a caveat. The
+                # TestHarness _will_ fail the job later, correctly, because of the non-zero exit code.
+                if tester.exit_code == '271':
+                    tester.addCaveats('Killed by PBS')
 
             # Job is currently running
             elif job_state.group(1) == 'R':

--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -123,6 +123,9 @@ class RunPBS(QueueManager):
             if job_state.group(1) == 'F':
                 reason = 'WAITING'
 
+                # The exit code PBS recorded when the application exited
+                tester.exit_code = re.search(r'Exit_status = (\d+)', output)
+
                 # Set the bucket that allows processResults to commence
                 bucket = tester.bucket_waiting_processing
 

--- a/python/TestHarness/tests/qstat_output.txt
+++ b/python/TestHarness/tests/qstat_output.txt
@@ -47,7 +47,7 @@ Job Id: <JOB_ID>.somemachine.org
     etime = Wed Oct 18 09:08:22 2017
     run_count = 1
     Stageout_status = 1
-    Exit_status = 0
+    Exit_status = <EXIT_STATUS>
     Submit_arguments = -h /some/path/to/qsub_batch/kernelssimple_diffusiontest.sh
     history_timestamp = 1508339302
     project = moose

--- a/python/TestHarness/tests/test_QueuePBS.py
+++ b/python/TestHarness/tests/test_QueuePBS.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from TestHarness import TestHarness
 from TestHarness import util
 import mock
-import os, sys, unittest, time, shutil, json
+import os, sys, unittest, time, shutil, json, re
 
 
 class HarnessAndDAG(object):
@@ -179,9 +179,18 @@ class TestHarnessTestCase(unittest.TestCase):
 
         return result_output_list
 
-    def getQstatOutput(self, job_id, job_state):
+    def getQstatOutput(self, **kwargs):
         """ return valid qstat output """
-        return self.qstat_output.replace('<JOB_ID>', str(job_id)).replace('<JOB_STATE>', str(job_state))
+        tmp_qstat = self.qstat_output
+        for tag, value in kwargs.iteritems():
+            tmp_qstat = tmp_qstat.replace('<' + str(tag).upper() + '>', str(value))
+
+        # set any remaining unset tags to a working default:
+        default_tags = [('<EXIT_STATUS>', '0'), ('<JOB_STATE>', 'F'), ('<JOB_ID>', '1')]
+        for unset_tag in default_tags:
+            tmp_qstat = tmp_qstat.replace(unset_tag[0], unset_tag[1])
+
+        return tmp_qstat
 
     def yieldJobs(self, job_dag):
         """ return each job in the dag with an id """
@@ -264,6 +273,49 @@ class TestHarnessTestCase(unittest.TestCase):
                 elif job_id == 1 and result_list != None:
                     self.fail('Failed: A job that should not have launched attempted to do so')
 
+    def testExceededWalltime(self):
+        """
+        Test QueueManagers ability to handle jobs killed by PBS due to
+        exceeding walltime (exit code 271).
+
+        Caveat (more of a note to myself, this stumped me...):
+        Because we are mocking the results, we will never see the actual
+        error we are testing for. Remember: @mockSinglePBS can not grab
+        returned strings _from_ called methods (formatResults() in our
+        case). Mock instead allows us to ask what _variables_ were
+        _sent_ to them (using call_args).
+
+        So, instead, we will interface with the tester directly and parse
+        through the caveats searching for what we expect (getCaveats()).
+
+        See 'testPBSProcessResults' below for 'NO STDOUT FILE' explination.
+        """
+
+        # Launch jobs correctly to create a session file (QUEUED status)
+        self.testPBSGoodLaunch()
+
+        with self.harnessDAG() as harness_dag:
+            (harness, job_dag) = harness_dag
+
+            ### Test for non-qstat type output (command not found or the like)
+            for job_id, job in self.yieldJobs(job_dag):
+                qstat_return = self.getQstatOutput(job_id=job_id, job_state='F', exit_status='271')
+                result_list = self._mockSinglePBSLaunch(harness, job, qstat_return)
+                tester = job.getTester()
+
+                # Join the results, because the TestHarness receives them out-of-order
+                if job_id == 0:
+                    join_results = ' '.join([result_list[0], result_list[1]])
+                    self.assertRegexpMatches(join_results, 'FAILED \(NO STDOUT FILE\)')
+                    self.assertRegexpMatches(join_results, 'SKIP')
+
+                    # check caveats for specific string
+                    self.assertRegexpMatches(' '.join(tester.getCaveats()).upper(), 'KILLED BY PBS')
+
+                # We _should_ actually have no results
+                elif job_id == 1 and result_list != None:
+                    self.fail('Failed: A job that should not have launched attempted to do so')
+
     def testPBSUnknownQstat(self):
         """
         Test QueueManager's ability to handle unknown qstat output
@@ -276,7 +328,7 @@ class TestHarnessTestCase(unittest.TestCase):
             (harness, job_dag) = harness_dag
 
             for job_id, job in self.yieldJobs(job_dag):
-                qstat_return = self.getQstatOutput(job_id, 'gibberish')
+                qstat_return = self.getQstatOutput(job_id=job_id, job_state='gibberish')
                 result_list = self._mockSinglePBSLaunch(harness, job, qstat_return)
 
                 # Join the results, because the TestHarness receives them out-of-order
@@ -306,7 +358,7 @@ class TestHarnessTestCase(unittest.TestCase):
             (harness, job_dag) = harness_dag
 
             for job_id, job in self.yieldJobs(job_dag):
-                qstat_return = self.getQstatOutput(job_id, 'F')
+                qstat_return = self.getQstatOutput(job_id=job_id, job_state='F')
                 result_list = self._mockSinglePBSLaunch(harness, job, qstat_return)
 
                 # Join the results, because the TestHarness receives them out-of-order
@@ -335,7 +387,7 @@ class TestHarnessTestCase(unittest.TestCase):
                 (harness, job_dag) = harness_dag
 
                 for job_id, job in self.yieldJobs(job_dag):
-                    qstat_return = self.getQstatOutput(job_id, status[0])
+                    qstat_return = self.getQstatOutput(job_id=job_id, job_state=status[0])
                     result_list = self._mockSinglePBSLaunch(harness, job, qstat_return)
                     if len(result_list) == 1:
                         self.assertRegexpMatches(result_list[0], status)

--- a/python/TestHarness/tests/test_QueuePBS.py
+++ b/python/TestHarness/tests/test_QueuePBS.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from TestHarness import TestHarness
 from TestHarness import util
 import mock
-import os, sys, unittest, time, shutil, json, re
+import os, sys, unittest, time, shutil, json
 
 
 class HarnessAndDAG(object):


### PR DESCRIPTION
Set the exit code to what ever it was when the
application exited, as PBS saw it.

If PBS kills the job due to exceeding walltime,
a non-zero value is recorded, and the test will
now be labeled as failed (crash).

Closes #10476
