### PR TITLE
Remove compile warnings with clang and boost

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -70,7 +70,7 @@ unity_files::
 pcre%.$(obj-suffix) : pcre%.cc
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
-          $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
+          $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 %.$(obj-suffix) : %.cc
 	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
@@ -114,7 +114,7 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 pcre%.$(obj-suffix) : pcre%.c
 	@echo "MOOSE Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
-          $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
+          $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 %.$(obj-suffix) : %.c
 	@echo "MOOSE Compiling C (in "$(METHOD)" mode) "$<"..."

--- a/modules/stochastic_tools/include/distributions/BoostDistribution.h
+++ b/modules/stochastic_tools/include/distributions/BoostDistribution.h
@@ -13,7 +13,9 @@
 #include "Distribution.h"
 
 #ifdef LIBMESH_HAVE_EXTERNAL_BOOST
+#include "libmesh/ignore_warnings.h"
 #include <boost/math/distributions.hpp>
+#include "libmesh/restore_warnings.h"
 #else
 class BoostDistributionDummy
 {


### PR DESCRIPTION
Gets rid of a pcre compile warning with clang and a bunch
of boost warnings.

refs #10733

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
