### PR TITLE
Enable materials to get phase number etc from fluidstate userobjects

### DIFF
--- a/modules/porous_flow/include/materials/PorousFlowFluidStateFlashBase.h
+++ b/modules/porous_flow/include/materials/PorousFlowFluidStateFlashBase.h
@@ -82,6 +82,8 @@ protected:
   std::vector<unsigned int> _zvar;
   /// Number of coupled total mass fractions. Should be _num_phases - 1
   const unsigned int _num_z_vars;
+  /// FluidState UserObject
+  const PorousFlowFluidStateBase & _fs_base;
   /// Phase number of the aqueous phase
   const unsigned int _aqueous_phase_number;
   /// Phase number of the gas phase

--- a/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
@@ -67,6 +67,36 @@ public:
   PorousFlowFluidStateBase(const InputParameters & parameters);
 
   /**
+   * The maximum number of phases in this model
+   * @return number of phases
+   */
+  unsigned int numPhases() const;
+
+  /**
+   * The index of the aqueous phase
+   * @return aqueous phase number
+   */
+  unsigned int aqueousPhaseIndex() const;
+
+  /**
+   * The index of the gas phase
+   * @return gas phase number
+   */
+  unsigned int gasPhaseIndex() const;
+
+  /**
+   * The index of the aqueous fluid component
+   * @return aqueous fluid component number
+   */
+  unsigned int aqueousComponentIndex() const;
+
+  /**
+   * The index of the gas fluid component
+   * @return gas fluid component number
+   */
+  unsigned int gasComponentIndex() const;
+
+  /**
    * Clears the contents of the FluidStateProperties data structure
    * @param[out] fsp FluidStateProperties data structure with all data initialized to 0
    */

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateBrineCO2.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateBrineCO2.C
@@ -14,7 +14,6 @@ InputParameters
 validParams<PorousFlowFluidStateBrineCO2>()
 {
   InputParameters params = validParams<PorousFlowFluidStateFlashBase>();
-  params.addRequiredParam<UserObjectName>("fluid_state", "Name of the FluidState UserObject");
   params.addCoupledVar("xnacl", 0, "The salt mass fraction in the brine (kg/kg)");
   params.addClassDescription("Fluid state class for brine and CO2");
   return params;

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateWaterNCG.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateWaterNCG.C
@@ -14,7 +14,6 @@ InputParameters
 validParams<PorousFlowFluidStateWaterNCG>()
 {
   InputParameters params = validParams<PorousFlowFluidStateFlashBase>();
-  params.addRequiredParam<UserObjectName>("fluid_state", "Name of the FluidState UserObject");
   params.addClassDescription("Fluid state class for water and non-condensable gas");
   return params;
 }

--- a/modules/porous_flow/src/userobjects/PorousFlowFluidStateBase.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowFluidStateBase.C
@@ -46,6 +46,36 @@ PorousFlowFluidStateBase::PorousFlowFluidStateBase(const InputParameters & param
                " is larger than the number of fluid components");
 }
 
+unsigned int
+PorousFlowFluidStateBase::numPhases() const
+{
+  return _num_phases;
+}
+
+unsigned int
+PorousFlowFluidStateBase::aqueousPhaseIndex() const
+{
+  return _aqueous_phase_number;
+}
+
+unsigned int
+PorousFlowFluidStateBase::gasPhaseIndex() const
+{
+  return _gas_phase_number;
+}
+
+unsigned int
+PorousFlowFluidStateBase::aqueousComponentIndex() const
+{
+  return _aqueous_fluid_component;
+}
+
+unsigned int
+PorousFlowFluidStateBase::gasComponentIndex() const
+{
+  return _gas_fluid_component;
+}
+
 void
 PorousFlowFluidStateBase::clearFluidStateProperties(std::vector<FluidStateProperties> & fsp) const
 {


### PR DESCRIPTION
This change also allows the check on the number of phases in the material to not need a hard coded number 2.

Closes #10528