### PR TITLE
remove modifyMeshOnlyTasks callback

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -567,10 +567,6 @@ protected:
   /// Constructor is protected so that this object is constructed through the AppFactory object
   MooseApp(InputParameters parameters);
 
-  /// TODO: remove this function after updating rattlesnake to not use it
-  /// Populate the _syntax object with mesh only tasks that will be executed before writing mesh.
-  virtual void modifyMeshOnlyTasks(Syntax &) {}
-
   /**
    * NOTE: This is an internal function meant for MOOSE use only!
    *


### PR DESCRIPTION
It is no longer needed now that mesh_only runs don't clear the task list
anymore.  Follow up to #10648.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
