### PR TITLE
Ability to provide reference value for P or T to PorousFlowSinks

### DIFF
--- a/docs/content/documentation/modules/porous_flow/boundaries.md
+++ b/docs/content/documentation/modules/porous_flow/boundaries.md
@@ -22,11 +22,12 @@ This basic sink boundary condition is implemented in [`PorousFlowSink`](/porous_
 The basic sink may be multiplied by a MOOSE Function of the pressure
 of a fluid phase *or* the temperature:
 \begin{equation}
-s = f(t, x) \times g(P^{\beta}) \ \ \ \textrm{or}\ \ \ s = f(t, x)
-\times g(T) \ .
+s = f(t, x) \times g(P^{\beta} - P_{\mathrm{e}}) \ \ \ \textrm{or}\ \ \ s = f(t, x)
+\times g(T - T_{\mathrm{e}}) \ .
 \end{equation}
 Here the units of $f\times g$ are kg.m$^{-2}$.s$^{-1}$ (for fluids) or
-J.m$^{-1}$.s$^{-1}$ (for heat).  Some commonly use forms have been
+J.m$^{-1}$.s$^{-1}$ (for heat).  $P_{\mathrm{e}}$ and $T_{\mathrm{e}}$ are reference values, that
+may be AuxVariables to allow spatial and temporal variance.  Some commonly use forms have been
 hard-coded into the Porous Flow module for ease of use in simulations:
 
 - A piecewise linear function (for simulating fluid or heat exchange with an external
@@ -102,13 +103,13 @@ Eq \eqref{eq:fix.pp.bc} (`Eq` `\eqref{eq:fix.pp.bc}`)Eqn~(\ref{}) may
 be implemented in a number of ways.  A
 [`PorousFlowPiecewiseLinearSink`](/porous_flow/PorousFlowPiecewiseLinearSink.md)
 may be constructed that models \begin{equation} f = C (P -
-P_{\mathrm{e}}) \ , \end{equation} that is, with `pt_vals =
-'-1E9+Pe Pe 1E9+Pe'` and
-`multipliers = '-C*1E9 0 C*1E9'` (the `1E9` is just an
-example: the point is that it should be much greater than any expected
-porepressure).  The numerical value of the conductance, $C$, is $\rho
-k_{nn}k_{\mathrm{r}}/\mu/L$, must be set at an appropriate value for
-the model.
+P_{\mathrm{e}}) \ , \end{equation} that is, with `pt_vals = '-1E9
+1E9'` and `multipliers = '-C C'` (the `1E9` is just an example: the
+point is that it should be much greater than any expected
+porepressure) and $P_{\mathrm{e}}$ provided by an AuxVariable (or set
+to a constant value).  The numerical value of the conductance, $C$, is
+$\rho k_{nn}k_{\mathrm{r}}/\mu/L$, must be set at an appropriate value
+for the model.
 
 Alternately, a
 [`PorousFlowPiecewiseLinearSink`](/porous_flow/PorousFlowPiecewiseLinearSink.md)
@@ -119,8 +120,7 @@ mobility and relative permeability to use; (3) these parameters are
 appropriate to the model so it reduces the potential for difficult
 numerical situations occuring.
 
-Finally, if $P_{\mathrm{e}}$ is varying over the boundary, the flux
-should be split \begin{equation} f = CP - CP_{\mathrm{e}}\ .
+Finally, if $P_{\mathrm{e}}$ is varying over the boundary it must be constructed as an AuxVariable.  An alternative is to split the flux \begin{equation} f = CP - CP_{\mathrm{e}}\ .
 \end{equation} Two PorousFlowSinks may be used.  The first term is a
 `PorousFlowPiecewiseLinearSink` as just described (with
 $P_{\mathrm{e}} = 0$).  The second term is a plain

--- a/docs/content/documentation/systems/BCs/porous_flow/PorousFlowPiecewiseLinearSink.md
+++ b/docs/content/documentation/systems/BCs/porous_flow/PorousFlowPiecewiseLinearSink.md
@@ -2,10 +2,10 @@
 !syntax description /BCs/PorousFlowPiecewiseLinearSink
 
 The basic sink $f(x,t)$ is multiplied by a piecewise linear MOOSE Function of the pressure
-of a fluid phase $g(P^{\beta})$ *or* the temperature $g(T)$:
+of a fluid phase $g(P^{\beta}-P_{\mathrm{e}})$ *or* the temperature $g(T-T_{\mathrm{e}})$:
 \begin{equation*}
-s = f(t, x) \times g(P^{\beta}) \ \ \ \textrm{or}\ \ \ s = f(t, x)
-\times g(T) \ .
+s = f(t, x) \times g(P^{\beta}-P_{\mathrm{e}}) \ \ \ \textrm{or}\ \ \ s = f(t, x)
+\times g(T-T_{\mathrm{e}}) \ .
 \end{equation*}
 Here the units of $f\times g$ are kg.m$^{-2}$.s$^{-1}$ (for fluids) or
 J.m$^{-1}$.s$^{-1}$ (for heat).

--- a/modules/porous_flow/include/bcs/PorousFlowSinkPTDefiner.h
+++ b/modules/porous_flow/include/bcs/PorousFlowSinkPTDefiner.h
@@ -39,6 +39,9 @@ protected:
   /// d(Nodal temperature)/d(PorousFlow variable)
   const MaterialProperty<std::vector<Real>> * const _dtemp_dvar;
 
+  /// Subtract this from porepressure or temperature before evaluating PiecewiseLinearSink, HalfCubicSink, etc
+  const VariableValue & _pt_shift;
+
   /// Provides the variable value (either porepressure, or temperature, depending on _involves_fluid)
   virtual Real ptVar() const;
 

--- a/modules/porous_flow/src/bcs/PorousFlowSinkPTDefiner.C
+++ b/modules/porous_flow/src/bcs/PorousFlowSinkPTDefiner.C
@@ -12,6 +12,7 @@ InputParameters
 validParams<PorousFlowSinkPTDefiner>()
 {
   InputParameters params = validParams<PorousFlowSink>();
+  params.addCoupledVar("PT_shift", 0.0, "Whenever the sink is an explicit function of porepressure (such as a PiecewiseLinear function) the argument of the function is set to P - PT_shift instead of simply P.  Similarly for temperature.  PT_shift does not enter into any use_* calculations.");
   return params;
 }
 
@@ -26,7 +27,8 @@ PorousFlowSinkPTDefiner::PorousFlowSinkPTDefiner(const InputParameters & paramet
     _temp(!_involves_fluid ? &getMaterialProperty<Real>("PorousFlow_temperature_nodal") : nullptr),
     _dtemp_dvar(!_involves_fluid
                     ? &getMaterialProperty<std::vector<Real>>("dPorousFlow_temperature_nodal_dvar")
-                    : nullptr)
+                : nullptr),
+              _pt_shift(coupledNodalValue("PT_shift"))
 {
   if (_involves_fluid && (_pp == nullptr || _dpp_dvar == nullptr))
     mooseError("PorousFlowSink: There is no porepressure Material");
@@ -38,8 +40,8 @@ Real
 PorousFlowSinkPTDefiner::ptVar() const
 {
   if (_involves_fluid)
-    return (*_pp)[_i][_ph];
-  return (*_temp)[_i];
+    return (*_pp)[_i][_ph] - _pt_shift[_i];
+  return (*_temp)[_i] - _pt_shift[_i];
 }
 
 Real

--- a/modules/porous_flow/src/bcs/PorousFlowSinkPTDefiner.C
+++ b/modules/porous_flow/src/bcs/PorousFlowSinkPTDefiner.C
@@ -12,7 +12,13 @@ InputParameters
 validParams<PorousFlowSinkPTDefiner>()
 {
   InputParameters params = validParams<PorousFlowSink>();
-  params.addCoupledVar("PT_shift", 0.0, "Whenever the sink is an explicit function of porepressure (such as a PiecewiseLinear function) the argument of the function is set to P - PT_shift instead of simply P.  Similarly for temperature.  PT_shift does not enter into any use_* calculations.");
+  params.addCoupledVar("PT_shift",
+                       0.0,
+                       "Whenever the sink is an explicit function of porepressure "
+                       "(such as a PiecewiseLinear function) the argument of the "
+                       "function is set to P - PT_shift instead of simply P.  "
+                       "Similarly for temperature.  PT_shift does not enter into "
+                       "any use_* calculations.");
   return params;
 }
 
@@ -27,8 +33,8 @@ PorousFlowSinkPTDefiner::PorousFlowSinkPTDefiner(const InputParameters & paramet
     _temp(!_involves_fluid ? &getMaterialProperty<Real>("PorousFlow_temperature_nodal") : nullptr),
     _dtemp_dvar(!_involves_fluid
                     ? &getMaterialProperty<std::vector<Real>>("dPorousFlow_temperature_nodal_dvar")
-                : nullptr),
-              _pt_shift(coupledNodalValue("PT_shift"))
+                    : nullptr),
+    _pt_shift(coupledNodalValue("PT_shift"))
 {
   if (_involves_fluid && (_pp == nullptr || _dpp_dvar == nullptr))
     mooseError("PorousFlowSink: There is no porepressure Material");

--- a/modules/porous_flow/test/tests/sinks/s04.i
+++ b/modules/porous_flow/test/tests/sinks/s04.i
@@ -125,6 +125,9 @@
   [../]
   [./yval]
   [../]
+  [./pt_shift]
+    initial_condition = 0.3
+  [../]
 []
 
 [ICs]
@@ -252,7 +255,8 @@
   [./flux]
     type = PorousFlowPiecewiseLinearSink
     boundary = 'right'
-    pt_vals = '0.3 0.8'
+    PT_shift = pt_shift
+    pt_vals = '0.0 0.5'
     multipliers = '0.5 1'
     variable = pp
     use_mobility = false


### PR DESCRIPTION
with the reference value being an AuxVariable

Fixes #10543

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
