### PR TITLE
Change member access in FunctionPenaltyDirichletBC

### DIFF
--- a/framework/include/bcs/FunctionPenaltyDirichletBC.h
+++ b/framework/include/bcs/FunctionPenaltyDirichletBC.h
@@ -42,9 +42,9 @@ protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
 
-private:
   Function & _func;
 
+private:
   Real _p;
 };
 


### PR DESCRIPTION
Moves the `_func` member variable of `FunctionPenaltyDirichletBC` to `protected` accessibility.

Closes #10580