### PR TITLE
Make MOOSE converged test more consistent with PETSc's default one

### DIFF
--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -200,6 +200,7 @@ public:
                             const Real abstol,
                             const PetscInt nfuncs,
                             const PetscInt max_funcs,
+                            const PetscBool force_iteration,
                             const Real initial_residual_before_preset_bcs,
                             const Real div_threshold);
 

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -5012,6 +5012,7 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
                                          const Real abstol,
                                          const PetscInt nfuncs,
                                          const PetscInt max_funcs,
+                                         const PetscBool force_iteration,
                                          const Real initial_residual_before_preset_bcs,
                                          const Real div_threshold)
 {
@@ -5031,7 +5032,7 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
     oss << "Failed to converge, function norm is NaN\n";
     reason = MOOSE_DIVERGED_FNORM_NAN;
   }
-  else if (fnorm < abstol)
+  else if (fnorm < abstol && (it || !force_iteration))
   {
     oss << "Converged due to function norm " << fnorm << " < " << abstol << '\n';
     reason = MOOSE_CONVERGED_FNORM_ABS;

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -404,6 +404,14 @@ petscNonlinearConverged(SNES snes,
   ierr = SNESGetNumberFunctionEvals(snes, &nfuncs);
   CHKERRABORT(problem.comm().get(), ierr);
 
+  // Whether or not to force SNESSolve() take at least one iteration regardless of the initial
+  // residual norm
+  PetscBool force_iteration = PETSC_FALSE;
+#if !PETSC_VERSION_LESS_THAN(3, 8, 3) || !PETSC_RELEASE_LESS_THAN(3, 8, 3)
+  ierr = SNESGetForceIteration(snes, &force_iteration);
+  CHKERRABORT(problem.comm().get(), ierr);
+#endif
+
 // See if SNESSetFunctionDomainError() has been called.  Note:
 // SNESSetFunctionDomainError() and SNESGetFunctionDomainError()
 // were added in different releases of PETSc.
@@ -435,6 +443,7 @@ petscNonlinearConverged(SNES snes,
       atol,
       nfuncs,
       maxf,
+      force_iteration,
       system._initial_residual_before_preset_bcs,
       /*div_threshold=*/(1.0 / rtol) * system._initial_residual_before_preset_bcs);
 

--- a/modules/contact/include/AugmentedLagrangianContactProblem.h
+++ b/modules/contact/include/AugmentedLagrangianContactProblem.h
@@ -42,6 +42,7 @@ public:
                             const Real abstol,
                             const PetscInt nfuncs,
                             const PetscInt max_funcs,
+                            const PetscBool force_iteration,
                             const Real ref_resid,
                             const Real div_threshold) override;
 

--- a/modules/contact/include/ReferenceResidualProblem.h
+++ b/modules/contact/include/ReferenceResidualProblem.h
@@ -25,21 +25,23 @@ public:
   ReferenceResidualProblem(const InputParameters & params);
   virtual ~ReferenceResidualProblem();
 
-  virtual void initialSetup();
-  virtual void timestepSetup();
+  virtual void initialSetup() override;
+  virtual void timestepSetup() override;
   void updateReferenceResidual();
-  virtual MooseNonlinearConvergenceReason checkNonlinearConvergence(std::string & msg,
-                                                                    const PetscInt it,
-                                                                    const Real xnorm,
-                                                                    const Real snorm,
-                                                                    const Real fnorm,
-                                                                    const Real rtol,
-                                                                    const Real stol,
-                                                                    const Real abstol,
-                                                                    const PetscInt nfuncs,
-                                                                    const PetscInt max_funcs,
-                                                                    const Real ref_resid,
-                                                                    const Real div_threshold);
+  virtual MooseNonlinearConvergenceReason
+  checkNonlinearConvergence(std::string & msg,
+                            const PetscInt it,
+                            const Real xnorm,
+                            const Real snorm,
+                            const Real fnorm,
+                            const Real rtol,
+                            const Real stol,
+                            const Real abstol,
+                            const PetscInt nfuncs,
+                            const PetscInt max_funcs,
+                            const PetscBool force_iteration,
+                            const Real ref_resid,
+                            const Real div_threshold) override;
 
   bool checkConvergenceIndividVars(const Real fnorm,
                                    const Real abstol,

--- a/modules/contact/src/AugmentedLagrangianContactProblem.C
+++ b/modules/contact/src/AugmentedLagrangianContactProblem.C
@@ -59,6 +59,7 @@ AugmentedLagrangianContactProblem::checkNonlinearConvergence(std::string & msg,
                                                              const Real abstol,
                                                              const PetscInt nfuncs,
                                                              const PetscInt /*max_funcs*/,
+                                                             const PetscBool force_iteration,
                                                              const Real ref_resid,
                                                              const Real /*div_threshold*/)
 {
@@ -77,6 +78,7 @@ AugmentedLagrangianContactProblem::checkNonlinearConvergence(std::string & msg,
                                                           abstol,
                                                           nfuncs,
                                                           my_max_funcs,
+                                                          force_iteration,
                                                           ref_resid,
                                                           my_div_threshold);
 

--- a/modules/contact/src/ReferenceResidualProblem.C
+++ b/modules/contact/src/ReferenceResidualProblem.C
@@ -156,6 +156,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
                                                     const Real abstol,
                                                     const PetscInt nfuncs,
                                                     const PetscInt max_funcs,
+                                                    const PetscBool force_iteration,
                                                     const Real ref_resid,
                                                     const Real /*div_threshold*/)
 {
@@ -188,7 +189,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
     oss << "Failed to converge, function norm is NaN\n";
     reason = MOOSE_DIVERGED_FNORM_NAN;
   }
-  else if (fnorm < abstol)
+  else if (fnorm < abstol && (it || !force_iteration))
   {
     oss << "Converged due to function norm " << fnorm << " < " << abstol << std::endl;
     reason = MOOSE_CONVERGED_FNORM_ABS;

--- a/test/tests/kernels/2d_diffusion/tests
+++ b/test/tests/kernels/2d_diffusion/tests
@@ -27,4 +27,13 @@
     cli_args = 'Outputs/exodus=false'
     recover = false
   [../]
+
+  [./test_force_iteration]
+    type = 'Exodiff'
+    input = '2d_diffusion_test.i'
+    exodiff = 'out.e'
+    cli_args = 'Executioner/nl_abs_tol=1e+1 Executioner/petsc_options_iname=-snes_force_iteration Executioner/petsc_options_value=1'
+    petsc_version = '>=3.8.3'
+    prereq = testdirichlet
+  [../]
 []


### PR DESCRIPTION
There is an option, "-snes_force_iteration", in PETSc, that forces the nonlinear solver take at least one iteration. 

MOOSE did not honor this option because it uses a different converged test from PETSc. This PR fixes this by making the MOOSE converged test function to take the option into account. 

This requires an API update at the PETSc side. Once the API is added into PETSc, I will retest this PR against PETSc-master. 

Close #10599 