### PR TITLE
disallow setting parameters not registered in validParams

### DIFF
--- a/framework/src/actions/AddFieldSplitAction.C
+++ b/framework/src/actions/AddFieldSplitAction.C
@@ -37,6 +37,5 @@ AddFieldSplitAction::AddFieldSplitAction(InputParameters params) : MooseObjectAc
 void
 AddFieldSplitAction::act()
 {
-  _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
   _problem->getNonlinearSystemBase().addSplit(_type, _name, _moose_object_pars);
 }

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -34,12 +34,6 @@ CreateExecutionerAction::CreateExecutionerAction(InputParameters params) : Moose
 void
 CreateExecutionerAction::act()
 {
-  _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
-
-  std::shared_ptr<FEProblem> fe_problem = std::dynamic_pointer_cast<FEProblem>(_problem);
-  if (fe_problem)
-    _moose_object_pars.set<FEProblem *>("_fe_problem") = fe_problem.get();
-
   std::shared_ptr<EigenProblem> eigen_problem = std::dynamic_pointer_cast<EigenProblem>(_problem);
   if (eigen_problem)
     _moose_object_pars.set<EigenProblem *>("_eigen_problem") = eigen_problem.get();

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -58,15 +58,6 @@ validParams<CreateProblemAction>()
                                         "by objects which compute residuals and Jacobians "
                                         "(Kernels, BCs, etc.) by setting tags on them.");
 
-#ifdef LIBMESH_HAVE_PETSC
-  params.addParam<MultiMooseEnum>(
-      "petsc_options", MultiMooseEnum("", "", true), "TODO: add doc message");
-  params.addParam<std::vector<std::string>>(
-      "petsc_inames", std::vector<std::string>(), "TODO: add doc message");
-  params.addParam<std::vector<std::string>>(
-      "petsc_values", std::vector<std::string>(), "TODO: add doc message");
-#endif
-
   return params;
 }
 

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -58,6 +58,15 @@ validParams<CreateProblemAction>()
                                         "by objects which compute residuals and Jacobians "
                                         "(Kernels, BCs, etc.) by setting tags on them.");
 
+#ifdef LIBMESH_HAVE_PETSC
+  params.addParam<MultiMooseEnum>(
+      "petsc_options", MultiMooseEnum("", "", true), "TODO: add doc message");
+  params.addParam<std::vector<std::string>>(
+      "petsc_inames", std::vector<std::string>(), "TODO: add doc message");
+  params.addParam<std::vector<std::string>>(
+      "petsc_values", std::vector<std::string>(), "TODO: add doc message");
+#endif
+
   return params;
 }
 
@@ -78,12 +87,6 @@ CreateProblemAction::act()
       _moose_object_pars.set<MooseMesh *>("mesh") = _mesh.get();
       _moose_object_pars.set<bool>("use_nonlinear") = _app.useNonlinear();
 
-#ifdef LIBMESH_HAVE_PETSC
-      // put in empty arrays for PETSc options
-      _moose_object_pars.set<MultiMooseEnum>("petsc_options") = MultiMooseEnum("", "", true);
-      _moose_object_pars.set<std::vector<std::string>>("petsc_inames") = std::vector<std::string>();
-      _moose_object_pars.set<std::vector<std::string>>("petsc_values") = std::vector<std::string>();
-#endif
       _problem =
           _factory.create<FEProblemBase>(_type, getParam<std::string>("name"), _moose_object_pars);
       if (!_problem.get())

--- a/framework/src/actions/MaterialDerivativeTestAction.C
+++ b/framework/src/actions/MaterialDerivativeTestAction.C
@@ -233,7 +233,6 @@ MaterialDerivativeTestAction::act()
 
     if (_problem.get() != nullptr)
     {
-      params.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
       std::shared_ptr<MoosePreconditioner> pc =
           _factory.create<MoosePreconditioner>("SMP", "material_derivative_SMP", params);
 

--- a/framework/src/actions/SetupPreconditionerAction.C
+++ b/framework/src/actions/SetupPreconditionerAction.C
@@ -40,7 +40,6 @@ SetupPreconditionerAction::act()
   if (_problem.get() != NULL)
   {
     // build the preconditioner
-    _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
     std::shared_ptr<MoosePreconditioner> pc =
         _factory.create<MoosePreconditioner>(_type, _name, _moose_object_pars);
 

--- a/framework/src/actions/SetupPredictorAction.C
+++ b/framework/src/actions/SetupPredictorAction.C
@@ -39,7 +39,6 @@ SetupPredictorAction::act()
     if (transient == NULL)
       mooseError("You can setup time stepper only with executioners of transient type.");
 
-    _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
     _moose_object_pars.set<Transient *>("_executioner") = transient;
     std::shared_ptr<Predictor> predictor =
         _factory.create<Predictor>(_type, "Predictor", _moose_object_pars);

--- a/framework/src/actions/SetupTimeStepperAction.C
+++ b/framework/src/actions/SetupTimeStepperAction.C
@@ -37,6 +37,7 @@ SetupTimeStepperAction::act()
     if (transient == NULL)
       mooseError("You can setup time stepper only with executioners of transient type.");
 
+    _moose_object_pars.set<SubProblem *>("_subproblem") = _problem.get();
     _moose_object_pars.set<Transient *>("_executioner") = transient;
     std::shared_ptr<TimeStepper> ts =
         _factory.create<TimeStepper>(_type, "TimeStepper", _moose_object_pars);

--- a/framework/src/actions/SetupTimeStepperAction.C
+++ b/framework/src/actions/SetupTimeStepperAction.C
@@ -37,8 +37,6 @@ SetupTimeStepperAction::act()
     if (transient == NULL)
       mooseError("You can setup time stepper only with executioners of transient type.");
 
-    _moose_object_pars.set<SubProblem *>("_subproblem") = _problem.get();
-    _moose_object_pars.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
     _moose_object_pars.set<Transient *>("_executioner") = transient;
     std::shared_ptr<TimeStepper> ts =
         _factory.create<TimeStepper>(_type, "TimeStepper", _moose_object_pars);

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -117,6 +117,10 @@ Factory::create(const std::string & obj_name,
   buildPtr & func = it->second;
   auto obj = (*func)(params);
 
+  auto fep = std::dynamic_pointer_cast<FEProblemBase>(obj);
+  if (fep)
+    _app.actionWarehouse().problemBase() = fep;
+
   // Make sure no unexpected parameters were added by the object's constructor or by the action
   // initiating this create call.  All parameters modified by the constructor must have already
   // been specified in the object's validParams function.

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -109,10 +109,46 @@ Factory::create(const std::string & obj_name,
   // register type name as constructed
   _constructed_types.insert(obj_name);
 
-  // Actually call the function pointer.  You can do this in one line,
-  // but it's a bit more obvious what's happening if you do it in two...
+  // add FEProblem pointers to object's params object
+  if (_app.actionWarehouse().problemBase())
+    _app.actionWarehouse().problemBase()->setInputParametersFEProblem(params);
+
+  // call the function pointer to build the object
   buildPtr & func = it->second;
-  return (*func)(params);
+  auto obj = (*func)(params);
+
+  // Make sure no unexpected parameters were added by the object's constructor or by the action
+  // initiating this create call.  All parameters modified by the constructor must have already
+  // been specified in the object's validParams function.
+  InputParameters orig_params = getValidParams(obj_name);
+  if (orig_params.n_parameters() != parameters.n_parameters())
+  {
+    std::set<std::string> orig, populated;
+    for (const auto & it : orig_params)
+      orig.emplace(it.first);
+    for (const auto & it : parameters)
+      populated.emplace(it.first);
+
+    std::set<std::string> diff;
+    std::set_difference(populated.begin(),
+                        populated.end(),
+                        orig.begin(),
+                        orig.end(),
+                        std::inserter(diff, diff.begin()));
+
+    if (!diff.empty())
+    {
+      std::stringstream ss;
+      for (const auto & name : diff)
+        ss << ", " << name;
+      mooseError("attempted to set unregistered parameter(s) for ",
+                 obj_name,
+                 " object:\n    ",
+                 ss.str().substr(2));
+    }
+  }
+
+  return obj;
 }
 
 void

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -12,6 +12,14 @@
 #include "MooseApp.h"
 #include "MooseUtils.h"
 
+class FEProblem;
+class FEProblemBase;
+class EigenProblem;
+class SubProblem;
+class SystemBase;
+class AuxiliarySystem;
+class Transient;
+
 template <>
 InputParameters
 validParams<MooseObject>()
@@ -21,8 +29,18 @@ validParams<MooseObject>()
   params.addParam<std::vector<std::string>>(
       "control_tags",
       "Adds user-defined labels for accessing object parameters via control logic.");
-  params.addPrivateParam<std::string>("_object_name"); // the name passed to Factory::create
   params.addParamNamesToGroup("enable control_tags", "Advanced");
+
+  params.addPrivateParam<std::string>("_object_name"); // the name passed to Factory::create
+  params.addPrivateParam<FEProblem *>("_fe_problem");
+  params.addPrivateParam<FEProblemBase *>("_fe_problem_base");
+  params.addPrivateParam<EigenProblem *>("_eigen_problem");
+  params.addPrivateParam<SubProblem *>("_subproblem");
+  params.addPrivateParam<SystemBase *>("_sys");
+  params.addPrivateParam<SystemBase *>("_nl_sys");
+  params.addPrivateParam<AuxiliarySystem *>("_aux_sys");
+  params.addPrivateParam<Transient *>("_executioner");
+  params.addPrivateParam<THREAD_ID>("_tid");
 
   return params;
 }

--- a/framework/src/distributions/Distribution.C
+++ b/framework/src/distributions/Distribution.C
@@ -15,6 +15,7 @@ InputParameters
 validParams<Distribution>()
 {
   InputParameters params = validParams<MooseObject>();
+  params.addRequiredParam<std::string>("type", "class/type name identifying the distribution");
   params.registerBase("Distribution");
   return params;
 }

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -267,6 +267,7 @@ Transient::init()
   if (!_time_stepper.get())
   {
     InputParameters pars = _app.getFactory().getValidParams("ConstantDT");
+    pars.set<SubProblem *>("_subproblem") = &_problem;
     pars.set<Transient *>("_executioner") = this;
 
     /**

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -267,8 +267,6 @@ Transient::init()
   if (!_time_stepper.get())
   {
     InputParameters pars = _app.getFactory().getValidParams("ConstantDT");
-    pars.set<SubProblem *>("_subproblem") = &_problem;
-    pars.set<FEProblemBase *>("_fe_problem_base") = &_problem;
     pars.set<Transient *>("_executioner") = this;
 
     /**

--- a/framework/src/interfaces/ScalarCoupleable.C
+++ b/framework/src/interfaces/ScalarCoupleable.C
@@ -24,8 +24,7 @@ ScalarCoupleable::ScalarCoupleable(const MooseObject * moose_object)
                         ? _sc_parameters.get<bool>("implicit")
                         : true),
     _coupleable_params(_sc_parameters),
-    _sc_tid(_sc_parameters.have_parameter<THREAD_ID>("_tid") ? _sc_parameters.get<THREAD_ID>("_tid")
-                                                             : 0),
+    _sc_tid(_sc_parameters.isParamValid("_tid") ? _sc_parameters.get<THREAD_ID>("_tid") : 0),
     _real_zero(_sc_fe_problem._real_zero[_sc_tid]),
     _scalar_zero(_sc_fe_problem._scalar_zero[_sc_tid]),
     _point_zero(_sc_fe_problem._point_zero[_sc_tid])

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -51,6 +51,8 @@ validParams<Material>()
       "quadrature point, and then copy that value to the other qps. Evaluations on element qps "
       "will be skipped");
 
+  params.addPrivateParam<bool>("_neighbor", false);
+
   // Outputs
   params += validParams<OutputInterface>();
   params.set<std::vector<OutputName>>("outputs") = {"none"};

--- a/framework/src/meshmodifiers/MeshModifier.C
+++ b/framework/src/meshmodifiers/MeshModifier.C
@@ -24,8 +24,9 @@ validParams<MeshModifier>()
                         "flag can be set on an individual modifier "
                         "to force preperation between modifiers where they might be needed.");
 
-  params.registerBase("MeshModifier");
+  params.addPrivateParam<MooseMesh *>("_mesh");
 
+  params.registerBase("MeshModifier");
   return params;
 }
 

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -138,6 +138,7 @@ validParams<MultiApp>()
   params.addParam<std::vector<Point>>("move_positions",
                                       "The positions corresponding to each move_app.");
 
+  params.addPrivateParam<std::shared_ptr<CommandLine>>("_command_line");
   params.addPrivateParam<bool>("use_positions", true);
   params.declareControllable("enable");
   params.registerBase("MultiApp");

--- a/framework/src/partitioner/MoosePartitioner.C
+++ b/framework/src/partitioner/MoosePartitioner.C
@@ -15,6 +15,7 @@ InputParameters
 validParams<MoosePartitioner>()
 {
   InputParameters params = validParams<MooseObject>();
+  params.addPrivateParam<MooseMesh *>("mesh");
   params.registerBase("MoosePartitioner");
   return params;
 }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4906,8 +4906,9 @@ FEProblemBase::checkProblemIntegrity()
                   std::ostream_iterator<unsigned int>(extra_subdomain_ids, " "));
 
         mooseError("The following blocks from your input mesh do not contain an active material: " +
-                   extra_subdomain_ids.str() + "\nWhen ANY mesh block contains a Material object, "
-                                               "all blocks must contain a Material object.\n");
+                   extra_subdomain_ids.str() +
+                   "\nWhen ANY mesh block contains a Material object, "
+                   "all blocks must contain a Material object.\n");
       }
     }
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1539,7 +1539,6 @@ FEProblemBase::neighborSubdomainSetup(SubdomainID subdomain, THREAD_ID tid)
 void
 FEProblemBase::addFunction(std::string type, const std::string & name, InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   parameters.set<SubProblem *>("_subproblem") = this;
 
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
@@ -1615,7 +1614,6 @@ FEProblemBase::addDistribution(std::string type,
                                const std::string & name,
                                InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   parameters.set<std::string>("type") = type;
   std::shared_ptr<Distribution> dist = _factory.create<Distribution>(type, name, parameters);
   _distributions.addObject(dist);
@@ -1633,7 +1631,6 @@ FEProblemBase::getDistribution(const std::string & name)
 void
 FEProblemBase::addSampler(std::string type, const std::string & name, InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
     std::shared_ptr<Sampler> dist = _factory.create<Sampler>(type, name, parameters, tid);
@@ -1722,7 +1719,6 @@ FEProblemBase::addKernel(const std::string & kernel_name,
                          const std::string & name,
                          InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -1760,7 +1756,6 @@ FEProblemBase::addNodalKernel(const std::string & kernel_name,
                               const std::string & name,
                               InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -1797,7 +1792,6 @@ FEProblemBase::addScalarKernel(const std::string & kernel_name,
                                const std::string & name,
                                InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -1834,7 +1828,6 @@ FEProblemBase::addBoundaryCondition(const std::string & bc_name,
                                     const std::string & name,
                                     InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -1874,7 +1867,6 @@ FEProblemBase::addConstraint(const std::string & c_name,
 {
   _has_constraints = true;
 
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -1937,7 +1929,6 @@ FEProblemBase::addAuxKernel(const std::string & kernel_name,
                             const std::string & name,
                             InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -1980,7 +1971,6 @@ FEProblemBase::addAuxScalarKernel(const std::string & kernel_name,
                                   const std::string & name,
                                   InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -2017,7 +2007,6 @@ FEProblemBase::addDiracKernel(const std::string & kernel_name,
                               const std::string & name,
                               InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -2057,7 +2046,6 @@ FEProblemBase::addDGKernel(const std::string & dg_kernel_name,
                            const std::string & name,
                            InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -2099,7 +2087,6 @@ FEProblemBase::addInterfaceKernel(const std::string & interface_kernel_name,
                                   const std::string & name,
                                   InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -2143,7 +2130,6 @@ FEProblemBase::addInitialCondition(const std::string & ic_name,
   // before we start to mess with the initial condition, we need to check parameters for errors.
   parameters.checkParams(name);
 
-  setInputParametersFEProblem(parameters);
   parameters.set<SubProblem *>("_subproblem") = this;
 
   const std::string & var_name = parameters.get<VariableName>("variable");
@@ -2287,7 +2273,6 @@ FEProblemBase::addMaterial(const std::string & mat_name,
                            const std::string & name,
                            InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -2613,7 +2598,6 @@ FEProblemBase::addUserObject(std::string user_object_name,
                              const std::string & name,
                              InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
   else
@@ -3105,7 +3089,6 @@ FEProblemBase::addDamper(std::string damper_name,
                          const std::string & name,
                          InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   parameters.set<SubProblem *>("_subproblem") = this;
   parameters.set<SystemBase *>("_sys") = _nl.get();
 
@@ -3124,7 +3107,6 @@ FEProblemBase::addIndicator(std::string indicator_name,
                             const std::string & name,
                             InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -3166,7 +3148,6 @@ FEProblemBase::addMarker(std::string marker_name,
                          const std::string & name,
                          InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -3201,7 +3182,6 @@ FEProblemBase::addMultiApp(const std::string & multi_app_name,
                            const std::string & name,
                            InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   parameters.set<MPI_Comm>("_mpi_comm") = _communicator.get();
   parameters.set<std::shared_ptr<CommandLine>>("_command_line") = _app.commandLine();
 
@@ -3449,7 +3429,6 @@ FEProblemBase::addTransfer(const std::string & transfer_name,
                            const std::string & name,
                            InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
   {
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
@@ -4020,7 +3999,6 @@ FEProblemBase::addTimeIntegrator(const std::string & type,
                                  const std::string & name,
                                  InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   parameters.set<SubProblem *>("_subproblem") = this;
   _aux->addTimeIntegrator(type, name + ":aux", parameters);
   _nl->addTimeIntegrator(type, name, parameters);
@@ -4032,7 +4010,6 @@ FEProblemBase::addPredictor(const std::string & type,
                             const std::string & name,
                             InputParameters parameters)
 {
-  setInputParametersFEProblem(parameters);
   parameters.set<SubProblem *>("_subproblem") = this;
   std::shared_ptr<Predictor> predictor = _factory.create<Predictor>(type, name, parameters);
   _nl->setPredictor(predictor);
@@ -4929,9 +4906,8 @@ FEProblemBase::checkProblemIntegrity()
                   std::ostream_iterator<unsigned int>(extra_subdomain_ids, " "));
 
         mooseError("The following blocks from your input mesh do not contain an active material: " +
-                   extra_subdomain_ids.str() +
-                   "\nWhen ANY mesh block contains a Material object, "
-                   "all blocks must contain a Material object.\n");
+                   extra_subdomain_ids.str() + "\nWhen ANY mesh block contains a Material object, "
+                                               "all blocks must contain a Material object.\n");
       }
     }
 

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -21,6 +21,7 @@ InputParameters
 validParams<SubProblem>()
 {
   InputParameters params = validParams<Problem>();
+  params.addPrivateParam<MooseMesh *>("mesh");
   return params;
 }
 

--- a/framework/src/timeintegrators/AStableDirk4.C
+++ b/framework/src/timeintegrators/AStableDirk4.C
@@ -68,7 +68,6 @@ AStableDirk4::AStableDirk4(const InputParameters & parameters)
     // FEProblemBase::addTimeIntegrator() to ensure that the
     // getCheckedPointerParam() sanity checking is happy.  This is why
     // constructing MOOSE objects "manually" is generally frowned upon.
-    params.set<FEProblemBase *>("_fe_problem_base") = &_fe_problem;
     params.set<SystemBase *>("_sys") = &_sys;
 
     _bootstrap_method = factory.create<LStableDirk4>("LStableDirk4", name() + "_bootstrap", params);

--- a/modules/contact/src/ContactPressureAux.C
+++ b/modules/contact/src/ContactPressureAux.C
@@ -24,6 +24,8 @@ validParams<ContactPressureAux>()
   params.addRequiredCoupledVar("nodal_area", "The nodal area");
   params.addRequiredParam<BoundaryName>("paired_boundary", "The boundary to be penetrated");
   params.set<ExecFlagEnum>("execute_on") = EXEC_NONLINEAR;
+  MooseEnum orders("FIRST SECOND THIRD FOURTH", "FIRST");
+  params.addParam<MooseEnum>("order", orders, "The finite element order: " + orders.getRawNames());
   return params;
 }
 

--- a/modules/heat_conduction/src/materials/GapConductance.C
+++ b/modules/heat_conduction/src/materials/GapConductance.C
@@ -60,6 +60,10 @@ validParams<GapConductance>()
                         "are provided in the Mesh block the "
                         "undisplaced mesh will still be used.");
 
+  params.addParam<std::string>("conductivity_name",
+                               "thermal_conductivity",
+                               "The name of the MaterialProperty associated with conductivity "
+                               "(\"thermal_conductivity\" in the case of heat conduction)");
   return params;
 }
 

--- a/modules/navier_stokes/src/auxkernels/NSVelocityAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSVelocityAux.C
@@ -21,8 +21,8 @@ validParams<NSVelocityAux>()
   params.addClassDescription("Velocity auxiliary value.");
   params.addRequiredCoupledVar(NS::density, "Density (conserved form)");
   params.addRequiredCoupledVar("momentum", "Momentum (conserved form)");
-  params.addRequiredParam<UserObjectName>("fluid_properties",
-                                          "The name of the user object for fluid properties");
+  params.addParam<UserObjectName>(
+      "fluid_properties", "", "The name of the user object for fluid properties");
   return params;
 }
 

--- a/modules/navier_stokes/src/auxkernels/NSVelocityAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSVelocityAux.C
@@ -21,6 +21,8 @@ validParams<NSVelocityAux>()
   params.addClassDescription("Velocity auxiliary value.");
   params.addRequiredCoupledVar(NS::density, "Density (conserved form)");
   params.addRequiredCoupledVar("momentum", "Momentum (conserved form)");
+  params.addRequiredParam<UserObjectName>("fluid_properties",
+                                          "The name of the user object for fluid properties");
   return params;
 }
 

--- a/modules/navier_stokes/src/bcs/NSEnergyInviscidSpecifiedBC.C
+++ b/modules/navier_stokes/src/bcs/NSEnergyInviscidSpecifiedBC.C
@@ -16,7 +16,6 @@ InputParameters
 validParams<NSEnergyInviscidSpecifiedBC>()
 {
   InputParameters params = validParams<NSEnergyInviscidBC>();
-  params.addRequiredParam<Real>("specified_pressure", "The specified pressure for this boundary");
   params.addRequiredParam<Real>("un", "The specified value of u.n for this boundary");
   return params;
 }

--- a/modules/navier_stokes/src/bcs/NSEnergyInviscidSpecifiedPressureBC.C
+++ b/modules/navier_stokes/src/bcs/NSEnergyInviscidSpecifiedPressureBC.C
@@ -16,7 +16,6 @@ InputParameters
 validParams<NSEnergyInviscidSpecifiedPressureBC>()
 {
   InputParameters params = validParams<NSEnergyInviscidBC>();
-  params.addRequiredParam<Real>("specified_pressure", "The specified pressure for this boundary");
   return params;
 }
 

--- a/modules/navier_stokes/src/bcs/NSIntegratedBC.C
+++ b/modules/navier_stokes/src/bcs/NSIntegratedBC.C
@@ -38,6 +38,7 @@ validParams<NSIntegratedBC>()
   params.addRequiredCoupledVar(NS::total_energy, "total energy");
   params.addRequiredParam<UserObjectName>("fluid_properties",
                                           "The name of the user object for fluid properties");
+  params.addParam<Real>("specified_pressure", 0.0, "The specified pressure for this boundary");
 
   return params;
 }

--- a/modules/navier_stokes/src/bcs/NSMomentumInviscidSpecifiedPressureBC.C
+++ b/modules/navier_stokes/src/bcs/NSMomentumInviscidSpecifiedPressureBC.C
@@ -19,7 +19,6 @@ validParams<NSMomentumInviscidSpecifiedPressureBC>()
   params.addClassDescription("Momentum equation boundary condition in which pressure is specified "
                              "(given) and the value of the convective part is allowed to vary (is "
                              "computed implicitly).");
-  params.addRequiredParam<Real>("specified_pressure", "The specified pressure for this boundary");
   return params;
 }
 

--- a/modules/phase_field/src/kernels/ACSEDGPoly.C
+++ b/modules/phase_field/src/kernels/ACSEDGPoly.C
@@ -24,6 +24,7 @@ validParams<ACSEDGPoly>()
                                         "Number of OP representing deformed grains");
   params.addRequiredParam<UserObjectName>("grain_tracker",
                                           "The GrainTracker UserObject to get values from.");
+  params.addRequiredParam<unsigned int>("op_index", "The index for the current order parameter");
   return params;
 }
 

--- a/modules/solid_mechanics/src/kernels/StressDivergenceRSpherical.C
+++ b/modules/solid_mechanics/src/kernels/StressDivergenceRSpherical.C
@@ -27,6 +27,14 @@ validParams<StressDivergenceRSpherical>()
   //  params.addCoupledVar("disp_z", "The z displacement");
   params.addCoupledVar("temp", "The temperature");
 
+  params.addParam<Real>("zeta", 0.0, "Stiffness dependent damping parameter for Rayleigh damping");
+  params.addParam<Real>("alpha", 0.0, "alpha parameter for HHT time integration");
+  params.addParam<std::string>(
+      "appended_property_name", "", "Name appended to material properties to make them unique");
+  params.addParam<bool>("volumetric_locking_correction",
+                        true,
+                        "Set to false to turn off volumetric locking correction");
+
   params.set<bool>("use_displaced_mesh") = true;
 
   return params;

--- a/modules/solid_mechanics/src/kernels/StressDivergenceRZ.C
+++ b/modules/solid_mechanics/src/kernels/StressDivergenceRZ.C
@@ -33,6 +33,14 @@ validParams<StressDivergenceRZ>()
   params.addCoupledVar("disp_z", "The z displacement");
   params.addCoupledVar("temp", "The temperature");
 
+  params.addParam<Real>("zeta", 0.0, "Stiffness dependent damping parameter for Rayleigh damping");
+  params.addParam<Real>("alpha", 0.0, "alpha parameter for HHT time integration");
+  params.addParam<std::string>(
+      "appended_property_name", "", "Name appended to material properties to make them unique");
+  params.addParam<bool>("volumetric_locking_correction",
+                        true,
+                        "Set to false to turn off volumetric locking correction");
+
   params.set<bool>("use_displaced_mesh") = true;
 
   return params;

--- a/modules/solid_mechanics/src/materials/ConstitutiveModel.C
+++ b/modules/solid_mechanics/src/materials/ConstitutiveModel.C
@@ -8,13 +8,14 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ConstitutiveModel.h"
+#include "SolidModel.h"
 #include "Function.h"
 
 template <>
 InputParameters
 validParams<ConstitutiveModel>()
 {
-  InputParameters params = validParams<Material>();
+  InputParameters params = validParams<SolidModel>();
 
   params.addCoupledVar("temp", "Coupled Temperature");
 

--- a/modules/solid_mechanics/src/materials/ElasticModel.C
+++ b/modules/solid_mechanics/src/materials/ElasticModel.C
@@ -18,6 +18,39 @@ InputParameters
 validParams<ElasticModel>()
 {
   InputParameters params = validParams<ConstitutiveModel>();
+
+  // These parameters are a hack to get around the fact that SolidModel::createConstitutiveModel
+  // function is used to create ElasticModel objects by injecting other parameters into it
+  // (which it doesn't understand).  This is an ugly hack to get around this behavior which MOOSE
+  // will no longer allow.
+  params.addCoupledVar("X_Pu", 0, "Coupled plutonium atom fraction");
+  params.addCoupledVar("X_Zr", 0, "Coupled zirconium atom fraction");
+  params.addParam<bool>("calc_youngs", true, "Flag to calculate Youngs Modulus or use given value");
+  params.addParam<bool>(
+      "calc_poissons", true, "Flag to calculate Poissons ratio or use given value");
+  params.addParam<bool>("model_creep", true, "Flag for creep model");
+  params.addParam<std::vector<std::string>>("volumetric_models", "Volumetric models to apply");
+  params.addParam<Real>("A_U", 0.2380289, "Atomic weight of uranium [kg/mol]");
+  params.addParam<Real>("A_Pu", 0.244, "Atomic weight of plutonium [kg/mol]");
+  params.addParam<Real>("A_Zr", 0.091224, "Atomic weight of zirconium [kg/mol]");
+  params.addParam<bool>("absolute_tolerance", "dummy");
+  params.addParam<bool>("acceptable_multiplier", "dummy");
+  params.addParam<bool>("compute_material_timestep_limit", "dummy");
+  params.addParam<bool>("fission_rate", "dummy");
+  params.addParam<bool>("fission_rate_material", "dummy");
+  params.addParam<bool>("gamma_transition", "dummy");
+  params.addParam<bool>("hydrostatic_stress", "dummy");
+  params.addParam<bool>("legacy_return_mapping", "dummy");
+  params.addParam<bool>("max_inelastic_increment", "dummy");
+  params.addParam<bool>("max_its", "dummy");
+  params.addParam<bool>("open_pore_compressibility_factor", "dummy");
+  params.addParam<bool>("output_iteration_info", "dummy");
+  params.addParam<bool>("output_iteration_info_on_error", "dummy");
+  params.addParam<bool>("plenum_pressure", "dummy");
+  params.addParam<bool>("porosity", "dummy");
+  params.addParam<bool>("relative_tolerance", "dummy");
+  params.addParam<bool>("use_material_fission_rate", "dummy");
+
   return params;
 }
 

--- a/modules/solid_mechanics/src/materials/SolidModel.C
+++ b/modules/solid_mechanics/src/materials/SolidModel.C
@@ -1600,6 +1600,7 @@ SolidModel::createConstitutiveModel(const std::string & cm_name)
   params.set_attributes("absolute_tolerance", false);
   params.set_attributes("relative_tolerance", false);
   params.set_attributes("max_its", false);
+
   params += parameters();
   MooseSharedPointer<ConstitutiveModel> cm =
       factory.create<ConstitutiveModel>(cm_name, name() + "Model", params, _tid);

--- a/modules/solid_mechanics/src/postprocessors/InteractionIntegralSM.C
+++ b/modules/solid_mechanics/src/postprocessors/InteractionIntegralSM.C
@@ -55,6 +55,8 @@ validParams<InteractionIntegralSM>()
   params.addParam<Real>("poissons_ratio", "Poisson's ratio for the material.");
   params.addParam<Real>("youngs_modulus", "Young's modulus of the material.");
   params.set<bool>("use_displaced_mesh") = false;
+  params.addParam<unsigned int>("ring_first",
+                                "The first ring of elements for volume integral domain");
   params.addParam<unsigned int>("ring_index", "Ring ID");
   params.addParam<MooseEnum>("q_function_type",
                              InteractionIntegralSM::qFunctionType(),

--- a/modules/tensor_mechanics/src/postprocessors/InteractionIntegral.C
+++ b/modules/tensor_mechanics/src/postprocessors/InteractionIntegral.C
@@ -56,6 +56,8 @@ validParams<InteractionIntegral>()
   params.addParam<Real>("poissons_ratio", "Poisson's ratio for the material.");
   params.addParam<Real>("youngs_modulus", "Young's modulus of the material.");
   params.set<bool>("use_displaced_mesh") = false;
+  params.addParam<unsigned int>("ring_first",
+                                "The first ring of elements for volume integral domain");
   params.addParam<unsigned int>("ring_index", "Ring ID");
   params.addParam<MooseEnum>("q_function_type",
                              InteractionIntegral::qFunctionType(),

--- a/modules/tensor_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/tensor_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -73,6 +73,7 @@ addCrackFrontDefinitionParams(InputParameters & params)
   params.addParam<bool>("q_function_rings", false, "Generate rings of nodes for q-function");
   params.addParam<unsigned int>("last_ring", "The number of rings of nodes to generate");
   params.addParam<unsigned int>("first_ring", "The number of rings of nodes to generate");
+  params.addParam<unsigned int>("nrings", "The number of rings of nodes to generate");
   params.addParam<VariableName>("disp_x", "Variable containing the x displacement");
   params.addParam<VariableName>("disp_y", "Variable containing the y displacement");
   params.addParam<VariableName>("disp_z", "Variable containing the z displacement");

--- a/test/src/kernels/Convection.C
+++ b/test/src/kernels/Convection.C
@@ -17,6 +17,7 @@ validParams<Convection>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredParam<RealVectorValue>("velocity", "Velocity Vector");
+  params.addPrivateParam<std::vector<std::string>>("some_variable");
   return params;
 }
 

--- a/unit/include/BrineFluidPropertiesTest.h
+++ b/unit/include/BrineFluidPropertiesTest.h
@@ -57,9 +57,7 @@ protected:
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
     problem_params.set<std::string>("_object_name") = "name2";
-
-    auto & fep = _app->actionWarehouse().problemBase();
-    fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     // The brine fluid properties
     InputParameters uo_pars = _factory->getValidParams("BrineFluidProperties");
@@ -70,8 +68,8 @@ protected:
     _water_fp = &_fp->getComponent(BrineFluidProperties::WATER);
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
   Factory * _factory;
   const BrineFluidProperties * _fp;
   const SinglePhaseFluidPropertiesPT * _water_fp;

--- a/unit/include/BrineFluidPropertiesTest.h
+++ b/unit/include/BrineFluidPropertiesTest.h
@@ -56,14 +56,15 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+
+    auto & fep = _app->actionWarehouse().problemBase();
+    fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     // The brine fluid properties
     InputParameters uo_pars = _factory->getValidParams("BrineFluidProperties");
-    _fe_problem->addUserObject("BrineFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<BrineFluidProperties>("fp");
+    fep->addUserObject("BrineFluidProperties", "fp", uo_pars);
+    _fp = &fep->getUserObject<BrineFluidProperties>("fp");
 
     // Get the water properties UserObject
     _water_fp = &_fp->getComponent(BrineFluidProperties::WATER);
@@ -71,7 +72,6 @@ protected:
 
   std::shared_ptr<MooseApp> _app;
   std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const BrineFluidProperties * _fp;
   const SinglePhaseFluidPropertiesPT * _water_fp;

--- a/unit/include/CO2FluidPropertiesTest.h
+++ b/unit/include/CO2FluidPropertiesTest.h
@@ -37,13 +37,12 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters uo_pars = _factory->getValidParams("CO2FluidProperties");
-    _fe_problem->addUserObject("CO2FluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<CO2FluidProperties>("fp");
+    fep->addUserObject("CO2FluidProperties", "fp", uo_pars);
+    _fp = &fep->getUserObject<CO2FluidProperties>("fp");
   }
 
   void SetUp()
@@ -57,9 +56,8 @@ protected:
     buildObjects();
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const CO2FluidProperties * _fp;
 };

--- a/unit/include/IdealGasFluidPropertiesPTTest.h
+++ b/unit/include/IdealGasFluidPropertiesPTTest.h
@@ -44,18 +44,16 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters uo_pars = _factory->getValidParams("IdealGasFluidPropertiesPT");
-    _fe_problem->addUserObject("IdealGasFluidPropertiesPT", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<IdealGasFluidPropertiesPT>("fp");
+    fep->addUserObject("IdealGasFluidPropertiesPT", "fp", uo_pars);
+    _fp = &fep->getUserObject<IdealGasFluidPropertiesPT>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const SinglePhaseFluidPropertiesPT * _fp;
 };

--- a/unit/include/IdealGasFluidPropertiesTest.h
+++ b/unit/include/IdealGasFluidPropertiesTest.h
@@ -44,20 +44,18 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters uo_pars = _factory->getValidParams("IdealGasFluidProperties");
     uo_pars.set<Real>("R") = 287.04;
     uo_pars.set<Real>("gamma") = 1.41;
-    _fe_problem->addUserObject("IdealGasFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<IdealGasFluidProperties>("fp");
+    fep->addUserObject("IdealGasFluidProperties", "fp", uo_pars);
+    _fp = &fep->getUserObject<IdealGasFluidProperties>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const IdealGasFluidProperties * _fp;
 };

--- a/unit/include/MethaneFluidPropertiesTest.h
+++ b/unit/include/MethaneFluidPropertiesTest.h
@@ -44,18 +44,16 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters uo_pars = _factory->getValidParams("MethaneFluidProperties");
-    _fe_problem->addUserObject("MethaneFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<MethaneFluidProperties>("fp");
+    fep->addUserObject("MethaneFluidProperties", "fp", uo_pars);
+    _fp = &fep->getUserObject<MethaneFluidProperties>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const MethaneFluidProperties * _fp;
 };

--- a/unit/include/NaClFluidPropertiesTest.h
+++ b/unit/include/NaClFluidPropertiesTest.h
@@ -44,18 +44,16 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters uo_pars = _factory->getValidParams("NaClFluidProperties");
-    _fe_problem->addUserObject("NaClFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<NaClFluidProperties>("fp");
+    fep->addUserObject("NaClFluidProperties", "fp", uo_pars);
+    _fp = &fep->getUserObject<NaClFluidProperties>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const NaClFluidProperties * _fp;
 };

--- a/unit/include/PorousFlowBrineCO2Test.h
+++ b/unit/include/PorousFlowBrineCO2Test.h
@@ -58,39 +58,37 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters pc_params = _factory->getValidParams("PorousFlowCapillaryPressureVG");
     pc_params.set<Real>("m") = 0.5;
     pc_params.set<Real>("alpha") = 0.1;
-    _fe_problem->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
-    _pc = &_fe_problem->getUserObject<PorousFlowCapillaryPressureVG>("pc");
+    fep->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
+    _pc = &fep->getUserObject<PorousFlowCapillaryPressureVG>("pc");
 
     InputParameters brine_params = _factory->getValidParams("BrineFluidProperties");
-    _fe_problem->addUserObject("BrineFluidProperties", "brine_fp", brine_params);
-    _brine_fp = &_fe_problem->getUserObject<BrineFluidProperties>("brine_fp");
+    fep->addUserObject("BrineFluidProperties", "brine_fp", brine_params);
+    _brine_fp = &fep->getUserObject<BrineFluidProperties>("brine_fp");
 
     InputParameters water_params = _factory->getValidParams("Water97FluidProperties");
-    _fe_problem->addUserObject("Water97FluidProperties", "water_fp", water_params);
-    _water_fp = &_fe_problem->getUserObject<Water97FluidProperties>("water_fp");
+    fep->addUserObject("Water97FluidProperties", "water_fp", water_params);
+    _water_fp = &fep->getUserObject<Water97FluidProperties>("water_fp");
 
     InputParameters co2_params = _factory->getValidParams("CO2FluidProperties");
-    _fe_problem->addUserObject("CO2FluidProperties", "co2_fp", co2_params);
-    _co2_fp = &_fe_problem->getUserObject<CO2FluidProperties>("co2_fp");
+    fep->addUserObject("CO2FluidProperties", "co2_fp", co2_params);
+    _co2_fp = &fep->getUserObject<CO2FluidProperties>("co2_fp");
 
     InputParameters uo_params = _factory->getValidParams("PorousFlowBrineCO2");
     uo_params.set<UserObjectName>("brine_fp") = "brine_fp";
     uo_params.set<UserObjectName>("co2_fp") = "co2_fp";
     uo_params.set<UserObjectName>("capillary_pressure") = "pc";
-    _fe_problem->addUserObject("PorousFlowBrineCO2", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<PorousFlowBrineCO2>("fp");
+    fep->addUserObject("PorousFlowBrineCO2", "fp", uo_params);
+    _fp = &fep->getUserObject<PorousFlowBrineCO2>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   MooseAppPtr _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const PorousFlowCapillaryPressureVG * _pc;
   const PorousFlowBrineCO2 * _fp;

--- a/unit/include/PorousFlowFluidStateFlashTest.h
+++ b/unit/include/PorousFlowFluidStateFlashTest.h
@@ -45,18 +45,16 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters uo_params = _factory->getValidParams("PorousFlowFluidStateFlash");
-    _fe_problem->addUserObject("PorousFlowFluidStateFlash", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<PorousFlowFluidStateFlash>("fp");
+    fep->addUserObject("PorousFlowFluidStateFlash", "fp", uo_params);
+    _fp = &fep->getUserObject<PorousFlowFluidStateFlash>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   MooseAppPtr _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const PorousFlowFluidStateFlash * _fp;
 };

--- a/unit/include/PorousFlowWaterNCGTest.h
+++ b/unit/include/PorousFlowWaterNCGTest.h
@@ -54,35 +54,33 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters pc_params = _factory->getValidParams("PorousFlowCapillaryPressureVG");
     pc_params.set<Real>("m") = 0.5;
     pc_params.set<Real>("alpha") = 0.1;
-    _fe_problem->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
-    _pc = &_fe_problem->getUserObject<PorousFlowCapillaryPressureVG>("pc");
+    fep->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
+    _pc = &fep->getUserObject<PorousFlowCapillaryPressureVG>("pc");
 
     InputParameters water_params = _factory->getValidParams("Water97FluidProperties");
-    _fe_problem->addUserObject("Water97FluidProperties", "water_fp", water_params);
-    _water_fp = &_fe_problem->getUserObject<Water97FluidProperties>("water_fp");
+    fep->addUserObject("Water97FluidProperties", "water_fp", water_params);
+    _water_fp = &fep->getUserObject<Water97FluidProperties>("water_fp");
 
     InputParameters ncg_params = _factory->getValidParams("CO2FluidProperties");
-    _fe_problem->addUserObject("CO2FluidProperties", "ncg_fp", ncg_params);
-    _ncg_fp = &_fe_problem->getUserObject<CO2FluidProperties>("ncg_fp");
+    fep->addUserObject("CO2FluidProperties", "ncg_fp", ncg_params);
+    _ncg_fp = &fep->getUserObject<CO2FluidProperties>("ncg_fp");
 
     InputParameters uo_params = _factory->getValidParams("PorousFlowWaterNCG");
     uo_params.set<UserObjectName>("water_fp") = "water_fp";
     uo_params.set<UserObjectName>("gas_fp") = "ncg_fp";
     uo_params.set<UserObjectName>("capillary_pressure") = "pc";
-    _fe_problem->addUserObject("PorousFlowWaterNCG", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<PorousFlowWaterNCG>("fp");
+    fep->addUserObject("PorousFlowWaterNCG", "fp", uo_params);
+    _fp = &fep->getUserObject<PorousFlowWaterNCG>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   MooseAppPtr _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const PorousFlowCapillaryPressureVG * _pc;
   const PorousFlowWaterNCG * _fp;

--- a/unit/include/SimpleFluidPropertiesTest.h
+++ b/unit/include/SimpleFluidPropertiesTest.h
@@ -44,23 +44,21 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters uo_params = _factory->getValidParams("SimpleFluidProperties");
-    _fe_problem->addUserObject("SimpleFluidProperties", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<SimpleFluidProperties>("fp");
+    fep->addUserObject("SimpleFluidProperties", "fp", uo_params);
+    _fp = &fep->getUserObject<SimpleFluidProperties>("fp");
 
     InputParameters uo2_params = _factory->getValidParams("SimpleFluidProperties");
     uo2_params.set<Real>("porepressure_coefficient") = 0.0;
-    _fe_problem->addUserObject("SimpleFluidProperties", "fp2", uo2_params);
-    _fp2 = &_fe_problem->getUserObject<SimpleFluidProperties>("fp2");
+    fep->addUserObject("SimpleFluidProperties", "fp2", uo2_params);
+    _fp2 = &fep->getUserObject<SimpleFluidProperties>("fp2");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const SimpleFluidProperties * _fp;
   const SimpleFluidProperties * _fp2;

--- a/unit/include/SodiumPropertiesTest.h
+++ b/unit/include/SodiumPropertiesTest.h
@@ -49,19 +49,17 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     // The sodium fluid properties
     InputParameters uo_pars = _factory->getValidParams("SodiumProperties");
-    _fe_problem->addUserObject("SodiumProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<SodiumProperties>("fp");
+    fep->addUserObject("SodiumProperties", "fp", uo_pars);
+    _fp = &fep->getUserObject<SodiumProperties>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const SodiumProperties * _fp;
 };

--- a/unit/include/StiffenedGasFluidPropertiesTest.h
+++ b/unit/include/StiffenedGasFluidPropertiesTest.h
@@ -44,9 +44,8 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters eos_pars = _factory->getValidParams("StiffenedGasFluidProperties");
     eos_pars.set<Real>("gamma") = 2.35;
@@ -55,13 +54,12 @@ protected:
     eos_pars.set<Real>("p_inf") = 1.e9;
     eos_pars.set<Real>("cv") = 1816;
     eos_pars.set<std::string>("_object_name") = "name3";
-    _fe_problem->addUserObject("StiffenedGasFluidProperties", "fp", eos_pars);
-    _fp = &_fe_problem->getUserObject<StiffenedGasFluidProperties>("fp");
+    fep->addUserObject("StiffenedGasFluidProperties", "fp", eos_pars);
+    _fp = &fep->getUserObject<StiffenedGasFluidProperties>("fp");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const StiffenedGasFluidProperties * _fp;
 };

--- a/unit/include/TabulatedFluidPropertiesTest.h
+++ b/unit/include/TabulatedFluidPropertiesTest.h
@@ -64,8 +64,8 @@ protected:
     tab_gen_uo_params.set<Real>("pressure_max") = 2e6;
     tab_gen_uo_params.set<unsigned int>("num_T") = 6;
     tab_gen_uo_params.set<unsigned int>("num_p") = 6;
-    _fe_problem->addUserObject("TabulatedFluidProperties", "tab_gen_fp", tab_gen_uo_params);
-    _tab_gen_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("tab_gen_fp");
+    fep->addUserObject("TabulatedFluidProperties", "tab_gen_fp", tab_gen_uo_params);
+    _tab_gen_fp = &fep->getUserObject<TabulatedFluidProperties>("tab_gen_fp");
 
     InputParameters unordered_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     unordered_uo_params.set<UserObjectName>("fp") = "co2_fp";
@@ -89,8 +89,8 @@ protected:
     InputParameters unknown_col_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     unknown_col_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unknown_col_uo_params.set<FileName>("fluid_property_file") = "data/csv/unknown_fluid_props.csv";
-    _fe_problem->addUserObject("TabulatedFluidProperties", "unknown_col_fp", unknown_col_uo_params);
-    _unknown_col_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unknown_col_fp");
+    fep->addUserObject("TabulatedFluidProperties", "unknown_col_fp", unknown_col_uo_params);
+    _unknown_col_fp = &fep->getUserObject<TabulatedFluidProperties>("unknown_col_fp");
 
     InputParameters missing_data_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     missing_data_uo_params.set<UserObjectName>("fp") = "co2_fp";

--- a/unit/include/TabulatedFluidPropertiesTest.h
+++ b/unit/include/TabulatedFluidPropertiesTest.h
@@ -43,19 +43,18 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters co2_uo_params = _factory->getValidParams("CO2FluidProperties");
-    _fe_problem->addUserObject("CO2FluidProperties", "co2_fp", co2_uo_params);
-    _co2_fp = &_fe_problem->getUserObject<CO2FluidProperties>("co2_fp");
+    fep->addUserObject("CO2FluidProperties", "co2_fp", co2_uo_params);
+    _co2_fp = &fep->getUserObject<CO2FluidProperties>("co2_fp");
 
     InputParameters tab_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     tab_uo_params.set<UserObjectName>("fp") = "co2_fp";
     tab_uo_params.set<FileName>("fluid_property_file") = "data/csv/fluid_props.csv";
-    _fe_problem->addUserObject("TabulatedFluidProperties", "tab_fp", tab_uo_params);
-    _tab_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("tab_fp");
+    fep->addUserObject("TabulatedFluidProperties", "tab_fp", tab_uo_params);
+    _tab_fp = &fep->getUserObject<TabulatedFluidProperties>("tab_fp");
 
     InputParameters tab_gen_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     tab_gen_uo_params.set<UserObjectName>("fp") = "co2_fp";
@@ -71,21 +70,21 @@ protected:
     InputParameters unordered_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     unordered_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unordered_uo_params.set<FileName>("fluid_property_file") = "data/csv/unordered_fluid_props.csv";
-    _fe_problem->addUserObject("TabulatedFluidProperties", "unordered_fp", unordered_uo_params);
-    _unordered_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unordered_fp");
+    fep->addUserObject("TabulatedFluidProperties", "unordered_fp", unordered_uo_params);
+    _unordered_fp = &fep->getUserObject<TabulatedFluidProperties>("unordered_fp");
 
     InputParameters unequal_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     unequal_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unequal_uo_params.set<FileName>("fluid_property_file") = "data/csv/unequal_fluid_props.csv";
-    _fe_problem->addUserObject("TabulatedFluidProperties", "unequal_fp", unequal_uo_params);
-    _unequal_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unequal_fp");
+    fep->addUserObject("TabulatedFluidProperties", "unequal_fp", unequal_uo_params);
+    _unequal_fp = &fep->getUserObject<TabulatedFluidProperties>("unequal_fp");
 
     InputParameters missing_col_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     missing_col_uo_params.set<UserObjectName>("fp") = "co2_fp";
     missing_col_uo_params.set<FileName>("fluid_property_file") =
         "data/csv/missing_col_fluid_props.csv";
-    _fe_problem->addUserObject("TabulatedFluidProperties", "missing_col_fp", missing_col_uo_params);
-    _missing_col_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("missing_col_fp");
+    fep->addUserObject("TabulatedFluidProperties", "missing_col_fp", missing_col_uo_params);
+    _missing_col_fp = &fep->getUserObject<TabulatedFluidProperties>("missing_col_fp");
 
     InputParameters unknown_col_uo_params = _factory->getValidParams("TabulatedFluidProperties");
     unknown_col_uo_params.set<UserObjectName>("fp") = "co2_fp";
@@ -97,9 +96,8 @@ protected:
     missing_data_uo_params.set<UserObjectName>("fp") = "co2_fp";
     missing_data_uo_params.set<FileName>("fluid_property_file") =
         "data/csv/missing_data_fluid_props.csv";
-    _fe_problem->addUserObject(
-        "TabulatedFluidProperties", "missing_data_fp", missing_data_uo_params);
-    _missing_data_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("missing_data_fp");
+    fep->addUserObject("TabulatedFluidProperties", "missing_data_fp", missing_data_uo_params);
+    _missing_data_fp = &fep->getUserObject<TabulatedFluidProperties>("missing_data_fp");
   }
 
   void SetUp()
@@ -120,9 +118,8 @@ protected:
     std::remove("fluid_properties.csv");
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const CO2FluidProperties * _co2_fp;
   const TabulatedFluidProperties * _tab_fp;

--- a/unit/include/Water97FluidPropertiesTest.h
+++ b/unit/include/Water97FluidPropertiesTest.h
@@ -45,13 +45,12 @@ protected:
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("name") = "problem";
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
 
     InputParameters uo_pars = _factory->getValidParams("Water97FluidProperties");
-    _fe_problem->addUserObject("Water97FluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<Water97FluidProperties>("fp");
+    fep->addUserObject("Water97FluidProperties", "fp", uo_pars);
+    _fp = &fep->getUserObject<Water97FluidProperties>("fp");
   }
 
   void regionDerivatives(Real p, Real T, Real tol)
@@ -91,9 +90,8 @@ protected:
     REL_TEST("de_dT", de_dT, de_dT_fd, tol);
   }
 
+  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
   std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
   Factory * _factory;
   const Water97FluidProperties * _fp;
 };


### PR DESCRIPTION
There were several places in moose and the modules where we were inserting parameters that weren't logged in validParams functions that had to be fixed.  All setting of the ``_fe_problem`` special parameter was also consolidated/refactored to reside inside the factory.

fixes #10357