### PR TITLE
hit: fix mis-lexed numbers before "["

### DIFF
--- a/framework/contrib/hit/lex.cc
+++ b/framework/contrib/hit/lex.cc
@@ -382,7 +382,7 @@ lexNumber(Lexer * l)
     return lexHit;
   }
 
-  if (!charIn(l->peek(), allspace) && l->peek() != '\0')
+  if (!charIn(l->peek(), allspace + "[") && l->peek() != '\0')
   {
     // fall back to string
     consumeUnquotedString(l);

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -174,6 +174,7 @@ TEST(HitTests, ParseFields)
        "hello_./:<>-+world",
        "foo",
        hit::Field::Kind::String},
+      {"left-bracket-after-number", "[hello]foo=42[]", "hello/foo", "42", hit::Field::Kind::Int},
       {"ignore leading spaces 1", "foo=    bar", "foo", "bar", hit::Field::Kind::String},
       {"ignore leading spaces 2", "foo=     \t42", "foo", "42", hit::Field::Kind::Int},
       {"ignore trailing spaces", "foo=bar\t   ", "foo", "bar", hit::Field::Kind::String},


### PR DESCRIPTION
Fixes a case where hit would incorrectly lex the string "...=42[..." as
a string-typed value instead of a number.  This would happen for any
number followed by a left bracket.

fix #10736

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
