### PR TITLE
Another fix to VTKWindowPlugin highlight crash

### DIFF
--- a/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
@@ -106,12 +106,16 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
         """
         Clears the VTK windows and restarts the initialize timer.
         """
+        self._window.reset()
         self._window.clear()
-        self._window.update()
         self._initialized = False
         self._reset_required = False
         self._highlight = None
         self._adjustTimers(start=['initialize'], stop=['update'])
+        self._result = None
+        self._reader = None
+        self.setLoadingMessage('No file selected.')
+        self.setEnabled(False)
         self.windowReset.emit()
 
     def onReloadWindow(self):
@@ -176,24 +180,20 @@ class VTKWindowPlugin(QtWidgets.QFrame, ExodusPlugin):
             self.setEnabled(True)
 
         # Display loading message
-        elif self._peacock_logo not in self._window:
-            if self._filename:
-                msg = '{} does not currently exist.\nIt will load automatically when it is created.'
-                self._peacock_text.update(text=msg.format(self._filename))
-
-            self._window.reset()
-            self._result = None
-            self._reader = None
-            self._window.append(self._peacock_logo)
-            self._window.append(self._peacock_text)
-            self._window.update()
-            self.setEnabled(False)
+        elif self._filename:
+            msg = '{} does not currently exist.\nIt will load automatically when it is created.'
+            self.setLoadingMessage(msg.format(self._filename))
+        else:
+            self.setLoadingMessage("No file selected.")
 
     def setLoadingMessage(self, msg):
         """
         Set the text shown when there isn't a file.
         """
         self._peacock_text.update(text=msg)
+        if self._peacock_logo not in self._window:
+            self._window.append(self._peacock_logo)
+            self._window.append(self._peacock_text)
         self._window.update()
 
     def onInputFileChanged(self, *args):


### PR DESCRIPTION
Looks like #10523 didn't fix the problem: https://www.moosebuild.org/job/146226/
Not exactly sure how the VTKWindowPlugin gets in this state, ie initialized but self._results being None.

closes #10539

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
