### PR TITLE
Adjust csv diff criteria for mu_0_2_kin test

### DIFF
--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
@@ -81,7 +81,7 @@
     csvdiff = 'single_point_2d_out_frictional_0_2_kin.csv'
     cli_args = 'Executioner/end_time=0.002 Executioner/nl_rel_tol=1e-8 Executioner/nl_abs_tol=1e-10 Contact/leftright/friction_coefficient=0.2 Outputs/file_base=single_point_2d_out_frictional_0_2_kin'
     rel_err = 1e-4
-    abs_zero = 3e-5
+    abs_zero = 4e-5
     max_parallel = 1
     superlu = true
     prereq = 'mu_0_2_kin_sm'


### PR DESCRIPTION
This test is failing after #10597 with 64 bit dof indices. Adjusting the absolute_zero for this test should fix the csv diffing.

Refs #8649 
