### PR TITLE
Elasticity tensor and Rank*Aux documentation

### DIFF
--- a/docs/content/bib/tensor_mechanics.bib
+++ b/docs/content/bib/tensor_mechanics.bib
@@ -125,3 +125,20 @@
     Title = {Energy {Relations} and the {Energy}-{Momentum} {Tensor} in {Continuum} {Mechanics}},
     Year = {1999}}
 
+@book{slaughter2012linearized,
+  title={The Linearized Theory of Elasticity},
+  author={Slaughter, William S},
+  year={2012},
+  publisher={Springer Science \& Business Media}}
+
+@book{malvern1969introduction,
+  title={Introduction to the Mechanics of a Continuous Medium},
+  author={Malvern, Lawrence E},
+  year={1969},
+  publisher={Prentice-Hall}}
+
+@book{hjelmstad2007fundamentals,
+  title={Fundamentals of Structural Mechanics},
+  author={Hjelmstad, Keith D},
+  year={2007},
+  publisher={Springer Science \& Business Media}}

--- a/docs/content/documentation/systems/AuxKernels/tensor_mechanics/CylindricalRankTwoAux.md
+++ b/docs/content/documentation/systems/AuxKernels/tensor_mechanics/CylindricalRankTwoAux.md
@@ -1,7 +1,29 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# CylindricalRankTwoAux
+# Cylindrical Rank Two Aux
 !syntax description /AuxKernels/CylindricalRankTwoAux
+
+## Description
+The AuxKernel `CylindricalRankTwoAux` transforms a Rank-2 tensor, $T$, into cylinderical coordinates, where the cylindrical rotation axis is along the Cartesian $\hat{z}$ axis and the user-defined center point lies within the Cartesian $\hat{x}$-$\hat{y}$ plane, as shown in Eq \eqref{eq:cylindrical_rank_two_aux}.
+The AuxKernel will save the component of the tranformed Rank-2 tensor, $T^R$, as defined by the arguments for the `index_i` and `index_j` parameters.
+\begin{equation}
+\label{eq:cylindrical_rank_two_aux}
+T^R_{ij} = \mathbf{R} \cdot \mathbf{T} \cdot \mathbf{R}^T
+\end{equation}
+The rotation tensor $R$ is defined as
+\begin{equation}
+\label{eq:cylindrical_rotation_tensor}
+  R = \begin{bmatrix}
+      cos(\theta) & sin(\theta) \\
+      -sin(\theta) & cos(\theta)
+      \end{bmatrix}
+      \quad \text{ where } \quad \theta = atan2 \left( \frac{P^{qp}_y - P^c_y}{P^{qp}_x - P^c_x} \right)
+\end{equation}
+where $P^{qp}$ is the location of the current quadrature point being evaluated and $P^c$ is the center point defined by the user with the parameter `center_point` in the input file.
+
+## Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/CylindricalRankTwoAux/test.i block=AuxKernels/stress_tt
+
+and an AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `CylindricalRankTwoAux` block.
+!listing modules/tensor_mechanics/test/tests/CylindricalRankTwoAux/test.i block=AuxVariables/stress_tt
 
 !syntax parameters /AuxKernels/CylindricalRankTwoAux
 

--- a/docs/content/documentation/systems/AuxKernels/tensor_mechanics/RankFourAux.md
+++ b/docs/content/documentation/systems/AuxKernels/tensor_mechanics/RankFourAux.md
@@ -1,7 +1,39 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# RankFourAux
+# Rank Four Aux
 !syntax description /AuxKernels/RankFourAux
+
+## Description
+The AuxKernel `RankFourAux` is used to save single components of Rank-4 tensors into an AuxVariable for visualization and/or post-processing purposes, similar to the functionality provided by [RankTwoAux](/RankTwoAux.md) for Rank-2 tensors
+`RankFourAux` is commonly used to output components of the elasticity (or stiffness) tensor, $C_{ijkl}$, in mechanics simulations.
+
+The `RankFourAux` takes as arguments the values of the `index_i`, `index_j`, `index_k`, and `index_l` for the single Rank-4 tensor component to save into an AuxVariable.
+\begin{equation}
+\label{eq:rank4tensor_aux_indices}
+  \begin{aligned}
+        C_{ijkl} \implies & \underbrace{\begin{bmatrix}
+                      C_{11} & C_{12} & C_{13} & C_{14} & C_{15} & C_{16} \\
+                      C_{21} & C_{22} & C_{23} & C_{24} & C_{25} & C_{26} \\
+                      C_{31} & C_{32} & C_{33} & C_{34} & C_{35} & C_{36} \\
+                      C_{41} & C_{42} & C_{43} & C_{44} & C_{45} & C_{46} \\
+                      C_{51} & C_{52} & C_{53} & C_{54} & C_{55} & C_{56} \\
+                      C_{61} & C_{62} & C_{63} & C_{64} & C_{65} & C_{66}
+                      \end{bmatrix}}_{\text{textbook notation}} \\[5.0em]
+         \implies & \underbrace{\begin{bmatrix}
+                      C_{0000} & C_{0011} & C_{0022} & C_{0012} & C_{0020} & C_{0001} \\
+                      C_{1100} & C_{1111} & C_{1122} & C_{1112} & C_{1120} & C_{1101} \\
+                      C_{2200} & C_{2211} & C_{2222} & C_{2212} & C_{2220} & C_{2201} \\
+                      C_{1200} & C_{1211} & C_{1222} & C_{1212} & C_{1220} & C_{1201} \\
+                      C_{2000} & C_{2011} & C_{2022} & C_{2012} & C_{2020} & C_{2001} \\
+                      C_{0100} & C_{0111} & C_{0122} & C_{0112} & C_{0120} & C_{0101}
+                      \end{bmatrix}}_{\text{Rank Four Aux indices}}
+  \end{aligned}
+\end{equation}
+Eq \eqref{eq:rank4tensor_aux_indices} shows the index values for a linear hyperelastic stiffness tensor with 21 indepent material parameters; the various available elasticity tensor symmetry options is discussed in the material [ComputeElasticityTensor](/Materials/tensor_mechanics/ComputeElasticityTensor.md) documentation.
+
+## Example Input File Syntax
+!listing modules/combined/test/tests/linear_elasticity/tensor.i block=AuxKernels/matl_C25
+
+An AuxVariable is required to store the `RankFourAux` AuxKernel information. Note that the name of the AuxVariable is used as the arguement for the `variable` input parameter in the `RankFourAux` block.
+!listing modules/combined/test/tests/linear_elasticity/tensor.i block=AuxVariables/C25
 
 !syntax parameters /AuxKernels/RankFourAux
 

--- a/docs/content/documentation/systems/AuxKernels/tensor_mechanics/RankTwoAux.md
+++ b/docs/content/documentation/systems/AuxKernels/tensor_mechanics/RankTwoAux.md
@@ -1,7 +1,31 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# RankTwoAux
+# Rank Two Aux
 !syntax description /AuxKernels/RankTwoAux
+
+## Description
+The AuxKernel `RankTwoAux` is used to save single components of Rank-2 tensors into an AuxVariable for visualization and/or post-processing purposes. An antisymmetric Rank-2 tensor would require nine separate `RankTwoAux` AuxKernel-AuxVariable pairs to store all of the components of the antisymmetric Rank-2 tensor; six separate AuxKernel-AuxVariable pairs are required to print out all the unique components of a symmetric Rank-2 tensor.
+Quantities commonly examined with `RankTwoAux` are stress ($\boldsymbol{\sigma}$) and strain ($\boldsymbol{\epsilon}$).
+
+The `RankTwoAux` takes as arguments the values of the `index_i` and the `index_j` for the single tensor component to save into an AuxVariable.
+Eq \eqref{eq:rank2tensor_aux_indices} shows the index values for each Rank-2 tensor component.
+\begin{equation}
+\label{eq:rank2tensor_aux_indices}
+\sigma_{ij} \implies \begin{bmatrix}
+                      \sigma_{00} & \sigma_{01} & \sigma_{02} \\
+                      \sigma_{10} & \sigma_{11} & \sigma_{12} \\
+                      \sigma_{20} & \sigma_{21} & \sigma_{22}
+                      \end{bmatrix}
+\end{equation}
+
+If desired, `RankTwoAux` can be restricted to save data from a Rank-2 tensor at a single specified quadrature point per element. This option is generally used for debugging purposes.
+
+## Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxKernels/stress_xy
+
+An AuxVariable is required to store the `RankTwoAux` AuxKernel information. Note that the name of the AuxVariable is used as the arguement for the `variable` input parameter in the `RankTwoAux` block.
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxVariables/stress_xy
+
+!!! info "Elemental vs Nodal Visualization of Quadrature Field Values"
+    Using an AuxVariable with `family = MONOMIAL` and `order = CONSTANT` will give a constant value of the AuxVariable for the entire element, which is computed by taking a volume-weighted average of the integration point quantities. Using an AuxVariable with `family = MONOMIAL` and `order = FIRST` or higher will result in fields that vary linearly (or with higher order) within each element, which are computed using a local least-squares procedure. Because the Exodus mesh format does not support higher-order elemental variables, these AuxVariables are output by libMesh as nodal variables for visualization purposes. Using higher order monomial variables in this way can produce smoother visualizations of results for a properly converged simulation.
 
 !syntax parameters /AuxKernels/RankTwoAux
 

--- a/docs/content/documentation/systems/AuxKernels/tensor_mechanics/RankTwoScalarAux.md
+++ b/docs/content/documentation/systems/AuxKernels/tensor_mechanics/RankTwoScalarAux.md
@@ -1,10 +1,242 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# RankTwoScalarAux
+# Rank Two Scalar Aux
 !syntax description /AuxKernels/RankTwoScalarAux
+
+##Description
+The AuxKernel `RankTwoScalarAux` provides methods to calculate several different scalar quantities for a Rank-2 tensor, described below.
+In some types of calculations, the scalar quantity is calculated in a user-specified direction (by default set to the (0, 0, 1) axis); in other calculation types the user can specify the start and end points of a line along which the scalar quantity is calculated.
+Quantities commonly examined with `RankTwoScalarAux` are stress ($\boldsymbol{\sigma}$) and strain ($\boldsymbol{\epsilon}$).
+
+If desired, `RankTwoScalarAux` can be restricted to calculate the scalar quantity data for a Rank-2 tensor at a single specified quadrature point per element. This option is generally used only for debugging purposes.
+
+## Axial Stress
+The scalar type `AxialStress` calculates the scalar value of a Rank-2 tensor, $T$, in the direction of the axis specified by the user.
+The user should give the starting point, $P^1$, and the end point, $P^2$ which define the axis.
+
+\begin{equation}
+\label{eq:axial_stress_scalar_type}
+s = \hat{a}_i T_{ij} \hat{a}_j \quad \text{ where } \quad \hat{a}_i = \frac{P^2_i - P^1_i}{\left| P^2_i - P^1_i \right|}
+\end{equation}
+where $\hat{a}$ is the normalized direction vector for the axis defined by the points $P^1$ and $P^2$.
+
+## Direction
+The scalar type `direction` calculates the scalar value of a Rank-2 tensor, $T$, in the direction selected by the user as shown by Eq \eqref{eq:direction_scalar_type}:
+\begin{equation}
+\label{eq:direction_scalar_type}
+s = D_i T_{ij} D_j
+\end{equation}
+where $D$ is the direction vector specified in the input file.
+
+### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxKernels/direction
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxVariables/direction
+
+## Effective Strain
+The scalar type `EffectiveStrain` calculates an effective scalar measure of a Rank-2 tensor, often strain ($\epsilon_{ij}$) according to Eq
+\eqref{eq:effective_strain_scalar_type}.
+\begin{equation}
+\label{eq:effective_strain_scalar_type}
+s = \sqrt{\frac{2}{3} \epsilon_{ij} \epsilon_{ij}}
+\end{equation}
+
+!!! warning "This Strain Measure is not for Inelastic Strains"
+    This effective strain measure, `EffectiveStrain`, should not be confused with the effective plastic strain or effective creep strain, which are computed as integrals over the history of the inelastic strain; these effective inelastic strain measures are computed as scalar material properties (named `effective_plastic_strain` and `effective_creep_strain`) for applicable $J_2$ models. The effective inelastic strains are computed as:
+    \begin{equation}
+    s = \int_t\sqrt{\frac{2}{3} \dot{\epsilon}^p_{ij} \dot{\epsilon}^p_{ij}} \mathrm{d}t
+    \end{equation}
+    where $t$ is time and $\dot{\epsilon}^p_{ij}$ is the inelastic strain increment.
+
+### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/auxkernels/ranktwoscalaraux.i block=AuxKernels/peeq
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/auxkernels/ranktwoscalaraux.i block=AuxVariables/peeq
+
+## Hoop Stress
+The scalar type `HoopStress` calculates the value of a Rank-2 tensor along the hoop direction of a cylinder, shown in Eq \eqref{eq:hoop_stress_scalar_type}.
+The cylinder is defined with a normal vector from the current position to the cylinder surface and a user specified axis of rotation.
+The user defines this rotation axis with a starting point, $P^1$, and the end point, $P^2$.
+
+\begin{equation}
+\label{eq:hoop_stress_scalar_type}
+s = \hat{n}^h_i T_{ij} \hat{n}^h_j
+\end{equation}
+where $\hat{n}^h$ is the hoop direction normal, defined as
+\begin{equation}
+\label{eq:hoop_direction_normal}
+  \begin{aligned}
+    \hat{n}^h & = \hat{n}^c \times \hat{a} \\
+    \hat{n}^c & = \frac{P^c - \hat{n}^r}{\left| P^c - \hat{n}^r \right|} \\
+    \hat{a} & = \frac{P^2 - P^1}{\left| P^2 - P^1 \right|}
+  \end{aligned}
+\end{equation}
+where $P^c$ is the current sampling position point, and $\hat{n}^r$ is the direction normal to the plane defined by the cylinder axis of rotation vector and the direction normal to the axis of rotation at the current position $P^c$.
+
+### Example Input File Syntax
+!listing modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d.i block=AuxKernels/hoop_stress
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d.i block=AuxVariables/hoop_stress
+
+## Hydrostatic Stress
+The scalar type `Hydrostatic` calculates the hydrostatic scalar of a Rank-2 tensor, $T_{ij}$, as shown in Eq \eqref{eq:hydrostatic_scalar_type}.
+\begin{equation}
+\label{eq:hydrostatic_scalar_type}
+s = \frac{Tr \left( T_{ij} \right)}{3} = \frac{T_{ii}}{3}
+\end{equation}
+
+### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim.i block=AuxKernels/pressure
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim.i block=AuxVariables/pressure
+
+
+## Invariant Values
+### First Invariant
+The scalar type `FirstInvariant` calculates the first invariant of the specified Rank-2 tensor, $T_{ij}$, according to Eq \eqref{eq:first_invariant_scalar_type} from \cite{malvern1969introduction}.
+\begin{equation}
+\label{eq:first_invariant_scalar_type}
+I_T = Tr \left( T_{ij} \right) = T_{ii}
+\end{equation}
+
+#### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxKernels/fi
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxVariables/firstinv
+
+### Second Invariant
+Similarly, the scalar type `SecondInvariant` finds the second invariant of the Rank-2 tensor, $T_{ij}$, as shown in Eq \eqref{eq:second_invariant_scalar_type}
+This method is defined in \cite{hjelmstad2007fundamentals}.
+\begin{equation}
+\label{eq:second_invariant_scalar_type}
+II_T = T_{ii} T_{jj} - \frac{1}{2} \left( T_{ij} T_{ij} + T_{ji} T_{ji} \right)
+\end{equation}
+
+#### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxKernels/si
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxVariables/secondinv
+
+### Third Invariant
+The scalar type `ThirdInvariant` computes the value of the Rank-2 tensor, $T_ij$, third invariant as given in Eq \eqref{eq:third_invariant_scalar_type} from \cite{malvern1969introduction}.
+\begin{equation}
+\label{eq:third_invariant_scalar_type}
+III_T = det \left( T_{ij} \right)  = \frac{1}{6} e_{ijk} e_{pqr} T_{ip} T_{jq} T_{kr}
+\end{equation}
+where $e$ is the Rank-3 permutation tensor.
+
+#### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxKernels/ti
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxVariables/thirdinv
+
+
+## L2 Norm
+The scalar type `L2Norm` calculates the L2 normal of a Rank-2 tensor, $T_{ij}$, as shown in Eq \eqref{eq:l2_norm_scalar_type}.
+\begin{equation}
+\label{eq:l2_norm_scalar_type}
+s = \sqrt{T_{ij} T_{ij}}
+\end{equation}
+
+## Principal Values
+### Maximum Principal Quantity
+The scalar type `MaxPrincipal` calculates the largest principal value for a symmetric tensor, using the calcEigenValues method from the Rank Two Tensor utility class.
+
+#### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxKernels/maxprincipal
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxVariables/maxprincipal
+
+### Middle Principal Quantity
+Similarly, the scalar type `MidPrincipal` finds the second largest principal value for a symmetric tensor, using the calcEigenValues method from the Rank Two Tensor utility class.
+
+#### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxKernels/midprincipal
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxVariables/midprincipal
+
+### Minimum Principal Quantity
+The scalar type `MinPrincipal` computes the smallest principal value for a symmetric tensor, using the calcEigenValues method from the Rank Two Tensor utility class.
+
+#### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxKernels/minprincipal
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=AuxVariables/minprincipal
+
+
+## Radial Stress
+The scalar type `RadialStress` calculates the scalar component for a Rank-2 tensor, $T_{ij}$, in the direction of the normal vector from the user-defined axis of rotation, as shown in Eq \eqref{eq:radial_stress_scalar_type}.
+\begin{equation}
+\label{eq:radial_stress_scalar_type}
+s = \hat{n}^r_i T_{ij} \hat{n}^r_j
+\end{equation}
+where $\hat{n}^r$ is the direction normal to the plane defined by the cylinder axis of rotation vector and the direction normal to the axis of rotation at the current position $P^c$.
+
+### Example Input File Syntax
+!listing modules/porous_flow/test/tests/thm_rehbinder/free_outer.i block=AuxKernels/stress_rr
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/porous_flow/test/tests/thm_rehbinder/free_outer.i block=AuxVariables/stress_rr
+
+## Triaxiality Stress
+The scalar type `TriaxialityStress` finds the ratio of the hydrostatic measure, $T_{hydrostatic}$, to the von Mises measure, $T_{vonMises}$, as shown in Eq \eqref{eq:triaxiality_scalar_type}.
+As the name suggests, this scalar measure is most often used for stress tensors.
+\begin{equation}
+\label{eq:triaxiality_scalar_type}
+s = \frac{T_{hydrostatic}}{T_{vonMises}} = \frac{\frac{1}{3} T_{ii}}{\sqrt{\frac{3}{2} S_{ij} S_{ij}}}
+\end{equation}
+where $S_{ij}$ is the deviatoric tensor of the Rank-2 tensor $T_{ij}$.
+
+## Volumetric Strain
+The scalar type `VolumetricStrain` computes the change in volume divided by the original volume and is most appliable for strain.
+For a Rank-2 tensor, $T_{ij}$, the volumetric strain quantity is calculated with Eq \eqref{eq:volumetric_strain_scalar_type}.
+\begin{equation}
+\label{eq:volumetric_strain_scalar_type}
+s = T_{11} \cdot \left( T_{22} + T_{33} \right) + T_{22} \cdot T_{33} + T_{11} \cdot T_{22} \cdot T_{33}
+\end{equation}
+
+### Example Input File Syntax
+!listing modules/combined/test/tests/internal_volume/rz_displaced.i block=AuxKernels/fred
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/combined/test/tests/internal_volume/rz_displaced.i block=AuxVariables/volumetric_strain
+
+## Von Mises Stress
+The scalar type `VonMisesStress` calculates the vonMises measure for a Rank-2 tensor, as shown in Eq \eqref{eq:vonmises_scalar_type}.
+This quantity is usually applied to the stress tensor.
+\begin{equation}
+\label{eq:vonmises_scalar_type}
+s = \sqrt{\frac{3}{2} S_{ij} S_{ij}}
+\end{equation}
+where $S_{ij}$ is the deviatoric tensor of the Rank-2 tensor $T_{ij}$.
+
+### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i block=AuxKernels/vonmises
+
+An AuxVariable is required to store the AuxKernel information. Note that the name of the AuxVariable is used as the argument for the `variable` input parameter in the `RankTwoScalarAux` block.
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i block=AuxVariables/vonmises
+
+As with the [RankTwoAux](/RankTwoAux.md) AuxKernel, `RankTwoScalarAux` requires the inclusion of an AuxVariable block for each AuxKernel block.
+
+## AuxVariable Order
+
+!!! info "Elemental vs Nodal Visualization of Quadrature Field Values"
+    Using an AuxVariable with `family = MONOMIAL` and `order = CONSTANT` will give a constant value of the AuxVariable for the entire element, which is computed by taking a volume-weighted average of the integration point quantities. Using an AuxVariable with `family = MONOMIAL` and `order = FIRST` or higher will result in fields that vary linearly (or with higher order) within each element, which are computed using a local least-squares procedure. Because the Exodus mesh format does not support higher-order elemental variables, these AuxVariables are output by libMesh as nodal variables for visualization purposes. Using higher order monomial variables in this way can produce smoother visualizations of results for a properly converged simulation.
 
 !syntax parameters /AuxKernels/RankTwoScalarAux
 
 !syntax inputs /AuxKernels/RankTwoScalarAux
 
 !syntax children /AuxKernels/RankTwoScalarAux
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{tensor_mechanics.bib}

--- a/docs/content/documentation/systems/Materials/tensor_mechanics/ComputeElasticityTensor.md
+++ b/docs/content/documentation/systems/Materials/tensor_mechanics/ComputeElasticityTensor.md
@@ -1,10 +1,182 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# ComputeElasticityTensor
+# Compute Elasticity Tensor
 !syntax description /Materials/ComputeElasticityTensor
+
+## Description
+The material `ComputeElasticityTensor` builds the elasticity (stiffness) tensor with various user-selected material symmetry options.
+`ComputeElasticityTensor` also rotates the elasticity tensor during the initial time step only; this class does not rotate the elasticity tensor during the simulation.
+The initial rotation is only performed if the user provides arguments to the three Euler angle parameters.
+
+For a general stiffness tensor with 21 independent components, the elasticity tensor within the tensor mechanics module can be represented with the notation shown in Eq \eqref{eq:rank4tensor_aux_indices}.
+Nonetheless, the full Rank-4 tensor with all 81 components is created by `ComputeElasticityTensor`.
+\begin{equation}
+\label{eq:rank4tensor_aux_indices}
+  \begin{aligned}
+        C_{ijkl} \implies & \underbrace{\begin{bmatrix}
+                      C_{11} & C_{12} & C_{13} & C_{14} & C_{15} & C_{16} \\
+                      C_{21} & C_{22} & C_{23} & C_{24} & C_{25} & C_{26} \\
+                      C_{31} & C_{32} & C_{33} & C_{34} & C_{35} & C_{36} \\
+                      C_{41} & C_{42} & C_{43} & C_{44} & C_{45} & C_{46} \\
+                      C_{51} & C_{52} & C_{53} & C_{54} & C_{55} & C_{56} \\
+                      C_{61} & C_{62} & C_{63} & C_{64} & C_{65} & C_{66}
+                      \end{bmatrix}}_{\text{textbook engineering notation}} \\[5.0em]
+         \implies & \underbrace{\begin{bmatrix}
+                                   C_{1111} & C_{1122} & C_{1133} & C_{1123} & C_{1131} & C_{1112} \\
+                                   C_{2211} & C_{2222} & C_{2233} & C_{2223} & C_{2231} & C_{2212} \\
+                                   C_{3311} & C_{3322} & C_{3333} & C_{3323} & C_{3331} & C_{3312} \\
+                                   C_{2311} & C_{2322} & C_{2333} & C_{2323} & C_{2331} & C_{2312} \\
+                                   C_{3111} & C_{3122} & C_{3133} & C_{3123} & C_{3131} & C_{3112} \\
+                                   C_{1211} & C_{1222} & C_{1233} & C_{1223} & C_{1231} & C_{1212}
+                                   \end{bmatrix}}_{\text{textbook Einstein index notation}} \\[5.0em]
+         \implies & \underbrace{\begin{bmatrix}
+                      C_{0000} & C_{0011} & C_{0022} & C_{0012} & C_{0020} & C_{0001} \\
+                      C_{1100} & C_{1111} & C_{1122} & C_{1112} & C_{1120} & C_{1101} \\
+                      C_{2200} & C_{2211} & C_{2222} & C_{2212} & C_{2220} & C_{2201} \\
+                      C_{1200} & C_{1211} & C_{1222} & C_{1212} & C_{1220} & C_{1201} \\
+                      C_{2000} & C_{2011} & C_{2022} & C_{2012} & C_{2020} & C_{2001} \\
+                      C_{0100} & C_{0111} & C_{0122} & C_{0112} & C_{0120} & C_{0101}
+                      \end{bmatrix}}_{\text{Compute Elasticity Tensor indices}}
+  \end{aligned}
+\end{equation}
+
+There are several different material symmetry options that a user can apply to build the elasticity tensor for a mechanics simulation that are discussed below.
+
+## General Symmetry
+The fill method `symmetric21` is used to create the elasticity tensor for a linear hyperelastic material with 21 independent components: the symmetries shown in Eq \eqref{eq:symmetric21_cijkl_cases} are used to determine the independent components \cite{slaughter2012linearized}.
+\begin{equation}
+\label{eq:symmetric21_cijkl_cases}
+  \begin{aligned}
+    C_{ijkl} & = C_{jikl} \impliedby \quad \text{satisfies angular momentum} \\
+    C_{ijkl} & = C_{ijlk} \impliedby \quad \text{symmetric strain tensor assumption} \\
+    C_{ijkl} & = C_{klij} \impliedby \quad \text{linear hyperelastic material assumption}
+  \end{aligned}
+\end{equation}
+
+### Example Input File Syntax
+!listing modules/combined/test/tests/linear_elasticity/tensor.i block=Materials/elasticity_tensor
+
+which shows the expected order of the elasticity tensor components in the input argument string.
+
+## Orthotropic Symmetry
+The fill method `symmetric9` is appropriate for materials with three orthotropic planes of symmetry \cite{malvern1969introduction}, and is often used for simulations of anistropic materials such as cubic crystals.
+The enginering elasticity tensor notation, Eq \eqref{eq:rank4tensor_aux_indices}, for an orthotropic material is given in Eq \eqref{eq:symmetric9_fill_method}
+\begin{equation}
+\label{eq:symmetric9_fill_method}
+C_{ijkl}^{orthotropic} = \begin{bmatrix}
+              C_{11} & C_{12} & C_{13} &      0 &      0 &      0 \\
+              C_{12} & C_{22} & C_{23} &      0 &      0 &      0 \\
+              C_{13} & C_{23} & C_{33} &      0 &      0 &      0 \\
+                   0 &      0 &      0 & C_{44} &      0 &      0 \\
+                   0 &      0 &      0 &      0 & C_{55} &      0 \\
+                   0 &      0 &      0 &      0 &      0 & C_{66}
+              \end{bmatrix}
+\end{equation}
+
+### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i block=Materials/elasticity_tensor
+
+In the Einstein index notation shown in Eq \eqref{eq:rank4tensor_aux_indices}, the parameter `C_ijkl` expects the elasticity components in the order `C_ijkl = '1111 1122 1133 2222 2233 3333 2323 3131 1212'` for the `symmetric9` fill method option.
+
+## Linear Isotropic Symmetry
+The two constant istropic symmetry fill methods `symmetric_isotropic` and `symmetric_isotropic_E_nu` are used in the dedicated isotropic elasticity tensor [ComputeIsotropicElasticityTensor](/ComputeIsotropicElasticityTensor.md).
+These two fill methods use the symmetries shown in Eq \eqref{eq:symmetric_isotropic_fill_method} to build the elasticity tensor.
+\begin{equation}
+\label{eq:symmetric_isotropic_fill_method}
+C_{ijkl} = C_{klij} = C_{jikl} = C_{jilk}
+\end{equation}
+Please see the documentation page for [ComputeIsotropicElasticityTensor](/ComputeIsotropicElasticityTensor.md) for details and examples of the input file syntax for linear elastic isotropic elasticity tensors.
+
+## Antisymmetric Isotropic Symmetry
+The fill method `antisymmetric_isotropic` is used for an antisymmetric isotropic material in a shear case.
+The elasticity tensor is built using the symmetries shown in Eq \eqref{eq:antisymmetric_isotropic_fill_method}
+\begin{equation}
+\label{eq:antisymmetric_isotropic_fill_method}
+C_{ijkl}^{antisymmetric-isotropic} = \kappa e_{ijm} e_{klm}
+\end{equation}
+where $e$ is the permutation tensor and $m$ is the summation index.
+
+## Transverse Isotropic (Axisymmetric)
+The fill method `axisymmetric_rz` is used for materials which are isotropic with respect to an axis of symmetry, such as a material composed of fibers which are parallel to the axis of symmetry \cite{slaughter2012linearized}.
+The engineering notation matrix in this case is shown by Eq \eqref{eq:axisymmetric_rz_fill_method}.
+\begin{equation}
+\label{eq:axisymmetric_rz_fill_method}
+C_{ijkl}^{axisymmetric} = \begin{bmatrix}
+              C_{11} & C_{12} & C_{13} &      0 &      0 &      0 \\
+              C_{12} & C_{22} & C_{13} &      0 &      0 &      0 \\
+              C_{13} & C_{13} & C_{33} &      0 &      0 &      0 \\
+                   0 &      0 &      0 & C_{44} &      0 &      0 \\
+                   0 &      0 &      0 &      0 & C_{44} &      0 \\
+                   0 &      0 &      0 &      0 &      0 & \frac{1}{2} \left( C_{11} - C_{22} \right)
+              \end{bmatrix}
+\end{equation}
+
+### Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/isotropic_elasticity_tensor/2D-axisymmetric_rz_test.i block=Materials/elasticity_tensor
+
+In the Einstein index notation shown in Eq \eqref{eq:rank4tensor_aux_indices}, the parameter `C_ijkl` expects the elasticity components in the order `C_ijkl = '1111, 1122, 1133, 3333, 2323'` for the `axisymmetric_rz` fill method option.
+
+## Principal Directions for Stress and Strain
+The fill method `principal` is appropriate for the case when the principal directions of strain and stress align.
+The engineering notation representation of the elasticity tensor is shown in Eq \eqref{eq:principal_fill_method}.
+\begin{equation}
+\label{eq:principal_fill_method}
+C_{ijkl}^{orthotropic} = \begin{bmatrix}
+              C_{11} & C_{12} & C_{13} &      0 &      0 &      0 \\
+              C_{21} & C_{22} & C_{23} &      0 &      0 &      0 \\
+              C_{31} & C_{32} & C_{33} &      0 &      0 &      0 \\
+                   0 &      0 &      0 &      0 &      0 &      0 \\
+                   0 &      0 &      0 &      0 &      0 &      0 \\
+                   0 &      0 &      0 &      0 &      0 &      0
+              \end{bmatrix}
+\end{equation}
+
+In the Einstein index notation shown in Eq \eqref{eq:rank4tensor_aux_indices}, the parameter `C_ijkl` expects the elasticity components in the order `C_ijkl = '1111 1122 1133 2211 2222 2233 3311 3322 3333'` for the `principal` fill method option.
+
+
+## Cosserat Elasticity Specific Fill Methods
+The following fill methods are available within `ComputeElasticityTensor`, but the use cases for these methods fall within the Cosserat applications which do not preserve the equilibruim of angular momentum.
+
+### General Isotropic Symmetry
+The fill method `general_isotropic` is used for the case of three independent components of an elasticity tensor, Eq \eqref{eq:general_isotropic_cijkl}.
+\begin{equation}
+\label{eq:general_isotropic_cijkl}
+C_{ijkl}^{isotropic} = \lambda \delta_{ij} \delta_{kl} + \mu \delta_{ik} \delta_{ji} + \kappa \delta_{il} \delta_{jk}
+\end{equation}
+
+This fill method case is used in the child class [ComputeCosseratElasticityTensor](/ComputeCosseratElasticityTensor.md); please see the documentation for [ComputeCosseratElasticityTensor](/ComputeCosseratElasticityTensor.md) for details and examples of the input file syntax.
+
+### General Antisymmetric
+The fill method `antisymmetric` builds an antisymmetric elasticity tensor for a shear-only case.
+The symmetries shown in Eq \eqref{eq:antisymmetric_symmetries} are used to create the complete tensor
+\begin{equation}
+\label{eq:antisymmetric_symmetries}
+C_{ijkl} = - C_{jikl} = - C_{ijlk} = C_{klij}
+\end{equation}
+and the engineering notation representation of the anitsymmetric elasticity tensor is given in Eq \eqref{eq:antisymmetric_fill_method}.
+\begin{equation}
+\label{eq:antisymmetric_fill_method}
+C_{ijkl}^{antisymmetric} = \begin{bmatrix}
+                   0 &      0 &      0 &      0 &      0 &      0 \\
+                   0 &      0 &      0 &      0 &      0 &      0 \\
+                   0 &      0 &      0 &      0 &      0 &      0 \\
+                   0 &      0 &      0 &  C_{44} & -C_{54} &  C_{64} \\
+                   0 &      0 &      0 & -C_{54} & -C_{55} & -C_{65} \\
+                   0 &      0 &      0 &  C_{64} & -C_{65} &  C_{66}
+              \end{bmatrix}
+\end{equation}
+
+This fill method case is used in the child class [ComputeCosseratElasticityTensor](/ComputeCosseratElasticityTensor.md); please see the documentation for [ComputeCosseratElasticityTensor](/ComputeCosseratElasticityTensor.md) for details and examples of the input file syntax.
+
+### No Symmetry
+The `general` fill method for the Compute Elasticity Tensor class does not make any assumptions about symmetry for the elasticity tensor and requires all 81 components of the stiffness tensor as an input string.
+This fill method case is used in the child class [ComputeCosseratElasticityTensor](/ComputeCosseratElasticityTensor.md); please see the documentation for [ComputeCosseratElasticityTensor](/ComputeCosseratElasticityTensor.md) for details and examples of the input file syntax.
+
 
 !syntax parameters /Materials/ComputeElasticityTensor
 
 !syntax inputs /Materials/ComputeElasticityTensor
 
 !syntax children /Materials/ComputeElasticityTensor
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{tensor_mechanics.bib}

--- a/docs/content/documentation/systems/Materials/tensor_mechanics/ComputeElasticityTensorCP.md
+++ b/docs/content/documentation/systems/Materials/tensor_mechanics/ComputeElasticityTensorCP.md
@@ -1,10 +1,61 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# ComputeElasticityTensorCP
+# Compute Elasticity Tensor CP
 !syntax description /Materials/ComputeElasticityTensorCP
+
+## Description
+The material `ComputeElasticityTensorCP` is used to create an elasticity tensor for crystal plasticity simulations.
+This material builds an orthotropic elasticity tensor using the fill_method `symmetric9` from [ComputeElasticityTensor](/ComputeElasticityTensor.md).
+`ComputeElasticityTensorCP` rotates the elasticity tensor both during the initial setup step, if Euler angles are provided, and at the start of each timestep as the crystal lattice rotates during plastic deformation.
+
+The fill method `symmetric9` is appropriate for materials with three orthotropic planes of symmetry \cite{malvern1969introduction}, and is used for simulations of anistropic materials such as cubic crystals.
+The enginering elasticity tensor notation for an orthotropic material is given in Eq \eqref{eq:symmetric9_fill_method}:
+\begin{equation}
+\label{eq:symmetric9_fill_method}
+C_{ijkl} = \begin{bmatrix}
+              C_{11} & C_{12} & C_{13} &      0 &      0 &      0 \\
+              C_{12} & C_{22} & C_{23} &      0 &      0 &      0 \\
+              C_{13} & C_{23} & C_{33} &      0 &      0 &      0 \\
+                   0 &      0 &      0 & C_{44} &      0 &      0 \\
+                   0 &      0 &      0 &      0 & C_{55} &      0 \\
+                   0 &      0 &      0 &      0 &      0 & C_{66}
+              \end{bmatrix}
+\end{equation}
+
+## Rotation Tensor Conventions
+The [Euler angle convention](http://mathworld.wolfram.com/EulerAngles.html) used in `ComputeElasticityTensorCP` is the $z$-$x'$-$z'$ (3-1-3) convention.
+The Euler angles arguments are expected in degrees, not radians, and are denoted as $\phi_1$, $\Phi$, and $\phi_2$, corresponding to the axis rotations.
+The rotation tensor, $R$, is calculated from the current Euler angles at each timestep as shown in Eq \eqref{eq:rotation_tensor}.
+\begin{equation}
+\label{eq:rotation_tensor}
+  \begin{aligned}
+  R_{11} & = cos(\phi_1)cos(\phi_2) - cos(\Phi)sin(\phi_1)sin(\phi_2) \\
+  R_{12} & = -cos(\phi_1)sin(\phi_2) - cos(\Phi)cos(\phi_2)sin(\phi_1) \\
+  R_{13} & = sin(\phi_1)sin(\Phi) \\
+  R_{21} & = cos(\phi_2)sin(\phi_1) + cos(\phi_1)cos(\Phi)sin(\phi_2) \\
+  R_{22} & = -sin(\phi_1)sin(\phi_2) + cos(\phi_1)cos(\Phi)cos(\phi_2) \\
+  R_{23} & = -cos(\phi_1)sin(\Phi) \\
+  R_{31} & = sin(\Phi) sin(\phi_2) \\
+  R_{32} & = cos(\phi_2) sin(\Phi) \\
+  R_{33} & = cos(\Phi)
+  \end{aligned}
+\end{equation}
+The elasticity tensor is then rotated with Eq \eqref{eq:cp_elasticity_tensor_rotation}
+\begin{equation}
+\label{eq:cp_elasticity_tensor_rotation}
+  C'_{ijkl} = R^T_{im} R^T_{jn} R^T_{ko} R^T_{lp} C_{mnop}
+\end{equation}
+at the beginning of each material timestep calculation.
+
+
+## Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/cp_user_object/crysp.i block=Materials/elasticity_tensor
+
 
 !syntax parameters /Materials/ComputeElasticityTensorCP
 
 !syntax inputs /Materials/ComputeElasticityTensorCP
 
 !syntax children /Materials/ComputeElasticityTensorCP
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{tensor_mechanics.bib}

--- a/docs/content/documentation/systems/Materials/tensor_mechanics/ComputeIsotropicElasticityTensor.md
+++ b/docs/content/documentation/systems/Materials/tensor_mechanics/ComputeIsotropicElasticityTensor.md
@@ -1,10 +1,34 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# ComputeIsotropicElasticityTensor
+# Compute Isotropic Elasticity Tensor
 !syntax description /Materials/ComputeIsotropicElasticityTensor
+
+## Description
+The material `ComputeIsotropicElasticityTensor` builds the isotropic elasticity (stiffness) tensor with two user provided elastic constants.
+
+The isotropic elasticity tensor is given, in engineering matrix notation \cite{malvern1969introduction}, as
+\begin{equation}
+\label{eq:isotropic_fill_method}
+C_{ijkl}^{isotropic} = \begin{bmatrix}
+              \lambda + 2 \mu & \lambda & \lambda &      0 &      0 &      0 \\
+              \lambda & \lambda + 2 \mu & \lambda &      0 &      0 &      0 \\
+              \lambda & \lambda & \lambda + 2 \mu &      0 &      0 &      0 \\
+                   0 &      0 &      0 &    \mu &      0 &      0 \\
+                   0 &      0 &      0 &      0 &    \mu &      0 \\
+                   0 &      0 &      0 &      0 &      0 &    \mu
+              \end{bmatrix}
+\end{equation}
+
+`ComputeIsotropicElasticityTensor` accepts as an argument two of five isotropic elastic constants: lambda $\lambda$, the shear modulus $\mu$, the bulk modulus $K$, the Young's modulus $E$, or the Poisson's ratio $\nu$.
+The material includes the conversions into Lame constants, see \cite{slaughter2012linearized} for the conversion equations among the isotropic elastic constants.
+
+## Example Input File Syntax
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch_quadratic.i block=Materials/elast_tensor
 
 !syntax parameters /Materials/ComputeIsotropicElasticityTensor
 
 !syntax inputs /Materials/ComputeIsotropicElasticityTensor
 
 !syntax children /Materials/ComputeIsotropicElasticityTensor
+
+## References
+\bibliographystyle{unsrt}
+\bibliography{tensor_mechanics.bib}

--- a/docs/hidden.yml
+++ b/docs/hidden.yml
@@ -859,15 +859,11 @@ stochastic_tools_test:
 tensor_mechanics:
     - /AuxKernels/AccumulateAux
     - /AuxKernels/CrystalPlasticityRotationOutAux
-    - /AuxKernels/CylindricalRankTwoAux
     - /AuxKernels/ElasticEnergyAux
     - /AuxKernels/NewmarkAccelAux
     - /AuxKernels/NewmarkVelAux
     - /AuxKernels/RadialDisplacementCylinderAux
     - /AuxKernels/RadialDisplacementSphereAux
-    - /AuxKernels/RankFourAux
-    - /AuxKernels/RankTwoAux
-    - /AuxKernels/RankTwoScalarAux
     - /BCs
     - /BCs/DashpotBC
     - /BCs/DisplacementAboutAxis
@@ -919,12 +915,10 @@ tensor_mechanics:
     - /Materials/ComputeDeformGradBasedStress
     - /Materials/ComputeEigenstrain
     - /Materials/ComputeElasticSmearedCrackingStress
-    - /Materials/ComputeElasticityTensor
     - /Materials/ComputeElasticityTensorCP
     - /Materials/ComputeExtraStressConstant
     - /Materials/ComputeFiniteStrainElasticStress
     - /Materials/ComputeIncrementalSmallStrain
-    - /Materials/ComputeIsotropicElasticityTensor
     - /Materials/ComputeLayeredCosseratElasticityTensor
     - /Materials/ComputeLinearElasticPFFractureStress
     - /Materials/ComputeLinearElasticStress

--- a/framework/include/utils/RankFourTensor.h
+++ b/framework/include/utils/RankFourTensor.h
@@ -167,7 +167,7 @@ public:
 
   /**
    * Rotate the tensor using
-   * C_ijkl = R_im R_in R_ko R_lp C_mnop
+   * C_ijkl = R_im R_jn R_ko R_lp C_mnop
    */
   void rotate(const RankTwoTensor & R);
 

--- a/modules/tensor_mechanics/include/utils/RankTwoScalarTools.h
+++ b/modules/tensor_mechanics/include/utils/RankTwoScalarTools.h
@@ -125,8 +125,7 @@ Real maxPrincipal(const RankTwoTensor & r2tensor, Point & direction);
 
 /*
  * The mid Principal method calculates the second largest principal value for a
- * tensor.  This method is valid only for 3D problems and will return an error
- * if called in 2D problems.
+ * tensor.
  * param r2tensor RankTwoTensor from which to extract the principal value
  * param direction Direction corresponding to the principal value
  */

--- a/modules/tensor_mechanics/src/utils/RankTwoScalarTools.C
+++ b/modules/tensor_mechanics/src/utils/RankTwoScalarTools.C
@@ -272,7 +272,7 @@ radialStress(const RankTwoTensor & stress,
   Point radial_norm;
   normalPositionVector(point1, point2, curr_point, radial_norm);
 
-  // Compute the scalar stress component in the direciton of the normal vector from the
+  // Compute the scalar stress component in the direction of the normal vector from the
   // user-defined axis of rotation.
   Real radial_stress = 0.0;
   for (unsigned int i = 0; i < 3; ++i)


### PR DESCRIPTION
Adds documentation in the MooseDocs system for six classes.  

In cases where `MooseEnum` is used to provide several options, I've deviated from the proposed Documentation Standards (#10510) and have included an `### Example Input File Syntax` section for each of the enum options after discussion with @bwspenc. In cases where an enum option is not used in a regression test (e.g. `RankTwoScalarTools`), I've simply omitted the example input file syntax section.

Pinging @WilkAndy @dschwen or @aeslaughter  for review.

Refs #10516