### PR TITLE
Improve test robustness

### DIFF
--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -596,7 +596,7 @@ FeatureFloodCount::getFeatureVar(unsigned int feature_id) const
   {
     mooseAssert(local_index < _feature_sets.size(), "local_index out of bounds");
     return _feature_sets[local_index]._status != Status::INACTIVE
-               ? _feature_sets[feature_id]._var_index
+               ? _feature_sets[local_index]._var_index
                : invalid_id;
   }
 
@@ -617,7 +617,9 @@ FeatureFloodCount::doesFeatureIntersectBoundary(unsigned int feature_id) const
   if (local_index != invalid_size_t)
   {
     mooseAssert(local_index < _feature_sets.size(), "local_index out of bounds");
-    return _feature_sets[local_index]._intersects_boundary;
+    return _feature_sets[local_index]._status != Status::INACTIVE
+               ? _feature_sets[local_index]._intersects_boundary
+               : invalid_id;
   }
 
   return false;

--- a/modules/phase_field/test/tests/grain_tracker_test/tests
+++ b/modules/phase_field/test/tests/grain_tracker_test/tests
@@ -106,6 +106,9 @@
     input = 'grain_tracker_volume.i'
     csvdiff = 'grain_tracker_volume_out_grain_volumes_0000.csv grain_tracker_volume_out.csv'
     rel_err = 1.e-3
+
+    # Lots of adaptivity, slower test
+    min_parallel = 4
   [../]
 
   [./grain_tracker_volume_single]
@@ -113,6 +116,9 @@
     input = 'grain_tracker_volume_single.i'
     csvdiff = 'grain_tracker_volume_single_out_grain_volumes_0000.csv'
     rel_err = 1.e-3
+
+    # Lots of adaptivity, slower test
+    min_parallel = 4
   [../]
 
   # This test should work the same with the FeatureFloodCount object


### PR DESCRIPTION
These tests occasionally fail on Macs. I looked into it, and it appears that
the recursion is chewing up a lot of stack space with all of the adpativity that
these tests have. For some odd reason, this sometimes causes the Mac tests to just
run out of memory? Adding more procs makes these tests more stable.

refs #7816

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
