### PR TITLE
refactor mesh-only behavior into an action

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -148,6 +148,8 @@ public:
     return action_vector;
   }
 
+  void setFinalTask(const std::string & task);
+
   /**
    * Check if Actions associated with passed in task exist.
    */
@@ -244,6 +246,10 @@ protected:
 
   /// Problem class
   std::shared_ptr<FEProblemBase> _problem;
+
+private:
+  /// Last task to run before (optional) early termination - blank means no early termination.
+  std::string _final_task;
 };
 
 #endif // ACTIONWAREHOUSE_H

--- a/framework/include/actions/MeshOnlyAction.h
+++ b/framework/include/actions/MeshOnlyAction.h
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef MESHONLYACTION_H
+#define MESHONLYACTION_H
+
+#include "Action.h"
+
+#include <string>
+
+class MeshOnlyAction;
+
+template <>
+InputParameters validParams<MeshOnlyAction>();
+
+class MeshOnlyAction : public Action
+{
+public:
+  MeshOnlyAction(InputParameters params);
+
+  virtual void act() override;
+};
+
+#endif // MESHONLYACTION_H

--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -165,7 +165,6 @@ void registerObjects(Factory & factory);
 void addActionTypes(Syntax & syntax);
 void registerActions(Syntax & syntax, ActionFactory & action_factory);
 void registerExecFlags(Factory & factory);
-void populateMeshOnlyTasks(Syntax & syntax);
 
 void setSolverDefaults(FEProblemBase & problem);
 

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -567,6 +567,7 @@ protected:
   /// Constructor is protected so that this object is constructed through the AppFactory object
   MooseApp(InputParameters parameters);
 
+  /// TODO: remove this function after updating rattlesnake to not use it
   /// Populate the _syntax object with mesh only tasks that will be executed before writing mesh.
   virtual void modifyMeshOnlyTasks(Syntax &) {}
 

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -570,12 +570,6 @@ protected:
   /// Populate the _syntax object with mesh only tasks that will be executed before writing mesh.
   virtual void modifyMeshOnlyTasks(Syntax &) {}
 
-  /// Write out the mesh file (used by the --mesh-only command line flag).
-  virtual void writeMeshOnly(std::string mesh_file_name);
-
-  /// TODO: Deprecated, remove
-  virtual void meshOnly(std::string /*mesh_file_name*/) { mooseDeprecated("Use writeMeshOnly"); }
-
   /**
    * NOTE: This is an internal function meant for MOOSE use only!
    *

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -36,6 +36,14 @@ ActionWarehouse::ActionWarehouse(MooseApp & app, Syntax & syntax, ActionFactory 
 ActionWarehouse::~ActionWarehouse() {}
 
 void
+ActionWarehouse::setFinalTask(const std::string & task)
+{
+  if (!_syntax.hasTask(task))
+    mooseError("cannot use unregistered task '", task, "' as final task");
+  _final_task = task;
+}
+
+void
 ActionWarehouse::build()
 {
   _ordered_names = _syntax.getSortedTask();
@@ -324,7 +332,11 @@ ActionWarehouse::executeAllActions()
   }
 
   for (const auto & task : _ordered_names)
+  {
     executeActionsWithAction(task);
+    if (_final_task != "" && task == _final_task)
+      break;
+  }
 }
 
 void

--- a/framework/src/actions/MeshOnlyAction.C
+++ b/framework/src/actions/MeshOnlyAction.C
@@ -1,0 +1,74 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "MeshOnlyAction.h"
+
+#include "MooseApp.h"
+#include "MooseMesh.h"
+#include "libmesh/exodusII_io.h"
+
+template <>
+InputParameters
+validParams<MeshOnlyAction>()
+{
+  return validParams<Action>();
+}
+
+MeshOnlyAction::MeshOnlyAction(InputParameters params) : Action(params) {}
+
+void
+MeshOnlyAction::act()
+{
+  auto mesh_file = _app.parameters().get<std::string>("mesh_only");
+  auto & mesh_ptr = _app.actionWarehouse().mesh();
+
+  bool should_generate = false;
+  // If no argument specified or if the argument following --mesh-only starts
+  // with a dash, try to build an output filename based on the input mesh filename.
+  if (mesh_file.empty() || (mesh_file[0] == '-'))
+    should_generate = true;
+  // There's something following the --mesh-only flag, let's make an attempt to validate it.
+  // If we don't find a '.' or we DO find an equals sign, chances are this is not a file!
+  else if ((mesh_file.find('.') == std::string::npos || mesh_file.find('=') != std::string::npos))
+  {
+    mooseWarning("The --mesh-only option should be followed by a file name. Move it to the end of "
+                 "your CLI args or follow it by another \"-\" argument.");
+    should_generate = true;
+  }
+
+  if (should_generate)
+  {
+    mesh_file = _app.parser().getFileName();
+    size_t pos = mesh_file.find_last_of('.');
+
+    // Default to writing out an ExodusII mesh base on the input filename.
+    mesh_file = mesh_file.substr(0, pos) + "_in.e";
+  }
+
+  // If we're writing an Exodus file, write the Mesh using its logical
+  // element dimension rather than the spatial dimension, unless it's
+  // a 1D Mesh.  One reason to prefer this approach is that sidesets
+  // are displayed incorrectly for 2D triangular elements in both
+  // Paraview and Cubit if num_dim==3 in the Exodus file. We do the
+  // same thing in MOOSE's Exodus Output object, so we are mimicking
+  // that behavior here.
+  if (mesh_file.find(".e") + 2 == mesh_file.size())
+  {
+    ExodusII_IO exio(mesh_ptr->getMesh());
+    if (mesh_ptr->getMesh().mesh_dimension() != 1)
+      exio.use_mesh_dimension_instead_of_spatial_dimension(true);
+
+    exio.write(mesh_file);
+  }
+  else
+  {
+    // Just write the file using the name requested by the user.
+    mesh_ptr->getMesh().write(mesh_file);
+  }
+}

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -443,6 +443,7 @@
 #include "AddNodalKernelAction.h"
 #include "MaterialDerivativeTestAction.h"
 #include "AddRelationshipManager.h"
+#include "MeshOnlyAction.h"
 
 // Outputs
 #ifdef LIBMESH_HAVE_EXODUS_API
@@ -1116,22 +1117,6 @@ addActionTypes(Syntax & syntax)
                            "(check_integrity)");
 }
 
-void
-populateMeshOnlyTasks(Syntax & syntax)
-{
-  syntax.addDependencySets("(meta_action)"
-                           "(set_global_params)"
-                           "(setup_mesh)"
-                           "(add_partitioner)"
-                           "(init_mesh)"
-                           "(prepare_mesh)"
-                           "(add_mesh_modifier)"
-                           "(execute_mesh_modifiers)"
-                           "(add_mortar_interface)"
-                           "(uniform_refine_mesh)"
-                           "(setup_mesh_complete)");
-}
-
 /**
  * Multiple Action class can be associated with a single input file section, in which case all
  * associated Actions will be created and "acted" on when the associated input file section is
@@ -1170,6 +1155,7 @@ registerActions(Syntax & syntax, ActionFactory & action_factory)
 
   registerAction(SetupPostprocessorDataAction, "setup_postprocessor_data");
 
+  registerAction(MeshOnlyAction, "mesh_only");
   registerAction(SetupMeshAction, "setup_mesh");
   registerAction(SetupMeshAction, "init_mesh");
   registerAction(SetupMeshCompleteAction, "prepare_mesh");


### PR DESCRIPTION
This required adding the ability to specify a "final" task to run in the
action warehouse.  The setFinalTask function can be called by anybody to
make any task the last one to run.

Cleans up a special case in preparation for work on #10458.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
