### PR TITLE
Print better TestHarness stack traces

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -237,7 +237,7 @@ class TestHarness:
             self.cleanup()
 
             # flags for the TestHarness start at the high bit
-            if self.num_failed:
+            if self.num_failed or self.scheduler.schedulerError():
                 self.error_code = self.error_code | 0x80
 
         except KeyboardInterrupt:

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -89,6 +89,9 @@ class Scheduler(MooseObject):
         # iterate over and kill any subprocesses
         self.tester_datas = set([])
 
+        # Allow threads to set an exception state
+        self.error_state = False
+
     def killRemaining(self):
         """
         Method to kill any running subprocess started by the Scheduler. This also
@@ -101,6 +104,13 @@ class Scheduler(MooseObject):
         for tester_data in self.tester_datas:
             tester_data.killProcess()
         self.job_queue_count = 0
+
+    def schedulerError(self):
+        """
+        If any runWorker, statusWorker threads caused an exception, this method
+        will admit to it.
+        """
+        return self.error_state
 
     def reportSkipped(self, jobs):
         """
@@ -281,7 +291,7 @@ class Scheduler(MooseObject):
         """
         # If any threads caused an exception, we have already closed down the queue and need to
         # not schedule any more jobs
-        if self.run_pool._state:
+        if self.run_pool._state or self.error_state:
             return
 
         # Instance the DAG class so we can share it amongst all the Job containers
@@ -361,6 +371,10 @@ class Scheduler(MooseObject):
         the Tester pool first, and then we do the same to the Status pool.
         """
         while self.job_queue_count > 0:
+            # One of our children died :( so exit uncleanly
+            if self.error_state:
+                self.killRemaining()
+                return
             sleep(0.5)
 
         self.run_pool.close()
@@ -476,11 +490,11 @@ class Scheduler(MooseObject):
 
         """
         for job_container in run_jobs:
-            if not self.run_pool._state:
+            if not self.error_state or not self.error_state:
                 self.run_pool.apply_async(self.runWorker, (job_container,))
 
         for job_container in status_jobs:
-            if not self.status_pool._state:
+            if not self.status_pool._state or not self.error_state:
                 self.status_pool.apply_async(self.statusWorker, (job_container,))
 
     def statusWorker(self, job_container):
@@ -522,9 +536,9 @@ class Scheduler(MooseObject):
             if not tester.isSilent() or not tester.isDeleted():
                 self.last_reported = clock()
 
-        except Exception as e:
-            print('statusWorker Exception: %s' % (e))
-            self.killRemaining()
+        except Exception:
+            self.error_state = True
+            print('statusWorker Exception: %s' % (traceback.format_exc()))
 
     def runWorker(self, job_container):
         """ Method the run_pool calls when an available thread becomes ready """
@@ -595,5 +609,5 @@ class Scheduler(MooseObject):
                     sleep(0.3)
 
         except Exception:
+            self.error_state = True
             print('runWorker Exception: %s' % (traceback.format_exc()))
-            self.killRemaining()

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -1,7 +1,7 @@
 from time import sleep
 from FactorySystem.MooseObject import MooseObject
 from Job import Job
-import os
+import os, traceback
 from contrib import dag
 from timeit import default_timer as clock
 
@@ -594,6 +594,6 @@ class Scheduler(MooseObject):
                     self.queueJobs(run_jobs=[job_container])
                     sleep(0.3)
 
-        except Exception as e:
-            print('runWorker Exception: %s' % (e))
+        except Exception:
+            print('runWorker Exception: %s' % (traceback.format_exc()))
             self.killRemaining()


### PR DESCRIPTION
While in the runworker thread, print the actual stack trace
that occurred, if one occurred.

Closes #10607
