### PR TITLE
Continue explicitly enabling OpenMP.

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -92,7 +92,7 @@ if [ -z "$go_fast" ]; then
                --enable-unique-id \
                --disable-warnings \
                --enable-unique-ptr \
-               --enable-openmp \
+               --with-thread-model=openmp \
                --disable-maintainer-mode \
                --enable-petsc-required \
                --disable-metaphysicl \


### PR DESCRIPTION
We used to pass `--enable-openmp` to the update_and_rebuild_libmesh.sh
script, but `--enable-openmp` was essentially replaced by
`--with-thread-model=openmp` in libMesh/libmesh#1579. This commit should
turn that flag back on.

Refs #10740.
