### PR TITLE
Restore petsc jfnk options

### DIFF
--- a/framework/src/base/NonlinearSystem.C
+++ b/framework/src/base/NonlinearSystem.C
@@ -152,16 +152,7 @@ NonlinearSystem::solve()
 #ifdef LIBMESH_HAVE_PETSC
   PetscNonlinearSolver<Real> & solver =
       static_cast<PetscNonlinearSolver<Real> &>(*_transient_sys.nonlinear_solver);
-  Moose::SolveType moose_solve_type = _fe_problem.solverParams()._type;
-  if (moose_solve_type == Moose::ST_PJFNK || moose_solve_type == Moose::ST_JFNK)
-  {
-    if (moose_solve_type == Moose::ST_PJFNK)
-      solver.solve_type() = PetscNonlinearSolver<Real>::MF_OPERATOR;
-    else
-      solver.solve_type() = PetscNonlinearSolver<Real>::MF;
-
-    solver.mffd_residual_object = &_fd_residual_functor;
-  }
+  solver.mffd_residual_object = &_fd_residual_functor;
 #endif
 
   if (_time_integrator)

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -125,7 +125,12 @@ setSolverOptions(SolverParams & solver_params)
   switch (solver_params._type)
   {
     case Moose::ST_PJFNK:
+      setSinglePetscOption("-snes_mf_operator");
+      setSinglePetscOption("-mat_mffd_type", stringify(solver_params._mffd_type));
+      break;
+
     case Moose::ST_JFNK:
+      setSinglePetscOption("-snes_mf");
       setSinglePetscOption("-mat_mffd_type", stringify(solver_params._mffd_type));
       break;
 


### PR DESCRIPTION
If we restore application of these Petsc options for matrix-free solves, then we can remove a significant amount of code from libmesh's `PetscNonlinearSolver<T>::solve` routine (e.g. the code block starting [here](https://github.com/libMesh/libmesh/blob/master/src/solvers/petsc_nonlinear_solver.C#L712) for example) and still maintain our capability of supplying different residual functions for non-linear and linear solves.

Closes #10756
