### PR TITLE
Reduce scope of Include Directories

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -195,9 +195,13 @@ endif
 BUILD_EXEC :=
 
 app_GIT_DIR := $(shell cd "$(APPLICATION_DIR)" && which git &> /dev/null && git rev-parse --show-toplevel)
+
 # Use wildcard in case the files don't exist
 app_HEADER_deps := $(wildcard $(app_GIT_DIR)/.git/HEAD $(app_GIT_DIR)/.git/index)
+
 # Target-specific Variable Values (See GNU-make manual)
+$(app_objects): app_INCLUDES := $(moose_INCLUDE) $(app_INCLUDES)
+
 $(app_HEADER): curr_dir    := $(APPLICATION_DIR)
 $(app_HEADER): curr_app    := $(APPLICATION_NAME)
 $(app_HEADER): $(app_HEADER_deps)
@@ -241,3 +245,9 @@ $(app_EXEC): $(app_LIBS) $(mesh_library) $(main_object) $(app_test_LIB) $(depend
 sa:: $(app_analyzer)
 
 compile_commands_all_srcfiles += $(srcfiles)
+
+# Publish this incase someone wants it
+$(APPLICATION_NAME)_INCLUDES := $(app_INCLUDES)
+
+# Restore app_INCLUDES and append the ones for this app
+app_INCLUDES := $(backup_app_INCLUDES) $(app_INCLUDES)

--- a/framework/app_begin.mk
+++ b/framework/app_begin.mk
@@ -1,0 +1,7 @@
+#This makes sure that each app only sees the includes it needs - even through multiple levels
+
+# Save off app_INCLUDES
+backup_app_INCLUDES := $(app_INCLUDES)
+
+# Clear it
+app_INCLUDES :=

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -68,7 +68,7 @@ pcre%.$(obj-suffix) : pcre%.cc
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 %.$(obj-suffix) : %.cc
-	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
+	@echo "MOOSE Compiling C++ (CC) (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
@@ -87,7 +87,7 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 
 %.$(obj-suffix) : %.cpp
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
-	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
+	$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 #

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -14,6 +14,9 @@ pcre_csrcfiles := $(shell find $(pcre_DIR) -name "*.c")
 pcre_objects   := $(patsubst %.cc, %.$(obj-suffix), $(pcre_srcfiles))
 pcre_objects   += $(patsubst %.c, %.$(obj-suffix), $(pcre_csrcfiles))
 pcre_LIB       :=  $(pcre_DIR)/libpcre-$(METHOD).la
+
+$(pcre_objects): app_INCLUDES := -I$(pcre_DIR)/include
+
 # dependency files
 pcre_deps      := $(patsubst %.cc, %.$(obj-suffix).d, $(pcre_srcfiles)) \
 
@@ -73,6 +76,9 @@ moose_objects   += $(patsubst %.f90, %.$(obj-suffix), $(moose_f90srcfiles))
 # dependency files
 moose_deps := $(patsubst %.C, %.$(obj-suffix).d, $(moose_srcfiles)) \
               $(patsubst %.c, %.$(obj-suffix).d, $(moose_csrcfiles))
+
+# Define target specific includes so that when compiling MOOSE files only the includes for MOOSE are on the line
+$(moose_objects): app_INCLUDES := $(moose_INCLUDE)
 
 # clang static analyzer files
 moose_analyzer := $(patsubst %.C, %.plist.$(obj-suffix), $(moose_srcfiles))
@@ -147,6 +153,9 @@ exodiff_APP := $(exodiff_DIR)/exodiff
 exodiff_srcfiles := $(shell find $(exodiff_DIR) -name "*.C")
 exodiff_objects  := $(patsubst %.C, %.$(obj-suffix), $(exodiff_srcfiles))
 exodiff_includes := $(app_INCLUDES) -I$(exodiff_DIR) $(libmesh_INCLUDE)
+
+$(exodiff_objects): app_INCLUDES := $(exodiff_includes)
+
 # dependency files
 exodiff_deps := $(patsubst %.C, %.$(obj-suffix).d, $(exodiff_srcfiles))
 

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -11,6 +11,9 @@ MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
+# Start building this app
+include            $(FRAMEWORK_DIR)/app_begin.mk
+
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk

--- a/modules/modules.mk
+++ b/modules/modules.mk
@@ -52,6 +52,8 @@ MODULE_NAMES := "chemical_reactions contact fluid_properties heat_conduction lev
 ###############################################################################
 
 ifeq ($(CHEMICAL_REACTIONS),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/chemical_reactions
   APPLICATION_NAME   := chemical_reactions
   SUFFIX             := cr
@@ -59,6 +61,8 @@ ifeq ($(CHEMICAL_REACTIONS),yes)
 endif
 
 ifeq ($(CONTACT),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/contact
   APPLICATION_NAME   := contact
   SUFFIX             := con
@@ -66,6 +70,8 @@ ifeq ($(CONTACT),yes)
 endif
 
 ifeq ($(FLUID_PROPERTIES),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/fluid_properties
   APPLICATION_NAME   := fluid_properties
   SUFFIX             := fp
@@ -73,6 +79,8 @@ ifeq ($(FLUID_PROPERTIES),yes)
 endif
 
 ifeq ($(RDG),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/rdg
   APPLICATION_NAME   := rdg
   SUFFIX             := rdg
@@ -80,6 +88,8 @@ ifeq ($(RDG),yes)
 endif
 
 ifeq ($(HEAT_CONDUCTION),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/heat_conduction
   APPLICATION_NAME   := heat_conduction
   SUFFIX             := hc
@@ -87,6 +97,8 @@ ifeq ($(HEAT_CONDUCTION),yes)
 endif
 
 ifeq ($(MISC),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/misc
   APPLICATION_NAME   := misc
   SUFFIX             := misc
@@ -94,6 +106,8 @@ ifeq ($(MISC),yes)
 endif
 
 ifeq ($(NAVIER_STOKES),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/navier_stokes
   APPLICATION_NAME   := navier_stokes
 
@@ -104,6 +118,8 @@ ifeq ($(NAVIER_STOKES),yes)
 endif
 
 ifeq ($(TENSOR_MECHANICS),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/tensor_mechanics
   APPLICATION_NAME   := tensor_mechanics
   SUFFIX             := tm
@@ -111,6 +127,8 @@ ifeq ($(TENSOR_MECHANICS),yes)
 endif
 
 ifeq ($(PHASE_FIELD),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/phase_field
   APPLICATION_NAME   := phase_field
 
@@ -122,6 +140,8 @@ ifeq ($(PHASE_FIELD),yes)
 endif
 
 ifeq ($(RICHARDS),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/richards
   APPLICATION_NAME   := richards
   SUFFIX             := rich
@@ -129,6 +149,8 @@ ifeq ($(RICHARDS),yes)
 endif
 
 ifeq ($(SOLID_MECHANICS),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/solid_mechanics
   APPLICATION_NAME   := solid_mechanics
 
@@ -139,6 +161,8 @@ ifeq ($(SOLID_MECHANICS),yes)
 endif
 
 ifeq ($(STOCHASTIC_TOOLS),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/stochastic_tools
   APPLICATION_NAME   := stochastic_tools
   SUFFIX             := st
@@ -146,6 +170,8 @@ ifeq ($(STOCHASTIC_TOOLS),yes)
 endif
 
 ifeq ($(WATER_STEAM_EOS),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/water_steam_eos
   APPLICATION_NAME   := water_steam_eos
   SUFFIX             := ws
@@ -153,6 +179,11 @@ ifeq ($(WATER_STEAM_EOS),yes)
 endif
 
 ifeq ($(XFEM),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
+  #Dependency on tensor mechanics
+  app_INCLUDES += $(solid_mechanics_INCLUDES)
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/xfem
   APPLICATION_NAME   := xfem
 
@@ -163,6 +194,8 @@ ifeq ($(XFEM),yes)
 endif
 
 ifeq ($(POROUS_FLOW),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/porous_flow
   APPLICATION_NAME   := porous_flow
 
@@ -173,6 +206,8 @@ ifeq ($(POROUS_FLOW),yes)
 endif
 
 ifeq ($(LEVEL_SET),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/level_set
   APPLICATION_NAME   := level_set
   SUFFIX             := ls
@@ -181,6 +216,8 @@ endif
 
 ifeq ($(ALL_MODULES),yes)
   ifneq ($(INCLUDE_COMBINED),no)
+    include            $(FRAMEWORK_DIR)/app_begin.mk
+
     APPLICATION_DIR    := $(MOOSE_DIR)/modules/combined
     APPLICATION_NAME   := combined
     SUFFIX             := comb
@@ -191,6 +228,10 @@ endif
 # The loader should be used for all applications. We
 # only skip it when compiling individual modules
 ifneq ($(SKIP_LOADER),yes)
+  include            $(FRAMEWORK_DIR)/app_begin.mk
+
+  app_INCLUDES  := $(foreach i, $(MODULE_NAMES), -I$(MOOSE_DIR)/modules/$(i)/include/base)
+
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/module_loader
   APPLICATION_NAME   := module_loader
   LIBRARY_SUFFIX     := yes


### PR DESCRIPTION
This is an attempt to fix #10524

The idea is to clear `app_INCLUDES` before setting it up for the app currently being built... then restore it afterward (so that multiple level inclusion works properly).

This relies on using "Target Specific Variable Values" to assign `app_INCLUDES` a different value depending on the target being compiled.  That part works well.

This might not be the very best way to achieve this... but I was going for something that will work without changing the existing system too much (most app's input files won't need to change at all because of this change).

The speed increase of this PR is _staggering_.  Compiling in `modules` with nothing compiled yet the time goes from ~13 minutes to ~4 minutes using `-j 100` on the icecream network!

I expect that this will be a HUGE win for CIVET... and possibly even a bigger win on Falcon!  This will also be a big win for people on slower computers and virtual machines.

However: I must admit that this is a bandaid over the actual problem... the number of include paths in MOOSE and modules (and apps) is growing to be huge.  I'm not quite sure what we're going to do about this in the long term....