### PR TITLE
parser: don't add special "_[bla]" parameters to InputParams

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1331,10 +1331,7 @@ template <typename T>
 const T &
 InputParameters::getParamHelper(const std::string & name, const InputParameters & pars, const T *)
 {
-  // TODO: after updating apps (i.e. rattlesnake) remove the first if clause+body:
-  if (name == "parser_syntax")
-    return (const T &)pars.blockFullpath();
-  else if (!pars.isParamValid(name))
+  if (!pars.isParamValid(name))
     mooseError("The parameter \"", name, "\" is being retrieved before being set.\n");
   return pars.get<T>(name);
 }

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -1336,8 +1336,6 @@ Parser::setFilePathParam(const std::string & full_name,
   if (pos != std::string::npos && postfix[0] != '/' && !postfix.empty())
     prefix = _input_filename.substr(0, pos + 1);
 
-  // TODO: delete the following line after apps have been updated to use rawParamVal API:
-  params.set<std::string>("_raw_" + short_name) = postfix;
   params.rawParamVal(short_name) = postfix;
   param->set() = prefix + postfix;
 
@@ -1419,8 +1417,6 @@ Parser::setVectorFilePathParam(const std::string & full_name,
     }
   }
 
-  // TODO: delete the following line after apps have been updated to use rawParamVal API:
-  params.set<std::vector<std::string>>("_raw_" + short_name) = rawvec;
   param->set() = vec;
 
   if (in_global)


### PR DESCRIPTION
All special "_" prefixed special parameters have been moved to explicit
metadata APIs in the InputParameters class.  This change modifies the
parser to stop injecting them into InputParameters objects.

This had to be separate from #10411 because some moose apps needed to
use the new metadata APIs in order to stop using the special parameters
- so those APIs needed to be in place before the apps could be updated.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
