### PR TITLE
Add input file name to peacock temporary input file names.

### DIFF
--- a/python/peacock/Execute/ExecuteRunnerPlugin.py
+++ b/python/peacock/Execute/ExecuteRunnerPlugin.py
@@ -80,11 +80,22 @@ class ExecuteRunnerPlugin(QWidget, Plugin):
         self.exe_path = None
         self.exe_args = []
         self.has_csv = False
+        self._input_file = ""
 
         self.setup()
 
+    def setInputFile(self, input_file):
+        if input_file:
+            self._input_file = os.path.basename(input_file)
+        else:
+            self._input_file = ""
+
     def _tempInputFile(self):
-        return os.path.abspath("peacock_run_exe_tmp.i")
+        if self._input_file:
+            tmp = "peacock_run_exe_tmp_%s" % self._input_file
+        else:
+            tmp = "peacock_run_exe_tmp.i"
+        return os.path.abspath(tmp)
 
     def _showProgressBar(self, show):
         """

--- a/python/peacock/PeacockMainWindow.py
+++ b/python/peacock/PeacockMainWindow.py
@@ -99,8 +99,10 @@ class PeacockMainWindow(BasePeacockMainWindow):
             input_filename: Name of the new input_filename
         """
         self.input_file_path = input_filename
-        new_dir = os.path.dirname(os.path.abspath(input_filename))
+        full_filename = os.path.abspath(input_filename)
+        new_dir = os.path.dirname(full_filename)
         self.tab_plugin.ExecuteTabPlugin.ExecuteOptionsPlugin.setWorkingDir(new_dir)
+        self.tab_plugin.ExecuteTabPlugin.ExecuteRunnerPlugin.setInputFile(full_filename)
         self._setTitle()
 
     def setTab(self, tabName):


### PR DESCRIPTION
The old temporary file name was `peacock_run_exe_tmp.i`
Now it will be `peacock_run_exe_tmp_<input file>.i`
This avoids clobbering the temporary input file and output files
when changing input files.

closes #10493

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
