### PR TITLE
Fixing parser bugs

### DIFF
--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -459,7 +459,12 @@ Field::vecIntVal()
   {
     try
     {
-      vec.push_back(std::stoi(s));
+      size_t pos = 0;
+      auto converted_val = std::stoi(s, &pos);
+      if (pos != s.size())
+        throw std::invalid_argument("dummy");
+
+      vec.push_back(converted_val);
     }
     catch (...)
     {
@@ -478,7 +483,12 @@ Field::vecFloatVal()
   {
     try
     {
-      vec.push_back(std::stod(s));
+      size_t pos = 0;
+      auto converted_val = std::stod(s, &pos);
+      if (pos != s.size())
+        throw std::invalid_argument("dummy");
+
+      vec.push_back(converted_val);
     }
     catch (...)
     {
@@ -520,7 +530,11 @@ Field::intVal()
                 "')");
   try
   {
-    return std::stoi(_val);
+    size_t pos = 0;
+    auto converted_val = std::stoi(_val, &pos);
+    if (pos != _val.size())
+      throw std::invalid_argument("dummy");
+    return converted_val;
   }
   catch (...)
   {
@@ -535,7 +549,11 @@ Field::floatVal()
                 "')");
   try
   {
-    return std::stod(_val);
+    size_t pos = 0;
+    auto converted_val = std::stod(_val, &pos);
+    if (pos != _val.size())
+      throw std::invalid_argument("dummy");
+    return converted_val;
   }
   catch (...)
   {
@@ -812,10 +830,10 @@ public:
     }
     else if (result->type() == NodeType::Field)
     {
-      // node exists - overwrite its value
+      // node exists - overwrite its value and kind
       auto dst = static_cast<Field *>(result);
       auto src = static_cast<Field *>(n);
-      dst->setVal(src->val());
+      dst->setVal(src->val(), src->kind());
     }
   }
 

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -347,12 +347,12 @@ class Field : public Node
 {
 public:
   // Kind represents all possible value types that can be stored in a field.
-  enum class Kind
+  enum class Kind : unsigned char
   {
     None,
+    Bool,
     Int,
     Float,
-    Bool,
     String,
   };
   Field(const std::string & field, Kind k, const std::string & val);

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -1285,7 +1285,7 @@ Parser::setScalarParameter(const std::string & full_name,
                    "\n";
       }
     }
-    else if (t == typeid(double))
+    else if (t == typeid(double) || t == typeid(float))
     {
       try
       {

--- a/modules/navier_stokes/test/tests/ins/jeffery_hamel/wedge_dirichlet.i
+++ b/modules/navier_stokes/test/tests/ins/jeffery_hamel/wedge_dirichlet.i
@@ -29,7 +29,7 @@
     # work.
     type = AddExtraNodeset
     new_boundary = pinned_node
-    coord = '1, 0'
+    coord = '1 0'
   [../]
 []
 

--- a/test/tests/controls/time_periods/error/control.i
+++ b/test/tests/controls/time_periods/error/control.i
@@ -60,8 +60,12 @@
   [./damping_control]
     type = TimePeriod
     disable_objects = 'const_damp'
-    start_time = 0.25
-    end_time = 0.55
+
+    # Note: These numbers are quoted to get around an issue when
+    # overriding numeric types with vectors of numeric types
+    # on the CLI. They are still interpreted as numbers.
+    start_time = '0.25'
+    end_time = '0.55'
     execute_on = 'initial timestep_begin'
   [../]
 []

--- a/test/tests/time_steppers/iteration_adaptive/adapt_tstep_grow_dtfunc.i
+++ b/test/tests/time_steppers/iteration_adaptive/adapt_tstep_grow_dtfunc.i
@@ -48,8 +48,8 @@
     type = IterationAdaptiveDT
     dt = 1.0
     optimal_iterations = 10
-    time_t = '0.0, 5.0'
-    time_dt = '1.0, 5.0'
+    time_t = '0.0 5.0'
+    time_dt = '1.0 5.0'
   [../]
 []
 
@@ -64,4 +64,3 @@
   exodus = true
   checkpoint = true
 []
-

--- a/test/tests/time_steppers/iteration_adaptive/adapt_tstep_grow_dtfunc_restart.i
+++ b/test/tests/time_steppers/iteration_adaptive/adapt_tstep_grow_dtfunc_restart.i
@@ -56,8 +56,8 @@
     type = IterationAdaptiveDT
     dt = 1.0
     optimal_iterations = 10
-    time_t = '0.0, 5.0'
-    time_dt = '1.0, 5.0'
+    time_t = '0.0 5.0'
+    time_dt = '1.0 5.0'
   [../]
 []
 

--- a/unit/include/BrineFluidPropertiesTest.h
+++ b/unit/include/BrineFluidPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef BRINEFLUIDPROPERTIESTEST_H
 #define BRINEFLUIDPROPERTIESTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "MooseApp.h"
 #include "Utils.h"

--- a/unit/include/CO2FluidPropertiesTest.h
+++ b/unit/include/CO2FluidPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef CO2FLUIDPROPERTIESTEST_H
 #define CO2FLUIDPROPERTIESTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "FEProblem.h"
 #include "AppFactory.h"

--- a/unit/include/ColumnMajorMatrixTest.h
+++ b/unit/include/ColumnMajorMatrixTest.h
@@ -11,7 +11,7 @@
 #define COLUMNMAJORMATRIXTEST_H
 
 // CPPUnit includes
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 // Moose includes
 #include "ColumnMajorMatrix.h"

--- a/unit/include/DependencyResolverTest.h
+++ b/unit/include/DependencyResolverTest.h
@@ -11,7 +11,7 @@
 #define DEPENDENCYRESOLVERTEST_H
 
 // CPPUnit includes
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "DependencyResolver.h"
 

--- a/unit/include/EBSDAccessFunctorsTest.h
+++ b/unit/include/EBSDAccessFunctorsTest.h
@@ -10,7 +10,7 @@
 #ifndef EBSDACCESSFUNCTORSTEST_H
 #define EBSDACCESSFUNCTORSTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 #include "EBSDAccessFunctors.h"
 
 class EBSDAccessFunctorsTest : public ::testing::Test, public EBSDAccessFunctors

--- a/unit/include/EBSDMeshErrorTest.h
+++ b/unit/include/EBSDMeshErrorTest.h
@@ -11,7 +11,7 @@
 #define EBSDMESHERRORTEST_H
 
 // CPPUnit includes
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 // Moose includes
 #include "EBSDMesh.h"

--- a/unit/include/IdealGasFluidPropertiesPTTest.h
+++ b/unit/include/IdealGasFluidPropertiesPTTest.h
@@ -10,7 +10,7 @@
 #ifndef IDEALGASFLUIDPROPERTIESPTTEST_H
 #define IDEALGASFLUIDPROPERTIESPTTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "FEProblem.h"
 #include "AppFactory.h"

--- a/unit/include/IdealGasFluidPropertiesTest.h
+++ b/unit/include/IdealGasFluidPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef IDEALGASFLUIDPROPERTIESTEST_H
 #define IDEALGASFLUIDPROPERTIESTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "MooseApp.h"
 #include "Utils.h"

--- a/unit/include/IsotropicElasticityTensorTest.h
+++ b/unit/include/IsotropicElasticityTensorTest.h
@@ -10,7 +10,7 @@
 #ifndef ISOTROPICELASTICITYTENSORTEST_H
 #define ISOTROPICELASTICITYTENSORTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "IsotropicElasticityTensor.h"
 

--- a/unit/include/LineSegmentTest.h
+++ b/unit/include/LineSegmentTest.h
@@ -10,7 +10,7 @@
 #ifndef LINESEGMENTTEST_H
 #define LINESEGMENTTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "LineSegment.h"
 

--- a/unit/include/MethaneFluidPropertiesTest.h
+++ b/unit/include/MethaneFluidPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef METHANEFLUIDPROPERTIESTEST_H
 #define METHANEFLUIDPROPERTIESTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "FEProblem.h"
 #include "AppFactory.h"

--- a/unit/include/NaClFluidPropertiesTest.h
+++ b/unit/include/NaClFluidPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef NACLFLUIDPROPERTIESTEST_H
 #define NACLFLUIDPROPERTIESTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "MooseApp.h"
 #include "Utils.h"

--- a/unit/include/ParsedFunctionTest.h
+++ b/unit/include/ParsedFunctionTest.h
@@ -10,7 +10,7 @@
 #ifndef USERFUNCTIONTEST_H
 #define USERFUNCTIONTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "InputParameters.h"
 #include "MooseParsedFunction.h"

--- a/unit/include/PorousFlowBrineCO2Test.h
+++ b/unit/include/PorousFlowBrineCO2Test.h
@@ -10,7 +10,7 @@
 #ifndef POROUSFLOWBRINECO2TEST_H
 #define POROUSFLOWBRINECO2TEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "FEProblem.h"
 #include "AppFactory.h"

--- a/unit/include/PorousFlowFluidStateFlashTest.h
+++ b/unit/include/PorousFlowFluidStateFlashTest.h
@@ -10,7 +10,7 @@
 #ifndef POROUSFLOWFLUIDSTATEFLASHTEST_H
 #define POROUSFLOWFLUIDSTATEFLASHTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "FEProblem.h"
 #include "AppFactory.h"

--- a/unit/include/PorousFlowWaterNCGTest.h
+++ b/unit/include/PorousFlowWaterNCGTest.h
@@ -10,7 +10,7 @@
 #ifndef POROUSFLOWWATERNCGTEST_H
 #define POROUSFLOWWATERNCGTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "FEProblem.h"
 #include "AppFactory.h"

--- a/unit/include/RankTwoTensorTest.h
+++ b/unit/include/RankTwoTensorTest.h
@@ -10,7 +10,7 @@
 #ifndef RANKTWOTENSORTEST_H
 #define RANKTWOTENSORTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 // Moose includes
 #include "RankTwoTensor.h"

--- a/unit/include/SimpleFluidPropertiesTest.h
+++ b/unit/include/SimpleFluidPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef SIMPLEFLUIDPROPERTIESTEST_H
 #define SIMPLEFLUIDPROPERTIESTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "FEProblem.h"
 #include "AppFactory.h"

--- a/unit/include/SodiumPropertiesTest.h
+++ b/unit/include/SodiumPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef SODIUMPROPERTIESTEST_H
 #define SODIUMPROPERTIESTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "MooseApp.h"
 #include "Utils.h"

--- a/unit/include/StiffenedGasFluidPropertiesTest.h
+++ b/unit/include/StiffenedGasFluidPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef StiffenedGasFluidPropertiesTest_H
 #define StiffenedGasFluidPropertiesTest_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "MooseApp.h"
 #include "Utils.h"

--- a/unit/include/TabulatedFluidPropertiesTest.h
+++ b/unit/include/TabulatedFluidPropertiesTest.h
@@ -10,7 +10,7 @@
 #ifndef TABULATEDFLUIDPROPERTIESTEST_H
 #define TABULATEDFLUIDPROPERTIESTEST_H
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "FEProblem.h"
 #include "AppFactory.h"

--- a/unit/include/Water97FluidPropertiesTest.h
+++ b/unit/include/Water97FluidPropertiesTest.h
@@ -11,7 +11,7 @@
 #define WATER97FLUIDPROPERTIESTEST_H
 
 // CPPUnit includes
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "MooseApp.h"
 #include "Utils.h"

--- a/unit/include/gtest_include.h
+++ b/unit/include/gtest_include.h
@@ -1,0 +1,17 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef GTESTINCLUDE
+#define GTESTINCLUDE
+
+#include "libmesh/ignore_warnings.h"
+#include "gtest/gtest.h"
+#include "libmesh/restore_warnings.h"
+
+#endif

--- a/unit/src/BrentsMethodTest.C
+++ b/unit/src/BrentsMethodTest.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "BrentsMethod.h"
 

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -10,7 +10,7 @@
 #include "hit.h"
 #include "Parser.h"
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include <iostream>
 #include <vector>

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -344,9 +344,25 @@ TEST(HitTests, RenderCases)
 
 TEST(HitTests, MergeTree)
 {
-  auto root1 = hit::parse("TESTCASE", "[foo]bar=42[]");
-  auto root2 = hit::parse("TESTCASE", "foo/baz/boo=42");
-  hit::explode(root2);
-  hit::merge(root2, root1);
-  EXPECT_EQ("[foo]\n  bar = 42\n  [baz]\n    boo = 42\n  []\n[]", root1->render());
+  {
+    auto root1 = hit::parse("TESTCASE", "[foo]bar=42[]");
+    auto root2 = hit::parse("TESTCASE", "foo/baz/boo=42");
+    hit::explode(root2);
+    hit::merge(root2, root1);
+    EXPECT_EQ("[foo]\n  bar = 42\n  [baz]\n    boo = 42\n  []\n[]", root1->render());
+  }
+
+  {
+    auto root1 = hit::parse("TESTCASE", "foo/bar=baz");
+    auto root2 = hit::parse("TESTCASE", "foo/bar=42");
+    hit::merge(root2, root1);
+    auto n = root1->find("foo/bar");
+    auto f = dynamic_cast<hit::Field *>(n);
+    if (!f)
+      FAIL() << "merge case node type is not NodeType::Field";
+
+    // Make sure that the the from type overrides the into type on merge
+    else if (f->kind() != hit::Field::Kind::Int)
+      FAIL() << "merge case kind type is not overridden (string)";
+  }
 }

--- a/unit/src/MinimalApp.C
+++ b/unit/src/MinimalApp.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#include "gtest/gtest.h"
+#include "gtest_include.h"
 
 #include "AppFactory.h"
 #include "Executioner.h"


### PR DESCRIPTION
1) Merging two trees doesn't throw an error if field kinds don't match
2) Fixing unprotected raw calls to std::stod and std::stoi to verify all characters are used.

closes #10691

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
