### PR TITLE
Skip heat conduction recover test in PBS mode

### DIFF
--- a/modules/heat_conduction/test/tests/recover/tests
+++ b/modules/heat_conduction/test/tests/recover/tests
@@ -4,6 +4,7 @@
     input = recover.i
     exodiff = recover_out.e
     superlu = true
+    queue_scheduler = false # This test doesn't play well with PBS
   [../]
 
   [./recover_2]


### PR DESCRIPTION
closes #10742

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
