### PR TITLE
Nodal kernel compute jacobian thread bug fix #10620

### DIFF
--- a/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelBCJacobiansThread.C
@@ -72,25 +72,25 @@ ComputeNodalKernelBCJacobiansThread::onNode(ConstBndNodeRange::const_iterator & 
       const auto & objects = _nodal_kernels.getActiveBoundaryObjects(boundary_id, _tid);
       for (const auto & nodal_kernel : objects)
       {
-        // If this NodalKernel isn't operating on this ivar... skip it
-        if (nodal_kernel->variable().number() != ivar)
-          break;
-
-        // If this NodalKernel is acting on the jvar add it to the list and short-circuit the loop
-        if (nodal_kernel->variable().number() == jvar)
+        if (nodal_kernel->variable().number() == ivar)
         {
-          active_involved_kernels.push_back(nodal_kernel);
-          continue;
-        }
-
-        // See if this NodalKernel is coupled to the jvar
-        const std::vector<MooseVariable *> & coupled_vars = nodal_kernel->getCoupledMooseVars();
-        for (const auto & var : coupled_vars)
-        {
-          if (var->number() == jvar)
+          // If this NodalKernel is acting on the jvar add it to the list and short-circuit the
+          // loop
+          if (nodal_kernel->variable().number() == jvar)
           {
             active_involved_kernels.push_back(nodal_kernel);
-            break; // It only takes one
+            continue;
+          }
+
+          // See if this NodalKernel is coupled to the jvar
+          const std::vector<MooseVariable *> & coupled_vars = nodal_kernel->getCoupledMooseVars();
+          for (const auto & var : coupled_vars)
+          {
+            if (var->number() == jvar)
+            {
+              active_involved_kernels.push_back(nodal_kernel);
+              break; // It only takes one
+            }
           }
         }
       }

--- a/framework/src/base/ComputeNodalKernelJacobiansThread.C
+++ b/framework/src/base/ComputeNodalKernelJacobiansThread.C
@@ -74,25 +74,25 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
         const auto & objects = _nodal_kernels.getActiveBlockObjects(block, _tid);
         for (const auto & nodal_kernel : objects)
         {
-          // If this NodalKernel isn't operating on this ivar... skip it
-          if (nodal_kernel->variable().number() != ivar)
-            break;
-
-          // If this NodalKernel is acting on the jvar add it to the list and short-circuit the loop
-          if (nodal_kernel->variable().number() == jvar)
+          if (nodal_kernel->variable().number() == ivar)
           {
-            active_involved_kernels.push_back(nodal_kernel);
-            continue;
-          }
-
-          // See if this NodalKernel is coupled to the jvar
-          const std::vector<MooseVariable *> & coupled_vars = nodal_kernel->getCoupledMooseVars();
-          for (const auto & var : coupled_vars)
-            if (var->number() == jvar)
+            // If this NodalKernel is acting on the jvar add it to the list and short-circuit the
+            // loop
+            if (nodal_kernel->variable().number() == jvar)
             {
               active_involved_kernels.push_back(nodal_kernel);
-              break; // It only takes one
+              continue;
             }
+
+            // See if this NodalKernel is coupled to the jvar
+            const std::vector<MooseVariable *> & coupled_vars = nodal_kernel->getCoupledMooseVars();
+            for (const auto & var : coupled_vars)
+              if (var->number() == jvar)
+              {
+                active_involved_kernels.push_back(nodal_kernel);
+                break; // It only takes one
+              }
+          }
         }
       }
     }

--- a/test/include/nodalkernels/JacobianCheck.h
+++ b/test/include/nodalkernels/JacobianCheck.h
@@ -1,0 +1,35 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef JACOBIANCHECK_H
+#define JACOBIANCHECK_H
+
+#include "NodalKernel.h"
+
+// Forward Declarations
+class JacobianCheck;
+
+template <>
+InputParameters validParams<JacobianCheck>();
+
+/**
+ * Dummy class that tests the Jacobian calculation
+ */
+class JacobianCheck : public NodalKernel
+{
+public:
+  JacobianCheck(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual() override;
+
+  virtual Real computeQpJacobian() override;
+};
+
+#endif /*JACOBIANCHECK_H*/

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -129,6 +129,9 @@
 // dg kernels
 #include "DGCoupledDiffusion.h"
 
+// Nodal Kernels
+#include "JacobianCheck.h"
+
 // ICs
 #include "TEIC.h"
 #include "MTICSum.h"
@@ -465,6 +468,9 @@ MooseTestApp::registerObjects(Factory & factory)
 
   // dg kernels
   registerDGKernel(DGCoupledDiffusion);
+
+  // Nodal Kernels
+  registerNodalKernel(JacobianCheck);
 
   // Initial conditions
   registerInitialCondition(TEIC);

--- a/test/src/nodalkernels/JacobianCheck.C
+++ b/test/src/nodalkernels/JacobianCheck.C
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "JacobianCheck.h"
+
+template <>
+InputParameters
+validParams<JacobianCheck>()
+{
+  InputParameters params = validParams<NodalKernel>();
+  return params;
+}
+
+JacobianCheck::JacobianCheck(const InputParameters & parameters) : NodalKernel(parameters) {}
+
+Real
+JacobianCheck::computeQpResidual()
+{
+  return -5.0 * _u[_qp];
+}
+
+Real
+JacobianCheck::computeQpJacobian()
+{
+  return -5.0;
+}

--- a/test/tests/nodalkernels/jac_test/bc_jacobian_test.i
+++ b/test/tests/nodalkernels/jac_test/bc_jacobian_test.i
@@ -1,0 +1,74 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 4
+  ny = 4
+[]
+
+[Variables]
+  [./u_x]
+  [../]
+  [./u_y]
+  [../]
+[]
+
+[Kernels]
+  [./diff_x]
+    type = CoefDiffusion
+    variable = u_x
+    coef = 0.1
+  [../]
+  [./diff_y]
+    type = CoefDiffusion
+    variable = u_y
+    coef = 0.1
+  [../]
+[]
+
+[NodalKernels]
+  [./test_y]
+    type = JacobianCheck
+    variable = u_y
+    boundary = top
+  [../]
+  [./test_x]
+    type = JacobianCheck
+    variable = u_x
+    boundary = top
+  [../]
+[]
+
+[BCs]
+  [./left_x]
+    type = DirichletBC
+    variable = u_x
+    boundary = left
+    value = 0
+  [../]
+  [./right_x]
+    type = DirichletBC
+    variable = u_x
+    boundary = right
+    value = 1
+  [../]
+  [./left_y]
+    type = DirichletBC
+    variable = u_y
+    boundary = left
+    value = 0
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+  dt = 0.1
+  solve_type = NEWTON
+# petsc_options = '-snes_check_jacobian -snes_check_jacobian_view'
+  nl_max_its = 1
+  nl_abs_tol = 1e0
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/nodalkernels/jac_test/block_jacobian_test.i
+++ b/test/tests/nodalkernels/jac_test/block_jacobian_test.i
@@ -1,0 +1,72 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 4
+  ny = 4
+[]
+
+[Variables]
+  [./u_x]
+  [../]
+  [./u_y]
+  [../]
+[]
+
+[Kernels]
+  [./diff_x]
+    type = CoefDiffusion
+    variable = u_x
+    coef = 0.1
+  [../]
+  [./diff_y]
+    type = CoefDiffusion
+    variable = u_y
+    coef = 0.1
+  [../]
+[]
+
+[NodalKernels]
+  [./test_y]
+    type = JacobianCheck
+    variable = u_y
+  [../]
+  [./test_x]
+    type = JacobianCheck
+    variable = u_x
+  [../]
+[]
+
+[BCs]
+  [./left_x]
+    type = DirichletBC
+    variable = u_x
+    boundary = left
+    value = 0
+  [../]
+  [./right_x]
+    type = DirichletBC
+    variable = u_x
+    boundary = right
+    value = 1
+  [../]
+  [./left_y]
+    type = DirichletBC
+    variable = u_y
+    boundary = left
+    value = 0
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+  dt = 0.1
+  solve_type = NEWTON
+#  petsc_options = '-snes_check_jacobian -snes_check_jacobian_view'
+  nl_max_its = 1
+  nl_abs_tol = 1e0
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/nodalkernels/jac_test/tests
+++ b/test/tests/nodalkernels/jac_test/tests
@@ -5,4 +5,16 @@
     exodiff = 'jac_test_out.e'
     max_parallel = 1 # Because we're using LU
   [../]
+  [./block_jacobian_test]
+    type = 'PetscJacobianTester'
+    input = 'block_jacobian_test.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E-10
+  [../]
+  [./bc_jacobian_test]
+    type = 'PetscJacobianTester'
+    input = 'bc_jacobian_test.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E-10
+  [../]
 []


### PR DESCRIPTION
There is a break statement in both ComputeNodalKernelJacobiansThread.C and ComputeNodalKernelBCJacobiansThread.C that breaks out of the loop over nodal kernels if the first nodal kernel's variable is not equal to ivar. So, even if the second nodal kernel's variable is same as ivar, it does not get added to the active_involved_kernels list. 

I removed the break statement and modified the code such that nodal kernel gets added to the list of active_nodal_kernels if its variable is same as ivar and either jvar equals ivar or jvar is one of the coupled variables. 

closes #10620 
