### PR TITLE
Header Linking For Compile Speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ temp_print_trace.*
 .clang_complete
 .failed_tests
 compile_commands.json
+build
 
 # Allow certain files in gold directories
 !**/gold/*.e

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -5,6 +5,8 @@
 # list of application-wide excluded source files
 excluded_srcfiles :=
 
+APPLICATION_INCLUDE_DEPTH ?= 3
+
 #
 # Save off parameters for possible app.mk recursion
 #
@@ -127,15 +129,18 @@ else
 endif
 
 # all_header_directory
-app_all_header_dir := $(APPLICATION_DIR)/all_headers
-
-$(shell mkdir -p $(app_all_header_dir))
+all_header_dir := $(APPLICATION_DIR)/build/header_symlinks
 
 # header file links
 
-link_names := $(foreach i, $(include_files), $(app_all_header_dir)/$(notdir $(i)))
+link_names := $(foreach i, $(include_files), $(all_header_dir)/$(notdir $(i)))
 
-$(foreach i, $(include_files), $(shell ln -sf $(i) $(app_all_header_dir)/$(notdir $(i))))
+$(eval $(call all_header_dir_rule, $(all_header_dir)))
+$(call create_symlink_rules,$(APPLICATION_DIR),$(APPLICATION_INCLUDE_DEPTH))
+
+header_symlinks:: $(all_header_dir) $(link_names)
+
+#$(foreach i, $(include_files), $(shell ln -sf $(i) $(app_all_header_dir)/$(notdir $(i))))
 
 # application
 app_EXEC    := $(APPLICATION_DIR)/$(APPLICATION_NAME)-$(METHOD)
@@ -175,7 +180,7 @@ endif
 app_LIBS       := $(app_LIB) $(app_LIBS)
 app_LIBS_other := $(filter-out $(app_LIB),$(app_LIBS))
 app_HEADERS    := $(app_HEADER) $(app_HEADERS)
-app_INCLUDES   += -I$(app_all_header_dir) $(ADDITIONAL_INCLUDES)
+app_INCLUDES   += -I$(all_header_dir) $(ADDITIONAL_INCLUDES)
 app_DIRS       += $(APPLICATION_DIR)
 
 # WARNING: the += operator does NOT work here!

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -65,18 +65,18 @@ header_symlinks::
 #
 # C++ rules
 #
-pcre%.$(obj-suffix) : pcre%.cc header_symlinks
+pcre%.$(obj-suffix) : pcre%.cc
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-%.$(obj-suffix) : %.cc header_symlinks
+%.$(obj-suffix) : %.cc
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 define CXX_RULE_TEMPLATE
-%$(1).$(obj-suffix) : %.C header_symlinks
+%$(1).$(obj-suffix) : %.C
 ifeq ($(1),)
 	@echo "MOOSE Compiling C++ (in "$$(METHOD)" mode) "$$<"..."
 else
@@ -88,7 +88,7 @@ endef
 # Instantiate Rules
 $(eval $(call CXX_RULE_TEMPLATE,))
 
-%.$(obj-suffix) : %.cpp header_symlinks
+%.$(obj-suffix) : %.cpp
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
@@ -97,11 +97,11 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 # Static Analysis
 #
 
-%.plist.$(obj-suffix) : %.C header_symlinks
+%.plist.$(obj-suffix) : %.C
 	@echo "Clang Static Analysis (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_CXX) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) --analyze $< -o $@
 
-%.plist.$(obj-suffix) : %.cc header_symlinks
+%.plist.$(obj-suffix) : %.cc
 	@echo "Clang Static Analysis (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_CXX) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) --analyze $< -o $@
 
@@ -109,12 +109,12 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 # C rules
 #
 
-pcre%.$(obj-suffix) : pcre%.c header_symlinks
+pcre%.$(obj-suffix) : pcre%.c
 	@echo "MOOSE Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-%.$(obj-suffix) : %.c header_symlinks
+%.$(obj-suffix) : %.c
 	@echo "MOOSE Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
@@ -125,7 +125,7 @@ pcre%.$(obj-suffix) : pcre%.c header_symlinks
 # Fortran77 rules
 #
 
-%.$(obj-suffix) : %.f header_symlinks
+%.$(obj-suffix) : %.f
 	@echo "MOOSE Compiling Fortan (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=F77 $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_F77) $(libmesh_FFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -c $< -o $@
@@ -136,7 +136,7 @@ pcre%.$(obj-suffix) : pcre%.c header_symlinks
 #
 
 PreProcessed_FFLAGS := $(libmesh_FFLAGS)
-%.$(obj-suffix) : %.F header_symlinks
+%.$(obj-suffix) : %.F
 	@echo "MOOSE Compiling Fortran (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=F77 $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_F90) $(PreProcessed_FFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -c $< $(module_dir_flag) -o $@

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -59,33 +59,36 @@ endif
 
 all::
 
+# Add all header symlinks as dependencies to this target
+header_symlinks::
+
 #
 # C++ rules
 #
-pcre%.$(obj-suffix) : pcre%.cc
+pcre%.$(obj-suffix) : pcre%.cc header_symlinks
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-%.$(obj-suffix) : %.cc
+%.$(obj-suffix) : %.cc header_symlinks
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 define CXX_RULE_TEMPLATE
-%$(1).$(obj-suffix) : %.C
+%$(1).$(obj-suffix) : %.C header_symlinks
 ifeq ($(1),)
 	@echo "MOOSE Compiling C++ (in "$$(METHOD)" mode) "$$<"..."
 else
 	@echo "MOOSE Compiling C++ with suffix (in "$$(METHOD)" mode) "$$<"..."
 endif
-	$$(libmesh_LIBTOOL) --tag=CXX $$(LIBTOOLFLAGS) --mode=compile --quiet \
+	@$$(libmesh_LIBTOOL) --tag=CXX $$(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $$(libmesh_CXX) $$(libmesh_CPPFLAGS) $$(ADDITIONAL_CPPFLAGS) $$(libmesh_CXXFLAGS) $$(app_INCLUDES) $$(libmesh_INCLUDE) -MMD -MP -MF $$@.d -MT $$@ -c $$< -o $$@
 endef
 # Instantiate Rules
 $(eval $(call CXX_RULE_TEMPLATE,))
 
-%.$(obj-suffix) : %.cpp
+%.$(obj-suffix) : %.cpp header_symlinks
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
@@ -94,11 +97,11 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 # Static Analysis
 #
 
-%.plist.$(obj-suffix) : %.C
+%.plist.$(obj-suffix) : %.C header_symlinks
 	@echo "Clang Static Analysis (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_CXX) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) --analyze $< -o $@
 
-%.plist.$(obj-suffix) : %.cc
+%.plist.$(obj-suffix) : %.cc header_symlinks
 	@echo "Clang Static Analysis (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_CXX) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) --analyze $< -o $@
 
@@ -106,12 +109,12 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 # C rules
 #
 
-pcre%.$(obj-suffix) : pcre%.c
+pcre%.$(obj-suffix) : pcre%.c header_symlinks
 	@echo "MOOSE Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-%.$(obj-suffix) : %.c
+%.$(obj-suffix) : %.c header_symlinks
 	@echo "MOOSE Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
@@ -122,7 +125,7 @@ pcre%.$(obj-suffix) : pcre%.c
 # Fortran77 rules
 #
 
-%.$(obj-suffix) : %.f
+%.$(obj-suffix) : %.f header_symlinks
 	@echo "MOOSE Compiling Fortan (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=F77 $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_F77) $(libmesh_FFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -c $< -o $@
@@ -133,7 +136,7 @@ pcre%.$(obj-suffix) : pcre%.c
 #
 
 PreProcessed_FFLAGS := $(libmesh_FFLAGS)
-%.$(obj-suffix) : %.F
+%.$(obj-suffix) : %.F header_symlinks
 	@echo "MOOSE Compiling Fortran (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=F77 $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_F90) $(PreProcessed_FFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -c $< $(module_dir_flag) -o $@

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -79,7 +79,7 @@ ifeq ($(1),)
 else
 	@echo "MOOSE Compiling C++ with suffix (in "$$(METHOD)" mode) "$$<"..."
 endif
-	@$$(libmesh_LIBTOOL) --tag=CXX $$(LIBTOOLFLAGS) --mode=compile --quiet \
+	$$(libmesh_LIBTOOL) --tag=CXX $$(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $$(libmesh_CXX) $$(libmesh_CPPFLAGS) $$(ADDITIONAL_CPPFLAGS) $$(libmesh_CXXFLAGS) $$(app_INCLUDES) $$(libmesh_INCLUDE) -MMD -MP -MF $$@.d -MT $$@ -c $$< -o $$@
 endef
 # Instantiate Rules

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -47,7 +47,25 @@ gtest_LIB       := $(gtest_DIR)/libgtest.la
 # dependency files
 gtest_deps      := $(patsubst %.cc, %.$(obj-suffix).d, $(gtest_srcfiles))
 
-moose_INC_DIRS := $(shell find $(FRAMEWORK_DIR)/include -type d -not -path "*/.svn*")
+#moose_INC_DIRS := $(shell find $(FRAMEWORK_DIR)/include -type d -not -path "*/.svn*")
+
+moose_all_header_dir := $(FRAMEWORK_DIR)/all_headers
+
+$(shell mkdir -p $(moose_all_header_dir))
+
+include_files	:= $(shell find $(FRAMEWORK_DIR)/include -name "*.h" | grep -v "\.svn")
+link_names := $(foreach i, $(include_files), $(moose_all_header_dir)/$(notdir $(i)))
+
+#define header_rule
+#$(moose_all_header_dir)/$(notdir $(1)): $(1) $(moose_all_header_dir)
+#	ln -sf $$< $$@
+#endef
+
+#$(foreach i, $(include_files), $(eval $(call header_rule, $(i))))
+
+$(foreach i, $(include_files), $(shell ln -sf $(i) $(moose_all_header_dir)/$(notdir $(i))))
+
+moose_INC_DIRS := $(moose_all_header_dir)
 moose_INC_DIRS += $(shell find $(FRAMEWORK_DIR)/contrib/*/include -type d -not -path "*/.svn*")
 moose_INC_DIRS += "$(gtest_DIR)"
 moose_INC_DIRS += "$(hit_DIR)"
@@ -81,7 +99,7 @@ moose_analyzer += $(patsubst %.cc, %.plist.$(obj-suffix), $(hit_srcfiles))
 app_INCLUDES := $(moose_INCLUDE)
 app_LIBS     := $(moose_LIBS)
 app_DIRS     := $(FRAMEWORK_DIR)
-all:: libmesh_submodule_status moose_revision moose
+all:: | libmesh_submodule_status moose_revision $(link_names) moose
 
 # revision header
 moose_revision_header = $(FRAMEWORK_DIR)/include/base/MooseRevision.h


### PR DESCRIPTION
This PR closes #10524 by linking all of the headers of each app into a directory called `build/header_symlinks` in each app.  By doing this compilation of modules+moose went from ~13m to ~3m.

Everything is implemented using pure Make by adding a few more rules.  I think the end code is pretty clean.