### PR TITLE
Get rid of trailing dot in NaN or Inf

### DIFF
--- a/test/tests/misc/jacobian/inf_nan.i
+++ b/test/tests/misc/jacobian/inf_nan.i
@@ -1,0 +1,23 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./td]
+    type = NanKernel
+    variable = u
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+  petsc_options_iname = '-snes_type'
+  petsc_options_value = ' test'
+[]

--- a/test/tests/misc/jacobian/tests
+++ b/test/tests/misc/jacobian/tests
@@ -41,4 +41,13 @@
     cli_args = 'Kernels/diff/use_displaced_mesh=true Executioner/dt=0.8'
     expect_err = 'ERROR: negative Jacobian -0.0625 at point \(x,y,z\)=\(-0.105662, 0.211325, 0.211325\) in element 0'
   [../]
+
+  [./inf_nan]
+    type = PetscJacobianTester
+    input = 'inf_nan.i'
+    recover = false
+    ratio_tol = nan
+    difference_tol = nan
+    cli_args = '--no-trap-fpe'
+  [../]
 []

--- a/test/tests/time_steppers/zero_dt/test.i
+++ b/test/tests/time_steppers/zero_dt/test.i
@@ -1,0 +1,21 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./td]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 0
+[]

--- a/test/tests/time_steppers/zero_dt/tests
+++ b/test/tests/time_steppers/zero_dt/tests
@@ -1,0 +1,8 @@
+[Tests]
+  [./test]
+  type = 'RunException'
+    input = 'test.i'
+    expect_err = "Time stepper computed zero time step size on initial which is not allowed."
+    recover = false
+  [../]
+[]


### PR DESCRIPTION
PETSc reports back `nan.` and `inf.` during the FD Jacobian process.
This confuses the Python float conversion and then the test harness
throws an error.

Closes #10788

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
