### PR TITLE
Don't symbolic link the MooseRevision if it already exists.

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -194,7 +194,9 @@ moose_revision:
 	@echo Regenerating MooseRevision
 	$(shell $(FRAMEWORK_DIR)/scripts/get_repo_revision.py $(FRAMEWORK_DIR) \
 	  $(moose_revision_header) MOOSE)
-	@ln -sf $(moose_revision_header) $(moose_all_header_dir)
+	@if [ ! -e "$(moose_all_header_dir)/MooseRevision.h" ]; then \
+		ln -sf $(moose_revision_header) $(moose_all_header_dir); \
+	fi
 
 # libmesh submodule status
 libmesh_status := $(shell git -C $(MOOSE_DIR) submodule status 2>/dev/null | grep libmesh | cut -c1)


### PR DESCRIPTION
When building examples, it sporadically fails due to a race condition where multiple processes
are doing the `ln -sf`, one of which gets a "File exists" error, and causes a non zero exit status.

Not sure if this is the best solution, it only tries to create the link if it doesn't exist. There is still potentially a race condition if the framework hasn't been built yet (so MooseRevision.h doesn't exist). In the common case where framework is already built, it will prevent the problem.

closes #10617

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
