### PR TITLE
Clean up fluidstate materials and userobjects

### DIFF
--- a/modules/porous_flow/include/materials/PorousFlowFluidStateFlashBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowFluidStateFlashBase.h
@@ -116,12 +116,6 @@ protected:
 
   /// Conversion from degrees Celsius to degrees Kelvin
   const Real _T_c2k;
-  /// Universal gas constant (J/mol/K)
-  const Real _R;
-  /// Maximum number of iterations for the Newton-Raphson iterations
-  const Real _nr_max_its;
-  /// Tolerance for Newton-Raphson iterations
-  const Real _nr_tol;
   /// Flag to indicate whether to calculate stateful properties
   bool _is_initqp;
   /// FluidStateProperties data structure

--- a/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
@@ -11,7 +11,6 @@
 #include "PorousFlowFluidStateFlash.h"
 #include "PorousFlowCapillaryPressure.h"
 
-class PorousFlowDictator;
 class PorousFlowFluidStateBase;
 
 /// Data structure to pass calculated thermophysical properties
@@ -78,8 +77,6 @@ protected:
   const unsigned int _num_phases;
   /// Number of components
   const unsigned int _num_components;
-  /// Number of mass fraction primary variables
-  const unsigned int _num_z_vars;
   /// Phase number of the aqueous phase
   const unsigned int _aqueous_phase_number;
   /// Phase number of the gas phase

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateFlashBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateFlashBase.C
@@ -85,12 +85,15 @@ PorousFlowFluidStateFlashBase::PorousFlowFluidStateFlashBase(const InputParamete
             : declareProperty<std::vector<std::vector<Real>>>("dPorousFlow_viscosity_qp_dvar")),
 
     _T_c2k(getParam<MooseEnum>("temperature_unit") == 0 ? 0.0 : 273.15),
-    _R(8.3144598),
-    _nr_max_its(42),
-    _nr_tol(1.0e-12),
     _is_initqp(false),
     _pc_uo(getUserObject<PorousFlowCapillaryPressure>("capillary_pressure"))
 {
+  // Only two phases are possible in the fluidstate classes
+  if (_num_phases != 2)
+    mooseError("Only two phases are allowed in ",
+               _name,
+               ". Please check the number of phases entered in the dictator is 2");
+
   // Check that the number of total mass fractions provided as primary variables is correct
   if (_num_z_vars != _num_components - 1)
     mooseError("The number of supplied mass fraction variables should be ",

--- a/modules/porous_flow/src/userobjects/PorousFlowFluidStateBase.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowFluidStateBase.C
@@ -6,7 +6,6 @@
 /****************************************************************/
 
 #include "PorousFlowFluidStateBase.h"
-#include "PorousFlowDictator.h"
 
 template <>
 InputParameters
@@ -26,7 +25,6 @@ PorousFlowFluidStateBase::PorousFlowFluidStateBase(const InputParameters & param
   : PorousFlowFluidStateFlash(parameters),
     _num_phases(2),
     _num_components(2),
-    _num_z_vars(1),
     _aqueous_phase_number(getParam<unsigned int>("liquid_phase_number")),
     _gas_phase_number(1 - _aqueous_phase_number),
     _aqueous_fluid_component(getParam<unsigned int>("liquid_fluid_component")),


### PR DESCRIPTION
Removes some unused parameters in material and userobjects.

The fluidstate userobjects now obtain the number of phases
and fluid components from the dictator. The number of phases
is then checked to ensure that the only two phases are used
in simulations.

Closes #10508