### PR TITLE
Deprecation

### DIFF
--- a/docs/content/documentation/application_development/index.md
+++ b/docs/content/documentation/application_development/index.md
@@ -1,1 +1,3 @@
 [Build System](/build_system.md)
+
+[Test System](/test_system.md)

--- a/docs/content/documentation/application_development/test_system.md
+++ b/docs/content/documentation/application_development/test_system.md
@@ -1,0 +1,19 @@
+# MOOSE Test System
+
+MOOSE comes with a rich system for testing MOOSE-based applications.
+
+## Testing Philosophy
+
+The ideas behind software testing have been constantly evolving since the beginning.  When software was small and simple you could possibly prove it to be correct.  Later on human testers were employed to find flaws in software before releases.  In the late 90s and early 00s the idea of "Extreme Programming" and "Test Driven Development" really pushed for automated testing.  Lately, automated testing was utilized in Continuous Integration and Continuous Deployment systems to allow developers to constantly integrate changes while still being able to ship a working product in a timely manner.  And most recently, sites like GitHub have allowed for every change to be tested _before_ integration within "Pull Requests".
+
+Within MOOSE there are three different testing ideas:
+
+1.  The "tests": which are typically "Regression Tests" consisting of input files and known good outputs ("gold" files).
+2.  Unit tests that test the funcationality of small seperable pieces
+3.  The TestHarness: a piece of software that was written to _run_ tests and aggregate the results.
+
+MOOSE uses tests to do both continuous integration (CI) and continuous deployment (CD).  Each and every change to MOOSE is tested across multiple operating systems, in parallel, with threads, in debug, with Valgrind and several other configurations.  On average, our testing clusters are running ~5 Million tests every week as we develop the Framework and applications
+
+## TestHarness
+
+The `TestHarness` is a piece of Python software that is responsible for finding and running tests.  You can read more about it on the [TestHarness](TestHarness.md) page.

--- a/docs/content/utilities/python/TestHarness.md
+++ b/docs/content/utilities/python/TestHarness.md
@@ -1,0 +1,41 @@
+# TestHarness
+
+The TestHarness is the Python code behind the `run_tests` script in MOOSE and every MOOSE-based application.  It is responsible for finding tests and running them.  Here we'll describe how to use the `run_tests` script and how to create your own tests.
+
+The ideas behind testing are described over the in the [MOOSE Test System](test_system.md) documentation.
+
+## run_tests
+`run_tests` is a small Python script that can be found in every MOOSE-based application and in the framework itself (under `moose/test`).  The `run_tests` script will find tests and run them with your compiled binary for your app.
+
+### Basic Usage
+
+To run the tests for any application, make sure the executable is built (generally by running `make` see the [Build System](build_system.md)) and then do:
+
+```bash
+./run_tests -j 8
+```
+
+There are many options for `run_tests`, but the `-j` option shown above is by far the most widely used.  It tells the `run_tests` script how many processors to utilize on your local machine for running tests concurrently.  Put the correct number there (instead of 8).
+
+The script will then go find and run your tests and display the results
+
+
+### More Options
+
+To see more options for `run_tests` you can invoke it with `-h`.  There are many options to look through, but some of the important ones are:
+
+ * `--failed-tests`: Runs the tests that just failed.  Note: as long as you keep using the `--failed-tests` option the set of failed tests will not change.
+ * `--n-threads #`: Causes the tests to run with `#` of (OpenMP/Pthread/TBB) threads.
+ * `-p #`: Causes the tests to run with `#` MPI processes.  Useful for guaranteeing that you get the same result in parallel!
+ * `--valgrind`: Run all of the tests with the [Valgrind](http://valgrind.org) utility.  Does extensive memory checking to catch segfaults and uninitialized memory errors.
+ * `--recover`: Run all of the tests in "recovery" mode.  This runs the test halfway, stops, then attempts to "recover" it and run until the end.  This is very rigorous testing that tests whether everything in your application can work with restart/recover.
+
+## `testroot`
+
+The `testroot` file is a small configuration file that is formatted like a MOOSE input file.  It is read by the `run_tests` script.  It should be placed in the root of your application directory (i.e. right next to where the binary is).  Some things you can set in that file are:
+
+ * `app_name`: A unique, short name for your application
+ * `allow_warnings`: `true` by default, set this to `false` to make all warnings from running tests be _errors_ instead.
+ * `allow_override` and `allow_unused`: `true` by default if set to `false` then syntax errors in your test input files will be treated as errors.
+
+The one thing we do _NOT_ recommend is enforcing that the use of deprecated code should be treated like an error.  That is entirely too rigid of a requirement and impedes the normal flow of development.  Instead, developers should periodically run their tests with `--error-deprecated` to see if any of their tests are using deprecated code / parameters and then fix them up at that point.  The MOOSE team is not responsible for fixing deprecations.

--- a/docs/content/utilities/python/index.md
+++ b/docs/content/utilities/python/index.md
@@ -1,0 +1,7 @@
+# MOOSE Python Tools
+
+The MOOSE code itself is written in C++, but everything around it that supports it is written in Python.  Here we detail some of the tools/scripts developed in Python that are distributed with MOOSE.  Click on each one for further information
+
+## [TestHarness](TestHarness.md)
+
+The [TestHarness](TestHarness.md) is responsible for finding and running tests that ensure that the framework and applications continue to work correctly as we develop them.

--- a/docs/website.yml
+++ b/docs/website.yml
@@ -61,6 +61,7 @@
                 - MooseUtils: docs/content/documentation/MooseUtils/index.md
                 - Software Quality: docs/content/documentation/sqa/index.md
             - Utilites:
+                - Python Tools: docs/content/utilities/python/index.md
                 - MooseDocs: docs/content/utilities/moose_docs/index.md
                 - Developing MOOSE Apps: docs/content/utilities/development/index.md
                 - Memory Logger: docs/content/utilities/memory_logger/memory_logger.md

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -212,7 +212,8 @@ public:
   /**
    * Register a deprecated object that expires
    * @param obj_name The name of the object to register
-   * @param t_str String containing the expiration date for the object
+   * @param t_str String containing the expiration date for the object in "MM/DD/YYYY HH:MM" format.
+   * Note that the HH:MM is not optional
    *
    * Note: Params file and line are supplied by the macro
    */
@@ -234,6 +235,7 @@ public:
    * @param dep_obj - The name (type) of the object being registered (the deprecated type)
    * @param replacement_name - The name of the object replacing the deprecated object (new name)
    * @param time_str - Time at which the deprecated message prints as  an error "MM/DD/YYYY HH:MM"
+   * Note that the HH:MM is not optional
    *
    * Note: Params file and line are supplied by the macro
    */

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -159,7 +159,7 @@ mooseInfoStream(S & oss, Args &&... args)
 
 template <typename S, typename... Args>
 void
-mooseDeprecatedStream(S & oss, Args &&... args)
+mooseDeprecatedStream(S & oss, bool expired, Args &&... args)
 {
   if (Moose::_deprecated_is_error)
     mooseError("\n\nDeprecated code:\n", std::forward<Args>(args)...);
@@ -167,8 +167,8 @@ mooseDeprecatedStream(S & oss, Args &&... args)
   mooseDoOnce(std::ostringstream ss; mooseStreamAll(ss, args...);
               std::string msg = mooseMsgFmt(
                   ss.str(),
-                  "*** Warning, This code is deprecated and will be removed in future versions!",
-                  COLOR_YELLOW);
+                  "*** Warning, This code is deprecated and will be removed in future versions!\n",
+                  expired ? COLOR_RED : COLOR_YELLOW);
               oss << msg;
               ss.str("");
               if (libMesh::global_n_processors() == 1) print_trace(ss);
@@ -206,7 +206,15 @@ template <typename... Args>
 void
 mooseDeprecated(Args &&... args)
 {
-  moose::internal::mooseDeprecatedStream(Moose::out, std::forward<Args>(args)...);
+  moose::internal::mooseDeprecatedStream(Moose::out, false, std::forward<Args>(args)...);
+}
+
+/// Emit a deprecated code/feature message with the given stringified, concatenated args.
+template <typename... Args>
+void
+mooseDeprecationExpired(Args &&... args)
+{
+  moose::internal::mooseDeprecatedStream(Moose::out, true, std::forward<Args>(args)...);
 }
 
 /// Emit an informational message with the given stringified, concatenated args.

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -147,6 +147,19 @@ mooseWarningStream(S & oss, Args &&... args)
 
 template <typename S, typename... Args>
 void
+mooseUnusedStream(S & oss, Args &&... args)
+{
+  std::ostringstream ss;
+  mooseStreamAll(ss, args...);
+  std::string msg = mooseMsgFmt(ss.str(), "*** Warning ***", COLOR_YELLOW);
+  if (Moose::_throw_on_error)
+    throw std::runtime_error(msg);
+
+  oss << msg << std::flush;
+}
+
+template <typename S, typename... Args>
+void
 mooseInfoStream(S & oss, Args &&... args)
 {
   mooseDoOnce({
@@ -199,6 +212,14 @@ void
 mooseWarning(Args &&... args)
 {
   moose::internal::mooseWarningStream(Moose::out, std::forward<Args>(args)...);
+}
+
+/// Warning message used to notify the users of unused parts of their input files
+template <typename... Args>
+void
+mooseUnused(Args &&... args)
+{
+  moose::internal::mooseUnusedStream(Moose::out, std::forward<Args>(args)...);
 }
 
 /// Emit a deprecated code/feature message with the given stringified, concatenated args.

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -119,6 +119,11 @@ mooseMsgFmt(const std::string & msg, const std::string & title, const std::strin
 
 [[noreturn]] void mooseErrorRaw(std::string msg, const std::string prefix = "");
 
+/**
+ * All of the following are not meant to be called directly - they are called by the normal macros
+ * (mooseError(), etc.) down below
+ * @{
+ */
 void mooseStreamAll(std::ostringstream & ss);
 
 template <typename T, typename... Args>
@@ -188,6 +193,9 @@ mooseDeprecatedStream(S & oss, bool expired, Args &&... args)
               else libMesh::write_traceout();
               oss << ss.str() << std::endl;);
 }
+/**
+ * @}
+ */
 
 } // namespace internal
 } // namespace moose
@@ -215,6 +223,7 @@ mooseWarning(Args &&... args)
 }
 
 /// Warning message used to notify the users of unused parts of their input files
+/// Really used internally by the parser and shouldn't really be called elsewhere
 template <typename... Args>
 void
 mooseUnused(Args &&... args)

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -114,7 +114,7 @@ public:
   template <typename... Args>
   void mooseDeprecated(Args &&... args) const
   {
-    moose::internal::mooseDeprecatedStream(_console, std::forward<Args>(args)...);
+    moose::internal::mooseDeprecatedStream(_console, false, std::forward<Args>(args)...);
   }
 
   template <typename... Args>

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -133,7 +133,7 @@ Factory::deprecatedMessage(const std::string obj_name)
       msg << "Update your application using the '" << name_it->second << "' object";
 
     // Produce the error message
-    mooseError(msg.str());
+    mooseDeprecationExpired(msg.str());
   }
 
   // Expiring object
@@ -145,7 +145,7 @@ Factory::deprecatedMessage(const std::string obj_name)
 
     // Append replacement object, if it exsits
     if (name_it != _deprecated_name.end())
-      msg << "Replaced " << obj_name << " with " << name_it->second;
+      msg << "Replace " << obj_name << " with " << name_it->second;
 
     // Produce the error message
     mooseDeprecated(msg.str());

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -557,9 +557,7 @@ registerObjects(Factory & factory)
   registerKernel(Diffusion);
   registerKernel(AnisotropicDiffusion);
   registerKernel(CoupledForce);
-  registerNamedObject(BodyForce, "UserForcingFunction");
-  factory.deprecateObject("UserForcingFunction", "BodyForce");
-  registerKernel(BodyForce);
+  registerRenamedObject("UserForcingFunction", BodyForce, "04/01/2018 00:00");
   registerKernel(Reaction);
   registerKernel(MassEigenKernel);
   registerKernel(NullKernel);

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -124,11 +124,6 @@ validParams<MooseApp>()
       "Error when encountering overridden or parameters supplied multiple times");
   params.addCommandLineParam<bool>(
       "error_deprecated", "--error-deprecated", false, "Turn deprecated code messages into Errors");
-  params.addCommandLineParam<bool>(
-      "allow_deprecated",
-      "--allow-deprecated",
-      false,
-      "Can be used in conjunction with --error to turn off deprecated errors");
 
   params.addCommandLineParam<bool>(
       "distributed_mesh",
@@ -260,9 +255,6 @@ MooseApp::MooseApp(InputParameters parameters)
     _command_line = getParam<std::shared_ptr<CommandLine>>("_command_line");
   else
     mooseError("Valid CommandLine object required");
-
-  if (getParam<bool>("error_deprecated") && getParam<bool>("allow_deprecated"))
-    mooseError("Both error deprecated and allowed deprecated were set.");
 
   if (_check_input && isParamValid("recover"))
     mooseError("Cannot run --check-input with --recover. Recover files might not exist");

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -343,16 +343,8 @@ MooseApp::setupOptions()
   // Turn all warnings in MOOSE to errors (almost see next logic block)
   Moose::_warnings_are_errors = getParam<bool>("error");
 
-  /**
-   * Deprecated messages can be toggled to errors independently from everything else.
-   * Normally they are toggled with the --error flag but that behavior can
-   * be modified with the --allow-warnings.
-   */
-  if (getParam<bool>("error_deprecated") ||
-      (Moose::_warnings_are_errors && !getParam<bool>("allow_deprecated")))
-    Moose::_deprecated_is_error = true;
-  else
-    Moose::_deprecated_is_error = false;
+  // Deprecated messages can be toggled to errors independently from everything else.
+  Moose::_deprecated_is_error = getParam<bool>("error_deprecated");
 
   if (isUltimateMaster()) // makes sure coloring isn't reset incorrectly in multi-app settings
   {
@@ -582,6 +574,7 @@ MooseApp::errorCheck()
 {
   bool warn = _enable_unused_check == WARN_UNUSED;
   bool err = _enable_unused_check == ERROR_UNUSED;
+
   _parser.errorCheck(*_comm, warn, err);
 
   auto apps = _executioner->feProblem().getMultiAppWarehouse().getObjects();

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -607,7 +607,7 @@ Parser::errorCheck(const Parallel::Communicator & comm, bool warn_unused, bool e
   }
 
   if (_warnmsg.size() > 0)
-    mooseWarning(_warnmsg);
+    mooseUnused(_warnmsg);
   if (_errmsg.size() > 0)
     mooseError(_errmsg);
 }

--- a/modules/chemical_reactions/testroot
+++ b/modules/chemical_reactions/testroot
@@ -1,1 +1,2 @@
 app_name = chemical_reactions
+allow_warnings = false

--- a/modules/chemical_reactions/testroot
+++ b/modules/chemical_reactions/testroot
@@ -1,2 +1,1 @@
 app_name = chemical_reactions
-cli_args = '--error'

--- a/modules/chemical_reactions/testroot
+++ b/modules/chemical_reactions/testroot
@@ -1,2 +1,4 @@
 app_name = chemical_reactions
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/combined/testroot
+++ b/modules/combined/testroot
@@ -1,1 +1,2 @@
 app_name = combined
+allow_warnings = false

--- a/modules/combined/testroot
+++ b/modules/combined/testroot
@@ -1,2 +1,1 @@
 app_name = combined
-cli_args = '--error'

--- a/modules/combined/testroot
+++ b/modules/combined/testroot
@@ -1,2 +1,4 @@
 app_name = combined
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/contact/testroot
+++ b/modules/contact/testroot
@@ -1,1 +1,2 @@
 app_name = contact
+allow_warnings = false

--- a/modules/contact/testroot
+++ b/modules/contact/testroot
@@ -1,2 +1,1 @@
 app_name = contact
-cli_args = '--error'

--- a/modules/contact/testroot
+++ b/modules/contact/testroot
@@ -1,2 +1,4 @@
 app_name = contact
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/fluid_properties/testroot
+++ b/modules/fluid_properties/testroot
@@ -1,1 +1,2 @@
 app_name = fluid_properties
+allow_warnings = false

--- a/modules/fluid_properties/testroot
+++ b/modules/fluid_properties/testroot
@@ -1,2 +1,1 @@
 app_name = fluid_properties
-cli_args = '--error'

--- a/modules/fluid_properties/testroot
+++ b/modules/fluid_properties/testroot
@@ -1,2 +1,4 @@
 app_name = fluid_properties
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/heat_conduction/testroot
+++ b/modules/heat_conduction/testroot
@@ -1,2 +1,1 @@
 app_name = heat_conduction
-cli_args = '--error'

--- a/modules/heat_conduction/testroot
+++ b/modules/heat_conduction/testroot
@@ -1,1 +1,2 @@
 app_name = heat_conduction
+allow_warnings = false

--- a/modules/heat_conduction/testroot
+++ b/modules/heat_conduction/testroot
@@ -1,2 +1,4 @@
 app_name = heat_conduction
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/level_set/testroot
+++ b/modules/level_set/testroot
@@ -1,1 +1,2 @@
 app_name = level_set
+allow_warnings = false

--- a/modules/level_set/testroot
+++ b/modules/level_set/testroot
@@ -1,2 +1,1 @@
 app_name = level_set
-cli_args = '--error'

--- a/modules/level_set/testroot
+++ b/modules/level_set/testroot
@@ -1,2 +1,4 @@
 app_name = level_set
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/misc/testroot
+++ b/modules/misc/testroot
@@ -1,1 +1,2 @@
 app_name = misc
+allow_warnings = false

--- a/modules/misc/testroot
+++ b/modules/misc/testroot
@@ -1,2 +1,1 @@
 app_name = misc
-cli_args = '--error'

--- a/modules/misc/testroot
+++ b/modules/misc/testroot
@@ -1,2 +1,4 @@
 app_name = misc
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/navier_stokes/testroot
+++ b/modules/navier_stokes/testroot
@@ -1,2 +1,1 @@
 app_name = navier_stokes
-cli_args = '--error'

--- a/modules/navier_stokes/testroot
+++ b/modules/navier_stokes/testroot
@@ -1,1 +1,2 @@
 app_name = navier_stokes
+allow_warnings = false

--- a/modules/navier_stokes/testroot
+++ b/modules/navier_stokes/testroot
@@ -1,2 +1,4 @@
 app_name = navier_stokes
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/phase_field/src/base/PhaseFieldApp.C
+++ b/modules/phase_field/src/base/PhaseFieldApp.C
@@ -343,7 +343,7 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerKernel(CahnHilliard);
   registerKernel(CahnHilliardAniso);
   registerKernel(CHBulkPFCTrad);
-  registerDeprecatedObject(CHCpldPFCTrad);
+  registerDeprecatedObject(CHCpldPFCTrad, "08/01/2018 00:00");
   registerKernel(CHInterface);
   registerKernel(CHInterfaceAniso);
   registerKernel(CHMath);
@@ -376,9 +376,9 @@ PhaseFieldApp::registerObjects(Factory & factory)
   registerKernel(MatDiffusion);
   registerKernel(MatReaction);
   registerKernel(MultiGrainRigidBodyMotion);
-  registerDeprecatedObject(PFFracBulkRate);
+  registerDeprecatedObject(PFFracBulkRate, "08/01/2018 00:00");
   registerKernel(PFFractureBulkRate);
-  registerDeprecatedObject(PFFracCoupledInterface);
+  registerDeprecatedObject(PFFracCoupledInterface, "08/01/2018 00:00");
   registerKernel(SimpleACInterface);
   registerKernel(SimpleCHInterface);
   registerKernel(SimpleCoupledACInterface);

--- a/modules/phase_field/testroot
+++ b/modules/phase_field/testroot
@@ -1,2 +1,1 @@
 app_name = phase_field
-cli_args = '--error'

--- a/modules/phase_field/testroot
+++ b/modules/phase_field/testroot
@@ -1,1 +1,2 @@
 app_name = phase_field
+allow_warnings = false

--- a/modules/phase_field/testroot
+++ b/modules/phase_field/testroot
@@ -1,2 +1,4 @@
 app_name = phase_field
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/porous_flow/testroot
+++ b/modules/porous_flow/testroot
@@ -1,1 +1,2 @@
 app_name = porous_flow
+allow_warnings = false

--- a/modules/porous_flow/testroot
+++ b/modules/porous_flow/testroot
@@ -1,2 +1,1 @@
 app_name = porous_flow
-cli_args = '--error'

--- a/modules/porous_flow/testroot
+++ b/modules/porous_flow/testroot
@@ -1,2 +1,4 @@
 app_name = porous_flow
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/rdg/testroot
+++ b/modules/rdg/testroot
@@ -1,1 +1,2 @@
 app_name = rdg
+allow_warnings = false

--- a/modules/rdg/testroot
+++ b/modules/rdg/testroot
@@ -1,2 +1,1 @@
 app_name = rdg
-cli_args = '--error'

--- a/modules/rdg/testroot
+++ b/modules/rdg/testroot
@@ -1,2 +1,4 @@
 app_name = rdg
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/richards/testroot
+++ b/modules/richards/testroot
@@ -1,1 +1,2 @@
 app_name = richards
+allow_warnings = false

--- a/modules/richards/testroot
+++ b/modules/richards/testroot
@@ -1,2 +1,1 @@
 app_name = richards
-cli_args = '--error'

--- a/modules/richards/testroot
+++ b/modules/richards/testroot
@@ -1,2 +1,4 @@
 app_name = richards
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/solid_mechanics/testroot
+++ b/modules/solid_mechanics/testroot
@@ -1,1 +1,2 @@
 app_name = solid_mechanics
+allow_warnings = false

--- a/modules/solid_mechanics/testroot
+++ b/modules/solid_mechanics/testroot
@@ -1,2 +1,1 @@
 app_name = solid_mechanics
-cli_args = '--error'

--- a/modules/solid_mechanics/testroot
+++ b/modules/solid_mechanics/testroot
@@ -1,2 +1,4 @@
 app_name = solid_mechanics
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/stochastic_tools/testroot
+++ b/modules/stochastic_tools/testroot
@@ -1,2 +1,1 @@
 app_name = stochastic_tools
-cli_args = '--error'

--- a/modules/stochastic_tools/testroot
+++ b/modules/stochastic_tools/testroot
@@ -1,1 +1,2 @@
 app_name = stochastic_tools
+allow_warnings = false

--- a/modules/stochastic_tools/testroot
+++ b/modules/stochastic_tools/testroot
@@ -1,2 +1,4 @@
 app_name = stochastic_tools
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/tensor_mechanics/testroot
+++ b/modules/tensor_mechanics/testroot
@@ -1,1 +1,2 @@
 app_name = tensor_mechanics
+allow_warnings = false

--- a/modules/tensor_mechanics/testroot
+++ b/modules/tensor_mechanics/testroot
@@ -1,2 +1,1 @@
 app_name = tensor_mechanics
-cli_args = '--error'

--- a/modules/tensor_mechanics/testroot
+++ b/modules/tensor_mechanics/testroot
@@ -1,2 +1,4 @@
 app_name = tensor_mechanics
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/testroot
+++ b/modules/testroot
@@ -1,2 +1,2 @@
 app_name = combined/combined
-cli_args = '--color-first-directory --error'
+cli_args = '--color-first-directory'

--- a/modules/testroot
+++ b/modules/testroot
@@ -1,2 +1,3 @@
 app_name = combined/combined
 cli_args = '--color-first-directory'
+allow_warnings = false

--- a/modules/testroot
+++ b/modules/testroot
@@ -1,3 +1,5 @@
 app_name = combined/combined
 cli_args = '--color-first-directory'
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/water_steam_eos/testroot
+++ b/modules/water_steam_eos/testroot
@@ -1,1 +1,2 @@
 app_name = water_steam_eos
+allow_warnings = false

--- a/modules/water_steam_eos/testroot
+++ b/modules/water_steam_eos/testroot
@@ -1,2 +1,1 @@
 app_name = water_steam_eos
-cli_args = '--error'

--- a/modules/water_steam_eos/testroot
+++ b/modules/water_steam_eos/testroot
@@ -1,2 +1,4 @@
 app_name = water_steam_eos
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/modules/xfem/testroot
+++ b/modules/xfem/testroot
@@ -1,2 +1,1 @@
 app_name = xfem
-cli_args = '--error'

--- a/modules/xfem/testroot
+++ b/modules/xfem/testroot
@@ -1,1 +1,2 @@
 app_name = xfem
+allow_warnings = false

--- a/modules/xfem/testroot
+++ b/modules/xfem/testroot
@@ -1,2 +1,4 @@
 app_name = xfem
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/python/FactorySystem/Factory.py
+++ b/python/FactorySystem/Factory.py
@@ -60,12 +60,12 @@ class Factory:
     def printDump(self, root_node_name):
         print "[" + root_node_name + "]"
 
-        for name, object in self.objects.iteritems():
+        for name, object in sorted(self.objects.iteritems()):
             print "  [./" + name + "]"
 
             params = self.validParams(name)
 
-            for key in params.desc:
+            for key in sorted(params.desc):
                 default = ''
                 if params.isValid(key):
                     the_param = params[key]

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -39,7 +39,7 @@ class RunApp(Tester):
         params.addParam('min_threads',     1, "Min number of threads (Default: 1)")
         params.addParam('redirect_output',  False, "Redirect stdout to files. Neccessary when expecting an error when using parallel options")
 
-        params.addParam('allow_warnings',   False, "Whether or not warnings are allowed.  If this is False (the default) then a warning will be treated as an error.  Can be globally overridden by setting 'allow_warnings = True' in the testroot file.");
+        params.addParam('allow_warnings',   True, "Whether or not warnings are allowed.  If this is False then a warning will be treated as an error.  Can be globally overridden by setting 'allow_warnings = True' in the testroot file.");
         params.addParam('allow_unused',   False, "Whether or not unused parameters are allowed in the input file.  Can be globally overridden by setting 'allow_unused = True' in the testroot file.");
         params.addParam('allow_override', False, "Whether or not overriding a parameter/block in the input file generates an error.  Can be globally overridden by setting 'allow_override = True' in the testroot file.");
         params.addParam('allow_deprecated', True, "Whether or not deprecated warnings are allowed.  Setting to False will cause deprecation warnings to be treated as test failures.  We do NOT recommend you globally set this permanently to False!  Deprecations are a part of the normal development flow and _SHOULD_ be allowed!")

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -7,7 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-import re, os, time
+import re, os
 from Tester import Tester
 from TestHarness import util
 
@@ -120,9 +120,6 @@ class RunApp(Tester):
             # The user has passed the parallel-mesh option to the test harness
             # and it is NOT supplied already in the cli-args option
             cli_args.append('--distributed-mesh')
-
-
-        root_params = specs['root_params']
 
         if '--error' not in cli_args and (not specs["allow_warnings"] or options.error):
             cli_args.append('--error')

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -39,9 +39,9 @@ class RunApp(Tester):
         params.addParam('min_threads',     1, "Min number of threads (Default: 1)")
         params.addParam('redirect_output',  False, "Redirect stdout to files. Neccessary when expecting an error when using parallel options")
 
-        params.addParam('allow_warnings',   True, "Whether or not warnings are allowed.  If this is False then a warning will be treated as an error.  Can be globally overridden by setting 'allow_warnings = True' in the testroot file.");
-        params.addParam('allow_unused',   True, "Whether or not unused parameters are allowed in the input file.  Can be globally overridden by setting 'allow_unused = True' in the testroot file.");
-        params.addParam('allow_override', True, "Whether or not overriding a parameter/block in the input file generates an error.  Can be globally overridden by setting 'allow_override = True' in the testroot file.");
+        params.addParam('allow_warnings',   True, "Whether or not warnings are allowed.  If this is False then a warning will be treated as an error.  Can be globally overridden by setting 'allow_warnings = False' in the testroot file.");
+        params.addParam('allow_unused',   True, "Whether or not unused parameters are allowed in the input file.  Can be globally overridden by setting 'allow_unused = False' in the testroot file.");
+        params.addParam('allow_override', True, "Whether or not overriding a parameter/block in the input file generates an error.  Can be globally overridden by setting 'allow_override = False' in the testroot file.");
         params.addParam('allow_deprecated', True, "Whether or not deprecated warnings are allowed.  Setting to False will cause deprecation warnings to be treated as test failures.  We do NOT recommend you globally set this permanently to False!  Deprecations are a part of the normal development flow and _SHOULD_ be allowed!")
 
         # Valgrind

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -40,8 +40,8 @@ class RunApp(Tester):
         params.addParam('redirect_output',  False, "Redirect stdout to files. Neccessary when expecting an error when using parallel options")
 
         params.addParam('allow_warnings',   True, "Whether or not warnings are allowed.  If this is False then a warning will be treated as an error.  Can be globally overridden by setting 'allow_warnings = True' in the testroot file.");
-        params.addParam('allow_unused',   False, "Whether or not unused parameters are allowed in the input file.  Can be globally overridden by setting 'allow_unused = True' in the testroot file.");
-        params.addParam('allow_override', False, "Whether or not overriding a parameter/block in the input file generates an error.  Can be globally overridden by setting 'allow_override = True' in the testroot file.");
+        params.addParam('allow_unused',   True, "Whether or not unused parameters are allowed in the input file.  Can be globally overridden by setting 'allow_unused = True' in the testroot file.");
+        params.addParam('allow_override', True, "Whether or not overriding a parameter/block in the input file generates an error.  Can be globally overridden by setting 'allow_override = True' in the testroot file.");
         params.addParam('allow_deprecated', True, "Whether or not deprecated warnings are allowed.  Setting to False will cause deprecation warnings to be treated as test failures.  We do NOT recommend you globally set this permanently to False!  Deprecations are a part of the normal development flow and _SHOULD_ be allowed!")
 
         # Valgrind

--- a/python/TestHarness/tests/test_ParserErrors.py
+++ b/python/TestHarness/tests/test_ParserErrors.py
@@ -19,4 +19,3 @@ class TestHarnessTester(TestHarnessTestCase):
         # TODO: Are there more we can test?
         output = self.runExceptionTests('-i', 'parse_errors')
         self.assertIn('duplicate parameter', output)
-        self.assertIn('invalid date value', output)

--- a/python/mooseutils/__init__.py
+++ b/python/mooseutils/__init__.py
@@ -10,7 +10,7 @@
 from mooseutils import colorText, str2bool, find_moose_executable, runExe, check_configuration
 from mooseutils import touch, unique_list, gold, make_chunks, check_file_size, camel_to_space
 from message import mooseDebug, mooseWarning, mooseMessage, mooseError
-from hit_load import hit_load
+from hit_load import hit_load, HitNode, hit_parse
 from MooseException import MooseException
 try:
     from MooseYaml import MooseYaml

--- a/python/mooseutils/hit_load.py
+++ b/python/mooseutils/hit_load.py
@@ -144,10 +144,10 @@ def hit_load(filename):
 
     hit_node = hit.parse(filename, content)
     root = HitNode(hitnode=hit_node)
-    _hit_parse(root, hit_node, filename)
+    hit_parse(root, hit_node, filename)
     return root
 
-def _hit_parse(root, hit_node, filename):
+def hit_parse(root, hit_node, filename):
     """
     Parse the supplied content into a hit tree.
 
@@ -162,7 +162,7 @@ def _hit_parse(root, hit_node, filename):
     for hit_child in hit_node.children():
         if hit_child.type() == hit.NodeType.Section:
             new = HitNode(parent=root, hitnode=hit_child)
-            _hit_parse(new, hit_child, filename)
+            hit_parse(new, hit_child, filename)
 
     return root
 

--- a/python/testroot
+++ b/python/testroot
@@ -1,1 +1,2 @@
 app_name = moose_python
+allow_warnings = false

--- a/python/testroot
+++ b/python/testroot
@@ -1,2 +1,4 @@
 app_name = moose_python
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/stork/testroot
+++ b/stork/testroot
@@ -1,1 +1,2 @@
 app_name = stork
+allow_warnings = false

--- a/stork/testroot
+++ b/stork/testroot
@@ -1,2 +1,1 @@
 app_name = stork
-cli_args = '--error'

--- a/stork/testroot
+++ b/stork/testroot
@@ -1,2 +1,4 @@
 app_name = stork
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/test/include/kernels/CoefDiffusion.h
+++ b/test/include/kernels/CoefDiffusion.h
@@ -24,8 +24,8 @@ public:
   CoefDiffusion(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   const Real & _coef;
 };

--- a/test/include/kernels/DeprecatedKernel.h
+++ b/test/include/kernels/DeprecatedKernel.h
@@ -1,0 +1,33 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef DEPRECATEDKERNEL_H
+#define DEPRECATEDKERNEL_H
+
+#include "Reaction.h"
+
+// Forward Declarations
+class DeprecatedKernel;
+
+template <>
+InputParameters validParams<DeprecatedKernel>();
+
+class DeprecatedKernel : public Reaction
+{
+public:
+  DeprecatedKernel(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+
+  Real _coef;
+};
+
+#endif // DEPRECATEDKERNEL_H

--- a/test/include/kernels/DeprecatedParamKernel.h
+++ b/test/include/kernels/DeprecatedParamKernel.h
@@ -1,0 +1,33 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef DEPRECATEDPARAMKERNEL_H
+#define DEPRECATEDPARAMKERNEL_H
+
+#include "Reaction.h"
+
+// Forward Declarations
+class DeprecatedParamKernel;
+
+template <>
+InputParameters validParams<DeprecatedParamKernel>();
+
+class DeprecatedParamKernel : public Reaction
+{
+public:
+  DeprecatedParamKernel(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+
+  Real _coef;
+};
+
+#endif // DEPRECATEDPARAMKERNEL_H

--- a/test/include/kernels/DeprecatedParamKernel.h
+++ b/test/include/kernels/DeprecatedParamKernel.h
@@ -24,8 +24,8 @@ public:
   DeprecatedParamKernel(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   Real _coef;
 };

--- a/test/include/kernels/ExpiredKernel.h
+++ b/test/include/kernels/ExpiredKernel.h
@@ -1,0 +1,33 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef EXPIREDKERNEL_H
+#define EXPIREDKERNEL_H
+
+#include "Reaction.h"
+
+// Forward Declarations
+class ExpiredKernel;
+
+template <>
+InputParameters validParams<ExpiredKernel>();
+
+class ExpiredKernel : public Reaction
+{
+public:
+  ExpiredKernel(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+
+  Real _coef;
+};
+
+#endif // EXPIREDKERNEL_H

--- a/test/include/kernels/ExpiredKernel.h
+++ b/test/include/kernels/ExpiredKernel.h
@@ -24,8 +24,8 @@ public:
   ExpiredKernel(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   Real _coef;
 };

--- a/test/include/kernels/RenamedKernel.h
+++ b/test/include/kernels/RenamedKernel.h
@@ -1,0 +1,33 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef RENAMEDKERNEL_H
+#define RENAMEDKERNEL_H
+
+#include "Reaction.h"
+
+// Forward Declarations
+class RenamedKernel;
+
+template <>
+InputParameters validParams<RenamedKernel>();
+
+class RenamedKernel : public Reaction
+{
+public:
+  RenamedKernel(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+
+  Real _coef;
+};
+
+#endif // RENAMEDKERNEL_H

--- a/test/include/kernels/RenamedKernel.h
+++ b/test/include/kernels/RenamedKernel.h
@@ -24,8 +24,8 @@ public:
   RenamedKernel(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   Real _coef;
 };

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -416,7 +416,7 @@ MooseTestApp::registerObjects(Factory & factory)
 
   registerDeprecatedObject(ExpiredKernel, "01/01/2018 00:00");
   registerDeprecatedObject(DeprecatedKernel, "01/01/2050 00:00");
-  registerRenamedObject("OldName", RenamedKernel, "01/01/2050 00:00");
+  registerRenamedObject("OldNamedKernel", RenamedKernel, "01/01/2050 00:00");
 
   // Aux kernels
   registerAux(DriftDiffusionFluxAux);

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -73,6 +73,10 @@
 #include "CoupledEigenKernel.h"
 #include "ConsoleMessageKernel.h"
 #include "WrongJacobianDiffusion.h"
+#include "DeprecatedKernel.h"
+#include "ExpiredKernel.h"
+#include "RenamedKernel.h"
+
 #include "DefaultMatPropConsumerKernel.h"
 #include "DoNotCopyParametersKernel.h"
 #include "DriftDiffusionFluxAux.h"
@@ -409,6 +413,10 @@ MooseTestApp::registerObjects(Factory & factory)
   registerKernel(ExampleShapeElementKernel);
   registerKernel(ExampleShapeElementKernel2);
   registerKernel(SimpleTestShapeElementKernel);
+
+  registerDeprecatedObject(ExpiredKernel, "01/01/2018 00:00");
+  registerDeprecatedObject(DeprecatedKernel, "01/01/2050 00:00");
+  registerRenamedObject("OldName", RenamedKernel, "01/01/2050 00:00");
 
   // Aux kernels
   registerAux(DriftDiffusionFluxAux);

--- a/test/src/kernels/DeprecatedKernel.C
+++ b/test/src/kernels/DeprecatedKernel.C
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "DeprecatedKernel.h"
+
+template <>
+InputParameters
+validParams<DeprecatedKernel>()
+{
+  InputParameters params = validParams<Reaction>();
+  params.addParam<Real>("coefficient", 1.0, "Coefficient of the term");
+  return params;
+}
+
+DeprecatedKernel::DeprecatedKernel(const InputParameters & parameters)
+  : Reaction(parameters), _coef(getParam<Real>("coefficient"))
+{
+}
+
+Real
+DeprecatedKernel::computeQpResidual()
+{
+  return _coef * Reaction::computeQpResidual();
+}
+
+Real
+DeprecatedKernel::computeQpJacobian()
+{
+  return _coef * Reaction::computeQpJacobian();
+}

--- a/test/src/kernels/DeprecatedParamKernel.C
+++ b/test/src/kernels/DeprecatedParamKernel.C
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "DeprecatedParamKernel.h"
+
+template <>
+InputParameters
+validParams<DeprecatedParamKernel>()
+{
+  InputParameters params = validParams<Reaction>();
+  params.addParam<Real>("coefficient", 1.0, "Coefficient of the term");
+  return params;
+}
+
+DeprecatedParamKernel::DeprecatedParamKernel(const InputParameters & parameters)
+  : Reaction(parameters), _coef(getParam<Real>("coefficient"))
+{
+}
+
+Real
+DeprecatedParamKernel::computeQpResidual()
+{
+  return _coef * Reaction::computeQpResidual();
+}
+
+Real
+DeprecatedParamKernel::computeQpJacobian()
+{
+  return _coef * Reaction::computeQpJacobian();
+}

--- a/test/src/kernels/ExpiredKernel.C
+++ b/test/src/kernels/ExpiredKernel.C
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ExpiredKernel.h"
+
+template <>
+InputParameters
+validParams<ExpiredKernel>()
+{
+  InputParameters params = validParams<Reaction>();
+  params.addParam<Real>("coefficient", 1.0, "Coefficient of the term");
+  return params;
+}
+
+ExpiredKernel::ExpiredKernel(const InputParameters & parameters)
+  : Reaction(parameters), _coef(getParam<Real>("coefficient"))
+{
+}
+
+Real
+ExpiredKernel::computeQpResidual()
+{
+  return _coef * Reaction::computeQpResidual();
+}
+
+Real
+ExpiredKernel::computeQpJacobian()
+{
+  return _coef * Reaction::computeQpJacobian();
+}

--- a/test/src/kernels/RenamedKernel.C
+++ b/test/src/kernels/RenamedKernel.C
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "RenamedKernel.h"
+
+template <>
+InputParameters
+validParams<RenamedKernel>()
+{
+  InputParameters params = validParams<Reaction>();
+  params.addParam<Real>("coefficient", 1.0, "Coefficient of the term");
+  return params;
+}
+
+RenamedKernel::RenamedKernel(const InputParameters & parameters)
+  : Reaction(parameters), _coef(getParam<Real>("coefficient"))
+{
+}
+
+Real
+RenamedKernel::computeQpResidual()
+{
+  return _coef * Reaction::computeQpResidual();
+}
+
+Real
+RenamedKernel::computeQpJacobian()
+{
+  return _coef * Reaction::computeQpJacobian();
+}

--- a/test/testroot
+++ b/test/testroot
@@ -1,1 +1,2 @@
 app_name = moose_test
+allow_warnings = false

--- a/test/testroot
+++ b/test/testroot
@@ -1,2 +1,1 @@
 app_name = moose_test
-cli_args = '--error'

--- a/test/testroot
+++ b/test/testroot
@@ -1,2 +1,4 @@
 app_name = moose_test
 allow_warnings = false
+allow_unused = false
+allow_override = false

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -95,14 +95,14 @@
     type = 'RunException'
     input = 'deprecated_param_test.i'
     expect_err = "The parameter \w+ is deprecated."
-    cli_args = '--error Kernels/nan/deprecated_default=1'
+    cli_args = 'Kernels/nan/deprecated_default=1'
   [../]
 
   [./deprecated_param_no_default]
     type = 'RunException'
     input = 'deprecated_param_test.i'
     expect_err = "The parameter \w+ is deprecated."
-    cli_args = '--error Kernels/nan/deprecated_no_default=1'
+    cli_args = 'Kernels/nan/deprecated_no_default=1'
   [../]
 
   [./double_restrict_uo_test]
@@ -432,8 +432,7 @@
     type = 'RunApp'
     expect_out = "unused parameter 'Mesh/unused_param'"
     input = 'unused_param_test.i'
-    cli_args = '--warn-unused'
-    allow_warnings = true
+    allow_unused = true
     max_parallel = 1 # warning can mix on multiple processes
   [../]
 
@@ -441,8 +440,8 @@
     type = 'RunApp'
     expect_out = "unused parameter 'Executioner/unused_param'"
     input = 'unused_param_test.i'
-    cli_args = '--warn-unused Executioner/unused_param=true'
-    allow_warnings = true
+    cli_args = 'Executioner/unused_param=true'
+    allow_unused = true
     max_parallel = 1 # warning can mix on multiple processes
   [../]
 

--- a/test/tests/misc/deprecation/deprecation.i
+++ b/test/tests/misc/deprecation/deprecation.i
@@ -1,0 +1,44 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/misc/deprecation/deprecation.i
+++ b/test/tests/misc/deprecation/deprecation.i
@@ -38,7 +38,3 @@
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
 []
-
-[Outputs]
-  exodus = true
-[]

--- a/test/tests/misc/deprecation/tests
+++ b/test/tests/misc/deprecation/tests
@@ -1,0 +1,27 @@
+[Tests]
+  [./deprecated]
+    type = 'RunApp'
+    input = 'deprecation.i'
+    cli_args = 'Kernels/diff/type=DeprecatedKernel'
+    expect_out = 'Deprecated Object: DeprecatedKernel'
+  [../]
+  [./expired]
+    type = 'RunApp'
+    input = 'deprecation.i'
+    cli_args = 'Kernels/diff/type=ExpiredKernel'
+    expect_out = 'Expired on Mon Jan'
+  [../]
+  [./expired_error]
+    type = 'RunException'
+    input = 'deprecation.i'
+    cli_args = 'Kernels/diff/type=ExpiredKernel'
+    expect_err = 'ERROR.*Expired on Mon Jan'
+    allow_deprecated = False
+  [../]
+  [./renamed]
+    type = 'RunApp'
+    input = 'deprecation.i'
+    cli_args = 'Kernels/diff/type=OldNamedKernel'
+    expect_out = 'Replace OldNamedKernel with RenamedKernel'
+  [../]
+[]

--- a/test/tests/multiapps/picard_catch_up/sub.i
+++ b/test/tests/multiapps/picard_catch_up/sub.i
@@ -43,7 +43,6 @@
     type = FunctionDirichletBC
     variable = v
     boundary = right
-    value = 0
     function = 't + 1'
   [../]
 []

--- a/test/tests/multiapps/picard_catch_up_keep_solution/sub.i
+++ b/test/tests/multiapps/picard_catch_up_keep_solution/sub.i
@@ -38,7 +38,6 @@
     type = FunctionDirichletBC
     variable = v
     boundary = right
-    value = 0
     function = 't + 1'
   [../]
 []

--- a/test/tests/test_harness/parse_errors
+++ b/test/tests/test_harness/parse_errors
@@ -4,6 +4,5 @@
     input = good.i
     check_input = true
     check_input = true
-    allow_deprecated_until = 13/32/2000
   [../]
 []

--- a/tutorials/darcy_thermo_mech/step01_diffusion/testroot
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/testroot
@@ -1,1 +1,2 @@
 app_name = darcy_thermo_mech
+allow_warnings = false

--- a/tutorials/darcy_thermo_mech/step01_diffusion/testroot
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/testroot
@@ -1,2 +1,4 @@
 app_name = darcy_thermo_mech
 allow_warnings = false
+allow_unused = false
+allow_override = false


### PR DESCRIPTION
Everything on this PR is here to make it easier to deprecate things.

The idea is that deprecation should never be an error unless _explicitly_ asked to be (so that you can manually check for deprecation).  Further, the testing systems should not default to errors for deprecations... that is simply too rigid... and doesn't allow development to unfold naturally.

After this PR tests that use deprecated code will no longer fail.  It will be up to each application to remove deprecated code from their input files regularly.  The MOOSE team will no longer go fix applications.

In addition, this PR adds back in the idea that deprecations will sunset at a particular date.  Once they do the deprecation message will turn _red_... but it will NOT be an error.  Anytime after the sunset date that code can be removed from MOOSE by the MOOSE developers and we are _NOT_ going to fix it in downstream applications.  We will provide very long sunset dates as we can.

Note: This PR is not _quite_ ready to go.  I want to write some documentation for it and I'm sure it's going to fail plenty of module tests and application tests until I update them (yes, ironic!).  I'm putting this here because the code in MOOSE is mostly finished at this point so we can start the discussion...

refs #10745 
