### PR TITLE
AverageElementSize PPS does not require variable

### DIFF
--- a/framework/include/postprocessors/AverageElementSize.h
+++ b/framework/include/postprocessors/AverageElementSize.h
@@ -15,7 +15,7 @@
 #ifndef AVERAGEELEMENTSIZE_H
 #define AVERAGEELEMENTSIZE_H
 
-#include "ElementAverageValue.h"
+#include "ElementPostprocessor.h"
 
 // Forward Declarations
 class AverageElementSize;
@@ -26,7 +26,7 @@ InputParameters validParams<AverageElementSize>();
 /**
  * This postprocessor computes an average element size (h) for the whole domain.
  */
-class AverageElementSize : public ElementAverageValue
+class AverageElementSize : public ElementPostprocessor
 {
 public:
   AverageElementSize(const InputParameters & parameters);
@@ -34,12 +34,11 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
 
-  virtual Real computeIntegral() override;
-
   virtual Real getValue() override;
   virtual void threadJoin(const UserObject & y) override;
 
 protected:
+  Real _total_size;
   int _elems;
 };
 

--- a/framework/src/postprocessors/AverageElementSize.C
+++ b/framework/src/postprocessors/AverageElementSize.C
@@ -18,49 +18,42 @@ template <>
 InputParameters
 validParams<AverageElementSize>()
 {
-  InputParameters params = validParams<ElementAverageValue>();
+  InputParameters params = validParams<ElementPostprocessor>();
   return params;
 }
 
 AverageElementSize::AverageElementSize(const InputParameters & parameters)
-  : ElementAverageValue(parameters)
+  : ElementPostprocessor(parameters)
 {
 }
 
 void
 AverageElementSize::initialize()
 {
-  ElementAverageValue::initialize();
+  _total_size = 0;
   _elems = 0;
 }
 
 void
 AverageElementSize::execute()
 {
-  ElementIntegralPostprocessor::execute();
+  _total_size += _current_elem->hmax();
   _elems++;
-}
-
-Real
-AverageElementSize::computeIntegral()
-{
-  return _current_elem->hmax();
 }
 
 Real
 AverageElementSize::getValue()
 {
-  Real integral = ElementIntegralPostprocessor::getValue();
-
+  gatherSum(_total_size);
   gatherSum(_elems);
 
-  return integral / _elems;
+  return _total_size / _elems;
 }
 
 void
 AverageElementSize::threadJoin(const UserObject & y)
 {
-  ElementAverageValue::threadJoin(y);
   const AverageElementSize & pps = static_cast<const AverageElementSize &>(y);
+  _total_size += pps._total_size;
   _elems += pps._elems;
 }

--- a/modules/level_set/test/tests/kernels/advection/advection_mms.i
+++ b/modules/level_set/test/tests/kernels/advection/advection_mms.i
@@ -73,7 +73,6 @@
   [../]
   [./h]
     type = AverageElementSize
-    variable = phi
   [../]
 []
 

--- a/modules/level_set/test/tests/verification/1d_level_set_mms/level_set_mms.i
+++ b/modules/level_set/test/tests/verification/1d_level_set_mms/level_set_mms.i
@@ -66,7 +66,6 @@
   [../]
   [./h]
     type = AverageElementSize
-    variable = phi
   [../]
   [./point]
     type = PointValue

--- a/modules/level_set/test/tests/verification/1d_level_set_supg_mms/1d_level_set_supg_mms.i
+++ b/modules/level_set/test/tests/verification/1d_level_set_supg_mms/1d_level_set_supg_mms.i
@@ -81,7 +81,6 @@
   [../]
   [./h]
     type = AverageElementSize
-    variable = phi
   [../]
   [./point]
     type = PointValue

--- a/test/tests/bcs/penalty_dirichlet_bc/function_penalty_dirichlet_bc_test.i
+++ b/test/tests/bcs/penalty_dirichlet_bc/function_penalty_dirichlet_bc_test.i
@@ -68,7 +68,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/bcs/penalty_dirichlet_bc/penalty_dirichlet_bc_test.i
+++ b/test/tests/bcs/penalty_dirichlet_bc/penalty_dirichlet_bc_test.i
@@ -68,7 +68,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/dgkernels/2d_diffusion_dg/2d_diffusion_dg_test.i
+++ b/test/tests/dgkernels/2d_diffusion_dg/2d_diffusion_dg_test.i
@@ -147,7 +147,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./dofs]

--- a/test/tests/dgkernels/3d_diffusion_dg/3d_diffusion_dg_test.i
+++ b/test/tests/dgkernels/3d_diffusion_dg/3d_diffusion_dg_test.i
@@ -100,7 +100,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
     execute_on = 'initial timestep_end'
   [../]
 

--- a/test/tests/kernels/coupled_kernel_grad/coupled_kernel_grad_test.i
+++ b/test/tests/kernels/coupled_kernel_grad/coupled_kernel_grad_test.i
@@ -170,7 +170,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2u]

--- a/test/tests/kernels/coupled_kernel_value/coupled_kernel_value_test.i
+++ b/test/tests/kernels/coupled_kernel_value/coupled_kernel_value_test.i
@@ -151,7 +151,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2u]

--- a/test/tests/misc/check_error/coupled_grad_without_declare.i
+++ b/test/tests/misc/check_error/coupled_grad_without_declare.i
@@ -173,7 +173,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2u]

--- a/test/tests/outputs/debug/show_var_residual_norms.i
+++ b/test/tests/outputs/debug/show_var_residual_norms.i
@@ -170,7 +170,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2u]

--- a/test/tests/outputs/debug/show_var_residual_norms_debug.i
+++ b/test/tests/outputs/debug/show_var_residual_norms_debug.i
@@ -170,7 +170,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2u]

--- a/test/tests/postprocessors/nodal_var_value/pps_output_test.i
+++ b/test/tests/postprocessors/nodal_var_value/pps_output_test.i
@@ -118,7 +118,6 @@
 
   [./avg_v]
     type = AverageElementSize
-    variable = v
     outputs = none
   [../]
 []

--- a/test/tests/postprocessors/num_vars/num_vars.i
+++ b/test/tests/postprocessors/num_vars/num_vars.i
@@ -145,7 +145,6 @@
   [../]
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
   [./L2u]
     type = ElementL2Error

--- a/test/tests/variables/fe_hermite/hermite-3-1d.i
+++ b/test/tests/variables/fe_hermite/hermite-3-1d.i
@@ -86,7 +86,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hermite/hermite-3-2d.i
+++ b/test/tests/variables/fe_hermite/hermite-3-2d.i
@@ -101,7 +101,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hermite/hermite-3-3d.i
+++ b/test/tests/variables/fe_hermite/hermite-3-3d.i
@@ -129,7 +129,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hermite_convergence/hermite_converge_dirichlet.i
+++ b/test/tests/variables/fe_hermite_convergence/hermite_converge_dirichlet.i
@@ -65,7 +65,6 @@
   [../]
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
   [./L2error]
     type = ElementL2Error

--- a/test/tests/variables/fe_hermite_convergence/hermite_converge_periodic.i
+++ b/test/tests/variables/fe_hermite_convergence/hermite_converge_periodic.i
@@ -85,7 +85,6 @@
   [../]
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
   [./L2error]
     type = ElementL2Error

--- a/test/tests/variables/fe_hier/hier-1-1d.i
+++ b/test/tests/variables/fe_hier/hier-1-1d.i
@@ -86,7 +86,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hier/hier-1-2d.i
+++ b/test/tests/variables/fe_hier/hier-1-2d.i
@@ -101,7 +101,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hier/hier-1-3d.i
+++ b/test/tests/variables/fe_hier/hier-1-3d.i
@@ -125,7 +125,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hier/hier-2-1d.i
+++ b/test/tests/variables/fe_hier/hier-2-1d.i
@@ -77,7 +77,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hier/hier-2-2d.i
+++ b/test/tests/variables/fe_hier/hier-2-2d.i
@@ -101,7 +101,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hier/hier-2-3d.i
+++ b/test/tests/variables/fe_hier/hier-2-3d.i
@@ -129,7 +129,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hier/hier-3-1d.i
+++ b/test/tests/variables/fe_hier/hier-3-1d.i
@@ -77,7 +77,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hier/hier-3-2d.i
+++ b/test/tests/variables/fe_hier/hier-3-2d.i
@@ -101,7 +101,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_hier/hier-3-3d.i
+++ b/test/tests/variables/fe_hier/hier-3-3d.i
@@ -129,7 +129,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_monomial_const/monomial-const-1d.i
+++ b/test/tests/variables/fe_monomial_const/monomial-const-1d.i
@@ -69,7 +69,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_monomial_const/monomial-const-2d.i
+++ b/test/tests/variables/fe_monomial_const/monomial-const-2d.i
@@ -114,7 +114,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]

--- a/test/tests/variables/fe_monomial_const/monomial-const-3d.i
+++ b/test/tests/variables/fe_monomial_const/monomial-const-3d.i
@@ -117,7 +117,6 @@
 
   [./h]
     type = AverageElementSize
-    variable = u
   [../]
 
   [./L2error]


### PR DESCRIPTION
The computation of average element size is agnostic of varaible the PPS
is using.  There is no need to require a variable.

Closes #10590

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
