### PR TITLE
Fix peacock saving block comments

### DIFF
--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -41,6 +41,7 @@ class BlockEditor(QWidget, MooseWidget):
         super(BlockEditor, self).__init__(**kwds)
         self.block = block
         self.comment_edit = CommentEditor()
+        self.comment_edit.setComments(self.block.comments)
         self.comment_edit.textChanged.connect(self._blockChanged)
         self.splitter = None
         self.clone_button = None

--- a/python/peacock/Input/CommentEditor.py
+++ b/python/peacock/Input/CommentEditor.py
@@ -26,4 +26,4 @@ class CommentEditor(QWidget):
         self.editor.setPlainText(comments)
 
     def getComments(self):
-        return self.editor.toPlainText()
+        return str(self.editor.toPlainText())

--- a/python/peacock/tests/input_tab/InputFileEditor/gold/fsp_test.i
+++ b/python/peacock/tests/input_tab/InputFileEditor/gold/fsp_test.i
@@ -89,6 +89,8 @@
       splitting_type = additive
     [../]
     [./u]
+      # PETSc options for this subsolver
+      # A prefix will be applied, so just put the options for this subsolver only
       vars = 'u'
       petsc_options_iname = '-pc_type -ksp_type'
       petsc_options_value = '     hypre preonly'


### PR DESCRIPTION
Adding comments on the "Name" parameter has been replaced with adding block level comments, which is edited in a separate editing block below the parameters. This is due to block level comments typically being much larger than the parameter level comments.
This fixes it so that it actually saves the block level comments between editing a block.

closes #2321

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
