### PR TITLE
Initial implementation of the RelationshipManager system.

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -43,7 +43,16 @@ public:
 
   virtual ~Action() {}
 
+  /**
+   * Method to add objects to the simulation or perform other setup tasks.
+   */
   virtual void act() = 0;
+
+  /**
+   * Method to add a relationship manager for the objects being added to the system. The type
+   * eligible to be added is passed in as an argument.
+   */
+  virtual void addRelationshipManagers(Moose::RelationshipManagerType type);
 
   /**
    * The name of the action

--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -49,10 +49,15 @@ public:
   virtual void act() = 0;
 
   /**
-   * Method to add a relationship manager for the objects being added to the system. The type
-   * eligible to be added is passed in as an argument.
+   * Method to add a relationship manager for the objects being added to the system. Relationship
+   * managers have to be added relatively early. In many cases before the Action::act() method
+   * is called.
+   * @param when_type The parameter indicating the normal time for adding either Geometric or
+   *        Algebraic RelationshipManagers. It may not always be possible to add your
+   *        RelationshipManager as early as you'd like. In these cases, your DistributedMesh may
+   *        consume more memory during the problem setup.
    */
-  virtual void addRelationshipManagers(Moose::RelationshipManagerType type);
+  virtual void addRelationshipManagers(Moose::RelationshipManagerType when_type);
 
   /**
    * The name of the action

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -86,6 +86,7 @@ public:
    */
   void printInputFile(std::ostream & out);
 
+  ///@{
   /**
    * Iterators to the Actions in the warehouse.  Iterators should always be used when executing
    * Actions to capture dynamically added Actions (meta-Actions).  Meta-Actions are allowed to
@@ -94,6 +95,12 @@ public:
    */
   ActionIterator actionBlocksWithActionBegin(const std::string & task);
   ActionIterator actionBlocksWithActionEnd(const std::string & task);
+  ///@}
+
+  /**
+   * Returns a reference to all of the actions.
+   */
+  const std::vector<std::shared_ptr<Action>> & allActionBlocks() const;
 
   /**
    * Retrieve a constant list of \p Action pointers associated with the passed in task.

--- a/framework/include/actions/AddRelationshipManager.h
+++ b/framework/include/actions/AddRelationshipManager.h
@@ -12,41 +12,22 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef MOOSEOBJECTACTION_H
-#define MOOSEOBJECTACTION_H
+#ifndef ADDRELATIONSHIPMANAGER_H
+#define ADDRELATIONSHIPMANAGER_H
 
 #include "Action.h"
 
-#include <string>
-
-class MooseObjectAction;
+class AddRelationshipManager;
 
 template <>
-InputParameters validParams<MooseObjectAction>();
+InputParameters validParams<AddRelationshipManager>();
 
-class MooseObjectAction : public Action
+class AddRelationshipManager : public Action
 {
 public:
-  MooseObjectAction(InputParameters params);
+  AddRelationshipManager(InputParameters params);
 
-  virtual void addRelationshipManagers(Moose::RelationshipManagerType type) override;
-
-  /**
-   * Retreive the parameters of the object to be created by this action
-   */
-  InputParameters & getObjectParams() { return _moose_object_pars; }
-
-  /**
-   * Return the object type to be created
-   */
-  const std::string & getMooseObjectType() const { return _type; }
-
-protected:
-  /// The Object type that is being created
-  std::string _type;
-
-  /// The parameters for the object to be created
-  InputParameters _moose_object_pars;
+  virtual void act() override;
 };
 
-#endif // MOOSEOBJECTACTION_H
+#endif // ADDRELATIONSHIPMANAGER_H

--- a/framework/include/actions/AddRelationshipManager.h
+++ b/framework/include/actions/AddRelationshipManager.h
@@ -22,6 +22,11 @@ class AddRelationshipManager;
 template <>
 InputParameters validParams<AddRelationshipManager>();
 
+/**
+ * This Action retrieves all of the Actions from the MooseAction Warehouse and triggers the
+ * addRelationshipManagers() call on each of them. Additionally, it is responsible for triggering
+ * the attachment of those relationship managers to the relevant libMesh objects.
+ */
 class AddRelationshipManager : public Action
 {
 public:

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -333,9 +333,6 @@ protected:
   /// True if implicit value is required
   bool _c_is_implicit;
 
-  /// Local InputParameters
-  const InputParameters & _coupleable_params;
-
   /// Will hold the default value for optional coupled variables.
   std::map<std::string, VariableValue *> _default_value;
 

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -81,6 +81,7 @@ class InputParameters;
 #define registerOutput(name) registerObject(name)
 #define registerControl(name) registerObject(name)
 #define registerPartitioner(name) registerObject(name)
+#define registerRelationshipManager(name) registerObject(name)
 
 #define registerNamedKernel(obj, name) registerNamedObject(obj, name)
 #define registerNamedNodalKernel(obj, name) registerNamedObject(obj, name)

--- a/framework/include/base/LazyCoupleable.h
+++ b/framework/include/base/LazyCoupleable.h
@@ -1,0 +1,71 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef LAZYCOUPLEABLE_H
+#define LAZYCOUPLEABLE_H
+
+// MOOSE includes
+#include "MooseVariableBase.h"
+
+// Forward declarations
+class InputParameters;
+class MooseObject;
+
+/**
+ * Interface for objects that needs coupling capabilities
+ *
+ */
+class LazyCoupleable
+{
+public:
+  /**
+   * Constructing the object
+   * @param parameters Parameters that come from constructing the object
+   * @param nodal true if we need to couple with nodal values, otherwise false
+   */
+  LazyCoupleable(const MooseObject * moose_object);
+
+  ~LazyCoupleable();
+
+  void setFEProblemPtr(FEProblemBase * fe_problem);
+
+private:
+  void init();
+
+  /**
+   * Returns the index for a coupled variable by name
+   * @param var_name Name of coupled variable
+   * @param comp Component number for vector of coupled variables
+   * @return Index of coupled variable, if this is an optionally coupled variable that wasn't
+   * provided this will return a unique "invalid" index.
+   */
+  unsigned int & coupled(const std::string & var_name, unsigned int comp = 0);
+
+  // Reference to the interface's input parameters
+  const InputParameters & _l_parameters;
+
+  /// The name of the object this interface is part of
+  const std::string & _l_name;
+
+  /// Reference to FEProblemBase
+  FEProblemBase * _l_fe_problem;
+
+  /// Reference to the MooseApp
+  MooseApp & _l_app;
+
+  /// Coupled vars whose values we provide
+  std::map<std::string, std::unique_ptr<unsigned int>> _coupled_var_numbers;
+};
+
+#endif /* LAZYCOUPLEABLE_H */

--- a/framework/include/base/LazyCoupleable.h
+++ b/framework/include/base/LazyCoupleable.h
@@ -21,9 +21,10 @@
 // Forward declarations
 class InputParameters;
 class MooseObject;
+class MooseApp;
 
 /**
- * Interface for objects that needs coupling capabilities
+ * Interface for objects that need coupling capabilities
  *
  */
 class LazyCoupleable
@@ -36,8 +37,14 @@ public:
    */
   LazyCoupleable(const MooseObject * moose_object);
 
-  ~LazyCoupleable();
+  virtual ~LazyCoupleable() = default;
 
+  /**
+   * Sets the FEProblem pointer which can (and is expected) to happen long after this interface is
+   * constructed. Once this pointer is set, this interface can retrieve the information it requires
+   * from the underlying class and the internal methods can be called. Errors are throw if internal
+   * methods are called when this pointer is nullptr.
+   */
   void setFEProblemPtr(FEProblemBase * fe_problem);
 
 private:

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -41,6 +41,7 @@ class MeshModifier;
 class InputParameterWarehouse;
 class SystemInfo;
 class CommandLine;
+class RelationshipManager;
 
 template <>
 InputParameters validParams<MooseApp>();
@@ -230,7 +231,11 @@ public:
   /**
    * Retrieve the Executioner for this App
    */
-  Executioner * getExecutioner() { return _executioner.get(); }
+  Executioner * getExecutioner()
+  {
+    mooseAssert(_executioner, "Executioner is nullptr");
+    return _executioner.get();
+  }
 
   /**
    * Retrieve the Executioner shared pointer for this App
@@ -523,6 +528,17 @@ public:
    */
   virtual void registerExecFlags();
 
+  bool hasRelationshipManager(const std::string & name) const;
+
+  void addRelationshipManager(std::shared_ptr<RelationshipManager> relationship_manager);
+
+  void attachRelationshipManagers(Moose::RelationshipManagerType rm_type);
+
+  /**
+   * Returns the Relationship managers info suitable for printing.
+   */
+  std::vector<std::pair<std::string, std::string>> getRelationshipManagerInfo();
+
 protected:
   /**
    * Register individual flag.
@@ -686,6 +702,8 @@ protected:
 
   /// true if we want to just check the input file
   bool _check_input;
+
+  std::vector<std::shared_ptr<RelationshipManager>> _relationship_managers;
 
   /// The library, registration method and the handle to the method
   std::map<std::pair<std::string, std::string>, void *> _lib_handles;

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -142,7 +142,7 @@ public:
   /**
    * Returns the input file name that was set with setInputFileName
    */
-  std::string getInputFileName() { return _input_filename; }
+  std::string getInputFileName() const { return _input_filename; }
 
   /**
    * Override the selection of the output file base name.
@@ -169,13 +169,13 @@ public:
    * Whether or not an output position has been set.
    * @return True if it has
    */
-  bool hasOutputPosition() { return _output_position_set; }
+  bool hasOutputPosition() const { return _output_position_set; }
 
   /**
    * Get the output position.
    * @return The position offset for the output.
    */
-  Point getOutputPosition() { return _output_position; }
+  Point getOutputPosition() const { return _output_position; }
 
   /**
    * Set the starting time for the simulation.  This will override any choice
@@ -188,12 +188,12 @@ public:
   /**
    * @return Whether or not a start time has been programmatically set using setStartTime()
    */
-  bool hasStartTime() { return _start_time_set; }
+  bool hasStartTime() const { return _start_time_set; }
 
   /**
    * @return The start time
    */
-  Real getStartTime() { return _start_time; }
+  Real getStartTime() const { return _start_time; }
 
   /**
    * Each App has it's own local time.  The "global" time of the whole problem might be
@@ -205,7 +205,7 @@ public:
    * Each App has it's own local time.  The "global" time of the whole problem might be
    * different.  This offset is how far off the local App time is from the global time.
    */
-  Real getGlobalTimeOffset() { return _global_time_offset; }
+  Real getGlobalTimeOffset() const { return _global_time_offset; }
 
   /**
    * Return the filename that was parsed
@@ -231,7 +231,7 @@ public:
   /**
    * Retrieve the Executioner for this App
    */
-  Executioner * getExecutioner()
+  Executioner * getExecutioner() const
   {
     mooseAssert(_executioner, "Executioner is nullptr");
     return _executioner.get();
@@ -267,7 +267,7 @@ public:
    * @return The reference to the command line object
    * Setup options based on InputParameters.
    */
-  std::shared_ptr<CommandLine> commandLine() { return _command_line; }
+  std::shared_ptr<CommandLine> commandLine() const { return _command_line; }
 
   /**
    * This method is here so we can determine whether or not we need to

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -79,12 +79,12 @@ public:
   /**
    * Get the MooseApp this object is associated with.
    */
-  MooseApp & getMooseApp() { return _app; }
+  MooseApp & getMooseApp() const { return _app; }
 
   /**
    * Return the enabled status of the object.
    */
-  virtual bool enabled() { return _enabled; }
+  virtual bool enabled() const { return _enabled; }
 
   /**
    * Emits an error prefixed with the file and line number of the given param (from the input

--- a/framework/include/kernels/EigenKernel.h
+++ b/framework/include/kernels/EigenKernel.h
@@ -40,7 +40,7 @@ public:
   virtual void computeOffDiagJacobianScalar(unsigned int /*jvar*/) override {}
 
   EigenKernel(const InputParameters & parameters);
-  virtual bool enabled() override;
+  virtual bool enabled() const override;
 
 protected:
   virtual Real computeQpResidual() = 0;

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -831,11 +831,6 @@ public:
    */
   virtual std::unique_ptr<PointLocatorBase> getPointLocator() const;
 
-  /**
-   * Returns the Relationship managers info suitable for printing.
-   */
-  std::vector<std::string> getRelationshipManagerInfo();
-
 protected:
   /// Deprecated (DO NOT USE)
   std::vector<std::unique_ptr<GhostingFunctor>> _ghosting_functors;

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -451,14 +451,6 @@ public:
   const Moose::PatchUpdateType & getPatchUpdateStrategy() const;
 
   /**
-   * Method for adding Relationship managers (libMesh ghosting functors) to the Mesh object. The
-   * parameter is passed in via shared_ptr. It's expected that the Mesh object will assume ownership
-   * of the relationship manager since it's lifetime needs to last as long as the underlying
-   * MeshBase lasts.
-   */
-  void addRelationshipManager(std::shared_ptr<RelationshipManager> relationship_manager);
-
-  /**
    * Get a (slightly inflated) processor bounding box.
    *
    * @param inflation_multiplier This amount will be multiplied by the length of the diagonal of the

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -32,6 +32,7 @@
 // forward declaration
 class MooseMesh;
 class Assembly;
+class RelationshipManager;
 
 // libMesh forward declarations
 namespace libMesh
@@ -450,6 +451,14 @@ public:
   const Moose::PatchUpdateType & getPatchUpdateStrategy() const;
 
   /**
+   * Method for adding Relationship managers (libMesh ghosting functors) to the Mesh object. The
+   * parameter is passed in via shared_ptr. It's expected that the Mesh object will assume ownership
+   * of the relationship manager since it's lifetime needs to last as long as the underlying
+   * MeshBase lasts.
+   */
+  void addRelationshipManager(std::shared_ptr<RelationshipManager> relationship_manager);
+
+  /**
    * Get a (slightly inflated) processor bounding box.
    *
    * @param inflation_multiplier This amount will be multiplied by the length of the diagonal of the
@@ -822,8 +831,17 @@ public:
    */
   virtual std::unique_ptr<PointLocatorBase> getPointLocator() const;
 
+  /**
+   * Returns the Relationship managers info suitable for printing.
+   */
+  std::vector<std::string> getRelationshipManagerInfo();
+
 protected:
+  /// Deprecated (DO NOT USE)
   std::vector<std::unique_ptr<GhostingFunctor>> _ghosting_functors;
+
+  /// The list of active geometric relationship managers (bound to the underlying MeshBase object).
+  std::vector<std::shared_ptr<RelationshipManager>> _relationship_managers;
 
   /// Can be set to DISTRIBUTED, REPLICATED, or DEFAULT.  Determines whether
   /// the underlying libMesh mesh is a ReplicatedMesh or DistributedMesh.

--- a/framework/include/outputs/ConsoleUtils.h
+++ b/framework/include/outputs/ConsoleUtils.h
@@ -65,6 +65,11 @@ std::string outputAuxiliarySystemInformation(FEProblemBase & problem);
 std::string outputNonlinearSystemInformation(FEProblemBase & problem);
 
 /**
+ * Output action RelationshipManager information
+ */
+std::string outputRelationshipManagerInformation(MooseApp & app);
+
+/**
  * Output execution information
  */
 std::string outputExecutionInformation(MooseApp & app, FEProblemBase & problem);

--- a/framework/include/relationshipmanagers/AlgebraicRelationshipManager.h
+++ b/framework/include/relationshipmanagers/AlgebraicRelationshipManager.h
@@ -1,0 +1,51 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef ALGEBRAICRELATIONSHIPMANAGER_H
+#define ALGEBRAICRELATIONSHIPMANAGER_H
+
+#include "GeometricRelationshipManager.h"
+#include "LazyCoupleable.h"
+
+// Forward declarations
+class AlgebraicRelationshipManager;
+class FEProblem;
+
+template <>
+InputParameters validParams<AlgebraicRelationshipManager>();
+
+/**
+ * AlgebraicRelationshipManagers are used for describing what kinds of non-local resources are
+ * needed for an objects calculations. Non-local resources include geometric element information,
+ * and solution information that may be more than a single side-neighbor away in a mesh. This
+ * includes physically disconnected elements that might be needed for contact or mortar
+ * calculations. AlgebraicRelationshipManagers should also be attached the the Mesh for full
+ * DistributedMesh capability.
+ */
+class AlgebraicRelationshipManager : public GeometricRelationshipManager, public LazyCoupleable
+{
+public:
+  AlgebraicRelationshipManager(const InputParameters & parameters);
+
+protected:
+  /**
+   * Helper method for attaching ghosting functors to the relevant EquationSystem's DofMap.
+   */
+  void attachAlgebraicFunctorHelper(GhostingFunctor & gf) const;
+
+  /// Problem pointer
+  FEProblem * _problem;
+};
+
+#endif /* ALGEBRAICRELATIONSHIPMANAGER_H */

--- a/framework/include/relationshipmanagers/AlgebraicRelationshipManager.h
+++ b/framework/include/relationshipmanagers/AlgebraicRelationshipManager.h
@@ -30,7 +30,7 @@ InputParameters validParams<AlgebraicRelationshipManager>();
  * needed for an objects calculations. Non-local resources include geometric element information,
  * and solution information that may be more than a single side-neighbor away in a mesh. This
  * includes physically disconnected elements that might be needed for contact or mortar
- * calculations. AlgebraicRelationshipManagers should also be attached the the Mesh for full
+ * calculations. AlgebraicRelationshipManagers should also be attached to the Mesh for full
  * DistributedMesh capability.
  */
 class AlgebraicRelationshipManager : public GeometricRelationshipManager, public LazyCoupleable

--- a/framework/include/relationshipmanagers/ElementPointNeighbors.h
+++ b/framework/include/relationshipmanagers/ElementPointNeighbors.h
@@ -15,7 +15,7 @@
 #ifndef ELEMENTPOINTNEIGHBORS_H
 #define ELEMENTPOINTNEIGHBORS_H
 
-#include "RelationshipManager.h"
+#include "GeometricRelationshipManager.h"
 #include "InputParameters.h"
 
 #include "libmesh/ghost_point_neighbors.h"
@@ -30,24 +30,27 @@ class GhostingFunctor;
 template <>
 InputParameters validParams<ElementPointNeighbors>();
 
-class ElementPointNeighbors : public RelationshipManager
+/**
+ * ElementSideNeighborLayers is ensure that all pointwise-connected elements in ghosted to
+ * every processor's partition. It is useful when non-local element resources are needed when using
+ * DistributedMesh.
+ */
+class ElementPointNeighbors : public GeometricRelationshipManager
 {
 public:
   ElementPointNeighbors(const InputParameters & parameters);
-  virtual ~ElementPointNeighbors() {}
 
-  virtual void init() override;
+  virtual void attachRelationshipManagersInternal(Moose::RelationshipManagerType rm_type) override;
+  virtual std::string getInfo() const override;
+
   virtual void operator()(const MeshBase::const_element_iterator & range_begin,
                           const MeshBase::const_element_iterator & range_end,
                           processor_id_type p,
                           map_type & coupled_elements) override;
-  virtual bool isActive() const override;
-  virtual std::string getInfo() const override;
 
 protected:
-  GhostPointNeighbors _point_coupling;
-
-  bool _is_active;
+  /// The libMesh coupling object that provides this RM's functionality.
+  std::unique_ptr<GhostPointNeighbors> _point_coupling;
 };
 
 #endif /* ELEMENTPOINTNEIGHBORS_H */

--- a/framework/include/relationshipmanagers/ElementPointNeighbors.h
+++ b/framework/include/relationshipmanagers/ElementPointNeighbors.h
@@ -31,7 +31,7 @@ template <>
 InputParameters validParams<ElementPointNeighbors>();
 
 /**
- * ElementSideNeighborLayers is ensure that all pointwise-connected elements in ghosted to
+ * ElementSideNeighborLayers ensures that all pointwise-connected elements are ghosted to
  * every processor's partition. It is useful when non-local element resources are needed when using
  * DistributedMesh.
  */

--- a/framework/include/relationshipmanagers/ElementPointNeighbors.h
+++ b/framework/include/relationshipmanagers/ElementPointNeighbors.h
@@ -1,0 +1,53 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef ELEMENTPOINTNEIGHBORS_H
+#define ELEMENTPOINTNEIGHBORS_H
+
+#include "RelationshipManager.h"
+#include "InputParameters.h"
+
+#include "libmesh/ghost_point_neighbors.h"
+
+// Forward declarations
+class ElementPointNeighbors;
+namespace libMesh
+{
+class GhostingFunctor;
+}
+
+template <>
+InputParameters validParams<ElementPointNeighbors>();
+
+class ElementPointNeighbors : public RelationshipManager
+{
+public:
+  ElementPointNeighbors(const InputParameters & parameters);
+  virtual ~ElementPointNeighbors() {}
+
+  virtual void init() override;
+  virtual void operator()(const MeshBase::const_element_iterator & range_begin,
+                          const MeshBase::const_element_iterator & range_end,
+                          processor_id_type p,
+                          map_type & coupled_elements) override;
+  virtual bool isActive() const override;
+  virtual std::string getInfo() const override;
+
+protected:
+  GhostPointNeighbors _point_coupling;
+
+  bool _is_active;
+};
+
+#endif /* ELEMENTPOINTNEIGHBORS_H */

--- a/framework/include/relationshipmanagers/ElementSideNeighborLayers.h
+++ b/framework/include/relationshipmanagers/ElementSideNeighborLayers.h
@@ -15,8 +15,7 @@
 #ifndef ELEMENTSIDENEIGHBORLAYERS_H
 #define ELEMENTSIDENEIGHBORLAYERS_H
 
-#include "RelationshipManager.h"
-#include "InputParameters.h"
+#include "GeometricRelationshipManager.h"
 
 #include "libmesh/default_coupling.h"
 
@@ -30,26 +29,30 @@ class GhostingFunctor;
 template <>
 InputParameters validParams<ElementSideNeighborLayers>();
 
-class ElementSideNeighborLayers : public RelationshipManager
+/**
+ * ElementSideNeighborLayers is used to increase the halo or stencil depth of each processor's
+ * partition. It is useful when non-local element resources are needed when using DistributedMesh.
+ */
+class ElementSideNeighborLayers : public GeometricRelationshipManager
 {
 public:
   ElementSideNeighborLayers(const InputParameters & parameters);
-  virtual ~ElementSideNeighborLayers() {}
 
-  virtual void init() override;
+  virtual void attachRelationshipManagersInternal(Moose::RelationshipManagerType rm_type) override;
+  virtual std::string getInfo() const override;
+
   virtual void operator()(const MeshBase::const_element_iterator & range_begin,
                           const MeshBase::const_element_iterator & range_end,
                           processor_id_type p,
                           map_type & coupled_elements) override;
-  virtual bool isActive() const override;
-  virtual std::string getInfo() const override;
 
 protected:
+  /// Size of the halo or stencil of elements available in each local processors partition. Only
+  /// applicable and necessary when using DistributedMesh.
   const unsigned short _element_side_neighbor_layers;
 
-  DefaultCoupling _default_coupling;
-
-  bool _is_active;
+  /// The libMesh coupling object that provides this RM's functionality.
+  std::unique_ptr<DefaultCoupling> _default_coupling;
 };
 
 #endif /* ELEMENTSIDENEIGHBORLAYERS_H */

--- a/framework/include/relationshipmanagers/ElementSideNeighborLayers.h
+++ b/framework/include/relationshipmanagers/ElementSideNeighborLayers.h
@@ -1,0 +1,55 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef ELEMENTSIDENEIGHBORLAYERS_H
+#define ELEMENTSIDENEIGHBORLAYERS_H
+
+#include "RelationshipManager.h"
+#include "InputParameters.h"
+
+#include "libmesh/default_coupling.h"
+
+// Forward declarations
+class ElementSideNeighborLayers;
+namespace libMesh
+{
+class GhostingFunctor;
+}
+
+template <>
+InputParameters validParams<ElementSideNeighborLayers>();
+
+class ElementSideNeighborLayers : public RelationshipManager
+{
+public:
+  ElementSideNeighborLayers(const InputParameters & parameters);
+  virtual ~ElementSideNeighborLayers() {}
+
+  virtual void init() override;
+  virtual void operator()(const MeshBase::const_element_iterator & range_begin,
+                          const MeshBase::const_element_iterator & range_end,
+                          processor_id_type p,
+                          map_type & coupled_elements) override;
+  virtual bool isActive() const override;
+  virtual std::string getInfo() const override;
+
+protected:
+  const unsigned short _element_side_neighbor_layers;
+
+  DefaultCoupling _default_coupling;
+
+  bool _is_active;
+};
+
+#endif /* ELEMENTSIDENEIGHBORLAYERS_H */

--- a/framework/include/relationshipmanagers/GeometricRelationshipManager.h
+++ b/framework/include/relationshipmanagers/GeometricRelationshipManager.h
@@ -1,0 +1,45 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef GEOMETRICRELATIONSHIPMANAGER_H
+#define GEOMETRICRELATIONSHIPMANAGER_H
+
+#include "RelationshipManager.h"
+
+// Forward declarations
+class GeometricRelationshipManager;
+
+template <>
+InputParameters validParams<GeometricRelationshipManager>();
+
+/**
+ * GeometricRelationshipManagers are used for describing what kinds of non-local resources are
+ * needed for an object's calculations. Non-local resources include geometric element information,
+ * such as elements or boundaries that may be more than a single side-neighbor away within the mesh.
+ * This includes physically disconnected elements that might be needed for contact or mortar
+ * calculations.
+ */
+class GeometricRelationshipManager : public RelationshipManager
+{
+public:
+  GeometricRelationshipManager(const InputParameters & parameters);
+
+protected:
+  /**
+   * Helper method for attaching ghosting functors to the Mesh object.
+   */
+  void attachGeometricFunctorHelper(GhostingFunctor & gf) const;
+};
+
+#endif /* GEOMETRICRELATIONSHIPMANAGER_H */

--- a/framework/include/relationshipmanagers/RelationshipManager.h
+++ b/framework/include/relationshipmanagers/RelationshipManager.h
@@ -17,6 +17,8 @@
 
 #include "MooseObject.h"
 #include "InputParameters.h"
+#include "MooseMesh.h"
+
 #include "libmesh/ghosting_functor.h"
 
 // Forward declarations
@@ -36,28 +38,56 @@ class RelationshipManager : public MooseObject, public libMesh::GhostingFunctor
 {
 public:
   RelationshipManager(const InputParameters & parameters);
-  virtual ~RelationshipManager() {}
 
   /**
-   * Method to setup the RelationshipManager for use in the simulation.
+   * System entry point to trigger the addition of RelationshipManagers to the system. It is not
+   * virtual and not intended to be overridden by a derived class.
+   * See attachRelationshipManagersInternal()
    */
-  virtual void init() = 0;
-
-  /**
-   * Method to indicate whether the status of the relationship manager.
-   *
-   * @return bool Indicates whether the relationship manager should be made active (i.e. attached to
-   * the mesh or dof_map in libMesh).
-   */
-  virtual bool isActive() const { return false; }
+  void attachRelationshipManagers(Moose::RelationshipManagerType rm_type);
 
   /**
    * Method for returning relationship manager information (suitable for console output).
    */
   virtual std::string getInfo() const = 0;
 
+  /**
+   * Getter for returning the enum type for this RM.
+   */
+  Moose::RelationshipManagerType getType() const { return _rm_type; }
+
 protected:
+  /**
+   * Method to setup the RelationshipManager for use in the simulation. It is called exactly
+   * once for each type of functor object that this RelationshipManager is capable of creating.
+   * For GeometricRelationshipManagers, it is called exactly once. For
+   * AlgebraicRelationshipManagers, it is called twice, once for the geometric RM and once for
+   * the algebraic RM. This method should make the decision of whether or not a RM is needed
+   * for the current simulation and attach it to the right libMesh object. Note the helper
+   * methods available in the two major types of RMs.
+   */
+  virtual void attachRelationshipManagersInternal(Moose::RelationshipManagerType when_type) = 0;
+
+  /// Reference to the Mesh object
   MooseMesh & _mesh;
+
+  /// Boolean indicating whether this RM can be attached early (e.g. all parameters are known
+  /// without the need for inspecting things like variables or other parts of the system that
+  /// are not available.
+  const bool _attach_geometric_early;
+
+  /// The type of RM this object is. Note that the underlying enum is capable of holding
+  /// multiple values simultaneously, so you must use bitwise operators to test values.
+  Moose::RelationshipManagerType _rm_type;
+
+private:
+  /// Value to keep track of whether the attachRelationshipManagerInternal callback has been
+  /// called for this "when_type"
+  Moose::RelationshipManagerType _cached_callbacks;
+
+  /// Internal variable indicating whether the mesh is allowed to have elements deleted during
+  /// the initial setup phase.
+  bool _has_set_remote_elem_removal_flag;
 };
 
 #endif /* RELATIONSHIPMANAGER_H */

--- a/framework/include/relationshipmanagers/RelationshipManager.h
+++ b/framework/include/relationshipmanagers/RelationshipManager.h
@@ -1,0 +1,63 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifndef RELATIONSHIPMANAGER_H
+#define RELATIONSHIPMANAGER_H
+
+#include "MooseObject.h"
+#include "InputParameters.h"
+#include "libmesh/ghosting_functor.h"
+
+// Forward declarations
+class RelationshipManager;
+class MooseMesh;
+
+template <>
+InputParameters validParams<RelationshipManager>();
+
+/**
+ * RelationshipManagers are used for describing what kinds of non-local resources are needed for an
+ * objects calculations. Non-local resources include geometric element information, or solution
+ * information that may be more than a single side-neighbor away in a mesh. This includes
+ * physically disconnected elements that might be needed for contact or mortar calculations.
+ */
+class RelationshipManager : public MooseObject, public libMesh::GhostingFunctor
+{
+public:
+  RelationshipManager(const InputParameters & parameters);
+  virtual ~RelationshipManager() {}
+
+  /**
+   * Method to setup the RelationshipManager for use in the simulation.
+   */
+  virtual void init() = 0;
+
+  /**
+   * Method to indicate whether the status of the relationship manager.
+   *
+   * @return bool Indicates whether the relationship manager should be made active (i.e. attached to
+   * the mesh or dof_map in libMesh).
+   */
+  virtual bool isActive() const { return false; }
+
+  /**
+   * Method for returning relationship manager information (suitable for console output).
+   */
+  virtual std::string getInfo() const = 0;
+
+protected:
+  MooseMesh & _mesh;
+};
+
+#endif /* RELATIONSHIPMANAGER_H */

--- a/framework/include/relationshipmanagers/RelationshipManager.h
+++ b/framework/include/relationshipmanagers/RelationshipManager.h
@@ -58,13 +58,17 @@ public:
 
 protected:
   /**
-   * Method to setup the RelationshipManager for use in the simulation. It is called exactly
-   * once for each type of functor object that this RelationshipManager is capable of creating.
-   * For GeometricRelationshipManagers, it is called exactly once. For
-   * AlgebraicRelationshipManagers, it is called twice, once for the geometric RM and once for
-   * the algebraic RM. This method should make the decision of whether or not a RM is needed
-   * for the current simulation and attach it to the right libMesh object. Note the helper
-   * methods available in the two major types of RMs.
+   * This method should make the decision of whether or not RMs are needed for the current
+   * simulation and attach them to the corresponding libMesh objects. Helper methods exist to
+   * attach geometric and algebraic RMs to the right places.
+   *
+   * This method is called at most once for each "when_type":
+   * For GeometricRelationshipManagers it'll be called exactly once. However, "when" it is called
+   * depends on the value of the developer-controlled "attach_geometric_early" value.
+   * For AlgebraicRelationshipManagers, this method may be called twice, but only once per "when"
+   * type. If the RM is able to create its geometric RM early, it should do so and attach it
+   * during the normal geometric add time. However, if that's not possible, both the geometric and
+   * algebraic RMs can be added during the "late" when time.
    */
   virtual void attachRelationshipManagersInternal(Moose::RelationshipManagerType when_type) = 0;
 

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -433,15 +433,14 @@ public:
   void registerBuildableTypes(const std::string & names);
 
   /**
-   * Declares the types of RelationshipManagers that the owning object will either constructor (in
-   * the case of Actions) or requires (in the case of every other MooseObject). With normal
+   * Declares the types of RelationshipManagers that the owning object will either construct (in the
+   * case of Actions) or requires (in the case of every other MooseObject). With normal
    * MooseObject-derived types built by MooseObjectAction, MOOSE will attempt to use the
    * InputParameters available to it to construct the required RelationshipManager automatically.
    * Actions may run custom logic to create RelationshipManagers. The names and rm_type lists must
    * have the same number of entries.
    *
    * @param names A space delimited list of RelationshipMangers that may be built by this object.
-   * @param rm_type A space delimited list of RelationshipmanagerTypes corresponding to each name.
    */
   void registerRelationshipManagers(const std::string & names);
 
@@ -831,7 +830,6 @@ private:
   std::vector<std::string> _buildable_types;
 
   /// The RelationshipManagers that this object may either build or requires
-  /// Pair of RelationshipManager type name and RelationshipMangerType.
   std::vector<std::string> _buildable_rm_types;
 
   /// This parameter collapses one level of nesting in the syntax blocks.  It is used

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -21,6 +21,7 @@
 #include "MooseUtils.h"
 #include "MultiMooseEnum.h"
 #include "ExecFlagEnum.h"
+#include "Conversion.h"
 
 #include "libmesh/parameters.h"
 #include "libmesh/parsed_function.h"
@@ -1301,6 +1302,12 @@ void InputParameters::addParam<MultiMooseEnum>(const std::string & /*name*/,
 template <>
 void InputParameters::addParam<std::vector<MooseEnum>>(const std::string & /*name*/,
                                                        const std::string & /*doc_string*/);
+
+template <>
+void InputParameters::addPrivateParam<MooseEnum>(const std::string & /*name*/);
+
+template <>
+void InputParameters::addPrivateParam<MultiMooseEnum>(const std::string & /*name*/);
 
 template <>
 void InputParameters::addDeprecatedParam<MooseEnum>(const std::string & name,

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -138,9 +138,9 @@ public:
 
   /**
    * These methods add an option parameter and a documentation string to the InputParameters object.
-   * The first version of this function takes a default value which is used if the parameter
-   * is not found in the input file.  The second method will leave the parameter uninitialized
-   * but can be checked with "isParamValid" before use
+   * The first version of this function takes a default value which is used if the parameter is not
+   * found in the input file. The second method will leave the parameter uninitialized but can be
+   * checked with "isParamValid" before use.
    */
   template <typename T, typename S>
   void addParam(const std::string & name, const S & value, const std::string & doc_string);
@@ -185,10 +185,10 @@ public:
                           const std::string & doc_string);
 
   /**
-   * These method add a parameter to the InputParameters object which can be retrieved
-   * like any other parameter.  This parameter however is not printed in the Input file syntax
-   * dump or web page dump so does not take a documentation string.  The first version
-   * of this function takes an optional default value.
+   * These method add a parameter to the InputParameters object which can be retrieved like any
+   * other parameter. This parameter however is not printed in the Input file syntax dump or web
+   * page dump so does not take a documentation string.  The first version of this function takes an
+   * optional default value.
    */
   template <typename T>
   void addPrivateParam(const std::string & name, const T & value);
@@ -424,14 +424,25 @@ public:
 
   /**
    * This method is here to indicate which Moose types a particular Action may build. It takes a
-   * space
-   * delimited list of registered MooseObjects.  TODO: For now we aren't actually checking this list
-   * when we build objects. Since individual actions can do whatever they want it's not exactly
-   * trivial
-   * to check this without changing the user API.  This function properly restricts the syntax and
-   * yaml dumps.
+   * space delimited list of registered MooseObjects.  TODO: For now we aren't actually checking
+   * this list when we build objects. Since individual actions can do whatever they want it's not
+   * exactly trivial to check this without changing the user API.  This function properly restricts
+   * the syntax and YAML dumps.
    */
   void registerBuildableTypes(const std::string & names);
+
+  /**
+   * Declares the types of RelationshipManagers that the owning object will either constructor (in
+   * the case of Actions) or requires (in the case of every other MooseObject). With normal
+   * MooseObject-derived types built by MooseObjectAction, MOOSE will attempt to use the
+   * InputParameters available to it to construct the required RelationshipManager automatically.
+   * Actions may run custom logic to create RelationshipManagers. The names and rm_type lists must
+   * have the same number of entries.
+   *
+   * @param names A space delimited list of RelationshipMangers that may be built by this object.
+   * @param rm_type A space delimited list of RelationshipmanagerTypes corresponding to each name.
+   */
+  void registerRelationshipManagers(const std::string & names);
 
   /**
    * Returns the list of buildable types as a std::vector<std::string>
@@ -439,19 +450,29 @@ public:
   const std::vector<std::string> & getBuildableTypes() const;
 
   /**
+   * Returns the list of buildable (or required) RelationshipManager object types for this object.
+   */
+  const std::vector<std::string> & getBuildableRelationshipManagerTypes() const;
+
+  ///@{
+  /**
    * Mutators for controlling whether or not the outermost level of syntax will be collapsed when
    * printed.
    */
   void collapseSyntaxNesting(bool collapse);
   bool collapseSyntaxNesting() const;
+  ///@}
 
+  ///@{
   /**
    * Mutators for controlling whether or not the outermost level of syntax will be collapsed when
    * printed.
    */
   void mooseObjectSyntaxVisibility(bool visibility);
   bool mooseObjectSyntaxVisibility() const;
+  ///@}
 
+  ///@{
   /**
    * Copy and Copy/Add operators for the InputParameters object
    */
@@ -459,6 +480,7 @@ public:
   using Parameters::operator+=;
   InputParameters & operator=(const InputParameters & rhs);
   InputParameters & operator+=(const InputParameters & rhs);
+  ///@}
 
   /**
    * This function checks parameters stored in the object to make sure they are in the correct
@@ -774,27 +796,42 @@ private:
    */
   void allowCopy(bool status) { _allow_copy = status; }
 
-  /// Make sure the parameter name doesn't have any invalid characters.
+  /**
+   * Make sure the parameter name doesn't have any invalid characters.
+   */
   void checkParamName(const std::string & name) const;
 
-  /// This method is called when adding a Parameter with a default value, can be specialized for non-matching types
+  /**
+   * This method is called when adding a Parameter with a default value, can be specialized for
+   * non-matching types.
+   */
   template <typename T, typename S>
   void setParamHelper(const std::string & name, T & l_value, const S & r_value);
 
   /// original location of input block (i.e. filename,linenum) - used for nice error messages.
   std::string _block_location;
+
   /// full HIT path of the block from the input file - used for nice error messages.
   std::string _block_fullpath;
 
+  /// The actual parameter data. Each Metadata object contains attributes for the corresponding
+  /// parameter.
   std::map<std::string, Metadata> _params;
 
   /// The coupled variables set
   std::set<std::string> _coupled_vars;
 
+  /// The class description for the owning object. This string is used in many places including
+  /// mouse-over events, and external documentation produced from the source code.
   std::string _class_description;
-  /// The parameter is used to restrict types that can be built.  Typically this
-  /// is used for MooseObjectAction derived Actions.
+
+  /// The parameter is used to restrict types that can be built.  Typically this is used for
+  /// MooseObjectAction derived Actions.
   std::vector<std::string> _buildable_types;
+
+  /// The RelationshipManagers that this object may either build or requires
+  /// Pair of RelationshipManager type name and RelationshipMangerType.
+  std::vector<std::string> _buildable_rm_types;
 
   /// This parameter collapses one level of nesting in the syntax blocks.  It is used
   /// in conjunction with MooseObjectAction derived Actions.
@@ -803,10 +840,11 @@ private:
   /// This parameter hides derived MOOSE object types from appearing in syntax dumps
   bool _moose_object_syntax_visibility;
 
-  /// Flag for disabling deprecated parameters message, this is used by applyParameters to avoid dumping messages
+  /// Flag for disabling deprecated parameters message, this is used by applyParameters to avoid
+  /// dumping messages.
   bool _show_deprecated_message;
 
-  /// A flag for toggling the error message in the copy constructor
+  /// A flag for toggling the error message in the copy constructor.
   bool _allow_copy;
 
   // These are the only objects allowed to _create_ InputParameters

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -327,6 +327,15 @@ enum PatchUpdateType
   Auto,
   Iteration
 };
+
+/**
+ * Main types of Relationship Managers
+ */
+enum RelationshipManagerType
+{
+  Geometric,
+  Algebriac
+};
 }
 
 /**

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -23,6 +23,10 @@
 #include "libmesh/elem.h"
 #include "libmesh/petsc_macro.h"
 #include "libmesh/boundary_info.h"
+#include "libmesh/parameters.h"
+
+// BOOST include
+#include "bitmask_operators.h"
 
 #include <string>
 #include <vector>
@@ -331,12 +335,32 @@ enum PatchUpdateType
 /**
  * Main types of Relationship Managers
  */
-enum RelationshipManagerType
+enum class RelationshipManagerType : unsigned char
 {
-  Geometric,
-  Algebriac
+  Invalid = 0x0,
+  Geometric = 0x1,
+  Algebraic = 0x2
 };
+
+std::string stringify(const Moose::RelationshipManagerType & t);
 }
+
+namespace libMesh
+{
+template <>
+inline void
+print_helper(std::ostream & os, const Moose::RelationshipManagerType * param)
+{
+  // Specialization so that we don't print out unprintable characters
+  os << Moose::stringify(*param);
+}
+}
+
+template <>
+struct enable_bitmask_operators<Moose::RelationshipManagerType>
+{
+  static const bool enable = true;
+};
 
 /**
  * This Macro is used to generate std::string derived types useful for

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -16,6 +16,7 @@
 #include "ActionWarehouse.h"
 #include "MooseMesh.h"
 #include "MooseApp.h"
+#include "MooseTypes.h"
 #include "MooseUtils.h" // remove when getBaseName is removed
 
 template <>
@@ -69,6 +70,8 @@ Action::Action(InputParameters parameters)
     _executioner(_app.executioner())
 {
 }
+
+void Action::addRelationshipManagers(Moose::RelationshipManagerType) {}
 
 /// DEPRECATED METHODS
 std::string

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -25,6 +25,8 @@
 #include "InfixIterator.h"
 #include "FEProblem.h"
 
+#include "libmesh/simple_range.h"
+
 ActionWarehouse::ActionWarehouse(MooseApp & app, Syntax & syntax, ActionFactory & factory)
   : ConsoleStreamInterface(app),
     _app(app),
@@ -69,14 +71,11 @@ ActionWarehouse::addActionBlock(std::shared_ptr<Action> action)
 {
   /**
    * Note: This routine uses the XTerm colors directly which is not advised for general purpose
-   * output coloring.
-   * Most users should prefer using Problem::colorText() which respects the "color_output" option
-   * for terminals
-   * that do not support coloring.  Since this routine is intended for debugging only and runs
-   * before several
-   * objects exist in the system, we are just using the constants directly.
+   * output coloring. Most users should prefer using Problem::colorText() which respects the
+   * "color_output" optionfor terminals that do not support coloring.  Since this routine is
+   * intended for debugging only and runs before several objects exist in the system, we are just
+   * using the constants directly.
    */
-
   std::string registered_identifier =
       action->parameters().get<std::string>("registered_identifier");
   std::set<std::string> tasks;
@@ -96,18 +95,14 @@ ActionWarehouse::addActionBlock(std::shared_ptr<Action> action)
    * consider:
    *
    * 1. The current Action is registered with multiple syntax blocks. In this case we can only use
-   * the
-   *    current instance to satisfy the specific task listed for this syntax block.  We can detect
-   * this
-   *    case by inspecting whether it has a "specific task name" set in the Action instance.
+   *    the current instance to satisfy the specific task listed for this syntax block.  We can
+   *    detect this case by inspecting whether it has a "specific task name" set in the Action
+   *    instance.
    *
    * 2. This action does not have a valid "registered identifier" set in the Action instance. This
-   * means
-   *    that this Action was not built by the Parser.  It was most likely created through a
-   * Meta-Action.
-   *    In this case, the ActionFactory itself would have already set the task it found from the
-   * build
-   *    info used to construct the Action.
+   *    means that this Action was not built by the Parser.  It was most likely created through a
+   *    Meta-Action. In this case, the ActionFactory itself would have already set the task it found
+   *    from the build info used to construct the Action.
    *
    * 3. The current Action is registered with only a single syntax block. In this case we can simply
    *    re-use the current instance to act and satisfy _all_ registered tasks. This is the normal
@@ -158,9 +153,9 @@ ActionWarehouse::addActionBlock(std::shared_ptr<Action> action)
                  << " (" << COLOR_YELLOW << task << COLOR_DEFAULT << ")\n";
 
     // Add it to the warehouse
-    _all_ptrs.push_back(action);
     _action_blocks[task].push_back(action.get());
   }
+  _all_ptrs.push_back(action);
 
   if (_show_parser)
     Moose::err << std::endl;
@@ -176,6 +171,12 @@ ActionIterator
 ActionWarehouse::actionBlocksWithActionEnd(const std::string & task)
 {
   return _action_blocks[task].end();
+}
+
+const std::vector<std::shared_ptr<Action>> &
+ActionWarehouse::allActionBlocks() const
+{
+  return _all_ptrs;
 }
 
 const std::list<Action *> &
@@ -200,21 +201,16 @@ ActionWarehouse::buildBuildableActions(const std::string & task)
   if (_syntax.isActionRequired(task) && _action_blocks[task].empty())
   {
     bool ret_value = false;
-    std::pair<std::multimap<std::string, std::string>::const_iterator,
-              std::multimap<std::string, std::string>::const_iterator>
-        range = _action_factory.getActionsByTask(task);
-    for (std::multimap<std::string, std::string>::const_iterator it = range.first;
-         it != range.second;
-         ++it)
+    auto it_pair = _action_factory.getActionsByTask(task);
+    for (const auto & action_pair : as_range(it_pair))
     {
-      InputParameters params = _action_factory.getValidParams(it->second);
+      InputParameters params = _action_factory.getValidParams(action_pair.second);
       params.set<ActionWarehouse *>("awh") = this;
 
       if (params.areAllRequiredParamsValid())
       {
         params.set<std::string>("registered_identifier") = "(AutoBuilt)";
-        params.set<std::string>("task") = task;
-        addActionBlock(_action_factory.create(it->second, "", params));
+        addActionBlock(_action_factory.create(action_pair.second, "", params));
         ret_value = true;
       }
     }

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -72,7 +72,7 @@ ActionWarehouse::addActionBlock(std::shared_ptr<Action> action)
   /**
    * Note: This routine uses the XTerm colors directly which is not advised for general purpose
    * output coloring. Most users should prefer using Problem::colorText() which respects the
-   * "color_output" optionfor terminals that do not support coloring.  Since this routine is
+   * "color_output" option for terminals that do not support coloring.  Since this routine is
    * intended for debugging only and runs before several objects exist in the system, we are just
    * using the constants directly.
    */

--- a/framework/src/actions/AddRelationshipManager.C
+++ b/framework/src/actions/AddRelationshipManager.C
@@ -27,10 +27,13 @@ AddRelationshipManager::AddRelationshipManager(InputParameters params) : Action(
 void
 AddRelationshipManager::act()
 {
-  Moose::RelationshipManagerType rm_type =
-      _current_task == "add_geometric_rm" ? Moose::Geometric : Moose::Algebriac;
+  Moose::RelationshipManagerType rm_type = _current_task == "add_geometric_rm"
+                                               ? Moose::RelationshipManagerType::Geometric
+                                               : Moose::RelationshipManagerType::Algebraic;
 
   const auto & all_action_ptrs = _awh.allActionBlocks();
   for (const auto & action_ptr : all_action_ptrs)
     action_ptr->addRelationshipManagers(rm_type);
+
+  _app.attachRelationshipManagers(rm_type);
 }

--- a/framework/src/actions/AddRelationshipManager.C
+++ b/framework/src/actions/AddRelationshipManager.C
@@ -27,9 +27,9 @@ AddRelationshipManager::AddRelationshipManager(InputParameters params) : Action(
 void
 AddRelationshipManager::act()
 {
-  Moose::RelationshipManagerType rm_type = _current_task == "add_geometric_rm"
-                                               ? Moose::RelationshipManagerType::Geometric
-                                               : Moose::RelationshipManagerType::Algebraic;
+  Moose::RelationshipManagerType rm_type =
+      (_current_task == "add_geometric_rm" ? Moose::RelationshipManagerType::Geometric
+                                           : Moose::RelationshipManagerType::Algebraic);
 
   const auto & all_action_ptrs = _awh.allActionBlocks();
   for (const auto & action_ptr : all_action_ptrs)

--- a/framework/src/actions/AddRelationshipManager.C
+++ b/framework/src/actions/AddRelationshipManager.C
@@ -12,41 +12,25 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef MOOSEOBJECTACTION_H
-#define MOOSEOBJECTACTION_H
-
-#include "Action.h"
-
-#include <string>
-
-class MooseObjectAction;
+#include "AddRelationshipManager.h"
+#include "FEProblem.h"
 
 template <>
-InputParameters validParams<MooseObjectAction>();
-
-class MooseObjectAction : public Action
+InputParameters
+validParams<AddRelationshipManager>()
 {
-public:
-  MooseObjectAction(InputParameters params);
+  return validParams<Action>();
+}
 
-  virtual void addRelationshipManagers(Moose::RelationshipManagerType type) override;
+AddRelationshipManager::AddRelationshipManager(InputParameters params) : Action(params) {}
 
-  /**
-   * Retreive the parameters of the object to be created by this action
-   */
-  InputParameters & getObjectParams() { return _moose_object_pars; }
+void
+AddRelationshipManager::act()
+{
+  Moose::RelationshipManagerType rm_type =
+      _current_task == "add_geometric_rm" ? Moose::Geometric : Moose::Algebriac;
 
-  /**
-   * Return the object type to be created
-   */
-  const std::string & getMooseObjectType() const { return _type; }
-
-protected:
-  /// The Object type that is being created
-  std::string _type;
-
-  /// The parameters for the object to be created
-  InputParameters _moose_object_pars;
-};
-
-#endif // MOOSEOBJECTACTION_H
+  const auto & all_action_ptrs = _awh.allActionBlocks();
+  for (const auto & action_ptr : all_action_ptrs)
+    action_ptr->addRelationshipManagers(rm_type);
+}

--- a/framework/src/actions/MooseObjectAction.C
+++ b/framework/src/actions/MooseObjectAction.C
@@ -15,6 +15,9 @@
 #include "MooseObjectAction.h"
 #include "MooseUtils.h"
 #include "Factory.h"
+#include "RelationshipManager.h"
+#include "Conversion.h"
+#include "MooseMesh.h"
 
 template <>
 InputParameters
@@ -38,4 +41,40 @@ MooseObjectAction::MooseObjectAction(InputParameters params)
                            : validParams<MooseObject>())
 {
   _moose_object_pars.blockFullpath() = params.blockFullpath();
+}
+
+void
+MooseObjectAction::addRelationshipManagers(Moose::RelationshipManagerType rm_type)
+{
+  const auto & buildable_types = _moose_object_pars.getBuildableRelationshipManagerTypes();
+
+  for (const auto & buildable_type : buildable_types)
+  {
+    auto rm_params = _factory.getValidParams(buildable_type);
+    mooseAssert(rm_params.isParamValid("RelationshipManagerType"),
+                "RelationshipManagerType is not set for " + buildable_type);
+
+    if (rm_type != rm_params.get<Moose::RelationshipManagerType>("RelationshipManagerType"))
+      continue;
+
+    rm_params.applyParameters(_moose_object_pars);
+    rm_params.set<MooseMesh *>("mesh") = _mesh.get();
+
+    if (rm_params.areAllRequiredParamsValid())
+    {
+      auto rm_obj = _factory.create<RelationshipManager>(
+          buildable_type, name() + "_rm" + Moose::stringify(rm_type), rm_params);
+
+      rm_obj->init();
+
+      if (rm_obj->isActive())
+      {
+        if (rm_type == Moose::Geometric)
+          // Hand off ownership of the shared pointer to the Mesh
+          _mesh->addRelationshipManager(std::move(rm_obj));
+        //      else
+        //        _problem->getNonlinearSystemBase().dofMap().add_coupling_functor(std::move(rm_obj));
+      }
+    }
+  }
 }

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -29,7 +29,6 @@ Coupleable::Coupleable(const MooseObject * moose_object, bool nodal)
     _c_is_implicit(_c_parameters.have_parameter<bool>("implicit")
                        ? _c_parameters.get<bool>("implicit")
                        : true),
-    _coupleable_params(_c_parameters),
     _coupleable_neighbor(_c_parameters.have_parameter<bool>("_neighbor")
                              ? _c_parameters.get<bool>("_neighbor")
                              : false),
@@ -102,7 +101,7 @@ Coupleable::isCoupled(const std::string & var_name, unsigned int i)
   else
   {
     // Make sure the user originally requested this value in the InputParameter syntax
-    if (!_coupleable_params.hasCoupledValue(var_name))
+    if (!_c_parameters.hasCoupledValue(var_name))
       mooseError(_c_name,
                  ": The coupled variable \"",
                  var_name,
@@ -179,7 +178,7 @@ Coupleable::getDefaultValue(const std::string & var_name)
   if (default_value_it == _default_value.end())
   {
     VariableValue * value =
-        new VariableValue(_coupleable_max_qps, _coupleable_params.defaultCoupledValue(var_name));
+        new VariableValue(_coupleable_max_qps, _c_parameters.defaultCoupledValue(var_name));
     default_value_it = _default_value.insert(std::make_pair(var_name, value)).first;
   }
 

--- a/framework/src/base/LazyCoupleable.C
+++ b/framework/src/base/LazyCoupleable.C
@@ -1,0 +1,75 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "LazyCoupleable.h"
+#include "FEProblem.h"
+#include "MooseVariable.h"
+#include "InputParameters.h"
+#include "MooseObject.h"
+
+#include "libmesh/simple_range.h"
+
+LazyCoupleable::LazyCoupleable(const MooseObject * moose_object)
+  : _l_parameters(moose_object->parameters()),
+    _l_name(_l_parameters.get<std::string>("_object_name")),
+    _l_fe_problem(nullptr),
+    _l_app(moose_object->getMooseApp())
+{
+  for (const auto & var_name :
+       as_range(std::make_pair(_l_parameters.coupledVarsBegin(), _l_parameters.coupledVarsEnd())))
+    _coupled_var_numbers[var_name] = libmesh_make_unique<unsigned int>(0);
+}
+
+LazyCoupleable::~LazyCoupleable() {}
+
+void
+LazyCoupleable::setFEProblemPtr(FEProblemBase * fe_problem)
+{
+  _l_fe_problem = fe_problem;
+  init();
+}
+
+void
+LazyCoupleable::init()
+{
+  for (const auto & var_pair : _coupled_var_numbers)
+  {
+    if (!_l_fe_problem->hasVariable(var_pair.first))
+      mooseError("Unable to find variable ", var_pair.first);
+
+    auto & moose_var = _l_fe_problem->getVariable(0, var_pair.first);
+    if (moose_var.kind() == Moose::VAR_NONLINEAR)
+      *(var_pair.second) = moose_var.number();
+    else
+      *(var_pair.second) = std::numeric_limits<unsigned int>::max() - moose_var.number();
+  }
+}
+
+unsigned int &
+LazyCoupleable::coupled(const std::string & var_name, unsigned int /*comp*/)
+{
+  if (!_l_fe_problem)
+  {
+    auto & executioner_ptr = _l_app.executioner();
+    if (!executioner_ptr)
+      mooseError("Executioner is nullptr in LazyCoupleable. You cannot call the \"coupled\" method "
+                 "until the add_algebraic_rm task");
+    setFEProblemPtr(executioner_ptr->feProblem());
+  }
+
+  const auto & var_pair = _coupled_var_numbers.find(var_name);
+  mooseAssert(var_pair != _coupled_var_numbers.end(), "Internal error in LazyCoupleable");
+
+  return *(var_pair->second);
+}

--- a/framework/src/base/LazyCoupleable.C
+++ b/framework/src/base/LazyCoupleable.C
@@ -17,6 +17,8 @@
 #include "MooseVariable.h"
 #include "InputParameters.h"
 #include "MooseObject.h"
+#include "MooseApp.h"
+#include "Executioner.h"
 
 #include "libmesh/simple_range.h"
 
@@ -30,8 +32,6 @@ LazyCoupleable::LazyCoupleable(const MooseObject * moose_object)
        as_range(std::make_pair(_l_parameters.coupledVarsBegin(), _l_parameters.coupledVarsEnd())))
     _coupled_var_numbers[var_name] = libmesh_make_unique<unsigned int>(0);
 }
-
-LazyCoupleable::~LazyCoupleable() {}
 
 void
 LazyCoupleable::setFEProblemPtr(FEProblemBase * fe_problem)
@@ -65,7 +65,7 @@ LazyCoupleable::coupled(const std::string & var_name, unsigned int /*comp*/)
     if (!executioner_ptr)
       mooseError("Executioner is nullptr in LazyCoupleable. You cannot call the \"coupled\" method "
                  "until the add_algebraic_rm task");
-    setFEProblemPtr(executioner_ptr->feProblem());
+    setFEProblemPtr(&executioner_ptr->feProblem());
   }
 
   const auto & var_pair = _coupled_var_numbers.find(var_name);

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -447,6 +447,7 @@
 #include "SetupRecoverFileBaseAction.h"
 #include "AddNodalKernelAction.h"
 #include "MaterialDerivativeTestAction.h"
+#include "AddRelationshipManager.h"
 
 // Outputs
 #ifdef LIBMESH_HAVE_EXODUS_API
@@ -479,6 +480,10 @@
 #include "ConstantRate.h"
 #include "TimeDerivativeNodalKernel.h"
 #include "UserForcingFunctionNodalKernel.h"
+
+// relationship managers
+#include "ElementSideNeighborLayers.h"
+#include "ElementPointNeighbors.h"
 
 #include <unistd.h>
 
@@ -907,6 +912,10 @@ registerObjects(Factory & factory)
   registerNodalKernel(ConstantRate);
   registerNodalKernel(UserForcingFunctionNodalKernel);
 
+  // RelationshipManagers
+  registerRelationshipManager(ElementSideNeighborLayers);
+  registerRelationshipManager(ElementPointNeighbors);
+
   registered = true;
 }
 
@@ -914,7 +923,7 @@ void
 addActionTypes(Syntax & syntax)
 {
   /**
-   * The second param here indicates whether the task must be satisfied or not for a successful run.
+   * The last param here indicates whether the task must be satisfied or not for a successful run.
    * If set to true, then the ActionWarehouse will attempt to create "Action"s automatically if they
    * have not been explicitly created by the parser or some other mechanism.
    *
@@ -1001,10 +1010,12 @@ addActionTypes(Syntax & syntax)
   registerTask("execute_mesh_modifiers", false);
   registerTask("uniform_refine_mesh", false);
   registerTask("prepare_mesh", false);
+  registerTask("add_geometric_rm", true);
   registerTask("setup_mesh_complete", false); // calls prepare
 
   registerTask("init_displaced_problem", false);
 
+  registerTask("add_algebraic_rm", true);
   registerTask("init_problem", true);
   registerTask("check_copy_nodal_vars", true);
   registerTask("copy_nodal_vars", true);
@@ -1056,6 +1067,7 @@ addActionTypes(Syntax & syntax)
                            "(check_copy_nodal_vars)"
                            "(setup_mesh)"
                            "(add_partitioner)"
+                           "(add_geometric_rm)"
                            "(init_mesh)"
                            "(prepare_mesh)"
                            "(add_mesh_modifier)"
@@ -1094,6 +1106,7 @@ addActionTypes(Syntax & syntax)
                            "(copy_nodal_vars, copy_nodal_aux_vars)"
                            "(add_material)"
                            "(setup_material_output)"
+                           "(add_algebraic_rm)"
                            "(init_problem)"
                            "(setup_debug)"
                            "(add_output)"
@@ -1245,6 +1258,9 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
   // NonParsedActions
   registerAction(SetupDampersAction, "setup_dampers");
   registerAction(EmptyAction, "ready_to_init");
+  registerAction(AddRelationshipManager, "add_algebraic_rm");
+  registerAction(AddRelationshipManager, "add_geometric_rm");
+
   registerAction(InitProblemAction, "init_problem");
   registerAction(CheckIntegrityAction, "check_integrity");
 

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -165,7 +165,7 @@ EigenKernel::computeOffDiagJacobian(unsigned int jvar)
 }
 
 bool
-EigenKernel::enabled()
+EigenKernel::enabled() const
 {
   bool flag = MooseObject::enabled();
   if (_eigen)

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -18,6 +18,7 @@
 #include "Assembly.h"
 #include "MooseUtils.h"
 #include "MooseApp.h"
+#include "RelationshipManager.h"
 
 #include <utility>
 
@@ -2613,4 +2614,23 @@ MooseMesh::addMortarInterface(const std::string & name,
   _mortar_interface_by_name[name] = _mortar_interface.back().get();
   _mortar_interface_by_ids[std::pair<BoundaryID, BoundaryID>(master_id, slave_id)] =
       _mortar_interface.back().get();
+}
+
+void
+MooseMesh::addRelationshipManager(std::shared_ptr<RelationshipManager> relationship_manager)
+{
+  _relationship_managers.emplace_back(relationship_manager);
+  getMesh().add_ghosting_functor(*relationship_manager);
+}
+
+std::vector<std::string>
+MooseMesh::getRelationshipManagerInfo()
+{
+  std::vector<std::string> info_strings;
+  info_strings.reserve(_relationship_managers.size());
+
+  for (const auto & rm : _relationship_managers)
+    info_strings.emplace_back(rm->getInfo());
+
+  return info_strings;
 }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2615,22 +2615,3 @@ MooseMesh::addMortarInterface(const std::string & name,
   _mortar_interface_by_ids[std::pair<BoundaryID, BoundaryID>(master_id, slave_id)] =
       _mortar_interface.back().get();
 }
-
-void
-MooseMesh::addRelationshipManager(std::shared_ptr<RelationshipManager> relationship_manager)
-{
-  _relationship_managers.emplace_back(relationship_manager);
-  getMesh().add_ghosting_functor(*relationship_manager);
-}
-
-std::vector<std::string>
-MooseMesh::getRelationshipManagerInfo()
-{
-  std::vector<std::string> info_strings;
-  info_strings.reserve(_relationship_managers.size());
-
-  for (const auto & rm : _relationship_managers)
-    info_strings.emplace_back(rm->getInfo());
-
-  return info_strings;
-}

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -106,12 +106,12 @@ validParams<Console>()
                                      "the average residual it is colored yellow.");
 
   // System information controls
-  MultiMooseEnum info("framework mesh aux nonlinear execution output",
-                      "framework mesh aux nonlinear execution");
+  MultiMooseEnum info("framework mesh aux nonlinear relationship execution output",
+                      "framework mesh aux nonlinear relationship execution");
   params.addParam<MultiMooseEnum>("system_info",
                                   info,
                                   "List of information types to display "
-                                  "('framework', 'mesh', 'aux', 'nonlinear', "
+                                  "('framework', 'mesh', 'aux', 'nonlinear', 'relationship', "
                                   "'execution', 'output')");
 
   // Advanced group
@@ -613,6 +613,13 @@ Console::outputSystemInformation()
     std::string output = ConsoleUtils::outputAuxiliarySystemInformation(*_problem_ptr);
     if (!output.empty())
       _console << "Auxiliary System:\n" << output;
+  }
+
+  if (_system_info_flags.contains("relationship"))
+  {
+    std::string output = ConsoleUtils::outputRelationshipManagerInformation(_app);
+    if (!output.empty())
+      _console << "Relationship Managers:\n" << output;
   }
 
   if (_system_info_flags.contains("execution"))

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -92,15 +92,6 @@ outputMeshInformation(FEProblemBase & problem, bool verbose)
     if (problem.n_processors() > 1)
       oss << std::setw(console_field_width) << "  Partitioner: " << moose_mesh.partitionerName()
           << (moose_mesh.isPartitionerForced() ? " (forced) " : "") << '\n';
-
-    auto info_strings = moose_mesh.getRelationshipManagerInfo();
-    if (info_strings.size())
-    {
-      oss << std::setw(console_field_width) << "  Relationship Manager(s): " << info_strings[0]
-          << '\n';
-      for (auto i = beginIndex(info_strings, 1); i < info_strings.size(); ++i)
-        oss << std::setw(console_field_width) << "" << info_strings[i] << '\n';
-    }
   }
 
   oss << '\n';
@@ -212,6 +203,24 @@ outputSystemInformationHelper(const System & system)
       insertNewline(oss, begin_string_pos, curr_string_pos);
     }
     oss << "\n\n";
+  }
+
+  return oss.str();
+}
+
+std::string
+outputRelationshipManagerInformation(MooseApp & app)
+{
+  std::stringstream oss;
+  oss << std::left;
+
+  auto info_strings = app.getRelationshipManagerInfo();
+  if (info_strings.size())
+  {
+    for (const auto & info_pair : info_strings)
+      oss << std::setw(console_field_width) << std::string("  ") + info_pair.first << ": "
+          << info_pair.second << '\n';
+    oss << '\n';
   }
 
   return oss.str();

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -92,6 +92,15 @@ outputMeshInformation(FEProblemBase & problem, bool verbose)
     if (problem.n_processors() > 1)
       oss << std::setw(console_field_width) << "  Partitioner: " << moose_mesh.partitionerName()
           << (moose_mesh.isPartitionerForced() ? " (forced) " : "") << '\n';
+
+    auto info_strings = moose_mesh.getRelationshipManagerInfo();
+    if (info_strings.size())
+    {
+      oss << std::setw(console_field_width) << "  Relationship Manager(s): " << info_strings[0]
+          << '\n';
+      for (auto i = beginIndex(info_strings, 1); i < info_strings.size(); ++i)
+        oss << std::setw(console_field_width) << "" << info_strings[i] << '\n';
+    }
   }
 
   oss << '\n';

--- a/framework/src/relationshipmanagers/ElementPointNeighbors.C
+++ b/framework/src/relationshipmanagers/ElementPointNeighbors.C
@@ -1,0 +1,62 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ElementPointNeighbors.h"
+#include "MooseMesh.h"
+#include "Conversion.h"
+
+template <>
+InputParameters
+validParams<ElementPointNeighbors>()
+{
+  InputParameters params = validParams<RelationshipManager>();
+
+  params.set<Moose::RelationshipManagerType>("RelationshipManagerType") = Moose::Geometric;
+
+  return params;
+}
+
+ElementPointNeighbors::ElementPointNeighbors(const InputParameters & parameters)
+  : RelationshipManager(parameters), _point_coupling(_mesh), _is_active(false)
+{
+}
+
+void
+ElementPointNeighbors::init()
+{
+  _is_active = true;
+}
+
+bool
+ElementPointNeighbors::isActive() const
+{
+  return _is_active;
+}
+
+std::string
+ElementPointNeighbors::getInfo() const
+{
+  std::ostringstream oss;
+  oss << "ElementPointNeighbors";
+  return oss.str();
+}
+
+void
+ElementPointNeighbors::operator()(const MeshBase::const_element_iterator & range_begin,
+                                  const MeshBase::const_element_iterator & range_end,
+                                  processor_id_type p,
+                                  map_type & coupled_elements)
+{
+  _point_coupling(range_begin, range_end, p, coupled_elements);
+}

--- a/framework/src/relationshipmanagers/ElementSideNeighborLayers.C
+++ b/framework/src/relationshipmanagers/ElementSideNeighborLayers.C
@@ -1,0 +1,74 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "ElementSideNeighborLayers.h"
+#include "MooseMesh.h"
+#include "Conversion.h"
+
+template <>
+InputParameters
+validParams<ElementSideNeighborLayers>()
+{
+  InputParameters params = validParams<RelationshipManager>();
+
+  params.addRequiredRangeCheckedParam<unsigned short>(
+      "element_side_neighbor_layers",
+      "element_side_neighbor_layers>=1 & element_side_neighbor_layers<=10",
+      "The number of additional geometric elements to make available when "
+      "using distributed mesh. No effect with replicated mesh.");
+
+  params.set<Moose::RelationshipManagerType>("RelationshipManagerType") = Moose::Geometric;
+
+  return params;
+}
+
+ElementSideNeighborLayers::ElementSideNeighborLayers(const InputParameters & parameters)
+  : RelationshipManager(parameters),
+    _element_side_neighbor_layers(getParam<unsigned short>("element_side_neighbor_layers")),
+    _is_active(false)
+{
+}
+
+void
+ElementSideNeighborLayers::init()
+{
+  if (_mesh.isDistributedMesh() && _element_side_neighbor_layers > 1)
+  {
+    _default_coupling.set_n_levels(_element_side_neighbor_layers);
+    _is_active = true;
+  }
+}
+
+bool
+ElementSideNeighborLayers::isActive() const
+{
+  return _is_active;
+}
+
+std::string
+ElementSideNeighborLayers::getInfo() const
+{
+  std::ostringstream oss;
+  oss << "ElementSideNeighborLayers (" << _element_side_neighbor_layers << " layers)";
+  return oss.str();
+}
+
+void
+ElementSideNeighborLayers::operator()(const MeshBase::const_element_iterator & range_begin,
+                                      const MeshBase::const_element_iterator & range_end,
+                                      processor_id_type p,
+                                      map_type & coupled_elements)
+{
+  _default_coupling(range_begin, range_end, p, coupled_elements);
+}

--- a/framework/src/relationshipmanagers/GeometricRelationshipManager.C
+++ b/framework/src/relationshipmanagers/GeometricRelationshipManager.C
@@ -12,41 +12,26 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef MOOSEOBJECTACTION_H
-#define MOOSEOBJECTACTION_H
-
-#include "Action.h"
-
-#include <string>
-
-class MooseObjectAction;
+#include "GeometricRelationshipManager.h"
+#include "MooseMesh.h"
 
 template <>
-InputParameters validParams<MooseObjectAction>();
-
-class MooseObjectAction : public Action
+InputParameters
+validParams<GeometricRelationshipManager>()
 {
-public:
-  MooseObjectAction(InputParameters params);
+  InputParameters params = validParams<RelationshipManager>();
 
-  virtual void addRelationshipManagers(Moose::RelationshipManagerType when_type) override;
+  params.set<Moose::RelationshipManagerType>("rm_type") = Moose::RelationshipManagerType::Geometric;
+  return params;
+}
 
-  /**
-   * Retreive the parameters of the object to be created by this action
-   */
-  InputParameters & getObjectParams() { return _moose_object_pars; }
+GeometricRelationshipManager::GeometricRelationshipManager(const InputParameters & parameters)
+  : RelationshipManager(parameters)
+{
+}
 
-  /**
-   * Return the object type to be created
-   */
-  const std::string & getMooseObjectType() const { return _type; }
-
-protected:
-  /// The Object type that is being created
-  std::string _type;
-
-  /// The parameters for the object to be created
-  InputParameters _moose_object_pars;
-};
-
-#endif // MOOSEOBJECTACTION_H
+void
+GeometricRelationshipManager::attachGeometricFunctorHelper(GhostingFunctor & gf) const
+{
+  _mesh.getMesh().add_ghosting_functor(gf);
+}

--- a/framework/src/relationshipmanagers/RelationshipManager.C
+++ b/framework/src/relationshipmanagers/RelationshipManager.C
@@ -13,24 +13,39 @@
 /****************************************************************/
 
 #include "RelationshipManager.h"
-#include "MooseMesh.h"
 
 template <>
 InputParameters
 validParams<RelationshipManager>()
 {
   InputParameters params = validParams<MooseObject>();
+
   /**
-   * This param must be set by the Developer so that MOOSE knows what type of object this
-   * is before it is constructed. An alternative design was considered where we would just create
-   * separate base classes and have developers register against those bases separately but we don't
-   * actually store the base type in the Factory anyway so this would still require several more
-   * changes and not solve every problem.
+   * Param to indicate whether all necessary GeometricRelationshipManagers can be attached during
+   * the setup of the mesh. When true (and when running with DistributedMesh) the framework can
+   * perform two optimizations:
    *
-   * TL;DR: When building a relationship manager you _must_ set this parameter directly in your
-   * validparams() method or you will receive an error prior to this object's construction.
+   * 1) Elements not needed by any ghosting functor can be safely deleted during Mesh::init() prior
+   *    to building the EquationSystems object or other MOOSE objects. This may result in
+   *    significant memory savings during the setup phase.
+   *
+   * 2) A late mesh reinitialization can be skipped reducing the overall setup time of the
+   *    simulation.
+   *
+   * When in doubt and to allow for maximum flexibility, developers may choose to return false here
+   * to simplify setting up Algebraic and Geometric at the same time.
    */
-  params.addPrivateParam<Moose::RelationshipManagerType>("RelationshipManagerType");
+  params.addPrivateParam<bool>("attach_geometric_early", true);
+
+  /**
+   * This parameter indicates which type of RelationshipManager this class represents prior to
+   * its
+   * construction. Geometric-only RelationshipManagers may be buildable early in which case the
+   * framework can optimize memory usage for Distributed Mesh by allowing remote elements to be
+   * deleted. Depending on the mesh size and EquationSystems size, this may have a significant
+   * impact on total memory usage during the problem setup phase.
+   */
+  params.addPrivateParam<Moose::RelationshipManagerType>("rm_type");
 
   // Set by MOOSE
   params.addPrivateParam<MooseMesh *>("mesh");
@@ -41,6 +56,72 @@ validParams<RelationshipManager>()
 RelationshipManager::RelationshipManager(const InputParameters & parameters)
   : MooseObject(parameters),
     GhostingFunctor(),
-    _mesh(*getCheckedPointerParam<MooseMesh *>("mesh", "Mesh is null in RelationshipManager ctor"))
+    _mesh(*getCheckedPointerParam<MooseMesh *>(
+        "mesh", "Mesh is null in GeometricRelationshipManager ctor")),
+    _attach_geometric_early(getParam<bool>("attach_geometric_early")),
+    _rm_type(getParam<Moose::RelationshipManagerType>("rm_type")),
+    _cached_callbacks(Moose::RelationshipManagerType::Invalid),
+    _has_set_remote_elem_removal_flag(false)
 {
+}
+
+void
+RelationshipManager::attachRelationshipManagers(Moose::RelationshipManagerType when_type)
+{
+  /**
+   * If we cannot attach the geometric functor early, we have to prevent the mesh from deleting
+   * elements that we might need for a future relationship manager.
+   */
+  if (!_has_set_remote_elem_removal_flag && !_attach_geometric_early && _mesh.isDistributedMesh())
+  {
+    _mesh.getMesh().allow_remote_element_removal(false);
+    _has_set_remote_elem_removal_flag = true;
+  }
+
+  // Next make sure that we haven't already triggered this type of callback
+  if ((_cached_callbacks & when_type) == when_type)
+    return;
+
+  /**
+   * We have a few different cases to handle when attaching RelationshipManagers to the
+   * corresponding libMesh objects.
+   *
+   * 1) GeometricRelationshipManager objects will only respond to the Geometric rm_type, However
+   *    they can be attached either early or late.
+   *
+   * 2) AlgebraicRelationshipManager objects will respond to both the Geometric and Algebraic
+   *    rm_types. Additionally, the object can decide to attach the geometric rm_type either early
+   *    or late depending on the needs of the developer.
+   *
+   * Finally, we will make sure that each RelationshipManager receives only a single callback per
+   * type.
+   */
+  auto obj_type = getType();
+  if (obj_type == Moose::RelationshipManagerType::Geometric)
+  {
+    if ((_attach_geometric_early && when_type == Moose::RelationshipManagerType::Geometric) ||
+        (!_attach_geometric_early && when_type == Moose::RelationshipManagerType::Algebraic))
+    {
+      attachRelationshipManagersInternal(obj_type);
+      // Toggle the flag for this enum
+      _cached_callbacks |= obj_type;
+    }
+  }
+  else if (obj_type == Moose::RelationshipManagerType::Algebraic)
+  {
+    if (_attach_geometric_early && when_type == Moose::RelationshipManagerType::Geometric)
+    {
+      attachRelationshipManagersInternal(Moose::RelationshipManagerType::Geometric);
+      _cached_callbacks |= Moose::RelationshipManagerType::Geometric;
+    }
+    else if (when_type == Moose::RelationshipManagerType::Algebraic)
+    {
+      // Note: We won't double add due to the early return above
+      attachRelationshipManagersInternal(Moose::RelationshipManagerType::Geometric);
+      attachRelationshipManagersInternal(Moose::RelationshipManagerType::Algebraic);
+
+      _cached_callbacks |= Moose::RelationshipManagerType::Geometric;
+      _cached_callbacks |= Moose::RelationshipManagerType::Algebraic;
+    }
+  }
 }

--- a/framework/src/relationshipmanagers/RelationshipManager.C
+++ b/framework/src/relationshipmanagers/RelationshipManager.C
@@ -38,8 +38,7 @@ validParams<RelationshipManager>()
   params.addPrivateParam<bool>("attach_geometric_early", true);
 
   /**
-   * This parameter indicates which type of RelationshipManager this class represents prior to
-   * its
+   * This parameter indicates which type of RelationshipManager this class represents prior to its
    * construction. Geometric-only RelationshipManagers may be buildable early in which case the
    * framework can optimize memory usage for Distributed Mesh by allowing remote elements to be
    * deleted. Depending on the mesh size and EquationSystems size, this may have a significant

--- a/framework/src/relationshipmanagers/RelationshipManager.C
+++ b/framework/src/relationshipmanagers/RelationshipManager.C
@@ -1,0 +1,46 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*                                                              */
+/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#include "RelationshipManager.h"
+#include "MooseMesh.h"
+
+template <>
+InputParameters
+validParams<RelationshipManager>()
+{
+  InputParameters params = validParams<MooseObject>();
+  /**
+   * This param must be set by the Developer so that MOOSE knows what type of object this
+   * is before it is constructed. An alternative design was considered where we would just create
+   * separate base classes and have developers register against those bases separately but we don't
+   * actually store the base type in the Factory anyway so this would still require several more
+   * changes and not solve every problem.
+   *
+   * TL;DR: When building a relationship manager you _must_ set this parameter directly in your
+   * validparams() method or you will receive an error prior to this object's construction.
+   */
+  params.addPrivateParam<Moose::RelationshipManagerType>("RelationshipManagerType");
+
+  // Set by MOOSE
+  params.addPrivateParam<MooseMesh *>("mesh");
+  params.registerBase("RelationshipManager");
+  return params;
+}
+
+RelationshipManager::RelationshipManager(const InputParameters & parameters)
+  : MooseObject(parameters),
+    GhostingFunctor(),
+    _mesh(*getCheckedPointerParam<MooseMesh *>("mesh", "Mesh is null in RelationshipManager ctor"))
+{
+}

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -321,6 +321,21 @@ stringToEnum<MffdType>(const std::string & s)
   return mffd_type_to_enum[upper];
 }
 
+// Definition in MooseTypes.h
+std::string
+stringify(const Moose::RelationshipManagerType & t)
+{
+  switch (t)
+  {
+    case Moose::RelationshipManagerType::Geometric:
+      return "Geometric";
+    case Moose::RelationshipManagerType::Algebraic:
+      return "Algebraic";
+    default:
+      return "ERROR";
+  }
+}
+
 std::string
 stringify(const SolveType & t)
 {

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -824,6 +824,22 @@ InputParameters::addParam<std::vector<MooseEnum>>(const std::string & /*name*/,
 
 template <>
 void
+InputParameters::addPrivateParam<MooseEnum>(const std::string & /*name*/)
+{
+  mooseError("You must supply a MooseEnum object when using addPrivateParam, even if the parameter "
+             "is not required!");
+}
+
+template <>
+void
+InputParameters::addPrivateParam<MultiMooseEnum>(const std::string & /*name*/)
+{
+  mooseError("You must supply a MultiMooseEnum object when using addPrivateParam, even if the "
+             "parameter is not required!");
+}
+
+template <>
+void
 InputParameters::addDeprecatedParam<MooseEnum>(const std::string & /*name*/,
                                                const std::string & /*doc_string*/,
                                                const std::string & /*deprecation_message*/)

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -132,6 +132,7 @@ InputParameters::operator=(const InputParameters & rhs)
   _params = rhs._params;
 
   _buildable_types = rhs._buildable_types;
+  _buildable_rm_types = rhs._buildable_rm_types;
   _collapse_nesting = rhs._collapse_nesting;
   _moose_object_syntax_visibility = rhs._moose_object_syntax_visibility;
   _coupled_vars = rhs._coupled_vars;
@@ -154,6 +155,9 @@ InputParameters::operator+=(const InputParameters & rhs)
 
   _buildable_types.insert(
       _buildable_types.end(), rhs._buildable_types.begin(), rhs._buildable_types.end());
+  _buildable_rm_types.insert(
+      _buildable_rm_types.end(), rhs._buildable_rm_types.begin(), rhs._buildable_rm_types.end());
+
   // Collapse nesting and moose object syntax hiding are not modified with +=
   _coupled_vars.insert(rhs._coupled_vars.begin(), rhs._coupled_vars.end());
   return *this;
@@ -306,10 +310,23 @@ InputParameters::registerBuildableTypes(const std::string & names)
   MooseUtils::tokenize(names, _buildable_types, 1, " \t\n\v\f\r"); // tokenize on whitespace
 }
 
+void
+InputParameters::registerRelationshipManagers(const std::string & names)
+{
+  _buildable_rm_types.clear();
+  MooseUtils::tokenize(names, _buildable_rm_types, 1, " \t\n\v\f\r"); // tokenize on whitespace
+}
+
 const std::vector<std::string> &
 InputParameters::getBuildableTypes() const
 {
   return _buildable_types;
+}
+
+const std::vector<std::string> &
+InputParameters::getBuildableRelationshipManagerTypes() const
+{
+  return _buildable_rm_types;
 }
 
 void

--- a/test/src/userobjects/GhostUserObject.C
+++ b/test/src/userobjects/GhostUserObject.C
@@ -29,6 +29,11 @@ validParams<GhostUserObject>()
       "The rank for which the ghosted elements are recorded (Default: ALL)");
 
   params.set<ExecFlagEnum>("execute_on") = EXEC_TIMESTEP_BEGIN;
+
+  params.registerRelationshipManagers("ElementSideNeighborLayers");
+  params.addRequiredParam<unsigned short>("element_side_neighbor_layers",
+                                          "Number of layers to ghost");
+
   params.addClassDescription("User object to calculate ghosted elements on a single processor or "
                              "the union across all processors.");
   return params;

--- a/test/tests/ics/depend_on_uo/geometric_neighbors_ic.i
+++ b/test/tests/ics/depend_on_uo/geometric_neighbors_ic.i
@@ -10,10 +10,6 @@
   # We are testing geometric ghosted functors
   # so we have to use distributed mesh
   parallel_type = distributed
-
-  # We are testing these two parameters
-  num_ghosted_layers = 1
-  ghost_point_neighbors = false
 []
 
 [Variables]
@@ -35,6 +31,7 @@
   [./ghost_uo]
     type = GhostUserObject
     execute_on = initial
+    element_side_neighbor_layers = 1
   [../]
 []
 

--- a/test/tests/mesh/ghost_functors/geometric_neighbors.i
+++ b/test/tests/mesh/ghost_functors/geometric_neighbors.i
@@ -7,10 +7,6 @@
   # We are testing geometric ghosted functors
   # so we have to use distributed mesh
   parallel_type = distributed
-
-  # We are testing these two parameters
-  num_ghosted_layers = 1
-  ghost_point_neighbors = false
 []
 
 [Variables]
@@ -48,6 +44,7 @@
   [./ghost_uo]
     type = GhostUserObject
     execute_on = initial
+    element_side_neighbor_layers = 1
   [../]
 []
 

--- a/test/tests/mesh/ghost_functors/tests
+++ b/test/tests/mesh/ghost_functors/tests
@@ -12,7 +12,7 @@
   [./geometric_edge_neighbor_two_2D]
     type = 'Exodiff'
     input = 'geometric_neighbors.i'
-    cli_args = 'Mesh/num_ghosted_layers=2 Outputs/file_base=geometric_edge_two_2D_out'
+    cli_args = 'UserObjects/ghost_uo/element_side_neighbor_layers=2 Outputs/file_base=geometric_edge_two_2D_out'
     exodiff = 'geometric_edge_two_2D_out.e'
 
     min_parallel = 3
@@ -33,7 +33,7 @@
   [./geometric_edge_neighbor_two_3D_Mac]
     type = 'Exodiff'
     input = 'geometric_neighbors.i'
-    cli_args = 'Mesh/num_ghosted_layers=2 Mesh/dim=3 Mesh/nz=8 Outputs/file_base=geometric_edge_two_3D_out_Mac'
+    cli_args = 'UserObjects/ghost_uo/element_side_neighbor_layers=2 Mesh/dim=3 Mesh/nz=8 Outputs/file_base=geometric_edge_two_3D_out_Mac'
     exodiff = 'geometric_edge_two_3D_out_Mac.e'
     platform = DARWIN
 
@@ -55,7 +55,7 @@
   [./geometric_edge_neighbor_two_3D_Linux]
     type = 'Exodiff'
     input = 'geometric_neighbors.i'
-    cli_args = 'Mesh/num_ghosted_layers=2 Mesh/dim=3 Mesh/nz=8 Outputs/file_base=geometric_edge_two_3D_out_Linux'
+    cli_args = 'UserObjects/ghost_uo/element_side_neighbor_layers=2 Mesh/dim=3 Mesh/nz=8 Outputs/file_base=geometric_edge_two_3D_out_Linux'
     exodiff = 'geometric_edge_two_3D_out_Linux.e'
     platform = LINUX
 


### PR DESCRIPTION
More work needs to be done to remove the existing ghosting methods
out of MooseMesh.

refs #10455

RelationshipManagers are wrappers for libMesh ghosting_functors. They are made to be created AND executed during the ActionWarehouse traversal (i.e. way early in MOOSE setup) so that they can be attached to the corresponding libMesh objects at the right times.

Along with this PR, I have implemented the first two RelationshipManagers (ElementSideNeighborLayers and ElementPointNeighbors) which make both of those "entities" available when using distributed mesh.