### PR TITLE
Libmesh update

### DIFF
--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -316,6 +316,12 @@ indentMessage(const std::string & prefix, std::string & message, const char * co
  */
 std::string & removeColor(std::string & msg);
 
+std::list<std::string> listDir(const std::string path, bool files_only = false);
+
+bool pathExists(const std::string & path);
+
+void rmAll(const std::string & path);
+
 /**
  * Retrieves the names of all of the files contained within the list of directories passed into the
  * routine.

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -98,8 +98,7 @@ FileMesh::buildMesh()
       // and renumbering, at least at first.
       if (file == "LATEST")
       {
-        std::list<std::string> dir_list(1, path);
-        std::list<std::string> files = MooseUtils::getFilesInDirs(dir_list);
+        std::list<std::string> files = MooseUtils::listDir(path);
 
         // Fill in the name of the LATEST file so we can open it and read it.
         _file_name = MooseUtils::getLatestMeshCheckpointFile(files);
@@ -118,7 +117,8 @@ FileMesh::buildMesh()
         getMesh().allow_renumbering(false);
       }
 
-      MooseUtils::checkFileReadable(_file_name);
+      if (!MooseUtils::pathExists(_file_name))
+        mooseError("cannot locate mesh file '", _file_name, "'");
       getMesh().read(_file_name);
 
       if (restarting)

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -152,31 +152,7 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
       std::ostringstream oss;
       oss << delete_files.checkpoint;
       std::string file_name = oss.str();
-      int ret = remove(file_name.c_str());
-      if (ret != 0)
-        mooseWarning("Error during the deletion of file '", file_name, "': ", std::strerror(ret));
-    }
-
-    if (_parallel_mesh)
-    {
-      std::ostringstream oss;
-      oss << delete_files.checkpoint << '-' << n_processors() << '-' << proc_id;
-      std::string file_name = oss.str();
-      int ret = remove(file_name.c_str());
-      if (ret != 0)
-        mooseWarning("Error during the deletion of file '", file_name, "': ", std::strerror(ret));
-    }
-    else
-    {
-      if (proc_id == 0)
-      {
-        std::ostringstream oss;
-        oss << delete_files.checkpoint << "-1-0";
-        std::string file_name = oss.str();
-        int ret = remove(file_name.c_str());
-        if (ret != 0)
-          mooseWarning("Error during the deletion of file '", file_name, "': ", std::strerror(ret));
-      }
+      MooseUtils::rmAll(file_name);
     }
 
     // Delete the system files (xdr and xdr.0000, ...)
@@ -189,6 +165,7 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
       if (ret != 0)
         mooseWarning("Error during the deletion of file '", file_name, "': ", std::strerror(ret));
     }
+
     {
       std::ostringstream oss;
       oss << delete_files.system << "." << std::setw(4) << std::setprecision(0) << std::setfill('0')

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -116,6 +116,13 @@ pathContains(const std::string & expression,
 }
 
 bool
+pathExists(const std::string & path)
+{
+  struct stat buffer;
+  return (stat(path.c_str(), &buffer) == 0);
+}
+
+bool
 checkFileReadable(const std::string & filename, bool check_line_endings, bool throw_on_unreadable)
 {
   std::ifstream in(filename.c_str(), std::ifstream::in);
@@ -245,6 +252,15 @@ hasExtension(const std::string & filename, std::string ext, bool strip_exodus_ex
     return true;
   else
     return false;
+}
+
+void
+rmAll(const std::string & path)
+{
+  auto cmd = std::string("rm -rf ") + path;
+  auto ret = system(cmd.c_str());
+  if (ret != 0)
+    mooseError("failed to remove path '", path, "'");
 }
 
 std::pair<std::string, std::string>
@@ -463,30 +479,38 @@ indentMessage(const std::string & prefix,
 }
 
 std::list<std::string>
+listDir(const std::string path, bool files_only)
+{
+  std::list<std::string> files;
+
+  tinydir_dir dir;
+  dir.has_next = 0; // Avoid a garbage value in has_next (clang StaticAnalysis)
+  tinydir_open(&dir, path.c_str());
+
+  while (dir.has_next)
+  {
+    tinydir_file file;
+    file.is_dir = 0; // Avoid a garbage value in is_dir (clang StaticAnalysis)
+    tinydir_readfile(&dir, &file);
+
+    if (!files_only || !file.is_dir)
+      files.push_back(path + "/" + file.name);
+
+    tinydir_next(&dir);
+  }
+
+  tinydir_close(&dir);
+
+  return files;
+}
+
+std::list<std::string>
 getFilesInDirs(const std::list<std::string> & directory_list)
 {
   std::list<std::string> files;
 
   for (const auto & dir_name : directory_list)
-  {
-    tinydir_dir dir;
-    dir.has_next = 0; // Avoid a garbage value in has_next (clang StaticAnalysis)
-    tinydir_open(&dir, dir_name.c_str());
-
-    while (dir.has_next)
-    {
-      tinydir_file file;
-      file.is_dir = 0; // Avoid a garbage value in is_dir (clang StaticAnalysis)
-      tinydir_readfile(&dir, &file);
-
-      if (!file.is_dir)
-        files.push_back(dir_name + "/" + file.name);
-
-      tinydir_next(&dir);
-    }
-
-    tinydir_close(&dir);
-  }
+    files.splice(files.end(), listDir(dir_name, true));
 
   return files;
 }

--- a/test/tests/checkpoint/tests
+++ b/test/tests/checkpoint/tests
@@ -5,23 +5,23 @@
     check_files =      'checkpoint_interval_out_cp/0006.xdr
                         checkpoint_interval_out_cp/0006.xdr.0000
 			checkpoint_interval_out_cp/0006.rd-0
-			checkpoint_interval_out_cp/0006_mesh.cpr
+			checkpoint_interval_out_cp/0006_mesh.cpr/1/header.cpr
     		        checkpoint_interval_out_cp/0009.xdr
                         checkpoint_interval_out_cp/0009.xdr.0000
 			checkpoint_interval_out_cp/0009.rd-0
-			checkpoint_interval_out_cp/0009_mesh.cpr'
+			checkpoint_interval_out_cp/0009_mesh.cpr/1/header.cpr'
     check_not_exists = 'checkpoint_interval_out_cp/0007.xdr
                         checkpoint_interval_out_cp/0007.xdr.0000
 			checkpoint_interval_out_cp/0007.rd-0
-			checkpoint_interval_out_cp/0007_mesh.cpr
+			checkpoint_interval_out_cp/0007_mesh.cpr/1/header.cpr
 			checkpoint_interval_out_cp/0008.xdr
                         checkpoint_interval_out_cp/0008.xdr.0000
 			checkpoint_interval_out_cp/0008.rd-0
-			checkpoint_interval_out_cp/0008_mesh.cpr
+			checkpoint_interval_out_cp/0008_mesh.cpr/1/header.cpr
     		        checkpoint_interval_out_cp/0010.xdr
                         checkpoint_interval_out_cp/0010.xdr.0000
 			checkpoint_interval_out_cp/0010.rd-0
-			checkpoint_interval_out_cp/0010_mesh.cpr'
+			checkpoint_interval_out_cp/0010_mesh.cpr/1/header.cpr'
     recover = false
     delete_output_folders = false
 

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -325,7 +325,7 @@
   [./missing_mesh_test]
     type = 'RunException'
     input = 'missing_mesh_test.i'
-    expect_err = "Unable to open file \S+"
+    expect_err = "cannot locate mesh file '\S+'"
   [../]
 
   [./missing_req_par_action_obj_test]

--- a/test/tests/outputs/checkpoint/tests
+++ b/test/tests/outputs/checkpoint/tests
@@ -5,27 +5,27 @@
     check_files =      'checkpoint_interval_out_cp/0006.xdr
                         checkpoint_interval_out_cp/0006.xdr.0000
                         checkpoint_interval_out_cp/0006.rd-0
-                        checkpoint_interval_out_cp/0006_mesh.cpr
+                        checkpoint_interval_out_cp/0006_mesh.cpr/1/header.cpr
                         checkpoint_interval_out_cp/0009.xdr
                         checkpoint_interval_out_cp/0009.xdr.0000
                         checkpoint_interval_out_cp/0009.rd-0
-                        checkpoint_interval_out_cp/0009_mesh.cpr'
+                        checkpoint_interval_out_cp/0009_mesh.cpr/1/header.cpr'
     check_not_exists = 'checkpoint_interval_out_cp/0003.xdr
                         checkpoint_interval_out_cp/0003.xdr.0000
                         checkpoint_interval_out_cp/0003.rd-0
-                        checkpoint_interval_out_cp/0003_mesh.cpr
+                        checkpoint_interval_out_cp/0003_mesh.cpr/1/header.cpr
                         checkpoint_interval_out_cp/0007.xdr
                         checkpoint_interval_out_cp/0007.xdr.0000
                         checkpoint_interval_out_cp/0007.rd-0
-                        checkpoint_interval_out_cp/0007_mesh.cpr
+                        checkpoint_interval_out_cp/0007_mesh.cpr/1/header.cpr
                         checkpoint_interval_out_cp/0008.xdr
                         checkpoint_interval_out_cp/0008.xdr.0000
                         checkpoint_interval_out_cp/0008.rd-0
-                        checkpoint_interval_out_cp/0008_mesh.cpr
+                        checkpoint_interval_out_cp/0008_mesh.cpr/1/header.cpr
                         checkpoint_interval_out_cp/0010.xdr
                         checkpoint_interval_out_cp/0010.xdr.0000
                         checkpoint_interval_out_cp/0010.rd-0
-                        checkpoint_interval_out_cp/0010_mesh.cpr'
+                        checkpoint_interval_out_cp/0010_mesh.cpr/1/header.cpr'
     recover = false
 
     # The suffixes of these files change when running in parallel or with threads


### PR DESCRIPTION
Brief summary of libMesh changes in this update:
* CouplingMatrix sparsity optimization.
* Changes to the directory structure used to write CheckpointIO files.
* Fix memory leak introduced in PetscNonlinearSolver::solve().
* Fixes/updates to the CheckpointIO splitter app.

This also includes a fix from @rwcarlsen required to get MOOSE CheckpointIO tests passing.