### PR TITLE
coupledDot fixes

### DIFF
--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -368,7 +368,7 @@ protected:
   MooseVariable * getVar(const std::string & var_name, unsigned int comp);
 
   /**
-   * Checks to make sure that the current Executioner has set "_it_transient" when old/older values
+   * Checks to make sure that the current Executioner has set "_is_transient" when old/older values
    * are coupled in.
    * @param name the name of the variable
    */

--- a/framework/include/base/Coupleable.h
+++ b/framework/include/base/Coupleable.h
@@ -371,8 +371,9 @@ protected:
    * Checks to make sure that the current Executioner has set "_is_transient" when old/older values
    * are coupled in.
    * @param name the name of the variable
+   * @param fn_name The name of the function that called this method - used in the error message
    */
-  void validateExecutionerType(const std::string & name) const;
+  void validateExecutionerType(const std::string & name, const std::string & fn_name) const;
 
   /// Whether or not this object is a "neighbor" object: ie all of it's coupled values should be neighbor values
   bool _coupleable_neighbor;

--- a/framework/include/base/ScalarCoupleable.h
+++ b/framework/include/base/ScalarCoupleable.h
@@ -182,6 +182,13 @@ protected:
    */
   MooseVariableScalar * getScalarVar(const std::string & var_name, unsigned int comp);
 
+  /**
+   * Checks to make sure that the current Executioner has set "_is_transient" when old/older values
+   * are coupled in.
+   * @param name the name of the variable
+   */
+  void validateExecutionerType(const std::string & name) const;
+
 private:
   /// Field variables coupled into this object (for error checking)
   std::map<std::string, std::vector<MooseVariable *>> _sc_coupled_vars;

--- a/framework/include/base/ScalarCoupleable.h
+++ b/framework/include/base/ScalarCoupleable.h
@@ -186,8 +186,9 @@ protected:
    * Checks to make sure that the current Executioner has set "_is_transient" when old/older values
    * are coupled in.
    * @param name the name of the variable
+   * @param fn_name The name of the function that called this method - used in the error message
    */
-  void validateExecutionerType(const std::string & name) const;
+  void validateExecutionerType(const std::string & name, const std::string & fn_name) const;
 
 private:
   /// Field variables coupled into this object (for error checking)

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -222,7 +222,7 @@ Coupleable::coupledValueOld(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name))
     return *getDefaultValue(var_name);
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledValueOld");
   coupledCallback(var_name, true);
   MooseVariable * var = getVar(var_name, comp);
 
@@ -249,7 +249,7 @@ Coupleable::coupledValueOlder(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name))
     return *getDefaultValue(var_name);
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledValueOlder");
   coupledCallback(var_name, true);
   MooseVariable * var = getVar(var_name, comp);
 
@@ -323,7 +323,7 @@ Coupleable::coupledDot(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledDot");
   MooseVariable * var = getVar(var_name, comp);
 
   if (!_coupleable_neighbor)
@@ -349,7 +349,7 @@ Coupleable::coupledDotDu(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledDotDu");
   MooseVariable * var = getVar(var_name, comp);
 
   if (!_coupleable_neighbor)
@@ -398,7 +398,7 @@ Coupleable::coupledGradientOld(const std::string & var_name, unsigned int comp)
   if (_c_nodal)
     mooseError(_c_name, ": Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledGradientOld");
   MooseVariable * var = getVar(var_name, comp);
 
   if (!_coupleable_neighbor)
@@ -418,7 +418,7 @@ Coupleable::coupledGradientOlder(const std::string & var_name, unsigned int comp
   if (_c_nodal)
     mooseError(_c_name, ": Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledGradientOlder");
   MooseVariable * var = getVar(var_name, comp);
 
   if (_c_is_implicit)
@@ -482,7 +482,7 @@ Coupleable::coupledSecondOld(const std::string & var_name, unsigned int comp)
   if (_c_nodal)
     mooseError(_c_name, ": Nodal variables do not have second derivatives");
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledSecondOld");
   MooseVariable * var = getVar(var_name, comp);
   if (!_coupleable_neighbor)
     return (_c_is_implicit) ? var->secondSlnOld() : var->secondSlnOlder();
@@ -501,7 +501,7 @@ Coupleable::coupledSecondOlder(const std::string & var_name, unsigned int comp)
   if (_c_nodal)
     mooseError(_c_name, ": Nodal variables do not have second derivatives");
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledSecondOlder");
   MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
   {
@@ -556,7 +556,7 @@ Coupleable::coupledNodalValueOld(const std::string & var_name, unsigned int comp
   if (!isCoupled(var_name))
     return *getDefaultValue(var_name);
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledNodalValueOld");
   coupledCallback(var_name, true);
   MooseVariable * var = getVar(var_name, comp);
 
@@ -573,7 +573,7 @@ Coupleable::coupledNodalValueOlder(const std::string & var_name, unsigned int co
   if (!isCoupled(var_name))
     return *getDefaultValue(var_name);
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledNodalValueOlder");
   coupledCallback(var_name, true);
   MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
@@ -611,7 +611,7 @@ Coupleable::coupledNodalDot(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledNodalDot");
   coupledCallback(var_name, false);
   MooseVariable * var = getVar(var_name, comp);
 
@@ -652,7 +652,7 @@ Coupleable::coupledSolutionDoFsOld(const std::string & var_name, unsigned int co
   if (_c_nodal)
     mooseError(_c_name, ": nodal objects should not call coupledSolutionDoFsOld");
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledSolutionDoFsOld");
   coupledCallback(var_name, true);
   MooseVariable * var = getVar(var_name, comp);
 
@@ -673,7 +673,7 @@ Coupleable::coupledSolutionDoFsOlder(const std::string & var_name, unsigned int 
   if (_c_nodal)
     mooseError(_c_name, ": nodal objects should not call coupledSolutionDoFsOlder");
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledSolutionDoFsOlder");
   coupledCallback(var_name, true);
   MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
@@ -688,11 +688,14 @@ Coupleable::coupledSolutionDoFsOlder(const std::string & var_name, unsigned int 
 }
 
 void
-Coupleable::validateExecutionerType(const std::string & name) const
+Coupleable::validateExecutionerType(const std::string & name, const std::string & fn_name) const
 {
   if (!_c_fe_problem.isTransient())
     mooseError(_c_name,
-               ": You may not couple in old, older or time derivative values of \"",
+               ": Calling '",
+               fn_name,
+               "' on variable \"",
                name,
-               "\" when using a \"Steady\" executioner.");
+               "\" when using a \"Steady\" executioner is not allowed. This value is available "
+               "only in transient simulations.");
 }

--- a/framework/src/base/Coupleable.C
+++ b/framework/src/base/Coupleable.C
@@ -323,6 +323,7 @@ Coupleable::coupledDot(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
+  validateExecutionerType(var_name);
   MooseVariable * var = getVar(var_name, comp);
 
   if (!_coupleable_neighbor)
@@ -348,6 +349,7 @@ Coupleable::coupledDotDu(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
+  validateExecutionerType(var_name);
   MooseVariable * var = getVar(var_name, comp);
 
   if (!_coupleable_neighbor)
@@ -609,6 +611,7 @@ Coupleable::coupledNodalDot(const std::string & var_name, unsigned int comp)
   if (!isCoupled(var_name)) // Return default 0
     return _default_value_zero;
 
+  validateExecutionerType(var_name);
   coupledCallback(var_name, false);
   MooseVariable * var = getVar(var_name, comp);
 
@@ -689,7 +692,7 @@ Coupleable::validateExecutionerType(const std::string & name) const
 {
   if (!_c_fe_problem.isTransient())
     mooseError(_c_name,
-               ": You may not couple in old or older values of \"",
+               ": You may not couple in old, older or time derivative values of \"",
                name,
                "\" when using a \"Steady\" executioner.");
 }

--- a/framework/src/base/NeighborCoupleable.C
+++ b/framework/src/base/NeighborCoupleable.C
@@ -37,7 +37,7 @@ NeighborCoupleable::coupledNeighborValue(const std::string & var_name, unsigned 
 const VariableValue &
 NeighborCoupleable::coupledNeighborValueOld(const std::string & var_name, unsigned int comp)
 {
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledNeighborValueOld");
 
   MooseVariable * var = getVar(var_name, comp);
   if (_neighbor_nodal)
@@ -49,7 +49,7 @@ NeighborCoupleable::coupledNeighborValueOld(const std::string & var_name, unsign
 const VariableValue &
 NeighborCoupleable::coupledNeighborValueOlder(const std::string & var_name, unsigned int comp)
 {
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledNeighborValueOlder");
 
   MooseVariable * var = getVar(var_name, comp);
   if (_neighbor_nodal)
@@ -84,7 +84,7 @@ NeighborCoupleable::coupledNeighborGradientOld(const std::string & var_name, uns
   if (_neighbor_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledNeighborGradientOld");
   MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->gradSlnOldNeighbor() : var->gradSlnOlderNeighbor();
 }
@@ -95,7 +95,7 @@ NeighborCoupleable::coupledNeighborGradientOlder(const std::string & var_name, u
   if (_neighbor_nodal)
     mooseError("Nodal variables do not have gradients");
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledNeighborGradientOlder");
   MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
     return var->gradSlnOlderNeighbor();
@@ -129,6 +129,7 @@ NeighborCoupleable::coupledNeighborSolutionDoFsOld(const std::string & var_name,
   if (_neighbor_nodal)
     mooseError("nodal objects should not call coupledSolutionDoFsOld");
 
+  validateExecutionerType(var_name, "coupledNeighborSolutionDoFsOld");
   MooseVariable * var = getVar(var_name, comp);
   return (_c_is_implicit) ? var->solutionDoFsOldNeighbor() : var->solutionDoFsOlderNeighbor();
 }
@@ -140,6 +141,7 @@ NeighborCoupleable::coupledNeighborSolutionDoFsOlder(const std::string & var_nam
   if (_neighbor_nodal)
     mooseError("nodal objects should not call coupledSolutionDoFsOlder");
 
+  validateExecutionerType(var_name, "coupledNeighborSolutionDoFsOlder");
   MooseVariable * var = getVar(var_name, comp);
   if (_c_is_implicit)
     return var->solutionDoFsOlderNeighbor();

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -147,6 +147,7 @@ ScalarCoupleable::coupledScalarValueOld(const std::string & var_name, unsigned i
   if (!isCoupledScalar(var_name, comp))
     return *getDefaultValue(var_name);
 
+  validateExecutionerType(var_name);
   MooseVariableScalar * var = getScalarVar(var_name, comp);
   return (_sc_is_implicit) ? var->slnOld() : var->slnOlder();
 }
@@ -158,6 +159,7 @@ ScalarCoupleable::coupledScalarValueOlder(const std::string & var_name, unsigned
   if (!isCoupledScalar(var_name, comp))
     return *getDefaultValue(var_name);
 
+  validateExecutionerType(var_name);
   MooseVariableScalar * var = getScalarVar(var_name, comp);
   if (_sc_is_implicit)
     return var->slnOlder();
@@ -169,6 +171,7 @@ VariableValue &
 ScalarCoupleable::coupledScalarDot(const std::string & var_name, unsigned int comp)
 {
   checkVar(var_name);
+  validateExecutionerType(var_name);
   MooseVariableScalar * var = getScalarVar(var_name, comp);
   return var->uDot();
 }
@@ -177,6 +180,7 @@ VariableValue &
 ScalarCoupleable::coupledScalarDotDu(const std::string & var_name, unsigned int comp)
 {
   checkVar(var_name);
+  validateExecutionerType(var_name);
   MooseVariableScalar * var = getScalarVar(var_name, comp);
   return var->duDotDu();
 }
@@ -212,6 +216,16 @@ ScalarCoupleable::getScalarVar(const std::string & var_name, unsigned int comp)
   }
   else
     mooseError(_sc_name, "Trying to get a non-existent variable '", var_name, "'");
+}
+
+void
+ScalarCoupleable::validateExecutionerType(const std::string & name) const
+{
+  if (!_sc_fe_problem.isTransient())
+    mooseError(_sc_name,
+               ": You may not couple in old, older or time derivative values of \"",
+               name,
+               "\" when using a \"Steady\" executioner.");
 }
 
 unsigned int

--- a/framework/src/base/ScalarCoupleable.C
+++ b/framework/src/base/ScalarCoupleable.C
@@ -147,7 +147,7 @@ ScalarCoupleable::coupledScalarValueOld(const std::string & var_name, unsigned i
   if (!isCoupledScalar(var_name, comp))
     return *getDefaultValue(var_name);
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledScalarValueOld");
   MooseVariableScalar * var = getScalarVar(var_name, comp);
   return (_sc_is_implicit) ? var->slnOld() : var->slnOlder();
 }
@@ -159,7 +159,7 @@ ScalarCoupleable::coupledScalarValueOlder(const std::string & var_name, unsigned
   if (!isCoupledScalar(var_name, comp))
     return *getDefaultValue(var_name);
 
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledScalarValueOlder");
   MooseVariableScalar * var = getScalarVar(var_name, comp);
   if (_sc_is_implicit)
     return var->slnOlder();
@@ -171,7 +171,7 @@ VariableValue &
 ScalarCoupleable::coupledScalarDot(const std::string & var_name, unsigned int comp)
 {
   checkVar(var_name);
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledScalarDot");
   MooseVariableScalar * var = getScalarVar(var_name, comp);
   return var->uDot();
 }
@@ -180,7 +180,7 @@ VariableValue &
 ScalarCoupleable::coupledScalarDotDu(const std::string & var_name, unsigned int comp)
 {
   checkVar(var_name);
-  validateExecutionerType(var_name);
+  validateExecutionerType(var_name, "coupledScalarDotDu");
   MooseVariableScalar * var = getScalarVar(var_name, comp);
   return var->duDotDu();
 }
@@ -219,13 +219,17 @@ ScalarCoupleable::getScalarVar(const std::string & var_name, unsigned int comp)
 }
 
 void
-ScalarCoupleable::validateExecutionerType(const std::string & name) const
+ScalarCoupleable::validateExecutionerType(const std::string & name,
+                                          const std::string & fn_name) const
 {
   if (!_sc_fe_problem.isTransient())
     mooseError(_sc_name,
-               ": You may not couple in old, older or time derivative values of \"",
+               ": Calling '",
+               fn_name,
+               "' on variable \"",
                name,
-               "\" when using a \"Steady\" executioner.");
+               "\" when using a \"Steady\" executioner is not allowed. This value is available "
+               "only in transient simulations.");
 }
 
 unsigned int

--- a/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
@@ -24,7 +24,7 @@ ElementIntegralVariablePostprocessor::ElementIntegralVariablePostprocessor(
     MooseVariableInterface(this, false),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable")),
-    _u_dot(coupledDot("variable"))
+    _u_dot(_is_transient ? coupledDot("variable") : _zero)
 {
   addMooseVariableDependency(mooseVariable());
 }

--- a/framework/src/postprocessors/ElementVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementVariablePostprocessor.C
@@ -29,7 +29,7 @@ ElementVariablePostprocessor::ElementVariablePostprocessor(const InputParameters
     MooseVariableInterface(this, false),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable")),
-    _u_dot(coupledDot("variable")),
+    _u_dot(_is_transient ? coupledDot("variable") : _zero),
     _qp(0)
 {
   addMooseVariableDependency(mooseVariable());

--- a/modules/navier_stokes/src/kernels/INSBase.C
+++ b/modules/navier_stokes/src/kernels/INSBase.C
@@ -64,14 +64,14 @@ INSBase::INSBase(const InputParameters & parameters)
     _second_w_vel(coupledSecond("w")),
 
     // time derivatives
-    _u_vel_dot(coupledDot("u")),
-    _v_vel_dot(coupledDot("v")),
-    _w_vel_dot(coupledDot("w")),
+    _u_vel_dot(_is_transient ? coupledDot("u") : _zero),
+    _v_vel_dot(_is_transient ? coupledDot("v") : _zero),
+    _w_vel_dot(_is_transient ? coupledDot("w") : _zero),
 
     // derivatives of time derivatives
-    _d_u_vel_dot_du(coupledDotDu("u")),
-    _d_v_vel_dot_dv(coupledDotDu("v")),
-    _d_w_vel_dot_dw(coupledDotDu("w")),
+    _d_u_vel_dot_du(_is_transient ? coupledDotDu("u") : _zero),
+    _d_v_vel_dot_dv(_is_transient ? coupledDotDu("v") : _zero),
+    _d_w_vel_dot_dw(_is_transient ? coupledDotDu("w") : _zero),
 
     // Variable numberings
     _u_vel_var_number(coupled("u")),

--- a/test/include/auxkernels/ScalarDotCouplingAux.h
+++ b/test/include/auxkernels/ScalarDotCouplingAux.h
@@ -1,0 +1,35 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef SCALARDOTCOUPLINGAUX_H
+#define SCALARDOTCOUPLINGAUX_H
+
+#include "AuxKernel.h"
+
+class ScalarDotCouplingAux;
+
+template <>
+InputParameters validParams<ScalarDotCouplingAux>();
+
+/**
+ * Couples in the time derivatives of a scalar variable
+ */
+class ScalarDotCouplingAux : public AuxKernel
+{
+public:
+  ScalarDotCouplingAux(const InputParameters & parameters);
+  virtual ~ScalarDotCouplingAux();
+
+protected:
+  virtual Real computeValue();
+
+  const VariableValue & _v_dot;
+};
+
+#endif /* DOTCOUPLINGAUX_H */

--- a/test/src/auxkernels/ScalarDotCouplingAux.C
+++ b/test/src/auxkernels/ScalarDotCouplingAux.C
@@ -1,0 +1,33 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ScalarDotCouplingAux.h"
+
+template <>
+InputParameters
+validParams<ScalarDotCouplingAux>()
+{
+  InputParameters params = validParams<AuxKernel>();
+  params.addRequiredCoupledVar("v", "Coupled variable");
+
+  return params;
+}
+
+ScalarDotCouplingAux::ScalarDotCouplingAux(const InputParameters & parameters)
+  : AuxKernel(parameters), _v_dot(coupledScalarDot("v"))
+{
+}
+
+ScalarDotCouplingAux::~ScalarDotCouplingAux() {}
+
+Real
+ScalarDotCouplingAux::computeValue()
+{
+  return _v_dot[_qp];
+}

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -92,6 +92,7 @@
 #include "FluxAverageAux.h"
 #include "OldMaterialAux.h"
 #include "DotCouplingAux.h"
+#include "ScalarDotCouplingAux.h"
 #include "VectorPostprocessorAux.h"
 #include "ExampleShapeElementKernel.h"
 #include "ExampleShapeElementKernel2.h"
@@ -428,6 +429,7 @@ MooseTestApp::registerObjects(Factory & factory)
   registerAux(FluxAverageAux);
   registerAux(OldMaterialAux);
   registerAux(DotCouplingAux);
+  registerAux(ScalarDotCouplingAux);
   registerAux(VectorPostprocessorAux);
   registerAux(GhostAux);
   registerAux(FunctionGradAux);

--- a/test/src/kernels/OptionallyCoupledForce.C
+++ b/test/src/kernels/OptionallyCoupledForce.C
@@ -26,8 +26,8 @@ OptionallyCoupledForce::OptionallyCoupledForce(const InputParameters & parameter
     _v(coupledValue("v")),
     _grad_v(coupledGradient("v")),
     _second_v(coupledSecond("v")),
-    _v_dot(coupledDot("v")),
-    _v_dot_du(coupledDotDu("v")),
+    _v_dot(_is_transient ? coupledDot("v") : _zero),
+    _v_dot_du(_is_transient ? coupledDotDu("v") : _zero),
     _v_coupled(isCoupled("v"))
 {
   if (!_v_coupled && _v_var < 64)

--- a/test/tests/misc/check_error/dot_integrity_check.i
+++ b/test/tests/misc/check_error/dot_integrity_check.i
@@ -1,0 +1,33 @@
+# Test that coupling a time derivative of a variable (DotCouplingKernel) and using a Steady executioner
+# errors out
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[Variables]
+  [./v]
+  [../]
+
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff_v]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.5
+  [../]
+
+  [./conv_v]
+    type = DotCouplingKernel
+    variable = v
+    v = u
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_error/scalar_dot_integrity_check.i
+++ b/test/tests/misc/check_error/scalar_dot_integrity_check.i
@@ -1,0 +1,56 @@
+# Test that coupling a time derivative of a scalar variable (ScalarDotCouplingAux) and
+# using a Steady executioner errors out
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[Functions]
+  [./a_fn]
+    type = ParsedFunction
+    value = t
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+
+  [./a]
+    family = SCALAR
+    order = FIRST
+  [../]
+[]
+
+[AuxScalarKernels]
+  [./a_sak]
+    type = FunctionScalarAux
+    variable = a
+    function = a_fn
+  [../]
+[]
+
+[AuxKernels]
+  [./ak_v]
+    type = ScalarDotCouplingAux
+    variable = v
+    v = a
+  [../]
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./td]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_error/scalar_old_integrity_check.i
+++ b/test/tests/misc/check_error/scalar_old_integrity_check.i
@@ -1,0 +1,57 @@
+# Test that coupling a time derivative of a scalar variable (ScalarDotCouplingAux) and
+# using a Steady executioner errors out
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[Functions]
+  [./a_fn]
+    type = ParsedFunction
+    value = t
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+
+  [./a]
+    family = SCALAR
+    order = FIRST
+  [../]
+[]
+
+[AuxScalarKernels]
+  [./a_sak]
+    type = FunctionScalarAux
+    variable = a
+    function = a_fn
+  [../]
+[]
+
+[AuxKernels]
+  [./ak_v]
+    type = CoupledScalarAux
+    variable = v
+    coupled = a
+    lag = OLD
+  [../]
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./td]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -493,7 +493,25 @@
   [./old_integrity_check]
     type = 'RunException'
     input = 'old_integrity_check.i'
-    expect_err = 'You may not couple in old or older values of \S+ when using a \"Steady\" executioner.'
+    expect_err = 'You may not couple in old, older or time derivative values of \S+ when using a \"Steady\" executioner.'
+  [../]
+
+  [./dot_integrity_check]
+    type = 'RunException'
+    input = 'dot_integrity_check.i'
+    expect_err = 'You may not couple in old, older or time derivative values of \S+ when using a \"Steady\" executioner.'
+  [../]
+
+  [./scalar_old_integrity_check]
+    type = 'RunException'
+    input = 'scalar_old_integrity_check.i'
+    expect_err = 'You may not couple in old, older or time derivative values of \S+ when using a \"Steady\" executioner.'
+  [../]
+
+  [./scalar_dot_integrity_check]
+    type = 'RunException'
+    input = 'scalar_dot_integrity_check.i'
+    expect_err = 'You may not couple in old, older or time derivative values of \S+ when using a \"Steady\" executioner.'
   [../]
 
   [./node_value_off_block]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -493,25 +493,25 @@
   [./old_integrity_check]
     type = 'RunException'
     input = 'old_integrity_check.i'
-    expect_err = 'You may not couple in old, older or time derivative values of \S+ when using a \"Steady\" executioner.'
+    expect_err = 'Calling \'coupledGradientOld\' on variable \S+ when using a \"Steady\" executioner is not allowed. This value is available only in transient simulations.'
   [../]
 
   [./dot_integrity_check]
     type = 'RunException'
     input = 'dot_integrity_check.i'
-    expect_err = 'You may not couple in old, older or time derivative values of \S+ when using a \"Steady\" executioner.'
+    expect_err = 'Calling \'coupledDot\' on variable \S+ when using a \"Steady\" executioner is not allowed. This value is available only in transient simulations.'
   [../]
 
   [./scalar_old_integrity_check]
     type = 'RunException'
     input = 'scalar_old_integrity_check.i'
-    expect_err = 'You may not couple in old, older or time derivative values of \S+ when using a \"Steady\" executioner.'
+    expect_err = 'Calling \'coupledScalarValueOld\' on variable \S+ when using a \"Steady\" executioner is not allowed. This value is available only in transient simulations.'
   [../]
 
   [./scalar_dot_integrity_check]
     type = 'RunException'
     input = 'scalar_dot_integrity_check.i'
-    expect_err = 'You may not couple in old, older or time derivative values of \S+ when using a \"Steady\" executioner.'
+    expect_err = 'Calling \'coupledScalarDot\' on variable \S+ when using a \"Steady\" executioner is not allowed. This value is available only in transient simulations.'
   [../]
 
   [./node_value_off_block]


### PR DESCRIPTION
1. Prevent users to get time derivative related quantities (like `coupledDot`, `coupledDotDu`) when running steady state simulations
2. Improve error message users obtain when they call such methods


<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
