### PR TITLE
Restrict ShapeElementUserObject tests to run single-threaded.

### DIFF
--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -4,6 +4,7 @@
     input = 'shape_element_user_object.i'
     recover = false
     allow_warnings = true
+    max_threads = 1
   [../]
 
   [./simple_shape_element_uo]
@@ -14,6 +15,7 @@
     difference_tol = 1E10
     recover = false
     allow_warnings = true
+    max_threads = 1
   [../]
 
   [./jacobian_test1]
@@ -24,6 +26,7 @@
     difference_tol = 1E10
     recover = false
     allow_warnings = true
+    max_threads = 1
   [../]
 
   [./jacobian_test2]
@@ -34,6 +37,7 @@
     difference_tol = 1E10
     recover = false
     allow_warnings = true
+    max_threads = 1
   [../]
 
   [./shape_side_uo_jac_test]
@@ -54,5 +58,6 @@
     exodiff = 'shape_side_uo_physics_test_out.e'
     allow_warnings = true
     recover = false
+    max_threads = 1
   [../]
 []


### PR DESCRIPTION
This issue was uncovered when we switched the default thread model to
pthreads/openmp (https://www.moosebuild.org/job/156256). We conjecture
that the problem may have been masked by TBB's dynamic scheduling
algorithms in the past, and that the object in question is simply not
thread safe in general.

Refs #8352, #10772.

Hopefully this will MMGA (make master green again).
