### PR TITLE
Get correct contact node output in parallel

### DIFF
--- a/modules/contact/src/ContactAction.C
+++ b/modules/contact/src/ContactAction.C
@@ -78,6 +78,8 @@ validParams<ContactAction>()
 
   params.addParam<Real>("al_frictional_force_tolerance",
                         "The tolerance of the frictional force for augmented Lagrangian method.");
+  params.addParam<bool>(
+      "print_contact_nodes", false, "Whether to print the number of nodes in contact.");
   return params;
 }
 
@@ -150,6 +152,7 @@ ContactAction::act()
       params.set<std::vector<VariableName>>("displacements") = coupled_displacements;
       params.set<BoundaryName>("boundary") = _master;
       params.set<bool>("use_displaced_mesh") = true;
+      params.set<bool>("print_contact_nodes") = getParam<bool>("print_contact_nodes");
 
       for (unsigned int i = 0; i < ndisp; ++i)
       {

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -469,7 +469,7 @@ MechanicalContactConstraint::shouldApply()
       if (pinfo->isCaptured())
       {
         in_contact = true;
-        if (is_nonlinear)
+        if (is_nonlinear && _print_contact_nodes)
           _current_contact_state.insert(pinfo->_node->id());
       }
     }
@@ -1783,12 +1783,13 @@ MechanicalContactConstraint::residualEnd()
 {
   if (_component == 0 && _print_contact_nodes)
   {
+    _communicator.set_union(_current_contact_state, 0);
     if (_current_contact_state == _old_contact_state)
-      mooseWarning(
-          "Unchanged contact state. ", _current_contact_state.size(), " nodes in contact.");
+      _console << "Unchanged contact state. " << _current_contact_state.size()
+               << " nodes in contact.\n";
     else
-      mooseWarning(
-          "Changed contact state!!! ", _current_contact_state.size(), " nodes in contact.");
+      _console << "Changed contact state!!! " << _current_contact_state.size()
+               << " nodes in contact.\n";
 
     _old_contact_state = _current_contact_state;
     _current_contact_state.clear();


### PR DESCRIPTION
- Call `set_union` to build the total set of nodes in contact on processor 0
- Add `print_contact_nodes` option to `Contact` action as this is almost always how contact users access `MechanicalContactConstraint`

Closes #10678
