### PR TITLE
Libmesh update

### DIFF
--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -316,6 +316,10 @@ indentMessage(const std::string & prefix, std::string & message, const char * co
  */
 std::string & removeColor(std::string & msg);
 
+std::list<std::string> listDir(const std::string path, bool files_only = false);
+
+bool pathExists(const std::string & path);
+
 /**
  * Retrieves the names of all of the files contained within the list of directories passed into the
  * routine.

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -98,8 +98,7 @@ FileMesh::buildMesh()
       // and renumbering, at least at first.
       if (file == "LATEST")
       {
-        std::list<std::string> dir_list(1, path);
-        std::list<std::string> files = MooseUtils::getFilesInDirs(dir_list);
+        std::list<std::string> files = MooseUtils::listDir(path);
 
         // Fill in the name of the LATEST file so we can open it and read it.
         _file_name = MooseUtils::getLatestMeshCheckpointFile(files);
@@ -118,7 +117,8 @@ FileMesh::buildMesh()
         getMesh().allow_renumbering(false);
       }
 
-      MooseUtils::checkFileReadable(_file_name);
+      if (!MooseUtils::pathExists(_file_name))
+        mooseError("cannot locate mesh file '", _file_name, "'");
       getMesh().read(_file_name);
 
       if (restarting)

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -152,31 +152,7 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
       std::ostringstream oss;
       oss << delete_files.checkpoint;
       std::string file_name = oss.str();
-      int ret = remove(file_name.c_str());
-      if (ret != 0)
-        mooseWarning("Error during the deletion of file '", file_name, "': ", std::strerror(ret));
-    }
-
-    if (_parallel_mesh)
-    {
-      std::ostringstream oss;
-      oss << delete_files.checkpoint << '-' << n_processors() << '-' << proc_id;
-      std::string file_name = oss.str();
-      int ret = remove(file_name.c_str());
-      if (ret != 0)
-        mooseWarning("Error during the deletion of file '", file_name, "': ", std::strerror(ret));
-    }
-    else
-    {
-      if (proc_id == 0)
-      {
-        std::ostringstream oss;
-        oss << delete_files.checkpoint << "-1-0";
-        std::string file_name = oss.str();
-        int ret = remove(file_name.c_str());
-        if (ret != 0)
-          mooseWarning("Error during the deletion of file '", file_name, "': ", std::strerror(ret));
-      }
+      CheckpointIO::cleanup(file_name, comm().size());
     }
 
     // Delete the system files (xdr and xdr.0000, ...)
@@ -189,6 +165,7 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
       if (ret != 0)
         mooseWarning("Error during the deletion of file '", file_name, "': ", std::strerror(ret));
     }
+
     {
       std::ostringstream oss;
       oss << delete_files.system << "." << std::setw(4) << std::setprecision(0) << std::setfill('0')

--- a/modules/solid_mechanics/test/tests/cracking/cracking_xyz.i
+++ b/modules/solid_mechanics/test/tests/cracking/cracking_xyz.i
@@ -283,7 +283,7 @@
   l_tol = 1e-6
 
   nl_max_its = 100
-  nl_abs_tol = 1e-8
+  nl_abs_tol = 4e-8
   #nl_rel_tol = 1e-3
   nl_rel_tol = 1e-6
 

--- a/python/TestHarness/suppressions/errors.supp
+++ b/python/TestHarness/suppressions/errors.supp
@@ -112,3 +112,11 @@
    fun:MatLUFactorNumeric_SuperLU_DIST
    ...
 }
+{
+   Super_LU_possible_leak
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:MatLUFactorNumeric_SuperLU_DIST
+   ...
+}

--- a/test/tests/checkpoint/tests
+++ b/test/tests/checkpoint/tests
@@ -5,23 +5,23 @@
     check_files =      'checkpoint_interval_out_cp/0006.xdr
                         checkpoint_interval_out_cp/0006.xdr.0000
 			checkpoint_interval_out_cp/0006.rd-0
-			checkpoint_interval_out_cp/0006_mesh.cpr
+			checkpoint_interval_out_cp/0006_mesh.cpr/1/header.cpr
     		        checkpoint_interval_out_cp/0009.xdr
                         checkpoint_interval_out_cp/0009.xdr.0000
 			checkpoint_interval_out_cp/0009.rd-0
-			checkpoint_interval_out_cp/0009_mesh.cpr'
+			checkpoint_interval_out_cp/0009_mesh.cpr/1/header.cpr'
     check_not_exists = 'checkpoint_interval_out_cp/0007.xdr
                         checkpoint_interval_out_cp/0007.xdr.0000
 			checkpoint_interval_out_cp/0007.rd-0
-			checkpoint_interval_out_cp/0007_mesh.cpr
+			checkpoint_interval_out_cp/0007_mesh.cpr/1/header.cpr
 			checkpoint_interval_out_cp/0008.xdr
                         checkpoint_interval_out_cp/0008.xdr.0000
 			checkpoint_interval_out_cp/0008.rd-0
-			checkpoint_interval_out_cp/0008_mesh.cpr
+			checkpoint_interval_out_cp/0008_mesh.cpr/1/header.cpr
     		        checkpoint_interval_out_cp/0010.xdr
                         checkpoint_interval_out_cp/0010.xdr.0000
 			checkpoint_interval_out_cp/0010.rd-0
-			checkpoint_interval_out_cp/0010_mesh.cpr'
+			checkpoint_interval_out_cp/0010_mesh.cpr/1/header.cpr'
     recover = false
     delete_output_folders = false
 

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -325,7 +325,7 @@
   [./missing_mesh_test]
     type = 'RunException'
     input = 'missing_mesh_test.i'
-    expect_err = "Unable to open file \S+"
+    expect_err = "cannot locate mesh file '\S+'"
   [../]
 
   [./missing_req_par_action_obj_test]

--- a/test/tests/outputs/checkpoint/tests
+++ b/test/tests/outputs/checkpoint/tests
@@ -5,27 +5,27 @@
     check_files =      'checkpoint_interval_out_cp/0006.xdr
                         checkpoint_interval_out_cp/0006.xdr.0000
                         checkpoint_interval_out_cp/0006.rd-0
-                        checkpoint_interval_out_cp/0006_mesh.cpr
+                        checkpoint_interval_out_cp/0006_mesh.cpr/1/header.cpr
                         checkpoint_interval_out_cp/0009.xdr
                         checkpoint_interval_out_cp/0009.xdr.0000
                         checkpoint_interval_out_cp/0009.rd-0
-                        checkpoint_interval_out_cp/0009_mesh.cpr'
+                        checkpoint_interval_out_cp/0009_mesh.cpr/1/header.cpr'
     check_not_exists = 'checkpoint_interval_out_cp/0003.xdr
                         checkpoint_interval_out_cp/0003.xdr.0000
                         checkpoint_interval_out_cp/0003.rd-0
-                        checkpoint_interval_out_cp/0003_mesh.cpr
+                        checkpoint_interval_out_cp/0003_mesh.cpr/1/header.cpr
                         checkpoint_interval_out_cp/0007.xdr
                         checkpoint_interval_out_cp/0007.xdr.0000
                         checkpoint_interval_out_cp/0007.rd-0
-                        checkpoint_interval_out_cp/0007_mesh.cpr
+                        checkpoint_interval_out_cp/0007_mesh.cpr/1/header.cpr
                         checkpoint_interval_out_cp/0008.xdr
                         checkpoint_interval_out_cp/0008.xdr.0000
                         checkpoint_interval_out_cp/0008.rd-0
-                        checkpoint_interval_out_cp/0008_mesh.cpr
+                        checkpoint_interval_out_cp/0008_mesh.cpr/1/header.cpr
                         checkpoint_interval_out_cp/0010.xdr
                         checkpoint_interval_out_cp/0010.xdr.0000
                         checkpoint_interval_out_cp/0010.rd-0
-                        checkpoint_interval_out_cp/0010_mesh.cpr'
+                        checkpoint_interval_out_cp/0010_mesh.cpr/1/header.cpr'
     recover = false
 
     # The suffixes of these files change when running in parallel or with threads


### PR DESCRIPTION
Brief summary of changes in this update:
* CouplingMatrix sparsity optimization/bugfix.
* Changes to the directory structure used to write CheckpointIO files.
* Fix memory leak introduced in PetscNonlinearSolver::solve().
* Fixes/updates to the CheckpointIO splitter app.
* Add --with-thread-model=openmp configure option.
* pthreads replaced TBB as first choice when configuring thread models.
* Short circuit pthread/openmp execution for serial runs.

Note: this is an update to a non-master libmesh hash which is in upstream. If this libmesh update ends up getting merged, libMesh/libmesh@cee543d will then also be merged into libmesh master...

Refs libMesh/libmesh#1581.
