### PR TITLE
Return a list of files ready to be read

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -359,6 +359,8 @@ class Tester(MooseObject):
         timer.stop()
 
         self.exit_code = process.poll()
+        self.outfile.flush()
+        self.errfile.flush()
 
         # store the contents of output, and close the file
         self.joined_out = util.readOutput(self.outfile, self.errfile, options)

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -583,22 +583,21 @@ def deleteFilesAndFolders(test_dir, paths, delete_folders=True):
 
 # Check if test has any redirected output, and if its ready to be read
 def checkOutputReady(tester, options):
+    checked_files = []
     for redirected_file in tester.getRedirectedOutputFiles(options):
         file_path = os.path.join(tester.getTestDir(), redirected_file)
-        if not os.access(file_path, os.R_OK):
-            return False
-
-    return True
+        if os.access(file_path, os.R_OK):
+            checked_files.append(file_path)
+    return checked_files
 
 # return concatenated output from tests with redirected output
 def getOutputFromFiles(tester, options):
     file_output = ''
-    if checkOutputReady(tester, options):
-        for iteration, redirected_file in enumerate(tester.getRedirectedOutputFiles(options)):
-            file_path = os.path.join(tester.getTestDir(), redirected_file)
-            with open(file_path, 'r') as f:
-                file_output += "#"*80 + "\nOutput from processor " + str(iteration) \
-                               + "\n" + "#"*80 + "\n" + readOutput(f, None, options)
+    output_files = checkOutputReady(tester, options)
+    for process, file_path in enumerate(output_files):
+        with open(file_path, 'r') as f:
+            file_output += "#"*80 + "\nOutput from processor " + str(process) \
+                           + "\n" + "#"*80 + "\n" + readOutput(f, None, options)
     return file_output
 
 # This function reads output from the file (i.e. the test output)

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -594,9 +594,9 @@ def checkOutputReady(tester, options):
 def getOutputFromFiles(tester, options):
     file_output = ''
     output_files = checkOutputReady(tester, options)
-    for process, file_path in enumerate(output_files):
+    for file_path in output_files:
         with open(file_path, 'r') as f:
-            file_output += "#"*80 + "\nOutput from processor " + str(process) \
+            file_output += "#"*80 + "\nOutput from " + file_path \
                            + "\n" + "#"*80 + "\n" + readOutput(f, None, options)
     return file_output
 


### PR DESCRIPTION
Instead of returning False or True, return a list of available files. The
issue with no expected out, was due to having just one output not available.

Take the following example:

  ./run_tests -p 4

Process 2 has the output we need to regex (RunException), but process 3, was
killed by MPI, and never created a file. This caused checkOutputReady to
return false. Yet the other processes successfully created output, and thus,
would have been found by RunException.

This issue was most apparent on Virtual Machines with slow filesystems:

  https://www.moosebuild.org/job/147018/

However, we rarely also saw this on our build machines (invalidate, and then
the test magically passes later). Finally... a fix!

The change to the Tester (outfie, errfile) .flush was something recommended
by Brian, that might solve this issue. Leaving it in there, because we should
be flushing the buffer anyways.

Closes #10570 
