### PR TITLE
Fixed a build warning in ALM MechanicalContactConstraint

### DIFF
--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -1577,6 +1577,8 @@ MechanicalContactConstraint::computeQpOffDiagJacobian(Moose::ConstraintJacobianT
             if (pinfo->_mech_status == PenetrationInfo::MS_SLIPPING ||
                 pinfo->_mech_status == PenetrationInfo::MS_SLIPPING_FRICTION)
               return normal_comp;
+            else
+              return 0.0;
           }
           else if (_formulation == CF_PENALTY &&
                    (pinfo->_mech_status == PenetrationInfo::MS_SLIPPING ||


### PR DESCRIPTION
Fixed a warning that can cause a nested statements to fall through in CM_COULOMB with ALM. 

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->