### PR TITLE
Use PETSC_RELEASE_LESS_THAN instead of PETSC_VERSION_LESS_THAN

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -397,7 +397,7 @@ petscNonlinearConverged(SNES snes,
   // Whether or not to force SNESSolve() take at least one iteration regardless of the initial
   // residual norm
   PetscBool force_iteration = PETSC_FALSE;
-#if !PETSC_VERSION_LESS_THAN(3, 8, 3)
+#if !PETSC_RELEASE_LESS_THAN(3, 8, 4)
   ierr = SNESGetForceIteration(snes, &force_iteration);
   CHKERRABORT(problem.comm().get(), ierr);
 #endif

--- a/test/tests/kernels/2d_diffusion/tests
+++ b/test/tests/kernels/2d_diffusion/tests
@@ -33,7 +33,7 @@
     input = '2d_diffusion_test.i'
     exodiff = 'out.e'
     cli_args = 'Executioner/nl_abs_tol=1e+1 Executioner/petsc_options_iname=-snes_force_iteration Executioner/petsc_options_value=1'
-    petsc_version = '>=3.8.3'
+    petsc_version = '>=3.8.4'
     prereq = testdirichlet
   [../]
 []


### PR DESCRIPTION
"SNESGetForceIteration" is now already in petsc-master and petsc-maint. But PETSc-3.8.3 was released without patches.

We should simply skip 3.8.3. 

Close #10599

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->