### PR TITLE
Fix validParams brain damage 

### DIFF
--- a/framework/include/auxkernels/AuxNodalScalarKernel.h
+++ b/framework/include/auxkernels/AuxNodalScalarKernel.h
@@ -20,9 +20,10 @@
 #include "MooseVariableDependencyInterface.h"
 
 class NodalScalarKernel;
+class AuxNodalScalarKernel;
 
 template <>
-InputParameters validParams<NodalScalarKernel>();
+InputParameters validParams<AuxNodalScalarKernel>();
 
 /**
  *

--- a/framework/include/auxkernels/ParsedAux.h
+++ b/framework/include/auxkernels/ParsedAux.h
@@ -22,7 +22,7 @@
 class ParsedAux;
 
 template <>
-InputParameters validParams<AuxKernel>();
+InputParameters validParams<ParsedAux>();
 
 /**
  * AuxKernel that evaluates a parsed function expression

--- a/framework/include/base/ComputeMaterialsObjectThread.h
+++ b/framework/include/base/ComputeMaterialsObjectThread.h
@@ -12,8 +12,8 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef COMPUTERESIDUALTHREAD_H
-#define COMPUTERESIDUALTHREAD_H
+#ifndef COMPUTEMATERIALOBJECTTHREAD_H
+#define COMPUTEMATERIALOBJECTTHREAD_H
 
 #include "ThreadedElementLoop.h"
 

--- a/framework/include/kernels/ParsedODEKernel.h
+++ b/framework/include/kernels/ParsedODEKernel.h
@@ -22,7 +22,7 @@
 class ParsedODEKernel;
 
 template <>
-InputParameters validParams<ODEKernel>();
+InputParameters validParams<ParsedODEKernel>();
 
 /**
  *

--- a/framework/include/outputs/AdvancedOutput.h
+++ b/framework/include/outputs/AdvancedOutput.h
@@ -29,6 +29,11 @@ class PetscOutput;
 class Console;
 class TransientMultiApp;
 
+class AdvancedOutput;
+
+template <>
+InputParameters validParams<AdvancedOutput>();
+
 /**
  * Based class for output objects
  *

--- a/framework/include/splits/Split.h
+++ b/framework/include/splits/Split.h
@@ -24,6 +24,11 @@
 // Forward declarations
 class FEProblemBase;
 
+class Split;
+
+template <>
+InputParameters validParams<Split>();
+
 /**
  * Base class for split-based preconditioners.
  */

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -516,8 +516,8 @@ public:
   void defaultCoupledValue(const std::string & coupling_name, Real value);
 
   /**
-  * Returns the auto build vectors for all parameters.
-  */
+   * Returns the auto build vectors for all parameters.
+   */
   std::map<std::string, std::pair<std::string, std::string>> getAutoBuildVectors() const;
 
   /**
@@ -810,11 +810,7 @@ private:
   bool _allow_copy;
 
   // These are the only objects allowed to _create_ InputParameters
-  friend InputParameters validParams<MooseObject>();
-  friend InputParameters validParams<Action>();
-  friend InputParameters validParams<Problem>();
   friend InputParameters emptyInputParameters();
-  friend InputParameters validParams<MooseApp>();
   friend class InputParameterWarehouse;
 };
 
@@ -1343,5 +1339,14 @@ InputParameters::getParamHelper(const std::string & name,
 }
 
 InputParameters emptyInputParameters();
+
+template <class T>
+InputParameters
+validParams()
+{
+  static_assert(false && sizeof(T), "Missing validParams declaration!");
+
+  mooseError("Missing validParams declaration!");
+}
 
 #endif /* INPUTPARAMETERS_H */

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -22,7 +22,7 @@ template <>
 InputParameters
 validParams<Action>()
 {
-  InputParameters params;
+  InputParameters params = emptyInputParameters();
 
   /**
    * Add the "active" and "inactive" parameters so that all blocks in the input file can selectively

--- a/framework/src/actions/MooseObjectAction.C
+++ b/framework/src/actions/MooseObjectAction.C
@@ -12,6 +12,7 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
+#include "MooseObject.h"
 #include "MooseObjectAction.h"
 #include "MooseUtils.h"
 #include "Factory.h"
@@ -26,6 +27,9 @@ validParams<MooseObjectAction>()
   params.addParam<bool>("isObjectAction", true, "Indicates that this is a MooseObjectAction.");
   return params;
 }
+
+template <>
+InputParameters validParams<MooseObject>();
 
 MooseObjectAction::MooseObjectAction(InputParameters params)
   : Action(params),

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -59,7 +59,7 @@ template <>
 InputParameters
 validParams<MooseApp>()
 {
-  InputParameters params;
+  InputParameters params = emptyInputParameters();
 
   params.addCommandLineParam<bool>(
       "display_version", "-v --version", false, "Print application version");

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -21,7 +21,7 @@ template <>
 InputParameters
 validParams<MooseObject>()
 {
-  InputParameters params;
+  InputParameters params = emptyInputParameters();
   params.addParam<bool>("enable", true, "Set the enabled status of the MooseObject.");
   params.addParam<std::vector<std::string>>(
       "control_tags",

--- a/framework/src/base/Problem.C
+++ b/framework/src/base/Problem.C
@@ -20,7 +20,7 @@ template <>
 InputParameters
 validParams<Problem>()
 {
-  InputParameters params;
+  InputParameters params = emptyInputParameters();
   params += validParams<MooseObject>();
   params.registerBase("Problem");
   return params;

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -20,6 +20,7 @@
 #include "ExecFlagEnum.h"
 #include "Parser.h"
 #include "pcrecpp.h"
+#include "Action.h"
 
 // C++ includes
 #include <algorithm>

--- a/modules/contact/include/ContactSplit.h
+++ b/modules/contact/include/ContactSplit.h
@@ -18,6 +18,11 @@
 // MOOSE includes
 #include "Split.h"
 
+class ContactSplit;
+
+template <>
+InputParameters validParams<ContactSplit>();
+
 /**
  * Split-based preconditioner for contact problems.
  */

--- a/modules/fluid_properties/include/userobjects/TwoPhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TwoPhaseFluidProperties.h
@@ -13,6 +13,9 @@
 class TwoPhaseFluidProperties;
 class SinglePhaseFluidProperties;
 
+template <>
+InputParameters validParams<TwoPhaseFluidProperties>();
+
 /**
  * Base class for fluid properties used with two phase flow
  */

--- a/modules/level_set/include/base/LevelSetProblem.h
+++ b/modules/level_set/include/base/LevelSetProblem.h
@@ -5,6 +5,9 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
+#ifndef LEVELSETPROBLEM_H
+#define LEVELSETPROBLEM_H
+
 #include "FEProblem.h"
 
 class LevelSetProblem;
@@ -23,3 +26,5 @@ public:
 
   virtual bool adaptMesh() override;
 };
+
+#endif

--- a/modules/level_set/include/base/LevelSetReinitializationProblem.h
+++ b/modules/level_set/include/base/LevelSetReinitializationProblem.h
@@ -5,6 +5,9 @@
 /*             See LICENSE for full restrictions                */
 /****************************************************************/
 
+#ifndef LEVELSETREINITIALIZATIONPROBLEM_H
+#define LEVELSETREINITIALIZATIONPROBLEM_H
+
 #include "FEProblem.h"
 
 class LevelSetReinitializationProblem;
@@ -27,3 +30,5 @@ public:
    */
   void resetTime();
 };
+
+#endif

--- a/modules/phase_field/include/kernels/ConservedLangevinNoise.h
+++ b/modules/phase_field/include/kernels/ConservedLangevinNoise.h
@@ -14,7 +14,7 @@
 class ConservedLangevinNoise;
 
 template <>
-InputParameters validParams<LangevinNoise>();
+InputParameters validParams<ConservedLangevinNoise>();
 
 class ConservedLangevinNoise : public LangevinNoise
 {

--- a/modules/phase_field/include/materials/ComputePolycrystalElasticityTensor.h
+++ b/modules/phase_field/include/materials/ComputePolycrystalElasticityTensor.h
@@ -15,6 +15,9 @@
 class ComputePolycrystalElasticityTensor;
 class EulerAngleProvider;
 
+template <>
+InputParameters validParams<ComputePolycrystalElasticityTensor>();
+
 /**
  * Compute an evolving elasticity tensor coupled to a grain growth phase field model.
  */

--- a/modules/phase_field/include/materials/ElasticEnergyMaterial.h
+++ b/modules/phase_field/include/materials/ElasticEnergyMaterial.h
@@ -15,7 +15,7 @@ class RankTwoTensor;
 class RankFourTensor;
 
 template <>
-InputParameters validParams<DerivativeFunctionMaterialBase>();
+InputParameters validParams<ElasticEnergyMaterial>();
 
 /**
  * Material class to compute the elastic free energy and its derivatives

--- a/modules/porous_flow/include/materials/PorousFlowVolumetricStrain.h
+++ b/modules/porous_flow/include/materials/PorousFlowVolumetricStrain.h
@@ -11,6 +11,11 @@
 #include "PorousFlowMaterialVectorBase.h"
 #include "RankTwoTensor.h"
 
+class PorousFlowVolumetricStrain;
+
+template <>
+InputParameters validParams<PorousFlowVolumetricStrain>();
+
 /**
  * PorousFlowVolumetricStrain computes volumetric strains, and derivatives thereof
  */

--- a/modules/solid_mechanics/include/materials/CLSHPlasticMaterial.h
+++ b/modules/solid_mechanics/include/materials/CLSHPlasticMaterial.h
@@ -25,7 +25,4 @@ public:
 protected:
 };
 
-template <>
-InputParameters validParams<CLSHPlasticMaterial>();
-
 #endif // CLSHPLASTICMATERIAL_H

--- a/modules/solid_mechanics/include/materials/CLSHPlasticMaterial.h
+++ b/modules/solid_mechanics/include/materials/CLSHPlasticMaterial.h
@@ -9,6 +9,11 @@
 
 #include "SolidModel.h"
 
+class CLSHPlasticMaterial;
+
+template <>
+InputParameters validParams<CLSHPlasticMaterial>();
+
 /**
  * Plastic material
  */

--- a/modules/solid_mechanics/include/materials/CLSHPlasticModel.h
+++ b/modules/solid_mechanics/include/materials/CLSHPlasticModel.h
@@ -9,6 +9,11 @@
 
 #include "ReturnMappingModel.h"
 
+class CLSHPlasticModel;
+
+template <>
+InputParameters validParams<CLSHPlasticModel>();
+
 /**
  * Plastic material
  */

--- a/modules/solid_mechanics/include/materials/CLSHPlasticModel.h
+++ b/modules/solid_mechanics/include/materials/CLSHPlasticModel.h
@@ -49,7 +49,4 @@ protected:
   const MaterialProperty<SymmTensor> & _plastic_strain_old;
 };
 
-template <>
-InputParameters validParams<CLSHPlasticModel>();
-
 #endif // CLSHPLASTICMODEL_H

--- a/modules/solid_mechanics/include/materials/CombinedCreepPlasticity.h
+++ b/modules/solid_mechanics/include/materials/CombinedCreepPlasticity.h
@@ -11,6 +11,11 @@
 
 class ReturnMappingModel;
 
+class CombinedCreepPlasticity;
+
+template <>
+InputParameters validParams<CombinedCreepPlasticity>();
+
 /**
  * One or more constitutive models coupled together.
  */

--- a/modules/solid_mechanics/include/materials/CombinedCreepPlasticity.h
+++ b/modules/solid_mechanics/include/materials/CombinedCreepPlasticity.h
@@ -51,7 +51,4 @@ protected:
 private:
 };
 
-template <>
-InputParameters validParams<CombinedCreepPlasticity>();
-
 #endif // MATERIALDRIVER_H

--- a/modules/solid_mechanics/include/materials/ConstitutiveModel.h
+++ b/modules/solid_mechanics/include/materials/ConstitutiveModel.h
@@ -12,8 +12,10 @@
 #include "SymmElasticityTensor.h"
 #include "SymmTensor.h"
 
-/**
- */
+class ConstitutiveModel;
+
+template <>
+InputParameters validParams<ConstitutiveModel>();
 
 class ConstitutiveModel : public Material
 {

--- a/modules/solid_mechanics/include/materials/ConstitutiveModel.h
+++ b/modules/solid_mechanics/include/materials/ConstitutiveModel.h
@@ -63,7 +63,4 @@ private:
   using Material::computeProperties;
 };
 
-template <>
-InputParameters validParams<ConstitutiveModel>();
-
 #endif // CONSTITUTIVEMODEL_H

--- a/modules/solid_mechanics/include/materials/Elastic.h
+++ b/modules/solid_mechanics/include/materials/Elastic.h
@@ -23,7 +23,4 @@ public:
 protected:
 };
 
-template <>
-InputParameters validParams<Elastic>();
-
 #endif

--- a/modules/solid_mechanics/include/materials/Elastic.h
+++ b/modules/solid_mechanics/include/materials/Elastic.h
@@ -9,6 +9,11 @@
 
 #include "SolidModel.h"
 
+class Elastic;
+
+template <>
+InputParameters validParams<Elastic>();
+
 class Elastic : public SolidModel
 {
 public:

--- a/modules/solid_mechanics/include/materials/ElasticModel.h
+++ b/modules/solid_mechanics/include/materials/ElasticModel.h
@@ -9,6 +9,11 @@
 
 #include "ConstitutiveModel.h"
 
+class ElasticModel;
+
+template <>
+InputParameters validParams<ElasticModel>();
+
 class ElasticModel : public ConstitutiveModel
 {
 public:

--- a/modules/solid_mechanics/include/materials/ElasticModel.h
+++ b/modules/solid_mechanics/include/materials/ElasticModel.h
@@ -29,7 +29,4 @@ protected:
                              SymmTensor & stress_new);
 };
 
-template <>
-InputParameters validParams<ElasticModel>();
-
 #endif

--- a/modules/solid_mechanics/include/materials/IsotropicPlasticity.h
+++ b/modules/solid_mechanics/include/materials/IsotropicPlasticity.h
@@ -11,8 +11,10 @@
 
 class PiecewiseLinear;
 
-/**
- */
+class IsotropicPlasticity;
+
+template <>
+InputParameters validParams<IsotropicPlasticity>();
 
 class IsotropicPlasticity : public ReturnMappingModel
 {

--- a/modules/solid_mechanics/include/materials/IsotropicPlasticity.h
+++ b/modules/solid_mechanics/include/materials/IsotropicPlasticity.h
@@ -52,7 +52,4 @@ protected:
   const MaterialProperty<Real> & _hardening_variable_old;
 };
 
-template <>
-InputParameters validParams<IsotropicPlasticity>();
-
 #endif // ISOTROPICPLASTICITY_H

--- a/modules/solid_mechanics/include/materials/IsotropicPowerLawHardening.h
+++ b/modules/solid_mechanics/include/materials/IsotropicPowerLawHardening.h
@@ -9,13 +9,17 @@
 
 #include "IsotropicPlasticity.h"
 
+class IsotropicPowerLawHardening;
+
+template <>
+InputParameters validParams<IsotropicPowerLawHardening>();
+
 /**
  * This class creates an Isotropic power law hardening plasticity model.
  * Before yield, stress is youngs modulus* strain. After yield, stress is
  * K*pow(strain, n) where K is the strength coefficient, n is the strain
  * rate exponent and strain is the total strain.
  **/
-
 class IsotropicPowerLawHardening : public IsotropicPlasticity
 {
 public:

--- a/modules/solid_mechanics/include/materials/IsotropicPowerLawHardening.h
+++ b/modules/solid_mechanics/include/materials/IsotropicPowerLawHardening.h
@@ -43,7 +43,4 @@ protected:
 private:
 };
 
-template <>
-InputParameters validParams<IsotropicPowerLawHardening>();
-
 #endif // ISOTROPICPOWERLAWHARDENING_H

--- a/modules/solid_mechanics/include/materials/IsotropicTempDepHardening.h
+++ b/modules/solid_mechanics/include/materials/IsotropicTempDepHardening.h
@@ -12,6 +12,11 @@
 class PiecewiseLinear;
 class LinearInterpolation;
 
+class IsotropicTempDepHardening;
+
+template <>
+InputParameters validParams<IsotropicTempDepHardening>();
+
 class IsotropicTempDepHardening : public IsotropicPlasticity
 {
 public:

--- a/modules/solid_mechanics/include/materials/IsotropicTempDepHardening.h
+++ b/modules/solid_mechanics/include/materials/IsotropicTempDepHardening.h
@@ -41,7 +41,4 @@ protected:
   Real _hf_fraction;
 };
 
-template <>
-InputParameters validParams<IsotropicTempDepHardening>();
-
 #endif // ISOTROPICTEMPDEPHARDENING_H

--- a/modules/solid_mechanics/include/materials/LinearStrainHardening.h
+++ b/modules/solid_mechanics/include/materials/LinearStrainHardening.h
@@ -21,7 +21,4 @@ public:
   virtual ~LinearStrainHardening() {}
 };
 
-template <>
-InputParameters validParams<LinearStrainHardening>();
-
 #endif // LINEARSTRAINHARDENING_H

--- a/modules/solid_mechanics/include/materials/LinearStrainHardening.h
+++ b/modules/solid_mechanics/include/materials/LinearStrainHardening.h
@@ -9,6 +9,11 @@
 
 #include "SolidModel.h"
 
+class LinearStrainHardening;
+
+template <>
+InputParameters validParams<LinearStrainHardening>();
+
 class LinearStrainHardening : public SolidModel
 {
 public:

--- a/modules/solid_mechanics/include/materials/MacroElastic.h
+++ b/modules/solid_mechanics/include/materials/MacroElastic.h
@@ -9,6 +9,11 @@
 
 #include "Elastic.h"
 
+class MacroElastic;
+
+template <>
+InputParameters validParams<MacroElastic>();
+
 class MacroElastic : public Elastic
 {
 public:

--- a/modules/solid_mechanics/include/materials/MacroElastic.h
+++ b/modules/solid_mechanics/include/materials/MacroElastic.h
@@ -39,7 +39,4 @@ private:
   const PostprocessorValue & _C3131;
 };
 
-template <>
-InputParameters validParams<Elastic>();
-
 #endif

--- a/modules/solid_mechanics/include/materials/PLC_LSH.h
+++ b/modules/solid_mechanics/include/materials/PLC_LSH.h
@@ -20,7 +20,6 @@ InputParameters validParams<PLC_LSH>();
  * Power law creep is specified by the time-hardening form
  * edot = A(sigma)**n * exp(-Q/(RT)) * t**m
  */
-
 class PLC_LSH : public SolidModel
 {
 public:

--- a/modules/solid_mechanics/include/materials/PowerLawCreepModel.h
+++ b/modules/solid_mechanics/include/materials/PowerLawCreepModel.h
@@ -9,8 +9,10 @@
 
 #include "ReturnMappingModel.h"
 
-/**
- */
+class PowerLawCreepModel;
+
+template <>
+InputParameters validParams<PowerLawCreepModel>();
 
 class PowerLawCreepModel : public ReturnMappingModel
 {

--- a/modules/solid_mechanics/include/materials/PowerLawCreepModel.h
+++ b/modules/solid_mechanics/include/materials/PowerLawCreepModel.h
@@ -44,7 +44,4 @@ protected:
 private:
 };
 
-template <>
-InputParameters validParams<PowerLawCreepModel>();
-
 #endif // POWERLAWCREEPMODEL_H

--- a/modules/solid_mechanics/include/materials/ReturnMappingModel.h
+++ b/modules/solid_mechanics/include/materials/ReturnMappingModel.h
@@ -10,13 +10,17 @@
 #include "ConstitutiveModel.h"
 #include "SingleVariableReturnMappingSolution.h"
 
+class ReturnMappingModel;
+
+template <>
+InputParameters validParams<ReturnMappingModel>();
+
 /**
  * Base class for models that perform return mapping iterations to compute stress.  This
  * is for a single model to compute inelastic behavior.  This class can be used directly
  * as a standalone model for a single source of inelasticity.  It can also be called from
  * another model that combines together multiple inelastic models using Picard iterations.
  */
-
 class ReturnMappingModel : public ConstitutiveModel, public SingleVariableReturnMappingSolution
 {
 public:

--- a/modules/solid_mechanics/include/materials/ReturnMappingModel.h
+++ b/modules/solid_mechanics/include/materials/ReturnMappingModel.h
@@ -91,7 +91,4 @@ protected:
   MaterialProperty<Real> * _matl_timestep_limit;
 };
 
-template <>
-InputParameters validParams<ReturnMappingModel>();
-
 #endif // RETURNMAPPINGMODEL_H

--- a/modules/tensor_mechanics/include/kernels/DynamicStressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/DynamicStressDivergenceTensors.h
@@ -9,10 +9,15 @@
 
 #include "StressDivergenceTensors.h"
 
+class DynamicStressDivergenceTensors;
+
+template <>
+InputParameters validParams<DynamicStressDivergenceTensors>();
+
 /**
-* DynamicStressDivergenceTensors derives from StressDivergenceTensors and adds stress related
-* Rayleigh and HHT time integration terms.
-*/
+ * DynamicStressDivergenceTensors derives from StressDivergenceTensors and adds stress related
+ * Rayleigh and HHT time integration terms.
+ */
 class DynamicStressDivergenceTensors : public StressDivergenceTensors
 {
 public:

--- a/modules/tensor_mechanics/include/materials/CompositeEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/CompositeEigenstrain.h
@@ -11,6 +11,11 @@
 #include "CompositeTensorBase.h"
 #include "RankTwoTensor.h"
 
+class CompositeEigenstrain;
+
+template <>
+InputParameters validParams<CompositeEigenstrain>();
+
 /**
  * CompositeEigenstrain provides a simple RankTwoTensor type
  * MaterialProperty that can be used as an Eigenstrain tensor in a mechanics simulation.

--- a/modules/tensor_mechanics/include/materials/CompositeEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/CompositeEigenstrain.h
@@ -35,7 +35,4 @@ protected:
   const std::string _M_name;
 };
 
-template <>
-InputParameters validParams<CompositeEigenstrain>();
-
 #endif // COMPOSITEEIGENSTRAIN_H

--- a/modules/tensor_mechanics/include/materials/CompositeElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/CompositeElasticityTensor.h
@@ -38,7 +38,4 @@ protected:
   MaterialProperty<RankFourTensor> & _M;
 };
 
-template <>
-InputParameters validParams<CompositeElasticityTensor>();
-
 #endif // COMPOSITEELASTICITYTENSOR_H

--- a/modules/tensor_mechanics/include/materials/CompositeElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/CompositeElasticityTensor.h
@@ -11,6 +11,11 @@
 #include "CompositeTensorBase.h"
 #include "RankFourTensor.h"
 
+class CompositeElasticityTensor;
+
+template <>
+InputParameters validParams<CompositeElasticityTensor>();
+
 /**
  * CompositeElasticityTensor provides a simple RankFourTensor type
  * MaterialProperty that can be used as an Elasticity tensor in a mechanics simulation.

--- a/modules/tensor_mechanics/include/materials/Compute1DFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/Compute1DFiniteStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeFiniteStrain.h"
 
+class Compute1DFiniteStrain;
+
+template <>
+InputParameters validParams<Compute1DFiniteStrain>();
+
 /**
  * Compute1DFiniteStrain defines a strain increment for finite strains in 1D problems,
  * handling strains in other two directions. It contains virtual methods to define

--- a/modules/tensor_mechanics/include/materials/Compute1DIncrementalStrain.h
+++ b/modules/tensor_mechanics/include/materials/Compute1DIncrementalStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeIncrementalSmallStrain.h"
 
+class Compute1DIncrementalStrain;
+
+template <>
+InputParameters validParams<Compute1DIncrementalStrain>();
+
 /**
  * Compute1DIncrementalStrain defines a strain increment only for incremental
  * small strains in 1D problems, handling strains in other two directions.

--- a/modules/tensor_mechanics/include/materials/Compute1DSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/Compute1DSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeSmallStrain.h"
 
+class Compute1DSmallStrain;
+
+template <>
+InputParameters validParams<Compute1DSmallStrain>();
+
 /**
  * Compute1DSmallStrain defines a strain tensor, assuming small strains,
  * in 1D problems, handling strains in other two directions.

--- a/modules/tensor_mechanics/include/materials/Compute2DFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/Compute2DFiniteStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeFiniteStrain.h"
 
+class Compute2DFiniteStrain;
+
+template <>
+InputParameters validParams<Compute2DFiniteStrain>();
+
 /**
  * Compute2DFiniteStrain defines a strain increment and a rotation increment
  * for finite strains in 2D geometries, handling the out of plane strains.

--- a/modules/tensor_mechanics/include/materials/Compute2DIncrementalStrain.h
+++ b/modules/tensor_mechanics/include/materials/Compute2DIncrementalStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeIncrementalSmallStrain.h"
 
+class Compute2DIncrementalStrain;
+
+template <>
+InputParameters validParams<Compute2DIncrementalStrain>();
+
 /**
  * Compute2DIncrementalStrain defines a strain increment only for
  * incremental strains in 2D geometries, handling the out of plane strains.

--- a/modules/tensor_mechanics/include/materials/Compute2DSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/Compute2DSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeSmallStrain.h"
 
+class Compute2DSmallStrain;
+
+template <>
+InputParameters validParams<Compute2DSmallStrain>();
+
 /**
  * Compute2DSmallStrain defines a strain tensor, assuming small strains,
  * in 2D geometries / simulations.  ComputePlaneSmallStrain acts as a

--- a/modules/tensor_mechanics/include/materials/ComputeAxisymmetric1DFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeAxisymmetric1DFiniteStrain.h
@@ -10,6 +10,11 @@
 #include "Compute1DFiniteStrain.h"
 #include "SubblockIndexProvider.h"
 
+class ComputeAxisymmetric1DFiniteStrain;
+
+template <>
+InputParameters validParams<ComputeAxisymmetric1DFiniteStrain>();
+
 /**
  * ComputeAxisymmetric1DFiniteStrain defines a strain increment for finite strains
  * in an Axisymmetric 1D problem. The COORD_TYPE in the Problem block must be set to RZ.

--- a/modules/tensor_mechanics/include/materials/ComputeAxisymmetric1DIncrementalStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeAxisymmetric1DIncrementalStrain.h
@@ -10,6 +10,11 @@
 #include "Compute1DIncrementalStrain.h"
 #include "SubblockIndexProvider.h"
 
+class ComputeAxisymmetric1DIncrementalStrain;
+
+template <>
+InputParameters validParams<ComputeAxisymmetric1DIncrementalStrain>();
+
 /**
  * ComputeAxisymmetric1DIncrementalStrain defines a strain increment only
  * for incremental small strains in an Axisymmetric 1D problem.

--- a/modules/tensor_mechanics/include/materials/ComputeAxisymmetric1DSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeAxisymmetric1DSmallStrain.h
@@ -10,6 +10,11 @@
 #include "Compute1DSmallStrain.h"
 #include "SubblockIndexProvider.h"
 
+class ComputeAxisymmetric1DSmallStrain;
+
+template <>
+InputParameters validParams<ComputeAxisymmetric1DSmallStrain>();
+
 /**
  * ComputeAxisymmetric1DSmallStrain defines small strains in an Axisymmetric 1D problem.
  * The COORD_TYPE in the Problem block must be set to RZ.

--- a/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZFiniteStrain.h
@@ -9,6 +9,11 @@
 
 #include "Compute2DFiniteStrain.h"
 
+class ComputeAxisymmetricRZFiniteStrain;
+
+template <>
+InputParameters validParams<ComputeAxisymmetricRZFiniteStrain>();
+
 /**
  * ComputeAxisymmetricRZFiniteStrain defines a strain increment and rotation
  * increment for finite strains in an Axisymmetric simulation.

--- a/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZIncrementalStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZIncrementalStrain.h
@@ -9,6 +9,11 @@
 
 #include "Compute2DIncrementalStrain.h"
 
+class ComputeAxisymmetricRZIncrementalStrain;
+
+template <>
+InputParameters validParams<ComputeAxisymmetricRZIncrementalStrain>();
+
 /**
  * ComputeAxisymmetricRZIncrementalStrain defines a strain increment only
  * for incremental strains in an Axisymmetric simulation.

--- a/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeAxisymmetricRZSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "Compute2DSmallStrain.h"
 
+class ComputeAxisymmetricRZSmallStrain;
+
+template <>
+InputParameters validParams<ComputeAxisymmetricRZSmallStrain>();
+
 /**
  * ComputeAxisymmetricRZSmallStrain defines small strains in an Axisymmetric system.
  * The COORD_TYPE in the Problem block must be set to RZ.

--- a/modules/tensor_mechanics/include/materials/ComputeConcentrationDependentElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeConcentrationDependentElasticityTensor.h
@@ -9,6 +9,11 @@
 
 #include "ComputeRotatedElasticityTensorBase.h"
 
+class ComputeConcentrationDependentElasticityTensor;
+
+template <>
+InputParameters validParams<ComputeConcentrationDependentElasticityTensor>();
+
 /**
  * ComputeElasticityTensor defines an elasticity tensor material object as a function of
  * concentration field.

--- a/modules/tensor_mechanics/include/materials/ComputeCosseratElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCosseratElasticityTensor.h
@@ -9,6 +9,11 @@
 
 #include "ComputeElasticityTensorBase.h"
 
+class ComputeCosseratElasticityTensor;
+
+template <>
+InputParameters validParams<ComputeCosseratElasticityTensor>();
+
 /**
  * ComputeElasticityTensor defines an elasticity tensor material for isi.
  */

--- a/modules/tensor_mechanics/include/materials/ComputeCosseratIncrementalSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCosseratIncrementalSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeIncrementalStrainBase.h"
 
+class ComputeCosseratIncrementalSmallStrain;
+
+template <>
+InputParameters validParams<ComputeCosseratIncrementalSmallStrain>();
+
 /**
  * ComputeCosseratIncrementalSmallStrain defines various incremental versions
  * of the Cossserat strain tensor, assuming small strains.

--- a/modules/tensor_mechanics/include/materials/ComputeCosseratLinearElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCosseratLinearElasticStress.h
@@ -9,6 +9,11 @@
 
 #include "ComputeCosseratStressBase.h"
 
+class ComputeCosseratLinearElasticStress;
+
+template <>
+InputParameters validParams<ComputeCosseratLinearElasticStress>();
+
 /**
  * ComputeCosseratLinearElasticStress computes the Cosserat stress
  * and couple-stress following linear elasticity theory

--- a/modules/tensor_mechanics/include/materials/ComputeCosseratSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCosseratSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeStrainBase.h"
 
+class ComputeCosseratSmallStrain;
+
+template <>
+InputParameters validParams<ComputeCosseratSmallStrain>();
+
 /**
  * ComputeCosseratSmallStrain defines Cossserat strain tensor, assuming small strains.
  */

--- a/modules/tensor_mechanics/include/materials/ComputeCosseratStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeCosseratStressBase.h
@@ -9,6 +9,11 @@
 
 #include "ComputeStressBase.h"
 
+class ComputeCosseratStressBase;
+
+template <>
+InputParameters validParams<ComputeCosseratStressBase>();
+
 /**
  * ComputeCosseratStressBase is the base class for stress tensors
  */

--- a/modules/tensor_mechanics/include/materials/ComputeDeformGradBasedStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeDeformGradBasedStress.h
@@ -13,6 +13,11 @@
 #include "RotationTensor.h"
 #include "DerivativeMaterialInterface.h"
 
+class ComputeDeformGradBasedStress;
+
+template <>
+InputParameters validParams<ComputeDeformGradBasedStress>();
+
 /**
  * ComputeDeformGradBasedStress computes stress based on lagrangian strain definition
  **/

--- a/modules/tensor_mechanics/include/materials/ComputeEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeEigenstrain.h
@@ -11,6 +11,11 @@
 
 #include "RankTwoTensor.h"
 
+class ComputeEigenstrain;
+
+template <>
+InputParameters validParams<ComputeEigenstrain>();
+
 /**
  * ComputeEigenstrain computes an Eigenstrain that is a function of a single variable defined by a
  * base tensor and a scalar function defined in a Derivative Material.

--- a/modules/tensor_mechanics/include/materials/ComputeEigenstrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeEigenstrainBase.h
@@ -11,6 +11,11 @@
 
 class RankTwoTensor;
 
+class ComputeEigenstrainBase;
+
+template <>
+InputParameters validParams<ComputeEigenstrainBase>();
+
 /**
  * ComputeEigenstrainBase is the base class for eigenstrain tensors
  */

--- a/modules/tensor_mechanics/include/materials/ComputeEigenstrainFromInitialStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeEigenstrainFromInitialStress.h
@@ -10,6 +10,11 @@
 #include "ComputeEigenstrainBase.h"
 #include "RankFourTensor.h"
 
+class ComputeEigenstrainFromInitialStress;
+
+template <>
+InputParameters validParams<ComputeEigenstrainFromInitialStress>();
+
 /**
  * ComputeEigenstrain computes an Eigenstrain that results from an initial stress
  */

--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTensor.h
@@ -9,6 +9,11 @@
 
 #include "ComputeRotatedElasticityTensorBase.h"
 
+class ComputeElasticityTensor;
+
+template <>
+InputParameters validParams<ComputeElasticityTensor>();
+
 /**
  * ComputeElasticityTensor defines an elasticity tensor material object with a given base name.
  */

--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTensorBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTensorBase.h
@@ -12,6 +12,11 @@
 #include "RankFourTensor.h"
 #include "GuaranteeProvider.h"
 
+class ComputeElasticityTensorBase;
+
+template <>
+InputParameters validParams<ComputeElasticityTensorBase>();
+
 /**
  * ComputeElasticityTensorBase the base class for computing elasticity tensors
  */

--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTensorCP.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTensorCP.h
@@ -12,6 +12,11 @@
 #include "RankTwoTensor.h"
 #include "RotationTensor.h"
 
+class ComputeElasticityTensorCP;
+
+template <>
+InputParameters validParams<ComputeElasticityTensorCP>();
+
 /**
  * ComputeElasticityTensorCP defines an elasticity tensor material object for crystal plasticity.
  */

--- a/modules/tensor_mechanics/include/materials/ComputeExtraStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeExtraStressBase.h
@@ -10,6 +10,11 @@
 #include "Material.h"
 #include "RankTwoTensor.h"
 
+class ComputeExtraStressBase;
+
+template <>
+InputParameters validParams<ComputeExtraStressBase>();
+
 /**
  * ComputeExtraStressBase is the base class for extra_stress, which is added to stress
  * calculated by the material's constitutive model

--- a/modules/tensor_mechanics/include/materials/ComputeExtraStressConstant.h
+++ b/modules/tensor_mechanics/include/materials/ComputeExtraStressConstant.h
@@ -9,6 +9,11 @@
 
 #include "ComputeExtraStressBase.h"
 
+class ComputeExtraStressConstant;
+
+template <>
+InputParameters validParams<ComputeExtraStressConstant>();
+
 /**
  * ComputeEigenstrain computes an Eigenstrain that is a function of a single variable defined by a
  * base tensor and a scalar function defined in a Derivative Material.

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeIncrementalStrainBase.h"
 
+class ComputeFiniteStrain;
+
+template <>
+InputParameters validParams<ComputeFiniteStrain>();
+
 /**
  * ComputeFiniteStrain defines a strain increment and rotation increment, for finite strains.
  */

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
@@ -10,6 +10,11 @@
 #include "ComputeStressBase.h"
 #include "GuaranteeConsumer.h"
 
+class ComputeFiniteStrainElasticStress;
+
+template <>
+InputParameters validParams<ComputeFiniteStrainElasticStress>();
+
 /**
  * ComputeFiniteStrainElasticStress computes the stress following elasticity
  * theory for finite strains

--- a/modules/tensor_mechanics/include/materials/ComputeIncrementalSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIncrementalSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeIncrementalStrainBase.h"
 
+class ComputeIncrementalSmallStrain;
+
+template <>
+InputParameters validParams<ComputeIncrementalSmallStrain>();
+
 /**
  * ComputeIncrementalSmallStrain defines a strain increment and rotation increment (=1), for small
  * strains.

--- a/modules/tensor_mechanics/include/materials/ComputeIncrementalStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIncrementalStrainBase.h
@@ -9,6 +9,11 @@
 
 #include "ComputeStrainBase.h"
 
+class ComputeIncrementalStrainBase;
+
+template <>
+InputParameters validParams<ComputeIncrementalStrainBase>();
+
 /**
  * ComputeIncrementalStrainBase is the base class for strain tensors using incremental formulations
  */

--- a/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIsotropicElasticityTensor.h
@@ -9,6 +9,11 @@
 
 #include "ComputeElasticityTensorBase.h"
 
+class ComputeIsotropicElasticityTensor;
+
+template <>
+InputParameters validParams<ComputeIsotropicElasticityTensor>();
+
 /**
  * ComputeIsotropicElasticityTensor defines an elasticity tensor material for
  * isotropic materials.

--- a/modules/tensor_mechanics/include/materials/ComputeIsotropicLinearElasticPFFractureStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIsotropicLinearElasticPFFractureStress.h
@@ -9,6 +9,11 @@
 
 #include "ComputeStressBase.h"
 
+class ComputeIsotropicLinearElasticPFFractureStress;
+
+template <>
+InputParameters validParams<ComputeIsotropicLinearElasticPFFractureStress>();
+
 /**
  * Phase-field fracture
  * This class computes the stress and energy contribution for the

--- a/modules/tensor_mechanics/include/materials/ComputeLayeredCosseratElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeLayeredCosseratElasticityTensor.h
@@ -9,6 +9,11 @@
 
 #include "ComputeElasticityTensorBase.h"
 
+class ComputeLayeredCosseratElasticityTensor;
+
+template <>
+InputParameters validParams<ComputeLayeredCosseratElasticityTensor>();
+
 /**
  * ComputeLayeredCosseratElasticityTensor defines an
  * elasticity tensor and an elastic flexural rigidity

--- a/modules/tensor_mechanics/include/materials/ComputeLinearElasticPFFractureStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeLinearElasticPFFractureStress.h
@@ -9,6 +9,11 @@
 
 #include "ComputeStressBase.h"
 
+class ComputeLinearElasticPFFractureStress;
+
+template <>
+InputParameters validParams<ComputeLinearElasticPFFractureStress>();
+
 /**
  * Phase-field fracture
  * This class computes the stress and energy contribution to fracture

--- a/modules/tensor_mechanics/include/materials/ComputeLinearElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeLinearElasticStress.h
@@ -9,6 +9,11 @@
 
 #include "ComputeStressBase.h"
 
+class ComputeLinearElasticStress;
+
+template <>
+InputParameters validParams<ComputeLinearElasticStress>();
+
 /**
  * ComputeLinearElasticStress computes the stress following linear elasticity theory (small strains)
  */

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticCosseratStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticCosseratStress.h
@@ -11,6 +11,9 @@
 
 class ComputeMultipleInelasticCosseratStress;
 
+template <>
+InputParameters validParams<ComputeMultipleInelasticCosseratStress>();
+
 /**
  * ComputeMultipleInelasticStress computes the stress, the consistent tangent
  * operator (or an approximation to it), and a decomposition of the strain

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -11,6 +11,11 @@
 
 class StressUpdateBase;
 
+class ComputeMultipleInelasticStress;
+
+template <>
+InputParameters validParams<ComputeMultipleInelasticStress>();
+
 /**
  * ComputeMultipleInelasticStress computes the stress, the consistent tangent
  * operator (or an approximation to it), and a decomposition of the strain

--- a/modules/tensor_mechanics/include/materials/ComputePlaneFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlaneFiniteStrain.h
@@ -9,6 +9,11 @@
 
 #include "Compute2DFiniteStrain.h"
 
+class ComputePlaneFiniteStrain;
+
+template <>
+InputParameters validParams<ComputePlaneFiniteStrain>();
+
 /**
  * ComputePlaneFiniteStrain defines strain increment and rotation
  * increment for finite strain under 2D planar assumptions.

--- a/modules/tensor_mechanics/include/materials/ComputePlaneIncrementalStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlaneIncrementalStrain.h
@@ -9,6 +9,11 @@
 
 #include "Compute2DIncrementalStrain.h"
 
+class ComputePlaneIncrementalStrain;
+
+template <>
+InputParameters validParams<ComputePlaneIncrementalStrain>();
+
 /**
  * ComputePlaneIncrementalStrain defines strain increment
  * for small strains in a 2D planar simulation.

--- a/modules/tensor_mechanics/include/materials/ComputePlaneSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlaneSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "Compute2DSmallStrain.h"
 
+class ComputePlaneSmallStrain;
+
+template <>
+InputParameters validParams<ComputePlaneSmallStrain>();
+
 /**
  * ComputePlaneSmallStrain defines small strains under generalized
  * plane strain and plane stress assumptions, where the out of plane strain

--- a/modules/tensor_mechanics/include/materials/ComputePlasticHeatEnergy.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlasticHeatEnergy.h
@@ -12,6 +12,11 @@
 #include "RankTwoTensor.h"
 #include "RankFourTensor.h"
 
+class ComputePlasticHeatEnergy;
+
+template <>
+InputParameters validParams<ComputePlasticHeatEnergy>();
+
 /**
  * ComputePlasticHeatEnergy computes stress * (plastic_strain - plastic_strain_old)
  * and, if currentlyComputingJacobian, then the derivative of this quantity wrt total strain

--- a/modules/tensor_mechanics/include/materials/ComputeRSphericalFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeRSphericalFiniteStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeFiniteStrain.h"
 
+class ComputeRSphericalFiniteStrain;
+
+template <>
+InputParameters validParams<ComputeRSphericalFiniteStrain>();
+
 /**
  * ComputeRSphericalFiniteStrain defines a strain increment and a rotation increment
  * for finite strains in 1D spherical symmetry geometries.  The strains in the

--- a/modules/tensor_mechanics/include/materials/ComputeRSphericalIncrementalStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeRSphericalIncrementalStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeIncrementalSmallStrain.h"
 
+class ComputeRSphericalIncrementalStrain;
+
+template <>
+InputParameters validParams<ComputeRSphericalIncrementalStrain>();
+
 /**
  * ComputeRSphericalIncrementalStrain defines a strain increment only
  * for small strains in 1D spherical symmetry geometries.  The strains in the

--- a/modules/tensor_mechanics/include/materials/ComputeRSphericalSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeRSphericalSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeSmallStrain.h"
 
+class ComputeRSphericalSmallStrain;
+
+template <>
+InputParameters validParams<ComputeRSphericalSmallStrain>();
+
 /**
  * ComputeRSphericalSmallStrain defines a strain tensor, assuming small strains,
  * in a 1D simulation assumming spherical symmetry.  The polar and azimuthal

--- a/modules/tensor_mechanics/include/materials/ComputeReducedOrderEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeReducedOrderEigenstrain.h
@@ -17,6 +17,11 @@ class InputParameters;
 class MooseObject;
 class SubProblem;
 
+class ComputeReducedOrderEigenstrain;
+
+template <>
+InputParameters validParams<ComputeReducedOrderEigenstrain>();
+
 class ComputeReducedOrderEigenstrain : public ComputeEigenstrainBase
 {
 public:

--- a/modules/tensor_mechanics/include/materials/ComputeRotatedElasticityTensorBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeRotatedElasticityTensorBase.h
@@ -9,6 +9,11 @@
 
 #include "ComputeElasticityTensorBase.h"
 
+class ComputeRotatedElasticityTensorBase;
+
+template <>
+InputParameters validParams<ComputeRotatedElasticityTensorBase>();
+
 /**
  * ComputeRotatedElasticityTensorBase is an intermediate base class that rotates an elasticity
  * tensor based on euler angles.

--- a/modules/tensor_mechanics/include/materials/ComputeSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeSmallStrain.h
@@ -9,6 +9,11 @@
 
 #include "ComputeStrainBase.h"
 
+class ComputeSmallStrain;
+
+template <>
+InputParameters validParams<ComputeSmallStrain>();
+
 /**
  * ComputeSmallStrain defines a strain tensor, assuming small strains.
  */

--- a/modules/tensor_mechanics/include/materials/ComputeSmearedCrackingStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeSmearedCrackingStress.h
@@ -11,6 +11,11 @@
 #include "ComputeMultipleInelasticStress.h"
 #include "Function.h"
 
+class ComputeSmearedCrackingStress;
+
+template <>
+InputParameters validParams<ComputeSmearedCrackingStress>();
+
 /**
  * ComputeSmearedCrackingStress computes the stress for a finite strain
  * material with smeared cracking

--- a/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
@@ -13,6 +13,11 @@
 #include "RotationTensor.h"
 #include "DerivativeMaterialInterface.h"
 
+class ComputeStrainBase;
+
+template <>
+InputParameters validParams<ComputeStrainBase>();
+
 /**
  * ComputeStrainBase is the base class for strain tensors
  */

--- a/modules/tensor_mechanics/include/materials/ComputeStrainIncrementBasedStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainIncrementBasedStress.h
@@ -11,6 +11,9 @@
 
 class ComputeStrainIncrementBasedStress;
 
+template <>
+InputParameters validParams<ComputeStrainIncrementBasedStress>();
+
 /**
  * ComputeStrainIncrementBasedStress computes stress considering list of inelastic strain increments
  */

--- a/modules/tensor_mechanics/include/materials/ComputeStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStressBase.h
@@ -13,6 +13,11 @@
 #include "RotationTensor.h"
 #include "DerivativeMaterialInterface.h"
 
+class ComputeStressBase;
+
+template <>
+InputParameters validParams<ComputeStressBase>();
+
 /**
  * ComputeStressBase is the base class for stress tensors
  */

--- a/modules/tensor_mechanics/include/materials/ComputeVariableEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeVariableEigenstrain.h
@@ -10,6 +10,11 @@
 #include "ComputeEigenstrain.h"
 #include "DerivativeMaterialInterface.h"
 
+class ComputeVariableEigenstrain;
+
+template <>
+InputParameters validParams<ComputeVariableEigenstrain>();
+
 /**
  * ComputeVariableEigenstrain computes an Eigenstrain that is a function of a single
  * variable defined by a base tensor and a scalar function defined in a Derivative Material.

--- a/modules/tensor_mechanics/include/materials/ComputeVariableIsotropicElasticityTensor.h
+++ b/modules/tensor_mechanics/include/materials/ComputeVariableIsotropicElasticityTensor.h
@@ -9,6 +9,11 @@
 
 #include "ComputeElasticityTensorBase.h"
 
+class ComputeVariableIsotropicElasticityTensor;
+
+template <>
+InputParameters validParams<ComputeVariableIsotropicElasticityTensor>();
+
 /**
  * ComputeVariableIsotropicElasticityTensor defines an elasticity tensor material for
  * isotropic materials in which the elastic constants (Young's modulus and Poisson's ratio)

--- a/modules/tensor_mechanics/include/materials/ComputeVolumetricDeformGrad.h
+++ b/modules/tensor_mechanics/include/materials/ComputeVolumetricDeformGrad.h
@@ -11,6 +11,11 @@
 #include "DerivativeMaterialInterface.h"
 #include "RankTwoTensor.h"
 
+class ComputeVolumetricDeformGrad;
+
+template <>
+InputParameters validParams<ComputeVolumetricDeformGrad>();
+
 /**
  * ComputeVolumetricDeformGrad is the class to compute volumetric deformation gradient
  * Modification based on pre-multiplication to a deformation gradient

--- a/modules/tensor_mechanics/include/materials/ComputeVolumetricEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeVolumetricEigenstrain.h
@@ -10,6 +10,11 @@
 #include "ComputeEigenstrainBase.h"
 #include "DerivativeMaterialInterface.h"
 
+class ComputeVolumetricEigenstrain;
+
+template <>
+InputParameters validParams<ComputeVolumetricEigenstrain>();
+
 /**
  * ComputeVolumetricEigenstrain computes an eigenstrain that is defined by a set of scalar
  * material properties that summed together define the volumetric change.  This also

--- a/modules/tensor_mechanics/include/materials/EshelbyTensor.h
+++ b/modules/tensor_mechanics/include/materials/EshelbyTensor.h
@@ -12,6 +12,11 @@
 
 class RankTwoTensor;
 
+class EshelbyTensor;
+
+template <>
+InputParameters validParams<EshelbyTensor>();
+
 /**
  * EshelbyTensor defines a strain increment and rotation increment, for finite strains.
  */

--- a/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
+++ b/modules/tensor_mechanics/include/materials/FiniteStrainCrystalPlasticity.h
@@ -9,6 +9,11 @@
 
 #include "ComputeStressBase.h"
 
+class FiniteStrainCrystalPlasticity;
+
+template <>
+InputParameters validParams<FiniteStrainCrystalPlasticity>();
+
 /**
  * FiniteStrainCrystalPlasticity uses the multiplicative decomposition of deformation gradient
  * and solves the PK2 stress residual equation at the intermediate configuration to evolve the
@@ -16,11 +21,6 @@
  * The internal variables are updated using an interative predictor-corrector algorithm.
  * Backward Euler integration rule is used for the rate equations.
  */
-class FiniteStrainCrystalPlasticity;
-
-template <>
-InputParameters validParams<FiniteStrainCrystalPlasticity>();
-
 class FiniteStrainCrystalPlasticity : public ComputeStressBase
 {
 public:

--- a/modules/tensor_mechanics/include/materials/FluxBasedStrainIncrement.h
+++ b/modules/tensor_mechanics/include/materials/FluxBasedStrainIncrement.h
@@ -13,6 +13,9 @@
 
 class FluxBasedStrainIncrement;
 
+template <>
+InputParameters validParams<FluxBasedStrainIncrement>();
+
 /**
  * FluxBasedStrainIncrement computes strain increment based on flux (vacancy)
  * Forest et. al. MSMSE 2015

--- a/modules/tensor_mechanics/include/materials/GBRelaxationStrainIncrement.h
+++ b/modules/tensor_mechanics/include/materials/GBRelaxationStrainIncrement.h
@@ -13,6 +13,9 @@
 
 class GBRelaxationStrainIncrement;
 
+template <>
+InputParameters validParams<GBRelaxationStrainIncrement>();
+
 /**
  * GBRelaxationStrainIncrement computes strain increment due to lattice relaxation at GB
  * Forest et. al. MSMSE 2015

--- a/modules/tensor_mechanics/include/materials/HyperbolicViscoplasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/HyperbolicViscoplasticityStressUpdate.h
@@ -9,6 +9,11 @@
 
 #include "RadialReturnStressUpdate.h"
 
+class HyperbolicViscoplasticityStressUpdate;
+
+template <>
+InputParameters validParams<HyperbolicViscoplasticityStressUpdate>();
+
 /**
  * This class uses the Discrete material in an isotropic radial return hyperbolic
  * sine viscoplasticity model.
@@ -23,7 +28,6 @@
  * Petrinic's Introduction to Computational Plasticity (2004) Oxford University
  * Press, pg. 162 - 163.
  */
-
 class HyperbolicViscoplasticityStressUpdate : public RadialReturnStressUpdate
 {
 public:

--- a/modules/tensor_mechanics/include/materials/IsotropicPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/IsotropicPlasticityStressUpdate.h
@@ -9,6 +9,11 @@
 
 #include "RadialReturnStressUpdate.h"
 
+class IsotropicPlasticityStressUpdate;
+
+template <>
+InputParameters validParams<IsotropicPlasticityStressUpdate>();
+
 /**
  * This class uses the Discrete material in a radial return isotropic plasticity
  * model.  This class is one of the basic radial return constitutive models;

--- a/modules/tensor_mechanics/include/materials/IsotropicPowerLawHardeningStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/IsotropicPowerLawHardeningStressUpdate.h
@@ -10,6 +10,11 @@
 #include "IsotropicPlasticityStressUpdate.h"
 #include "MooseMesh.h"
 
+class IsotropicPowerLawHardeningStressUpdate;
+
+template <>
+InputParameters validParams<IsotropicPowerLawHardeningStressUpdate>();
+
 /**
  * This class uses the Discrete material in a radial return isotropic plasticity
  * model.  This class is one of the basic radial return constitutive models;
@@ -26,7 +31,6 @@
  * suppressed to enable this class to solve for yield stress:
  * \f$ \sigma_y = \left( \frac{E^n}{K} \right)^{1/(n-1)} \f$
  */
-
 class IsotropicPowerLawHardeningStressUpdate : public IsotropicPlasticityStressUpdate
 {
 public:

--- a/modules/tensor_mechanics/include/materials/LinearElasticTruss.h
+++ b/modules/tensor_mechanics/include/materials/LinearElasticTruss.h
@@ -10,6 +10,11 @@
 
 #include "TrussMaterial.h"
 
+class LinearElasticTruss;
+
+template <>
+InputParameters validParams<LinearElasticTruss>();
+
 class LinearElasticTruss : public TrussMaterial
 {
 public:

--- a/modules/tensor_mechanics/include/materials/LinearIsoElasticPFDamage.h
+++ b/modules/tensor_mechanics/include/materials/LinearIsoElasticPFDamage.h
@@ -10,6 +10,11 @@
 #include "ComputeStressBase.h"
 #include "Function.h"
 
+class LinearIsoElasticPFDamage;
+
+template <>
+InputParameters validParams<LinearIsoElasticPFDamage>();
+
 /**
  * Phase-field fracture
  * This class computes the energy contribution to damage growth

--- a/modules/tensor_mechanics/include/materials/PowerLawCreepStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/PowerLawCreepStressUpdate.h
@@ -10,6 +10,11 @@
 #include "RadialReturnStressUpdate.h"
 #include "MooseMesh.h"
 
+class PowerLawCreepStressUpdate;
+
+template <>
+InputParameters validParams<PowerLawCreepStressUpdate>();
+
 /**
  * This class uses the Discrete material in a radial return isotropic creep
  * model.  This class is one of the basic
@@ -21,7 +26,6 @@
  * creep based on stress, temperature, and time effects.  This class also
  * computes the creep strain as a stateful material property.
  */
-
 class PowerLawCreepStressUpdate : public RadialReturnStressUpdate
 {
 public:

--- a/modules/tensor_mechanics/include/materials/SumTensorIncrements.h
+++ b/modules/tensor_mechanics/include/materials/SumTensorIncrements.h
@@ -11,7 +11,10 @@
 #include "RankTwoTensor.h"
 #include "DerivativeMaterialInterface.h"
 
-class SumStraubIncrements;
+class SumTensorIncrements;
+
+template <>
+InputParameters validParams<SumTensorIncrements>();
 
 /**
  * SumTensorIncrements update a tensor by summing tensor increments passed as property

--- a/modules/tensor_mechanics/include/materials/TemperatureDependentHardeningStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/TemperatureDependentHardeningStressUpdate.h
@@ -12,12 +12,16 @@
 class PiecewiseLinear;
 class LinearInterpolation;
 
+class TemperatureDependentHardeningStressUpdate;
+
+template <>
+InputParameters validParams<TemperatureDependentHardeningStressUpdate>();
+
 /**
  * This class inherits from IsotropicPlasticityStressUpdate. It
  * calculates stress as a function of temperature and plastic strain by
  * interpolating hardening functions at different temperatures input by the user.
  */
-
 class TemperatureDependentHardeningStressUpdate : public IsotropicPlasticityStressUpdate
 {
 public:

--- a/modules/tensor_mechanics/include/materials/ThermalFractureIntegral.h
+++ b/modules/tensor_mechanics/include/materials/ThermalFractureIntegral.h
@@ -12,6 +12,11 @@
 
 class RankTwoTensor;
 
+class ThermalFractureIntegral;
+
+template <>
+InputParameters validParams<ThermalFractureIntegral>();
+
 /**
  * ThermalFractureIntegral computes the summation of the derivative of the
  * eigenstrains with respect to temperature.

--- a/modules/tensor_mechanics/include/materials/VolumeDeformGradCorrectedStress.h
+++ b/modules/tensor_mechanics/include/materials/VolumeDeformGradCorrectedStress.h
@@ -13,6 +13,11 @@
 #include "RotationTensor.h"
 #include "DerivativeMaterialInterface.h"
 
+class VolumeDeformGradCorrectedStress;
+
+template <>
+InputParameters validParams<VolumeDeformGradCorrectedStress>();
+
 /**
  * VolumeDeformGradCorrectedStress transforms the Cauchy stress calculated in the previous
  *configuration to its configuration

--- a/modules/xfem/include/materials/ComputeCrackTipEnrichmentSmallStrain.h
+++ b/modules/xfem/include/materials/ComputeCrackTipEnrichmentSmallStrain.h
@@ -16,6 +16,11 @@
 #include "CrackFrontDefinition.h"
 #include "EnrichmentFunctionCalculation.h"
 
+class ComputeCrackTipEnrichmentSmallStrain;
+
+template <>
+InputParameters validParams<ComputeCrackTipEnrichmentSmallStrain>();
+
 /**
  * ComputeCrackTipEnrichmentSmallStrain calculates the sum of standard strain and enrichement strain
  */

--- a/modules/xfem/include/userobjects/GeometricCut3DUserObject.h
+++ b/modules/xfem/include/userobjects/GeometricCut3DUserObject.h
@@ -12,6 +12,11 @@
 
 using namespace libMesh;
 
+class GeometricCut3DUserObject;
+
+template <>
+InputParameters validParams<GeometricCut3DUserObject>();
+
 class GeometricCut3DUserObject : public GeometricCutUserObject
 {
 public:

--- a/test/include/materials/IncrementMaterial.h
+++ b/test/include/materials/IncrementMaterial.h
@@ -19,7 +19,7 @@
 class IncrementMaterial;
 
 template <>
-InputParameters validParams<GenericConstantMaterial>();
+InputParameters validParams<IncrementMaterial>();
 
 /**
  * A material that tracks the number of times computeQpProperties has been called.

--- a/test/include/postprocessors/NumElemQPs.h
+++ b/test/include/postprocessors/NumElemQPs.h
@@ -22,7 +22,7 @@
 class NumElemQPs;
 
 template <>
-InputParameters validParams<ElementIntegralPostprocessor>();
+InputParameters validParams<NumElemQPs>();
 
 /**
  * An object for testing that the specified quadrature order is used.  It

--- a/test/include/postprocessors/NumSideQPs.h
+++ b/test/include/postprocessors/NumSideQPs.h
@@ -22,7 +22,7 @@
 class NumSideQPs;
 
 template <>
-InputParameters validParams<SideIntegralPostprocessor>();
+InputParameters validParams<NumSideQPs>();
 
 /**
  * An object for testing that the specified quadrature order is used.  It


### PR DESCRIPTION
Fix all of the validParams errors in MOOSE, test and Modules.  Also: change the default implementation of `validParams()` to disallow this in the future.

fixes #10586