### PR TITLE
Adding API for setting output dimension

### DIFF
--- a/framework/include/outputs/Exodus.h
+++ b/framework/include/outputs/Exodus.h
@@ -72,6 +72,13 @@ public:
    */
   virtual void sequence(bool state);
 
+  /**
+   * Force the output dimension programatically
+   *
+   * @param dim The dimension written in the output file
+   */
+  void setOutputDimension(unsigned int dim);
+
 protected:
   /**
    * Outputs nodal, nonlinear variables

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -90,6 +90,16 @@ Exodus::Exodus(const InputParameters & parameters)
 }
 
 void
+Exodus::setOutputDimension(unsigned int dim)
+{
+  if (dim >= 1 && dim <= 3)
+    _output_dimension = dim;
+  else
+    mooseError(
+        name(), ": Invalid dimension (", dim, ") specified.  Allowed dimensions are 1, 2 or 3.");
+}
+
+void
 Exodus::initialSetup()
 {
   // Call base class setup method


### PR DESCRIPTION
When using lower dimensional elements in higher dimensional space, an
application might require to force the dimension of the Exodus output.
If this is supposed to happen via an action, an API for this is needed.
The manipulation of input parameters is not possible, becuase the object
already exists.

Also, requiring users to enter an extra line into all their input files
is not friendly, becuase we know what the dimension always is, so we
just need to set it for them.

Refs #9205

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
