### PR TITLE
Python DupWalker only errors for duplicate parameters

### DIFF
--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -72,7 +72,7 @@ class Parser:
         self.root = root
 
         w = DupWalker(os.path.abspath(filename))
-        root.walk(w, hit.NodeType.All)
+        root.walk(w, hit.NodeType.Field)
         self.errors.extend(w.errors)
 
         self._parseNode(filename, root)

--- a/python/peacock/Input/InputFile.py
+++ b/python/peacock/Input/InputFile.py
@@ -77,7 +77,7 @@ class InputFile(object):
             root = hit.parse(os.path.abspath(filename), data)
             hit.explode(root)
             w = DupWalker(os.path.abspath(filename))
-            root.walk(w, hit.NodeType.All)
+            root.walk(w, hit.NodeType.Field)
             if w.errors:
                 for err in w.errors:
                     mooseutils.mooseWarning(err)


### PR DESCRIPTION
It was warning for duplicate section names
which is allowed.

This allows loading the input file from the user on the mailing list (see #10783).

closes #10783

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
