### PR TITLE
Fix compile warnings with -Wall -Wextra

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -263,7 +263,7 @@ all:: exodiff
 
 # Target-specific Variable Values (See GNU-make manual)
 exodiff: app_INCLUDES := $(exodiff_includes)
-exodiff: libmesh_CXXFLAGS := -std=gnu++11 -O2 -felide-constructors -Wno-parentheses-equality
+exodiff: libmesh_CXXFLAGS := -std=gnu++11 -O2 -felide-constructors -w
 exodiff: $(exodiff_APP)
 $(exodiff_APP): $(exodiff_objects)
 	@echo "Linking Executable "$@"..."

--- a/modules/phase_field/src/kernels/CHPFCRFF.C
+++ b/modules/phase_field/src/kernels/CHPFCRFF.C
@@ -66,7 +66,7 @@ CHPFCRFF::computeQpResidual()
   for (unsigned int i = 0; i < _num_L; ++i)
     sum_grad_L += (*_grad_vals[i])[_qp] * 0.5;
 
-  Real frac;
+  Real frac = 0.0;
   Real ln_expansion = 0.0;
 
   switch (_log_approach)
@@ -132,7 +132,8 @@ CHPFCRFF::computeQpJacobian()
   for (unsigned int i = 0; i < _num_L; ++i)
     sum_grad_L += (*_grad_vals[i])[_qp] * 0.5;
 
-  Real frac, dfrac;
+  Real frac = 0.0;
+  Real dfrac = 0.0;
   Real ln_expansion = 0.0;
 
   switch (_log_approach)

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -15,7 +15,7 @@ FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 
 # Extra stuff for GTEST
-ADDITIONAL_INCLUDES	:= -I$(FRAMEWORK_DIR)/contrib/gtest
+ADDITIONAL_INCLUDES	:= -isystem $(FRAMEWORK_DIR)/contrib/gtest
 ADDITIONAL_LIBS 	:= $(FRAMEWORK_DIR)/contrib/gtest/libgtest.la
 
 # framework

--- a/unit/src/Water97FluidPropertiesTest.C
+++ b/unit/src/Water97FluidPropertiesTest.C
@@ -37,11 +37,10 @@ TEST_F(Water97FluidPropertiesTest, inRegion)
   EXPECT_EQ(_fp->inRegion(30.0e6, 2000), 5);
 
   // Test out of range errors
-  unsigned int region;
   try
   {
     // Trigger invalid pressure error
-    region = _fp->inRegion(101.0e6, 300.0);
+    _fp->inRegion(101.0e6, 300.0);
     // TODO: this test fails with the following line that should be uncommented:
     // FAIL() << "missing expected error";
   }
@@ -55,7 +54,7 @@ TEST_F(Water97FluidPropertiesTest, inRegion)
   try
   {
     // Trigger another invalid pressure error
-    region = _fp->inRegion(51.0e6, 1200.0);
+    _fp->inRegion(51.0e6, 1200.0);
     FAIL() << "missing expected error";
   }
   catch (const std::exception & e)
@@ -68,7 +67,7 @@ TEST_F(Water97FluidPropertiesTest, inRegion)
   try
   {
     // Trigger invalid temperature error
-    region = _fp->inRegion(5.0e6, 2001.0);
+    _fp->inRegion(5.0e6, 2001.0);
     // TODO: this test fails with the following line that should be uncommented:
     // FAIL() << "missing expected error";
   }


### PR DESCRIPTION
refs #10733

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
