### PR TITLE
KDTree optimizations

### DIFF
--- a/framework/include/utils/KDTree.h
+++ b/framework/include/utils/KDTree.h
@@ -14,6 +14,7 @@
 #include "MooseMesh.h"
 
 #include "libmesh/nanoflann.hpp"
+#include "libmesh/utility.h"
 
 class KDTree
 {
@@ -65,7 +66,7 @@ public:
       coord_t dist = 0.0;
 
       for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
-        dist += std::pow(p1[i] - p2(i), 2.0);
+        dist += Utility::pow<2>(p1[i] - p2(i));
 
       return dist;
     }

--- a/framework/include/utils/KDTree.h
+++ b/framework/include/utils/KDTree.h
@@ -97,10 +97,10 @@ public:
     }
 
     /**
-    * Optional bounding-box computation. This function is called by the nanoflann library.
-    * If the return value is false, the standard bbox computation loop in the nanoflann
-    * library is activated.
-    **/
+     * Optional bounding-box computation. This function is called by the nanoflann library.
+     * If the return value is false, the standard bbox computation loop in the nanoflann
+     * library is activated.
+     */
     template <class BBOX>
     bool kdtree_get_bbox(BBOX & /* bb */) const
     {

--- a/framework/include/utils/KDTree.h
+++ b/framework/include/utils/KDTree.h
@@ -27,6 +27,11 @@ public:
                       unsigned int patch_size,
                       std::vector<std::size_t> & return_index);
 
+  void neighborSearch(Point & query_point,
+                      unsigned int patch_size,
+                      std::vector<std::size_t> & return_index,
+                      std::vector<Real> & return_dist_sqr);
+
   /**
    * PointListAdaptor is required to use libMesh Point coordinate type with
    * nanoflann KDTree library. The member functions within the PointListAdaptor

--- a/framework/src/geomsearch/SlaveNeighborhoodThread.C
+++ b/framework/src/geomsearch/SlaveNeighborhoodThread.C
@@ -74,8 +74,8 @@ SlaveNeighborhoodThread::operator()(const NodeIdRange & range)
 
     _kd_tree.neighborSearch(query_pt, patch_size, return_index);
 
-    std::vector<dof_id_type> neighbor_nodes(patch_size);
-    for (unsigned int i = 0; i < patch_size; ++i)
+    std::vector<dof_id_type> neighbor_nodes(return_index.size());
+    for (unsigned int i = 0; i < return_index.size(); ++i)
       neighbor_nodes[i] = _trial_master_nodes[return_index[i]];
 
     processor_id_type processor_id = _mesh.processor_id();

--- a/framework/src/utils/KDTree.C
+++ b/framework/src/utils/KDTree.C
@@ -27,14 +27,10 @@ KDTree::neighborSearch(Point & query_point,
                        unsigned int patch_size,
                        std::vector<std::size_t> & return_index)
 {
-  // The query point has to be converted from a C++ array to a C array because nanoflann library
-  // expects C arrays.
-  const Real query_pt[] = {query_point(0), query_point(1), query_point(2)};
-
   return_index.resize(patch_size, std::numeric_limits<std::size_t>::max());
   std::vector<Real> return_dist_sqr(patch_size, std::numeric_limits<Real>::max());
 
-  _kd_tree->knnSearch(&query_pt[0], patch_size, &return_index[0], &return_dist_sqr[0]);
+  _kd_tree->knnSearch(&query_point(0), patch_size, return_index.data(), return_dist_sqr.data());
 
   if (return_dist_sqr[0] == std::numeric_limits<Real>::max() ||
       return_index[0] == std::numeric_limits<std::size_t>::max())

--- a/framework/src/utils/KDTree.C
+++ b/framework/src/utils/KDTree.C
@@ -27,8 +27,17 @@ KDTree::neighborSearch(Point & query_point,
                        unsigned int patch_size,
                        std::vector<std::size_t> & return_index)
 {
-  return_index.resize(patch_size, std::numeric_limits<std::size_t>::max());
   std::vector<Real> return_dist_sqr(patch_size, std::numeric_limits<Real>::max());
+  neighborSearch(query_point, patch_size, return_index, return_dist_sqr);
+}
+
+void
+KDTree::neighborSearch(Point & query_point,
+                       unsigned int patch_size,
+                       std::vector<std::size_t> & return_index,
+                       std::vector<Real> & return_dist_sqr)
+{
+  return_index.assign(patch_size, std::numeric_limits<std::size_t>::max());
 
   _kd_tree->knnSearch(&query_point(0), patch_size, return_index.data(), return_dist_sqr.data());
 

--- a/framework/src/utils/KDTree.C
+++ b/framework/src/utils/KDTree.C
@@ -27,7 +27,7 @@ KDTree::neighborSearch(Point & query_point,
                        unsigned int patch_size,
                        std::vector<std::size_t> & return_index)
 {
-  std::vector<Real> return_dist_sqr(patch_size, std::numeric_limits<Real>::max());
+  std::vector<Real> return_dist_sqr(patch_size);
   neighborSearch(query_point, patch_size, return_index, return_dist_sqr);
 }
 
@@ -37,11 +37,14 @@ KDTree::neighborSearch(Point & query_point,
                        std::vector<std::size_t> & return_index,
                        std::vector<Real> & return_dist_sqr)
 {
-  return_index.assign(patch_size, std::numeric_limits<std::size_t>::max());
+  return_index.resize(patch_size);
 
-  _kd_tree->knnSearch(&query_point(0), patch_size, return_index.data(), return_dist_sqr.data());
+  std::size_t n_result =
+      _kd_tree->knnSearch(&query_point(0), patch_size, return_index.data(), return_dist_sqr.data());
 
-  if (return_dist_sqr[0] == std::numeric_limits<Real>::max() ||
-      return_index[0] == std::numeric_limits<std::size_t>::max())
+  if (n_result == 0)
     mooseError("Unable to find closest node!");
+
+  return_index.resize(n_result);
+  return_dist_sqr.resize(n_result);
 }


### PR DESCRIPTION
Uses the updated nanoflann API to get the number of matches for the neighbors. Avoid padding vector with maxint values. USe faster square. Avoid copying point data. Avoid local vector creation. Add additional API for obtaining distances.

Closes #10546