### PR TITLE
Adding scalar zero into ScalarCoupleable

### DIFF
--- a/framework/include/base/FEProblemBase.h
+++ b/framework/include/base/FEProblemBase.h
@@ -1278,9 +1278,9 @@ public:
   ///@{
   /**
    * Convenience zeros
-   * @see ZeroInterface
    */
   std::vector<Real> _real_zero;
+  std::vector<VariableValue> _scalar_zero;
   std::vector<VariableValue> _zero;
   std::vector<VariableGradient> _grad_zero;
   std::vector<VariableSecond> _second_zero;

--- a/framework/include/base/ScalarCoupleable.h
+++ b/framework/include/base/ScalarCoupleable.h
@@ -153,6 +153,9 @@ protected:
   /// Scalar zero
   const Real & _real_zero;
 
+  /// Zero value of a scalar variable
+  const VariableValue & _scalar_zero;
+
   /// Zero point
   const Point & _point_zero;
 

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -226,6 +226,7 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
   unsigned int n_threads = libMesh::n_threads();
 
   _real_zero.resize(n_threads, 0.);
+  _scalar_zero.resize(n_threads);
   _zero.resize(n_threads);
   _grad_zero.resize(n_threads);
   _second_zero.resize(n_threads);
@@ -321,6 +322,7 @@ FEProblemBase::~FEProblemBase()
   for (unsigned int i = 0; i < n_threads; i++)
   {
     _zero[i].release();
+    _scalar_zero[i].release();
     _grad_zero[i].release();
     _second_zero[i].release();
     _second_phi_zero[i].release();
@@ -1268,6 +1270,8 @@ FEProblemBase::reinitDirac(const Elem * elem, THREAD_ID tid)
       unsigned int max_qpts = getMaxQps();
       for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
       {
+        // the highest available order in libMesh is 43
+        _scalar_zero[tid].resize(FORTYTHIRD, 0);
         _zero[tid].resize(max_qpts, 0);
         _grad_zero[tid].resize(max_qpts, RealGradient(0.));
         _second_zero[tid].resize(max_qpts, RealTensor(0.));
@@ -3572,6 +3576,8 @@ FEProblemBase::createQRules(QuadratureType type, Order order, Order volume_order
   unsigned int max_qpts = getMaxQps();
   for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
   {
+    // the highest available order in libMesh is 43
+    _scalar_zero[tid].resize(FORTYTHIRD, 0);
     _zero[tid].resize(max_qpts, 0);
     _grad_zero[tid].resize(max_qpts, RealGradient(0.));
     _second_zero[tid].resize(max_qpts, RealTensor(0.));

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -27,6 +27,7 @@ ScalarCoupleable::ScalarCoupleable(const MooseObject * moose_object)
     _sc_tid(_sc_parameters.have_parameter<THREAD_ID>("_tid") ? _sc_parameters.get<THREAD_ID>("_tid")
                                                              : 0),
     _real_zero(_sc_fe_problem._real_zero[_sc_tid]),
+    _scalar_zero(_sc_fe_problem._scalar_zero[_sc_tid]),
     _point_zero(_sc_fe_problem._point_zero[_sc_tid])
 {
   SubProblem & problem = *_sc_parameters.getCheckedPointerParam<SubProblem *>("_subproblem");


### PR DESCRIPTION
Scalar zero is equivalent of zero in normal coupling, but for scalar
variables.  This version is needed, so that when people use it, they get
properly sized zero for their scalar variable. The _zero would be sized
to the number of q-points, while we need number of components.  However,
to make things easier we always resize to order 43, becuase we cannot
have higer number of component for scalar variables (libMesh
limitation).

Refs #10630

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
