### PR TITLE
Output variable residuals on non-linear as intended

### DIFF
--- a/framework/src/outputs/VariableResidualNormsDebugOutput.C
+++ b/framework/src/outputs/VariableResidualNormsDebugOutput.C
@@ -23,7 +23,8 @@ validParams<VariableResidualNormsDebugOutput>()
   InputParameters params = validParams<PetscOutput>();
 
   // By default this outputs on every nonlinear iteration
-  params.set<ExecFlagEnum>("execute_on", true) = EXEC_NONLINEAR;
+  params.set<ExecFlagEnum>("execute_on") = EXEC_NONLINEAR;
+  params.suppressParameter<ExecFlagEnum>("execute_on");
   return params;
 }
 

--- a/test/tests/outputs/debug/tests
+++ b/test/tests/outputs/debug/tests
@@ -3,14 +3,14 @@
     # Use the debug block to print variable residual norms
     type = 'RunApp'
     input = 'show_var_residual_norms.i'
-    expect_out = "\|residual\|_2 of individual variables:"
+    expect_out = "\|residual\|_2 of individual variables:.*\|residual\|_2 of individual variables:.*\|residual\|_2 of individual variables:"
   [../]
 
   [./show_var_residual_norms_debug]
     # Use the debug block to print variable residual norms
     type = 'RunApp'
     input = 'show_var_residual_norms_debug.i'
-    expect_out = "\|residual\|_2 of individual variables:"
+    expect_out = "\|residual\|_2 of individual variables:.*\|residual\|_2 of individual variables:.*\|residual\|_2 of individual variables:"
   [../]
 
   [./show_material_props]


### PR DESCRIPTION
Set parameter in the `validParams` method is not honored.

Closes #10792