### PR TITLE
Split stderr and stdout

### DIFF
--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -114,8 +114,8 @@ class Job(object):
 
     def setOutput(self, output):
         """ Method to allow schedulers to overwrite the output if certain conditions are met """
-        if not self.__tester.outfile is None and not self.__tester.outfile.closed \
-           and not self.__tester.errfile is None and not self.__tester.errfile.closed:
+        if (not self.__tester.outfile is None and not self.__tester.outfile.closed
+           and not self.__tester.errfile is None and not self.__tester.errfile.closed):
             return
         self.__joined_out = output
 

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -42,7 +42,7 @@ class Job(object):
         self.__outfile = None
         self.__start_time = clock()
         self.__end_time = None
-        self.__std_out = ''
+        self.__joined_out = ''
         self.report_timer = None
         self.__slots = None
         self.__unique_identifier = os.path.join(tester.getTestDir(), tester.getTestName())
@@ -94,7 +94,7 @@ class Job(object):
         self.__tester.run(self.timer, self.options)
         self.__start_time = self.timer.starts[0]
         self.__end_time = self.timer.ends[-1]
-        self.__std_out = self.__tester.std_out
+        self.__joined_out = self.__tester.joined_out
 
     def killProcess(self):
         """ Kill remaining process that may be running """
@@ -110,23 +110,24 @@ class Job(object):
 
     def getOutput(self):
         """ Return the contents of output """
-        return self.__std_out
+        return self.__joined_out
 
     def setOutput(self, output):
         """ Method to allow schedulers to overwrite the output if certain conditions are met """
-        if not self.__tester.outfile is None and not self.__tester.outfile.closed:
+        if not self.__tester.outfile is None and not self.__tester.outfile.closed \
+           and not self.__tester.errfile is None and not self.__tester.errfile.closed:
             return
-        self.__std_out = output
+        self.__joined_out = output
 
     def getActiveTime(self):
         """ Return active time """
-        m = re.search(r"Active time=(\S+)", self.__std_out)
+        m = re.search(r"Active time=(\S+)", self.__joined_out)
         if m != None:
             return m.group(1)
 
     def getSolveTime(self):
         """ Return solve time """
-        m = re.search(r"solve().*", self.__std_out)
+        m = re.search(r"solve().*", self.__joined_out)
         if m != None:
             return m.group().split()[5]
 

--- a/python/TestHarness/schedulers/QueueManager.py
+++ b/python/TestHarness/schedulers/QueueManager.py
@@ -427,7 +427,7 @@ class QueueManager(Scheduler):
                     with open(stdout_file, 'r') as f:
                         # We can use trimmed output here, now that the job has a proper
                         # status (we are not going to run processResults again).
-                        outfile = util.readOutput(f, self.options)
+                        outfile = util.readOutput(f, None, self.options)
                     job.setOutput(outfile)
                 else:
                     with self.dag_lock:

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -597,20 +597,24 @@ def getOutputFromFiles(tester, options):
         for iteration, redirected_file in enumerate(tester.getRedirectedOutputFiles(options)):
             file_path = os.path.join(tester.getTestDir(), redirected_file)
             with open(file_path, 'r') as f:
-                file_output += "#"*80 + "\nOutput from processor " + str(iteration) + "\n" + "#"*80 + "\n" + readOutput(f, options)
+                file_output += "#"*80 + "\nOutput from processor " + str(iteration) \
+                               + "\n" + "#"*80 + "\n" + readOutput(f, None, options)
     return file_output
 
 # This function reads output from the file (i.e. the test output)
 # but trims it down to the specified size.  It'll save the first two thirds
 # of the requested size and the last third trimming from the middle
-def readOutput(f, options, max_size=100000):
+def readOutput(f, e, options, max_size=100000):
     first_part = int(max_size*(2.0/3.0))
     second_part = int(max_size*(1.0/3.0))
     output = ''
 
     f.seek(0)
+    if e:
+        e.seek(0)
     if options.no_trimmed_output or options.sep_files == True:
         output += f.read()
+        output += e.read()
 
     else:
         output = f.read(first_part)     # Limit the output to 1MB
@@ -621,7 +625,9 @@ def readOutput(f, options, max_size=100000):
             if (f.tell() <= first_part):  # Don't re-read some of what you've already read
                 f.seek(first_part+1, 0)
 
-        output += f.read()              # Now read the rest
+        output += f.read()          # Now read the rest
+        if e:
+            output += e.read()      # Do not trim errors
     return output
 
 class TestStatus(object):


### PR DESCRIPTION
When launching subprocess, split the stdout and stderr
streams into two tempfiles. Combine them later once the
job has finished, so as to prevent possible clobbered
results.

Closes #10552
