### PR TITLE
Load VTK libraries after matplotlib's

### DIFF
--- a/python/peacock/CheckRequirements.py
+++ b/python/peacock/CheckRequirements.py
@@ -101,4 +101,4 @@ def check_pandas():
     return True
 
 def has_requirements():
-    return check_qt() and check_vtk() and check_matplotlib() and check_pandas()
+    return check_qt() and check_matplotlib() and check_vtk() and check_pandas()


### PR DESCRIPTION
Have Peacock load VTK libraries after matplotlib's to avoid a
missing symbol/version issue on the aging Ubuntu 14.x platform.

Closes #10643 
