### PR TITLE
Make the TestHarness ignore .git directories.

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -188,8 +188,11 @@ class TestHarness:
             self.base_dir = os.getcwd()
             for dirpath, dirnames, filenames in os.walk(self.base_dir, followlinks=True):
                 # Prune submdule paths when searching for tests
-                if self.base_dir != dirpath and os.path.exists(os.path.join(dirpath, '.git')):
+
+                dir_name = os.path.basename(dirpath)
+                if (self.base_dir != dirpath and os.path.exists(os.path.join(dirpath, '.git'))) or dir_name in [".git", ".svn"]:
                     dirnames[:] = []
+                    filenames[:] = []
 
                 # walk into directories that aren't contrib directories
                 if "contrib" not in os.path.relpath(dirpath, os.getcwd()):


### PR DESCRIPTION
I reproduced the problem in #10435 by putting an invalid `tests` file in bison/.git/ and bison/moose/

Before this patch, both were found by the TestHarness and showed parser errors.
Ran fine after this patch.

closes #10435 
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
